### PR TITLE
test: add stream-error injection and cancellation checks to test mocks

### DIFF
--- a/Sources/BaseChatTestSupport/MidStreamErrorBackend.swift
+++ b/Sources/BaseChatTestSupport/MidStreamErrorBackend.swift
@@ -45,6 +45,7 @@ public final class MidStreamErrorBackend: InferenceBackend, @unchecked Sendable 
         return AsyncThrowingStream { [self] continuation in
             Task {
                 for token in tokens {
+                    if Task.isCancelled { break }
                     continuation.yield(token)
                 }
                 self.isGenerating = false

--- a/Sources/BaseChatTestSupport/MockInferenceBackend.swift
+++ b/Sources/BaseChatTestSupport/MockInferenceBackend.swift
@@ -5,7 +5,7 @@ import BaseChatCore
 /// Configurable mock inference backend for testing.
 ///
 /// Shared across all test targets via the `BaseChatTestSupport` module.
-public final class MockInferenceBackend: InferenceBackend, @unchecked Sendable {
+public final class MockInferenceBackend: InferenceBackend, ConversationHistoryReceiver, @unchecked Sendable {
     public var isModelLoaded: Bool = false
     public var isGenerating: Bool = false
     public var capabilities: BackendCapabilities
@@ -14,6 +14,11 @@ public final class MockInferenceBackend: InferenceBackend, @unchecked Sendable {
     public var tokensToYield: [String] = ["Hello", " world"]
     public var shouldThrowOnGenerate: Error? = nil
     public var shouldThrowOnLoad: Error? = nil
+
+    /// Error to throw INSIDE the stream after yielding all tokens.
+    /// This simulates network/stream failures that real backends deliver
+    /// via the AsyncThrowingStream rather than from generate() itself.
+    public var shouldThrowInsideStream: Error?
 
     // Track calls
     public var loadModelCallCount = 0
@@ -75,6 +80,10 @@ public final class MockInferenceBackend: InferenceBackend, @unchecked Sendable {
                     continuation.yield(token)
                 }
                 self.isGenerating = false
+                if let streamError = self.shouldThrowInsideStream {
+                    continuation.finish(throwing: streamError)
+                    return
+                }
                 continuation.finish()
             }
         }
@@ -91,5 +100,13 @@ public final class MockInferenceBackend: InferenceBackend, @unchecked Sendable {
         unloadCallCount += 1
         isModelLoaded = false
         isGenerating = false
+    }
+
+    // MARK: - ConversationHistoryReceiver
+
+    public var lastReceivedHistory: [(role: String, content: String)]?
+
+    public func setConversationHistory(_ messages: [(role: String, content: String)]) {
+        lastReceivedHistory = messages
     }
 }


### PR DESCRIPTION
## Summary

- **MockInferenceBackend**: Added `shouldThrowInsideStream` property — yields all tokens then finishes with the error inside the stream, exercising the stream-error code path that real backends use for network failures. Existing `shouldThrowOnGenerate` (synchronous throw) is unchanged.
- **MockInferenceBackend**: Added `ConversationHistoryReceiver` conformance with `lastReceivedHistory` tracking.
- **MidStreamErrorBackend**: Added `Task.isCancelled` check before each token yield, matching real backend cancellation patterns.

These are additive changes — no existing test behavior is modified.

## Test plan

- [x] BaseChatCoreTests pass (83 tests)
- [x] BaseChatUITests pass (289 tests) — StreamingFailureTests, CancellationTests verified
- [x] BaseChatBackendsTests pass (77 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)