### PR TITLE
feat(inference): generic ToolCall / ToolResult contract in BaseChatInference (#433)

### DIFF
--- a/Sources/BaseChatInference/Models/GenerationEvent.swift
+++ b/Sources/BaseChatInference/Models/GenerationEvent.swift
@@ -9,4 +9,12 @@ public enum GenerationEvent: Sendable, Equatable {
 
     /// Token usage reported by the backend (cloud backends only today).
     case usage(prompt: Int, completion: Int)
+
+    /// A tool invocation requested by the model.
+    ///
+    /// Backends that support tool calling (``BackendCapabilities/supportsToolCalling``)
+    /// emit this event when the model decides to call a tool defined in
+    /// ``GenerationConfig/tools``.  The host is responsible for executing the
+    /// call and feeding a ``ToolResult`` back into the conversation.
+    case toolCall(ToolCall)
 }

--- a/Sources/BaseChatInference/Models/ToolTypes.swift
+++ b/Sources/BaseChatInference/Models/ToolTypes.swift
@@ -1,0 +1,265 @@
+import Foundation
+
+// MARK: - ToolDefinition
+
+/// Describes a tool (function) that an inference backend can invoke.
+///
+/// Backends that set ``BackendCapabilities/supportsToolCalling`` to `true` accept
+/// a list of ``ToolDefinition`` values in ``GenerationConfig/tools``.  The backend
+/// serialises these into its native tool-schema format (e.g. OpenAI `functions`,
+/// Anthropic `tools`, llama.cpp grammar) before sending the request.
+///
+/// ## Example
+/// ```swift
+/// let weatherTool = ToolDefinition(
+///     name: "get_weather",
+///     description: "Returns current weather for a city.",
+///     parameters: [
+///         "type": "object",
+///         "properties": [
+///             "city": ["type": "string", "description": "City name"]
+///         ],
+///         "required": ["city"]
+///     ]
+/// )
+/// ```
+public struct ToolDefinition: Sendable, Codable, Equatable, Hashable {
+
+    /// Unique identifier for the tool — the model uses this name in a ``ToolCall``.
+    public let name: String
+
+    /// Human-readable description of what the tool does.
+    ///
+    /// Good descriptions help the model decide when to invoke the tool.
+    public let description: String
+
+    /// JSON-Schema-shaped parameter spec, serialised as a generic dictionary.
+    ///
+    /// Use the standard JSON Schema vocabulary (`"type"`, `"properties"`,
+    /// `"required"`, etc.).  The backend is responsible for mapping this to
+    /// its own wire format.
+    ///
+    /// `Codable` is synthesised via a ``JSONSchemaValue`` bridge so the
+    /// dictionary round-trips through `Encoder`/`Decoder` without loss.
+    public let parameters: JSONSchemaValue
+
+    /// Creates a tool definition.
+    ///
+    /// - Parameters:
+    ///   - name: The tool name the model will use in ``ToolCall/toolName``.
+    ///   - description: What the tool does.
+    ///   - parameters: A JSON-Schema object describing the tool's arguments.
+    public init(name: String, description: String, parameters: JSONSchemaValue = .object([:])) {
+        self.name = name
+        self.description = description
+        self.parameters = parameters
+    }
+}
+
+// MARK: - JSONSchemaValue
+
+/// A recursive value type that can represent any JSON-Schema document.
+///
+/// Using a typed enum rather than `[String: Any]` gives `Sendable`, `Codable`,
+/// `Equatable`, and `Hashable` conformances without custom boilerplate.
+///
+/// Backends serialise this to their native wire format (dictionaries, JSON
+/// strings, etc.) at the point of use.
+public indirect enum JSONSchemaValue: Sendable, Codable, Equatable, Hashable {
+    /// A JSON string.
+    case string(String)
+    /// A JSON number (stored as `Double` to cover both int and float cases).
+    case number(Double)
+    /// A JSON boolean.
+    case bool(Bool)
+    /// A JSON null.
+    case null
+    /// A JSON array.
+    case array([JSONSchemaValue])
+    /// A JSON object.
+    case object([String: JSONSchemaValue])
+
+    // MARK: Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let b = try? container.decode(Bool.self) {
+            self = .bool(b)
+        } else if let n = try? container.decode(Double.self) {
+            self = .number(n)
+        } else if let s = try? container.decode(String.self) {
+            self = .string(s)
+        } else if let arr = try? container.decode([JSONSchemaValue].self) {
+            self = .array(arr)
+        } else {
+            let dict = try container.decode([String: JSONSchemaValue].self)
+            self = .object(dict)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null:
+            try container.encodeNil()
+        case .bool(let b):
+            try container.encode(b)
+        case .number(let n):
+            try container.encode(n)
+        case .string(let s):
+            try container.encode(s)
+        case .array(let arr):
+            try container.encode(arr)
+        case .object(let dict):
+            try container.encode(dict)
+        }
+    }
+}
+
+// MARK: - ToolCall
+
+/// A tool invocation emitted by the model during generation.
+///
+/// When the backend decides to call a tool, it emits a
+/// ``GenerationEvent/toolCall(_:)`` event carrying one of these values.
+/// The host application is responsible for executing the tool and
+/// returning a ``ToolResult``.
+///
+/// ```swift
+/// for try await event in stream.events {
+///     switch event {
+///     case .token(let text):
+///         appendText(text)
+///     case .toolCall(let call):
+///         let result = await myToolDispatcher.execute(call)
+///         // Feed result back into the conversation …
+///     default:
+///         break
+///     }
+/// }
+/// ```
+public struct ToolCall: Sendable, Codable, Equatable, Hashable {
+
+    /// Opaque identifier assigned by the backend; echoed back in ``ToolResult/callId``.
+    public let id: String
+
+    /// The name of the tool to invoke (matches ``ToolDefinition/name``).
+    public let toolName: String
+
+    /// JSON-encoded arguments for the tool, as a raw string.
+    ///
+    /// Decode this with `JSONDecoder` or `JSONSerialization` according to the
+    /// schema declared in the corresponding ``ToolDefinition/parameters``.
+    public let arguments: String
+
+    /// Creates a tool call.
+    ///
+    /// - Parameters:
+    ///   - id: Backend-assigned call identifier.
+    ///   - toolName: The tool name the model chose to invoke.
+    ///   - arguments: JSON-encoded argument payload.
+    public init(id: String, toolName: String, arguments: String) {
+        self.id = id
+        self.toolName = toolName
+        self.arguments = arguments
+    }
+}
+
+// MARK: - ToolResult
+
+/// The outcome of executing a ``ToolCall``.
+///
+/// Feed this back to the backend (e.g. as an additional message in the
+/// conversation history) so the model can incorporate the tool output
+/// into its final response.
+public struct ToolResult: Sendable, Codable, Equatable, Hashable {
+
+    /// The ``ToolCall/id`` this result corresponds to.
+    public let callId: String
+
+    /// The tool's output, serialised as a string.
+    ///
+    /// For structured data, JSON-encode it before assigning.
+    public let content: String
+
+    /// `true` when the tool execution failed.
+    ///
+    /// Backends that support error context (e.g. OpenAI) surface this flag
+    /// so the model can reason about the failure and potentially retry.
+    public let isError: Bool
+
+    /// Creates a tool result.
+    ///
+    /// - Parameters:
+    ///   - callId: The ``ToolCall/id`` this result belongs to.
+    ///   - content: The tool's output string.
+    ///   - isError: Whether the execution failed. Defaults to `false`.
+    public init(callId: String, content: String, isError: Bool = false) {
+        self.callId = callId
+        self.content = content
+        self.isError = isError
+    }
+}
+
+// MARK: - ToolChoice
+
+/// Controls how the backend selects which tool to call, if any.
+///
+/// Pass this via ``GenerationConfig/toolChoice`` alongside a non-empty
+/// ``GenerationConfig/tools`` list.
+public enum ToolChoice: Sendable, Codable, Equatable, Hashable {
+
+    /// The backend decides whether to call a tool (default behaviour).
+    case auto
+
+    /// The backend must not call any tool; it must produce a text response.
+    case none
+
+    /// The backend must call at least one tool.
+    case required
+
+    /// The backend must call the named tool specifically.
+    case tool(name: String)
+
+    // MARK: Codable
+
+    private enum CodingKeys: String, CodingKey {
+        case type, name
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type_ = try container.decode(String.self, forKey: .type)
+        switch type_ {
+        case "auto":     self = .auto
+        case "none":     self = .none
+        case "required": self = .required
+        case "tool":
+            let name = try container.decode(String.self, forKey: .name)
+            self = .tool(name: name)
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .type,
+                in: container,
+                debugDescription: "Unknown ToolChoice type '\(type_)'"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .auto:
+            try container.encode("auto", forKey: .type)
+        case .none:
+            try container.encode("none", forKey: .type)
+        case .required:
+            try container.encode("required", forKey: .type)
+        case .tool(let name):
+            try container.encode("tool", forKey: .type)
+            try container.encode(name, forKey: .name)
+        }
+    }
+}

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Sampling and generation parameters shared across all inference backends.
-public struct GenerationConfig: Sendable {
+public struct GenerationConfig: Sendable, Codable {
     public var temperature: Float
     public var topP: Float
     public var repeatPenalty: Float
@@ -17,6 +17,19 @@ public struct GenerationConfig: Sendable {
     /// `nil` means no explicit limit beyond the backend's own defaults.
     public var maxOutputTokens: Int?
 
+    /// Tool definitions made available to the model for this generation request.
+    ///
+    /// Only honoured by backends that set ``BackendCapabilities/supportsToolCalling``
+    /// to `true`.  Backends that do not support tool calling silently ignore this
+    /// field.  Defaults to an empty array (no tools).
+    public var tools: [ToolDefinition]
+
+    /// Controls which tool, if any, the backend is allowed to call.
+    ///
+    /// Only honoured when ``tools`` is non-empty and the backend supports tool
+    /// calling.  Defaults to ``ToolChoice/auto``.
+    public var toolChoice: ToolChoice
+
     @available(*, deprecated, message: "Use init(temperature:topP:repeatPenalty:topK:typicalP:maxOutputTokens:) instead.")
     public init(
         temperature: Float = 0.7,
@@ -25,7 +38,9 @@ public struct GenerationConfig: Sendable {
         maxTokens: Int32,
         topK: Int32? = nil,
         typicalP: Float? = nil,
-        maxOutputTokens: Int? = 2048
+        maxOutputTokens: Int? = 2048,
+        tools: [ToolDefinition] = [],
+        toolChoice: ToolChoice = .auto
     ) {
         self.temperature = temperature
         self.topP = topP
@@ -34,6 +49,8 @@ public struct GenerationConfig: Sendable {
         self.topK = topK
         self.typicalP = typicalP
         self.maxOutputTokens = maxOutputTokens
+        self.tools = tools
+        self.toolChoice = toolChoice
     }
 
     public init(
@@ -42,7 +59,9 @@ public struct GenerationConfig: Sendable {
         repeatPenalty: Float = 1.1,
         topK: Int32? = nil,
         typicalP: Float? = nil,
-        maxOutputTokens: Int? = 2048
+        maxOutputTokens: Int? = 2048,
+        tools: [ToolDefinition] = [],
+        toolChoice: ToolChoice = .auto
     ) {
         self.temperature = temperature
         self.topP = topP
@@ -51,6 +70,8 @@ public struct GenerationConfig: Sendable {
         self.topK = topK
         self.typicalP = typicalP
         self.maxOutputTokens = maxOutputTokens
+        self.tools = tools
+        self.toolChoice = toolChoice
     }
 }
 

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -73,6 +73,41 @@ public struct GenerationConfig: Sendable, Codable {
         self.tools = tools
         self.toolChoice = toolChoice
     }
+
+    // MARK: Codable
+
+    private enum CodingKeys: String, CodingKey {
+        case temperature, topP, repeatPenalty, maxTokens, topK, typicalP, maxOutputTokens
+        case tools, toolChoice
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        temperature = try c.decode(Float.self, forKey: .temperature)
+        topP = try c.decode(Float.self, forKey: .topP)
+        repeatPenalty = try c.decode(Float.self, forKey: .repeatPenalty)
+        // maxTokens is deprecated; absent from payloads that never encoded it — fall back to 512.
+        maxTokens = (try c.decodeIfPresent(Int32.self, forKey: .maxTokens)) ?? 512
+        topK = try c.decodeIfPresent(Int32.self, forKey: .topK)
+        typicalP = try c.decodeIfPresent(Float.self, forKey: .typicalP)
+        maxOutputTokens = try c.decodeIfPresent(Int.self, forKey: .maxOutputTokens)
+        // New fields added in v0.10; absent from payloads serialised before their introduction.
+        tools = (try c.decodeIfPresent([ToolDefinition].self, forKey: .tools)) ?? []
+        toolChoice = (try c.decodeIfPresent(ToolChoice.self, forKey: .toolChoice)) ?? .auto
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(temperature, forKey: .temperature)
+        try c.encode(topP, forKey: .topP)
+        try c.encode(repeatPenalty, forKey: .repeatPenalty)
+        try c.encode(maxTokens, forKey: .maxTokens)
+        try c.encodeIfPresent(topK, forKey: .topK)
+        try c.encodeIfPresent(typicalP, forKey: .typicalP)
+        try c.encodeIfPresent(maxOutputTokens, forKey: .maxOutputTokens)
+        try c.encode(tools, forKey: .tools)
+        try c.encode(toolChoice, forKey: .toolChoice)
+    }
 }
 
 /// Common interface for inference backends.

--- a/Sources/BaseChatInference/Services/GenerationStreamConsumer.swift
+++ b/Sources/BaseChatInference/Services/GenerationStreamConsumer.swift
@@ -21,6 +21,9 @@ public struct GenerationStreamConsumer: Sendable {
 
         case .usage(let prompt, let completion):
             return .recordUsage(prompt: prompt, completion: completion)
+
+        case .toolCall(let call):
+            return .dispatchToolCall(call)
         }
     }
 
@@ -40,5 +43,7 @@ public struct GenerationStreamConsumer: Sendable {
         case appendText(String)
         /// Record token usage on the current assistant message.
         case recordUsage(prompt: Int, completion: Int)
+        /// Execute the requested tool call and feed a ``ToolResult`` back into the conversation.
+        case dispatchToolCall(ToolCall)
     }
 }

--- a/Sources/BaseChatTestSupport/MockInferenceBackend.swift
+++ b/Sources/BaseChatTestSupport/MockInferenceBackend.swift
@@ -20,6 +20,14 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
     /// via the AsyncThrowingStream rather than from generate() itself.
     public var shouldThrowInsideStream: Error?
 
+    /// Tool calls to emit during generation, interleaved after all text tokens.
+    ///
+    /// When non-empty the backend emits all ``tokensToYield`` tokens first,
+    /// then emits one ``GenerationEvent/toolCall(_:)`` event per entry in
+    /// this array before finishing the stream.  This lets tests assert on
+    /// the full stream event sequence without wiring up a real backend.
+    public var scriptedToolCalls: [ToolCall] = []
+
     // Track calls
     public var loadModelCallCount = 0
     public var generateCallCount = 0
@@ -69,6 +77,7 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
 
         isGenerating = true
         let tokens = tokensToYield
+        let toolCalls = scriptedToolCalls
 
         let stream = AsyncThrowingStream<GenerationEvent, Error> { [self] continuation in
             self.activeContinuation = continuation
@@ -79,6 +88,12 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
                 for token in tokens {
                     if Task.isCancelled { break }
                     continuation.yield(.token(token))
+                }
+                if !Task.isCancelled {
+                    for call in toolCalls {
+                        if Task.isCancelled { break }
+                        continuation.yield(.toolCall(call))
+                    }
                 }
                 self.isGenerating = false
                 if let streamError = self.shouldThrowInsideStream, !Task.isCancelled {

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
@@ -163,6 +163,12 @@ extension ChatViewModel {
                                 msg.promptTokens = prompt
                                 msg.completionTokens = completion
                             }
+
+                        case .dispatchToolCall:
+                            // Tool execution is a host-app concern; ChatViewModel does not
+                            // implement a tool dispatch loop. Apps that need tool calling
+                            // should drive generation directly via InferenceService.
+                            break
                         }
                     }
                 } catch {

--- a/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
+++ b/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
@@ -39,6 +39,13 @@ final class SilentCatchAuditTest: XCTestCase {
     /// DO NOT add entries to make a failing test pass without human review.
     private static let allowlist: Set<String> = [
         // BaseChatInference
+        // JSONSchemaValue uses the standard "try-each-type-in-order" decoder pattern for
+        // heterogeneous JSON. Each `try?` is bound to a named constant and the result is
+        // used immediately; there is no silent discard — the next branch handles the miss.
+        "BaseChatInference/Models/ToolTypes.swift:} else if let b = try? container.decode(Bool.self) {",
+        "BaseChatInference/Models/ToolTypes.swift:} else if let n = try? container.decode(Double.self) {",
+        "BaseChatInference/Models/ToolTypes.swift:} else if let s = try? container.decode(String.self) {",
+        "BaseChatInference/Models/ToolTypes.swift:} else if let arr = try? container.decode([JSONSchemaValue].self) {",
         "BaseChatInference/Models/ModelInfo.swift:guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),",
         "BaseChatInference/Models/ModelInfo.swift:if let metadata = try? GGUFMetadataReader.readMetadata(from: url) {",
         "BaseChatInference/Models/ModelInfo.swift:guard let contents = try? fileManager.contentsOfDirectory(",

--- a/Tests/BaseChatInferenceTests/ToolCallContractTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolCallContractTests.swift
@@ -1,0 +1,283 @@
+import XCTest
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Tests for the ``ToolCall`` / ``ToolResult`` / ``ToolDefinition`` / ``ToolChoice``
+/// contract introduced in BaseChatInference.
+///
+/// Covers:
+/// - `GenerationConfig` round-trips (Codable) with tools and toolChoice
+/// - `MockInferenceBackend` emits scripted tool calls in order
+/// - `GenerationEvent.toolCall` is carried through a stream and consumed
+/// - `GenerationStreamConsumer` maps `.toolCall` to `.dispatchToolCall`
+final class ToolCallContractTests: XCTestCase {
+
+    // MARK: - ToolDefinition Codable
+
+    func test_toolDefinition_roundTrips() throws {
+        let schema: JSONSchemaValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "city": .object(["type": .string("string")])
+            ]),
+            "required": .array([.string("city")])
+        ])
+        let def = ToolDefinition(name: "get_weather", description: "Returns weather.", parameters: schema)
+
+        let encoded = try JSONEncoder().encode(def)
+        let decoded = try JSONDecoder().decode(ToolDefinition.self, from: encoded)
+
+        // Sabotage check: changing `def.name` to "" before encoding causes XCTAssertEqual to fail
+        XCTAssertEqual(decoded.name, "get_weather")
+        XCTAssertEqual(decoded.description, "Returns weather.")
+        XCTAssertEqual(decoded.parameters, schema)
+    }
+
+    // MARK: - ToolCall Codable
+
+    func test_toolCall_roundTrips() throws {
+        let call = ToolCall(id: "call-1", toolName: "get_weather", arguments: #"{"city":"Paris"}"#)
+
+        let encoded = try JSONEncoder().encode(call)
+        let decoded = try JSONDecoder().decode(ToolCall.self, from: encoded)
+
+        // Sabotage check: swapping `id` and `toolName` fields in encoding causes this to fail
+        XCTAssertEqual(decoded.id, "call-1")
+        XCTAssertEqual(decoded.toolName, "get_weather")
+        XCTAssertEqual(decoded.arguments, #"{"city":"Paris"}"#)
+    }
+
+    // MARK: - ToolResult Codable
+
+    func test_toolResult_roundTrips_success() throws {
+        let result = ToolResult(callId: "call-1", content: "Sunny, 22°C")
+
+        let encoded = try JSONEncoder().encode(result)
+        let decoded = try JSONDecoder().decode(ToolResult.self, from: encoded)
+
+        XCTAssertEqual(decoded.callId, "call-1")
+        XCTAssertEqual(decoded.content, "Sunny, 22°C")
+        XCTAssertFalse(decoded.isError)
+    }
+
+    func test_toolResult_roundTrips_error() throws {
+        let result = ToolResult(callId: "call-2", content: "City not found", isError: true)
+
+        let encoded = try JSONEncoder().encode(result)
+        let decoded = try JSONDecoder().decode(ToolResult.self, from: encoded)
+
+        // Sabotage check: defaulting `isError` to `false` in the init causes this to fail
+        XCTAssertTrue(decoded.isError)
+        XCTAssertEqual(decoded.content, "City not found")
+    }
+
+    // MARK: - ToolChoice Codable
+
+    func test_toolChoice_auto_roundTrips() throws {
+        let encoded = try JSONEncoder().encode(ToolChoice.auto)
+        let decoded = try JSONDecoder().decode(ToolChoice.self, from: encoded)
+        XCTAssertEqual(decoded, .auto)
+    }
+
+    func test_toolChoice_none_roundTrips() throws {
+        let encoded = try JSONEncoder().encode(ToolChoice.none)
+        let decoded = try JSONDecoder().decode(ToolChoice.self, from: encoded)
+        XCTAssertEqual(decoded, .none)
+    }
+
+    func test_toolChoice_required_roundTrips() throws {
+        let encoded = try JSONEncoder().encode(ToolChoice.required)
+        let decoded = try JSONDecoder().decode(ToolChoice.self, from: encoded)
+        XCTAssertEqual(decoded, .required)
+    }
+
+    func test_toolChoice_tool_roundTrips() throws {
+        let encoded = try JSONEncoder().encode(ToolChoice.tool(name: "get_weather"))
+        let decoded = try JSONDecoder().decode(ToolChoice.self, from: encoded)
+        // Sabotage check: encoding the name as empty string causes XCTAssertEqual to fail
+        XCTAssertEqual(decoded, .tool(name: "get_weather"))
+    }
+
+    // MARK: - GenerationConfig Codable with tools
+
+    func test_generationConfig_defaultTools_isEmpty() {
+        let config = GenerationConfig()
+        XCTAssertTrue(config.tools.isEmpty)
+        XCTAssertEqual(config.toolChoice, .auto)
+    }
+
+    func test_generationConfig_roundTrips_withTools() throws {
+        let tool = ToolDefinition(
+            name: "search",
+            description: "Web search",
+            parameters: .object(["type": .string("object")])
+        )
+        let config = GenerationConfig(tools: [tool], toolChoice: .required)
+
+        let encoded = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: encoded)
+
+        // Sabotage check: not encoding `tools` or `toolChoice` causes count == 0 and choice == .auto
+        XCTAssertEqual(decoded.tools.count, 1)
+        XCTAssertEqual(decoded.tools[0].name, "search")
+        XCTAssertEqual(decoded.toolChoice, .required)
+    }
+
+    func test_generationConfig_roundTrips_toolChoiceTool() throws {
+        let config = GenerationConfig(toolChoice: .tool(name: "search"))
+
+        let encoded = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: encoded)
+
+        XCTAssertEqual(decoded.toolChoice, .tool(name: "search"))
+    }
+
+    func test_generationConfig_existingProperties_unaffected() throws {
+        // Adding tools/toolChoice fields must not break existing serialised GenerationConfig values.
+        let config = GenerationConfig(temperature: 0.8, topP: 0.95, maxOutputTokens: 512)
+
+        let encoded = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: encoded)
+
+        XCTAssertEqual(decoded.temperature, 0.8, accuracy: 0.001)
+        XCTAssertEqual(decoded.topP, 0.95, accuracy: 0.001)
+        XCTAssertEqual(decoded.maxOutputTokens, 512)
+        // Defaults must survive the round-trip
+        XCTAssertTrue(decoded.tools.isEmpty)
+        XCTAssertEqual(decoded.toolChoice, .auto)
+    }
+
+    // MARK: - MockInferenceBackend emits scripted tool calls
+
+    func test_mockBackend_emitsScriptedToolCalls_afterTokens() async throws {
+        let backend = MockInferenceBackend()
+        try await backend.loadModel(
+            from: URL(string: "file:///mock")!,
+            plan: .testStub(effectiveContextSize: 512)
+        )
+
+        let call1 = ToolCall(id: "tc-1", toolName: "get_weather", arguments: #"{"city":"London"}"#)
+        let call2 = ToolCall(id: "tc-2", toolName: "get_time", arguments: #"{"tz":"UTC"}"#)
+        backend.tokensToYield = ["Hello"]
+        backend.scriptedToolCalls = [call1, call2]
+
+        let stream = try backend.generate(prompt: "test", systemPrompt: nil, config: .init())
+
+        var tokens: [String] = []
+        var toolCalls: [ToolCall] = []
+        for try await event in stream.events {
+            switch event {
+            case .token(let text): tokens.append(text)
+            case .toolCall(let call): toolCalls.append(call)
+            case .usage: break
+            }
+        }
+
+        // Sabotage check: removing scriptedToolCalls emission from MockInferenceBackend.generate causes toolCalls.count == 0
+        XCTAssertEqual(tokens, ["Hello"])
+        XCTAssertEqual(toolCalls.count, 2)
+        XCTAssertEqual(toolCalls[0].id, "tc-1")
+        XCTAssertEqual(toolCalls[1].id, "tc-2")
+    }
+
+    func test_mockBackend_emitsNoToolCalls_whenScriptedEmpty() async throws {
+        let backend = MockInferenceBackend()
+        try await backend.loadModel(
+            from: URL(string: "file:///mock")!,
+            plan: .testStub(effectiveContextSize: 512)
+        )
+        backend.tokensToYield = ["Hi"]
+        // scriptedToolCalls defaults to []
+
+        let stream = try backend.generate(prompt: "test", systemPrompt: nil, config: .init())
+
+        var toolCalls: [ToolCall] = []
+        for try await event in stream.events {
+            if case .toolCall(let call) = event { toolCalls.append(call) }
+        }
+
+        XCTAssertTrue(toolCalls.isEmpty)
+    }
+
+    // MARK: - GenerationEvent.toolCall in stream
+
+    func test_generationStream_deliversToolCallEvent() async throws {
+        let expectedCall = ToolCall(id: "c1", toolName: "fn", arguments: "{}")
+        let inner = AsyncThrowingStream<GenerationEvent, Error> { continuation in
+            continuation.yield(.toolCall(expectedCall))
+            continuation.finish()
+        }
+        let stream = GenerationStream(inner)
+
+        var received: [ToolCall] = []
+        for try await event in stream.events {
+            if case .toolCall(let call) = event { received.append(call) }
+        }
+
+        // Sabotage check: removing `.toolCall` from GenerationEvent causes this stream to carry nothing
+        XCTAssertEqual(received.count, 1)
+        XCTAssertEqual(received[0].id, "c1")
+        XCTAssertEqual(received[0].toolName, "fn")
+    }
+
+    func test_generationStream_mixedTokensAndToolCall() async throws {
+        let call = ToolCall(id: "tc-3", toolName: "lookup", arguments: #"{"q":"swift"}"#)
+        let inner = AsyncThrowingStream<GenerationEvent, Error> { continuation in
+            continuation.yield(.token("Result: "))
+            continuation.yield(.toolCall(call))
+            continuation.finish()
+        }
+        let stream = GenerationStream(inner)
+
+        var tokens: [String] = []
+        var toolCalls: [ToolCall] = []
+        for try await event in stream.events {
+            switch event {
+            case .token(let t): tokens.append(t)
+            case .toolCall(let c): toolCalls.append(c)
+            case .usage: break
+            }
+        }
+
+        XCTAssertEqual(tokens, ["Result: "])
+        XCTAssertEqual(toolCalls.count, 1)
+        XCTAssertEqual(toolCalls[0].toolName, "lookup")
+    }
+
+    // MARK: - GenerationStreamConsumer handles toolCall
+
+    func test_streamConsumer_toolCall_returnsDispatchToolCall() {
+        var consumer = GenerationStreamConsumer()
+        let call = ToolCall(id: "sc-1", toolName: "weather", arguments: "{}")
+
+        let action = consumer.handle(.toolCall(call))
+
+        // Sabotage check: returning .appendText("") for .toolCall in handle() causes XCTAssertEqual to fail
+        XCTAssertEqual(action, .dispatchToolCall(call))
+    }
+
+    // MARK: - JSONSchemaValue edge cases
+
+    func test_jsonSchemaValue_null_roundTrips() throws {
+        let encoded = try JSONEncoder().encode(JSONSchemaValue.null)
+        let decoded = try JSONDecoder().decode(JSONSchemaValue.self, from: encoded)
+        XCTAssertEqual(decoded, .null)
+    }
+
+    func test_jsonSchemaValue_number_roundTrips() throws {
+        let encoded = try JSONEncoder().encode(JSONSchemaValue.number(3.14))
+        let decoded = try JSONDecoder().decode(JSONSchemaValue.self, from: encoded)
+        if case .number(let n) = decoded {
+            XCTAssertEqual(n, 3.14, accuracy: 0.001)
+        } else {
+            XCTFail("Expected .number, got \(decoded)")
+        }
+    }
+
+    func test_jsonSchemaValue_array_roundTrips() throws {
+        let value = JSONSchemaValue.array([.string("a"), .bool(true), .null])
+        let encoded = try JSONEncoder().encode(value)
+        let decoded = try JSONDecoder().decode(JSONSchemaValue.self, from: encoded)
+        XCTAssertEqual(decoded, value)
+    }
+}

--- a/Tests/BaseChatInferenceTests/ToolCallContractTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolCallContractTests.swift
@@ -147,6 +147,22 @@ final class ToolCallContractTests: XCTestCase {
         XCTAssertEqual(decoded.toolChoice, .auto)
     }
 
+    func test_generationConfig_decodesLegacyJSON_withoutToolsOrToolChoice() throws {
+        // Payloads serialised before the tools/toolChoice fields were introduced must
+        // decode successfully, falling back to the canonical defaults ([] and .auto).
+        // Sabotage check: using `decode` instead of `decodeIfPresent` in init(from:)
+        // causes a keyNotFound DecodingError here.
+        let legacyJSON = """
+        {"temperature":0.7,"topP":0.9,"repeatPenalty":1.1,"maxTokens":512}
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: legacyJSON)
+
+        XCTAssertEqual(decoded.temperature, 0.7, accuracy: 0.001)
+        XCTAssertTrue(decoded.tools.isEmpty, "Missing 'tools' key must default to []")
+        XCTAssertEqual(decoded.toolChoice, .auto, "Missing 'toolChoice' key must default to .auto")
+    }
+
     // MARK: - MockInferenceBackend emits scripted tool calls
 
     func test_mockBackend_emitsScriptedToolCalls_afterTokens() async throws {


### PR DESCRIPTION
## Summary

Backends that support tool calling now have a shared, vendor-neutral contract in `BaseChatInference`. Apps can describe tools once and wire them to any backend without touching vendor-specific code.

## What changed

**New types** (`Sources/BaseChatInference/Models/ToolTypes.swift`):
- `ToolDefinition` — name, description, `JSONSchemaValue` parameters
- `JSONSchemaValue` — recursive typed enum that models any JSON Schema document; `Sendable`, `Codable`, `Equatable`, `Hashable`
- `ToolCall` — id, toolName, JSON-encoded arguments; emitted by backends
- `ToolResult` — callId, content, isError; returned by the host after execution
- `ToolChoice` — `.auto` / `.none` / `.required` / `.tool(name:)`

**Extended types:**
- `GenerationConfig` — adds `tools: [ToolDefinition]` and `toolChoice: ToolChoice` (both defaulted; all existing call sites unchanged). Also gains `Codable` conformance.
- `GenerationEvent` — adds `.toolCall(ToolCall)` case alongside `.token` and `.usage`
- `GenerationStreamConsumer` — maps `.toolCall` to a new `.dispatchToolCall(ToolCall)` `StreamAction`
- `ChatViewModel+Generation` — handles `.dispatchToolCall` with a no-op (tool execution is a host-app concern)
- `MockInferenceBackend` — adds `scriptedToolCalls: [ToolCall]`; emitted in order after text tokens

**Tests** (`Tests/BaseChatInferenceTests/ToolCallContractTests.swift`): 20 new tests covering `Codable` round-trips for all new types, `MockInferenceBackend` scripted emission, stream event delivery, and `GenerationStreamConsumer` dispatch.

`SilentCatchAuditTest.allowlist` updated with the 4 bound `try?` calls in `JSONSchemaValue.init(from:)` (standard heterogeneous JSON decoder pattern).

## Test plan

- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 765 tests, 0 failures (20 new)
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 196 tests, 0 failures
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 437 tests, 0 failures
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 138 tests, 0 failures

## Release Note

Before this change, BaseChatKit had no shared vocabulary for tool calling — each backend that wanted function-calling support would have needed to define its own types, making cross-backend portability impossible. This PR introduces `ToolDefinition`, `ToolCall`, `ToolResult`, and `ToolChoice` as first-class types in `BaseChatInference`, along with `GenerationConfig.tools` / `toolChoice` and a new `GenerationEvent.toolCall(_:)` stream event. Apps can now describe tools once and route `ToolCall` events from any compliant backend to their own dispatch layer. `MockInferenceBackend.scriptedToolCalls` makes this fully unit-testable without hardware.

Closes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)