### PR TITLE
docs: document InferenceService dependency injection pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,18 @@ When writing hardware-gated tests, add `XCTSkipIf` guards at the top of the test
 - After asserting an expected outcome, add a sabotage check: temporarily break the code path being tested and confirm the test fails. Remove the sabotage before committing.
 - Performance tests use `measure { }` (XCTMeasure). Build all fixtures before the measure block.
 
+## Service sharing
+
+`ChatViewModel.inferenceService` is `internal` by design. Apps that need the same `InferenceService` instance in multiple components (e.g., a story engine, character creator) should create it at the app level and inject it:
+
+```swift
+let inference = InferenceService()
+let chatVM = ChatViewModel(inferenceService: inference)
+let storyStore = StoryStore(inferenceService: inference)
+```
+
+Do not widen `inferenceService` to `public` — it exposes load coordination internals and makes `InferenceService`'s full API part of `ChatViewModel`'s public contract.
+
 ## Coding conventions
 
 - **Concurrency**: async/await throughout. No Combine, no callback pyramids.

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -8,6 +8,21 @@ import BaseChatCore
 /// Manages the message history, model lifecycle, generation settings, context
 /// tracking, export, and SwiftData persistence. Views observe this via
 /// `@Environment` and never call services directly.
+///
+/// ## Sharing InferenceService across components
+///
+/// `inferenceService` is intentionally `internal` — downstream apps should
+/// create the service at the app level and inject it into all consumers:
+///
+/// ```swift
+/// let inference = InferenceService()
+/// let chatVM = ChatViewModel(inferenceService: inference)
+/// let storyStore = StoryStore(inferenceService: inference)
+/// ```
+///
+/// This keeps ChatViewModel's load coordination and state machine consistent.
+/// Do not expose `inferenceService` publicly; if new consumers need generation
+/// without lifecycle control, extract a focused protocol instead.
 @Observable
 @MainActor
 public final class ChatViewModel {


### PR DESCRIPTION
## Summary
- Adds header doc on `ChatViewModel` explaining why `inferenceService` is `internal` and showing the injection pattern
- Adds "Service sharing" section to CLAUDE.md so future contributors don't widen the property to `public`
- Closes the discussion from #177 (which was closed without merging)

## Test plan
- [x] `swift build` passes
- [x] Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)