### PR TITLE
fix(llama): guard against context overflow in long multi-turn sessions (#417)

### DIFF
--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -752,4 +752,30 @@ extension LlamaBackend: TokenizerVendor, TokenizerProvider {
         return tokens.isEmpty ? max(1, text.count / 4) : tokens.count
     }
 }
+
+// MARK: - TokenCountingBackend
+
+extension LlamaBackend: TokenCountingBackend {
+    /// Returns the exact token count for `text` using the loaded model's vocabulary.
+    ///
+    /// This calls `llama_tokenize` directly — a pure vocabulary lookup with no
+    /// context state involved. Safe to call from any thread while the model is loaded.
+    ///
+    /// - Throws: ``InferenceError/inferenceFailure(_:)`` when the model is not loaded
+    ///   or when `llama_tokenize` returns a negative value (buffer sizing failure).
+    /// - Note: Call only after a successful `loadModel`. The model pointer is guarded
+    ///   under `stateLock` to prevent a use-after-free race with `unloadModel()`.
+    public func countTokens(_ text: String) throws -> Int {
+        // Read vocab under stateLock to avoid a use-after-free race with unloadModel().
+        let currentVocab = withStateLock { vocab }
+        guard currentVocab != nil else {
+            throw InferenceError.inferenceFailure("countTokens called before model was loaded")
+        }
+        let tokens = tokenize(text, addBos: true)
+        guard !tokens.isEmpty || text.isEmpty else {
+            throw InferenceError.inferenceFailure("countTokens: llama_tokenize failed for text of length \(text.utf8.count)")
+        }
+        return tokens.count
+    }
+}
 #endif

--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -766,16 +766,23 @@ extension LlamaBackend: TokenCountingBackend {
     /// - Note: Call only after a successful `loadModel`. The model pointer is guarded
     ///   under `stateLock` to prevent a use-after-free race with `unloadModel()`.
     public func countTokens(_ text: String) throws -> Int {
-        // Read vocab under stateLock to avoid a use-after-free race with unloadModel().
-        let currentVocab = withStateLock { vocab }
-        guard currentVocab != nil else {
+        // Snapshot the vocab pointer under stateLock and use it directly for
+        // llama_tokenize. Without this snapshot, calling tokenize() outside the
+        // lock would re-read `self.vocab` and race with unloadModel() setting it
+        // to nil and freeing the backing model — a use-after-free crash.
+        // Holding the lock only for the snapshot (not the whole C call) keeps
+        // `unloadModel()` responsive while still preventing the race.
+        guard let currentVocab = withStateLock({ vocab }) else {
             throw InferenceError.inferenceFailure("countTokens called before model was loaded")
         }
-        let tokens = tokenize(text, addBos: true)
-        guard !tokens.isEmpty || text.isEmpty else {
+        let utf8 = text.utf8CString
+        let maxTokens = Int32(utf8.count) + 1  // +1 for BOS
+        var tokens = [llama_token](repeating: 0, count: Int(maxTokens))
+        let count = llama_tokenize(currentVocab, text, Int32(text.utf8.count), &tokens, maxTokens, true, false)
+        guard count >= 0 || text.isEmpty else {
             throw InferenceError.inferenceFailure("countTokens: llama_tokenize failed for text of length \(text.utf8.count)")
         }
-        return tokens.count
+        return text.isEmpty ? 0 : Int(count)
     }
 }
 #endif

--- a/Sources/BaseChatInference/Models/ChatError.swift
+++ b/Sources/BaseChatInference/Models/ChatError.swift
@@ -61,6 +61,10 @@ public struct ChatError: Identifiable, Sendable {
                 switch inference {
                 case .modelNotFound, .memoryInsufficient:
                     recovery = .selectModel
+                case .contextExhausted:
+                    // The conversation exceeds the model's context window.
+                    // Prompt the user to switch to a model with a larger context.
+                    recovery = .selectModel
                 default:
                     recovery = .dismissOnly
                 }

--- a/Sources/BaseChatInference/Protocols/BackendOptInProtocols.swift
+++ b/Sources/BaseChatInference/Protocols/BackendOptInProtocols.swift
@@ -44,3 +44,21 @@ public protocol LoadProgressReporting: AnyObject {
     /// should retain the handler only for the duration of the active load.
     func setLoadProgressHandler(_ handler: (@Sendable (Double) async -> Void)?)
 }
+
+/// Adopted by local backends that can count tokens exactly using their loaded vocabulary.
+///
+/// Non-local backends (cloud, Ollama) should not conform — they have no
+/// local tokenizer. `GenerationCoordinator` gates the exact pre-flight
+/// check on this protocol so the trim-and-retry path only activates for
+/// backends where KV cache overflow is a real concern.
+///
+/// - Note: `countTokens` must only be called after the model is loaded.
+///   Implementations throw ``InferenceError/modelNotLoaded`` when invoked
+///   on an unloaded backend.
+public protocol TokenCountingBackend: AnyObject {
+    /// Returns the exact token count for `text` using the loaded model's vocabulary.
+    ///
+    /// - Throws: ``InferenceError/inferenceFailure(_:)`` if the model is not loaded,
+    ///   or if tokenization fails (e.g., vocabulary is unavailable).
+    func countTokens(_ text: String) throws -> Int
+}

--- a/Sources/BaseChatInference/Services/GenerationCoordinator.swift
+++ b/Sources/BaseChatInference/Services/GenerationCoordinator.swift
@@ -73,6 +73,14 @@ final class GenerationCoordinator {
     ///
     /// This is the low-level, non-queued entry point. It does **not** participate
     /// in the generation queue.
+    ///
+    /// When the backend conforms to ``TokenCountingBackend``, an exact token count
+    /// of the assembled prompt is taken before the C-level call. If the prompt
+    /// exceeds `effectiveContextSize - maxOutputTokens`, the oldest non-system
+    /// messages are trimmed one pair at a time and the prompt is re-assembled,
+    /// up to `maxTrimAttempts` times. If the prompt still doesn't fit after
+    /// trimming, ``InferenceError/contextExhausted(promptTokens:maxOutputTokens:contextSize:)``
+    /// is thrown — the overflow never reaches the C layer.
     func generate(
         messages: [(role: String, content: String)],
         systemPrompt: String? = nil,
@@ -92,18 +100,46 @@ final class GenerationCoordinator {
             maxOutputTokens: maxOutputTokens
         )
 
-        let prompt: String
+        // Exact-count pre-flight: backends that conform to TokenCountingBackend
+        // expose the real tokenizer. Use it to verify the assembled prompt fits
+        // inside the context window before committing to the C-level decode.
+        // The heuristic guard inside LlamaBackend.generate() remains as a
+        // fast-path sanity check for obviously-too-large prompts, but this
+        // trim-and-retry loop is the definitive gate that prevents KV overflow.
+        if let counter = backend as? TokenCountingBackend,
+           backend.capabilities.requiresPromptTemplate {
+            let result = try exactPreflightAndTrim(
+                counter: counter,
+                backend: backend,
+                messages: messages,
+                systemPrompt: systemPrompt,
+                config: config
+            )
+            if let historyReceiver = backend as? ConversationHistoryReceiver {
+                // Pass the trimmed messages so the backend's own history buffer
+                // reflects what was actually sent in the prompt.
+                historyReceiver.setConversationHistory(result.trimmedMessages)
+            }
+            return try backend.generate(
+                prompt: result.prompt,
+                systemPrompt: nil,
+                config: config
+            )
+        }
+
+        // Non-TokenCountingBackend path: assemble prompt and forward.
+        // For backends that require a prompt template, messages are formatted
+        // into a single string. Otherwise the most recent user message is
+        // passed directly and the system prompt goes through a separate channel.
+        let assembledPrompt: String
         let effectiveSystemPrompt: String?
 
         if backend.capabilities.requiresPromptTemplate {
             let template = provider?.selectedPromptTemplate ?? .chatML
-            prompt = template.format(
-                messages: messages,
-                systemPrompt: systemPrompt
-            )
+            assembledPrompt = template.format(messages: messages, systemPrompt: systemPrompt)
             effectiveSystemPrompt = nil
         } else {
-            prompt = messages.last(where: { $0.role == "user" })?.content ?? ""
+            assembledPrompt = messages.last(where: { $0.role == "user" })?.content ?? ""
             effectiveSystemPrompt = systemPrompt
         }
 
@@ -112,10 +148,91 @@ final class GenerationCoordinator {
         }
 
         return try backend.generate(
-            prompt: prompt,
+            prompt: assembledPrompt,
             systemPrompt: effectiveSystemPrompt,
             config: config
         )
+    }
+
+    // MARK: - Exact Pre-flight (Private)
+
+    private struct ExactPreflightResult {
+        let prompt: String
+        let trimmedMessages: [(role: String, content: String)]
+    }
+
+    /// Counts tokens on the assembled prompt and trims the oldest non-system
+    /// messages until the prompt fits inside the context window.
+    ///
+    /// Up to `maxTrimAttempts` trimming rounds are performed. Each round drops
+    /// one non-system message from the front of the history. If the budget is
+    /// still exceeded after all attempts, throws
+    /// ``InferenceError/contextExhausted(promptTokens:maxOutputTokens:contextSize:)``.
+    private func exactPreflightAndTrim(
+        counter: TokenCountingBackend,
+        backend: InferenceBackend,
+        messages: [(role: String, content: String)],
+        systemPrompt: String?,
+        config: GenerationConfig,
+        maxTrimAttempts: Int = 20
+    ) throws -> ExactPreflightResult {
+        let contextSize = Int(backend.capabilities.maxContextTokens)
+        let maxOutput = config.maxOutputTokens ?? 2048
+        let template = provider?.selectedPromptTemplate ?? .chatML
+
+        var workingMessages = messages
+        var attempt = 0
+
+        while true {
+            let prompt = template.format(messages: workingMessages, systemPrompt: systemPrompt)
+            let promptTokens = try counter.countTokens(prompt)
+
+            if promptTokens + maxOutput <= contextSize {
+                // Fits — return the (possibly trimmed) result.
+                return ExactPreflightResult(prompt: prompt, trimmedMessages: workingMessages)
+            }
+
+            // Over budget. If we've used all trim rounds, surface the error before
+            // anything reaches the C layer.
+            guard attempt < maxTrimAttempts else {
+                throw InferenceError.contextExhausted(
+                    promptTokens: promptTokens,
+                    maxOutputTokens: maxOutput,
+                    contextSize: contextSize
+                )
+            }
+
+            // Find the oldest non-system message to drop. System messages are
+            // passed in the `systemPrompt` parameter, not as tuples, so any
+            // "system"-role tuple here is a slot injected by PromptAssembler.
+            // We trim those too — keeping only the final user turn is better
+            // than overflowing the KV cache.
+            guard let dropIndex = workingMessages.firstIndex(where: { $0.role != "system" }) else {
+                // Only system messages remain — nothing left to trim.
+                throw InferenceError.contextExhausted(
+                    promptTokens: promptTokens,
+                    maxOutputTokens: maxOutput,
+                    contextSize: contextSize
+                )
+            }
+
+            // Always protect the last user message: if dropping it would leave
+            // no user turn, stop trimming and surface the error.
+            let userCount = workingMessages.filter { $0.role == "user" }.count
+            if userCount <= 1 && workingMessages[dropIndex].role == "user" {
+                throw InferenceError.contextExhausted(
+                    promptTokens: promptTokens,
+                    maxOutputTokens: maxOutput,
+                    contextSize: contextSize
+                )
+            }
+
+            Log.inference.warning(
+                "GenerationCoordinator: prompt over budget — trimming oldest non-system message (attempt \(attempt + 1)/\(maxTrimAttempts))"
+            )
+            workingMessages.remove(at: dropIndex)
+            attempt += 1
+        }
     }
 
     // MARK: - Generation Queue

--- a/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
@@ -458,6 +458,70 @@ final class LlamaBackendTests: XCTestCase {
         XCTAssertLessThan(short, long, "Longer text should produce a higher token count")
     }
 
+    // MARK: - countTokens (TokenCountingBackend)
+
+    /// `countTokens` must throw when called before any model is loaded, because
+    /// the vocab pointer is nil and there is nothing to tokenize against.
+    ///
+    /// Sabotage check: if `countTokens` silently fell back to the heuristic
+    /// instead of throwing, this test would fail (no error thrown).
+    func test_countTokens_withoutModel_throws() {
+        let backend = LlamaBackend()
+        XCTAssertFalse(backend.isModelLoaded)
+        XCTAssertThrowsError(try backend.countTokens("hello world")) { error in
+            guard case InferenceError.inferenceFailure = error else {
+                XCTFail("Expected InferenceError.inferenceFailure, got \(error)")
+                return
+            }
+        }
+    }
+
+    /// When a real GGUF model is loaded, `countTokens` must return a positive
+    /// and plausible count — not the heuristic fallback and not zero.
+    ///
+    /// The assertion checks lower bound only; exact token counts are
+    /// model-specific and change with vocabulary.
+    ///
+    /// Sabotage check: if `countTokens` were hardcoded to return 1 for all
+    /// input, `XCTAssertGreaterThan(count, 1)` would fail.
+    func test_countTokens_withLoadedModel_returnsPlausibleCount() async throws {
+        guard let modelURL = HardwareRequirements.findGGUFModel() else {
+            throw XCTSkip(
+                "No GGUF model on disk. Place a `.gguf` file in ~/Documents/Models/ to run this test."
+            )
+        }
+
+        let backend = LlamaBackend()
+        addTeardownBlock { await backend.unloadAndWait() }
+        try await backend.loadModel(from: modelURL, plan: .testStub(effectiveContextSize: 1024))
+
+        // A multi-word English phrase typically produces several tokens.
+        let count = try backend.countTokens("The quick brown fox jumps over the lazy dog.")
+        XCTAssertGreaterThan(count, 1,
+                             "A non-trivial sentence must produce more than one token")
+        // Rough sanity bound: BPE models compress ~4 chars/token on average English.
+        // 45-character phrase → at most ~30 tokens even for a small vocab.
+        XCTAssertLessThan(count, 30,
+                          "Token count seems implausibly large — possible tokenizer bug")
+    }
+
+    /// `countTokens` must be consistent: calling it twice on the same string
+    /// must return the same value (pure vocabulary lookup, no stochastic state).
+    func test_countTokens_idempotent_withLoadedModel() async throws {
+        guard let modelURL = HardwareRequirements.findGGUFModel() else {
+            throw XCTSkip("No GGUF model on disk.")
+        }
+
+        let backend = LlamaBackend()
+        addTeardownBlock { await backend.unloadAndWait() }
+        try await backend.loadModel(from: modelURL, plan: .testStub(effectiveContextSize: 1024))
+
+        let text = "Consistency is key."
+        let first = try backend.countTokens(text)
+        let second = try backend.countTokens(text)
+        XCTAssertEqual(first, second, "countTokens must be deterministic")
+    }
+
     // MARK: - Backend Contract
 
     func test_contract_allInvariants() {

--- a/Tests/BaseChatInferenceTests/GenerationCoordinatorTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationCoordinatorTests.swift
@@ -445,6 +445,142 @@ final class GenerationCoordinatorTests: XCTestCase {
         )
     }
 
+    // MARK: - Exact preflight (TokenCountingBackend)
+
+    /// When the backend fits within the context window on the first count,
+    /// `generate` must call `backend.generate()` exactly once without trimming.
+    ///
+    /// Sabotage check: if `exactPreflightAndTrim` always trimmed at least one
+    /// message regardless of fit, `backend.generateCallCount` would still be 1
+    /// but the prompt passed to the backend would be shorter than the full
+    /// history — `backend.lastPrompt` would not contain all messages.
+    func test_exactPreflight_promptFits_noTrimAndGenerateCalled() async throws {
+        let tcBackend = TokenCountingMockBackend(contextSize: 256)
+        // countTokens returns 50 on first call → 50 + 128 (default maxOutput) = 178 ≤ 256 → fits.
+        tcBackend.countTokensResponses = [50]
+        tcBackend.tokensToYield = ["ok"]
+        let tcProvider = TokenCountingFakeProvider(backend: tcBackend)
+
+        let coord = GenerationCoordinator()
+        coord.provider = tcProvider
+
+        let (_, stream) = try coord.enqueue(
+            messages: [("user", "hello")],
+            maxOutputTokens: 128
+        )
+        for try await _ in stream.events {}
+
+        XCTAssertEqual(tcBackend.generateCallCount, 1,
+                       "generate must be called exactly once when the prompt fits")
+        XCTAssertEqual(tcBackend.countTokensCalled, 1,
+                       "countTokens must be called exactly once when the prompt fits")
+    }
+
+    /// When the first count is over budget but trimming brings it under,
+    /// `generate` must eventually be called with the trimmed prompt.
+    ///
+    /// The mock returns counts that decrease across retries: first call is over
+    /// budget, second call (after one trim) is within budget.
+    ///
+    /// Sabotage check: if the trim loop never removed a message,
+    /// `countTokens` would always return the over-budget value and
+    /// `contextExhausted` would be thrown, failing this test.
+    func test_exactPreflight_promptOverBudget_trimsAndGenerates() async throws {
+        // Context = 200, maxOutput = 100 → budget = 100 prompt tokens allowed.
+        // First count = 150 (over), second count = 90 (under after one trim).
+        let tcBackend = TokenCountingMockBackend(contextSize: 200)
+        tcBackend.countTokensResponses = [150, 90]
+        tcBackend.tokensToYield = ["trimmed"]
+        let tcProvider = TokenCountingFakeProvider(backend: tcBackend)
+
+        let coord = GenerationCoordinator()
+        coord.provider = tcProvider
+
+        // Two messages so we have something to trim.
+        let (_, stream) = try coord.enqueue(
+            messages: [
+                (role: "user", content: "first message that will be trimmed"),
+                (role: "user", content: "second message kept"),
+            ],
+            maxOutputTokens: 100
+        )
+        for try await _ in stream.events {}
+
+        XCTAssertEqual(tcBackend.generateCallCount, 1,
+                       "generate must be called once after successful trim")
+        // Two count calls: one over-budget, one under-budget after trim.
+        XCTAssertEqual(tcBackend.countTokensCalled, 2,
+                       "countTokens must be called twice: once over budget, once after trim")
+    }
+
+    /// When trimming cannot bring the prompt under budget (all trim attempts
+    /// exhausted or only the final user message remains),
+    /// `InferenceError.contextExhausted` must be thrown.
+    ///
+    /// Sabotage check: if the coordinator silently forwarded the over-budget
+    /// prompt to the backend, `generateCallCount` would be 1 and no error
+    /// would be thrown — the XCTAssertThrowsError would fail.
+    func test_exactPreflight_cannotTrim_throwsContextExhausted() throws {
+        // Context = 100, maxOutput = 50 → only 50 prompt tokens allowed.
+        // countTokens always returns 80 — over budget even with a single message.
+        let tcBackend = TokenCountingMockBackend(contextSize: 100)
+        tcBackend.countTokensResponses = [80, 80, 80, 80, 80]
+        let tcProvider = TokenCountingFakeProvider(backend: tcBackend)
+
+        let coord = GenerationCoordinator()
+        coord.provider = tcProvider
+
+        // Single user message — cannot trim (would remove the only user turn).
+        XCTAssertThrowsError(
+            try coord.generate(
+                messages: [("user", "a question that is too long for the context window")],
+                maxOutputTokens: 50
+            )
+        ) { error in
+            guard case InferenceError.contextExhausted = error else {
+                XCTFail("Expected contextExhausted, got \(error)")
+                return
+            }
+        }
+
+        XCTAssertEqual(tcBackend.generateCallCount, 0,
+                       "generate must never be called when context is exhausted — "
+                       + "the overflow must not reach the C layer")
+    }
+
+    /// Verifies the trim-and-retry loop reduces the message list across
+    /// multiple rounds. With three messages and counts that only fit after
+    /// two trims, the final call to `backend.generate` must receive a shorter
+    /// prompt than the original.
+    func test_exactPreflight_multiRoundTrim_reducesHistory() async throws {
+        // Context = 300, maxOutput = 100 → 200 token budget.
+        // Round 0 (3 msgs): 250 tokens → over budget (250+100=350 > 300) → trim.
+        // Round 1 (2 msgs): 210 tokens → over budget (210+100=310 > 300) → trim.
+        // Round 2 (1 msg):  180 tokens → fits     (180+100=280 ≤ 300) → call generate.
+        let tcBackend = TokenCountingMockBackend(contextSize: 300)
+        tcBackend.countTokensResponses = [250, 210, 180]
+        tcBackend.tokensToYield = ["done"]
+        let tcProvider = TokenCountingFakeProvider(backend: tcBackend)
+
+        let coord = GenerationCoordinator()
+        coord.provider = tcProvider
+
+        let (_, stream) = try coord.enqueue(
+            messages: [
+                (role: "user", content: "oldest message"),
+                (role: "assistant", content: "middle reply"),
+                (role: "user", content: "latest question"),
+            ],
+            maxOutputTokens: 100
+        )
+        for try await _ in stream.events {}
+
+        XCTAssertEqual(tcBackend.generateCallCount, 1,
+                       "generate must succeed after multi-round trim")
+        XCTAssertEqual(tcBackend.countTokensCalled, 3,
+                       "three count rounds expected: 2 over-budget, 1 under-budget")
+    }
+
     // MARK: - Provider teardown safety
 
     /// Deallocating the provider mid-stream must not crash the coordinator.
@@ -524,4 +660,87 @@ private final class NilBackendProvider: GenerationContextProvider {
     var currentBackend: (any InferenceBackend)? { nil }
     var isBackendLoaded: Bool { false }
     var selectedPromptTemplate: PromptTemplate { .chatML }
+}
+
+// MARK: - TokenCounting fakes
+
+/// An inference backend that also conforms to `TokenCountingBackend` for testing
+/// the exact pre-flight trim loop in `GenerationCoordinator`.
+///
+/// `countTokensResponses` controls what `countTokens` returns on each successive
+/// call (FIFO). Once exhausted the last value is repeated.
+/// `requiresPromptTemplate = true` so the coordinator takes the exact-preflight
+/// path instead of the cloud/MLX fallback path.
+final class TokenCountingMockBackend: InferenceBackend, TokenCountingBackend, @unchecked Sendable {
+
+    // InferenceBackend
+    var isModelLoaded: Bool = true
+    var isGenerating: Bool = false
+    var capabilities: BackendCapabilities
+
+    var tokensToYield: [String] = ["Hello", " world"]
+    var shouldThrowOnGenerate: Error?
+    private(set) var generateCallCount = 0
+    private(set) var lastPrompt: String?
+
+    // TokenCountingBackend
+    var countTokensResponses: [Int] = []
+    var countTokensError: Error?
+    private(set) var countTokensCalled = 0
+
+    init(contextSize: Int32 = 256) {
+        self.capabilities = BackendCapabilities(
+            supportedParameters: [.temperature, .topP, .repeatPenalty],
+            maxContextTokens: contextSize,
+            requiresPromptTemplate: true,      // triggers exact-preflight path
+            supportsSystemPrompt: true,
+            supportsToolCalling: false,
+            supportsStructuredOutput: false,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: true
+        )
+    }
+
+    func loadModel(from url: URL, plan: ModelLoadPlan) async throws {}
+
+    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> GenerationStream {
+        generateCallCount += 1
+        lastPrompt = prompt
+        if let error = shouldThrowOnGenerate { throw error }
+        let tokens = tokensToYield
+        let stream = AsyncThrowingStream<GenerationEvent, Error> { continuation in
+            Task {
+                for token in tokens { continuation.yield(.token(token)) }
+                continuation.finish()
+            }
+        }
+        return GenerationStream(stream)
+    }
+
+    func stopGeneration() { isGenerating = false }
+    func unloadModel() { isModelLoaded = false }
+
+    func countTokens(_ text: String) throws -> Int {
+        if let error = countTokensError { throw error }
+        countTokensCalled += 1
+        guard !countTokensResponses.isEmpty else { return 10 }
+        let idx = min(countTokensCalled - 1, countTokensResponses.count - 1)
+        return countTokensResponses[idx]
+    }
+}
+
+/// A fake provider that vends a `TokenCountingMockBackend`.
+@MainActor
+final class TokenCountingFakeProvider: GenerationContextProvider {
+    let backend: TokenCountingMockBackend
+    var promptTemplate: PromptTemplate = .chatML
+
+    init(backend: TokenCountingMockBackend = TokenCountingMockBackend()) {
+        self.backend = backend
+        self.backend.isModelLoaded = true
+    }
+
+    var currentBackend: (any InferenceBackend)? { backend }
+    var isBackendLoaded: Bool { backend.isModelLoaded }
+    var selectedPromptTemplate: PromptTemplate { promptTemplate }
 }

--- a/Tests/BaseChatInferenceTests/GenerationCoordinatorTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationCoordinatorTests.swift
@@ -671,7 +671,7 @@ private final class NilBackendProvider: GenerationContextProvider {
 /// call (FIFO). Once exhausted the last value is repeated.
 /// `requiresPromptTemplate = true` so the coordinator takes the exact-preflight
 /// path instead of the cloud/MLX fallback path.
-final class TokenCountingMockBackend: InferenceBackend, TokenCountingBackend, @unchecked Sendable {
+private final class TokenCountingMockBackend: InferenceBackend, TokenCountingBackend, @unchecked Sendable {
 
     // InferenceBackend
     var isModelLoaded: Bool = true
@@ -731,7 +731,7 @@ final class TokenCountingMockBackend: InferenceBackend, TokenCountingBackend, @u
 
 /// A fake provider that vends a `TokenCountingMockBackend`.
 @MainActor
-final class TokenCountingFakeProvider: GenerationContextProvider {
+private final class TokenCountingFakeProvider: GenerationContextProvider {
     let backend: TokenCountingMockBackend
     var promptTemplate: PromptTemplate = .chatML
 


### PR DESCRIPTION
## Summary

- Add `TokenCountingBackend` protocol to `BackendOptInProtocols.swift` for backends that can count tokens exactly using their loaded vocabulary
- Implement `countTokens(_ text: String) throws -> Int` on `LlamaBackend` — calls `llama_tokenize` directly (pure vocab lookup, thread-safe, throws if model is not loaded)
- Add exact pre-flight gate in `GenerationCoordinator.generate()`: when the backend conforms to `TokenCountingBackend`, count tokens on the assembled prompt before passing it to the C layer; trim the oldest non-system messages and re-assemble up to 20 times; throw `InferenceError.contextExhausted` if the prompt still won't fit after trimming

## Test plan

- [ ] `test_countTokens_withoutModel_throws` — throws `inferenceFailure` when no model loaded (sabotage: removing the guard makes this fail)
- [ ] `test_countTokens_withLoadedModel_returnsPlausibleCount` — real GGUF tokenizer returns >1 for a multi-word phrase (hardware-gated, `XCTSkipIf` for simulator)
- [ ] `test_countTokens_idempotent_withLoadedModel` — same string, same count on two calls
- [ ] `test_exactPreflight_promptFits_noTrimAndGenerateCalled` — no trimming when prompt fits; `countTokens` called once, `generate` called once
- [ ] `test_exactPreflight_promptOverBudget_trimsAndGenerates` — one trim round; `countTokens` called twice, `generate` called once
- [ ] `test_exactPreflight_cannotTrim_throwsContextExhausted` — single user message that won't fit; `generate` never called
- [ ] `test_exactPreflight_multiRoundTrim_reducesHistory` — two trim rounds; three `countTokens` calls, one `generate` call

## Release Note

Long multi-turn sessions where the assembled prompt approached the model's context window could silently overflow the llama.cpp KV cache, causing undefined behaviour — assertion failures, corrupt output, or crashes. The heuristic token estimator introduced in PR #409 drifts for Unicode-heavy text and verbose chat templates.

This fix replaces the heuristic with an exact pre-flight gate using `llama_tokenize` on the full assembled prompt string before any C API call. When the prompt is over budget, the coordinator trims the oldest non-system messages one at a time and re-assembles until it fits (up to 20 rounds). If it still won't fit — because only the final user turn remains — `InferenceError.contextExhausted` is thrown with accurate token counts. The overflow can no longer reach the C layer.

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)