### PR TITLE
feat(security): apply NSFileProtectionCompleteUntilFirstUserAuthentication to SwiftData store

### DIFF
--- a/Sources/BaseChatCore/ModelContainerFactory.swift
+++ b/Sources/BaseChatCore/ModelContainerFactory.swift
@@ -1,4 +1,6 @@
+import Foundation
 import SwiftData
+import BaseChatInference
 
 /// Creates `ModelContainer` instances configured with the current schema.
 ///
@@ -11,6 +13,15 @@ import SwiftData
 /// // In-memory store (tests, previews, ephemeral sessions)
 /// let container = try ModelContainerFactory.makeInMemoryContainer()
 /// ```
+///
+/// On iOS, tvOS, and watchOS the factory applies the Data Protection class
+/// configured via ``BaseChatConfiguration/fileProtectionClass`` to the store
+/// file (and its SQLite `-shm` / `-wal` sidecars). The default class is
+/// `.completeUntilFirstUserAuthentication`, which keeps chat history
+/// unreadable until the user first unlocks the device after reboot while
+/// still allowing background tasks to read the database. Protection is a
+/// no-op on macOS and Mac Catalyst (where at-rest protection is handled by
+/// FileVault) and on in-memory stores.
 public enum ModelContainerFactory {
     /// The current schema version.
     public static var currentSchema: any VersionedSchema.Type {
@@ -26,10 +37,12 @@ public enum ModelContainerFactory {
     public static func makeContainer(
         configurations: [ModelConfiguration] = [ModelConfiguration()]
     ) throws -> ModelContainer {
-        try ModelContainer(
+        let container = try ModelContainer(
             for: Schema(versionedSchema: currentSchema),
             configurations: configurations
         )
+        applyFileProtection(to: configurations)
+        return container
     }
 
     /// Returns an ephemeral in-memory `ModelContainer` configured with the
@@ -44,4 +57,71 @@ public enum ModelContainerFactory {
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         return try makeContainer(configurations: [config])
     }
+
+    // MARK: - File Protection
+
+    /// Applies the configured Data Protection class to each on-disk store
+    /// backing `configurations`, including any SQLite `-shm` / `-wal` sidecars
+    /// SwiftData may have created alongside the main store file.
+    ///
+    /// This is a best-effort hardening step: failures are logged and swallowed
+    /// because a missing protection attribute should never block container
+    /// creation. No-op on macOS / Mac Catalyst and for in-memory stores.
+    private static func applyFileProtection(to configurations: [ModelConfiguration]) {
+        #if (os(iOS) || os(tvOS) || os(watchOS)) && !targetEnvironment(macCatalyst)
+        guard let protection = BaseChatConfiguration.shared.fileProtectionClass else {
+            return
+        }
+        for config in configurations where !isInMemoryStore(config) {
+            applyProtection(protection, toStoreAt: config.url)
+        }
+        #endif
+    }
+
+    #if (os(iOS) || os(tvOS) || os(watchOS)) && !targetEnvironment(macCatalyst)
+    /// Applies `protection` to `storeURL` plus any sibling files SwiftData may
+    /// have created for SQLite WAL journalling (`<name>-shm`, `<name>-wal`).
+    private static func applyProtection(
+        _ protection: FileProtectionType,
+        toStoreAt storeURL: URL
+    ) {
+        let fm = FileManager.default
+        let attributes: [FileAttributeKey: Any] = [.protectionKey: protection]
+
+        setAttributes(attributes, at: storeURL.path)
+
+        // Sidecars live in the same directory and share the store basename.
+        let directory = storeURL.deletingLastPathComponent()
+        let baseName = storeURL.lastPathComponent
+        guard let entries = try? fm.contentsOfDirectory(atPath: directory.path) else {
+            return
+        }
+        for entry in entries where entry != baseName && entry.hasPrefix(baseName) {
+            setAttributes(attributes, at: directory.appendingPathComponent(entry).path)
+        }
+    }
+
+    private static func setAttributes(
+        _ attributes: [FileAttributeKey: Any],
+        at path: String
+    ) {
+        guard FileManager.default.fileExists(atPath: path) else { return }
+        do {
+            try FileManager.default.setAttributes(attributes, ofItemAtPath: path)
+        } catch {
+            Log.persistence.warning(
+                "Failed to apply file protection to SwiftData store at \(path, privacy: .private): \(error.localizedDescription)"
+            )
+        }
+    }
+
+    /// Returns `true` if `config` represents an in-memory SwiftData store.
+    ///
+    /// `ModelConfiguration` doesn't expose `isStoredInMemoryOnly` publicly, but
+    /// in-memory configurations resolve `url` to `/dev/null`, which is easy to
+    /// detect and never a legitimate on-disk target.
+    private static func isInMemoryStore(_ config: ModelConfiguration) -> Bool {
+        config.url.path == "/dev/null"
+    }
+    #endif
 }

--- a/Sources/BaseChatInference/BaseChatConfiguration.swift
+++ b/Sources/BaseChatInference/BaseChatConfiguration.swift
@@ -41,16 +41,34 @@ public struct BaseChatConfiguration: Sendable {
     /// simplify the interface or lock down functionality for specific deployments.
     public var features: Features
 
+    /// Data Protection class applied to the SwiftData store on iOS/tvOS/watchOS.
+    ///
+    /// Defaults to `.completeUntilFirstUserAuthentication` — the store is sealed
+    /// until the user unlocks the device once after reboot, then remains
+    /// accessible until the next reboot. This is the right balance for a chat
+    /// app: sensitive data is protected at rest, but background tasks (silent
+    /// pushes, downloads resumed after app termination) continue to work.
+    ///
+    /// Set to `.complete` for the strongest protection (file is sealed whenever
+    /// the device is locked) — note this breaks background reads while locked.
+    /// Set to `nil` to opt out entirely (not recommended; the OS default applies).
+    ///
+    /// This value is ignored on macOS and Mac Catalyst, where at-rest protection
+    /// is handled by FileVault. It is also ignored for in-memory SwiftData stores.
+    public var fileProtectionClass: FileProtectionType?
+
     public init(
         appName: String = "BaseChatKit",
         bundleIdentifier: String = "com.basechatkit",
         modelsDirectoryName: String = "Models",
-        features: Features = Features()
+        features: Features = Features(),
+        fileProtectionClass: FileProtectionType? = .completeUntilFirstUserAuthentication
     ) {
         self.appName = appName
         self.bundleIdentifier = bundleIdentifier
         self.modelsDirectoryName = modelsDirectoryName
         self.features = features
+        self.fileProtectionClass = fileProtectionClass
     }
 
     // MARK: - Derived identifiers

--- a/Tests/BaseChatCoreTests/ModelContainerFileProtectionTests.swift
+++ b/Tests/BaseChatCoreTests/ModelContainerFileProtectionTests.swift
@@ -1,0 +1,204 @@
+import XCTest
+import SwiftData
+@testable import BaseChatCore
+import BaseChatInference
+
+/// Tests covering the Data Protection attribute applied to the SwiftData
+/// store by ``ModelContainerFactory`` on iOS/tvOS/watchOS.
+///
+/// These are integration tests: they write real SwiftData stores to the
+/// filesystem and inspect `URLResourceValues` on the resulting files.
+final class ModelContainerFileProtectionTests: XCTestCase {
+
+    private var tempStoreDirectory: URL?
+    private var originalFileProtectionClass: FileProtectionType?
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        originalFileProtectionClass = BaseChatConfiguration.shared.fileProtectionClass
+    }
+
+    override func tearDownWithError() throws {
+        if let tempStoreDirectory {
+            try? FileManager.default.removeItem(at: tempStoreDirectory)
+        }
+        tempStoreDirectory = nil
+        BaseChatConfiguration.shared.fileProtectionClass = originalFileProtectionClass
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Helpers
+
+    /// Creates an isolated per-test directory under the system temp folder.
+    /// Captured in `tempStoreDirectory` so `tearDown` can clean it up even if
+    /// assertions fail mid-test.
+    private func makeTempStoreURL() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BaseChatFileProtection-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        tempStoreDirectory = directory
+        return directory.appendingPathComponent("BaseChat.sqlite")
+    }
+
+    /// Reads the Data Protection class from `url` via `FileManager` attributes.
+    /// Returns `nil` if the key is unset (expected on macOS) or the file is
+    /// missing. We read via `attributesOfItem(atPath:)` rather than
+    /// `URLResourceValues` because the latter has known Swift type-checker
+    /// issues around `fileProtection` in some SDK/compiler combinations.
+    private func readFileProtection(at url: URL) -> FileProtectionType? {
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path) else {
+            return nil
+        }
+        guard let raw = attrs[.protectionKey] as? String else { return nil }
+        return FileProtectionType(rawValue: raw)
+    }
+
+    // MARK: - iOS / tvOS / watchOS: protection IS applied
+
+    func test_makeContainer_appliesDefaultFileProtection_onMobilePlatforms() throws {
+        #if !(os(iOS) || os(tvOS) || os(watchOS)) || targetEnvironment(macCatalyst)
+        try XCTSkipIf(true, "File protection only applies on iOS/tvOS/watchOS (not macOS or Catalyst)")
+        #else
+        // Default config should be .completeUntilFirstUserAuthentication.
+        XCTAssertEqual(
+            BaseChatConfiguration().fileProtectionClass,
+            .completeUntilFirstUserAuthentication
+        )
+
+        let storeURL = try makeTempStoreURL()
+        let config = ModelConfiguration(url: storeURL)
+        _ = try ModelContainerFactory.makeContainer(configurations: [config])
+
+        XCTAssertEqual(
+            readFileProtection(at: storeURL),
+            BaseChatConfiguration.shared.fileProtectionClass
+        )
+        #endif
+    }
+
+    func test_makeContainer_honoursCustomProtectionClass() throws {
+        #if !(os(iOS) || os(tvOS) || os(watchOS)) || targetEnvironment(macCatalyst)
+        try XCTSkipIf(true, "File protection only applies on iOS/tvOS/watchOS")
+        #else
+        BaseChatConfiguration.shared.fileProtectionClass = .complete
+
+        let storeURL = try makeTempStoreURL()
+        let config = ModelConfiguration(url: storeURL)
+        _ = try ModelContainerFactory.makeContainer(configurations: [config])
+
+        XCTAssertEqual(readFileProtection(at: storeURL), .complete)
+        #endif
+    }
+
+    func test_makeContainer_optOut_doesNotRaiseProtection() throws {
+        #if !(os(iOS) || os(tvOS) || os(watchOS)) || targetEnvironment(macCatalyst)
+        try XCTSkipIf(true, "File protection only applies on iOS/tvOS/watchOS")
+        #else
+        // With opt-out (`fileProtectionClass == nil`), the factory must skip
+        // setAttributes entirely. We verify this by comparing against a
+        // non-opted-out run at `.complete`: the opt-out store must NOT carry
+        // `.complete`, while the non-opt-out store must.
+        BaseChatConfiguration.shared.fileProtectionClass = nil
+
+        let storeURL = try makeTempStoreURL()
+        let config = ModelConfiguration(url: storeURL)
+        _ = try ModelContainerFactory.makeContainer(configurations: [config])
+
+        XCTAssertNotEqual(
+            readFileProtection(at: storeURL),
+            .complete,
+            "Opt-out should have skipped setAttributes — the store should not carry the strict .complete class"
+        )
+        #endif
+    }
+
+    func test_makeContainer_appliesProtectionToSidecars() throws {
+        #if !(os(iOS) || os(tvOS) || os(watchOS)) || targetEnvironment(macCatalyst)
+        try XCTSkipIf(true, "File protection only applies on iOS/tvOS/watchOS")
+        #else
+        BaseChatConfiguration.shared.fileProtectionClass = .completeUntilFirstUserAuthentication
+
+        let storeURL = try makeTempStoreURL()
+        let config = ModelConfiguration(url: storeURL)
+        let container = try ModelContainerFactory.makeContainer(configurations: [config])
+
+        // Force a write so SwiftData creates any WAL sidecars it needs.
+        let context = ModelContext(container)
+        context.insert(ChatSession(title: "fp-test"))
+        try context.save()
+
+        // Re-apply protection now that sidecars may exist (the factory only
+        // runs once; reopening the container exercises the same code path).
+        _ = try ModelContainerFactory.makeContainer(configurations: [ModelConfiguration(url: storeURL)])
+
+        let directory = storeURL.deletingLastPathComponent()
+        let baseName = storeURL.lastPathComponent
+        let entries = try FileManager.default.contentsOfDirectory(atPath: directory.path)
+        let sidecars = entries.filter { $0 != baseName && $0.hasPrefix(baseName) }
+        // This assertion only has teeth if SwiftData actually produced WAL
+        // sidecars. If it didn't (e.g. journal_mode=delete), sidecars is empty
+        // and the loop below trivially passes — which is the correct outcome:
+        // nothing to protect.
+        for sidecar in sidecars {
+            let url = directory.appendingPathComponent(sidecar)
+            XCTAssertEqual(readFileProtection(at: url), .completeUntilFirstUserAuthentication,
+                           "Sidecar \(sidecar) should inherit the same Data Protection class as the main store")
+        }
+        #endif
+    }
+
+    // MARK: - In-memory stores: protection NOT applied
+
+    func test_inMemoryContainer_doesNotAttemptProtection() throws {
+        // An in-memory store resolves to /dev/null — calling setAttributes on
+        // that would fail with EPERM and spam the log. The factory must skip
+        // in-memory stores entirely on every platform.
+        _ = try ModelContainerFactory.makeInMemoryContainer()
+        // Success == no crash, no log-level failure. We verify the guard is
+        // reachable by also checking an explicit in-memory configuration.
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        _ = try ModelContainerFactory.makeContainer(configurations: [config])
+        XCTAssertEqual(config.url.path, "/dev/null",
+                       "In-memory SwiftData stores resolve to /dev/null — this is the guard the factory keys off")
+    }
+
+    // MARK: - macOS / Catalyst: protection is a no-op
+
+    func test_makeContainer_onMacOS_isNoOp() throws {
+        #if (os(iOS) || os(tvOS) || os(watchOS)) && !targetEnvironment(macCatalyst)
+        try XCTSkipIf(true, "macOS-only test — Data Protection is handled by FileVault")
+        #else
+        // On macOS/Catalyst the factory should complete without error and
+        // never touch the file protection attribute. If the file exists after
+        // container creation, its protection key should be either `nil` or
+        // unchanged from whatever the OS set by default.
+        let storeURL = try makeTempStoreURL()
+        let config = ModelConfiguration(url: storeURL)
+        _ = try ModelContainerFactory.makeContainer(configurations: [config])
+
+        // The key part of this test is just that the call completed: the
+        // #if guards in the factory mean `applyFileProtection` is an empty
+        // function on macOS/Catalyst. Assert the store file exists so we know
+        // we exercised the real code path.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: storeURL.path))
+        #endif
+    }
+
+    // MARK: - Failure isolation
+
+    func test_makeContainer_missingStoreFile_doesNotThrow() throws {
+        // If the store hasn't been written to disk yet at the moment we apply
+        // protection, setAttributes would fail with ENOENT. The factory must
+        // swallow that and log a warning instead of propagating the error:
+        // protection is best-effort, container creation must not regress.
+        //
+        // We simulate the "missing file" path by pointing at a non-existent
+        // URL inside a fresh temp directory before calling makeContainer.
+        // SwiftData will still create the file during container init, but the
+        // exercise is that no throw escapes.
+        let storeURL = try makeTempStoreURL()
+        let config = ModelConfiguration(url: storeURL)
+        XCTAssertNoThrow(try ModelContainerFactory.makeContainer(configurations: [config]))
+    }
+}

--- a/Tests/BaseChatInferenceTests/BaseChatConfigurationTests.swift
+++ b/Tests/BaseChatInferenceTests/BaseChatConfigurationTests.swift
@@ -119,4 +119,25 @@ final class BaseChatConfigurationTests: XCTestCase {
         XCTAssertTrue(features.showCloudAPIManagement)
         XCTAssertFalse(features.showUpgradeHint)
     }
+
+    // MARK: - File Protection
+
+    func test_defaultInit_fileProtectionClass_isCompleteUntilFirstUserAuth() {
+        let config = BaseChatConfiguration()
+        XCTAssertEqual(
+            config.fileProtectionClass,
+            .completeUntilFirstUserAuthentication,
+            "Default Data Protection class must stay at completeUntilFirstUserAuthentication — it balances at-rest protection with background-task compatibility"
+        )
+    }
+
+    func test_customInit_fileProtectionClass_canOptOut() {
+        let config = BaseChatConfiguration(fileProtectionClass: nil)
+        XCTAssertNil(config.fileProtectionClass)
+    }
+
+    func test_customInit_fileProtectionClass_canRaiseToComplete() {
+        let config = BaseChatConfiguration(fileProtectionClass: .complete)
+        XCTAssertEqual(config.fileProtectionClass, .complete)
+    }
 }

--- a/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
+++ b/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
@@ -61,6 +61,13 @@ final class SilentCatchAuditTest: XCTestCase {
         "BaseChatInference/Services/GGUFMetadataReader.swift:guard let handle = try? FileHandle(forReadingFrom: url) else { return false }",
         "BaseChatInference/Services/ModelStorageService.swift:guard let contents = try? fileManager.contentsOfDirectory(",
 
+        // BaseChatCore
+        // File-protection hardening: enumerating the store directory to locate
+        // SQLite WAL sidecars is best-effort. If the directory read fails
+        // (permissions race, parent unmounted), we skip sidecar protection and
+        // the main store is still protected — the error is not actionable.
+        "BaseChatCore/ModelContainerFactory.swift:guard let entries = try? fm.contentsOfDirectory(atPath: directory.path) else {",
+
         // BaseChatBackends
         "BaseChatBackends/ClaudeBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],",
         "BaseChatBackends/OllamaBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {",


### PR DESCRIPTION
## Summary

- `ModelContainerFactory.makeContainer(configurations:)` now applies a configurable Data Protection class to the SwiftData store file (and any SQLite `-shm`/`-wal` sidecars) on iOS, tvOS, and watchOS after the container is created.
- Default class is `.completeUntilFirstUserAuthentication`, surfaced via a new `BaseChatConfiguration.shared.fileProtectionClass` knob so hosts can raise to `.complete`, keep the default, or opt out with `nil`.
- No-op on macOS and Mac Catalyst (FileVault covers at-rest protection) and on in-memory stores (`/dev/null`-backed configurations).

## Why

SwiftData has no built-in at-rest encryption; the chat database inherits only whatever default Data Protection class the OS applies to the app sandbox. Anyone with physical access to an unlocked-before-reboot device (e.g. a lost phone that was unlocked at least once since boot) can exfiltrate the SQLite file. Applying `NSFileProtectionCompleteUntilFirstUserAuthentication` keeps the store sealed across reboots until the user first unlocks, bringing BaseChatKit in line with standard iOS data-protection guidance for personal messaging data.

## Trade-off: why `CompleteUntilFirstUserAuthentication` and not `Complete`?

- `.complete` is the strictest class — the file is sealed whenever the device is locked, even mid-session. That breaks background URLSession downloads, silent pushes, and anything that needs to read the DB while locked. For a chat app that resumes downloads and posts user notifications in the background, it is too aggressive.
- `.completeUntilFirstUserAuthentication` protects the DB across reboot (the threat model we care about) but keeps it accessible once the user has unlocked even once. This is the class Apple recommends for "sensitive but must work in background".

Hosts with higher security requirements can opt into `.complete` via `BaseChatConfiguration.shared.fileProtectionClass = .complete`.

## Opt-out / override

```swift
// Raise to strictest (breaks background reads while locked):
BaseChatConfiguration.shared.fileProtectionClass = .complete

// Keep default:
// BaseChatConfiguration.shared.fileProtectionClass = .completeUntilFirstUserAuthentication

// Opt out entirely (not recommended; OS default applies):
BaseChatConfiguration.shared.fileProtectionClass = nil
```

Protection failures (e.g. the store file doesn't yet exist on disk when the factory runs) are logged via `Log.persistence.warning` and swallowed — container creation is never blocked by a best-effort hardening step.

## Release Note

**At-rest protection for SwiftData chat history** — BaseChatKit now applies iOS Data Protection to the SwiftData store so chat history cannot be read from a powered-off or just-rebooted device until the user unlocks it. The default class, `NSFileProtectionCompleteUntilFirstUserAuthentication`, balances real-world security with continued compatibility with background downloads and silent notifications. Apps that need stricter behaviour can raise to `.complete`, and apps that embed BaseChatKit in environments with their own policy can opt out via `BaseChatConfiguration.shared.fileProtectionClass = nil`. macOS and Mac Catalyst are unaffected (FileVault covers this at-rest threat model), and in-memory SwiftData stores used in tests and previews are never touched.

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` passes (90 tests; 4 mobile-only tests correctly skipped on macOS)
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` passes (647 tests, including new `BaseChatConfigurationTests` cases for the default class, `.complete` override, and `nil` opt-out)
- [x] `swift test --filter BaseChatUITests --disable-default-traits` passes (431 tests)
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` passes (131 tests)
- [x] SilentCatchAuditTest allowlist updated with reviewer-visible comment for the new best-effort `try?` in sidecar enumeration
- [x] Sabotage-verify: temporarily changed the default `fileProtectionClass` to `.complete` and confirmed `test_defaultInit_fileProtectionClass_isCompleteUntilFirstUserAuth` fails; reverted
- [ ] Full coverage of the iOS code path requires an iOS simulator / device run; the new tests under `ModelContainerFileProtectionTests` are `XCTSkipIf`-guarded on macOS and document the expected behaviour for future device CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)