### PR TITLE
fix: chunk llama prompt decode and preflight context exhaustion

### DIFF
--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -550,6 +550,14 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
                 return
             }
 
+            // `n_batch` caps how many tokens can flow through a single
+            // `llama_decode` call. llama.cpp asserts
+            // `GGML_ASSERT(n_tokens_all <= cparams.n_batch)` in
+            // `llama-context.cpp`, so prompts longer than this must be decoded
+            // in chunks. We never set `n_batch` on `ctxParams`, so it inherits
+            // llama.cpp's default (2048 at the time of writing).
+            let batchSize = max(1, Int(llama_n_batch(context)))
+
             // Clear KV cache at the start so state from any prior run (including
             // one terminated by stopGeneration) can't collide with this run's
             // positions.
@@ -583,34 +591,76 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
             llama_sampler_chain_add(sampler, llama_sampler_init_temp(config.temperature))
             llama_sampler_chain_add(sampler, llama_sampler_init_dist(UInt32.random(in: 0...UInt32.max)))
 
-            // Create batch and process prompt
-            var batch = llama_batch_init(Int32(tokens.count), 0, 1)
-            defer { llama_batch_free(batch) }
+            // Process prompt in `n_batch`-sized chunks. A single `llama_decode`
+            // call cannot exceed `n_batch` tokens, so we stride through the
+            // prompt and decode each chunk separately. Only the last token of
+            // the final chunk has `logits = 1` — that's the one we sample from
+            // to kick off generation.
+            var promptDecodeFailed = false
+            var promptPos = 0
+            while promptPos < tokens.count {
+                if Task.isCancelled || self.withStateLock({ self.cancelled }) { break }
 
-            for (i, token) in tokens.enumerated() {
-                batch.token[i] = token
-                batch.pos[i] = Int32(i)
-                batch.n_seq_id[i] = 1
-                batch.seq_id[i]?[0] = 0
-                batch.logits[i] = (i == tokens.count - 1) ? 1 : 0
+                let chunkSize = min(batchSize, tokens.count - promptPos)
+                let isLastChunk = (promptPos + chunkSize) == tokens.count
+
+                var promptBatch = llama_batch_init(Int32(chunkSize), 0, 1)
+                for i in 0..<chunkSize {
+                    promptBatch.token[i] = tokens[promptPos + i]
+                    promptBatch.pos[i] = Int32(promptPos + i)
+                    promptBatch.n_seq_id[i] = 1
+                    promptBatch.seq_id[i]?[0] = 0
+                    promptBatch.logits[i] = (isLastChunk && i == chunkSize - 1) ? 1 : 0
+                }
+                promptBatch.n_tokens = Int32(chunkSize)
+
+                let decodeResult = llama_decode(context, promptBatch)
+                llama_batch_free(promptBatch)
+
+                if decodeResult != 0 {
+                    promptDecodeFailed = true
+                    break
+                }
+
+                promptPos += chunkSize
             }
-            batch.n_tokens = Int32(tokens.count)
 
-            if llama_decode(context, batch) != 0 {
+            if promptDecodeFailed {
                 await MainActor.run { generationStream.setPhase(.failed("Failed to decode prompt")) }
                 continuation.finish(throwing: InferenceError.inferenceFailure("Failed to decode prompt"))
                 return
             }
 
-            // Generation loop
-            var nCur = Int(batch.n_tokens)
+            // Honour cancellation that fired mid-prompt before entering the
+            // generation loop.
+            if Task.isCancelled || self.withStateLock({ self.cancelled }) {
+                await MainActor.run { generationStream.setPhase(.done) }
+                continuation.finish()
+                return
+            }
+
+            // Generation loop uses a fresh 1-capacity batch — the prompt loop
+            // allocated and freed a batch per chunk, so there's nothing to
+            // reuse here.
+            var genBatch = llama_batch_init(1, 0, 1)
+            defer { llama_batch_free(genBatch) }
+
+            // The chunked prompt loop placed tokens at positions
+            // [0, tokens.count - 1]; the next decoded token goes at
+            // `tokens.count`.
+            var nCur = tokens.count
             var invalidUTF8: [CChar] = []
             var isFirstToken = true
 
-            for _ in 0..<maxTokens {
+            for iteration in 0..<maxTokens {
                 if Task.isCancelled || self.withStateLock({ self.cancelled }) { break }
 
-                let token = llama_sampler_sample(sampler, context, batch.n_tokens - 1)
+                // First iteration samples from the final prompt chunk's logits,
+                // which llama.cpp exposes at index -1 ("last available").
+                // Subsequent iterations sample from the 1-token gen batch
+                // decoded at the end of the previous iteration, at index 0.
+                let logitIndex: Int32 = iteration == 0 ? -1 : 0
+                let token = llama_sampler_sample(sampler, context, logitIndex)
 
                 if llama_vocab_is_eog(vocab, token) { break }
 
@@ -624,18 +674,18 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
                 }
 
                 // Prepare next batch
-                batch.n_tokens = 0
-                batch.token[0] = token
-                batch.pos[0] = Int32(nCur)
-                batch.n_seq_id[0] = 1
-                batch.seq_id[0]?[0] = 0
-                batch.logits[0] = 1
-                batch.n_tokens = 1
+                genBatch.n_tokens = 0
+                genBatch.token[0] = token
+                genBatch.pos[0] = Int32(nCur)
+                genBatch.n_seq_id[0] = 1
+                genBatch.seq_id[0]?[0] = 0
+                genBatch.logits[0] = 1
+                genBatch.n_tokens = 1
                 nCur += 1
 
                 if Task.isCancelled || self.withStateLock({ self.cancelled }) { break }
 
-                if llama_decode(context, batch) != 0 {
+                if llama_decode(context, genBatch) != 0 {
                     await MainActor.run { generationStream.setPhase(.failed("Decode failed during generation")) }
                     continuation.finish(throwing: InferenceError.inferenceFailure("Decode failed during generation"))
                     return

--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -493,20 +493,31 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
             throw InferenceError.alreadyGenerating
         }
 
+        // Tokenize up front (pure vocab lookup — doesn't touch context KV
+        // state) so we can preflight prompt + output against the context
+        // window before flipping `isGenerating`. If we failed this check
+        // after the flip, callers who retry on `.contextExhausted` would see
+        // an unnecessary `.alreadyGenerating` on the next call.
+        let tokens = tokenize(prompt, addBos: true)
+        guard !tokens.isEmpty else {
+            throw InferenceError.inferenceFailure("Failed to tokenize prompt")
+        }
+
+        let maxTokens = config.maxOutputTokens ?? 2048
+        let contextSize = Int(withStateLock { _effectiveContextSize })
+        guard tokens.count + maxTokens <= contextSize else {
+            throw InferenceError.contextExhausted(
+                promptTokens: tokens.count,
+                maxOutputTokens: maxTokens,
+                contextSize: contextSize
+            )
+        }
+
         withStateLock {
             isGenerating = true
             cancelled = false
         }
         Self.logger.debug("Llama generate started")
-
-        // Tokenize prompt (pure vocab lookup — doesn't touch context KV state)
-        let tokens = tokenize(prompt, addBos: true)
-        guard !tokens.isEmpty else {
-            withStateLock { isGenerating = false }
-            throw InferenceError.inferenceFailure("Failed to tokenize prompt")
-        }
-
-        let maxTokens = config.maxOutputTokens ?? 2048
 
         let (stream, continuation) = AsyncThrowingStream.makeStream(of: GenerationEvent.self)
         let generationStream = GenerationStream(stream)

--- a/Sources/BaseChatInference/Services/InferenceError.swift
+++ b/Sources/BaseChatInference/Services/InferenceError.swift
@@ -8,6 +8,11 @@ public enum InferenceError: LocalizedError {
     case memoryInsufficient(required: UInt64, available: UInt64)
     case alreadyGenerating
     case generationError(String)
+    /// Thrown by backends when `prompt_tokens + maxOutputTokens` exceeds the
+    /// loaded model's effective context window. Surfaced up front so callers
+    /// can trim history or reduce `maxOutputTokens` instead of seeing an
+    /// opaque decode failure mid-stream once the KV cache runs out.
+    case contextExhausted(promptTokens: Int, maxOutputTokens: Int, contextSize: Int)
 
     public var errorDescription: String? {
         switch self {
@@ -25,6 +30,8 @@ public enum InferenceError: LocalizedError {
             return "Cannot start generation while another generation is in progress"
         case .generationError(let message):
             return "Generation error: \(message)"
+        case .contextExhausted(let promptTokens, let maxOutputTokens, let contextSize):
+            return "Prompt (\(promptTokens) tokens) plus requested output (\(maxOutputTokens) tokens) exceeds context window (\(contextSize) tokens)."
         }
     }
 
@@ -38,7 +45,7 @@ public enum InferenceError: LocalizedError {
         case .alreadyGenerating:
             return true
         case .modelNotFound, .modelLoadFailed, .inferenceFailure,
-             .memoryInsufficient, .generationError:
+             .memoryInsufficient, .generationError, .contextExhausted:
             return false
         }
     }

--- a/Tests/BaseChatE2ETests/LlamaE2ETests.swift
+++ b/Tests/BaseChatE2ETests/LlamaE2ETests.swift
@@ -187,6 +187,41 @@ final class LlamaE2ETests: XCTestCase {
         XCTAssertFalse(response.isEmpty, "Should still generate some output")
     }
 
+    // MARK: - Long-prompt regressions
+
+    /// Regression for the n_batch chunking fix: prompts longer than llama.cpp's
+    /// default `n_batch` (2 048 tokens) used to trip
+    /// `GGML_ASSERT(n_tokens_all <= cparams.n_batch)` in `llama-context.cpp`,
+    /// aborting the process. The fix strides the prompt decode in
+    /// `llama_n_batch`-sized chunks so any prompt that fits the context window
+    /// runs cleanly.
+    func test_realInference_longPrompt_exceedsNBatch_doesNotCrash() async throws {
+        // ~2 500 tokens of repeated text — comfortably above the 2 048 default
+        // n_batch but well under the shared backend's 2 048 context? The shared
+        // backend is loaded at contextSize: 2048. We need the prompt > n_batch
+        // (2048) and prompt + maxOutputTokens <= contextSize. The shared
+        // fixture loads at 2048, so this test alone can't both exceed n_batch
+        // *and* fit the context. Load a dedicated backend at a higher context.
+        let modelURL = try XCTUnwrap(HardwareRequirements.findGGUFModel())
+        let dedicatedBackend = LlamaBackend()
+        defer { dedicatedBackend.unloadModel() }
+        try await dedicatedBackend.loadModel(from: modelURL, contextSize: 4096)
+
+        let longInput = String(repeating: "The quick brown fox jumps over the lazy dog. ", count: 250)
+        let formattedPrompt = PromptTemplate.chatML.format(
+            messages: [(role: "user", content: longInput)],
+            systemPrompt: nil
+        )
+        let config = GenerationConfig(temperature: 0.3, maxOutputTokens: 32)
+        let stream = try dedicatedBackend.generate(
+            prompt: formattedPrompt,
+            systemPrompt: nil,
+            config: config
+        )
+        let response = try await collectTokens(stream)
+        XCTAssertFalse(response.isEmpty, "Long prompts that span multiple n_batch chunks should generate a response")
+    }
+
     func test_backendCapabilities() {
         XCTAssertTrue(backend.capabilities.supportsStreaming)
         XCTAssertFalse(backend.capabilities.isRemote)

--- a/Tests/BaseChatE2ETests/LlamaE2ETests.swift
+++ b/Tests/BaseChatE2ETests/LlamaE2ETests.swift
@@ -141,9 +141,12 @@ final class LlamaE2ETests: XCTestCase {
     }
 
     func test_realInference_stopGeneration() async throws {
+        // Shared backend is loaded at contextSize: 2048; maxOutputTokens must
+        // leave room for the formatted prompt (≈47 tokens) or the new
+        // context-exhaustion preflight will reject the request.
         let config = GenerationConfig(
             temperature: 0.7,
-            maxOutputTokens: 2048
+            maxOutputTokens: 1024
         )
 
         let formattedPrompt = PromptTemplate.chatML.format(
@@ -196,17 +199,17 @@ final class LlamaE2ETests: XCTestCase {
     /// `llama_n_batch`-sized chunks so any prompt that fits the context window
     /// runs cleanly.
     func test_realInference_longPrompt_exceedsNBatch_doesNotCrash() async throws {
-        // ~2 500 tokens of repeated text — comfortably above the 2 048 default
-        // n_batch but well under the shared backend's 2 048 context? The shared
-        // backend is loaded at contextSize: 2048. We need the prompt > n_batch
-        // (2048) and prompt + maxOutputTokens <= contextSize. The shared
-        // fixture loads at 2048, so this test alone can't both exceed n_batch
-        // *and* fit the context. Load a dedicated backend at a higher context.
+        // We need a prompt that exceeds n_batch (llama.cpp default 2 048) and
+        // still fits in the context window with room for `maxOutputTokens`.
+        // The shared backend is loaded at contextSize: 2048, so it can't hold
+        // both conditions at once — load a dedicated backend at 4096.
         let modelURL = try XCTUnwrap(HardwareRequirements.findGGUFModel())
         let dedicatedBackend = LlamaBackend()
         defer { dedicatedBackend.unloadModel() }
         try await dedicatedBackend.loadModel(from: modelURL, contextSize: 4096)
 
+        // ~2 500 tokens of repeated text — comfortably above the 2 048 n_batch
+        // boundary so the prompt decode must span multiple chunks.
         let longInput = String(repeating: "The quick brown fox jumps over the lazy dog. ", count: 250)
         let formattedPrompt = PromptTemplate.chatML.format(
             messages: [(role: "user", content: longInput)],
@@ -220,6 +223,35 @@ final class LlamaE2ETests: XCTestCase {
         )
         let response = try await collectTokens(stream)
         XCTAssertFalse(response.isEmpty, "Long prompts that span multiple n_batch chunks should generate a response")
+    }
+
+    /// Regression for the context-exhaustion preflight: `generate()` must
+    /// reject `prompt_tokens + maxOutputTokens > contextSize` up front with a
+    /// typed `InferenceError.contextExhausted` instead of failing opaquely
+    /// inside the llama.cpp decode loop when the KV cache runs out.
+    func test_realInference_preflight_throwsContextExhausted() async throws {
+        let modelURL = try XCTUnwrap(HardwareRequirements.findGGUFModel())
+        let dedicatedBackend = LlamaBackend()
+        defer { dedicatedBackend.unloadModel() }
+        try await dedicatedBackend.loadModel(from: modelURL, contextSize: 2048)
+
+        // ~1 800-token prompt plus a 1 000-token max output blows the
+        // 2 048-token context window.
+        let longInput = String(repeating: "token ", count: 1800)
+        let config = GenerationConfig(temperature: 0.3, maxOutputTokens: 1000)
+        let formatted = PromptTemplate.chatML.format(
+            messages: [(role: "user", content: longInput)],
+            systemPrompt: nil
+        )
+
+        XCTAssertThrowsError(
+            try dedicatedBackend.generate(prompt: formatted, systemPrompt: nil, config: config)
+        ) { error in
+            guard case InferenceError.contextExhausted = error else {
+                XCTFail("Expected .contextExhausted, got \(error)")
+                return
+            }
+        }
     }
 
     func test_backendCapabilities() {

--- a/Tests/BaseChatE2ETests/LlamaE2ETests.swift
+++ b/Tests/BaseChatE2ETests/LlamaE2ETests.swift
@@ -205,7 +205,7 @@ final class LlamaE2ETests: XCTestCase {
         // both conditions at once — load a dedicated backend at 4096.
         let modelURL = try XCTUnwrap(HardwareRequirements.findGGUFModel())
         let dedicatedBackend = LlamaBackend()
-        defer { dedicatedBackend.unloadModel() }
+        addTeardownBlock { await dedicatedBackend.unloadAndWait() }
         try await dedicatedBackend.loadModel(from: modelURL, contextSize: 4096)
 
         // ~2 500 tokens of repeated text — comfortably above the 2 048 n_batch
@@ -232,7 +232,7 @@ final class LlamaE2ETests: XCTestCase {
     func test_realInference_preflight_throwsContextExhausted() async throws {
         let modelURL = try XCTUnwrap(HardwareRequirements.findGGUFModel())
         let dedicatedBackend = LlamaBackend()
-        defer { dedicatedBackend.unloadModel() }
+        addTeardownBlock { await dedicatedBackend.unloadAndWait() }
         try await dedicatedBackend.loadModel(from: modelURL, contextSize: 2048)
 
         // ~1 800-token prompt plus a 1 000-token max output blows the


### PR DESCRIPTION
## Summary

- Chunk `LlamaBackend`'s prompt decode into `llama_n_batch`-sized slices so prompts longer than llama.cpp's default 2 048-token batch limit no longer trip `GGML_ASSERT(n_tokens_all <= cparams.n_batch)` in `llama-context.cpp:1599`.
- Preflight `prompt_tokens + maxOutputTokens` against the effective context window before `generate()` starts, throwing a typed `InferenceError.contextExhausted` instead of failing opaquely inside the generation loop when the KV cache runs out.

## Root cause

`n_ctx` and `n_batch` are independent llama.cpp parameters. `n_ctx` is correctly clamped against jetsam/RAM budgets via `computeRamSafeCap` (PR #399 / #403). `n_batch` was never set — it inherited the llama.cpp default of 2 048 — and the prompt-decode path built one batch for the entire prompt, calling `llama_decode` once. Any prompt over 2 048 tokens crashed.

The context-window preflight is the second half: even after the batch-size fix, there was no guard that `prompt + maxOutput` fits the loaded context. Long prompts plus default `maxOutputTokens = 2048` would run `llama_decode` out of KV cache mid-generation, surfacing as an opaque "Decode failed during generation" error.

## Testing

Local on Apple Silicon (real GGUF in `~/Documents/Models/`). All suites pass:

- `swift test --filter BaseChatCoreTests --disable-default-traits`
- `swift test --filter BaseChatInferenceTests --disable-default-traits`
- `swift test --filter BaseChatUITests --disable-default-traits`
- `swift test --filter BaseChatBackendsTests --disable-default-traits`
- `swift test --filter LlamaE2ETests --traits Llama`

Two new E2E regression tests in `Tests/BaseChatE2ETests/LlamaE2ETests.swift`:

- `test_realInference_longPrompt_exceedsNBatch_doesNotCrash` — sends ~2 500-token prompt, asserts non-empty response (would have crashed before commit 1 with `GGML_ASSERT`).
- `test_realInference_preflight_throwsContextExhausted` — loads model at 2 048 context, submits ~1 800-token prompt with `maxOutputTokens = 1 000`, asserts `InferenceError.contextExhausted` thrown synchronously (before generation kicks off).

Both tests sabotage-verified: reverting each fix makes the corresponding test fail in the expected way (GGML assert for commit 1, "did not throw an error" for commit 2).

Also adjusted `test_realInference_stopGeneration` (`maxOutputTokens`: 2 048 → 1 024) so it continues to fit inside the shared backend's 2 048-token context after the preflight lands.

## Release Note

**Long-prompt crashes on iPad and silent mid-stream failures** — `LlamaBackend` now decodes prompts in chunks that respect llama.cpp's `n_batch` limit (default 2 048), eliminating a hard crash (`GGML_ASSERT` in `llama-context.cpp`) that fired on any prompt longer than 2 048 tokens. A new preflight also checks that `prompt_tokens + maxOutputTokens` fits the loaded context window and surfaces a typed `InferenceError.contextExhausted` before generation starts, instead of failing opaquely mid-stream when the KV cache runs out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)