### PR TITLE
feat: LlamaBackend consumes ModelLoadPlan natively; add loadModel(from:plan:) overload

### DIFF
--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -119,7 +119,40 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
 
     // MARK: - Model Lifecycle
 
+    /// Stage 3 shim: legacy contextSize-taking entry point. Builds a minimal plan
+    /// and delegates to ``loadModel(from:plan:)``. Stage 4 removes this method;
+    /// the protocol flip promotes the plan-taking method to the sole requirement.
+    ///
+    /// Because this shim has no ``ModelInfo`` to consult, it does not perform
+    /// memory-aware clamping — it trusts the requested context and lets the
+    /// plan-taking implementation pass it straight to llama.cpp. Callers that
+    /// want real memory gating should build a plan via ``ModelLoadPlan.compute``
+    /// and call ``loadModel(from:plan:)`` directly.
     public func loadModel(from url: URL, contextSize: Int32) async throws {
+        let inputs = ModelLoadPlan.Inputs(
+            modelFileSize: 0,
+            memoryStrategy: .mappable,
+            requestedContextSize: Int(contextSize),
+            trainedContextLength: nil,
+            kvBytesPerToken: 0,
+            availableMemoryBytes: UInt64.max,
+            physicalMemoryBytes: UInt64.max,
+            absoluteContextCeiling: 128_000,
+            headroomFraction: 0.40
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+        try await loadModel(from: url, plan: plan)
+    }
+
+    /// Plan-aware model load. The plan's ``ModelLoadPlan/effectiveContextSize``
+    /// is authoritative — no clamping happens inside llama.cpp's initializer.
+    ///
+    /// - Precondition: `plan.verdict != .deny`. Callers must check the verdict
+    ///   before invoking; the backend assumes the plan is allow/warn.
+    public func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
+        assert(plan.verdict != .deny,
+               "ModelLoadPlan was denied; callers must check verdict before invoking backend")
+
         unloadModel()
         await waitForPendingCleanup()
 
@@ -135,9 +168,10 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         // InferenceService.applyLoadProgress(_:for:) drops values whose request
         // token no longer matches the active loading phase.
         let capturedHandler = withStateLock { _loadProgressHandler }
+        let effectiveContextSize = Int32(plan.effectiveContextSize)
 
         let loadedResources = try await Task.detached(priority: .userInitiated) { [self] in
-            return try self.serializedModelLoad(at: url, contextSize: contextSize, progressHandler: capturedHandler)
+            return try self.serializedModelLoad(at: url, effectiveContextSize: effectiveContextSize, progressHandler: capturedHandler)
         }.value
 
         let didCommit = withStateLock {
@@ -167,12 +201,12 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
     /// in a synchronous context (required by Swift 6.3 strict concurrency).
     private func serializedModelLoad(
         at url: URL,
-        contextSize: Int32,
+        effectiveContextSize: Int32,
         progressHandler: (@Sendable (Double) async -> Void)?
     ) throws -> LoadedResources {
         loadSerializationLock.lock()
         defer { loadSerializationLock.unlock() }
-        return try Self.initializeModel(at: url, requestedContextSize: contextSize, progressHandler: progressHandler)
+        return try Self.initializeModel(at: url, effectiveContextSize: effectiveContextSize, progressHandler: progressHandler)
     }
 
     private struct LoadedResources: @unchecked Sendable {
@@ -226,139 +260,9 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         }
     }
 
-    static func computeKVBytesPerToken(
-        from parameters: GGUFKVCacheParameters,
-        bytesPerElement: Int64 = Int64(GGUFKVCacheEstimator.defaultBytesPerElement)
-    ) -> Int64? {
-        guard bytesPerElement > 0,
-              let estimate = GGUFKVCacheEstimator.estimateBytesPerToken(
-                from: parameters,
-                bytesPerElement: UInt64(bytesPerElement)
-              ) else {
-            return nil
-        }
-        return Int64(estimate)
-    }
-
-    static func computeKVBytesPerToken(
-        for model: OpaquePointer,
-        bytesPerElement: Int64 = Int64(GGUFKVCacheEstimator.defaultBytesPerElement)
-    ) -> Int64? {
-        computeKVBytesPerToken(
-            from: kvCacheParameters(for: model),
-            bytesPerElement: bytesPerElement
-        )
-    }
-
-    /// Returns the maximum context size (in tokens) that is safe to allocate given
-    /// the memory available to this process.
-    ///
-    /// On iOS/iPadOS, `os_proc_available_memory()` returns the per-app jetsam budget —
-    /// the number of bytes the process can allocate before the system kills it. This is
-    /// typically ~3 GB on an 8 GB iPad, regardless of how much physical RAM exists.
-    /// Using physical memory here would produce a meaningless cap (e.g., 128 000 on
-    /// every modern device) and defeat the purpose of the guard.
-    ///
-    /// On macOS there is no per-app jetsam limit, so physical memory is the right ceiling.
-    ///
-    /// The loaded model's KV geometry is preferred when available; otherwise the legacy
-    /// 8 KB/token fallback is used. The result is clamped to 128 000 as an absolute ceiling.
-    static func computeRamSafeCap(
-        for model: OpaquePointer? = nil,
-        kvBytesPerToken: Int64? = nil
-    ) -> Int32 {
-        let kvBytesPerToken = max(
-            1,
-            kvBytesPerToken
-                ?? model.flatMap { Self.computeKVBytesPerToken(for: $0) }
-                ?? Int64(GGUFKVCacheEstimator.legacyFallbackBytesPerToken)
-        )
-        #if os(iOS) || os(tvOS) || os(watchOS)
-        let available = os_proc_available_memory()
-        // os_proc_available_memory() can return 0 or negative in edge cases (simulator boot);
-        // fall through to the physical-memory path if that happens.
-        if available > 0 {
-            return Int32(min(Int64(128_000), Int64(available) / kvBytesPerToken))
-        }
-        #endif
-        let physical = Int64(ProcessInfo.processInfo.physicalMemory)
-        return Int32(min(Int64(128_000), physical / kvBytesPerToken))
-    }
-
-    private static func kvCacheParameters(for model: OpaquePointer) -> GGUFKVCacheParameters {
-        let architecture = modelMetadataString(for: model, key: "general.architecture")
-        let attentionHeadCount = modelMetadataInteger(
-            for: model,
-            key: architecture.map { "\($0).attention.head_count" }
-        ) ?? positive(llama_model_n_head(model))
-
-        return GGUFKVCacheParameters(
-            blockCount: modelMetadataInteger(
-                for: model,
-                key: architecture.map { "\($0).block_count" }
-            ) ?? positive(llama_model_n_layer(model)),
-            embeddingLength: modelMetadataInteger(
-                for: model,
-                key: architecture.map { "\($0).embedding_length" }
-            ) ?? positive(llama_model_n_embd(model)),
-            attentionHeadCount: attentionHeadCount,
-            attentionHeadCountKV: modelMetadataInteger(
-                for: model,
-                key: architecture.map { "\($0).attention.head_count_kv" }
-            ) ?? positive(llama_model_n_head_kv(model)) ?? attentionHeadCount,
-            attentionKeyLength: modelMetadataInteger(
-                for: model,
-                key: architecture.map { "\($0).attention.key_length" }
-            ),
-            attentionValueLength: modelMetadataInteger(
-                for: model,
-                key: architecture.map { "\($0).attention.value_length" }
-            )
-        )
-    }
-
-    private static func modelMetadataInteger(for model: OpaquePointer, key: String?) -> Int? {
-        guard let key,
-              let rawValue = modelMetadataString(for: model, key: key)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) else {
-            return nil
-        }
-        return Int(rawValue)
-    }
-
-    /// Looks up a short scalar/identifier metadata value (architecture name, integer-as-string).
-    /// Not suitable for long values like chat templates — the 4 KB cap silently returns `nil`
-    /// when the value is larger.
-    private static func modelMetadataString(for model: OpaquePointer, key: String) -> String? {
-        var bufferSize = 64
-
-        while bufferSize <= 4096 {
-            var buffer = [CChar](repeating: 0, count: bufferSize)
-            let requiredLength = buffer.withUnsafeMutableBufferPointer { pointer in
-                key.withCString { keyPointer in
-                    llama_model_meta_val_str(model, keyPointer, pointer.baseAddress, pointer.count)
-                }
-            }
-
-            guard requiredLength >= 0 else { return nil }
-            if Int(requiredLength) < buffer.count {
-                return String(cString: buffer)
-            }
-
-            bufferSize = Int(requiredLength) + 1
-        }
-
-        return nil
-    }
-
-    private static func positive(_ value: Int32) -> Int? {
-        guard value > 0 else { return nil }
-        return Int(value)
-    }
-
     private static func initializeModel(
         at url: URL,
-        requestedContextSize: Int32,
+        effectiveContextSize: Int32,
         progressHandler: (@Sendable (Double) async -> Void)? = nil
     ) throws -> LoadedResources {
         var modelParams = llama_model_default_params()
@@ -402,75 +306,41 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         let modelHandle = LlamaModelHandle(rawModel)
 
         var ctxParams = llama_context_default_params()
-        // Respect the model's actual training context length — hard-capping at 8192
-        // prevents long-context models (32K–128K) from using their full window.
-        let trainedContextLength = Int32(llama_model_n_ctx_train(rawModel))
-        // On iOS the per-app jetsam limit is a fraction of physical RAM (~3 GB on an 8 GB
-        // iPad), so we derive the cap from os_proc_available_memory() rather than total
-        // physical memory. On macOS there is no per-app cap, so physical memory is used.
-        let kvBytesPerToken = Self.computeKVBytesPerToken(for: rawModel)
-        let ramSafeCap = Self.computeRamSafeCap(kvBytesPerToken: kvBytesPerToken)
-        let effectiveContextSize = min(requestedContextSize, trainedContextLength, ramSafeCap)
+        ctxParams.n_ctx = UInt32(effectiveContextSize)
         ctxParams.n_threads = Int32(max(1, min(8, ProcessInfo.processInfo.processorCount - 2)))
         ctxParams.n_threads_batch = ctxParams.n_threads
 
         Self.logger.info(
-            "LlamaBackend: RAM-safe cap = \(ramSafeCap) tokens (kvBytesPerToken = \(kvBytesPerToken ?? Int64(GGUFKVCacheEstimator.legacyFallbackBytesPerToken)), effective = \(effectiveContextSize))"
+            "LlamaBackend: initializing context at \(effectiveContextSize) tokens (plan-authoritative)"
         )
 
-        // Retry with progressively halved context on init failure.
-        //
-        // When llama_init_from_model returns nil, the most common cause is a failed
-        // KV-cache allocation. Halving the context reduces KV memory by 50% per attempt.
-        // We retry up to 2 additional times (3 total), stopping at a floor of 1 024 tokens.
-        //
-        // Caveat: on iOS, a jetsam SIGKILL fires before llama_init_from_model returns,
-        // so this retry only helps for clean-nil cases (macOS allocation failure, or iOS
-        // near-threshold failures that return nil rather than being killed). It is
-        // defense-in-depth, not a guarantee against jetsam.
-        var n_ctx = effectiveContextSize
-        let contextFloor: Int32 = 1024
-        let maxAttempts = 3
-        var contextHandle: LlamaContextHandle?
-        for attempt in 1...maxAttempts {
-            ctxParams.n_ctx = UInt32(n_ctx)
-            if let ctx = llama_init_from_model(rawModel, ctxParams) {
-                if attempt > 1 {
-                    Self.logger.info(
-                        "LlamaBackend: context init succeeded on attempt \(attempt) with \(n_ctx) tokens"
-                    )
-                }
-                contextHandle = LlamaContextHandle(
-                    context: ctx,
-                    vocab: llama_model_get_vocab(rawModel)
-                )
-                break
-            }
-            let nextCtx = max(n_ctx / 2, contextFloor)
-            if nextCtx == n_ctx {
-                // Already at the floor and still failing; stop.
-                break
-            }
-            Self.logger.warning(
-                "LlamaBackend: llama_init_from_model failed at \(n_ctx) tokens (attempt \(attempt)/\(maxAttempts)); retrying with \(nextCtx)"
-            )
-            n_ctx = nextCtx
-        }
-
-        guard let contextHandle else {
+        // Single attempt. The plan is authoritative — it has already clamped the
+        // context to a memory-safe value. If llama_init_from_model still returns
+        // nil at this size, we surface a typed error so the caller can request a
+        // smaller plan rather than silently allocating half of what was asked for.
+        guard let ctx = llama_init_from_model(rawModel, ctxParams) else {
             // modelHandle goes out of scope here → llama_model_free called automatically
             throw InferenceError.modelLoadFailed(underlying: NSError(
                 domain: "LlamaBackend",
                 code: -2,
-                userInfo: [NSLocalizedDescriptionKey: "Failed to create llama context"]
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Failed to create llama context at \(effectiveContextSize) tokens. "
+                        + "The memory estimate did not account for an allocator failure at this size. "
+                        + "Retry with a smaller requested context size.",
+                ]
             ))
         }
 
-        // n_ctx reflects the context size that was successfully allocated.
+        let contextHandle = LlamaContextHandle(
+            context: ctx,
+            vocab: llama_model_get_vocab(rawModel)
+        )
+
         return LoadedResources(
             model: modelHandle,
             context: contextHandle,
-            effectiveContextSize: n_ctx
+            effectiveContextSize: effectiveContextSize
         )
     }
 

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -133,3 +133,19 @@ public protocol InferenceBackend: AnyObject, Sendable {
 extension InferenceBackend {
     public func resetConversation() {}
 }
+
+public extension InferenceBackend {
+    /// Load a model using a precomputed ``ModelLoadPlan``.
+    ///
+    /// Default implementation delegates to ``loadModel(from:contextSize:)`` using
+    /// `plan.effectiveContextSize`. Backends that care about the plan's richer
+    /// information (memory strategy, verdict reasons) should override.
+    ///
+    /// - Precondition: `plan.verdict != .deny`. Callers must check verdict first;
+    ///   invoking this with a denied plan is a programming error.
+    func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
+        assert(plan.verdict != .deny,
+               "ModelLoadPlan was denied; callers must check verdict before invoking backend")
+        try await loadModel(from: url, contextSize: Int32(plan.effectiveContextSize))
+    }
+}

--- a/Sources/BaseChatInference/Services/InferenceService.swift
+++ b/Sources/BaseChatInference/Services/InferenceService.swift
@@ -118,7 +118,25 @@ public final class InferenceService {
     ) async throws {
         ensureProviderWired()
         generation.stopGeneration()
+        // Delegation without a plan: the coordinator picks the backend first and
+        // then builds a plan using the backend's declared memory strategy. This
+        // preserves the legacy behaviour where `MemoryStrategy` was sourced from
+        // `backend.capabilities.memoryStrategy`.
         try await lifecycle.loadModel(from: modelInfo, contextSize: contextSize)
+    }
+
+    /// Loads a model using a precomputed ``ModelLoadPlan``.
+    ///
+    /// Prefer this over ``loadModel(from:contextSize:)`` when the caller has already
+    /// produced a plan (for example via the UI load flow). The plan carries the
+    /// authoritative effective context size and memory verdict.
+    public func loadModel(
+        from modelInfo: ModelInfo,
+        plan: ModelLoadPlan
+    ) async throws {
+        ensureProviderWired()
+        generation.stopGeneration()
+        try await lifecycle.loadModel(from: modelInfo, plan: plan)
     }
 
     /// Loads a cloud API backend from an `APIEndpointRecord` configuration.

--- a/Sources/BaseChatInference/Services/ModelLifecycleCoordinator.swift
+++ b/Sources/BaseChatInference/Services/ModelLifecycleCoordinator.swift
@@ -118,30 +118,94 @@ final class ModelLifecycleCoordinator {
             )
         }
 
-        // Pre-flight memory check
-        if let gate = memoryGate {
-            let verdict = gate.check(
-                modelFileSize: modelInfo.fileSize,
-                strategy: newBackend.capabilities.memoryStrategy
+        // Legacy path: build a plan using the backend's declared memory strategy,
+        // then delegate to the shared implementation. Sourcing the strategy from
+        // the backend (rather than from `modelType`) preserves pre-plan behaviour
+        // for callers that register backends with non-default strategies.
+        //
+        // When a `MemoryGate` is installed, its `availableMemoryBytes` closure is
+        // used as the plan's environment so that tests and custom gates continue
+        // to control what the plan sees as "available". Stage 5 will drop the gate
+        // entirely in favour of `ModelLoadPlan.Environment` directly.
+        let plan: ModelLoadPlan
+        if newBackend.capabilities.memoryStrategy == .external {
+            // `.external` backends own their own memory (Foundation Models / cloud);
+            // the plan is always-allow, matching the legacy MemoryGate behaviour.
+            plan = ModelLoadPlan.systemManaged(requestedContextSize: Int(contextSize))
+        } else {
+            let environment: ModelLoadPlan.Environment = memoryGate.map { gate in
+                ModelLoadPlan.Environment(
+                    availableMemoryBytes: gate.availableMemoryBytes,
+                    physicalMemoryBytes: gate.physicalMemoryBytes
+                )
+            } ?? .current
+            plan = ModelLoadPlan.compute(
+                for: modelInfo,
+                requestedContextSize: Int(contextSize),
+                strategy: newBackend.capabilities.memoryStrategy,
+                environment: environment
             )
-            switch verdict {
-            case .allow:
-                break
-            case .warn(let estimated, let available):
-                let estMB = estimated / 1_048_576
-                let availMB = available / 1_048_576
-                Log.inference.warning("Memory warning: model needs ~\(estMB) MB, \(availMB) MB available")
-            case .deny(let estimated, let available):
-                switch gate.denyBehavior {
-                case .throwError:
-                    throw InferenceError.memoryInsufficient(
-                        required: estimated, available: available
+        }
+        try await performLoad(modelInfo: modelInfo, plan: plan, backend: newBackend)
+    }
+
+    func loadModel(
+        from modelInfo: ModelInfo,
+        plan: ModelLoadPlan
+    ) async throws {
+        unloadModel()
+
+        guard let newBackend = createBackend(for: modelInfo.modelType) else {
+            throw InferenceError.inferenceFailure(
+                "No registered backend can handle model type \(modelInfo.modelType). "
+                + "Register a BackendFactory before loading models."
+            )
+        }
+
+        try await performLoad(modelInfo: modelInfo, plan: plan, backend: newBackend)
+    }
+
+    /// Shared implementation for the two `loadModel` overloads. Assumes the caller
+    /// has already created the backend and built the plan.
+    private func performLoad(
+        modelInfo: ModelInfo,
+        plan: ModelLoadPlan,
+        backend newBackend: any InferenceBackend
+    ) async throws {
+        // Pre-flight memory check based on the plan's verdict. Stage 5 deletes
+        // the MemoryGate reference entirely; for now we consult `denyBehavior`
+        // on the gate if one is installed so existing warn-only callers retain
+        // their semantics.
+        //
+        // Downgrade the plan to `.warn` when the caller chose warnOnly — doing
+        // so keeps the backend's `plan.verdict != .deny` precondition satisfied
+        // when we force a load through against the gate's advice.
+        var effectivePlan = plan
+        switch plan.verdict {
+        case .allow:
+            break
+        case .warn:
+            let estMB = plan.outcome.totalEstimatedBytes / 1_048_576
+            let availMB = plan.inputs.availableMemoryBytes / 1_048_576
+            Log.inference.warning("Memory warning (plan): needs ~\(estMB) MB, \(availMB) MB available")
+        case .deny:
+            let required = plan.outcome.totalEstimatedBytes
+            let available = plan.inputs.availableMemoryBytes
+            if let gate = memoryGate, gate.denyBehavior == .warnOnly {
+                Log.inference.warning("Memory insufficient (plan): ~\(required / 1_048_576) MB needed, \(available / 1_048_576) MB available. Proceeding (may swap).")
+                effectivePlan = ModelLoadPlan(
+                    inputs: plan.inputs,
+                    outcome: ModelLoadPlan.Outcome(
+                        effectiveContextSize: plan.outcome.effectiveContextSize,
+                        estimatedResidentBytes: plan.outcome.estimatedResidentBytes,
+                        estimatedKVBytes: plan.outcome.estimatedKVBytes,
+                        totalEstimatedBytes: plan.outcome.totalEstimatedBytes,
+                        verdict: .warn,
+                        reasons: plan.outcome.reasons
                     )
-                case .warnOnly:
-                    let estMB = estimated / 1_048_576
-                    let availMB = available / 1_048_576
-                    Log.inference.warning("Memory insufficient: model needs ~\(estMB) MB, \(availMB) MB available. Proceeding (may swap).")
-                }
+                )
+            } else {
+                throw InferenceError.memoryInsufficient(required: required, available: available)
             }
         }
 
@@ -154,8 +218,9 @@ final class ModelLifecycleCoordinator {
         installProgressHandler(on: newBackend, for: request)
         do {
             let url = modelInfo.url
+            let dispatchPlan = effectivePlan
             try await Task.detached(priority: .userInitiated) {
-                try await newBackend.loadModel(from: url, contextSize: contextSize)
+                try await newBackend.loadModel(from: url, plan: dispatchPlan)
             }.value
         } catch {
             (newBackend as? LoadProgressReporting)?.setLoadProgressHandler(nil)

--- a/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
@@ -136,83 +136,13 @@ final class LlamaBackendTests: XCTestCase {
                         + "spinning on the calling thread would freeze the UI")
     }
 
-    func test_contextSize_capLogic_ramSafeCapCalculation() {
-        // Validates computeRamSafeCap() — the RAM-safe cap helper used in initializeModel.
-        //
-        // The cap is `min(128_000, memoryAvailable / kvBytesPerToken)`. To keep the
-        // monotonicity assertion meaningful on arbitrarily large hosts, we derive
-        // `largeEstimate` from physical RAM so the result lands strictly below the
-        // 128K absolute ceiling regardless of how much memory the CI runner has.
-        let legacyEstimate: Int64 = Int64(GGUFKVCacheEstimator.legacyFallbackBytesPerToken)
-        let physical = Int64(ProcessInfo.processInfo.physicalMemory)
-        // Guarantees physical / largeEstimate < 64_000 → sub-ceiling on any host.
-        let largeEstimate = max(Int64(131_072), physical / 64_000 + 1)
-
-        let legacyCap = LlamaBackend.computeRamSafeCap(kvBytesPerToken: legacyEstimate)
-        let ramSafeCap = LlamaBackend.computeRamSafeCap(kvBytesPerToken: largeEstimate)
-
-        XCTAssertGreaterThan(ramSafeCap, 0,
-                             "RAM-safe cap must be positive; formula may have underflowed")
-        XCTAssertLessThanOrEqual(ramSafeCap, 128_000,
-                                 "RAM-safe cap must not exceed the absolute maximum of 128_000")
-        XCTAssertLessThan(ramSafeCap, legacyCap,
-                          "A larger per-token KV estimate must clamp harder than a smaller one")
-        // A small requested size still wins when it is the smallest of the three values.
-        let requested = Int32(512)
-        let effective = min(requested, Int32(32_000), ramSafeCap)
-        XCTAssertEqual(effective, requested,
-                       "Requested context size should win when it is the smallest of the three values")
-    }
-
-    func test_computeKVBytesPerToken_fromParameters_matchesLlama7BGQAMath() {
-        let estimate = LlamaBackend.computeKVBytesPerToken(
-            from: GGUFKVCacheParameters(
-                blockCount: 32,
-                embeddingLength: 4096,
-                attentionHeadCount: 32,
-                attentionHeadCountKV: 8
-            )
-        )
-
-        XCTAssertEqual(estimate, 131_072)
-    }
-
-    // MARK: - Retry context-halving progression
-
-    func test_retryContextHalving_progressionStopsAtFloor() {
-        // Validates the halve-until-floor logic used in initializeModel's retry loop.
-        // This is a pure-logic test — no C API is called.
-        //
-        // Starting at 8 192 with floor 1 024, halving produces:
-        //   8 192 → 4 096 → 2 048 → 1 024 (floor reached — further halving is clamped)
-        // Running 6 iterations is enough to prove the sequence stops at 1 024.
-        let floor: Int32 = 1024
-        var n_ctx: Int32 = 8192
-        var sequence: [Int32] = [n_ctx]
-        for _ in 1..<6 {
-            let next = max(n_ctx / 2, floor)
-            if next == n_ctx { break }
-            n_ctx = next
-            sequence.append(n_ctx)
-        }
-        XCTAssertEqual(sequence, [8192, 4096, 2048, 1024],
-                       "Retry sequence must halve from 8192 down to the floor (1024) and stop there")
-
-        // Sabotage check: with floor = 0 the sequence is NOT clamped at 1024, so it
-        // continues past that value. Verifying that sequenceNoFloor is strictly longer
-        // than the floored sequence proves the floor guard is doing real work.
-        var n_ctxNoFloor: Int32 = 8192
-        var sequenceNoFloor: [Int32] = [n_ctxNoFloor]
-        for _ in 1..<6 {
-            let next = max(n_ctxNoFloor / 2, 0)
-            if next == n_ctxNoFloor { break }   // prevents infinite loop at 0
-            n_ctxNoFloor = next
-            sequenceNoFloor.append(n_ctxNoFloor)
-        }
-        // With floor=0 we expect [8192, 4096, 2048, 1024, 512, 256] — longer than [8192, 4096, 2048, 1024].
-        XCTAssertGreaterThan(sequenceNoFloor.count, sequence.count,
-                             "Removing the floor must produce a longer sequence — proves the floor guard actually terminates halving")
-    }
+    // Note: context-clamp logic and KV bytes-per-token computation moved from
+    // LlamaBackend into `ModelLoadPlan` / `GGUFKVCacheEstimator` in Stage 3 of
+    // the load-path refactor. The tests that previously exercised
+    // `computeRamSafeCap` / `computeKVBytesPerToken` here were superseded by
+    // `ModelLoadPlanTests` and `ModelLoadPlanParityTests` in
+    // `BaseChatInferenceTests`. The retry-on-nil halving loop was deleted
+    // outright — the plan is authoritative, so there is no fallback to test.
 
     func test_unloadModel_fromCleanState_isNoOp() {
         let backend = LlamaBackend()
@@ -365,6 +295,100 @@ final class LlamaBackendTests: XCTestCase {
             let backend = LlamaBackend()
             backend.unloadModel()
         }
+    }
+
+    // MARK: - Plan-Taking loadModel
+
+    /// The plan's `effectiveContextSize` must be honoured verbatim — no clamping,
+    /// no RAM-safe cap, no trained-context re-check. Prove it by passing a plan
+    /// with a very small context (1 024) and asserting the backend reports it.
+    ///
+    /// Sabotage check: if `initializeModel` hardcoded `n_ctx = 2048` regardless
+    /// of the plan, `backend.capabilities.maxContextTokens` would be 2 048 and
+    /// this assertion would fail.
+    func test_loadModel_fromPlan_passesEffectiveContextSizeToCContext() async throws {
+        guard let modelURL = HardwareRequirements.findGGUFModel() else {
+            throw XCTSkip(
+                "No GGUF model found on disk. Place a `.gguf` file in ~/Documents/Models/ to run this test."
+            )
+        }
+
+        let backend = LlamaBackend()
+        addTeardownBlock { await backend.unloadAndWait() }
+
+        let requested = 1024
+        let inputs = ModelLoadPlan.Inputs(
+            modelFileSize: 0,
+            memoryStrategy: .mappable,
+            requestedContextSize: requested,
+            trainedContextLength: nil,
+            kvBytesPerToken: 0,
+            availableMemoryBytes: UInt64.max,
+            physicalMemoryBytes: UInt64.max,
+            absoluteContextCeiling: 128_000,
+            headroomFraction: 0.40
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+        XCTAssertEqual(plan.effectiveContextSize, requested,
+                       "Plan must pass through the requested context when no ceilings bind")
+
+        try await backend.loadModel(from: modelURL, plan: plan)
+        XCTAssertTrue(backend.isModelLoaded)
+        XCTAssertEqual(backend.capabilities.maxContextTokens, Int32(requested),
+                       "Backend must honour the plan's effectiveContextSize verbatim — "
+                       + "a mismatch means the plan was not authoritative")
+    }
+
+    /// Regression test for #398/#411: when the plan clamps the context to a
+    /// smaller value than requested (the normal memory-gated path), the C API
+    /// must allocate the clamped size, not the requested size. This is the
+    /// named regression for the ggml_metal_host_malloc crash: before the plan,
+    /// the backend would attempt the full requested context and crash.
+    ///
+    /// The assertion here is indirect — we cannot inspect ggml_metal_host_malloc
+    /// error output from a unit test without OSLogStore plumbing — but load
+    /// success at a plan-clamped size confirms the new path respects the clamp.
+    ///
+    /// Sabotage check: if the backend ignored the plan and used `requested`,
+    /// the load would attempt a larger allocation than we requested and either
+    /// succeed (invalidating the test's premise) or crash (failing the test).
+    /// A non-throwing load at the clamped size is what we want to see.
+    func test_loadModel_fromPlan_clampRespected_noMetalHostMallocFailure() async throws {
+        guard let modelURL = HardwareRequirements.findGGUFModel() else {
+            throw XCTSkip(
+                "No GGUF model found on disk. Place a `.gguf` file in ~/Documents/Models/ to run this regression test."
+            )
+        }
+
+        // Build a plan with a generous request but a tight memory budget so the
+        // plan's memoryCeiling clamps `effectiveContextSize` well below the
+        // request. The inputs are synthetic — we don't need the real file size
+        // because `mappable` strategy uses a fraction.
+        let inputs = ModelLoadPlan.Inputs(
+            modelFileSize: 1_073_741_824,  // 1 GB, mappable ⇒ 256 MB resident reserve
+            memoryStrategy: .mappable,
+            requestedContextSize: 65_536,
+            trainedContextLength: nil,
+            kvBytesPerToken: 131_072,      // ~128 KB/tok (large; forces aggressive clamp)
+            availableMemoryBytes: 2_147_483_648,  // 2 GB available
+            physicalMemoryBytes: 8_589_934_592,   // 8 GB physical
+            absoluteContextCeiling: 128_000,
+            headroomFraction: 0.40
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+        XCTAssertLessThan(plan.effectiveContextSize, inputs.requestedContextSize,
+                          "Test setup requires the plan to clamp — inputs must force a memory ceiling")
+        XCTAssertNotEqual(plan.verdict, .deny,
+                          "Test setup requires a plan that is safe to load (not denied)")
+
+        let backend = LlamaBackend()
+        addTeardownBlock { await backend.unloadAndWait() }
+
+        try await backend.loadModel(from: modelURL, plan: plan)
+        XCTAssertTrue(backend.isModelLoaded,
+                      "Load at plan-clamped context size must succeed; a failure here would "
+                      + "indicate the backend allocated more than the plan authorized")
+        XCTAssertEqual(backend.capabilities.maxContextTokens, Int32(plan.effectiveContextSize))
     }
 
     // MARK: - TokenizerVendor

--- a/Tests/BaseChatInferenceTests/MemoryGateInferenceServiceTests.swift
+++ b/Tests/BaseChatInferenceTests/MemoryGateInferenceServiceTests.swift
@@ -44,7 +44,12 @@ final class MemoryGateInferenceServiceTests: XCTestCase {
             XCTFail("Expected memoryInsufficient error")
         } catch let error as InferenceError {
             if case .memoryInsufficient(let required, let available) = error {
-                XCTAssertEqual(required, 4_000_000_000)
+                // Post-ModelLoadPlan: the `required` value is the plan's total estimated
+                // footprint (resident + KV), not just the raw file size. For a resident
+                // strategy with no architectural KV hint, the total is fileSize + an
+                // estimate based on the legacy fallback KV bytes-per-token.
+                XCTAssertGreaterThanOrEqual(required, 4_000_000_000,
+                                            "required must at least cover the model file size")
                 XCTAssertEqual(available, 500_000_000)
             } else {
                 XCTFail("Expected memoryInsufficient, got \(error)")

--- a/Tests/BaseChatInferenceTests/ModelLifecycleCoordinatorTests.swift
+++ b/Tests/BaseChatInferenceTests/ModelLifecycleCoordinatorTests.swift
@@ -75,6 +75,75 @@ final class ModelLifecycleCoordinatorTests: XCTestCase {
                        "activeBackendName must reflect the backend that committed the load")
     }
 
+    // MARK: - 1b. Plan-taking overload commits identically
+
+    /// The plan-taking overload must drive the same commit lifecycle as the
+    /// legacy contextSize overload. This verifies Stage 3's refactor didn't
+    /// break the delegation path.
+    ///
+    /// Sabotage: changing `loadModel(from:plan:)` to skip `commitLoadIfCurrent`
+    /// would leave `isModelLoaded = false` and fail the assertion below.
+    func test_planLoad_commitsIdentically() async throws {
+        let (coordinator, backend) = makeCoordinatorAndGate()
+        let modelInfo = makeModelInfo()
+        let plan = ModelLoadPlan.compute(
+            for: modelInfo,
+            requestedContextSize: 2048,
+            strategy: .mappable
+        )
+
+        let task = Task { try await coordinator.loadModel(from: modelInfo, plan: plan) }
+        await backend.waitUntilLoadStarted()
+        await backend.releaseSuccess()
+        try await task.value
+
+        XCTAssertTrue(coordinator.isModelLoaded,
+                      "Plan-taking overload must flip isModelLoaded on successful commit")
+        XCTAssertEqual(coordinator.activeBackendName, "llama.cpp")
+    }
+
+    /// A plan with `verdict == .deny` must throw `memoryInsufficient` before
+    /// ever dispatching to the backend — no load task should start.
+    ///
+    /// Sabotage: deleting the `.deny` throw branch would let the load proceed
+    /// and either commit or block on the gated backend.
+    func test_planLoad_deniedPlan_throwsMemoryInsufficient() async throws {
+        let (coordinator, backend) = makeCoordinatorAndGate()
+        let modelInfo = makeModelInfo()
+
+        // Synthesize a plan whose inputs force a deny verdict.
+        let denied = ModelLoadPlan.compute(inputs: ModelLoadPlan.Inputs(
+            modelFileSize: 64 * 1_073_741_824,   // 64 GB model
+            memoryStrategy: .resident,
+            requestedContextSize: 4096,
+            trainedContextLength: nil,
+            kvBytesPerToken: 8_192,
+            availableMemoryBytes: 1_073_741_824, // 1 GB available — model won't fit
+            physicalMemoryBytes: 1_073_741_824,
+            absoluteContextCeiling: 128_000,
+            headroomFraction: 0.40
+        ))
+        XCTAssertEqual(denied.verdict, .deny,
+                       "Test setup: crafted inputs must produce a deny verdict")
+
+        do {
+            try await coordinator.loadModel(from: modelInfo, plan: denied)
+            XCTFail("Denied plan must throw before calling into the backend")
+        } catch let error as InferenceError {
+            if case .memoryInsufficient = error {
+                // Expected
+            } else {
+                XCTFail("Expected memoryInsufficient, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+
+        XCTAssertFalse(coordinator.isModelLoaded)
+        // Backend must not have been invoked.
+        XCTAssertFalse(backend.isModelLoaded)
+    }
+
     // MARK: - 2. Stale load suppressed
 
     /// When request B supersedes request A (B starts after A), A's completion


### PR DESCRIPTION
## Summary

Stage 3 of 5 in the load-path refactor. Stages 1 (#419) and 2 (#420) already merged.

- Adds `InferenceBackend.loadModel(from:plan:)` as a **non-required** protocol extension. Default implementation delegates to `loadModel(from:contextSize:)` using `plan.effectiveContextSize` — existing conformers work unchanged.
- `LlamaBackend` overrides the new method and consumes the plan verbatim. Deletes the retry-on-nil halving loop and the RAM/KV helper cluster (`computeKVBytesPerToken`, `computeRamSafeCap`, `kvCacheParameters`, `modelMetadataInteger/String`, `positive`) — that math now lives in `ModelLoadPlan.compute` / `GGUFKVCacheEstimator`, already covered by `ModelLoadPlanTests` + `ModelLoadPlanParityTests`.
- `InferenceService` and `ModelLifecycleCoordinator` gain plan-taking variants. Legacy `contextSize:` overloads remain; they now build the plan using the **backend's declared** `memoryStrategy` (not a `modelType` mapping), preserving pre-plan behaviour for non-default strategies.
- When a `MemoryGate` is installed, its `availableMemoryBytes` closure is used as the plan's environment so existing test hooks still control what the plan sees. `.external` strategy short-circuits to `ModelLoadPlan.systemManaged(...)` (always-allow), matching legacy `MemoryGate.check`.

Non-goals per Stage 3:

- MLX / Foundation / Cloud / Mock backends are **not** modified — they inherit the default extension delegation and migrate atomically in Stage 4.
- `MemoryGate`, `DeviceCapabilityService.canLoadModel`, `.safeContextSize` remain — Stage 5 deletes them.
- `loadCloudBackend` path is unchanged (still uses the contextSize overload).

LlamaBackend.swift shrinks **882 → 752 lines** (-130).

## Sabotage verification

3 sabotage runs, each failed the corresponding new test and was reverted:

1. `_effectiveContextSize = 2048` (ignore plan) — broke both `test_loadModel_fromPlan_*` tests.
2. Swallow `.deny` verdict in coordinator — broke `test_planLoad_deniedPlan_throwsMemoryInsufficient` (assertion abort path).
3. Skip `commitLoadIfCurrent` in plan-taking path — broke `test_planLoad_commitsIdentically`.

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 176 tests, 0 failures (4 skipped)
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 737 tests, 0 failures
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 436 tests, 0 failures
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 84 tests, 0 failures
- [x] `swift test --filter BaseChatBackendsTests --traits MLX,Llama` — 188 tests, 0 failures (2 skipped)
- [x] `swift test --filter BaseChatE2ETests --disable-default-traits` — 51 tests, 6 Ollama skipped (no local server), 0 failures
- [x] `swift test --filter ModelLoadPlanTests --disable-default-traits` — 19 tests, 0 failures
- [x] `swift test --filter ModelLoadPlanParityTests --disable-default-traits` — 1 test, 0 failures
- [x] `swift test --filter ChatViewModelLoadPlanWiringTests --disable-default-traits` — 4 tests, 0 failures
- [x] `swift test --filter ModelLifecycleCoordinatorTests --disable-default-traits` — 10 tests, 0 failures

## Release Note

**Plan-authoritative llama.cpp loads** — `LlamaBackend` now consumes `ModelLoadPlan` natively and trusts the plan's `effectiveContextSize` verbatim. The in-backend RAM-safe cap, per-architecture KV probing, and retry-on-nil halving loop are gone — those belong in `ModelLoadPlan.compute`, where they are unit-tested against the legacy gates via the parity harness. Callers can opt in via the new `InferenceService.loadModel(from:plan:)` overload; the legacy `contextSize:` entry point still works and builds an equivalent plan under the hood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)