### PR TITLE
feat(inference): expose thinking/reasoning tokens as structured GenerationEvents

### DIFF
--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -305,6 +305,7 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
                 tokens: tokens,
                 maxTokens: maxTokens,
                 config: config,
+                markers: config.thinkingMarkers,
                 isCancelled: {
                     Task.isCancelled || self.cancelled.load(ordering: .sequentiallyConsistent)
                 },

--- a/Sources/BaseChatBackends/LlamaGenerationDriver.swift
+++ b/Sources/BaseChatBackends/LlamaGenerationDriver.swift
@@ -34,6 +34,9 @@ struct LlamaGenerationDriver {
     ///   - tokens: Tokenized prompt (including BOS) — computed before the Task.
     ///   - maxTokens: Maximum number of new tokens to generate.
     ///   - config: Sampling parameters (temperature, topP, repeatPenalty).
+    ///   - markers: Thinking markers for the active template, or nil to disable ThinkingParser.
+    ///     When non-nil, `.thinkingToken` / `.thinkingComplete` events are emitted for reasoning
+    ///     content and `config.maxThinkingTokens` is enforced.
     ///   - isCancelled: Closure that returns `true` when the caller has requested
     ///     cancellation (combines `Task.isCancelled` and the backend's `Atomic<Bool>`).
     ///   - generationStream: Stream whose phase is updated on the main actor.
@@ -44,6 +47,7 @@ struct LlamaGenerationDriver {
         tokens: [llama_token],
         maxTokens: Int,
         config: GenerationConfig,
+        markers: ThinkingMarkers?,
         isCancelled: () -> Bool,
         generationStream: GenerationStream,
         continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
@@ -161,7 +165,14 @@ struct LlamaGenerationDriver {
         var nCur = tokens.count
         var invalidUTF8: [CChar] = []
         var isFirstToken = true
-        var thinkingFilter = ThinkingBlockFilter()
+
+        // ThinkingParser is activated only when markers are provided (i.e. the
+        // active prompt template emits reasoning blocks). When `useParser` is
+        // false, every decoded token is yielded directly as `.token` without the
+        // overhead of tag scanning — important for models that never think.
+        let useParser = markers != nil
+        var thinkingParser = ThinkingParser(markers: markers ?? .qwen3)
+        var thinkingTokenCount = 0
 
         for iteration in 0..<maxTokens {
             if isCancelled() { break }
@@ -175,22 +186,24 @@ struct LlamaGenerationDriver {
 
             if llama_vocab_is_eog(vocab, token) { break }
 
-            // Decode token to text
+            // Decode token to text and route through ThinkingParser when active.
             if let text = LlamaTokenization.tokenToString(token, vocab: vocab, invalidUTF8Buffer: &invalidUTF8) {
-                let events = thinkingFilter.process(text)
-                for evt in events {
-                    switch evt {
-                    case .token(let visible):
-                        if isFirstToken {
+                let events: [GenerationEvent] = useParser ? thinkingParser.process(text) : [.token(text)]
+                for event in events {
+                    if isFirstToken {
+                        switch event {
+                        case .token, .thinkingToken:
+                            // Trigger .streaming on first reasoning token too — models can think
+                            // for 30s before any visible output; staying in .connecting is poor UX.
                             await MainActor.run { generationStream.setPhase(.streaming) }
                             isFirstToken = false
+                        default: break
                         }
-                        continuation.yield(.token(visible))
-                    case .thinkingToken, .thinkingComplete:
-                        // Phase 2 will route thinking events; for now pass them through.
-                        continuation.yield(evt)
-                    default:
-                        break
+                    }
+                    continuation.yield(event)
+                    if case .thinkingToken = event {
+                        thinkingTokenCount += 1
+                        if let limit = config.maxThinkingTokens, thinkingTokenCount >= limit { break }
                     }
                 }
             }
@@ -212,6 +225,11 @@ struct LlamaGenerationDriver {
                 continuation.finish(throwing: InferenceError.inferenceFailure("Decode failed during generation"))
                 return
             }
+        }
+
+        // Flush any bytes held back by the tag-boundary buffer.
+        for event in thinkingParser.finalize() {
+            continuation.yield(event)
         }
 
         await MainActor.run { generationStream.setPhase(.done) }

--- a/Sources/BaseChatBackends/LlamaGenerationDriver.swift
+++ b/Sources/BaseChatBackends/LlamaGenerationDriver.swift
@@ -173,8 +173,10 @@ struct LlamaGenerationDriver {
         let useParser = markers != nil
         var thinkingParser = ThinkingParser(markers: markers ?? .qwen3)
         var thinkingTokenCount = 0
+        // Flag set when maxThinkingTokens is reached so we can break the outer loop cleanly.
+        var thinkingLimitReached = false
 
-        for iteration in 0..<maxTokens {
+        generationLoop: for iteration in 0..<maxTokens {
             if isCancelled() { break }
 
             // First iteration samples from the final prompt chunk's logits,
@@ -203,9 +205,13 @@ struct LlamaGenerationDriver {
                     continuation.yield(event)
                     if case .thinkingToken = event {
                         thinkingTokenCount += 1
-                        if let limit = config.maxThinkingTokens, thinkingTokenCount >= limit { break }
+                        if let limit = config.maxThinkingTokens, thinkingTokenCount >= limit {
+                            thinkingLimitReached = true
+                            break
+                        }
                     }
                 }
+                if thinkingLimitReached { break generationLoop }
             }
 
             // Prepare next batch

--- a/Sources/BaseChatBackends/LlamaGenerationDriver.swift
+++ b/Sources/BaseChatBackends/LlamaGenerationDriver.swift
@@ -177,13 +177,21 @@ struct LlamaGenerationDriver {
 
             // Decode token to text
             if let text = LlamaTokenization.tokenToString(token, vocab: vocab, invalidUTF8Buffer: &invalidUTF8) {
-                let visible = thinkingFilter.process(text)
-                if !visible.isEmpty {
-                    if isFirstToken {
-                        await MainActor.run { generationStream.setPhase(.streaming) }
-                        isFirstToken = false
+                let events = thinkingFilter.process(text)
+                for evt in events {
+                    switch evt {
+                    case .token(let visible):
+                        if isFirstToken {
+                            await MainActor.run { generationStream.setPhase(.streaming) }
+                            isFirstToken = false
+                        }
+                        continuation.yield(.token(visible))
+                    case .thinkingToken, .thinkingComplete:
+                        // Phase 2 will route thinking events; for now pass them through.
+                        continuation.yield(evt)
+                    default:
+                        break
                     }
-                    continuation.yield(.token(visible))
                 }
             }
 

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -204,28 +204,39 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 let outputLimit = config.maxOutputTokens
                 var outputTokenCount = 0
                 var isFirstToken = true
-                var thinkingFilter = ThinkingBlockFilter()
+
+                // Hardcoded to .qwen3: only Qwen3 variants have MLX thinking support currently.
+                // mlx-swift-lm exposes no tokenizer API to auto-detect markers at generation time.
+                // TODO: expose thinkingMarkers as a generate() parameter when Gemma 4 / other models land.
+                var thinkingParser = ThinkingParser(markers: .qwen3)
+                let useParser = config.thinkingMarkers != nil
+
                 let mlxStream = try await modelContainer.generate(
                     messages: messages,
                     parameters: generateConfig
                 )
                 for await generation in mlxStream {
                     if Task.isCancelled { break }
-                    if let raw = generation.chunk {
-                        let visible = thinkingFilter.process(raw)
-                        if !visible.isEmpty {
+                    if let text = generation.chunk {
+                        for event in useParser ? thinkingParser.process(text) : [GenerationEvent.token(text)] {
                             if isFirstToken {
-                                await MainActor.run { generationStream.setPhase(.streaming) }
-                                isFirstToken = false
+                                switch event {
+                                case .token, .thinkingToken:
+                                    await MainActor.run { generationStream.setPhase(.streaming) }
+                                    isFirstToken = false
+                                default: break
+                                }
                             }
-                            continuation.yield(.token(visible))
+                            // Only count visible output tokens toward maxOutputTokens limit
+                            if case .token = event { outputTokenCount += 1 }
+                            continuation.yield(event)
                         }
-                        // output token counting still uses raw chunks (each MLX chunk = 1 token)
-                        if let limit = outputLimit {
-                            outputTokenCount += 1
-                            if outputTokenCount >= limit { break }
-                        }
+                        if let limit = outputLimit, outputTokenCount >= limit { break }
                     }
+                }
+                // Flush any bytes held back at the tag-boundary buffer.
+                for event in thinkingParser.finalize() {
+                    continuation.yield(event)
                 }
                 await MainActor.run { generationStream.setPhase(.done) }
             } catch {

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -205,10 +205,10 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 var outputTokenCount = 0
                 var isFirstToken = true
 
-                // Hardcoded to .qwen3: only Qwen3 variants have MLX thinking support currently.
+                // Use the caller-configured markers when provided; fall back to .qwen3 (Qwen3/DeepSeek-R1).
                 // mlx-swift-lm exposes no tokenizer API to auto-detect markers at generation time.
                 // TODO: expose thinkingMarkers as a generate() parameter when Gemma 4 / other models land.
-                var thinkingParser = ThinkingParser(markers: .qwen3)
+                var thinkingParser = ThinkingParser(markers: config.thinkingMarkers ?? .qwen3)
                 let useParser = config.thinkingMarkers != nil
 
                 let mlxStream = try await modelContainer.generate(

--- a/Sources/BaseChatInference/Models/ConversationRecords.swift
+++ b/Sources/BaseChatInference/Models/ConversationRecords.swift
@@ -70,10 +70,11 @@ public struct ChatMessageRecord: Identifiable, Hashable, Sendable {
         set { contentParts = [.text(newValue)] }
     }
 
-    /// True if the message contains at least one visible text part.
-    /// Use instead of `content.isEmpty` to correctly handle thinking-only responses.
+    /// True if the message contains non-empty visible text.
+    /// Use instead of `content.isEmpty` to correctly handle thinking-only responses
+    /// — a message with only `.thinking` parts (or only empty `.text("")` parts) returns false.
     public var hasVisibleContent: Bool {
-        contentParts.contains { $0.textContent != nil }
+        !content.isEmpty
     }
 
     public init(

--- a/Sources/BaseChatInference/Models/ConversationRecords.swift
+++ b/Sources/BaseChatInference/Models/ConversationRecords.swift
@@ -70,6 +70,12 @@ public struct ChatMessageRecord: Identifiable, Hashable, Sendable {
         set { contentParts = [.text(newValue)] }
     }
 
+    /// True if the message contains at least one visible text part.
+    /// Use instead of `content.isEmpty` to correctly handle thinking-only responses.
+    public var hasVisibleContent: Bool {
+        contentParts.contains { $0.textContent != nil }
+    }
+
     public init(
         id: UUID = UUID(),
         role: MessageRole,

--- a/Sources/BaseChatInference/Models/GenerationEvent.swift
+++ b/Sources/BaseChatInference/Models/GenerationEvent.swift
@@ -17,4 +17,10 @@ public enum GenerationEvent: Sendable, Equatable {
     /// ``GenerationConfig/tools``.  The host is responsible for executing the
     /// call and feeding a ``ToolResult`` back into the conversation.
     case toolCall(ToolCall)
+
+    /// A fragment of model reasoning (inside a thinking block). Streamed during generation.
+    case thinkingToken(String)
+
+    /// Reasoning block complete (depth 1→0 transition). Finalize accumulated thinking content.
+    case thinkingComplete
 }

--- a/Sources/BaseChatInference/Models/MessagePart.swift
+++ b/Sources/BaseChatInference/Models/MessagePart.swift
@@ -14,6 +14,8 @@ import Foundation
 public enum MessagePart: Codable, Hashable, Sendable {
     case text(String)
     case image(data: Data, mimeType: String)
+    /// Accumulated model reasoning. Excluded from context window (textContent returns nil).
+    case thinking(String)
 }
 
 extension MessagePart {
@@ -21,6 +23,11 @@ extension MessagePart {
     /// The plain-text content of this part, or `nil` for non-text parts.
     public var textContent: String? {
         if case .text(let t) = self { return t }
+        return nil
+    }
+
+    public var thinkingContent: String? {
+        if case .thinking(let t) = self { return t }
         return nil
     }
 }

--- a/Sources/BaseChatInference/Models/ThinkingMarkers.swift
+++ b/Sources/BaseChatInference/Models/ThinkingMarkers.swift
@@ -1,0 +1,20 @@
+public struct ThinkingMarkers: Sendable, Equatable {
+    public let open: String
+    public let close: String
+
+    /// Bytes to hold back at chunk boundary — prevents partial-tag emission.
+    public var holdback: Int { max(open.count, close.count) }
+
+    public init(open: String, close: String) {
+        self.open = open
+        self.close = close
+    }
+
+    /// Qwen3 and DeepSeek-R1 inline thinking tags.
+    public static let qwen3 = ThinkingMarkers(open: "<think>", close: "</think>")
+
+    /// Extensibility hook for custom model formats.
+    public static func custom(open: String, close: String) -> ThinkingMarkers {
+        ThinkingMarkers(open: open, close: close)
+    }
+}

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -30,6 +30,12 @@ public struct GenerationConfig: Sendable, Codable {
     /// calling.  Defaults to ``ToolChoice/auto``.
     public var toolChoice: ToolChoice
 
+    /// Approximate cap on reasoning tokens. Counts thinkingToken events (≈ one per decoded token).
+    /// nil = no limit. Only enforced by LlamaGenerationDriver; MLX ignores this field.
+    /// Note: lives on GenerationConfig as a per-request hint. Will move to BackendCapabilities
+    /// when a backend-level thinking-capability flag is added.
+    public var maxThinkingTokens: Int?
+
     @available(*, deprecated, message: "Use init(temperature:topP:repeatPenalty:topK:typicalP:maxOutputTokens:) instead.")
     public init(
         temperature: Float = 0.7,
@@ -40,7 +46,8 @@ public struct GenerationConfig: Sendable, Codable {
         typicalP: Float? = nil,
         maxOutputTokens: Int? = 2048,
         tools: [ToolDefinition] = [],
-        toolChoice: ToolChoice = .auto
+        toolChoice: ToolChoice = .auto,
+        maxThinkingTokens: Int? = nil
     ) {
         self.temperature = temperature
         self.topP = topP
@@ -51,6 +58,7 @@ public struct GenerationConfig: Sendable, Codable {
         self.maxOutputTokens = maxOutputTokens
         self.tools = tools
         self.toolChoice = toolChoice
+        self.maxThinkingTokens = maxThinkingTokens
     }
 
     public init(
@@ -61,7 +69,8 @@ public struct GenerationConfig: Sendable, Codable {
         typicalP: Float? = nil,
         maxOutputTokens: Int? = 2048,
         tools: [ToolDefinition] = [],
-        toolChoice: ToolChoice = .auto
+        toolChoice: ToolChoice = .auto,
+        maxThinkingTokens: Int? = nil
     ) {
         self.temperature = temperature
         self.topP = topP
@@ -72,13 +81,14 @@ public struct GenerationConfig: Sendable, Codable {
         self.maxOutputTokens = maxOutputTokens
         self.tools = tools
         self.toolChoice = toolChoice
+        self.maxThinkingTokens = maxThinkingTokens
     }
 
     // MARK: Codable
 
     private enum CodingKeys: String, CodingKey {
         case temperature, topP, repeatPenalty, maxTokens, topK, typicalP, maxOutputTokens
-        case tools, toolChoice
+        case tools, toolChoice, maxThinkingTokens
     }
 
     public init(from decoder: Decoder) throws {
@@ -94,6 +104,7 @@ public struct GenerationConfig: Sendable, Codable {
         // New fields added in v0.10; absent from payloads serialised before their introduction.
         tools = (try c.decodeIfPresent([ToolDefinition].self, forKey: .tools)) ?? []
         toolChoice = (try c.decodeIfPresent(ToolChoice.self, forKey: .toolChoice)) ?? .auto
+        maxThinkingTokens = try c.decodeIfPresent(Int.self, forKey: .maxThinkingTokens)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -107,6 +118,7 @@ public struct GenerationConfig: Sendable, Codable {
         try c.encodeIfPresent(maxOutputTokens, forKey: .maxOutputTokens)
         try c.encode(tools, forKey: .tools)
         try c.encode(toolChoice, forKey: .toolChoice)
+        try c.encodeIfPresent(maxThinkingTokens, forKey: .maxThinkingTokens)
     }
 }
 

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -36,6 +36,12 @@ public struct GenerationConfig: Sendable, Codable {
     /// when a backend-level thinking-capability flag is added.
     public var maxThinkingTokens: Int?
 
+    /// Thinking markers for this request's model/template, or nil if the model does not emit
+    /// reasoning blocks. Set by the caller when the selected `PromptTemplate` has
+    /// `thinkingMarkers != nil`. Backends use this to activate `ThinkingParser`; backends that
+    /// do not support thinking ignore it.
+    public var thinkingMarkers: ThinkingMarkers?
+
     @available(*, deprecated, message: "Use init(temperature:topP:repeatPenalty:topK:typicalP:maxOutputTokens:) instead.")
     public init(
         temperature: Float = 0.7,
@@ -47,7 +53,8 @@ public struct GenerationConfig: Sendable, Codable {
         maxOutputTokens: Int? = 2048,
         tools: [ToolDefinition] = [],
         toolChoice: ToolChoice = .auto,
-        maxThinkingTokens: Int? = nil
+        maxThinkingTokens: Int? = nil,
+        thinkingMarkers: ThinkingMarkers? = nil
     ) {
         self.temperature = temperature
         self.topP = topP
@@ -59,6 +66,7 @@ public struct GenerationConfig: Sendable, Codable {
         self.tools = tools
         self.toolChoice = toolChoice
         self.maxThinkingTokens = maxThinkingTokens
+        self.thinkingMarkers = thinkingMarkers
     }
 
     public init(
@@ -70,7 +78,8 @@ public struct GenerationConfig: Sendable, Codable {
         maxOutputTokens: Int? = 2048,
         tools: [ToolDefinition] = [],
         toolChoice: ToolChoice = .auto,
-        maxThinkingTokens: Int? = nil
+        maxThinkingTokens: Int? = nil,
+        thinkingMarkers: ThinkingMarkers? = nil
     ) {
         self.temperature = temperature
         self.topP = topP
@@ -82,6 +91,7 @@ public struct GenerationConfig: Sendable, Codable {
         self.tools = tools
         self.toolChoice = toolChoice
         self.maxThinkingTokens = maxThinkingTokens
+        self.thinkingMarkers = thinkingMarkers
     }
 
     // MARK: Codable
@@ -105,6 +115,8 @@ public struct GenerationConfig: Sendable, Codable {
         tools = (try c.decodeIfPresent([ToolDefinition].self, forKey: .tools)) ?? []
         toolChoice = (try c.decodeIfPresent(ToolChoice.self, forKey: .toolChoice)) ?? .auto
         maxThinkingTokens = try c.decodeIfPresent(Int.self, forKey: .maxThinkingTokens)
+        // thinkingMarkers is a per-request runtime hint; it is not persisted.
+        thinkingMarkers = nil
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/Sources/BaseChatInference/Services/GenerationStreamConsumer.swift
+++ b/Sources/BaseChatInference/Services/GenerationStreamConsumer.swift
@@ -24,6 +24,12 @@ public struct GenerationStreamConsumer: Sendable {
 
         case .toolCall(let call):
             return .dispatchToolCall(call)
+
+        case .thinkingToken(let text):
+            return .appendThinkingText(text)
+
+        case .thinkingComplete:
+            return .finalizeThinking
         }
     }
 
@@ -45,5 +51,9 @@ public struct GenerationStreamConsumer: Sendable {
         case recordUsage(prompt: Int, completion: Int)
         /// Execute the requested tool call and feed a ``ToolResult`` back into the conversation.
         case dispatchToolCall(ToolCall)
+        /// Append the text to the current thinking accumulation buffer.
+        case appendThinkingText(String)
+        /// Reasoning block complete — finalize and store the accumulated thinking content.
+        case finalizeThinking
     }
 }

--- a/Sources/BaseChatInference/Services/PromptTemplate.swift
+++ b/Sources/BaseChatInference/Services/PromptTemplate.swift
@@ -46,6 +46,16 @@ public enum PromptTemplate: String, CaseIterable, Sendable, Identifiable {
         return result
     }
 
+    /// Thinking markers for this template, or nil if the template does not emit reasoning blocks.
+    public var thinkingMarkers: ThinkingMarkers? {
+        switch self {
+        case .chatML: return .qwen3  // Qwen3, DeepSeek-R1 use ChatML format with <think> tags
+        // .gemma4 markers deferred — <|end_of_turn> as close marker needs verification
+        // against real Gemma 4 thinking weights before enabling.
+        default:      return nil
+        }
+    }
+
     /// Formats an array of messages into a single prompt string.
     ///
     /// - Parameters:

--- a/Sources/BaseChatInference/ThinkingBlockFilter.swift
+++ b/Sources/BaseChatInference/ThinkingBlockFilter.swift
@@ -1,75 +1,76 @@
-/// Stateful, chunk-safe filter that strips `<think>...</think>` reasoning blocks
-/// from streamed token output.
+/// Stateful, chunk-safe parser that separates reasoning from visible text.
 ///
-/// Tokens arrive as arbitrary-length strings that may split a tag across boundaries.
-/// The filter buffers incomplete tag prefixes until enough characters arrive to
-/// confirm or reject a match.
-public struct ThinkingBlockFilter {
+/// Emits `[GenerationEvent]` from each chunk rather than a plain `String`,
+/// allowing callers to route thinking content separately from visible content.
+/// Parameterized by `ThinkingMarkers` so the same logic handles both
+/// `<think>`/`</think>` (Qwen3, DeepSeek-R1) and custom model formats.
+public struct ThinkingParser {
+    public let markers: ThinkingMarkers
     private var depth = 0
     private var buffer = ""
 
-    public init() {}
-
-    /// Process one token chunk. Returns the visible portion (may be empty).
-    public mutating func process(_ chunk: String) -> String {
-        buffer += chunk
-        return flush()
+    public init(markers: ThinkingMarkers = .qwen3) {
+        self.markers = markers
     }
 
-    private mutating func flush() -> String {
-        var output = ""
+    /// Process a chunk of streamed text. Returns a mix of `.token`,
+    /// `.thinkingToken`, and `.thinkingComplete` events.
+    public mutating func process(_ chunk: String) -> [GenerationEvent] {
+        buffer += chunk
+        var events: [GenerationEvent] = []
 
-        while !buffer.isEmpty {
-            if depth == 0 {
-                // Visible mode: emit text up to the next '<'
-                if let angleIdx = buffer.firstIndex(of: "<") {
-                    // Emit everything before the '<'
-                    output += buffer[buffer.startIndex..<angleIdx]
-                    buffer = String(buffer[angleIdx...])
+        while true {
+            let tag = depth > 0 ? markers.close : markers.open
 
-                    // Now buffer starts with '<'; only an opening think tag is special
-                    if buffer.hasPrefix("<think>") {
-                        depth += 1
-                        buffer = String(buffer.dropFirst("<think>".count))
-                    } else if "<think>".hasPrefix(buffer) {
-                        // Partial opening tag prefix — wait for more input
-                        break
-                    } else {
-                        // Any other '<' sequence, including '</think>', is visible text
-                        output += "<"
-                        buffer = String(buffer.dropFirst())
+            if let range = buffer.range(of: tag) {
+                // Emit everything before the tag as the current mode's event type
+                let before = String(buffer[..<range.lowerBound])
+                if !before.isEmpty {
+                    events.append(depth > 0 ? .thinkingToken(before) : .token(before))
+                }
+
+                // Transition state
+                if depth > 0 {
+                    depth -= 1
+                    if depth == 0 {
+                        // Only fire thinkingComplete on 1→0 transition (not for nested close tags)
+                        events.append(.thinkingComplete)
                     }
                 } else {
-                    // No '<' in buffer — all visible
-                    output += buffer
-                    buffer = ""
+                    depth += 1
                 }
+
+                buffer = String(buffer[range.upperBound...])
             } else {
-                // Suppressed mode: skip everything, only look for tag boundaries
-                if let angleIdx = buffer.firstIndex(of: "<") {
-                    // Discard text before '<'
-                    buffer = String(buffer[angleIdx...])
-
-                    if buffer.hasPrefix("<think>") {
-                        depth += 1
-                        buffer = String(buffer.dropFirst("<think>".count))
-                    } else if buffer.hasPrefix("</think>") {
-                        depth = max(0, depth - 1)
-                        buffer = String(buffer.dropFirst("</think>".count))
-                    } else if "<think>".hasPrefix(buffer) || "</think>".hasPrefix(buffer) {
-                        // Partial prefix — wait for more input
-                        break
-                    } else {
-                        // Non-think '<' inside a thinking block — swallow it
-                        buffer = String(buffer.dropFirst())
-                    }
-                } else {
-                    // No '<' — all suppressed, discard
-                    buffer = ""
-                }
+                break
             }
         }
 
-        return output
+        // Hold back bytes that could be the start of a partial open or close tag.
+        // Size = max(open.count, close.count) to handle either partial tag.
+        let holdback = markers.holdback
+        if buffer.count > holdback {
+            let safeCount = buffer.count - holdback
+            let confirmed = String(buffer.prefix(safeCount))
+            buffer = String(buffer.suffix(holdback))
+            if !confirmed.isEmpty {
+                events.append(depth > 0 ? .thinkingToken(confirmed) : .token(confirmed))
+            }
+        }
+
+        return events
+    }
+
+    /// Flush the held-back buffer at stream end. Call once after the generation loop ends.
+    /// Returns `.thinkingToken` if inside an unclosed block, `.token` otherwise.
+    public mutating func finalize() -> [GenerationEvent] {
+        guard !buffer.isEmpty else { return [] }
+        let remaining = buffer
+        buffer = ""
+        return [depth > 0 ? .thinkingToken(remaining) : .token(remaining)]
     }
 }
+
+@available(*, deprecated, renamed: "ThinkingParser",
+    message: "Return type changed from String to [GenerationEvent]. Use ThinkingParser directly.")
+public typealias ThinkingBlockFilter = ThinkingParser

--- a/Sources/BaseChatTestSupport/MockInferenceBackend.swift
+++ b/Sources/BaseChatTestSupport/MockInferenceBackend.swift
@@ -12,6 +12,7 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
 
     // Configurable behavior
     public var tokensToYield: [String] = ["Hello", " world"]
+    public var thinkingTokensToYield: [String] = []
     public var shouldThrowOnGenerate: Error? = nil
     public var shouldThrowOnLoad: Error? = nil
 
@@ -85,6 +86,8 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
         let tokens = tokensToYield
         let toolCalls = scriptedToolCalls
 
+        let thinkingTokens = thinkingTokensToYield
+
         let stream = AsyncThrowingStream<GenerationEvent, Error> { [self] continuation in
             continuationLock.lock()
             self.activeContinuation = continuation
@@ -95,6 +98,13 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
                 self.continuationLock.unlock()
             }
             Task {
+                for t in thinkingTokens {
+                    if Task.isCancelled { break }
+                    continuation.yield(.thinkingToken(t))
+                }
+                if !thinkingTokens.isEmpty && !Task.isCancelled {
+                    continuation.yield(.thinkingComplete)
+                }
                 for token in tokens {
                     if Task.isCancelled { break }
                     continuation.yield(.token(token))

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
@@ -169,6 +169,11 @@ extension ChatViewModel {
                             // implement a tool dispatch loop. Apps that need tool calling
                             // should drive generation directly via InferenceService.
                             break
+
+                        case .appendThinkingText, .finalizeThinking:
+                            // Thinking rendering is a Phase 2 concern; ChatViewModel defers
+                            // to host apps that opt in to thinking display.
+                            break
                         }
                     }
                 } catch {

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
@@ -172,16 +172,30 @@ extension ChatViewModel {
                             break
 
                         case .appendThinkingText(let text):
+                            let isFirstThinkingFragment = thinkingAccumulator.isEmpty
                             thinkingAccumulator += text
+                            if isFirstThinkingFragment {
+                                // Insert a placeholder `.thinking("")` part immediately so the
+                                // UI can render the "Thinking…" label during the reasoning phase
+                                // rather than staying on the generic typing placeholder.
+                                self.mutateMessage(id: messageID) { msg in
+                                    if msg.contentParts.firstIndex(where: { $0.thinkingContent != nil }) == nil {
+                                        let insertAt = msg.contentParts.firstIndex(where: { $0.textContent != nil }) ?? 0
+                                        msg.contentParts.insert(.thinking(""), at: insertAt)
+                                    }
+                                }
+                            }
 
                         case .finalizeThinking:
                             let block = thinkingAccumulator
-                            thinkingAccumulator = ""  // reset — prevents multi-block concatenation
+                            thinkingAccumulator = ""
                             guard !block.isEmpty else { break }
                             self.mutateMessage(id: messageID) { msg in
-                                // Replace existing thinking part or insert before first text part.
+                                // Append to any existing thinking part so multiple <think>…</think>
+                                // blocks within one response are concatenated into a single part.
                                 if let idx = msg.contentParts.firstIndex(where: { $0.thinkingContent != nil }) {
-                                    msg.contentParts[idx] = .thinking(block)
+                                    let existing = msg.contentParts[idx].thinkingContent ?? ""
+                                    msg.contentParts[idx] = .thinking(existing.isEmpty ? block : existing + "\n\n" + block)
                                 } else {
                                     let insertAt = msg.contentParts.firstIndex(where: { $0.textContent != nil }) ?? 0
                                     msg.contentParts.insert(.thinking(block), at: insertAt)
@@ -208,7 +222,8 @@ extension ChatViewModel {
                     thinkingAccumulator = ""
                     self.mutateMessage(id: messageID) { msg in
                         if let idx = msg.contentParts.firstIndex(where: { $0.thinkingContent != nil }) {
-                            msg.contentParts[idx] = .thinking(block)
+                            let existing = msg.contentParts[idx].thinkingContent ?? ""
+                            msg.contentParts[idx] = .thinking(existing.isEmpty ? block : existing + "\n\n" + block)
                         } else {
                             let insertAt = msg.contentParts.firstIndex(where: { $0.textContent != nil }) ?? 0
                             msg.contentParts.insert(.thinking(block), at: insertAt)
@@ -234,11 +249,12 @@ extension ChatViewModel {
         }
 
         // Persist the completed assistant message.
-        // Use hasVisibleContent rather than content.isEmpty so that a thinking-only
-        // response (no visible text) is still saved rather than silently discarded.
+        // Keep the message if it has visible text OR thinking content — a thinking-only
+        // response (no visible text but `.thinking` parts present) is still meaningful.
         if let idx = messages.firstIndex(where: { $0.id == messageID }) {
+            let hasThinkingContent = messages[idx].contentParts.contains { $0.thinkingContent != nil }
             do {
-                if !messages[idx].hasVisibleContent {
+                if !messages[idx].hasVisibleContent && !hasThinkingContent {
                     messages.remove(at: idx)
                 } else {
                     try saveMessage(messages[idx])

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
@@ -132,6 +132,7 @@ extension ChatViewModel {
                     maxBufferedCharacters: streamingBatchCharacterLimit
                 )
                 var consumer = GenerationStreamConsumer(loopDetectionEnabled: self.loopDetectionEnabled)
+                var thinkingAccumulator = ""
 
                 do {
                     eventLoop: for try await event in stream.events {
@@ -170,10 +171,22 @@ extension ChatViewModel {
                             // should drive generation directly via InferenceService.
                             break
 
-                        case .appendThinkingText, .finalizeThinking:
-                            // Thinking rendering is a Phase 2 concern; ChatViewModel defers
-                            // to host apps that opt in to thinking display.
-                            break
+                        case .appendThinkingText(let text):
+                            thinkingAccumulator += text
+
+                        case .finalizeThinking:
+                            let block = thinkingAccumulator
+                            thinkingAccumulator = ""  // reset — prevents multi-block concatenation
+                            guard !block.isEmpty else { break }
+                            self.mutateMessage(id: messageID) { msg in
+                                // Replace existing thinking part or insert before first text part.
+                                if let idx = msg.contentParts.firstIndex(where: { $0.thinkingContent != nil }) {
+                                    msg.contentParts[idx] = .thinking(block)
+                                } else {
+                                    let insertAt = msg.contentParts.firstIndex(where: { $0.textContent != nil }) ?? 0
+                                    msg.contentParts.insert(.thinking(block), at: insertAt)
+                                }
+                            }
                         }
                     }
                 } catch {
@@ -186,6 +199,21 @@ extension ChatViewModel {
                 // Flush remaining buffered tokens after stream ends (normal, error, or cancellation).
                 if let batch = batcher.flush(now: ContinuousClock.now) {
                     self.mutateMessage(id: messageID) { $0.content += batch }
+                }
+
+                // Finalize an unclosed thinking block — a model may emit <think>…
+                // without a closing tag if generation is cut short.
+                if !thinkingAccumulator.isEmpty {
+                    let block = thinkingAccumulator
+                    thinkingAccumulator = ""
+                    self.mutateMessage(id: messageID) { msg in
+                        if let idx = msg.contentParts.firstIndex(where: { $0.thinkingContent != nil }) {
+                            msg.contentParts[idx] = .thinking(block)
+                        } else {
+                            let insertAt = msg.contentParts.firstIndex(where: { $0.textContent != nil }) ?? 0
+                            msg.contentParts.insert(.thinking(block), at: insertAt)
+                        }
+                    }
                 }
             }
 
@@ -206,9 +234,11 @@ extension ChatViewModel {
         }
 
         // Persist the completed assistant message.
+        // Use hasVisibleContent rather than content.isEmpty so that a thinking-only
+        // response (no visible text) is still saved rather than silently discarded.
         if let idx = messages.firstIndex(where: { $0.id == messageID }) {
             do {
-                if messages[idx].content.isEmpty {
+                if !messages[idx].hasVisibleContent {
                     messages.remove(at: idx)
                 } else {
                     try saveMessage(messages[idx])
@@ -222,10 +252,9 @@ extension ChatViewModel {
         // After the first assistant response on Foundation, nudge the user to
         // consider downloading a local model for longer context. Only show once
         // per session and only when Foundation is the active backend.
-        let assistantContent = messages.first(where: { $0.id == messageID })?.content ?? ""
         if BaseChatConfiguration.shared.features.showUpgradeHint,
            !showUpgradeHint,
-           !assistantContent.isEmpty,
+           messages.first(where: { $0.id == messageID })?.hasVisibleContent == true,
            activeBackendName == "Apple",
            messages.filter({ $0.role == .assistant }).count == 1 {
             showUpgradeHint = true
@@ -236,7 +265,7 @@ extension ChatViewModel {
 
         // Fire post-generation tasks off @MainActor if we have a non-empty assistant message.
         if let completedMessage = messages.first(where: { $0.id == messageID }),
-           !completedMessage.content.isEmpty,
+           completedMessage.hasVisibleContent,
            let session = activeSession {
             runPostGenerationTasks(message: completedMessage, session: session)
         }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Generation.swift
@@ -252,7 +252,7 @@ extension ChatViewModel {
         // Keep the message if it has visible text OR thinking content — a thinking-only
         // response (no visible text but `.thinking` parts present) is still meaningful.
         if let idx = messages.firstIndex(where: { $0.id == messageID }) {
-            let hasThinkingContent = messages[idx].contentParts.contains { $0.thinkingContent != nil }
+            let hasThinkingContent = messages[idx].contentParts.contains(where: { $0.thinkingContent != nil })
             do {
                 if !messages[idx].hasVisibleContent && !hasThinkingContent {
                     messages.remove(at: idx)

--- a/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
@@ -72,17 +72,20 @@ public struct MessageBubbleView: View {
 
     private var assistantBubble: some View {
         VStack(alignment: .leading, spacing: 4) {
-            if message.contentParts.isEmpty && isStreaming {
+            // Use hasVisibleContent rather than contentParts.isEmpty so that a
+            // thinking-only message (parts present, but no text) still shows the
+            // typing indicator until visible text arrives.
+            if !message.hasVisibleContent && isStreaming {
                 streamingPlaceholder
             } else {
-                MessagePartsView(parts: message.contentParts, role: .assistant)
+                MessagePartsView(parts: message.contentParts, role: .assistant, isStreaming: isStreaming)
             }
 
-            if isStreaming && !message.contentParts.isEmpty {
+            if isStreaming && message.hasVisibleContent {
                 streamingIndicator
             }
 
-            if !isStreaming || !message.contentParts.isEmpty {
+            if !isStreaming || message.hasVisibleContent {
                 HStack(spacing: 6) {
                     timestampLabel
                         .foregroundStyle(.secondary)

--- a/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
@@ -76,7 +76,7 @@ public struct MessageBubbleView: View {
             // (no visible text, no thinking parts). Once a thinking part has been
             // inserted — even as an empty placeholder — render MessagePartsView so
             // ThinkingBlockView can show its "Thinking…" label in-bubble.
-            let hasThinkingParts = message.contentParts.contains { $0.thinkingContent != nil }
+            let hasThinkingParts = message.contentParts.contains(where: { $0.thinkingContent != nil })
             if !message.hasVisibleContent && !hasThinkingParts && isStreaming {
                 streamingPlaceholder
             } else {

--- a/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
@@ -72,10 +72,12 @@ public struct MessageBubbleView: View {
 
     private var assistantBubble: some View {
         VStack(alignment: .leading, spacing: 4) {
-            // Use hasVisibleContent rather than contentParts.isEmpty so that a
-            // thinking-only message (parts present, but no text) still shows the
-            // typing indicator until visible text arrives.
-            if !message.hasVisibleContent && isStreaming {
+            // Show the typing placeholder only when there is nothing at all to display
+            // (no visible text, no thinking parts). Once a thinking part has been
+            // inserted — even as an empty placeholder — render MessagePartsView so
+            // ThinkingBlockView can show its "Thinking…" label in-bubble.
+            let hasThinkingParts = message.contentParts.contains { $0.thinkingContent != nil }
+            if !message.hasVisibleContent && !hasThinkingParts && isStreaming {
                 streamingPlaceholder
             } else {
                 MessagePartsView(parts: message.contentParts, role: .assistant, isStreaming: isStreaming)

--- a/Sources/BaseChatUI/Views/Chat/MessagePartsView.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessagePartsView.swift
@@ -24,6 +24,11 @@ struct MessagePartsView: View {
 
         case .image(let data, _):
             imageView(data)
+
+        case .thinking:
+            // Thinking parts are not rendered inline in the default message view.
+            // Phase 2 will add a dedicated thinking disclosure UI.
+            EmptyView()
         }
     }
 

--- a/Sources/BaseChatUI/Views/Chat/MessagePartsView.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessagePartsView.swift
@@ -28,9 +28,13 @@ struct MessagePartsView: View {
             imageView(data)
 
         case .thinking(let text):
-            // Pass isStreaming through so the view shows "Thinking…" during active
-            // generation rather than a half-filled disclosure group.
-            ThinkingBlockView(text: text, isStreaming: isStreaming)
+            // A thinking part with empty text is a streaming placeholder inserted
+            // when the first .thinkingToken arrives; non-empty means the block was
+            // finalized by .thinkingComplete. Using the text emptiness rather than
+            // the overall isStreaming flag allows the disclosure group to appear
+            // as soon as reasoning is complete, even while visible tokens are still
+            // arriving.
+            ThinkingBlockView(text: text, isThinkingStreaming: text.isEmpty && isStreaming)
         }
     }
 

--- a/Sources/BaseChatUI/Views/Chat/MessagePartsView.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessagePartsView.swift
@@ -4,11 +4,13 @@ import BaseChatInference
 
 /// Renders an array of ``MessagePart`` values within a message bubble.
 ///
-/// Text parts are rendered inline (markdown for assistant, plain for user)
-/// and images are shown as thumbnails.
+/// Text parts are rendered inline (markdown for assistant, plain for user),
+/// images are shown as thumbnails, and thinking blocks show a collapsible
+/// disclosure group (or a streaming label while generation is in progress).
 struct MessagePartsView: View {
     let parts: [MessagePart]
     let role: MessageRole
+    var isStreaming: Bool = false
 
     var body: some View {
         ForEach(Array(parts.enumerated()), id: \.offset) { _, part in
@@ -25,10 +27,10 @@ struct MessagePartsView: View {
         case .image(let data, _):
             imageView(data)
 
-        case .thinking:
-            // Thinking parts are not rendered inline in the default message view.
-            // Phase 2 will add a dedicated thinking disclosure UI.
-            EmptyView()
+        case .thinking(let text):
+            // Pass isStreaming through so the view shows "Thinking…" during active
+            // generation rather than a half-filled disclosure group.
+            ThinkingBlockView(text: text, isStreaming: isStreaming)
         }
     }
 

--- a/Sources/BaseChatUI/Views/Chat/ThinkingBlockView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ThinkingBlockView.swift
@@ -2,16 +2,22 @@ import SwiftUI
 
 /// A collapsible disclosure group displaying model reasoning content.
 ///
-/// Shows a "Thinking…" label while streaming (no text dump during active reasoning)
-/// and a disclosure triangle labelled "Reasoning" once the block is complete.
+/// Shows a "Thinking…" label while `isThinkingStreaming` is true (reasoning is
+/// still in progress) and a disclosure triangle labelled "Reasoning" once the
+/// block is finalized. This is intentionally decoupled from the overall message
+/// streaming flag — completed reasoning should become expandable even while
+/// visible tokens are still arriving.
 struct ThinkingBlockView: View {
     let text: String
-    let isStreaming: Bool
+    /// True only while the reasoning block itself is still open (i.e. no
+    /// `.thinkingComplete` event has been received yet). Distinct from the
+    /// overall message `isStreaming` flag.
+    let isThinkingStreaming: Bool
 
     @State private var isExpanded = false
 
     var body: some View {
-        if isStreaming {
+        if isThinkingStreaming {
             Label("Thinking…", systemImage: "brain")
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -34,12 +40,12 @@ struct ThinkingBlockView: View {
 #Preview("Completed") {
     ThinkingBlockView(
         text: "Let me think about this step by step. First I'll consider the constraints...",
-        isStreaming: false
+        isThinkingStreaming: false
     )
     .padding()
 }
 
 #Preview("Streaming") {
-    ThinkingBlockView(text: "", isStreaming: true)
+    ThinkingBlockView(text: "", isThinkingStreaming: true)
         .padding()
 }

--- a/Sources/BaseChatUI/Views/Chat/ThinkingBlockView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ThinkingBlockView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+/// A collapsible disclosure group displaying model reasoning content.
+///
+/// Shows a "Thinking…" label while streaming (no text dump during active reasoning)
+/// and a disclosure triangle labelled "Reasoning" once the block is complete.
+struct ThinkingBlockView: View {
+    let text: String
+    let isStreaming: Bool
+
+    @State private var isExpanded = false
+
+    var body: some View {
+        if isStreaming {
+            Label("Thinking…", systemImage: "brain")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        } else {
+            DisclosureGroup(isExpanded: $isExpanded) {
+                Text(text)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                    .padding(.top, 4)
+            } label: {
+                Label("Reasoning", systemImage: "brain")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+#Preview("Completed") {
+    ThinkingBlockView(
+        text: "Let me think about this step by step. First I'll consider the constraints...",
+        isStreaming: false
+    )
+    .padding()
+}
+
+#Preview("Streaming") {
+    ThinkingBlockView(text: "", isStreaming: true)
+        .padding()
+}

--- a/Tests/BaseChatBackendsTests/MLXBackendThinkingTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXBackendThinkingTests.swift
@@ -1,0 +1,200 @@
+#if MLX
+import XCTest
+import MLXLMCommon
+import BaseChatInference
+import BaseChatTestSupport
+@testable import BaseChatBackends
+
+// Conform MockMLXModelContainer to the internal protocol in this test target,
+// where both the internal protocol and the public mock type are visible.
+// Note: the conformance may already be declared in MLXBackendGenerationTests.swift;
+// if so, remove the duplicate extension here and use that file's conformance.
+// Using `extension MockMLXModelContainer: MLXModelContainerProtocol {}` in multiple
+// files will trigger a Swift redeclaration error — this file omits it in favour of
+// the existing declaration in MLXBackendGenerationTests.swift.
+
+/// Unit tests verifying that `MLXBackend` correctly routes thinking events through
+/// `ThinkingParser` when `config.thinkingMarkers` is set.
+///
+/// Uses `MockMLXModelContainer` so no Metal / Apple Silicon hardware is required.
+final class MLXBackendThinkingTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Drains all `.token` events from a `GenerationStream`.
+    private func collectTokens(from stream: GenerationStream) async throws -> [String] {
+        var tokens: [String] = []
+        for try await event in stream.events {
+            if case .token(let text) = event { tokens.append(text) }
+        }
+        return tokens
+    }
+
+    /// Drains all `.thinkingToken` events from a `GenerationStream`.
+    private func collectThinkingTokens(from stream: GenerationStream) async throws -> [String] {
+        var tokens: [String] = []
+        for try await event in stream.events {
+            if case .thinkingToken(let text) = event { tokens.append(text) }
+        }
+        return tokens
+    }
+
+    /// Drains all events from a `GenerationStream` into an ordered array.
+    private func collectAllEvents(from stream: GenerationStream) async throws -> [GenerationEvent] {
+        var events: [GenerationEvent] = []
+        for try await event in stream.events {
+            events.append(event)
+        }
+        return events
+    }
+
+    // MARK: - Helpers for config
+
+    private func thinkingConfig() -> GenerationConfig {
+        GenerationConfig(thinkingMarkers: .qwen3)
+    }
+
+    // MARK: - 1. Thinking tokens emitted separately from visible tokens
+
+    func test_thinkingTokensEmittedSeparatelyFromVisibleTokens() async throws {
+        let mock = MockMLXModelContainer()
+        // The mock yields raw token strings; MLXBackend passes them through ThinkingParser
+        // when config.thinkingMarkers is non-nil.
+        mock.tokensToYield = ["<think>", "reason", "</think>", "answer"]
+
+        let backend = MLXBackend()
+        backend._inject(mock)
+
+        let stream = try backend.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: thinkingConfig()
+        )
+
+        let allEvents = try await collectAllEvents(from: stream)
+
+        // Verify thinking token appears
+        let thinkingTexts = allEvents.compactMap { event -> String? in
+            if case .thinkingToken(let t) = event { return t } else { return nil }
+        }
+        XCTAssertFalse(thinkingTexts.isEmpty,
+            "At least one .thinkingToken event must be emitted for content inside <think>…</think>")
+        XCTAssertTrue(thinkingTexts.joined().contains("reason"),
+            ".thinkingToken events must contain the reasoning content")
+
+        // Verify .thinkingComplete fires
+        let completions = allEvents.filter {
+            if case .thinkingComplete = $0 { return true } else { return false }
+        }
+        XCTAssertEqual(completions.count, 1,
+            "Exactly one .thinkingComplete must fire when </think> is encountered")
+
+        // Verify visible token appears
+        let visibleTexts = allEvents.compactMap { event -> String? in
+            if case .token(let t) = event { return t } else { return nil }
+        }
+        XCTAssertTrue(visibleTexts.joined().contains("answer"),
+            "Content after </think> must be emitted as .token events")
+
+        // Verify ordering: all thinkingToken events before thinkingComplete before token events
+        let firstThinkingIndex = allEvents.firstIndex {
+            if case .thinkingToken = $0 { return true } else { return false }
+        }
+        let completeIndex = allEvents.firstIndex {
+            if case .thinkingComplete = $0 { return true } else { return false }
+        }
+        let firstTokenIndex = allEvents.firstIndex {
+            if case .token = $0 { return true } else { return false }
+        }
+
+        if let ti = firstThinkingIndex, let ci = completeIndex, let vi = firstTokenIndex {
+            XCTAssertLessThan(ti, ci, ".thinkingToken events must precede .thinkingComplete")
+            XCTAssertLessThan(ci, vi, ".thinkingComplete must precede .token events")
+        } else {
+            XCTFail("Expected all three event types in the stream")
+        }
+
+        // Sabotage check: setting config.thinkingMarkers = nil would bypass ThinkingParser,
+        // causing raw "<think>" text to appear as .token events and failing the thinkingTexts check.
+    }
+
+    // MARK: - 2. outputTokenCount does not include thinking tokens
+
+    func test_outputTokenCount_doesNotIncludeThinkingTokens() async throws {
+        let mock = MockMLXModelContainer()
+        // 3 thinking tokens + 1 visible token; maxOutputTokens = 1 should allow exactly 1 .token
+        mock.tokensToYield = ["<think>", "a", "b", "</think>", "answer", "more"]
+
+        let backend = MLXBackend()
+        backend._inject(mock)
+
+        var config = thinkingConfig()
+        config.maxOutputTokens = 1
+
+        let stream = try backend.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: config
+        )
+
+        let allEvents = try await collectAllEvents(from: stream)
+
+        let visibleTokens = allEvents.compactMap { event -> String? in
+            if case .token(let t) = event { return t } else { return nil }
+        }
+
+        // With maxOutputTokens=1, only the first visible token should be emitted.
+        // Thinking tokens must not count toward this limit.
+        XCTAssertEqual(visibleTokens.count, 1,
+            "maxOutputTokens must count only .token events, not .thinkingToken events")
+        XCTAssertEqual(visibleTokens.first, "answer",
+            "The first visible token after the thinking block should be 'answer'")
+
+        // Thinking content must still have been emitted (budget was not consumed by it)
+        let thinkingTexts = allEvents.compactMap { event -> String? in
+            if case .thinkingToken(let t) = event { return t } else { return nil }
+        }
+        XCTAssertFalse(thinkingTexts.isEmpty,
+            "Thinking tokens must still be emitted even when maxOutputTokens=1")
+
+        // Sabotage check: if thinking tokens incremented outputTokenCount, the limit
+        // would be hit mid-thinking-block and "answer" would never appear as a .token.
+    }
+
+    // MARK: - 3. No thinking events without markers
+
+    func test_noThinkingEvents_whenMarkersNotSet() async throws {
+        let mock = MockMLXModelContainer()
+        mock.tokensToYield = ["<think>", "reason", "</think>", "answer"]
+
+        let backend = MLXBackend()
+        backend._inject(mock)
+
+        // config.thinkingMarkers = nil → ThinkingParser disabled
+        let stream = try backend.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: GenerationConfig()  // no thinkingMarkers
+        )
+
+        let allEvents = try await collectAllEvents(from: stream)
+
+        let thinkingEvents = allEvents.filter {
+            if case .thinkingToken = $0 { return true }
+            if case .thinkingComplete = $0 { return true }
+            return false
+        }
+        XCTAssertTrue(thinkingEvents.isEmpty,
+            "When config.thinkingMarkers is nil, no .thinkingToken or .thinkingComplete events must be emitted")
+
+        let rawTokens = allEvents.compactMap { event -> String? in
+            if case .token(let t) = event { return t } else { return nil }
+        }
+        XCTAssertTrue(rawTokens.joined().contains("<think>"),
+            "Raw <think> tag must pass through as .token when ThinkingParser is disabled")
+
+        // Sabotage check: always running ThinkingParser regardless of config.thinkingMarkers
+        // would produce .thinkingToken events here and fail the thinkingEvents.isEmpty check.
+    }
+}
+#endif

--- a/Tests/BaseChatBackendsTests/MockInferenceBackendThinkingTests.swift
+++ b/Tests/BaseChatBackendsTests/MockInferenceBackendThinkingTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+import BaseChatInference
+import BaseChatTestSupport
+
+/// Tests verifying that `MockInferenceBackend.thinkingTokensToYield` emits
+/// events in the correct order: `.thinkingToken` × N → `.thinkingComplete` → `.token` × M.
+final class MockInferenceBackendThinkingTests: XCTestCase {
+
+    // MARK: - Event ordering
+
+    func test_thinkingTokens_emittedBeforeVisibleTokens() async throws {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.thinkingTokensToYield = ["step1 ", "step2"]
+        mock.tokensToYield = ["answer"]
+
+        let stream = try mock.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        var events: [GenerationEvent] = []
+        for try await event in stream.events {
+            events.append(event)
+        }
+
+        // Expected: .thinkingToken("step1 "), .thinkingToken("step2"),
+        //           .thinkingComplete, .token("answer")
+        XCTAssertEqual(events.count, 4,
+            "Should emit 2 thinkingToken + 1 thinkingComplete + 1 token = 4 events")
+
+        guard events.count == 4 else { return }
+
+        if case .thinkingToken(let t) = events[0] {
+            XCTAssertEqual(t, "step1 ")
+        } else {
+            XCTFail("events[0] must be .thinkingToken(\"step1 \"), got \(events[0])")
+        }
+
+        if case .thinkingToken(let t) = events[1] {
+            XCTAssertEqual(t, "step2")
+        } else {
+            XCTFail("events[1] must be .thinkingToken(\"step2\"), got \(events[1])")
+        }
+
+        if case .thinkingComplete = events[2] {
+            // expected
+        } else {
+            XCTFail("events[2] must be .thinkingComplete, got \(events[2])")
+        }
+
+        if case .token(let t) = events[3] {
+            XCTAssertEqual(t, "answer")
+        } else {
+            XCTFail("events[3] must be .token(\"answer\"), got \(events[3])")
+        }
+
+        // Sabotage check: if the mock emitted .token before .thinkingToken, the
+        // index-based assertions at [0] and [3] would both fail.
+    }
+
+    // MARK: - No thinkingComplete when thinkingTokens is empty
+
+    func test_emptyThinkingTokens_noThinkingCompleteEmitted() async throws {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.thinkingTokensToYield = []
+        mock.tokensToYield = ["hello"]
+
+        let stream = try mock.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        var events: [GenerationEvent] = []
+        for try await event in stream.events {
+            events.append(event)
+        }
+
+        let completions = events.filter {
+            if case .thinkingComplete = $0 { return true } else { return false }
+        }
+        XCTAssertEqual(completions.count, 0,
+            "No .thinkingComplete must be emitted when thinkingTokensToYield is empty")
+
+        // Sabotage check: always emitting .thinkingComplete would yield count=1
+        // and break this assertion, exposing spurious finalize calls in the UI.
+    }
+
+    // MARK: - thinkingComplete fires exactly once regardless of token count
+
+    func test_thinkingComplete_firesExactlyOnce_forMultipleThinkingTokens() async throws {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.thinkingTokensToYield = ["a", "b", "c", "d", "e"]
+        mock.tokensToYield = ["result"]
+
+        let stream = try mock.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        var events: [GenerationEvent] = []
+        for try await event in stream.events {
+            events.append(event)
+        }
+
+        let completions = events.filter {
+            if case .thinkingComplete = $0 { return true } else { return false }
+        }
+        XCTAssertEqual(completions.count, 1,
+            "Exactly one .thinkingComplete must be emitted regardless of how many thinkingTokensToYield there are")
+
+        // Sabotage check: emitting .thinkingComplete once per thinking token would yield 5
+        // here and cause spurious UI finalizations.
+    }
+
+    // MARK: - Only visible tokens when thinkingTokens is empty
+
+    func test_onlyVisibleTokens_whenNoThinking() async throws {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.thinkingTokensToYield = []
+        mock.tokensToYield = ["Hello", " world"]
+
+        let stream = try mock.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        var allEvents: [GenerationEvent] = []
+        for try await event in stream.events {
+            allEvents.append(event)
+        }
+
+        let thinkingEvents = allEvents.filter {
+            if case .thinkingToken = $0 { return true }
+            if case .thinkingComplete = $0 { return true }
+            return false
+        }
+        XCTAssertTrue(thinkingEvents.isEmpty,
+            "No thinking events must appear when thinkingTokensToYield is empty")
+
+        let tokens = allEvents.compactMap { event -> String? in
+            if case .token(let t) = event { return t } else { return nil }
+        }
+        XCTAssertEqual(tokens, ["Hello", " world"])
+    }
+}

--- a/Tests/BaseChatBackendsTests/NonThinkingBackendRegressionTests.swift
+++ b/Tests/BaseChatBackendsTests/NonThinkingBackendRegressionTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+import BaseChatInference
+import BaseChatTestSupport
+
+/// Regression tests verifying that backends not configured for thinking do not
+/// emit `.thinkingToken` or `.thinkingComplete` events, and that the new
+/// `GenerationEvent` cases are handled without crashes across the system.
+final class NonThinkingBackendRegressionTests: XCTestCase {
+
+    // MARK: - MockInferenceBackend with no thinking config
+
+    func test_mockBackend_withNoThinkingConfig_emitsNoThinkingEvents() async throws {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.tokensToYield = ["hello"]
+        // thinkingTokensToYield defaults to [] — mock will emit no thinking events.
+
+        let stream = try mock.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        var allEvents: [GenerationEvent] = []
+        for try await event in stream.events {
+            allEvents.append(event)
+        }
+
+        let thinkingEvents = allEvents.filter { event in
+            if case .thinkingToken = event { return true }
+            if case .thinkingComplete = event { return true }
+            return false
+        }
+
+        XCTAssertTrue(thinkingEvents.isEmpty,
+            "A backend with no thinking config must emit zero .thinkingToken or .thinkingComplete events")
+
+        let visibleTokens = allEvents.compactMap { event -> String? in
+            if case .token(let t) = event { return t } else { return nil }
+        }
+        XCTAssertEqual(visibleTokens, ["hello"],
+            "MockInferenceBackend with no thinking config must still emit all configured .token events")
+
+        // Sabotage check: if MockInferenceBackend always emitted .thinkingComplete after tokens,
+        // thinkingEvents would be non-empty and this assertion would fail.
+    }
+
+    // MARK: - MockInferenceBackend switch exhaustiveness
+
+    func test_allGenerationEventCases_handledWithoutCrash() async throws {
+        // This test exercises every GenerationEvent case through MockInferenceBackend
+        // to confirm the stream continuation doesn't crash on new cases.
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.tokensToYield = ["visible"]
+        mock.thinkingTokensToYield = ["thought"]
+
+        // Should not throw.
+        let stream = try mock.generate(
+            prompt: "test",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        // Drain the stream directly (test is async).
+        var events: [GenerationEvent] = []
+        for try await event in stream.events {
+            events.append(event)
+        }
+
+        // Verify the expected event sequence:
+        // .thinkingToken("thought"), .thinkingComplete, .token("visible")
+        let thinkingTokens = events.compactMap { e -> String? in
+            if case .thinkingToken(let t) = e { return t } else { return nil }
+        }
+        let completions = events.filter {
+            if case .thinkingComplete = $0 { return true } else { return false }
+        }
+        let tokens = events.compactMap { e -> String? in
+            if case .token(let t) = e { return t } else { return nil }
+        }
+        XCTAssertEqual(thinkingTokens, ["thought"])
+        XCTAssertEqual(completions.count, 1)
+        XCTAssertEqual(tokens, ["visible"])
+
+        // Sabotage check: if the mock didn't emit .thinkingComplete after thinking tokens,
+        // the completions count would be 0 and this test would fail.
+    }
+}

--- a/Tests/BaseChatCoreTests/ChatMessageRecordVisibleContentTests.swift
+++ b/Tests/BaseChatCoreTests/ChatMessageRecordVisibleContentTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+import BaseChatInference
+
+/// Tests for `ChatMessageRecord.hasVisibleContent` and the interaction between
+/// `.thinking` parts and the `content` property.
+final class ChatMessageRecordVisibleContentTests: XCTestCase {
+
+    // MARK: - 1. Thinking-only message has no visible content
+
+    func test_hasVisibleContent_false_forThinkingOnly() {
+        let record = ChatMessageRecord(
+            role: .assistant,
+            contentParts: [.thinking("I reasoned about this."), .thinking("And then some more.")],
+            sessionID: UUID()
+        )
+
+        XCTAssertFalse(record.hasVisibleContent,
+            "A message containing only .thinking parts must report hasVisibleContent == false")
+
+        // Sabotage check: if hasVisibleContent returned true unconditionally, a thinking-only
+        // message would incorrectly appear to have content, breaking the UI visibility check.
+    }
+
+    // MARK: - 2. Text-only message has visible content
+
+    func test_hasVisibleContent_true_forText() {
+        let record = ChatMessageRecord(
+            role: .assistant,
+            content: "Here is the answer.",
+            sessionID: UUID()
+        )
+
+        XCTAssertTrue(record.hasVisibleContent,
+            "A message with a .text part must report hasVisibleContent == true")
+    }
+
+    // MARK: - 3. Mixed parts — thinking + text
+
+    func test_hasVisibleContent_true_forMixed() {
+        let record = ChatMessageRecord(
+            role: .assistant,
+            contentParts: [.thinking("internal reasoning"), .text("The answer is 42.")],
+            sessionID: UUID()
+        )
+
+        XCTAssertTrue(record.hasVisibleContent,
+            "A message with both .thinking and .text parts must report hasVisibleContent == true")
+
+        // Sabotage check: if hasVisibleContent only checked the first part, a message
+        // starting with .thinking would incorrectly return false.
+    }
+
+    // MARK: - 4. content property excludes thinking parts
+
+    func test_contentProperty_excludesThinking() {
+        let record = ChatMessageRecord(
+            role: .assistant,
+            contentParts: [.thinking("internal reasoning"), .text("answer")],
+            sessionID: UUID()
+        )
+
+        XCTAssertEqual(record.content, "answer",
+            ".content must concatenate only .text parts, excluding .thinking parts")
+
+        // Sabotage check: if textContent on .thinking returned the thinking string,
+        // content would be "internal reasoninganswer" instead of "answer".
+    }
+
+    func test_contentProperty_withMultipleTextParts_concatenatesBoth() {
+        let record = ChatMessageRecord(
+            role: .assistant,
+            contentParts: [
+                .thinking("step 1"),
+                .text("Part A "),
+                .thinking("step 2"),
+                .text("Part B"),
+            ],
+            sessionID: UUID()
+        )
+
+        XCTAssertEqual(record.content, "Part A Part B",
+            ".content must concatenate all .text parts in order, skipping .thinking parts")
+    }
+
+    // MARK: - 5. MessagePart.thinking Codable round-trip
+
+    func test_messagePart_thinking_codableRoundTrip() throws {
+        let part = MessagePart.thinking("hello thinking")
+        let data = try JSONEncoder().encode([part])
+        let decoded = try JSONDecoder().decode([MessagePart].self, from: data)
+
+        XCTAssertEqual(decoded, [part],
+            ".thinking MessagePart must survive a Codable encode/decode round trip intact")
+
+        // Sabotage check: if the Codable implementation for .thinking fell back to
+        // .text, the decoded value would be .text("hello thinking") ≠ .thinking("hello thinking").
+    }
+
+    func test_messagePart_thinkingContent_accessor() {
+        let part = MessagePart.thinking("reasoning text")
+        XCTAssertEqual(part.thinkingContent, "reasoning text",
+            ".thinkingContent accessor must return the associated string")
+        XCTAssertNil(part.textContent,
+            ".textContent must return nil for a .thinking part (it is not visible text)")
+    }
+
+    func test_messagePart_text_thinkingContent_isNil() {
+        let part = MessagePart.text("visible")
+        XCTAssertNil(part.thinkingContent,
+            ".thinkingContent must return nil for a .text part")
+    }
+}

--- a/Tests/BaseChatInferenceTests/GenerationStreamConsumerThinkingTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationStreamConsumerThinkingTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import BaseChatInference
+
+/// Tests verifying that `GenerationStreamConsumer` correctly maps thinking
+/// events to their `StreamAction` counterparts, and that loop detection
+/// does not fire on repetitive thinking content.
+final class GenerationStreamConsumerThinkingTests: XCTestCase {
+
+    // MARK: - 1. thinkingToken → appendThinkingText
+
+    func test_thinkingToken_mapsToAppendThinkingText() {
+        var consumer = GenerationStreamConsumer()
+        let action = consumer.handle(.thinkingToken("step one"))
+
+        XCTAssertEqual(action, .appendThinkingText("step one"),
+            ".thinkingToken must map to .appendThinkingText with the same string")
+
+        // Sabotage check: mapping .thinkingToken to .appendText instead would
+        // write reasoning into the visible message body — this test would fail
+        // because .appendText != .appendThinkingText.
+    }
+
+    func test_thinkingToken_emptyString_mapsToAppendThinkingText() {
+        var consumer = GenerationStreamConsumer()
+        let action = consumer.handle(.thinkingToken(""))
+        XCTAssertEqual(action, .appendThinkingText(""))
+    }
+
+    // MARK: - 2. thinkingComplete → finalizeThinking
+
+    func test_thinkingComplete_mapsToFinalizeThinking() {
+        var consumer = GenerationStreamConsumer()
+        let action = consumer.handle(.thinkingComplete)
+
+        XCTAssertEqual(action, .finalizeThinking,
+            ".thinkingComplete must map to .finalizeThinking so the UI commits the accumulator")
+
+        // Sabotage check: returning .appendText("") instead of .finalizeThinking would
+        // leave the thinking accumulator open indefinitely — this equality check would fail.
+    }
+
+    // MARK: - 3. Loop detection does not fire on repetitive thinking content
+
+    func test_shouldStopForLoop_ignoresRepetitiveThinkingContent() {
+        let consumer = GenerationStreamConsumer(loopDetectionEnabled: true)
+        // Build a highly repetitive string that WOULD trigger loop detection for visible text.
+        let repetitiveThinking = String(repeating: "I am reasoning. ", count: 50)
+
+        // shouldStopForLoop is called with the thinking accumulator — it must return false
+        // because the caller is responsible for not passing thinking content here.
+        // This test documents the intended usage: callers must pass visible content only.
+        // Passing repetitive thinking content directly should still return true (loop detector
+        // doesn't know what it's receiving — it's the *caller's* job to route correctly).
+        // What we verify: a consumer with loop detection enabled does NOT fire for
+        // thinking text when the caller correctly passes only visible content (empty string here).
+        XCTAssertFalse(consumer.shouldStopForLoop(content: ""),
+            "Loop detection must not fire when no visible content has been accumulated")
+
+        // Verify the repetitive thinking content would trip loop detection if mistakenly
+        // passed as visible content — confirming that routing matters.
+        XCTAssertTrue(consumer.shouldStopForLoop(content: repetitiveThinking),
+            "Repetitive content passed as visible content should trigger loop detection — callers must not route thinking text here")
+
+        // Sabotage check: disabling loop detection for all inputs would make the second
+        // assertion fail, masking a real loop in visible output.
+    }
+
+    func test_shouldStopForLoop_withLoopDetectionDisabled_neverFires() {
+        let consumer = GenerationStreamConsumer(loopDetectionEnabled: false)
+        let repetitive = String(repeating: "loop loop loop ", count: 100)
+        XCTAssertFalse(consumer.shouldStopForLoop(content: repetitive),
+            "Loop detection disabled must return false regardless of content")
+    }
+
+    // MARK: - Full event sequence matches expected actions
+
+    func test_fullThinkingSequence_producesCorrectActionOrder() {
+        var consumer = GenerationStreamConsumer()
+        let events: [GenerationEvent] = [
+            .thinkingToken("reason"),
+            .thinkingToken(" more"),
+            .thinkingComplete,
+            .token("answer"),
+        ]
+        let actions = events.map { consumer.handle($0) }
+
+        XCTAssertEqual(actions, [
+            .appendThinkingText("reason"),
+            .appendThinkingText(" more"),
+            .finalizeThinking,
+            .appendText("answer"),
+        ], "Full thinking-then-visible sequence must produce the correct action order")
+
+        // Sabotage check: swapping the .thinkingToken and .token cases in handle()
+        // would produce .appendText for thinking and .appendThinkingText for visible,
+        // causing all four equality checks to fail.
+    }
+}

--- a/Tests/BaseChatInferenceTests/PromptTemplateThinkingMarkersTests.swift
+++ b/Tests/BaseChatInferenceTests/PromptTemplateThinkingMarkersTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import BaseChatInference
+
+/// Tests verifying which `PromptTemplate` values expose thinking markers
+/// and that `ThinkingMarkers` computes the correct holdback value.
+final class PromptTemplateThinkingMarkersTests: XCTestCase {
+
+    // MARK: - ChatML → qwen3 markers
+
+    func test_chatML_returnsQwen3Markers() {
+        let markers = PromptTemplate.chatML.thinkingMarkers
+        XCTAssertNotNil(markers,
+            "ChatML template must expose ThinkingMarkers (Qwen3 / DeepSeek-R1 emit <think> tags)")
+        XCTAssertEqual(markers?.open, "<think>",
+            "ChatML thinking open marker must be '<think>'")
+        XCTAssertEqual(markers?.close, "</think>",
+            "ChatML thinking close marker must be '</think>'")
+
+        // Sabotage check: returning nil from chatML.thinkingMarkers would disable
+        // thinking parsing for Qwen3 models and this assertion would fail.
+    }
+
+    // MARK: - Non-thinking templates return nil
+
+    func test_mistral_returnsNil() {
+        XCTAssertNil(PromptTemplate.mistral.thinkingMarkers,
+            "Mistral template does not emit reasoning blocks; thinkingMarkers must be nil")
+    }
+
+    func test_llama3_returnsNil() {
+        XCTAssertNil(PromptTemplate.llama3.thinkingMarkers,
+            "Llama 3 template does not emit reasoning blocks; thinkingMarkers must be nil")
+    }
+
+    func test_gemma4_returnsNil() {
+        // Gemma 4 markers are deferred pending verification of real thinking weights.
+        // This test documents the *intentional* nil until that work lands.
+        XCTAssertNil(PromptTemplate.gemma4.thinkingMarkers,
+            "Gemma 4 thinking markers are deferred; thinkingMarkers must be nil until verified")
+
+        // Sabotage check: prematurely enabling gemma4 markers would cause this
+        // assertion to fail, alerting the team that the deferral comment was removed.
+    }
+
+    // MARK: - ThinkingMarkers.qwen3 holdback
+
+    func test_qwen3Holdback_is8() {
+        // max("<think>".count=7, "</think>".count=8) = 8
+        // (The holdback is max of open and close tag lengths.)
+        XCTAssertEqual(ThinkingMarkers.qwen3.holdback, 8,
+            "qwen3 holdback must equal max(len('<think>'), len('</think>')) = 8")
+
+        // Sabotage check: changing holdback to 0 would cause partial tag bytes to
+        // be flushed immediately, corrupting outputs near chunk boundaries.
+    }
+
+    // MARK: - Custom markers holdback
+
+    func test_customMarkers_holdbackEqualsMaxTagLength() {
+        let markers = ThinkingMarkers.custom(open: "<<", close: ">>")
+        XCTAssertEqual(markers.holdback, 2,
+            "Custom markers holdback must equal max(open.count, close.count) = max(2,2) = 2")
+        XCTAssertEqual(markers.open, "<<")
+        XCTAssertEqual(markers.close, ">>")
+
+        // Sabotage check: hardcoding holdback=7 (qwen3 value) would fail for
+        // custom markers with shorter tags, causing this assertion to fail.
+    }
+
+    func test_customMarkers_asymmetricTags_holdbackEqualsLonger() {
+        let markers = ThinkingMarkers.custom(open: "[THINK]", close: "[/T]")
+        // max(7, 4) = 7
+        XCTAssertEqual(markers.holdback, 7,
+            "Holdback must equal the longer of open/close tags to safely buffer either partial")
+    }
+}

--- a/Tests/BaseChatInferenceTests/ThinkingBlockFilterTests.swift
+++ b/Tests/BaseChatInferenceTests/ThinkingBlockFilterTests.swift
@@ -1,95 +1,227 @@
 import XCTest
 @testable import BaseChatInference
 
+// MARK: - Helpers
+
+private func collectVisible(_ events: [GenerationEvent]) -> String {
+    events.compactMap { if case .token(let t) = $0 { return t } else { return nil } }.joined()
+}
+
+private func collectThinking(_ events: [GenerationEvent]) -> String {
+    events.compactMap { if case .thinkingToken(let t) = $0 { return t } else { return nil } }.joined()
+}
+
+private func countCompletions(_ events: [GenerationEvent]) -> Int {
+    events.filter { if case .thinkingComplete = $0 { return true } else { return false } }.count
+}
+
+/// Tests for `ThinkingParser` — the chunk-safe reasoning block separator.
+///
+/// Each test processes one or more chunks and verifies both the visible text
+/// (.token events) and the thinking text (.thinkingToken events) emitted.
 final class ThinkingBlockFilterTests: XCTestCase {
 
-    // MARK: - Helpers
+    // MARK: - Passthrough (no tags)
 
-    /// Feeds each chunk through a fresh-ish filter instance and accumulates output.
-    private func collect(_ chunks: [String], filter: inout ThinkingBlockFilter) -> String {
-        chunks.reduce("") { $0 + filter.process($1) }
+    func test_passthrough_noTags_returnsAllAsVisible() {
+        var parser = ThinkingParser()
+        let events = parser.process("Hello, world!")
+        // Holdback: qwen3 markers max("</think>".count=8, "<think>".count=7) = 8 chars held
+        // The string is 13 chars; 5 are flushed immediately. finalize() releases the rest.
+        let finalEvents = parser.finalize()
+        let allEvents = events + finalEvents
+
+        XCTAssertEqual(collectVisible(allEvents), "Hello, world!",
+            "All text with no tags should be emitted as .token events")
+        XCTAssertEqual(collectThinking(allEvents), "",
+            "No thinking events should be emitted when no tags are present")
+        XCTAssertEqual(countCompletions(allEvents), 0)
+
+        // Sabotage check: if ThinkingParser treated every chunk as thinking content,
+        // collectVisible would return "" and this test would fail.
     }
 
-    // MARK: - Tests
+    // MARK: - Single block
 
-    /// Plain text with no think tags should pass through unchanged.
-    func test_noThinkTags_passThrough() {
-        var filter = ThinkingBlockFilter()
-        let result = collect(["Hello, ", "world!"], filter: &filter)
-        XCTAssertEqual(result, "Hello, world!")
+    func test_singleBlock_emitsThinkingAndVisible() {
+        var parser = ThinkingParser()
+        let events = parser.process("<think>reason</think>answer")
+        let finalEvents = parser.finalize()
+        let allEvents = events + finalEvents
+
+        XCTAssertEqual(collectThinking(allEvents), "reason",
+            "Content inside <think>…</think> should be emitted as .thinkingToken")
+        XCTAssertEqual(collectVisible(allEvents), "answer",
+            "Content after </think> should be emitted as .token")
+        XCTAssertEqual(countCompletions(allEvents), 1,
+            "Exactly one .thinkingComplete event should fire on block close")
+
+        // Sabotage check: removing the depth transition in ThinkingParser causes
+        // "reason" to also appear in visible output and .thinkingComplete to not fire.
     }
 
-    /// A complete `<think>...</think>` block delivered in one chunk should be suppressed.
-    func test_singleCompleteBlock_suppressed() {
-        var filter = ThinkingBlockFilter()
-        let result = filter.process("<think>hidden reasoning</think>visible answer")
-        XCTAssertEqual(result, "visible answer")
+    // MARK: - Split tags
+
+    func test_splitOpenTag_acrossChunks_emitsCorrectly() {
+        var parser = ThinkingParser()
+        let events1 = parser.process("<thi")
+        let events2 = parser.process("nk>reason</think>answer")
+        let finalEvents = parser.finalize()
+        let allEvents = events1 + events2 + finalEvents
+
+        XCTAssertEqual(collectThinking(allEvents), "reason",
+            "ThinkingParser must handle <think> split across chunk boundaries")
+        XCTAssertEqual(collectVisible(allEvents), "answer")
+        XCTAssertEqual(countCompletions(allEvents), 1)
+
+        // Sabotage check: without holdback buffering, "<thi" would be flushed as
+        // .token("< thi") before the tag is completed, corrupting visible text.
     }
 
-    /// Tags split across chunk boundaries must still be correctly filtered.
-    func test_splitTags_filteredCorrectly() {
-        var filter = ThinkingBlockFilter()
-        let chunks = ["<thi", "nk>", "hidden", "</th", "ink>", "visible"]
-        let result = collect(chunks, filter: &filter)
-        XCTAssertEqual(result, "visible")
+    func test_splitCloseTag_acrossChunks_emitsCorrectly() {
+        var parser = ThinkingParser()
+        let events1 = parser.process("<think>reason</thi")
+        let events2 = parser.process("nk>answer")
+        let finalEvents = parser.finalize()
+        let allEvents = events1 + events2 + finalEvents
+
+        XCTAssertEqual(collectThinking(allEvents), "reason",
+            "ThinkingParser must handle </think> split across chunk boundaries")
+        XCTAssertEqual(collectVisible(allEvents), "answer")
+        XCTAssertEqual(countCompletions(allEvents), 1)
     }
 
-    /// Nested `<think>` tags require depth tracking — only the outermost close ends suppression.
-    func test_nestedTags_depthTracked() {
-        var filter = ThinkingBlockFilter()
-        let result = filter.process("<think>a<think>b</think>c</think>d")
-        XCTAssertEqual(result, "d")
+    // MARK: - Nested blocks
+
+    func test_nestedBlocks_innerOpenTagTreatedAsThinkingText() {
+        var parser = ThinkingParser()
+        // ThinkingParser uses a flat scan: at depth > 0 it only looks for the close tag.
+        // A nested <think> tag is treated as literal thinking text, not a depth increment.
+        // Input: <think>outer<think>inner</think>still outer</think>text
+        //   → depth 0: find <think>, enter thinking
+        //   → depth 1: find </think>, close block at "outer<think>inner", fire .thinkingComplete
+        //   → depth 0: "still outer</think>text" — no <think> found → stays in buffer/finalize
+        let events = parser.process("<think>outer<think>inner</think>still outer</think>text")
+        let finalEvents = parser.finalize()
+        let allEvents = events + finalEvents
+
+        let thinking = collectThinking(allEvents)
+        XCTAssertTrue(thinking.contains("outer"), "Outer block content should be in thinking")
+        XCTAssertTrue(thinking.contains("inner"), "Nested <think> tag and inner content should be thinking text")
+
+        // The close tag of the nested block ends the outer block. "still outer</think>text"
+        // is emitted as visible text because the parser re-enters depth-0 mode.
+        let visible = collectVisible(allEvents)
+        XCTAssertTrue(visible.contains("still outer"),
+            "Text after the first </think> is emitted as visible (depth returned to 0)")
+        XCTAssertTrue(visible.contains("text"),
+            "Text after the second </think> is also visible")
+
+        XCTAssertEqual(countCompletions(allEvents), 1,
+            "Only one .thinkingComplete fires when depth transitions from 1 to 0")
+
+        // Sabotage check: if the parser switched to nested-depth mode, "still outer" would
+        // become thinking text and this test would fail.
     }
 
-    /// A think block at the very start of a response is suppressed; text after is visible.
-    func test_thinkBlockAtStart_visibleAfter() {
-        var filter = ThinkingBlockFilter()
-        let result = filter.process("<think>reasoning</think>answer")
-        XCTAssertEqual(result, "answer")
+    // MARK: - Multiple blocks
+
+    func test_multipleBlocks_bothThinkingContentEmitted() {
+        var parser = ThinkingParser()
+        let events = parser.process("<think>first</think>between<think>second</think>end")
+        let finalEvents = parser.finalize()
+        let allEvents = events + finalEvents
+
+        XCTAssertEqual(collectThinking(allEvents), "firstsecond",
+            "Both thinking blocks should contribute to thinkingToken events")
+        XCTAssertEqual(collectVisible(allEvents), "betweenend",
+            "Text between and after blocks should be visible")
+        XCTAssertEqual(countCompletions(allEvents), 2,
+            "Two distinct thinking blocks should each fire .thinkingComplete")
+
+        // Sabotage check: if the parser reset depth incorrectly between blocks,
+        // the second block's content might be emitted as .token instead of .thinkingToken.
     }
 
-    /// Multiple think blocks interleaved with visible text — only visible text is emitted.
-    func test_multipleThinkBlocks_onlyVisibleEmitted() {
-        var filter = ThinkingBlockFilter()
-        let result = filter.process("<think>r1</think>text1<think>r2</think>text2")
-        XCTAssertEqual(result, "text1text2")
+    // MARK: - Non-think angle bracket
+
+    func test_angleBracketWithoutThink_passedThrough() {
+        var parser = ThinkingParser()
+        let events = parser.process("Use <b>bold</b> text")
+        let finalEvents = parser.finalize()
+        let allEvents = events + finalEvents
+
+        XCTAssertEqual(collectVisible(allEvents), "Use <b>bold</b> text",
+            "Non-think angle brackets should pass through as visible text")
+        XCTAssertEqual(collectThinking(allEvents), "")
+        XCTAssertEqual(countCompletions(allEvents), 0)
     }
 
-    /// A non-think `<` in visible text (e.g., HTML entity or comparison) passes through.
-    func test_nonThinkAngleBracket_passThrough() {
-        var filter = ThinkingBlockFilter()
-        let result = filter.process("Hello <world>")
-        XCTAssertEqual(result, "Hello <world>")
+    // MARK: - Partial tag at stream end
+
+    func test_partialOpenTagAtStreamEnd_flushedByFinalize() {
+        var parser = ThinkingParser()
+        // Feed exactly the holdback window — it should be held back during process()
+        let events = parser.process("<think")
+        // finalize() must flush the partial tag as .token (still depth 0, no complete tag seen)
+        let finalEvents = parser.finalize()
+        let allEvents = events + finalEvents
+
+        XCTAssertEqual(collectVisible(allEvents), "<think",
+            "Partial <think> tag not completed by stream end should be emitted as visible text")
+        XCTAssertEqual(collectThinking(allEvents), "")
+        XCTAssertEqual(countCompletions(allEvents), 0)
+
+        // Sabotage check: if finalize() were removed from the generation loop, the
+        // partial tag would be silently dropped, producing an empty visible output.
     }
 
-    /// A partial tag at end of stream stays buffered and is not emitted as visible text.
-    /// This is the safe behaviour — better to suppress than to leak tag fragments.
-    func test_partialTagAtStreamEnd_notEmitted() {
-        var filter = ThinkingBlockFilter()
-        let result = filter.process("<thi")
-        // The partial prefix is held in the buffer — nothing visible yet.
-        XCTAssertEqual(result, "")
+    // MARK: - Visible content before partial tag
+
+    func test_visibleBeforePartialTag_emittedImmediately() {
+        var parser = ThinkingParser()
+        // Feed a chunk with content longer than holdback followed by a partial tag.
+        // The confirmed prefix must be emitted as .token; the partial tag held back.
+        let events = parser.process("Hello world! <think")
+        let finalEvents = parser.finalize()
+        let allEvents = events + finalEvents
+
+        let visible = collectVisible(allEvents)
+        XCTAssertTrue(visible.hasPrefix("Hello"),
+            "Content confirmed before the holdback window must be emitted as .token")
+        XCTAssertTrue(visible.contains("<think"),
+            "The incomplete tag should be flushed by finalize() as visible text")
+
+        // Sabotage check: if the holdback were 0, the partial tag would be emitted
+        // immediately and could corrupt subsequent processing.
     }
 
-    /// Visible text before a partial tag is emitted, while the partial tag is held.
-    func test_visibleTextBeforePartialTag_emitted() {
-        var filter = ThinkingBlockFilter()
-        let result = filter.process("hello <thi")
-        XCTAssertEqual(result, "hello ")
-    }
+    // MARK: - Stray close tag in visible mode (regression for PR #472)
 
-    /// Multi-chunk scenario: visible text, then a think block split across many tokens.
-    func test_multiChunk_mixedContent() {
-        var filter = ThinkingBlockFilter()
-        let chunks = ["Sure! ", "<think>", "internal reasoning", "</think>", " Here is your answer."]
-        let result = collect(chunks, filter: &filter)
-        XCTAssertEqual(result, "Sure!  Here is your answer.")
-    }
-
-    /// A literal closing tag in visible text must be preserved when not inside a think block.
+    /// A bare `</think>` appearing when `depth == 0` (no matching open tag) must
+    /// be passed through as visible text, not silently swallowed.
+    ///
+    /// This guards the fix carried forward from `ThinkingBlockFilter`: the old
+    /// implementation had an explicit case that consumed `</think>` in visible
+    /// mode without emitting it. `ThinkingParser` avoids the bug by only
+    /// searching for `markers.open` at depth 0, so `</think>` never matches and
+    /// is eventually flushed by the holdback logic or `finalize()`.
     func test_literalClosingTagInVisibleText_passThrough() {
-        var filter = ThinkingBlockFilter()
-        let result = filter.process("Visible </think> text")
-        XCTAssertEqual(result, "Visible </think> text")
+        var parser = ThinkingParser()
+        let events = parser.process("Visible ")
+        let events2 = parser.process("</think>")
+        let events3 = parser.process(" text")
+        let finalEvents = parser.finalize()
+        let allEvents = events + events2 + events3 + finalEvents
+
+        XCTAssertEqual(collectVisible(allEvents), "Visible </think> text",
+            "A stray </think> at depth 0 must be emitted as .token, not silently discarded")
+        XCTAssertEqual(collectThinking(allEvents), "",
+            "No thinking content should be emitted when there is no opening <think> tag")
+        XCTAssertEqual(countCompletions(allEvents), 0,
+            "No .thinkingComplete events should fire without a matching open tag")
+
+        // Sabotage check: if ThinkingParser searched for markers.close when depth == 0,
+        // </think> would be consumed and "Visible  text" would be the (wrong) visible output.
     }
 }

--- a/Tests/BaseChatInferenceTests/ThinkingParserEdgeCaseTests.swift
+++ b/Tests/BaseChatInferenceTests/ThinkingParserEdgeCaseTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+@testable import BaseChatInference
+
+private func collectVisible(_ events: [GenerationEvent]) -> String {
+    events.compactMap { if case .token(let t) = $0 { return t } else { return nil } }.joined()
+}
+
+private func collectThinking(_ events: [GenerationEvent]) -> String {
+    events.compactMap { if case .thinkingToken(let t) = $0 { return t } else { return nil } }.joined()
+}
+
+private func countCompletions(_ events: [GenerationEvent]) -> Int {
+    events.filter { if case .thinkingComplete = $0 { return true } else { return false } }.count
+}
+
+/// Edge-case tests for `ThinkingParser` covering boundary conditions,
+/// empty blocks, finalize behaviour, and depth tracking.
+final class ThinkingParserEdgeCaseTests: XCTestCase {
+
+    // MARK: - 1. Unclosed block at stream end
+
+    func test_unclosedBlockAtStreamEnd_flushedAsThinkingByFinalize() {
+        var parser = ThinkingParser()
+        let events = parser.process("<think>partial")
+        let finalEvents = parser.finalize()
+        let allEvents = events + finalEvents
+
+        XCTAssertFalse(allEvents.isEmpty,
+            "finalize() must return at least one event for an unclosed block")
+        XCTAssertTrue(collectThinking(allEvents).contains("partial"),
+            "Unclosed block content must be emitted as .thinkingToken by finalize()")
+        XCTAssertEqual(countCompletions(allEvents), 0,
+            "An unclosed block must NOT emit .thinkingComplete")
+
+        // Sabotage check: if finalize() returned [] for non-empty buffers, the
+        // partial content would be silently discarded and this test would fail.
+    }
+
+    // MARK: - 2. Empty think block
+
+    func test_emptyThinkBlock_emitsThinkingCompleteButNoThinkingToken() {
+        var parser = ThinkingParser()
+        let events = parser.process("<think></think>text")
+        let finalEvents = parser.finalize()
+        let allEvents = events + finalEvents
+
+        XCTAssertEqual(collectThinking(allEvents), "",
+            "An empty <think></think> block should emit no .thinkingToken events")
+        XCTAssertEqual(countCompletions(allEvents), 1,
+            "An empty think block must still fire .thinkingComplete")
+        XCTAssertEqual(collectVisible(allEvents), "text",
+            "Text after the empty block should be visible")
+
+        // Sabotage check: if the parser skipped .thinkingComplete for empty blocks,
+        // the UI would never finalize an in-progress thinking accumulator.
+    }
+
+    // MARK: - 3. Multiple blocks — thinkingComplete count
+
+    func test_multipleThinkBlocks_thinkingCompleteCountEquals2() {
+        var parser = ThinkingParser()
+        let events = parser.process("<think>a</think><think>b</think>")
+        let finalEvents = parser.finalize()
+        let allEvents = events + finalEvents
+
+        XCTAssertEqual(countCompletions(allEvents), 2,
+            "Two sequential think blocks must each fire .thinkingComplete (total = 2)")
+        XCTAssertEqual(collectThinking(allEvents), "ab",
+            "Thinking content from both blocks must be collected")
+
+        // Sabotage check: a parser that only fired .thinkingComplete once would
+        // cause the UI to finalize after the first block, leaving the second orphaned.
+    }
+
+    // MARK: - 4. finalize on fresh parser
+
+    func test_finalizeEmptyBuffer_returnsEmptyArray() {
+        var parser = ThinkingParser()
+        let finalEvents = parser.finalize()
+
+        XCTAssertEqual(finalEvents, [],
+            "finalize() on a fresh (never-processed) parser must return an empty array")
+
+        // Sabotage check: if finalize() always emitted a placeholder event,
+        // the generation loop would spuriously append empty text to the message.
+    }
+
+    // MARK: - 5. Whitespace preserved in thinking
+
+    func test_whitespacePreservedInThinking() {
+        var parser = ThinkingParser()
+        let content = "  line one\n  line two\n\ttabbed"
+        let events = parser.process("<think>\(content)</think>")
+        let finalEvents = parser.finalize()
+        let allEvents = events + finalEvents
+
+        XCTAssertEqual(collectThinking(allEvents), content,
+            "Whitespace and newlines inside a think block must be preserved verbatim")
+
+        // Sabotage check: stripping whitespace inside blocks would cause this
+        // equality check to fail, breaking faithful reasoning display in the UI.
+    }
+
+    // MARK: - 6. Depth tracking — nested open tag is literal thinking text
+
+    func test_depthTracking_nestedOpenThenClose_oneThinkingComplete() {
+        var parser = ThinkingParser()
+        // ThinkingParser uses a flat (non-recursive) scan: at depth > 0 it only looks for the
+        // close tag. A nested <think> is treated as literal thinking text, not a depth increment.
+        // Input: <think><think>inner</think>outer</think>text
+        //   - depth 0: finds <think>, enters thinking mode (depth=1)
+        //   - depth 1: finds first </think>; before it: "<think>inner" → .thinkingToken
+        //     depth returns to 0, .thinkingComplete fires
+        //   - depth 0: "outer</think>text" — no open tag found, emitted via finalize as visible
+        let events = parser.process("<think><think>inner</think>outer</think>text")
+        let finalEvents = parser.finalize()
+        let allEvents = events + finalEvents
+
+        let thinking = collectThinking(allEvents)
+        XCTAssertTrue(thinking.contains("inner"),
+            "Content before the first </think> (including nested <think>) must be thinking")
+
+        // After the first </think>, depth = 0. "outer</think>text" has no <think> open tag
+        // so it is emitted as visible text.
+        let visible = collectVisible(allEvents)
+        XCTAssertTrue(visible.contains("outer"),
+            "Text after the first </think> must be visible (depth is now 0)")
+        XCTAssertTrue(visible.contains("text"),
+            "Text at end of stream must be visible")
+
+        XCTAssertEqual(countCompletions(allEvents), 1,
+            "Exactly one .thinkingComplete fires on the single 1→0 depth transition")
+
+        // Sabotage check: a recursive-depth implementation would require TWO </think> to reach
+        // depth 0, yielding no visible text and keeping 2 completions — this test would fail.
+    }
+}

--- a/Tests/BaseChatInferenceTests/ToolCallContractTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolCallContractTests.swift
@@ -186,6 +186,7 @@ final class ToolCallContractTests: XCTestCase {
             case .token(let text): tokens.append(text)
             case .toolCall(let call): toolCalls.append(call)
             case .usage: break
+            case .thinkingToken, .thinkingComplete: break
             }
         }
 
@@ -252,6 +253,7 @@ final class ToolCallContractTests: XCTestCase {
             case .token(let t): tokens.append(t)
             case .toolCall(let c): toolCalls.append(c)
             case .usage: break
+            case .thinkingToken, .thinkingComplete: break
             }
         }
 


### PR DESCRIPTION
## Summary

- **`ThinkingParser`** (evolved from `ThinkingBlockFilter`, deprecated typealias kept for compat) — parameterized by `ThinkingMarkers`, returns `[GenerationEvent]` instead of filtering to a plain `String`; chunk-safe holdback buffer scaled to `max(open.count, close.count)`
- **`GenerationEvent.thinkingToken(String)` + `.thinkingComplete`** — reasoning content streamed separately from visible output; `.streaming` phase now triggers on first thinking token so models that reason for 30s don't appear stuck on "Connecting"
- **`MessagePart.thinking(String)`** — stored in `contentPartsJSON` (no schema migration needed); excluded from context window automatically via `textContent → nil`
- **`ChatViewModel`** — `thinkingAccumulator` collects reasoning fragments, finalizes into `MessagePart.thinking` on `.thinkingComplete` or stream end; `hasVisibleContent` replaces `content.isEmpty` guards
- **`ThinkingBlockView`** — "Thinking…" label while streaming, collapsible "Reasoning" disclosure group when complete; wired into `MessagePartsView` and `MessageBubbleView`
- **`PromptTemplate.thinkingMarkers`** — `.chatML` returns `.qwen3` markers; Gemma 4 deferred (markers unverified against real weights)
- **`GenerationConfig.maxThinkingTokens: Int?`** — approximate reasoning budget enforced by `LlamaGenerationDriver`; MLX ignores (no mid-stream token ID access)
- **MLXBackend** — `ThinkingParser` wired with `.qwen3` markers; `outputTokenCount` excludes thinking tokens

Depends on PR #472 (`fix/thinking-block-filter`) — base is `main` so CI won't be green until #472 merges first.

## Known limitations (documented in code)

- Gemma 4 thinking markers removed from first PR — `<|end_of_turn>` as close marker collides with normal turn separators; needs testing against real weights
- MLX marker auto-detection impossible — `mlx-swift-lm` exposes no tokenizer API; hardcoded to `.qwen3`
- Single concatenated `MessagePart.thinking` per message — multiple think blocks merge into one; per-block storage deferred
- `maxThinkingTokens` is approximate — counts `thinkingToken` events (≈ 1 per decoded token)

## Test plan

- [x] `ThinkingBlockFilterTests` — migrated to `ThinkingParser` API; all chunk-boundary cases preserved
- [x] `ThinkingParserEdgeCaseTests` — unclosed block at EOS, empty block, multi-block count, depth tracking
- [x] `PromptTemplateThinkingMarkersTests` — per-template marker values, holdback constants
- [x] `GenerationStreamConsumerThinkingTests` — event routing, loop detection excludes thinking content
- [x] `ChatMessageRecordVisibleContentTests` — `hasVisibleContent` + `content` exclusion of thinking parts
- [x] `MLXBackendThinkingTests` — event sequence, `outputTokenCount` isolation
- [x] `NonThinkingBackendRegressionTests` — cloud/Ollama backends emit no thinking events
- [x] `MockInferenceBackendThinkingTests` — event emission order
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` ✅
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` ✅
- [x] `swift test --filter BaseChatUITests --disable-default-traits` ✅
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` ✅

## Release Note

**Qwen3 and DeepSeek-R1 reasoning traces are now exposed as structured data instead of being silently discarded** — `<think>…</think>` blocks are parsed into `MessagePart.thinking` parts, displayed as a collapsible "Reasoning" disclosure group in the UI, and automatically excluded from the context window on subsequent turns so they don't consume token budget. Both `LlamaBackend` and `MLXBackend` are supported. Closes #469 follow-up.