### PR TITLE
fix: restore public access to ChatViewModel.inferenceService

### DIFF
--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -14,7 +14,7 @@ public final class ChatViewModel {
 
     // MARK: - Services
 
-    let inferenceService: InferenceService
+    public let inferenceService: InferenceService
     let deviceCapability: DeviceCapabilityService
     let modelStorage: ModelStorageService
     let memoryPressure: MemoryPressureHandler


### PR DESCRIPTION
## Summary
- Restores `public` access on `ChatViewModel.inferenceService` which was narrowed to `internal` by the decomposition refactor (#174)
- Downstream consumers (Fireside) need direct access to share the InferenceService instance across StoryStore and CharacterCreatorService

## Test plan
- [x] `swift build` passes
- [x] One-line access level change, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)