### PR TITLE
docs: rewrite v0.3.1 changelog in prose style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## [0.3.1](https://github.com/roryford/BaseChatKit/compare/v0.3.0...v0.3.1) (2026-04-06)
 
-
 ### Bug Fixes
 
-* update test mocks to use GenerationEvent stream signature ([eff073a](https://github.com/roryford/BaseChatKit/commit/eff073ac763625982beda2819da54199532c6621))
+**Test mocks aligned with GenerationEvent stream** — The v0.3.0 streaming API change (`AsyncThrowingStream<GenerationEvent, Error>`) left `MockInferenceBackend` and other test doubles still returning the old `String` stream signature, causing compilation failures in downstream test targets. All mocks in `BaseChatTestSupport` now return `GenerationEvent` streams. ([eff073a](https://github.com/roryford/BaseChatKit/commit/eff073ac763625982beda2819da54199532c6621))
 
 ## [0.3.0](https://github.com/roryford/BaseChatKit/compare/v0.2.22...v0.3.0) (2026-04-06)
 


### PR DESCRIPTION
## Summary
- Rewrites the auto-generated v0.3.1 changelog bullet into prose-style release notes consistent with v0.3.0 format
- Explains the problem (mock signatures lagged behind the GenerationEvent API change) and what was fixed

## Test plan
- [x] No code changes — changelog only

🤖 Generated with [Claude Code](https://claude.com/claude-code)