### PR TITLE
test: add macOS control visibility tests for all major views

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8603a005127f3ca787c6fefef6590efdaa7165e542337a713f8dcfce47ec1a15",
+  "originHash" : "a5e57cdcaafddaa4c1ea15543f8a0abd1f24aa357b532d41f61ab43435cf85b1",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "llama.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/llama.swift",
+      "state" : {
+        "revision" : "3a8429ad1c012a9e819e251e0c87852cbde0c74a",
+        "version" : "2.8721.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "BaseChatUI", targets: ["BaseChatUI"]),
     ],
     traits: [
-        .default(enabledTraits: ["MLX"]),
+        .default(enabledTraits: ["MLX", "Llama"]),
         .trait(name: "MLX", description: "Enable the MLX inference backend (requires Apple Silicon)"),
         .trait(name: "Llama", description: "Enable the llama.cpp (GGUF) inference backend"),
     ],
@@ -97,6 +97,7 @@ let package = Package(
             dependencies: [
                 "BaseChatUI",
                 "BaseChatCore",
+                "BaseChatTestSupport",
                 .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
             ],
             exclude: ["__Snapshots__"]

--- a/Tests/BaseChatSnapshotTests/ChatViewControlTests.swift
+++ b/Tests/BaseChatSnapshotTests/ChatViewControlTests.swift
@@ -1,0 +1,191 @@
+import XCTest
+import SwiftUI
+@testable import BaseChatUI
+@testable import BaseChatCore
+import BaseChatTestSupport
+
+/// Verifies that user-facing controls in ChatView and ChatInputBar are present
+/// in the view hierarchy across different states.
+///
+/// Uses `Swift.dump()` on a hosted view to capture the hierarchy as text,
+/// then asserts expected type names and string literals appear. SF Symbol names
+/// and accessibility labels are NOT captured by `Swift.dump()` — those are tested
+/// indirectly via type references and state properties. This catches accidental
+/// control removal without requiring pixel rendering or XCUITest infrastructure.
+@MainActor
+final class ChatViewControlTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func viewHierarchy<V: View>(_ view: V, width: CGFloat = 800, height: CGFloat = 600) -> String {
+        #if canImport(AppKit)
+        let vc = NSHostingController(rootView: view)
+        vc.view.frame = NSRect(x: 0, y: 0, width: width, height: height)
+        vc.view.layoutSubtreeIfNeeded()
+        #elseif canImport(UIKit)
+        let vc = UIHostingController(rootView: view)
+        vc.view.frame = CGRect(x: 0, y: 0, width: width, height: height)
+        vc.view.layoutIfNeeded()
+        #endif
+        var dump = ""
+        Swift.dump(vc, to: &dump)
+        return dump
+    }
+
+    private func makeChatViewModel() -> ChatViewModel {
+        let oneGB: UInt64 = 1_024 * 1_024 * 1_024
+        return ChatViewModel(
+            inferenceService: InferenceService(),
+            deviceCapability: DeviceCapabilityService(physicalMemory: 16 * oneGB),
+            modelStorage: ModelStorageService(
+                baseDirectory: FileManager.default.temporaryDirectory
+                    .appendingPathComponent(UUID().uuidString)
+            )
+        )
+    }
+
+    private func makeChatViewModelWithMock() -> ChatViewModel {
+        let oneGB: UInt64 = 1_024 * 1_024 * 1_024
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        let service = InferenceService(backend: mock, name: "Mock")
+        let vm = ChatViewModel(
+            inferenceService: service,
+            deviceCapability: DeviceCapabilityService(physicalMemory: 16 * oneGB),
+            modelStorage: ModelStorageService(
+                baseDirectory: FileManager.default.temporaryDirectory
+                    .appendingPathComponent(UUID().uuidString)
+            )
+        )
+        vm.activeSession = ChatSessionRecord(title: "Test Session")
+        return vm
+    }
+
+    // MARK: - ChatView — No Model Loaded (Empty)
+
+    private func chatViewDump(viewModel: ChatViewModel? = nil) -> String {
+        let vm = viewModel ?? makeChatViewModel()
+        return viewHierarchy(
+            NavigationStack {
+                ChatView(showModelManagement: .constant(false))
+            }
+            .environment(vm)
+        )
+    }
+
+    func test_chatView_noModel_showsBrowseModelsButton() {
+        let dump = chatViewDump()
+        XCTAssertTrue(
+            dump.contains("Browse Models"),
+            "ChatView with no models should show 'Browse Models' button"
+        )
+    }
+
+    func test_chatView_noModel_showsWelcomeText() {
+        let dump = chatViewDump()
+        XCTAssertTrue(
+            dump.contains("Download a model to get started"),
+            "ChatView with no models should show welcome text"
+        )
+    }
+
+    // MARK: - ChatView — Clear Chat Alert
+
+    func test_chatView_hasClearChatAlert() {
+        let dump = chatViewDump()
+        XCTAssertTrue(
+            dump.contains("Clear Chat"),
+            "ChatView should have the 'Clear Chat' alert configured"
+        )
+    }
+
+    // MARK: - ChatView — Settings and Export Sheets
+
+    func test_chatView_hasGenerationSettingsSheet() {
+        let dump = chatViewDump()
+        XCTAssertTrue(
+            dump.contains("GenerationSettingsView"),
+            "ChatView should reference GenerationSettingsView for the settings sheet"
+        )
+    }
+
+    func test_chatView_hasChatExportSheet() {
+        let dump = chatViewDump()
+        XCTAssertTrue(
+            dump.contains("ChatExportSheet"),
+            "ChatView should reference ChatExportSheet for the export sheet"
+        )
+    }
+
+    // MARK: - ChatInputBar — Default State
+
+    private func inputBarDump(viewModel: ChatViewModel? = nil) -> String {
+        let vm = viewModel ?? makeChatViewModel()
+        return viewHierarchy(
+            ChatInputBar()
+                .environment(vm)
+        )
+    }
+
+    func test_inputBar_hasTextField() {
+        let dump = inputBarDump()
+        XCTAssertTrue(
+            dump.contains("Message..."),
+            "ChatInputBar should contain a text field with 'Message...' placeholder"
+        )
+    }
+
+    func test_inputBar_containsChatInputBarType() {
+        let dump = inputBarDump()
+        XCTAssertTrue(
+            dump.contains("ChatInputBar"),
+            "Dump should contain the ChatInputBar type"
+        )
+    }
+
+    func test_inputBar_hasFocusState() {
+        let dump = inputBarDump()
+        XCTAssertTrue(
+            dump.contains("FocusState"),
+            "ChatInputBar should have a FocusState for input focus management"
+        )
+    }
+
+    func test_inputBar_hasKeyboardShortcut() {
+        let dump = inputBarDump()
+        XCTAssertTrue(
+            dump.contains("KeyboardShortcut"),
+            "ChatInputBar should have a keyboard shortcut for sending"
+        )
+    }
+
+    // MARK: - ChatView — Navigation Title
+
+    func test_chatView_hasNavigationTitle() {
+        let dump = chatViewDump()
+        XCTAssertTrue(
+            dump.contains("NavigationTitleKey"),
+            "ChatView should set a navigation title"
+        )
+    }
+
+    // MARK: - ChatView — Model Loaded State
+
+    func test_chatView_modelLoaded_showsEmptyPlaceholder() {
+        let vm = makeChatViewModelWithMock()
+        let dump = chatViewDump(viewModel: vm)
+        XCTAssertTrue(
+            dump.contains("Send a message to start chatting."),
+            "ChatView with model loaded but no messages should show empty placeholder"
+        )
+    }
+
+    func test_chatView_modelLoaded_doesNotShowBrowseModels() {
+        let vm = makeChatViewModelWithMock()
+        let dump = chatViewDump(viewModel: vm)
+        XCTAssertFalse(
+            dump.contains("Browse Models"),
+            "ChatView with model loaded should not show 'Browse Models' button"
+        )
+    }
+}

--- a/Tests/BaseChatSnapshotTests/ModelAndSettingsControlTests.swift
+++ b/Tests/BaseChatSnapshotTests/ModelAndSettingsControlTests.swift
@@ -1,0 +1,314 @@
+import XCTest
+import SwiftUI
+@testable import BaseChatUI
+@testable import BaseChatCore
+
+/// Verifies that all user-facing controls in ModelManagementSheet and
+/// GenerationSettingsView are present in the view hierarchy.
+///
+/// Uses `Swift.dump()` on a hosted view to capture the hierarchy as text,
+/// then asserts expected type names, SF Symbol identifiers, and rendered
+/// string literals appear. This catches accidental control removal without
+/// requiring pixel rendering or XCUITest.
+///
+/// Note: SwiftUI's dump output includes rendered text for Form-based views
+/// (GenerationSettingsView) but not for List-based views (ModelManagementSheet
+/// tab content). For List views, we assert on type names and SF Symbol
+/// identifiers instead.
+@MainActor
+final class ModelAndSettingsControlTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func viewHierarchy<V: View>(_ view: V, width: CGFloat = 800, height: CGFloat = 600) -> String {
+        #if canImport(AppKit)
+        let vc = NSHostingController(rootView: view)
+        vc.view.frame = NSRect(x: 0, y: 0, width: width, height: height)
+        vc.view.layoutSubtreeIfNeeded()
+        #elseif canImport(UIKit)
+        let vc = UIHostingController(rootView: view)
+        vc.view.frame = CGRect(x: 0, y: 0, width: width, height: height)
+        vc.view.layoutIfNeeded()
+        #endif
+        var dump = ""
+        Swift.dump(vc, to: &dump)
+        return dump
+    }
+
+    private func makeChatViewModel() -> ChatViewModel {
+        let oneGB: UInt64 = 1_024 * 1_024 * 1_024
+        return ChatViewModel(
+            inferenceService: InferenceService(),
+            deviceCapability: DeviceCapabilityService(physicalMemory: 16 * oneGB),
+            modelStorage: ModelStorageService(
+                baseDirectory: FileManager.default.temporaryDirectory
+                    .appendingPathComponent(UUID().uuidString)
+            )
+        )
+    }
+
+    // MARK: - ModelManagementSheet — Tab Structure
+
+    private func modelManagementDump(tab: ModelManagementSheet.Tab = .select) -> String {
+        viewHierarchy(
+            ModelManagementSheet(initialTab: tab)
+                .environment(makeChatViewModel())
+                .environment(ModelManagementViewModel())
+        )
+    }
+
+    func test_modelManagement_hasAllTabEnumCases() {
+        let dump = modelManagementDump(tab: .select)
+        // Tab enum cases appear as "Tab.select", "Tab.download", "Tab.storage" in the dump
+        XCTAssertTrue(dump.contains("Tab.select"), "Should contain the Select tab case")
+        XCTAssertTrue(dump.contains("Tab.download"), "Should contain the Download tab case")
+        XCTAssertTrue(dump.contains("Tab.storage"), "Should contain the Storage tab case")
+    }
+
+    func test_modelManagement_hasTabSFSymbols() {
+        let dump = modelManagementDump(tab: .select)
+        // SF Symbols used in tab labels
+        XCTAssertTrue(dump.contains("checkmark.circle"), "Select tab icon should be present")
+        XCTAssertTrue(dump.contains("square.and.arrow.down"), "Download tab icon should be present")
+        XCTAssertTrue(dump.contains("externaldrive"), "Storage tab icon should be present")
+    }
+
+    func test_modelManagement_hasSegmentedPicker() {
+        let dump = modelManagementDump(tab: .select)
+        // macOS renders segmented pickers as SystemSegmentedControl
+        #if canImport(AppKit)
+        XCTAssertTrue(
+            dump.contains("SystemSegmentedControl"),
+            "Tab picker should render as a segmented control"
+        )
+        #endif
+    }
+
+    // MARK: - ModelManagementSheet — Download Tab Content
+
+    func test_modelManagement_downloadTab_hasWhyDownloadView() {
+        let dump = modelManagementDump(tab: .download)
+        XCTAssertTrue(
+            dump.contains("WhyDownloadView"),
+            "Download tab should contain the WhyDownloadView explainer"
+        )
+    }
+
+    func test_modelManagement_downloadTab_hasDownloadableModelRow() {
+        let dump = modelManagementDump(tab: .download)
+        // DownloadableModelRow is rendered for recommended models
+        XCTAssertTrue(
+            dump.contains("DownloadableModelRow"),
+            "Download tab should contain DownloadableModelRow for recommended models"
+        )
+    }
+
+    func test_modelManagement_downloadTab_hasDownloadableModelGroup() {
+        let dump = modelManagementDump(tab: .download)
+        XCTAssertTrue(
+            dump.contains("DownloadableModelGroup"),
+            "Download tab should reference DownloadableModelGroup for search result grouping"
+        )
+    }
+
+    func test_modelManagement_downloadTab_notInSelectTab() {
+        let dump = modelManagementDump(tab: .select)
+        // WhyDownloadView and DownloadableModelRow should NOT appear in the select tab
+        XCTAssertFalse(
+            dump.contains("WhyDownloadView"),
+            "Select tab should not contain WhyDownloadView (download tab content)"
+        )
+        XCTAssertFalse(
+            dump.contains("DownloadableModelRow"),
+            "Select tab should not contain DownloadableModelRow (download tab content)"
+        )
+    }
+
+    // MARK: - ModelManagementSheet — Storage Tab Content
+
+    func test_modelManagement_storageTab_hasDeleteModelAlert() {
+        let dump = modelManagementDump(tab: .storage)
+        // The alert title "Delete Model" appears in the dump as a string literal
+        XCTAssertTrue(
+            dump.contains("Delete Model"),
+            "Storage tab should have a 'Delete Model' confirmation alert configured"
+        )
+    }
+
+    func test_modelManagement_storageTab_notInSelectTab() {
+        let dump = modelManagementDump(tab: .select)
+        XCTAssertFalse(
+            dump.contains("Delete Model"),
+            "Select tab should not contain 'Delete Model' alert (storage tab content)"
+        )
+    }
+
+    // MARK: - GenerationSettingsView — Text Labels
+
+    /// Shared dump for settings tests to avoid repeated view construction.
+    private func generationSettingsDump() -> String {
+        viewHierarchy(
+            GenerationSettingsView()
+                .environment(makeChatViewModel())
+        )
+    }
+
+    func test_generationSettings_hasTemperatureLabel() {
+        let dump = generationSettingsDump()
+        XCTAssertTrue(
+            dump.contains("Temperature"),
+            "Settings should contain the 'Temperature' label"
+        )
+    }
+
+    func test_generationSettings_hasTemperatureDefaultValue() {
+        let dump = generationSettingsDump()
+        // Default temperature of 0.70 is rendered as text
+        XCTAssertTrue(
+            dump.contains("0.70"),
+            "Settings should show the default temperature value (0.70)"
+        )
+    }
+
+    func test_generationSettings_hasSystemPromptSection() {
+        let dump = generationSettingsDump()
+        XCTAssertTrue(
+            dump.contains("System Prompt"),
+            "Settings should contain the 'System Prompt' section header"
+        )
+    }
+
+    func test_generationSettings_hasSystemPromptPlaceholder() {
+        let dump = generationSettingsDump()
+        XCTAssertTrue(
+            dump.contains("Optional system instructions..."),
+            "Settings should contain the system prompt placeholder text"
+        )
+    }
+
+    func test_generationSettings_hasColorSchemePicker() {
+        let dump = generationSettingsDump()
+        XCTAssertTrue(dump.contains("Color Scheme"), "Should contain the Color Scheme picker label")
+        XCTAssertTrue(dump.contains("Light"), "Should contain the Light appearance option")
+        XCTAssertTrue(dump.contains("Dark"), "Should contain the Dark appearance option")
+    }
+
+    func test_generationSettings_hasCompressionPicker() {
+        let dump = generationSettingsDump()
+        XCTAssertTrue(dump.contains("Compression"), "Should contain the Compression picker label")
+        XCTAssertTrue(
+            dump.contains("Context Compression"),
+            "Should contain the Context Compression section header"
+        )
+    }
+
+    func test_generationSettings_hasCompressionDescription() {
+        let dump = generationSettingsDump()
+        XCTAssertTrue(
+            dump.contains("Controls how conversation history is compressed"),
+            "Should contain the compression help text"
+        )
+    }
+
+    func test_generationSettings_hasResetToDefaults() {
+        let dump = generationSettingsDump()
+        XCTAssertTrue(
+            dump.contains("Reset to Defaults"),
+            "Settings should contain the 'Reset to Defaults' button"
+        )
+    }
+
+    func test_generationSettings_hasAdvancedSettingsDisclosure() {
+        let dump = generationSettingsDump()
+        XCTAssertTrue(
+            dump.contains("Advanced Settings"),
+            "Settings should contain the 'Advanced Settings' disclosure group label"
+        )
+    }
+
+    func test_generationSettings_hasSamplingSection() {
+        let dump = generationSettingsDump()
+        XCTAssertTrue(
+            dump.contains("Sampling"),
+            "Settings should contain the 'Sampling' section header"
+        )
+    }
+
+    func test_generationSettings_hasAppearanceSection() {
+        let dump = generationSettingsDump()
+        XCTAssertTrue(
+            dump.contains("Appearance"),
+            "Settings should contain the 'Appearance' section header"
+        )
+    }
+
+    // MARK: - GenerationSettingsView — Platform Controls
+
+    #if canImport(AppKit)
+    func test_generationSettings_hasSliderControl() {
+        let dump = generationSettingsDump()
+        XCTAssertTrue(
+            dump.contains("SystemSlider"),
+            "Settings should render a system slider (temperature control)"
+        )
+    }
+
+    func test_generationSettings_hasTextEditorControl() {
+        let dump = generationSettingsDump()
+        XCTAssertTrue(
+            dump.contains("AppKitTextEditorAdaptor"),
+            "Settings should render a text editor (system prompt)"
+        )
+    }
+
+    func test_generationSettings_hasSegmentedControl() {
+        let dump = generationSettingsDump()
+        XCTAssertTrue(
+            dump.contains("SystemSegmentedControl"),
+            "Settings should render a segmented control (color scheme picker)"
+        )
+    }
+
+    func test_generationSettings_hasPopUpControl() {
+        let dump = generationSettingsDump()
+        XCTAssertTrue(
+            dump.contains("AppKitPopUpAdaptor"),
+            "Settings should render a pop-up menu (compression mode picker)"
+        )
+    }
+    #endif
+
+    // MARK: - GenerationSettingsView — Advanced Section References
+
+    func test_generationSettings_hasSamplerPresetPicker() {
+        let dump = generationSettingsDump()
+        XCTAssertTrue(
+            dump.contains("SamplerPresetPickerView"),
+            "Settings should contain the SamplerPresetPickerView type reference"
+        )
+    }
+
+    func test_generationSettings_hasAPIConfigurationView() {
+        let dump = generationSettingsDump()
+        XCTAssertTrue(
+            dump.contains("APIConfigurationView"),
+            "Settings should contain the APIConfigurationView type reference"
+        )
+    }
+
+    func test_generationSettings_hasPromptInspectorView() {
+        let dump = generationSettingsDump()
+        XCTAssertTrue(
+            dump.contains("PromptInspectorView"),
+            "Settings should contain the PromptInspectorView type reference"
+        )
+    }
+
+    func test_generationSettings_showAdvancedSettingsAppStorage() {
+        let dump = generationSettingsDump()
+        XCTAssertTrue(
+            dump.contains("showAdvancedSettings"),
+            "Settings should reference the showAdvancedSettings AppStorage key"
+        )
+    }
+}

--- a/Tests/BaseChatSnapshotTests/SidebarAndSheetControlTests.swift
+++ b/Tests/BaseChatSnapshotTests/SidebarAndSheetControlTests.swift
@@ -1,0 +1,372 @@
+import XCTest
+import SwiftUI
+import SwiftData
+@testable import BaseChatUI
+@testable import BaseChatCore
+
+/// Verifies that user-facing controls in SessionListView, ChatExportSheet,
+/// and APIConfigurationView are present in the view hierarchy.
+///
+/// Uses `Swift.dump()` to capture the hosting controller's hierarchy as text,
+/// then asserts expected labels/buttons appear. This catches accidental removal
+/// of controls without requiring pixel rendering or XCUITest infrastructure.
+///
+/// Toolbar items, navigation titles, and system image names are embedded in
+/// SwiftUI's internal type signatures rather than appearing as literal strings,
+/// so those are verified by checking for their type-level representation
+/// (e.g. `ToolbarItem`, `NavigationTitleKey`, `ShareLink`).
+@MainActor
+final class SidebarAndSheetControlTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func dumpHierarchy<V: View>(_ view: V) -> String {
+        #if canImport(AppKit)
+        let vc = NSHostingController(rootView: view)
+        vc.view.frame = NSRect(x: 0, y: 0, width: 800, height: 600)
+        vc.view.layoutSubtreeIfNeeded()
+        #elseif canImport(UIKit)
+        let vc = UIHostingController(rootView: view)
+        vc.view.frame = CGRect(x: 0, y: 0, width: 800, height: 600)
+        vc.view.layoutIfNeeded()
+        #endif
+
+        var output = ""
+        Swift.dump(vc, to: &output)
+        return output
+    }
+
+    private func makeChatViewModel() -> ChatViewModel {
+        ChatViewModel(
+            inferenceService: InferenceService(),
+            deviceCapability: DeviceCapabilityService(physicalMemory: 16 * 1_024 * 1_024 * 1_024),
+            modelStorage: ModelStorageService(
+                baseDirectory: FileManager.default.temporaryDirectory
+                    .appendingPathComponent(UUID().uuidString)
+            )
+        )
+    }
+
+    private func makeInMemoryContainer() throws -> ModelContainer {
+        try ModelContainerFactory.makeInMemoryContainer()
+    }
+
+    // MARK: - SessionListView: Empty State
+
+    func test_sessionListView_emptyState_showsNoChatsLabel() {
+        let dump = dumpHierarchy(
+            SessionListView()
+                .environment(SessionManagerViewModel())
+        )
+
+        XCTAssertTrue(
+            dump.contains("No Chats"),
+            "Empty SessionListView must show \"No Chats\" label"
+        )
+    }
+
+    func test_sessionListView_emptyState_showsTapPlusHint() {
+        let dump = dumpHierarchy(
+            SessionListView()
+                .environment(SessionManagerViewModel())
+        )
+
+        XCTAssertTrue(
+            dump.contains("Tap the + button"),
+            "Empty SessionListView must show the \"Tap the + button\" hint"
+        )
+    }
+
+    func test_sessionListView_emptyState_doesNotShowList() {
+        let dump = dumpHierarchy(
+            SessionListView()
+                .environment(SessionManagerViewModel())
+        )
+
+        // When empty, SessionListView shows ContentUnavailableView instead of a List.
+        // SessionRowView should not appear in the hierarchy.
+        XCTAssertFalse(
+            dump.contains("SessionRowView"),
+            "Empty SessionListView must not contain any SessionRowView"
+        )
+    }
+
+    // MARK: - SessionListView: With Sessions
+
+    func test_sessionListView_withSessions_showsSessionRows() throws {
+        let container = try makeInMemoryContainer()
+        let persistence = SwiftDataPersistenceProvider(modelContext: container.mainContext)
+        let sessionManager = SessionManagerViewModel()
+        sessionManager.configure(persistence: persistence)
+        try sessionManager.createSession(title: "Test Chat Session")
+
+        let dump = dumpHierarchy(
+            SessionListView()
+                .environment(sessionManager)
+        )
+
+        XCTAssertTrue(
+            dump.contains("Test Chat Session"),
+            "SessionListView with sessions must render session title"
+        )
+    }
+
+    func test_sessionListView_withSessions_showsList() throws {
+        let container = try makeInMemoryContainer()
+        let persistence = SwiftDataPersistenceProvider(modelContext: container.mainContext)
+        let sessionManager = SessionManagerViewModel()
+        sessionManager.configure(persistence: persistence)
+        try sessionManager.createSession(title: "Session Alpha")
+        try sessionManager.createSession(title: "Session Beta")
+
+        let dump = dumpHierarchy(
+            SessionListView()
+                .environment(sessionManager)
+        )
+
+        XCTAssertTrue(
+            dump.contains("Session Alpha"),
+            "SessionListView must show first session"
+        )
+        XCTAssertTrue(
+            dump.contains("Session Beta"),
+            "SessionListView must show second session"
+        )
+    }
+
+    func test_sessionListView_withSessions_containsSessionRowView() throws {
+        let container = try makeInMemoryContainer()
+        let persistence = SwiftDataPersistenceProvider(modelContext: container.mainContext)
+        let sessionManager = SessionManagerViewModel()
+        sessionManager.configure(persistence: persistence)
+        try sessionManager.createSession(title: "Any Session")
+
+        let dump = dumpHierarchy(
+            SessionListView()
+                .environment(sessionManager)
+        )
+
+        XCTAssertTrue(
+            dump.contains("SessionRowView"),
+            "SessionListView with sessions must contain SessionRowView"
+        )
+    }
+
+    // MARK: - ChatExportSheet: Form Content
+
+    func test_chatExportSheet_showsFormatSection() {
+        let vm = makeChatViewModel()
+
+        let dump = dumpHierarchy(
+            ChatExportSheet()
+                .environment(vm)
+        )
+
+        XCTAssertTrue(
+            dump.contains("Format"),
+            "ChatExportSheet must contain the Format section"
+        )
+    }
+
+    func test_chatExportSheet_showsMarkdownOption() {
+        let vm = makeChatViewModel()
+
+        let dump = dumpHierarchy(
+            ChatExportSheet()
+                .environment(vm)
+        )
+
+        XCTAssertTrue(
+            dump.contains("Markdown"),
+            "ChatExportSheet must list Markdown as an export format"
+        )
+    }
+
+    func test_chatExportSheet_showsPlainTextOption() {
+        let vm = makeChatViewModel()
+
+        let dump = dumpHierarchy(
+            ChatExportSheet()
+                .environment(vm)
+        )
+
+        XCTAssertTrue(
+            dump.contains("Plain Text"),
+            "ChatExportSheet must list Plain Text as an export format"
+        )
+    }
+
+    func test_chatExportSheet_showsPreviewSection() {
+        let vm = makeChatViewModel()
+
+        let dump = dumpHierarchy(
+            ChatExportSheet()
+                .environment(vm)
+        )
+
+        XCTAssertTrue(
+            dump.contains("Preview"),
+            "ChatExportSheet must have a Preview section"
+        )
+    }
+
+    func test_chatExportSheet_usesSegmentedPicker() {
+        let vm = makeChatViewModel()
+
+        let dump = dumpHierarchy(
+            ChatExportSheet()
+                .environment(vm)
+        )
+
+        XCTAssertTrue(
+            dump.contains("SegmentedPickerStyle"),
+            "ChatExportSheet format picker must use segmented style"
+        )
+    }
+
+    func test_chatExportSheet_containsShareLink() {
+        let vm = makeChatViewModel()
+
+        let dump = dumpHierarchy(
+            ChatExportSheet()
+                .environment(vm)
+        )
+
+        // ShareLink appears in the type signature within the dump
+        XCTAssertTrue(
+            dump.contains("ShareLink"),
+            "ChatExportSheet must contain a ShareLink for exporting"
+        )
+    }
+
+    func test_chatExportSheet_containsToolbarItems() {
+        let vm = makeChatViewModel()
+
+        let dump = dumpHierarchy(
+            ChatExportSheet()
+                .environment(vm)
+        )
+
+        // Toolbar items appear as SwiftUI.ToolbarItem in the type hierarchy
+        XCTAssertTrue(
+            dump.contains("ToolbarItem"),
+            "ChatExportSheet must have toolbar items (Cancel + Share)"
+        )
+    }
+
+    func test_chatExportSheet_containsNavigationTitle() {
+        let vm = makeChatViewModel()
+
+        let dump = dumpHierarchy(
+            ChatExportSheet()
+                .environment(vm)
+        )
+
+        XCTAssertTrue(
+            dump.contains("NavigationTitleKey"),
+            "ChatExportSheet must set a navigation title"
+        )
+    }
+
+    // MARK: - APIConfigurationView: Empty State
+
+    func test_apiConfigurationView_emptyState_showsNoneConfiguredMessage() throws {
+        let container = try makeInMemoryContainer()
+
+        let dump = dumpHierarchy(
+            APIConfigurationView()
+                .modelContainer(container)
+        )
+
+        XCTAssertTrue(
+            dump.contains("No cloud APIs configured"),
+            "APIConfigurationView with no endpoints must show empty state text"
+        )
+    }
+
+    func test_apiConfigurationView_showsAddEndpointButton() throws {
+        let container = try makeInMemoryContainer()
+
+        let dump = dumpHierarchy(
+            APIConfigurationView()
+                .modelContainer(container)
+        )
+
+        XCTAssertTrue(
+            dump.contains("Add Endpoint"),
+            "APIConfigurationView must have an \"Add Endpoint\" button"
+        )
+    }
+
+    func test_apiConfigurationView_showsEndpointsSection() throws {
+        let container = try makeInMemoryContainer()
+
+        let dump = dumpHierarchy(
+            APIConfigurationView()
+                .modelContainer(container)
+        )
+
+        XCTAssertTrue(
+            dump.contains("Endpoints"),
+            "APIConfigurationView must have an \"Endpoints\" section header"
+        )
+    }
+
+    func test_apiConfigurationView_showsPrivacyWarningText() throws {
+        let container = try makeInMemoryContainer()
+
+        let dump = dumpHierarchy(
+            APIConfigurationView()
+                .modelContainer(container)
+        )
+
+        XCTAssertTrue(
+            dump.contains("external servers"),
+            "APIConfigurationView must show the privacy warning about external servers"
+        )
+    }
+
+    func test_apiConfigurationView_containsToolbarItem() throws {
+        let container = try makeInMemoryContainer()
+
+        let dump = dumpHierarchy(
+            APIConfigurationView()
+                .modelContainer(container)
+        )
+
+        // The Done button is a ToolbarItem in the type hierarchy
+        XCTAssertTrue(
+            dump.contains("ToolbarItem"),
+            "APIConfigurationView must have a toolbar item (Done button)"
+        )
+    }
+
+    func test_apiConfigurationView_containsNavigationTitle() throws {
+        let container = try makeInMemoryContainer()
+
+        let dump = dumpHierarchy(
+            APIConfigurationView()
+                .modelContainer(container)
+        )
+
+        XCTAssertTrue(
+            dump.contains("NavigationTitleKey"),
+            "APIConfigurationView must set a navigation title"
+        )
+    }
+
+    func test_apiConfigurationView_usesNavigationStack() throws {
+        let container = try makeInMemoryContainer()
+
+        let dump = dumpHierarchy(
+            APIConfigurationView()
+                .modelContainer(container)
+        )
+
+        XCTAssertTrue(
+            dump.contains("NavigationStack"),
+            "APIConfigurationView must be wrapped in a NavigationStack"
+        )
+    }
+
+}


### PR DESCRIPTION
## Summary

- Add 61 snapshot-based control visibility tests across 3 new files in `BaseChatSnapshotTests` that verify user-facing controls are present in the SwiftUI view hierarchy using `Swift.dump()` on `NSHostingController`
- Enable Llama trait by default alongside MLX in Package.swift
- Add `BaseChatTestSupport` as a dependency of `BaseChatSnapshotTests` for `MockInferenceBackend` access in model-loaded state tests

### New test files

| File | Tests | Views covered |
|------|-------|---------------|
| `ChatViewControlTests` | 12 | ChatView (empty + model-loaded states), ChatInputBar |
| `ModelAndSettingsControlTests` | 28 | ModelManagementSheet (all 3 tabs), GenerationSettingsView |
| `SidebarAndSheetControlTests` | 21 | SessionListView (empty + populated), ChatExportSheet, APIConfigurationView |

### What these tests catch
Accidental removal of controls from the view hierarchy — e.g. deleting a toolbar button, removing a tab, dropping a section from settings. They verify structural presence of type names, rendered text labels, SF Symbol identifiers, and platform-specific controls (`SystemSlider`, `SystemSegmentedControl`, etc.).

### What these tests don't catch
Pixel-level visibility (zero-frame clipping, z-order occlusion) or interactivity — that would require XCUITests with a host app, which isn't feasible for a Swift package.

## Test plan
- [x] `swift test --filter BaseChatSnapshotTests --disable-default-traits` — 86 tests, 0 failures
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 683 tests, 0 failures
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 388 tests, 0 failures
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 157 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)