### PR TITLE
chore: adopt n-1 platform policy and bump to macOS 15 / iOS 18

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,17 @@ Do not widen `inferenceService` to `public` — it exposes load coordination int
 - **Error handling**: only validate at system boundaries (user input, external APIs, file I/O). Don't add defensive guards for internal invariants that Swift's type system already enforces.
 - **Comments**: explain *why*, not *what*. Omit when the code is self-evident.
 
+## Platform policy
+
+BaseChatKit targets **n-1**: the current Apple OS release and the one immediately before it.
+
+| Platform | Current (n) | Minimum (n-1) |
+|----------|-------------|---------------|
+| macOS    | 26          | 15            |
+| iOS      | 26          | 18            |
+
+When Apple ships a new major OS each September, bump both minimums by one and remove any `#available` guards that were added to paper over the previous floor. Do not use `Atomic`, `OSAllocatedUnfairLock`, or other APIs that post-date the minimum without first checking their availability annotation.
+
 ## Hardware constraints (simulator / CI)
 
 - `LlamaBackend` uses a global `llama_backend_init` — only one instance can exist per process. Tests must share a single instance or use `MockInferenceBackend`.

--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 let package = Package(
     name: "BaseChatKit",
     platforms: [
-        .iOS(.v17),
-        .macOS(.v14),
+        .iOS(.v18),
+        .macOS(.v15),
     ],
     products: [
         .library(name: "BaseChatInference", targets: ["BaseChatInference"]),


### PR DESCRIPTION
## Summary

- Documents the n-1 support window in `CLAUDE.md`: macOS 15 / iOS 18 minimum going forward, bumped each September when Apple ships a new major OS
- Raises `Package.swift` deployment targets from macOS 14 / iOS 17 to macOS 15 / iOS 18
- Unblocks `Synchronization.Atomic` (used in `LlamaBackend` since #418) which was silently requiring macOS 15 despite the old macOS 14 floor

No code changes — the policy bump makes the existing `Atomic<Bool>` in `LlamaBackend` valid without any `#available` scaffolding.

## Test plan

- [x] `swift build` — clean, no errors
- [ ] Full CI suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)