### PR TITLE
ci: use arm64 runner, combine test steps, remove redundant release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-15
+    runs-on: macos-15-xlarge  # Apple Silicon (arm64) — ~2x faster than Intel
 
     steps:
       - name: Checkout
@@ -23,18 +23,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .build
-          key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-spm-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-spm-
+            ${{ runner.os }}-${{ runner.arch }}-spm-
 
-      - name: Build
-        run: swift build -c release
-
-      - name: Run BaseChatCoreTests
-        run: swift test --filter BaseChatCoreTests
-
-      - name: Run BaseChatUITests
-        run: swift test --filter BaseChatUITests
+      - name: Run tests
+        run: swift test --filter "BaseChatCoreTests|BaseChatUITests"
 
       # BaseChatBackendsTests and BaseChatE2ETests require physical hardware
       # or specific OS versions (iOS 26 / macOS 26 for FoundationBackend).


### PR DESCRIPTION
## Summary

- Switch from `macos-15` (Intel) to `macos-15-xlarge` (Apple Silicon) — ~2x faster Swift compilation
- Remove `swift build -c release` — redundant since `swift test` builds in debug mode anyway
- Combine `BaseChatCoreTests` and `BaseChatUITests` into one `swift test` invocation — shares the build
- Add `runner.arch` to SPM cache key so Intel and ARM caches don't collide

## Test plan

- [ ] CI passes and completes noticeably faster than the ~2 min baseline