### PR TITLE
test: extend ModelLoadPlan/KVCache edges and SSE hazard coverage

### DIFF
--- a/Tests/BaseChatBackendsTests/CloudBackendSSETests.swift
+++ b/Tests/BaseChatBackendsTests/CloudBackendSSETests.swift
@@ -508,3 +508,298 @@ struct SSEStreamParserE2ETests {
         #expect(payloads.count == 1)
     }
 }
+
+// MARK: - SSE Hazard Tests (W4)
+//
+// These tests pin specific protocol hazards that `SSECloudBackend.parseResponseStream`
+// and `SSEStreamParser` must survive without losing, reordering, or duplicating
+// events. Each test isolates one concrete race or boundary:
+//
+// 1. A `done: true` signal arriving alongside the final token — the token must
+//    yield before the stream terminates.
+// 2. A tool-call JSON delta fragmented across two URLSession chunks — the
+//    partial fragment must be buffered until the next chunk completes it.
+// 3. `.usage` co-arriving with an end-of-stream signal in the same payload —
+//    usage must be delivered before termination so clients see token totals.
+// 4. A partial SSE frame split across two `URLSession` data callbacks —
+//    the parser must reassemble the frame into one event.
+
+/// Test-only payload handler with pluggable behaviour. Each closure is
+/// invoked per payload so a suite can exercise specific code paths without
+/// constructing a full provider-specific backend.
+private struct ProgrammablePayloadHandler: SSEPayloadHandler {
+    var token: @Sendable (String) -> String?
+    var usage: @Sendable (String) -> (promptTokens: Int?, completionTokens: Int?)?
+    var streamEnd: @Sendable (String) -> Bool
+    var streamError: @Sendable (String) -> Error?
+
+    init(
+        token: @escaping @Sendable (String) -> String? = { _ in nil },
+        usage: @escaping @Sendable (String) -> (promptTokens: Int?, completionTokens: Int?)? = { _ in nil },
+        streamEnd: @escaping @Sendable (String) -> Bool = { _ in false },
+        streamError: @escaping @Sendable (String) -> Error? = { _ in nil }
+    ) {
+        self.token = token
+        self.usage = usage
+        self.streamEnd = streamEnd
+        self.streamError = streamError
+    }
+
+    func extractToken(from payload: String) -> String? { token(payload) }
+    func extractUsage(from payload: String) -> (promptTokens: Int?, completionTokens: Int?)? { usage(payload) }
+    func isStreamEnd(_ payload: String) -> Bool { streamEnd(payload) }
+    func extractStreamError(from payload: String) -> Error? { streamError(payload) }
+}
+
+/// Minimal concrete `SSECloudBackend` used only by hazard tests. Real
+/// backends (OpenAI/Claude) enforce their own payload formats; this one
+/// hands raw SSE payloads straight to a programmable handler.
+private final class ProgrammableSSEBackend: SSECloudBackend, @unchecked Sendable {
+    override var backendName: String { "ProgrammableSSE" }
+
+    override var capabilities: BackendCapabilities {
+        BackendCapabilities(
+            supportedParameters: [.temperature],
+            maxContextTokens: 4096,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: false,
+            supportsToolCalling: true,
+            supportsStructuredOutput: false,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: true,
+            memoryStrategy: .external,
+            maxOutputTokens: 4096,
+            supportsStreaming: true,
+            isRemote: true
+        )
+    }
+
+    override func buildRequest(
+        prompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig
+    ) throws -> URLRequest {
+        guard let baseURL else {
+            throw CloudBackendError.invalidURL("No base URL configured")
+        }
+        var request = URLRequest(url: baseURL.appendingPathComponent("stream"))
+        request.httpMethod = "POST"
+        return request
+    }
+}
+
+@Suite("SSE Hazard Coverage", .serialized)
+struct SSEHazardTests {
+
+    private func makeBackend(handler: ProgrammablePayloadHandler) -> (ProgrammableSSEBackend, URL) {
+        let session = makeMockSession()
+        let backend = ProgrammableSSEBackend(
+            defaultModelName: "hazard-test",
+            urlSession: session,
+            payloadHandler: handler
+        )
+        let baseURL = URL(string: "https://hazard-\(UUID().uuidString).test")!
+        backend.configure(baseURL: baseURL, apiKey: "test", modelName: "hazard-test")
+        return (backend, baseURL.appendingPathComponent("stream"))
+    }
+
+    private func loadBackend(_ backend: ProgrammableSSEBackend) async throws {
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+    }
+
+    // MARK: - Hazard 1: done-signal co-arrives with final token
+
+    /// A single payload produces BOTH a token AND signals end-of-stream.
+    /// `parseResponseStream` runs token-extraction first and stream-end last,
+    /// so the final token must reach the consumer before `break`. If a future
+    /// refactor swaps the order, clients see truncated responses.
+    @Test func hazard_doneSignalWithFinalToken_tokenYieldsFirst() async throws {
+        // Handler reads a synthetic payload format: `TOKEN:value|END`.
+        // If "END" substring is present, isStreamEnd returns true. The same
+        // payload can therefore yield a token AND signal termination.
+        let handler = ProgrammablePayloadHandler(
+            token: { payload in
+                guard payload.hasPrefix("TOKEN:") else { return nil }
+                // Strip the "TOKEN:" prefix and any "|END" suffix.
+                let afterPrefix = payload.dropFirst("TOKEN:".count)
+                if let barIndex = afterPrefix.firstIndex(of: "|") {
+                    return String(afterPrefix[..<barIndex])
+                }
+                return String(afterPrefix)
+            },
+            streamEnd: { payload in payload.contains("|END") }
+        )
+        let (backend, url) = makeBackend(handler: handler)
+
+        // Single chunk: one token delivered in the same payload that ends the stream.
+        let chunks: [Data] = [
+            sseData("TOKEN:hello"),
+            sseData("TOKEN:world|END"),
+            // A later frame that must never be consumed because streamEnd triggered.
+            sseData("TOKEN:never"),
+        ]
+        MockURLProtocol.stub(url: url, response: .sse(chunks: chunks, statusCode: 200))
+
+        try await loadBackend(backend)
+        let stream = try backend.generate(prompt: "x", systemPrompt: nil, config: GenerationConfig())
+
+        var tokens: [String] = []
+        for try await event in stream.events {
+            if case .token(let t) = event { tokens.append(t) }
+        }
+
+        #expect(tokens == ["hello", "world"],
+                "Final token must yield before the end-of-stream break; post-end tokens must not leak through")
+    }
+
+    // MARK: - Hazard 2: tool-call JSON delta fragmented across two chunks
+
+    /// A provider may flush a multi-kilobyte tool-call JSON delta across
+    /// multiple TCP segments. The SSE parser must buffer bytes until the
+    /// terminating `\n\n` — losing the fragment would corrupt tool calls.
+    ///
+    /// This splits a single SSE frame's payload down the middle of the JSON.
+    /// The first chunk returns `nil` from extractToken (incomplete), the
+    /// second chunk completes the frame and produces one well-formed event.
+    @Test func hazard_toolCallJSONFragmented_parserReassembles() async throws {
+        // Handler treats the payload as a JSON object and extracts the
+        // `tool_call.name` field. If it can't parse, it returns nil — which
+        // is exactly what a half-fragment would produce if the parser
+        // leaked it as a separate event.
+        let handler = ProgrammablePayloadHandler(
+            token: { payload in
+                guard let data = payload.data(using: .utf8),
+                      let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let toolCall = parsed["tool_call"] as? [String: Any],
+                      let name = toolCall["name"] as? String else {
+                    return nil
+                }
+                return name
+            }
+        )
+        let (backend, url) = makeBackend(handler: handler)
+
+        // One complete SSE frame split mid-JSON. The parser must buffer the
+        // first half until the newline in the second half closes the frame.
+        let fullFrame = "data: {\"tool_call\":{\"name\":\"search_docs\",\"arguments\":{\"q\":\"sse\"}}}\n\n"
+        let splitIndex = fullFrame.utf8.index(fullFrame.utf8.startIndex, offsetBy: 30)
+        let firstHalf = Data(fullFrame.utf8[..<splitIndex])
+        let secondHalf = Data(fullFrame.utf8[splitIndex...])
+
+        MockURLProtocol.stub(url: url, response: .sse(chunks: [firstHalf, secondHalf], statusCode: 200))
+
+        try await loadBackend(backend)
+        let stream = try backend.generate(prompt: "x", systemPrompt: nil, config: GenerationConfig())
+
+        var tokens: [String] = []
+        for try await event in stream.events {
+            if case .token(let t) = event { tokens.append(t) }
+        }
+
+        #expect(tokens == ["search_docs"],
+                "Fragmented JSON must produce exactly one reassembled event; got \(tokens)")
+    }
+
+    // MARK: - Hazard 3: usage co-arrives with stream-end in same payload
+
+    /// Usage and isStreamEnd in a single payload: usage must emit BEFORE the
+    /// break. `extractUsage` dictionary iteration order is currently the
+    /// ordering guarantor (see SSECloudBackend.swift 405-423) — pin the
+    /// behaviour so a reordering refactor fails loudly instead of silently
+    /// dropping the final usage event that clients rely on for totals.
+    @Test func hazard_usageCoArrivesWithStreamEnd_usageEmitsFirst() async throws {
+        // Single payload format: `USAGE:P=10,C=5|END`.
+        // Both extractUsage and isStreamEnd fire on the same payload.
+        let handler = ProgrammablePayloadHandler(
+            usage: { payload in
+                guard payload.hasPrefix("USAGE:") else { return nil }
+                let after = payload.dropFirst("USAGE:".count)
+                let endStripped: Substring
+                if let bar = after.firstIndex(of: "|") {
+                    endStripped = after[..<bar]
+                } else {
+                    endStripped = after
+                }
+                var prompt: Int?
+                var completion: Int?
+                for part in endStripped.split(separator: ",") {
+                    let kv = part.split(separator: "=")
+                    guard kv.count == 2, let value = Int(kv[1]) else { continue }
+                    switch kv[0] {
+                    case "P": prompt = value
+                    case "C": completion = value
+                    default: break
+                    }
+                }
+                guard prompt != nil || completion != nil else { return nil }
+                return (promptTokens: prompt, completionTokens: completion)
+            },
+            streamEnd: { payload in payload.contains("|END") }
+        )
+        let (backend, url) = makeBackend(handler: handler)
+
+        let chunks: [Data] = [
+            sseData("USAGE:P=10,C=5|END"),
+        ]
+        MockURLProtocol.stub(url: url, response: .sse(chunks: chunks, statusCode: 200))
+
+        try await loadBackend(backend)
+        let stream = try backend.generate(prompt: "x", systemPrompt: nil, config: GenerationConfig())
+
+        var events: [GenerationEvent] = []
+        for try await event in stream.events {
+            events.append(event)
+        }
+
+        // Must contain exactly one .usage event, and it must precede termination.
+        var sawUsage = false
+        for event in events {
+            if case .usage(let prompt, let completion) = event {
+                #expect(prompt == 10)
+                #expect(completion == 5)
+                sawUsage = true
+            }
+        }
+        #expect(sawUsage, "Usage event must emit before stream-end break; got events: \(events)")
+        // Also pin: lastUsage on the backend is populated (handleUsage ran before break).
+        #expect(backend.lastUsage?.promptTokens == 10)
+        #expect(backend.lastUsage?.completionTokens == 5)
+    }
+
+    // MARK: - Hazard 4: partial SSE frame split across URLSession callbacks
+
+    /// One logical `event: data` frame delivered in two separate URLSession
+    /// data callbacks. The parser's byte buffer must reassemble them into a
+    /// single `GenerationEvent`. A regression that flushed per-callback
+    /// would produce two malformed events (or zero, if the halves parse as
+    /// junk) instead of one.
+    @Test func hazard_sseFrameSplitAcrossCallbacks_reassemblesIntoOneEvent() async throws {
+        let handler = ProgrammablePayloadHandler(
+            token: { payload in
+                guard payload.hasPrefix("T:") else { return nil }
+                return String(payload.dropFirst(2))
+            }
+        )
+        let (backend, url) = makeBackend(handler: handler)
+
+        // Split a single frame halfway through the payload, BEFORE the
+        // terminating \n\n. Each half arrives as a separate didLoad call.
+        let frame = "data: T:reassembled\n\n"
+        let midpoint = frame.utf8.index(frame.utf8.startIndex, offsetBy: 10)
+        let part1 = Data(frame.utf8[..<midpoint])
+        let part2 = Data(frame.utf8[midpoint...])
+
+        MockURLProtocol.stub(url: url, response: .sse(chunks: [part1, part2], statusCode: 200))
+
+        try await loadBackend(backend)
+        let stream = try backend.generate(prompt: "x", systemPrompt: nil, config: GenerationConfig())
+
+        var tokens: [String] = []
+        for try await event in stream.events {
+            if case .token(let t) = event { tokens.append(t) }
+        }
+
+        #expect(tokens == ["reassembled"],
+                "Split SSE frame must produce exactly one event; got \(tokens)")
+    }
+}

--- a/Tests/BaseChatInferenceTests/GGUFKVCacheEstimatorTests.swift
+++ b/Tests/BaseChatInferenceTests/GGUFKVCacheEstimatorTests.swift
@@ -39,4 +39,125 @@ final class GGUFKVCacheEstimatorTests: XCTestCase {
 
         XCTAssertNil(GGUFKVCacheEstimator.estimateBytesPerToken(from: parameters))
     }
+
+    // MARK: - Architecture matrix
+
+    /// Llama-3 8B-ish: GQA 8:1 (`attentionHeadCountKV < attentionHeadCount`).
+    /// This is the dominant modern architecture and the canonical case that
+    /// the GQA divisor matters for — a regression here silently over- or
+    /// under-estimates KV for Llama-3 and most of its derivatives.
+    ///
+    /// Hand math (fp16 = 2 B/element):
+    /// ```
+    /// headDim       = embedding / heads   = 4096 / 32 = 128
+    /// keyWidth      = headDim * kvHeads   = 128 * 8   = 1024
+    /// valueWidth    = same (no explicit)  = 1024
+    /// bytesPerToken = blocks * (K + V) * element
+    ///               = 32 * 2048 * 2       = 131 072
+    /// ```
+    func test_estimateBytesPerToken_llama3_8B_GQA_matchesHandCalculation() {
+        let parameters = GGUFKVCacheParameters(
+            blockCount: 32,
+            embeddingLength: 4096,
+            attentionHeadCount: 32,
+            attentionHeadCountKV: 8
+        )
+
+        let estimate = GGUFKVCacheEstimator.estimateBytesPerToken(from: parameters)
+
+        XCTAssertEqual(estimate, 131_072)
+    }
+
+    /// Mistral 7B-ish: MHA (`attentionHeadCountKV == attentionHeadCount`).
+    /// Pre-GQA models. The divisor is 1, so the estimate is 4x an 8:1 GQA
+    /// model of the same shape — catch a regression where the GQA path
+    /// accidentally ignores MHA.
+    ///
+    /// Hand math: 32 * (4096 + 4096) * 2 = 524 288 B/token.
+    func test_estimateBytesPerToken_mistral7B_MHA_matchesHandCalculation() {
+        let parameters = GGUFKVCacheParameters(
+            blockCount: 32,
+            embeddingLength: 4096,
+            attentionHeadCount: 32,
+            attentionHeadCountKV: 32
+        )
+
+        let estimate = GGUFKVCacheEstimator.estimateBytesPerToken(from: parameters)
+
+        XCTAssertEqual(estimate, 524_288)
+    }
+
+    /// Qwen2-ish asymmetric: explicit `attentionKeyLength != attentionValueLength`.
+    /// Newer architectures (Qwen, some DeepSeek variants) separate key and value
+    /// head dims. A naive estimator that assumed K == V would silently under-
+    /// estimate when value dim is larger, or over-estimate when smaller.
+    ///
+    /// Fixture uses exaggerated asymmetry (128 vs 64) so the K-path and V-path
+    /// cannot collapse into the same value and silently pass the test.
+    ///
+    /// Hand math (28 blocks, 4 KV heads, fp16):
+    /// ```
+    /// keyWidth   = 128 * 4 = 512
+    /// valueWidth =  64 * 4 = 256
+    /// total      = 28 * (512 + 256) * 2 = 43 008 B/token
+    /// ```
+    func test_estimateBytesPerToken_qwen2_asymmetricKVDims_matchesHandCalculation() {
+        let parameters = GGUFKVCacheParameters(
+            blockCount: 28,
+            embeddingLength: 3584,           // unused when explicit lengths are present
+            attentionHeadCount: 28,          // unused when explicit lengths are present
+            attentionHeadCountKV: 4,
+            attentionKeyLength: 128,
+            attentionValueLength: 64
+        )
+
+        let estimate = GGUFKVCacheEstimator.estimateBytesPerToken(from: parameters)
+
+        XCTAssertEqual(estimate, 43_008)
+    }
+
+    // MARK: - Quantization assumption
+
+    /// Pin the fp16 (`defaultBytesPerElement == 2`) assumption that the whole
+    /// estimator rests on. If llama.cpp ever adds Q4/Q8 KV cache support and a
+    /// downstream change starts passing `bytesPerElement < 2`, the plan will
+    /// suddenly estimate half as much memory — silently allowing OOM-bound
+    /// loads that previously warned. This test is the alarm.
+    ///
+    /// Asserts two invariants:
+    /// 1. The default constant is exactly 2 (fp16).
+    /// 2. Halving the byte width halves the estimate — so callers who
+    ///    customise `bytesPerElement` get a linear, predictable change.
+    func test_defaultBytesPerElement_isFP16_andScalesLinearly() {
+        XCTAssertEqual(GGUFKVCacheEstimator.defaultBytesPerElement, 2,
+                       "defaultBytesPerElement must stay fp16 (2 bytes) until Q4/Q8 KV is supported")
+
+        let parameters = GGUFKVCacheParameters(
+            blockCount: 32,
+            embeddingLength: 4096,
+            attentionHeadCount: 32,
+            attentionHeadCountKV: 8
+        )
+
+        let fp16 = GGUFKVCacheEstimator.estimateBytesPerToken(from: parameters, bytesPerElement: 2)
+        let q8 = GGUFKVCacheEstimator.estimateBytesPerToken(from: parameters, bytesPerElement: 1)
+
+        XCTAssertEqual(fp16, 131_072)
+        XCTAssertEqual(q8, 65_536, "Halving bytesPerElement must halve the estimate")
+    }
+
+    /// `bytesPerElement == 0` must be rejected — otherwise the estimator would
+    /// return 0 and `ModelLoadPlan` would see "KV costs nothing" and allow any
+    /// context. This is a defensive contract with the estimator's callers.
+    func test_bytesPerElementZero_returnsNil() {
+        let parameters = GGUFKVCacheParameters(
+            blockCount: 32,
+            embeddingLength: 4096,
+            attentionHeadCount: 32,
+            attentionHeadCountKV: 8
+        )
+        XCTAssertNil(
+            GGUFKVCacheEstimator.estimateBytesPerToken(from: parameters, bytesPerElement: 0)
+        )
+    }
 }

--- a/Tests/BaseChatInferenceTests/GGUFKVCacheEstimatorTests.swift
+++ b/Tests/BaseChatInferenceTests/GGUFKVCacheEstimatorTests.swift
@@ -42,10 +42,13 @@ final class GGUFKVCacheEstimatorTests: XCTestCase {
 
     // MARK: - Architecture matrix
 
-    /// Llama-3 8B-ish: GQA 8:1 (`attentionHeadCountKV < attentionHeadCount`).
-    /// This is the dominant modern architecture and the canonical case that
-    /// the GQA divisor matters for — a regression here silently over- or
-    /// under-estimates KV for Llama-3 and most of its derivatives.
+    /// Llama-3 8B: GQA 8:1 (`attentionHeadCountKV < attentionHeadCount`).
+    /// Ref: https://huggingface.co/meta-llama/Meta-Llama-3-8B/blob/main/config.json
+    /// (num_hidden_layers=32, hidden_size=4096, num_attention_heads=32,
+    /// num_key_value_heads=8). This is the dominant modern architecture and
+    /// the canonical case the GQA divisor matters for — a regression here
+    /// silently over- or under-estimates KV for Llama-3 and most of its
+    /// derivatives.
     ///
     /// Hand math (fp16 = 2 B/element):
     /// ```
@@ -68,13 +71,18 @@ final class GGUFKVCacheEstimatorTests: XCTestCase {
         XCTAssertEqual(estimate, 131_072)
     }
 
-    /// Mistral 7B-ish: MHA (`attentionHeadCountKV == attentionHeadCount`).
-    /// Pre-GQA models. The divisor is 1, so the estimate is 4x an 8:1 GQA
-    /// model of the same shape — catch a regression where the GQA path
-    /// accidentally ignores MHA.
+    /// Llama-2 7B shape: MHA (`attentionHeadCountKV == attentionHeadCount`).
+    /// Llama-2 7B uses 32 blocks, 4096 embedding, 32 attention heads, 32 KV heads
+    /// (MHA) — ref: https://huggingface.co/meta-llama/Llama-2-7b-hf/blob/main/config.json
+    /// (num_hidden_layers=32, hidden_size=4096, num_attention_heads=32, no
+    /// num_key_value_heads → MHA with KV == Q). Catches a regression where
+    /// the GQA divisor path accidentally treats every model as GQA:8.
+    ///
+    /// NOTE: Mistral 7B looks similar but uses GQA 4:1 (num_key_value_heads=8);
+    /// don't conflate the two. The MHA case here is specifically Llama-2.
     ///
     /// Hand math: 32 * (4096 + 4096) * 2 = 524 288 B/token.
-    func test_estimateBytesPerToken_mistral7B_MHA_matchesHandCalculation() {
+    func test_estimateBytesPerToken_llama2_7B_MHA_matchesHandCalculation() {
         let parameters = GGUFKVCacheParameters(
             blockCount: 32,
             embeddingLength: 4096,
@@ -87,10 +95,12 @@ final class GGUFKVCacheEstimatorTests: XCTestCase {
         XCTAssertEqual(estimate, 524_288)
     }
 
-    /// Qwen2-ish asymmetric: explicit `attentionKeyLength != attentionValueLength`.
-    /// Newer architectures (Qwen, some DeepSeek variants) separate key and value
-    /// head dims. A naive estimator that assumed K == V would silently under-
-    /// estimate when value dim is larger, or over-estimate when smaller.
+    /// Synthetic asymmetric K/V: explicit `attentionKeyLength != attentionValueLength`.
+    /// No shipped Qwen2/Llama GGUFs we've seen use K ≠ V, but the GGUF spec allows it
+    /// (`.attention.key_length` and `.attention.value_length` are independent keys) and
+    /// Multi-head Latent Attention variants (DeepSeek-V2) and future architectures
+    /// may. A naive estimator that assumed K == V would silently under-estimate when
+    /// value dim is larger, or over-estimate when smaller.
     ///
     /// Fixture uses exaggerated asymmetry (128 vs 64) so the K-path and V-path
     /// cannot collapse into the same value and silently pass the test.
@@ -101,7 +111,7 @@ final class GGUFKVCacheEstimatorTests: XCTestCase {
     /// valueWidth =  64 * 4 = 256
     /// total      = 28 * (512 + 256) * 2 = 43 008 B/token
     /// ```
-    func test_estimateBytesPerToken_qwen2_asymmetricKVDims_matchesHandCalculation() {
+    func test_estimateBytesPerToken_asymmetricKVDims_matchesHandCalculation() {
         let parameters = GGUFKVCacheParameters(
             blockCount: 28,
             embeddingLength: 3584,           // unused when explicit lengths are present

--- a/Tests/BaseChatInferenceTests/LoadDenyPolicyInferenceServiceTests.swift
+++ b/Tests/BaseChatInferenceTests/LoadDenyPolicyInferenceServiceTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import os
 @testable import BaseChatInference
 import BaseChatTestSupport
 
@@ -142,6 +143,172 @@ final class LoadDenyPolicyInferenceServiceTests: XCTestCase {
         }
         XCTAssertFalse(service.isModelLoaded)
     }
+
+    // MARK: - .allow verdict bypasses policy entirely
+
+    /// With a plan that produces `.allow`, no policy branch fires — even a
+    /// custom hook that would reject is never consulted. The backend receives
+    /// the plan unmodified (verdict preserved, no reasons appended).
+    @MainActor
+    func test_allowPlan_customPolicyNotInvoked_planDispatchedUnchanged() async throws {
+        let service = InferenceService()
+        let capturingBackend = PlanCapturingBackend()
+        service.registerBackendFactory { _ in capturingBackend }
+
+        // Custom policy that would throw if invoked.
+        struct ShouldNotBeInvoked: Error {}
+        let customCalled = LockedValue<Bool>(false)
+        service.denyPolicy = .custom { _ in
+            customCalled.set(true)
+            throw ShouldNotBeInvoked()
+        }
+
+        let model = makeModel()
+        let plan = makeAllowingPlan(for: model)
+
+        try await service.loadModel(from: model, plan: plan)
+
+        XCTAssertFalse(customCalled.get(), "Custom policy was invoked despite .allow verdict")
+        XCTAssertTrue(service.isModelLoaded)
+
+        let received = capturingBackend.lastPlan
+        XCTAssertEqual(received?.verdict, .allow)
+        // Plan delivered to the backend must be the *original* — not downgraded.
+        XCTAssertEqual(received?.outcome.totalEstimatedBytes, plan.outcome.totalEstimatedBytes)
+    }
+
+    // MARK: - .warn verdict proceeds and dispatches .warn plan to backend
+
+    /// The `.warn` verdict is an "info" state — load proceeds regardless of
+    /// `denyPolicy`, and the backend observes the warning via the plan's
+    /// verdict (the only public handle the warning has).
+    @MainActor
+    func test_warnPlan_loadProceeds_backendReceivesWarnVerdict() async throws {
+        let service = InferenceService()
+        let capturingBackend = PlanCapturingBackend()
+        service.registerBackendFactory { _ in capturingBackend }
+
+        // Even .throwError policy must not fire on a .warn plan.
+        service.denyPolicy = .throwError
+
+        let model = makeModel()
+        let plan = makeWarningPlan(for: model)
+
+        try await service.loadModel(from: model, plan: plan)
+
+        XCTAssertTrue(service.isModelLoaded)
+        let received = capturingBackend.lastPlan
+        XCTAssertEqual(received?.verdict, .warn,
+                       "Backend must observe the .warn verdict so it can surface the warning itself")
+    }
+
+    /// `.deny` + `.warnOnly` downgrades the plan to `.warn` before dispatching
+    /// to the backend (backends assert `plan.verdict != .deny`). This is the
+    /// observable difference between a native-.warn plan and a downgraded one:
+    /// the backend still sees `.warn`, but the service's `isModelLoaded`
+    /// flips after proceeding despite insufficient memory.
+    @MainActor
+    func test_denyPlan_warnOnlyPolicy_dispatchesDowngradedWarnVerdict() async throws {
+        let service = InferenceService()
+        let capturingBackend = PlanCapturingBackend()
+        service.registerBackendFactory { _ in capturingBackend }
+        service.denyPolicy = .warnOnly
+
+        let model = makeModel()
+        let plan = makeDenyingPlan(for: model)
+
+        try await service.loadModel(from: model, plan: plan)
+
+        // The coordinator promises to downgrade .deny → .warn before handing
+        // the plan to the backend. This is the invariant backends rely on.
+        XCTAssertEqual(capturingBackend.lastPlan?.verdict, .warn,
+                       "warnOnly policy must downgrade .deny to .warn before dispatch")
+    }
+
+    // MARK: - Fixtures for allow/warn
+
+    private func makeAllowingPlan(for model: ModelInfo) -> ModelLoadPlan {
+        let environment = ModelLoadPlan.Environment(
+            availableMemoryBytes: { 64_000_000_000 },  // 64 GB — plenty
+            physicalMemoryBytes: 128_000_000_000
+        )
+        let plan = ModelLoadPlan.compute(
+            for: model,
+            requestedContextSize: 2048,
+            strategy: .mappable,
+            environment: environment
+        )
+        XCTAssertEqual(plan.verdict, .allow,
+                       "Fixture must produce an .allow plan; got \(plan.verdict)")
+        return plan
+    }
+
+    /// Builds an inputs fixture guaranteed to produce `.warn`.
+    ///
+    /// Headroom 0.0 + no resident + kv total == available → above the 85%
+    /// allow threshold but within the available ceiling → `.warn`.
+    private func makeWarningPlan(for model: ModelInfo) -> ModelLoadPlan {
+        let inputs = ModelLoadPlan.Inputs(
+            modelFileSize: 0,
+            memoryStrategy: .external,
+            requestedContextSize: 1_000_000,
+            trainedContextLength: 1_000_000,
+            kvBytesPerToken: 1,
+            availableMemoryBytes: 1_000_000,
+            physicalMemoryBytes: 16_000_000_000,
+            absoluteContextCeiling: 128_000_000,
+            headroomFraction: 0.0
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+        XCTAssertEqual(plan.verdict, .warn,
+                       "Fixture must produce a .warn plan; got \(plan.verdict)")
+        // Keep the fixture coupled to the real model identifier so test logs
+        // show the same modelName as other cases.
+        _ = model
+        return plan
+    }
+}
+
+// MARK: - Plan-capturing backend
+
+/// Mock backend that records the `ModelLoadPlan` it receives on `loadModel`.
+/// Used to verify the coordinator dispatches the right verdict (pre-downgrade
+/// for `.allow`/`.warn`, downgraded for `.deny` + `.warnOnly`).
+private final class PlanCapturingBackend: InferenceBackend, @unchecked Sendable {
+    var isModelLoaded: Bool = false
+    var isGenerating: Bool = false
+    var capabilities: BackendCapabilities = BackendCapabilities(
+        supportedParameters: [.temperature],
+        maxContextTokens: 2048,
+        requiresPromptTemplate: false,
+        supportsSystemPrompt: true,
+        supportsToolCalling: false,
+        supportsStructuredOutput: false,
+        cancellationStyle: .cooperative,
+        supportsTokenCounting: false,
+        memoryStrategy: .mappable
+    )
+
+    // OSAllocatedUnfairLock is the async-safe variant; NSLock is not allowed
+    // inside Swift-6 async contexts.
+    private let state = OSAllocatedUnfairLock<ModelLoadPlan?>(initialState: nil)
+
+    var lastPlan: ModelLoadPlan? {
+        state.withLock { $0 }
+    }
+
+    func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
+        state.withLock { $0 = plan }
+        isModelLoaded = true
+    }
+
+    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> GenerationStream {
+        throw InferenceError.inferenceFailure("unused in these tests")
+    }
+
+    func stopGeneration() {}
+    func unloadModel() { isModelLoaded = false }
+    func resetConversation() {}
 }
 
 // MARK: - Test helpers

--- a/Tests/BaseChatInferenceTests/ModelLoadPlanTests.swift
+++ b/Tests/BaseChatInferenceTests/ModelLoadPlanTests.swift
@@ -659,6 +659,48 @@ final class ModelLoadPlanTests: XCTestCase {
     /// separate heuristic concern that is out of scope for this test.
     /// (See report: the mappable heuristic under-estimates for huge files
     /// and can silently `.allow` a 140 GB file; not fixed here.)
+    /// Companion to the `.resident` case above. Under `.mappable`, a 140 GB
+    /// file's resident estimate caps at `min(fileSize/4, 1 GB) == 1 GB`
+    /// regardless of the file being 140 × the available RAM. The plan then
+    /// computes total ≈ 1 GB (resident) + a few hundred MB (KV) and returns
+    /// `.allow` — silently telling a user on a 4 GB device that a 70B model
+    /// will load fine.
+    ///
+    /// This test PINS the current (broken) behavior so a good-faith fix
+    /// — e.g., scaling `residentBudget` by `fileSize / availableMemory`, or
+    /// clamping on raw `fileSize > 2 * available` regardless of strategy —
+    /// will cause the test to fail and force an explicit update.
+    ///
+    // FIXME: file a GitHub issue and replace this URL — `.mappable` residentBudget
+    // caps at min(fileSize/4, 1 GB), so huge models on small devices are silently
+    // allowed. When fixed, flip this test's expectation to `.deny` and remove the
+    // FIXME.
+    func test_70BModelOn4GBDevice_mappableStrategy_currentlyAllowsDespiteImpossibleFit() {
+        let seventyBBytes: UInt64 = 140 * oneGB
+        let fourGB: UInt64 = 4 * oneGB
+        let inputs = makeInputs(
+            modelFileSize: seventyBBytes,
+            strategy: .mappable,                   // residentBudget caps at 1 GB
+            requested: 2048,
+            trained: 131_072,
+            kvBytesPerToken: 400_000,
+            available: fourGB,
+            physical: fourGB
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+
+        // Production bug: this should be .deny but is currently .allow because
+        // residentBudget under .mappable is capped to 1 GB regardless of how
+        // much larger the file is than available memory.
+        XCTAssertEqual(plan.verdict, .allow,
+                       "Current .mappable heuristic allows 140 GB file on 4 GB device (bug). If this assertion fails because the bug was fixed, flip to .deny and remove the FIXME above.")
+        // Pin the underestimate: resident estimate is ~1 GB, not the ~140 GB
+        // the file actually implies. This inequality is what a fix should make
+        // false.
+        XCTAssertLessThanOrEqual(plan.outcome.estimatedResidentBytes, oneGB + 1,
+                                 "residentBudget under .mappable currently caps at 1 GB; a fix should grow this with fileSize")
+    }
+
     func test_70BModelOn4GBDevice_residentStrategy_neverAllows() {
         // 70B at ~4-bit quant ~ 40 GB file. Use a generous 140 GB upper bound
         // to also cover fp16 distributions.

--- a/Tests/BaseChatInferenceTests/ModelLoadPlanTests.swift
+++ b/Tests/BaseChatInferenceTests/ModelLoadPlanTests.swift
@@ -561,6 +561,126 @@ final class ModelLoadPlanTests: XCTestCase {
         // boundary case below would silently flip from false to true.
         XCTAssertFalse(ModelLoadPlan.canRunModel(sizeBytes: 6 * oneGB, physicalMemoryBytes: 4 * oneGB))
     }
+
+    // MARK: - Saturating-arithmetic edges (W2)
+
+    /// Available memory well below the resident budget must not underflow
+    /// `UInt64`. The saturating-subtraction branch around line 162 guards
+    /// this. A regression that accidentally uses wrapping subtraction would
+    /// produce a kvBudget of ~18 exabytes and silently `.allow` everything.
+    func test_nearZeroMemory_saturatingSubtractionDoesNotUnderflow() {
+        // 4 GB model, mappable (resident budget 1 GB), 1 KB available.
+        // reserveAfterHeadroom = 1000 * 0.6 = 600 bytes.
+        // residentBudget (1 GB) > reserveAfterHeadroom (600 B) → kvBudget == 0.
+        let inputs = makeInputs(
+            modelFileSize: 4 * oneGB,
+            strategy: .mappable,
+            requested: 4096,
+            trained: 8192,
+            kvBytesPerToken: 8_192,
+            available: 1_000
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+
+        // effective is floored to 1 (not a huge wrapped number).
+        XCTAssertEqual(plan.effectiveContextSize, 1,
+                       "Effective context must floor at 1, not wrap from UInt64 underflow")
+        // KV = 1 * 8_192 = 8_192. Total = resident (≤1 GB) + 8 KB, which is
+        // vastly greater than the 1 000 B available → .deny.
+        XCTAssertEqual(plan.verdict, .deny)
+        // And critically, totalEstimatedBytes stays a sane number — not
+        // anywhere near UInt64.max that an underflow would produce.
+        XCTAssertLessThan(plan.outcome.totalEstimatedBytes, 2 * oneGB,
+                          "Total must not contain a wrapped-underflow value")
+    }
+
+    /// `kvBytesPerToken == 0` sets `memoryCeiling = Int.max`, which is the
+    /// div-by-zero guard at line 168. A regression that made memoryCeiling
+    /// small (e.g., 0) would falsely clamp every context to 1. A regression
+    /// that dropped the guard would crash. Verify the verdict stays sensible:
+    /// the estimator never pretends zero KV is unlimited free memory.
+    func test_kvBytesPerTokenZero_memoryCeilingIntMax_verdictReflectsOnlyResident() {
+        // Modest resident cost, no KV cost. Should be freely .allow — and
+        // effective context == requested, because memoryCeiling is Int.max.
+        let inputs = makeInputs(
+            modelFileSize: 100_000_000,
+            strategy: .mappable,
+            requested: 8192,
+            trained: 16_384,
+            kvBytesPerToken: 0,
+            available: 4 * oneGB
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+
+        XCTAssertEqual(plan.effectiveContextSize, 8192)
+        XCTAssertEqual(plan.verdict, .allow)
+        XCTAssertEqual(plan.outcome.estimatedKVBytes, 0)
+        // No memoryCeilingReached reason when the kv-divisor path is stubbed out.
+        let hasMemoryReason = plan.reasons.contains { reason in
+            if case .memoryCeilingReached = reason { return true }
+            return false
+        }
+        XCTAssertFalse(hasMemoryReason,
+                       "kvBytesPerToken == 0 must not surface a memoryCeilingReached reason")
+    }
+
+    /// `kvBytesPerToken == 0` with resident overrunning available must still
+    /// `.deny` — the Int.max ceiling isn't a free pass. Verifies the verdict
+    /// is driven by total cost, not just the ceiling.
+    func test_kvBytesPerTokenZero_residentOverrunsAvailable_stillDenies() {
+        let inputs = makeInputs(
+            modelFileSize: 16 * oneGB,
+            strategy: .resident,
+            requested: 8192,
+            trained: 16_384,
+            kvBytesPerToken: 0,
+            available: 2 * oneGB
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+
+        XCTAssertEqual(plan.verdict, .deny,
+                       "kvBytesPerToken == 0 must not mask an insufficient-resident deny")
+        let hasInsufficientResident = plan.reasons.contains { reason in
+            if case .insufficientResident = reason { return true }
+            return false
+        }
+        XCTAssertTrue(hasInsufficientResident,
+                      "Expected .insufficientResident reason; got \(plan.reasons)")
+    }
+
+    /// 70B-class model (~140 GB weights, ~400 KB/token KV) on a 4 GB device
+    /// must never `.allow`. This is the "catastrophically wrong" case — if
+    /// anything in the plan silently permits it, users on small devices see
+    /// OOM crashes with no upstream warning.
+    ///
+    /// Uses the `.resident` strategy because that's the path where
+    /// `estimatedResidentBytes` actually tracks the file size. Under
+    /// `.mappable`, resident caps at 1 GB regardless of file size — a
+    /// separate heuristic concern that is out of scope for this test.
+    /// (See report: the mappable heuristic under-estimates for huge files
+    /// and can silently `.allow` a 140 GB file; not fixed here.)
+    func test_70BModelOn4GBDevice_residentStrategy_neverAllows() {
+        // 70B at ~4-bit quant ~ 40 GB file. Use a generous 140 GB upper bound
+        // to also cover fp16 distributions.
+        let seventyBBytes: UInt64 = 140 * oneGB
+        let fourGB: UInt64 = 4 * oneGB
+        let inputs = makeInputs(
+            modelFileSize: seventyBBytes,
+            strategy: .resident,                   // residentBudget == file size
+            requested: 2048,                       // small context — favours .allow
+            trained: 131_072,
+            kvBytesPerToken: 400_000,              // 70B-ish architectural KV
+            available: fourGB,
+            physical: fourGB
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+
+        XCTAssertNotEqual(plan.verdict, .allow,
+                          "70B-class on 4 GB must never .allow; got \(plan.verdict) with total=\(plan.outcome.totalEstimatedBytes)")
+        // Stronger: it should be a flat deny — .warn would still be wrong
+        // here, because a 140 GB file cannot fit with only 4 GB resident.
+        XCTAssertEqual(plan.verdict, .deny)
+    }
 }
 
 // MARK: - Convenience accessor (test-scoped, avoids repeating `plan.outcome.totalEstimatedBytes`)


### PR DESCRIPTION
## Summary

PR 3 of 4 from the test-coverage plan. Pure test additions — no source changes.

**W2 — `ModelLoadPlan` + `LoadDenyPolicy` + `GGUFKVCacheEstimator` edges**
- `.allow` and `.warn` verdict coverage in `LoadDenyPolicyInferenceServiceTests` (only `.deny` was covered). `.allow` bypasses even a rejecting custom policy; `.warn` proceeds regardless of `denyPolicy`; `.deny` + `.warnOnly` downgrades the plan to `.warn` before dispatching so backend preconditions hold.
- GQA / MHA / asymmetric-head quantization matrix in `GGUFKVCacheEstimatorTests` so KV-size estimation regressions on modern architectures fail loudly (Llama-3 8B GQA 8:1, Mistral 7B MHA, Qwen2-ish asymmetric K/V dims — each with hand-verified byte totals).
- `fp16` `defaultBytesPerElement` pinned so future Q4/Q8 KV support can't silently halve estimates and bypass memory gating. `bytesPerElement == 0` must return `nil`.
- Saturating-arithmetic edges in `ModelLoadPlanTests`: near-zero available memory doesn't underflow `UInt64`; `kvBytesPerToken == 0` sets `memoryCeiling = Int.max` but doesn't mask resident-overrun denials; 70B-class on 4 GB (resident strategy) never `.allow`s.

**W4 — SSE hazards**
- `done: true` before final `.token` → ordering preserved (token yields before break).
- Tool-call JSON delta fragmented across two chunks → buffered and reassembled into one well-formed event.
- `.usage` co-arrival with `isStreamEnd` → usage emitted before termination so token totals reach clients.
- SSE frame split across URLSession data callbacks → reassembled into a single `GenerationEvent`.

Uses a `ProgrammablePayloadHandler` + minimal `ProgrammableSSEBackend` subclass so tests can construct synthetic SSE payloads that exercise single-payload ordering hazards (real Claude/OpenAI formats split these across events).

## Release Note

_Not user-facing — tests only. No release note._

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits`
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits`
- [x] `swift test --filter BaseChatUITests --disable-default-traits`
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits`
- [x] Sabotage-check (W2): widened `allowThreshold = UInt64.max` in `ModelLoadPlan.compute` → 70B-on-4GB test failed with `.allow` instead of `.deny`. Reverted.
- [x] Sabotage-check (W4): swapped `isStreamEnd` before `extractToken` in `SSECloudBackend.parseResponseStream` → `hazard_doneSignalWithFinalToken_tokenYieldsFirst` failed (`["hello"]` instead of `["hello", "world"]`). Reverted.

## Notes for reviewer

- Deviation from plan: the brief suggested the 70B-on-4GB test use `.mappable` as "most permissive realistic strategy". Under `.mappable`, `residentBudget` caps at `min(fileSize/4, 1 GB)` — so a 140 GB file's resident estimate is only 1 GB, and the plan returns `.allow` with ~1.8 GB total on 4 GB available. The test now uses `.resident` (where `residentBudget == fileSize`) to actually exercise the "huge estimatedResidentBytes" intent. The mappable under-estimate for huge files is a real scope-limited finding — see below.
- Scope-limited finding (not fixed): `ModelLoadPlan.compute` with `.mappable` and a 140 GB file returns `.allow` on 4 GB available because `residentBudget` caps at 1 GB regardless of file size. A user who picks `.mappable` for a 70B GGUF would be silently told "safe to proceed". Fix would widen `residentBudget` to at least account for the ratio of file-to-available, but that's a behavior change outside PR scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)