### PR TITLE
fix(inference): architecture wins over Jinja template for unambiguous archs

### DIFF
--- a/Sources/BaseChatInference/Services/PromptTemplateDetector.swift
+++ b/Sources/BaseChatInference/Services/PromptTemplateDetector.swift
@@ -3,26 +3,32 @@ import Foundation
 /// Detects the best `PromptTemplate` for a model based on GGUF metadata.
 ///
 /// Uses a cascading strategy:
-/// 1. If a Jinja chat template string is present, pattern-match on template tokens.
-/// 2. If architecture is known (e.g. "llama", "phi"), map it to a template.
+/// 1. If architecture maps to an unambiguous format (phi, gemma, mistral), trust it —
+///    some Jinja templates contain compatibility-branch tokens from other formats.
+/// 2. If a Jinja chat template string is present, pattern-match on template tokens.
 /// 3. If only the model name is available, use keyword heuristics.
 /// 4. Falls back to ChatML (the most widely compatible format).
 struct PromptTemplateDetector {
 
     /// Detects the best prompt template from GGUF metadata.
     ///
-    /// Tries chat template first (most reliable), then architecture, then model name.
-    /// Returns `.chatML` as a safe default if nothing matches.
+    /// Architecture wins for unambiguous formats. For ambiguous architectures
+    /// (e.g. "llama", where many fine-tunes use different chat formats), the
+    /// Jinja template takes precedence over the architecture field.
     static func detect(from metadata: GGUFMetadata) -> PromptTemplate {
-        // 1. Try chat template string first (most reliable)
+        // 1. Architecture wins for unambiguous formats — some phi3/phi4 Jinja templates
+        //    contain <|im_start|> in compatibility branches, which fires the ChatML
+        //    heuristic before the phi-specific token check.
+        if let arch = metadata.generalArchitecture {
+            let result = detect(fromArchitecture: arch)
+            if result != .chatML { return result }
+        }
+        // 2. Chat template for ambiguous architectures (e.g. "llama" maps many
+        //    fine-tunes that use different formats the architecture can't distinguish).
         if let chatTemplate = metadata.chatTemplate {
             return detect(fromChatTemplate: chatTemplate)
         }
-        // 2. Try architecture
-        if let arch = metadata.generalArchitecture {
-            return detect(fromArchitecture: arch)
-        }
-        // 3. Try model name
+        // 3. Model name heuristic as last resort.
         if let name = metadata.generalName {
             return detect(fromFileName: name)
         }

--- a/Tests/BaseChatInferenceTests/PromptTemplateDetectorTests.swift
+++ b/Tests/BaseChatInferenceTests/PromptTemplateDetectorTests.swift
@@ -103,8 +103,24 @@ final class PromptTemplateDetectorTests: XCTestCase {
 
     // MARK: - Full Metadata Detection (Cascading Priority)
 
-    func test_detect_fromMetadata_prefersChatTemplate() {
-        // Even with architecture = "llama", a ChatML template should win
+    func test_detect_fromMetadata_unambiguousArch_winsOverChatMLTemplate() {
+        // phi3 architecture is unambiguous — even if the Jinja template contains
+        // <|im_start|> in a compatibility branch, architecture must win.
+        // Regression: Phi-4-mini-instruct was misidentified as ChatML (issue #464).
+        let metadata = GGUFMetadata(
+            generalName: "Phi-4-mini-instruct",
+            generalArchitecture: "phi3",
+            contextLength: 4096,
+            chatTemplate: "{% if true %}<|im_start|>system\n{{ content }}<|im_end|>{% endif %}<|user|>\n{{ content }}<|end|>\n<|assistant|>",
+            fileType: nil
+        )
+        XCTAssertEqual(PromptTemplateDetector.detect(from: metadata), .phi,
+                       "phi3 architecture must override a Jinja template that contains ChatML tokens")
+    }
+
+    func test_detect_fromMetadata_llama_chatTemplateWinsOverArchitecture() {
+        // "llama" is ambiguous — many fine-tunes use different formats.
+        // A ChatML Jinja template on an llama-arch model should still produce ChatML.
         let metadata = GGUFMetadata(
             generalName: "Mistral-7B",
             generalArchitecture: "llama",
@@ -112,7 +128,6 @@ final class PromptTemplateDetectorTests: XCTestCase {
             chatTemplate: "<|im_start|>system\n{{ content }}<|im_end|>",
             fileType: nil
         )
-
         XCTAssertEqual(PromptTemplateDetector.detect(from: metadata), .chatML)
     }
 

--- a/Tests/BaseChatInferenceTests/PromptTemplateDetectorTests.swift
+++ b/Tests/BaseChatInferenceTests/PromptTemplateDetectorTests.swift
@@ -131,7 +131,9 @@ final class PromptTemplateDetectorTests: XCTestCase {
         XCTAssertEqual(PromptTemplateDetector.detect(from: metadata), .chatML)
     }
 
-    func test_detect_fromMetadata_fallsBackToArchitecture() {
+    func test_detect_fromMetadata_unambiguousArch_noTemplate_returnsArchFormat() {
+        // Architecture is the primary check for unambiguous formats — "fallback" framing
+        // no longer applies now that architecture is checked first.
         let metadata = GGUFMetadata(
             generalName: "SomeModel",
             generalArchitecture: "mistral",
@@ -139,8 +141,37 @@ final class PromptTemplateDetectorTests: XCTestCase {
             chatTemplate: nil,
             fileType: nil
         )
-
         XCTAssertEqual(PromptTemplateDetector.detect(from: metadata), .mistral)
+    }
+
+    func test_detect_fromMetadata_unambiguousArch_winsOverConflictingTemplate() {
+        // Architecture wins for unambiguous formats even when the Jinja template
+        // would map to a different non-ChatML format. Ensures the fix is not
+        // limited to the ChatML collision case.
+        let metadata = GGUFMetadata(
+            generalName: "SomeGemmaModel",
+            generalArchitecture: "gemma",
+            contextLength: 4096,
+            chatTemplate: "<|user|>\n{{ content }}<|end|>\n<|assistant|>",
+            fileType: nil
+        )
+        XCTAssertEqual(PromptTemplateDetector.detect(from: metadata), .gemma,
+                       "gemma architecture must win over a phi-style Jinja template")
+    }
+
+    func test_detect_fromMetadata_llama_nonChatMLTemplateWinsOverArchitecture() {
+        // "llama" is ambiguous: SmolLM2, TinyLlama, etc. use llama arch but different
+        // chat formats. A llama3-header Jinja template on a llama-arch model must
+        // produce .llama3, not the .chatML that the architecture alone would return.
+        let metadata = GGUFMetadata(
+            generalName: "SmolLM2-1.7B-Instruct",
+            generalArchitecture: "llama",
+            contextLength: 8192,
+            chatTemplate: "<|begin_of_text|><|start_header_id|>system<|end_header_id|>{{ content }}<|eot_id|>",
+            fileType: nil
+        )
+        XCTAssertEqual(PromptTemplateDetector.detect(from: metadata), .llama3,
+                       "llama3-format Jinja template must win over ambiguous llama architecture")
     }
 
     func test_detect_fromMetadata_fallsBackToName() {


### PR DESCRIPTION
Closes #464

## Summary
- `PromptTemplateDetector.detect(from:)` checked the Jinja chat template before the model architecture. Some phi3/phi4 GGUF files contain `<|im_start|>` tokens in compatibility branches of their Jinja template, causing the ChatML heuristic to fire before the phi-specific `<|user|>`/`<|assistant|>` check.
- New cascade order: architecture first for unambiguous formats (phi, phi3, gemma, gemma2, mistral); Jinja template for ambiguous architectures (llama and unknown); model name heuristic as last resort.

## Test plan
- [ ] `Phi-4-mini-instruct-Q4_K_M.gguf` (arch = `phi3`, template contains `<|im_start|>`) → detects `.phi`, not `.chatML`
- [ ] `llama`-arch model with ChatML Jinja template → still detects `.chatML` (llama stays ambiguous, template wins)
- [ ] Unambiguous archs without a template → still fall through to architecture correctly
- [ ] All existing `PromptTemplateDetectorTests` pass

## Release Note
**Fix phi3/phi4 prompt template misdetection** — `Phi-4-mini-instruct` and similar models whose GGUF Jinja templates contain ChatML compatibility tokens were incorrectly identified as ChatML format. The detector now trusts the `general.architecture` field for unambiguous architectures (phi, gemma, mistral), preventing mixed-format tokens in generated output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)