### PR TITLE
feat: document and test stopGeneration() protocol contract

### DIFF
--- a/Sources/BaseChatCore/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatCore/Protocols/InferenceBackend.swift
@@ -54,6 +54,20 @@ public protocol InferenceBackend: AnyObject, Sendable {
     ) throws -> AsyncThrowingStream<String, Error>
 
     /// Requests that the current generation stop as soon as possible.
+    ///
+    /// ## Contract
+    ///
+    /// After `stopGeneration()` returns, the backend **must** satisfy all of:
+    ///
+    /// 1. **Cancel in-flight generation** — any running `generate()` stream is
+    ///    terminated. The stream's `onTermination` handler fires.
+    /// 2. **Ready for reuse** — the backend accepts a new `generate()` call
+    ///    without requiring `loadModel()` or `resetConversation()` first.
+    ///    There must be no corrupted sessions or stale state.
+    /// 3. **`isGenerating` is `false`** — callers can check this synchronously
+    ///    to confirm the stop took effect.
+    ///
+    /// Calling `stopGeneration()` when no generation is in progress is a no-op.
     func stopGeneration()
 
     /// Unloads the model and frees all associated memory.

--- a/Sources/BaseChatTestSupport/MockInferenceBackend.swift
+++ b/Sources/BaseChatTestSupport/MockInferenceBackend.swift
@@ -25,6 +25,9 @@ public final class MockInferenceBackend: InferenceBackend, @unchecked Sendable {
     public var lastSystemPrompt: String?
     public var lastConfig: GenerationConfig?
 
+    /// Stored so stopGeneration() can terminate the in-flight stream.
+    private var activeContinuation: AsyncThrowingStream<String, Error>.Continuation?
+
     public init(capabilities: BackendCapabilities = BackendCapabilities(
         supportedParameters: [.temperature, .topP, .repeatPenalty],
         maxContextTokens: 4096,
@@ -52,6 +55,10 @@ public final class MockInferenceBackend: InferenceBackend, @unchecked Sendable {
         let tokens = tokensToYield
 
         return AsyncThrowingStream { [self] continuation in
+            self.activeContinuation = continuation
+            continuation.onTermination = { @Sendable _ in
+                self.activeContinuation = nil
+            }
             Task {
                 for token in tokens {
                     if Task.isCancelled { break }
@@ -66,6 +73,8 @@ public final class MockInferenceBackend: InferenceBackend, @unchecked Sendable {
     public func stopGeneration() {
         stopCallCount += 1
         isGenerating = false
+        activeContinuation?.finish()
+        activeContinuation = nil
     }
 
     public func unloadModel() {

--- a/Sources/BaseChatTestSupport/StopGenerationContractTests.swift
+++ b/Sources/BaseChatTestSupport/StopGenerationContractTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+import BaseChatCore
+
+/// Shared conformance tests that verify the `stopGeneration()` contract
+/// documented on `InferenceBackend`.
+///
+/// Any test target can call these helpers with a concrete backend instance
+/// to verify it honours the protocol contract.
+public enum StopGenerationContractTests {
+
+    /// Verifies that `isGenerating` is `false` after `stopGeneration()` and
+    /// that a subsequent `generate()` call succeeds cleanly.
+    ///
+    /// The backend must already have a model loaded before calling this.
+    public static func verifyStopLeavesBackendReusable(
+        _ backend: some InferenceBackend,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let config = GenerationConfig(maxTokens: 64)
+
+        // 1. Start generation and immediately stop.
+        let stream = try backend.generate(
+            prompt: "Hello",
+            systemPrompt: nil,
+            config: config
+        )
+        backend.stopGeneration()
+
+        // 2. isGenerating must be false after stop.
+        XCTAssertFalse(
+            backend.isGenerating,
+            "isGenerating must be false after stopGeneration()",
+            file: file,
+            line: line
+        )
+
+        // Drain the stream so the backend's internal task completes.
+        for try await _ in stream {}
+
+        // 3. A new generate() call must work without errors.
+        let secondStream = try backend.generate(
+            prompt: "World",
+            systemPrompt: nil,
+            config: config
+        )
+
+        var tokens: [String] = []
+        for try await token in secondStream {
+            tokens.append(token)
+        }
+
+        XCTAssertFalse(
+            tokens.isEmpty,
+            "Second generate() after stop must produce tokens",
+            file: file,
+            line: line
+        )
+
+        XCTAssertFalse(
+            backend.isGenerating,
+            "isGenerating must be false after second stream completes",
+            file: file,
+            line: line
+        )
+    }
+}

--- a/Tests/BaseChatCoreTests/StopGenerationContractTests.swift
+++ b/Tests/BaseChatCoreTests/StopGenerationContractTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+import BaseChatCore
+import BaseChatTestSupport
+
+/// Runs the shared `stopGeneration()` contract tests against MockInferenceBackend.
+final class StopGenerationContractMockTests: XCTestCase {
+
+    func test_mockBackend_honoursStopGenerationContract() async throws {
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["one", "two", "three"]
+
+        try await StopGenerationContractTests.verifyStopLeavesBackendReusable(backend)
+    }
+
+    func test_stopGeneration_whenIdle_isNoOp() {
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+
+        // Stopping with no generation in progress must not crash or corrupt state.
+        backend.stopGeneration()
+
+        XCTAssertFalse(backend.isGenerating)
+        XCTAssertTrue(backend.isModelLoaded)
+        XCTAssertEqual(backend.stopCallCount, 1)
+    }
+}


### PR DESCRIPTION
## Summary
- Added protocol-level documentation to `stopGeneration()` on `InferenceBackend` specifying the full contract: cancel in-flight generation, leave backend ready for reuse, `isGenerating` returns `false`, stream termination fires
- Created `StopGenerationContractTests` shared test helper in `BaseChatTestSupport` that any backend can use to verify contract conformance
- Added tests in `BaseChatCoreTests` running the contract against `MockInferenceBackend`

Closes #59

## Test plan
- [x] `swift test --filter StopGenerationContract` — both tests pass
- [ ] CI passes (`BaseChatCoreTests`, `BaseChatUITests`, `BaseChatBackendsTests`)
- [ ] Concrete backends can adopt `StopGenerationContractTests.verifyStopLeavesBackendReusable()` in their own test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)