### PR TITLE
feat: add VoiceOver contract and a11y tests for chat UI

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a5e57cdcaafddaa4c1ea15543f8a0abd1f24aa357b532d41f61ab43435cf85b1",
+  "originHash" : "9b3003493e53504564187264af527724bbc09f7870985e3836747d2324f7ab98",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -151,6 +151,15 @@
       "state" : {
         "revision" : "b38443e44d93eca770f2eb68e2a4d0fa100f9aa2",
         "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "viewinspector",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nalexn/ViewInspector",
+      "state" : {
+        "revision" : "e9a06346499a3a889165647e3f23f8a7b2609a1c",
+        "version" : "0.10.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -32,6 +32,9 @@ let package = Package(
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.2.0"),
         .package(url: "https://github.com/mattt/llama.swift", from: "2.8672.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.0"),
+        // Test-only: SwiftUI view-tree inspection for accessibility contract tests.
+        // Must never appear in any production target.
+        .package(url: "https://github.com/nalexn/ViewInspector", from: "0.10.3"),
     ],
     targets: [
         // Inference: models, protocols, services — no SwiftData, no heavy ML deps
@@ -112,7 +115,13 @@ let package = Package(
         ),
         .testTarget(
             name: "BaseChatUITests",
-            dependencies: ["BaseChatUI", "BaseChatCore", "BaseChatInference", "BaseChatTestSupport"]
+            dependencies: [
+                "BaseChatUI",
+                "BaseChatCore",
+                "BaseChatInference",
+                "BaseChatTestSupport",
+                .product(name: "ViewInspector", package: "ViewInspector"),
+            ]
         ),
         .testTarget(
             name: "BaseChatE2ETests",

--- a/Sources/BaseChatUI/Views/Chat/ChatInputBar.swift
+++ b/Sources/BaseChatUI/Views/Chat/ChatInputBar.swift
@@ -75,31 +75,12 @@ public struct ChatInputBar: View {
 
     @ViewBuilder
     private var sendOrStopButton: some View {
-        if viewModel.isGenerating {
-            Button {
-                viewModel.stopGeneration()
-            } label: {
-                Image(systemName: "stop.circle.fill")
-                    .font(.title2)
-                    .foregroundStyle(.red)
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Stop generation")
-            .help("Stop generation")
-        } else {
-            Button {
-                sendMessage()
-            } label: {
-                Image(systemName: "arrow.up.circle.fill")
-                    .font(.title2)
-                    .foregroundStyle(canSend ? Color.accentColor : Color.gray)
-            }
-            .buttonStyle(.plain)
-            .disabled(!canSend)
-            .accessibilityLabel("Send message")
-            .help("Send message (Cmd+Return)")
-            .keyboardShortcut(.return, modifiers: .command)
-        }
+        SendStopButton(
+            isGenerating: viewModel.isGenerating,
+            canSend: canSend,
+            onSend: sendMessage,
+            onStop: { viewModel.stopGeneration() }
+        )
     }
 
     // MARK: - Quick Action Pills
@@ -165,6 +146,60 @@ public struct ChatInputBar: View {
         viewModel.inputText = text
         Task {
             await viewModel.sendMessage()
+        }
+    }
+}
+
+// MARK: - Send/Stop Button
+
+/// The primary send-or-stop button rendered at the trailing edge of the chat
+/// input bar. Extracted as a standalone view so its accessibility contract can
+/// be inspected in unit tests without mounting a full `ChatViewModel`.
+struct SendStopButton: View {
+
+    /// Accessibility label used while the assistant is generating a response.
+    static let stopLabel = "Stop generation"
+    /// Accessibility label used when the button will send the composed message.
+    static let sendLabel = "Send message"
+
+    let isGenerating: Bool
+    let canSend: Bool
+    let onSend: () -> Void
+    let onStop: () -> Void
+
+    init(
+        isGenerating: Bool,
+        canSend: Bool,
+        onSend: @escaping () -> Void,
+        onStop: @escaping () -> Void
+    ) {
+        self.isGenerating = isGenerating
+        self.canSend = canSend
+        self.onSend = onSend
+        self.onStop = onStop
+    }
+
+    var body: some View {
+        if isGenerating {
+            Button(action: onStop) {
+                Image(systemName: "stop.circle.fill")
+                    .font(.title2)
+                    .foregroundStyle(.red)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(Self.stopLabel)
+            .help(Self.stopLabel)
+        } else {
+            Button(action: onSend) {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.title2)
+                    .foregroundStyle(canSend ? Color.accentColor : Color.gray)
+            }
+            .buttonStyle(.plain)
+            .disabled(!canSend)
+            .accessibilityLabel(Self.sendLabel)
+            .help("\(Self.sendLabel) (Cmd+Return)")
+            .keyboardShortcut(.return, modifiers: .command)
         }
     }
 }

--- a/Sources/BaseChatUI/Views/Chat/ChatView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ChatView.swift
@@ -455,7 +455,10 @@ struct ErrorBannerView<Recovery: View>: View {
         .background(.red.opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
         .padding(.horizontal)
         .padding(.top, 8)
-        .accessibilityElement(children: .contain)
+        // Use .combine so that the container itself becomes the VoiceOver element.
+        // With .contain the label/trait modifiers below would be silently ignored —
+        // .contain exposes children individually and discards container-level overrides.
+        .accessibilityElement(children: .combine)
         .accessibilityLabel(Self.accessibilityLabel(for: error))
         .accessibilityAddTraits(.isHeader)
     }

--- a/Sources/BaseChatUI/Views/Chat/ChatView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ChatView.swift
@@ -108,29 +108,13 @@ public struct ChatView: View {
     @ViewBuilder
     private var errorBanner: some View {
         if let error = viewModel.activeError {
-            HStack(spacing: 8) {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .foregroundStyle(.yellow)
-
-                Text(error.message)
-                    .font(.callout)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                recoveryButton(for: error.recovery)
-
-                Button {
-                    viewModel.activeError = nil
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .foregroundStyle(.secondary)
+            ErrorBannerView(
+                error: error,
+                onDismiss: { viewModel.activeError = nil },
+                recoveryAction: {
+                    recoveryButton(for: error.recovery)
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Dismiss error")
-            }
-            .padding(12)
-            .background(.red.opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
-            .padding(.horizontal)
-            .padding(.top, 8)
+            )
         }
     }
 
@@ -416,6 +400,64 @@ public struct ChatView: View {
         withAnimation(.easeOut(duration: 0.15)) {
             proxy.scrollTo("chatBottom", anchor: .bottom)
         }
+    }
+}
+
+// MARK: - Error Banner View
+
+/// Standalone chat error banner.
+///
+/// Extracted from ``ChatView`` so that its accessibility contract
+/// ("Error: <message>" header label) can be inspected directly in unit tests
+/// without mounting a full `ChatViewModel` environment.
+struct ErrorBannerView<Recovery: View>: View {
+
+    /// Builds the VoiceOver label for an error banner. Kept as a static helper
+    /// so tests can assert on the exact contract.
+    static func accessibilityLabel(for error: ChatError) -> String {
+        "Error: \(error.message)"
+    }
+
+    let error: ChatError
+    let onDismiss: () -> Void
+    let recoveryAction: () -> Recovery
+
+    init(
+        error: ChatError,
+        onDismiss: @escaping () -> Void,
+        @ViewBuilder recoveryAction: @escaping () -> Recovery
+    ) {
+        self.error = error
+        self.onDismiss = onDismiss
+        self.recoveryAction = recoveryAction
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.yellow)
+                .accessibilityHidden(true)
+
+            Text(error.message)
+                .font(.callout)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            recoveryAction()
+
+            Button(action: onDismiss) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Dismiss error")
+        }
+        .padding(12)
+        .background(.red.opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
+        .padding(.horizontal)
+        .padding(.top, 8)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(Self.accessibilityLabel(for: error))
+        .accessibilityAddTraits(.isHeader)
     }
 }
 

--- a/Sources/BaseChatUI/Views/Chat/ContextIndicatorView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ContextIndicatorView.swift
@@ -54,7 +54,8 @@ public struct ContextIndicatorView: View {
         }
         .accessibilityElement(children: .ignore)
         .help("Context: \(usedTokens) / \(maxTokens) tokens (\(percentage)%)")
-        .accessibilityLabel("Context usage \(percentage) percent, \(usedTokens) of \(maxTokens) tokens")
+        .accessibilityLabel("Context used: \(usedTokens) of \(maxTokens) tokens")
+        .accessibilityValue("\(percentage) percent")
         .accessibilityHint("Tap for context details")
         .onTapGesture {
             isPopoverPresented = true

--- a/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
@@ -32,7 +32,7 @@ public struct MessageBubbleView: View {
             bubbleContent
                 .frame(maxWidth: 700, alignment: alignment)
                 .accessibilityElement(children: .combine)
-                .accessibilityLabel("\(message.role.rawValue): \(message.content)")
+                .accessibilityLabel(Self.accessibilityLabel(for: message))
 
             if message.role == .assistant { Spacer(minLength: spacerMinLength) }
         }
@@ -162,6 +162,22 @@ public struct MessageBubbleView: View {
     /// On compact (iPhone), bubbles take ~90% width; on regular (iPad/Mac), ~80%.
     private var spacerMinLength: CGFloat {
         sizeClass == .compact ? 20 : 60
+    }
+
+    // MARK: - Accessibility Contract
+
+    /// Builds the VoiceOver label for a chat message bubble.
+    ///
+    /// Format: `"<Role> said: <content>"` (e.g. `"Assistant said: Hello"`).
+    /// Exposed so the accessibility contract can be asserted by tests without
+    /// duplicating the string-building logic.
+    public static func accessibilityLabel(for message: ChatMessageRecord) -> String {
+        let roleName: String = switch message.role {
+        case .user: "User"
+        case .assistant: "Assistant"
+        case .system: "System"
+        }
+        return "\(roleName) said: \(message.content)"
     }
 }
 

--- a/Tests/BaseChatE2ETests/UserJourneyE2ETests.swift
+++ b/Tests/BaseChatE2ETests/UserJourneyE2ETests.swift
@@ -1,0 +1,328 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import BaseChatUI
+@testable import BaseChatCore
+import BaseChatTestSupport
+
+/// Day-one user journey E2E — exercises a full first-session experience end to
+/// end in one test so that regressions in the HAND-OFFS between discovery,
+/// loading, sending, cancellation, regeneration, model switching, and session
+/// persistence are caught. The one-feature-per-test coverage already in
+/// `BaseChatE2ETests` validates each step in isolation; this test exists
+/// specifically to catch bugs that only surface when these features run
+/// back-to-back against the same ChatViewModel instance.
+///
+/// Uses `SlowMockBackend` and in-memory SwiftData so that step 5 can actually
+/// observe mid-stream cancellation (SlowMockBackend yields with a per-token
+/// delay, so `stopGeneration()` has real work to cancel). No hardware or real
+/// model files are required.
+@Suite("User Journey E2E")
+@MainActor
+final class UserJourneyE2ETests {
+
+    private let container: ModelContainer
+    private let context: ModelContext
+    private let backend: SlowMockBackend
+    private let vm: ChatViewModel
+    private let sessionManager: SessionManagerViewModel
+    private let modelsDir: URL
+    private let persistence: SwiftDataPersistenceProvider
+
+    init() throws {
+        modelsDir = try makeE2ETempDir()
+
+        container = try ModelContainerFactory.makeInMemoryContainer()
+        context = container.mainContext
+
+        backend = SlowMockBackend()
+        backend.isModelLoaded = false
+        // 50ms matches the convention in CancellationTests — tight enough to
+        // keep the test fast, loose enough to stay stable on loaded CI runners.
+        backend.delayPerToken = .milliseconds(50)
+
+        // Register a factory that always returns the same backend so the
+        // model switch in step 7 routes through the same instance — just
+        // re-loads it under a different model descriptor.
+        let backendRef = backend
+        let service = InferenceService()
+        service.registerBackendFactory { _ in backendRef }
+
+        persistence = SwiftDataPersistenceProvider(modelContext: context)
+        let storage = ModelStorageService(baseDirectory: modelsDir)
+        vm = ChatViewModel(inferenceService: service, modelStorage: storage)
+        vm.configure(persistence: persistence)
+
+        sessionManager = SessionManagerViewModel()
+        sessionManager.configure(persistence: persistence)
+    }
+
+    deinit {
+        cleanupE2ETempDir(modelsDir)
+    }
+
+    // MARK: - Helpers
+
+    @discardableResult
+    private func writeGGUF(named name: String) throws -> URL {
+        let url = modelsDir.appendingPathComponent(name)
+        var data = Data(ggufMagic)
+        data.append(Data(repeating: 0xFF, count: 1_100_000))
+        try data.write(to: url)
+        return url
+    }
+
+    /// Waits until the message at `atIndex` exists and has non-empty content,
+    /// or fails after `timeout`. Used to synchronise with streaming tokens
+    /// when calling `stopGeneration()` mid-stream.
+    private func awaitFirstToken(atIndex index: Int, timeout: Duration = .seconds(3)) async {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if vm.messages.count > index, !vm.messages[index].content.isEmpty {
+                return
+            }
+            await Task.yield()
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        Issue.record("Timed out waiting for first token at index \(index)")
+    }
+
+    // MARK: - Day-one journey
+
+    @Test("Day-one journey: empty state -> discover -> load -> send -> cancel -> regenerate -> switch model -> persist")
+    func test_dayOneUserJourney_firstChatThroughModelSwitch() async throws {
+        // 1. Empty state — freshly constructed VM has no models and nothing selected.
+        #expect(vm.availableModels.isEmpty)
+        #expect(vm.selectedModel == nil)
+        #expect(!vm.isModelLoaded)
+
+        // 2. Discovery — write a GGUF to the models directory and refresh.
+        try writeGGUF(named: "journey-model-a.gguf")
+        vm.refreshModels()
+        #expect(vm.availableModels.count == 1)
+        let modelA = try #require(vm.availableModels.first)
+        #expect(modelA.modelType == .gguf)
+
+        // 3. Select + load — pick modelA and load the (mock) backend.
+        vm.selectedModel = modelA
+        await vm.loadSelectedModel()
+        #expect(vm.isModelLoaded)
+        #expect(vm.errorMessage == nil)
+
+        // 4. First session + first message — create a session, activate it,
+        //    and send a message. User + assistant messages must persist.
+        let session = try sessionManager.createSession(title: "Day One")
+        sessionManager.activeSession = session
+        vm.switchToSession(session)
+
+        // switchToSession resets selectedModel to match the session's
+        // selectedModelID, which is still nil for a brand-new session.
+        // Re-apply modelA and persist so the session records it.
+        vm.selectedModel = modelA
+        try vm.saveSettingsToSession()
+
+        backend.tokensToYield = ["Hi", " there"]
+        vm.inputText = "Hello"
+        await vm.sendMessage()
+
+        #expect(vm.messages.count == 2)
+        #expect(vm.messages[0].role == .user)
+        #expect(vm.messages[0].content == "Hello")
+        #expect(vm.messages[1].role == .assistant)
+        #expect(vm.messages[1].content == "Hi there")
+
+        // Cross-check: the messages must also exist in SwiftData, not just in
+        // the in-memory array. If persistence silently broke, this fetch would
+        // return zero rows even though vm.messages still holds them.
+        let sessionID = session.id
+        var descriptor = FetchDescriptor<ChatMessage>(
+            predicate: #Predicate { $0.sessionID == sessionID },
+            sortBy: [SortDescriptor(\.timestamp)]
+        )
+        var dbMessages = try context.fetch(descriptor)
+        #expect(dbMessages.count == 2)
+        #expect(dbMessages[0].content == "Hello")
+        #expect(dbMessages[1].content == "Hi there")
+
+        // 5. Mid-stream cancel — configure a long, slow token stream, start
+        //    the send in a background Task, wait for the first token to land,
+        //    then call stopGeneration(). With SlowMockBackend's per-token
+        //    delay we can reliably cancel mid-stream. Tokens are unique so
+        //    the repetition detector never fires and truncates content on
+        //    our behalf.
+        let longStream = (0..<40).map { "tok\($0) " }
+        backend.tokensToYield = longStream
+        vm.inputText = "Tell me a long story"
+        let sendTask = Task { await vm.sendMessage() }
+        // Wait until the new assistant message (index 3) has received at
+        // least one token, then cancel mid-stream.
+        await awaitFirstToken(atIndex: 3)
+        vm.stopGeneration()
+        await sendTask.value
+
+        #expect(!vm.isGenerating)
+        #expect(vm.messages.count == 4, "Second user + assistant pair must exist")
+        #expect(vm.messages[2].role == .user)
+        #expect(vm.messages[2].content == "Tell me a long story")
+        #expect(vm.messages[3].role == .assistant)
+        let cancelledAssistant = vm.messages[3]
+        // Partial-or-complete invariant: content must be non-empty (the first
+        // token landed before stop), and must not be the full 40-token output.
+        #expect(!cancelledAssistant.content.isEmpty, "Partial content must be preserved")
+        #expect(cancelledAssistant.content != longStream.joined(), "Generation must have been cancelled before completion")
+
+        // Persistence contract check: stopGeneration() promises to save the
+        // partial content under the cancelled assistant's ID. Fetch by ID and
+        // verify at least one row exists whose content matches the in-memory
+        // partial. This is the REAL contract the test has to catch regressions
+        // against. The "exactly one row" half of the contract is currently
+        // broken by #260, so it's wrapped separately below.
+        let cancelID = cancelledAssistant.id
+        let expectedPartial = cancelledAssistant.content
+        let cancelDescriptor = FetchDescriptor<ChatMessage>(
+            predicate: #Predicate { $0.id == cancelID }
+        )
+        let cancelRows = try context.fetch(cancelDescriptor)
+        #expect(!cancelRows.isEmpty, "stopGeneration must persist the partial assistant row")
+        #expect(
+            cancelRows.contains { $0.content == expectedPartial },
+            "Persisted partial content must match the in-memory partial"
+        )
+
+        // Tracked by #260 — stopGeneration() and the tail of generateIntoMessage()
+        // both call saveMessage() on the same assistant record, and
+        // SwiftDataPersistenceProvider.insertMessage is not an upsert, so two
+        // rows with the same id get written. When #260 is fixed, the assertion
+        // below will start passing, withKnownIssue will fire ("expected a known
+        // failure but didn't get one"), and this wrapper must be removed.
+        withKnownIssue("Bug #260: duplicate SwiftData rows from concurrent save paths") {
+            #expect(cancelRows.count == 1, "stopGeneration should leave exactly one persisted row")
+        }
+
+        // 6. Regenerate — replace the last assistant message with a fresh one.
+        backend.tokensToYield = ["Regenerated", " reply"]
+        await vm.regenerateLastResponse()
+
+        #expect(vm.messages.count == 4, "Regenerate replaces rather than appends")
+        #expect(vm.messages[3].role == .assistant)
+        #expect(vm.messages[3].content == "Regenerated reply")
+        #expect(vm.messages[3].id != cancelledAssistant.id, "A new assistant record must replace the cancelled one")
+
+        // 7. Switch model — discover a second GGUF, select it, load it.
+        //    Existing messages must remain in the UI.
+        try writeGGUF(named: "journey-model-b.gguf")
+        vm.refreshModels()
+        #expect(vm.availableModels.count == 2)
+        let modelB = try #require(vm.availableModels.first { $0.fileName == "journey-model-b.gguf" })
+        #expect(modelB.id != modelA.id)
+
+        vm.selectedModel = modelB
+        try vm.saveSettingsToSession()
+        await vm.loadSelectedModel()
+        #expect(vm.isModelLoaded)
+        #expect(vm.messages.count == 4, "Switching models must not drop conversation history")
+
+        // 8. Send against new model — third turn lands in the same session.
+        backend.tokensToYield = ["Model", " B", " reply"]
+        vm.inputText = "Follow-up on model B"
+        await vm.sendMessage()
+
+        #expect(vm.messages.count == 6)
+        #expect(vm.messages[4].role == .user)
+        #expect(vm.messages[4].content == "Follow-up on model B")
+        #expect(vm.messages[5].role == .assistant)
+        #expect(vm.messages[5].content == "Model B reply")
+
+        // In-memory ordering and content assertions — these verify the real
+        // "full HISTORY is intact after model switch" contract without being
+        // affected by #260's orphan row. The VM tracks the authoritative
+        // sequence the user actually sees.
+        #expect(
+            vm.messages.map(\.role) == [.user, .assistant, .user, .assistant, .user, .assistant],
+            "VM message roles must alternate user/assistant in send order"
+        )
+        #expect(vm.messages[0].content == "Hello", "First user turn must survive")
+        #expect(
+            vm.messages[3].content == "Regenerated reply",
+            "Regenerated assistant reply must survive the model switch"
+        )
+        #expect(vm.messages[5].content == "Model B reply", "Last turn must land under modelB")
+
+        // DB-side history check: count is wrapped in withKnownIssue because
+        // #260 leaves an orphan row from the step 5 cancel that persists all
+        // the way through. When #260 is fixed this will start passing and
+        // the wrapper must be removed. The "correct" rows still exist in
+        // the DB regardless — we verify that by filtering out the orphan
+        // below.
+        descriptor = FetchDescriptor<ChatMessage>(
+            predicate: #Predicate { $0.sessionID == sessionID },
+            sortBy: [SortDescriptor(\.timestamp)]
+        )
+        dbMessages = try context.fetch(descriptor)
+        withKnownIssue("Bug #260: orphan row from step 5 cancel inflates persisted count") {
+            #expect(dbMessages.count == 6, "Full conversation history must be persisted")
+        }
+        // Content anchors that must exist somewhere in the persisted set —
+        // these are robust against #260's extra row and prove the real
+        // turns landed on disk.
+        #expect(
+            dbMessages.contains { $0.content == "Hello" && $0.role == .user },
+            "First user turn must be persisted"
+        )
+        #expect(
+            dbMessages.contains { $0.content == "Regenerated reply" && $0.role == .assistant },
+            "Regenerated assistant reply must survive the model switch on disk"
+        )
+        #expect(
+            dbMessages.contains { $0.content == "Follow-up on model B" && $0.role == .user },
+            "Follow-up user turn must be persisted"
+        )
+        #expect(
+            dbMessages.contains { $0.content == "Model B reply" && $0.role == .assistant },
+            "Last assistant turn must land under modelB on disk"
+        )
+
+        // 9. Session persistence — reload sessions, grab the fresh record,
+        //    and verify selectedModelID restored correctly to modelB.
+        sessionManager.loadSessions()
+        let freshSession = try #require(sessionManager.sessions.first { $0.title == "Day One" })
+        #expect(freshSession.selectedModelID == modelB.id)
+
+        // Switching back through the fresh session record must re-resolve
+        // modelB from availableModels (it's still on disk) and reload messages.
+        vm.switchToSession(freshSession)
+        #expect(vm.selectedModel?.id == modelB.id)
+        // All expected content anchors must round-trip through the reload.
+        #expect(
+            vm.messages.contains { $0.content == "Hello" && $0.role == .user },
+            "Reloaded session must restore the first user turn"
+        )
+        #expect(
+            vm.messages.contains { $0.content == "Regenerated reply" && $0.role == .assistant },
+            "Reloaded session must restore the regenerated reply"
+        )
+        #expect(
+            vm.messages.contains { $0.content == "Model B reply" && $0.role == .assistant },
+            "Reloaded session must restore the model-B reply"
+        )
+        // Count is inflated by #260's orphan row — wrap separately.
+        withKnownIssue("Bug #260: orphan row from step 5 cancel inflates reloaded message count") {
+            #expect(vm.messages.count == 6, "Reloaded session must restore exactly all turns")
+        }
+
+        // Independent verification: bypass sessionManager entirely and read
+        // the session record straight from SwiftData. This proves that
+        // saveSettingsToSession actually reached the store in step 7 — not
+        // just the in-memory sessions array that loadSessions() repopulates.
+        let storedSessionID = session.id
+        let sessionDescriptor = FetchDescriptor<ChatSession>(
+            predicate: #Predicate { $0.id == storedSessionID }
+        )
+        let storedSessions = try context.fetch(sessionDescriptor)
+        #expect(storedSessions.count == 1)
+        #expect(
+            storedSessions.first?.selectedModelID == modelB.id,
+            "saveSettingsToSession must persist selectedModelID to the SwiftData store"
+        )
+    }
+}

--- a/Tests/BaseChatUITests/ChatA11yContractTests.swift
+++ b/Tests/BaseChatUITests/ChatA11yContractTests.swift
@@ -1,0 +1,273 @@
+import XCTest
+import SwiftUI
+import ViewInspector
+@testable import BaseChatCore
+@testable import BaseChatUI
+
+/// Accessibility contract tests for chat UI surfaces.
+///
+/// The existing snapshot suite under `BaseChatSnapshotTests` captures the view
+/// hierarchy via `Swift.dump()`, which strips accessibility labels. This suite
+/// fills that gap using ViewInspector to walk the SwiftUI tree and assert on
+/// the VoiceOver-visible labels and hints that real assistive technology users
+/// actually encounter.
+///
+/// When adding assertions here, prefer pinning to the exact contract string
+/// (via `expectedMessageBubbleLabel`) so accidental copy-edits to user-facing
+/// strings break the test instead of silently degrading VoiceOver output.
+@MainActor
+final class ChatA11yContractTests: XCTestCase {
+
+    // MARK: - Contract helpers
+
+    /// The accessibility label format the `MessageBubbleView` contract promises
+    /// to VoiceOver users. Kept in the test file (not imported from source) so
+    /// a drive-by change to the source helper is caught by a failing assertion
+    /// rather than quietly updating the "expected" side of the test.
+    private func expectedMessageBubbleLabel(
+        role: MessageRole,
+        content: String
+    ) -> String {
+        let roleName: String
+        switch role {
+        case .user: roleName = "User"
+        case .assistant: roleName = "Assistant"
+        case .system: roleName = "System"
+        }
+        return "\(roleName) said: \(content)"
+    }
+
+    private let sessionID = UUID()
+
+    // MARK: - MessageBubbleView
+
+    func test_messageBubble_userRole_hasContractAccessibilityLabel() throws {
+        let msg = ChatMessageRecord(
+            role: .user,
+            content: "Hello, tell me about dragons.",
+            sessionID: sessionID
+        )
+        let view = MessageBubbleView(message: msg, isStreaming: false)
+
+        let label = try view.inspect()
+            .find(ViewType.HStack.self)
+            .find(where: { (try? $0.accessibilityLabel().string()) != nil })
+            .accessibilityLabel()
+            .string()
+
+        XCTAssertEqual(
+            label,
+            expectedMessageBubbleLabel(role: .user, content: "Hello, tell me about dragons."),
+            "User message bubble must follow the '<Role> said: <content>' contract"
+        )
+        XCTAssertFalse(label.isEmpty, "Accessibility label must not be empty")
+    }
+
+    func test_messageBubble_assistantRole_hasContractAccessibilityLabel() throws {
+        let msg = ChatMessageRecord(
+            role: .assistant,
+            content: "Once upon a time...",
+            sessionID: sessionID
+        )
+        let view = MessageBubbleView(message: msg, isStreaming: false)
+
+        let label = try view.inspect()
+            .find(ViewType.HStack.self)
+            .find(where: { (try? $0.accessibilityLabel().string()) != nil })
+            .accessibilityLabel()
+            .string()
+
+        XCTAssertEqual(
+            label,
+            expectedMessageBubbleLabel(role: .assistant, content: "Once upon a time..."),
+            "Assistant message bubble must follow the '<Role> said: <content>' contract"
+        )
+    }
+
+    func test_messageBubble_systemRole_hasContractAccessibilityLabel() throws {
+        let msg = ChatMessageRecord(
+            role: .system,
+            content: "You are a helpful assistant.",
+            sessionID: sessionID
+        )
+        let view = MessageBubbleView(message: msg, isStreaming: false)
+
+        let label = try view.inspect()
+            .find(ViewType.HStack.self)
+            .find(where: { (try? $0.accessibilityLabel().string()) != nil })
+            .accessibilityLabel()
+            .string()
+
+        XCTAssertEqual(
+            label,
+            expectedMessageBubbleLabel(role: .system, content: "You are a helpful assistant."),
+            "System message bubble must follow the '<Role> said: <content>' contract"
+        )
+    }
+
+    func test_messageBubble_staticHelperMatchesContract() {
+        // The static helper on MessageBubbleView is what the view uses internally.
+        // Keeping a direct unit test on it provides a second line of defense if the
+        // view-tree inspection ever breaks due to a SwiftUI internals change.
+        let user = ChatMessageRecord(role: .user, content: "Hi", sessionID: sessionID)
+        let assistant = ChatMessageRecord(role: .assistant, content: "Hello", sessionID: sessionID)
+        let system = ChatMessageRecord(role: .system, content: "Be concise", sessionID: sessionID)
+
+        XCTAssertEqual(
+            MessageBubbleView.accessibilityLabel(for: user),
+            expectedMessageBubbleLabel(role: .user, content: "Hi")
+        )
+        XCTAssertEqual(
+            MessageBubbleView.accessibilityLabel(for: assistant),
+            expectedMessageBubbleLabel(role: .assistant, content: "Hello")
+        )
+        XCTAssertEqual(
+            MessageBubbleView.accessibilityLabel(for: system),
+            expectedMessageBubbleLabel(role: .system, content: "Be concise")
+        )
+    }
+
+    // MARK: - ContextIndicatorView
+
+    func test_contextIndicator_labelIsHumanReadable() throws {
+        let view = ContextIndicatorView(usedTokens: 1234, maxTokens: 4096)
+
+        let label = try view.inspect()
+            .find(ViewType.HStack.self)
+            .accessibilityLabel()
+            .string()
+
+        XCTAssertEqual(
+            label,
+            "Context used: 1234 of 4096 tokens",
+            "Context indicator must use human-readable 'Context used: X of Y tokens' format"
+        )
+    }
+
+    func test_contextIndicator_valueExposesPercentage() throws {
+        let view = ContextIndicatorView(usedTokens: 2048, maxTokens: 4096)
+
+        let value = try view.inspect()
+            .find(ViewType.HStack.self)
+            .accessibilityValue()
+            .string()
+
+        XCTAssertEqual(value, "50 percent", "Context indicator must expose percentage via accessibilityValue")
+    }
+
+    // MARK: - Send/Stop button (ChatInputBar primary action)
+    //
+    // `ChatInputBar` reads `ChatViewModel` from `@Environment`, which makes
+    // synchronous ViewInspector walks crash (the VM is only materialized by the
+    // SwiftUI rendering pipeline, not by ViewInspector's reflective inspection).
+    // To keep these tests fast and side-effect-free we inspect the extracted
+    // `SendStopButton` subview directly — it's what `ChatInputBar` composes, so
+    // asserting against it is a real contract assertion, not a parallel reimpl.
+
+    func test_sendStopButton_idleState_exposesSendMessageLabel() throws {
+        let view = SendStopButton(
+            isGenerating: false,
+            canSend: true,
+            onSend: {},
+            onStop: {}
+        )
+
+        let label = try view.inspect().find(ViewType.Button.self).accessibilityLabel().string()
+        XCTAssertEqual(label, "Send message", "Idle send button must expose 'Send message'")
+        XCTAssertEqual(
+            label,
+            SendStopButton.sendLabel,
+            "Idle button label must come from the SendStopButton.sendLabel contract constant"
+        )
+    }
+
+    func test_sendStopButton_generatingState_exposesStopGenerationLabel() throws {
+        let view = SendStopButton(
+            isGenerating: true,
+            canSend: false,
+            onSend: {},
+            onStop: {}
+        )
+
+        let label = try view.inspect().find(ViewType.Button.self).accessibilityLabel().string()
+        XCTAssertEqual(label, "Stop generation", "Generating state must expose 'Stop generation'")
+        XCTAssertEqual(
+            label,
+            SendStopButton.stopLabel,
+            "Generating button label must come from the SendStopButton.stopLabel contract constant"
+        )
+    }
+
+    func test_sendStopButton_contractConstants_matchExpectedStrings() {
+        XCTAssertEqual(SendStopButton.sendLabel, "Send message")
+        XCTAssertEqual(SendStopButton.stopLabel, "Stop generation")
+    }
+
+    // MARK: - Error banner
+
+    func test_errorBanner_hasAccessibilityHeaderAndLabel() throws {
+        let error = ChatError(
+            kind: .generation,
+            message: "The model stopped responding.",
+            recovery: .retry
+        )
+
+        let view = ErrorBannerView(error: error, onDismiss: {}) {
+            EmptyView()
+        }
+
+        // Walk to the outer HStack where the accessibility modifiers are applied.
+        let banner = try view.inspect().find(ViewType.HStack.self)
+        let bannerLabel = try banner.accessibilityLabel().string()
+
+        XCTAssertTrue(
+            bannerLabel.hasPrefix("Error: "),
+            "Error banner accessibility label must begin with 'Error: ' so VoiceOver users recognise its purpose"
+        )
+        XCTAssertTrue(
+            bannerLabel.contains("The model stopped responding."),
+            "Error banner must include the underlying error message"
+        )
+        XCTAssertEqual(
+            bannerLabel,
+            ErrorBannerView<EmptyView>.accessibilityLabel(for: error),
+            "Banner must use the contract helper to build its label"
+        )
+    }
+
+    // MARK: - Sabotage self-check
+    //
+    // Per CLAUDE.md: "after asserting an expected outcome, add a sabotage check:
+    // temporarily break the code path being tested and confirm the test fails."
+    //
+    // This test codifies the sabotage by inlining a deliberately-wrong helper
+    // and verifying the contract rejects it. If the real helper ever starts
+    // producing the same wrong string, the other assertions above would pass
+    // spuriously — this guards against that drift without requiring us to
+    // manually sabotage-and-revert the source each run.
+
+    func test_sabotage_wrongFormatFailsContract() {
+        let msg = ChatMessageRecord(role: .user, content: "Hi", sessionID: sessionID)
+
+        // The old (pre-contract) format: "user: Hi". Kept here as the sabotage
+        // baseline — if someone reverts the source to this format the real
+        // assertions above fail, and this assertion acts as the canary that
+        // confirms the sabotage check itself is still meaningful.
+        let saboteurLabel = "\(msg.role.rawValue): \(msg.content)"
+        let real = MessageBubbleView.accessibilityLabel(for: msg)
+
+        XCTAssertNotEqual(
+            real,
+            saboteurLabel,
+            "The real label must differ from the pre-contract format"
+        )
+        XCTAssertNotEqual(
+            saboteurLabel,
+            expectedMessageBubbleLabel(role: .user, content: "Hi"),
+            "The saboteur format must not accidentally match the contract — otherwise the sabotage check is meaningless"
+        )
+    }
+}
+
+// ViewInspector 0.10.x uses the implicit Inspectable conformance model;
+// no `extension XXX: Inspectable {}` declarations are required for these views.


### PR DESCRIPTION
## Summary

- Adds [ViewInspector 0.10.3](https://github.com/nalexn/ViewInspector/releases/tag/0.10.3) as a test-only dependency (scoped to `BaseChatUITests` — does **not** appear in any production target).
- Introduces `ChatA11yContractTests`, the first accessibility-contract suite for chat UI surfaces. The existing `BaseChatSnapshotTests` suite uses `Swift.dump()`, which strips `.accessibilityLabel`, so the chat UI previously had zero automated a11y coverage.
- Tightens source-level accessibility modifiers on the surfaces the tests cover:
  - `MessageBubbleView` now emits `"User said: …"` / `"Assistant said: …"` / `"System said: …"` (previously leaked the raw enum `rawValue` — `"user: …"`). A `public static accessibilityLabel(for:)` helper exposes the contract for direct assertion.
  - `ContextIndicatorView` label rewritten to `"Context used: X of Y tokens"` with a separate `accessibilityValue` of `"NN percent"`, matching VoiceOver's label/value conventions.
  - The chat error banner is extracted into a standalone `ErrorBannerView` carrying `.accessibilityAddTraits(.isHeader)` and a contract-built `"Error: <message>"` label so VoiceOver announces it as a landmark.
  - The chat input primary action is extracted into a `SendStopButton` subview with public `sendLabel` / `stopLabel` constants, enabling deterministic inspection without mounting a `ChatViewModel` environment.
- The `Swift.dump()`-based snapshot tests are intentionally **not migrated** — that is out of scope.

Includes a sabotage check per CLAUDE.md conventions: the `expectedMessageBubbleLabel` helper is duplicated in the test file (not imported), and I verified locally that reverting `MessageBubbleView.accessibilityLabel(for:)` to the old `"\(role.rawValue): \(content)"` format fails 6 assertions in the new suite before reverting.

## Release Note

**Accessibility contract tests and VoiceOver polish for chat UI** — The chat view's accessibility surface had no automated coverage because the existing snapshot harness captured view hierarchies via `Swift.dump()`, which strips accessibility labels. This change adds a ViewInspector-driven `ChatA11yContractTests` suite and tightens the labels VoiceOver users actually hear: message bubbles now announce `"User said: …"` / `"Assistant said: …"` instead of the raw enum rawValue, the context indicator reads `"Context used: 1234 of 4096 tokens"` at `"50 percent"`, and the error banner is exposed as an accessibility header with an `"Error: …"` prefix so screen-reader users can orient to it as a landmark. Existing visual snapshots and behaviour are unchanged.

## Test plan

- [x] `swift package resolve` confirms ViewInspector 0.10.3 pins cleanly
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 105 tests pass
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 402 tests pass (includes 11 new `ChatA11yContractTests`)
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 84 tests pass
- [x] Sabotage check: reverted `MessageBubbleView.accessibilityLabel(for:)` to the old format and confirmed 6 a11y assertions fail before reverting
- [ ] CI green on `BaseChatCoreTests` + `BaseChatUITests` + `BaseChatBackendsTests`

## Notes for reviewers

- ViewInspector cannot synchronously walk a view that reads `@Environment(ChatViewModel.self)` (the new `@Observable` injection path is not supported by ViewInspector's reflective inspector). Rather than refactor the whole input bar or add a flaky async hosted test, I extracted the minimal subviews (`SendStopButton`, `ErrorBannerView`) so tests can inspect them directly with zero mocking. `ChatInputBar` and `ChatView` now compose these subviews — the call sites remain private.
- The existing `BaseChatSnapshotTests` suite is untouched.