### PR TITLE
test: add ChaosBackend and PerceivedLatencyBackend test doubles

### DIFF
--- a/Sources/BaseChatTestSupport/ChaosBackend.swift
+++ b/Sources/BaseChatTestSupport/ChaosBackend.swift
@@ -1,0 +1,223 @@
+import Foundation
+import BaseChatCore
+
+/// A test double that deterministically injects streaming failures.
+///
+/// `MockInferenceBackend` only reveals happy-path bugs. Real backends can
+/// drop the socket mid-stream, take a long time to reach the first token,
+/// deliver bursts of tokens followed by a stall, or surface a transport error
+/// partway through a response. Each of those scenarios produces a distinct
+/// UX failure mode in the chat layer: orphaned typing indicators, partial
+/// assistant messages, stuck loading states, missing error banners.
+///
+/// `ChaosBackend` reproduces each scenario on demand so tests can pin the
+/// expected behaviour. The failure mode is set via ``mode`` and is honoured
+/// on every subsequent call to ``generate(prompt:systemPrompt:config:)``.
+///
+/// ## Reproducibility
+///
+/// All timings are scheduled with `Task.sleep(for:)` against real wall-clock
+/// time. Tests should keep delays small (≤ 100 ms) to stay CI-friendly. The
+/// backend does not use a PRNG — every failure mode is deterministic given
+/// the same inputs, which makes assertions straightforward.
+public final class ChaosBackend: InferenceBackend, @unchecked Sendable {
+
+    /// Failure modes the backend can inject into its stream.
+    public enum FailureMode: Sendable, Equatable {
+        /// Yields tokens and finishes normally. Baseline happy-path.
+        case none
+
+        /// Yields `afterTokens` tokens, then terminates the stream without
+        /// throwing or finishing the remaining tokens. Simulates a socket
+        /// drop where the server closes the connection silently.
+        case dropMidStream(afterTokens: Int)
+
+        /// Delays the first token by `delay`, then streams the rest normally.
+        /// Simulates a cold backend, a queued request, or head-of-line blocking.
+        case slowFirstToken(delay: Duration)
+
+        /// Yields `burstSize` tokens back-to-back with no delay, then stalls
+        /// for `stallDuration` before finishing the remaining tokens.
+        /// Exposes UI batching assumptions and idle-timeout tuning.
+        case burstThenStall(burstSize: Int, stallDuration: Duration)
+
+        /// Yields `afterTokens` tokens, then throws an `InferenceError` into
+        /// the stream. Simulates a transport error mid-generation.
+        case networkError(afterTokens: Int)
+    }
+
+    private let stateLock = NSLock()
+    private var _isModelLoaded = true
+    private var _isGenerating = false
+    private var generationTask: Task<Void, Never>?
+    private var _mode: FailureMode
+    private var _tokensToYield: [String]
+
+    public var isModelLoaded: Bool { withStateLock { _isModelLoaded } }
+    public var isGenerating: Bool { withStateLock { _isGenerating } }
+
+    public let capabilities = BackendCapabilities(
+        supportedParameters: [.temperature, .topP, .repeatPenalty],
+        maxContextTokens: 4096,
+        requiresPromptTemplate: false,
+        supportsSystemPrompt: true
+    )
+
+    /// The currently active failure mode. Changes take effect on the next
+    /// call to `generate()`; in-flight streams are unaffected.
+    public var mode: FailureMode {
+        get { withStateLock { _mode } }
+        set { withStateLock { _mode = newValue } }
+    }
+
+    public var tokensToYield: [String] {
+        get { withStateLock { _tokensToYield } }
+        set { withStateLock { _tokensToYield = newValue } }
+    }
+
+    /// Creates a chaos backend.
+    ///
+    /// - Parameters:
+    ///   - mode: Initial failure mode. Defaults to `.none` (happy path).
+    ///   - tokensToYield: The token sequence the backend will attempt to
+    ///     produce. Failure modes truncate or interrupt this sequence.
+    public init(
+        mode: FailureMode = .none,
+        tokensToYield: [String] = ["Hello", " ", "world"]
+    ) {
+        self._mode = mode
+        self._tokensToYield = tokensToYield
+    }
+
+    deinit {
+        cancelGeneration(markModelUnloaded: false)
+    }
+
+    public func loadModel(from url: URL, contextSize: Int32) async throws {
+        withStateLock { _isModelLoaded = true }
+    }
+
+    public func generate(
+        prompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig
+    ) throws -> GenerationStream {
+        let (tokens, mode, loaded) = withStateLock {
+            (_tokensToYield, _mode, _isModelLoaded)
+        }
+        guard loaded else {
+            throw InferenceError.inferenceFailure("No model loaded")
+        }
+        withStateLock { _isGenerating = true }
+
+        let stream = AsyncThrowingStream<GenerationEvent, Error> { [weak self] continuation in
+            let task = Task { [weak self] in
+                await Self.runFailureMode(
+                    mode: mode,
+                    tokens: tokens,
+                    continuation: continuation
+                )
+                self?.finishGeneration()
+            }
+            continuation.onTermination = { @Sendable _ in
+                task.cancel()
+            }
+            self?.setGenerationTask(task)
+        }
+        return GenerationStream(stream)
+    }
+
+    public func stopGeneration() {
+        cancelGeneration(markModelUnloaded: false)
+    }
+
+    public func unloadModel() {
+        cancelGeneration(markModelUnloaded: true)
+    }
+
+    // MARK: - Failure orchestration
+
+    private static func runFailureMode(
+        mode: FailureMode,
+        tokens: [String],
+        continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
+    ) async {
+        switch mode {
+        case .none:
+            for token in tokens {
+                if Task.isCancelled { break }
+                continuation.yield(.token(token))
+            }
+            continuation.finish()
+
+        case .dropMidStream(let afterTokens):
+            for (index, token) in tokens.enumerated() {
+                if Task.isCancelled { break }
+                if index >= afterTokens { break }
+                continuation.yield(.token(token))
+            }
+            // Silent drop: no throw, just finish early.
+            continuation.finish()
+
+        case .slowFirstToken(let delay):
+            if Task.isCancelled { continuation.finish(); return }
+            try? await Task.sleep(for: delay)
+            for token in tokens {
+                if Task.isCancelled { break }
+                continuation.yield(.token(token))
+            }
+            continuation.finish()
+
+        case .burstThenStall(let burstSize, let stallDuration):
+            for (index, token) in tokens.enumerated() {
+                if Task.isCancelled { continuation.finish(); return }
+                if index == burstSize {
+                    try? await Task.sleep(for: stallDuration)
+                    if Task.isCancelled { continuation.finish(); return }
+                }
+                continuation.yield(.token(token))
+            }
+            continuation.finish()
+
+        case .networkError(let afterTokens):
+            for (index, token) in tokens.enumerated() {
+                if Task.isCancelled { continuation.finish(); return }
+                if index >= afterTokens { break }
+                continuation.yield(.token(token))
+            }
+            continuation.finish(
+                throwing: InferenceError.inferenceFailure("Chaos: injected network error")
+            )
+        }
+    }
+
+    // MARK: - State plumbing
+
+    private func withStateLock<T>(_ body: () -> T) -> T {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return body()
+    }
+
+    private func setGenerationTask(_ task: Task<Void, Never>) {
+        withStateLock { generationTask = task }
+    }
+
+    private func finishGeneration() {
+        withStateLock {
+            _isGenerating = false
+            generationTask = nil
+        }
+    }
+
+    private func cancelGeneration(markModelUnloaded: Bool) {
+        let task = withStateLock { () -> Task<Void, Never>? in
+            if markModelUnloaded { _isModelLoaded = false }
+            _isGenerating = false
+            let task = generationTask
+            generationTask = nil
+            return task
+        }
+        task?.cancel()
+    }
+}

--- a/Sources/BaseChatTestSupport/PerceivedLatencyBackend.swift
+++ b/Sources/BaseChatTestSupport/PerceivedLatencyBackend.swift
@@ -1,0 +1,222 @@
+import Foundation
+import BaseChatCore
+
+/// A test double that models the latency profile of a real streaming backend.
+///
+/// Unlike ``MockInferenceBackend`` — which yields tokens instantly and masks any
+/// UX regression tied to timing — `PerceivedLatencyBackend` reproduces the three
+/// latencies a user actually notices:
+///
+/// 1. **Cold start**: the one-time cost of loading the model on first use.
+/// 2. **Time to first token (TTFT)**: the pause between `generate()` being
+///    called and the first token arriving on the stream.
+/// 3. **Inter-token jitter**: the randomised gap between subsequent tokens,
+///    which drives UI batching and scroll stickiness.
+///
+/// Use this backend in tests that care about responsiveness, typing indicators,
+/// load-phase transitions, or streaming UI jank. For functional correctness
+/// tests without timing, prefer ``MockInferenceBackend``.
+///
+/// The backend honours cooperative cancellation: every sleep and every yield
+/// checks `Task.isCancelled` before proceeding, so `stopGeneration()` takes
+/// effect at the next scheduling point.
+public final class PerceivedLatencyBackend: InferenceBackend, @unchecked Sendable {
+    private let stateLock = NSLock()
+    private var _isModelLoaded = false
+    private var _isGenerating = false
+    private var _hasPaidColdStart = false
+    private var generationTask: Task<Void, Never>?
+
+    // Configuration — immutable after init to keep the double simple.
+    private let coldStartDelay: Duration
+    private let timeToFirstToken: Duration
+    private let interTokenJitter: ClosedRange<Duration>
+    private let _tokensToYield: [String]
+    private let rngSeed: UInt64
+
+    public var isModelLoaded: Bool {
+        withStateLock { _isModelLoaded }
+    }
+
+    public var isGenerating: Bool {
+        withStateLock { _isGenerating }
+    }
+
+    public let capabilities = BackendCapabilities(
+        supportedParameters: [.temperature, .topP, .repeatPenalty],
+        maxContextTokens: 4096,
+        requiresPromptTemplate: false,
+        supportsSystemPrompt: true
+    )
+
+    public var tokensToYield: [String] { _tokensToYield }
+
+    /// Creates a latency-modelling backend.
+    ///
+    /// - Parameters:
+    ///   - coldStartDelay: Paid exactly once on the first `loadModel()` call,
+    ///     mimicking on-disk model materialisation.
+    ///   - timeToFirstToken: Delay between `generate()` being invoked and the
+    ///     first `.token` event arriving on the stream.
+    ///   - interTokenJitter: Random range sampled between subsequent tokens.
+    ///     A degenerate range (lower == upper) produces constant-rate output.
+    ///   - tokensToYield: The token sequence the backend will produce.
+    ///   - rngSeed: Seed for the jitter RNG. Default `0xBADC_0FFEE_0DDF00D`
+    ///     keeps runs reproducible; pass a different value to vary jitter.
+    public init(
+        coldStartDelay: Duration = .milliseconds(500),
+        timeToFirstToken: Duration = .milliseconds(300),
+        interTokenJitter: ClosedRange<Duration> = .milliseconds(20)...(.milliseconds(80)),
+        tokensToYield: [String],
+        rngSeed: UInt64 = 0xBADC_0FFE_E0DD_F00D
+    ) {
+        self.coldStartDelay = coldStartDelay
+        self.timeToFirstToken = timeToFirstToken
+        self.interTokenJitter = interTokenJitter
+        self._tokensToYield = tokensToYield
+        self.rngSeed = rngSeed
+    }
+
+    deinit {
+        cancelGeneration(markModelUnloaded: false)
+    }
+
+    public func loadModel(from url: URL, contextSize: Int32) async throws {
+        let needsColdStart = withStateLock { !_hasPaidColdStart }
+        if needsColdStart {
+            try await Task.sleep(for: coldStartDelay)
+            withStateLock { _hasPaidColdStart = true }
+        }
+        withStateLock { _isModelLoaded = true }
+    }
+
+    public func generate(
+        prompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig
+    ) throws -> GenerationStream {
+        let loaded = withStateLock { _isModelLoaded }
+        guard loaded else {
+            throw InferenceError.inferenceFailure("No model loaded")
+        }
+
+        let tokens = _tokensToYield
+        let ttft = timeToFirstToken
+        let jitter = interTokenJitter
+        let seed = rngSeed
+
+        withStateLock { _isGenerating = true }
+
+        let stream = AsyncThrowingStream<GenerationEvent, Error> { [weak self] continuation in
+            let task = Task { [weak self] in
+                defer {
+                    self?.finishGeneration()
+                    continuation.finish()
+                }
+
+                // TTFT — the pause the user sees after hitting "send".
+                if Task.isCancelled { return }
+                try? await Task.sleep(for: ttft)
+
+                var rng = SplitMix64(seed: seed)
+                for (index, token) in tokens.enumerated() {
+                    if Task.isCancelled { return }
+                    if index > 0 {
+                        let delay = Self.sample(range: jitter, using: &rng)
+                        try? await Task.sleep(for: delay)
+                        if Task.isCancelled { return }
+                    }
+                    continuation.yield(.token(token))
+                }
+            }
+            continuation.onTermination = { @Sendable _ in
+                task.cancel()
+            }
+            self?.setGenerationTask(task)
+        }
+        return GenerationStream(stream)
+    }
+
+    public func stopGeneration() {
+        cancelGeneration(markModelUnloaded: false)
+    }
+
+    public func unloadModel() {
+        cancelGeneration(markModelUnloaded: true)
+    }
+
+    // MARK: - Private
+
+    private func withStateLock<T>(_ body: () -> T) -> T {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return body()
+    }
+
+    private func setGenerationTask(_ task: Task<Void, Never>) {
+        withStateLock { generationTask = task }
+    }
+
+    private func finishGeneration() {
+        withStateLock {
+            _isGenerating = false
+            generationTask = nil
+        }
+    }
+
+    private func cancelGeneration(markModelUnloaded: Bool) {
+        let task = withStateLock { () -> Task<Void, Never>? in
+            if markModelUnloaded { _isModelLoaded = false }
+            _isGenerating = false
+            let task = generationTask
+            generationTask = nil
+            return task
+        }
+        task?.cancel()
+    }
+
+    /// Uniformly samples a Duration from an inclusive range.
+    ///
+    /// Durations are sampled in nanoseconds because `Duration` does not expose
+    /// direct arithmetic with a scalar multiplier that would survive across
+    /// platforms. Nanoseconds give us sufficient resolution for UI-scale
+    /// jitter (microseconds to hundreds of milliseconds).
+    private static func sample(range: ClosedRange<Duration>, using rng: inout SplitMix64) -> Duration {
+        let lowerNs = nanoseconds(of: range.lowerBound)
+        let upperNs = nanoseconds(of: range.upperBound)
+        if upperNs <= lowerNs { return .nanoseconds(lowerNs) }
+        let span = UInt64(upperNs - lowerNs)
+        let offset = Int64(rng.next() % (span + 1))
+        return .nanoseconds(lowerNs + offset)
+    }
+
+    private static func nanoseconds(of duration: Duration) -> Int64 {
+        let comps = duration.components
+        // `seconds` is Int64, `attoseconds` is Int64 with 1e-18 resolution.
+        // 1 ns = 1e9 attoseconds.
+        return comps.seconds * 1_000_000_000 + comps.attoseconds / 1_000_000_000
+    }
+}
+
+// MARK: - Deterministic RNG
+
+/// Tiny splitmix64 PRNG used so jitter is reproducible across test runs.
+///
+/// We avoid `SystemRandomNumberGenerator` specifically because test timing
+/// assertions would otherwise be flaky under load.
+struct SplitMix64: RandomNumberGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        // A zero seed produces a zero stream with splitmix64; nudge it.
+        self.state = seed == 0 ? 0x9E37_79B9_7F4A_7C15 : seed
+    }
+
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z &>> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z &>> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z &>> 31)
+    }
+}

--- a/Tests/BaseChatBackendsTests/ChaosBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/ChaosBackendTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+import BaseChatCore
+import BaseChatTestSupport
+
+/// One assertion per failure mode on `ChaosBackend`. These tests lock in the
+/// contract each mode promises to deliver so UI-layer regressions have a
+/// stable fixture to point at.
+final class ChaosBackendTests: XCTestCase {
+
+    private let modelURL = URL(fileURLWithPath: "/tmp/fake-model")
+    private let allTokens = ["a", "b", "c", "d", "e"]
+
+    private func collect(_ backend: ChaosBackend) async -> (tokens: [String], error: Error?) {
+        let stream: GenerationStream
+        do {
+            stream = try backend.generate(prompt: "x", systemPrompt: nil, config: GenerationConfig())
+        } catch {
+            return ([], error)
+        }
+        var collected: [String] = []
+        do {
+            for try await event in stream.events {
+                if case .token(let t) = event { collected.append(t) }
+            }
+            return (collected, nil)
+        } catch {
+            return (collected, error)
+        }
+    }
+
+    func test_noneMode_yieldsEverything() async throws {
+        let backend = ChaosBackend(mode: .none, tokensToYield: allTokens)
+        try await backend.loadModel(from: modelURL, contextSize: 512)
+        let (tokens, error) = await collect(backend)
+        XCTAssertNil(error)
+        XCTAssertEqual(tokens, allTokens)
+    }
+
+    func test_dropMidStream_truncatesWithoutThrowing() async throws {
+        let backend = ChaosBackend(mode: .dropMidStream(afterTokens: 2), tokensToYield: allTokens)
+        try await backend.loadModel(from: modelURL, contextSize: 512)
+        let (tokens, error) = await collect(backend)
+        XCTAssertNil(error, "dropMidStream must silently finish, not throw")
+        XCTAssertEqual(tokens, ["a", "b"])
+    }
+
+    func test_slowFirstToken_delaysBeforeFirstEvent() async throws {
+        let delay: Duration = .milliseconds(50)
+        let backend = ChaosBackend(mode: .slowFirstToken(delay: delay), tokensToYield: allTokens)
+        try await backend.loadModel(from: modelURL, contextSize: 512)
+
+        let clock = ContinuousClock()
+        let start = clock.now
+        let (tokens, error) = await collect(backend)
+        let elapsed = start.duration(to: clock.now)
+
+        XCTAssertNil(error)
+        XCTAssertEqual(tokens, allTokens)
+        XCTAssertGreaterThanOrEqual(
+            elapsed, delay,
+            "slowFirstToken must wait the configured delay before streaming"
+        )
+    }
+
+    func test_burstThenStall_pausesMidStream() async throws {
+        let stall: Duration = .milliseconds(50)
+        let backend = ChaosBackend(
+            mode: .burstThenStall(burstSize: 2, stallDuration: stall),
+            tokensToYield: allTokens
+        )
+        try await backend.loadModel(from: modelURL, contextSize: 512)
+
+        let clock = ContinuousClock()
+        let start = clock.now
+        let (tokens, error) = await collect(backend)
+        let elapsed = start.duration(to: clock.now)
+
+        XCTAssertNil(error)
+        XCTAssertEqual(tokens, allTokens)
+        XCTAssertGreaterThanOrEqual(
+            elapsed, stall,
+            "burstThenStall must include at least one stall period"
+        )
+    }
+
+    func test_networkError_throwsAfterPartialStream() async throws {
+        let backend = ChaosBackend(mode: .networkError(afterTokens: 3), tokensToYield: allTokens)
+        try await backend.loadModel(from: modelURL, contextSize: 512)
+        let (tokens, error) = await collect(backend)
+        XCTAssertEqual(tokens, ["a", "b", "c"])
+        XCTAssertNotNil(error, "networkError must surface an error on the stream")
+        guard case .inferenceFailure = error as? InferenceError else {
+            XCTFail("Expected InferenceError.inferenceFailure, got \(String(describing: error))")
+            return
+        }
+    }
+}

--- a/Tests/BaseChatBackendsTests/PerceivedLatencyBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/PerceivedLatencyBackendTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+import BaseChatCore
+import BaseChatTestSupport
+
+/// Real-clock tests for `PerceivedLatencyBackend`.
+///
+/// Delays are kept small (≤ 100 ms) so these tests stay CI-friendly while
+/// still exercising the timing paths. Tolerances bias towards the lower bound
+/// to catch regressions that would accidentally deliver tokens too fast;
+/// upper bounds are generous to survive scheduler jitter on busy CI runners.
+final class PerceivedLatencyBackendTests: XCTestCase {
+
+    private let modelURL = URL(fileURLWithPath: "/tmp/fake-model")
+
+    func test_timeToFirstToken_respectsConfiguredDelay() async throws {
+        let ttft: Duration = .milliseconds(50)
+        let backend = PerceivedLatencyBackend(
+            coldStartDelay: .milliseconds(0),
+            timeToFirstToken: ttft,
+            interTokenJitter: .milliseconds(1)...(.milliseconds(1)),
+            tokensToYield: ["a", "b", "c"]
+        )
+        try await backend.loadModel(from: modelURL, contextSize: 512)
+
+        let clock = ContinuousClock()
+        let start = clock.now
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: GenerationConfig())
+        var firstTokenAt: ContinuousClock.Instant?
+        for try await event in stream.events {
+            if case .token = event {
+                firstTokenAt = clock.now
+                break
+            }
+        }
+        let elapsed = start.duration(to: try XCTUnwrap(firstTokenAt))
+        XCTAssertGreaterThanOrEqual(
+            elapsed, ttft,
+            "First token arrived before configured TTFT (\(elapsed) < \(ttft))"
+        )
+        // Upper bound: generous but still a regression if we blow past it.
+        XCTAssertLessThan(elapsed, ttft + .milliseconds(500))
+    }
+
+    func test_coldStartDelay_paidOnFirstLoadOnly() async throws {
+        let coldStart: Duration = .milliseconds(50)
+        let backend = PerceivedLatencyBackend(
+            coldStartDelay: coldStart,
+            timeToFirstToken: .milliseconds(0),
+            interTokenJitter: .milliseconds(0)...(.milliseconds(0)),
+            tokensToYield: ["hi"]
+        )
+
+        let clock = ContinuousClock()
+        let firstLoadStart = clock.now
+        try await backend.loadModel(from: modelURL, contextSize: 512)
+        let firstLoadElapsed = firstLoadStart.duration(to: clock.now)
+        XCTAssertGreaterThanOrEqual(firstLoadElapsed, coldStart)
+
+        // Second load should be fast — cold start already paid.
+        let secondLoadStart = clock.now
+        try await backend.loadModel(from: modelURL, contextSize: 512)
+        let secondLoadElapsed = secondLoadStart.duration(to: clock.now)
+        XCTAssertLessThan(
+            secondLoadElapsed, coldStart,
+            "Cold start should only be paid on the first loadModel call"
+        )
+    }
+
+    func test_yieldsAllTokens_inOrder() async throws {
+        let backend = PerceivedLatencyBackend(
+            coldStartDelay: .milliseconds(0),
+            timeToFirstToken: .milliseconds(5),
+            interTokenJitter: .milliseconds(1)...(.milliseconds(3)),
+            tokensToYield: ["Hello", ", ", "world", "!"]
+        )
+        try await backend.loadModel(from: modelURL, contextSize: 512)
+        let stream = try backend.generate(prompt: "x", systemPrompt: nil, config: GenerationConfig())
+
+        var collected: [String] = []
+        for try await event in stream.events {
+            if case .token(let t) = event { collected.append(t) }
+        }
+        XCTAssertEqual(collected, ["Hello", ", ", "world", "!"])
+    }
+
+    func test_cancellationStops_generation() async throws {
+        let backend = PerceivedLatencyBackend(
+            coldStartDelay: .milliseconds(0),
+            timeToFirstToken: .milliseconds(5),
+            interTokenJitter: .milliseconds(50)...(.milliseconds(50)),
+            tokensToYield: Array(repeating: "x", count: 50)
+        )
+        try await backend.loadModel(from: modelURL, contextSize: 512)
+
+        let stream = try backend.generate(prompt: "x", systemPrompt: nil, config: GenerationConfig())
+        var count = 0
+        for try await event in stream.events {
+            if case .token = event {
+                count += 1
+                if count == 2 {
+                    backend.stopGeneration()
+                }
+            }
+        }
+        XCTAssertLessThan(count, 50, "stopGeneration() should truncate the stream")
+        XCTAssertFalse(backend.isGenerating)
+    }
+}

--- a/Tests/BaseChatUITests/PerceivedLatencyDemoTests.swift
+++ b/Tests/BaseChatUITests/PerceivedLatencyDemoTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+import SwiftData
+@testable import BaseChatUI
+@testable import BaseChatCore
+import BaseChatTestSupport
+
+/// Demonstrates running the full `ChatViewModel.sendMessage()` flow through
+/// a backend that models realistic streaming latency.
+///
+/// The intent is not to retrofit every existing test — it's to show that the
+/// happy-path assistant content is preserved even when tokens arrive with a
+/// TTFT pause and inter-token jitter. If a future UI change breaks streaming
+/// assembly under realistic timing (e.g. batching the wrong slice), this
+/// test will catch it while other `MockInferenceBackend`-based tests stay
+/// green.
+@MainActor
+final class PerceivedLatencyDemoTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+    private var vm: ChatViewModel!
+    private var sessionManager: SessionManagerViewModel!
+    private var backend: PerceivedLatencyBackend!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        container = try makeInMemoryContainer()
+        context = container.mainContext
+
+        backend = PerceivedLatencyBackend(
+            coldStartDelay: .milliseconds(0),
+            timeToFirstToken: .milliseconds(100),
+            interTokenJitter: .milliseconds(10)...(.milliseconds(30)),
+            tokensToYield: ["Hello", ", ", "world", "!"]
+        )
+        // InferenceService(backend:name:) treats the supplied backend as
+        // already loaded, so we must preload the backend too or generate()
+        // will throw its own "No model loaded" guard.
+        try await backend.loadModel(from: URL(fileURLWithPath: "/tmp/fake"), contextSize: 512)
+
+        let service = InferenceService(backend: backend, name: "PerceivedLatency")
+        vm = ChatViewModel(inferenceService: service)
+        vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
+
+        sessionManager = SessionManagerViewModel()
+        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
+    }
+
+    override func tearDown() async throws {
+        vm?.stopGeneration()
+        vm?.inferenceService.unloadModel()
+        vm = nil
+        sessionManager = nil
+        backend = nil
+        context = nil
+        container = nil
+        try await super.tearDown()
+    }
+
+    func test_sendMessage_assemblesFullResponse_withRealisticLatency() async throws {
+        let session = try sessionManager.createSession(title: "Demo")
+        sessionManager.activeSession = session
+        vm.switchToSession(session)
+
+        vm.inputText = "Greet me"
+        await vm.sendMessage()
+
+        XCTAssertEqual(vm.messages.count, 2)
+        XCTAssertEqual(vm.messages[0].role, .user)
+        XCTAssertEqual(vm.messages[0].content, "Greet me")
+        XCTAssertEqual(vm.messages[1].role, .assistant)
+        XCTAssertEqual(
+            vm.messages[1].content, "Hello, world!",
+            "Assistant content should equal the concatenated token stream even under jittered delivery"
+        )
+        XCTAssertFalse(vm.isGenerating)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `PerceivedLatencyBackend` — models cold-start, time-to-first-token, and seeded inter-token jitter so tests can catch TTFT regressions and UI jank hidden by the instant-yielding `MockInferenceBackend`.
- Adds `ChaosBackend` — deterministically injects five failure modes (`.none`, `.dropMidStream`, `.slowFirstToken`, `.burstThenStall`, `.networkError`) to pin the chat pipeline's behaviour under realistic streaming failures.
- Adds unit tests for both backends in `BaseChatBackendsTests` plus one demo integration test in `BaseChatUITests` that runs a full `ChatViewModel.sendMessage` flow through `PerceivedLatencyBackend` (TTFT 100 ms, jitter 10–30 ms) and asserts the assembled assistant content.

Both backends live in `BaseChatTestSupport` and take no dependency on `BaseChatBackends`. Existing tests are untouched — the scope is infrastructure plus one demo.

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits`
- [x] `swift test --filter BaseChatUITests --disable-default-traits`
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits`
- [x] Sabotage check: temporarily broke each new assertion and confirmed failure, then reverted