### PR TITLE
fix: use architecture-aware llama KV cache estimates

### DIFF
--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -226,6 +226,30 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         }
     }
 
+    static func computeKVBytesPerToken(
+        from parameters: GGUFKVCacheParameters,
+        bytesPerElement: Int64 = Int64(GGUFKVCacheEstimator.defaultBytesPerElement)
+    ) -> Int64? {
+        guard bytesPerElement > 0,
+              let estimate = GGUFKVCacheEstimator.estimateBytesPerToken(
+                from: parameters,
+                bytesPerElement: UInt64(bytesPerElement)
+              ) else {
+            return nil
+        }
+        return Int64(estimate)
+    }
+
+    static func computeKVBytesPerToken(
+        for model: OpaquePointer,
+        bytesPerElement: Int64 = Int64(GGUFKVCacheEstimator.defaultBytesPerElement)
+    ) -> Int64? {
+        computeKVBytesPerToken(
+            from: kvCacheParameters(for: model),
+            bytesPerElement: bytesPerElement
+        )
+    }
+
     /// Returns the maximum context size (in tokens) that is safe to allocate given
     /// the memory available to this process.
     ///
@@ -237,9 +261,18 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
     ///
     /// On macOS there is no per-app jetsam limit, so physical memory is the right ceiling.
     ///
-    /// 1 token ≈ 8 KB of KV cache; the result is clamped to 128 000 as an absolute ceiling.
-    static func computeRamSafeCap() -> Int32 {
-        let kvBytesPerToken: Int64 = 8_192  // 8 KB/token — matches DeviceCapabilityService
+    /// The loaded model's KV geometry is preferred when available; otherwise the legacy
+    /// 8 KB/token fallback is used. The result is clamped to 128 000 as an absolute ceiling.
+    static func computeRamSafeCap(
+        for model: OpaquePointer? = nil,
+        kvBytesPerToken: Int64? = nil
+    ) -> Int32 {
+        let kvBytesPerToken = max(
+            1,
+            kvBytesPerToken
+                ?? model.flatMap { Self.computeKVBytesPerToken(for: $0) }
+                ?? Int64(GGUFKVCacheEstimator.legacyFallbackBytesPerToken)
+        )
         #if os(iOS) || os(tvOS) || os(watchOS)
         let available = os_proc_available_memory()
         // os_proc_available_memory() can return 0 or negative in edge cases (simulator boot);
@@ -250,6 +283,74 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         #endif
         let physical = Int64(ProcessInfo.processInfo.physicalMemory)
         return Int32(min(Int64(128_000), physical / kvBytesPerToken))
+    }
+
+    private static func kvCacheParameters(for model: OpaquePointer) -> GGUFKVCacheParameters {
+        let architecture = modelMetadataString(for: model, key: "general.architecture")
+        let attentionHeadCount = modelMetadataInteger(
+            for: model,
+            key: architecture.map { "\($0).attention.head_count" }
+        ) ?? positive(llama_model_n_head(model))
+
+        return GGUFKVCacheParameters(
+            blockCount: modelMetadataInteger(
+                for: model,
+                key: architecture.map { "\($0).block_count" }
+            ) ?? positive(llama_model_n_layer(model)),
+            embeddingLength: modelMetadataInteger(
+                for: model,
+                key: architecture.map { "\($0).embedding_length" }
+            ) ?? positive(llama_model_n_embd(model)),
+            attentionHeadCount: attentionHeadCount,
+            attentionHeadCountKV: modelMetadataInteger(
+                for: model,
+                key: architecture.map { "\($0).attention.head_count_kv" }
+            ) ?? positive(llama_model_n_head_kv(model)) ?? attentionHeadCount,
+            attentionKeyLength: modelMetadataInteger(
+                for: model,
+                key: architecture.map { "\($0).attention.key_length" }
+            ),
+            attentionValueLength: modelMetadataInteger(
+                for: model,
+                key: architecture.map { "\($0).attention.value_length" }
+            )
+        )
+    }
+
+    private static func modelMetadataInteger(for model: OpaquePointer, key: String?) -> Int? {
+        guard let key,
+              let rawValue = modelMetadataString(for: model, key: key)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) else {
+            return nil
+        }
+        return Int(rawValue)
+    }
+
+    private static func modelMetadataString(for model: OpaquePointer, key: String) -> String? {
+        var bufferSize = 64
+
+        while bufferSize <= 4096 {
+            var buffer = [CChar](repeating: 0, count: bufferSize)
+            let requiredLength = buffer.withUnsafeMutableBufferPointer { pointer in
+                key.withCString { keyPointer in
+                    llama_model_meta_val_str(model, keyPointer, pointer.baseAddress, pointer.count)
+                }
+            }
+
+            guard requiredLength >= 0 else { return nil }
+            if Int(requiredLength) < buffer.count {
+                return String(cString: buffer)
+            }
+
+            bufferSize = Int(requiredLength) + 1
+        }
+
+        return nil
+    }
+
+    private static func positive(_ value: Int32) -> Int? {
+        guard value > 0 else { return nil }
+        return Int(value)
     }
 
     private static func initializeModel(
@@ -304,14 +405,14 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         // On iOS the per-app jetsam limit is a fraction of physical RAM (~3 GB on an 8 GB
         // iPad), so we derive the cap from os_proc_available_memory() rather than total
         // physical memory. On macOS there is no per-app cap, so physical memory is used.
-        // 1 token ≈ 8 KB of KV cache; clamped to 128 000 as an absolute ceiling.
-        let ramSafeCap = Self.computeRamSafeCap()
+        let kvBytesPerToken = Self.computeKVBytesPerToken(for: rawModel)
+        let ramSafeCap = Self.computeRamSafeCap(for: rawModel, kvBytesPerToken: kvBytesPerToken)
         let effectiveContextSize = min(requestedContextSize, trainedContextLength, ramSafeCap)
         ctxParams.n_threads = Int32(max(1, min(8, ProcessInfo.processInfo.processorCount - 2)))
         ctxParams.n_threads_batch = ctxParams.n_threads
 
         Self.logger.info(
-            "LlamaBackend: RAM-safe cap = \(ramSafeCap) tokens (effective = \(effectiveContextSize))"
+            "LlamaBackend: RAM-safe cap = \(ramSafeCap) tokens (kvBytesPerToken = \(kvBytesPerToken ?? Int64(GGUFKVCacheEstimator.legacyFallbackBytesPerToken)), effective = \(effectiveContextSize))"
         )
 
         // Retry with progressively halved context on init failure.

--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -326,6 +326,9 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         return Int(rawValue)
     }
 
+    /// Looks up a short scalar/identifier metadata value (architecture name, integer-as-string).
+    /// Not suitable for long values like chat templates — the 4 KB cap silently returns `nil`
+    /// when the value is larger.
     private static func modelMetadataString(for model: OpaquePointer, key: String) -> String? {
         var bufferSize = 64
 
@@ -406,7 +409,7 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         // iPad), so we derive the cap from os_proc_available_memory() rather than total
         // physical memory. On macOS there is no per-app cap, so physical memory is used.
         let kvBytesPerToken = Self.computeKVBytesPerToken(for: rawModel)
-        let ramSafeCap = Self.computeRamSafeCap(for: rawModel, kvBytesPerToken: kvBytesPerToken)
+        let ramSafeCap = Self.computeRamSafeCap(kvBytesPerToken: kvBytesPerToken)
         let effectiveContextSize = min(requestedContextSize, trainedContextLength, ramSafeCap)
         ctxParams.n_threads = Int32(max(1, min(8, ProcessInfo.processInfo.processorCount - 2)))
         ctxParams.n_threads_batch = ctxParams.n_threads

--- a/Sources/BaseChatInference/Models/ModelInfo.swift
+++ b/Sources/BaseChatInference/Models/ModelInfo.swift
@@ -29,6 +29,8 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
     public var modelArchitecture: String?
     /// The raw Jinja chat template string from `tokenizer.chat_template`, if present.
     public var chatTemplateRaw: String?
+    /// Best-effort KV-cache bytes-per-token estimate derived from GGUF metadata.
+    public var estimatedKVBytesPerToken: UInt64?
 
     // MARK: - Capability
 
@@ -100,6 +102,7 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
             self.detectedContextLength = metadata.contextLength
             self.modelArchitecture = metadata.generalArchitecture
             self.chatTemplateRaw = metadata.chatTemplate
+            self.estimatedKVBytesPerToken = GGUFKVCacheEstimator.estimateBytesPerToken(from: metadata)
         }
 
         // Static tier estimate; may be upgraded by a benchmark result later.
@@ -175,6 +178,7 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
         detectedContextLength: Int? = nil,
         modelArchitecture: String? = nil,
         chatTemplateRaw: String? = nil,
+        estimatedKVBytesPerToken: UInt64? = nil,
         capabilityTier: ModelCapabilityTier? = nil,
         benchmarkResult: ModelBenchmarkResult? = nil
     ) {
@@ -188,6 +192,7 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
         self.detectedContextLength = detectedContextLength
         self.modelArchitecture = modelArchitecture
         self.chatTemplateRaw = chatTemplateRaw
+        self.estimatedKVBytesPerToken = estimatedKVBytesPerToken
         self.capabilityTier = capabilityTier
         self.benchmarkResult = benchmarkResult
     }

--- a/Sources/BaseChatInference/Services/DeviceCapabilityService.swift
+++ b/Sources/BaseChatInference/Services/DeviceCapabilityService.swift
@@ -54,17 +54,9 @@ public final class DeviceCapabilityService: Sendable {
     /// is a fraction of physical RAM, so we must budget from available memory, not physical.
     private static let kvHeadroomFraction: Double = 0.40
 
-    /// Conservative-but-imprecise KV-cache cost per context token in bytes.
-    ///
-    /// This value (8 KB/token) is preserved from the legacy `LlamaBackend` RAM-safe
-    /// cap and is deliberately much smaller than the real KV cost on modern models —
-    /// a 7B GQA model, for example, uses ~128 KB/token at fp16. The intent here is
-    /// only a coarse jetsam-avoidance heuristic, not a faithful KV estimate.
-    ///
-    /// Proper per-architecture KV math — using `llama_model_n_layer`,
-    /// `llama_model_n_embd_k_gqa`, and the active quantization — is tracked as
-    /// follow-up work (see issue for per-architecture KV calculation).
-    private static let kvBytesPerToken: UInt64 = 8_192
+    /// Legacy fallback used when GGUF metadata is missing the architectural fields
+    /// required for a more realistic KV-cache estimate.
+    private static let legacyFallbackKVBytesPerToken = GGUFKVCacheEstimator.legacyFallbackBytesPerToken
 
     /// Absolute maximum context tokens we will ever request, regardless of model or device.
     private static let absoluteContextCeiling: Int = 128_000
@@ -102,17 +94,23 @@ public final class DeviceCapabilityService: Sendable {
     ///     Pass `nil` when unknown — the method falls back to `unknownContextDefault` (8 192).
     ///   - availableMemoryBytes: Available memory in bytes. When `nil`, the method queries
     ///     the system itself — useful for injection in tests.
+    ///   - estimatedKVBytesPerToken: Best-effort per-token KV estimate. Pass a GGUF-derived
+    ///     value when available; otherwise the helper falls back to the legacy 8 KB heuristic.
     /// - Returns: A safe `Int32` context token count.
     public static func safeContextSize(
         for detectedContextLength: Int?,
-        availableMemoryBytes: UInt64? = nil
+        availableMemoryBytes: UInt64? = nil,
+        estimatedKVBytesPerToken: UInt64? = nil
     ) -> Int32 {
         let available = availableMemoryBytes ?? Self.queryAvailableMemory()
+        let kvBytesPerToken = estimatedKVBytesPerToken
+            .flatMap { $0 > 0 ? $0 : nil }
+            ?? legacyFallbackKVBytesPerToken
 
         // Reserve 40% for model weights + runtime; KV cache gets the rest.
         let kvBudgetBytes = UInt64(Double(available) * (1.0 - kvHeadroomFraction))
 
-        // Derive token ceiling: kvBudgetBytes / 8 KB per token.
+        // Derive token ceiling from the per-token KV estimate.
         let memoryCeiling = Int(kvBudgetBytes / kvBytesPerToken)
 
         // Clamp to the model's trained length (never exceed what it was designed for).

--- a/Sources/BaseChatInference/Services/GGUFKVCacheEstimator.swift
+++ b/Sources/BaseChatInference/Services/GGUFKVCacheEstimator.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+package struct GGUFKVCacheParameters: Sendable, Equatable {
+    let blockCount: Int?
+    let embeddingLength: Int?
+    let attentionHeadCount: Int?
+    let attentionHeadCountKV: Int?
+    let attentionKeyLength: Int?
+    let attentionValueLength: Int?
+
+    package init(
+        blockCount: Int? = nil,
+        embeddingLength: Int? = nil,
+        attentionHeadCount: Int? = nil,
+        attentionHeadCountKV: Int? = nil,
+        attentionKeyLength: Int? = nil,
+        attentionValueLength: Int? = nil
+    ) {
+        self.blockCount = blockCount
+        self.embeddingLength = embeddingLength
+        self.attentionHeadCount = attentionHeadCount
+        self.attentionHeadCountKV = attentionHeadCountKV
+        self.attentionKeyLength = attentionKeyLength
+        self.attentionValueLength = attentionValueLength
+    }
+}
+
+package enum GGUFKVCacheEstimator {
+    package static let defaultBytesPerElement: UInt64 = 2
+    package static let legacyFallbackBytesPerToken: UInt64 = 8_192
+
+    package static func estimateBytesPerToken(
+        from parameters: GGUFKVCacheParameters,
+        bytesPerElement: UInt64 = defaultBytesPerElement
+    ) -> UInt64? {
+        guard bytesPerElement > 0,
+              let blockCount = positive(parameters.blockCount) else {
+            return nil
+        }
+
+        let kvHeadCount = positive(parameters.attentionHeadCountKV)
+            ?? positive(parameters.attentionHeadCount)
+
+        guard let kvHeadCount else {
+            return nil
+        }
+
+        guard let keyWidth = gqaWidth(
+            explicitHeadLength: parameters.attentionKeyLength,
+            embeddingLength: parameters.embeddingLength,
+            headCount: parameters.attentionHeadCount,
+            kvHeadCount: kvHeadCount
+        ) else {
+            return nil
+        }
+
+        guard let valueWidth = gqaWidth(
+            explicitHeadLength: parameters.attentionValueLength ?? parameters.attentionKeyLength,
+            embeddingLength: parameters.embeddingLength,
+            headCount: parameters.attentionHeadCount,
+            kvHeadCount: kvHeadCount
+        ) else {
+            return nil
+        }
+
+        return UInt64(blockCount) * UInt64(keyWidth + valueWidth) * bytesPerElement
+    }
+
+    static func estimateBytesPerToken(
+        from metadata: GGUFMetadata,
+        bytesPerElement: UInt64 = defaultBytesPerElement
+    ) -> UInt64? {
+        guard let parameters = metadata.kvCacheParameters else {
+            return nil
+        }
+        return estimateBytesPerToken(from: parameters, bytesPerElement: bytesPerElement)
+    }
+
+    private static func gqaWidth(
+        explicitHeadLength: Int?,
+        embeddingLength: Int?,
+        headCount: Int?,
+        kvHeadCount: Int
+    ) -> Int? {
+        if let explicitHeadLength = positive(explicitHeadLength) {
+            return explicitHeadLength * kvHeadCount
+        }
+
+        guard let embeddingLength = positive(embeddingLength),
+              let headCount = positive(headCount),
+              embeddingLength % headCount == 0 else {
+            return nil
+        }
+
+        return (embeddingLength / headCount) * kvHeadCount
+    }
+
+    private static func positive(_ value: Int?) -> Int? {
+        guard let value, value > 0 else { return nil }
+        return value
+    }
+}

--- a/Sources/BaseChatInference/Services/GGUFMetadataReader.swift
+++ b/Sources/BaseChatInference/Services/GGUFMetadataReader.swift
@@ -11,19 +11,22 @@ struct GGUFMetadata: Sendable, Equatable {
     let contextLength: Int?
     let chatTemplate: String?
     let fileType: Int?
+    let kvCacheParameters: GGUFKVCacheParameters?
 
     init(
         generalName: String?,
         generalArchitecture: String?,
         contextLength: Int?,
         chatTemplate: String?,
-        fileType: Int?
+        fileType: Int?,
+        kvCacheParameters: GGUFKVCacheParameters? = nil
     ) {
         self.generalName = generalName
         self.generalArchitecture = generalArchitecture
         self.contextLength = contextLength
         self.chatTemplate = chatTemplate
         self.fileType = fileType
+        self.kvCacheParameters = kvCacheParameters
     }
 }
 
@@ -120,6 +123,13 @@ struct GGUFMetadataReader {
             var contextLength: Int?
             var chatTemplate: String?
             var fileType: Int?
+            var inferredArchitecture: String?
+            var blockCount: Int?
+            var embeddingLength: Int?
+            var attentionHeadCount: Int?
+            var attentionHeadCountKV: Int?
+            var attentionKeyLength: Int?
+            var attentionValueLength: Int?
 
             // Iterate KV pairs
             for _ in 0..<metadataCount {
@@ -133,23 +143,68 @@ struct GGUFMetadataReader {
 
                 case "general.architecture":
                     generalArchitecture = try readStringValue(type: valueTypeRaw, from: handle)
+                    if inferredArchitecture == nil {
+                        inferredArchitecture = generalArchitecture
+                    }
 
                 case "general.file_type":
-                    fileType = try readUInt32Value(type: valueTypeRaw, from: handle)
+                    fileType = try readIntegerValue(type: valueTypeRaw, from: handle)
 
                 case "tokenizer.chat_template":
                     chatTemplate = try readStringValue(type: valueTypeRaw, from: handle)
 
                 default:
-                    // Check for {arch}.context_length dynamically
-                    if key.hasSuffix(".context_length") {
-                        let prefix = String(key.dropLast(".context_length".count))
-                        let isArchMatch = generalArchitecture.map { $0 == prefix } ?? true
-                        if isArchMatch && contextLength == nil {
-                            contextLength = try readUInt32Value(type: valueTypeRaw, from: handle)
-                        } else {
-                            try skipValue(type: valueTypeRaw, from: handle)
-                        }
+                    let activeArchitecture = generalArchitecture ?? inferredArchitecture
+
+                    if let prefix = matchingArchitecturePrefix(
+                        for: key,
+                        suffix: ".context_length",
+                        expectedArchitecture: activeArchitecture
+                    ) {
+                        inferredArchitecture = inferredArchitecture ?? prefix
+                        contextLength = try readIntegerValue(type: valueTypeRaw, from: handle)
+                    } else if let prefix = matchingArchitecturePrefix(
+                        for: key,
+                        suffix: ".block_count",
+                        expectedArchitecture: activeArchitecture
+                    ) {
+                        inferredArchitecture = inferredArchitecture ?? prefix
+                        blockCount = try readIntegerValue(type: valueTypeRaw, from: handle)
+                    } else if let prefix = matchingArchitecturePrefix(
+                        for: key,
+                        suffix: ".embedding_length",
+                        expectedArchitecture: activeArchitecture
+                    ) {
+                        inferredArchitecture = inferredArchitecture ?? prefix
+                        embeddingLength = try readIntegerValue(type: valueTypeRaw, from: handle)
+                    } else if let prefix = matchingArchitecturePrefix(
+                        for: key,
+                        suffix: ".attention.head_count",
+                        expectedArchitecture: activeArchitecture
+                    ) {
+                        inferredArchitecture = inferredArchitecture ?? prefix
+                        attentionHeadCount = try readIntegerValue(type: valueTypeRaw, from: handle)
+                    } else if let prefix = matchingArchitecturePrefix(
+                        for: key,
+                        suffix: ".attention.head_count_kv",
+                        expectedArchitecture: activeArchitecture
+                    ) {
+                        inferredArchitecture = inferredArchitecture ?? prefix
+                        attentionHeadCountKV = try readIntegerValue(type: valueTypeRaw, from: handle)
+                    } else if let prefix = matchingArchitecturePrefix(
+                        for: key,
+                        suffix: ".attention.key_length",
+                        expectedArchitecture: activeArchitecture
+                    ) {
+                        inferredArchitecture = inferredArchitecture ?? prefix
+                        attentionKeyLength = try readIntegerValue(type: valueTypeRaw, from: handle)
+                    } else if let prefix = matchingArchitecturePrefix(
+                        for: key,
+                        suffix: ".attention.value_length",
+                        expectedArchitecture: activeArchitecture
+                    ) {
+                        inferredArchitecture = inferredArchitecture ?? prefix
+                        attentionValueLength = try readIntegerValue(type: valueTypeRaw, from: handle)
                     } else {
                         try skipValue(type: valueTypeRaw, from: handle)
                     }
@@ -165,7 +220,15 @@ struct GGUFMetadataReader {
                 generalArchitecture: generalArchitecture,
                 contextLength: contextLength,
                 chatTemplate: chatTemplate,
-                fileType: fileType
+                fileType: fileType,
+                kvCacheParameters: GGUFKVCacheParameters(
+                    blockCount: blockCount,
+                    embeddingLength: embeddingLength,
+                    attentionHeadCount: attentionHeadCount,
+                    attentionHeadCountKV: attentionHeadCountKV,
+                    attentionKeyLength: attentionKeyLength,
+                    attentionValueLength: attentionValueLength
+                )
             )
         }
     }
@@ -272,13 +335,34 @@ struct GGUFMetadataReader {
         return try readString(from: handle)
     }
 
-    /// Reads a value expected to be a UINT32, returning it as Int. Throws if wrong type.
-    private static func readUInt32Value(type: UInt32, from handle: FileHandle) throws -> Int? {
-        guard type == ValueType.uint32.rawValue else {
+    /// Reads a scalar integer value, accepting signed or unsigned 32/64-bit GGUF integers.
+    private static func readIntegerValue(type: UInt32, from handle: FileHandle) throws -> Int? {
+        switch ValueType(rawValue: type) {
+        case .uint32:
+            return Int(try readUInt32(from: handle))
+        case .int32:
+            return Int(try readInt32(from: handle))
+        case .uint64:
+            return Int(try readUInt64(from: handle))
+        case .int64:
+            return Int(try readInt64(from: handle))
+        default:
             try skipValue(type: type, from: handle)
             return nil
         }
-        return Int(try readUInt32(from: handle))
+    }
+
+    private static func matchingArchitecturePrefix(
+        for key: String,
+        suffix: String,
+        expectedArchitecture: String?
+    ) -> String? {
+        guard key.hasSuffix(suffix) else { return nil }
+        let prefix = String(key.dropLast(suffix.count))
+        guard expectedArchitecture == nil || expectedArchitecture == prefix else {
+            return nil
+        }
+        return prefix
     }
 
     // MARK: - Value Skipping

--- a/Sources/BaseChatInference/Services/GGUFMetadataReader.swift
+++ b/Sources/BaseChatInference/Services/GGUFMetadataReader.swift
@@ -359,6 +359,10 @@ struct GGUFMetadataReader {
     ) -> String? {
         guard key.hasSuffix(suffix) else { return nil }
         let prefix = String(key.dropLast(suffix.count))
+        // GGUF architecture names are single identifiers (llama, phi, gemma, …).
+        // Reject multi-component prefixes so keys like `general.custom.context_length`
+        // don't poison inferredArchitecture with "general.custom".
+        guard !prefix.isEmpty, !prefix.contains(".") else { return nil }
         guard expectedArchitecture == nil || expectedArchitecture == prefix else {
             return nil
         }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+ModelLoading.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+ModelLoading.swift
@@ -209,7 +209,8 @@ extension ChatViewModel {
             // (the per-app budget) and physical memory on macOS, then applies a 60% KV
             // budget after reserving 40% headroom for model weights and runtime.
             let contextSize = DeviceCapabilityService.safeContextSize(
-                for: model.detectedContextLength
+                for: model.detectedContextLength,
+                estimatedKVBytesPerToken: model.estimatedKVBytesPerToken
             )
             try await inferenceService.loadModel(from: model, contextSize: contextSize)
         } catch is CancellationError {

--- a/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
@@ -139,24 +139,24 @@ final class LlamaBackendTests: XCTestCase {
     func test_contextSize_capLogic_ramSafeCapCalculation() {
         // Validates computeRamSafeCap() — the RAM-safe cap helper used in initializeModel.
         //
-        // On macOS (where CI runs), the cap is derived from physical memory divided by the
-        // effective KV bytes/token estimate. Use a guaranteed-large override so the result
-        // tightens even on very high-RAM developer machines where 128 KB/token still hits
-        // the 128K absolute ceiling.
-        let legacyCap = LlamaBackend.computeRamSafeCap(
-            kvBytesPerToken: Int64(GGUFKVCacheEstimator.legacyFallbackBytesPerToken)
-        )
-        let tighteningEstimate = max(
-            Int64(131_072),
-            Int64(ProcessInfo.processInfo.physicalMemory / 64_000) + 1
-        )
-        let ramSafeCap = LlamaBackend.computeRamSafeCap(kvBytesPerToken: tighteningEstimate)
+        // The cap is `min(128_000, memoryAvailable / kvBytesPerToken)`. To keep the
+        // monotonicity assertion meaningful on arbitrarily large hosts, we derive
+        // `largeEstimate` from physical RAM so the result lands strictly below the
+        // 128K absolute ceiling regardless of how much memory the CI runner has.
+        let legacyEstimate: Int64 = Int64(GGUFKVCacheEstimator.legacyFallbackBytesPerToken)
+        let physical = Int64(ProcessInfo.processInfo.physicalMemory)
+        // Guarantees physical / largeEstimate < 64_000 → sub-ceiling on any host.
+        let largeEstimate = max(Int64(131_072), physical / 64_000 + 1)
+
+        let legacyCap = LlamaBackend.computeRamSafeCap(kvBytesPerToken: legacyEstimate)
+        let ramSafeCap = LlamaBackend.computeRamSafeCap(kvBytesPerToken: largeEstimate)
+
         XCTAssertGreaterThan(ramSafeCap, 0,
                              "RAM-safe cap must be positive; formula may have underflowed")
         XCTAssertLessThanOrEqual(ramSafeCap, 128_000,
-                                  "RAM-safe cap must not exceed the absolute maximum of 128_000")
+                                 "RAM-safe cap must not exceed the absolute maximum of 128_000")
         XCTAssertLessThan(ramSafeCap, legacyCap,
-                          "A realistic KV estimate should clamp harder than the legacy 8 KB heuristic")
+                          "A larger per-token KV estimate must clamp harder than a smaller one")
         // A small requested size still wins when it is the smallest of the three values.
         let requested = Int32(512)
         let effective = min(requested, Int32(32_000), ramSafeCap)

--- a/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
@@ -139,18 +139,42 @@ final class LlamaBackendTests: XCTestCase {
     func test_contextSize_capLogic_ramSafeCapCalculation() {
         // Validates computeRamSafeCap() — the RAM-safe cap helper used in initializeModel.
         //
-        // On macOS (where CI runs), the cap is derived from physical memory / 8 192.
-        // On any modern Apple Silicon Mac this must be positive and ≤ 128 000.
-        let ramSafeCap = LlamaBackend.computeRamSafeCap()
+        // On macOS (where CI runs), the cap is derived from physical memory divided by the
+        // effective KV bytes/token estimate. Use a guaranteed-large override so the result
+        // tightens even on very high-RAM developer machines where 128 KB/token still hits
+        // the 128K absolute ceiling.
+        let legacyCap = LlamaBackend.computeRamSafeCap(
+            kvBytesPerToken: Int64(GGUFKVCacheEstimator.legacyFallbackBytesPerToken)
+        )
+        let tighteningEstimate = max(
+            Int64(131_072),
+            Int64(ProcessInfo.processInfo.physicalMemory / 64_000) + 1
+        )
+        let ramSafeCap = LlamaBackend.computeRamSafeCap(kvBytesPerToken: tighteningEstimate)
         XCTAssertGreaterThan(ramSafeCap, 0,
                              "RAM-safe cap must be positive; formula may have underflowed")
         XCTAssertLessThanOrEqual(ramSafeCap, 128_000,
-                                 "RAM-safe cap must not exceed the absolute maximum of 128_000")
+                                  "RAM-safe cap must not exceed the absolute maximum of 128_000")
+        XCTAssertLessThan(ramSafeCap, legacyCap,
+                          "A realistic KV estimate should clamp harder than the legacy 8 KB heuristic")
         // A small requested size still wins when it is the smallest of the three values.
         let requested = Int32(512)
         let effective = min(requested, Int32(32_000), ramSafeCap)
         XCTAssertEqual(effective, requested,
                        "Requested context size should win when it is the smallest of the three values")
+    }
+
+    func test_computeKVBytesPerToken_fromParameters_matchesLlama7BGQAMath() {
+        let estimate = LlamaBackend.computeKVBytesPerToken(
+            from: GGUFKVCacheParameters(
+                blockCount: 32,
+                embeddingLength: 4096,
+                attentionHeadCount: 32,
+                attentionHeadCountKV: 8
+            )
+        )
+
+        XCTAssertEqual(estimate, 131_072)
     }
 
     // MARK: - Retry context-halving progression

--- a/Tests/BaseChatE2ETests/LlamaE2ETests.swift
+++ b/Tests/BaseChatE2ETests/LlamaE2ETests.swift
@@ -193,5 +193,32 @@ final class LlamaE2ETests: XCTestCase {
         XCTAssertTrue(backend.capabilities.supportsSystemPrompt)
         XCTAssertTrue(backend.capabilities.requiresPromptTemplate)
     }
+
+    func test_realModel_architecturalClamp_isTighterThanLegacyHeuristic() throws {
+        let model = try XCTUnwrap(ModelInfo(ggufURL: modelURL))
+        let trainedContext = try XCTUnwrap(model.detectedContextLength)
+        let estimatedKVBytesPerToken = try XCTUnwrap(model.estimatedKVBytesPerToken)
+        let availableMemory = DeviceCapabilityService.queryAvailableMemory()
+
+        let architecturalClamp = DeviceCapabilityService.safeContextSize(
+            for: trainedContext,
+            availableMemoryBytes: availableMemory,
+            estimatedKVBytesPerToken: estimatedKVBytesPerToken
+        )
+        let legacyClamp = DeviceCapabilityService.safeContextSize(
+            for: trainedContext,
+            availableMemoryBytes: availableMemory,
+            estimatedKVBytesPerToken: GGUFKVCacheEstimator.legacyFallbackBytesPerToken
+        )
+
+        if architecturalClamp == legacyClamp {
+            throw XCTSkip(
+                "Selected GGUF fixture does not expose a tighter architectural clamp on this device"
+            )
+        }
+
+        XCTAssertLessThan(architecturalClamp, legacyClamp,
+                          "Real 7B-class GGUFs should clamp below the legacy 8 KB/token heuristic")
+    }
 }
 #endif

--- a/Tests/BaseChatInferenceTests/DeviceCapabilityServiceTests.swift
+++ b/Tests/BaseChatInferenceTests/DeviceCapabilityServiceTests.swift
@@ -165,6 +165,30 @@ final class DeviceCapabilityServiceTests: XCTestCase {
                           "512 MB budget should constrain context well below 128 000 tokens")
     }
 
+    func test_safeContextSize_usesArchitecturalKVEstimateWhenProvided() {
+        let available = oneGB
+        let architecturalEstimate: UInt64 = 131_072
+
+        let result = DeviceCapabilityService.safeContextSize(
+            for: 128_000,
+            availableMemoryBytes: available,
+            estimatedKVBytesPerToken: architecturalEstimate
+        )
+        let expected = expectedSafeContext(
+            availableBytes: available,
+            detectedLength: 128_000,
+            kvBytesPerToken: architecturalEstimate
+        )
+        let legacy = DeviceCapabilityService.safeContextSize(
+            for: 128_000,
+            availableMemoryBytes: available
+        )
+
+        XCTAssertEqual(result, expected)
+        XCTAssertLessThan(result, legacy,
+                          "A realistic GGUF KV estimate should tighten the clamp versus the legacy 8 KB heuristic")
+    }
+
     func test_safeContextSize_floorsAtOne_whenAvailableMemoryIsNearZero() {
         // Pathological case: essentially no memory available — result should be 1, not 0 or negative.
         let nearZero: UInt64 = 1000

--- a/Tests/BaseChatInferenceTests/GGUFKVCacheEstimatorTests.swift
+++ b/Tests/BaseChatInferenceTests/GGUFKVCacheEstimatorTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import BaseChatInference
+
+final class GGUFKVCacheEstimatorTests: XCTestCase {
+
+    func test_estimateBytesPerToken_llama7BGQAMatchesExpectedMath() {
+        let parameters = GGUFKVCacheParameters(
+            blockCount: 32,
+            embeddingLength: 4096,
+            attentionHeadCount: 32,
+            attentionHeadCountKV: 8
+        )
+
+        let estimate = GGUFKVCacheEstimator.estimateBytesPerToken(from: parameters)
+
+        XCTAssertEqual(estimate, 131_072)
+    }
+
+    func test_estimateBytesPerToken_explicitKeyAndValueLengthsOverrideEmbeddingHeuristic() {
+        let parameters = GGUFKVCacheParameters(
+            blockCount: 28,
+            embeddingLength: 3072,
+            attentionHeadCount: 24,
+            attentionHeadCountKV: 6,
+            attentionKeyLength: 96,
+            attentionValueLength: 128
+        )
+
+        let estimate = GGUFKVCacheEstimator.estimateBytesPerToken(from: parameters)
+
+        XCTAssertEqual(estimate, 75_264)
+    }
+
+    func test_estimateBytesPerToken_returnsNilWhenMetadataIsIncomplete() {
+        let parameters = GGUFKVCacheParameters(
+            blockCount: 32,
+            attentionHeadCountKV: 8
+        )
+
+        XCTAssertNil(GGUFKVCacheEstimator.estimateBytesPerToken(from: parameters))
+    }
+}

--- a/Tests/BaseChatInferenceTests/GGUFMetadataReaderTests.swift
+++ b/Tests/BaseChatInferenceTests/GGUFMetadataReaderTests.swift
@@ -77,6 +77,33 @@ final class GGUFMetadataReaderTests: XCTestCase {
         XCTAssertEqual(metadata.fileType, 7)
     }
 
+    func test_readMetadata_validV3Header_extractsKVCacheParameters() throws {
+        let data = makeGGUFV3Header(metadata: [
+            makeStringKV(key: "general.architecture", value: "llama"),
+            makeUInt32KV(key: "llama.block_count", value: 32),
+            makeUInt32KV(key: "llama.embedding_length", value: 4096),
+            makeUInt32KV(key: "llama.attention.head_count", value: 32),
+            makeUInt32KV(key: "llama.attention.head_count_kv", value: 8),
+            makeUInt32KV(key: "llama.attention.key_length", value: 128),
+            makeUInt32KV(key: "llama.attention.value_length", value: 128)
+        ])
+        let url = try writeTempFile(named: "kv-params.gguf", data: data)
+
+        let metadata = try GGUFMetadataReader.readMetadata(from: url)
+
+        XCTAssertEqual(
+            metadata.kvCacheParameters,
+            GGUFKVCacheParameters(
+                blockCount: 32,
+                embeddingLength: 4096,
+                attentionHeadCount: 32,
+                attentionHeadCountKV: 8,
+                attentionKeyLength: 128,
+                attentionValueLength: 128
+            )
+        )
+    }
+
     func test_readMetadata_validV3Header_multipleKeys() throws {
         let data = makeGGUFV3Header(metadata: [
             makeStringKV(key: "general.name", value: "MyLlama"),


### PR DESCRIPTION
Closes #401

## Summary
- replace the flat 8 KB/token heuristic with architecture-aware GGUF KV-cache estimation
- thread the preload estimate through ModelInfo, DeviceCapabilityService, and chat model loading
- derive the runtime llama cap from loaded-model metadata/API and cover the new math with unit and gated E2E tests

## Testing
- swift test --filter BaseChatCoreTests --disable-default-traits
- swift test --filter BaseChatInferenceTests --disable-default-traits
- swift test --filter BaseChatUITests --disable-default-traits
- swift test --filter BaseChatBackendsTests --disable-default-traits
- swift test --filter LlamaBackendTests --traits Llama
- swift test --filter LlamaE2ETests --traits Llama

## Release Note
**Architecture-aware llama KV cache math** — Replace the old flat 8 KB/token heuristic with GGUF-driven KV-cache estimates so context clamps reflect each model's actual layer and attention geometry. This tightens overly optimistic clamps for larger GQA models, preserves the legacy fallback when metadata is incomplete, and keeps the UI preload estimate aligned with the runtime llama load path.