### PR TITLE
fix(memory): subtract iOS app-overhead margin from KV budget to prevent jetsam SIGKILL (#471)

### DIFF
--- a/Sources/BaseChatInference/Services/ModelLoadPlan.swift
+++ b/Sources/BaseChatInference/Services/ModelLoadPlan.swift
@@ -20,6 +20,7 @@ public struct ModelLoadPlan: Sendable {
         public let physicalMemoryBytes: UInt64
         public let absoluteContextCeiling: Int
         public let headroomFraction: Double
+        public let appOverheadBytes: UInt64
 
         public init(
             modelFileSize: UInt64,
@@ -30,7 +31,8 @@ public struct ModelLoadPlan: Sendable {
             availableMemoryBytes: UInt64,
             physicalMemoryBytes: UInt64,
             absoluteContextCeiling: Int,
-            headroomFraction: Double
+            headroomFraction: Double,
+            appOverheadBytes: UInt64 = 0
         ) {
             self.modelFileSize = modelFileSize
             self.memoryStrategy = memoryStrategy
@@ -41,6 +43,7 @@ public struct ModelLoadPlan: Sendable {
             self.physicalMemoryBytes = physicalMemoryBytes
             self.absoluteContextCeiling = absoluteContextCeiling
             self.headroomFraction = headroomFraction
+            self.appOverheadBytes = appOverheadBytes
         }
     }
 
@@ -140,6 +143,13 @@ public struct ModelLoadPlan: Sendable {
         let available = inputs.availableMemoryBytes
         let headroom = inputs.headroomFraction
 
+        // Subtract platform app overhead before KV budget math. On iOS the jetsam limit
+        // is below `recommendedMaxWorkingSetSize`; leaving no headroom for SwiftData, UI,
+        // and OS bookkeeping causes SIGKILL. See issue #471.
+        let effective_available = available > inputs.appOverheadBytes
+            ? available - inputs.appOverheadBytes
+            : 0
+
         // Resident budget: full weights for .resident, a mmap-style fraction for .mappable.
         // .external keeps the legacy behaviour of "no local weight memory" — 0 resident.
         let residentBudget: UInt64
@@ -164,7 +174,7 @@ public struct ModelLoadPlan: Sendable {
         // KV budget: what's left of available memory after the resident reserve, minus
         // the caller-specified headroom fraction. Saturating subtraction so we never
         // underflow UInt64 when resident > available * (1 - headroom).
-        let reserveAfterHeadroom = UInt64(Double(available) * (1.0 - headroom))
+        let reserveAfterHeadroom = UInt64(Double(effective_available) * (1.0 - headroom))
         let kvBudget: UInt64 = reserveAfterHeadroom > residentBudget
             ? reserveAfterHeadroom - residentBudget
             : 0
@@ -282,6 +292,18 @@ public struct ModelLoadPlan: Sendable {
             ? model.estimatedKVBytesPerToken!
             : GGUFKVCacheEstimator.legacyFallbackBytesPerToken
 
+        #if os(iOS) || os(visionOS)
+        // 800 MiB headroom for SwiftData, UI, and OS on memory-constrained iOS devices.
+        // iOS jetsam kills apps below `recommendedMaxWorkingSetSize`; this margin keeps
+        // the KV budget inside the true usable ceiling. Not applied on high-RAM iPads
+        // (≥ 12 GB physical) where pressure behaviour is closer to macOS. See #471.
+        let appOverhead: UInt64 = environment.physicalMemoryBytes < 12_884_901_888
+            ? 838_860_800   // 800 MiB
+            : 0
+        #else
+        let appOverhead: UInt64 = 0
+        #endif
+
         let inputs = Inputs(
             modelFileSize: model.fileSize,
             memoryStrategy: strategy,
@@ -291,7 +313,8 @@ public struct ModelLoadPlan: Sendable {
             availableMemoryBytes: environment.availableMemoryBytes(),
             physicalMemoryBytes: environment.physicalMemoryBytes,
             absoluteContextCeiling: absoluteContextCeiling,
-            headroomFraction: headroomFraction
+            headroomFraction: headroomFraction,
+            appOverheadBytes: appOverhead
         )
         return compute(inputs: inputs)
     }

--- a/Tests/BaseChatInferenceTests/ModelLoadPlanTests.swift
+++ b/Tests/BaseChatInferenceTests/ModelLoadPlanTests.swift
@@ -796,6 +796,105 @@ final class ModelLoadPlanTests: XCTestCase {
                           "12 GB - 1B / 4 GB (ratio < 3) must not be denied by the impossible-fit guard")
     }
 
+    // MARK: - App overhead (issue #471)
+
+    /// Overhead bytes reduce the effective KV budget, producing a smaller
+    /// `effectiveContextSize` than the same inputs with no overhead.
+    func test_appOverhead_reducesKVBudget() {
+        let available: UInt64 = 5_000_000_000
+        let overhead: UInt64 = 838_860_800  // 800 MiB
+
+        let withOverhead = ModelLoadPlan.compute(inputs: ModelLoadPlan.Inputs(
+            modelFileSize: 3 * oneGB,
+            memoryStrategy: .mappable,
+            requestedContextSize: 128_000,
+            trainedContextLength: 131_072,
+            kvBytesPerToken: 65_536,
+            availableMemoryBytes: available,
+            physicalMemoryBytes: 8 * oneGB,
+            absoluteContextCeiling: 128_000,
+            headroomFraction: 0.40,
+            appOverheadBytes: overhead
+        ))
+
+        let withoutOverhead = ModelLoadPlan.compute(inputs: ModelLoadPlan.Inputs(
+            modelFileSize: 3 * oneGB,
+            memoryStrategy: .mappable,
+            requestedContextSize: 128_000,
+            trainedContextLength: 131_072,
+            kvBytesPerToken: 65_536,
+            availableMemoryBytes: available,
+            physicalMemoryBytes: 8 * oneGB,
+            absoluteContextCeiling: 128_000,
+            headroomFraction: 0.40,
+            appOverheadBytes: 0
+        ))
+
+        XCTAssertLessThan(
+            withOverhead.effectiveContextSize,
+            withoutOverhead.effectiveContextSize,
+            "App overhead must reduce the effective context size vs no-overhead baseline"
+        )
+    }
+
+    /// When `appOverheadBytes` exceeds `availableMemoryBytes`, the plan must not
+    /// underflow UInt64 and must floor `effectiveContextSize` at 1.
+    func test_appOverhead_largerThanAvailable_doesNotUnderflow() {
+        let plan = ModelLoadPlan.compute(inputs: ModelLoadPlan.Inputs(
+            modelFileSize: 500_000_000,
+            memoryStrategy: .mappable,
+            requestedContextSize: 4096,
+            trainedContextLength: 8192,
+            kvBytesPerToken: 8_192,
+            availableMemoryBytes: 100_000_000,
+            physicalMemoryBytes: 8 * oneGB,
+            absoluteContextCeiling: 128_000,
+            headroomFraction: 0.40,
+            appOverheadBytes: 200_000_000  // overhead > available
+        ))
+
+        XCTAssertGreaterThanOrEqual(plan.effectiveContextSize, 1,
+            "Effective context must floor at 1 when overhead exceeds available memory")
+        // Also verify totalEstimatedBytes is a sane value, not a UInt64 wraparound.
+        XCTAssertLessThan(plan.outcome.totalEstimatedBytes, UInt64.max / 2,
+            "Total estimated bytes must not contain a UInt64 underflow value")
+    }
+
+    /// Default `appOverheadBytes: 0` must produce exactly the same
+    /// `effectiveContextSize` as inputs constructed without the field — no-op
+    /// regression guard for existing callers.
+    func test_appOverhead_zero_preservesExistingBehaviour() {
+        let inputsOld = makeInputs(
+            modelFileSize: 4 * oneGB,
+            strategy: .mappable,
+            requested: 32_000,
+            trained: 131_072,
+            kvBytesPerToken: 65_536,
+            available: 8 * oneGB
+        )
+        // New inputs with explicit appOverheadBytes: 0 — must be identical.
+        let inputsNew = ModelLoadPlan.Inputs(
+            modelFileSize: 4 * oneGB,
+            memoryStrategy: .mappable,
+            requestedContextSize: 32_000,
+            trainedContextLength: 131_072,
+            kvBytesPerToken: 65_536,
+            availableMemoryBytes: 8 * oneGB,
+            physicalMemoryBytes: 16_000_000_000,
+            absoluteContextCeiling: 128_000,
+            headroomFraction: 0.40,
+            appOverheadBytes: 0
+        )
+
+        let planOld = ModelLoadPlan.compute(inputs: inputsOld)
+        let planNew = ModelLoadPlan.compute(inputs: inputsNew)
+
+        XCTAssertEqual(planNew.effectiveContextSize, planOld.effectiveContextSize,
+            "appOverheadBytes: 0 must preserve existing behaviour")
+        XCTAssertEqual(planNew.verdict, planOld.verdict,
+            "appOverheadBytes: 0 must produce the same verdict as the legacy path")
+    }
+
     func test_70BModelOn4GBDevice_residentStrategy_neverAllows() {
         // 70B at ~4-bit quant ~ 40 GB file. Use a generous 140 GB upper bound
         // to also cover fp16 distributions.


### PR DESCRIPTION
## Summary

On iPhone (A18 Pro, 8 GB), loading Phi-4-mini-instruct-Q4_K_M.gguf was crashing with SIGKILL from the iOS jetsam watchdog. `ModelLoadPlan` was using `recommendedMaxWorkingSetSize` as the memory ceiling and computing a KV budget that left no room for SwiftData, UI, and OS overhead (~800 MiB in practice). The jetsam limit is consistently lower than `recommendedMaxWorkingSetSize`.

**`ModelLoadPlan.Inputs`** gains a new `appOverheadBytes: UInt64 = 0` field (default preserves all existing behaviour). In `compute(inputs:)`, this is subtracted from `availableMemoryBytes` before the KV budget calculation, tightening the context size ceiling.

**`compute(for:model:...)`** sets `appOverheadBytes` to 800 MiB on iOS/visionOS devices with < 12 GB physical RAM. High-RAM iPads and macOS are unaffected.

## Test plan

- [x] `test_appOverhead_reducesKVBudget` — overhead reduces effective context vs no-overhead baseline
- [x] `test_appOverhead_largerThanAvailable_doesNotUnderflow` — no crash when overhead > available
- [x] `test_appOverhead_zero_preservesExistingBehaviour` — default `appOverheadBytes: 0` is a no-op
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — all passed
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — all passed
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — all passed
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — all passed

## Release Note

**Fixed SIGKILL crash when loading large GGUF models on iPhone** — `ModelLoadPlan` now subtracts an 800 MiB app-overhead margin from the available memory on iOS/visionOS devices with less than 12 GB RAM before computing the KV cache budget. This keeps the effective context size inside the real jetsam ceiling rather than the optimistic `recommendedMaxWorkingSetSize` value. Closes #471.