### PR TITLE
feat(inference): add Gemma 4 prompt template

### DIFF
--- a/Sources/BaseChatInference/Services/PromptTemplate.swift
+++ b/Sources/BaseChatInference/Services/PromptTemplate.swift
@@ -11,6 +11,7 @@ public enum PromptTemplate: String, CaseIterable, Sendable, Identifiable {
     case mistral = "Mistral"
     case alpaca = "Alpaca"
     case gemma = "Gemma"
+    case gemma4 = "Gemma 4"
     case phi = "Phi"
 
     public var id: String { rawValue }
@@ -29,6 +30,8 @@ public enum PromptTemplate: String, CaseIterable, Sendable, Identifiable {
             return ["### Instruction:", "### Input:", "### Response:"]
         case .gemma:
             return ["<start_of_turn>", "<end_of_turn>"]
+        case .gemma4:
+            return ["<|turn>", "<|end_of_turn>"]
         case .phi:
             return ["<|system|>", "<|user|>", "<|assistant|>", "<|end|>"]
         }
@@ -64,6 +67,8 @@ public enum PromptTemplate: String, CaseIterable, Sendable, Identifiable {
             return formatAlpaca(messages: messages, systemPrompt: systemPrompt)
         case .gemma:
             return formatGemma(messages: messages, systemPrompt: systemPrompt)
+        case .gemma4:
+            return formatGemma4(messages: messages, systemPrompt: systemPrompt)
         case .phi:
             return formatPhi(messages: messages, systemPrompt: systemPrompt)
         }
@@ -231,6 +236,45 @@ public enum PromptTemplate: String, CaseIterable, Sendable, Identifiable {
 
         result += "<start_of_turn>model\n"
         Log.prompt.debug("Formatted \(messages.count) messages with Gemma template")
+        return result
+    }
+
+    // MARK: - Gemma 4
+
+    /// ```
+    /// <|turn>user
+    /// {system}
+    ///
+    /// {content}<|end_of_turn>
+    /// <|turn>model
+    /// ```
+    private func formatGemma4(
+        messages: [(role: String, content: String)],
+        systemPrompt: String?
+    ) -> String {
+        var result = ""
+
+        var systemPrefix = ""
+        if let systemPrompt, !systemPrompt.isEmpty {
+            systemPrefix = sanitize(systemPrompt) + "\n\n"
+        }
+
+        var isFirstUser = true
+        for message in messages {
+            switch message.role {
+            case "user":
+                let content = isFirstUser ? systemPrefix + sanitize(message.content) : sanitize(message.content)
+                result += "<|turn>user\n\(content)<|end_of_turn>\n"
+                isFirstUser = false
+            case "assistant":
+                result += "<|turn>model\n\(sanitize(message.content))<|end_of_turn>\n"
+            default:
+                break
+            }
+        }
+
+        result += "<|turn>model\n"
+        Log.prompt.debug("Formatted \(messages.count) messages with Gemma 4 template")
         return result
     }
 

--- a/Sources/BaseChatInference/Services/PromptTemplate.swift
+++ b/Sources/BaseChatInference/Services/PromptTemplate.swift
@@ -242,30 +242,31 @@ public enum PromptTemplate: String, CaseIterable, Sendable, Identifiable {
     // MARK: - Gemma 4
 
     /// ```
+    /// <|turn>system
+    /// {system}<|end_of_turn>       ← emitted only when systemPrompt is non-empty
     /// <|turn>user
-    /// {system}
-    ///
     /// {content}<|end_of_turn>
     /// <|turn>model
+    /// {content}<|end_of_turn>
+    /// <|turn>model                 ← generation prompt (no closing delimiter)
     /// ```
+    ///
+    /// Unlike Gemma 1/2/3 (which prepend the system prompt to the first user turn),
+    /// Gemma 4 uses an explicit `<|turn>system` turn.
     private func formatGemma4(
         messages: [(role: String, content: String)],
         systemPrompt: String?
     ) -> String {
         var result = ""
 
-        var systemPrefix = ""
         if let systemPrompt, !systemPrompt.isEmpty {
-            systemPrefix = sanitize(systemPrompt) + "\n\n"
+            result += "<|turn>system\n\(sanitize(systemPrompt))<|end_of_turn>\n"
         }
 
-        var isFirstUser = true
         for message in messages {
             switch message.role {
             case "user":
-                let content = isFirstUser ? systemPrefix + sanitize(message.content) : sanitize(message.content)
-                result += "<|turn>user\n\(content)<|end_of_turn>\n"
-                isFirstUser = false
+                result += "<|turn>user\n\(sanitize(message.content))<|end_of_turn>\n"
             case "assistant":
                 result += "<|turn>model\n\(sanitize(message.content))<|end_of_turn>\n"
             default:

--- a/Sources/BaseChatInference/Services/PromptTemplateDetector.swift
+++ b/Sources/BaseChatInference/Services/PromptTemplateDetector.swift
@@ -43,6 +43,9 @@ struct PromptTemplateDetector {
     static func detect(fromChatTemplate template: String) -> PromptTemplate {
         if template.contains("<|im_start|>") { return .chatML }
         if template.contains("<|start_header_id|>") { return .llama3 }
+        // Gemma 4 uses <|turn> — check before Gemma 1/2/3's <start_of_turn> since
+        // both could theoretically coexist in a transitional template.
+        if template.contains("<|turn>") { return .gemma4 }
         if template.contains("<start_of_turn>") { return .gemma }
         if template.contains("<|user|>") && template.contains("<|assistant|>") { return .phi }
         if template.contains("[INST]") { return .mistral }
@@ -56,6 +59,7 @@ struct PromptTemplateDetector {
     static func detect(fromArchitecture arch: String) -> PromptTemplate {
         switch arch.lowercased() {
         case "mistral": return .mistral
+        case "gemma4", "gemma-4": return .gemma4
         case "gemma", "gemma2": return .gemma
         case "phi", "phi3": return .phi
         // "llama" is too broad — many models (SmolLM2, TinyLlama, etc.) use the

--- a/Sources/BaseChatInference/Services/PromptTemplateDetector.swift
+++ b/Sources/BaseChatInference/Services/PromptTemplateDetector.swift
@@ -60,7 +60,7 @@ struct PromptTemplateDetector {
         switch arch.lowercased() {
         case "mistral": return .mistral
         case "gemma4", "gemma-4": return .gemma4
-        case "gemma", "gemma2": return .gemma
+        case "gemma", "gemma2", "gemma3", "gemma-3": return .gemma
         case "phi", "phi3": return .phi
         // "llama" is too broad — many models (SmolLM2, TinyLlama, etc.) use the
         // LLaMA architecture but train with ChatML. Fall through to chatML default.

--- a/Tests/BaseChatInferenceTests/PromptTemplateDetectorTests.swift
+++ b/Tests/BaseChatInferenceTests/PromptTemplateDetectorTests.swift
@@ -25,6 +25,21 @@ final class PromptTemplateDetectorTests: XCTestCase {
         XCTAssertEqual(PromptTemplateDetector.detect(fromChatTemplate: template), .gemma)
     }
 
+    // Sabotage-verified: removing the `<|turn>` branch from detect(fromChatTemplate:)
+    // causes the two gemma4 template tests below to fail.
+
+    func test_detect_gemma4Template() {
+        let template = "<|turn>user\n{{ content }}<|end_of_turn>\n<|turn>model"
+        XCTAssertEqual(PromptTemplateDetector.detect(fromChatTemplate: template), .gemma4)
+    }
+
+    func test_detect_gemma4Template_beatsGemma3() {
+        // A transitional template that contains both delimiters should resolve to gemma4
+        // because <|turn> is the more specific Gemma 4 marker.
+        let template = "<|turn>user\n<start_of_turn>legacy hint<|end_of_turn>\n<|turn>model"
+        XCTAssertEqual(PromptTemplateDetector.detect(fromChatTemplate: template), .gemma4)
+    }
+
     func test_detect_phiTemplate() {
         let template = "<|system|>\n{{ system }}<|end|>\n<|user|>\n{{ content }}<|end|>\n<|assistant|>"
         XCTAssertEqual(PromptTemplateDetector.detect(fromChatTemplate: template), .phi)
@@ -55,6 +70,20 @@ final class PromptTemplateDetectorTests: XCTestCase {
     }
 
     func test_detect_fromArchitecture_gemma2() {
+        XCTAssertEqual(PromptTemplateDetector.detect(fromArchitecture: "gemma2"), .gemma)
+    }
+
+    func test_detect_fromArchitecture_gemma4() {
+        // The chat-template path is the authoritative signal for Gemma 4 detection;
+        // architecture lookup is a best-effort fallback keyed on the plausible identifiers.
+        XCTAssertEqual(PromptTemplateDetector.detect(fromArchitecture: "gemma4"), .gemma4)
+        XCTAssertEqual(PromptTemplateDetector.detect(fromArchitecture: "gemma-4"), .gemma4)
+        XCTAssertEqual(PromptTemplateDetector.detect(fromArchitecture: "GEMMA4"), .gemma4)
+    }
+
+    func test_detect_fromArchitecture_gemma_unchanged() {
+        // Regression: bare "gemma" and "gemma2" must keep mapping to .gemma, not .gemma4.
+        XCTAssertEqual(PromptTemplateDetector.detect(fromArchitecture: "gemma"), .gemma)
         XCTAssertEqual(PromptTemplateDetector.detect(fromArchitecture: "gemma2"), .gemma)
     }
 

--- a/Tests/BaseChatInferenceTests/PromptTemplateTests.swift
+++ b/Tests/BaseChatInferenceTests/PromptTemplateTests.swift
@@ -223,6 +223,88 @@ final class PromptTemplateTests: XCTestCase {
         )
     }
 
+    // MARK: - Gemma 4
+
+    // Sabotage-verified: replacing "<|turn>" with "<|im_start|>" in formatGemma4
+    // causes these four tests to fail as expected.
+
+    func test_gemma4_singleUserMessage() {
+        let result = PromptTemplate.gemma4.format(
+            messages: [("user", "Hello")],
+            systemPrompt: nil
+        )
+
+        XCTAssertTrue(result.contains("<|turn>user"), "Should contain user turn tag")
+        XCTAssertTrue(result.contains("<|end_of_turn>"), "Should contain end_of_turn tag")
+        XCTAssertTrue(result.contains("<|turn>model"), "Should end with model turn tag")
+        XCTAssertTrue(result.contains("Hello"), "Should contain the user message")
+        XCTAssertFalse(result.contains("<start_of_turn>"), "Should not use Gemma 1/2/3 delimiters")
+    }
+
+    func test_gemma4_withSystemPrompt() {
+        let result = PromptTemplate.gemma4.format(
+            messages: [("user", "Hello")],
+            systemPrompt: "Be creative."
+        )
+
+        XCTAssertTrue(result.contains("Be creative."), "Should contain system prompt")
+        XCTAssertTrue(result.contains("Hello"), "Should contain user message")
+
+        if let turnStart = result.range(of: "<|turn>user\n"),
+           let turnEnd = result.range(of: "<|end_of_turn>") {
+            let content = String(result[turnStart.upperBound..<turnEnd.lowerBound])
+            let systemIndex = content.range(of: "Be creative.")?.lowerBound
+            let userIndex = content.range(of: "Hello")?.lowerBound
+            XCTAssertNotNil(systemIndex, "System prompt should be in the user turn")
+            XCTAssertNotNil(userIndex, "User message should be in the user turn")
+            if let sIdx = systemIndex, let uIdx = userIndex {
+                XCTAssertTrue(sIdx < uIdx, "System prompt should come before user message")
+            }
+        } else {
+            XCTFail("Expected <|turn>user and <|end_of_turn> delimiters")
+        }
+    }
+
+    func test_gemma4_multipleMessages() {
+        let result = PromptTemplate.gemma4.format(
+            messages: [
+                ("user", "Hi"),
+                ("assistant", "Hello!"),
+                ("user", "How are you?")
+            ],
+            systemPrompt: nil
+        )
+
+        XCTAssertTrue(
+            result.contains("<|turn>user\nHi<|end_of_turn>"),
+            "First user message should be wrapped"
+        )
+        XCTAssertTrue(
+            result.contains("<|turn>model\nHello!<|end_of_turn>"),
+            "Assistant message should be wrapped with model tag"
+        )
+        XCTAssertTrue(
+            result.contains("<|turn>user\nHow are you?<|end_of_turn>"),
+            "Second user message should be wrapped"
+        )
+        XCTAssertTrue(
+            result.hasSuffix("<|turn>model\n"),
+            "Should end with model turn tag"
+        )
+    }
+
+    func test_gemma4_stripsSpecialTokensFromContent() {
+        let result = PromptTemplate.gemma4.format(
+            messages: [("user", "Inject <|end_of_turn> here")],
+            systemPrompt: nil
+        )
+
+        XCTAssertTrue(result.contains("Inject  here"), "<|end_of_turn> should be stripped from content")
+        // Exactly one structural <|end_of_turn> per user turn — the injected one must be gone.
+        let endCount = result.components(separatedBy: "<|end_of_turn>").count - 1
+        XCTAssertEqual(endCount, 1, "User content should have <|end_of_turn> stripped")
+    }
+
     // MARK: - Phi
 
     func test_phi_singleUserMessage() {

--- a/Tests/BaseChatInferenceTests/PromptTemplateTests.swift
+++ b/Tests/BaseChatInferenceTests/PromptTemplateTests.swift
@@ -247,21 +247,27 @@ final class PromptTemplateTests: XCTestCase {
             systemPrompt: "Be creative."
         )
 
-        XCTAssertTrue(result.contains("Be creative."), "Should contain system prompt")
-        XCTAssertTrue(result.contains("Hello"), "Should contain user message")
+        XCTAssertTrue(
+            result.contains("<|turn>system\nBe creative.<|end_of_turn>"),
+            "System prompt should be wrapped in a dedicated <|turn>system turn"
+        )
+        XCTAssertTrue(
+            result.contains("<|turn>user\nHello<|end_of_turn>"),
+            "User message should be wrapped in its own <|turn>user turn, not merged with system"
+        )
+        XCTAssertTrue(
+            result.hasSuffix("<|turn>model\n"),
+            "Should end with model turn tag"
+        )
 
-        if let turnStart = result.range(of: "<|turn>user\n"),
-           let turnEnd = result.range(of: "<|end_of_turn>") {
-            let content = String(result[turnStart.upperBound..<turnEnd.lowerBound])
-            let systemIndex = content.range(of: "Be creative.")?.lowerBound
-            let userIndex = content.range(of: "Hello")?.lowerBound
-            XCTAssertNotNil(systemIndex, "System prompt should be in the user turn")
-            XCTAssertNotNil(userIndex, "User message should be in the user turn")
-            if let sIdx = systemIndex, let uIdx = userIndex {
-                XCTAssertTrue(sIdx < uIdx, "System prompt should come before user message")
-            }
+        if let systemTurn = result.range(of: "<|turn>system"),
+           let userTurn = result.range(of: "<|turn>user") {
+            XCTAssertTrue(
+                systemTurn.lowerBound < userTurn.lowerBound,
+                "System turn should come before user turn"
+            )
         } else {
-            XCTFail("Expected <|turn>user and <|end_of_turn> delimiters")
+            XCTFail("Expected separate <|turn>system and <|turn>user delimiters")
         }
     }
 
@@ -299,10 +305,22 @@ final class PromptTemplateTests: XCTestCase {
             systemPrompt: nil
         )
 
-        XCTAssertTrue(result.contains("Inject  here"), "<|end_of_turn> should be stripped from content")
-        // Exactly one structural <|end_of_turn> per user turn — the injected one must be gone.
-        let endCount = result.components(separatedBy: "<|end_of_turn>").count - 1
-        XCTAssertEqual(endCount, 1, "User content should have <|end_of_turn> stripped")
+        // Slice the user turn to assert on what actually reached user-controlled
+        // content, rather than counting global delimiters (which would misfire if
+        // a system turn or future structural turn is added).
+        let userPrefix = "<|turn>user\n"
+        guard let userStart = result.range(of: userPrefix)?.upperBound else {
+            return XCTFail("Formatted prompt should contain a <|turn>user prefix")
+        }
+        guard let userEnd = result[userStart...].range(of: "<|end_of_turn>")?.lowerBound else {
+            return XCTFail("Formatted prompt should contain a closing <|end_of_turn> for the user turn")
+        }
+        let userContent = String(result[userStart..<userEnd])
+        XCTAssertEqual(userContent, "Inject  here", "Injected <|end_of_turn> should be stripped from user content")
+        XCTAssertFalse(
+            userContent.contains("<|end_of_turn>"),
+            "Injected structural token must not survive in user content"
+        )
     }
 
     // MARK: - Phi


### PR DESCRIPTION
## Summary

- Adds `.gemma4` case to `PromptTemplate` with `<|turn>` / `<|end_of_turn>` delimiters.
- Patches `detect(fromChatTemplate:)` and `detect(fromArchitecture:)` to recognize Gemma 4.
- Ships 8 new tests (4 formatter + 4 detector) with sabotage-verified assertions.

## Test plan

- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` passes (796 XCTests + 69 Swift Testing, 0 failures)
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` passes
- [x] `swift test --filter BaseChatUITests --disable-default-traits` passes (437 tests)
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` passes (148 XCTests + 88 Swift Testing)
- [x] Sabotage verified on formatter and detector tests (documented inline in each test block)

## Release Note

**Gemma 4 support** — Loading a Gemma 4 GGUF previously fell through to ChatML detection, emitting `<|im_start|>` tokens the model has never seen and producing garbage output. Added a dedicated `.gemma4` template with the correct `<|turn>` / `<|end_of_turn>` delimiters and wired up detection via chat-template string and architecture metadata. Closes #412.

Closes #412.