### PR TITLE
feat: add Swift 6.1 package traits for selective backend compilation

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "e6491edfbdfae9aa60767f3fddaa4ded45c929796e6081d0db50aa4553923424",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -136,5 +137,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.1
 
 import PackageDescription
 
@@ -12,6 +12,10 @@ let package = Package(
         .library(name: "BaseChatCore", targets: ["BaseChatCore"]),
         .library(name: "BaseChatBackends", targets: ["BaseChatBackends"]),
         .library(name: "BaseChatUI", targets: ["BaseChatUI"]),
+    ],
+    traits: [
+        .trait(name: "MLX", description: "Enable the MLX inference backend (requires Apple Silicon)"),
+        .trait(name: "Llama", description: "Enable the llama.cpp (GGUF) inference backend"),
     ],
     dependencies: [
         .package(url: "https://github.com/ml-explore/mlx-swift.git", from: "0.30.0"),
@@ -33,10 +37,10 @@ let package = Package(
             name: "BaseChatBackends",
             dependencies: [
                 "BaseChatCore",
-                .product(name: "MLX", package: "mlx-swift"),
-                .product(name: "MLXLLM", package: "mlx-swift-lm"),
-                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
-                .product(name: "LlamaSwift", package: "llama.swift"),
+                .product(name: "MLX", package: "mlx-swift", condition: .when(traits: ["MLX"])),
+                .product(name: "MLXLLM", package: "mlx-swift-lm", condition: .when(traits: ["MLX"])),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm", condition: .when(traits: ["MLX"])),
+                .product(name: "LlamaSwift", package: "llama.swift", condition: .when(traits: ["Llama"])),
             ],
             path: "Sources/BaseChatBackends"
         ),
@@ -68,5 +72,6 @@ let package = Package(
             name: "BaseChatE2ETests",
             dependencies: ["BaseChatBackends", "BaseChatCore", "BaseChatTestSupport"]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/Sources/BaseChatBackends/DefaultBackends.swift
+++ b/Sources/BaseChatBackends/DefaultBackends.swift
@@ -12,14 +12,21 @@ public enum DefaultBackends {
     public static func register(with service: InferenceService) {
         service.registerBackendFactory { modelType in
             switch modelType {
+            #if MLX
             case .mlx: return MLXBackend()
+            #endif
+            #if canImport(FoundationModels)
             case .foundation:
                 if #available(iOS 26, macOS 26, *) {
                     return FoundationBackend()
                 } else {
                     return nil
                 }
+            #endif
+            #if Llama
             case .gguf: return LlamaBackend()
+            #endif
+            default: return nil
             }
         }
         service.registerCloudBackendFactory { provider in

--- a/Sources/BaseChatBackends/FoundationBackend.swift
+++ b/Sources/BaseChatBackends/FoundationBackend.swift
@@ -1,3 +1,4 @@
+#if canImport(FoundationModels)
 import Foundation
 import FoundationModels
 import os
@@ -215,3 +216,4 @@ struct FoundationTokenizer: TokenizerProvider {
         max(1, text.count / 3)
     }
 }
+#endif

--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -1,3 +1,4 @@
+#if Llama
 import Foundation
 import LlamaSwift
 import os
@@ -340,3 +341,4 @@ extension LlamaBackend: TokenizerVendor, TokenizerProvider {
         return tokens.isEmpty ? max(1, text.count / 4) : tokens.count
     }
 }
+#endif

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -1,3 +1,4 @@
+#if MLX
 import Foundation
 import MLX
 import MLXLLM
@@ -156,3 +157,4 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         Self.logger.info("MLX backend unloaded")
     }
 }
+#endif

--- a/Tests/BaseChatBackendsTests/DefaultBackendsTests.swift
+++ b/Tests/BaseChatBackendsTests/DefaultBackendsTests.swift
@@ -21,6 +21,7 @@ final class DefaultBackendsTests: XCTestCase {
         // Should not crash or corrupt state
     }
 
+    #if Llama
     func test_loadModel_gguf_invalidPath_throwsModelLoadFailed() async {
         let service = InferenceService()
         DefaultBackends.register(with: service)
@@ -41,6 +42,7 @@ final class DefaultBackendsTests: XCTestCase {
             XCTAssertFalse(service.isModelLoaded)
         }
     }
+    #endif
 
     // Note: MLX backend tests require Xcode's Metal toolchain and cannot
     // run under `swift test`. Test MLX through the Xcode scheme instead.

--- a/Tests/BaseChatBackendsTests/FoundationBackendUnitTests.swift
+++ b/Tests/BaseChatBackendsTests/FoundationBackendUnitTests.swift
@@ -1,3 +1,4 @@
+#if canImport(FoundationModels)
 import XCTest
 import BaseChatCore
 @testable import BaseChatBackends
@@ -186,3 +187,4 @@ final class FoundationBackendUnitTests: XCTestCase {
         XCTAssertFalse(backend.isGenerating)
     }
 }
+#endif

--- a/Tests/BaseChatBackendsTests/FoundationModelE2ETests.swift
+++ b/Tests/BaseChatBackendsTests/FoundationModelE2ETests.swift
@@ -1,3 +1,4 @@
+#if canImport(FoundationModels)
 import XCTest
 import SwiftData
 import BaseChatCore
@@ -169,3 +170,4 @@ final class FoundationModelE2ETests: XCTestCase {
         XCTAssertGreaterThanOrEqual(vm.messages.count, 1)
     }
 }
+#endif

--- a/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
@@ -1,3 +1,4 @@
+#if Llama
 import XCTest
 import BaseChatCore
 @testable import BaseChatBackends
@@ -184,3 +185,4 @@ final class LlamaBackendTests: XCTestCase {
         XCTAssertLessThan(short, long, "Longer text should produce a higher token count")
     }
 }
+#endif


### PR DESCRIPTION
## Summary

- Add `MLX` and `Llama` package traits so consumers compile only the backends they need
- Gate `MLXBackend`, `LlamaBackend`, and `FoundationBackend` behind `#if` compilation conditions
- Cloud backends (Claude, OpenAI) remain always available with no trait required
- Bump swift-tools-version from 5.9 to 6.1 (minimum for package traits)
- Add `swiftLanguageModes: [.v5]` to preserve existing concurrency behavior

## Consumer usage

```swift
// Cloud-only (smallest binary)
.package(url: "...", from: "1.0.0")

// With specific local backends
.package(url: "...", from: "1.0.0", traits: ["MLX"])
.package(url: "...", from: "1.0.0", traits: ["MLX", "Llama"])
```

## Test plan

- [x] `swift build --target BaseChatBackends` (no traits, cloud-only) — builds clean
- [x] `swift build --target BaseChatBackends --traits MLX,Llama` (all traits) — builds clean
- [x] `swift test --filter BaseChatCoreTests --traits MLX,Llama` — 20 tests pass
- [x] `swift test --filter BaseChatUITests --traits MLX,Llama` — 195 tests pass
- [ ] `swift test --filter BaseChatBackendsTests --traits MLX,Llama` — Apple Silicon only
- [ ] `swift test --filter BaseChatE2ETests --traits MLX,Llama` — Apple Silicon only

🤖 Generated with [Claude Code](https://claude.com/claude-code)