### PR TITLE
feat(ipad): popover sheets and medium detent for model management (#345, #346)

### DIFF
--- a/Sources/BaseChatUI/Views/Chat/ChatView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ChatView.swift
@@ -114,15 +114,24 @@ public struct ChatView: View {
             ChatExportSheet()
         }
         #endif
-        // API configuration can be triggered from the error recovery button which has
-        // no natural popover anchor, so it uses a sheet on all platforms. On iPad the
-        // drag indicator makes it clear the sheet is dismissible.
+        // API configuration: on compact size class (iPhone) or macOS, use a full sheet
+        // because there is no stable toolbar anchor. On regular size class (iPad) the
+        // presentation is anchored to the recovery button via `.popover` — see
+        // `recoveryButton(for:)` below which attaches the popover directly to the button
+        // so the sheet modifier here is skipped on that path.
+        #if os(iOS)
+        .sheet(isPresented: Binding(
+            get: { showAPIConfiguration && horizontalSizeClass == .compact },
+            set: { if !$0 { showAPIConfiguration = false } }
+        )) {
+            APIConfigurationView()
+                .presentationDragIndicator(.visible)
+        }
+        #else
         .sheet(isPresented: $showAPIConfiguration) {
             APIConfigurationView()
-                #if os(iOS)
-                .presentationDragIndicator(.visible)
-                #endif
         }
+        #endif
     }
 
     // MARK: - Error Banner
@@ -159,6 +168,18 @@ public struct ChatView: View {
             }
             .buttonStyle(.borderless)
             .font(.callout.bold())
+            #if os(iOS)
+            // On regular size class (iPad), anchor the API config as a popover on the
+            // recovery button so the split view stays visible. On compact (iPhone) the
+            // view-level `.sheet` above handles presentation instead.
+            .popover(isPresented: Binding(
+                get: { showAPIConfiguration && horizontalSizeClass == .regular },
+                set: { if !$0 { showAPIConfiguration = false } }
+            )) {
+                APIConfigurationView()
+                    .frame(minWidth: 360, minHeight: 440)
+            }
+            #endif
         case .selectModel:
             Button("Select Model") {
                 viewModel.activeError = nil

--- a/Sources/BaseChatUI/Views/Chat/ChatView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ChatView.swift
@@ -163,8 +163,24 @@ public struct ChatView: View {
             .font(.callout.bold())
         case .configureAPIKey:
             Button("Check API Key") {
+                #if os(iOS)
+                // On regular size class (iPad) the popover is anchored to this button,
+                // so we must NOT clear activeError here — doing so removes the error
+                // banner (and this button) from the view tree before SwiftUI can capture
+                // the anchor, causing the popover to present without an anchor or not at
+                // all. Instead, we clear activeError in the popover's dismissal handler.
+                // On compact (iPhone) the sheet is attached to the root view rather than
+                // this button, so the anchor disappearing is harmless there.
+                if horizontalSizeClass == .regular {
+                    showAPIConfiguration = true
+                } else {
+                    viewModel.activeError = nil
+                    showAPIConfiguration = true
+                }
+                #else
                 viewModel.activeError = nil
                 showAPIConfiguration = true
+                #endif
             }
             .buttonStyle(.borderless)
             .font(.callout.bold())
@@ -174,7 +190,15 @@ public struct ChatView: View {
             // view-level `.sheet` above handles presentation instead.
             .popover(isPresented: Binding(
                 get: { showAPIConfiguration && horizontalSizeClass == .regular },
-                set: { if !$0 { showAPIConfiguration = false } }
+                set: {
+                    if !$0 {
+                        showAPIConfiguration = false
+                        // Clear the error now that the popover is gone — this removes the
+                        // banner and keeps the screen clean after the user is done
+                        // configuring their API key.
+                        viewModel.activeError = nil
+                    }
+                }
             )) {
                 APIConfigurationView()
                     .frame(minWidth: 360, minHeight: 440)


### PR DESCRIPTION
## Summary

- On iPad (regular horizontal size class), the \"Check API Key\" error recovery button now presents `APIConfigurationView` as a `.popover` anchored to the button itself, so the split-view context stays visible instead of being covered by a full-screen sheet
- On iPhone (compact size class), the existing full `.sheet` presentation is retained unchanged
- `ModelManagementSheet` already supports `.medium` detent on regular size class (landed in #352); this PR confirms and closes that issue

## What changed

**`ChatView.swift`**: The view-level `.sheet(isPresented: $showAPIConfiguration)` is now guarded to only fire on compact size class (iPhone). On regular size class (iPad), a `.popover` is attached directly to the \"Check API Key\" recovery button, anchoring the popover to its call site. On macOS, the existing unconditional sheet is preserved.

## Release Note

On iPad, the API Configuration view no longer hijacks the full screen when it opens from an authentication error. Tapping \"Check API Key\" in an error banner now presents the config panel as a compact popover anchored to the button, leaving the chat and split-view sidebar visible behind it. iPhone users see no change — the full-screen sheet presentation is unchanged on compact size class. The Model Management sheet already supports a half-height (medium) detent on iPad so users can switch models without losing their place in the split view.

Closes #345
Closes #346