### PR TITLE
fix: add missing BaseChatInference imports to MLXBackend tests

### DIFF
--- a/Tests/BaseChatBackendsTests/MLXBackendGenerationTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXBackendGenerationTests.swift
@@ -2,6 +2,7 @@
 import XCTest
 import MLXLMCommon
 import BaseChatCore
+import BaseChatInference
 import BaseChatTestSupport
 @testable import BaseChatBackends
 

--- a/Tests/BaseChatBackendsTests/MLXBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXBackendTests.swift
@@ -1,6 +1,7 @@
 #if MLX
 import XCTest
 import BaseChatCore
+import BaseChatInference
 import BaseChatTestSupport
 @testable import BaseChatBackends
 


### PR DESCRIPTION
## Summary

`Tests/BaseChatBackendsTests/MLXBackendTests.swift` and `Tests/BaseChatBackendsTests/MLXBackendGenerationTests.swift` both reference `GenerationConfig` and `GenerationStream` from `BaseChatInference` but did not import the module. `BaseChatCore` no longer re-exports `BaseChatInference` (see #338), so the `MLX` trait build failed locally with `cannot find 'GenerationConfig' in scope`.

Same class of bug as #350, which fixed the identical missing import in `MLXModelE2ETests.swift`. CI does not catch these because the `MLX` trait is disabled in CI.

## Test plan
- [ ] `swift test --filter BaseChatBackendsTests --traits MLX,Llama` compiles and passes on Apple Silicon
- [ ] Existing no-trait suite continues to pass

## Release Note
Restores the ability to run MLX-trait backend tests locally on Apple Silicon. No runtime behavior changes — test imports only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)