### PR TITLE
fix: correct 6 compression bugs affecting context management

### DIFF
--- a/Sources/BaseChatCore/Services/Compression/AnchoredCompressor.swift
+++ b/Sources/BaseChatCore/Services/Compression/AnchoredCompressor.swift
@@ -105,19 +105,7 @@ public final class AnchoredCompressor: ContextCompressor, @unchecked Sendable {
 
         // 4. If no generate function is available, fall back.
         guard let generate = generateFn else {
-            var result = await fallback.compress(messages: messages, systemPrompt: systemPrompt, contextSize: contextSize, tokenizer: tokenizer)
-            result = CompressionResult(
-                messages: result.messages,
-                stats: CompressionStats(
-                    strategy: "anchored-fallback",
-                    originalNodeCount: result.stats.originalNodeCount,
-                    outputMessageCount: result.stats.outputMessageCount,
-                    estimatedTokens: result.stats.estimatedTokens,
-                    compressionRatio: result.stats.compressionRatio,
-                    keywordSurvivalRate: result.stats.keywordSurvivalRate
-                )
-            )
-            return result
+            return await fallbackResult(messages: messages, systemPrompt: systemPrompt, contextSize: contextSize, tokenizer: tokenizer)
         }
 
         // 5. Build the summary prompt and call inference.
@@ -126,50 +114,47 @@ public final class AnchoredCompressor: ContextCompressor, @unchecked Sendable {
 
         let summaryText: String
         do {
+            try Task.checkCancellation()
             summaryText = try await generate(prompt)
         } catch {
-            var result = await fallback.compress(messages: messages, systemPrompt: systemPrompt, contextSize: contextSize, tokenizer: tokenizer)
-            result = CompressionResult(
-                messages: result.messages,
-                stats: CompressionStats(
-                    strategy: "anchored-fallback",
-                    originalNodeCount: result.stats.originalNodeCount,
-                    outputMessageCount: result.stats.outputMessageCount,
-                    estimatedTokens: result.stats.estimatedTokens,
-                    compressionRatio: result.stats.compressionRatio,
-                    keywordSurvivalRate: result.stats.keywordSurvivalRate
+            // On cancellation, return a minimal result rather than starting a new
+            // fallback compression pass that will also be cancelled.
+            if error is CancellationError {
+                return CompressionResult(
+                    messages: messageTuples(from: tailMessages),
+                    stats: CompressionStats(
+                        strategy: "anchored-cancelled",
+                        originalNodeCount: messages.count,
+                        outputMessageCount: tailMessages.count,
+                        estimatedTokens: tailTokens,
+                        compressionRatio: Double(originalTokens) / Double(max(tailTokens, 1)),
+                        keywordSurvivalRate: nil
+                    )
                 )
-            )
-            return result
+            }
+            return await fallbackResult(messages: messages, systemPrompt: systemPrompt, contextSize: contextSize, tokenizer: tokenizer)
         }
 
-        // 6. Parse the structured summary.
+        // 6. If the summary is empty, fall back to extractive instead of injecting a placeholder.
+        guard !summaryText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return await fallbackResult(messages: messages, systemPrompt: systemPrompt, contextSize: contextSize, tokenizer: tokenizer)
+        }
+
+        // 7. Parse the structured summary.
         let parsedSummary = parseSummaryResponse(summaryText)
 
-        // 7. Assemble: summary system message + verbatim tail.
+        // 8. Assemble: summary system message + verbatim tail.
         var outputMessages: [(role: String, content: String)] = [("system", parsedSummary)]
         outputMessages.append(contentsOf: messageTuples(from: tailMessages))
 
         let outputTokens = totalTokens(of: outputMessages, tokenizer: tokenizer)
 
-        // 8. If summary + tail exceeds budget, the summary was too long -- fall back.
+        // 9. If summary + tail exceeds budget, the summary was too long -- fall back.
         if outputTokens > budget {
-            var result = await fallback.compress(messages: messages, systemPrompt: systemPrompt, contextSize: contextSize, tokenizer: tokenizer)
-            result = CompressionResult(
-                messages: result.messages,
-                stats: CompressionStats(
-                    strategy: "anchored-fallback",
-                    originalNodeCount: result.stats.originalNodeCount,
-                    outputMessageCount: result.stats.outputMessageCount,
-                    estimatedTokens: result.stats.estimatedTokens,
-                    compressionRatio: result.stats.compressionRatio,
-                    keywordSurvivalRate: result.stats.keywordSurvivalRate
-                )
-            )
-            return result
+            return await fallbackResult(messages: messages, systemPrompt: systemPrompt, contextSize: contextSize, tokenizer: tokenizer)
         }
 
-        // 9. Return the anchored result.
+        // 10. Return the anchored result.
         return CompressionResult(
             messages: outputMessages,
             stats: CompressionStats(
@@ -183,12 +168,37 @@ public final class AnchoredCompressor: ContextCompressor, @unchecked Sendable {
         )
     }
 
+    // MARK: - Fallback
+
+    private func fallbackResult(
+        messages: [CompressibleMessage],
+        systemPrompt: String?,
+        contextSize: Int,
+        tokenizer: TokenizerProvider?
+    ) async -> CompressionResult {
+        let result = await fallback.compress(
+            messages: messages, systemPrompt: systemPrompt,
+            contextSize: contextSize, tokenizer: tokenizer
+        )
+        return CompressionResult(
+            messages: result.messages,
+            stats: CompressionStats(
+                strategy: "anchored-fallback",
+                originalNodeCount: result.stats.originalNodeCount,
+                outputMessageCount: result.stats.outputMessageCount,
+                estimatedTokens: result.stats.estimatedTokens,
+                compressionRatio: result.stats.compressionRatio,
+                keywordSurvivalRate: result.stats.keywordSurvivalRate
+            )
+        )
+    }
+
     // MARK: - Summary Parsing
 
     /// Extracts structured fields from the summary response and reassembles them.
     /// Falls back to a trimmed raw response if fewer than 2 fields are found.
     private func parseSummaryResponse(_ response: String) -> String {
-        let pattern = "^(CHARACTERS|LOCATION|PLOT THREADS|LAST EVENT|TONE):\\s*(.+)$"
+        let pattern = "^([A-Z][A-Z _]*[A-Z]):\\s*(.+)$"
         guard let regex = try? NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines, .caseInsensitive]) else {
             let trimmed = response.trimmingCharacters(in: .whitespacesAndNewlines)
             return trimmed.isEmpty ? "[Summary unavailable]" : String(trimmed.prefix(400))

--- a/Sources/BaseChatCore/Services/Compression/CompressionOrchestrator.swift
+++ b/Sources/BaseChatCore/Services/Compression/CompressionOrchestrator.swift
@@ -42,10 +42,12 @@ public final class CompressionOrchestrator {
         let responseBuffer = 512
         let tuples = extractive.messageTuples(from: messages)
         let tokens = extractive.totalTokens(of: tuples, tokenizer: tokenizer)
+        let systemTokens = systemPrompt.map { ContextWindowManager.estimateTokenCount($0, tokenizer: tokenizer) } ?? 0
+        let totalTokens = tokens + systemTokens
         let usableContext = contextSize - responseBuffer
         guard usableContext > 0 else { return false }
 
-        let utilization = Double(tokens) / Double(usableContext)
+        let utilization = Double(totalTokens) / Double(usableContext)
         return utilization >= compressionThreshold(for: contextSize)
     }
 

--- a/Sources/BaseChatCore/Services/Compression/ExtractiveCompressor.swift
+++ b/Sources/BaseChatCore/Services/Compression/ExtractiveCompressor.swift
@@ -153,13 +153,17 @@ public final class ExtractiveCompressor: ContextCompressor, @unchecked Sendable 
         candidates.sort { $0.score > $1.score }
 
         // --- Step 3: Greedy selection within candidate budget ---
+        // Skip candidate selection entirely if pinned/tail messages already exceed budget.
         var selectedIndices = Set<Int>()
         var candidateTokensUsed = 0
 
-        for candidate in candidates {
-            if candidateTokensUsed + candidate.tokens <= candidateBudget {
-                selectedIndices.insert(candidate.index)
-                candidateTokensUsed += candidate.tokens
+        if tailTokensUsed <= budget {
+            let effectiveCandidateBudget = min(candidateBudget, budget - tailTokensUsed)
+            for candidate in candidates {
+                if candidateTokensUsed + candidate.tokens <= effectiveCandidateBudget {
+                    selectedIndices.insert(candidate.index)
+                    candidateTokensUsed += candidate.tokens
+                }
             }
         }
 

--- a/Tests/BaseChatCoreTests/CompressionP0AnchoredFallbackTests.swift
+++ b/Tests/BaseChatCoreTests/CompressionP0AnchoredFallbackTests.swift
@@ -5,7 +5,7 @@ import BaseChatTestSupport
 final class CompressionP0AnchoredFallbackTests: XCTestCase {
     private let tokenizer = CharTokenizer()
 
-    func test_emptyOrWhitespaceSummary_usesStableSummaryUnavailableBehavior() async {
+    func test_emptyOrWhitespaceSummary_fallsBackToExtractive() async {
         let compressor = AnchoredCompressor()
         compressor.generateFn = { _ in " \n\t  " }
 
@@ -17,14 +17,47 @@ final class CompressionP0AnchoredFallbackTests: XCTestCase {
             tokenizer: tokenizer
         )
 
-        XCTAssertEqual(result.stats.strategy, "anchored",
-                       "Current behavior for empty summary text is anchored with a placeholder summary.")
-        XCTAssertEqual(result.messages.first?.role, "system")
-        XCTAssertEqual(result.messages.first?.content, "[Summary unavailable]")
+        XCTAssertEqual(result.stats.strategy, "anchored-fallback",
+                       "Empty summary should fall back to extractive rather than injecting a placeholder.")
+        XCTAssertEqual(result.messages.first?.role, "user",
+                       "Extractive fallback does not inject a system summary message.")
 
         let budget = compressor.historyBudget(contextSize: 700, systemPrompt: nil, tokenizer: tokenizer)
         XCTAssertLessThanOrEqual(totalTokens(in: result.messages), budget,
-                                 "Anchored output must respect the history budget.")
+                                 "Fallback output must respect the history budget.")
+    }
+
+    func test_customFieldNames_parsedCorrectly() async {
+        let compressor = AnchoredCompressor()
+        // Return summary with underscored and spaced field names (Fireside-style)
+        compressor.generateFn = { _ in """
+            CHARACTERS: Alice, Bob
+            LOCATION: Forest clearing
+            PLOT_THREADS: escape plan; hidden treasure
+            LAST_EVENT: Alice found the map
+            TONE: tense
+            """
+        }
+
+        // 10 messages * 80 chars = 800 total. contextSize=1000, budget=488.
+        // Compression triggers (800 > 488). Summary (~100 chars) + tail (~244 chars) fits in budget.
+        let messages = makeMessages(count: 10, contentLength: 80)
+        let result = await compressor.compress(
+            messages: messages,
+            systemPrompt: nil,
+            contextSize: 1000,
+            tokenizer: tokenizer
+        )
+
+        XCTAssertEqual(result.stats.strategy, "anchored")
+        guard let summary = result.messages.first, summary.role == "system" else {
+            XCTFail("Expected system summary as first message")
+            return
+        }
+        // All 5 fields should be parsed, including underscored variants
+        XCTAssertTrue(summary.content.contains("PLOT_THREADS"), "Underscored field PLOT_THREADS should be preserved")
+        XCTAssertTrue(summary.content.contains("LAST_EVENT"), "Underscored field LAST_EVENT should be preserved")
+        XCTAssertTrue(summary.content.contains("CHARACTERS"), "Standard field should be preserved")
     }
 
     func test_extremelyLongSummary_fallsBackAndRespectsBudget() async {

--- a/Tests/BaseChatCoreTests/CompressionP1CoreBehaviorTests.swift
+++ b/Tests/BaseChatCoreTests/CompressionP1CoreBehaviorTests.swift
@@ -89,7 +89,7 @@ final class CompressionP1CoreBehaviorTests: XCTestCase {
         XCTAssertEqual(result.messages.first?.role, "system")
     }
 
-    func test_anchoredCompressor_cancelledGenerateFunction_fallsBackDeterministically() async {
+    func test_anchoredCompressor_cancelledGenerateFunction_returnsMinimalResult() async {
         let compressor = AnchoredCompressor()
         compressor.generateFn = { _ in
             throw CancellationError()
@@ -98,7 +98,8 @@ final class CompressionP1CoreBehaviorTests: XCTestCase {
         let messages = makeAlternatingMessages(count: 40, contentLength: 100)
         let result = await compressor.compress(messages: messages, systemPrompt: nil, contextSize: 900, tokenizer: tokenizer)
 
-        XCTAssertEqual(result.stats.strategy, "anchored-fallback")
+        // Cancellation returns the tail directly instead of starting a new fallback pass.
+        XCTAssertEqual(result.stats.strategy, "anchored-cancelled")
         XCTAssertTrue(result.messages.contains(where: { $0.content == messages.last?.content }))
     }
 


### PR DESCRIPTION
## Summary

- **parseSummaryResponse field-name-agnostic regex**: The hardcoded `CHARACTERS|LOCATION|PLOT THREADS|LAST EVENT|TONE` pattern rejected custom field names (e.g. `PLOT_THREADS`) from downstream `summaryTemplate` overrides. Now matches any `^([A-Z][A-Z _]*[A-Z]):` label.
- **shouldCompress includes system prompt tokens**: Utilization calculation ignored system prompt size, causing compression to trigger too late when large system prompts consumed significant context.
- **ExtractiveCompressor respects budget when pinned messages are large**: Pinned messages could push output over budget because candidate selection ran unconditionally. Now skips candidate selection when tail tokens already exceed budget.
- **Task.checkCancellation() before generateFn**: The 1-5 second inference call had no cancellation check, so user cancellation was delayed until after the LLM returned.
- **Empty summary falls back to extractive**: An empty generateFn response injected `[Summary unavailable]` as a system message, wasting tokens. Now routes to extractive fallback instead.
- **Extracted fallback helper**: Three identical copy-pasted blocks calling `fallback.compress()` and rewrapping with `"anchored-fallback"` strategy consolidated into `fallbackResult()`.

## Test plan
- [x] `swift build` compiles cleanly
- [x] `swift test --filter BaseChatCoreTests` — all 83 tests pass
- [ ] Verify custom `summaryTemplate` field names parse correctly (manual or new test)
- [ ] Verify compression triggers earlier with large system prompts
- [ ] Verify cancellation during anchored compression returns promptly

🤖 Generated with [Claude Code](https://claude.com/claude-code)