### PR TITLE
refactor: decompose InferenceService into ModelLifecycleCoordinator + GenerationCoordinator

### DIFF
--- a/Sources/BaseChatInference/Models/GenerationTypes.swift
+++ b/Sources/BaseChatInference/Models/GenerationTypes.swift
@@ -2,10 +2,6 @@
 public struct GenerationRequestToken: Hashable, Comparable, Sendable, CustomStringConvertible {
     public let rawValue: UInt64
 
-    public init(rawValue: UInt64) {
-        self.rawValue = rawValue
-    }
-
     static let zero = Self(rawValue: 0)
 
     public static func < (lhs: Self, rhs: Self) -> Bool {

--- a/Sources/BaseChatInference/Models/GenerationTypes.swift
+++ b/Sources/BaseChatInference/Models/GenerationTypes.swift
@@ -1,0 +1,28 @@
+/// Monotonic identity for each generation request.
+public struct GenerationRequestToken: Hashable, Comparable, Sendable, CustomStringConvertible {
+    public let rawValue: UInt64
+
+    public init(rawValue: UInt64) {
+        self.rawValue = rawValue
+    }
+
+    static let zero = Self(rawValue: 0)
+
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+
+    public var description: String { "gen-\(rawValue)" }
+}
+
+/// Priority for queued generation requests.
+/// Higher priority runs first; FIFO within the same level.
+public enum GenerationPriority: Int, Comparable, Sendable {
+    case background = 0
+    case normal = 1
+    case userInitiated = 2
+
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}

--- a/Sources/BaseChatInference/Protocols/GenerationContextProvider.swift
+++ b/Sources/BaseChatInference/Protocols/GenerationContextProvider.swift
@@ -1,0 +1,11 @@
+/// Provides the generation coordinator with read access to the currently loaded
+/// backend, model-loaded state, and prompt template.
+///
+/// `InferenceService` conforms to this protocol so the `GenerationCoordinator`
+/// can operate without a direct dependency on `ModelLifecycleCoordinator`.
+@MainActor
+protocol GenerationContextProvider: AnyObject {
+    var currentBackend: (any InferenceBackend)? { get }
+    var isBackendLoaded: Bool { get }
+    var selectedPromptTemplate: PromptTemplate { get }
+}

--- a/Sources/BaseChatInference/Services/GenerationCoordinator.swift
+++ b/Sources/BaseChatInference/Services/GenerationCoordinator.swift
@@ -296,7 +296,4 @@ final class GenerationCoordinator {
         requestQueue.removeAll()
     }
 
-    func resetConversation() {
-        provider?.currentBackend?.resetConversation()
-    }
 }

--- a/Sources/BaseChatInference/Services/GenerationCoordinator.swift
+++ b/Sources/BaseChatInference/Services/GenerationCoordinator.swift
@@ -1,0 +1,302 @@
+import Foundation
+import Observation
+
+/// Owns the generation queue, in-flight request tracking, prompt formatting,
+/// and generation lifecycle management.
+///
+/// This is an internal implementation detail of `BaseChatInference`.
+/// `InferenceService` delegates all generation operations to this coordinator
+/// and preserves the unchanged public API.
+@Observable
+@MainActor
+final class GenerationCoordinator {
+
+    // MARK: - Published State
+
+    /// Whether the coordinator has an active generation in progress.
+    ///
+    /// `internal` storage, exposed as `public` via `InferenceService.isGenerating`.
+    private(set) var isGenerating = false
+
+    // MARK: - Dependencies
+
+    weak var provider: (any GenerationContextProvider)?
+
+    // MARK: - Queue Types (Private)
+
+    private struct QueuedRequest {
+        let token: GenerationRequestToken
+        let priority: GenerationPriority
+        let sessionID: UUID?
+        let messages: [(role: String, content: String)]
+        let systemPrompt: String?
+        let config: GenerationConfig
+        let stream: GenerationStream
+    }
+
+    // MARK: - Queue State (Private)
+
+    private var nextGenerationToken: GenerationRequestToken = .zero
+    private var requestQueue: [QueuedRequest] = []
+    private var activeRequest: QueuedRequest?
+    private var activeTask: Task<Void, Never>?
+    private var continuations: [GenerationRequestToken: AsyncThrowingStream<GenerationEvent, Error>.Continuation] = [:]
+    private let maxQueueDepth = 8
+
+    // MARK: - Computed
+
+    var hasQueuedRequests: Bool { !requestQueue.isEmpty }
+
+    var lastTokenUsage: (promptTokens: Int, completionTokens: Int)? {
+        (provider?.currentBackend as? TokenUsageProvider)?.lastUsage
+    }
+
+    // MARK: - Initializers
+
+    nonisolated init() {}
+
+    // MARK: - Generation (Non-Queued)
+
+    /// Generates text from a message history, streaming tokens via the active backend.
+    ///
+    /// This is the low-level, non-queued entry point. It does **not** participate
+    /// in the generation queue.
+    func generate(
+        messages: [(role: String, content: String)],
+        systemPrompt: String? = nil,
+        temperature: Float = 0.7,
+        topP: Float = 0.9,
+        repeatPenalty: Float = 1.1,
+        maxOutputTokens: Int? = 2048
+    ) throws -> GenerationStream {
+        guard let backend = provider?.currentBackend else {
+            throw InferenceError.inferenceFailure("No model loaded")
+        }
+
+        let config = GenerationConfig(
+            temperature: temperature,
+            topP: topP,
+            repeatPenalty: repeatPenalty,
+            maxOutputTokens: maxOutputTokens
+        )
+
+        let prompt: String
+        let effectiveSystemPrompt: String?
+
+        if backend.capabilities.requiresPromptTemplate {
+            let template = provider?.selectedPromptTemplate ?? .chatML
+            prompt = template.format(
+                messages: messages,
+                systemPrompt: systemPrompt
+            )
+            effectiveSystemPrompt = nil
+        } else {
+            prompt = messages.last(where: { $0.role == "user" })?.content ?? ""
+            effectiveSystemPrompt = systemPrompt
+        }
+
+        if let historyReceiver = backend as? ConversationHistoryReceiver {
+            historyReceiver.setConversationHistory(messages)
+        }
+
+        return try backend.generate(
+            prompt: prompt,
+            systemPrompt: effectiveSystemPrompt,
+            config: config
+        )
+    }
+
+    // MARK: - Generation Queue
+
+    func enqueue(
+        messages: [(role: String, content: String)],
+        systemPrompt: String? = nil,
+        temperature: Float = 0.7,
+        topP: Float = 0.9,
+        repeatPenalty: Float = 1.1,
+        maxOutputTokens: Int? = 2048,
+        priority: GenerationPriority = .normal,
+        sessionID: UUID? = nil
+    ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
+        guard provider?.currentBackend != nil, provider?.isBackendLoaded == true else {
+            throw InferenceError.inferenceFailure("No model loaded")
+        }
+        guard requestQueue.count < maxQueueDepth else {
+            throw InferenceError.inferenceFailure("Generation queue is full")
+        }
+
+        let token = GenerationRequestToken(rawValue: nextGenerationToken.rawValue + 1)
+        nextGenerationToken = token
+
+        var continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation!
+        let rawStream = AsyncThrowingStream<GenerationEvent, Error> { continuation = $0 }
+        let stream = GenerationStream(rawStream)
+        stream.setPhase(.queued)
+        continuations[token] = continuation
+
+        let config = GenerationConfig(
+            temperature: temperature,
+            topP: topP,
+            repeatPenalty: repeatPenalty,
+            maxOutputTokens: maxOutputTokens
+        )
+
+        let request = QueuedRequest(
+            token: token,
+            priority: priority,
+            sessionID: sessionID,
+            messages: messages,
+            systemPrompt: systemPrompt,
+            config: config,
+            stream: stream
+        )
+
+        if let insertIdx = requestQueue.firstIndex(where: { $0.priority < priority }) {
+            requestQueue.insert(request, at: insertIdx)
+        } else {
+            requestQueue.append(request)
+        }
+
+        drainQueue()
+        return (token: token, stream: stream)
+    }
+
+    /// Processes the next queued request if no generation is active.
+    private func drainQueue() {
+        guard activeRequest == nil, !requestQueue.isEmpty else { return }
+
+        let next = requestQueue.removeFirst()
+
+        // Thermal gate: drop background requests under thermal pressure.
+        if next.priority == .background {
+            let thermal = ProcessInfo.processInfo.thermalState
+            if thermal == .serious || thermal == .critical {
+                let throttleError = InferenceError.inferenceFailure("Thermal throttle")
+                Log.inference.warning("Dropping background generation \(next.token): thermal state \(thermal.rawValue)")
+                next.stream.setPhase(.failed(throttleError.localizedDescription))
+                finishAndDiscard(next.token, error: throttleError)
+                drainQueue()
+                return
+            }
+        }
+
+        activeRequest = next
+        isGenerating = true
+        next.stream.setPhase(.connecting)
+
+        activeTask = Task { [weak self] in
+            guard let self else { return }
+
+            var thrownError: Error?
+            defer {
+                if let continuation = self.continuations.removeValue(forKey: next.token) {
+                    if let thrownError {
+                        continuation.finish(throwing: thrownError)
+                    } else {
+                        continuation.finish()
+                    }
+                }
+                if self.activeRequest?.token == next.token {
+                    self.activeRequest = nil
+                    self.activeTask = nil
+                    self.isGenerating = false
+                    self.drainQueue()
+                }
+            }
+
+            do {
+                let backendStream = try self.generate(
+                    messages: next.messages,
+                    systemPrompt: next.systemPrompt,
+                    temperature: next.config.temperature,
+                    topP: next.config.topP,
+                    repeatPenalty: next.config.repeatPenalty,
+                    maxOutputTokens: next.config.maxOutputTokens
+                )
+
+                for try await event in backendStream.events {
+                    guard !Task.isCancelled else { break }
+                    if case .token = event, next.stream.phase != .streaming {
+                        next.stream.setPhase(.streaming)
+                    }
+                    self.continuations[next.token]?.yield(event)
+                }
+
+                if Task.isCancelled {
+                    next.stream.setPhase(.failed("Cancelled"))
+                } else {
+                    next.stream.setPhase(.done)
+                }
+            } catch {
+                thrownError = error
+                if Task.isCancelled {
+                    next.stream.setPhase(.failed("Cancelled"))
+                } else {
+                    next.stream.setPhase(.failed(error.localizedDescription))
+                }
+            }
+        }
+    }
+
+    private func finishAndDiscard(_ token: GenerationRequestToken, error: Error? = nil) {
+        if let error {
+            continuations[token]?.finish(throwing: error)
+        } else {
+            continuations[token]?.finish(throwing: CancellationError())
+        }
+        continuations.removeValue(forKey: token)
+    }
+
+    func cancel(_ token: GenerationRequestToken) {
+        if activeRequest?.token == token {
+            provider?.currentBackend?.stopGeneration()
+            activeTask?.cancel()
+            activeTask = nil
+            activeRequest?.stream.setPhase(.failed("Cancelled"))
+            finishAndDiscard(token)
+            activeRequest = nil
+            isGenerating = false
+            drainQueue()
+        } else if let idx = requestQueue.firstIndex(where: { $0.token == token }) {
+            let req = requestQueue.remove(at: idx)
+            req.stream.setPhase(.failed("Cancelled"))
+            finishAndDiscard(token)
+        }
+    }
+
+    func discardRequests(notMatching sessionID: UUID) {
+        requestQueue.removeAll { req in
+            guard let reqSession = req.sessionID, reqSession != sessionID else { return false }
+            req.stream.setPhase(.failed("Session changed"))
+            finishAndDiscard(req.token, error: InferenceError.inferenceFailure("Session changed"))
+            return true
+        }
+        if let active = activeRequest,
+           let activeSession = active.sessionID,
+           activeSession != sessionID {
+            cancel(active.token)
+        }
+    }
+
+    func stopGeneration() {
+        provider?.currentBackend?.stopGeneration()
+        activeTask?.cancel()
+        activeTask = nil
+        if let active = activeRequest {
+            active.stream.setPhase(.failed("Cancelled"))
+            finishAndDiscard(active.token, error: CancellationError())
+        }
+        activeRequest = nil
+        isGenerating = false
+
+        for req in requestQueue {
+            req.stream.setPhase(.failed("Cancelled"))
+            finishAndDiscard(req.token, error: CancellationError())
+        }
+        requestQueue.removeAll()
+    }
+
+    func resetConversation() {
+        provider?.currentBackend?.resetConversation()
+    }
+}

--- a/Sources/BaseChatInference/Services/InferenceService.swift
+++ b/Sources/BaseChatInference/Services/InferenceService.swift
@@ -108,6 +108,10 @@ public final class InferenceService {
 
     // MARK: - Model Lifecycle
 
+    /// Loads a model using the appropriate backend for its format.
+    ///
+    /// If another load request starts before this call completes, this request is
+    /// treated as stale and its completion is suppressed.
     public func loadModel(
         from modelInfo: ModelInfo,
         contextSize: Int32 = 2048
@@ -117,12 +121,18 @@ public final class InferenceService {
         try await lifecycle.loadModel(from: modelInfo, contextSize: contextSize)
     }
 
+    /// Loads a cloud API backend from an `APIEndpointRecord` configuration.
+    ///
+    /// Follows the same latest-wins/stale-suppression semantics as `loadModel`.
     public func loadCloudBackend(from endpoint: APIEndpointRecord) async throws {
         ensureProviderWired()
         generation.stopGeneration()
         try await lifecycle.loadCloudBackend(from: endpoint)
     }
 
+    /// Unloads the current model and frees all associated memory.
+    ///
+    /// Also cancels in-flight generation and preempts outstanding load requests.
     public func unloadModel() {
         ensureProviderWired()
         generation.stopGeneration()
@@ -131,6 +141,10 @@ public final class InferenceService {
 
     // MARK: - Generation
 
+    /// Generates text from a message history, streaming tokens via the active backend.
+    ///
+    /// This is the low-level, non-queued entry point. Use ``enqueue`` for
+    /// user-facing chat generation that must be serialized.
     public func generate(
         messages: [(role: String, content: String)],
         systemPrompt: String? = nil,
@@ -152,6 +166,10 @@ public final class InferenceService {
 
     // MARK: - Generation Queue
 
+    /// Enqueues a generation request and returns a token + stream pair.
+    ///
+    /// The stream starts in `.queued` phase and transitions to `.connecting`
+    /// when the request reaches the front of the queue.
     public func enqueue(
         messages: [(role: String, content: String)],
         systemPrompt: String? = nil,
@@ -175,6 +193,10 @@ public final class InferenceService {
         )
     }
 
+    /// Cancels a specific generation request by token.
+    ///
+    /// If the token matches the active request, it is stopped and the next
+    /// queued item begins. If queued, the request is removed without executing.
     public func cancel(_ token: GenerationRequestToken) {
         ensureProviderWired()
         generation.cancel(token)
@@ -186,15 +208,20 @@ public final class InferenceService {
     }
 
     public var lastTokenUsage: (promptTokens: Int, completionTokens: Int)? {
-        generation.lastTokenUsage
+        ensureProviderWired()
+        return generation.lastTokenUsage
     }
 
+    /// Requests that the current generation stop and cancels all queued requests.
     public func stopGeneration() {
         ensureProviderWired()
         generation.stopGeneration()
     }
 
-    public var hasQueuedRequests: Bool { generation.hasQueuedRequests }
+    public var hasQueuedRequests: Bool {
+        ensureProviderWired()
+        return generation.hasQueuedRequests
+    }
 
     @available(*, deprecated, message: "The queue auto-drains when the stream terminates. This method is a no-op and will be removed in a future release.")
     public func generationDidFinish() {}

--- a/Sources/BaseChatInference/Services/InferenceService.swift
+++ b/Sources/BaseChatInference/Services/InferenceService.swift
@@ -54,370 +54,83 @@ public typealias CloudBackendFactory = @MainActor (APIProvider) -> (any Inferenc
 @MainActor
 public final class InferenceService {
 
-    // MARK: - Published State
+    // MARK: - Internal Coordinators
 
-    public private(set) var isModelLoaded = false
-    public private(set) var isGenerating = false
+    private let lifecycle: ModelLifecycleCoordinator
+    private let generation: GenerationCoordinator
 
-    /// The name of the active backend (e.g., "MLX", "llama.cpp"), for display.
-    public private(set) var activeBackendName: String?
+    // MARK: - Public Type Aliases (preserve InferenceService.GenerationRequestToken syntax)
 
-    /// Progress of the in-flight model load, in `[0.0, 1.0]`.
-    ///
-    /// `nil` means no load is in progress. Set to `0.0` when `loadModel` or
-    /// `loadCloudBackend` begins, then updated by backends that adopt
-    /// ``LoadProgressReporting``. Backends without granular progress simply
-    /// stay at `0.0` until ``isModelLoaded`` flips to `true`. Returns to `nil`
-    /// once the load completes (success, failure, or supersession by a newer
-    /// request).
-    public private(set) var modelLoadProgress: Double?
+    public typealias GenerationRequestToken = BaseChatInference.GenerationRequestToken
+    public typealias GenerationPriority = BaseChatInference.GenerationPriority
+
+    // MARK: - Published State (forwarded from coordinators)
+
+    public var isModelLoaded: Bool { lifecycle.isModelLoaded }
+    public var isGenerating: Bool { generation.isGenerating }
+    public var activeBackendName: String? { lifecycle.activeBackendName }
+    public var modelLoadProgress: Double? { lifecycle.modelLoadProgress }
 
     /// The prompt template to apply for backends that require one (GGUF).
-    public var selectedPromptTemplate: PromptTemplate = .chatML
+    public var selectedPromptTemplate: PromptTemplate {
+        get { lifecycle.selectedPromptTemplate }
+        set { lifecycle.selectedPromptTemplate = newValue }
+    }
 
     // MARK: - Computed
 
-    /// Capabilities of the currently loaded backend, or `nil` if none loaded.
-    public var capabilities: BackendCapabilities? {
-        backend?.capabilities
-    }
+    public var capabilities: BackendCapabilities? { lifecycle.capabilities }
 
     // MARK: - Memory Gate
 
-    /// Optional pre-flight memory check. When set, `loadModel()` checks available
-    /// memory before loading and either throws (iOS) or warns (macOS) if insufficient.
-    public var memoryGate: MemoryGate?
+    public var memoryGate: MemoryGate? {
+        get { lifecycle.memoryGate }
+        set { lifecycle.memoryGate = newValue }
+    }
 
-    // MARK: - Backend Registry
+    // MARK: - Backend Registration
 
-    private var backendFactories: [BackendFactory] = []
-    private var cloudBackendFactories: [CloudBackendFactory] = []
-
-    /// Model types that have at least one registered factory.
-    ///
-    /// Populated by callers via `declareSupport(for:)` at registration time
-    /// so the service can answer capability queries without instantiating backends.
-    private var supportedLocalModelTypes: Set<ModelType> = []
-
-    /// API providers that have at least one registered cloud factory.
-    ///
-    /// Cloud providers are always registered together by `DefaultBackends`, so
-    /// callers declare the full set they support when they register factories.
-    private var supportedCloudProviders: Set<APIProvider> = []
-
-    /// Registers a factory that can create a local inference backend.
-    ///
-    /// Factories are tried in registration order; the first non-nil result wins.
     public func registerBackendFactory(_ factory: @escaping BackendFactory) {
-        backendFactories.append(factory)
+        lifecycle.registerBackendFactory(factory)
     }
 
-    /// Registers a factory that can create a cloud inference backend.
-    ///
-    /// Factories are tried in registration order; the first non-nil result wins.
     public func registerCloudBackendFactory(_ factory: @escaping CloudBackendFactory) {
-        cloudBackendFactories.append(factory)
+        lifecycle.registerCloudBackendFactory(factory)
     }
 
-    /// Declares that a registered factory supports the given local model type.
-    ///
-    /// Call this immediately after `registerBackendFactory` for each model type
-    /// the factory handles. `DefaultBackends.register(with:)` calls this automatically.
     public func declareSupport(for modelType: ModelType) {
-        supportedLocalModelTypes.insert(modelType)
+        lifecycle.declareSupport(for: modelType)
     }
 
-    /// Declares that a registered factory supports the given API provider.
-    ///
-    /// Call this immediately after `registerCloudBackendFactory` for each provider
-    /// the factory handles. `DefaultBackends.register(with:)` calls this automatically.
     public func declareSupport(for provider: APIProvider) {
-        supportedCloudProviders.insert(provider)
+        lifecycle.declareSupport(for: provider)
     }
-
-    // MARK: - Private State
-
-    private var backend: (any InferenceBackend)?
-    /// Monotonic identity for each load attempt.
-    ///
-    /// Invariants:
-    /// - Tokens are strictly increasing for the lifetime of the service.
-    /// - Only the latest requested token can commit a loaded backend.
-    /// - `unloadModel()` invalidates all tokens issued up to that moment.
-    private struct LoadRequestToken: Hashable, Comparable, Sendable {
-        let rawValue: UInt64
-
-        static let zero = Self(rawValue: 0)
-
-        static func < (lhs: Self, rhs: Self) -> Bool {
-            lhs.rawValue < rhs.rawValue
-        }
-    }
-
-    // MARK: - Generation Queue Types
-
-    /// Monotonic identity for each generation request.
-    public struct GenerationRequestToken: Hashable, Comparable, Sendable, CustomStringConvertible {
-        public let rawValue: UInt64
-        static let zero = Self(rawValue: 0)
-        public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
-        public var description: String { "gen-\(rawValue)" }
-    }
-
-    /// Priority for queued generation requests.
-    /// Higher priority runs first; FIFO within the same level.
-    public enum GenerationPriority: Int, Comparable, Sendable {
-        case background = 0
-        case normal = 1
-        case userInitiated = 2
-        public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
-    }
-
-    private struct QueuedRequest {
-        let token: GenerationRequestToken
-        let priority: GenerationPriority
-        let sessionID: UUID?
-        let messages: [(role: String, content: String)]
-        let systemPrompt: String?
-        let config: GenerationConfig
-        let stream: GenerationStream
-    }
-
-    // MARK: - Generation Queue State
-
-    private var nextGenerationToken: GenerationRequestToken = .zero
-    private var requestQueue: [QueuedRequest] = []
-    private var activeRequest: QueuedRequest?
-    private var activeTask: Task<Void, Never>?
-    private var continuations: [GenerationRequestToken: AsyncThrowingStream<GenerationEvent, Error>.Continuation] = [:]
-
-    /// Maximum queued requests. Excess enqueues fail immediately.
-    private let maxQueueDepth = 8
-
-    /// Whether there are pending requests behind the active one.
-    public var hasQueuedRequests: Bool { !requestQueue.isEmpty }
-
-    /// Tracks model-load lifecycle state.
-    ///
-    /// Invariants:
-    /// - `.loading` and `.loaded` always reference a previously issued token.
-    /// - `.loaded` means the loaded backend was committed by the same token.
-    /// - Any completion that does not match the active `.loading` token is stale.
-    private enum LoadPhase: Equatable {
-        case idle
-        case loading(request: LoadRequestToken)
-        case loaded(request: LoadRequestToken)
-    }
-
-    private struct LoadRequestMetadata {
-        let source: String
-        let target: String
-        let backend: String
-        let startedAtUptime: TimeInterval
-    }
-
-    // Two-tier load coordination:
-    // - InferenceService (this layer) owns backend state correctness via monotonic
-    //   LoadRequestToken — stale successes are unloaded and stale failures are ignored.
-    // - ChatViewModel owns UI task lifecycle via `latestLoadIntentGeneration` — it cancels
-    //   superseded async tasks before they reach this layer.
-    // Together they provide defense-in-depth: the VM avoids redundant load attempts;
-    // this layer provides the hard correctness guarantee.
-    private var nextLoadRequestToken: LoadRequestToken = .zero
-    private var latestRequestedLoadToken: LoadRequestToken?
-    private var invalidatedThroughToken: LoadRequestToken = .zero
-    private var loadPhase: LoadPhase = .idle
-    private var loadRequestMetadataByToken: [LoadRequestToken: LoadRequestMetadata] = [:]
 
     // MARK: - Model Lifecycle
 
-    /// Loads a model using the appropriate backend for its format.
-    ///
-    /// If another load request starts before this call completes, this request is
-    /// treated as stale and its completion is suppressed.
     public func loadModel(
         from modelInfo: ModelInfo,
         contextSize: Int32 = 2048
     ) async throws {
-        unloadModel()
-
-        guard let newBackend = createBackend(for: modelInfo.modelType) else {
-            throw InferenceError.inferenceFailure(
-                "No registered backend can handle model type \(modelInfo.modelType). "
-                + "Register a BackendFactory before loading models."
-            )
-        }
-
-        // Pre-flight memory check
-        if let gate = memoryGate {
-            let verdict = gate.check(
-                modelFileSize: modelInfo.fileSize,
-                strategy: newBackend.capabilities.memoryStrategy
-            )
-            switch verdict {
-            case .allow:
-                break
-            case .warn(let estimated, let available):
-                let estMB = estimated / 1_048_576
-                let availMB = available / 1_048_576
-                Log.inference.warning("Memory warning: model needs ~\(estMB) MB, \(availMB) MB available")
-            case .deny(let estimated, let available):
-                switch gate.denyBehavior {
-                case .throwError:
-                    throw InferenceError.memoryInsufficient(
-                        required: estimated, available: available
-                    )
-                case .warnOnly:
-                    let estMB = estimated / 1_048_576
-                    let availMB = available / 1_048_576
-                    Log.inference.warning("Memory insufficient: model needs ~\(estMB) MB, \(availMB) MB available. Proceeding (may swap).")
-                }
-            }
-        }
-
-        let backendName = backendDisplayName(for: modelInfo.modelType)
-        let request = beginLoadRequest(
-            source: "local",
-            target: modelTypeLogLabel(modelInfo.modelType),
-            backend: backendName
-        )
-        installProgressHandler(on: newBackend, for: request)
-        do {
-            // Run backend model loading off the main actor so heavy blocking work
-            // (e.g. llama_model_load_from_file, llama_init_from_model) does not
-            // freeze the UI or trigger the iOS watchdog gesture gate timeout.
-            // After the Task completes we resume on @MainActor for the commit step.
-            let url = modelInfo.url
-            try await Task.detached(priority: .userInitiated) {
-                try await newBackend.loadModel(from: url, contextSize: contextSize)
-            }.value
-        } catch {
-            (newBackend as? LoadProgressReporting)?.setLoadProgressHandler(nil)
-            let isStale = finishLoadAttemptWithFailure(request, error: error)
-            if isStale {
-                // The failure arrived after a newer request superseded this one.
-                // Clean up any partial backend state so resources are not leaked.
-                newBackend.unloadModel()
-            }
-            throw error
-        }
-        (newBackend as? LoadProgressReporting)?.setLoadProgressHandler(nil)
-
-        logLoadEvent("load.complete", request: request)
-        guard commitLoadIfCurrent(request: request, backend: newBackend, backendName: backendName) else {
-            newBackend.unloadModel()
-            logLoadEvent("load.suppress", request: request, reason: "stale-success", clearMetadata: true)
-            return
-        }
+        ensureProviderWired()
+        generation.stopGeneration()
+        try await lifecycle.loadModel(from: modelInfo, contextSize: contextSize)
     }
 
-    /// Loads a cloud API backend from an `APIEndpointRecord` configuration.
-    ///
-    /// Follows the same latest-wins/stale-suppression semantics as `loadModel`.
     public func loadCloudBackend(from endpoint: APIEndpointRecord) async throws {
-        unloadModel()
-
-        guard let url = URL(string: endpoint.baseURL) else {
-            throw CloudBackendError.invalidURL(endpoint.baseURL)
-        }
-
-        guard let newBackend = createCloudBackend(for: endpoint.provider) else {
-            throw InferenceError.inferenceFailure(
-                "No registered cloud backend factory can handle provider \(endpoint.provider.rawValue). "
-                + "Register a CloudBackendFactory before loading cloud backends."
-            )
-        }
-
-        switch endpoint.provider {
-        case .claude, .openAI, .custom:
-            guard let keychainConfigurable = newBackend as? CloudBackendKeychainConfigurable else {
-                throw InferenceError.inferenceFailure(
-                    "Cloud backend \(type(of: newBackend)) must conform to CloudBackendKeychainConfigurable "
-                    + "for provider \(endpoint.provider.rawValue)."
-                )
-            }
-            keychainConfigurable.configure(
-                baseURL: url,
-                keychainAccount: endpoint.keychainAccount,
-                modelName: endpoint.modelName
-            )
-
-        case .ollama, .lmStudio:
-            guard let urlModelConfigurable = newBackend as? CloudBackendURLModelConfigurable else {
-                throw InferenceError.inferenceFailure(
-                    "Cloud backend \(type(of: newBackend)) must conform to CloudBackendURLModelConfigurable "
-                    + "for provider \(endpoint.provider.rawValue)."
-                )
-            }
-            urlModelConfigurable.configure(baseURL: url, modelName: endpoint.modelName)
-        }
-
-        let request = beginLoadRequest(
-            source: "cloud",
-            target: endpoint.provider.rawValue,
-            backend: endpoint.provider.rawValue
-        )
-        installProgressHandler(on: newBackend, for: request)
-        do {
-            // Run backend initialisation off the main actor for consistency with
-            // local model loading — cloud backends may perform blocking I/O during
-            // their loadModel step (e.g. keychain reads, capability negotiation).
-            let backendURL = url
-            try await Task.detached(priority: .userInitiated) {
-                try await newBackend.loadModel(from: backendURL, contextSize: 0)
-            }.value
-        } catch {
-            (newBackend as? LoadProgressReporting)?.setLoadProgressHandler(nil)
-            let isStale = finishLoadAttemptWithFailure(request, error: error)
-            if isStale {
-                // Clean up any partial backend state so resources are not leaked.
-                newBackend.unloadModel()
-            }
-            throw error
-        }
-        (newBackend as? LoadProgressReporting)?.setLoadProgressHandler(nil)
-
-        logLoadEvent("load.complete", request: request)
-        guard commitLoadIfCurrent(
-            request: request,
-            backend: newBackend,
-            backendName: endpoint.provider.rawValue
-        ) else {
-            newBackend.unloadModel()
-            logLoadEvent("load.suppress", request: request, reason: "stale-success", clearMetadata: true)
-            return
-        }
+        ensureProviderWired()
+        generation.stopGeneration()
+        try await lifecycle.loadCloudBackend(from: endpoint)
     }
 
-    /// Unloads the current model and frees all associated memory.
-    ///
-    /// Also preempts in-flight load requests by invalidating their request tokens.
-    /// Any late completion from an invalidated request is discarded.
     public func unloadModel() {
-        invalidateOutstandingLoads()
-        stopGeneration()
-        backend?.unloadModel()
-        backend = nil
-        isModelLoaded = false
-        activeBackendName = nil
+        ensureProviderWired()
+        generation.stopGeneration()
+        lifecycle.unloadModel()
     }
 
     // MARK: - Generation
 
-    /// Generates text from a message history, streaming tokens via the active backend.
-    ///
-    /// This is the low-level, non-queued entry point. It does **not** participate
-    /// in the generation queue — use ``enqueue(messages:systemPrompt:temperature:topP:repeatPenalty:maxOutputTokens:priority:sessionID:)``
-    /// for user-facing chat generation that must be serialized.
-    ///
-    /// Direct callers (e.g. title generation) are short-lived and don't
-    /// conflict with queued work because backends serialize at their own
-    /// level (LlamaBackend via NSLock, MLXBackend via actor isolation).
-    ///
-    /// For backends that require prompt templates (GGUF), messages are formatted
-    /// into a single prompt string using `selectedPromptTemplate`. For MLX and
-    /// Foundation, the last user message is passed directly (they handle chat
-    /// formatting internally).
     public func generate(
         messages: [(role: String, content: String)],
         systemPrompt: String? = nil,
@@ -426,54 +139,19 @@ public final class InferenceService {
         repeatPenalty: Float = 1.1,
         maxOutputTokens: Int? = 2048
     ) throws -> GenerationStream {
-        guard let backend else {
-            throw InferenceError.inferenceFailure("No model loaded")
-        }
-
-        let config = GenerationConfig(
+        ensureProviderWired()
+        return try generation.generate(
+            messages: messages,
+            systemPrompt: systemPrompt,
             temperature: temperature,
             topP: topP,
             repeatPenalty: repeatPenalty,
             maxOutputTokens: maxOutputTokens
         )
-
-        let prompt: String
-        let effectiveSystemPrompt: String?
-
-        if backend.capabilities.requiresPromptTemplate {
-            // GGUF: format the entire conversation using the selected template.
-            // System prompt is baked into the formatted string.
-            prompt = selectedPromptTemplate.format(
-                messages: messages,
-                systemPrompt: systemPrompt
-            )
-            effectiveSystemPrompt = nil
-        } else {
-            // MLX / Foundation / Cloud: pass the last user message as prompt.
-            // Cloud backends receive full history via their own mechanism.
-            prompt = messages.last(where: { $0.role == "user" })?.content ?? ""
-            effectiveSystemPrompt = systemPrompt
-        }
-
-        // For cloud backends, allow them to receive the full conversation history
-        // via the ConversationHistoryReceiver protocol if they adopt it.
-        if let historyReceiver = backend as? ConversationHistoryReceiver {
-            historyReceiver.setConversationHistory(messages)
-        }
-
-        return try backend.generate(
-            prompt: prompt,
-            systemPrompt: effectiveSystemPrompt,
-            config: config
-        )
     }
 
     // MARK: - Generation Queue
 
-    /// Enqueues a generation request and returns a token + stream pair.
-    ///
-    /// The stream starts in `.queued` phase and transitions to `.connecting`
-    /// when the request reaches the front of the queue.
     public func enqueue(
         messages: [(role: String, content: String)],
         systemPrompt: String? = nil,
@@ -484,454 +162,94 @@ public final class InferenceService {
         priority: GenerationPriority = .normal,
         sessionID: UUID? = nil
     ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
-        guard backend != nil, isModelLoaded else {
-            throw InferenceError.inferenceFailure("No model loaded")
-        }
-        guard requestQueue.count < maxQueueDepth else {
-            throw InferenceError.inferenceFailure("Generation queue is full")
-        }
-
-        let token = GenerationRequestToken(rawValue: nextGenerationToken.rawValue + 1)
-        nextGenerationToken = token
-
-        var continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation!
-        let rawStream = AsyncThrowingStream<GenerationEvent, Error> { continuation = $0 }
-        let stream = GenerationStream(rawStream)
-        stream.setPhase(.queued)
-        continuations[token] = continuation
-
-        let config = GenerationConfig(
+        ensureProviderWired()
+        return try generation.enqueue(
+            messages: messages,
+            systemPrompt: systemPrompt,
             temperature: temperature,
             topP: topP,
             repeatPenalty: repeatPenalty,
-            maxOutputTokens: maxOutputTokens
-        )
-
-        let request = QueuedRequest(
-            token: token,
+            maxOutputTokens: maxOutputTokens,
             priority: priority,
-            sessionID: sessionID,
-            messages: messages,
-            systemPrompt: systemPrompt,
-            config: config,
-            stream: stream
+            sessionID: sessionID
         )
-
-        // Priority-sorted insertion: higher priority before lower, FIFO within same level.
-        if let insertIdx = requestQueue.firstIndex(where: { $0.priority < priority }) {
-            requestQueue.insert(request, at: insertIdx)
-        } else {
-            requestQueue.append(request)
-        }
-
-        drainQueue()
-        return (token: token, stream: stream)
     }
 
-    /// Processes the next queued request if no generation is active.
-    ///
-    /// Synchronous — launches a Task for the active generation, never awaits inline.
-    /// This prevents actor reentrancy corruption.
-    private func drainQueue() {
-        guard activeRequest == nil, !requestQueue.isEmpty else { return }
-
-        let next = requestQueue.removeFirst()
-
-        // Thermal gate: drop background requests under thermal pressure.
-        if next.priority == .background {
-            let thermal = ProcessInfo.processInfo.thermalState
-            if thermal == .serious || thermal == .critical {
-                let throttleError = InferenceError.inferenceFailure("Thermal throttle")
-                Log.inference.warning("Dropping background generation \(next.token): thermal state \(thermal.rawValue)")
-                next.stream.setPhase(.failed(throttleError.localizedDescription))
-                finishAndDiscard(next.token, error: throttleError)
-                drainQueue()
-                return
-            }
-        }
-
-        activeRequest = next
-        isGenerating = true
-        next.stream.setPhase(.connecting)
-
-        activeTask = Task { [weak self] in
-            guard let self else { return }
-
-            // Ensure the continuation is always cleaned up, even if a new
-            // cancellation or error path is added later. The nil-check is
-            // intentional: cancel() may have already called finishAndDiscard().
-            var thrownError: Error?
-            defer {
-                if let continuation = self.continuations.removeValue(forKey: next.token) {
-                    if let thrownError {
-                        continuation.finish(throwing: thrownError)
-                    } else {
-                        continuation.finish()
-                    }
-                }
-                // Auto-drain: clear the active slot and start the next queued
-                // request without requiring the consumer to call generationDidFinish().
-                //
-                // The token guard is critical: cancel() and stopGeneration() nil
-                // out activeRequest synchronously BEFORE this defer fires. Without
-                // the guard, a cancelled slot would re-enter drain and incorrectly
-                // start a new generation.
-                if self.activeRequest?.token == next.token {
-                    self.activeRequest = nil
-                    self.activeTask = nil
-                    self.isGenerating = false
-                    self.drainQueue()
-                }
-            }
-
-            do {
-                let backendStream = try self.generate(
-                    messages: next.messages,
-                    systemPrompt: next.systemPrompt,
-                    temperature: next.config.temperature,
-                    topP: next.config.topP,
-                    repeatPenalty: next.config.repeatPenalty,
-                    maxOutputTokens: next.config.maxOutputTokens
-                )
-
-                for try await event in backendStream.events {
-                    guard !Task.isCancelled else { break }
-                    if case .token = event, next.stream.phase != .streaming {
-                        next.stream.setPhase(.streaming)
-                    }
-                    self.continuations[next.token]?.yield(event)
-                }
-
-                if Task.isCancelled {
-                    next.stream.setPhase(.failed("Cancelled"))
-                } else {
-                    next.stream.setPhase(.done)
-                }
-            } catch {
-                thrownError = error
-                if Task.isCancelled {
-                    next.stream.setPhase(.failed("Cancelled"))
-                } else {
-                    next.stream.setPhase(.failed(error.localizedDescription))
-                }
-            }
-        }
-    }
-
-    /// Finishes the continuation for a token and removes it from the map.
-    /// Every removal path must use this to prevent leaked continuations.
-    private func finishAndDiscard(_ token: GenerationRequestToken, error: Error? = nil) {
-        if let error {
-            continuations[token]?.finish(throwing: error)
-        } else {
-            continuations[token]?.finish(throwing: CancellationError())
-        }
-        continuations.removeValue(forKey: token)
-    }
-
-    /// Cancels a specific generation request by token.
-    ///
-    /// If the token matches the active request, it is stopped and the next
-    /// queued item begins. If queued, the request is removed without executing.
     public func cancel(_ token: GenerationRequestToken) {
-        if activeRequest?.token == token {
-            backend?.stopGeneration()
-            activeTask?.cancel()
-            activeTask = nil
-            activeRequest?.stream.setPhase(.failed("Cancelled"))
-            finishAndDiscard(token)
-            activeRequest = nil
-            isGenerating = false
-            drainQueue()
-        } else if let idx = requestQueue.firstIndex(where: { $0.token == token }) {
-            let req = requestQueue.remove(at: idx)
-            req.stream.setPhase(.failed("Cancelled"))
-            finishAndDiscard(token)
-        }
+        ensureProviderWired()
+        generation.cancel(token)
     }
 
-    /// Discards all queued and active requests that don't match the given session.
-    ///
-    /// Requests with `nil` sessionID are session-agnostic and are never discarded.
     public func discardRequests(notMatching sessionID: UUID) {
-        requestQueue.removeAll { req in
-            guard let reqSession = req.sessionID, reqSession != sessionID else { return false }
-            req.stream.setPhase(.failed("Session changed"))
-            finishAndDiscard(req.token, error: InferenceError.inferenceFailure("Session changed"))
-            return true
-        }
-        if let active = activeRequest,
-           let activeSession = active.sessionID,
-           activeSession != sessionID {
-            cancel(active.token)
-        }
+        ensureProviderWired()
+        generation.discardRequests(notMatching: sessionID)
     }
 
-    /// Token usage from the last cloud API generation, if available.
-    ///
-    /// Backends that track token usage should adopt the `TokenUsageProvider` protocol.
     public var lastTokenUsage: (promptTokens: Int, completionTokens: Int)? {
-        (backend as? TokenUsageProvider)?.lastUsage
+        generation.lastTokenUsage
     }
 
-    /// Requests that the current generation stop and cancels all queued requests.
     public func stopGeneration() {
-        backend?.stopGeneration()
-        activeTask?.cancel()
-        activeTask = nil
-        if let active = activeRequest {
-            active.stream.setPhase(.failed("Cancelled"))
-            finishAndDiscard(active.token, error: CancellationError())
-        }
-        activeRequest = nil
-        isGenerating = false
-
-        for req in requestQueue {
-            req.stream.setPhase(.failed("Cancelled"))
-            finishAndDiscard(req.token, error: CancellationError())
-        }
-        requestQueue.removeAll()
+        ensureProviderWired()
+        generation.stopGeneration()
     }
 
-    /// Notifies the service that generation has finished.
-    ///
-    /// - Note: Deprecated. The queue auto-drains when the stream terminates.
-    ///   This method is a no-op and will be removed in a future release.
+    public var hasQueuedRequests: Bool { generation.hasQueuedRequests }
+
     @available(*, deprecated, message: "The queue auto-drains when the stream terminates. This method is a no-op and will be removed in a future release.")
-    public func generationDidFinish() {
-        // No-op. The queue auto-drains via the activeTask defer in drainQueue().
-    }
+    public func generationDidFinish() {}
 
-    /// Resets conversation state in the active backend without unloading the model.
-    ///
-    /// Call when switching between sessions or stories so backends that track
-    /// multi-turn history (e.g. Foundation) start fresh.
     public func resetConversation() {
-        backend?.resetConversation()
+        lifecycle.resetConversation()
     }
 
-    // MARK: - Backend Selection
+    // MARK: - Tokenizer
 
-    private func createBackend(for modelType: ModelType) -> (any InferenceBackend)? {
-        for factory in backendFactories {
-            if let backend = factory(modelType) {
-                return backend
-            }
-        }
-        return nil
-    }
-
-    private func createCloudBackend(for provider: APIProvider) -> (any InferenceBackend)? {
-        for factory in cloudBackendFactories {
-            if let backend = factory(provider) {
-                return backend
-            }
-        }
-        return nil
-    }
-
-    private func backendDisplayName(for modelType: ModelType) -> String {
-        switch modelType {
-        case .mlx: "MLX"
-        case .gguf: "llama.cpp"
-        case .foundation: "Apple"
-        }
-    }
-
-    private func beginLoadRequest(
-        source: String,
-        target: String,
-        backend: String
-    ) -> LoadRequestToken {
-        let request = LoadRequestToken(rawValue: nextLoadRequestToken.rawValue + 1)
-        nextLoadRequestToken = request
-        latestRequestedLoadToken = request
-        loadPhase = .loading(request: request)
-        modelLoadProgress = 0.0
-        loadRequestMetadataByToken[request] = LoadRequestMetadata(
-            source: source,
-            target: target,
-            backend: backend,
-            startedAtUptime: ProcessInfo.processInfo.systemUptime
-        )
-        logLoadEvent("load.start", request: request)
-        return request
-    }
-
-    /// Returns `true` if the failure was stale (superseded by a newer request).
-    @discardableResult
-    private func finishLoadAttemptWithFailure(_ request: LoadRequestToken, error: any Error) -> Bool {
-        guard case .loading(let activeRequest) = loadPhase, activeRequest == request else {
-            logLoadEvent("load.suppress", request: request, reason: "stale-failure", clearMetadata: true)
-            return true
-        }
-        loadPhase = .idle
-        modelLoadProgress = nil
-        logLoadEvent(
-            "load.failed",
-            request: request,
-            reason: String(reflecting: type(of: error)),
-            clearMetadata: true
-        )
-        return false
-    }
-
-    private func invalidateOutstandingLoads() {
-        if case .loading(let activeRequest) = loadPhase {
-            logLoadEvent("load.cancel", request: activeRequest, reason: "unload")
-        }
-        if let latestRequestedLoadToken {
-            invalidatedThroughToken = max(invalidatedThroughToken, latestRequestedLoadToken)
-        }
-        loadPhase = .idle
-        modelLoadProgress = nil
-    }
-
-    private func canCommitLoad(_ request: LoadRequestToken) -> Bool {
-        guard request > invalidatedThroughToken else {
-            return false
-        }
-        guard latestRequestedLoadToken == request else {
-            return false
-        }
-        guard case .loading(let activeRequest) = loadPhase, activeRequest == request else {
-            return false
-        }
-        return true
-    }
-
-    @discardableResult
-    private func commitLoadIfCurrent(
-        request: LoadRequestToken,
-        backend newBackend: any InferenceBackend,
-        backendName: String
-    ) -> Bool {
-        guard canCommitLoad(request) else {
-            return false
-        }
-
-        backend = newBackend
-        isModelLoaded = true
-        modelLoadProgress = nil
-        activeBackendName = backendName
-        loadPhase = .loaded(request: request)
-        logLoadEvent("load.commit", request: request, clearMetadata: true)
-        return true
-    }
-
-    /// Installs a stale-suppressing progress handler on the backend if it
-    /// adopts ``LoadProgressReporting``. The handler hops to the main actor
-    /// and only updates ``modelLoadProgress`` while `request` is still the
-    /// active loading request.
-    private func installProgressHandler(
-        on newBackend: any InferenceBackend,
-        for request: LoadRequestToken
-    ) {
-        guard let reporting = newBackend as? LoadProgressReporting else { return }
-        reporting.setLoadProgressHandler { [weak self] progress in
-            await MainActor.run { [weak self] in
-                self?.applyLoadProgress(progress, for: request)
-            }
-        }
-    }
-
-    private func applyLoadProgress(_ progress: Double, for request: LoadRequestToken) {
-        guard case .loading(let activeRequest) = loadPhase, activeRequest == request else {
-            return
-        }
-        modelLoadProgress = max(0.0, min(1.0, progress))
-    }
-
-    private func modelTypeLogLabel(_ modelType: ModelType) -> String {
-        switch modelType {
-        case .mlx: "mlx"
-        case .gguf: "gguf"
-        case .foundation: "foundation"
-        }
-    }
-
-    private func logLoadEvent(
-        _ event: String,
-        request: LoadRequestToken,
-        reason: String? = nil,
-        clearMetadata: Bool = false
-    ) {
-        let metadata = loadRequestMetadataByToken[request]
-        let latencyMs = metadata.map {
-            max(0, Int((ProcessInfo.processInfo.systemUptime - $0.startedAtUptime) * 1_000))
-        }
-
-        var message = "event=\(event) req=\(request.rawValue)"
-        if let metadata {
-            message += " source=\(metadata.source) target=\(metadata.target) backend=\(metadata.backend)"
-        }
-        if let latencyMs {
-            message += " latency_ms=\(latencyMs)"
-        }
-        if let reason {
-            message += " reason=\(reason)"
-        }
-
-        if event == "load.failed" {
-            Log.inference.error("\(message, privacy: .public)")
-        } else {
-            Log.inference.info("\(message, privacy: .public)")
-        }
-
-        if clearMetadata {
-            loadRequestMetadataByToken.removeValue(forKey: request)
-        }
+    public var tokenizer: (any TokenizerProvider)? {
+        lifecycle.tokenizer
     }
 
     // MARK: - Initializers
 
-    public nonisolated init() {}
+    public nonisolated init() {
+        self.lifecycle = ModelLifecycleCoordinator()
+        self.generation = GenerationCoordinator()
+        // Provider wiring happens lazily via ensureProviderWired() on first use,
+        // since `self` is not available inside a nonisolated init.
+    }
 
     #if DEBUG
-    /// Creates an InferenceService with a pre-loaded backend. For tests only.
     public init(backend: any InferenceBackend, name: String = "Mock") {
-        self.backend = backend
-        self.isModelLoaded = true
-        self.activeBackendName = name
-        let request = LoadRequestToken(rawValue: 1)
-        self.nextLoadRequestToken = request
-        self.latestRequestedLoadToken = request
-        self.loadPhase = .loaded(request: request)
-        // Populate metadata so unloadModel() log calls have context for this request.
-        self.loadRequestMetadataByToken[request] = LoadRequestMetadata(
-            source: "debug",
-            target: name,
-            backend: name,
-            startedAtUptime: ProcessInfo.processInfo.systemUptime
-        )
+        self.lifecycle = ModelLifecycleCoordinator(backend: backend, name: name)
+        self.generation = GenerationCoordinator()
+        generation.provider = self
     }
     #endif
 
-    // MARK: - Tokenizer
-
-    /// A real tokenizer from the currently loaded backend, or `nil` if the active
-    /// backend does not expose one (falls back to ``HeuristicTokenizer`` at call sites).
+    /// Ensures the generation coordinator has a reference to this service.
     ///
-    /// Only backends that can tokenize synchronously vend a tokenizer here. Backends
-    /// that require async tokenization (e.g. MLX via `ModelContainer.perform`) and
-    /// backends with no tokenizer API (Foundation, cloud) return `nil`.
-    public var tokenizer: (any TokenizerProvider)? {
-        (backend as? TokenizerVendor)?.tokenizer
+    /// Called lazily because `nonisolated init()` cannot access `self` as a
+    /// `@MainActor`-isolated reference. All public entry points that touch the
+    /// generation coordinator call this first.
+    private func ensureProviderWired() {
+        if generation.provider == nil {
+            generation.provider = self
+        }
     }
+}
+
+// MARK: - GenerationContextProvider Conformance
+
+extension InferenceService: GenerationContextProvider {
+    var currentBackend: (any InferenceBackend)? { lifecycle.backend }
+    var isBackendLoaded: Bool { lifecycle.isModelLoaded }
 }
 
 // MARK: - Backend Snapshot
 
 extension InferenceService {
-    /// Returns a value snapshot of the currently declared-supported backends.
-    ///
-    /// Used by `FrameworkCapabilityService` to populate its `enabledBackends`
-    /// property after backend registration completes.
     public func registeredBackendSnapshot() -> EnabledBackends {
-        EnabledBackends(
-            localModelTypes: supportedLocalModelTypes,
-            cloudProviders: supportedCloudProviders
-        )
+        lifecycle.registeredBackendSnapshot()
     }
 }
 
@@ -939,34 +257,11 @@ extension InferenceService {
 
 extension InferenceService: ModelTypeCompatibilityProvider {
 
-    /// Returns whether a local model type has a registered backend in this service.
     public func compatibility(for modelType: ModelType) -> ModelCompatibilityResult {
-        if supportedLocalModelTypes.contains(modelType) {
-            return .supported
-        }
-        return .unsupported(reason: unavailableReasonString(for: modelType))
+        lifecycle.compatibility(for: modelType)
     }
 
-    /// Returns whether a cloud API provider has a registered backend in this service.
     public func compatibility(for provider: APIProvider) -> ModelCompatibilityResult {
-        if supportedCloudProviders.contains(provider) {
-            return .supported
-        }
-        // Cloud backends are registered unconditionally when DefaultBackends is used,
-        // so if a provider is missing it means no factory was registered at all.
-        return .unsupported(reason: "No backend registered for \(provider.rawValue). Register a cloud backend factory at startup.")
-    }
-
-    // MARK: - Private helpers
-
-    private func unavailableReasonString(for modelType: ModelType) -> String {
-        switch modelType {
-        case .gguf:
-            return "GGUF models require the llama.cpp backend. Build with the Llama Swift package dependency to enable it."
-        case .mlx:
-            return "MLX models require Apple Silicon and the MLX backend. Build with the MLX Swift package dependency to enable it."
-        case .foundation:
-            return "Apple Foundation Models require iOS 26 / macOS 26 or later."
-        }
+        lifecycle.compatibility(for: provider)
     }
 }

--- a/Sources/BaseChatInference/Services/ModelLifecycleCoordinator.swift
+++ b/Sources/BaseChatInference/Services/ModelLifecycleCoordinator.swift
@@ -1,0 +1,471 @@
+import Foundation
+import Observation
+
+/// Owns backend registration, model loading/unloading, the `LoadRequestToken`
+/// lifecycle, progress reporting, memory gating, and capability/compatibility queries.
+///
+/// This is an internal implementation detail of `BaseChatInference`.
+/// `InferenceService` delegates all lifecycle operations to this coordinator
+/// and preserves the unchanged public API.
+@Observable
+@MainActor
+final class ModelLifecycleCoordinator {
+
+    // MARK: - Published State
+
+    private(set) var isModelLoaded = false
+    private(set) var activeBackendName: String?
+    private(set) var modelLoadProgress: Double?
+
+    // MARK: - Backend
+
+    private(set) var backend: (any InferenceBackend)?
+
+    // MARK: - Memory Gate
+
+    var memoryGate: MemoryGate?
+
+    // MARK: - Prompt Template
+
+    var selectedPromptTemplate: PromptTemplate = .chatML
+
+    // MARK: - Backend Registry
+
+    private var backendFactories: [BackendFactory] = []
+    private var cloudBackendFactories: [CloudBackendFactory] = []
+    private var supportedLocalModelTypes: Set<ModelType> = []
+    private var supportedCloudProviders: Set<APIProvider> = []
+
+    // MARK: - Load Request Token State
+
+    private struct LoadRequestToken: Hashable, Comparable, Sendable {
+        let rawValue: UInt64
+        static let zero = Self(rawValue: 0)
+        static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+    }
+
+    private enum LoadPhase: Equatable {
+        case idle
+        case loading(request: LoadRequestToken)
+        case loaded(request: LoadRequestToken)
+    }
+
+    private struct LoadRequestMetadata {
+        let source: String
+        let target: String
+        let backend: String
+        let startedAtUptime: TimeInterval
+    }
+
+    private var nextLoadRequestToken: LoadRequestToken = .zero
+    private var latestRequestedLoadToken: LoadRequestToken?
+    private var invalidatedThroughToken: LoadRequestToken = .zero
+    private var loadPhase: LoadPhase = .idle
+    private var loadRequestMetadataByToken: [LoadRequestToken: LoadRequestMetadata] = [:]
+
+    // MARK: - Initializers
+
+    nonisolated init() {}
+
+    #if DEBUG
+    init(backend: any InferenceBackend, name: String = "Mock") {
+        self.backend = backend
+        self.isModelLoaded = true
+        self.activeBackendName = name
+        let request = LoadRequestToken(rawValue: 1)
+        self.nextLoadRequestToken = request
+        self.latestRequestedLoadToken = request
+        self.loadPhase = .loaded(request: request)
+        self.loadRequestMetadataByToken[request] = LoadRequestMetadata(
+            source: "debug",
+            target: name,
+            backend: name,
+            startedAtUptime: ProcessInfo.processInfo.systemUptime
+        )
+    }
+    #endif
+
+    // MARK: - Backend Registration
+
+    func registerBackendFactory(_ factory: @escaping BackendFactory) {
+        backendFactories.append(factory)
+    }
+
+    func registerCloudBackendFactory(_ factory: @escaping CloudBackendFactory) {
+        cloudBackendFactories.append(factory)
+    }
+
+    func declareSupport(for modelType: ModelType) {
+        supportedLocalModelTypes.insert(modelType)
+    }
+
+    func declareSupport(for provider: APIProvider) {
+        supportedCloudProviders.insert(provider)
+    }
+
+    // MARK: - Model Loading
+
+    func loadModel(
+        from modelInfo: ModelInfo,
+        contextSize: Int32 = 2048
+    ) async throws {
+        unloadModel()
+
+        guard let newBackend = createBackend(for: modelInfo.modelType) else {
+            throw InferenceError.inferenceFailure(
+                "No registered backend can handle model type \(modelInfo.modelType). "
+                + "Register a BackendFactory before loading models."
+            )
+        }
+
+        // Pre-flight memory check
+        if let gate = memoryGate {
+            let verdict = gate.check(
+                modelFileSize: modelInfo.fileSize,
+                strategy: newBackend.capabilities.memoryStrategy
+            )
+            switch verdict {
+            case .allow:
+                break
+            case .warn(let estimated, let available):
+                let estMB = estimated / 1_048_576
+                let availMB = available / 1_048_576
+                Log.inference.warning("Memory warning: model needs ~\(estMB) MB, \(availMB) MB available")
+            case .deny(let estimated, let available):
+                switch gate.denyBehavior {
+                case .throwError:
+                    throw InferenceError.memoryInsufficient(
+                        required: estimated, available: available
+                    )
+                case .warnOnly:
+                    let estMB = estimated / 1_048_576
+                    let availMB = available / 1_048_576
+                    Log.inference.warning("Memory insufficient: model needs ~\(estMB) MB, \(availMB) MB available. Proceeding (may swap).")
+                }
+            }
+        }
+
+        let backendName = backendDisplayName(for: modelInfo.modelType)
+        let request = beginLoadRequest(
+            source: "local",
+            target: modelTypeLogLabel(modelInfo.modelType),
+            backend: backendName
+        )
+        installProgressHandler(on: newBackend, for: request)
+        do {
+            let url = modelInfo.url
+            try await Task.detached(priority: .userInitiated) {
+                try await newBackend.loadModel(from: url, contextSize: contextSize)
+            }.value
+        } catch {
+            (newBackend as? LoadProgressReporting)?.setLoadProgressHandler(nil)
+            let isStale = finishLoadAttemptWithFailure(request, error: error)
+            if isStale {
+                newBackend.unloadModel()
+            }
+            throw error
+        }
+        (newBackend as? LoadProgressReporting)?.setLoadProgressHandler(nil)
+
+        logLoadEvent("load.complete", request: request)
+        guard commitLoadIfCurrent(request: request, backend: newBackend, backendName: backendName) else {
+            newBackend.unloadModel()
+            logLoadEvent("load.suppress", request: request, reason: "stale-success", clearMetadata: true)
+            return
+        }
+    }
+
+    func loadCloudBackend(from endpoint: APIEndpointRecord) async throws {
+        unloadModel()
+
+        guard let url = URL(string: endpoint.baseURL) else {
+            throw CloudBackendError.invalidURL(endpoint.baseURL)
+        }
+
+        guard let newBackend = createCloudBackend(for: endpoint.provider) else {
+            throw InferenceError.inferenceFailure(
+                "No registered cloud backend factory can handle provider \(endpoint.provider.rawValue). "
+                + "Register a CloudBackendFactory before loading cloud backends."
+            )
+        }
+
+        switch endpoint.provider {
+        case .claude, .openAI, .custom:
+            guard let keychainConfigurable = newBackend as? CloudBackendKeychainConfigurable else {
+                throw InferenceError.inferenceFailure(
+                    "Cloud backend \(type(of: newBackend)) must conform to CloudBackendKeychainConfigurable "
+                    + "for provider \(endpoint.provider.rawValue)."
+                )
+            }
+            keychainConfigurable.configure(
+                baseURL: url,
+                keychainAccount: endpoint.keychainAccount,
+                modelName: endpoint.modelName
+            )
+
+        case .ollama, .lmStudio:
+            guard let urlModelConfigurable = newBackend as? CloudBackendURLModelConfigurable else {
+                throw InferenceError.inferenceFailure(
+                    "Cloud backend \(type(of: newBackend)) must conform to CloudBackendURLModelConfigurable "
+                    + "for provider \(endpoint.provider.rawValue)."
+                )
+            }
+            urlModelConfigurable.configure(baseURL: url, modelName: endpoint.modelName)
+        }
+
+        let request = beginLoadRequest(
+            source: "cloud",
+            target: endpoint.provider.rawValue,
+            backend: endpoint.provider.rawValue
+        )
+        installProgressHandler(on: newBackend, for: request)
+        do {
+            let backendURL = url
+            try await Task.detached(priority: .userInitiated) {
+                try await newBackend.loadModel(from: backendURL, contextSize: 0)
+            }.value
+        } catch {
+            (newBackend as? LoadProgressReporting)?.setLoadProgressHandler(nil)
+            let isStale = finishLoadAttemptWithFailure(request, error: error)
+            if isStale {
+                newBackend.unloadModel()
+            }
+            throw error
+        }
+        (newBackend as? LoadProgressReporting)?.setLoadProgressHandler(nil)
+
+        logLoadEvent("load.complete", request: request)
+        guard commitLoadIfCurrent(
+            request: request,
+            backend: newBackend,
+            backendName: endpoint.provider.rawValue
+        ) else {
+            newBackend.unloadModel()
+            logLoadEvent("load.suppress", request: request, reason: "stale-success", clearMetadata: true)
+            return
+        }
+    }
+
+    /// Unloads the current model and frees all associated memory.
+    ///
+    /// Does NOT stop generation — that is the facade's responsibility.
+    /// The facade calls `stopGeneration()` before delegating here.
+    func unloadModel() {
+        invalidateOutstandingLoads()
+        backend?.unloadModel()
+        backend = nil
+        isModelLoaded = false
+        activeBackendName = nil
+    }
+
+    // MARK: - Capability Queries
+
+    var capabilities: BackendCapabilities? {
+        backend?.capabilities
+    }
+
+    var tokenizer: (any TokenizerProvider)? {
+        (backend as? TokenizerVendor)?.tokenizer
+    }
+
+    var lastTokenUsage: (promptTokens: Int, completionTokens: Int)? {
+        (backend as? TokenUsageProvider)?.lastUsage
+    }
+
+    func registeredBackendSnapshot() -> EnabledBackends {
+        EnabledBackends(
+            localModelTypes: supportedLocalModelTypes,
+            cloudProviders: supportedCloudProviders
+        )
+    }
+
+    func resetConversation() {
+        backend?.resetConversation()
+    }
+
+    // MARK: - Compatibility
+
+    func compatibility(for modelType: ModelType) -> ModelCompatibilityResult {
+        if supportedLocalModelTypes.contains(modelType) {
+            return .supported
+        }
+        return .unsupported(reason: unavailableReasonString(for: modelType))
+    }
+
+    func compatibility(for provider: APIProvider) -> ModelCompatibilityResult {
+        if supportedCloudProviders.contains(provider) {
+            return .supported
+        }
+        return .unsupported(reason: "No backend registered for \(provider.rawValue). Register a cloud backend factory at startup.")
+    }
+
+    // MARK: - Backend Selection (Private)
+
+    private func createBackend(for modelType: ModelType) -> (any InferenceBackend)? {
+        for factory in backendFactories {
+            if let backend = factory(modelType) {
+                return backend
+            }
+        }
+        return nil
+    }
+
+    private func createCloudBackend(for provider: APIProvider) -> (any InferenceBackend)? {
+        for factory in cloudBackendFactories {
+            if let backend = factory(provider) {
+                return backend
+            }
+        }
+        return nil
+    }
+
+    private func backendDisplayName(for modelType: ModelType) -> String {
+        switch modelType {
+        case .mlx: "MLX"
+        case .gguf: "llama.cpp"
+        case .foundation: "Apple"
+        }
+    }
+
+    // MARK: - Load Token Lifecycle (Private)
+
+    private func beginLoadRequest(
+        source: String,
+        target: String,
+        backend: String
+    ) -> LoadRequestToken {
+        let request = LoadRequestToken(rawValue: nextLoadRequestToken.rawValue + 1)
+        nextLoadRequestToken = request
+        latestRequestedLoadToken = request
+        loadPhase = .loading(request: request)
+        modelLoadProgress = 0.0
+        loadRequestMetadataByToken[request] = LoadRequestMetadata(
+            source: source,
+            target: target,
+            backend: backend,
+            startedAtUptime: ProcessInfo.processInfo.systemUptime
+        )
+        logLoadEvent("load.start", request: request)
+        return request
+    }
+
+    @discardableResult
+    private func finishLoadAttemptWithFailure(_ request: LoadRequestToken, error: any Error) -> Bool {
+        guard case .loading(let activeRequest) = loadPhase, activeRequest == request else {
+            logLoadEvent("load.suppress", request: request, reason: "stale-failure", clearMetadata: true)
+            return true
+        }
+        loadPhase = .idle
+        modelLoadProgress = nil
+        logLoadEvent(
+            "load.failed",
+            request: request,
+            reason: String(reflecting: type(of: error)),
+            clearMetadata: true
+        )
+        return false
+    }
+
+    private func invalidateOutstandingLoads() {
+        if case .loading(let activeRequest) = loadPhase {
+            logLoadEvent("load.cancel", request: activeRequest, reason: "unload")
+        }
+        if let latestRequestedLoadToken {
+            invalidatedThroughToken = max(invalidatedThroughToken, latestRequestedLoadToken)
+        }
+        loadPhase = .idle
+        modelLoadProgress = nil
+    }
+
+    private func canCommitLoad(_ request: LoadRequestToken) -> Bool {
+        guard request > invalidatedThroughToken else { return false }
+        guard latestRequestedLoadToken == request else { return false }
+        guard case .loading(let activeRequest) = loadPhase, activeRequest == request else { return false }
+        return true
+    }
+
+    @discardableResult
+    private func commitLoadIfCurrent(
+        request: LoadRequestToken,
+        backend newBackend: any InferenceBackend,
+        backendName: String
+    ) -> Bool {
+        guard canCommitLoad(request) else { return false }
+        backend = newBackend
+        isModelLoaded = true
+        modelLoadProgress = nil
+        activeBackendName = backendName
+        loadPhase = .loaded(request: request)
+        logLoadEvent("load.commit", request: request, clearMetadata: true)
+        return true
+    }
+
+    private func installProgressHandler(
+        on newBackend: any InferenceBackend,
+        for request: LoadRequestToken
+    ) {
+        guard let reporting = newBackend as? LoadProgressReporting else { return }
+        reporting.setLoadProgressHandler { [weak self] progress in
+            await MainActor.run { [weak self] in
+                self?.applyLoadProgress(progress, for: request)
+            }
+        }
+    }
+
+    private func applyLoadProgress(_ progress: Double, for request: LoadRequestToken) {
+        guard case .loading(let activeRequest) = loadPhase, activeRequest == request else { return }
+        modelLoadProgress = max(0.0, min(1.0, progress))
+    }
+
+    private func modelTypeLogLabel(_ modelType: ModelType) -> String {
+        switch modelType {
+        case .mlx: "mlx"
+        case .gguf: "gguf"
+        case .foundation: "foundation"
+        }
+    }
+
+    private func logLoadEvent(
+        _ event: String,
+        request: LoadRequestToken,
+        reason: String? = nil,
+        clearMetadata: Bool = false
+    ) {
+        let metadata = loadRequestMetadataByToken[request]
+        let latencyMs = metadata.map {
+            max(0, Int((ProcessInfo.processInfo.systemUptime - $0.startedAtUptime) * 1_000))
+        }
+
+        var message = "event=\(event) req=\(request.rawValue)"
+        if let metadata {
+            message += " source=\(metadata.source) target=\(metadata.target) backend=\(metadata.backend)"
+        }
+        if let latencyMs {
+            message += " latency_ms=\(latencyMs)"
+        }
+        if let reason {
+            message += " reason=\(reason)"
+        }
+
+        if event == "load.failed" {
+            Log.inference.error("\(message, privacy: .public)")
+        } else {
+            Log.inference.info("\(message, privacy: .public)")
+        }
+
+        if clearMetadata {
+            loadRequestMetadataByToken.removeValue(forKey: request)
+        }
+    }
+
+    private func unavailableReasonString(for modelType: ModelType) -> String {
+        switch modelType {
+        case .gguf:
+            return "GGUF models require the llama.cpp backend. Build with the Llama Swift package dependency to enable it."
+        case .mlx:
+            return "MLX models require Apple Silicon and the MLX backend. Build with the MLX Swift package dependency to enable it."
+        case .foundation:
+            return "Apple Foundation Models require iOS 26 / macOS 26 or later."
+        }
+    }
+}

--- a/Sources/BaseChatInference/Services/ModelLifecycleCoordinator.swift
+++ b/Sources/BaseChatInference/Services/ModelLifecycleCoordinator.swift
@@ -268,10 +268,6 @@ final class ModelLifecycleCoordinator {
         (backend as? TokenizerVendor)?.tokenizer
     }
 
-    var lastTokenUsage: (promptTokens: Int, completionTokens: Int)? {
-        (backend as? TokenUsageProvider)?.lastUsage
-    }
-
     func registeredBackendSnapshot() -> EnabledBackends {
         EnabledBackends(
             localModelTypes: supportedLocalModelTypes,

--- a/Sources/BaseChatTestSupport/MockInferenceBackend.swift
+++ b/Sources/BaseChatTestSupport/MockInferenceBackend.swift
@@ -25,6 +25,7 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
     public var generateCallCount = 0
     public var stopCallCount = 0
     public var unloadCallCount = 0
+    public var resetConversationCallCount = 0
 
     /// Records whether `loadModel` was called on the main thread.
     /// `nil` until `loadModel` has been called at least once.
@@ -101,6 +102,10 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
         unloadCallCount += 1
         isModelLoaded = false
         isGenerating = false
+    }
+
+    public func resetConversation() {
+        resetConversationCallCount += 1
     }
 
     // MARK: - ConversationHistoryReceiver

--- a/Tests/BaseChatInferenceTests/InferenceServiceFacadeTests.swift
+++ b/Tests/BaseChatInferenceTests/InferenceServiceFacadeTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+import Observation
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Tests that the InferenceService facade correctly dispatches to
+/// both coordinators after the decomposition (#279).
+@MainActor
+final class InferenceServiceFacadeTests: XCTestCase {
+
+    // MARK: - End-to-end roundtrips
+
+    func test_facade_loadAndGenerate_endToEnd() async throws {
+        let mock = MockInferenceBackend()
+        mock.tokensToYield = ["Hello", " world"]
+        let service = InferenceService()
+        service.registerBackendFactory { type in type == .gguf ? mock : nil }
+
+        try await service.loadModel(from: makeModelInfo())
+        XCTAssertTrue(service.isModelLoaded)
+
+        let (_, stream) = try service.enqueue(messages: [("user", "hi")])
+        var tokens: [String] = []
+        for try await event in stream.events {
+            if case .token(let t) = event { tokens.append(t) }
+        }
+
+        XCTAssertEqual(tokens, ["Hello", " world"])
+        XCTAssertFalse(service.isGenerating)
+    }
+
+    func test_facade_unloadCancelsQueue() async throws {
+        let mock = GatedBackend()
+        let service = InferenceService(backend: mock, name: "Mock")
+
+        let (_, stream1) = try service.enqueue(messages: [("user", "first")])
+        let (_, stream2) = try service.enqueue(messages: [("user", "second")])
+
+        service.unloadModel()
+
+        XCTAssertFalse(service.isModelLoaded)
+        XCTAssertFalse(service.isGenerating)
+        XCTAssertFalse(service.hasQueuedRequests)
+        XCTAssertTrue(
+            { if case .failed = stream1.phase { return true }; return false }()
+        )
+        XCTAssertTrue(
+            { if case .failed = stream2.phase { return true }; return false }()
+        )
+    }
+
+    // MARK: - Observable propagation through facade
+
+    func test_facade_observableProperties_propagateFromCoordinators() async throws {
+        // isModelLoaded observation through facade
+        let mock = MockInferenceBackend()
+        let service = InferenceService()
+        service.registerBackendFactory { type in type == .gguf ? mock : nil }
+
+        let loadObserved = expectation(description: "isModelLoaded")
+        withObservationTracking {
+            _ = service.isModelLoaded
+        } onChange: {
+            loadObserved.fulfill()
+        }
+
+        try await service.loadModel(from: makeModelInfo())
+        await fulfillment(of: [loadObserved], timeout: 2)
+        XCTAssertTrue(service.isModelLoaded)
+
+        // isGenerating observation through facade
+        let gatedMock = GatedBackend()
+        let gatedService = InferenceService(backend: gatedMock, name: "Gated")
+        let genObserved = expectation(description: "isGenerating")
+        withObservationTracking {
+            _ = gatedService.isGenerating
+        } onChange: {
+            genObserved.fulfill()
+        }
+        _ = try gatedService.enqueue(messages: [("user", "hi")])
+        await fulfillment(of: [genObserved], timeout: 2)
+        XCTAssertTrue(gatedService.isGenerating)
+    }
+
+    // MARK: - Public API compile check
+
+    func test_facade_publicAPICompileCheck() throws {
+        let service = InferenceService()
+
+        // Registration
+        service.registerBackendFactory { _ in nil }
+        service.registerCloudBackendFactory { _ in nil }
+        service.declareSupport(for: .gguf)
+        service.declareSupport(for: .ollama)
+
+        // State reads
+        _ = service.isModelLoaded
+        _ = service.isGenerating
+        _ = service.activeBackendName
+        _ = service.modelLoadProgress
+        _ = service.capabilities
+        _ = service.hasQueuedRequests
+        _ = service.lastTokenUsage
+        _ = service.tokenizer
+        _ = service.selectedPromptTemplate
+        _ = service.memoryGate
+
+        // Capability queries
+        _ = service.compatibility(for: .gguf)
+        _ = service.compatibility(for: .ollama)
+        _ = service.registeredBackendSnapshot()
+
+        // Actions (no model loaded, so these just verify compilation)
+        service.unloadModel()
+        service.resetConversation()
+        service.stopGeneration()
+        service.generationDidFinish()
+    }
+
+    // MARK: - Helpers
+
+    private func makeModelInfo() -> ModelInfo {
+        ModelInfo(
+            name: "Test",
+            fileName: "Test.bin",
+            url: URL(fileURLWithPath: "/Test.bin"),
+            fileSize: 0,
+            modelType: .gguf
+        )
+    }
+}
+
+// MARK: - Test Backends
+
+private final class GatedBackend: InferenceBackend, @unchecked Sendable {
+    var isModelLoaded: Bool = true
+    var isGenerating: Bool = false
+    let capabilities = BackendCapabilities(
+        supportedParameters: [.temperature],
+        maxContextTokens: 4096,
+        requiresPromptTemplate: false,
+        supportsSystemPrompt: true
+    )
+
+    func loadModel(from url: URL, contextSize: Int32) async throws {
+        isModelLoaded = true
+    }
+
+    func generate(
+        prompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig
+    ) throws -> GenerationStream {
+        isGenerating = true
+        let stream = AsyncThrowingStream<GenerationEvent, Error> { _ in }
+        return GenerationStream(stream)
+    }
+
+    func stopGeneration() {
+        isGenerating = false
+    }
+
+    func unloadModel() {
+        isModelLoaded = false
+        isGenerating = false
+    }
+}

--- a/Tests/BaseChatInferenceTests/InferenceServiceFacadeTests.swift
+++ b/Tests/BaseChatInferenceTests/InferenceServiceFacadeTests.swift
@@ -142,6 +142,8 @@ private final class GatedBackend: InferenceBackend, @unchecked Sendable {
         supportsSystemPrompt: true
     )
 
+    private var activeContinuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation?
+
     func loadModel(from url: URL, contextSize: Int32) async throws {
         isModelLoaded = true
     }
@@ -152,16 +154,22 @@ private final class GatedBackend: InferenceBackend, @unchecked Sendable {
         config: GenerationConfig
     ) throws -> GenerationStream {
         isGenerating = true
-        let stream = AsyncThrowingStream<GenerationEvent, Error> { _ in }
+        let stream = AsyncThrowingStream<GenerationEvent, Error> { [weak self] continuation in
+            self?.activeContinuation = continuation
+        }
         return GenerationStream(stream)
     }
 
     func stopGeneration() {
         isGenerating = false
+        activeContinuation?.finish()
+        activeContinuation = nil
     }
 
     func unloadModel() {
         isModelLoaded = false
         isGenerating = false
+        activeContinuation?.finish()
+        activeContinuation = nil
     }
 }

--- a/Tests/BaseChatInferenceTests/InferenceServiceObservationTests.swift
+++ b/Tests/BaseChatInferenceTests/InferenceServiceObservationTests.swift
@@ -1,0 +1,242 @@
+import XCTest
+import Observation
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Tests that `@Observable` property changes on `InferenceService` trigger
+/// observation tracking.
+///
+/// Written **before** the decomposition (#279) so that if the extraction breaks
+/// observation propagation through the facade's computed properties, these tests
+/// fail immediately.
+@MainActor
+final class InferenceServiceObservationTests: XCTestCase {
+
+    // MARK: - isModelLoaded
+
+    func test_isModelLoaded_triggersObservation_onLoad() async throws {
+        let mock = MockInferenceBackend()
+        let service = InferenceService()
+        service.registerBackendFactory { type in type == .gguf ? mock : nil }
+
+        let changed = expectation(description: "isModelLoaded observed")
+        withObservationTracking {
+            _ = service.isModelLoaded
+        } onChange: {
+            changed.fulfill()
+        }
+
+        try await service.loadModel(from: makeModelInfo())
+        await fulfillment(of: [changed], timeout: 2)
+        XCTAssertTrue(service.isModelLoaded)
+    }
+
+    func test_isModelLoaded_triggersObservation_onUnload() {
+        let mock = MockInferenceBackend()
+        let service = InferenceService(backend: mock, name: "Mock")
+        XCTAssertTrue(service.isModelLoaded)
+
+        let changed = expectation(description: "isModelLoaded observed")
+        withObservationTracking {
+            _ = service.isModelLoaded
+        } onChange: {
+            changed.fulfill()
+        }
+
+        service.unloadModel()
+        wait(for: [changed], timeout: 2)
+        XCTAssertFalse(service.isModelLoaded)
+    }
+
+    // MARK: - isGenerating
+
+    func test_isGenerating_triggersObservation_onEnqueue() throws {
+        let mock = GatedBackend()
+        let service = InferenceService(backend: mock, name: "Mock")
+
+        let changed = expectation(description: "isGenerating observed")
+        withObservationTracking {
+            _ = service.isGenerating
+        } onChange: {
+            changed.fulfill()
+        }
+
+        _ = try service.enqueue(messages: [("user", "hi")])
+        wait(for: [changed], timeout: 2)
+        XCTAssertTrue(service.isGenerating)
+    }
+
+    // MARK: - activeBackendName
+
+    func test_activeBackendName_triggersObservation_onLoad() async throws {
+        let mock = MockInferenceBackend()
+        let service = InferenceService()
+        service.registerBackendFactory { type in type == .gguf ? mock : nil }
+
+        let changed = expectation(description: "activeBackendName observed")
+        withObservationTracking {
+            _ = service.activeBackendName
+        } onChange: {
+            changed.fulfill()
+        }
+
+        try await service.loadModel(from: makeModelInfo())
+        await fulfillment(of: [changed], timeout: 2)
+        XCTAssertNotNil(service.activeBackendName)
+    }
+
+    // MARK: - modelLoadProgress
+
+    func test_modelLoadProgress_triggersObservation_onLoadStart() async throws {
+        let service = InferenceService()
+        let backend = GatedLoadBackend()
+        service.registerBackendFactory { type in type == .gguf ? backend : nil }
+
+        let changed = expectation(description: "modelLoadProgress observed")
+        withObservationTracking {
+            _ = service.modelLoadProgress
+        } onChange: {
+            changed.fulfill()
+        }
+
+        let loadTask = Task { try await service.loadModel(from: makeModelInfo()) }
+        await backend.waitUntilLoadStarted()
+
+        await fulfillment(of: [changed], timeout: 2)
+        XCTAssertEqual(service.modelLoadProgress, 0.0)
+
+        await backend.releaseLoad()
+        try await loadTask.value
+    }
+
+    func test_modelLoadProgress_triggersObservation_onComplete() async throws {
+        let service = InferenceService()
+        let backend = GatedLoadBackend()
+        service.registerBackendFactory { type in type == .gguf ? backend : nil }
+
+        let loadTask = Task { try await service.loadModel(from: makeModelInfo()) }
+        await backend.waitUntilLoadStarted()
+
+        // Now modelLoadProgress is 0.0 — observe the transition to nil on completion.
+        XCTAssertEqual(service.modelLoadProgress, 0.0)
+
+        let changed = expectation(description: "modelLoadProgress nil on complete")
+        withObservationTracking {
+            _ = service.modelLoadProgress
+        } onChange: {
+            changed.fulfill()
+        }
+
+        await backend.releaseLoad()
+        try await loadTask.value
+
+        await fulfillment(of: [changed], timeout: 2)
+        XCTAssertNil(service.modelLoadProgress)
+    }
+
+    // MARK: - Helpers
+
+    private func makeModelInfo() -> ModelInfo {
+        ModelInfo(
+            name: "Test",
+            fileName: "Test.bin",
+            url: URL(fileURLWithPath: "/Test.bin"),
+            fileSize: 0,
+            modelType: .gguf
+        )
+    }
+}
+
+// MARK: - Test Backends
+
+/// Blocks generation until explicitly released, for observing isGenerating transitions.
+private final class GatedBackend: InferenceBackend, @unchecked Sendable {
+    var isModelLoaded: Bool = true
+    var isGenerating: Bool = false
+    let capabilities = BackendCapabilities(
+        supportedParameters: [.temperature],
+        maxContextTokens: 4096,
+        requiresPromptTemplate: false,
+        supportsSystemPrompt: true
+    )
+
+    func loadModel(from url: URL, contextSize: Int32) async throws {
+        isModelLoaded = true
+    }
+
+    func generate(
+        prompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig
+    ) throws -> GenerationStream {
+        isGenerating = true
+        let stream = AsyncThrowingStream<GenerationEvent, Error> { _ in
+            // Never finishes — caller doesn't need to consume for this test.
+        }
+        return GenerationStream(stream)
+    }
+
+    func stopGeneration() { isGenerating = false }
+    func unloadModel() { isModelLoaded = false }
+}
+
+/// Blocks loadModel until explicitly released, for observing modelLoadProgress transitions.
+private final class GatedLoadBackend: InferenceBackend, @unchecked Sendable {
+    var isModelLoaded: Bool = false
+    var isGenerating: Bool = false
+    let capabilities = BackendCapabilities(
+        supportedParameters: [.temperature],
+        maxContextTokens: 4096,
+        requiresPromptTemplate: false,
+        supportsSystemPrompt: true
+    )
+
+    private let gate = LoadGate()
+
+    func waitUntilLoadStarted() async { await gate.waitUntilStarted() }
+    func releaseLoad() async { await gate.release() }
+
+    func loadModel(from url: URL, contextSize: Int32) async throws {
+        await gate.markStarted()
+        await gate.waitForRelease()
+        isModelLoaded = true
+    }
+
+    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> GenerationStream {
+        let stream = AsyncThrowingStream<GenerationEvent, Error> { $0.finish() }
+        return GenerationStream(stream)
+    }
+
+    func stopGeneration() {}
+    func unloadModel() { isModelLoaded = false }
+}
+
+/// Simple actor-based gate for controlling when loadModel completes.
+private actor LoadGate {
+    private var started = false
+    private var released = false
+    private var startedContinuation: CheckedContinuation<Void, Never>?
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    func markStarted() {
+        started = true
+        startedContinuation?.resume()
+        startedContinuation = nil
+    }
+
+    func waitUntilStarted() async {
+        if started { return }
+        await withCheckedContinuation { startedContinuation = $0 }
+    }
+
+    func release() {
+        released = true
+        releaseContinuation?.resume()
+        releaseContinuation = nil
+    }
+
+    func waitForRelease() async {
+        if released { return }
+        await withCheckedContinuation { releaseContinuation = $0 }
+    }
+}

--- a/Tests/BaseChatInferenceTests/InferenceServiceObservationTests.swift
+++ b/Tests/BaseChatInferenceTests/InferenceServiceObservationTests.swift
@@ -160,6 +160,8 @@ private final class GatedBackend: InferenceBackend, @unchecked Sendable {
         supportsSystemPrompt: true
     )
 
+    private var activeContinuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation?
+
     func loadModel(from url: URL, contextSize: Int32) async throws {
         isModelLoaded = true
     }
@@ -170,14 +172,23 @@ private final class GatedBackend: InferenceBackend, @unchecked Sendable {
         config: GenerationConfig
     ) throws -> GenerationStream {
         isGenerating = true
-        let stream = AsyncThrowingStream<GenerationEvent, Error> { _ in
-            // Never finishes — caller doesn't need to consume for this test.
+        let stream = AsyncThrowingStream<GenerationEvent, Error> { [weak self] continuation in
+            self?.activeContinuation = continuation
         }
         return GenerationStream(stream)
     }
 
-    func stopGeneration() { isGenerating = false }
-    func unloadModel() { isModelLoaded = false }
+    func stopGeneration() {
+        isGenerating = false
+        activeContinuation?.finish()
+        activeContinuation = nil
+    }
+
+    func unloadModel() {
+        isModelLoaded = false
+        activeContinuation?.finish()
+        activeContinuation = nil
+    }
 }
 
 /// Blocks loadModel until explicitly released, for observing modelLoadProgress transitions.

--- a/Tests/BaseChatInferenceTests/InferenceServiceQueueTests.swift
+++ b/Tests/BaseChatInferenceTests/InferenceServiceQueueTests.swift
@@ -239,17 +239,21 @@ final class InferenceServiceQueueTests: XCTestCase {
         XCTAssertEqual(streamNorm.phase, .queued, "normal should still be queued")
         XCTAssertEqual(streamBg.phase, .queued, "background should still be queued")
 
-        // Release stream at index 1 and yield to let the activeTask's defer fire
-        // (auto-drain). Without consuming the stream, a yield is required.
+        // Release the userInitiated stream and consume it so the auto-drain
+        // fires deterministically (consuming the consumer stream waits for the
+        // Task's defer block, which calls drainQueue for the next request).
         await Task.yield()
-        mock.release(at: 1)
-        await Task.yield()
+        mock.release(at: 1, tokens: ["tok"])
+        for try await _ in streamUi.events {}
+
         XCTAssertEqual(streamNorm.phase, .connecting, "normal should run second")
         XCTAssertEqual(streamBg.phase, .queued, "background should still be queued")
 
+        // Same pattern for normal → background.
         await Task.yield()
-        mock.release(at: 2)
-        await Task.yield()
+        mock.release(at: 2, tokens: ["tok"])
+        for try await _ in streamNorm.events {}
+
         XCTAssertEqual(streamBg.phase, .connecting, "background should run last")
     }
 

--- a/Tests/BaseChatInferenceTests/InferenceServiceRegressionLockTests.swift
+++ b/Tests/BaseChatInferenceTests/InferenceServiceRegressionLockTests.swift
@@ -1,0 +1,185 @@
+import XCTest
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Regression lock tests written **before** the InferenceService decomposition (#279).
+///
+/// These cover previously untested public API surface so that any behavioral change
+/// introduced during the coordinator extraction is caught immediately.
+@MainActor
+final class InferenceServiceRegressionLockTests: XCTestCase {
+
+    // MARK: - resetConversation
+
+    func test_resetConversation_delegatesToBackend() {
+        let mock = MockInferenceBackend()
+        let service = InferenceService(backend: mock, name: "Mock")
+        XCTAssertEqual(mock.resetConversationCallCount, 0)
+
+        service.resetConversation()
+
+        XCTAssertEqual(mock.resetConversationCallCount, 1)
+    }
+
+    func test_resetConversation_noopWhenNoBackend() {
+        let service = InferenceService()
+        // Must not crash.
+        service.resetConversation()
+    }
+
+    // MARK: - registeredBackendSnapshot
+
+    func test_registeredBackendSnapshot_emptyWhenNoFactories() {
+        let service = InferenceService()
+        let snapshot = service.registeredBackendSnapshot()
+        XCTAssertTrue(snapshot.localModelTypes.isEmpty)
+        XCTAssertTrue(snapshot.cloudProviders.isEmpty)
+    }
+
+    func test_registeredBackendSnapshot_reflectsDeclaredSupport() {
+        let service = InferenceService()
+        service.registerBackendFactory { _ in nil }
+        service.declareSupport(for: .gguf)
+        service.registerCloudBackendFactory { _ in nil }
+        service.declareSupport(for: .ollama)
+
+        let snapshot = service.registeredBackendSnapshot()
+        XCTAssertTrue(snapshot.localModelTypes.contains(.gguf))
+        XCTAssertTrue(snapshot.cloudProviders.contains(.ollama))
+    }
+
+    // MARK: - compatibility
+
+    func test_compatibility_forModelType_supported() {
+        let service = InferenceService()
+        service.declareSupport(for: .gguf)
+
+        let result = service.compatibility(for: .gguf)
+        XCTAssertEqual(result, .supported)
+    }
+
+    func test_compatibility_forModelType_unsupported() {
+        let service = InferenceService()
+        // No declarations.
+        let result = service.compatibility(for: .mlx)
+        if case .unsupported(let reason) = result {
+            XCTAssertFalse(reason.isEmpty, "Unsupported result should include a reason")
+        } else {
+            XCTFail("Expected .unsupported, got \(result)")
+        }
+    }
+
+    func test_compatibility_forAPIProvider_supported() {
+        let service = InferenceService()
+        service.declareSupport(for: .ollama)
+
+        let result = service.compatibility(for: .ollama)
+        XCTAssertEqual(result, .supported)
+    }
+
+    func test_compatibility_forAPIProvider_unsupported() {
+        let service = InferenceService()
+        // No declarations.
+        let result = service.compatibility(for: .claude)
+        if case .unsupported(let reason) = result {
+            XCTAssertFalse(reason.isEmpty, "Unsupported result should include a reason")
+        } else {
+            XCTFail("Expected .unsupported, got \(result)")
+        }
+    }
+
+    // MARK: - lastTokenUsage
+
+    func test_lastTokenUsage_nilWhenNoBackend() {
+        let service = InferenceService()
+        XCTAssertNil(service.lastTokenUsage)
+    }
+
+    func test_lastTokenUsage_nilWhenBackendLacksProvider() {
+        let mock = MockInferenceBackend()
+        let service = InferenceService(backend: mock, name: "Mock")
+        // MockInferenceBackend does not conform to TokenUsageProvider.
+        XCTAssertNil(service.lastTokenUsage)
+    }
+
+    // MARK: - generationDidFinish (deprecated no-op)
+
+    func test_generationDidFinish_isNoOp() throws {
+        let mock = GatedMockBackend()
+        let service = InferenceService(backend: mock, name: "Mock")
+        let (_, _) = try service.enqueue(messages: [("user", "hi")])
+
+        // Service should be generating.
+        XCTAssertTrue(service.isGenerating)
+
+        // Calling the deprecated method should be a no-op — state unchanged.
+        service.generationDidFinish()
+        XCTAssertTrue(service.isGenerating, "generationDidFinish() should be a no-op")
+    }
+
+    // MARK: - declareSupport accumulation
+
+    func test_declareSupport_accumulatesMultipleTypes() {
+        let service = InferenceService()
+        service.declareSupport(for: .gguf)
+        service.declareSupport(for: .mlx)
+
+        let snapshot = service.registeredBackendSnapshot()
+        XCTAssertEqual(snapshot.localModelTypes, [.gguf, .mlx])
+    }
+
+    func test_declareSupport_accumulatesMultipleProviders() {
+        let service = InferenceService()
+        service.declareSupport(for: .ollama)
+        service.declareSupport(for: .lmStudio)
+
+        let snapshot = service.registeredBackendSnapshot()
+        XCTAssertEqual(snapshot.cloudProviders, [.ollama, .lmStudio])
+    }
+}
+
+// MARK: - Test Helpers
+
+/// Minimal gated backend that blocks generation until explicitly released.
+/// Duplicated here (also exists in InferenceServiceQueueTests) to keep test files
+/// self-contained without coupling their helpers.
+private final class GatedMockBackend: InferenceBackend, @unchecked Sendable {
+    var isModelLoaded: Bool = true
+    var isGenerating: Bool = false
+    let capabilities = BackendCapabilities(
+        supportedParameters: [.temperature, .topP, .repeatPenalty],
+        maxContextTokens: 4096,
+        requiresPromptTemplate: false,
+        supportsSystemPrompt: true
+    )
+
+    private var gates: [AsyncThrowingStream<GenerationEvent, Error>.Continuation] = []
+
+    func loadModel(from url: URL, contextSize: Int32) async throws {
+        isModelLoaded = true
+    }
+
+    func generate(
+        prompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig
+    ) throws -> GenerationStream {
+        isGenerating = true
+        let stream = AsyncThrowingStream<GenerationEvent, Error> { [weak self] continuation in
+            self?.gates.append(continuation)
+        }
+        return GenerationStream(stream)
+    }
+
+    func stopGeneration() {
+        isGenerating = false
+        for gate in gates { gate.finish() }
+    }
+
+    func unloadModel() {
+        isModelLoaded = false
+        isGenerating = false
+        for gate in gates { gate.finish() }
+        gates.removeAll()
+    }
+}

--- a/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
+++ b/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
@@ -43,9 +43,9 @@ final class SilentCatchAuditTest: XCTestCase {
         "BaseChatInference/Models/ModelInfo.swift:if let metadata = try? GGUFMetadataReader.readMetadata(from: url) {",
         "BaseChatInference/Models/ModelInfo.swift:guard let contents = try? fileManager.contentsOfDirectory(",
         "BaseChatInference/Models/ModelInfo.swift:let values = try? fileURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])",
-        "BaseChatInference/Services/BackgroundDownloadManager.swift:guard let handle = try? FileHandle(forReadingFrom: fileURL) else {",
-        "BaseChatInference/Services/BackgroundDownloadManager.swift:guard let headerData = try? handle.read(upToCount: 4), headerData.count == 4 else {",
         "BaseChatInference/Services/BackgroundDownloadManager.swift:try? FileManager.default.removeItem(at: tempURL)",
+        "BaseChatInference/Services/DownloadFileValidator.swift:guard let handle = try? FileHandle(forReadingFrom: fileURL) else {",
+        "BaseChatInference/Services/DownloadFileValidator.swift:guard let headerData = try? handle.read(upToCount: 4), headerData.count == 4 else {",
         "BaseChatInference/Services/GGUFMetadataReader.swift:guard let handle = try? FileHandle(forReadingFrom: url) else { return false }",
         "BaseChatInference/Services/ModelStorageService.swift:guard let contents = try? fileManager.contentsOfDirectory(",
 
@@ -58,7 +58,6 @@ final class SilentCatchAuditTest: XCTestCase {
 
         // BaseChatUI — Task.sleep cancellation is intentionally ignored;
         // parser/rendering fallbacks are benign optional conversions.
-        "BaseChatUI/ViewModels/ChatViewModel+Generation.swift:guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {",
         "BaseChatUI/ViewModels/ModelManagementViewModel.swift:try? await Task.sleep(for: .milliseconds(500))",
         "BaseChatUI/Views/Chat/AssistantMarkdownView.swift:if let parsed = try? AttributedString(",
         "BaseChatUI/Views/Chat/TypingIndicatorView.swift:try? await Task.sleep(for: .milliseconds(400))",
@@ -71,6 +70,8 @@ final class SilentCatchAuditTest: XCTestCase {
         "BaseChatTestSupport/PerceivedLatencyBackend.swift:try? await Task.sleep(for: delay)",
         "BaseChatTestSupport/ChaosBackend.swift:try? await Task.sleep(for: delay)",
         "BaseChatTestSupport/ChaosBackend.swift:try? await Task.sleep(for: stallDuration)",
+        "BaseChatTestSupport/HardwareRequirements.swift:let configData = try? Data(contentsOf: configURL),",
+        "BaseChatTestSupport/HardwareRequirements.swift:let json = try? JSONSerialization.jsonObject(with: configData) as? [String: Any],",
         "BaseChatTestSupport/HardwareRequirements.swift:let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],",
         "BaseChatTestSupport/HardwareRequirements.swift:if let containers = try? fm.contentsOfDirectory(",
         "BaseChatTestSupport/HardwareRequirements.swift:guard let contents = try? fm.contentsOfDirectory(",


### PR DESCRIPTION
## Summary

- Splits the 972-LOC `InferenceService` god-object into two focused internal coordinators (`ModelLifecycleCoordinator` at 471 LOC, `GenerationCoordinator` at 302 LOC) while `InferenceService` becomes a 267-LOC facade preserving the identical public API
- Introduces `GenerationContextProvider` internal protocol so the generation coordinator can access the backend without depending on the lifecycle coordinator directly
- Adds 23 new shift-left tests (regression locks, `@Observable` propagation, facade integration) written before and alongside the extraction

## Design

```
InferenceService (facade, 267 LOC)
  ├── ModelLifecycleCoordinator (471 LOC)
  │     Backend registry, load/unload, LoadRequestToken, progress,
  │     memory gate, capability/compatibility, tokenizer
  └── GenerationCoordinator (302 LOC)
        Queue state, enqueue/cancel/stop, drainQueue + defer block,
        generate() prompt formatting, resetConversation
```

Key decisions:
- **Zero public API changes** — all 19 source files and 48 test files continue compiling without modification
- **`@Observable` propagation** verified via `withObservationTracking` tests — facade computed properties correctly track through to coordinator storage
- **`drainQueue` defer block atomicity** preserved — all state mutations stay on `GenerationCoordinator`, no cross-object writes
- **`LoadRequestToken` monotonicity** preserved — counter exclusively owned by `ModelLifecycleCoordinator`

## Test plan

- [x] All 4 CI suites pass locally (1,218 tests, 0 failures)
- [x] 13 regression lock tests cover previously untested API (`resetConversation`, `registeredBackendSnapshot`, `compatibility`, `lastTokenUsage`, `generationDidFinish` no-op)
- [x] 6 observation propagation tests verify `@Observable` tracking through facade
- [x] 4 facade integration tests verify cross-coordinator dispatch
- [x] Fixed timing-sensitive `test_enqueue_priority_threeLevel_ordering` to consume streams deterministically
- [ ] Coordinator-targeted unit tests deferred to follow-up (existing tests exercise all behavior through facade)

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)