### PR TITLE
refactor: extract SessionController from ChatViewModel

### DIFF
--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Messages.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Messages.swift
@@ -37,7 +37,12 @@ extension ChatViewModel {
         }
 
         // Update session timestamp.
-        activeSession?.updatedAt = Date()
+        do {
+            try sessionController.touchActiveSessionUpdatedAt()
+        } catch {
+            Log.persistence.error("Failed to persist session timestamp: \(error)")
+            surfaceError(error, kind: .persistence)
+        }
 
         // Trigger auto-title on the first user message in this session.
         if let session = activeSession, messages.filter({ $0.role == .user }).count == 1 {

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Persistence.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Persistence.swift
@@ -7,27 +7,7 @@ extension ChatViewModel {
 
     /// Loads the most recent page of messages for the active session.
     func loadMessages() {
-        guard let persistence else {
-            Log.persistence.warning("loadMessages called before persistence was configured — messages will not load")
-            return
-        }
-        guard let sessionID = activeSessionID else {
-            messages = []
-            hasOlderMessages = false
-            return
-        }
-
-        do {
-            let page = try persistence.fetchRecentMessages(for: sessionID, limit: Self.messagePageSize)
-            messages = page
-            // If we got a full page, there may be older messages above.
-            hasOlderMessages = page.count >= Self.messagePageSize
-            Log.persistence.info("Loaded \(page.count) messages (hasOlder: \(self.hasOlderMessages))")
-        } catch {
-            Log.persistence.error("Failed to load messages: \(error)")
-            messages = []
-            hasOlderMessages = false
-        }
+        sessionController.loadMessages()
     }
 
     /// Loads the next page of older messages and prepends them.
@@ -36,29 +16,7 @@ extension ChatViewModel {
     /// so the caller can restore scroll position to it after the prepend.
     @discardableResult
     public func loadOlderMessages() -> UUID? {
-        guard !isLoadingOlderMessages, hasOlderMessages else { return nil }
-        guard let persistence else { return nil }
-        guard let sessionID = activeSessionID else { return nil }
-        guard let oldestTimestamp = messages.first?.timestamp else { return nil }
-
-        let anchorID = messages.first?.id
-        isLoadingOlderMessages = true
-        defer { isLoadingOlderMessages = false }
-
-        do {
-            let older = try persistence.fetchMessages(for: sessionID, before: oldestTimestamp, limit: Self.messagePageSize)
-            if older.isEmpty {
-                hasOlderMessages = false
-                return anchorID
-            }
-            hasOlderMessages = older.count >= Self.messagePageSize
-            messages.insert(contentsOf: older, at: 0)
-            Log.persistence.info("Prepended \(older.count) older messages (hasOlder: \(self.hasOlderMessages))")
-        } catch {
-            Log.persistence.error("Failed to load older messages: \(error)")
-        }
-
-        return anchorID
+        sessionController.loadOlderMessages()
     }
 
     /// Persists a message via the persistence provider.
@@ -69,41 +27,21 @@ extension ChatViewModel {
     /// `generateIntoMessage`). Treat it as an upsert at the view-model boundary so
     /// callers do not need to coordinate insert vs. update ownership.
     func saveMessage(_ message: ChatMessageRecord) throws {
-        guard let persistence else {
-            Log.persistence.warning("saveMessage called before persistence was configured — message will not be persisted")
-            return
-        }
-        do {
-            try persistence.updateMessage(message)
-        } catch ChatPersistenceError.messageNotFound {
-            try persistence.insertMessage(message)
-        }
+        try sessionController.saveMessage(message)
     }
 
     /// Updates an existing message via the persistence provider.
     func updateMessage(_ message: ChatMessageRecord) throws {
-        guard let persistence else {
-            Log.persistence.warning("updateMessage called before persistence was configured — message will not be updated")
-            return
-        }
-        try persistence.updateMessage(message)
+        try sessionController.updateMessage(message)
     }
 
     /// Deletes a message via the persistence provider.
     func deleteMessage(_ message: ChatMessageRecord) throws {
-        guard let persistence else {
-            Log.persistence.warning("deleteMessage called before persistence was configured — message will not be deleted")
-            return
-        }
-        try persistence.deleteMessage(message.id)
+        try sessionController.deleteMessage(message)
     }
 
     /// Deletes all messages for a session via the persistence provider.
     func deleteMessages(for sessionID: UUID) throws {
-        guard let persistence else {
-            Log.persistence.warning("deleteMessages called before persistence was configured — messages will not be deleted")
-            return
-        }
-        try persistence.deleteMessages(for: sessionID)
+        try sessionController.deleteMessages(for: sessionID)
     }
 }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+SessionManagement.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+SessionManagement.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftData
 import BaseChatCore
 
 // MARK: - ChatViewModel + Session Management
@@ -16,8 +15,9 @@ extension ChatViewModel {
         isRestoringSession = true
         defer { isRestoringSession = false }
 
-        activeSession = session
+        let selectionState = sessionController.activateSession(session)
         inferenceService.resetConversation()
+        inferenceService.selectedPromptTemplate = sessionController.selectedPromptTemplate
 
         // Discard any queued requests that belong to a different session.
         inferenceService.discardRequests(notMatching: session.id)
@@ -27,21 +27,10 @@ extension ChatViewModel {
         backgroundTask = nil
         backgroundTaskError = nil
 
-        // Load session's generation settings (fall back to defaults)
-        systemPrompt = session.systemPrompt
-        temperature = session.temperature ?? 0.7
-        topP = session.topP ?? 0.9
-        repeatPenalty = session.repeatPenalty ?? 1.1
-
-        // Load prompt template if session has one
-        if let template = session.promptTemplate {
-            selectedPromptTemplate = template
-        }
-
-        let resolvedEndpoint = session.selectedEndpointID.flatMap { endpointID in
+        let resolvedEndpoint = selectionState.selectedEndpointID.flatMap { endpointID in
             availableEndpoints.first(where: { $0.id == endpointID })
         }
-        let resolvedModel = session.selectedModelID.flatMap { modelID in
+        let resolvedModel = selectionState.selectedModelID.flatMap { modelID in
             availableModels.first(where: { $0.id == modelID })
         }
 
@@ -54,8 +43,6 @@ extension ChatViewModel {
             selectedEndpoint = nil
         }
 
-        pinnedMessageIDs = session.pinnedMessageIDs
-
         showUpgradeHint = false
         loadMessages()
         updateContextEstimate()
@@ -64,21 +51,10 @@ extension ChatViewModel {
 
     /// Saves the current generation settings back to the active session.
     func saveSettingsToSession() throws {
-        guard var session = activeSession else { return }
-        guard let persistence else {
-            Log.persistence.warning("saveSettingsToSession called before persistence was configured")
-            throw ChatPersistenceError.providerNotConfigured
-        }
-        session.temperature = temperature
-        session.topP = topP
-        session.repeatPenalty = repeatPenalty
-        session.systemPrompt = systemPrompt
-        session.selectedModelID = selectedModel?.id
-        session.selectedEndpointID = selectedEndpoint?.id
-        session.pinnedMessageIDs = pinnedMessageIDs
-        session.updatedAt = Date()
-        try persistence.updateSession(session)
-        activeSession = session
+        try sessionController.saveSettingsToSession(
+            selectedModelID: selectedModel?.id,
+            selectedEndpointID: selectedEndpoint?.id
+        )
     }
 
     // MARK: - Model Discovery

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -35,15 +35,23 @@ public final class ChatViewModel {
 
     // MARK: - Persistence
 
-    var persistence: ChatPersistenceProvider?
+    let sessionController: SessionController
+
+    var persistence: ChatPersistenceProvider? {
+        get { sessionController.persistence }
+        set { sessionController.persistence = newValue }
+    }
 
     // MARK: - Session
 
     /// The currently active chat session. Set via `switchToSession(_:)`.
-    public var activeSession: ChatSessionRecord?
+    public var activeSession: ChatSessionRecord? {
+        get { sessionController.activeSession }
+        set { sessionController.activeSession = newValue }
+    }
 
     /// The session ID for the active session, or `nil` if no session is selected.
-    var activeSessionID: UUID? { activeSession?.id }
+    var activeSessionID: UUID? { sessionController.activeSessionID }
 
     /// Called when a session might need its title auto-generated.
     /// Set by the view layer to connect to SessionManagerViewModel.
@@ -97,13 +105,19 @@ public final class ChatViewModel {
     }
 
     /// Ordered messages for the active session.
-    public internal(set) var messages: [ChatMessageRecord] = []
+    public internal(set) var messages: [ChatMessageRecord] {
+        get { sessionController.messages }
+        set { sessionController.messages = newValue }
+    }
 
     /// The user's current input text.
     public var inputText: String = ""
 
     /// Editable system prompt prepended to every generation.
-    public var systemPrompt: String = ""
+    public var systemPrompt: String {
+        get { sessionController.systemPrompt }
+        set { sessionController.systemPrompt = newValue }
+    }
 
     /// The current phase of backend activity, driving all status indicators.
     ///
@@ -212,13 +226,25 @@ public final class ChatViewModel {
     ///
     /// Populated from ``ChatSessionRecord/pinnedMessageIDs`` when switching
     /// sessions. Persisted back to the session on changes.
-    public internal(set) var pinnedMessageIDs: Set<UUID> = []
+    public internal(set) var pinnedMessageIDs: Set<UUID> {
+        get { sessionController.pinnedMessageIDs }
+        set { sessionController.pinnedMessageIDs = newValue }
+    }
 
     // MARK: - Generation Settings
 
-    public var temperature: Float = 0.7
-    public var topP: Float = 0.9
-    public var repeatPenalty: Float = 1.1
+    public var temperature: Float {
+        get { sessionController.temperature }
+        set { sessionController.temperature = newValue }
+    }
+    public var topP: Float {
+        get { sessionController.topP }
+        set { sessionController.topP = newValue }
+    }
+    public var repeatPenalty: Float {
+        get { sessionController.repeatPenalty }
+        set { sessionController.repeatPenalty = newValue }
+    }
     /// Minimum interval between batched UI updates during streaming (~30 fps by default).
     public var streamingUpdateInterval: Duration = .milliseconds(33)
     /// Maximum characters to buffer before forcing a UI flush during streaming.
@@ -255,8 +281,11 @@ public final class ChatViewModel {
 
     /// Prompt template for GGUF backends. Ignored by MLX/Foundation.
     public var selectedPromptTemplate: PromptTemplate {
-        get { inferenceService.selectedPromptTemplate }
-        set { inferenceService.selectedPromptTemplate = newValue }
+        get { sessionController.selectedPromptTemplate }
+        set {
+            sessionController.selectedPromptTemplate = newValue
+            inferenceService.selectedPromptTemplate = newValue
+        }
     }
 
     // MARK: - Context Tracking
@@ -386,13 +415,19 @@ public final class ChatViewModel {
     }
 
     /// Number of messages to load per page when paginating history.
-    static let messagePageSize = 50
+    static let messagePageSize = SessionController.messagePageSize
 
     /// Whether older messages are available to load above the current page.
-    public internal(set) var hasOlderMessages: Bool = false
+    public internal(set) var hasOlderMessages: Bool {
+        get { sessionController.hasOlderMessages }
+        set { sessionController.hasOlderMessages = newValue }
+    }
 
     /// Whether a page of older messages is currently being fetched.
-    public internal(set) var isLoadingOlderMessages: Bool = false
+    public internal(set) var isLoadingOlderMessages: Bool {
+        get { sessionController.isLoadingOlderMessages }
+        set { sessionController.isLoadingOlderMessages = newValue }
+    }
 
     // MARK: - Initialisation
 
@@ -419,6 +454,7 @@ public final class ChatViewModel {
         self.deviceCapability = deviceCapability
         self.modelStorage = modelStorage
         self.memoryPressure = memoryPressure
+        self.sessionController = SessionController(selectedPromptTemplate: inferenceService.selectedPromptTemplate)
 
         if inferenceService.memoryGate == nil {
             inferenceService.memoryGate = MemoryGate()
@@ -431,9 +467,7 @@ public final class ChatViewModel {
     /// Injects the persistence provider. Call once from the view layer
     /// after the storage backend is available.
     public func configure(persistence: ChatPersistenceProvider) {
-        guard self.persistence == nil else { return }
-        self.persistence = persistence
-        Log.persistence.info("ChatViewModel configured with persistence provider")
+        sessionController.configure(persistence: persistence)
     }
 
     // MARK: - Structured Error Surfacing

--- a/Sources/BaseChatUI/ViewModels/SessionController.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionController.swift
@@ -1,0 +1,187 @@
+import Foundation
+import Observation
+import BaseChatCore
+
+@Observable
+@MainActor
+final class SessionController {
+
+    static let defaultTemperature: Float = 0.7
+    static let defaultTopP: Float = 0.9
+    static let defaultRepeatPenalty: Float = 1.1
+    static let messagePageSize = 50
+
+    struct SessionSelectionState {
+        let selectedModelID: UUID?
+        let selectedEndpointID: UUID?
+    }
+
+    var persistence: ChatPersistenceProvider?
+    var activeSession: ChatSessionRecord?
+    var messages: [ChatMessageRecord] = []
+    var systemPrompt: String = ""
+    var temperature: Float = defaultTemperature
+    var topP: Float = defaultTopP
+    var repeatPenalty: Float = defaultRepeatPenalty
+    var selectedPromptTemplate: PromptTemplate
+    let defaultPromptTemplate: PromptTemplate
+    var pinnedMessageIDs: Set<UUID> = []
+    var hasOlderMessages: Bool = false
+    var isLoadingOlderMessages: Bool = false
+
+    init(selectedPromptTemplate: PromptTemplate = .chatML) {
+        self.selectedPromptTemplate = selectedPromptTemplate
+        self.defaultPromptTemplate = selectedPromptTemplate
+    }
+
+    var activeSessionID: UUID? {
+        activeSession?.id
+    }
+
+    func configure(persistence: ChatPersistenceProvider) {
+        guard self.persistence == nil else { return }
+        self.persistence = persistence
+        Log.persistence.info("ChatViewModel configured with persistence provider")
+    }
+
+    @discardableResult
+    func activateSession(_ session: ChatSessionRecord) -> SessionSelectionState {
+        activeSession = session
+        systemPrompt = session.systemPrompt
+        temperature = session.temperature ?? Self.defaultTemperature
+        topP = session.topP ?? Self.defaultTopP
+        repeatPenalty = session.repeatPenalty ?? Self.defaultRepeatPenalty
+        selectedPromptTemplate = session.promptTemplate ?? defaultPromptTemplate
+        pinnedMessageIDs = session.pinnedMessageIDs
+        return SessionSelectionState(
+            selectedModelID: session.selectedModelID,
+            selectedEndpointID: session.selectedEndpointID
+        )
+    }
+
+    func touchActiveSessionUpdatedAt(_ date: Date = Date()) throws {
+        guard var session = activeSession else { return }
+
+        session.updatedAt = date
+        activeSession = session
+
+        guard let persistence else {
+            Log.persistence.warning("touchActiveSessionUpdatedAt called before persistence was configured")
+            return
+        }
+
+        try persistence.updateSession(session)
+    }
+
+    func saveSettingsToSession(
+        selectedModelID: UUID?,
+        selectedEndpointID: UUID?
+    ) throws {
+        guard var session = activeSession else { return }
+        guard let persistence else {
+            Log.persistence.warning("saveSettingsToSession called before persistence was configured")
+            throw ChatPersistenceError.providerNotConfigured
+        }
+        session.temperature = temperature
+        session.topP = topP
+        session.repeatPenalty = repeatPenalty
+        session.systemPrompt = systemPrompt
+        session.selectedModelID = selectedModelID
+        session.selectedEndpointID = selectedEndpointID
+        session.promptTemplate = selectedPromptTemplate
+        session.pinnedMessageIDs = pinnedMessageIDs
+        session.updatedAt = Date()
+        try persistence.updateSession(session)
+        activeSession = session
+    }
+
+    func loadMessages() {
+        guard let persistence else {
+            Log.persistence.warning("loadMessages called before persistence was configured — messages will not load")
+            return
+        }
+        guard let sessionID = activeSessionID else {
+            messages = []
+            hasOlderMessages = false
+            return
+        }
+
+        do {
+            let page = try persistence.fetchRecentMessages(for: sessionID, limit: Self.messagePageSize)
+            messages = page
+            hasOlderMessages = page.count >= Self.messagePageSize
+            Log.persistence.info("Loaded \(page.count) messages (hasOlder: \(self.hasOlderMessages))")
+        } catch {
+            Log.persistence.error("Failed to load messages: \(error)")
+            messages = []
+            hasOlderMessages = false
+        }
+    }
+
+    @discardableResult
+    func loadOlderMessages() -> UUID? {
+        guard !isLoadingOlderMessages, hasOlderMessages else { return nil }
+        guard let persistence else { return nil }
+        guard let sessionID = activeSessionID else { return nil }
+        guard let oldestTimestamp = messages.first?.timestamp else { return nil }
+
+        let anchorID = messages.first?.id
+        isLoadingOlderMessages = true
+        defer { isLoadingOlderMessages = false }
+
+        do {
+            let older = try persistence.fetchMessages(
+                for: sessionID,
+                before: oldestTimestamp,
+                limit: Self.messagePageSize
+            )
+            if older.isEmpty {
+                hasOlderMessages = false
+                return anchorID
+            }
+            hasOlderMessages = older.count >= Self.messagePageSize
+            messages.insert(contentsOf: older, at: 0)
+            Log.persistence.info("Prepended \(older.count) older messages (hasOlder: \(self.hasOlderMessages))")
+        } catch {
+            Log.persistence.error("Failed to load older messages: \(error)")
+        }
+
+        return anchorID
+    }
+
+    func saveMessage(_ message: ChatMessageRecord) throws {
+        guard let persistence else {
+            Log.persistence.warning("saveMessage called before persistence was configured — message will not be persisted")
+            return
+        }
+        do {
+            try persistence.updateMessage(message)
+        } catch ChatPersistenceError.messageNotFound {
+            try persistence.insertMessage(message)
+        }
+    }
+
+    func updateMessage(_ message: ChatMessageRecord) throws {
+        guard let persistence else {
+            Log.persistence.warning("updateMessage called before persistence was configured — message will not be updated")
+            return
+        }
+        try persistence.updateMessage(message)
+    }
+
+    func deleteMessage(_ message: ChatMessageRecord) throws {
+        guard let persistence else {
+            Log.persistence.warning("deleteMessage called before persistence was configured — message will not be deleted")
+            return
+        }
+        try persistence.deleteMessage(message.id)
+    }
+
+    func deleteMessages(for sessionID: UUID) throws {
+        guard let persistence else {
+            Log.persistence.warning("deleteMessages called before persistence was configured — messages will not be deleted")
+            return
+        }
+        try persistence.deleteMessages(for: sessionID)
+    }
+}

--- a/Sources/BaseChatUI/ViewModels/SessionController.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionController.swift
@@ -70,7 +70,13 @@ final class SessionController {
             return
         }
 
-        try persistence.updateSession(session)
+        do {
+            try persistence.updateSession(session)
+        } catch ChatPersistenceError.sessionNotFound {
+            Log.persistence.warning(
+                "Active session was not yet persisted when updating session timestamp: \(session.id, privacy: .private)"
+            )
+        }
     }
 
     func saveSettingsToSession(

--- a/Tests/BaseChatUITests/ChatViewModelIntegrationTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelIntegrationTests.swift
@@ -102,6 +102,25 @@ final class ChatViewModelIntegrationTests: XCTestCase {
         XCTAssertEqual(dbMessages[1].content, "Hello from the assistant")
     }
 
+    func test_sendMessage_persistsSessionUpdatedAt() async throws {
+        let provider = SwiftDataPersistenceProvider(modelContext: context)
+        var session = createAndActivateSession()
+        let originalUpdatedAt = Date(timeIntervalSince1970: 1)
+        session.updatedAt = originalUpdatedAt
+        try provider.updateSession(session)
+        vm.switchToSession(session)
+
+        vm.inputText = "Update the timestamp"
+        await vm.sendMessage()
+
+        let updatedSession = try XCTUnwrap(fetchSessions().first { $0.id == session.id })
+        XCTAssertGreaterThan(
+            updatedSession.updatedAt,
+            originalUpdatedAt,
+            "Sending a message should persist the session's updatedAt timestamp"
+        )
+    }
+
     // MARK: - Multi-Turn Conversation Persistence
 
     func test_multiTurnConversation_allMessagesPersisted() async {
@@ -248,6 +267,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
         vm.topP = 0.8
         vm.repeatPenalty = 1.3
         vm.systemPrompt = "You are a pirate."
+        vm.selectedPromptTemplate = .llama3
         try! vm.saveSettingsToSession()
 
         // Fetch session from database and verify
@@ -258,15 +278,19 @@ final class ChatViewModelIntegrationTests: XCTestCase {
         XCTAssertEqual(dbSession?.topP, 0.8)
         XCTAssertEqual(dbSession?.repeatPenalty, 1.3)
         XCTAssertEqual(dbSession?.systemPrompt, "You are a pirate.")
+        XCTAssertEqual(dbSession?.promptTemplate, .llama3)
     }
 
     // MARK: - Session Switching Restores Settings
 
     func test_switchSession_restoresGenerationSettings() async {
+        let defaultPromptTemplate = vm.selectedPromptTemplate
+
         // Session A with custom settings
         createAndActivateSession(title: "Session A")
         vm.temperature = 0.3
         vm.systemPrompt = "Be concise."
+        vm.selectedPromptTemplate = .llama3
         try! vm.saveSettingsToSession()
         let sessionA = vm.activeSession!
 
@@ -274,6 +298,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
         createAndActivateSession(title: "Session B")
         vm.temperature = 1.8
         vm.systemPrompt = "Be verbose."
+        vm.selectedPromptTemplate = .mistral
         try! vm.saveSettingsToSession()
         let sessionB = vm.activeSession!
 
@@ -281,11 +306,22 @@ final class ChatViewModelIntegrationTests: XCTestCase {
         vm.switchToSession(sessionA)
         XCTAssertEqual(vm.temperature, 0.3, "Temperature should restore from session A")
         XCTAssertEqual(vm.systemPrompt, "Be concise.", "System prompt should restore from session A")
+        XCTAssertEqual(vm.selectedPromptTemplate, .llama3, "Prompt template should restore from session A")
 
         // Switch to B — settings should restore
         vm.switchToSession(sessionB)
         XCTAssertEqual(vm.temperature, 1.8, "Temperature should restore from session B")
         XCTAssertEqual(vm.systemPrompt, "Be verbose.", "System prompt should restore from session B")
+        XCTAssertEqual(vm.selectedPromptTemplate, .mistral, "Prompt template should restore from session B")
+
+        // Session C keeps the default template when it has never saved an override.
+        let sessionC = createAndActivateSession(title: "Session C")
+        vm.switchToSession(sessionC)
+        XCTAssertEqual(
+            vm.selectedPromptTemplate,
+            defaultPromptTemplate,
+            "Sessions without a saved prompt template should fall back to the default template instead of inheriting the prior session's override"
+        )
     }
 
     // MARK: - Empty Response DB Verification

--- a/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
+++ b/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
@@ -66,6 +66,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         vm.topP = 0.8
         vm.repeatPenalty = 1.5
         vm.systemPrompt = "Be concise."
+        vm.selectedPromptTemplate = .llama3
 
         try vm.saveSettingsToSession()
 
@@ -78,6 +79,8 @@ final class ViewModelEdgeCaseTests: XCTestCase {
                        "Session repeatPenalty should match view model value")
         XCTAssertEqual(updated.systemPrompt, "Be concise.",
                        "Session systemPrompt should match view model value")
+        XCTAssertEqual(updated.promptTemplate, .llama3,
+                       "Session promptTemplate should match view model value")
     }
 
     func test_saveSettingsToSession_noActiveSession_isNoop() throws {


### PR DESCRIPTION
## Summary
- extract an internal SessionController to own session state, persistence, pagination, and settings
- keep ChatViewModel's API source-compatible by forwarding session-facing properties and methods
- add regression coverage for prompt-template fallback and persisted session activity timestamps

Closes #281

## Testing
- swift test --filter BaseChatCoreTests --disable-default-traits
- swift test --filter BaseChatInferenceTests --disable-default-traits
- swift test --filter BaseChatUITests --disable-default-traits
- swift test --filter BaseChatBackendsTests --disable-default-traits
- swift test --filter BaseChatSnapshotTests --disable-default-traits

## Release Note
Refactors ChatViewModel internals by moving session-scoped state into a dedicated SessionController without changing the public API. This keeps session selection, message persistence, pagination, and per-session settings isolated while preserving existing UI behavior.
