### PR TITLE
fix: eliminate static race conditions in singleton types

### DIFF
--- a/Sources/BaseChatCore/BaseChatConfiguration.swift
+++ b/Sources/BaseChatCore/BaseChatConfiguration.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// Global configuration for BaseChatKit. Set this once at app startup before
 /// using any BaseChatKit types.
@@ -14,20 +15,15 @@ import Foundation
 /// )
 /// ```
 public struct BaseChatConfiguration: Sendable {
-    private static let lock = NSLock()
-    private nonisolated(unsafe) static var _shared = BaseChatConfiguration()
+    // OSAllocatedUnfairLock wraps value and lock together, making it
+    // structurally impossible to access the value without holding the lock.
+    private static let storage = OSAllocatedUnfairLock(
+        initialState: BaseChatConfiguration()
+    )
 
     public static var shared: BaseChatConfiguration {
-        get {
-            lock.lock()
-            defer { lock.unlock() }
-            return _shared
-        }
-        set {
-            lock.lock()
-            _shared = newValue
-            lock.unlock()
-        }
+        get { storage.withLock { $0 } }
+        set { storage.withLock { $0 = newValue } }
     }
 
     /// Display name used in export headers, empty states, etc.

--- a/Sources/BaseChatCore/Models/CuratedModel.swift
+++ b/Sources/BaseChatCore/Models/CuratedModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// A recommended model from the curated list, with known-good metadata.
 ///
@@ -50,19 +51,12 @@ public struct CuratedModel: Identifiable, Sendable {
     ///
     /// This is empty by default — apps should populate it with their own list
     /// at startup or by subclassing/extending CuratedModel as needed.
-    private static let lock = NSLock()
-    private nonisolated(unsafe) static var _all: [CuratedModel] = []
+    private static let storage = OSAllocatedUnfairLock<[CuratedModel]>(
+        initialState: []
+    )
 
     public static var all: [CuratedModel] {
-        get {
-            lock.lock()
-            defer { lock.unlock() }
-            return _all
-        }
-        set {
-            lock.lock()
-            _all = newValue
-            lock.unlock()
-        }
+        get { storage.withLock { $0 } }
+        set { storage.withLock { $0 = newValue } }
     }
 }


### PR DESCRIPTION
## Summary

- Replaces `nonisolated(unsafe) static var` + `NSLock` with `OSAllocatedUnfairLock` in both `BaseChatConfiguration` and `CuratedModel`
- `OSAllocatedUnfairLock` wraps the value inside the lock, making it structurally impossible to access the backing store without holding the lock — eliminates the class of bug where future code could bypass the lock
- No API changes; all existing call sites (`BaseChatConfiguration.shared`, `CuratedModel.all`) work identically

Closes #156

## Test plan

- [x] `swift test --filter BaseChatCoreTests` — all 83 tests pass
- [ ] Verify CI passes (`BaseChatCoreTests` + `BaseChatUITests` + `BaseChatBackendsTests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)