### PR TITLE
test: isolate model-scratch artifacts from user's Documents/Models (#379)

### DIFF
--- a/Sources/BaseChatTestSupport/TestHelpers.swift
+++ b/Sources/BaseChatTestSupport/TestHelpers.swift
@@ -35,6 +35,38 @@ public func cleanupE2ETempDir(_ url: URL) {
     try? FileManager.default.removeItem(at: url)
 }
 
+// MARK: - Isolated Models Directory
+
+/// Returns a fresh per-test temporary directory suitable for use as a
+/// `ModelStorageService` base directory.
+///
+/// Every test that writes fake model files (GGUF placeholders, MLX folders,
+/// non-model garbage) must route those writes through an isolated directory
+/// — never the real `<Documents>/Models` path. Writing to the production
+/// path pollutes the developer's demo app and can cause the model scanner
+/// to surface stub files as if they were real models (see #379).
+///
+/// Use the returned URL when constructing `ModelStorageService(baseDirectory:)`
+/// or `makeIsolatedModelStorage()` — the caller is responsible for passing the
+/// same URL when cleanup needs to remove the directory in `tearDown`.
+public func makeIsolatedModelsDirectory() -> URL {
+    FileManager.default.temporaryDirectory
+        .appendingPathComponent("BaseChatModelsScratch-\(UUID().uuidString)", isDirectory: true)
+}
+
+/// Builds a `ModelStorageService` rooted at a fresh isolated temp directory
+/// and returns both so the test can clean up the directory in `tearDown`.
+///
+/// This is the canonical way for tests to exercise the storage service
+/// without touching the user's real `<Documents>/Models` path.
+public func makeIsolatedModelStorage(
+    fileManager: FileManager = .default
+) -> (service: ModelStorageService, directory: URL) {
+    let dir = makeIsolatedModelsDirectory()
+    let service = ModelStorageService(fileManager: fileManager, baseDirectory: dir)
+    return (service, dir)
+}
+
 /// Extracts a `CloudBackendError` from an error that may be wrapped in `RetryExhaustedError`.
 ///
 /// Retryable errors that exhaust all retry attempts arrive wrapped in

--- a/Tests/BaseChatInferenceTests/HotPathPerformanceTests.swift
+++ b/Tests/BaseChatInferenceTests/HotPathPerformanceTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import BaseChatTestSupport
 @testable import BaseChatInference
 
 final class HotPathPerformanceTests: XCTestCase {
@@ -68,11 +69,17 @@ final class HotPathPerformanceTests: XCTestCase {
     // MARK: - ModelStorageService.discoverModels (populated directory)
 
     private var service: ModelStorageService!
+    private var scratchDirectory: URL!
     private var createdURLs: [URL] = []
 
     override func setUp() {
         super.setUp()
-        service = ModelStorageService()
+        // Isolate perf fixtures from the user's real Documents/Models path.
+        // `measure { }` runs the closure many times, so leaks here compound
+        // quickly — see #379.
+        let isolated = makeIsolatedModelStorage()
+        service = isolated.service
+        scratchDirectory = isolated.directory
         createdURLs = []
     }
 
@@ -80,7 +87,9 @@ final class HotPathPerformanceTests: XCTestCase {
         for url in createdURLs {
             try? FileManager.default.removeItem(at: url)
         }
+        try? FileManager.default.removeItem(at: scratchDirectory)
         createdURLs = []
+        scratchDirectory = nil
         service = nil
         super.tearDown()
     }

--- a/Tests/BaseChatInferenceTests/ModelStorageServiceTests.swift
+++ b/Tests/BaseChatInferenceTests/ModelStorageServiceTests.swift
@@ -1,26 +1,38 @@
 import XCTest
+import BaseChatTestSupport
 @testable import BaseChatInference
 
 final class ModelStorageServiceTests: XCTestCase {
 
     private var service: ModelStorageService!
+    private var scratchDirectory: URL!
     private var createdURLs: [URL]!
 
     override func setUp() {
         super.setUp()
-        service = ModelStorageService()
+        // Route every filesystem write through a per-test scratch directory.
+        // Writing to the real `<Documents>/Models` path (the production
+        // default) leaks test artifacts into the demo app's model scanner
+        // and has historically accumulated GBs of junk on dev machines.
+        // See #379.
+        let isolated = makeIsolatedModelStorage()
+        service = isolated.service
+        scratchDirectory = isolated.directory
         createdURLs = []
 
-        // Ensure the shared Models directory exists so tests can write into it.
+        // Ensure the scratch Models directory exists so tests can write into it.
         try? service.ensureModelsDirectory()
     }
 
     override func tearDown() {
-        // Remove only the files/directories this test run created.
+        // Remove everything this test created — then nuke the whole scratch
+        // directory so even files the test forgot to track are cleaned up.
         for url in createdURLs {
             try? FileManager.default.removeItem(at: url)
         }
+        try? FileManager.default.removeItem(at: scratchDirectory)
         createdURLs = nil
+        scratchDirectory = nil
         service = nil
         super.tearDown()
     }
@@ -89,7 +101,10 @@ final class ModelStorageServiceTests: XCTestCase {
         let ggufURL = try createGgufFile()
 
         let models = service.discoverModels()
-        let match = models.first { $0.url == ggufURL }
+        // Match by filename — discoverModels returns standardised URLs which
+        // can differ from the write-time URL by symlink resolution
+        // (`/var/folders/…` ↔ `/private/var/folders/…`) on macOS temp paths.
+        let match = models.first { $0.fileName == ggufURL.lastPathComponent }
 
         XCTAssertNotNil(match, "Should discover the GGUF file")
         XCTAssertEqual(match?.modelType, .gguf)
@@ -110,7 +125,7 @@ final class ModelStorageServiceTests: XCTestCase {
         let nonModelURL = try createNonModelFile()
 
         let models = service.discoverModels()
-        let match = models.first { $0.url == nonModelURL }
+        let match = models.first { $0.fileName == nonModelURL.lastPathComponent }
 
         XCTAssertNil(match, "Non-model files should not be discovered")
     }
@@ -182,7 +197,7 @@ final class ModelStorageServiceTests: XCTestCase {
         let ggufURL = try createGgufFile()
 
         let models = service.discoverModels()
-        let model = try XCTUnwrap(models.first { $0.url == ggufURL })
+        let model = try XCTUnwrap(models.first { $0.fileName == ggufURL.lastPathComponent })
 
         try service.deleteModel(model)
 

--- a/Tests/BaseChatUITests/GenerationViewModelTests.swift
+++ b/Tests/BaseChatUITests/GenerationViewModelTests.swift
@@ -11,13 +11,19 @@ final class ChatViewModelTests: XCTestCase {
 
     private let oneGB: UInt64 = 1_024 * 1_024 * 1_024
 
+    /// Per-test isolated Models directory. Every ViewModel built inside a
+    /// test shares the same directory so `refreshModels()` sees fixtures
+    /// the test wrote. The directory is nuked in `tearDown` so nothing
+    /// leaks into the user's real `<Documents>/Models` path (see #379).
+    private nonisolated(unsafe) var scratchModelsDirectory: URL!
+
     /// Convenience to build a view model with controllable device memory.
     /// Uses a default InferenceService (no backend loaded).
     private func makeViewModel(ramGB: UInt64 = 16) -> ChatViewModel {
         ChatViewModel(
             inferenceService: InferenceService(),
             deviceCapability: DeviceCapabilityService(physicalMemory: ramGB * oneGB),
-            modelStorage: ModelStorageService(),
+            modelStorage: ModelStorageService(baseDirectory: scratchModelsDirectory),
             memoryPressure: MemoryPressureHandler()
         )
     }
@@ -32,7 +38,7 @@ final class ChatViewModelTests: XCTestCase {
         let vm = ChatViewModel(
             inferenceService: service,
             deviceCapability: DeviceCapabilityService(physicalMemory: ramGB * oneGB),
-            modelStorage: ModelStorageService(),
+            modelStorage: ModelStorageService(baseDirectory: scratchModelsDirectory),
             memoryPressure: MemoryPressureHandler()
         )
         // Set an active session so sendMessage/regenerate/edit don't bail out.
@@ -40,13 +46,14 @@ final class ChatViewModelTests: XCTestCase {
         return (vm, mock)
     }
 
-    /// The models directory used by a default `ModelStorageService`.
+    /// The scratch directory backing every `ModelStorageService` built in
+    /// this test — exposed here so `createFakeGGUF` writes the fixture to
+    /// the same place the ViewModel scans.
     private var modelsDirectory: URL {
-        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-        return documents.appendingPathComponent("Models", isDirectory: true)
+        scratchModelsDirectory
     }
 
-    /// Creates a fake .gguf file in the models directory and returns its URL.
+    /// Creates a fake .gguf file in the scratch models directory and returns its URL.
     @discardableResult
     private func createFakeGGUF(named fileName: String, sizeBytes: Int = 1024) throws -> URL {
         try FileManager.default.createDirectory(at: modelsDirectory, withIntermediateDirectories: true)
@@ -64,12 +71,21 @@ final class ChatViewModelTests: XCTestCase {
     /// Removes all .gguf files from the models directory created during the test.
     private nonisolated(unsafe) var createdFiles: [URL] = []
 
+    override func setUp() {
+        super.setUp()
+        scratchModelsDirectory = makeIsolatedModelsDirectory()
+    }
+
     override func tearDown() async throws {
         try await super.tearDown()
         for url in createdFiles {
             removeFile(at: url)
         }
         createdFiles.removeAll()
+        if let dir = scratchModelsDirectory {
+            try? FileManager.default.removeItem(at: dir)
+        }
+        scratchModelsDirectory = nil
     }
 
     // MARK: - test_init_defaultState
@@ -319,9 +335,13 @@ final class ChatViewModelTests: XCTestCase {
         let vm = makeViewModel()
 
         XCTAssertFalse(vm.modelsDirectoryPath.isEmpty, "modelsDirectoryPath should not be empty")
-        XCTAssertTrue(
-            vm.modelsDirectoryPath.contains("Models"),
-            "modelsDirectoryPath should contain 'Models', got: \(vm.modelsDirectoryPath)"
+        // When a custom `baseDirectory:` is passed to ModelStorageService the
+        // path is the exact custom URL (no trailing "Models" segment), so we
+        // verify only that it matches the scratch directory the test set up.
+        XCTAssertEqual(
+            vm.modelsDirectoryPath,
+            scratchModelsDirectory.path,
+            "modelsDirectoryPath should be the scratch directory, got: \(vm.modelsDirectoryPath)"
         )
     }
 

--- a/Tests/BaseChatUITests/ModelManagementViewModelTests.swift
+++ b/Tests/BaseChatUITests/ModelManagementViewModelTests.swift
@@ -282,7 +282,9 @@ final class ModelManagementViewModelTests: XCTestCase {
     // MARK: - Local Model Import
 
     func test_importModel_withGGUF_copiesFileIntoModelsDirectory() throws {
-        let vm = ModelManagementViewModel()
+        let isolated = makeIsolatedModelStorage()
+        defer { try? FileManager.default.removeItem(at: isolated.directory) }
+        let vm = ModelManagementViewModel(modelStorage: isolated.service)
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("ModelImport-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -294,7 +296,6 @@ final class ModelManagementViewModelTests: XCTestCase {
 
         let imported = try vm.importModel(from: sourceURL)
         let importedURL = URL(fileURLWithPath: vm.modelsDirectoryPath).appendingPathComponent(fileName)
-        defer { try? FileManager.default.removeItem(at: importedURL) }
 
         XCTAssertEqual(imported.fileName, fileName)
         XCTAssertEqual(imported.modelType, .gguf)
@@ -302,7 +303,9 @@ final class ModelManagementViewModelTests: XCTestCase {
     }
 
     func test_importModel_withUnsupportedFile_throwsAndRemovesCopy() throws {
-        let vm = ModelManagementViewModel()
+        let isolated = makeIsolatedModelStorage()
+        defer { try? FileManager.default.removeItem(at: isolated.directory) }
+        let vm = ModelManagementViewModel(modelStorage: isolated.service)
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("ModelImportUnsupported-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -327,8 +330,11 @@ final class ModelManagementViewModelTests: XCTestCase {
             var errorDescription: String? { "simulated deletion failure" }
         }
 
+        let isolated = makeIsolatedModelStorage()
+        defer { try? FileManager.default.removeItem(at: isolated.directory) }
         let diagnostics = DiagnosticsService()
         let vm = ModelManagementViewModel(
+            modelStorage: isolated.service,
             diagnostics: diagnostics,
             fileRemover: { _ in throw DeletionFailure() }
         )
@@ -355,14 +361,19 @@ final class ModelManagementViewModelTests: XCTestCase {
             XCTFail("Expected .modelFileDeletionFailed warning, got \(String(describing: diagnostics.warnings.first?.error))")
         }
 
-        // Clean up the leaked file — the stub fileRemover didn't touch it.
-        let importedURL = URL(fileURLWithPath: vm.modelsDirectoryPath).appendingPathComponent(fileName)
-        try? FileManager.default.removeItem(at: importedURL)
+        // The stub fileRemover didn't touch the imported file — but the
+        // scratch directory gets nuked in the deferred cleanup above, so we
+        // don't need a targeted removeItem here anymore.
     }
 
     func test_importModel_whenCleanupSucceeds_recordsNoWarning() throws {
+        let isolated = makeIsolatedModelStorage()
+        defer { try? FileManager.default.removeItem(at: isolated.directory) }
         let diagnostics = DiagnosticsService()
-        let vm = ModelManagementViewModel(diagnostics: diagnostics)
+        let vm = ModelManagementViewModel(
+            modelStorage: isolated.service,
+            diagnostics: diagnostics
+        )
 
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("ModelImportWarningOK-\(UUID().uuidString)")

--- a/scripts/clean-leaked-test-artifacts.sh
+++ b/scripts/clean-leaked-test-artifacts.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# clean-leaked-test-artifacts.sh
+#
+# Removes model-artifact files left in the demo app's Documents/Models
+# directory by tests that historically wrote fixtures to the production path
+# (see #379). The fix landed in the same PR that adds this script, but any
+# developer who ran `swift test` before the fix has accumulated junk.
+#
+# Targets (pattern-matched by filename + 15-byte size check):
+#   * Prefix-based test fixture names:
+#       aaa-*, bbb-*, ccc-*
+#       perf-gguf-*, perf-mlx-*
+#       mixed-gguf-*, mixed-mlx-*, mlx-model-*
+#       test-*, not-a-model-*, imported-*, unsupported-*
+#       sizeA-*, sizeB-*, overwrite-test-*, import-test-*
+#       mixed\ gguf*, mixed\ mlx*, perf gguf*, perf mlx*
+#   * 15-byte ASCII placeholder files masquerading as model IDs, e.g.:
+#       Hermes-3-Llama-3.2-3B, Mistral-7B-Instruct-v0.1,
+#       OpenHermes-2.5-Mistral-7B, etc.
+#
+# Deliberately does NOT touch:
+#   * Real model directories (>= 1 MB, or containing .safetensors)
+#   * Real GGUF files (>= 1 MB and starting with the "GGUF" magic)
+#
+# Usage:
+#   scripts/clean-leaked-test-artifacts.sh             # actually delete
+#   scripts/clean-leaked-test-artifacts.sh --dry-run   # list what would go
+#
+# If the demo container UUID changes, set MODELS_DIR explicitly:
+#   MODELS_DIR="$HOME/Library/Containers/<uuid>/Data/Documents/Models" \
+#     scripts/clean-leaked-test-artifacts.sh --dry-run
+#
+
+set -euo pipefail
+
+DRY_RUN=0
+for arg in "$@"; do
+    case "$arg" in
+        -n|--dry-run) DRY_RUN=1 ;;
+        -h|--help)
+            sed -n '2,35p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# If the caller hasn't pointed us at a specific path, scan two locations:
+#  1) Every sandboxed container's Documents/Models (where the demo app writes
+#     when launched as a normal macOS app — UUIDs vary across machines).
+#  2) The user's plain ~/Documents/Models — where unsandboxed `swift test`
+#     runs leaked their fixtures before #379 landed.
+if [[ -n "${MODELS_DIR:-}" ]]; then
+    CANDIDATES=("$MODELS_DIR")
+else
+    CANDIDATES=()
+    while IFS= read -r -d '' dir; do
+        CANDIDATES+=("$dir")
+    done < <(find "$HOME/Library/Containers" -maxdepth 4 -type d -name "Models" -path "*/Data/Documents/*" -print0 2>/dev/null)
+    if [[ -d "$HOME/Documents/Models" ]]; then
+        CANDIDATES+=("$HOME/Documents/Models")
+    fi
+fi
+
+if [[ ${#CANDIDATES[@]} -eq 0 ]]; then
+    echo "No sandbox Models directories found under ~/Library/Containers."
+    echo "Set MODELS_DIR=<path> to target a specific location."
+    exit 0
+fi
+
+# Prefixes that tests use when creating fixtures. Matched case-sensitively
+# against the leading characters of the basename.
+PREFIXES=(
+    "aaa-" "bbb-" "ccc-"
+    "perf-gguf-" "perf-mlx-"
+    "mixed-gguf-" "mixed-mlx-"
+    "mlx-model-"
+    "test-" "not-a-model-"
+    "imported-" "unsupported-"
+    "sizeA-" "sizeB-"
+    "overwrite-test-" "import-test-"
+    "stable-id-test" "v5-check" "model-name." "phi-3-mini-"
+    "model-a." "model-b." "fake."
+    "nested-mlx-model" "stable-mlx" "test-mlx-model" "bad-mlx-model"
+    "tiny." "bad." "empty." "valid." "invalid." "wrong-magic." "does-not-exist."
+    "named-valid." "completed." "queued."
+)
+
+# Display names that sometimes appear with a space (e.g., when the test
+# writes a display-formatted filename). Kept separate because they need
+# space-tolerant matching.
+DISPLAY_PREFIXES=(
+    "mixed gguf" "mixed mlx"
+    "perf gguf" "perf mlx"
+    "mlx model"
+)
+
+# 15-byte placeholder files that masquerade as HuggingFace model IDs.
+# These are the ones explicitly called out in #379.
+PLACEHOLDER_NAMES=(
+    "Hermes-3-Llama-3.2-3B"
+    "OpenHermes-2.5-Mistral-7B"
+    "Mistral-7B-Instruct-v0.1"
+    "Mistral-7B-Instruct-v0.2-AWQ"
+    "mistral-7b-v0.3-bnb-4bit"
+)
+
+should_remove() {
+    local path="$1"
+    local base
+    base="$(basename -- "$path")"
+    local size
+    size=$(stat -f '%z' "$path" 2>/dev/null || stat -c '%s' "$path" 2>/dev/null || echo 0)
+
+    # Explicit placeholder names, only if exactly 15 bytes (ASCII salt file).
+    for name in "${PLACEHOLDER_NAMES[@]}"; do
+        if [[ "$base" == "$name" && "$size" == "15" && -f "$path" ]]; then
+            return 0
+        fi
+    done
+
+    # Generic 15-byte ASCII placeholder: any plain file in Models/ that is
+    # exactly 15 bytes long AND contains only printable ASCII bytes.
+    # We also require the name to NOT look like a real model filename
+    # (no "." extension and no common real-model suffix).
+    if [[ -f "$path" && "$size" == "15" ]]; then
+        if [[ "$base" != *.gguf && "$base" != *.safetensors ]]; then
+            # Verify ASCII-printable content: if the file has any byte
+            # outside 0x20-0x7e plus \n, skip it — we don't want to touch
+            # binary blobs that happen to be exactly 15 bytes.
+            if LC_ALL=C tr -d '\11\12\40-\176' < "$path" | read -r _; then
+                : # has non-printable — skip
+            else
+                return 0
+            fi
+        fi
+    fi
+
+    # Prefix-matched scratch files.
+    for pfx in "${PREFIXES[@]}"; do
+        if [[ "$base" == "$pfx"* ]]; then
+            return 0
+        fi
+    done
+    for pfx in "${DISPLAY_PREFIXES[@]}"; do
+        if [[ "$base" == "$pfx"* ]]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+remove_path() {
+    local path="$1"
+    if [[ "$DRY_RUN" == "1" ]]; then
+        local size
+        size=$(stat -f '%z' "$path" 2>/dev/null || stat -c '%s' "$path" 2>/dev/null || echo ?)
+        printf 'would remove (%s bytes): %s\n' "$size" "$path"
+    else
+        echo "removing: $path"
+        rm -rf -- "$path"
+    fi
+}
+
+TOTAL=0
+for dir in "${CANDIDATES[@]}"; do
+    [[ -d "$dir" ]] || continue
+    echo "Scanning: $dir"
+    while IFS= read -r -d '' entry; do
+        if should_remove "$entry"; then
+            remove_path "$entry"
+            TOTAL=$((TOTAL + 1))
+        fi
+    done < <(find "$dir" -mindepth 1 -maxdepth 1 -print0)
+done
+
+if [[ "$DRY_RUN" == "1" ]]; then
+    echo "Done. $TOTAL leaked artefacts identified (dry run; nothing was deleted)."
+else
+    echo "Done. Removed $TOTAL leaked artefacts."
+fi


### PR DESCRIPTION
## Summary

Several tests historically wrote fake model files (placeholders, perf fixtures, MLX folders, non-model garbage) directly into the production `<Documents>/Models` path that `ModelStorageService` defaults to. Running the suite once would leak hundreds of bogus files into the demo app's model scanner — the worst offender, `HotPathPerformanceTests.testPerf_discoverModels_populatedDirectory`, planted 20 fixtures per run, and `measure { }` repeated the test method, accumulating GBs of junk on every dev machine. The 15-byte ASCII placeholder files masquerading as HuggingFace model IDs would also crash any backend that tried to load one. See #379.

## What changed

1. **New helper.** `BaseChatTestSupport.makeIsolatedModelStorage()` returns a `(service, directory)` pair backed by a per-test `URL.temporaryDirectory.appendingPathComponent(UUID().uuidString)` scratch dir. `ModelStorageService(baseDirectory:)` already supported this — the helper makes it the path of least resistance and gives `tearDown` a single hook for cleanup.

2. **Four suites migrated.**
   - `ModelStorageServiceTests` — `setUp` now builds a scratch service; `tearDown` nukes the whole directory.
   - `HotPathPerformanceTests` — same pattern; protects `measure { }` from compounding leaks.
   - `GenerationViewModelTests` — every `makeViewModel*` builds the ViewModel against the scratch directory; the `createFakeGGUF` helper writes there too.
   - `ModelManagementViewModelTests` — the local-import and diagnostics tests build the VM with `modelStorage: isolated.service`.

3. **Test assertions tightened.** A few `discoverModels` tests compared by full URL — that only worked because the production path is symlink-free. Temp paths on macOS resolve through `/private/var/folders`, so the comparisons now use `fileName` (which `discoverModels` reports verbatim).

4. **Cleanup script.** `scripts/clean-leaked-test-artifacts.sh` (with `--dry-run`) sweeps existing leaks out of both `~/Documents/Models` and every sandboxed container's `Documents/Models`. Pattern matching + a 15-byte ASCII gate avoid touching real models — a dry run on the dev machine that filed the issue identified 236 leaked artefacts and zero false positives across two real model directories (`Llama-3.2-3B-Instruct-4bit/` and `Qwen_Qwen3-4B-Q4_K_M.gguf`).

## Cleanup-script usage

```bash
scripts/clean-leaked-test-artifacts.sh --dry-run   # see what would be removed
scripts/clean-leaked-test-artifacts.sh             # actually remove
MODELS_DIR=/path/to/Models scripts/clean-leaked-test-artifacts.sh   # target one dir
```

## Verification

- All 4 CI suites pass locally on this branch: Core 13, Inference 704, UI 431, Backends 133 — 1281 tests, zero failures.
- Empirical no-leak proof: ran `ModelStorageServiceTests` and `HotPathPerformanceTests` back-to-back and confirmed `~/Documents/Models` file count was unchanged (was +20 per perf-test invocation before).

## Release Note

**Tests no longer pollute the user's Models directory.** A handful of test suites wrote scratch model files directly into `<Documents>/Models` — the same path the demo app's model scanner reads — leaving GBs of bogus entries that masqueraded as real models and could crash backends that tried to load them. Tests now route every write through a per-test scratch directory using a new `makeIsolatedModelStorage()` helper in `BaseChatTestSupport`, and a `scripts/clean-leaked-test-artifacts.sh` with a `--dry-run` flag is included to sweep up artefacts left behind by earlier runs without touching real model files.

Closes #379.