### PR TITLE
feat(backends): adopt LoadProgressReporting in LlamaBackend and MLXBackend

### DIFF
--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -129,6 +129,11 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
             return activeLoadToken
         }
 
+        // Snapshotting the handler here means calling setLoadProgressHandler(nil)
+        // mid-load will not cancel in-flight Task callbacks already dispatched by
+        // the C progress hook. Stale callbacks become no-ops at the consumer:
+        // InferenceService.applyLoadProgress(_:for:) drops values whose request
+        // token no longer matches the active loading phase.
         let capturedHandler = withStateLock { _loadProgressHandler }
 
         let loadedResources = try await Task.detached(priority: .userInitiated) { [self] in
@@ -244,6 +249,11 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
             modelParams.progress_callback_user_data = callbackContextRef!.toOpaque()
             modelParams.progress_callback = { progress, userData -> Bool in
                 guard let ptr = userData else { return true }
+                // `takeUnretainedValue()` does not bump ARC here — the Task closure below
+                // captures `ctx` as a Swift reference, which provides its own ARC retain
+                // for the Task's lifetime. The Unmanaged retain managed by the outer defer
+                // in `loadModel` is separate and only responsible for keeping the context
+                // alive during the synchronous C load call.
                 let ctx = Unmanaged<ProgressCallbackContext>.fromOpaque(ptr).takeUnretainedValue()
                 let value = Double(progress)
                 Task { await ctx.handler(value) }

--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -76,6 +76,9 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
     private var nextLoadToken: UInt64 = 0
     private var activeLoadToken: UInt64 = 0
 
+    /// Guarded by `stateLock`. Set by `setLoadProgressHandler(_:)` before each load.
+    private var _loadProgressHandler: (@Sendable (Double) async -> Void)?
+
     // MARK: - Global Backend Lifecycle
 
     /// Guards `llama_backend_init/free` which are global and must only be
@@ -126,8 +129,10 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
             return activeLoadToken
         }
 
+        let capturedHandler = withStateLock { _loadProgressHandler }
+
         let loadedResources = try await Task.detached(priority: .userInitiated) { [self] in
-            return try self.serializedModelLoad(at: url, contextSize: contextSize)
+            return try self.serializedModelLoad(at: url, contextSize: contextSize, progressHandler: capturedHandler)
         }.value
 
         let didCommit = withStateLock {
@@ -155,10 +160,14 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
     /// Synchronous wrapper that holds `loadSerializationLock` while calling the
     /// C-level model init. Called from a detached task so the lock/unlock stays
     /// in a synchronous context (required by Swift 6.3 strict concurrency).
-    private func serializedModelLoad(at url: URL, contextSize: Int32) throws -> LoadedResources {
+    private func serializedModelLoad(
+        at url: URL,
+        contextSize: Int32,
+        progressHandler: (@Sendable (Double) async -> Void)?
+    ) throws -> LoadedResources {
         loadSerializationLock.lock()
         defer { loadSerializationLock.unlock() }
-        return try Self.initializeModel(at: url, requestedContextSize: contextSize)
+        return try Self.initializeModel(at: url, requestedContextSize: contextSize, progressHandler: progressHandler)
     }
 
     private struct LoadedResources: @unchecked Sendable {
@@ -200,9 +209,22 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         deinit { if let p = pointer { llama_free(p) } }
     }
 
+    /// Heap-allocated box used to bridge a Swift async progress handler through the C callback ABI.
+    ///
+    /// `llama_model_params.progress_callback` is a C function pointer — it cannot capture Swift
+    /// context directly. We store the handler in this class, pass an `Unmanaged` retain into
+    /// `progress_callback_user_data`, then release it after `llama_model_load_from_file` returns.
+    private final class ProgressCallbackContext: @unchecked Sendable {
+        let handler: @Sendable (Double) async -> Void
+        init(_ handler: @escaping @Sendable (Double) async -> Void) {
+            self.handler = handler
+        }
+    }
+
     private static func initializeModel(
         at url: URL,
-        requestedContextSize: Int32
+        requestedContextSize: Int32,
+        progressHandler: (@Sendable (Double) async -> Void)? = nil
     ) throws -> LoadedResources {
         var modelParams = llama_model_default_params()
         #if targetEnvironment(simulator)
@@ -210,6 +232,25 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         #else
         modelParams.n_gpu_layers = 99  // Offload all layers to Metal
         #endif
+
+        // Wire up the progress callback when a handler is installed.
+        // The C callback fires on the loader thread; we bridge to async by
+        // creating an unstructured Task so the synchronous C callback returns
+        // quickly. The Unmanaged retain is released once the load call returns.
+        var callbackContextRef: Unmanaged<ProgressCallbackContext>?
+        if let handler = progressHandler {
+            let ctx = ProgressCallbackContext(handler)
+            callbackContextRef = Unmanaged.passRetained(ctx)
+            modelParams.progress_callback_user_data = callbackContextRef!.toOpaque()
+            modelParams.progress_callback = { progress, userData -> Bool in
+                guard let ptr = userData else { return true }
+                let ctx = Unmanaged<ProgressCallbackContext>.fromOpaque(ptr).takeUnretainedValue()
+                let value = Double(progress)
+                Task { await ctx.handler(value) }
+                return true
+            }
+        }
+        defer { callbackContextRef?.release() }
 
         guard let rawModel = llama_model_load_from_file(url.path, modelParams) else {
             throw InferenceError.modelLoadFailed(underlying: NSError(
@@ -506,6 +547,17 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         }
         invalidUTF8Buffer.removeLast() // remove null terminator, keep accumulating
         return nil
+    }
+}
+
+// MARK: - LoadProgressReporting
+
+extension LlamaBackend: LoadProgressReporting {
+    /// Installs a progress handler that receives fractional progress values in `[0.0, 1.0]`
+    /// delivered by the llama.cpp `progress_callback` during `llama_model_load_from_file`.
+    /// The handler fires from the loader thread via an unstructured Task.
+    public func setLoadProgressHandler(_ handler: (@Sendable (Double) async -> Void)?) {
+        withStateLock { _loadProgressHandler = handler }
     }
 }
 

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -74,6 +74,16 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
     /// Access only under `stateLock`.
     private var _generationTask: Task<Void, Never>?
 
+    // MARK: - Load Progress
+
+    /// Guarded by `stateLock`. Set by `setLoadProgressHandler(_:)` before each load.
+    ///
+    /// `loadModelContainer(from: URL)` in `mlx-swift-lm` provides no granular progress hook
+    /// on local directory loads — the progress handler overload is only available for download
+    /// paths. We emit synthetic bookends (0.0 before, 1.0 after) so `InferenceService` can
+    /// distinguish "load started" from "load complete" rather than showing a flat 0% spinner.
+    private var _loadProgressHandler: (@Sendable (Double) async -> Void)?
+
     // MARK: - Configuration
 
     /// Policy controlling MLX's GPU buffer cache size. See `MLXCachePolicy`.
@@ -90,6 +100,14 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
 
     public func loadModel(from url: URL, contextSize: Int32) async throws {
         unloadModel()
+
+        let progressHandler = withStateLock { _loadProgressHandler }
+
+        // Signal "load started". The `mlx-swift-lm` local-directory API has no granular
+        // progress hook, so we emit a 0.0 bookend here and a 1.0 bookend after the load
+        // completes. This gives InferenceService enough signal to animate a progress
+        // indicator rather than showing a flat 0% spinner for the full load duration.
+        await progressHandler?(0.0)
 
         do {
             // Load from a local directory containing config.json + .safetensors.
@@ -115,6 +133,9 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             Memory.cacheLimit = cacheBytes
             Self.logger.info("MLX cache limit set to \(cacheBytes / (1024 * 1024)) MB (policy: \(String(describing: self.cachePolicy)))")
             isModelLoaded = true
+            // Signal load complete before returning so InferenceService sees 1.0
+            // before it clears the handler and flips isModelLoaded.
+            await progressHandler?(1.0)
             Self.logger.info("MLX backend loaded model from \(url.lastPathComponent)")
         } catch {
             Self.logger.error("MLX model load failed: \(error)")
@@ -263,6 +284,18 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             Memory.clearCache()
         }
         Self.logger.info("MLX backend unloaded")
+    }
+}
+
+// MARK: - LoadProgressReporting
+
+extension MLXBackend: LoadProgressReporting {
+    /// Installs a synthetic-bookend progress handler. Because `mlx-swift-lm`'s local-directory
+    /// load path exposes no granular progress, the handler receives `0.0` when the load begins
+    /// and `1.0` when it completes successfully. This is enough for `InferenceService` to show
+    /// a non-zero progress indicator rather than a flat 0% spinner.
+    public func setLoadProgressHandler(_ handler: (@Sendable (Double) async -> Void)?) {
+        withStateLock { _loadProgressHandler = handler }
     }
 }
 #endif

--- a/Sources/BaseChatTestSupport/MockLoadProgressBackend.swift
+++ b/Sources/BaseChatTestSupport/MockLoadProgressBackend.swift
@@ -1,0 +1,81 @@
+import Foundation
+import BaseChatInference
+
+/// A minimal ``InferenceBackend`` + ``LoadProgressReporting`` stub for contract tests.
+///
+/// Calls the installed handler with configurable progress values during `loadModel`.
+/// Does not perform real inference — use `MockInferenceBackend` when generation is needed.
+public final class MockLoadProgressBackend: InferenceBackend, LoadProgressReporting, @unchecked Sendable {
+
+    // MARK: - InferenceBackend
+
+    public var isModelLoaded: Bool = false
+    public var isGenerating: Bool = false
+    public var capabilities: BackendCapabilities = BackendCapabilities(
+        supportedParameters: [.temperature, .topP, .repeatPenalty],
+        maxContextTokens: 4096,
+        requiresPromptTemplate: false,
+        supportsSystemPrompt: true
+    )
+
+    // MARK: - Configuration
+
+    /// Progress values the handler will be called with during `loadModel`, in order.
+    public var progressValuesToEmit: [Double]
+
+    // MARK: - Tracking
+
+    /// Recorded values delivered to the handler during the most recent `loadModel` call.
+    public private(set) var deliveredValues: [Double] = []
+
+    // MARK: - Private
+
+    private let lock = NSLock()
+    private var _handler: (@Sendable (Double) async -> Void)?
+
+    // MARK: - Init
+
+    public init(progressValuesToEmit: [Double] = [0.0, 0.5, 1.0]) {
+        self.progressValuesToEmit = progressValuesToEmit
+    }
+
+    // MARK: - LoadProgressReporting
+
+    public func setLoadProgressHandler(_ handler: (@Sendable (Double) async -> Void)?) {
+        lock.lock()
+        defer { lock.unlock() }
+        _handler = handler
+    }
+
+    // MARK: - InferenceBackend methods
+
+    public func loadModel(from url: URL, contextSize: Int32) async throws {
+        let handler = lock.withLock { _handler }
+        deliveredValues = []
+        for value in progressValuesToEmit {
+            deliveredValues.append(value)
+            await handler?(value)
+        }
+        isModelLoaded = true
+    }
+
+    public func generate(
+        prompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig
+    ) throws -> GenerationStream {
+        guard isModelLoaded else { throw InferenceError.inferenceFailure("No model loaded") }
+        let stream = AsyncThrowingStream<GenerationEvent, Error> { continuation in
+            continuation.finish()
+        }
+        return GenerationStream(stream)
+    }
+
+    public func stopGeneration() { isGenerating = false }
+
+    public func unloadModel() {
+        isModelLoaded = false
+        isGenerating = false
+        lock.withLock { _handler = nil }
+    }
+}

--- a/Tests/BaseChatBackendsTests/LoadProgressReportingContractTests.swift
+++ b/Tests/BaseChatBackendsTests/LoadProgressReportingContractTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+import BaseChatCore
+import BaseChatTestSupport
+
+/// Thread-safe value collector for `@Sendable` progress handler closures.
+private actor ProgressCollector {
+    private(set) var values: [Double] = []
+    private(set) var callCount: Int = 0
+
+    func record(_ value: Double) {
+        values.append(value)
+        callCount += 1
+    }
+}
+
+/// Contract tests for the ``LoadProgressReporting`` protocol.
+///
+/// These tests use ``MockLoadProgressBackend`` — a minimal stub that adopts the protocol
+/// without any hardware dependency. The contract verified here is:
+///   1. A handler installed via `setLoadProgressHandler(_:)` is called during `loadModel`.
+///   2. Every delivered value is in `[0.0, 1.0]`.
+///   3. Clearing the handler (`nil`) before load causes zero calls.
+///
+/// Real backend coverage (LlamaBackend, MLXBackend) lives in `BaseChatMLXIntegrationTests`
+/// and `BaseChatE2ETests` which require hardware and are gated accordingly.
+final class LoadProgressReportingContractTests: XCTestCase {
+
+    private let modelURL = URL(fileURLWithPath: "/tmp/fake-model")
+
+    // MARK: - 1. Handler receives values during loadModel
+
+    func test_handler_isCalledDuringLoad() async throws {
+        let backend = MockLoadProgressBackend(progressValuesToEmit: [0.0, 0.5, 1.0])
+        let collector = ProgressCollector()
+
+        backend.setLoadProgressHandler { value in
+            await collector.record(value)
+        }
+
+        try await backend.loadModel(from: modelURL, contextSize: 512)
+
+        let count = await collector.callCount
+        XCTAssertGreaterThan(count, 0, "Handler must be called at least once during loadModel")
+    }
+
+    // MARK: - 2. All delivered values are in [0.0, 1.0]
+
+    func test_handler_receivesValuesInRange() async throws {
+        let backend = MockLoadProgressBackend(progressValuesToEmit: [0.0, 0.25, 0.75, 1.0])
+        let collector = ProgressCollector()
+
+        backend.setLoadProgressHandler { value in
+            await collector.record(value)
+        }
+
+        try await backend.loadModel(from: modelURL, contextSize: 512)
+
+        let received = await collector.values
+        XCTAssertFalse(received.isEmpty, "At least one progress value must be delivered")
+        for value in received {
+            XCTAssertGreaterThanOrEqual(value, 0.0, "Progress value \(value) is below 0.0")
+            XCTAssertLessThanOrEqual(value, 1.0, "Progress value \(value) exceeds 1.0")
+        }
+    }
+
+    // MARK: - 3. Clearing the handler suppresses all calls
+
+    func test_nilHandler_suppressesAllCalls() async throws {
+        let backend = MockLoadProgressBackend(progressValuesToEmit: [0.0, 0.5, 1.0])
+        let collector = ProgressCollector()
+
+        // Install then immediately clear.
+        backend.setLoadProgressHandler { value in await collector.record(value) }
+        backend.setLoadProgressHandler(nil)
+
+        try await backend.loadModel(from: modelURL, contextSize: 512)
+
+        let count = await collector.callCount
+        XCTAssertEqual(count, 0,
+            "After setLoadProgressHandler(nil), handler must never be called during loadModel")
+    }
+
+    // MARK: - Sabotage check (verify tests are sensitive)
+
+    // To confirm test 1 would catch a broken implementation:
+    // Temporarily remove the `await handler?(value)` call in
+    // `MockLoadProgressBackend.loadModel` — test_handler_isCalledDuringLoad
+    // must fail with "Handler must be called at least once".
+    // Remove the sabotage before committing.
+}

--- a/Tests/BaseChatBackendsTests/LoadProgressReportingContractTests.swift
+++ b/Tests/BaseChatBackendsTests/LoadProgressReportingContractTests.swift
@@ -13,16 +13,13 @@ private actor ProgressCollector {
     }
 }
 
-/// Contract tests for the ``LoadProgressReporting`` protocol.
+/// Verifies the ``LoadProgressReporting`` protocol contract using ``MockLoadProgressBackend``.
 ///
-/// These tests use ``MockLoadProgressBackend`` — a minimal stub that adopts the protocol
-/// without any hardware dependency. The contract verified here is:
-///   1. A handler installed via `setLoadProgressHandler(_:)` is called during `loadModel`.
-///   2. Every delivered value is in `[0.0, 1.0]`.
-///   3. Clearing the handler (`nil`) before load causes zero calls.
-///
-/// Real backend coverage (LlamaBackend, MLXBackend) lives in `BaseChatMLXIntegrationTests`
-/// and `BaseChatE2ETests` which require hardware and are gated accordingly.
+/// These tests confirm the mock is self-consistent and that the protocol's handler
+/// install/clear/deliver lifecycle works as specified. They do **not** verify that
+/// ``LlamaBackend`` or ``MLXBackend`` implement the protocol correctly — real backend
+/// coverage requires hardware and lives in ``BaseChatMLXIntegrationTests`` and
+/// ``BaseChatE2ETests``.
 final class LoadProgressReportingContractTests: XCTestCase {
 
     private let modelURL = URL(fileURLWithPath: "/tmp/fake-model")


### PR DESCRIPTION
## Summary
- `LoadProgressReporting` was fully implemented in `InferenceService` but adopted by no production backend — both MLX and llama.cpp showed a flat 0% spinner during model load
- **LlamaBackend**: wires `llama_model_params.progress_callback` with a C function pointer. A heap-allocated `ProgressCallbackContext` class bridges the `@Sendable` Swift async handler through `progress_callback_user_data` (the only way to carry context through a C function pointer). The callback fires on the loader thread and dispatches an unstructured `Task` to call the handler asynchronously, returning immediately so the C load loop is never blocked.
- **MLXBackend**: emits synthetic bookend progress (`0.0` before `loadModelContainer`, `1.0` after). The `mlx-swift-lm` local-directory API (`loadModelContainer(from: URL, using:)`) exposes no granular progress hook — the `progressHandler:` overload is only available on download paths. The bookends convert the flat 0% spinner into a brief indeterminate pulse that at minimum reflects real load state.

## Test plan
- [x] `BaseChatBackendsTests` pass in CI (63 tests, no hardware required)
- [x] `LoadProgressReportingContractTests` verify: handler is called during load, all values are in `[0.0, 1.0]`, clearing the handler suppresses all calls
- [ ] Real LlamaBackend progress requires hardware — exercise via `BaseChatE2ETests` or Xcode integration tests, gated with `XCTSkipIf`
- [ ] Real MLXBackend bookend progress requires hardware — same gating

## Release Note
`InferenceService.modelLoadProgress` previously published a flat `0.0` for the entire duration of local model loads because no production backend adopted `LoadProgressReporting`. `LlamaBackend` now delivers real fractional progress from the llama.cpp C API; `MLXBackend` emits start/end bookends (the mlx-swift-lm local-directory load path has no granular progress hook). Users will see a responsive progress indicator instead of an unmoving spinner during model load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)