### PR TITLE
fix(ui): macOS ModelSelectTab renders blank in ModelManagementSheet

### DIFF
--- a/Sources/BaseChatUI/Views/Models/ModelManagementSheet.swift
+++ b/Sources/BaseChatUI/Views/Models/ModelManagementSheet.swift
@@ -64,6 +64,7 @@ public struct ModelManagementSheet: View {
             VStack(spacing: 0) {
                 tabPickerBar
                 tabContent
+                    .frame(maxHeight: .infinity)
             }
             .navigationTitle(selectedTab.rawValue)
             .toolbar {
@@ -157,12 +158,33 @@ private struct ModelSelectTab: View {
     var body: some View {
         List {
             if chatViewModel.availableModels.isEmpty {
+                #if os(macOS)
+                // ContentUnavailableView renders near-zero height inside a List row on macOS.
+                HStack {
+                    Spacer()
+                    VStack(spacing: 8) {
+                        Image(systemName: "cpu")
+                            .font(.largeTitle)
+                            .foregroundStyle(.secondary)
+                        Text("No Models Available")
+                            .font(.headline)
+                        Text("Download a model from the Download tab to get started.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .padding()
+                    Spacer()
+                }
+                .listRowBackground(Color.clear)
+                #else
                 ContentUnavailableView(
                     "No Models Available",
                     systemImage: "cpu",
                     description: Text("Download a model from the Download tab to get started.")
                 )
                 .listRowBackground(Color.clear)
+                #endif
             } else {
                 Section {
                     ForEach(chatViewModel.availableModels) { model in
@@ -182,6 +204,8 @@ private struct ModelSelectTab: View {
         }
         #if os(iOS)
         .listStyle(.insetGrouped)
+        #else
+        .listStyle(.plain)
         #endif
         .accessibilityLabel("Available models")
     }


### PR DESCRIPTION
## Summary

Closes #208.

Three fixes to `ModelManagementSheet.swift`:

- Added `.frame(maxHeight: .infinity)` to `tabContent` in the macOS `VStack` — the blocker that caused the inner `List` to collapse to zero height
- Added `.listStyle(.plain)` on macOS in `ModelSelectTab` — consistency fix, avoids `.sidebar` style misbehaving inside a sheet `VStack`
- Replaced `ContentUnavailableView` empty state with a plain `HStack/VStack` on macOS — `ContentUnavailableView` renders near-zero height inside a `List` row on macOS

## Test plan

- [x] 299 `BaseChatUITests` pass
- [x] 58 `BaseChatE2ETests` pass

## Release Note

**macOS model selection tab no longer renders blank** — opening the Change Model sheet on macOS showed the tab picker correctly but the Select tab content was invisible. Three layout fixes to `ModelManagementSheet`: the `List` now fills available height, uses `.plain` list style consistent with macOS sheet context, and the empty state no longer collapses to zero height. Closes #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)