### PR TITLE
fix: propagate MLX and Llama package traits as Swift compilation conditions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,11 @@ let package = Package(
                 .product(name: "Tokenizers", package: "swift-transformers", condition: .when(traits: ["MLX"])),
                 .product(name: "LlamaSwift", package: "llama.swift", condition: .when(traits: ["Llama"])),
             ],
-            path: "Sources/BaseChatBackends"
+            path: "Sources/BaseChatBackends",
+            swiftSettings: [
+                .define("MLX", .when(traits: ["MLX"])),
+                .define("Llama", .when(traits: ["Llama"])),
+            ]
         ),
         // UI: SwiftUI views and view models
         .target(
@@ -68,7 +72,11 @@ let package = Package(
                 "BaseChatCore",
                 .product(name: "MLXLMCommon", package: "mlx-swift-lm", condition: .when(traits: ["MLX"])),
             ],
-            path: "Sources/BaseChatTestSupport"
+            path: "Sources/BaseChatTestSupport",
+            swiftSettings: [
+                .define("MLX", .when(traits: ["MLX"])),
+                .define("Llama", .when(traits: ["Llama"])),
+            ]
         ),
         .testTarget(
             name: "BaseChatCoreTests",
@@ -82,6 +90,10 @@ let package = Package(
                 "BaseChatCore",
                 "BaseChatTestSupport",
                 .product(name: "MLXLMCommon", package: "mlx-swift-lm", condition: .when(traits: ["MLX"])),
+            ],
+            swiftSettings: [
+                .define("MLX", .when(traits: ["MLX"])),
+                .define("Llama", .when(traits: ["Llama"])),
             ]
         ),
         .testTarget(
@@ -111,6 +123,10 @@ let package = Package(
                 "BaseChatBackends",
                 "BaseChatCore",
                 "BaseChatTestSupport",
+            ],
+            swiftSettings: [
+                .define("MLX", .when(traits: ["MLX"])),
+                .define("Llama", .when(traits: ["Llama"])),
             ]
         ),
     ],


### PR DESCRIPTION
## Summary

SwiftPM 6.1 package traits gate dependency *linkage* via `.when(traits:)`, but they do **not** automatically define corresponding Swift compilation conditions. Since [PR #22](https://github.com/roryford/BaseChatKit/pull/22) introduced the `MLX` and `Llama` traits, every source and test file wrapped in `#if MLX` / `#if Llama` has been silently excluded from `swift build` / `swift test` — the compilation condition was never defined, so `MLXBackend`, `LlamaBackend`, `MLXCachePolicy`, their supporting types, and their entire test coverage have been dead code for SwiftPM consumers.

Xcode's build system handles the trait→compilation-condition mapping correctly, which is why the Xcode-only `BaseChatMLXIntegrationTests` suite kept working and nobody noticed. Downstream consumers that use BCK via SwiftPM with `traits: ["MLX", "Llama"]` (e.g. Fireside) have been receiving empty MLX/Llama modules with no way to tell.

The fix is additive: add `swiftSettings: [.define("MLX", .when(traits: ["MLX"])), .define("Llama", .when(traits: ["Llama"]))]` to the four targets that contain `#if MLX` / `#if Llama` guards:

- `BaseChatBackends` (5 guarded source files)
- `BaseChatTestSupport` (`MockMLXModelContainer`)
- `BaseChatBackendsTests` (7 guarded test files)
- `BaseChatMLXIntegrationTests` (redundant under Xcode, added for SwiftPM parity)

**CI behavior is unchanged.** CI runs with `--disable-default-traits` so `MLX` and `Llama` remain undefined there — the same cloud-backend-only subset compiles and runs. The observable behavior change is entirely downstream: SwiftPM consumers who opt into the traits now actually receive the local inference backends.

## Release Note

**Package traits now correctly gate `#if MLX` and `#if Llama` code** — fixed a latent SwiftPM 6.1 packaging bug where the `MLX` and `Llama` package traits toggled dependency linkage but never defined the matching Swift compilation conditions. As a result, every downstream SwiftPM consumer that opted into `traits: ["MLX", "Llama"]` was silently receiving empty backend modules, because `MLXBackend`, `LlamaBackend`, `MLXCachePolicy`, and their supporting files are wrapped in `#if MLX` / `#if Llama` guards that were never active. Xcode's build system handled trait propagation correctly, which is why BCK's own integration tests kept passing and the regression was not noticed until a downstream consumer hit it. The fix adds `swiftSettings: [.define("MLX", .when(traits: ["MLX"])), .define("Llama", .when(traits: ["Llama"]))]` to the four targets that contain guarded code, so `swift build` and `swift test` now behave the same way Xcode already did. CI behavior is unchanged — CI already builds with `--disable-default-traits`, so the cloud-only subset continues to compile and run exactly as before.

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 697 + 105 tests, 0 failures
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 391 tests, 0 failures
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 157 + 76 tests, 0 failures
- [x] `swift test --filter BaseChatBackendsTests --traits MLX,Llama` — 207 tests, 2 skipped, 0 failures (all previously-dormant MLX/Llama tests now actually execute)
- [x] Verified `BaseChatMLXIntegrationTests` behavior is identical on `main` and on this branch (pre-existing fixture failures on my local machine from a stray `~/Documents/Models/perf-mlx-1-*` directory, unrelated to this change)
- [ ] CI: `BaseChatCoreTests` + `BaseChatUITests` + `BaseChatBackendsTests` (all with `--disable-default-traits`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)