### PR TITLE
test: add in-memory SwiftData harness and direct provider tests

### DIFF
--- a/Sources/BaseChatCore/Protocols/ChatPersistenceProvider.swift
+++ b/Sources/BaseChatCore/Protocols/ChatPersistenceProvider.swift
@@ -21,8 +21,10 @@ public enum ChatPersistenceError: Error, LocalizedError, Sendable, Equatable {
 
 /// Abstraction over chat persistence, decoupling view models from SwiftData.
 ///
-/// The default implementation is ``SwiftDataPersistenceProvider``. Tests can
-/// substitute ``MockPersistenceProvider`` from `BaseChatTestSupport`.
+/// The default implementation is ``SwiftDataPersistenceProvider``. Tests
+/// should build a real provider over an in-memory container via
+/// ``InMemoryPersistenceHarness`` in `BaseChatTestSupport`, optionally wrapped
+/// in ``ErrorInjectingPersistenceProvider`` when failure injection is needed.
 @MainActor
 public protocol ChatPersistenceProvider: AnyObject, Sendable {
 

--- a/Sources/BaseChatTestSupport/ErrorInjectingPersistenceProvider.swift
+++ b/Sources/BaseChatTestSupport/ErrorInjectingPersistenceProvider.swift
@@ -2,25 +2,19 @@ import Foundation
 import BaseChatCore
 import BaseChatInference
 
-/// In-memory mock of ``ChatPersistenceProvider`` for testing.
+/// Test double that wraps any ``ChatPersistenceProvider`` and adds two
+/// facilities the real provider cannot offer: per-method error injection
+/// and call counting.
 ///
-/// Stores sessions and messages in plain arrays. Thread-safe via `@MainActor`.
+/// Pair it with ``InMemoryPersistenceHarness`` when a test needs to assert
+/// that a view model handles persistence failures correctly, or that it
+/// routed through the persistence layer the expected number of times.
+/// All other persistence behaviour (CRUD, ordering, pagination) is the
+/// real provider's, so tests written against this wrapper stay honest.
 @MainActor
-public final class MockPersistenceProvider: ChatPersistenceProvider {
+public final class ErrorInjectingPersistenceProvider: ChatPersistenceProvider {
 
-    public var sessions: [ChatSessionRecord] = []
-    public var messages: [ChatMessageRecord] = []
-
-    // Call tracking
-    public var insertSessionCallCount = 0
-    public var updateSessionCallCount = 0
-    public var deleteSessionCallCount = 0
-    public var fetchSessionsCallCount = 0
-    public var insertMessageCallCount = 0
-    public var updateMessageCallCount = 0
-    public var deleteMessageCallCount = 0
-    public var deleteMessagesCallCount = 0
-    public var fetchMessagesCallCount = 0
+    private let wrapped: any ChatPersistenceProvider
 
     public var shouldThrowOnInsertSession: Error?
     public var shouldThrowOnUpdateSession: Error?
@@ -28,96 +22,83 @@ public final class MockPersistenceProvider: ChatPersistenceProvider {
     public var shouldThrowOnInsertMessage: Error?
     public var shouldThrowOnFetchMessages: Error?
     public var shouldThrowOnDeleteMessages: Error?
+
+    public var insertSessionCallCount = 0
+    public var updateSessionCallCount = 0
+    public var deleteSessionCallCount = 0
+    public var fetchSessionsCallCount = 0
+    public var insertMessageCallCount = 0
+    public var updateMessageCallCount = 0
+    public var deleteMessageCallCount = 0
+    public var fetchMessagesCallCount = 0
     public var fetchRecentMessagesCallCount = 0
     public var fetchMessagesBeforeCallCount = 0
+    public var deleteMessagesCallCount = 0
 
-    public init() {}
-
-    // MARK: - Sessions
+    public init(wrapping wrapped: any ChatPersistenceProvider) {
+        self.wrapped = wrapped
+    }
 
     public func insertSession(_ session: ChatSessionRecord) throws {
         insertSessionCallCount += 1
         if let error = shouldThrowOnInsertSession { throw error }
-        sessions.append(session)
+        try wrapped.insertSession(session)
     }
 
     public func updateSession(_ session: ChatSessionRecord) throws {
         updateSessionCallCount += 1
         if let error = shouldThrowOnUpdateSession { throw error }
-        guard let idx = sessions.firstIndex(where: { $0.id == session.id }) else {
-            throw ChatPersistenceError.sessionNotFound(session.id)
-        }
-        sessions[idx] = session
+        try wrapped.updateSession(session)
     }
 
     public func deleteSession(_ sessionID: UUID) throws {
         deleteSessionCallCount += 1
-        guard sessions.contains(where: { $0.id == sessionID }) else {
-            throw ChatPersistenceError.sessionNotFound(sessionID)
-        }
-        try deleteMessages(for: sessionID)
-        sessions.removeAll { $0.id == sessionID }
+        try wrapped.deleteSession(sessionID)
     }
 
     public func fetchSessions() throws -> [ChatSessionRecord] {
         fetchSessionsCallCount += 1
         if let error = shouldThrowOnFetchSessions { throw error }
-        return sessions.sorted { $0.updatedAt > $1.updatedAt }
+        return try wrapped.fetchSessions()
     }
-
-    // MARK: - Messages
 
     public func insertMessage(_ message: ChatMessageRecord) throws {
         insertMessageCallCount += 1
         if let error = shouldThrowOnInsertMessage { throw error }
-        messages.append(message)
+        try wrapped.insertMessage(message)
     }
 
     public func updateMessage(_ message: ChatMessageRecord) throws {
         updateMessageCallCount += 1
-        guard let idx = messages.firstIndex(where: { $0.id == message.id }) else {
-            throw ChatPersistenceError.messageNotFound(message.id)
-        }
-        messages[idx] = message
+        try wrapped.updateMessage(message)
     }
 
     public func deleteMessage(_ messageID: UUID) throws {
         deleteMessageCallCount += 1
-        guard messages.contains(where: { $0.id == messageID }) else {
-            throw ChatPersistenceError.messageNotFound(messageID)
-        }
-        messages.removeAll { $0.id == messageID }
+        try wrapped.deleteMessage(messageID)
     }
 
     public func fetchMessages(for sessionID: UUID) throws -> [ChatMessageRecord] {
         fetchMessagesCallCount += 1
         if let error = shouldThrowOnFetchMessages { throw error }
-        return messages
-            .filter { $0.sessionID == sessionID }
-            .sorted { $0.timestamp < $1.timestamp }
+        return try wrapped.fetchMessages(for: sessionID)
     }
 
     public func fetchRecentMessages(for sessionID: UUID, limit: Int) throws -> [ChatMessageRecord] {
         fetchRecentMessagesCallCount += 1
         if let error = shouldThrowOnFetchMessages { throw error }
-        let sorted = messages
-            .filter { $0.sessionID == sessionID }
-            .sorted { $0.timestamp < $1.timestamp }
-        return Array(sorted.suffix(limit))
+        return try wrapped.fetchRecentMessages(for: sessionID, limit: limit)
     }
 
     public func fetchMessages(for sessionID: UUID, before: Date, limit: Int) throws -> [ChatMessageRecord] {
         fetchMessagesBeforeCallCount += 1
         if let error = shouldThrowOnFetchMessages { throw error }
-        let older = messages
-            .filter { $0.sessionID == sessionID && $0.timestamp < before }
-            .sorted { $0.timestamp < $1.timestamp }
-        return Array(older.suffix(limit))
+        return try wrapped.fetchMessages(for: sessionID, before: before, limit: limit)
     }
 
     public func deleteMessages(for sessionID: UUID) throws {
         deleteMessagesCallCount += 1
         if let error = shouldThrowOnDeleteMessages { throw error }
-        messages.removeAll { $0.sessionID == sessionID }
+        try wrapped.deleteMessages(for: sessionID)
     }
 }

--- a/Sources/BaseChatTestSupport/InMemoryPersistenceHarness.swift
+++ b/Sources/BaseChatTestSupport/InMemoryPersistenceHarness.swift
@@ -1,0 +1,55 @@
+import Foundation
+import SwiftData
+import BaseChatCore
+import BaseChatInference
+
+/// Builds a fresh in-memory SwiftData stack wrapped in the production
+/// ``SwiftDataPersistenceProvider``.
+///
+/// Tests that exercise persistence behaviour should use this harness rather
+/// than a hand-rolled mock — it catches schema mismatches, predicate bugs,
+/// and ordering regressions that in-memory arrays silently accept. The
+/// container is ephemeral and must not be reused across tests; call
+/// ``make()`` from every `setUp`.
+///
+/// ```swift
+/// override func setUp() async throws {
+///     stack = try InMemoryPersistenceHarness.make()
+/// }
+/// ```
+///
+/// > Important: Hold onto the returned ``Stack`` (store it on the test case
+/// > for the duration of the test). If the stack is only captured inside a
+/// > helper function and that function returns, the `ModelContainer` is
+/// > deallocated, the underlying `ModelContext` becomes invalid, and
+/// > SwiftData will trap on the next fetch/save with `SIGTRAP`.
+@MainActor
+public enum InMemoryPersistenceHarness {
+
+    /// Bundles the SwiftData stack so callers can both drive the public
+    /// provider and poke at the raw `ModelContext` for ad-hoc assertions.
+    public struct Stack {
+        public let container: ModelContainer
+        public let context: ModelContext
+        public let provider: SwiftDataPersistenceProvider
+    }
+
+    /// Creates a fresh in-memory stack. Safe to call from `setUp`.
+    ///
+    /// The caller can verify the store is in-memory by asserting on
+    /// ``isInMemoryStore(_:)`` — kept as an explicit check rather than a
+    /// `precondition` so a misconfiguration surfaces as a test failure
+    /// instead of crashing every suite that shares the harness.
+    public static func make() throws -> Stack {
+        let container = try ModelContainerFactory.makeInMemoryContainer()
+        let context = container.mainContext
+        let provider = SwiftDataPersistenceProvider(modelContext: context)
+        return Stack(container: container, context: context, provider: provider)
+    }
+
+    /// Returns `true` when the container is backed by an in-memory store.
+    /// SwiftData resolves in-memory configurations to a `/dev/null` URL.
+    public static func isInMemoryStore(_ container: ModelContainer) -> Bool {
+        container.configurations.first?.url.path == "/dev/null"
+    }
+}

--- a/TESTING.md
+++ b/TESTING.md
@@ -519,7 +519,8 @@ All shared test infrastructure lives in `Sources/BaseChatTestSupport/`:
 | Mock | Purpose |
 |------|---------|
 | `MockHuggingFaceService` | Stubs HF search results, tracks call counts |
-| `MockPersistenceProvider` | In-memory session/message storage with configurable errors |
+| `InMemoryPersistenceHarness` | Fresh in-memory `SwiftDataPersistenceProvider` stack — preferred over mocked storage |
+| `ErrorInjectingPersistenceProvider` | Wraps any `ChatPersistenceProvider` to add per-method error injection and call counting |
 | `MockURLProtocol` | HTTP interception with immediate, SSE (chunked), and error modes |
 
 ### Utilities

--- a/Tests/BaseChatCoreTests/SwiftDataPersistenceProviderTests.swift
+++ b/Tests/BaseChatCoreTests/SwiftDataPersistenceProviderTests.swift
@@ -1,0 +1,307 @@
+import XCTest
+import SwiftData
+@testable import BaseChatCore
+import BaseChatInference
+import BaseChatTestSupport
+
+/// Unit tests for ``SwiftDataPersistenceProvider`` against a fresh in-memory
+/// SwiftData stack per test. Covers CRUD, ordering, pagination, cascade scope,
+/// and the malformed-CSV footgun on `pinnedMessageIDsRaw`.
+@MainActor
+final class SwiftDataPersistenceProviderTests: XCTestCase {
+
+    private var stack: InMemoryPersistenceHarness.Stack!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        stack = try InMemoryPersistenceHarness.make()
+    }
+
+    override func tearDown() async throws {
+        stack = nil
+        try await super.tearDown()
+    }
+
+    private var provider: SwiftDataPersistenceProvider { stack.provider }
+    private var context: ModelContext { stack.context }
+
+    // MARK: - Sessions
+
+    func test_insertSession_roundTripsAllFields() throws {
+        let modelID = UUID()
+        let endpointID = UUID()
+        let pinned: Set<UUID> = [UUID(), UUID()]
+        let record = ChatSessionRecord(
+            title: "Round Trip",
+            systemPrompt: "be concise",
+            selectedModelID: modelID,
+            selectedEndpointID: endpointID,
+            temperature: 0.3,
+            topP: 0.8,
+            repeatPenalty: 1.2,
+            promptTemplate: .llama3,
+            contextSizeOverride: 2048,
+            pinnedMessageIDs: pinned
+        )
+
+        try provider.insertSession(record)
+
+        let fetched = try provider.fetchSessions()
+        XCTAssertEqual(fetched.count, 1)
+        let first = fetched[0]
+        XCTAssertEqual(first.id, record.id)
+        XCTAssertEqual(first.title, "Round Trip")
+        XCTAssertEqual(first.systemPrompt, "be concise")
+        XCTAssertEqual(first.selectedModelID, modelID)
+        XCTAssertEqual(first.selectedEndpointID, endpointID)
+        XCTAssertEqual(first.temperature, 0.3)
+        XCTAssertEqual(first.topP, 0.8)
+        XCTAssertEqual(first.repeatPenalty, 1.2)
+        XCTAssertEqual(first.promptTemplate, .llama3)
+        XCTAssertEqual(first.contextSizeOverride, 2048)
+        XCTAssertEqual(first.pinnedMessageIDs, pinned)
+    }
+
+    func test_fetchSessions_ordersByUpdatedAtDescending() throws {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let older = ChatSessionRecord(title: "Older", updatedAt: now)
+        let newer = ChatSessionRecord(title: "Newer", updatedAt: now.addingTimeInterval(60))
+        let middle = ChatSessionRecord(title: "Middle", updatedAt: now.addingTimeInterval(30))
+
+        try provider.insertSession(older)
+        try provider.insertSession(newer)
+        try provider.insertSession(middle)
+
+        let fetched = try provider.fetchSessions()
+        XCTAssertEqual(fetched.map(\.title), ["Newer", "Middle", "Older"])
+    }
+
+    func test_updateSession_persistsFieldChanges() throws {
+        var record = ChatSessionRecord(title: "Before")
+        try provider.insertSession(record)
+
+        record.title = "After"
+        record.systemPrompt = "new prompt"
+        record.temperature = 0.9
+        record.updatedAt = Date()
+        try provider.updateSession(record)
+
+        let fetched = try provider.fetchSessions()
+        XCTAssertEqual(fetched[0].title, "After")
+        XCTAssertEqual(fetched[0].systemPrompt, "new prompt")
+        XCTAssertEqual(fetched[0].temperature, 0.9)
+    }
+
+    func test_updateSession_throwsWhenSessionMissing() {
+        let record = ChatSessionRecord(title: "Ghost")
+        XCTAssertThrowsError(try provider.updateSession(record)) { error in
+            XCTAssertEqual(error as? ChatPersistenceError, .sessionNotFound(record.id))
+        }
+    }
+
+    func test_deleteSession_removesSessionAndItsMessages() throws {
+        let session = ChatSessionRecord(title: "To Delete")
+        try provider.insertSession(session)
+        try provider.insertMessage(ChatMessageRecord(role: .user, content: "hi", sessionID: session.id))
+        try provider.insertMessage(ChatMessageRecord(role: .assistant, content: "hello", sessionID: session.id))
+
+        try provider.deleteSession(session.id)
+
+        XCTAssertEqual(try provider.fetchSessions().count, 0)
+        XCTAssertEqual(try provider.fetchMessages(for: session.id).count, 0)
+    }
+
+    func test_deleteSession_throwsWhenSessionMissing() {
+        let ghost = UUID()
+        XCTAssertThrowsError(try provider.deleteSession(ghost)) { error in
+            XCTAssertEqual(error as? ChatPersistenceError, .sessionNotFound(ghost))
+        }
+    }
+
+    // MARK: - Messages
+
+    func test_insertMessage_roundTripsAllFields() throws {
+        let session = ChatSessionRecord(title: "Msg Test")
+        try provider.insertSession(session)
+        let record = ChatMessageRecord(
+            role: .assistant,
+            content: "answer",
+            sessionID: session.id,
+            promptTokens: 12,
+            completionTokens: 7
+        )
+
+        try provider.insertMessage(record)
+
+        let fetched = try provider.fetchMessages(for: session.id)
+        XCTAssertEqual(fetched.count, 1)
+        XCTAssertEqual(fetched[0].id, record.id)
+        XCTAssertEqual(fetched[0].role, .assistant)
+        XCTAssertEqual(fetched[0].content, "answer")
+        XCTAssertEqual(fetched[0].promptTokens, 12)
+        XCTAssertEqual(fetched[0].completionTokens, 7)
+    }
+
+    func test_fetchMessages_ordersByTimestampAscending() throws {
+        let session = ChatSessionRecord(title: "Order Test")
+        try provider.insertSession(session)
+        let base = Date(timeIntervalSince1970: 1_000)
+        // Insert in reverse order to prove the fetch re-sorts.
+        try provider.insertMessage(ChatMessageRecord(role: .user, content: "C", timestamp: base.addingTimeInterval(20), sessionID: session.id))
+        try provider.insertMessage(ChatMessageRecord(role: .user, content: "A", timestamp: base, sessionID: session.id))
+        try provider.insertMessage(ChatMessageRecord(role: .user, content: "B", timestamp: base.addingTimeInterval(10), sessionID: session.id))
+
+        let fetched = try provider.fetchMessages(for: session.id)
+        XCTAssertEqual(fetched.map(\.content), ["A", "B", "C"])
+    }
+
+    func test_fetchRecentMessages_returnsTailInAscendingOrder() throws {
+        let session = ChatSessionRecord(title: "Recent Test")
+        try provider.insertSession(session)
+        let base = Date(timeIntervalSince1970: 1_000)
+        for i in 0..<5 {
+            try provider.insertMessage(ChatMessageRecord(
+                role: .user,
+                content: "m\(i)",
+                timestamp: base.addingTimeInterval(Double(i)),
+                sessionID: session.id
+            ))
+        }
+
+        let recent = try provider.fetchRecentMessages(for: session.id, limit: 3)
+        XCTAssertEqual(recent.map(\.content), ["m2", "m3", "m4"])
+    }
+
+    func test_fetchMessagesBefore_returnsOlderPageInAscendingOrder() throws {
+        let session = ChatSessionRecord(title: "Before Test")
+        try provider.insertSession(session)
+        let base = Date(timeIntervalSince1970: 1_000)
+        for i in 0..<5 {
+            try provider.insertMessage(ChatMessageRecord(
+                role: .user,
+                content: "m\(i)",
+                timestamp: base.addingTimeInterval(Double(i)),
+                sessionID: session.id
+            ))
+        }
+
+        // Anchor at m3's timestamp — expect m0, m1, m2 in ascending order.
+        let cursor = base.addingTimeInterval(3)
+        let older = try provider.fetchMessages(for: session.id, before: cursor, limit: 10)
+        XCTAssertEqual(older.map(\.content), ["m0", "m1", "m2"])
+    }
+
+    func test_fetchMessagesBefore_returnsEmptyAtOldestCursor() throws {
+        let session = ChatSessionRecord(title: "Empty Before")
+        try provider.insertSession(session)
+        let base = Date(timeIntervalSince1970: 1_000)
+        try provider.insertMessage(ChatMessageRecord(role: .user, content: "first", timestamp: base, sessionID: session.id))
+
+        let older = try provider.fetchMessages(for: session.id, before: base, limit: 10)
+        XCTAssertTrue(older.isEmpty)
+    }
+
+    func test_updateMessage_throwsWhenMissing() {
+        let ghost = ChatMessageRecord(role: .user, content: "ghost", sessionID: UUID())
+        XCTAssertThrowsError(try provider.updateMessage(ghost)) { error in
+            XCTAssertEqual(error as? ChatPersistenceError, .messageNotFound(ghost.id))
+        }
+    }
+
+    func test_deleteMessage_throwsWhenMissing() {
+        let ghost = UUID()
+        XCTAssertThrowsError(try provider.deleteMessage(ghost)) { error in
+            XCTAssertEqual(error as? ChatPersistenceError, .messageNotFound(ghost))
+        }
+    }
+
+    /// The exact bug shape that silently nukes user data: a session-scoped
+    /// delete that accidentally matches messages in other sessions.
+    func test_deleteMessages_doesNotCascadeAcrossSessions() throws {
+        let sessionA = ChatSessionRecord(title: "A")
+        let sessionB = ChatSessionRecord(title: "B")
+        try provider.insertSession(sessionA)
+        try provider.insertSession(sessionB)
+        try provider.insertMessage(ChatMessageRecord(role: .user, content: "A1", sessionID: sessionA.id))
+        try provider.insertMessage(ChatMessageRecord(role: .user, content: "A2", sessionID: sessionA.id))
+        let keptID = UUID()
+        try provider.insertMessage(ChatMessageRecord(id: keptID, role: .user, content: "B1", sessionID: sessionB.id))
+
+        try provider.deleteMessages(for: sessionA.id)
+
+        XCTAssertEqual(try provider.fetchMessages(for: sessionA.id).count, 0)
+        let remaining = try provider.fetchMessages(for: sessionB.id)
+        XCTAssertEqual(remaining.map(\.id), [keptID])
+    }
+
+    // MARK: - pinnedMessageIDs CSV parsing (model-level footgun)
+
+    func test_pinnedMessageIDs_parsesMalformedCSVAsEmpty() throws {
+        // Bypass the provider to write a raw CSV value that a buggy migration
+        // or corrupt store could produce, then verify the model's getter is
+        // tolerant — empty set, no crash.
+        let session = ChatSession(title: "Malformed")
+        session.pinnedMessageIDsRaw = "not-a-uuid,also-not,@@@"
+        context.insert(session)
+        try context.save()
+
+        let fetched = try provider.fetchSessions()
+        XCTAssertEqual(fetched.count, 1)
+        XCTAssertEqual(fetched[0].pinnedMessageIDs, [])
+    }
+
+    func test_pinnedMessageIDs_parsesTrailingCommaWithoutThrowing() throws {
+        let valid = UUID()
+        let session = ChatSession(title: "Trailing Comma")
+        session.pinnedMessageIDsRaw = "\(valid.uuidString),"
+        context.insert(session)
+        try context.save()
+
+        let fetched = try provider.fetchSessions()
+        XCTAssertEqual(fetched[0].pinnedMessageIDs, [valid])
+    }
+
+    func test_pinnedMessageIDs_filtersNonUUIDTokensMixedWithValid() throws {
+        let valid = UUID()
+        let session = ChatSession(title: "Mixed")
+        session.pinnedMessageIDsRaw = "garbage,\(valid.uuidString),more-garbage"
+        context.insert(session)
+        try context.save()
+
+        let fetched = try provider.fetchSessions()
+        XCTAssertEqual(fetched[0].pinnedMessageIDs, [valid])
+    }
+
+    func test_pinnedMessageIDs_emptyStringProducesEmptySet() throws {
+        let session = ChatSession(title: "Empty Raw")
+        session.pinnedMessageIDsRaw = ""
+        context.insert(session)
+        try context.save()
+
+        let fetched = try provider.fetchSessions()
+        XCTAssertEqual(fetched[0].pinnedMessageIDs, [])
+    }
+
+    func test_pinnedMessageIDs_roundTripsThroughProvider() throws {
+        let pin = UUID()
+        var record = ChatSessionRecord(title: "Pin", pinnedMessageIDs: [pin])
+        try provider.insertSession(record)
+
+        record.pinnedMessageIDs = [pin, UUID()]
+        try provider.updateSession(record)
+
+        let fetched = try provider.fetchSessions()
+        XCTAssertEqual(fetched[0].pinnedMessageIDs.count, 2)
+        XCTAssertTrue(fetched[0].pinnedMessageIDs.contains(pin))
+    }
+
+    // MARK: - Harness invariant
+
+    func test_harness_isInMemoryStore() throws {
+        let freshStack = try InMemoryPersistenceHarness.make()
+        XCTAssertTrue(
+            InMemoryPersistenceHarness.isInMemoryStore(freshStack.container),
+            "Harness must resolve to an in-memory store so tests never touch disk"
+        )
+    }
+}

--- a/Tests/BaseChatUITests/PaginationTests.swift
+++ b/Tests/BaseChatUITests/PaginationTests.swift
@@ -11,7 +11,8 @@ final class PaginationTests: XCTestCase {
 
     private var vm: ChatViewModel!
     private var mock: MockInferenceBackend!
-    private var persistence: MockPersistenceProvider!
+    private var stack: InMemoryPersistenceHarness.Stack!
+    private var persistence: ErrorInjectingPersistenceProvider!
 
     override func setUp() async throws {
         try await super.setUp()
@@ -22,7 +23,8 @@ final class PaginationTests: XCTestCase {
         let service = InferenceService(backend: mock, name: "MockPagination")
         vm = ChatViewModel(inferenceService: service)
 
-        persistence = MockPersistenceProvider()
+        stack = try InMemoryPersistenceHarness.make()
+        persistence = ErrorInjectingPersistenceProvider(wrapping: stack.provider)
         vm.configure(persistence: persistence)
     }
 
@@ -30,6 +32,7 @@ final class PaginationTests: XCTestCase {
         vm = nil
         mock = nil
         persistence = nil
+        stack = nil
         try await super.tearDown()
     }
 

--- a/Tests/BaseChatUITests/SessionAutoRenameTests.swift
+++ b/Tests/BaseChatUITests/SessionAutoRenameTests.swift
@@ -92,19 +92,19 @@ final class SessionAutoRenameTests: XCTestCase {
     }
 
     func test_autoRename_onPersistenceFailure_recordsDistinctDiagnostic() async throws {
-        // Use a MockPersistenceProvider so we can force updateSession to
-        // throw after inference succeeds. This separates the inference
-        // path (which records .titleGenerationFailed) from the persistence
-        // path (which must record .sessionRenamePersistenceFailed).
-        let mockPersistence = MockPersistenceProvider()
+        // Wrap the real in-memory provider so createSession's insert goes
+        // through, then switch on shouldThrowOnUpdateSession to make the
+        // rename path trip. This separates the inference failure path
+        // (.titleGenerationFailed) from the persistence failure path
+        // (.sessionRenamePersistenceFailed).
+        let freshStack = try InMemoryPersistenceHarness.make()
+        let wrappedPersistence = ErrorInjectingPersistenceProvider(wrapping: freshStack.provider)
         let diagnostics = DiagnosticsService()
         let freshVM = SessionManagerViewModel()
-        freshVM.configure(persistence: mockPersistence, diagnostics: diagnostics)
+        freshVM.configure(persistence: wrappedPersistence, diagnostics: diagnostics)
 
         let session = try freshVM.createSession()
-        // Make updateSession throw AFTER createSession has inserted the
-        // record, so the auto-rename path is the one that trips.
-        mockPersistence.shouldThrowOnUpdateSession = ChatPersistenceError.providerNotConfigured
+        wrappedPersistence.shouldThrowOnUpdateSession = ChatPersistenceError.providerNotConfigured
 
         let service = makeInferenceService(tokens: ["Cooking", " Basics"])
 

--- a/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
+++ b/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
@@ -36,10 +36,23 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         return (vm, mock)
     }
 
-    /// Creates a view model with an in-memory mock persistence provider.
+    /// Retains the persistence stack across the test's lifetime. Without this,
+    /// the `ModelContainer` from a harness built inside a helper function would
+    /// be deallocated when the helper returns, invalidating the `ModelContext`
+    /// the provider holds and causing SwiftData to trap on next access.
+    private var persistenceStack: InMemoryPersistenceHarness.Stack?
+
+    override func tearDown() async throws {
+        persistenceStack = nil
+        try await super.tearDown()
+    }
+
+    /// Creates a view model backed by real in-memory SwiftData persistence,
+    /// wrapped in an error-injecting shim so tests can simulate storage
+    /// failures without also lying about what storage actually does.
     private func makeViewModelWithPersistence(
         mock: MockInferenceBackend = MockInferenceBackend()
-    ) throws -> (ChatViewModel, MockInferenceBackend, MockPersistenceProvider) {
+    ) throws -> (ChatViewModel, MockInferenceBackend, ErrorInjectingPersistenceProvider) {
         mock.isModelLoaded = true
         let service = InferenceService(backend: mock, name: "Mock")
         let vm = ChatViewModel(
@@ -48,7 +61,9 @@ final class ViewModelEdgeCaseTests: XCTestCase {
             modelStorage: ModelStorageService(),
             memoryPressure: MemoryPressureHandler()
         )
-        let persistence = MockPersistenceProvider()
+        let stack = try InMemoryPersistenceHarness.make()
+        persistenceStack = stack
+        let persistence = ErrorInjectingPersistenceProvider(wrapping: stack.provider)
         vm.configure(persistence: persistence)
         return (vm, mock, persistence)
     }
@@ -150,12 +165,19 @@ final class ViewModelEdgeCaseTests: XCTestCase {
     func test_clearChat_whenPersistenceDeleteFails_reloadsPersistedMessages() async throws {
         let (vm, _, persistence) = try makeViewModelWithPersistence()
         let session = ChatSessionRecord(title: "Clear Chat Failure")
+        try persistence.insertSession(session)
         vm.activeSession = session
 
         vm.inputText = "Hello"
         await vm.sendMessage()
 
-        let expectedMessages = persistence.messages
+        // vm.sendMessage() auto-creates and persists a session if needed; read
+        // whichever session id ended up active to get the persisted messages.
+        guard let activeID = vm.activeSession?.id else {
+            XCTFail("Expected an active session after sendMessage")
+            return
+        }
+        let expectedMessages = try persistence.fetchMessages(for: activeID)
         XCTAssertEqual(expectedMessages.count, 2, "Precondition: the chat should have persisted user and assistant messages")
 
         let deleteError = NSError(
@@ -169,7 +191,8 @@ final class ViewModelEdgeCaseTests: XCTestCase {
 
         XCTAssertEqual(vm.messages.map(\.id), expectedMessages.map(\.id),
                        "clearChat should reload persisted messages when deletion fails")
-        XCTAssertEqual(persistence.messages.map(\.id), expectedMessages.map(\.id),
+        let stillPersisted = try persistence.fetchMessages(for: activeID)
+        XCTAssertEqual(stillPersisted.map(\.id), expectedMessages.map(\.id),
                        "Persistence should still contain the original messages after a failed clear")
         XCTAssertNotNil(vm.activeError, "activeError should be set when clear chat fails")
         XCTAssertEqual(vm.activeError?.kind, .persistence, "Error kind should be .persistence")


### PR DESCRIPTION
## Summary

PR 1 of 4 in the [test-coverage plan](../blob/test/w3-inmemory-persistence-harness/.claude/plans/peppy-sprouting-fairy.md). Enforces CLAUDE.md's "do not mock the persistence layer to make tests faster" rule and adds the direct `SwiftDataPersistenceProvider` unit coverage that was previously only transitive through integration tests.

- `InMemoryPersistenceHarness` builds a fresh in-memory `ModelContainer` + real `SwiftDataPersistenceProvider` per call — one line in `setUp`, honest CRUD semantics.
- `ErrorInjectingPersistenceProvider` wraps any real provider to add per-method error injection and call counting. Replaces the features that kept `MockPersistenceProvider` alive.
- 20 new `SwiftDataPersistenceProviderTests` covering CRUD round-trips across every `@Model` in `BaseChatSchemaV3`, pagination ordering (`fetchRecentMessages`, `fetchMessages(for:before:limit:)`), the cascade-scope invariant (`test_deleteMessages_doesNotCascadeAcrossSessions` — the bug shape that silently nukes user data), and the malformed-CSV tolerance on `pinnedMessageIDsRaw`.
- Migrates `PaginationTests`, `ViewModelEdgeCaseTests`, `SessionAutoRenameTests` to the harness + wrapper; deletes `MockPersistenceProvider`.

## Release Note

**Honest persistence tests by default** — `BaseChatTestSupport` now provides `InMemoryPersistenceHarness`, a fresh in-memory `SwiftDataPersistenceProvider` stack that tests can use in place of a hand-rolled mock. Paired with `ErrorInjectingPersistenceProvider` for failure-injection needs, it closes a long-standing test/production divergence where mocked storage could silently drift from the real SwiftData predicates, ordering, and cascade semantics. `MockPersistenceProvider` has been removed; all internal tests have been migrated.

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 196 tests, 0 failures (includes 20 new)
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 713 tests, 0 failures
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 436 tests, 0 failures (migration unaffected)
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 138 tests, 0 failures
- [x] Sabotage check: removing the `sessionID` predicate in `SwiftDataPersistenceProvider.deleteMessages` flips `test_deleteMessages_doesNotCascadeAcrossSessions` to red; reverting restores green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)