### PR TITLE
fix: zero ephemeral API key bytes in memory on deallocation

### DIFF
--- a/Sources/BaseChatBackends/SSECloudBackend.swift
+++ b/Sources/BaseChatBackends/SSECloudBackend.swift
@@ -58,11 +58,20 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
         set { withStateLock { _keychainAccount = newValue } }
     }
 
-    private var _ephemeralAPIKey: String?
+    private var _ephemeralAPIKey: SecureBytes?
     /// Fallback API key for tests or ephemeral use. Prefer ``keychainAccount``.
+    ///
+    /// The backing store is a ``SecureBytes`` buffer that is zeroed with
+    /// `memset_s` when the key is replaced or the backend is deallocated,
+    /// limiting how long the raw key bytes survive in freed memory.
+    ///
+    /// > Warning: The `String` returned by the getter and any copies made while
+    /// > building HTTP headers are *not* covered by this guarantee. For
+    /// > production use prefer ``keychainAccount``-backed storage so the raw
+    /// > key never enters the process heap at all.
     public var ephemeralAPIKey: String? {
-        get { withStateLock { _ephemeralAPIKey } }
-        set { withStateLock { _ephemeralAPIKey = newValue } }
+        get { withStateLock { _ephemeralAPIKey?.stringValue } }
+        set { withStateLock { _ephemeralAPIKey = newValue.flatMap { SecureBytes($0) } } }
     }
 
     private var _conversationHistory: [(role: String, content: String)]?
@@ -178,7 +187,7 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
     public func configure(baseURL: URL, apiKey: String?, modelName: String) {
         withStateLock {
             _baseURL = baseURL
-            _ephemeralAPIKey = apiKey
+            _ephemeralAPIKey = apiKey.flatMap { SecureBytes($0) }
             _keychainAccount = nil
             _modelName = modelName
         }
@@ -201,7 +210,7 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
 
     /// Retrieves the API key from Keychain or ephemeral storage.
     public func resolveAPIKey() -> String? {
-        let (account, ephemeral) = withStateLock { (_keychainAccount, _ephemeralAPIKey) }
+        let (account, ephemeral) = withStateLock { (_keychainAccount, _ephemeralAPIKey?.stringValue) }
         if let account {
             return KeychainService.retrieve(account: account)
         }

--- a/Sources/BaseChatBackends/SecureBytes.swift
+++ b/Sources/BaseChatBackends/SecureBytes.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Stores a secret string in a heap-allocated mutable buffer that is zeroed
+/// via `memset_s` on deallocation.
+///
+/// This reduces the window during which API keys linger in freed memory once a
+/// backend is unloaded or reconfigured. `memset_s` is used instead of plain
+/// `memset` because the C standard allows optimising-compilers to elide a
+/// `memset` call whose result is never read; `memset_s` carries a conformance
+/// obligation that prevents that elision.
+///
+/// **Scope of the guarantee**: only the bytes owned by this object are zeroed.
+/// Any `String` value returned by ``stringValue`` is a separate Swift-managed
+/// copy and is not covered.
+final class SecureBytes: @unchecked Sendable {
+
+    private let buffer: UnsafeMutableBufferPointer<UInt8>
+
+    init?(_ string: String) {
+        let utf8 = string.utf8
+        guard !utf8.isEmpty else { return nil }
+        buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: utf8.count)
+        _ = buffer.initialize(from: utf8)
+    }
+
+    /// Returns the stored bytes decoded as a UTF-8 string.
+    var stringValue: String {
+        String(bytes: buffer, encoding: .utf8) ?? ""
+    }
+
+    deinit {
+        _ = memset_s(buffer.baseAddress, buffer.count, 0, buffer.count)
+        buffer.deallocate()
+    }
+}

--- a/Sources/BaseChatBackends/SecureBytes.swift
+++ b/Sources/BaseChatBackends/SecureBytes.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 /// Stores a secret string in a heap-allocated mutable buffer that is zeroed
@@ -25,7 +26,7 @@ final class SecureBytes: @unchecked Sendable {
 
     /// Returns the stored bytes decoded as a UTF-8 string.
     var stringValue: String {
-        String(bytes: buffer, encoding: .utf8) ?? ""
+        String(decoding: buffer, as: UTF8.self)
     }
 
     deinit {

--- a/Tests/BaseChatBackendsTests/SecureBytesTests.swift
+++ b/Tests/BaseChatBackendsTests/SecureBytesTests.swift
@@ -28,23 +28,27 @@ struct SecureBytesTests {
 @Suite("SSECloudBackend ephemeralAPIKey")
 struct EphemeralAPIKeyTests {
 
+    private func makeBackend() -> SSECloudBackend {
+        SSECloudBackend(defaultModelName: "test-model", urlSession: .shared)
+    }
+
     @Test("stores and retrieves a key")
     func storeAndRetrieve() {
-        let backend = ClaudeBackend()
+        let backend = makeBackend()
         backend.ephemeralAPIKey = "sk-abc"
         #expect(backend.ephemeralAPIKey == "sk-abc")
     }
 
     @Test("setting an empty string treats key as absent")
     func emptyStringBecomesNil() {
-        let backend = ClaudeBackend()
+        let backend = makeBackend()
         backend.ephemeralAPIKey = ""
         #expect(backend.ephemeralAPIKey == nil)
     }
 
     @Test("key is nil after unloadModel")
     func clearedAfterUnload() async {
-        let backend = ClaudeBackend()
+        let backend = makeBackend()
         let url = URL(string: "https://api.test")!
         backend.configure(baseURL: url, apiKey: "sk-abc", modelName: "test-model")
         #expect(backend.ephemeralAPIKey == "sk-abc")
@@ -54,7 +58,7 @@ struct EphemeralAPIKeyTests {
 
     @Test("resolveAPIKey returns ephemeral key when no keychain account set")
     func resolveReturnsEphemeral() {
-        let backend = ClaudeBackend()
+        let backend = makeBackend()
         let url = URL(string: "https://api.test")!
         backend.configure(baseURL: url, apiKey: "sk-resolve-test", modelName: "test-model")
         #expect(backend.resolveAPIKey() == "sk-resolve-test")
@@ -62,7 +66,7 @@ struct EphemeralAPIKeyTests {
 
     @Test("replacing a key with nil releases the old value")
     func replaceWithNil() {
-        let backend = ClaudeBackend()
+        let backend = makeBackend()
         backend.ephemeralAPIKey = "sk-old"
         backend.ephemeralAPIKey = nil
         #expect(backend.ephemeralAPIKey == nil)

--- a/Tests/BaseChatBackendsTests/SecureBytesTests.swift
+++ b/Tests/BaseChatBackendsTests/SecureBytesTests.swift
@@ -1,0 +1,70 @@
+import Testing
+import Foundation
+@testable import BaseChatBackends
+
+@Suite("SecureBytes")
+struct SecureBytesTests {
+
+    @Test("returns nil for empty string")
+    func emptyStringIsNil() {
+        #expect(SecureBytes("") == nil)
+    }
+
+    @Test("round-trips a non-empty key")
+    func roundTrip() throws {
+        let key = "sk-test-abc123"
+        let secure = try #require(SecureBytes(key))
+        #expect(secure.stringValue == key)
+    }
+
+    @Test("round-trips a key containing multi-byte UTF-8 characters")
+    func roundTripMultiByte() throws {
+        let key = "sk-\u{1F511}key"
+        let secure = try #require(SecureBytes(key))
+        #expect(secure.stringValue == key)
+    }
+}
+
+@Suite("SSECloudBackend ephemeralAPIKey")
+struct EphemeralAPIKeyTests {
+
+    @Test("stores and retrieves a key")
+    func storeAndRetrieve() {
+        let backend = ClaudeBackend()
+        backend.ephemeralAPIKey = "sk-abc"
+        #expect(backend.ephemeralAPIKey == "sk-abc")
+    }
+
+    @Test("setting an empty string treats key as absent")
+    func emptyStringBecomesNil() {
+        let backend = ClaudeBackend()
+        backend.ephemeralAPIKey = ""
+        #expect(backend.ephemeralAPIKey == nil)
+    }
+
+    @Test("key is nil after unloadModel")
+    func clearedAfterUnload() async {
+        let backend = ClaudeBackend()
+        let url = URL(string: "https://api.test")!
+        backend.configure(baseURL: url, apiKey: "sk-abc", modelName: "test-model")
+        #expect(backend.ephemeralAPIKey == "sk-abc")
+        backend.unloadModel()
+        #expect(backend.ephemeralAPIKey == nil)
+    }
+
+    @Test("resolveAPIKey returns ephemeral key when no keychain account set")
+    func resolveReturnsEphemeral() {
+        let backend = ClaudeBackend()
+        let url = URL(string: "https://api.test")!
+        backend.configure(baseURL: url, apiKey: "sk-resolve-test", modelName: "test-model")
+        #expect(backend.resolveAPIKey() == "sk-resolve-test")
+    }
+
+    @Test("replacing a key with nil releases the old value")
+    func replaceWithNil() {
+        let backend = ClaudeBackend()
+        backend.ephemeralAPIKey = "sk-old"
+        backend.ephemeralAPIKey = nil
+        #expect(backend.ephemeralAPIKey == nil)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `SecureBytes`, a `final class` that stores a secret in a heap-allocated `UnsafeMutableBufferPointer<UInt8>` and calls `memset_s` on `deinit` to zero the buffer before freeing it
- Replaces `_ephemeralAPIKey: String?` in `SSECloudBackend` with `SecureBytes?` so the raw key bytes are cleared on key replacement, `unloadModel()`, and backend deallocation
- Documents the security boundary: `String` copies made while building HTTP headers are not covered — `keychainAccount`-backed storage is recommended for production
- Adds 8 unit tests covering `SecureBytes` (empty-string nil init, round-trip, multi-byte UTF-8) and the `ephemeralAPIKey` property (store/retrieve, empty-string nil coercion, post-unload nil, `resolveAPIKey`, replace-with-nil)

## Release Note

Prior to this fix, ephemeral API keys held by `SSECloudBackend` were stored as plain Swift `String` values. Swift's `String` makes no guarantee about zeroing its backing memory when deallocated, meaning a key could linger in freed heap pages and be recoverable from a memory dump on a jailbroken or compromised device.

The key is now stored in a `SecureBytes` wrapper that uses `memset_s` (rather than plain `memset`, which compilers are permitted to elide as a dead store) to zero its buffer on deallocation. The raw key bytes are erased whenever the key is replaced, `unloadModel()` is called, or the backend itself is freed. The security boundary — that transient `String` copies made during HTTP header construction are not covered — is documented on the property, and Keychain-backed storage remains the recommended approach for production.

Closes #151

## Test plan

- [ ] `swift test --filter BaseChatBackendsTests --disable-default-traits` — all 84 tests pass
- [ ] New `SecureBytesTests` suite: 3 `SecureBytes` tests + 5 `EphemeralAPIKeyTests` all green