### PR TITLE
feat: explicit state machine for ChatViewModel activityPhase

### DIFF
--- a/Sources/BaseChatCore/Models/ActivityPhaseStateMachine.swift
+++ b/Sources/BaseChatCore/Models/ActivityPhaseStateMachine.swift
@@ -10,29 +10,20 @@ import Foundation
 ///
 /// `ActivityPhaseStateMachine` is the single source of truth for the
 /// legal transition graph. Every phase mutation in the view model now
-/// goes through ``transition(to:)``, and every illegal attempt is either
-/// rejected (for races) or surfaced as a programmer error.
+/// goes through ``transition(to:)``, which reports the outcome via
+/// ``TransitionResult`` so callers can branch on it.
 ///
 /// ## Illegal-transition policy
 ///
 /// Per `CLAUDE.md`, `assertionFailure` is reserved for true programmer
-/// errors with no recovery path. The phase state machine has two flavours
-/// of illegal transition:
-///
-/// 1. **Programmer errors** — e.g. calling `.streaming` before requesting
-///    generation. These cannot legitimately arise from async races and
-///    indicate a bug in the caller. Detected only when ``strictMode`` is
-///    true (default). Still recoverable (we log and ignore), but noisy
-///    in debug so the bug surfaces early.
-///
-/// 2. **Stale async events** — e.g. a late load-progress callback arriving
-///    after a cancellation flipped the phase to `.idle`, or a stalled
-///    backend notification arriving after the user cancelled. These are
-///    race conditions by design and must be silently ignored.
-///
-/// The machine does not itself distinguish (1) from (2); callers pass
-/// ``TransitionOptions/ignoreIfIllegal`` when they know the event can
-/// legitimately lose a race.
+/// errors with no recovery path. Illegal transitions here are always
+/// recoverable — they arise from async races (e.g. a late load-progress
+/// callback arriving after cancellation flipped the phase to `.idle`, or
+/// a stalled-backend notification landing after the user cancelled). The
+/// machine therefore rejects every illegal transition the same way:
+/// `phase` is left untouched and the caller receives
+/// ``TransitionResult/rejected(from:to:)``. Callers log and move on; the
+/// machine never traps.
 public struct ActivityPhaseStateMachine: Sendable {
 
     /// The machine's current phase. Callers mutate this via ``transition(to:)``.

--- a/Sources/BaseChatCore/Models/ActivityPhaseStateMachine.swift
+++ b/Sources/BaseChatCore/Models/ActivityPhaseStateMachine.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+/// Explicit, validated transitions for ``BackendActivityPhase``.
+///
+/// Before this machine existed, phase mutations were scattered across
+/// `ChatViewModel+Generation`, `ChatViewModel+ModelLoading`, and
+/// `ChatViewModel+Messages`, each enforcing its own ad-hoc preconditions.
+/// That made races like "model load fails while user taps send" fragile —
+/// nothing centralised the question "is this transition legal?"
+///
+/// `ActivityPhaseStateMachine` is the single source of truth for the
+/// legal transition graph. Every phase mutation in the view model now
+/// goes through ``transition(to:)``, and every illegal attempt is either
+/// rejected (for races) or surfaced as a programmer error.
+///
+/// ## Illegal-transition policy
+///
+/// Per `CLAUDE.md`, `assertionFailure` is reserved for true programmer
+/// errors with no recovery path. The phase state machine has two flavours
+/// of illegal transition:
+///
+/// 1. **Programmer errors** — e.g. calling `.streaming` before requesting
+///    generation. These cannot legitimately arise from async races and
+///    indicate a bug in the caller. Detected only when ``strictMode`` is
+///    true (default). Still recoverable (we log and ignore), but noisy
+///    in debug so the bug surfaces early.
+///
+/// 2. **Stale async events** — e.g. a late load-progress callback arriving
+///    after a cancellation flipped the phase to `.idle`, or a stalled
+///    backend notification arriving after the user cancelled. These are
+///    race conditions by design and must be silently ignored.
+///
+/// The machine does not itself distinguish (1) from (2); callers pass
+/// ``TransitionOptions/ignoreIfIllegal`` when they know the event can
+/// legitimately lose a race.
+public struct ActivityPhaseStateMachine: Sendable {
+
+    /// The machine's current phase. Callers mutate this via ``transition(to:)``.
+    public private(set) var phase: BackendActivityPhase
+
+    public init(phase: BackendActivityPhase = .idle) {
+        self.phase = phase
+    }
+
+    /// Result of an attempted transition.
+    public enum TransitionResult: Sendable, Equatable {
+        /// The transition was applied. `phase` now reflects the new state.
+        case applied
+        /// No state change occurred — the transition was a same-phase no-op
+        /// (e.g. progress update during `.modelLoading`, or token arriving
+        /// mid-`.streaming`).
+        case unchanged
+        /// The transition was rejected as illegal for the current phase.
+        case rejected(from: BackendActivityPhase, to: BackendActivityPhase)
+    }
+
+    /// Attempt to move to `to`. Returns the outcome so callers can decide
+    /// whether to proceed. Rejected transitions leave `phase` unchanged.
+    @discardableResult
+    public mutating func transition(to: BackendActivityPhase) -> TransitionResult {
+        let from = phase
+        if Self.isSameStatePhase(from, to) {
+            // Progress updates (same case, possibly different payload) are
+            // always permitted — they're how the UI mirrors long-running
+            // work without hitting the illegal-transition path.
+            phase = to
+            return from == to ? .unchanged : .applied
+        }
+        guard Self.isLegalTransition(from: from, to: to) else {
+            return .rejected(from: from, to: to)
+        }
+        phase = to
+        return .applied
+    }
+
+    /// Static predicate exposed for tests and for callers that want to
+    /// check legality without mutating.
+    public static func isLegalTransition(
+        from: BackendActivityPhase,
+        to: BackendActivityPhase
+    ) -> Bool {
+        // Same-case transitions (e.g. .modelLoading → .modelLoading with a
+        // new progress value) are handled separately in `transition(to:)`.
+        if isSameStatePhase(from, to) { return true }
+
+        // Universal escapes: cancellation and model swap can happen from
+        // any state. `.idle` is always safe (cancel/reset), and the user
+        // can always start loading a different model mid-activity — the
+        // old activity is cancelled as a side effect at the call site.
+        if case .idle = to { return true }
+        if case .modelLoading = to { return true }
+
+        switch (from, to) {
+
+        // MARK: From .idle
+        case (.idle, .waitingForFirstToken):
+            // User tapped send while a model was already loaded.
+            return true
+
+        // MARK: From .modelLoading
+        case (.modelLoading, .waitingForFirstToken):
+            // Rare: a queued send runs the instant a load completes, before
+            // the load bridge has flipped to `.idle`. We allow it so the
+            // send doesn't have to wait a tick for the idle intermediate.
+            return true
+
+        // MARK: From .waitingForFirstToken
+        case (.waitingForFirstToken, .streaming),
+             (.waitingForFirstToken, .stalled),
+             (.waitingForFirstToken, .retrying):
+            return true
+
+        // MARK: From .streaming
+        case (.streaming, .stalled),
+             (.streaming, .retrying):
+            return true
+
+        // MARK: From .stalled
+        case (.stalled, .streaming),
+             (.stalled, .waitingForFirstToken),
+             (.stalled, .retrying):
+            return true
+
+        // MARK: From .retrying
+        case (.retrying, .streaming),
+             (.retrying, .waitingForFirstToken),
+             (.retrying, .stalled):
+            return true
+
+        default:
+            return false
+        }
+    }
+
+    /// Two phases are considered the "same state" if they use the same
+    /// enum case even if their associated values differ. Progress updates
+    /// inside `.modelLoading` and retry-attempt updates inside `.retrying`
+    /// are not real transitions.
+    public static func isSameStatePhase(
+        _ a: BackendActivityPhase,
+        _ b: BackendActivityPhase
+    ) -> Bool {
+        switch (a, b) {
+        case (.idle, .idle),
+             (.waitingForFirstToken, .waitingForFirstToken),
+             (.streaming, .streaming),
+             (.stalled, .stalled):
+            return true
+        case (.modelLoading, .modelLoading):
+            return true
+        case (.retrying, .retrying):
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
@@ -57,7 +57,7 @@ extension ChatViewModel {
     /// and the Foundation model upgrade hint.
     func generateIntoMessage(_ assistantMessage: ChatMessageRecord) async {
         backgroundTaskError = nil
-        activityPhase = .waitingForFirstToken
+        transitionPhase(to: .waitingForFirstToken)
         let messageID = assistantMessage.id
         defer {
             // Only call generationDidFinish (which drains the queue) if we
@@ -72,10 +72,10 @@ extension ChatViewModel {
                 // Check before drain, since drain may empty the queue while
                 // starting a new generation.
                 if !willDrainNext {
-                    activityPhase = .idle
+                    transitionPhase(to: .idle)
                 }
             } else {
-                activityPhase = .idle
+                transitionPhase(to: .idle)
             }
         }
 
@@ -161,7 +161,7 @@ extension ChatViewModel {
                         case .token(let token):
                             tokenCount += 1
                             if tokenCount == 1 {
-                                self.activityPhase = .streaming
+                                self.transitionPhase(to: .streaming)
                             }
                             if let batch = batcher.append(token, now: ContinuousClock.now) {
                                 var looping = false

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Messages.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Messages.swift
@@ -129,7 +129,7 @@ extension ChatViewModel {
         generationTask = nil
         activeGenerationToken = nil
         inferenceService.stopGeneration()
-        activityPhase = .idle
+        transitionPhase(to: .idle)
 
         // Persist whatever has been generated so far.
         if let lastAssistant = messages.last(where: { $0.role == .assistant }),

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+ModelLoading.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+ModelLoading.swift
@@ -82,7 +82,7 @@ extension ChatViewModel {
     private func invalidatePendingLoadIntent(resetActivityPhase: Bool = false) {
         _ = nextLoadIntentGeneration(cancelInFlightTask: true)
         if resetActivityPhase, isLoading {
-            activityPhase = .idle
+            transitionPhase(to: .idle)
         }
     }
 
@@ -94,7 +94,7 @@ extension ChatViewModel {
     private func beginLoadUIState(generation: UInt64?) -> Bool {
         guard isCurrentLoadIntentGeneration(generation) else { return false }
         errorMessage = nil
-        activityPhase = .modelLoading(progress: inferenceService.modelLoadProgress)
+        transitionPhase(to: .modelLoading(progress: inferenceService.modelLoadProgress))
         return true
     }
 
@@ -126,14 +126,14 @@ extension ChatViewModel {
         guard case .modelLoading(let current) = activityPhase else { return }
         let snapshot = inferenceService.modelLoadProgress
         if current != snapshot {
-            activityPhase = .modelLoading(progress: snapshot)
+            transitionPhase(to: .modelLoading(progress: snapshot))
         }
     }
 
     private func endLoadUIState(generation: UInt64?) {
         guard isCurrentLoadIntentGeneration(generation) else { return }
         if case .modelLoading = activityPhase {
-            activityPhase = .idle
+            transitionPhase(to: .idle)
         }
     }
 

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -107,14 +107,56 @@ public final class ChatViewModel {
     public var systemPrompt: String = ""
 
     /// The current phase of backend activity, driving all status indicators.
+    ///
+    /// The setter is `internal(set)` for SwiftUI observation, but all production
+    /// code paths must mutate this via ``transitionPhase(to:)`` so the
+    /// ``ActivityPhaseStateMachine`` can validate the transition. Test-only
+    /// direct writes bypass validation — see the state machine tests for
+    /// exhaustive legal-transition coverage.
     public internal(set) var activityPhase: BackendActivityPhase = .idle {
         didSet {
+            phaseMachine = ActivityPhaseStateMachine(phase: activityPhase)
             let wasGenerating = oldValue == .waitingForFirstToken || oldValue == .streaming
             let nowGenerating = activityPhase == .waitingForFirstToken || activityPhase == .streaming
             if wasGenerating != nowGenerating {
                 onGeneratingChanged?(nowGenerating)
             }
             onActivityPhaseChanged?(activityPhase)
+        }
+    }
+
+    /// Single source of truth for legal phase transitions. The view model
+    /// never mutates `activityPhase` directly — every production code path
+    /// routes through ``transitionPhase(to:)``.
+    @ObservationIgnored
+    private var phaseMachine = ActivityPhaseStateMachine(phase: .idle)
+
+    /// Attempt to move to `newPhase`. Illegal transitions are logged and
+    /// dropped — callers that know they may lose a race (stale progress
+    /// callbacks, late stall notifications) rely on this to be a no-op.
+    ///
+    /// Returns `true` if the phase actually changed, `false` if the
+    /// transition was rejected or was a same-phase no-op.
+    @discardableResult
+    func transitionPhase(to newPhase: BackendActivityPhase) -> Bool {
+        let result = phaseMachine.transition(to: newPhase)
+        switch result {
+        case .applied:
+            activityPhase = phaseMachine.phase
+            return true
+        case .unchanged:
+            return false
+        case .rejected(let from, let to):
+            // Rejected transitions are a defence against bugs *and* a
+            // defence against stale async events. We log at warning level
+            // so CI surfaces unexpected bugs without crashing tests in
+            // debug — per CLAUDE.md, `assertionFailure` is reserved for
+            // conditions with no recovery path, and every rejection here
+            // has an implicit recovery (ignore the event).
+            Log.ui.warning(
+                "ActivityPhaseStateMachine rejected transition: \(String(describing: from)) → \(String(describing: to))"
+            )
+            return false
         }
     }
 

--- a/Tests/BaseChatCoreTests/ActivityPhaseStateMachinePropertyTests.swift
+++ b/Tests/BaseChatCoreTests/ActivityPhaseStateMachinePropertyTests.swift
@@ -1,0 +1,131 @@
+import Testing
+import Foundation
+@testable import BaseChatCore
+
+/// Property-based stress tests for ``ActivityPhaseStateMachine``. A
+/// deterministic-but-seeded PRNG generates sequences of pseudo-random
+/// events and feeds them into the machine. The invariants asserted are:
+///
+/// 1. The machine never panics or diverges — rejected transitions leave
+///    the phase unchanged.
+/// 2. `phase` after every step must always be one of the known cases.
+/// 3. Any transition the machine accepts must also satisfy
+///    ``ActivityPhaseStateMachine/isLegalTransition(from:to:)``, so the
+///    static predicate and the mutating apply stay in lock-step.
+@Suite("ActivityPhaseStateMachine property tests")
+struct ActivityPhaseStateMachinePropertyTests {
+
+    /// The machine accepts `BackendActivityPhase` targets directly.
+    /// We model an "event" as a candidate target drawn from the full
+    /// phase vocabulary — this is denser and more stressing than a
+    /// narrow event alphabet, because it forces the machine to deal
+    /// with genuinely arbitrary sequences.
+    private static let candidates: [BackendActivityPhase] = [
+        .idle,
+        .modelLoading(progress: nil),
+        .modelLoading(progress: 0.25),
+        .modelLoading(progress: 0.75),
+        .waitingForFirstToken,
+        .streaming,
+        .stalled,
+        .retrying(attempt: 1, of: 3),
+        .retrying(attempt: 2, of: 3),
+        .retrying(attempt: 3, of: 3)
+    ]
+
+    /// 128 seeded sequences (>=100 required by the issue). Each seed
+    /// is the test argument, so failures print the exact seed and are
+    /// trivially reproducible.
+    @Test(
+        "Random event sequences never drive the machine into an inconsistent state",
+        arguments: Array(0..<128)
+    )
+    func randomSequenceRespectsInvariants(seed: Int) {
+        var rng = SeededRNG(seed: UInt64(seed))
+        var machine = ActivityPhaseStateMachine()
+
+        for _ in 0..<64 {
+            let from = machine.phase
+            let candidate = Self.candidates.randomElement(using: &rng)!
+            let result = machine.transition(to: candidate)
+
+            switch result {
+            case .applied, .unchanged:
+                // Accepted: either the transition was legal per the
+                // static predicate OR it was a same-case progress
+                // update (which the predicate also reports as legal).
+                #expect(
+                    ActivityPhaseStateMachine.isLegalTransition(
+                        from: from,
+                        to: candidate
+                    ),
+                    "Machine accepted \(from) → \(candidate) but static predicate disagreed (seed \(seed))"
+                )
+            case .rejected(let rFrom, let rTo):
+                // Rejected: phase must not have moved.
+                #expect(
+                    machine.phase == from,
+                    "Rejected transition should not mutate phase (seed \(seed))"
+                )
+                #expect(rFrom == from)
+                #expect(rTo == candidate)
+            }
+        }
+    }
+
+    /// Idle and modelLoading are the universal escapes — every
+    /// reachable phase must accept them. We drive the machine through
+    /// random sequences and then prove that from wherever it lands,
+    /// cancel (`.idle`) and model-swap (`.modelLoading`) always work.
+    @Test(
+        "Idle and modelLoading are always reachable from any random walk endpoint",
+        arguments: Array(0..<128)
+    )
+    func universalEscapesAlwaysWork(seed: Int) {
+        var rng = SeededRNG(seed: UInt64(seed) ^ 0xDEADBEEF)
+        var machine = ActivityPhaseStateMachine()
+
+        for _ in 0..<32 {
+            let candidate = Self.candidates.randomElement(using: &rng)!
+            _ = machine.transition(to: candidate)
+        }
+
+        // From wherever we ended up, cancelling to idle must succeed.
+        var cancelMachine = machine
+        let cancelResult = cancelMachine.transition(to: .idle)
+        #expect(
+            cancelResult != .rejected(from: machine.phase, to: .idle),
+            "Cancel should never be rejected (seed \(seed), landed in \(machine.phase))"
+        )
+
+        // And swapping to a new model must also succeed.
+        var swapMachine = machine
+        let swapResult = swapMachine.transition(to: .modelLoading(progress: nil))
+        #expect(
+            swapResult != .rejected(
+                from: machine.phase,
+                to: .modelLoading(progress: nil)
+            ),
+            "Model swap should never be rejected (seed \(seed), landed in \(machine.phase))"
+        )
+    }
+}
+
+// MARK: - Seeded RNG
+//
+// Swift Testing + Foundation's `SystemRandomNumberGenerator` would give
+// us non-deterministic sequences — if a property fails in CI we'd have
+// no way to reproduce it locally. A tiny splitmix64 keeps each seed
+// independent and cheap.
+
+private struct SeededRNG: RandomNumberGenerator {
+    private var state: UInt64
+    init(seed: UInt64) { self.state = seed &+ 0x9E3779B97F4A7C15 }
+    mutating func next() -> UInt64 {
+        state &+= 0x9E3779B97F4A7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58476D1CE4E5B9
+        z = (z ^ (z >> 27)) &* 0x94D049BB133111EB
+        return z ^ (z >> 31)
+    }
+}

--- a/Tests/BaseChatCoreTests/ActivityPhaseStateMachineTests.swift
+++ b/Tests/BaseChatCoreTests/ActivityPhaseStateMachineTests.swift
@@ -70,6 +70,10 @@ final class ActivityPhaseStateMachineTests: XCTestCase {
         assertLegal(.waitingForFirstToken, .idle)
     }
 
+    func test_waitingForFirstToken_to_modelLoading_legal() {
+        assertLegal(.waitingForFirstToken, .modelLoading(progress: nil))
+    }
+
     func test_waitingForFirstToken_to_stalled_legal() {
         assertLegal(.waitingForFirstToken, .stalled)
     }
@@ -80,6 +84,10 @@ final class ActivityPhaseStateMachineTests: XCTestCase {
 
     func test_streaming_to_idle_legal() {
         assertLegal(.streaming, .idle)
+    }
+
+    func test_streaming_to_modelLoading_legal() {
+        assertLegal(.streaming, .modelLoading(progress: nil))
     }
 
     func test_streaming_to_stalled_legal() {
@@ -94,8 +102,16 @@ final class ActivityPhaseStateMachineTests: XCTestCase {
         assertLegal(.stalled, .streaming)
     }
 
+    func test_stalled_to_waitingForFirstToken_legal() {
+        assertLegal(.stalled, .waitingForFirstToken)
+    }
+
     func test_stalled_to_idle_legal() {
         assertLegal(.stalled, .idle)
+    }
+
+    func test_stalled_to_modelLoading_legal() {
+        assertLegal(.stalled, .modelLoading(progress: nil))
     }
 
     func test_stalled_to_retrying_legal() {
@@ -110,8 +126,16 @@ final class ActivityPhaseStateMachineTests: XCTestCase {
         assertLegal(.retrying(attempt: 2, of: 3), .waitingForFirstToken)
     }
 
+    func test_retrying_to_stalled_legal() {
+        assertLegal(.retrying(attempt: 2, of: 3), .stalled)
+    }
+
     func test_retrying_to_idle_legal() {
         assertLegal(.retrying(attempt: 3, of: 3), .idle)
+    }
+
+    func test_retrying_to_modelLoading_legal() {
+        assertLegal(.retrying(attempt: 2, of: 3), .modelLoading(progress: nil))
     }
 
     func test_retrying_attemptBump_legal() {
@@ -193,6 +217,106 @@ final class ActivityPhaseStateMachineTests: XCTestCase {
     func test_samePhaseSameValue_isUnchanged() {
         var machine = ActivityPhaseStateMachine(phase: .streaming)
         XCTAssertEqual(machine.transition(to: .streaming), .unchanged)
+    }
+
+    func test_idle_to_idle_unchanged() {
+        var machine = ActivityPhaseStateMachine(phase: .idle)
+        XCTAssertEqual(machine.transition(to: .idle), .unchanged)
+    }
+
+    func test_waitingForFirstToken_to_waitingForFirstToken_unchanged() {
+        var machine = ActivityPhaseStateMachine(phase: .waitingForFirstToken)
+        XCTAssertEqual(machine.transition(to: .waitingForFirstToken), .unchanged)
+    }
+
+    func test_stalled_to_stalled_unchanged() {
+        var machine = ActivityPhaseStateMachine(phase: .stalled)
+        XCTAssertEqual(machine.transition(to: .stalled), .unchanged)
+    }
+
+    // MARK: - Exhaustive matrix
+    //
+    // Mechanical backstop for the header invariant: every (from, to) pair
+    // must match the table below. If a transition is added or removed
+    // without updating this table the test fails loudly, which forces the
+    // author to also update the named per-pair tests above.
+
+    func test_exhaustiveTransitionMatrix() {
+        // Legal cross-pairs. Same-case pairs are handled separately by the
+        // `unchanged` tests and are not listed here.
+        let legalCrossPairs: Set<Pair> = [
+            Pair(.idle, .modelLoading),
+            Pair(.idle, .waitingForFirstToken),
+            Pair(.modelLoading, .idle),
+            Pair(.modelLoading, .waitingForFirstToken),
+            Pair(.waitingForFirstToken, .idle),
+            Pair(.waitingForFirstToken, .modelLoading),
+            Pair(.waitingForFirstToken, .streaming),
+            Pair(.waitingForFirstToken, .stalled),
+            Pair(.waitingForFirstToken, .retrying),
+            Pair(.streaming, .idle),
+            Pair(.streaming, .modelLoading),
+            Pair(.streaming, .stalled),
+            Pair(.streaming, .retrying),
+            Pair(.stalled, .idle),
+            Pair(.stalled, .modelLoading),
+            Pair(.stalled, .waitingForFirstToken),
+            Pair(.stalled, .streaming),
+            Pair(.stalled, .retrying),
+            Pair(.retrying, .idle),
+            Pair(.retrying, .modelLoading),
+            Pair(.retrying, .waitingForFirstToken),
+            Pair(.retrying, .streaming),
+            Pair(.retrying, .stalled),
+        ]
+
+        for fromKind in PhaseKind.allCases {
+            for toKind in PhaseKind.allCases {
+                let from = fromKind.representative
+                let to = toKind.representative
+                let expectedLegal: Bool
+                if fromKind == toKind {
+                    // Same-case pairs are always "legal" in the sense that
+                    // `transition(to:)` accepts them (as .applied or
+                    // .unchanged). They're exercised by the named
+                    // `_unchanged` tests.
+                    expectedLegal = true
+                } else {
+                    expectedLegal = legalCrossPairs.contains(Pair(fromKind, toKind))
+                }
+                let actualLegal = ActivityPhaseStateMachine.isLegalTransition(
+                    from: from, to: to
+                )
+                XCTAssertEqual(
+                    actualLegal,
+                    expectedLegal,
+                    "\(fromKind) → \(toKind): expected legal=\(expectedLegal), got \(actualLegal)"
+                )
+            }
+        }
+    }
+
+    private enum PhaseKind: CaseIterable, Hashable {
+        case idle, modelLoading, waitingForFirstToken, streaming, stalled, retrying
+        var representative: BackendActivityPhase {
+            switch self {
+            case .idle: return .idle
+            case .modelLoading: return .modelLoading(progress: 0.5)
+            case .waitingForFirstToken: return .waitingForFirstToken
+            case .streaming: return .streaming
+            case .stalled: return .stalled
+            case .retrying: return .retrying(attempt: 1, of: 3)
+            }
+        }
+    }
+
+    private struct Pair: Hashable {
+        let from: PhaseKind
+        let to: PhaseKind
+        init(_ from: PhaseKind, _ to: PhaseKind) {
+            self.from = from
+            self.to = to
+        }
     }
 
     // MARK: - Race regression scenarios

--- a/Tests/BaseChatCoreTests/ActivityPhaseStateMachineTests.swift
+++ b/Tests/BaseChatCoreTests/ActivityPhaseStateMachineTests.swift
@@ -1,0 +1,294 @@
+import XCTest
+@testable import BaseChatCore
+
+/// Exhaustively verifies the legal-transition graph for
+/// ``ActivityPhaseStateMachine``. Every `(from, to)` pair is asserted
+/// explicitly so a behaviour change forces a test update — no implicit
+/// "default rule" means "legal".
+final class ActivityPhaseStateMachineTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Canonical representatives of each phase case. Associated values
+    /// are fixed so we test the shape of the transition graph, not the
+    /// specifics of progress values or retry attempts.
+    private let allPhases: [BackendActivityPhase] = [
+        .idle,
+        .modelLoading(progress: 0.0),
+        .waitingForFirstToken,
+        .streaming,
+        .stalled,
+        .retrying(attempt: 1, of: 3)
+    ]
+
+    // MARK: - Initial State
+
+    func test_initialPhase_isIdle() {
+        let machine = ActivityPhaseStateMachine()
+        XCTAssertEqual(machine.phase, .idle)
+    }
+
+    func test_initialPhase_customisable() {
+        let machine = ActivityPhaseStateMachine(phase: .streaming)
+        XCTAssertEqual(machine.phase, .streaming)
+    }
+
+    // MARK: - Legal transitions (exhaustive)
+
+    func test_idle_to_modelLoading_legal() {
+        assertLegal(.idle, .modelLoading(progress: nil))
+    }
+
+    func test_idle_to_waitingForFirstToken_legal() {
+        assertLegal(.idle, .waitingForFirstToken)
+    }
+
+    func test_modelLoading_to_idle_legal() {
+        assertLegal(.modelLoading(progress: 0.5), .idle)
+    }
+
+    func test_modelLoading_to_waitingForFirstToken_legal() {
+        // Rare race: a queued send runs the instant a load completes,
+        // before the load bridge flips to .idle.
+        assertLegal(.modelLoading(progress: 1.0), .waitingForFirstToken)
+    }
+
+    func test_modelLoading_progressUpdate_legal() {
+        var machine = ActivityPhaseStateMachine(phase: .modelLoading(progress: 0.1))
+        XCTAssertEqual(
+            machine.transition(to: .modelLoading(progress: 0.5)),
+            .applied
+        )
+        XCTAssertEqual(machine.phase, .modelLoading(progress: 0.5))
+    }
+
+    func test_waitingForFirstToken_to_streaming_legal() {
+        assertLegal(.waitingForFirstToken, .streaming)
+    }
+
+    func test_waitingForFirstToken_to_idle_legal() {
+        assertLegal(.waitingForFirstToken, .idle)
+    }
+
+    func test_waitingForFirstToken_to_stalled_legal() {
+        assertLegal(.waitingForFirstToken, .stalled)
+    }
+
+    func test_waitingForFirstToken_to_retrying_legal() {
+        assertLegal(.waitingForFirstToken, .retrying(attempt: 1, of: 3))
+    }
+
+    func test_streaming_to_idle_legal() {
+        assertLegal(.streaming, .idle)
+    }
+
+    func test_streaming_to_stalled_legal() {
+        assertLegal(.streaming, .stalled)
+    }
+
+    func test_streaming_to_retrying_legal() {
+        assertLegal(.streaming, .retrying(attempt: 1, of: 3))
+    }
+
+    func test_stalled_to_streaming_legal() {
+        assertLegal(.stalled, .streaming)
+    }
+
+    func test_stalled_to_idle_legal() {
+        assertLegal(.stalled, .idle)
+    }
+
+    func test_stalled_to_retrying_legal() {
+        assertLegal(.stalled, .retrying(attempt: 1, of: 3))
+    }
+
+    func test_retrying_to_streaming_legal() {
+        assertLegal(.retrying(attempt: 2, of: 3), .streaming)
+    }
+
+    func test_retrying_to_waitingForFirstToken_legal() {
+        assertLegal(.retrying(attempt: 2, of: 3), .waitingForFirstToken)
+    }
+
+    func test_retrying_to_idle_legal() {
+        assertLegal(.retrying(attempt: 3, of: 3), .idle)
+    }
+
+    func test_retrying_attemptBump_legal() {
+        var machine = ActivityPhaseStateMachine(phase: .retrying(attempt: 1, of: 3))
+        XCTAssertEqual(
+            machine.transition(to: .retrying(attempt: 2, of: 3)),
+            .applied
+        )
+        XCTAssertEqual(machine.phase, .retrying(attempt: 2, of: 3))
+    }
+
+    // MARK: - Universal transitions
+
+    func test_anyPhase_toIdle_legal() {
+        for from in allPhases {
+            XCTAssertTrue(
+                ActivityPhaseStateMachine.isLegalTransition(from: from, to: .idle),
+                "\(from) → .idle should always be legal (cancel/reset path)"
+            )
+        }
+    }
+
+    func test_anyPhase_toModelLoading_legal() {
+        for from in allPhases {
+            XCTAssertTrue(
+                ActivityPhaseStateMachine.isLegalTransition(
+                    from: from,
+                    to: .modelLoading(progress: nil)
+                ),
+                "\(from) → .modelLoading should always be legal (model swap path)"
+            )
+        }
+    }
+
+    // MARK: - Illegal transitions
+
+    func test_idle_to_streaming_illegal() {
+        assertIllegal(.idle, .streaming)
+    }
+
+    func test_idle_to_stalled_illegal() {
+        assertIllegal(.idle, .stalled)
+    }
+
+    func test_idle_to_retrying_illegal() {
+        assertIllegal(.idle, .retrying(attempt: 1, of: 3))
+    }
+
+    func test_modelLoading_to_streaming_illegal() {
+        // Must go through waitingForFirstToken first.
+        assertIllegal(.modelLoading(progress: 1.0), .streaming)
+    }
+
+    func test_modelLoading_to_stalled_illegal() {
+        assertIllegal(.modelLoading(progress: 0.5), .stalled)
+    }
+
+    func test_modelLoading_to_retrying_illegal() {
+        assertIllegal(.modelLoading(progress: 0.5), .retrying(attempt: 1, of: 3))
+    }
+
+    func test_streaming_to_waitingForFirstToken_illegal() {
+        // Once tokens are flowing, there is no backwards path to "waiting".
+        assertIllegal(.streaming, .waitingForFirstToken)
+    }
+
+    // MARK: - Rejected transitions don't mutate state
+
+    func test_rejectedTransition_leavesPhaseUnchanged() {
+        var machine = ActivityPhaseStateMachine(phase: .idle)
+        let result = machine.transition(to: .streaming)
+        guard case .rejected = result else {
+            XCTFail("Expected rejected, got \(result)")
+            return
+        }
+        XCTAssertEqual(machine.phase, .idle)
+    }
+
+    func test_samePhaseSameValue_isUnchanged() {
+        var machine = ActivityPhaseStateMachine(phase: .streaming)
+        XCTAssertEqual(machine.transition(to: .streaming), .unchanged)
+    }
+
+    // MARK: - Race regression scenarios
+    //
+    // Each scenario below reproduces one of the four race conditions
+    // called out in issue #240's "Root cause 4" audit finding. The
+    // state machine must either accept the sequence without diverging
+    // or reject obviously-wrong events cleanly.
+
+    func test_race_modelLoadFailsWhileUserTyping_thenSendTapped() {
+        // User types → load fails → user taps send without reloading.
+        // The machine is in .idle (load bridge transitioned it on
+        // failure), so sendRequested → waitingForFirstToken is legal.
+        var machine = ActivityPhaseStateMachine(phase: .idle)
+        _ = machine.transition(to: .modelLoading(progress: 0.2))
+        _ = machine.transition(to: .idle) // load failed
+        XCTAssertEqual(machine.transition(to: .waitingForFirstToken), .applied)
+    }
+
+    func test_race_modelSwitchMidStream() {
+        // User is mid-stream, switches models. Model swap must be legal
+        // from every active phase.
+        var machine = ActivityPhaseStateMachine(phase: .streaming)
+        XCTAssertEqual(
+            machine.transition(to: .modelLoading(progress: nil)),
+            .applied
+        )
+        // After the new load completes, generation must be able to
+        // start fresh.
+        _ = machine.transition(to: .idle)
+        XCTAssertEqual(machine.transition(to: .waitingForFirstToken), .applied)
+    }
+
+    func test_race_rapidSendCancelSendCancelSend() {
+        var machine = ActivityPhaseStateMachine(phase: .idle)
+        for _ in 0..<3 {
+            XCTAssertEqual(machine.transition(to: .waitingForFirstToken), .applied)
+            XCTAssertEqual(machine.transition(to: .idle), .applied)
+        }
+        XCTAssertEqual(machine.phase, .idle)
+    }
+
+    func test_race_scenePhaseBackground_whileStreaming() {
+        // App backgrounds mid-stream. The VM emits cancel → idle.
+        // Returning foreground, the user can start a new generation.
+        var machine = ActivityPhaseStateMachine(phase: .streaming)
+        XCTAssertEqual(machine.transition(to: .idle), .applied)
+        XCTAssertEqual(machine.transition(to: .waitingForFirstToken), .applied)
+    }
+
+    // MARK: - Helpers
+
+    private func assertLegal(
+        _ from: BackendActivityPhase,
+        _ to: BackendActivityPhase,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(
+            ActivityPhaseStateMachine.isLegalTransition(from: from, to: to),
+            "Expected \(from) → \(to) to be legal",
+            file: file,
+            line: line
+        )
+        var machine = ActivityPhaseStateMachine(phase: from)
+        let result = machine.transition(to: to)
+        XCTAssertNotEqual(
+            result,
+            .rejected(from: from, to: to),
+            "transition(to:) rejected \(from) → \(to)",
+            file: file,
+            line: line
+        )
+    }
+
+    private func assertIllegal(
+        _ from: BackendActivityPhase,
+        _ to: BackendActivityPhase,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertFalse(
+            ActivityPhaseStateMachine.isLegalTransition(from: from, to: to),
+            "Expected \(from) → \(to) to be illegal",
+            file: file,
+            line: line
+        )
+        var machine = ActivityPhaseStateMachine(phase: from)
+        let result = machine.transition(to: to)
+        guard case .rejected = result else {
+            XCTFail(
+                "Expected rejected for \(from) → \(to), got \(result)",
+                file: file,
+                line: line
+            )
+            return
+        }
+    }
+}

--- a/Tests/BaseChatUITests/BackendActivityPhaseTests.swift
+++ b/Tests/BaseChatUITests/BackendActivityPhaseTests.swift
@@ -52,13 +52,13 @@ final class BackendActivityPhaseTests: XCTestCase {
         let vm = ChatViewModel()
         XCTAssertFalse(vm.isLoading)
 
-        vm.activityPhase = .modelLoading(progress: nil)
+        vm.transitionPhase(to: .modelLoading(progress: nil))
         XCTAssertTrue(vm.isLoading)
 
-        vm.activityPhase = .modelLoading(progress: 0.5)
+        vm.transitionPhase(to: .modelLoading(progress: 0.5))
         XCTAssertTrue(vm.isLoading)
 
-        vm.activityPhase = .idle
+        vm.transitionPhase(to: .idle)
         XCTAssertFalse(vm.isLoading)
     }
 
@@ -66,26 +66,27 @@ final class BackendActivityPhaseTests: XCTestCase {
         let vm = ChatViewModel()
         XCTAssertFalse(vm.isGenerating)
 
-        vm.activityPhase = .waitingForFirstToken
+        vm.transitionPhase(to: .waitingForFirstToken)
         XCTAssertTrue(vm.isGenerating)
 
-        vm.activityPhase = .streaming
+        vm.transitionPhase(to: .streaming)
         XCTAssertTrue(vm.isGenerating)
 
-        vm.activityPhase = .idle
+        vm.transitionPhase(to: .idle)
         XCTAssertFalse(vm.isGenerating)
     }
 
     func testIsLoadingFalseWhenGenerating() {
         let vm = ChatViewModel()
-        vm.activityPhase = .streaming
+        vm.transitionPhase(to: .waitingForFirstToken)
+        vm.transitionPhase(to: .streaming)
         XCTAssertFalse(vm.isLoading)
         XCTAssertTrue(vm.isGenerating)
     }
 
     func testIsGeneratingFalseWhenLoading() {
         let vm = ChatViewModel()
-        vm.activityPhase = .modelLoading(progress: 0.3)
+        vm.transitionPhase(to: .modelLoading(progress: 0.3))
         XCTAssertTrue(vm.isLoading)
         XCTAssertFalse(vm.isGenerating)
     }
@@ -97,9 +98,9 @@ final class BackendActivityPhaseTests: XCTestCase {
         var observations: [Bool] = []
         vm.onGeneratingChanged = { observations.append($0) }
 
-        vm.activityPhase = .waitingForFirstToken
-        vm.activityPhase = .streaming
-        vm.activityPhase = .idle
+        vm.transitionPhase(to: .waitingForFirstToken)
+        vm.transitionPhase(to: .streaming)
+        vm.transitionPhase(to: .idle)
 
         // waitingForFirstToken: generating becomes true
         // streaming: generating stays true -- no fire

--- a/Tests/BaseChatUITests/ChatInputBarLogicTests.swift
+++ b/Tests/BaseChatUITests/ChatInputBarLogicTests.swift
@@ -85,7 +85,7 @@ final class ChatInputBarLogicTests: XCTestCase {
     func test_canSend_falseWhileLoading() {
         let (vm, _) = makeViewModelWithMock()
         vm.inputText = "Hello"
-        vm.activityPhase = .modelLoading(progress: nil)
+        vm.transitionPhase(to: .modelLoading(progress: nil))
         XCTAssertTrue(vm.isLoading, "Precondition: isLoading should be true")
         XCTAssertFalse(canSend(vm), "canSend should be false while model is loading")
     }
@@ -93,7 +93,8 @@ final class ChatInputBarLogicTests: XCTestCase {
     func test_canSend_falseWhileGenerating() {
         let (vm, _) = makeViewModelWithMock()
         vm.inputText = "Hello"
-        vm.activityPhase = .streaming
+        vm.transitionPhase(to: .waitingForFirstToken)
+        vm.transitionPhase(to: .streaming)
         XCTAssertTrue(vm.isGenerating, "Precondition: isGenerating should be true")
         XCTAssertFalse(canSend(vm), "canSend should be false while generating")
     }
@@ -123,7 +124,7 @@ final class ChatInputBarLogicTests: XCTestCase {
 
     func test_textFieldDisabled_whileLoading() {
         let (vm, _) = makeViewModelWithMock()
-        vm.activityPhase = .modelLoading(progress: nil)
+        vm.transitionPhase(to: .modelLoading(progress: nil))
         XCTAssertTrue(isTextFieldDisabled(vm), "Text field should be disabled while model is loading")
     }
 
@@ -169,7 +170,8 @@ final class ChatInputBarLogicTests: XCTestCase {
             ChatMessageRecord(role: .user, content: "Hello", sessionID: sessionID),
             ChatMessageRecord(role: .assistant, content: "Hi", sessionID: sessionID)
         ]
-        vm.activityPhase = .streaming
+        vm.transitionPhase(to: .waitingForFirstToken)
+        vm.transitionPhase(to: .streaming)
         XCTAssertFalse(showRegenerateButton(vm), "Regenerate should be hidden while generating")
     }
 
@@ -192,7 +194,8 @@ final class ChatInputBarLogicTests: XCTestCase {
 
     func test_quickActionDisabled_whileGenerating() {
         let (vm, _) = makeViewModelWithMock()
-        vm.activityPhase = .streaming
+        vm.transitionPhase(to: .waitingForFirstToken)
+        vm.transitionPhase(to: .streaming)
         XCTAssertTrue(isQuickActionDisabled(vm), "Quick actions should be disabled while generating")
     }
 


### PR DESCRIPTION
## Summary

- Introduces `ActivityPhaseStateMachine` in `BaseChatCore` as the single source of truth for legal `BackendActivityPhase` transitions, replacing ad-hoc guards spread across three `ChatViewModel` extensions.
- Every production phase mutation now routes through a new internal `transitionPhase(to:)` on `ChatViewModel`, which validates against the machine and logs + ignores rejected events rather than trapping (per `CLAUDE.md`'s no-`assertionFailure`-in-recoverable-paths rule — the rejected events here are genuine async races).
- Ships exhaustive XCTest coverage of every `(from, to)` pair, Swift Testing `@Test(arguments:)` property tests over 128 seeded random walks, and regression tests for the four race scenarios from the original audit (load-fail-then-send, model switch mid-stream, rapid send/cancel chaining, scene phase backgrounding).

Closes #240

## Release Note

`BaseChatKit` now enforces `ChatViewModel.activityPhase` transitions through a single explicit state machine. Previously, every file that touched the phase held its own mental model of which transitions were legal, and several known race conditions (load failing while the user tapped send, switching models mid-stream, rapidly cancelling and resending) relied on implicit guards to stay consistent. With the state machine in place, late callbacks that arrive after the user has cancelled or swapped models are rejected at a single checkpoint and logged, so UI state can no longer diverge from backend reality through a stale event. The machine's legal transition graph is exhaustively covered by unit tests and a 128-sequence property test, giving downstream apps a contract they can rely on when composing their own activity indicators.

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 107 tests passed
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 391 tests passed
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 84 tests passed
- [x] Sabotage check: temporarily disabled the legality guard inside `ActivityPhaseStateMachine.transition(to:)`; `test_idle_to_streaming_illegal` failed as expected, then reverted and confirmed green.

Generated with Claude Code.