### PR TITLE
fix: stable reverse-scroll when prepending older messages

### DIFF
--- a/Sources/BaseChatCore/Protocols/ChatPersistenceProvider.swift
+++ b/Sources/BaseChatCore/Protocols/ChatPersistenceProvider.swift
@@ -180,8 +180,42 @@ public protocol ChatPersistenceProvider: AnyObject, Sendable {
     /// - Throws: Storage errors from the underlying provider.
     func fetchMessages(for sessionID: UUID) throws -> [ChatMessageRecord]
 
+    /// Fetches the most recent messages for a session, up to `limit`.
+    ///
+    /// Results are returned in ascending timestamp order (oldest first).
+    /// Use ``fetchMessages(for:before:limit:)`` to page backwards from a known timestamp.
+    ///
+    /// - Throws: Storage errors from the underlying provider.
+    func fetchRecentMessages(for sessionID: UUID, limit: Int) throws -> [ChatMessageRecord]
+
+    /// Fetches messages older than `before` for a session, up to `limit`.
+    ///
+    /// Results are returned in ascending timestamp order (oldest first).
+    /// Returns an empty array when no older messages exist.
+    ///
+    /// - Throws: Storage errors from the underlying provider.
+    func fetchMessages(for sessionID: UUID, before: Date, limit: Int) throws -> [ChatMessageRecord]
+
     /// Deletes all messages for a session.
     ///
     /// - Throws: Storage errors from the underlying provider.
     func deleteMessages(for sessionID: UUID) throws
+}
+
+// MARK: - Default pagination implementations
+
+extension ChatPersistenceProvider {
+
+    /// Default: fetches all messages then returns the last `limit`.
+    public func fetchRecentMessages(for sessionID: UUID, limit: Int) throws -> [ChatMessageRecord] {
+        let all = try fetchMessages(for: sessionID)
+        return Array(all.suffix(limit))
+    }
+
+    /// Default: fetches all messages then filters to those before `before`.
+    public func fetchMessages(for sessionID: UUID, before: Date, limit: Int) throws -> [ChatMessageRecord] {
+        let all = try fetchMessages(for: sessionID)
+        let older = all.filter { $0.timestamp < before }
+        return Array(older.suffix(limit))
+    }
 }

--- a/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
+++ b/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
@@ -107,6 +107,28 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider, @unche
         return try modelContext.fetch(descriptor).map { $0.toRecord() }
     }
 
+    public func fetchRecentMessages(for sessionID: UUID, limit: Int) throws -> [ChatMessageRecord] {
+        // Fetch newest-first, take `limit`, then reverse to ascending order.
+        var descriptor = FetchDescriptor<ChatMessage>(
+            predicate: #Predicate { $0.sessionID == sessionID },
+            sortBy: [SortDescriptor(\.timestamp, order: .reverse)]
+        )
+        descriptor.fetchLimit = limit
+        let results = try modelContext.fetch(descriptor)
+        return results.reversed().map { $0.toRecord() }
+    }
+
+    public func fetchMessages(for sessionID: UUID, before: Date, limit: Int) throws -> [ChatMessageRecord] {
+        // Fetch messages older than `before`, newest-first, take `limit`, then reverse.
+        var descriptor = FetchDescriptor<ChatMessage>(
+            predicate: #Predicate { $0.sessionID == sessionID && $0.timestamp < before },
+            sortBy: [SortDescriptor(\.timestamp, order: .reverse)]
+        )
+        descriptor.fetchLimit = limit
+        let results = try modelContext.fetch(descriptor)
+        return results.reversed().map { $0.toRecord() }
+    }
+
     public func deleteMessages(for sessionID: UUID) throws {
         let descriptor = FetchDescriptor<ChatMessage>(
             predicate: #Predicate { $0.sessionID == sessionID }

--- a/Sources/BaseChatTestSupport/MockPersistenceProvider.swift
+++ b/Sources/BaseChatTestSupport/MockPersistenceProvider.swift
@@ -26,6 +26,8 @@ public final class MockPersistenceProvider: ChatPersistenceProvider, @unchecked 
     public var shouldThrowOnInsertMessage: Error?
     public var shouldThrowOnFetchMessages: Error?
     public var shouldThrowOnDeleteMessages: Error?
+    public var fetchRecentMessagesCallCount = 0
+    public var fetchMessagesBeforeCallCount = 0
 
     public init() {}
 
@@ -90,6 +92,24 @@ public final class MockPersistenceProvider: ChatPersistenceProvider, @unchecked 
         return messages
             .filter { $0.sessionID == sessionID }
             .sorted { $0.timestamp < $1.timestamp }
+    }
+
+    public func fetchRecentMessages(for sessionID: UUID, limit: Int) throws -> [ChatMessageRecord] {
+        fetchRecentMessagesCallCount += 1
+        if let error = shouldThrowOnFetchMessages { throw error }
+        let sorted = messages
+            .filter { $0.sessionID == sessionID }
+            .sorted { $0.timestamp < $1.timestamp }
+        return Array(sorted.suffix(limit))
+    }
+
+    public func fetchMessages(for sessionID: UUID, before: Date, limit: Int) throws -> [ChatMessageRecord] {
+        fetchMessagesBeforeCallCount += 1
+        if let error = shouldThrowOnFetchMessages { throw error }
+        let older = messages
+            .filter { $0.sessionID == sessionID && $0.timestamp < before }
+            .sorted { $0.timestamp < $1.timestamp }
+        return Array(older.suffix(limit))
     }
 
     public func deleteMessages(for sessionID: UUID) throws {

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Persistence.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Persistence.swift
@@ -5,7 +5,7 @@ import BaseChatCore
 
 extension ChatViewModel {
 
-    /// Loads messages for the active session from the persistence provider.
+    /// Loads the most recent page of messages for the active session.
     func loadMessages() {
         guard let persistence else {
             Log.persistence.warning("loadMessages called before persistence was configured — messages will not load")
@@ -13,16 +13,52 @@ extension ChatViewModel {
         }
         guard let sessionID = activeSessionID else {
             messages = []
+            hasOlderMessages = false
             return
         }
 
         do {
-            messages = try persistence.fetchMessages(for: sessionID)
-            Log.persistence.info("Loaded \(self.messages.count) messages")
+            let page = try persistence.fetchRecentMessages(for: sessionID, limit: Self.messagePageSize)
+            messages = page
+            // If we got a full page, there may be older messages above.
+            hasOlderMessages = page.count >= Self.messagePageSize
+            Log.persistence.info("Loaded \(page.count) messages (hasOlder: \(self.hasOlderMessages))")
         } catch {
             Log.persistence.error("Failed to load messages: \(error)")
             messages = []
+            hasOlderMessages = false
         }
+    }
+
+    /// Loads the next page of older messages and prepends them.
+    ///
+    /// Returns the ID of the message that was previously first in the list,
+    /// so the caller can restore scroll position to it after the prepend.
+    @discardableResult
+    public func loadOlderMessages() -> UUID? {
+        guard !isLoadingOlderMessages, hasOlderMessages else { return nil }
+        guard let persistence else { return nil }
+        guard let sessionID = activeSessionID else { return nil }
+        guard let oldestTimestamp = messages.first?.timestamp else { return nil }
+
+        let anchorID = messages.first?.id
+        isLoadingOlderMessages = true
+        defer { isLoadingOlderMessages = false }
+
+        do {
+            let older = try persistence.fetchMessages(for: sessionID, before: oldestTimestamp, limit: Self.messagePageSize)
+            if older.isEmpty {
+                hasOlderMessages = false
+                return anchorID
+            }
+            hasOlderMessages = older.count >= Self.messagePageSize
+            messages.insert(contentsOf: older, at: 0)
+            Log.persistence.info("Prepended \(older.count) older messages (hasOlder: \(self.hasOlderMessages))")
+        } catch {
+            Log.persistence.error("Failed to load older messages: \(error)")
+        }
+
+        return anchorID
     }
 
     /// Persists a message via the persistence provider.

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -219,6 +219,15 @@ public final class ChatViewModel {
     /// Cached per-message token counts keyed by message ID, to avoid recalculating all messages.
     var tokenCountCache: [UUID: Int] = [:]
 
+    /// Number of messages to load per page when paginating history.
+    static let messagePageSize = 50
+
+    /// Whether older messages are available to load above the current page.
+    public internal(set) var hasOlderMessages: Bool = false
+
+    /// Whether a page of older messages is currently being fetched.
+    public internal(set) var isLoadingOlderMessages: Bool = false
+
     // MARK: - Initialisation
 
     public init(
@@ -584,6 +593,7 @@ public final class ChatViewModel {
         guard let activeSessionID else {
             messages.removeAll()
             tokenCountCache.removeAll()
+            hasOlderMessages = false
             updateContextEstimate()
             Log.ui.info("Chat cleared")
             return
@@ -593,6 +603,7 @@ public final class ChatViewModel {
             try deleteMessages(for: activeSessionID)
             messages.removeAll()
             tokenCountCache.removeAll()
+            hasOlderMessages = false
             updateContextEstimate()
             Log.ui.info("Chat cleared")
         } catch {

--- a/Sources/BaseChatUI/Views/Chat/ChatView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ChatView.swift
@@ -222,6 +222,16 @@ public struct ChatView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(spacing: 4) {
+                    // Trigger for loading older messages when the user scrolls to the top.
+                    if viewModel.hasOlderMessages {
+                        ProgressView()
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 8)
+                            .onAppear {
+                                loadOlderAndRestore(proxy: proxy)
+                            }
+                    }
+
                     if viewModel.messages.isEmpty && !viewModel.isGenerating {
                         emptyPlaceholder
                     }
@@ -243,8 +253,13 @@ public struct ChatView: View {
                 }
                 .padding(.vertical, 8)
             }
+            .defaultScrollAnchor(.bottom)
             .onChange(of: viewModel.messages.count) {
-                scrollToBottom(proxy: proxy)
+                // Only auto-scroll to bottom for new messages appended at the end,
+                // not when older messages are prepended at the top.
+                if !viewModel.isLoadingOlderMessages {
+                    scrollToBottom(proxy: proxy)
+                }
             }
             .onChange(of: viewModel.messages.last?.content) {
                 scrollToBottom(proxy: proxy)
@@ -340,6 +355,17 @@ public struct ChatView: View {
         viewModel.isGenerating
         && message.role == .assistant
         && message.id == viewModel.messages.last?.id
+    }
+
+    /// Loads the next page of older messages and scrolls back to the anchor
+    /// so the viewport doesn't jump when content is prepended above.
+    private func loadOlderAndRestore(proxy: ScrollViewProxy) {
+        guard let anchorID = viewModel.loadOlderMessages() else { return }
+        // Scroll back to the message that was at the top before prepend,
+        // keeping it at the top of the viewport to prevent visible jump.
+        DispatchQueue.main.async {
+            proxy.scrollTo(anchorID, anchor: .top)
+        }
     }
 
     private func scrollToBottom(proxy: ScrollViewProxy) {

--- a/Tests/BaseChatUITests/PaginationTests.swift
+++ b/Tests/BaseChatUITests/PaginationTests.swift
@@ -1,0 +1,233 @@
+import XCTest
+@testable import BaseChatUI
+import BaseChatCore
+import BaseChatTestSupport
+
+/// Tests for message pagination: loadMessages pages, loadOlderMessages prepend,
+/// hasOlderMessages heuristic, and guard against concurrent loads.
+@MainActor
+final class PaginationTests: XCTestCase {
+
+    private var vm: ChatViewModel!
+    private var mock: MockInferenceBackend!
+    private var persistence: MockPersistenceProvider!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+
+        let service = InferenceService(backend: mock, name: "MockPagination")
+        vm = ChatViewModel(inferenceService: service)
+
+        persistence = MockPersistenceProvider()
+        vm.configure(persistence: persistence)
+    }
+
+    override func tearDown() async throws {
+        vm = nil
+        mock = nil
+        persistence = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    @discardableResult
+    private func makeSession() -> ChatSessionRecord {
+        let session = ChatSessionRecord(title: "Pagination Test")
+        try! persistence.insertSession(session)
+        vm.switchToSession(session)
+        return session
+    }
+
+    /// Inserts `count` messages with sequential timestamps starting from `baseTime`.
+    @discardableResult
+    private func insertMessages(
+        count: Int,
+        sessionID: UUID,
+        baseTime: Date = Date(timeIntervalSince1970: 1000)
+    ) -> [ChatMessageRecord] {
+        var records: [ChatMessageRecord] = []
+        for i in 0..<count {
+            let msg = ChatMessageRecord(
+                role: i % 2 == 0 ? .user : .assistant,
+                content: "Message \(i)",
+                timestamp: baseTime.addingTimeInterval(Double(i)),
+                sessionID: sessionID
+            )
+            try! persistence.insertMessage(msg)
+            records.append(msg)
+        }
+        return records
+    }
+
+    // MARK: - loadMessages
+
+    func test_loadMessages_loadsRecentPage() {
+        let session = makeSession()
+        let msgs = insertMessages(count: 10, sessionID: session.id)
+
+        vm.loadMessages()
+
+        XCTAssertEqual(vm.messages.count, 10)
+        XCTAssertEqual(vm.messages.first?.content, msgs.first?.content)
+        XCTAssertEqual(vm.messages.last?.content, msgs.last?.content)
+        XCTAssertFalse(vm.hasOlderMessages, "Fewer than pageSize messages means no older messages")
+    }
+
+    func test_loadMessages_setsHasOlderMessages_whenFullPage() {
+        let session = makeSession()
+        insertMessages(count: ChatViewModel.messagePageSize, sessionID: session.id)
+
+        vm.loadMessages()
+
+        XCTAssertEqual(vm.messages.count, ChatViewModel.messagePageSize)
+        XCTAssertTrue(vm.hasOlderMessages, "Full page should indicate older messages may exist")
+    }
+
+    func test_loadMessages_setsHasOlderMessages_whenMoreThanPageSize() {
+        let session = makeSession()
+        let totalCount = ChatViewModel.messagePageSize + 20
+        insertMessages(count: totalCount, sessionID: session.id)
+
+        vm.loadMessages()
+
+        XCTAssertEqual(vm.messages.count, ChatViewModel.messagePageSize)
+        XCTAssertTrue(vm.hasOlderMessages)
+        // Verify we got the most recent messages, not the oldest.
+        XCTAssertEqual(vm.messages.last?.content, "Message \(totalCount - 1)")
+    }
+
+    func test_loadMessages_withNoSession_clearsState() {
+        vm.activeSession = nil
+        vm.messages = [ChatMessageRecord(role: .user, content: "stale", sessionID: UUID())]
+        vm.hasOlderMessages = true
+
+        vm.loadMessages()
+
+        XCTAssertTrue(vm.messages.isEmpty)
+        XCTAssertFalse(vm.hasOlderMessages)
+    }
+
+    // MARK: - loadOlderMessages
+
+    func test_loadOlderMessages_prependsOlderPage() {
+        let session = makeSession()
+        let totalCount = ChatViewModel.messagePageSize + 20
+        let msgs = insertMessages(count: totalCount, sessionID: session.id)
+
+        vm.loadMessages()
+        XCTAssertEqual(vm.messages.count, ChatViewModel.messagePageSize)
+
+        let anchorID = vm.loadOlderMessages()
+
+        XCTAssertEqual(vm.messages.count, totalCount)
+        // Anchor should be the first message from the initial page (index 20 overall).
+        XCTAssertEqual(anchorID, msgs[20].id, "Anchor should be the message that was first before prepend")
+        XCTAssertEqual(vm.messages.first?.content, "Message 0")
+    }
+
+    func test_loadOlderMessages_returnsNil_whenNoOlderMessages() {
+        makeSession()
+
+        let anchorID = vm.loadOlderMessages()
+        XCTAssertNil(anchorID, "Should return nil when hasOlderMessages is false")
+    }
+
+    func test_loadOlderMessages_setsHasOlderToFalse_whenPartialPage() {
+        let session = makeSession()
+        let totalCount = ChatViewModel.messagePageSize + 10
+        insertMessages(count: totalCount, sessionID: session.id)
+
+        vm.loadMessages()
+        XCTAssertTrue(vm.hasOlderMessages)
+
+        vm.loadOlderMessages()
+
+        // Only 10 older messages were loaded, which is less than pageSize.
+        XCTAssertFalse(vm.hasOlderMessages, "Partial page means no more older messages")
+    }
+
+    func test_loadOlderMessages_setsHasOlderToFalse_whenFetchReturnsEmpty() {
+        let session = makeSession()
+        // Insert exactly messagePageSize -- heuristic says there may be more.
+        insertMessages(count: ChatViewModel.messagePageSize, sessionID: session.id)
+
+        vm.loadMessages()
+        XCTAssertTrue(vm.hasOlderMessages)
+
+        vm.loadOlderMessages()
+
+        XCTAssertFalse(vm.hasOlderMessages)
+    }
+
+    func test_loadOlderMessages_guardsAgainstConcurrentLoads() {
+        let session = makeSession()
+        let totalCount = ChatViewModel.messagePageSize + 20
+        insertMessages(count: totalCount, sessionID: session.id)
+
+        vm.loadMessages()
+
+        // Simulate isLoadingOlderMessages being true.
+        vm.isLoadingOlderMessages = true
+        let anchorID = vm.loadOlderMessages()
+        XCTAssertNil(anchorID, "Should not load while another load is in progress")
+        XCTAssertEqual(vm.messages.count, ChatViewModel.messagePageSize, "Message count should not change")
+
+        vm.isLoadingOlderMessages = false
+    }
+
+    func test_loadOlderMessages_resetsLoadingFlag() {
+        let session = makeSession()
+        let totalCount = ChatViewModel.messagePageSize + 20
+        insertMessages(count: totalCount, sessionID: session.id)
+
+        vm.loadMessages()
+        vm.loadOlderMessages()
+
+        XCTAssertFalse(vm.isLoadingOlderMessages, "Loading flag should be cleared after load completes")
+    }
+
+    // MARK: - clearChat resets pagination state
+
+    func test_clearChat_resetsHasOlderMessages() {
+        let session = makeSession()
+        insertMessages(count: ChatViewModel.messagePageSize + 10, sessionID: session.id)
+
+        vm.loadMessages()
+        XCTAssertTrue(vm.hasOlderMessages)
+
+        vm.clearChat()
+
+        XCTAssertFalse(vm.hasOlderMessages)
+        XCTAssertTrue(vm.messages.isEmpty)
+    }
+
+    // MARK: - Mock call tracking
+
+    func test_loadMessages_callsFetchRecentMessages() {
+        let session = makeSession()
+        insertMessages(count: 5, sessionID: session.id)
+
+        // Reset count after switchToSession's loadMessages call.
+        persistence.fetchRecentMessagesCallCount = 0
+
+        vm.loadMessages()
+
+        XCTAssertEqual(persistence.fetchRecentMessagesCallCount, 1)
+    }
+
+    func test_loadOlderMessages_callsFetchMessagesBefore() {
+        let session = makeSession()
+        insertMessages(count: ChatViewModel.messagePageSize + 10, sessionID: session.id)
+
+        vm.loadMessages()
+        persistence.fetchMessagesBeforeCallCount = 0
+
+        vm.loadOlderMessages()
+
+        XCTAssertEqual(persistence.fetchMessagesBeforeCallCount, 1)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds paginated message fetching (`fetchRecentMessages`, `fetchMessages(before:limit:)`) to `ChatPersistenceProvider` with default implementations and efficient SwiftData overrides
- `ChatViewModel` now loads only the most recent 50 messages on session switch; `loadOlderMessages()` prepends earlier pages on demand
- `ChatView` uses a top-of-list `ProgressView` trigger with `ScrollViewReader` anchor restoration to keep the viewport stable when older messages are prepended
- `.defaultScrollAnchor(.bottom)` ensures initial load starts at the newest messages

Closes #15

## Test plan
- [ ] No existing scroll-related UI tests; adding a meaningful test for scroll-position stability requires XCUITest infrastructure that doesn't exist yet
- [ ] Verified all 293+ existing tests pass (`BaseChatCoreTests`, `BaseChatUITests`, `BaseChatBackendsTests`)
- [ ] Manual testing: open a session with 100+ messages, scroll to top, verify older messages load without viewport jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)