### PR TITLE
refactor(ui): extract ContextEstimator and MemoryPressureResponder from ChatViewModel

### DIFF
--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+ContextEstimation.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+ContextEstimation.swift
@@ -10,32 +10,19 @@ extension ChatViewModel {
     ///
     /// Uses a per-message token count cache to avoid re-estimating unchanged messages.
     func updateContextEstimate() {
-        // Resolve max context: session override > model metadata > backend > default
-        contextMaxTokens = ContextWindowManager.resolveContextSize(
-            sessionOverride: activeSession?.contextSizeOverride,
+        let estimator = ContextEstimator()
+        let inputs = ContextEstimator.Inputs(
+            messages: messages,
+            systemPrompt: systemPrompt,
             modelContextLength: selectedModel?.detectedContextLength,
-            backendMaxTokens: backendCapabilities.map { Int($0.maxContextTokens) },
-            defaultSize: 2048
+            contextSizeOverride: activeSession?.contextSizeOverride,
+            backendMaxContextTokens: backendCapabilities.map { Int($0.maxContextTokens) },
+            tokenizer: inferenceService.tokenizer,
+            cache: tokenCountCache
         )
-
-        // Estimate tokens for all messages + system prompt, using cache for unchanged messages.
-        // Use the real tokenizer from the loaded backend when available (GGUF/llama.cpp),
-        // falling back to the 4-chars/token heuristic for MLX, Foundation, and cloud.
-        let activeTokenizer = inferenceService.tokenizer
-        let systemTokens = ContextWindowManager.estimateTokenCount(systemPrompt, tokenizer: activeTokenizer)
-        var messageTokens = 0
-        var newCache: [UUID: Int] = [:]
-        for message in messages {
-            let count: Int
-            if let cached = tokenCountCache[message.id] {
-                count = cached
-            } else {
-                count = ContextWindowManager.estimateTokenCount(message.content, tokenizer: activeTokenizer)
-            }
-            newCache[message.id] = count
-            messageTokens += count
-        }
-        tokenCountCache = newCache
-        contextUsedTokens = systemTokens + messageTokens
+        let result = estimator.estimate(inputs)
+        contextMaxTokens = result.maxTokens
+        tokenCountCache = result.updatedCache
+        contextUsedTokens = result.usedTokens
     }
 }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+MemoryPressure.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+MemoryPressure.swift
@@ -29,7 +29,7 @@ extension ChatViewModel {
                 unloadModel()
             case .setError(let error):
                 activeError = error
-            case .clearError:
+            case .clearMemoryPressureError:
                 if activeError?.kind == .memoryPressure {
                     activeError = nil
                 }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+MemoryPressure.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+MemoryPressure.swift
@@ -16,19 +16,23 @@ extension ChatViewModel {
 
     public func handleMemoryPressure() {
         let level = memoryPressure.pressureLevel
-        guard level != lastPressureLevel else { return }
+        let responder = MemoryPressureResponder()
+        let actions = responder.actions(for: level, lastLevel: lastPressureLevel)
+        guard !actions.isEmpty else { return }
         lastPressureLevel = level
 
-        switch level {
-        case .critical:
-            stopGeneration()
-            unloadModel()
-            activeError = ChatError(kind: .memoryPressure, message: "Memory pressure is critical. The model was unloaded to prevent the app from being terminated.", recovery: .dismissOnly)
-        case .warning:
-            activeError = ChatError(kind: .memoryPressure, message: "Memory pressure is elevated. Consider closing other apps.", recovery: .dismissOnly)
-        case .nominal:
-            if activeError?.kind == .memoryPressure {
-                activeError = nil
+        for action in actions {
+            switch action {
+            case .stopGeneration:
+                stopGeneration()
+            case .unloadModel:
+                unloadModel()
+            case .setError(let error):
+                activeError = error
+            case .clearError:
+                if activeError?.kind == .memoryPressure {
+                    activeError = nil
+                }
             }
         }
     }

--- a/Sources/BaseChatUI/ViewModels/ContextEstimator.swift
+++ b/Sources/BaseChatUI/ViewModels/ContextEstimator.swift
@@ -1,0 +1,64 @@
+import Foundation
+import BaseChatInference
+
+// MARK: - ContextEstimator
+
+/// Pure token-budget calculator for the chat context window.
+///
+/// Extracted from `ChatViewModel` (phase 2 of #329) so estimation is a value-type
+/// function of its inputs — the owning view model is still responsible for
+/// holding the mutable caches and publishing the results.
+struct ContextEstimator {
+
+    struct Inputs {
+        let messages: [ChatMessageRecord]
+        let systemPrompt: String
+        let modelContextLength: Int?
+        let contextSizeOverride: Int?
+        let backendMaxContextTokens: Int?
+        let tokenizer: (any TokenizerProvider)?
+        let cache: [UUID: Int]
+    }
+
+    struct Result {
+        let usedTokens: Int
+        let maxTokens: Int
+        let updatedCache: [UUID: Int]
+    }
+
+    func estimate(_ inputs: Inputs) -> Result {
+        let maxTokens = ContextWindowManager.resolveContextSize(
+            sessionOverride: inputs.contextSizeOverride,
+            modelContextLength: inputs.modelContextLength,
+            backendMaxTokens: inputs.backendMaxContextTokens,
+            defaultSize: 2048
+        )
+
+        let systemTokens = ContextWindowManager.estimateTokenCount(
+            inputs.systemPrompt,
+            tokenizer: inputs.tokenizer
+        )
+
+        var messageTokens = 0
+        var newCache: [UUID: Int] = [:]
+        for message in inputs.messages {
+            let count: Int
+            if let cached = inputs.cache[message.id] {
+                count = cached
+            } else {
+                count = ContextWindowManager.estimateTokenCount(
+                    message.content,
+                    tokenizer: inputs.tokenizer
+                )
+            }
+            newCache[message.id] = count
+            messageTokens += count
+        }
+
+        return Result(
+            usedTokens: systemTokens + messageTokens,
+            maxTokens: maxTokens,
+            updatedCache: newCache
+        )
+    }
+}

--- a/Sources/BaseChatUI/ViewModels/MemoryPressureResponder.swift
+++ b/Sources/BaseChatUI/ViewModels/MemoryPressureResponder.swift
@@ -13,7 +13,7 @@ struct MemoryPressureResponder {
 
     enum Action {
         case setError(ChatError)
-        case clearError
+        case clearMemoryPressureError
         case stopGeneration
         case unloadModel
     }
@@ -45,7 +45,7 @@ struct MemoryPressureResponder {
                 )
             ]
         case .nominal:
-            return [.clearError]
+            return [.clearMemoryPressureError]
         }
     }
 }

--- a/Sources/BaseChatUI/ViewModels/MemoryPressureResponder.swift
+++ b/Sources/BaseChatUI/ViewModels/MemoryPressureResponder.swift
@@ -1,0 +1,51 @@
+import Foundation
+import BaseChatInference
+
+// MARK: - MemoryPressureResponder
+
+/// Pure decision tree that maps a memory-pressure level transition to a list of
+/// actions for `ChatViewModel` to apply.
+///
+/// Extracted from `ChatViewModel+MemoryPressure.swift` (phase 2 of #329). The
+/// responder owns no mutable state; the view model reads the current/previous
+/// pressure levels, asks for actions, and applies them.
+struct MemoryPressureResponder {
+
+    enum Action {
+        case setError(ChatError)
+        case clearError
+        case stopGeneration
+        case unloadModel
+    }
+
+    func actions(for level: MemoryPressureLevel, lastLevel: MemoryPressureLevel) -> [Action] {
+        guard level != lastLevel else { return [] }
+
+        switch level {
+        case .critical:
+            return [
+                .stopGeneration,
+                .unloadModel,
+                .setError(
+                    ChatError(
+                        kind: .memoryPressure,
+                        message: "Memory pressure is critical. The model was unloaded to prevent the app from being terminated.",
+                        recovery: .dismissOnly
+                    )
+                )
+            ]
+        case .warning:
+            return [
+                .setError(
+                    ChatError(
+                        kind: .memoryPressure,
+                        message: "Memory pressure is elevated. Consider closing other apps.",
+                        recovery: .dismissOnly
+                    )
+                )
+            ]
+        case .nominal:
+            return [.clearError]
+        }
+    }
+}

--- a/Tests/BaseChatUITests/ContextEstimatorTests.swift
+++ b/Tests/BaseChatUITests/ContextEstimatorTests.swift
@@ -1,0 +1,186 @@
+import XCTest
+@testable import BaseChatUI
+@testable import BaseChatInference
+
+/// Unit tests for the pure `ContextEstimator` struct extracted from
+/// `ChatViewModel.updateContextEstimate()`. No ChatViewModel, no persistence.
+final class ContextEstimatorTests: XCTestCase {
+
+    // MARK: - Fakes
+
+    /// Call-counting tokenizer with the same ~4 chars/token heuristic used by
+    /// `HeuristicTokenizer`. Lets the cache tests assert no redundant work.
+    private final class CountingTokenizer: TokenizerProvider, @unchecked Sendable {
+        private(set) var callCount = 0
+        func tokenCount(_ text: String) -> Int {
+            callCount += 1
+            return max(1, text.count / 4)
+        }
+    }
+
+    private let sessionID = UUID()
+
+    private func makeMessage(_ content: String, id: UUID = UUID()) -> ChatMessageRecord {
+        ChatMessageRecord(id: id, role: .user, content: content, sessionID: sessionID)
+    }
+
+    // MARK: - Tests
+
+    func testSingleMessageNoSystemPrompt() {
+        let tokenizer = CountingTokenizer()
+        let estimator = ContextEstimator()
+        let msg = makeMessage("12345678") // 8 chars -> 2 tokens
+        let inputs = ContextEstimator.Inputs(
+            messages: [msg],
+            systemPrompt: "",
+            modelContextLength: nil,
+            contextSizeOverride: nil,
+            backendMaxContextTokens: nil,
+            tokenizer: tokenizer,
+            cache: [:]
+        )
+
+        let result = estimator.estimate(inputs)
+
+        XCTAssertEqual(result.usedTokens, 1 + 2, "empty system prompt tokenizes to 1 + message = 2")
+        XCTAssertEqual(result.maxTokens, 2048, "default context size fallback")
+        XCTAssertEqual(result.updatedCache[msg.id], 2)
+    }
+
+    func testSystemPromptPlusMessagesCountsBoth() {
+        let tokenizer = CountingTokenizer()
+        let estimator = ContextEstimator()
+        let m1 = makeMessage("abcdefgh")      // 8 -> 2
+        let m2 = makeMessage("abcdefghijkl")  // 12 -> 3
+        let inputs = ContextEstimator.Inputs(
+            messages: [m1, m2],
+            systemPrompt: "abcdefgh",         // 8 -> 2
+            modelContextLength: nil,
+            contextSizeOverride: nil,
+            backendMaxContextTokens: nil,
+            tokenizer: tokenizer,
+            cache: [:]
+        )
+
+        let result = estimator.estimate(inputs)
+
+        XCTAssertEqual(result.usedTokens, 2 + 2 + 3)
+        XCTAssertEqual(result.updatedCache.count, 2)
+    }
+
+    func testCacheHitSkipsTokenizer() {
+        let tokenizer = CountingTokenizer()
+        let estimator = ContextEstimator()
+        let m1 = makeMessage("any content here, ignored because cache hit")
+        let m2 = makeMessage("also cached, ignored")
+
+        let preloaded: [UUID: Int] = [m1.id: 7, m2.id: 11]
+        let inputs = ContextEstimator.Inputs(
+            messages: [m1, m2],
+            systemPrompt: "",
+            modelContextLength: nil,
+            contextSizeOverride: nil,
+            backendMaxContextTokens: nil,
+            tokenizer: tokenizer,
+            cache: preloaded
+        )
+
+        let result = estimator.estimate(inputs)
+
+        // 1 call for the (empty) system prompt; zero for cached messages.
+        XCTAssertEqual(tokenizer.callCount, 1)
+        XCTAssertEqual(result.usedTokens, 1 + 7 + 11)
+        XCTAssertEqual(result.updatedCache[m1.id], 7)
+        XCTAssertEqual(result.updatedCache[m2.id], 11)
+    }
+
+    func testCacheMissPopulatesUpdatedCache() {
+        let tokenizer = CountingTokenizer()
+        let estimator = ContextEstimator()
+        let m1 = makeMessage("abcdefgh")     // 2
+        let m2 = makeMessage("abcdefghijkl") // 3
+        let inputs = ContextEstimator.Inputs(
+            messages: [m1, m2],
+            systemPrompt: "",
+            modelContextLength: nil,
+            contextSizeOverride: nil,
+            backendMaxContextTokens: nil,
+            tokenizer: tokenizer,
+            cache: [:]
+        )
+
+        let result = estimator.estimate(inputs)
+
+        XCTAssertEqual(result.updatedCache[m1.id], 2)
+        XCTAssertEqual(result.updatedCache[m2.id], 3)
+        // One call for system prompt + one per uncached message.
+        XCTAssertEqual(tokenizer.callCount, 3)
+    }
+
+    func testStaleCacheEntriesAreDropped() {
+        // Messages that disappeared from the conversation must not linger in the cache.
+        let tokenizer = CountingTokenizer()
+        let estimator = ContextEstimator()
+        let kept = makeMessage("abcd")
+        let droppedID = UUID()
+        let inputs = ContextEstimator.Inputs(
+            messages: [kept],
+            systemPrompt: "",
+            modelContextLength: nil,
+            contextSizeOverride: nil,
+            backendMaxContextTokens: nil,
+            tokenizer: tokenizer,
+            cache: [kept.id: 99, droppedID: 42]
+        )
+
+        let result = estimator.estimate(inputs)
+
+        XCTAssertNil(result.updatedCache[droppedID])
+        XCTAssertEqual(result.updatedCache[kept.id], 99)
+    }
+
+    func testOverrideBeatsModelAndBackend() {
+        let estimator = ContextEstimator()
+        let inputs = ContextEstimator.Inputs(
+            messages: [],
+            systemPrompt: "",
+            modelContextLength: 4096,
+            contextSizeOverride: 8192,
+            backendMaxContextTokens: 2048,
+            tokenizer: nil,
+            cache: [:]
+        )
+        let result = estimator.estimate(inputs)
+        XCTAssertEqual(result.maxTokens, 8192)
+    }
+
+    func testModelContextLengthBeatsBackendWhenNoOverride() {
+        let estimator = ContextEstimator()
+        let inputs = ContextEstimator.Inputs(
+            messages: [],
+            systemPrompt: "",
+            modelContextLength: 4096,
+            contextSizeOverride: nil,
+            backendMaxContextTokens: 2048,
+            tokenizer: nil,
+            cache: [:]
+        )
+        let result = estimator.estimate(inputs)
+        XCTAssertEqual(result.maxTokens, 4096)
+    }
+
+    func testBackendUsedWhenNothingElseSet() {
+        let estimator = ContextEstimator()
+        let inputs = ContextEstimator.Inputs(
+            messages: [],
+            systemPrompt: "",
+            modelContextLength: nil,
+            contextSizeOverride: nil,
+            backendMaxContextTokens: 12345,
+            tokenizer: nil,
+            cache: [:]
+        )
+        let result = estimator.estimate(inputs)
+        XCTAssertEqual(result.maxTokens, 12345)
+    }
+}

--- a/Tests/BaseChatUITests/ContextEstimatorTests.swift
+++ b/Tests/BaseChatUITests/ContextEstimatorTests.swift
@@ -10,10 +10,23 @@ final class ContextEstimatorTests: XCTestCase {
 
     /// Call-counting tokenizer with the same ~4 chars/token heuristic used by
     /// `HeuristicTokenizer`. Lets the cache tests assert no redundant work.
+    ///
+    /// `callCount` is guarded by an NSLock to honor the `@unchecked Sendable`
+    /// conformance. Even though the current tests drive this synchronously from
+    /// the main actor, leaving the counter unsynchronized would be a latent
+    /// Sendable violation if a future test ever calls `tokenCount` off-actor.
     private final class CountingTokenizer: TokenizerProvider, @unchecked Sendable {
-        private(set) var callCount = 0
+        private let lock = NSLock()
+        private var _callCount = 0
+        var callCount: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return _callCount
+        }
         func tokenCount(_ text: String) -> Int {
-            callCount += 1
+            lock.lock()
+            _callCount += 1
+            lock.unlock()
             return max(1, text.count / 4)
         }
     }
@@ -42,7 +55,7 @@ final class ContextEstimatorTests: XCTestCase {
 
         let result = estimator.estimate(inputs)
 
-        XCTAssertEqual(result.usedTokens, 1 + 2, "empty system prompt tokenizes to 1 + message = 2")
+        XCTAssertEqual(result.usedTokens, 1 + 2, "empty system prompt tokenizes to 1 + message = 3")
         XCTAssertEqual(result.maxTokens, 2048, "default context size fallback")
         XCTAssertEqual(result.updatedCache[msg.id], 2)
     }

--- a/Tests/BaseChatUITests/MemoryPressureResponderTests.swift
+++ b/Tests/BaseChatUITests/MemoryPressureResponderTests.swift
@@ -69,8 +69,8 @@ final class MemoryPressureResponderTests: XCTestCase {
     func testNominalAfterWarningReturnsClearError() {
         let actions = responder.actions(for: .nominal, lastLevel: .warning)
         XCTAssertEqual(actions.count, 1)
-        guard case .clearError = actions[0] else {
-            XCTFail("expected .clearError, got \(actions[0])")
+        guard case .clearMemoryPressureError = actions[0] else {
+            XCTFail("expected .clearMemoryPressureError, got \(actions[0])")
             return
         }
     }
@@ -78,8 +78,8 @@ final class MemoryPressureResponderTests: XCTestCase {
     func testNominalAfterCriticalReturnsClearError() {
         let actions = responder.actions(for: .nominal, lastLevel: .critical)
         XCTAssertEqual(actions.count, 1)
-        guard case .clearError = actions[0] else {
-            XCTFail("expected .clearError, got \(actions[0])")
+        guard case .clearMemoryPressureError = actions[0] else {
+            XCTFail("expected .clearMemoryPressureError, got \(actions[0])")
             return
         }
     }

--- a/Tests/BaseChatUITests/MemoryPressureResponderTests.swift
+++ b/Tests/BaseChatUITests/MemoryPressureResponderTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import BaseChatUI
+@testable import BaseChatInference
+
+/// Unit tests for the pure `MemoryPressureResponder` action tree extracted from
+/// `ChatViewModel.handleMemoryPressure()`.
+final class MemoryPressureResponderTests: XCTestCase {
+
+    private let responder = MemoryPressureResponder()
+
+    // MARK: - Same level returns no actions
+
+    func testSameLevelReturnsEmpty() {
+        XCTAssertTrue(responder.actions(for: .nominal, lastLevel: .nominal).isEmpty)
+        XCTAssertTrue(responder.actions(for: .warning, lastLevel: .warning).isEmpty)
+        XCTAssertTrue(responder.actions(for: .critical, lastLevel: .critical).isEmpty)
+    }
+
+    // MARK: - Warning
+
+    func testWarningReturnsSetErrorWithoutUnload() {
+        let actions = responder.actions(for: .warning, lastLevel: .nominal)
+        XCTAssertEqual(actions.count, 1)
+        guard case let .setError(error) = actions[0] else {
+            XCTFail("expected .setError action, got \(actions[0])")
+            return
+        }
+        XCTAssertEqual(error.kind, .memoryPressure)
+        XCTAssertEqual(error.recovery, .dismissOnly)
+        XCTAssertTrue(error.message.contains("elevated"))
+
+        // Crucially: no stop/unload on a warning.
+        for action in actions {
+            switch action {
+            case .stopGeneration, .unloadModel:
+                XCTFail("warning must not stop generation or unload")
+            default:
+                break
+            }
+        }
+    }
+
+    // MARK: - Critical
+
+    func testCriticalReturnsStopUnloadAndError() {
+        let actions = responder.actions(for: .critical, lastLevel: .warning)
+        XCTAssertEqual(actions.count, 3)
+
+        // Order matters — the original VM called stopGeneration() and
+        // unloadModel() *before* assigning activeError.
+        guard case .stopGeneration = actions[0] else {
+            XCTFail("first action must be .stopGeneration, got \(actions[0])")
+            return
+        }
+        guard case .unloadModel = actions[1] else {
+            XCTFail("second action must be .unloadModel, got \(actions[1])")
+            return
+        }
+        guard case let .setError(error) = actions[2] else {
+            XCTFail("third action must be .setError, got \(actions[2])")
+            return
+        }
+        XCTAssertEqual(error.kind, .memoryPressure)
+        XCTAssertTrue(error.message.contains("critical"))
+    }
+
+    // MARK: - Recovery to nominal
+
+    func testNominalAfterWarningReturnsClearError() {
+        let actions = responder.actions(for: .nominal, lastLevel: .warning)
+        XCTAssertEqual(actions.count, 1)
+        guard case .clearError = actions[0] else {
+            XCTFail("expected .clearError, got \(actions[0])")
+            return
+        }
+    }
+
+    func testNominalAfterCriticalReturnsClearError() {
+        let actions = responder.actions(for: .nominal, lastLevel: .critical)
+        XCTAssertEqual(actions.count, 1)
+        guard case .clearError = actions[0] else {
+            XCTFail("expected .clearError, got \(actions[0])")
+            return
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Phase 2 of #329 — decomposes `ChatViewModel`.
- Extracts `ContextEstimator` (pure struct) from `ChatViewModel+ContextEstimation.swift`. The extension becomes a thin adapter that reads inputs from `self`, calls `estimate`, and writes the results back to `@Observable` properties and `tokenCountCache`.
- Extracts `MemoryPressureResponder` (pure struct returning actions) from `ChatViewModel+MemoryPressure.swift`. The extension applies the returned actions by mutating `activeError` / calling `stopGeneration()` / `unloadModel()`.
- Adds unit tests for each struct; existing integration/E2E tests pass unchanged.

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits`
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits`
- [x] `swift test --filter BaseChatUITests --disable-default-traits`
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits`
- [x] Sabotage verified on both new test suites

Progresses #329. Closes #353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)