### PR TITLE
feat: add focused example app scaffold with MinimalExample

### DIFF
--- a/Example/Examples/BaseChatExamples.xcodeproj/project.pbxproj
+++ b/Example/Examples/BaseChatExamples.xcodeproj/project.pbxproj
@@ -1,0 +1,745 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		09C86A21537F0ED2862D66ED /* MinimalExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA4C42C4D0FB1CD0ECBDA84 /* MinimalExampleApp.swift */; };
+		237BDDDF6342A3C558D183DE /* NarrationContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E2455118D791BCB4EE9A8E /* NarrationContentView.swift */; };
+		34606F73E74AAFC63E24F59A /* MinimalContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37540D69A62A294DAAD7FC1 /* MinimalContentView.swift */; };
+		37169A54399BCE198B0CAFC1 /* BaseChatUI in Frameworks */ = {isa = PBXBuildFile; productRef = C74D4B5129B915241F3B729F /* BaseChatUI */; };
+		40C7626D4A44DD1D18F0A1BF /* BaseChatCore in Frameworks */ = {isa = PBXBuildFile; productRef = 35D03E318932E0724E391E54 /* BaseChatCore */; };
+		593465922A0280A61667345C /* BaseChatCore in Frameworks */ = {isa = PBXBuildFile; productRef = FCA39DE093311FED76430749 /* BaseChatCore */; };
+		6AEB1D7BE1075645E3BE86EE /* BaseChatBackends in Frameworks */ = {isa = PBXBuildFile; productRef = BCABDB4A71329FBBFC4B5E62 /* BaseChatBackends */; };
+		6F9A1CA5CA7FF16DB36A5861 /* BaseChatUI in Frameworks */ = {isa = PBXBuildFile; productRef = 4C28E08B212DBDD057CE27CF /* BaseChatUI */; };
+		71AD992412A5389B7BBF7D4E /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 29A877C460BD339F65BF8C76 /* README.md */; };
+		79E6928B6CE7E3461758C5D9 /* MinimalExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA4C42C4D0FB1CD0ECBDA84 /* MinimalExampleApp.swift */; };
+		7BF6618749829CBFDBE2E6BA /* BaseChatBackends in Frameworks */ = {isa = PBXBuildFile; productRef = 87A24B749DC86C84D687588D /* BaseChatBackends */; };
+		958FF9C8DBB5C5C151DFF5D7 /* MinimalContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37540D69A62A294DAAD7FC1 /* MinimalContentView.swift */; };
+		9784B251D853FA597B206D29 /* BaseChatBackends in Frameworks */ = {isa = PBXBuildFile; productRef = 56CCAAB5544541CD79EE64CD /* BaseChatBackends */; };
+		A19A3DAEB85A136F8D62D31D /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 365ABBF494EF2955A53C327F /* README.md */; };
+		A336FC431FF118C880002B21 /* BaseChatCore in Frameworks */ = {isa = PBXBuildFile; productRef = DE250A4FF8082BF6714FE36C /* BaseChatCore */; };
+		A9BB32CEAF191F5FF101B54C /* BaseChatBackends in Frameworks */ = {isa = PBXBuildFile; productRef = 7A5841AF39A6AB3B5022006D /* BaseChatBackends */; };
+		BDEFF2A70B1C230BAE40611B /* NarrationContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E2455118D791BCB4EE9A8E /* NarrationContentView.swift */; };
+		BE8D5327EDF62C7A07496DAD /* NarrationExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DADCE8769857652ED74498 /* NarrationExampleApp.swift */; };
+		D2930E9046EADB459A40EA45 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 365ABBF494EF2955A53C327F /* README.md */; };
+		D5C8FE43A6514231E493B3F0 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 29A877C460BD339F65BF8C76 /* README.md */; };
+		ED126D062FB5AE041EBED7A0 /* NarrationExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DADCE8769857652ED74498 /* NarrationExampleApp.swift */; };
+		EFA072F50C91195B4A338E8C /* BaseChatUI in Frameworks */ = {isa = PBXBuildFile; productRef = 5D2764E94034C1EB5E482F75 /* BaseChatUI */; };
+		F7E8A441EA53E7632943B7FB /* BaseChatCore in Frameworks */ = {isa = PBXBuildFile; productRef = E094138144BB9C8FC4E2732A /* BaseChatCore */; };
+		FC60E8ABA29780124562917E /* BaseChatUI in Frameworks */ = {isa = PBXBuildFile; productRef = 2A3B642179F83C0DE269F84E /* BaseChatUI */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		09DADCE8769857652ED74498 /* NarrationExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NarrationExampleApp.swift; sourceTree = "<group>"; };
+		0B803E317BA994107EA819AE /* MinimalExample.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = MinimalExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		0F5292FF1CF8CD14B8E07E9D /* BaseChatKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = BaseChatKit; path = ../..; sourceTree = SOURCE_ROOT; };
+		29A877C460BD339F65BF8C76 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		365ABBF494EF2955A53C327F /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		7BB63271FCEF6B359D9491ED /* NarrationExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NarrationExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		92BE324A993DAA5220792683 /* MinimalExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MinimalExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A829E557A353C731F9479B4 /* NarrationExample.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = NarrationExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A37540D69A62A294DAAD7FC1 /* MinimalContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimalContentView.swift; sourceTree = "<group>"; };
+		A5E2455118D791BCB4EE9A8E /* NarrationContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NarrationContentView.swift; sourceTree = "<group>"; };
+		ECA4C42C4D0FB1CD0ECBDA84 /* MinimalExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimalExampleApp.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		015C9298259F064137388FE4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				40C7626D4A44DD1D18F0A1BF /* BaseChatCore in Frameworks */,
+				EFA072F50C91195B4A338E8C /* BaseChatUI in Frameworks */,
+				9784B251D853FA597B206D29 /* BaseChatBackends in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6844FD7C3F449E752F4FC0C4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				593465922A0280A61667345C /* BaseChatCore in Frameworks */,
+				FC60E8ABA29780124562917E /* BaseChatUI in Frameworks */,
+				7BF6618749829CBFDBE2E6BA /* BaseChatBackends in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9DAB966B831C7D8FA2F24A98 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A336FC431FF118C880002B21 /* BaseChatCore in Frameworks */,
+				6F9A1CA5CA7FF16DB36A5861 /* BaseChatUI in Frameworks */,
+				A9BB32CEAF191F5FF101B54C /* BaseChatBackends in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F8ABCF61E1D5D5798EA97857 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F7E8A441EA53E7632943B7FB /* BaseChatCore in Frameworks */,
+				37169A54399BCE198B0CAFC1 /* BaseChatUI in Frameworks */,
+				6AEB1D7BE1075645E3BE86EE /* BaseChatBackends in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		091468DD26BB7CAAC1DB9424 = {
+			isa = PBXGroup;
+			children = (
+				42DC84986F1D4D965373F51B /* MinimalExample */,
+				B2C1139A401C5A0E19FE3308 /* NarrationExample */,
+				E03E0C62E216829522D5D8B5 /* Packages */,
+				38BB536CCAD94BD0FE87DFC6 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		38BB536CCAD94BD0FE87DFC6 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				0B803E317BA994107EA819AE /* MinimalExample.app */,
+				92BE324A993DAA5220792683 /* MinimalExample.app */,
+				9A829E557A353C731F9479B4 /* NarrationExample.app */,
+				7BB63271FCEF6B359D9491ED /* NarrationExample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		42DC84986F1D4D965373F51B /* MinimalExample */ = {
+			isa = PBXGroup;
+			children = (
+				A37540D69A62A294DAAD7FC1 /* MinimalContentView.swift */,
+				ECA4C42C4D0FB1CD0ECBDA84 /* MinimalExampleApp.swift */,
+				365ABBF494EF2955A53C327F /* README.md */,
+			);
+			path = MinimalExample;
+			sourceTree = "<group>";
+		};
+		B2C1139A401C5A0E19FE3308 /* NarrationExample */ = {
+			isa = PBXGroup;
+			children = (
+				A5E2455118D791BCB4EE9A8E /* NarrationContentView.swift */,
+				09DADCE8769857652ED74498 /* NarrationExampleApp.swift */,
+				29A877C460BD339F65BF8C76 /* README.md */,
+			);
+			path = NarrationExample;
+			sourceTree = "<group>";
+		};
+		E03E0C62E216829522D5D8B5 /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				0F5292FF1CF8CD14B8E07E9D /* BaseChatKit */,
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		089761BD700E47F290C37794 /* MinimalExample_iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 082185DE6FA7704817B21C6D /* Build configuration list for PBXNativeTarget "MinimalExample_iOS" */;
+			buildPhases = (
+				3005C4AD05504348A18E66DE /* Sources */,
+				CB0E10FB70F06B69CBA6AFA6 /* Resources */,
+				9DAB966B831C7D8FA2F24A98 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MinimalExample_iOS;
+			packageProductDependencies = (
+				DE250A4FF8082BF6714FE36C /* BaseChatCore */,
+				4C28E08B212DBDD057CE27CF /* BaseChatUI */,
+				7A5841AF39A6AB3B5022006D /* BaseChatBackends */,
+			);
+			productName = MinimalExample_iOS;
+			productReference = 0B803E317BA994107EA819AE /* MinimalExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+		0977ED799142D3D0E3F29259 /* NarrationExample_macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7F5497B20FB911510AE98DFB /* Build configuration list for PBXNativeTarget "NarrationExample_macOS" */;
+			buildPhases = (
+				349C7744CF6EDD6114099308 /* Sources */,
+				9BF5E56A13231F5583FFBB10 /* Resources */,
+				F8ABCF61E1D5D5798EA97857 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = NarrationExample_macOS;
+			packageProductDependencies = (
+				E094138144BB9C8FC4E2732A /* BaseChatCore */,
+				C74D4B5129B915241F3B729F /* BaseChatUI */,
+				BCABDB4A71329FBBFC4B5E62 /* BaseChatBackends */,
+			);
+			productName = NarrationExample_macOS;
+			productReference = 7BB63271FCEF6B359D9491ED /* NarrationExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+		5685D4CAAF752A9614E7EF5A /* NarrationExample_iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BA37C037FCF266C2194F81D8 /* Build configuration list for PBXNativeTarget "NarrationExample_iOS" */;
+			buildPhases = (
+				B900561FBD9A0D9B53105345 /* Sources */,
+				65874E66996F2A2EC527115E /* Resources */,
+				6844FD7C3F449E752F4FC0C4 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = NarrationExample_iOS;
+			packageProductDependencies = (
+				FCA39DE093311FED76430749 /* BaseChatCore */,
+				2A3B642179F83C0DE269F84E /* BaseChatUI */,
+				87A24B749DC86C84D687588D /* BaseChatBackends */,
+			);
+			productName = NarrationExample_iOS;
+			productReference = 9A829E557A353C731F9479B4 /* NarrationExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+		A0F65594E03C815EB84528A5 /* MinimalExample_macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2E0408BFF6E87A490B424BB2 /* Build configuration list for PBXNativeTarget "MinimalExample_macOS" */;
+			buildPhases = (
+				510098C91DBEE09F09488F04 /* Sources */,
+				72A8E61D380813E8468E0C8F /* Resources */,
+				015C9298259F064137388FE4 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MinimalExample_macOS;
+			packageProductDependencies = (
+				35D03E318932E0724E391E54 /* BaseChatCore */,
+				5D2764E94034C1EB5E482F75 /* BaseChatUI */,
+				56CCAAB5544541CD79EE64CD /* BaseChatBackends */,
+			);
+			productName = MinimalExample_macOS;
+			productReference = 92BE324A993DAA5220792683 /* MinimalExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		B8622008F22D998CA7C8DE9A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1600;
+				TargetAttributes = {
+				};
+			};
+			buildConfigurationList = 507BF4BDD44480B0FB14C508 /* Build configuration list for PBXProject "BaseChatExamples" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 091468DD26BB7CAAC1DB9424;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				E1E92C0816C1D3B33B7A189D /* XCLocalSwiftPackageReference "../.." */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 38BB536CCAD94BD0FE87DFC6 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				089761BD700E47F290C37794 /* MinimalExample_iOS */,
+				A0F65594E03C815EB84528A5 /* MinimalExample_macOS */,
+				5685D4CAAF752A9614E7EF5A /* NarrationExample_iOS */,
+				0977ED799142D3D0E3F29259 /* NarrationExample_macOS */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		65874E66996F2A2EC527115E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				71AD992412A5389B7BBF7D4E /* README.md in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		72A8E61D380813E8468E0C8F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D2930E9046EADB459A40EA45 /* README.md in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9BF5E56A13231F5583FFBB10 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D5C8FE43A6514231E493B3F0 /* README.md in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB0E10FB70F06B69CBA6AFA6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A19A3DAEB85A136F8D62D31D /* README.md in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		3005C4AD05504348A18E66DE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				958FF9C8DBB5C5C151DFF5D7 /* MinimalContentView.swift in Sources */,
+				09C86A21537F0ED2862D66ED /* MinimalExampleApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		349C7744CF6EDD6114099308 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				237BDDDF6342A3C558D183DE /* NarrationContentView.swift in Sources */,
+				BE8D5327EDF62C7A07496DAD /* NarrationExampleApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		510098C91DBEE09F09488F04 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				34606F73E74AAFC63E24F59A /* MinimalContentView.swift in Sources */,
+				79E6928B6CE7E3461758C5D9 /* MinimalExampleApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B900561FBD9A0D9B53105345 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BDEFF2A70B1C230BAE40611B /* NarrationContentView.swift in Sources */,
+				ED126D062FB5AE041EBED7A0 /* NarrationExampleApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		125FD25FB0E801688E5C5454 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.basechatkit.minimal-example";
+				PRODUCT_NAME = MinimalExample;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		60884D0E74614765453DE9CE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.basechatkit.minimal-example";
+				PRODUCT_NAME = MinimalExample;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
+		633B09FE5F00AD7CD1B249D8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.basechatkit.narration-example";
+				PRODUCT_NAME = NarrationExample;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Release;
+		};
+		6E5B0D378FD8C1A976A31BD6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		9D52E7C08BA74C7F5008F0F4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.basechatkit.narration-example";
+				PRODUCT_NAME = NarrationExample;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		9F6A5672C2DE1BEA2BE47927 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		A535C6BFC950213072902033 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.basechatkit.narration-example";
+				PRODUCT_NAME = NarrationExample;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		A8C1DBF0CFE609B166EEF7A0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.basechatkit.minimal-example";
+				PRODUCT_NAME = MinimalExample;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Release;
+		};
+		A99AE9F4F8D78A227632A154 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.basechatkit.narration-example";
+				PRODUCT_NAME = NarrationExample;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
+		E486144CB49497356A2F195A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.basechatkit.minimal-example";
+				PRODUCT_NAME = MinimalExample;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		082185DE6FA7704817B21C6D /* Build configuration list for PBXNativeTarget "MinimalExample_iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				125FD25FB0E801688E5C5454 /* Debug */,
+				E486144CB49497356A2F195A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		2E0408BFF6E87A490B424BB2 /* Build configuration list for PBXNativeTarget "MinimalExample_macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				60884D0E74614765453DE9CE /* Debug */,
+				A8C1DBF0CFE609B166EEF7A0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		507BF4BDD44480B0FB14C508 /* Build configuration list for PBXProject "BaseChatExamples" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9F6A5672C2DE1BEA2BE47927 /* Debug */,
+				6E5B0D378FD8C1A976A31BD6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		7F5497B20FB911510AE98DFB /* Build configuration list for PBXNativeTarget "NarrationExample_macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A99AE9F4F8D78A227632A154 /* Debug */,
+				633B09FE5F00AD7CD1B249D8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		BA37C037FCF266C2194F81D8 /* Build configuration list for PBXNativeTarget "NarrationExample_iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9D52E7C08BA74C7F5008F0F4 /* Debug */,
+				A535C6BFC950213072902033 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		E1E92C0816C1D3B33B7A189D /* XCLocalSwiftPackageReference "../.." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../..;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		2A3B642179F83C0DE269F84E /* BaseChatUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BaseChatUI;
+		};
+		35D03E318932E0724E391E54 /* BaseChatCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BaseChatCore;
+		};
+		4C28E08B212DBDD057CE27CF /* BaseChatUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BaseChatUI;
+		};
+		56CCAAB5544541CD79EE64CD /* BaseChatBackends */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BaseChatBackends;
+		};
+		5D2764E94034C1EB5E482F75 /* BaseChatUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BaseChatUI;
+		};
+		7A5841AF39A6AB3B5022006D /* BaseChatBackends */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BaseChatBackends;
+		};
+		87A24B749DC86C84D687588D /* BaseChatBackends */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BaseChatBackends;
+		};
+		BCABDB4A71329FBBFC4B5E62 /* BaseChatBackends */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BaseChatBackends;
+		};
+		C74D4B5129B915241F3B729F /* BaseChatUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BaseChatUI;
+		};
+		DE250A4FF8082BF6714FE36C /* BaseChatCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BaseChatCore;
+		};
+		E094138144BB9C8FC4E2732A /* BaseChatCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BaseChatCore;
+		};
+		FCA39DE093311FED76430749 /* BaseChatCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BaseChatCore;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = B8622008F22D998CA7C8DE9A /* Project object */;
+}

--- a/Example/Examples/BaseChatExamples.xcodeproj/project.pbxproj
+++ b/Example/Examples/BaseChatExamples.xcodeproj/project.pbxproj
@@ -8,42 +8,25 @@
 
 /* Begin PBXBuildFile section */
 		09C86A21537F0ED2862D66ED /* MinimalExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA4C42C4D0FB1CD0ECBDA84 /* MinimalExampleApp.swift */; };
-		237BDDDF6342A3C558D183DE /* NarrationContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E2455118D791BCB4EE9A8E /* NarrationContentView.swift */; };
 		34606F73E74AAFC63E24F59A /* MinimalContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37540D69A62A294DAAD7FC1 /* MinimalContentView.swift */; };
-		37169A54399BCE198B0CAFC1 /* BaseChatUI in Frameworks */ = {isa = PBXBuildFile; productRef = C74D4B5129B915241F3B729F /* BaseChatUI */; };
 		40C7626D4A44DD1D18F0A1BF /* BaseChatCore in Frameworks */ = {isa = PBXBuildFile; productRef = 35D03E318932E0724E391E54 /* BaseChatCore */; };
-		593465922A0280A61667345C /* BaseChatCore in Frameworks */ = {isa = PBXBuildFile; productRef = FCA39DE093311FED76430749 /* BaseChatCore */; };
-		6AEB1D7BE1075645E3BE86EE /* BaseChatBackends in Frameworks */ = {isa = PBXBuildFile; productRef = BCABDB4A71329FBBFC4B5E62 /* BaseChatBackends */; };
 		6F9A1CA5CA7FF16DB36A5861 /* BaseChatUI in Frameworks */ = {isa = PBXBuildFile; productRef = 4C28E08B212DBDD057CE27CF /* BaseChatUI */; };
-		71AD992412A5389B7BBF7D4E /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 29A877C460BD339F65BF8C76 /* README.md */; };
 		79E6928B6CE7E3461758C5D9 /* MinimalExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA4C42C4D0FB1CD0ECBDA84 /* MinimalExampleApp.swift */; };
-		7BF6618749829CBFDBE2E6BA /* BaseChatBackends in Frameworks */ = {isa = PBXBuildFile; productRef = 87A24B749DC86C84D687588D /* BaseChatBackends */; };
 		958FF9C8DBB5C5C151DFF5D7 /* MinimalContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37540D69A62A294DAAD7FC1 /* MinimalContentView.swift */; };
 		9784B251D853FA597B206D29 /* BaseChatBackends in Frameworks */ = {isa = PBXBuildFile; productRef = 56CCAAB5544541CD79EE64CD /* BaseChatBackends */; };
 		A19A3DAEB85A136F8D62D31D /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 365ABBF494EF2955A53C327F /* README.md */; };
 		A336FC431FF118C880002B21 /* BaseChatCore in Frameworks */ = {isa = PBXBuildFile; productRef = DE250A4FF8082BF6714FE36C /* BaseChatCore */; };
 		A9BB32CEAF191F5FF101B54C /* BaseChatBackends in Frameworks */ = {isa = PBXBuildFile; productRef = 7A5841AF39A6AB3B5022006D /* BaseChatBackends */; };
-		BDEFF2A70B1C230BAE40611B /* NarrationContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E2455118D791BCB4EE9A8E /* NarrationContentView.swift */; };
-		BE8D5327EDF62C7A07496DAD /* NarrationExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DADCE8769857652ED74498 /* NarrationExampleApp.swift */; };
 		D2930E9046EADB459A40EA45 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 365ABBF494EF2955A53C327F /* README.md */; };
-		D5C8FE43A6514231E493B3F0 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 29A877C460BD339F65BF8C76 /* README.md */; };
-		ED126D062FB5AE041EBED7A0 /* NarrationExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DADCE8769857652ED74498 /* NarrationExampleApp.swift */; };
 		EFA072F50C91195B4A338E8C /* BaseChatUI in Frameworks */ = {isa = PBXBuildFile; productRef = 5D2764E94034C1EB5E482F75 /* BaseChatUI */; };
-		F7E8A441EA53E7632943B7FB /* BaseChatCore in Frameworks */ = {isa = PBXBuildFile; productRef = E094138144BB9C8FC4E2732A /* BaseChatCore */; };
-		FC60E8ABA29780124562917E /* BaseChatUI in Frameworks */ = {isa = PBXBuildFile; productRef = 2A3B642179F83C0DE269F84E /* BaseChatUI */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		09DADCE8769857652ED74498 /* NarrationExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NarrationExampleApp.swift; sourceTree = "<group>"; };
 		0B803E317BA994107EA819AE /* MinimalExample.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = MinimalExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0F5292FF1CF8CD14B8E07E9D /* BaseChatKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = BaseChatKit; path = ../..; sourceTree = SOURCE_ROOT; };
-		29A877C460BD339F65BF8C76 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		365ABBF494EF2955A53C327F /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		7BB63271FCEF6B359D9491ED /* NarrationExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NarrationExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		92BE324A993DAA5220792683 /* MinimalExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MinimalExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		9A829E557A353C731F9479B4 /* NarrationExample.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = NarrationExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A37540D69A62A294DAAD7FC1 /* MinimalContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimalContentView.swift; sourceTree = "<group>"; };
-		A5E2455118D791BCB4EE9A8E /* NarrationContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NarrationContentView.swift; sourceTree = "<group>"; };
 		ECA4C42C4D0FB1CD0ECBDA84 /* MinimalExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimalExampleApp.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -58,16 +41,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6844FD7C3F449E752F4FC0C4 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				593465922A0280A61667345C /* BaseChatCore in Frameworks */,
-				FC60E8ABA29780124562917E /* BaseChatUI in Frameworks */,
-				7BF6618749829CBFDBE2E6BA /* BaseChatBackends in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		9DAB966B831C7D8FA2F24A98 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -78,16 +51,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		F8ABCF61E1D5D5798EA97857 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F7E8A441EA53E7632943B7FB /* BaseChatCore in Frameworks */,
-				37169A54399BCE198B0CAFC1 /* BaseChatUI in Frameworks */,
-				6AEB1D7BE1075645E3BE86EE /* BaseChatBackends in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -95,7 +58,6 @@
 			isa = PBXGroup;
 			children = (
 				42DC84986F1D4D965373F51B /* MinimalExample */,
-				B2C1139A401C5A0E19FE3308 /* NarrationExample */,
 				E03E0C62E216829522D5D8B5 /* Packages */,
 				38BB536CCAD94BD0FE87DFC6 /* Products */,
 			);
@@ -106,8 +68,6 @@
 			children = (
 				0B803E317BA994107EA819AE /* MinimalExample.app */,
 				92BE324A993DAA5220792683 /* MinimalExample.app */,
-				9A829E557A353C731F9479B4 /* NarrationExample.app */,
-				7BB63271FCEF6B359D9491ED /* NarrationExample.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -120,16 +80,6 @@
 				365ABBF494EF2955A53C327F /* README.md */,
 			);
 			path = MinimalExample;
-			sourceTree = "<group>";
-		};
-		B2C1139A401C5A0E19FE3308 /* NarrationExample */ = {
-			isa = PBXGroup;
-			children = (
-				A5E2455118D791BCB4EE9A8E /* NarrationContentView.swift */,
-				09DADCE8769857652ED74498 /* NarrationExampleApp.swift */,
-				29A877C460BD339F65BF8C76 /* README.md */,
-			);
-			path = NarrationExample;
 			sourceTree = "<group>";
 		};
 		E03E0C62E216829522D5D8B5 /* Packages */ = {
@@ -163,50 +113,6 @@
 			);
 			productName = MinimalExample_iOS;
 			productReference = 0B803E317BA994107EA819AE /* MinimalExample.app */;
-			productType = "com.apple.product-type.application";
-		};
-		0977ED799142D3D0E3F29259 /* NarrationExample_macOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 7F5497B20FB911510AE98DFB /* Build configuration list for PBXNativeTarget "NarrationExample_macOS" */;
-			buildPhases = (
-				349C7744CF6EDD6114099308 /* Sources */,
-				9BF5E56A13231F5583FFBB10 /* Resources */,
-				F8ABCF61E1D5D5798EA97857 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = NarrationExample_macOS;
-			packageProductDependencies = (
-				E094138144BB9C8FC4E2732A /* BaseChatCore */,
-				C74D4B5129B915241F3B729F /* BaseChatUI */,
-				BCABDB4A71329FBBFC4B5E62 /* BaseChatBackends */,
-			);
-			productName = NarrationExample_macOS;
-			productReference = 7BB63271FCEF6B359D9491ED /* NarrationExample.app */;
-			productType = "com.apple.product-type.application";
-		};
-		5685D4CAAF752A9614E7EF5A /* NarrationExample_iOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = BA37C037FCF266C2194F81D8 /* Build configuration list for PBXNativeTarget "NarrationExample_iOS" */;
-			buildPhases = (
-				B900561FBD9A0D9B53105345 /* Sources */,
-				65874E66996F2A2EC527115E /* Resources */,
-				6844FD7C3F449E752F4FC0C4 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = NarrationExample_iOS;
-			packageProductDependencies = (
-				FCA39DE093311FED76430749 /* BaseChatCore */,
-				2A3B642179F83C0DE269F84E /* BaseChatUI */,
-				87A24B749DC86C84D687588D /* BaseChatBackends */,
-			);
-			productName = NarrationExample_iOS;
-			productReference = 9A829E557A353C731F9479B4 /* NarrationExample.app */;
 			productType = "com.apple.product-type.application";
 		};
 		A0F65594E03C815EB84528A5 /* MinimalExample_macOS */ = {
@@ -261,34 +167,16 @@
 			targets = (
 				089761BD700E47F290C37794 /* MinimalExample_iOS */,
 				A0F65594E03C815EB84528A5 /* MinimalExample_macOS */,
-				5685D4CAAF752A9614E7EF5A /* NarrationExample_iOS */,
-				0977ED799142D3D0E3F29259 /* NarrationExample_macOS */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		65874E66996F2A2EC527115E /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				71AD992412A5389B7BBF7D4E /* README.md in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		72A8E61D380813E8468E0C8F /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				D2930E9046EADB459A40EA45 /* README.md in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		9BF5E56A13231F5583FFBB10 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D5C8FE43A6514231E493B3F0 /* README.md in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -312,30 +200,12 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		349C7744CF6EDD6114099308 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				237BDDDF6342A3C558D183DE /* NarrationContentView.swift in Sources */,
-				BE8D5327EDF62C7A07496DAD /* NarrationExampleApp.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		510098C91DBEE09F09488F04 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				34606F73E74AAFC63E24F59A /* MinimalContentView.swift in Sources */,
 				79E6928B6CE7E3461758C5D9 /* MinimalExampleApp.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		B900561FBD9A0D9B53105345 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BDEFF2A70B1C230BAE40611B /* NarrationContentView.swift in Sources */,
-				ED126D062FB5AE041EBED7A0 /* NarrationExampleApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -384,27 +254,6 @@
 				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
-		};
-		633B09FE5F00AD7CD1B249D8 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				COMBINE_HIDPI_IMAGES = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.basechatkit.narration-example";
-				PRODUCT_NAME = NarrationExample;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 6.0;
-			};
-			name = Release;
 		};
 		6E5B0D378FD8C1A976A31BD6 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -461,28 +310,6 @@
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
-		};
-		9D52E7C08BA74C7F5008F0F4 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.basechatkit.narration-example";
-				PRODUCT_NAME = NarrationExample;
-				SDKROOT = iphoneos;
-				SWIFT_VERSION = 6.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
 		};
 		9F6A5672C2DE1BEA2BE47927 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -547,28 +374,6 @@
 			};
 			name = Debug;
 		};
-		A535C6BFC950213072902033 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.basechatkit.narration-example";
-				PRODUCT_NAME = NarrationExample;
-				SDKROOT = iphoneos;
-				SWIFT_VERSION = 6.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Release;
-		};
 		A8C1DBF0CFE609B166EEF7A0 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -589,27 +394,6 @@
 				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
-		};
-		A99AE9F4F8D78A227632A154 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				COMBINE_HIDPI_IMAGES = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.basechatkit.narration-example";
-				PRODUCT_NAME = NarrationExample;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 6.0;
-			};
-			name = Debug;
 		};
 		E486144CB49497356A2F195A /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -663,24 +447,6 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		7F5497B20FB911510AE98DFB /* Build configuration list for PBXNativeTarget "NarrationExample_macOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				A99AE9F4F8D78A227632A154 /* Debug */,
-				633B09FE5F00AD7CD1B249D8 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
-		BA37C037FCF266C2194F81D8 /* Build configuration list for PBXNativeTarget "NarrationExample_iOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				9D52E7C08BA74C7F5008F0F4 /* Debug */,
-				A535C6BFC950213072902033 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
@@ -691,10 +457,6 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		2A3B642179F83C0DE269F84E /* BaseChatUI */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = BaseChatUI;
-		};
 		35D03E318932E0724E391E54 /* BaseChatCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = BaseChatCore;
@@ -715,27 +477,7 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = BaseChatBackends;
 		};
-		87A24B749DC86C84D687588D /* BaseChatBackends */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = BaseChatBackends;
-		};
-		BCABDB4A71329FBBFC4B5E62 /* BaseChatBackends */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = BaseChatBackends;
-		};
-		C74D4B5129B915241F3B729F /* BaseChatUI */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = BaseChatUI;
-		};
 		DE250A4FF8082BF6714FE36C /* BaseChatCore */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = BaseChatCore;
-		};
-		E094138144BB9C8FC4E2732A /* BaseChatCore */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = BaseChatCore;
-		};
-		FCA39DE093311FED76430749 /* BaseChatCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = BaseChatCore;
 		};

--- a/Example/Examples/BaseChatExamples.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Examples/BaseChatExamples.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example/Examples/MinimalExample/MinimalContentView.swift
+++ b/Example/Examples/MinimalExample/MinimalContentView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import SwiftData
 import BaseChatCore
 import BaseChatUI
 
@@ -18,8 +19,9 @@ struct MinimalContentView: View {
                 }
         }
         .onAppear {
-            viewModel.configure(modelContext: modelContext)
-            sessionManager.configure(modelContext: modelContext)
+            let persistence = SwiftDataPersistenceProvider(modelContext: modelContext)
+            viewModel.configure(persistence: persistence)
+            sessionManager.configure(persistence: persistence)
 
             viewModel.refreshModels()
 

--- a/Example/Examples/MinimalExample/MinimalContentView.swift
+++ b/Example/Examples/MinimalExample/MinimalContentView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+import BaseChatCore
+import BaseChatUI
+
+struct MinimalContentView: View {
+    @Environment(ChatViewModel.self) private var viewModel
+    @Environment(SessionManagerViewModel.self) private var sessionManager
+    @Environment(\.modelContext) private var modelContext
+
+    @State private var isModelManagementPresented = false
+
+    var body: some View {
+        NavigationStack {
+            ChatView(showModelManagement: $isModelManagementPresented)
+                .sheet(isPresented: $isModelManagementPresented) {
+                    ModelManagementSheet()
+                        .environment(viewModel)
+                }
+        }
+        .onAppear {
+            viewModel.configure(modelContext: modelContext)
+            sessionManager.configure(modelContext: modelContext)
+
+            viewModel.refreshModels()
+
+            if sessionManager.sessions.isEmpty {
+                _ = try? sessionManager.createSession()
+            }
+
+            sessionManager.loadSessions()
+        }
+    }
+}

--- a/Example/Examples/MinimalExample/MinimalExampleApp.swift
+++ b/Example/Examples/MinimalExample/MinimalExampleApp.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+import SwiftData
+import BaseChatCore
+import BaseChatUI
+import BaseChatBackends
+
+/// The simplest possible BaseChatKit app — under 40 lines.
+///
+/// This registers all built-in backends, creates an in-memory SwiftData store,
+/// and presents the standard ChatView. No model curation, no custom UI.
+@main
+struct MinimalExampleApp: App {
+    @State private var chatViewModel: ChatViewModel
+    @State private var sessionManager = SessionManagerViewModel()
+
+    private let modelContainer: ModelContainer
+
+    init() {
+        BaseChatConfiguration.shared = BaseChatConfiguration(
+            appName: "Minimal Chat",
+            bundleIdentifier: "com.basechatkit.minimal-example"
+        )
+
+        let service = InferenceService()
+        DefaultBackends.register(with: service)
+
+        let vm = ChatViewModel(inferenceService: service)
+        vm.foundationModelProvider = {
+            if #available(iOS 26, macOS 26, *) {
+                return FoundationBackend.isAvailable
+            }
+            return false
+        }
+        _chatViewModel = State(initialValue: vm)
+
+        let schema = Schema(BaseChatSchema.allModelTypes)
+        self.modelContainer = try! ModelContainer(for: schema)
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            MinimalContentView()
+                .environment(chatViewModel)
+                .environment(sessionManager)
+        }
+        .modelContainer(modelContainer)
+    }
+}

--- a/Example/Examples/MinimalExample/README.md
+++ b/Example/Examples/MinimalExample/README.md
@@ -10,7 +10,7 @@ The simplest possible BaseChatKit app. Demonstrates the bare minimum setup:
 
 ## Running
 
-1. Open `Examples.xcodeproj` in Xcode
+1. Open `BaseChatExamples.xcodeproj` in Xcode
 2. Select the **MinimalExample** scheme
 3. Build and run on iOS Simulator or Mac
 

--- a/Example/Examples/MinimalExample/README.md
+++ b/Example/Examples/MinimalExample/README.md
@@ -1,0 +1,24 @@
+# Minimal Example
+
+The simplest possible BaseChatKit app. Demonstrates the bare minimum setup:
+
+- Configure `BaseChatConfiguration` at startup
+- Register backends with `DefaultBackends.register(with:)`
+- Create a `ChatViewModel` and `SessionManagerViewModel`
+- Set up SwiftData with `BaseChatSchema.allModelTypes`
+- Present `ChatView` with environment wiring
+
+## Running
+
+1. Open `Examples.xcodeproj` in Xcode
+2. Select the **MinimalExample** scheme
+3. Build and run on iOS Simulator or Mac
+
+## What to Look At
+
+- `MinimalExampleApp.swift` — app entry point and backend registration (~35 lines)
+- `MinimalContentView.swift` — wraps `ChatView` with minimal onAppear setup
+
+## Next Steps
+
+See the other examples for specific features (narration, remote backends, tool calling, RAG).

--- a/Example/Examples/project.yml
+++ b/Example/Examples/project.yml
@@ -33,25 +33,3 @@ targets:
         INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
         SWIFT_VERSION: "6.0"
         GENERATE_INFOPLIST_FILE: YES
-
-  NarrationExample:
-    type: application
-    platform: [iOS, macOS]
-    sources:
-      - NarrationExample
-    dependencies:
-      - package: BaseChatKit
-        product: BaseChatCore
-      - package: BaseChatKit
-        product: BaseChatUI
-      - package: BaseChatKit
-        product: BaseChatBackends
-    settings:
-      base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.basechatkit.narration-example
-        INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
-        INFOPLIST_KEY_UILaunchScreen_Generation: YES
-        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
-        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
-        SWIFT_VERSION: "6.0"
-        GENERATE_INFOPLIST_FILE: YES

--- a/Example/Examples/project.yml
+++ b/Example/Examples/project.yml
@@ -1,0 +1,57 @@
+name: BaseChatExamples
+options:
+  bundleIdPrefix: com.basechatkit
+  deploymentTarget:
+    iOS: "18.0"
+    macOS: "15.0"
+  xcodeVersion: "16.0"
+  generateEmptyDirectories: true
+
+packages:
+  BaseChatKit:
+    path: ../..
+
+targets:
+  MinimalExample:
+    type: application
+    platform: [iOS, macOS]
+    sources:
+      - MinimalExample
+    dependencies:
+      - package: BaseChatKit
+        product: BaseChatCore
+      - package: BaseChatKit
+        product: BaseChatUI
+      - package: BaseChatKit
+        product: BaseChatBackends
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.basechatkit.minimal-example
+        INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
+        INFOPLIST_KEY_UILaunchScreen_Generation: YES
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        SWIFT_VERSION: "6.0"
+        GENERATE_INFOPLIST_FILE: YES
+
+  NarrationExample:
+    type: application
+    platform: [iOS, macOS]
+    sources:
+      - NarrationExample
+    dependencies:
+      - package: BaseChatKit
+        product: BaseChatCore
+      - package: BaseChatKit
+        product: BaseChatUI
+      - package: BaseChatKit
+        product: BaseChatBackends
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.basechatkit.narration-example
+        INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
+        INFOPLIST_KEY_UILaunchScreen_Generation: YES
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        SWIFT_VERSION: "6.0"
+        GENERATE_INFOPLIST_FILE: YES

--- a/Example/README.md
+++ b/Example/README.md
@@ -1,19 +1,32 @@
-# BaseChat Demo
+# BaseChatKit Examples
 
-Minimal example app showing how to build a chat interface with BaseChatKit.
+## BaseChatDemo (Full Reference App)
 
-## Running
+The full-featured demo showing all BaseChatKit capabilities working together. This is also the host for UI tests.
 
-1. Open the `BaseChatDemo.xcodeproj` in Xcode
+1. Open `BaseChatDemo.xcodeproj` in Xcode
 2. The project references `BaseChatKit` as a local package from `../../`
 3. Build and run on iOS Simulator or Mac
 
-## What This Demonstrates
+### What This Demonstrates
 
 - Configuring `BaseChatConfiguration` at startup
 - Composing `BaseChatUI` views (ChatView, SessionListView, ModelManagementSheet)
 - Setting up SwiftData with `BaseChatSchema.allModelTypes`
 - Wiring view models via `@Environment`
+- Cloud API endpoint management
+- Multi-session chat with auto-rename
+- Model download and storage management
+
+## Focused Examples
+
+Small, purpose-built apps that each showcase a single feature. Open `Examples/BaseChatExamples.xcodeproj` in Xcode and select the scheme for the example you want to run.
+
+| Example | Scheme | What It Shows |
+|---------|--------|---------------|
+| [MinimalExample](Examples/MinimalExample/) | `MinimalExample_iOS` / `MinimalExample_macOS` | Bare-minimum BaseChatKit app (~40 lines) |
+
+More examples ship alongside new features — see each example's README for details.
 
 ## Customization
 


### PR DESCRIPTION
## Summary
- Introduces a hybrid demo architecture: `BaseChatDemo` (full reference) + `Example/Examples/` (focused mini-apps)
- Adds `BaseChatExamples.xcodeproj` (xcodegen-managed) with per-platform schemes
- Ships `MinimalExample`: bare-minimum BaseChatKit app (~40 lines) showing the absolute minimum setup
- Updates `Example/README.md` to index all examples with a table

## Test plan
- [ ] `xcodebuild build -scheme MinimalExample_iOS` compiles cleanly
- [ ] `xcodebuild build -scheme MinimalExample_macOS` compiles cleanly
- [ ] `swift test` — all existing tests pass (no library changes)
- [ ] MinimalExample launches on simulator and shows ChatView

🤖 Generated with [Claude Code](https://claude.com/claude-code)