### PR TITLE
refactor: harden compression system configuration and defaults

### DIFF
--- a/Sources/BaseChatCore/Services/Compression/AnchoredCompressor.swift
+++ b/Sources/BaseChatCore/Services/Compression/AnchoredCompressor.swift
@@ -7,32 +7,41 @@ public final class AnchoredCompressor: ContextCompressor, @unchecked Sendable {
     public let strategyName = "anchored"
 
     /// Fraction of the history budget reserved for the verbatim recent tail.
-    public var tailBudgetFraction: Double = 0.50
+    public let tailBudgetFraction: Double
 
     /// Injected by the caller; performs a single-turn inference call for summarization.
+    /// Must be set before the first call to `compress()`. Not safe to mutate while
+    /// `compress()` is in flight.
     public var generateFn: (@Sendable (String) async throws -> String)?
 
     private let fallback = ExtractiveCompressor()
 
     // MARK: - Summary Prompt Template
 
-    /// The prompt template used to summarize old messages.
-    /// Callers can replace this with a domain-specific prompt.
-    /// The placeholder `{old_nodes_text}` is replaced with the concatenated message content.
-    public var summaryTemplate: String = """
-        Read the story excerpt and fill in these fields. Be concise. Use only what is in the text.
+    public static let defaultSummaryTemplate: String = """
+        Summarize the conversation so far. Be concise. Use only what is in the text.
 
-        CHARACTERS: [names of characters present or mentioned, comma-separated]
-        LOCATION: [current setting]
-        PLOT THREADS: [up to 3 unresolved threads, semicolon-separated]
-        LAST EVENT: [most recent significant event, one sentence]
-        TONE: [emotional mood, 1-2 words]
+        TOPIC: [main subject of the conversation, brief]
+        KEY POINTS: [up to 3 important points, semicolon-separated]
+        OPEN QUESTIONS: [unresolved items or pending decisions, if any]
+        LAST DISCUSSED: [most recent topic or conclusion, one sentence]
 
-        Story excerpt:
+        Conversation:
         {old_nodes_text}
         """
 
-    public init() {}
+    /// The prompt template used to summarize old messages.
+    /// Pass a domain-specific prompt at init time to override.
+    /// The placeholder `{old_nodes_text}` is replaced with the concatenated message content.
+    public let summaryTemplate: String
+
+    public init(
+        tailBudgetFraction: Double = 0.50,
+        summaryTemplate: String? = nil
+    ) {
+        self.tailBudgetFraction = tailBudgetFraction
+        self.summaryTemplate = summaryTemplate ?? Self.defaultSummaryTemplate
+    }
 
     // MARK: - ContextCompressor
 
@@ -82,7 +91,9 @@ public final class AnchoredCompressor: ContextCompressor, @unchecked Sendable {
 
         // Ensure at least the newest message is in the tail.
         if tailIndices.isEmpty, !messages.isEmpty {
-            tailIndices.insert(messages.count - 1)
+            let newestIndex = messages.count - 1
+            tailIndices.insert(newestIndex)
+            tailTokens += ContextWindowManager.estimateTokenCount(messages[newestIndex].content, tokenizer: tokenizer)
         }
 
         let tailMessages = messages.indices.filter { tailIndices.contains($0) }.map { messages[$0] }
@@ -149,8 +160,32 @@ public final class AnchoredCompressor: ContextCompressor, @unchecked Sendable {
 
         let outputTokens = totalTokens(of: outputMessages, tokenizer: tokenizer)
 
-        // 9. If summary + tail exceeds budget, the summary was too long -- fall back.
+        // 9. If summary + tail exceeds budget, try truncating the summary first.
         if outputTokens > budget {
+            let summaryBudget = budget - tailTokens
+            if summaryBudget > 0 {
+                let truncated = truncateToFit(parsedSummary, budget: summaryBudget, tokenizer: tokenizer)
+                guard !truncated.isEmpty else {
+                    return await fallbackResult(messages: messages, systemPrompt: systemPrompt, contextSize: contextSize, tokenizer: tokenizer)
+                }
+                var truncatedOutput: [(role: String, content: String)] = [("system", truncated)]
+                truncatedOutput.append(contentsOf: messageTuples(from: tailMessages))
+                let truncatedTokens = totalTokens(of: truncatedOutput, tokenizer: tokenizer)
+                if truncatedTokens <= budget {
+                    return CompressionResult(
+                        messages: truncatedOutput,
+                        stats: CompressionStats(
+                            strategy: strategyName,
+                            originalNodeCount: messages.count,
+                            outputMessageCount: truncatedOutput.count,
+                            estimatedTokens: truncatedTokens,
+                            compressionRatio: Double(originalTokens) / Double(max(truncatedTokens, 1)),
+                            keywordSurvivalRate: nil
+                        )
+                    )
+                }
+            }
+
             return await fallbackResult(messages: messages, systemPrompt: systemPrompt, contextSize: contextSize, tokenizer: tokenizer)
         }
 
@@ -197,6 +232,9 @@ public final class AnchoredCompressor: ContextCompressor, @unchecked Sendable {
 
     /// Extracts structured fields from the summary response and reassembles them.
     /// Falls back to a trimmed raw response if fewer than 2 fields are found.
+    /// Recognises both the domain-neutral fields (TOPIC, KEY POINTS, OPEN QUESTIONS,
+    /// LAST DISCUSSED) and legacy story fields (CHARACTERS, LOCATION, etc.) so that
+    /// custom templates work transparently.
     private func parseSummaryResponse(_ response: String) -> String {
         let pattern = "^([A-Z][A-Z _]*[A-Z]):\\s*(.+)$"
         guard let regex = try? NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines, .caseInsensitive]) else {
@@ -226,5 +264,21 @@ public final class AnchoredCompressor: ContextCompressor, @unchecked Sendable {
             return "[Summary unavailable]"
         }
         return String(trimmed.prefix(400))
+    }
+
+    /// Truncates text word-by-word from the end until it fits within the token budget.
+    private func truncateToFit(_ text: String, budget: Int, tokenizer: TokenizerProvider?) -> String {
+        if ContextWindowManager.estimateTokenCount(text, tokenizer: tokenizer) <= budget {
+            return text
+        }
+        var words = text.split(separator: " ", omittingEmptySubsequences: true)
+        while !words.isEmpty {
+            words.removeLast()
+            let candidate = words.joined(separator: " ")
+            if ContextWindowManager.estimateTokenCount(candidate, tokenizer: tokenizer) <= budget {
+                return candidate
+            }
+        }
+        return ""
     }
 }

--- a/Sources/BaseChatCore/Services/Compression/CompressionOrchestrator.swift
+++ b/Sources/BaseChatCore/Services/Compression/CompressionOrchestrator.swift
@@ -12,10 +12,16 @@ public final class CompressionOrchestrator {
     /// The user-selected compression mode. Defaults to automatic.
     public var mode: CompressionMode = .automatic
 
-    public let extractive = ExtractiveCompressor()
-    public let anchored = AnchoredCompressor()
+    public let extractive: ExtractiveCompressor
+    public let anchored: AnchoredCompressor
 
-    public init() {}
+    public init(
+        extractive: ExtractiveCompressor = ExtractiveCompressor(),
+        anchored: AnchoredCompressor = AnchoredCompressor()
+    ) {
+        self.extractive = extractive
+        self.anchored = anchored
+    }
 
     // MARK: - Threshold
 
@@ -87,7 +93,7 @@ public final class CompressionOrchestrator {
             }
             return anchored.generateFn != nil ? anchored : extractive
 
-        case .balanced, .quality:
+        case .balanced:
             return anchored.generateFn != nil ? anchored : extractive
         }
     }

--- a/Sources/BaseChatCore/Services/Compression/ContextCompressor.swift
+++ b/Sources/BaseChatCore/Services/Compression/ContextCompressor.swift
@@ -5,7 +5,6 @@ public enum CompressionMode: String, CaseIterable, Identifiable {
     case automatic = "Automatic"
     case off = "Off"
     case balanced = "Balanced"    // AnchoredCompressor
-    case quality = "Best Quality" // AnchoredCompressor with richer prompt (future: SceneCompressor)
 
     public var id: String { rawValue }
 }

--- a/Sources/BaseChatCore/Services/Compression/ExtractiveCompressor.swift
+++ b/Sources/BaseChatCore/Services/Compression/ExtractiveCompressor.swift
@@ -10,18 +10,28 @@ public final class ExtractiveCompressor: ContextCompressor, @unchecked Sendable 
     public let strategyName = "extractive"
 
     /// Fraction of the history budget reserved for the verbatim tail (newest messages).
-    public var tailBudgetFraction: Double = 0.40
+    public let tailBudgetFraction: Double
 
     /// Weight for how recently a message appears in the conversation.
-    public var recencyWeight: Double = 0.5
+    public let recencyWeight: Double
 
     /// Weight for message content length (longer messages carry more narrative).
-    public var lengthWeight: Double = 0.3
+    public let lengthWeight: Double
 
     /// Weight for capitalized-word density (proxy for proper noun / keyword richness).
-    public var keywordDensityWeight: Double = 0.2
+    public let keywordDensityWeight: Double
 
-    public init() {}
+    public init(
+        tailBudgetFraction: Double = 0.40,
+        recencyWeight: Double = 0.5,
+        lengthWeight: Double = 0.3,
+        keywordDensityWeight: Double = 0.2
+    ) {
+        self.tailBudgetFraction = tailBudgetFraction
+        self.recencyWeight = recencyWeight
+        self.lengthWeight = lengthWeight
+        self.keywordDensityWeight = keywordDensityWeight
+    }
 
     // MARK: - ContextCompressor
 

--- a/Tests/BaseChatCoreTests/CompressionP0AnchoredFallbackTests.swift
+++ b/Tests/BaseChatCoreTests/CompressionP0AnchoredFallbackTests.swift
@@ -60,9 +60,12 @@ final class CompressionP0AnchoredFallbackTests: XCTestCase {
         XCTAssertTrue(summary.content.contains("CHARACTERS"), "Standard field should be preserved")
     }
 
-    func test_extremelyLongSummary_fallsBackAndRespectsBudget() async {
+    func test_extremelyLongSummary_truncatesThenFallsBackIfNeeded() async {
         let compressor = AnchoredCompressor()
-        compressor.generateFn = { _ in String(repeating: "L", count: 5_000) }
+        // Multi-word oversized summary so truncation can partially salvage it.
+        compressor.generateFn = { _ in
+            (0..<500).map { "word\($0)" }.joined(separator: " ")
+        }
 
         let messages = makeMessages(count: 10, contentLength: 100)
         let contextSize = 800
@@ -73,12 +76,39 @@ final class CompressionP0AnchoredFallbackTests: XCTestCase {
             tokenizer: tokenizer
         )
 
-        XCTAssertEqual(result.stats.strategy, "anchored-fallback",
-                       "Oversized summary + tail should trigger anchored fallback.")
+        // Truncation should salvage the summary by trimming words to fit budget.
+        XCTAssertEqual(result.stats.strategy, "anchored",
+                       "Oversized summary should be truncated to fit, not immediately fall back.")
 
         let budget = compressor.historyBudget(contextSize: contextSize, systemPrompt: nil, tokenizer: tokenizer)
         XCTAssertLessThanOrEqual(totalTokens(in: result.messages), budget,
-                                 "Fallback output must remain within history budget.")
+                                 "Truncated output must remain within history budget.")
+    }
+
+    func test_extremelyLongSummary_tailAloneExceedsBudget_fallsBack() async {
+        let compressor = AnchoredCompressor()
+        compressor.generateFn = { _ in String(repeating: "L", count: 5_000) }
+
+        // Tail alone exceeds budget: newest message is 400 chars, budget = 800-512 = 288.
+        // tailTokens (400) > budget (288), so summaryBudget <= 0 and truncation can't help.
+        let messages = makeMessages(count: 10, contentLength: 400)
+        let contextSize = 800
+        let result = await compressor.compress(
+            messages: messages,
+            systemPrompt: nil,
+            contextSize: contextSize,
+            tokenizer: tokenizer
+        )
+
+        // With no room for summary, falls back to extractive.
+        XCTAssertEqual(result.stats.strategy, "anchored-fallback",
+                       "When tail alone leaves no summary budget, should fall back to extractive.")
+
+        // Note: when even the newest message exceeds the history budget, the compressor
+        // still preserves it (never evicts the entire conversation). The budget is a target,
+        // not a hard cap — the newest message invariant takes priority.
+        XCTAssertEqual(result.stats.outputMessageCount, 1,
+                       "Fallback should preserve at minimum the newest message.")
     }
 }
 

--- a/Tests/BaseChatCoreTests/CompressionP0OrchestratorEdgeCaseTests.swift
+++ b/Tests/BaseChatCoreTests/CompressionP0OrchestratorEdgeCaseTests.swift
@@ -63,11 +63,11 @@ final class CompressionP0OrchestratorEdgeCaseTests: XCTestCase {
         let gate = AsyncGate()
         let generationStarted = expectation(description: "Anchored generation started")
 
-        orchestrator.mode = .quality
+        orchestrator.mode = .balanced
         orchestrator.anchored.generateFn = { _ in
             generationStarted.fulfill()
             await gate.wait()
-            return "CHARACTERS: Ava\nLOCATION: Station"
+            return "TOPIC: Ava\nKEY POINTS: Station"
         }
 
         // Ensure history exceeds budget so anchored summarization is invoked.

--- a/Tests/BaseChatCoreTests/CompressionP1CoreBehaviorTests.swift
+++ b/Tests/BaseChatCoreTests/CompressionP1CoreBehaviorTests.swift
@@ -19,8 +19,7 @@ final class CompressionP1CoreBehaviorTests: XCTestCase {
     }
 
     func test_extractiveCompressor_tailBudgetFractionZero_stillKeepsNewestMessage() async {
-        let compressor = ExtractiveCompressor()
-        compressor.tailBudgetFraction = 0.0
+        let compressor = ExtractiveCompressor(tailBudgetFraction: 0.0)
 
         let messages = makeAlternatingMessages(count: 12, contentLength: 90)
         let result = await compressor.compress(messages: messages, systemPrompt: nil, contextSize: 700, tokenizer: tokenizer)
@@ -30,8 +29,7 @@ final class CompressionP1CoreBehaviorTests: XCTestCase {
     }
 
     func test_extractiveCompressor_tailBudgetFractionOne_prefersRecentTail() async {
-        let compressor = ExtractiveCompressor()
-        compressor.tailBudgetFraction = 1.0
+        let compressor = ExtractiveCompressor(tailBudgetFraction: 1.0)
 
         let messages = makeAlternatingMessages(count: 20, contentLength: 80)
         let result = await compressor.compress(messages: messages, systemPrompt: nil, contextSize: 900, tokenizer: tokenizer)

--- a/Tests/BaseChatCoreTests/CompressionTests.swift
+++ b/Tests/BaseChatCoreTests/CompressionTests.swift
@@ -41,13 +41,8 @@ final class CompressionModeTests: XCTestCase {
         XCTAssertEqual(CompressionMode.balanced.rawValue, "Balanced")
     }
 
-    func test_rawValue_roundtrip_quality() {
-        XCTAssertEqual(CompressionMode(rawValue: "Best Quality"), .quality)
-        XCTAssertEqual(CompressionMode.quality.rawValue, "Best Quality")
-    }
-
     func test_caseIterable_coversAllExpectedCases() {
-        let expected: Set<CompressionMode> = [.automatic, .off, .balanced, .quality]
+        let expected: Set<CompressionMode> = [.automatic, .off, .balanced]
         let all = Set(CompressionMode.allCases)
         XCTAssertEqual(all, expected)
     }
@@ -264,9 +259,8 @@ final class AnchoredCompressorTests: XCTestCase {
     }
 
     func test_summaryTemplate_customValueUsedInPrompt() async {
-        let compressor = AnchoredCompressor()
         let customTemplate = "Summarize this: {old_nodes_text}"
-        compressor.summaryTemplate = customTemplate
+        let compressor = AnchoredCompressor(summaryTemplate: customTemplate)
 
         final class PromptBox: @unchecked Sendable {
             private let lock = NSLock()
@@ -390,10 +384,10 @@ final class CompressionOrchestratorTests: XCTestCase {
                        "Balanced mode routes to ExtractiveCompressor (strategy 'extractive'), not AnchoredCompressor")
     }
 
-    func test_compress_withQualityMode_routesToAnchoredWhenGenerateFnSet() async {
+    func test_compress_withBalancedMode_routesToAnchoredWhenGenerateFnSet() async {
         let orchestrator = CompressionOrchestrator()
-        orchestrator.mode = .quality
-        orchestrator.anchored.generateFn = { _ in "CHARACTERS: X\nLOCATION: Y" }
+        orchestrator.mode = .balanced
+        orchestrator.anchored.generateFn = { _ in "TOPIC: X\nKEY POINTS: Y" }
 
         let messages = makeMessages(count: 10, contentLength: 100)
         let result = await orchestrator.compress(
@@ -404,7 +398,7 @@ final class CompressionOrchestratorTests: XCTestCase {
         )
 
         XCTAssertEqual(result.stats.strategy, "anchored",
-                       "Quality mode with generateFn should route to AnchoredCompressor")
+                       "Balanced mode with generateFn should route to AnchoredCompressor")
     }
 
     func test_compress_withAutomaticMode_smallContext_routesToExtractiveCompressor() async {

--- a/Tests/BaseChatUITests/CompressionIntegrationTests.swift
+++ b/Tests/BaseChatUITests/CompressionIntegrationTests.swift
@@ -274,10 +274,6 @@ final class CompressionIntegrationTests: XCTestCase {
     func test_compressionMode_didSet_syncsToOrchestrator() {
         createSession()
 
-        vm.compressionMode = .quality
-        XCTAssertEqual(vm.compressionOrchestrator.mode, .quality,
-                       "Setting compressionMode to .quality should sync to orchestrator.mode")
-
         vm.compressionMode = .balanced
         XCTAssertEqual(vm.compressionOrchestrator.mode, .balanced,
                        "Setting compressionMode to .balanced should sync to orchestrator.mode")

--- a/Tests/BaseChatUITests/CompressionSettingsViewModelTests.swift
+++ b/Tests/BaseChatUITests/CompressionSettingsViewModelTests.swift
@@ -67,11 +67,10 @@ final class CompressionSettingsViewModelTests: XCTestCase {
     // MARK: - test_compressionMode_allCasesAreAvailable
 
     func test_compressionMode_allCasesAreAvailable() {
-        XCTAssertEqual(CompressionMode.allCases.count, 4,
-                       "CompressionMode should have exactly 4 cases")
+        XCTAssertEqual(CompressionMode.allCases.count, 3,
+                       "CompressionMode should have exactly 3 cases")
         XCTAssertTrue(CompressionMode.allCases.contains(.automatic))
         XCTAssertTrue(CompressionMode.allCases.contains(.balanced))
-        XCTAssertTrue(CompressionMode.allCases.contains(.quality))
         XCTAssertTrue(CompressionMode.allCases.contains(.off))
     }
 
@@ -80,13 +79,11 @@ final class CompressionSettingsViewModelTests: XCTestCase {
     func test_compressionMode_displayNameRoundTrip() {
         XCTAssertEqual(CompressionMode.automatic.rawValue, "Automatic")
         XCTAssertEqual(CompressionMode.balanced.rawValue, "Balanced")
-        XCTAssertEqual(CompressionMode.quality.rawValue, "Best Quality")
         XCTAssertEqual(CompressionMode.off.rawValue, "Off")
 
         // Verify rawValue round-trips back to the correct case.
         XCTAssertEqual(CompressionMode(rawValue: "Automatic"), .automatic)
         XCTAssertEqual(CompressionMode(rawValue: "Balanced"), .balanced)
-        XCTAssertEqual(CompressionMode(rawValue: "Best Quality"), .quality)
         XCTAssertEqual(CompressionMode(rawValue: "Off"), .off)
     }
 }


### PR DESCRIPTION
## Summary
- Make `AnchoredCompressor` and `ExtractiveCompressor` config properties immutable (`let`) — set via init parameters with current defaults. `generateFn` remains `var` since it's wired after init by ChatViewModel.
- `CompressionOrchestrator` now accepts pre-configured compressor instances in its init, so downstream consumers (e.g. Fireside) can inject custom templates without mutating after construction.
- Replace the story-specific default summary template (CHARACTERS/LOCATION/PLOT THREADS) with a domain-neutral one (TOPIC/KEY POINTS/OPEN QUESTIONS/LAST DISCUSSED). The parser recognises both field sets for backward compatibility.
- Before falling back to extractive compression on oversized summaries, attempt word-by-word truncation to salvage the anchored result.
- Remove `CompressionMode.quality` which was identical to `.balanced` with a "future: SceneCompressor" comment — dead code in unreleased API.

## Test plan
- [x] `swift build` compiles cleanly
- [x] `swift test --filter BaseChatCoreTests` — 83 tests pass
- [x] `swift test --filter BaseChatUITests` — 292 tests pass
- [ ] Verify CI passes (BaseChatCoreTests + BaseChatUITests + BaseChatBackendsTests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)