### PR TITLE
fix: audit and remove unnecessary @unchecked Sendable conformances

### DIFF
--- a/Sources/BaseChatBackends/ClaudeBackend.swift
+++ b/Sources/BaseChatBackends/ClaudeBackend.swift
@@ -7,7 +7,7 @@ import BaseChatCore
 /// Streams completions from the Anthropic Messages API (`/v1/messages`).
 /// Handles Claude-specific SSE event types (`content_block_delta`, etc.)
 /// and authentication via `x-api-key` header.
-public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBackendKeychainConfigurable, @unchecked Sendable {
+public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBackendKeychainConfigurable {
 
     /// Shared session with certificate pinning delegate.
     private static let pinnedSession: URLSession = {

--- a/Sources/BaseChatBackends/KoboldCppBackend.swift
+++ b/Sources/BaseChatBackends/KoboldCppBackend.swift
@@ -22,7 +22,7 @@ import BaseChatCore
 /// let stream = try backend.generate(prompt: "### Instruction:\nHello\n### Response:\n", systemPrompt: nil, config: .init())
 /// for try await token in stream { print(token, terminator: "") }
 /// ```
-public final class KoboldCppBackend: SSECloudBackend, CloudBackendURLModelConfigurable, @unchecked Sendable {
+public final class KoboldCppBackend: SSECloudBackend, CloudBackendURLModelConfigurable {
 
     /// Optional GBNF grammar constraint sent in the request body.
     /// KoboldCpp-specific — not part of the shared `GenerationConfig`.

--- a/Sources/BaseChatBackends/OpenAIBackend.swift
+++ b/Sources/BaseChatBackends/OpenAIBackend.swift
@@ -19,7 +19,7 @@ import BaseChatCore
 /// let stream = try backend.generate(prompt: "Hello", systemPrompt: nil, config: .init())
 /// for try await token in stream { print(token, terminator: "") }
 /// ```
-public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBackendURLModelConfigurable, CloudBackendKeychainConfigurable, @unchecked Sendable {
+public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBackendURLModelConfigurable, CloudBackendKeychainConfigurable {
 
     /// Shared session with certificate pinning delegate.
     private static let pinnedSession: URLSession = {

--- a/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
+++ b/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
@@ -7,7 +7,7 @@ import SwiftData
 /// SwiftData `@Model` objects and plain ``ChatSessionRecord`` / ``ChatMessageRecord``
 /// value types at the boundary.
 @MainActor
-public final class SwiftDataPersistenceProvider: ChatPersistenceProvider, @unchecked Sendable {
+public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
 
     private let modelContext: ModelContext
 

--- a/Sources/BaseChatTestSupport/MockPersistenceProvider.swift
+++ b/Sources/BaseChatTestSupport/MockPersistenceProvider.swift
@@ -5,7 +5,7 @@ import BaseChatCore
 ///
 /// Stores sessions and messages in plain arrays. Thread-safe via `@MainActor`.
 @MainActor
-public final class MockPersistenceProvider: ChatPersistenceProvider, @unchecked Sendable {
+public final class MockPersistenceProvider: ChatPersistenceProvider {
 
     public var sessions: [ChatSessionRecord] = []
     public var messages: [ChatMessageRecord] = []

--- a/Tests/BaseChatE2ETests/CloudEndpointSelectionE2ETests.swift
+++ b/Tests/BaseChatE2ETests/CloudEndpointSelectionE2ETests.swift
@@ -31,8 +31,7 @@ private func makeMockSession() -> URLSession {
 private final class ConfiguringOpenAICloudBackend: InferenceBackend,
                                                    ConversationHistoryReceiver,
                                                    CloudBackendURLModelConfigurable,
-                                                   CloudBackendKeychainConfigurable,
-                                                   @unchecked Sendable {
+                                                   CloudBackendKeychainConfigurable {
     private let backend: OpenAIBackend
     private let probeOnLoad: Bool
 
@@ -84,8 +83,7 @@ private final class ConfiguringOpenAICloudBackend: InferenceBackend,
 
 private final class ConfiguringClaudeCloudBackend: InferenceBackend,
                                                    ConversationHistoryReceiver,
-                                                   CloudBackendKeychainConfigurable,
-                                                   @unchecked Sendable {
+                                                   CloudBackendKeychainConfigurable {
     private let backend: ClaudeBackend
 
     init(urlSession: URLSession) {

--- a/Tests/BaseChatUITests/PostGenerationTaskTests.swift
+++ b/Tests/BaseChatUITests/PostGenerationTaskTests.swift
@@ -230,7 +230,7 @@ private actor ActorBox<T: Sendable> {
     func append(_ element: Int) where T == [Int] { value.append(element) }
 }
 
-private final class OrderCapturingTask: PostGenerationTask, @unchecked Sendable {
+private final class OrderCapturingTask: PostGenerationTask, Sendable {
     let index: Int
     let box: ActorBox<[Int]>
     init(index: Int, box: ActorBox<[Int]>) {


### PR DESCRIPTION
## Summary

Audited all 21 `@unchecked Sendable` conformances in the codebase and removed 8 that are unnecessary:

- **ClaudeBackend, OpenAIBackend, KoboldCppBackend**: redundant — `@unchecked Sendable` is already declared on the `SSECloudBackend` superclass and inherited by all final subclasses
- **SwiftDataPersistenceProvider, MockPersistenceProvider**: `@MainActor` isolation already satisfies `Sendable` without needing `@unchecked`
- **ConfiguringOpenAICloudBackend, ConfiguringClaudeCloudBackend** (E2E tests): `final class` with only `let` stored properties of `Sendable` types — the compiler can verify safety statically
- **OrderCapturingTask** (UI tests): `final class` with only `let` stored properties (`Int` and `ActorBox`) — replaced `@unchecked Sendable` with `Sendable`

The remaining 13 `@unchecked Sendable` conformances are legitimate:
- **SSECloudBackend**: `open class` with NSLock-guarded mutable state (can't be verified statically for non-final classes)
- **OllamaBackend, FoundationBackend, SlowMockBackend**: NSLock-guarded mutable state
- **MLXBackend, LlamaBackend**: C interop wrappers with non-Sendable foreign types
- **MemoryPressureHandler, SettingsService**: `@Observable` with GCD/UserDefaults internals
- **ExtractiveCompressor, AnchoredCompressor**: mutable configuration properties
- **MockURLProtocol.StubbedResponse**: enum with `Error` associated value (Error is not Sendable)
- **Test-local mocks** (InferenceServiceTests, LoadDispatchCoordinationTests, CompressionTests): mutable `var` stored properties

Closes #150

## Test plan

- [x] `swift test --filter BaseChatCoreTests` — 83 tests passed
- [x] `swift test --filter BaseChatUITests` — 292 tests passed
- [x] `swift test --filter BaseChatBackendsTests` — 77 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)