### PR TITLE
fix(inference): strip <think>...</think> reasoning blocks from MLX and Llama output (#469)

### DIFF
--- a/Sources/BaseChatBackends/LlamaGenerationDriver.swift
+++ b/Sources/BaseChatBackends/LlamaGenerationDriver.swift
@@ -161,6 +161,7 @@ struct LlamaGenerationDriver {
         var nCur = tokens.count
         var invalidUTF8: [CChar] = []
         var isFirstToken = true
+        var thinkingFilter = ThinkingBlockFilter()
 
         for iteration in 0..<maxTokens {
             if isCancelled() { break }
@@ -176,11 +177,14 @@ struct LlamaGenerationDriver {
 
             // Decode token to text
             if let text = LlamaTokenization.tokenToString(token, vocab: vocab, invalidUTF8Buffer: &invalidUTF8) {
-                if isFirstToken {
-                    await MainActor.run { generationStream.setPhase(.streaming) }
-                    isFirstToken = false
+                let visible = thinkingFilter.process(text)
+                if !visible.isEmpty {
+                    if isFirstToken {
+                        await MainActor.run { generationStream.setPhase(.streaming) }
+                        isFirstToken = false
+                    }
+                    continuation.yield(.token(visible))
                 }
-                continuation.yield(.token(text))
             }
 
             // Prepare next batch

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -204,19 +204,23 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 let outputLimit = config.maxOutputTokens
                 var outputTokenCount = 0
                 var isFirstToken = true
+                var thinkingFilter = ThinkingBlockFilter()
                 let mlxStream = try await modelContainer.generate(
                     messages: messages,
                     parameters: generateConfig
                 )
                 for await generation in mlxStream {
                     if Task.isCancelled { break }
-                    if let text = generation.chunk {
-                        if isFirstToken {
-                            await MainActor.run { generationStream.setPhase(.streaming) }
-                            isFirstToken = false
+                    if let raw = generation.chunk {
+                        let visible = thinkingFilter.process(raw)
+                        if !visible.isEmpty {
+                            if isFirstToken {
+                                await MainActor.run { generationStream.setPhase(.streaming) }
+                                isFirstToken = false
+                            }
+                            continuation.yield(.token(visible))
                         }
-                        continuation.yield(.token(text))
-                        // Each chunk from MLX corresponds to one token.
+                        // output token counting still uses raw chunks (each MLX chunk = 1 token)
                         if let limit = outputLimit {
                             outputTokenCount += 1
                             if outputTokenCount >= limit { break }

--- a/Sources/BaseChatInference/ThinkingBlockFilter.swift
+++ b/Sources/BaseChatInference/ThinkingBlockFilter.swift
@@ -1,0 +1,79 @@
+/// Stateful, chunk-safe filter that strips `<think>...</think>` reasoning blocks
+/// from streamed token output.
+///
+/// Tokens arrive as arbitrary-length strings that may split a tag across boundaries.
+/// The filter buffers incomplete tag prefixes until enough characters arrive to
+/// confirm or reject a match.
+public struct ThinkingBlockFilter {
+    private var depth = 0
+    private var buffer = ""
+
+    public init() {}
+
+    /// Process one token chunk. Returns the visible portion (may be empty).
+    public mutating func process(_ chunk: String) -> String {
+        buffer += chunk
+        return flush()
+    }
+
+    private mutating func flush() -> String {
+        var output = ""
+
+        while !buffer.isEmpty {
+            if depth == 0 {
+                // Visible mode: emit text up to the next '<'
+                if let angleIdx = buffer.firstIndex(of: "<") {
+                    // Emit everything before the '<'
+                    output += buffer[buffer.startIndex..<angleIdx]
+                    buffer = String(buffer[angleIdx...])
+
+                    // Now buffer starts with '<'; check for tag or partial
+                    if buffer.hasPrefix("<think>") {
+                        depth += 1
+                        buffer = String(buffer.dropFirst("<think>".count))
+                    } else if buffer.hasPrefix("</think>") {
+                        // Mismatched close tag in visible mode — swallow it
+                        // (depth can't go negative, so treat as visible but consume the tag)
+                        buffer = String(buffer.dropFirst("</think>".count))
+                    } else if "<think>".hasPrefix(buffer) || "</think>".hasPrefix(buffer) {
+                        // Partial prefix — wait for more input
+                        break
+                    } else {
+                        // Not a think-related tag; emit the '<' and continue
+                        output += "<"
+                        buffer = String(buffer.dropFirst())
+                    }
+                } else {
+                    // No '<' in buffer — all visible
+                    output += buffer
+                    buffer = ""
+                }
+            } else {
+                // Suppressed mode: skip everything, only look for tag boundaries
+                if let angleIdx = buffer.firstIndex(of: "<") {
+                    // Discard text before '<'
+                    buffer = String(buffer[angleIdx...])
+
+                    if buffer.hasPrefix("<think>") {
+                        depth += 1
+                        buffer = String(buffer.dropFirst("<think>".count))
+                    } else if buffer.hasPrefix("</think>") {
+                        depth = max(0, depth - 1)
+                        buffer = String(buffer.dropFirst("</think>".count))
+                    } else if "<think>".hasPrefix(buffer) || "</think>".hasPrefix(buffer) {
+                        // Partial prefix — wait for more input
+                        break
+                    } else {
+                        // Non-think '<' inside a thinking block — swallow it
+                        buffer = String(buffer.dropFirst())
+                    }
+                } else {
+                    // No '<' — all suppressed, discard
+                    buffer = ""
+                }
+            }
+        }
+
+        return output
+    }
+}

--- a/Sources/BaseChatInference/ThinkingBlockFilter.swift
+++ b/Sources/BaseChatInference/ThinkingBlockFilter.swift
@@ -27,19 +27,15 @@ public struct ThinkingBlockFilter {
                     output += buffer[buffer.startIndex..<angleIdx]
                     buffer = String(buffer[angleIdx...])
 
-                    // Now buffer starts with '<'; check for tag or partial
+                    // Now buffer starts with '<'; only an opening think tag is special
                     if buffer.hasPrefix("<think>") {
                         depth += 1
                         buffer = String(buffer.dropFirst("<think>".count))
-                    } else if buffer.hasPrefix("</think>") {
-                        // Mismatched close tag in visible mode — swallow it
-                        // (depth can't go negative, so treat as visible but consume the tag)
-                        buffer = String(buffer.dropFirst("</think>".count))
-                    } else if "<think>".hasPrefix(buffer) || "</think>".hasPrefix(buffer) {
-                        // Partial prefix — wait for more input
+                    } else if "<think>".hasPrefix(buffer) {
+                        // Partial opening tag prefix — wait for more input
                         break
                     } else {
-                        // Not a think-related tag; emit the '<' and continue
+                        // Any other '<' sequence, including '</think>', is visible text
                         output += "<"
                         buffer = String(buffer.dropFirst())
                     }

--- a/Tests/BaseChatInferenceTests/ThinkingBlockFilterTests.swift
+++ b/Tests/BaseChatInferenceTests/ThinkingBlockFilterTests.swift
@@ -85,4 +85,11 @@ final class ThinkingBlockFilterTests: XCTestCase {
         let result = collect(chunks, filter: &filter)
         XCTAssertEqual(result, "Sure!  Here is your answer.")
     }
+
+    /// A literal closing tag in visible text must be preserved when not inside a think block.
+    func test_literalClosingTagInVisibleText_passThrough() {
+        var filter = ThinkingBlockFilter()
+        let result = filter.process("Visible </think> text")
+        XCTAssertEqual(result, "Visible </think> text")
+    }
 }

--- a/Tests/BaseChatInferenceTests/ThinkingBlockFilterTests.swift
+++ b/Tests/BaseChatInferenceTests/ThinkingBlockFilterTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import BaseChatInference
+
+final class ThinkingBlockFilterTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Feeds each chunk through a fresh-ish filter instance and accumulates output.
+    private func collect(_ chunks: [String], filter: inout ThinkingBlockFilter) -> String {
+        chunks.reduce("") { $0 + filter.process($1) }
+    }
+
+    // MARK: - Tests
+
+    /// Plain text with no think tags should pass through unchanged.
+    func test_noThinkTags_passThrough() {
+        var filter = ThinkingBlockFilter()
+        let result = collect(["Hello, ", "world!"], filter: &filter)
+        XCTAssertEqual(result, "Hello, world!")
+    }
+
+    /// A complete `<think>...</think>` block delivered in one chunk should be suppressed.
+    func test_singleCompleteBlock_suppressed() {
+        var filter = ThinkingBlockFilter()
+        let result = filter.process("<think>hidden reasoning</think>visible answer")
+        XCTAssertEqual(result, "visible answer")
+    }
+
+    /// Tags split across chunk boundaries must still be correctly filtered.
+    func test_splitTags_filteredCorrectly() {
+        var filter = ThinkingBlockFilter()
+        let chunks = ["<thi", "nk>", "hidden", "</th", "ink>", "visible"]
+        let result = collect(chunks, filter: &filter)
+        XCTAssertEqual(result, "visible")
+    }
+
+    /// Nested `<think>` tags require depth tracking — only the outermost close ends suppression.
+    func test_nestedTags_depthTracked() {
+        var filter = ThinkingBlockFilter()
+        let result = filter.process("<think>a<think>b</think>c</think>d")
+        XCTAssertEqual(result, "d")
+    }
+
+    /// A think block at the very start of a response is suppressed; text after is visible.
+    func test_thinkBlockAtStart_visibleAfter() {
+        var filter = ThinkingBlockFilter()
+        let result = filter.process("<think>reasoning</think>answer")
+        XCTAssertEqual(result, "answer")
+    }
+
+    /// Multiple think blocks interleaved with visible text — only visible text is emitted.
+    func test_multipleThinkBlocks_onlyVisibleEmitted() {
+        var filter = ThinkingBlockFilter()
+        let result = filter.process("<think>r1</think>text1<think>r2</think>text2")
+        XCTAssertEqual(result, "text1text2")
+    }
+
+    /// A non-think `<` in visible text (e.g., HTML entity or comparison) passes through.
+    func test_nonThinkAngleBracket_passThrough() {
+        var filter = ThinkingBlockFilter()
+        let result = filter.process("Hello <world>")
+        XCTAssertEqual(result, "Hello <world>")
+    }
+
+    /// A partial tag at end of stream stays buffered and is not emitted as visible text.
+    /// This is the safe behaviour — better to suppress than to leak tag fragments.
+    func test_partialTagAtStreamEnd_notEmitted() {
+        var filter = ThinkingBlockFilter()
+        let result = filter.process("<thi")
+        // The partial prefix is held in the buffer — nothing visible yet.
+        XCTAssertEqual(result, "")
+    }
+
+    /// Visible text before a partial tag is emitted, while the partial tag is held.
+    func test_visibleTextBeforePartialTag_emitted() {
+        var filter = ThinkingBlockFilter()
+        let result = filter.process("hello <thi")
+        XCTAssertEqual(result, "hello ")
+    }
+
+    /// Multi-chunk scenario: visible text, then a think block split across many tokens.
+    func test_multiChunk_mixedContent() {
+        var filter = ThinkingBlockFilter()
+        let chunks = ["Sure! ", "<think>", "internal reasoning", "</think>", " Here is your answer."]
+        let result = collect(chunks, filter: &filter)
+        XCTAssertEqual(result, "Sure!  Here is your answer.")
+    }
+}


### PR DESCRIPTION
## Summary

Qwen3 and other chain-of-thought models emit `<think>...</think>` reasoning blocks before their actual response. Both `MLXBackend` and `LlamaBackend` previously forwarded every token to the UI, leaking the internal monologue into the chat canvas.

- **`ThinkingBlockFilter`** (`Sources/BaseChatInference/ThinkingBlockFilter.swift`) — chunk-safe, stateful filter that strips `<think>…</think>` blocks from streamed token output. Handles tags split across token boundaries by buffering partial matches. Supports nested blocks via a depth counter.
- **`MLXBackend`** — `ThinkingBlockFilter` applied to each `generation.chunk` in the stream loop. The `.streaming` phase transition is deferred until the first *visible* token.
- **`LlamaBackend`** — same filter applied to each decoded token string in the generation loop.

## Test plan

- [x] `ThinkingBlockFilterTests` — 10 cases: passthrough, single block, split tags, nested, multi-block, non-think `<`, partial-at-stream-end, visible text before partial tag, multi-chunk mixed content
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — all passed
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — all passed
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — all passed
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — all passed

## Release Note

**Qwen3 and reasoning model thinking blocks are now filtered from chat output** — `<think>…</think>` sections emitted by chain-of-thought models (Qwen3, DeepSeek-R1, etc.) are stripped before tokens reach the UI. The filter is chunk-safe and handles tags split across token boundaries. Closes #469.