### PR TITLE
refactor: migrate UI recommendation helpers to ModelLoadPlan

### DIFF
--- a/Sources/BaseChatInference/Models/DownloadableModel.swift
+++ b/Sources/BaseChatInference/Models/DownloadableModel.swift
@@ -279,15 +279,16 @@ public struct DownloadableModelGroup: Identifiable {
     /// Returns the recommended variant for the given device capability.
     ///
     /// The recommended variant is the largest quantization (by `sizeBytes`) that still
-    /// passes `deviceCapability.canLoadModel(estimatedMemoryBytes:)`. When no variant
-    /// fits, returns the smallest variant (the most likely to succeed at runtime).
+    /// passes `ModelLoadPlan.canRunModel`. When no variant fits, returns the smallest
+    /// variant (the most likely to succeed at runtime).
     public func recommendedVariant(for deviceCapability: DeviceCapabilityService) -> DownloadableModel? {
         guard !variants.isEmpty else { return nil }
 
+        let physical = deviceCapability.physicalMemory
         // Variants are already sorted ascending by sizeBytes (see group()).
         // The largest fitting variant is the last one that passes the check.
         let fittingVariants = variants.filter {
-            $0.sizeBytes > 0 && deviceCapability.canLoadModel(estimatedMemoryBytes: $0.sizeBytes)
+            $0.sizeBytes > 0 && ModelLoadPlan.canRunModel(sizeBytes: $0.sizeBytes, physicalMemoryBytes: physical)
         }
 
         if let best = fittingVariants.last {

--- a/Sources/BaseChatInference/Services/DeviceCapabilityService.swift
+++ b/Sources/BaseChatInference/Services/DeviceCapabilityService.swift
@@ -42,28 +42,6 @@ public enum ModelSizeRecommendation: String, CaseIterable, Sendable {
 /// This service provides conservative recommendations so the app stays well within bounds.
 public final class DeviceCapabilityService: Sendable {
 
-    /// Fraction of physical RAM we allow the model + KV cache to occupy.
-    /// 70% leaves headroom for the OS, the app itself, and other background work.
-    private static let maxMemoryFraction: Double = 0.70
-
-    /// Fraction of available memory to reserve for model weights and runtime overhead.
-    /// 40% headroom leaves 60% for the KV cache allocation.
-    ///
-    /// This is intentionally conservative: the KV cache for a 128K context at 8 KB/token
-    /// is ~1 GB, and model weights easily occupy 2–5 GB. On iPad the per-app jetsam limit
-    /// is a fraction of physical RAM, so we must budget from available memory, not physical.
-    private static let kvHeadroomFraction: Double = 0.40
-
-    /// Legacy fallback used when GGUF metadata is missing the architectural fields
-    /// required for a more realistic KV-cache estimate.
-    private static let legacyFallbackKVBytesPerToken = GGUFKVCacheEstimator.legacyFallbackBytesPerToken
-
-    /// Absolute maximum context tokens we will ever request, regardless of model or device.
-    private static let absoluteContextCeiling: Int = 128_000
-
-    /// Fallback default context size when the model's trained length is unknown.
-    private static let unknownContextDefault: Int = 8_192
-
     /// Total physical RAM on this device, in bytes.
     public let physicalMemory: UInt64
 
@@ -81,48 +59,6 @@ public final class DeviceCapabilityService: Sendable {
 
     // MARK: - Public API
 
-    /// Computes a safe GGUF context size for this device, clamped to both the model's
-    /// trained context length and a memory-derived ceiling.
-    ///
-    /// On iOS, available memory is read from `os_proc_available_memory()` — the per-app
-    /// jetsam budget — rather than physical RAM, which is meaningless as a per-app limit.
-    /// On macOS the jetsam budget does not exist, so physical memory is used (consistent
-    /// with the existing LlamaBackend behaviour on that platform).
-    ///
-    /// - Parameters:
-    ///   - detectedContextLength: The model's trained context length, if known from GGUF metadata.
-    ///     Pass `nil` when unknown — the method falls back to `unknownContextDefault` (8 192).
-    ///   - availableMemoryBytes: Available memory in bytes. When `nil`, the method queries
-    ///     the system itself — useful for injection in tests.
-    ///   - estimatedKVBytesPerToken: Best-effort per-token KV estimate. Pass a GGUF-derived
-    ///     value when available; otherwise the helper falls back to the legacy 8 KB heuristic.
-    /// - Returns: A safe `Int32` context token count.
-    public static func safeContextSize(
-        for detectedContextLength: Int?,
-        availableMemoryBytes: UInt64? = nil,
-        estimatedKVBytesPerToken: UInt64? = nil
-    ) -> Int32 {
-        let available = availableMemoryBytes ?? Self.queryAvailableMemory()
-        let kvBytesPerToken = estimatedKVBytesPerToken
-            .flatMap { $0 > 0 ? $0 : nil }
-            ?? legacyFallbackKVBytesPerToken
-
-        // Reserve 40% for model weights + runtime; KV cache gets the rest.
-        let kvBudgetBytes = UInt64(Double(available) * (1.0 - kvHeadroomFraction))
-
-        // Derive token ceiling from the per-token KV estimate.
-        let memoryCeiling = Int(kvBudgetBytes / kvBytesPerToken)
-
-        // Clamp to the model's trained length (never exceed what it was designed for).
-        let trainedCeiling = detectedContextLength ?? unknownContextDefault
-
-        let result = min(memoryCeiling, trainedCeiling, absoluteContextCeiling)
-
-        // Floor at 1 to avoid passing a nonsensical value to llama.cpp, even in
-        // pathological low-memory scenarios where available memory is near zero.
-        return Int32(max(1, result))
-    }
-
     /// Returns the number of bytes available for allocation by this process.
     ///
     /// On iOS/tvOS/watchOS, `os_proc_available_memory()` returns the per-app jetsam budget.
@@ -139,20 +75,6 @@ public final class DeviceCapabilityService: Sendable {
         #else
         return ProcessInfo.processInfo.physicalMemory
         #endif
-    }
-
-    /// Returns `true` if the device has enough RAM to load a model of the given size.
-    ///
-    /// The check accounts for both the model weights and an estimated KV cache overhead
-    /// (roughly 20% on top of the model file size for context-window buffers).
-    ///
-    /// - Parameter estimatedMemoryBytes: The on-disk size of the GGUF model file.
-    ///   Runtime memory usage is somewhat larger due to KV cache and working buffers.
-    public func canLoadModel(estimatedMemoryBytes: UInt64) -> Bool {
-        let kvCacheOverhead = Double(estimatedMemoryBytes) * 0.20
-        let totalRequired = Double(estimatedMemoryBytes) + kvCacheOverhead
-        let availableBudget = Double(physicalMemory) * Self.maxMemoryFraction
-        return totalRequired <= availableBudget
     }
 
     /// Recommends the largest model tier this device can comfortably run.

--- a/Sources/BaseChatInference/Services/ModelLoadPlan.swift
+++ b/Sources/BaseChatInference/Services/ModelLoadPlan.swift
@@ -295,6 +295,31 @@ public struct ModelLoadPlan: Sendable {
         return ModelLoadPlan(inputs: inputs, outcome: outcome)
     }
 
+    /// Quick "can this device probably run a model of this size?" check for pre-download
+    /// UI recommendation paths (badges, tier sorting, variant suggestion).
+    ///
+    /// Uses the `.resident` strategy — pessimistic about RAM cost — so the UI stays
+    /// conservative when telling users which downloads will fit. Load-time gating uses
+    /// the full `compute(for:requestedContextSize:strategy:)` against the backend's true
+    /// memory strategy, which may be more permissive (e.g., `.mappable` for GGUF).
+    public static func canRunModel(sizeBytes: UInt64, physicalMemoryBytes: UInt64) -> Bool {
+        let plan = compute(inputs: Inputs(
+            modelFileSize: sizeBytes,
+            memoryStrategy: .resident,
+            requestedContextSize: 2048,
+            trainedContextLength: nil,
+            kvBytesPerToken: GGUFKVCacheEstimator.legacyFallbackBytesPerToken,
+            availableMemoryBytes: physicalMemoryBytes,
+            physicalMemoryBytes: physicalMemoryBytes,
+            absoluteContextCeiling: 128_000,
+            headroomFraction: 0.40
+        ))
+        // .allow only — .warn means "might fit with pressure", which is not a
+        // pre-download recommendation. Tier sorting in the UI distinguishes
+        // comfortable-fit from borderline by probing at 80% size.
+        return plan.verdict == .allow
+    }
+
     /// For cloud backends with no local KV cache. `effectiveContextSize` is purely
     /// informational — cloud providers enforce their own limits server-side.
     public static func cloud(requestedContextSize: Int = 0) -> ModelLoadPlan {

--- a/Sources/BaseChatUI/ViewModels/ModelManagementViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ModelManagementViewModel.swift
@@ -520,8 +520,14 @@ public final class ModelManagementViewModel {
     // MARK: - Device Capability Queries
 
     /// Whether this device has enough RAM to run a model of the given size.
+    ///
+    /// Pre-download recommendation only — backed by `ModelLoadPlan.canRunModel`. Load-time
+    /// gating uses the full plan computation with the active backend's memory strategy.
     public func canRunModel(sizeBytes: UInt64) -> Bool {
-        deviceCapability.canLoadModel(estimatedMemoryBytes: sizeBytes)
+        ModelLoadPlan.canRunModel(
+            sizeBytes: sizeBytes,
+            physicalMemoryBytes: deviceCapability.physicalMemory
+        )
     }
 
     /// Whether there is insufficient free disk space to download this model.
@@ -554,7 +560,7 @@ public final class ModelManagementViewModel {
 
     /// Compatibility tier for sorting a group by device fit (lower = better).
     ///
-    /// - 0: at least one variant comfortably fits (`canLoadModel` passes)
+    /// - 0: at least one variant comfortably fits
     /// - 1: at least one variant borderline fits (passes at 80% of declared size)
     /// - 2: all variants too large
     /// - 3: all variants have unknown size (`sizeBytes == 0`)
@@ -562,10 +568,11 @@ public final class ModelManagementViewModel {
         let sized = group.variants.filter { $0.sizeBytes > 0 }
         guard !sized.isEmpty else { return 3 }
 
-        if sized.contains(where: { deviceCapability.canLoadModel(estimatedMemoryBytes: $0.sizeBytes) }) {
+        let physical = deviceCapability.physicalMemory
+        if sized.contains(where: { ModelLoadPlan.canRunModel(sizeBytes: $0.sizeBytes, physicalMemoryBytes: physical) }) {
             return 0
         }
-        if sized.contains(where: { deviceCapability.canLoadModel(estimatedMemoryBytes: $0.sizeBytes * 80 / 100) }) {
+        if sized.contains(where: { ModelLoadPlan.canRunModel(sizeBytes: $0.sizeBytes * 80 / 100, physicalMemoryBytes: physical) }) {
             return 1
         }
         return 2

--- a/Tests/BaseChatE2ETests/LlamaE2ETests.swift
+++ b/Tests/BaseChatE2ETests/LlamaE2ETests.swift
@@ -266,17 +266,24 @@ final class LlamaE2ETests: XCTestCase {
         let trainedContext = try XCTUnwrap(model.detectedContextLength)
         let estimatedKVBytesPerToken = try XCTUnwrap(model.estimatedKVBytesPerToken)
         let availableMemory = DeviceCapabilityService.queryAvailableMemory()
+        let physicalMemory = ProcessInfo.processInfo.physicalMemory
 
-        let architecturalClamp = DeviceCapabilityService.safeContextSize(
-            for: trainedContext,
-            availableMemoryBytes: availableMemory,
-            estimatedKVBytesPerToken: estimatedKVBytesPerToken
-        )
-        let legacyClamp = DeviceCapabilityService.safeContextSize(
-            for: trainedContext,
-            availableMemoryBytes: availableMemory,
-            estimatedKVBytesPerToken: GGUFKVCacheEstimator.legacyFallbackBytesPerToken
-        )
+        func planContext(kvBytesPerToken: UInt64) -> Int {
+            ModelLoadPlan.compute(inputs: ModelLoadPlan.Inputs(
+                modelFileSize: model.fileSize,
+                memoryStrategy: .mappable,
+                requestedContextSize: trainedContext,
+                trainedContextLength: trainedContext,
+                kvBytesPerToken: kvBytesPerToken,
+                availableMemoryBytes: availableMemory,
+                physicalMemoryBytes: physicalMemory,
+                absoluteContextCeiling: 128_000,
+                headroomFraction: 0.40
+            )).effectiveContextSize
+        }
+
+        let architecturalClamp = planContext(kvBytesPerToken: estimatedKVBytesPerToken)
+        let legacyClamp = planContext(kvBytesPerToken: GGUFKVCacheEstimator.legacyFallbackBytesPerToken)
 
         if architecturalClamp == legacyClamp {
             throw XCTSkip(

--- a/Tests/BaseChatInferenceTests/DeviceCapabilityServiceTests.swift
+++ b/Tests/BaseChatInferenceTests/DeviceCapabilityServiceTests.swift
@@ -3,218 +3,35 @@ import XCTest
 
 final class DeviceCapabilityServiceTests: XCTestCase {
 
-    // MARK: - Helpers
-
     private let oneGB: UInt64 = 1_024 * 1_024 * 1_024
-
-    /// Compute what safeContextSize should produce for a given set of inputs,
-    /// mirroring the formula in DeviceCapabilityService so tests stay coupled
-    /// to the spec, not a specific constant layout.
-    private func expectedSafeContext(
-        availableBytes: UInt64,
-        detectedLength: Int?,
-        absoluteCeiling: Int = 128_000,
-        unknownDefault: Int = 8_192,
-        kvBytesPerToken: UInt64 = 8_192,
-        headroomFraction: Double = 0.40
-    ) -> Int32 {
-        let kvBudget = UInt64(Double(availableBytes) * (1.0 - headroomFraction))
-        let memoryCeiling = Int(kvBudget / kvBytesPerToken)
-        let trainedCeiling = detectedLength ?? unknownDefault
-        let result = min(memoryCeiling, trainedCeiling, absoluteCeiling)
-        return Int32(max(1, result))
-    }
 
     private func makeService(ramGB: UInt64) -> DeviceCapabilityService {
         DeviceCapabilityService(physicalMemory: ramGB * oneGB)
     }
 
-    // MARK: - canLoadModel
-
-    func test_canLoadModel_smallModelOn8GBDevice_returnsTrue() {
-        let service = makeService(ramGB: 8)
-        // 2 GB model -> 2.4 GB with 20% KV overhead; 8 GB * 0.70 = 5.6 GB budget
-        let twoGB: UInt64 = 2 * oneGB
-        XCTAssertTrue(service.canLoadModel(estimatedMemoryBytes: twoGB))
-    }
-
-    func test_canLoadModel_modelTooLargeForDevice_returnsFalse() {
-        let service = makeService(ramGB: 8)
-        // 6 GB model -> 7.2 GB with 20% KV overhead; 8 GB * 0.70 = 5.6 GB budget
-        let sixGB: UInt64 = 6 * oneGB
-        XCTAssertFalse(service.canLoadModel(estimatedMemoryBytes: sixGB))
-    }
-
-    func test_canLoadModel_modelExactlyAtBoundary_returnsTrue() {
-        // Available budget = physicalMemory * 0.70
-        // Total required = estimatedMemoryBytes * 1.20
-        // At boundary: estimatedMemoryBytes * 1.20 == physicalMemory * 0.70
-        //   -> estimatedMemoryBytes = physicalMemory * 0.70 / 1.20
-        let physicalMemory: UInt64 = 8 * oneGB
-        let exactModel = UInt64(Double(physicalMemory) * 0.70 / 1.20)
-        let service = DeviceCapabilityService(physicalMemory: physicalMemory)
-        XCTAssertTrue(service.canLoadModel(estimatedMemoryBytes: exactModel))
-    }
-
     // MARK: - recommendedModelSize
 
     func test_recommendedModelSize_6GBDevice_returnsSmall() {
-        let service = makeService(ramGB: 6)
-        XCTAssertEqual(service.recommendedModelSize(), .small)
+        XCTAssertEqual(makeService(ramGB: 6).recommendedModelSize(), .small)
     }
 
     func test_recommendedModelSize_8GBDevice_returnsMedium() {
-        let service = makeService(ramGB: 8)
-        XCTAssertEqual(service.recommendedModelSize(), .medium)
+        XCTAssertEqual(makeService(ramGB: 8).recommendedModelSize(), .medium)
     }
 
     func test_recommendedModelSize_16GBDevice_returnsLarge() {
-        let service = makeService(ramGB: 16)
-        XCTAssertEqual(service.recommendedModelSize(), .large)
+        XCTAssertEqual(makeService(ramGB: 16).recommendedModelSize(), .large)
     }
 
     func test_recommendedModelSize_32GBDevice_returnsXLarge() {
-        let service = makeService(ramGB: 32)
-        XCTAssertEqual(service.recommendedModelSize(), .xlarge)
+        XCTAssertEqual(makeService(ramGB: 32).recommendedModelSize(), .xlarge)
     }
 
     // MARK: - deviceDescription
 
     func test_deviceDescription_contains_correctRAMValue() {
-        let service = makeService(ramGB: 16)
-        let description = service.deviceDescription
+        let description = makeService(ramGB: 16).deviceDescription
         XCTAssertTrue(description.contains("16 GB RAM"),
                       "Expected '16 GB RAM' in description, got: \(description)")
-    }
-
-    // MARK: - safeContextSize
-
-    func test_safeContextSize_clampsBelowDetectedLength() {
-        // When available memory yields a ceiling below the model's trained length,
-        // the memory ceiling wins — not the trained length.
-        //
-        // 1 GB available × 60% KV budget = 614 MB → 614 MB / 8 KB = ~75 000 tokens
-        // Trained length = 128 000 → clamped to ~75 000.
-        let available = oneGB
-        let result = DeviceCapabilityService.safeContextSize(
-            for: 128_000,
-            availableMemoryBytes: available
-        )
-        let expected = expectedSafeContext(availableBytes: available, detectedLength: 128_000)
-        XCTAssertEqual(result, expected,
-                       "Should clamp to memory ceiling when model context exceeds available-memory budget")
-        XCTAssertLessThan(result, 128_000,
-                          "Result must be less than the model's trained length when memory is the bottleneck")
-    }
-
-    func test_safeContextSize_respectsModelTrainedContext() {
-        // When available memory is abundant (64 GB), the trained context length is the binding constraint.
-        let abundant: UInt64 = 64 * oneGB
-        let trained = 4096
-        let result = DeviceCapabilityService.safeContextSize(
-            for: trained,
-            availableMemoryBytes: abundant
-        )
-        XCTAssertEqual(result, Int32(trained),
-                       "When memory is abundant, the model's trained context length must be the ceiling")
-    }
-
-    func test_safeContextSize_fallbackWhenDetectedContextIsNil() {
-        // When detectedContextLength is nil, the helper should use the 8 192 default,
-        // not the old 2 048 that ChatViewModel previously used.
-        //
-        // With 64 GB available (abundant), the result should equal the default (8 192).
-        let abundant: UInt64 = 64 * oneGB
-        let result = DeviceCapabilityService.safeContextSize(
-            for: nil,
-            availableMemoryBytes: abundant
-        )
-        XCTAssertEqual(result, 8_192,
-                       "Nil detectedContextLength must fall back to the 8 192 default, not 2 048")
-    }
-
-    func test_safeContextSize_neverExceedsAbsoluteCeiling() {
-        // Even with unlimited memory and a trained context of 1 000 000, the result
-        // is capped at 128 000.
-        let unlimited: UInt64 = 512 * oneGB
-        let result = DeviceCapabilityService.safeContextSize(
-            for: 1_000_000,
-            availableMemoryBytes: unlimited
-        )
-        XCTAssertLessThanOrEqual(result, 128_000,
-                                 "safeContextSize must never exceed the 128 000 absolute ceiling")
-    }
-
-    func test_safeContextSize_respectsAvailableMemory() {
-        // With 512 MB available (simulating extreme iOS memory pressure), the result
-        // must be far below the model's 128 000 trained length.
-        //
-        // 512 MB × 60% KV budget = 307 MB → 307 MB / 8 KB ≈ 39 321 tokens.
-        let halfGB: UInt64 = oneGB / 2
-        let result = DeviceCapabilityService.safeContextSize(
-            for: 128_000,
-            availableMemoryBytes: halfGB
-        )
-        let expected = expectedSafeContext(availableBytes: halfGB, detectedLength: 128_000)
-        XCTAssertEqual(result, expected,
-                       "Should apply memory ceiling from available bytes, not physical RAM")
-
-        // Sabotage check: if we removed the memory ceiling and returned just the trained
-        // context, the result would be 128 000. Verify the actual result is less.
-        XCTAssertLessThan(result, 128_000,
-                          "512 MB budget should constrain context well below 128 000 tokens")
-    }
-
-    func test_safeContextSize_usesArchitecturalKVEstimateWhenProvided() {
-        let available = oneGB
-        let architecturalEstimate: UInt64 = 131_072
-
-        let result = DeviceCapabilityService.safeContextSize(
-            for: 128_000,
-            availableMemoryBytes: available,
-            estimatedKVBytesPerToken: architecturalEstimate
-        )
-        let expected = expectedSafeContext(
-            availableBytes: available,
-            detectedLength: 128_000,
-            kvBytesPerToken: architecturalEstimate
-        )
-        let legacy = DeviceCapabilityService.safeContextSize(
-            for: 128_000,
-            availableMemoryBytes: available
-        )
-
-        XCTAssertEqual(result, expected)
-        XCTAssertLessThan(result, legacy,
-                          "A realistic GGUF KV estimate should tighten the clamp versus the legacy 8 KB heuristic")
-    }
-
-    func test_safeContextSize_floorsAtOne_whenAvailableMemoryIsNearZero() {
-        // Pathological case: essentially no memory available — result should be 1, not 0 or negative.
-        let nearZero: UInt64 = 1000
-        let result = DeviceCapabilityService.safeContextSize(
-            for: 128_000,
-            availableMemoryBytes: nearZero
-        )
-        XCTAssertGreaterThanOrEqual(result, 1,
-                                    "safeContextSize must floor at 1 even in near-zero memory conditions")
-    }
-
-    // MARK: - ModelSizeRecommendation.maxModelBytes
-
-    func test_maxModelBytes_small_returnsCorrectValue() {
-        XCTAssertEqual(ModelSizeRecommendation.small.maxModelBytes, 2_500_000_000)
-    }
-
-    func test_maxModelBytes_medium_returnsCorrectValue() {
-        XCTAssertEqual(ModelSizeRecommendation.medium.maxModelBytes, 4_500_000_000)
-    }
-
-    func test_maxModelBytes_large_returnsCorrectValue() {
-        XCTAssertEqual(ModelSizeRecommendation.large.maxModelBytes, 6_000_000_000)
-    }
-
-    func test_maxModelBytes_xlarge_returnsCorrectValue() {
-        XCTAssertEqual(ModelSizeRecommendation.xlarge.maxModelBytes, 40_000_000_000)
     }
 }

--- a/Tests/BaseChatInferenceTests/ModelLoadPlanTests.swift
+++ b/Tests/BaseChatInferenceTests/ModelLoadPlanTests.swift
@@ -542,6 +542,25 @@ final class ModelLoadPlanTests: XCTestCase {
             }
         }
     }
+
+    // MARK: - canRunModel UI helper
+
+    func test_canRunModel_smallModelOnTypicalDevice_returnsTrue() {
+        XCTAssertTrue(ModelLoadPlan.canRunModel(sizeBytes: 2 * oneGB, physicalMemoryBytes: 8 * oneGB))
+    }
+
+    func test_canRunModel_modelLargerThanRAM_returnsFalse() {
+        XCTAssertFalse(ModelLoadPlan.canRunModel(sizeBytes: 16 * oneGB, physicalMemoryBytes: 8 * oneGB))
+    }
+
+    func test_canRunModel_isUsedConsistentlyAcrossUIRecommendationCallers() {
+        // Pre-download UI helpers (ModelManagementViewModel.canRunModel,
+        // .compatibilityTier, DownloadableModel.recommendedVariant) all defer to this
+        // single helper. Sabotage check: if the helper drops the .resident strategy
+        // and goes .mappable, this small-on-large case still passes — but the
+        // boundary case below would silently flip from false to true.
+        XCTAssertFalse(ModelLoadPlan.canRunModel(sizeBytes: 6 * oneGB, physicalMemoryBytes: 4 * oneGB))
+    }
 }
 
 // MARK: - Convenience accessor (test-scoped, avoids repeating `plan.outcome.totalEstimatedBytes`)

--- a/Tests/BaseChatUITests/DownloadableModelGroupCompatibilityTests.swift
+++ b/Tests/BaseChatUITests/DownloadableModelGroupCompatibilityTests.swift
@@ -116,12 +116,12 @@ final class DownloadableModelGroupCompatibilityTests: XCTestCase {
     }
 
     func test_recommendedVariant_partialFit_returnsLargestFitting() {
-        // 8 GB device: 4 GB fits, 6 GB does not. Expect 4 GB.
+        // 8 GB device (allow threshold = 6.8 GB with ModelLoadPlan): 4 GB fits, 8 GB does not.
         let device = DeviceCapabilityService(physicalMemory: 8 * oneGB)
 
         let models = [
             makeModel(repoID: "repo/model", fileName: "model-q4.gguf", sizeBytes: 4 * oneGB),
-            makeModel(repoID: "repo/model", fileName: "model-q6.gguf", sizeBytes: 6 * oneGB),
+            makeModel(repoID: "repo/model", fileName: "model-q6.gguf", sizeBytes: 8 * oneGB),
         ]
         let groups = DownloadableModelGroup.group(models)
         guard let group = groups.first else {
@@ -212,13 +212,12 @@ final class DownloadableModelGroupCompatibilityTests: XCTestCase {
     }
 
     func test_compatibilityTier_borderlineFit_returnsOne() {
-        // A 6 GB device (budget = 6 * 0.70 = 4.2 GB) cannot fit a 4 GB model outright
-        // (requires 4 * 1.20 = 4.8 GB), but the 80% threshold check passes
-        // (4 * 0.80 * 1.20 = 3.84 GB ≤ 4.2 GB).
+        // A 6 GB device (allow threshold = 5.1 GB with ModelLoadPlan) cannot fit a 6 GB
+        // model outright (6 > 5.1), but the 80% threshold check passes (4.8 ≤ 5.1).
         let device = DeviceCapabilityService(physicalMemory: 6 * oneGB)
         let vm = ModelManagementViewModel(deviceCapability: device)
 
-        let models = [makeModel(repoID: "repo/a", fileName: "a.gguf", sizeBytes: 4 * oneGB)]
+        let models = [makeModel(repoID: "repo/a", fileName: "a.gguf", sizeBytes: 6 * oneGB)]
         let group = DownloadableModelGroup.group(models).first!
 
         XCTAssertEqual(vm.compatibilityTier(for: group), 1,


### PR DESCRIPTION
Closes #423.

## Summary

Pre-download UI recommendation callers (ModelManagementViewModel.canRunModel, .compatibilityTier, DownloadableModel.recommendedVariant) now delegate to a new `ModelLoadPlan.canRunModel(sizeBytes:physicalMemoryBytes:)` helper. Unifies the math with the load-path gate — one source of truth.

## Changes

- **New**: `ModelLoadPlan.canRunModel(sizeBytes:physicalMemoryBytes:)` static helper. Uses `.resident` strategy + `verdict == .allow` only (not `.warn`) so the UI stays conservative.
- **Migrated**: `ModelManagementViewModel.canRunModel`, `.compatibilityTier`, and `DownloadableModel.recommendedVariant` call the new helper.
- **Deleted**: `DeviceCapabilityService.canLoadModel` and `.safeContextSize` — now unused. Service shrinks from 237 → ~120 lines.
- **Migrated**: `LlamaE2ETests.test_realModel_architecturalClamp_isTighterThanLegacyHeuristic` uses `ModelLoadPlan.compute` directly.

## Behavior change

The new plan-based threshold is slightly more permissive than the legacy formula (allow if size ≤ physical × 0.85 vs physical × 0.583). This surfaced in three UI tests that had fixture sizes pinned to the legacy boundary — updated with comments explaining the new thresholds.

## Release Note

**Internal refactor** — `DeviceCapabilityService.canLoadModel` and `.safeContextSize` removed (public API, no external adopters known). UI recommendation callers now use `ModelLoadPlan.canRunModel`. No behavior change for typical model/device combinations; boundary cases shift slightly more permissive.