### PR TITLE
fix: wire live model management services

### DIFF
--- a/Sources/BaseChatUI/ViewModels/ModelManagementViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ModelManagementViewModel.swift
@@ -66,6 +66,22 @@ public final class ModelManagementViewModel {
         self.modelStorage = modelStorage
     }
 
+    /// Creates a production-ready model manager with search and downloads enabled.
+    public static func live(
+        huggingFaceService: any HuggingFaceServiceProtocol = HuggingFaceService(),
+        downloadManager: BackgroundDownloadManager = BackgroundDownloadManager(),
+        deviceCapability: DeviceCapabilityService = DeviceCapabilityService(),
+        modelStorage: ModelStorageService = ModelStorageService()
+    ) -> ModelManagementViewModel {
+        downloadManager.reconnectBackgroundSession()
+        return ModelManagementViewModel(
+            huggingFaceService: huggingFaceService,
+            downloadManager: downloadManager,
+            deviceCapability: deviceCapability,
+            modelStorage: modelStorage
+        )
+    }
+
     // MARK: - Computed Properties
 
     /// The recommended model size tier for this device.

--- a/Sources/BaseChatUI/Views/Models/ModelBrowserView.swift
+++ b/Sources/BaseChatUI/Views/Models/ModelBrowserView.swift
@@ -18,6 +18,10 @@ public struct ModelBrowserView: View {
 
         NavigationStack {
             List {
+                Section {
+                    ModelBrowserSearchField(text: $viewModel.searchQuery)
+                }
+
                 WhyDownloadView()
 
                 Section("Recommended for Your Device") {
@@ -64,8 +68,10 @@ public struct ModelBrowserView: View {
                     }
                 }
             }
-            .searchable(text: $viewModel.searchQuery, prompt: "Search HuggingFace models...")
             .onSubmit(of: .search) {
+                Task { await viewModel.search() }
+            }
+            .onChange(of: viewModel.searchQuery) { _, _ in
                 Task { await viewModel.search() }
             }
             .navigationTitle("Browse Models")
@@ -78,6 +84,44 @@ public struct ModelBrowserView: View {
                 viewModel.loadRecommendations()
             }
         }
+    }
+}
+
+private struct ModelBrowserSearchField: View {
+
+    @Binding var text: String
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+
+            searchTextField
+
+            if !text.isEmpty {
+                Button {
+                    text = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private var searchTextField: some View {
+        #if os(iOS)
+        TextField("Search HuggingFace models...", text: $text)
+            .textInputAutocapitalization(.never)
+            .disableAutocorrection(true)
+            .submitLabel(.search)
+        #else
+        TextField("Search HuggingFace models...", text: $text)
+        #endif
     }
 }
 

--- a/Sources/BaseChatUI/Views/Models/ModelManagementSheet.swift
+++ b/Sources/BaseChatUI/Views/Models/ModelManagementSheet.swift
@@ -57,15 +57,37 @@ public struct ModelManagementSheet: View {
                 .navigationBarTitleDisplayMode(.inline)
             #endif
         }
-                            ModelSearchField(text: $viewModel.searchQuery)
+        .navigationTitle(selectedTab.rawValue)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Done") { dismiss() }
+            }
+        }
+        .presentationDetents([.large])
+        .onAppear {
+            chatViewModel.refreshModels()
+            managementViewModel.invalidateModelCache()
+        }
+    }
+
+    private var tabPickerBar: some View {
+        VStack(spacing: 0) {
+            tabPicker
+                .padding(.horizontal)
+                .padding(.top, 8)
+                .padding(.bottom, 4)
+
+            Divider()
+                .accessibilityHidden(true)
+        }
+        .background(.bar)
+    }
+
     // MARK: - Tab Picker
 
     @ViewBuilder
     private var tabPicker: some View {
         let tabs = availableTabs
-                    .onChange(of: viewModel.searchQuery) { _, _ in
-                        Task { await viewModel.search() }
-                    }
         if tabs.count > 1 {
             Picker("Section", selection: $selectedTab) {
                 ForEach(tabs, id: \.self) { tab in
@@ -76,43 +98,6 @@ public struct ModelManagementSheet: View {
             .pickerStyle(.segmented)
             .accessibilityLabel("Model management section")
         }
-            private struct ModelSearchField: View {
-
-                @Binding var text: String
-
-                var body: some View {
-                    HStack(spacing: 10) {
-                        Image(systemName: "magnifyingglass")
-                            .foregroundStyle(.secondary)
-
-                        searchTextField
-
-                        if !text.isEmpty {
-                            Button {
-                                text = ""
-                            } label: {
-                                Image(systemName: "xmark.circle.fill")
-                                    .foregroundStyle(.secondary)
-                            }
-                            .buttonStyle(.plain)
-                            .accessibilityLabel("Clear search")
-                        }
-                    }
-                    .padding(.vertical, 4)
-                }
-
-                @ViewBuilder
-                private var searchTextField: some View {
-                    #if os(iOS)
-                    TextField("Search HuggingFace models...", text: $text)
-                        .textInputAutocapitalization(.never)
-                        .disableAutocorrection(true)
-                        .submitLabel(.search)
-                    #else
-                    TextField("Search HuggingFace models...", text: $text)
-                    #endif
-                }
-            }
     }
 
     // MARK: - Tab Content

--- a/Sources/BaseChatUI/Views/Models/ModelManagementSheet.swift
+++ b/Sources/BaseChatUI/Views/Models/ModelManagementSheet.swift
@@ -57,37 +57,15 @@ public struct ModelManagementSheet: View {
                 .navigationBarTitleDisplayMode(.inline)
             #endif
         }
-        .navigationTitle(selectedTab.rawValue)
-        .toolbar {
-            ToolbarItem(placement: .cancellationAction) {
-                Button("Done") { dismiss() }
-            }
-        }
-        .presentationDetents([.large])
-        .onAppear {
-            chatViewModel.refreshModels()
-            managementViewModel.invalidateModelCache()
-        }
-    }
-
-    private var tabPickerBar: some View {
-        VStack(spacing: 0) {
-            tabPicker
-                .padding(.horizontal)
-                .padding(.top, 8)
-                .padding(.bottom, 4)
-
-            Divider()
-                .accessibilityHidden(true)
-        }
-        .background(.bar)
-    }
-
+                            ModelSearchField(text: $viewModel.searchQuery)
     // MARK: - Tab Picker
 
     @ViewBuilder
     private var tabPicker: some View {
         let tabs = availableTabs
+                    .onChange(of: viewModel.searchQuery) { _, _ in
+                        Task { await viewModel.search() }
+                    }
         if tabs.count > 1 {
             Picker("Section", selection: $selectedTab) {
                 ForEach(tabs, id: \.self) { tab in
@@ -98,6 +76,43 @@ public struct ModelManagementSheet: View {
             .pickerStyle(.segmented)
             .accessibilityLabel("Model management section")
         }
+            private struct ModelSearchField: View {
+
+                @Binding var text: String
+
+                var body: some View {
+                    HStack(spacing: 10) {
+                        Image(systemName: "magnifyingglass")
+                            .foregroundStyle(.secondary)
+
+                        searchTextField
+
+                        if !text.isEmpty {
+                            Button {
+                                text = ""
+                            } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundStyle(.secondary)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Clear search")
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+
+                @ViewBuilder
+                private var searchTextField: some View {
+                    #if os(iOS)
+                    TextField("Search HuggingFace models...", text: $text)
+                        .textInputAutocapitalization(.never)
+                        .disableAutocorrection(true)
+                        .submitLabel(.search)
+                    #else
+                    TextField("Search HuggingFace models...", text: $text)
+                    #endif
+                }
+            }
     }
 
     // MARK: - Tab Content

--- a/Tests/BaseChatUITests/ModelManagementViewModelTests.swift
+++ b/Tests/BaseChatUITests/ModelManagementViewModelTests.swift
@@ -187,6 +187,30 @@ final class ModelManagementViewModelTests: XCTestCase {
         )
     }
 
+    func test_liveFactory_usesInjectedSearchService() async {
+        let mock = MockHuggingFaceService()
+        mock.searchResults = [
+            DownloadableModel(
+                repoID: "test/repo",
+                fileName: "configured.gguf",
+                displayName: "Configured Model",
+                modelType: .gguf,
+                sizeBytes: 2_000_000_000
+            )
+        ]
+
+        let vm = ModelManagementViewModel.live(
+            huggingFaceService: mock,
+            downloadManager: BackgroundDownloadManager()
+        )
+        vm.searchQuery = "configured"
+
+        await vm.search()
+
+        XCTAssertEqual(vm.searchResults.map(\.displayName), ["Configured Model"])
+        XCTAssertNil(vm.searchError)
+    }
+
     // MARK: - Device Capability Queries
 
     func test_canRunModel_delegatesToDeviceCapability() {


### PR DESCRIPTION
## Summary
- add a `ModelManagementViewModel.live()` factory that wires in `HuggingFaceService` and `BackgroundDownloadManager`
- move `ModelBrowserView` search into inline content and trigger searches from query changes
- add regression coverage for the live factory wiring path

## Testing
- `swift test --filter ModelManagementViewModelTests` *(currently blocked by an existing package build issue: missing `Sources/BaseChatCore/Protocols/BackendError.swift` input)*
- VS Code diagnostics on edited files
