### PR TITLE
ci: cache .build keyed on swift sources for incremental builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,14 @@ jobs:
         with:
           xcode-version: latest-stable
 
-      - name: Cache SPM dependencies
+      - name: Cache build artifacts
         uses: actions/cache@v4
         with:
           path: .build
-          key: ${{ runner.os }}-${{ runner.arch }}-spm-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-build-${{ hashFiles('Package.resolved', '**/*.swift') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-spm-
+            ${{ runner.os }}-${{ runner.arch }}-build-${{ hashFiles('Package.resolved') }}-
+            ${{ runner.os }}-${{ runner.arch }}-build-
 
       - name: Run tests
         run: swift test --filter "BaseChatCoreTests|BaseChatUITests"


### PR DESCRIPTION
Extends the cache key to include all `.swift` source files alongside `Package.resolved`. On a cache hit Swift only recompiles changed files. Restore keys fall back from exact-source-match → exact-package-match → any prior build, so there's always a warm cache to build incrementally from.