### PR TITLE
fix: move search field below tab picker and fix macOS tab switching in ModelManagementSheet

### DIFF
--- a/Sources/BaseChatUI/Views/Models/ModelManagementSheet.swift
+++ b/Sources/BaseChatUI/Views/Models/ModelManagementSheet.swift
@@ -42,34 +42,53 @@ public struct ModelManagementSheet: View {
 
     public var body: some View {
         NavigationStack {
+            #if os(macOS)
+            // On macOS, VStack works correctly and avoids the safeAreaInset
+            // state propagation bug where tab content doesn't update on selection.
+            VStack(spacing: 0) {
+                tabPickerBar
+                tabContent
+            }
+            .navigationTitle(selectedTab.rawValue)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            #else
+            // On iOS/iPadOS, safeAreaInset is required so the List is a direct
+            // child of NavigationStack — a VStack wrapper breaks hit testing on iPad.
             tabContent
                 .safeAreaInset(edge: .top, spacing: 0) {
-                    VStack(spacing: 0) {
-                        tabPicker
-                            .padding(.horizontal)
-                            .padding(.top, 8)
-                            .padding(.bottom, 4)
-
-                        Divider()
-                            .accessibilityHidden(true)
-                    }
-                    .background(.bar)
+                    tabPickerBar
                 }
                 .navigationTitle(selectedTab.rawValue)
-                #if os(iOS)
                 .navigationBarTitleDisplayMode(.inline)
-                #endif
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
                         Button("Done") { dismiss() }
                     }
                 }
+            #endif
         }
         .presentationDetents([.large])
         .onAppear {
             chatViewModel.refreshModels()
             managementViewModel.invalidateModelCache()
         }
+    }
+
+    private var tabPickerBar: some View {
+        VStack(spacing: 0) {
+            tabPicker
+                .padding(.horizontal)
+                .padding(.top, 8)
+                .padding(.bottom, 4)
+
+            Divider()
+                .accessibilityHidden(true)
+        }
+        .background(.bar)
     }
 
     // MARK: - Tab Picker
@@ -235,6 +254,33 @@ private struct ModelDownloadTab: View {
         @Bindable var viewModel = viewModel
 
         List {
+            Section {
+                HStack {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundStyle(.secondary)
+                    TextField("Search HuggingFace models...", text: $viewModel.searchQuery)
+                        .textFieldStyle(.plain)
+                        .autocorrectionDisabled()
+                        #if os(iOS)
+                        .keyboardType(.webSearch)
+                        .submitLabel(.search)
+                        #endif
+                        .onSubmit {
+                            Task { await viewModel.search() }
+                        }
+                    if !viewModel.searchQuery.isEmpty {
+                        Button {
+                            viewModel.searchQuery = ""
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Clear search")
+                    }
+                }
+            }
+
             WhyDownloadView()
 
             Section("Recommended for Your Device") {
@@ -305,10 +351,6 @@ private struct ModelDownloadTab: View {
                     .accessibilityLabel("Search error: \(error)")
                 }
             }
-        }
-        .searchable(text: $viewModel.searchQuery, prompt: "Search HuggingFace models...")
-        .onSubmit(of: .search) {
-            Task { await viewModel.search() }
         }
         .onChange(of: viewModel.completedDownloadCount) {
             viewModel.invalidateModelCache()

--- a/Sources/BaseChatUI/Views/Models/ModelManagementSheet.swift
+++ b/Sources/BaseChatUI/Views/Models/ModelManagementSheet.swift
@@ -49,27 +49,19 @@ public struct ModelManagementSheet: View {
                 tabPickerBar
                 tabContent
             }
-            .navigationTitle(selectedTab.rawValue)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Done") { dismiss() }
-                }
-            }
             #else
             // On iOS/iPadOS, safeAreaInset is required so the List is a direct
             // child of NavigationStack — a VStack wrapper breaks hit testing on iPad.
             tabContent
-                .safeAreaInset(edge: .top, spacing: 0) {
-                    tabPickerBar
-                }
-                .navigationTitle(selectedTab.rawValue)
+                .safeAreaInset(edge: .top, spacing: 0) { tabPickerBar }
                 .navigationBarTitleDisplayMode(.inline)
-                .toolbar {
-                    ToolbarItem(placement: .cancellationAction) {
-                        Button("Done") { dismiss() }
-                    }
-                }
             #endif
+        }
+        .navigationTitle(selectedTab.rawValue)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Done") { dismiss() }
+            }
         }
         .presentationDetents([.large])
         .onAppear {
@@ -258,6 +250,7 @@ private struct ModelDownloadTab: View {
                 HStack {
                     Image(systemName: "magnifyingglass")
                         .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
                     TextField("Search HuggingFace models...", text: $viewModel.searchQuery)
                         .textFieldStyle(.plain)
                         .autocorrectionDisabled()
@@ -268,6 +261,7 @@ private struct ModelDownloadTab: View {
                         .onSubmit {
                             Task { await viewModel.search() }
                         }
+                        .accessibilityLabel("Search HuggingFace models")
                     if !viewModel.searchQuery.isEmpty {
                         Button {
                             viewModel.searchQuery = ""


### PR DESCRIPTION
## Summary

- Search field in the Download tab was rendered in the navigation bar area via `.searchable`, appearing *above* the segmented tab picker. Replaced with an inline `TextField` inside the list so it sits below the picker, with a clear button when text is entered.
- On macOS, switching tabs visually updated the picker but the content area didn't change. Root cause: `safeAreaInset` (added in af4dafd to fix iPadOS List hit-testing) has a state-propagation bug on macOS where picker binding changes don't trigger a re-render of `tabContent`. Fixed with `#if os(macOS)` using `VStack`, keeping `safeAreaInset` on iOS/iPadOS.

## Test plan

- [ ] macOS: open model selector, confirm all three tabs (Select / Download / Storage) switch content correctly
- [ ] macOS: confirm search field appears below the segmented picker in the Download tab
- [ ] iOS/iPadOS: confirm tab switching still works and List rows are tappable
- [ ] CI passes (BaseChatCoreTests + BaseChatUITests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)