### PR TITLE
chore: configure bump-minor-pre-major to stay in 0.x

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
   "packages": {
     ".": {}
   }


### PR DESCRIPTION
## Summary
- Adds `bump-minor-pre-major` and `bump-patch-for-minor-pre-major` to release-please config
- Breaking changes now bump minor (0.1→0.2) instead of major, keeping the project in 0.x until the API is declared stable
- Closed the incorrect v1.0.0 release PR (#24)

After merge, release-please will create a new release PR targeting **v0.2.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)