### PR TITLE
perf(ui): throttle model-load progress phase transitions to 4 Hz

### DIFF
--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+ModelLoading.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+ModelLoading.swift
@@ -95,6 +95,7 @@ extension ChatViewModel {
     private func beginLoadUIState(generation: UInt64?) -> Bool {
         guard isCurrentLoadIntentGeneration(generation) else { return false }
         errorMessage = nil
+        lastProgressTransitionInstant = nil
         transitionPhase(to: .modelLoading(progress: inferenceService.modelLoadProgress))
         return true
     }
@@ -126,13 +127,27 @@ extension ChatViewModel {
         guard isCurrentLoadIntentGeneration(generation) else { return }
         guard case .modelLoading(let current) = activityPhase else { return }
         let snapshot = inferenceService.modelLoadProgress
-        if current != snapshot {
-            transitionPhase(to: .modelLoading(progress: snapshot))
+        guard current != snapshot else { return }
+
+        // Terminal progress (>= 1.0) and the first emission after a new load
+        // cycle bypass the throttle so the progress UI feels immediate at the
+        // start and lands cleanly at 100% before the phase flips to .idle.
+        let isTerminal = (snapshot ?? 0.0) >= 1.0
+        let now = ContinuousClock.now
+        if let last = lastProgressTransitionInstant,
+           !isTerminal,
+           now - last < progressBridgeMinTransitionInterval {
+            return
+        }
+
+        if transitionPhase(to: .modelLoading(progress: snapshot)) {
+            lastProgressTransitionInstant = now
         }
     }
 
     private func endLoadUIState(generation: UInt64?) {
         guard isCurrentLoadIntentGeneration(generation) else { return }
+        lastProgressTransitionInstant = nil
         if case .modelLoading = activityPhase {
             transitionPhase(to: .idle)
         }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -381,6 +381,20 @@ public final class ChatViewModel {
     /// `inferenceService.modelLoadProgress` into ``activityPhase``. Tests may
     /// override this to a small value for deterministic timing.
     var progressBridgePollInterval: Duration = .milliseconds(50)
+
+    /// Minimum interval between published phase transitions for in-flight
+    /// model-load progress. Keeps steadily-progressing backends from
+    /// re-rendering every view observing ``activityPhase`` on every poll tick.
+    /// The first emission in a load cycle and the terminal (≥ 1.0) emission
+    /// always publish regardless of this window.
+    var progressBridgeMinTransitionInterval: Duration = .milliseconds(250)
+
+    /// Timestamp of the most recent published phase transition from
+    /// ``applyModelLoadProgress``. `nil` means the next progress change will
+    /// publish immediately (either because no progress has been published yet
+    /// in this load cycle or a fresh cycle just began).
+    @ObservationIgnored
+    var lastProgressTransitionInstant: ContinuousClock.Instant?
     var lastPressureLevel: MemoryPressureLevel = .nominal
     private var isSynchronizingSelection = false
     var isRestoringSession = false

--- a/Tests/BaseChatUITests/ChatViewModelLoadProgressBridgeTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelLoadProgressBridgeTests.swift
@@ -108,6 +108,103 @@ final class ChatViewModelLoadProgressBridgeTests: XCTestCase {
         XCTAssertTrue(vm.isModelLoaded)
     }
 
+    // MARK: - Throttling
+
+    /// Rapid progress emissions within the throttle window must coalesce.
+    /// After the initial 0.0 is published and the first fractional value
+    /// lands, any further non-terminal updates within the throttle window
+    /// must be suppressed so SwiftUI isn't invalidated on every 50ms poll.
+    func test_rapidProgressEmissions_areThrottledToAtMostTwoTransitions() async throws {
+        let backend = ProgressBridgeBackend()
+        let service = InferenceService()
+        service.registerBackendFactory { type in type == .gguf ? backend : nil }
+
+        let vm = ChatViewModel(inferenceService: service)
+        vm.progressBridgePollInterval = .milliseconds(2)
+        // Use a long throttle window so 10 rapid emissions land inside it.
+        vm.progressBridgeMinTransitionInterval = .milliseconds(500)
+        vm.selectedModel = makeModelInfo()
+
+        // Record every modelLoading(progress:) transition the bridge publishes.
+        // The callback is invoked on MainActor (matching this test class), so a
+        // plain ivar is safe.
+        final class Counter: @unchecked Sendable { var value = 0 }
+        let counter = Counter()
+        vm.onActivityPhaseChanged = { phase in
+            if case .modelLoading = phase {
+                counter.value += 1
+            }
+        }
+
+        let loadTask = Task { await vm.loadSelectedModel() }
+        await backend.waitUntilLoadStarted()
+
+        // Wait for the seed 0.0 emission so the throttle clock starts from the
+        // first fractional update below.
+        await waitForPhase(.modelLoading(progress: 0.0), on: vm)
+
+        // Publish 10 progress changes back-to-back. With the throttle window
+        // set to 500 ms, only the first should make it through as a new
+        // transition — the next 9 must be suppressed.
+        for step in 1...10 {
+            await backend.fireProgress(Double(step) / 100.0) // 0.01 ... 0.10
+        }
+
+        // Give the bridge several poll intervals to observe each of those
+        // values. 10 polls at 2 ms is far shorter than the 500 ms throttle.
+        try await Task.sleep(for: .milliseconds(50))
+
+        let observed = counter.value
+
+        // Expected: 1 (seed 0.0) + 1 (first throttled emission) = 2.
+        // Without the throttle the bridge polls at 2 ms and each new value is
+        // different, so this would be ~10+ transitions.
+        XCTAssertLessThanOrEqual(
+            observed, 2,
+            "Rapid progress updates should be throttled to at most 2 phase transitions (initial + first throttled). Observed: \(observed)"
+        )
+
+        await backend.releaseLoadSuccess()
+        await loadTask.value
+    }
+
+    /// Terminal progress (1.0) must bypass the throttle window so the progress
+    /// bar reaches 100% promptly before the phase flips to .idle.
+    func test_terminalProgress_bypassesThrottleWindow() async throws {
+        let backend = ProgressBridgeBackend()
+        let service = InferenceService()
+        service.registerBackendFactory { type in type == .gguf ? backend : nil }
+
+        let vm = ChatViewModel(inferenceService: service)
+        vm.progressBridgePollInterval = .milliseconds(2)
+        // Long throttle window so anything non-terminal after the seed 0.0
+        // cannot land on its own.
+        vm.progressBridgeMinTransitionInterval = .seconds(30)
+        vm.selectedModel = makeModelInfo()
+
+        let loadTask = Task { await vm.loadSelectedModel() }
+        await backend.waitUntilLoadStarted()
+
+        // Seed 0.0 publishes (first bridge emission bypasses the throttle).
+        await waitForPhase(.modelLoading(progress: 0.0), on: vm)
+
+        // A non-terminal update inside the 30 s window must stay suppressed.
+        await backend.fireProgress(0.5)
+        try await Task.sleep(for: .milliseconds(30))
+        XCTAssertEqual(
+            vm.activityPhase, .modelLoading(progress: 0.0),
+            "Non-terminal progress within the throttle window should be suppressed"
+        )
+
+        // A terminal value must bypass the throttle even though we're still
+        // well inside the 30 s window.
+        await backend.fireProgress(1.0)
+        await waitForPhase(.modelLoading(progress: 1.0), on: vm)
+
+        await backend.releaseLoadSuccess()
+        await loadTask.value
+    }
+
     // MARK: - Failure path
 
     func test_activityPhase_resetsToIdle_onLoadFailure() async throws {


### PR DESCRIPTION
## Summary

`ChatViewModel.applyModelLoadProgress` called `transitionPhase()` on every 50ms poll tick when backend progress values changed. For a steadily progressing backend this produced up to 20 SwiftUI invalidations per second, re-rendering every view observing `activityPhase` (ChatView, ChatInputBar, progress indicators) on each tick.

Throttles progress transitions to ~4 Hz while preserving the first progress emission and the terminal (1.0) emission so progress UIs still feel immediate at start and end.

## Test plan
- [x] New test: 10 rapid progress emissions produce <= 2 phase transitions
- [x] New test: terminal progress (1.0) always emits even within throttle window
- [x] Sabotage-verified (both tests fail when the throttle is removed)
- [x] Full CI suite passes (Core 83, Inference 69, UI 426, Backends 63)

## Release Note
Reduces SwiftUI redraw overhead during model loading. Rapidly changing load progress values previously triggered up to 20 view invalidations per second; they're now coalesced to 4 Hz while keeping start and completion of the progress bar immediate.

Generated with [Claude Code](https://claude.com/claude-code)