### PR TITLE
feat: add ModelLoadPlan type and parity harness

### DIFF
--- a/Sources/BaseChatInference/Services/ModelLoadPlan.swift
+++ b/Sources/BaseChatInference/Services/ModelLoadPlan.swift
@@ -1,0 +1,326 @@
+import Foundation
+
+/// Stage 1 of the llama.cpp load-path refactor.
+///
+/// `ModelLoadPlan` unifies the memory / context decisions that today live in two
+/// separate places: `DeviceCapabilityService.safeContextSize(...)` (context clamp)
+/// and `MemoryGate.check(...)` (fit verdict). This additive type captures both in a
+/// single value so later stages (UI wiring, backend consumption, protocol flip) have
+/// a stable surface to code against.
+///
+/// This file is intentionally side-effect-free: no backends, UI, or persistence
+/// layers consume it yet. Stages 2+ will wire it in.
+public struct ModelLoadPlan: Sendable {
+
+    /// The raw inputs a plan was computed from. Captured on the plan so callers can
+    /// log, diff, or re-evaluate with different parameters without re-querying state.
+    public struct Inputs: Sendable, Equatable {
+        public let modelFileSize: UInt64
+        public let memoryStrategy: MemoryStrategy
+        public let requestedContextSize: Int
+        public let trainedContextLength: Int?
+        public let kvBytesPerToken: UInt64
+        public let availableMemoryBytes: UInt64
+        public let physicalMemoryBytes: UInt64
+        public let absoluteContextCeiling: Int
+        public let headroomFraction: Double
+
+        public init(
+            modelFileSize: UInt64,
+            memoryStrategy: MemoryStrategy,
+            requestedContextSize: Int,
+            trainedContextLength: Int?,
+            kvBytesPerToken: UInt64,
+            availableMemoryBytes: UInt64,
+            physicalMemoryBytes: UInt64,
+            absoluteContextCeiling: Int,
+            headroomFraction: Double
+        ) {
+            self.modelFileSize = modelFileSize
+            self.memoryStrategy = memoryStrategy
+            self.requestedContextSize = requestedContextSize
+            self.trainedContextLength = trainedContextLength
+            self.kvBytesPerToken = kvBytesPerToken
+            self.availableMemoryBytes = availableMemoryBytes
+            self.physicalMemoryBytes = physicalMemoryBytes
+            self.absoluteContextCeiling = absoluteContextCeiling
+            self.headroomFraction = headroomFraction
+        }
+    }
+
+    /// The decision produced from an `Inputs`. Decoupled from `Inputs` so UI code can
+    /// show the verdict summary without re-carrying every input field.
+    public struct Outcome: Sendable, Equatable {
+        public let effectiveContextSize: Int
+        public let estimatedResidentBytes: UInt64
+        public let estimatedKVBytes: UInt64
+        public let totalEstimatedBytes: UInt64
+        public let verdict: Verdict
+        /// Info-only reasons (clamps) may appear even when `verdict == .allow`.
+        public let reasons: [Reason]
+
+        public init(
+            effectiveContextSize: Int,
+            estimatedResidentBytes: UInt64,
+            estimatedKVBytes: UInt64,
+            totalEstimatedBytes: UInt64,
+            verdict: Verdict,
+            reasons: [Reason]
+        ) {
+            self.effectiveContextSize = effectiveContextSize
+            self.estimatedResidentBytes = estimatedResidentBytes
+            self.estimatedKVBytes = estimatedKVBytes
+            self.totalEstimatedBytes = totalEstimatedBytes
+            self.verdict = verdict
+            self.reasons = reasons
+        }
+    }
+
+    public let inputs: Inputs
+    public let outcome: Outcome
+
+    public init(inputs: Inputs, outcome: Outcome) {
+        self.inputs = inputs
+        self.outcome = outcome
+    }
+
+    // MARK: - Convenience pass-throughs
+
+    public var effectiveContextSize: Int { outcome.effectiveContextSize }
+    public var verdict: Verdict { outcome.verdict }
+    public var reasons: [Reason] { outcome.reasons }
+
+    // MARK: - Verdict / Reason
+
+    public enum Verdict: Sendable, Equatable {
+        /// Safe to proceed.
+        case allow
+        /// Tight fit — may work but risks swapping / pressure.
+        case warn
+        /// Insufficient memory — loading will likely fail.
+        case deny
+    }
+
+    public enum Reason: Sendable, Equatable {
+        case insufficientResident(required: UInt64, available: UInt64)
+        case insufficientKVCache(required: UInt64, available: UInt64)
+        /// Info-only: requested context exceeded the model's trained length, clamped.
+        case trainedContextExceeded(requested: Int, trained: Int)
+        /// Info-only: requested context exceeded the absolute ceiling, clamped.
+        case absoluteCeilingReached(requested: Int, ceiling: Int)
+        /// Info-only: requested context exceeded what memory allows, clamped.
+        case memoryCeilingReached(requested: Int, ceiling: Int)
+    }
+
+    // MARK: - Environment
+
+    /// Injects system-memory queries so tests (and callers that want to evaluate
+    /// hypothetical devices) can avoid hitting the real OS.
+    public struct Environment: Sendable {
+        public let availableMemoryBytes: @Sendable () -> UInt64
+        public let physicalMemoryBytes: UInt64
+
+        public init(
+            availableMemoryBytes: @escaping @Sendable () -> UInt64,
+            physicalMemoryBytes: UInt64
+        ) {
+            self.availableMemoryBytes = availableMemoryBytes
+            self.physicalMemoryBytes = physicalMemoryBytes
+        }
+
+        /// Real-device environment backed by `DeviceCapabilityService.queryAvailableMemory`
+        /// and `ProcessInfo.physicalMemory`.
+        public static let current: Environment = Environment(
+            availableMemoryBytes: { DeviceCapabilityService.queryAvailableMemory() },
+            physicalMemoryBytes: ProcessInfo.processInfo.physicalMemory
+        )
+    }
+
+    // MARK: - Computation
+
+    /// Primary entry point. All state must be pre-materialised on the `Inputs`.
+    public static func compute(inputs: Inputs) -> ModelLoadPlan {
+        let strategy = inputs.memoryStrategy
+        let available = inputs.availableMemoryBytes
+        let headroom = inputs.headroomFraction
+
+        // Resident budget: full weights for .resident, a mmap-style fraction for .mappable.
+        // .external keeps the legacy behaviour of "no local weight memory" — 0 resident.
+        let residentBudget: UInt64
+        switch strategy {
+        case .resident:
+            residentBudget = inputs.modelFileSize
+        case .mappable:
+            // Matches the legacy MemoryGate mappable heuristic: min(fileSize/4, 1 GB).
+            let oneGB: UInt64 = 1_073_741_824
+            residentBudget = min(inputs.modelFileSize / 4, oneGB)
+        case .external:
+            residentBudget = 0
+        }
+
+        // KV budget: what's left of available memory after the resident reserve, minus
+        // the caller-specified headroom fraction. Saturating subtraction so we never
+        // underflow UInt64 when resident > available * (1 - headroom).
+        let reserveAfterHeadroom = UInt64(Double(available) * (1.0 - headroom))
+        let kvBudget: UInt64 = reserveAfterHeadroom > residentBudget
+            ? reserveAfterHeadroom - residentBudget
+            : 0
+
+        // Memory-derived token ceiling. Guarding against div-by-zero when the caller
+        // passed kvBytesPerToken == 0 (shouldn't happen in practice, but cheap to be safe).
+        let memoryCeiling: Int = inputs.kvBytesPerToken == 0
+            ? Int.max
+            : Int(kvBudget / inputs.kvBytesPerToken)
+
+        // Walk the ceilings in turn, recording a `Reason` each time a tighter bound wins.
+        // `effective` tracks the winning value; we re-check against `requestedContextSize`
+        // for the "clamped" comparison so reasons report what the user asked for, not the
+        // already-reduced interim value.
+        var reasons: [Reason] = []
+        var effective = inputs.requestedContextSize
+
+        let trainedCeiling = inputs.trainedContextLength
+        if let trained = trainedCeiling, trained < effective {
+            reasons.append(.trainedContextExceeded(
+                requested: inputs.requestedContextSize,
+                trained: trained
+            ))
+            effective = trained
+        }
+
+        if inputs.absoluteContextCeiling < effective {
+            reasons.append(.absoluteCeilingReached(
+                requested: inputs.requestedContextSize,
+                ceiling: inputs.absoluteContextCeiling
+            ))
+            effective = inputs.absoluteContextCeiling
+        }
+
+        if memoryCeiling < effective {
+            reasons.append(.memoryCeilingReached(
+                requested: inputs.requestedContextSize,
+                ceiling: memoryCeiling
+            ))
+            effective = memoryCeiling
+        }
+
+        // Never pass 0 / negative to llama.cpp, even in pathological near-zero memory.
+        let effectiveContextSize = max(1, effective)
+
+        let estimatedKV = UInt64(effectiveContextSize) * inputs.kvBytesPerToken
+        let total = residentBudget &+ estimatedKV  // residentBudget is already bounded
+
+        // Verdict thresholds mirror the legacy MemoryGate for continuity.
+        let allowThreshold = UInt64(Double(available) * 0.85)
+        let verdict: Verdict
+        var finalReasons = reasons
+        if total <= allowThreshold {
+            verdict = .allow
+        } else if total <= available {
+            verdict = .warn
+        } else {
+            verdict = .deny
+            if residentBudget > available {
+                finalReasons.append(.insufficientResident(
+                    required: residentBudget,
+                    available: available
+                ))
+            } else {
+                finalReasons.append(.insufficientKVCache(
+                    required: total,
+                    available: available
+                ))
+            }
+        }
+
+        let outcome = Outcome(
+            effectiveContextSize: effectiveContextSize,
+            estimatedResidentBytes: residentBudget,
+            estimatedKVBytes: estimatedKV,
+            totalEstimatedBytes: total,
+            verdict: verdict,
+            reasons: finalReasons
+        )
+        return ModelLoadPlan(inputs: inputs, outcome: outcome)
+    }
+
+    /// Ergonomic factory for a real `ModelInfo`. Fills in architectural KV estimates
+    /// from the model when present, otherwise uses the legacy 8 KB/token fallback.
+    public static func compute(
+        for model: ModelInfo,
+        requestedContextSize: Int,
+        strategy: MemoryStrategy,
+        environment: Environment = .current,
+        absoluteContextCeiling: Int = 128_000,
+        headroomFraction: Double = 0.40
+    ) -> ModelLoadPlan {
+        let kvBytesPerToken = (model.estimatedKVBytesPerToken ?? 0) > 0
+            ? model.estimatedKVBytesPerToken!
+            : GGUFKVCacheEstimator.legacyFallbackBytesPerToken
+
+        let inputs = Inputs(
+            modelFileSize: model.fileSize,
+            memoryStrategy: strategy,
+            requestedContextSize: requestedContextSize,
+            trainedContextLength: model.detectedContextLength,
+            kvBytesPerToken: kvBytesPerToken,
+            availableMemoryBytes: environment.availableMemoryBytes(),
+            physicalMemoryBytes: environment.physicalMemoryBytes,
+            absoluteContextCeiling: absoluteContextCeiling,
+            headroomFraction: headroomFraction
+        )
+        return compute(inputs: inputs)
+    }
+
+    /// For system-managed backends (Apple Foundation Models) where memory is owned
+    /// by the OS and there's nothing to estimate. Always allows with stub fields.
+    public static func systemManaged(requestedContextSize: Int) -> ModelLoadPlan {
+        let effective = max(1, requestedContextSize)
+        let inputs = Inputs(
+            modelFileSize: 0,
+            memoryStrategy: .external,
+            requestedContextSize: requestedContextSize,
+            trainedContextLength: nil,
+            kvBytesPerToken: 0,
+            availableMemoryBytes: 0,
+            physicalMemoryBytes: 0,
+            absoluteContextCeiling: 0,
+            headroomFraction: 0
+        )
+        let outcome = Outcome(
+            effectiveContextSize: effective,
+            estimatedResidentBytes: 0,
+            estimatedKVBytes: 0,
+            totalEstimatedBytes: 0,
+            verdict: .allow,
+            reasons: []
+        )
+        return ModelLoadPlan(inputs: inputs, outcome: outcome)
+    }
+
+    /// For cloud backends with no local KV cache. `effectiveContextSize` is purely
+    /// informational — cloud providers enforce their own limits server-side.
+    public static func cloud(requestedContextSize: Int = 0) -> ModelLoadPlan {
+        let effective = max(1, requestedContextSize)
+        let inputs = Inputs(
+            modelFileSize: 0,
+            memoryStrategy: .external,
+            requestedContextSize: requestedContextSize,
+            trainedContextLength: nil,
+            kvBytesPerToken: 0,
+            availableMemoryBytes: 0,
+            physicalMemoryBytes: 0,
+            absoluteContextCeiling: 0,
+            headroomFraction: 0
+        )
+        let outcome = Outcome(
+            effectiveContextSize: effective,
+            estimatedResidentBytes: 0,
+            estimatedKVBytes: 0,
+            totalEstimatedBytes: 0,
+            verdict: .allow,
+            reasons: []
+        )
+        return ModelLoadPlan(inputs: inputs, outcome: outcome)
+    }
+}

--- a/Tests/BaseChatInferenceTests/ModelLoadPlanParityTests.swift
+++ b/Tests/BaseChatInferenceTests/ModelLoadPlanParityTests.swift
@@ -1,0 +1,215 @@
+import XCTest
+@testable import BaseChatInference
+
+/// Parity harness between `ModelLoadPlan` and the legacy gates (`DeviceCapabilityService.canLoadModel`
+/// + `MemoryGate.check`).
+///
+/// This is the safety rail for Stages 2–4 of the load-path refactor. The invariant it
+/// enforces is the **union** of the legacy checks: if *either* legacy gate rejects,
+/// the plan must deny; if *both* accept, the plan must not deny.
+///
+/// The two legacy gates use different denominators (physical vs available memory), so
+/// they sometimes disagree. Those one-side-rejects cases are the overlap region where
+/// the plan's new unified math supersedes — we record them but do not assert on them.
+///
+/// Grid sizing: we curate a ~60-case grid that exercises both the agreement region
+/// (clear pass / clear fail) and the rejection region, rather than the full 6 000
+/// cross-product. Selection criterion: sweep one dimension at a time around the
+/// agreement boundaries.
+final class ModelLoadPlanParityTests: XCTestCase {
+
+    private let oneGB: UInt64 = 1_073_741_824
+
+    /// A single test input row. Kept as a tuple rather than a struct to make the
+    /// curated grid readable inline.
+    private struct Row {
+        let fileSize: UInt64
+        let strategy: MemoryStrategy
+        let requested: Int
+        let trained: Int?
+        let kvPerTok: UInt64
+        let available: UInt64
+        let physical: UInt64
+    }
+
+    /// The curated grid. We take 5 cross-cut slices rather than a full cross-product:
+    ///   1. Small models, varied memory — should mostly agree and allow.
+    ///   2. Large models on small devices — should agree and deny.
+    ///   3. Boundary-of-resident-fit cases — tests the agreement region carefully.
+    ///   4. Large context on tight memory — exercises the plan's context-clamp path.
+    ///   5. A handful of the full-grid's disagreement cases — the overlap region.
+    private func buildGrid() -> [Row] {
+        var rows: [Row] = []
+
+        // Slice 1: Small 0.5 GB model — trivially fits on anything.
+        for avail in [oneGB, 2 * oneGB, 4 * oneGB, 8 * oneGB] {
+            for strategy in [MemoryStrategy.resident, .mappable] {
+                rows.append(Row(
+                    fileSize: oneGB / 2, strategy: strategy,
+                    requested: 2048, trained: 8192, kvPerTok: 8_192,
+                    available: avail, physical: 8 * oneGB
+                ))
+            }
+        }
+
+        // Slice 2: Large 16 GB model — doesn't fit on consumer devices.
+        for avail in [oneGB, 2 * oneGB, 4 * oneGB] {
+            for strategy in [MemoryStrategy.resident, .mappable] {
+                rows.append(Row(
+                    fileSize: 16 * oneGB, strategy: strategy,
+                    requested: 4096, trained: 8192, kvPerTok: 8_192,
+                    available: avail, physical: 8 * oneGB
+                ))
+            }
+        }
+
+        // Slice 3: 4 GB models around the boundary — both strategies against both RAM sizes.
+        for avail in [2 * oneGB, 4 * oneGB, 8 * oneGB] {
+            for strategy in [MemoryStrategy.resident, .mappable] {
+                for physical in [UInt64(8) * oneGB, UInt64(16) * oneGB] {
+                    rows.append(Row(
+                        fileSize: 4 * oneGB, strategy: strategy,
+                        requested: 4096, trained: 8192, kvPerTok: 8_192,
+                        available: avail, physical: physical
+                    ))
+                }
+            }
+        }
+
+        // Slice 4: Large-context requests. Plan clamps, legacy doesn't care about context
+        // for MemoryGate but canLoadModel ignores requested too — so these should align
+        // with slice 3 on verdict.
+        for requested in [32_000, 128_000] {
+            for kv in [UInt64(8_192), UInt64(131_072)] {
+                rows.append(Row(
+                    fileSize: 4 * oneGB, strategy: .mappable,
+                    requested: requested, trained: 131_072, kvPerTok: kv,
+                    available: 8 * oneGB, physical: 16 * oneGB
+                ))
+                rows.append(Row(
+                    fileSize: 4 * oneGB, strategy: .mappable,
+                    requested: requested, trained: 131_072, kvPerTok: kv,
+                    available: 2 * oneGB, physical: 8 * oneGB
+                ))
+            }
+        }
+
+        // Slice 5: Intentional disagreement region — available >> 0.70*physical
+        // (e.g., macOS reports lots of free memory on a lightly-loaded 8 GB Mac).
+        rows.append(Row(
+            fileSize: 4 * oneGB, strategy: .resident,
+            requested: 4096, trained: 8192, kvPerTok: 8_192,
+            available: 7 * oneGB, physical: 8 * oneGB
+        ))
+        // And the reverse — plenty of physical, but current available is low.
+        rows.append(Row(
+            fileSize: 4 * oneGB, strategy: .resident,
+            requested: 4096, trained: 8192, kvPerTok: 8_192,
+            available: oneGB / 2, physical: 32 * oneGB
+        ))
+
+        return rows
+    }
+
+    /// Collapses a `MemoryGate.Verdict` to "is this a rejection?" because the parity
+    /// invariant treats warn as non-rejection.
+    private func gateRejects(_ verdict: MemoryGate.Verdict) -> Bool {
+        if case .deny = verdict { return true }
+        return false
+    }
+
+    /// Evaluates the union invariant across the curated grid.
+    ///
+    /// The strongest form of the invariant (both legacy reject ⇒ plan denies, both
+    /// accept ⇒ plan doesn't deny) does **not** hold perfectly — the plan's new
+    /// unified math intentionally diverges in two places:
+    ///   1. Mappable strategy: plan caps resident at min(fileSize/4, 1 GB) whereas
+    ///      legacy MemoryGate uses uncapped fileSize/4. For very large mmap files
+    ///      the plan is *more* permissive than legacy.
+    ///   2. Boundary arithmetic: when residentBudget == available, the plan floors
+    ///      the context at 1 which causes total to micro-overshoot and deny, while
+    ///      both legacy gates warn/accept at that same boundary.
+    ///
+    /// Stages 2–4 will need to choose a reconciliation (either widen the plan's
+    /// mappable estimate, or relax the boundary verdict). Until then, we record
+    /// divergence counts rather than asserting on them, and assert only the *weak*
+    /// invariant: when the plan *and* both legacy gates all agree, nothing surprises.
+    func test_unionInvariant_recordsDivergenceWithoutFailing() {
+        let grid = buildGrid()
+        XCTAssertGreaterThanOrEqual(grid.count, 30, "grid too small to be meaningful")
+
+        var bothRejectPlanAllows: [Row] = []
+        var bothAcceptPlanDenies: [Row] = []
+        var oneRejectsOneAccepts = 0
+        var allAgree = 0
+
+        for row in grid {
+            let capacityService = DeviceCapabilityService(physicalMemory: row.physical)
+            let canLoad = capacityService.canLoadModel(estimatedMemoryBytes: row.fileSize)
+
+            let availableLocal = row.available
+            let gate = MemoryGate(
+                availableMemoryBytes: { availableLocal },
+                physicalMemoryBytes: row.physical,
+                denyBehavior: .warnOnly
+            )
+            let gateVerdict = gate.check(modelFileSize: row.fileSize, strategy: row.strategy)
+
+            let plan = ModelLoadPlan.compute(inputs: ModelLoadPlan.Inputs(
+                modelFileSize: row.fileSize,
+                memoryStrategy: row.strategy,
+                requestedContextSize: row.requested,
+                trainedContextLength: row.trained,
+                kvBytesPerToken: row.kvPerTok,
+                availableMemoryBytes: row.available,
+                physicalMemoryBytes: row.physical,
+                absoluteContextCeiling: 128_000,
+                headroomFraction: 0.40
+            ))
+
+            let legacyCapacityRejects = !canLoad
+            let legacyGateRejects = gateRejects(gateVerdict)
+
+            switch (legacyCapacityRejects, legacyGateRejects) {
+            case (true, true):
+                if plan.verdict != .deny {
+                    bothRejectPlanAllows.append(row)
+                } else {
+                    allAgree += 1
+                }
+            case (false, false):
+                if plan.verdict == .deny {
+                    bothAcceptPlanDenies.append(row)
+                } else {
+                    allAgree += 1
+                }
+            default:
+                oneRejectsOneAccepts += 1
+            }
+        }
+
+        // Sanity that the grid exercised enough of the space to be meaningful.
+        XCTAssertGreaterThan(allAgree, 0, "grid produced no agreement cases — check grid coverage")
+
+        // Document the known divergences so a reviewer in Stage 2–4 sees the count
+        // before changing anything. We do not fail on them — that's the whole point
+        // of the safety rail being a tracking harness rather than a gate.
+        print("""
+        [ModelLoadPlan parity summary]
+          total grid rows: \(grid.count)
+          all three agree: \(allAgree)
+          one-side-rejects (plan unconstrained): \(oneRejectsOneAccepts)
+          both-legacy-reject, plan allows: \(bothRejectPlanAllows.count)
+          both-legacy-accept, plan denies: \(bothAcceptPlanDenies.count)
+        """)
+
+        // Weak invariant: divergence should be small relative to the grid. If Stage 2–4
+        // code accidentally inverts the plan's verdict, the divergence count will
+        // balloon and this guard fires.
+        let divergence = bothRejectPlanAllows.count + bothAcceptPlanDenies.count
+        XCTAssertLessThan(
+            divergence, grid.count / 2,
+            "plan diverged from both legacy gates on more than half the grid — likely regression"
+        )
+    }
+}

--- a/Tests/BaseChatInferenceTests/ModelLoadPlanTests.swift
+++ b/Tests/BaseChatInferenceTests/ModelLoadPlanTests.swift
@@ -1,0 +1,551 @@
+import XCTest
+@testable import BaseChatInference
+
+/// Spec-coupled tests for `ModelLoadPlan`.
+///
+/// These tests mirror the formula in `ModelLoadPlan.compute(inputs:)` through an
+/// `expectedOutcome(...)` helper rather than hard-coding constants. That way, a
+/// change to (for example) the headroom fraction in a future stage is caught by
+/// a *legitimate* test-spec mismatch rather than a brittle literal.
+final class ModelLoadPlanTests: XCTestCase {
+
+    private let oneGB: UInt64 = 1_073_741_824
+
+    // MARK: - Helpers
+
+    /// Shadow implementation of `ModelLoadPlan.compute` used purely for assertions.
+    /// Kept verbatim with the production formula so the tests break if either drifts
+    /// in a way that wasn't a coordinated change.
+    private func expectedOutcome(
+        modelFileSize: UInt64,
+        strategy: MemoryStrategy,
+        requested: Int,
+        trained: Int?,
+        kvBytesPerToken: UInt64,
+        available: UInt64,
+        absoluteCeiling: Int = 128_000,
+        headroom: Double = 0.40
+    ) -> (effective: Int, verdict: ModelLoadPlan.Verdict, resident: UInt64, kv: UInt64, total: UInt64) {
+        let residentBudget: UInt64
+        switch strategy {
+        case .resident: residentBudget = modelFileSize
+        case .mappable: residentBudget = min(modelFileSize / 4, oneGB)
+        case .external: residentBudget = 0
+        }
+        let reserveAfterHeadroom = UInt64(Double(available) * (1.0 - headroom))
+        let kvBudget: UInt64 = reserveAfterHeadroom > residentBudget
+            ? reserveAfterHeadroom - residentBudget
+            : 0
+        let memoryCeiling = kvBytesPerToken == 0 ? Int.max : Int(kvBudget / kvBytesPerToken)
+
+        var effective = requested
+        if let t = trained, t < effective { effective = t }
+        if absoluteCeiling < effective { effective = absoluteCeiling }
+        if memoryCeiling < effective { effective = memoryCeiling }
+        effective = max(1, effective)
+
+        let kvBytes = UInt64(effective) * kvBytesPerToken
+        let total = residentBudget &+ kvBytes
+        let allowThreshold = UInt64(Double(available) * 0.85)
+        let verdict: ModelLoadPlan.Verdict
+        if total <= allowThreshold {
+            verdict = .allow
+        } else if total <= available {
+            verdict = .warn
+        } else {
+            verdict = .deny
+        }
+        return (effective, verdict, residentBudget, kvBytes, total)
+    }
+
+    private func makeInputs(
+        modelFileSize: UInt64 = 4_000_000_000,
+        strategy: MemoryStrategy = .mappable,
+        requested: Int = 4096,
+        trained: Int? = 8192,
+        kvBytesPerToken: UInt64 = 8_192,
+        available: UInt64 = 8_000_000_000,
+        physical: UInt64 = 16_000_000_000,
+        absoluteCeiling: Int = 128_000,
+        headroom: Double = 0.40
+    ) -> ModelLoadPlan.Inputs {
+        ModelLoadPlan.Inputs(
+            modelFileSize: modelFileSize,
+            memoryStrategy: strategy,
+            requestedContextSize: requested,
+            trainedContextLength: trained,
+            kvBytesPerToken: kvBytesPerToken,
+            availableMemoryBytes: available,
+            physicalMemoryBytes: physical,
+            absoluteContextCeiling: absoluteCeiling,
+            headroomFraction: headroom
+        )
+    }
+
+    // MARK: - Basic cases
+
+    func test_plentyOfMemory_allowsAtRequestedContext() {
+        let inputs = makeInputs(
+            modelFileSize: 4 * oneGB,
+            strategy: .mappable,
+            requested: 4096,
+            trained: 8192,
+            available: 64 * oneGB
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+        XCTAssertEqual(plan.verdict, .allow)
+        XCTAssertEqual(plan.effectiveContextSize, 4096)
+    }
+
+    func test_constrainedDevice_clampsContextAndAllows() {
+        // 1 GB available, 8_192 bytes/token → ~73 000 memory ceiling;
+        // requested 128 000 with trained 128 000 → memory is the binding clamp.
+        let inputs = makeInputs(
+            modelFileSize: 500_000_000,
+            strategy: .mappable,
+            requested: 128_000,
+            trained: 128_000,
+            kvBytesPerToken: 8_192,
+            available: oneGB
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+        let exp = expectedOutcome(
+            modelFileSize: 500_000_000, strategy: .mappable,
+            requested: 128_000, trained: 128_000,
+            kvBytesPerToken: 8_192, available: oneGB
+        )
+        XCTAssertEqual(plan.effectiveContextSize, exp.effective)
+        XCTAssertLessThan(plan.effectiveContextSize, 128_000)
+        XCTAssertEqual(plan.verdict, exp.verdict)
+        XCTAssertTrue(plan.reasons.contains(.memoryCeilingReached(requested: 128_000, ceiling: exp.effective)))
+    }
+
+    func test_trainedContextShorterThanRequested_clampsWithInfoReason() {
+        let inputs = makeInputs(
+            modelFileSize: 2 * oneGB,
+            strategy: .mappable,
+            requested: 8192,
+            trained: 2048,
+            available: 32 * oneGB
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+        XCTAssertEqual(plan.effectiveContextSize, 2048)
+        XCTAssertEqual(plan.verdict, .allow)
+        XCTAssertTrue(plan.reasons.contains(.trainedContextExceeded(requested: 8192, trained: 2048)))
+    }
+
+    // MARK: - Denial paths
+
+    func test_residentStrategy_deniesWhenWeightsExceedAvailable() {
+        // 8 GB model loaded resident, only 3 GB available.
+        let inputs = makeInputs(
+            modelFileSize: 8 * oneGB,
+            strategy: .resident,
+            requested: 4096,
+            trained: 8192,
+            available: 3 * oneGB
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+        XCTAssertEqual(plan.verdict, .deny)
+        let hasInsufficientResident = plan.reasons.contains { reason in
+            if case .insufficientResident = reason { return true }
+            return false
+        }
+        XCTAssertTrue(hasInsufficientResident, "Expected an .insufficientResident reason; got \(plan.reasons)")
+    }
+
+    func test_mappableStrategy_deniesWhenKVOverrunsBudget_withInsufficientKVCacheReason() {
+        // #400 regression: mappable strategy, weights mmap'd fine, but KV overruns available.
+        // The algorithm's fix is to *clamp* the context to what fits, surfacing a
+        // `.memoryCeilingReached` info-only reason. The clamp is what prevents the crash —
+        // the verdict stays `.allow` by design because the clamped total fits.
+        //
+        // Deviation from brief: the brief anticipated `.deny` + `.insufficientKVCache`
+        // here, but per the explicit formula (verdict computed from *clamped* total,
+        // not requested total), denial is impossible once the clamp is applied. We
+        // instead assert the clamp is large and surfaces the correct reason — which is
+        // still the #400 regression guard because it proves the requested 128 K was
+        // rejected. See report for full rationale.
+        let inputs = makeInputs(
+            modelFileSize: 4 * oneGB,
+            strategy: .mappable,
+            requested: 128_000,
+            trained: 131_072,
+            kvBytesPerToken: 65_536,
+            available: 2 * oneGB
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+        // The requested 128 000 must have been clamped hard.
+        XCTAssertLessThan(plan.effectiveContextSize, 128_000 / 4)
+        let hasMemoryReason = plan.reasons.contains { reason in
+            if case .memoryCeilingReached = reason { return true }
+            return false
+        }
+        XCTAssertTrue(hasMemoryReason, "Expected a .memoryCeilingReached reason; got \(plan.reasons)")
+    }
+
+    func test_iPad8GB_128kContext_Qwen7B_profile_clampsContextHard() {
+        // #398/#411 regression: iPad jetsam limit ~3 GB on 8 GB device.
+        // Qwen2.5 7B Q4 (~4.5 GB file), architectural KV ~131 KB/token.
+        // The plan must clamp context drastically to avoid the OOM that #398 reported,
+        // and expose a .memoryCeilingReached info-reason for diagnostics.
+        //
+        // Deviation from brief: per the formula the verdict is `.allow` (clamped total
+        // fits). The fix for #398 is the clamp itself. See report.
+        let inputs = makeInputs(
+            modelFileSize: 4_500_000_000,
+            strategy: .mappable,
+            requested: 128_000,
+            trained: 131_072,
+            kvBytesPerToken: 131_072,
+            available: 3_000_000_000,
+            physical: 8_000_000_000
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+        XCTAssertLessThan(plan.effectiveContextSize, 128_000 / 10)
+        let hasMemoryReason = plan.reasons.contains { reason in
+            if case .memoryCeilingReached = reason { return true }
+            return false
+        }
+        XCTAssertTrue(hasMemoryReason, "Expected a .memoryCeilingReached reason; got \(plan.reasons)")
+    }
+
+    // MARK: - Ceiling info-only
+
+    func test_absoluteCeiling_capsAt128k_withAbsoluteCeilingReasonOnInfoOnly() {
+        // Petabytes of memory, trained context 1 M, requested 500 K → clamps to 128 K via absolute ceiling.
+        let huge: UInt64 = 1_000_000_000_000
+        let inputs = makeInputs(
+            modelFileSize: 500_000_000,
+            strategy: .mappable,
+            requested: 500_000,
+            trained: 1_000_000,
+            kvBytesPerToken: 8_192,
+            available: huge
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+        XCTAssertEqual(plan.effectiveContextSize, 128_000)
+        XCTAssertEqual(plan.verdict, .allow)
+        XCTAssertTrue(plan.reasons.contains(.absoluteCeilingReached(requested: 500_000, ceiling: 128_000)))
+    }
+
+    // MARK: - KV fallback
+
+    func test_nilKVEstimate_usesLegacyFallback_produces8kbPerTokenClamp() {
+        // Use the ModelInfo factory with no KV estimate — should fall back to 8 192 bytes/token.
+        let model = ModelInfo(
+            name: "test",
+            fileName: "test.gguf",
+            url: URL(fileURLWithPath: "/tmp/test.gguf"),
+            fileSize: 500_000_000,
+            modelType: .gguf,
+            detectedContextLength: 128_000,
+            estimatedKVBytesPerToken: nil
+        )
+        let oneGBLocal = oneGB
+        let env = ModelLoadPlan.Environment(
+            availableMemoryBytes: { oneGBLocal },
+            physicalMemoryBytes: 8 * oneGBLocal
+        )
+        let plan = ModelLoadPlan.compute(
+            for: model,
+            requestedContextSize: 128_000,
+            strategy: .mappable,
+            environment: env
+        )
+        // With 8 KB/token: kvBudget ≈ 0.6 GB → ~75 000 tokens.
+        let expected = expectedOutcome(
+            modelFileSize: 500_000_000, strategy: .mappable,
+            requested: 128_000, trained: 128_000,
+            kvBytesPerToken: 8_192, available: oneGB
+        )
+        XCTAssertEqual(plan.effectiveContextSize, expected.effective)
+    }
+
+    func test_architecturalKVEstimate_tightensClampVersusLegacy() {
+        // Same available memory; architectural estimate (131 072) must clamp tighter than legacy 8 192.
+        let available: UInt64 = 2 * oneGB
+        let legacy = ModelLoadPlan.compute(inputs: makeInputs(
+            modelFileSize: 500_000_000, strategy: .mappable,
+            requested: 128_000, trained: 128_000,
+            kvBytesPerToken: 8_192, available: available
+        ))
+        let architectural = ModelLoadPlan.compute(inputs: makeInputs(
+            modelFileSize: 500_000_000, strategy: .mappable,
+            requested: 128_000, trained: 128_000,
+            kvBytesPerToken: 131_072, available: available
+        ))
+        XCTAssertLessThan(architectural.effectiveContextSize, legacy.effectiveContextSize)
+    }
+
+    // MARK: - Monotonicity
+
+    func test_sameModel_doubledContext_producesProportionallyTighterVerdict() {
+        // Doubling the requested context on a constrained device must never *relax* the verdict.
+        // allow (0) <= warn (1) <= deny (2) ordinality.
+        func rank(_ v: ModelLoadPlan.Verdict) -> Int {
+            switch v { case .allow: return 0; case .warn: return 1; case .deny: return 2 }
+        }
+        let base = makeInputs(
+            modelFileSize: 4 * oneGB,
+            strategy: .mappable,
+            requested: 2048,
+            trained: 131_072,
+            kvBytesPerToken: 65_536,
+            available: 2 * oneGB
+        )
+        let doubled = makeInputs(
+            modelFileSize: 4 * oneGB,
+            strategy: .mappable,
+            requested: 4096,
+            trained: 131_072,
+            kvBytesPerToken: 65_536,
+            available: 2 * oneGB
+        )
+        let quadrupled = makeInputs(
+            modelFileSize: 4 * oneGB,
+            strategy: .mappable,
+            requested: 8192,
+            trained: 131_072,
+            kvBytesPerToken: 65_536,
+            available: 2 * oneGB
+        )
+        let p1 = ModelLoadPlan.compute(inputs: base)
+        let p2 = ModelLoadPlan.compute(inputs: doubled)
+        let p3 = ModelLoadPlan.compute(inputs: quadrupled)
+        XCTAssertLessThanOrEqual(rank(p1.verdict), rank(p2.verdict))
+        XCTAssertLessThanOrEqual(rank(p2.verdict), rank(p3.verdict))
+    }
+
+    // MARK: - Edge cases
+
+    func test_nearZeroMemory_floorsContextAtOne() {
+        let inputs = makeInputs(
+            modelFileSize: 100_000_000,
+            strategy: .mappable,
+            requested: 4096,
+            trained: 8192,
+            kvBytesPerToken: 8_192,
+            available: 1000
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+        XCTAssertGreaterThanOrEqual(plan.effectiveContextSize, 1)
+    }
+
+    // MARK: - Verdict boundaries
+
+    func test_verdict_atExactFit_isWarn() {
+        // Construct inputs so totalEstimatedBytes == availableMemoryBytes.
+        // Use .external strategy → resident = 0, so total == effective * kvBytes/token.
+        // Choose kv = 1, effective = 1_000_000, available = 1_000_000 → total == available → warn.
+        // But we also need total > available * 0.85, which is 850_000 — 1_000_000 > 850_000 ✓.
+        let inputs = ModelLoadPlan.Inputs(
+            modelFileSize: 0,
+            memoryStrategy: .external,
+            requestedContextSize: 1_000_000,
+            trainedContextLength: 1_000_000,
+            kvBytesPerToken: 1,
+            availableMemoryBytes: 1_000_000,
+            physicalMemoryBytes: 16 * oneGB,
+            absoluteContextCeiling: 128_000_000,
+            headroomFraction: 0.0
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+        // With headroom 0.0 and no resident, kvBudget == available, so memoryCeiling = 1_000_000.
+        // effective == requested == 1_000_000. Total = 1_000_000 bytes == available → warn.
+        XCTAssertEqual(plan.totalEstimatedBytesForAssertion, 1_000_000)
+        XCTAssertEqual(plan.verdict, .warn)
+    }
+
+    func test_exactFitBoundary_85PercentThreshold_isWarn() {
+        // total == 86% of available → should be .warn (above .allow 85% threshold but <= available).
+        // total == 84% → .allow.
+        let available: UInt64 = 1_000_000_000
+        // Warn case: effective fixed such that kv = ~0.86 GB.
+        let warnInputs = ModelLoadPlan.Inputs(
+            modelFileSize: 0,
+            memoryStrategy: .external,
+            requestedContextSize: 860_000,
+            trainedContextLength: 860_000,
+            kvBytesPerToken: 1_000,
+            availableMemoryBytes: available,
+            physicalMemoryBytes: 16 * oneGB,
+            absoluteContextCeiling: 128_000_000,
+            headroomFraction: 0.0
+        )
+        let warnPlan = ModelLoadPlan.compute(inputs: warnInputs)
+        XCTAssertEqual(warnPlan.verdict, .warn)
+
+        // Allow case: total = 0.84 GB → below 0.85 threshold.
+        let allowInputs = ModelLoadPlan.Inputs(
+            modelFileSize: 0,
+            memoryStrategy: .external,
+            requestedContextSize: 840_000,
+            trainedContextLength: 840_000,
+            kvBytesPerToken: 1_000,
+            availableMemoryBytes: available,
+            physicalMemoryBytes: 16 * oneGB,
+            absoluteContextCeiling: 128_000_000,
+            headroomFraction: 0.0
+        )
+        let allowPlan = ModelLoadPlan.compute(inputs: allowInputs)
+        XCTAssertEqual(allowPlan.verdict, .allow)
+    }
+
+    // MARK: - Info-only + allow coexistence
+
+    func test_reasons_includeInfoOnlyWhenVerdictIsAllow() {
+        // Plenty of memory, but trained context is smaller than requested → allow + info reason.
+        let inputs = makeInputs(
+            modelFileSize: 1 * oneGB,
+            strategy: .mappable,
+            requested: 8192,
+            trained: 2048,
+            available: 64 * oneGB
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+        XCTAssertEqual(plan.verdict, .allow)
+        XCTAssertTrue(plan.reasons.contains(.trainedContextExceeded(requested: 8192, trained: 2048)))
+    }
+
+    // MARK: - System-managed / cloud factories
+
+    func test_systemManaged_factory_allowsWithStubMemory() {
+        let plan = ModelLoadPlan.systemManaged(requestedContextSize: 4096)
+        XCTAssertEqual(plan.verdict, .allow)
+        XCTAssertEqual(plan.effectiveContextSize, 4096)
+        XCTAssertEqual(plan.outcome.estimatedKVBytes, 0)
+    }
+
+    func test_cloud_factory_allowsWithInformationalContext() {
+        let plan = ModelLoadPlan.cloud(requestedContextSize: 0)
+        XCTAssertEqual(plan.verdict, .allow)
+    }
+
+    // MARK: - Property-style grid tests
+
+    /// For every grid input, total must equal resident + kv (the two sub-estimates).
+    func test_property_totalEqualsResidentPlusKV() {
+        let strategies: [MemoryStrategy] = [.resident, .mappable, .external]
+        let fileSizes: [UInt64] = [1 * oneGB, 4 * oneGB, 16 * oneGB]
+        let requesteds = [1024, 8192, 32_000]
+        let trainedOpts: [Int?] = [nil, 8192, 131_072]
+        let kvs: [UInt64] = [8_192, 65_536, 131_072]
+        let availables: [UInt64] = [oneGB, 4 * oneGB, 16 * oneGB]
+
+        for strategy in strategies {
+            for fs in fileSizes {
+                for req in requesteds {
+                    for trained in trainedOpts {
+                        for kv in kvs {
+                            for avail in availables {
+                                let inputs = self.makeInputs(
+                                    modelFileSize: fs, strategy: strategy, requested: req,
+                                    trained: trained, kvBytesPerToken: kv, available: avail
+                                )
+                                let plan = ModelLoadPlan.compute(inputs: inputs)
+                                XCTAssertEqual(
+                                    plan.outcome.totalEstimatedBytes,
+                                    plan.outcome.estimatedResidentBytes + plan.outcome.estimatedKVBytes,
+                                    "total != resident + kv for \(inputs)"
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// effectiveContextSize must be <= every ceiling (requested, trained, memory, absolute).
+    func test_property_effectiveContextLEAllCeilings() {
+        let strategies: [MemoryStrategy] = [.resident, .mappable]
+        let fileSizes: [UInt64] = [1 * oneGB, 4 * oneGB]
+        let requesteds = [1024, 8192, 64_000, 200_000]
+        let trainedOpts: [Int?] = [nil, 4096, 131_072]
+        let kvs: [UInt64] = [8_192, 131_072]
+        let availables: [UInt64] = [oneGB, 8 * oneGB]
+
+        for strategy in strategies {
+            for fs in fileSizes {
+                for req in requesteds {
+                    for trained in trainedOpts {
+                        for kv in kvs {
+                            for avail in availables {
+                                let inputs = self.makeInputs(
+                                    modelFileSize: fs, strategy: strategy, requested: req,
+                                    trained: trained, kvBytesPerToken: kv, available: avail
+                                )
+                                let plan = ModelLoadPlan.compute(inputs: inputs)
+
+                                // Recompute the memory ceiling locally, same formula as production.
+                                let residentBudget: UInt64
+                                switch strategy {
+                                case .resident: residentBudget = fs
+                                case .mappable: residentBudget = min(fs / 4, oneGB)
+                                case .external: residentBudget = 0
+                                }
+                                let reserveAfter = UInt64(Double(avail) * 0.60)
+                                let kvBudget: UInt64 = reserveAfter > residentBudget ? reserveAfter - residentBudget : 0
+                                let memoryCeiling = Int(kvBudget / kv)
+                                // Production only clamps to trained when trained != nil; when nil the
+                                // effective size can still be bounded by requested/absolute/memory.
+                                let trainedCeiling = trained ?? Int.max
+                                let upperBound = min(req, trainedCeiling, memoryCeiling, 128_000)
+
+                                XCTAssertLessThanOrEqual(
+                                    plan.effectiveContextSize,
+                                    max(1, upperBound),
+                                    "effective exceeded a ceiling for \(inputs)"
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Doubling availableMemoryBytes must never make the verdict *stricter*.
+    func test_property_verdictMonotonicInAvailableMemory() {
+        func rank(_ v: ModelLoadPlan.Verdict) -> Int {
+            switch v { case .allow: return 0; case .warn: return 1; case .deny: return 2 }
+        }
+        let fileSizes: [UInt64] = [1 * oneGB, 4 * oneGB]
+        let kvs: [UInt64] = [8_192, 131_072]
+        let requesteds = [4096, 64_000]
+
+        // We keep strategy, fileSize, requested, trained, kv fixed and vary `available`.
+        for fs in fileSizes {
+            for kv in kvs {
+                for req in requesteds {
+                    let base = self.makeInputs(
+                        modelFileSize: fs, strategy: .mappable, requested: req,
+                        trained: 131_072, kvBytesPerToken: kv, available: oneGB
+                    )
+                    let doubled = self.makeInputs(
+                        modelFileSize: fs, strategy: .mappable, requested: req,
+                        trained: 131_072, kvBytesPerToken: kv, available: 2 * oneGB
+                    )
+                    let quadrupled = self.makeInputs(
+                        modelFileSize: fs, strategy: .mappable, requested: req,
+                        trained: 131_072, kvBytesPerToken: kv, available: 4 * oneGB
+                    )
+                    let p1 = ModelLoadPlan.compute(inputs: base)
+                    let p2 = ModelLoadPlan.compute(inputs: doubled)
+                    let p3 = ModelLoadPlan.compute(inputs: quadrupled)
+                    XCTAssertLessThanOrEqual(rank(p2.verdict), rank(p1.verdict),
+                        "doubling memory made verdict stricter: \(p1.verdict) -> \(p2.verdict)")
+                    XCTAssertLessThanOrEqual(rank(p3.verdict), rank(p2.verdict),
+                        "quadrupling memory made verdict stricter: \(p2.verdict) -> \(p3.verdict)")
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Convenience accessor (test-scoped, avoids repeating `plan.outcome.totalEstimatedBytes`)
+
+private extension ModelLoadPlan {
+    var totalEstimatedBytesForAssertion: UInt64 { outcome.totalEstimatedBytes }
+}


### PR DESCRIPTION
## Summary

**Stage 1 of 5** of the llama.cpp load-path refactor. This PR is strictly additive — it introduces the new `ModelLoadPlan` value type plus its unit tests and a legacy-parity harness, with **zero changes** to existing production or test files.

Later stages will wire `ModelLoadPlan` through the UI, into `LlamaBackend`, flip the protocol, and finally retire `MemoryGate` + shrink `DeviceCapabilityService`. This PR gives those stages a stable type to code against and a safety rail that catches behavioural drift.

### What's added

- `Sources/BaseChatInference/Services/ModelLoadPlan.swift` (326 lines) — public value type unifying the memory-fit and context-clamp decisions currently split across `DeviceCapabilityService.safeContextSize(...)` and `MemoryGate.check(...)`.
- `Tests/BaseChatInferenceTests/ModelLoadPlanTests.swift` (551 lines) — 19 tests covering allow/warn/deny verdicts, info-only clamp reasons, the #398/#411 iPad profile, a `ModelInfo` factory path, three property-style grid tests, and the system-managed / cloud convenience factories.
- `Tests/BaseChatInferenceTests/ModelLoadPlanParityTests.swift` (215 lines) — curated ~36-row grid comparing the plan's verdict against the two legacy gates, summarising divergence without failing on it.

### Shape

```swift
ModelLoadPlan.compute(inputs: Inputs) -> ModelLoadPlan
ModelLoadPlan.compute(for: ModelInfo, requestedContextSize:, strategy:, environment:, ...) -> ModelLoadPlan
ModelLoadPlan.systemManaged(requestedContextSize:) -> ModelLoadPlan
ModelLoadPlan.cloud(requestedContextSize:) -> ModelLoadPlan
```

`Inputs` and `Outcome` are separately `Equatable`. `Verdict` is flat (`.allow | .warn | .deny`); `reasons: [Reason]` may include info-only entries (`.trainedContextExceeded`, `.absoluteCeilingReached`, `.memoryCeilingReached`) even under `.allow`. Arithmetic uses `UInt64` throughout; `Int` only appears at the `effectiveContextSize` boundary.

### Deviations from the Stage 1 brief

Two cases flagged as `.deny + .insufficientKVCache` in the brief (`test_mappableStrategy_deniesWhenKVOverrunsBudget_...` and the iPad/Qwen #398 profile) are impossible under the explicit algorithm: the verdict is computed from `totalEstimatedBytes = residentBudget + effectiveContextSize * kvBytesPerToken` using the **clamped** effective context. Once the memory ceiling clamps the context, the resulting total fits by construction, so the verdict is `.allow`.

Resolution: those two tests now assert the regression behaviour by proving the clamp is aggressive (`< 128_000 / 4` and `< 128_000 / 10` respectively) and surfaces a `.memoryCeilingReached` reason — which is the actual fix for the OOM symptom reported in #398/#411. Inline comments explain the deviation in each test.

The parity harness likewise can't assert the strong union invariant ("both legacy reject ⇒ plan denies; both accept ⇒ plan doesn't deny") because the plan's new unified math diverges from legacy in two known places: (1) mappable strategy caps resident at `min(fileSize/4, 1 GB)` whereas legacy `MemoryGate` uses uncapped `fileSize/4`, and (2) boundary arithmetic at `residentBudget == availableMemoryBytes` floors the context at 1 and micro-overshoots. It records divergence counts and asserts only the weak invariant (<50% of rows diverge) so Stages 2–4 see a tracking number before choosing a reconciliation.

### Sabotage verification

Per CLAUDE.md, every non-property assertion was batch-sabotage-verified:

- **S1** (invert verdict ordering) → 11 unit-test failures
- **S2** (skip trained-context clamp) → 30 failures
- **S3** (drop resident from total) → 488 failures (catches property + unit)
- **S4** (zero resident budget under `.resident`) → resident-denial test fails
- **S5** (`systemManaged` returns effective 0) → factory test fails
- **S6** (force `.deny` for all cases) → parity test fails with 27 divergences

Each was reverted and tests re-run green. 19 unit-test assertions + 1 parity assertion covered.

### Pre-push suite

All four CI suites green locally on Apple Silicon:

- `BaseChatCoreTests`: empty target, run cleanly
- `BaseChatInferenceTests`: 735 tests, 0 failures
- `BaseChatUITests`: 69 tests, 0 failures
- `BaseChatBackendsTests`: 84 tests, 0 failures

## Test plan

- [x] `swift test --filter ModelLoadPlanTests --disable-default-traits` — 19 tests, 0 failures
- [x] `swift test --filter ModelLoadPlanParityTests --disable-default-traits` — 1 test, 0 failures, ~36-row grid
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 735 tests, 0 failures
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — green
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — green
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — green
- [x] Sabotage-verified 20 assertions across 6 production-code mutations