### PR TITLE
test: add XCTSkipIf hardware gates to hardware-dependent tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Tests that need specific hardware use `XCTSkipUnless` with flags from `HardwareR
 |------|-------------|
 | `HardwareRequirements.isAppleSilicon` | Running on arm64 (Apple Silicon) |
 | `HardwareRequirements.isPhysicalDevice` | Running on a real device, not the iOS Simulator |
-| `HardwareRequirements.hasFoundationModels` | macOS 26+ / iOS 26+ SDK is available at runtime |
+| `HardwareRequirements.hasFoundationModels` | Running on macOS 26+ / iOS 26+ (does not check Apple Intelligence) |
 
 Tests also check `FoundationBackend.isAvailable` for Apple Intelligence availability, which is distinct from the OS version check (the user may not have Apple Intelligence enabled).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,28 @@ To run everything at once on a capable machine:
 swift test
 ```
 
+### Hardware gate helpers
+
+Tests that need specific hardware use `XCTSkipUnless` with flags from `HardwareRequirements` (in `BaseChatTestSupport`):
+
+| Flag | When `true` |
+|------|-------------|
+| `HardwareRequirements.isAppleSilicon` | Running on arm64 (Apple Silicon) |
+| `HardwareRequirements.isPhysicalDevice` | Running on a real device, not the iOS Simulator |
+| `HardwareRequirements.hasFoundationModels` | macOS 26+ / iOS 26+ SDK is available at runtime |
+
+Tests also check `FoundationBackend.isAvailable` for Apple Intelligence availability, which is distinct from the OS version check (the user may not have Apple Intelligence enabled).
+
+Use these at the top of `setUp()` or individual test methods:
+
+```swift
+override func setUp() async throws {
+    try await super.setUp()
+    try XCTSkipUnless(HardwareRequirements.isAppleSilicon, "Requires Apple Silicon")
+    try XCTSkipUnless(HardwareRequirements.isPhysicalDevice, "Metal unavailable in simulator")
+}
+```
+
 ## Adding a New Backend
 
 1. Implement the `InferenceBackend` protocol (defined in `Sources/BaseChatCore`).

--- a/Sources/BaseChatTestSupport/HardwareRequirements.swift
+++ b/Sources/BaseChatTestSupport/HardwareRequirements.swift
@@ -27,8 +27,9 @@ public enum HardwareRequirements {
         #endif
     }
 
-    /// `true` when the Foundation Models framework is available at runtime.
-    /// Requires macOS 26+ / iOS 26+ with Apple Intelligence enabled.
+    /// `true` when the OS version supports Foundation Models (macOS 26+ / iOS 26+).
+    /// This does NOT check whether Apple Intelligence is enabled — use
+    /// `FoundationBackend.isAvailable` for that.
     public static var hasFoundationModels: Bool {
         if #available(macOS 26, iOS 26, *) {
             return true

--- a/Sources/BaseChatTestSupport/HardwareRequirements.swift
+++ b/Sources/BaseChatTestSupport/HardwareRequirements.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Static flags for hardware-gated test skipping.
+///
+/// Use these with `XCTSkipUnless` / `XCTSkipIf` at the top of tests that
+/// require specific hardware or OS capabilities.
+public enum HardwareRequirements {
+
+    /// `true` when running on Apple Silicon (arm64). MLX and llama.cpp
+    /// backends require this architecture.
+    public static var isAppleSilicon: Bool {
+        #if arch(arm64)
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    /// `true` when running on a physical device rather than the iOS Simulator.
+    /// Metal compute is unavailable in the simulator, so backends that use
+    /// GPU acceleration (MLX, llama.cpp) will fail there.
+    public static var isPhysicalDevice: Bool {
+        #if targetEnvironment(simulator)
+        return false
+        #else
+        return true
+        #endif
+    }
+
+    /// `true` when the Foundation Models framework is available at runtime.
+    /// Requires macOS 26+ / iOS 26+ with Apple Intelligence enabled.
+    public static var hasFoundationModels: Bool {
+        if #available(macOS 26, iOS 26, *) {
+            return true
+        }
+        return false
+    }
+}

--- a/Tests/BaseChatBackendsTests/DefaultBackendsTests.swift
+++ b/Tests/BaseChatBackendsTests/DefaultBackendsTests.swift
@@ -1,12 +1,21 @@
 import XCTest
 import BaseChatCore
+import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Tests that DefaultBackends.register completes without error and
 /// that the resulting InferenceService can attempt model loads
 /// (which exercises the factory lookup path).
+///
+/// Registration creates LlamaBackend instances, which require Apple Silicon.
 @MainActor
 final class DefaultBackendsTests: XCTestCase {
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try XCTSkipUnless(HardwareRequirements.isPhysicalDevice, "DefaultBackends registers LlamaBackend which requires Metal")
+        try XCTSkipUnless(HardwareRequirements.isAppleSilicon, "DefaultBackends registers LlamaBackend which requires Apple Silicon")
+    }
 
     func test_register_doesNotCrash() {
         let service = InferenceService()

--- a/Tests/BaseChatBackendsTests/FoundationBackendUnitTests.swift
+++ b/Tests/BaseChatBackendsTests/FoundationBackendUnitTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import BaseChatCore
+import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Isolated unit tests for `FoundationBackend` state management and guard paths.
@@ -8,8 +9,8 @@ import BaseChatCore
 /// They run everywhere that iOS 26 / macOS 26 SDK symbols are available (which is
 /// satisfied at compile time even on the simulator / CI machines with Xcode 26 SDKs).
 ///
-/// Tests that would require live model inference are marked with `XCTSkip` when
-/// `FoundationBackend.isAvailable` returns `false`.
+/// Tests that would require live model inference are gated with
+/// `XCTSkipUnless(HardwareRequirements.hasFoundationModels)`.
 @available(iOS 26, macOS 26, *)
 final class FoundationBackendUnitTests: XCTestCase {
 
@@ -89,9 +90,7 @@ final class FoundationBackendUnitTests: XCTestCase {
     /// On a real device with Apple Intelligence, verify the full round-trip:
     /// loadModel() → isModelLoaded==true, resetConversation() → still true.
     func test_resetConversation_preservesIsModelLoaded_afterLoad() async throws {
-        guard FoundationBackend.isAvailable else {
-            throw XCTSkip("Apple Intelligence not available on this device")
-        }
+        try XCTSkipUnless(FoundationBackend.isAvailable, "Apple Intelligence not available on this device")
 
         let url = URL(fileURLWithPath: "/dev/null") // ignored by FoundationBackend
         try await backend.loadModel(from: url, contextSize: 4096)
@@ -148,9 +147,7 @@ final class FoundationBackendUnitTests: XCTestCase {
         // is not loaded. To reach the alreadyGenerating path we need isModelLoaded
         // to be true. Since we cannot call loadModel() without Apple Intelligence,
         // skip this sub-test when unavailable.
-        guard FoundationBackend.isAvailable else {
-            throw XCTSkip("Apple Intelligence not available — cannot reach isGenerating guard without a loaded model")
-        }
+        try XCTSkipUnless(FoundationBackend.isAvailable, "Apple Intelligence not available — cannot reach isGenerating guard without a loaded model")
 
         // If we get here we could load the model and start a long generation,
         // but that would be an E2E test. Instead, we verify the guard order
@@ -169,9 +166,7 @@ final class FoundationBackendUnitTests: XCTestCase {
     /// State-only version (no real inference): checks that isModelLoaded is
     /// still true after reset, meaning the generate() guard would pass.
     func test_generate_afterResetConversation_isModelLoadedRemainsTrue() async throws {
-        guard FoundationBackend.isAvailable else {
-            throw XCTSkip("Apple Intelligence not available on this device")
-        }
+        try XCTSkipUnless(FoundationBackend.isAvailable, "Apple Intelligence not available on this device")
 
         let url = URL(fileURLWithPath: "/dev/null")
         try await backend.loadModel(from: url, contextSize: 4096)

--- a/Tests/BaseChatBackendsTests/FoundationModelE2ETests.swift
+++ b/Tests/BaseChatBackendsTests/FoundationModelE2ETests.swift
@@ -1,9 +1,9 @@
 import XCTest
 import SwiftData
 import BaseChatCore
+import BaseChatTestSupport
 @testable import BaseChatBackends
 @testable import BaseChatUI
-import BaseChatTestSupport
 
 /// True end-to-end tests using Apple's Foundation Models backend.
 ///
@@ -26,9 +26,8 @@ final class FoundationModelE2ETests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
 
-        guard FoundationBackend.isAvailable else {
-            throw XCTSkip("Foundation Models not available on this device")
-        }
+        try XCTSkipUnless(HardwareRequirements.hasFoundationModels, "Requires macOS 26+ / iOS 26+")
+        try XCTSkipUnless(FoundationBackend.isAvailable, "Apple Intelligence not available on this device")
 
         let schema = Schema(BaseChatSchema.allModelTypes)
         let config = ModelConfiguration(isStoredInMemoryOnly: true)

--- a/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
@@ -1,12 +1,21 @@
 import XCTest
 import BaseChatCore
+import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Tests for LlamaBackend state, capabilities, and error handling.
 ///
 /// These tests exercise everything that does not require a real GGUF model file:
 /// init state, capabilities, error paths, lifecycle transitions, and stop/unload.
+///
+/// All tests require Apple Silicon (llama_backend_init uses Metal).
 final class LlamaBackendTests: XCTestCase {
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try XCTSkipUnless(HardwareRequirements.isPhysicalDevice, "LlamaBackend requires Metal (unavailable in simulator)")
+        try XCTSkipUnless(HardwareRequirements.isAppleSilicon, "LlamaBackend requires Apple Silicon")
+    }
 
     // MARK: - Init & State
 


### PR DESCRIPTION
## Summary

- Add `HardwareRequirements` enum in `BaseChatTestSupport` with static flags: `isAppleSilicon`, `isPhysicalDevice`, `hasFoundationModels`
- Wire `try XCTSkipUnless` guards into `LlamaBackendTests` and `DefaultBackendsTests` (both require Apple Silicon + physical device for Metal)
- Convert `guard/throw XCTSkip` patterns to idiomatic `try XCTSkipUnless` in `FoundationBackendUnitTests` and `FoundationModelE2ETests`
- Document hardware gate conventions and the `HardwareRequirements` helper in CONTRIBUTING.md

## Test plan

- [ ] `swift build --build-tests` passes (verified locally)
- [ ] `swift test --filter BaseChatCoreTests` passes (no hardware gates touched)
- [ ] `swift test --filter BaseChatUITests` passes (no hardware gates touched)
- [ ] On Apple Silicon: `swift test --filter BaseChatBackendsTests` runs all gated tests
- [ ] In simulator: gated tests are skipped with descriptive messages rather than failing

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)