### PR TITLE
feat(model-browser): surface disk space errors and distinguish active model badge

### DIFF
--- a/Sources/BaseChatUI/ViewModels/ModelManagementViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ModelManagementViewModel.swift
@@ -79,6 +79,14 @@ public final class ModelManagementViewModel {
         didSet { loadCachedBenchmarkResults() }
     }
 
+    // MARK: - Active Model
+
+    /// The file name of the currently active (loaded) model.
+    ///
+    /// Set externally by the host view whenever `ChatViewModel.selectedModel` changes,
+    /// so `DownloadableModelRow` can distinguish the in-use model from other downloaded models.
+    public var activeModelFileName: String?
+
     // MARK: - Private State
 
     private var searchTask: Task<Void, Never>?
@@ -279,6 +287,13 @@ public final class ModelManagementViewModel {
                 trackedDownloads[model.id] = state
                 Log.download.info("Started download: \(model.displayName), id=\(state.id)")
                 startDownloadSync()
+            } catch HuggingFaceError.insufficientDiskSpace(let required, let available) {
+                let fmt = ByteCountFormatter()
+                fmt.countStyle = .file
+                let requiredStr = fmt.string(fromByteCount: Int64(required))
+                let availableStr = fmt.string(fromByteCount: Int64(available))
+                searchError = "Not enough storage — this model needs \(requiredStr) but only \(availableStr) is available."
+                Log.download.error("Insufficient disk space: need \(required) bytes, have \(available)")
             } catch {
                 searchError = "Failed to start download: \(error.localizedDescription)"
                 Log.download.error("Download start error: \(error)")
@@ -468,6 +483,27 @@ public final class ModelManagementViewModel {
     /// Whether this device has enough RAM to run a model of the given size.
     public func canRunModel(sizeBytes: UInt64) -> Bool {
         deviceCapability.canLoadModel(estimatedMemoryBytes: sizeBytes)
+    }
+
+    /// Whether there is insufficient free disk space to download this model.
+    ///
+    /// Returns `true` when `model.sizeBytes > 0` and the volume's available capacity
+    /// for important usage is less than `model.sizeBytes`. Returns `false` when the
+    /// size is unknown (`sizeBytes == 0`) or on any filesystem query error, so the
+    /// download button is not blocked unnecessarily.
+    public func diskSpaceInsufficient(for model: DownloadableModel) -> Bool {
+        guard model.sizeBytes > 0 else { return false }
+        do {
+            let values = try URL.documentsDirectory
+                .resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
+            guard let available = values.volumeAvailableCapacityForImportantUsage else {
+                return false
+            }
+            return UInt64(available) < model.sizeBytes
+        } catch {
+            Log.download.warning("Disk space query failed: \(error.localizedDescription)")
+            return false
+        }
     }
 
     /// Whether a downloadable model's file already exists on disk.

--- a/Sources/BaseChatUI/ViewModels/ModelManagementViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ModelManagementViewModel.swift
@@ -496,7 +496,8 @@ public final class ModelManagementViewModel {
         do {
             let values = try URL.documentsDirectory
                 .resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
-            guard let available = values.volumeAvailableCapacityForImportantUsage else {
+            guard let available = values.volumeAvailableCapacityForImportantUsage,
+                  available >= 0 else {
                 return false
             }
             return UInt64(available) < model.sizeBytes

--- a/Sources/BaseChatUI/Views/Models/DownloadableModelRow.swift
+++ b/Sources/BaseChatUI/Views/Models/DownloadableModelRow.swift
@@ -165,7 +165,7 @@ public struct DownloadableModelRow: View {
             } label: {
                 Image(systemName: "arrow.down.circle")
                     .font(.title2)
-                    .foregroundColor(insufficient ? Color.secondary : Color.blue)
+                    .foregroundStyle(insufficient ? Color.secondary : Color.blue)
             }
             .buttonStyle(.plain)
             .disabled(insufficient)

--- a/Sources/BaseChatUI/Views/Models/DownloadableModelRow.swift
+++ b/Sources/BaseChatUI/Views/Models/DownloadableModelRow.swift
@@ -130,12 +130,24 @@ public struct DownloadableModelRow: View {
     @ViewBuilder
     private var trailingContent: some View {
         if viewModel.isModelDownloaded(model) {
-            downloadedBadge
+            if viewModel.activeModelFileName == model.fileName {
+                activeModelBadge
+            } else {
+                downloadedBadge
+            }
         } else if let state = viewModel.downloadState(for: model) {
             DownloadProgressView(state: state)
         } else {
             downloadButton
         }
+    }
+
+    private var activeModelBadge: some View {
+        Label("In Use", systemImage: "checkmark.circle.fill")
+            .font(.caption)
+            .foregroundStyle(.blue)
+            .labelStyle(.titleAndIcon)
+            .accessibilityLabel("Active model")
     }
 
     private var downloadedBadge: some View {
@@ -146,16 +158,30 @@ public struct DownloadableModelRow: View {
     }
 
     private var downloadButton: some View {
-        Button {
-            viewModel.startDownload(model)
-        } label: {
-            Image(systemName: "arrow.down.circle")
-                .font(.title2)
-                .foregroundStyle(.blue)
+        let insufficient = viewModel.diskSpaceInsufficient(for: model)
+        return VStack(alignment: .trailing, spacing: 2) {
+            Button {
+                viewModel.startDownload(model)
+            } label: {
+                Image(systemName: "arrow.down.circle")
+                    .font(.title2)
+                    .foregroundColor(insufficient ? Color.secondary : Color.blue)
+            }
+            .buttonStyle(.plain)
+            .disabled(insufficient)
+            .accessibilityLabel("Download \(model.displayName)")
+            .accessibilityHint(
+                insufficient
+                ? "Insufficient storage"
+                : "Downloads \(model.sizeFormatted) model to this device"
+            )
+
+            if insufficient {
+                Text("Insufficient storage")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
         }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Download \(model.displayName)")
-        .accessibilityHint("Downloads \(model.sizeFormatted) model to this device")
     }
 }
 

--- a/Sources/BaseChatUI/Views/Models/HuggingFaceBrowserView.swift
+++ b/Sources/BaseChatUI/Views/Models/HuggingFaceBrowserView.swift
@@ -166,6 +166,9 @@ struct HuggingFaceBrowserView: View {
             viewModel.invalidateModelCache()
             chatViewModel.refreshModels()
         }
+        .onChange(of: chatViewModel.selectedModel) { _, newModel in
+            viewModel.activeModelFileName = newModel?.fileName
+        }
         .fileImporter(
             isPresented: $showImporter,
             allowedContentTypes: Self.importContentTypes,
@@ -174,6 +177,7 @@ struct HuggingFaceBrowserView: View {
             handleImport(result)
         }
         .onAppear {
+            viewModel.activeModelFileName = chatViewModel.selectedModel?.fileName
             viewModel.loadRecommendations(preferredModelIDs: recommendedModelIDs)
         }
     }

--- a/Sources/BaseChatUI/Views/Models/ModelManagementSheet.swift
+++ b/Sources/BaseChatUI/Views/Models/ModelManagementSheet.swift
@@ -137,6 +137,7 @@ public struct ModelManagementSheet: View {
     }
 }
 
+
 #Preview {
     ModelManagementSheet()
         .environment(ChatViewModel())

--- a/Tests/BaseChatUITests/ModelManagementViewModelTests.swift
+++ b/Tests/BaseChatUITests/ModelManagementViewModelTests.swift
@@ -378,6 +378,7 @@ final class ModelManagementViewModelTests: XCTestCase {
         XCTAssertTrue(diagnostics.isEmpty, "Successful cleanup should not record a warning")
     }
 
+
     // MARK: - Issue #309: Auto-clean failed/cancelled downloads from trackedDownloads
 
     func test_downloadSync_removesFailedEntry_afterDisplayWindow() async {
@@ -623,5 +624,94 @@ final class ModelManagementViewModelTests: XCTestCase {
             "the cancelled first task must not clear it"
         )
         XCTAssertFalse(vm.isSearching, "isSearching must be false after the second search completes")
+    }
+
+    // MARK: - Disk Space (#312)
+
+    func test_diskSpaceInsufficient_returnsFalse_whenSizeBytesIsZero() {
+        let vm = ModelManagementViewModel()
+        let model = DownloadableModel(
+            repoID: "test/repo",
+            fileName: "unknown-size.gguf",
+            displayName: "Unknown Size Model",
+            modelType: .gguf,
+            sizeBytes: 0
+        )
+        // sizeBytes == 0 means the size is unknown — should never block the download button.
+        XCTAssertFalse(
+            vm.diskSpaceInsufficient(for: model),
+            "Model with unknown size (sizeBytes == 0) should never report insufficient disk space"
+        )
+    }
+
+    func test_diskSpaceInsufficient_returnsTrue_whenModelExceedsAvailableCapacity() {
+        let vm = ModelManagementViewModel()
+        // UInt64.max bytes is guaranteed to exceed any real device's free space.
+        let model = DownloadableModel(
+            repoID: "test/repo",
+            fileName: "impossibly-large.gguf",
+            displayName: "Impossibly Large Model",
+            modelType: .gguf,
+            sizeBytes: UInt64.max
+        )
+        XCTAssertTrue(
+            vm.diskSpaceInsufficient(for: model),
+            "A model requiring UInt64.max bytes should always report insufficient disk space"
+        )
+    }
+
+    func test_diskSpaceInsufficient_returnsFalse_whenModelFitsOnDisk() {
+        let vm = ModelManagementViewModel()
+        // 1 byte is guaranteed to fit in available disk space on any real device.
+        let model = DownloadableModel(
+            repoID: "test/repo",
+            fileName: "tiny.gguf",
+            displayName: "Tiny Model",
+            modelType: .gguf,
+            sizeBytes: 1
+        )
+        XCTAssertFalse(
+            vm.diskSpaceInsufficient(for: model),
+            "A model requiring 1 byte should never report insufficient disk space"
+        )
+    }
+
+    // MARK: - Active Model Badge (#315)
+
+    func test_activeModelFileName_isNilByDefault() {
+        let vm = ModelManagementViewModel()
+        XCTAssertNil(vm.activeModelFileName, "activeModelFileName should be nil on init")
+    }
+
+    func test_activeModelFileName_canBeSetExternally() {
+        let vm = ModelManagementViewModel()
+        vm.activeModelFileName = "active-model.gguf"
+        XCTAssertEqual(
+            vm.activeModelFileName,
+            "active-model.gguf",
+            "activeModelFileName should reflect the assigned value"
+        )
+    }
+
+    func test_activeModelFileName_distinguishesActiveFromDownloaded() {
+        let vm = ModelManagementViewModel()
+        let activeFileName = "active-model.gguf"
+        let otherFileName = "other-model.gguf"
+
+        vm.activeModelFileName = activeFileName
+
+        XCTAssertEqual(vm.activeModelFileName, activeFileName)
+        // The active file name does not match the other model.
+        XCTAssertNotEqual(vm.activeModelFileName, otherFileName)
+    }
+
+    func test_activeModelFileName_nilAfterClearing() {
+        let vm = ModelManagementViewModel()
+        vm.activeModelFileName = "some-model.gguf"
+        vm.activeModelFileName = nil
+        XCTAssertNil(
+            vm.activeModelFileName,
+            "activeModelFileName should be nil after being cleared"
+        )
     }
 }


### PR DESCRIPTION
## Summary

- **#312 (fix):** `ModelManagementViewModel.startDownload` now catches `HuggingFaceError.insufficientDiskSpace` specifically and shows a clear message like _"Not enough storage — this model needs 4.1 GB but only 1.2 GB is available."_ A new `diskSpaceInsufficient(for:)` method (checking `volumeAvailableCapacityForImportantUsage`) drives a visual indicator in `DownloadableModelRow`: when space is low, the download button is grayed out and disabled, with a small "Insufficient storage" caption below it.
- **#315 (feat):** `ModelManagementViewModel` gains a public `activeModelFileName: String?` property. `ModelDownloadTab` sets it on `.onAppear` and updates it via `.onChange(of: chatViewModel.selectedModel)`. `DownloadableModelRow` checks this against `model.fileName`; when they match, it shows a blue "In Use" badge (`checkmark.circle.fill`) instead of the green "Downloaded" badge, reactively reflecting the currently loaded model.

## Test plan

- [ ] `diskSpaceInsufficient(for:)` returns `false` when `sizeBytes == 0` (unknown size)
- [ ] `diskSpaceInsufficient(for:)` returns `true` when `sizeBytes == UInt64.max`
- [ ] `diskSpaceInsufficient(for:)` returns `false` when `sizeBytes == 1`
- [ ] `activeModelFileName` is nil on init, can be set externally, and can be cleared
- [ ] `activeModelFileName` correctly distinguishes active vs other model file names
- [ ] All four CI suites pass: `BaseChatCoreTests`, `BaseChatInferenceTests`, `BaseChatUITests`, `BaseChatBackendsTests`

## Release Note

Before this change, if a download failed because the device was out of disk space, the error message was a generic "Failed to start download" with the raw system error buried inside. The download button was also always enabled, even when the device clearly didn't have room. This release surfaces the disk space error as a friendly formatted message (e.g., "Not enough storage — this model needs 4.1 GB but only 1.2 GB is available") and proactively grays out the download button before the user even taps it. It also adds a blue "In Use" badge to the model that is currently loaded, so users can immediately tell which model is active versus which ones are merely on disk.

Closes #312
Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)