### PR TITLE
chore: sync ViewInspector lockfile

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "966e85381c49081885a22b7dcdbbf80588eb7b44262630b041f833cecde51dfd",
+  "originHash" : "772b362ea69d9759a9c24e33007c26cf9209579d8d1cd3dd9978f7f44827352f",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -98,6 +98,15 @@
       "state" : {
         "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
         "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "viewinspector",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nalexn/ViewInspector",
+      "state" : {
+        "revision" : "e9a06346499a3a889165647e3f23f8a7b2609a1c",
+        "version" : "0.10.3"
       }
     },
     {


### PR DESCRIPTION
## What does this change?

Syncs the tracked root `Package.resolved` with the already-declared `ViewInspector` package in `Package.swift` by adding the missing `0.10.3` pin.

## Motivation

`Package.swift` already declares `ViewInspector` and `BaseChatUITests` imports it, but the tracked root lockfile still omitted that package. That left the repository in a state where local resolves kept reintroducing a `Package.resolved` diff.

## Release Note

N/A

## Testing

- `swift package resolve`
- `swift test --filter BaseChatUITests --disable-default-traits`

## Checklist

- [ ] Tests added or updated for new behaviour
- [ ] Public API changes have `///` doc comments
- [x] No hardcoded secrets, API keys, or personal data
- [ ] Breaking change? (if yes, describe migration path below)
