### PR TITLE
docs: add DocC catalogs for BaseChatCore and BaseChatUI

### DIFF
--- a/Sources/BaseChatCore/BaseChatCore.docc/Articles/GettingStarted.md
+++ b/Sources/BaseChatCore/BaseChatCore.docc/Articles/GettingStarted.md
@@ -1,0 +1,128 @@
+# Getting Started with BaseChatCore
+
+Configure BaseChatKit and wire up your first inference-backed chat session.
+
+## Overview
+
+This article walks you through the three steps needed to get BaseChatKit running in a new app:
+
+1. Configure the framework at startup
+2. Register backends
+3. Create an `InferenceService` and begin generating
+
+### Step 1 — Configure the framework
+
+Set ``BaseChatConfiguration/shared`` once, as early as possible in your app's lifecycle (typically in your `@main` struct or `AppDelegate`):
+
+```swift
+import BaseChatCore
+import BaseChatBackends
+
+@main
+struct MyApp: App {
+    init() {
+        BaseChatConfiguration.shared = BaseChatConfiguration(
+            appName: "MyApp",
+            bundleIdentifier: Bundle.main.bundleIdentifier ?? "com.example.myapp"
+        )
+    }
+
+    var body: some Scene { ... }
+}
+```
+
+Use ``BaseChatConfiguration/Features`` to disable UI features that don't apply to your deployment. For example, an offline-only app might disable cloud API management:
+
+```swift
+BaseChatConfiguration.shared = BaseChatConfiguration(
+    appName: "MyApp",
+    bundleIdentifier: "com.example.myapp",
+    features: .init(
+        showCloudAPIManagement: false,
+        showServerDiscovery: false
+    )
+)
+```
+
+### Step 2 — Register backends
+
+Backends live in `BaseChatBackends` and are registered against `InferenceService` via factory closures. This keeps `BaseChatCore` free of any dependency on MLX, llama.cpp, or Foundation Models — you only pull in the backends you need.
+
+```swift
+import BaseChatBackends
+
+// Register all available backends in one call:
+DefaultBackends.registerAll(with: inferenceService)
+
+// Or register individually for more control:
+inferenceService.registerBackendFactory { modelType in
+    switch modelType {
+    case .gguf: return LlamaBackend()
+    case .mlx:  return MLXBackend()
+    default:    return nil
+    }
+}
+
+inferenceService.registerCloudBackendFactory { provider in
+    switch provider {
+    case .claude: return ClaudeBackend()
+    case .openAI: return OpenAIBackend()
+    default:      return OpenAICompatibleBackend(provider: provider)
+    }
+}
+```
+
+### Step 3 — Load a model and generate
+
+```swift
+let service = InferenceService()
+
+// Load a GGUF model from disk
+let modelURL = URL.documentsDirectory
+    .appending(path: "Models/llama-3.2-3b-instruct.Q4_K_M.gguf")
+try await service.loadModel(from: modelURL, type: .gguf, contextSize: 4096)
+
+// Generate a response
+let stream = try service.generate(
+    messages: [ChatMessageRecord(role: .user, content: "Hello!")],
+    config: GenerationConfig(temperature: 0.7)
+)
+
+for await event in stream.events {
+    if case let .token(text) = event {
+        print(text, terminator: "")
+    }
+}
+```
+
+## Sharing InferenceService across components
+
+Create `InferenceService` once at the app level and inject it wherever you need generation. Do not create multiple instances — each instance manages its own backend lifecycle and they will step on each other.
+
+```swift
+// App level
+let inference = InferenceService()
+let chatVM = ChatViewModel(inferenceService: inference)
+let storyStore = StoryStore(inferenceService: inference)  // your own type
+```
+
+See ``ChatViewModel`` in `BaseChatUI` for the primary consumer.
+
+## Persistence
+
+BaseChatKit persists sessions and messages through ``ChatPersistenceProvider``. The default implementation uses SwiftData. Create a ``ModelContainerFactory`` container and wire it to ``SwiftDataPersistenceProvider``:
+
+```swift
+let container = try ModelContainerFactory.makeContainer()
+let persistence = SwiftDataPersistenceProvider(container: container)
+chatViewModel.configure(persistence: persistence)
+```
+
+Use ``ModelContainerFactory/makeInMemoryContainer()`` in tests and SwiftUI previews.
+
+## Next Steps
+
+- See ``BaseChatConfiguration/Features`` for the full list of feature flags
+- See ``GenerationConfig`` for sampling parameters (temperature, top-p, repeat penalty)
+- See ``PromptTemplate`` for the supported chat formatting templates
+- See ``ChatPersistenceProvider`` to implement a custom storage backend

--- a/Sources/BaseChatCore/BaseChatCore.docc/Articles/GettingStarted.md
+++ b/Sources/BaseChatCore/BaseChatCore.docc/Articles/GettingStarted.md
@@ -52,7 +52,7 @@ Backends live in `BaseChatBackends` and are registered against `InferenceService
 import BaseChatBackends
 
 // Register all available backends in one call:
-DefaultBackends.registerAll(with: inferenceService)
+DefaultBackends.register(with: inferenceService)
 
 // Or register individually for more control:
 inferenceService.registerBackendFactory { modelType in
@@ -80,15 +80,16 @@ let service = InferenceService()
 // Load a GGUF model from disk
 let modelURL = URL.documentsDirectory
     .appending(path: "Models/llama-3.2-3b-instruct.Q4_K_M.gguf")
-try await service.loadModel(from: modelURL, type: .gguf, contextSize: 4096)
+let model = ModelInfo(ggufURL: modelURL)!
+try await service.loadModel(from: model, contextSize: 4096)
 
 // Generate a response
 let stream = try service.generate(
-    messages: [ChatMessageRecord(role: .user, content: "Hello!")],
-    config: GenerationConfig(temperature: 0.7)
+    messages: [(role: "user", content: "Hello!")],
+    temperature: 0.7
 )
 
-for await event in stream.events {
+for try await event in stream.events {
     if case let .token(text) = event {
         print(text, terminator: "")
     }
@@ -114,7 +115,8 @@ BaseChatKit persists sessions and messages through ``ChatPersistenceProvider``. 
 
 ```swift
 let container = try ModelContainerFactory.makeContainer()
-let persistence = SwiftDataPersistenceProvider(container: container)
+let context = ModelContext(container)
+let persistence = SwiftDataPersistenceProvider(modelContext: context)
 chatViewModel.configure(persistence: persistence)
 ```
 

--- a/Sources/BaseChatCore/BaseChatCore.docc/BaseChatCore.md
+++ b/Sources/BaseChatCore/BaseChatCore.docc/BaseChatCore.md
@@ -1,0 +1,130 @@
+# ``BaseChatCore``
+
+Models, protocols, and services for building on-device and cloud-connected chat applications.
+
+## Overview
+
+BaseChatCore is the foundation layer of BaseChatKit. It defines the protocol surface that backends and UI targets both depend on, and provides production-ready services for inference orchestration, context management, compression, and persistence — with no dependency on MLX, llama.cpp, or any UI framework.
+
+The two key entry points are ``BaseChatConfiguration`` (set once at app startup) and ``InferenceService`` (coordinates all model loading and generation). Everything else — persistence, compression, context budgeting — is wired together by the service layer and exposed through SwiftData-backed models.
+
+### Architecture
+
+```
+App
+ ├── BaseChatConfiguration.shared   ← configure once at startup
+ ├── InferenceService               ← orchestrates all backends
+ │    ├── MLXBackend    (via BaseChatBackends)
+ │    ├── LlamaBackend  (via BaseChatBackends)
+ │    ├── FoundationBackend (via BaseChatBackends)
+ │    └── CloudBackends (Claude, OpenAI, Ollama, …)
+ └── ChatPersistenceProvider        ← SwiftData or custom storage
+```
+
+Backends are registered as factories so BaseChatCore stays free of any direct MLX, llama.cpp, or Foundation Models import. See <doc:GettingStarted> for the full wiring example.
+
+## Topics
+
+### Getting Started
+
+- <doc:GettingStarted>
+
+### Configuration
+
+- ``BaseChatConfiguration``
+
+### Inference
+
+- ``InferenceService``
+- ``InferenceBackend``
+- ``GenerationConfig``
+- ``GenerationStream``
+- ``BackendCapabilities``
+- ``GenerationParameter``
+- ``BackendActivityPhase``
+- ``GenerationEvent``
+
+### Models on Disk
+
+- ``ModelInfo``
+- ``ModelType``
+- ``ModelStorageService``
+- ``DownloadableModel``
+- ``DownloadableModelGroup``
+- ``DownloadState``
+- ``DownloadStatus``
+
+### Cloud & Remote
+
+- ``APIEndpoint``
+- ``APIProvider``
+- ``DiscoveredServer``
+- ``RemoteBackendConfig``
+- ``ServerDiscoveryService``
+- ``ServerType``
+
+### Chat Sessions & Persistence
+
+- ``ChatPersistenceProvider``
+- ``ChatSessionRecord``
+- ``ChatMessageRecord``
+- ``ChatPersistenceError``
+- ``SwiftDataPersistenceProvider``
+- ``ModelContainerFactory``
+
+### Messages & Content
+
+- ``ChatMessage``
+- ``ChatSession``
+- ``MessageRole``
+- ``MessagePart``
+- ``ChatError``
+
+### Context & Compression
+
+- ``ContextWindowManager``
+- ``PromptAssembler``
+- ``PromptSlot``
+- ``CompressionOrchestrator``
+- ``TokenizerProvider``
+
+### Prompt Formatting
+
+- ``PromptTemplate``
+- ``PromptTemplateDetector``
+- ``MacroExpander``
+
+### Tool Calling
+
+- ``ToolProvider``
+- ``ToolCallingBackend``
+- ``ToolDefinition``
+- ``ToolCall``
+- ``ToolResult``
+- ``ToolInputSchema``
+- ``ToolCallingError``
+
+### Post-Generation Tasks
+
+- ``PostGenerationTask``
+
+### Settings
+
+- ``SettingsService``
+
+### Reliability & Diagnostics
+
+- ``RetryPolicy``
+- ``CircuitBreaker``
+- ``RepetitionDetector``
+- ``BackendError``
+- ``ModelCompatibilityResult``
+- ``ModelTypeCompatibilityProvider``
+- ``FrameworkCapabilityService``
+
+### Schema & Migration
+
+- ``BaseChatSchema``
+- ``BaseChatSchemaV1``
+- ``BaseChatSchemaV2``
+- ``BaseChatMigrationPlan``

--- a/Sources/BaseChatCore/BaseChatCore.docc/BaseChatCore.md
+++ b/Sources/BaseChatCore/BaseChatCore.docc/BaseChatCore.md
@@ -86,6 +86,8 @@ Backends are registered as factories so BaseChatCore stays free of any direct ML
 - ``PromptAssembler``
 - ``PromptSlot``
 - ``CompressionOrchestrator``
+- ``CompressionMode``
+- ``CompressionStats``
 - ``TokenizerProvider``
 
 ### Prompt Formatting

--- a/Sources/BaseChatCore/BaseChatCore.docc/Extensions/InferenceService.md
+++ b/Sources/BaseChatCore/BaseChatCore.docc/Extensions/InferenceService.md
@@ -1,0 +1,49 @@
+# ``InferenceService``
+
+## Topics
+
+### State
+
+- ``isModelLoaded``
+- ``isGenerating``
+- ``activeBackendName``
+- ``capabilities``
+- ``selectedPromptTemplate``
+- ``lastTokenUsage``
+
+### Loading Models
+
+- ``loadModel(from:type:contextSize:)``
+- ``loadCloudBackend(from:)``
+- ``unloadModel()``
+- ``resetConversation()``
+
+### Generation
+
+- ``generate(messages:config:)``
+- ``stopGeneration()``
+- ``generationDidFinish()``
+
+### Backend Registration
+
+- ``registerBackendFactory(_:)``
+- ``registerCloudBackendFactory(_:)``
+- ``BackendFactory``
+- ``CloudBackendFactory``
+
+### Compatibility
+
+- ``registeredBackendSnapshot()``
+
+### Tool Calling
+
+- ``toolProvider``
+- ``toolCallObserver``
+
+### Tokenization
+
+- ``tokenizer``
+
+### Memory Management
+
+- ``memoryGate``

--- a/Sources/BaseChatCore/BaseChatCore.docc/Extensions/InferenceService.md
+++ b/Sources/BaseChatCore/BaseChatCore.docc/Extensions/InferenceService.md
@@ -20,7 +20,7 @@
 
 ### Generation
 
-- ``generate(messages:config:)``
+- ``generate(messages:systemPrompt:temperature:topP:repeatPenalty:maxOutputTokens:)``
 - ``stopGeneration()``
 - ``generationDidFinish()``
 

--- a/Sources/BaseChatUI/BaseChatUI.docc/Articles/BuildingAChatUI.md
+++ b/Sources/BaseChatUI/BaseChatUI.docc/Articles/BuildingAChatUI.md
@@ -28,13 +28,13 @@ struct MyApp: App {
             appName: "MyApp",
             bundleIdentifier: Bundle.main.bundleIdentifier ?? "com.example.myapp"
         )
-        DefaultBackends.registerAll(with: inferenceService)
+        DefaultBackends.register(with: inferenceService)
         chatVM = ChatViewModel(inferenceService: inferenceService)
 
         // Connect session title generation to InferenceService
-        chatVM.onFirstMessage = { session, firstMessage in
+        chatVM.onFirstMessage = { _, firstMessage in
             Task { @MainActor in
-                await sessionVM.generateTitle(for: session, from: firstMessage)
+                await sessionVM.generateTitle(from: firstMessage, using: inferenceService)
             }
         }
     }
@@ -68,7 +68,7 @@ struct RootView: View {
             let provider = SwiftDataPersistenceProvider(modelContext: modelContext)
             sessionVM.configure(persistence: provider)
             chatVM.configure(persistence: provider)
-            await chatVM.loadInitialState()
+            chatVM.refreshModels()
         }
     }
 }

--- a/Sources/BaseChatUI/BaseChatUI.docc/Articles/BuildingAChatUI.md
+++ b/Sources/BaseChatUI/BaseChatUI.docc/Articles/BuildingAChatUI.md
@@ -1,0 +1,158 @@
+# Building a Chat UI
+
+Compose BaseChatUI components into a multi-session chat application.
+
+## Overview
+
+This article shows the full layout pattern for an app with a sidebar session list and a main chat area, wired to the two primary view models: ``ChatViewModel`` and ``SessionManagerViewModel``.
+
+### App scaffold
+
+Create both view models at the app level and share the same `InferenceService` between them. ``SessionManagerViewModel`` only manages session metadata — it never touches inference directly. ``ChatViewModel`` drives all generation.
+
+```swift
+import BaseChatCore
+import BaseChatBackends
+import BaseChatUI
+import SwiftUI
+import SwiftData
+
+@main
+struct MyApp: App {
+    let inferenceService = InferenceService()
+    let chatVM: ChatViewModel
+    let sessionVM = SessionManagerViewModel()
+
+    init() {
+        BaseChatConfiguration.shared = BaseChatConfiguration(
+            appName: "MyApp",
+            bundleIdentifier: Bundle.main.bundleIdentifier ?? "com.example.myapp"
+        )
+        DefaultBackends.registerAll(with: inferenceService)
+        chatVM = ChatViewModel(inferenceService: inferenceService)
+
+        // Connect session title generation to InferenceService
+        chatVM.onFirstMessage = { session, firstMessage in
+            Task { @MainActor in
+                await sessionVM.generateTitle(for: session, from: firstMessage)
+            }
+        }
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environment(chatVM)
+                .environment(sessionVM)
+        }
+        .modelContainer(try! ModelContainerFactory.makeContainer())
+    }
+}
+```
+
+### Root layout with NavigationSplitView
+
+```swift
+struct RootView: View {
+    @Environment(ChatViewModel.self) var chatVM
+    @Environment(SessionManagerViewModel.self) var sessionVM
+    @Environment(\.modelContext) var modelContext
+
+    var body: some View {
+        NavigationSplitView {
+            SessionListView()
+        } detail: {
+            ChatView()
+        }
+        .task {
+            let provider = SwiftDataPersistenceProvider(modelContext: modelContext)
+            sessionVM.configure(persistence: provider)
+            chatVM.configure(persistence: provider)
+            await chatVM.loadInitialState()
+        }
+    }
+}
+```
+
+Both view models share the same ``SwiftDataPersistenceProvider`` instance so session records created by `SessionManagerViewModel` are immediately visible to `ChatViewModel`.
+
+### Switching sessions
+
+When the user selects a session in the sidebar, switch the active chat context:
+
+```swift
+struct SessionListView: View {
+    @Environment(ChatViewModel.self) var chatVM
+    @Environment(SessionManagerViewModel.self) var sessionVM
+
+    var body: some View {
+        List(sessionVM.sessions, selection: $sessionVM.activeSession) { session in
+            SessionRowView(session: session)
+        }
+        .onChange(of: sessionVM.activeSession) { _, newSession in
+            if let session = newSession {
+                chatVM.switchToSession(session)
+            }
+        }
+        .toolbar {
+            Button("New Chat", systemImage: "square.and.pencil") {
+                let session = try? sessionVM.createSession()
+                if let session { chatVM.switchToSession(session) }
+            }
+        }
+    }
+}
+```
+
+### Customizing the model selection experience
+
+``ChatViewModel`` exposes ``ChatViewModel/onFirstLaunch`` for apps that want to control the initial model selection flow — for example, showing an onboarding sheet instead of auto-selecting the Foundation model:
+
+```swift
+chatVM.onFirstLaunch = {
+    showOnboardingSheet = true
+}
+```
+
+When `onFirstLaunch` is `nil`, BaseChatKit auto-selects the Foundation model if ``ChatViewModel/foundationModelProvider`` returns `true`:
+
+```swift
+chatVM.foundationModelProvider = { FoundationBackend.isAvailable }
+```
+
+### Adding tool calling
+
+Set a ``ToolProvider`` on ``ChatViewModel`` before the first generation to make tools available to capable backends:
+
+```swift
+struct WeatherTool: ToolProvider {
+    var tools: [ToolDefinition] { [weatherDefinition] }
+
+    func execute(call: ToolCall) async throws -> ToolResult {
+        // …
+    }
+}
+
+chatVM.toolProvider = WeatherTool()
+```
+
+Backends that don't adopt ``ToolCallingBackend`` silently ignore the provider.
+
+### Adding post-generation tasks
+
+Register background tasks that run after each response completes:
+
+```swift
+chatVM.postGenerationTasks = [
+    AnalyticsLogger(),       // your PostGenerationTask conforming types
+    LocalIndexUpdater()
+]
+```
+
+Tasks run sequentially off `@MainActor`. Errors surface in ``ChatViewModel/backgroundTaskError`` but don't interrupt the session.
+
+## Next Steps
+
+- See ``GenerationSettingsView`` to give users control over temperature and prompt templates
+- See ``ModelManagementSheet`` for the combined model selection, download, and storage UI
+- See ``BaseChatConfiguration/Features`` to hide UI features that don't apply to your deployment

--- a/Sources/BaseChatUI/BaseChatUI.docc/BaseChatUI.md
+++ b/Sources/BaseChatUI/BaseChatUI.docc/BaseChatUI.md
@@ -1,0 +1,87 @@
+# ``BaseChatUI``
+
+SwiftUI views and view models for building on-device and cloud-connected chat interfaces.
+
+## Overview
+
+BaseChatUI provides the view layer for BaseChatKit. It depends only on ``BaseChatCore`` — it has no knowledge of specific inference backends. Drop ``ChatView`` into your app and supply a ``ChatViewModel`` to get a fully-featured chat interface: streaming generation, model selection, session management, context compression, and tool calling.
+
+### Minimum wiring
+
+```swift
+import BaseChatCore
+import BaseChatBackends
+import BaseChatUI
+import SwiftUI
+import SwiftData
+
+@main
+struct MyApp: App {
+    let inferenceService = InferenceService()
+    let chatVM: ChatViewModel
+
+    init() {
+        BaseChatConfiguration.shared = BaseChatConfiguration(
+            appName: "MyApp",
+            bundleIdentifier: Bundle.main.bundleIdentifier ?? "com.example.myapp"
+        )
+        DefaultBackends.registerAll(with: inferenceService)
+        chatVM = ChatViewModel(inferenceService: inferenceService)
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environment(chatVM)
+        }
+        .modelContainer(try! ModelContainerFactory.makeContainer())
+    }
+}
+```
+
+Then place ``ChatView`` in your view hierarchy:
+
+```swift
+struct ContentView: View {
+    @Environment(ChatViewModel.self) var chatVM
+
+    var body: some View {
+        ChatView()
+    }
+}
+```
+
+For a sidebar-based layout with multiple sessions, combine ``ChatView`` with ``SessionListView`` and ``SessionManagerViewModel``. See <doc:BuildingAChatUI> for the full pattern.
+
+## Topics
+
+### Getting Started
+
+- <doc:BuildingAChatUI>
+
+### View Models
+
+- ``ChatViewModel``
+- ``SessionManagerViewModel``
+- ``ModelManagementViewModel``
+- ``ServerDiscoveryViewModel``
+
+### Chat Views
+
+- ``ChatView``
+- ``ChatInputBar``
+- ``MessageBubbleView``
+
+### Model Management
+
+- ``ModelManagementSheet``
+- ``ModelBrowserView``
+
+### Settings
+
+- ``GenerationSettingsView``
+- ``APIConfigurationView``
+
+### Session Management
+
+- ``SessionListView``

--- a/Sources/BaseChatUI/BaseChatUI.docc/BaseChatUI.md
+++ b/Sources/BaseChatUI/BaseChatUI.docc/BaseChatUI.md
@@ -25,7 +25,7 @@ struct MyApp: App {
             appName: "MyApp",
             bundleIdentifier: Bundle.main.bundleIdentifier ?? "com.example.myapp"
         )
-        DefaultBackends.registerAll(with: inferenceService)
+        DefaultBackends.register(with: inferenceService)
         chatVM = ChatViewModel(inferenceService: inferenceService)
     }
 

--- a/Sources/BaseChatUI/BaseChatUI.docc/Extensions/ChatViewModel.md
+++ b/Sources/BaseChatUI/BaseChatUI.docc/Extensions/ChatViewModel.md
@@ -1,0 +1,61 @@
+# ``ChatViewModel``
+
+## Topics
+
+### Session
+
+- ``activeSession``
+- ``switchToSession(_:)``
+
+### Messages
+
+- ``messages``
+- ``inputText``
+- ``sendMessage()``
+- ``clearChat()``
+- ``regenerateLastResponse()``
+- ``editMessage(_:newContent:)``
+- ``pinMessage(id:)``
+- ``unpinMessage(id:)``
+
+### Generation State
+
+- ``isGenerating``
+- ``isLoading``
+- ``activityPhase``
+- ``stopGeneration()``
+
+### Model Selection
+
+- ``selectedModel``
+- ``selectedEndpoint``
+- ``availableModels``
+- ``availableEndpoints``
+
+### Generation Settings
+
+- ``systemPrompt``
+- ``compressionMode``
+- ``pinnedMessageIDs``
+- ``lastCompressionStats``
+
+### Errors
+
+- ``activeError``
+- ``errorMessage``
+- ``backgroundTaskError``
+
+### Extensibility
+
+- ``toolProvider``
+- ``postGenerationTasks``
+- ``onFirstMessage``
+- ``onFirstLaunch``
+- ``foundationModelProvider``
+
+### Initialization & Setup
+
+- ``configure(persistence:)``
+- ``refreshModels()``
+- ``loadSelectedModel()``
+- ``unloadModel()``


### PR DESCRIPTION
## Summary

- Adds `BaseChatCore.docc` with a landing page, Getting Started article, and `InferenceService` symbol extension
- Adds `BaseChatUI.docc` with a landing page, Building a Chat UI article, and `ChatViewModel` symbol extension
- No code changes — docs-only, no test impact

## Release Note

No release — documentation only. DocC catalogs are picked up automatically by SwiftPM 5.5+ and Xcode; no Package.swift changes needed.

## What's included

**`BaseChatCore.docc`**
- Landing page organising ~50 public types into logical topic groups (Inference, Persistence, Compression, Tool Calling, Schema, etc.)
- *Getting Started* article: step-by-step from `BaseChatConfiguration.shared` through backend registration and first generation call
- `InferenceService` extension: curated topic groups for its public API surface

**`BaseChatUI.docc`**
- Landing page with minimum wiring example (6-line app scaffold)
- *Building a Chat UI* article: full `NavigationSplitView` scaffold, session switching, tool calling, and post-generation task patterns
- `ChatViewModel` extension: full public API organised by concern (session, messages, generation, model selection, extensibility)

Closes #152