### PR TITLE
fix: add missing import BaseChatInference to MLXModelE2ETests (#350)

### DIFF
--- a/Tests/BaseChatMLXIntegrationTests/MLXModelE2ETests.swift
+++ b/Tests/BaseChatMLXIntegrationTests/MLXModelE2ETests.swift
@@ -1,6 +1,7 @@
 #if MLX
 import XCTest
 import BaseChatCore
+import BaseChatInference
 import BaseChatTestSupport
 @testable import BaseChatBackends
 


### PR DESCRIPTION
## Summary

`MLXModelE2ETests.swift` was missing `import BaseChatInference`, causing `GenerationConfig` to be unresolved at compile time when running with `--traits MLX,Llama`. `BaseChatCore` does not re-export `BaseChatInference`, so any file using `GenerationConfig` or other inference types directly must import it explicitly (same rule as #341 and #343).

## Changes

- Added `import BaseChatInference` to `Tests/BaseChatMLXIntegrationTests/MLXModelE2ETests.swift`

## Test plan

- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 63 tests, all pass
- [ ] `swift test --filter BaseChatBackendsTests --traits MLX,Llama` — requires Apple Silicon with MLX model on disk; compile error is resolved by this change

## Release Note

Fixed a compile error in `BaseChatMLXIntegrationTests` — `GenerationConfig` was unresolved because `import BaseChatInference` was missing from `MLXModelE2ETests.swift`. Closes #350.