### PR TITLE
chore: pin release-as 0.1.1 to bootstrap Release Please versioning

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: googleapis/release-please-action@v4
         with:
           release-type: simple
-          package-name: BaseChatKit
+          release-as: 0.1.1


### PR DESCRIPTION
Release Please defaults to `1.0.0` for the first release when no prior Release Please-managed tag exists. This pins `release-as: 0.1.1` to force the correct bootstrap version. Once `v0.1.1` is tagged, remove this line and Release Please will auto-compute from there.