### PR TITLE
feat: replace raw String token stream with GenerationEvent enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ class MyBackend: InferenceBackend, @unchecked Sendable {
 
     func loadModel(from url: URL, contextSize: Int32) async throws { /* ... */ }
     func generate(prompt: String, systemPrompt: String?, config: GenerationConfig)
-        throws -> AsyncThrowingStream<String, Error> { /* ... */ }
+        throws -> AsyncThrowingStream<GenerationEvent, Error> { /* ... */ }
     func stopGeneration() { /* ... */ }
     func unloadModel() { /* ... */ }
 }

--- a/Sources/BaseChatBackends/FoundationBackend.swift
+++ b/Sources/BaseChatBackends/FoundationBackend.swift
@@ -133,7 +133,7 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
         prompt: String,
         systemPrompt: String?,
         config: GenerationConfig
-    ) throws -> AsyncThrowingStream<String, Error> {
+    ) throws -> AsyncThrowingStream<GenerationEvent, Error> {
         let activeSession: LanguageModelSession = try withStateLock {
             guard _isModelLoaded else {
                 throw InferenceError.inferenceFailure("No model loaded")
@@ -198,7 +198,7 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
                                     offsetBy: previousText.count
                                 )...]
                             )
-                            continuation.yield(newContent)
+                            continuation.yield(.token(newContent))
                             previousText = currentText
 
                             // Approximate token count using the conservative 3-char heuristic.

--- a/Sources/BaseChatBackends/KoboldCppBackend.swift
+++ b/Sources/BaseChatBackends/KoboldCppBackend.swift
@@ -20,7 +20,7 @@ import BaseChatCore
 /// )
 /// try await backend.loadModel(from: URL(string: "unused:")!, contextSize: 0)
 /// let stream = try backend.generate(prompt: "### Instruction:\nHello\n### Response:\n", systemPrompt: nil, config: .init())
-/// for try await token in stream { print(token, terminator: "") }
+/// for try await event in stream { if case .token(let t) = event { print(t, terminator: "") } }
 /// ```
 public final class KoboldCppBackend: SSECloudBackend, CloudBackendURLModelConfigurable {
 

--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -216,7 +216,7 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         prompt: String,
         systemPrompt: String?,
         config: GenerationConfig
-    ) throws -> AsyncThrowingStream<String, Error> {
+    ) throws -> AsyncThrowingStream<GenerationEvent, Error> {
         guard isModelLoaded, let context, let vocab, model != nil else {
             throw InferenceError.inferenceFailure("No model loaded")
         }
@@ -307,7 +307,7 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
 
                     // Decode token to text
                     if let text = self.tokenToString(token, invalidUTF8Buffer: &invalidUTF8) {
-                        continuation.yield(text)
+                        continuation.yield(.token(text))
                     }
 
                     // Prepare next batch

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -91,7 +91,7 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         prompt: String,
         systemPrompt: String?,
         config: GenerationConfig
-    ) throws -> AsyncThrowingStream<String, Error> {
+    ) throws -> AsyncThrowingStream<GenerationEvent, Error> {
         guard isModelLoaded, let modelContainer else {
             throw InferenceError.inferenceFailure("No model loaded")
         }
@@ -138,7 +138,7 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                     for await generation in stream {
                         if Task.isCancelled { break }
                         if let text = generation.chunk {
-                            continuation.yield(text)
+                            continuation.yield(.token(text))
                             // Each chunk from MLX corresponds to one token.
                             if let limit = outputLimit {
                                 outputTokenCount += 1

--- a/Sources/BaseChatBackends/OllamaBackend.swift
+++ b/Sources/BaseChatBackends/OllamaBackend.swift
@@ -22,7 +22,7 @@ import BaseChatCore
 /// backend.configure(baseURL: URL(string: "http://localhost:11434")!, modelName: "llama3.2")
 /// try await backend.loadModel(from: URL(string: "unused:")!, contextSize: 0)
 /// let stream = try backend.generate(prompt: "Hello", systemPrompt: nil, config: .init())
-/// for try await token in stream { print(token, terminator: "") }
+/// for try await event in stream { if case .token(let t) = event { print(t, terminator: "") } }
 /// ```
 public final class OllamaBackend: InferenceBackend, ConversationHistoryReceiver, CloudBackendURLModelConfigurable, @unchecked Sendable {
 
@@ -131,7 +131,7 @@ public final class OllamaBackend: InferenceBackend, ConversationHistoryReceiver,
         prompt: String,
         systemPrompt: String?,
         config: GenerationConfig
-    ) throws -> AsyncThrowingStream<String, Error> {
+    ) throws -> AsyncThrowingStream<GenerationEvent, Error> {
         let (loaded, capturedURL) = withStateLock { (isModelLoaded, baseURL) }
         guard loaded, let baseURL = capturedURL else {
             throw CloudBackendError.invalidURL("Backend not configured. Call loadModel first.")
@@ -181,7 +181,7 @@ public final class OllamaBackend: InferenceBackend, ConversationHistoryReceiver,
                                 if !lineBuffer.isEmpty {
                                     if let line = String(data: lineBuffer, encoding: .utf8),
                                        let token = Self.extractToken(from: line) {
-                                        continuation.yield(token)
+                                        continuation.yield(.token(token))
                                     }
                                     lineBuffer.removeAll(keepingCapacity: true)
                                 }
@@ -194,7 +194,7 @@ public final class OllamaBackend: InferenceBackend, ConversationHistoryReceiver,
                         if !lineBuffer.isEmpty,
                            let line = String(data: lineBuffer, encoding: .utf8),
                            let token = Self.extractToken(from: line) {
-                            continuation.yield(token)
+                            continuation.yield(.token(token))
                         }
                     }
 

--- a/Sources/BaseChatBackends/OpenAIBackend.swift
+++ b/Sources/BaseChatBackends/OpenAIBackend.swift
@@ -17,7 +17,7 @@ import BaseChatCore
 /// )
 /// try await backend.loadModel(from: URL(string: "unused:")!, contextSize: 0)
 /// let stream = try backend.generate(prompt: "Hello", systemPrompt: nil, config: .init())
-/// for try await token in stream { print(token, terminator: "") }
+/// for try await event in stream { if case .token(let t) = event { print(t, terminator: "") } }
 /// ```
 public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBackendURLModelConfigurable, CloudBackendKeychainConfigurable {
 

--- a/Sources/BaseChatBackends/OpenAICompatibleBackend.swift
+++ b/Sources/BaseChatBackends/OpenAICompatibleBackend.swift
@@ -21,6 +21,6 @@ import BaseChatCore
 /// )
 /// try await backend.loadModel(from: URL(string: "unused:")!, contextSize: 0)
 /// let stream = try backend.generate(prompt: "Hello", systemPrompt: nil, config: .init())
-/// for try await token in stream { print(token, terminator: "") }
+/// for try await event in stream { if case .token(let t) = event { print(t, terminator: "") } }
 /// ```
 public typealias OpenAICompatibleBackend = OpenAIBackend

--- a/Sources/BaseChatBackends/SSECloudBackend.swift
+++ b/Sources/BaseChatBackends/SSECloudBackend.swift
@@ -225,7 +225,7 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
         prompt: String,
         systemPrompt: String?,
         config: GenerationConfig
-    ) throws -> AsyncThrowingStream<String, Error> {
+    ) throws -> AsyncThrowingStream<GenerationEvent, Error> {
         guard withStateLock({ _isModelLoaded && _baseURL != nil }) else {
             throw CloudBackendError.invalidURL("Backend not configured. Call loadModel first.")
         }
@@ -269,11 +269,15 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
                             if Task.isCancelled { break }
 
                             if let token = self?.extractToken(from: payload) {
-                                continuation.yield(token)
+                                continuation.yield(.token(token))
                             }
 
                             if let usage = self?.extractUsage(from: payload) {
                                 self?.handleUsage(usage)
+                                if let prompt = usage.promptTokens,
+                                   let completion = usage.completionTokens {
+                                    continuation.yield(.usage(prompt: prompt, completion: completion))
+                                }
                             }
 
                             if self?.isStreamEnd(payload) == true {

--- a/Sources/BaseChatCore/Models/GenerationEvent.swift
+++ b/Sources/BaseChatCore/Models/GenerationEvent.swift
@@ -1,0 +1,18 @@
+/// Events emitted by inference backends during text generation.
+///
+/// Replaces the raw `String` token stream to support tool calling (#55),
+/// usage reporting, and future structured output without breaking the
+/// `InferenceBackend` contract again.
+public enum GenerationEvent: Sendable {
+    /// A fragment of generated text (typically one token).
+    case token(String)
+
+    /// A tool/function call emitted by the model.
+    case toolCall(name: String, arguments: String)
+
+    /// Token usage reported by the backend (cloud backends only today).
+    case usage(prompt: Int, completion: Int)
+
+    /// The generation stream has finished normally.
+    case done
+}

--- a/Sources/BaseChatCore/Models/GenerationEvent.swift
+++ b/Sources/BaseChatCore/Models/GenerationEvent.swift
@@ -3,7 +3,7 @@
 /// Replaces the raw `String` token stream to support tool calling (#55),
 /// usage reporting, and future structured output without breaking the
 /// `InferenceBackend` contract again.
-public enum GenerationEvent: Sendable {
+public enum GenerationEvent: Sendable, Equatable {
     /// A fragment of generated text (typically one token).
     case token(String)
 
@@ -14,5 +14,9 @@ public enum GenerationEvent: Sendable {
     case usage(prompt: Int, completion: Int)
 
     /// The generation stream has finished normally.
+    ///
+    /// Reserved for future use. Backends currently signal completion by
+    /// finishing the stream (`continuation.finish()`), so consumers should
+    /// treat stream termination as the authoritative end signal.
     case done
 }

--- a/Sources/BaseChatCore/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatCore/Protocols/InferenceBackend.swift
@@ -54,13 +54,13 @@ public protocol InferenceBackend: AnyObject, Sendable {
     ///   `config.json` + `.safetensors` weights.
     func loadModel(from url: URL, contextSize: Int32) async throws
 
-    /// Generates text from a prompt, streaming tokens as they are produced.
+    /// Generates a response from a prompt, streaming events as they are produced.
     /// Errors during generation are thrown into the stream.
     func generate(
         prompt: String,
         systemPrompt: String?,
         config: GenerationConfig
-    ) throws -> AsyncThrowingStream<String, Error>
+    ) throws -> AsyncThrowingStream<GenerationEvent, Error>
 
     /// Requests that the current generation stop as soon as possible.
     ///

--- a/Sources/BaseChatCore/Services/InferenceService.swift
+++ b/Sources/BaseChatCore/Services/InferenceService.swift
@@ -341,7 +341,7 @@ public final class InferenceService {
         topP: Float = 0.9,
         repeatPenalty: Float = 1.1,
         maxOutputTokens: Int? = 2048
-    ) throws -> AsyncThrowingStream<String, Error> {
+    ) throws -> AsyncThrowingStream<GenerationEvent, Error> {
         guard let backend else {
             throw InferenceError.inferenceFailure("No model loaded")
         }

--- a/Sources/BaseChatCore/Services/SSEStreamParser.swift
+++ b/Sources/BaseChatCore/Services/SSEStreamParser.swift
@@ -105,11 +105,10 @@ public struct SSEStreamParser {
     ///   - handler: A payload handler that interprets the provider's JSON format.
     ///   - onUsage: Called when usage information is extracted from a payload.
     /// - Returns: An `AsyncThrowingStream` of text tokens.
-    public static func streamTokens<S: AsyncSequence & Sendable>(
+    public static func streamEvents<S: AsyncSequence & Sendable>(
         from bytes: S,
-        using handler: some SSEPayloadHandler,
-        onUsage: (@Sendable (Int?, Int?) -> Void)? = nil
-    ) -> AsyncThrowingStream<String, Error> where S.Element == UInt8 {
+        using handler: some SSEPayloadHandler
+    ) -> AsyncThrowingStream<GenerationEvent, Error> where S.Element == UInt8 {
         AsyncThrowingStream { continuation in
             let task = Task {
                 do {
@@ -118,11 +117,13 @@ public struct SSEStreamParser {
                         if Task.isCancelled { break }
 
                         if let token = handler.extractToken(from: payload) {
-                            continuation.yield(token)
+                            continuation.yield(.token(token))
                         }
 
-                        if let usage = handler.extractUsage(from: payload) {
-                            onUsage?(usage.promptTokens, usage.completionTokens)
+                        if let usage = handler.extractUsage(from: payload),
+                           let prompt = usage.promptTokens,
+                           let completion = usage.completionTokens {
+                            continuation.yield(.usage(prompt: prompt, completion: completion))
                         }
 
                         if handler.isStreamEnd(payload) {

--- a/Sources/BaseChatCore/Services/SSEStreamParser.swift
+++ b/Sources/BaseChatCore/Services/SSEStreamParser.swift
@@ -94,17 +94,16 @@ public struct SSEStreamParser {
         }
     }
 
-    /// Streams tokens from an HTTP response using an SSE payload handler.
+    /// Streams generation events from an HTTP response using an SSE payload handler.
     ///
     /// Combines `parse(bytes:)` with a payload handler to extract tokens,
-    /// track usage, detect stream end, and surface errors. This eliminates
-    /// the duplicated streaming loop in each cloud backend.
+    /// emit usage reports, detect stream end, and surface errors. This
+    /// eliminates the duplicated streaming loop in each cloud backend.
     ///
     /// - Parameters:
     ///   - bytes: The raw byte stream from `URLSession.bytes(for:)`.
     ///   - handler: A payload handler that interprets the provider's JSON format.
-    ///   - onUsage: Called when usage information is extracted from a payload.
-    /// - Returns: An `AsyncThrowingStream` of text tokens.
+    /// - Returns: An `AsyncThrowingStream` of ``GenerationEvent`` values.
     public static func streamEvents<S: AsyncSequence & Sendable>(
         from bytes: S,
         using handler: some SSEPayloadHandler

--- a/Sources/BaseChatTestSupport/MidStreamErrorBackend.swift
+++ b/Sources/BaseChatTestSupport/MidStreamErrorBackend.swift
@@ -38,7 +38,7 @@ public final class MidStreamErrorBackend: InferenceBackend, @unchecked Sendable 
         prompt: String,
         systemPrompt: String?,
         config: GenerationConfig
-    ) throws -> AsyncThrowingStream<String, Error> {
+    ) throws -> AsyncThrowingStream<GenerationEvent, Error> {
         let tokens = tokensBeforeError
         let error = errorToThrow
         isGenerating = true
@@ -46,7 +46,7 @@ public final class MidStreamErrorBackend: InferenceBackend, @unchecked Sendable 
             Task {
                 for token in tokens {
                     if Task.isCancelled { break }
-                    continuation.yield(token)
+                    continuation.yield(.token(token))
                 }
                 self.isGenerating = false
                 continuation.finish(throwing: error)

--- a/Sources/BaseChatTestSupport/MockInferenceBackend.swift
+++ b/Sources/BaseChatTestSupport/MockInferenceBackend.swift
@@ -36,7 +36,7 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
     public var lastConfig: GenerationConfig?
 
     /// Stored so stopGeneration() can terminate the in-flight stream.
-    private var activeContinuation: AsyncThrowingStream<String, Error>.Continuation?
+    private var activeContinuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation?
 
     public init(capabilities: BackendCapabilities = BackendCapabilities(
         supportedParameters: [.temperature, .topP, .repeatPenalty],
@@ -58,7 +58,7 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
         isModelLoaded = true
     }
 
-    public func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> AsyncThrowingStream<String, Error> {
+    public func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> AsyncThrowingStream<GenerationEvent, Error> {
         generateCallCount += 1
         lastPrompt = prompt
         lastSystemPrompt = systemPrompt
@@ -77,7 +77,7 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
             Task {
                 for token in tokens {
                     if Task.isCancelled { break }
-                    continuation.yield(token)
+                    continuation.yield(.token(token))
                 }
                 self.isGenerating = false
                 if let streamError = self.shouldThrowInsideStream, !Task.isCancelled {

--- a/Sources/BaseChatTestSupport/MockTokenizerVendorBackend.swift
+++ b/Sources/BaseChatTestSupport/MockTokenizerVendorBackend.swift
@@ -31,7 +31,7 @@ public final class MockTokenizerVendorBackend: InferenceBackend,
         prompt: String,
         systemPrompt: String?,
         config: GenerationConfig
-    ) throws -> AsyncThrowingStream<String, Error> {
+    ) throws -> AsyncThrowingStream<GenerationEvent, Error> {
         guard isModelLoaded else { throw InferenceError.inferenceFailure("No model loaded") }
         isGenerating = true
         let tokens = tokensToYield
@@ -39,7 +39,7 @@ public final class MockTokenizerVendorBackend: InferenceBackend,
             Task {
                 for token in tokens {
                     if Task.isCancelled { break }
-                    continuation.yield(token)
+                    continuation.yield(.token(token))
                 }
                 self.isGenerating = false
                 continuation.finish()

--- a/Sources/BaseChatTestSupport/SlowMockBackend.swift
+++ b/Sources/BaseChatTestSupport/SlowMockBackend.swift
@@ -64,7 +64,7 @@ public final class SlowMockBackend: InferenceBackend, @unchecked Sendable {
         prompt: String,
         systemPrompt: String?,
         config: GenerationConfig
-    ) throws -> AsyncThrowingStream<String, Error> {
+    ) throws -> AsyncThrowingStream<GenerationEvent, Error> {
         let (tokens, delay) = withStateLock {
             _isGenerating = true
             return (_tokensToYield, _delayPerToken)
@@ -81,7 +81,7 @@ public final class SlowMockBackend: InferenceBackend, @unchecked Sendable {
                     if Task.isCancelled { break }
                     try? await Task.sleep(for: delay)
                     if Task.isCancelled { break }
-                    continuation.yield(token)
+                    continuation.yield(.token(token))
                 }
             }
             continuation.onTermination = { @Sendable _ in

--- a/Sources/BaseChatTestSupport/StopGenerationContractTests.swift
+++ b/Sources/BaseChatTestSupport/StopGenerationContractTests.swift
@@ -46,8 +46,10 @@ public enum StopGenerationContractTests {
         )
 
         var tokens: [String] = []
-        for try await token in secondStream {
-            tokens.append(token)
+        for try await event in secondStream {
+            if case .token(let text) = event {
+                tokens.append(text)
+            }
         }
 
         XCTAssertFalse(

--- a/Sources/BaseChatTestSupport/TestHelpers.swift
+++ b/Sources/BaseChatTestSupport/TestHelpers.swift
@@ -34,11 +34,13 @@ public func cleanupE2ETempDir(_ url: URL) {
     try? FileManager.default.removeItem(at: url)
 }
 
-/// Collects all tokens from an async throwing stream into a single string.
-public func collectTokens(_ stream: AsyncThrowingStream<String, Error>) async throws -> String {
+/// Collects all token text from a generation event stream into a single string.
+public func collectTokens(_ stream: AsyncThrowingStream<GenerationEvent, Error>) async throws -> String {
     var tokens: [String] = []
-    for try await token in stream {
-        tokens.append(token)
+    for try await event in stream {
+        if case .token(let text) = event {
+            tokens.append(text)
+        }
     }
     return tokens.joined()
 }

--- a/Sources/BaseChatTestSupport/TokenTrackingMockBackend.swift
+++ b/Sources/BaseChatTestSupport/TokenTrackingMockBackend.swift
@@ -41,7 +41,7 @@ public final class TokenTrackingMockBackend: InferenceBackend, TokenUsageProvide
         prompt: String,
         systemPrompt: String?,
         config: GenerationConfig
-    ) throws -> AsyncThrowingStream<String, Error> {
+    ) throws -> AsyncThrowingStream<GenerationEvent, Error> {
         isGenerating = true
         let tokens = tokensToYield
 
@@ -59,7 +59,7 @@ public final class TokenTrackingMockBackend: InferenceBackend, TokenUsageProvide
             Task {
                 for token in tokens {
                     if Task.isCancelled { break }
-                    continuation.yield(token)
+                    continuation.yield(.token(token))
                 }
                 self.lastUsage = usage
                 self.isGenerating = false

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
@@ -119,22 +119,35 @@ extension ChatViewModel {
                 )
 
                 do {
-                    for try await token in stream {
+                    eventLoop: for try await event in stream {
                         if Task.isCancelled { break }
-                        tokenCount += 1
-                        if tokenCount == 1 {
-                            self.activityPhase = .streaming
-                        }
-                        if let batch = batcher.append(token, now: ContinuousClock.now),
-                           let idx = self.messages.firstIndex(where: { $0.id == messageID }) {
-                            self.messages[idx].content += batch
-                            if self.loopDetectionEnabled,
-                               self.messages[idx].content.count >= 100,
-                               RepetitionDetector.looksLikeLooping(self.messages[idx].content) {
-                                self.inferenceService.stopGeneration()
-                                self.errorMessage = "Generation stopped: the model appears to be repeating itself."
-                                break
+
+                        switch event {
+                        case .token(let token):
+                            tokenCount += 1
+                            if tokenCount == 1 {
+                                self.activityPhase = .streaming
                             }
+                            if let batch = batcher.append(token, now: ContinuousClock.now),
+                               let idx = self.messages.firstIndex(where: { $0.id == messageID }) {
+                                self.messages[idx].content += batch
+                                if self.loopDetectionEnabled,
+                                   self.messages[idx].content.count >= 100,
+                                   RepetitionDetector.looksLikeLooping(self.messages[idx].content) {
+                                    self.inferenceService.stopGeneration()
+                                    self.errorMessage = "Generation stopped: the model appears to be repeating itself."
+                                    break eventLoop
+                                }
+                            }
+
+                        case .usage(let prompt, let completion):
+                            if let idx = self.messages.firstIndex(where: { $0.id == messageID }) {
+                                self.messages[idx].promptTokens = prompt
+                                self.messages[idx].completionTokens = completion
+                            }
+
+                        case .toolCall, .done:
+                            break
                         }
                     }
                 } catch {

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -336,7 +336,9 @@ public final class ChatViewModel {
                 )
             }
             var result = ""
-            for try await token in stream { result += token }
+            for try await event in stream {
+                if case .token(let text) = event { result += text }
+            }
             return result
         }
     }

--- a/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
@@ -96,8 +96,10 @@ public final class SessionManagerViewModel {
                 repeatPenalty: 1.0
             )
             var result = ""
-            for try await token in stream {
-                result += token
+            for try await event in stream {
+                if case .token(let text) = event {
+                    result += text
+                }
             }
             let trimmed = result.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { return nil }

--- a/Tests/BaseChatBackendsTests/CloudBackendSSETests.swift
+++ b/Tests/BaseChatBackendsTests/CloudBackendSSETests.swift
@@ -74,8 +74,10 @@ struct ClaudeBackendSSETests {
         )
 
         var tokens: [String] = []
-        for try await token in stream {
-            tokens.append(token)
+        for try await event in stream {
+            if case .token(let text) = event {
+                tokens.append(text)
+            }
         }
 
         #expect(tokens == ["Hello", " world"])
@@ -169,8 +171,10 @@ struct ClaudeBackendSSETests {
         )
 
         var tokens: [String] = []
-        for try await token in stream {
-            tokens.append(token)
+        for try await event in stream {
+            if case .token(let text) = event {
+                tokens.append(text)
+            }
         }
 
         // Malformed JSON is simply not a token event -- extractToken returns nil.
@@ -203,8 +207,10 @@ struct ClaudeBackendSSETests {
 
         var tokens: [String] = []
         do {
-            for try await token in stream {
-                tokens.append(token)
+            for try await event in stream {
+                if case .token(let text) = event {
+                    tokens.append(text)
+                }
             }
             Issue.record("Expected an error from the stream error event")
         } catch let error as CloudBackendError {
@@ -296,8 +302,10 @@ struct OpenAIBackendSSETests {
         )
 
         var tokens: [String] = []
-        for try await token in stream {
-            tokens.append(token)
+        for try await event in stream {
+            if case .token(let text) = event {
+                tokens.append(text)
+            }
         }
 
         #expect(tokens == ["Hello", " there"])
@@ -360,8 +368,10 @@ struct OpenAIBackendSSETests {
         )
 
         var tokens: [String] = []
-        for try await token in stream {
-            tokens.append(token)
+        for try await event in stream {
+            if case .token(let text) = event {
+                tokens.append(text)
+            }
         }
 
         // The role-only chunk has no "content", so extractToken returns nil.

--- a/Tests/BaseChatBackendsTests/KoboldCppSSETests.swift
+++ b/Tests/BaseChatBackendsTests/KoboldCppSSETests.swift
@@ -70,8 +70,10 @@ struct KoboldCppBackendSSETests {
         )
 
         var tokens: [String] = []
-        for try await token in stream {
-            tokens.append(token)
+        for try await event in stream {
+            if case .token(let text) = event {
+                tokens.append(text)
+            }
         }
 
         #expect(tokens == ["Hello", " world", "!"])
@@ -266,8 +268,10 @@ struct KoboldCppBackendSSETests {
         )
 
         var tokens: [String] = []
-        for try await token in stream {
-            tokens.append(token)
+        for try await event in stream {
+            if case .token(let text) = event {
+                tokens.append(text)
+            }
         }
 
         #expect(tokens == ["OK"])

--- a/Tests/BaseChatBackendsTests/OllamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/OllamaBackendTests.swift
@@ -111,8 +111,10 @@ struct OllamaBackendTests {
 
         let stream = try backend.generate(prompt: "Say hello", systemPrompt: nil, config: .init())
         var tokens: [String] = []
-        for try await token in stream {
-            tokens.append(token)
+        for try await event in stream {
+            if case .token(let text) = event {
+                tokens.append(text)
+            }
         }
 
         #expect(tokens == ["Hello", " world", "!"])
@@ -156,7 +158,7 @@ struct OllamaBackendTests {
 
         let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: .init())
         var tokens: [String] = []
-        for try await token in stream { tokens.append(token) }
+        for try await event in stream { if case .token(let text) = event { tokens.append(text) } }
 
         #expect(tokens == ["Hi"])
     }
@@ -175,7 +177,7 @@ struct OllamaBackendTests {
 
         let stream = try backend.generate(prompt: "hello", systemPrompt: nil, config: .init())
         var tokens: [String] = []
-        for try await token in stream { tokens.append(token) }
+        for try await event in stream { if case .token(let text) = event { tokens.append(text) } }
 
         #expect(tokens == ["OK"])
     }

--- a/Tests/BaseChatBackendsTests/OpenAICompatEndpointTests.swift
+++ b/Tests/BaseChatBackendsTests/OpenAICompatEndpointTests.swift
@@ -124,8 +124,10 @@ struct OpenAICompatEndpointTests {
         )
 
         var tokens: [String] = []
-        for try await token in stream {
-            tokens.append(token)
+        for try await event in stream {
+            if case .token(let text) = event {
+                tokens.append(text)
+            }
         }
 
         // Empty first chunk (role-only) yields empty string; content chunks follow.
@@ -191,8 +193,10 @@ struct OpenAICompatEndpointTests {
         )
 
         var tokens: [String] = []
-        for try await token in stream {
-            tokens.append(token)
+        for try await event in stream {
+            if case .token(let text) = event {
+                tokens.append(text)
+            }
         }
 
         #expect(tokens == ["Hello"])
@@ -307,8 +311,10 @@ struct OpenAICompatEndpointTests {
         )
 
         var tokens: [String] = []
-        for try await token in stream {
-            tokens.append(token)
+        for try await event in stream {
+            if case .token(let text) = event {
+                tokens.append(text)
+            }
         }
 
         let meaningful = tokens.filter { !$0.isEmpty }
@@ -340,8 +346,10 @@ struct OpenAICompatEndpointTests {
         )
 
         var tokens: [String] = []
-        for try await token in stream {
-            tokens.append(token)
+        for try await event in stream {
+            if case .token(let text) = event {
+                tokens.append(text)
+            }
         }
 
         #expect(tokens == ["truncated output"])

--- a/Tests/BaseChatBackendsTests/RetryPolicyIntegrationTests.swift
+++ b/Tests/BaseChatBackendsTests/RetryPolicyIntegrationTests.swift
@@ -59,8 +59,10 @@ final class RetryPolicyIntegrationTests: XCTestCase {
         )
 
         var tokens: [String] = []
-        for try await token in stream {
-            tokens.append(token)
+        for try await event in stream {
+            if case .token(let text) = event {
+                tokens.append(text)
+            }
         }
 
         XCTAssertEqual(tokens, ["hello"], "Should receive token after retrying past 429s")
@@ -164,8 +166,10 @@ final class RetryPolicyIntegrationTests: XCTestCase {
 
         let start = ContinuousClock.now
         var tokens: [String] = []
-        for try await token in stream {
-            tokens.append(token)
+        for try await event in stream {
+            if case .token(let text) = event {
+                tokens.append(text)
+            }
         }
         let elapsed = ContinuousClock.now - start
 

--- a/Tests/BaseChatCoreTests/InferenceServiceTests.swift
+++ b/Tests/BaseChatCoreTests/InferenceServiceTests.swift
@@ -39,12 +39,14 @@ final class InferenceServiceTests: XCTestCase {
         let stream = try service.generate(messages: [("user", "Tell me a story")])
 
         var collected: [String] = []
-        for try await token in stream {
-            collected.append(token)
+        for try await event in stream {
+            if case .token(let text) = event {
+                collected.append(text)
+            }
         }
 
         XCTAssertEqual(collected, ["Once", " upon", " a", " time"],
-                        "Should stream all tokens from the mock backend")
+                        "Should stream all token events from the mock backend")
         XCTAssertEqual(mock.generateCallCount, 1, "Should have called generate once")
     }
 
@@ -777,7 +779,7 @@ private final class MockConversationHistoryBackend: InferenceBackend,
 
     func loadModel(from url: URL, contextSize: Int32) async throws {}
 
-    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> AsyncThrowingStream<String, Error> {
+    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> AsyncThrowingStream<GenerationEvent, Error> {
         AsyncThrowingStream { continuation in continuation.finish() }
     }
 
@@ -803,7 +805,7 @@ private final class MockTokenUsageBackend: InferenceBackend,
 
     func loadModel(from url: URL, contextSize: Int32) async throws {}
 
-    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> AsyncThrowingStream<String, Error> {
+    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> AsyncThrowingStream<GenerationEvent, Error> {
         AsyncThrowingStream { continuation in continuation.finish() }
     }
 
@@ -839,7 +841,7 @@ private final class MockCloudURLModelBackend: InferenceBackend,
         didConfigureBeforeLoad = (configuredBaseURL != nil && configuredModelName != nil)
     }
 
-    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> AsyncThrowingStream<String, Error> {
+    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> AsyncThrowingStream<GenerationEvent, Error> {
         AsyncThrowingStream { continuation in continuation.finish() }
     }
 
@@ -881,7 +883,7 @@ private final class MockCloudKeychainBackend: InferenceBackend,
         )
     }
 
-    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> AsyncThrowingStream<String, Error> {
+    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> AsyncThrowingStream<GenerationEvent, Error> {
         AsyncThrowingStream { continuation in continuation.finish() }
     }
 
@@ -1006,7 +1008,7 @@ private final class ControlledLoadBackend: InferenceBackend,
         }
     }
 
-    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> AsyncThrowingStream<String, Error> {
+    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> AsyncThrowingStream<GenerationEvent, Error> {
         AsyncThrowingStream { continuation in
             continuation.finish()
         }

--- a/Tests/BaseChatE2ETests/ServerDiscoveryGenerateE2ETests.swift
+++ b/Tests/BaseChatE2ETests/ServerDiscoveryGenerateE2ETests.swift
@@ -128,7 +128,7 @@ struct ServerDiscoveryGenerateE2ETests {
         let stream = try backend.generate(prompt: "Hi", systemPrompt: nil, config: GenerationConfig())
 
         var tokens: [String] = []
-        for try await token in stream { tokens.append(token) }
+        for try await event in stream { if case .token(let text) = event { tokens.append(text) } }
 
         #expect(tokens == ["Hello", " world"])
     }
@@ -170,7 +170,7 @@ struct ServerDiscoveryGenerateE2ETests {
         let stream = try backend.generate(prompt: "Test", systemPrompt: nil, config: GenerationConfig())
 
         var tokens: [String] = []
-        for try await token in stream { tokens.append(token) }
+        for try await event in stream { if case .token(let text) = event { tokens.append(text) } }
 
         #expect(tokens == ["Probed", " reply"])
     }
@@ -261,7 +261,7 @@ struct ServerDiscoveryGenerateE2ETests {
         let stream = try backend.generate(prompt: "Test", systemPrompt: nil, config: GenerationConfig())
 
         var tokens: [String] = []
-        for try await token in stream { tokens.append(token) }
+        for try await event in stream { if case .token(let text) = event { tokens.append(text) } }
 
         #expect(tokens == ["From", " LM", " Studio"])
     }

--- a/Tests/BaseChatUITests/LoadDispatchCoordinationTests.swift
+++ b/Tests/BaseChatUITests/LoadDispatchCoordinationTests.swift
@@ -348,7 +348,7 @@ private final class ControlledLoadBackend: InferenceBackend,
         prompt: String,
         systemPrompt: String?,
         config: GenerationConfig
-    ) throws -> AsyncThrowingStream<String, Error> {
+    ) throws -> AsyncThrowingStream<GenerationEvent, Error> {
         guard isModelLoaded else {
             throw InferenceError.inferenceFailure("No model loaded")
         }


### PR DESCRIPTION
## Summary

- Introduces `GenerationEvent` enum in BaseChatCore with cases: `.token(String)`, `.toolCall(name:arguments:)`, `.usage(prompt:completion:)`, and `.done`
- Changes `InferenceBackend.generate()` return type from `AsyncThrowingStream<String, Error>` to `AsyncThrowingStream<GenerationEvent, Error>`
- Updates all 7 backend implementations (MLX, Llama, Foundation, OpenAI, Claude, Ollama, KoboldCpp), both stream consumers (ChatViewModel, SessionManagerViewModel), SSEStreamParser, all 6 mock backends, and all affected tests (452 tests passing)

## Migration guide

**Backend conformers:** Change `generate()` return type to `AsyncThrowingStream<GenerationEvent, Error>` and wrap token yields in `.token(...)`.

**Stream consumers:** Replace `for try await token in stream` with pattern matching:
```swift
for try await event in stream {
    switch event {
    case .token(let text): // handle text
    case .usage(let prompt, let completion): // handle usage
    case .toolCall, .done: break
    }
}
```

## Why

This is the most expensive API surface to change post-1.0. Multiple roadmap items (#55 tool calling, #14 MCP, #108 structured output) need the stream to carry more than raw string tokens. Doing this now avoids breaking every backend conformer and every call site after 1.0.

Closes #130

## Test plan

- [x] `swift test --filter BaseChatCoreTests` — 83 tests passing
- [x] `swift test --filter BaseChatUITests` — 292 tests passing
- [x] `swift test --filter BaseChatBackendsTests` — 77 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)