### PR TITLE
fix(security): path traversal in download placement + cancelDownload race

### DIFF
--- a/Sources/BaseChatInference/Services/BackgroundDownloadManager+URLSessionDelegate.swift
+++ b/Sources/BaseChatInference/Services/BackgroundDownloadManager+URLSessionDelegate.swift
@@ -79,6 +79,12 @@ extension BackgroundDownloadManager: URLSessionDownloadDelegate {
                 } else {
                     try self.validateDownloadedFile(at: tempURL, modelType: model.modelType)
                     let destination = self.storageService.modelsDirectory.appendingPathComponent(model.fileName)
+                    let resolvedDestination = destination.standardized
+                    let resolvedModels = self.storageService.modelsDirectory.standardized
+                    guard resolvedDestination.path.hasPrefix(resolvedModels.path + "/") else {
+                        try? FileManager.default.removeItem(at: tempURL)
+                        throw HuggingFaceError.invalidDownloadedFile(reason: "Model filename escapes models directory: \(model.fileName)")
+                    }
                     if FileManager.default.fileExists(atPath: destination.path) {
                         try FileManager.default.removeItem(at: destination)
                     }

--- a/Sources/BaseChatInference/Services/BackgroundDownloadManager.swift
+++ b/Sources/BaseChatInference/Services/BackgroundDownloadManager.swift
@@ -268,19 +268,23 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable {
     @MainActor public func cancelDownload(id: String) {
         Log.download.info("Cancelling download: \(id)")
 
+        // getAllTasks delivers its callback on the URLSession delegate queue (a background
+        // thread). Reading taskContexts — which is written from @MainActor — on that queue
+        // is a data race. We hop back to @MainActor for the dictionary read, match tasks
+        // by model ID, and then cancel them. URLSessionTask.cancel() is thread-safe.
         backgroundSession.getAllTasks { [weak self] tasks in
             guard let self else { return }
-            for task in tasks {
-                let context = self.taskContext(
-                    for: task.taskIdentifier,
-                    taskDescription: task.taskDescription
-                )
-                if context?.modelID == id {
-                    task.cancel()
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                for task in tasks {
+                    let context = self.taskContext(
+                        for: task.taskIdentifier,
+                        taskDescription: task.taskDescription
+                    )
+                    if context?.modelID == id {
+                        task.cancel()
+                    }
                 }
-            }
-
-            Task { @MainActor in
                 self.activeDownloads[id]?.markCancelled()
                 self.removePendingDownload(id: id)
                 // Mark the snapshot as cancelling rather than removing it immediately.
@@ -565,7 +569,13 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable {
         guard snapshot.completedFiles.count == snapshot.files.count else { return }
 
         try validateDownloadedFile(at: snapshot.stagingDirectory, modelType: .mlx)
-        let finalURL = storageService.modelsDirectory.appendingPathComponent(activeDownloads[modelID]?.model.fileName ?? snapshot.stagingDirectory.lastPathComponent)
+        let finalFileName = activeDownloads[modelID]?.model.fileName ?? snapshot.stagingDirectory.lastPathComponent
+        let finalURL = storageService.modelsDirectory.appendingPathComponent(finalFileName)
+        let resolvedFinalURL = finalURL.standardized
+        let resolvedModelsDir = storageService.modelsDirectory.standardized
+        guard resolvedFinalURL.path.hasPrefix(resolvedModelsDir.path + "/") else {
+            throw HuggingFaceError.invalidDownloadedFile(reason: "Model filename escapes models directory: \(finalFileName)")
+        }
         if FileManager.default.fileExists(atPath: finalURL.path) {
             try FileManager.default.removeItem(at: finalURL)
         }


### PR DESCRIPTION
## Summary

- Sanitize `model.fileName` against path traversal in both single-file and MLX snapshot final placement, using the same guard already applied for per-file staging.
- Serialize `BackgroundDownloadManager.cancelDownload`'s `taskContext` dictionary read on `@MainActor` to eliminate a data race with the URLSession delegate queue.

## Changes

### Fix 1 — Path traversal in final file placement (security)

`model.fileName` was used unsanitized in two `moveItem` call sites:

1. **Single-file download** (`BackgroundDownloadManager+URLSessionDelegate.swift`): the destination was constructed as `storageService.modelsDirectory.appendingPathComponent(model.fileName)` without checking for directory escape.
2. **MLX snapshot final placement** (`BackgroundDownloadManager.swift`, `completeSnapshotFile`): the final move from staging to the models directory used `model.fileName` directly without checking it escapes.

Both sites now apply the same `standardized.path.hasPrefix(modelsDirectory.path + "/")` guard that was already present for per-file staging. A crafted HuggingFace repository with a filename like `../../Library/Preferences/com.apple.something` can no longer write outside the models directory.

### Fix 2 — `cancelDownload` data race

`cancelDownload(id:)` called `backgroundSession.getAllTasks { ... }` and then read `self.taskContexts` (via `taskContext(for:taskDescription:)`) directly inside the completion handler, which runs on the URLSession delegate queue — a background thread. `taskContexts` is written exclusively from `@MainActor` methods, making this a data race.

The fix wraps all mutable `self` access inside a `Task { @MainActor [weak self] in }` block within the `getAllTasks` completion handler. `URLSessionTask.cancel()` is thread-safe and is now called on `@MainActor` after the dictionary lookup completes, preserving correct cancellation behaviour.

## Test plan

- [ ] All four CI test suites pass locally with zero failures:
  ```
  swift test --filter BaseChatCoreTests --disable-default-traits
  swift test --filter BaseChatInferenceTests --disable-default-traits
  swift test --filter BaseChatUITests --disable-default-traits
  swift test --filter BaseChatBackendsTests --disable-default-traits
  ```
- [ ] Existing `BackgroundDownloadIntegrationTests.test_cancelDownload_removesFromActive` and snapshot cancellation tests pass unchanged — the async structure of the fix is already compatible with the existing `getAllTasks` + `Task { @MainActor }` test expectations.
- [ ] Manual: attempt a download with a model whose `fileName` contains `../` and confirm it fails with `invalidDownloadedFile` rather than writing outside the models directory.

## Release Note

**Path traversal and data race fixed in `BackgroundDownloadManager`**

A crafted HuggingFace repository filename such as `../../Library/Preferences/com.apple.something` could bypass the per-file staging guard that was already in place, and write the finished model file outside the designated models directory — both in single-file (GGUF) and multi-file (MLX snapshot) download paths. Both final-placement call sites now apply the same `standardized.path.hasPrefix` guard already used for staging, and any filename that escapes the models directory throws `HuggingFaceError.invalidDownloadedFile` and discards the temp file.

A secondary data race in `cancelDownload(id:)` has also been fixed: the `taskContexts` dictionary was being read on the URLSession delegate queue (a background thread) while all writes to it happen on `@MainActor`. The lookup and all subsequent mutable access are now serialized on `@MainActor` inside the `getAllTasks` callback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)