### PR TITLE
fix: restore macOS demo UI test visibility

### DIFF
--- a/Example/BaseChatDemo/DemoContentView.swift
+++ b/Example/BaseChatDemo/DemoContentView.swift
@@ -33,6 +33,7 @@ struct DemoContentView: View {
         } detail: {
             ChatView(showModelManagement: $isModelManagementPresented)
                 .toolbar {
+                    #if os(iOS)
                     if horizontalSizeClass == .compact {
                         ToolbarItem(placement: .topBarLeading) {
                             Button {
@@ -44,6 +45,7 @@ struct DemoContentView: View {
                             .accessibilityIdentifier("show-sidebar-button")
                         }
                     }
+                    #endif
                 }
         }
         .sheet(isPresented: $isModelManagementPresented) {

--- a/Example/BaseChatDemoUITests/ModelManagementUITests.swift
+++ b/Example/BaseChatDemoUITests/ModelManagementUITests.swift
@@ -14,7 +14,7 @@ final class ModelManagementUITests: XCTestCase {
     func testModelButtonOpensSheet() throws {
         openModelManagementSheet()
 
-        let selectTab = app.segmentedControls.buttons["Select"]
+        let selectTab = modelManagementTab("Select", app: app)
         XCTAssertTrue(selectTab.waitForExistence(timeout: 3), "Select tab should appear in model management sheet")
     }
 
@@ -24,9 +24,9 @@ final class ModelManagementUITests: XCTestCase {
         openModelManagementSheet()
 
         // Verify all three tabs exist
-        let selectTab = app.segmentedControls.buttons["Select"]
-        let downloadTab = app.segmentedControls.buttons["Download"]
-        let storageTab = app.segmentedControls.buttons["Storage"]
+        let selectTab = modelManagementTab("Select", app: app)
+        let downloadTab = modelManagementTab("Download", app: app)
+        let storageTab = modelManagementTab("Storage", app: app)
 
         XCTAssertTrue(selectTab.exists, "Select tab should exist")
         XCTAssertTrue(downloadTab.exists, "Download tab should exist")
@@ -122,7 +122,7 @@ final class ModelManagementUITests: XCTestCase {
     func testDownloadTabShowsRecommendations() throws {
         openModelManagementSheet()
 
-        app.segmentedControls.buttons["Download"].tap()
+        modelManagementTab("Download", app: app).tap()
         sleep(1)
 
         takeScreenshot(name: "Download-Tab-Content")
@@ -141,7 +141,7 @@ final class ModelManagementUITests: XCTestCase {
     func testDownloadTabSearchFieldIsInteractive() throws {
         openModelManagementSheet()
 
-        app.segmentedControls.buttons["Download"].tap()
+        modelManagementTab("Download", app: app).tap()
         sleep(1)
 
         let searchField = app.textFields["Search HuggingFace models"]
@@ -156,7 +156,7 @@ final class ModelManagementUITests: XCTestCase {
     func testDownloadButtonIsHittable() throws {
         openModelManagementSheet()
 
-        app.segmentedControls.buttons["Download"].tap()
+        modelManagementTab("Download", app: app).tap()
         sleep(1)
 
         // Look for download buttons (arrow.down.circle)
@@ -177,7 +177,7 @@ final class ModelManagementUITests: XCTestCase {
     func testStorageTabShowsOverview() throws {
         openModelManagementSheet()
 
-        app.segmentedControls.buttons["Storage"].tap()
+        modelManagementTab("Storage", app: app).tap()
         sleep(1)
 
         takeScreenshot(name: "Storage-Tab-Content")
@@ -210,9 +210,9 @@ final class ModelManagementUITests: XCTestCase {
         openModelManagementSheet()
 
         let controls = [
-            app.segmentedControls.buttons["Select"],
-            app.segmentedControls.buttons["Download"],
-            app.segmentedControls.buttons["Storage"],
+            modelManagementTab("Select", app: app),
+            modelManagementTab("Download", app: app),
+            modelManagementTab("Storage", app: app),
             app.buttons["Done"]
         ]
 
@@ -227,7 +227,7 @@ final class ModelManagementUITests: XCTestCase {
     private func openModelManagementSheet() {
         openModelManagementIfNeeded(app: app)
 
-        let selectTab = app.segmentedControls.buttons["Select"]
+        let selectTab = modelManagementTab("Select", app: app)
         guard selectTab.waitForExistence(timeout: 5) else {
             takeScreenshot(name: "Sidebar-No-Model-Button")
             XCTFail("Model management sheet did not open")

--- a/Example/BaseChatDemoUITests/UITestHelpers.swift
+++ b/Example/BaseChatDemoUITests/UITestHelpers.swift
@@ -7,10 +7,22 @@ extension XCTestCase {
 
     /// Launches the demo app in deterministic UI-testing mode.
     @discardableResult
-    func launchDemoApp() -> XCUIApplication {
+    func launchDemoApp(file: StaticString = #filePath, line: UInt = #line) -> XCUIApplication {
         let app = XCUIApplication()
-        app.launchArguments += ["--uitesting", "-ApplePersistenceIgnoreState", "YES"]
+        app.launchArguments += ["--uitesting"]
+        #if !os(macOS)
+        app.launchArguments += ["-ApplePersistenceIgnoreState", "YES"]
+        #endif
         app.launch()
+        #if os(macOS)
+        app.activate()
+        XCTAssertTrue(
+            app.wait(for: .runningForeground, timeout: 5),
+            "BaseChatDemo should reach the foreground under macOS UI tests",
+            file: file,
+            line: line
+        )
+        #endif
         return app
     }
 
@@ -120,8 +132,8 @@ extension XCTestCase {
     }
 
     func openModelManagementIfNeeded(app: XCUIApplication) {
-        if app.segmentedControls["model-management-tab-picker"].exists
-            || app.segmentedControls.buttons["Select"].exists {
+        if app.descendants(matching: .any).matching(identifier: "model-management-tab-picker").firstMatch.exists
+            || modelManagementTab("Select", app: app).exists {
             return
         }
 
@@ -141,6 +153,28 @@ extension XCTestCase {
             candidate.tap()
             break
         }
+    }
+
+    func modelManagementTab(_ label: String, app: XCUIApplication) -> XCUIElement {
+        let labelMatch = NSPredicate(format: "label == %@", label)
+        let pickerTab = app
+            .descendants(matching: .any)
+            .matching(identifier: "model-management-tab-picker")
+            .firstMatch
+            .descendants(matching: .any)
+            .matching(labelMatch)
+            .firstMatch
+        let candidates = [
+            pickerTab,
+            app.segmentedControls.buttons[label],
+            app.buttons[label]
+        ]
+
+        for candidate in candidates where candidate.exists {
+            return candidate
+        }
+
+        return pickerTab
     }
 
     func advancedSettingsDisclosure(app: XCUIApplication) -> XCUIElement {


### PR DESCRIPTION
## What does this change?

Restores native macOS demo UI testing by ensuring the app is foregrounded when XCUITest launches it, and updates the model-management tab test interactions to match the macOS accessibility hierarchy.

## Motivation

Closes #377.

Native macOS XCUITests could only see the menu bar because `BaseChatDemo` never reached the foreground under the runner. That made the existing model-management coverage ineffective on macOS even though the app worked when launched normally.

## Release Note

**Restore macOS demo UI test visibility** — Native macOS UI tests could not see the BaseChatDemo window because the app stayed backgrounded under XCUITest. This change activates the app during UI-test launch, updates the affected model-management tests to use the macOS radio-button tab hierarchy, and keeps the demo app building on macOS by guarding an iOS-only toolbar placement.

## Testing

- `scripts/example-ui-tests.sh build-for-testing --destination 'platform=macOS,arch=arm64'`
- `scripts/example-ui-tests.sh test-without-building --destination 'platform=macOS,arch=arm64' -only-testing:BaseChatDemoUITests/ModelManagementUITests/testModelButtonOpensSheet -only-testing:BaseChatDemoUITests/ModelManagementUITests/testCanSwitchBetweenTabs`

## Checklist

- [x] Tests added or updated for new behaviour
- [ ] Public API changes have `///` doc comments
- [x] No hardcoded secrets, API keys, or personal data
- [ ] Breaking change? (if yes, describe migration path below)
