### PR TITLE
feat: add typing indicators and streaming status UI with activity phase tracking

### DIFF
--- a/Sources/BaseChatCore/Models/BackendActivityPhase.swift
+++ b/Sources/BaseChatCore/Models/BackendActivityPhase.swift
@@ -1,0 +1,7 @@
+/// Represents the current phase of backend activity, enabling UI to show appropriate indicators.
+public enum BackendActivityPhase: Sendable, Equatable {
+    case idle
+    case modelLoading(progress: Double?)
+    case waitingForFirstToken
+    case streaming
+}

--- a/Sources/BaseChatUI/Environment/ActivityIndicatorStyle.swift
+++ b/Sources/BaseChatUI/Environment/ActivityIndicatorStyle.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+/// Protocol for custom activity indicator styles.
+public protocol ActivityIndicatorStyle {
+    associatedtype TypingBody: View
+    associatedtype StreamingBody: View
+    associatedtype LoadingBody: View
+
+    @ViewBuilder func makeTypingIndicator() -> TypingBody
+    @ViewBuilder func makeStreamingCursor() -> StreamingBody
+    @ViewBuilder func makeLoadingIndicator(progress: Double?) -> LoadingBody
+}
+
+/// Default activity indicator style using the built-in views.
+public struct DefaultActivityIndicatorStyle: ActivityIndicatorStyle {
+    public init() {}
+
+    public func makeTypingIndicator() -> some View { TypingIndicatorView() }
+    public func makeStreamingCursor() -> some View { StreamingCursorView() }
+    public func makeLoadingIndicator(progress: Double?) -> some View { ModelLoadingIndicatorView(progress: progress) }
+}

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
@@ -47,10 +47,10 @@ extension ChatViewModel {
     /// Handles context trimming, token usage capture, empty response cleanup,
     /// and the Foundation model upgrade hint.
     func generateIntoMessage(_ assistantMessage: ChatMessageRecord) async {
-        isGenerating = true
+        activityPhase = .waitingForFirstToken
         let messageID = assistantMessage.id
         defer {
-            isGenerating = false
+            activityPhase = .idle
             inferenceService.generationDidFinish()
         }
 
@@ -121,6 +121,9 @@ extension ChatViewModel {
                     for try await token in stream {
                         if Task.isCancelled { break }
                         tokenCount += 1
+                        if tokenCount == 1 {
+                            self.activityPhase = .streaming
+                        }
                         if let batch = batcher.append(token, now: ContinuousClock.now),
                            let idx = self.messages.firstIndex(where: { $0.id == messageID }) {
                             self.messages[idx].content += batch

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -73,12 +73,26 @@ public final class ChatViewModel {
     /// Editable system prompt prepended to every generation.
     public var systemPrompt: String = ""
 
-    /// Whether a model is currently being loaded.
-    public private(set) var isLoading: Bool = false
+    /// The current phase of backend activity, driving all status indicators.
+    public internal(set) var activityPhase: BackendActivityPhase = .idle {
+        didSet {
+            let wasGenerating = oldValue == .waitingForFirstToken || oldValue == .streaming
+            let nowGenerating = activityPhase == .waitingForFirstToken || activityPhase == .streaming
+            if wasGenerating != nowGenerating {
+                onGeneratingChanged?(nowGenerating)
+            }
+        }
+    }
 
-    /// Whether inference is currently streaming tokens.
-    public internal(set) var isGenerating: Bool = false {
-        didSet { onGeneratingChanged?(isGenerating) }
+    /// Whether a model is currently being loaded. Derived from `activityPhase`.
+    public var isLoading: Bool {
+        if case .modelLoading = activityPhase { return true }
+        return false
+    }
+
+    /// Whether inference is currently streaming tokens. Derived from `activityPhase`.
+    public var isGenerating: Bool {
+        activityPhase == .waitingForFirstToken || activityPhase == .streaming
     }
 
     /// Test-only hook invoked whenever `isGenerating` changes.
@@ -421,8 +435,8 @@ public final class ChatViewModel {
         }
 
         errorMessage = nil
-        isLoading = true
-        defer { isLoading = false }
+        activityPhase = .modelLoading(progress: nil)
+        defer { activityPhase = .idle }
 
         do {
             let contextSize: Int32 = Int32(model.detectedContextLength ?? 2048)
@@ -437,8 +451,8 @@ public final class ChatViewModel {
     /// Loads a cloud API endpoint for the active session.
     public func loadCloudEndpoint(_ endpoint: APIEndpoint) async {
         errorMessage = nil
-        isLoading = true
-        defer { isLoading = false }
+        activityPhase = .modelLoading(progress: nil)
+        defer { activityPhase = .idle }
 
         do {
             try await inferenceService.loadCloudBackend(from: endpoint)
@@ -572,7 +586,7 @@ public final class ChatViewModel {
         generationTask?.cancel()
         generationTask = nil
         inferenceService.stopGeneration()
-        isGenerating = false
+        activityPhase = .idle
 
         // Persist whatever has been generated so far.
         if let lastAssistant = messages.last(where: { $0.role == .assistant }),

--- a/Sources/BaseChatUI/Views/Chat/ChatView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ChatView.swift
@@ -160,16 +160,11 @@ public struct ChatView: View {
     // MARK: - Loading
 
     private var loadingView: some View {
-        VStack(spacing: 16) {
-            ProgressView()
-                .controlSize(.large)
-            Text("Setting things up...")
-                .font(.headline)
-                .foregroundStyle(.secondary)
+        Group {
+            if case .modelLoading(let progress) = viewModel.activityPhase {
+                ModelLoadingIndicatorView(progress: progress)
+            }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("Setting things up, please wait")
     }
 
     // MARK: - No Model Loaded

--- a/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
@@ -133,22 +133,13 @@ public struct MessageBubbleView: View {
     // MARK: - Streaming Indicator
 
     private var streamingPlaceholder: some View {
-        ProgressView()
-            .controlSize(.small)
+        TypingIndicatorView()
             .padding(.vertical, 4)
-            .accessibilityLabel("Generating response")
     }
 
     private var streamingIndicator: some View {
-        HStack(spacing: 4) {
-            Text("...")
-                .font(.body)
-                .foregroundStyle(.secondary)
-                .symbolEffect(.pulse)
-            ProgressView()
-                .controlSize(.mini)
-        }
-        .accessibilityLabel("Still generating")
+        StreamingCursorView()
+            .accessibilityLabel("Still generating")
     }
 
     // MARK: - Timestamp

--- a/Sources/BaseChatUI/Views/Chat/ModelLoadingIndicatorView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ModelLoadingIndicatorView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+/// Loading indicator shown during model loading, with optional progress.
+public struct ModelLoadingIndicatorView: View {
+    public let progress: Double?
+
+    public init(progress: Double? = nil) {
+        self.progress = progress
+    }
+
+    public var body: some View {
+        VStack(spacing: 8) {
+            if let progress {
+                ProgressView(value: progress)
+                    .progressViewStyle(.linear)
+                    .frame(maxWidth: 200)
+            } else {
+                ProgressView()
+            }
+            Text("Loading model…")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Loading model, please wait")
+    }
+}

--- a/Sources/BaseChatUI/Views/Chat/StreamingCursorView.swift
+++ b/Sources/BaseChatUI/Views/Chat/StreamingCursorView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+/// Pulsing cursor appended to the end of a streaming message to indicate ongoing generation.
+public struct StreamingCursorView: View {
+    @State private var isVisible = true
+
+    public init() {}
+
+    public var body: some View {
+        Rectangle()
+            .fill(Color.primary)
+            .frame(width: 2, height: 16)
+            .opacity(isVisible ? 1.0 : 0.0)
+            .animation(.easeInOut(duration: 0.5).repeatForever(autoreverses: true), value: isVisible)
+            .onAppear { isVisible = false }
+            .accessibilityHidden(true)
+    }
+}

--- a/Sources/BaseChatUI/Views/Chat/TypingIndicatorView.swift
+++ b/Sources/BaseChatUI/Views/Chat/TypingIndicatorView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// Animated typing indicator shown while waiting for the first token from the backend.
+public struct TypingIndicatorView: View {
+    @State private var animationPhase: Int = 0
+
+    public init() {}
+
+    public var body: some View {
+        HStack(spacing: 4) {
+            ForEach(0..<3, id: \.self) { index in
+                Circle()
+                    .fill(Color.secondary)
+                    .frame(width: 8, height: 8)
+                    .scaleEffect(animationPhase == index ? 1.3 : 0.7)
+                    .opacity(animationPhase == index ? 1.0 : 0.4)
+                    .animation(.easeInOut(duration: 0.4), value: animationPhase)
+            }
+        }
+        .onAppear {
+            Timer.scheduledTimer(withTimeInterval: 0.4, repeats: true) { _ in
+                animationPhase = (animationPhase + 1) % 3
+            }
+        }
+        .accessibilityLabel("Generating response")
+    }
+}

--- a/Tests/BaseChatUITests/BackendActivityPhaseTests.swift
+++ b/Tests/BaseChatUITests/BackendActivityPhaseTests.swift
@@ -1,0 +1,179 @@
+import XCTest
+@testable import BaseChatUI
+import BaseChatCore
+import BaseChatTestSupport
+
+@MainActor
+final class BackendActivityPhaseTests: XCTestCase {
+
+    private let oneGB: UInt64 = 1_024 * 1_024 * 1_024
+
+    private func makeViewModelWithMock(
+        mock: MockInferenceBackend = MockInferenceBackend()
+    ) -> (ChatViewModel, MockInferenceBackend) {
+        mock.isModelLoaded = true
+        let service = InferenceService(backend: mock, name: "Mock")
+        let vm = ChatViewModel(
+            inferenceService: service,
+            deviceCapability: DeviceCapabilityService(physicalMemory: 16 * oneGB),
+            modelStorage: ModelStorageService(),
+            memoryPressure: MemoryPressureHandler()
+        )
+        vm.activeSession = ChatSessionRecord(title: "Test")
+        return (vm, mock)
+    }
+
+    private func makeViewModelWithSlowMock(
+        tokenCount: Int = 5,
+        delayMilliseconds: Int = 20
+    ) -> (ChatViewModel, SlowMockBackend) {
+        let mock = SlowMockBackend(tokenCount: tokenCount, delayMilliseconds: delayMilliseconds)
+        let service = InferenceService(backend: mock, name: "SlowMock")
+        let vm = ChatViewModel(
+            inferenceService: service,
+            deviceCapability: DeviceCapabilityService(physicalMemory: 16 * oneGB),
+            modelStorage: ModelStorageService(),
+            memoryPressure: MemoryPressureHandler()
+        )
+        vm.activeSession = ChatSessionRecord(title: "Test")
+        return (vm, mock)
+    }
+
+    // MARK: - Initial State
+
+    func testInitialPhaseIsIdle() {
+        let vm = ChatViewModel()
+        XCTAssertEqual(vm.activityPhase, .idle)
+    }
+
+    // MARK: - Backward Compatibility
+
+    func testIsLoadingDerivedFromModelLoadingPhase() {
+        let vm = ChatViewModel()
+        XCTAssertFalse(vm.isLoading)
+
+        vm.activityPhase = .modelLoading(progress: nil)
+        XCTAssertTrue(vm.isLoading)
+
+        vm.activityPhase = .modelLoading(progress: 0.5)
+        XCTAssertTrue(vm.isLoading)
+
+        vm.activityPhase = .idle
+        XCTAssertFalse(vm.isLoading)
+    }
+
+    func testIsGeneratingDerivedFromStreamingPhases() {
+        let vm = ChatViewModel()
+        XCTAssertFalse(vm.isGenerating)
+
+        vm.activityPhase = .waitingForFirstToken
+        XCTAssertTrue(vm.isGenerating)
+
+        vm.activityPhase = .streaming
+        XCTAssertTrue(vm.isGenerating)
+
+        vm.activityPhase = .idle
+        XCTAssertFalse(vm.isGenerating)
+    }
+
+    func testIsLoadingFalseWhenGenerating() {
+        let vm = ChatViewModel()
+        vm.activityPhase = .streaming
+        XCTAssertFalse(vm.isLoading)
+        XCTAssertTrue(vm.isGenerating)
+    }
+
+    func testIsGeneratingFalseWhenLoading() {
+        let vm = ChatViewModel()
+        vm.activityPhase = .modelLoading(progress: 0.3)
+        XCTAssertTrue(vm.isLoading)
+        XCTAssertFalse(vm.isGenerating)
+    }
+
+    // MARK: - onGeneratingChanged Hook
+
+    func testOnGeneratingChangedFiringOnPhaseTransitions() {
+        let vm = ChatViewModel()
+        var observations: [Bool] = []
+        vm.onGeneratingChanged = { observations.append($0) }
+
+        vm.activityPhase = .waitingForFirstToken
+        vm.activityPhase = .streaming
+        vm.activityPhase = .idle
+
+        // waitingForFirstToken: generating becomes true
+        // streaming: generating stays true -- no fire
+        // idle: generating becomes false
+        XCTAssertEqual(observations, [true, false])
+    }
+
+    // MARK: - Phase Transitions During Generation
+
+    func testPhaseTransitionsDuringGeneration() async {
+        let (vm, _) = makeViewModelWithSlowMock(tokenCount: 3, delayMilliseconds: 30)
+
+        XCTAssertEqual(vm.activityPhase, .idle)
+
+        vm.inputText = "Hello"
+        let sendTask = Task { await vm.sendMessage() }
+
+        // Wait for generation to start
+        await vm.awaitGenerating(true)
+        // Phase should be waitingForFirstToken or streaming (depending on timing)
+        XCTAssertTrue(vm.isGenerating)
+
+        // Wait for first token to arrive, which transitions to .streaming
+        await vm.awaitFirstToken()
+        XCTAssertEqual(vm.activityPhase, .streaming)
+
+        // Let generation finish
+        await sendTask.value
+        XCTAssertEqual(vm.activityPhase, .idle)
+    }
+
+    // MARK: - Stop Generation Resets Phase
+
+    func testStopGenerationResetsToIdle() async {
+        let (vm, _) = makeViewModelWithSlowMock(tokenCount: 20, delayMilliseconds: 50)
+
+        vm.inputText = "Hello"
+        let sendTask = Task { await vm.sendMessage() }
+        await vm.awaitGenerating(true)
+        await vm.awaitFirstToken()
+        XCTAssertEqual(vm.activityPhase, .streaming)
+
+        vm.stopGeneration()
+        XCTAssertEqual(vm.activityPhase, .idle)
+
+        await sendTask.value
+    }
+
+    // MARK: - Fast Generation (instant tokens)
+
+    func testFastGenerationTransitionsToIdleWhenDone() async {
+        let (vm, _) = makeViewModelWithMock()
+
+        vm.inputText = "Hi"
+        await vm.sendMessage()
+
+        XCTAssertEqual(vm.activityPhase, .idle)
+        XCTAssertFalse(vm.isGenerating)
+    }
+
+    // MARK: - Equatable
+
+    func testBackendActivityPhaseEquality() {
+        XCTAssertEqual(BackendActivityPhase.idle, BackendActivityPhase.idle)
+        XCTAssertEqual(BackendActivityPhase.streaming, BackendActivityPhase.streaming)
+        XCTAssertEqual(BackendActivityPhase.waitingForFirstToken, BackendActivityPhase.waitingForFirstToken)
+        XCTAssertEqual(
+            BackendActivityPhase.modelLoading(progress: 0.5),
+            BackendActivityPhase.modelLoading(progress: 0.5)
+        )
+        XCTAssertNotEqual(
+            BackendActivityPhase.modelLoading(progress: 0.5),
+            BackendActivityPhase.modelLoading(progress: 0.7)
+        )
+        XCTAssertNotEqual(BackendActivityPhase.idle, BackendActivityPhase.streaming)
+    }
+}

--- a/Tests/BaseChatUITests/TypingIndicatorViewTests.swift
+++ b/Tests/BaseChatUITests/TypingIndicatorViewTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+import SwiftUI
+@testable import BaseChatUI
+
+final class TypingIndicatorViewTests: XCTestCase {
+
+    func testTypingIndicatorViewInitializes() {
+        // Verify the view can be constructed without crashing.
+        let view = TypingIndicatorView()
+        XCTAssertNotNil(view)
+    }
+
+    func testStreamingCursorViewInitializes() {
+        let view = StreamingCursorView()
+        XCTAssertNotNil(view)
+    }
+
+    func testModelLoadingIndicatorViewInitializesWithoutProgress() {
+        let view = ModelLoadingIndicatorView()
+        XCTAssertNil(view.progress)
+    }
+
+    func testModelLoadingIndicatorViewInitializesWithProgress() {
+        let view = ModelLoadingIndicatorView(progress: 0.75)
+        XCTAssertEqual(view.progress, 0.75)
+    }
+
+    func testDefaultActivityIndicatorStyleInitializes() {
+        let style = DefaultActivityIndicatorStyle()
+        // Verify the style can produce all three indicator views without crashing.
+        _ = style.makeTypingIndicator()
+        _ = style.makeStreamingCursor()
+        _ = style.makeLoadingIndicator(progress: nil)
+        _ = style.makeLoadingIndicator(progress: 0.5)
+    }
+}


### PR DESCRIPTION
## Summary
- Introduces `BackendActivityPhase` enum in BaseChatCore replacing boolean `isLoading`/`isGenerating` with a state machine: `idle` → `modelLoading(progress:)` → `waitingForFirstToken` → `streaming` → `idle`
- Adds three new indicator views: `TypingIndicatorView` (bouncing dots), `StreamingCursorView` (pulsing cursor), `ModelLoadingIndicatorView` (progress bar with label)
- Adds `ActivityIndicatorStyle` protocol and `DefaultActivityIndicatorStyle` for custom indicator overrides
- `isLoading` and `isGenerating` remain as backward-compatible computed properties derived from `activityPhase`

Closes #21

## Test plan
- [x] All 271 existing BaseChatUITests pass (no regressions)
- [x] All 64 BaseChatCoreTests pass
- [x] New `BackendActivityPhaseTests`: verifies phase transitions during generation, backward compatibility of computed properties, `onGeneratingChanged` hook firing, stop generation reset
- [x] New `TypingIndicatorViewTests`: verifies all indicator views initialize correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)