### PR TITLE
fix: reset isGenerating on synchronous backend throw, extend retry to all retryable errors

### DIFF
--- a/Sources/BaseChatBackends/ClaudeBackend.swift
+++ b/Sources/BaseChatBackends/ClaudeBackend.swift
@@ -74,7 +74,7 @@ public final class ClaudeBackend: InferenceBackend, ConversationHistoryReceiver,
     private static let pinnedSession: URLSession = {
         let delegate = PinnedSessionDelegate()
         let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 60
+        config.timeoutIntervalForRequest = 300
         return URLSession(configuration: config, delegate: delegate, delegateQueue: nil)
     }()
 

--- a/Sources/BaseChatCore/Services/InferenceService.swift
+++ b/Sources/BaseChatCore/Services/InferenceService.swift
@@ -351,11 +351,16 @@ public final class InferenceService {
             historyReceiver.setConversationHistory(messages)
         }
 
-        return try backend.generate(
-            prompt: prompt,
-            systemPrompt: effectiveSystemPrompt,
-            config: config
-        )
+        do {
+            return try backend.generate(
+                prompt: prompt,
+                systemPrompt: effectiveSystemPrompt,
+                config: config
+            )
+        } catch {
+            isGenerating = false
+            throw error
+        }
     }
 
     /// Token usage from the last cloud API generation, if available.

--- a/Sources/BaseChatCore/Services/RetryPolicy.swift
+++ b/Sources/BaseChatCore/Services/RetryPolicy.swift
@@ -45,7 +45,7 @@ public func withExponentialBackoff<T>(
                 throw error
             }
 
-            Log.network.info("Rate limited (attempt \(attempt + 1)/\(maxRetries)). Retrying in \(String(format: "%.1f", delay))s")
+            Log.network.info("Retryable error (attempt \(attempt + 1)/\(maxRetries), \(error)). Retrying in \(String(format: "%.1f", delay))s")
 
             try await Task.sleep(for: .milliseconds(Int(delay * 1000)))
             totalDelayed += delay

--- a/Sources/BaseChatCore/Services/RetryPolicy.swift
+++ b/Sources/BaseChatCore/Services/RetryPolicy.swift
@@ -1,10 +1,12 @@
 import Foundation
 
-/// Executes an async operation with exponential backoff on rate-limit errors.
+/// Executes an async operation with exponential backoff on retryable errors.
 ///
-/// Retries only `CloudBackendError.rateLimited` errors. All other errors are
-/// thrown immediately. Uses the `Retry-After` header value when available,
-/// otherwise falls back to exponential backoff with jitter.
+/// Retries any `CloudBackendError` where `isRetryable` is true (rate limits,
+/// network errors, stream interruptions, 5xx server errors). Non-retryable
+/// errors are thrown immediately. Uses the `Retry-After` header value when
+/// available (rate limits only), otherwise falls back to exponential backoff
+/// with jitter.
 ///
 /// - Parameters:
 ///   - maxRetries: Maximum number of retry attempts (default 3).
@@ -12,7 +14,7 @@ import Foundation
 ///   - maxTotalDelay: Maximum cumulative wait in seconds across all retries (default 60.0).
 ///   - operation: The async throwing operation to execute.
 /// - Returns: The result of the operation.
-/// - Throws: The last `rateLimited` error if all retries are exhausted, or any non-rate-limit error immediately.
+/// - Throws: The last retryable error if all retries are exhausted, or any non-retryable error immediately.
 public func withExponentialBackoff<T>(
     maxRetries: Int = 3,
     baseDelay: TimeInterval = 1.0,
@@ -25,18 +27,17 @@ public func withExponentialBackoff<T>(
         do {
             return try await operation()
         } catch let error as CloudBackendError {
-            guard case .rateLimited(let retryAfter) = error else {
-                throw error
-            }
+            guard error.isRetryable else { throw error }
 
             // Last attempt — don't retry, just throw.
             if attempt == maxRetries {
                 throw error
             }
 
-            // Calculate delay: use Retry-After if present, otherwise exponential backoff with jitter.
+            // Calculate delay: use Retry-After if present (only for rate limits), otherwise exponential backoff with jitter.
             let exponentialDelay = baseDelay * pow(2.0, Double(attempt))
             let jitter = Double.random(in: 0...(exponentialDelay * 0.25))
+            let retryAfter: TimeInterval? = if case .rateLimited(let ra) = error { ra } else { nil }
             let delay = retryAfter ?? (exponentialDelay + jitter)
 
             // Respect the total delay cap.

--- a/Tests/BaseChatCoreTests/InferenceServiceTests.swift
+++ b/Tests/BaseChatCoreTests/InferenceServiceTests.swift
@@ -373,6 +373,65 @@ final class InferenceServiceTests: XCTestCase {
         XCTAssertEqual(backend.unloadCallCount, 1, "Late completion should unload its stale backend")
     }
 
+    // MARK: - isGenerating lifecycle
+
+    func test_generate_backendThrowsSynchronously_resetsIsGenerating() async throws {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.shouldThrowOnGenerate = InferenceError.inferenceFailure("boom")
+
+        let service = InferenceService(backend: mock, name: "Mock")
+
+        do {
+            _ = try service.generate(messages: [("user", "hello")])
+            XCTFail("Expected generate to throw")
+        } catch {
+            // expected
+        }
+
+        XCTAssertFalse(service.isGenerating,
+                        "isGenerating must be reset when backend.generate() throws synchronously")
+    }
+
+    func test_generate_streamCompletesNormally_isGeneratingResetByFinish() async throws {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.tokensToYield = ["a", "b"]
+
+        let service = InferenceService(backend: mock, name: "Mock")
+        let stream = try service.generate(messages: [("user", "hi")])
+
+        for try await _ in stream {}
+
+        service.generationDidFinish()
+        XCTAssertFalse(service.isGenerating,
+                        "isGenerating should be false after generationDidFinish()")
+    }
+
+    func test_generate_streamErrorMidStream_isGeneratingStillTrue() async throws {
+        let midStreamBackend = MidStreamErrorBackend(
+            tokensBeforeError: ["partial"],
+            errorToThrow: NSError(domain: "test", code: 1)
+        )
+        let service = InferenceService(backend: midStreamBackend, name: "MidStream")
+
+        let stream = try service.generate(messages: [("user", "hi")])
+
+        var caughtError = false
+        do {
+            for try await _ in stream {}
+        } catch {
+            caughtError = true
+        }
+
+        XCTAssertTrue(caughtError, "Stream should have thrown mid-stream")
+        // The service's isGenerating stays true because only generationDidFinish() resets it.
+        // The backend's own isGenerating is reset by its stream, but InferenceService.isGenerating
+        // is set at the service level (line 328) and only cleared by generationDidFinish() or stopGeneration().
+        XCTAssertTrue(service.isGenerating,
+                       "isGenerating should remain true until generationDidFinish() is called — mid-stream errors don't auto-reset it")
+    }
+
     // MARK: - Cloud backend interop
 
     func test_generate_cloudBackend_passesConversationHistory() throws {

--- a/Tests/BaseChatCoreTests/RetryPolicyTests.swift
+++ b/Tests/BaseChatCoreTests/RetryPolicyTests.swift
@@ -89,6 +89,42 @@ final class RetryPolicyTests: XCTestCase {
         XCTAssertLessThan(callCount, 10, "Should stop before max retries due to delay cap")
     }
 
+    // MARK: - Retries Network Error
+
+    func test_withExponentialBackoff_retriesNetworkError() async throws {
+        var callCount = 0
+        let result: String = try await withExponentialBackoff(baseDelay: 0.01) {
+            callCount += 1
+            if callCount < 3 {
+                throw CloudBackendError.networkError(
+                    underlying: NSError(domain: "test", code: -1)
+                )
+            }
+            return "recovered"
+        }
+        XCTAssertEqual(result, "recovered")
+        XCTAssertEqual(callCount, 3, "Should retry networkError twice before succeeding")
+    }
+
+    // MARK: - Does Not Retry Auth Error
+
+    func test_withExponentialBackoff_doesNotRetryAuthError() async {
+        var callCount = 0
+        do {
+            _ = try await withExponentialBackoff(baseDelay: 0.01) {
+                callCount += 1
+                throw CloudBackendError.authenticationFailed(provider: "Test")
+            }
+            XCTFail("Should have thrown")
+        } catch {
+            guard case CloudBackendError.authenticationFailed = error else {
+                XCTFail("Expected authenticationFailed, got: \(error)")
+                return
+            }
+        }
+        XCTAssertEqual(callCount, 1, "Should not retry non-retryable authenticationFailed error")
+    }
+
     // MARK: - Uses Retry-After Header
 
     func test_usesRetryAfterWhenProvided() async throws {


### PR DESCRIPTION
## Summary

- **InferenceService state machine bug**: `isGenerating` was set to `true` before `backend.generate()` — if the backend threw synchronously (e.g., missing API key), the flag stayed stuck permanently. Wrapped in do/catch to reset on failure.
- **Claude timeout**: Changed `timeoutIntervalForRequest` from 60s to 300s, matching all other backends. The 60s timeout was causing premature failures on streaming responses.
- **Retry policy expanded**: `withExponentialBackoff` now retries all `isRetryable` CloudBackendErrors (`.networkError`, `.streamInterrupted`, 5xx `.serverError`), not just `.rateLimited`. `Retry-After` header is still extracted only for rate-limit errors.

## Test plan

- [x] `test_generate_backendThrowsSynchronously_resetsIsGenerating` — verifies the state machine fix
- [x] `test_generate_streamCompletesNormally_isGeneratingResetByFinish` — documents normal lifecycle
- [x] `test_generate_streamErrorMidStream_isGeneratingStillTrue` — documents expected contract
- [x] `test_withExponentialBackoff_retriesNetworkError` — verifies expanded retry
- [x] `test_withExponentialBackoff_doesNotRetryAuthError` — verifies non-retryable errors propagate
- [x] BaseChatCoreTests pass (83 tests)
- [x] BaseChatBackendsTests pass (77 tests)

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)