### PR TITLE
perf(ui): cache NSRegularExpression for system prompt context substitution

### DIFF
--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
@@ -40,6 +40,15 @@ struct StreamingTokenBatcher {
     }
 }
 
+// File-private top-level — nonisolated, initialized once, thread-safe.
+// Kept outside the @MainActor-isolated ChatViewModel extension so that
+// nonisolated `applySystemPromptContext` can access it without a Swift 6
+// actor-isolation warning.
+private let _systemPromptContextRegex: NSRegularExpression = {
+    // Force-unwrap is safe: the pattern is a compile-time constant with no user input.
+    try! NSRegularExpression(pattern: #"\{\{(\w+)\}\}"#, options: [])
+}()
+
 extension ChatViewModel {
 
     /// Looks up a message by ID and applies a mutation in a single step,
@@ -243,11 +252,6 @@ extension ChatViewModel {
         }
     }
 
-    private static let systemPromptContextRegex: NSRegularExpression = {
-        // Force-unwrap is safe: the pattern is a compile-time constant with no user input.
-        try! NSRegularExpression(pattern: #"\{\{(\w+)\}\}"#, options: [])
-    }()
-
     /// Substitutes `{{key}}` tokens in `text` with values from `context`.
     ///
     /// Single-pass scan: each `{{word}}` token in the source is examined exactly
@@ -260,7 +264,7 @@ extension ChatViewModel {
         guard !context.isEmpty, text.contains("{{") else { return text }
         // `{{word}}` where `word` is one or more word characters. Anything that
         // doesn't match (whitespace, dots, empty `{{}}`) is ignored.
-        let regex = Self.systemPromptContextRegex
+        let regex = _systemPromptContextRegex
         let fullRange = NSRange(location: 0, length: (text as NSString).length)
         // Walk matches in reverse so replacement ranges remain valid as we mutate.
         let matches = regex.matches(in: text, options: [], range: fullRange).reversed()

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
@@ -243,6 +243,11 @@ extension ChatViewModel {
         }
     }
 
+    private static let systemPromptContextRegex: NSRegularExpression = {
+        // Force-unwrap is safe: the pattern is a compile-time constant with no user input.
+        try! NSRegularExpression(pattern: #"\{\{(\w+)\}\}"#, options: [])
+    }()
+
     /// Substitutes `{{key}}` tokens in `text` with values from `context`.
     ///
     /// Single-pass scan: each `{{word}}` token in the source is examined exactly
@@ -255,10 +260,7 @@ extension ChatViewModel {
         guard !context.isEmpty, text.contains("{{") else { return text }
         // `{{word}}` where `word` is one or more word characters. Anything that
         // doesn't match (whitespace, dots, empty `{{}}`) is ignored.
-        let pattern = #"\{\{(\w+)\}\}"#
-        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
-            return text
-        }
+        let regex = Self.systemPromptContextRegex
         let fullRange = NSRange(location: 0, length: (text as NSString).length)
         // Walk matches in reverse so replacement ranges remain valid as we mutate.
         let matches = regex.matches(in: text, options: [], range: fullRange).reversed()

--- a/Tests/BaseChatUITests/ChatViewModelSystemPromptContextTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelSystemPromptContextTests.swift
@@ -139,6 +139,51 @@ final class ChatViewModelSystemPromptContextTests: XCTestCase {
         )
     }
 
+    // MARK: - Direct unit tests for applySystemPromptContext
+
+    func test_applySystemPromptContext_emptyBraces_areIgnored() {
+        // `{{}}` contains no word characters so `\w+` won't match — the token
+        // should pass through verbatim even when the empty string is in the dict.
+        let result = ChatViewModel.applySystemPromptContext(
+            "Hello {{}} world",
+            context: ["": "X"]
+        )
+        XCTAssertEqual(result, "Hello {{}} world",
+            "Empty `{{}}` must not be substituted — `\\w+` requires at least one word character")
+    }
+
+    func test_applySystemPromptContext_unicodeKey_behavior() {
+        // NSRegularExpression uses ICU's `\w`, which matches Unicode word characters,
+        // so Cyrillic keys are matched and substituted.
+        let result = ChatViewModel.applySystemPromptContext(
+            "{{имя}}",
+            context: ["имя": "Иван"]
+        )
+        XCTAssertEqual(result, "Иван",
+            "ICU `\\w` matches Unicode word chars, so Cyrillic keys must be substituted")
+    }
+
+    func test_applySystemPromptContext_noDoubleBraces_returnsEarly() {
+        // The early-exit guard `text.contains("{{")` should short-circuit before
+        // touching the regex when there is nothing to substitute.
+        let result = ChatViewModel.applySystemPromptContext(
+            "No tokens here.",
+            context: ["name": "Alice"]
+        )
+        XCTAssertEqual(result, "No tokens here.",
+            "Text without `{{` must be returned unchanged (exercises the early-exit path)")
+    }
+
+    func test_applySystemPromptContext_missingKey_passesThrough() {
+        // A key present in the text but absent from the dict must survive verbatim.
+        let result = ChatViewModel.applySystemPromptContext(
+            "Hello {{unknown}}",
+            context: [:]
+        )
+        XCTAssertEqual(result, "Hello {{unknown}}",
+            "An unrecognized `{{key}}` must pass through unchanged when the dict is empty")
+    }
+
     // MARK: - Mid-conversation mutation between sends
 
     func test_systemPromptContext_mutationBetweenSends_appliesToSecondPrompt() async {


### PR DESCRIPTION
## Summary
- `applySystemPromptContext` compiled a new `NSRegularExpression` on every generation even though the pattern is a compile-time constant
- Replaced with a `private static let` initialised once via a force-unwrap closure (safe: pattern is not user input)
- No behaviour change — same replacement logic, same early-exit guards

## Test plan
- [ ] All `BaseChatUITests` pass
- [ ] Verify `applySystemPromptContext` tests still exercise substitution, passthrough, and empty-context paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)