### PR TITLE
docs(security): correct PinnedSessionDelegate pin documentation + CI guard

### DIFF
--- a/Sources/BaseChatBackends/PinnedSessionDelegate.swift
+++ b/Sources/BaseChatBackends/PinnedSessionDelegate.swift
@@ -25,12 +25,23 @@ final class PinnedSessionDelegate: NSObject, @preconcurrency URLSessionDelegate 
     ///   openssl dgst -sha256 -binary | base64
     /// ```
     ///
-    /// These pins are intentionally left empty and must be populated with actual
-    /// SPKI hashes before enabling pinning in production.
+    /// Default pins are populated lazily by `loadDefaultPins()` on first access.
+    /// Today that function ships two SPKI hashes — the Google Trust Services WE1
+    /// intermediate CA and its issuing GTS Root R4 — and applies them to both
+    /// `api.openai.com` and `api.anthropic.com` because both providers sit
+    /// behind Google Trust Services. Pinning the intermediate (plus the root as
+    /// a backup) rather than the leaf keeps the pin set stable across routine
+    /// leaf-certificate renewals: pins only need to change when a provider
+    /// rotates its signing infrastructure.
     ///
     /// `api.openai.com` and `api.anthropic.com` are treated as required pinned
     /// production hosts: missing or empty pin sets fail closed.
     /// Unknown custom hosts continue to use default trust when no pins are set.
+    ///
+    /// Host apps that need to override or extend the shipped pin set (e.g.
+    /// pointing a provider at a private gateway with its own CA) can write
+    /// directly to `pinnedHosts` before any network requests are issued; values
+    /// set by the host app are preserved by `loadDefaultPins()`.
     // NSLock guards concurrent reads/writes from multiple URLSession delegate
     // callback threads, which can arrive on arbitrary background threads.
     private static let _pinnedHostsLock = NSLock()

--- a/Sources/BaseChatBackends/PinnedSessionDelegate.swift
+++ b/Sources/BaseChatBackends/PinnedSessionDelegate.swift
@@ -78,7 +78,7 @@ final class PinnedSessionDelegate: NSObject, @preconcurrency URLSessionDelegate 
         guard !_defaultPinsLoaded else { return }
         _defaultPinsLoaded = true
 
-        // Google Trust Services WE1 (intermediate �� shared by both hosts)
+        // Google Trust Services WE1 (intermediate — shared by both hosts)
         let gtsWE1 = "kIdp6NNEd8wsugYyyIYFsi1ylMCED3hZbSR8ZFsa/A4="
         // GTS Root R4 (root CA — backup pin for rotation safety)
         let gtsRootR4 = "mEflZT5enoR1FuXLgYYGqnVEoZvmf9c2bVBpiOjYQ0c="

--- a/Tests/BaseChatBackendsTests/PinnedSessionDelegateTests.swift
+++ b/Tests/BaseChatBackendsTests/PinnedSessionDelegateTests.swift
@@ -137,6 +137,59 @@ final class PinnedSessionDelegateTests: XCTestCase {
         XCTAssertFalse(afterFirstLoad.isEmpty, "First call should have populated pins")
     }
 
+    // MARK: - CI Regression Guard
+    //
+    // These tests exist specifically to catch a future maintainer accidentally
+    // deleting or neutering `PinnedSessionDelegate.loadDefaultPins()`. The
+    // delegate fails-closed when required production hosts have no pins, so a
+    // well-intentioned "remove placeholder pin code" change would silently
+    // break every OpenAI and Anthropic request shipped by the framework.
+    //
+    // If either of these tests fails in CI, DO NOT weaken the assertion. The
+    // correct fix is to restore `loadDefaultPins()` (or replace its pin values
+    // with freshly rotated SPKI hashes — see the rotation procedure in the
+    // source doc comment).
+
+    func test_ciGuard_loadDefaultPins_shipsOpenAIPins() {
+        let savedPins = PinnedSessionDelegate.pinnedHosts
+        PinnedSessionDelegate.pinnedHosts = [:]
+        PinnedSessionDelegate.resetDefaultPinsForTesting()
+        defer {
+            PinnedSessionDelegate.pinnedHosts = savedPins
+            PinnedSessionDelegate.resetDefaultPinsForTesting()
+        }
+
+        PinnedSessionDelegate.loadDefaultPins()
+
+        let openAIPins = PinnedSessionDelegate.pinnedHosts["api.openai.com"]
+        XCTAssertNotNil(openAIPins,
+                        "loadDefaultPins() must populate api.openai.com or the delegate will fail-closed on every OpenAI request.")
+        XCTAssertEqual(openAIPins?.isEmpty, false,
+                       "api.openai.com pin set must be non-empty — empty sets fail-closed on required production hosts.")
+        XCTAssertGreaterThanOrEqual(openAIPins?.count ?? 0, 2,
+                                    "api.openai.com needs at least 2 pins (primary + backup) for rotation safety; losing the backup risks lockout during cert rotation.")
+    }
+
+    func test_ciGuard_loadDefaultPins_shipsAnthropicPins() {
+        let savedPins = PinnedSessionDelegate.pinnedHosts
+        PinnedSessionDelegate.pinnedHosts = [:]
+        PinnedSessionDelegate.resetDefaultPinsForTesting()
+        defer {
+            PinnedSessionDelegate.pinnedHosts = savedPins
+            PinnedSessionDelegate.resetDefaultPinsForTesting()
+        }
+
+        PinnedSessionDelegate.loadDefaultPins()
+
+        let anthropicPins = PinnedSessionDelegate.pinnedHosts["api.anthropic.com"]
+        XCTAssertNotNil(anthropicPins,
+                        "loadDefaultPins() must populate api.anthropic.com or the delegate will fail-closed on every Anthropic request.")
+        XCTAssertEqual(anthropicPins?.isEmpty, false,
+                       "api.anthropic.com pin set must be non-empty — empty sets fail-closed on required production hosts.")
+        XCTAssertGreaterThanOrEqual(anthropicPins?.count ?? 0, 2,
+                                    "api.anthropic.com needs at least 2 pins (primary + backup) for rotation safety; losing the backup risks lockout during cert rotation.")
+    }
+
     // MARK: - Non-ServerTrust Challenge
 
     func test_nonServerTrustChallenge_returnsDefaultHandling() async {


### PR DESCRIPTION
## Summary

- Rewrites the stale `PinnedSessionDelegate.pinnedHosts` doc comment that told maintainers the pins were "intentionally left empty."
- Adds two CI regression-guard tests (`test_ciGuard_loadDefaultPins_shipsOpenAIPins` / `test_ciGuard_loadDefaultPins_shipsAnthropicPins`) so nobody can remove `loadDefaultPins()` as dead code without turning CI red.

## Why

`PinnedSessionDelegate` ships real certificate pins for `api.openai.com` and `api.anthropic.com` (Google Trust Services WE1 intermediate + GTS Root R4 backup), and the delegate fails-closed when a required production host has an empty pin set. But the doc comment on the pin-set storage still said:

> These pins are intentionally left empty and must be populated with actual SPKI hashes before enabling pinning in production.

A future maintainer reading that comment could delete `loadDefaultPins()` as obvious placeholder code and silently break every OpenAI and Anthropic request shipped by the framework. Nothing in CI would have caught it.

This PR fixes both halves: the doc now describes what actually ships and how to override it, and two guard tests assert that `loadDefaultPins()` populates both required hosts with at least two pins each (primary + backup, so routine cert rotation doesn't lock the framework out). The guard tests include comments explaining why they exist and instructing future maintainers not to weaken them.

Sabotage-verified: temporarily removing `api.openai.com` from the `loadDefaultPins()` loop trips all three assertions in the OpenAI guard test (nil, empty, and < 2 pins).

No behavior change, no new dependencies, no scope creep — doc + one test file.

## Release Note

**Clarified certificate-pinning docs and hardened CI against accidental regressions** — The `PinnedSessionDelegate.pinnedHosts` doc comment previously described the default pin set as empty placeholders, contradicting the `loadDefaultPins()` function that actually populates real GTS WE1 intermediate + GTS Root R4 backup pins for `api.openai.com` and `api.anthropic.com`. The doc now accurately describes the shipped pin set, why intermediate pinning is preferred, and how host apps can override `pinnedHosts` for custom gateways. Two new CI regression-guard tests assert both production hosts ship with a minimum of two pins (primary + backup for rotation safety), so future maintainers can't silently remove `loadDefaultPins()` without turning CI red.

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — passes (83 tests)
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — passes (69 tests)
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — passes (431 tests)
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — passes (includes 14 PinnedSessionDelegate tests, 2 new)
- [x] Sabotage verified: skipping `api.openai.com` in `loadDefaultPins()` trips all three assertions in the new OpenAI guard test.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>