### PR TITLE
feat: configurable MLX buffer cache policy

### DIFF
--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -74,9 +74,17 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
     /// Access only under `stateLock`.
     private var _generationTask: Task<Void, Never>?
 
+    // MARK: - Configuration
+
+    /// Policy controlling MLX's GPU buffer cache size. See `MLXCachePolicy`.
+    /// Defaults to `.auto`, which picks a sensible value based on device RAM.
+    public let cachePolicy: MLXCachePolicy
+
     // MARK: - Init
 
-    public init() {}
+    public init(cachePolicy: MLXCachePolicy = .auto) {
+        self.cachePolicy = cachePolicy
+    }
 
     // MARK: - Model Lifecycle
 
@@ -95,7 +103,17 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             withStateLock {
                 _modelContainer = container
             }
-            Memory.cacheLimit = 20 * 1024 * 1024
+            // Apply the cache policy after loadModelContainer succeeds. Doing
+            // this *after* the load (rather than before) keeps it inside the
+            // implicit "MLX runtime is initialized" window — touching MLX's
+            // Memory namespace before the runtime is up trips a metallib
+            // load error in environments without Xcode-compiled shaders
+            // (e.g. `swift test`). The cost is that the load itself runs
+            // under whatever cacheLimit was previously in effect — usually
+            // mlx-swift's own default on a fresh process, which is fine.
+            let cacheBytes = cachePolicy.resolvedBytes()
+            Memory.cacheLimit = cacheBytes
+            Self.logger.info("MLX cache limit set to \(cacheBytes / (1024 * 1024)) MB (policy: \(String(describing: self.cachePolicy)))")
             isModelLoaded = true
             Self.logger.info("MLX backend loaded model from \(url.lastPathComponent)")
         } catch {
@@ -225,12 +243,25 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
 
     public func unloadModel() {
         stopGeneration()
-        withStateLock {
+        // Capture whether we actually had a loaded container *before* clearing
+        // state. We use this to decide whether to call Memory.clearCache()
+        // below — touching MLX's Memory namespace requires the metallib to be
+        // resident in the process, which is only true after a successful
+        // model load. Calling clearCache() on a never-loaded backend (e.g.
+        // from BackendContractChecks.assertAllInvariants) trips a "Failed to
+        // load default metallib" error under `swift test`, because the
+        // metallib is only compiled by Xcode and isn't present in the SwiftPM
+        // build output.
+        let hadContainer: Bool = withStateLock {
+            let had = _modelContainer != nil
             _modelContainer = nil
             _isModelLoaded = false
             _isGenerating = false
+            return had
         }
-        Memory.clearCache()
+        if hadContainer {
+            Memory.clearCache()
+        }
         Self.logger.info("MLX backend unloaded")
     }
 }

--- a/Sources/BaseChatBackends/MLXCachePolicy.swift
+++ b/Sources/BaseChatBackends/MLXCachePolicy.swift
@@ -1,0 +1,79 @@
+#if MLX
+import Foundation
+
+/// Policy controlling how much GPU buffer cache MLX retains for reuse between
+/// operations.
+///
+/// MLX maintains a pool of freed Metal buffers up to a configurable limit so
+/// that subsequent allocations of the same shape can recycle them instead of
+/// going through the OS allocator. The right size is a tradeoff between
+/// per-step allocator overhead (smaller pool = more thrashing, slower decode)
+/// and peak resident memory (larger pool = more headroom held).
+///
+/// The historical default of 20 MB was inherited from the `mlx-swift-examples`
+/// LLMEval sample, which uses it as a "minimum footprint demo" value. It is
+/// dramatically too small for sustained chat or story workloads on Apple
+/// Silicon Macs, where 256 MB–1 GB is more appropriate. Use `.auto` (the
+/// default) unless you have measured something specific.
+///
+/// The cache is process-global on the MLX module. If multiple `MLXBackend`
+/// instances load models sequentially, the most recent load's policy wins.
+public enum MLXCachePolicy: Sendable, Equatable {
+
+    /// Auto-pick a sensible cache size based on the device's physical RAM.
+    /// This is the default and the right choice unless you have benchmarked
+    /// something specific.
+    case auto
+
+    /// Minimal caching (~20 MB) — the historical default and the value used
+    /// by the `mlx-swift-examples` LLMEval sample. Trades throughput for
+    /// minimum peak memory. Use only on extremely memory-constrained devices
+    /// where allocator thrashing is preferable to peak footprint.
+    case minimal
+
+    /// Generous caching — roughly 25% of physical RAM, capped at 4 GB. Use
+    /// when you have plenty of headroom and want maximum sustained throughput.
+    case generous
+
+    /// An explicit byte count, for when you have benchmarked your specific
+    /// model + workload combination and know exactly what you want.
+    case explicit(bytes: Int)
+
+    /// Resolves the policy to a concrete byte count for the current device.
+    public func resolvedBytes() -> Int {
+        switch self {
+        case .auto:
+            return Self.autoBytes()
+        case .minimal:
+            return 20 * 1024 * 1024
+        case .generous:
+            return Self.generousBytes()
+        case .explicit(let bytes):
+            return max(0, bytes)
+        }
+    }
+
+    // MARK: - Heuristics
+
+    /// Bucketed by device class. These numbers are informed guesses, not
+    /// measured optima — they will be tuned in a follow-up once we have real
+    /// per-device throughput data.
+    private static func autoBytes() -> Int {
+        let physicalGB = Double(ProcessInfo.processInfo.physicalMemory) / 1_073_741_824
+        switch physicalGB {
+        case ..<7:    return  64 * 1024 * 1024  // older iPhones (~6 GB)
+        case ..<10:   return 128 * 1024 * 1024  // current mid iPhones, base iPads (~8 GB)
+        case ..<18:   return 256 * 1024 * 1024  // 16 GB Macs, high-end iPads
+        case ..<36:   return 512 * 1024 * 1024  // 24-32 GB Macs
+        default:      return 1024 * 1024 * 1024 // 36+ GB Macs (M-Pro/Max/Ultra)
+        }
+    }
+
+    private static func generousBytes() -> Int {
+        let physical = ProcessInfo.processInfo.physicalMemory
+        let quarter = physical / 4
+        let cap: UInt64 = 4 * 1024 * 1024 * 1024
+        return Int(min(quarter, cap))
+    }
+}
+#endif

--- a/Tests/BaseChatBackendsTests/MLXCachePolicyTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXCachePolicyTests.swift
@@ -1,0 +1,72 @@
+#if MLX
+import XCTest
+@testable import BaseChatBackends
+
+/// Pure-logic tests for `MLXCachePolicy.resolvedBytes()`.
+///
+/// These do not exercise MLX's `Memory.cacheLimit` global directly — that
+/// would require the MLX runtime and a way to read the value back, which
+/// isn't worth the surface area for verifying one assignment. Instead we
+/// test that the policy resolver returns sensible byte counts across the
+/// four cases. Integration with the actual MLX backend is covered by the
+/// existing `MLXBackendTests` suite.
+final class MLXCachePolicyTests: XCTestCase {
+
+    func test_minimal_returnsTwentyMegabytes() {
+        XCTAssertEqual(MLXCachePolicy.minimal.resolvedBytes(), 20 * 1024 * 1024)
+    }
+
+    func test_explicit_returnsRequestedBytes() {
+        XCTAssertEqual(
+            MLXCachePolicy.explicit(bytes: 123_456).resolvedBytes(),
+            123_456
+        )
+    }
+
+    func test_explicit_clampsNegativeToZero() {
+        XCTAssertEqual(MLXCachePolicy.explicit(bytes: -1).resolvedBytes(), 0)
+    }
+
+    /// `.auto`'s smallest bucket is 64 MB; any test machine should be at
+    /// least there. This guards against the resolver returning the historical
+    /// 20 MB value or accidentally returning zero.
+    func test_auto_isAtLeastSixtyFourMegabytes() {
+        XCTAssertGreaterThanOrEqual(
+            MLXCachePolicy.auto.resolvedBytes(),
+            64 * 1024 * 1024
+        )
+    }
+
+    /// `.auto`'s largest bucket is 1 GB. This guards against the resolver
+    /// accidentally returning physical RAM directly.
+    func test_auto_isAtMostOneGigabyte() {
+        XCTAssertLessThanOrEqual(
+            MLXCachePolicy.auto.resolvedBytes(),
+            1024 * 1024 * 1024
+        )
+    }
+
+    func test_generous_isLargerThanMinimal() {
+        XCTAssertGreaterThan(
+            MLXCachePolicy.generous.resolvedBytes(),
+            MLXCachePolicy.minimal.resolvedBytes()
+        )
+    }
+
+    /// `.generous` is capped at 4 GB regardless of physical RAM. This guards
+    /// against allocating absurd amounts on Mac Studio-class machines.
+    func test_generous_isCappedAtFourGigabytes() {
+        XCTAssertLessThanOrEqual(
+            MLXCachePolicy.generous.resolvedBytes(),
+            4 * 1024 * 1024 * 1024
+        )
+    }
+
+    func test_equatable() {
+        XCTAssertEqual(MLXCachePolicy.auto, MLXCachePolicy.auto)
+        XCTAssertEqual(MLXCachePolicy.explicit(bytes: 100), MLXCachePolicy.explicit(bytes: 100))
+        XCTAssertNotEqual(MLXCachePolicy.auto, MLXCachePolicy.minimal)
+        XCTAssertNotEqual(MLXCachePolicy.explicit(bytes: 100), MLXCachePolicy.explicit(bytes: 200))
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- New `MLXCachePolicy` enum (`.auto` / `.minimal` / `.generous` / `.explicit`) and `MLXBackend.init(cachePolicy:)` so consumer apps can override the GPU buffer cache size MLX retains between operations.
- `.auto` (the new default) scales by physical RAM: 64 MB on ~6 GB iOS devices through 1 GB on 36+ GB Macs. Replaces the hardcoded 20 MB literal that was inherited verbatim from the mlx-swift-examples LLMEval sample.
- Source-compatible: every existing `MLXBackend()` call site (factory in `DefaultBackends`, ~15 test files, docs example) keeps compiling unchanged because the new init parameter has a default value.
- Drive-by fix: `unloadModel()` now skips `Memory.clearCache()` when no model was ever loaded, fixing a pre-existing issue where `MLXBackendTests/test_contract_allInvariants` was silently aborting under `swift test` with a metallib initialization error.

## Release Note

**Configurable MLX buffer cache policy** — MLX's GPU buffer cache size is now consumer-tunable on `MLXBackend`, and the default is no longer the historical 20 MB. The 20 MB literal had been inherited verbatim from the `mlx-swift-examples` LLMEval sample, where it serves as a "minimum footprint demo" value, and was dramatically too small for sustained chat or story generation on Apple Silicon Macs — it forced MLX to constantly evict and reallocate Metal buffers between forward passes instead of recycling them. The new `.auto` default scales by device physical memory, giving 16 GB Macs 256 MB and high-end 36+ GB Macs up to 1 GB. Consumer apps that have benchmarked their workload can pass `.generous` (~25% of RAM, capped at 4 GB), `.minimal` (the previous 20 MB, for tight iOS), or `.explicit(bytes:)` to `MLXBackend.init(cachePolicy:)`. All existing call sites that don't specify a policy automatically pick up the new default. Expect a small steady-state throughput improvement on warm runs; the larger cold-start cost on first model load is a separate concern (Metal shader compilation) tracked elsewhere.

## Test plan

- [x] `swift test --filter MLXCachePolicyTests --traits MLX` — 8 new tests covering `.auto` / `.minimal` / `.generous` / `.explicit` resolution and equatable conformance
- [x] `swift test --filter MLXBackendTests --traits MLX` — 12 tests pass cleanly, including the previously-aborting `test_contract_allInvariants` and `test_loadModel_invalidDirectory_throws`
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 157 tests, no regressions
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 697 tests, no regressions
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 391 tests, no regressions
- [ ] Real-workload validation against an MLX model on Apple Silicon (deferred to a follow-up benchmarking pass; the policy heuristic numbers in `.auto` are informed guesses, not measured optima)

## Notes for reviewers

- The `.auto` bucket numbers (64/128/256/512/1024 MB) are guesses informed by device class, not measured optima. They are intentionally much larger than 20 MB everywhere but should be tuned in a follow-up once we have real per-device throughput data from a benchmark sweep. The policy enum exists so that consumers like Fireside can override with `.explicit(bytes:)` once they have measured their own workloads.
- `Memory.cacheLimit` is intentionally applied **after** `loadModelContainer` succeeds, not before. An earlier draft of this change set the policy before the load to make weight staging run under the new policy, but that placement broke `test_loadModel_invalidDirectory_throws` because touching MLX's `Memory` namespace requires the metallib to be initialized first. The post-load placement keeps the assignment inside the implicit "MLX runtime is up" window. The cost is that the load itself runs under whatever cacheLimit was previously in effect (mlx-swift's default on a fresh process), which matches the previous behavior.
- The `unloadModel` guard is the same idea applied to `Memory.clearCache()`: skip it when there was nothing to clear, avoiding the metallib trip when the contract test exercises `unloadModel()` on a never-loaded backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)