### PR TITLE
feat(security): bound SSE stream memory and rate to defeat hostile-server DoS

### DIFF
--- a/Sources/BaseChatBackends/OllamaBackend.swift
+++ b/Sources/BaseChatBackends/OllamaBackend.swift
@@ -129,24 +129,55 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
     // timeout/2 partially addresses this by showing .stalled.
 
     /// Parses Ollama's NDJSON response format instead of SSE.
+    ///
+    /// Applies the same ``SSEStreamLimits`` caps as the SSE parser so a
+    /// hostile Ollama-compatible server cannot exhaust memory with oversized
+    /// lines, total volume, or an event flood.
     public override func parseResponseStream(
         bytes: URLSession.AsyncBytes,
         continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
     ) async throws {
+        let limits = effectiveSSEStreamLimits
         var lineBuffer = Data()
+        var totalBytes = 0
+        var rateWindowStart = ContinuousClock.now
+        var rateWindowCount = 0
+
+        func noteEventYielded() throws {
+            let now = ContinuousClock.now
+            if now - rateWindowStart >= .seconds(1) {
+                rateWindowStart = now
+                rateWindowCount = 1
+                return
+            }
+            rateWindowCount += 1
+            if rateWindowCount > limits.maxEventsPerSecond {
+                throw SSEStreamError.eventRateExceeded(rateWindowCount)
+            }
+        }
+
         for try await byte in bytes {
             if Task.isCancelled { break }
+
+            totalBytes += 1
+            if totalBytes > limits.maxTotalBytes {
+                throw SSEStreamError.streamTooLarge(totalBytes)
+            }
 
             if byte == UInt8(ascii: "\n") {
                 if !lineBuffer.isEmpty {
                     if let line = String(data: lineBuffer, encoding: .utf8),
                        let token = Self.extractToken(from: line) {
+                        try noteEventYielded()
                         continuation.yield(.token(token))
                     }
                     lineBuffer.removeAll(keepingCapacity: true)
                 }
             } else {
                 lineBuffer.append(byte)
+                if lineBuffer.count > limits.maxEventBytes {
+                    throw SSEStreamError.eventTooLarge(lineBuffer.count)
+                }
             }
         }
 
@@ -154,6 +185,7 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
         if !lineBuffer.isEmpty,
            let line = String(data: lineBuffer, encoding: .utf8),
            let token = Self.extractToken(from: line) {
+            try noteEventYielded()
             continuation.yield(.token(token))
         }
     }

--- a/Sources/BaseChatBackends/SSECloudBackend.swift
+++ b/Sources/BaseChatBackends/SSECloudBackend.swift
@@ -110,6 +110,22 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
     /// `nil` disables idle detection (default).
     public var streamIdleTimeout: Duration?
 
+    /// Per-backend override for the SSE / NDJSON stream caps that defend
+    /// against hostile upstream servers. When `nil` (default), the value
+    /// from `BaseChatConfiguration.shared.sseStreamLimits` is used at
+    /// parse time.
+    ///
+    /// Set this to tune limits for a specific backend — for example, to
+    /// tighten bounds on an untrusted `CustomEndpoint` while leaving OpenAI
+    /// and Anthropic at the global defaults.
+    public var sseStreamLimits: SSEStreamLimits?
+
+    /// Resolved stream limits, preferring the per-backend override and
+    /// falling back to the global configuration.
+    public var effectiveSSEStreamLimits: SSEStreamLimits {
+        sseStreamLimits ?? BaseChatConfiguration.shared.sseStreamLimits
+    }
+
     // MARK: - Init
 
     /// Creates an SSE cloud backend.
@@ -378,7 +394,7 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
         bytes: URLSession.AsyncBytes,
         continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
     ) async throws {
-        let tokenStream = SSEStreamParser.parse(bytes: bytes)
+        let tokenStream = SSEStreamParser.parse(bytes: bytes, limits: effectiveSSEStreamLimits)
         for try await payload in tokenStream {
             if Task.isCancelled { break }
 

--- a/Sources/BaseChatInference/BaseChatConfiguration.swift
+++ b/Sources/BaseChatInference/BaseChatConfiguration.swift
@@ -57,18 +57,29 @@ public struct BaseChatConfiguration: Sendable {
     /// is handled by FileVault. It is also ignored for in-memory SwiftData stores.
     public var fileProtectionClass: FileProtectionType?
 
+    /// Caps applied to SSE / NDJSON streaming from cloud backends. These
+    /// defend against hostile or misconfigured upstream servers that try to
+    /// exhaust client memory or starve the consumer. See ``SSEStreamLimits``.
+    ///
+    /// Defaults to ``SSEStreamLimits/default`` — well above any realistic
+    /// provider throughput. Host apps that point `CustomEndpoint.baseURL` at
+    /// untrusted servers can tighten these further.
+    public var sseStreamLimits: SSEStreamLimits
+
     public init(
         appName: String = "BaseChatKit",
         bundleIdentifier: String = "com.basechatkit",
         modelsDirectoryName: String = "Models",
         features: Features = Features(),
-        fileProtectionClass: FileProtectionType? = .completeUntilFirstUserAuthentication
+        fileProtectionClass: FileProtectionType? = .completeUntilFirstUserAuthentication,
+        sseStreamLimits: SSEStreamLimits = .default
     ) {
         self.appName = appName
         self.bundleIdentifier = bundleIdentifier
         self.modelsDirectoryName = modelsDirectoryName
         self.features = features
         self.fileProtectionClass = fileProtectionClass
+        self.sseStreamLimits = sseStreamLimits
     }
 
     // MARK: - Derived identifiers

--- a/Sources/BaseChatInference/Services/SSEStreamParser.swift
+++ b/Sources/BaseChatInference/Services/SSEStreamParser.swift
@@ -1,5 +1,88 @@
 import Foundation
 
+/// Configurable caps applied to SSE (and NDJSON) parsing to defend against
+/// hostile or misconfigured upstream servers.
+///
+/// The parser enforces three separate bounds:
+///
+/// - ``maxEventBytes`` caps the size of a single event payload buffer. A
+///   malicious server cannot make the client swallow a 100 MB `data:` line.
+/// - ``maxTotalBytes`` caps cumulative bytes across the whole stream. This
+///   stops a server that drips just-small-enough events forever.
+/// - ``maxEventsPerSecond`` caps the yield rate. A flood of 1-byte events is
+///   rejected before it can starve the consumer.
+///
+/// Defaults (``default``) are intentionally well above any realistic provider
+/// throughput — OpenAI, Anthropic, and Ollama all emit events far smaller
+/// than 1 MB and well under 5,000 events per second — so legitimate traffic is
+/// never throttled. Host apps can tune the limits globally via
+/// `BaseChatConfiguration.shared.sseStreamLimits` or per-backend by setting
+/// `SSECloudBackend.sseStreamLimits`.
+///
+/// There is deliberately no "unlimited" option: bounded caps are the point.
+public struct SSEStreamLimits: Sendable, Equatable {
+
+    /// Maximum byte size of a single event payload buffer, including bytes
+    /// that have not yet reached a newline.
+    public var maxEventBytes: Int
+
+    /// Maximum cumulative byte count across the entire stream, counting all
+    /// bytes the parser consumes (including control and ignored lines).
+    public var maxTotalBytes: Int
+
+    /// Maximum events the parser may yield within any one-second window.
+    public var maxEventsPerSecond: Int
+
+    public init(
+        maxEventBytes: Int,
+        maxTotalBytes: Int,
+        maxEventsPerSecond: Int
+    ) {
+        self.maxEventBytes = maxEventBytes
+        self.maxTotalBytes = maxTotalBytes
+        self.maxEventsPerSecond = maxEventsPerSecond
+    }
+
+    /// Conservative defaults suitable for every mainstream provider.
+    ///
+    /// - 1 MB per event: large enough for chunked usage payloads and tool
+    ///   call metadata, small enough to reject a pathological upstream.
+    /// - 50 MB per stream: covers hours of conversation tokens without
+    ///   allowing unbounded streams.
+    /// - 5,000 events/s: roughly 100x real provider throughput; a healthy
+    ///   LLM tops out at a few hundred tokens/s.
+    public static let `default` = SSEStreamLimits(
+        maxEventBytes: 1_000_000,
+        maxTotalBytes: 50_000_000,
+        maxEventsPerSecond: 5_000
+    )
+}
+
+/// Errors thrown by ``SSEStreamParser`` when a stream violates its limits.
+///
+/// These surface through the existing `AsyncThrowingStream` failure channel
+/// exactly like any other parsing error, so backend retry/error UI continues
+/// to work unchanged.
+public enum SSEStreamError: Error, Equatable {
+    /// A single event exceeded ``SSEStreamLimits/maxEventBytes``. The
+    /// associated value is the observed size in bytes.
+    case eventTooLarge(Int)
+
+    /// Cumulative bytes across the stream exceeded
+    /// ``SSEStreamLimits/maxTotalBytes``. The associated value is the total
+    /// bytes consumed before the limit tripped.
+    case streamTooLarge(Int)
+
+    /// More events than ``SSEStreamLimits/maxEventsPerSecond`` were produced
+    /// within a single one-second window. The associated value is the event
+    /// count observed in that window.
+    case eventRateExceeded(Int)
+
+    /// The stream bytes were structurally unparseable (reserved for future
+    /// strict-mode use). Not currently thrown by the tolerant parser.
+    case malformed
+}
+
 /// Parses Server-Sent Events (SSE) from a byte stream.
 ///
 /// SSE format:
@@ -35,17 +118,56 @@ package struct SSEStreamParser {
     ///
     /// Yields the payload of each `data:` line (with the prefix stripped).
     /// Stops when the stream ends or when `[DONE]` is received.
+    ///
+    /// The stream is bounded by the supplied ``SSEStreamLimits``; a violation
+    /// is surfaced by finishing the stream with the appropriate
+    /// ``SSEStreamError``.
+    ///
+    /// - Parameters:
+    ///   - bytes: The raw byte stream.
+    ///   - limits: Caps that defend against hostile upstreams. Defaults to
+    ///     `BaseChatConfiguration.shared.sseStreamLimits`.
     package static func parse<S: AsyncSequence & Sendable>(
-        bytes: S
+        bytes: S,
+        limits: SSEStreamLimits = BaseChatConfiguration.shared.sseStreamLimits
     ) -> AsyncThrowingStream<String, Error> where S.Element == UInt8 {
         AsyncThrowingStream { continuation in
             let task = Task {
                 var byteBuffer = Data()
                 var iterator = bytes.makeAsyncIterator()
 
+                // Cumulative bytes consumed across the whole stream.
+                var totalBytes = 0
+
+                // Sliding one-second event-rate window. We keep things cheap
+                // by bucketing to integer seconds of the monotonic clock and
+                // resetting the count when the bucket changes.
+                var rateWindowStart = ContinuousClock.now
+                var rateWindowCount = 0
+                let maxRate = limits.maxEventsPerSecond
+
+                func noteEventYielded() -> SSEStreamError? {
+                    let now = ContinuousClock.now
+                    if now - rateWindowStart >= .seconds(1) {
+                        rateWindowStart = now
+                        rateWindowCount = 1
+                        return nil
+                    }
+                    rateWindowCount += 1
+                    if rateWindowCount > maxRate {
+                        return .eventRateExceeded(rateWindowCount)
+                    }
+                    return nil
+                }
+
                 do {
                     while let byte = try await iterator.next() {
                         if Task.isCancelled { break }
+
+                        totalBytes += 1
+                        if totalBytes > limits.maxTotalBytes {
+                            throw SSEStreamError.streamTooLarge(totalBytes)
+                        }
 
                         if byte == UInt8(ascii: "\n") {
                             // Decode accumulated bytes as UTF-8.
@@ -71,12 +193,18 @@ package struct SSEStreamParser {
                                 }
 
                                 if !payload.isEmpty {
+                                    if let rateError = noteEventYielded() {
+                                        throw rateError
+                                    }
                                     continuation.yield(payload)
                                 }
                             }
                             // Ignore event:, id:, retry:, and comment lines
                         } else {
                             byteBuffer.append(byte)
+                            if byteBuffer.count > limits.maxEventBytes {
+                                throw SSEStreamError.eventTooLarge(byteBuffer.count)
+                            }
                         }
                     }
                 } catch {
@@ -106,15 +234,18 @@ package struct SSEStreamParser {
     /// - Parameters:
     ///   - bytes: The raw byte stream from `URLSession.bytes(for:)`.
     ///   - handler: A payload handler that interprets the provider's JSON format.
+    ///   - limits: Caps that defend against hostile upstreams. Defaults to
+    ///     `BaseChatConfiguration.shared.sseStreamLimits`.
     /// - Returns: An `AsyncThrowingStream` of ``GenerationEvent`` values.
     package static func streamEvents<S: AsyncSequence & Sendable>(
         from bytes: S,
-        using handler: some SSEPayloadHandler
+        using handler: some SSEPayloadHandler,
+        limits: SSEStreamLimits = BaseChatConfiguration.shared.sseStreamLimits
     ) -> AsyncThrowingStream<GenerationEvent, Error> where S.Element == UInt8 {
         AsyncThrowingStream { continuation in
             let task = Task {
                 do {
-                    let sseStream = parse(bytes: bytes)
+                    let sseStream = parse(bytes: bytes, limits: limits)
                     for try await payload in sseStream {
                         if Task.isCancelled { break }
 

--- a/Sources/BaseChatInference/Services/SSEStreamParser.swift
+++ b/Sources/BaseChatInference/Services/SSEStreamParser.swift
@@ -15,9 +15,33 @@ import Foundation
 /// Defaults (``default``) are intentionally well above any realistic provider
 /// throughput — OpenAI, Anthropic, and Ollama all emit events far smaller
 /// than 1 MB and well under 5,000 events per second — so legitimate traffic is
-/// never throttled. Host apps can tune the limits globally via
-/// `BaseChatConfiguration.shared.sseStreamLimits` or per-backend by setting
-/// `SSECloudBackend.sseStreamLimits`.
+/// never throttled.
+///
+/// ## Tuning
+///
+/// Most apps never need to change these. Raise a cap only if you observe
+/// legitimate traffic failing — for example, a provider that ships a
+/// multi-megabyte tool-use result in a single event. Lower a cap when you
+/// point a backend at an untrusted endpoint and want to narrow the attack
+/// surface further.
+///
+/// ```swift
+/// // App-wide: applies to every SSECloudBackend at launch.
+/// BaseChatConfiguration.shared.sseStreamLimits = SSEStreamLimits(
+///     maxEventBytes: 500_000,
+///     maxTotalBytes: 10_000_000,
+///     maxEventsPerSecond: 2_000
+/// )
+///
+/// // Per backend: leaves OpenAI/Anthropic at defaults while tightening an
+/// // untrusted CustomEndpoint.
+/// let backend = OpenAIBackend(endpoint: untrusted)
+/// backend.sseStreamLimits = SSEStreamLimits(
+///     maxEventBytes: 64_000,
+///     maxTotalBytes: 1_000_000,
+///     maxEventsPerSecond: 500
+/// )
+/// ```
 ///
 /// There is deliberately no "unlimited" option: bounded caps are the point.
 public struct SSEStreamLimits: Sendable, Equatable {
@@ -30,7 +54,12 @@ public struct SSEStreamLimits: Sendable, Equatable {
     /// bytes the parser consumes (including control and ignored lines).
     public var maxTotalBytes: Int
 
-    /// Maximum events the parser may yield within any one-second window.
+    /// Maximum events the parser may yield within a one-second rate window.
+    ///
+    /// The window is fixed (not sliding): it opens on the first event and
+    /// resets once at least one wall-clock second has elapsed. A burst that
+    /// exceeds this count within the active window finishes the stream with
+    /// ``SSEStreamError/eventRateExceeded(_:)``.
     public var maxEventsPerSecond: Int
 
     public init(
@@ -77,10 +106,6 @@ public enum SSEStreamError: Error, Equatable {
     /// within a single one-second window. The associated value is the event
     /// count observed in that window.
     case eventRateExceeded(Int)
-
-    /// The stream bytes were structurally unparseable (reserved for future
-    /// strict-mode use). Not currently thrown by the tolerant parser.
-    case malformed
 }
 
 /// Parses Server-Sent Events (SSE) from a byte stream.
@@ -139,9 +164,11 @@ package struct SSEStreamParser {
                 // Cumulative bytes consumed across the whole stream.
                 var totalBytes = 0
 
-                // Sliding one-second event-rate window. We keep things cheap
-                // by bucketing to integer seconds of the monotonic clock and
-                // resetting the count when the bucket changes.
+                // Fixed-window rate limiter: the window starts on the first
+                // event and resets to "now" whenever at least one second has
+                // elapsed. Cheaper than a true sliding window and tight enough
+                // for DoS defence — a burst above the cap still trips inside
+                // the active window, which is what matters.
                 var rateWindowStart = ContinuousClock.now
                 var rateWindowCount = 0
                 let maxRate = limits.maxEventsPerSecond

--- a/Tests/BaseChatInferenceTests/SSEStreamParserTests.swift
+++ b/Tests/BaseChatInferenceTests/SSEStreamParserTests.swift
@@ -81,4 +81,176 @@ final class SSEStreamParserTests: XCTestCase {
         let results = try await collect("")
         XCTAssertTrue(results.isEmpty, "Empty input should yield nothing")
     }
+
+    // MARK: - Limits
+
+    /// A normal OpenAI-style SSE trace completes under the default caps with
+    /// every token yielded in order. Guards against over-tightening defaults.
+    func test_limits_defaultsDoNotThrottleRealProviderTraffic() async throws {
+        var sse = ""
+        for i in 0..<1_000 {
+            sse += #"data: {"choices":[{"delta":{"content":"tok\#(i)"}}]}\#n\#n"#
+        }
+        let stream = SSEStreamParser.parse(
+            bytes: makeByteStream(sse),
+            limits: .default
+        )
+        var count = 0
+        for try await _ in stream { count += 1 }
+        XCTAssertEqual(count, 1_000)
+    }
+
+    /// A single ~2 MB `data:` line must be rejected with
+    /// `SSEStreamError.eventTooLarge` before it can be fully buffered.
+    func test_limits_eventTooLarge_rejectsOversizedLine() async throws {
+        // Build a 2 MB payload; the parser enforces the cap while buffering.
+        let big = String(repeating: "A", count: 2_000_000)
+        let sse = "data: \(big)\n\n"
+        let limits = SSEStreamLimits(
+            maxEventBytes: 1_000_000,
+            maxTotalBytes: 50_000_000,
+            maxEventsPerSecond: 5_000
+        )
+
+        let stream = SSEStreamParser.parse(
+            bytes: makeByteStream(sse),
+            limits: limits
+        )
+
+        do {
+            for try await _ in stream {}
+            XCTFail("Expected SSEStreamError.eventTooLarge")
+        } catch let error as SSEStreamError {
+            guard case .eventTooLarge(let size) = error else {
+                XCTFail("Expected .eventTooLarge, got \(error)")
+                return
+            }
+            XCTAssertGreaterThan(size, 1_000_000, "Reported size should exceed the cap")
+        }
+    }
+
+    /// Many legitimate-looking small events that sum above the total-bytes
+    /// cap must be rejected with `SSEStreamError.streamTooLarge`.
+    func test_limits_streamTooLarge_rejectsUnboundedStream() async throws {
+        // Craft a stream whose cumulative bytes exceed the 50 KB cap we set
+        // while each individual event stays small.
+        var sse = ""
+        for i in 0..<10_000 {
+            sse += "data: \(i)\n\n"  // ~10+ bytes each
+        }
+
+        let limits = SSEStreamLimits(
+            maxEventBytes: 1_000_000,
+            maxTotalBytes: 50_000,
+            maxEventsPerSecond: 100_000
+        )
+
+        let stream = SSEStreamParser.parse(
+            bytes: makeByteStream(sse),
+            limits: limits
+        )
+
+        do {
+            for try await _ in stream {}
+            XCTFail("Expected SSEStreamError.streamTooLarge")
+        } catch let error as SSEStreamError {
+            guard case .streamTooLarge(let total) = error else {
+                XCTFail("Expected .streamTooLarge, got \(error)")
+                return
+            }
+            XCTAssertGreaterThan(total, 50_000)
+        }
+    }
+
+    /// A burst of events within a single one-second window that exceeds
+    /// `maxEventsPerSecond` must be rejected with `.eventRateExceeded`.
+    func test_limits_eventRateExceeded_rejectsFlood() async throws {
+        // 6,000 small events over the 5,000 / s cap.
+        var sse = ""
+        for _ in 0..<6_000 {
+            sse += "data: x\n\n"
+        }
+
+        let limits = SSEStreamLimits(
+            maxEventBytes: 1_000_000,
+            maxTotalBytes: 50_000_000,
+            maxEventsPerSecond: 5_000
+        )
+
+        let stream = SSEStreamParser.parse(
+            bytes: makeByteStream(sse),
+            limits: limits
+        )
+
+        do {
+            for try await _ in stream {}
+            XCTFail("Expected SSEStreamError.eventRateExceeded")
+        } catch let error as SSEStreamError {
+            guard case .eventRateExceeded(let count) = error else {
+                XCTFail("Expected .eventRateExceeded, got \(error)")
+                return
+            }
+            XCTAssertGreaterThan(count, 5_000)
+        }
+    }
+
+    /// Sabotage check: raising the rate cap 100x must let the same 6,000-event
+    /// burst complete without tripping `.eventRateExceeded`.
+    func test_limits_eventRateExceeded_sabotage_raisedCapPasses() async throws {
+        var sse = ""
+        for _ in 0..<6_000 {
+            sse += "data: x\n\n"
+        }
+
+        let limits = SSEStreamLimits(
+            maxEventBytes: 1_000_000,
+            maxTotalBytes: 50_000_000,
+            maxEventsPerSecond: 500_000  // 100x the default
+        )
+
+        let stream = SSEStreamParser.parse(
+            bytes: makeByteStream(sse),
+            limits: limits
+        )
+
+        var count = 0
+        for try await _ in stream { count += 1 }
+        XCTAssertEqual(count, 6_000, "Flood should pass with rate cap raised 100x")
+    }
+
+    // MARK: - BaseChatConfiguration wiring
+
+    func test_config_sseStreamLimits_defaultIsShared() {
+        // Restoring shared state around the assertion prevents flakes if
+        // another test mutated it.
+        let original = BaseChatConfiguration.shared.sseStreamLimits
+        defer { BaseChatConfiguration.shared.sseStreamLimits = original }
+
+        BaseChatConfiguration.shared.sseStreamLimits = .default
+        XCTAssertEqual(BaseChatConfiguration.shared.sseStreamLimits, .default)
+    }
+
+    func test_config_sseStreamLimits_overrideIsHonoured() async throws {
+        let original = BaseChatConfiguration.shared.sseStreamLimits
+        defer { BaseChatConfiguration.shared.sseStreamLimits = original }
+
+        BaseChatConfiguration.shared.sseStreamLimits = SSEStreamLimits(
+            maxEventBytes: 10,
+            maxTotalBytes: 50_000_000,
+            maxEventsPerSecond: 5_000
+        )
+
+        let sse = "data: this-is-more-than-ten-bytes\n\n"
+        let stream = SSEStreamParser.parse(bytes: makeByteStream(sse))
+
+        do {
+            for try await _ in stream {}
+            XCTFail("Expected SSEStreamError.eventTooLarge from global override")
+        } catch let error as SSEStreamError {
+            guard case .eventTooLarge = error else {
+                XCTFail("Expected .eventTooLarge, got \(error)")
+                return
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `SSEStreamLimits` (per-event bytes, total bytes, events/sec) and `SSEStreamError` in `BaseChatInference`, wired into `SSEStreamParser.parse` and `SSEStreamParser.streamEvents`.
- Exposes configuration globally via `BaseChatConfiguration.sseStreamLimits` and per backend via `SSECloudBackend.sseStreamLimits`, with conservative `.default` values (1 MB / 50 MB / 5,000 events per second) well above any mainstream provider's real throughput.
- Applies the same caps to `OllamaBackend`'s NDJSON path so a hostile Ollama-compatible server gets the same treatment as SSE.

## Why

`SSEStreamParser` had no bounds on per-event payload size, total stream size, or event frequency. Users who point `CustomEndpoint.baseURL` at an untrusted server were exposed to trivial denial-of-service vectors: a single 100 MB `data:` line exhausted memory, an unbounded stream of small valid events persisted forever, and millions of 1-byte events starved the UI. The defaults here cost zero to legitimate use while making those attacks impossible.

## Tuning guide

- Global: `BaseChatConfiguration.shared.sseStreamLimits = SSEStreamLimits(maxEventBytes: 500_000, maxTotalBytes: 10_000_000, maxEventsPerSecond: 2_000)` at app launch to tighten across every cloud backend.
- Per backend: `backend.sseStreamLimits = SSEStreamLimits(...)` to lock down a single untrusted endpoint while leaving OpenAI/Anthropic at the defaults.
- There is deliberately no `nil`/unlimited option. Bounded caps are the point.

## Release Note

**SSE DoS hardening for cloud backends** — BaseChatKit now bounds every Server-Sent Events and NDJSON stream by per-event size, total size, and events-per-second. Defaults are well above any real provider so legitimate OpenAI, Anthropic, and Ollama traffic is unaffected, but a hostile or misconfigured upstream can no longer drive a chat app out of memory or starve its UI. Host apps can tighten the caps globally via `BaseChatConfiguration.sseStreamLimits` or per backend via `SSECloudBackend.sseStreamLimits`, which is especially useful when pointing `CustomEndpoint.baseURL` at an untrusted server.

## Test plan

- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` (651 tests, 0 failures) — includes 7 new limits tests in `SSEStreamParserTests`.
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` (83, 0 failures).
- [x] `swift test --filter BaseChatUITests --disable-default-traits` (431, 0 failures).
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` (131, 0 failures).
- [x] Happy path: 1,000-event OpenAI-style stream passes under `.default`.
- [x] `eventTooLarge`: 2 MB single `data:` line rejected with correct error and observed size.
- [x] `streamTooLarge`: many small events summing above a 50 KB total cap rejected.
- [x] `eventRateExceeded`: 6,000-event burst against a 5,000/s cap rejected.
- [x] Sabotage: raising the rate cap 100x lets the same burst pass — confirms the test actually exercises the limit.
- [x] `BaseChatConfiguration` override is honoured by `SSEStreamParser.parse` callers that don't pass `limits:` explicitly.