### PR TITLE
feat: add max output token limit to generation pipeline

### DIFF
--- a/Sources/BaseChatBackends/ClaudeBackend.swift
+++ b/Sources/BaseChatBackends/ClaudeBackend.swift
@@ -269,7 +269,7 @@ public final class ClaudeBackend: InferenceBackend, ConversationHistoryReceiver,
 
         var body: [String: Any] = [
             "model": modelName,
-            "max_tokens": Int(config.maxTokens),
+            "max_tokens": config.maxOutputTokens ?? Int(config.maxTokens),
             "messages": chatMessages,
             "stream": true,
             "temperature": config.temperature,

--- a/Sources/BaseChatBackends/FoundationBackend.swift
+++ b/Sources/BaseChatBackends/FoundationBackend.swift
@@ -176,6 +176,8 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
                         options: options
                     )
 
+                    let outputLimit = config.maxOutputTokens
+                    var outputTokenCount = 0
                     var previousText = ""
                     for try await partial in stream {
                         if Task.isCancelled { break }
@@ -190,6 +192,16 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
                             )
                             continuation.yield(newContent)
                             previousText = currentText
+
+                            // Approximate token count using the conservative 3-char heuristic.
+                            // Stops runaway generation for open-ended prompts.
+                            if let limit = outputLimit {
+                                outputTokenCount += max(1, newContent.count / 3)
+                                if outputTokenCount >= limit {
+                                    Self.logger.info("Output token limit (\(limit)) reached")
+                                    break
+                                }
+                            }
                         }
                     }
                 } catch {

--- a/Sources/BaseChatBackends/KoboldCppBackend.swift
+++ b/Sources/BaseChatBackends/KoboldCppBackend.swift
@@ -238,7 +238,7 @@ public final class KoboldCppBackend: InferenceBackend, ConversationHistoryReceiv
 
         var body: [String: Any] = [
             "prompt": prompt,
-            "max_length": Int(config.maxTokens),
+            "max_length": config.maxOutputTokens ?? Int(config.maxTokens),
             "temperature": config.temperature,
             "top_p": config.topP,
             "top_k": config.topK.map { Int($0) } ?? 40,

--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -171,7 +171,7 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
             throw InferenceError.inferenceFailure("Failed to tokenize prompt")
         }
 
-        let maxTokens = Int(config.maxTokens)
+        let maxTokens = config.maxOutputTokens ?? Int(config.maxTokens)
 
         return AsyncThrowingStream { [weak self] continuation in
             let task = Task { [weak self] in

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -121,6 +121,8 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                     let input = try await modelContainer.perform { context in
                         try await context.processor.prepare(input: .init(messages: messages))
                     }
+                    let outputLimit = config.maxOutputTokens
+                    var outputTokenCount = 0
                     let stream = try await modelContainer.generate(
                         input: input,
                         parameters: generateConfig
@@ -129,6 +131,11 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                         if Task.isCancelled { break }
                         if let text = generation.chunk {
                             continuation.yield(text)
+                            // Each chunk from MLX corresponds to one token.
+                            if let limit = outputLimit {
+                                outputTokenCount += 1
+                                if outputTokenCount >= limit { break }
+                            }
                         }
                     }
                 } catch {

--- a/Sources/BaseChatBackends/OpenAIBackend.swift
+++ b/Sources/BaseChatBackends/OpenAIBackend.swift
@@ -253,7 +253,7 @@ public final class OpenAIBackend: InferenceBackend, ConversationHistoryReceiver,
             "stream_options": ["include_usage": true],
             "temperature": config.temperature,
             "top_p": config.topP,
-            "max_tokens": Int(config.maxTokens)
+            "max_tokens": config.maxOutputTokens ?? Int(config.maxTokens)
         ]
 
         var request = URLRequest(url: completionsURL)

--- a/Sources/BaseChatCore/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatCore/Protocols/InferenceBackend.swift
@@ -9,13 +9,21 @@ public struct GenerationConfig: Sendable {
     public var topK: Int32?
     public var typicalP: Float?
 
+    /// Maximum number of tokens the model should generate in a single response.
+    ///
+    /// Cloud backends send this as their `max_tokens` API parameter.
+    /// Local backends (Foundation, MLX, llama.cpp) use it to cap the generation loop.
+    /// `nil` means no explicit limit beyond the backend's own defaults.
+    public var maxOutputTokens: Int?
+
     public init(
         temperature: Float = 0.7,
         topP: Float = 0.9,
         repeatPenalty: Float = 1.1,
         maxTokens: Int32 = 512,
         topK: Int32? = nil,
-        typicalP: Float? = nil
+        typicalP: Float? = nil,
+        maxOutputTokens: Int? = 2048
     ) {
         self.temperature = temperature
         self.topP = topP
@@ -23,6 +31,7 @@ public struct GenerationConfig: Sendable {
         self.maxTokens = maxTokens
         self.topK = topK
         self.typicalP = typicalP
+        self.maxOutputTokens = maxOutputTokens
     }
 }
 

--- a/Sources/BaseChatCore/Services/InferenceService.swift
+++ b/Sources/BaseChatCore/Services/InferenceService.swift
@@ -131,7 +131,8 @@ public final class InferenceService {
         systemPrompt: String? = nil,
         temperature: Float = 0.7,
         topP: Float = 0.9,
-        repeatPenalty: Float = 1.1
+        repeatPenalty: Float = 1.1,
+        maxOutputTokens: Int? = 2048
     ) throws -> AsyncThrowingStream<String, Error> {
         guard let backend else {
             throw InferenceError.inferenceFailure("No model loaded")
@@ -140,7 +141,8 @@ public final class InferenceService {
         let config = GenerationConfig(
             temperature: temperature,
             topP: topP,
-            repeatPenalty: repeatPenalty
+            repeatPenalty: repeatPenalty,
+            maxOutputTokens: maxOutputTokens
         )
 
         isGenerating = true

--- a/Tests/BaseChatCoreTests/GenerationConfigTests.swift
+++ b/Tests/BaseChatCoreTests/GenerationConfigTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import BaseChatCore
+import BaseChatTestSupport
 
 final class GenerationConfigTests: XCTestCase {
 
@@ -25,6 +26,11 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertEqual(config.maxTokens, 512)
     }
 
+    func test_defaultInit_maxOutputTokens() {
+        let config = GenerationConfig()
+        XCTAssertEqual(config.maxOutputTokens, 2048)
+    }
+
     // MARK: - Custom Init
 
     func test_customInit_propagatesAllValues() {
@@ -48,5 +54,35 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertEqual(config.topP, 0.9, accuracy: 0.001, "Non-overridden topP should use default")
         XCTAssertEqual(config.repeatPenalty, 1.1, accuracy: 0.001, "Non-overridden repeatPenalty should use default")
         XCTAssertEqual(config.maxTokens, 1024)
+        XCTAssertEqual(config.maxOutputTokens, 2048, "Non-overridden maxOutputTokens should use default")
+    }
+
+    func test_customInit_maxOutputTokens_customValue() {
+        let config = GenerationConfig(maxOutputTokens: 4096)
+        XCTAssertEqual(config.maxOutputTokens, 4096)
+    }
+
+    func test_customInit_maxOutputTokens_nil() {
+        let config = GenerationConfig(maxOutputTokens: nil)
+        XCTAssertNil(config.maxOutputTokens)
+    }
+
+    func test_maxOutputTokens_isMutable() {
+        var config = GenerationConfig()
+        config.maxOutputTokens = 512
+        XCTAssertEqual(config.maxOutputTokens, 512)
+    }
+
+    // MARK: - Mock Backend Captures maxOutputTokens
+
+    func test_mockBackend_capturesMaxOutputTokens() async throws {
+        let backend = MockInferenceBackend()
+        try await backend.loadModel(from: URL(string: "file:///mock")!, contextSize: 512)
+
+        let config = GenerationConfig(maxOutputTokens: 1024)
+        let stream = try backend.generate(prompt: "test", systemPrompt: nil, config: config)
+        for try await _ in stream {}
+
+        XCTAssertEqual(backend.lastConfig?.maxOutputTokens, 1024)
     }
 }


### PR DESCRIPTION
## Summary
- Adds `maxOutputTokens: Int?` field to `GenerationConfig` with a default of 2048, configurable per-request
- Cloud backends (Claude, OpenAI, KoboldCpp) wire the value to their `max_tokens` / `max_length` API parameters
- Local backends (FoundationBackend, MLXBackend, LlamaBackend) enforce the limit via token counting in the generation loop, breaking out of streaming when the cap is reached

Closes #58

## Test plan
- [x] `GenerationConfig` defaults `maxOutputTokens` to 2048
- [x] Custom values and `nil` are stored correctly
- [x] `MockInferenceBackend` captures `maxOutputTokens` through the config
- [x] All existing tests pass (`BaseChatCoreTests`: 64, `BaseChatUITests`: 229, `BaseChatBackendsTests`: 25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)