### PR TITLE
fix(security): block SSRF via custom endpoint private-range URLs

### DIFF
--- a/Sources/BaseChatCore/BaseChatSchemaV3.swift
+++ b/Sources/BaseChatCore/BaseChatSchemaV3.swift
@@ -265,13 +265,37 @@ public enum BaseChatSchemaV3: VersionedSchema {
         /// exists in the Keychain. Use `APIProvider.requiresAPIKey` and
         /// `KeychainService.retrieve(account: endpoint.keychainAccount)` separately
         /// to check credential readiness.
+        ///
+        /// Security: rejects URLs that would let a malicious endpoint config pivot
+        /// into the user's LAN or cloud metadata services (SSRF). See
+        /// ``APIEndpoint/isDisallowedPrivateHost(_:)`` for the blocked IP ranges.
+        /// Only `http`/`https` schemes are accepted. Non-HTTPS is permitted only for
+        /// the explicit loopback allowlist (`127.0.0.1`, `::1`, `localhost`).
         public var isValid: Bool {
-            guard let url = URL(string: baseURL), url.scheme != nil, url.host != nil else {
+            guard let url = URL(string: baseURL),
+                  let scheme = url.scheme?.lowercased(),
+                  url.host() != nil else {
                 return false
             }
 
-            // HTTPS required for remote endpoints
-            if !isLocalhost(url) && url.scheme != "https" {
+            // Only http/https are valid. Reject file, ftp, data, javascript, etc.
+            guard scheme == "http" || scheme == "https" else {
+                return false
+            }
+
+            // Loopback dev servers (e.g. Ollama, LM Studio) are allowed over plain HTTP.
+            if Self.isLocalhost(url) {
+                return true
+            }
+
+            // Non-loopback must be HTTPS.
+            if scheme != "https" {
+                return false
+            }
+
+            // Block SSRF into LAN / cloud metadata even when HTTPS is used. A
+            // cert-pinned private-range target is still a private-range target.
+            if Self.isDisallowedPrivateHost(url) {
                 return false
             }
 
@@ -279,9 +303,168 @@ public enum BaseChatSchemaV3: VersionedSchema {
         }
 
         /// Checks if the URL points to a local server.
-        private func isLocalhost(_ url: URL) -> Bool {
-            guard let host = url.host() else { return false }
-            return host == "localhost" || host == "127.0.0.1" || host == "::1" || host == "[::1]"
+        ///
+        /// Only the explicit loopback literals are matched — broader `127.x.x.x`
+        /// and IPv4-mapped IPv6 loopback (`::ffff:127.0.0.1`) are intentionally
+        /// excluded because they are easy SSRF bypass vectors.
+        static func isLocalhost(_ url: URL) -> Bool {
+            guard let host = url.host()?.lowercased() else { return false }
+            return host == "localhost" || host == "127.0.0.1" || host == "::1"
+        }
+
+        /// Classifies a URL's host as pointing at a private, link-local, or
+        /// otherwise reserved IP range.
+        ///
+        /// Only IP literals are inspected. DNS names are not resolved — validation
+        /// is called synchronously from SwiftUI settings forms and must stay fast.
+        /// DNS rebinding is therefore out of scope for this layer and should be
+        /// mitigated at the request layer (e.g. by pinning resolution or by
+        /// rejecting private IPs returned by `URLSession` host resolution) if a
+        /// deployment needs that guarantee.
+        ///
+        /// Blocked IPv4 ranges:
+        /// - `0.0.0.0/8` (non-routable "this host")
+        /// - `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` (RFC1918)
+        /// - `127.0.0.0/8` except `127.0.0.1` (alternate loopback encodings)
+        /// - `169.254.0.0/16` (link-local incl. AWS/GCP/Azure metadata at `169.254.169.254`)
+        /// - `224.0.0.0/4` (multicast) and `240.0.0.0/4` (reserved/future use)
+        ///
+        /// Blocked IPv6 ranges:
+        /// - `fc00::/7` (unique local addresses)
+        /// - `fe80::/10` (link-local)
+        /// - `::ffff:0:0/96` (IPv4-mapped; would otherwise bypass the IPv4 filter)
+        static func isDisallowedPrivateHost(_ url: URL) -> Bool {
+            guard let host = url.host()?.lowercased() else { return false }
+
+            if let octets = parseIPv4Literal(host) {
+                return isDisallowedIPv4(octets)
+            }
+
+            if let words = parseIPv6Literal(host) {
+                return isDisallowedIPv6(words)
+            }
+
+            // DNS names reach here. Do not resolve synchronously — return false
+            // and rely on the HTTPS-required rule plus any higher-layer mitigation.
+            return false
+        }
+
+        // MARK: IPv4
+
+        /// Parses a dotted-quad IPv4 literal into four octets.
+        ///
+        /// Returns `nil` for anything that isn't exactly four 0-255 components
+        /// (including shorthand forms like `127.1`, which `inet_aton` would accept
+        /// but modern URL parsers reject).
+        private static func parseIPv4Literal(_ host: String) -> [UInt8]? {
+            let parts = host.split(separator: ".", omittingEmptySubsequences: false)
+            guard parts.count == 4 else { return nil }
+            var octets: [UInt8] = []
+            octets.reserveCapacity(4)
+            for part in parts {
+                guard !part.isEmpty, part.allSatisfy(\.isASCII),
+                      let value = UInt16(part), value <= 255 else {
+                    return nil
+                }
+                octets.append(UInt8(value))
+            }
+            return octets
+        }
+
+        private static func isDisallowedIPv4(_ octets: [UInt8]) -> Bool {
+            let a = octets[0]
+            let b = octets[1]
+
+            // 0.0.0.0/8 — "this host" / any-address
+            if a == 0 { return true }
+            // 10.0.0.0/8 — RFC1918
+            if a == 10 { return true }
+            // 127.0.0.0/8 — loopback; the exact 127.0.0.1 is approved by
+            // isLocalhost before this helper is called, so any 127.x.x.x
+            // reaching here is an alternate loopback encoding.
+            if a == 127 { return true }
+            // 169.254.0.0/16 — link-local (AWS/GCP/Azure IMDS sits here)
+            if a == 169 && b == 254 { return true }
+            // 172.16.0.0/12 — RFC1918
+            if a == 172 && (16...31).contains(b) { return true }
+            // 192.168.0.0/16 — RFC1918
+            if a == 192 && b == 168 { return true }
+            // 224.0.0.0/4 — multicast
+            if (224...239).contains(a) { return true }
+            // 240.0.0.0/4 — reserved / future use (includes 255.255.255.255 broadcast)
+            if a >= 240 { return true }
+
+            return false
+        }
+
+        // MARK: IPv6
+
+        /// Parses an IPv6 literal (as returned by `URL.host()` — without the
+        /// surrounding brackets) into eight 16-bit words.
+        ///
+        /// Supports `::` zero-run compression and embedded IPv4 suffixes
+        /// (e.g. `::ffff:127.0.0.1`). Zone identifiers (`fe80::1%en0`) are
+        /// stripped before parsing.
+        private static func parseIPv6Literal(_ host: String) -> [UInt16]? {
+            // Strip IPv6 zone identifier if present.
+            let bare = host.split(separator: "%", maxSplits: 1).first.map(String.init) ?? host
+            guard bare.contains(":") else { return nil }
+
+            // Split on "::" which represents a run of zero words.
+            let doubleColonParts = bare.components(separatedBy: "::")
+            guard doubleColonParts.count <= 2 else { return nil }
+
+            func expand(_ segment: String) -> [UInt16]? {
+                if segment.isEmpty { return [] }
+                let groups = segment.split(separator: ":", omittingEmptySubsequences: false)
+                var words: [UInt16] = []
+                for (i, group) in groups.enumerated() {
+                    if group.contains(".") {
+                        // Embedded IPv4 — only legal as the last group.
+                        guard i == groups.count - 1,
+                              let v4 = parseIPv4Literal(String(group)) else { return nil }
+                        let high = (UInt16(v4[0]) << 8) | UInt16(v4[1])
+                        let low = (UInt16(v4[2]) << 8) | UInt16(v4[3])
+                        words.append(high)
+                        words.append(low)
+                    } else {
+                        guard !group.isEmpty, group.count <= 4,
+                              let value = UInt16(group, radix: 16) else { return nil }
+                        words.append(value)
+                    }
+                }
+                return words
+            }
+
+            let head = expand(doubleColonParts[0])
+            let tail = doubleColonParts.count == 2 ? expand(doubleColonParts[1]) : []
+            guard let headWords = head, let tailWords = tail else { return nil }
+
+            let total = headWords.count + tailWords.count
+            if doubleColonParts.count == 2 {
+                guard total <= 8 else { return nil }
+                let zeros = Array(repeating: UInt16(0), count: 8 - total)
+                return headWords + zeros + tailWords
+            } else {
+                guard total == 8 else { return nil }
+                return headWords
+            }
+        }
+
+        private static func isDisallowedIPv6(_ words: [UInt16]) -> Bool {
+            guard words.count == 8 else { return false }
+
+            // fc00::/7 — unique local addresses (first 7 bits are 1111110).
+            if (words[0] & 0xfe00) == 0xfc00 { return true }
+            // fe80::/10 — link-local (first 10 bits are 1111111010).
+            if (words[0] & 0xffc0) == 0xfe80 { return true }
+            // ::ffff:0:0/96 — IPv4-mapped IPv6. Reject so mapped loopback /
+            // mapped RFC1918 can't bypass the IPv4 filter.
+            let isIPv4Mapped = words[0] == 0 && words[1] == 0 && words[2] == 0
+                && words[3] == 0 && words[4] == 0 && words[5] == 0xffff
+            if isIPv4Mapped { return true }
+
+            return false
         }
     }
 

--- a/Sources/BaseChatCore/BaseChatSchemaV3.swift
+++ b/Sources/BaseChatCore/BaseChatSchemaV3.swift
@@ -334,7 +334,14 @@ public enum BaseChatSchemaV3: VersionedSchema {
         /// - `fe80::/10` (link-local)
         /// - `::ffff:0:0/96` (IPv4-mapped; would otherwise bypass the IPv4 filter)
         static func isDisallowedPrivateHost(_ url: URL) -> Bool {
-            guard let host = url.host()?.lowercased() else { return false }
+            guard let rawHost = url.host()?.lowercased() else { return false }
+
+            // FQDN form with a trailing dot (e.g. `192.168.1.1.`) resolves
+            // identically to the dotless form on every mainstream resolver, so
+            // treat it as equivalent for IP-literal classification. Without
+            // this, `https://192.168.1.1.` would bypass the private-range
+            // gate and reach a LAN host under HTTPS.
+            let host = rawHost.hasSuffix(".") ? String(rawHost.dropLast()) : rawHost
 
             if let octets = parseIPv4Literal(host) {
                 return isDisallowedIPv4(octets)

--- a/Tests/BaseChatCoreTests/CustomEndpointValidationTests.swift
+++ b/Tests/BaseChatCoreTests/CustomEndpointValidationTests.swift
@@ -142,6 +142,32 @@ final class CustomEndpointValidationTests: XCTestCase {
         assertRejected("http://[::ffff:192.168.1.1]:80", reason: "IPv4-mapped RFC1918")
     }
 
+    // MARK: - Rejected: uppercase IPv6 hex
+
+    func test_rejects_ipv6LinkLocal_uppercaseHex() {
+        // URL.host() preserves original case for IPv6 literals. The classifier
+        // must lowercase before matching or FE80::1 would bypass the fe80::/10
+        // rule.
+        assertRejected("https://[FE80::1]", reason: "uppercase IPv6 link-local")
+    }
+
+    func test_rejects_ipv4MappedLoopback_uppercaseHex() {
+        assertRejected("https://[::FFFF:127.0.0.1]", reason: "uppercase IPv4-mapped loopback")
+    }
+
+    // MARK: - Rejected: trailing-dot FQDN bypass
+
+    func test_rejects_rfc1918_trailingDot() {
+        // `192.168.1.1.` resolves identically to `192.168.1.1` on every
+        // mainstream resolver. Without trailing-dot normalisation it would
+        // parse as a DNS name and slip through under HTTPS.
+        assertRejected("https://192.168.1.1.", reason: "RFC1918 with trailing dot")
+    }
+
+    func test_rejects_imds_trailingDot() {
+        assertRejected("https://169.254.169.254.", reason: "IMDS with trailing dot")
+    }
+
     // MARK: - Rejected: non-http schemes
 
     func test_rejects_fileScheme() {

--- a/Tests/BaseChatCoreTests/CustomEndpointValidationTests.swift
+++ b/Tests/BaseChatCoreTests/CustomEndpointValidationTests.swift
@@ -1,0 +1,220 @@
+import XCTest
+@testable import BaseChatCore
+import BaseChatInference
+
+/// Security-focused coverage for `APIEndpoint.isValid`.
+///
+/// Guards against SSRF via user-configured custom endpoints that could pivot
+/// into the LAN, link-local metadata services (e.g. AWS IMDS at
+/// 169.254.169.254), or non-HTTP schemes (`file://`, `ftp://`, `data:`).
+final class CustomEndpointValidationTests: XCTestCase {
+
+    private var endpointIDs: [String] = []
+
+    override func tearDown() {
+        super.tearDown()
+        for id in endpointIDs {
+            KeychainService.delete(account: id)
+        }
+        endpointIDs.removeAll()
+    }
+
+    private func makeEndpoint(baseURL: String) -> APIEndpoint {
+        let endpoint = APIEndpoint(name: "Test", provider: .custom, baseURL: baseURL)
+        endpointIDs.append(endpoint.id.uuidString)
+        return endpoint
+    }
+
+    private func assertAccepted(
+        _ url: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let endpoint = makeEndpoint(baseURL: url)
+        XCTAssertTrue(
+            endpoint.isValid,
+            "Expected \(url) to be accepted but isValid returned false",
+            file: file,
+            line: line
+        )
+    }
+
+    private func assertRejected(
+        _ url: String,
+        reason: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let endpoint = makeEndpoint(baseURL: url)
+        XCTAssertFalse(
+            endpoint.isValid,
+            "Expected \(url) to be rejected (\(reason)) but isValid returned true",
+            file: file,
+            line: line
+        )
+    }
+
+    // MARK: - Accepted URLs
+
+    func test_accepts_publicHTTPS() {
+        assertAccepted("https://api.openai.com")
+    }
+
+    func test_accepts_localhostOllama() {
+        assertAccepted("http://localhost:11434")
+    }
+
+    func test_accepts_loopbackIPv4() {
+        assertAccepted("http://127.0.0.1:8080")
+    }
+
+    func test_accepts_loopbackIPv6() {
+        assertAccepted("http://[::1]:8080")
+    }
+
+    func test_accepts_httpsLoopback() {
+        // Loopback over HTTPS (self-signed dev setups) is legitimate.
+        assertAccepted("https://localhost:11434")
+    }
+
+    // MARK: - Rejected: private IPv4 (RFC1918)
+
+    func test_rejects_rfc1918_192_168() {
+        assertRejected("http://192.168.1.1", reason: "RFC1918 192.168/16")
+    }
+
+    func test_rejects_rfc1918_10_x() {
+        assertRejected("http://10.0.0.1", reason: "RFC1918 10/8")
+    }
+
+    func test_rejects_rfc1918_172_20() {
+        assertRejected("http://172.20.0.1", reason: "RFC1918 172.16/12")
+    }
+
+    func test_rejects_rfc1918_over_https() {
+        // HTTPS does not redeem a private-range target — the device is still
+        // being turned into a LAN proxy.
+        assertRejected("https://192.168.1.1", reason: "RFC1918 even over HTTPS")
+    }
+
+    func test_rejects_imds_over_https() {
+        assertRejected("https://169.254.169.254", reason: "IMDS even over HTTPS")
+    }
+
+    func test_rejects_ipv6ULA_over_https() {
+        assertRejected("https://[fc00::1]", reason: "IPv6 ULA even over HTTPS")
+    }
+
+    func test_rejects_ipv4MappedLoopback_over_https() {
+        assertRejected("https://[::ffff:127.0.0.1]", reason: "IPv4-mapped loopback over HTTPS")
+    }
+
+    // MARK: - Rejected: link-local (IMDS)
+
+    func test_rejects_imds() {
+        assertRejected("http://169.254.169.254", reason: "AWS/GCP/Azure IMDS")
+    }
+
+    func test_rejects_linkLocalRange() {
+        assertRejected("http://169.254.1.1", reason: "link-local 169.254/16")
+    }
+
+    // MARK: - Rejected: IPv6 private / link-local
+
+    func test_rejects_ipv6ULA() {
+        assertRejected("http://[fc00::1]:80", reason: "IPv6 ULA fc00::/7")
+    }
+
+    func test_rejects_ipv6FD() {
+        assertRejected("http://[fd12:3456:789a::1]:80", reason: "IPv6 ULA fd00::/8")
+    }
+
+    func test_rejects_ipv6LinkLocal() {
+        assertRejected("http://[fe80::1]:80", reason: "IPv6 link-local fe80::/10")
+    }
+
+    func test_rejects_ipv4MappedLoopback() {
+        // Would otherwise bypass the IPv4 loopback-allowlist check.
+        assertRejected("http://[::ffff:127.0.0.1]:80", reason: "IPv4-mapped loopback")
+    }
+
+    func test_rejects_ipv4MappedRFC1918() {
+        assertRejected("http://[::ffff:192.168.1.1]:80", reason: "IPv4-mapped RFC1918")
+    }
+
+    // MARK: - Rejected: non-http schemes
+
+    func test_rejects_fileScheme() {
+        assertRejected("file:///etc/passwd", reason: "file://")
+    }
+
+    func test_rejects_ftpScheme() {
+        assertRejected("ftp://example.com", reason: "ftp://")
+    }
+
+    func test_rejects_dataScheme() {
+        assertRejected("data:text/html;base64,PHNjcmlwdD4=", reason: "data:")
+    }
+
+    func test_rejects_javascriptScheme() {
+        assertRejected("javascript:alert(1)", reason: "javascript:")
+    }
+
+    // MARK: - Rejected: reserved / multicast / broadcast
+
+    func test_rejects_zeroAddress() {
+        assertRejected("http://0.0.0.0", reason: "0.0.0.0/8 this-host")
+    }
+
+    func test_rejects_multicast() {
+        assertRejected("http://224.0.0.1", reason: "224.0.0.0/4 multicast")
+    }
+
+    func test_rejects_reservedRange() {
+        assertRejected("http://240.0.0.1", reason: "240.0.0.0/4 reserved")
+    }
+
+    func test_rejects_broadcast() {
+        assertRejected("http://255.255.255.255", reason: "limited broadcast")
+    }
+
+    // MARK: - Rejected: alternate loopback encodings
+
+    func test_rejects_loopbackRangeNon127001() {
+        // 127.0.0.1 is explicitly allowed by isLocalhost, but the rest of
+        // 127/8 is a common SSRF bypass surface and is blocked.
+        assertRejected("http://127.0.0.2", reason: "alternate loopback")
+    }
+
+    func test_rejects_loopback127_1_1_1() {
+        assertRejected("http://127.1.1.1", reason: "alternate loopback")
+    }
+
+    // MARK: - Rejected: non-HTTPS public host
+
+    func test_rejects_httpPublicHost() {
+        // Plain HTTP to a remote DNS name is rejected — only loopback is
+        // exempt from the HTTPS requirement.
+        assertRejected("http://api.openai.com", reason: "non-HTTPS public host")
+    }
+
+    // MARK: - Rejected: structurally invalid
+
+    func test_rejects_empty() {
+        assertRejected("", reason: "empty URL")
+    }
+
+    func test_rejects_missingScheme() {
+        assertRejected("api.openai.com", reason: "no scheme")
+    }
+
+    // MARK: - DNS names (out of scope)
+
+    func test_acceptsPublicDNSName() {
+        // DNS rebinding mitigation is explicitly out of scope for this layer.
+        // The validator cannot resolve synchronously, so a DNS name that could
+        // *resolve* to a private range still passes the structural check as
+        // long as it uses HTTPS.
+        assertAccepted("https://api.example.com")
+    }
+}


### PR DESCRIPTION
## Summary

`APIEndpoint.isValid` previously accepted any URL that parsed and had a non-nil host, and only required HTTPS for non-loopback hosts. This PR tightens it so that private, link-local, reserved, and alternate-loopback IP ranges are rejected even over HTTPS, and non-`http`/`https` schemes are rejected outright.

## Why

`APIEndpoint` is user-configurable from the settings UI. A user tricked into importing a malicious endpoint config — or a compromised sync path that seeds one — turns the device into a proxy into whatever the endpoint's host resolves to. Concretely:

- **LAN pivot** via RFC1918 (10/8, 172.16/12, 192.168/16) — router admin panels, printers, home-assistant dashboards, internal APIs.
- **Cloud metadata exfil** via 169.254.169.254 (AWS/GCP/Azure IMDS). On an EC2-hosted macOS runner or a corp device on a cloud VPN, that endpoint hands out short-lived credentials with whatever role is attached to the instance.
- **Alternate loopback encodings** (`127.0.0.2`, `[::ffff:127.0.0.1]`) bypass the old `isLocalhost` allowlist while still reaching a local service the user didn't intend to expose.
- **Non-HTTP schemes** (`file://`, `ftp://`, `data:`, `javascript:`) were never explicitly forbidden — the old check only gated HTTPS-vs-localhost.

## What's blocked

IPv4:
- `0.0.0.0/8` — "this host" / any-address
- `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` — RFC1918
- `127.0.0.0/8` except the exact `127.0.0.1` — alternate loopback encodings
- `169.254.0.0/16` — link-local (AWS/GCP/Azure IMDS)
- `224.0.0.0/4` — multicast
- `240.0.0.0/4` — reserved / future use (includes `255.255.255.255` broadcast)

IPv6:
- `fc00::/7` — unique local addresses
- `fe80::/10` — link-local
- `::ffff:0:0/96` — IPv4-mapped (would otherwise bypass the IPv4 filter via `[::ffff:192.168.1.1]`)

Schemes:
- Anything other than `http`/`https` (includes `file`, `ftp`, `data`, `javascript`, `gopher`, etc.)

## What's NOT blocked

- **Loopback allowlist preserved**: `127.0.0.1`, `::1`, and `localhost` continue to work over plain HTTP so local Ollama / LM Studio dev servers are unaffected.
- **DNS rebinding is explicitly out of scope for this layer.** `APIEndpoint.isValid` is called synchronously from SwiftUI settings forms and must stay fast, so DNS names are not resolved at validation time. A DNS name that later resolves to a private range is still a risk and should be mitigated at the request layer (pinned resolution, or rejecting private IPs returned by URLSession host resolution) if a deployment needs that guarantee. This is documented in the helper's doc comment.

## Implementation notes

- New `static func isDisallowedPrivateHost(_ url: URL) -> Bool` on `APIEndpoint`. It parses IPv4 dotted-quad and IPv6 literal hosts (including `::` zero-run compression, embedded IPv4 suffixes, and zone identifiers) and classifies them against the block list.
- `isLocalhost` tightened to the three explicit literals only; broader `127.x.x.x` and `[::ffff:127.0.0.1]` now fall through to the disallowed-range gate.
- `isValid` signature unchanged (`public var isValid: Bool`) — no UI impact.
- No new dependencies.

## Release Note

**Custom API endpoints can no longer target private networks.** `APIEndpoint.isValid` now rejects URLs whose host is in an RFC1918 range, the 169.254.0.0/16 link-local range (which includes cloud-metadata services like AWS IMDS at 169.254.169.254), IPv6 ULA/link-local ranges, or alternate loopback encodings like `127.0.0.2` and `[::ffff:127.0.0.1]`. It also rejects any scheme other than `http` and `https`, closing the door on `file://`, `data:`, and `javascript:` URLs. The loopback bypass (`127.0.0.1`, `::1`, `localhost`) is preserved so local Ollama and LM Studio setups keep working. DNS rebinding is out of scope for the validator and should be mitigated at the request layer if a deployment needs that guarantee.

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 116 pass, 0 fail
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 69 pass, 0 fail
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 431 pass, 0 fail
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 63 pass, 0 fail
- [x] 33 new tests in `Tests/BaseChatCoreTests/CustomEndpointValidationTests.swift` cover every accepted URL class and every rejection class called out in the threat model.
- [x] Sabotage check: commented out `if Self.isDisallowedPrivateHost(url) { return false }` and confirmed the four HTTPS-private-range tests (`test_rejects_rfc1918_over_https`, `test_rejects_imds_over_https`, `test_rejects_ipv6ULA_over_https`, `test_rejects_ipv4MappedLoopback_over_https`) fail. Restored before commit.
- [x] Existing `APIEndpointTests` unchanged and still passing — no behavior drift for already-covered cases.