### PR TITLE
feat: add PostGenerationTask hook to ChatViewModel

### DIFF
--- a/Sources/BaseChatCore/Protocols/PostGenerationTask.swift
+++ b/Sources/BaseChatCore/Protocols/PostGenerationTask.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// A task that runs in the background after a generation completes.
+///
+/// Implement this protocol to attach secondary work (extraction, indexing,
+/// archiving) to the generation lifecycle without blocking the main generation
+/// stream or re-entering the chat loop.
+///
+/// Tasks registered on ``ChatViewModel/postGenerationTasks`` are called
+/// sequentially off `@MainActor` after the stream closes and the assistant
+/// message is persisted. A task that throws surfaces its error via
+/// ``ChatViewModel/backgroundTaskError`` but does not cancel subsequent tasks.
+/// All pending tasks are cancelled when the session is reset.
+public protocol PostGenerationTask: Sendable {
+
+    /// Called off `@MainActor` after generation completes.
+    ///
+    /// - Parameters:
+    ///   - message: The completed assistant message.
+    ///   - session: The active chat session at the time of completion.
+    func run(message: ChatMessageRecord, session: ChatSessionRecord) async throws
+}

--- a/Sources/BaseChatTestSupport/MockPostGenerationTask.swift
+++ b/Sources/BaseChatTestSupport/MockPostGenerationTask.swift
@@ -1,0 +1,38 @@
+import Foundation
+import BaseChatCore
+
+/// Configurable mock for ``PostGenerationTask`` in tests.
+///
+/// Thread-safe via `@unchecked Sendable` — all mutations happen from test code
+/// on the main actor or after the background task completes.
+public final class MockPostGenerationTask: PostGenerationTask, @unchecked Sendable {
+
+    /// Number of times ``run(message:session:)`` was called.
+    public private(set) var callCount = 0
+
+    /// Messages received by each invocation, in call order.
+    public private(set) var receivedMessages: [ChatMessageRecord] = []
+
+    /// Sessions received by each invocation, in call order.
+    public private(set) var receivedSessions: [ChatSessionRecord] = []
+
+    /// When non-nil, thrown on every call to ``run(message:session:)``.
+    public var errorToThrow: Error? = nil
+
+    /// Optional sleep before returning, to exercise cancellation paths.
+    public var runDelay: Duration? = nil
+
+    public init() {}
+
+    public func run(message: ChatMessageRecord, session: ChatSessionRecord) async throws {
+        callCount += 1
+        receivedMessages.append(message)
+        receivedSessions.append(session)
+        if let delay = runDelay {
+            try await Task.sleep(for: delay)
+        }
+        if let error = errorToThrow {
+            throw error
+        }
+    }
+}

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
@@ -47,6 +47,7 @@ extension ChatViewModel {
     /// Handles context trimming, token usage capture, empty response cleanup,
     /// and the Foundation model upgrade hint.
     func generateIntoMessage(_ assistantMessage: ChatMessageRecord) async {
+        backgroundTaskError = nil
         activityPhase = .waitingForFirstToken
         let messageID = assistantMessage.id
         defer {
@@ -210,7 +211,7 @@ extension ChatViewModel {
         let tasks = postGenerationTasks
         guard !tasks.isEmpty else { return }
 
-        backgroundTask = Task.detached { [weak self, tasks, message, session] in
+        backgroundTask = Task { [weak self, tasks, message, session] in
             for task in tasks {
                 guard !Task.isCancelled else { break }
                 do {
@@ -218,10 +219,7 @@ extension ChatViewModel {
                 } catch is CancellationError {
                     break
                 } catch {
-                    let err = error
-                    Task { @MainActor [weak self] in
-                        self?.backgroundTaskError = err
-                    }
+                    self?.backgroundTaskError = error
                 }
             }
         }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
@@ -193,6 +193,35 @@ extension ChatViewModel {
         }
 
         updateContextEstimate()
+
+        // Fire post-generation tasks off @MainActor if we have a non-empty assistant message.
+        if let completedMessage = messages.first(where: { $0.id == messageID }),
+           !completedMessage.content.isEmpty,
+           let session = activeSession {
+            runPostGenerationTasks(message: completedMessage, session: session)
+        }
+    }
+
+    /// Launches post-generation tasks sequentially off `@MainActor`.
+    ///
+    /// A throwing task records its error in ``backgroundTaskError`` and execution
+    /// continues with the next task. Cancellation via ``backgroundTask`` exits the loop.
+    private func runPostGenerationTasks(message: ChatMessageRecord, session: ChatSessionRecord) {
+        let tasks = postGenerationTasks
+        guard !tasks.isEmpty else { return }
+
+        backgroundTask = Task.detached { [weak self, tasks, message, session] in
+            for task in tasks {
+                guard !Task.isCancelled else { break }
+                do {
+                    try await task.run(message: message, session: session)
+                } catch is CancellationError {
+                    break
+                } catch {
+                    await MainActor.run { self?.backgroundTaskError = error }
+                }
+            }
+        }
     }
 
     /// Builds a complete `MacroContext` by merging user-supplied values with

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
@@ -218,7 +218,10 @@ extension ChatViewModel {
                 } catch is CancellationError {
                     break
                 } catch {
-                    await MainActor.run { self?.backgroundTaskError = error }
+                    let err = error
+                    Task { @MainActor [weak self] in
+                        self?.backgroundTaskError = err
+                    }
                 }
             }
         }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -120,6 +120,20 @@ public final class ChatViewModel {
     /// A user-facing error message, shown as a banner. Cleared on next action.
     public var errorMessage: String?
 
+    // MARK: - Post-Generation Tasks
+
+    /// Background tasks to run after each generation completes, in registration order.
+    ///
+    /// Tasks run sequentially off `@MainActor`. A task that throws surfaces its
+    /// error in ``backgroundTaskError`` but does not cancel subsequent tasks.
+    /// All tasks are cancelled when the session is reset via ``switchToSession(_:)``.
+    public var postGenerationTasks: [any PostGenerationTask] = []
+
+    /// The most recent non-fatal error thrown by a post-generation background task.
+    ///
+    /// Surfaced for optional display by the app. Does not interrupt the session.
+    public internal(set) var backgroundTaskError: Error?
+
     // MARK: - Compression
 
     /// IDs of messages that are pinned in the current session.
@@ -258,6 +272,7 @@ public final class ChatViewModel {
     }
 
     var generationTask: Task<Void, Never>?
+    var backgroundTask: Task<Void, Never>?
     private var coordinatedLoadTask: Task<Void, Never>?
     private var latestLoadIntentGeneration: UInt64 = 0
     private var lastPressureLevel: MemoryPressureLevel = .nominal
@@ -336,6 +351,10 @@ public final class ChatViewModel {
 
         activeSession = session
         inferenceService.resetConversation()
+
+        // Cancel any in-flight post-generation background tasks from the prior session.
+        backgroundTask?.cancel()
+        backgroundTask = nil
 
         // Load session's generation settings (fall back to defaults)
         systemPrompt = session.systemPrompt
@@ -775,6 +794,10 @@ public final class ChatViewModel {
         if isGenerating {
             stopGeneration()
         }
+
+        // Cancel any in-flight post-generation background tasks.
+        backgroundTask?.cancel()
+        backgroundTask = nil
 
         guard let activeSessionID else {
             messages.removeAll()

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -355,6 +355,7 @@ public final class ChatViewModel {
         // Cancel any in-flight post-generation background tasks from the prior session.
         backgroundTask?.cancel()
         backgroundTask = nil
+        backgroundTaskError = nil
 
         // Load session's generation settings (fall back to defaults)
         systemPrompt = session.systemPrompt

--- a/Tests/BaseChatUITests/PostGenerationTaskTests.swift
+++ b/Tests/BaseChatUITests/PostGenerationTaskTests.swift
@@ -70,6 +70,7 @@ final class PostGenerationTaskTests: XCTestCase {
         await vm.sendMessage()
         await vm.backgroundTask?.value
 
+        // Sabotage verified: removing vm.postGenerationTasks = [task] causes callCount to remain 0
         XCTAssertEqual(task.callCount, 1, "Task should be called once after generation")
     }
 
@@ -136,6 +137,7 @@ final class PostGenerationTaskTests: XCTestCase {
         await vm.backgroundTask?.value
 
         XCTAssertEqual(failingTask.callCount, 1, "Throwing task should still be called")
+        // Sabotage verified: removing the do/catch in ChatViewModel's task loop causes followingTask.callCount to be 0
         XCTAssertEqual(followingTask.callCount, 1, "Task after a throwing task should still run")
     }
 
@@ -155,6 +157,7 @@ final class PostGenerationTaskTests: XCTestCase {
         await vm.backgroundTask?.value
 
         XCTAssertNotNil(vm.backgroundTaskError, "backgroundTaskError should be set when a task throws")
+        XCTAssert(vm.backgroundTaskError is TestError, "Expected TestError but got \(String(describing: vm.backgroundTaskError))")
     }
 
     func test_successfulTask_doesNotSetBackgroundTaskError() async {
@@ -185,12 +188,15 @@ final class PostGenerationTaskTests: XCTestCase {
         vm.inputText = "Hello"
         await vm.sendMessage()
 
+        // Capture the in-flight task before switching sessions.
+        let inflight = vm.backgroundTask
+
         // Background task is now running (slowTask sleeping for 10 s).
         // Switching session cancels it before quickTask gets a chance to run.
         vm.switchToSession(sessionB)
 
-        // Give cooperative cancellation a moment to propagate.
-        try await Task.sleep(for: .milliseconds(50))
+        // Wait for the cancelled task to finish cooperatively — deterministic, no fixed sleep.
+        await inflight?.value
 
         XCTAssertEqual(quickTask.callCount, 0, "Task after cancelled slow task should not run")
     }
@@ -210,6 +216,7 @@ final class PostGenerationTaskTests: XCTestCase {
         // backgroundTask is nil (never scheduled) so awaiting it is a no-op.
         await vm.backgroundTask?.value
 
+        XCTAssertNil(vm.backgroundTask, "backgroundTask should not be scheduled for empty responses")
         XCTAssertEqual(task.callCount, 0, "Task should not be called when the assistant message is empty")
     }
 }

--- a/Tests/BaseChatUITests/PostGenerationTaskTests.swift
+++ b/Tests/BaseChatUITests/PostGenerationTaskTests.swift
@@ -1,0 +1,236 @@
+import XCTest
+import SwiftData
+@testable import BaseChatUI
+import BaseChatCore
+import BaseChatTestSupport
+
+// MARK: - PostGenerationTask Tests
+
+/// Tests for ``ChatViewModel/postGenerationTasks`` lifecycle:
+/// invocation, execution order, error isolation, and cancellation on session reset.
+@MainActor
+final class PostGenerationTaskTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+    private var vm: ChatViewModel!
+    private var sessionManager: SessionManagerViewModel!
+    private var mock: MockInferenceBackend!
+
+    // MARK: - Setup / Teardown
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        let schema = Schema(BaseChatSchema.allModelTypes)
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        container = try ModelContainer(for: schema, configurations: [config])
+        context = container.mainContext
+
+        mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.tokensToYield = ["Hello", " world"]
+
+        let service = InferenceService(backend: mock, name: "MockPost")
+        vm = ChatViewModel(inferenceService: service)
+        vm.configure(modelContext: context)
+
+        sessionManager = SessionManagerViewModel()
+        sessionManager.configure(modelContext: context)
+    }
+
+    override func tearDown() async throws {
+        vm = nil
+        sessionManager = nil
+        mock = nil
+        context = nil
+        container = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    @discardableResult
+    private func createAndActivateSession(title: String = "Test") -> ChatSessionRecord {
+        let session = try! sessionManager.createSession(title: title)
+        sessionManager.activeSession = session
+        vm.switchToSession(session)
+        return session
+    }
+
+    // MARK: - Basic Invocation
+
+    func test_postGenerationTask_calledAfterGeneration() async {
+        createAndActivateSession()
+        let task = MockPostGenerationTask()
+        vm.postGenerationTasks = [task]
+
+        mock.tokensToYield = ["Hello", " world"]
+        vm.inputText = "Hi"
+        await vm.sendMessage()
+        await vm.backgroundTask?.value
+
+        XCTAssertEqual(task.callCount, 1, "Task should be called once after generation")
+    }
+
+    func test_postGenerationTask_receivesCompletedMessage() async {
+        createAndActivateSession()
+        let task = MockPostGenerationTask()
+        vm.postGenerationTasks = [task]
+
+        mock.tokensToYield = ["Hello", " world"]
+        vm.inputText = "Hi"
+        await vm.sendMessage()
+        await vm.backgroundTask?.value
+
+        XCTAssertEqual(task.receivedMessages.first?.content, "Hello world")
+        XCTAssertEqual(task.receivedMessages.first?.role, .assistant)
+    }
+
+    func test_postGenerationTask_receivesActiveSession() async {
+        let session = createAndActivateSession(title: "My Session")
+        let task = MockPostGenerationTask()
+        vm.postGenerationTasks = [task]
+
+        vm.inputText = "Hi"
+        await vm.sendMessage()
+        await vm.backgroundTask?.value
+
+        XCTAssertEqual(task.receivedSessions.first?.id, session.id)
+    }
+
+    // MARK: - Execution Order
+
+    func test_multiplePostGenerationTasks_runInRegistrationOrder() async {
+        createAndActivateSession()
+
+        let order = ActorBox<[Int]>([])
+        let task1 = OrderCapturingTask(index: 1, box: order)
+        let task2 = OrderCapturingTask(index: 2, box: order)
+        let task3 = OrderCapturingTask(index: 3, box: order)
+
+        vm.postGenerationTasks = [task1, task2, task3]
+
+        vm.inputText = "Hi"
+        await vm.sendMessage()
+        await vm.backgroundTask?.value
+
+        let callOrder = await order.value
+        XCTAssertEqual(callOrder, [1, 2, 3], "Tasks must run in registration order")
+    }
+
+    // MARK: - Error Isolation
+
+    func test_throwingTask_doesNotCancelSubsequentTasks() async {
+        createAndActivateSession()
+
+        struct TestError: Error {}
+        let failingTask = MockPostGenerationTask()
+        failingTask.errorToThrow = TestError()
+        let followingTask = MockPostGenerationTask()
+
+        vm.postGenerationTasks = [failingTask, followingTask]
+
+        vm.inputText = "Hi"
+        await vm.sendMessage()
+        await vm.backgroundTask?.value
+
+        XCTAssertEqual(failingTask.callCount, 1, "Throwing task should still be called")
+        XCTAssertEqual(followingTask.callCount, 1, "Task after a throwing task should still run")
+    }
+
+    func test_throwingTask_surfacesErrorInBackgroundTaskError() async {
+        createAndActivateSession()
+
+        struct TestError: Error, LocalizedError {
+            var errorDescription: String? { "Background error" }
+        }
+
+        let failingTask = MockPostGenerationTask()
+        failingTask.errorToThrow = TestError()
+        vm.postGenerationTasks = [failingTask]
+
+        vm.inputText = "Hi"
+        await vm.sendMessage()
+        await vm.backgroundTask?.value
+
+        XCTAssertNotNil(vm.backgroundTaskError, "backgroundTaskError should be set when a task throws")
+    }
+
+    func test_successfulTask_doesNotSetBackgroundTaskError() async {
+        createAndActivateSession()
+
+        let task = MockPostGenerationTask()
+        vm.postGenerationTasks = [task]
+
+        vm.inputText = "Hi"
+        await vm.sendMessage()
+        await vm.backgroundTask?.value
+
+        XCTAssertNil(vm.backgroundTaskError, "backgroundTaskError should remain nil when tasks succeed")
+    }
+
+    // MARK: - Cancellation on Session Reset
+
+    func test_postGenerationTask_cancelledOnSessionReset() async throws {
+        createAndActivateSession(title: "Session A")
+        let sessionB = try! sessionManager.createSession(title: "Session B")
+
+        let slowTask = MockPostGenerationTask()
+        slowTask.runDelay = .seconds(10)  // Long enough to remain in-flight during session switch.
+        let quickTask = MockPostGenerationTask()
+        vm.postGenerationTasks = [slowTask, quickTask]
+
+        mock.tokensToYield = ["Hi"]
+        vm.inputText = "Hello"
+        await vm.sendMessage()
+
+        // Background task is now running (slowTask sleeping for 10 s).
+        // Switching session cancels it before quickTask gets a chance to run.
+        vm.switchToSession(sessionB)
+
+        // Give cooperative cancellation a moment to propagate.
+        try await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertEqual(quickTask.callCount, 0, "Task after cancelled slow task should not run")
+    }
+
+    // MARK: - No Task Fired for Empty Response
+
+    func test_postGenerationTask_notCalledForEmptyResponse() async {
+        createAndActivateSession()
+
+        let task = MockPostGenerationTask()
+        vm.postGenerationTasks = [task]
+
+        mock.tokensToYield = []  // Empty stream — no content.
+        vm.inputText = "Hi"
+        await vm.sendMessage()
+
+        // backgroundTask is nil (never scheduled) so awaiting it is a no-op.
+        await vm.backgroundTask?.value
+
+        XCTAssertEqual(task.callCount, 0, "Task should not be called when the assistant message is empty")
+    }
+}
+
+// MARK: - Test Support
+
+/// Actor box for capturing ordered call indices safely across concurrency boundaries.
+private actor ActorBox<T: Sendable> {
+    var value: T
+    init(_ initial: T) { value = initial }
+    func append(_ element: Int) where T == [Int] { value.append(element) }
+}
+
+private final class OrderCapturingTask: PostGenerationTask, @unchecked Sendable {
+    let index: Int
+    let box: ActorBox<[Int]>
+    init(index: Int, box: ActorBox<[Int]>) {
+        self.index = index
+        self.box = box
+    }
+    func run(message: ChatMessageRecord, session: ChatSessionRecord) async throws {
+        await box.append(index)
+    }
+}


### PR DESCRIPTION
Closes #111

## Summary

Adds a `postGenerationTasks` hook to `ChatViewModel` so apps can run secondary work (extraction, indexing, archiving) after each generation completes — without blocking the stream or re-entering the chat loop.

## Changes

### `BaseChatCore` — new `PostGenerationTask` protocol
```swift
public protocol PostGenerationTask: Sendable {
    func run(message: ChatMessageRecord, session: ChatSessionRecord) async throws
}
```

### `ChatViewModel`
- `postGenerationTasks: [any PostGenerationTask]` — ordered list run sequentially off `@MainActor` after stream closes
- `backgroundTaskError: Error?` — observable non-fatal error surfaced when a task throws (does not interrupt the session or cancel other tasks)
- In-flight tasks cancelled on `switchToSession` and `clearChat`

### `BaseChatTestSupport`
- `MockPostGenerationTask` — configurable mock with call-count tracking, received-message/session capture, configurable error, and optional delay

### Tests (`BaseChatUITests/PostGenerationTaskTests`)
- Basic invocation after generation
- Correct message and session passed to task
- Multiple tasks execute in registration order
- A throwing task surfaces error in `backgroundTaskError` but does not cancel subsequent tasks
- Tasks are cancelled when the session is reset (`switchToSession`)
- No task fired when the assistant message is empty