### PR TITLE
feat!: prepare public API surface for open-source release

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,24 @@
       }
     },
     {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift.git",
+      "state" : {
+        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
+        "version" : "0.31.3"
+      }
+    },
+    {
+      "identity" : "mlx-swift-lm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
+      "state" : {
+        "revision" : "25b00d4e22e61ec9c41efda47990cd2084ec87ff",
+        "version" : "2.31.3"
+      }
+    },
+    {
       "identity" : "swift-asn1",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
@@ -65,12 +83,30 @@
       }
     },
     {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
+        "version" : "2.3.5"
+      }
+    },
+    {
       "identity" : "swift-nio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
         "revision" : "558f24a4647193b5a0e2104031b71c55d31ff83a",
         "version" : "2.97.1"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
       }
     },
     {
@@ -101,12 +137,30 @@
       }
     },
     {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers",
+      "state" : {
+        "revision" : "58c4bc11963a140358d791f678a60a2745a23146",
+        "version" : "1.2.1"
+      }
+    },
+    {
       "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
         "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
         "version" : "1.9.0"
+      }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "bf3a6192adf8b60c579c135ebfae13e49da37ba3f9246c6cde590fb633c5155a",
+  "originHash" : "9fa99d330dfc1bf6c292f67b019f7482ceea8eb502c0b2b3829cd7c49929d202",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -8,33 +8,6 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "llama.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattt/llama.swift",
-      "state" : {
-        "revision" : "80abe47d1475ca23a93eb102eb6e90793c807640",
-        "version" : "2.8705.0"
-      }
-    },
-    {
-      "identity" : "mlx-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift.git",
-      "state" : {
-        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
-        "version" : "0.31.3"
-      }
-    },
-    {
-      "identity" : "mlx-swift-lm",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
-      "state" : {
-        "revision" : "25b00d4e22e61ec9c41efda47990cd2084ec87ff",
-        "version" : "2.31.3"
       }
     },
     {
@@ -92,30 +65,12 @@
       }
     },
     {
-      "identity" : "swift-jinja",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-jinja.git",
-      "state" : {
-        "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
-        "version" : "2.3.5"
-      }
-    },
-    {
       "identity" : "swift-nio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
         "revision" : "558f24a4647193b5a0e2104031b71c55d31ff83a",
         "version" : "2.97.1"
-      }
-    },
-    {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics",
-      "state" : {
-        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
-        "version" : "1.1.1"
       }
     },
     {
@@ -146,30 +101,12 @@
       }
     },
     {
-      "identity" : "swift-transformers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-transformers",
-      "state" : {
-        "revision" : "58c4bc11963a140358d791f678a60a2745a23146",
-        "version" : "1.2.1"
-      }
-    },
-    {
       "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
         "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
         "version" : "1.9.0"
-      }
-    },
-    {
-      "identity" : "yyjson",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ibireme/yyjson.git",
-      "state" : {
-        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
-        "version" : "0.12.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,6 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/ml-explore/mlx-swift.git", from: "0.31.3"),
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", from: "2.31.3"),
-        .package(url: "https://github.com/huggingface/swift-transformers.git", from: "1.2.0"),
         .package(url: "https://github.com/huggingface/swift-huggingface.git", from: "0.9.0"),
         .package(url: "https://github.com/mattt/llama.swift", from: "2.8672.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.0"),
@@ -90,7 +89,8 @@ let package = Package(
                 "BaseChatUI",
                 "BaseChatCore",
                 .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
-            ]
+            ],
+            exclude: ["__Snapshots__"]
         ),
         // Xcode-only: real MLX model inference requiring Metal shader library.
         // Cannot run via `swift test` — MLX's metallib is only compiled by Xcode.

--- a/README.md
+++ b/README.md
@@ -6,16 +6,6 @@ BaseChatKit provides a complete, production-ready chat UI with pluggable inferen
 
 ## Demo
 
-<!-- TODO: Replace these placeholders with actual screenshots captured from the Example app.
-     Capture instructions:
-       1. Run the Example app in the iOS Simulator
-       2. Use `xcrun simctl io booted screenshot Example/Screenshots/demo.png`
-          or record a GIF with QuickTime + Gifski (~10-15 seconds, ~600px wide)
-       3. Capture: a chat conversation mid-stream, the session list sidebar,
-          and the model management sheet / HuggingFace browser tab
-       4. Optimise the image and commit it to Example/Screenshots/
-       5. Update the image path below and remove this comment block
-     Optionally add both light and dark mode screenshots side by side. -->
 
 ![BaseChatKit demo — chat conversation with streaming, session sidebar, and model browser](Example/Screenshots/demo.png)
 

--- a/Sources/BaseChatCore/ModelContainerFactory.swift
+++ b/Sources/BaseChatCore/ModelContainerFactory.swift
@@ -12,9 +12,9 @@ import SwiftData
 /// // In-memory store (tests, previews, ephemeral sessions)
 /// let container = try ModelContainerFactory.makeInMemoryContainer()
 /// ```
-package enum ModelContainerFactory {
+public enum ModelContainerFactory {
     /// The newest schema version that should be opened for application stores.
-    package static var currentSchema: any VersionedSchema.Type {
+    public static var currentSchema: any VersionedSchema.Type {
         BaseChatMigrationPlan.schemas.last ?? BaseChatSchemaV1.self
     }
 
@@ -24,7 +24,7 @@ package enum ModelContainerFactory {
     ///   pass to `ModelContainer`. Defaults to a single default (on-disk) config.
     /// - Returns: A `ModelContainer` whose store will be automatically migrated.
     /// - Throws: If `ModelContainer` initialisation fails.
-    package static func makeContainer(
+    public static func makeContainer(
         configurations: [ModelConfiguration] = [ModelConfiguration()]
     ) throws -> ModelContainer {
         try ModelContainer(
@@ -42,7 +42,7 @@ package enum ModelContainerFactory {
     ///
     /// - Returns: An in-memory `ModelContainer`.
     /// - Throws: If `ModelContainer` initialisation fails.
-    package static func makeInMemoryContainer() throws -> ModelContainer {
+    public static func makeInMemoryContainer() throws -> ModelContainer {
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         return try makeContainer(configurations: [config])
     }

--- a/Sources/BaseChatCore/ModelContainerFactory.swift
+++ b/Sources/BaseChatCore/ModelContainerFactory.swift
@@ -12,9 +12,9 @@ import SwiftData
 /// // In-memory store (tests, previews, ephemeral sessions)
 /// let container = try ModelContainerFactory.makeInMemoryContainer()
 /// ```
-public enum ModelContainerFactory {
+package enum ModelContainerFactory {
     /// The newest schema version that should be opened for application stores.
-    public static var currentSchema: any VersionedSchema.Type {
+    package static var currentSchema: any VersionedSchema.Type {
         BaseChatMigrationPlan.schemas.last ?? BaseChatSchemaV1.self
     }
 
@@ -24,7 +24,7 @@ public enum ModelContainerFactory {
     ///   pass to `ModelContainer`. Defaults to a single default (on-disk) config.
     /// - Returns: A `ModelContainer` whose store will be automatically migrated.
     /// - Throws: If `ModelContainer` initialisation fails.
-    public static func makeContainer(
+    package static func makeContainer(
         configurations: [ModelConfiguration] = [ModelConfiguration()]
     ) throws -> ModelContainer {
         try ModelContainer(
@@ -42,7 +42,7 @@ public enum ModelContainerFactory {
     ///
     /// - Returns: An in-memory `ModelContainer`.
     /// - Throws: If `ModelContainer` initialisation fails.
-    public static func makeInMemoryContainer() throws -> ModelContainer {
+    package static func makeInMemoryContainer() throws -> ModelContainer {
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         return try makeContainer(configurations: [config])
     }

--- a/Sources/BaseChatCore/Services/BackgroundDownloadManager.swift
+++ b/Sources/BaseChatCore/Services/BackgroundDownloadManager.swift
@@ -34,7 +34,11 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable {
     /// Setter is `internal` (not `private`) so tests can inject state via `@testable import`.
     public internal(set) var activeDownloads: [String: DownloadState] = [:]
 
-    /// Whether any download is currently in progress.
+    /// Whether any download is currently queued or actively transferring data.
+    ///
+    /// Returns `true` if at least one entry in ``activeDownloads`` has a status of
+    /// `.queued` or `.downloading`. Completed, failed, and cancelled downloads are
+    /// not counted.
     public var hasActiveDownloads: Bool {
         activeDownloads.values.contains { state in
             switch state.status {

--- a/Sources/BaseChatCore/Services/CachingTokenizer.swift
+++ b/Sources/BaseChatCore/Services/CachingTokenizer.swift
@@ -13,17 +13,17 @@ import Foundation
 /// let tok = CachingTokenizer(wrapping: activeTokenizer ?? HeuristicTokenizer())
 /// // Pass tok wherever a TokenizerProvider is accepted.
 /// ```
-public final class CachingTokenizer: TokenizerProvider, @unchecked Sendable {
+package final class CachingTokenizer: TokenizerProvider, @unchecked Sendable {
 
     private let base: TokenizerProvider
     private var cache: [String: Int] = [:]
     private let lock = NSLock()
 
-    public init(wrapping base: TokenizerProvider) {
+    package init(wrapping base: TokenizerProvider) {
         self.base = base
     }
 
-    public func tokenCount(_ text: String) -> Int {
+    package func tokenCount(_ text: String) -> Int {
         lock.lock()
         defer { lock.unlock() }
         if let cached = cache[text] { return cached }

--- a/Sources/BaseChatCore/Services/Compression/AnchoredCompressor.swift
+++ b/Sources/BaseChatCore/Services/Compression/AnchoredCompressor.swift
@@ -3,22 +3,22 @@ import Foundation
 /// Compressor that summarizes old messages via an inference call, then prepends the
 /// summary to a verbatim tail of recent messages. Falls back to ``ExtractiveCompressor``
 /// on any error (missing generate function, failed inference, oversized summary).
-public final class AnchoredCompressor: ContextCompressor, @unchecked Sendable {
-    public let strategyName = "anchored"
+package final class AnchoredCompressor: ContextCompressor, @unchecked Sendable {
+    package let strategyName = "anchored"
 
     /// Fraction of the history budget reserved for the verbatim recent tail.
-    public let tailBudgetFraction: Double
+    package let tailBudgetFraction: Double
 
     /// Injected by the caller; performs a single-turn inference call for summarization.
     /// Must be set before the first call to `compress()`. Not safe to mutate while
     /// `compress()` is in flight.
-    public var generateFn: (@Sendable (String) async throws -> String)?
+    package var generateFn: (@Sendable (String) async throws -> String)?
 
     private let fallback = ExtractiveCompressor()
 
     // MARK: - Summary Prompt Template
 
-    public static let defaultSummaryTemplate: String = """
+    package static let defaultSummaryTemplate: String = """
         Summarize the conversation so far. Be concise. Use only what is in the text.
 
         TOPIC: [main subject of the conversation, brief]
@@ -33,9 +33,9 @@ public final class AnchoredCompressor: ContextCompressor, @unchecked Sendable {
     /// The prompt template used to summarize old messages.
     /// Pass a domain-specific prompt at init time to override.
     /// The placeholder `{old_nodes_text}` is replaced with the concatenated message content.
-    public let summaryTemplate: String
+    package let summaryTemplate: String
 
-    public init(
+    package init(
         tailBudgetFraction: Double = 0.50,
         summaryTemplate: String? = nil
     ) {
@@ -45,7 +45,7 @@ public final class AnchoredCompressor: ContextCompressor, @unchecked Sendable {
 
     // MARK: - ContextCompressor
 
-    public func compress(
+    package func compress(
         messages: [CompressibleMessage],
         systemPrompt: String?,
         contextSize: Int,

--- a/Sources/BaseChatCore/Services/Compression/CompressionOrchestrator.swift
+++ b/Sources/BaseChatCore/Services/Compression/CompressionOrchestrator.swift
@@ -7,15 +7,15 @@ import Foundation
 /// (higher quality, requires a generate function) based on the active mode and
 /// available capabilities.
 @MainActor
-public final class CompressionOrchestrator {
+package final class CompressionOrchestrator {
 
     /// The user-selected compression mode. Defaults to automatic.
-    public var mode: CompressionMode = .automatic
+    package var mode: CompressionMode = .automatic
 
-    public let extractive: ExtractiveCompressor
-    public let anchored: AnchoredCompressor
+    package let extractive: ExtractiveCompressor
+    package let anchored: AnchoredCompressor
 
-    public init(
+    package init(
         extractive: ExtractiveCompressor = ExtractiveCompressor(),
         anchored: AnchoredCompressor = AnchoredCompressor()
     ) {
@@ -29,7 +29,7 @@ public final class CompressionOrchestrator {
     ///
     /// Larger context windows can afford to wait longer before compressing,
     /// so the threshold is higher for models with more than 16k tokens.
-    public func compressionThreshold(for contextSize: Int) -> Double {
+    package func compressionThreshold(for contextSize: Int) -> Double {
         contextSize > 16_000 ? 0.85 : 0.75
     }
 
@@ -37,7 +37,7 @@ public final class CompressionOrchestrator {
 
     /// Determines whether the current conversation history is large enough to
     /// warrant compression given the active mode and context window.
-    public func shouldCompress(
+    package func shouldCompress(
         messages: [CompressibleMessage],
         systemPrompt: String?,
         contextSize: Int,
@@ -63,7 +63,7 @@ public final class CompressionOrchestrator {
     ///
     /// Strategy routing depends on the current ``mode``, the model's context size,
     /// and whether `AnchoredCompressor` has a generate function configured.
-    public func compress(
+    package func compress(
         messages: [CompressibleMessage],
         systemPrompt: String?,
         contextSize: Int,

--- a/Sources/BaseChatCore/Services/Compression/ExtractiveCompressor.swift
+++ b/Sources/BaseChatCore/Services/Compression/ExtractiveCompressor.swift
@@ -6,22 +6,22 @@ import Foundation
 ///
 /// The newest messages are always kept verbatim (the "tail"), and pinned messages are
 /// never evicted. Remaining messages compete for the leftover budget by score.
-public final class ExtractiveCompressor: ContextCompressor, @unchecked Sendable {
-    public let strategyName = "extractive"
+package final class ExtractiveCompressor: ContextCompressor, @unchecked Sendable {
+    package let strategyName = "extractive"
 
     /// Fraction of the history budget reserved for the verbatim tail (newest messages).
-    public let tailBudgetFraction: Double
+    package let tailBudgetFraction: Double
 
     /// Weight for how recently a message appears in the conversation.
-    public let recencyWeight: Double
+    package let recencyWeight: Double
 
     /// Weight for message content length (longer messages carry more narrative).
-    public let lengthWeight: Double
+    package let lengthWeight: Double
 
     /// Weight for capitalized-word density (proxy for proper noun / keyword richness).
-    public let keywordDensityWeight: Double
+    package let keywordDensityWeight: Double
 
-    public init(
+    package init(
         tailBudgetFraction: Double = 0.40,
         recencyWeight: Double = 0.5,
         lengthWeight: Double = 0.3,
@@ -35,7 +35,7 @@ public final class ExtractiveCompressor: ContextCompressor, @unchecked Sendable 
 
     // MARK: - ContextCompressor
 
-    public nonisolated func compress(
+    package nonisolated func compress(
         messages: [CompressibleMessage],
         systemPrompt: String?,
         contextSize: Int,

--- a/Sources/BaseChatCore/Services/GGUFMetadataReader.swift
+++ b/Sources/BaseChatCore/Services/GGUFMetadataReader.swift
@@ -5,14 +5,14 @@ import os
 ///
 /// Contains the subset of GGUF metadata fields relevant to inference:
 /// model name, architecture, context length, chat template, and file type (quantization).
-public struct GGUFMetadata: Sendable, Equatable {
-    public let generalName: String?
-    public let generalArchitecture: String?
-    public let contextLength: Int?
-    public let chatTemplate: String?
-    public let fileType: Int?
+struct GGUFMetadata: Sendable, Equatable {
+    let generalName: String?
+    let generalArchitecture: String?
+    let contextLength: Int?
+    let chatTemplate: String?
+    let fileType: Int?
 
-    public init(
+    init(
         generalName: String?,
         generalArchitecture: String?,
         contextLength: Int?,
@@ -28,12 +28,12 @@ public struct GGUFMetadata: Sendable, Equatable {
 }
 
 /// Errors that can occur when reading GGUF metadata.
-public enum GGUFReaderError: LocalizedError {
+enum GGUFReaderError: LocalizedError {
     case invalidMagic
     case unsupportedVersion(Int)
     case readError(String)
 
-    public var errorDescription: String? {
+    var errorDescription: String? {
         switch self {
         case .invalidMagic:
             "File is not a valid GGUF file (invalid magic bytes)"
@@ -50,7 +50,7 @@ public enum GGUFReaderError: LocalizedError {
 /// Only reads the metadata key-value section at the start of the file. Tensor data
 /// (which can be many gigabytes) is never touched. Uses `FileHandle` for sequential
 /// reads to avoid loading the file into memory.
-public struct GGUFMetadataReader {
+struct GGUFMetadataReader {
 
     /// The four-byte magic at offset 0 of every GGUF file.
     private static let magicBytes: [UInt8] = [0x47, 0x47, 0x55, 0x46] // "GGUF"
@@ -82,7 +82,7 @@ public struct GGUFMetadataReader {
     /// - Parameter url: Path to a `.gguf` file on disk.
     /// - Returns: Parsed metadata fields.
     /// - Throws: `GGUFReaderError` if the file is invalid or unreadable.
-    public static func readMetadata(from url: URL) throws -> GGUFMetadata {
+    static func readMetadata(from url: URL) throws -> GGUFMetadata {
         let handle: FileHandle
         do {
             handle = try FileHandle(forReadingFrom: url)
@@ -174,7 +174,7 @@ public struct GGUFMetadataReader {
     ///
     /// - Parameter url: Path to check.
     /// - Returns: `true` if the first 4 bytes are the GGUF magic.
-    public static func isValidGGUF(at url: URL) -> Bool {
+    static func isValidGGUF(at url: URL) -> Bool {
         guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
         defer { handle.closeFile() }
 

--- a/Sources/BaseChatCore/Services/HeuristicTokenizer.swift
+++ b/Sources/BaseChatCore/Services/HeuristicTokenizer.swift
@@ -4,10 +4,10 @@ import Foundation
 ///
 /// This matches the heuristic already used by ``ContextWindowManager`` and is suitable
 /// as a fallback when no model-specific tokenizer is available.
-public struct HeuristicTokenizer: TokenizerProvider {
-    public init() {}
+package struct HeuristicTokenizer: TokenizerProvider {
+    package init() {}
 
-    public func tokenCount(_ text: String) -> Int {
+    package func tokenCount(_ text: String) -> Int {
         max(1, text.count / 4)
     }
 }

--- a/Sources/BaseChatCore/Services/HuggingFaceService.swift
+++ b/Sources/BaseChatCore/Services/HuggingFaceService.swift
@@ -35,6 +35,10 @@ public final class HuggingFaceService: HuggingFaceServiceProtocol {
 
     private let hubClient: HubClient
 
+    /// Creates a service backed by the given Hugging Face Hub client.
+    ///
+    /// - Parameter hubClient: The Hub client used for API requests and repo operations.
+    ///   Defaults to `.default`, which uses the shared Hub configuration.
     public init(hubClient: HubClient = .default) {
         self.hubClient = hubClient
     }

--- a/Sources/BaseChatCore/Services/InferenceError.swift
+++ b/Sources/BaseChatCore/Services/InferenceError.swift
@@ -28,6 +28,11 @@ public enum InferenceError: LocalizedError {
         }
     }
 
+    /// Whether this error represents a transient condition that may succeed on retry.
+    ///
+    /// Currently only ``alreadyGenerating`` is retryable -- the caller can wait for the
+    /// in-flight generation to finish and try again. All other cases indicate permanent
+    /// failures (missing model, OOM, etc.).
     public var isRetryable: Bool {
         switch self {
         case .alreadyGenerating:

--- a/Sources/BaseChatCore/Services/MemoryPressureHandler.swift
+++ b/Sources/BaseChatCore/Services/MemoryPressureHandler.swift
@@ -19,12 +19,12 @@ public enum MemoryPressureLevel: String, Sendable {
 ///
 /// Uses `DispatchSource.makeMemoryPressureSource`, which works identically on iOS and macOS.
 @Observable
-public final class MemoryPressureHandler: @unchecked Sendable {
+package final class MemoryPressureHandler: @unchecked Sendable {
 
     // MARK: - Published State
 
     /// The current memory pressure level reported by the OS.
-    public internal(set) var pressureLevel: MemoryPressureLevel = .nominal
+    package internal(set) var pressureLevel: MemoryPressureLevel = .nominal
 
     // MARK: - Private State
 
@@ -39,7 +39,7 @@ public final class MemoryPressureHandler: @unchecked Sendable {
 
     // MARK: - Lifecycle
 
-    public init() {}
+    package init() {}
 
     deinit {
         stopMonitoring()
@@ -50,7 +50,7 @@ public final class MemoryPressureHandler: @unchecked Sendable {
     /// Begins listening for memory pressure notifications from the OS.
     ///
     /// Safe to call multiple times -- subsequent calls are no-ops while monitoring is active.
-    public func startMonitoring() {
+    package func startMonitoring() {
         guard source == nil else { return }
 
         let newSource = DispatchSource.makeMemoryPressureSource(
@@ -94,7 +94,7 @@ public final class MemoryPressureHandler: @unchecked Sendable {
     /// Stops listening for memory pressure notifications.
     ///
     /// Safe to call multiple times -- subsequent calls are no-ops if not monitoring.
-    public func stopMonitoring() {
+    package func stopMonitoring() {
         source?.cancel()
         source = nil
     }

--- a/Sources/BaseChatCore/Services/NetworkDiscoveryService.swift
+++ b/Sources/BaseChatCore/Services/NetworkDiscoveryService.swift
@@ -54,6 +54,11 @@ public actor NetworkDiscoveryService: ServerDiscoveryService {
         }
     }
 
+    /// Scans known local ports for running inference servers and yields any discovered endpoints.
+    ///
+    /// Probes Ollama (11434), KoboldCpp (5001), and LM Studio (1234) in sequence.
+    /// Results are delivered through ``discoveredServers``. Safe to call while a scan
+    /// is already running -- subsequent calls are no-ops until the first completes.
     public func startDiscovery() async {
         let alreadyScanning = scanningLock.withLock { state -> Bool in
             if state { return true }
@@ -77,10 +82,19 @@ public actor NetworkDiscoveryService: ServerDiscoveryService {
         scanningLock.withLock { $0 = false }
     }
 
+    /// Cancels any in-progress discovery scan.
+    ///
+    /// Does not invalidate the ``discoveredServers`` stream -- previously yielded
+    /// results remain available. Safe to call when no scan is active.
     public nonisolated func stopDiscovery() {
         scanningLock.withLock { $0 = false }
     }
 
+    /// Probes a single host/port combination for an inference server.
+    ///
+    /// If the port matches a known server (Ollama, KoboldCpp, LM Studio), uses the
+    /// server-specific health endpoint. Otherwise falls back to the OpenAI-compatible
+    /// `/v1/models` endpoint. Returns `nil` if no server responds.
     public func probe(host: String, port: Int) async -> DiscoveredServer? {
         // Check if this matches a known server port
         if let known = Self.knownServers.first(where: { $0.port == port }) {

--- a/Sources/BaseChatCore/Services/PromptTemplateDetector.swift
+++ b/Sources/BaseChatCore/Services/PromptTemplateDetector.swift
@@ -7,13 +7,13 @@ import Foundation
 /// 2. If architecture is known (e.g. "llama", "phi"), map it to a template.
 /// 3. If only the model name is available, use keyword heuristics.
 /// 4. Falls back to ChatML (the most widely compatible format).
-public struct PromptTemplateDetector {
+struct PromptTemplateDetector {
 
     /// Detects the best prompt template from GGUF metadata.
     ///
     /// Tries chat template first (most reliable), then architecture, then model name.
     /// Returns `.chatML` as a safe default if nothing matches.
-    public static func detect(from metadata: GGUFMetadata) -> PromptTemplate {
+    static func detect(from metadata: GGUFMetadata) -> PromptTemplate {
         // 1. Try chat template string first (most reliable)
         if let chatTemplate = metadata.chatTemplate {
             return detect(fromChatTemplate: chatTemplate)
@@ -34,7 +34,7 @@ public struct PromptTemplateDetector {
     /// Looks for unique token markers that identify each format. Order matters:
     /// more specific patterns (ChatML, Llama 3, Gemma) are checked before broader
     /// ones (Mistral `[INST]`, Alpaca `### Instruction`).
-    public static func detect(fromChatTemplate template: String) -> PromptTemplate {
+    static func detect(fromChatTemplate template: String) -> PromptTemplate {
         if template.contains("<|im_start|>") { return .chatML }
         if template.contains("<|start_header_id|>") { return .llama3 }
         if template.contains("<start_of_turn>") { return .gemma }
@@ -47,7 +47,7 @@ public struct PromptTemplateDetector {
     /// Detects a prompt template from the GGUF `general.architecture` field.
     ///
     /// Maps known architecture identifiers to their canonical prompt formats.
-    public static func detect(fromArchitecture arch: String) -> PromptTemplate {
+    static func detect(fromArchitecture arch: String) -> PromptTemplate {
         switch arch.lowercased() {
         case "mistral": return .mistral
         case "gemma", "gemma2": return .gemma
@@ -62,7 +62,7 @@ public struct PromptTemplateDetector {
     ///
     /// Least reliable strategy -- only used as a last resort when neither a chat
     /// template nor architecture string is available.
-    public static func detect(fromFileName name: String) -> PromptTemplate {
+    static func detect(fromFileName name: String) -> PromptTemplate {
         let lower = name.lowercased()
         if lower.contains("llama") { return .llama3 }
         if lower.contains("mistral") { return .mistral }

--- a/Sources/BaseChatCore/Services/RetryPolicy.swift
+++ b/Sources/BaseChatCore/Services/RetryPolicy.swift
@@ -142,7 +142,7 @@ public func withRetry<T>(
 ///
 /// Convenience wrapper around ``withRetry(strategy:operation:)`` using
 /// ``ExponentialBackoffStrategy``.
-public func withExponentialBackoff<T>(
+func withExponentialBackoff<T>(
     maxRetries: Int = 3,
     baseDelay: TimeInterval = 1.0,
     maxTotalDelay: TimeInterval = 60.0,

--- a/Sources/BaseChatCore/Services/SSEStreamParser.swift
+++ b/Sources/BaseChatCore/Services/SSEStreamParser.swift
@@ -29,13 +29,13 @@ public protocol SSEPayloadHandler: Sendable {
     func extractStreamError(from payload: String) -> Error?
 }
 
-public struct SSEStreamParser {
+package struct SSEStreamParser {
 
     /// Parses an `AsyncSequence` of bytes into an `AsyncThrowingStream` of SSE data lines.
     ///
     /// Yields the payload of each `data:` line (with the prefix stripped).
     /// Stops when the stream ends or when `[DONE]` is received.
-    public static func parse<S: AsyncSequence & Sendable>(
+    package static func parse<S: AsyncSequence & Sendable>(
         bytes: S
     ) -> AsyncThrowingStream<String, Error> where S.Element == UInt8 {
         AsyncThrowingStream { continuation in
@@ -107,7 +107,7 @@ public struct SSEStreamParser {
     ///   - bytes: The raw byte stream from `URLSession.bytes(for:)`.
     ///   - handler: A payload handler that interprets the provider's JSON format.
     /// - Returns: An `AsyncThrowingStream` of ``GenerationEvent`` values.
-    public static func streamEvents<S: AsyncSequence & Sendable>(
+    package static func streamEvents<S: AsyncSequence & Sendable>(
         from bytes: S,
         using handler: some SSEPayloadHandler
     ) -> AsyncThrowingStream<GenerationEvent, Error> where S.Element == UInt8 {

--- a/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
+++ b/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
@@ -7,17 +7,17 @@ import SwiftData
 /// SwiftData `@Model` objects and plain ``ChatSessionRecord`` / ``ChatMessageRecord``
 /// value types at the boundary.
 @MainActor
-package final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
+public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
 
     private let modelContext: ModelContext
 
-    package init(modelContext: ModelContext) {
+    public init(modelContext: ModelContext) {
         self.modelContext = modelContext
     }
 
     // MARK: - Sessions
 
-    package func insertSession(_ record: ChatSessionRecord) throws {
+    public func insertSession(_ record: ChatSessionRecord) throws {
         let session = ChatSession(title: record.title)
         session.id = record.id
         session.createdAt = record.createdAt
@@ -36,7 +36,7 @@ package final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         try modelContext.save()
     }
 
-    package func updateSession(_ record: ChatSessionRecord) throws {
+    public func updateSession(_ record: ChatSessionRecord) throws {
         guard let session = try fetchSwiftDataSession(id: record.id) else {
             throw ChatPersistenceError.sessionNotFound(record.id)
         }
@@ -55,7 +55,7 @@ package final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         try modelContext.save()
     }
 
-    package func deleteSession(_ sessionID: UUID) throws {
+    public func deleteSession(_ sessionID: UUID) throws {
         guard let session = try fetchSwiftDataSession(id: sessionID) else {
             throw ChatPersistenceError.sessionNotFound(sessionID)
         }
@@ -64,7 +64,7 @@ package final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         try modelContext.save()
     }
 
-    package func fetchSessions() throws -> [ChatSessionRecord] {
+    public func fetchSessions() throws -> [ChatSessionRecord] {
         let descriptor = FetchDescriptor<ChatSession>(
             sortBy: [SortDescriptor(\.updatedAt, order: .reverse)]
         )
@@ -73,7 +73,7 @@ package final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
 
     // MARK: - Messages
 
-    package func insertMessage(_ record: ChatMessageRecord) throws {
+    public func insertMessage(_ record: ChatMessageRecord) throws {
         let message = ChatMessage(role: record.role, contentParts: record.contentParts, sessionID: record.sessionID)
         message.id = record.id
         message.timestamp = record.timestamp
@@ -83,7 +83,7 @@ package final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         try modelContext.save()
     }
 
-    package func updateMessage(_ record: ChatMessageRecord) throws {
+    public func updateMessage(_ record: ChatMessageRecord) throws {
         guard let message = try fetchSwiftDataMessage(id: record.id) else {
             throw ChatPersistenceError.messageNotFound(record.id)
         }
@@ -93,7 +93,7 @@ package final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         try modelContext.save()
     }
 
-    package func deleteMessage(_ messageID: UUID) throws {
+    public func deleteMessage(_ messageID: UUID) throws {
         guard let message = try fetchSwiftDataMessage(id: messageID) else {
             throw ChatPersistenceError.messageNotFound(messageID)
         }
@@ -101,7 +101,7 @@ package final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         try modelContext.save()
     }
 
-    package func fetchMessages(for sessionID: UUID) throws -> [ChatMessageRecord] {
+    public func fetchMessages(for sessionID: UUID) throws -> [ChatMessageRecord] {
         let descriptor = FetchDescriptor<ChatMessage>(
             predicate: #Predicate { $0.sessionID == sessionID },
             sortBy: [SortDescriptor(\.timestamp)]
@@ -109,7 +109,7 @@ package final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         return try modelContext.fetch(descriptor).map { $0.toRecord() }
     }
 
-    package func fetchRecentMessages(for sessionID: UUID, limit: Int) throws -> [ChatMessageRecord] {
+    public func fetchRecentMessages(for sessionID: UUID, limit: Int) throws -> [ChatMessageRecord] {
         // Fetch newest-first, take `limit`, then reverse to ascending order.
         var descriptor = FetchDescriptor<ChatMessage>(
             predicate: #Predicate { $0.sessionID == sessionID },
@@ -120,7 +120,7 @@ package final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         return results.reversed().map { $0.toRecord() }
     }
 
-    package func fetchMessages(for sessionID: UUID, before: Date, limit: Int) throws -> [ChatMessageRecord] {
+    public func fetchMessages(for sessionID: UUID, before: Date, limit: Int) throws -> [ChatMessageRecord] {
         // Fetch messages older than `before`, newest-first, take `limit`, then reverse.
         var descriptor = FetchDescriptor<ChatMessage>(
             predicate: #Predicate { $0.sessionID == sessionID && $0.timestamp < before },
@@ -131,7 +131,7 @@ package final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         return results.reversed().map { $0.toRecord() }
     }
 
-    package func deleteMessages(for sessionID: UUID) throws {
+    public func deleteMessages(for sessionID: UUID) throws {
         let descriptor = FetchDescriptor<ChatMessage>(
             predicate: #Predicate { $0.sessionID == sessionID }
         )

--- a/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
+++ b/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
@@ -7,17 +7,17 @@ import SwiftData
 /// SwiftData `@Model` objects and plain ``ChatSessionRecord`` / ``ChatMessageRecord``
 /// value types at the boundary.
 @MainActor
-public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
+package final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
 
     private let modelContext: ModelContext
 
-    public init(modelContext: ModelContext) {
+    package init(modelContext: ModelContext) {
         self.modelContext = modelContext
     }
 
     // MARK: - Sessions
 
-    public func insertSession(_ record: ChatSessionRecord) throws {
+    package func insertSession(_ record: ChatSessionRecord) throws {
         let session = ChatSession(title: record.title)
         session.id = record.id
         session.createdAt = record.createdAt
@@ -36,7 +36,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         try modelContext.save()
     }
 
-    public func updateSession(_ record: ChatSessionRecord) throws {
+    package func updateSession(_ record: ChatSessionRecord) throws {
         guard let session = try fetchSwiftDataSession(id: record.id) else {
             throw ChatPersistenceError.sessionNotFound(record.id)
         }
@@ -55,7 +55,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         try modelContext.save()
     }
 
-    public func deleteSession(_ sessionID: UUID) throws {
+    package func deleteSession(_ sessionID: UUID) throws {
         guard let session = try fetchSwiftDataSession(id: sessionID) else {
             throw ChatPersistenceError.sessionNotFound(sessionID)
         }
@@ -64,7 +64,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         try modelContext.save()
     }
 
-    public func fetchSessions() throws -> [ChatSessionRecord] {
+    package func fetchSessions() throws -> [ChatSessionRecord] {
         let descriptor = FetchDescriptor<ChatSession>(
             sortBy: [SortDescriptor(\.updatedAt, order: .reverse)]
         )
@@ -73,7 +73,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
 
     // MARK: - Messages
 
-    public func insertMessage(_ record: ChatMessageRecord) throws {
+    package func insertMessage(_ record: ChatMessageRecord) throws {
         let message = ChatMessage(role: record.role, contentParts: record.contentParts, sessionID: record.sessionID)
         message.id = record.id
         message.timestamp = record.timestamp
@@ -83,7 +83,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         try modelContext.save()
     }
 
-    public func updateMessage(_ record: ChatMessageRecord) throws {
+    package func updateMessage(_ record: ChatMessageRecord) throws {
         guard let message = try fetchSwiftDataMessage(id: record.id) else {
             throw ChatPersistenceError.messageNotFound(record.id)
         }
@@ -93,7 +93,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         try modelContext.save()
     }
 
-    public func deleteMessage(_ messageID: UUID) throws {
+    package func deleteMessage(_ messageID: UUID) throws {
         guard let message = try fetchSwiftDataMessage(id: messageID) else {
             throw ChatPersistenceError.messageNotFound(messageID)
         }
@@ -101,7 +101,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         try modelContext.save()
     }
 
-    public func fetchMessages(for sessionID: UUID) throws -> [ChatMessageRecord] {
+    package func fetchMessages(for sessionID: UUID) throws -> [ChatMessageRecord] {
         let descriptor = FetchDescriptor<ChatMessage>(
             predicate: #Predicate { $0.sessionID == sessionID },
             sortBy: [SortDescriptor(\.timestamp)]
@@ -109,7 +109,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         return try modelContext.fetch(descriptor).map { $0.toRecord() }
     }
 
-    public func fetchRecentMessages(for sessionID: UUID, limit: Int) throws -> [ChatMessageRecord] {
+    package func fetchRecentMessages(for sessionID: UUID, limit: Int) throws -> [ChatMessageRecord] {
         // Fetch newest-first, take `limit`, then reverse to ascending order.
         var descriptor = FetchDescriptor<ChatMessage>(
             predicate: #Predicate { $0.sessionID == sessionID },
@@ -120,7 +120,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         return results.reversed().map { $0.toRecord() }
     }
 
-    public func fetchMessages(for sessionID: UUID, before: Date, limit: Int) throws -> [ChatMessageRecord] {
+    package func fetchMessages(for sessionID: UUID, before: Date, limit: Int) throws -> [ChatMessageRecord] {
         // Fetch messages older than `before`, newest-first, take `limit`, then reverse.
         var descriptor = FetchDescriptor<ChatMessage>(
             predicate: #Predicate { $0.sessionID == sessionID && $0.timestamp < before },
@@ -131,7 +131,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         return results.reversed().map { $0.toRecord() }
     }
 
-    public func deleteMessages(for sessionID: UUID) throws {
+    package func deleteMessages(for sessionID: UUID) throws {
         let descriptor = FetchDescriptor<ChatMessage>(
             predicate: #Predicate { $0.sessionID == sessionID }
         )
@@ -162,7 +162,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
 
 extension ChatSession {
     /// Converts a SwiftData model to a plain record.
-    public func toRecord() -> ChatSessionRecord {
+    func toRecord() -> ChatSessionRecord {
         ChatSessionRecord(
             id: id,
             title: title,
@@ -184,7 +184,7 @@ extension ChatSession {
 
 extension ChatMessage {
     /// Converts a SwiftData model to a plain record.
-    public func toRecord() -> ChatMessageRecord {
+    func toRecord() -> ChatMessageRecord {
         ChatMessageRecord(
             id: id,
             role: role,

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -339,11 +339,24 @@ public final class ChatViewModel {
 
     // MARK: - Initialisation
 
-    public init(
+    public convenience init(
+        inferenceService: InferenceService = InferenceService(),
+        deviceCapability: DeviceCapabilityService = DeviceCapabilityService(),
+        modelStorage: ModelStorageService = ModelStorageService()
+    ) {
+        self.init(
+            inferenceService: inferenceService,
+            deviceCapability: deviceCapability,
+            modelStorage: modelStorage,
+            memoryPressure: MemoryPressureHandler()
+        )
+    }
+
+    package init(
         inferenceService: InferenceService = InferenceService(),
         deviceCapability: DeviceCapabilityService = DeviceCapabilityService(),
         modelStorage: ModelStorageService = ModelStorageService(),
-        memoryPressure: MemoryPressureHandler = MemoryPressureHandler()
+        memoryPressure: MemoryPressureHandler
     ) {
         self.inferenceService = inferenceService
         self.deviceCapability = deviceCapability

--- a/Tests/BaseChatBackendsTests/CloudEndpointSelectionIntegrationTests.swift
+++ b/Tests/BaseChatBackendsTests/CloudEndpointSelectionIntegrationTests.swift
@@ -5,7 +5,7 @@ import SwiftData
 // is needed to exercise the endpoint selection → load → generate pipeline that
 // wires cloud backends through InferenceService.
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 /// Integration tests for the cloud endpoint selection and generation pipeline.

--- a/Tests/BaseChatBackendsTests/FoundationModelE2ETests.swift
+++ b/Tests/BaseChatBackendsTests/FoundationModelE2ETests.swift
@@ -1,7 +1,7 @@
 #if canImport(FoundationModels)
 import XCTest
 import SwiftData
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 @testable import BaseChatBackends
 @testable import BaseChatUI

--- a/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
@@ -1,6 +1,6 @@
 #if Llama
 import XCTest
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 @testable import BaseChatBackends
 

--- a/Tests/BaseChatBackendsTests/RetryPolicyIntegrationTests.swift
+++ b/Tests/BaseChatBackendsTests/RetryPolicyIntegrationTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 @testable import BaseChatBackends
 

--- a/Tests/BaseChatBackendsTests/SSEPayloadReplayTests.swift
+++ b/Tests/BaseChatBackendsTests/SSEPayloadReplayTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import BaseChatBackends
-import BaseChatCore
+@testable import BaseChatCore
 
 // MARK: - Byte Sequence Helper
 

--- a/Tests/BaseChatE2ETests/ChatTurnRoundTripE2ETests.swift
+++ b/Tests/BaseChatE2ETests/ChatTurnRoundTripE2ETests.swift
@@ -2,7 +2,7 @@ import Testing
 import Foundation
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 /// E2E round-trip: send -> stream -> persist -> reload across session switch.

--- a/Tests/BaseChatE2ETests/CompressionContextPressureE2ETests.swift
+++ b/Tests/BaseChatE2ETests/CompressionContextPressureE2ETests.swift
@@ -2,7 +2,7 @@ import Testing
 import Foundation
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 /// E2E: fill context → compression fires → generation continues → messages persist.

--- a/Tests/BaseChatE2ETests/LoopDetectionE2ETests.swift
+++ b/Tests/BaseChatE2ETests/LoopDetectionE2ETests.swift
@@ -1,7 +1,7 @@
 import Testing
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 /// E2E test for loop detection → auto-stop.

--- a/Tests/BaseChatE2ETests/ModelSelectionE2ETests.swift
+++ b/Tests/BaseChatE2ETests/ModelSelectionE2ETests.swift
@@ -2,7 +2,7 @@ import Testing
 import Foundation
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 /// E2E tests for the model selection and loading pipeline.

--- a/Tests/BaseChatUITests/BackendActivityPhaseTests.swift
+++ b/Tests/BaseChatUITests/BackendActivityPhaseTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 @MainActor

--- a/Tests/BaseChatUITests/CancellationTests.swift
+++ b/Tests/BaseChatUITests/CancellationTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 // MARK: - Cancellation Tests

--- a/Tests/BaseChatUITests/ChatViewModelIntegrationTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelIntegrationTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 /// Integration tests for ChatViewModel with a real in-memory SwiftData store and mock inference backend.

--- a/Tests/BaseChatUITests/ChatViewModelLoopDetectionTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelLoopDetectionTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 @MainActor

--- a/Tests/BaseChatUITests/ChatViewModelMacroExpansionTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelMacroExpansionTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 @MainActor

--- a/Tests/BaseChatUITests/CompressionIntegrationTests.swift
+++ b/Tests/BaseChatUITests/CompressionIntegrationTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 /// Integration tests for the compression system as wired into ChatViewModel.

--- a/Tests/BaseChatUITests/CompressionP1IntegrationTests.swift
+++ b/Tests/BaseChatUITests/CompressionP1IntegrationTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 @MainActor

--- a/Tests/BaseChatUITests/CompressionSettingsViewModelTests.swift
+++ b/Tests/BaseChatUITests/CompressionSettingsViewModelTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 @MainActor

--- a/Tests/BaseChatUITests/CompressionStatsDisplayTests.swift
+++ b/Tests/BaseChatUITests/CompressionStatsDisplayTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 /// Tests that `ChatViewModel.lastCompressionStats` is correctly nil by default,

--- a/Tests/BaseChatUITests/ConcurrencyTests.swift
+++ b/Tests/BaseChatUITests/ConcurrencyTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 // MARK: - Concurrency Tests

--- a/Tests/BaseChatUITests/ContextEstimationIntegrationTests.swift
+++ b/Tests/BaseChatUITests/ContextEstimationIntegrationTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 /// Integration tests for context estimation using REAL HeuristicTokenizer and

--- a/Tests/BaseChatUITests/EditUserMessageIntegrationTests.swift
+++ b/Tests/BaseChatUITests/EditUserMessageIntegrationTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 /// Integration tests for the edit-user-message feature (`ChatViewModel.editMessage`).

--- a/Tests/BaseChatUITests/GenerationExtensionTests.swift
+++ b/Tests/BaseChatUITests/GenerationExtensionTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 // MARK: - Tests

--- a/Tests/BaseChatUITests/GenerationViewModelTests.swift
+++ b/Tests/BaseChatUITests/GenerationViewModelTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 @MainActor

--- a/Tests/BaseChatUITests/InterleavingTests.swift
+++ b/Tests/BaseChatUITests/InterleavingTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 // MARK: - Interleaving Tests

--- a/Tests/BaseChatUITests/PersistenceIntegrationTests.swift
+++ b/Tests/BaseChatUITests/PersistenceIntegrationTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 /// Integration tests for ChatViewModel persistence using REAL SwiftData (in-memory).

--- a/Tests/BaseChatUITests/PinMessageTests.swift
+++ b/Tests/BaseChatUITests/PinMessageTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 @MainActor

--- a/Tests/BaseChatUITests/PinnedMessageIndicatorTests.swift
+++ b/Tests/BaseChatUITests/PinnedMessageIndicatorTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 /// ViewModel integration tests for the data that drives the pin indicator in MessageBubbleView.

--- a/Tests/BaseChatUITests/PostGenerationTaskTests.swift
+++ b/Tests/BaseChatUITests/PostGenerationTaskTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 // MARK: - PostGenerationTask Tests

--- a/Tests/BaseChatUITests/ServerDiscoveryViewModelTests.swift
+++ b/Tests/BaseChatUITests/ServerDiscoveryViewModelTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import SwiftData
 import Observation
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 @MainActor

--- a/Tests/BaseChatUITests/SessionAutoRenameTests.swift
+++ b/Tests/BaseChatUITests/SessionAutoRenameTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 @MainActor

--- a/Tests/BaseChatUITests/SessionManagerViewModelTests.swift
+++ b/Tests/BaseChatUITests/SessionManagerViewModelTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 @MainActor

--- a/Tests/BaseChatUITests/SessionOverrideTests.swift
+++ b/Tests/BaseChatUITests/SessionOverrideTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 // MARK: - Session Override Tests

--- a/Tests/BaseChatUITests/SessionQueueIsolationTests.swift
+++ b/Tests/BaseChatUITests/SessionQueueIsolationTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 // MARK: - Session Queue Isolation Tests

--- a/Tests/BaseChatUITests/StreamingFailureTests.swift
+++ b/Tests/BaseChatUITests/StreamingFailureTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 // MARK: - Tests

--- a/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
+++ b/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+@testable import BaseChatCore
 import BaseChatTestSupport
 
 @MainActor


### PR DESCRIPTION
## Summary

- **Narrow public API**: Demoted ~14 implementation-detail types from `public` to `package` or `internal` access. Types needed cross-module within the package (e.g. `SwiftDataPersistenceProvider`, `MemoryPressureHandler`, `SSEStreamParser`, `CompressionOrchestrator`, `CachingTokenizer`, `HeuristicTokenizer`, `ModelContainerFactory`) use `package`; types used only within `BaseChatCore` (`GGUFMetadataReader`, `GGUFMetadata`, `GGUFReaderError`, `PromptTemplateDetector`, `withExponentialBackoff`) use `internal`. External consumers of the library will no longer see these implementation details.
- **Remove unused dependency**: Removed `swift-transformers` from Package.swift (transitive dep of mlx-swift-lm, not directly used).
- **Silence build warning**: Added `exclude: ["__Snapshots__"]` to the `BaseChatSnapshotTests` target.
- **Add doc comments**: Added `///` documentation to `NetworkDiscoveryService.startDiscovery()`, `.stopDiscovery()`, `.probe(host:port:)`, `HuggingFaceService.init(hubClient:)`, `InferenceError.isRetryable`, and `BackgroundDownloadManager.hasActiveDownloads`.
- **Clean up README**: Removed stale screenshot placeholder TODO comment block.
- **Branch protection**: Bumped required PR approvals to 1.

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` -- 677 XCTest + 105 Swift Testing tests pass
- [x] `swift test --filter BaseChatUITests --disable-default-traits` -- 299 tests pass
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` -- 155 XCTest + 77 Swift Testing tests pass
- [x] All 35 test files updated with `@testable import BaseChatCore` where needed
- [x] `ChatViewModel` public init preserved (convenience init delegates to package-level designated init)

🤖 Generated with [Claude Code](https://claude.com/claude-code)