### PR TITLE
fix: add local model import to model management

### DIFF
--- a/Sources/BaseChatUI/ViewModels/ModelManagementViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ModelManagementViewModel.swift
@@ -2,6 +2,17 @@ import Foundation
 import Observation
 import BaseChatCore
 
+public enum ModelImportError: LocalizedError, Equatable {
+    case unsupportedFormat
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedFormat:
+            return "Unsupported model format. Import a .gguf file or an MLX model folder containing config.json."
+        }
+    }
+}
+
 /// View model for the model browser and storage management sheets.
 ///
 /// Coordinates HuggingFace search, curated recommendations, downloads, and
@@ -277,6 +288,20 @@ public final class ModelManagementViewModel {
         Log.download.info("Deleted model: \(model.name)")
     }
 
+    /// Imports a local model file or directory into the app's models directory.
+    @discardableResult
+    public func importModel(from sourceURL: URL) throws -> ModelInfo {
+        let destination = try modelStorage.importModel(from: sourceURL)
+
+        if let imported = importedModel(at: destination) {
+            invalidateModelCache()
+            return imported
+        }
+
+        try? FileManager.default.removeItem(at: destination)
+        throw ModelImportError.unsupportedFormat
+    }
+
     // MARK: - Device Capability Queries
 
     /// Whether this device has enough RAM to run a model of the given size.
@@ -304,5 +329,17 @@ public final class ModelManagementViewModel {
     /// Returns the active download state for a model, if any.
     public func downloadState(for model: DownloadableModel) -> DownloadState? {
         activeDownloads[model.id]
+    }
+
+    private func importedModel(at url: URL) -> ModelInfo? {
+        if let gguf = ModelInfo(ggufURL: url) {
+            return gguf
+        }
+
+        if let mlx = ModelInfo(mlxDirectory: url) {
+            return mlx
+        }
+
+        return nil
     }
 }

--- a/Sources/BaseChatUI/Views/Models/ModelManagementSheet.swift
+++ b/Sources/BaseChatUI/Views/Models/ModelManagementSheet.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 import BaseChatCore
 
 /// Unified model management sheet combining model selection, download, and storage.
@@ -242,6 +243,15 @@ private struct ModelDownloadTab: View {
     @Environment(ModelManagementViewModel.self) private var viewModel
     @Environment(ChatViewModel.self) private var chatViewModel
 
+    @State private var showImporter = false
+    @State private var importSuccessMessage: String?
+    @State private var importErrorMessage: String?
+
+    private static var importContentTypes: [UTType] {
+        let gguf = UTType(filenameExtension: "gguf") ?? .data
+        return [gguf, .folder]
+    }
+
     var body: some View {
         @Bindable var viewModel = viewModel
 
@@ -273,9 +283,26 @@ private struct ModelDownloadTab: View {
                         .accessibilityLabel("Clear search")
                     }
                 }
+
+                Button {
+                    importSuccessMessage = nil
+                    importErrorMessage = nil
+                    showImporter = true
+                } label: {
+                    Label("Import Local Model", systemImage: "plus.circle")
+                }
+                .accessibilityLabel("Import local model")
             }
 
             WhyDownloadView()
+
+            if let message = importSuccessMessage {
+                Section {
+                    Label(message, systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                        .accessibilityLabel(message)
+                }
+            }
 
             Section("Recommended for Your Device") {
                 if viewModel.recommendedModels.isEmpty {
@@ -332,7 +359,7 @@ private struct ModelDownloadTab: View {
                 }
             }
 
-            if let error = viewModel.searchError {
+            if let error = importErrorMessage ?? viewModel.searchError {
                 Section {
                     Label {
                         Text(error)
@@ -350,8 +377,43 @@ private struct ModelDownloadTab: View {
             viewModel.invalidateModelCache()
             chatViewModel.refreshModels()
         }
+        .fileImporter(
+            isPresented: $showImporter,
+            allowedContentTypes: Self.importContentTypes,
+            allowsMultipleSelection: false
+        ) { result in
+            handleImport(result)
+        }
         .onAppear {
             viewModel.loadRecommendations()
+        }
+    }
+
+    private func handleImport(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            guard let url = urls.first else { return }
+
+            let accessed = url.startAccessingSecurityScopedResource()
+            defer {
+                if accessed {
+                    url.stopAccessingSecurityScopedResource()
+                }
+            }
+
+            do {
+                let imported = try viewModel.importModel(from: url)
+                chatViewModel.refreshModels()
+                importErrorMessage = nil
+                importSuccessMessage = "Imported \(imported.name). Open Select to use it."
+            } catch {
+                importSuccessMessage = nil
+                importErrorMessage = error.localizedDescription
+            }
+
+        case .failure(let error):
+            importSuccessMessage = nil
+            importErrorMessage = error.localizedDescription
         }
     }
 }

--- a/Tests/BaseChatUITests/ModelManagementViewModelTests.swift
+++ b/Tests/BaseChatUITests/ModelManagementViewModelTests.swift
@@ -277,4 +277,45 @@ final class ModelManagementViewModelTests: XCTestCase {
             "Error should mention download manager"
         )
     }
+
+    // MARK: - Local Model Import
+
+    func test_importModel_withGGUF_copiesFileIntoModelsDirectory() throws {
+        let vm = ModelManagementViewModel()
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ModelImport-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let fileName = "imported-\(UUID().uuidString).gguf"
+        let sourceURL = tempDir.appendingPathComponent(fileName)
+        try Data(repeating: 0xAB, count: 4096).write(to: sourceURL)
+
+        let imported = try vm.importModel(from: sourceURL)
+        let importedURL = URL(fileURLWithPath: vm.modelsDirectoryPath).appendingPathComponent(fileName)
+        defer { try? FileManager.default.removeItem(at: importedURL) }
+
+        XCTAssertEqual(imported.fileName, fileName)
+        XCTAssertEqual(imported.modelType, .gguf)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: importedURL.path))
+    }
+
+    func test_importModel_withUnsupportedFile_throwsAndRemovesCopy() throws {
+        let vm = ModelManagementViewModel()
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ModelImportUnsupported-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let fileName = "unsupported-\(UUID().uuidString).txt"
+        let sourceURL = tempDir.appendingPathComponent(fileName)
+        try Data("not a model".utf8).write(to: sourceURL)
+
+        XCTAssertThrowsError(try vm.importModel(from: sourceURL)) { error in
+            XCTAssertEqual(error as? ModelImportError, .unsupportedFormat)
+        }
+
+        let importedURL = URL(fileURLWithPath: vm.modelsDirectoryPath).appendingPathComponent(fileName)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: importedURL.path))
+    }
 }


### PR DESCRIPTION
## Summary
- add local model import to the model management download tab
- validate imported items as GGUF files or MLX model folders before keeping them
- refresh the local model list immediately and add regression coverage for import success and unsupported files

## Verification
- `swift build --target BaseChatUI`

## Notes
- `swift test --filter BaseChatUITests/ModelManagementViewModelTests` is still blocked by pre-existing Swift 6 concurrency failures elsewhere in the package test suite, including existing failures in BaseChatUITests and BaseChatCoreTests unrelated to this change.