### PR TITLE
fix(llama): abort in-progress generation on memory pressure before OS revokes Metal buffers (#415)

### DIFF
--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -149,10 +149,11 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
     /// cleanly before the OS escalates. `stopGeneration()` uses `Atomic<Bool>` and is
     /// safe to call from any thread (PR #456).
     ///
-    /// On `.critical`: calls `stopGeneration()` AND schedules a detached Task to call
+    /// On `.critical`: calls `stopGeneration()` AND schedules a `Task.detached` to call
     /// `unloadAndWait()`, releasing Metal buffers before the OS reclaims them forcibly.
-    /// The Task is detached so the synchronous GCD callback can return quickly. A weak
-    /// capture prevents a retain cycle with the handler's closure storage.
+    /// `Task.detached` is used explicitly so the task does not inherit any actor isolation
+    /// from the GCD callback's execution context, and the GCD callback returns immediately.
+    /// A weak capture prevents a retain cycle with the handler's closure storage.
     private func registerMemoryPressureCallback() {
         memoryPressure.addPressureCallback(for: self) { [weak self] level in
             guard let self else { return }
@@ -163,7 +164,7 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
             case .critical:
                 Self.logger.warning("Memory pressure: critical — stopping generation and scheduling model unload (#415)")
                 self.stopGeneration()
-                Task { [weak self] in
+                Task.detached { [weak self] in
                     await self?.unloadAndWait()
                 }
             case .nominal:

--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -88,6 +88,17 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
     /// Guarded by `stateLock`. Set by `setLoadProgressHandler(_:)` before each load.
     private var _loadProgressHandler: (@Sendable (Double) async -> Void)?
 
+    // MARK: - Memory Pressure
+
+    /// Monitors OS-level memory pressure so the decode loop can be aborted before
+    /// the OS revokes Metal buffers, which would cause llama_decode to dereference
+    /// a freed pointer and crash with SIGSEGV / EXC_BAD_ACCESS. See issue #415.
+    ///
+    /// `LlamaBackend` owns this handler and registers its callback in `init`, so
+    /// pressure events are handled here regardless of whether a `ChatViewModel` or
+    /// any other higher-level observer is also listening.
+    private let memoryPressure = MemoryPressureHandler()
+
     // MARK: - Global Backend Lifecycle
 
     /// Guards `llama_backend_init/free` which are global and must only be
@@ -119,11 +130,46 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
 
     public init() {
         Self.retainBackend()
+        registerMemoryPressureCallback()
+        memoryPressure.startMonitoring()
     }
 
     deinit {
+        memoryPressure.removeCallback(for: self)
+        memoryPressure.stopMonitoring()
         unloadModel()
         Self.releaseBackend()
+    }
+
+    // MARK: - Memory Pressure Wiring
+
+    /// Registers the backend-level memory pressure callback.
+    ///
+    /// On `.warning`: calls `stopGeneration()` immediately so the decode loop exits
+    /// cleanly before the OS escalates. `stopGeneration()` uses `Atomic<Bool>` and is
+    /// safe to call from any thread (PR #456).
+    ///
+    /// On `.critical`: calls `stopGeneration()` AND schedules a detached Task to call
+    /// `unloadAndWait()`, releasing Metal buffers before the OS reclaims them forcibly.
+    /// The Task is detached so the synchronous GCD callback can return quickly. A weak
+    /// capture prevents a retain cycle with the handler's closure storage.
+    private func registerMemoryPressureCallback() {
+        memoryPressure.addPressureCallback(for: self) { [weak self] level in
+            guard let self else { return }
+            switch level {
+            case .warning:
+                Self.logger.warning("Memory pressure: warning — stopping generation to prevent Metal buffer revocation (#415)")
+                self.stopGeneration()
+            case .critical:
+                Self.logger.warning("Memory pressure: critical — stopping generation and scheduling model unload (#415)")
+                self.stopGeneration()
+                Task { [weak self] in
+                    await self?.unloadAndWait()
+                }
+            case .nominal:
+                break
+            }
+        }
     }
 
     // MARK: - Model Lifecycle

--- a/Sources/BaseChatInference/Services/MemoryPressureHandler.swift
+++ b/Sources/BaseChatInference/Services/MemoryPressureHandler.swift
@@ -151,7 +151,13 @@ package final class MemoryPressureHandler: @unchecked Sendable {
 
     // MARK: - Private
 
-    private func fireCallbacks(level: MemoryPressureLevel) {
+    /// Fires all registered callbacks with `level`.
+    ///
+    /// Package-internal so tests can simulate a pressure event without relying on a
+    /// real OS `DispatchSource` firing. Takes a snapshot under the lock so callbacks
+    /// run outside the critical section, allowing re-entrant `addPressureCallback` /
+    /// `removeCallback` calls from within a callback.
+    package func fireCallbacks(level: MemoryPressureLevel) {
         // Take a snapshot under the lock so callbacks run outside it.
         callbackLock.lock()
         let snapshot = _callbacks.values.map { $0 }

--- a/Sources/BaseChatInference/Services/MemoryPressureHandler.swift
+++ b/Sources/BaseChatInference/Services/MemoryPressureHandler.swift
@@ -18,6 +18,14 @@ public enum MemoryPressureLevel: String, Sendable {
 /// can react (pause generation on `.warning`, unload the model on `.critical`).
 ///
 /// Uses `DispatchSource.makeMemoryPressureSource`, which works identically on iOS and macOS.
+///
+/// In addition to the `@Observable` `pressureLevel` property (for SwiftUI / MainActor
+/// consumers), backends can register a callback via `addPressureCallback(_:)` that
+/// fires **synchronously on the GCD dispatch queue** before the MainActor hop. This
+/// lets `LlamaBackend` call `stopGeneration()` — an atomic, thread-safe operation —
+/// immediately when pressure is detected, rather than waiting for the next run-loop
+/// cycle. The callback fires from an arbitrary thread; callers must not perform
+/// blocking work inside it.
 @Observable
 package final class MemoryPressureHandler: @unchecked Sendable {
 
@@ -36,6 +44,11 @@ package final class MemoryPressureHandler: @unchecked Sendable {
         label: BaseChatConfiguration.shared.memoryPressureQueueLabel,
         qos: .utility
     )
+
+    /// Guards `_callbacks` from concurrent mutation.
+    private let callbackLock = NSLock()
+    /// Registered callbacks keyed by opaque token. Callbacks fire on `queue`.
+    private var _callbacks: [ObjectIdentifier: @Sendable (MemoryPressureLevel) -> Void] = [:]
 
     // MARK: - Lifecycle
 
@@ -73,6 +86,11 @@ package final class MemoryPressureHandler: @unchecked Sendable {
                 level = .nominal
             }
 
+            // Fire registered callbacks synchronously on this queue before the
+            // MainActor hop. This lets backends (e.g. LlamaBackend) abort the
+            // decode loop immediately, before the OS can escalate further.
+            self.fireCallbacks(level: level)
+
             // Update on main actor so SwiftUI observation triggers correctly.
             Task { @MainActor in
                 self.pressureLevel = level
@@ -97,5 +115,49 @@ package final class MemoryPressureHandler: @unchecked Sendable {
     package func stopMonitoring() {
         source?.cancel()
         source = nil
+    }
+
+    // MARK: - Callback Registration
+
+    /// Registers a callback to be invoked synchronously on the pressure dispatch queue
+    /// whenever the pressure level changes.
+    ///
+    /// The callback fires **before** the `@MainActor` `pressureLevel` update — use
+    /// this when latency matters (e.g., stopping the llama.cpp decode loop before the
+    /// OS can revoke Metal buffers).
+    ///
+    /// - Parameters:
+    ///   - owner: An object whose lifetime gates the callback. Pass `self` from the
+    ///     registering type and use `removeCallback(for:)` in that type's `deinit`.
+    ///   - callback: A `@Sendable` closure that receives the new pressure level.
+    ///     Must not perform blocking work — it runs on a utility GCD queue.
+    package func addPressureCallback(
+        for owner: AnyObject,
+        _ callback: @escaping @Sendable (MemoryPressureLevel) -> Void
+    ) {
+        callbackLock.lock()
+        defer { callbackLock.unlock() }
+        _callbacks[ObjectIdentifier(owner)] = callback
+    }
+
+    /// Removes the callback previously registered for `owner`.
+    ///
+    /// Safe to call from `deinit` — no-op if no callback was registered.
+    package func removeCallback(for owner: AnyObject) {
+        callbackLock.lock()
+        defer { callbackLock.unlock() }
+        _callbacks.removeValue(forKey: ObjectIdentifier(owner))
+    }
+
+    // MARK: - Private
+
+    private func fireCallbacks(level: MemoryPressureLevel) {
+        // Take a snapshot under the lock so callbacks run outside it.
+        callbackLock.lock()
+        let snapshot = _callbacks.values.map { $0 }
+        callbackLock.unlock()
+        for callback in snapshot {
+            callback(level)
+        }
     }
 }

--- a/Tests/BaseChatBackendsTests/LlamaBackendMemoryPressureTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaBackendMemoryPressureTests.swift
@@ -1,0 +1,180 @@
+#if Llama
+import XCTest
+@testable import BaseChatInference
+@testable import BaseChatBackends
+import BaseChatTestSupport
+
+// MARK: - Hardware-gated tests
+
+/// Tests for LlamaBackend's memory pressure abort wiring (issue #415).
+///
+/// `LlamaBackend` owns a private `MemoryPressureHandler` and registers a callback
+/// in `init` that calls `stopGeneration()` on `.warning` and `stopGeneration()` +
+/// `unloadAndWait()` on `.critical`. Because the handler and its callback are
+/// private, these tests exercise the same *operations* the callback performs,
+/// verifying they are safe to call from a background GCD queue (the thread model
+/// the `DispatchSource` callback uses on a real device).
+///
+/// All tests skip in the simulator and on non-Apple-Silicon hosts, where
+/// `llama_backend_init` (invoked by `LlamaBackend.init`) requires Metal.
+final class LlamaBackendMemoryPressureTests: XCTestCase {
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try XCTSkipUnless(HardwareRequirements.isPhysicalDevice,
+            "LlamaBackend requires Metal (unavailable in simulator)")
+        try XCTSkipUnless(HardwareRequirements.isAppleSilicon,
+            "LlamaBackend requires Apple Silicon")
+    }
+
+    // MARK: - stopGeneration() is safe from a GCD utility queue
+
+    /// The memory pressure callback fires on a GCD utility queue.
+    /// `stopGeneration()` must not crash when called from that context on an
+    /// idle (unloaded) backend — the same state LlamaBackend is in at app
+    /// launch before the user picks a model.
+    ///
+    /// Sabotage check: replacing `Atomic<Bool>` with a plain `var Bool` in
+    /// LlamaBackend would produce a TSan data-race violation here when multiple
+    /// concurrent queues call `stopGeneration()` simultaneously.
+    func test_stopGeneration_fromGCDQueue_doesNotCrash() async {
+        let backend = LlamaBackend()
+
+        // Fire stopGeneration() concurrently from 20 GCD utility threads,
+        // matching the kind of concurrent access a real pressure callback
+        // could produce if multiple watchdog sources fired simultaneously.
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<20 {
+                group.addTask {
+                    await withCheckedContinuation { continuation in
+                        DispatchQueue.global(qos: .utility).async {
+                            backend.stopGeneration()
+                            continuation.resume()
+                        }
+                    }
+                }
+            }
+        }
+
+        XCTAssertFalse(backend.isGenerating,
+            "isGenerating must remain false after concurrent GCD-queue stopGeneration() calls")
+    }
+
+    // MARK: - unloadAndWait() is safe from a detached Task
+
+    /// On `.critical` pressure the callback spawns:
+    ///   `Task { [weak self] in await self?.unloadAndWait() }`
+    /// Verify that `unloadAndWait()` called from a detached Task on an unloaded
+    /// backend completes without crashing and leaves the backend clean.
+    ///
+    /// Sabotage check: if `unloadAndWait()` were not safe to call from a
+    /// non-MainActor context this test would fail with a concurrency violation.
+    func test_unloadAndWait_fromDetachedTask_isIdempotentAndSafe() async {
+        let backend = LlamaBackend()
+
+        // Replicate exactly what the critical-pressure arm does.
+        let task = Task.detached { [weak backend] in
+            await backend?.unloadAndWait()
+        }
+        await task.value
+
+        XCTAssertFalse(backend.isModelLoaded,
+            "isModelLoaded must be false after unloadAndWait() from a detached task")
+        XCTAssertFalse(backend.isGenerating,
+            "isGenerating must be false after unloadAndWait() from a detached task")
+    }
+
+    // MARK: - Callback registration does not cause a retain cycle
+
+    /// `registerMemoryPressureCallback()` captures `self` weakly. If the capture
+    /// were strong, the `MemoryPressureHandler` closure would keep `LlamaBackend`
+    /// alive past its last external reference, causing a leak.
+    ///
+    /// We verify this by releasing the backend and confirming no crash occurs.
+    /// A retain cycle would keep `backend` alive, and `deinit` would not call
+    /// `memoryPressure.removeCallback(for:)`, leaving a dangling AnyObject key.
+    /// The absence of EXC_BAD_ACCESS confirms the weak capture is in effect.
+    func test_deinit_removesCallbackWithoutCrash() {
+        var backend: LlamaBackend? = LlamaBackend()
+        // Force release — if a retain cycle existed, deinit would not run here.
+        withExtendedLifetime(backend) {}
+        backend = nil
+        // If we reach this line, deinit ran and the callback was safely removed.
+        XCTAssert(true, "LlamaBackend deinit must not crash when cleaning up the memory pressure callback")
+    }
+}
+
+// MARK: - Hardware-free: MemoryPressureHandler callback API
+
+/// Exercises the `addPressureCallback` / `removeCallback` API added to
+/// `MemoryPressureHandler` in support of issue #415.
+///
+/// These tests do not instantiate `LlamaBackend` and run without special hardware.
+final class MemoryPressureCallbackAPITests: XCTestCase {
+
+    // MARK: - Registration and removal
+
+    func test_addPressureCallback_replacesExistingEntryForSameOwner() {
+        let handler = MemoryPressureHandler()
+        let owner = NSObject()
+        var callCount = 0
+
+        handler.addPressureCallback(for: owner) { _ in callCount += 1 }
+        // Registering again for the same owner replaces the previous entry.
+        handler.addPressureCallback(for: owner) { _ in callCount += 10 }
+
+        // Verify no crash and the table updated correctly.
+        handler.removeCallback(for: owner)
+        // callCount is still 0 — no real DispatchSource has fired.
+        XCTAssertEqual(callCount, 0,
+            "No callback should have fired — DispatchSource has not received an OS event")
+    }
+
+    func test_removeCallback_forUnregisteredOwner_isNoOp() {
+        let handler = MemoryPressureHandler()
+        let owner = NSObject()
+
+        // Remove before registering — must be a no-op.
+        handler.removeCallback(for: owner)
+        handler.removeCallback(for: owner)
+        // No crash = pass.
+    }
+
+    func test_removeCallback_afterRegistration_isIdempotent() {
+        let handler = MemoryPressureHandler()
+        let owner = NSObject()
+
+        handler.addPressureCallback(for: owner) { _ in }
+        handler.removeCallback(for: owner)
+        // Second remove must be a no-op.
+        handler.removeCallback(for: owner)
+        // No crash = pass.
+    }
+
+    func test_multipleOwners_independentCallbacks() {
+        let handler = MemoryPressureHandler()
+        let owner1 = NSObject()
+        let owner2 = NSObject()
+
+        handler.addPressureCallback(for: owner1) { _ in }
+        handler.addPressureCallback(for: owner2) { _ in }
+
+        // Remove one; the other must still be present (no crash on re-removal).
+        handler.removeCallback(for: owner1)
+        // If owner2's callback were also removed, re-adding for owner2 would
+        // be a brand-new insert rather than a no-op — we can't distinguish
+        // from outside, but we confirm no crash on the whole sequence.
+        handler.removeCallback(for: owner2)
+    }
+
+    // MARK: - Lifecycle: deinit of handler while callbacks are registered
+
+    func test_handlerDeinit_withRegisteredCallbacks_doesNotCrash() {
+        let owner = NSObject()
+        var handler: MemoryPressureHandler? = MemoryPressureHandler()
+        handler?.addPressureCallback(for: owner) { _ in }
+        handler = nil
+        // If we reach here, the handler released its callback table cleanly.
+    }
+}
+#endif

--- a/Tests/BaseChatBackendsTests/LlamaBackendMemoryPressureTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaBackendMemoryPressureTests.swift
@@ -1,6 +1,172 @@
-#if Llama
 import XCTest
 @testable import BaseChatInference
+
+// MARK: - Thread-safe counter for @Sendable callback closures
+
+/// A minimal thread-safe integer counter for use inside `@Sendable` closures.
+///
+/// `@Sendable` closures cannot mutate captured `var` locals. This wrapper is
+/// `@unchecked Sendable` because the counter is protected by the `NSLock`, but
+/// Swift's type system cannot verify that automatically.
+private final class SendableCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func increment(by n: Int = 1) {
+        lock.lock()
+        defer { lock.unlock() }
+        value += n
+    }
+
+    var current: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
+
+// MARK: - Hardware-free: MemoryPressureHandler callback API
+
+/// Exercises the `addPressureCallback` / `removeCallback` / `fireCallbacks` API
+/// added to `MemoryPressureHandler` in support of issue #415.
+///
+/// These tests do not instantiate `LlamaBackend` and run without special hardware.
+/// The `#if Llama` guard is intentionally absent — these tests run in CI to give
+/// continuous coverage of the callback machinery that `LlamaBackend` relies on
+/// for memory pressure abort.
+final class MemoryPressureCallbackAPITests: XCTestCase {
+
+    // MARK: - Registration and removal
+
+    func test_addPressureCallback_replacesExistingEntryForSameOwner() {
+        let handler = MemoryPressureHandler()
+        let owner = NSObject()
+        let callCount = SendableCounter()
+
+        handler.addPressureCallback(for: owner) { _ in callCount.increment(by: 1) }
+        // Registering again for the same owner replaces the previous entry.
+        handler.addPressureCallback(for: owner) { _ in callCount.increment(by: 10) }
+
+        // Verify no crash and the table updated correctly.
+        handler.removeCallback(for: owner)
+        // callCount is still 0 — no real DispatchSource has fired.
+        XCTAssertEqual(callCount.current, 0,
+            "No callback should have fired — DispatchSource has not received an OS event")
+    }
+
+    func test_removeCallback_forUnregisteredOwner_isNoOp() {
+        let handler = MemoryPressureHandler()
+        let owner = NSObject()
+
+        // Remove before registering — must be a no-op.
+        handler.removeCallback(for: owner)
+        handler.removeCallback(for: owner)
+        // No crash = pass.
+    }
+
+    func test_removeCallback_afterRegistration_isIdempotent() {
+        let handler = MemoryPressureHandler()
+        let owner = NSObject()
+
+        handler.addPressureCallback(for: owner) { _ in }
+        handler.removeCallback(for: owner)
+        // Second remove must be a no-op.
+        handler.removeCallback(for: owner)
+        // No crash = pass.
+    }
+
+    func test_multipleOwners_independentCallbacks() {
+        let handler = MemoryPressureHandler()
+        let owner1 = NSObject()
+        let owner2 = NSObject()
+
+        handler.addPressureCallback(for: owner1) { _ in }
+        handler.addPressureCallback(for: owner2) { _ in }
+
+        // Remove one; the other must still be present (no crash on re-removal).
+        handler.removeCallback(for: owner1)
+        handler.removeCallback(for: owner2)
+    }
+
+    // MARK: - Lifecycle: deinit of handler while callbacks are registered
+
+    func test_handlerDeinit_withRegisteredCallbacks_doesNotCrash() {
+        let owner = NSObject()
+        var handler: MemoryPressureHandler? = MemoryPressureHandler()
+        handler?.addPressureCallback(for: owner) { _ in }
+        handler = nil
+        // If we reach here, the handler released its callback table cleanly.
+    }
+
+    // MARK: - Callback firing via fireCallbacks
+
+    /// Verifies that `fireCallbacks` actually invokes registered callbacks and
+    /// delivers the correct level. This exercises the same synchronous dispatch path
+    /// the DispatchSource event handler uses when the OS sends a pressure event.
+    ///
+    /// Sabotage check: comment out `self.fireCallbacks(level: level)` in
+    /// `startMonitoring`'s event handler — the production wiring stops working,
+    /// but this test (which calls `fireCallbacks` directly) still catches regressions
+    /// in the dispatch logic itself.
+    func test_fireCallbacks_invokesRegisteredCallbackWithCorrectLevel() {
+        let handler = MemoryPressureHandler()
+        let owner = NSObject()
+
+        // Use a class box so the @Sendable closure can mutate the array.
+        // fireCallbacks is always called synchronously on one thread in these tests,
+        // so no actual concurrent access occurs — the wrapper satisfies the
+        // @Sendable requirement at the type-system level.
+        final class LevelBox: @unchecked Sendable { var levels: [MemoryPressureLevel] = [] }
+        let box = LevelBox()
+
+        handler.addPressureCallback(for: owner) { level in box.levels.append(level) }
+
+        handler.fireCallbacks(level: .warning)
+        handler.fireCallbacks(level: .critical)
+        handler.fireCallbacks(level: .nominal)
+
+        // fireCallbacks runs synchronously; no async coordination needed.
+        XCTAssertEqual(box.levels, [.warning, .critical, .nominal],
+            "fireCallbacks must invoke the registered callback once per call, in order")
+    }
+
+    /// Verifies that after `removeCallback`, subsequent `fireCallbacks` calls do
+    /// not invoke the removed callback. This guards against a stale closure firing
+    /// after `LlamaBackend` has been deallocated.
+    func test_fireCallbacks_afterRemove_doesNotInvokeCallback() {
+        let handler = MemoryPressureHandler()
+        let owner = NSObject()
+        let callCount = SendableCounter()
+
+        handler.addPressureCallback(for: owner) { _ in callCount.increment() }
+        handler.removeCallback(for: owner)
+
+        handler.fireCallbacks(level: .critical)
+
+        XCTAssertEqual(callCount.current, 0, "Callback must not fire after removeCallback")
+    }
+
+    /// Verifies that removing one owner does not suppress other registered callbacks —
+    /// each `ObjectIdentifier` key is independent.
+    func test_fireCallbacks_removingOneOwner_preservesOtherCallbacks() {
+        let handler = MemoryPressureHandler()
+        let owner1 = NSObject()
+        let owner2 = NSObject()
+        let count1 = SendableCounter()
+        let count2 = SendableCounter()
+
+        handler.addPressureCallback(for: owner1) { _ in count1.increment() }
+        handler.addPressureCallback(for: owner2) { _ in count2.increment() }
+
+        handler.removeCallback(for: owner1)
+        handler.fireCallbacks(level: .warning)
+
+        XCTAssertEqual(count1.current, 0, "Removed owner1 callback must not fire")
+        XCTAssertEqual(count2.current, 1, "owner2 callback must still fire after owner1 is removed")
+    }
+}
+
+#if Llama
 @testable import BaseChatBackends
 import BaseChatTestSupport
 
@@ -63,7 +229,7 @@ final class LlamaBackendMemoryPressureTests: XCTestCase {
     // MARK: - unloadAndWait() is safe from a detached Task
 
     /// On `.critical` pressure the callback spawns:
-    ///   `Task { [weak self] in await self?.unloadAndWait() }`
+    ///   `Task.detached { [weak self] in await self?.unloadAndWait() }`
     /// Verify that `unloadAndWait()` called from a detached Task on an unloaded
     /// backend completes without crashing and leaves the backend clean.
     ///
@@ -101,80 +267,6 @@ final class LlamaBackendMemoryPressureTests: XCTestCase {
         backend = nil
         // If we reach this line, deinit ran and the callback was safely removed.
         XCTAssert(true, "LlamaBackend deinit must not crash when cleaning up the memory pressure callback")
-    }
-}
-
-// MARK: - Hardware-free: MemoryPressureHandler callback API
-
-/// Exercises the `addPressureCallback` / `removeCallback` API added to
-/// `MemoryPressureHandler` in support of issue #415.
-///
-/// These tests do not instantiate `LlamaBackend` and run without special hardware.
-final class MemoryPressureCallbackAPITests: XCTestCase {
-
-    // MARK: - Registration and removal
-
-    func test_addPressureCallback_replacesExistingEntryForSameOwner() {
-        let handler = MemoryPressureHandler()
-        let owner = NSObject()
-        var callCount = 0
-
-        handler.addPressureCallback(for: owner) { _ in callCount += 1 }
-        // Registering again for the same owner replaces the previous entry.
-        handler.addPressureCallback(for: owner) { _ in callCount += 10 }
-
-        // Verify no crash and the table updated correctly.
-        handler.removeCallback(for: owner)
-        // callCount is still 0 — no real DispatchSource has fired.
-        XCTAssertEqual(callCount, 0,
-            "No callback should have fired — DispatchSource has not received an OS event")
-    }
-
-    func test_removeCallback_forUnregisteredOwner_isNoOp() {
-        let handler = MemoryPressureHandler()
-        let owner = NSObject()
-
-        // Remove before registering — must be a no-op.
-        handler.removeCallback(for: owner)
-        handler.removeCallback(for: owner)
-        // No crash = pass.
-    }
-
-    func test_removeCallback_afterRegistration_isIdempotent() {
-        let handler = MemoryPressureHandler()
-        let owner = NSObject()
-
-        handler.addPressureCallback(for: owner) { _ in }
-        handler.removeCallback(for: owner)
-        // Second remove must be a no-op.
-        handler.removeCallback(for: owner)
-        // No crash = pass.
-    }
-
-    func test_multipleOwners_independentCallbacks() {
-        let handler = MemoryPressureHandler()
-        let owner1 = NSObject()
-        let owner2 = NSObject()
-
-        handler.addPressureCallback(for: owner1) { _ in }
-        handler.addPressureCallback(for: owner2) { _ in }
-
-        // Remove one; the other must still be present (no crash on re-removal).
-        handler.removeCallback(for: owner1)
-        // If owner2's callback were also removed, re-adding for owner2 would
-        // be a brand-new insert rather than a no-op — we can't distinguish
-        // from outside, but we confirm no crash on the whole sequence.
-        handler.removeCallback(for: owner2)
-    }
-
-    // MARK: - Lifecycle: deinit of handler while callbacks are registered
-
-    func test_handlerDeinit_withRegisteredCallbacks_doesNotCrash() {
-        let owner = NSObject()
-        var handler: MemoryPressureHandler? = MemoryPressureHandler()
-        handler?.addPressureCallback(for: owner) { _ in }
-        handler = nil
-        // If we reach here, the handler released its callback table cleanly.
     }
 }
 #endif


### PR DESCRIPTION
## Summary

- iOS can revoke Metal buffers mid-generation when memory peaks, causing the next `llama_decode` call to dereference a freed pointer and crash with SIGSEGV / EXC_BAD_ACCESS. This PR intercepts pressure events before the OS escalates, stopping the decode loop cleanly.
- Extends `MemoryPressureHandler` with a synchronous callback registration API (`addPressureCallback(for:_:)` / `removeCallback(for:)`) that fires on the GCD utility queue **before** the `@MainActor` property update — giving the earliest possible signal to native backends.
- `LlamaBackend` now owns a private `MemoryPressureHandler`, registers its callback in `init`, and cleans up in `deinit`. On `.warning` it calls `stopGeneration()` (thread-safe via `Atomic<Bool>` after PR #456); on `.critical` it calls `stopGeneration()` and spawns `Task { [weak self] in await self?.unloadAndWait() }` to free Metal buffers before the OS reclaims them forcibly.

## Test plan

- [ ] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 88 tests, 0 failures
- [ ] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 69 tests, 0 failures
- [ ] `swift test --filter BaseChatCoreTests --disable-default-traits` — 196 tests, 0 failures
- [ ] `swift test --filter BaseChatUITests --disable-default-traits` — 437 tests, 0 failures
- [ ] New `LlamaBackendMemoryPressureTests` (hardware-gated) verify `stopGeneration()` and `unloadAndWait()` are safe from GCD queues and detached Tasks
- [ ] New `MemoryPressureCallbackAPITests` (hardware-free) verify the callback registration / removal lifecycle

## Release Note

**Memory pressure abort in LlamaBackend** — iOS was crashing with SIGSEGV / EXC_BAD_ACCESS when the OS revoked Metal buffers mid-generation, because `llama_decode` then dereferenced a freed pointer. `LlamaBackend` now monitors OS memory pressure directly: on `.warning` it stops the decode loop cleanly; on `.critical` it stops generation and unloads the model before the OS reclaims buffers forcibly. The wiring uses an extended `MemoryPressureHandler` callback API that fires synchronously on the GCD pressure queue — earlier than the existing `@MainActor` UI path — so the C decode loop exits before any buffer revocation can occur.

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)