### PR TITLE
feat: render markdown in assistant bubbles

### DIFF
--- a/Sources/BaseChatUI/Views/Chat/AssistantMarkdownView.swift
+++ b/Sources/BaseChatUI/Views/Chat/AssistantMarkdownView.swift
@@ -26,54 +26,90 @@ struct AssistantMarkdownBlock: Identifiable, Equatable {
 enum AssistantMarkdownParser {
     static func parseBlocks(from source: String) -> [AssistantMarkdownBlock] {
         guard !source.isEmpty else { return [] }
-
-        let pattern = #"```([^\n`]*)\n([\s\S]*?)```"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else {
-            return [AssistantMarkdownBlock(id: 0, kind: .markdown, text: source)]
-        }
-
-        let fullRange = NSRange(source.startIndex..<source.endIndex, in: source)
-        let matches = regex.matches(in: source, options: [], range: fullRange)
-        guard !matches.isEmpty else {
-            return [AssistantMarkdownBlock(id: 0, kind: .markdown, text: source)]
-        }
-
         var blocks: [AssistantMarkdownBlock] = []
         var nextID = 0
-        var cursor = source.startIndex
+        var markdownBuffer = ""
+        var codeBuffer = ""
+        var isInCodeBlock = false
+        var codeLanguage: String?
+        var openingFenceLength = 0
+        var nestedFenceDepth = 0
 
-        for match in matches {
-            guard
-                let matchRange = Range(match.range, in: source),
-                let languageRange = Range(match.range(at: 1), in: source),
-                let codeRange = Range(match.range(at: 2), in: source)
-            else { continue }
+        let lines = source.components(separatedBy: "\n")
+        for (lineIndex, line) in lines.enumerated() {
+            let hadTrailingNewline = lineIndex < lines.count - 1
 
-            if cursor < matchRange.lowerBound {
-                let markdownText = String(source[cursor..<matchRange.lowerBound])
-                if !markdownText.isEmpty {
-                    blocks.append(.init(id: nextID, kind: .markdown, text: markdownText))
-                    nextID += 1
+            if !isInCodeBlock {
+                if let fence = parseFenceLine(line) {
+                    if !markdownBuffer.isEmpty {
+                        blocks.append(.init(id: nextID, kind: .markdown, text: markdownBuffer))
+                        nextID += 1
+                        markdownBuffer = ""
+                    }
+                    isInCodeBlock = true
+                    openingFenceLength = fence.ticks
+                    codeLanguage = fence.rest.isEmpty ? nil : fence.rest
+                    nestedFenceDepth = 0
+                } else {
+                    append(line: line, hadTrailingNewline: hadTrailingNewline, to: &markdownBuffer)
+                }
+                continue
+            }
+
+            if let fence = parseFenceLine(line), fence.ticks >= openingFenceLength {
+                if fence.rest.isEmpty {
+                    if nestedFenceDepth == 0 {
+                        let code = codeBuffer.trimmingCharacters(in: .newlines)
+                        blocks.append(.init(id: nextID, kind: .code(language: codeLanguage), text: code))
+                        nextID += 1
+                        codeBuffer = ""
+                        isInCodeBlock = false
+                        openingFenceLength = 0
+                        codeLanguage = nil
+                        continue
+                    }
+                    nestedFenceDepth -= 1
+                } else {
+                    nestedFenceDepth += 1
                 }
             }
 
-            let rawLanguage = source[languageRange].trimmingCharacters(in: .whitespacesAndNewlines)
-            let normalizedLanguage = rawLanguage.isEmpty ? nil : rawLanguage
-            let code = String(source[codeRange]).trimmingCharacters(in: CharacterSet(charactersIn: "\n"))
-            blocks.append(.init(id: nextID, kind: .code(language: normalizedLanguage), text: code))
-            nextID += 1
-
-            cursor = matchRange.upperBound
+            append(line: line, hadTrailingNewline: hadTrailingNewline, to: &codeBuffer)
         }
 
-        if cursor < source.endIndex {
-            let trailingText = String(source[cursor..<source.endIndex])
-            if !trailingText.isEmpty {
-                blocks.append(.init(id: nextID, kind: .markdown, text: trailingText))
-            }
+        // Streaming can end mid-fence; keep partially parsed content as plain markdown.
+        if isInCodeBlock {
+            return [AssistantMarkdownBlock(id: 0, kind: .markdown, text: source)]
+        }
+
+        if !markdownBuffer.isEmpty {
+            blocks.append(.init(id: nextID, kind: .markdown, text: markdownBuffer))
         }
 
         return blocks.isEmpty ? [AssistantMarkdownBlock(id: 0, kind: .markdown, text: source)] : blocks
+    }
+
+    private static func parseFenceLine(_ line: String) -> (ticks: Int, rest: String)? {
+        let trimmedLeading = line.trimmingCharacters(in: .whitespaces)
+        guard trimmedLeading.first == "`" else { return nil }
+
+        var tickCount = 0
+        var index = trimmedLeading.startIndex
+        while index < trimmedLeading.endIndex, trimmedLeading[index] == "`" {
+            tickCount += 1
+            index = trimmedLeading.index(after: index)
+        }
+        guard tickCount >= 3 else { return nil }
+
+        let rest = String(trimmedLeading[index...]).trimmingCharacters(in: .whitespacesAndNewlines)
+        return (ticks: tickCount, rest: rest)
+    }
+
+    private static func append(line: String, hadTrailingNewline: Bool, to target: inout String) {
+        target += line
+        if hadTrailingNewline {
+            target += "\n"
+        }
     }
 
     static func attributedString(from markdown: String) -> AttributedString {

--- a/Sources/BaseChatUI/Views/Chat/AssistantMarkdownView.swift
+++ b/Sources/BaseChatUI/Views/Chat/AssistantMarkdownView.swift
@@ -1,0 +1,163 @@
+import SwiftUI
+import BaseChatCore
+
+enum MessageRenderingMode: Equatable {
+    case plainText
+    case markdown
+}
+
+enum MessageRenderingModeResolver {
+    static func mode(for role: MessageRole) -> MessageRenderingMode {
+        role == .assistant ? .markdown : .plainText
+    }
+}
+
+struct AssistantMarkdownBlock: Identifiable, Equatable {
+    enum Kind: Equatable {
+        case markdown
+        case code(language: String?)
+    }
+
+    let id: Int
+    let kind: Kind
+    let text: String
+}
+
+enum AssistantMarkdownParser {
+    static func parseBlocks(from source: String) -> [AssistantMarkdownBlock] {
+        guard !source.isEmpty else { return [] }
+
+        let pattern = #"```([^\n`]*)\n([\s\S]*?)```"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return [AssistantMarkdownBlock(id: 0, kind: .markdown, text: source)]
+        }
+
+        let fullRange = NSRange(source.startIndex..<source.endIndex, in: source)
+        let matches = regex.matches(in: source, options: [], range: fullRange)
+        guard !matches.isEmpty else {
+            return [AssistantMarkdownBlock(id: 0, kind: .markdown, text: source)]
+        }
+
+        var blocks: [AssistantMarkdownBlock] = []
+        var nextID = 0
+        var cursor = source.startIndex
+
+        for match in matches {
+            guard
+                let matchRange = Range(match.range, in: source),
+                let languageRange = Range(match.range(at: 1), in: source),
+                let codeRange = Range(match.range(at: 2), in: source)
+            else { continue }
+
+            if cursor < matchRange.lowerBound {
+                let markdownText = String(source[cursor..<matchRange.lowerBound])
+                if !markdownText.isEmpty {
+                    blocks.append(.init(id: nextID, kind: .markdown, text: markdownText))
+                    nextID += 1
+                }
+            }
+
+            let rawLanguage = source[languageRange].trimmingCharacters(in: .whitespacesAndNewlines)
+            let normalizedLanguage = rawLanguage.isEmpty ? nil : rawLanguage
+            let code = String(source[codeRange]).trimmingCharacters(in: CharacterSet(charactersIn: "\n"))
+            blocks.append(.init(id: nextID, kind: .code(language: normalizedLanguage), text: code))
+            nextID += 1
+
+            cursor = matchRange.upperBound
+        }
+
+        if cursor < source.endIndex {
+            let trailingText = String(source[cursor..<source.endIndex])
+            if !trailingText.isEmpty {
+                blocks.append(.init(id: nextID, kind: .markdown, text: trailingText))
+            }
+        }
+
+        return blocks.isEmpty ? [AssistantMarkdownBlock(id: 0, kind: .markdown, text: source)] : blocks
+    }
+
+    static func attributedString(from markdown: String) -> AttributedString {
+        if let parsed = try? AttributedString(
+            markdown: markdown,
+            options: AttributedString.MarkdownParsingOptions(interpretedSyntax: .full)
+        ) {
+            return parsed
+        }
+        return AttributedString(markdown)
+    }
+}
+
+struct AssistantMarkdownView: View {
+    let content: String
+
+    @State private var blocks: [AssistantMarkdownBlock]
+
+    init(content: String) {
+        self.content = content
+        self._blocks = State(initialValue: AssistantMarkdownParser.parseBlocks(from: content))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(blocks) { block in
+                switch block.kind {
+                case .markdown:
+                    Text(AssistantMarkdownParser.attributedString(from: block.text))
+                        .font(.body)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .textSelection(.enabled)
+                case .code(let language):
+                    AssistantCodeBlockView(code: block.text, language: language)
+                }
+            }
+        }
+        .onChange(of: content) {
+            blocks = AssistantMarkdownParser.parseBlocks(from: content)
+        }
+    }
+}
+
+private struct AssistantCodeBlockView: View {
+    let code: String
+    let language: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                if let language {
+                    Text(language.uppercased())
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button {
+                    copyToClipboard(code)
+                } label: {
+                    Label("Copy", systemImage: "doc.on.doc")
+                        .font(.caption)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Copy code block")
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                Text(code)
+                    .font(.system(.body, design: .monospaced))
+                    .foregroundStyle(.primary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+            }
+        }
+        .padding(10)
+        .background(.fill.quaternary, in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    private func copyToClipboard(_ text: String) {
+        #if os(iOS)
+        UIPasteboard.general.string = text
+        #elseif os(macOS)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        #endif
+    }
+}

--- a/Sources/BaseChatUI/Views/Chat/AssistantMarkdownView.swift
+++ b/Sources/BaseChatUI/Views/Chat/AssistantMarkdownView.swift
@@ -1,17 +1,6 @@
 import SwiftUI
 import BaseChatCore
 
-enum MessageRenderingMode: Equatable {
-    case plainText
-    case markdown
-}
-
-enum MessageRenderingModeResolver {
-    static func mode(for role: MessageRole) -> MessageRenderingMode {
-        role == .assistant ? .markdown : .plainText
-    }
-}
-
 struct AssistantMarkdownBlock: Identifiable, Equatable {
     enum Kind: Equatable {
         case markdown
@@ -33,6 +22,7 @@ enum AssistantMarkdownParser {
         var isInCodeBlock = false
         var codeLanguage: String?
         var openingFenceLength = 0
+        // Intentionally support markdown-in-markdown examples from LLM output.
         var nestedFenceDepth = 0
 
         let lines = source.components(separatedBy: "\n")
@@ -90,6 +80,7 @@ enum AssistantMarkdownParser {
     }
 
     private static func parseFenceLine(_ line: String) -> (ticks: Int, rest: String)? {
+        // Accept arbitrary indentation to be lenient with streamed/model-formatted fences.
         let trimmedLeading = line.trimmingCharacters(in: .whitespaces)
         guard trimmedLeading.first == "`" else { return nil }
 

--- a/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
@@ -75,9 +75,7 @@ public struct MessageBubbleView: View {
             if message.content.isEmpty && isStreaming {
                 streamingPlaceholder
             } else {
-                Text(message.content)
-                    .font(.body)
-                    .textSelection(.enabled)
+                AssistantMarkdownView(content: message.content)
             }
 
             if isStreaming && !message.content.isEmpty {

--- a/Tests/BaseChatUITests/AssistantMarkdownRenderingTests.swift
+++ b/Tests/BaseChatUITests/AssistantMarkdownRenderingTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import BaseChatUI
+import BaseChatCore
+
+@MainActor
+final class AssistantMarkdownRenderingTests: XCTestCase {
+
+    func test_renderingMode_assistantUsesMarkdown() {
+        XCTAssertEqual(MessageRenderingModeResolver.mode(for: .assistant), .markdown)
+    }
+
+    func test_renderingMode_userUsesPlainText() {
+        XCTAssertEqual(MessageRenderingModeResolver.mode(for: .user), .plainText)
+    }
+
+    func test_renderingMode_systemUsesPlainText() {
+        XCTAssertEqual(MessageRenderingModeResolver.mode(for: .system), .plainText)
+    }
+
+    func test_parseBlocks_mixedMarkdownAndFencedCode_splitsIntoOrderedBlocks() {
+        let input = """
+        Intro **bold**
+
+        ```swift
+        let x = 1
+        print(x)
+        ```
+
+        - Item 1
+        [Link](https://example.com)
+        """
+
+        let blocks = AssistantMarkdownParser.parseBlocks(from: input)
+        XCTAssertEqual(blocks.count, 3)
+        XCTAssertEqual(blocks[0].kind, .markdown)
+        XCTAssertEqual(blocks[1].kind, .code(language: "swift"))
+        XCTAssertEqual(blocks[2].kind, .markdown)
+        XCTAssertTrue(blocks[0].text.contains("**bold**"))
+        XCTAssertTrue(blocks[2].text.contains("- Item 1"))
+        XCTAssertTrue(blocks[2].text.contains("[Link](https://example.com)"))
+    }
+
+    func test_parseBlocks_unclosedFenceTreatsAsMarkdownForStreaming() {
+        let input = """
+        Partial response
+        ```swift
+        let inFlight = true
+        """
+
+        let blocks = AssistantMarkdownParser.parseBlocks(from: input)
+        XCTAssertEqual(blocks.count, 1)
+        XCTAssertEqual(blocks[0].kind, .markdown)
+        XCTAssertEqual(blocks[0].text, input)
+    }
+
+    func test_parseBlocks_codeOnly_parsesSingleCodeBlock() {
+        let input = """
+        ```python
+        print("hi")
+        ```
+        """
+
+        let blocks = AssistantMarkdownParser.parseBlocks(from: input)
+        XCTAssertEqual(blocks.count, 1)
+        XCTAssertEqual(blocks[0].kind, .code(language: "python"))
+        XCTAssertEqual(blocks[0].text, #"print("hi")"#)
+    }
+
+    func test_attributedString_inlineFormattingIncludesIntents() {
+        let rendered = AssistantMarkdownParser.attributedString(from: "**bold** *italic* `code`")
+        let rawValues = rendered.runs.compactMap(\.inlinePresentationIntent?.rawValue)
+        XCTAssertTrue(rawValues.contains(InlinePresentationIntent.emphasized.rawValue))
+        XCTAssertTrue(rawValues.contains(InlinePresentationIntent.stronglyEmphasized.rawValue))
+        XCTAssertTrue(rawValues.contains(InlinePresentationIntent.code.rawValue))
+    }
+
+    func test_attributedString_headersListsAndLinksIncludePresentationAndLink() {
+        let rendered = AssistantMarkdownParser.attributedString(from: "# Header\n- Item\n[Docs](https://example.com)")
+        let hasHeader = rendered.runs.contains { run in
+            run.presentationIntent?.components.contains(where: {
+                if case .header(level: 1) = $0.kind { return true }
+                return false
+            }) == true
+        }
+        let hasListItem = rendered.runs.contains { run in
+            run.presentationIntent?.components.contains(where: {
+                if case .listItem = $0.kind { return true }
+                return false
+            }) == true
+        }
+        let hasLink = rendered.runs.contains { $0.link == URL(string: "https://example.com") }
+
+        XCTAssertTrue(hasHeader)
+        XCTAssertTrue(hasListItem)
+        XCTAssertTrue(hasLink)
+    }
+}

--- a/Tests/BaseChatUITests/AssistantMarkdownRenderingTests.swift
+++ b/Tests/BaseChatUITests/AssistantMarkdownRenderingTests.swift
@@ -5,18 +5,6 @@ import BaseChatCore
 @MainActor
 final class AssistantMarkdownRenderingTests: XCTestCase {
 
-    func test_renderingMode_assistantUsesMarkdown() {
-        XCTAssertEqual(MessageRenderingModeResolver.mode(for: .assistant), .markdown)
-    }
-
-    func test_renderingMode_userUsesPlainText() {
-        XCTAssertEqual(MessageRenderingModeResolver.mode(for: .user), .plainText)
-    }
-
-    func test_renderingMode_systemUsesPlainText() {
-        XCTAssertEqual(MessageRenderingModeResolver.mode(for: .system), .plainText)
-    }
-
     func test_parseBlocks_mixedMarkdownAndFencedCode_splitsIntoOrderedBlocks() {
         let input = """
         Intro **bold**

--- a/Tests/BaseChatUITests/AssistantMarkdownRenderingTests.swift
+++ b/Tests/BaseChatUITests/AssistantMarkdownRenderingTests.swift
@@ -66,6 +66,30 @@ final class AssistantMarkdownRenderingTests: XCTestCase {
         XCTAssertEqual(blocks[0].text, #"print("hi")"#)
     }
 
+    func test_parseBlocks_nestedFenceInsideCodeBlock_keepsSingleOuterBlock() {
+        let input = """
+        Here's how:
+        ```markdown
+        Use fenced blocks:
+        ```swift
+        print("hi")
+        ```
+        Done
+        ```
+        End.
+        """
+
+        let blocks = AssistantMarkdownParser.parseBlocks(from: input)
+        XCTAssertEqual(blocks.count, 3)
+        XCTAssertEqual(blocks[0].kind, .markdown)
+        XCTAssertEqual(blocks[1].kind, .code(language: "markdown"))
+        XCTAssertEqual(blocks[2].kind, .markdown)
+
+        XCTAssertTrue(blocks[1].text.contains("```swift"))
+        XCTAssertTrue(blocks[1].text.contains(#"print("hi")"#))
+        XCTAssertTrue(blocks[1].text.contains("Done"))
+    }
+
     func test_attributedString_inlineFormattingIncludesIntents() {
         let rendered = AssistantMarkdownParser.attributedString(from: "**bold** *italic* `code`")
         let rawValues = rendered.runs.compactMap(\.inlinePresentationIntent?.rawValue)


### PR DESCRIPTION
## Summary
- render assistant messages as markdown instead of raw text
- parse fenced code blocks and render as styled mono blocks with copy button
- keep user/system messages as plain text
- add UI tests for markdown parsing/rendering behavior

## Testing
- swift test --filter BaseChatUITests

Closes #19