### PR TITLE
chore: land reliability and settings follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ BaseChatKit provides a complete, production-ready chat UI with pluggable inferen
 
 **Built for production failure modes.** BCK is designed around the things that go wrong between a working demo and an App Store release:
 
-- **Streaming resilience** — retry with backoff and a per-host circuit breaker so transient network loss, provider 429s, and cold TLS handshakes don't kill generations mid-token.
+- **Streaming resilience** — cloud backends retry the initial connection with backoff on retryable errors and preserve already-yielded output if a later failure occurs.
 - **Latest-wins model handoff** — racing model loads can't corrupt active state. If the user taps model A, then model B before A finishes, A is discarded and B wins deterministically.
-- **Memory pressure auto-unload** — loaded models are released before iOS reclaims them, so the next generation doesn't crash on a stale pointer.
+- **Memory admission and pressure handling** — `MemoryGate` can reject risky loads, and the drop-in `ChatViewModel` stops generation and unloads the model on critical memory pressure.
 - **Mock backend for app-level testing** — `MockInferenceBackend` implements the full streaming contract so your app's tests can exercise BCK without loading a real model.
-- **Certificate pinning with fail-closed defaults** — `api.openai.com` and `api.anthropic.com` fail closed if pin sets are missing or empty, so a compromised CA can't silently reroute chat traffic.
+- **Certificate pinning with fail-closed defaults** — `api.openai.com` and `api.anthropic.com` fail closed if pin sets are missing or empty, while custom hosts use platform trust unless you configure pins.
 
+For the exact source-backed contract, see [docs/RELIABILITY.md](docs/RELIABILITY.md).
 See [docs/SCOPE_DECISION.md](docs/SCOPE_DECISION.md) for the scoping rationale behind BCK 0.6.0.
 
 ## Demo

--- a/Sources/BaseChatCore/ChatSession+Record.swift
+++ b/Sources/BaseChatCore/ChatSession+Record.swift
@@ -1,0 +1,28 @@
+import Foundation
+import BaseChatInference
+
+// Source-compatibility shim: lets callers convert the SwiftData `@Model`
+// `ChatSession` into the storage-agnostic `ChatSessionRecord` used by
+// BaseChatInference APIs.
+extension ChatSession {
+
+    /// Returns a storage-agnostic snapshot of this session suitable for
+    /// passing to inference services that don't depend on SwiftData.
+    public var record: ChatSessionRecord {
+        ChatSessionRecord(
+            id: id,
+            title: title,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            systemPrompt: systemPrompt,
+            selectedModelID: selectedModelID,
+            selectedEndpointID: selectedEndpointID,
+            temperature: temperature,
+            topP: topP,
+            repeatPenalty: repeatPenalty,
+            promptTemplate: promptTemplate,
+            contextSizeOverride: contextSizeOverride,
+            pinnedMessageIDs: pinnedMessageIDs
+        )
+    }
+}

--- a/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
+++ b/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
@@ -161,21 +161,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
 extension ChatSession {
     /// Converts a SwiftData model to a plain record.
     func toRecord() -> ChatSessionRecord {
-        ChatSessionRecord(
-            id: id,
-            title: title,
-            createdAt: createdAt,
-            updatedAt: updatedAt,
-            systemPrompt: systemPrompt,
-            selectedModelID: selectedModelID,
-            selectedEndpointID: selectedEndpointID,
-            temperature: temperature,
-            topP: topP,
-            repeatPenalty: repeatPenalty,
-            promptTemplate: promptTemplateRawValue.flatMap(PromptTemplate.init(rawValue:)),
-            contextSizeOverride: contextSizeOverride,
-            pinnedMessageIDs: Set(pinnedMessageIDsRaw?.split(separator: ",").compactMap { UUID(uuidString: String($0)) } ?? [])
-        )
+        record
     }
 }
 

--- a/Sources/BaseChatCore/SettingsService+ChatSession.swift
+++ b/Sources/BaseChatCore/SettingsService+ChatSession.swift
@@ -8,16 +8,16 @@ extension SettingsService {
     /// Returns the effective temperature, using session override if available.
     @MainActor
     public func effectiveTemperature(session: ChatSession?) -> Float {
-        session?.temperature ?? globalTemperature ?? 0.7
+        effectiveTemperature(session: session?.record)
     }
 
     @MainActor
     public func effectiveTopP(session: ChatSession?) -> Float {
-        session?.topP ?? globalTopP ?? 0.9
+        effectiveTopP(session: session?.record)
     }
 
     @MainActor
     public func effectiveRepeatPenalty(session: ChatSession?) -> Float {
-        session?.repeatPenalty ?? globalRepeatPenalty ?? 1.1
+        effectiveRepeatPenalty(session: session?.record)
     }
 }

--- a/Sources/BaseChatInference/BaseChatInference.docc/BaseChatInference.md
+++ b/Sources/BaseChatInference/BaseChatInference.docc/BaseChatInference.md
@@ -19,6 +19,8 @@ provider) out of their build graph.
 For apps that want the full chat experience, `BaseChatCore` re-exports
 `BaseChatInference` so a single `import BaseChatCore` brings in everything.
 
+For the source-backed operational contract around loading, streaming, memory handling, cancellation, and pinning, see [`docs/RELIABILITY.md`](../../../docs/RELIABILITY.md).
+
 ## Topics
 
 ### Configuration

--- a/Tests/BaseChatCoreTests/ChatSessionTests.swift
+++ b/Tests/BaseChatCoreTests/ChatSessionTests.swift
@@ -63,4 +63,43 @@ final class ChatSessionTests: XCTestCase {
         XCTAssertEqual(session.topP, 0.8)
         XCTAssertEqual(session.repeatPenalty, 1.3)
     }
+
+    func test_record_mapsSessionState() {
+        let session = ChatSession(title: "Bridge")
+        let selectedModelID = UUID()
+        let selectedEndpointID = UUID()
+        let firstPinnedID = UUID()
+        let secondPinnedID = UUID()
+        let createdAt = Date(timeIntervalSinceReferenceDate: 100)
+        let updatedAt = Date(timeIntervalSinceReferenceDate: 200)
+
+        session.id = UUID()
+        session.createdAt = createdAt
+        session.updatedAt = updatedAt
+        session.systemPrompt = "System prompt"
+        session.selectedModelID = selectedModelID
+        session.selectedEndpointID = selectedEndpointID
+        session.temperature = 0.8
+        session.topP = 0.95
+        session.repeatPenalty = 1.25
+        session.promptTemplate = .llama3
+        session.contextSizeOverride = 4096
+        session.pinnedMessageIDs = [firstPinnedID, secondPinnedID]
+
+        let record = session.record
+
+        XCTAssertEqual(record.id, session.id)
+        XCTAssertEqual(record.title, "Bridge")
+        XCTAssertEqual(record.createdAt, createdAt)
+        XCTAssertEqual(record.updatedAt, updatedAt)
+        XCTAssertEqual(record.systemPrompt, "System prompt")
+        XCTAssertEqual(record.selectedModelID, selectedModelID)
+        XCTAssertEqual(record.selectedEndpointID, selectedEndpointID)
+        XCTAssertEqual(record.temperature, 0.8)
+        XCTAssertEqual(record.topP, 0.95)
+        XCTAssertEqual(record.repeatPenalty, 1.25)
+        XCTAssertEqual(record.promptTemplate, .llama3)
+        XCTAssertEqual(record.contextSizeOverride, 4096)
+        XCTAssertEqual(record.pinnedMessageIDs, [firstPinnedID, secondPinnedID])
+    }
 }

--- a/Tests/BaseChatCoreTests/SettingsServiceTests.swift
+++ b/Tests/BaseChatCoreTests/SettingsServiceTests.swift
@@ -85,6 +85,33 @@ final class SettingsServiceTests: XCTestCase {
         XCTAssertEqual(service.effectiveTemperature(session: ChatSession?.none), 0.5, accuracy: 0.01)
     }
 
+    func test_chatSessionOverloads_matchRecordOverloads() {
+        service.globalTemperature = 0.6
+        service.globalTopP = 0.85
+        service.globalRepeatPenalty = 1.05
+
+        let session = ChatSession()
+        session.temperature = 0.8
+        session.topP = nil
+        session.repeatPenalty = 1.2
+
+        XCTAssertEqual(
+            service.effectiveTemperature(session: session),
+            service.effectiveTemperature(session: session.record),
+            accuracy: 0.01
+        )
+        XCTAssertEqual(
+            service.effectiveTopP(session: session),
+            service.effectiveTopP(session: session.record),
+            accuracy: 0.01
+        )
+        XCTAssertEqual(
+            service.effectiveRepeatPenalty(session: session),
+            service.effectiveRepeatPenalty(session: session.record),
+            accuracy: 0.01
+        )
+    }
+
     // MARK: - Appearance
 
     func test_appearanceMode_defaultsToSystem() {
@@ -148,6 +175,14 @@ final class SettingsServiceTests: XCTestCase {
     func test_effectiveTemperature_nilGlobalFallsToHardcodedDefault() {
         // Neither session nor global is set
         XCTAssertEqual(service.effectiveTemperature(session: ChatSession?.none), 0.7, accuracy: 0.01)
+    }
+
+    func test_effectiveTopP_nilGlobalFallsToHardcodedDefault() {
+        XCTAssertEqual(service.effectiveTopP(session: ChatSession?.none), 0.9, accuracy: 0.01)
+    }
+
+    func test_effectiveRepeatPenalty_nilGlobalFallsToHardcodedDefault() {
+        XCTAssertEqual(service.effectiveRepeatPenalty(session: ChatSession?.none), 1.1, accuracy: 0.01)
     }
 
     func test_effectiveTemperature_zeroGlobalDoesNotFallToDefault() {

--- a/Tests/BaseChatSnapshotTests/ChatViewControlTests.swift
+++ b/Tests/BaseChatSnapshotTests/ChatViewControlTests.swift
@@ -103,7 +103,7 @@ final class ChatViewControlTests: XCTestCase {
         )
     }
 
-    // MARK: - ChatInputBar — Default State
+    // MARK: - ChatInputBar — Text Input Affordance
 
     private func inputBarDump(viewModel: ChatViewModel? = nil) -> String {
         let vm = viewModel ?? makeChatViewModel()
@@ -114,10 +114,10 @@ final class ChatViewControlTests: XCTestCase {
     }
 
     func test_inputBar_hasTextField() {
-        let dump = inputBarDump()
+        let dump = inputBarDump(viewModel: makeChatViewModelWithMock())
         XCTAssertTrue(
-            dump.contains("Message..."),
-            "ChatInputBar should contain a text field with 'Message...' placeholder"
+            dump.contains("Message…"),
+            "ChatInputBar should contain a text field with 'Message…' placeholder when input is available"
         )
     }
 

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -1,0 +1,53 @@
+# Reliability contract
+
+This document describes the operational behavior BaseChatKit implements today. It is intentionally narrower than product copy: if a behavior is not backed by the current source, it is not promised here.
+
+## Model handoff
+
+`InferenceService` gives every `loadModel(...)` and `loadCloudBackend(...)` call a monotonic `LoadRequestToken` and only allows the newest token to commit. If an older load finishes after a newer request has started, the older success is unloaded instead of replacing the active backend, and the older failure is ignored for visible state transitions. `unloadModel()` invalidates every outstanding token before clearing the active backend, so a late completion cannot resurrect a model the user already switched away from. Load progress is token-scoped as well: stale loads stop updating `modelLoadProgress`. The coordination logic lives in [`Sources/BaseChatInference/Services/InferenceService.swift`](../Sources/BaseChatInference/Services/InferenceService.swift).
+
+The same service also serializes queued generation. `enqueue(...)` runs one backend generation at a time, orders queued work by priority, and only advances after the consumer calls `generationDidFinish()`. That is a real contract, not a convenience API: if the caller forgets to signal completion, the queue stays blocked.
+
+## Streaming resilience
+
+For the SSE-based cloud backends, retry logic exists, but it is narrower than "retry the whole stream until it works." `SSECloudBackend` wraps only the connection/setup phase — the `URLSession.bytes(for:)` call plus HTTP status validation — in [`withRetry(...)`](../Sources/BaseChatInference/Services/RetryPolicy.swift). The default strategy is exponential backoff with jitter (`maxRetries: 3`, `baseDelay: 1s`, `maxTotalDelay: 60s`) and it honors `Retry-After` when a provider returns HTTP 429. Retries only happen for errors that declare themselves retryable in [`CloudBackendError`](../Sources/BaseChatInference/Services/CloudBackendError.swift): rate limits, network errors, timeouts, `streamInterrupted`, and 5xx server errors. Authentication failures, parse errors, invalid URLs, missing keys, and backend deallocation are surfaced immediately.
+
+Once the first response bytes arrive, parsing runs outside the retry wrapper. That means BaseChatKit preserves partial output instead of replaying the request from the top: if a provider sends tokens and then fails, the error is surfaced to the stream rather than hidden behind a transparent retry. `GenerationStream` can expose `.retrying`, `.stalled`, `.failed`, and an idle-timeout-driven `.timeout(...)` path, but the backends in `BaseChatBackends` leave `streamIdleTimeout` unset by default, so stall detection is opt-in rather than automatic. See [`Sources/BaseChatBackends/SSECloudBackend.swift`](../Sources/BaseChatBackends/SSECloudBackend.swift), [`Sources/BaseChatInference/Services/GenerationStream.swift`](../Sources/BaseChatInference/Services/GenerationStream.swift), and [`Sources/BaseChatInference/Services/SSEStreamParser.swift`](../Sources/BaseChatInference/Services/SSEStreamParser.swift).
+
+## Memory behavior
+
+BaseChatKit has two separate memory defenses. The first is preflight admission control through [`MemoryGate`](../Sources/BaseChatInference/Services/MemoryGate.swift), which `InferenceService` consults only if the app sets `inferenceService.memoryGate`. For `resident` backends it estimates roughly the full model file size; for `mappable` backends it estimates roughly 25% of the file size; for `external` backends it always allows the load. The default gate throws on deny on iOS and only warns on macOS.
+
+The second is runtime memory-pressure handling. [`MemoryPressureHandler`](../Sources/BaseChatInference/Services/MemoryPressureHandler.swift) reports `.nominal`, `.warning`, and `.critical`, but it does not unload anything by itself. In the drop-in UI, [`ChatViewModel.handleMemoryPressure()`](../Sources/BaseChatUI/ViewModels/ChatViewModel+MemoryPressure.swift) shows a warning banner at `.warning` and stops generation plus unloads the model at `.critical`. If an app never starts monitoring or never forwards those events into the view model, there is no automatic unload path. Also, despite the handler comment mentioning "pause heavy work," the current UI behavior does not pause generation at `.warning`; only `.critical` triggers a stop and unload.
+
+## Cancellation semantics by backend
+
+Cancellation is not identical across backends, and the current implementation exposes that difference through [`BackendCapabilities.cancellationStyle`](../Sources/BaseChatInference/Protocols/BackendCapabilities.swift).
+
+`LlamaBackend` is the only backend marked `.explicit`. Its `stopGeneration()` sets an internal `cancelled` flag and cancels the active task; the llama.cpp loop checks that flag between sampling and decode steps. `unloadModel()` clears observable state immediately, invalidates any in-flight load token, and frees the C resources only after the generation task has exited, which avoids use-after-free races. See [`Sources/BaseChatBackends/LlamaBackend.swift`](../Sources/BaseChatBackends/LlamaBackend.swift).
+
+`MLXBackend`, `FoundationBackend`, and the `SSECloudBackend` family (`OpenAIBackend`, `ClaudeBackend`, `OllamaBackend`) are `.cooperative`: they cancel the active Swift task and let the generation loop unwind. `FoundationBackend` goes further and discards its `LanguageModelSession` after cancellation so a partial cancelled turn is not kept in later conversation history. See [`Sources/BaseChatBackends/MLXBackend.swift`](../Sources/BaseChatBackends/MLXBackend.swift), [`Sources/BaseChatBackends/FoundationBackend.swift`](../Sources/BaseChatBackends/FoundationBackend.swift), and [`Sources/BaseChatBackends/SSECloudBackend.swift`](../Sources/BaseChatBackends/SSECloudBackend.swift).
+
+At the service layer, `InferenceService.cancel(_:)` removes a queued request immediately or stops the active request and drains the next one. `InferenceService.stopGeneration()` cancels the active request and every queued request. Queue consumers see their outward-facing `GenerationStream` transition to a cancelled failure path even if the backend stream itself simply finishes after task cancellation. One detail that is important for callers: some cooperative backends clear `isGenerating` during asynchronous cleanup rather than synchronously inside `stopGeneration()`, so BCK does not currently provide a cross-backend guarantee that `isGenerating == false` the instant `stopGeneration()` returns.
+
+## Test backends
+
+`BaseChatTestSupport` ships a real test double rather than a stub-only protocol mock. [`MockInferenceBackend`](../Sources/BaseChatTestSupport/MockInferenceBackend.swift) implements `InferenceBackend`, yields a real `GenerationStream`, and can be configured to fail at load time, fail before generation starts, or throw from inside the stream after some tokens have already been produced. It also records call counts and the last prompt, system prompt, config, and conversation history it saw. `stopGeneration()` finishes the active continuation, which makes it suitable for app-level tests that need to exercise the same streaming and cancellation surface the real backends use.
+
+If you need harsher timing and failure-path tests, the same target also includes `SlowMockBackend` and `ChaosBackend`, but `MockInferenceBackend` is the baseline contract-oriented fake.
+
+## Certificate pinning
+
+OpenAI and Claude use [`URLSessionProvider.pinned`](../Sources/BaseChatBackends/URLSessionProvider.swift) by default, which installs [`PinnedSessionDelegate`](../Sources/BaseChatBackends/PinnedSessionDelegate.swift). The delegate loads default SPKI pins for `api.openai.com` and `api.anthropic.com`; those two hosts are treated as required pinned hosts, so a missing or empty pin set cancels the TLS challenge instead of falling back to system trust. `localhost`, `127.0.0.1`, and `::1` always bypass pinning.
+
+For custom hosts, the behavior is weaker by design. If the hostname is not one of the required production hosts and `PinnedSessionDelegate.pinnedHosts` does not contain pins for it, the delegate falls back to normal platform trust evaluation. That means `APIProvider.custom` is not automatically pinned even though it is routed through `OpenAIBackend`; the host app must populate `PinnedSessionDelegate.pinnedHosts` itself if it wants pinning for that endpoint. `OllamaBackend` uses [`URLSessionProvider.unpinned`](../Sources/BaseChatBackends/URLSessionProvider.swift) by default, so local and LAN deployments are unpinned unless the app opts into something stricter. See [`Sources/BaseChatBackends/DefaultBackends.swift`](../Sources/BaseChatBackends/DefaultBackends.swift).
+
+## What is not guaranteed
+
+- BaseChatKit does **not** currently implement a circuit breaker.
+- BaseChatKit does **not** automatically reconnect or resume a stream after bytes have started arriving; retries cover connection setup, not mid-stream replay.
+- The default cloud backends do **not** enable idle-timeout detection unless the app sets `streamIdleTimeout`.
+- `CloudBackendError.streamInterrupted` exists, but the default SSE/NDJSON backends do not currently synthesize it for a silent EOF.
+- `InferenceService` alone does **not** monitor memory pressure; the app has to wire `MemoryPressureHandler` into a consumer such as `ChatViewModel`.
+- Arbitrary custom HTTPS hosts are **not** pinned unless the host app configures pins for them.
+- `stopGeneration()` does **not** have a universal "backend is fully quiesced before return" guarantee across every current backend.

--- a/docs/SCOPE_DECISION.md
+++ b/docs/SCOPE_DECISION.md
@@ -37,6 +37,8 @@ The internal consumer is the original home of the compression pipeline and exerc
 - **Mock backend (`MockInferenceBackend`)** — production failure mode where an app-level feature depends on BCK's streaming contract and has no way to test it without loading a real model. We caught this because BCK consumers write XCTests.
 - **Certificate pinning (fail-closed on known cloud APIs)** — production failure mode where a mis-configured device trusts a compromised CA and silently leaks chat traffic. We caught this because BCK ships cloud backends that actually get used in production.
 
+The concrete, implementation-backed version of those guarantees lives in [RELIABILITY.md](RELIABILITY.md).
+
 ## Positioning
 
 BaseChatKit is a drop-in chat framework with operational reliability guarantees, optimized for the ChatbotUI-iOS-shaped consumer: take `ChatView`, `SessionListView`, and `ModelManagementSheet` wholesale, inject an `InferenceService`, and compose app-level features on top of the `ChatViewModel` API. The value is not "we support every backend" — it's "your chat UI keeps working when the network flickers, the user changes their mind mid-load, or iOS decides to reclaim your model's memory."


### PR DESCRIPTION
## Summary
- add a source-backed reliability contract doc and link it from the README, scope decision doc, and BaseChatInference docc overview
- add `ChatSession.record`, route the Core-side `SettingsService` overloads through the inference-side defaults, and cover the bridge/delegation in tests
- update `ChatViewControlTests.test_inputBar_hasTextField` to assert the current loaded-session placeholder instead of the stale default-state string

## Testing
- swift test --filter BaseChatCoreTests --disable-default-traits
- swift test --filter BaseChatInferenceTests --disable-default-traits
- swift test --filter BaseChatUITests --disable-default-traits
- swift test --filter BaseChatBackendsTests --disable-default-traits
- swift test --filter BaseChatSnapshotTests --disable-default-traits

Closes #273
Closes #278
Closes #283

## Not included
- #260 remains blocked by an unrelated local change in `Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift`, so it is not part of this PR.