### PR TITLE
fix: animate session list transition and defer auto-rename until generation completes

### DIFF
--- a/Example/BaseChatDemo/DemoContentView.swift
+++ b/Example/BaseChatDemo/DemoContentView.swift
@@ -63,8 +63,13 @@ struct DemoContentView: View {
             }
 
             // Wire AI auto-rename: fires after the first user message in a session.
+            // We defer the rename call until generation finishes so the rename
+            // inference request does not compete with the active streaming reply.
             viewModel.onFirstMessage = { [inferenceService] session, text in
-                Task {
+                Task { @MainActor in
+                    while viewModel.isGenerating {
+                        try? await Task.sleep(nanoseconds: 100_000_000)
+                    }
                     await sessionManager.autoRenameSession(
                         session,
                         firstMessage: text,

--- a/Sources/BaseChatUI/Views/Sidebar/SessionListView.swift
+++ b/Sources/BaseChatUI/Views/Sidebar/SessionListView.swift
@@ -20,77 +20,77 @@ public struct SessionListView: View {
         @Bindable var sessionManager = sessionManager
 
         Group {
-        if sessionManager.sessions.isEmpty {
-            ContentUnavailableView {
-                Label("No Chats", systemImage: "bubble.left.and.bubble.right")
-            } description: {
-                Text("Tap the + button to start a new chat.")
-            }
-        } else {
-            List(sessionManager.sessions, selection: $sessionManager.activeSession) { session in
-                SessionRowView(session: session)
-                    .tag(session)
-                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                        Button(role: .destructive) {
-                            sessionToDelete = session
-                        } label: {
-                            Label("Delete", systemImage: "trash")
+            if sessionManager.sessions.isEmpty {
+                ContentUnavailableView {
+                    Label("No Chats", systemImage: "bubble.left.and.bubble.right")
+                } description: {
+                    Text("Tap the + button to start a new chat.")
+                }
+            } else {
+                List(sessionManager.sessions, selection: $sessionManager.activeSession) { session in
+                    SessionRowView(session: session)
+                        .tag(session)
+                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                            Button(role: .destructive) {
+                                sessionToDelete = session
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
                         }
-                    }
-                    .swipeActions(edge: .leading) {
-                        Button {
-                            renameText = session.title
-                            sessionToRename = session
-                        } label: {
-                            Label("Rename", systemImage: "pencil")
+                        .swipeActions(edge: .leading) {
+                            Button {
+                                renameText = session.title
+                                sessionToRename = session
+                            } label: {
+                                Label("Rename", systemImage: "pencil")
+                            }
+                            .tint(.blue)
                         }
-                        .tint(.blue)
-                    }
-            }
-            .alert("Rename Chat", isPresented: .init(
-                get: { sessionToRename != nil },
-                set: { if !$0 { sessionToRename = nil } }
-            )) {
-                TextField("Chat title", text: $renameText)
-                Button("Cancel", role: .cancel) { sessionToRename = nil }
-                Button("Rename") {
-                    if let session = sessionToRename {
-                        do {
-                            try sessionManager.renameSession(session, title: renameText)
-                        } catch {
-                            errorMessage = "Failed to rename session: \(error.localizedDescription)"
-                        }
-                    }
-                    sessionToRename = nil
                 }
             }
-            .alert("Delete Chat?", isPresented: .init(
-                get: { sessionToDelete != nil },
-                set: { if !$0 { sessionToDelete = nil } }
-            ), presenting: sessionToDelete) { session in
-                Button("Delete", role: .destructive) {
-                    do {
-                        try sessionManager.deleteSession(session)
-                    } catch {
-                        errorMessage = "Failed to delete session: \(error.localizedDescription)"
-                    }
-                    sessionToDelete = nil
-                }
-                Button("Cancel", role: .cancel) { sessionToDelete = nil }
-            } message: { session in
-                Text("This will permanently delete \"\(session.title)\" and all its messages.")
-            }
-            .alert("Error", isPresented: Binding(
-                get: { errorMessage != nil },
-                set: { if !$0 { errorMessage = nil } }
-            )) {
-                Button("OK") { errorMessage = nil }
-            } message: {
-                if let errorMessage { Text(errorMessage) }
-            }
-        }
         }
         .animation(.default, value: sessionManager.sessions.isEmpty)
+        .alert("Rename Chat", isPresented: .init(
+            get: { sessionToRename != nil },
+            set: { if !$0 { sessionToRename = nil } }
+        )) {
+            TextField("Chat title", text: $renameText)
+            Button("Cancel", role: .cancel) { sessionToRename = nil }
+            Button("Rename") {
+                if let session = sessionToRename {
+                    do {
+                        try sessionManager.renameSession(session, title: renameText)
+                    } catch {
+                        errorMessage = "Failed to rename session: \(error.localizedDescription)"
+                    }
+                }
+                sessionToRename = nil
+            }
+        }
+        .alert("Delete Chat?", isPresented: .init(
+            get: { sessionToDelete != nil },
+            set: { if !$0 { sessionToDelete = nil } }
+        ), presenting: sessionToDelete) { session in
+            Button("Delete", role: .destructive) {
+                do {
+                    try sessionManager.deleteSession(session)
+                } catch {
+                    errorMessage = "Failed to delete session: \(error.localizedDescription)"
+                }
+                sessionToDelete = nil
+            }
+            Button("Cancel", role: .cancel) { sessionToDelete = nil }
+        } message: { session in
+            Text("This will permanently delete \"\(session.title)\" and all its messages.")
+        }
+        .alert("Error", isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )) {
+            Button("OK") { errorMessage = nil }
+        } message: {
+            if let errorMessage { Text(errorMessage) }
+        }
     }
 }
 

--- a/Sources/BaseChatUI/Views/Sidebar/SessionListView.swift
+++ b/Sources/BaseChatUI/Views/Sidebar/SessionListView.swift
@@ -19,6 +19,7 @@ public struct SessionListView: View {
     public var body: some View {
         @Bindable var sessionManager = sessionManager
 
+        Group {
         if sessionManager.sessions.isEmpty {
             ContentUnavailableView {
                 Label("No Chats", systemImage: "bubble.left.and.bubble.right")
@@ -88,6 +89,8 @@ public struct SessionListView: View {
                 if let errorMessage { Text(errorMessage) }
             }
         }
+        }
+        .animation(.default, value: sessionManager.sessions.isEmpty)
     }
 }
 


### PR DESCRIPTION
## Summary

- Wraps the session list `if/else` in a `Group` with `.animation(.default, value: sessions.isEmpty)` so the empty→list transition crossfades instead of hard-cutting
- Defers `autoRenameSession` until `isGenerating` is false to prevent the rename inference call from racing with active generation
- Moves `.alert` modifiers from the `List` to after the `Group` to fix a Swift parser error caused by deeply nested trailing closures inside a ViewBuilder

## Test plan

- [ ] Create a new session — verify the list fades in rather than snapping
- [ ] Send a first message, confirm the session title updates after generation finishes (not mid-stream)
- [ ] CI passes (`BaseChatCoreTests`, `BaseChatUITests`, `BaseChatBackendsTests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)