### PR TITLE
fix: restore macOS model management sheet content

### DIFF
--- a/Tests/BaseChatUITests/ModelManagementSheetLogicTests.swift
+++ b/Tests/BaseChatUITests/ModelManagementSheetLogicTests.swift
@@ -1,4 +1,8 @@
 @preconcurrency import XCTest
+#if canImport(AppKit)
+import AppKit
+#endif
+import SwiftUI
 @testable import BaseChatUI
 @testable import BaseChatCore
 @testable import BaseChatInference
@@ -50,6 +54,29 @@ final class ModelManagementSheetLogicTests: XCTestCase {
         XCTAssertEqual(cases.count, 3)
         XCTAssertEqual(cases, [.select, .download, .storage])
     }
+
+    #if canImport(AppKit)
+    // Regression guard for #378: a `NavigationStack { VStack { List } }` sheet
+    // collapses to zero height on native macOS without an explicit outer frame.
+    // Keep thresholds in lock-step with the `.frame(minWidth:minHeight:)` in
+    // `ModelManagementSheet` (currently 560 x 480) so a future refactor that
+    // drops the frame fails here rather than silently regressing the sheet.
+    func test_macOS_sheetHasStableMinimumLayoutForAllTabs() {
+        for tab in ModelManagementSheet.Tab.allCases {
+            let size = hostedSheetFittingSize(for: tab)
+            XCTAssertGreaterThanOrEqual(
+                size.width,
+                560,
+                "\(tab.rawValue) tab should reserve enough width for its content on macOS"
+            )
+            XCTAssertGreaterThanOrEqual(
+                size.height,
+                480,
+                "\(tab.rawValue) tab should reserve enough height for its content on macOS"
+            )
+        }
+    }
+    #endif
 
     // MARK: - Model selection state transitions
 
@@ -268,4 +295,19 @@ final class ModelManagementSheetLogicTests: XCTestCase {
         XCTAssertTrue(ModelCapabilityTier.balanced < .capable)
         XCTAssertTrue(ModelCapabilityTier.capable < .frontier)
     }
+
+    #if canImport(AppKit)
+    private func hostedSheetFittingSize(for tab: ModelManagementSheet.Tab) -> CGSize {
+        let (vm, _) = makeViewModelWithMock()
+        let controller = NSHostingController(
+            rootView: ModelManagementSheet(initialTab: tab)
+                .environment(vm)
+                .environment(ModelManagementViewModel())
+        )
+
+        _ = controller.view
+        controller.view.layoutSubtreeIfNeeded()
+        return controller.view.fittingSize
+    }
+    #endif
 }


### PR DESCRIPTION
## What does this change?

Fixes the macOS Model Management sheet so the Select, Download, and Storage tabs render their content again instead of collapsing to a blank area below the segmented control.

## Motivation

Closes #378.

On native macOS the sheet gave its tab content no stable size, so the list-based views collapsed and users could not select, download, or inspect models from the demo app.

## Release Note

**Restore macOS model management sheet content** — On macOS the Model Management sheet could open with a blank content region for every tab, making model selection and downloads unavailable. This change gives the tab content a stable layout in the sheet so Select, Download, and Storage all render correctly again.

## Testing

- `swift test --filter BaseChatUITests --disable-default-traits`
- `swift test --filter BaseChatSnapshotTests --disable-default-traits`
- `xcodebuild -project Example/BaseChatDemo.xcodeproj -scheme BaseChatDemo -destination 'platform=macOS,arch=arm64' build CODE_SIGNING_ALLOWED=NO`

## Checklist

- [x] Tests added or updated for new behaviour
- [ ] Public API changes have `///` doc comments
- [x] No hardcoded secrets, API keys, or personal data
- [ ] Breaking change? (if yes, describe migration path below)
