### PR TITLE
feat: tool call approval flow with edit, reject, and trusted-tools modes

### DIFF
--- a/Sources/BaseChatCore/Models/MessagePart.swift
+++ b/Sources/BaseChatCore/Models/MessagePart.swift
@@ -1,5 +1,27 @@
 import Foundation
 
+/// Lifecycle state of a tool call persisted inside a message bubble.
+///
+/// Stored alongside the ``MessagePart/toolCall(id:name:arguments:state:)``
+/// payload so history reloads can faithfully render whether a tool call is
+/// still waiting, was run, was rejected, or had its arguments edited before
+/// execution.
+public enum ToolCallApprovalState: String, Codable, Hashable, Sendable {
+
+    /// The model requested this call but the user has not yet decided.
+    case pending
+
+    /// The call ran (either auto-approved or explicitly approved).
+    case approved
+
+    /// The user approved execution after editing the arguments.
+    case edited
+
+    /// The user explicitly rejected the call. A synthetic rejection result
+    /// was fed back to the model.
+    case rejected
+}
+
 /// A discrete piece of content within a chat message.
 ///
 /// Messages can contain multiple parts to support multimodal input (images),
@@ -7,10 +29,16 @@ import Foundation
 /// independently typed so the UI can render appropriate controls (e.g.,
 /// inline images, collapsible tool call blocks) and backends can map parts
 /// to their native message formats.
-public enum MessagePart: Codable, Hashable, Sendable {
+public enum MessagePart: Hashable, Sendable {
     case text(String)
     case image(data: Data, mimeType: String)
-    case toolCall(id: String, name: String, arguments: String)
+
+    /// A tool invocation. `state` defaults to `.approved` to keep sources
+    /// that do not pass the argument compiling, and to match the
+    /// pre-approval-gate historical behaviour where every tool call that
+    /// landed in history had already executed.
+    case toolCall(id: String, name: String, arguments: String, state: ToolCallApprovalState = .approved)
+
     case toolResult(id: String, content: String)
 }
 
@@ -20,5 +48,102 @@ extension MessagePart {
     public var textContent: String? {
         if case .text(let t) = self { return t }
         return nil
+    }
+}
+
+// MARK: - Codable
+
+/// Custom Codable matches Swift's synthesised enum format so persisted
+/// history from before the approval feature still decodes. Adding
+/// ``ToolCallApprovalState`` to `.toolCall` via default parameter is source-
+/// compatible for callers, but the default synthesised decoder would reject
+/// old rows that lack the `state` key — so we decode it as optional and
+/// fall back to ``ToolCallApprovalState/approved``, which matches the
+/// semantics of pre-existing rows (they ran silently).
+extension MessagePart: Codable {
+
+    private enum RootKey: String, CodingKey {
+        case text
+        case image
+        case toolCall
+        case toolResult
+    }
+
+    private enum TextKey: String, CodingKey {
+        case _0
+    }
+
+    private enum ImageKey: String, CodingKey {
+        case data
+        case mimeType
+    }
+
+    private enum ToolCallKey: String, CodingKey {
+        case id
+        case name
+        case arguments
+        case state
+    }
+
+    private enum ToolResultKey: String, CodingKey {
+        case id
+        case content
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: RootKey.self)
+        if let textContainer = try? container.nestedContainer(keyedBy: TextKey.self, forKey: .text) {
+            self = .text(try textContainer.decode(String.self, forKey: ._0))
+            return
+        }
+        if let imageContainer = try? container.nestedContainer(keyedBy: ImageKey.self, forKey: .image) {
+            let data = try imageContainer.decode(Data.self, forKey: .data)
+            let mimeType = try imageContainer.decode(String.self, forKey: .mimeType)
+            self = .image(data: data, mimeType: mimeType)
+            return
+        }
+        if let toolCallContainer = try? container.nestedContainer(keyedBy: ToolCallKey.self, forKey: .toolCall) {
+            let id = try toolCallContainer.decode(String.self, forKey: .id)
+            let name = try toolCallContainer.decode(String.self, forKey: .name)
+            let arguments = try toolCallContainer.decode(String.self, forKey: .arguments)
+            let state = try toolCallContainer.decodeIfPresent(ToolCallApprovalState.self, forKey: .state) ?? .approved
+            self = .toolCall(id: id, name: name, arguments: arguments, state: state)
+            return
+        }
+        if let toolResultContainer = try? container.nestedContainer(keyedBy: ToolResultKey.self, forKey: .toolResult) {
+            let id = try toolResultContainer.decode(String.self, forKey: .id)
+            let content = try toolResultContainer.decode(String.self, forKey: .content)
+            self = .toolResult(id: id, content: content)
+            return
+        }
+        throw DecodingError.dataCorrupted(
+            DecodingError.Context(
+                codingPath: decoder.codingPath,
+                debugDescription: "No recognised MessagePart case found in payload"
+            )
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: RootKey.self)
+        switch self {
+        case .text(let text):
+            var nested = container.nestedContainer(keyedBy: TextKey.self, forKey: .text)
+            try nested.encode(text, forKey: ._0)
+        case .image(let data, let mimeType):
+            var nested = container.nestedContainer(keyedBy: ImageKey.self, forKey: .image)
+            try nested.encode(data, forKey: .data)
+            try nested.encode(mimeType, forKey: .mimeType)
+        case .toolCall(let id, let name, let arguments, let state):
+            var nested = container.nestedContainer(keyedBy: ToolCallKey.self, forKey: .toolCall)
+            try nested.encode(id, forKey: .id)
+            try nested.encode(name, forKey: .name)
+            try nested.encode(arguments, forKey: .arguments)
+            try nested.encode(state, forKey: .state)
+        case .toolResult(let id, let content):
+            var nested = container.nestedContainer(keyedBy: ToolResultKey.self, forKey: .toolResult)
+            try nested.encode(id, forKey: .id)
+            try nested.encode(content, forKey: .content)
+        }
     }
 }

--- a/Sources/BaseChatCore/Models/ToolCallApprovalMode.swift
+++ b/Sources/BaseChatCore/Models/ToolCallApprovalMode.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Policy that controls whether tool calls run automatically or require
+/// explicit user approval before execution.
+///
+/// The approval gate lives on ``InferenceService/toolApprovalCoordinator``.
+/// BaseChatKit defaults to ``alwaysAsk`` because tool calling can invoke
+/// destructive side effects (file deletion, HTTP requests, outbound email)
+/// that must never run silently in a framework whose host app cannot predict
+/// which tools a model will request. Apps that know their tools are safe —
+/// for example a read-only web search — can opt into ``autoApprove`` or
+/// ``trustedTools(_:)`` at setup time.
+public enum ToolCallApprovalMode: Sendable, Equatable {
+
+    /// Every tool call is paused until the user decides what to do.
+    case alwaysAsk
+
+    /// Tool calls whose name matches one of the listed names auto-approve;
+    /// all others are paused for user decision.
+    ///
+    /// This is the right mode for apps that ship a mix of safe read-only
+    /// tools and risky write tools from the same provider — e.g. auto-allow
+    /// `get_weather` but gate `send_email`.
+    case trustedTools(Set<String>)
+
+    /// All tool calls run immediately, matching pre-approval behaviour.
+    ///
+    /// Only select this mode when you control every tool the model can see
+    /// and have audited them for safe, reversible side effects.
+    case autoApprove
+
+    /// Returns `true` when a tool of the given name runs without prompting.
+    public func allowsAutoApproval(of toolName: String) -> Bool {
+        switch self {
+        case .alwaysAsk:
+            return false
+        case .trustedTools(let names):
+            return names.contains(toolName)
+        case .autoApprove:
+            return true
+        }
+    }
+}
+
+/// The decision a user (or approval policy) makes for a pending tool call.
+public enum ToolCallApprovalDecision: Sendable, Equatable {
+
+    /// Execute the tool with the original or edited arguments.
+    ///
+    /// - Parameter arguments: The JSON arguments to pass to the tool. Pass
+    ///   the original arguments to approve unchanged, or an edited JSON
+    ///   string to run with user-modified inputs.
+    case approved(arguments: String)
+
+    /// Skip execution and feed a synthetic rejection message back to the
+    /// model as if the tool returned it.
+    ///
+    /// - Parameter reason: Human-readable reason shown to both the user and
+    ///   the model. When `nil`, a generic message is used.
+    case rejected(reason: String?)
+}

--- a/Sources/BaseChatCore/Services/ApprovingToolProvider.swift
+++ b/Sources/BaseChatCore/Services/ApprovingToolProvider.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Wraps a host-provided ``ToolProvider`` with an approval gate.
+///
+/// ``InferenceService`` installs this wrapper transparently when a tool
+/// provider is configured so backends can call `execute(_:)` without knowing
+/// whether the gate exists. The wrapper forwards the tool list through
+/// unchanged but routes every execution through
+/// ``ToolCallApprovalCoordinator/requestDecision(for:definition:)``.
+///
+/// When the decision is `.rejected`, the wrapper synthesises an error-style
+/// ``ToolResult`` containing the rejection reason instead of calling the
+/// underlying provider. This lets the model see the rejection and continue
+/// without a dangling tool-call round.
+///
+/// The wrapper is marked `@unchecked Sendable` because `ToolProvider` only
+/// requires `Sendable` conformance; the underlying provider is responsible
+/// for its own state synchronisation. The coordinator is `@MainActor`, so
+/// the approval hop crosses actors once per call.
+public final class ApprovingToolProvider: ToolProvider, @unchecked Sendable {
+
+    public let underlying: any ToolProvider
+    private let coordinator: ToolCallApprovalCoordinator
+
+    public var tools: [ToolDefinition] {
+        underlying.tools
+    }
+
+    public init(underlying: any ToolProvider, coordinator: ToolCallApprovalCoordinator) {
+        self.underlying = underlying
+        self.coordinator = coordinator
+    }
+
+    public func execute(_ toolCall: ToolCall) async throws -> ToolResult {
+        // Look up the tool definition on the underlying provider so the
+        // approval sheet can show a schema-aware editor. Tools with an
+        // unknown name (backend bug or streaming race) still surface to
+        // the user via the sheet; the UI falls back to a raw JSON editor.
+        let definition = underlying.tools.first { $0.name == toolCall.name }
+
+        let decision = await coordinator.requestDecision(for: toolCall, definition: definition)
+
+        switch decision {
+        case .approved(let arguments):
+            let effective: ToolCall
+            if arguments == toolCall.arguments {
+                effective = toolCall
+            } else {
+                effective = ToolCall(id: toolCall.id, name: toolCall.name, arguments: arguments)
+            }
+            return try await underlying.execute(effective)
+
+        case .rejected(let reason):
+            // Synthetic rejection result matches the tool's call ID so the
+            // backend can hand it back to the model as the tool's answer.
+            // `isError: true` gives the model a strong hint to try another
+            // approach or ask the user for clarification.
+            let message = reason ?? "User rejected this tool call."
+            return ToolResult(
+                toolCallID: toolCall.id,
+                content: message,
+                isError: true
+            )
+        }
+    }
+}

--- a/Sources/BaseChatCore/Services/InferenceService.swift
+++ b/Sources/BaseChatCore/Services/InferenceService.swift
@@ -415,10 +415,45 @@ public final class InferenceService {
         didSet { propagateToolStateToBackend() }
     }
 
+    /// Coordinator that gates tool execution on user approval.
+    ///
+    /// Defaults to ``ToolCallApprovalMode/alwaysAsk`` so destructive tools
+    /// never run silently. Host apps that ship only read-only tools (or
+    /// fully trust their tool set) can flip ``ToolCallApprovalCoordinator/mode``
+    /// to ``ToolCallApprovalMode/autoApprove`` at startup.
+    ///
+    /// Lazily created on first access because the nonisolated `init()` cannot
+    /// synthesise a `@MainActor`-isolated default; the getter runs on the
+    /// main actor like the rest of the service.
+    public var toolApprovalCoordinator: ToolCallApprovalCoordinator {
+        if let existing = _toolApprovalCoordinator {
+            return existing
+        }
+        let created = ToolCallApprovalCoordinator()
+        _toolApprovalCoordinator = created
+        return created
+    }
+
+    private var _toolApprovalCoordinator: ToolCallApprovalCoordinator?
+
     /// Single propagation point so didSet and generate() stay in sync.
+    ///
+    /// Wraps `toolProvider` in ``ApprovingToolProvider`` before handing it to
+    /// the backend so every tool execution routes through
+    /// ``toolApprovalCoordinator``. Backends do not need to know the wrapper
+    /// exists — `ToolProvider` conformance is forwarded transparently.
     private func propagateToolStateToBackend() {
         guard let toolBackend = backend as? ToolCallingBackend else { return }
-        toolBackend.setToolProvider(toolProvider)
+        let effectiveProvider: (any ToolProvider)?
+        if let toolProvider {
+            effectiveProvider = ApprovingToolProvider(
+                underlying: toolProvider,
+                coordinator: toolApprovalCoordinator
+            )
+        } else {
+            effectiveProvider = nil
+        }
+        toolBackend.setToolProvider(effectiveProvider)
         toolBackend.setTools(toolProvider?.tools ?? [])
         toolBackend.toolCallObserver = toolCallObserver
     }
@@ -708,6 +743,11 @@ public final class InferenceService {
             finishAndDiscard(req.token, error: CancellationError())
         }
         requestQueue.removeAll()
+
+        // Releasing any tool-call approval continuations prevents the
+        // approval sheet from dangling when the user cancels generation.
+        // Only touch the coordinator if it was actually created.
+        _toolApprovalCoordinator?.rejectAllPending(reason: "Generation cancelled")
     }
 
     /// Notifies the service that generation has finished (called by view model

--- a/Sources/BaseChatCore/Services/ToolCallApprovalCoordinator.swift
+++ b/Sources/BaseChatCore/Services/ToolCallApprovalCoordinator.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Observation
+
+/// Coordinates user approval of model-requested tool calls.
+///
+/// The coordinator is the single gate that tool execution paths traverse
+/// before a backend runs a tool. It is owned by ``InferenceService`` and
+/// wired into the execution pipeline by wrapping the host app's
+/// ``ToolProvider`` in an ``ApprovingToolProvider``.
+///
+/// ## Flow
+///
+/// 1. A backend asks its (wrapped) provider to execute a ``ToolCall``.
+/// 2. The wrapper calls ``requestDecision(for:)`` on this coordinator.
+/// 3. If the active ``mode`` auto-approves the call, the call runs immediately.
+/// 4. Otherwise the coordinator appends the call to ``pendingApprovals`` and
+///    suspends on a `CheckedContinuation` until the UI invokes
+///    ``resolve(id:with:)``.
+///
+/// The coordinator is `@MainActor` isolated so the UI can observe
+/// ``pendingApprovals`` directly and mutate the active mode in response to
+/// user preferences.
+@Observable
+@MainActor
+public final class ToolCallApprovalCoordinator {
+
+    /// A pending tool call that is waiting for user input.
+    public struct PendingApproval: Identifiable, Sendable, Equatable {
+
+        public let id: String
+        public let call: ToolCall
+        public let requestedAt: Date
+
+        /// The tool definition that backs this call, when known. The sheet
+        /// uses the schema to drive the edit UI; `nil` means the UI falls
+        /// back to a raw JSON editor.
+        public let definition: ToolDefinition?
+
+        public init(id: String, call: ToolCall, definition: ToolDefinition?, requestedAt: Date = Date()) {
+            self.id = id
+            self.call = call
+            self.definition = definition
+            self.requestedAt = requestedAt
+        }
+    }
+
+    // MARK: - Observable state
+
+    /// The active approval policy. Mutating this does not retroactively
+    /// resolve calls already waiting in ``pendingApprovals``; it only
+    /// affects calls that arrive after the change.
+    public var mode: ToolCallApprovalMode
+
+    /// Tool calls currently waiting on user input, in arrival order.
+    public private(set) var pendingApprovals: [PendingApproval] = []
+
+    // MARK: - Internal state
+
+    /// Continuations suspended on ``requestDecision(for:)``.
+    ///
+    /// Keyed by the pending approval ID (which matches the tool call ID).
+    /// Stored outside observable state because `CheckedContinuation` is not
+    /// `Equatable` and we don't want to drive view updates from it.
+    private var continuations: [String: CheckedContinuation<ToolCallApprovalDecision, Never>] = [:]
+
+    /// Records the most recent decision per pending ID so repeat
+    /// ``resolve(id:with:)`` calls (e.g. from double-taps) are ignored.
+    private var resolvedIDs: Set<String> = []
+
+    public init(mode: ToolCallApprovalMode = .alwaysAsk) {
+        self.mode = mode
+    }
+
+    // MARK: - API
+
+    /// Requests a decision for the given tool call.
+    ///
+    /// - Parameters:
+    ///   - call: The call the model wants to run.
+    ///   - definition: Optional tool definition used by the edit sheet to
+    ///     show a schema-aware argument editor.
+    /// - Returns: The user (or policy) decision. When the active mode
+    ///   auto-approves, returns `.approved(arguments:)` with the original
+    ///   arguments without going through the UI at all.
+    public func requestDecision(
+        for call: ToolCall,
+        definition: ToolDefinition? = nil
+    ) async -> ToolCallApprovalDecision {
+        if mode.allowsAutoApproval(of: call.name) {
+            return .approved(arguments: call.arguments)
+        }
+
+        let pending = PendingApproval(id: call.id, call: call, definition: definition)
+        pendingApprovals.append(pending)
+
+        return await withCheckedContinuation { continuation in
+            // If a decision has already been filed synchronously (e.g. a
+            // test injected it before calling `requestDecision`), short-
+            // circuit without storing the continuation.
+            if resolvedIDs.contains(pending.id) {
+                resolvedIDs.remove(pending.id)
+                pendingApprovals.removeAll { $0.id == pending.id }
+                continuation.resume(returning: .rejected(reason: "Already resolved"))
+                return
+            }
+            continuations[pending.id] = continuation
+        }
+    }
+
+    /// Resolves a pending approval with the given decision.
+    ///
+    /// Called by the UI when the user taps Approve, Reject, or submits an
+    /// edited-arguments sheet. Safe to call multiple times — only the first
+    /// resolution fires; subsequent calls are dropped.
+    public func resolve(id: String, with decision: ToolCallApprovalDecision) {
+        guard let continuation = continuations.removeValue(forKey: id) else {
+            // Either unknown or already resolved. Record so a late
+            // `requestDecision` can see it.
+            resolvedIDs.insert(id)
+            return
+        }
+        pendingApprovals.removeAll { $0.id == id }
+        continuation.resume(returning: decision)
+    }
+
+    /// Rejects every pending approval with a single reason, typically when
+    /// the user cancels the entire generation.
+    public func rejectAllPending(reason: String? = "User cancelled") {
+        let toRelease = continuations
+        continuations.removeAll()
+        pendingApprovals.removeAll()
+        for (_, continuation) in toRelease {
+            continuation.resume(returning: .rejected(reason: reason))
+        }
+    }
+}

--- a/Sources/BaseChatUI/Views/Chat/ChatView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ChatView.swift
@@ -284,7 +284,8 @@ public struct ChatView: View {
                         MessageBubbleView(
                             message: message,
                             isStreaming: isMessageStreaming(message),
-                            isPinned: viewModel.isMessagePinned(id: message.id)
+                            isPinned: viewModel.isMessagePinned(id: message.id),
+                            approvalCoordinator: viewModel.inferenceService.toolApprovalCoordinator
                         )
                         .messageActionMenu(message: message, viewModel: viewModel)
                         .id(message.id)

--- a/Sources/BaseChatUI/Views/Chat/EditToolArgumentsSheet.swift
+++ b/Sources/BaseChatUI/Views/Chat/EditToolArgumentsSheet.swift
@@ -1,0 +1,201 @@
+import SwiftUI
+import BaseChatCore
+
+/// Sheet that lets the user inspect and edit the arguments of a pending
+/// tool call before approving execution.
+///
+/// Shows the tool's JSON schema (when provided) as guidance alongside a
+/// free-form JSON editor. The "Run" button is disabled while the text is
+/// not well-formed JSON — there is no full JSON Schema validator yet, so
+/// we enforce parseability only and leave type-level checks to the tool
+/// itself. This is a deliberate minimum-viable gate: a follow-up can add
+/// real schema validation without changing the sheet's contract.
+struct EditToolArgumentsSheet: View {
+
+    let call: ToolCall
+    let definition: ToolDefinition?
+    let onSubmit: (String) -> Void
+    let onCancel: () -> Void
+
+    @State private var arguments: String
+    @State private var validationError: String? = nil
+    @Environment(\.dismiss) private var dismiss
+
+    init(
+        call: ToolCall,
+        definition: ToolDefinition?,
+        onSubmit: @escaping (String) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self.call = call
+        self.definition = definition
+        self.onSubmit = onSubmit
+        self.onCancel = onCancel
+        _arguments = State(initialValue: Self.prettyPrint(call.arguments))
+    }
+
+    var body: some View {
+        #if os(macOS)
+        sheetContent
+            .frame(minWidth: 480, minHeight: 420)
+        #else
+        NavigationStack {
+            sheetContent
+        }
+        #endif
+    }
+
+    private var sheetContent: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            header
+
+            if let definition {
+                schemaSection(for: definition)
+            }
+
+            Text("Arguments")
+                .font(.callout.bold())
+
+            argumentsEditor
+
+            if let validationError {
+                Label(validationError, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            Spacer(minLength: 0)
+
+            footer
+        }
+        .padding()
+        .onChange(of: arguments) { _, newValue in
+            validationError = Self.validationMessage(for: newValue)
+        }
+    }
+
+    // MARK: - Sections
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Review tool call")
+                .font(.title3.bold())
+            Text(call.name)
+                .font(.body.monospaced())
+                .foregroundStyle(.secondary)
+            if let description = definition?.description, !description.isEmpty {
+                Text(description)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func schemaSection(for definition: ToolDefinition) -> some View {
+        DisclosureGroup("Schema") {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(definition.inputSchema.properties.keys.sorted(), id: \.self) { key in
+                    if let prop = definition.inputSchema.properties[key] {
+                        schemaRow(key: key, property: prop, required: definition.inputSchema.required.contains(key))
+                    }
+                }
+            }
+            .padding(.top, 4)
+        }
+    }
+
+    private func schemaRow(key: String, property: ToolParameterProperty, required: Bool) -> some View {
+        HStack(alignment: .top, spacing: 6) {
+            Text(key)
+                .font(.caption.monospaced().bold())
+            Text("(\(property.type)\(required ? ", required" : ""))")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text(property.description)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var argumentsEditor: some View {
+        TextEditor(text: $arguments)
+            .font(.callout.monospaced())
+            .frame(minHeight: 120)
+            .padding(6)
+            .background(.fill.quaternary, in: RoundedRectangle(cornerRadius: 6))
+            .accessibilityLabel("Tool arguments JSON")
+    }
+
+    private var footer: some View {
+        HStack {
+            Button("Cancel") {
+                onCancel()
+            }
+            .keyboardShortcut(.cancelAction)
+
+            Spacer()
+
+            Button("Run") {
+                onSubmit(arguments)
+            }
+            .buttonStyle(.borderedProminent)
+            .keyboardShortcut(.defaultAction)
+            .disabled(validationError != nil)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Pretty-prints JSON when possible, otherwise returns the raw string so
+    /// the user still sees something editable.
+    static func prettyPrint(_ raw: String) -> String {
+        guard let data = raw.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              let pretty = try? JSONSerialization.data(
+                withJSONObject: object,
+                options: [.prettyPrinted, .sortedKeys]
+              ),
+              let string = String(data: pretty, encoding: .utf8) else {
+            return raw
+        }
+        return string
+    }
+
+    /// Returns a human-readable error when the arguments are not parseable JSON,
+    /// or `nil` when they are valid. Empty strings are treated as `{}` — most
+    /// tool schemas default missing keys to required, which the tool itself
+    /// surfaces as an error if they aren't provided.
+    static func validationMessage(for text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return nil }
+        guard let data = trimmed.data(using: .utf8) else {
+            return "Arguments are not valid UTF-8."
+        }
+        do {
+            _ = try JSONSerialization.jsonObject(with: data)
+            return nil
+        } catch {
+            return "Arguments are not valid JSON."
+        }
+    }
+}
+
+#Preview {
+    EditToolArgumentsSheet(
+        call: ToolCall(id: "call_1", name: "send_email", arguments: "{\"to\":\"user@example.com\",\"subject\":\"Hi\"}"),
+        definition: ToolDefinition(
+            name: "send_email",
+            description: "Send an email to a given address.",
+            inputSchema: ToolInputSchema(
+                properties: [
+                    "to": ToolParameterProperty(type: "string", description: "Destination address"),
+                    "subject": ToolParameterProperty(type: "string", description: "Subject line")
+                ],
+                required: ["to"]
+            )
+        ),
+        onSubmit: { _ in },
+        onCancel: { }
+    )
+}

--- a/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
@@ -13,6 +13,7 @@ public struct MessageBubbleView: View {
     public let message: ChatMessageRecord
     public let isStreaming: Bool
     public let isPinned: Bool
+    let approvalCoordinator: ToolCallApprovalCoordinator?
 
     @Environment(\.horizontalSizeClass) private var sizeClass
 
@@ -20,6 +21,19 @@ public struct MessageBubbleView: View {
         self.message = message
         self.isStreaming = isStreaming
         self.isPinned = isPinned
+        self.approvalCoordinator = nil
+    }
+
+    init(
+        message: ChatMessageRecord,
+        isStreaming: Bool,
+        isPinned: Bool,
+        approvalCoordinator: ToolCallApprovalCoordinator?
+    ) {
+        self.message = message
+        self.isStreaming = isStreaming
+        self.isPinned = isPinned
+        self.approvalCoordinator = approvalCoordinator
     }
 
     // MARK: - Body
@@ -56,7 +70,11 @@ public struct MessageBubbleView: View {
 
     private var userBubble: some View {
         VStack(alignment: .trailing, spacing: 4) {
-            MessagePartsView(parts: message.contentParts, role: .user)
+            MessagePartsView(
+                parts: message.contentParts,
+                role: .user,
+                approvalCoordinator: approvalCoordinator
+            )
 
             timestampLabel
                 .foregroundStyle(.white.opacity(0.7))
@@ -73,7 +91,11 @@ public struct MessageBubbleView: View {
             if message.contentParts.isEmpty && isStreaming {
                 streamingPlaceholder
             } else {
-                MessagePartsView(parts: message.contentParts, role: .assistant)
+                MessagePartsView(
+                    parts: message.contentParts,
+                    role: .assistant,
+                    approvalCoordinator: approvalCoordinator
+                )
             }
 
             if isStreaming && !message.contentParts.isEmpty {

--- a/Sources/BaseChatUI/Views/Chat/MessagePartsView.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessagePartsView.swift
@@ -6,13 +6,41 @@ import BaseChatCore
 /// Text parts are rendered inline (markdown for assistant, plain for user),
 /// images are shown as thumbnails, and tool calls/results are displayed as
 /// labeled disclosure groups.
+///
+/// When the optional ``approvalCoordinator`` is provided and a tool call
+/// has state ``ToolCallApprovalState/pending``, the bubble renders Approve /
+/// Reject / Edit controls that route back through the coordinator. Without
+/// the coordinator the view is strictly read-only, matching the legacy
+/// behaviour used by snapshot tests and preview contexts.
 struct MessagePartsView: View {
     let parts: [MessagePart]
     let role: MessageRole
+    var approvalCoordinator: ToolCallApprovalCoordinator? = nil
+
+    @State private var editingCall: ToolCall? = nil
+    @State private var editingDefinition: ToolDefinition? = nil
 
     var body: some View {
         ForEach(Array(parts.enumerated()), id: \.offset) { _, part in
             partView(for: part)
+        }
+        .sheet(item: $editingCall) { call in
+            EditToolArgumentsSheet(
+                call: call,
+                definition: editingDefinition,
+                onSubmit: { newArguments in
+                    approvalCoordinator?.resolve(
+                        id: call.id,
+                        with: .approved(arguments: newArguments)
+                    )
+                    editingCall = nil
+                    editingDefinition = nil
+                },
+                onCancel: {
+                    editingCall = nil
+                    editingDefinition = nil
+                }
+            )
         }
     }
 
@@ -25,8 +53,8 @@ struct MessagePartsView: View {
         case .image(let data, _):
             imageView(data)
 
-        case .toolCall(let id, let name, let arguments):
-            toolCallView(id: id, name: name, arguments: arguments)
+        case .toolCall(let id, let name, let arguments, let state):
+            toolCallView(id: id, name: name, arguments: arguments, state: state)
 
         case .toolResult(let id, let content):
             toolResultView(id: id, content: content)
@@ -66,18 +94,71 @@ struct MessagePartsView: View {
         #endif
     }
 
-    private func toolCallView(id: String, name: String, arguments: String) -> some View {
-        DisclosureGroup {
-            Text(arguments)
-                .font(.caption.monospaced())
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        } label: {
-            Label(name, systemImage: "wrench")
-                .font(.callout.bold())
+    private func toolCallView(
+        id: String,
+        name: String,
+        arguments: String,
+        state: ToolCallApprovalState
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            DisclosureGroup {
+                Text(arguments)
+                    .font(.caption.monospaced())
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } label: {
+                HStack(spacing: 6) {
+                    Label(name, systemImage: icon(for: state))
+                        .font(.callout.bold())
+                        .foregroundStyle(foregroundStyle(for: state))
+                    Spacer()
+                    statusBadge(for: state)
+                }
+            }
+
+            if state == .pending && approvalCoordinator != nil {
+                approvalControls(id: id, name: name, arguments: arguments)
+            }
         }
         .padding(8)
-        .background(.fill.quaternary, in: RoundedRectangle(cornerRadius: 8))
+        .background(backgroundStyle(for: state), in: RoundedRectangle(cornerRadius: 8))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel(for: state, name: name))
+    }
+
+    @ViewBuilder
+    private func approvalControls(id: String, name: String, arguments: String) -> some View {
+        HStack(spacing: 8) {
+            Button {
+                approvalCoordinator?.resolve(id: id, with: .approved(arguments: arguments))
+            } label: {
+                Label("Approve", systemImage: "checkmark.circle.fill")
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.green)
+            .controlSize(.small)
+
+            Button {
+                let call = ToolCall(id: id, name: name, arguments: arguments)
+                editingDefinition = approvalCoordinator?
+                    .pendingApprovals
+                    .first(where: { $0.id == id })?
+                    .definition
+                editingCall = call
+            } label: {
+                Label("Edit", systemImage: "pencil")
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+
+            Button(role: .destructive) {
+                approvalCoordinator?.resolve(id: id, with: .rejected(reason: "User rejected tool call"))
+            } label: {
+                Label("Reject", systemImage: "xmark.circle")
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
     }
 
     private func toolResultView(id: String, content: String) -> some View {
@@ -93,6 +174,73 @@ struct MessagePartsView: View {
         .padding(8)
         .background(.fill.quaternary, in: RoundedRectangle(cornerRadius: 8))
     }
+
+    // MARK: - Styling helpers
+
+    private func icon(for state: ToolCallApprovalState) -> String {
+        switch state {
+        case .pending:  return "clock"
+        case .approved: return "wrench"
+        case .edited:   return "wrench.adjustable"
+        case .rejected: return "nosign"
+        }
+    }
+
+    @ViewBuilder
+    private func statusBadge(for state: ToolCallApprovalState) -> some View {
+        switch state {
+        case .pending:
+            Text("Pending approval")
+                .font(.caption2.bold())
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(Color.orange.opacity(0.2), in: Capsule())
+                .foregroundStyle(.orange)
+        case .edited:
+            Text("Edited")
+                .font(.caption2.bold())
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(Color.blue.opacity(0.2), in: Capsule())
+                .foregroundStyle(.blue)
+        case .rejected:
+            Text("Rejected")
+                .font(.caption2.bold())
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(Color.red.opacity(0.2), in: Capsule())
+                .foregroundStyle(.red)
+        case .approved:
+            EmptyView()
+        }
+    }
+
+    private func foregroundStyle(for state: ToolCallApprovalState) -> Color {
+        switch state {
+        case .pending:  return .orange
+        case .rejected: return .red
+        case .edited:   return .blue
+        case .approved: return .primary
+        }
+    }
+
+    private func backgroundStyle(for state: ToolCallApprovalState) -> AnyShapeStyle {
+        switch state {
+        case .pending:  return AnyShapeStyle(Color.orange.opacity(0.1))
+        case .rejected: return AnyShapeStyle(Color.red.opacity(0.08))
+        case .edited:   return AnyShapeStyle(Color.blue.opacity(0.08))
+        case .approved: return AnyShapeStyle(.fill.quaternary)
+        }
+    }
+
+    private func accessibilityLabel(for state: ToolCallApprovalState, name: String) -> String {
+        switch state {
+        case .pending:  return "Tool call \(name), waiting for approval"
+        case .approved: return "Tool call \(name)"
+        case .edited:   return "Tool call \(name), edited before execution"
+        case .rejected: return "Tool call \(name), rejected by user"
+        }
+    }
 }
 
 #Preview("Text Only") {
@@ -101,6 +249,14 @@ struct MessagePartsView: View {
 
 #Preview("Tool Call") {
     MessagePartsView(parts: [.toolCall(id: "1", name: "get_weather", arguments: "{\"city\": \"London\"}")], role: .assistant)
+}
+
+#Preview("Pending Tool Call") {
+    MessagePartsView(
+        parts: [.toolCall(id: "1", name: "send_email", arguments: "{\"to\": \"user@example.com\", \"subject\": \"Hi\"}", state: .pending)],
+        role: .assistant,
+        approvalCoordinator: ToolCallApprovalCoordinator()
+    )
 }
 
 #Preview("Mixed Parts") {

--- a/Tests/BaseChatCoreTests/ToolCallApprovalTests.swift
+++ b/Tests/BaseChatCoreTests/ToolCallApprovalTests.swift
@@ -1,0 +1,267 @@
+import XCTest
+@testable import BaseChatCore
+import BaseChatTestSupport
+
+/// Exercises the approval gate in isolation from any backend. The gate
+/// enforces three behaviours the rest of BaseChatKit depends on:
+///
+/// - `.alwaysAsk` pauses every call until the UI resolves it.
+/// - `.trustedTools` auto-approves matches and pauses everything else.
+/// - `.autoApprove` passes every call through untouched.
+///
+/// Rejection and argument-edit paths also live here because they are
+/// decisions the gate itself makes before any `ToolProvider.execute` runs.
+@MainActor
+final class ToolCallApprovalTests: XCTestCase {
+
+    private func makeCall(id: String = "call_1", name: String = "send_email", arguments: String = #"{"to":"a@b.com"}"#) -> ToolCall {
+        ToolCall(id: id, name: name, arguments: arguments)
+    }
+
+    // MARK: - Mode behaviour
+
+    func test_autoApprove_returnsApprovedWithOriginalArguments() async {
+        let coordinator = ToolCallApprovalCoordinator(mode: .autoApprove)
+        let call = makeCall()
+
+        let decision = await coordinator.requestDecision(for: call)
+
+        guard case .approved(let args) = decision else {
+            XCTFail("Expected .approved, got \(decision)")
+            return
+        }
+        XCTAssertEqual(args, call.arguments)
+        XCTAssertTrue(coordinator.pendingApprovals.isEmpty)
+    }
+
+    func test_alwaysAsk_suspendsUntilResolved() async {
+        let coordinator = ToolCallApprovalCoordinator(mode: .alwaysAsk)
+        let call = makeCall()
+
+        let task = Task { () -> ToolCallApprovalDecision in
+            await coordinator.requestDecision(for: call)
+        }
+
+        // Poll for the pending approval showing up. No artificial sleeps —
+        // we just yield to the scheduler until the continuation is filed.
+        for _ in 0..<100 {
+            if !coordinator.pendingApprovals.isEmpty { break }
+            await Task.yield()
+        }
+
+        XCTAssertEqual(coordinator.pendingApprovals.count, 1)
+        XCTAssertEqual(coordinator.pendingApprovals.first?.id, call.id)
+
+        coordinator.resolve(id: call.id, with: .approved(arguments: call.arguments))
+
+        let decision = await task.value
+        guard case .approved = decision else {
+            XCTFail("Expected .approved, got \(decision)")
+            return
+        }
+        XCTAssertTrue(coordinator.pendingApprovals.isEmpty)
+    }
+
+    func test_trustedTools_autoApprovesListedName() async {
+        let coordinator = ToolCallApprovalCoordinator(mode: .trustedTools(["get_weather"]))
+        let trusted = makeCall(name: "get_weather", arguments: "{}")
+
+        let decision = await coordinator.requestDecision(for: trusted)
+
+        guard case .approved = decision else {
+            XCTFail("Trusted tool should auto-approve, got \(decision)")
+            return
+        }
+        XCTAssertTrue(coordinator.pendingApprovals.isEmpty)
+    }
+
+    func test_trustedTools_stillPausesOtherTools() async {
+        let coordinator = ToolCallApprovalCoordinator(mode: .trustedTools(["get_weather"]))
+        let risky = makeCall(name: "delete_file")
+
+        let task = Task { () -> ToolCallApprovalDecision in
+            await coordinator.requestDecision(for: risky)
+        }
+        for _ in 0..<100 {
+            if !coordinator.pendingApprovals.isEmpty { break }
+            await Task.yield()
+        }
+        XCTAssertEqual(coordinator.pendingApprovals.count, 1)
+
+        coordinator.resolve(id: risky.id, with: .rejected(reason: "nope"))
+        let decision = await task.value
+        guard case .rejected(let reason) = decision else {
+            XCTFail("Expected .rejected, got \(decision)")
+            return
+        }
+        XCTAssertEqual(reason, "nope")
+    }
+
+    // MARK: - Rejection synthesis through ApprovingToolProvider
+
+    func test_approvingProvider_rejectPath_producesSyntheticErrorResult() async throws {
+        let coordinator = ToolCallApprovalCoordinator(mode: .alwaysAsk)
+        let underlying = MockToolProvider(
+            tools: [ToolDefinition(
+                name: "delete_file",
+                description: "Delete a file",
+                inputSchema: ToolInputSchema(properties: [:])
+            )]
+        )
+        let wrapper = ApprovingToolProvider(underlying: underlying, coordinator: coordinator)
+        let call = makeCall(name: "delete_file")
+
+        let execTask = Task { try await wrapper.execute(call) }
+        for _ in 0..<100 {
+            if !coordinator.pendingApprovals.isEmpty { break }
+            await Task.yield()
+        }
+        coordinator.resolve(id: call.id, with: .rejected(reason: "User rejected"))
+
+        let result = try await execTask.value
+        XCTAssertTrue(result.isError)
+        XCTAssertEqual(result.toolCallID, call.id)
+        XCTAssertEqual(result.content, "User rejected")
+        // The underlying provider must never see the call.
+        XCTAssertEqual(underlying.receivedCalls.count, 0)
+    }
+
+    func test_approvingProvider_editPath_passesEditedArgumentsToUnderlying() async throws {
+        let coordinator = ToolCallApprovalCoordinator(mode: .alwaysAsk)
+        let underlying = MockToolProvider(
+            tools: [ToolDefinition(
+                name: "send_email",
+                description: "Send",
+                inputSchema: ToolInputSchema(properties: [:])
+            )],
+            results: ["send_email": ToolResult(toolCallID: "", content: "sent")]
+        )
+        let wrapper = ApprovingToolProvider(underlying: underlying, coordinator: coordinator)
+        let call = makeCall(name: "send_email", arguments: #"{"to":"old@example.com"}"#)
+
+        let execTask = Task { try await wrapper.execute(call) }
+        for _ in 0..<100 {
+            if !coordinator.pendingApprovals.isEmpty { break }
+            await Task.yield()
+        }
+        coordinator.resolve(
+            id: call.id,
+            with: .approved(arguments: #"{"to":"new@example.com"}"#)
+        )
+
+        let result = try await execTask.value
+        XCTAssertEqual(result.content, "sent")
+        XCTAssertEqual(underlying.receivedCalls.count, 1)
+        XCTAssertEqual(
+            underlying.receivedCalls.first?.arguments,
+            #"{"to":"new@example.com"}"#
+        )
+    }
+
+    func test_approvingProvider_autoApproveMode_forwardsWithoutPause() async throws {
+        let coordinator = ToolCallApprovalCoordinator(mode: .autoApprove)
+        let underlying = MockToolProvider(
+            tools: [ToolDefinition(
+                name: "get_weather",
+                description: "",
+                inputSchema: ToolInputSchema(properties: [:])
+            )],
+            results: ["get_weather": ToolResult(toolCallID: "", content: "sunny")]
+        )
+        let wrapper = ApprovingToolProvider(underlying: underlying, coordinator: coordinator)
+        let call = makeCall(name: "get_weather")
+
+        let result = try await wrapper.execute(call)
+        XCTAssertEqual(result.content, "sunny")
+        XCTAssertEqual(underlying.receivedCalls.count, 1)
+        XCTAssertTrue(coordinator.pendingApprovals.isEmpty)
+    }
+
+    // MARK: - Cancellation
+
+    func test_rejectAllPending_releasesAllSuspendedContinuations() async {
+        let coordinator = ToolCallApprovalCoordinator(mode: .alwaysAsk)
+
+        let first = Task { await coordinator.requestDecision(for: self.makeCall(id: "c1")) }
+        let second = Task { await coordinator.requestDecision(for: self.makeCall(id: "c2")) }
+
+        for _ in 0..<200 {
+            if coordinator.pendingApprovals.count == 2 { break }
+            await Task.yield()
+        }
+        XCTAssertEqual(coordinator.pendingApprovals.count, 2)
+
+        coordinator.rejectAllPending(reason: "batch cancel")
+
+        let decisions = await [first.value, second.value]
+        for decision in decisions {
+            guard case .rejected(let reason) = decision else {
+                XCTFail("Expected rejection, got \(decision)")
+                return
+            }
+            XCTAssertEqual(reason, "batch cancel")
+        }
+        XCTAssertTrue(coordinator.pendingApprovals.isEmpty)
+    }
+
+    // MARK: - Service integration
+
+    func test_inferenceService_installsApprovingWrapperOnBackend() async {
+        let backend = RecordingToolCallingBackend()
+        let service = InferenceService(backend: backend, name: "Mock")
+        service.toolApprovalCoordinator.mode = .alwaysAsk
+
+        let underlying = MockToolProvider()
+        service.toolProvider = underlying
+
+        XCTAssertTrue(
+            backend.lastToolProvider is ApprovingToolProvider,
+            "InferenceService should hand the backend a wrapped provider"
+        )
+    }
+}
+
+// MARK: - Test doubles
+
+private final class RecordingToolCallingBackend: InferenceBackend, ToolCallingBackend, ConversationHistoryReceiver, @unchecked Sendable {
+    var isModelLoaded: Bool = true
+    var isGenerating: Bool = false
+
+    var capabilities: BackendCapabilities {
+        BackendCapabilities(
+            supportedParameters: [.temperature],
+            maxContextTokens: 4096,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsToolCalling: true,
+            supportsStructuredOutput: false,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: false
+        )
+    }
+
+    var lastToolDefinitions: [ToolDefinition]?
+    var lastToolProvider: (any ToolProvider)?
+    var toolCallObserver: (any ToolCallObserver)?
+
+    func setTools(_ tools: [ToolDefinition]) {
+        lastToolDefinitions = tools
+    }
+
+    func setToolProvider(_ provider: (any ToolProvider)?) {
+        lastToolProvider = provider
+    }
+
+    func loadModel(from url: URL, contextSize: Int32) async throws {}
+
+    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> GenerationStream {
+        let stream = AsyncThrowingStream<GenerationEvent, Error> { continuation in
+            continuation.finish()
+        }
+        return GenerationStream(stream)
+    }
+
+    func stopGeneration() {}
+    func unloadModel() {}
+    func setConversationHistory(_ messages: [(role: String, content: String)]) {}
+}

--- a/Tests/BaseChatCoreTests/ToolCallPersistenceTests.swift
+++ b/Tests/BaseChatCoreTests/ToolCallPersistenceTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+import SwiftData
+@testable import BaseChatCore
+
+/// Verifies that ``ToolCallApprovalState`` round-trips through SwiftData so
+/// chat history reloads preserve whether a call was approved, edited, or
+/// rejected. The state is persisted inside the JSON payload stored in
+/// ``ChatMessage.contentPartsJSON``, not a separate column, so these tests
+/// double as a contract for the custom ``MessagePart`` Codable.
+final class ToolCallPersistenceTests: XCTestCase {
+
+    // MARK: - Codable round-trip
+
+    func test_toolCallPart_withPendingState_roundTrips() throws {
+        let part = MessagePart.toolCall(
+            id: "call_1",
+            name: "send_email",
+            arguments: #"{"to":"a@b.com"}"#,
+            state: .pending
+        )
+        let data = try JSONEncoder().encode([part])
+        let decoded = try JSONDecoder().decode([MessagePart].self, from: data)
+        XCTAssertEqual(decoded, [part])
+    }
+
+    func test_toolCallPart_withRejectedState_roundTrips() throws {
+        let part = MessagePart.toolCall(
+            id: "call_2",
+            name: "delete_file",
+            arguments: #"{"path":"/tmp/x"}"#,
+            state: .rejected
+        )
+        let data = try JSONEncoder().encode([part])
+        let decoded = try JSONDecoder().decode([MessagePart].self, from: data)
+        XCTAssertEqual(decoded, [part])
+    }
+
+    func test_toolCallPart_withEditedState_roundTrips() throws {
+        let part = MessagePart.toolCall(
+            id: "call_3",
+            name: "http_get",
+            arguments: #"{"url":"https://example.com"}"#,
+            state: .edited
+        )
+        let data = try JSONEncoder().encode([part])
+        let decoded = try JSONDecoder().decode([MessagePart].self, from: data)
+        XCTAssertEqual(decoded, [part])
+    }
+
+    // MARK: - Backward compatibility
+
+    func test_legacyPayloadWithoutStateField_decodesAsApproved() throws {
+        // Synthesised Swift enum encoding used before the state field existed.
+        let legacy = #"[{"toolCall":{"id":"x","name":"fn","arguments":"{}"}}]"#
+        let data = Data(legacy.utf8)
+        let decoded = try JSONDecoder().decode([MessagePart].self, from: data)
+        XCTAssertEqual(
+            decoded,
+            [.toolCall(id: "x", name: "fn", arguments: "{}", state: .approved)]
+        )
+    }
+
+    // MARK: - SwiftData round-trip
+
+    @MainActor
+    func test_swiftData_toolCallStatePersistsAcrossFetch() throws {
+        let container = try ModelContainerFactory.makeInMemoryContainer()
+        let context = ModelContext(container)
+        let sessionID = UUID()
+        let parts: [MessagePart] = [
+            .text("I should ask first."),
+            .toolCall(id: "tc1", name: "delete_file", arguments: #"{"path":"/tmp/x"}"#, state: .pending)
+        ]
+        let message = ChatMessage(role: .assistant, contentParts: parts, sessionID: sessionID)
+        context.insert(message)
+        try context.save()
+
+        // Refetch from SwiftData — not just re-read the property.
+        let fetched = try context.fetch(FetchDescriptor<ChatMessage>())
+        XCTAssertEqual(fetched.count, 1)
+        XCTAssertEqual(fetched.first?.contentParts, parts)
+    }
+
+    @MainActor
+    func test_swiftData_pendingToApproved_persists() throws {
+        let container = try ModelContainerFactory.makeInMemoryContainer()
+        let context = ModelContext(container)
+        let sessionID = UUID()
+        let pending: [MessagePart] = [
+            .toolCall(id: "tc1", name: "ping", arguments: "{}", state: .pending)
+        ]
+        let message = ChatMessage(role: .assistant, contentParts: pending, sessionID: sessionID)
+        context.insert(message)
+        try context.save()
+
+        // Mutate in place — the UI layer does this when the coordinator
+        // resolves a pending call.
+        message.contentParts = [
+            .toolCall(id: "tc1", name: "ping", arguments: "{}", state: .approved)
+        ]
+        try context.save()
+
+        let reloaded = try context.fetch(FetchDescriptor<ChatMessage>())
+        guard case .toolCall(_, _, _, let state) = reloaded.first?.contentParts.first else {
+            XCTFail("Expected toolCall part")
+            return
+        }
+        XCTAssertEqual(state, .approved)
+    }
+
+    @MainActor
+    func test_swiftData_pendingToRejected_persists() throws {
+        let container = try ModelContainerFactory.makeInMemoryContainer()
+        let context = ModelContext(container)
+        let sessionID = UUID()
+        let pending: [MessagePart] = [
+            .toolCall(id: "tc1", name: "rm_rf", arguments: "{}", state: .pending)
+        ]
+        let message = ChatMessage(role: .assistant, contentParts: pending, sessionID: sessionID)
+        context.insert(message)
+        try context.save()
+
+        message.contentParts = [
+            .toolCall(id: "tc1", name: "rm_rf", arguments: "{}", state: .rejected),
+            .toolResult(id: "tc1", content: "User rejected this tool call.")
+        ]
+        try context.save()
+
+        let reloaded = try context.fetch(FetchDescriptor<ChatMessage>())
+        XCTAssertEqual(reloaded.first?.contentParts.count, 2)
+        if case .toolCall(_, _, _, let state) = reloaded.first?.contentParts.first {
+            XCTAssertEqual(state, .rejected)
+        } else {
+            XCTFail("Expected first part to be a toolCall")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ToolCallApprovalCoordinator` on `InferenceService` that gates every tool call on a user decision before execution. Three modes: `alwaysAsk` (default), `trustedTools(Set<String>)`, and `autoApprove`.
- `ApprovingToolProvider` transparently wraps the host's `ToolProvider` so no backend has to change — existing `ToolCallingBackend` adopters continue to work.
- `MessagePart.toolCall` now carries a `ToolCallApprovalState` (`pending` / `approved` / `edited` / `rejected`). Custom `Codable` decodes pre-existing history as `.approved` so nothing in old chat logs has to migrate.
- `MessagePartsView` renders Approve / Reject / Edit buttons when a call is pending, and a new `EditToolArgumentsSheet` shows the tool's JSON schema alongside an editable arguments field with JSON validity checking.
- Rejection synthesises an `isError: true` `ToolResult` with the user's reason so the model can read "user rejected this" and plan around it.

Closes #247

## Release Note

**Users can now approve or reject every tool call before it runs.** Tool calling in BaseChatKit used to execute automatically the moment the model emitted a call, which made it unsafe to wire up tools with real side effects — a single unlucky `delete_file` or `send_email` would run before the user could blink. The new approval flow pauses each tool call until the user explicitly decides what to do, with three policies apps can choose between: `alwaysAsk` (the new default, safe by construction), `trustedTools` (auto-allow a named allowlist, prompt for everything else), and `autoApprove` (the old behaviour, now opt-in). Pending calls show inline Approve / Reject / Edit controls in the chat bubble, and the edit sheet renders the tool's JSON schema next to an editable arguments field so users can inspect exactly what is about to run. Rejections are sent back to the model as a synthetic error result so the conversation keeps flowing without a dangling tool-call round. Approval states persist across reloads, so users who come back to an old session see faithfully whether each tool call ran, was edited, or was turned down.

## Test plan

- [x] `BaseChatCoreTests` — 713 tests pass (adds 16: 9 `ToolCallApprovalTests`, 7 `ToolCallPersistenceTests`)
- [x] `BaseChatUITests` — 391 tests pass
- [x] `BaseChatBackendsTests` — 84 tests pass (no hardware traits)
- [x] `swift build --traits MLX,Llama` — clean on Apple Silicon
- [x] Sabotage verify: flipped `.alwaysAsk` to return `true` from `allowsAutoApproval(of:)`, confirmed 4 approval tests failed; reverted.
- [ ] Maintainer to visually verify the Approve/Reject/Edit bubble state and EditToolArgumentsSheet in a running host app (local tests do not render SwiftUI).

## New UI states

- **Pending bubble**: orange-tinted tool call block with `Pending approval` capsule and three inline controls (`Approve`, `Edit`, `Reject`). The disclosure still expands to show the raw arguments.
- **Edit sheet**: title, tool name, description, collapsible schema listing per-parameter type and required-ness, `TextEditor` with monospaced JSON and a live "not valid JSON" inline error.
- **Rejected bubble**: red-tinted with `Rejected` capsule; no buttons.
- **Edited bubble**: blue-tinted with `Edited` capsule indicating the user modified the arguments before letting it run.
- **Approved bubble**: unchanged from existing appearance.

## Notes / follow-ups

- The edit sheet validates that arguments are well-formed JSON, not that they match the `ToolInputSchema`. Full JSON Schema validation (type checks, enum matching, required key enforcement) needs a real validator — not pulling a dependency for this PR, the current gate is an explicit minimum-viable guard. A follow-up issue can add schema-aware validation.
- Tool calling is currently plumbed into `ClaudeBackend` and `OpenAIBackend` at the payload-parsing layer only — neither one yet runs the full multi-round execution loop. The approval gate is wired at `InferenceService` so it is ready the moment a backend starts calling `execute(_:)` on its (now wrapped) provider.