### PR TITLE
test: remove stale XCTSkipIf guards for closed #377

### DIFF
--- a/Example/BaseChatDemoUITests/ModelManagementUITests.swift
+++ b/Example/BaseChatDemoUITests/ModelManagementUITests.swift
@@ -301,11 +301,6 @@ final class ModelManagementUITests: XCTestCase {
     }
 
     func testSelectingGGUFModelProducesResponse() throws {
-        // FIXME: https://github.com/roryford/BaseChatKit/issues/377
-        // XCTSkipIf(true, ...) (rather than `throw XCTSkip`) keeps the body
-        // below reachable so the compiler keeps type-checking it against
-        // helper changes; remove this guard when #377 is fixed.
-        try XCTSkipIf(true, "Disabled pending fix for #377 — restoration requires native macOS with on-disk models, not iOS Simulator")
         try skipUnlessRealModelE2EEnabled()
         #if !arch(arm64)
         throw XCTSkip("GGUF backend (llama.cpp) requires Apple Silicon")
@@ -318,8 +313,6 @@ final class ModelManagementUITests: XCTestCase {
     }
 
     func testSelectingMLXModelProducesResponse() throws {
-        // FIXME: https://github.com/roryford/BaseChatKit/issues/377
-        try XCTSkipIf(true, "Disabled pending fix for #377 — restoration requires native macOS with on-disk models, not iOS Simulator")
         try skipUnlessRealModelE2EEnabled()
         #if !arch(arm64)
         throw XCTSkip("MLX backend requires Apple Silicon")
@@ -332,8 +325,6 @@ final class ModelManagementUITests: XCTestCase {
     }
 
     func testSelectingFoundationModelProducesResponse() throws {
-        // FIXME: https://github.com/roryford/BaseChatKit/issues/377
-        try XCTSkipIf(true, "Disabled pending fix for #377 — restoration requires native macOS, not iOS Simulator")
         try skipUnlessRealModelE2EEnabled()
 
         guard #available(macOS 26, iOS 26, *) else {


### PR DESCRIPTION
## Summary

Drops the stale `try XCTSkipIf(true, ...)` guards from the three opt-in real-model E2E tests in `ModelManagementUITests`, re-enabling the coverage added in #376.

## Context

Issue #377 (XCUITest cannot see the demo app's window on native macOS) was fixed by PR #386 and merged to `main`. However, the three real-model E2E tests added in #376 (GGUF / MLX / Foundation) still open with:

```swift
// FIXME: https://github.com/roryford/BaseChatKit/issues/377
try XCTSkipIf(true, "Disabled pending fix for #377 — ...")
```

Those guards unconditionally short-circuit the tests regardless of the sentinel-file opt-in, so the coverage added in #376 is currently dead code. Per `CLAUDE.md` §withKnownIssue Policy: "Remove the wrapper in the same PR that fixes the underlying bug" — that step was missed for #376, so this is the follow-up cleanup.

The surviving gating is intact and in order:
1. `CI` env var check (skips in CI)
2. Sentinel-file check (`~/.basechatkit_real_e2e`)
3. Arch check (`arm64` for GGUF/MLX) or `@available(macOS 26, iOS 26)` for Foundation

Tests continue to skip by default for developers without the opt-in sentinel.

## Verification

Ran the four CI test suites locally (synchronously, per saved feedback on backgrounded `swift test`):

- `swift test --filter BaseChatCoreTests --disable-default-traits` — 176 tests, 0 failures
- `swift test --filter BaseChatInferenceTests --disable-default-traits` — 69 tests, 0 failures
- `swift test --filter BaseChatUITests --disable-default-traits` — 432 tests, 0 failures
- `swift test --filter BaseChatBackendsTests --disable-default-traits` — 84 tests, 0 failures

Demo UI test target compiles:

- `scripts/example-ui-tests.sh build-for-testing` — `** TEST BUILD SUCCEEDED **`

The real-model E2E tests themselves were **not** executed end-to-end. They require ~4 GB of on-disk models, the opt-in `~/.basechatkit_real_e2e` sentinel file, Accessibility permission, and Apple Silicon hardware — outside the scope of a guard-removal PR. The remaining `skipUnlessRealModelE2EEnabled()` + arch/availability gates are unchanged, so the skip behaviour for developers without the sentinel is identical to before.

Post-edit grep of the file confirms zero `#377`, zero `FIXME`, zero `XCTSkipIf(true,` references remain.

## Release Note

Test-only cleanup, no release impact.

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` passes
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` passes
- [x] `swift test --filter BaseChatUITests --disable-default-traits` passes
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` passes
- [x] `scripts/example-ui-tests.sh build-for-testing` succeeds
- [x] Grep confirms no `#377` / `FIXME` / `XCTSkipIf(true,` references remain in the edited file
- [ ] Opt-in real-model E2E tests exercised end-to-end (deferred — requires maintainer hardware + sentinel opt-in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)