### PR TITLE
fix: wrap llama.cpp C pointers in RAII handles to prevent load-path leaks

### DIFF
--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -178,7 +178,7 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
 
     /// Owns a `llama_model *`. Calls `llama_model_free` on deinit unless
     /// ownership was transferred via `steal()`.
-    final class LlamaModelHandle: @unchecked Sendable {
+    private final class LlamaModelHandle: @unchecked Sendable {
         private(set) var pointer: OpaquePointer?
         init(_ pointer: OpaquePointer) { self.pointer = pointer }
         /// Transfers ownership to the caller. Subsequent deinit is a no-op.
@@ -188,7 +188,7 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
 
     /// Owns a `llama_context *`. Calls `llama_free` on deinit unless
     /// ownership was transferred via `steal()`.
-    final class LlamaContextHandle: @unchecked Sendable {
+    private final class LlamaContextHandle: @unchecked Sendable {
         private(set) var pointer: OpaquePointer?
         let vocabPtr: OpaquePointer?
         init(context: OpaquePointer, vocab: OpaquePointer?) {

--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -134,8 +134,9 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
             guard activeLoadToken == loadToken else {
                 return false
             }
-            self.model = loadedResources.model
-            self.context = loadedResources.context
+            // steal() transfers ownership; unloadModel's explicit ordered cleanup takes over.
+            self.model = loadedResources.model.steal()
+            self.context = loadedResources.context.steal()
             self.vocab = loadedResources.vocab
             self.isModelLoaded = true
             self._effectiveContextSize = loadedResources.effectiveContextSize
@@ -143,8 +144,8 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         }
 
         guard didCommit else {
-            llama_free(loadedResources.context)
-            llama_model_free(loadedResources.model)
+            // loadedResources goes out of scope here. steal() was never called, so
+            // LlamaContextHandle/LlamaModelHandle deinits free the C memory automatically.
             throw CancellationError()
         }
 
@@ -161,10 +162,42 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
     }
 
     private struct LoadedResources: @unchecked Sendable {
-        let model: OpaquePointer
-        let context: OpaquePointer
-        let vocab: OpaquePointer?
+        let model: LlamaModelHandle
+        let context: LlamaContextHandle
         let effectiveContextSize: Int32
+        var vocab: OpaquePointer? { context.vocabPtr }
+    }
+
+    // MARK: - RAII Pointer Wrappers
+    //
+    // These types own C pointers and free them on deinit, making error-path
+    // cleanup in initializeModel automatic. On the successful load path,
+    // steal() transfers ownership to the instance vars so that unloadModel's
+    // explicit ordered cleanup (context before model, both before
+    // llama_backend_free) is unaffected.
+
+    /// Owns a `llama_model *`. Calls `llama_model_free` on deinit unless
+    /// ownership was transferred via `steal()`.
+    final class LlamaModelHandle: @unchecked Sendable {
+        private(set) var pointer: OpaquePointer?
+        init(_ pointer: OpaquePointer) { self.pointer = pointer }
+        /// Transfers ownership to the caller. Subsequent deinit is a no-op.
+        func steal() -> OpaquePointer? { defer { pointer = nil }; return pointer }
+        deinit { if let p = pointer { llama_model_free(p) } }
+    }
+
+    /// Owns a `llama_context *`. Calls `llama_free` on deinit unless
+    /// ownership was transferred via `steal()`.
+    final class LlamaContextHandle: @unchecked Sendable {
+        private(set) var pointer: OpaquePointer?
+        let vocabPtr: OpaquePointer?
+        init(context: OpaquePointer, vocab: OpaquePointer?) {
+            self.pointer = context
+            self.vocabPtr = vocab
+        }
+        /// Transfers ownership to the caller. Subsequent deinit is a no-op.
+        func steal() -> OpaquePointer? { defer { pointer = nil }; return pointer }
+        deinit { if let p = pointer { llama_free(p) } }
     }
 
     private static func initializeModel(
@@ -178,18 +211,19 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         modelParams.n_gpu_layers = 99  // Offload all layers to Metal
         #endif
 
-        guard let loadedModel = llama_model_load_from_file(url.path, modelParams) else {
+        guard let rawModel = llama_model_load_from_file(url.path, modelParams) else {
             throw InferenceError.modelLoadFailed(underlying: NSError(
                 domain: "LlamaBackend",
                 code: -1,
                 userInfo: [NSLocalizedDescriptionKey: "Failed to load GGUF model from \(url.lastPathComponent)"]
             ))
         }
+        let modelHandle = LlamaModelHandle(rawModel)
 
         var ctxParams = llama_context_default_params()
         // Respect the model's actual training context length — hard-capping at 8192
         // prevents long-context models (32K–128K) from using their full window.
-        let trainedContextLength = Int32(llama_model_n_ctx_train(loadedModel))
+        let trainedContextLength = Int32(llama_model_n_ctx_train(rawModel))
         // Device-safe cap: 1 token ≈ 8 KB of KV cache (2 KB per layer element × 4 bytes);
         // physicalMemory / 8 192 gives the token count that would exhaust all RAM,
         // clamped to 128 000 as an absolute ceiling.
@@ -200,8 +234,8 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         ctxParams.n_threads = Int32(max(1, min(8, ProcessInfo.processInfo.processorCount - 2)))
         ctxParams.n_threads_batch = ctxParams.n_threads
 
-        guard let ctx = llama_init_from_model(loadedModel, ctxParams) else {
-            llama_model_free(loadedModel)
+        guard let ctx = llama_init_from_model(rawModel, ctxParams) else {
+            // modelHandle goes out of scope here → llama_model_free called automatically
             throw InferenceError.modelLoadFailed(underlying: NSError(
                 domain: "LlamaBackend",
                 code: -2,
@@ -209,10 +243,13 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
             ))
         }
 
-        return LoadedResources(
-            model: loadedModel,
+        let contextHandle = LlamaContextHandle(
             context: ctx,
-            vocab: llama_model_get_vocab(loadedModel),
+            vocab: llama_model_get_vocab(rawModel)
+        )
+        return LoadedResources(
+            model: modelHandle,
+            context: contextHandle,
             effectiveContextSize: effectiveContextSize
         )
     }


### PR DESCRIPTION
## Summary

- Introduces `LlamaModelHandle` and `LlamaContextHandle` — private final classes that own their respective C pointers and call `llama_model_free` / `llama_free` on `deinit`
- A `steal()` method transfers ownership to the instance vars on a successful load, leaving `unloadModel`'s existing explicit ordered cleanup (context → model → `llama_backend_free`) completely intact
- `LoadedResources` now carries the typed handles instead of raw `OpaquePointer` fields

## What this fixes

Two code paths previously required manual cleanup that was easy to get wrong or forget in future edits:

1. **`initializeModel` context-init failure**: previously called `llama_model_free(loadedModel)` explicitly before the throw. Now `modelHandle` goes out of scope and deinit handles it automatically.

2. **`loadModel` superseded-load path** (`guard didCommit else`): previously called `llama_free` / `llama_model_free` explicitly. Now `loadedResources` going out of scope handles it — `steal()` was never called, so both deinits fire.

`unloadModel`'s cleanup task is unchanged: it still calls `llama_free(ctx)` then `llama_model_free(mdl)` then `Self.releaseBackend()` in explicit order, which is required because the RAII deinit would fire after `releaseBackend` if we relied on end-of-scope ordering there.

## Release Note

`LlamaBackend` now wraps its raw `llama_model *` and `llama_context *` pointers in typed RAII handles. Two previously manual cleanup paths (context-init failure in `initializeModel`, and load cancellation in `loadModel`) are now automatic via `deinit`, eliminating the risk of leaks if those paths are touched in future edits.

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)