### PR TITLE
fix: demo app hardening — build fix, recovery UX, layout, validation

### DIFF
--- a/Example/BaseChatDemo/BaseChatDemoApp.swift
+++ b/Example/BaseChatDemo/BaseChatDemoApp.swift
@@ -132,7 +132,11 @@ struct BaseChatDemoApp: App {
                 .environment(chatViewModel)
                 .environment(modelManagementViewModel)
                 .environment(sessionManager)
+                .frame(minWidth: 600, minHeight: 400)
         }
         .modelContainer(modelContainer)
+        #if os(macOS)
+        .defaultSize(width: 900, height: 700)
+        #endif
     }
 }

--- a/Example/BaseChatDemo/DemoContentView.swift
+++ b/Example/BaseChatDemo/DemoContentView.swift
@@ -122,6 +122,18 @@ struct DemoContentView: View {
                     Label("Ready", systemImage: "checkmark.circle.fill")
                         .font(.caption)
                         .foregroundStyle(.green)
+                } else if viewModel.isLoading {
+                    HStack(spacing: 4) {
+                        ProgressView()
+                            .controlSize(.mini)
+                        Text("Loading…")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if viewModel.activeError != nil {
+                    Label("Error", systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.red)
                 }
             }
             .padding()

--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -82,7 +82,7 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
     /// called once, not per-instance.
     /// NSLock is intentional here: init/deinit are synchronous, so actor
     /// isolation would require fire-and-forget Tasks with no ordering guarantee.
-    private static var backendRefCount = 0
+    nonisolated(unsafe) private static var backendRefCount = 0
     private static let backendLock = NSLock()
 
     private static func retainBackend() {
@@ -127,9 +127,7 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         }
 
         let loadedResources = try await Task.detached(priority: .userInitiated) { [self] in
-            self.loadSerializationLock.lock()
-            defer { self.loadSerializationLock.unlock() }
-            return try Self.initializeModel(at: url, requestedContextSize: contextSize)
+            return try self.serializedModelLoad(at: url, contextSize: contextSize)
         }.value
 
         let didCommit = withStateLock {
@@ -153,7 +151,16 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         Self.logger.info("Llama backend loaded \(url.lastPathComponent) with context \(loadedResources.effectiveContextSize)")
     }
 
-    private struct LoadedResources {
+    /// Synchronous wrapper that holds `loadSerializationLock` while calling the
+    /// C-level model init. Called from a detached task so the lock/unlock stays
+    /// in a synchronous context (required by Swift 6.3 strict concurrency).
+    private func serializedModelLoad(at url: URL, contextSize: Int32) throws -> LoadedResources {
+        loadSerializationLock.lock()
+        defer { loadSerializationLock.unlock() }
+        return try Self.initializeModel(at: url, requestedContextSize: contextSize)
+    }
+
+    private struct LoadedResources: @unchecked Sendable {
         let model: OpaquePointer
         let context: OpaquePointer
         let vocab: OpaquePointer?
@@ -366,39 +373,34 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
     }
 
     public func unloadModel() {
-        let state = withStateLock {
-            cancelled = true
-            nextLoadToken &+= 1
-            activeLoadToken = nextLoadToken
+        stateLock.lock()
+        cancelled = true
+        nextLoadToken &+= 1
+        activeLoadToken = nextLoadToken
 
-            let previousCleanup = cleanupTask
-            cleanupTask = nil
-            let capturedTask = generationTask
-            let capturedContext = context
-            let capturedModel = model
+        let previousCleanup = cleanupTask
+        cleanupTask = nil
+        let capturedTask = generationTask
+        let capturedContext = context
+        let capturedModel = model
 
-            // Clear state immediately so callers see the backend as unloaded
-            // without waiting for C memory deallocation.
-            generationTask = nil
-            context = nil
-            model = nil
-            vocab = nil
-            isModelLoaded = false
-            isGenerating = false
-            return (
-                previousCleanup: previousCleanup,
-                capturedTask: capturedTask,
-                capturedContext: capturedContext,
-                capturedModel: capturedModel
-            )
-        }
-        state.capturedTask?.cancel()
+        // Clear state immediately so callers see the backend as unloaded
+        // without waiting for C memory deallocation.
+        generationTask = nil
+        context = nil
+        model = nil
+        vocab = nil
+        isModelLoaded = false
+        isGenerating = false
+        stateLock.unlock()
+
+        capturedTask?.cancel()
 
         Self.logger.info("Llama backend unloaded")
 
-        guard state.capturedTask != nil || state.capturedContext != nil || state.capturedModel != nil else {
+        guard capturedTask != nil || capturedContext != nil || capturedModel != nil else {
             withStateLock {
-                cleanupTask = state.previousCleanup
+                cleanupTask = previousCleanup
             }
             return
         }
@@ -409,15 +411,15 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         // so blocking here would freeze the UI for the duration of the spin-wait.
         // We await the generation task to ensure the C loop has stopped before
         // touching the pointers, preventing a use-after-free crash.
-        let cleanupTask = Task.detached(priority: .utility) {
-            await state.previousCleanup?.value
-            await state.capturedTask?.value
-            if let ctx = state.capturedContext { llama_free(ctx) }
-            if let mdl = state.capturedModel { llama_model_free(mdl) }
+        let newCleanupTask = Task.detached(priority: .utility) {
+            await previousCleanup?.value
+            await capturedTask?.value
+            if let ctx = capturedContext { llama_free(ctx) }
+            if let mdl = capturedModel { llama_model_free(mdl) }
             Self.releaseBackend()
         }
         withStateLock {
-            self.cleanupTask = cleanupTask
+            self.cleanupTask = newCleanupTask
         }
     }
 

--- a/Sources/BaseChatCore/Services/MemoryGate.swift
+++ b/Sources/BaseChatCore/Services/MemoryGate.swift
@@ -69,9 +69,9 @@ public struct MemoryGate: Sendable {
             return evaluate(estimatedBytes: estimated)
 
         case .resident:
-            // Full model + ~20% KV cache overhead must fit.
-            let estimated = UInt64(Double(modelFileSize) * 1.20)
-            return evaluate(estimatedBytes: estimated)
+            // Full model weights must fit at load time.
+            // KV cache is allocated separately during inference.
+            return evaluate(estimatedBytes: modelFileSize)
         }
     }
 

--- a/Sources/BaseChatUI/Views/Chat/ChatView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ChatView.swift
@@ -19,6 +19,7 @@ public struct ChatView: View {
     @State private var isSettingsPresented: Bool = false
     @State private var isExportPresented: Bool = false
     @State private var showClearConfirmation: Bool = false
+    @State private var showAPIConfiguration: Bool = false
 
     public init(showModelManagement: Binding<Bool>) {
         self._showModelManagement = showModelManagement
@@ -97,6 +98,9 @@ public struct ChatView: View {
         .sheet(isPresented: $isExportPresented) {
             ChatExportSheet()
         }
+        .sheet(isPresented: $showAPIConfiguration) {
+            APIConfigurationView()
+        }
     }
 
     // MARK: - Error Banner
@@ -136,12 +140,16 @@ public struct ChatView: View {
         case .retry:
             Button("Retry") {
                 viewModel.activeError = nil
+                Task {
+                    await viewModel.regenerateLastResponse()
+                }
             }
             .buttonStyle(.borderless)
             .font(.callout.bold())
         case .configureAPIKey:
             Button("Check API Key") {
                 viewModel.activeError = nil
+                showAPIConfiguration = true
             }
             .buttonStyle(.borderless)
             .font(.callout.bold())
@@ -191,7 +199,9 @@ public struct ChatView: View {
     private var loadingView: some View {
         Group {
             if case .modelLoading(let progress) = viewModel.activityPhase {
-                ModelLoadingIndicatorView(progress: progress)
+                ModelLoadingIndicatorView(progress: progress) {
+                    viewModel.unloadModel()
+                }
             }
         }
     }

--- a/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
@@ -29,6 +29,7 @@ public struct MessageBubbleView: View {
             if message.role == .user { Spacer(minLength: spacerMinLength) }
 
             bubbleContent
+                .frame(maxWidth: 700, alignment: alignment)
                 .accessibilityElement(children: .combine)
                 .accessibilityLabel("\(message.role.rawValue): \(message.content)")
 

--- a/Sources/BaseChatUI/Views/Chat/ModelLoadingIndicatorView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ModelLoadingIndicatorView.swift
@@ -3,9 +3,11 @@ import SwiftUI
 /// Loading indicator shown during model loading, with optional progress.
 public struct ModelLoadingIndicatorView: View {
     public let progress: Double?
+    public let onCancel: () -> Void
 
-    public init(progress: Double? = nil) {
+    public init(progress: Double? = nil, onCancel: @escaping () -> Void = {}) {
         self.progress = progress
+        self.onCancel = onCancel
     }
 
     public var body: some View {
@@ -20,6 +22,12 @@ public struct ModelLoadingIndicatorView: View {
             Text("Loading model…")
                 .font(.caption)
                 .foregroundStyle(.secondary)
+            Button("Cancel") {
+                onCancel()
+            }
+            .buttonStyle(.plain)
+            .font(.caption)
+            .foregroundStyle(.secondary)
         }
         .padding()
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/BaseChatUI/Views/Settings/APIConfigurationView.swift
+++ b/Sources/BaseChatUI/Views/Settings/APIConfigurationView.swift
@@ -116,7 +116,11 @@ public struct APIConfigurationView: View {
     private func deleteEndpoint(_ endpoint: APIEndpoint) {
         endpoint.deleteAPIKey()
         modelContext.delete(endpoint)
-        try? modelContext.save()
+        do {
+            try modelContext.save()
+        } catch {
+            Log.persistence.error("Failed to delete endpoint: \(error)")
+        }
     }
 }
 

--- a/Sources/BaseChatUI/Views/Settings/APIEndpointEditorView.swift
+++ b/Sources/BaseChatUI/Views/Settings/APIEndpointEditorView.swift
@@ -102,7 +102,10 @@ public struct APIEndpointEditorView: View {
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") { save() }
-                        .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        .disabled(
+                            name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            || modelName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        )
                 }
             }
             .onAppear { populateFields() }
@@ -152,7 +155,7 @@ public struct APIEndpointEditorView: View {
             endpoint.name = trimmedName
             endpoint.provider = provider
             endpoint.baseURL = trimmedURL.isEmpty ? provider.defaultBaseURL : trimmedURL
-            endpoint.modelName = modelName
+            endpoint.modelName = modelName.trimmingCharacters(in: .whitespacesAndNewlines)
 
             if !apiKey.isEmpty {
                 endpoint.setAPIKey(apiKey)

--- a/Tests/BaseChatCoreTests/MemoryGateInferenceServiceTests.swift
+++ b/Tests/BaseChatCoreTests/MemoryGateInferenceServiceTests.swift
@@ -35,7 +35,7 @@ final class MemoryGateInferenceServiceTests: XCTestCase {
             name: "test-model",
             fileName: "fake.gguf",
             url: URL(fileURLWithPath: "/tmp/fake.gguf"),
-            fileSize: 4_000_000_000,  // 4 GB -> 4.8 GB estimated, way over 500 MB
+            fileSize: 4_000_000_000,  // 4 GB raw size, way over 500 MB
             modelType: .gguf
         )
 
@@ -44,7 +44,7 @@ final class MemoryGateInferenceServiceTests: XCTestCase {
             XCTFail("Expected memoryInsufficient error")
         } catch let error as InferenceError {
             if case .memoryInsufficient(let required, let available) = error {
-                XCTAssertEqual(required, 4_800_000_000)
+                XCTAssertEqual(required, 4_000_000_000)
                 XCTAssertEqual(available, 500_000_000)
             } else {
                 XCTFail("Expected memoryInsufficient, got \(error)")
@@ -164,7 +164,7 @@ final class MemoryGateInferenceServiceTests: XCTestCase {
             name: "small-model",
             fileName: "fake.gguf",
             url: URL(fileURLWithPath: "/tmp/fake.gguf"),
-            fileSize: 1_000_000_000,  // 1 GB -> 1.2 GB estimated, fits in 16 GB
+            fileSize: 1_000_000_000,  // 1 GB raw size, fits in 16 GB
             modelType: .gguf
         )
 

--- a/Tests/BaseChatCoreTests/MemoryGateTests.swift
+++ b/Tests/BaseChatCoreTests/MemoryGateTests.swift
@@ -17,7 +17,7 @@ final class MemoryGateTests: XCTestCase {
     // MARK: - Resident Strategy
 
     func test_residentStrategy_allowsWhenPlentyOfMemory() {
-        // 4 GB model, 1.2x = 4.8 GB estimated. 8 GB available. 4.8 < 8*0.85=6.8 -> allow
+        // 4 GB model, raw size used (no KV overhead at load time). 8 GB available. 4 < 8*0.85=6.8 -> allow
         let gate = MemoryGate(
             availableMemoryBytes: { 8_000_000_000 },
             physicalMemoryBytes: 16_000_000_000
@@ -27,29 +27,29 @@ final class MemoryGateTests: XCTestCase {
     }
 
     func test_residentStrategy_warnsWhenTight() {
-        // 4 GB model, 1.2x = 4.8 GB estimated. 5 GB available. 4.8 > 5*0.85=4.25 but 4.8 < 5 -> warn
+        // 4 GB model, raw size. 4.5 GB available. 4 > 4.5*0.85=3.825 but 4 < 4.5 -> warn
         let gate = MemoryGate(
-            availableMemoryBytes: { 5_000_000_000 },
+            availableMemoryBytes: { 4_500_000_000 },
             physicalMemoryBytes: 16_000_000_000
         )
         let verdict = gate.check(modelFileSize: 4_000_000_000, strategy: .resident)
         if case .warn(let est, let avail) = verdict {
-            XCTAssertEqual(est, 4_800_000_000)
-            XCTAssertEqual(avail, 5_000_000_000)
+            XCTAssertEqual(est, 4_000_000_000)
+            XCTAssertEqual(avail, 4_500_000_000)
         } else {
             XCTFail("Expected .warn, got \(verdict)")
         }
     }
 
     func test_residentStrategy_deniesWhenInsufficient() {
-        // 4 GB model, 1.2x = 4.8 GB estimated. 3 GB available. 4.8 > 3 -> deny
+        // 4 GB model, raw size. 3 GB available. 4 > 3 -> deny
         let gate = MemoryGate(
             availableMemoryBytes: { 3_000_000_000 },
             physicalMemoryBytes: 8_000_000_000
         )
         let verdict = gate.check(modelFileSize: 4_000_000_000, strategy: .resident)
         if case .deny(let est, let avail) = verdict {
-            XCTAssertEqual(est, 4_800_000_000)
+            XCTAssertEqual(est, 4_000_000_000)
             XCTAssertEqual(avail, 3_000_000_000)
         } else {
             XCTFail("Expected .deny, got \(verdict)")
@@ -131,13 +131,13 @@ final class MemoryGateTests: XCTestCase {
     // MARK: - Boundary: Exact Fit
 
     func test_residentStrategy_exactFitIsWarn() {
-        // 1 GB model, 1.2x = 1.2 GB estimated. 1.2 GB available. 1.2 == 1.2 -> warn (not allow, since 1.2 > 1.2*0.85)
-        let estimated: UInt64 = 1_200_000_000
+        // 1 GB model, raw size. 1 GB available. 1 == 1 -> warn (not allow, since 1 > 1*0.85)
+        let modelSize: UInt64 = 1_000_000_000
         let gate = MemoryGate(
-            availableMemoryBytes: { estimated },
+            availableMemoryBytes: { modelSize },
             physicalMemoryBytes: 4_000_000_000
         )
-        let verdict = gate.check(modelFileSize: 1_000_000_000, strategy: .resident)
+        let verdict = gate.check(modelFileSize: modelSize, strategy: .resident)
         if case .warn = verdict {
             // pass -- exact fit is a warning because there's no headroom
         } else {


### PR DESCRIPTION
## Summary

- **LlamaBackend Swift 6.3 build fix**: `nonisolated(unsafe)` for lock-guarded static, extracted synchronous lock helper for `Task.detached`, replaced `withStateLock` circular reference in `unloadModel()` with direct lock calls
- **Recovery buttons actually recover**: Retry button now calls `regenerateLastResponse()`, Check API Key opens the API configuration sheet, model loading indicator has a Cancel button
- **Message bubble max width**: Capped at 700pt so text stays readable on ultrawide/5K displays
- **macOS window sizing**: Default 900×700, minimum 600×400 — prevents unusable resize states
- **Endpoint editor validation**: Save button requires non-empty model name, trims whitespace; deletion logs errors instead of swallowing with `try?`
- **Sidebar model status**: Shows loading spinner during model load and error indicator on failure, eliminating the first-run dead-end
- **MemoryGate load-time check**: Removed 1.20× KV overhead multiplier — KV cache is allocated at inference time, not load time, so the gate was rejecting models that fit fine on 16 GB devices

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` (105 passed)
- [x] `swift test --filter BaseChatUITests --disable-default-traits` (388 passed)
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` (76 passed)
- [ ] Manual: open demo app on macOS, verify window defaults and min size
- [ ] Manual: trigger a generation error, verify Retry button regenerates
- [ ] Manual: verify message bubbles don't stretch on wide windows
- [ ] Manual: verify model loading shows cancel button

## Release Note

**Demo app hardening** — Fixed an Xcode 26 build failure in LlamaBackend caused by Swift 6.3 strict concurrency rules. Recovery buttons in the error banner now perform their advertised actions (retry, configure API key). Message bubbles are capped at 700pt width for readability on large displays. The macOS window has sensible default and minimum dimensions. The memory gate no longer over-estimates load-time requirements by including KV cache overhead that isn't allocated until inference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)