### PR TITLE
fix(test): reveal sidebar reliably on iPhone compact

### DIFF
--- a/Example/BaseChatDemoUITests/SessionManagementUITests.swift
+++ b/Example/BaseChatDemoUITests/SessionManagementUITests.swift
@@ -82,6 +82,10 @@ final class SessionManagementUITests: XCTestCase {
 
         newChatButton.tap()
 
+        // On compact, creating a session activates it and collapses to the
+        // detail column, so reveal the sidebar again before counting rows.
+        showSidebarIfNeeded(app: app)
+
         // Wait for the new session to appear
         let cellsAfterPredicate = NSPredicate(format: "count > %d", cellsBefore)
         let cellsQuery = app.cells
@@ -108,9 +112,12 @@ final class SessionManagementUITests: XCTestCase {
             return
         }
 
-        // Create a second session if needed
+        // Create a second session if needed. On compact, the tap activates the
+        // new session and collapses to the detail column, so re-reveal the
+        // sidebar before checking the row count.
         if app.cells.count < 2 {
             newChatButton.tap()
+            showSidebarIfNeeded(app: app)
             _ = app.cells.element(boundBy: 1).waitForExistence(timeout: 3)
         }
 

--- a/Example/BaseChatDemoUITests/UITestHelpers.swift
+++ b/Example/BaseChatDemoUITests/UITestHelpers.swift
@@ -30,28 +30,48 @@ extension XCTestCase {
 
     /// Shows the sidebar if the "Show Sidebar" button is visible (e.g. on iPad or compact layout).
     func showSidebarIfNeeded(app: XCUIApplication) {
-        if app.staticTexts["Chats"].exists {
+        if isSidebarVisible(app: app) {
             return
         }
 
+        // On iPhone compact, NavigationSplitView launches in detail-only mode
+        // and the sidebar toggle button's accessibility frame reaches past the
+        // window's left edge, so `.tap()` on it can deliver an event that
+        // never lands on screen. Try a right-edge coordinate tap as a first
+        // fallback, then a full-width edge swipe as a last resort.
         let sidebarButtons = [
             app.buttons["show-sidebar-button"],
             app.buttons["Show Sidebar"]
         ]
-        for sidebarButton in sidebarButtons where sidebarButton.waitForExistence(timeout: 2) && sidebarButton.isHittable {
-            sidebarButton.tap()
-            if app.staticTexts["Chats"].waitForExistence(timeout: 2)
-                || app.buttons["new-chat-button"].waitForExistence(timeout: 2)
-                || firstSessionRow(app: app).waitForExistence(timeout: 2) {
-                return
+        for sidebarButton in sidebarButtons where sidebarButton.waitForExistence(timeout: 2) {
+            if sidebarButton.isHittable {
+                sidebarButton.tap()
+                if waitForSidebar(app: app) { return }
             }
+
+            sidebarButton.coordinate(withNormalizedOffset: CGVector(dx: 1.0, dy: 0.5)).tap()
+            if waitForSidebar(app: app) { return }
         }
 
+        app.swipeRight()
+        if waitForSidebar(app: app) { return }
+
         let start = app.coordinate(withNormalizedOffset: CGVector(dx: 0.02, dy: 0.5))
-        let end = app.coordinate(withNormalizedOffset: CGVector(dx: 0.65, dy: 0.5))
-        start.press(forDuration: 0.05, thenDragTo: end)
-        _ = app.staticTexts["Chats"].waitForExistence(timeout: 2)
-            || app.buttons["new-chat-button"].waitForExistence(timeout: 2)
+        let end = app.coordinate(withNormalizedOffset: CGVector(dx: 0.95, dy: 0.5))
+        start.press(forDuration: 0.1, thenDragTo: end)
+        _ = waitForSidebar(app: app)
+    }
+
+    private func isSidebarVisible(app: XCUIApplication) -> Bool {
+        app.staticTexts["Chats"].exists
+            || app.buttons["new-chat-button"].exists
+            || firstSessionRow(app: app).exists
+    }
+
+    private func waitForSidebar(app: XCUIApplication, timeout: TimeInterval = 2) -> Bool {
+        app.staticTexts["Chats"].waitForExistence(timeout: timeout)
+            || app.buttons["new-chat-button"].waitForExistence(timeout: timeout)
+            || firstSessionRow(app: app).waitForExistence(timeout: timeout)
     }
 
     // MARK: - Chat Detail


### PR DESCRIPTION
## Summary

Fix three SessionManagementUITests that were failing on the default iPhone 17 Pro / iOS 26 simulator because the shared `showSidebarIfNeeded` helper could not open the sidebar on compact layouts.

## Root cause

On iPhone compact, `DemoContentView` launches in `columnVisibility = .detailOnly` with a toolbar button (`show-sidebar-button`) that toggles `preferredCompactColumn`. In the accessibility tree the button's frame reaches past the window's left edge (origin at negative x), so `XCUIElement.tap()` synthesised the event at the button's centroid — off-screen — and never revealed the sidebar. The existing coordinate-swipe fallback (`0.02 → 0.65`, `0.05s` press) was too short to commit the edge pan either.

With the sidebar never opening:

- `SessionManagementUITests.swift:22` — `testSidebarShowsSessions` failed on the "Chats" / `new-chat-button` / first-cell existence check.
- `SessionManagementUITests.swift:79` — `testCreateNewSession` failed in its `findNewChatButton` guard because the toolbar's New Chat button wasn't reachable.
- `SessionManagementUITests.swift:107` — `testSwitchBetweenSessions` failed in the same guard.

Once the helper is fixed and the sidebar actually opens, two of those tests surface a second issue: tapping New Chat activates a session, and on compact that flips the split view back to `.detailOnly` via `onChange(of: activeSession)`, so the cell count drops to zero before the assertion runs.

## Fix

1. `Example/BaseChatDemoUITests/UITestHelpers.swift` — rework `showSidebarIfNeeded` into a layered-fallback cascade: `isSidebarVisible` short-circuit → plain `.tap()` → right-edge coordinate tap (always on-screen because the button's right edge sits inside the window) → `app.swipeRight()` → a longer press+drag. Factor the visibility polling into `isSidebarVisible` / `waitForSidebar` so every retry uses the same "Chats" + `new-chat-button` + first-session-row signal. The helper stays a no-op on iPad/macOS because those layouts always match `isSidebarVisible` on the early-return.

2. `Example/BaseChatDemoUITests/SessionManagementUITests.swift` — after the New Chat tap in `testCreateNewSession` and the "create a second session" branch of `testSwitchBetweenSessions`, call `showSidebarIfNeeded(app: app)` again so the cell-count assertion runs against a visible session list.

No `Sources/` or `DemoContentView.swift` changes — the compact-on-iPhone hidden-sidebar default is preserved.

## Verification

All commands run from `.claude/worktrees/agent-a63645d1` against a booted iPhone 17 Pro (iOS 26.4) simulator.

- `scripts/example-ui-tests.sh build-for-testing` → `** TEST BUILD SUCCEEDED **`
- `scripts/example-ui-tests.sh test-without-building -only-testing:BaseChatDemoUITests/SessionManagementUITests` → **6 / 6 passed** (was 3 / 6 before).
- `scripts/example-ui-tests.sh test-without-building -only-testing:BaseChatDemoUITests/ModelManagementUITests -only-testing:BaseChatDemoUITests/SettingsUITests -only-testing:BaseChatDemoUITests/ChatFlowUITests` → **24 / 24 passed** (3 skipped for real-model E2E hardware gates, as before).
- `swift test --filter BaseChatCoreTests --disable-default-traits` → 176 passed, 4 skipped.
- `swift test --filter BaseChatInferenceTests --disable-default-traits` → 69 passed.
- `swift test --filter BaseChatUITests --disable-default-traits` → 432 passed.
- `swift test --filter BaseChatBackendsTests --disable-default-traits` → 84 passed.
- Sabotage check: temporarily commented out the post-tap `showSidebarIfNeeded(app: app)` in `testCreateNewSession`, rebuilt, and confirmed the original failure reproduced — `XCTAssertGreaterThan failed: ("0") is not greater than ("0") - At least one session should exist after creation`. Restored and re-ran: passes.

## Release Note

Test-only fix, no release impact.

## Test plan

- [x] `SessionManagementUITests` — all 6 tests pass on iPhone 17 Pro / iOS 26
- [x] `ModelManagementUITests`, `SettingsUITests`, `ChatFlowUITests` — no regressions on the same simulator
- [x] `BaseChatCoreTests`, `BaseChatInferenceTests`, `BaseChatUITests`, `BaseChatBackendsTests` — all pass with `--disable-default-traits`
- [x] Sabotage check reproduces the original failure when the fix is removed