### PR TITLE
fix: render Model Management sheet tab content on macOS (#378)

### DIFF
--- a/Sources/BaseChatUI/Views/Models/ModelManagementSheet.swift
+++ b/Sources/BaseChatUI/Views/Models/ModelManagementSheet.swift
@@ -60,8 +60,9 @@ public struct ModelManagementSheet: View {
             VStack(spacing: 0) {
                 tabPickerBar
                 tabContent
-                    .frame(maxHeight: .infinity)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
             .navigationTitle(selectedTab.rawValue)
             .toolbar {
                 doneToolbarItem
@@ -82,7 +83,11 @@ public struct ModelManagementSheet: View {
         .presentationDetents(horizontalSizeClass == .regular ? [.medium, .large] : [.large])
         .presentationDragIndicator(.visible)
         #else
-        .presentationDetents([.large])
+        // macOS sheets don't honor `.presentationDetents` and don't get a
+        // useful intrinsic size from a `NavigationStack { VStack { List } }`
+        // tree — without an explicit frame, the inner List collapses to zero
+        // height and every tab renders blank below the picker. See #378.
+        .frame(minWidth: 560, idealWidth: 720, minHeight: 480, idealHeight: 640)
         #endif
         .onAppear {
             if !availableTabs.contains(selectedTab) {


### PR DESCRIPTION
## Summary

On native macOS 26, opening the Model Management sheet shows the Select / Download / Storage picker and the Done button, but the content area below is blank — for all three tabs. The demo app is effectively unusable: users can't select, download, or manage models. See #378.

## Root cause

`ModelManagementSheet` wraps content in `NavigationStack { VStack { tabPickerBar; tabContent } }` on macOS. The `tabContent` is always a `List` (`ModelSelectionTabView`, `HuggingFaceBrowserView`, `LocalModelStorageView`). macOS sheets don't honor `.presentationDetents`, and a `NavigationStack { VStack { List } }` tree has no intrinsic size — so without an explicit frame, the inner list collapses to zero height and every tab renders blank below the picker bar.

The previous fix for #208 added `.frame(maxHeight: .infinity)` to `tabContent`, but that only works inside a VStack whose parent offers finite height — here the NavigationStack in a sheet offers zero, so the fix had nothing to expand into.

## Fix

Give the macOS sheet an explicit `.frame(minWidth: 560, idealWidth: 720, minHeight: 480, idealHeight: 640)`, and let the inner VStack + tab content expand to fill it. iOS is unchanged — it uses `.presentationDetents` on iPhone and iPad, which drive sheet sizing there.

## Verification

Built and launched `BaseChatDemo.app` for native macOS (`xcodebuild -destination 'platform=macOS,arch=arm64'`). Cycled through all three tabs — each now shows real content:

- **Select tab:** model rows render (Foundation Model, Llama, GGUF / MLX entries with type and tier badges)
- **Download tab:** recommended models section with SmolLM, Phi-4, Mistral 7B, Llama 3.2, Qwen 2.5 rows
- **Storage tab:** Storage Overview with total used, Models Directory link, Downloaded Models list with delete buttons

Screenshots of each tab were captured during verification and confirm content now renders. The existing iOS Simulator `ModelManagementUITests` suite still passes 10/10 — no regression on the iOS path.

## Release Note

**Model Management sheet renders on macOS.** A SwiftUI sizing interaction between `NavigationStack`, `VStack`, and `List` inside a macOS sheet left the Select, Download, and Storage tabs blank for host apps that used `ModelManagementSheet` on native macOS 26. The sheet now carries an explicit minimum frame on macOS so its content lays out correctly, without affecting the iOS or iPad presentation that uses `.presentationDetents`.

Closes #378.