### PR TITLE
feat(security): reap orphaned Keychain items on boot

### DIFF
--- a/Sources/BaseChatCore/BaseChatBootstrap.swift
+++ b/Sources/BaseChatCore/BaseChatBootstrap.swift
@@ -1,0 +1,49 @@
+import Foundation
+import SwiftData
+import BaseChatInference
+
+/// One-time boot hooks that bridge SwiftData persistence and the framework's
+/// non-persistent services.
+///
+/// Call the entry points here once at app launch — they are idempotent at the
+/// boot-once granularity, but there is no caching; repeated calls do repeated
+/// work. Host apps that use ``SwiftDataPersistenceProvider`` get the default
+/// hooks wired automatically and should not call these directly.
+public enum BaseChatBootstrap {
+
+    /// Removes Keychain items whose owning ``BaseChatSchemaV3/APIEndpoint`` row
+    /// no longer exists.
+    ///
+    /// Orphans accumulate when an endpoint row is deleted while the matching
+    /// Keychain delete silently fails, or when rows are wiped directly through
+    /// SwiftData without routing through the UI. The reaper compares every
+    /// account in the framework's Keychain namespace against the current set of
+    /// endpoint IDs and deletes anything that no longer has an owner.
+    ///
+    /// The sweep is a no-op when
+    /// ``BaseChatInference/BaseChatConfiguration/keychainReaperEnabled`` is
+    /// `false`. Errors (including Keychain access denial in sandboxed contexts)
+    /// are logged and swallowed so a boot hook can never crash the app.
+    ///
+    /// Fire-and-forget — call once per app boot. Returns the number of items
+    /// that were actually reaped, for testing and diagnostics.
+    @discardableResult
+    @MainActor
+    public static func reapOrphanedKeychainItems(in modelContext: ModelContext) -> Int {
+        guard BaseChatConfiguration.shared.keychainReaperEnabled else {
+            return 0
+        }
+
+        let validAccounts: Set<String>
+        do {
+            let descriptor = FetchDescriptor<BaseChatSchemaV3.APIEndpoint>()
+            let endpoints = try modelContext.fetch(descriptor)
+            validAccounts = Set(endpoints.map(\.keychainAccount))
+        } catch {
+            Log.security.warning("BaseChatBootstrap.reapOrphanedKeychainItems: failed to fetch APIEndpoint rows — skipping reap: \(error.localizedDescription)")
+            return 0
+        }
+
+        return KeychainService.sweep(validAccounts: validAccounts)
+    }
+}

--- a/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
+++ b/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
@@ -14,6 +14,15 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
 
     public init(modelContext: ModelContext) {
         self.modelContext = modelContext
+
+        // Reap orphaned Keychain items once per provider instance. Runs
+        // synchronously because ModelContext is not Sendable and deferring
+        // into a Task would race against provider teardown (notably in tests
+        // that rebuild the container per-method). SecItemCopyMatching on the
+        // apikeys namespace completes in milliseconds — a boot-time cost we
+        // accept to guarantee no orphan can outlive its owning endpoint row.
+        // Gated by BaseChatConfiguration.keychainReaperEnabled.
+        BaseChatBootstrap.reapOrphanedKeychainItems(in: modelContext)
     }
 
     // MARK: - Sessions

--- a/Sources/BaseChatInference/BaseChatConfiguration.swift
+++ b/Sources/BaseChatInference/BaseChatConfiguration.swift
@@ -66,13 +66,22 @@ public struct BaseChatConfiguration: Sendable {
     /// untrusted servers can tighten these further.
     public var sseStreamLimits: SSEStreamLimits
 
+    /// When `true`, a boot-time sweep removes Keychain items whose owning
+    /// `APIEndpoint` row no longer exists — recovering storage from orphaned
+    /// credentials left behind by failed deletions or direct SwiftData wipes.
+    ///
+    /// Disable only for test harnesses that populate the framework's Keychain
+    /// namespace independently and don't want their fixtures reaped.
+    public var keychainReaperEnabled: Bool
+
     public init(
         appName: String = "BaseChatKit",
         bundleIdentifier: String = "com.basechatkit",
         modelsDirectoryName: String = "Models",
         features: Features = Features(),
         fileProtectionClass: FileProtectionType? = .completeUntilFirstUserAuthentication,
-        sseStreamLimits: SSEStreamLimits = .default
+        sseStreamLimits: SSEStreamLimits = .default,
+        keychainReaperEnabled: Bool = true
     ) {
         self.appName = appName
         self.bundleIdentifier = bundleIdentifier
@@ -80,6 +89,7 @@ public struct BaseChatConfiguration: Sendable {
         self.features = features
         self.fileProtectionClass = fileProtectionClass
         self.sseStreamLimits = sseStreamLimits
+        self.keychainReaperEnabled = keychainReaperEnabled
     }
 
     // MARK: - Derived identifiers

--- a/Sources/BaseChatInference/Services/KeychainService.swift
+++ b/Sources/BaseChatInference/Services/KeychainService.swift
@@ -168,4 +168,67 @@ public enum KeychainService {
         let suffix = String(key.suffix(3))
         return "\(prefix)...\(suffix)"
     }
+
+    // MARK: - Orphan reaping
+
+    /// Returns every account identifier stored in the framework's Keychain
+    /// service namespace.
+    ///
+    /// Returns an empty array when the namespace is empty or when Keychain
+    /// access is denied (e.g. sandboxed contexts missing the entitlement).
+    static func allAccounts() -> [String] {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+            kSecReturnAttributes as String: true,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        if status == errSecItemNotFound {
+            return []
+        }
+        guard status == errSecSuccess else {
+            Log.security.warning("KeychainService.allAccounts SecItemCopyMatching failed with status \(status)")
+            return []
+        }
+        guard let items = result as? [[String: Any]] else {
+            return []
+        }
+
+        return items.compactMap { $0[kSecAttrAccount as String] as? String }
+    }
+
+    /// Removes every Keychain item in the framework's service namespace whose
+    /// account is not present in `validAccounts`. Returns the number of items
+    /// actually reaped.
+    ///
+    /// Failures on individual items are logged at `.warning` and do not halt
+    /// the sweep — a single bad row should not prevent the rest from being
+    /// reclaimed. Intended to be driven once at boot from ``BaseChatBootstrap``.
+    @discardableResult
+    public static func sweep(validAccounts: Set<String>) -> Int {
+        let stored = allAccounts()
+        guard !stored.isEmpty else {
+            Log.security.info("KeychainService.sweep: namespace empty, nothing to reap")
+            return 0
+        }
+
+        var reaped = 0
+        for account in stored where !validAccounts.contains(account) {
+            do {
+                try KeychainService.delete(account: account)
+                reaped += 1
+            } catch {
+                // Individual failure must not abort the sweep — keep reaping.
+                Log.security.warning("KeychainService.sweep: failed to delete orphaned account: \(error.localizedDescription, privacy: .public)")
+                continue
+            }
+        }
+
+        Log.security.info("KeychainService.sweep: reaped \(reaped) orphaned Keychain item(s) from \(stored.count) stored")
+        return reaped
+    }
 }

--- a/Sources/BaseChatInference/Utilities/Logging.swift
+++ b/Sources/BaseChatInference/Utilities/Logging.swift
@@ -15,4 +15,5 @@ public enum Log {
     public static var ui: Logger { Logger(subsystem: subsystem, category: "ui") }
     public static var network: Logger { Logger(subsystem: subsystem, category: "network") }
     public static var download: Logger { Logger(subsystem: subsystem, category: "download") }
+    public static var security: Logger { Logger(subsystem: subsystem, category: "security") }
 }

--- a/Tests/BaseChatInferenceTests/KeychainServiceSweepTests.swift
+++ b/Tests/BaseChatInferenceTests/KeychainServiceSweepTests.swift
@@ -1,0 +1,121 @@
+import XCTest
+@testable import BaseChatInference
+
+/// Tests for the boot-time Keychain reaper (`allAccounts` and `sweep`).
+///
+/// Each test uses a unique service name so parallel test runs cannot collide
+/// on the shared framework namespace. See `KeychainIntegrationTests` for the
+/// pattern this builds on.
+final class KeychainServiceSweepTests: XCTestCase {
+
+    private var testServiceName: String!
+    private var originalConfig: BaseChatConfiguration!
+
+    override func setUp() {
+        super.setUp()
+        originalConfig = BaseChatConfiguration.shared
+
+        testServiceName = "com.basechatkit.tests.reaper.\(UUID().uuidString)"
+        var config = BaseChatConfiguration.shared
+        config.bundleIdentifier = testServiceName
+        BaseChatConfiguration.shared = config
+    }
+
+    override func tearDown() {
+        // Belt-and-braces: sweep the namespace clean before releasing it.
+        // `sweep` swallows individual delete failures, so a leftover item
+        // can't trip tearDown.
+        _ = KeychainService.sweep(validAccounts: [])
+
+        BaseChatConfiguration.shared = originalConfig
+        originalConfig = nil
+        testServiceName = nil
+        super.tearDown()
+    }
+
+    // MARK: - allAccounts
+
+    func test_allAccounts_emptyNamespace_returnsEmpty() {
+        XCTAssertEqual(KeychainService.allAccounts(), [])
+    }
+
+    func test_allAccounts_returnsStoredAccounts() throws {
+        let a = UUID().uuidString
+        let b = UUID().uuidString
+        let c = UUID().uuidString
+
+        try KeychainService.store(key: "k1", account: a)
+        try KeychainService.store(key: "k2", account: b)
+        try KeychainService.store(key: "k3", account: c)
+
+        let accounts = Set(KeychainService.allAccounts())
+        XCTAssertEqual(accounts, [a, b, c])
+    }
+
+    // MARK: - sweep
+
+    func test_sweep_emptyNamespace_returnsZero() {
+        let reaped = KeychainService.sweep(validAccounts: [])
+        XCTAssertEqual(reaped, 0)
+    }
+
+    func test_sweep_emptyValidSet_removesEverything() throws {
+        let a = UUID().uuidString
+        let b = UUID().uuidString
+        try KeychainService.store(key: "k1", account: a)
+        try KeychainService.store(key: "k2", account: b)
+
+        let reaped = KeychainService.sweep(validAccounts: [])
+
+        XCTAssertEqual(reaped, 2)
+        XCTAssertEqual(KeychainService.allAccounts(), [])
+        XCTAssertNil(KeychainService.retrieve(account: a))
+        XCTAssertNil(KeychainService.retrieve(account: b))
+    }
+
+    func test_sweep_preservesValidAccountsAndRemovesOrphans() throws {
+        let keep1 = UUID().uuidString
+        let keep2 = UUID().uuidString
+        let orphan1 = UUID().uuidString
+        let orphan2 = UUID().uuidString
+
+        try KeychainService.store(key: "valid1", account: keep1)
+        try KeychainService.store(key: "valid2", account: keep2)
+        try KeychainService.store(key: "orphan1", account: orphan1)
+        try KeychainService.store(key: "orphan2", account: orphan2)
+
+        let reaped = KeychainService.sweep(validAccounts: [keep1, keep2])
+
+        XCTAssertEqual(reaped, 2, "Only the two orphans should be reaped")
+
+        XCTAssertEqual(KeychainService.retrieve(account: keep1), "valid1")
+        XCTAssertEqual(KeychainService.retrieve(account: keep2), "valid2")
+        XCTAssertNil(KeychainService.retrieve(account: orphan1))
+        XCTAssertNil(KeychainService.retrieve(account: orphan2))
+    }
+
+    func test_sweep_allAccountsValid_returnsZero() throws {
+        let a = UUID().uuidString
+        let b = UUID().uuidString
+        try KeychainService.store(key: "k1", account: a)
+        try KeychainService.store(key: "k2", account: b)
+
+        let reaped = KeychainService.sweep(validAccounts: [a, b])
+
+        XCTAssertEqual(reaped, 0)
+        XCTAssertEqual(Set(KeychainService.allAccounts()), [a, b])
+    }
+
+    func test_sweep_validSetContainsUnknownAccount_isIgnored() throws {
+        let real = UUID().uuidString
+        let notStored = UUID().uuidString
+        try KeychainService.store(key: "real", account: real)
+
+        // validAccounts may contain accounts that were never in the Keychain
+        // (e.g. an endpoint row without a stored key). Sweep should ignore them.
+        let reaped = KeychainService.sweep(validAccounts: [real, notStored])
+
+        XCTAssertEqual(reaped, 0)
+        XCTAssertEqual(KeychainService.retrieve(account: real), "real")
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a boot-time reaper that deletes Keychain entries whose owning `APIEndpoint` row no longer exists.
- Wires it into `SwiftDataPersistenceProvider.init` so host apps using the default persistence get it automatically; exposes `BaseChatBootstrap.reapOrphanedKeychainItems(in:)` for apps with custom providers.
- Gated by `BaseChatConfiguration.keychainReaperEnabled` (default `true`) for test harnesses that populate the namespace independently.

## Why

`APIConfigurationView.deleteEndpoint` deletes the SwiftData row even if the paired `KeychainService.delete` call silently fails — the right trade-off for the user's flow, but it leaks an API key into the Keychain that nothing can ever reclaim. Direct SwiftData wipes (migrations, debug tools, test cleanup) have the same effect. Over time these accumulate, and because the row that referenced them is gone there is no way to find the dangling keys.

The reaper closes this hole: at boot it enumerates every account in the framework's Keychain service namespace, diffs against the current set of `APIEndpoint.keychainAccount` values from SwiftData, and deletes the difference. One pass at boot, not per-view, not per-generation.

`KeychainService.sweep(validAccounts:)` never aborts on a single failed delete — it logs at `.warning` and continues, so a single stuck row can't block reclaiming the rest. Keychain access denial (sandboxed contexts, missing entitlement) returns `0` cleanly; the reaper never crashes the app.

## Opt-out

```swift
BaseChatConfiguration.shared.keychainReaperEnabled = false
```

Intended for test fixtures that populate the framework's Keychain namespace independently of `APIEndpoint` rows. Production apps should leave this enabled.

## Test plan

- [x] `KeychainServiceSweepTests` — 7 new tests covering `allAccounts` and `sweep` round-trips, empty/populated/all-valid/unknown-valid edge cases; each test scopes its own service name so parallel runs don't collide.
- [x] Sabotage check — reverse the `!validAccounts.contains(account)` guard: five of the seven tests correctly fail; restored before committing.
- [x] `BaseChatCoreTests` (83 tests) — pass.
- [x] `BaseChatInferenceTests` (651 tests, including existing `KeychainServiceTests` and `KeychainIntegrationTests`) — pass.
- [x] `BaseChatUITests` (431 tests) — pass.
- [x] `BaseChatBackendsTests` (131 tests, including `CloudEndpointSelectionIntegrationTests` which re-runs `SwiftDataPersistenceProvider.init` 8 times with Keychain entries live in the same process) — pass.

## Release Note

**Orphaned Keychain cleanup on app launch** — API keys whose owning cloud endpoint was deleted (either via a Keychain failure during row deletion or a direct SwiftData wipe) could previously accumulate indefinitely in the Keychain with no way for the app to reclaim them. BaseChatKit now runs a one-shot sweep at boot that removes any Keychain entry in the framework's namespace whose account ID is not present in the current set of `APIEndpoint` rows. The sweep is opt-out via `BaseChatConfiguration.keychainReaperEnabled`, logs failures per-item without aborting, and exits cleanly if Keychain access is denied. Host apps using `SwiftDataPersistenceProvider` get this automatically; apps with custom persistence can call `BaseChatBootstrap.reapOrphanedKeychainItems(in:)` from their launch path.