### PR TITLE
perf: eliminate redundant tokenization across the generation pipeline

### DIFF
--- a/Sources/BaseChatCore/Services/CachingTokenizer.swift
+++ b/Sources/BaseChatCore/Services/CachingTokenizer.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// A ``TokenizerProvider`` that memoizes token counts for the lifetime of this instance.
+///
+/// Construct one per generation cycle and discard it afterward. Messages whose content
+/// does not change between subsystem calls pay the tokenization cost exactly once —
+/// subsequent lookups for the same string return the cached count.
+///
+/// Thread-safe: concurrent reads and writes from different actors are safe.
+///
+/// ## Usage
+/// ```swift
+/// let tok = CachingTokenizer(wrapping: activeTokenizer ?? HeuristicTokenizer())
+/// // Pass tok wherever a TokenizerProvider is accepted.
+/// ```
+public final class CachingTokenizer: TokenizerProvider, @unchecked Sendable {
+
+    private let base: TokenizerProvider
+    private var cache: [String: Int] = [:]
+    private let lock = NSLock()
+
+    public init(wrapping base: TokenizerProvider) {
+        self.base = base
+    }
+
+    public func tokenCount(_ text: String) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        if let cached = cache[text] { return cached }
+        let count = base.tokenCount(text)
+        cache[text] = count
+        return count
+    }
+}

--- a/Sources/BaseChatCore/Services/ContextWindowManager.swift
+++ b/Sources/BaseChatCore/Services/ContextWindowManager.swift
@@ -14,7 +14,7 @@ public enum ContextWindowManager {
         if let tokenizer {
             return tokenizer.tokenCount(text)
         }
-        return max(1, text.count / 4)
+        return HeuristicTokenizer().tokenCount(text)
     }
 
     /// Resolves the effective context size from available sources.

--- a/Sources/BaseChatCore/Services/PromptAssembler.swift
+++ b/Sources/BaseChatCore/Services/PromptAssembler.swift
@@ -115,9 +115,10 @@ public enum PromptAssembler {
     // MARK: - Private Helpers
 
     /// Trims messages to fit within the given token budget.
-    /// Walks backward from the newest message, always keeping at least the last message.
-    /// Returns both the trimmed messages and their total token count, so the caller
-    /// does not need a second pass to compute the budget breakdown.
+    /// Walks backward from the newest message. When `budget <= 0`, it prefers keeping
+    /// the most recent user message, or falls back to the newest message if no user
+    /// message exists. Returns both the trimmed messages and their total token count,
+    /// so the caller does not need a second pass to compute the budget breakdown.
     private static func trimMessagesToFit(
         _ messages: [ChatMessageRecord],
         budget: Int,

--- a/Sources/BaseChatCore/Services/PromptAssembler.swift
+++ b/Sources/BaseChatCore/Services/PromptAssembler.swift
@@ -84,9 +84,9 @@ public enum PromptAssembler {
         let totalSlotTokens = resolvedSlots.reduce(0) { $0 + $1.tokenCount }
         let availableForMessages = max(0, contextSize - totalSlotTokens - responseBuffer)
 
-        // 4. Trim messages to fit remaining budget (newest first, like ContextWindowManager)
-        let trimmedMessages = trimMessagesToFit(messages, budget: availableForMessages, tokenizer: tok)
-        let messageTokens = trimmedMessages.reduce(0) { $0 + tok.tokenCount($1.content) }
+        // 4. Trim messages to fit remaining budget (newest first, like ContextWindowManager).
+        // totalTokens comes free from the trim loop — no second pass needed.
+        let (trimmedMessages, messageTokens) = trimMessagesToFit(messages, budget: availableForMessages, tokenizer: tok)
         budgetBreakdown["history"] = messageTokens
 
         // 5. Sort resolved slots by position for final ordering.
@@ -116,16 +116,21 @@ public enum PromptAssembler {
 
     /// Trims messages to fit within the given token budget.
     /// Walks backward from the newest message, always keeping at least the last message.
+    /// Returns both the trimmed messages and their total token count, so the caller
+    /// does not need a second pass to compute the budget breakdown.
     private static func trimMessagesToFit(
         _ messages: [ChatMessageRecord],
         budget: Int,
         tokenizer: TokenizerProvider
-    ) -> [ChatMessageRecord] {
-        guard !messages.isEmpty else { return [] }
+    ) -> (messages: [ChatMessageRecord], totalTokens: Int) {
+        guard !messages.isEmpty else { return ([], 0) }
 
         if budget <= 0 {
-            if let lastUser = messages.last(where: { $0.role == .user }) { return [lastUser] }
-            return Array(messages.suffix(1))
+            if let lastUser = messages.last(where: { $0.role == .user }) {
+                return ([lastUser], tokenizer.tokenCount(lastUser.content))
+            }
+            let last = messages.suffix(1)
+            return (Array(last), last.reduce(0) { $0 + tokenizer.tokenCount($1.content) })
         }
 
         var kept: [ChatMessageRecord] = []
@@ -138,7 +143,7 @@ public enum PromptAssembler {
             usedTokens += count
         }
 
-        return kept.reversed()
+        return (kept.reversed(), usedTokens)
     }
 
     /// Inserts slots into the message history based on their position.

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
@@ -65,7 +65,11 @@ extension ChatViewModel {
             } else {
                 effectiveSystemPrompt = rawSystemPrompt
             }
-            let activeTokenizer = inferenceService.tokenizer
+            // Wrap the tokenizer in a per-cycle cache so each message string is tokenized
+            // at most once across shouldCompress, compress, and trimMessages.
+            let cachingTokenizer: TokenizerProvider = CachingTokenizer(
+                wrapping: inferenceService.tokenizer ?? HeuristicTokenizer()
+            )
 
             let compressible = allMessages.map {
                 CompressibleMessage(
@@ -81,13 +85,13 @@ extension ChatViewModel {
                 messages: compressible,
                 systemPrompt: effectiveSystemPrompt,
                 contextSize: contextMaxTokens,
-                tokenizer: activeTokenizer
+                tokenizer: cachingTokenizer
             ) {
                 let result = await compressionOrchestrator.compress(
                     messages: compressible,
                     systemPrompt: effectiveSystemPrompt,
                     contextSize: contextMaxTokens,
-                    tokenizer: activeTokenizer
+                    tokenizer: cachingTokenizer
                 )
                 lastCompressionStats = result.stats
                 history = result.messages
@@ -98,7 +102,7 @@ extension ChatViewModel {
                     systemPrompt: effectiveSystemPrompt,
                     maxTokens: contextMaxTokens,
                     responseBuffer: 512,
-                    tokenizer: activeTokenizer
+                    tokenizer: cachingTokenizer
                 )
                 history = trimmed.map { (role: $0.role.rawValue, content: $0.content) }
             }

--- a/Tests/BaseChatCoreTests/CachingTokenizerTests.swift
+++ b/Tests/BaseChatCoreTests/CachingTokenizerTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+@testable import BaseChatCore
+
+// MARK: - Test double
+
+/// Counts every call to tokenCount so tests can verify cache behaviour.
+private final class CountingTokenizer: TokenizerProvider, @unchecked Sendable {
+    private(set) var callCount = 0
+
+    func tokenCount(_ text: String) -> Int {
+        callCount += 1
+        return max(1, text.count / 4)
+    }
+}
+
+// MARK: - Tests
+
+final class CachingTokenizerTests: XCTestCase {
+
+    // MARK: Correctness
+
+    func test_returnsCorrectCount() {
+        let base = CountingTokenizer()
+        let cache = CachingTokenizer(wrapping: base)
+        XCTAssertEqual(cache.tokenCount("hello world"), base.tokenCount("hello world"))
+    }
+
+    // Sabotage: if caching always returned 0 this would fail.
+    func test_returnsCorrectCount_sabotage() {
+        let base = HeuristicTokenizer()
+        let cache = CachingTokenizer(wrapping: base)
+        XCTAssertEqual(cache.tokenCount("abcdefgh"), 2) // 8 chars / 4
+    }
+
+    // MARK: Cache hits
+
+    func test_sameString_callsBaseOnce() {
+        let base = CountingTokenizer()
+        let cache = CachingTokenizer(wrapping: base)
+        let text = "The quick brown fox"
+
+        _ = cache.tokenCount(text)
+        _ = cache.tokenCount(text)
+        _ = cache.tokenCount(text)
+
+        // base should be called exactly once; the other two are cache hits.
+        XCTAssertEqual(base.callCount, 1)
+    }
+
+    // Sabotage: if every call went to base this would be 3, not 1.
+    func test_sameString_callsBaseOnce_sabotage() {
+        let base = CountingTokenizer()
+        let cache = CachingTokenizer(wrapping: base)
+        _ = cache.tokenCount("abc")
+        _ = cache.tokenCount("abc")
+        XCTAssertLessThan(base.callCount, 2)
+    }
+
+    func test_differentStrings_callsBaseForEach() {
+        let base = CountingTokenizer()
+        let cache = CachingTokenizer(wrapping: base)
+
+        _ = cache.tokenCount("apple")
+        _ = cache.tokenCount("banana")
+        _ = cache.tokenCount("cherry")
+
+        XCTAssertEqual(base.callCount, 3)
+    }
+
+    func test_emptyString_cached() {
+        let base = CountingTokenizer()
+        let cache = CachingTokenizer(wrapping: base)
+
+        _ = cache.tokenCount("")
+        _ = cache.tokenCount("")
+
+        XCTAssertEqual(base.callCount, 1)
+    }
+
+    // MARK: Isolation between instances
+
+    func test_separateInstances_doNotShareCache() {
+        let base = CountingTokenizer()
+        let cacheA = CachingTokenizer(wrapping: base)
+        let cacheB = CachingTokenizer(wrapping: base)
+        let text = "shared text"
+
+        _ = cacheA.tokenCount(text)
+        _ = cacheB.tokenCount(text)
+
+        // Each instance has its own cache, so base is called twice.
+        XCTAssertEqual(base.callCount, 2)
+    }
+
+    // MARK: Thread safety
+
+    func test_concurrentReads_doNotCrash() {
+        let cache = CachingTokenizer(wrapping: HeuristicTokenizer())
+        let group = DispatchGroup()
+
+        for i in 0..<100 {
+            group.enter()
+            DispatchQueue.global().async {
+                _ = cache.tokenCount("token \(i % 10)") // reuse 10 strings to exercise caching
+                group.leave()
+            }
+        }
+
+        group.wait()
+        // No assertion needed — the test passes if it doesn't crash or deadlock.
+    }
+
+    func test_concurrentReadWrite_noDuplicateCalls() {
+        let base = CountingTokenizer()
+        let cache = CachingTokenizer(wrapping: base)
+        let text = "concurrent text"
+        let group = DispatchGroup()
+
+        for _ in 0..<50 {
+            group.enter()
+            DispatchQueue.global().async {
+                _ = cache.tokenCount(text)
+                group.leave()
+            }
+        }
+
+        group.wait()
+        // With a lock, base should be called exactly once.
+        XCTAssertEqual(base.callCount, 1)
+    }
+
+    // MARK: Protocol conformance
+
+    func test_conformsToTokenizerProvider() {
+        let provider: any TokenizerProvider = CachingTokenizer(wrapping: HeuristicTokenizer())
+        XCTAssertEqual(provider.tokenCount("abcdefgh"), 2)
+    }
+}

--- a/Tests/BaseChatCoreTests/CachingTokenizerTests.swift
+++ b/Tests/BaseChatCoreTests/CachingTokenizerTests.swift
@@ -5,10 +5,19 @@ import XCTest
 
 /// Counts every call to tokenCount so tests can verify cache behaviour.
 private final class CountingTokenizer: TokenizerProvider, @unchecked Sendable {
-    private(set) var callCount = 0
+    private let lock = NSLock()
+    private var _callCount = 0
+
+    var callCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _callCount
+    }
 
     func tokenCount(_ text: String) -> Int {
-        callCount += 1
+        lock.lock()
+        _callCount += 1
+        lock.unlock()
         return max(1, text.count / 4)
     }
 }
@@ -106,8 +115,8 @@ final class CachingTokenizerTests: XCTestCase {
             }
         }
 
-        group.wait()
-        // No assertion needed — the test passes if it doesn't crash or deadlock.
+        let result = group.wait(timeout: .now() + 5)
+        XCTAssertEqual(result, .success, "Concurrent reads timed out — possible deadlock")
     }
 
     func test_concurrentReadWrite_noDuplicateCalls() {
@@ -124,7 +133,8 @@ final class CachingTokenizerTests: XCTestCase {
             }
         }
 
-        group.wait()
+        let result = group.wait(timeout: .now() + 5)
+        XCTAssertEqual(result, .success, "Concurrent writes timed out — possible deadlock")
         // With a lock, base should be called exactly once.
         XCTAssertEqual(base.callCount, 1)
     }


### PR DESCRIPTION
Closes #185

## What changed

Three sources of redundant tokenization across a single generation cycle, identified in #185, are eliminated:

**`CachingTokenizer`** (new) — a `TokenizerProvider` that memoizes results by content string behind an `NSLock`. Construct one per generation cycle and pass it in place of the raw tokenizer; any string already seen returns a cached count with no further work.

**`ChatViewModel+Generation`** — wraps `inferenceService.tokenizer` in a `CachingTokenizer` at the top of the generation block. The same instance is threaded through `shouldCompress`, `compress`, and `trimMessages`, so a message tokenized during the threshold check is a free lookup in the compression pass and the trim fallback.

**`PromptAssembler.trimMessagesToFit`** — the trim loop already accumulated the total token count in `usedTokens`. The function now returns `(messages, totalTokens)` instead of forcing the caller to immediately re-tokenize the same messages to build `budgetBreakdown["history"]`.

**`ContextWindowManager.estimateTokenCount`** — the nil-tokenizer fallback now delegates to `HeuristicTokenizer().tokenCount()` instead of duplicating the `text.count / 4` arithmetic inline. One canonical implementation of the heuristic (AC5 from #185).

## Tests

`CachingTokenizerTests` (10 tests, XCTestCase): correctness, cache-hit counting via `CountingTokenizer`, per-instance isolation, concurrent-access safety (no crash or deadlock under 50 goroutine-style concurrent calls to the same key).

All three CI suites pass locally:
```
swift test --filter BaseChatCoreTests   ✓
swift test --filter BaseChatUITests     ✓
swift test --filter BaseChatBackendsTests ✓
```

## Release Note

Before this change, BaseChatKit tokenized the same message strings up to five times in a single generation cycle — once to check whether compression was needed, again inside the compressor, again for the per-message breakdown, and twice more inside `PromptAssembler`. On a 50-message context this meant ~100–150 redundant `tokenCount` calls per inference request. This PR introduces `CachingTokenizer`, a lightweight per-cycle memoization wrapper, and fixes a structural double-pass in `PromptAssembler`, so each unique message content is tokenized at most once regardless of how many subsystems ask for it. No public API signatures change; the optimization is entirely internal.