### PR TITLE
fix(arch): remove SwiftUI from inference layer and deprecate maxTokens

### DIFF
--- a/Sources/BaseChatBackends/ClaudeBackend.swift
+++ b/Sources/BaseChatBackends/ClaudeBackend.swift
@@ -81,7 +81,7 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
 
         var body: [String: Any] = [
             "model": modelName,
-            "max_tokens": config.maxOutputTokens ?? Int(config.maxTokens),
+            "max_tokens": config.maxOutputTokens ?? 2048,
             "messages": chatMessages,
             "stream": true,
             "temperature": config.temperature,

--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -332,7 +332,7 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
             throw InferenceError.inferenceFailure("Failed to tokenize prompt")
         }
 
-        let maxTokens = config.maxOutputTokens ?? Int(config.maxTokens)
+        let maxTokens = config.maxOutputTokens ?? 2048
 
         let (stream, continuation) = AsyncThrowingStream.makeStream(of: GenerationEvent.self)
         let generationStream = GenerationStream(stream)

--- a/Sources/BaseChatBackends/OllamaBackend.swift
+++ b/Sources/BaseChatBackends/OllamaBackend.swift
@@ -98,7 +98,7 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
             "top_p": config.topP,
             "top_k": config.topK.map { Int($0) } ?? 40,
             "repeat_penalty": config.repeatPenalty,
-            "num_predict": config.maxOutputTokens ?? Int(config.maxTokens),
+            "num_predict": config.maxOutputTokens ?? 2048,
         ]
 
         let body: [String: Any] = [

--- a/Sources/BaseChatBackends/OpenAIBackend.swift
+++ b/Sources/BaseChatBackends/OpenAIBackend.swift
@@ -97,7 +97,7 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             "stream_options": ["include_usage": true],
             "temperature": config.temperature,
             "top_p": config.topP,
-            "max_tokens": config.maxOutputTokens ?? Int(config.maxTokens)
+            "max_tokens": config.maxOutputTokens ?? 2048
         ]
 
         var request = URLRequest(url: completionsURL)

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -5,6 +5,7 @@ public struct GenerationConfig: Sendable {
     public var temperature: Float
     public var topP: Float
     public var repeatPenalty: Float
+    @available(*, deprecated, renamed: "maxOutputTokens", message: "Use maxOutputTokens instead.")
     public var maxTokens: Int32
     public var topK: Int32?
     public var typicalP: Float?
@@ -16,11 +17,12 @@ public struct GenerationConfig: Sendable {
     /// `nil` means no explicit limit beyond the backend's own defaults.
     public var maxOutputTokens: Int?
 
+    @available(*, deprecated, message: "Use init(temperature:topP:repeatPenalty:topK:typicalP:maxOutputTokens:) instead.")
     public init(
         temperature: Float = 0.7,
         topP: Float = 0.9,
         repeatPenalty: Float = 1.1,
-        maxTokens: Int32 = 512,
+        maxTokens: Int32,
         topK: Int32? = nil,
         typicalP: Float? = nil,
         maxOutputTokens: Int? = 2048
@@ -29,6 +31,23 @@ public struct GenerationConfig: Sendable {
         self.topP = topP
         self.repeatPenalty = repeatPenalty
         self.maxTokens = maxTokens
+        self.topK = topK
+        self.typicalP = typicalP
+        self.maxOutputTokens = maxOutputTokens
+    }
+
+    public init(
+        temperature: Float = 0.7,
+        topP: Float = 0.9,
+        repeatPenalty: Float = 1.1,
+        topK: Int32? = nil,
+        typicalP: Float? = nil,
+        maxOutputTokens: Int? = 2048
+    ) {
+        self.temperature = temperature
+        self.topP = topP
+        self.repeatPenalty = repeatPenalty
+        self.maxTokens = 512
         self.topK = topK
         self.typicalP = typicalP
         self.maxOutputTokens = maxOutputTokens

--- a/Sources/BaseChatInference/Services/SettingsService.swift
+++ b/Sources/BaseChatInference/Services/SettingsService.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Observation
-import SwiftUI
 
 /// Manages global default settings persisted via UserDefaults.
 ///
@@ -84,14 +83,4 @@ public enum AppearanceMode: String, CaseIterable, Identifiable {
     case dark = "Dark"
 
     public var id: String { rawValue }
-
-    /// Maps to SwiftUI's `ColorScheme` for use with `.preferredColorScheme()`.
-    /// Returns `nil` for `.system` to follow the OS setting.
-    public var colorScheme: ColorScheme? {
-        switch self {
-        case .system: nil
-        case .light: .light
-        case .dark: .dark
-        }
-    }
 }

--- a/Sources/BaseChatTestSupport/StopGenerationContractTests.swift
+++ b/Sources/BaseChatTestSupport/StopGenerationContractTests.swift
@@ -17,7 +17,7 @@ public enum StopGenerationContractTests {
         file: StaticString = #filePath,
         line: UInt = #line
     ) async throws {
-        let config = GenerationConfig(maxTokens: 64)
+        let config = GenerationConfig(maxOutputTokens: 64)
 
         // 1. Start generation and immediately stop.
         let stream = try backend.generate(

--- a/Sources/BaseChatUI/Extensions/AppearanceMode+ColorScheme.swift
+++ b/Sources/BaseChatUI/Extensions/AppearanceMode+ColorScheme.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+import BaseChatCore  // AppearanceMode is re-exported from BaseChatInference via BaseChatCore
+
+extension AppearanceMode {
+    /// Maps to SwiftUI's `ColorScheme` for use with `.preferredColorScheme()`.
+    /// Returns `nil` for `.system` to follow the OS setting.
+    public var colorScheme: ColorScheme? {
+        switch self {
+        case .system: return nil
+        case .light: return .light
+        case .dark: return .dark
+        }
+    }
+}

--- a/Tests/BaseChatE2ETests/DownloadValidateLoadGenerateE2ETests.swift
+++ b/Tests/BaseChatE2ETests/DownloadValidateLoadGenerateE2ETests.swift
@@ -49,7 +49,7 @@ struct DownloadValidateLoadGenerateE2ETests {
         #expect(backend.loadModelCallCount == 1)
 
         // 4. Generate tokens.
-        let config = GenerationConfig(temperature: 0.7, maxTokens: 512)
+        let config = GenerationConfig(temperature: 0.7, maxOutputTokens: 512)
         let output = try await collectTokens(backend.generate(
             prompt: "Tell me a story",
             systemPrompt: "You are a storyteller.",

--- a/Tests/BaseChatE2ETests/OllamaE2ETests.swift
+++ b/Tests/BaseChatE2ETests/OllamaE2ETests.swift
@@ -54,7 +54,6 @@ final class OllamaE2ETests: XCTestCase {
     ) async throws -> String {
         let config = GenerationConfig(
             temperature: 0.3,
-            maxTokens: Int32(maxTokens),
             maxOutputTokens: maxTokens
         )
         let stream = try backend.generate(
@@ -96,7 +95,6 @@ final class OllamaE2ETests: XCTestCase {
     func test_realInference_stopGeneration() async throws {
         let config = GenerationConfig(
             temperature: 0.7,
-            maxTokens: 2048,
             maxOutputTokens: 2048
         )
 

--- a/Tests/BaseChatInferenceTests/GenerationConfigTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationConfigTests.swift
@@ -21,11 +21,6 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertEqual(config.repeatPenalty, 1.1, accuracy: 0.001)
     }
 
-    func test_defaultInit_maxTokens() {
-        let config = GenerationConfig()
-        XCTAssertEqual(config.maxTokens, 512)
-    }
-
     func test_defaultInit_maxOutputTokens() {
         let config = GenerationConfig()
         XCTAssertEqual(config.maxOutputTokens, 2048)
@@ -38,23 +33,22 @@ final class GenerationConfigTests: XCTestCase {
             temperature: 1.2,
             topP: 0.95,
             repeatPenalty: 1.5,
-            maxTokens: 2048
+            maxOutputTokens: 2048
         )
 
         XCTAssertEqual(config.temperature, 1.2, accuracy: 0.001)
         XCTAssertEqual(config.topP, 0.95, accuracy: 0.001)
         XCTAssertEqual(config.repeatPenalty, 1.5, accuracy: 0.001)
-        XCTAssertEqual(config.maxTokens, 2048)
+        XCTAssertEqual(config.maxOutputTokens, 2048)
     }
 
     func test_customInit_partialOverride() {
-        let config = GenerationConfig(temperature: 0.0, maxTokens: 1024)
+        let config = GenerationConfig(temperature: 0.0, maxOutputTokens: 1024)
 
         XCTAssertEqual(config.temperature, 0.0, accuracy: 0.001)
         XCTAssertEqual(config.topP, 0.9, accuracy: 0.001, "Non-overridden topP should use default")
         XCTAssertEqual(config.repeatPenalty, 1.1, accuracy: 0.001, "Non-overridden repeatPenalty should use default")
-        XCTAssertEqual(config.maxTokens, 1024)
-        XCTAssertEqual(config.maxOutputTokens, 2048, "Non-overridden maxOutputTokens should use default")
+        XCTAssertEqual(config.maxOutputTokens, 1024, "maxOutputTokens should match provided value")
     }
 
     func test_customInit_maxOutputTokens_customValue() {

--- a/Tests/BaseChatInferenceTests/InferenceServiceTests.swift
+++ b/Tests/BaseChatInferenceTests/InferenceServiceTests.swift
@@ -109,7 +109,7 @@ final class InferenceServiceTests: XCTestCase {
         XCTAssertEqual(config.temperature, 0.7)
         XCTAssertEqual(config.topP, 0.9)
         XCTAssertEqual(config.repeatPenalty, 1.1)
-        XCTAssertEqual(config.maxTokens, 512)
+        XCTAssertEqual(config.maxOutputTokens, 2048)
     }
 
     // MARK: - ModelType backend selection

--- a/Tests/BaseChatMLXIntegrationTests/MLXModelE2ETests.swift
+++ b/Tests/BaseChatMLXIntegrationTests/MLXModelE2ETests.swift
@@ -63,7 +63,6 @@ final class MLXModelE2ETests: XCTestCase {
     ) async throws -> String {
         let config = GenerationConfig(
             temperature: 0.3,
-            maxTokens: Int32(maxTokens),
             maxOutputTokens: maxTokens
         )
         let stream = try backend.generate(
@@ -108,7 +107,6 @@ final class MLXModelE2ETests: XCTestCase {
     func test_realInference_stopGeneration() async throws {
         let config = GenerationConfig(
             temperature: 0.7,
-            maxTokens: 2048,
             maxOutputTokens: 2048
         )
 


### PR DESCRIPTION
## Summary

- Remove `import SwiftUI` from `BaseChatInference/Services/SettingsService.swift` by moving `AppearanceMode.colorScheme` into a new `BaseChatUI` extension
- Deprecate `GenerationConfig.maxTokens` and its init overload in favour of `maxOutputTokens`, and eliminate the silent cross-backend behavioural difference in the fallback

## Changes

**Fix 1 — SwiftUI import removal**

`SettingsService.swift` had `import SwiftUI` solely for `AppearanceMode.colorScheme`, a computed property returning `ColorScheme?`. This dragged SwiftUI into the headless inference layer, making `BaseChatInference` unusable in CLI or server contexts. The property is moved to a new file `Sources/BaseChatUI/Extensions/AppearanceMode+ColorScheme.swift` as a conditional extension, restoring the existing call-site contract for consuming apps (`.preferredColorScheme(mode.colorScheme)` still works).

**Fix 2 — maxTokens deprecation**

`GenerationConfig` has had two output-length fields since the `maxOutputTokens` field was added: `maxTokens: Int32` (legacy, default 512) and `maxOutputTokens: Int?` (current, default 2048). Foundation and MLX backends ignored `maxTokens` entirely, while Llama, OpenAI, Claude, and Ollama backends used `config.maxOutputTokens ?? Int(config.maxTokens)`. A caller who set `maxTokens` but left `maxOutputTokens` at nil would therefore get silently different caps on different backends. Both `maxTokens` and its init overload are now marked `@available(*, deprecated, ...)`, and all four backend fallback expressions are replaced with the explicit default `?? 2048`. A non-deprecated init overload (omitting `maxTokens`) is provided as the canonical path forward.

## Release Note

**BaseChatInference no longer imports SwiftUI, and GenerationConfig.maxTokens is deprecated.**

`BaseChatInference` was inadvertently pulling in SwiftUI through `SettingsService.swift`, preventing the framework from being used in headless CLI or server contexts where SwiftUI is unavailable. The `AppearanceMode.colorScheme` bridge property now lives in `BaseChatUI`, where it belongs — consuming apps using `.preferredColorScheme(mode.colorScheme)` continue to work without any changes.

`GenerationConfig.maxTokens` created a silent cross-backend behavioural difference: Foundation and MLX backends ignored it, while Llama and cloud backends used it as a fallback cap. This meant a caller setting `maxTokens` but not `maxOutputTokens` would see wildly different output lengths depending on which backend was active. `maxTokens` is now deprecated; all backends fall back to the `maxOutputTokens` default of 2048, giving consistent behaviour across the board. Migrate to `maxOutputTokens` — the init without `maxTokens` is provided as the canonical replacement.

## Test plan

- [x] `BaseChatCoreTests` — 83 tests, 0 failures
- [x] `BaseChatInferenceTests` — 69 tests, 0 failures
- [x] `BaseChatUITests` — 423 tests, 0 failures
- [x] `BaseChatBackendsTests` — 63 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)