### PR TITLE
feat(test): add real-device E2E tests for MLX and Ollama backends

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,14 +51,15 @@ jobs:
       - name: Run CI smoke tests
         run: |
           set -euo pipefail
-          swift test --filter BaseChatCoreTests
-          swift test --filter BaseChatUITests
-          swift test --filter BaseChatBackendsTests
+          swift test --filter BaseChatCoreTests --disable-default-traits
+          swift test --filter BaseChatUITests --disable-default-traits
+          swift test --filter BaseChatBackendsTests --disable-default-traits
 
       # CI smoke profile (GitHub macOS Apple Silicon runners):
       # - Runs BaseChatCoreTests + BaseChatUITests + BaseChatBackendsTests.
-      # - BaseChatBackendsTests runs without MLX/Llama traits, so only CI-safe
-      #   cloud/SSE and non-hardware tests execute.
+      # - --disable-default-traits skips MLX (default-enabled) to avoid metallib
+      #   crashes in CI — Metal shaders are only compiled by Xcode.
+      # - BaseChatBackendsTests without traits runs only CI-safe cloud/SSE tests.
       # Local-only coverage:
       # - Run `swift test --filter BaseChatBackendsTests --traits MLX,Llama` on
       #   Apple Silicon for MLX/llama.cpp paths.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,20 +8,28 @@
 | `BaseChatBackends` | MLX, llama.cpp, Foundation, cloud backends | MLX, LlamaSwift |
 | `BaseChatUI` | SwiftUI views and view models | None |
 | `BaseChatTestSupport` | Shared mocks and fakes (`MockInferenceBackend`, `CharTokenizer`, etc.) | None |
+| `BaseChatMLXIntegrationTests` | Xcode-only real MLX model E2E tests | MLX |
 
 `BaseChatUI` depends only on `BaseChatCore` — keep it that way. Never import `BaseChatBackends` from UI.
 
 ## Running tests
 
 ```bash
-# Runs in CI — no hardware required
-swift test --filter BaseChatCoreTests
-swift test --filter BaseChatUITests
-swift test --filter BaseChatBackendsTests   # cloud/SSE tests only; MLX and Llama excluded by #if traits
+# Runs in CI — no hardware required (disable default MLX trait to skip heavy deps)
+swift test --filter BaseChatCoreTests --disable-default-traits
+swift test --filter BaseChatUITests --disable-default-traits
+swift test --filter BaseChatBackendsTests --disable-default-traits
 
-# Apple Silicon only — MLX, llama.cpp, on-device models
+# Apple Silicon only — MLX mock tests + llama.cpp
 swift test --filter BaseChatBackendsTests --traits MLX,Llama
-swift test --filter BaseChatE2ETests
+swift test --filter BaseChatE2ETests --disable-default-traits
+
+# Xcode-only — real MLX model inference (metallib required)
+# Cannot run via swift test; MLX Metal shaders are only compiled by Xcode.
+xcodebuild test -scheme BaseChatKit-Package -only-testing BaseChatMLXIntegrationTests -destination 'platform=macOS'
+
+# Real Ollama server E2E (requires Ollama running at localhost:11434)
+swift test --filter OllamaE2ETests --disable-default-traits
 ```
 
 When writing hardware-gated tests, add `XCTSkipIf` guards at the top of the test rather than assuming the environment.
@@ -67,7 +75,7 @@ Do not widen `inferenceService` to `public` — it exposes load coordination int
 Before pushing any branch, run all three CI test suites locally and confirm zero failures:
 
 ```bash
-swift test --filter BaseChatCoreTests && swift test --filter BaseChatUITests && swift test --filter BaseChatBackendsTests
+swift test --filter BaseChatCoreTests --disable-default-traits && swift test --filter BaseChatUITests --disable-default-traits && swift test --filter BaseChatBackendsTests --disable-default-traits
 ```
 
 Never push based on a subset passing. After rebasing, always re-run the full suite before pushing — conflicts can silently break tests that compiled fine before.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "41ade1f0c022fc310291383134944fdecac10fae80a6406436729df270f9f01b",
+  "originHash" : "bf3a6192adf8b60c579c135ebfae13e49da37ba3f9246c6cde590fb633c5155a",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -8,6 +8,33 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "llama.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/llama.swift",
+      "state" : {
+        "revision" : "80abe47d1475ca23a93eb102eb6e90793c807640",
+        "version" : "2.8705.0"
+      }
+    },
+    {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift.git",
+      "state" : {
+        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
+        "version" : "0.31.3"
+      }
+    },
+    {
+      "identity" : "mlx-swift-lm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
+      "state" : {
+        "revision" : "25b00d4e22e61ec9c41efda47990cd2084ec87ff",
+        "version" : "2.31.3"
       }
     },
     {
@@ -80,6 +107,15 @@
       "state" : {
         "revision" : "558f24a4647193b5a0e2104031b71c55d31ff83a",
         "version" : "2.97.1"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
         .library(name: "BaseChatUI", targets: ["BaseChatUI"]),
     ],
     traits: [
+        .default(enabledTraits: ["MLX"]),
         .trait(name: "MLX", description: "Enable the MLX inference backend (requires Apple Silicon)"),
         .trait(name: "Llama", description: "Enable the llama.cpp (GGUF) inference backend"),
     ],
@@ -89,6 +90,17 @@ let package = Package(
                 "BaseChatUI",
                 "BaseChatCore",
                 .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
+            ]
+        ),
+        // Xcode-only: real MLX model inference requiring Metal shader library.
+        // Cannot run via `swift test` — MLX's metallib is only compiled by Xcode.
+        // Run with: xcodebuild test -scheme BaseChatKit-Package -only-testing BaseChatMLXIntegrationTests
+        .testTarget(
+            name: "BaseChatMLXIntegrationTests",
+            dependencies: [
+                "BaseChatBackends",
+                "BaseChatCore",
+                "BaseChatTestSupport",
             ]
         ),
     ],

--- a/Sources/BaseChatTestSupport/HardwareRequirements.swift
+++ b/Sources/BaseChatTestSupport/HardwareRequirements.swift
@@ -52,4 +52,138 @@ public enum HardwareRequirements {
         }
         return false
     }
+
+    // MARK: - Ollama
+
+    /// `true` when a local Ollama server is reachable at `localhost:11434`.
+    ///
+    /// Performs a synchronous HTTP GET to `/api/tags` with a short timeout.
+    /// Use with `XCTSkipUnless` to skip Ollama E2E tests when the server is down.
+    public static var hasOllamaServer: Bool {
+        fetchOllamaModels() != nil
+    }
+
+    /// Returns the first Ollama model name in the 7-8B parameter range, or `nil`.
+    ///
+    /// Queries `/api/tags` synchronously. Prefers models whose `parameter_size`
+    /// contains "7" or "8" (e.g. "7.2B", "8.0B").
+    public static func findOllamaModel(preferredSizeRange: ClosedRange<Double> = 6.5...9.0) -> String? {
+        guard let models = fetchOllamaModels() else { return nil }
+        return selectOllamaModel(from: models, preferredSizeRange: preferredSizeRange)
+    }
+
+    /// Selects the best model from a pre-fetched Ollama model list.
+    /// Extracted from `findOllamaModel` for testability.
+    static func selectOllamaModel(
+        from models: [[String: Any]],
+        preferredSizeRange: ClosedRange<Double> = 6.5...9.0
+    ) -> String? {
+        for model in models {
+            guard let name = model["name"] as? String,
+                  let details = model["details"] as? [String: Any],
+                  let paramSize = details["parameter_size"] as? String else { continue }
+            let numeric = paramSize.replacingOccurrences(of: "B", with: "")
+            if let value = Double(numeric), preferredSizeRange.contains(value) {
+                return name
+            }
+        }
+        return models.first?["name"] as? String
+    }
+
+    /// Fetches the model list from Ollama's `/api/tags` endpoint synchronously.
+    /// Returns `nil` if the server is unreachable or the response is malformed.
+    private static func fetchOllamaModels() -> [[String: Any]]? {
+        guard let url = URL(string: "http://localhost:11434/api/tags") else { return nil }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 3
+
+        let semaphore = DispatchSemaphore(value: 0)
+        // Box to avoid "mutation of captured var in concurrently-executing code" warning.
+        final class Box: @unchecked Sendable { var value: [[String: Any]]?  }
+        let box = Box()
+
+        URLSession.shared.dataTask(with: request) { data, response, _ in
+            defer { semaphore.signal() }
+            guard let data,
+                  let http = response as? HTTPURLResponse, http.statusCode == 200,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let models = json["models"] as? [[String: Any]] else { return }
+            box.value = models
+        }.resume()
+        semaphore.wait()
+        return box.value
+    }
+
+    // MARK: - MLX Models
+
+    /// Scans common model directories for a valid MLX model directory
+    /// (contains `config.json` and at least one `.safetensors` file).
+    ///
+    /// Searches:
+    /// 1. `~/Documents/Models/` (default `ModelStorageService` location)
+    /// 2. App container `Documents/Models/` directories
+    ///
+    /// Returns the URL of the first valid MLX directory found, or `nil`.
+    public static func findMLXModelDirectory() -> URL? {
+        let fm = FileManager.default
+
+        // Collect candidate directories to scan.
+        var searchDirs: [URL] = []
+
+        // 1. Default ~/Documents/Models/
+        if let docs = fm.urls(for: .documentDirectory, in: .userDomainMask).first {
+            searchDirs.append(docs.appendingPathComponent("Models", isDirectory: true))
+        }
+
+        // 2. App container directories: ~/Library/Containers/*/Data/Documents/Models/
+        if let library = fm.urls(for: .libraryDirectory, in: .userDomainMask).first {
+            let containersDir = library.appendingPathComponent("Containers", isDirectory: true)
+            if let containers = try? fm.contentsOfDirectory(
+                at: containersDir,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            ) {
+                for container in containers {
+                    let modelsDir = container
+                        .appendingPathComponent("Data/Documents/Models", isDirectory: true)
+                    searchDirs.append(modelsDir)
+                }
+            }
+        }
+
+        // Scan each directory for valid MLX model subdirectories.
+        for dir in searchDirs {
+            guard let contents = try? fm.contentsOfDirectory(
+                at: dir,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            ) else { continue }
+
+            for candidate in contents {
+                if isValidMLXDirectory(candidate, fileManager: fm) {
+                    return candidate
+                }
+            }
+        }
+
+        return nil
+    }
+
+    /// Checks whether a directory contains `config.json` and at least one `.safetensors` file.
+    static func isValidMLXDirectory(_ url: URL, fileManager: FileManager = .default) -> Bool {
+        var isDir: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue else {
+            return false
+        }
+        let configPath = url.appendingPathComponent("config.json").path
+        guard fileManager.fileExists(atPath: configPath) else { return false }
+
+        guard let files = try? fileManager.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else { return false }
+
+        return files.contains { $0.pathExtension.lowercased() == "safetensors" }
+    }
 }

--- a/Sources/BaseChatTestSupport/HardwareRequirements.swift
+++ b/Sources/BaseChatTestSupport/HardwareRequirements.swift
@@ -63,10 +63,12 @@ public enum HardwareRequirements {
         fetchOllamaModels() != nil
     }
 
-    /// Returns the first Ollama model name in the 7-8B parameter range, or `nil`.
+    /// Returns an Ollama model name, preferring one in the given parameter size range.
     ///
     /// Queries `/api/tags` synchronously. Prefers models whose `parameter_size`
-    /// contains "7" or "8" (e.g. "7.2B", "8.0B").
+    /// falls in `preferredSizeRange` (e.g. "7.2B" → 7.2). Falls back to the
+    /// first available model if none match the range. Returns `nil` only if the
+    /// server is unreachable or has no models.
     public static func findOllamaModel(preferredSizeRange: ClosedRange<Double> = 6.5...9.0) -> String? {
         guard let models = fetchOllamaModels() else { return nil }
         return selectOllamaModel(from: models, preferredSizeRange: preferredSizeRange)
@@ -110,8 +112,10 @@ public enum HardwareRequirements {
                   let models = json["models"] as? [[String: Any]] else { return }
             box.value = models
         }.resume()
-        semaphore.wait()
-        return box.value
+        // Timeout slightly above the request timeout to avoid hanging if the
+        // URLSession completion handler is never invoked.
+        let result = semaphore.wait(timeout: .now() + 5)
+        return result == .success ? box.value : nil
     }
 
     // MARK: - MLX Models

--- a/Tests/BaseChatCoreTests/HardwareRequirementsMLXTests.swift
+++ b/Tests/BaseChatCoreTests/HardwareRequirementsMLXTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import BaseChatTestSupport
+
+final class HardwareRequirementsMLXTests: XCTestCase {
+
+    private var tempDirectory: URL!
+    private let fm = FileManager.default
+
+    override func setUp() {
+        super.setUp()
+        tempDirectory = fm.temporaryDirectory
+            .appendingPathComponent("HardwareRequirementsMLXTests-\(UUID().uuidString)")
+        try? fm.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? fm.removeItem(at: tempDirectory)
+        tempDirectory = nil
+        super.tearDown()
+    }
+
+    // MARK: - Valid directories
+
+    func test_isValidMLXDirectory_withConfigAndSafetensors_returnsTrue() {
+        createFile("config.json")
+        createFile("model.safetensors")
+
+        XCTAssertTrue(HardwareRequirements.isValidMLXDirectory(tempDirectory))
+    }
+
+    func test_isValidMLXDirectory_withMultipleSafetensors_returnsTrue() {
+        createFile("config.json")
+        createFile("model-00001-of-00002.safetensors")
+        createFile("model-00002-of-00002.safetensors")
+
+        XCTAssertTrue(HardwareRequirements.isValidMLXDirectory(tempDirectory))
+    }
+
+    // MARK: - Missing files
+
+    func test_isValidMLXDirectory_missingConfig_returnsFalse() {
+        createFile("model.safetensors")
+
+        XCTAssertFalse(HardwareRequirements.isValidMLXDirectory(tempDirectory))
+    }
+
+    func test_isValidMLXDirectory_missingSafetensors_returnsFalse() {
+        createFile("config.json")
+
+        XCTAssertFalse(HardwareRequirements.isValidMLXDirectory(tempDirectory))
+    }
+
+    func test_isValidMLXDirectory_emptyDirectory_returnsFalse() {
+        XCTAssertFalse(HardwareRequirements.isValidMLXDirectory(tempDirectory))
+    }
+
+    // MARK: - Not a directory
+
+    func test_isValidMLXDirectory_fileInsteadOfDirectory_returnsFalse() {
+        let fileURL = tempDirectory.appendingPathComponent("not-a-directory")
+        fm.createFile(atPath: fileURL.path, contents: Data("hello".utf8))
+
+        XCTAssertFalse(HardwareRequirements.isValidMLXDirectory(fileURL))
+    }
+
+    // MARK: - Helpers
+
+    @discardableResult
+    private func createFile(_ name: String) -> URL {
+        let url = tempDirectory.appendingPathComponent(name)
+        fm.createFile(atPath: url.path, contents: Data())
+        return url
+    }
+}

--- a/Tests/BaseChatCoreTests/HardwareRequirementsOllamaTests.swift
+++ b/Tests/BaseChatCoreTests/HardwareRequirementsOllamaTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+@testable import BaseChatTestSupport
+
+final class HardwareRequirementsOllamaTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func model(name: String, parameterSize: String) -> [String: Any] {
+        ["name": name, "details": ["parameter_size": parameterSize]]
+    }
+
+    // MARK: - selectOllamaModel
+
+    func test_picks7BModelFromMixedList() {
+        let models = [
+            model(name: "phi:3b", parameterSize: "3.0B"),
+            model(name: "llama3:7b", parameterSize: "7.2B"),
+            model(name: "llama3:13b", parameterSize: "13.0B"),
+        ]
+        let result = HardwareRequirements.selectOllamaModel(from: models)
+        XCTAssertEqual(result, "llama3:7b")
+    }
+
+    func test_picks8BModel() {
+        let models = [
+            model(name: "llama3.1:8b", parameterSize: "8.0B"),
+        ]
+        let result = HardwareRequirements.selectOllamaModel(from: models)
+        XCTAssertEqual(result, "llama3.1:8b")
+    }
+
+    func test_fallsBackToFirstWhenNoneInRange() {
+        let models = [
+            model(name: "tinyllama:1b", parameterSize: "1.0B"),
+            model(name: "phi:3b", parameterSize: "3.0B"),
+        ]
+        let result = HardwareRequirements.selectOllamaModel(from: models)
+        XCTAssertEqual(result, "tinyllama:1b")
+    }
+
+    func test_emptyModelList_returnsNil() {
+        let result = HardwareRequirements.selectOllamaModel(from: [])
+        XCTAssertNil(result)
+    }
+
+    func test_missingDetailsField_skippedAndFallsBack() {
+        let models: [[String: Any]] = [
+            ["name": "broken-model"],
+            model(name: "fallback:7b", parameterSize: "7.2B"),
+        ]
+        let result = HardwareRequirements.selectOllamaModel(from: models)
+        XCTAssertEqual(result, "fallback:7b")
+    }
+
+    func test_missingParameterSize_skippedAndFallsBack() {
+        let models: [[String: Any]] = [
+            ["name": "no-size", "details": ["family": "llama"]],
+            model(name: "good:8b", parameterSize: "8.0B"),
+        ]
+        let result = HardwareRequirements.selectOllamaModel(from: models)
+        XCTAssertEqual(result, "good:8b")
+    }
+
+    func test_customSizeRange() {
+        let models = [
+            model(name: "mistral:7b", parameterSize: "7.2B"),
+            model(name: "llama3:13b", parameterSize: "13.0B"),
+        ]
+        let result = HardwareRequirements.selectOllamaModel(
+            from: models,
+            preferredSizeRange: 12.0...14.0
+        )
+        XCTAssertEqual(result, "llama3:13b")
+    }
+
+    func test_unparseableParameterSize_skippedAndFallsBack() {
+        let models: [[String: Any]] = [
+            model(name: "weird:latest", parameterSize: "large"),
+            model(name: "fallback:3b", parameterSize: "3.0B"),
+        ]
+        // Neither model is in the default 6.5...9.0 range, so falls back to first.
+        let result = HardwareRequirements.selectOllamaModel(from: models)
+        XCTAssertEqual(result, "weird:latest")
+    }
+
+    func test_multipleModelsInRange_returnsFirst() {
+        let models = [
+            model(name: "mistral:7b", parameterSize: "7.2B"),
+            model(name: "llama3.1:8b", parameterSize: "8.0B"),
+        ]
+        let result = HardwareRequirements.selectOllamaModel(from: models)
+        XCTAssertEqual(result, "mistral:7b")
+    }
+}

--- a/Tests/BaseChatE2ETests/OllamaE2ETests.swift
+++ b/Tests/BaseChatE2ETests/OllamaE2ETests.swift
@@ -1,0 +1,147 @@
+import XCTest
+import BaseChatCore
+import BaseChatTestSupport
+@testable import BaseChatBackends
+
+/// True end-to-end tests hitting a real local Ollama server.
+///
+/// These tests perform real inference against Ollama at `localhost:11434`.
+/// They are automatically skipped when:
+/// - No Ollama server is reachable
+/// - No models are available (or none in the preferred 7-8B range)
+///
+/// Unlike mock-based tests, these use NO stubs — real HTTP, real NDJSON
+/// streaming, real token generation from a real model.
+@MainActor
+final class OllamaE2ETests: XCTestCase {
+
+    private var backend: OllamaBackend!
+    private var modelName: String!
+
+    // MARK: - Setup
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        try XCTSkipUnless(HardwareRequirements.hasOllamaServer, "Ollama server not running at localhost:11434")
+
+        guard let model = HardwareRequirements.findOllamaModel() else {
+            throw XCTSkip("No Ollama model available")
+        }
+        modelName = model
+
+        backend = OllamaBackend()
+        backend.configure(
+            baseURL: URL(string: "http://localhost:11434")!,
+            modelName: modelName
+        )
+        try await backend.loadModel(from: URL(string: "unused:")!, contextSize: 0)
+    }
+
+    override func tearDown() async throws {
+        backend?.unloadModel()
+        backend = nil
+        modelName = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func generate(
+        prompt: String,
+        systemPrompt: String? = nil,
+        maxTokens: Int = 64
+    ) async throws -> String {
+        let config = GenerationConfig(
+            temperature: 0.3,
+            maxTokens: Int32(maxTokens),
+            maxOutputTokens: maxTokens
+        )
+        let stream = try backend.generate(
+            prompt: prompt,
+            systemPrompt: systemPrompt,
+            config: config
+        )
+        return try await collectTokens(stream)
+    }
+
+    // MARK: - Real Inference Tests
+
+    func test_realInference_generatesNonEmptyResponse() async throws {
+        let response = try await generate(prompt: "Reply with exactly one word.")
+
+        XCTAssertFalse(response.isEmpty, "Ollama should generate a non-empty response (model: \(modelName!))")
+    }
+
+    func test_realInference_withSystemPrompt() async throws {
+        let response = try await generate(
+            prompt: "What are you?",
+            systemPrompt: "You are a helpful pirate. Always respond in pirate speak."
+        )
+
+        XCTAssertFalse(response.isEmpty, "Should generate a response with system prompt")
+    }
+
+    func test_realInference_multiTurn() async throws {
+        // First turn
+        let firstResponse = try await generate(prompt: "Remember the number 42.")
+        XCTAssertFalse(firstResponse.isEmpty, "First response should not be empty")
+
+        // Second turn — Ollama is stateless per request, so multi-turn requires
+        // conversation history. Test that a second generation works independently.
+        let secondResponse = try await generate(prompt: "What is 2 + 2?")
+        XCTAssertFalse(secondResponse.isEmpty, "Second response should not be empty")
+    }
+
+    func test_realInference_stopGeneration() async throws {
+        let config = GenerationConfig(
+            temperature: 0.7,
+            maxTokens: 2048,
+            maxOutputTokens: 2048
+        )
+
+        let stream = try backend.generate(
+            prompt: "Write a very detailed essay about the history of computing from the 1940s to today.",
+            systemPrompt: nil,
+            config: config
+        )
+
+        // Wait for at least a few tokens to arrive, then stop.
+        // Ollama may take 10-20s to load the model into VRAM on first request.
+        var tokenCount = 0
+        let collectTask = Task {
+            for try await event in stream.events {
+                if case .token = event {
+                    tokenCount += 1
+                    if tokenCount >= 5 { break }
+                }
+            }
+        }
+
+        try await collectTask.value
+        XCTAssertGreaterThanOrEqual(tokenCount, 5, "Should have received at least 5 tokens")
+
+        // Now stop — verify the backend accepts it without crashing.
+        backend.stopGeneration()
+    }
+
+    func test_realInference_respectsMaxOutputTokens() async throws {
+        // Request a very short response via maxOutputTokens.
+        let response = try await generate(
+            prompt: "Write a long story about a dragon.",
+            maxTokens: 10
+        )
+
+        // The response should be relatively short. With 10 max output tokens
+        // and Ollama's num_predict, we can't assert exact token count but
+        // the response shouldn't be novel-length.
+        XCTAssertFalse(response.isEmpty, "Should still generate some output")
+    }
+
+    func test_backendCapabilities() {
+        XCTAssertTrue(backend.capabilities.supportsStreaming)
+        XCTAssertTrue(backend.capabilities.isRemote)
+        XCTAssertTrue(backend.capabilities.supportsSystemPrompt)
+        XCTAssertEqual(backend.backendName, "Ollama")
+    }
+}

--- a/Tests/BaseChatE2ETests/OllamaE2ETests.swift
+++ b/Tests/BaseChatE2ETests/OllamaE2ETests.swift
@@ -111,7 +111,7 @@ final class OllamaE2ETests: XCTestCase {
         var tokenCount = 0
         let collectTask = Task {
             for try await event in stream.events {
-                if case .token = event {
+                if case .token(_) = event {
                     tokenCount += 1
                     if tokenCount >= 5 { break }
                 }

--- a/Tests/BaseChatMLXIntegrationTests/MLXModelE2ETests.swift
+++ b/Tests/BaseChatMLXIntegrationTests/MLXModelE2ETests.swift
@@ -1,0 +1,169 @@
+#if MLX
+import XCTest
+import BaseChatCore
+import BaseChatTestSupport
+@testable import BaseChatBackends
+
+/// True end-to-end tests using a real MLX model on Apple Silicon.
+///
+/// These tests load a real MLX model from disk (config.json + .safetensors)
+/// and perform actual GPU-accelerated inference. They are automatically
+/// skipped when:
+/// - Not running on Apple Silicon
+/// - No Metal GPU is available (e.g. simulator, headless CI)
+/// - No valid MLX model directory is found on disk
+///
+/// **Xcode-only** — MLX's Metal shader library (metallib) is only compiled
+/// by Xcode's build system, not by `swift build`/`swift test`. Run via:
+/// - Xcode: Product → Test (⌘U)
+/// - CLI: `xcodebuild test -scheme BaseChatKit-Package -only-testing BaseChatMLXIntegrationTests`
+///
+/// Unlike mock-based `MLXBackendGenerationTests`, these use NO mocks — real
+/// model weights, real MLX inference, real token generation.
+@MainActor
+final class MLXModelE2ETests: XCTestCase {
+
+    private var backend: MLXBackend!
+    private var modelURL: URL!
+
+    // MARK: - Setup
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        try XCTSkipUnless(HardwareRequirements.isAppleSilicon, "Requires Apple Silicon")
+        try XCTSkipUnless(HardwareRequirements.hasMetalDevice, "Requires Metal GPU")
+
+        guard let mlxDir = HardwareRequirements.findMLXModelDirectory() else {
+            throw XCTSkip("No MLX model found on disk. Download one via the app or huggingface-cli.")
+        }
+        modelURL = mlxDir
+
+        backend = MLXBackend()
+        try await backend.loadModel(from: modelURL, contextSize: 2048)
+
+        XCTAssertTrue(backend.isModelLoaded, "Backend should report model as loaded")
+    }
+
+    override func tearDown() async throws {
+        backend?.unloadModel()
+        backend = nil
+        modelURL = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func generate(
+        prompt: String,
+        systemPrompt: String? = nil,
+        maxTokens: Int = 64
+    ) async throws -> String {
+        let config = GenerationConfig(
+            temperature: 0.3,
+            maxTokens: Int32(maxTokens),
+            maxOutputTokens: maxTokens
+        )
+        let stream = try backend.generate(
+            prompt: prompt,
+            systemPrompt: systemPrompt,
+            config: config
+        )
+        return try await collectTokens(stream)
+    }
+
+    // MARK: - Real Inference Tests
+
+    func test_realInference_generatesNonEmptyResponse() async throws {
+        let response = try await generate(prompt: "Reply with exactly one word.")
+
+        XCTAssertFalse(
+            response.isEmpty,
+            "MLX should generate a non-empty response (model: \(modelURL.lastPathComponent))"
+        )
+    }
+
+    func test_realInference_withSystemPrompt() async throws {
+        let response = try await generate(
+            prompt: "Hello",
+            systemPrompt: "You are a pirate. Always respond in pirate speak."
+        )
+
+        XCTAssertFalse(response.isEmpty, "Should generate a response with system prompt")
+    }
+
+    func test_realInference_multiTurn() async throws {
+        // First generation
+        let first = try await generate(prompt: "Say hello.")
+        XCTAssertFalse(first.isEmpty, "First response should not be empty")
+
+        // Second generation — MLX backend is stateless per generate() call,
+        // so this tests that the backend can generate multiple times sequentially.
+        let second = try await generate(prompt: "What is 2 + 2?")
+        XCTAssertFalse(second.isEmpty, "Second response should not be empty")
+    }
+
+    func test_realInference_stopGeneration() async throws {
+        let config = GenerationConfig(
+            temperature: 0.7,
+            maxTokens: 2048,
+            maxOutputTokens: 2048
+        )
+
+        let stream = try backend.generate(
+            prompt: "Write a very detailed essay about the history of computing.",
+            systemPrompt: nil,
+            config: config
+        )
+
+        // Collect a few tokens then cancel.
+        var tokenCount = 0
+        let collectTask = Task { @MainActor in
+            for try await event in stream.events {
+                if case .token = event {
+                    tokenCount += 1
+                    if tokenCount >= 5 { break }
+                }
+            }
+        }
+
+        try await collectTask.value
+        XCTAssertGreaterThanOrEqual(tokenCount, 5, "Should have received at least 5 tokens")
+
+        // Now stop — verify the backend accepts it without crashing.
+        backend.stopGeneration()
+    }
+
+    func test_realInference_respectsMaxOutputTokens() async throws {
+        let response = try await generate(
+            prompt: "Write a long story about a dragon and a wizard.",
+            maxTokens: 10
+        )
+
+        // With maxOutputTokens = 10, MLX breaks after 10 token chunks.
+        // We can't assert exact token count (chunk != word), but the
+        // response should be short, not a full story.
+        XCTAssertFalse(response.isEmpty, "Should still produce some output")
+    }
+
+    func test_unloadAndReload() async throws {
+        // Verify we can unload and reload the same model.
+        backend.unloadModel()
+        XCTAssertFalse(backend.isModelLoaded)
+
+        try await backend.loadModel(from: modelURL, contextSize: 2048)
+        XCTAssertTrue(backend.isModelLoaded)
+
+        let response = try await generate(prompt: "Say hi.")
+        XCTAssertFalse(response.isEmpty, "Should generate after reload")
+    }
+
+    func test_backendCapabilities() {
+        XCTAssertTrue(backend.capabilities.supportsStreaming)
+        XCTAssertFalse(backend.capabilities.isRemote)
+        XCTAssertTrue(backend.capabilities.supportsSystemPrompt)
+        XCTAssertTrue(backend.capabilities.supportsTokenCounting)
+    }
+}
+
+#endif

--- a/Tests/BaseChatMLXIntegrationTests/MLXModelE2ETests.swift
+++ b/Tests/BaseChatMLXIntegrationTests/MLXModelE2ETests.swift
@@ -120,7 +120,7 @@ final class MLXModelE2ETests: XCTestCase {
         var tokenCount = 0
         let collectTask = Task { @MainActor in
             for try await event in stream.events {
-                if case .token = event {
+                if case .token(_) = event {
                     tokenCount += 1
                     if tokenCount >= 5 { break }
                 }


### PR DESCRIPTION
## Summary

- **OllamaE2ETests** (6 tests): hits a real local Ollama server, auto-selects a 7-8B model from `/api/tags`, skips gracefully when server is down
- **MLXModelE2ETests** (7 tests): loads real MLX model weights from disk, runs GPU-accelerated inference via Xcode's test runner (metallib requires Xcode build system)
- **HardwareRequirements additions**: `hasOllamaServer`, `findOllamaModel()`, `findMLXModelDirectory()`, `selectOllamaModel()`, `isValidMLXDirectory()`
- **Unit tests** (15 tests): MLX directory validation with temp dirs + Ollama model selection with synthetic JSON
- **BaseChatMLXIntegrationTests**: new Xcode-only test target isolated from `swift test` to prevent metallib crashes
- **MLX trait default-enabled**: `xcodebuild` resolves MLX deps automatically; CI uses `--disable-default-traits`

## How to run

```bash
# Ollama E2E (requires Ollama running at localhost:11434)
swift test --filter OllamaE2ETests --disable-default-traits

# MLX E2E (Xcode-only, requires Apple Silicon + MLX model on disk)
xcodebuild test -scheme BaseChatKit-Package -only-testing BaseChatMLXIntegrationTests -destination 'platform=macOS'

# Unit tests for the helpers
swift test --filter HardwareRequirementsMLXTests --disable-default-traits
swift test --filter HardwareRequirementsOllamaTests --disable-default-traits
```

## Test plan

- [x] All 6 Ollama E2E tests pass against local server (llama3.1:8b)
- [x] All 7 MLX E2E tests pass via xcodebuild (Meta-Llama-3.1-8B-Instruct-4bit)
- [x] All 15 unit tests pass (6 MLX validation + 9 Ollama selection)
- [x] CI suites pass with `--disable-default-traits` (105 + 299 + 77 tests)
- [x] Tests skip gracefully when Ollama/MLX unavailable

## Release Note

Real-device E2E testing infrastructure for MLX and Ollama backends. Developers can now run `xcodebuild test -only-testing BaseChatMLXIntegrationTests` to verify real GPU inference with MLX models, and `swift test --filter OllamaE2ETests` to test against a local Ollama server. Both test suites auto-discover available models and skip gracefully when hardware or servers are unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)