### PR TITLE
fix(test): pin denyPolicy in test_planLoad_deniedPlan_throwsMemoryInsufficient

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-spm-
 
       # CI smoke profile (GitHub macOS Apple Silicon runners):
-      # - Runs BaseChatCoreTests + BaseChatUITests + BaseChatBackendsTests.
+      # - Runs BaseChatCoreTests + BaseChatInferenceTests + BaseChatUITests + BaseChatBackendsTests.
       # - --disable-default-traits skips MLX (default-enabled) to avoid metallib
       #   crashes in CI — Metal shaders are only compiled by Xcode.
       # - BaseChatBackendsTests without traits runs only CI-safe cloud/SSE tests.
@@ -66,6 +66,9 @@ jobs:
 
       - name: Test — Core
         run: swift test --filter BaseChatCoreTests --disable-default-traits
+
+      - name: Test — Inference
+        run: swift test --filter BaseChatInferenceTests --disable-default-traits
 
       - name: Test — UI
         run: swift test --filter BaseChatUITests --disable-default-traits

--- a/Tests/BaseChatInferenceTests/ModelLifecycleCoordinatorTests.swift
+++ b/Tests/BaseChatInferenceTests/ModelLifecycleCoordinatorTests.swift
@@ -109,6 +109,7 @@ final class ModelLifecycleCoordinatorTests: XCTestCase {
     /// and either commit or block on the gated backend.
     func test_planLoad_deniedPlan_throwsMemoryInsufficient() async throws {
         let (coordinator, backend) = makeCoordinatorAndGate()
+        coordinator.denyPolicy = .throwError   // pin policy — platformDefault is .warnOnly on macOS and would downgrade .deny to proceed, hanging the GatedLoadBackend
         let modelInfo = makeModelInfo()
 
         // Synthesize a plan whose inputs force a deny verdict.


### PR DESCRIPTION
## Summary

Closes #425.

`test_planLoad_deniedPlan_throwsMemoryInsufficient` (added in #422) hangs indefinitely on macOS. Root cause: the test relied on the coordinator's default `denyPolicy` to throw on a `.deny` verdict, but `LoadDenyPolicy.platformDefault` resolves to `.warnOnly` on macOS (vs `.throwError` on iOS). On macOS the coordinator logged the deny and proceeded to the `GatedLoadBackend`, which was waiting on a `releaseSuccess()` signal the test never sent.

Fix: pin `coordinator.denyPolicy = .throwError` at the top of the test so it exercises the intended path on every platform.

Also added `BaseChatInferenceTests` to the CI matrix so this class of regression is caught by CI — `BaseChatInferenceTests` was previously absent from `.github/workflows/ci.yml`, which is why the macOS hang slipped past CI.

## Sabotage verification

Removed the new line, re-ran the test on macOS — confirmed it hangs (killed after 60s). Restored the line — test passes in 0.001s. **sabotage-verified.**

## Test plan

- [x] `swift test --filter ModelLifecycleCoordinatorTests --disable-default-traits` — passes
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 724 tests, 0 failures
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 176 tests, 0 failures
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 436 tests, 0 failures
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 138 tests, 0 failures

## Release Note

**Test reliability on macOS** — Fixed `test_planLoad_deniedPlan_throwsMemoryInsufficient` hanging on macOS because the default `LoadDenyPolicy.platformDefault` is `.warnOnly` there; the test now pins `.throwError` explicitly. Added `BaseChatInferenceTests` to the CI matrix so inference-layer regressions are caught before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)