### PR TITLE
fix: unbreak main after #360 + #363 interleaved merge

### DIFF
--- a/Tests/BaseChatCoreTests/CustomEndpointValidationTests.swift
+++ b/Tests/BaseChatCoreTests/CustomEndpointValidationTests.swift
@@ -14,7 +14,7 @@ final class CustomEndpointValidationTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         for id in endpointIDs {
-            KeychainService.delete(account: id)
+            try? KeychainService.delete(account: id)
         }
         endpointIDs.removeAll()
     }


### PR DESCRIPTION
## Summary

Main is broken. One-line fix.

## Why

- PR #360 added `Tests/BaseChatCoreTests/CustomEndpointValidationTests.swift` with `KeychainService.delete(account:)` calls in `tearDown`.
- PR #363 converted `KeychainService.delete` to `throws` and audited 8 test files at the time, but #360's test file hadn't merged yet so it wasn't in the audit.
- Both PRs' CI was green against their own base. The interaction only surfaced once both hit main.

## Fix

Change the test tear-down to `try? KeychainService.delete(account: id)`. The tear-down already treats cleanup as best-effort (and `delete` treats `errSecItemNotFound` as success internally), so swallowing the error matches existing intent.

## Test plan

- [x] `swift build --build-tests` succeeds
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` → 127 passed, 4 skipped, 0 failures

## Release Note

None — test-only, unblocks the post-merge CI on main.