### PR TITLE
test: add day-one user journey E2E coverage

### DIFF
--- a/Tests/BaseChatE2ETests/UserJourneyE2ETests.swift
+++ b/Tests/BaseChatE2ETests/UserJourneyE2ETests.swift
@@ -314,6 +314,12 @@ final class UserJourneyE2ETests {
         // the session record straight from SwiftData. This proves that
         // saveSettingsToSession actually reached the store in step 7 — not
         // just the in-memory sessions array that loadSessions() repopulates.
+        //
+        // Sabotage verified: removing the `try vm.saveSettingsToSession()` call
+        // in step 7 causes the assertion below to fail with
+        // `storedSessions.first?.selectedModelID == modelA.id` (or nil) instead
+        // of modelB.id, confirming this assertion catches the real persistence
+        // contract and is not accidentally vacuous.
         let storedSessionID = session.id
         let sessionDescriptor = FetchDescriptor<ChatSession>(
             predicate: #Predicate { $0.id == storedSessionID }


### PR DESCRIPTION
## Summary

Adds a single end-to-end test that walks a first-time user through the full day-one journey in one `ChatViewModel` instance: empty state, model discovery, load, session creation, first turn, mid-stream cancellation, regeneration, model switch, a second turn against the new model, and session persistence restore.

The existing one-feature-per-test coverage in `BaseChatE2ETests/` validates each step in isolation. This new test exists specifically to catch bugs that only surface when these features run back-to-back against the same view model — hand-offs between discovery, load, send, cancel, regenerate, switch, and persistence.

- Uses `SlowMockBackend` and in-memory SwiftData so step 5 can deterministically observe mid-stream cancellation (per-token delay gives `stopGeneration()` real work to cancel).
- No hardware dependencies; runs in the `BaseChatE2ETests --disable-default-traits` suite.
- Includes a sabotage-check assertion on the final reload, verified to fail when the step-7 `saveSettingsToSession()` call is removed.

## Findings

While writing this test I hit a latent bug in the send-then-cancel path: both `ChatViewModel.stopGeneration()` and the tail of `generateIntoMessage()` call `saveMessage()` on the same assistant record, which double-inserts a SwiftData row (same `id`, two rows). The test works around it by deleting the duplicate row directly via `ModelContext` before proceeding to the regenerate step, with a comment flagging the issue. Fixing the underlying bug is out of scope for this test-only PR and should be tracked separately.

## Test plan

- [x] `swift test --filter BaseChatE2ETests.UserJourneyE2ETests --disable-default-traits` passes locally
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` passes
- [x] `swift test --filter BaseChatUITests --disable-default-traits` passes
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` passes
- [x] `swift test --filter BaseChatE2ETests --disable-default-traits` passes (60 tests)
- [x] Sabotage check: commenting out the step-7 `saveSettingsToSession()` call fails the sabotage assertion