### PR TITLE
chore: add release-please-config.json and update CLAUDE.md worker instructions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,7 @@ name: Release Please
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -14,4 +15,5 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          release-type: simple
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,10 @@ All changes go through PRs — direct pushes to `main` are blocked for everyone.
 
 1. Branch off `main`
 2. Write code, commit with conventional commits
-3. Open a PR with a conventional title
-4. CI must pass (`BaseChatCoreTests` + `BaseChatUITests`)
-5. Merge
+3. Open a PR: `gh pr create --title "feat: ..." --body "..."`
+4. Report the PR URL — the maintainer reviews and merges manually
+5. Do NOT pass `--auto` or `--merge` — merges require human approval
+
+CI must pass (`BaseChatCoreTests` + `BaseChatUITests`) before merge is allowed.
 
 Hardware-gated tests (`BaseChatBackendsTests`, `BaseChatE2ETests`) do not run in CI. Run them locally on Apple Silicon before merging backend changes.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "simple",
+  "packages": {
+    ".": {}
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `release-please-config.json` to the repo root, moving `release-type: simple` out of the workflow and into the config file (required for release-please v4 config-driven mode)
- Updates `.github/workflows/release-please.yml` to reference the config and manifest files, and adds `workflow_dispatch` so the workflow can be manually re-run
- Updates the "PR workflow" section in `CLAUDE.md` so workers know to use `gh pr create` with a conventional commit title, report the PR URL, and not pass `--auto` or `--merge`

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Confirm release-please workflow runs without error on next push to `main`