### PR TITLE
fix(security): small hardening — HTML check guard + pin doc DocC attachment

### DIFF
--- a/Sources/BaseChatBackends/CloudErrorSanitizer.swift
+++ b/Sources/BaseChatBackends/CloudErrorSanitizer.swift
@@ -161,8 +161,19 @@ enum CloudErrorSanitizer {
 
     /// Returns `true` when the string contains `<` directly followed by an
     /// ASCII letter, indicating an HTML tag opener.
-    private static func containsHTMLTag(_ s: String) -> Bool {
+    ///
+    /// The pairwise scan expresses its upper bound as `scalars.count - 1`, so
+    /// it must not be called with fewer than two scalars — with zero scalars
+    /// the range would trap as `0..<-1`. `sanitize(_:host:)` already early-
+    /// returns for empty input, but we guard here defensively because a
+    /// reorder upstream would otherwise be a crash rather than a logic bug.
+    ///
+    /// Exposed at `internal` so that unit tests can exercise the empty and
+    /// single-character edge cases without having to round-trip through
+    /// `sanitize(_:host:)`'s early returns.
+    static func containsHTMLTag(_ s: String) -> Bool {
         let scalars = Array(s.unicodeScalars)
+        guard scalars.count >= 2 else { return false }
         for i in 0..<(scalars.count - 1) where scalars[i].value == 0x3C { // '<'
             let next = scalars[i + 1].value
             let isLetter = (next >= 0x41 && next <= 0x5A) || (next >= 0x61 && next <= 0x7A)

--- a/Sources/BaseChatBackends/PinnedSessionDelegate.swift
+++ b/Sources/BaseChatBackends/PinnedSessionDelegate.swift
@@ -15,6 +15,11 @@ final class PinnedSessionDelegate: NSObject, @preconcurrency URLSessionDelegate 
 
     // MARK: - Pin Sets
 
+    // NSLock guards concurrent reads/writes from multiple URLSession delegate
+    // callback threads, which can arrive on arbitrary background threads.
+    private static let _pinnedHostsLock = NSLock()
+    private nonisolated(unsafe) static var _pinnedHosts: [String: Set<String>] = [:]
+
     /// SPKI SHA-256 hashes for known API hosts.
     ///
     /// To generate a pin from a certificate:
@@ -42,11 +47,6 @@ final class PinnedSessionDelegate: NSObject, @preconcurrency URLSessionDelegate 
     /// pointing a provider at a private gateway with its own CA) can write
     /// directly to `pinnedHosts` before any network requests are issued; values
     /// set by the host app are preserved by `loadDefaultPins()`.
-    // NSLock guards concurrent reads/writes from multiple URLSession delegate
-    // callback threads, which can arrive on arbitrary background threads.
-    private static let _pinnedHostsLock = NSLock()
-    private nonisolated(unsafe) static var _pinnedHosts: [String: Set<String>] = [:]
-
     public static var pinnedHosts: [String: Set<String>] {
         get {
             _pinnedHostsLock.lock()
@@ -59,6 +59,10 @@ final class PinnedSessionDelegate: NSObject, @preconcurrency URLSessionDelegate 
             _pinnedHosts = newValue
         }
     }
+
+    // One-shot guard so `loadDefaultPins()` is idempotent across callers.
+    private nonisolated(unsafe) static var _defaultPinsLoaded = false
+
     /// Populates pin sets for known production hosts on first access.
     ///
     /// Pins target the intermediate CA (Google Trust Services WE1) and its
@@ -70,8 +74,6 @@ final class PinnedSessionDelegate: NSObject, @preconcurrency URLSessionDelegate 
     /// 1. Run the `openssl` pipeline from the doc comment above for each host.
     /// 2. Add the *new* intermediate/root pins to the set **before** removing old ones.
     /// 3. Ship the update. Once no connections use the old chain, remove stale pins.
-    private nonisolated(unsafe) static var _defaultPinsLoaded = false
-
     static func loadDefaultPins() {
         _pinnedHostsLock.lock()
         defer { _pinnedHostsLock.unlock() }

--- a/Tests/BaseChatBackendsTests/CloudErrorSanitizerTests.swift
+++ b/Tests/BaseChatBackendsTests/CloudErrorSanitizerTests.swift
@@ -32,6 +32,20 @@ struct CloudErrorSanitizerTests {
         #expect(out == msg)
     }
 
+    // Directly exercises the pairwise scan's empty and single-character
+    // boundary. `sanitize(_:host:)` early-returns on empty input today, but
+    // the scan expresses its upper bound as `scalars.count - 1` and would
+    // crash with `0..<-1` if a future reorder let empty input reach it.
+    @Test func test_containsHTMLTag_empty_returnsFalse() {
+        #expect(CloudErrorSanitizer.containsHTMLTag("") == false)
+    }
+
+    @Test func test_containsHTMLTag_singleChar_returnsFalse() {
+        // A bare `<` cannot be a tag opener — there is no next scalar to be
+        // an ASCII letter.
+        #expect(CloudErrorSanitizer.containsHTMLTag("<") == false)
+    }
+
     // MARK: - Length cap
 
     @Test func longMessage_isTruncatedTo256WithEllipsis() {


### PR DESCRIPTION
## Summary

Two tiny hardening fixes in `BaseChatBackends`:

1. Add a defensive `guard scalars.count >= 2 else { return false }` at the top of `CloudErrorSanitizer.containsHTMLTag`, preventing a `0..<-1` range trap if a future reorder lets empty input reach the pairwise scan.
2. Move the `///` pin-set doc block so it sits directly above `public static var pinnedHosts`, restoring the DocC attachment that was silently landing on the private `_pinnedHostsLock` storage.

Stacked on `security/upstream-error-sanitization` (PR #364) because fix #1 touches `CloudErrorSanitizer.swift`, which is introduced by that PR. Rebase onto `main` once #364 merges.

## Why

**Fix #1 — `containsHTMLTag` empty-input near-crash.**

`containsHTMLTag` scans pairs of scalars using `0..<(scalars.count - 1)`. If it is ever called with an empty string the expression becomes `0..<-1`, which traps at runtime (`Range requires lowerBound <= upperBound`). `sanitize(_:host:)` already early-returns on empty input, so the crash is unreachable today — but the guard lives one function away, and a reorder (or a future helper that re-calls `containsHTMLTag` on cleaned input without checking) would turn a logic bug into a full-process crash, including inside the UI when an error flow runs.

The guard is three tokens and costs nothing. The function's access goes from `private` to the enum's default `internal` so the regression tests can call it directly at the `""` / `"<"` boundary, rather than relying on `sanitize`'s pre-checks to keep them out of harm's way.

**Fix #2 — `PinnedSessionDelegate.pinnedHosts` DocC attachment.**

The `///` block describing the pin sets (how to generate pins, which hosts fail closed, etc.) was separated from `public static var pinnedHosts` by a `//` non-doc comment and two `private` declarations (`_pinnedHostsLock`, `_pinnedHosts`). DocC attaches a `///` block to the next declaration — so the pin-set documentation was landing on `_pinnedHostsLock`, a file-private implementation detail, and the *actual* public API (`pinnedHosts`) had no doc attached at all.

The reorder puts private storage + its `//` comment first, then the `///` doc block directly above `public static var pinnedHosts`. No behavioural change; only the generated DocC output changes.

## Test plan

- [x] Added `test_containsHTMLTag_empty_returnsFalse` + `test_containsHTMLTag_singleChar_returnsFalse` in `CloudErrorSanitizerTests.swift`.
- [x] Sabotage check: removed the new guard and re-ran the tests. `test_containsHTMLTag_empty_returnsFalse` fails with `Fatal error: Range requires lowerBound <= upperBound`. Guard restored.
- [x] Full CI suite runs green locally: `BaseChatCoreTests`, `BaseChatInferenceTests`, `BaseChatUITests`, `BaseChatBackendsTests` (`--disable-default-traits`, as per CLAUDE.md).
- [x] `PinnedSessionDelegateTests` (12 tests) still pass after the reorder — storage/access semantics are unchanged.
- [x] Visually verified: the `///` block in `PinnedSessionDelegate.swift` is now the line immediately above `public static var pinnedHosts`.

## Release Note

**Hardening: HTML-tag scanner guarded, pin-set docs now attach to the right API.** `CloudErrorSanitizer.containsHTMLTag` now guards against empty input at the function boundary, so a future caller that skips `sanitize(_:host:)`'s early-return can't trap the process with a `0..<-1` range. The `PinnedSessionDelegate.pinnedHosts` DocC comment block previously attached to a private NSLock because a `//` comment and the private storage declarations sat between the doc block and the public property; reordering the declarations restores the docs on the right API surface. Pure documentation and defensive hardening — no behavioural change.