### PR TITLE
feat: publish granular model load progress via InferenceService

### DIFF
--- a/Sources/BaseChatCore/Services/InferenceService.swift
+++ b/Sources/BaseChatCore/Services/InferenceService.swift
@@ -62,6 +62,16 @@ public final class InferenceService {
     /// The name of the active backend (e.g., "MLX", "llama.cpp"), for display.
     public private(set) var activeBackendName: String?
 
+    /// Progress of the in-flight model load, in `[0.0, 1.0]`.
+    ///
+    /// `nil` means no load is in progress. Set to `0.0` when `loadModel` or
+    /// `loadCloudBackend` begins, then updated by backends that adopt
+    /// ``LoadProgressReporting``. Backends without granular progress simply
+    /// stay at `0.0` until ``isModelLoaded`` flips to `true`. Returns to `nil`
+    /// once the load completes (success, failure, or supersession by a newer
+    /// request).
+    public private(set) var modelLoadProgress: Double?
+
     /// The prompt template to apply for backends that require one (GGUF).
     public var selectedPromptTemplate: PromptTemplate = .chatML
 
@@ -271,6 +281,7 @@ public final class InferenceService {
             target: modelTypeLogLabel(modelInfo.modelType),
             backend: backendName
         )
+        installProgressHandler(on: newBackend, for: request)
         do {
             // Run backend model loading off the main actor so heavy blocking work
             // (e.g. llama_model_load_from_file, llama_init_from_model) does not
@@ -281,6 +292,7 @@ public final class InferenceService {
                 try await newBackend.loadModel(from: url, contextSize: contextSize)
             }.value
         } catch {
+            (newBackend as? LoadProgressReporting)?.setLoadProgressHandler(nil)
             let isStale = finishLoadAttemptWithFailure(request, error: error)
             if isStale {
                 // The failure arrived after a newer request superseded this one.
@@ -289,6 +301,7 @@ public final class InferenceService {
             }
             throw error
         }
+        (newBackend as? LoadProgressReporting)?.setLoadProgressHandler(nil)
 
         logLoadEvent("load.complete", request: request)
         guard commitLoadIfCurrent(request: request, backend: newBackend, backendName: backendName) else {
@@ -344,6 +357,7 @@ public final class InferenceService {
             target: endpoint.provider.rawValue,
             backend: endpoint.provider.rawValue
         )
+        installProgressHandler(on: newBackend, for: request)
         do {
             // Run backend initialisation off the main actor for consistency with
             // local model loading — cloud backends may perform blocking I/O during
@@ -353,6 +367,7 @@ public final class InferenceService {
                 try await newBackend.loadModel(from: backendURL, contextSize: 0)
             }.value
         } catch {
+            (newBackend as? LoadProgressReporting)?.setLoadProgressHandler(nil)
             let isStale = finishLoadAttemptWithFailure(request, error: error)
             if isStale {
                 // Clean up any partial backend state so resources are not leaked.
@@ -360,6 +375,7 @@ public final class InferenceService {
             }
             throw error
         }
+        (newBackend as? LoadProgressReporting)?.setLoadProgressHandler(nil)
 
         logLoadEvent("load.complete", request: request)
         guard commitLoadIfCurrent(
@@ -748,6 +764,7 @@ public final class InferenceService {
         nextLoadRequestToken = request
         latestRequestedLoadToken = request
         loadPhase = .loading(request: request)
+        modelLoadProgress = 0.0
         loadRequestMetadataByToken[request] = LoadRequestMetadata(
             source: source,
             target: target,
@@ -766,6 +783,7 @@ public final class InferenceService {
             return true
         }
         loadPhase = .idle
+        modelLoadProgress = nil
         logLoadEvent(
             "load.failed",
             request: request,
@@ -783,6 +801,7 @@ public final class InferenceService {
             invalidatedThroughToken = max(invalidatedThroughToken, latestRequestedLoadToken)
         }
         loadPhase = .idle
+        modelLoadProgress = nil
     }
 
     private func canCommitLoad(_ request: LoadRequestToken) -> Bool {
@@ -810,10 +829,34 @@ public final class InferenceService {
 
         backend = newBackend
         isModelLoaded = true
+        modelLoadProgress = nil
         activeBackendName = backendName
         loadPhase = .loaded(request: request)
         logLoadEvent("load.commit", request: request, clearMetadata: true)
         return true
+    }
+
+    /// Installs a stale-suppressing progress handler on the backend if it
+    /// adopts ``LoadProgressReporting``. The handler hops to the main actor
+    /// and only updates ``modelLoadProgress`` while `request` is still the
+    /// active loading request.
+    private func installProgressHandler(
+        on newBackend: any InferenceBackend,
+        for request: LoadRequestToken
+    ) {
+        guard let reporting = newBackend as? LoadProgressReporting else { return }
+        reporting.setLoadProgressHandler { [weak self] progress in
+            Task { @MainActor [weak self] in
+                self?.applyLoadProgress(progress, for: request)
+            }
+        }
+    }
+
+    private func applyLoadProgress(_ progress: Double, for request: LoadRequestToken) {
+        guard case .loading(let activeRequest) = loadPhase, activeRequest == request else {
+            return
+        }
+        modelLoadProgress = max(0.0, min(1.0, progress))
     }
 
     private func modelTypeLogLabel(_ modelType: ModelType) -> String {
@@ -974,4 +1017,18 @@ public protocol CloudBackendURLModelConfigurable: AnyObject {
 /// Adopted by cloud backends that resolve API keys via a Keychain account.
 public protocol CloudBackendKeychainConfigurable: AnyObject {
     func configure(baseURL: URL, keychainAccount: String, modelName: String)
+}
+
+/// Adopted by backends that can report granular model-load progress.
+///
+/// `InferenceService` installs a handler before each load and clears it
+/// (`nil`) once the load has completed or failed. Handlers may be invoked
+/// from any thread; the closure is `@Sendable`. Backends without granular
+/// progress need not adopt this protocol — `InferenceService` will simply
+/// publish `0.0` until `isModelLoaded` flips to `true`.
+public protocol LoadProgressReporting: AnyObject {
+    /// Installs (or clears, when `nil`) a progress callback for the next
+    /// `loadModel` call. Values must be in `[0.0, 1.0]`. Implementations
+    /// should retain the handler only for the duration of the active load.
+    func setLoadProgressHandler(_ handler: (@Sendable (Double) -> Void)?)
 }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+ModelLoading.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+ModelLoading.swift
@@ -94,8 +94,40 @@ extension ChatViewModel {
     private func beginLoadUIState(generation: UInt64?) -> Bool {
         guard isCurrentLoadIntentGeneration(generation) else { return false }
         errorMessage = nil
-        activityPhase = .modelLoading(progress: nil)
+        activityPhase = .modelLoading(progress: inferenceService.modelLoadProgress)
         return true
+    }
+
+    /// Mirrors `inferenceService.modelLoadProgress` into ``activityPhase`` for
+    /// the duration of a model load. Polls instead of using
+    /// `withObservationTracking` so cancellation is reliable — observation
+    /// continuations don't resume on `Task.cancel()`, which makes them
+    /// deadlock-prone for a long-running mirror like this.
+    ///
+    /// The bridge only writes when the load generation is still current AND
+    /// `activityPhase` is still `.modelLoading`, so any late wake-up after
+    /// `endLoadUIState` has flipped the phase to `.idle` is a no-op.
+    private func observeModelLoadProgress(generation: UInt64?) async {
+        while !Task.isCancelled {
+            applyModelLoadProgress(generation: generation)
+            do {
+                try await Task.sleep(for: progressBridgePollInterval)
+            } catch {
+                // Sleep throws on cancel; one final apply ensures the latest
+                // value is published before the bridge exits.
+                applyModelLoadProgress(generation: generation)
+                return
+            }
+        }
+    }
+
+    private func applyModelLoadProgress(generation: UInt64?) {
+        guard isCurrentLoadIntentGeneration(generation) else { return }
+        guard case .modelLoading(let current) = activityPhase else { return }
+        let snapshot = inferenceService.modelLoadProgress
+        if current != snapshot {
+            activityPhase = .modelLoading(progress: snapshot)
+        }
     }
 
     private func endLoadUIState(generation: UInt64?) {
@@ -141,7 +173,13 @@ extension ChatViewModel {
         }
 
         guard beginLoadUIState(generation: generation) else { return }
-        defer { endLoadUIState(generation: generation) }
+        let bridge = Task { @MainActor [weak self] in
+            await self?.observeModelLoadProgress(generation: generation)
+        }
+        defer {
+            bridge.cancel()
+            endLoadUIState(generation: generation)
+        }
 
         do {
             let contextSize: Int32 = Int32(model.detectedContextLength ?? 2048)
@@ -155,7 +193,13 @@ extension ChatViewModel {
 
     private func loadCloudEndpointInternal(_ endpoint: APIEndpoint, generation: UInt64?) async {
         guard beginLoadUIState(generation: generation) else { return }
-        defer { endLoadUIState(generation: generation) }
+        let bridge = Task { @MainActor [weak self] in
+            await self?.observeModelLoadProgress(generation: generation)
+        }
+        defer {
+            bridge.cancel()
+            endLoadUIState(generation: generation)
+        }
 
         do {
             try await inferenceService.loadCloudBackend(from: endpoint)

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -320,6 +320,11 @@ public final class ChatViewModel {
     var backgroundTask: Task<Void, Never>?
     var coordinatedLoadTask: Task<Void, Never>?
     var latestLoadIntentGeneration: UInt64 = 0
+
+    /// Polling interval for the model-load progress bridge task that mirrors
+    /// `inferenceService.modelLoadProgress` into ``activityPhase``. Tests may
+    /// override this to a small value for deterministic timing.
+    var progressBridgePollInterval: Duration = .milliseconds(50)
     var lastPressureLevel: MemoryPressureLevel = .nominal
     private var isSynchronizingSelection = false
     var isRestoringSession = false

--- a/Tests/BaseChatCoreTests/InferenceServiceProgressTests.swift
+++ b/Tests/BaseChatCoreTests/InferenceServiceProgressTests.swift
@@ -1,0 +1,438 @@
+import XCTest
+@testable import BaseChatCore
+
+/// Tests for `InferenceService.modelLoadProgress` and the `LoadProgressReporting`
+/// opt-in protocol.
+///
+/// These tests verify the progress lifecycle (nil → 0.0 → fractional → nil) and
+/// the stale-request suppression that prevents progress from one load corrupting
+/// the state of a newer load.
+@MainActor
+final class InferenceServiceProgressTests: XCTestCase {
+
+    // MARK: - Resting state
+
+    func test_modelLoadProgress_isNilAtRest() {
+        let service = InferenceService()
+        XCTAssertNil(service.modelLoadProgress)
+    }
+
+    // MARK: - Load lifecycle
+
+    func test_modelLoadProgress_zeroOnLoadStart() async throws {
+        let service = InferenceService()
+        let backend = ProgressReportingBackend()
+        service.registerBackendFactory { type in type == .gguf ? backend : nil }
+
+        let task = Task { try await service.loadModel(from: makeModelInfo()) }
+        await backend.waitUntilLoadStarted()
+
+        XCTAssertEqual(service.modelLoadProgress, 0.0,
+                       "modelLoadProgress should be seeded to 0.0 once loadModel begins")
+
+        await backend.releaseLoadSuccess()
+        try await task.value
+    }
+
+    func test_modelLoadProgress_handlerUpdatesArePublished() async throws {
+        let service = InferenceService()
+        let backend = ProgressReportingBackend()
+        service.registerBackendFactory { type in type == .gguf ? backend : nil }
+
+        let task = Task { try await service.loadModel(from: makeModelInfo()) }
+        await backend.waitUntilLoadStarted()
+
+        backend.fireProgress(0.25)
+        try await waitForProgress(0.25, on: service)
+
+        backend.fireProgress(0.75)
+        try await waitForProgress(0.75, on: service)
+
+        await backend.releaseLoadSuccess()
+        try await task.value
+    }
+
+    func test_modelLoadProgress_returnsToNilOnSuccess() async throws {
+        let service = InferenceService()
+        let backend = ProgressReportingBackend()
+        service.registerBackendFactory { type in type == .gguf ? backend : nil }
+
+        let task = Task { try await service.loadModel(from: makeModelInfo()) }
+        await backend.waitUntilLoadStarted()
+        backend.fireProgress(0.5)
+        try await waitForProgress(0.5, on: service)
+
+        await backend.releaseLoadSuccess()
+        try await task.value
+
+        XCTAssertTrue(service.isModelLoaded)
+        XCTAssertNil(service.modelLoadProgress,
+                     "modelLoadProgress should be cleared once isModelLoaded flips true")
+    }
+
+    func test_modelLoadProgress_returnsToNilOnFailure() async throws {
+        let service = InferenceService()
+        let backend = ProgressReportingBackend()
+        service.registerBackendFactory { type in type == .gguf ? backend : nil }
+
+        let task = Task { try await service.loadModel(from: makeModelInfo()) }
+        await backend.waitUntilLoadStarted()
+        backend.fireProgress(0.4)
+        try await waitForProgress(0.4, on: service)
+
+        await backend.releaseLoadFailure(ProgressTestError.plannedFailure)
+        do {
+            try await task.value
+            XCTFail("Expected planned failure")
+        } catch ProgressTestError.plannedFailure {
+            // expected
+        }
+
+        XCTAssertFalse(service.isModelLoaded)
+        XCTAssertNil(service.modelLoadProgress,
+                     "modelLoadProgress should be cleared after a non-stale load failure")
+    }
+
+    // MARK: - Stale-request suppression
+
+    func test_modelLoadProgress_staleRequestUpdatesAreDropped() async throws {
+        let service = InferenceService()
+        let firstBackend = ProgressReportingBackend()
+        let secondBackend = ProgressReportingBackend()
+
+        service.registerBackendFactory { type in
+            switch type {
+            case .gguf: firstBackend
+            case .foundation: secondBackend
+            case .mlx: nil
+            }
+        }
+
+        // Start first load and let it report some progress.
+        let firstTask = Task {
+            try await service.loadModel(from: makeModelInfo(name: "First", modelType: .gguf))
+        }
+        await firstBackend.waitUntilLoadStarted()
+        firstBackend.fireProgress(0.3)
+        try await waitForProgress(0.3, on: service)
+
+        // Start a second load that supersedes the first.
+        let secondTask = Task {
+            try await service.loadModel(from: makeModelInfo(name: "Second", modelType: .foundation))
+        }
+        await secondBackend.waitUntilLoadStarted()
+
+        // Second load is now active — progress should be 0.0 again.
+        XCTAssertEqual(service.modelLoadProgress, 0.0,
+                       "Newer load should reset modelLoadProgress to 0.0")
+
+        // First backend keeps firing — these MUST NOT touch modelLoadProgress.
+        firstBackend.fireProgress(0.9)
+        firstBackend.fireProgress(0.95)
+        // Give the late hops a chance to run.
+        try await Task.sleep(for: .milliseconds(20))
+        XCTAssertEqual(service.modelLoadProgress, 0.0,
+                       "Stale progress from a superseded load must be ignored")
+
+        // Newer load completes normally.
+        secondBackend.fireProgress(0.6)
+        try await waitForProgress(0.6, on: service)
+        await secondBackend.releaseLoadSuccess()
+        try await secondTask.value
+
+        XCTAssertNil(service.modelLoadProgress)
+
+        // Drain the first task to avoid leaks. It will complete as a stale success
+        // and be unloaded by the service.
+        await firstBackend.releaseLoadSuccess()
+        _ = try? await firstTask.value
+    }
+
+    // MARK: - Clamping
+
+    func test_modelLoadProgress_clampsToValidRange() async throws {
+        let service = InferenceService()
+        let backend = ProgressReportingBackend()
+        service.registerBackendFactory { type in type == .gguf ? backend : nil }
+
+        let task = Task { try await service.loadModel(from: makeModelInfo()) }
+        await backend.waitUntilLoadStarted()
+
+        backend.fireProgress(-0.5)
+        try await waitForProgress(0.0, on: service)
+
+        backend.fireProgress(2.0)
+        try await waitForProgress(1.0, on: service)
+
+        backend.fireProgress(0.5)
+        try await waitForProgress(0.5, on: service)
+
+        await backend.releaseLoadSuccess()
+        try await task.value
+    }
+
+    // MARK: - Handler teardown (leak check)
+
+    func test_setLoadProgressHandler_clearedAfterSuccessfulLoad() async throws {
+        let service = InferenceService()
+        let backend = ProgressReportingBackend()
+        service.registerBackendFactory { type in type == .gguf ? backend : nil }
+
+        let task = Task { try await service.loadModel(from: makeModelInfo()) }
+        await backend.waitUntilLoadStarted()
+        XCTAssertEqual(backend.handlerInstallCount, 1, "Service should install a handler at load start")
+        XCTAssertFalse(backend.hasNilHandler, "Handler should be non-nil during load")
+
+        await backend.releaseLoadSuccess()
+        try await task.value
+
+        XCTAssertTrue(backend.hasNilHandler,
+                      "Service must clear the handler after a successful load to prevent retain leaks")
+    }
+
+    func test_setLoadProgressHandler_clearedAfterFailedLoad() async throws {
+        let service = InferenceService()
+        let backend = ProgressReportingBackend()
+        service.registerBackendFactory { type in type == .gguf ? backend : nil }
+
+        let task = Task { try await service.loadModel(from: makeModelInfo()) }
+        await backend.waitUntilLoadStarted()
+        await backend.releaseLoadFailure(ProgressTestError.plannedFailure)
+        _ = try? await task.value
+
+        XCTAssertTrue(backend.hasNilHandler,
+                      "Service must clear the handler after a failed load to prevent retain leaks")
+    }
+
+    // MARK: - Cloud backend path
+
+    func test_modelLoadProgress_cloudLoadAlsoPublishesProgress() async throws {
+        let service = InferenceService()
+        let backend = ProgressReportingCloudBackend()
+        service.registerCloudBackendFactory { provider in
+            provider == .ollama ? backend : nil
+        }
+
+        let endpoint = APIEndpoint(name: "Test", provider: .ollama, modelName: "demo")
+        let task = Task { try await service.loadCloudBackend(from: endpoint) }
+        await backend.waitUntilLoadStarted()
+
+        XCTAssertEqual(service.modelLoadProgress, 0.0)
+        backend.fireProgress(0.5)
+        try await waitForProgress(0.5, on: service)
+
+        await backend.releaseLoadSuccess()
+        try await task.value
+        XCTAssertNil(service.modelLoadProgress)
+        XCTAssertTrue(backend.hasNilHandler)
+    }
+
+    // MARK: - Helpers
+
+    private func makeModelInfo(name: String = "Test", modelType: ModelType = .gguf) -> ModelInfo {
+        ModelInfo(
+            name: name,
+            fileName: "\(name).bin",
+            url: URL(fileURLWithPath: "/\(name).bin"),
+            fileSize: 0,
+            modelType: modelType
+        )
+    }
+
+    /// Polls `service.modelLoadProgress` until it equals `expected` or times out.
+    /// Required because progress handlers hop to the main actor via an unstructured
+    /// `Task { @MainActor in }`, which we can't directly await.
+    private func waitForProgress(
+        _ expected: Double?,
+        on service: InferenceService,
+        timeout: TimeInterval = 1.0
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if service.modelLoadProgress == expected {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        XCTFail("Timed out waiting for modelLoadProgress to become \(String(describing: expected)) — current: \(String(describing: service.modelLoadProgress))")
+    }
+}
+
+// MARK: - Test backends
+
+private enum ProgressTestError: Error, Sendable {
+    case plannedFailure
+}
+
+private actor ProgressGate {
+    enum Release: Sendable {
+        case success
+        case failure(any Error & Sendable)
+    }
+
+    private var didStart = false
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseDecision: Release?
+    private var releaseWaiters: [CheckedContinuation<Release, Never>] = []
+
+    func markStarted() {
+        didStart = true
+        for w in startWaiters { w.resume() }
+        startWaiters.removeAll()
+    }
+
+    func waitUntilStarted() async {
+        if didStart { return }
+        await withCheckedContinuation { startWaiters.append($0) }
+    }
+
+    func waitForRelease() async -> Release {
+        if let releaseDecision { return releaseDecision }
+        return await withCheckedContinuation { releaseWaiters.append($0) }
+    }
+
+    func releaseSuccess() { release(.success) }
+    func releaseFailure(_ error: any Error & Sendable) { release(.failure(error)) }
+
+    private func release(_ decision: Release) {
+        guard releaseDecision == nil else { return }
+        releaseDecision = decision
+        for w in releaseWaiters { w.resume(returning: decision) }
+        releaseWaiters.removeAll()
+    }
+}
+
+/// Test backend that conforms to `LoadProgressReporting` and exposes a manually
+/// fireable progress hook plus a gate to control when `loadModel` returns.
+private final class ProgressReportingBackend: InferenceBackend,
+                                              LoadProgressReporting,
+                                              @unchecked Sendable {
+    var isModelLoaded = false
+    var isGenerating = false
+    var capabilities: BackendCapabilities = BackendCapabilities(
+        supportedParameters: [.temperature],
+        maxContextTokens: 4096,
+        requiresPromptTemplate: false,
+        supportsSystemPrompt: true
+    )
+
+    private let lock = NSLock()
+    private var handler: (@Sendable (Double) -> Void)?
+    private var _handlerInstallCount = 0
+    private var _hasNilHandler = true
+
+    var handlerInstallCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return _handlerInstallCount
+    }
+
+    var hasNilHandler: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _hasNilHandler
+    }
+
+    private let gate = ProgressGate()
+
+    func setLoadProgressHandler(_ handler: (@Sendable (Double) -> Void)?) {
+        lock.lock()
+        self.handler = handler
+        _hasNilHandler = (handler == nil)
+        if handler != nil {
+            _handlerInstallCount += 1
+        }
+        lock.unlock()
+    }
+
+    func fireProgress(_ value: Double) {
+        lock.lock()
+        let h = handler
+        lock.unlock()
+        h?(value)
+    }
+
+    func waitUntilLoadStarted() async { await gate.waitUntilStarted() }
+    func releaseLoadSuccess() async { await gate.releaseSuccess() }
+    func releaseLoadFailure(_ error: any Error & Sendable) async { await gate.releaseFailure(error) }
+
+    func loadModel(from url: URL, contextSize: Int32) async throws {
+        await gate.markStarted()
+        switch await gate.waitForRelease() {
+        case .success:
+            isModelLoaded = true
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> GenerationStream {
+        let stream = AsyncThrowingStream<GenerationEvent, Error> { $0.finish() }
+        return GenerationStream(stream)
+    }
+
+    func stopGeneration() {}
+    func unloadModel() { isModelLoaded = false }
+}
+
+/// Cloud variant of `ProgressReportingBackend` that conforms to the
+/// URL+model configurable protocol so `loadCloudBackend(from:)` accepts it.
+private final class ProgressReportingCloudBackend: InferenceBackend,
+                                                   LoadProgressReporting,
+                                                   CloudBackendURLModelConfigurable,
+                                                   @unchecked Sendable {
+    var isModelLoaded = false
+    var isGenerating = false
+    var capabilities: BackendCapabilities = BackendCapabilities(
+        supportedParameters: [.temperature],
+        maxContextTokens: 4096,
+        requiresPromptTemplate: false,
+        supportsSystemPrompt: true
+    )
+
+    private let lock = NSLock()
+    private var handler: (@Sendable (Double) -> Void)?
+    private var _hasNilHandler = true
+
+    var hasNilHandler: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _hasNilHandler
+    }
+
+    private let gate = ProgressGate()
+
+    func configure(baseURL: URL, modelName: String) {}
+
+    func setLoadProgressHandler(_ handler: (@Sendable (Double) -> Void)?) {
+        lock.lock()
+        self.handler = handler
+        _hasNilHandler = (handler == nil)
+        lock.unlock()
+    }
+
+    func fireProgress(_ value: Double) {
+        lock.lock()
+        let h = handler
+        lock.unlock()
+        h?(value)
+    }
+
+    func waitUntilLoadStarted() async { await gate.waitUntilStarted() }
+    func releaseLoadSuccess() async { await gate.releaseSuccess() }
+
+    func loadModel(from url: URL, contextSize: Int32) async throws {
+        await gate.markStarted()
+        switch await gate.waitForRelease() {
+        case .success:
+            isModelLoaded = true
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> GenerationStream {
+        let stream = AsyncThrowingStream<GenerationEvent, Error> { $0.finish() }
+        return GenerationStream(stream)
+    }
+
+    func stopGeneration() {}
+    func unloadModel() { isModelLoaded = false }
+}

--- a/Tests/BaseChatUITests/ChatViewModelLoadProgressBridgeTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelLoadProgressBridgeTests.swift
@@ -1,0 +1,261 @@
+import XCTest
+@testable import BaseChatUI
+@testable import BaseChatCore
+
+/// Tests for the ChatViewModel ↔ InferenceService.modelLoadProgress bridge.
+///
+/// Verifies that ChatViewModel mirrors `inferenceService.modelLoadProgress` into
+/// `activityPhase = .modelLoading(progress:)` while a load is in flight, and
+/// resets to `.idle` when the load completes.
+@MainActor
+final class ChatViewModelLoadProgressBridgeTests: XCTestCase {
+
+    private func makeModelInfo(name: String = "Bridge", modelType: ModelType = .gguf) -> ModelInfo {
+        ModelInfo(
+            name: name,
+            fileName: "\(name).bin",
+            url: URL(fileURLWithPath: "/\(name).bin"),
+            fileSize: 0,
+            modelType: modelType
+        )
+    }
+
+    /// Polls until `vm.activityPhase` matches `expected`, or fails after timeout.
+    private func waitForPhase(
+        _ expected: BackendActivityPhase,
+        on vm: ChatViewModel,
+        timeout: TimeInterval = 1.0,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if vm.activityPhase == expected { return }
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+        XCTFail(
+            "Timed out waiting for activityPhase \(expected) — current: \(vm.activityPhase)",
+            file: file,
+            line: line
+        )
+    }
+
+    // MARK: - Reporting backend
+
+    func test_activityPhase_reflectsProgressFromReportingBackend() async throws {
+        let backend = ProgressBridgeBackend()
+        let service = InferenceService()
+        service.registerBackendFactory { type in type == .gguf ? backend : nil }
+
+        let vm = ChatViewModel(inferenceService: service)
+        vm.progressBridgePollInterval = .milliseconds(2)
+        vm.selectedModel = makeModelInfo()
+
+        let loadTask = Task { await vm.loadSelectedModel() }
+        await backend.waitUntilLoadStarted()
+
+        // Bridge should publish 0.0 first (the seed value from beginLoadRequest).
+        await waitForPhase(.modelLoading(progress: 0.0), on: vm)
+
+        backend.fireProgress(0.4)
+        await waitForPhase(.modelLoading(progress: 0.4), on: vm)
+
+        backend.fireProgress(0.85)
+        await waitForPhase(.modelLoading(progress: 0.85), on: vm)
+
+        await backend.releaseLoadSuccess()
+        await loadTask.value
+
+        // Once the load commits, activityPhase should return to .idle.
+        XCTAssertEqual(vm.activityPhase, .idle)
+        XCTAssertTrue(vm.isModelLoaded)
+    }
+
+    // MARK: - Non-reporting backend
+
+    func test_activityPhase_staysAtZero_whenBackendDoesNotReportProgress() async throws {
+        let backend = PlainBridgeBackend()
+        let service = InferenceService()
+        service.registerBackendFactory { type in type == .gguf ? backend : nil }
+
+        let vm = ChatViewModel(inferenceService: service)
+        vm.progressBridgePollInterval = .milliseconds(2)
+        vm.selectedModel = makeModelInfo()
+
+        let loadTask = Task { await vm.loadSelectedModel() }
+        await backend.waitUntilLoadStarted()
+
+        // For a non-reporting backend, the service still seeds modelLoadProgress
+        // to 0.0 at load start. The bridge should publish that and never
+        // produce any fractional value.
+        await waitForPhase(.modelLoading(progress: 0.0), on: vm)
+
+        // Hold for a few poll intervals and confirm nothing else appears.
+        try await Task.sleep(for: .milliseconds(20))
+        XCTAssertEqual(
+            vm.activityPhase,
+            .modelLoading(progress: 0.0),
+            "A non-LoadProgressReporting backend must keep activityPhase at progress 0.0 throughout"
+        )
+
+        await backend.releaseLoadSuccess()
+        await loadTask.value
+
+        XCTAssertEqual(vm.activityPhase, .idle)
+        XCTAssertTrue(vm.isModelLoaded)
+    }
+
+    // MARK: - Failure path
+
+    func test_activityPhase_resetsToIdle_onLoadFailure() async throws {
+        let backend = ProgressBridgeBackend()
+        let service = InferenceService()
+        service.registerBackendFactory { type in type == .gguf ? backend : nil }
+
+        let vm = ChatViewModel(inferenceService: service)
+        vm.progressBridgePollInterval = .milliseconds(2)
+        vm.selectedModel = makeModelInfo()
+
+        let loadTask = Task { await vm.loadSelectedModel() }
+        await backend.waitUntilLoadStarted()
+
+        backend.fireProgress(0.5)
+        await waitForPhase(.modelLoading(progress: 0.5), on: vm)
+
+        await backend.releaseLoadFailure(BridgeTestError.plannedFailure)
+        await loadTask.value
+
+        XCTAssertEqual(vm.activityPhase, .idle)
+        XCTAssertFalse(vm.isModelLoaded)
+        XCTAssertNotNil(vm.errorMessage)
+    }
+}
+
+// MARK: - Test backends
+
+private enum BridgeTestError: Error, Sendable {
+    case plannedFailure
+}
+
+private actor BridgeGate {
+    enum Release: Sendable {
+        case success
+        case failure(any Error & Sendable)
+    }
+
+    private var didStart = false
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseDecision: Release?
+    private var releaseWaiters: [CheckedContinuation<Release, Never>] = []
+
+    func markStarted() {
+        didStart = true
+        for w in startWaiters { w.resume() }
+        startWaiters.removeAll()
+    }
+
+    func waitUntilStarted() async {
+        if didStart { return }
+        await withCheckedContinuation { startWaiters.append($0) }
+    }
+
+    func waitForRelease() async -> Release {
+        if let releaseDecision { return releaseDecision }
+        return await withCheckedContinuation { releaseWaiters.append($0) }
+    }
+
+    func releaseSuccess() { release(.success) }
+    func releaseFailure(_ error: any Error & Sendable) { release(.failure(error)) }
+
+    private func release(_ decision: Release) {
+        guard releaseDecision == nil else { return }
+        releaseDecision = decision
+        for w in releaseWaiters { w.resume(returning: decision) }
+        releaseWaiters.removeAll()
+    }
+}
+
+/// Test backend that adopts `LoadProgressReporting` and exposes a manual progress hook.
+private final class ProgressBridgeBackend: InferenceBackend,
+                                           LoadProgressReporting,
+                                           @unchecked Sendable {
+    var isModelLoaded = false
+    var isGenerating = false
+    var capabilities = BackendCapabilities(
+        supportedParameters: [.temperature],
+        maxContextTokens: 4096,
+        requiresPromptTemplate: false,
+        supportsSystemPrompt: true
+    )
+
+    private let lock = NSLock()
+    private var handler: (@Sendable (Double) -> Void)?
+
+    private let gate = BridgeGate()
+
+    func setLoadProgressHandler(_ handler: (@Sendable (Double) -> Void)?) {
+        lock.lock()
+        self.handler = handler
+        lock.unlock()
+    }
+
+    func fireProgress(_ value: Double) {
+        lock.lock()
+        let h = handler
+        lock.unlock()
+        h?(value)
+    }
+
+    func waitUntilLoadStarted() async { await gate.waitUntilStarted() }
+    func releaseLoadSuccess() async { await gate.releaseSuccess() }
+    func releaseLoadFailure(_ error: any Error & Sendable) async { await gate.releaseFailure(error) }
+
+    func loadModel(from url: URL, contextSize: Int32) async throws {
+        await gate.markStarted()
+        switch await gate.waitForRelease() {
+        case .success: isModelLoaded = true
+        case .failure(let error): throw error
+        }
+    }
+
+    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> GenerationStream {
+        let stream = AsyncThrowingStream<GenerationEvent, Error> { $0.finish() }
+        return GenerationStream(stream)
+    }
+
+    func stopGeneration() {}
+    func unloadModel() { isModelLoaded = false }
+}
+
+/// Test backend that does NOT adopt `LoadProgressReporting`.
+private final class PlainBridgeBackend: InferenceBackend, @unchecked Sendable {
+    var isModelLoaded = false
+    var isGenerating = false
+    var capabilities = BackendCapabilities(
+        supportedParameters: [.temperature],
+        maxContextTokens: 4096,
+        requiresPromptTemplate: false,
+        supportsSystemPrompt: true
+    )
+
+    private let gate = BridgeGate()
+
+    func waitUntilLoadStarted() async { await gate.waitUntilStarted() }
+    func releaseLoadSuccess() async { await gate.releaseSuccess() }
+
+    func loadModel(from url: URL, contextSize: Int32) async throws {
+        await gate.markStarted()
+        switch await gate.waitForRelease() {
+        case .success: isModelLoaded = true
+        case .failure(let error): throw error
+        }
+    }
+
+    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> GenerationStream {
+        let stream = AsyncThrowingStream<GenerationEvent, Error> { $0.finish() }
+        return GenerationStream(stream)
+    }
+
+    func stopGeneration() {}
+    func unloadModel() { isModelLoaded = false }
+}


### PR DESCRIPTION
## Summary

- Adds `InferenceService.modelLoadProgress: Double?` — `nil` at rest, seeded to `0.0` on every `loadModel` / `loadCloudBackend`, cleared back to `nil` on commit, failure, or supersession.
- Introduces `LoadProgressReporting`, a sibling opt-in protocol (alongside `TokenizerVendor`, `ConversationHistoryReceiver`, etc.) so backends with granular progress hooks (e.g. llama.cpp's `progress_callback`, MLX load steps) can publish fractional values without changing the core `InferenceBackend` protocol.
- Stale-request suppression: progress callbacks are keyed to a `LoadRequestToken` and ignored if a newer load has superseded them. Handlers are cleared on every exit path (success, failure, stale) so backends never retain dangling closures.
- Bridges the value into `ChatViewModel.activityPhase = .modelLoading(progress:)` via a short-lived polling task spawned in `loadLocalModel` / `loadCloudEndpointInternal`. Lifetime is scoped to the load function via `defer { bridge.cancel() }`. Polling is used over `withObservationTracking` because observation continuations don't resume on `Task.cancel()`, which leaves long-running mirror tasks deadlock-prone. Poll interval is internally tunable (`progressBridgePollInterval`, default 50 ms) for deterministic test timing.
- 13 new tests, all sabotage-verified for the critical assertions (clamp, stale-suppression, bridge propagation).

No existing backend conforms to `LoadProgressReporting` yet — that's a follow-up per backend. Until then, every backend transparently shows `0.0` for the load duration and the UI can already render an indeterminate spinner driven off the non-nil state.

## Release Note

**Granular model-load progress** — `InferenceService` now publishes a `modelLoadProgress: Double?` value that UI code can observe to render real load progress instead of an indeterminate spinner. Backends with granular hooks (llama.cpp, MLX) can opt into the new `LoadProgressReporting` protocol to publish fractional updates; backends without it continue to work unchanged and will publish `0.0` until the load completes. `ChatViewModel.activityPhase` automatically mirrors the value through `.modelLoading(progress:)`, so views consuming `activityPhase` get the new behavior without any changes.

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 697/697 ✓
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 391/391 ✓
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 157/157 ✓
- [x] Sabotage-verified clamp test (removed `max(0, min(1, ...))` → test caught `Optional(2.0)`)
- [x] Sabotage-verified stale-suppression test (removed token guard → test caught `Optional(0.95)` leaking through to a newer load)
- [x] Sabotage-verified bridge propagation test (stubbed out `applyModelLoadProgress` → test caught `current: modelLoading(progress: nil)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)