### PR TITLE
docs: add SecurityModel DocC page documenting framework defenses and threat model

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,8 @@ Templates auto-detect from GGUF metadata when available. User content is sanitis
 
 ## Security
 
+See the [Security Model](Sources/BaseChatCore/BaseChatCore.docc/Articles/SecurityModel.md) DocC article for the full threat model, what BCK protects against, what remains your responsibility, and how to tune for stricter environments. A quick summary:
+
 - API keys stored in Keychain with `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`
 - Keys read just-in-time from Keychain, never held as stored properties
 - Certificate pinning support via `PinnedSessionDelegate` — configure `pinnedHosts` with SPKI SHA-256 hashes; `api.openai.com` and `api.anthropic.com` fail closed if pin sets are missing/empty, while localhost and custom hosts retain existing bypass/default-trust behavior

--- a/Sources/BaseChatCore/BaseChatCore.docc/Articles/SecurityModel.md
+++ b/Sources/BaseChatCore/BaseChatCore.docc/Articles/SecurityModel.md
@@ -4,24 +4,17 @@ What BaseChatKit protects against out of the box, what remains your responsibili
 
 ## Overview
 
-BaseChatKit ships with defense-in-depth for the common LLM-chat threats: stolen API keys, MITM on cloud calls, crafted filenames from remote metadata, and prompt template leakage. This page documents what's protected *today on main*, what's your responsibility, and how to raise the floor for stricter environments.
-
-The framework targets integrators building consumer or prosumer Apple-platform chat apps. It is not hardened for kiosk, MDM-managed, or regulated deployments without additional controls on top.
+BaseChatKit ships defense-in-depth for the common LLM-chat threats: stolen API keys, MITM on cloud calls, SSRF via user-entered endpoints, crafted filenames from remote metadata, and hostile upstream error bodies. This page documents what's protected *today on main*. The framework targets integrators building consumer or prosumer Apple-platform chat apps; it is not hardened for kiosk, MDM-managed, or regulated deployments without additional controls on top.
 
 ## Transport security
 
-Cloud backends (Claude, OpenAI, and OpenAI-compatible) route through a shared `URLSession` guarded by a certificate-pinning delegate. Pinning runs at the **public-key (SPKI) level** and checks every certificate in the presented chain, not just the leaf — so a routine leaf rotation does not trigger a lockout.
+**Protected:** MITM on Claude and OpenAI traffic, including a rogue CA silently installed on the device.
 
-The default pin set covers the two hosts BCK makes production calls to:
+Cloud backends route through a shared `URLSession` guarded by a certificate-pinning delegate. Pinning runs at the **SPKI level** and checks every certificate in the presented chain, so routine leaf rotation does not trigger a lockout.
 
-| Host | Pinned SPKI |
-|------|-------------|
-| `api.anthropic.com` | Google Trust Services WE1 (intermediate) and GTS Root R4 (backup) |
-| `api.openai.com`    | Google Trust Services WE1 (intermediate) and GTS Root R4 (backup) |
+The default pin set, populated by `PinnedSessionDelegate.loadDefaultPins()`, pins Google Trust Services WE1 (intermediate) plus GTS Root R4 (backup) on both `api.anthropic.com` and `api.openai.com`. Both are classified as *required pinned hosts*: if the pin set is empty or no certificate in the chain matches, the challenge is cancelled — no fallback to default trust.
 
-**Fail-closed behaviour.** These two hosts are classified as *required pinned hosts*. If the pin set is empty or the chain does not match, the authentication challenge is cancelled — there is no fallback to default trust. This is intentional: a misconfiguration on a known production host should stop the request, not silently downgrade.
-
-**Custom hosts.** Any other host (your own OpenAI-compatible endpoint, a self-hosted gateway, Ollama on a remote machine) falls through to the platform's default trust evaluation *unless* you add pins for it:
+**Custom hosts** (your own OpenAI-compatible endpoint, a self-hosted gateway, remote Ollama) fall through to the platform's default trust evaluation *unless* you add pins:
 
 ```swift
 import BaseChatBackends
@@ -32,98 +25,95 @@ PinnedSessionDelegate.pinnedHosts["chat.mycompany.com"] = [
 ]
 ```
 
-**Localhost is exempt.** `localhost`, `127.0.0.1`, and `::1` always bypass pinning so local Ollama or LM Studio development servers keep working without ceremony.
+`localhost`, `127.0.0.1`, and `::1` always bypass pinning for local development.
 
-**Pin rotation.** When a provider rotates their chain, add new pins *before* removing the old ones, ship the update, and only retire the stale pin once no clients are still presenting the previous chain. Always carry at least one backup pin per host to survive an emergency rotation.
+**Pin rotation.** Add new pins *before* removing the old ones, ship the update, and retire the stale pin only once no clients are still presenting the previous chain. Always carry at least one backup pin per host.
+
+## Custom endpoints (SSRF)
+
+**Protected:** a user-pasted base URL that resolves to the LAN or a cloud metadata service (`169.254.169.254`) cannot be persisted.
+
+``APIEndpoint/isValid`` performs a structural check on every user-entered base URL:
+
+- **Scheme** must be `http` or `https`. `file://`, `ftp://`, `data:`, `javascript:` and friends are rejected.
+- **HTTPS is required** for non-loopback hosts. Plain `http://` is accepted only for `localhost`, `127.0.0.1`, and `::1`.
+- **IP-literal hosts** are classified against blocked ranges. IPv4: `0.0.0.0/8`, RFC 1918 (`10/8`, `172.16/12`, `192.168/16`), `127/8` except `127.0.0.1`, `169.254/16` (link-local, incl. `169.254.169.254` cloud metadata), `224/4` (multicast), `240/4` (reserved). IPv6: `fc00::/7` (unique local), `fe80::/10` (link-local), `::ffff:0:0/96` (IPv4-mapped — would otherwise bypass the IPv4 filter).
+- **Trailing-dot FQDNs** (`https://192.168.1.1.`) are canonicalised so they cannot bypass the gate.
+
+What this check does **not** do: it does not resolve DNS names (validation runs synchronously from SwiftUI forms and must stay fast), and it does not defeat **DNS rebinding** — the resolver's answer at request time may differ from any answer observed at validation time. Deployments that need that guarantee should add a request-layer mitigation (reject private IPs returned by `URLSession` host resolution, or pin resolution to a known resolver).
 
 ## Credentials and API keys
 
-API keys are stored in the system Keychain via ``KeychainService``, keyed by each endpoint's UUID. Storage attributes:
+**Protected:** API keys do not live on disk, never sync to iCloud Keychain, and silent Keychain failures cannot leave the UI thinking a key is saved when it isn't.
 
-- `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` — keys are unavailable when the device is locked and **do not** sync via iCloud Keychain.
-- Service name comes from `BaseChatConfiguration.shared.keychainServiceName` so multiple apps sharing a team ID stay isolated.
+Keys are stored in the system Keychain via ``KeychainService``, keyed by each endpoint's UUID. The access class is `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` — keys are unavailable while the device is locked and **do not** sync via iCloud Keychain. The service name comes from `BaseChatConfiguration.shared.keychainServiceName`, so apps sharing a team ID stay isolated.
 
-**Just-in-time retrieval.** Backends read the key from Keychain per request rather than caching it as a stored property, which limits the window where a memory-dump attacker sees the plaintext.
+`KeychainService.store(key:account:)` and `KeychainService.delete(account:)` **throw** `KeychainError` on failure; `retrieve(account:)` returns `nil` because a missing item is a normal state. `KeychainError.localizedDescription` maps common `OSStatus` codes (locked device, missing entitlement, auth failure) to a user-facing string; `KeychainError.osStatus` exposes the raw code for callers that need to branch on it. Backends read the key per request rather than caching it as a stored property, limiting the window where a memory-dump attacker sees the plaintext. `KeychainService.masked(_:)` returns `"sk-a...xyz"` for diagnostics; never log the raw key.
 
-**Masked logging.** `KeychainService.masked(_:)` returns a truncated form (`"sk-a...xyz"`) suitable for diagnostics. Never log the raw key.
-
-On main today, `store` and `delete` return `Bool`. Failures are surfaced to the caller but are not thrown. Treat a `false` return as a terminal failure for that endpoint — do not retry silently, because repeated Keychain errors usually indicate a provisioning, entitlement, or system policy problem.
+**Migration note.** `APIEndpoint.setAPIKey(_:)` and `deleteAPIKey()` are `throws`; call sites must be `try endpoint.setAPIKey(key)`. Surfacing the error is load-bearing — swallowing it leaves the user believing their key is saved when the Keychain actually rejected the write.
 
 ## At-rest data
 
-Chat sessions and messages live in a SwiftData store under Application Support. The store itself inherits **whatever file-protection class the platform applies by default**: on iOS that is effectively `CompleteUntilFirstUserAuthentication`, on macOS it relies on FileVault.
+**Protected (iOS / iPadOS / tvOS / watchOS):** the SwiftData store is sealed by Data Protection until the user first unlocks the device after reboot.
 
-SwiftData has no built-in payload encryption beyond file protection. If your threat model requires strict data-at-rest protection (for example, a note-taking app that must remain sealed while locked even after first unlock), layer your own encryption on top or configure a stricter file-protection class on the container URL at startup.
+``ModelContainerFactory/makeContainer(configurations:)`` applies the file-protection class configured via `BaseChatConfiguration.fileProtectionClass` to the store file and its SQLite `-shm` / `-wal` sidecars. The default is `.completeUntilFirstUserAuthentication` — sensitive data is protected at rest, but background tasks (silent pushes, downloads resumed after app termination) still work. Set `.complete` for the strongest sealing (breaks background reads while locked), or `nil` to opt out entirely:
 
-## Custom endpoints
+```swift
+BaseChatConfiguration.shared = BaseChatConfiguration(
+    fileProtectionClass: .complete
+)
+```
 
-``APIEndpoint/isValid`` performs a structural check on user-entered base URLs: it parses the URL, requires a scheme and host, and **rejects non-HTTPS schemes for anything that is not localhost**. Localhost (`localhost`, `127.0.0.1`, `::1`, `[::1]`) is allowed to use `http://` so developers can target Ollama or LM Studio without certificates.
+On macOS and Mac Catalyst, file-level protection is a no-op — at-rest protection is handled by FileVault. In-memory stores (tests, previews) skip protection entirely.
 
-What this check does **not** do today:
+## Upstream error sanitisation
 
-- It does not enumerate RFC 1918 / link-local / IPv6 ULA ranges. An entered hostname that resolves to `10.0.0.0/8` or `169.254.169.254` is not blocked at the model layer.
-- It does not defeat DNS rebinding — the hostname is resolved by the underlying `URLSession` at request time, not validated structurally here.
+**Protected:** a hostile proxy, a misconfigured custom endpoint, or an upstream bug cannot inject HTML, invisible bidi characters, or leaked tokens into the chat UI via an error message.
 
-If your host environment allows untrusted users to configure endpoints (for example, a shared Mac or an MDM-provisioned iPad), add a validation layer above `APIEndpoint` that resolves the host and rejects private address space before you persist the record. A stricter validator is on the roadmap (see the "Roadmap" section below).
+Before any cloud error body is surfaced through `CloudBackendError.serverError(statusCode:message:)`, `SSECloudBackend.checkStatusCode(_:bytes:)` runs it through `CloudErrorSanitizer.sanitize(_:host:)`. The sanitiser strips control bytes (C0/C1), zero-width joiners, BOMs, and bidirectional overrides; collapses whitespace; rejects HTML-shaped bodies (`<` followed by an ASCII letter — Cloudflare 5xx pages, proxy interstitials) and substitutes `"Server error from <host>"`; redacts messages containing a URL scheme or a JWT prefix (`eyJ`), which almost always means the upstream is echoing a token or callback URL; and truncates to 256 characters with an ellipsis.
+
+Raw bodies are logged via `Log.*` at `privacy: .debug` only — they never appear in production Console output, and never reach the UI unfiltered.
+
+## Model downloads
+
+**Protected:** a malicious HuggingFace manifest (`../../Library/Preferences/…`) cannot write outside the models directory, and a previous-run crash cannot accumulate multi-GB temp files indefinitely.
+
+``DownloadableModel/validate(fileName:)`` runs at the earliest point a filename enters the system (manifest parsing, Hub search results, snapshot downloads) and rejects: empty or `>= 255` characters (POSIX `NAME_MAX`); any backslash (never legitimate on Apple platforms); any control character (C0, DEL, C1 — truncation hazards and invisible `U+0085 NEXT LINE` injection); any `..` or `.` component (classic path traversal); a leading, trailing, or consecutive `/`; more than one `/` (only `<namespace>/<name>` is honoured — `a/b/c` is rejected rather than silently accepting a sub-path write); and any component beginning with `.` (hides the file and collides with `.DS_Store`, `.git`).
+
+Placement into `modelsDirectory` additionally enforces a `.standardized.path` prefix check, so a filename that slips past structural validation still cannot escape the models directory.
+
+**Stale-temp sweep.** `BackgroundDownloadManager.cleanupStaleTempFiles()` runs on launch from `reconnectBackgroundSession()`. It removes regular files in `FileManager.default.temporaryDirectory` that match *all* of: filename prefix `"basechatkit-dl-"`, extension `"download"`, and modification date older than 24 hours. The prefix keeps the sweep from touching files produced by other subsystems; the 24-hour floor keeps it from clobbering an in-flight download that the system's background transfer service hasn't handed back yet.
+
+## Regex ReDoS
+
+**Protected:** a filename crafted to induce catastrophic backtracking cannot freeze the UI.
+
+`DownloadableModel.quantization` extracts the quant tag (`Q4_K_M`, `IQ2_XXS`, `BF16`) with a regex whose trailing `(?:_[A-Z0-9]+)` group is bounded to `{0,5}` repetitions, and the input is clipped to a 128-character prefix before evaluation. Real quant tags cap at two suffix components; the bounded envelope neutralises pathological input.
 
 ## Prompt template hardening
 
-GGUF models do not apply their own chat templates, so BCK's ``PromptTemplate`` wraps messages in the format the model was trained on (ChatML, Llama 3, Mistral, Alpaca, Gemma, Phi). Before each user message is interpolated, the template strips the **special tokens specific to that format** (`<|im_start|>`, `[INST]`, `<|eot_id|>`, etc.). This prevents a user pasting a fake `<|im_start|>system` turn and reshaping the conversation.
+**Protected:** a user cannot paste a fake `<|im_start|>system` turn and reshape the conversation.
 
-This is a narrow defense against *structural* injection, not semantic jailbreaks. See "Prompt injection" below.
-
-## Downloads
-
-Model downloads from HuggingFace stage into a per-download directory before being moved into `modelsDirectory`. Both the staging path and the final placement are checked:
-
-- Each file in a multi-file snapshot must resolve to a path whose `.standardized.path` has the staging directory as a prefix. A crafted relative path (e.g. from manipulated `siblings` metadata containing `../`) is rejected with ``HuggingFaceError``.
-- The final move into `modelsDirectory` applies the same prefix check against the models directory. A `fileName` that escapes is rejected before the move.
-
-On main, those checks live in the download placement path. A dedicated filename validator and orphan-temp-sweep are tracked for a future release (see "Roadmap").
+GGUF models do not apply their own chat templates, so ``PromptTemplate`` wraps messages in the format the model was trained on (ChatML, Llama 3, Mistral, Alpaca, Gemma, Phi). Before each user message is interpolated, the template strips the special tokens specific to that format (`<|im_start|>`, `[INST]`, `<|eot_id|>`, …). Narrow defense against *structural* injection, not semantic jailbreaks.
 
 ## Observability
 
-Calls to `Log.*` use `privacy: .private` for credentials, prompts, and user content. `privacy: .public` is reserved for stable identifiers (host names, model file names that the app itself chose, task phases). If you re-use the logger in your own integration code, mirror the same annotation discipline — Console redaction is lost the moment a single `%{public}s` leaks a secret.
+`Log.*` calls use `privacy: .private` for credentials, prompts, and user content; `privacy: .public` is reserved for stable identifiers (host names, chosen file names, task phases, `OSStatus` codes). Mirror the same discipline in your own integration code — Console redaction is lost the moment a single `%{public}s` leaks a secret.
 
-## Prompt injection — explicit threat-model disclaimer
+## Prompt injection — explicit disclaimer
 
-**Prompt injection is inherent to the LLM-chat domain and BaseChatKit does not solve it.**
+**Prompt injection is inherent to the LLM-chat domain and BaseChatKit does not solve it.** The framework does not sanitize the semantic boundary between system prompt and user content; only the structural special-token strip above. System prompts are not a security boundary — any user, or any document pasted into context, can override them with enough determination. Tool calls, retrieved content, and pasted web pages are untrusted input from the model's perspective; treat their influence on the conversation the way you would treat a cross-origin iframe.
 
-- The framework does **not** sanitize the boundary between system prompt and user content at the semantic level. Only the structural special-token strip described above.
-- System prompts are **not a security boundary**. Any user or any document you paste into the context can override them with enough determination.
-- Tool calls, retrieval-augmented content, and pasted web pages are untrusted input from the model's perspective. Treat their influence on the conversation the same way you would treat a cross-origin iframe in a browser.
-
-Recommended mitigations, in roughly increasing cost:
-
-1. Use **structured message formats** where the provider exposes them (OpenAI/Anthropic `tool_use` payloads, response JSON schemas) instead of stuffing instructions into plain prose.
-2. Add a **content-filtering layer** before the model sees the text when your app ingests user-uploaded documents.
-3. Keep **capability scopes small** — a tool that can only read today's calendar is much cheaper to expose than one that can send email.
+Mitigations, in roughly increasing cost: use structured message formats (provider `tool_use` payloads, JSON schemas) rather than stuffing instructions into prose; add a content-filtering layer before user-uploaded documents reach the model; keep capability scopes small — a tool that reads today's calendar is much cheaper to expose than one that sends email.
 
 ## Out of scope
 
-The framework does not attempt to protect against:
-
-- DNS rebinding
-- User-installed MITM certificates (corporate proxies, jailbreak tweaks)
-- Compromised host OS, jailbroken or rooted devices
-- Side-channel attacks on shared Mac user sessions
-- Supply-chain attacks on pre-built model weights — GGUF SHA manifest verification is **roadmap**, not current
-- Physical-access and social-engineering attacks (these are also excluded from our disclosure scope in [SECURITY.md](https://github.com/roryford/BaseChatKit/blob/main/.github/SECURITY.md))
+The framework does not attempt to protect against DNS rebinding; user-installed MITM certificates (corporate proxies, jailbreak tweaks); a compromised host OS or jailbroken/rooted device; side-channel attacks on shared Mac user sessions; supply-chain attacks on pre-built model weights (GGUF SHA manifest verification is **roadmap**); or physical-access and social-engineering attacks (also excluded from our disclosure scope in [SECURITY.md](https://github.com/roryford/BaseChatKit/blob/main/.github/SECURITY.md)).
 
 ## Roadmap
 
-Security work that is in progress but not yet on `main`:
-
-- Private/link-local range rejection inside ``APIEndpoint/isValid`` (SSRF hardening for user-entered base URLs)
-- SSE stream size and rate caps to defeat hostile-server resource exhaustion
-- Upstream error-body sanitization before surfacing to the UI
-- Throwing Keychain APIs (`store` / `delete`)
-- Dedicated ``DownloadableModel`` filename validator plus an orphan temp-directory sweep
-- ReDoS-bounded quantization-tag regex
-- GGUF SHA manifest verification
-
-Pin this page in your security review checklist — the "Roadmap" section shrinks as those ship.
+In progress, not yet on `main`: SSE stream size and rate caps (hostile-server DoS); Keychain orphan reaper (prunes items whose owning `APIEndpoint` has been deleted); GGUF SHA manifest verification for downloaded weights.
 
 ## Reporting a vulnerability
 
-Report suspected vulnerabilities through [GitHub Security Advisories](https://github.com/roryford/BaseChatKit/security/advisories/new). Do not open public issues for security reports. Full policy and response timelines: [SECURITY.md](https://github.com/roryford/BaseChatKit/blob/main/.github/SECURITY.md).
+Report suspected vulnerabilities through [GitHub Security Advisories](https://github.com/roryford/BaseChatKit/security/advisories/new) — do not open public issues. Full policy: [SECURITY.md](https://github.com/roryford/BaseChatKit/blob/main/.github/SECURITY.md).

--- a/Sources/BaseChatCore/BaseChatCore.docc/Articles/SecurityModel.md
+++ b/Sources/BaseChatCore/BaseChatCore.docc/Articles/SecurityModel.md
@@ -1,0 +1,129 @@
+# Security Model
+
+What BaseChatKit protects against out of the box, what remains your responsibility, and how to tune the framework for stricter threat models.
+
+## Overview
+
+BaseChatKit ships with defense-in-depth for the common LLM-chat threats: stolen API keys, MITM on cloud calls, crafted filenames from remote metadata, and prompt template leakage. This page documents what's protected *today on main*, what's your responsibility, and how to raise the floor for stricter environments.
+
+The framework targets integrators building consumer or prosumer Apple-platform chat apps. It is not hardened for kiosk, MDM-managed, or regulated deployments without additional controls on top.
+
+## Transport security
+
+Cloud backends (Claude, OpenAI, and OpenAI-compatible) route through a shared `URLSession` guarded by a certificate-pinning delegate. Pinning runs at the **public-key (SPKI) level** and checks every certificate in the presented chain, not just the leaf — so a routine leaf rotation does not trigger a lockout.
+
+The default pin set covers the two hosts BCK makes production calls to:
+
+| Host | Pinned SPKI |
+|------|-------------|
+| `api.anthropic.com` | Google Trust Services WE1 (intermediate) and GTS Root R4 (backup) |
+| `api.openai.com`    | Google Trust Services WE1 (intermediate) and GTS Root R4 (backup) |
+
+**Fail-closed behaviour.** These two hosts are classified as *required pinned hosts*. If the pin set is empty or the chain does not match, the authentication challenge is cancelled — there is no fallback to default trust. This is intentional: a misconfiguration on a known production host should stop the request, not silently downgrade.
+
+**Custom hosts.** Any other host (your own OpenAI-compatible endpoint, a self-hosted gateway, Ollama on a remote machine) falls through to the platform's default trust evaluation *unless* you add pins for it:
+
+```swift
+import BaseChatBackends
+
+PinnedSessionDelegate.pinnedHosts["chat.mycompany.com"] = [
+    "base64-spki-sha256-pin-1=",
+    "base64-spki-sha256-pin-2=" // backup for rotation
+]
+```
+
+**Localhost is exempt.** `localhost`, `127.0.0.1`, and `::1` always bypass pinning so local Ollama or LM Studio development servers keep working without ceremony.
+
+**Pin rotation.** When a provider rotates their chain, add new pins *before* removing the old ones, ship the update, and only retire the stale pin once no clients are still presenting the previous chain. Always carry at least one backup pin per host to survive an emergency rotation.
+
+## Credentials and API keys
+
+API keys are stored in the system Keychain via ``KeychainService``, keyed by each endpoint's UUID. Storage attributes:
+
+- `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` — keys are unavailable when the device is locked and **do not** sync via iCloud Keychain.
+- Service name comes from `BaseChatConfiguration.shared.keychainServiceName` so multiple apps sharing a team ID stay isolated.
+
+**Just-in-time retrieval.** Backends read the key from Keychain per request rather than caching it as a stored property, which limits the window where a memory-dump attacker sees the plaintext.
+
+**Masked logging.** `KeychainService.masked(_:)` returns a truncated form (`"sk-a...xyz"`) suitable for diagnostics. Never log the raw key.
+
+On main today, `store` and `delete` return `Bool`. Failures are surfaced to the caller but are not thrown. Treat a `false` return as a terminal failure for that endpoint — do not retry silently, because repeated Keychain errors usually indicate a provisioning, entitlement, or system policy problem.
+
+## At-rest data
+
+Chat sessions and messages live in a SwiftData store under Application Support. The store itself inherits **whatever file-protection class the platform applies by default**: on iOS that is effectively `CompleteUntilFirstUserAuthentication`, on macOS it relies on FileVault.
+
+SwiftData has no built-in payload encryption beyond file protection. If your threat model requires strict data-at-rest protection (for example, a note-taking app that must remain sealed while locked even after first unlock), layer your own encryption on top or configure a stricter file-protection class on the container URL at startup.
+
+## Custom endpoints
+
+``APIEndpoint/isValid`` performs a structural check on user-entered base URLs: it parses the URL, requires a scheme and host, and **rejects non-HTTPS schemes for anything that is not localhost**. Localhost (`localhost`, `127.0.0.1`, `::1`, `[::1]`) is allowed to use `http://` so developers can target Ollama or LM Studio without certificates.
+
+What this check does **not** do today:
+
+- It does not enumerate RFC 1918 / link-local / IPv6 ULA ranges. An entered hostname that resolves to `10.0.0.0/8` or `169.254.169.254` is not blocked at the model layer.
+- It does not defeat DNS rebinding — the hostname is resolved by the underlying `URLSession` at request time, not validated structurally here.
+
+If your host environment allows untrusted users to configure endpoints (for example, a shared Mac or an MDM-provisioned iPad), add a validation layer above `APIEndpoint` that resolves the host and rejects private address space before you persist the record. A stricter validator is on the roadmap (see the "Roadmap" section below).
+
+## Prompt template hardening
+
+GGUF models do not apply their own chat templates, so BCK's ``PromptTemplate`` wraps messages in the format the model was trained on (ChatML, Llama 3, Mistral, Alpaca, Gemma, Phi). Before each user message is interpolated, the template strips the **special tokens specific to that format** (`<|im_start|>`, `[INST]`, `<|eot_id|>`, etc.). This prevents a user pasting a fake `<|im_start|>system` turn and reshaping the conversation.
+
+This is a narrow defense against *structural* injection, not semantic jailbreaks. See "Prompt injection" below.
+
+## Downloads
+
+Model downloads from HuggingFace stage into a per-download directory before being moved into `modelsDirectory`. Both the staging path and the final placement are checked:
+
+- Each file in a multi-file snapshot must resolve to a path whose `.standardized.path` has the staging directory as a prefix. A crafted relative path (e.g. from manipulated `siblings` metadata containing `../`) is rejected with ``HuggingFaceError``.
+- The final move into `modelsDirectory` applies the same prefix check against the models directory. A `fileName` that escapes is rejected before the move.
+
+On main, those checks live in the download placement path. A dedicated filename validator and orphan-temp-sweep are tracked for a future release (see "Roadmap").
+
+## Observability
+
+Calls to `Log.*` use `privacy: .private` for credentials, prompts, and user content. `privacy: .public` is reserved for stable identifiers (host names, model file names that the app itself chose, task phases). If you re-use the logger in your own integration code, mirror the same annotation discipline — Console redaction is lost the moment a single `%{public}s` leaks a secret.
+
+## Prompt injection — explicit threat-model disclaimer
+
+**Prompt injection is inherent to the LLM-chat domain and BaseChatKit does not solve it.**
+
+- The framework does **not** sanitize the boundary between system prompt and user content at the semantic level. Only the structural special-token strip described above.
+- System prompts are **not a security boundary**. Any user or any document you paste into the context can override them with enough determination.
+- Tool calls, retrieval-augmented content, and pasted web pages are untrusted input from the model's perspective. Treat their influence on the conversation the same way you would treat a cross-origin iframe in a browser.
+
+Recommended mitigations, in roughly increasing cost:
+
+1. Use **structured message formats** where the provider exposes them (OpenAI/Anthropic `tool_use` payloads, response JSON schemas) instead of stuffing instructions into plain prose.
+2. Add a **content-filtering layer** before the model sees the text when your app ingests user-uploaded documents.
+3. Keep **capability scopes small** — a tool that can only read today's calendar is much cheaper to expose than one that can send email.
+
+## Out of scope
+
+The framework does not attempt to protect against:
+
+- DNS rebinding
+- User-installed MITM certificates (corporate proxies, jailbreak tweaks)
+- Compromised host OS, jailbroken or rooted devices
+- Side-channel attacks on shared Mac user sessions
+- Supply-chain attacks on pre-built model weights — GGUF SHA manifest verification is **roadmap**, not current
+- Physical-access and social-engineering attacks (these are also excluded from our disclosure scope in [SECURITY.md](https://github.com/roryford/BaseChatKit/blob/main/.github/SECURITY.md))
+
+## Roadmap
+
+Security work that is in progress but not yet on `main`:
+
+- Private/link-local range rejection inside ``APIEndpoint/isValid`` (SSRF hardening for user-entered base URLs)
+- SSE stream size and rate caps to defeat hostile-server resource exhaustion
+- Upstream error-body sanitization before surfacing to the UI
+- Throwing Keychain APIs (`store` / `delete`)
+- Dedicated ``DownloadableModel`` filename validator plus an orphan temp-directory sweep
+- ReDoS-bounded quantization-tag regex
+- GGUF SHA manifest verification
+
+Pin this page in your security review checklist — the "Roadmap" section shrinks as those ship.
+
+## Reporting a vulnerability
+
+Report suspected vulnerabilities through [GitHub Security Advisories](https://github.com/roryford/BaseChatKit/security/advisories/new). Do not open public issues for security reports. Full policy and response timelines: [SECURITY.md](https://github.com/roryford/BaseChatKit/blob/main/.github/SECURITY.md).

--- a/Sources/BaseChatCore/BaseChatCore.docc/Articles/SecurityModel.md
+++ b/Sources/BaseChatCore/BaseChatCore.docc/Articles/SecurityModel.md
@@ -10,9 +10,7 @@ BaseChatKit ships defense-in-depth for the common LLM-chat threats: stolen API k
 
 **Protected:** MITM on Claude and OpenAI traffic, including a rogue CA silently installed on the device.
 
-Cloud backends route through a shared `URLSession` guarded by a certificate-pinning delegate. Pinning runs at the **SPKI level** and checks every certificate in the presented chain, so routine leaf rotation does not trigger a lockout.
-
-The default pin set, populated by `PinnedSessionDelegate.loadDefaultPins()`, pins Google Trust Services WE1 (intermediate) plus GTS Root R4 (backup) on both `api.anthropic.com` and `api.openai.com`. Both are classified as *required pinned hosts*: if the pin set is empty or no certificate in the chain matches, the challenge is cancelled — no fallback to default trust.
+Cloud backends route through a shared `URLSession` guarded by a certificate-pinning delegate. Pinning runs at the **SPKI level** and checks every certificate in the presented chain, so routine leaf rotation does not trigger a lockout. The default pin set, populated by `PinnedSessionDelegate.loadDefaultPins()`, pins Google Trust Services WE1 (intermediate) plus GTS Root R4 (backup) on both `api.anthropic.com` and `api.openai.com`. Both are classified as *required pinned hosts*: if the pin set is empty or no certificate in the chain matches, the challenge is cancelled — no fallback to default trust.
 
 **Custom hosts** (your own OpenAI-compatible endpoint, a self-hosted gateway, remote Ollama) fall through to the platform's default trust evaluation *unless* you add pins:
 
@@ -25,22 +23,34 @@ PinnedSessionDelegate.pinnedHosts["chat.mycompany.com"] = [
 ]
 ```
 
-`localhost`, `127.0.0.1`, and `::1` always bypass pinning for local development.
-
-**Pin rotation.** Add new pins *before* removing the old ones, ship the update, and retire the stale pin only once no clients are still presenting the previous chain. Always carry at least one backup pin per host.
+`localhost`, `127.0.0.1`, and `::1` always bypass pinning for local development. When rotating pins, add the new pin alongside the old one before shipping the update — always carry at least one backup pin per host.
 
 ## Custom endpoints (SSRF)
 
-**Protected:** a user-pasted base URL that resolves to the LAN or a cloud metadata service (`169.254.169.254`) cannot be persisted.
+**Protected:** a user-pasted base URL that resolves to the LAN or a cloud metadata service (`169.254.169.254`) cannot be persisted, and the UI can explain *why* an endpoint was rejected instead of a generic "invalid" label.
 
-``APIEndpoint/isValid`` performs a structural check on every user-entered base URL:
+``APIEndpoint/validate()`` returns `Result<Void, APIEndpointValidationReason>`; surface `reason.errorDescription` (it conforms to `LocalizedError`) and branch on the specific case for diagnostics:
 
-- **Scheme** must be `http` or `https`. `file://`, `ftp://`, `data:`, `javascript:` and friends are rejected.
-- **HTTPS is required** for non-loopback hosts. Plain `http://` is accepted only for `localhost`, `127.0.0.1`, and `::1`.
-- **IP-literal hosts** are classified against blocked ranges. IPv4: `0.0.0.0/8`, RFC 1918 (`10/8`, `172.16/12`, `192.168/16`), `127/8` except `127.0.0.1`, `169.254/16` (link-local, incl. `169.254.169.254` cloud metadata), `224/4` (multicast), `240/4` (reserved). IPv6: `fc00::/7` (unique local), `fe80::/10` (link-local), `::ffff:0:0/96` (IPv4-mapped — would otherwise bypass the IPv4 filter).
+```swift
+switch endpoint.validate() {
+case .success:
+    // persist and use the endpoint
+case .failure(let reason):
+    settings.errorMessage = reason.errorDescription
+    // reason is one of .emptyURL, .malformedURL, .unsupportedScheme(String),
+    // .insecureScheme, .privateHost, .linkLocalHost, .ipv6UniqueLocal,
+    // .ipv4MappedLoopback, .multicastReserved — use to tailor recovery UI.
+}
+```
+
+``APIEndpoint/isValid`` is a boolean convenience derived from `validate()` — use it for a simple "ready to save" check. The nine ``APIEndpointValidationReason`` cases map 1:1 to the enforced rules:
+
+- **Scheme** must be `http` or `https` — `file://`, `ftp://`, `data:`, `javascript:` trip `.unsupportedScheme(String)` (associated value carries the offending scheme).
+- **HTTPS required** for non-loopback hosts; plain `http://` is accepted only for `localhost`, `127.0.0.1`, and `::1`, otherwise `.insecureScheme`.
+- **IP-literal hosts** are bucketed by address class: `.privateHost` for RFC 1918 (`10/8`, `172.16/12`, `192.168/16`); `.linkLocalHost` for IPv4 `169.254/16` (including `169.254.169.254` cloud metadata) and IPv6 `fe80::/10`; `.ipv6UniqueLocal` for `fc00::/7`; `.ipv4MappedLoopback` for `::ffff:0:0/96` (would otherwise bypass the IPv4 filter); `.multicastReserved` for `0.0.0.0/8`, non-`127.0.0.1` encodings in `127/8`, `224/4` multicast, and `240/4` reserved.
 - **Trailing-dot FQDNs** (`https://192.168.1.1.`) are canonicalised so they cannot bypass the gate.
 
-What this check does **not** do: it does not resolve DNS names (validation runs synchronously from SwiftUI forms and must stay fast), and it does not defeat **DNS rebinding** — the resolver's answer at request time may differ from any answer observed at validation time. Deployments that need that guarantee should add a request-layer mitigation (reject private IPs returned by `URLSession` host resolution, or pin resolution to a known resolver).
+What this check does **not** do: it does not resolve DNS names (validation runs synchronously from SwiftUI forms), and it does not defeat **DNS rebinding** — the resolver's answer at request time may differ from any answer observed at validation time. Deployments that need that guarantee should add a request-layer mitigation (reject private IPs returned by `URLSession` host resolution, or pin resolution to a known resolver).
 
 ## Credentials and API keys
 
@@ -48,15 +58,17 @@ What this check does **not** do: it does not resolve DNS names (validation runs 
 
 Keys are stored in the system Keychain via ``KeychainService``, keyed by each endpoint's UUID. The access class is `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` — keys are unavailable while the device is locked and **do not** sync via iCloud Keychain. The service name comes from `BaseChatConfiguration.shared.keychainServiceName`, so apps sharing a team ID stay isolated.
 
-`KeychainService.store(key:account:)` and `KeychainService.delete(account:)` **throw** `KeychainError` on failure; `retrieve(account:)` returns `nil` because a missing item is a normal state. `KeychainError.localizedDescription` maps common `OSStatus` codes (locked device, missing entitlement, auth failure) to a user-facing string; `KeychainError.osStatus` exposes the raw code for callers that need to branch on it. Backends read the key per request rather than caching it as a stored property, limiting the window where a memory-dump attacker sees the plaintext. `KeychainService.masked(_:)` returns `"sk-a...xyz"` for diagnostics; never log the raw key.
+`KeychainService.store(key:account:)` and `KeychainService.delete(account:)` **throw** `KeychainError` on failure; `retrieve(account:)` returns `nil` because a missing item is a normal state. `KeychainError.localizedDescription` maps common `OSStatus` codes (locked device, missing entitlement, auth failure) to a user-facing string; `KeychainError.osStatus` exposes the raw code. Backends read the key per request rather than caching it as a stored property, limiting the memory-dump window. `KeychainService.masked(_:)` returns `"sk-a...xyz"` for diagnostics; never log the raw key.
 
 **Migration note.** `APIEndpoint.setAPIKey(_:)` and `deleteAPIKey()` are `throws`; call sites must be `try endpoint.setAPIKey(key)`. Surfacing the error is load-bearing — swallowing it leaves the user believing their key is saved when the Keychain actually rejected the write.
+
+**Orphan reaper.** ``BaseChatBootstrap/reapOrphanedKeychainItems(in:)`` runs once from ``SwiftDataPersistenceProvider``'s initialiser and deletes any Keychain item in the framework's service namespace whose owning ``BaseChatSchemaV3/APIEndpoint`` row no longer exists, via ``KeychainService/sweep(validAccounts:)``. Orphans accumulate when the SwiftData row is removed while the paired Keychain delete silently fails, or when rows are wiped directly through SwiftData without routing through the UI. Individual failures log at `.warning` without halting the sweep. Gated by `BaseChatConfiguration.keychainReaperEnabled` (default `true`) — host apps whose test fixtures populate the shared namespace independently should disable it.
 
 ## At-rest data
 
 **Protected (iOS / iPadOS / tvOS / watchOS):** the SwiftData store is sealed by Data Protection until the user first unlocks the device after reboot.
 
-``ModelContainerFactory/makeContainer(configurations:)`` applies the file-protection class configured via `BaseChatConfiguration.fileProtectionClass` to the store file and its SQLite `-shm` / `-wal` sidecars. The default is `.completeUntilFirstUserAuthentication` — sensitive data is protected at rest, but background tasks (silent pushes, downloads resumed after app termination) still work. Set `.complete` for the strongest sealing (breaks background reads while locked), or `nil` to opt out entirely:
+``ModelContainerFactory/makeContainer(configurations:)`` applies the file-protection class configured via `BaseChatConfiguration.fileProtectionClass` to the store file and its SQLite `-shm` / `-wal` sidecars. The default `.completeUntilFirstUserAuthentication` protects data at rest while letting background tasks (silent pushes, resumed downloads) still work. Set `.complete` for the strongest sealing (breaks background reads while locked) or `nil` to opt out:
 
 ```swift
 BaseChatConfiguration.shared = BaseChatConfiguration(
@@ -70,19 +82,31 @@ On macOS and Mac Catalyst, file-level protection is a no-op — at-rest protecti
 
 **Protected:** a hostile proxy, a misconfigured custom endpoint, or an upstream bug cannot inject HTML, invisible bidi characters, or leaked tokens into the chat UI via an error message.
 
-Before any cloud error body is surfaced through `CloudBackendError.serverError(statusCode:message:)`, `SSECloudBackend.checkStatusCode(_:bytes:)` runs it through `CloudErrorSanitizer.sanitize(_:host:)`. The sanitiser strips control bytes (C0/C1), zero-width joiners, BOMs, and bidirectional overrides; collapses whitespace; rejects HTML-shaped bodies (`<` followed by an ASCII letter — Cloudflare 5xx pages, proxy interstitials) and substitutes `"Server error from <host>"`; redacts messages containing a URL scheme or a JWT prefix (`eyJ`), which almost always means the upstream is echoing a token or callback URL; and truncates to 256 characters with an ellipsis.
+Before any cloud error body is surfaced through `CloudBackendError.serverError(statusCode:message:)`, `SSECloudBackend.checkStatusCode(_:bytes:)` runs it through `CloudErrorSanitizer.sanitize(_:host:)`. The sanitiser strips control bytes (C0/C1), zero-width joiners, BOMs, and bidirectional overrides; collapses whitespace; replaces HTML-shaped bodies (Cloudflare 5xx pages, proxy interstitials) with `"Server error from <host>"`; redacts messages containing a URL scheme or JWT prefix (`eyJ`) — almost always an echoed token or callback URL; and truncates to 256 characters. Raw bodies log at `privacy: .debug` only, and never reach the UI unfiltered.
 
-Raw bodies are logged via `Log.*` at `privacy: .debug` only — they never appear in production Console output, and never reach the UI unfiltered.
+## SSE stream bounds
+
+**Protected:** a hostile upstream (or a compromised proxy) cannot hand the client an unbounded stream that exhausts memory or pins the event loop.
+
+Every SSE stream is consumed through ``SSEStreamParser`` under ``SSEStreamLimits``. The defaults (``SSEStreamLimits/default``) cap a single event payload at **1 MB** (big enough for chunked usage payloads and tool-call metadata, small enough to reject a pathological event), cumulative stream bytes at **50 MB** (hours of conversation tokens without unbounded memory growth), and event yield rate at **5,000 events/second** (roughly 100× real provider throughput). There is deliberately no "unlimited" option — bounded caps are the point.
+
+Violations surface through the existing `AsyncThrowingStream` failure channel as ``SSEStreamError/eventTooLarge(_:)``, ``SSEStreamError/streamTooLarge(_:)``, or ``SSEStreamError/eventRateExceeded(_:)``, so backend retry and error-UI logic works unchanged. Tune globally via `BaseChatConfiguration.shared.sseStreamLimits`, or per backend via the `sseStreamLimits: SSEStreamLimits?` override on each ``SSECloudBackend`` instance:
+
+```swift
+BaseChatConfiguration.shared.sseStreamLimits = SSEStreamLimits(
+    maxEventBytes: 64_000,
+    maxTotalBytes: 1_000_000,
+    maxEventsPerSecond: 500
+)
+```
 
 ## Model downloads
 
 **Protected:** a malicious HuggingFace manifest (`../../Library/Preferences/…`) cannot write outside the models directory, and a previous-run crash cannot accumulate multi-GB temp files indefinitely.
 
-``DownloadableModel/validate(fileName:)`` runs at the earliest point a filename enters the system (manifest parsing, Hub search results, snapshot downloads) and rejects: empty or `>= 255` characters (POSIX `NAME_MAX`); any backslash (never legitimate on Apple platforms); any control character (C0, DEL, C1 — truncation hazards and invisible `U+0085 NEXT LINE` injection); any `..` or `.` component (classic path traversal); a leading, trailing, or consecutive `/`; more than one `/` (only `<namespace>/<name>` is honoured — `a/b/c` is rejected rather than silently accepting a sub-path write); and any component beginning with `.` (hides the file and collides with `.DS_Store`, `.git`).
+``DownloadableModel/validate(fileName:)`` runs at the earliest point a filename enters the system (manifest parsing, Hub search results, snapshot downloads) and rejects: empty or `>= 255` characters (POSIX `NAME_MAX`); backslashes; control characters (C0, DEL, C1 — truncation hazards and invisible `U+0085 NEXT LINE` injection); `..` or `.` components; leading, trailing, or consecutive `/`; more than one `/` (only `<namespace>/<name>` is honoured); and any component starting with `.` (hides the file and collides with `.DS_Store`, `.git`). Placement into `modelsDirectory` additionally enforces a `.standardized.path` prefix check, so a filename that slips past structural validation still cannot escape the models directory.
 
-Placement into `modelsDirectory` additionally enforces a `.standardized.path` prefix check, so a filename that slips past structural validation still cannot escape the models directory.
-
-**Stale-temp sweep.** `BackgroundDownloadManager.cleanupStaleTempFiles()` runs on launch from `reconnectBackgroundSession()`. It removes regular files in `FileManager.default.temporaryDirectory` that match *all* of: filename prefix `"basechatkit-dl-"`, extension `"download"`, and modification date older than 24 hours. The prefix keeps the sweep from touching files produced by other subsystems; the 24-hour floor keeps it from clobbering an in-flight download that the system's background transfer service hasn't handed back yet.
+**Stale-temp sweep.** `BackgroundDownloadManager.cleanupStaleTempFiles()` runs on launch from `reconnectBackgroundSession()` and removes regular files in `FileManager.default.temporaryDirectory` matching *all* of: prefix `"basechatkit-dl-"`, extension `"download"`, and modification date older than 24 hours. The prefix scopes the sweep; the 24-hour floor avoids clobbering an in-flight download the system's background transfer service hasn't handed back yet.
 
 ## Regex ReDoS
 
@@ -98,13 +122,13 @@ GGUF models do not apply their own chat templates, so ``PromptTemplate`` wraps m
 
 ## Observability
 
-`Log.*` calls use `privacy: .private` for credentials, prompts, and user content; `privacy: .public` is reserved for stable identifiers (host names, chosen file names, task phases, `OSStatus` codes). Mirror the same discipline in your own integration code — Console redaction is lost the moment a single `%{public}s` leaks a secret.
+`Log.*` calls use `privacy: .private` for credentials, prompts, and user content; `privacy: .public` is reserved for stable identifiers (host names, file names, task phases, `OSStatus` codes). Mirror the same discipline in your own code — Console redaction is lost the moment a single `%{public}s` leaks a secret.
 
 ## Prompt injection — explicit disclaimer
 
-**Prompt injection is inherent to the LLM-chat domain and BaseChatKit does not solve it.** The framework does not sanitize the semantic boundary between system prompt and user content; only the structural special-token strip above. System prompts are not a security boundary — any user, or any document pasted into context, can override them with enough determination. Tool calls, retrieved content, and pasted web pages are untrusted input from the model's perspective; treat their influence on the conversation the way you would treat a cross-origin iframe.
+**Prompt injection is inherent to the LLM-chat domain and BaseChatKit does not solve it.** The framework does not sanitize the semantic boundary between system prompt and user content — only the structural special-token strip above. System prompts are not a security boundary; any user or pasted document can override them. Tool calls, retrieved content, and pasted web pages are untrusted input from the model's perspective — treat them the way you would a cross-origin iframe.
 
-Mitigations, in roughly increasing cost: use structured message formats (provider `tool_use` payloads, JSON schemas) rather than stuffing instructions into prose; add a content-filtering layer before user-uploaded documents reach the model; keep capability scopes small — a tool that reads today's calendar is much cheaper to expose than one that sends email.
+Mitigations, in roughly increasing cost: use structured message formats (provider `tool_use` payloads, JSON schemas) rather than stuffing instructions into prose; add a content filter before user-uploaded documents reach the model; keep tool capability scopes small — a calendar reader is much cheaper to expose than email send.
 
 ## Out of scope
 
@@ -112,7 +136,7 @@ The framework does not attempt to protect against DNS rebinding; user-installed 
 
 ## Roadmap
 
-In progress, not yet on `main`: SSE stream size and rate caps (hostile-server DoS); Keychain orphan reaper (prunes items whose owning `APIEndpoint` has been deleted); GGUF SHA manifest verification for downloaded weights.
+The remaining hardening item not yet on `main` is **GGUF signed-manifest verification** — checking a signed SHA manifest for downloaded weights so a MITM or a tampered mirror cannot swap in a different model file under the same filename. Tracked in [issue #367](https://github.com/roryford/BaseChatKit/issues/367).
 
 ## Reporting a vulnerability
 

--- a/Sources/BaseChatCore/BaseChatCore.docc/BaseChatCore.md
+++ b/Sources/BaseChatCore/BaseChatCore.docc/BaseChatCore.md
@@ -29,6 +29,10 @@ Backends are registered as factories so BaseChatCore stays free of any direct ML
 
 - <doc:GettingStarted>
 
+### Security
+
+- <doc:SecurityModel>
+
 ### Configuration
 
 - ``BaseChatConfiguration``


### PR DESCRIPTION
## Summary

Adds a DocC article at `Sources/BaseChatCore/BaseChatCore.docc/Articles/SecurityModel.md` giving integrators a single page that explains the framework's security posture. Referenced from the BaseChatCore DocC index (`## Topics` → Security) and linked from the README Security section.

Docs-only change. No code touched. `Package.resolved` not modified.

## What's covered (matches what's on `main` today)

- **Transport** — Certificate pinning via `PinnedSessionDelegate`. GTS WE1 + GTS Root R4 for `api.anthropic.com` and `api.openai.com`. Fail-closed on required hosts, default trust for custom hosts unless pinned, localhost bypass. Pin rotation procedure.
- **Credentials** — Keychain via `KeychainService` with `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`, no iCloud sync, just-in-time retrieval, `masked(_:)` for logs. `store` / `delete` currently return `Bool`.
- **At-rest data** — SwiftData file protection, no payload encryption; note about layering your own if you need strict-while-locked.
- **Custom endpoints** — `APIEndpoint.isValid` does a structural check and requires HTTPS for non-localhost. Explicitly notes it does not enumerate RFC 1918 / link-local today.
- **Prompt template hardening** — Per-format special-token stripping in `PromptTemplate.sanitize`.
- **Downloads** — `BackgroundDownloadManager` path-traversal containment (staging + final-placement prefix checks).
- **Observability** — `privacy: .private` discipline in `Log.*`.
- **Prompt injection** — Explicit disclaimer: BCK does not solve prompt injection, system prompts are not a security boundary, only structural special tokens are stripped. Recommends tool_use / content filters / small capability scopes.

## What's explicitly out of scope

DNS rebinding, user-installed MITM certs, compromised OS, jailbroken devices, shared-Mac side channels, supply-chain on pre-built weights (GGUF SHA manifest marked **roadmap**, not current), physical access / social engineering.

## Honest roadmap section

The task brief referenced seven just-shipped security PRs, but most of that work lives on unmerged `security/*` branches today. Rather than claim defenses the code doesn't yet implement, those items are listed under a **Roadmap** section — to be promoted into the main narrative as the PRs land:

- Private/link-local rejection inside `APIEndpoint.isValid`
- SSE stream size / rate caps
- Upstream error-body sanitization
- Throwing Keychain APIs
- Dedicated filename validator + orphan temp sweep
- ReDoS-bounded quantization regex
- GGUF SHA manifest verification

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 83 passed
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 69 passed
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 431 passed
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 63 passed
- [x] Word count: 1370 / 1500 cap
- [x] DocC symbol references use `` ``Type`` `` / `` ``Type/member`` `` form, article registered via `<doc:SecurityModel>` under a new "Security" topic group

## Release Note

**Security model DocC page** — Integrators now have a single, source-backed article (`<doc:SecurityModel>` under BaseChatCore) that documents what the framework actually protects against today, what remains their responsibility, and which defenses are on the near-term roadmap. Covers certificate pinning, Keychain storage, HTTPS enforcement, download path containment, prompt-template token stripping, logger privacy, and an explicit prompt-injection disclaimer. Linked from the README Security section.