### PR TITLE
ci: add changelog prose-style lint for release PRs

### DIFF
--- a/.github/workflows/changelog-lint.yml
+++ b/.github/workflows/changelog-lint.yml
@@ -1,0 +1,65 @@
+name: Changelog Lint
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "CHANGELOG.md"
+      - ".release-please-manifest.json"
+      - "version.txt"
+
+concurrency:
+  group: changelog-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changelog-lint:
+    # Only run on Release Please PRs
+    if: startsWith(github.head_ref, 'release-please--branches--')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check changelog entries are prose-style
+        run: |
+          set -euo pipefail
+
+          # Extract the newest version section from CHANGELOG.md
+          # (everything between the first ## [x.y.z] and the second ## [x.y.z])
+          newest_section=$(awk '/^## \[/{n++} n==1' CHANGELOG.md)
+
+          if [ -z "$newest_section" ]; then
+            echo "::error::Could not find a version section in CHANGELOG.md"
+            exit 1
+          fi
+
+          echo "=== Newest changelog section ==="
+          echo "$newest_section"
+          echo "================================"
+
+          # Check for auto-generated bullet entries (Release Please format):
+          # Lines starting with "* " followed by lowercase text
+          # These indicate the entry hasn't been rewritten in prose style
+          if echo "$newest_section" | grep -qE '^\* [a-z]'; then
+            echo ""
+            echo "::error::CHANGELOG.md contains auto-generated bullet entries."
+            echo "::error::Release notes must be rewritten in prose style before merging."
+            echo "::error::"
+            echo "::error::Expected format:  **Bold title** — Description of the change..."
+            echo "::error::Found format:     * auto-generated commit message"
+            echo ""
+            echo "Auto-generated entries found:"
+            echo "$newest_section" | grep -E '^\* [a-z]'
+            exit 1
+          fi
+
+          # Verify at least one prose entry exists (bold title followed by em dash)
+          if ! echo "$newest_section" | grep -qE '^\*\*[^*]+\*\* —'; then
+            echo ""
+            echo "::error::No prose-style entries found in the newest changelog section."
+            echo "::error::Each entry should start with: **Bold title** — Description..."
+            exit 1
+          fi
+
+          echo ""
+          echo "✓ Changelog entries are in prose style"


### PR DESCRIPTION
## Summary
- New workflow that runs on release-please PRs when CHANGELOG.md changes
- Fails if entries are still in auto-generated bullet format (`* lowercase...`)
- Requires prose-style entries (`**Bold title** — description...`)
- Runs on ubuntu-latest (1x billing), only on release PRs

## How it works
1. Extracts the newest version section from CHANGELOG.md
2. Checks for auto-generated `* bullet` entries (fail if found)
3. Verifies at least one `**prose** —` entry exists (fail if none)

## Next step
Add `changelog-lint` as a required check in branch protection to block unformatted releases.

## Test plan
- [x] Tested lint logic against current (prose) changelog — passes
- [x] Tested against simulated auto-generated entries — correctly fails
- [x] Only triggers on release-please branches (conditional `if`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)