### PR TITLE
test: add snapshot tests for SwiftUI previews

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d5ac47e86d5f1524abb6d80363ee945483462efe271edbb0e8111ed34d38345d",
+  "originHash" : "81ed52b3a16017f5bca0fe3d48094b138a76535bc2d764f5c51160c3949ac8e4",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -47,6 +47,15 @@
       }
     },
     {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
+        "version" : "1.5.0"
+      }
+    },
+    {
       "identity" : "swift-huggingface",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-huggingface.git",
@@ -65,12 +74,39 @@
       }
     },
     {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
+      "state" : {
+        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
+        "version" : "1.19.2"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "2b59c0c741e9184ab057fd22950b491076d42e91",
+        "version" : "603.0.0"
+      }
+    },
+    {
       "identity" : "swift-system",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
         "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
         "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -78,7 +78,6 @@ let package = Package(
             dependencies: [
                 "BaseChatUI",
                 "BaseChatCore",
-                "BaseChatTestSupport",
                 .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", from: "2.30.6"),
         .package(url: "https://github.com/huggingface/swift-huggingface.git", from: "0.9.0"),
         .package(url: "https://github.com/mattt/llama.swift", from: "2.8563.0"),
-        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.17.0"),
+        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.0"),
     ],
     targets: [
         // Core: models, protocols, services — no heavy ML deps

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", from: "2.30.6"),
         .package(url: "https://github.com/huggingface/swift-huggingface.git", from: "0.9.0"),
         .package(url: "https://github.com/mattt/llama.swift", from: "2.8563.0"),
+        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.17.0"),
     ],
     targets: [
         // Core: models, protocols, services — no heavy ML deps
@@ -71,6 +72,15 @@ let package = Package(
         .testTarget(
             name: "BaseChatE2ETests",
             dependencies: ["BaseChatBackends", "BaseChatUI", "BaseChatCore", "BaseChatTestSupport"]
+        ),
+        .testTarget(
+            name: "BaseChatSnapshotTests",
+            dependencies: [
+                "BaseChatUI",
+                "BaseChatCore",
+                "BaseChatTestSupport",
+                .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
+            ]
         ),
     ],
     swiftLanguageModes: [.v6]

--- a/Tests/BaseChatSnapshotTests/ViewSnapshotTests.swift
+++ b/Tests/BaseChatSnapshotTests/ViewSnapshotTests.swift
@@ -1,0 +1,185 @@
+import XCTest
+import SnapshotTesting
+import SwiftUI
+@testable import BaseChatUI
+import BaseChatCore
+import BaseChatTestSupport
+
+/// Snapshot tests for SwiftUI preview configurations.
+///
+/// Uses the `.dump` text-based strategy which works headless in CI — no simulator
+/// or rendering pipeline required. Catches structural regressions (view hierarchy
+/// changes, missing data, wrong bindings) without XCUITest overhead.
+///
+/// Views that require complex environment objects (ChatInputBar, DownloadProgressView,
+/// ChatView, model management views) are excluded — they need a full app environment.
+/// This covers the self-contained indicator and bubble views (16 of 26 previews).
+///
+/// On first run, set `isRecording = true` to generate reference snapshots.
+@MainActor
+final class ViewSnapshotTests: XCTestCase {
+
+    // Set to true to record new reference snapshots, then set back to false.
+    private let isRecordMode = false
+
+    private func assertDumpSnapshot<V: View>(
+        _ view: V,
+        named name: String,
+        file: StaticString = #filePath,
+        testName: String = #function,
+        line: UInt = #line
+    ) {
+        #if canImport(UIKit)
+        let vc = UIHostingController(rootView: view)
+        #elseif canImport(AppKit)
+        let vc = NSHostingController(rootView: view)
+        #endif
+        assertSnapshot(
+            of: vc,
+            as: .dump,
+            named: name,
+            record: isRecordMode,
+            file: file,
+            testName: testName,
+            line: line
+        )
+    }
+
+    // MARK: - MessageBubbleView (4 previews)
+
+    func test_messageBubble_userMessage() {
+        assertDumpSnapshot(
+            MessageBubbleView(
+                message: ChatMessageRecord(role: .user, content: "Hello, tell me a story.", sessionID: UUID()),
+                isStreaming: false
+            ),
+            named: "user_message"
+        )
+    }
+
+    func test_messageBubble_assistantMessage() {
+        assertDumpSnapshot(
+            MessageBubbleView(
+                message: ChatMessageRecord(role: .assistant, content: "Once upon a time...", sessionID: UUID()),
+                isStreaming: false
+            ),
+            named: "assistant_message"
+        )
+    }
+
+    func test_messageBubble_assistantStreaming() {
+        assertDumpSnapshot(
+            MessageBubbleView(
+                message: ChatMessageRecord(role: .assistant, content: "Once upon a time...", sessionID: UUID()),
+                isStreaming: true
+            ),
+            named: "assistant_streaming"
+        )
+    }
+
+    func test_messageBubble_systemMessage() {
+        assertDumpSnapshot(
+            MessageBubbleView(
+                message: ChatMessageRecord(role: .system, content: "You are a creative assistant.", sessionID: UUID()),
+                isStreaming: false
+            ),
+            named: "system_message"
+        )
+    }
+
+    // MARK: - ContextIndicatorView (4 previews)
+
+    func test_contextIndicator_lowUsage() {
+        assertDumpSnapshot(
+            ContextIndicatorView(usedTokens: 500, maxTokens: 4096),
+            named: "low_usage"
+        )
+    }
+
+    func test_contextIndicator_highUsage() {
+        assertDumpSnapshot(
+            ContextIndicatorView(usedTokens: 3500, maxTokens: 4096),
+            named: "high_usage"
+        )
+    }
+
+    func test_contextIndicator_critical() {
+        assertDumpSnapshot(
+            ContextIndicatorView(usedTokens: 3900, maxTokens: 4096),
+            named: "critical"
+        )
+    }
+
+    func test_contextIndicator_withCompressionStats() {
+        assertDumpSnapshot(
+            ContextIndicatorView(
+                usedTokens: 800,
+                maxTokens: 4096,
+                lastCompressionStats: CompressionStats(
+                    strategy: "extractive",
+                    originalNodeCount: 12,
+                    outputMessageCount: 5,
+                    estimatedTokens: 800,
+                    compressionRatio: 2.4,
+                    keywordSurvivalRate: nil
+                )
+            ),
+            named: "with_compression_stats"
+        )
+    }
+
+    // MARK: - MemoryIndicatorView (4 previews)
+
+    func test_memoryIndicator_nominal() {
+        assertDumpSnapshot(
+            MemoryIndicatorView(
+                pressureLevel: .nominal,
+                physicalMemoryBytes: 16 * 1024 * 1024 * 1024,
+                appMemoryBytes: 432 * 1024 * 1024
+            ),
+            named: "nominal"
+        )
+    }
+
+    func test_memoryIndicator_warning() {
+        assertDumpSnapshot(
+            MemoryIndicatorView(
+                pressureLevel: .warning,
+                physicalMemoryBytes: 8 * 1024 * 1024 * 1024,
+                appMemoryBytes: 5_800 * 1024 * 1024
+            ),
+            named: "warning"
+        )
+    }
+
+    func test_memoryIndicator_critical() {
+        assertDumpSnapshot(
+            MemoryIndicatorView(
+                pressureLevel: .critical,
+                physicalMemoryBytes: 6 * 1024 * 1024 * 1024,
+                appMemoryBytes: 5_900 * 1024 * 1024
+            ),
+            named: "critical"
+        )
+    }
+
+    func test_memoryIndicator_noAppUsage() {
+        assertDumpSnapshot(
+            MemoryIndicatorView(
+                pressureLevel: .nominal,
+                physicalMemoryBytes: 8 * 1024 * 1024 * 1024,
+                appMemoryBytes: nil
+            ),
+            named: "no_app_usage"
+        )
+    }
+
+    // MARK: - WhyDownloadView (1 preview)
+
+    func test_whyDownloadView() {
+        assertDumpSnapshot(
+            WhyDownloadView(),
+            named: "why_download"
+        )
+    }
+}

--- a/Tests/BaseChatSnapshotTests/ViewSnapshotTests.swift
+++ b/Tests/BaseChatSnapshotTests/ViewSnapshotTests.swift
@@ -14,12 +14,17 @@ import BaseChatCore
 /// ChatView, model management views) are excluded — they need a full app environment.
 /// This covers the self-contained indicator and bubble views (13 of 26 previews).
 ///
-/// On first run, set `isRecording = .all` to generate reference snapshots.
+/// On first run, set `recordMode = .all` to generate reference snapshots.
 @MainActor
 final class ViewSnapshotTests: XCTestCase {
 
-    // Set to .all to record new reference snapshots, then set back to nil.
-    private let recordMode: SnapshotTestingConfiguration.Record? = nil
+    // Set to .all to record new reference snapshots, then set back to .missing.
+    private let recordMode: SnapshotTestingConfiguration.Record? = .missing
+
+    // Fixed identifiers so `.dump` output is deterministic across runs.
+    private let fixedID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+    private let fixedSessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+    private let fixedDate = Date(timeIntervalSinceReferenceDate: 0)
 
     private func assertDumpSnapshot<V: View>(
         _ view: V,
@@ -49,7 +54,7 @@ final class ViewSnapshotTests: XCTestCase {
     func test_messageBubble_userMessage() {
         assertDumpSnapshot(
             MessageBubbleView(
-                message: ChatMessageRecord(role: .user, content: "Hello, tell me a story.", sessionID: UUID()),
+                message: ChatMessageRecord(id: fixedID, role: .user, content: "Hello, tell me a story.", timestamp: fixedDate, sessionID: fixedSessionID),
                 isStreaming: false
             ),
             named: "user_message"
@@ -59,7 +64,7 @@ final class ViewSnapshotTests: XCTestCase {
     func test_messageBubble_assistantMessage() {
         assertDumpSnapshot(
             MessageBubbleView(
-                message: ChatMessageRecord(role: .assistant, content: "Once upon a time...", sessionID: UUID()),
+                message: ChatMessageRecord(id: fixedID, role: .assistant, content: "Once upon a time...", timestamp: fixedDate, sessionID: fixedSessionID),
                 isStreaming: false
             ),
             named: "assistant_message"
@@ -69,7 +74,7 @@ final class ViewSnapshotTests: XCTestCase {
     func test_messageBubble_assistantStreaming() {
         assertDumpSnapshot(
             MessageBubbleView(
-                message: ChatMessageRecord(role: .assistant, content: "Once upon a time...", sessionID: UUID()),
+                message: ChatMessageRecord(id: fixedID, role: .assistant, content: "Once upon a time...", timestamp: fixedDate, sessionID: fixedSessionID),
                 isStreaming: true
             ),
             named: "assistant_streaming"
@@ -79,7 +84,7 @@ final class ViewSnapshotTests: XCTestCase {
     func test_messageBubble_systemMessage() {
         assertDumpSnapshot(
             MessageBubbleView(
-                message: ChatMessageRecord(role: .system, content: "You are a creative assistant.", sessionID: UUID()),
+                message: ChatMessageRecord(id: fixedID, role: .system, content: "You are a creative assistant.", timestamp: fixedDate, sessionID: fixedSessionID),
                 isStreaming: false
             ),
             named: "system_message"
@@ -177,7 +182,8 @@ final class ViewSnapshotTests: XCTestCase {
 
     func test_whyDownloadView() {
         assertDumpSnapshot(
-            WhyDownloadView(),
+            WhyDownloadView()
+                .environment(ModelManagementViewModel()),
             named: "why_download"
         )
     }

--- a/Tests/BaseChatSnapshotTests/ViewSnapshotTests.swift
+++ b/Tests/BaseChatSnapshotTests/ViewSnapshotTests.swift
@@ -3,7 +3,6 @@ import SnapshotTesting
 import SwiftUI
 @testable import BaseChatUI
 import BaseChatCore
-import BaseChatTestSupport
 
 /// Snapshot tests for SwiftUI preview configurations.
 ///
@@ -13,14 +12,14 @@ import BaseChatTestSupport
 ///
 /// Views that require complex environment objects (ChatInputBar, DownloadProgressView,
 /// ChatView, model management views) are excluded — they need a full app environment.
-/// This covers the self-contained indicator and bubble views (16 of 26 previews).
+/// This covers the self-contained indicator and bubble views (13 of 26 previews).
 ///
-/// On first run, set `isRecording = true` to generate reference snapshots.
+/// On first run, set `isRecording = .all` to generate reference snapshots.
 @MainActor
 final class ViewSnapshotTests: XCTestCase {
 
-    // Set to true to record new reference snapshots, then set back to false.
-    private let isRecordMode = false
+    // Set to .all to record new reference snapshots, then set back to nil.
+    private let recordMode: SnapshotTestingConfiguration.Record? = nil
 
     private func assertDumpSnapshot<V: View>(
         _ view: V,
@@ -38,7 +37,7 @@ final class ViewSnapshotTests: XCTestCase {
             of: vc,
             as: .dump,
             named: name,
-            record: isRecordMode,
+            record: recordMode,
             file: file,
             testName: testName,
             line: line


### PR DESCRIPTION
## Summary
- Adds `swift-snapshot-testing` dependency and new `BaseChatSnapshotTests` target
- 13 dump-based snapshot tests covering self-contained views: MessageBubbleView (4), ContextIndicatorView (4), MemoryIndicatorView (4), WhyDownloadView (1)
- Uses `.dump` text strategy — works headless in CI, no simulator rendering needed
- Views requiring complex environment objects (ChatInputBar, DownloadProgressView, etc.) excluded for now

Closes #72

## Test plan
- [ ] `swift test --filter BaseChatSnapshotTests` with `isRecordMode = true` to generate initial snapshots
- [ ] Set `isRecordMode = false` and re-run to verify comparison works
- [ ] Commit `__Snapshots__` reference files

🤖 Generated with [Claude Code](https://claude.com/claude-code)