### PR TITLE
docs: add scope decision document and reframe positioning around operational reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ A modular SwiftUI framework for building chat interfaces powered by local and cl
 
 BaseChatKit provides a complete, production-ready chat UI with pluggable inference backends, model management, and SwiftData persistence. Drop it into your app, register backends, and you have a working chat interface.
 
+**Built for production failure modes.** BCK is designed around the things that go wrong between a working demo and an App Store release:
+
+- **Streaming resilience** — retry with backoff and a per-host circuit breaker so transient network loss, provider 429s, and cold TLS handshakes don't kill generations mid-token.
+- **Latest-wins model handoff** — racing model loads can't corrupt active state. If the user taps model A, then model B before A finishes, A is discarded and B wins deterministically.
+- **Memory pressure auto-unload** — loaded models are released before iOS reclaims them, so the next generation doesn't crash on a stale pointer.
+- **Mock backend for app-level testing** — `MockInferenceBackend` implements the full streaming contract so your app's tests can exercise BCK without loading a real model.
+- **Certificate pinning with fail-closed defaults** — `api.openai.com` and `api.anthropic.com` fail closed if pin sets are missing or empty, so a compromised CA can't silently reroute chat traffic.
+
+See [docs/SCOPE_DECISION.md](docs/SCOPE_DECISION.md) for the scoping rationale behind BCK 0.6.0.
+
 ## Demo
 
 
@@ -26,6 +36,12 @@ BaseChatKit provides a complete, production-ready chat UI with pluggable inferen
 - Swift 5.9+
 - iOS 17+ / macOS 14+
 - Apple Foundation Models require iOS 26+ / macOS 26+
+
+## How BCK compares to AnyLanguageModel
+
+AnyLanguageModel is HuggingFace's Swift package. It mirrors Apple's `FoundationModels` API and exposes many providers behind a single protocol, so code written against Apple's built-in model API can target cloud and open-source models with minimal changes.
+
+BCK and AnyLanguageModel occupy adjacent niches. AnyLanguageModel optimizes for provider coverage and API familiarity — if you need "any LLM behind one protocol that looks like `FoundationModels`," it's the simpler choice. BCK optimizes for production reliability and drop-in chat UI — if you need "a chat framework that survives real failures and ships a working `ChatView` + `SessionListView` + `ModelManagementSheet` on day one," BCK is designed for that. The two aren't competing on the same axis; pick the one whose axis matches the problem you're solving.
 
 ## Architecture
 

--- a/docs/SCOPE_DECISION.md
+++ b/docs/SCOPE_DECISION.md
@@ -1,0 +1,56 @@
+# Scope Decision — BCK 0.6.0
+
+## Why we slimmed BCK
+
+Consumer audits of BaseChatKit's two known consumers — Fireside and ChatbotUI-iOS — showed that less than half of the codebase had any real demand. Several large subsystems had zero consumers at all, and several more had a single consumer that used only a narrow slice of the public API. The April 2026 feature-expansion plan that introduced most of this surface area was built without this data, so 0.6.0 is the correction: we are deleting what nobody used and repositioning BCK around what actually makes it valuable to the apps that ship it.
+
+## Consumer audit summary
+
+| Capability | Fireside | ChatbotUI-iOS |
+|---|---|---|
+| `InferenceService` + `DefaultBackends` | transparent-use | transparent-use |
+| `ChatViewModel` | ✓ | ✓ |
+| `ChatView` (drop-in) | ✗ | ✓ |
+| `SessionListView` (drop-in) | ✗ | ✓ |
+| `ModelManagementSheet` | ✗ | ✓ |
+| `APIConfigurationView` | ✗ | ✓ |
+| HuggingFace downloader | ✗ | ✓ |
+| Compression pipeline | ✓ | ✗ |
+| Macro system (full) | ✓ | ✗ (uses only `macroContext.userName`) |
+| Server discovery | ✗ | ✗ |
+| Tool calling | ✗ | ✗ |
+
+Fireside is the original home of the compression pipeline and uses the macro system to drive its `LorebookTriggerEngine`. ChatbotUI-iOS is the drop-in consumer — it takes the UI wholesale (`ChatView`, `SessionListView`, `ModelManagementSheet`, `APIConfigurationView`) plus the HuggingFace downloader, and touches macros only through `macroContext.userName`. Neither consumer uses server discovery, the benchmark runner, or the tool-calling public API.
+
+## What's leaving in 0.6.0
+
+- **KoboldCpp backend** — zero consumers on either audited app, no evidence of external interest, pure maintenance cost.
+- **Server discovery subsystem** (~1,643 LOC) — zero consumers; built speculatively for a "find local LLM servers on the LAN" flow that never shipped.
+- **Tool calling public API** (~800+ LOC) — zero consumers; the public surface is being removed while we audit the underlying `MessagePart` tool cases separately.
+- **`MessagePart` tool cases** — pending schema audit; removed from the public API in 0.6.0 but kept in the persistence layer until the migration path is clear.
+
+## What's staying (and why)
+
+- **Streaming resilience** — production failure mode where transient network loss, provider 429s, or cold TLS handshakes kill a stream mid-token. We caught this because BCK runs in apps that ship to real users on real networks, not just demo flows.
+- **Model handoff (latest-wins `LoadRequestToken`)** — production failure mode where the user taps model A, then model B before A finishes loading, and the stale A load corrupts the active state. We caught this because BCK runs in apps where users actually change their mind.
+- **Memory pressure auto-unload** — production failure mode where iOS pages out the loaded model silently and the next generation crashes on a zero pointer. We caught this because BCK runs on real devices that also run Safari, Messages, and background tasks.
+- **Mock backend (`MockInferenceBackend`)** — production failure mode where an app-level feature depends on BCK's streaming contract and has no way to test it without loading a real model. We caught this because BCK consumers write XCTests.
+- **Certificate pinning (fail-closed on known cloud APIs)** — production failure mode where a mis-configured device trusts a compromised CA and silently leaks chat traffic. We caught this because BCK ships cloud backends that actually get used in production.
+
+## Positioning
+
+BaseChatKit is a drop-in chat framework with operational reliability guarantees, optimized for the ChatbotUI-iOS-shaped consumer: take `ChatView`, `SessionListView`, and `ModelManagementSheet` wholesale, inject an `InferenceService`, and compose app-level features (personas, story engines, lorebooks, custom tools) on top of the `ChatViewModel` API. The value is not "we support every backend" — it's "your chat UI keeps working when the network flickers, the user changes their mind mid-load, or iOS decides to reclaim your model's memory."
+
+AnyLanguageModel optimizes for provider abstraction — one protocol, many providers, API familiarity with Apple's `FoundationModels`. BCK optimizes for production failure modes — drop-in UI, operational reliability, and the things that go wrong between the demo and the App Store review. These are adjacent but distinct positions. We don't compete on backend count; we compete on what happens when the demo ends.
+
+## Deferred to Weeks 2-3
+
+- **Compression repatriation** — the compression pipeline was originally Fireside's and will be moved back there once Fireside has a clean extraction path. It stays in BCK 0.6.0 to avoid breaking Fireside mid-release.
+- **Macro engine deletion** — the full macro system is Fireside-only and will be deleted from BCK after Fireside takes ownership in its own codebase. ChatbotUI-iOS's `macroContext.userName` usage will migrate to a new `systemPromptContext` property before the engine leaves.
+- **`BaseChatInference` target extraction** — splitting the inference-only surface out of `BaseChatCore` so that UI-less consumers (server-side, CLI tools, test harnesses) can depend on the engine without pulling SwiftUI types. Target for 0.7.0.
+
+## Consumer impact
+
+Fireside keeps building — `MacroExpander` and the compression pipeline both stay in 0.6.0. The macro engine deletion is explicitly coordinated with Fireside's extraction timeline; Fireside will not be broken by this release.
+
+ChatbotUI-iOS keeps building — the `macroContext` property still exists in 0.6.0 alongside the new `systemPromptContext`. The migration is additive, not breaking. Drop-in UI, `ChatViewModel`, `ModelManagementSheet`, `APIConfigurationView`, and the HuggingFace downloader all remain unchanged.

--- a/docs/SCOPE_DECISION.md
+++ b/docs/SCOPE_DECISION.md
@@ -2,11 +2,11 @@
 
 ## Why we slimmed BCK
 
-Consumer audits of BaseChatKit's two known consumers — Fireside and ChatbotUI-iOS — showed that less than half of the codebase had any real demand. Several large subsystems had zero consumers at all, and several more had a single consumer that used only a narrow slice of the public API. The April 2026 feature-expansion plan that introduced most of this surface area was built without this data, so 0.6.0 is the correction: we are deleting what nobody used and repositioning BCK around what actually makes it valuable to the apps that ship it.
+Consumer audits of BaseChatKit's two known consumers — a private internal app and the public [ChatbotUI-iOS](https://github.com/roryford/ChatbotUI-iOS) demo — showed that less than half of the codebase had any real demand. Several large subsystems had zero consumers at all, and several more had a single consumer that used only a narrow slice of the public API. The April 2026 feature-expansion plan that introduced most of this surface area was built without this data, so 0.6.0 is the correction: we are deleting what nobody used and repositioning BCK around what actually makes it valuable to the apps that ship it.
 
 ## Consumer audit summary
 
-| Capability | Fireside | ChatbotUI-iOS |
+| Capability | Internal consumer | ChatbotUI-iOS |
 |---|---|---|
 | `InferenceService` + `DefaultBackends` | transparent-use | transparent-use |
 | `ChatViewModel` | ✓ | ✓ |
@@ -20,7 +20,7 @@ Consumer audits of BaseChatKit's two known consumers — Fireside and ChatbotUI-
 | Server discovery | ✗ | ✗ |
 | Tool calling | ✗ | ✗ |
 
-Fireside is the original home of the compression pipeline and uses the macro system to drive its `LorebookTriggerEngine`. ChatbotUI-iOS is the drop-in consumer — it takes the UI wholesale (`ChatView`, `SessionListView`, `ModelManagementSheet`, `APIConfigurationView`) plus the HuggingFace downloader, and touches macros only through `macroContext.userName`. Neither consumer uses server discovery, the benchmark runner, or the tool-calling public API.
+The internal consumer is the original home of the compression pipeline and exercises the full macro system through an app-level engine built on top of it. ChatbotUI-iOS is the drop-in consumer — it takes the UI wholesale (`ChatView`, `SessionListView`, `ModelManagementSheet`, `APIConfigurationView`) plus the HuggingFace downloader, and touches macros only through `macroContext.userName`. Neither consumer uses server discovery, the benchmark runner, or the tool-calling public API.
 
 ## What's leaving in 0.6.0
 
@@ -39,18 +39,18 @@ Fireside is the original home of the compression pipeline and uses the macro sys
 
 ## Positioning
 
-BaseChatKit is a drop-in chat framework with operational reliability guarantees, optimized for the ChatbotUI-iOS-shaped consumer: take `ChatView`, `SessionListView`, and `ModelManagementSheet` wholesale, inject an `InferenceService`, and compose app-level features (personas, story engines, lorebooks, custom tools) on top of the `ChatViewModel` API. The value is not "we support every backend" — it's "your chat UI keeps working when the network flickers, the user changes their mind mid-load, or iOS decides to reclaim your model's memory."
+BaseChatKit is a drop-in chat framework with operational reliability guarantees, optimized for the ChatbotUI-iOS-shaped consumer: take `ChatView`, `SessionListView`, and `ModelManagementSheet` wholesale, inject an `InferenceService`, and compose app-level features on top of the `ChatViewModel` API. The value is not "we support every backend" — it's "your chat UI keeps working when the network flickers, the user changes their mind mid-load, or iOS decides to reclaim your model's memory."
 
 AnyLanguageModel optimizes for provider abstraction — one protocol, many providers, API familiarity with Apple's `FoundationModels`. BCK optimizes for production failure modes — drop-in UI, operational reliability, and the things that go wrong between the demo and the App Store review. These are adjacent but distinct positions. We don't compete on backend count; we compete on what happens when the demo ends.
 
 ## Deferred to Weeks 2-3
 
-- **Compression repatriation** — the compression pipeline was originally Fireside's and will be moved back there once Fireside has a clean extraction path. It stays in BCK 0.6.0 to avoid breaking Fireside mid-release.
-- **Macro engine deletion** — the full macro system is Fireside-only and will be deleted from BCK after Fireside takes ownership in its own codebase. ChatbotUI-iOS's `macroContext.userName` usage will migrate to a new `systemPromptContext` property before the engine leaves.
+- **Compression repatriation** — the compression pipeline was originally extracted from the internal consumer and will be moved back there once that app has a clean extraction path. It stays in BCK 0.6.0 to avoid breaking the internal consumer mid-release.
+- **Macro engine deletion** — the full macro system has only one consumer and will be deleted from BCK after that consumer takes ownership in its own codebase. ChatbotUI-iOS's `macroContext.userName` usage will migrate to a new `systemPromptContext` property before the engine leaves.
 - **`BaseChatInference` target extraction** — splitting the inference-only surface out of `BaseChatCore` so that UI-less consumers (server-side, CLI tools, test harnesses) can depend on the engine without pulling SwiftUI types. Target for 0.7.0.
 
 ## Consumer impact
 
-Fireside keeps building — `MacroExpander` and the compression pipeline both stay in 0.6.0. The macro engine deletion is explicitly coordinated with Fireside's extraction timeline; Fireside will not be broken by this release.
+The internal consumer keeps building — `MacroExpander` and the compression pipeline both stay in 0.6.0. The macro engine deletion is explicitly coordinated with that consumer's extraction timeline; it will not be broken by this release.
 
 ChatbotUI-iOS keeps building — the `macroContext` property still exists in 0.6.0 alongside the new `systemPromptContext`. The migration is additive, not breaking. Drop-in UI, `ChatViewModel`, `ModelManagementSheet`, `APIConfigurationView`, and the HuggingFace downloader all remain unchanged.


### PR DESCRIPTION
## Summary
- Adds `docs/SCOPE_DECISION.md` explaining the slimming initiative with consumer audit data
- Rewrites `README.md` positioning to lead with operational reliability (streaming resilience, model handoff, memory pressure, mock backend, cert pinning)
- Adds a new "How BCK compares to AnyLanguageModel" section framing the two as adjacent, not competing

## Context
Consumer audits of the two known BCK consumers (Fireside, ChatbotUI-iOS) showed less than half of BCK's codebase had real demand. This PR documents the resulting scoping decision and updates the public positioning to match. It's the narrative companion to the deletion PRs landing this week (KoboldCpp, server discovery, tool calling public API, additive macro migration).

Foundation for BCK 0.6.0 release.

## Test plan
- [ ] Verify docs/SCOPE_DECISION.md renders cleanly in GitHub preview
- [ ] Verify README.md sections remain coherent after the positioning edits
- [ ] Confirm no emojis added (project convention)

## Release Note
**Clearer positioning for BCK's production-reliability focus** — documents the scoping decision that drives 0.6.0's slimming, reframes BCK around operational guarantees (streaming resilience, latest-wins model handoff, memory pressure auto-unload, mock backend, cert pinning), and clarifies how BCK and AnyLanguageModel occupy adjacent rather than competing niches.

Generated with [Claude Code](https://claude.com/claude-code)