### PR TITLE
feat: add curated model presets to management sheet

### DIFF
--- a/Sources/BaseChatUI/ViewModels/ModelManagementViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ModelManagementViewModel.swift
@@ -146,17 +146,18 @@ public final class ModelManagementViewModel {
 
     // MARK: - Recommendations
 
-    /// Loads curated model recommendations for this device's capability tier.
-    public func loadRecommendations() {
-        guard let service = huggingFaceService else {
-            // No service wired yet — fall back to showing curated models directly.
-            recommendedModels = CuratedModel.all
-                .filter { $0.recommendedFor.contains(recommendation) }
-                .map { DownloadableModel(from: $0) }
-            return
+    /// Loads curated model recommendations for this device's capability tier,
+    /// or a caller-supplied curated preset when specific model IDs are preferred.
+    public func loadRecommendations(preferredModelIDs: Set<String>? = nil) {
+        let curatedModels: [CuratedModel]
+
+        if let preferredModelIDs, !preferredModelIDs.isEmpty {
+            curatedModels = CuratedModel.all.filter { preferredModelIDs.contains($0.id) }
+        } else {
+            curatedModels = CuratedModel.all.filter { $0.recommendedFor.contains(recommendation) }
         }
 
-        recommendedModels = service.curatedModels(for: recommendation)
+        recommendedModels = curatedModels.map { DownloadableModel(from: $0) }
     }
 
     // MARK: - Search

--- a/Sources/BaseChatUI/Views/Models/ModelManagementSheet.swift
+++ b/Sources/BaseChatUI/Views/Models/ModelManagementSheet.swift
@@ -14,6 +14,10 @@ public struct ModelManagementSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     private var features: BaseChatConfiguration.Features { BaseChatConfiguration.shared.features }
+    private let initialTab: Tab
+    private let recommendedModelIDs: Set<String>?
+    private let recommendationTitle: String?
+    private let recommendationMessage: String?
 
     public enum Tab: String, CaseIterable {
         case select = "Select"
@@ -37,9 +41,20 @@ public struct ModelManagementSheet: View {
         return tabs
     }
 
-    @State private var selectedTab: Tab = .select
+    @State private var selectedTab: Tab
 
-    public init() {}
+    public init(
+        initialTab: Tab = .select,
+        recommendedModelIDs: Set<String>? = nil,
+        recommendationTitle: String? = nil,
+        recommendationMessage: String? = nil
+    ) {
+        self.initialTab = initialTab
+        self.recommendedModelIDs = recommendedModelIDs
+        self.recommendationTitle = recommendationTitle
+        self.recommendationMessage = recommendationMessage
+        _selectedTab = State(initialValue: initialTab)
+    }
 
     public var body: some View {
         NavigationStack {
@@ -72,6 +87,11 @@ public struct ModelManagementSheet: View {
         }
         .presentationDetents([.large])
         .onAppear {
+            if !availableTabs.contains(selectedTab) {
+                selectedTab = .select
+            } else if selectedTab != initialTab {
+                selectedTab = initialTab
+            }
             chatViewModel.refreshModels()
             managementViewModel.invalidateModelCache()
         }
@@ -115,7 +135,11 @@ public struct ModelManagementSheet: View {
         case .select:
             ModelSelectTab(onSelect: { dismiss() })
         case .download:
-            ModelDownloadTab()
+            ModelDownloadTab(
+                recommendedModelIDs: recommendedModelIDs,
+                recommendationTitle: recommendationTitle,
+                recommendationMessage: recommendationMessage
+            )
         case .storage:
             ModelStorageTab()
         }
@@ -249,6 +273,10 @@ private struct ModelDownloadTab: View {
     @Environment(ModelManagementViewModel.self) private var viewModel
     @Environment(ChatViewModel.self) private var chatViewModel
 
+    let recommendedModelIDs: Set<String>?
+    let recommendationTitle: String?
+    let recommendationMessage: String?
+
     @State private var showImporter = false
     @State private var importSuccessMessage: String?
     @State private var importErrorMessage: String?
@@ -307,6 +335,20 @@ private struct ModelDownloadTab: View {
                     Label(message, systemImage: "checkmark.circle.fill")
                         .foregroundStyle(.green)
                         .accessibilityLabel(message)
+                }
+            }
+
+            if let recommendationTitle, let recommendationMessage {
+                Section {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(recommendationTitle)
+                            .font(.headline)
+
+                        Text(recommendationMessage)
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 2)
                 }
             }
 
@@ -391,7 +433,7 @@ private struct ModelDownloadTab: View {
             handleImport(result)
         }
         .onAppear {
-            viewModel.loadRecommendations()
+            viewModel.loadRecommendations(preferredModelIDs: recommendedModelIDs)
         }
     }
 


### PR DESCRIPTION
## Summary
- allow model management to open directly on a caller-selected tab
- allow apps to pass a curated subset of recommended model IDs
- allow optional recommendation title and helper copy above the curated list

## Testing
- swift test --filter OpenAICompatEndpointTests/requestFormat_containsExpectedFields
- swift test

## Notes
- this supports the Fireside first-run download flow so app-level recommendations can feel intentional without hardcoding Fireside-specific opinions into BaseChatKit