### PR TITLE
fix: .mappable strategy should deny huge models on small-RAM devices

### DIFF
--- a/Sources/BaseChatInference/Services/ModelLoadPlan.swift
+++ b/Sources/BaseChatInference/Services/ModelLoadPlan.swift
@@ -149,6 +149,12 @@ public struct ModelLoadPlan: Sendable {
         case .mappable:
             // Mappable heuristic: min(fileSize/4, 1 GB). mmap-backed loads only need
             // a fraction of the file resident in RAM for active working pages.
+            //
+            // BUT: even with mmap, a file that is wildly larger than the device's
+            // available RAM cannot stream through the page cache without
+            // catastrophic thrashing — llama.cpp will either crash or appear to
+            // hang. The 1 GB cap alone silently allows e.g. a 140 GB 70B model on
+            // a 4 GB iPad. Guard against that below via `impossibleFitRatio`.
             let oneGB: UInt64 = 1_073_741_824
             residentBudget = min(inputs.modelFileSize / 4, oneGB)
         case .external:
@@ -207,11 +213,32 @@ public struct ModelLoadPlan: Sendable {
         let estimatedKV = UInt64(effectiveContextSize) * inputs.kvBytesPerToken
         let total = residentBudget &+ estimatedKV  // residentBudget is already bounded
 
+        // Impossible-fit guard: regardless of strategy, a model file that is
+        // dramatically larger than the device's available RAM cannot load
+        // successfully. Under `.mappable`, the residentBudget heuristic caps at
+        // 1 GB so a 140 GB file on a 4 GB device would otherwise silently
+        // `.allow`; under `.resident` the normal threshold check already denies,
+        // but the explicit guard keeps the reason informative. A ratio of 3
+        // means a 12 GB file on 4 GB RAM is still permitted (mmap can plausibly
+        // handle ~3× working set) while a 30 GB file on 4 GB RAM is rejected
+        // before it reaches llama.cpp. `.external` (cloud / system-managed)
+        // reports fileSize == 0 and is unaffected.
+        let impossibleFitRatio: UInt64 = 3
+        let impossibleFit = inputs.modelFileSize > 0
+            && available > 0
+            && inputs.modelFileSize / available >= impossibleFitRatio
+
         // Verdict thresholds: allow ≤85% of available, warn up to 100%, deny above.
         let allowThreshold = UInt64(Double(available) * 0.85)
         let verdict: Verdict
         var finalReasons = reasons
-        if total <= allowThreshold {
+        if impossibleFit {
+            verdict = .deny
+            finalReasons.append(.insufficientResident(
+                required: inputs.modelFileSize,
+                available: available
+            ))
+        } else if total <= allowThreshold {
             verdict = .allow
         } else if total <= available {
             verdict = .warn

--- a/Tests/BaseChatInferenceTests/ModelLoadPlanTests.swift
+++ b/Tests/BaseChatInferenceTests/ModelLoadPlanTests.swift
@@ -47,8 +47,15 @@ final class ModelLoadPlanTests: XCTestCase {
         let kvBytes = UInt64(effective) * kvBytesPerToken
         let total = residentBudget &+ kvBytes
         let allowThreshold = UInt64(Double(available) * 0.85)
+        // Mirror production's impossible-fit guard: see ModelLoadPlan.compute.
+        let impossibleFitRatio: UInt64 = 3
+        let impossibleFit = modelFileSize > 0
+            && available > 0
+            && modelFileSize / available >= impossibleFitRatio
         let verdict: ModelLoadPlan.Verdict
-        if total <= allowThreshold {
+        if impossibleFit {
+            verdict = .deny
+        } else if total <= allowThreshold {
             verdict = .allow
         } else if total <= available {
             verdict = .warn
@@ -660,27 +667,21 @@ final class ModelLoadPlanTests: XCTestCase {
     /// (See report: the mappable heuristic under-estimates for huge files
     /// and can silently `.allow` a 140 GB file; not fixed here.)
     /// Companion to the `.resident` case above. Under `.mappable`, a 140 GB
-    /// file's resident estimate caps at `min(fileSize/4, 1 GB) == 1 GB`
-    /// regardless of the file being 140 × the available RAM. The plan then
-    /// computes total ≈ 1 GB (resident) + a few hundred MB (KV) and returns
-    /// `.allow` — silently telling a user on a 4 GB device that a 70B model
-    /// will load fine.
+    /// file on a 4 GB device is 35× the available RAM — far beyond what mmap
+    /// can stream without catastrophic thrashing. The plan must `.deny` before
+    /// the load ever reaches llama.cpp (where it would crash or hang with a
+    /// useless error).
     ///
-    /// This test PINS the current (broken) behavior so a good-faith fix
-    /// — e.g., scaling `residentBudget` by `fileSize / availableMemory`, or
-    /// clamping on raw `fileSize > 2 * available` regardless of strategy —
-    /// will cause the test to fail and force an explicit update.
-    ///
-    // FIXME: file a GitHub issue and replace this URL — `.mappable` residentBudget
-    // caps at min(fileSize/4, 1 GB), so huge models on small devices are silently
-    // allowed. When fixed, flip this test's expectation to `.deny` and remove the
-    // FIXME.
-    func test_70BModelOn4GBDevice_mappableStrategy_currentlyAllowsDespiteImpossibleFit() {
+    /// Historical note: prior to the impossible-fit guard, the `.mappable`
+    /// residentBudget capped at `min(fileSize/4, 1 GB) == 1 GB` for any huge
+    /// file, so total ≈ 1 GB + a few hundred MB of KV fit under the 85%
+    /// threshold and the plan silently returned `.allow`.
+    func test_70BModelOn4GBDevice_mappableStrategy_denies() {
         let seventyBBytes: UInt64 = 140 * oneGB
         let fourGB: UInt64 = 4 * oneGB
         let inputs = makeInputs(
             modelFileSize: seventyBBytes,
-            strategy: .mappable,                   // residentBudget caps at 1 GB
+            strategy: .mappable,
             requested: 2048,
             trained: 131_072,
             kvBytesPerToken: 400_000,
@@ -689,16 +690,65 @@ final class ModelLoadPlanTests: XCTestCase {
         )
         let plan = ModelLoadPlan.compute(inputs: inputs)
 
-        // Production bug: this should be .deny but is currently .allow because
-        // residentBudget under .mappable is capped to 1 GB regardless of how
-        // much larger the file is than available memory.
+        XCTAssertEqual(plan.verdict, .deny,
+                       "140 GB file on 4 GB device must .deny; got \(plan.verdict)")
+        // A primary reason the UI can surface — not just a silent deny.
+        let hasInsufficientResident = plan.reasons.contains { reason in
+            if case .insufficientResident = reason { return true }
+            return false
+        }
+        XCTAssertTrue(hasInsufficientResident,
+                      "Expected .insufficientResident reason; got \(plan.reasons)")
+    }
+
+    /// Boundary case on the permissive side of the impossible-fit guard: a
+    /// 10 GB model on an 8 GB-RAM device (ratio 1.25×) must still be allowed
+    /// under `.mappable`. The fix must not over-reject legitimate loads —
+    /// page-cache-backed mmap handles working sets up to ~2-3× RAM routinely.
+    func test_10GBModelOn8GBDevice_mappableStrategy_allows() {
+        let tenGB: UInt64 = 10 * oneGB
+        let eightGB: UInt64 = 8 * oneGB
+        let inputs = makeInputs(
+            modelFileSize: tenGB,
+            strategy: .mappable,
+            requested: 4096,
+            trained: 32_768,
+            kvBytesPerToken: 8_192,
+            available: eightGB,
+            physical: eightGB
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+
         XCTAssertEqual(plan.verdict, .allow,
-                       "Current .mappable heuristic allows 140 GB file on 4 GB device (bug). If this assertion fails because the bug was fixed, flip to .deny and remove the FIXME above.")
-        // Pin the underestimate: resident estimate is ~1 GB, not the ~140 GB
-        // the file actually implies. This inequality is what a fix should make
-        // false.
-        XCTAssertLessThanOrEqual(plan.outcome.estimatedResidentBytes, oneGB + 1,
-                                 "residentBudget under .mappable currently caps at 1 GB; a fix should grow this with fileSize")
+                       "10 GB / 8 GB RAM (1.25×) must remain allowed; impossible-fit guard must not over-reject")
+    }
+
+    /// Boundary case on the deny side: 30 GB file on 4 GB RAM (ratio 7.5×)
+    /// is far beyond what mmap can realistically stream — the guard must
+    /// reject it pre-load. This tests the core invariant the fix enforces
+    /// without relying on 70B-scale numbers.
+    func test_30GBModelOn4GBDevice_mappableStrategy_denies() {
+        let thirtyGB: UInt64 = 30 * oneGB
+        let fourGB: UInt64 = 4 * oneGB
+        let inputs = makeInputs(
+            modelFileSize: thirtyGB,
+            strategy: .mappable,
+            requested: 2048,
+            trained: 32_768,
+            kvBytesPerToken: 8_192,
+            available: fourGB,
+            physical: fourGB
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+
+        XCTAssertEqual(plan.verdict, .deny,
+                       "30 GB / 4 GB RAM (7.5×) must deny; mmap cannot stream at that ratio without thrashing")
+        let hasInsufficientResident = plan.reasons.contains { reason in
+            if case .insufficientResident = reason { return true }
+            return false
+        }
+        XCTAssertTrue(hasInsufficientResident,
+                      "Expected .insufficientResident reason for impossible fit; got \(plan.reasons)")
     }
 
     func test_70BModelOn4GBDevice_residentStrategy_neverAllows() {

--- a/Tests/BaseChatInferenceTests/ModelLoadPlanTests.swift
+++ b/Tests/BaseChatInferenceTests/ModelLoadPlanTests.swift
@@ -751,6 +751,51 @@ final class ModelLoadPlanTests: XCTestCase {
                       "Expected .insufficientResident reason for impossible fit; got \(plan.reasons)")
     }
 
+    /// Boundary tests for the impossible-fit guard (ratio == 3). The production
+    /// formula uses integer division `file / available >= 3`, which denies
+    /// exactly when `file >= 3 * available`. A regression that flips the
+    /// comparison (> vs >=) or bumps the ratio (3 → 4) silently lets a 12 GB
+    /// model slip through on a 4 GB device — exactly the class of bug this
+    /// guard was added to prevent. These pin the boundary so future changes
+    /// require an explicit update.
+    func test_impossibleFitGuard_atRatioExactlyThree_denies() {
+        // 12 GB / 4 GB = exactly 3× → must deny.
+        let inputs = makeInputs(
+            modelFileSize: 12 * oneGB,
+            strategy: .mappable,
+            requested: 2048,
+            trained: 32_768,
+            kvBytesPerToken: 8_192,
+            available: 4 * oneGB,
+            physical: 4 * oneGB
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+        XCTAssertEqual(plan.verdict, .deny,
+                       "12 GB / 4 GB (ratio == 3) must deny; guard uses >= comparison")
+    }
+
+    func test_impossibleFitGuard_justBelowRatioThree_doesNotDeny() {
+        // 12 GB - 1 byte over 4 GB → integer ratio = 2 → guard does NOT fire.
+        // Verdict is whatever the normal thresholds produce; the point is that
+        // the new guard alone doesn't flip it to deny.
+        let inputs = makeInputs(
+            modelFileSize: 12 * oneGB - 1,
+            strategy: .mappable,
+            requested: 2048,
+            trained: 32_768,
+            kvBytesPerToken: 8_192,
+            available: 4 * oneGB,
+            physical: 4 * oneGB
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+        // Without the guard firing, a 12 GB mmap'd file on 4 GB available with
+        // tiny context (2048 tokens * 8 KB = 16 MB KV) totals ~1.016 GB
+        // (resident 1 GB cap + 16 MB KV) which is < 85% of 4 GB → .allow.
+        // If the guard fires incorrectly here the verdict would be .deny.
+        XCTAssertNotEqual(plan.verdict, .deny,
+                          "12 GB - 1B / 4 GB (ratio < 3) must not be denied by the impossible-fit guard")
+    }
+
     func test_70BModelOn4GBDevice_residentStrategy_neverAllows() {
         // 70B at ~4-bit quant ~ 40 GB file. Use a generous 140 GB upper bound
         // to also cover fp16 distributions.


### PR DESCRIPTION
## Summary

Fixes a silent `.allow` verdict from `ModelLoadPlan.compute(.mappable)` for huge models on small-RAM devices. A 70B GGUF (~140 GB) on a 4 GB iPad previously passed the check because `residentBudget` capped at `min(fileSize/4, 1 GB)` — this resulted in users getting past the gate only for the load to fail at llama.cpp time with an unclear error.

**Fix**: Added an orthogonal impossible-fit guard in `ModelLoadPlan.compute` that denies when `fileSize / available >= 3`, regardless of strategy. This sits alongside — not inside — the existing `residentBudget` heuristic, so the `.mappable` fraction-of-file formula is untouched for reasonable cases. The ratio of 3 permits legitimate mmap workloads (10 GB / 8 GB RAM passes at 1.25×) while rejecting the impossible cases (30 GB / 4 GB at 7.5×, 140 GB / 4 GB at 35×). Under `.resident` the normal threshold check was already denying these, but the explicit guard now produces an `.insufficientResident` reason with the true file size rather than whatever the resident heuristic happened to produce. `.external` is unaffected (fileSize is 0).

**Flipped FIXME test**: `test_70BModelOn4GBDevice_mappableStrategy_currentlyAllowsDespiteImpossibleFit` was pinned on main as a characterization test for the broken behavior. Renamed to `test_70BModelOn4GBDevice_mappableStrategy_denies`, flipped to assert `.deny` + `.insufficientResident`, and the FIXME comment dropped.

## Release Note

**Stop silently approving impossible model loads** — the `.mappable` strategy now correctly rejects models whose file size cannot plausibly fit the device's available memory, replacing a misleading `.allow` verdict with an actionable `.deny` before the load even begins. Users on small-RAM devices trying to load 70B-class models will now see a clear "won't fit" message instead of a mysterious llama.cpp crash.

## Test plan

- [x] Flipped FIXME test: previously asserted broken `.allow`, now asserts `.deny` + `.insufficientResident`
- [x] New positive test: 10 GB / 8 GB RAM still allowed (no over-rejection)
- [x] New negative test: 30 GB / 4 GB RAM denied
- [x] Sabotage check: reverted production fix, both new negative tests (70B and 30GB) failed as expected; re-applied
- [x] All four CI suites green locally (Core 196 tests, Inference pass, UI 437 tests, Backends 88 tests)
- [x] `swift build` completes (the `-Xswiftc -warnings-as-errors` surfaces three pre-existing warnings in unrelated files: `InferenceBackend.swift`, `UUID+v5.swift`, `BackgroundDownloadManager.swift` — none introduced by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)