### PR TITLE
test: add XCTMeasure performance baselines for hot paths

### DIFF
--- a/Tests/BaseChatCoreTests/HotPathPerformanceTests.swift
+++ b/Tests/BaseChatCoreTests/HotPathPerformanceTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+@testable import BaseChatCore
+
+final class HotPathPerformanceTests: XCTestCase {
+
+    private static let sessionID = UUID()
+
+    // MARK: - trimMessages (100+ messages, mixed lengths)
+
+    func testPerf_trimMessages_mixedLengths() {
+        let shortContent = "Quick reply."
+        let mediumContent = String(repeating: "This is a medium-length message. ", count: 10)
+        let longContent = String(repeating: "This is a longer message with more content to process. ", count: 50)
+
+        let messages: [ChatMessage] = (0..<200).map { i in
+            let role: MessageRole = i % 2 == 0 ? .user : .assistant
+            let content: String
+            switch i % 3 {
+            case 0: content = shortContent
+            case 1: content = mediumContent
+            default: content = longContent
+            }
+            return ChatMessage(role: role, content: content, sessionID: Self.sessionID)
+        }
+        let systemPrompt = "You are a helpful assistant that provides detailed answers."
+
+        measure {
+            _ = ContextWindowManager.trimMessages(
+                messages,
+                systemPrompt: systemPrompt,
+                maxTokens: 4096,
+                responseBuffer: 512
+            )
+        }
+    }
+
+    // MARK: - SSEStreamParser (1000+ tokens)
+
+    func testPerf_sseStreamParser_1000tokens() async throws {
+        var ssePayload = ""
+        for i in 0..<1200 {
+            let json = #"{"choices":[{"delta":{"content":"token\#(i) "}}]}"#
+            ssePayload += "data: \(json)\n\n"
+        }
+        ssePayload += "data: [DONE]\n\n"
+        let sseData = Array(ssePayload.utf8)
+
+        measure {
+            let expectation = self.expectation(description: "stream")
+            Task {
+                let byteStream = AsyncThrowingStream<UInt8, Error> { continuation in
+                    for byte in sseData {
+                        continuation.yield(byte)
+                    }
+                    continuation.finish()
+                }
+                let stream = SSEStreamParser.parse(bytes: byteStream)
+                var count = 0
+                for try await _ in stream {
+                    count += 1
+                }
+                expectation.fulfill()
+            }
+            self.wait(for: [expectation], timeout: 10)
+        }
+    }
+
+    // MARK: - ModelStorageService.discoverModels (populated directory)
+
+    private var service: ModelStorageService!
+    private var createdURLs: [URL] = []
+
+    override func setUp() {
+        super.setUp()
+        service = ModelStorageService()
+        createdURLs = []
+    }
+
+    override func tearDown() {
+        for url in createdURLs {
+            try? FileManager.default.removeItem(at: url)
+        }
+        createdURLs = []
+        service = nil
+        super.tearDown()
+    }
+
+    @discardableResult
+    private func createGgufFile(named prefix: String, size: Int = 512) throws -> URL {
+        try service.ensureModelsDirectory()
+        let fileName = "\(prefix)-\(UUID().uuidString).gguf"
+        let url = service.modelsDirectory.appendingPathComponent(fileName)
+        try Data(repeating: 0xAA, count: size).write(to: url)
+        createdURLs.append(url)
+        return url
+    }
+
+    @discardableResult
+    private func createMlxDirectory(named prefix: String) throws -> URL {
+        try service.ensureModelsDirectory()
+        let dirName = "\(prefix)-\(UUID().uuidString)"
+        let url = service.modelsDirectory.appendingPathComponent(dirName)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: url.appendingPathComponent("config.json"))
+        try Data(repeating: 0xBB, count: 1024).write(to: url.appendingPathComponent("weights.safetensors"))
+        createdURLs.append(url)
+        return url
+    }
+
+    func testPerf_discoverModels_populatedDirectory() throws {
+        for i in 0..<15 {
+            try createGgufFile(named: "perf-gguf-\(i)")
+        }
+        for i in 0..<5 {
+            try createMlxDirectory(named: "perf-mlx-\(i)")
+        }
+
+        measure {
+            _ = service.discoverModels()
+        }
+    }
+
+    // MARK: - HeuristicTokenizer.estimateTokenCount (long inputs)
+
+    func testPerf_heuristicTokenizer_longRealisticInput() {
+        let paragraph = "The quick brown fox jumps over the lazy dog. "
+        let longInput = String(repeating: paragraph, count: 2000)
+        let tokenizer = HeuristicTokenizer()
+
+        measure {
+            _ = tokenizer.tokenCount(longInput)
+        }
+    }
+
+    func testPerf_heuristicTokenizer_100kChars() {
+        let longInput = String(repeating: "abcdefghij", count: 10_000)
+        let tokenizer = HeuristicTokenizer()
+
+        measure {
+            _ = tokenizer.tokenCount(longInput)
+        }
+    }
+}

--- a/Tests/BaseChatCoreTests/HotPathPerformanceTests.swift
+++ b/Tests/BaseChatCoreTests/HotPathPerformanceTests.swift
@@ -61,7 +61,7 @@ final class HotPathPerformanceTests: XCTestCase {
                 }
                 expectation.fulfill()
             }
-            self.wait(for: [expectation], timeout: 10)
+            self.wait(for: [expectation], timeout: 5)
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `HotPathPerformanceTests.swift` with `measure {}` baselines for the four hot paths from #3
- `ContextWindowManager.trimMessages`: 200 messages with mixed short/medium/long content
- `SSEStreamParser.parse`: 1200 SSE data lines simulating a streaming response
- `ModelStorageService.discoverModels`: 20 models (15 GGUF files + 5 MLX directories)
- `HeuristicTokenizer.tokenCount`: realistic paragraph input (~90k chars) and 100k-char uniform input
- All fixtures built before the `measure` block per project conventions
- Tests are in `BaseChatCoreTests` and run in CI without hardware

## Test plan
- [ ] `swift test --filter HotPathPerformanceTests` passes locally
- [ ] `swift test --filter BaseChatCoreTests` passes in CI
- [ ] Verify measure output appears in Xcode test results

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)