### PR TITLE
feat!: bundle breaking changes for v1.0.0 — mlx-swift-lm migration + API improvements

### DIFF
--- a/Example/BaseChatDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/BaseChatDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
       "state" : {
-        "revision" : "25b00d4e22e61ec9c41efda47990cd2084ec87ff",
-        "version" : "2.31.3"
+        "revision" : "d1b14783c93902b74c1211f480ece8f776f4c29c"
       }
     },
     {
@@ -98,6 +97,15 @@
       "state" : {
         "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
         "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
       }
     },
     {

--- a/Example/BaseChatDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/BaseChatDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,21 +11,12 @@
       }
     },
     {
-      "identity" : "llama.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattt/llama.swift",
-      "state" : {
-        "revision" : "ab7929766c2ea594cecd698c801089308c59c450",
-        "version" : "2.8563.0"
-      }
-    },
-    {
       "identity" : "mlx-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift",
       "state" : {
-        "revision" : "6ba4827fb82c97d012eec9ab4b2de21f85c3b33d",
-        "version" : "0.30.6"
+        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
+        "version" : "0.31.3"
       }
     },
     {
@@ -33,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
       "state" : {
-        "revision" : "7e19e09027923d89ac47dd087d9627f610e5a91a",
-        "version" : "2.30.6"
+        "revision" : "25b00d4e22e61ec9c41efda47990cd2084ec87ff",
+        "version" : "2.31.3"
       }
     },
     {
@@ -123,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers",
       "state" : {
-        "revision" : "150169bfba0889c229a2ce7494cf8949f18e6906",
-        "version" : "1.1.9"
+        "revision" : "58c4bc11963a140358d791f678a60a2745a23146",
+        "version" : "1.2.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9fa99d330dfc1bf6c292f67b019f7482ceea8eb502c0b2b3829cd7c49929d202",
+  "originHash" : "ddb381a0019b8f66f05dcbccb8e52f9469f8a5b12b45fb880853d850b8dd165b",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -8,24 +8,6 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "mlx-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift.git",
-      "state" : {
-        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
-        "version" : "0.31.3"
-      }
-    },
-    {
-      "identity" : "mlx-swift-lm",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
-      "state" : {
-        "revision" : "25b00d4e22e61ec9c41efda47990cd2084ec87ff",
-        "version" : "2.31.3"
       }
     },
     {
@@ -83,30 +65,12 @@
       }
     },
     {
-      "identity" : "swift-jinja",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-jinja.git",
-      "state" : {
-        "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
-        "version" : "2.3.5"
-      }
-    },
-    {
       "identity" : "swift-nio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
         "revision" : "558f24a4647193b5a0e2104031b71c55d31ff83a",
         "version" : "2.97.1"
-      }
-    },
-    {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics",
-      "state" : {
-        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
-        "version" : "1.1.1"
       }
     },
     {
@@ -137,30 +101,12 @@
       }
     },
     {
-      "identity" : "swift-transformers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-transformers",
-      "state" : {
-        "revision" : "58c4bc11963a140358d791f678a60a2745a23146",
-        "version" : "1.2.1"
-      }
-    },
-    {
       "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
         "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
         "version" : "1.9.0"
-      }
-    },
-    {
-      "identity" : "yyjson",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ibireme/yyjson.git",
-      "state" : {
-        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
-        "version" : "0.12.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ddb381a0019b8f66f05dcbccb8e52f9469f8a5b12b45fb880853d850b8dd165b",
+  "originHash" : "8603a005127f3ca787c6fefef6590efdaa7165e542337a713f8dcfce47ec1a15",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -8,6 +8,23 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift.git",
+      "state" : {
+        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
+        "version" : "0.31.3"
+      }
+    },
+    {
+      "identity" : "mlx-swift-lm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
+      "state" : {
+        "revision" : "d1b14783c93902b74c1211f480ece8f776f4c29c"
       }
     },
     {
@@ -42,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "fa308c07a6fa04a727212d793e761460e41049c3",
-        "version" : "4.3.0"
+        "revision" : "bb4ba815dab96d4edc1e0b86d7b9acf9ff973a84",
+        "version" : "4.3.1"
       }
     },
     {
@@ -65,12 +82,30 @@
       }
     },
     {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
+        "version" : "2.3.5"
+      }
+    },
+    {
       "identity" : "swift-nio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
         "revision" : "558f24a4647193b5a0e2104031b71c55d31ff83a",
         "version" : "2.97.1"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
       }
     },
     {
@@ -85,10 +120,10 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-syntax",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "2b59c0c741e9184ab057fd22950b491076d42e91",
-        "version" : "603.0.0"
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
       }
     },
     {
@@ -101,12 +136,30 @@
       }
     },
     {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers",
+      "state" : {
+        "revision" : "b38443e44d93eca770f2eb68e2a4d0fa100f9aa2",
+        "version" : "1.3.0"
+      }
+    },
+    {
       "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
         "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
         "version" : "1.9.0"
+      }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .package(url: "https://github.com/huggingface/swift-huggingface.git", from: "0.9.0"),
         // Explicit dep required: mlx-swift-lm no longer pulls swift-transformers transitively.
         // The MLXHuggingFace macro generates `AutoTokenizer.from(modelFolder:)` which lives here.
-        .package(url: "https://github.com/huggingface/swift-transformers", from: "0.9.0"),
+        .package(url: "https://github.com/huggingface/swift-transformers", from: "1.2.0"),
         .package(url: "https://github.com/mattt/llama.swift", from: "2.8672.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,15 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ml-explore/mlx-swift.git", from: "0.31.3"),
-        .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", from: "2.31.3"),
+        // Pinned to main-branch commit — mlx-swift-lm 2.31.3 uses HuggingFace.HubCache in
+        // MLXLMCommon without declaring swift-huggingface as an explicit SPM dependency.
+        // Swift 6.3 / Xcode 26 enforces this strictly. The fix (decoupled MLXHuggingFace
+        // target) landed in main but has no tag yet. Revisit when ≥2.32.0 is tagged.
+        .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", revision: "d1b14783c93902b74c1211f480ece8f776f4c29c"),
         .package(url: "https://github.com/huggingface/swift-huggingface.git", from: "0.9.0"),
+        // Explicit dep required: mlx-swift-lm no longer pulls swift-transformers transitively.
+        // The MLXHuggingFace macro generates `AutoTokenizer.from(modelFolder:)` which lives here.
+        .package(url: "https://github.com/huggingface/swift-transformers", from: "0.9.0"),
         .package(url: "https://github.com/mattt/llama.swift", from: "2.8672.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.0"),
     ],
@@ -42,6 +49,8 @@ let package = Package(
                 .product(name: "MLX", package: "mlx-swift", condition: .when(traits: ["MLX"])),
                 .product(name: "MLXLLM", package: "mlx-swift-lm", condition: .when(traits: ["MLX"])),
                 .product(name: "MLXLMCommon", package: "mlx-swift-lm", condition: .when(traits: ["MLX"])),
+                .product(name: "MLXHuggingFace", package: "mlx-swift-lm", condition: .when(traits: ["MLX"])),
+                .product(name: "Tokenizers", package: "swift-transformers", condition: .when(traits: ["MLX"])),
                 .product(name: "LlamaSwift", package: "llama.swift", condition: .when(traits: ["Llama"])),
             ],
             path: "Sources/BaseChatBackends"

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -3,6 +3,8 @@ import Foundation
 import MLX
 import MLXLLM
 import MLXLMCommon
+import MLXHuggingFace
+import Tokenizers
 import os
 import BaseChatCore
 
@@ -83,13 +85,13 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
 
         do {
             // Load from a local directory containing config.json + .safetensors.
-            // loadModelContainer is a free function from MLXLMCommon.
+            // loadModelContainer(from:using:) is a free function from MLXLMCommon.
+            // #huggingFaceTokenizerLoader() (from MLXHuggingFace) adapts swift-transformers'
+            // AutoTokenizer to the TokenizerLoader protocol required by the new API.
             let container: ModelContainer = try await loadModelContainer(
-                directory: url
-            ) { _ in
-                // Loading progress — useful for large models.
-                // For local models this completes quickly.
-            }
+                from: url,
+                using: #huggingFaceTokenizerLoader()
+            )
             withStateLock {
                 _modelContainer = container
             }

--- a/Sources/BaseChatCore/BaseChatSchemaV3.swift
+++ b/Sources/BaseChatCore/BaseChatSchemaV3.swift
@@ -258,11 +258,6 @@ public enum BaseChatSchemaV3: VersionedSchema {
             id.uuidString
         }
 
-        /// Retrieves the API key from the Keychain.
-        public var apiKey: String? {
-            KeychainService.retrieve(account: keychainAccount)
-        }
-
         /// Stores an API key in the Keychain for this endpoint.
         @discardableResult
         public func setAPIKey(_ key: String) -> Bool {
@@ -274,7 +269,12 @@ public enum BaseChatSchemaV3: VersionedSchema {
             KeychainService.delete(account: keychainAccount)
         }
 
-        /// Validates the endpoint configuration.
+        /// Validates the endpoint's URL structure.
+        ///
+        /// This is a pure structural check — it does NOT verify whether an API key
+        /// exists in the Keychain. Use `APIProvider.requiresAPIKey` and
+        /// `KeychainService.retrieve(account: endpoint.keychainAccount)` separately
+        /// to check credential readiness.
         public var isValid: Bool {
             guard let url = URL(string: baseURL), url.scheme != nil, url.host != nil else {
                 return false
@@ -282,11 +282,6 @@ public enum BaseChatSchemaV3: VersionedSchema {
 
             // HTTPS required for remote endpoints
             if !isLocalhost(url) && url.scheme != "https" {
-                return false
-            }
-
-            // API key required for providers that need one
-            if provider.requiresAPIKey && (apiKey?.isEmpty ?? true) {
                 return false
             }
 

--- a/Sources/BaseChatCore/Protocols/BackendCapabilities.swift
+++ b/Sources/BaseChatCore/Protocols/BackendCapabilities.swift
@@ -83,34 +83,14 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
     }
 
     public init(
-        supportedParameters: Set<GenerationParameter>,
-        maxContextTokens: Int32,
-        requiresPromptTemplate: Bool,
-        supportsSystemPrompt: Bool
-    ) {
-        self.supportedParameters = supportedParameters
-        self.maxContextTokens = maxContextTokens
-        self.requiresPromptTemplate = requiresPromptTemplate
-        self.supportsSystemPrompt = supportsSystemPrompt
-        self.supportsToolCalling = false
-        self.supportsStructuredOutput = false
-        self.cancellationStyle = .cooperative
-        self.supportsTokenCounting = false
-        self.memoryStrategy = .resident
-        self.maxOutputTokens = 4096
-        self.supportsStreaming = true
-        self.isRemote = false
-    }
-
-    public init(
-        supportedParameters: Set<GenerationParameter>,
-        maxContextTokens: Int32,
-        requiresPromptTemplate: Bool,
-        supportsSystemPrompt: Bool,
-        supportsToolCalling: Bool,
-        supportsStructuredOutput: Bool,
-        cancellationStyle: CancellationStyle,
-        supportsTokenCounting: Bool,
+        supportedParameters: Set<GenerationParameter> = [.temperature],
+        maxContextTokens: Int32 = 4096,
+        requiresPromptTemplate: Bool = false,
+        supportsSystemPrompt: Bool = true,
+        supportsToolCalling: Bool = false,
+        supportsStructuredOutput: Bool = false,
+        cancellationStyle: CancellationStyle = .cooperative,
+        supportsTokenCounting: Bool = false,
         memoryStrategy: MemoryStrategy = .resident,
         maxOutputTokens: Int = 4096,
         supportsStreaming: Bool = true,

--- a/Sources/BaseChatCore/Protocols/ChatPersistenceProvider.swift
+++ b/Sources/BaseChatCore/Protocols/ChatPersistenceProvider.swift
@@ -32,10 +32,10 @@ public struct ChatSessionRecord: Identifiable, Hashable, Sendable {
     public var temperature: Float?
     public var topP: Float?
     public var repeatPenalty: Float?
-    public var promptTemplateRawValue: String?
+    public var promptTemplate: PromptTemplate?
     public var contextSizeOverride: Int?
-    public var compressionModeRaw: String?
-    public var pinnedMessageIDsRaw: String?
+    public var compressionMode: CompressionMode
+    public var pinnedMessageIDs: Set<UUID>
 
     public init(
         id: UUID = UUID(),
@@ -48,10 +48,10 @@ public struct ChatSessionRecord: Identifiable, Hashable, Sendable {
         temperature: Float? = nil,
         topP: Float? = nil,
         repeatPenalty: Float? = nil,
-        promptTemplateRawValue: String? = nil,
+        promptTemplate: PromptTemplate? = nil,
         contextSizeOverride: Int? = nil,
-        compressionModeRaw: String? = nil,
-        pinnedMessageIDsRaw: String? = nil
+        compressionMode: CompressionMode = .automatic,
+        pinnedMessageIDs: Set<UUID> = []
     ) {
         self.id = id
         self.title = title
@@ -63,35 +63,10 @@ public struct ChatSessionRecord: Identifiable, Hashable, Sendable {
         self.temperature = temperature
         self.topP = topP
         self.repeatPenalty = repeatPenalty
-        self.promptTemplateRawValue = promptTemplateRawValue
+        self.promptTemplate = promptTemplate
         self.contextSizeOverride = contextSizeOverride
-        self.compressionModeRaw = compressionModeRaw
-        self.pinnedMessageIDsRaw = pinnedMessageIDsRaw
-    }
-
-    public var pinnedMessageIDs: Set<UUID> {
-        get {
-            guard let raw = pinnedMessageIDsRaw else { return [] }
-            return Set(raw.split(separator: ",").compactMap { UUID(uuidString: String($0)) })
-        }
-        set {
-            pinnedMessageIDsRaw = newValue.isEmpty ? nil : newValue.map(\.uuidString).joined(separator: ",")
-        }
-    }
-
-    public var compressionMode: CompressionMode {
-        get { compressionModeRaw.flatMap(CompressionMode.init(rawValue:)) ?? .automatic }
-        set { compressionModeRaw = newValue.rawValue }
-    }
-
-    public var promptTemplate: PromptTemplate? {
-        get {
-            guard let raw = promptTemplateRawValue else { return nil }
-            return PromptTemplate(rawValue: raw)
-        }
-        set {
-            promptTemplateRawValue = newValue?.rawValue
-        }
+        self.compressionMode = compressionMode
+        self.pinnedMessageIDs = pinnedMessageIDs
     }
 }
 

--- a/Sources/BaseChatCore/Services/Compression/AnchoredCompressor.swift
+++ b/Sources/BaseChatCore/Services/Compression/AnchoredCompressor.swift
@@ -3,22 +3,22 @@ import Foundation
 /// Compressor that summarizes old messages via an inference call, then prepends the
 /// summary to a verbatim tail of recent messages. Falls back to ``ExtractiveCompressor``
 /// on any error (missing generate function, failed inference, oversized summary).
-package final class AnchoredCompressor: ContextCompressor, @unchecked Sendable {
-    package let strategyName = "anchored"
+public final class AnchoredCompressor: ContextCompressor, @unchecked Sendable {
+    public let strategyName = "anchored"
 
     /// Fraction of the history budget reserved for the verbatim recent tail.
-    package let tailBudgetFraction: Double
+    public let tailBudgetFraction: Double
 
     /// Injected by the caller; performs a single-turn inference call for summarization.
     /// Must be set before the first call to `compress()`. Not safe to mutate while
     /// `compress()` is in flight.
-    package var generateFn: (@Sendable (String) async throws -> String)?
+    public var generateFn: (@Sendable (String) async throws -> String)?
 
     private let fallback = ExtractiveCompressor()
 
     // MARK: - Summary Prompt Template
 
-    package static let defaultSummaryTemplate: String = """
+    public static let defaultSummaryTemplate: String = """
         Summarize the conversation so far. Be concise. Use only what is in the text.
 
         TOPIC: [main subject of the conversation, brief]
@@ -33,9 +33,9 @@ package final class AnchoredCompressor: ContextCompressor, @unchecked Sendable {
     /// The prompt template used to summarize old messages.
     /// Pass a domain-specific prompt at init time to override.
     /// The placeholder `{old_nodes_text}` is replaced with the concatenated message content.
-    package let summaryTemplate: String
+    public let summaryTemplate: String
 
-    package init(
+    public init(
         tailBudgetFraction: Double = 0.50,
         summaryTemplate: String? = nil
     ) {
@@ -45,7 +45,7 @@ package final class AnchoredCompressor: ContextCompressor, @unchecked Sendable {
 
     // MARK: - ContextCompressor
 
-    package func compress(
+    public func compress(
         messages: [CompressibleMessage],
         systemPrompt: String?,
         contextSize: Int,

--- a/Sources/BaseChatCore/Services/Compression/CompressionOrchestrator.swift
+++ b/Sources/BaseChatCore/Services/Compression/CompressionOrchestrator.swift
@@ -7,15 +7,15 @@ import Foundation
 /// (higher quality, requires a generate function) based on the active mode and
 /// available capabilities.
 @MainActor
-package final class CompressionOrchestrator {
+public final class CompressionOrchestrator {
 
     /// The user-selected compression mode. Defaults to automatic.
-    package var mode: CompressionMode = .automatic
+    public var mode: CompressionMode = .automatic
 
-    package let extractive: ExtractiveCompressor
-    package let anchored: AnchoredCompressor
+    public let extractive: ExtractiveCompressor
+    public let anchored: AnchoredCompressor
 
-    package init(
+    public init(
         extractive: ExtractiveCompressor = ExtractiveCompressor(),
         anchored: AnchoredCompressor = AnchoredCompressor()
     ) {
@@ -29,7 +29,7 @@ package final class CompressionOrchestrator {
     ///
     /// Larger context windows can afford to wait longer before compressing,
     /// so the threshold is higher for models with more than 16k tokens.
-    package func compressionThreshold(for contextSize: Int) -> Double {
+    public func compressionThreshold(for contextSize: Int) -> Double {
         contextSize > 16_000 ? 0.85 : 0.75
     }
 
@@ -37,7 +37,7 @@ package final class CompressionOrchestrator {
 
     /// Determines whether the current conversation history is large enough to
     /// warrant compression given the active mode and context window.
-    package func shouldCompress(
+    public func shouldCompress(
         messages: [CompressibleMessage],
         systemPrompt: String?,
         contextSize: Int,
@@ -63,7 +63,7 @@ package final class CompressionOrchestrator {
     ///
     /// Strategy routing depends on the current ``mode``, the model's context size,
     /// and whether `AnchoredCompressor` has a generate function configured.
-    package func compress(
+    public func compress(
         messages: [CompressibleMessage],
         systemPrompt: String?,
         contextSize: Int,

--- a/Sources/BaseChatCore/Services/Compression/ContextCompressor.swift
+++ b/Sources/BaseChatCore/Services/Compression/ContextCompressor.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// User-facing compression mode labels. No algorithm names are exposed to the UI.
-public enum CompressionMode: String, CaseIterable, Identifiable {
+public enum CompressionMode: String, CaseIterable, Identifiable, Sendable {
     case automatic = "Automatic"
     case off = "Off"
     case balanced = "Balanced"    // AnchoredCompressor

--- a/Sources/BaseChatCore/Services/Compression/ExtractiveCompressor.swift
+++ b/Sources/BaseChatCore/Services/Compression/ExtractiveCompressor.swift
@@ -6,22 +6,22 @@ import Foundation
 ///
 /// The newest messages are always kept verbatim (the "tail"), and pinned messages are
 /// never evicted. Remaining messages compete for the leftover budget by score.
-package final class ExtractiveCompressor: ContextCompressor, @unchecked Sendable {
-    package let strategyName = "extractive"
+public final class ExtractiveCompressor: ContextCompressor, @unchecked Sendable {
+    public let strategyName = "extractive"
 
     /// Fraction of the history budget reserved for the verbatim tail (newest messages).
-    package let tailBudgetFraction: Double
+    public let tailBudgetFraction: Double
 
     /// Weight for how recently a message appears in the conversation.
-    package let recencyWeight: Double
+    public let recencyWeight: Double
 
     /// Weight for message content length (longer messages carry more narrative).
-    package let lengthWeight: Double
+    public let lengthWeight: Double
 
     /// Weight for capitalized-word density (proxy for proper noun / keyword richness).
-    package let keywordDensityWeight: Double
+    public let keywordDensityWeight: Double
 
-    package init(
+    public init(
         tailBudgetFraction: Double = 0.40,
         recencyWeight: Double = 0.5,
         lengthWeight: Double = 0.3,
@@ -35,7 +35,7 @@ package final class ExtractiveCompressor: ContextCompressor, @unchecked Sendable
 
     // MARK: - ContextCompressor
 
-    package nonisolated func compress(
+    public nonisolated func compress(
         messages: [CompressibleMessage],
         systemPrompt: String?,
         contextSize: Int,

--- a/Sources/BaseChatCore/Services/SettingsService.swift
+++ b/Sources/BaseChatCore/Services/SettingsService.swift
@@ -19,28 +19,28 @@ public final class SettingsService: @unchecked Sendable {
 
     // MARK: - Generation Defaults
 
-    public var globalTemperature: Float {
-        get {
-            let value = defaults.float(forKey: "globalTemperature")
-            return value == 0 ? 0.7 : value
+    public var globalTemperature: Float? {
+        get { defaults.object(forKey: "globalTemperature") as? Float }
+        set {
+            if let newValue { defaults.set(newValue, forKey: "globalTemperature") }
+            else { defaults.removeObject(forKey: "globalTemperature") }
         }
-        set { defaults.set(newValue, forKey: "globalTemperature") }
     }
 
-    public var globalTopP: Float {
-        get {
-            let value = defaults.float(forKey: "globalTopP")
-            return value == 0 ? 0.9 : value
+    public var globalTopP: Float? {
+        get { defaults.object(forKey: "globalTopP") as? Float }
+        set {
+            if let newValue { defaults.set(newValue, forKey: "globalTopP") }
+            else { defaults.removeObject(forKey: "globalTopP") }
         }
-        set { defaults.set(newValue, forKey: "globalTopP") }
     }
 
-    public var globalRepeatPenalty: Float {
-        get {
-            let value = defaults.float(forKey: "globalRepeatPenalty")
-            return value == 0 ? 1.1 : value
+    public var globalRepeatPenalty: Float? {
+        get { defaults.object(forKey: "globalRepeatPenalty") as? Float }
+        set {
+            if let newValue { defaults.set(newValue, forKey: "globalRepeatPenalty") }
+            else { defaults.removeObject(forKey: "globalRepeatPenalty") }
         }
-        set { defaults.set(newValue, forKey: "globalRepeatPenalty") }
     }
 
     public var globalPromptTemplate: PromptTemplate? {
@@ -65,15 +65,15 @@ public final class SettingsService: @unchecked Sendable {
 
     /// Returns the effective temperature, using session override if available.
     public func effectiveTemperature(session: ChatSession?) -> Float {
-        session?.temperature ?? globalTemperature
+        session?.temperature ?? globalTemperature ?? 0.7
     }
 
     public func effectiveTopP(session: ChatSession?) -> Float {
-        session?.topP ?? globalTopP
+        session?.topP ?? globalTopP ?? 0.9
     }
 
     public func effectiveRepeatPenalty(session: ChatSession?) -> Float {
-        session?.repeatPenalty ?? globalRepeatPenalty
+        session?.repeatPenalty ?? globalRepeatPenalty ?? 1.1
     }
 }
 

--- a/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
+++ b/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
@@ -31,7 +31,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         session.promptTemplateRawValue = record.promptTemplate?.rawValue
         session.contextSizeOverride = record.contextSizeOverride
         session.compressionModeRaw = record.compressionMode == .automatic ? nil : record.compressionMode.rawValue
-        session.pinnedMessageIDsRaw = record.pinnedMessageIDs.isEmpty ? nil : record.pinnedMessageIDs.map(\.uuidString).joined(separator: ",")
+        session.pinnedMessageIDsRaw = record.pinnedMessageIDs.isEmpty ? nil : record.pinnedMessageIDs.map(\.uuidString).sorted().joined(separator: ",")
         modelContext.insert(session)
         try modelContext.save()
     }
@@ -51,7 +51,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         session.promptTemplateRawValue = record.promptTemplate?.rawValue
         session.contextSizeOverride = record.contextSizeOverride
         session.compressionModeRaw = record.compressionMode == .automatic ? nil : record.compressionMode.rawValue
-        session.pinnedMessageIDsRaw = record.pinnedMessageIDs.isEmpty ? nil : record.pinnedMessageIDs.map(\.uuidString).joined(separator: ",")
+        session.pinnedMessageIDsRaw = record.pinnedMessageIDs.isEmpty ? nil : record.pinnedMessageIDs.map(\.uuidString).sorted().joined(separator: ",")
         try modelContext.save()
     }
 

--- a/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
+++ b/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
@@ -28,10 +28,10 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         session.temperature = record.temperature
         session.topP = record.topP
         session.repeatPenalty = record.repeatPenalty
-        session.promptTemplateRawValue = record.promptTemplateRawValue
+        session.promptTemplateRawValue = record.promptTemplate?.rawValue
         session.contextSizeOverride = record.contextSizeOverride
-        session.compressionModeRaw = record.compressionModeRaw
-        session.pinnedMessageIDsRaw = record.pinnedMessageIDsRaw
+        session.compressionModeRaw = record.compressionMode == .automatic ? nil : record.compressionMode.rawValue
+        session.pinnedMessageIDsRaw = record.pinnedMessageIDs.isEmpty ? nil : record.pinnedMessageIDs.map(\.uuidString).joined(separator: ",")
         modelContext.insert(session)
         try modelContext.save()
     }
@@ -48,10 +48,10 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         session.temperature = record.temperature
         session.topP = record.topP
         session.repeatPenalty = record.repeatPenalty
-        session.promptTemplateRawValue = record.promptTemplateRawValue
+        session.promptTemplateRawValue = record.promptTemplate?.rawValue
         session.contextSizeOverride = record.contextSizeOverride
-        session.compressionModeRaw = record.compressionModeRaw
-        session.pinnedMessageIDsRaw = record.pinnedMessageIDsRaw
+        session.compressionModeRaw = record.compressionMode == .automatic ? nil : record.compressionMode.rawValue
+        session.pinnedMessageIDsRaw = record.pinnedMessageIDs.isEmpty ? nil : record.pinnedMessageIDs.map(\.uuidString).joined(separator: ",")
         try modelContext.save()
     }
 
@@ -174,10 +174,10 @@ extension ChatSession {
             temperature: temperature,
             topP: topP,
             repeatPenalty: repeatPenalty,
-            promptTemplateRawValue: promptTemplateRawValue,
+            promptTemplate: promptTemplateRawValue.flatMap(PromptTemplate.init(rawValue:)),
             contextSizeOverride: contextSizeOverride,
-            compressionModeRaw: compressionModeRaw,
-            pinnedMessageIDsRaw: pinnedMessageIDsRaw
+            compressionMode: compressionModeRaw.flatMap(CompressionMode.init(rawValue:)) ?? .automatic,
+            pinnedMessageIDs: Set(pinnedMessageIDsRaw?.split(separator: ",").compactMap { UUID(uuidString: String($0)) } ?? [])
         )
     }
 }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Observation
-import SwiftData
 import BaseChatCore
 
 /// Central view model for the chat interface.
@@ -422,12 +421,6 @@ public final class ChatViewModel {
         guard self.persistence == nil else { return }
         self.persistence = persistence
         Log.persistence.info("ChatViewModel configured with persistence provider")
-    }
-
-    /// Convenience: wraps a SwiftData `ModelContext` in a ``SwiftDataPersistenceProvider``.
-    @available(*, deprecated, message: "Use configure(persistence:) with an explicit provider")
-    public func configure(modelContext: ModelContext) {
-        configure(persistence: SwiftDataPersistenceProvider(modelContext: modelContext))
     }
 
     // MARK: - Structured Error Surfacing

--- a/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
@@ -40,7 +40,11 @@ public final class SessionManagerViewModel {
 
     /// Deletes a session and all its messages.
     public func deleteSession(_ session: ChatSessionRecord) throws {
-        try persistence?.deleteSession(session.id)
+        guard let persistence else {
+            Log.persistence.warning("deleteSession called before persistence was configured")
+            throw ChatPersistenceError.providerNotConfigured
+        }
+        try persistence.deleteSession(session.id)
 
         if activeSession?.id == session.id {
             activeSession = nil
@@ -51,10 +55,14 @@ public final class SessionManagerViewModel {
 
     /// Renames a session.
     public func renameSession(_ session: ChatSessionRecord, title: String) throws {
+        guard let persistence else {
+            Log.persistence.warning("renameSession called before persistence was configured")
+            throw ChatPersistenceError.providerNotConfigured
+        }
         var updated = session
         updated.title = title
         updated.updatedAt = Date()
-        try persistence?.updateSession(updated)
+        try persistence.updateSession(updated)
         loadSessions()
     }
 

--- a/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Observation
-import SwiftData
 import BaseChatCore
 
 /// Manages chat session CRUD operations and the session list.
@@ -24,13 +23,6 @@ public final class SessionManagerViewModel {
         self.persistence = persistence
         loadSessions()
         Log.persistence.info("SessionManagerViewModel configured")
-    }
-
-    /// Convenience: wraps a SwiftData `ModelContext` in a ``SwiftDataPersistenceProvider``.
-    @available(*, deprecated, message: "Use configure(persistence:) with an explicit provider")
-    @MainActor
-    public func configure(modelContext: ModelContext) {
-        configure(persistence: SwiftDataPersistenceProvider(modelContext: modelContext))
     }
 
     /// Creates a new session, inserts it, and returns it.

--- a/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
@@ -39,12 +39,8 @@ public final class SessionManagerViewModel {
     }
 
     /// Deletes a session and all its messages.
-    public func deleteSession(_ session: ChatSessionRecord) {
-        do {
-            try persistence?.deleteSession(session.id)
-        } catch {
-            Log.persistence.error("Failed to delete session: \(error)")
-        }
+    public func deleteSession(_ session: ChatSessionRecord) throws {
+        try persistence?.deleteSession(session.id)
 
         if activeSession?.id == session.id {
             activeSession = nil
@@ -54,15 +50,11 @@ public final class SessionManagerViewModel {
     }
 
     /// Renames a session.
-    public func renameSession(_ session: ChatSessionRecord, title: String) {
+    public func renameSession(_ session: ChatSessionRecord, title: String) throws {
         var updated = session
         updated.title = title
         updated.updatedAt = Date()
-        do {
-            try persistence?.updateSession(updated)
-        } catch {
-            Log.persistence.error("Failed to rename session: \(error)")
-        }
+        try persistence?.updateSession(updated)
         loadSessions()
     }
 

--- a/Sources/BaseChatUI/Views/Settings/APIEndpointEditorView.swift
+++ b/Sources/BaseChatUI/Views/Settings/APIEndpointEditorView.swift
@@ -63,7 +63,8 @@ public struct APIEndpointEditorView: View {
                             .textInputAutocapitalization(.never)
                             #endif
 
-                        if isEditing, let existing = endpoint?.apiKey, !existing.isEmpty {
+                        if isEditing, let account = endpoint?.keychainAccount,
+                           let existing = KeychainService.retrieve(account: account), !existing.isEmpty {
                             Text("Current key: \(KeychainService.masked(existing))")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)

--- a/Sources/BaseChatUI/Views/Settings/GenerationSettingsView.swift
+++ b/Sources/BaseChatUI/Views/Settings/GenerationSettingsView.swift
@@ -93,9 +93,9 @@ public struct GenerationSettingsView: View {
                 Section {
                     Button("Reset to Defaults", role: .destructive) {
                         let settings = SettingsService.shared
-                        viewModel.temperature = settings.globalTemperature
-                        viewModel.topP = settings.globalTopP
-                        viewModel.repeatPenalty = settings.globalRepeatPenalty
+                        viewModel.temperature = settings.globalTemperature ?? 0.7
+                        viewModel.topP = settings.globalTopP ?? 0.9
+                        viewModel.repeatPenalty = settings.globalRepeatPenalty ?? 1.1
                     }
                 }
 

--- a/Sources/BaseChatUI/Views/Sidebar/SessionListView.swift
+++ b/Sources/BaseChatUI/Views/Sidebar/SessionListView.swift
@@ -12,6 +12,7 @@ public struct SessionListView: View {
     @State private var sessionToDelete: ChatSessionRecord?
     @State private var sessionToRename: ChatSessionRecord?
     @State private var renameText: String = ""
+    @State private var errorMessage: String?
 
     public init() {}
 
@@ -53,7 +54,11 @@ public struct SessionListView: View {
                 Button("Cancel", role: .cancel) { sessionToRename = nil }
                 Button("Rename") {
                     if let session = sessionToRename {
-                        sessionManager.renameSession(session, title: renameText)
+                        do {
+                            try sessionManager.renameSession(session, title: renameText)
+                        } catch {
+                            errorMessage = "Failed to rename session: \(error.localizedDescription)"
+                        }
                     }
                     sessionToRename = nil
                 }
@@ -63,12 +68,24 @@ public struct SessionListView: View {
                 set: { if !$0 { sessionToDelete = nil } }
             ), presenting: sessionToDelete) { session in
                 Button("Delete", role: .destructive) {
-                    sessionManager.deleteSession(session)
+                    do {
+                        try sessionManager.deleteSession(session)
+                    } catch {
+                        errorMessage = "Failed to delete session: \(error.localizedDescription)"
+                    }
                     sessionToDelete = nil
                 }
                 Button("Cancel", role: .cancel) { sessionToDelete = nil }
             } message: { session in
                 Text("This will permanently delete \"\(session.title)\" and all its messages.")
+            }
+            .alert("Error", isPresented: Binding(
+                get: { errorMessage != nil },
+                set: { if !$0 { errorMessage = nil } }
+            )) {
+                Button("OK") { errorMessage = nil }
+            } message: {
+                if let errorMessage { Text(errorMessage) }
             }
         }
     }

--- a/Tests/BaseChatCoreTests/APIEndpointTests.swift
+++ b/Tests/BaseChatCoreTests/APIEndpointTests.swift
@@ -63,8 +63,7 @@ final class APIEndpointTests: XCTestCase {
 
     func test_isValid_validHTTPS() {
         let endpoint = makeEndpoint(provider: .openAI, baseURL: "https://api.openai.com")
-        endpoint.setAPIKey("sk-valid-key")
-        XCTAssertTrue(endpoint.isValid)
+        XCTAssertTrue(endpoint.isValid, "Valid HTTPS URL should pass structural validation")
     }
 
     func test_isValid_httpLocalhost_valid() {
@@ -80,11 +79,28 @@ final class APIEndpointTests: XCTestCase {
                        "HTTP non-localhost should be invalid")
     }
 
-    func test_isValid_missingAPIKey_invalid() {
+    func test_isValid_structuralOnly_ignoresAPIKey() {
         let endpoint = makeEndpoint(provider: .openAI, baseURL: "https://api.openai.com")
-        // No API key set — provider requires one
-        XCTAssertFalse(endpoint.isValid,
-                       "OpenAI endpoint without API key should be invalid")
+        // isValid is now structural-only — no API key check
+        XCTAssertTrue(endpoint.isValid,
+                      "isValid should pass for valid URL regardless of API key presence")
+    }
+
+    func test_keychainService_replacesApiKeyProperty() {
+        let endpoint = makeEndpoint(provider: .openAI, baseURL: "https://api.openai.com")
+        XCTAssertNil(KeychainService.retrieve(account: endpoint.keychainAccount),
+                     "No key stored yet")
+
+        endpoint.setAPIKey("sk-test-key")
+        XCTAssertEqual(KeychainService.retrieve(account: endpoint.keychainAccount), "sk-test-key",
+                       "KeychainService.retrieve should replace the old .apiKey property")
+    }
+
+    func test_requiresAPIKey_availableOnProvider() {
+        XCTAssertTrue(APIProvider.openAI.requiresAPIKey,
+                      "OpenAI provider should declare it requires an API key")
+        XCTAssertFalse(APIProvider.ollama.requiresAPIKey,
+                       "Ollama provider should not require an API key")
     }
 
     func test_isValid_ollamaNoKey_valid() {

--- a/Tests/BaseChatCoreTests/BackendCapabilitiesTests.swift
+++ b/Tests/BaseChatCoreTests/BackendCapabilitiesTests.swift
@@ -369,6 +369,23 @@ final class BackendCapabilitiesTests: XCTestCase {
         XCTAssertEqual(result.totalTokens, 50)
     }
 
+    func test_backendCapabilities_allDefaultsInit() {
+        let caps = BackendCapabilities()
+
+        XCTAssertEqual(caps.supportedParameters, [.temperature])
+        XCTAssertEqual(caps.maxContextTokens, 4096)
+        XCTAssertFalse(caps.requiresPromptTemplate)
+        XCTAssertTrue(caps.supportsSystemPrompt)
+        XCTAssertFalse(caps.supportsToolCalling)
+        XCTAssertFalse(caps.supportsStructuredOutput)
+        XCTAssertEqual(caps.cancellationStyle, .cooperative)
+        XCTAssertFalse(caps.supportsTokenCounting)
+        XCTAssertEqual(caps.memoryStrategy, .resident)
+        XCTAssertEqual(caps.maxOutputTokens, 4096)
+        XCTAssertTrue(caps.supportsStreaming)
+        XCTAssertFalse(caps.isRemote)
+    }
+
     func test_promptAssembler_capabilities_overload_trimsWhenContextSmall() {
         struct CharTok: TokenizerProvider { func tokenCount(_ t: String) -> Int { t.count } }
         let caps = BackendCapabilities(

--- a/Tests/BaseChatCoreTests/SettingsServiceTests.swift
+++ b/Tests/BaseChatCoreTests/SettingsServiceTests.swift
@@ -22,10 +22,10 @@ final class SettingsServiceTests: XCTestCase {
 
     // MARK: - Global Defaults
 
-    func test_globalDefaults_returnsExpectedValues() {
-        XCTAssertEqual(service.globalTemperature, 0.7, accuracy: 0.01)
-        XCTAssertEqual(service.globalTopP, 0.9, accuracy: 0.01)
-        XCTAssertEqual(service.globalRepeatPenalty, 1.1, accuracy: 0.01)
+    func test_globalDefaults_nilWhenUnset() {
+        XCTAssertNil(service.globalTemperature)
+        XCTAssertNil(service.globalTopP)
+        XCTAssertNil(service.globalRepeatPenalty)
     }
 
     func test_globalDefaults_persistAcrossInstances() {
@@ -36,9 +36,9 @@ final class SettingsServiceTests: XCTestCase {
         // Create a new instance pointing to the same defaults
         let service2 = SettingsService(defaults: testDefaults)
 
-        XCTAssertEqual(service2.globalTemperature, 1.5, accuracy: 0.01)
-        XCTAssertEqual(service2.globalTopP, 0.5, accuracy: 0.01)
-        XCTAssertEqual(service2.globalRepeatPenalty, 1.8, accuracy: 0.01)
+        XCTAssertEqual(service2.globalTemperature!, 1.5, accuracy: 0.01)
+        XCTAssertEqual(service2.globalTopP!, 0.5, accuracy: 0.01)
+        XCTAssertEqual(service2.globalRepeatPenalty!, 1.8, accuracy: 0.01)
     }
 
     // MARK: - Effective Values (Session Override)
@@ -125,5 +125,34 @@ final class SettingsServiceTests: XCTestCase {
 
         let service2 = SettingsService(defaults: testDefaults)
         XCTAssertNil(service2.globalPromptTemplate)
+    }
+
+    // MARK: - Nil vs Zero Distinction
+
+    func test_globalTemperature_zeroIsDistinctFromNil() {
+        service.globalTemperature = 0.0
+
+        XCTAssertEqual(service.globalTemperature, 0.0,
+                       "Setting to 0.0 should persist as 0.0, not be treated as unset")
+    }
+
+    func test_globalTemperature_settingNilRemovesKey() {
+        service.globalTemperature = 0.5
+        XCTAssertNotNil(service.globalTemperature)
+
+        service.globalTemperature = nil
+        XCTAssertNil(service.globalTemperature)
+    }
+
+    func test_effectiveTemperature_nilGlobalFallsToHardcodedDefault() {
+        // Neither session nor global is set
+        XCTAssertEqual(service.effectiveTemperature(session: nil), 0.7, accuracy: 0.01)
+    }
+
+    func test_effectiveTemperature_zeroGlobalDoesNotFallToDefault() {
+        service.globalTemperature = 0.0
+
+        XCTAssertEqual(service.effectiveTemperature(session: nil), 0.0, accuracy: 0.01,
+                       "Global 0.0 should be used, not the hardcoded 0.7 default")
     }
 }

--- a/Tests/BaseChatUITests/ChatViewModelIntegrationTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelIntegrationTests.swift
@@ -375,20 +375,20 @@ final class ChatViewModelIntegrationTests: XCTestCase {
 
     // MARK: - Session Creation Through Manager
 
-    func test_sessionManager_createAndDelete_persistsCorrectly() {
+    func test_sessionManager_createAndDelete_persistsCorrectly() throws {
         XCTAssertTrue(fetchSessions().isEmpty, "Should start with no sessions")
 
         let session = try! sessionManager.createSession(title: "My Chat")
         XCTAssertEqual(fetchSessions().count, 1)
         XCTAssertEqual(fetchSessions().first?.title, "My Chat")
 
-        sessionManager.deleteSession(session)
+        try sessionManager.deleteSession(session)
         XCTAssertTrue(fetchSessions().isEmpty, "Session should be deleted from database")
     }
 
     // MARK: - Delete Session Cascades to Messages
 
-    func test_deleteSession_removesAllSessionMessages() async {
+    func test_deleteSession_removesAllSessionMessages() async throws {
         let session = createAndActivateSession()
 
         mock.tokensToYield = ["Reply"]
@@ -399,7 +399,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
 
         XCTAssertEqual(fetchMessages(for: session.id).count, 4)
 
-        sessionManager.deleteSession(session)
+        try sessionManager.deleteSession(session)
 
         XCTAssertEqual(fetchMessages(for: session.id).count, 0,
                        "All messages should be deleted when session is deleted")

--- a/Tests/BaseChatUITests/CompressionIntegrationTests.swift
+++ b/Tests/BaseChatUITests/CompressionIntegrationTests.swift
@@ -73,8 +73,6 @@ final class CompressionIntegrationTests: XCTestCase {
 
         XCTAssertEqual(session.toRecord().compressionMode, .balanced,
                        "Session should have .balanced after setting compressionMode")
-        XCTAssertEqual(session.toRecord().compressionModeRaw, "Balanced",
-                       "Raw storage should be 'Balanced'")
     }
 
     func test_compressionMode_switchToSession_restoresBalanced() {

--- a/Tests/BaseChatUITests/PersistenceIntegrationTests.swift
+++ b/Tests/BaseChatUITests/PersistenceIntegrationTests.swift
@@ -313,4 +313,49 @@ final class PersistenceIntegrationTests: XCTestCase {
             "Session B's messages should be deleted"
         )
     }
+
+    // MARK: - Typed Record Field Round-Trips
+
+    func test_sessionRecord_compressionMode_roundTrips() throws {
+        let persistence = SwiftDataPersistenceProvider(modelContext: context)
+        var record = ChatSessionRecord(title: "Compression Test")
+        record.compressionMode = .balanced
+        try persistence.insertSession(record)
+
+        let fetched = try persistence.fetchSessions().first { $0.id == record.id }
+        XCTAssertEqual(fetched?.compressionMode, .balanced)
+    }
+
+    func test_sessionRecord_promptTemplate_roundTrips() throws {
+        let persistence = SwiftDataPersistenceProvider(modelContext: context)
+        var record = ChatSessionRecord(title: "Template Test")
+        record.promptTemplate = .llama3
+        try persistence.insertSession(record)
+
+        let fetched = try persistence.fetchSessions().first { $0.id == record.id }
+        XCTAssertEqual(fetched?.promptTemplate, .llama3)
+    }
+
+    func test_sessionRecord_pinnedMessageIDs_roundTrips() throws {
+        let persistence = SwiftDataPersistenceProvider(modelContext: context)
+        let pinA = UUID()
+        let pinB = UUID()
+        var record = ChatSessionRecord(title: "Pin Test")
+        record.pinnedMessageIDs = [pinA, pinB]
+        try persistence.insertSession(record)
+
+        let fetched = try persistence.fetchSessions().first { $0.id == record.id }
+        XCTAssertEqual(fetched?.pinnedMessageIDs, [pinA, pinB])
+    }
+
+    func test_sessionRecord_defaults_roundTrip() throws {
+        let persistence = SwiftDataPersistenceProvider(modelContext: context)
+        let record = ChatSessionRecord(title: "Defaults Test")
+        try persistence.insertSession(record)
+
+        let fetched = try persistence.fetchSessions().first { $0.id == record.id }
+        XCTAssertEqual(fetched?.compressionMode, .automatic)
+        XCTAssertNil(fetched?.promptTemplate)
+        XCTAssertEqual(fetched?.pinnedMessageIDs, [])
+    }
 }

--- a/Tests/BaseChatUITests/PersistenceIntegrationTests.swift
+++ b/Tests/BaseChatUITests/PersistenceIntegrationTests.swift
@@ -256,7 +256,7 @@ final class PersistenceIntegrationTests: XCTestCase {
 
     // MARK: - Cascade: Deleting a Session Handles Its Messages
 
-    func test_deleteSession_removesAssociatedMessages() async {
+    func test_deleteSession_removesAssociatedMessages() async throws {
         let session = createSession(title: "Doomed Session")
         mock.tokensToYield = ["Doomed", " reply"]
         vm.inputText = "Message in doomed session"
@@ -270,7 +270,7 @@ final class PersistenceIntegrationTests: XCTestCase {
         // Use SessionManagerViewModel to delete the session (it handles cascade).
         let sessionManager = SessionManagerViewModel()
         sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
-        sessionManager.deleteSession(session.toRecord())
+        try sessionManager.deleteSession(session.toRecord())
 
         XCTAssertEqual(
             fetchMessages(for: sessionID).count, 0,
@@ -282,7 +282,7 @@ final class PersistenceIntegrationTests: XCTestCase {
         )
     }
 
-    func test_deleteSession_doesNotAffectOtherSessions() async {
+    func test_deleteSession_doesNotAffectOtherSessions() async throws {
         // Create session A with messages.
         let sessionA = createSession(title: "Survivor")
         mock.tokensToYield = ["Survivor", " reply"]
@@ -301,7 +301,7 @@ final class PersistenceIntegrationTests: XCTestCase {
         // Delete session B.
         let sessionManager = SessionManagerViewModel()
         sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
-        sessionManager.deleteSession(sessionB.toRecord())
+        try sessionManager.deleteSession(sessionB.toRecord())
 
         // Session A should be unaffected.
         XCTAssertEqual(

--- a/Tests/BaseChatUITests/SessionManagerViewModelTests.swift
+++ b/Tests/BaseChatUITests/SessionManagerViewModelTests.swift
@@ -46,27 +46,27 @@ final class SessionManagerViewModelTests: XCTestCase {
     // MARK: - Delete
 
     @MainActor
-    func test_deleteSession_removesSession() {
-        let session = try! vm.createSession(title: "To Delete")
+    func test_deleteSession_removesSession() throws {
+        let session = try vm.createSession(title: "To Delete")
         XCTAssertEqual(vm.sessions.count, 1)
 
-        vm.deleteSession(session)
+        try vm.deleteSession(session)
 
         XCTAssertEqual(vm.sessions.count, 0)
     }
 
     @MainActor
-    func test_deleteSession_removesAssociatedMessages() {
-        let session = try! vm.createSession()
+    func test_deleteSession_removesAssociatedMessages() throws {
+        let session = try vm.createSession()
 
         // Insert messages for this session
         let msg1 = ChatMessage(role: .user, content: "Hello", sessionID: session.id)
         let msg2 = ChatMessage(role: .assistant, content: "Hi", sessionID: session.id)
         context.insert(msg1)
         context.insert(msg2)
-        try? context.save()
+        try context.save()
 
-        vm.deleteSession(session)
+        try vm.deleteSession(session)
 
         // Verify messages are also deleted
         let sessionID = session.id
@@ -78,11 +78,11 @@ final class SessionManagerViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_deleteSession_clearsActiveIfDeleted() {
-        let session = try! vm.createSession()
+    func test_deleteSession_clearsActiveIfDeleted() throws {
+        let session = try vm.createSession()
         vm.activeSession = session
 
-        vm.deleteSession(session)
+        try vm.deleteSession(session)
 
         XCTAssertNil(vm.activeSession)
     }
@@ -90,10 +90,10 @@ final class SessionManagerViewModelTests: XCTestCase {
     // MARK: - Rename
 
     @MainActor
-    func test_renameSession_updatesTitle() {
-        let session = try! vm.createSession(title: "Original")
+    func test_renameSession_updatesTitle() throws {
+        let session = try vm.createSession(title: "Original")
 
-        vm.renameSession(session, title: "Renamed")
+        try vm.renameSession(session, title: "Renamed")
 
         let updated = vm.sessions.first { $0.id == session.id }
         XCTAssertEqual(updated?.title, "Renamed")
@@ -161,5 +161,44 @@ final class SessionManagerViewModelTests: XCTestCase {
         XCTAssertEqual(vm.sessions[0].title, "Newest")
         XCTAssertEqual(vm.sessions[1].title, "Middle")
         XCTAssertEqual(vm.sessions[2].title, "Oldest")
+    }
+
+    // MARK: - Error Propagation
+
+    @MainActor
+    func test_deleteSession_throwsOnMissingSession() {
+        let ghost = ChatSessionRecord(title: "Ghost")
+        XCTAssertThrowsError(try vm.deleteSession(ghost)) { error in
+            guard let persistError = error as? ChatPersistenceError,
+                  case .sessionNotFound = persistError else {
+                XCTFail("Expected sessionNotFound, got \(error)")
+                return
+            }
+        }
+    }
+
+    @MainActor
+    func test_renameSession_throwsOnMissingSession() {
+        let ghost = ChatSessionRecord(title: "Ghost")
+        XCTAssertThrowsError(try vm.renameSession(ghost, title: "New Name")) { error in
+            guard let persistError = error as? ChatPersistenceError,
+                  case .sessionNotFound = persistError else {
+                XCTFail("Expected sessionNotFound, got \(error)")
+                return
+            }
+        }
+    }
+
+    @MainActor
+    func test_deleteSession_throwDoesNotCorruptSessionList() throws {
+        let session = try vm.createSession(title: "Real")
+        let ghost = ChatSessionRecord(title: "Ghost")
+        XCTAssertEqual(vm.sessions.count, 1)
+
+        XCTAssertThrowsError(try vm.deleteSession(ghost))
+
+        // The real session should still be present
+        XCTAssertEqual(vm.sessions.count, 1)
+        XCTAssertEqual(vm.sessions.first?.title, "Real")
     }
 }


### PR DESCRIPTION
## Summary

- **Fix mlx-swift-lm HuggingFace linker error** — pin to commit `d1b14783` which adds the `MLXHuggingFace` target, fixing the transitive `Hub` import that Swift 6.3 / Xcode 26 rejects
- **Consolidate BackendCapabilities init** — remove the 4-param convenience init; all 12 parameters now have sensible defaults so adding new capabilities never forces changes to backends or mocks
- **Replace ChatSessionRecord raw strings with typed properties** — `compressionModeRaw`, `promptTemplateRawValue`, `pinnedMessageIDsRaw` replaced by `compressionMode: CompressionMode`, `promptTemplate: PromptTemplate?`, `pinnedMessageIDs: Set<UUID>`; raw↔typed conversion handled by SwiftDataPersistenceProvider
- **Remove APIEndpoint.apiKey computed property** — SwiftData `@Model` no longer performs Keychain I/O; callers use `KeychainService.retrieve(account: endpoint.keychainAccount)` directly; `isValid` is now structural-only (URL validation, no credential check)
- **Remove deprecated `configure(modelContext:)` initializers** — from both ChatViewModel and SessionManagerViewModel
- **Make SessionManagerViewModel delete/rename throwing** — `deleteSession` and `renameSession` propagate persistence errors instead of silently swallowing them; SessionListView surfaces errors via alert
- **Make SettingsService global defaults optional (Float?)** — fixes bug where `UserDefaults.float(forKey:)` returns 0 for missing keys, conflating "unset" with "user set 0.0"

## Breaking Changes

| Change | Migration |
|--------|-----------|
| MLXBackend uses new `loadModelContainer(from:using:)` API | Update any custom MLX loading code |
| BackendCapabilities 4-param init removed | All labeled-arg call sites compile unchanged; positional callers switch to labels |
| `ChatSessionRecord.compressionModeRaw` / `promptTemplateRawValue` / `pinnedMessageIDsRaw` removed | Use `.compressionMode`, `.promptTemplate`, `.pinnedMessageIDs` |
| `APIEndpoint.apiKey` removed | Use `KeychainService.retrieve(account: endpoint.keychainAccount)` |
| `APIEndpoint.isValid` no longer checks API key | Check `APIProvider.requiresAPIKey` separately |
| `configure(modelContext:)` removed | Use `configure(persistence: SwiftDataPersistenceProvider(modelContext:))` |
| `deleteSession` / `renameSession` now throw | Wrap in `do/catch` |
| `globalTemperature` / `globalTopP` / `globalRepeatPenalty` are `Float?` | Handle optional; use `?? 0.7` etc. for display |

## Release Note

**v1.0.0 — Breaking API improvements bundled with mlx-swift-lm migration.** An upstream change in mlx-swift-lm forced a breaking update to MLXBackend's model loading API. We used this as the trigger to ship six additional breaking improvements that fix real bugs (SettingsService zero/unset conflation), improve correctness (throwing CRUD, no Keychain I/O in SwiftData models), and reduce future maintenance cost (defaulted BackendCapabilities init, typed record fields). See the migration table above for upgrade guidance.

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 105 tests, 0 failures
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 388 tests, 0 failures
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 76 tests, 0 failures
- [x] ~15 new tests added covering: default-value verification, typed-field round-trips, structural isValid, error propagation, nil-vs-zero distinction

🤖 Generated with [Claude Code](https://claude.com/claude-code)