### PR TITLE
fix: move backend loadModel off @MainActor to prevent UI blocking

### DIFF
--- a/Sources/BaseChatCore/Services/InferenceService.swift
+++ b/Sources/BaseChatCore/Services/InferenceService.swift
@@ -184,7 +184,14 @@ public final class InferenceService {
             backend: backendName
         )
         do {
-            try await newBackend.loadModel(from: modelInfo.url, contextSize: contextSize)
+            // Run backend model loading off the main actor so heavy blocking work
+            // (e.g. llama_model_load_from_file, llama_init_from_model) does not
+            // freeze the UI or trigger the iOS watchdog gesture gate timeout.
+            // After the Task completes we resume on @MainActor for the commit step.
+            let url = modelInfo.url
+            try await Task.detached(priority: .userInitiated) {
+                try await newBackend.loadModel(from: url, contextSize: contextSize)
+            }.value
         } catch {
             let isStale = finishLoadAttemptWithFailure(request, error: error)
             if isStale {
@@ -250,7 +257,13 @@ public final class InferenceService {
             backend: endpoint.provider.rawValue
         )
         do {
-            try await newBackend.loadModel(from: url, contextSize: 0)
+            // Run backend initialisation off the main actor for consistency with
+            // local model loading — cloud backends may perform blocking I/O during
+            // their loadModel step (e.g. keychain reads, capability negotiation).
+            let backendURL = url
+            try await Task.detached(priority: .userInitiated) {
+                try await newBackend.loadModel(from: backendURL, contextSize: 0)
+            }.value
         } catch {
             let isStale = finishLoadAttemptWithFailure(request, error: error)
             if isStale {

--- a/Sources/BaseChatTestSupport/MockInferenceBackend.swift
+++ b/Sources/BaseChatTestSupport/MockInferenceBackend.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Darwin
 import BaseChatCore
 
 /// Configurable mock inference backend for testing.
@@ -19,6 +20,10 @@ public final class MockInferenceBackend: InferenceBackend, @unchecked Sendable {
     public var generateCallCount = 0
     public var stopCallCount = 0
     public var unloadCallCount = 0
+
+    /// Records whether `loadModel` was called on the main thread.
+    /// `nil` until `loadModel` has been called at least once.
+    public var loadModelCalledOnMainThread: Bool?
 
     // Capture last generate arguments
     public var lastPrompt: String?
@@ -43,6 +48,7 @@ public final class MockInferenceBackend: InferenceBackend, @unchecked Sendable {
 
     public func loadModel(from url: URL, contextSize: Int32) async throws {
         loadModelCallCount += 1
+        loadModelCalledOnMainThread = pthread_main_np() != 0
         if let error = shouldThrowOnLoad { throw error }
         isModelLoaded = true
     }

--- a/Tests/BaseChatCoreTests/InferenceServiceTests.swift
+++ b/Tests/BaseChatCoreTests/InferenceServiceTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Darwin
 @testable import BaseChatCore
 import BaseChatTestSupport
 
@@ -590,6 +591,38 @@ final class InferenceServiceTests: XCTestCase {
         XCTAssertTrue(service.isModelLoaded)
     }
 
+    // MARK: - Responsiveness: loadModel must not block the main thread
+
+    func test_loadModel_doesNotCallBackendLoadOnMainThread() async throws {
+        let service = InferenceService()
+        let mock = MockInferenceBackend()
+        service.registerBackendFactory { _ in mock }
+
+        let modelInfo = makeModelInfo(name: "TestModel", modelType: .gguf)
+        try await service.loadModel(from: modelInfo)
+
+        XCTAssertEqual(mock.loadModelCallCount, 1)
+        XCTAssertEqual(mock.loadModelCalledOnMainThread, false,
+                       "loadModel must NOT run on the main thread — blocking there triggers watchdog timeouts")
+    }
+
+    func test_loadCloudBackend_doesNotCallBackendLoadOnMainThread() async throws {
+        let service = InferenceService()
+        let mock = ControlledLoadBackend()
+        service.registerCloudBackendFactory { _ in mock }
+
+        let endpointTask = Task {
+            try await service.loadCloudBackend(from: makeEndpoint(name: "Cloud", provider: .ollama, modelName: "m"))
+        }
+        await mock.waitUntilLoadStarted()
+
+        XCTAssertEqual(mock.loadModelCalledOnMainThread, false,
+                       "cloud loadModel must NOT run on the main thread")
+
+        await mock.releaseLoadSuccess()
+        try await endpointTask.value
+    }
+
     private func makeModelInfo(name: String, modelType: ModelType) -> ModelInfo {
         ModelInfo(
             name: name,
@@ -817,6 +850,7 @@ private final class ControlledLoadBackend: InferenceBackend,
 
     var loadModelCallCount = 0
     var unloadCallCount = 0
+    var loadModelCalledOnMainThread: Bool?
     var configuredBaseURL: URL?
     var configuredModelName: String?
 
@@ -841,6 +875,7 @@ private final class ControlledLoadBackend: InferenceBackend,
 
     func loadModel(from url: URL, contextSize: Int32) async throws {
         loadModelCallCount += 1
+        loadModelCalledOnMainThread = pthread_main_np() != 0
         await gate.markStarted()
 
         switch await gate.waitForRelease() {


### PR DESCRIPTION
## Summary

Closes #100

Switching from Foundation to a downloaded GGUF model was blocking the UI thread long enough to trigger iOS watchdog warnings (`System gesture gate timed out`).

## Root cause

`InferenceService` is `@MainActor` and called `newBackend.loadModel(...)` directly. In Swift concurrency, when a `@MainActor` function awaits a non-isolated async function, the callee's synchronous preamble runs on the main actor before the first suspension. For `LlamaBackend`, this included `unloadModel()` and lock acquisition; for any backend that performs blocking I/O before its first suspension point, this would freeze the UI entirely.

## Fix

Wrap both `loadModel` call sites in `InferenceService` (local model path and cloud backend path) with `Task.detached(priority: .userInitiated)`. The detached task runs the backend initialisation off the main thread. The `@MainActor` commit/error-handling logic after the `await` resumes correctly on the main actor because Swift resumes the suspended task on its original actor.

## Changes

- **`InferenceService.swift`**: `loadModel` and `loadCloudBackend` now wrap `newBackend.loadModel(...)` in `Task.detached(priority: .userInitiated)`. The backend lifecycle correctness (single active backend, latest-wins token, stale suppression) is unchanged.
- **`MockInferenceBackend.swift`**: Added `loadModelCalledOnMainThread: Bool?` property, set via `pthread_main_np()` (used instead of the Swift-6-unavailable `Thread.isMainThread`/`Thread.current` APIs).
- **`InferenceServiceTests.swift`**: Two new regression tests assert that `loadModel` is never dispatched on the main thread for both the local and cloud loading paths.

## Testing

```bash
swift test --filter BaseChatCoreTests
swift test --filter BaseChatBackendsTests
```

New tests:
- `test_loadModel_doesNotCallBackendLoadOnMainThread`
- `test_loadCloudBackend_doesNotCallBackendLoadOnMainThread`