### PR TITLE
feat: wire ModelLoadPlan at UI entry point

### DIFF
--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+ModelLoading.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+ModelLoading.swift
@@ -174,15 +174,47 @@ extension ChatViewModel {
     private func loadLocalModel(_ model: ModelInfo, generation: UInt64?) async {
         guard isCurrentLoadIntentGeneration(generation) else { return }
 
-        if model.modelType != .foundation {
-            guard deviceCapability.canLoadModel(estimatedMemoryBytes: model.fileSize) else {
-                let ramGB = deviceCapability.physicalMemory / (1024 * 1024 * 1024)
-                setLoadErrorIfCurrent(
-                    "This model (\(model.fileSizeFormatted)) may be too large for this device (\(ramGB) GB RAM). Try a smaller quantisation.",
-                    generation: generation
-                )
-                return
-            }
+        // Stage 2: unified load plan. `ModelLoadPlan` fuses the legacy
+        // `DeviceCapabilityService.canLoadModel(...)` fit check and the
+        // `DeviceCapabilityService.safeContextSize(...)` context clamp into a single
+        // decision so backends see a consistent verdict + context pair. The
+        // legacy helpers are still in place for Stage 5 removal — the UI no
+        // longer calls them.
+        let requestedContext = model.detectedContextLength ?? 8_192
+        let plan: ModelLoadPlan
+        switch model.modelType {
+        case .foundation:
+            // Foundation models are system-managed: no weight or KV math applies.
+            plan = ModelLoadPlan.systemManaged(requestedContextSize: requestedContext)
+        case .gguf:
+            plan = ModelLoadPlan.compute(
+                for: model,
+                requestedContextSize: requestedContext,
+                strategy: .mappable,
+                environment: loadPlanEnvironment
+            )
+        case .mlx:
+            plan = ModelLoadPlan.compute(
+                for: model,
+                requestedContextSize: requestedContext,
+                strategy: .resident,
+                environment: loadPlanEnvironment
+            )
+        }
+
+        switch plan.verdict {
+        case .deny:
+            setLoadErrorIfCurrent(
+                loadPlanDenyMessage(for: plan, model: model),
+                generation: generation
+            )
+            return
+        case .warn:
+            Log.inference.warning(
+                "Proceeding with tight-fit model load: \(model.name) — \(String(describing: plan.reasons))"
+            )
+        case .allow:
+            break
         }
 
         // Auto-detect prompt template from GGUF metadata before loading.
@@ -202,22 +234,41 @@ extension ChatViewModel {
         }
 
         do {
-            // Derive a memory-safe context size rather than blindly using the model's
-            // trained length. A 128K GGUF loaded at full context on an 8 GB iPad consumes
-            // ~1 GB of KV cache, which can push the process over its jetsam limit.
-            // DeviceCapabilityService.safeContextSize uses os_proc_available_memory() on iOS
-            // (the per-app budget) and physical memory on macOS, then applies a 60% KV
-            // budget after reserving 40% headroom for model weights and runtime.
-            let contextSize = DeviceCapabilityService.safeContextSize(
-                for: model.detectedContextLength,
-                estimatedKVBytesPerToken: model.estimatedKVBytesPerToken
+            try await inferenceService.loadModel(
+                from: model,
+                contextSize: Int32(plan.effectiveContextSize)
             )
-            try await inferenceService.loadModel(from: model, contextSize: contextSize)
         } catch is CancellationError {
             return
         } catch {
             setLoadErrorIfCurrent("Failed to load model: \(error.localizedDescription)", generation: generation)
         }
+    }
+
+    /// Translates a denied plan's primary `Reason` into a user-visible message.
+    ///
+    /// Picks the first `.insufficientResident` or `.insufficientKVCache` as the
+    /// primary reason; clamp reasons (info-only) are not surfaced. Falls back to
+    /// the legacy shape when no primary reason is present.
+    private func loadPlanDenyMessage(for plan: ModelLoadPlan, model: ModelInfo) -> String {
+        let primary = plan.reasons.first { reason in
+            switch reason {
+            case .insufficientResident, .insufficientKVCache: return true
+            default: return false
+            }
+        }
+        switch primary {
+        case .insufficientResident(let required, let available):
+            return "This model (\(Self.formatBytes(required))) is too large for available memory (\(Self.formatBytes(available))). Try a smaller quantisation."
+        case .insufficientKVCache(let required, let available):
+            return "Model weights fit, but the requested context window doesn't (\(Self.formatBytes(required)) needed vs \(Self.formatBytes(available)) available). Try reducing the context size or closing other apps."
+        default:
+            return "This model (\(model.fileSizeFormatted)) may be too large for this device. Try a smaller quantisation."
+        }
+    }
+
+    private static func formatBytes(_ bytes: UInt64) -> String {
+        ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)
     }
 
     private func loadCloudEndpointInternal(_ endpoint: APIEndpoint, generation: UInt64?) async {

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -34,6 +34,11 @@ public final class ChatViewModel {
     let modelStorage: ModelStorageService
     let memoryPressure: MemoryPressureHandler
 
+    /// Test-only seam: overrides the system-memory source used by `ModelLoadPlan`
+    /// when deciding whether a local model load should proceed. Production code
+    /// leaves this at `.current`; tests assign a deterministic environment.
+    var loadPlanEnvironment: ModelLoadPlan.Environment = .current
+
     // MARK: - Persistence
 
     let sessionController: SessionController

--- a/Tests/BaseChatE2ETests/ModelSelectionE2ETests.swift
+++ b/Tests/BaseChatE2ETests/ModelSelectionE2ETests.swift
@@ -189,7 +189,10 @@ final class ModelSelectionE2ETests {
         let mockRef = mock
         let storage = ModelStorageService(baseDirectory: modelsDir)
 
-        // 1 MB of RAM — far too small for any real model.
+        // Stage 2: fit checks route through `ModelLoadPlan`, which consults
+        // `availableMemoryBytes` from an injected environment. The legacy
+        // `DeviceCapabilityService(physicalMemory:)` knob no longer influences
+        // load admission at the UI layer — pin the plan environment directly.
         let tinyDevice = DeviceCapabilityService(physicalMemory: 1_000_000)
         let restrictedService = InferenceService()
         restrictedService.registerBackendFactory { _ in mockRef }
@@ -197,6 +200,10 @@ final class ModelSelectionE2ETests {
             inferenceService: restrictedService,
             deviceCapability: tinyDevice,
             modelStorage: storage
+        )
+        restrictedVM.loadPlanEnvironment = ModelLoadPlan.Environment(
+            availableMemoryBytes: { 1_000_000 },  // 1 MB
+            physicalMemoryBytes: 1_000_000
         )
 
         let bigModel = ModelInfo(
@@ -213,7 +220,7 @@ final class ModelSelectionE2ETests {
         #expect(restrictedVM.errorMessage != nil)
         #expect(!restrictedVM.isModelLoaded)
 
-        // Sabotage: with enough RAM, the load should proceed.
+        // Sabotage: with enough RAM the plan allows and the load should proceed.
         let largeDevice = DeviceCapabilityService(physicalMemory: 32 * 1024 * 1024 * 1024)
         let permissiveService = InferenceService()
         permissiveService.registerBackendFactory { _ in mockRef }
@@ -221,6 +228,10 @@ final class ModelSelectionE2ETests {
             inferenceService: permissiveService,
             deviceCapability: largeDevice,
             modelStorage: storage
+        )
+        permissiveVM.loadPlanEnvironment = ModelLoadPlan.Environment(
+            availableMemoryBytes: { 32 * 1024 * 1024 * 1024 },
+            physicalMemoryBytes: 32 * 1024 * 1024 * 1024
         )
         permissiveVM.selectedModel = bigModel
         await permissiveVM.loadSelectedModel()

--- a/Tests/BaseChatUITests/ChatViewModelLoadPlanWiringTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelLoadPlanWiringTests.swift
@@ -1,0 +1,233 @@
+@preconcurrency import XCTest
+@testable import BaseChatUI
+@testable import BaseChatInference
+
+private let oneGB: UInt64 = 1_024 * 1_024 * 1_024
+
+/// Stage 2 wiring tests: the UI entry point now routes through `ModelLoadPlan`
+/// instead of `DeviceCapabilityService.canLoadModel`. These assert the behaviour
+/// the plan's verdict must produce end-to-end from `loadSelectedModel()`.
+@MainActor
+final class ChatViewModelLoadPlanWiringTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Builds a view model with a registered recording backend for the given
+    /// model type. `physicalMemory` is deliberately decoupled from the plan
+    /// environment: if legacy code paths are reached, `canLoadModel` will
+    /// evaluate against it, letting us detect regressions.
+    private func makeViewModel(
+        modelType: ModelType = .gguf,
+        physicalMemory: UInt64,
+        planEnvironment: ModelLoadPlan.Environment
+    ) -> (ChatViewModel, RecordingBackend) {
+        let backend = RecordingBackend()
+        let service = InferenceService()
+        service.registerBackendFactory { type in
+            type == modelType ? backend : nil
+        }
+        let vm = ChatViewModel(
+            inferenceService: service,
+            deviceCapability: DeviceCapabilityService(physicalMemory: physicalMemory),
+            modelStorage: ModelStorageService(),
+            memoryPressure: MemoryPressureHandler()
+        )
+        vm.loadPlanEnvironment = planEnvironment
+        return (vm, backend)
+    }
+
+    private func makeLocalModel(
+        modelType: ModelType = .gguf,
+        fileSize: UInt64 = 1_024,
+        detectedContextLength: Int? = 4_096,
+        estimatedKVBytesPerToken: UInt64? = 2_048
+    ) -> ModelInfo {
+        ModelInfo(
+            name: "Test",
+            fileName: "test.gguf",
+            url: URL(fileURLWithPath: "/virtual/test.gguf"),
+            fileSize: fileSize,
+            modelType: modelType,
+            detectedContextLength: detectedContextLength,
+            estimatedKVBytesPerToken: estimatedKVBytesPerToken
+        )
+    }
+
+    // MARK: - Tests
+
+    /// The legacy `canLoadModel` guard returned `false` for a model larger than
+    /// `physicalMemory * 0.70 / 1.20`. If the UI still consulted it, a 10 GB
+    /// model on a 1 GB device would refuse to load. The new plan uses
+    /// `availableMemoryBytes` from the injected environment — we set that to
+    /// plenty, so the load must proceed, proving `canLoadModel` is bypassed.
+    func test_loadLocalModel_doesNotInvokeDeviceCapabilityServiceCanLoadModel() async {
+        let env = ModelLoadPlan.Environment(
+            availableMemoryBytes: { 32 * oneGB },
+            physicalMemoryBytes: 32 * oneGB
+        )
+        let (vm, backend) = makeViewModel(
+            physicalMemory: 1 * oneGB,  // tiny — canLoadModel would reject
+            planEnvironment: env
+        )
+        let model = makeLocalModel(fileSize: 10 * oneGB)  // 10x physical RAM
+        vm.availableModels = [model]
+        vm.selectedModel = model
+
+        await vm.loadSelectedModel()
+
+        XCTAssertEqual(backend.loadCallCount, 1, "Plan must allow despite tiny physicalMemory")
+        XCTAssertNil(vm.errorMessage)
+    }
+
+    /// With an environment that reports almost no available memory, the plan
+    /// produces `.deny` with an `.insufficientResident` or `.insufficientKVCache`
+    /// reason. The UI must surface that reason's text instead of the legacy
+    /// RAM-in-GB message.
+    func test_loadLocalModel_denyVerdict_surfacesReasonInErrorMessage() async {
+        let env = ModelLoadPlan.Environment(
+            availableMemoryBytes: { 128 * 1024 * 1024 },  // 128 MB available
+            physicalMemoryBytes: 8 * oneGB
+        )
+        let (vm, backend) = makeViewModel(
+            physicalMemory: 8 * oneGB,
+            planEnvironment: env
+        )
+        // Model weights alone (2 GB) vastly exceed available memory.
+        let model = makeLocalModel(fileSize: 2 * oneGB)
+        vm.availableModels = [model]
+        vm.selectedModel = model
+
+        await vm.loadSelectedModel()
+
+        XCTAssertEqual(backend.loadCallCount, 0, "Denied load must not reach backend")
+        let message = vm.errorMessage ?? ""
+        let hasReasonText = message.contains("too large for available memory")
+            || message.contains("context window")
+        XCTAssertTrue(
+            hasReasonText,
+            "Expected plan-derived reason text in error message, got: \(message)"
+        )
+    }
+
+    /// Happy path: plan allows, backend is invoked, and the `contextSize` passed
+    /// to the backend equals `Int32(plan.effectiveContextSize)`. Using a
+    /// tight-but-allowed environment keeps the effective context below the
+    /// requested context, which lets us diff against a naive passthrough.
+    func test_loadLocalModel_allowVerdict_proceedsToInferenceService() async {
+        let env = ModelLoadPlan.Environment(
+            availableMemoryBytes: { 32 * oneGB },
+            physicalMemoryBytes: 32 * oneGB
+        )
+        let (vm, backend) = makeViewModel(
+            physicalMemory: 32 * oneGB,
+            planEnvironment: env
+        )
+        let model = makeLocalModel(
+            fileSize: 1 * oneGB,
+            detectedContextLength: 8_192,
+            estimatedKVBytesPerToken: 2_048
+        )
+        vm.availableModels = [model]
+        vm.selectedModel = model
+
+        let expectedPlan = ModelLoadPlan.compute(
+            for: model,
+            requestedContextSize: 8_192,
+            strategy: .mappable,
+            environment: env
+        )
+
+        await vm.loadSelectedModel()
+
+        XCTAssertEqual(backend.loadCallCount, 1)
+        XCTAssertEqual(backend.lastContextSize, Int32(expectedPlan.effectiveContextSize))
+        XCTAssertNil(vm.errorMessage)
+    }
+
+    /// Foundation models are system-managed and must bypass the memory math.
+    /// Even if the plan environment reports near-zero memory, a Foundation
+    /// load must still dispatch with `effectiveContextSize == requested`.
+    func test_loadLocalModel_foundationModelType_usesSystemManagedPlan() async {
+        let env = ModelLoadPlan.Environment(
+            availableMemoryBytes: { 1 },  // hostile: 1 byte available
+            physicalMemoryBytes: 1
+        )
+        let (vm, backend) = makeViewModel(
+            modelType: .foundation,
+            physicalMemory: 1,
+            planEnvironment: env
+        )
+        let model = ModelInfo.builtInFoundation
+        vm.availableModels = [model]
+        vm.selectedModel = model
+
+        // Foundation's detectedContextLength is nil -> requested == 8192.
+        let expectedPlan = ModelLoadPlan.systemManaged(requestedContextSize: 8_192)
+        XCTAssertEqual(expectedPlan.verdict, .allow)
+        XCTAssertEqual(expectedPlan.effectiveContextSize, 8_192)
+
+        await vm.loadSelectedModel()
+
+        XCTAssertEqual(backend.loadCallCount, 1)
+        XCTAssertEqual(backend.lastContextSize, 8_192)
+        XCTAssertNil(vm.errorMessage)
+    }
+}
+
+// MARK: - Recording Backend
+
+/// Captures the arguments of each `loadModel` call so tests can assert on the
+/// context size the UI forwarded to the backend.
+private final class RecordingBackend: InferenceBackend, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _loadCallCount = 0
+    private var _lastURL: URL?
+    private var _lastContextSize: Int32?
+    private var _isModelLoaded = false
+
+    var loadCallCount: Int { withLock { _loadCallCount } }
+    var lastURL: URL? { withLock { _lastURL } }
+    var lastContextSize: Int32? { withLock { _lastContextSize } }
+
+    var isModelLoaded: Bool {
+        get { withLock { _isModelLoaded } }
+        set { withLock { _isModelLoaded = newValue } }
+    }
+    var isGenerating: Bool = false
+
+    let capabilities = BackendCapabilities(
+        supportedParameters: [.temperature],
+        maxContextTokens: 8_192,
+        requiresPromptTemplate: false,
+        supportsSystemPrompt: true
+    )
+
+    func loadModel(from url: URL, contextSize: Int32) async throws {
+        withLock {
+            _loadCallCount += 1
+            _lastURL = url
+            _lastContextSize = contextSize
+            _isModelLoaded = true
+        }
+    }
+
+    func generate(
+        prompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig
+    ) throws -> GenerationStream {
+        let stream = AsyncThrowingStream<GenerationEvent, Error> { continuation in
+            continuation.finish()
+        }
+        return GenerationStream(stream)
+    }
+
+    func stopGeneration() {}
+    func unloadModel() { isModelLoaded = false }
+
+    private func withLock<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
+    }
+}

--- a/Tests/BaseChatUITests/GenerationViewModelTests.swift
+++ b/Tests/BaseChatUITests/GenerationViewModelTests.swift
@@ -155,9 +155,15 @@ final class ChatViewModelTests: XCTestCase {
     // MARK: - test_loadSelectedModel_modelTooLarge_setsError
 
     func test_loadSelectedModel_modelTooLarge_setsError() async {
-        // 4 GB device with a 4 GB model.
-        // Budget: 4 * 0.70 = 2.8 GB. Model + KV: 4 * 1.20 = 4.8 GB. Should fail.
+        // 4 GB device with a 4 GB model. Stage 2 routes fit checks through
+        // `ModelLoadPlan`, which reads `availableMemoryBytes` from an injected
+        // environment — pin it low so the plan denies deterministically on any
+        // host (the real CI box has far more RAM than the model's weights).
         let vm = makeViewModel(ramGB: 4)
+        vm.loadPlanEnvironment = ModelLoadPlan.Environment(
+            availableMemoryBytes: { 512 * 1024 * 1024 },  // 512 MB available
+            physicalMemoryBytes: 4 * oneGB
+        )
 
         let largeModel = ModelInfo(
             name: "huge-model",


### PR DESCRIPTION
## Summary

**Stage 2 of 5** in the llama.cpp load-path refactor (plan: `/Users/roryford/.claude/plans/switching-to-plan-mode-purrfect-widget.md`; Stage 1 = #419).

Routes `ChatViewModel.loadLocalModel` through `ModelLoadPlan` instead of the legacy pair of `DeviceCapabilityService.canLoadModel` + `DeviceCapabilityService.safeContextSize`. Backends now receive a single verdict + context size from a unified decision.

- GGUF loads -> `.mappable`
- MLX loads  -> `.resident`
- Foundation loads -> `ModelLoadPlan.systemManaged` (skips all memory math)
- `.deny` surfaces a primary-reason-derived error; `.warn` logs and proceeds; `.allow` proceeds.

The legacy `canLoadModel` / `safeContextSize` helpers are intentionally **left in place** — Stage 5 removes them. This PR only rewires the UI caller.

Adds a test-only `loadPlanEnvironment` seam on `ChatViewModel` so fit decisions are deterministic across hosts (the plan's `.current` environment queries the real OS, which varies).

## Release Note

_Not required — no external behavior change shipped to apps yet; the plan is still side-effect-free at the backend boundary (Stage 3 rewires backends)._

## Test plan

- [x] `swift test --filter ChatViewModelLoadPlanWiringTests --disable-default-traits` — 4/4 passing
- [x] `swift test --filter ModelLoadPlanTests --disable-default-traits`
- [x] `swift test --filter ModelLoadPlanParityTests --disable-default-traits`
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits`
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits`
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 436/436 passing (2 existing legacy-memory tests updated to inject a plan environment)
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits`
- [x] All 4 new assertions sabotage-verified (restored legacy guard; inverted deny verdict; +1 context size; routed foundation through compute — each sabotage flipped the corresponding test red before being reverted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)