### PR TITLE
test: replace Task.sleep polling with event-driven test patterns

### DIFF
--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -77,7 +77,12 @@ public final class ChatViewModel {
     public private(set) var isLoading: Bool = false
 
     /// Whether inference is currently streaming tokens.
-    public internal(set) var isGenerating: Bool = false
+    public internal(set) var isGenerating: Bool = false {
+        didSet { onGeneratingChanged?(isGenerating) }
+    }
+
+    /// Test-only hook invoked whenever `isGenerating` changes.
+    public var onGeneratingChanged: ((Bool) -> Void)?
 
     /// A user-facing error message, shown as a banner. Cleared on next action.
     public var errorMessage: String?

--- a/Tests/BaseChatUITests/CancellationTests.swift
+++ b/Tests/BaseChatUITests/CancellationTests.swift
@@ -79,10 +79,7 @@ final class CancellationTests: XCTestCase {
     private func sendAndStopMidStream(input: String = "Hello") async throws {
         vm.inputText = input
         let sendTask = Task { await vm.sendMessage() }
-        for _ in 0..<100 {
-            if vm.messages.count >= 2, !(vm.messages.last?.content ?? "").isEmpty { break }
-            try await Task.sleep(for: .milliseconds(20))
-        }
+        await vm.awaitFirstToken()
         vm.stopGeneration()
         await sendTask.value
     }
@@ -145,7 +142,7 @@ final class CancellationTests: XCTestCase {
 
         vm.inputText = "Hello"
         let sendTask = Task { await vm.sendMessage() }
-        try await Task.sleep(for: .milliseconds(150))
+        await vm.awaitGenerating(true)
         vm.clearChat()
         await sendTask.value
 
@@ -161,7 +158,7 @@ final class CancellationTests: XCTestCase {
 
         vm.inputText = "Hello"
         let sendTask = Task { await vm.sendMessage() }
-        try await Task.sleep(for: .milliseconds(100))
+        await vm.awaitGenerating(true)
 
         // Simulate model switch: unload while generating
         vm.inferenceService.unloadModel()
@@ -180,7 +177,7 @@ final class CancellationTests: XCTestCase {
 
         vm.inputText = "Hello"
         let sendTask = Task { await vm.sendMessage() }
-        try await Task.sleep(for: .milliseconds(100))
+        await vm.awaitGenerating(true)
 
         // Unload the old model (simulates switching models)
         vm.inferenceService.unloadModel()

--- a/Tests/BaseChatUITests/ChatViewModelTestHelpers.swift
+++ b/Tests/BaseChatUITests/ChatViewModelTestHelpers.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import BaseChatUI
+
+/// Event-driven helpers that replace Task.sleep polling in ChatViewModel tests.
+extension ChatViewModel {
+
+    /// Suspends until `isGenerating` becomes `expected`, or fails after `timeout`.
+    @MainActor
+    func awaitGenerating(
+        _ expected: Bool,
+        timeout: TimeInterval = 2.0,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        if isGenerating == expected { return }
+
+        let expectation = XCTestExpectation(description: "isGenerating == \(expected)")
+        let previous = onGeneratingChanged
+        onGeneratingChanged = { value in
+            previous?(value)
+            if value == expected { expectation.fulfill() }
+        }
+        let result = await XCTWaiter().fulfillment(of: [expectation], timeout: timeout)
+        onGeneratingChanged = previous
+        if result != .completed {
+            XCTFail("Timed out waiting for isGenerating == \(expected)", file: file, line: line)
+        }
+    }
+
+    /// Suspends until at least one token has been written into the last assistant message.
+    @MainActor
+    func awaitFirstToken(
+        timeout: TimeInterval = 2.0,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        if messages.count >= 2, !(messages.last?.content ?? "").isEmpty { return }
+
+        // Poll with a very tight yield rather than a fixed sleep.
+        let deadline = ContinuousClock.now + .seconds(timeout)
+        while ContinuousClock.now < deadline {
+            if messages.count >= 2, !(messages.last?.content ?? "").isEmpty { return }
+            await Task.yield()
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        XCTFail("Timed out waiting for first token", file: file, line: line)
+    }
+}

--- a/Tests/BaseChatUITests/ConcurrencyTests.swift
+++ b/Tests/BaseChatUITests/ConcurrencyTests.swift
@@ -98,9 +98,6 @@ final class ConcurrencyTests: XCTestCase {
             await task.value
         }
 
-        // Allow any remaining MainActor work to settle.
-        try await Task.sleep(nanoseconds: 200_000_000)
-
         // Verify: no crash (we got here), messages are non-empty, generation finished.
         XCTAssertFalse(vm.messages.isEmpty, "Messages should be non-empty after rapid sends")
         XCTAssertFalse(vm.isGenerating, "isGenerating should be false after all tasks complete")
@@ -174,9 +171,8 @@ final class ConcurrencyTests: XCTestCase {
             await self.vm.sendMessage()
         }
 
-        // Wait briefly for generation to start.
-        try await Task.sleep(nanoseconds: 100_000_000)
-        XCTAssertTrue(vm.isGenerating, "Should be generating after first send")
+        // Wait for generation to start.
+        await vm.awaitGenerating(true)
 
         // Send a second message while still generating.
         vm.inputText = "Second message"
@@ -187,9 +183,6 @@ final class ConcurrencyTests: XCTestCase {
         // Wait for both to complete.
         await firstTask.value
         await secondTask.value
-
-        // Allow settling.
-        try await Task.sleep(nanoseconds: 200_000_000)
 
         // sendMessage() does not guard isGenerating, so both messages should have
         // been sent. We should see user messages for both sends.
@@ -220,8 +213,7 @@ final class ConcurrencyTests: XCTestCase {
         }
 
         // Wait for generation to start streaming.
-        try await Task.sleep(nanoseconds: 150_000_000)
-        XCTAssertTrue(vm.isGenerating, "Should be generating on session A")
+        await vm.awaitGenerating(true)
 
         // Switch to session B mid-generation.
         sessionManager.activeSession = sessionB
@@ -298,8 +290,7 @@ final class ConcurrencyTests: XCTestCase {
         }
 
         // Wait for generation to start.
-        try await Task.sleep(nanoseconds: 150_000_000)
-        XCTAssertTrue(vm.isGenerating, "Should be generating")
+        await vm.awaitGenerating(true)
 
         // Capture message count before regenerate attempt.
         let messageCountBefore = vm.messages.count
@@ -313,9 +304,6 @@ final class ConcurrencyTests: XCTestCase {
 
         // Wait for original generation to complete.
         await genTask.value
-
-        // Allow settling.
-        try await Task.sleep(nanoseconds: 100_000_000)
 
         XCTAssertFalse(vm.isGenerating, "isGenerating should be false after generation completes")
 

--- a/Tests/BaseChatUITests/MemoryAndConcurrencyTests.swift
+++ b/Tests/BaseChatUITests/MemoryAndConcurrencyTests.swift
@@ -191,9 +191,6 @@ final class MemoryAndConcurrencyTests: XCTestCase {
             await task.value
         }
 
-        // Allow any remaining MainActor work to settle.
-        try await Task.sleep(nanoseconds: 100_000_000)
-
         // Verify: no crash (we got here), messages are present, generation is done.
         XCTAssertFalse(vm.messages.isEmpty,
             "Messages should be non-empty after rapid sends")
@@ -233,8 +230,7 @@ final class MemoryAndConcurrencyTests: XCTestCase {
         }
 
         // Wait for generation to start.
-        try await Task.sleep(nanoseconds: 150_000_000)
-        XCTAssertTrue(vm.isGenerating, "Should be generating")
+        await vm.awaitGenerating(true)
 
         // Attempt to edit the first user message while generating -- should be guarded.
         let messageCountBefore = vm.messages.count
@@ -279,8 +275,7 @@ final class MemoryAndConcurrencyTests: XCTestCase {
         }
 
         // Wait for generation to start streaming.
-        try await Task.sleep(nanoseconds: 150_000_000)
-        XCTAssertTrue(vm.isGenerating, "Should be generating")
+        await vm.awaitGenerating(true)
         XCTAssertFalse(vm.messages.isEmpty, "Should have messages during generation")
 
         // Clear chat while generating.

--- a/Tests/BaseChatUITests/ServerDiscoveryViewModelTests.swift
+++ b/Tests/BaseChatUITests/ServerDiscoveryViewModelTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import SwiftData
+import Observation
 @testable import BaseChatUI
 import BaseChatCore
 import BaseChatTestSupport
@@ -55,8 +56,18 @@ final class ServerDiscoveryViewModelTests: XCTestCase {
 
         sut.startDiscovery()
 
-        // Wait briefly for the async stream to deliver
-        try await Task.sleep(for: .milliseconds(100))
+        // Wait for the async stream to deliver using Observation tracking
+        let expectation = XCTestExpectation(description: "Server discovered")
+        if !sut.discoveredServers.isEmpty {
+            expectation.fulfill()
+        } else {
+            withObservationTracking {
+                _ = sut.discoveredServers
+            } onChange: {
+                Task { @MainActor in expectation.fulfill() }
+            }
+        }
+        await fulfillment(of: [expectation], timeout: 2.0)
 
         XCTAssertEqual(sut.discoveredServers.count, 1)
         XCTAssertEqual(sut.discoveredServers.first?.displayName, "Ollama")


### PR DESCRIPTION
## Summary
- Adds `onGeneratingChanged` callback hook to `ChatViewModel` for test observability
- Creates `ChatViewModelTestHelpers.swift` with `awaitGenerating(_:)` and `awaitFirstToken()` helpers
- Replaces all 14 `Task.sleep` polling sites across 4 test files with event-driven waiting
- Uses `withObservationTracking` for `@Observable` types (ServerDiscoveryViewModel)

Closes #73

## Test plan
- [ ] `swift test --filter BaseChatUITests` passes
- [ ] No remaining `Task.sleep` in test files (except 5ms yield in helper fallback)
- [ ] Tests are faster and less flaky without fixed-duration sleeps

🤖 Generated with [Claude Code](https://claude.com/claude-code)