### PR TITLE
ci: optimize macOS CI and add actionlint

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -22,5 +22,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+
+      - name: Install actionlint
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@latest
+
       - name: Lint GitHub Actions workflows
-        uses: rhysd/actionlint@v1
+        run: |
+          set -euo pipefail
+          ACTIONLINT_BIN="$(go env GOPATH)/bin/actionlint"
+          "$ACTIONLINT_BIN" -color

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,26 @@
+name: Actionlint
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actionlint*"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actionlint*"
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Lint GitHub Actions workflows
+        uses: rhysd/actionlint@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,30 +3,50 @@ name: CI
 on:
   push:
     branches: [main]
+    paths:
+      - "Sources/**"
+      - "Tests/**"
+      - "Package.swift"
+      - "Package.resolved"
+      - ".github/workflows/ci.yml"
   pull_request:
     branches: [main]
+    paths:
+      - "Sources/**"
+      - "Tests/**"
+      - "Package.swift"
+      - "Package.resolved"
+      - ".github/workflows/ci.yml"
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
-    runs-on: macos-15-xlarge  # Apple Silicon (arm64) — ~2x faster than Intel
+    runs-on: macos-15  # Apple Silicon (arm64) standard runner to reduce spend
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Select Xcode
+        id: setup-xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
 
-      - name: Cache build artifacts
+      - name: Cache SwiftPM dependencies
         uses: actions/cache@v4
         with:
-          path: .build
-          key: ${{ runner.os }}-${{ runner.arch }}-build-${{ hashFiles('Package.resolved', '**/*.swift') }}
+          path: |
+            .build/artifacts
+            .build/checkouts
+            .build/repositories
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-${{ steps.setup-xcode.outputs.xcode-version }}-spm-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-build-${{ hashFiles('Package.resolved') }}-
-            ${{ runner.os }}-${{ runner.arch }}-build-
+            ${{ runner.os }}-${{ runner.arch }}-xcode-${{ steps.setup-xcode.outputs.xcode-version }}-spm-
+            ${{ runner.os }}-${{ runner.arch }}-spm-
 
       - name: Run CI smoke tests
         run: swift test --filter "BaseChatCoreTests|BaseChatUITests|BaseChatBackendsTests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,11 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-spm-
 
       - name: Run CI smoke tests
-        run: swift test --filter "BaseChatCoreTests|BaseChatUITests|BaseChatBackendsTests"
+        run: |
+          set -euo pipefail
+          swift test --filter BaseChatCoreTests
+          swift test --filter BaseChatUITests
+          swift test --filter BaseChatBackendsTests
 
       # CI smoke profile (GitHub macOS Apple Silicon runners):
       # - Runs BaseChatCoreTests + BaseChatUITests + BaseChatBackendsTests.


### PR DESCRIPTION
## Summary
- optimize macOS CI cost with concurrency cancellation, path filters, standard macos-15 runner, and dependency-focused SwiftPM cache
- add actionlint workflow for GitHub Actions YAML validation

## Validation
- swift test --filter BaseChatCoreTests --quiet
- swift test --filter BaseChatUITests --quiet
- swift test --filter BaseChatBackendsTests --quiet
- actionlint -color