### PR TITLE
feat: support MLX search and snapshot downloads

### DIFF
--- a/Sources/BaseChatCore/Models/ModelDownloadPlan.swift
+++ b/Sources/BaseChatCore/Models/ModelDownloadPlan.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// A single file that belongs to a model download.
+public struct ModelDownloadFile: Sendable, Hashable, Codable {
+    /// Relative path inside the model snapshot directory.
+    public let relativePath: String
+    /// Direct HuggingFace download URL for this file.
+    public let url: URL
+    /// Expected file size in bytes, when known.
+    public let sizeBytes: UInt64
+
+    public init(relativePath: String, url: URL, sizeBytes: UInt64) {
+        self.relativePath = relativePath
+        self.url = url
+        self.sizeBytes = sizeBytes
+    }
+}
+
+/// The concrete download work needed for a `DownloadableModel`.
+public enum ModelDownloadPlan: Sendable, Hashable {
+    case singleFile(url: URL)
+    case snapshot(files: [ModelDownloadFile])
+}

--- a/Sources/BaseChatCore/Models/ModelInfo.swift
+++ b/Sources/BaseChatCore/Models/ModelInfo.swift
@@ -99,19 +99,36 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
         let configURL = url.appendingPathComponent("config.json")
         guard fileManager.fileExists(atPath: configURL.path) else { return nil }
 
-        // Sum the sizes of all files in the directory.
         guard let contents = try? fileManager.contentsOfDirectory(
             at: url,
-            includingPropertiesForKeys: [.fileSizeKey],
+            includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey],
             options: [.skipsHiddenFiles]
         ) else {
             return nil
         }
 
-        let totalSize = contents.reduce(UInt64(0)) { sum, fileURL in
-            let size = (try? fileURL.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
-            return sum + UInt64(size)
+        let allFiles = contents.flatMap { child -> [URL] in
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: child.path, isDirectory: &isDirectory), isDirectory.boolValue else {
+                return [child]
+            }
+            guard let enumerator = fileManager.enumerator(
+                at: child,
+                includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey],
+                options: [.skipsHiddenFiles]
+            ) else {
+                return [child]
+            }
+            return enumerator.compactMap { $0 as? URL }
         }
+
+        let totalSize = allFiles.reduce(UInt64(0)) { sum, fileURL in
+            let values = try? fileURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+            guard values?.isRegularFile == true else { return sum }
+            return sum + UInt64(values?.fileSize ?? 0)
+        }
+        let hasSafetensors = allFiles.contains { $0.pathExtension.lowercased() == "safetensors" }
+        guard hasSafetensors else { return nil }
 
         self.id = UUID()
         self.fileName = url.lastPathComponent

--- a/Sources/BaseChatCore/Services/BackgroundDownloadManager.swift
+++ b/Sources/BaseChatCore/Services/BackgroundDownloadManager.swift
@@ -48,8 +48,36 @@ public final class BackgroundDownloadManager: NSObject {
 
     // MARK: - Private State
 
-    /// Maps `URLSessionTask.taskIdentifier` to `DownloadableModel.id` for delegate routing.
-    private var downloadTaskMap: [Int: String] = [:]
+    private struct TaskContext: Codable, Sendable {
+        let modelID: String
+        let relativePath: String?
+        let expectedBytes: Int64
+    }
+
+    private struct SnapshotFileMetadata: Codable, Sendable {
+        let relativePath: String
+        let sizeBytes: UInt64
+    }
+
+    private struct SnapshotProgress: Sendable {
+        var bytesDownloaded: Int64
+        var expectedBytes: Int64
+    }
+
+    private struct SnapshotDownloadContext: Sendable {
+        let stagingDirectory: URL
+        let files: [String: SnapshotFileMetadata]
+        let totalBytes: Int64
+        var progressByFile: [String: SnapshotProgress]
+        var completedFiles: Set<String>
+        var taskIDs: Set<Int>
+    }
+
+    /// Maps `URLSessionTask.taskIdentifier` to task metadata for delegate routing.
+    private var taskContexts: [Int: TaskContext] = [:]
+
+    /// Tracks multi-file MLX downloads by logical model ID.
+    private var snapshotDownloads: [String: SnapshotDownloadContext] = [:]
 
     /// The storage service used to determine where to place completed files.
     private let storageService: ModelStorageService
@@ -108,30 +136,26 @@ public final class BackgroundDownloadManager: NSObject {
     /// - Throws: `HuggingFaceError.insufficientDiskSpace` if there isn't enough room.
     @MainActor @discardableResult
     public func startDownload(_ model: DownloadableModel, downloadURL: URL) async throws -> DownloadState {
-        Log.download.info("Starting download for \(model.displayName) from \(downloadURL)")
+        try await startDownload(model, plan: .singleFile(url: downloadURL))
+    }
 
-        // Check disk space.
+    /// Starts a background download using a resolved download plan.
+    @MainActor @discardableResult
+    public func startDownload(_ model: DownloadableModel, plan: ModelDownloadPlan) async throws -> DownloadState {
         try await checkDiskSpace(requiredBytes: model.sizeBytes)
-
-        // Ensure the models directory exists.
         try storageService.ensureModelsDirectory()
 
-        // Create the download state.
         let state = DownloadState(model: model)
-
-        // Create and start the URLSession download task.
-        let task = backgroundSession.downloadTask(with: downloadURL)
-        task.taskDescription = model.id
-
-        // Track the mapping.
-        downloadTaskMap[task.taskIdentifier] = model.id
         activeDownloads[model.id] = state
 
-        // Persist pending download info for reconnection.
-        savePendingDownload(model: model)
-
-        task.resume()
-        Log.download.info("Download task \(task.taskIdentifier) started for \(model.id)")
+        switch plan {
+        case .singleFile(let url):
+            Log.download.info("Starting single-file download for \(model.displayName) from \(url)")
+            try startSingleFileDownload(model: model, url: url)
+        case .snapshot(let files):
+            Log.download.info("Starting snapshot download for \(model.displayName) with \(files.count) files")
+            try startSnapshotDownload(model: model, files: files)
+        }
 
         return state
     }
@@ -142,16 +166,28 @@ public final class BackgroundDownloadManager: NSObject {
     @MainActor public func cancelDownload(id: String) {
         Log.download.info("Cancelling download: \(id)")
 
-        // Find and cancel the URLSession task.
         backgroundSession.getAllTasks { [weak self] tasks in
             guard let self else { return }
-            for task in tasks where task.taskDescription == id {
-                task.cancel()
+            for task in tasks {
+                let context = self.taskContext(
+                    for: task.taskIdentifier,
+                    taskDescription: task.taskDescription
+                )
+                if context?.modelID == id {
+                    task.cancel()
+                }
             }
 
             Task { @MainActor in
                 self.activeDownloads[id]?.markCancelled()
                 self.removePendingDownload(id: id)
+                if let snapshot = self.snapshotDownloads.removeValue(forKey: id) {
+                    do {
+                        try FileManager.default.removeItem(at: snapshot.stagingDirectory)
+                    } catch {
+                        Log.download.error("Failed to remove snapshot staging directory: \(error.localizedDescription)")
+                    }
+                }
             }
         }
     }
@@ -223,8 +259,17 @@ public final class BackgroundDownloadManager: NSObject {
             guard FileManager.default.fileExists(atPath: configPath) else {
                 throw HuggingFaceError.invalidDownloadedFile(reason: "MLX model directory is missing config.json")
             }
-            let contents = try FileManager.default.contentsOfDirectory(atPath: fileURL.path)
-            guard contents.contains(where: { $0.hasSuffix(".safetensors") }) else {
+            guard let enumerator = FileManager.default.enumerator(
+                at: fileURL,
+                includingPropertiesForKeys: [.isRegularFileKey],
+                options: [.skipsHiddenFiles]
+            ) else {
+                throw HuggingFaceError.invalidDownloadedFile(reason: "MLX model directory could not be enumerated")
+            }
+            let hasSafetensors = enumerator
+                .compactMap { $0 as? URL }
+                .contains { $0.pathExtension.lowercased() == "safetensors" }
+            guard hasSafetensors else {
                 throw HuggingFaceError.invalidDownloadedFile(reason: "MLX model directory contains no .safetensors files")
             }
         case .foundation:
@@ -264,16 +309,248 @@ public final class BackgroundDownloadManager: NSObject {
         Log.download.debug("GGUF file validated successfully at \(fileURL.lastPathComponent)")
     }
 
+    // MARK: - Download Coordination
+
+    @MainActor
+    private func startSingleFileDownload(model: DownloadableModel, url: URL) throws {
+        let task = backgroundSession.downloadTask(with: url)
+        let context = TaskContext(
+            modelID: model.id,
+            relativePath: nil,
+            expectedBytes: Int64(model.sizeBytes)
+        )
+        task.taskDescription = encodeTaskDescription(context)
+        taskContexts[task.taskIdentifier] = context
+        try savePendingDownload(model: model)
+        task.resume()
+        Log.download.info("Download task \(task.taskIdentifier) started for \(model.id)")
+    }
+
+    @MainActor
+    internal func prepareSnapshotDownload(
+        model: DownloadableModel,
+        files: [ModelDownloadFile],
+        stagingDirectory: URL
+    ) {
+        let metadataFiles = files.map { SnapshotFileMetadata(relativePath: $0.relativePath, sizeBytes: $0.sizeBytes) }
+        snapshotDownloads[model.id] = SnapshotDownloadContext(
+            stagingDirectory: stagingDirectory,
+            files: Dictionary(uniqueKeysWithValues: metadataFiles.map { ($0.relativePath, $0) }),
+            totalBytes: Int64(model.sizeBytes),
+            progressByFile: Dictionary(uniqueKeysWithValues: metadataFiles.map {
+                ($0.relativePath, SnapshotProgress(bytesDownloaded: 0, expectedBytes: Int64($0.sizeBytes)))
+            }),
+            completedFiles: [],
+            taskIDs: []
+        )
+    }
+
+    @MainActor
+    private func startSnapshotDownload(model: DownloadableModel, files: [ModelDownloadFile]) throws {
+        let stagingDirectory = try makeSnapshotStagingDirectory()
+        prepareSnapshotDownload(model: model, files: files, stagingDirectory: stagingDirectory)
+        guard var context = snapshotDownloads[model.id] else {
+            throw HuggingFaceError.invalidDownloadedFile(reason: "Failed to create MLX snapshot context")
+        }
+
+        for file in files {
+            let task = backgroundSession.downloadTask(with: file.url)
+            let taskContext = TaskContext(
+                modelID: model.id,
+                relativePath: file.relativePath,
+                expectedBytes: Int64(file.sizeBytes)
+            )
+            task.taskDescription = encodeTaskDescription(taskContext)
+            taskContexts[task.taskIdentifier] = taskContext
+            context.taskIDs.insert(task.taskIdentifier)
+            task.resume()
+        }
+
+        snapshotDownloads[model.id] = context
+        try savePendingDownload(
+            model: model,
+            snapshotFiles: files.map { SnapshotFileMetadata(relativePath: $0.relativePath, sizeBytes: $0.sizeBytes) },
+            stagingDirectoryName: stagingDirectory.lastPathComponent
+        )
+    }
+
+    private func makeSnapshotStagingDirectory() throws -> URL {
+        let url = storageService.modelsDirectory
+            .appendingPathComponent(".staging-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func encodeTaskDescription(_ context: TaskContext) -> String {
+        do {
+            let data = try JSONEncoder().encode(context)
+            guard let string = String(data: data, encoding: .utf8) else {
+                Log.download.error("Failed to encode task description for \(context.modelID)")
+                return context.modelID
+            }
+            return string
+        } catch {
+            Log.download.error("Failed to encode task description for \(context.modelID): \(error.localizedDescription)")
+            return context.modelID
+        }
+    }
+
+    private func taskContext(for taskID: Int, taskDescription: String?) -> TaskContext? {
+        if let context = taskContexts[taskID] {
+            return context
+        }
+        guard let taskDescription else { return nil }
+        if let data = taskDescription.data(using: .utf8),
+           let decoded = try? JSONDecoder().decode(TaskContext.self, from: data) {
+            return decoded
+        }
+        return TaskContext(modelID: taskDescription, relativePath: nil, expectedBytes: 0)
+    }
+
+    @MainActor
+    private func removeTaskTracking(taskID: Int, modelID: String) {
+        taskContexts.removeValue(forKey: taskID)
+        guard var snapshot = snapshotDownloads[modelID] else { return }
+        snapshot.taskIDs.remove(taskID)
+        snapshotDownloads[modelID] = snapshot
+    }
+
+    @MainActor
+    internal func updateSnapshotProgress(
+        modelID: String,
+        relativePath: String,
+        bytesDownloaded: Int64,
+        totalBytesExpected: Int64
+    ) {
+        guard var snapshot = snapshotDownloads[modelID] else { return }
+        let fallbackExpected = snapshot.files[relativePath].map { Int64($0.sizeBytes) } ?? 0
+        let expectedBytes = totalBytesExpected > 0 ? totalBytesExpected : fallbackExpected
+        snapshot.progressByFile[relativePath] = SnapshotProgress(
+            bytesDownloaded: bytesDownloaded,
+            expectedBytes: expectedBytes
+        )
+        snapshotDownloads[modelID] = snapshot
+
+        let totalDownloaded = snapshot.progressByFile.values.reduce(0) { $0 + $1.bytesDownloaded }
+        let totalExpected: Int64
+        if snapshot.totalBytes > 0 {
+            totalExpected = snapshot.totalBytes
+        } else {
+            totalExpected = snapshot.progressByFile.values.reduce(0) { $0 + $1.expectedBytes }
+        }
+        activeDownloads[modelID]?.updateProgress(
+            bytesDownloaded: totalDownloaded,
+            totalBytes: totalExpected
+        )
+    }
+
+    @MainActor
+    internal func completeSnapshotFile(
+        modelID: String,
+        relativePath: String,
+        tempURL: URL
+    ) throws {
+        guard var snapshot = snapshotDownloads[modelID] else {
+            throw HuggingFaceError.invalidDownloadedFile(reason: "Missing snapshot context for MLX download")
+        }
+
+        let destination = snapshot.stagingDirectory.appendingPathComponent(relativePath)
+        try FileManager.default.createDirectory(
+            at: destination.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        if FileManager.default.fileExists(atPath: destination.path) {
+            try FileManager.default.removeItem(at: destination)
+        }
+        try FileManager.default.moveItem(at: tempURL, to: destination)
+
+        let fileSize = (try FileManager.default.attributesOfItem(atPath: destination.path)[.size] as? NSNumber)?.int64Value ?? snapshot.progressByFile[relativePath]?.expectedBytes ?? 0
+        snapshot.completedFiles.insert(relativePath)
+        snapshot.progressByFile[relativePath] = SnapshotProgress(
+            bytesDownloaded: fileSize,
+            expectedBytes: snapshot.progressByFile[relativePath]?.expectedBytes ?? fileSize
+        )
+        snapshotDownloads[modelID] = snapshot
+
+        let totalDownloaded = snapshot.progressByFile.values.reduce(0) { $0 + $1.bytesDownloaded }
+        let totalExpected = snapshot.totalBytes > 0
+            ? snapshot.totalBytes
+            : snapshot.progressByFile.values.reduce(0) { $0 + $1.expectedBytes }
+        activeDownloads[modelID]?.updateProgress(
+            bytesDownloaded: totalDownloaded,
+            totalBytes: totalExpected
+        )
+
+        guard snapshot.completedFiles.count == snapshot.files.count else { return }
+
+        try validateDownloadedFile(at: snapshot.stagingDirectory, modelType: .mlx)
+        let finalURL = storageService.modelsDirectory.appendingPathComponent(activeDownloads[modelID]?.model.fileName ?? snapshot.stagingDirectory.lastPathComponent)
+        if FileManager.default.fileExists(atPath: finalURL.path) {
+            try FileManager.default.removeItem(at: finalURL)
+        }
+        try FileManager.default.moveItem(at: snapshot.stagingDirectory, to: finalURL)
+        activeDownloads[modelID]?.markCompleted(localURL: finalURL)
+        removePendingDownload(id: modelID)
+        snapshotDownloads.removeValue(forKey: modelID)
+    }
+
+    @MainActor
+    private func failSnapshotDownload(modelID: String, error: String, cancelRemainingTasks: Bool) {
+        guard let snapshot = snapshotDownloads[modelID] else {
+            if case .failed = activeDownloads[modelID]?.status {
+                return
+            }
+            activeDownloads[modelID]?.markFailed(error: error)
+            removePendingDownload(id: modelID)
+            return
+        }
+
+        if cancelRemainingTasks {
+            backgroundSession.getAllTasks { [weak self] tasks in
+                guard let self else { return }
+                let activeTaskIDs = snapshot.taskIDs
+                for task in tasks where activeTaskIDs.contains(task.taskIdentifier) {
+                    task.cancel()
+                }
+            }
+        }
+
+        activeDownloads[modelID]?.markFailed(error: error)
+        removePendingDownload(id: modelID)
+        snapshotDownloads.removeValue(forKey: modelID)
+        do {
+            try FileManager.default.removeItem(at: snapshot.stagingDirectory)
+        } catch {
+            Log.download.error("Failed to remove snapshot staging directory: \(error.localizedDescription)")
+        }
+    }
+
     // MARK: - Persistence (Pending Downloads)
 
-    private func savePendingDownload(model: DownloadableModel) {
+    private func savePendingDownload(
+        model: DownloadableModel,
+        snapshotFiles: [SnapshotFileMetadata] = [],
+        stagingDirectoryName: String? = nil
+    ) throws {
         var pending = defaults.dictionary(forKey: pendingDownloadsKey) as? [String: [String: String]] ?? [:]
-        pending[model.id] = [
+        var entry = [
             "repoID": model.repoID,
             "fileName": model.fileName,
             "displayName": model.displayName,
-            "modelType": model.modelType == .gguf ? "gguf" : "mlx"
+            "modelType": model.modelType == .gguf ? "gguf" : "mlx",
+            "sizeBytes": String(model.sizeBytes),
         ]
+        if !snapshotFiles.isEmpty {
+            let data = try JSONEncoder().encode(snapshotFiles)
+            guard let json = String(data: data, encoding: .utf8) else {
+                throw HuggingFaceError.invalidDownloadedFile(reason: "Failed to encode pending snapshot metadata")
+            }
+            entry["snapshotFiles"] = json
+        }
+        if let stagingDirectoryName {
+            entry["stagingDirectoryName"] = stagingDirectoryName
+        }
+        pending[model.id] = entry
         defaults.set(pending, forKey: pendingDownloadsKey)
     }
 
@@ -302,10 +579,36 @@ public final class BackgroundDownloadManager: NSObject {
                 fileName: fileName,
                 displayName: displayName,
                 modelType: modelType,
-                sizeBytes: 0  // Unknown after restart; progress will update it.
+                sizeBytes: UInt64(info["sizeBytes"] ?? "") ?? 0
             )
             let state = DownloadState(model: model)
             activeDownloads[id] = state
+            if modelType == .mlx,
+               let stagingDirectoryName = info["stagingDirectoryName"],
+               let snapshotJSON = info["snapshotFiles"],
+               let snapshotData = snapshotJSON.data(using: .utf8) {
+                do {
+                    let files = try JSONDecoder().decode([SnapshotFileMetadata].self, from: snapshotData)
+                    snapshotDownloads[id] = SnapshotDownloadContext(
+                        stagingDirectory: storageService.modelsDirectory.appendingPathComponent(
+                            stagingDirectoryName,
+                            isDirectory: true
+                        ),
+                        files: Dictionary(uniqueKeysWithValues: files.map { ($0.relativePath, $0) }),
+                        totalBytes: Int64(model.sizeBytes),
+                        progressByFile: Dictionary(uniqueKeysWithValues: files.map {
+                            ($0.relativePath, SnapshotProgress(
+                                bytesDownloaded: 0,
+                                expectedBytes: Int64($0.sizeBytes)
+                            ))
+                        }),
+                        completedFiles: [],
+                        taskIDs: []
+                    )
+                } catch {
+                    Log.download.error("Failed to restore snapshot metadata for \(id): \(error.localizedDescription)")
+                }
+            }
             Log.download.info("Restored pending download state for \(id)")
         }
     }
@@ -326,11 +629,21 @@ extension BackgroundDownloadManager: URLSessionDownloadDelegate {
         let taskDescription = downloadTask.taskDescription
 
         Task { @MainActor [weak self] in
-            guard let modelID = self?.downloadTaskMap[taskID] ?? taskDescription else { return }
-            self?.activeDownloads[modelID]?.updateProgress(
-                bytesDownloaded: totalBytesWritten,
-                totalBytes: totalBytesExpectedToWrite
-            )
+            guard let self,
+                  let context = self.taskContext(for: taskID, taskDescription: taskDescription) else { return }
+            if let relativePath = context.relativePath {
+                self.updateSnapshotProgress(
+                    modelID: context.modelID,
+                    relativePath: relativePath,
+                    bytesDownloaded: totalBytesWritten,
+                    totalBytesExpected: totalBytesExpectedToWrite
+                )
+            } else {
+                self.activeDownloads[context.modelID]?.updateProgress(
+                    bytesDownloaded: totalBytesWritten,
+                    totalBytes: totalBytesExpectedToWrite
+                )
+            }
         }
     }
 
@@ -357,43 +670,57 @@ extension BackgroundDownloadManager: URLSessionDownloadDelegate {
         Task { @MainActor [weak self] in
             guard let self else { return }
 
-            guard let modelID = self.downloadTaskMap[taskID] ?? taskDescription else {
+            guard let context = self.taskContext(for: taskID, taskDescription: taskDescription) else {
                 Log.download.error("Completed download has no model ID mapping (task \(taskID))")
                 return
             }
 
-            guard let state = self.activeDownloads[modelID] else {
-                Log.download.error("No DownloadState for completed download: \(modelID)")
+            guard let state = self.activeDownloads[context.modelID] else {
+                Log.download.error("No DownloadState for completed download: \(context.modelID)")
                 return
             }
 
             let model = state.model
 
             do {
-                // Validate the downloaded file.
-                try self.validateDownloadedFile(at: tempURL, modelType: model.modelType)
+                if let relativePath = context.relativePath {
+                    try self.completeSnapshotFile(
+                        modelID: context.modelID,
+                        relativePath: relativePath,
+                        tempURL: tempURL
+                    )
+                } else {
+                    try self.validateDownloadedFile(at: tempURL, modelType: model.modelType)
+                    let destination = self.storageService.modelsDirectory.appendingPathComponent(model.fileName)
+                    if FileManager.default.fileExists(atPath: destination.path) {
+                        try FileManager.default.removeItem(at: destination)
+                    }
 
-                // Move to the models directory.
-                let destination = self.storageService.modelsDirectory.appendingPathComponent(model.fileName)
+                    try FileManager.default.moveItem(at: tempURL, to: destination)
+                    Log.download.info("Download complete: \(model.displayName) → \(destination.lastPathComponent)")
 
-                // Remove any existing file at the destination.
-                if FileManager.default.fileExists(atPath: destination.path) {
-                    try FileManager.default.removeItem(at: destination)
+                    self.activeDownloads[context.modelID]?.markCompleted(localURL: destination)
+                    self.removePendingDownload(id: context.modelID)
                 }
-
-                try FileManager.default.moveItem(at: tempURL, to: destination)
-                Log.download.info("Download complete: \(model.displayName) → \(destination.lastPathComponent)")
-
-                self.activeDownloads[modelID]?.markCompleted(localURL: destination)
-                self.removePendingDownload(id: modelID)
-                self.downloadTaskMap.removeValue(forKey: taskID)
+                self.removeTaskTracking(taskID: taskID, modelID: context.modelID)
             } catch {
-                Log.download.error("Post-download processing failed for \(modelID): \(error.localizedDescription)")
-                self.activeDownloads[modelID]?.markFailed(error: error.localizedDescription)
-                self.removePendingDownload(id: modelID)
-                self.downloadTaskMap.removeValue(forKey: taskID)
-                // Clean up temp file on failure.
-                try? FileManager.default.removeItem(at: tempURL)
+                Log.download.error("Post-download processing failed for \(context.modelID): \(error.localizedDescription)")
+                if context.relativePath != nil {
+                    self.failSnapshotDownload(
+                        modelID: context.modelID,
+                        error: error.localizedDescription,
+                        cancelRemainingTasks: true
+                    )
+                } else {
+                    self.activeDownloads[context.modelID]?.markFailed(error: error.localizedDescription)
+                    self.removePendingDownload(id: context.modelID)
+                }
+                self.removeTaskTracking(taskID: taskID, modelID: context.modelID)
+                do {
+                    try FileManager.default.removeItem(at: tempURL)
+                } catch {
+                    Log.download.error("Failed to remove temp download \(tempURL.lastPathComponent): \(error.localizedDescription)")
+                }
             }
         }
     }
@@ -412,17 +739,30 @@ extension BackgroundDownloadManager: URLSessionDownloadDelegate {
 
         Task { @MainActor [weak self] in
             guard let self else { return }
-            let modelID = self.downloadTaskMap[taskID] ?? taskDescription ?? "unknown"
-            Log.download.error("Download failed for \(modelID): \(errorDesc)")
+            guard let context = self.taskContext(for: taskID, taskDescription: taskDescription) else { return }
+            Log.download.error("Download failed for \(context.modelID): \(errorDesc)")
 
-            // Don't report cancellation as a failure.
             if nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled {
-                self.activeDownloads[modelID]?.markCancelled()
+                if context.relativePath != nil {
+                    if case .failed = self.activeDownloads[context.modelID]?.status {
+                        self.removeTaskTracking(taskID: taskID, modelID: context.modelID)
+                        return
+                    }
+                }
+                self.activeDownloads[context.modelID]?.markCancelled()
             } else {
-                self.activeDownloads[modelID]?.markFailed(error: errorDesc)
+                if context.relativePath != nil {
+                    self.failSnapshotDownload(
+                        modelID: context.modelID,
+                        error: errorDesc,
+                        cancelRemainingTasks: true
+                    )
+                } else {
+                    self.activeDownloads[context.modelID]?.markFailed(error: errorDesc)
+                }
             }
-            self.removePendingDownload(id: modelID)
-            self.downloadTaskMap.removeValue(forKey: taskID)
+            self.removePendingDownload(id: context.modelID)
+            self.removeTaskTracking(taskID: taskID, modelID: context.modelID)
         }
     }
 }

--- a/Sources/BaseChatCore/Services/HuggingFaceService.swift
+++ b/Sources/BaseChatCore/Services/HuggingFaceService.swift
@@ -21,6 +21,9 @@ public protocol HuggingFaceServiceProtocol: Sendable {
     /// Fetches all downloadable files (GGUF + MLX) for a specific HuggingFace repo.
     func getModelFiles(repoID: String) async throws -> [DownloadableModel]
 
+    /// Resolves the concrete file download plan for a model.
+    func downloadPlan(for model: DownloadableModel) async throws -> ModelDownloadPlan
+
     /// Constructs the direct download URL for a model file on HuggingFace.
     func downloadURL(for model: DownloadableModel) -> URL
 }
@@ -56,17 +59,12 @@ public final class HuggingFaceService: HuggingFaceServiceProtocol {
             throw HuggingFaceError.searchFailed(underlying: error)
         }
 
-        // Filter to repos that contain GGUF files (single-file downloadable).
-        // MLX repos require snapshot downloads (multiple files) which is not yet supported.
-        let ggufRepos = response.items.filter { model in
-            guard let siblings = model.siblings else { return false }
-            return siblings.contains { $0.relativeFilename.lowercased().hasSuffix(".gguf") }
-        }
+        let downloadableRepos = response.items.filter(isDownloadableRepo)
 
-        // Fetch each GGUF repo with filesMetadata to get actual file sizes.
+        // Fetch each downloadable repo with filesMetadata to get actual file sizes.
         var allModels: [DownloadableModel] = []
         await withTaskGroup(of: [DownloadableModel].self) { group in
-            for model in ggufRepos {
+            for model in downloadableRepos {
                 group.addTask {
                     do {
                         let detailed = try await self.hubClient.getModel(
@@ -86,7 +84,7 @@ public final class HuggingFaceService: HuggingFaceServiceProtocol {
             }
         }
 
-        Log.network.info("Search returned \(allModels.count) downloadable files from \(ggufRepos.count) repos")
+        Log.network.info("Search returned \(allModels.count) downloadable files from \(downloadableRepos.count) repos")
         return allModels
     }
 
@@ -124,14 +122,46 @@ public final class HuggingFaceService: HuggingFaceServiceProtocol {
         return downloadables
     }
 
+    public func downloadPlan(for model: DownloadableModel) async throws -> ModelDownloadPlan {
+        switch model.modelType {
+        case .gguf:
+            return .singleFile(url: downloadURL(for: model))
+        case .mlx:
+            guard let repoIdentifier = Repo.ID(rawValue: model.repoID) else {
+                throw HuggingFaceError.invalidRepoID(model.repoID)
+            }
+            let detailed: Model
+            do {
+                detailed = try await hubClient.getModel(
+                    repoIdentifier,
+                    full: true,
+                    filesMetadata: true
+                )
+            } catch {
+                Log.network.error("Failed to fetch MLX snapshot for \(model.repoID): \(error.localizedDescription)")
+                throw HuggingFaceError.modelNotFound(repoID: model.repoID)
+            }
+            let files = snapshotFiles(from: detailed)
+            guard !files.isEmpty else {
+                throw HuggingFaceError.invalidDownloadedFile(reason: "MLX repo has no snapshot files to download")
+            }
+            return .snapshot(files: files)
+        case .foundation:
+            throw HuggingFaceError.invalidDownloadedFile(reason: "Foundation models cannot be downloaded")
+        }
+    }
+
     // MARK: - Download URL
 
     public func downloadURL(for model: DownloadableModel) -> URL {
-        // HuggingFace direct download: https://huggingface.co/{repoID}/resolve/main/{fileName}
+        downloadURL(repoID: model.repoID, filePath: model.fileName)
+    }
+
+    func downloadURL(repoID: String, filePath: String) -> URL {
         var components = URLComponents()
         components.scheme = "https"
         components.host = "huggingface.co"
-        components.path = "/\(model.repoID)/resolve/main/\(model.fileName)"
+        components.path = "/\(repoID)/resolve/main/\(filePath)"
         // Force unwrap is safe here: we control the components and they are always valid.
         // swiftlint:disable:next force_unwrapping
         return components.url!
@@ -140,10 +170,7 @@ public final class HuggingFaceService: HuggingFaceServiceProtocol {
     // MARK: - Private Helpers
 
     /// Converts a HuggingFace `Model` into zero or more `DownloadableModel` entries.
-    ///
-    /// Currently only supports GGUF repos (one entry per `.gguf` file).
-    /// MLX repos require snapshot downloads (multiple files) which is not yet implemented.
-    private func convertModelToDownloadables(_ model: Model) -> [DownloadableModel] {
+    internal func convertModelToDownloadables(_ model: Model) -> [DownloadableModel] {
         guard let siblings = model.siblings else { return [] }
 
         let repoID = model.id.rawValue
@@ -171,11 +198,50 @@ public final class HuggingFaceService: HuggingFaceServiceProtocol {
             ))
         }
 
-        // MLX repos (config.json + .safetensors) are not included in search results
-        // because they require snapshot downloads (multiple files), which is not yet
-        // supported. Users can manually import MLX models via drag-and-drop on macOS.
+        let snapshotFiles = snapshotFiles(from: model)
+        if !snapshotFiles.isEmpty {
+            let repoName = model.id.name
+            results.append(DownloadableModel(
+                repoID: repoID,
+                fileName: repoName,
+                displayName: Self.cleanDisplayName(from: repoName),
+                modelType: .mlx,
+                sizeBytes: snapshotFiles.reduce(0) { $0 + $1.sizeBytes },
+                downloads: model.downloads,
+                isCurated: false,
+                promptTemplate: nil,
+                description: nil
+            ))
+        }
 
         return results
+    }
+
+    private func isDownloadableRepo(_ model: Model) -> Bool {
+        guard let siblings = model.siblings else { return false }
+        return hasGGUFFiles(in: siblings) || isMLXSnapshot(siblings)
+    }
+
+    private func hasGGUFFiles(in siblings: [Model.SiblingInfo]) -> Bool {
+        siblings.contains { $0.relativeFilename.lowercased().hasSuffix(".gguf") }
+    }
+
+    private func isMLXSnapshot(_ siblings: [Model.SiblingInfo]) -> Bool {
+        let lowercasedNames = siblings.map { $0.relativeFilename.lowercased() }
+        let hasConfig = lowercasedNames.contains("config.json")
+        let hasSafetensors = lowercasedNames.contains { $0.hasSuffix(".safetensors") }
+        return hasConfig && hasSafetensors
+    }
+
+    private func snapshotFiles(from model: Model) -> [ModelDownloadFile] {
+        guard let siblings = model.siblings, isMLXSnapshot(siblings) else { return [] }
+        return siblings.map { file in
+            ModelDownloadFile(
+                relativePath: file.relativeFilename,
+                url: downloadURL(repoID: model.id.rawValue, filePath: file.relativeFilename),
+                sizeBytes: UInt64(file.size ?? 0)
+            )
+        }
     }
 
     /// Converts a repo name like "Mistral-7B-Instruct-v0.3-GGUF" into "Mistral 7B Instruct v0.3 GGUF".

--- a/Sources/BaseChatTestSupport/MockHuggingFaceService.swift
+++ b/Sources/BaseChatTestSupport/MockHuggingFaceService.swift
@@ -10,6 +10,8 @@ public final class MockHuggingFaceService: HuggingFaceServiceProtocol {
         var searchResults: [DownloadableModel] = []
         var searchError: Error?
         var modelFiles: [DownloadableModel] = []
+        var downloadPlans: [String: ModelDownloadPlan] = [:]
+        var downloadPlanError: Error?
         var searchCallCount = 0
     }
 
@@ -34,6 +36,16 @@ public final class MockHuggingFaceService: HuggingFaceServiceProtocol {
         state.withLock { $0.searchCallCount }
     }
 
+    public var downloadPlans: [String: ModelDownloadPlan] {
+        get { state.withLock { $0.downloadPlans } }
+        set { state.withLock { $0.downloadPlans = newValue } }
+    }
+
+    public var downloadPlanError: Error? {
+        get { state.withLock { $0.downloadPlanError } }
+        set { state.withLock { $0.downloadPlanError = newValue } }
+    }
+
     public init() {}
 
     public func searchModels(query: String) async throws -> [DownloadableModel] {
@@ -53,6 +65,15 @@ public final class MockHuggingFaceService: HuggingFaceServiceProtocol {
 
     public func getModelFiles(repoID: String) async throws -> [DownloadableModel] {
         state.withLock { $0.modelFiles }
+    }
+
+    public func downloadPlan(for model: DownloadableModel) async throws -> ModelDownloadPlan {
+        let (error, configuredPlan) = state.withLock { state in
+            (state.downloadPlanError, state.downloadPlans[model.id])
+        }
+        if let error { throw error }
+        if let configuredPlan { return configuredPlan }
+        return .singleFile(url: downloadURL(for: model))
     }
 
     public func downloadURL(for model: DownloadableModel) -> URL {

--- a/Sources/BaseChatUI/ViewModels/ModelManagementViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ModelManagementViewModel.swift
@@ -93,6 +93,19 @@ public final class ModelManagementViewModel {
         )
     }
 
+    /// Creates a lightweight model manager for Xcode previews.
+    ///
+    /// Skips URLSession background session reconnection and HuggingFace setup,
+    /// which are unnecessary and slow in the preview environment.
+    public static func preview() -> ModelManagementViewModel {
+        ModelManagementViewModel(
+            huggingFaceService: nil,
+            downloadManager: nil,
+            deviceCapability: DeviceCapabilityService(),
+            modelStorage: ModelStorageService()
+        )
+    }
+
     // MARK: - Computed Properties
 
     /// The recommended model size tier for this device.
@@ -223,11 +236,10 @@ public final class ModelManagementViewModel {
             return
         }
 
-        let url = service.downloadURL(for: model)
-
         Task {
             do {
-                let state = try await manager.startDownload(model, downloadURL: url)
+                let plan = try await service.downloadPlan(for: model)
+                let state = try await manager.startDownload(model, plan: plan)
                 trackedDownloads[model.id] = state
                 Log.download.info("Started download: \(model.displayName), id=\(state.id)")
                 startDownloadSync()

--- a/Tests/BaseChatCoreTests/BackgroundDownloadIntegrationTests.swift
+++ b/Tests/BaseChatCoreTests/BackgroundDownloadIntegrationTests.swift
@@ -386,6 +386,78 @@ final class BackgroundDownloadIntegrationTests: XCTestCase {
         )
     }
 
+    func test_reconnectBackgroundSession_restoresPendingMLXSnapshotMetadata() throws {
+        let realKey = BaseChatConfiguration.shared.pendingDownloadsKey
+        let previousValue = UserDefaults.standard.dictionary(forKey: realKey)
+        defer {
+            if let previousValue {
+                UserDefaults.standard.set(previousValue, forKey: realKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: realKey)
+            }
+        }
+
+        let manager = BackgroundDownloadManager(
+            storageService: ModelStorageService(baseDirectory: tempDirectory)
+        )
+        let model = makeModel(
+            repoID: "mlx-community/Test-4bit",
+            fileName: "Test-4bit",
+            displayName: "Test 4bit",
+            modelType: .mlx,
+            sizeBytes: 1_000
+        )
+        let snapshotFiles = """
+            [
+              { "relativePath": "config.json", "sizeBytes": 100 },
+              { "relativePath": "weights/model.safetensors", "sizeBytes": 900 }
+            ]
+            """
+        let pending: [String: [String: String]] = [
+            model.id: [
+                "repoID": model.repoID,
+                "fileName": model.fileName,
+                "displayName": model.displayName,
+                "modelType": "mlx",
+                "sizeBytes": "1000",
+                "stagingDirectoryName": ".staging-test-mlx",
+                "snapshotFiles": snapshotFiles,
+            ]
+        ]
+        UserDefaults.standard.set(pending, forKey: realKey)
+        UserDefaults.standard.synchronize()
+
+        manager.reconnectBackgroundSession()
+
+        let restored = try XCTUnwrap(manager.activeDownloads[model.id])
+        XCTAssertEqual(restored.model.modelType, .mlx)
+        XCTAssertEqual(restored.model.sizeBytes, 1_000)
+
+        let configTemp = tempDirectory.appendingPathComponent("config.restore")
+        try Data("{}".utf8).write(to: configTemp)
+        try manager.completeSnapshotFile(
+            modelID: model.id,
+            relativePath: "config.json",
+            tempURL: configTemp
+        )
+
+        let weightsTemp = tempDirectory.appendingPathComponent("weights.restore")
+        try Data(repeating: 0xAB, count: 900).write(to: weightsTemp)
+        try manager.completeSnapshotFile(
+            modelID: model.id,
+            relativePath: "weights/model.safetensors",
+            tempURL: weightsTemp
+        )
+
+        guard case .completed(let localURL) = restored.status else {
+            return XCTFail("Restored MLX snapshot should still be completable after reconnect")
+        }
+        XCTAssertEqual(
+            localURL.standardizedFileURL.path,
+            tempDirectory.appendingPathComponent("Test-4bit").standardizedFileURL.path
+        )
+    }
+
     func test_pendingDownload_removedOnCancellation() async throws {
         let realKey = BaseChatConfiguration.shared.pendingDownloadsKey
         defer {

--- a/Tests/BaseChatCoreTests/DownloadManagerTests.swift
+++ b/Tests/BaseChatCoreTests/DownloadManagerTests.swift
@@ -9,12 +9,12 @@ final class DownloadManagerTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
-        manager = BackgroundDownloadManager()
-
-        // Create a temporary directory for test files.
         tempDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("DownloadManagerTests-\(UUID().uuidString)")
-        try? FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        manager = BackgroundDownloadManager(
+            storageService: ModelStorageService(baseDirectory: tempDirectory)
+        )
     }
 
     override func tearDown() async throws {
@@ -25,6 +25,21 @@ final class DownloadManagerTests: XCTestCase {
         tempDirectory = nil
         manager = nil
         try await super.tearDown()
+    }
+
+    private func makeSnapshotFiles() -> [ModelDownloadFile] {
+        [
+            ModelDownloadFile(
+                relativePath: "config.json",
+                url: URL(string: "https://example.com/config.json")!,
+                sizeBytes: 100
+            ),
+            ModelDownloadFile(
+                relativePath: "weights/model.safetensors",
+                url: URL(string: "https://example.com/weights/model.safetensors")!,
+                sizeBytes: 900
+            ),
+        ]
     }
 
     // MARK: - Disk Space
@@ -284,6 +299,92 @@ final class DownloadManagerTests: XCTestCase {
         if case .cancelled = state.status { } else {
             XCTFail("Expected .cancelled after markCancelled, got: \(state.status)")
         }
+    }
+
+    // MARK: - MLX Snapshot Coordination
+
+    func test_updateSnapshotProgress_aggregatesAcrossFiles() {
+        let model = DownloadableModel(
+            repoID: "mlx-community/Test-4bit",
+            fileName: "Test-4bit",
+            displayName: "Test 4bit",
+            modelType: .mlx,
+            sizeBytes: 1_000
+        )
+        let state = DownloadState(model: model)
+        manager.activeDownloads[model.id] = state
+
+        let stagingDirectory = tempDirectory.appendingPathComponent(".staging-progress", isDirectory: true)
+        try? FileManager.default.createDirectory(at: stagingDirectory, withIntermediateDirectories: true)
+        manager.prepareSnapshotDownload(model: model, files: makeSnapshotFiles(), stagingDirectory: stagingDirectory)
+
+        manager.updateSnapshotProgress(
+            modelID: model.id,
+            relativePath: "config.json",
+            bytesDownloaded: 100,
+            totalBytesExpected: 100
+        )
+        manager.updateSnapshotProgress(
+            modelID: model.id,
+            relativePath: "weights/model.safetensors",
+            bytesDownloaded: 450,
+            totalBytesExpected: 900
+        )
+
+        guard case .downloading(let progress, let bytesDownloaded, let totalBytes) = state.status else {
+            return XCTFail("Expected aggregate snapshot progress to be reflected in DownloadState")
+        }
+        XCTAssertEqual(bytesDownloaded, 550)
+        XCTAssertEqual(totalBytes, 1_000)
+        XCTAssertEqual(progress, 0.55, accuracy: 0.001)
+    }
+
+    func test_completeSnapshotFile_finalizesDirectoryAfterLastFile() throws {
+        let model = DownloadableModel(
+            repoID: "mlx-community/Test-4bit",
+            fileName: "Test-4bit",
+            displayName: "Test 4bit",
+            modelType: .mlx,
+            sizeBytes: 1_000
+        )
+        let state = DownloadState(model: model)
+        manager.activeDownloads[model.id] = state
+
+        let stagingDirectory = tempDirectory.appendingPathComponent(".staging-finalize", isDirectory: true)
+        try FileManager.default.createDirectory(at: stagingDirectory, withIntermediateDirectories: true)
+        manager.prepareSnapshotDownload(model: model, files: makeSnapshotFiles(), stagingDirectory: stagingDirectory)
+
+        let configTemp = tempDirectory.appendingPathComponent("config.download")
+        try Data("{}".utf8).write(to: configTemp)
+        try manager.completeSnapshotFile(
+            modelID: model.id,
+            relativePath: "config.json",
+            tempURL: configTemp
+        )
+
+        if case .completed = state.status {
+            return XCTFail("Snapshot should not complete until every file is present")
+        }
+
+        let weightsTemp = tempDirectory.appendingPathComponent("weights.download")
+        try Data(repeating: 0xAB, count: 900).write(to: weightsTemp)
+        try manager.completeSnapshotFile(
+            modelID: model.id,
+            relativePath: "weights/model.safetensors",
+            tempURL: weightsTemp
+        )
+
+        let finalURL = tempDirectory.appendingPathComponent("Test-4bit", isDirectory: true)
+        guard case .completed(let localURL) = state.status else {
+            return XCTFail("Snapshot should complete after the last file is staged")
+        }
+        XCTAssertEqual(localURL.standardizedFileURL.path, finalURL.standardizedFileURL.path)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: finalURL.appendingPathComponent("config.json").path))
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: finalURL.appendingPathComponent("weights/model.safetensors").path
+            )
+        )
     }
 
     // MARK: - Disk Space Edge Cases

--- a/Tests/BaseChatCoreTests/HuggingFaceServiceTests.swift
+++ b/Tests/BaseChatCoreTests/HuggingFaceServiceTests.swift
@@ -1,13 +1,16 @@
 import XCTest
 @testable import BaseChatCore
 import BaseChatTestSupport
+import HuggingFace
 
 final class HuggingFaceServiceTests: XCTestCase {
 
     private var service: HuggingFaceService!
+    private var stubbedURLs: [URL] = []
 
     override func setUp() {
         super.setUp()
+        MockURLProtocol.reset()
         CuratedModel.all = [
             CuratedModel(
                 id: "test-phi",
@@ -62,9 +65,59 @@ final class HuggingFaceServiceTests: XCTestCase {
     }
 
     override func tearDown() {
+        for url in stubbedURLs {
+            MockURLProtocol.unstub(url: url)
+        }
+        stubbedURLs = []
+        MockURLProtocol.reset()
         service = nil
         CuratedModel.all = []
         super.tearDown()
+    }
+
+    private func makeMockService(
+        listResponseJSON: String = "[]",
+        modelDetailsByRepoID: [String: String] = [:]
+    ) -> HuggingFaceService {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        let hubClient = HubClient(
+            session: session,
+            host: URL(string: "https://huggingface.co")!,
+            userAgent: "BaseChatKitTests/1.0",
+            cache: nil
+        )
+
+        let listURL = URL(string: "https://huggingface.co/api/models")!
+        MockURLProtocol.stub(
+            url: listURL,
+            response: .immediate(
+                data: Data(listResponseJSON.utf8),
+                statusCode: 200,
+                headers: ["Content-Type": "application/json"]
+            )
+        )
+        stubbedURLs.append(listURL)
+
+        for (repoID, json) in modelDetailsByRepoID {
+            let detailURL = URL(string: "https://huggingface.co/api/models/\(repoID)")!
+            MockURLProtocol.stub(
+                url: detailURL,
+                response: .immediate(
+                    data: Data(json.utf8),
+                    statusCode: 200,
+                    headers: ["Content-Type": "application/json"]
+                )
+            )
+            stubbedURLs.append(detailURL)
+        }
+
+        return HuggingFaceService(hubClient: hubClient)
+    }
+
+    private func decodeModel(from json: String) throws -> Model {
+        try JSONDecoder().decode(Model.self, from: Data(json.utf8))
     }
 
     // MARK: - Curated Models
@@ -268,6 +321,103 @@ final class HuggingFaceServiceTests: XCTestCase {
             "https://huggingface.co/mlx-community/Qwen3-4B-4bit/resolve/main/Qwen3-4B-4bit",
             "MLX download URL should follow the standard HuggingFace resolve/main format"
         )
+    }
+
+    // MARK: - MLX Characterization
+
+    func test_convertModelToDownloadables_mlxRepo_returnsSingleDownloadableDirectory() throws {
+        let repoID = "mlx-community/Gemma-3-4B-it-4bit"
+        let detailedResponse = """
+            {
+                "id": "\(repoID)",
+                "downloads": 42,
+                "pipeline_tag": "text-generation",
+                "siblings": [
+                    { "rfilename": "config.json", "size": 1200 },
+                    { "rfilename": "model.safetensors", "size": 8000 },
+                    { "rfilename": "tokenizer.json", "size": 300 }
+                ]
+            }
+            """
+        let model = try decodeModel(from: detailedResponse)
+        let files = service.convertModelToDownloadables(model)
+        let mlxModel = try XCTUnwrap(files.first)
+
+        XCTAssertEqual(files.count, 1, "MLX repos should surface as one logical downloadable")
+        XCTAssertEqual(mlxModel.modelType, .mlx)
+        XCTAssertEqual(mlxModel.repoID, repoID)
+        XCTAssertEqual(mlxModel.fileName, "Gemma-3-4B-it-4bit")
+        XCTAssertEqual(mlxModel.sizeBytes, 9_500)
+    }
+
+    func test_searchModels_includesMLXReposAlongsideGGUFResults() async throws {
+        let mlxRepoID = "mlx-community/Gemma-3-4B-it-4bit"
+        let ggufRepoID = "bartowski/Mistral-7B-Instruct-v0.3-GGUF"
+        let listResponse = """
+            [
+                {
+                    "id": "\(mlxRepoID)",
+                    "downloads": 2500,
+                    "pipeline_tag": "text-generation",
+                    "siblings": [
+                        { "rfilename": "config.json", "size": 1200 },
+                        { "rfilename": "model.safetensors", "size": 8000 },
+                        { "rfilename": "tokenizer.json", "size": 300 }
+                    ]
+                },
+                {
+                    "id": "\(ggufRepoID)",
+                    "downloads": 1000,
+                    "pipeline_tag": "text-generation",
+                    "siblings": [
+                        { "rfilename": "Mistral-7B-Instruct-v0.3-Q4_K_M.gguf", "size": 4100000000 }
+                    ]
+                }
+            ]
+            """
+        let mlxDetail = """
+            {
+                "id": "\(mlxRepoID)",
+                "downloads": 2500,
+                "pipeline_tag": "text-generation",
+                "siblings": [
+                    { "rfilename": "config.json", "size": 1200 },
+                    { "rfilename": "model.safetensors", "size": 8000 },
+                    { "rfilename": "tokenizer.json", "size": 300 }
+                ]
+            }
+            """
+        let ggufDetail = """
+            {
+                "id": "\(ggufRepoID)",
+                "downloads": 1000,
+                "pipeline_tag": "text-generation",
+                "siblings": [
+                    { "rfilename": "Mistral-7B-Instruct-v0.3-Q4_K_M.gguf", "size": 4100000000 }
+                ]
+            }
+            """
+
+        let service = makeMockService(
+            listResponseJSON: listResponse,
+            modelDetailsByRepoID: [
+                mlxRepoID: mlxDetail,
+                ggufRepoID: ggufDetail,
+            ]
+        )
+
+        let results = try await service.searchModels(query: "gemma")
+
+        XCTAssertTrue(
+            results.contains(where: { $0.repoID == ggufRepoID && $0.modelType == .gguf }),
+            "Search should continue to include GGUF results"
+        )
+        let mlxModel = try XCTUnwrap(
+            results.first(where: { $0.repoID == mlxRepoID && $0.modelType == .mlx }),
+            "Search should include MLX repos as downloadable results"
+        )
+        XCTAssertEqual(mlxModel.fileName, "Gemma-3-4B-it-4bit")
+        XCTAssertEqual(mlxModel.sizeBytes, 9_500)
     }
 
     // MARK: - Curated Model Data Integrity

--- a/Tests/BaseChatCoreTests/ModelInfoTests.swift
+++ b/Tests/BaseChatCoreTests/ModelInfoTests.swift
@@ -87,6 +87,22 @@ final class ModelInfoTests: XCTestCase {
         XCTAssertNil(model)
     }
 
+    func test_mlxInit_nestedSafetensors_countsRecursiveSize() throws {
+        let mlxDir = tempDirectory.appendingPathComponent("nested-mlx-model")
+        try FileManager.default.createDirectory(at: mlxDir, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: mlxDir.appendingPathComponent("config.json"))
+
+        let weightsDirectory = mlxDir.appendingPathComponent("weights", isDirectory: true)
+        try FileManager.default.createDirectory(at: weightsDirectory, withIntermediateDirectories: true)
+        let weightsData = Data(repeating: 0xAB, count: 2048)
+        try weightsData.write(to: weightsDirectory.appendingPathComponent("model.safetensors"))
+
+        let model = try XCTUnwrap(ModelInfo(mlxDirectory: mlxDir))
+
+        XCTAssertEqual(model.modelType, .mlx)
+        XCTAssertEqual(model.fileSize, UInt64(2 + weightsData.count))
+    }
+
     // MARK: - Memberwise Initializer
 
     func test_memberwiseInit_setsAllFields() {
@@ -152,6 +168,7 @@ final class ModelInfoTests: XCTestCase {
         let mlxDir = tempDirectory.appendingPathComponent("phi-3-mini-4bit")
         try FileManager.default.createDirectory(at: mlxDir, withIntermediateDirectories: true)
         try Data("{}".utf8).write(to: mlxDir.appendingPathComponent("config.json"))
+        try Data(repeating: 0x00, count: 1).write(to: mlxDir.appendingPathComponent("model.safetensors"))
 
         let model = ModelInfo(mlxDirectory: mlxDir)
 


### PR DESCRIPTION
## Summary
- add MLX repo detection to HuggingFace search and return a single logical MLX result per repo
- add snapshot download planning plus multi-file MLX download orchestration with aggregated progress and reconnect metadata
- handle nested safetensors when validating and discovering MLX model directories
- add regression coverage for MLX conversion, snapshot coordination, reconnect restoration, and recursive MLX sizing

## Testing
- swift test --filter BackgroundDownloadIntegrationTests --quiet
- swift test --filter DownloadManagerTests --quiet
- swift test --filter HuggingFaceServiceTests --quiet
- swift test --filter ModelInfoTests --quiet
- swift test --filter BaseChatUITests --quiet
- swift test --filter BaseChatBackendsTests --quiet