### PR TITLE
chore: document APIEndpoint record bridge non-optionality

### DIFF
--- a/Sources/BaseChatCore/InferenceService+APIEndpoint.swift
+++ b/Sources/BaseChatCore/InferenceService+APIEndpoint.swift
@@ -9,6 +9,12 @@ extension APIEndpoint {
 
     /// Returns a storage-agnostic snapshot of this endpoint suitable for
     /// passing to inference services that don't depend on SwiftData.
+    ///
+    /// `baseURL` and `modelName` are forwarded directly because the `@Model`
+    /// stores them as non-optional `String` — the model's own initializer
+    /// resolves any nil inputs to `provider.defaultBaseURL` /
+    /// `provider.defaultModelName` at construction time, so persisted values
+    /// are always concrete. There is no nil sentinel to preserve here.
     public var record: APIEndpointRecord {
         APIEndpointRecord(
             id: id,


### PR DESCRIPTION
## Summary

Small follow-up from the #271 (BaseChatInference extraction) review. Covers two of the four deferred cleanup items; the other two are verification-only and summarised below.

### Item 2 — `APIEndpoint.record` bridge doc comment (applied)

Adds a doc comment on `APIEndpoint.record` in `Sources/BaseChatCore/InferenceService+APIEndpoint.swift` explaining why it is safe to forward `baseURL` and `modelName` directly into `APIEndpointRecord`:

- The SwiftData `@Model APIEndpoint` stores both as non-optional `String` (verified against `Sources/BaseChatCore/BaseChatSchemaV3.swift`).
- Nil fallback to `provider.defaultBaseURL` / `provider.defaultModelName` happens inside the `@Model`'s own initializer, so persisted values are always concrete.
- There is no nil sentinel for the record bridge to preserve. The current pass-through is correct.

No behavior change.

### Item 1 — `SettingsService+ChatSession.swift` delegate refactor (NOT applied)

The review flagged that `0.7 / 0.9 / 1.1` default literals are duplicated between `Sources/BaseChatCore/SettingsService+ChatSession.swift` and `Sources/BaseChatInference/Services/SettingsService.swift`. The proposed refactor was to delegate from the Core extension to a parameterless Inference-side method when `session` is `nil`.

After inspection, the Inference-side `SettingsService` only exposes these signatures:

```swift
public func effectiveTemperature(session: ChatSessionRecord?) -> Float { ... }
public func effectiveTopP(session: ChatSessionRecord?) -> Float { ... }
public func effectiveRepeatPenalty(session: ChatSessionRecord?) -> Float { ... }
```

No parameterless overload exists, and the Core extension's parameter type is the SwiftData `@Model ChatSession` rather than `ChatSessionRecord`. The review's suggested one-line delegation would require either widening the Inference API or writing a `ChatSession -> ChatSessionRecord` adapter inline. Neither is appropriate for a cosmetic duplication fix, so the refactor is deferred for a dedicated cleanup that can take a proper look at whether the two targets should share a helper.

### Item 3 — test count audit (verification only)

PR #271 moved many test files from `Tests/BaseChatCoreTests/` to `Tests/BaseChatInferenceTests/`. Verified that no files were dropped:

- Pre-#271 (`bb409a6^:Tests/BaseChatCoreTests`): 65 files
- Post-#271 `Tests/BaseChatCoreTests/`: 8 files
- Post-#271 `Tests/BaseChatInferenceTests/`: 57 files
- Union of the two post-#271 lists is **byte-identical** to the pre-#271 list (confirmed with `diff`).

Every test file is accounted for. No coverage regression.

### Item 4 — snapshot test failure issue (filed separately)

The pre-existing `BaseChatSnapshotTests.ChatViewControlTests.test_inputBar_hasTextField` failure is tracked in #273. Unrelated to the extraction work.

## Test plan

Full pre-push suite locally, single-threaded, zero failures:

- `BaseChatCoreTests`: 79 XCTest, 0 failures
- `BaseChatInferenceTests`: 635 XCTest + 107 Swift Testing = 742, 0 failures
- `BaseChatUITests`: 398 XCTest, 0 failures
- `BaseChatBackendsTests`: 128 XCTest + 63 Swift Testing = 191, 0 failures

Total: 1,410 tests passing.

## Release Note

Not user-facing; `chore` only. No changelog entry.