### PR TITLE
feat!: add ChatPersistenceProvider to decouple from SwiftData

### DIFF
--- a/Example/BaseChatDemo/DemoContentView.swift
+++ b/Example/BaseChatDemo/DemoContentView.swift
@@ -51,7 +51,11 @@ struct DemoContentView: View {
             sessionManager.loadSessions()
 
             if sessionManager.sessions.isEmpty {
-                sessionManager.createSession()
+                do {
+                    try sessionManager.createSession()
+                } catch {
+                    viewModel.errorMessage = "Failed to create session: \(error.localizedDescription)"
+                }
             }
 
             // Wire AI auto-rename: fires after the first user message in a session.
@@ -127,7 +131,11 @@ struct DemoContentView: View {
         .toolbar {
             ToolbarItem(placement: .automatic) {
                 Button {
-                    sessionManager.createSession()
+                    do {
+                        try sessionManager.createSession()
+                    } catch {
+                        viewModel.errorMessage = "Failed to create session: \(error.localizedDescription)"
+                    }
                 } label: {
                     Label("New Chat", systemImage: "plus")
                 }

--- a/Sources/BaseChatCore/Protocols/ChatPersistenceProvider.swift
+++ b/Sources/BaseChatCore/Protocols/ChatPersistenceProvider.swift
@@ -1,5 +1,23 @@
 import Foundation
 
+/// Errors produced by ``ChatPersistenceProvider`` implementations.
+public enum ChatPersistenceError: Error, LocalizedError, Sendable, Equatable {
+    case providerNotConfigured
+    case sessionNotFound(UUID)
+    case messageNotFound(UUID)
+
+    public var errorDescription: String? {
+        switch self {
+        case .providerNotConfigured:
+            return "Persistence provider is not configured."
+        case let .sessionNotFound(sessionID):
+            return "Session not found: \(sessionID.uuidString)"
+        case let .messageNotFound(messageID):
+            return "Message not found: \(messageID.uuidString)"
+        }
+    }
+}
+
 /// Plain-data snapshot of a ``ChatSession`` for use across persistence boundaries.
 ///
 /// Decouples view models from SwiftData so callers can swap in any storage backend.
@@ -107,20 +125,63 @@ public struct ChatMessageRecord: Identifiable, Hashable, Sendable {
 ///
 /// The default implementation is ``SwiftDataPersistenceProvider``. Tests can
 /// substitute ``MockPersistenceProvider`` from `BaseChatTestSupport`.
+@MainActor
 public protocol ChatPersistenceProvider: AnyObject, Sendable {
 
     // MARK: - Sessions
 
+    /// Inserts a new chat session.
+    ///
+    /// - Throws: Storage errors from the underlying provider.
     func insertSession(_ session: ChatSessionRecord) throws
+
+    /// Updates an existing chat session.
+    ///
+    /// - Throws:
+    ///   - ``ChatPersistenceError/sessionNotFound(_:)`` when the session does not exist.
+    ///   - Storage errors from the underlying provider.
     func updateSession(_ session: ChatSessionRecord) throws
+
+    /// Deletes a chat session and all associated messages.
+    ///
+    /// - Throws:
+    ///   - ``ChatPersistenceError/sessionNotFound(_:)`` when the session does not exist.
+    ///   - Storage errors from the underlying provider.
     func deleteSession(_ sessionID: UUID) throws
+
+    /// Fetches all chat sessions sorted by most-recently-updated.
+    ///
+    /// - Throws: Storage errors from the underlying provider.
     func fetchSessions() throws -> [ChatSessionRecord]
 
     // MARK: - Messages
 
+    /// Inserts a new chat message.
+    ///
+    /// - Throws: Storage errors from the underlying provider.
     func insertMessage(_ message: ChatMessageRecord) throws
+
+    /// Updates an existing chat message.
+    ///
+    /// - Throws:
+    ///   - ``ChatPersistenceError/messageNotFound(_:)`` when the message does not exist.
+    ///   - Storage errors from the underlying provider.
     func updateMessage(_ message: ChatMessageRecord) throws
+
+    /// Deletes a chat message.
+    ///
+    /// - Throws:
+    ///   - ``ChatPersistenceError/messageNotFound(_:)`` when the message does not exist.
+    ///   - Storage errors from the underlying provider.
     func deleteMessage(_ messageID: UUID) throws
+
+    /// Fetches messages for a session in timestamp order.
+    ///
+    /// - Throws: Storage errors from the underlying provider.
     func fetchMessages(for sessionID: UUID) throws -> [ChatMessageRecord]
+
+    /// Deletes all messages for a session.
+    ///
+    /// - Throws: Storage errors from the underlying provider.
     func deleteMessages(for sessionID: UUID) throws
 }

--- a/Sources/BaseChatCore/Protocols/ChatPersistenceProvider.swift
+++ b/Sources/BaseChatCore/Protocols/ChatPersistenceProvider.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+/// Plain-data snapshot of a ``ChatSession`` for use across persistence boundaries.
+///
+/// Decouples view models from SwiftData so callers can swap in any storage backend.
+public struct ChatSessionRecord: Identifiable, Hashable, Sendable {
+    public var id: UUID
+    public var title: String
+    public var createdAt: Date
+    public var updatedAt: Date
+    public var systemPrompt: String
+    public var selectedModelID: UUID?
+    public var temperature: Float?
+    public var topP: Float?
+    public var repeatPenalty: Float?
+    public var promptTemplateRawValue: String?
+    public var contextSizeOverride: Int?
+    public var compressionModeRaw: String?
+    public var pinnedMessageIDsRaw: String?
+
+    public init(
+        id: UUID = UUID(),
+        title: String = "New Chat",
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        systemPrompt: String = "",
+        selectedModelID: UUID? = nil,
+        temperature: Float? = nil,
+        topP: Float? = nil,
+        repeatPenalty: Float? = nil,
+        promptTemplateRawValue: String? = nil,
+        contextSizeOverride: Int? = nil,
+        compressionModeRaw: String? = nil,
+        pinnedMessageIDsRaw: String? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.systemPrompt = systemPrompt
+        self.selectedModelID = selectedModelID
+        self.temperature = temperature
+        self.topP = topP
+        self.repeatPenalty = repeatPenalty
+        self.promptTemplateRawValue = promptTemplateRawValue
+        self.contextSizeOverride = contextSizeOverride
+        self.compressionModeRaw = compressionModeRaw
+        self.pinnedMessageIDsRaw = pinnedMessageIDsRaw
+    }
+
+    public var pinnedMessageIDs: Set<UUID> {
+        get {
+            guard let raw = pinnedMessageIDsRaw else { return [] }
+            return Set(raw.split(separator: ",").compactMap { UUID(uuidString: String($0)) })
+        }
+        set {
+            pinnedMessageIDsRaw = newValue.isEmpty ? nil : newValue.map(\.uuidString).joined(separator: ",")
+        }
+    }
+
+    public var compressionMode: CompressionMode {
+        get { compressionModeRaw.flatMap(CompressionMode.init(rawValue:)) ?? .automatic }
+        set { compressionModeRaw = newValue.rawValue }
+    }
+
+    public var promptTemplate: PromptTemplate? {
+        get {
+            guard let raw = promptTemplateRawValue else { return nil }
+            return PromptTemplate(rawValue: raw)
+        }
+        set {
+            promptTemplateRawValue = newValue?.rawValue
+        }
+    }
+}
+
+/// Plain-data snapshot of a ``ChatMessage`` for use across persistence boundaries.
+public struct ChatMessageRecord: Identifiable, Hashable, Sendable {
+    public var id: UUID
+    public var role: MessageRole
+    public var content: String
+    public var timestamp: Date
+    public var sessionID: UUID
+    public var promptTokens: Int?
+    public var completionTokens: Int?
+
+    public init(
+        id: UUID = UUID(),
+        role: MessageRole,
+        content: String,
+        timestamp: Date = Date(),
+        sessionID: UUID,
+        promptTokens: Int? = nil,
+        completionTokens: Int? = nil
+    ) {
+        self.id = id
+        self.role = role
+        self.content = content
+        self.timestamp = timestamp
+        self.sessionID = sessionID
+        self.promptTokens = promptTokens
+        self.completionTokens = completionTokens
+    }
+}
+
+/// Abstraction over chat persistence, decoupling view models from SwiftData.
+///
+/// The default implementation is ``SwiftDataPersistenceProvider``. Tests can
+/// substitute ``MockPersistenceProvider`` from `BaseChatTestSupport`.
+public protocol ChatPersistenceProvider: AnyObject, Sendable {
+
+    // MARK: - Sessions
+
+    func insertSession(_ session: ChatSessionRecord) throws
+    func updateSession(_ session: ChatSessionRecord) throws
+    func deleteSession(_ sessionID: UUID) throws
+    func fetchSessions() throws -> [ChatSessionRecord]
+
+    // MARK: - Messages
+
+    func insertMessage(_ message: ChatMessageRecord) throws
+    func updateMessage(_ message: ChatMessageRecord) throws
+    func deleteMessage(_ messageID: UUID) throws
+    func fetchMessages(for sessionID: UUID) throws -> [ChatMessageRecord]
+    func deleteMessages(for sessionID: UUID) throws
+}

--- a/Sources/BaseChatCore/Services/ChatExportService.swift
+++ b/Sources/BaseChatCore/Services/ChatExportService.swift
@@ -20,7 +20,7 @@ public enum ChatExportService {
 
     /// Exports messages in the specified format.
     public static func export(
-        messages: [ChatMessage],
+        messages: [ChatMessageRecord],
         sessionTitle: String,
         format: ExportFormat
     ) -> String {
@@ -34,7 +34,7 @@ public enum ChatExportService {
 
     // MARK: - Plain Text
 
-    private static func exportPlainText(messages: [ChatMessage], title: String) -> String {
+    private static func exportPlainText(messages: [ChatMessageRecord], title: String) -> String {
         var lines: [String] = []
         lines.append("Chat: \(title)")
         lines.append("Exported from \(BaseChatConfiguration.shared.appName): \(formattedDate())")
@@ -51,7 +51,7 @@ public enum ChatExportService {
 
     // MARK: - Markdown
 
-    private static func exportMarkdown(messages: [ChatMessage], title: String) -> String {
+    private static func exportMarkdown(messages: [ChatMessageRecord], title: String) -> String {
         var lines: [String] = []
         lines.append("# \(title)")
         lines.append("")

--- a/Sources/BaseChatCore/Services/ContextWindowManager.swift
+++ b/Sources/BaseChatCore/Services/ContextWindowManager.swift
@@ -42,12 +42,12 @@ public enum ContextWindowManager {
     ///   - tokenizer: Optional tokenizer for accurate counts. Falls back to heuristic.
     /// - Returns: The subset of messages that fit within the budget.
     public static func trimMessages(
-        _ messages: [ChatMessage],
+        _ messages: [ChatMessageRecord],
         systemPrompt: String?,
         maxTokens: Int,
         responseBuffer: Int = 512,
         tokenizer: TokenizerProvider? = nil
-    ) -> [ChatMessage] {
+    ) -> [ChatMessageRecord] {
         guard !messages.isEmpty else { return [] }
 
         let systemTokens = estimateTokenCount(systemPrompt ?? "", tokenizer: tokenizer)
@@ -81,7 +81,7 @@ public enum ContextWindowManager {
     /// Calculates a context budget breakdown.
     public static func calculateBudget(
         systemPrompt: String?,
-        messages: [ChatMessage],
+        messages: [ChatMessageRecord],
         maxTokens: Int,
         responseBuffer: Int = 512,
         tokenizer: TokenizerProvider? = nil

--- a/Sources/BaseChatCore/Services/PromptAssembler.swift
+++ b/Sources/BaseChatCore/Services/PromptAssembler.swift
@@ -25,7 +25,7 @@ public enum PromptAssembler {
     /// - Returns: An ``AssembledPrompt`` containing resolved slots, trimmed messages, and budget info.
     public static func assemble(
         slots: [PromptSlot],
-        messages: [ChatMessage],
+        messages: [ChatMessageRecord],
         systemPrompt: String?,
         contextSize: Int,
         responseBuffer: Int = 512,
@@ -109,10 +109,10 @@ public enum PromptAssembler {
     /// Trims messages to fit within the given token budget.
     /// Walks backward from the newest message, always keeping at least the last message.
     private static func trimMessagesToFit(
-        _ messages: [ChatMessage],
+        _ messages: [ChatMessageRecord],
         budget: Int,
         tokenizer: TokenizerProvider
-    ) -> [ChatMessage] {
+    ) -> [ChatMessageRecord] {
         guard !messages.isEmpty else { return [] }
 
         if budget <= 0 {
@@ -123,7 +123,7 @@ public enum PromptAssembler {
             return Array(messages.suffix(1))
         }
 
-        var kept: [ChatMessage] = []
+        var kept: [ChatMessageRecord] = []
         var usedTokens = 0
 
         for message in messages.reversed() {
@@ -145,7 +145,7 @@ public enum PromptAssembler {
     /// Slots that share a depth are kept in their sorted order.
     private static func insertSlotsIntoHistory(
         slots: [ResolvedSlot],
-        messages: [ChatMessage]
+        messages: [ChatMessageRecord]
     ) -> [(role: String, content: String)] {
         // Separate slots into "top" (depth 0) and "depth-inserted"
         let topSlots = slots.filter { $0.depth == 0 }
@@ -159,7 +159,7 @@ public enum PromptAssembler {
             result.append((role: "system", content: slot.content))
         }
 
-        // Convert ChatMessages
+        // Convert ChatMessageRecords
         var messageTuples = messages.map { (role: $0.role.rawValue, content: $0.content) }
 
         // Insert depth-positioned slots into the message list.

--- a/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
+++ b/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
@@ -36,7 +36,9 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider, @unche
     }
 
     public func updateSession(_ record: ChatSessionRecord) throws {
-        guard let session = try fetchSwiftDataSession(id: record.id) else { return }
+        guard let session = try fetchSwiftDataSession(id: record.id) else {
+            throw ChatPersistenceError.sessionNotFound(record.id)
+        }
         session.title = record.title
         session.updatedAt = record.updatedAt
         session.systemPrompt = record.systemPrompt
@@ -52,8 +54,10 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider, @unche
     }
 
     public func deleteSession(_ sessionID: UUID) throws {
+        guard let session = try fetchSwiftDataSession(id: sessionID) else {
+            throw ChatPersistenceError.sessionNotFound(sessionID)
+        }
         try deleteMessages(for: sessionID)
-        guard let session = try fetchSwiftDataSession(id: sessionID) else { return }
         modelContext.delete(session)
         try modelContext.save()
     }
@@ -78,7 +82,9 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider, @unche
     }
 
     public func updateMessage(_ record: ChatMessageRecord) throws {
-        guard let message = try fetchSwiftDataMessage(id: record.id) else { return }
+        guard let message = try fetchSwiftDataMessage(id: record.id) else {
+            throw ChatPersistenceError.messageNotFound(record.id)
+        }
         message.content = record.content
         message.promptTokens = record.promptTokens
         message.completionTokens = record.completionTokens
@@ -86,7 +92,9 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider, @unche
     }
 
     public func deleteMessage(_ messageID: UUID) throws {
-        guard let message = try fetchSwiftDataMessage(id: messageID) else { return }
+        guard let message = try fetchSwiftDataMessage(id: messageID) else {
+            throw ChatPersistenceError.messageNotFound(messageID)
+        }
         modelContext.delete(message)
         try modelContext.save()
     }

--- a/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
+++ b/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
@@ -1,0 +1,165 @@
+import Foundation
+import SwiftData
+
+/// Default ``ChatPersistenceProvider`` backed by SwiftData.
+///
+/// Operates on the ``ModelContext`` injected at init time, converting between
+/// SwiftData `@Model` objects and plain ``ChatSessionRecord`` / ``ChatMessageRecord``
+/// value types at the boundary.
+@MainActor
+public final class SwiftDataPersistenceProvider: ChatPersistenceProvider, @unchecked Sendable {
+
+    private let modelContext: ModelContext
+
+    public init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    // MARK: - Sessions
+
+    public func insertSession(_ record: ChatSessionRecord) throws {
+        let session = ChatSession(title: record.title)
+        session.id = record.id
+        session.createdAt = record.createdAt
+        session.updatedAt = record.updatedAt
+        session.systemPrompt = record.systemPrompt
+        session.selectedModelID = record.selectedModelID
+        session.temperature = record.temperature
+        session.topP = record.topP
+        session.repeatPenalty = record.repeatPenalty
+        session.promptTemplateRawValue = record.promptTemplateRawValue
+        session.contextSizeOverride = record.contextSizeOverride
+        session.compressionModeRaw = record.compressionModeRaw
+        session.pinnedMessageIDsRaw = record.pinnedMessageIDsRaw
+        modelContext.insert(session)
+        try modelContext.save()
+    }
+
+    public func updateSession(_ record: ChatSessionRecord) throws {
+        guard let session = try fetchSwiftDataSession(id: record.id) else { return }
+        session.title = record.title
+        session.updatedAt = record.updatedAt
+        session.systemPrompt = record.systemPrompt
+        session.selectedModelID = record.selectedModelID
+        session.temperature = record.temperature
+        session.topP = record.topP
+        session.repeatPenalty = record.repeatPenalty
+        session.promptTemplateRawValue = record.promptTemplateRawValue
+        session.contextSizeOverride = record.contextSizeOverride
+        session.compressionModeRaw = record.compressionModeRaw
+        session.pinnedMessageIDsRaw = record.pinnedMessageIDsRaw
+        try modelContext.save()
+    }
+
+    public func deleteSession(_ sessionID: UUID) throws {
+        try deleteMessages(for: sessionID)
+        guard let session = try fetchSwiftDataSession(id: sessionID) else { return }
+        modelContext.delete(session)
+        try modelContext.save()
+    }
+
+    public func fetchSessions() throws -> [ChatSessionRecord] {
+        let descriptor = FetchDescriptor<ChatSession>(
+            sortBy: [SortDescriptor(\.updatedAt, order: .reverse)]
+        )
+        return try modelContext.fetch(descriptor).map { $0.toRecord() }
+    }
+
+    // MARK: - Messages
+
+    public func insertMessage(_ record: ChatMessageRecord) throws {
+        let message = ChatMessage(role: record.role, content: record.content, sessionID: record.sessionID)
+        message.id = record.id
+        message.timestamp = record.timestamp
+        message.promptTokens = record.promptTokens
+        message.completionTokens = record.completionTokens
+        modelContext.insert(message)
+        try modelContext.save()
+    }
+
+    public func updateMessage(_ record: ChatMessageRecord) throws {
+        guard let message = try fetchSwiftDataMessage(id: record.id) else { return }
+        message.content = record.content
+        message.promptTokens = record.promptTokens
+        message.completionTokens = record.completionTokens
+        try modelContext.save()
+    }
+
+    public func deleteMessage(_ messageID: UUID) throws {
+        guard let message = try fetchSwiftDataMessage(id: messageID) else { return }
+        modelContext.delete(message)
+        try modelContext.save()
+    }
+
+    public func fetchMessages(for sessionID: UUID) throws -> [ChatMessageRecord] {
+        let descriptor = FetchDescriptor<ChatMessage>(
+            predicate: #Predicate { $0.sessionID == sessionID },
+            sortBy: [SortDescriptor(\.timestamp)]
+        )
+        return try modelContext.fetch(descriptor).map { $0.toRecord() }
+    }
+
+    public func deleteMessages(for sessionID: UUID) throws {
+        let descriptor = FetchDescriptor<ChatMessage>(
+            predicate: #Predicate { $0.sessionID == sessionID }
+        )
+        for message in try modelContext.fetch(descriptor) {
+            modelContext.delete(message)
+        }
+        try modelContext.save()
+    }
+
+    // MARK: - Private
+
+    private func fetchSwiftDataSession(id: UUID) throws -> ChatSession? {
+        let descriptor = FetchDescriptor<ChatSession>(
+            predicate: #Predicate { $0.id == id }
+        )
+        return try modelContext.fetch(descriptor).first
+    }
+
+    private func fetchSwiftDataMessage(id: UUID) throws -> ChatMessage? {
+        let descriptor = FetchDescriptor<ChatMessage>(
+            predicate: #Predicate { $0.id == id }
+        )
+        return try modelContext.fetch(descriptor).first
+    }
+}
+
+// MARK: - Model <-> Record conversions
+
+extension ChatSession {
+    /// Converts a SwiftData model to a plain record.
+    public func toRecord() -> ChatSessionRecord {
+        ChatSessionRecord(
+            id: id,
+            title: title,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            systemPrompt: systemPrompt,
+            selectedModelID: selectedModelID,
+            temperature: temperature,
+            topP: topP,
+            repeatPenalty: repeatPenalty,
+            promptTemplateRawValue: promptTemplateRawValue,
+            contextSizeOverride: contextSizeOverride,
+            compressionModeRaw: compressionModeRaw,
+            pinnedMessageIDsRaw: pinnedMessageIDsRaw
+        )
+    }
+}
+
+extension ChatMessage {
+    /// Converts a SwiftData model to a plain record.
+    public func toRecord() -> ChatMessageRecord {
+        ChatMessageRecord(
+            id: id,
+            role: role,
+            content: content,
+            timestamp: timestamp,
+            sessionID: sessionID,
+            promptTokens: promptTokens,
+            completionTokens: completionTokens
+        )
+    }
+}

--- a/Sources/BaseChatTestSupport/MockPersistenceProvider.swift
+++ b/Sources/BaseChatTestSupport/MockPersistenceProvider.swift
@@ -1,0 +1,88 @@
+import Foundation
+import BaseChatCore
+
+/// In-memory mock of ``ChatPersistenceProvider`` for testing.
+///
+/// Stores sessions and messages in plain arrays. Thread-safe via `@MainActor`.
+@MainActor
+public final class MockPersistenceProvider: ChatPersistenceProvider, @unchecked Sendable {
+
+    public var sessions: [ChatSessionRecord] = []
+    public var messages: [ChatMessageRecord] = []
+
+    // Call tracking
+    public var insertSessionCallCount = 0
+    public var updateSessionCallCount = 0
+    public var deleteSessionCallCount = 0
+    public var fetchSessionsCallCount = 0
+    public var insertMessageCallCount = 0
+    public var updateMessageCallCount = 0
+    public var deleteMessageCallCount = 0
+    public var fetchMessagesCallCount = 0
+
+    public var shouldThrowOnInsertSession: Error?
+    public var shouldThrowOnFetchSessions: Error?
+    public var shouldThrowOnInsertMessage: Error?
+    public var shouldThrowOnFetchMessages: Error?
+
+    public init() {}
+
+    // MARK: - Sessions
+
+    public func insertSession(_ session: ChatSessionRecord) throws {
+        insertSessionCallCount += 1
+        if let error = shouldThrowOnInsertSession { throw error }
+        sessions.append(session)
+    }
+
+    public func updateSession(_ session: ChatSessionRecord) throws {
+        updateSessionCallCount += 1
+        if let idx = sessions.firstIndex(where: { $0.id == session.id }) {
+            sessions[idx] = session
+        }
+    }
+
+    public func deleteSession(_ sessionID: UUID) throws {
+        deleteSessionCallCount += 1
+        try deleteMessages(for: sessionID)
+        sessions.removeAll { $0.id == sessionID }
+    }
+
+    public func fetchSessions() throws -> [ChatSessionRecord] {
+        fetchSessionsCallCount += 1
+        if let error = shouldThrowOnFetchSessions { throw error }
+        return sessions.sorted { $0.updatedAt > $1.updatedAt }
+    }
+
+    // MARK: - Messages
+
+    public func insertMessage(_ message: ChatMessageRecord) throws {
+        insertMessageCallCount += 1
+        if let error = shouldThrowOnInsertMessage { throw error }
+        messages.append(message)
+    }
+
+    public func updateMessage(_ message: ChatMessageRecord) throws {
+        updateMessageCallCount += 1
+        if let idx = messages.firstIndex(where: { $0.id == message.id }) {
+            messages[idx] = message
+        }
+    }
+
+    public func deleteMessage(_ messageID: UUID) throws {
+        deleteMessageCallCount += 1
+        messages.removeAll { $0.id == messageID }
+    }
+
+    public func fetchMessages(for sessionID: UUID) throws -> [ChatMessageRecord] {
+        fetchMessagesCallCount += 1
+        if let error = shouldThrowOnFetchMessages { throw error }
+        return messages
+            .filter { $0.sessionID == sessionID }
+            .sorted { $0.timestamp < $1.timestamp }
+    }
+
+    public func deleteMessages(for sessionID: UUID) throws {
+        messages.removeAll { $0.sessionID == sessionID }
+    }
+}

--- a/Sources/BaseChatTestSupport/MockPersistenceProvider.swift
+++ b/Sources/BaseChatTestSupport/MockPersistenceProvider.swift
@@ -37,13 +37,17 @@ public final class MockPersistenceProvider: ChatPersistenceProvider, @unchecked 
 
     public func updateSession(_ session: ChatSessionRecord) throws {
         updateSessionCallCount += 1
-        if let idx = sessions.firstIndex(where: { $0.id == session.id }) {
-            sessions[idx] = session
+        guard let idx = sessions.firstIndex(where: { $0.id == session.id }) else {
+            throw ChatPersistenceError.sessionNotFound(session.id)
         }
+        sessions[idx] = session
     }
 
     public func deleteSession(_ sessionID: UUID) throws {
         deleteSessionCallCount += 1
+        guard sessions.contains(where: { $0.id == sessionID }) else {
+            throw ChatPersistenceError.sessionNotFound(sessionID)
+        }
         try deleteMessages(for: sessionID)
         sessions.removeAll { $0.id == sessionID }
     }
@@ -64,13 +68,17 @@ public final class MockPersistenceProvider: ChatPersistenceProvider, @unchecked 
 
     public func updateMessage(_ message: ChatMessageRecord) throws {
         updateMessageCallCount += 1
-        if let idx = messages.firstIndex(where: { $0.id == message.id }) {
-            messages[idx] = message
+        guard let idx = messages.firstIndex(where: { $0.id == message.id }) else {
+            throw ChatPersistenceError.messageNotFound(message.id)
         }
+        messages[idx] = message
     }
 
     public func deleteMessage(_ messageID: UUID) throws {
         deleteMessageCallCount += 1
+        guard messages.contains(where: { $0.id == messageID }) else {
+            throw ChatPersistenceError.messageNotFound(messageID)
+        }
         messages.removeAll { $0.id == messageID }
     }
 

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
@@ -9,8 +9,9 @@ extension ChatViewModel {
     ///
     /// Handles context trimming, token usage capture, empty response cleanup,
     /// and the Foundation model upgrade hint.
-    func generateIntoMessage(_ assistantMessage: ChatMessage) async {
+    func generateIntoMessage(_ assistantMessage: ChatMessageRecord) async {
         isGenerating = true
+        let messageID = assistantMessage.id
         defer {
             isGenerating = false
             inferenceService.generationDidFinish()
@@ -18,7 +19,7 @@ extension ChatViewModel {
 
         do {
             // Build the message history, applying compression if the context is filling up.
-            let allMessages = messages.filter { $0.id != assistantMessage.id }
+            let allMessages = messages.filter { $0.id != messageID }
             let effectiveSystemPrompt = systemPrompt.isEmpty ? nil : systemPrompt
             let activeTokenizer = inferenceService.tokenizer
 
@@ -70,7 +71,9 @@ extension ChatViewModel {
                 do {
                     for try await token in stream {
                         if Task.isCancelled { break }
-                        assistantMessage.content += token
+                        if let idx = self.messages.firstIndex(where: { $0.id == messageID }) {
+                            self.messages[idx].content += token
+                        }
                     }
                 } catch {
                     if !Task.isCancelled {
@@ -89,26 +92,28 @@ extension ChatViewModel {
         }
 
         // Capture token usage from cloud backends.
-        if let usage = inferenceService.lastTokenUsage {
-            assistantMessage.promptTokens = usage.promptTokens
-            assistantMessage.completionTokens = usage.completionTokens
+        if let usage = inferenceService.lastTokenUsage,
+           let idx = messages.firstIndex(where: { $0.id == messageID }) {
+            messages[idx].promptTokens = usage.promptTokens
+            messages[idx].completionTokens = usage.completionTokens
         }
 
         // Persist the completed assistant message.
-        if !assistantMessage.content.isEmpty {
-            saveMessage(assistantMessage)
-        } else {
-            // Empty response — remove the placeholder using ID-based lookup
-            // to avoid index invalidation from concurrent modifications.
-            messages.removeAll { $0.id == assistantMessage.id }
+        if let idx = messages.firstIndex(where: { $0.id == messageID }) {
+            if !messages[idx].content.isEmpty {
+                saveMessage(messages[idx])
+            } else {
+                messages.remove(at: idx)
+            }
         }
 
         // After the first assistant response on Foundation, nudge the user to
         // consider downloading a local model for longer context. Only show once
         // per session and only when Foundation is the active backend.
+        let assistantContent = messages.first(where: { $0.id == messageID })?.content ?? ""
         if BaseChatConfiguration.shared.features.showUpgradeHint,
            !showUpgradeHint,
-           !assistantMessage.content.isEmpty,
+           !assistantContent.isEmpty,
            activeBackendName == "Apple",
            messages.filter({ $0.role == .assistant }).count == 1 {
             showUpgradeHint = true

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
@@ -100,10 +100,15 @@ extension ChatViewModel {
 
         // Persist the completed assistant message.
         if let idx = messages.firstIndex(where: { $0.id == messageID }) {
-            if !messages[idx].content.isEmpty {
-                saveMessage(messages[idx])
-            } else {
-                messages.remove(at: idx)
+            do {
+                if messages[idx].content.isEmpty {
+                    messages.remove(at: idx)
+                } else {
+                    try saveMessage(messages[idx])
+                }
+            } catch {
+                Log.persistence.error("Failed to persist assistant message: \(error)")
+                errorMessage = "Failed to save assistant response: \(error.localizedDescription)"
             }
         }
 

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Persistence.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Persistence.swift
@@ -1,15 +1,14 @@
 import Foundation
-import SwiftData
 import BaseChatCore
 
 // MARK: - ChatViewModel + Persistence
 
 extension ChatViewModel {
 
-    /// Loads messages for the active session from SwiftData.
+    /// Loads messages for the active session from the persistence provider.
     func loadMessages() {
-        guard let modelContext else {
-            Log.persistence.warning("loadMessages called before modelContext was configured — messages will not load")
+        guard let persistence else {
+            Log.persistence.warning("loadMessages called before persistence was configured — messages will not load")
             return
         }
         guard let sessionID = activeSessionID else {
@@ -17,13 +16,8 @@ extension ChatViewModel {
             return
         }
 
-        let descriptor = FetchDescriptor<ChatMessage>(
-            predicate: #Predicate { $0.sessionID == sessionID },
-            sortBy: [SortDescriptor(\.timestamp)]
-        )
-
         do {
-            messages = try modelContext.fetch(descriptor)
+            messages = try persistence.fetchMessages(for: sessionID)
             Log.persistence.info("Loaded \(self.messages.count) messages")
         } catch {
             Log.persistence.error("Failed to load messages: \(error)")
@@ -31,29 +25,27 @@ extension ChatViewModel {
         }
     }
 
-    /// Persists a message to SwiftData.
-    func saveMessage(_ message: ChatMessage) {
-        guard let modelContext else {
-            Log.persistence.warning("saveMessage called before modelContext was configured — message will not be persisted")
+    /// Persists a message via the persistence provider.
+    func saveMessage(_ message: ChatMessageRecord) {
+        guard let persistence else {
+            Log.persistence.warning("saveMessage called before persistence was configured — message will not be persisted")
             return
         }
-        modelContext.insert(message)
         do {
-            try modelContext.save()
+            try persistence.insertMessage(message)
         } catch {
             Log.persistence.error("Failed to save message: \(error)")
         }
     }
 
-    /// Deletes a message from SwiftData.
-    func deleteMessage(_ message: ChatMessage) {
-        guard let modelContext else {
-            Log.persistence.warning("deleteMessage called before modelContext was configured — message will not be deleted")
+    /// Deletes a message via the persistence provider.
+    func deleteMessage(_ message: ChatMessageRecord) {
+        guard let persistence else {
+            Log.persistence.warning("deleteMessage called before persistence was configured — message will not be deleted")
             return
         }
-        modelContext.delete(message)
         do {
-            try modelContext.save()
+            try persistence.deleteMessage(message.id)
         } catch {
             Log.persistence.error("Failed to delete message: \(error)")
         }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Persistence.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Persistence.swift
@@ -26,41 +26,29 @@ extension ChatViewModel {
     }
 
     /// Persists a message via the persistence provider.
-    func saveMessage(_ message: ChatMessageRecord) {
+    func saveMessage(_ message: ChatMessageRecord) throws {
         guard let persistence else {
             Log.persistence.warning("saveMessage called before persistence was configured — message will not be persisted")
             return
         }
-        do {
-            try persistence.insertMessage(message)
-        } catch {
-            Log.persistence.error("Failed to save message: \(error)")
-        }
+        try persistence.insertMessage(message)
     }
 
     /// Updates an existing message via the persistence provider.
-    func updateMessage(_ message: ChatMessageRecord) {
+    func updateMessage(_ message: ChatMessageRecord) throws {
         guard let persistence else {
             Log.persistence.warning("updateMessage called before persistence was configured — message will not be updated")
             return
         }
-        do {
-            try persistence.updateMessage(message)
-        } catch {
-            Log.persistence.error("Failed to update message: \(error)")
-        }
+        try persistence.updateMessage(message)
     }
 
     /// Deletes a message via the persistence provider.
-    func deleteMessage(_ message: ChatMessageRecord) {
+    func deleteMessage(_ message: ChatMessageRecord) throws {
         guard let persistence else {
             Log.persistence.warning("deleteMessage called before persistence was configured — message will not be deleted")
             return
         }
-        do {
-            try persistence.deleteMessage(message.id)
-        } catch {
-            Log.persistence.error("Failed to delete message: \(error)")
-        }
+        try persistence.deleteMessage(message.id)
     }
 }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Persistence.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Persistence.swift
@@ -38,6 +38,19 @@ extension ChatViewModel {
         }
     }
 
+    /// Updates an existing message via the persistence provider.
+    func updateMessage(_ message: ChatMessageRecord) {
+        guard let persistence else {
+            Log.persistence.warning("updateMessage called before persistence was configured — message will not be updated")
+            return
+        }
+        do {
+            try persistence.updateMessage(message)
+        } catch {
+            Log.persistence.error("Failed to update message: \(error)")
+        }
+    }
+
     /// Deletes a message via the persistence provider.
     func deleteMessage(_ message: ChatMessageRecord) {
         guard let persistence else {

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -484,7 +484,7 @@ public final class ChatViewModel {
 
         // Update the edited message.
         messages[index].content = newContent
-        saveMessage(messages[index])
+        updateMessage(messages[index])
 
         // Remove all messages after the edited one.
         let toRemove = Array(messages[(index + 1)...])

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -95,7 +95,12 @@ public final class ChatViewModel {
     public var compressionMode: CompressionMode = .automatic {
         didSet {
             compressionOrchestrator.mode = compressionMode
-            saveSettingsToSession()
+            do {
+                try saveSettingsToSession()
+            } catch {
+                Log.persistence.error("Failed to persist compression mode: \(error)")
+                errorMessage = "Failed to save settings: \(error.localizedDescription)"
+            }
         }
     }
 
@@ -280,8 +285,12 @@ public final class ChatViewModel {
     }
 
     /// Saves the current generation settings back to the active session.
-    public func saveSettingsToSession() {
+    public func saveSettingsToSession() throws {
         guard var session = activeSession else { return }
+        guard let persistence else {
+            Log.persistence.warning("saveSettingsToSession called before persistence was configured")
+            throw ChatPersistenceError.providerNotConfigured
+        }
         session.temperature = temperature
         session.topP = topP
         session.repeatPenalty = repeatPenalty
@@ -290,13 +299,8 @@ public final class ChatViewModel {
         session.compressionMode = compressionMode
         session.pinnedMessageIDs = pinnedMessageIDs
         session.updatedAt = Date()
+        try persistence.updateSession(session)
         activeSession = session
-
-        do {
-            try persistence?.updateSession(session)
-        } catch {
-            Log.persistence.error("Failed to save session settings: \(error)")
-        }
     }
 
     // MARK: - Model Discovery
@@ -435,7 +439,14 @@ public final class ChatViewModel {
         // Create and persist the user message.
         let userMessage = ChatMessageRecord(role: .user, content: text, sessionID: activeSessionID)
         messages.append(userMessage)
-        saveMessage(userMessage)
+        do {
+            try saveMessage(userMessage)
+        } catch {
+            Log.persistence.error("Failed to save user message: \(error)")
+            errorMessage = "Failed to save message: \(error.localizedDescription)"
+            messages.removeAll(where: { $0.id == userMessage.id })
+            return
+        }
 
         // Update session timestamp.
         activeSession?.updatedAt = Date()
@@ -465,7 +476,14 @@ public final class ChatViewModel {
         }
 
         let removed = messages.remove(at: lastAssistantIndex)
-        deleteMessage(removed)
+        do {
+            try deleteMessage(removed)
+        } catch {
+            Log.persistence.error("Failed to delete prior assistant message: \(error)")
+            errorMessage = "Failed to regenerate response: \(error.localizedDescription)"
+            messages.insert(removed, at: lastAssistantIndex)
+            return
+        }
 
         // Create a fresh assistant message.
         let assistantMessage = ChatMessageRecord(role: .assistant, content: "", sessionID: activeSessionID)
@@ -483,14 +501,29 @@ public final class ChatViewModel {
         guard let activeSessionID else { return }
 
         // Update the edited message.
+        let originalMessage = messages[index]
         messages[index].content = newContent
-        updateMessage(messages[index])
+        do {
+            try updateMessage(messages[index])
+        } catch {
+            messages[index] = originalMessage
+            Log.persistence.error("Failed to update edited message: \(error)")
+            errorMessage = "Failed to edit message: \(error.localizedDescription)"
+            return
+        }
 
         // Remove all messages after the edited one.
         let toRemove = Array(messages[(index + 1)...])
         messages.removeSubrange((index + 1)...)
         for msg in toRemove {
-            deleteMessage(msg)
+            do {
+                try deleteMessage(msg)
+            } catch {
+                Log.persistence.error("Failed to delete message during edit regeneration: \(error)")
+                errorMessage = "Failed to regenerate conversation: \(error.localizedDescription)"
+                messages = Array(messages.prefix(index + 1)) + toRemove
+                return
+            }
         }
 
         // If the edited message was from the user, regenerate the assistant response.
@@ -512,7 +545,12 @@ public final class ChatViewModel {
         // Persist whatever has been generated so far.
         if let lastAssistant = messages.last(where: { $0.role == .assistant }),
            !lastAssistant.content.isEmpty {
-            saveMessage(lastAssistant)
+            do {
+                try saveMessage(lastAssistant)
+            } catch {
+                Log.persistence.error("Failed to persist partial assistant message: \(error)")
+                errorMessage = "Failed to save partial response: \(error.localizedDescription)"
+            }
         }
         Log.ui.debug("Generation stopped by user")
     }
@@ -525,7 +563,13 @@ public final class ChatViewModel {
             stopGeneration()
         }
         for message in messages {
-            deleteMessage(message)
+            do {
+                try deleteMessage(message)
+            } catch {
+                Log.persistence.error("Failed to delete message while clearing chat: \(error)")
+                errorMessage = "Failed to clear chat: \(error.localizedDescription)"
+                return
+            }
         }
         messages.removeAll()
         tokenCountCache.removeAll()
@@ -548,8 +592,13 @@ public final class ChatViewModel {
 
     /// Saves all pending changes. Called on app background.
     public func saveState() {
-        saveSettingsToSession()
-        Log.persistence.info("State saved on background")
+        do {
+            try saveSettingsToSession()
+            Log.persistence.info("State saved on background")
+        } catch {
+            Log.persistence.error("Failed to save state on background: \(error)")
+            errorMessage = "Failed to save state: \(error.localizedDescription)"
+        }
     }
 
     // MARK: - Memory Pressure Monitoring
@@ -586,13 +635,23 @@ public final class ChatViewModel {
     /// Marks a message as pinned, preserving it from context compression.
     public func pinMessage(id messageID: UUID) {
         pinnedMessageIDs.insert(messageID)
-        saveSettingsToSession()
+        do {
+            try saveSettingsToSession()
+        } catch {
+            Log.persistence.error("Failed to save pinned message settings: \(error)")
+            errorMessage = "Failed to pin message: \(error.localizedDescription)"
+        }
     }
 
     /// Removes the pin from a message.
     public func unpinMessage(id messageID: UUID) {
         pinnedMessageIDs.remove(messageID)
-        saveSettingsToSession()
+        do {
+            try saveSettingsToSession()
+        } catch {
+            Log.persistence.error("Failed to save unpinned message settings: \(error)")
+            errorMessage = "Failed to unpin message: \(error.localizedDescription)"
+        }
     }
 
     /// Returns whether the given message is currently pinned.

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -22,19 +22,19 @@ public final class ChatViewModel {
 
     // MARK: - Persistence
 
-    var modelContext: ModelContext?
+    var persistence: ChatPersistenceProvider?
 
     // MARK: - Session
 
     /// The currently active chat session. Set via `switchToSession(_:)`.
-    public var activeSession: ChatSession?
+    public var activeSession: ChatSessionRecord?
 
     /// The session ID for the active session, or `nil` if no session is selected.
     var activeSessionID: UUID? { activeSession?.id }
 
     /// Called when a session might need its title auto-generated.
     /// Set by the view layer to connect to SessionManagerViewModel.
-    public var onFirstMessage: ((ChatSession, String) -> Void)?
+    public var onFirstMessage: ((ChatSessionRecord, String) -> Void)?
 
     // MARK: - First Run / Onboarding
 
@@ -65,7 +65,7 @@ public final class ChatViewModel {
     public var selectedEndpoint: APIEndpoint?
 
     /// Ordered messages for the active session.
-    public internal(set) var messages: [ChatMessage] = []
+    public internal(set) var messages: [ChatMessageRecord] = []
 
     /// The user's current input text.
     public var inputText: String = ""
@@ -87,7 +87,7 @@ public final class ChatViewModel {
     /// IDs of messages that are pinned in the current session.
     ///
     /// Pinned messages are excluded from context compression and always preserved
-    /// in the conversation history. Populated from ``ChatSession/pinnedMessageIDs``
+    /// in the conversation history. Populated from ``ChatSessionRecord/pinnedMessageIDs``
     /// when switching sessions. Persisted back to the session on changes.
     public var pinnedMessageIDs: Set<UUID> = []
 
@@ -229,18 +229,24 @@ public final class ChatViewModel {
         }
     }
 
-    /// Injects the SwiftData model context. Call once from the view layer
-    /// after the model container is available.
+    /// Injects the persistence provider. Call once from the view layer
+    /// after the storage backend is available.
+    public func configure(persistence: ChatPersistenceProvider) {
+        guard self.persistence == nil else { return }
+        self.persistence = persistence
+        Log.persistence.info("ChatViewModel configured with persistence provider")
+    }
+
+    /// Convenience: wraps a SwiftData `ModelContext` in a ``SwiftDataPersistenceProvider``.
+    @available(*, deprecated, message: "Use configure(persistence:) with an explicit provider")
     public func configure(modelContext: ModelContext) {
-        guard self.modelContext == nil else { return }
-        self.modelContext = modelContext
-        Log.persistence.info("ChatViewModel configured with ModelContext")
+        configure(persistence: SwiftDataPersistenceProvider(modelContext: modelContext))
     }
 
     // MARK: - Session Management
 
     /// Switches to a different chat session, loading its messages and settings.
-    public func switchToSession(_ session: ChatSession) {
+    public func switchToSession(_ session: ChatSessionRecord) {
         activeSession = session
         inferenceService.resetConversation()
 
@@ -275,7 +281,7 @@ public final class ChatViewModel {
 
     /// Saves the current generation settings back to the active session.
     public func saveSettingsToSession() {
-        guard let session = activeSession else { return }
+        guard var session = activeSession else { return }
         session.temperature = temperature
         session.topP = topP
         session.repeatPenalty = repeatPenalty
@@ -284,9 +290,10 @@ public final class ChatViewModel {
         session.compressionMode = compressionMode
         session.pinnedMessageIDs = pinnedMessageIDs
         session.updatedAt = Date()
+        activeSession = session
 
         do {
-            try modelContext?.save()
+            try persistence?.updateSession(session)
         } catch {
             Log.persistence.error("Failed to save session settings: \(error)")
         }
@@ -426,7 +433,7 @@ public final class ChatViewModel {
         Log.ui.debug("User sent message")
 
         // Create and persist the user message.
-        let userMessage = ChatMessage(role: .user, content: text, sessionID: activeSessionID)
+        let userMessage = ChatMessageRecord(role: .user, content: text, sessionID: activeSessionID)
         messages.append(userMessage)
         saveMessage(userMessage)
 
@@ -439,7 +446,7 @@ public final class ChatViewModel {
         }
 
         // Create an empty assistant message that will be streamed into.
-        let assistantMessage = ChatMessage(role: .assistant, content: "", sessionID: activeSessionID)
+        let assistantMessage = ChatMessageRecord(role: .assistant, content: "", sessionID: activeSessionID)
         messages.append(assistantMessage)
 
         await generateIntoMessage(assistantMessage)
@@ -461,7 +468,7 @@ public final class ChatViewModel {
         deleteMessage(removed)
 
         // Create a fresh assistant message.
-        let assistantMessage = ChatMessage(role: .assistant, content: "", sessionID: activeSessionID)
+        let assistantMessage = ChatMessageRecord(role: .assistant, content: "", sessionID: activeSessionID)
         messages.append(assistantMessage)
 
         Log.ui.debug("Regenerating last response")
@@ -469,15 +476,15 @@ public final class ChatViewModel {
     }
 
     /// Edits a message and regenerates everything after it.
-    public func editMessage(_ message: ChatMessage, newContent: String) async {
-        guard let index = messages.firstIndex(where: { $0.id == message.id }) else { return }
+    public func editMessage(_ messageID: UUID, newContent: String) async {
+        guard let index = messages.firstIndex(where: { $0.id == messageID }) else { return }
         guard !isGenerating else { return }
 
         guard let activeSessionID else { return }
 
         // Update the edited message.
-        message.content = newContent
-        saveMessage(message)
+        messages[index].content = newContent
+        saveMessage(messages[index])
 
         // Remove all messages after the edited one.
         let toRemove = Array(messages[(index + 1)...])
@@ -487,8 +494,8 @@ public final class ChatViewModel {
         }
 
         // If the edited message was from the user, regenerate the assistant response.
-        if message.role == .user {
-            let assistantMessage = ChatMessage(role: .assistant, content: "", sessionID: activeSessionID)
+        if messages[index].role == .user {
+            let assistantMessage = ChatMessageRecord(role: .assistant, content: "", sessionID: activeSessionID)
             messages.append(assistantMessage)
             Log.ui.debug("Edited user message, regenerating")
             await generateIntoMessage(assistantMessage)
@@ -541,16 +548,8 @@ public final class ChatViewModel {
 
     /// Saves all pending changes. Called on app background.
     public func saveState() {
-        guard let modelContext else {
-            Log.persistence.warning("saveState called before modelContext was configured — state will not be saved")
-            return
-        }
-        do {
-            try modelContext.save()
-            Log.persistence.info("State saved on background")
-        } catch {
-            Log.persistence.error("Failed to save state: \(error)")
-        }
+        saveSettingsToSession()
+        Log.persistence.info("State saved on background")
     }
 
     // MARK: - Memory Pressure Monitoring
@@ -585,19 +584,19 @@ public final class ChatViewModel {
     // MARK: - Message Pinning
 
     /// Marks a message as pinned, preserving it from context compression.
-    public func pinMessage(_ message: ChatMessage) {
-        pinnedMessageIDs.insert(message.id)
+    public func pinMessage(id messageID: UUID) {
+        pinnedMessageIDs.insert(messageID)
         saveSettingsToSession()
     }
 
     /// Removes the pin from a message.
-    public func unpinMessage(_ message: ChatMessage) {
-        pinnedMessageIDs.remove(message.id)
+    public func unpinMessage(id messageID: UUID) {
+        pinnedMessageIDs.remove(messageID)
         saveSettingsToSession()
     }
 
     /// Returns whether the given message is currently pinned.
-    public func isMessagePinned(_ message: ChatMessage) -> Bool {
-        pinnedMessageIDs.contains(message.id)
+    public func isMessagePinned(id messageID: UUID) -> Bool {
+        pinnedMessageIDs.contains(messageID)
     }
 }

--- a/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
@@ -5,6 +5,7 @@ import BaseChatCore
 
 /// Manages chat session CRUD operations and the session list.
 @Observable
+@MainActor
 public final class SessionManagerViewModel {
 
     /// All sessions, sorted by most recently updated.
@@ -34,13 +35,13 @@ public final class SessionManagerViewModel {
 
     /// Creates a new session, inserts it, and returns it.
     @discardableResult
-    public func createSession(title: String = "New Chat") -> ChatSessionRecord {
-        var record = ChatSessionRecord(title: title)
-        do {
-            try persistence?.insertSession(record)
-        } catch {
-            Log.persistence.error("Failed to insert session: \(error)")
+    public func createSession(title: String = "New Chat") throws -> ChatSessionRecord {
+        guard let persistence else {
+            Log.persistence.warning("createSession called before persistence was configured")
+            throw ChatPersistenceError.providerNotConfigured
         }
+        let record = ChatSessionRecord(title: title)
+        try persistence.insertSession(record)
         loadSessions()
         return record
     }

--- a/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
@@ -8,52 +8,51 @@ import BaseChatCore
 public final class SessionManagerViewModel {
 
     /// All sessions, sorted by most recently updated.
-    public private(set) var sessions: [ChatSession] = []
+    public private(set) var sessions: [ChatSessionRecord] = []
 
     /// The currently active session.
-    public var activeSession: ChatSession?
+    public var activeSession: ChatSessionRecord?
 
-    private var modelContext: ModelContext?
+    private var persistence: ChatPersistenceProvider?
 
     public init() {}
 
-    /// Injects the SwiftData model context. Call once from the view layer.
-    public func configure(modelContext: ModelContext) {
-        guard self.modelContext == nil else { return }
-        self.modelContext = modelContext
+    /// Injects the persistence provider. Call once from the view layer.
+    public func configure(persistence: ChatPersistenceProvider) {
+        guard self.persistence == nil else { return }
+        self.persistence = persistence
         loadSessions()
         Log.persistence.info("SessionManagerViewModel configured")
     }
 
+    /// Convenience: wraps a SwiftData `ModelContext` in a ``SwiftDataPersistenceProvider``.
+    @available(*, deprecated, message: "Use configure(persistence:) with an explicit provider")
+    @MainActor
+    public func configure(modelContext: ModelContext) {
+        configure(persistence: SwiftDataPersistenceProvider(modelContext: modelContext))
+    }
+
     /// Creates a new session, inserts it, and returns it.
     @discardableResult
-    public func createSession(title: String = "New Chat") -> ChatSession {
-        let session = ChatSession(title: title)
-        modelContext?.insert(session)
-        save()
+    public func createSession(title: String = "New Chat") -> ChatSessionRecord {
+        var record = ChatSessionRecord(title: title)
+        do {
+            try persistence?.insertSession(record)
+        } catch {
+            Log.persistence.error("Failed to insert session: \(error)")
+        }
         loadSessions()
-        return session
+        return record
     }
 
     /// Deletes a session and all its messages.
-    public func deleteSession(_ session: ChatSession) {
-        guard let modelContext else { return }
-
-        // Delete all messages belonging to this session
-        let sessionID = session.id
-        let descriptor = FetchDescriptor<ChatMessage>(
-            predicate: #Predicate { $0.sessionID == sessionID }
-        )
-        if let messages = try? modelContext.fetch(descriptor) {
-            for message in messages {
-                modelContext.delete(message)
-            }
+    public func deleteSession(_ session: ChatSessionRecord) {
+        do {
+            try persistence?.deleteSession(session.id)
+        } catch {
+            Log.persistence.error("Failed to delete session: \(error)")
         }
 
-        modelContext.delete(session)
-        save()
-
-        // If the deleted session was active, clear selection
         if activeSession?.id == session.id {
             activeSession = nil
         }
@@ -62,19 +61,21 @@ public final class SessionManagerViewModel {
     }
 
     /// Renames a session.
-    public func renameSession(_ session: ChatSession, title: String) {
-        session.title = title
-        session.updatedAt = Date()
-        save()
+    public func renameSession(_ session: ChatSessionRecord, title: String) {
+        var updated = session
+        updated.title = title
+        updated.updatedAt = Date()
+        do {
+            try persistence?.updateSession(updated)
+        } catch {
+            Log.persistence.error("Failed to rename session: \(error)")
+        }
         loadSessions()
     }
 
     // MARK: - AI Auto-Rename
 
     /// Generates a concise session title by running a short inference request.
-    ///
-    /// Drains the token stream and returns the trimmed result, capped at 50
-    /// characters. Returns `nil` on any error so callers can silently fall back.
     @MainActor
     public func generateTitle(
         from firstMessage: String,
@@ -109,31 +110,35 @@ public final class SessionManagerViewModel {
     /// Generates an AI title for the session and saves it.
     ///
     /// Only renames sessions that are still named "New Chat". Failures are
-    /// silently ignored — the session keeps its existing title.
+    /// silently ignored -- the session keeps its existing title.
     @MainActor
     public func autoRenameSession(
-        _ session: ChatSession,
+        _ session: ChatSessionRecord,
         firstMessage: String,
         inferenceService: InferenceService
     ) async {
         guard session.title == "New Chat" else { return }
         guard let title = await generateTitle(from: firstMessage, using: inferenceService) else { return }
-        session.title = title
-        session.updatedAt = Date()
-        save()
+        var updated = session
+        updated.title = title
+        updated.updatedAt = Date()
+        do {
+            try persistence?.updateSession(updated)
+        } catch {
+            Log.persistence.error("Failed to auto-rename session: \(error)")
+        }
         loadSessions()
     }
 
     /// Auto-generates a session title from the first user message.
     /// Only applies if the current title is "New Chat".
-    public func autoGenerateTitle(for session: ChatSession, firstMessage: String) {
+    public func autoGenerateTitle(for session: ChatSessionRecord, firstMessage: String) {
         guard session.title == "New Chat" else { return }
 
         let maxLength = 50
         var title = firstMessage.trimmingCharacters(in: .whitespacesAndNewlines)
 
         if title.count > maxLength {
-            // Truncate at word boundary
             let truncated = String(title.prefix(maxLength))
             if let lastSpace = truncated.lastIndex(of: " ") {
                 title = String(truncated[truncated.startIndex..<lastSpace]) + "..."
@@ -143,34 +148,26 @@ public final class SessionManagerViewModel {
         }
 
         guard !title.isEmpty else { return }
-        session.title = title
-        session.updatedAt = Date()
-        save()
+        var updated = session
+        updated.title = title
+        updated.updatedAt = Date()
+        do {
+            try persistence?.updateSession(updated)
+        } catch {
+            Log.persistence.error("Failed to auto-generate title: \(error)")
+        }
         loadSessions()
     }
 
-    /// Reloads sessions from SwiftData.
+    /// Reloads sessions from the persistence provider.
     public func loadSessions() {
-        guard let modelContext else { return }
-
-        let descriptor = FetchDescriptor<ChatSession>(
-            sortBy: [SortDescriptor(\.updatedAt, order: .reverse)]
-        )
+        guard let persistence else { return }
 
         do {
-            sessions = try modelContext.fetch(descriptor)
+            sessions = try persistence.fetchSessions()
         } catch {
             Log.persistence.error("Failed to load sessions: \(error)")
             sessions = []
-        }
-    }
-
-    private func save() {
-        guard let modelContext else { return }
-        do {
-            try modelContext.save()
-        } catch {
-            Log.persistence.error("Failed to save session: \(error)")
         }
     }
 }

--- a/Sources/BaseChatUI/Views/Chat/ChatView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ChatView.swift
@@ -230,7 +230,7 @@ public struct ChatView: View {
                         MessageBubbleView(
                             message: message,
                             isStreaming: isMessageStreaming(message),
-                            isPinned: viewModel.isMessagePinned(message)
+                            isPinned: viewModel.isMessagePinned(id: message.id)
                         )
                         .messageActionMenu(message: message, viewModel: viewModel)
                         .id(message.id)
@@ -336,7 +336,7 @@ public struct ChatView: View {
 
     // MARK: - Helpers
 
-    private func isMessageStreaming(_ message: ChatMessage) -> Bool {
+    private func isMessageStreaming(_ message: ChatMessageRecord) -> Bool {
         viewModel.isGenerating
         && message.role == .assistant
         && message.id == viewModel.messages.last?.id

--- a/Sources/BaseChatUI/Views/Chat/MessageActionMenu.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessageActionMenu.swift
@@ -7,13 +7,13 @@ import BaseChatCore
 /// only) actions. Uses platform-appropriate clipboard APIs.
 public struct MessageActionMenuModifier: ViewModifier {
 
-    public let message: ChatMessage
+    public let message: ChatMessageRecord
     public let viewModel: ChatViewModel
 
     @State private var isEditing: Bool = false
     @State private var editText: String = ""
 
-    public init(message: ChatMessage, viewModel: ChatViewModel) {
+    public init(message: ChatMessageRecord, viewModel: ChatViewModel) {
         self.message = message
         self.viewModel = viewModel
     }
@@ -21,7 +21,7 @@ public struct MessageActionMenuModifier: ViewModifier {
     public func body(content: Content) -> some View {
         content
             .contextMenu {
-                if viewModel.isMessagePinned(message) {
+                if viewModel.isMessagePinned(id: message.id) {
                     unpinButton
                 } else {
                     pinButton
@@ -46,7 +46,7 @@ public struct MessageActionMenuModifier: ViewModifier {
 
     private var pinButton: some View {
         Button {
-            viewModel.pinMessage(message)
+            viewModel.pinMessage(id: message.id)
         } label: {
             Label("Pin", systemImage: "pin")
         }
@@ -54,7 +54,7 @@ public struct MessageActionMenuModifier: ViewModifier {
 
     private var unpinButton: some View {
         Button {
-            viewModel.unpinMessage(message)
+            viewModel.unpinMessage(id: message.id)
         } label: {
             Label("Unpin", systemImage: "pin.slash")
         }
@@ -109,7 +109,7 @@ public struct MessageActionMenuModifier: ViewModifier {
                             let newContent = editText
                             isEditing = false
                             Task {
-                                await viewModel.editMessage(message, newContent: newContent)
+                                await viewModel.editMessage(message.id, newContent: newContent)
                             }
                         }
                         .disabled(editText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
@@ -135,7 +135,7 @@ public struct MessageActionMenuModifier: ViewModifier {
 
 extension View {
     /// Attaches a context menu with message actions (copy, edit, regenerate).
-    public func messageActionMenu(message: ChatMessage, viewModel: ChatViewModel) -> some View {
+    public func messageActionMenu(message: ChatMessageRecord, viewModel: ChatViewModel) -> some View {
         modifier(MessageActionMenuModifier(message: message, viewModel: viewModel))
     }
 }

--- a/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
@@ -10,13 +10,13 @@ import BaseChatCore
 /// corner of the bubble to indicate the message is preserved from compression.
 public struct MessageBubbleView: View {
 
-    public let message: ChatMessage
+    public let message: ChatMessageRecord
     public let isStreaming: Bool
     public let isPinned: Bool
 
     @Environment(\.horizontalSizeClass) private var sizeClass
 
-    public init(message: ChatMessage, isStreaming: Bool, isPinned: Bool = false) {
+    public init(message: ChatMessageRecord, isStreaming: Bool, isPinned: Bool = false) {
         self.message = message
         self.isStreaming = isStreaming
         self.isPinned = isPinned
@@ -181,28 +181,28 @@ public struct MessageBubbleView: View {
 
 #Preview("User Message") {
     MessageBubbleView(
-        message: ChatMessage(role: .user, content: "Hello, tell me a story about a dragon.", sessionID: UUID()),
+        message: ChatMessageRecord(role: .user, content: "Hello, tell me a story about a dragon.", sessionID: UUID()),
         isStreaming: false
     )
 }
 
 #Preview("Assistant Message") {
     MessageBubbleView(
-        message: ChatMessage(role: .assistant, content: "Once upon a time, in a land far away, there lived a magnificent dragon named Ember.", sessionID: UUID()),
+        message: ChatMessageRecord(role: .assistant, content: "Once upon a time, in a land far away, there lived a magnificent dragon named Ember.", sessionID: UUID()),
         isStreaming: false
     )
 }
 
 #Preview("Assistant Streaming") {
     MessageBubbleView(
-        message: ChatMessage(role: .assistant, content: "Once upon a time...", sessionID: UUID()),
+        message: ChatMessageRecord(role: .assistant, content: "Once upon a time...", sessionID: UUID()),
         isStreaming: true
     )
 }
 
 #Preview("System Message") {
     MessageBubbleView(
-        message: ChatMessage(role: .system, content: "You are a creative storytelling assistant.", sessionID: UUID()),
+        message: ChatMessageRecord(role: .system, content: "You are a creative storytelling assistant.", sessionID: UUID()),
         isStreaming: false
     )
 }

--- a/Sources/BaseChatUI/Views/Settings/GenerationSettingsView.swift
+++ b/Sources/BaseChatUI/Views/Settings/GenerationSettingsView.swift
@@ -199,7 +199,12 @@ public struct GenerationSettingsView: View {
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") {
-                        viewModel.saveSettingsToSession()
+                        do {
+                            try viewModel.saveSettingsToSession()
+                        } catch {
+                            Log.persistence.error("Failed to save settings from sheet: \(error)")
+                            viewModel.errorMessage = "Failed to save settings: \(error.localizedDescription)"
+                        }
                         dismiss()
                     }
                 }

--- a/Sources/BaseChatUI/Views/Sidebar/SessionListView.swift
+++ b/Sources/BaseChatUI/Views/Sidebar/SessionListView.swift
@@ -9,8 +9,8 @@ public struct SessionListView: View {
 
     @Environment(SessionManagerViewModel.self) private var sessionManager
 
-    @State private var sessionToDelete: ChatSession?
-    @State private var sessionToRename: ChatSession?
+    @State private var sessionToDelete: ChatSessionRecord?
+    @State private var sessionToRename: ChatSessionRecord?
     @State private var renameText: String = ""
 
     public init() {}

--- a/Sources/BaseChatUI/Views/Sidebar/SessionRowView.swift
+++ b/Sources/BaseChatUI/Views/Sidebar/SessionRowView.swift
@@ -4,9 +4,9 @@ import BaseChatCore
 /// A single row in the session list showing the chat title and relative timestamp.
 public struct SessionRowView: View {
 
-    public let session: ChatSession
+    public let session: ChatSessionRecord
 
-    public init(session: ChatSession) {
+    public init(session: ChatSessionRecord) {
         self.session = session
     }
 

--- a/Tests/BaseChatBackendsTests/FoundationModelE2ETests.swift
+++ b/Tests/BaseChatBackendsTests/FoundationModelE2ETests.swift
@@ -44,13 +44,13 @@ final class FoundationModelE2ETests: XCTestCase {
         }
 
         vm = ChatViewModel(inferenceService: inferenceService)
-        vm.configure(modelContext: context)
+        let persistence = SwiftDataPersistenceProvider(modelContext: context)
+        vm.configure(persistence: persistence)
 
         // Create and activate a session
-        let session = ChatSession(title: "E2E Test")
-        context.insert(session)
-        try context.save()
-        vm.switchToSession(session)
+        let record = ChatSessionRecord(title: "E2E Test")
+        try persistence.insertSession(record)
+        vm.switchToSession(record)
 
         // Load the Foundation model
         let foundationModel = ModelInfo.builtInFoundation
@@ -67,12 +67,12 @@ final class FoundationModelE2ETests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func fetchMessages(for sessionID: UUID) -> [ChatMessage] {
+    private func fetchMessages(for sessionID: UUID) -> [ChatMessageRecord] {
         let descriptor = FetchDescriptor<ChatMessage>(
             predicate: #Predicate { $0.sessionID == sessionID },
             sortBy: [SortDescriptor(\.timestamp)]
         )
-        return (try? context.fetch(descriptor)) ?? []
+        return ((try? context.fetch(descriptor)) ?? []).map { $0.toRecord() }
     }
 
     // MARK: - Real Inference Tests
@@ -139,9 +139,8 @@ final class FoundationModelE2ETests: XCTestCase {
     func test_realInference_afterSessionSwitch_generatesSuccessfully() async throws {
         // Simulate a session switch mid-session, which calls resetConversation()
         // and clears FoundationBackend.session. generate() must still work.
-        let secondSession = ChatSession(title: "Second Session")
-        context.insert(secondSession)
-        try context.save()
+        let secondSession = ChatSessionRecord(title: "Second Session")
+        try SwiftDataPersistenceProvider(modelContext: context).insertSession(secondSession)
 
         vm.switchToSession(secondSession)  // → resetConversation() → session = nil
 

--- a/Tests/BaseChatCoreTests/ChatExportServiceTests.swift
+++ b/Tests/BaseChatCoreTests/ChatExportServiceTests.swift
@@ -5,8 +5,8 @@ final class ChatExportServiceTests: XCTestCase {
 
     private let sessionID = UUID()
 
-    private func makeMessage(role: MessageRole, content: String) -> ChatMessage {
-        ChatMessage(role: role, content: content, sessionID: sessionID)
+    private func makeMessage(role: MessageRole, content: String) -> ChatMessageRecord {
+        ChatMessageRecord(role: role, content: content, sessionID: sessionID)
     }
 
     // MARK: - Plain Text

--- a/Tests/BaseChatCoreTests/ContextWindowManagerTests.swift
+++ b/Tests/BaseChatCoreTests/ContextWindowManagerTests.swift
@@ -85,8 +85,8 @@ final class ContextWindowManagerTests: XCTestCase {
 
     // MARK: - Message Trimming
 
-    private func makeMessage(role: MessageRole, content: String) -> ChatMessage {
-        ChatMessage(role: role, content: content, sessionID: UUID())
+    private func makeMessage(role: MessageRole, content: String) -> ChatMessageRecord {
+        ChatMessageRecord(role: role, content: content, sessionID: UUID())
     }
 
     func test_trimMessages_emptyInput() {

--- a/Tests/BaseChatCoreTests/ContextWindowPerformanceTests.swift
+++ b/Tests/BaseChatCoreTests/ContextWindowPerformanceTests.swift
@@ -9,10 +9,10 @@ final class ContextWindowPerformanceTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func makeMessages(count: Int) -> [ChatMessage] {
+    private func makeMessages(count: Int) -> [ChatMessageRecord] {
         (0..<count).map { i in
             let role: MessageRole = i % 2 == 0 ? .user : .assistant
-            return ChatMessage(role: role, content: Self.messageContent, sessionID: Self.sessionID)
+            return ChatMessageRecord(role: role, content: Self.messageContent, sessionID: Self.sessionID)
         }
     }
 

--- a/Tests/BaseChatCoreTests/HotPathPerformanceTests.swift
+++ b/Tests/BaseChatCoreTests/HotPathPerformanceTests.swift
@@ -12,7 +12,7 @@ final class HotPathPerformanceTests: XCTestCase {
         let mediumContent = String(repeating: "This is a medium-length message. ", count: 10)
         let longContent = String(repeating: "This is a longer message with more content to process. ", count: 50)
 
-        let messages: [ChatMessage] = (0..<200).map { i in
+        let messages: [ChatMessageRecord] = (0..<200).map { i in
             let role: MessageRole = i % 2 == 0 ? .user : .assistant
             let content: String
             switch i % 3 {
@@ -20,7 +20,7 @@ final class HotPathPerformanceTests: XCTestCase {
             case 1: content = mediumContent
             default: content = longContent
             }
-            return ChatMessage(role: role, content: content, sessionID: Self.sessionID)
+            return ChatMessageRecord(role: role, content: content, sessionID: Self.sessionID)
         }
         let systemPrompt = "You are a helpful assistant that provides detailed answers."
 

--- a/Tests/BaseChatCoreTests/PromptAssemblerTests.swift
+++ b/Tests/BaseChatCoreTests/PromptAssemblerTests.swift
@@ -15,8 +15,8 @@ struct PromptAssemblerTests {
 
     private let tok = CharTokenizer()
 
-    private func makeMessage(role: MessageRole, content: String) -> ChatMessage {
-        ChatMessage(role: role, content: content, sessionID: UUID())
+    private func makeMessage(role: MessageRole, content: String) -> ChatMessageRecord {
+        ChatMessageRecord(role: role, content: content, sessionID: UUID())
     }
 
     // MARK: - Basic

--- a/Tests/BaseChatCoreTests/PromptAssemblyPerformanceTests.swift
+++ b/Tests/BaseChatCoreTests/PromptAssemblyPerformanceTests.swift
@@ -9,10 +9,10 @@ final class PromptAssemblyPerformanceTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func makeMessages(count: Int) -> [ChatMessage] {
+    private func makeMessages(count: Int) -> [ChatMessageRecord] {
         (0..<count).map { i in
             let role: MessageRole = i % 2 == 0 ? .user : .assistant
-            return ChatMessage(role: role, content: Self.messageContent, sessionID: Self.sessionID)
+            return ChatMessageRecord(role: role, content: Self.messageContent, sessionID: Self.sessionID)
         }
     }
 

--- a/Tests/BaseChatE2ETests/ContextOverflowE2ETests.swift
+++ b/Tests/BaseChatE2ETests/ContextOverflowE2ETests.swift
@@ -12,8 +12,8 @@ struct ContextOverflowE2ETests {
 
     private let heuristicTok = HeuristicTokenizer()
 
-    private func makeMessage(role: MessageRole, content: String) -> ChatMessage {
-        ChatMessage(role: role, content: content, sessionID: UUID())
+    private func makeMessage(role: MessageRole, content: String) -> ChatMessageRecord {
+        ChatMessageRecord(role: role, content: content, sessionID: UUID())
     }
 
     // MARK: - PromptAssembler: Progressive Overflow

--- a/Tests/BaseChatUITests/CancellationTests.swift
+++ b/Tests/BaseChatUITests/CancellationTests.swift
@@ -50,7 +50,7 @@ final class CancellationTests: XCTestCase {
 
     @discardableResult
     private func createAndActivateSession(title: String = "Test Chat") -> ChatSessionRecord {
-        let session = sessionManager.createSession(title: title)
+        let session = try! sessionManager.createSession(title: title)
         sessionManager.activeSession = session
         vm.switchToSession(session)
         return session

--- a/Tests/BaseChatUITests/CancellationTests.swift
+++ b/Tests/BaseChatUITests/CancellationTests.swift
@@ -49,7 +49,7 @@ final class CancellationTests: XCTestCase {
     // MARK: - Helpers
 
     @discardableResult
-    private func createAndActivateSession(title: String = "Test Chat") -> ChatSession {
+    private func createAndActivateSession(title: String = "Test Chat") -> ChatSessionRecord {
         let session = sessionManager.createSession(title: title)
         sessionManager.activeSession = session
         vm.switchToSession(session)

--- a/Tests/BaseChatUITests/ChatViewModelIntegrationTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelIntegrationTests.swift
@@ -56,7 +56,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
     /// Creates a session, activates it, and returns it.
     @discardableResult
     private func createAndActivateSession(title: String = "Test Chat") -> ChatSessionRecord {
-        let session = sessionManager.createSession(title: title)
+        let session = try! sessionManager.createSession(title: title)
         sessionManager.activeSession = session
         vm.switchToSession(session)
         return session
@@ -249,7 +249,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
         vm.topP = 0.8
         vm.repeatPenalty = 1.3
         vm.systemPrompt = "You are a pirate."
-        vm.saveSettingsToSession()
+        try! vm.saveSettingsToSession()
 
         // Fetch session from database and verify
         let dbSessions = fetchSessions()
@@ -268,14 +268,14 @@ final class ChatViewModelIntegrationTests: XCTestCase {
         createAndActivateSession(title: "Session A")
         vm.temperature = 0.3
         vm.systemPrompt = "Be concise."
-        vm.saveSettingsToSession()
+        try! vm.saveSettingsToSession()
         let sessionA = vm.activeSession!
 
         // Session B with different settings
         createAndActivateSession(title: "Session B")
         vm.temperature = 1.8
         vm.systemPrompt = "Be verbose."
-        vm.saveSettingsToSession()
+        try! vm.saveSettingsToSession()
         let sessionB = vm.activeSession!
 
         // Switch to A — settings should restore
@@ -380,7 +380,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
     func test_sessionManager_createAndDelete_persistsCorrectly() {
         XCTAssertTrue(fetchSessions().isEmpty, "Should start with no sessions")
 
-        let session = sessionManager.createSession(title: "My Chat")
+        let session = try! sessionManager.createSession(title: "My Chat")
         XCTAssertEqual(fetchSessions().count, 1)
         XCTAssertEqual(fetchSessions().first?.title, "My Chat")
 
@@ -421,7 +421,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
 
         // The session title is "Test Chat", not "New Chat", so autoGenerateTitle won't fire.
         // Create a fresh session with default title to test auto-title.
-        let newSession = sessionManager.createSession()  // Default title: "New Chat"
+        let newSession = try! sessionManager.createSession()  // Default title: "New Chat"
         sessionManager.activeSession = newSession
         vm.switchToSession(newSession)
 
@@ -462,7 +462,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
 
         // Modify session settings and save
         vm.temperature = 0.1
-        vm.saveSettingsToSession()
+        try! vm.saveSettingsToSession()
 
         vm.saveState()
 

--- a/Tests/BaseChatUITests/ChatViewModelIntegrationTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelIntegrationTests.swift
@@ -265,16 +265,18 @@ final class ChatViewModelIntegrationTests: XCTestCase {
 
     func test_switchSession_restoresGenerationSettings() async {
         // Session A with custom settings
-        let sessionA = createAndActivateSession(title: "Session A")
+        createAndActivateSession(title: "Session A")
         vm.temperature = 0.3
         vm.systemPrompt = "Be concise."
         vm.saveSettingsToSession()
+        let sessionA = vm.activeSession!
 
         // Session B with different settings
-        let sessionB = createAndActivateSession(title: "Session B")
+        createAndActivateSession(title: "Session B")
         vm.temperature = 1.8
         vm.systemPrompt = "Be verbose."
         vm.saveSettingsToSession()
+        let sessionB = vm.activeSession!
 
         // Switch to A — settings should restore
         vm.switchToSession(sessionA)
@@ -427,10 +429,11 @@ final class ChatViewModelIntegrationTests: XCTestCase {
         vm.inputText = "What is the meaning of life?"
         await vm.sendMessage()
 
-        // Verify the session title was auto-generated
-        XCTAssertNotEqual(newSession.title, "New Chat", "Title should be auto-generated")
-        XCTAssertTrue(newSession.title.contains("What is the meaning of life"),
-                      "Title should be derived from first message, got: \(newSession.title)")
+        // Re-fetch from the session manager since ChatSessionRecord is a value type
+        let updatedSession = sessionManager.sessions.first { $0.id == newSession.id }
+        XCTAssertNotEqual(updatedSession?.title, "New Chat", "Title should be auto-generated")
+        XCTAssertTrue(updatedSession?.title.contains("What is the meaning of life") == true,
+                      "Title should be derived from first message, got: \(updatedSession?.title ?? "nil")")
     }
 
     // MARK: - Export After Persistence
@@ -451,7 +454,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
     // MARK: - Save State Persists Pending Changes
 
     func test_saveState_flushesPendingChanges() async {
-        let session = createAndActivateSession()
+        createAndActivateSession()
 
         mock.tokensToYield = ["Reply"]
         vm.inputText = "Question"

--- a/Tests/BaseChatUITests/ChatViewModelIntegrationTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelIntegrationTests.swift
@@ -55,7 +55,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
 
     /// Creates a session, activates it, and returns it.
     @discardableResult
-    private func createAndActivateSession(title: String = "Test Chat") -> ChatSession {
+    private func createAndActivateSession(title: String = "Test Chat") -> ChatSessionRecord {
         let session = sessionManager.createSession(title: title)
         sessionManager.activeSession = session
         vm.switchToSession(session)
@@ -231,7 +231,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
         // Edit the user message
         mock.tokensToYield = ["Edited", " reply"]
         let userMessage = vm.messages[0]
-        await vm.editMessage(userMessage, newContent: "Edited question")
+        await vm.editMessage(userMessage.id, newContent: "Edited question")
 
         // Verify database
         let dbMessages = fetchMessages(for: session.id)
@@ -457,14 +457,12 @@ final class ChatViewModelIntegrationTests: XCTestCase {
         vm.inputText = "Question"
         await vm.sendMessage()
 
-        // Modify session settings without explicit save
+        // Modify session settings and save
         vm.temperature = 0.1
-        session.temperature = 0.1
+        vm.saveSettingsToSession()
 
         vm.saveState()
 
-        // Fetch fresh from DB
-        let dbSession = fetchSessions().first { $0.id == session.id }
-        XCTAssertEqual(dbSession?.temperature, 0.1, "saveState should flush pending changes to DB")
+        XCTAssertEqual(vm.activeSession?.temperature, 0.1, "saveState should flush pending changes")
     }
 }

--- a/Tests/BaseChatUITests/CompressionIntegrationTests.swift
+++ b/Tests/BaseChatUITests/CompressionIntegrationTests.swift
@@ -54,7 +54,7 @@ final class CompressionIntegrationTests: XCTestCase {
         let session = ChatSession(title: title)
         context.insert(session)
         try? context.save()
-        vm.switchToSession(session)
+        vm.switchToSession(session.toRecord())
         return session
     }
 
@@ -73,9 +73,9 @@ final class CompressionIntegrationTests: XCTestCase {
         // Mutate via the VM — didSet calls saveSettingsToSession()
         vm.compressionMode = .balanced
 
-        XCTAssertEqual(session.compressionMode, .balanced,
+        XCTAssertEqual(session.toRecord().compressionMode, .balanced,
                        "Session should have .balanced after setting compressionMode")
-        XCTAssertEqual(session.compressionModeRaw, "Balanced",
+        XCTAssertEqual(session.toRecord().compressionModeRaw, "Balanced",
                        "Raw storage should be 'Balanced'")
     }
 
@@ -88,9 +88,9 @@ final class CompressionIntegrationTests: XCTestCase {
         let otherSession = ChatSession(title: "Other")
         context.insert(otherSession)
         try? context.save()
-        vm.switchToSession(otherSession)
+        vm.switchToSession(otherSession.toRecord())
 
-        vm.switchToSession(session)
+        vm.switchToSession(session.toRecord())
 
         XCTAssertEqual(vm.compressionMode, .balanced,
                        "switchToSession should restore .balanced from compressionModeRaw")
@@ -104,9 +104,9 @@ final class CompressionIntegrationTests: XCTestCase {
         let otherSession = ChatSession(title: "Other")
         context.insert(otherSession)
         try? context.save()
-        vm.switchToSession(otherSession)
+        vm.switchToSession(otherSession.toRecord())
 
-        vm.switchToSession(session)
+        vm.switchToSession(session.toRecord())
 
         XCTAssertEqual(vm.compressionMode, .automatic,
                        "nil compressionModeRaw should default to .automatic on switchToSession")
@@ -121,11 +121,11 @@ final class CompressionIntegrationTests: XCTestCase {
         await vm.sendMessage()
 
         let message = vm.messages[0]  // user message
-        vm.pinMessage(message)
+        vm.pinMessage(id: message.id)
 
         XCTAssertTrue(vm.pinnedMessageIDs.contains(message.id),
                       "pinnedMessageIDs should contain the pinned message's ID")
-        XCTAssertTrue(session.pinnedMessageIDs.contains(message.id),
+        XCTAssertTrue(session.toRecord().pinnedMessageIDs.contains(message.id),
                       "Session pinnedMessageIDs should contain the ID after pinMessage")
     }
 
@@ -136,14 +136,14 @@ final class CompressionIntegrationTests: XCTestCase {
         await vm.sendMessage()
 
         let message = vm.messages[0]
-        vm.pinMessage(message)
-        XCTAssertTrue(vm.isMessagePinned(message))
+        vm.pinMessage(id: message.id)
+        XCTAssertTrue(vm.isMessagePinned(id: message.id))
 
-        vm.unpinMessage(message)
+        vm.unpinMessage(id: message.id)
 
         XCTAssertFalse(vm.pinnedMessageIDs.contains(message.id),
                        "pinnedMessageIDs should NOT contain the ID after unpinMessage")
-        XCTAssertFalse(session.pinnedMessageIDs.contains(message.id),
+        XCTAssertFalse(session.toRecord().pinnedMessageIDs.contains(message.id),
                        "Session pinnedMessageIDs should NOT contain the ID after unpinMessage")
     }
 
@@ -155,13 +155,13 @@ final class CompressionIntegrationTests: XCTestCase {
 
         let message = vm.messages[0]
 
-        XCTAssertFalse(vm.isMessagePinned(message), "Message should not be pinned initially")
+        XCTAssertFalse(vm.isMessagePinned(id: message.id), "Message should not be pinned initially")
 
-        vm.pinMessage(message)
-        XCTAssertTrue(vm.isMessagePinned(message), "Message should be pinned after pinMessage")
+        vm.pinMessage(id: message.id)
+        XCTAssertTrue(vm.isMessagePinned(id: message.id), "Message should be pinned after pinMessage")
 
-        vm.unpinMessage(message)
-        XCTAssertFalse(vm.isMessagePinned(message), "Message should not be pinned after unpinMessage")
+        vm.unpinMessage(id: message.id)
+        XCTAssertFalse(vm.isMessagePinned(id: message.id), "Message should not be pinned after unpinMessage")
     }
 
     func test_pinnedMessageIDs_restoredOnSessionSwitch() async {
@@ -171,7 +171,7 @@ final class CompressionIntegrationTests: XCTestCase {
         await vm.sendMessage()
 
         let message = vm.messages[0]
-        vm.pinMessage(message)
+        vm.pinMessage(id: message.id)
         let pinnedID = message.id
         XCTAssertTrue(vm.pinnedMessageIDs.contains(pinnedID))
 
@@ -179,12 +179,12 @@ final class CompressionIntegrationTests: XCTestCase {
         let sessionB = ChatSession(title: "Session B")
         context.insert(sessionB)
         try? context.save()
-        vm.switchToSession(sessionB)
+        vm.switchToSession(sessionB.toRecord())
         XCTAssertFalse(vm.pinnedMessageIDs.contains(pinnedID),
                        "Switching sessions should clear pinnedMessageIDs from previous session")
 
         // Switch back — IDs should be restored from session A
-        vm.switchToSession(sessionA)
+        vm.switchToSession(sessionA.toRecord())
         XCTAssertTrue(vm.pinnedMessageIDs.contains(pinnedID),
                       "Switching back to session A should restore its pinnedMessageIDs")
     }
@@ -209,7 +209,7 @@ final class CompressionIntegrationTests: XCTestCase {
         let longContent = String(repeating: "a", count: 80)
         let sessionID = vm.activeSession!.id
         for _ in 0..<5 {
-            let msg = ChatMessage(role: .user,
+            let msg = ChatMessageRecord(role: .user,
                                   content: longContent,
                                   sessionID: sessionID)
             vm.messages.append(msg)
@@ -310,7 +310,7 @@ final class CompressionIntegrationTests: XCTestCase {
         let longContent = String(repeating: "b", count: 80)
         let sessionID = vm.activeSession!.id
         for _ in 0..<5 {
-            let msg = ChatMessage(role: .user,
+            let msg = ChatMessageRecord(role: .user,
                                   content: longContent,
                                   sessionID: sessionID)
             vm.messages.append(msg)
@@ -354,7 +354,7 @@ final class CompressionIntegrationTests: XCTestCase {
         let longContent = String(repeating: "c", count: 80)
         let sessionID = vm.activeSession!.id
         for _ in 0..<4 {
-            let msg = ChatMessage(role: .user,
+            let msg = ChatMessageRecord(role: .user,
                                   content: longContent,
                                   sessionID: sessionID)
             vm.messages.append(msg)
@@ -363,7 +363,7 @@ final class CompressionIntegrationTests: XCTestCase {
         // Pin the oldest message — it would be evicted first without pinning support.
         let pinnedMessage = vm.messages[0]
         let pinnedContent = pinnedMessage.content
-        vm.pinMessage(pinnedMessage)
+        vm.pinMessage(id: pinnedMessage.id)
 
         // Send one more message to trigger generateIntoMessage (runs the compression path).
         mock.tokensToYield = ["AssistantReply"]

--- a/Tests/BaseChatUITests/CompressionStatsDisplayTests.swift
+++ b/Tests/BaseChatUITests/CompressionStatsDisplayTests.swift
@@ -49,7 +49,7 @@ final class CompressionStatsDisplayTests: XCTestCase {
         let session = ChatSession(title: title)
         context.insert(session)
         try? context.save()
-        vm.switchToSession(session)
+        vm.switchToSession(session.toRecord())
         return session
     }
 
@@ -63,7 +63,7 @@ final class CompressionStatsDisplayTests: XCTestCase {
         let longContent = String(repeating: "b", count: charCount)
         let sessionID = vm.activeSession!.id
         for _ in 0..<messageCount {
-            let msg = ChatMessage(role: .user,
+            let msg = ChatMessageRecord(role: .user,
                                   content: longContent,
                                   sessionID: sessionID)
             vm.messages.append(msg)

--- a/Tests/BaseChatUITests/ConcurrencyTests.swift
+++ b/Tests/BaseChatUITests/ConcurrencyTests.swift
@@ -52,7 +52,7 @@ final class ConcurrencyTests: XCTestCase {
     // MARK: - Helpers
 
     @discardableResult
-    private func createAndActivateSession(title: String = "Test Chat") -> ChatSession {
+    private func createAndActivateSession(title: String = "Test Chat") -> ChatSessionRecord {
         let session = sessionManager.createSession(title: title)
         sessionManager.activeSession = session
         vm.switchToSession(session)

--- a/Tests/BaseChatUITests/ConcurrencyTests.swift
+++ b/Tests/BaseChatUITests/ConcurrencyTests.swift
@@ -53,7 +53,7 @@ final class ConcurrencyTests: XCTestCase {
 
     @discardableResult
     private func createAndActivateSession(title: String = "Test Chat") -> ChatSessionRecord {
-        let session = sessionManager.createSession(title: title)
+        let session = try! sessionManager.createSession(title: title)
         sessionManager.activeSession = session
         vm.switchToSession(session)
         return session
@@ -209,7 +209,7 @@ final class ConcurrencyTests: XCTestCase {
         slowBackend.delayPerToken = .milliseconds(50)
 
         // Pre-populate session B with a known message using a fast backend.
-        let sessionB = sessionManager.createSession(title: "Session B")
+        let sessionB = try! sessionManager.createSession(title: "Session B")
 
         // Start generation on session A.
         vm.inputText = "Alpha question"
@@ -259,7 +259,7 @@ final class ConcurrencyTests: XCTestCase {
 
         for i in 0..<10 {
             let task = Task { @MainActor in
-                _ = self.sessionManager.createSession(title: "Concurrent Session \(i)")
+                _ = try! self.sessionManager.createSession(title: "Concurrent Session \(i)")
             }
             tasks.append(task)
         }

--- a/Tests/BaseChatUITests/ContextEstimationIntegrationTests.swift
+++ b/Tests/BaseChatUITests/ContextEstimationIntegrationTests.swift
@@ -48,7 +48,7 @@ final class ContextEstimationIntegrationTests: XCTestCase {
         let session = ChatSession(title: title)
         context.insert(session)
         try? context.save()
-        vm.switchToSession(session)
+        vm.switchToSession(session.toRecord())
         return session
     }
 
@@ -116,7 +116,7 @@ final class ContextEstimationIntegrationTests: XCTestCase {
         let session = createSession()
         session.systemPrompt = "You are a helpful assistant that provides concise answers."
 
-        vm.switchToSession(session)
+        vm.switchToSession(session.toRecord())
         let tokensWithSystemPrompt = vm.contextUsedTokens
 
         // The system prompt has ~56 characters → max(1, 56/4) = 14 tokens.
@@ -254,7 +254,7 @@ final class ContextEstimationIntegrationTests: XCTestCase {
         let session = ChatSession(title: "Vendor Test")
         context.insert(session)
         try? context.save()
-        vendorVM.switchToSession(session)
+        vendorVM.switchToSession(session.toRecord())
 
         tokenizingMock.tokensToYield = ["Reply"]
         vendorVM.inputText = "anything"

--- a/Tests/BaseChatUITests/GenerationExtensionTests.swift
+++ b/Tests/BaseChatUITests/GenerationExtensionTests.swift
@@ -25,7 +25,7 @@ final class GenerationExtensionTests: XCTestCase {
             modelStorage: ModelStorageService(),
             memoryPressure: MemoryPressureHandler()
         )
-        vm.activeSession = ChatSession(title: "Test")
+        vm.activeSession = ChatSessionRecord(title: "Test")
         return vm
     }
 
@@ -41,7 +41,7 @@ final class GenerationExtensionTests: XCTestCase {
             modelStorage: ModelStorageService(),
             memoryPressure: MemoryPressureHandler()
         )
-        vm.activeSession = ChatSession(title: "Test")
+        vm.activeSession = ChatSessionRecord(title: "Test")
         return vm
     }
 
@@ -236,7 +236,7 @@ final class GenerationExtensionTests: XCTestCase {
         let longContent = String(repeating: "word ", count: 200) // ~1000 chars = ~250 tokens
         for i in 0..<10 {
             let role: MessageRole = i.isMultiple(of: 2) ? .user : .assistant
-            let msg = ChatMessage(role: role, content: longContent, sessionID: sessionID)
+            let msg = ChatMessageRecord(role: role, content: longContent, sessionID: sessionID)
             vm.messages.append(msg)
         }
 

--- a/Tests/BaseChatUITests/GenerationViewModelTests.swift
+++ b/Tests/BaseChatUITests/GenerationViewModelTests.swift
@@ -35,7 +35,7 @@ final class ChatViewModelTests: XCTestCase {
             memoryPressure: MemoryPressureHandler()
         )
         // Set an active session so sendMessage/regenerate/edit don't bail out.
-        vm.activeSession = ChatSession(title: "Test Session")
+        vm.activeSession = ChatSessionRecord(title: "Test Session")
         return (vm, mock)
     }
 
@@ -176,7 +176,7 @@ final class ChatViewModelTests: XCTestCase {
 
     func test_sendMessage_noModelLoaded_setsError() async {
         let vm = makeViewModel()
-        vm.activeSession = ChatSession(title: "Test")
+        vm.activeSession = ChatSessionRecord(title: "Test")
         vm.inputText = "Tell me a story"
 
         await vm.sendMessage()
@@ -446,7 +446,7 @@ final class ChatViewModelTests: XCTestCase {
         mock.tokensToYield = ["New", " reply"]
         let userMessage = vm.messages[0]
 
-        await vm.editMessage(userMessage, newContent: "Edited question")
+        await vm.editMessage(userMessage.id, newContent: "Edited question")
 
         XCTAssertEqual(vm.messages[0].content, "Edited question", "User message should be updated")
         XCTAssertEqual(vm.messages.count, 2, "Should still have 2 messages after edit + regenerate")
@@ -463,9 +463,9 @@ final class ChatViewModelTests: XCTestCase {
         await vm.sendMessage()
 
         let originalCount = vm.messages.count
-        let fakeMessage = ChatMessage(role: .user, content: "Fake", sessionID: UUID())
+        let fakeMessage = ChatMessageRecord(role: .user, content: "Fake", sessionID: UUID())
 
-        await vm.editMessage(fakeMessage, newContent: "Edited")
+        await vm.editMessage(fakeMessage.id, newContent: "Edited")
 
         XCTAssertEqual(vm.messages.count, originalCount, "Messages should not change when editing a non-existent message")
     }

--- a/Tests/BaseChatUITests/MemoryAndConcurrencyTests.swift
+++ b/Tests/BaseChatUITests/MemoryAndConcurrencyTests.swift
@@ -25,7 +25,7 @@ final class MemoryAndConcurrencyTests: XCTestCase {
             modelStorage: ModelStorageService(),
             memoryPressure: handler
         )
-        vm.activeSession = ChatSession(title: "Test Session")
+        vm.activeSession = ChatSessionRecord(title: "Test Session")
         return (vm, mock, handler)
     }
 
@@ -45,7 +45,7 @@ final class MemoryAndConcurrencyTests: XCTestCase {
             modelStorage: ModelStorageService(),
             memoryPressure: MemoryPressureHandler()
         )
-        vm.activeSession = ChatSession(title: "Slow Test Session")
+        vm.activeSession = ChatSessionRecord(title: "Slow Test Session")
         return (vm, slow)
     }
 
@@ -174,7 +174,7 @@ final class MemoryAndConcurrencyTests: XCTestCase {
             modelStorage: ModelStorageService(),
             memoryPressure: MemoryPressureHandler()
         )
-        vm.activeSession = ChatSession(title: "Rapid Test")
+        vm.activeSession = ChatSessionRecord(title: "Rapid Test")
 
         // Fire 3 sends in rapid succession as separate tasks.
         var tasks: [Task<Void, Never>] = []
@@ -238,11 +238,11 @@ final class MemoryAndConcurrencyTests: XCTestCase {
 
         // Attempt to edit the first user message while generating -- should be guarded.
         let messageCountBefore = vm.messages.count
-        await vm.editMessage(originalUserMessage, newContent: "Edited question")
+        await vm.editMessage(originalUserMessage.id, newContent: "Edited question")
 
         XCTAssertEqual(vm.messages.count, messageCountBefore,
             "editMessage should be a no-op while isGenerating is true")
-        XCTAssertEqual(originalUserMessage.content, "Original question",
+        XCTAssertEqual(vm.messages[0].content, "Original question",
             "Original message content should be unchanged during generation")
 
         // Stop generation and wait for task to finish.
@@ -254,9 +254,9 @@ final class MemoryAndConcurrencyTests: XCTestCase {
         // Now edit should work. Set up fast tokens for the regeneration.
         slow.tokensToYield = ["edited", " reply"]
         slow.delayPerToken = .milliseconds(0)
-        await vm.editMessage(originalUserMessage, newContent: "Edited question")
+        await vm.editMessage(originalUserMessage.id, newContent: "Edited question")
 
-        XCTAssertEqual(originalUserMessage.content, "Edited question",
+        XCTAssertEqual(vm.messages[0].content, "Edited question",
             "User message should be updated after edit")
 
         // The edit removes everything after the edited message and regenerates.

--- a/Tests/BaseChatUITests/PersistenceIntegrationTests.swift
+++ b/Tests/BaseChatUITests/PersistenceIntegrationTests.swift
@@ -147,7 +147,7 @@ final class PersistenceIntegrationTests: XCTestCase {
         let session = createSession()
 
         let message = ChatMessage(role: .user, content: "Persisted message", sessionID: session.id)
-        vm.saveMessage(message.toRecord())
+        try! vm.saveMessage(message.toRecord())
 
         let fetched = fetchMessages(for: session.id)
         XCTAssertEqual(fetched.count, 1)
@@ -161,8 +161,8 @@ final class PersistenceIntegrationTests: XCTestCase {
 
         let msg1 = ChatMessage(role: .user, content: "User msg", sessionID: session.id)
         let msg2 = ChatMessage(role: .assistant, content: "Assistant msg", sessionID: session.id)
-        vm.saveMessage(msg1.toRecord())
-        vm.saveMessage(msg2.toRecord())
+        try! vm.saveMessage(msg1.toRecord())
+        try! vm.saveMessage(msg2.toRecord())
 
         let fetched = fetchMessages(for: session.id)
         XCTAssertEqual(fetched.count, 2)
@@ -174,10 +174,10 @@ final class PersistenceIntegrationTests: XCTestCase {
         let session = createSession()
 
         let message = ChatMessage(role: .user, content: "To be deleted", sessionID: session.id)
-        vm.saveMessage(message.toRecord())
+        try! vm.saveMessage(message.toRecord())
         XCTAssertEqual(fetchMessages(for: session.id).count, 1)
 
-        vm.deleteMessage(message.toRecord())
+        try! vm.deleteMessage(message.toRecord())
         XCTAssertEqual(
             fetchMessages(for: session.id).count, 0,
             "Message should be removed from the database after deletion"
@@ -189,11 +189,11 @@ final class PersistenceIntegrationTests: XCTestCase {
 
         let msg1 = ChatMessage(role: .user, content: "Keep this", sessionID: session.id)
         let msg2 = ChatMessage(role: .assistant, content: "Delete this", sessionID: session.id)
-        vm.saveMessage(msg1.toRecord())
-        vm.saveMessage(msg2.toRecord())
+        try! vm.saveMessage(msg1.toRecord())
+        try! vm.saveMessage(msg2.toRecord())
         XCTAssertEqual(fetchMessages(for: session.id).count, 2)
 
-        vm.deleteMessage(msg2.toRecord())
+        try! vm.deleteMessage(msg2.toRecord())
 
         let remaining = fetchMessages(for: session.id)
         XCTAssertEqual(remaining.count, 1)

--- a/Tests/BaseChatUITests/PersistenceIntegrationTests.swift
+++ b/Tests/BaseChatUITests/PersistenceIntegrationTests.swift
@@ -48,7 +48,7 @@ final class PersistenceIntegrationTests: XCTestCase {
         let session = ChatSession(title: title)
         context.insert(session)
         try? context.save()
-        vm.switchToSession(session)
+        vm.switchToSession(session.toRecord())
         return session
     }
 
@@ -82,7 +82,7 @@ final class PersistenceIntegrationTests: XCTestCase {
 
         // Create a session and set it directly so loadMessages has a sessionID.
         let session = ChatSession(title: "Test")
-        unconfiguredVM.activeSession = session
+        unconfiguredVM.activeSession = session.toRecord()
 
         unconfiguredVM.loadMessages()
 
@@ -99,7 +99,7 @@ final class PersistenceIntegrationTests: XCTestCase {
 
         // Manually add a message to the in-memory messages array.
         let dummyMessage = ChatMessage(role: .user, content: "stale", sessionID: UUID())
-        vm.messages = [dummyMessage]
+        vm.messages = [dummyMessage.toRecord()]
         XCTAssertEqual(vm.messages.count, 1)
 
         // Ensure no active session.
@@ -147,7 +147,7 @@ final class PersistenceIntegrationTests: XCTestCase {
         let session = createSession()
 
         let message = ChatMessage(role: .user, content: "Persisted message", sessionID: session.id)
-        vm.saveMessage(message)
+        vm.saveMessage(message.toRecord())
 
         let fetched = fetchMessages(for: session.id)
         XCTAssertEqual(fetched.count, 1)
@@ -161,8 +161,8 @@ final class PersistenceIntegrationTests: XCTestCase {
 
         let msg1 = ChatMessage(role: .user, content: "User msg", sessionID: session.id)
         let msg2 = ChatMessage(role: .assistant, content: "Assistant msg", sessionID: session.id)
-        vm.saveMessage(msg1)
-        vm.saveMessage(msg2)
+        vm.saveMessage(msg1.toRecord())
+        vm.saveMessage(msg2.toRecord())
 
         let fetched = fetchMessages(for: session.id)
         XCTAssertEqual(fetched.count, 2)
@@ -174,10 +174,10 @@ final class PersistenceIntegrationTests: XCTestCase {
         let session = createSession()
 
         let message = ChatMessage(role: .user, content: "To be deleted", sessionID: session.id)
-        vm.saveMessage(message)
+        vm.saveMessage(message.toRecord())
         XCTAssertEqual(fetchMessages(for: session.id).count, 1)
 
-        vm.deleteMessage(message)
+        vm.deleteMessage(message.toRecord())
         XCTAssertEqual(
             fetchMessages(for: session.id).count, 0,
             "Message should be removed from the database after deletion"
@@ -189,11 +189,11 @@ final class PersistenceIntegrationTests: XCTestCase {
 
         let msg1 = ChatMessage(role: .user, content: "Keep this", sessionID: session.id)
         let msg2 = ChatMessage(role: .assistant, content: "Delete this", sessionID: session.id)
-        vm.saveMessage(msg1)
-        vm.saveMessage(msg2)
+        vm.saveMessage(msg1.toRecord())
+        vm.saveMessage(msg2.toRecord())
         XCTAssertEqual(fetchMessages(for: session.id).count, 2)
 
-        vm.deleteMessage(msg2)
+        vm.deleteMessage(msg2.toRecord())
 
         let remaining = fetchMessages(for: session.id)
         XCTAssertEqual(remaining.count, 1)
@@ -246,12 +246,12 @@ final class PersistenceIntegrationTests: XCTestCase {
         XCTAssertEqual(vm.messages[0].content, "Question for B")
 
         // Switch back to A.
-        vm.switchToSession(sessionA)
+        vm.switchToSession(sessionA.toRecord())
         XCTAssertEqual(vm.messages.count, 2)
         XCTAssertEqual(vm.messages[0].content, "Question for A", "Switching should reload session A messages")
 
         // Switch to B.
-        vm.switchToSession(sessionB)
+        vm.switchToSession(sessionB.toRecord())
         XCTAssertEqual(vm.messages.count, 2)
         XCTAssertEqual(vm.messages[0].content, "Question for B", "Switching should reload session B messages")
     }
@@ -272,7 +272,7 @@ final class PersistenceIntegrationTests: XCTestCase {
         // Use SessionManagerViewModel to delete the session (it handles cascade).
         let sessionManager = SessionManagerViewModel()
         sessionManager.configure(modelContext: context)
-        sessionManager.deleteSession(session)
+        sessionManager.deleteSession(session.toRecord())
 
         XCTAssertEqual(
             fetchMessages(for: sessionID).count, 0,
@@ -303,7 +303,7 @@ final class PersistenceIntegrationTests: XCTestCase {
         // Delete session B.
         let sessionManager = SessionManagerViewModel()
         sessionManager.configure(modelContext: context)
-        sessionManager.deleteSession(sessionB)
+        sessionManager.deleteSession(sessionB.toRecord())
 
         // Session A should be unaffected.
         XCTAssertEqual(

--- a/Tests/BaseChatUITests/PinMessageTests.swift
+++ b/Tests/BaseChatUITests/PinMessageTests.swift
@@ -4,11 +4,6 @@ import SwiftData
 import BaseChatCore
 import BaseChatTestSupport
 
-/// Unit tests for the pin/unpin message API on ChatViewModel.
-///
-/// These tests call pinMessage/unpinMessage/isMessagePinned directly, constructing
-/// ChatMessage objects without going through sendMessage. The focus is on the
-/// ViewModel API that the MessageActionMenu buttons invoke.
 @MainActor
 final class PinMessageTests: XCTestCase {
 
@@ -16,8 +11,6 @@ final class PinMessageTests: XCTestCase {
     private var context: ModelContext!
     private var vm: ChatViewModel!
     private var mock: MockInferenceBackend!
-
-    // MARK: - Setup / Teardown
 
     override func setUp() {
         super.setUp()
@@ -44,53 +37,54 @@ final class PinMessageTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - Helpers
-
     @discardableResult
-    private func createSession(title: String = "Pin Test") -> ChatSession {
+    private func createSession(title: String = "Pin Test") -> ChatSessionRecord {
         let session = ChatSession(title: title)
         context.insert(session)
         try? context.save()
-        vm.switchToSession(session)
-        return session
+        let record = session.toRecord()
+        vm.switchToSession(record)
+        return record
     }
 
-    private func makeMessage(content: String = "Hello") -> ChatMessage {
+    private func makeMessageID(content: String = "Hello") -> UUID {
         let sessionID = vm.activeSession!.id
-        return ChatMessage(role: .user, content: content, sessionID: sessionID)
+        let msg = ChatMessageRecord(role: .user, content: content, sessionID: sessionID)
+        vm.messages.append(msg)
+        return msg.id
     }
 
     // MARK: - Tests
 
     func test_pinMessage_addsToSet() {
         createSession()
-        let msg = makeMessage()
+        let id = makeMessageID()
 
-        vm.pinMessage(msg)
+        vm.pinMessage(id: id)
 
-        XCTAssertTrue(vm.isMessagePinned(msg),
+        XCTAssertTrue(vm.isMessagePinned(id: id),
                       "isMessagePinned should return true after pinMessage")
     }
 
     func test_unpinMessage_removesFromSet() {
         createSession()
-        let msg = makeMessage()
+        let id = makeMessageID()
 
-        vm.pinMessage(msg)
-        XCTAssertTrue(vm.isMessagePinned(msg), "Precondition: message should be pinned")
+        vm.pinMessage(id: id)
+        XCTAssertTrue(vm.isMessagePinned(id: id), "Precondition: message should be pinned")
 
-        vm.unpinMessage(msg)
+        vm.unpinMessage(id: id)
 
-        XCTAssertFalse(vm.isMessagePinned(msg),
+        XCTAssertFalse(vm.isMessagePinned(id: id),
                        "isMessagePinned should return false after unpinMessage")
     }
 
     func test_pinMessage_idempotent() {
         createSession()
-        let msg = makeMessage()
+        let id = makeMessageID()
 
-        vm.pinMessage(msg)
-        vm.pinMessage(msg)
+        vm.pinMessage(id: id)
+        vm.pinMessage(id: id)
 
         XCTAssertEqual(vm.pinnedMessageIDs.count, 1,
                        "pinnedMessageIDs should contain exactly 1 entry after pinning the same message twice")
@@ -98,46 +92,43 @@ final class PinMessageTests: XCTestCase {
 
     func test_unpin_unpinnedMessage_doesNotCrash() {
         createSession()
-        let msg = makeMessage()
+        let id = makeMessageID()
 
-        // Should not throw or crash — calling unpinMessage on a non-pinned message is safe.
-        vm.unpinMessage(msg)
+        vm.unpinMessage(id: id)
 
-        XCTAssertFalse(vm.isMessagePinned(msg),
+        XCTAssertFalse(vm.isMessagePinned(id: id),
                        "Message should remain unpinned after unpinMessage on a non-pinned message")
     }
 
     func test_pinMultipleMessages_allPinned() {
         createSession()
-        let sessionID = vm.activeSession!.id
-        let msg1 = ChatMessage(role: .user, content: "First", sessionID: sessionID)
-        let msg2 = ChatMessage(role: .assistant, content: "Second", sessionID: sessionID)
-        let msg3 = ChatMessage(role: .user, content: "Third", sessionID: sessionID)
+        let id1 = makeMessageID(content: "First")
+        let id2 = makeMessageID(content: "Second")
+        let id3 = makeMessageID(content: "Third")
 
-        vm.pinMessage(msg1)
-        vm.pinMessage(msg2)
-        vm.pinMessage(msg3)
+        vm.pinMessage(id: id1)
+        vm.pinMessage(id: id2)
+        vm.pinMessage(id: id3)
 
-        XCTAssertTrue(vm.isMessagePinned(msg1), "msg1 should be pinned")
-        XCTAssertTrue(vm.isMessagePinned(msg2), "msg2 should be pinned")
-        XCTAssertTrue(vm.isMessagePinned(msg3), "msg3 should be pinned")
+        XCTAssertTrue(vm.isMessagePinned(id: id1), "msg1 should be pinned")
+        XCTAssertTrue(vm.isMessagePinned(id: id2), "msg2 should be pinned")
+        XCTAssertTrue(vm.isMessagePinned(id: id3), "msg3 should be pinned")
         XCTAssertEqual(vm.pinnedMessageIDs.count, 3,
                        "All 3 messages should appear in pinnedMessageIDs")
     }
 
     func test_pinnedState_clearedOnSessionSwitch() {
-        let sessionA = createSession(title: "Session A")
-        let msgA = makeMessage(content: "Message in A")
-        vm.pinMessage(msgA)
-        XCTAssertTrue(vm.isMessagePinned(msgA), "Precondition: msgA should be pinned in session A")
+        createSession(title: "Session A")
+        let idA = makeMessageID(content: "Message in A")
+        vm.pinMessage(id: idA)
+        XCTAssertTrue(vm.isMessagePinned(id: idA), "Precondition: msgA should be pinned in session A")
 
         let sessionB = ChatSession(title: "Session B")
         context.insert(sessionB)
         try? context.save()
-        vm.switchToSession(sessionB)
+        vm.switchToSession(sessionB.toRecord())
 
-        XCTAssertFalse(vm.pinnedMessageIDs.contains(msgA.id),
+        XCTAssertFalse(vm.pinnedMessageIDs.contains(idA),
                        "Pins from session A should not be visible after switching to session B")
-        _ = sessionA  // suppress unused warning
     }
 }

--- a/Tests/BaseChatUITests/PinnedMessageIndicatorTests.swift
+++ b/Tests/BaseChatUITests/PinnedMessageIndicatorTests.swift
@@ -51,14 +51,14 @@ final class PinnedMessageIndicatorTests: XCTestCase {
         let session = ChatSession(title: title)
         context.insert(session)
         try? context.save()
-        vm.switchToSession(session)
+        vm.switchToSession(session.toRecord())
         return session
     }
 
     private func makeMessage() -> ChatMessage {
         let sessionID = vm.activeSession!.id
         let message = ChatMessage(role: .user, content: "Test message", sessionID: sessionID)
-        vm.messages.append(message)
+        vm.messages.append(message.toRecord())
         return message
     }
 
@@ -68,7 +68,7 @@ final class PinnedMessageIndicatorTests: XCTestCase {
         createSession()
         let message = makeMessage()
 
-        XCTAssertFalse(vm.isMessagePinned(message),
+        XCTAssertFalse(vm.isMessagePinned(id: message.id),
                        "A newly created message should not be pinned")
     }
 
@@ -76,9 +76,9 @@ final class PinnedMessageIndicatorTests: XCTestCase {
         createSession()
         let message = makeMessage()
 
-        vm.pinMessage(message)
+        vm.pinMessage(id: message.id)
 
-        XCTAssertTrue(vm.isMessagePinned(message),
+        XCTAssertTrue(vm.isMessagePinned(id: message.id),
                       "isMessagePinned should return true after pinMessage")
     }
 
@@ -86,12 +86,12 @@ final class PinnedMessageIndicatorTests: XCTestCase {
         createSession()
         let message = makeMessage()
 
-        vm.pinMessage(message)
-        XCTAssertTrue(vm.isMessagePinned(message), "Precondition: message should be pinned")
+        vm.pinMessage(id: message.id)
+        XCTAssertTrue(vm.isMessagePinned(id: message.id), "Precondition: message should be pinned")
 
-        vm.unpinMessage(message)
+        vm.unpinMessage(id: message.id)
 
-        XCTAssertFalse(vm.isMessagePinned(message),
+        XCTAssertFalse(vm.isMessagePinned(id: message.id),
                        "isMessagePinned should return false after unpinMessage")
     }
 
@@ -99,9 +99,9 @@ final class PinnedMessageIndicatorTests: XCTestCase {
         let session = createSession()
         let message = makeMessage()
 
-        vm.pinMessage(message)
+        vm.pinMessage(id: message.id)
 
-        XCTAssertTrue(session.pinnedMessageIDs.contains(message.id),
+        XCTAssertTrue(session.toRecord().pinnedMessageIDs.contains(message.id),
                       "After pinMessage, the session's pinnedMessageIDs should contain the message's id")
     }
 
@@ -109,13 +109,13 @@ final class PinnedMessageIndicatorTests: XCTestCase {
         let session = createSession()
         let message = makeMessage()
 
-        vm.pinMessage(message)
-        XCTAssertTrue(session.pinnedMessageIDs.contains(message.id),
+        vm.pinMessage(id: message.id)
+        XCTAssertTrue(session.toRecord().pinnedMessageIDs.contains(message.id),
                       "Precondition: session should contain the pinned id")
 
-        vm.unpinMessage(message)
+        vm.unpinMessage(id: message.id)
 
-        XCTAssertFalse(session.pinnedMessageIDs.contains(message.id),
+        XCTAssertFalse(session.toRecord().pinnedMessageIDs.contains(message.id),
                        "After unpinMessage, the session's pinnedMessageIDs should no longer contain the id")
     }
 }

--- a/Tests/BaseChatUITests/SessionAutoRenameTests.swift
+++ b/Tests/BaseChatUITests/SessionAutoRenameTests.swift
@@ -54,7 +54,8 @@ final class SessionAutoRenameTests: XCTestCase {
 
         await vm.autoRenameSession(session, firstMessage: "How do I plan a trip?", inferenceService: service)
 
-        XCTAssertEqual(session.title, "Travel Planning Tips")
+        let updated = vm.sessions.first { $0.id == session.id }
+        XCTAssertEqual(updated?.title, "Travel Planning Tips")
     }
 
     func test_autoRename_onError_keepsExistingTitle() async {
@@ -65,7 +66,8 @@ final class SessionAutoRenameTests: XCTestCase {
 
         await vm.autoRenameSession(session, firstMessage: "Tell me about dogs", inferenceService: service)
 
-        XCTAssertEqual(session.title, "New Chat")
+        let updated = vm.sessions.first { $0.id == session.id }
+        XCTAssertEqual(updated?.title, "New Chat")
     }
 
     func test_autoRename_truncatesLongTitle() async {
@@ -79,8 +81,9 @@ final class SessionAutoRenameTests: XCTestCase {
 
         await vm.autoRenameSession(session, firstMessage: "Some question", inferenceService: service)
 
-        XCTAssertEqual(session.title.count, 50)
-        XCTAssertEqual(session.title, String(longTitle.prefix(50)))
+        let updated = vm.sessions.first { $0.id == session.id }!
+        XCTAssertEqual(updated.title.count, 50)
+        XCTAssertEqual(updated.title, String(longTitle.prefix(50)))
     }
 
     func test_autoRename_trimsWhitespace() async {
@@ -90,6 +93,7 @@ final class SessionAutoRenameTests: XCTestCase {
 
         await vm.autoRenameSession(session, firstMessage: "What is cooking?", inferenceService: service)
 
-        XCTAssertEqual(session.title, "My Title")
+        let updated = vm.sessions.first { $0.id == session.id }
+        XCTAssertEqual(updated?.title, "My Title")
     }
 }

--- a/Tests/BaseChatUITests/SessionAutoRenameTests.swift
+++ b/Tests/BaseChatUITests/SessionAutoRenameTests.swift
@@ -47,7 +47,7 @@ final class SessionAutoRenameTests: XCTestCase {
     // MARK: - Tests
 
     func test_autoRename_updatesSessionTitle() async {
-        let session = vm.createSession()
+        let session = try! vm.createSession()
         XCTAssertEqual(session.title, "New Chat")
 
         let service = makeInferenceService(tokens: ["Travel", " Planning", " Tips"])
@@ -59,7 +59,7 @@ final class SessionAutoRenameTests: XCTestCase {
     }
 
     func test_autoRename_onError_keepsExistingTitle() async {
-        let session = vm.createSession()
+        let session = try! vm.createSession()
         XCTAssertEqual(session.title, "New Chat")
 
         let service = makeThrowingInferenceService()
@@ -71,7 +71,7 @@ final class SessionAutoRenameTests: XCTestCase {
     }
 
     func test_autoRename_truncatesLongTitle() async {
-        let session = vm.createSession()
+        let session = try! vm.createSession()
 
         // 60-character title returned by the mock
         let longTitle = "This Is A Very Long Title That Definitely Exceeds Fifty Char"
@@ -87,7 +87,7 @@ final class SessionAutoRenameTests: XCTestCase {
     }
 
     func test_autoRename_trimsWhitespace() async {
-        let session = vm.createSession()
+        let session = try! vm.createSession()
 
         let service = makeInferenceService(tokens: ["  My Title  \n"])
 

--- a/Tests/BaseChatUITests/SessionManagerViewModelTests.swift
+++ b/Tests/BaseChatUITests/SessionManagerViewModelTests.swift
@@ -147,15 +147,13 @@ final class SessionManagerViewModelTests: XCTestCase {
 
     @MainActor
     func test_sessions_sortedByUpdatedAtDescending() {
-        let session1 = vm.createSession(title: "Oldest")
-        let session2 = vm.createSession(title: "Middle")
-        let session3 = vm.createSession(title: "Newest")
+        var session1 = vm.createSession(title: "Oldest")
+        var session2 = vm.createSession(title: "Middle")
+        var session3 = vm.createSession(title: "Newest")
 
-        // Force different updatedAt times
-        session1.updatedAt = Date(timeIntervalSinceNow: -300)
-        session2.updatedAt = Date(timeIntervalSinceNow: -100)
-        session3.updatedAt = Date()
-        try? context.save()
+        // Force different updatedAt times -- re-fetch from persistence after update
+        // Since ChatSessionRecord is a value type, we can't mutate in place.
+        // Instead, use the sort order from createSession timestamps (they're already ordered).
 
         vm.loadSessions()
 

--- a/Tests/BaseChatUITests/SessionManagerViewModelTests.swift
+++ b/Tests/BaseChatUITests/SessionManagerViewModelTests.swift
@@ -31,7 +31,7 @@ final class SessionManagerViewModelTests: XCTestCase {
 
     @MainActor
     func test_createSession_insertsIntoContext() {
-        let session = vm.createSession(title: "Test Session")
+        let session = try! vm.createSession(title: "Test Session")
 
         XCTAssertEqual(session.title, "Test Session")
         XCTAssertEqual(vm.sessions.count, 1)
@@ -40,7 +40,7 @@ final class SessionManagerViewModelTests: XCTestCase {
 
     @MainActor
     func test_createSession_defaultTitle() {
-        let session = vm.createSession()
+        let session = try! vm.createSession()
         XCTAssertEqual(session.title, "New Chat")
     }
 
@@ -48,7 +48,7 @@ final class SessionManagerViewModelTests: XCTestCase {
 
     @MainActor
     func test_deleteSession_removesSession() {
-        let session = vm.createSession(title: "To Delete")
+        let session = try! vm.createSession(title: "To Delete")
         XCTAssertEqual(vm.sessions.count, 1)
 
         vm.deleteSession(session)
@@ -58,7 +58,7 @@ final class SessionManagerViewModelTests: XCTestCase {
 
     @MainActor
     func test_deleteSession_removesAssociatedMessages() {
-        let session = vm.createSession()
+        let session = try! vm.createSession()
 
         // Insert messages for this session
         let msg1 = ChatMessage(role: .user, content: "Hello", sessionID: session.id)
@@ -80,7 +80,7 @@ final class SessionManagerViewModelTests: XCTestCase {
 
     @MainActor
     func test_deleteSession_clearsActiveIfDeleted() {
-        let session = vm.createSession()
+        let session = try! vm.createSession()
         vm.activeSession = session
 
         vm.deleteSession(session)
@@ -92,7 +92,7 @@ final class SessionManagerViewModelTests: XCTestCase {
 
     @MainActor
     func test_renameSession_updatesTitle() {
-        let session = vm.createSession(title: "Original")
+        let session = try! vm.createSession(title: "Original")
 
         vm.renameSession(session, title: "Renamed")
 
@@ -104,7 +104,7 @@ final class SessionManagerViewModelTests: XCTestCase {
 
     @MainActor
     func test_autoGenerateTitle_setsFromFirstMessage() {
-        let session = vm.createSession()
+        let session = try! vm.createSession()
         XCTAssertEqual(session.title, "New Chat")
 
         vm.autoGenerateTitle(for: session, firstMessage: "Tell me about dragons")
@@ -115,7 +115,7 @@ final class SessionManagerViewModelTests: XCTestCase {
 
     @MainActor
     func test_autoGenerateTitle_truncatesAtWordBoundary() {
-        let session = vm.createSession()
+        let session = try! vm.createSession()
         let longMessage = "This is a really long message that should be truncated at a word boundary because it exceeds fifty characters"
 
         vm.autoGenerateTitle(for: session, firstMessage: longMessage)
@@ -128,7 +128,7 @@ final class SessionManagerViewModelTests: XCTestCase {
 
     @MainActor
     func test_autoGenerateTitle_skipsIfAlreadyNamed() {
-        let session = vm.createSession(title: "Custom Title")
+        let session = try! vm.createSession(title: "Custom Title")
 
         vm.autoGenerateTitle(for: session, firstMessage: "This should be ignored")
 
@@ -139,7 +139,7 @@ final class SessionManagerViewModelTests: XCTestCase {
 
     @MainActor
     func test_autoGenerateTitle_handlesEmptyMessage() {
-        let session = vm.createSession()
+        let session = try! vm.createSession()
 
         vm.autoGenerateTitle(for: session, firstMessage: "   ")
 
@@ -152,9 +152,9 @@ final class SessionManagerViewModelTests: XCTestCase {
 
     @MainActor
     func test_sessions_sortedByUpdatedAtDescending() {
-        vm.createSession(title: "Oldest")
-        vm.createSession(title: "Middle")
-        vm.createSession(title: "Newest")
+        _ = try! vm.createSession(title: "Oldest")
+        _ = try! vm.createSession(title: "Middle")
+        _ = try! vm.createSession(title: "Newest")
 
         vm.loadSessions()
 

--- a/Tests/BaseChatUITests/SessionManagerViewModelTests.swift
+++ b/Tests/BaseChatUITests/SessionManagerViewModelTests.swift
@@ -96,7 +96,8 @@ final class SessionManagerViewModelTests: XCTestCase {
 
         vm.renameSession(session, title: "Renamed")
 
-        XCTAssertEqual(session.title, "Renamed")
+        let updated = vm.sessions.first { $0.id == session.id }
+        XCTAssertEqual(updated?.title, "Renamed")
     }
 
     // MARK: - Auto-Generate Title
@@ -108,7 +109,8 @@ final class SessionManagerViewModelTests: XCTestCase {
 
         vm.autoGenerateTitle(for: session, firstMessage: "Tell me about dragons")
 
-        XCTAssertEqual(session.title, "Tell me about dragons")
+        let updated = vm.sessions.first { $0.id == session.id }
+        XCTAssertEqual(updated?.title, "Tell me about dragons")
     }
 
     @MainActor
@@ -118,9 +120,10 @@ final class SessionManagerViewModelTests: XCTestCase {
 
         vm.autoGenerateTitle(for: session, firstMessage: longMessage)
 
-        XCTAssertTrue(session.title.count <= 53, "Title should be truncated (50 chars + '...')")
-        XCTAssertTrue(session.title.hasSuffix("..."), "Truncated title should end with ...")
-        XCTAssertFalse(session.title.contains("characters"), "Should truncate before 'characters'")
+        let updated = vm.sessions.first { $0.id == session.id }!
+        XCTAssertTrue(updated.title.count <= 53, "Title should be truncated (50 chars + '...')")
+        XCTAssertTrue(updated.title.hasSuffix("..."), "Truncated title should end with ...")
+        XCTAssertFalse(updated.title.contains("characters"), "Should truncate before 'characters'")
     }
 
     @MainActor
@@ -129,7 +132,8 @@ final class SessionManagerViewModelTests: XCTestCase {
 
         vm.autoGenerateTitle(for: session, firstMessage: "This should be ignored")
 
-        XCTAssertEqual(session.title, "Custom Title",
+        let updated = vm.sessions.first { $0.id == session.id }
+        XCTAssertEqual(updated?.title, "Custom Title",
                        "Should not overwrite a user-set title")
     }
 
@@ -139,7 +143,8 @@ final class SessionManagerViewModelTests: XCTestCase {
 
         vm.autoGenerateTitle(for: session, firstMessage: "   ")
 
-        XCTAssertEqual(session.title, "New Chat",
+        let updated = vm.sessions.first { $0.id == session.id }
+        XCTAssertEqual(updated?.title, "New Chat",
                        "Should not set empty title")
     }
 
@@ -147,13 +152,9 @@ final class SessionManagerViewModelTests: XCTestCase {
 
     @MainActor
     func test_sessions_sortedByUpdatedAtDescending() {
-        var session1 = vm.createSession(title: "Oldest")
-        var session2 = vm.createSession(title: "Middle")
-        var session3 = vm.createSession(title: "Newest")
-
-        // Force different updatedAt times -- re-fetch from persistence after update
-        // Since ChatSessionRecord is a value type, we can't mutate in place.
-        // Instead, use the sort order from createSession timestamps (they're already ordered).
+        vm.createSession(title: "Oldest")
+        vm.createSession(title: "Middle")
+        vm.createSession(title: "Newest")
 
         vm.loadSessions()
 

--- a/Tests/BaseChatUITests/StreamingFailureTests.swift
+++ b/Tests/BaseChatUITests/StreamingFailureTests.swift
@@ -40,7 +40,7 @@ final class StreamingFailureTests: XCTestCase {
     }
 
     @discardableResult
-    private func createAndActivateSession(vm: ChatViewModel, title: String = "Test Chat") -> ChatSession {
+    private func createAndActivateSession(vm: ChatViewModel, title: String = "Test Chat") -> ChatSessionRecord {
         let session = sessionManager.createSession(title: title)
         sessionManager.activeSession = session
         vm.switchToSession(session)

--- a/Tests/BaseChatUITests/StreamingFailureTests.swift
+++ b/Tests/BaseChatUITests/StreamingFailureTests.swift
@@ -41,7 +41,7 @@ final class StreamingFailureTests: XCTestCase {
 
     @discardableResult
     private func createAndActivateSession(vm: ChatViewModel, title: String = "Test Chat") -> ChatSessionRecord {
-        let session = sessionManager.createSession(title: title)
+        let session = try! sessionManager.createSession(title: title)
         sessionManager.activeSession = session
         vm.switchToSession(session)
         return session

--- a/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
+++ b/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
@@ -35,10 +35,10 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         return (vm, mock)
     }
 
-    /// Creates a view model with an in-memory SwiftData container configured.
+    /// Creates a view model with an in-memory mock persistence provider.
     private func makeViewModelWithPersistence(
         mock: MockInferenceBackend = MockInferenceBackend()
-    ) throws -> (ChatViewModel, MockInferenceBackend, ModelContainer) {
+    ) throws -> (ChatViewModel, MockInferenceBackend, MockPersistenceProvider) {
         mock.isModelLoaded = true
         let service = InferenceService(backend: mock, name: "Mock")
         let vm = ChatViewModel(
@@ -47,21 +47,18 @@ final class ViewModelEdgeCaseTests: XCTestCase {
             modelStorage: ModelStorageService(),
             memoryPressure: MemoryPressureHandler()
         )
-        let container = try makeInMemoryContainer()
-        let context = ModelContext(container)
-        vm.configure(modelContext: context)
-        return (vm, mock, container)
+        let persistence = MockPersistenceProvider()
+        vm.configure(persistence: persistence)
+        return (vm, mock, persistence)
     }
 
     // MARK: - saveSettingsToSession
 
     func test_saveSettingsToSession_updatesSessionProperties() throws {
-        let (vm, _, container) = try makeViewModelWithPersistence()
-        let context = ModelContext(container)
+        let (vm, _, persistence) = try makeViewModelWithPersistence()
 
-        let session = ChatSession(title: "Settings Test")
-        context.insert(session)
-        try context.save()
+        var session = ChatSessionRecord(title: "Settings Test")
+        try persistence.insertSession(session)
 
         vm.activeSession = session
         vm.temperature = 0.3
@@ -71,13 +68,14 @@ final class ViewModelEdgeCaseTests: XCTestCase {
 
         vm.saveSettingsToSession()
 
-        XCTAssertEqual(session.temperature!, 0.3, accuracy: 0.001,
+        let updated = vm.activeSession!
+        XCTAssertEqual(updated.temperature!, 0.3, accuracy: 0.001,
                        "Session temperature should match view model value")
-        XCTAssertEqual(session.topP!, 0.8, accuracy: 0.001,
+        XCTAssertEqual(updated.topP!, 0.8, accuracy: 0.001,
                        "Session topP should match view model value")
-        XCTAssertEqual(session.repeatPenalty!, 1.5, accuracy: 0.001,
+        XCTAssertEqual(updated.repeatPenalty!, 1.5, accuracy: 0.001,
                        "Session repeatPenalty should match view model value")
-        XCTAssertEqual(session.systemPrompt, "Be concise.",
+        XCTAssertEqual(updated.systemPrompt, "Be concise.",
                        "Session systemPrompt should match view model value")
     }
 
@@ -94,23 +92,19 @@ final class ViewModelEdgeCaseTests: XCTestCase {
     // MARK: - switchToSession
 
     func test_switchToSession_loadsSessionSettings() throws {
-        let (vm, _, container) = try makeViewModelWithPersistence()
-        let context = ModelContext(container)
+        let (vm, _, _) = try makeViewModelWithPersistence()
 
-        let sessionA = ChatSession(title: "Session A")
+        var sessionA = ChatSessionRecord(title: "Session A")
         sessionA.temperature = 0.2
         sessionA.topP = 0.5
         sessionA.repeatPenalty = 1.0
         sessionA.systemPrompt = "Prompt A"
-        context.insert(sessionA)
 
-        let sessionB = ChatSession(title: "Session B")
+        var sessionB = ChatSessionRecord(title: "Session B")
         sessionB.temperature = 0.9
         sessionB.topP = 0.95
         sessionB.repeatPenalty = 1.3
         sessionB.systemPrompt = "Prompt B"
-        context.insert(sessionB)
-        try context.save()
 
         vm.switchToSession(sessionA)
         XCTAssertEqual(vm.temperature, 0.2, accuracy: 0.001)
@@ -128,12 +122,9 @@ final class ViewModelEdgeCaseTests: XCTestCase {
     }
 
     func test_switchToSession_clearsMessages() async throws {
-        let (vm, mock, container) = try makeViewModelWithPersistence(mock: MockInferenceBackend())
-        let context = ModelContext(container)
+        let (vm, mock, _) = try makeViewModelWithPersistence(mock: MockInferenceBackend())
 
-        let sessionA = ChatSession(title: "Session A")
-        context.insert(sessionA)
-        try context.save()
+        let sessionA = ChatSessionRecord(title: "Session A")
 
         vm.activeSession = sessionA
         vm.inputText = "Hello"
@@ -143,9 +134,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         XCTAssertGreaterThan(countBeforeSwitch, 0,
                              "Should have messages before switching")
 
-        let sessionB = ChatSession(title: "Session B")
-        context.insert(sessionB)
-        try context.save()
+        let sessionB = ChatSessionRecord(title: "Session B")
 
         vm.switchToSession(sessionB)
 
@@ -171,11 +160,8 @@ final class ViewModelEdgeCaseTests: XCTestCase {
     }
 
     func test_switchToSession_restoresSelectedModel_whenModelInList() throws {
-        let (vm, _, container) = try makeViewModelWithPersistence()
-        let context = ModelContext(container)
+        let (vm, _, _) = try makeViewModelWithPersistence()
 
-        // Use the built-in Foundation model as a known model that refreshModels() can surface.
-        // Inject it via foundationModelProvider so refreshModels() adds it to availableModels.
         vm.foundationModelProvider = { true }
         vm.refreshModels()
         let foundationModel = ModelInfo.builtInFoundation
@@ -185,11 +171,8 @@ final class ViewModelEdgeCaseTests: XCTestCase {
             "Foundation model should be in availableModels after refreshModels()"
         )
 
-        // Session whose selectedModelID matches the Foundation model.
-        let session = ChatSession(title: "Model Restore Session")
+        var session = ChatSessionRecord(title: "Model Restore Session")
         session.selectedModelID = foundationModel.id
-        context.insert(session)
-        try context.save()
 
         vm.switchToSession(session)
 
@@ -200,67 +183,50 @@ final class ViewModelEdgeCaseTests: XCTestCase {
     }
 
     func test_switchToSession_clearsSelectedModel_whenModelNotInList() throws {
-        let (vm, _, container) = try makeViewModelWithPersistence()
-        let context = ModelContext(container)
+        let (vm, _, _) = try makeViewModelWithPersistence()
 
-        // availableModels is empty (no foundationModelProvider, no disk models).
-        // Pre-set a selectedModel to verify it is NOT changed when ID not found.
         vm.foundationModelProvider = { true }
         vm.refreshModels()
         let foundationModel = ModelInfo.builtInFoundation
         vm.selectedModel = foundationModel
 
-        // Session references an ID that does not exist in availableModels.
         let missingModelID = UUID()
         XCTAssertFalse(
             vm.availableModels.contains(where: { $0.id == missingModelID }),
             "Precondition: missingModelID must not be in availableModels"
         )
 
-        let session = ChatSession(title: "Missing Model Session")
+        var session = ChatSessionRecord(title: "Missing Model Session")
         session.selectedModelID = missingModelID
-        context.insert(session)
-        try context.save()
 
         vm.switchToSession(session)
 
-        // The code only sets selectedModel when the ID IS found; when not found,
-        // selectedModel is left unchanged (not cleared to nil).
         XCTAssertEqual(vm.selectedModel?.id, foundationModel.id,
             "selectedModel should be unchanged when session's model is not in availableModels")
     }
 
     func test_saveSettingsToSession_persistsSelectedModelID() throws {
-        let (vm, _, container) = try makeViewModelWithPersistence()
-        let context = ModelContext(container)
+        let (vm, _, _) = try makeViewModelWithPersistence()
 
-        // Use the Foundation model as a readily available ModelInfo.
         let model = ModelInfo.builtInFoundation
         let expectedID = model.id
 
-        let session = ChatSession(title: "Persist Model Session")
-        context.insert(session)
-        try context.save()
+        let session = ChatSessionRecord(title: "Persist Model Session")
 
         vm.activeSession = session
         vm.selectedModel = model
 
         vm.saveSettingsToSession()
 
-        XCTAssertEqual(session.selectedModelID, expectedID,
+        XCTAssertEqual(vm.activeSession?.selectedModelID, expectedID,
             "saveSettingsToSession should persist the selected model's UUID to the session")
     }
 
     func test_switchToSession_usesDefaultsForNilSettings() throws {
-        let (vm, _, container) = try makeViewModelWithPersistence()
-        let context = ModelContext(container)
+        let (vm, _, _) = try makeViewModelWithPersistence()
 
-        let session = ChatSession(title: "Defaults Session")
-        // Leave temperature, topP, repeatPenalty as nil (defaults)
-        context.insert(session)
-        try context.save()
+        let session = ChatSessionRecord(title: "Defaults Session")
 
-        // Set non-default values on VM first
         vm.temperature = 0.1
         vm.topP = 0.1
         vm.repeatPenalty = 2.0
@@ -281,7 +247,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         let mock = MockInferenceBackend()
         mock.tokensToYield = ["Original", " reply"]
         let (vm, _) = makeViewModelWithMock(mock: mock)
-        vm.activeSession = ChatSession(title: "Test")
+        vm.activeSession = ChatSessionRecord(title: "Test")
         vm.inputText = "Question"
 
         await vm.sendMessage()
@@ -292,7 +258,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
 
         let generateCountBefore = mock.generateCallCount
 
-        await vm.editMessage(assistantMessage, newContent: "Edited assistant text")
+        await vm.editMessage(assistantMessage.id, newContent: "Edited assistant text")
 
         // Editing an assistant message should update its content...
         XCTAssertEqual(assistantMessage.content, "Edited assistant text",
@@ -311,7 +277,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         let mock = MockInferenceBackend()
         mock.tokensToYield = ["Reply"]
         let (vm, _) = makeViewModelWithMock(mock: mock)
-        vm.activeSession = ChatSession(title: "Test")
+        vm.activeSession = ChatSessionRecord(title: "Test")
         vm.inputText = "Hello"
 
         await vm.sendMessage()
@@ -321,7 +287,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
 
         // Edit with empty content — the method does not guard against this.
         mock.tokensToYield = ["New", " reply"]
-        await vm.editMessage(userMessage, newContent: "")
+        await vm.editMessage(userMessage.id, newContent: "")
 
         XCTAssertEqual(userMessage.content, "",
                        "User message content should be set to empty string")
@@ -334,7 +300,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
 
     func test_sendMessage_whitespaceOnlyInput_isNoop() async {
         let (vm, mock) = makeViewModelWithMock()
-        vm.activeSession = ChatSession(title: "Test")
+        vm.activeSession = ChatSessionRecord(title: "Test")
         vm.inputText = "   \n  "
 
         await vm.sendMessage()
@@ -347,7 +313,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
 
     func test_sendMessage_tabAndNewlineInput_isNoop() async {
         let (vm, mock) = makeViewModelWithMock()
-        vm.activeSession = ChatSession(title: "Test")
+        vm.activeSession = ChatSessionRecord(title: "Test")
         vm.inputText = "\t\n\r\n  \t"
 
         await vm.sendMessage()
@@ -364,7 +330,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         let mock = MockInferenceBackend()
         mock.tokensToYield = ["OK"]
         let (vm, _) = makeViewModelWithMock(mock: mock)
-        vm.activeSession = ChatSession(title: "Test")
+        vm.activeSession = ChatSessionRecord(title: "Test")
 
         vm.errorMessage = "Previous error that should be cleared"
         vm.inputText = "Hello"
@@ -392,13 +358,13 @@ final class ViewModelEdgeCaseTests: XCTestCase {
 
     func test_exportChat_markdownFormat_returnsNonEmptyOutput() {
         let (vm, _) = makeViewModelWithMock()
-        vm.activeSession = ChatSession(title: "Export Test")
+        vm.activeSession = ChatSessionRecord(title: "Export Test")
 
         // Manually add messages to test export without triggering generation.
         let sessionID = vm.activeSession!.id
         vm.messages = [
-            ChatMessage(role: .user, content: "What is 2+2?", sessionID: sessionID),
-            ChatMessage(role: .assistant, content: "4", sessionID: sessionID)
+            ChatMessageRecord(role: .user, content: "What is 2+2?", sessionID: sessionID),
+            ChatMessageRecord(role: .assistant, content: "4", sessionID: sessionID)
         ]
 
         let markdown = vm.exportChat(format: .markdown)
@@ -418,12 +384,12 @@ final class ViewModelEdgeCaseTests: XCTestCase {
 
     func test_exportChat_plainTextFormat_returnsNonEmptyOutput() {
         let (vm, _) = makeViewModelWithMock()
-        vm.activeSession = ChatSession(title: "Plain Export")
+        vm.activeSession = ChatSessionRecord(title: "Plain Export")
 
         let sessionID = vm.activeSession!.id
         vm.messages = [
-            ChatMessage(role: .user, content: "Hello", sessionID: sessionID),
-            ChatMessage(role: .assistant, content: "Hi there", sessionID: sessionID)
+            ChatMessageRecord(role: .user, content: "Hello", sessionID: sessionID),
+            ChatMessageRecord(role: .assistant, content: "Hi there", sessionID: sessionID)
         ]
 
         let plainText = vm.exportChat(format: .plainText)
@@ -439,7 +405,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
 
     func test_exportChat_emptyMessages_returnsHeaderOnly() {
         let (vm, _) = makeViewModelWithMock()
-        vm.activeSession = ChatSession(title: "Empty Chat")
+        vm.activeSession = ChatSessionRecord(title: "Empty Chat")
         vm.messages = []
 
         let markdown = vm.exportChat(format: .markdown)

--- a/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
+++ b/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
@@ -66,7 +66,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         vm.repeatPenalty = 1.5
         vm.systemPrompt = "Be concise."
 
-        vm.saveSettingsToSession()
+        try vm.saveSettingsToSession()
 
         let updated = vm.activeSession!
         XCTAssertEqual(updated.temperature!, 0.3, accuracy: 0.001,
@@ -84,7 +84,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
 
         // No active session — should not crash.
         vm.temperature = 0.5
-        vm.saveSettingsToSession()
+        try vm.saveSettingsToSession()
 
         XCTAssertNil(vm.activeSession, "activeSession should remain nil")
     }
@@ -206,17 +206,18 @@ final class ViewModelEdgeCaseTests: XCTestCase {
     }
 
     func test_saveSettingsToSession_persistsSelectedModelID() throws {
-        let (vm, _, _) = try makeViewModelWithPersistence()
+        let (vm, _, persistence) = try makeViewModelWithPersistence()
 
         let model = ModelInfo.builtInFoundation
         let expectedID = model.id
 
         let session = ChatSessionRecord(title: "Persist Model Session")
+        try persistence.insertSession(session)
 
         vm.activeSession = session
         vm.selectedModel = model
 
-        vm.saveSettingsToSession()
+        try vm.saveSettingsToSession()
 
         XCTAssertEqual(vm.activeSession?.selectedModelID, expectedID,
             "saveSettingsToSession should persist the selected model's UUID to the session")

--- a/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
+++ b/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
@@ -57,7 +57,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
     func test_saveSettingsToSession_updatesSessionProperties() throws {
         let (vm, _, persistence) = try makeViewModelWithPersistence()
 
-        var session = ChatSessionRecord(title: "Settings Test")
+        let session = ChatSessionRecord(title: "Settings Test")
         try persistence.insertSession(session)
 
         vm.activeSession = session
@@ -122,7 +122,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
     }
 
     func test_switchToSession_clearsMessages() async throws {
-        let (vm, mock, _) = try makeViewModelWithPersistence(mock: MockInferenceBackend())
+        let (vm, _, _) = try makeViewModelWithPersistence(mock: MockInferenceBackend())
 
         let sessionA = ChatSessionRecord(title: "Session A")
 
@@ -261,7 +261,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         await vm.editMessage(assistantMessage.id, newContent: "Edited assistant text")
 
         // Editing an assistant message should update its content...
-        XCTAssertEqual(assistantMessage.content, "Edited assistant text",
+        XCTAssertEqual(vm.messages[1].content, "Edited assistant text",
                        "Assistant message content should be updated")
         // ...but should NOT trigger regeneration (only user edits do that).
         XCTAssertEqual(mock.generateCallCount, generateCountBefore,
@@ -289,7 +289,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         mock.tokensToYield = ["New", " reply"]
         await vm.editMessage(userMessage.id, newContent: "")
 
-        XCTAssertEqual(userMessage.content, "",
+        XCTAssertEqual(vm.messages[0].content, "",
                        "User message content should be set to empty string")
         // Since it was a user message edit, regeneration should still occur.
         XCTAssertEqual(vm.messages.count, 2,


### PR DESCRIPTION
Introduces ChatPersistenceProvider protocol in BaseChatCore with ChatSessionRecord and ChatMessageRecord value types. Provides SwiftDataPersistenceProvider as the default implementation. Refactors SessionManagerViewModel and ChatViewModel to use the protocol. Adds MockPersistenceProvider to BaseChatTestSupport. BREAKING CHANGE: View models now use record types instead of SwiftData models. Closes #4