### PR TITLE
fix: show loaded model name in device info popover

### DIFF
--- a/Sources/BaseChatInference/BaseChatInference.docc/Extensions/InferenceService.md
+++ b/Sources/BaseChatInference/BaseChatInference.docc/Extensions/InferenceService.md
@@ -7,6 +7,7 @@
 - ``isModelLoaded``
 - ``isGenerating``
 - ``activeBackendName``
+- ``activeModelName``
 - ``capabilities``
 - ``selectedPromptTemplate``
 - ``lastTokenUsage``

--- a/Sources/BaseChatInference/Services/InferenceService.swift
+++ b/Sources/BaseChatInference/Services/InferenceService.swift
@@ -269,8 +269,8 @@ public final class InferenceService {
     }
 
     #if DEBUG
-    public init(backend: any InferenceBackend, name: String = "Mock") {
-        self.lifecycle = ModelLifecycleCoordinator(backend: backend, name: name)
+    public init(backend: any InferenceBackend, name: String = "Mock", modelName: String? = nil) {
+        self.lifecycle = ModelLifecycleCoordinator(backend: backend, name: name, modelName: modelName)
         self.generation = GenerationCoordinator()
         generation.provider = self
     }

--- a/Sources/BaseChatInference/Services/InferenceService.swift
+++ b/Sources/BaseChatInference/Services/InferenceService.swift
@@ -69,6 +69,7 @@ public final class InferenceService {
     public var isModelLoaded: Bool { lifecycle.isModelLoaded }
     public var isGenerating: Bool { generation.isGenerating }
     public var activeBackendName: String? { lifecycle.activeBackendName }
+    public var activeModelName: String? { lifecycle.activeModelName }
     public var modelLoadProgress: Double? { lifecycle.modelLoadProgress }
 
     /// The prompt template to apply for backends that require one (GGUF).

--- a/Sources/BaseChatInference/Services/ModelLifecycleCoordinator.swift
+++ b/Sources/BaseChatInference/Services/ModelLifecycleCoordinator.swift
@@ -15,6 +15,7 @@ final class ModelLifecycleCoordinator {
 
     private(set) var isModelLoaded = false
     private(set) var activeBackendName: String?
+    private(set) var activeModelName: String?
     private(set) var modelLoadProgress: Double?
 
     // MARK: - Backend
@@ -75,6 +76,7 @@ final class ModelLifecycleCoordinator {
         self.backend = backend
         self.isModelLoaded = true
         self.activeBackendName = name
+        self.activeModelName = name
         let request = LoadRequestToken(rawValue: 1)
         self.nextLoadRequestToken = request
         self.latestRequestedLoadToken = request
@@ -219,7 +221,7 @@ final class ModelLifecycleCoordinator {
         (newBackend as? LoadProgressReporting)?.setLoadProgressHandler(nil)
 
         logLoadEvent("load.complete", request: request)
-        guard commitLoadIfCurrent(request: request, backend: newBackend, backendName: backendName) else {
+        guard commitLoadIfCurrent(request: request, backend: newBackend, backendName: backendName, modelName: modelInfo.name) else {
             newBackend.unloadModel()
             logLoadEvent("load.suppress", request: request, reason: "stale-success", clearMetadata: true)
             return
@@ -290,7 +292,8 @@ final class ModelLifecycleCoordinator {
         guard commitLoadIfCurrent(
             request: request,
             backend: newBackend,
-            backendName: endpoint.provider.rawValue
+            backendName: endpoint.provider.rawValue,
+            modelName: endpoint.modelName
         ) else {
             newBackend.unloadModel()
             logLoadEvent("load.suppress", request: request, reason: "stale-success", clearMetadata: true)
@@ -308,6 +311,7 @@ final class ModelLifecycleCoordinator {
         backend = nil
         isModelLoaded = false
         activeBackendName = nil
+        activeModelName = nil
     }
 
     // MARK: - Capability Queries
@@ -453,13 +457,15 @@ final class ModelLifecycleCoordinator {
     private func commitLoadIfCurrent(
         request: LoadRequestToken,
         backend newBackend: any InferenceBackend,
-        backendName: String
+        backendName: String,
+        modelName: String
     ) -> Bool {
         guard canCommitLoad(request) else { return false }
         backend = newBackend
         isModelLoaded = true
         modelLoadProgress = nil
         activeBackendName = backendName
+        activeModelName = modelName
         loadPhase = .loaded(request: request)
         logLoadEvent("load.commit", request: request, clearMetadata: true)
         return true

--- a/Sources/BaseChatInference/Services/ModelLifecycleCoordinator.swift
+++ b/Sources/BaseChatInference/Services/ModelLifecycleCoordinator.swift
@@ -72,18 +72,28 @@ final class ModelLifecycleCoordinator {
     nonisolated init() {}
 
     #if DEBUG
-    init(backend: any InferenceBackend, name: String = "Mock") {
+    /// Test-only seam for preloading a backend without driving the real load
+    /// pipeline.
+    ///
+    /// - Parameters:
+    ///   - backend: the pre-configured backend to install as current.
+    ///   - name: the backend engine label (e.g. "llama.cpp", "MLX"). Stored in
+    ///     ``activeBackendName`` and in request metadata as the `backend` field.
+    ///   - modelName: the human-readable model name (e.g. from `ModelInfo.name`).
+    ///     Stored in ``activeModelName``. Defaults to `nil` when the test did not
+    ///     load through the real pipeline and therefore has no model-level name.
+    init(backend: any InferenceBackend, name: String = "Mock", modelName: String? = nil) {
         self.backend = backend
         self.isModelLoaded = true
         self.activeBackendName = name
-        self.activeModelName = name
+        self.activeModelName = modelName
         let request = LoadRequestToken(rawValue: 1)
         self.nextLoadRequestToken = request
         self.latestRequestedLoadToken = request
         self.loadPhase = .loaded(request: request)
         self.loadRequestMetadataByToken[request] = LoadRequestMetadata(
             source: "debug",
-            target: name,
+            target: modelName ?? name,
             backend: name,
             startedAtUptime: ProcessInfo.processInfo.systemUptime
         )

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -335,6 +335,10 @@ public final class ChatViewModel {
         inferenceService.activeBackendName
     }
 
+    public var activeModelName: String? {
+        inferenceService.activeModelName
+    }
+
     // MARK: - Onboarding
 
     /// `true` on the very first launch (before first-run logic runs).

--- a/Sources/BaseChatUI/Views/Chat/ChatView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ChatView.swift
@@ -460,6 +460,14 @@ public struct ChatView: View {
             }
             .accessibilityValue(viewModel.isModelLoaded ? "Yes" : "No")
 
+            if let modelName = viewModel.activeModelName {
+                LabeledContent("Model") {
+                    Text(modelName)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.trailing)
+                }
+            }
+
             if let backend = viewModel.activeBackendName {
                 LabeledContent("Backend") {
                     Text(backend)

--- a/Tests/BaseChatInferenceTests/InferenceServiceObservationTests.swift
+++ b/Tests/BaseChatInferenceTests/InferenceServiceObservationTests.swift
@@ -85,6 +85,25 @@ final class InferenceServiceObservationTests: XCTestCase {
         XCTAssertNotNil(service.activeBackendName)
     }
 
+    // MARK: - activeModelName
+
+    func test_activeModelName_triggersObservation_onLoad() async throws {
+        let mock = MockInferenceBackend()
+        let service = InferenceService()
+        service.registerBackendFactory { type in type == .gguf ? mock : nil }
+
+        let changed = expectation(description: "activeModelName observed")
+        withObservationTracking {
+            _ = service.activeModelName
+        } onChange: {
+            changed.fulfill()
+        }
+
+        try await service.loadModel(from: makeModelInfo())
+        await fulfillment(of: [changed], timeout: 2)
+        XCTAssertEqual(service.activeModelName, "Test")
+    }
+
     // MARK: - modelLoadProgress
 
     func test_modelLoadProgress_triggersObservation_onLoadStart() async throws {

--- a/Tests/BaseChatInferenceTests/InferenceServiceTests.swift
+++ b/Tests/BaseChatInferenceTests/InferenceServiceTests.swift
@@ -24,6 +24,7 @@ final class InferenceServiceTests: XCTestCase {
         XCTAssertFalse(service.isModelLoaded)
         XCTAssertFalse(service.isGenerating)
         XCTAssertNil(service.activeBackendName)
+        XCTAssertNil(service.activeModelName)
     }
 
     // MARK: - Mock Backend via #if DEBUG init
@@ -121,6 +122,7 @@ final class InferenceServiceTests: XCTestCase {
         mock.isModelLoaded = true
         let service = InferenceService(backend: mock, name: "MockBackend")
         XCTAssertEqual(service.activeBackendName, "MockBackend")
+        XCTAssertEqual(service.activeModelName, "MockBackend")
     }
 
     // MARK: - loadCloudBackend
@@ -166,6 +168,7 @@ final class InferenceServiceTests: XCTestCase {
 
         XCTAssertTrue(service.isModelLoaded)
         XCTAssertEqual(service.activeBackendName, APIProvider.ollama.rawValue)
+        XCTAssertEqual(service.activeModelName, endpoint.modelName)
         XCTAssertEqual(mock.loadModelCallCount, 1)
         XCTAssertEqual(mock.configuredBaseURL?.absoluteString, endpoint.baseURL)
         XCTAssertEqual(mock.configuredModelName, endpoint.modelName)

--- a/Tests/BaseChatInferenceTests/InferenceServiceTests.swift
+++ b/Tests/BaseChatInferenceTests/InferenceServiceTests.swift
@@ -120,9 +120,19 @@ final class InferenceServiceTests: XCTestCase {
     func test_inferenceService_backendName_reflectsLoadedBackend() {
         let mock = MockInferenceBackend()
         mock.isModelLoaded = true
+        let service = InferenceService(backend: mock, name: "MockBackend", modelName: "tinyllama-1.1b")
+        XCTAssertEqual(service.activeBackendName, "MockBackend")
+        XCTAssertEqual(service.activeModelName, "tinyllama-1.1b",
+                       "debug init now routes backend label and model name to separate fields")
+    }
+
+    func test_inferenceService_activeModelName_isNilWhenDebugInitOmitsIt() {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
         let service = InferenceService(backend: mock, name: "MockBackend")
         XCTAssertEqual(service.activeBackendName, "MockBackend")
-        XCTAssertEqual(service.activeModelName, "MockBackend")
+        XCTAssertNil(service.activeModelName,
+                     "debug init without modelName leaves activeModelName unknown, not a copy of the backend label")
     }
 
     // MARK: - loadCloudBackend

--- a/Tests/BaseChatInferenceTests/ModelLifecycleCoordinatorTests.swift
+++ b/Tests/BaseChatInferenceTests/ModelLifecycleCoordinatorTests.swift
@@ -73,6 +73,8 @@ final class ModelLifecycleCoordinatorTests: XCTestCase {
         XCTAssertTrue(coordinator.isModelLoaded, "isModelLoaded must flip to true after successful commit")
         XCTAssertEqual(coordinator.activeBackendName, "llama.cpp",
                        "activeBackendName must reflect the backend that committed the load")
+        XCTAssertEqual(coordinator.activeModelName, "Test",
+                       "activeModelName must be set from ModelInfo.name at commit time")
     }
 
     // MARK: - 1b. Plan-taking overload commits identically
@@ -100,6 +102,7 @@ final class ModelLifecycleCoordinatorTests: XCTestCase {
         XCTAssertTrue(coordinator.isModelLoaded,
                       "Plan-taking overload must flip isModelLoaded on successful commit")
         XCTAssertEqual(coordinator.activeBackendName, "llama.cpp")
+        XCTAssertEqual(coordinator.activeModelName, "Test")
     }
 
     /// A plan with `verdict == .deny` must throw `memoryInsufficient` before
@@ -286,10 +289,11 @@ final class ModelLifecycleCoordinatorTests: XCTestCase {
     // MARK: - 5. Unload resets phase
 
     /// After a successful load, calling `unloadModel()` must reset `isModelLoaded`
-    /// to `false` and clear `activeBackendName`.
+    /// to `false` and clear `activeBackendName` and `activeModelName`.
     ///
     /// Sabotage: if `unloadModel()` omits resetting `isModelLoaded`, the assert below
-    /// would catch it. Equally, skipping `activeBackendName = nil` exposes the nil check.
+    /// would catch it. Equally, skipping `activeBackendName = nil` or `activeModelName = nil`
+    /// exposes those nil checks.
     func test_unloadModel_resetsPhaseToIdle() async throws {
         let (coordinator, backend) = makeCoordinatorAndGate()
 
@@ -304,6 +308,7 @@ final class ModelLifecycleCoordinatorTests: XCTestCase {
 
         XCTAssertFalse(coordinator.isModelLoaded, "isModelLoaded must be false after unloadModel()")
         XCTAssertNil(coordinator.activeBackendName, "activeBackendName must be nil after unloadModel()")
+        XCTAssertNil(coordinator.activeModelName, "activeModelName must be nil after unloadModel()")
     }
 
     // MARK: - 6. Failure on stale request is classified as stale


### PR DESCRIPTION
## Summary
- `activeBackendName` stored the backend engine name ("llama.cpp", "MLX") but there was no property for the actual loaded model name
- Added `activeModelName` to `ModelLifecycleCoordinator`, `InferenceService`, and `ChatViewModel`, populated from `ModelInfo.name` for local models and `endpoint.modelName` for cloud backends
- Device info popover now shows a "Model" row (the human-readable model name) above the existing "Backend" row

## Test plan
- [ ] Load a GGUF model and open the device info popover — "Model" row should show the model's display name, "Backend" should show "llama.cpp"
- [ ] Load an MLX model — "Model" shows the model name, "Backend" shows "MLX"
- [ ] Load a cloud endpoint — "Model" shows the configured model name (e.g. "gpt-4o"), "Backend" shows the provider
- [ ] Unload a model — both rows disappear

## Release Note
**Show loaded model name in device info popover** — the Device Info popover now shows the actual model name alongside the backend engine type, so users can confirm which model is active at a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)