### PR TITLE
refactor: route ChatViewModel streaming through GenerationStreamConsumer

### DIFF
--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
@@ -150,15 +150,14 @@ extension ChatViewModel {
                     interval: streamingUpdateInterval,
                     maxBufferedCharacters: streamingBatchCharacterLimit
                 )
+                var consumer = GenerationStreamConsumer(loopDetectionEnabled: self.loopDetectionEnabled)
 
                 do {
                     eventLoop: for try await event in stream.events {
                         if Task.isCancelled { break }
 
-                        // TODO: Migrate to GenerationStreamConsumer.handle() for testability.
-                        // The consumer is extracted and tested but not yet wired in here.
-                        switch event {
-                        case .token(let token):
+                        switch consumer.handle(event) {
+                        case .appendText(let token):
                             tokenCount += 1
                             if tokenCount == 1 {
                                 self.activityPhase = .streaming
@@ -167,9 +166,7 @@ extension ChatViewModel {
                                 var looping = false
                                 self.mutateMessage(id: messageID) { msg in
                                     msg.content += batch
-                                    if self.loopDetectionEnabled,
-                                       msg.content.count >= 100,
-                                       RepetitionDetector.looksLikeLooping(msg.content) {
+                                    if consumer.shouldStopForLoop(content: msg.content) {
                                         looping = true
                                     }
                                 }
@@ -180,13 +177,13 @@ extension ChatViewModel {
                                 }
                             }
 
-                        case .usage(let prompt, let completion):
+                        case .recordUsage(let prompt, let completion):
                             self.mutateMessage(id: messageID) { msg in
                                 msg.promptTokens = prompt
                                 msg.completionTokens = completion
                             }
 
-                        case .toolCall:
+                        case .noOp:
                             break
                         }
                     }


### PR DESCRIPTION
## Summary
- `GenerationStreamConsumer.handle(event) -> StreamAction` was extracted and tested, but `ChatViewModel+Generation.swift` still switched over `GenerationEvent` inline — the tested seam was unused in production.
- Wire the production stream loop through `consumer.handle(event)` and dispatch on `StreamAction` (`.appendText`, `.recordUsage`, `.noOp`). Loop detection now uses `consumer.shouldStopForLoop`, so tests and production share the same logic.
- Behavior-preserving refactor: cancellation checks, `StreamingTokenBatcher` flush on stream end, `surfaceError` propagation, upgrade-hint flow, and `postGenerationTasks` execution are all unchanged. `StreamAction` already covered all three `GenerationEvent` cases, so no enum extension was needed (`.toolCall` maps to `.noOp`, matching the prior `break`).

## Test plan
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` (105 tests pass)
- [x] `swift test --filter BaseChatUITests --disable-default-traits` (391 tests pass)
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` (84 tests pass)
- [x] Sabotage check: shadowed `.appendText` with a no-op case and confirmed `BackendActivityPhaseTests` + `CancellationTests` fail, proving the new dispatch path is exercised. Sabotage reverted.

Generated with [Claude Code](https://claude.com/claude-code)