### PR TITLE
refactor: remove MessagePart tool-call cases after schema audit

### DIFF
--- a/Sources/BaseChatCore/Models/MessagePart.swift
+++ b/Sources/BaseChatCore/Models/MessagePart.swift
@@ -7,10 +7,10 @@ import Foundation
 /// render appropriate controls (e.g., inline images) and backends can map
 /// parts to their native message formats.
 ///
-/// `ChatMessage.decode` falls back to a `.text` part when JSON decoding
-/// fails, so any pre-removal persisted rows containing `toolCall` /
-/// `toolResult` discriminators degrade gracefully to a text bubble rather
-/// than crashing.
+/// ``BaseChatSchemaV3/ChatMessage/decode(_:)`` falls back to a `.text` part
+/// when JSON decoding fails, so any pre-removal persisted rows containing
+/// `toolCall` / `toolResult` discriminators degrade gracefully to a text
+/// bubble rather than crashing.
 public enum MessagePart: Codable, Hashable, Sendable {
     case text(String)
     case image(data: Data, mimeType: String)

--- a/Sources/BaseChatCore/Models/MessagePart.swift
+++ b/Sources/BaseChatCore/Models/MessagePart.swift
@@ -2,16 +2,18 @@ import Foundation
 
 /// A discrete piece of content within a chat message.
 ///
-/// Messages can contain multiple parts to support multimodal input (images),
-/// tool calling, and tool results alongside plain text. Each part is
-/// independently typed so the UI can render appropriate controls (e.g.,
-/// inline images, collapsible tool call blocks) and backends can map parts
-/// to their native message formats.
+/// Messages can contain multiple parts to support multimodal input (images)
+/// alongside plain text. Each part is independently typed so the UI can
+/// render appropriate controls (e.g., inline images) and backends can map
+/// parts to their native message formats.
+///
+/// `ChatMessage.decode` falls back to a `.text` part when JSON decoding
+/// fails, so any pre-removal persisted rows containing `toolCall` /
+/// `toolResult` discriminators degrade gracefully to a text bubble rather
+/// than crashing.
 public enum MessagePart: Codable, Hashable, Sendable {
     case text(String)
     case image(data: Data, mimeType: String)
-    case toolCall(id: String, name: String, arguments: String)
-    case toolResult(id: String, content: String)
 }
 
 extension MessagePart {

--- a/Sources/BaseChatUI/Views/Chat/MessagePartsView.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessagePartsView.swift
@@ -3,9 +3,8 @@ import BaseChatCore
 
 /// Renders an array of ``MessagePart`` values within a message bubble.
 ///
-/// Text parts are rendered inline (markdown for assistant, plain for user),
-/// images are shown as thumbnails, and tool calls/results are displayed as
-/// labeled disclosure groups.
+/// Text parts are rendered inline (markdown for assistant, plain for user)
+/// and images are shown as thumbnails.
 struct MessagePartsView: View {
     let parts: [MessagePart]
     let role: MessageRole
@@ -24,12 +23,6 @@ struct MessagePartsView: View {
 
         case .image(let data, _):
             imageView(data)
-
-        case .toolCall(let id, let name, let arguments):
-            toolCallView(id: id, name: name, arguments: arguments)
-
-        case .toolResult(let id, let content):
-            toolResultView(id: id, content: content)
         }
     }
 
@@ -66,43 +59,8 @@ struct MessagePartsView: View {
         #endif
     }
 
-    private func toolCallView(id: String, name: String, arguments: String) -> some View {
-        DisclosureGroup {
-            Text(arguments)
-                .font(.caption.monospaced())
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        } label: {
-            Label(name, systemImage: "wrench")
-                .font(.callout.bold())
-        }
-        .padding(8)
-        .background(.fill.quaternary, in: RoundedRectangle(cornerRadius: 8))
-    }
-
-    private func toolResultView(id: String, content: String) -> some View {
-        DisclosureGroup {
-            Text(content)
-                .font(.caption.monospaced())
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        } label: {
-            Label("Tool Result", systemImage: "arrow.turn.down.left")
-                .font(.callout.bold())
-        }
-        .padding(8)
-        .background(.fill.quaternary, in: RoundedRectangle(cornerRadius: 8))
-    }
 }
 
 #Preview("Text Only") {
     MessagePartsView(parts: [.text("Hello world")], role: .assistant)
-}
-
-#Preview("Tool Call") {
-    MessagePartsView(parts: [.toolCall(id: "1", name: "get_weather", arguments: "{\"city\": \"London\"}")], role: .assistant)
-}
-
-#Preview("Mixed Parts") {
-    MessagePartsView(parts: [.text("Check this:"), .toolResult(id: "1", content: "Temperature: 18°C")], role: .user)
 }

--- a/Tests/BaseChatCoreTests/MessagePartTests.swift
+++ b/Tests/BaseChatCoreTests/MessagePartTests.swift
@@ -22,25 +22,10 @@ final class MessagePartTests: XCTestCase {
         XCTAssertEqual(decoded, [part])
     }
 
-    func test_toolCallPart_codableRoundTrip() throws {
-        let part = MessagePart.toolCall(id: "call_123", name: "get_weather", arguments: "{\"city\":\"London\"}")
-        let data = try JSONEncoder().encode([part])
-        let decoded = try JSONDecoder().decode([MessagePart].self, from: data)
-        XCTAssertEqual(decoded, [part])
-    }
-
-    func test_toolResultPart_codableRoundTrip() throws {
-        let part = MessagePart.toolResult(id: "call_123", content: "Sunny, 22C")
-        let data = try JSONEncoder().encode([part])
-        let decoded = try JSONDecoder().decode([MessagePart].self, from: data)
-        XCTAssertEqual(decoded, [part])
-    }
-
     func test_mixedParts_codableRoundTrip() throws {
         let parts: [MessagePart] = [
             .text("Here is the weather:"),
-            .toolCall(id: "tc1", name: "get_weather", arguments: "{}"),
-            .toolResult(id: "tc1", content: "Rainy"),
+            .image(data: Data([0xFF, 0xD8, 0xFF, 0xE0]), mimeType: "image/jpeg"),
             .text("It's rainy today."),
         ]
         let data = try JSONEncoder().encode(parts)
@@ -60,16 +45,6 @@ final class MessagePartTests: XCTestCase {
         XCTAssertNil(part.textContent)
     }
 
-    func test_textContent_returnsNilForToolCallPart() {
-        let part = MessagePart.toolCall(id: "1", name: "fn", arguments: "{}")
-        XCTAssertNil(part.textContent)
-    }
-
-    func test_textContent_returnsNilForToolResultPart() {
-        let part = MessagePart.toolResult(id: "1", content: "result")
-        XCTAssertNil(part.textContent)
-    }
-
     // MARK: - ChatMessageRecord backward compatibility
 
     func test_chatMessageRecord_contentStringInit_createsTextPart() {
@@ -81,7 +56,7 @@ final class MessagePartTests: XCTestCase {
     func test_chatMessageRecord_contentParts_concatenatesTextParts() {
         let record = ChatMessageRecord(
             role: .assistant,
-            contentParts: [.text("Part 1"), .toolCall(id: "t", name: "fn", arguments: "{}"), .text("Part 2")],
+            contentParts: [.text("Part 1"), .image(data: Data(), mimeType: "image/png"), .text("Part 2")],
             sessionID: UUID()
         )
         XCTAssertEqual(record.content, "Part 1Part 2")
@@ -125,7 +100,7 @@ final class MessagePartTests: XCTestCase {
         let sessionID = UUID()
         let message = ChatMessage(
             role: .assistant,
-            contentParts: [.text("hello "), .toolCall(id: "t1", name: "fn", arguments: "{}"), .text("world")],
+            contentParts: [.text("hello "), .image(data: Data(), mimeType: "image/png"), .text("world")],
             sessionID: sessionID
         )
         context.insert(message)

--- a/Tests/BaseChatCoreTests/MessagePartTests.swift
+++ b/Tests/BaseChatCoreTests/MessagePartTests.swift
@@ -27,6 +27,7 @@ final class MessagePartTests: XCTestCase {
             .text("Here is the weather:"),
             .image(data: Data([0xFF, 0xD8, 0xFF, 0xE0]), mimeType: "image/jpeg"),
             .text("It's rainy today."),
+            .image(data: Data([0x89, 0x50, 0x4E, 0x47]), mimeType: "image/png"),
         ]
         let data = try JSONEncoder().encode(parts)
         let decoded = try JSONDecoder().decode([MessagePart].self, from: data)
@@ -92,6 +93,20 @@ final class MessagePartTests: XCTestCase {
     func test_chatMessage_decode_emptyString_returnsEmptyArray() {
         let parts = BaseChatSchemaV3.ChatMessage.decode("")
         XCTAssertEqual(parts, [])
+    }
+
+    // Regression lock for the fallback behavior that made the tool-case removal safe — see PR #270 audit.
+    // Simulates a hypothetical pre-0.6.x persisted row containing a removed `.toolCall` discriminator
+    // alongside a still-valid `.text` part. The decode path must not crash; it must degrade to a single
+    // `.text` bubble containing the raw JSON so the user sees something rather than losing the message.
+    func test_chatMessage_decode_legacyToolCaseJSON_fallsBackToRawTextPart() {
+        let legacyJSON = #"""
+        [{"text":{"_0":"Hello"}},{"toolCall":{"_0":{"id":"tc1","name":"get_weather","arguments":"{\"city\":\"London\"}"}}}]
+        """#
+
+        let parts = BaseChatSchemaV3.ChatMessage.decode(legacyJSON)
+
+        XCTAssertEqual(parts, [.text(legacyJSON)])
     }
 
     func test_chatMessage_contentParts_syncContentString() throws {

--- a/Tests/BaseChatSnapshotTests/ViewSnapshotTests.swift
+++ b/Tests/BaseChatSnapshotTests/ViewSnapshotTests.swift
@@ -235,26 +235,12 @@ final class ViewSnapshotTests: XCTestCase {
         )
     }
 
-    // MARK: - MessagePartsView (3 snapshots)
+    // MARK: - MessagePartsView (1 snapshot)
 
     func test_messageParts_textOnly() {
         assertDumpSnapshot(
             MessagePartsView(parts: [.text("Hello world")], role: .assistant),
             named: "text_only"
-        )
-    }
-
-    func test_messageParts_toolCall() {
-        assertDumpSnapshot(
-            MessagePartsView(parts: [.toolCall(id: "1", name: "get_weather", arguments: "{\"city\": \"London\"}")], role: .assistant),
-            named: "tool_call"
-        )
-    }
-
-    func test_messageParts_mixedParts() {
-        assertDumpSnapshot(
-            MessagePartsView(parts: [.text("Check this:"), .toolResult(id: "1", content: "Temperature: 18°C")], role: .user),
-            named: "mixed_parts"
         )
     }
 

--- a/Tests/BaseChatSnapshotTests/__Snapshots__/ViewSnapshotTests/test_messageParts_toolCall.tool_call.txt
+++ b/Tests/BaseChatSnapshotTests/__Snapshots__/ViewSnapshotTests/test_messageParts_toolCall.tool_call.txt
@@ -1,1 +1,0 @@
-- <_TtGC7SwiftUI19NSHostingControllerV10BaseChatUI16MessagePartsView_>


### PR DESCRIPTION
## Summary
Completes the tool-calling removal from #269. Removes `MessagePart.toolCall` and `.toolResult` cases, the corresponding view render arms and previews, and the test fixtures that constructed them.

## Audit finding
`MessagePart` is `Codable` and persisted via `ChatMessage.contentPartsJSON` (a JSON string column on the `ChatMessage` `@Model`). However, no production source path on `main` has ever produced tool-call parts:

- The only `MessagePart.toolCall` / `.toolResult` constructions in `Sources/` were SwiftUI previews on `MessagePartsView`. The only constructions in `Tests/` were Codable round-trip fixtures and one snapshot test.
- The unmerged `feat/tool-call-approval-flow` branch (commit `483877d`) is the only place real production code was wired up, and it never landed on `main`.
- Schema versions V1 and V2 were collapsed into V3 in #220 with an explicit note that the repo was still private at the time and no users carry legacy data — so no shipped schema version has ever contained populated tool-case rows in a user's store.
- As an additional safety net, `ChatMessage.decode` already catches JSON decode errors and falls back to `[.text(json)]`. Any hypothetical row containing the removed discriminator after this PR ships would degrade gracefully to a text bubble rather than crashing.

Removal is therefore safe.

## Why this was split from #269
The cases were retained in 0.6.0 (#269) because `MessagePart` is persisted via SwiftData and a schema audit was needed to verify removal would not break decode of existing user data. This PR runs that audit and removes the cases now that safety is confirmed.

## Test plan
- [x] `grep -rn 'MessagePart\.toolCall\|MessagePart\.toolResult' Sources/ Tests/` returns zero
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 107 tests, 0 failures
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 398 tests, 0 failures
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 63 tests, 0 failures
- [x] `swift build` clean

## Breaking changes
`MessagePart.toolCall(id:name:arguments:)` and `MessagePart.toolResult(id:content:)` cases removed. Apps that pattern-match on `MessagePart` with exhaustive switches must remove those arms.

## Release Note
**Completed tool-calling removal** — `MessagePart.toolCall` and `.toolResult` enum cases are now removed after a schema audit confirmed they were never populated in any shipped SwiftData schema version. The Codable persistence path through `ChatMessage.contentPartsJSON` already had a decode-error fallback to a text part, so any hypothetical legacy rows degrade gracefully rather than crashing on load. This closes the W5b follow-up from BCK 0.6.0's tool-calling removal in #269.

Generated with [Claude Code](https://claude.com/claude-code)