### PR TITLE
fix: enforce SSECloudBackend overrides at compile time (#328)

### DIFF
--- a/Sources/BaseChatBackends/ClaudeBackend.swift
+++ b/Sources/BaseChatBackends/ClaudeBackend.swift
@@ -105,24 +105,6 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         return request
     }
 
-    // MARK: - SSE Payload Handling
-
-    public override func extractToken(from payload: String) -> String? {
-        Self.parseToken(from: payload)
-    }
-
-    public override func extractUsage(from payload: String) -> (promptTokens: Int?, completionTokens: Int?)? {
-        Self.parseUsage(from: payload)
-    }
-
-    public override func isStreamEnd(_ payload: String) -> Bool {
-        Self.parseIsStreamEnd(payload)
-    }
-
-    public override func extractStreamError(from payload: String) -> Error? {
-        Self.parseStreamError(from: payload)
-    }
-
     /// Claude reports usage split across `message_start` (prompt) and
     /// `message_delta` (completion), so we merge incrementally.
     public override func handleUsage(_ usage: (promptTokens: Int?, completionTokens: Int?)) {

--- a/Sources/BaseChatBackends/OllamaBackend.swift
+++ b/Sources/BaseChatBackends/OllamaBackend.swift
@@ -186,29 +186,6 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
         }
     }
 
-    // MARK: - SSE Payload Handler
-
-    /// Ollama-specific SSE payload handler.
-    ///
-    /// Ollama uses NDJSON rather than SSE, so ``parseResponseStream(bytes:continuation:)``
-    /// is overridden to bypass the SSE path entirely. This handler satisfies the
-    /// ``SSECloudBackend`` initialiser contract and delegates to the same static
-    /// parsing logic used by the NDJSON path.
-    struct OllamaPayloadHandler: SSEPayloadHandler {
-        func extractToken(from payload: String) -> String? {
-            OllamaBackend.extractToken(from: payload)
-        }
-        func extractUsage(from payload: String) -> (promptTokens: Int?, completionTokens: Int?)? { nil }
-        func isStreamEnd(_ payload: String) -> Bool { false }
-        func extractStreamError(from payload: String) -> Error? { nil }
-    }
-
-    // MARK: - SSE Hooks (unused for NDJSON, but required by base class)
-
-    public override func extractToken(from payload: String) -> String? {
-        Self.extractToken(from: payload)
-    }
-
     // MARK: - NDJSON Parsing
 
     /// Extracts the assistant content token from an Ollama `/api/chat` NDJSON line.
@@ -246,6 +223,22 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
             return nil
         }
         return message
+    }
+
+    // MARK: - SSE Payload Handler
+
+    /// Ollama-specific ``SSEPayloadHandler`` for use with ``SSEStreamParser``.
+    ///
+    /// ``OllamaBackend`` overrides ``parseResponseStream(bytes:continuation:)``
+    /// to handle NDJSON directly, so these methods are not called during normal
+    /// operation. They are provided for completeness and external reuse.
+    struct OllamaPayloadHandler: SSEPayloadHandler {
+        func extractToken(from payload: String) -> String? {
+            OllamaBackend.extractToken(from: payload)
+        }
+        func extractUsage(from payload: String) -> (promptTokens: Int?, completionTokens: Int?)? { nil }
+        func isStreamEnd(_ payload: String) -> Bool { false }
+        func extractStreamError(from payload: String) -> Error? { nil }
     }
 
     // MARK: - Unload

--- a/Sources/BaseChatBackends/OpenAIBackend.swift
+++ b/Sources/BaseChatBackends/OpenAIBackend.swift
@@ -116,17 +116,6 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         return request
     }
 
-    // MARK: - SSE Payload Handling
-
-    public override func extractToken(from payload: String) -> String? {
-        Self.parseToken(from: payload)
-    }
-
-    public override func extractUsage(from payload: String) -> (promptTokens: Int?, completionTokens: Int?)? {
-        guard let usage = Self.parseUsage(from: payload) else { return nil }
-        return (promptTokens: usage.promptTokens, completionTokens: usage.completionTokens)
-    }
-
     // MARK: - SSE Payload Handler
 
     /// OpenAI-specific SSE payload interpreter for use with `SSEStreamParser.streamTokens`.

--- a/Tests/BaseChatBackendsTests/SecureBytesTests.swift
+++ b/Tests/BaseChatBackendsTests/SecureBytesTests.swift
@@ -3,6 +3,14 @@ import Foundation
 import BaseChatInference
 @testable import BaseChatBackends
 
+// Minimal payload handler for tests that exercise SSECloudBackend state directly.
+private struct NoOpPayloadHandler: SSEPayloadHandler {
+    func extractToken(from payload: String) -> String? { nil }
+    func extractUsage(from payload: String) -> (promptTokens: Int?, completionTokens: Int?)? { nil }
+    func isStreamEnd(_ payload: String) -> Bool { false }
+    func extractStreamError(from payload: String) -> Error? { nil }
+}
+
 @Suite("SecureBytes")
 struct SecureBytesTests {
 
@@ -29,17 +37,12 @@ struct SecureBytesTests {
 @Suite("SSECloudBackend ephemeralAPIKey")
 struct EphemeralAPIKeyTests {
 
-    /// No-op payload handler used to satisfy `SSECloudBackend`'s init contract
-    /// in tests that only exercise key-storage behaviour.
-    private struct NullPayloadHandler: SSEPayloadHandler {
-        func extractToken(from payload: String) -> String? { nil }
-        func extractUsage(from payload: String) -> (promptTokens: Int?, completionTokens: Int?)? { nil }
-        func isStreamEnd(_ payload: String) -> Bool { false }
-        func extractStreamError(from payload: String) -> Error? { nil }
-    }
-
     private func makeBackend() -> SSECloudBackend {
-        SSECloudBackend(defaultModelName: "test-model", urlSession: .shared, payloadHandler: NullPayloadHandler())
+        SSECloudBackend(
+            defaultModelName: "test-model",
+            urlSession: .shared,
+            payloadHandler: NoOpPayloadHandler()
+        )
     }
 
     @Test("stores and retrieves a key")


### PR DESCRIPTION
## Summary

Fixes #328. Three methods on `SSECloudBackend` used `fatalError("Subclasses must override …")` as a runtime stand-in for abstract methods. External consumers who subclassed `SSECloudBackend` without overriding `extractToken(from:)`, `extractUsage(from:)`, `isStreamEnd(_:)`, or `extractStreamError(from:)` would crash at runtime with no compiler warning.

## What changed

`SSECloudBackend.init` now requires a `payloadHandler: any SSEPayloadHandler` parameter. The four previously-fatal methods delegate to this handler by default. Missing implementations now fail at compile time — the init call won't compile without a handler.

`OpenAIBackend`, `ClaudeBackend`, and `OllamaBackend` each pass their existing `*PayloadHandler` structs to the new parameter. The redundant `override` methods that simply forwarded to the same static functions are removed (the base-class delegation is equivalent). `SecureBytesTests` gains a private `NoOpPayloadHandler` to satisfy the updated init.

`capabilities` and `buildRequest(prompt:systemPrompt:config:)` remain `open` with improved `fatalError` messages (including `type(of: self)`) — a protocol-based solution for those two is tracked separately.

## Breaking change

`SSECloudBackend.init(defaultModelName:urlSession:)` gains a required `payloadHandler:` parameter. Any code that subclasses `SSECloudBackend` and calls `super.init(defaultModelName:urlSession:)` must be updated to pass a handler. This is the point of the fix — the compiler now enforces what was previously a runtime crash.

## Test plan

- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 63 tests, 0 failures
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 69 tests, 0 failures
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 83 tests, 0 failures
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 424 tests, 0 failures

## Release Note

**SSECloudBackend no longer crashes silently when subclasses miss payload methods.** Previously, forgetting to override `extractToken(from:)` or related SSE methods on a custom `SSECloudBackend` subclass would cause a runtime `fatalError` that only appeared when generation ran. The base class initialiser now requires an `SSEPayloadHandler` — the compiler rejects backends that omit it, turning a runtime crash into a compile error. Built-in backends (`OpenAIBackend`, `ClaudeBackend`, `OllamaBackend`) are unaffected by the runtime behaviour change; their existing `*PayloadHandler` structs are now passed at init instead of being wired through `override` methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)