### PR TITLE
fix: isolate test model storage

### DIFF
--- a/Sources/BaseChatTestSupport/TestModelStorageSandbox.swift
+++ b/Sources/BaseChatTestSupport/TestModelStorageSandbox.swift
@@ -1,0 +1,49 @@
+import Foundation
+import BaseChatInference
+
+/// Creates an isolated on-disk models directory for tests.
+///
+/// Tests that exercise `ModelStorageService`, `ChatViewModel.refreshModels()`,
+/// or model import flows must not touch the real user's Documents/Models
+/// directory. This sandbox provides a per-test storage root and cleans it up
+/// when the test ends.
+public final class TestModelStorageSandbox {
+    private let fileManager: FileManager
+
+    public let rootDirectory: URL
+    public let modelsDirectory: URL
+    public let storageService: ModelStorageService
+
+    public init(prefix: String = "BaseChatModelsTest", fileManager: FileManager = .default) throws {
+        self.fileManager = fileManager
+
+        let safePrefix = prefix.replacingOccurrences(
+            of: #"[^A-Za-z0-9._-]+"#,
+            with: "-",
+            options: .regularExpression
+        )
+        let rootDirectory = fileManager.temporaryDirectory
+            .appendingPathComponent("\(safePrefix)-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: rootDirectory, withIntermediateDirectories: true)
+
+        let modelsDirectory = rootDirectory.appendingPathComponent("Models", isDirectory: true)
+        self.rootDirectory = rootDirectory
+        self.modelsDirectory = modelsDirectory
+        self.storageService = ModelStorageService(fileManager: fileManager, baseDirectory: modelsDirectory)
+    }
+
+    public func cleanup() {
+        do {
+            try fileManager.removeItem(at: rootDirectory)
+        } catch let error as NSError
+            where error.domain == NSCocoaErrorDomain && error.code == NSFileNoSuchFileError {
+            return
+        } catch {
+            NSLog("Failed to remove test model sandbox at %@: %@", rootDirectory.path, error.localizedDescription)
+        }
+    }
+
+    deinit {
+        cleanup()
+    }
+}

--- a/TESTING.md
+++ b/TESTING.md
@@ -614,6 +614,14 @@ After your test passes, temporarily break the code path being tested and confirm
 - **Test methods:** `test_{method}_{scenario}_{expected}` — e.g., `test_stopGeneration_midStream_preservesPartialContent`
 - **Placement:** Match the target that owns the code being tested. ViewModel tests go in `BaseChatUITests`, service tests in `BaseChatCoreTests`, backend tests in `BaseChatBackendsTests`.
 
+### Filesystem isolation
+
+Tests that touch `ModelStorageService`, call `refreshModels()`, or import/download local
+models must use an isolated models directory (for example `TestModelStorageSandbox`) rather
+than the default user Documents/Models location. If you need to clean up artifacts from
+older test runs, use `scripts/cleanup-test-model-artifacts.sh --dry-run` to inspect them
+and `--apply` to remove them.
+
 ### Framework choice
 
 - **Existing files:** Match whatever the file already uses (XCTest or Swift Testing)

--- a/Tests/BaseChatInferenceTests/HotPathPerformanceTests.swift
+++ b/Tests/BaseChatInferenceTests/HotPathPerformanceTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import BaseChatInference
+import BaseChatTestSupport
 
 final class HotPathPerformanceTests: XCTestCase {
 
@@ -69,20 +70,24 @@ final class HotPathPerformanceTests: XCTestCase {
 
     private var service: ModelStorageService!
     private var createdURLs: [URL] = []
+    private var sandbox: TestModelStorageSandbox!
 
-    override func setUp() {
-        super.setUp()
-        service = ModelStorageService()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sandbox = try TestModelStorageSandbox(prefix: "HotPathPerformanceTests")
+        service = sandbox.storageService
         createdURLs = []
     }
 
-    override func tearDown() {
+    override func tearDownWithError() throws {
         for url in createdURLs {
             try? FileManager.default.removeItem(at: url)
         }
         createdURLs = []
         service = nil
-        super.tearDown()
+        sandbox.cleanup()
+        sandbox = nil
+        try super.tearDownWithError()
     }
 
     @discardableResult

--- a/Tests/BaseChatInferenceTests/ModelStorageServiceTests.swift
+++ b/Tests/BaseChatInferenceTests/ModelStorageServiceTests.swift
@@ -1,28 +1,30 @@
 import XCTest
 @testable import BaseChatInference
+import BaseChatTestSupport
 
 final class ModelStorageServiceTests: XCTestCase {
 
     private var service: ModelStorageService!
     private var createdURLs: [URL]!
+    private var sandbox: TestModelStorageSandbox!
 
-    override func setUp() {
-        super.setUp()
-        service = ModelStorageService()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sandbox = try TestModelStorageSandbox(prefix: "ModelStorageServiceTests")
+        service = sandbox.storageService
         createdURLs = []
-
-        // Ensure the shared Models directory exists so tests can write into it.
-        try? service.ensureModelsDirectory()
+        try service.ensureModelsDirectory()
     }
 
-    override func tearDown() {
-        // Remove only the files/directories this test run created.
+    override func tearDownWithError() throws {
         for url in createdURLs {
             try? FileManager.default.removeItem(at: url)
         }
         createdURLs = nil
         service = nil
-        super.tearDown()
+        sandbox.cleanup()
+        sandbox = nil
+        try super.tearDownWithError()
     }
 
     // MARK: - Helpers
@@ -33,7 +35,8 @@ final class ModelStorageServiceTests: XCTestCase {
     private func createGgufFile(named prefix: String = "test", size: Int = 1024) throws -> URL {
         let fileName = "\(prefix)-\(UUID().uuidString).gguf"
         let url = service.modelsDirectory.appendingPathComponent(fileName)
-        let data = Data(repeating: 0xAA, count: size)
+        var data = Data(ggufMagic)
+        data.append(Data(repeating: 0xAA, count: max(size - data.count, 0)))
         try data.write(to: url)
         createdURLs.append(url)
         return url
@@ -47,7 +50,7 @@ final class ModelStorageServiceTests: XCTestCase {
         let url = service.modelsDirectory.appendingPathComponent(dirName)
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
 
-        let configData = Data("{}".utf8)
+        let configData = Data(#"{"model_type":"llama"}"#.utf8)
         try configData.write(to: url.appendingPathComponent("config.json"))
 
         let weightsData = Data(repeating: 0xBB, count: weightsSize)
@@ -89,7 +92,7 @@ final class ModelStorageServiceTests: XCTestCase {
         let ggufURL = try createGgufFile()
 
         let models = service.discoverModels()
-        let match = models.first { $0.url == ggufURL }
+        let match = models.first { $0.fileName == ggufURL.lastPathComponent }
 
         XCTAssertNotNil(match, "Should discover the GGUF file")
         XCTAssertEqual(match?.modelType, .gguf)
@@ -116,23 +119,8 @@ final class ModelStorageServiceTests: XCTestCase {
     }
 
     func test_discoverModels_emptyDirectory_returnsEmpty() throws {
-        // Use a fresh service pointed at the real models directory.
-        // We can't guarantee the directory is truly empty (other tests may run),
-        // so instead verify that with no test files created, our test files aren't present.
-        // A more precise test: create a separate service with a temporary directory.
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("EmptyModelsTest-\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: tempDir) }
-
-        // discoverModels scans service.modelsDirectory, but we can verify that a directory
-        // with no model files returns nothing by checking none of our unique IDs appear.
-        // For a true empty-directory test, verify there are no models with our UUID prefix.
         let models = service.discoverModels()
-        let uniqueTag = UUID().uuidString
-        let match = models.first { $0.fileName.contains(uniqueTag) }
-
-        XCTAssertNil(match, "No models with the unique tag should be found")
+        XCTAssertTrue(models.isEmpty, "Empty isolated models directory should return no models")
     }
 
     func test_discoverModels_mixedFormats_findsBoth() throws {
@@ -182,7 +170,7 @@ final class ModelStorageServiceTests: XCTestCase {
         let ggufURL = try createGgufFile()
 
         let models = service.discoverModels()
-        let model = try XCTUnwrap(models.first { $0.url == ggufURL })
+        let model = try XCTUnwrap(models.first { $0.fileName == ggufURL.lastPathComponent })
 
         try service.deleteModel(model)
 

--- a/Tests/BaseChatUITests/GenerationViewModelTests.swift
+++ b/Tests/BaseChatUITests/GenerationViewModelTests.swift
@@ -10,6 +10,7 @@ final class ChatViewModelTests: XCTestCase {
     // MARK: - Helpers
 
     private let oneGB: UInt64 = 1_024 * 1_024 * 1_024
+    private var sandbox: TestModelStorageSandbox!
 
     /// Convenience to build a view model with controllable device memory.
     /// Uses a default InferenceService (no backend loaded).
@@ -17,7 +18,7 @@ final class ChatViewModelTests: XCTestCase {
         ChatViewModel(
             inferenceService: InferenceService(),
             deviceCapability: DeviceCapabilityService(physicalMemory: ramGB * oneGB),
-            modelStorage: ModelStorageService(),
+            modelStorage: sandbox.storageService,
             memoryPressure: MemoryPressureHandler()
         )
     }
@@ -32,7 +33,7 @@ final class ChatViewModelTests: XCTestCase {
         let vm = ChatViewModel(
             inferenceService: service,
             deviceCapability: DeviceCapabilityService(physicalMemory: ramGB * oneGB),
-            modelStorage: ModelStorageService(),
+            modelStorage: sandbox.storageService,
             memoryPressure: MemoryPressureHandler()
         )
         // Set an active session so sendMessage/regenerate/edit don't bail out.
@@ -40,16 +41,14 @@ final class ChatViewModelTests: XCTestCase {
         return (vm, mock)
     }
 
-    /// The models directory used by a default `ModelStorageService`.
     private var modelsDirectory: URL {
-        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-        return documents.appendingPathComponent("Models", isDirectory: true)
+        sandbox.modelsDirectory
     }
 
     /// Creates a fake .gguf file in the models directory and returns its URL.
     @discardableResult
     private func createFakeGGUF(named fileName: String, sizeBytes: Int = 1024) throws -> URL {
-        try FileManager.default.createDirectory(at: modelsDirectory, withIntermediateDirectories: true)
+        try sandbox.storageService.ensureModelsDirectory()
         let fileURL = modelsDirectory.appendingPathComponent(fileName)
         let data = Data(repeating: 0, count: sizeBytes)
         try data.write(to: fileURL)
@@ -64,12 +63,19 @@ final class ChatViewModelTests: XCTestCase {
     /// Removes all .gguf files from the models directory created during the test.
     private nonisolated(unsafe) var createdFiles: [URL] = []
 
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sandbox = try TestModelStorageSandbox(prefix: "GenerationViewModelTests")
+    }
+
     override func tearDown() async throws {
-        try await super.tearDown()
         for url in createdFiles {
             removeFile(at: url)
         }
         createdFiles.removeAll()
+        sandbox.cleanup()
+        sandbox = nil
+        try await super.tearDown()
     }
 
     // MARK: - test_init_defaultState

--- a/Tests/BaseChatUITests/ModelManagementViewModelTests.swift
+++ b/Tests/BaseChatUITests/ModelManagementViewModelTests.swift
@@ -8,9 +8,11 @@ import BaseChatTestSupport
 final class ModelManagementViewModelTests: XCTestCase {
 
     private let oneGB: UInt64 = 1_024 * 1_024 * 1_024
+    private var sandbox: TestModelStorageSandbox!
 
     override func setUp() async throws {
         try await super.setUp()
+        sandbox = try TestModelStorageSandbox(prefix: "ModelManagementViewModelTests")
         // Provide curated models for tests that depend on recommendations.
         // In production, the app populates CuratedModel.all at startup.
         CuratedModel.all = [
@@ -55,6 +57,8 @@ final class ModelManagementViewModelTests: XCTestCase {
 
     override func tearDown() async throws {
         CuratedModel.all = []
+        sandbox.cleanup()
+        sandbox = nil
         try await super.tearDown()
     }
 
@@ -282,7 +286,7 @@ final class ModelManagementViewModelTests: XCTestCase {
     // MARK: - Local Model Import
 
     func test_importModel_withGGUF_copiesFileIntoModelsDirectory() throws {
-        let vm = ModelManagementViewModel()
+        let vm = ModelManagementViewModel(modelStorage: sandbox.storageService)
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("ModelImport-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -302,7 +306,7 @@ final class ModelManagementViewModelTests: XCTestCase {
     }
 
     func test_importModel_withUnsupportedFile_throwsAndRemovesCopy() throws {
-        let vm = ModelManagementViewModel()
+        let vm = ModelManagementViewModel(modelStorage: sandbox.storageService)
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("ModelImportUnsupported-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -329,6 +333,7 @@ final class ModelManagementViewModelTests: XCTestCase {
 
         let diagnostics = DiagnosticsService()
         let vm = ModelManagementViewModel(
+            modelStorage: sandbox.storageService,
             diagnostics: diagnostics,
             fileRemover: { _ in throw DeletionFailure() }
         )
@@ -362,7 +367,10 @@ final class ModelManagementViewModelTests: XCTestCase {
 
     func test_importModel_whenCleanupSucceeds_recordsNoWarning() throws {
         let diagnostics = DiagnosticsService()
-        let vm = ModelManagementViewModel(diagnostics: diagnostics)
+        let vm = ModelManagementViewModel(
+            modelStorage: sandbox.storageService,
+            diagnostics: diagnostics
+        )
 
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("ModelImportWarningOK-\(UUID().uuidString)")

--- a/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
+++ b/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
@@ -11,12 +11,13 @@ final class ViewModelEdgeCaseTests: XCTestCase {
     // MARK: - Helpers
 
     private let oneGB: UInt64 = 1_024 * 1_024 * 1_024
+    private var sandbox: TestModelStorageSandbox!
 
     private func makeViewModel(ramGB: UInt64 = 16) -> ChatViewModel {
         ChatViewModel(
             inferenceService: InferenceService(),
             deviceCapability: DeviceCapabilityService(physicalMemory: ramGB * oneGB),
-            modelStorage: ModelStorageService(),
+            modelStorage: sandbox.storageService,
             memoryPressure: MemoryPressureHandler()
         )
     }
@@ -30,7 +31,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         let vm = ChatViewModel(
             inferenceService: service,
             deviceCapability: DeviceCapabilityService(physicalMemory: ramGB * oneGB),
-            modelStorage: ModelStorageService(),
+            modelStorage: sandbox.storageService,
             memoryPressure: MemoryPressureHandler()
         )
         return (vm, mock)
@@ -45,12 +46,23 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         let vm = ChatViewModel(
             inferenceService: service,
             deviceCapability: DeviceCapabilityService(physicalMemory: 16 * oneGB),
-            modelStorage: ModelStorageService(),
+            modelStorage: sandbox.storageService,
             memoryPressure: MemoryPressureHandler()
         )
         let persistence = MockPersistenceProvider()
         vm.configure(persistence: persistence)
         return (vm, mock, persistence)
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sandbox = try TestModelStorageSandbox(prefix: "ViewModelEdgeCaseTests")
+    }
+
+    override func tearDownWithError() throws {
+        sandbox.cleanup()
+        sandbox = nil
+        try super.tearDownWithError()
     }
 
     // MARK: - saveSettingsToSession

--- a/scripts/cleanup-test-model-artifacts.sh
+++ b/scripts/cleanup-test-model-artifacts.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/cleanup-test-model-artifacts.sh [--dry-run|--apply]
+
+Scans production model directories for files and directories leaked by older
+tests, then prints the matches. Pass --apply to delete them.
+EOF
+}
+
+mode="dry-run"
+case "${1:-}" in
+  "")
+    ;;
+  --dry-run)
+    ;;
+  --apply)
+    mode="apply"
+    ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac
+
+is_known_test_artifact() {
+  local name="$1"
+
+  [[ "$name" == "test-refresh-model.gguf" ]] && return 0
+  [[ "$name" == "test-stale-model.gguf" ]] && return 0
+
+  [[ "$name" =~ ^(test|mlx-model|not-a-model|mixed-gguf|mixed-mlx|sizeA|sizeB|import-test|overwrite-test|imported|unsupported|perf-gguf-[0-9]+|perf-mlx-[0-9]+)-[0-9A-Fa-f-]{36}(\.[A-Za-z0-9]+)?$ ]] && return 0
+  [[ "$name" =~ ^(aaa|bbb|ccc)-[0-9A-Fa-f]{8}-[0-9A-Fa-f-]{36}\.gguf$ ]] && return 0
+
+  return 1
+}
+
+declare -a search_roots=()
+documents_models="$HOME/Documents/Models"
+if [[ -d "$documents_models" ]]; then
+  search_roots+=("$documents_models")
+fi
+
+containers_root="$HOME/Library/Containers"
+if [[ -d "$containers_root" ]]; then
+  while IFS= read -r models_dir; do
+    search_roots+=("$models_dir")
+  done < <(find "$containers_root" -type d -path "*/Data/Documents/Models" -print 2>/dev/null)
+fi
+
+if [[ ${#search_roots[@]} -eq 0 ]]; then
+  echo "No production Models directories found."
+  exit 0
+fi
+
+declare -a matches=()
+for root in "${search_roots[@]}"; do
+  while IFS= read -r candidate; do
+    name="${candidate##*/}"
+    if is_known_test_artifact "$name"; then
+      matches+=("$candidate")
+    fi
+  done < <(find "$root" -mindepth 1 -maxdepth 1 -print 2>/dev/null)
+done
+
+if [[ ${#matches[@]} -eq 0 ]]; then
+  echo "No leaked test artifacts found."
+  exit 0
+fi
+
+printf 'Found %d leaked test artifact(s):\n' "${#matches[@]}"
+printf ' - %s\n' "${matches[@]}"
+
+if [[ "$mode" != "apply" ]]; then
+  echo "Dry run only. Re-run with --apply to delete these paths."
+  exit 0
+fi
+
+for path in "${matches[@]}"; do
+  rm -rf -- "$path"
+done
+
+echo "Removed leaked test artifacts."


### PR DESCRIPTION
## What does this change?

Moves model-storage tests onto isolated temporary sandboxes, adds a cleanup script for previously leaked artifacts, and documents the rule so test runs stop polluting real user model directories.

## Motivation

Closes #379.

Several tests and performance paths were using default model storage or hardcoded `Documents/Models` paths, which leaked fake GGUF and MLX artifacts into the real app container and polluted developer machines.

## Release Note

**Isolate test model storage from user data** — Some tests were writing fake model files into the real BaseChatDemo Models directory, polluting developer machines and making the app think bogus models were installed. This change moves those tests onto dedicated temporary sandboxes, adds a cleanup script for old leaked artifacts, and documents the isolation requirement so test runs no longer touch real user storage.

## Testing

- `swift test --filter BaseChatInferenceTests --disable-default-traits`
- `swift test --filter BaseChatUITests --disable-default-traits`
- `swift test --filter ModelStorageServiceTests --disable-default-traits`
- `swift test --filter SilentCatchAuditTest --disable-default-traits`
- `scripts/cleanup-test-model-artifacts.sh --dry-run`

## Checklist

- [x] Tests added or updated for new behaviour
- [ ] Public API changes have `///` doc comments
- [x] No hardcoded secrets, API keys, or personal data
- [ ] Breaking change? (if yes, describe migration path below)
