### PR TITLE
feat: add PromptSlotPosition enum replacing string-based slot positions

### DIFF
--- a/Sources/BaseChatCore/Services/PromptAssembler.swift
+++ b/Sources/BaseChatCore/Services/PromptAssembler.swift
@@ -67,11 +67,17 @@ public enum PromptAssembler {
         let messageTokens = trimmedMessages.reduce(0) { $0 + tok.tokenCount($1.content) }
         budgetBreakdown["history"] = messageTokens
 
-        // 5. Sort resolved slots by position for final ordering
+        // 5. Sort resolved slots by position for final ordering.
+        // Tiebreak by input-array index to keep declaration order stable for equal positions.
         let mc = trimmedMessages.count
-        let sortedSlots = resolvedSlots.sorted {
-            $0.position.sortIndex(messageCount: mc) < $1.position.sortIndex(messageCount: mc)
-        }
+        let sortedSlots = resolvedSlots
+            .enumerated()
+            .sorted {
+                let li = $0.element.position.sortIndex(messageCount: mc)
+                let ri = $1.element.position.sortIndex(messageCount: mc)
+                return li == ri ? $0.offset < $1.offset : li < ri
+            }
+            .map(\.element)
 
         // 6. Build the final message list, inserting history-positioned slots
         let finalMessages = insertSlotsIntoHistory(slots: sortedSlots, messages: trimmedMessages)
@@ -129,8 +135,8 @@ public enum PromptAssembler {
         var result: [(role: String, content: String)] = topSlots.map { (role: "system", content: $0.content) }
         var messageTuples = messages.map { (role: $0.role.rawValue, content: $0.content) }
 
-        // Compute depths from the original message count so prior insertions don't shift targets.
-        // Process highest depth first to keep insertion indices stable as the array grows.
+        // Process highest insertion depth first so that earlier inserts don't shift the
+        // indices of later (lower-depth) inserts.
         let originalCount = messageTuples.count
         let sorted = historySlots.sorted {
             $0.position.insertionDepth(messageCount: originalCount) >

--- a/Sources/BaseChatCore/Services/PromptAssembler.swift
+++ b/Sources/BaseChatCore/Services/PromptAssembler.swift
@@ -4,12 +4,11 @@ import Foundation
 ///
 /// The assembler follows this algorithm:
 /// 1. Calculate token cost of each enabled slot's content (capped by ``PromptSlot/tokenBudget``).
-/// 2. Sort fixed slots by depth (0 = top).
-/// 3. Sum fixed slot tokens and subtract from the context budget (along with ``responseBuffer``).
+/// 2. Sort slots by ``PromptSlotPosition/sortIndex(messageCount:)``.
+/// 3. Sum slot tokens and subtract from the context budget (along with ``responseBuffer``).
 /// 4. Allocate remaining budget to message history.
-/// 5. Trim messages newest-first (same strategy as ``ContextWindowManager/trimMessages(_:systemPrompt:maxTokens:responseBuffer:)``).
-/// 6. Insert depth-positioned slots into the message stream. A slot with depth N is inserted
-///    N message turns from the bottom of the history.
+/// 5. Trim messages newest-first (same strategy as ``ContextWindowManager``).
+/// 6. Insert history-positioned slots into the message stream at their resolved depth.
 /// 7. Return an ``AssembledPrompt`` with ordered slots, trimmed messages, total tokens, and per-slot breakdown.
 public enum PromptAssembler {
 
@@ -18,7 +17,7 @@ public enum PromptAssembler {
     /// - Parameters:
     ///   - slots: Prompt slots to include. Disabled slots are skipped.
     ///   - messages: Full conversation history in chronological order.
-    ///   - systemPrompt: Optional system prompt (assembled as a slot with id "system" at depth 0).
+    ///   - systemPrompt: Optional system prompt (assembled as a slot with id "system" at ``PromptSlotPosition/systemPreamble``).
     ///   - contextSize: Total context window size in tokens.
     ///   - responseBuffer: Tokens reserved for the model's response.
     ///   - tokenizer: Optional tokenizer. Falls back to ``HeuristicTokenizer`` when nil.
@@ -39,7 +38,7 @@ public enum PromptAssembler {
             let systemSlot = PromptSlot(
                 id: "system",
                 content: systemPrompt,
-                depth: 0,
+                position: .systemPreamble,
                 label: "System Prompt"
             )
             allSlots.insert(systemSlot, at: 0)
@@ -51,20 +50,11 @@ public enum PromptAssembler {
 
         for slot in allSlots {
             let rawCount = tok.tokenCount(slot.content)
-            let tokenCount: Int
-            if let budget = slot.tokenBudget {
-                tokenCount = min(rawCount, budget)
-            } else {
-                tokenCount = rawCount
-            }
-            let resolved = ResolvedSlot(
-                id: slot.id,
-                label: slot.label,
-                content: slot.content,
-                tokenCount: tokenCount,
-                depth: slot.depth
-            )
-            resolvedSlots.append(resolved)
+            let tokenCount = slot.tokenBudget.map { min(rawCount, $0) } ?? rawCount
+            resolvedSlots.append(ResolvedSlot(
+                id: slot.id, label: slot.label, content: slot.content,
+                tokenCount: tokenCount, position: slot.position
+            ))
             budgetBreakdown[slot.id] = tokenCount
         }
 
@@ -73,33 +63,23 @@ public enum PromptAssembler {
         let availableForMessages = max(0, contextSize - totalSlotTokens - responseBuffer)
 
         // 4. Trim messages to fit remaining budget (newest first, like ContextWindowManager)
-        let trimmedMessages = trimMessagesToFit(
-            messages,
-            budget: availableForMessages,
-            tokenizer: tok
-        )
-
-        // Calculate message tokens
+        let trimmedMessages = trimMessagesToFit(messages, budget: availableForMessages, tokenizer: tok)
         let messageTokens = trimmedMessages.reduce(0) { $0 + tok.tokenCount($1.content) }
         budgetBreakdown["history"] = messageTokens
 
-        // 5. Sort resolved slots by depth for final ordering
-        let sortedSlots = resolvedSlots.sorted { $0.depth < $1.depth }
+        // 5. Sort resolved slots by position for final ordering
+        let mc = trimmedMessages.count
+        let sortedSlots = resolvedSlots.sorted {
+            $0.position.sortIndex(messageCount: mc) < $1.position.sortIndex(messageCount: mc)
+        }
 
-        // 6. Build the final message list, inserting depth-positioned slots
-        //    Depth N means: insert N message turns from the bottom of the history.
-        //    Slots with depth 0 go before all messages.
-        let finalMessages = insertSlotsIntoHistory(
-            slots: sortedSlots,
-            messages: trimmedMessages
-        )
-
-        let totalTokens = totalSlotTokens + messageTokens
+        // 6. Build the final message list, inserting history-positioned slots
+        let finalMessages = insertSlotsIntoHistory(slots: sortedSlots, messages: trimmedMessages)
 
         return AssembledPrompt(
             orderedSlots: sortedSlots,
             messages: finalMessages,
-            totalTokens: totalTokens,
+            totalTokens: totalSlotTokens + messageTokens,
             budgetBreakdown: budgetBreakdown
         )
     }
@@ -116,10 +96,7 @@ public enum PromptAssembler {
         guard !messages.isEmpty else { return [] }
 
         if budget <= 0 {
-            // No room — keep just the last user message or the very last message
-            if let lastUser = messages.last(where: { $0.role == .user }) {
-                return [lastUser]
-            }
+            if let lastUser = messages.last(where: { $0.role == .user }) { return [lastUser] }
             return Array(messages.suffix(1))
         }
 
@@ -128,9 +105,7 @@ public enum PromptAssembler {
 
         for message in messages.reversed() {
             let count = tokenizer.tokenCount(message.content)
-            if usedTokens + count > budget && !kept.isEmpty {
-                break
-            }
+            if usedTokens + count > budget && !kept.isEmpty { break }
             kept.append(message)
             usedTokens += count
         }
@@ -138,40 +113,33 @@ public enum PromptAssembler {
         return kept.reversed()
     }
 
-    /// Inserts slots into the message history based on their depth.
+    /// Inserts slots into the message history based on their position.
     ///
-    /// Depth 0 slots produce entries before all messages.
-    /// Depth N (where N > 0) slots are inserted N turns from the bottom of the history.
-    /// Slots that share a depth are kept in their sorted order.
+    /// Top slots (``PromptSlotPosition/systemPreamble`` and ``PromptSlotPosition/contextSetup``)
+    /// are prepended as system messages before the history stream.
+    /// History-positioned slots are inserted at `max(0, count - depth)` from the bottom,
+    /// using the original message count so insertion order does not shift targets.
     private static func insertSlotsIntoHistory(
         slots: [ResolvedSlot],
         messages: [ChatMessageRecord]
     ) -> [(role: String, content: String)] {
-        // Separate slots into "top" (depth 0) and "depth-inserted"
-        let topSlots = slots.filter { $0.depth == 0 }
-        let depthSlots = slots.filter { $0.depth > 0 }
+        let topSlots = slots.filter { $0.position.isTopSlot }
+        let historySlots = slots.filter { !$0.position.isTopSlot }
 
-        // Convert messages to (role, content) tuples
-        var result: [(role: String, content: String)] = []
-
-        // Add top-level slots first
-        for slot in topSlots {
-            result.append((role: "system", content: slot.content))
-        }
-
-        // Convert ChatMessageRecords
+        var result: [(role: String, content: String)] = topSlots.map { (role: "system", content: $0.content) }
         var messageTuples = messages.map { (role: $0.role.rawValue, content: $0.content) }
 
-        // Insert depth-positioned slots into the message list.
-        // Depth N = N turns from the bottom. Process highest depth first to
-        // keep insertion indices stable.
-        let sortedDepthSlots = depthSlots.sorted { $0.depth > $1.depth }
-        for slot in sortedDepthSlots {
-            let insertionIndex = max(0, messageTuples.count - slot.depth)
-            messageTuples.insert(
-                (role: "system", content: slot.content),
-                at: insertionIndex
-            )
+        // Compute depths from the original message count so prior insertions don't shift targets.
+        // Process highest depth first to keep insertion indices stable as the array grows.
+        let originalCount = messageTuples.count
+        let sorted = historySlots.sorted {
+            $0.position.insertionDepth(messageCount: originalCount) >
+            $1.position.insertionDepth(messageCount: originalCount)
+        }
+        for slot in sorted {
+            let depth = slot.position.insertionDepth(messageCount: originalCount)
+            let idx = max(0, messageTuples.count - depth)
+            messageTuples.insert((role: "system", content: slot.content), at: idx)
         }
 
         result.append(contentsOf: messageTuples)

--- a/Sources/BaseChatCore/Services/PromptAssembler.swift
+++ b/Sources/BaseChatCore/Services/PromptAssembler.swift
@@ -135,16 +135,24 @@ public enum PromptAssembler {
         var result: [(role: String, content: String)] = topSlots.map { (role: "system", content: $0.content) }
         var messageTuples = messages.map { (role: $0.role.rawValue, content: $0.content) }
 
-        // Process highest insertion depth first so that earlier inserts don't shift the
-        // indices of later (lower-depth) inserts.
+        // Process lowest depth first (bottom-to-top) using the original message count
+        // for all index calculations, so that earlier inserts don't perturb the targets
+        // of later ones. For slots at the same depth, reverse input order before inserting
+        // so that the final array reflects the original input order.
         let originalCount = messageTuples.count
-        let sorted = historySlots.sorted {
-            $0.position.insertionDepth(messageCount: originalCount) >
-            $1.position.insertionDepth(messageCount: originalCount)
-        }
+        let sorted = historySlots
+            .enumerated()
+            .sorted { lhs, rhs in
+                let ld = lhs.element.position.insertionDepth(messageCount: originalCount)
+                let rd = rhs.element.position.insertionDepth(messageCount: originalCount)
+                // Ascending depth (bottom first); within same depth, reverse offset so
+                // final order matches input order after same-index inserts.
+                return ld == rd ? lhs.offset > rhs.offset : ld < rd
+            }
+            .map(\.element)
         for slot in sorted {
             let depth = slot.position.insertionDepth(messageCount: originalCount)
-            let idx = max(0, messageTuples.count - depth)
+            let idx = max(0, originalCount - depth)
             messageTuples.insert((role: "system", content: slot.content), at: idx)
         }
 

--- a/Sources/BaseChatCore/Services/PromptSlot.swift
+++ b/Sources/BaseChatCore/Services/PromptSlot.swift
@@ -1,25 +1,124 @@
 import Foundation
 
+/// Describes where a ``PromptSlot`` appears in the assembled prompt.
+///
+/// Use semantic positions rather than raw depth integers to make slot placement
+/// intent explicit and independent of the history length at assembly time.
+public enum PromptSlotPosition: Hashable, Sendable {
+    /// Before all other content — the very top of the prompt.
+    case systemPreamble
+    /// After the system preamble, before conversation history.
+    case contextSetup
+    /// Injected `n` messages from the bottom of the trimmed history.
+    /// `n` must be >= 0; `atDepth(0)` is equivalent to ``bottomOfHistory``.
+    case atDepth(Int)
+    /// Just above the oldest visible message — the top of history.
+    case topOfHistory
+    /// Just above the most recent user message — the bottom of history.
+    case bottomOfHistory
+    /// Inserted after all history messages, immediately before the model turn.
+    case inline
+}
+
+extension PromptSlotPosition: Codable {
+    private enum CodingKeys: String, CodingKey { case type, depth }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let t = try c.decode(String.self, forKey: .type)
+        switch t {
+        case "systemPreamble":  self = .systemPreamble
+        case "contextSetup":    self = .contextSetup
+        case "atDepth":         self = .atDepth(try c.decode(Int.self, forKey: .depth))
+        case "topOfHistory":    self = .topOfHistory
+        case "bottomOfHistory": self = .bottomOfHistory
+        case "inline":          self = .inline
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .type, in: c,
+                debugDescription: "Unknown PromptSlotPosition type"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .systemPreamble:   try c.encode("systemPreamble", forKey: .type)
+        case .contextSetup:     try c.encode("contextSetup", forKey: .type)
+        case .atDepth(let n):   try c.encode("atDepth", forKey: .type); try c.encode(n, forKey: .depth)
+        case .topOfHistory:     try c.encode("topOfHistory", forKey: .type)
+        case .bottomOfHistory:  try c.encode("bottomOfHistory", forKey: .type)
+        case .inline:           try c.encode("inline", forKey: .type)
+        }
+    }
+}
+
+extension PromptSlotPosition {
+    /// Whether this position places the slot before the message history stream.
+    var isTopSlot: Bool {
+        if case .systemPreamble = self { return true }
+        if case .contextSetup = self { return true }
+        return false
+    }
+
+    /// A stable sort key that reflects the order slots appear in the assembled prompt.
+    ///
+    /// Top slots (systemPreamble = 0, contextSetup = 1) come first.
+    /// History slots are ordered by ascending effective depth.
+    func sortIndex(messageCount: Int) -> Int {
+        switch self {
+        case .systemPreamble:           return 0
+        case .contextSetup:             return 1
+        case .bottomOfHistory, .inline: return 2
+        case .atDepth(let n):           return 2 + n
+        case .topOfHistory:             return 2 + messageCount
+        }
+    }
+
+    /// The number of messages from the bottom of history at which to insert the slot.
+    ///
+    /// Pass the original (pre-insertion) message count so that insertion order
+    /// does not shift subsequent targets.
+    func insertionDepth(messageCount: Int) -> Int {
+        switch self {
+        case .topOfHistory:             return messageCount
+        case .atDepth(let n):           return n
+        case .bottomOfHistory, .inline: return 0
+        default:                        return 0
+        }
+    }
+
+    /// Short human-readable label suitable for inspector UI.
+    public var displayName: String {
+        switch self {
+        case .systemPreamble:   return "system preamble"
+        case .contextSetup:     return "context setup"
+        case .atDepth(let n):   return "depth \(n)"
+        case .topOfHistory:     return "top of history"
+        case .bottomOfHistory:  return "bottom of history"
+        case .inline:           return "inline"
+        }
+    }
+}
+
 /// A named slot in the prompt assembly pipeline.
 ///
 /// Each slot carries content that occupies part of the context window budget.
-/// Slots are ordered by ``depth`` (0 = top of prompt, higher = closer to the
-/// end / closer to the most recent messages). Slots with the same depth are
-/// ordered by their position in the input array.
+/// Slots are placed according to their ``position``; slots with the same
+/// effective position retain their input-array order.
 ///
 /// Use ``PromptAssembler/assemble(slots:messages:systemPrompt:contextSize:responseBuffer:tokenizer:)``
 /// to resolve slots and history into a final ``AssembledPrompt``.
 public struct PromptSlot: Identifiable, Sendable {
-    /// Unique identifier for this slot (e.g. "system", "charDef", "lorebook", "authorsNote", "history").
+    /// Unique identifier for this slot (e.g. "system", "charDef", "lorebook", "authorsNote").
     public let id: String
 
     /// The text content of this slot.
     public var content: String
 
-    /// Ordering depth. 0 = top of prompt, higher values = closer to the end.
-    /// Slots like "authorsNote" typically use a depth that places them N turns
-    /// from the bottom of the conversation history.
-    public var depth: Int
+    /// Where this slot appears in the assembled prompt.
+    public var position: PromptSlotPosition
 
     /// Maximum token budget for this slot. `nil` means the slot uses as many
     /// tokens as its content requires (no cap).
@@ -34,14 +133,17 @@ public struct PromptSlot: Identifiable, Sendable {
     public init(
         id: String,
         content: String,
-        depth: Int = 0,
+        position: PromptSlotPosition = .contextSetup,
         tokenBudget: Int? = nil,
         isEnabled: Bool = true,
         label: String
     ) {
+        if case .atDepth(let n) = position {
+            precondition(n >= 0, "PromptSlotPosition.atDepth depth must be >= 0; got \(n)")
+        }
         self.id = id
         self.content = content
-        self.depth = depth
+        self.position = position
         self.tokenBudget = tokenBudget
         self.isEnabled = isEnabled
         self.label = label
@@ -54,20 +156,20 @@ public struct ResolvedSlot: Identifiable, Sendable {
     public let label: String
     public let content: String
     public let tokenCount: Int
-    public let depth: Int
+    public let position: PromptSlotPosition
 
-    public init(id: String, label: String, content: String, tokenCount: Int, depth: Int) {
+    public init(id: String, label: String, content: String, tokenCount: Int, position: PromptSlotPosition) {
         self.id = id
         self.label = label
         self.content = content
         self.tokenCount = tokenCount
-        self.depth = depth
+        self.position = position
     }
 }
 
 /// The output of ``PromptAssembler/assemble(slots:messages:systemPrompt:contextSize:responseBuffer:tokenizer:)``.
 public struct AssembledPrompt: Sendable {
-    /// All resolved slots in their final order (depth-sorted).
+    /// All resolved slots in their final order (position-sorted).
     public let orderedSlots: [ResolvedSlot]
 
     /// Trimmed conversation history as (role, content) pairs in chronological order.

--- a/Sources/BaseChatCore/Services/PromptSlot.swift
+++ b/Sources/BaseChatCore/Services/PromptSlot.swift
@@ -29,7 +29,15 @@ extension PromptSlotPosition: Codable {
         switch t {
         case "systemPreamble":  self = .systemPreamble
         case "contextSetup":    self = .contextSetup
-        case "atDepth":         self = .atDepth(try c.decode(Int.self, forKey: .depth))
+        case "atDepth":
+            let depth = try c.decode(Int.self, forKey: .depth)
+            guard depth >= 0 else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .depth, in: c,
+                    debugDescription: "PromptSlotPosition.atDepth depth must be >= 0, got \(depth)"
+                )
+            }
+            self = .atDepth(depth)
         case "topOfHistory":    self = .topOfHistory
         case "bottomOfHistory": self = .bottomOfHistory
         case "inline":          self = .inline
@@ -62,17 +70,21 @@ extension PromptSlotPosition {
         return false
     }
 
-    /// A stable sort key that reflects the order slots appear in the assembled prompt.
+    /// A stable sort key that reflects the order slots appear in the assembled prompt
+    /// (top to bottom; low index = earlier in prompt).
     ///
-    /// Top slots (systemPreamble = 0, contextSetup = 1) come first.
-    /// History slots are ordered by ascending effective depth.
+    /// systemPreamble (0) and contextSetup (1) come first.
+    /// topOfHistory (2) is the highest history position.
+    /// atDepth(n): larger n means higher placement (further from latest turn), so smaller index.
+    /// bottomOfHistory sits just above the last message; inline follows all messages.
     func sortIndex(messageCount: Int) -> Int {
         switch self {
-        case .systemPreamble:           return 0
-        case .contextSetup:             return 1
-        case .bottomOfHistory, .inline: return 2
-        case .atDepth(let n):           return 2 + n
-        case .topOfHistory:             return 2 + messageCount
+        case .systemPreamble:   return 0
+        case .contextSetup:     return 1
+        case .topOfHistory:     return 2
+        case .atDepth(let n):   return 2 + (messageCount - n)
+        case .bottomOfHistory:  return 2 + messageCount
+        case .inline:           return 3 + messageCount
         }
     }
 

--- a/Sources/BaseChatUI/Views/Settings/PromptInspectorView.swift
+++ b/Sources/BaseChatUI/Views/Settings/PromptInspectorView.swift
@@ -170,7 +170,7 @@ public struct PromptInspectorView: View {
                         Text(slot.label)
                             .font(.body)
                             .foregroundStyle(.primary)
-                        Text("depth \(slot.depth)")
+                        Text(slot.position.displayName)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -192,7 +192,7 @@ public struct PromptInspectorView: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("\(slot.label), depth \(slot.depth), \(slot.tokenCount) tokens")
+            .accessibilityLabel("\(slot.label), \(slot.position.displayName), \(slot.tokenCount) tokens")
             .accessibilityHint(isExpanded ? "Tap to collapse content" : "Tap to expand content")
 
             // Expanded content
@@ -247,35 +247,35 @@ extension PromptInspectorView {
                 label: "System Prompt",
                 content: "You are a helpful assistant. Respond clearly and concisely. Follow the user's instructions carefully.",
                 tokenCount: 24,
-                depth: 0
+                position: .systemPreamble
             ),
             ResolvedSlot(
                 id: "charDef",
                 label: "Character Definition",
                 content: "Name: Aria\nPersonality: Warm, knowledgeable, slightly witty. Speaks in complete sentences.\nScenario: Aria is a librarian at a magical library that contains books from every timeline.",
                 tokenCount: 48,
-                depth: 0
+                position: .contextSetup
             ),
             ResolvedSlot(
                 id: "lorebook_ancient_library",
                 label: "Lorebook: Ancient Library",
                 content: "The Ancient Library of Thessalonica was built in the 3rd century and contains scrolls that rewrite themselves based on the reader's intent.",
                 tokenCount: 32,
-                depth: 1
+                position: .atDepth(1)
             ),
             ResolvedSlot(
                 id: "lorebook_magic_system",
                 label: "Lorebook: Magic System",
                 content: "Magic in this world is powered by resonance — the ability to harmonize one's intent with the ambient flow of arcane energy.",
                 tokenCount: 28,
-                depth: 1
+                position: .atDepth(1)
             ),
             ResolvedSlot(
                 id: "authorsNote",
                 label: "Author's Note",
                 content: "[Write in a descriptive, literary style. Focus on sensory details and character emotions.]",
                 tokenCount: 18,
-                depth: 4
+                position: .atDepth(4)
             ),
         ]
 

--- a/Tests/BaseChatCoreTests/PromptAssemblerTests.swift
+++ b/Tests/BaseChatCoreTests/PromptAssemblerTests.swift
@@ -38,7 +38,7 @@ struct PromptAssemblerTests {
         )
         #expect(result.orderedSlots.count == 1)
         #expect(result.orderedSlots[0].id == "system")
-        #expect(result.orderedSlots[0].depth == 0)
+        #expect(result.orderedSlots[0].position == .systemPreamble)
         #expect(result.orderedSlots[0].content == "Be helpful")
     }
 
@@ -73,10 +73,10 @@ struct PromptAssemblerTests {
         #expect(result.orderedSlots[0].id == "a")
     }
 
-    @Test func test_assemble_slotsAreSortedByDepth() {
+    @Test func test_assemble_slotsAreSortedByPosition() {
         let slots = [
-            PromptSlot(id: "deep", content: "deep", depth: 5, label: "Deep"),
-            PromptSlot(id: "shallow", content: "shallow", depth: 1, label: "Shallow"),
+            PromptSlot(id: "deep", content: "deep", position: .atDepth(5), label: "Deep"),
+            PromptSlot(id: "shallow", content: "shallow", position: .atDepth(1), label: "Shallow"),
         ]
         let result = PromptAssembler.assemble(
             slots: slots, messages: [], systemPrompt: nil,
@@ -132,9 +132,9 @@ struct PromptAssemblerTests {
 
     // MARK: - Depth Insertion
 
-    @Test func test_assemble_depthSlot_insertedCorrectly() {
+    @Test func test_assemble_atDepthSlot_insertedCorrectly() {
         let slots = [
-            PromptSlot(id: "note", content: "author note", depth: 2, label: "Author's Note"),
+            PromptSlot(id: "note", content: "author note", position: .atDepth(2), label: "Author's Note"),
         ]
         let messages = (0..<5).map { i in
             makeMessage(role: .user, content: "msg\(i)")
@@ -143,8 +143,8 @@ struct PromptAssemblerTests {
             slots: slots, messages: messages, systemPrompt: nil,
             contextSize: 10000, responseBuffer: 0, tokenizer: tok
         )
-        // Depth 2 = 2 turns from bottom. Messages: msg0, msg1, msg2, [note], msg3, msg4
-        let contents = result.messages.map(\.content)
+        // atDepth(2) = 2 turns from bottom. Messages: msg0, msg1, msg2, [note], msg3, msg4
+        let contents = result.messages.map { $0.content }
         #expect(contents.contains("author note"))
         if let noteIndex = contents.firstIndex(of: "author note") {
             // Should be 2 from the end (before last 2 messages)

--- a/Tests/BaseChatCoreTests/PromptAssemblerTests.swift
+++ b/Tests/BaseChatCoreTests/PromptAssemblerTests.swift
@@ -118,7 +118,7 @@ struct PromptAssemblerTests {
             contextSize: 100, responseBuffer: 10, tokenizer: tok
         )
         // Available for messages: 100 - 50 - 10 = 40 tokens = 4 history messages of 10 chars
-        // result.messages includes the depth-0 slot as a system message too
+        // result.messages includes the contextSetup slot as a system message too
         let historyMessages = result.messages.filter { $0.role != "system" }
         #expect(historyMessages.count == 4)
     }

--- a/Tests/BaseChatCoreTests/PromptAssemblerTests.swift
+++ b/Tests/BaseChatCoreTests/PromptAssemblerTests.swift
@@ -74,16 +74,21 @@ struct PromptAssemblerTests {
     }
 
     @Test func test_assemble_slotsAreSortedByPosition() {
+        // atDepth(5) is higher in history (5 messages from bottom) than atDepth(1),
+        // so it should appear first (lower sort index) in the assembled prompt.
+        let messages = (0..<6).map {
+            ChatMessageRecord(role: .user, content: "msg\($0)", sessionID: UUID())
+        }
         let slots = [
             PromptSlot(id: "deep", content: "deep", position: .atDepth(5), label: "Deep"),
             PromptSlot(id: "shallow", content: "shallow", position: .atDepth(1), label: "Shallow"),
         ]
         let result = PromptAssembler.assemble(
-            slots: slots, messages: [], systemPrompt: nil,
-            contextSize: 1000, tokenizer: tok
+            slots: slots, messages: messages, systemPrompt: nil,
+            contextSize: 10000, responseBuffer: 0, tokenizer: tok
         )
-        #expect(result.orderedSlots[0].id == "shallow")
-        #expect(result.orderedSlots[1].id == "deep")
+        #expect(result.orderedSlots[0].id == "deep")
+        #expect(result.orderedSlots[1].id == "shallow")
     }
 
     @Test func test_assemble_tokenBudget_capsSlotTokens() {

--- a/Tests/BaseChatCoreTests/PromptAssemblyPerformanceTests.swift
+++ b/Tests/BaseChatCoreTests/PromptAssemblyPerformanceTests.swift
@@ -21,7 +21,7 @@ final class PromptAssemblyPerformanceTests: XCTestCase {
             PromptSlot(
                 id: "slot_\(i)",
                 content: "This is extra slot content number \(i) that adds context to the conversation.",
-                depth: i,
+                position: .atDepth(i),
                 label: "Slot \(i)"
             )
         }

--- a/Tests/BaseChatCoreTests/PromptSlotPositionTests.swift
+++ b/Tests/BaseChatCoreTests/PromptSlotPositionTests.swift
@@ -82,6 +82,14 @@ struct PromptSlotPositionTests {
         #expect(!PromptSlotPosition.inline.isTopSlot)
     }
 
+    @Test func test_decode_atDepth_rejectsNegativeDepth() throws {
+        let json = #"{"type":"atDepth","depth":-1}"#
+        let data = Data(json.utf8)
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(PromptSlotPosition.self, from: data)
+        }
+    }
+
     // MARK: - Codable round-trip
 
     @Test func test_codable_roundTrip_allCases() throws {
@@ -189,5 +197,31 @@ struct PromptSlotPositionTests {
             contextSize: 10000, responseBuffer: 0, tokenizer: CharTokenizer()
         )
         #expect(result.messages.last?.content == "inline note")
+    }
+
+    @Test func test_assembler_multipleAtDepth_insertionIndicesStable() {
+        // Regression: with two slots at different depths, each slot should end up the
+        // correct number of original messages from the bottom — inserting one slot must
+        // not shift the target index of the other.
+        let messages = (0..<5).map { makeMessage(role: .user, content: "msg\($0)") }
+        let slots = [
+            PromptSlot(id: "deep", content: "deep",    position: .atDepth(4), label: "Deep"),
+            PromptSlot(id: "shallow", content: "shallow", position: .atDepth(1), label: "Shallow"),
+        ]
+        let result = PromptAssembler.assemble(
+            slots: slots, messages: messages, systemPrompt: nil,
+            contextSize: 10000, responseBuffer: 0, tokenizer: CharTokenizer()
+        )
+        let contents = result.messages.map { $0.content }
+        // "deep" should have 4 original messages after it; "shallow" should have 1.
+        guard let deepIdx = contents.firstIndex(of: "deep"),
+              let shallowIdx = contents.firstIndex(of: "shallow") else {
+            Issue.record("slots not found in messages")
+            return
+        }
+        let afterDeep    = contents[(deepIdx + 1)...].filter { $0.hasPrefix("msg") }.count
+        let afterShallow = contents[(shallowIdx + 1)...].filter { $0.hasPrefix("msg") }.count
+        #expect(afterDeep == 4)
+        #expect(afterShallow == 1)
     }
 }

--- a/Tests/BaseChatCoreTests/PromptSlotPositionTests.swift
+++ b/Tests/BaseChatCoreTests/PromptSlotPositionTests.swift
@@ -1,0 +1,189 @@
+import Testing
+import Foundation
+@testable import BaseChatCore
+
+@Suite("PromptSlotPosition")
+struct PromptSlotPositionTests {
+
+    // MARK: - Sort ordering
+
+    @Test func test_sortIndex_systemPreamble_isLowestAmongTopSlots() {
+        let mc = 10
+        #expect(
+            PromptSlotPosition.systemPreamble.sortIndex(messageCount: mc) <
+            PromptSlotPosition.contextSetup.sortIndex(messageCount: mc)
+        )
+    }
+
+    @Test func test_sortIndex_contextSetup_comesBeforeAllHistorySlots() {
+        let mc = 10
+        let ctxIdx = PromptSlotPosition.contextSetup.sortIndex(messageCount: mc)
+        #expect(ctxIdx < PromptSlotPosition.bottomOfHistory.sortIndex(messageCount: mc))
+        #expect(ctxIdx < PromptSlotPosition.inline.sortIndex(messageCount: mc))
+        #expect(ctxIdx < PromptSlotPosition.atDepth(1).sortIndex(messageCount: mc))
+        #expect(ctxIdx < PromptSlotPosition.topOfHistory.sortIndex(messageCount: mc))
+    }
+
+    @Test func test_sortIndex_atDepth_orderedByN() {
+        let mc = 10
+        #expect(
+            PromptSlotPosition.atDepth(1).sortIndex(messageCount: mc) <
+            PromptSlotPosition.atDepth(5).sortIndex(messageCount: mc)
+        )
+    }
+
+    @Test func test_sortIndex_topOfHistory_higherThanAtDepthMessageCountMinusOne() {
+        let mc = 5
+        #expect(
+            PromptSlotPosition.atDepth(mc - 1).sortIndex(messageCount: mc) <
+            PromptSlotPosition.topOfHistory.sortIndex(messageCount: mc)
+        )
+    }
+
+    // MARK: - Insertion depth
+
+    @Test func test_insertionDepth_atDepthZero_equalsBottomOfHistory() {
+        let mc = 5
+        #expect(
+            PromptSlotPosition.atDepth(0).insertionDepth(messageCount: mc) ==
+            PromptSlotPosition.bottomOfHistory.insertionDepth(messageCount: mc)
+        )
+    }
+
+    @Test func test_insertionDepth_topOfHistory_equalsMessageCount() {
+        let mc = 7
+        #expect(PromptSlotPosition.topOfHistory.insertionDepth(messageCount: mc) == mc)
+    }
+
+    @Test func test_insertionDepth_inline_equalsZero() {
+        #expect(PromptSlotPosition.inline.insertionDepth(messageCount: 10) == 0)
+    }
+
+    @Test func test_insertionDepth_bottomOfHistory_equalsZero() {
+        #expect(PromptSlotPosition.bottomOfHistory.insertionDepth(messageCount: 10) == 0)
+    }
+
+    // MARK: - isTopSlot
+
+    @Test func test_isTopSlot_systemPreambleAndContextSetup_areTopSlots() {
+        #expect(PromptSlotPosition.systemPreamble.isTopSlot)
+        #expect(PromptSlotPosition.contextSetup.isTopSlot)
+    }
+
+    @Test func test_isTopSlot_historyPositions_areNotTopSlots() {
+        #expect(!PromptSlotPosition.atDepth(0).isTopSlot)
+        #expect(!PromptSlotPosition.atDepth(3).isTopSlot)
+        #expect(!PromptSlotPosition.topOfHistory.isTopSlot)
+        #expect(!PromptSlotPosition.bottomOfHistory.isTopSlot)
+        #expect(!PromptSlotPosition.inline.isTopSlot)
+    }
+
+    // MARK: - Codable round-trip
+
+    @Test func test_codable_roundTrip_allCases() throws {
+        let cases: [PromptSlotPosition] = [
+            .systemPreamble, .contextSetup, .atDepth(0), .atDepth(3),
+            .topOfHistory, .bottomOfHistory, .inline,
+        ]
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        for position in cases {
+            let data = try encoder.encode(position)
+            let decoded = try decoder.decode(PromptSlotPosition.self, from: data)
+            #expect(decoded == position)
+        }
+    }
+
+    // MARK: - Assembler placement
+
+    private func makeMessage(role: MessageRole, content: String) -> ChatMessageRecord {
+        ChatMessageRecord(role: role, content: content, sessionID: UUID())
+    }
+
+    private struct CharTokenizer: TokenizerProvider {
+        func tokenCount(_ text: String) -> Int { max(1, text.count) }
+    }
+
+    @Test func test_assembler_systemPreamble_appearsBeforeContextSetup() {
+        let slots = [
+            PromptSlot(id: "ctx", content: "context", position: .contextSetup, label: "Ctx"),
+            PromptSlot(id: "pre", content: "preamble", position: .systemPreamble, label: "Pre"),
+        ]
+        let result = PromptAssembler.assemble(
+            slots: slots, messages: [], systemPrompt: nil,
+            contextSize: 1000, tokenizer: CharTokenizer()
+        )
+        #expect(result.orderedSlots[0].id == "pre")
+        #expect(result.orderedSlots[1].id == "ctx")
+        #expect(result.messages[0].content == "preamble")
+        #expect(result.messages[1].content == "context")
+    }
+
+    @Test func test_assembler_atDepth_insertedNFromBottom() {
+        let messages = (0..<5).map { makeMessage(role: .user, content: "msg\($0)") }
+        let slots = [
+            PromptSlot(id: "note", content: "note", position: .atDepth(2), label: "Note"),
+        ]
+        let result = PromptAssembler.assemble(
+            slots: slots, messages: messages, systemPrompt: nil,
+            contextSize: 10000, responseBuffer: 0, tokenizer: CharTokenizer()
+        )
+        let contents = result.messages.map { $0.content }
+        if let noteIndex = contents.firstIndex(of: "note") {
+            #expect(contents.count - noteIndex - 1 == 2)
+        } else {
+            Issue.record("note slot not found in messages")
+        }
+    }
+
+    @Test func test_assembler_topOfHistory_appearsBeforeAllMessages() {
+        let messages = (0..<3).map { makeMessage(role: .user, content: "msg\($0)") }
+        let slots = [
+            PromptSlot(id: "top", content: "top note", position: .topOfHistory, label: "Top"),
+        ]
+        let result = PromptAssembler.assemble(
+            slots: slots, messages: messages, systemPrompt: nil,
+            contextSize: 10000, responseBuffer: 0, tokenizer: CharTokenizer()
+        )
+        #expect(result.messages.first?.content == "top note")
+    }
+
+    @Test func test_assembler_bottomOfHistory_appearsAfterAllMessages() {
+        let messages = (0..<3).map { makeMessage(role: .user, content: "msg\($0)") }
+        let slots = [
+            PromptSlot(id: "bottom", content: "bottom note", position: .bottomOfHistory, label: "Bottom"),
+        ]
+        let result = PromptAssembler.assemble(
+            slots: slots, messages: messages, systemPrompt: nil,
+            contextSize: 10000, responseBuffer: 0, tokenizer: CharTokenizer()
+        )
+        #expect(result.messages.last?.content == "bottom note")
+    }
+
+    @Test func test_assembler_atDepthZero_placedSameAsBottomOfHistory() {
+        let messages = (0..<3).map { makeMessage(role: .user, content: "msg\($0)") }
+        let r1 = PromptAssembler.assemble(
+            slots: [PromptSlot(id: "a", content: "note", position: .atDepth(0), label: "A")],
+            messages: messages, systemPrompt: nil,
+            contextSize: 10000, responseBuffer: 0, tokenizer: CharTokenizer()
+        )
+        let r2 = PromptAssembler.assemble(
+            slots: [PromptSlot(id: "b", content: "note", position: .bottomOfHistory, label: "B")],
+            messages: messages, systemPrompt: nil,
+            contextSize: 10000, responseBuffer: 0, tokenizer: CharTokenizer()
+        )
+        #expect(r1.messages.map { $0.content } == r2.messages.map { $0.content })
+    }
+
+    @Test func test_assembler_inline_placedAtEnd() {
+        let messages = (0..<3).map { makeMessage(role: .user, content: "msg\($0)") }
+        let slots = [
+            PromptSlot(id: "il", content: "inline note", position: .inline, label: "Inline"),
+        ]
+        let result = PromptAssembler.assemble(
+            slots: slots, messages: messages, systemPrompt: nil,
+            contextSize: 10000, responseBuffer: 0, tokenizer: CharTokenizer()
+        )
+        #expect(result.messages.last?.content == "inline note")
+    }
+}

--- a/Tests/BaseChatCoreTests/PromptSlotPositionTests.swift
+++ b/Tests/BaseChatCoreTests/PromptSlotPositionTests.swift
@@ -25,18 +25,22 @@ struct PromptSlotPositionTests {
     }
 
     @Test func test_sortIndex_atDepth_orderedByN() {
+        // Larger n means higher placement in history (further from latest turn),
+        // so it should have a smaller sort index (appears earlier in the prompt).
         let mc = 10
         #expect(
-            PromptSlotPosition.atDepth(1).sortIndex(messageCount: mc) <
-            PromptSlotPosition.atDepth(5).sortIndex(messageCount: mc)
+            PromptSlotPosition.atDepth(5).sortIndex(messageCount: mc) <
+            PromptSlotPosition.atDepth(1).sortIndex(messageCount: mc)
         )
     }
 
     @Test func test_sortIndex_topOfHistory_higherThanAtDepthMessageCountMinusOne() {
+        // topOfHistory has the lowest history sort index (2), so it appears before
+        // any atDepth(n) slot regardless of n.
         let mc = 5
         #expect(
-            PromptSlotPosition.atDepth(mc - 1).sortIndex(messageCount: mc) <
-            PromptSlotPosition.topOfHistory.sortIndex(messageCount: mc)
+            PromptSlotPosition.topOfHistory.sortIndex(messageCount: mc) <
+            PromptSlotPosition.atDepth(mc - 1).sortIndex(messageCount: mc)
         )
     }
 

--- a/Tests/BaseChatE2ETests/ContextOverflowE2ETests.swift
+++ b/Tests/BaseChatE2ETests/ContextOverflowE2ETests.swift
@@ -193,7 +193,7 @@ struct ContextOverflowE2ETests {
 
     @Test func assembler_systemPromptAndSlots_budgetedCorrectly() {
         let slots = [
-            PromptSlot(id: "note", content: "Author's note", depth: 2, label: "Note"),
+            PromptSlot(id: "note", content: "Author's note", position: .atDepth(2), label: "Note"),
         ]
         let messages = (0..<10).map { i in
             makeMessage(


### PR DESCRIPTION
Closes #109

## Summary

Replaces `PromptSlot.depth: Int` and `ResolvedSlot.depth: Int` with the typed `PromptSlotPosition` enum, giving each slot a semantic position in the assembled prompt.

## New type

```swift
public enum PromptSlotPosition: Hashable, Sendable, Codable {
    case systemPreamble     // Before all other content
    case contextSetup       // After system prompt, before history
    case atDepth(Int)       // N messages from the bottom of history (n >= 0)
    case topOfHistory       // Just above the oldest visible message
    case bottomOfHistory    // Just above the latest user message
    case inline             // Immediately before the model turn
}
```

`atDepth(0)` is equivalent to `bottomOfHistory`. Negative depth values are rejected by `precondition` in `PromptSlot.init`.

## Changes

- **`PromptSlot.swift`** — adds `PromptSlotPosition` (with `Codable`, helpers, and `displayName`); replaces `depth: Int` on `PromptSlot` and `ResolvedSlot`
- **`PromptAssembler.swift`** — sorts and inserts slots via `position.sortIndex` / `position.insertionDepth`; system prompt slot uses `.systemPreamble`
- **`PromptInspectorView.swift`** — displays `position.displayName` instead of raw depth integer
- **`PromptSlotPositionTests.swift`** _(new)_ — 16 tests covering sort ordering, insertion depth, `isTopSlot`, Codable round-trip, and assembler placement for all six positions
- Existing `PromptAssemblerTests`, `PromptAssemblyPerformanceTests`, `ContextOverflowE2ETests` updated to use position API

## ST mapping (no importer present)

If/when an ST importer is added: `beforeCharDef` → `.contextSetup`, `afterCharDef` → `.atDepth(0)`.