### PR TITLE
feat: add pre-load memory gate to prevent OOM crashes

### DIFF
--- a/Sources/BaseChatBackends/ClaudeBackend.swift
+++ b/Sources/BaseChatBackends/ClaudeBackend.swift
@@ -44,7 +44,8 @@ public final class ClaudeBackend: InferenceBackend, ConversationHistoryReceiver,
             supportsToolCalling: true,
             supportsStructuredOutput: true,
             cancellationStyle: .cooperative,
-            supportsTokenCounting: false
+            supportsTokenCounting: false,
+            memoryStrategy: .external
         )
     }
 

--- a/Sources/BaseChatBackends/FoundationBackend.swift
+++ b/Sources/BaseChatBackends/FoundationBackend.swift
@@ -42,7 +42,8 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
         supportsToolCalling: false,
         supportsStructuredOutput: false,
         cancellationStyle: .cooperative,
-        supportsTokenCounting: false
+        supportsTokenCounting: false,
+        memoryStrategy: .external
     )
 
     // MARK: - Private

--- a/Sources/BaseChatBackends/KoboldCppBackend.swift
+++ b/Sources/BaseChatBackends/KoboldCppBackend.swift
@@ -65,7 +65,12 @@ public final class KoboldCppBackend: InferenceBackend, ConversationHistoryReceiv
             supportedParameters: [.temperature, .topP, .topK, .typicalP, .repeatPenalty],
             maxContextTokens: maxContextLength,
             requiresPromptTemplate: true,
-            supportsSystemPrompt: false
+            supportsSystemPrompt: false,
+            supportsToolCalling: false,
+            supportsStructuredOutput: false,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: false,
+            memoryStrategy: .external
         )
     }
 

--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -46,7 +46,8 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         supportsToolCalling: false,
         supportsStructuredOutput: false,
         cancellationStyle: .explicit,
-        supportsTokenCounting: true
+        supportsTokenCounting: true,
+        memoryStrategy: .mappable
     )
 
     // MARK: - Private

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -37,7 +37,8 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         supportsToolCalling: false,
         supportsStructuredOutput: false,
         cancellationStyle: .cooperative,
-        supportsTokenCounting: true
+        supportsTokenCounting: true,
+        memoryStrategy: .resident
     )
 
     // MARK: - Private

--- a/Sources/BaseChatBackends/OpenAIBackend.swift
+++ b/Sources/BaseChatBackends/OpenAIBackend.swift
@@ -63,7 +63,8 @@ public final class OpenAIBackend: InferenceBackend, ConversationHistoryReceiver,
             supportsToolCalling: true,
             supportsStructuredOutput: true,
             cancellationStyle: .cooperative,
-            supportsTokenCounting: false
+            supportsTokenCounting: false,
+            memoryStrategy: .external
         )
     }
 

--- a/Sources/BaseChatCore/Protocols/BackendCapabilities.swift
+++ b/Sources/BaseChatCore/Protocols/BackendCapabilities.swift
@@ -9,6 +9,16 @@ public enum GenerationParameter: String, CaseIterable, Sendable {
     case typicalP
 }
 
+/// How the backend loads model weights into memory.
+public enum MemoryStrategy: Sendable, Equatable {
+    /// Model must be fully resident in RAM (e.g., MLX on unified memory).
+    case resident
+    /// Model is memory-mapped; only active pages + KV cache need RAM (e.g., llama.cpp).
+    case mappable
+    /// No local model memory needed (cloud APIs, OS-managed models).
+    case external
+}
+
 /// How the backend responds to a cancellation request.
 public enum CancellationStyle: Sendable, Equatable {
     /// Cancels via Swift task cancellation.
@@ -48,6 +58,9 @@ public struct BackendCapabilities: Sendable {
     /// Whether the backend can count tokens locally before sending a request.
     public let supportsTokenCounting: Bool
 
+    /// How the backend loads model weights into memory.
+    public let memoryStrategy: MemoryStrategy
+
     /// Parameters the UI should present controls for.
     public var visibleParameters: [GenerationParameter] {
         GenerationParameter.allCases.filter { supportedParameters.contains($0) }
@@ -67,6 +80,7 @@ public struct BackendCapabilities: Sendable {
         self.supportsStructuredOutput = false
         self.cancellationStyle = .cooperative
         self.supportsTokenCounting = false
+        self.memoryStrategy = .resident
     }
 
     public init(
@@ -77,7 +91,8 @@ public struct BackendCapabilities: Sendable {
         supportsToolCalling: Bool,
         supportsStructuredOutput: Bool,
         cancellationStyle: CancellationStyle,
-        supportsTokenCounting: Bool
+        supportsTokenCounting: Bool,
+        memoryStrategy: MemoryStrategy = .resident
     ) {
         self.supportedParameters = supportedParameters
         self.maxContextTokens = maxContextTokens
@@ -87,5 +102,6 @@ public struct BackendCapabilities: Sendable {
         self.supportsStructuredOutput = supportsStructuredOutput
         self.cancellationStyle = cancellationStyle
         self.supportsTokenCounting = supportsTokenCounting
+        self.memoryStrategy = memoryStrategy
     }
 }

--- a/Sources/BaseChatCore/Services/InferenceService.swift
+++ b/Sources/BaseChatCore/Services/InferenceService.swift
@@ -41,6 +41,12 @@ public final class InferenceService {
         backend?.capabilities
     }
 
+    // MARK: - Memory Gate
+
+    /// Optional pre-flight memory check. When set, `loadModel()` checks available
+    /// memory before loading and either throws (iOS) or warns (macOS) if insufficient.
+    public var memoryGate: MemoryGate?
+
     // MARK: - Backend Registry
 
     private var backendFactories: [BackendFactory] = []
@@ -79,6 +85,34 @@ public final class InferenceService {
                 + "Register a BackendFactory before loading models."
             )
         }
+
+        // Pre-flight memory check
+        if let gate = memoryGate {
+            let verdict = gate.check(
+                modelFileSize: modelInfo.fileSize,
+                strategy: newBackend.capabilities.memoryStrategy
+            )
+            switch verdict {
+            case .allow:
+                break
+            case .warn(let estimated, let available):
+                let estMB = estimated / 1_048_576
+                let availMB = available / 1_048_576
+                Log.inference.warning("Memory warning: model needs ~\(estMB) MB, \(availMB) MB available")
+            case .deny(let estimated, let available):
+                switch gate.denyBehavior {
+                case .throwError:
+                    throw InferenceError.memoryInsufficient(
+                        required: estimated, available: available
+                    )
+                case .warnOnly:
+                    let estMB = estimated / 1_048_576
+                    let availMB = available / 1_048_576
+                    Log.inference.warning("Memory insufficient: model needs ~\(estMB) MB, \(availMB) MB available. Proceeding (may swap).")
+                }
+            }
+        }
+
         try await newBackend.loadModel(from: modelInfo.url, contextSize: contextSize)
 
         backend = newBackend

--- a/Sources/BaseChatCore/Services/MemoryGate.swift
+++ b/Sources/BaseChatCore/Services/MemoryGate.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// Pre-flight memory check before loading a model.
+///
+/// Estimates whether the device has enough available memory to load a model
+/// based on the backend's memory strategy and the model's file size.
+public struct MemoryGate: Sendable {
+
+    /// Closure that returns the available memory budget in bytes.
+    /// Injectable for testing.
+    public let availableMemoryBytes: @Sendable () -> UInt64
+
+    /// Total physical memory, for heuristic fallback.
+    public let physicalMemoryBytes: UInt64
+
+    /// Controls whether a deny verdict throws an error or just logs a warning.
+    public let denyBehavior: DenyBehavior
+
+    public enum DenyBehavior: Sendable, Equatable {
+        case throwError
+        case warnOnly
+    }
+
+    public init(
+        availableMemoryBytes: @escaping @Sendable () -> UInt64,
+        physicalMemoryBytes: UInt64,
+        denyBehavior: DenyBehavior = .warnOnly
+    ) {
+        self.availableMemoryBytes = availableMemoryBytes
+        self.physicalMemoryBytes = physicalMemoryBytes
+        self.denyBehavior = denyBehavior
+    }
+
+    /// Creates a gate using real system values.
+    public init() {
+        self.physicalMemoryBytes = ProcessInfo.processInfo.physicalMemory
+        self.availableMemoryBytes = { Self.systemAvailableMemory() }
+        #if os(iOS)
+        self.denyBehavior = .throwError
+        #else
+        self.denyBehavior = .warnOnly
+        #endif
+    }
+
+    /// Result of a pre-load memory check.
+    public enum Verdict: Sendable, Equatable {
+        /// Safe to proceed.
+        case allow
+        /// Possible but risky -- model may cause swapping or pressure.
+        case warn(estimatedBytes: UInt64, availableBytes: UInt64)
+        /// Insufficient memory -- loading will likely crash (iOS) or severely degrade (macOS).
+        case deny(estimatedBytes: UInt64, availableBytes: UInt64)
+    }
+
+    /// Checks whether a model of the given file size can be loaded with the given memory strategy.
+    public func check(
+        modelFileSize: UInt64,
+        strategy: MemoryStrategy
+    ) -> Verdict {
+        switch strategy {
+        case .external:
+            return .allow
+
+        case .mappable:
+            // Only KV cache + working buffers need RAM.
+            let estimated = UInt64(Double(modelFileSize) * 0.25)
+            return evaluate(estimatedBytes: estimated)
+
+        case .resident:
+            // Full model + ~20% KV cache overhead must fit.
+            let estimated = UInt64(Double(modelFileSize) * 1.20)
+            return evaluate(estimatedBytes: estimated)
+        }
+    }
+
+    private func evaluate(estimatedBytes: UInt64) -> Verdict {
+        let available = availableMemoryBytes()
+
+        // Plenty of headroom.
+        if estimatedBytes <= UInt64(Double(available) * 0.85) {
+            return .allow
+        }
+
+        // Tight but might fit.
+        if estimatedBytes <= available {
+            return .warn(estimatedBytes: estimatedBytes, availableBytes: available)
+        }
+
+        // Won't fit.
+        return .deny(estimatedBytes: estimatedBytes, availableBytes: available)
+    }
+
+    // MARK: - System Memory Query
+
+    /// Returns an estimate of available memory in bytes.
+    ///
+    /// On iOS, uses `os_proc_available_memory()` which returns the number of bytes
+    /// the app can allocate before the system starts killing processes.
+    /// On macOS, uses Mach VM statistics (free + inactive pages) as a heuristic.
+    private static func systemAvailableMemory() -> UInt64 {
+        #if os(iOS) || os(tvOS) || os(watchOS)
+        return UInt64(os_proc_available_memory())
+        #else
+        return macAvailableMemory()
+        #endif
+    }
+
+    #if os(macOS)
+    private static func macAvailableMemory() -> UInt64 {
+        var stats = vm_statistics64_data_t()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<vm_statistics64_data_t>.size / MemoryLayout<integer_t>.size
+        )
+        let result = withUnsafeMutablePointer(to: &stats) { statsPtr in
+            statsPtr.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { ptr in
+                host_statistics64(mach_host_self(), HOST_VM_INFO64, ptr, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else {
+            // Fallback: estimate 60% of physical memory.
+            return UInt64(Double(ProcessInfo.processInfo.physicalMemory) * 0.60)
+        }
+        // vm_page_size is a mutable global; read it through sysctl to satisfy Sendable.
+        var pageSize: vm_size_t = 0
+        host_page_size(mach_host_self(), &pageSize)
+        let pageSizeU64 = UInt64(pageSize)
+        // Free + inactive pages are reclaimable without swapping.
+        let available = (UInt64(stats.free_count) + UInt64(stats.inactive_count)) * pageSizeU64
+        return available
+    }
+    #endif
+}

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -260,6 +260,8 @@ public final class ChatViewModel {
         self.modelStorage = modelStorage
         self.memoryPressure = memoryPressure
 
+        inferenceService.memoryGate = MemoryGate()
+
         let firstRunKey = "\(BaseChatConfiguration.shared.bundleIdentifier).hasCompletedFirstLaunch"
         self.isFirstRun = !UserDefaults.standard.bool(forKey: firstRunKey)
 

--- a/Tests/BaseChatBackendsTests/MemoryStrategyBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/MemoryStrategyBackendTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import BaseChatBackends
+import BaseChatCore
+
+final class MemoryStrategyBackendTests: XCTestCase {
+
+    // MARK: - Cloud Backends (no hardware needed)
+
+    func test_openAIBackend_declaresExternalStrategy() {
+        let backend = OpenAIBackend()
+        XCTAssertEqual(backend.capabilities.memoryStrategy, .external)
+    }
+
+    func test_claudeBackend_declaresExternalStrategy() {
+        let backend = ClaudeBackend()
+        XCTAssertEqual(backend.capabilities.memoryStrategy, .external)
+    }
+
+    func test_koboldCppBackend_declaresExternalStrategy() {
+        let backend = KoboldCppBackend()
+        XCTAssertEqual(backend.capabilities.memoryStrategy, .external)
+    }
+
+    // MARK: - Local Backends (hardware gated)
+
+    #if MLX
+    func test_mlxBackend_declaresResidentStrategy() {
+        let backend = MLXBackend()
+        XCTAssertEqual(backend.capabilities.memoryStrategy, .resident)
+    }
+    #endif
+
+    #if Llama
+    func test_llamaBackend_declaresMappableStrategy() throws {
+        try XCTSkipIf(true, "LlamaBackend requires global init -- tested manually on Apple Silicon")
+    }
+    #endif
+}

--- a/Tests/BaseChatCoreTests/BackendCapabilitiesTests.swift
+++ b/Tests/BaseChatCoreTests/BackendCapabilitiesTests.swift
@@ -93,6 +93,57 @@ final class BackendCapabilitiesTests: XCTestCase {
         XCTAssertTrue(caps.supportsTokenCounting)
     }
 
+    // MARK: - MemoryStrategy
+
+    func test_oldInitializer_defaultsMemoryStrategyToResident() {
+        let caps = BackendCapabilities(
+            supportedParameters: [.temperature],
+            maxContextTokens: 2048,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true
+        )
+        XCTAssertEqual(caps.memoryStrategy, .resident)
+    }
+
+    func test_fullInitializer_defaultsMemoryStrategyToResident() {
+        let caps = BackendCapabilities(
+            supportedParameters: [.temperature],
+            maxContextTokens: 2048,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsToolCalling: false,
+            supportsStructuredOutput: false,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: false
+        )
+        XCTAssertEqual(caps.memoryStrategy, .resident)
+    }
+
+    func test_fullInitializer_setsMemoryStrategy() {
+        let caps = BackendCapabilities(
+            supportedParameters: [.temperature],
+            maxContextTokens: 2048,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsToolCalling: false,
+            supportsStructuredOutput: false,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: false,
+            memoryStrategy: .external
+        )
+        XCTAssertEqual(caps.memoryStrategy, .external)
+    }
+
+    func test_memoryStrategy_allCasesAreDistinct() {
+        let resident = MemoryStrategy.resident
+        let mappable = MemoryStrategy.mappable
+        let external = MemoryStrategy.external
+
+        XCTAssertNotEqual(resident, mappable)
+        XCTAssertNotEqual(resident, external)
+        XCTAssertNotEqual(mappable, external)
+    }
+
     // MARK: - CancellationStyle
 
     func test_cancellationStyle_cooperativeAndExplicitAreDistinct() {

--- a/Tests/BaseChatCoreTests/MemoryGateInferenceServiceTests.swift
+++ b/Tests/BaseChatCoreTests/MemoryGateInferenceServiceTests.swift
@@ -1,0 +1,174 @@
+import XCTest
+@testable import BaseChatCore
+import BaseChatTestSupport
+
+final class MemoryGateInferenceServiceTests: XCTestCase {
+
+    // MARK: - Deny + throwError throws memoryInsufficient
+
+    @MainActor
+    func test_denyWithThrowError_throwsMemoryInsufficient() async {
+        let service = InferenceService()
+        service.registerBackendFactory { modelType in
+            let caps = BackendCapabilities(
+                supportedParameters: [.temperature],
+                maxContextTokens: 2048,
+                requiresPromptTemplate: false,
+                supportsSystemPrompt: true,
+                supportsToolCalling: false,
+                supportsStructuredOutput: false,
+                cancellationStyle: .cooperative,
+                supportsTokenCounting: false,
+                memoryStrategy: .resident
+            )
+            return MockInferenceBackend(capabilities: caps)
+        }
+
+        // Gate with very little available memory and throwError behavior.
+        service.memoryGate = MemoryGate(
+            availableMemoryBytes: { 500_000_000 },  // 500 MB
+            physicalMemoryBytes: 8_000_000_000,
+            denyBehavior: .throwError
+        )
+
+        let modelInfo = ModelInfo(
+            name: "test-model",
+            fileName: "fake.gguf",
+            url: URL(fileURLWithPath: "/tmp/fake.gguf"),
+            fileSize: 4_000_000_000,  // 4 GB -> 4.8 GB estimated, way over 500 MB
+            modelType: .gguf
+        )
+
+        do {
+            try await service.loadModel(from: modelInfo, contextSize: 2048)
+            XCTFail("Expected memoryInsufficient error")
+        } catch let error as InferenceError {
+            if case .memoryInsufficient(let required, let available) = error {
+                XCTAssertEqual(required, 4_800_000_000)
+                XCTAssertEqual(available, 500_000_000)
+            } else {
+                XCTFail("Expected memoryInsufficient, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    // MARK: - Deny + warnOnly proceeds without error
+
+    @MainActor
+    func test_denyWithWarnOnly_proceedsWithoutError() async throws {
+        let service = InferenceService()
+        service.registerBackendFactory { _ in
+            MockInferenceBackend()
+        }
+
+        service.memoryGate = MemoryGate(
+            availableMemoryBytes: { 500_000_000 },
+            physicalMemoryBytes: 8_000_000_000,
+            denyBehavior: .warnOnly
+        )
+
+        let modelInfo = ModelInfo(
+            name: "test-model",
+            fileName: "fake.gguf",
+            url: URL(fileURLWithPath: "/tmp/fake.gguf"),
+            fileSize: 4_000_000_000,
+            modelType: .gguf
+        )
+
+        // Should not throw -- warnOnly logs but proceeds.
+        try await service.loadModel(from: modelInfo, contextSize: 2048)
+        XCTAssertTrue(service.isModelLoaded)
+    }
+
+    // MARK: - External strategy skips check entirely
+
+    @MainActor
+    func test_externalStrategy_skipsMemoryCheck() async throws {
+        let service = InferenceService()
+        service.registerBackendFactory { _ in
+            let caps = BackendCapabilities(
+                supportedParameters: [.temperature],
+                maxContextTokens: 2048,
+                requiresPromptTemplate: false,
+                supportsSystemPrompt: true,
+                supportsToolCalling: false,
+                supportsStructuredOutput: false,
+                cancellationStyle: .cooperative,
+                supportsTokenCounting: false,
+                memoryStrategy: .external
+            )
+            return MockInferenceBackend(capabilities: caps)
+        }
+
+        // Even with throwError + tiny memory, external should always allow.
+        service.memoryGate = MemoryGate(
+            availableMemoryBytes: { 1024 },
+            physicalMemoryBytes: 1024,
+            denyBehavior: .throwError
+        )
+
+        let modelInfo = ModelInfo(
+            name: "test-model",
+            fileName: "fake.gguf",
+            url: URL(fileURLWithPath: "/tmp/fake.gguf"),
+            fileSize: 999_999_999_999,
+            modelType: .gguf
+        )
+
+        try await service.loadModel(from: modelInfo, contextSize: 2048)
+        XCTAssertTrue(service.isModelLoaded)
+    }
+
+    // MARK: - No gate set (backward compatibility)
+
+    @MainActor
+    func test_noGateSet_proceedsNormally() async throws {
+        let service = InferenceService()
+        service.registerBackendFactory { _ in
+            MockInferenceBackend()
+        }
+
+        // No memoryGate set -- should proceed without any check.
+        XCTAssertNil(service.memoryGate)
+
+        let modelInfo = ModelInfo(
+            name: "test-model",
+            fileName: "fake.gguf",
+            url: URL(fileURLWithPath: "/tmp/fake.gguf"),
+            fileSize: 4_000_000_000,
+            modelType: .gguf
+        )
+
+        try await service.loadModel(from: modelInfo, contextSize: 2048)
+        XCTAssertTrue(service.isModelLoaded)
+    }
+
+    // MARK: - Allow verdict proceeds
+
+    @MainActor
+    func test_allowVerdict_proceedsNormally() async throws {
+        let service = InferenceService()
+        service.registerBackendFactory { _ in
+            MockInferenceBackend()
+        }
+
+        service.memoryGate = MemoryGate(
+            availableMemoryBytes: { 16_000_000_000 },
+            physicalMemoryBytes: 32_000_000_000,
+            denyBehavior: .throwError
+        )
+
+        let modelInfo = ModelInfo(
+            name: "small-model",
+            fileName: "fake.gguf",
+            url: URL(fileURLWithPath: "/tmp/fake.gguf"),
+            fileSize: 1_000_000_000,  // 1 GB -> 1.2 GB estimated, fits in 16 GB
+            modelType: .gguf
+        )
+
+        try await service.loadModel(from: modelInfo, contextSize: 2048)
+        XCTAssertTrue(service.isModelLoaded)
+    }
+}

--- a/Tests/BaseChatCoreTests/MemoryGateTests.swift
+++ b/Tests/BaseChatCoreTests/MemoryGateTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+@testable import BaseChatCore
+
+final class MemoryGateTests: XCTestCase {
+
+    // MARK: - External Strategy
+
+    func test_externalStrategy_alwaysAllows() {
+        let gate = MemoryGate(
+            availableMemoryBytes: { 1024 },
+            physicalMemoryBytes: 1024
+        )
+        let verdict = gate.check(modelFileSize: 999_999_999_999, strategy: .external)
+        XCTAssertEqual(verdict, .allow)
+    }
+
+    // MARK: - Resident Strategy
+
+    func test_residentStrategy_allowsWhenPlentyOfMemory() {
+        // 4 GB model, 1.2x = 4.8 GB estimated. 8 GB available. 4.8 < 8*0.85=6.8 -> allow
+        let gate = MemoryGate(
+            availableMemoryBytes: { 8_000_000_000 },
+            physicalMemoryBytes: 16_000_000_000
+        )
+        let verdict = gate.check(modelFileSize: 4_000_000_000, strategy: .resident)
+        XCTAssertEqual(verdict, .allow)
+    }
+
+    func test_residentStrategy_warnsWhenTight() {
+        // 4 GB model, 1.2x = 4.8 GB estimated. 5 GB available. 4.8 > 5*0.85=4.25 but 4.8 < 5 -> warn
+        let gate = MemoryGate(
+            availableMemoryBytes: { 5_000_000_000 },
+            physicalMemoryBytes: 16_000_000_000
+        )
+        let verdict = gate.check(modelFileSize: 4_000_000_000, strategy: .resident)
+        if case .warn(let est, let avail) = verdict {
+            XCTAssertEqual(est, 4_800_000_000)
+            XCTAssertEqual(avail, 5_000_000_000)
+        } else {
+            XCTFail("Expected .warn, got \(verdict)")
+        }
+    }
+
+    func test_residentStrategy_deniesWhenInsufficient() {
+        // 4 GB model, 1.2x = 4.8 GB estimated. 3 GB available. 4.8 > 3 -> deny
+        let gate = MemoryGate(
+            availableMemoryBytes: { 3_000_000_000 },
+            physicalMemoryBytes: 8_000_000_000
+        )
+        let verdict = gate.check(modelFileSize: 4_000_000_000, strategy: .resident)
+        if case .deny(let est, let avail) = verdict {
+            XCTAssertEqual(est, 4_800_000_000)
+            XCTAssertEqual(avail, 3_000_000_000)
+        } else {
+            XCTFail("Expected .deny, got \(verdict)")
+        }
+    }
+
+    // MARK: - Mappable Strategy
+
+    func test_mappableStrategy_usesReducedEstimate() {
+        // 4 GB model, 0.25x = 1 GB estimated for KV cache. 2 GB available. 1 < 2*0.85=1.7 -> allow
+        let gate = MemoryGate(
+            availableMemoryBytes: { 2_000_000_000 },
+            physicalMemoryBytes: 8_000_000_000
+        )
+        let verdict = gate.check(modelFileSize: 4_000_000_000, strategy: .mappable)
+        XCTAssertEqual(verdict, .allow)
+    }
+
+    func test_mappableStrategy_deniesWhenKVCacheWontFit() {
+        // 16 GB model, 0.25x = 4 GB estimated. 2 GB available -> deny
+        let gate = MemoryGate(
+            availableMemoryBytes: { 2_000_000_000 },
+            physicalMemoryBytes: 8_000_000_000
+        )
+        let verdict = gate.check(modelFileSize: 16_000_000_000, strategy: .mappable)
+        if case .deny = verdict {
+            // pass
+        } else {
+            XCTFail("Expected .deny, got \(verdict)")
+        }
+    }
+
+    func test_mappableStrategy_warnsWhenTight() {
+        // 16 GB model, 0.25x = 4 GB estimated. 4.5 GB available. 4 > 4.5*0.85=3.825 but 4 < 4.5 -> warn
+        let gate = MemoryGate(
+            availableMemoryBytes: { 4_500_000_000 },
+            physicalMemoryBytes: 16_000_000_000
+        )
+        let verdict = gate.check(modelFileSize: 16_000_000_000, strategy: .mappable)
+        if case .warn(let est, let avail) = verdict {
+            XCTAssertEqual(est, 4_000_000_000)
+            XCTAssertEqual(avail, 4_500_000_000)
+        } else {
+            XCTFail("Expected .warn, got \(verdict)")
+        }
+    }
+
+    // MARK: - Zero Size
+
+    func test_zeroSizeModel_alwaysAllows() {
+        let gate = MemoryGate(
+            availableMemoryBytes: { 1024 },
+            physicalMemoryBytes: 1024
+        )
+        XCTAssertEqual(gate.check(modelFileSize: 0, strategy: .resident), .allow)
+        XCTAssertEqual(gate.check(modelFileSize: 0, strategy: .mappable), .allow)
+        XCTAssertEqual(gate.check(modelFileSize: 0, strategy: .external), .allow)
+    }
+
+    // MARK: - Deny Behavior
+
+    func test_denyBehavior_defaultsToWarnOnly() {
+        let gate = MemoryGate(
+            availableMemoryBytes: { 1024 },
+            physicalMemoryBytes: 1024
+        )
+        XCTAssertEqual(gate.denyBehavior, .warnOnly)
+    }
+
+    func test_denyBehavior_canBeSetToThrowError() {
+        let gate = MemoryGate(
+            availableMemoryBytes: { 1024 },
+            physicalMemoryBytes: 1024,
+            denyBehavior: .throwError
+        )
+        XCTAssertEqual(gate.denyBehavior, .throwError)
+    }
+
+    // MARK: - Boundary: Exact Fit
+
+    func test_residentStrategy_exactFitIsWarn() {
+        // 1 GB model, 1.2x = 1.2 GB estimated. 1.2 GB available. 1.2 == 1.2 -> warn (not allow, since 1.2 > 1.2*0.85)
+        let estimated: UInt64 = 1_200_000_000
+        let gate = MemoryGate(
+            availableMemoryBytes: { estimated },
+            physicalMemoryBytes: 4_000_000_000
+        )
+        let verdict = gate.check(modelFileSize: 1_000_000_000, strategy: .resident)
+        if case .warn = verdict {
+            // pass -- exact fit is a warning because there's no headroom
+        } else {
+            XCTFail("Expected .warn for exact fit, got \(verdict)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `MemoryStrategy` enum (`.resident`, `.mappable`, `.external`) to `BackendCapabilities` so each backend declares how it loads model weights into memory
- Creates `MemoryGate` in BaseChatCore that checks `os_proc_available_memory()` (iOS) or Mach VM stats (macOS) before loading, returning allow/warn/deny verdicts
- Wires the gate into `InferenceService.loadModel()` — throws `InferenceError.memoryInsufficient` on iOS deny, logs a warning on macOS
- Updates all six backends: MLX (`.resident`), llama.cpp (`.mappable`), Foundation/OpenAI/Claude/KoboldCpp (`.external`)
- `ChatViewModel` auto-installs a `MemoryGate()` on init; existing code without a gate continues to work (backward compatible)

## Test plan

- [x] `MemoryGateTests` — 11 tests covering all three strategies, boundary conditions, zero-size models, deny behavior
- [x] `MemoryGateInferenceServiceTests` — 5 integration tests: deny+throw, deny+warnOnly, external skip, no-gate backward compat, allow proceeds
- [x] `BackendCapabilitiesTests` — 4 new tests for `MemoryStrategy` defaults and init wiring
- [x] `MemoryStrategyBackendTests` — verifies cloud backends declare `.external` (MLX/Llama gated by `#if`)
- [x] All existing tests pass (449 XCTest + 64 Swift Testing in Core, 270 UI, 25 Backends)

🤖 Generated with [Claude Code](https://claude.com/claude-code)