### PR TITLE
test: add real-model E2E UI tests for GGUF, MLX, and Foundation

### DIFF
--- a/Example/BaseChatDemoUITests/ModelManagementUITests.swift
+++ b/Example/BaseChatDemoUITests/ModelManagementUITests.swift
@@ -302,7 +302,10 @@ final class ModelManagementUITests: XCTestCase {
 
     func testSelectingGGUFModelProducesResponse() throws {
         // FIXME: https://github.com/roryford/BaseChatKit/issues/377
-        throw XCTSkip("Disabled pending fix for https://github.com/roryford/BaseChatKit/issues/377 — XCUITest can't see the demo app's window on native macOS")
+        // XCTSkipIf(true, ...) (rather than `throw XCTSkip`) keeps the body
+        // below reachable so the compiler keeps type-checking it against
+        // helper changes; remove this guard when #377 is fixed.
+        try XCTSkipIf(true, "Disabled pending fix for #377 — restoration requires native macOS with on-disk models, not iOS Simulator")
         try skipUnlessRealModelE2EEnabled()
         #if !arch(arm64)
         throw XCTSkip("GGUF backend (llama.cpp) requires Apple Silicon")
@@ -316,7 +319,7 @@ final class ModelManagementUITests: XCTestCase {
 
     func testSelectingMLXModelProducesResponse() throws {
         // FIXME: https://github.com/roryford/BaseChatKit/issues/377
-        throw XCTSkip("Disabled pending fix for https://github.com/roryford/BaseChatKit/issues/377 — XCUITest can't see the demo app's window on native macOS")
+        try XCTSkipIf(true, "Disabled pending fix for #377 — restoration requires native macOS with on-disk models, not iOS Simulator")
         try skipUnlessRealModelE2EEnabled()
         #if !arch(arm64)
         throw XCTSkip("MLX backend requires Apple Silicon")
@@ -330,7 +333,7 @@ final class ModelManagementUITests: XCTestCase {
 
     func testSelectingFoundationModelProducesResponse() throws {
         // FIXME: https://github.com/roryford/BaseChatKit/issues/377
-        throw XCTSkip("Disabled pending fix for https://github.com/roryford/BaseChatKit/issues/377 — XCUITest can't see the demo app's window on native macOS")
+        try XCTSkipIf(true, "Disabled pending fix for #377 — restoration requires native macOS, not iOS Simulator")
         try skipUnlessRealModelE2EEnabled()
 
         guard #available(macOS 26, iOS 26, *) else {

--- a/Example/BaseChatDemoUITests/ModelManagementUITests.swift
+++ b/Example/BaseChatDemoUITests/ModelManagementUITests.swift
@@ -242,4 +242,149 @@ final class ModelManagementUITests: XCTestCase {
         attachment.lifetime = .keepAlways
         add(attachment)
     }
+
+    // MARK: - Real-Model E2E (opt-in, hardware-gated)
+    //
+    // These three tests prove that a real user can pick a model of each
+    // supported on-device type (GGUF / MLX / Apple Foundation) through the
+    // real UI and successfully generate a streamed response. They are
+    // opt-in via a sentinel file (`~/.basechatkit_real_e2e`) because:
+    //
+    //   1. They require ~4 GB of model files on disk under the demo app's
+    //      sandbox container (`~/Library/Containers/<app-id>/Data/Documents/Models`).
+    //   2. A cold MLX or GGUF load can take 10-30s and generation another
+    //      30-120s — too slow for a default developer test sweep.
+    //   3. CI runners do not have GPU/MLX/Metal acceleration nor Apple
+    //      Intelligence enabled.
+    //
+    // Prerequisites (one-time local setup on Apple Silicon):
+    //   1. Place model files in the demo app's sandbox Documents/Models:
+    //      - `Qwen_Qwen3-4B-Q4_K_M.gguf`           (for GGUF)
+    //      - `Llama-3.2-3B-Instruct-4bit/` dir     (for MLX)
+    //      (Apple Foundation Model needs no file.)
+    //   2. `touch ~/.basechatkit_real_e2e`
+    //   3. Native macOS runs require granting Accessibility permission to
+    //      `/Applications/Xcode.app` (or `Xcode-testmanagerd`) in
+    //      System Settings > Privacy & Security > Accessibility.
+    //
+    // Example run (native macOS):
+    //   scripts/example-ui-tests.sh test-without-building \
+    //     --destination 'platform=macOS,arch=arm64' \
+    //     -only-testing:BaseChatDemoUITests/ModelManagementUITests/testSelectingGGUFModelProducesResponse
+
+    /// Opt-in gate for real-model end-to-end tests.
+    ///
+    /// Uses two signals:
+    ///
+    /// 1. `CI` environment variable — automatically set by GitHub Actions and
+    ///    most other CI systems. When present (any non-empty value), we skip,
+    ///    because CI runners do not have the model files on disk nor the GPU
+    ///    to run them.
+    /// 2. Sentinel file at `~/.basechatkit_real_e2e` — developers opt in by
+    ///    creating this file (`touch ~/.basechatkit_real_e2e`). A sentinel file
+    ///    is used instead of an env var because `xcodebuild test` does not
+    ///    propagate arbitrary shell env vars into the XCUITest runner process
+    ///    on macOS/iOS, so env-var gates get silently skipped.
+    ///
+    /// Developers can also disable the gate by deleting the sentinel file.
+    private func skipUnlessRealModelE2EEnabled() throws {
+        let env = ProcessInfo.processInfo.environment
+        if let ci = env["CI"], !ci.isEmpty {
+            throw XCTSkip("Real-model E2E skipped in CI — requires ~4 GB on-disk models and Apple Silicon")
+        }
+
+        let home = ProcessInfo.processInfo.environment["HOME"] ?? NSHomeDirectory()
+        let sentinel = (home as NSString).appendingPathComponent(".basechatkit_real_e2e")
+        guard FileManager.default.fileExists(atPath: sentinel) else {
+            throw XCTSkip("Real-model E2E opt-in: create ~/.basechatkit_real_e2e (touch ~/.basechatkit_real_e2e) to run this test locally. Requires ~4 GB on-disk models and Apple Silicon.")
+        }
+    }
+
+    func testSelectingGGUFModelProducesResponse() throws {
+        try skipUnlessRealModelE2EEnabled()
+        #if !arch(arm64)
+        throw XCTSkip("GGUF backend (llama.cpp) requires Apple Silicon")
+        #endif
+
+        runRealModelSelectionFlow(
+            modelLabelNeedle: "Qwen3-4B",
+            screenshotPrefix: "GGUF"
+        )
+    }
+
+    func testSelectingMLXModelProducesResponse() throws {
+        try skipUnlessRealModelE2EEnabled()
+        #if !arch(arm64)
+        throw XCTSkip("MLX backend requires Apple Silicon")
+        #endif
+
+        runRealModelSelectionFlow(
+            modelLabelNeedle: "Llama-3.2-3B",
+            screenshotPrefix: "MLX"
+        )
+    }
+
+    func testSelectingFoundationModelProducesResponse() throws {
+        try skipUnlessRealModelE2EEnabled()
+
+        guard #available(macOS 26, iOS 26, *) else {
+            throw XCTSkip("Apple Foundation Model requires macOS 26 / iOS 26")
+        }
+
+        runRealModelSelectionFlow(
+            modelLabelNeedle: "Foundation",
+            screenshotPrefix: "Foundation",
+            // Foundation Model loads near-instantly and streams quickly; tighter
+            // timeouts surface regressions faster than the MLX/GGUF defaults.
+            loadTimeout: 30,
+            responseTimeout: 60
+        )
+    }
+
+    /// Drives the full real-model E2E flow: open the sheet, tap the row
+    /// matching `modelLabelNeedle`, wait for the model to load, send a short
+    /// deterministic prompt, and assert that an assistant response streams in.
+    /// Captures screenshots at each milestone for debugging.
+    private func runRealModelSelectionFlow(
+        modelLabelNeedle: String,
+        screenshotPrefix: String,
+        loadTimeout: TimeInterval = 60,
+        responseTimeout: TimeInterval = 120
+    ) {
+        openModelManagementSheet()
+        takeScreenshot(name: "\(screenshotPrefix)-01-Sheet-Open")
+
+        guard let row = findModelRow(in: app, containing: modelLabelNeedle) else {
+            takeScreenshot(name: "\(screenshotPrefix)-FAIL-Row-Not-Found")
+            XCTFail("Could not find a model row containing '\(modelLabelNeedle)' on the Select tab. Make sure the model is present in the demo app's sandbox container.")
+            return
+        }
+
+        XCTAssertTrue(row.isHittable, "Row for '\(modelLabelNeedle)' must be hittable to select it")
+        row.tap()
+        takeScreenshot(name: "\(screenshotPrefix)-02-Row-Tapped")
+
+        // The sheet should auto-dismiss after selection. We don't gate the rest
+        // of the flow on this — what really matters is that the chat input
+        // becomes ready, which only happens once the backend has loaded.
+        let inputReady = waitForChatInputReady(app: app, timeout: loadTimeout)
+        takeScreenshot(name: "\(screenshotPrefix)-03-After-Load-Wait")
+        guard inputReady else {
+            XCTFail("Chat input never became ready within \(loadTimeout)s after selecting '\(modelLabelNeedle)' — model load likely failed")
+            return
+        }
+
+        let prompt = "Reply with one word: ready"
+        let gotResponse = sendPromptAndAwaitResponse(
+            app: app,
+            prompt: prompt,
+            responseTimeout: responseTimeout
+        )
+        takeScreenshot(name: "\(screenshotPrefix)-04-After-Send")
+
+        XCTAssertTrue(
+            gotResponse,
+            "Expected an assistant response to stream within \(responseTimeout)s for model '\(modelLabelNeedle)'"
+        )
+    }
 }

--- a/Example/BaseChatDemoUITests/ModelManagementUITests.swift
+++ b/Example/BaseChatDemoUITests/ModelManagementUITests.swift
@@ -301,6 +301,8 @@ final class ModelManagementUITests: XCTestCase {
     }
 
     func testSelectingGGUFModelProducesResponse() throws {
+        // FIXME: https://github.com/roryford/BaseChatKit/issues/377
+        throw XCTSkip("Disabled pending fix for https://github.com/roryford/BaseChatKit/issues/377 — XCUITest can't see the demo app's window on native macOS")
         try skipUnlessRealModelE2EEnabled()
         #if !arch(arm64)
         throw XCTSkip("GGUF backend (llama.cpp) requires Apple Silicon")
@@ -313,6 +315,8 @@ final class ModelManagementUITests: XCTestCase {
     }
 
     func testSelectingMLXModelProducesResponse() throws {
+        // FIXME: https://github.com/roryford/BaseChatKit/issues/377
+        throw XCTSkip("Disabled pending fix for https://github.com/roryford/BaseChatKit/issues/377 — XCUITest can't see the demo app's window on native macOS")
         try skipUnlessRealModelE2EEnabled()
         #if !arch(arm64)
         throw XCTSkip("MLX backend requires Apple Silicon")
@@ -325,6 +329,8 @@ final class ModelManagementUITests: XCTestCase {
     }
 
     func testSelectingFoundationModelProducesResponse() throws {
+        // FIXME: https://github.com/roryford/BaseChatKit/issues/377
+        throw XCTSkip("Disabled pending fix for https://github.com/roryford/BaseChatKit/issues/377 — XCUITest can't see the demo app's window on native macOS")
         try skipUnlessRealModelE2EEnabled()
 
         guard #available(macOS 26, iOS 26, *) else {

--- a/Example/BaseChatDemoUITests/UITestHelpers.swift
+++ b/Example/BaseChatDemoUITests/UITestHelpers.swift
@@ -325,11 +325,7 @@ extension XCTestCase {
     // unit-test usage — the timeouts are generous because real model loads can
     // take 10–30 seconds and generation can take another 30–120 seconds.
 
-    /// Finds the model row in the Select tab whose accessibility label contains
-    /// `needle` (case-insensitive). Returns `nil` if no matching row exists.
-    ///
-    /// Looks first at buttons (the real `ModelSelectionRow` is a Button), then
-    /// falls back to any element that exposes a matching label, since
+    /// Falls back through buttons / cells / otherElements because
     /// `accessibilityElement(children: .combine)` can flatten the row into a
     /// non-button element on some platforms.
     func findModelRow(in app: XCUIApplication, containing needle: String) -> XCUIElement? {
@@ -353,24 +349,14 @@ extension XCTestCase {
         return nil
     }
 
-    /// Waits until the chat input field is hittable AND enabled, indicating
-    /// that the selected model has finished loading and the UI is ready to
-    /// accept a prompt.
-    ///
-    /// Returns `true` when the input is ready, `false` if the timeout expires.
-    /// The default timeout is 60s — enough for a cold MLX or GGUF load on
-    /// Apple Silicon. Polls every 0.5s using `XCUIElement` queries (no sleep
-    /// inside a Task; this runs on the test thread).
-    @discardableResult
+    /// Default timeout is 60s — enough for a cold MLX or GGUF load on Apple
+    /// Silicon. The input transitions through "exists but disabled" while the
+    /// model loads, so we re-check `isEnabled && isHittable` each iteration.
     func waitForChatInputReady(app: XCUIApplication, timeout: TimeInterval = 60) -> Bool {
         let messageInput = app.textFields["Message input"]
         let deadline = Date().addingTimeInterval(timeout)
 
         while Date() < deadline {
-            // `waitForExistence` provides the timed wait without a manual sleep
-            // loop. We re-check enabled+hittable each iteration because the
-            // input transitions through "exists but disabled" while the model
-            // is still loading.
             if messageInput.waitForExistence(timeout: 1),
                messageInput.isEnabled,
                messageInput.isHittable {
@@ -381,14 +367,9 @@ extension XCTestCase {
         return false
     }
 
-    /// Sends a prompt through the real chat input and waits for any assistant
-    /// response text to appear in the chat. Returns `true` when streamed
-    /// content is observed, `false` if no response arrives before the timeout.
-    ///
-    /// The assertion is intentionally lenient: it only verifies that *some*
-    /// non-prompt assistant text appears, not the specific content. Real models
-    /// are non-deterministic.
-    @discardableResult
+    /// Verifies *some* non-empty content appears beyond the "Assistant said: "
+    /// accessibility prefix; specific content is not asserted because real
+    /// models are non-deterministic.
     func sendPromptAndAwaitResponse(
         app: XCUIApplication,
         prompt: String,
@@ -408,24 +389,13 @@ extension XCTestCase {
         }
         sendButton.tap()
 
-        // The user message bubble appears as a static text containing the
-        // prompt. The assistant bubble accessibility label is
-        // "Assistant said: <content>" — wait for any such element to exist.
         let assistantPredicate = NSPredicate(format: "label BEGINSWITH[c] 'Assistant said:'")
         let assistantBubble = app.otherElements.matching(assistantPredicate).firstMatch
 
-        if assistantBubble.waitForExistence(timeout: responseTimeout) {
-            // Confirm the bubble has streamed *some* content beyond the prefix.
-            let label = assistantBubble.label
-            return label.count > "Assistant said: ".count
+        guard assistantBubble.waitForExistence(timeout: responseTimeout) else {
+            return false
         }
 
-        // Fall back to scanning static texts: streaming assistant content can
-        // appear as plain Text elements depending on rendering path.
-        let staticPredicate = NSPredicate(
-            format: "label != %@ AND label.length > 0", prompt
-        )
-        let texts = app.staticTexts.matching(staticPredicate)
-        return texts.count > 0
+        return assistantBubble.label.count > "Assistant said: ".count
     }
 }

--- a/Example/BaseChatDemoUITests/UITestHelpers.swift
+++ b/Example/BaseChatDemoUITests/UITestHelpers.swift
@@ -316,4 +316,116 @@ extension XCTestCase {
             topCoordinate.press(forDuration: 0.05, thenDragTo: bottomCoordinate)
         }
     }
+
+    // MARK: - Real-Model E2E Helpers
+    //
+    // These helpers support hardware-gated end-to-end tests that load real
+    // on-disk models (GGUF / MLX / Apple Foundation) through the real UI and
+    // verify that a streamed response actually appears. They are NOT meant for
+    // unit-test usage — the timeouts are generous because real model loads can
+    // take 10–30 seconds and generation can take another 30–120 seconds.
+
+    /// Finds the model row in the Select tab whose accessibility label contains
+    /// `needle` (case-insensitive). Returns `nil` if no matching row exists.
+    ///
+    /// Looks first at buttons (the real `ModelSelectionRow` is a Button), then
+    /// falls back to any element that exposes a matching label, since
+    /// `accessibilityElement(children: .combine)` can flatten the row into a
+    /// non-button element on some platforms.
+    func findModelRow(in app: XCUIApplication, containing needle: String) -> XCUIElement? {
+        let predicate = NSPredicate(format: "label CONTAINS[c] %@", needle)
+
+        let buttonMatch = app.buttons.matching(predicate).firstMatch
+        if buttonMatch.waitForExistence(timeout: 5) {
+            return buttonMatch
+        }
+
+        let cellMatch = app.cells.matching(predicate).firstMatch
+        if cellMatch.exists {
+            return cellMatch
+        }
+
+        let otherMatch = app.otherElements.matching(predicate).firstMatch
+        if otherMatch.exists {
+            return otherMatch
+        }
+
+        return nil
+    }
+
+    /// Waits until the chat input field is hittable AND enabled, indicating
+    /// that the selected model has finished loading and the UI is ready to
+    /// accept a prompt.
+    ///
+    /// Returns `true` when the input is ready, `false` if the timeout expires.
+    /// The default timeout is 60s — enough for a cold MLX or GGUF load on
+    /// Apple Silicon. Polls every 0.5s using `XCUIElement` queries (no sleep
+    /// inside a Task; this runs on the test thread).
+    @discardableResult
+    func waitForChatInputReady(app: XCUIApplication, timeout: TimeInterval = 60) -> Bool {
+        let messageInput = app.textFields["Message input"]
+        let deadline = Date().addingTimeInterval(timeout)
+
+        while Date() < deadline {
+            // `waitForExistence` provides the timed wait without a manual sleep
+            // loop. We re-check enabled+hittable each iteration because the
+            // input transitions through "exists but disabled" while the model
+            // is still loading.
+            if messageInput.waitForExistence(timeout: 1),
+               messageInput.isEnabled,
+               messageInput.isHittable {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    /// Sends a prompt through the real chat input and waits for any assistant
+    /// response text to appear in the chat. Returns `true` when streamed
+    /// content is observed, `false` if no response arrives before the timeout.
+    ///
+    /// The assertion is intentionally lenient: it only verifies that *some*
+    /// non-prompt assistant text appears, not the specific content. Real models
+    /// are non-deterministic.
+    @discardableResult
+    func sendPromptAndAwaitResponse(
+        app: XCUIApplication,
+        prompt: String,
+        responseTimeout: TimeInterval = 120
+    ) -> Bool {
+        let messageInput = app.textFields["Message input"]
+        guard messageInput.waitForExistence(timeout: 5), messageInput.isHittable else {
+            return false
+        }
+
+        messageInput.tap()
+        messageInput.typeText(prompt)
+
+        let sendButton = app.buttons["Send message"]
+        guard sendButton.waitForExistence(timeout: 5), sendButton.isEnabled else {
+            return false
+        }
+        sendButton.tap()
+
+        // The user message bubble appears as a static text containing the
+        // prompt. The assistant bubble accessibility label is
+        // "Assistant said: <content>" — wait for any such element to exist.
+        let assistantPredicate = NSPredicate(format: "label BEGINSWITH[c] 'Assistant said:'")
+        let assistantBubble = app.otherElements.matching(assistantPredicate).firstMatch
+
+        if assistantBubble.waitForExistence(timeout: responseTimeout) {
+            // Confirm the bubble has streamed *some* content beyond the prefix.
+            let label = assistantBubble.label
+            return label.count > "Assistant said: ".count
+        }
+
+        // Fall back to scanning static texts: streaming assistant content can
+        // appear as plain Text elements depending on rendering path.
+        let staticPredicate = NSPredicate(
+            format: "label != %@ AND label.length > 0", prompt
+        )
+        let texts = app.staticTexts.matching(staticPredicate)
+        return texts.count > 0
+    }
 }


### PR DESCRIPTION
## Summary

Adds three opt-in XCUITest cases to `ModelManagementUITests` that exercise the full user journey of picking each supported on-device model type through the real UI and confirming a streamed response:

- `testSelectingGGUFModelProducesResponse` (Qwen3-4B GGUF via llama.cpp)
- `testSelectingMLXModelProducesResponse` (Llama-3.2-3B-Instruct 4-bit MLX)
- `testSelectingFoundationModelProducesResponse` (Apple Foundation Model)

Each test opens the model management sheet, taps the row matching the target model (by accessibility label substring), waits for the backend to finish loading, types a short deterministic prompt, and asserts that an assistant response streams into the chat. Screenshots are captured at each milestone for debugging.

Also fixes a latent iOS-only API (`ToolbarItem(placement: .topBarLeading)`) in `DemoContentView.swift` that blocked any native macOS build of the demo app (see #375 for the root-cause write-up).

## Known Issue

The 3 new real-model E2E tests currently `XCTSkip` with a `// FIXME:` comment pointing to **#377** — XCUITest cannot see the demo app's window on native macOS (only the menu bar appears in the accessibility hierarchy), so these tests cannot execute end-to-end on native macOS. The pre-existing 10 `ModelManagementUITests` are unaffected because CI runs them on the iOS Simulator, where they pass. The skips are the first statement in each test method so they fire regardless of destination; the existing opt-in gating (sentinel file, arch check, availability check) stays intact below and will take over again once #377 is fixed.

This ships the PR as **iOS-only coverage** for now: the existing 10 tests keep CI green on iOS Simulator; the 3 new real-model tests will reactivate when #377 is resolved.

### Opt-in gating

The three tests skip unless a developer has created a sentinel file at `~/.basechatkit_real_e2e`. A sentinel file is used instead of an env var because `xcodebuild test` does not propagate arbitrary shell env vars into the XCUITest runner process on macOS/iOS. CI is also gated off by checking the standard `CI` env var. GGUF/MLX additionally require `arch(arm64)`, and Foundation requires `macOS 26 / iOS 26`.

### Why opt-in (not CI)

- Requires ~4 GB of on-disk model files in the demo app's sandbox container
- Cold MLX or GGUF load can take 10-30 s, generation another 30-120 s
- CI runners have no GPU and no Apple Intelligence; the Metal-dependent backends cannot run

### Developer workflow

One-time setup:

1. Place model files in the demo's sandbox `Documents/Models`:
   - `Qwen_Qwen3-4B-Q4_K_M.gguf`
   - `Llama-3.2-3B-Instruct-4bit/` directory
2. `touch ~/.basechatkit_real_e2e`
3. Grant Accessibility permission to Xcode / `testmanagerd` in System Settings > Privacy & Security

Then (once #377 is fixed):

```bash
scripts/example-ui-tests.sh test-without-building \
  --destination 'platform=macOS,arch=arm64' \
  -only-testing:BaseChatDemoUITests/ModelManagementUITests/testSelectingGGUFModelProducesResponse
```

### Reusable helpers

Three new helpers in `UITestHelpers.swift`, reused across all three test methods:

- `findModelRow(in:containing:)` — locates a model row on the Select tab by label substring
- `waitForChatInputReady(app:timeout:)` — polls `isEnabled && isHittable` on the message input (default 60s for MLX/GGUF cold-load)
- `sendPromptAndAwaitResponse(app:prompt:responseTimeout:)` — types + sends + waits for an assistant bubble to appear (default 120s)

### Bug surfaced during this work

Building the demo app with `platform=macOS,arch=arm64` failed with `'topBarLeading' is unavailable in macOS`. The iOS-only `ToolbarItem(placement: .topBarLeading)` is now guarded with `#if os(iOS)` since native macOS has a persistent sidebar. Filed as #375 and fixed in this PR to unblock native macOS test runs.

### Verification

- `swift test --filter BaseChatCoreTests --disable-default-traits` — 176 passed, 4 skipped, 0 failed
- `swift test --filter BaseChatInferenceTests --disable-default-traits` — 69 passed, 0 failed
- `swift test --filter BaseChatUITests --disable-default-traits` — 431 passed, 0 failed
- `swift test --filter BaseChatBackendsTests --disable-default-traits` — 84 passed, 0 failed
- `scripts/example-ui-tests.sh test-without-building -only-testing:BaseChatDemoUITests/ModelManagementUITests` — **13 tests, 3 skipped (the new ones, now skipping due to #377), 0 failed.** The existing 10 `ModelManagementUITests` continue to pass on iOS Simulator.
- `scripts/example-ui-tests.sh build-for-testing --destination 'platform=macOS,arch=arm64'` — BUILD SUCCEEDED (proves the `.topBarLeading` fix is correct).

### Sabotage check

The `row.tap()` line in `runRealModelSelectionFlow` was temporarily commented out and the suite rebuilt. Because the test author could not grant Accessibility permission to `testmanagerd` interactively in this environment, the sabotage was verified **by logical inspection** of the fail path: without the tap, `selectedModel` stays nil, `ChatViewModel.dispatchSelectedLoad()` never runs, `isModelLoaded` stays false, `ChatInputBar` keeps the input `.disabled(true)` (per `ChatInputBar.swift:42`), `waitForChatInputReady` times out, and the test hits its `XCTFail("Chat input never became ready...")` branch. Restored before commit.

## Release Note

**Real-model E2E coverage for on-device model selection** — adds three opt-in XCUITests that exercise the full user journey of picking a GGUF, MLX, or Apple Foundation model in the model management sheet and confirming a streamed response lands in the chat. The tests are developer-opt-in via a sentinel file so they never run in CI, and surface regressions in model loading, backend handoff, and chat input readiness that cannot be caught headlessly. They are temporarily skipped pending #377 (XCUITest cannot see the demo app's window on native macOS) and will reactivate once that fix lands. This PR also fixes a latent compile error in the demo app that prevented native macOS builds from succeeding (#375). Test-only change with no runtime impact on the framework.

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits`
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits`
- [x] `swift test --filter BaseChatUITests --disable-default-traits`
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits`
- [x] `scripts/example-ui-tests.sh test-without-building -only-testing:BaseChatDemoUITests/ModelManagementUITests` (iOS Simulator; 13 tests, 10 passed, 3 skipped via #377)
- [x] `scripts/example-ui-tests.sh build-for-testing --destination 'platform=macOS,arch=arm64'` (proves macOS compile fix works)
- [ ] **Blocked by #377**: `testSelectingGGUFModelProducesResponse` runs end-to-end on a macOS developer machine with the sentinel file and Accessibility permission granted.
- [ ] **Blocked by #377**: `testSelectingMLXModelProducesResponse` runs end-to-end on the same setup.
- [ ] **Blocked by #377**: `testSelectingFoundationModelProducesResponse` runs end-to-end on the same setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)