### PR TITLE
test: add regression test for model selection surviving refreshModels

### DIFF
--- a/Tests/BaseChatE2ETests/ModelSelectionE2ETests.swift
+++ b/Tests/BaseChatE2ETests/ModelSelectionE2ETests.swift
@@ -289,4 +289,30 @@ final class ModelSelectionE2ETests {
         vm.switchToSession(freshA2)
         #expect(vm.selectedModel == nil, "Model not restored when not in availableModels")
     }
+
+    @Test("Selected model survives refreshModels rescan (regression: random UUID bug)")
+    func selectedModel_survivesRefreshModels() throws {
+        // This is the exact scenario that broke with random UUIDs:
+        // select → save → refreshModels() rebuilds the list → selection must persist.
+        try writeGGUF(named: "stable-id-test.gguf")
+        vm.refreshModels()
+
+        let model = try #require(vm.availableModels.first)
+        let originalID = model.id
+        try makeSession(title: "Stable ID Session")
+        vm.selectedModel = model
+        try vm.saveSettingsToSession()
+
+        // refreshModels() re-discovers from disk — IDs must be stable.
+        vm.refreshModels()
+
+        #expect(vm.selectedModel != nil, "selectedModel must survive refreshModels()")
+        #expect(vm.selectedModel?.id == originalID, "Model ID must be identical after rescan")
+
+        // Also verify the session restore path after a rescan.
+        sessionManager.loadSessions()
+        let freshSession = try #require(sessionManager.sessions.first { $0.title == "Stable ID Session" })
+        vm.switchToSession(freshSession)
+        #expect(vm.selectedModel?.id == originalID, "Session restore must find the model after rescan")
+    }
 }


### PR DESCRIPTION
## Summary

- Add E2E regression test for the stable model ID bug fixed in #224
- Tests the exact failure scenario: select model → save to session → `refreshModels()` rescan → verify selection persists and session restore still works

The existing `sessionRestoresSelectedModel` test never called `refreshModels()` between save and restore, so it passed even with random UUIDs. This test would have caught the bug.

## Test plan
- [x] `swift test --filter BaseChatE2ETests --disable-default-traits` — 6 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)