### PR TITLE
test: add 5 test suites and TESTING.md covering E2E and integration gaps

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -70,7 +70,7 @@ let package = Package(
         ),
         .testTarget(
             name: "BaseChatE2ETests",
-            dependencies: ["BaseChatBackends", "BaseChatCore", "BaseChatTestSupport"]
+            dependencies: ["BaseChatBackends", "BaseChatUI", "BaseChatCore", "BaseChatTestSupport"]
         ),
     ],
     swiftLanguageModes: [.v6]

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,630 @@
+# Testing Guide
+
+This document describes BaseChatKit's testing philosophy, architecture, and patterns. It is aimed at contributors (including those new to Swift) and serves as both a reference and a rationale for how and why tests are structured the way they are.
+
+---
+
+## Table of Contents
+
+- [Testing Pyramid](#testing-pyramid)
+- [Test Targets](#test-targets)
+- [Feature Coverage Matrix](#feature-coverage-matrix)
+- [Async Testing Patterns](#async-testing-patterns)
+- [AI-Specific Flow Testing](#ai-specific-flow-testing)
+- [Mock Infrastructure](#mock-infrastructure)
+- [Writing New Tests](#writing-new-tests)
+- [Known Gaps](#known-gaps)
+
+---
+
+## Testing Pyramid
+
+BaseChatKit uses a four-layer testing pyramid. Each layer catches different classes of bugs at different costs:
+
+```
+         ╱  XCUITests (Example app)         ╲   Few, slow, high confidence
+        ╱   Headless E2E (real components)    ╲  Real wiring, no UI, CI-safe
+       ╱    Integration (ViewModel + SwiftData) ╲ Real persistence, mock backends
+      ╱     Unit (models, services, protocols)   ╲ Fast, isolated, exhaustive
+     ╱      Static (compiler + SwiftUI previews)  ╲ Free, always on
+```
+
+**Guiding principle:** push tests as far *down* the pyramid as they can go. A test that can run without a UI should not be an XCUITest. A test that can run without SwiftData should not be an integration test. The lower the layer, the faster and more reliable the test.
+
+### Layer 1 — Static Analysis (Compiler + Previews)
+
+Swift's type system is your first line of defence. Strong typing, `Sendable` checking, and exhaustive `switch` statements catch entire classes of bugs at compile time. SwiftUI `#Preview` blocks verify that views render without crashing and serve as living documentation for consumers.
+
+Previews are *not* asserted today (see [Known Gaps](#known-gaps)).
+
+### Layer 2 — Unit Tests
+
+Isolated tests for individual types: models, services, protocols, error types. These use no persistence, no UI, and no real backends.
+
+**Examples:** `PromptTemplateTests`, `CompressionTests`, `SSEStreamParserTests`, `RetryPolicyTests`
+
+### Layer 3 — Integration Tests
+
+Tests that wire together 2+ real components. The most common pattern is ChatViewModel + MockInferenceBackend + real in-memory SwiftData. These verify that the ViewModel orchestrates persistence, streaming, and state correctly.
+
+**Examples:** `ChatViewModelIntegrationTests`, `ConcurrencyTests`, `CancellationTests`, `StreamingFailureTests`
+
+### Layer 4 — Headless E2E Tests
+
+Tests that use *no mocks at all* (or mock only the network layer). These exercise real pipelines end-to-end without requiring a UI or hardware.
+
+**Examples:** `ContextOverflowE2ETests`, `DownloadValidationE2ETests`, `CloudBackendSSETests`
+
+### Layer 5 — XCUITests (Example App)
+
+UI automation tests that launch the real Example app in a simulator and drive it through user journeys. These are the slowest and most fragile tests, reserved for validating user-visible flows that can't be tested headlessly.
+
+**Examples:** `ChatFlowUITests`, `SessionManagementUITests`, `ModelManagementUITests`
+
+---
+
+## Test Targets
+
+| Target | Layer | Runs in CI | Hardware needed | Framework |
+|--------|-------|-----------|-----------------|-----------|
+| `BaseChatCoreTests` | Unit, Integration | Yes | None | Mixed (XCTest + Swift Testing) |
+| `BaseChatUITests` | Integration | Yes | None | XCTest |
+| `BaseChatBackendsTests` | Unit, E2E | Partial | MLX/Llama need Apple Silicon | Mixed |
+| `BaseChatE2ETests` | E2E | No | Apple Silicon | Swift Testing |
+| `BaseChatDemoUITests` | XCUITest | No | Simulator | XCTest (XCUIApplication) |
+
+### Running tests
+
+```bash
+# CI-safe (no hardware required)
+swift test --filter BaseChatCoreTests
+swift test --filter BaseChatUITests
+swift test --filter BaseChatBackendsTests   # cloud/SSE tests only
+
+# Apple Silicon only
+swift test --filter BaseChatBackendsTests --traits MLX,Llama
+swift test --filter BaseChatE2ETests
+
+# Example app UI tests (requires Xcode + simulator)
+cd Example
+xcodebuild test -project BaseChatDemo.xcodeproj -scheme BaseChatDemo -destination 'platform=iOS Simulator,name=iPhone 16'
+```
+
+### Hardware gating
+
+Tests that need specific hardware skip gracefully rather than failing:
+
+```swift
+override func setUp() async throws {
+    try await super.setUp()
+    try XCTSkipUnless(HardwareRequirements.isAppleSilicon, "Requires Apple Silicon")
+}
+```
+
+Available flags (from `BaseChatTestSupport/HardwareRequirements.swift`):
+
+| Flag | Meaning |
+|------|---------|
+| `isAppleSilicon` | Running on arm64 |
+| `isPhysicalDevice` | Not the iOS Simulator |
+| `hasFoundationModels` | macOS 26+ / iOS 26+ |
+
+---
+
+## Feature Coverage Matrix
+
+This matrix maps every major feature area to its current test coverage and identifies gaps.
+
+### Chat & Messaging
+
+| Feature | Unit | Integration | E2E | XCUITest | Gap? |
+|---------|------|-------------|-----|----------|------|
+| Send message | - | ChatViewModelIntegrationTests | - | ChatFlowUITests | - |
+| Stream tokens | - | StreamingFailureTests | CloudBackendSSETests | - | - |
+| Cancel mid-stream | - | CancellationTests | - | - | No headless E2E |
+| Partial content on error | - | StreamingFailureTests | - | - | - |
+| Empty stream cleanup | - | StreamingFailureTests | - | - | - |
+| Edit user message | - | - | - | - | **No tests** |
+| Regenerate response | - | ConcurrencyTests | - | - | - |
+| Pin messages | - | PinMessageTests | - | - | - |
+| Copy message | - | - | - | - | **No tests** (UI-only) |
+| Markdown rendering | - | AssistantMarkdownRenderingTests | - | - | - |
+| Loop detection | - | ChatViewModelLoopDetectionTests | - | - | No E2E for detect-and-stop |
+| Token batching | - | StreamingTokenBatcherTests | - | - | - |
+| Unicode preservation | - | StreamingFailureTests | - | - | - |
+| Large token count (1000) | - | StreamingFailureTests | - | - | - |
+
+### Sessions
+
+| Feature | Unit | Integration | E2E | XCUITest | Gap? |
+|---------|------|-------------|-----|----------|------|
+| Create session | - | SessionManagerViewModelTests | - | SessionManagementUITests | - |
+| Switch session | - | ConcurrencyTests | - | SessionManagementUITests | - |
+| Delete session | - | SessionManagerViewModelTests | - | SessionManagementUITests | - |
+| Auto-rename | - | SessionAutoRenameTests | - | - | - |
+| Switch mid-generation | - | ConcurrencyTests | - | - | No headless E2E |
+| Per-session overrides | ChatSessionTests | - | - | - | No integration test |
+| Session isolation | - | PersistenceIntegrationTests | - | - | - |
+
+### Context & Compression
+
+| Feature | Unit | Integration | E2E | XCUITest | Gap? |
+|---------|------|-------------|-----|----------|------|
+| Token estimation | ContextWindowManagerTests | - | - | - | - |
+| Message trimming | ContextWindowManagerTests | - | ContextOverflowE2ETests | - | - |
+| Budget calculation | ContextWindowManagerTests | - | ContextOverflowE2ETests | - | - |
+| Extractive compression | CompressionTests | - | - | - | No E2E |
+| Anchored compression | CompressionTests | - | - | - | No E2E |
+| Auto-compress at threshold | CompressionTests | CompressionIntegrationTests | - | - | **No E2E for full flow** |
+| Pinned messages survive compression | CompressionTests | - | - | - | - |
+| Compression stats display | - | CompressionStatsDisplayTests | - | - | - |
+
+### Model Management
+
+| Feature | Unit | Integration | E2E | XCUITest | Gap? |
+|---------|------|-------------|-----|----------|------|
+| Discover local models | ModelStorageServiceTests | - | - | - | - |
+| Download from HuggingFace | DownloadManagerTests | BackgroundDownloadIntegrationTests | DownloadValidationE2ETests | - | - |
+| GGUF validation | - | - | DownloadValidationE2ETests | - | - |
+| MLX validation | - | - | DownloadValidationE2ETests | - | - |
+| Delete models | ModelStorageServiceTests | - | - | - | - |
+| Storage accounting | - | - | - | ModelManagementUITests | No headless test |
+| GGUF metadata reading | GGUFMetadataReaderTests | - | - | - | - |
+| Template detection | PromptTemplateDetectorTests | - | - | - | - |
+| Device-aware recommendations | DeviceCapabilityServiceTests | - | - | - | - |
+
+### Remote Backends & Cloud APIs
+
+| Feature | Unit | Integration | E2E | XCUITest | Gap? |
+|---------|------|-------------|-----|----------|------|
+| OpenAI SSE streaming | - | - | CloudBackendSSETests | - | - |
+| Claude SSE streaming | - | - | CloudBackendSSETests | - | - |
+| KoboldCpp SSE | - | - | KoboldCppSSETests | - | - |
+| Auth errors (401) | - | - | CloudBackendSSETests | - | - |
+| Rate limiting (429) | - | - | CloudBackendSSETests | - | - |
+| Malformed SSE handling | - | - | CloudBackendSSETests | - | - |
+| Connection drop mid-stream | - | - | CloudBackendSSETests | - | - |
+| Server discovery | - | ServerDiscoveryViewModelTests | - | - | **No E2E** |
+| API endpoint config | APIEndpointTests | - | - | CloudAPIUITests | - |
+| Keychain storage | KeychainServiceTests | - | - | - | - |
+| Certificate pinning | - | PinnedSessionDelegateTests | - | - | - |
+| Retry with backoff | RetryPolicyTests | - | - | - | **No integration test** |
+
+### Generation & Prompt Assembly
+
+| Feature | Unit | Integration | E2E | XCUITest | Gap? |
+|---------|------|-------------|-----|----------|------|
+| Prompt template formatting | PromptTemplateTests | - | - | - | - |
+| Prompt slot assembly | PromptAssemblerTests | - | ContextOverflowE2ETests | - | - |
+| Sampler presets | SamplerPresetTests | - | - | - | No integration test |
+| Macro expansion | MacroExpanderTests | ChatViewModelMacroExpansionTests | - | - | - |
+| Generation settings | GenerationConfigTests | GenerationViewModelTests | - | SettingsUITests | - |
+| Backend capabilities | BackendCapabilitiesTests | - | - | - | - |
+| Backend contract | BackendContractTests | - | - | - | - |
+
+### System & Lifecycle
+
+| Feature | Unit | Integration | E2E | XCUITest | Gap? |
+|---------|------|-------------|-----|----------|------|
+| Memory pressure handling | MemoryPressureHandlerTests | - | - | - | **No E2E** |
+| Chat export | ChatExportServiceTests | - | - | - | - |
+| Concurrent access safety | - | ConcurrencyTests, MemoryAndConcurrencyTests | - | - | - |
+| Rapid sends | - | ConcurrencyTests | - | - | - |
+| Model load/unload mid-gen | - | CancellationTests | - | - | - |
+
+---
+
+## Async Testing Patterns
+
+AI applications are inherently asynchronous: tokens stream one at a time, generation can be cancelled, sessions can switch mid-stream, and network connections can drop. Testing these flows requires specific patterns.
+
+### Pattern 1: Await the Full Operation
+
+The simplest pattern. Call an async method and assert the result:
+
+```swift
+func test_sendMessage_persistsToDatabase() async {
+    vm.inputText = "Hello"
+    await vm.sendMessage()  // Blocks until generation completes
+
+    XCTAssertEqual(vm.messages.count, 2)  // user + assistant
+}
+```
+
+**When to use:** Testing the happy path where you don't need to interact mid-stream.
+
+**Used in:** `ChatViewModelIntegrationTests`, `StreamingFailureTests`
+
+### Pattern 2: Fire-and-Poll for Mid-Stream Interaction
+
+When you need to act *during* generation (cancel, switch session, unload model), launch generation in a detached `Task` and poll for the right moment:
+
+```swift
+func test_stopGeneration_midStream() async throws {
+    vm.inputText = "Hello"
+    let sendTask = Task { await vm.sendMessage() }
+
+    // Poll until at least one token has arrived
+    for _ in 0..<100 {
+        if vm.messages.count >= 2, !(vm.messages.last?.content ?? "").isEmpty { break }
+        try await Task.sleep(for: .milliseconds(20))
+    }
+
+    vm.stopGeneration()
+    await sendTask.value  // Wait for cleanup
+
+    XCTAssertFalse(vm.isGenerating)
+    XCTAssertFalse(vm.messages[1].content.isEmpty, "Partial content preserved")
+}
+```
+
+**When to use:** Cancellation, session switching mid-generation, model unloading mid-generation.
+
+**Why polling instead of a callback?** The ViewModel doesn't expose "first token arrived" as an event. Polling with tight sleeps (20ms) is pragmatic and fast. The total timeout (100 * 20ms = 2s) is generous enough for CI.
+
+**Used in:** `CancellationTests`, `ConcurrencyTests`
+
+### Pattern 3: SlowMockBackend for Timing Control
+
+`SlowMockBackend` yields tokens with a configurable delay, giving tests control over how long generation takes:
+
+```swift
+slowBackend.tokensToYield = (0..<20).map { "t\($0) " }
+slowBackend.delayPerToken = .milliseconds(50)  // 20 tokens * 50ms = ~1 second total
+```
+
+This makes mid-stream interactions predictable. A 150ms sleep will reliably land after 3 tokens have been emitted.
+
+**When to use:** Any test that needs to interact during generation.
+
+### Pattern 4: MidStreamErrorBackend for Error Injection
+
+`MidStreamErrorBackend` yields N tokens then throws, simulating a backend that fails partway through:
+
+```swift
+let backend = MidStreamErrorBackend(
+    tokensBeforeError: ["Hello", " world"],
+    errorToThrow: InferenceError.inferenceFailure("Connection lost")
+)
+```
+
+**When to use:** Testing error recovery, partial content preservation, error message display.
+
+**Used in:** `StreamingFailureTests`
+
+### Pattern 5: MockURLProtocol for Network Simulation
+
+For cloud backends, `MockURLProtocol` intercepts HTTP requests and returns canned responses, including chunked SSE streams:
+
+```swift
+let chunks: [Data] = [
+    "data: {\"type\":\"content_block_delta\",\"delta\":{\"text\":\"Hello\"}}\n\n".data(using: .utf8)!,
+    "data: {\"type\":\"message_stop\"}\n\n".data(using: .utf8)!,
+]
+MockURLProtocol.stub(url: endpoint, response: .sse(chunks: chunks, statusCode: 200))
+```
+
+**When to use:** Testing SSE parsing, auth errors, rate limiting, connection drops — all without a real server.
+
+**Used in:** `CloudBackendSSETests`, `KoboldCppSSETests`
+
+### Pattern 6: Concurrent Task Spawning
+
+For testing race conditions, spawn multiple tasks that compete for shared state:
+
+```swift
+var tasks: [Task<Void, Never>] = []
+for i in 0..<5 {
+    vm.inputText = "Rapid message \(i)"
+    let task = Task { @MainActor in await self.vm.sendMessage() }
+    tasks.append(task)
+}
+for task in tasks { await task.value }
+
+// Assert: no crash, messages non-empty, timestamps monotonic
+```
+
+**When to use:** Rapid sends, concurrent session creation, race condition detection.
+
+**Used in:** `ConcurrencyTests`, `MemoryAndConcurrencyTests`
+
+### Pattern 7: XCTestExpectation for Delegate Callbacks
+
+For APIs that use callbacks rather than async/await (e.g., URLSession delegates):
+
+```swift
+let expectation = XCTestExpectation(description: "delegate called")
+delegate.onComplete = { expectation.fulfill() }
+
+// Trigger the operation
+session.dataTask(with: request).resume()
+
+await fulfillment(of: [expectation], timeout: 2.0)
+```
+
+**When to use:** Only for callback-based APIs. Prefer `async/await` for everything else.
+
+**Used in:** `PinnedSessionDelegateTests`
+
+### Anti-patterns to avoid
+
+| Anti-pattern | Why it's bad | Do this instead |
+|-------------|-------------|-----------------|
+| `Thread.sleep()` | Blocks the thread, can deadlock @MainActor | `Task.sleep(for:)` |
+| Fixed long sleeps (`sleep(2)`) | Slow in CI, still flaky | Poll with short intervals + deadline |
+| `DispatchSemaphore` in async code | Can deadlock with Swift concurrency | Use `async/await` or `AsyncStream` |
+| `XCTestExpectation` for async code | Verbose, timeout-dependent | `await` the async method directly |
+| Mocking `Task.sleep` | Over-engineering | Use `SlowMockBackend` to control timing |
+
+---
+
+## AI-Specific Flow Testing
+
+AI chat applications have unique testing challenges that traditional app testing doesn't address. Here are the patterns specific to LLM-backed chat.
+
+### Streaming Token Flows
+
+Unlike a REST API that returns a complete response, LLM backends stream tokens one at a time. This creates several testable states:
+
+```
+[idle] → [generating: 0 tokens] → [generating: N tokens] → [complete]
+                                        ↓
+                                  [error: partial content]
+                                        ↓
+                                  [cancelled: partial content]
+```
+
+Each transition is tested:
+- `idle → complete`: `ChatViewModelIntegrationTests.test_sendMessage_persistsUserAndAssistantToDatabase`
+- `generating → cancelled`: `CancellationTests.test_stopGeneration_midStream_stopsTokenFlow`
+- `generating → error`: `StreamingFailureTests.test_streamError_midStream_preservesPartialContent`
+- `generating → complete (empty)`: `StreamingFailureTests.test_emptyStream_removesAssistantPlaceholder`
+
+### Multi-Turn Conversation
+
+AI conversations are stateful — each turn builds on the last. Tests must verify:
+
+1. **Message ordering** — user/assistant pairs are interleaved correctly
+2. **Context accumulation** — previous messages are sent to the backend
+3. **Session isolation** — switching sessions doesn't leak messages
+4. **Persistence** — all turns survive app restart (SwiftData)
+
+```swift
+// From ChatViewModelIntegrationTests
+func test_multiTurnConversation_allMessagesPersisted() async {
+    // Turn 1
+    vm.inputText = "First question"
+    await vm.sendMessage()
+    // Turn 2
+    vm.inputText = "Follow-up"
+    await vm.sendMessage()
+    // Turn 3
+    vm.inputText = "One more"
+    await vm.sendMessage()
+
+    XCTAssertEqual(vm.messages.count, 6)  // 3 user + 3 assistant
+    // Verify database has all 6 messages
+}
+```
+
+### Context Window Pressure
+
+LLMs have finite context windows. As conversations grow, older messages must be trimmed or compressed. Testing this requires:
+
+1. **Deterministic token counting** — `CharTokenizer` (1 char = 1 token) makes budgets predictable
+2. **Controlled context sizes** — test with tiny windows (50-512 tokens) to trigger trimming
+3. **Boundary assertions** — verify the newest message is always preserved, even when the budget is exceeded
+
+```swift
+// From ContextOverflowE2ETests — real components, no mocks
+@Test func progressiveTruncation_keepsNewest() async throws {
+    let assembler = PromptAssembler(tokenizer: HeuristicTokenizer())
+    // ... fill context past budget ...
+    // Assert: most recent message always survives
+}
+```
+
+### Cancellation Semantics
+
+When a user taps "Stop", the contract is:
+1. Token streaming stops (no new tokens appended)
+2. Partial content is preserved (not discarded)
+3. `isGenerating` becomes `false`
+4. The user can send a new message immediately
+
+Each guarantee has a dedicated test in `CancellationTests`.
+
+### Loop Detection
+
+LLMs sometimes get stuck repeating the same phrase. `RepetitionDetector` catches this and auto-stops generation. Tests verify:
+- Detection threshold (how many repeats trigger it)
+- That generation stops when a loop is detected
+- That the partial (pre-loop) content is preserved
+
+### Error Recovery
+
+AI backends fail in ways traditional APIs don't:
+- **Mid-stream errors** — the backend crashes after sending some tokens
+- **Empty responses** — the model generates nothing
+- **Malformed SSE** — the cloud API sends bad JSON
+- **Connection drops** — the network dies mid-stream
+
+Each failure mode is tested with purpose-built mock backends (`MidStreamErrorBackend`, `MockURLProtocol`).
+
+### Concurrency Under AI Workloads
+
+Users do unexpected things during generation:
+- Send another message while generating
+- Switch to a different conversation
+- Unload the model
+- Close the app
+
+`ConcurrencyTests` covers all of these with `SlowMockBackend`, verifying no crashes, no data corruption, and correct state cleanup.
+
+---
+
+## Mock Infrastructure
+
+All shared test infrastructure lives in `Sources/BaseChatTestSupport/`:
+
+### Mock Backends
+
+| Mock | Purpose | Key Feature |
+|------|---------|-------------|
+| `MockInferenceBackend` | General-purpose fast backend | Configurable tokens, call tracking, argument capture |
+| `SlowMockBackend` | Timing-controlled backend | Per-token delay, cancellation support via `Task.isCancelled` |
+| `MidStreamErrorBackend` | Error injection | Yields N tokens then throws a configurable error |
+| `TokenTrackingMockBackend` | Token usage reporting | Tracks prompt/completion token counts per call |
+| `MockTokenizerVendorBackend` | Tokenizer provision | Backend that also provides a tokenizer with stubbed counts |
+
+### Service Mocks
+
+| Mock | Purpose |
+|------|---------|
+| `MockHuggingFaceService` | Stubs HF search results, tracks call counts |
+| `MockServerDiscoveryService` | Emits canned server lists, manual emit for incremental testing |
+| `MockPersistenceProvider` | In-memory session/message storage with configurable errors |
+| `MockURLProtocol` | HTTP interception with immediate, SSE (chunked), and error modes |
+
+### Utilities
+
+| Utility | Purpose |
+|---------|---------|
+| `CharTokenizer` | Deterministic tokenizer: 1 character = 1 token |
+| `HardwareRequirements` | Static flags for `XCTSkipUnless` hardware gating |
+| `TestHelpers.makeInMemoryContainer()` | Creates ephemeral SwiftData ModelContainer |
+
+### Design principles for mocks
+
+1. **Protocol witnesses, not subclasses.** Every mock implements a protocol (`InferenceBackend`, `ChatPersistenceProvider`, etc.). This is idiomatic Swift and avoids fragile base class problems.
+
+2. **Thread-safe.** Mocks that might be accessed from multiple isolation domains use `NSLock` or `@MainActor`. `SlowMockBackend` uses `NSLock` for its token state; `MockHuggingFaceService` uses `OSAllocatedUnfairLock`.
+
+3. **Call tracking.** Mocks expose `loadModelCallCount`, `generateCallCount`, etc. for verifying interactions.
+
+4. **Configurable failure.** Every mock can be told to throw on specific operations, enabling negative-path testing without complex setup.
+
+---
+
+## Writing New Tests
+
+### Choosing the right layer
+
+Ask these questions in order:
+
+1. **Can this be tested with just the type and its direct dependencies?** → Unit test in `BaseChatCoreTests`
+2. **Does it need ChatViewModel + SwiftData + a mock backend?** → Integration test in `BaseChatUITests`
+3. **Does it need real (non-mock) components wired together?** → E2E test in `BaseChatE2ETests`
+4. **Does it need the real UI in a simulator?** → XCUITest in `BaseChatDemoUITests`
+
+### Test structure template
+
+```swift
+import XCTest
+import SwiftData
+@testable import BaseChatUI
+import BaseChatCore
+import BaseChatTestSupport
+
+@MainActor
+final class MyFeatureTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+    private var vm: ChatViewModel!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        let schema = Schema(BaseChatSchema.allModelTypes)
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        container = try ModelContainer(for: schema, configurations: [config])
+        context = container.mainContext
+
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["Hello", " world"]
+
+        let service = InferenceService(backend: backend, name: "Mock")
+        vm = ChatViewModel(inferenceService: service)
+        vm.configure(modelContext: context)
+    }
+
+    override func tearDown() async throws {
+        vm = nil
+        context = nil
+        container = nil
+        try await super.tearDown()
+    }
+
+    func test_myFeature_doesExpectedThing() async {
+        // Arrange
+        let session = // create and activate session
+
+        // Act
+        vm.inputText = "Test input"
+        await vm.sendMessage()
+
+        // Assert
+        XCTAssertEqual(vm.messages.count, 2)
+    }
+}
+```
+
+### Sabotage check
+
+After your test passes, temporarily break the code path being tested and confirm the test fails. This catches tests that pass for the wrong reason (e.g., assertions against the wrong variable). Remove the sabotage before committing.
+
+### Naming conventions
+
+- **Test files:** `{Feature}Tests.swift` for unit, `{Feature}IntegrationTests.swift` for integration, `{Feature}E2ETests.swift` for E2E
+- **Test methods:** `test_{method}_{scenario}_{expected}` — e.g., `test_stopGeneration_midStream_preservesPartialContent`
+- **Placement:** Match the target that owns the code being tested. ViewModel tests go in `BaseChatUITests`, service tests in `BaseChatCoreTests`, backend tests in `BaseChatBackendsTests`.
+
+### Framework choice
+
+- **Existing files:** Match whatever the file already uses (XCTest or Swift Testing)
+- **New files:** Use XCTest (`XCTestCase`) for new test suites — this is the project convention
+- **Swift Testing** (`@Suite`, `@Test`, `#expect`): Used in some newer E2E tests. Fine for pure logic tests, but XCTest is better for tests needing `setUp`/`tearDown` lifecycle management
+
+---
+
+## Known Gaps
+
+These are features or flows that lack adequate test coverage. They represent the highest-value areas for new test contributions.
+
+### E2E Flows (no headless E2E exists)
+
+| Flow | What to test | Suggested approach |
+|------|-------------|-------------------|
+| **Full chat turn** | Send → stream → persist → reload | Wire real ViewModel + MockBackend + in-memory SwiftData. Verify messages survive `switchToSession` round-trip. |
+| **Compression under pressure** | Fill context → auto-compress → continue generating | Use `CharTokenizer` with a tiny context window (100 tokens). Send enough messages to trigger compression. Verify generation continues with compressed context. |
+| **Server discovery → generate** | Discover server → configure endpoint → stream tokens | Use `MockServerDiscoveryService` + `MockURLProtocol`. Verify the full path from discovery to token streaming. |
+| **Download → validate → load → generate** | Download model → validate files → load backend → generate tokens | End-to-end with real filesystem (temp dir). Currently download validation and generation are tested separately. |
+| **Loop detect → auto-stop** | Generate repetitive tokens → detector fires → generation stops | Use `MockInferenceBackend` with repeating tokens. Verify `RepetitionDetector` triggers and partial content is preserved. |
+| **Memory pressure → unload** | Memory warning fires → model unloaded → user informed | Requires simulating memory pressure dispatch source. |
+
+### Integration Tests (missing or thin)
+
+| Area | What to test |
+|------|-------------|
+| **Per-session generation overrides** | Session with custom temperature/topP → verify backend receives correct config |
+| **Retry policy under real network errors** | RetryPolicy + real URLSession error → verify backoff timing and retry count |
+| **Sampler preset round-trip** | Save preset → reload → apply to generation config → verify values match |
+| **Export with real conversation data** | Generate a multi-turn conversation → export as markdown → verify format |
+
+### UI Tests (structural gaps)
+
+| Area | What to test |
+|------|-------------|
+| **Edit message flow** | Tap edit → modify text → save → verify message updated |
+| **Compression mode picker** | Switch modes in settings → verify compression behavior changes |
+| **Prompt inspector** | Open inspector → verify slot breakdown matches assembled prompt |
+| **Error banner display** | Trigger backend error → verify banner appears and dismisses |
+
+### Preview Assertions
+
+The 26 SwiftUI previews compile but are not snapshot-tested. Adding snapshot tests (e.g., with `swift-snapshot-testing`) would catch visual regressions without XCUITest overhead.
+
+### Timing Robustness
+
+16 tests use `Task.sleep` for timing. While functional, these can be flaky under CI load. Consider migrating to event-driven patterns where the ViewModel exposes observable state changes that tests can await directly, rather than polling.

--- a/TESTING.md
+++ b/TESTING.md
@@ -19,7 +19,7 @@ This document describes BaseChatKit's testing philosophy, architecture, and patt
 
 ## Testing Pyramid
 
-BaseChatKit uses a four-layer testing pyramid. Each layer catches different classes of bugs at different costs:
+BaseChatKit uses a five-layer testing pyramid. Each layer catches different classes of bugs at different costs:
 
 ```
          ╱  XCUITests (Example app)         ╲   Few, slow, high confidence
@@ -51,7 +51,7 @@ Tests that wire together 2+ real components. The most common pattern is ChatView
 
 ### Layer 4 — Headless E2E Tests
 
-Tests that use *no mocks at all* (or mock only the network layer). These exercise real pipelines end-to-end without requiring a UI or hardware.
+Tests that use real components wired together — real ViewModels, real SwiftData, real compression pipelines — with only the inference backend mocked (to avoid hardware dependencies). These exercise real pipelines end-to-end without requiring a UI or hardware.
 
 **Examples:** `ContextOverflowE2ETests`, `DownloadValidationE2ETests`, `CloudBackendSSETests`
 
@@ -70,7 +70,7 @@ UI automation tests that launch the real Example app in a simulator and drive it
 | `BaseChatCoreTests` | Unit, Integration | Yes | None | Mixed (XCTest + Swift Testing) |
 | `BaseChatUITests` | Integration | Yes | None | XCTest |
 | `BaseChatBackendsTests` | Unit, E2E | Partial | MLX/Llama need Apple Silicon | Mixed |
-| `BaseChatE2ETests` | E2E | No | Apple Silicon | Swift Testing |
+| `BaseChatE2ETests` | E2E | Yes | None (mock backends) | Swift Testing |
 | `BaseChatDemoUITests` | XCUITest | No | Simulator | XCTest (XCUIApplication) |
 
 ### Running tests

--- a/Tests/BaseChatCoreTests/SamplerPresetRoundTripTests.swift
+++ b/Tests/BaseChatCoreTests/SamplerPresetRoundTripTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+import SwiftData
+@testable import BaseChatCore
+import BaseChatTestSupport
+
+final class SamplerPresetRoundTripTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+
+    override func setUpWithError() throws {
+        container = try makeInMemoryContainer()
+        context = ModelContext(container)
+    }
+
+    override func tearDown() {
+        context = nil
+        container = nil
+    }
+
+    // MARK: - Save and fetch round-trip
+
+    func test_insertAndFetch_allValuesMatch() throws {
+        let preset = SamplerPreset(
+            name: "Precise",
+            temperature: 0.2,
+            topP: 0.85,
+            repeatPenalty: 1.05
+        )
+        let savedID = preset.id
+
+        context.insert(preset)
+        try context.save()
+
+        var descriptor = FetchDescriptor<SamplerPreset>(
+            predicate: #Predicate { $0.id == savedID }
+        )
+        descriptor.fetchLimit = 1
+        let results = try context.fetch(descriptor)
+
+        XCTAssertEqual(results.count, 1)
+        let fetched = try XCTUnwrap(results.first)
+        XCTAssertEqual(fetched.id, savedID)
+        XCTAssertEqual(fetched.name, "Precise")
+        XCTAssertEqual(fetched.temperature, 0.2, accuracy: 0.001)
+        XCTAssertEqual(fetched.topP, 0.85, accuracy: 0.001)
+        XCTAssertEqual(fetched.repeatPenalty, 1.05, accuracy: 0.001)
+        XCTAssertNotNil(fetched.createdAt)
+    }
+
+    // MARK: - Update round-trip
+
+    func test_updateAndFetch_persistsNewValue() throws {
+        let preset = SamplerPreset(
+            name: "Draft",
+            temperature: 0.9,
+            topP: 0.95,
+            repeatPenalty: 1.2
+        )
+        let savedID = preset.id
+
+        context.insert(preset)
+        try context.save()
+
+        // Mutate and re-save
+        preset.temperature = 1.4
+        preset.name = "Creative"
+        try context.save()
+
+        var descriptor = FetchDescriptor<SamplerPreset>(
+            predicate: #Predicate { $0.id == savedID }
+        )
+        descriptor.fetchLimit = 1
+        let results = try context.fetch(descriptor)
+
+        let fetched = try XCTUnwrap(results.first)
+        XCTAssertEqual(fetched.name, "Creative")
+        XCTAssertEqual(fetched.temperature, 1.4, accuracy: 0.001)
+        // Unchanged fields stay intact
+        XCTAssertEqual(fetched.topP, 0.95, accuracy: 0.001)
+        XCTAssertEqual(fetched.repeatPenalty, 1.2, accuracy: 0.001)
+    }
+
+    // MARK: - Multiple presets coexist
+
+    func test_multiplePresets_fetchedIndependently() throws {
+        let presetA = SamplerPreset(name: "A", temperature: 0.1, topP: 0.5, repeatPenalty: 1.0)
+        let presetB = SamplerPreset(name: "B", temperature: 1.8, topP: 0.99, repeatPenalty: 1.5)
+        let presetC = SamplerPreset(name: "C", temperature: 0.7, topP: 0.9, repeatPenalty: 1.1)
+
+        context.insert(presetA)
+        context.insert(presetB)
+        context.insert(presetC)
+        try context.save()
+
+        // Fetch all
+        let all = try context.fetch(FetchDescriptor<SamplerPreset>())
+        XCTAssertEqual(all.count, 3)
+
+        // Fetch each by ID and verify independence
+        let idA = presetA.id
+        let idB = presetB.id
+
+        let fetchedA = try context.fetch(FetchDescriptor<SamplerPreset>(
+            predicate: #Predicate { $0.id == idA }
+        ))
+        XCTAssertEqual(fetchedA.count, 1)
+        XCTAssertEqual(fetchedA.first?.name, "A")
+        XCTAssertEqual(fetchedA.first?.temperature ?? -1, 0.1, accuracy: 0.001)
+
+        let fetchedB = try context.fetch(FetchDescriptor<SamplerPreset>(
+            predicate: #Predicate { $0.id == idB }
+        ))
+        XCTAssertEqual(fetchedB.count, 1)
+        XCTAssertEqual(fetchedB.first?.name, "B")
+        XCTAssertEqual(fetchedB.first?.temperature ?? -1, 1.8, accuracy: 0.001)
+        XCTAssertEqual(fetchedB.first?.repeatPenalty ?? -1, 1.5, accuracy: 0.001)
+    }
+}

--- a/Tests/BaseChatCoreTests/SamplerPresetRoundTripTests.swift
+++ b/Tests/BaseChatCoreTests/SamplerPresetRoundTripTests.swift
@@ -45,7 +45,7 @@ final class SamplerPresetRoundTripTests: XCTestCase {
         XCTAssertEqual(fetched.temperature, 0.2, accuracy: 0.001)
         XCTAssertEqual(fetched.topP, 0.85, accuracy: 0.001)
         XCTAssertEqual(fetched.repeatPenalty, 1.05, accuracy: 0.001)
-        XCTAssertNotNil(fetched.createdAt)
+        XCTAssertLessThanOrEqual(fetched.createdAt, Date())
     }
 
     // MARK: - Update round-trip

--- a/Tests/BaseChatE2ETests/ChatTurnRoundTripE2ETests.swift
+++ b/Tests/BaseChatE2ETests/ChatTurnRoundTripE2ETests.swift
@@ -29,19 +29,20 @@ struct ChatTurnRoundTripE2ETests {
         mock.isModelLoaded = true
         mock.tokensToYield = ["Hello", " from", " mock"]
 
+        let persistence = SwiftDataPersistenceProvider(modelContext: context)
         let service = InferenceService(backend: mock, name: "MockE2E")
         vm = ChatViewModel(inferenceService: service)
-        vm.configure(modelContext: context)
+        vm.configure(persistence: persistence)
 
         sessionManager = SessionManagerViewModel()
-        sessionManager.configure(modelContext: context)
+        sessionManager.configure(persistence: persistence)
     }
 
     // MARK: - Helpers
 
     @discardableResult
-    private func createAndActivateSession(title: String = "Test Chat") -> ChatSessionRecord {
-        let session = try! sessionManager.createSession(title: title)
+    private func createAndActivateSession(title: String = "Test Chat") throws -> ChatSessionRecord {
+        let session = try sessionManager.createSession(title: title)
         sessionManager.activeSession = session
         vm.switchToSession(session)
         return session
@@ -58,8 +59,8 @@ struct ChatTurnRoundTripE2ETests {
     // MARK: - Tests
 
     @Test("Single turn: user + assistant messages appear with correct content")
-    func singleTurnRoundTrip() async {
-        let session = createAndActivateSession()
+    func singleTurnRoundTrip() async throws {
+        let session = try createAndActivateSession()
 
         mock.tokensToYield = ["Good", " morning"]
         vm.inputText = "Hello"
@@ -78,8 +79,8 @@ struct ChatTurnRoundTripE2ETests {
     }
 
     @Test("Multi-turn: all 4 messages present and ordered")
-    func multiTurnRoundTrip() async {
-        let session = createAndActivateSession()
+    func multiTurnRoundTrip() async throws {
+        let session = try createAndActivateSession()
 
         mock.tokensToYield = ["Reply", " one"]
         vm.inputText = "First"
@@ -104,8 +105,8 @@ struct ChatTurnRoundTripE2ETests {
     }
 
     @Test("New session starts empty")
-    func newSessionIsEmpty() async {
-        let sessionA = createAndActivateSession(title: "Session A")
+    func newSessionIsEmpty() async throws {
+        try createAndActivateSession(title: "Session A")
 
         mock.tokensToYield = ["Alpha"]
         vm.inputText = "Question"
@@ -113,22 +114,21 @@ struct ChatTurnRoundTripE2ETests {
         #expect(vm.messages.count == 2)
 
         // Switch to a brand-new session
-        let sessionB = createAndActivateSession(title: "Session B")
-        _ = sessionB
+        try createAndActivateSession(title: "Session B")
 
         #expect(vm.messages.isEmpty, "New session should have no messages")
     }
 
     @Test("Switch back reloads messages from SwiftData")
-    func switchBackReloadsMessages() async {
-        let sessionA = createAndActivateSession(title: "Session A")
+    func switchBackReloadsMessages() async throws {
+        let sessionA = try createAndActivateSession(title: "Session A")
 
         mock.tokensToYield = ["Alpha", " reply"]
         vm.inputText = "Alpha question"
         await vm.sendMessage()
 
         // Switch to session B
-        createAndActivateSession(title: "Session B")
+        try createAndActivateSession(title: "Session B")
         #expect(vm.messages.isEmpty)
 
         // Switch back to session A
@@ -140,8 +140,8 @@ struct ChatTurnRoundTripE2ETests {
     }
 
     @Test("Database persistence: direct ModelContext fetch matches")
-    func databasePersistenceVerification() async {
-        let session = createAndActivateSession()
+    func databasePersistenceVerification() async throws {
+        let session = try createAndActivateSession()
 
         mock.tokensToYield = ["Persisted", " response"]
         vm.inputText = "Persist me"

--- a/Tests/BaseChatE2ETests/ChatTurnRoundTripE2ETests.swift
+++ b/Tests/BaseChatE2ETests/ChatTurnRoundTripE2ETests.swift
@@ -1,0 +1,176 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import BaseChatUI
+import BaseChatCore
+import BaseChatTestSupport
+
+/// E2E round-trip: send -> stream -> persist -> reload across session switch.
+///
+/// Uses a real in-memory SwiftData store with `MockInferenceBackend` so the
+/// full ChatViewModel pipeline executes without hardware dependencies.
+@Suite("Chat Turn Round-Trip E2E")
+@MainActor
+struct ChatTurnRoundTripE2ETests {
+
+    private let container: ModelContainer
+    private let context: ModelContext
+    private let mock: MockInferenceBackend
+    private let vm: ChatViewModel
+    private let sessionManager: SessionManagerViewModel
+
+    init() throws {
+        let schema = Schema(BaseChatSchema.allModelTypes)
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        container = try ModelContainer(for: schema, configurations: [config])
+        context = container.mainContext
+
+        mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.tokensToYield = ["Hello", " from", " mock"]
+
+        let service = InferenceService(backend: mock, name: "MockE2E")
+        vm = ChatViewModel(inferenceService: service)
+        vm.configure(modelContext: context)
+
+        sessionManager = SessionManagerViewModel()
+        sessionManager.configure(modelContext: context)
+    }
+
+    // MARK: - Helpers
+
+    @discardableResult
+    private func createAndActivateSession(title: String = "Test Chat") -> ChatSessionRecord {
+        let session = try! sessionManager.createSession(title: title)
+        sessionManager.activeSession = session
+        vm.switchToSession(session)
+        return session
+    }
+
+    private func fetchMessages(for sessionID: UUID) -> [ChatMessage] {
+        let descriptor = FetchDescriptor<ChatMessage>(
+            predicate: #Predicate { $0.sessionID == sessionID },
+            sortBy: [SortDescriptor(\.timestamp)]
+        )
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
+    // MARK: - Tests
+
+    @Test("Single turn: user + assistant messages appear with correct content")
+    func singleTurnRoundTrip() async {
+        let session = createAndActivateSession()
+
+        mock.tokensToYield = ["Good", " morning"]
+        vm.inputText = "Hello"
+        await vm.sendMessage()
+
+        #expect(vm.messages.count == 2)
+        #expect(vm.messages[0].role == .user)
+        #expect(vm.messages[0].content == "Hello")
+        #expect(vm.messages[1].role == .assistant)
+        #expect(vm.messages[1].content == "Good morning")
+
+        let dbMessages = fetchMessages(for: session.id)
+        #expect(dbMessages.count == 2)
+        #expect(dbMessages[0].content == "Hello")
+        #expect(dbMessages[1].content == "Good morning")
+    }
+
+    @Test("Multi-turn: all 4 messages present and ordered")
+    func multiTurnRoundTrip() async {
+        let session = createAndActivateSession()
+
+        mock.tokensToYield = ["Reply", " one"]
+        vm.inputText = "First"
+        await vm.sendMessage()
+
+        mock.tokensToYield = ["Reply", " two"]
+        vm.inputText = "Second"
+        await vm.sendMessage()
+
+        #expect(vm.messages.count == 4)
+        #expect(vm.messages[0].content == "First")
+        #expect(vm.messages[1].content == "Reply one")
+        #expect(vm.messages[2].content == "Second")
+        #expect(vm.messages[3].content == "Reply two")
+
+        let dbMessages = fetchMessages(for: session.id)
+        #expect(dbMessages.count == 4)
+        // Verify chronological ordering
+        for i in 1..<dbMessages.count {
+            #expect(dbMessages[i].timestamp >= dbMessages[i - 1].timestamp)
+        }
+    }
+
+    @Test("New session starts empty")
+    func newSessionIsEmpty() async {
+        let sessionA = createAndActivateSession(title: "Session A")
+
+        mock.tokensToYield = ["Alpha"]
+        vm.inputText = "Question"
+        await vm.sendMessage()
+        #expect(vm.messages.count == 2)
+
+        // Switch to a brand-new session
+        let sessionB = createAndActivateSession(title: "Session B")
+        _ = sessionB
+
+        #expect(vm.messages.isEmpty, "New session should have no messages")
+    }
+
+    @Test("Switch back reloads messages from SwiftData")
+    func switchBackReloadsMessages() async {
+        let sessionA = createAndActivateSession(title: "Session A")
+
+        mock.tokensToYield = ["Alpha", " reply"]
+        vm.inputText = "Alpha question"
+        await vm.sendMessage()
+
+        // Switch to session B
+        createAndActivateSession(title: "Session B")
+        #expect(vm.messages.isEmpty)
+
+        // Switch back to session A
+        vm.switchToSession(sessionA)
+
+        #expect(vm.messages.count == 2, "Session A messages should reload")
+        #expect(vm.messages[0].content == "Alpha question")
+        #expect(vm.messages[1].content == "Alpha reply")
+    }
+
+    @Test("Database persistence: direct ModelContext fetch matches")
+    func databasePersistenceVerification() async {
+        let session = createAndActivateSession()
+
+        mock.tokensToYield = ["Persisted", " response"]
+        vm.inputText = "Persist me"
+        await vm.sendMessage()
+
+        mock.tokensToYield = ["Second", " response"]
+        vm.inputText = "And me"
+        await vm.sendMessage()
+
+        // Fetch directly from the ModelContext, bypassing the view model
+        let dbMessages = fetchMessages(for: session.id)
+        #expect(dbMessages.count == 4)
+
+        #expect(dbMessages[0].role == .user)
+        #expect(dbMessages[0].content == "Persist me")
+        #expect(dbMessages[0].sessionID == session.id)
+
+        #expect(dbMessages[1].role == .assistant)
+        #expect(dbMessages[1].content == "Persisted response")
+
+        #expect(dbMessages[2].role == .user)
+        #expect(dbMessages[2].content == "And me")
+
+        #expect(dbMessages[3].role == .assistant)
+        #expect(dbMessages[3].content == "Second response")
+
+        // Every message belongs to the correct session
+        for msg in dbMessages {
+            #expect(msg.sessionID == session.id)
+        }
+    }
+}

--- a/Tests/BaseChatE2ETests/LoopDetectionE2ETests.swift
+++ b/Tests/BaseChatE2ETests/LoopDetectionE2ETests.swift
@@ -1,0 +1,130 @@
+import Testing
+import SwiftData
+@testable import BaseChatUI
+import BaseChatCore
+import BaseChatTestSupport
+
+/// E2E test for loop detection → auto-stop.
+///
+/// Feeds repeating tokens through a real ChatViewModel pipeline and verifies
+/// that RepetitionDetector fires, stops generation early, and preserves
+/// partial content.
+@Suite("Loop Detection E2E")
+@MainActor
+struct LoopDetectionE2ETests {
+
+    private let container: ModelContainer
+    private let context: ModelContext
+
+    init() throws {
+        container = try makeInMemoryContainer()
+        context = container.mainContext
+    }
+
+    // MARK: - Helpers
+
+    private func makeVM(backend: MockInferenceBackend) -> ChatViewModel {
+        backend.isModelLoaded = true
+        let service = InferenceService(backend: backend, name: "Mock")
+        let persistence = SwiftDataPersistenceProvider(modelContext: context)
+        let vm = ChatViewModel(inferenceService: service)
+        vm.configure(persistence: persistence)
+
+        let sessionManager = SessionManagerViewModel()
+        sessionManager.configure(persistence: persistence)
+        let session = try! sessionManager.createSession(title: "Test")
+        sessionManager.activeSession = session
+        vm.switchToSession(session)
+
+        return vm
+    }
+
+    // MARK: - Loop detection stops generation early
+
+    @Test func repetitiveTokens_detectedAndStopped() async {
+        let mock = MockInferenceBackend()
+        let repeatedChunk = "The world ended now. "
+        let totalChunks = 200
+        mock.tokensToYield = Array(repeating: repeatedChunk, count: totalChunks)
+        let vm = makeVM(backend: mock)
+
+        vm.inputText = "Hello"
+        await vm.sendMessage()
+
+        // Generation should have completed (not stuck).
+        #expect(!vm.isGenerating)
+
+        // Loop detector should have fired — error message mentions repetition.
+        #expect(vm.errorMessage != nil, "Loop detection should set an error message")
+        #expect(
+            vm.errorMessage?.contains("repeating") == true,
+            "Error should mention repetition, got: \(vm.errorMessage ?? "nil")"
+        )
+
+        // Assistant message should exist with partial content.
+        let assistant = vm.messages.first(where: { $0.role == .assistant })
+        #expect(assistant != nil, "Partial assistant message should be preserved")
+        #expect(
+            !assistant!.content.isEmpty,
+            "Assistant message should have non-empty partial content"
+        )
+
+        // Fewer tokens than the full 200 chunks should have been accumulated.
+        let fullLength = repeatedChunk.count * totalChunks
+        #expect(
+            assistant!.content.count < fullLength,
+            "Content length \(assistant!.content.count) should be less than full \(fullLength)"
+        )
+    }
+
+    // MARK: - Loop detection disabled yields all tokens
+
+    @Test func repetitiveTokens_allYielded_whenDetectionDisabled() async {
+        let mock = MockInferenceBackend()
+        let repeatedChunk = "The world ended now. "
+        let totalChunks = 200
+        mock.tokensToYield = Array(repeating: repeatedChunk, count: totalChunks)
+        let vm = makeVM(backend: mock)
+        vm.loopDetectionEnabled = false
+
+        vm.inputText = "Hello"
+        await vm.sendMessage()
+
+        #expect(!vm.isGenerating)
+
+        let assistant = vm.messages.first(where: { $0.role == .assistant })
+        #expect(assistant != nil)
+
+        let expectedFull = String(repeating: repeatedChunk, count: totalChunks)
+        #expect(
+            assistant!.content == expectedFull,
+            "All tokens should be accumulated when loop detection is off"
+        )
+        #expect(vm.errorMessage == nil, "No error should be set when loop detection is disabled")
+    }
+
+    // MARK: - Partial content persists across session reload
+
+    @Test func loopStop_partialContent_survivesSessionReload() async {
+        let mock = MockInferenceBackend()
+        let repeatedChunk = "The world ended now. "
+        mock.tokensToYield = Array(repeating: repeatedChunk, count: 200)
+        let vm = makeVM(backend: mock)
+        let session = vm.activeSession!
+
+        vm.inputText = "Hello"
+        await vm.sendMessage()
+
+        let partialContent = vm.messages.first(where: { $0.role == .assistant })!.content
+
+        // Reload the session to verify persistence round-trip.
+        vm.switchToSession(session)
+
+        let reloaded = vm.messages.first(where: { $0.role == .assistant })
+        #expect(reloaded != nil, "Assistant message should survive session reload")
+        #expect(
+            reloaded!.content == partialContent,
+            "Reloaded content should match partial content from loop stop"
+        )
+    }
+}

--- a/Tests/BaseChatE2ETests/LoopDetectionE2ETests.swift
+++ b/Tests/BaseChatE2ETests/LoopDetectionE2ETests.swift
@@ -23,7 +23,7 @@ struct LoopDetectionE2ETests {
 
     // MARK: - Helpers
 
-    private func makeVM(backend: MockInferenceBackend) -> ChatViewModel {
+    private func makeVM(backend: MockInferenceBackend) throws -> ChatViewModel {
         backend.isModelLoaded = true
         let service = InferenceService(backend: backend, name: "Mock")
         let persistence = SwiftDataPersistenceProvider(modelContext: context)
@@ -32,7 +32,7 @@ struct LoopDetectionE2ETests {
 
         let sessionManager = SessionManagerViewModel()
         sessionManager.configure(persistence: persistence)
-        let session = try! sessionManager.createSession(title: "Test")
+        let session = try sessionManager.createSession(title: "Test")
         sessionManager.activeSession = session
         vm.switchToSession(session)
 
@@ -41,12 +41,12 @@ struct LoopDetectionE2ETests {
 
     // MARK: - Loop detection stops generation early
 
-    @Test func repetitiveTokens_detectedAndStopped() async {
+    @Test func repetitiveTokens_detectedAndStopped() async throws {
         let mock = MockInferenceBackend()
         let repeatedChunk = "The world ended now. "
         let totalChunks = 200
         mock.tokensToYield = Array(repeating: repeatedChunk, count: totalChunks)
-        let vm = makeVM(backend: mock)
+        let vm = try makeVM(backend: mock)
 
         vm.inputText = "Hello"
         await vm.sendMessage()
@@ -62,29 +62,31 @@ struct LoopDetectionE2ETests {
         )
 
         // Assistant message should exist with partial content.
-        let assistant = vm.messages.first(where: { $0.role == .assistant })
-        #expect(assistant != nil, "Partial assistant message should be preserved")
+        let assistant = try #require(
+            vm.messages.first(where: { $0.role == .assistant }),
+            "Partial assistant message should be preserved"
+        )
         #expect(
-            !assistant!.content.isEmpty,
+            !assistant.content.isEmpty,
             "Assistant message should have non-empty partial content"
         )
 
         // Fewer tokens than the full 200 chunks should have been accumulated.
         let fullLength = repeatedChunk.count * totalChunks
         #expect(
-            assistant!.content.count < fullLength,
-            "Content length \(assistant!.content.count) should be less than full \(fullLength)"
+            assistant.content.count < fullLength,
+            "Content length \(assistant.content.count) should be less than full \(fullLength)"
         )
     }
 
     // MARK: - Loop detection disabled yields all tokens
 
-    @Test func repetitiveTokens_allYielded_whenDetectionDisabled() async {
+    @Test func repetitiveTokens_allYielded_whenDetectionDisabled() async throws {
         let mock = MockInferenceBackend()
         let repeatedChunk = "The world ended now. "
         let totalChunks = 200
         mock.tokensToYield = Array(repeating: repeatedChunk, count: totalChunks)
-        let vm = makeVM(backend: mock)
+        let vm = try makeVM(backend: mock)
         vm.loopDetectionEnabled = false
 
         vm.inputText = "Hello"
@@ -92,12 +94,11 @@ struct LoopDetectionE2ETests {
 
         #expect(!vm.isGenerating)
 
-        let assistant = vm.messages.first(where: { $0.role == .assistant })
-        #expect(assistant != nil)
+        let assistant = try #require(vm.messages.first(where: { $0.role == .assistant }))
 
         let expectedFull = String(repeating: repeatedChunk, count: totalChunks)
         #expect(
-            assistant!.content == expectedFull,
+            assistant.content == expectedFull,
             "All tokens should be accumulated when loop detection is off"
         )
         #expect(vm.errorMessage == nil, "No error should be set when loop detection is disabled")
@@ -105,25 +106,28 @@ struct LoopDetectionE2ETests {
 
     // MARK: - Partial content persists across session reload
 
-    @Test func loopStop_partialContent_survivesSessionReload() async {
+    @Test func loopStop_partialContent_survivesSessionReload() async throws {
         let mock = MockInferenceBackend()
         let repeatedChunk = "The world ended now. "
         mock.tokensToYield = Array(repeating: repeatedChunk, count: 200)
-        let vm = makeVM(backend: mock)
-        let session = vm.activeSession!
+        let vm = try makeVM(backend: mock)
+        let session = try #require(vm.activeSession)
 
         vm.inputText = "Hello"
         await vm.sendMessage()
 
-        let partialContent = vm.messages.first(where: { $0.role == .assistant })!.content
+        let assistant = try #require(vm.messages.first(where: { $0.role == .assistant }))
+        let partialContent = assistant.content
 
         // Reload the session to verify persistence round-trip.
         vm.switchToSession(session)
 
-        let reloaded = vm.messages.first(where: { $0.role == .assistant })
-        #expect(reloaded != nil, "Assistant message should survive session reload")
+        let reloaded = try #require(
+            vm.messages.first(where: { $0.role == .assistant }),
+            "Assistant message should survive session reload"
+        )
         #expect(
-            reloaded!.content == partialContent,
+            reloaded.content == partialContent,
             "Reloaded content should match partial content from loop stop"
         )
     }

--- a/Tests/BaseChatUITests/ChatExportIntegrationTests.swift
+++ b/Tests/BaseChatUITests/ChatExportIntegrationTests.swift
@@ -1,0 +1,199 @@
+import XCTest
+import SwiftData
+@testable import BaseChatCore
+@testable import BaseChatUI
+import BaseChatTestSupport
+
+/// Integration test: generates real conversation turns via ChatViewModel,
+/// then exports through ChatExportService and verifies the output format.
+@MainActor
+final class ChatExportIntegrationTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+    private var sessionManager: SessionManagerViewModel!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        let schema = Schema(BaseChatSchema.allModelTypes)
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        container = try! ModelContainer(for: schema, configurations: [config])
+        context = container.mainContext
+        sessionManager = SessionManagerViewModel()
+        sessionManager.configure(modelContext: context)
+    }
+
+    override func tearDown() async throws {
+        sessionManager = nil
+        context = nil
+        container = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeMockBackend(tokens: [String]) -> MockInferenceBackend {
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = tokens
+        return backend
+    }
+
+    private func makeViewModel(backend: MockInferenceBackend) -> ChatViewModel {
+        let service = InferenceService(backend: backend, name: "ExportTest")
+        let vm = ChatViewModel(inferenceService: service)
+        vm.configure(modelContext: context)
+        return vm
+    }
+
+    @discardableResult
+    private func createAndActivateSession(
+        vm: ChatViewModel,
+        title: String = "Test Chat"
+    ) -> ChatSessionRecord {
+        let session = try! sessionManager.createSession(title: title)
+        sessionManager.activeSession = session
+        vm.switchToSession(session)
+        return session
+    }
+
+    // MARK: - Multi-turn markdown export
+
+    func test_multiTurnConversation_markdownExport_containsAllTurns() async {
+        let backend = makeMockBackend(tokens: ["Hello", " there!"])
+        let vm = makeViewModel(backend: backend)
+        createAndActivateSession(vm: vm, title: "Story Time")
+
+        // Turn 1
+        vm.inputText = "Hi"
+        await vm.sendMessage()
+
+        // Turn 2
+        backend.tokensToYield = ["Sure,", " here", " you go."]
+        vm.inputText = "Tell me a story"
+        await vm.sendMessage()
+
+        let markdown = ChatExportService.export(
+            messages: vm.messages,
+            sessionTitle: "Story Time",
+            format: .markdown
+        )
+
+        // Title as H1
+        XCTAssertTrue(markdown.hasPrefix("# Story Time"), "Markdown should start with H1 title")
+
+        // Horizontal rule
+        XCTAssertTrue(markdown.contains("---"), "Markdown should contain a horizontal rule")
+
+        // Role labels
+        XCTAssertTrue(markdown.contains("**User:**"), "Markdown should contain bold User label")
+        XCTAssertTrue(markdown.contains("**Assistant:**"), "Markdown should contain bold Assistant label")
+
+        // User messages in order
+        XCTAssertTrue(markdown.contains("Hi"), "First user message should appear")
+        XCTAssertTrue(markdown.contains("Tell me a story"), "Second user message should appear")
+
+        // Assistant messages
+        XCTAssertTrue(markdown.contains("Hello there!"), "First assistant reply should appear")
+        XCTAssertTrue(markdown.contains("Sure, here you go."), "Second assistant reply should appear")
+
+        // Verify ordering: first user turn appears before second
+        let hiRange = markdown.range(of: "\nHi\n")!
+        let storyRange = markdown.range(of: "Tell me a story")!
+        XCTAssertTrue(hiRange.lowerBound < storyRange.lowerBound,
+                      "First user message should precede the second")
+    }
+
+    // MARK: - Multi-turn plaintext export
+
+    func test_multiTurnConversation_plaintextExport_containsAllTurns() async {
+        let backend = makeMockBackend(tokens: ["I'm", " fine."])
+        let vm = makeViewModel(backend: backend)
+        createAndActivateSession(vm: vm, title: "Casual Chat")
+
+        // Turn 1
+        vm.inputText = "How are you?"
+        await vm.sendMessage()
+
+        // Turn 2
+        backend.tokensToYield = ["Goodbye!"]
+        vm.inputText = "See you later"
+        await vm.sendMessage()
+
+        let plaintext = ChatExportService.export(
+            messages: vm.messages,
+            sessionTitle: "Casual Chat",
+            format: .plainText
+        )
+
+        // Title line
+        XCTAssertTrue(plaintext.contains("Chat: Casual Chat"), "Plaintext should include session title")
+
+        // Role-prefixed content
+        XCTAssertTrue(plaintext.contains("User: How are you?"), "First user message with role prefix")
+        XCTAssertTrue(plaintext.contains("Assistant: I'm fine."), "First assistant reply with role prefix")
+        XCTAssertTrue(plaintext.contains("User: See you later"), "Second user message with role prefix")
+        XCTAssertTrue(plaintext.contains("Assistant: Goodbye!"), "Second assistant reply with role prefix")
+
+        // No markdown formatting leaked
+        XCTAssertFalse(plaintext.contains("**User:**"), "Plaintext should not contain markdown bold")
+        XCTAssertFalse(plaintext.contains("# "), "Plaintext should not contain markdown headers")
+    }
+
+    // MARK: - Session title in export
+
+    func test_export_sessionTitle_appearsInBothFormats() async {
+        let backend = makeMockBackend(tokens: ["Noted."])
+        let vm = makeViewModel(backend: backend)
+        createAndActivateSession(vm: vm, title: "Important Discussion")
+
+        vm.inputText = "Remember this"
+        await vm.sendMessage()
+
+        let markdown = ChatExportService.export(
+            messages: vm.messages,
+            sessionTitle: "Important Discussion",
+            format: .markdown
+        )
+        let plaintext = ChatExportService.export(
+            messages: vm.messages,
+            sessionTitle: "Important Discussion",
+            format: .plainText
+        )
+
+        XCTAssertTrue(markdown.contains("# Important Discussion"),
+                      "Markdown export should include session title as H1")
+        XCTAssertTrue(plaintext.contains("Chat: Important Discussion"),
+                      "Plaintext export should include session title in header")
+    }
+
+    // MARK: - Empty conversation export
+
+    func test_emptyConversation_exportsHeaderOnly() {
+        let backend = makeMockBackend(tokens: [])
+        let vm = makeViewModel(backend: backend)
+        createAndActivateSession(vm: vm, title: "Empty Session")
+
+        // No messages sent
+        let markdown = ChatExportService.export(
+            messages: vm.messages,
+            sessionTitle: "Empty Session",
+            format: .markdown
+        )
+        let plaintext = ChatExportService.export(
+            messages: vm.messages,
+            sessionTitle: "Empty Session",
+            format: .plainText
+        )
+
+        // Headers present
+        XCTAssertTrue(markdown.contains("# Empty Session"))
+        XCTAssertTrue(plaintext.contains("Chat: Empty Session"))
+
+        // No role labels
+        XCTAssertFalse(markdown.contains("**User:**"), "Empty export should have no user labels")
+        XCTAssertFalse(markdown.contains("**Assistant:**"), "Empty export should have no assistant labels")
+        XCTAssertFalse(plaintext.contains("User:"), "Empty plaintext should have no user labels")
+        XCTAssertFalse(plaintext.contains("Assistant:"), "Empty plaintext should have no assistant labels")
+    }
+}

--- a/Tests/BaseChatUITests/ChatExportIntegrationTests.swift
+++ b/Tests/BaseChatUITests/ChatExportIntegrationTests.swift
@@ -17,10 +17,11 @@ final class ChatExportIntegrationTests: XCTestCase {
         try await super.setUp()
         let schema = Schema(BaseChatSchema.allModelTypes)
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
-        container = try! ModelContainer(for: schema, configurations: [config])
+        container = try ModelContainer(for: schema, configurations: [config])
         context = container.mainContext
+        let persistence = SwiftDataPersistenceProvider(modelContext: context)
         sessionManager = SessionManagerViewModel()
-        sessionManager.configure(modelContext: context)
+        sessionManager.configure(persistence: persistence)
     }
 
     override func tearDown() async throws {
@@ -41,8 +42,9 @@ final class ChatExportIntegrationTests: XCTestCase {
 
     private func makeViewModel(backend: MockInferenceBackend) -> ChatViewModel {
         let service = InferenceService(backend: backend, name: "ExportTest")
+        let persistence = SwiftDataPersistenceProvider(modelContext: context)
         let vm = ChatViewModel(inferenceService: service)
-        vm.configure(modelContext: context)
+        vm.configure(persistence: persistence)
         return vm
     }
 
@@ -50,8 +52,8 @@ final class ChatExportIntegrationTests: XCTestCase {
     private func createAndActivateSession(
         vm: ChatViewModel,
         title: String = "Test Chat"
-    ) -> ChatSessionRecord {
-        let session = try! sessionManager.createSession(title: title)
+    ) throws -> ChatSessionRecord {
+        let session = try sessionManager.createSession(title: title)
         sessionManager.activeSession = session
         vm.switchToSession(session)
         return session
@@ -59,10 +61,10 @@ final class ChatExportIntegrationTests: XCTestCase {
 
     // MARK: - Multi-turn markdown export
 
-    func test_multiTurnConversation_markdownExport_containsAllTurns() async {
+    func test_multiTurnConversation_markdownExport_containsAllTurns() async throws {
         let backend = makeMockBackend(tokens: ["Hello", " there!"])
         let vm = makeViewModel(backend: backend)
-        createAndActivateSession(vm: vm, title: "Story Time")
+        try createAndActivateSession(vm: vm, title: "Story Time")
 
         // Turn 1
         vm.inputText = "Hi"
@@ -98,18 +100,18 @@ final class ChatExportIntegrationTests: XCTestCase {
         XCTAssertTrue(markdown.contains("Sure, here you go."), "Second assistant reply should appear")
 
         // Verify ordering: first user turn appears before second
-        let hiRange = markdown.range(of: "\nHi\n")!
-        let storyRange = markdown.range(of: "Tell me a story")!
+        let hiRange = try XCTUnwrap(markdown.range(of: "\nHi\n"), "First user message not found in markdown")
+        let storyRange = try XCTUnwrap(markdown.range(of: "Tell me a story"), "Second user message not found in markdown")
         XCTAssertTrue(hiRange.lowerBound < storyRange.lowerBound,
                       "First user message should precede the second")
     }
 
     // MARK: - Multi-turn plaintext export
 
-    func test_multiTurnConversation_plaintextExport_containsAllTurns() async {
+    func test_multiTurnConversation_plaintextExport_containsAllTurns() async throws {
         let backend = makeMockBackend(tokens: ["I'm", " fine."])
         let vm = makeViewModel(backend: backend)
-        createAndActivateSession(vm: vm, title: "Casual Chat")
+        try createAndActivateSession(vm: vm, title: "Casual Chat")
 
         // Turn 1
         vm.inputText = "How are you?"
@@ -142,10 +144,10 @@ final class ChatExportIntegrationTests: XCTestCase {
 
     // MARK: - Session title in export
 
-    func test_export_sessionTitle_appearsInBothFormats() async {
+    func test_export_sessionTitle_appearsInBothFormats() async throws {
         let backend = makeMockBackend(tokens: ["Noted."])
         let vm = makeViewModel(backend: backend)
-        createAndActivateSession(vm: vm, title: "Important Discussion")
+        try createAndActivateSession(vm: vm, title: "Important Discussion")
 
         vm.inputText = "Remember this"
         await vm.sendMessage()
@@ -169,10 +171,10 @@ final class ChatExportIntegrationTests: XCTestCase {
 
     // MARK: - Empty conversation export
 
-    func test_emptyConversation_exportsHeaderOnly() {
+    func test_emptyConversation_exportsHeaderOnly() throws {
         let backend = makeMockBackend(tokens: [])
         let vm = makeViewModel(backend: backend)
-        createAndActivateSession(vm: vm, title: "Empty Session")
+        try createAndActivateSession(vm: vm, title: "Empty Session")
 
         // No messages sent
         let markdown = ChatExportService.export(

--- a/Tests/BaseChatUITests/SessionOverrideTests.swift
+++ b/Tests/BaseChatUITests/SessionOverrideTests.swift
@@ -22,19 +22,20 @@ final class SessionOverrideTests: XCTestCase {
 
         let schema = Schema(BaseChatSchema.allModelTypes)
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
-        container = try! ModelContainer(for: schema, configurations: [config])
+        container = try ModelContainer(for: schema, configurations: [config])
         context = container.mainContext
 
         mockBackend = MockInferenceBackend()
         mockBackend.isModelLoaded = true
         mockBackend.tokensToYield = ["ok"]
 
+        let persistence = SwiftDataPersistenceProvider(modelContext: context)
         let service = InferenceService(backend: mockBackend, name: "Mock")
         vm = ChatViewModel(inferenceService: service)
-        vm.configure(modelContext: context)
+        vm.configure(persistence: persistence)
 
         sessionManager = SessionManagerViewModel()
-        sessionManager.configure(modelContext: context)
+        sessionManager.configure(persistence: persistence)
     }
 
     override func tearDown() async throws {
@@ -56,8 +57,8 @@ final class SessionOverrideTests: XCTestCase {
         temperature: Float? = nil,
         topP: Float? = nil,
         repeatPenalty: Float? = nil
-    ) -> ChatSessionRecord {
-        var session = try! sessionManager.createSession(title: title)
+    ) throws -> ChatSessionRecord {
+        var session = try sessionManager.createSession(title: title)
         session.temperature = temperature
         session.topP = topP
         session.repeatPenalty = repeatPenalty
@@ -74,7 +75,7 @@ final class SessionOverrideTests: XCTestCase {
     // MARK: - Tests
 
     func test_customOverrides_passedToBackend() async throws {
-        createAndActivateSession(
+        try createAndActivateSession(
             title: "Custom",
             temperature: 0.3,
             topP: 0.5,
@@ -90,7 +91,7 @@ final class SessionOverrideTests: XCTestCase {
     }
 
     func test_noOverrides_usesDefaults() async throws {
-        createAndActivateSession(title: "Default")
+        try createAndActivateSession(title: "Default")
 
         await sendMessage()
 
@@ -102,7 +103,7 @@ final class SessionOverrideTests: XCTestCase {
 
     func test_switchBackToCustomSession_overridesStillApplied() async throws {
         // Session A: custom overrides
-        let sessionA = createAndActivateSession(
+        let sessionA = try createAndActivateSession(
             title: "Session A",
             temperature: 0.3,
             topP: 0.5,
@@ -112,7 +113,7 @@ final class SessionOverrideTests: XCTestCase {
         await sendMessage("From A first")
 
         // Session B: defaults
-        createAndActivateSession(title: "Session B")
+        try createAndActivateSession(title: "Session B")
 
         await sendMessage("From B")
 

--- a/Tests/BaseChatUITests/SessionOverrideTests.swift
+++ b/Tests/BaseChatUITests/SessionOverrideTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+import SwiftData
+@testable import BaseChatUI
+import BaseChatCore
+import BaseChatTestSupport
+
+// MARK: - Session Override Tests
+
+@MainActor
+final class SessionOverrideTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+    private var vm: ChatViewModel!
+    private var sessionManager: SessionManagerViewModel!
+    private var mockBackend: MockInferenceBackend!
+
+    // MARK: - Setup / Teardown
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        let schema = Schema(BaseChatSchema.allModelTypes)
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        container = try! ModelContainer(for: schema, configurations: [config])
+        context = container.mainContext
+
+        mockBackend = MockInferenceBackend()
+        mockBackend.isModelLoaded = true
+        mockBackend.tokensToYield = ["ok"]
+
+        let service = InferenceService(backend: mockBackend, name: "Mock")
+        vm = ChatViewModel(inferenceService: service)
+        vm.configure(modelContext: context)
+
+        sessionManager = SessionManagerViewModel()
+        sessionManager.configure(modelContext: context)
+    }
+
+    override func tearDown() async throws {
+        vm?.stopGeneration()
+        vm?.inferenceService.unloadModel()
+        vm = nil
+        sessionManager = nil
+        mockBackend = nil
+        context = nil
+        container = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    @discardableResult
+    private func createAndActivateSession(
+        title: String = "Test Chat",
+        temperature: Float? = nil,
+        topP: Float? = nil,
+        repeatPenalty: Float? = nil
+    ) -> ChatSessionRecord {
+        var session = try! sessionManager.createSession(title: title)
+        session.temperature = temperature
+        session.topP = topP
+        session.repeatPenalty = repeatPenalty
+        sessionManager.activeSession = session
+        vm.switchToSession(session)
+        return session
+    }
+
+    private func sendMessage(_ text: String = "Hello") async {
+        vm.inputText = text
+        await vm.sendMessage()
+    }
+
+    // MARK: - Tests
+
+    func test_customOverrides_passedToBackend() async throws {
+        createAndActivateSession(
+            title: "Custom",
+            temperature: 0.3,
+            topP: 0.5,
+            repeatPenalty: 1.5
+        )
+
+        await sendMessage()
+
+        let config = try XCTUnwrap(mockBackend.lastConfig)
+        XCTAssertEqual(config.temperature, 0.3, accuracy: 0.001)
+        XCTAssertEqual(config.topP, 0.5, accuracy: 0.001)
+        XCTAssertEqual(config.repeatPenalty, 1.5, accuracy: 0.001)
+    }
+
+    func test_noOverrides_usesDefaults() async throws {
+        createAndActivateSession(title: "Default")
+
+        await sendMessage()
+
+        let config = try XCTUnwrap(mockBackend.lastConfig)
+        XCTAssertEqual(config.temperature, 0.7, accuracy: 0.001)
+        XCTAssertEqual(config.topP, 0.9, accuracy: 0.001)
+        XCTAssertEqual(config.repeatPenalty, 1.1, accuracy: 0.001)
+    }
+
+    func test_switchBackToCustomSession_overridesStillApplied() async throws {
+        // Session A: custom overrides
+        let sessionA = createAndActivateSession(
+            title: "Session A",
+            temperature: 0.3,
+            topP: 0.5,
+            repeatPenalty: 1.5
+        )
+
+        await sendMessage("From A first")
+
+        // Session B: defaults
+        createAndActivateSession(title: "Session B")
+
+        await sendMessage("From B")
+
+        let defaultConfig = try XCTUnwrap(mockBackend.lastConfig)
+        XCTAssertEqual(defaultConfig.temperature, 0.7, accuracy: 0.001)
+        XCTAssertEqual(defaultConfig.topP, 0.9, accuracy: 0.001)
+        XCTAssertEqual(defaultConfig.repeatPenalty, 1.1, accuracy: 0.001)
+
+        // Switch back to Session A
+        vm.switchToSession(sessionA)
+
+        await sendMessage("From A again")
+
+        let overriddenConfig = try XCTUnwrap(mockBackend.lastConfig)
+        XCTAssertEqual(overriddenConfig.temperature, 0.3, accuracy: 0.001)
+        XCTAssertEqual(overriddenConfig.topP, 0.5, accuracy: 0.001)
+        XCTAssertEqual(overriddenConfig.repeatPenalty, 1.5, accuracy: 0.001)
+    }
+}


### PR DESCRIPTION
## Summary

- **5 new test suites (18 tests)** closing the highest-value coverage gaps identified in a full feature-vs-test audit
- **TESTING.md** — comprehensive testing guide documenting the pyramid, async patterns, AI-specific flow testing, mock infrastructure, and remaining gaps
- **8 GitHub issues filed** for remaining gaps (#66–#73)

### New tests

| File | Tests | Layer | What it covers |
|------|-------|-------|----------------|
| `ChatTurnRoundTripE2ETests` | 5 | Headless E2E | Send → stream → persist → session switch → reload |
| `LoopDetectionE2ETests` | 3 | Headless E2E | Repetitive tokens → auto-stop → partial content preserved |
| `SessionOverrideTests` | 3 | Integration | Per-session temperature/topP/repeatPenalty reach the backend |
| `SamplerPresetRoundTripTests` | 3 | Integration | SwiftData insert → fetch → update → verify |
| `ChatExportIntegrationTests` | 4 | Integration | Real ViewModel conversation → markdown/plaintext export |

### Other changes

- `Package.swift`: added `BaseChatUI` to `BaseChatE2ETests` dependencies (needed for ViewModel access in E2E tests)
- All 652 existing XCTest + 72 Swift Testing tests continue to pass

## Test plan

- [x] All 18 new tests pass locally
- [x] Full CI-safe suite (652 + 72 tests) passes with 0 failures
- [ ] CI runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)