### PR TITLE
fix: persist cloud endpoint selection and loading

### DIFF
--- a/Example/BaseChatDemo/DemoContentView.swift
+++ b/Example/BaseChatDemo/DemoContentView.swift
@@ -33,6 +33,7 @@ struct DemoContentView: View {
         .onAppear {
             viewModel.configure(modelContext: modelContext)
             sessionManager.configure(modelContext: modelContext)
+            viewModel.setAvailableEndpoints(cloudEndpoints)
 
             if !skipAutoModelLoad {
                 viewModel.refreshModels()
@@ -71,17 +72,16 @@ struct DemoContentView: View {
         }
         .onChange(of: viewModel.selectedModel) {
             if viewModel.selectedModel != nil {
-                viewModel.selectedEndpoint = nil
+                Task { await viewModel.loadSelectedModel() }
             }
-            Task { await viewModel.loadSelectedModel() }
         }
         .onChange(of: viewModel.selectedEndpoint) {
-            if viewModel.selectedEndpoint != nil {
-                viewModel.selectedModel = nil
-            }
             if let endpoint = viewModel.selectedEndpoint {
                 Task { await viewModel.loadCloudEndpoint(endpoint) }
             }
+        }
+        .onChange(of: cloudEndpoints) {
+            viewModel.setAvailableEndpoints(cloudEndpoints)
         }
         .onChange(of: sessionManager.activeSession) { _, newSession in
             if let session = newSession {

--- a/Sources/BaseChatBackends/ClaudeBackend.swift
+++ b/Sources/BaseChatBackends/ClaudeBackend.swift
@@ -7,7 +7,7 @@ import BaseChatCore
 /// Streams completions from the Anthropic Messages API (`/v1/messages`).
 /// Handles Claude-specific SSE event types (`content_block_delta`, etc.)
 /// and authentication via `x-api-key` header.
-public final class ClaudeBackend: InferenceBackend, ConversationHistoryReceiver, TokenUsageProvider, @unchecked Sendable {
+public final class ClaudeBackend: InferenceBackend, ConversationHistoryReceiver, TokenUsageProvider, CloudBackendKeychainConfigurable, @unchecked Sendable {
 
     // MARK: - Logging
 

--- a/Sources/BaseChatBackends/KoboldCppBackend.swift
+++ b/Sources/BaseChatBackends/KoboldCppBackend.swift
@@ -22,7 +22,7 @@ import BaseChatCore
 /// let stream = try backend.generate(prompt: "### Instruction:\nHello\n### Response:\n", systemPrompt: nil, config: .init())
 /// for try await token in stream { print(token, terminator: "") }
 /// ```
-public final class KoboldCppBackend: InferenceBackend, ConversationHistoryReceiver, @unchecked Sendable {
+public final class KoboldCppBackend: InferenceBackend, ConversationHistoryReceiver, CloudBackendURLModelConfigurable, @unchecked Sendable {
 
     // MARK: - Logging
 

--- a/Sources/BaseChatBackends/OpenAIBackend.swift
+++ b/Sources/BaseChatBackends/OpenAIBackend.swift
@@ -19,7 +19,7 @@ import BaseChatCore
 /// let stream = try backend.generate(prompt: "Hello", systemPrompt: nil, config: .init())
 /// for try await token in stream { print(token, terminator: "") }
 /// ```
-public final class OpenAIBackend: InferenceBackend, ConversationHistoryReceiver, TokenUsageProvider, @unchecked Sendable {
+public final class OpenAIBackend: InferenceBackend, ConversationHistoryReceiver, TokenUsageProvider, CloudBackendURLModelConfigurable, CloudBackendKeychainConfigurable, @unchecked Sendable {
 
     // MARK: - Logging
 
@@ -119,6 +119,11 @@ public final class OpenAIBackend: InferenceBackend, ConversationHistoryReceiver,
         self.keychainAccount = keychainAccount
         self.ephemeralAPIKey = nil
         self.modelName = modelName
+    }
+
+    /// Configures the backend for OpenAI-compatible servers that do not require API keys.
+    public func configure(baseURL: URL, modelName: String) {
+        configure(baseURL: baseURL, apiKey: nil, modelName: modelName)
     }
 
     /// Retrieves the API key from Keychain or ephemeral storage.

--- a/Sources/BaseChatCore/Models/ChatSession.swift
+++ b/Sources/BaseChatCore/Models/ChatSession.swift
@@ -18,6 +18,9 @@ public final class ChatSession {
     /// The UUID of the selected ModelInfo for this session.
     public var selectedModelID: UUID?
 
+    /// The UUID of the selected APIEndpoint for this session.
+    public var selectedEndpointID: UUID?
+
     // Per-session generation overrides (nil = use global default)
     public var temperature: Float?
     public var topP: Float?

--- a/Sources/BaseChatCore/Protocols/ChatPersistenceProvider.swift
+++ b/Sources/BaseChatCore/Protocols/ChatPersistenceProvider.swift
@@ -28,6 +28,7 @@ public struct ChatSessionRecord: Identifiable, Hashable, Sendable {
     public var updatedAt: Date
     public var systemPrompt: String
     public var selectedModelID: UUID?
+    public var selectedEndpointID: UUID?
     public var temperature: Float?
     public var topP: Float?
     public var repeatPenalty: Float?
@@ -43,6 +44,7 @@ public struct ChatSessionRecord: Identifiable, Hashable, Sendable {
         updatedAt: Date = Date(),
         systemPrompt: String = "",
         selectedModelID: UUID? = nil,
+        selectedEndpointID: UUID? = nil,
         temperature: Float? = nil,
         topP: Float? = nil,
         repeatPenalty: Float? = nil,
@@ -57,6 +59,7 @@ public struct ChatSessionRecord: Identifiable, Hashable, Sendable {
         self.updatedAt = updatedAt
         self.systemPrompt = systemPrompt
         self.selectedModelID = selectedModelID
+        self.selectedEndpointID = selectedEndpointID
         self.temperature = temperature
         self.topP = topP
         self.repeatPenalty = repeatPenalty

--- a/Sources/BaseChatCore/Services/InferenceService.swift
+++ b/Sources/BaseChatCore/Services/InferenceService.swift
@@ -136,6 +136,30 @@ public final class InferenceService {
             )
         }
 
+        switch endpoint.provider {
+        case .claude, .openAI, .custom:
+            guard let keychainConfigurable = newBackend as? CloudBackendKeychainConfigurable else {
+                throw InferenceError.inferenceFailure(
+                    "Cloud backend \(type(of: newBackend)) must conform to CloudBackendKeychainConfigurable "
+                    + "for provider \(endpoint.provider.rawValue)."
+                )
+            }
+            keychainConfigurable.configure(
+                baseURL: url,
+                keychainAccount: endpoint.keychainAccount,
+                modelName: endpoint.modelName
+            )
+
+        case .ollama, .lmStudio, .koboldCpp:
+            guard let urlModelConfigurable = newBackend as? CloudBackendURLModelConfigurable else {
+                throw InferenceError.inferenceFailure(
+                    "Cloud backend \(type(of: newBackend)) must conform to CloudBackendURLModelConfigurable "
+                    + "for provider \(endpoint.provider.rawValue)."
+                )
+            }
+            urlModelConfigurable.configure(baseURL: url, modelName: endpoint.modelName)
+        }
+
         try await newBackend.loadModel(from: url, contextSize: 0)
         backend = newBackend
         isModelLoaded = true
@@ -311,4 +335,14 @@ public protocol ConversationHistoryReceiver: AnyObject {
 /// Adopted by cloud backends that track token usage per response.
 public protocol TokenUsageProvider: AnyObject {
     var lastUsage: (promptTokens: Int, completionTokens: Int)? { get }
+}
+
+/// Adopted by cloud backends configured with endpoint URL + model name.
+public protocol CloudBackendURLModelConfigurable: AnyObject {
+    func configure(baseURL: URL, modelName: String)
+}
+
+/// Adopted by cloud backends that resolve API keys via a Keychain account.
+public protocol CloudBackendKeychainConfigurable: AnyObject {
+    func configure(baseURL: URL, keychainAccount: String, modelName: String)
 }

--- a/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
+++ b/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
@@ -24,6 +24,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider, @unche
         session.updatedAt = record.updatedAt
         session.systemPrompt = record.systemPrompt
         session.selectedModelID = record.selectedModelID
+        session.selectedEndpointID = record.selectedEndpointID
         session.temperature = record.temperature
         session.topP = record.topP
         session.repeatPenalty = record.repeatPenalty
@@ -43,6 +44,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider, @unche
         session.updatedAt = record.updatedAt
         session.systemPrompt = record.systemPrompt
         session.selectedModelID = record.selectedModelID
+        session.selectedEndpointID = record.selectedEndpointID
         session.temperature = record.temperature
         session.topP = record.topP
         session.repeatPenalty = record.repeatPenalty
@@ -168,6 +170,7 @@ extension ChatSession {
             updatedAt: updatedAt,
             systemPrompt: systemPrompt,
             selectedModelID: selectedModelID,
+            selectedEndpointID: selectedEndpointID,
             temperature: temperature,
             topP: topP,
             repeatPenalty: repeatPenalty,

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -133,6 +133,7 @@ public final class ChatViewModel {
     public var compressionMode: CompressionMode = .automatic {
         didSet {
             compressionOrchestrator.mode = compressionMode
+            guard !isRestoringSession else { return }
             do {
                 try saveSettingsToSession()
             } catch {
@@ -254,6 +255,7 @@ public final class ChatViewModel {
     var generationTask: Task<Void, Never>?
     private var lastPressureLevel: MemoryPressureLevel = .nominal
     private var isSynchronizingSelection = false
+    private var isRestoringSession = false
 
     /// Cached per-message token counts keyed by message ID, to avoid recalculating all messages.
     var tokenCountCache: [UUID: Int] = [:]
@@ -322,6 +324,9 @@ public final class ChatViewModel {
 
     /// Switches to a different chat session, loading its messages and settings.
     public func switchToSession(_ session: ChatSessionRecord) {
+        isRestoringSession = true
+        defer { isRestoringSession = false }
+
         activeSession = session
         inferenceService.resetConversation()
 

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -57,12 +57,31 @@ public final class ChatViewModel {
     /// All models discovered on disk plus the built-in Foundation model.
     public private(set) var availableModels: [ModelInfo] = []
 
+    /// Enabled cloud endpoints available for selection.
+    public private(set) var availableEndpoints: [APIEndpoint] = []
+
     /// The model the user has selected in the sidebar.
-    public var selectedModel: ModelInfo?
+    public var selectedModel: ModelInfo? {
+        didSet {
+            guard !isSynchronizingSelection else { return }
+            guard selectedModel != nil, selectedEndpoint != nil else { return }
+            isSynchronizingSelection = true
+            selectedEndpoint = nil
+            isSynchronizingSelection = false
+        }
+    }
 
     /// The cloud API endpoint the user has selected, or `nil` for local models.
     /// Setting this clears `selectedModel` and vice versa.
-    public var selectedEndpoint: APIEndpoint?
+    public var selectedEndpoint: APIEndpoint? {
+        didSet {
+            guard !isSynchronizingSelection else { return }
+            guard selectedEndpoint != nil, selectedModel != nil else { return }
+            isSynchronizingSelection = true
+            selectedModel = nil
+            isSynchronizingSelection = false
+        }
+    }
 
     /// Ordered messages for the active session.
     public internal(set) var messages: [ChatMessageRecord] = []
@@ -234,6 +253,7 @@ public final class ChatViewModel {
 
     var generationTask: Task<Void, Never>?
     private var lastPressureLevel: MemoryPressureLevel = .nominal
+    private var isSynchronizingSelection = false
 
     /// Cached per-message token counts keyed by message ID, to avoid recalculating all messages.
     var tokenCountCache: [UUID: Int] = [:]
@@ -316,10 +336,20 @@ public final class ChatViewModel {
             selectedPromptTemplate = template
         }
 
-        // Try to select the session's model
-        if let modelID = session.selectedModelID,
-           let model = availableModels.first(where: { $0.id == modelID }) {
-            selectedModel = model
+        let resolvedEndpoint = session.selectedEndpointID.flatMap { endpointID in
+            availableEndpoints.first(where: { $0.id == endpointID })
+        }
+        let resolvedModel = session.selectedModelID.flatMap { modelID in
+            availableModels.first(where: { $0.id == modelID })
+        }
+
+        if let resolvedEndpoint {
+            selectedEndpoint = resolvedEndpoint
+        } else if let resolvedModel {
+            selectedModel = resolvedModel
+        } else {
+            selectedModel = nil
+            selectedEndpoint = nil
         }
 
         // pinnedMessageIDs must be set before compressionMode: the compressionMode
@@ -346,6 +376,7 @@ public final class ChatViewModel {
         session.repeatPenalty = repeatPenalty
         session.systemPrompt = systemPrompt
         session.selectedModelID = selectedModel?.id
+        session.selectedEndpointID = selectedEndpoint?.id
         session.compressionMode = compressionMode
         session.pinnedMessageIDs = pinnedMessageIDs
         session.updatedAt = Date()
@@ -378,6 +409,17 @@ public final class ChatViewModel {
 
         if let selected = selectedModel, !availableModels.contains(where: { $0.id == selected.id }) {
             selectedModel = nil
+        }
+    }
+
+    /// Replaces the in-memory list of selectable cloud endpoints.
+    ///
+    /// Clears `selectedEndpoint` when that endpoint is no longer available.
+    public func setAvailableEndpoints(_ endpoints: [APIEndpoint]) {
+        availableEndpoints = endpoints
+        if let selected = selectedEndpoint,
+           !availableEndpoints.contains(where: { $0.id == selected.id }) {
+            selectedEndpoint = nil
         }
     }
 

--- a/Tests/BaseChatBackendsTests/OpenAICompatEndpointTests.swift
+++ b/Tests/BaseChatBackendsTests/OpenAICompatEndpointTests.swift
@@ -263,9 +263,7 @@ struct OpenAICompatEndpointTests {
         for try await _ in stream { }
 
         // Verify no Authorization header was sent (apiKey was nil)
-        let captured = MockURLProtocol.capturedRequests.last(where: {
-            $0.url?.absoluteString.contains("v1/chat/completions") == true
-        })
+        let captured = MockURLProtocol.capturedRequests.last(where: { $0.url == url })
         #expect(captured != nil)
         let authHeader = captured?.value(forHTTPHeaderField: "Authorization")
         #expect(authHeader == nil, "Ollama doesn't need auth -- no Authorization header should be sent")
@@ -456,9 +454,7 @@ struct OpenAICompatEndpointTests {
         )
         for try await _ in stream { }
 
-        let captured = MockURLProtocol.capturedRequests.last(where: {
-            $0.url?.absoluteString.contains("v1/chat/completions") == true
-        })
+        let captured = MockURLProtocol.capturedRequests.last(where: { $0.url == url })
         #expect(captured != nil)
         #expect(captured?.value(forHTTPHeaderField: "Authorization") == nil,
                 "KoboldCpp doesn't require auth -- no header should be present")
@@ -490,9 +486,7 @@ struct OpenAICompatEndpointTests {
         )
         for try await _ in stream { }
 
-        let captured = MockURLProtocol.capturedRequests.last(where: {
-            $0.url?.absoluteString.contains("v1/chat/completions") == true
-        })
+        let captured = MockURLProtocol.capturedRequests.last(where: { $0.url == url })
         let body = try extractBody(from: captured)
         let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
 
@@ -537,9 +531,7 @@ struct OpenAICompatEndpointTests {
         )
         for try await _ in stream { }
 
-        let captured = MockURLProtocol.capturedRequests.last(where: {
-            $0.url?.absoluteString.contains("v1/chat/completions") == true
-        })
+        let captured = MockURLProtocol.capturedRequests.last(where: { $0.url == url })
         let body = try extractBody(from: captured)
         let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
 
@@ -579,9 +571,7 @@ struct OpenAICompatEndpointTests {
         )
         for try await _ in stream { }
 
-        let captured = MockURLProtocol.capturedRequests.last(where: {
-            $0.url?.absoluteString.contains("v1/chat/completions") == true
-        })
+        let captured = MockURLProtocol.capturedRequests.last(where: { $0.url == url })
         let body = try extractBody(from: captured)
         let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
         let messages = try #require(json["messages"] as? [[String: Any]])

--- a/Tests/BaseChatCoreTests/ChatSessionTests.swift
+++ b/Tests/BaseChatCoreTests/ChatSessionTests.swift
@@ -27,6 +27,7 @@ final class ChatSessionTests: XCTestCase {
         XCTAssertNil(session.promptTemplateRawValue)
         XCTAssertNil(session.contextSizeOverride)
         XCTAssertNil(session.selectedModelID)
+        XCTAssertNil(session.selectedEndpointID)
     }
 
     func test_promptTemplate_roundTrip() {

--- a/Tests/BaseChatCoreTests/InferenceServiceTests.swift
+++ b/Tests/BaseChatCoreTests/InferenceServiceTests.swift
@@ -154,7 +154,7 @@ final class InferenceServiceTests: XCTestCase {
 
     func test_loadCloudBackend_setsIsModelLoaded() async throws {
         let service = InferenceService()
-        let mock = MockInferenceBackend()
+        let mock = MockCloudURLModelBackend()
 
         service.registerCloudBackendFactory { _ in mock }
 
@@ -164,13 +164,16 @@ final class InferenceServiceTests: XCTestCase {
         XCTAssertTrue(service.isModelLoaded)
         XCTAssertEqual(service.activeBackendName, APIProvider.ollama.rawValue)
         XCTAssertEqual(mock.loadModelCallCount, 1)
+        XCTAssertEqual(mock.configuredBaseURL?.absoluteString, endpoint.baseURL)
+        XCTAssertEqual(mock.configuredModelName, endpoint.modelName)
+        XCTAssertTrue(mock.didConfigureBeforeLoad)
     }
 
     func test_loadCloudBackend_unloadsExistingModel() async throws {
         let firstMock = MockInferenceBackend()
         let service = InferenceService(backend: firstMock, name: "First")
 
-        let cloudMock = MockInferenceBackend()
+        let cloudMock = MockCloudURLModelBackend()
         service.registerCloudBackendFactory { _ in cloudMock }
 
         let endpoint = APIEndpoint(name: "Ollama", provider: .ollama)
@@ -181,6 +184,42 @@ final class InferenceServiceTests: XCTestCase {
         // New backend is active.
         XCTAssertTrue(service.isModelLoaded)
         XCTAssertEqual(service.activeBackendName, APIProvider.ollama.rawValue)
+    }
+
+    func test_loadCloudBackend_configuresKeychainBackend_beforeLoad() async throws {
+        let service = InferenceService()
+        let mock = MockCloudKeychainBackend()
+        service.registerCloudBackendFactory { _ in mock }
+
+        let endpoint = APIEndpoint(
+            name: "Claude",
+            provider: .claude,
+            baseURL: "https://api.anthropic.com",
+            modelName: "claude-sonnet-4-6"
+        )
+        try await service.loadCloudBackend(from: endpoint)
+
+        XCTAssertEqual(mock.configuredBaseURL?.absoluteString, endpoint.baseURL)
+        XCTAssertEqual(mock.configuredModelName, endpoint.modelName)
+        XCTAssertEqual(mock.configuredKeychainAccount, endpoint.keychainAccount)
+        XCTAssertTrue(mock.didConfigureBeforeLoad)
+    }
+
+    func test_loadCloudBackend_nonConfigurableBackend_throwsError() async {
+        let service = InferenceService()
+        let mock = MockInferenceBackend()
+        service.registerCloudBackendFactory { _ in mock }
+
+        let endpoint = APIEndpoint(name: "Ollama", provider: .ollama)
+
+        do {
+            try await service.loadCloudBackend(from: endpoint)
+            XCTFail("Expected InferenceError.inferenceFailure when backend does not conform to config protocol")
+        } catch InferenceError.inferenceFailure {
+            // expected
+        } catch {
+            XCTFail("Expected InferenceError.inferenceFailure, got \(error)")
+        }
     }
 
     // MARK: - Cloud backend interop
@@ -323,7 +362,7 @@ final class InferenceServiceTests: XCTestCase {
         }
 
         var secondCallCount = 0
-        let secondMock = MockInferenceBackend()
+        let secondMock = MockCloudURLModelBackend()
         service.registerCloudBackendFactory { provider in
             guard provider == .ollama else { return nil }
             secondCallCount += 1
@@ -435,8 +474,8 @@ private final class MockConversationHistoryBackend: InferenceBackend,
 
 /// A mock backend that also adopts TokenUsageProvider.
 private final class MockTokenUsageBackend: InferenceBackend,
-                                           TokenUsageProvider,
-                                           @unchecked Sendable {
+                                            TokenUsageProvider,
+                                            @unchecked Sendable {
     var isModelLoaded: Bool = true
     var isGenerating: Bool = false
     var capabilities: BackendCapabilities = BackendCapabilities(
@@ -457,4 +496,84 @@ private final class MockTokenUsageBackend: InferenceBackend,
 
     func stopGeneration() {}
     func unloadModel() {}
+}
+
+private final class MockCloudURLModelBackend: InferenceBackend,
+                                              CloudBackendURLModelConfigurable,
+                                              @unchecked Sendable {
+    var isModelLoaded: Bool = false
+    var isGenerating: Bool = false
+    var capabilities: BackendCapabilities = BackendCapabilities(
+        supportedParameters: [.temperature],
+        maxContextTokens: 4096,
+        requiresPromptTemplate: false,
+        supportsSystemPrompt: true
+    )
+
+    var loadModelCallCount = 0
+    var configuredBaseURL: URL?
+    var configuredModelName: String?
+    var didConfigureBeforeLoad = false
+
+    func configure(baseURL: URL, modelName: String) {
+        configuredBaseURL = baseURL
+        configuredModelName = modelName
+    }
+
+    func loadModel(from url: URL, contextSize: Int32) async throws {
+        loadModelCallCount += 1
+        isModelLoaded = true
+        didConfigureBeforeLoad = (configuredBaseURL != nil && configuredModelName != nil)
+    }
+
+    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in continuation.finish() }
+    }
+
+    func stopGeneration() {}
+    func unloadModel() {
+        isModelLoaded = false
+    }
+}
+
+private final class MockCloudKeychainBackend: InferenceBackend,
+                                              CloudBackendKeychainConfigurable,
+                                              @unchecked Sendable {
+    var isModelLoaded: Bool = false
+    var isGenerating: Bool = false
+    var capabilities: BackendCapabilities = BackendCapabilities(
+        supportedParameters: [.temperature],
+        maxContextTokens: 4096,
+        requiresPromptTemplate: false,
+        supportsSystemPrompt: true
+    )
+
+    var configuredBaseURL: URL?
+    var configuredKeychainAccount: String?
+    var configuredModelName: String?
+    var didConfigureBeforeLoad = false
+
+    func configure(baseURL: URL, keychainAccount: String, modelName: String) {
+        configuredBaseURL = baseURL
+        configuredKeychainAccount = keychainAccount
+        configuredModelName = modelName
+    }
+
+    func loadModel(from url: URL, contextSize: Int32) async throws {
+        isModelLoaded = true
+        didConfigureBeforeLoad = (
+            configuredBaseURL != nil
+                && configuredKeychainAccount != nil
+                && configuredModelName != nil
+        )
+    }
+
+    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in continuation.finish() }
+    }
+
+    func stopGeneration() {}
+    func unloadModel() {
+        isModelLoaded = false
+    }
 }

--- a/Tests/BaseChatE2ETests/CloudEndpointSelectionE2ETests.swift
+++ b/Tests/BaseChatE2ETests/CloudEndpointSelectionE2ETests.swift
@@ -1,0 +1,369 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import BaseChatUI
+import BaseChatBackends
+import BaseChatCore
+import BaseChatTestSupport
+
+private func sseData(_ json: String) -> Data {
+    Data("data: \(json)\n\n".utf8)
+}
+
+private let sseDone = Data("data: [DONE]\n\n".utf8)
+
+private func sseChunks(_ tokens: [String]) -> [Data] {
+    var chunks = tokens.map { token in
+        sseData("""
+        {"choices":[{"delta":{"content":"\(token)"}}]}
+        """)
+    }
+    chunks.append(sseDone)
+    return chunks
+}
+
+private func makeMockSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+private final class ConfiguringOpenAICloudBackend: InferenceBackend,
+                                                   ConversationHistoryReceiver,
+                                                   CloudBackendURLModelConfigurable,
+                                                   CloudBackendKeychainConfigurable,
+                                                   @unchecked Sendable {
+    private let backend: OpenAIBackend
+    private let probeOnLoad: Bool
+
+    init(urlSession: URLSession, probeOnLoad: Bool = false) {
+        self.backend = OpenAIBackend(urlSession: urlSession)
+        self.probeOnLoad = probeOnLoad
+    }
+
+    var isModelLoaded: Bool { backend.isModelLoaded }
+    var isGenerating: Bool { backend.isGenerating }
+    var capabilities: BackendCapabilities { backend.capabilities }
+
+    func setConversationHistory(_ messages: [(role: String, content: String)]) {
+        backend.setConversationHistory(messages)
+    }
+
+    func configure(baseURL: URL, modelName: String) {
+        backend.configure(baseURL: baseURL, apiKey: nil, modelName: modelName)
+    }
+
+    func configure(baseURL: URL, keychainAccount: String, modelName: String) {
+        backend.configure(baseURL: baseURL, keychainAccount: keychainAccount, modelName: modelName)
+    }
+
+    func loadModel(from url: URL, contextSize: Int32) async throws {
+        try await backend.loadModel(from: url, contextSize: contextSize)
+
+        guard probeOnLoad else { return }
+        let stream = try backend.generate(
+            prompt: "probe",
+            systemPrompt: nil,
+            config: GenerationConfig(maxOutputTokens: 1)
+        )
+        for try await _ in stream { break }
+    }
+
+    func generate(
+        prompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig
+    ) throws -> AsyncThrowingStream<String, Error> {
+        try backend.generate(prompt: prompt, systemPrompt: systemPrompt, config: config)
+    }
+
+    func stopGeneration() { backend.stopGeneration() }
+    func unloadModel() { backend.unloadModel() }
+    func resetConversation() { backend.resetConversation() }
+}
+
+private final class ConfiguringClaudeCloudBackend: InferenceBackend,
+                                                   ConversationHistoryReceiver,
+                                                   CloudBackendKeychainConfigurable,
+                                                   @unchecked Sendable {
+    private let backend: ClaudeBackend
+
+    init(urlSession: URLSession) {
+        self.backend = ClaudeBackend(urlSession: urlSession)
+    }
+
+    var isModelLoaded: Bool { backend.isModelLoaded }
+    var isGenerating: Bool { backend.isGenerating }
+    var capabilities: BackendCapabilities { backend.capabilities }
+
+    func setConversationHistory(_ messages: [(role: String, content: String)]) {
+        backend.setConversationHistory(messages)
+    }
+
+    func configure(baseURL: URL, keychainAccount: String, modelName: String) {
+        backend.configure(baseURL: baseURL, keychainAccount: keychainAccount, modelName: modelName)
+    }
+
+    func loadModel(from url: URL, contextSize: Int32) async throws {
+        try await backend.loadModel(from: url, contextSize: contextSize)
+    }
+
+    func generate(
+        prompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig
+    ) throws -> AsyncThrowingStream<String, Error> {
+        try backend.generate(prompt: prompt, systemPrompt: systemPrompt, config: config)
+    }
+
+    func stopGeneration() { backend.stopGeneration() }
+    func unloadModel() { backend.unloadModel() }
+    func resetConversation() { backend.resetConversation() }
+}
+
+@Suite("Cloud Endpoint Selection E2E", .serialized)
+@MainActor
+final class CloudEndpointSelectionE2ETests {
+
+    private let container: ModelContainer
+    private let context: ModelContext
+    private let localBackend: MockInferenceBackend
+    private let vm: ChatViewModel
+    private let sessionManager: SessionManagerViewModel
+    private let cloudSession: URLSession
+
+    init() throws {
+        container = try makeInMemoryContainer()
+        context = container.mainContext
+
+        localBackend = MockInferenceBackend()
+        cloudSession = makeMockSession()
+
+        let service = InferenceService()
+        let localRef = localBackend
+        let cloudSessionRef = cloudSession
+        service.registerBackendFactory { _ in localRef }
+        service.registerCloudBackendFactory { _ in
+            ConfiguringOpenAICloudBackend(urlSession: cloudSessionRef)
+        }
+
+        let persistence = SwiftDataPersistenceProvider(modelContext: context)
+        vm = ChatViewModel(inferenceService: service)
+        vm.configure(persistence: persistence)
+
+        sessionManager = SessionManagerViewModel()
+        sessionManager.configure(persistence: persistence)
+    }
+
+    private func makeLocalModel(name: String = "Local GGUF") -> ModelInfo {
+        ModelInfo(
+            name: name,
+            fileName: "\(name).gguf",
+            url: URL(fileURLWithPath: "/dev/null"),
+            fileSize: 400_000_000,
+            modelType: .gguf
+        )
+    }
+
+    @discardableResult
+    private func makeSession(title: String = "Test") throws -> ChatSessionRecord {
+        let session = try sessionManager.createSession(title: title)
+        sessionManager.activeSession = session
+        vm.switchToSession(session)
+        return session
+    }
+
+    private func persistEndpoint(_ endpoint: APIEndpoint) throws {
+        context.insert(endpoint)
+        try context.save()
+    }
+
+    private func makeViewModel(cloudFactory: @escaping CloudBackendFactory) -> ChatViewModel {
+        let service = InferenceService()
+        service.registerCloudBackendFactory(cloudFactory)
+        let viewModel = ChatViewModel(inferenceService: service)
+        let persistence = SwiftDataPersistenceProvider(modelContext: context)
+        viewModel.configure(persistence: persistence)
+        return viewModel
+    }
+
+    @Test("selectedEndpoint + loadCloudEndpoint(endpoint) marks cloud backend as loaded")
+    func selectedEndpointAndLoad_setsIsModelLoaded() async throws {
+        let endpoint = APIEndpoint(
+            name: "Local Ollama",
+            provider: .ollama,
+            baseURL: "http://localhost:11434",
+            modelName: "llama3.2"
+        )
+        try persistEndpoint(endpoint)
+
+        vm.selectedEndpoint = endpoint
+        await vm.loadCloudEndpoint(endpoint)
+
+        #expect(vm.selectedEndpoint?.id == endpoint.id)
+        #expect(vm.isModelLoaded)
+        #expect(vm.errorMessage == nil)
+    }
+
+    @Test("sendMessage() streams cloud response via MockURLProtocol")
+    func sendMessage_streamsCloudResponseViaMockURLProtocol() async throws {
+        MockURLProtocol.reset()
+        defer { MockURLProtocol.reset() }
+
+        try makeSession(title: "Cloud Chat")
+        let endpoint = APIEndpoint(
+            name: "Local LM Studio",
+            provider: .lmStudio,
+            baseURL: "http://localhost:1234",
+            modelName: "local-model"
+        )
+        try persistEndpoint(endpoint)
+
+        let baseURL = try #require(URL(string: endpoint.baseURL))
+        let completionsURL = baseURL.appendingPathComponent("v1/chat/completions")
+        MockURLProtocol.stub(
+            url: completionsURL,
+            response: .sse(chunks: sseChunks(["Hello", " cloud"]), statusCode: 200)
+        )
+
+        vm.selectedEndpoint = endpoint
+        await vm.loadCloudEndpoint(endpoint)
+        #expect(vm.isModelLoaded)
+
+        vm.inputText = "Hi"
+        await vm.sendMessage()
+
+        #expect(vm.messages.count == 2)
+        let user = try #require(vm.messages.first)
+        let assistant = try #require(vm.messages.last)
+        #expect(user.role == .user)
+        #expect(assistant.role == .assistant)
+        #expect(assistant.content == "Hello cloud")
+        #expect(
+            MockURLProtocol.capturedRequests.contains {
+                $0.url?.absoluteString.hasPrefix(completionsURL.absoluteString) == true
+            }
+        )
+    }
+
+    @Test("Switching local model ↔ cloud endpoint keeps selections mutually exclusive")
+    func modelAndEndpointSelection_areMutuallyExclusive() {
+        let localModel = makeLocalModel()
+        let endpoint = APIEndpoint(
+            name: "Cloud Endpoint",
+            provider: .ollama,
+            baseURL: "http://localhost:11434",
+            modelName: "llama3.2"
+        )
+
+        vm.selectedModel = localModel
+        vm.selectedEndpoint = endpoint
+        #expect(vm.selectedModel == nil)
+        #expect(vm.selectedEndpoint?.id == endpoint.id)
+
+        vm.selectedModel = localModel
+        #expect(vm.selectedEndpoint == nil)
+        #expect(vm.selectedModel?.id == localModel.id)
+    }
+
+    @Test("Cloud endpoint is persisted to session and restored on switch-back")
+    func sessionRestoresSelectedEndpoint() throws {
+        let endpointA = APIEndpoint(
+            name: "Endpoint A",
+            provider: .ollama,
+            baseURL: "http://localhost:11434",
+            modelName: "llama3.2"
+        )
+        let endpointB = APIEndpoint(
+            name: "Endpoint B",
+            provider: .lmStudio,
+            baseURL: "http://localhost:1234",
+            modelName: "local-model"
+        )
+        try persistEndpoint(endpointA)
+        try persistEndpoint(endpointB)
+        vm.setAvailableEndpoints([endpointA, endpointB])
+
+        try makeSession(title: "Session A")
+        vm.selectedEndpoint = endpointA
+        try vm.saveSettingsToSession()
+
+        let sessionB = try sessionManager.createSession(title: "Session B")
+        sessionManager.activeSession = sessionB
+        vm.switchToSession(sessionB)
+        vm.selectedEndpoint = endpointB
+        try vm.saveSettingsToSession()
+
+        sessionManager.loadSessions()
+        let freshA = try #require(sessionManager.sessions.first { $0.title == "Session A" })
+        sessionManager.activeSession = freshA
+        vm.switchToSession(freshA)
+
+        #expect(vm.selectedEndpoint?.id == endpointA.id)
+    }
+
+    @Test("loadCloudEndpoint failure path surfaces invalid URL, missing API key, and network error")
+    func loadCloudEndpoint_failurePath_surfacesErrors() async throws {
+        // Invalid URL
+        let invalidEndpoint = APIEndpoint(
+            name: "Bad URL",
+            provider: .custom,
+            baseURL: "http://foo\0bar",
+            modelName: "model"
+        )
+        await vm.loadCloudEndpoint(invalidEndpoint)
+        let invalidError = try #require(vm.errorMessage)
+        #expect(invalidError.contains("Invalid server URL"))
+        #expect(!vm.isModelLoaded)
+
+        // Missing API key
+        let missingKeyVM = makeViewModel { _ in
+            ConfiguringClaudeCloudBackend(urlSession: makeMockSession())
+        }
+        let claudeEndpoint = APIEndpoint(
+            name: "Claude Endpoint",
+            provider: .claude,
+            baseURL: "https://api.anthropic.com",
+            modelName: "claude-sonnet-4-20250514"
+        )
+        KeychainService.delete(account: claudeEndpoint.keychainAccount)
+        await missingKeyVM.loadCloudEndpoint(claudeEndpoint)
+        let missingKeyError = try #require(missingKeyVM.errorMessage)
+        #expect(missingKeyError.contains("No API key configured"))
+        #expect(!missingKeyVM.isModelLoaded)
+
+        // Network error from MockURLProtocol during load probe
+        MockURLProtocol.reset()
+        defer { MockURLProtocol.reset() }
+
+        let probingSession = makeMockSession()
+        let networkVM = makeViewModel { _ in
+            ConfiguringOpenAICloudBackend(
+                urlSession: probingSession,
+                probeOnLoad: true
+            )
+        }
+        let networkEndpoint = APIEndpoint(
+            name: "Flaky Endpoint",
+            provider: .ollama,
+            baseURL: "http://localhost:11434",
+            modelName: "llama3.2"
+        )
+        let networkBaseURL = try #require(URL(string: networkEndpoint.baseURL))
+        let networkCompletionsURL = networkBaseURL.appendingPathComponent("v1/chat/completions")
+        MockURLProtocol.stub(
+            url: networkCompletionsURL,
+            response: .error(URLError(.networkConnectionLost))
+        )
+
+        await networkVM.loadCloudEndpoint(networkEndpoint)
+        let networkError = try #require(networkVM.errorMessage)
+        #expect(!networkError.isEmpty)
+        #expect(
+            networkError.localizedCaseInsensitiveContains("nsurlerrordomain")
+            || networkError.localizedCaseInsensitiveContains("connect")
+            || networkError.localizedCaseInsensitiveContains("network")
+        )
+        #expect(!networkVM.isModelLoaded)
+    }
+}

--- a/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
+++ b/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
@@ -288,6 +288,25 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         XCTAssertNil(vm.selectedEndpoint, "Missing endpoint should clear selectedEndpoint")
     }
 
+    func test_switchToSession_doesNotPersistNilSelectionWhenEndpointUnavailable() throws {
+        let (vm, _, persistence) = try makeViewModelWithPersistence()
+
+        let endpoint = APIEndpoint(name: "Delayed Endpoint", provider: .openAI)
+        var session = ChatSessionRecord(title: "Deferred Endpoint Session")
+        session.selectedEndpointID = endpoint.id
+        try persistence.insertSession(session)
+        vm.activeSession = session
+
+        vm.setAvailableEndpoints([])
+        vm.switchToSession(session)
+
+        XCTAssertEqual(persistence.updateSessionCallCount, 0,
+                       "switchToSession should not auto-persist settings while restoring")
+        let stored = try persistence.fetchSessions().first(where: { $0.id == session.id })
+        XCTAssertEqual(stored?.selectedEndpointID, endpoint.id,
+                       "Unresolved endpoint ID should remain persisted until user saves settings")
+    }
+
     func test_saveSettingsToSession_persistsSelectedEndpointID() throws {
         let (vm, _, persistence) = try makeViewModelWithPersistence()
         let endpoint = APIEndpoint(name: "Claude", provider: .claude)

--- a/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
+++ b/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
@@ -172,20 +172,6 @@ final class ViewModelEdgeCaseTests: XCTestCase {
 
     // MARK: - switchToSession model-selection restoration
 
-    /// Creates a fake .gguf file in a temp directory for the duration of a test.
-    /// Returns the ModelInfo built from the file and the URL for cleanup.
-    private func makeTempGGUF(named fileName: String = "test-model-restore.gguf") throws -> (ModelInfo, URL) {
-        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent("BaseChatKitTests", isDirectory: true)
-        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
-        let url = tmp.appendingPathComponent(fileName)
-        let data = Data(repeating: 0, count: 1024)
-        try data.write(to: url)
-        guard let model = ModelInfo(ggufURL: url) else {
-            throw XCTSkip("Could not create ModelInfo from temp GGUF — skipping")
-        }
-        return (model, url)
-    }
-
     func test_switchToSession_restoresSelectedModel_whenModelInList() throws {
         let (vm, _, _) = try makeViewModelWithPersistence()
 
@@ -228,8 +214,8 @@ final class ViewModelEdgeCaseTests: XCTestCase {
 
         vm.switchToSession(session)
 
-        XCTAssertEqual(vm.selectedModel?.id, foundationModel.id,
-            "selectedModel should be unchanged when session's model is not in availableModels")
+        XCTAssertNil(vm.selectedModel,
+            "selectedModel should be cleared when session's model is not in availableModels")
     }
 
     func test_saveSettingsToSession_persistsSelectedModelID() throws {
@@ -248,6 +234,74 @@ final class ViewModelEdgeCaseTests: XCTestCase {
 
         XCTAssertEqual(vm.activeSession?.selectedModelID, expectedID,
             "saveSettingsToSession should persist the selected model's UUID to the session")
+    }
+
+    func test_selectionMutualExclusion_selectingEndpoint_clearsModel() {
+        let vm = makeViewModel()
+        vm.selectedModel = ModelInfo.builtInFoundation
+
+        let endpoint = APIEndpoint(name: "OpenAI", provider: .openAI)
+        vm.selectedEndpoint = endpoint
+
+        XCTAssertNil(vm.selectedModel, "Selecting an endpoint should clear selectedModel")
+        XCTAssertEqual(vm.selectedEndpoint?.id, endpoint.id)
+    }
+
+    func test_selectionMutualExclusion_selectingModel_clearsEndpoint() {
+        let vm = makeViewModel()
+        let endpoint = APIEndpoint(name: "OpenAI", provider: .openAI)
+        vm.selectedEndpoint = endpoint
+
+        vm.selectedModel = ModelInfo.builtInFoundation
+
+        XCTAssertNil(vm.selectedEndpoint, "Selecting a model should clear selectedEndpoint")
+        XCTAssertEqual(vm.selectedModel?.id, ModelInfo.builtInFoundation.id)
+    }
+
+    func test_switchToSession_restoresSelectedEndpoint_whenEndpointExists() throws {
+        let (vm, _, _) = try makeViewModelWithPersistence()
+        let endpoint = APIEndpoint(name: "OpenAI", provider: .openAI)
+        vm.setAvailableEndpoints([endpoint])
+        vm.selectedModel = ModelInfo.builtInFoundation
+
+        var session = ChatSessionRecord(title: "Endpoint Session")
+        session.selectedEndpointID = endpoint.id
+        session.selectedModelID = ModelInfo.builtInFoundation.id
+
+        vm.switchToSession(session)
+
+        XCTAssertEqual(vm.selectedEndpoint?.id, endpoint.id)
+        XCTAssertNil(vm.selectedModel, "Endpoint restore should not leak prior model selection")
+    }
+
+    func test_switchToSession_clearsSelectedEndpoint_whenEndpointMissing() throws {
+        let (vm, _, _) = try makeViewModelWithPersistence()
+        let oldEndpoint = APIEndpoint(name: "Old", provider: .openAI)
+        vm.setAvailableEndpoints([oldEndpoint])
+        vm.selectedEndpoint = oldEndpoint
+
+        var session = ChatSessionRecord(title: "Missing Endpoint Session")
+        session.selectedEndpointID = UUID()
+
+        vm.switchToSession(session)
+
+        XCTAssertNil(vm.selectedEndpoint, "Missing endpoint should clear selectedEndpoint")
+    }
+
+    func test_saveSettingsToSession_persistsSelectedEndpointID() throws {
+        let (vm, _, persistence) = try makeViewModelWithPersistence()
+        let endpoint = APIEndpoint(name: "Claude", provider: .claude)
+        vm.setAvailableEndpoints([endpoint])
+
+        let session = ChatSessionRecord(title: "Persist Endpoint Session")
+        try persistence.insertSession(session)
+        vm.activeSession = session
+        vm.selectedEndpoint = endpoint
+
+        try vm.saveSettingsToSession()
+
+        XCTAssertEqual(vm.activeSession?.selectedEndpointID, endpoint.id)
+        XCTAssertNil(vm.activeSession?.selectedModelID, "Endpoint selection should clear model selection")
     }
 
     func test_switchToSession_usesDefaultsForNilSettings() throws {


### PR DESCRIPTION
## Summary
- configure cloud backends from APIEndpoint before loading so cloud providers receive URL, model, and keychain context
- persist and restore selectedEndpointID in session records and SwiftData mapping
- enforce model and endpoint mutual exclusion in ChatViewModel and sync available endpoints from demo view
- add coverage across core, UI, and E2E for cloud endpoint selection, loading, and restore flows
- harden OpenAI-compat auth-header tests by asserting against the exact request URL to avoid cross-test request capture

## Validation
- swift test --filter CloudEndpointSelectionE2ETests --quiet
- swift test --filter BaseChatCoreTests --quiet
- swift test --filter BaseChatUITests --quiet
- swift test --filter BaseChatBackendsTests --quiet