### PR TITLE
fix: prevent task-teardown bleed and replace preconditionFailure in ModelStorageService

### DIFF
--- a/Sources/BaseChatInference/Services/GenerationCoordinator.swift
+++ b/Sources/BaseChatInference/Services/GenerationCoordinator.swift
@@ -428,7 +428,7 @@ final class GenerationCoordinator {
     /// Cancels active generation and awaits the task's completion before returning.
     ///
     /// Captures the active task handle before calling `stopGeneration()` so the
-    /// task's defer block finishes before tearDown proceeds to the next test.
+    /// task's defer block fully completes before the caller proceeds.
     func stopGenerationAndWait() async {
         let task = activeTask
         stopGeneration()

--- a/Sources/BaseChatInference/Services/GenerationCoordinator.swift
+++ b/Sources/BaseChatInference/Services/GenerationCoordinator.swift
@@ -425,4 +425,14 @@ final class GenerationCoordinator {
         requestQueue.removeAll()
     }
 
+    /// Cancels active generation and awaits the task's completion before returning.
+    ///
+    /// Captures the active task handle before calling `stopGeneration()` so the
+    /// task's defer block finishes before tearDown proceeds to the next test.
+    func stopGenerationAndWait() async {
+        let task = activeTask
+        stopGeneration()
+        await task?.value
+    }
+
 }

--- a/Sources/BaseChatInference/Services/ModelStorageService.swift
+++ b/Sources/BaseChatInference/Services/ModelStorageService.swift
@@ -24,12 +24,14 @@ public final class ModelStorageService {
     /// Can be overridden via `baseDirectory` at init time (used in tests).
     public var modelsDirectory: URL {
         if let custom = customDirectory { return custom }
-        guard let documents = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else {
-            // documentDirectory is always available on Apple platforms.
-            // Crash here would indicate a fundamental OS problem.
-            preconditionFailure("Documents directory unavailable")
+        let base: URL
+        if let documents = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first {
+            base = documents
+        } else {
+            Log.inference.fault("Documents directory unavailable — falling back to temp directory")
+            base = fileManager.temporaryDirectory
         }
-        return documents.appendingPathComponent(
+        return base.appendingPathComponent(
             BaseChatConfiguration.shared.modelsDirectoryName,
             isDirectory: true
         )

--- a/Tests/BaseChatInferenceTests/GenerationCoordinatorTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationCoordinatorTests.swift
@@ -32,7 +32,9 @@ final class GenerationCoordinatorTests: XCTestCase {
     }
 
     override func tearDown() async throws {
-        coordinator?.stopGeneration()
+        // stopGenerationAndWait() cancels the active task and awaits its completion,
+        // preventing the task's defer block from bleeding into the next test's setUp.
+        await coordinator?.stopGenerationAndWait()
         coordinator = nil
         provider = nil
         try await super.tearDown()


### PR DESCRIPTION
## Summary

Fixes #465 — intermittent SIGABRT in `BaseChatInferenceTests` CI (signal 6, fires between `BackendCapabilitiesTests` tests).

Two root-cause candidates addressed:

- **`preconditionFailure` in `ModelStorageService.modelsDirectory`**: fires in ALL build configs (including CI), violates CLAUDE.md policy for conditions with fallback logic. Replaced with `Log.inference.fault` + `fileManager.temporaryDirectory` fallback.

- **Task-teardown bleed in `GenerationCoordinatorTests`**: `tearDown` called `stopGeneration()` which cancelled `activeTask` and nilled it synchronously, but the `@MainActor` task's `defer` block could fire during the *next* test's setUp, corrupting the coordinator's state. Added `stopGenerationAndWait()` that captures the task handle before cancelling and awaits its natural completion.

## Test plan

- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 69 tests, 0 failures
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 196 tests, 0 failures
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 437 tests, 0 failures
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 88 tests, 0 failures
- [ ] Confirm green on 5 consecutive CI runs after merge

## Release Note

**Fix intermittent SIGABRT in BaseChatInferenceTests CI** — replaces a `preconditionFailure` (active in all build configs) with a graceful fallback in `ModelStorageService`, and adds `stopGenerationAndWait()` to `GenerationCoordinator` so cancelled task defer blocks complete before the next test begins, eliminating a state-corruption window between tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)