### PR TITLE
test: add integration test for retry policy with real network errors

### DIFF
--- a/Sources/BaseChatTestSupport/MockURLProtocol.swift
+++ b/Sources/BaseChatTestSupport/MockURLProtocol.swift
@@ -40,6 +40,9 @@ public final class MockURLProtocol: URLProtocol {
     /// Thread-safe storage for stubs keyed by absolute URL string.
     private static let lock = NSLock()
     private nonisolated(unsafe) static var stubs: [String: StubbedResponse] = [:]
+    /// Ordered sequences of responses: each call pops the first element.
+    /// When exhausted, falls back to the single-response stub (if any).
+    private nonisolated(unsafe) static var stubSequences: [String: [StubbedResponse]] = [:]
     private nonisolated(unsafe) static var _capturedRequests: [URLRequest] = []
 
     /// All requests intercepted since the last `reset()` call, in order.
@@ -56,18 +59,37 @@ public final class MockURLProtocol: URLProtocol {
         stubs[url.absoluteString] = response
     }
 
+    /// Registers an ordered sequence of responses for a URL.
+    ///
+    /// Each request pops the first element. When the sequence is exhausted,
+    /// falls back to the single-response stub registered via ``stub(url:response:)``.
+    public static func stubSequence(url: URL, responses: [StubbedResponse]) {
+        lock.lock()
+        defer { lock.unlock() }
+        stubSequences[url.absoluteString] = responses
+    }
+
     /// Removes all registered stubs and captured requests.
     public static func reset() {
         lock.lock()
         defer { lock.unlock() }
         stubs.removeAll()
+        stubSequences.removeAll()
         _capturedRequests.removeAll()
     }
 
-    /// Finds a stub matching the URL — tries exact match first, then path-contains match.
+    /// Finds a stub matching the URL — tries sequence first, then exact match, then path-contains.
     private static func findStub(for url: URL) -> StubbedResponse? {
         lock.lock()
         defer { lock.unlock() }
+
+        // Sequence match: pop the first element if available.
+        let key = url.absoluteString
+        if var seq = stubSequences[key], !seq.isEmpty {
+            let next = seq.removeFirst()
+            stubSequences[key] = seq
+            return next
+        }
 
         // Exact match.
         if let stub = stubs[url.absoluteString] {
@@ -98,10 +120,10 @@ public final class MockURLProtocol: URLProtocol {
     // MARK: - URLProtocol Overrides
 
     public override class func canInit(with request: URLRequest) -> Bool {
-        // Intercept all requests when any stubs are registered.
+        // Intercept all requests when any stubs or sequences are registered.
         lock.lock()
         defer { lock.unlock() }
-        return !stubs.isEmpty
+        return !stubs.isEmpty || !stubSequences.isEmpty
     }
 
     public override class func canonicalRequest(for request: URLRequest) -> URLRequest {

--- a/Sources/BaseChatTestSupport/MockURLProtocol.swift
+++ b/Sources/BaseChatTestSupport/MockURLProtocol.swift
@@ -120,10 +120,11 @@ public final class MockURLProtocol: URLProtocol {
     // MARK: - URLProtocol Overrides
 
     public override class func canInit(with request: URLRequest) -> Bool {
-        // Intercept all requests when any stubs or sequences are registered.
+        // Intercept all requests when any stubs or non-exhausted sequences are registered.
         lock.lock()
         defer { lock.unlock() }
-        return !stubs.isEmpty || !stubSequences.isEmpty
+        let hasActiveSequences = stubSequences.values.contains { !$0.isEmpty }
+        return !stubs.isEmpty || hasActiveSequences
     }
 
     public override class func canonicalRequest(for request: URLRequest) -> URLRequest {

--- a/Tests/BaseChatBackendsTests/RetryPolicyIntegrationTests.swift
+++ b/Tests/BaseChatBackendsTests/RetryPolicyIntegrationTests.swift
@@ -18,6 +18,7 @@ final class RetryPolicyIntegrationTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        MockURLProtocol.reset()
         let config = URLSessionConfiguration.ephemeral
         config.protocolClasses = [MockURLProtocol.self]
         session = URLSession(configuration: config)

--- a/Tests/BaseChatBackendsTests/RetryPolicyIntegrationTests.swift
+++ b/Tests/BaseChatBackendsTests/RetryPolicyIntegrationTests.swift
@@ -1,0 +1,179 @@
+import XCTest
+import BaseChatCore
+import BaseChatTestSupport
+@testable import BaseChatBackends
+
+/// Integration tests verifying that `withExponentialBackoff` retries rate-limited
+/// requests end-to-end through a real `URLSession` + `MockURLProtocol` stack.
+///
+/// Unlike the unit tests for `withExponentialBackoff` (which test timing math in
+/// isolation), these tests wire a cloud backend to `MockURLProtocol` and confirm
+/// the full retry loop — HTTP 429 → `CloudBackendError.rateLimited` → backoff →
+/// re-request → eventual success or exhaustion.
+final class RetryPolicyIntegrationTests: XCTestCase {
+
+    private var session: URLSession!
+    private var backend: OpenAIBackend!
+    private let baseURL = URL(string: "https://retry-test.example")!
+
+    override func setUp() {
+        super.setUp()
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        session = URLSession(configuration: config)
+        backend = OpenAIBackend(urlSession: session)
+        backend.configure(baseURL: baseURL, apiKey: "sk-test", modelName: "test-model")
+    }
+
+    override func tearDown() {
+        MockURLProtocol.reset()
+        backend = nil
+        session = nil
+        super.tearDown()
+    }
+
+    // MARK: - Transient 429 then success
+
+    /// Two 429 responses followed by a 200 with valid SSE data.
+    /// The backend should retry through the 429s and yield tokens from the final response.
+    func test_retries429ThenSucceeds() async throws {
+        try await backend.loadModel(from: URL(string: "unused:")!, contextSize: 0)
+
+        let completionsURL = baseURL.appendingPathComponent("v1/chat/completions")
+
+        // First two requests: 429 with Retry-After header.
+        // Third request: 200 with a valid SSE stream.
+        let successChunk = Data("data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\ndata: [DONE]\n\n".utf8)
+
+        MockURLProtocol.stubSequence(url: completionsURL, responses: [
+            .immediate(data: Data(), statusCode: 429, headers: ["Retry-After": "0.01"]),
+            .immediate(data: Data(), statusCode: 429, headers: ["Retry-After": "0.01"]),
+            .sse(chunks: [successChunk], statusCode: 200),
+        ])
+
+        let stream = try backend.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        var tokens: [String] = []
+        for try await token in stream {
+            tokens.append(token)
+        }
+
+        XCTAssertEqual(tokens, ["hello"], "Should receive token after retrying past 429s")
+
+        // Verify three requests were made: 2 retries + 1 success.
+        let requestCount = MockURLProtocol.capturedRequests.count
+        XCTAssertEqual(requestCount, 3, "Expected 2 retried requests + 1 successful request")
+    }
+
+    // MARK: - Exhausted retries
+
+    /// All attempts return 429. The backend should exhaust retries and throw rateLimited.
+    func test_exhaustsRetriesAndThrows() async throws {
+        try await backend.loadModel(from: URL(string: "unused:")!, contextSize: 0)
+
+        let completionsURL = baseURL.appendingPathComponent("v1/chat/completions")
+
+        // Default maxRetries is 3, so 4 attempts total (initial + 3 retries).
+        // Use short Retry-After to keep test fast.
+        MockURLProtocol.stubSequence(url: completionsURL, responses: [
+            .immediate(data: Data(), statusCode: 429, headers: ["Retry-After": "0.01"]),
+            .immediate(data: Data(), statusCode: 429, headers: ["Retry-After": "0.01"]),
+            .immediate(data: Data(), statusCode: 429, headers: ["Retry-After": "0.01"]),
+            .immediate(data: Data(), statusCode: 429, headers: ["Retry-After": "0.01"]),
+        ])
+
+        let stream = try backend.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        do {
+            for try await _ in stream { }
+            XCTFail("Should have thrown after exhausting retries")
+        } catch let error as CloudBackendError {
+            guard case .rateLimited = error else {
+                XCTFail("Expected rateLimited error, got \(error)")
+                return
+            }
+        }
+
+        // All 4 attempts should have been made (initial + 3 retries).
+        let requestCount = MockURLProtocol.capturedRequests.count
+        XCTAssertEqual(requestCount, 4, "Expected initial attempt + 3 retries = 4 total requests")
+    }
+
+    // MARK: - Non-retryable errors propagate immediately
+
+    /// A 401 should not be retried — it should propagate as authenticationFailed immediately.
+    func test_nonRetryableErrorDoesNotRetry() async throws {
+        try await backend.loadModel(from: URL(string: "unused:")!, contextSize: 0)
+
+        let completionsURL = baseURL.appendingPathComponent("v1/chat/completions")
+
+        MockURLProtocol.stub(url: completionsURL, response: .immediate(
+            data: Data(), statusCode: 401
+        ))
+
+        let stream = try backend.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        do {
+            for try await _ in stream { }
+            XCTFail("Should have thrown authenticationFailed")
+        } catch let error as CloudBackendError {
+            guard case .authenticationFailed = error else {
+                XCTFail("Expected authenticationFailed, got \(error)")
+                return
+            }
+        }
+
+        // Only one request — no retries for auth errors.
+        XCTAssertEqual(MockURLProtocol.capturedRequests.count, 1,
+                       "Non-retryable errors must not trigger retries")
+    }
+
+    // MARK: - Retry-After header respected
+
+    /// Verifies that backoff timing approximately matches the Retry-After header value.
+    func test_retryAfterHeaderInfluencesTiming() async throws {
+        try await backend.loadModel(from: URL(string: "unused:")!, contextSize: 0)
+
+        let completionsURL = baseURL.appendingPathComponent("v1/chat/completions")
+        let successChunk = Data("data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\ndata: [DONE]\n\n".utf8)
+
+        // One 429 with a 0.1s Retry-After, then success.
+        MockURLProtocol.stubSequence(url: completionsURL, responses: [
+            .immediate(data: Data(), statusCode: 429, headers: ["Retry-After": "0.1"]),
+            .sse(chunks: [successChunk], statusCode: 200),
+        ])
+
+        let stream = try backend.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        let start = ContinuousClock.now
+        var tokens: [String] = []
+        for try await token in stream {
+            tokens.append(token)
+        }
+        let elapsed = ContinuousClock.now - start
+
+        XCTAssertEqual(tokens, ["ok"])
+        // The Retry-After is 0.1s. Allow a generous range to avoid flakiness,
+        // but ensure the delay actually happened (not instant).
+        XCTAssertGreaterThan(elapsed, .milliseconds(50),
+                             "Backoff delay should be at least ~100ms from Retry-After header")
+        XCTAssertLessThan(elapsed, .seconds(5),
+                          "Retry should complete well under 5s for a 0.1s Retry-After")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `RetryPolicyIntegrationTests` to `BaseChatBackendsTests` with 4 test cases wiring `OpenAIBackend` through `MockURLProtocol` to verify the full retry loop end-to-end
- Adds `stubSequence(url:responses:)` to `MockURLProtocol` enabling ordered multi-response stubs (first N calls return one response, then fall back)
- Covers: transient 429 → success, retry exhaustion, non-retryable error propagation (401), and Retry-After header timing verification

Closes #70

## Test plan
- [x] All 4 new tests pass locally (`swift test --filter RetryPolicyIntegrationTests`)
- [x] Full build succeeds (`swift build --build-tests`)
- [ ] CI passes (`BaseChatBackendsTests` suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)