### PR TITLE
refactor(ui): extract ModelLoadCoordinator from ChatViewModel (phase 3 of #329)

### DIFF
--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+ModelLoading.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+ModelLoading.swift
@@ -2,10 +2,10 @@ import Foundation
 import BaseChatCore
 import BaseChatInference
 
-// MARK: - ChatViewModel + Model Loading
+// MARK: - ChatViewModel + Model Loading (facade)
 
 // Two-tier load coordination:
-// - ChatViewModel (this layer) owns UI task lifecycle via `latestLoadIntentGeneration` —
+// - ChatViewModel (this layer) owns UI task lifecycle via `ModelLoadCoordinator` —
 //   superseded async tasks are cancelled before they reach InferenceService.
 // - InferenceService owns backend state correctness via monotonic LoadRequestToken —
 //   any stale completion that does reach the service layer is suppressed there.
@@ -19,17 +19,13 @@ extension ChatViewModel {
     /// Newest selection always wins; any older in-flight coordinated load intent is
     /// cancelled and invalidated.
     public func dispatchSelectedLoad() {
-        let generation = nextLoadIntentGeneration(cancelInFlightTask: true)
         guard let intent = currentLoadIntent else { return }
-
-        coordinatedLoadTask = Task { [weak self] in
-            await self?.performLoad(intent, generation: generation)
-        }
+        loadCoordinator.dispatchLoad(intent)
     }
 
     /// Manually unloads the active backend and invalidates any pending coordinated load.
     public func unloadModel() {
-        invalidatePendingLoadIntent(resetActivityPhase: true)
+        loadCoordinator.invalidatePendingLoadIntent(resetActivityPhase: true)
         inferenceService.unloadModel()
         // Token counts are keyed by message UUID, which is reused across sessions.
         // Dropping them here prevents counts computed with the previous model's
@@ -53,7 +49,7 @@ extension ChatViewModel {
             return
         }
 
-        await loadLocalModel(model, generation: nil)
+        await loadCoordinator.loadLocalModel(model, generation: nil)
     }
 
     /// Loads a cloud API endpoint for the active session.
@@ -61,8 +57,10 @@ extension ChatViewModel {
     /// - Note: Prefer `dispatchSelectedLoad()` for UI-driven loads — it coordinates
     ///   intent and cancels superseded requests.
     public func loadCloudEndpoint(_ endpoint: APIEndpoint) async {
-        await loadCloudEndpointInternal(endpoint, generation: nil)
+        await loadCoordinator.loadCloudEndpointInternal(endpoint, generation: nil)
     }
+
+    // MARK: - Private helpers
 
     private var currentLoadIntent: LoadIntent? {
         if let endpoint = selectedEndpoint {
@@ -72,218 +70,5 @@ extension ChatViewModel {
             return .localModel(model)
         }
         return nil
-    }
-
-    @discardableResult
-    private func nextLoadIntentGeneration(cancelInFlightTask: Bool) -> UInt64 {
-        latestLoadIntentGeneration &+= 1
-        if cancelInFlightTask {
-            coordinatedLoadTask?.cancel()
-            coordinatedLoadTask = nil
-        }
-        return latestLoadIntentGeneration
-    }
-
-    private func invalidatePendingLoadIntent(resetActivityPhase: Bool = false) {
-        _ = nextLoadIntentGeneration(cancelInFlightTask: true)
-        if resetActivityPhase, isLoading {
-            transitionPhase(to: .idle)
-        }
-    }
-
-    private func isCurrentLoadIntentGeneration(_ generation: UInt64?) -> Bool {
-        guard let generation else { return true }
-        return generation == latestLoadIntentGeneration
-    }
-
-    private func beginLoadUIState(generation: UInt64?) -> Bool {
-        guard isCurrentLoadIntentGeneration(generation) else { return false }
-        errorMessage = nil
-        lastProgressTransitionInstant = nil
-        transitionPhase(to: .modelLoading(progress: inferenceService.modelLoadProgress))
-        return true
-    }
-
-    /// Mirrors `inferenceService.modelLoadProgress` into ``activityPhase`` for
-    /// the duration of a model load. Polls instead of using
-    /// `withObservationTracking` so cancellation is reliable — observation
-    /// continuations don't resume on `Task.cancel()`, which makes them
-    /// deadlock-prone for a long-running mirror like this.
-    ///
-    /// The bridge only writes when the load generation is still current AND
-    /// `activityPhase` is still `.modelLoading`, so any late wake-up after
-    /// `endLoadUIState` has flipped the phase to `.idle` is a no-op.
-    private func observeModelLoadProgress(generation: UInt64?) async {
-        while !Task.isCancelled {
-            applyModelLoadProgress(generation: generation)
-            do {
-                try await Task.sleep(for: progressBridgePollInterval)
-            } catch {
-                // Sleep throws on cancel; one final apply ensures the latest
-                // value is published before the bridge exits.
-                applyModelLoadProgress(generation: generation)
-                return
-            }
-        }
-    }
-
-    private func applyModelLoadProgress(generation: UInt64?) {
-        guard isCurrentLoadIntentGeneration(generation) else { return }
-        guard case .modelLoading(let current) = activityPhase else { return }
-        let snapshot = inferenceService.modelLoadProgress
-        guard current != snapshot else { return }
-
-        // Terminal progress (>= 1.0) and the first emission after a new load
-        // cycle bypass the throttle so the progress UI feels immediate at the
-        // start and lands cleanly at 100% before the phase flips to .idle.
-        let isTerminal = (snapshot ?? 0.0) >= 1.0
-        let now = ContinuousClock.now
-        if let last = lastProgressTransitionInstant,
-           !isTerminal,
-           now - last < progressBridgeMinTransitionInterval {
-            return
-        }
-
-        if transitionPhase(to: .modelLoading(progress: snapshot)) {
-            lastProgressTransitionInstant = now
-        }
-    }
-
-    private func endLoadUIState(generation: UInt64?) {
-        guard isCurrentLoadIntentGeneration(generation) else { return }
-        lastProgressTransitionInstant = nil
-        if case .modelLoading = activityPhase {
-            transitionPhase(to: .idle)
-        }
-    }
-
-    private func setLoadErrorIfCurrent(_ message: String, generation: UInt64?) {
-        guard isCurrentLoadIntentGeneration(generation) else { return }
-        errorMessage = message
-    }
-
-    private func performLoad(_ intent: LoadIntent, generation: UInt64?) async {
-        switch intent {
-        case .localModel(let model):
-            await loadLocalModel(model, generation: generation)
-        case .cloudEndpoint(let endpoint):
-            await loadCloudEndpointInternal(endpoint, generation: generation)
-        }
-    }
-
-    private func loadLocalModel(_ model: ModelInfo, generation: UInt64?) async {
-        guard isCurrentLoadIntentGeneration(generation) else { return }
-
-        // Stage 2: unified load plan. `ModelLoadPlan` fuses the legacy
-        // `DeviceCapabilityService.canLoadModel(...)` fit check and the
-        // `DeviceCapabilityService.safeContextSize(...)` context clamp into a single
-        // decision so backends see a consistent verdict + context pair. The
-        // legacy helpers are still in place for Stage 5 removal — the UI no
-        // longer calls them.
-        let requestedContext = model.detectedContextLength ?? 8_192
-        let plan: ModelLoadPlan
-        switch model.modelType {
-        case .foundation:
-            // Foundation models are system-managed: no weight or KV math applies.
-            plan = ModelLoadPlan.systemManaged(requestedContextSize: requestedContext)
-        case .gguf:
-            plan = ModelLoadPlan.compute(
-                for: model,
-                requestedContextSize: requestedContext,
-                strategy: .mappable,
-                environment: loadPlanEnvironment
-            )
-        case .mlx:
-            plan = ModelLoadPlan.compute(
-                for: model,
-                requestedContextSize: requestedContext,
-                strategy: .resident,
-                environment: loadPlanEnvironment
-            )
-        }
-
-        switch plan.verdict {
-        case .deny:
-            setLoadErrorIfCurrent(
-                loadPlanDenyMessage(for: plan, model: model),
-                generation: generation
-            )
-            return
-        case .warn:
-            Log.inference.warning(
-                "Proceeding with tight-fit model load: \(model.name) — \(String(describing: plan.reasons))"
-            )
-        case .allow:
-            break
-        }
-
-        // Auto-detect prompt template from GGUF metadata before loading.
-        if let detected = model.detectedPromptTemplate,
-           isCurrentLoadIntentGeneration(generation) {
-            selectedPromptTemplate = detected
-            Log.inference.info("Auto-detected prompt template: \(detected.rawValue)")
-        }
-
-        guard beginLoadUIState(generation: generation) else { return }
-        let bridge = Task { @MainActor [weak self] in
-            await self?.observeModelLoadProgress(generation: generation)
-        }
-        defer {
-            bridge.cancel()
-            endLoadUIState(generation: generation)
-        }
-
-        do {
-            try await inferenceService.loadModel(from: model, plan: plan)
-        } catch is CancellationError {
-            return
-        } catch {
-            setLoadErrorIfCurrent("Failed to load model: \(error.localizedDescription)", generation: generation)
-        }
-    }
-
-    /// Translates a denied plan's primary `Reason` into a user-visible message.
-    ///
-    /// Picks the first `.insufficientResident` or `.insufficientKVCache` as the
-    /// primary reason; clamp reasons (info-only) are not surfaced. Falls back to
-    /// the legacy shape when no primary reason is present.
-    private func loadPlanDenyMessage(for plan: ModelLoadPlan, model: ModelInfo) -> String {
-        let primary = plan.reasons.first { reason in
-            switch reason {
-            case .insufficientResident, .insufficientKVCache: return true
-            default: return false
-            }
-        }
-        switch primary {
-        case .insufficientResident(let required, let available):
-            return "This model (\(Self.formatBytes(required))) is too large for available memory (\(Self.formatBytes(available))). Try a smaller quantisation."
-        case .insufficientKVCache(let required, let available):
-            return "Model weights fit, but the requested context window doesn't (\(Self.formatBytes(required)) needed vs \(Self.formatBytes(available)) available). Try reducing the context size or closing other apps."
-        default:
-            return "This model (\(model.fileSizeFormatted)) may be too large for this device. Try a smaller quantisation."
-        }
-    }
-
-    private static func formatBytes(_ bytes: UInt64) -> String {
-        ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)
-    }
-
-    private func loadCloudEndpointInternal(_ endpoint: APIEndpoint, generation: UInt64?) async {
-        guard beginLoadUIState(generation: generation) else { return }
-        let bridge = Task { @MainActor [weak self] in
-            await self?.observeModelLoadProgress(generation: generation)
-        }
-        defer {
-            bridge.cancel()
-            endLoadUIState(generation: generation)
-        }
-
-        do {
-            try await inferenceService.loadCloudBackend(from: endpoint)
-        } catch is CancellationError {
-            return
-        } catch {
-            setLoadErrorIfCurrent("Failed to connect: \(error.localizedDescription)", generation: generation)
-        }
     }
 }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -372,38 +372,31 @@ public final class ChatViewModel {
         AppMemoryUsage.currentBytes()
     }
 
-    // MARK: - Private State
+    // MARK: - Load Coordinator
 
-    enum LoadIntent {
-        case localModel(ModelInfo)
-        case cloudEndpoint(APIEndpoint)
+    /// Owns the "latest-wins with cancellation" model-load state machine.
+    /// Extracted from `ChatViewModel` in phase 3 of #329.
+    var loadCoordinator: ModelLoadCoordinator!
+
+    /// Forwarding accessor so tests that mutate `vm.progressBridgePollInterval`
+    /// continue to work without changes.
+    var progressBridgePollInterval: Duration {
+        get { loadCoordinator.progressBridgePollInterval }
+        set { loadCoordinator.progressBridgePollInterval = newValue }
     }
+
+    /// Forwarding accessor for completeness / test parity.
+    var progressBridgeMinTransitionInterval: Duration {
+        get { loadCoordinator.progressBridgeMinTransitionInterval }
+        set { loadCoordinator.progressBridgeMinTransitionInterval = newValue }
+    }
+
+    // MARK: - Private State
 
     /// Token for the currently active generation request, if any.
     var activeGenerationToken: InferenceService.GenerationRequestToken?
     var generationTask: Task<Void, Never>?
     var backgroundTask: Task<Void, Never>?
-    var coordinatedLoadTask: Task<Void, Never>?
-    var latestLoadIntentGeneration: UInt64 = 0
-
-    /// Polling interval for the model-load progress bridge task that mirrors
-    /// `inferenceService.modelLoadProgress` into ``activityPhase``. Tests may
-    /// override this to a small value for deterministic timing.
-    var progressBridgePollInterval: Duration = .milliseconds(50)
-
-    /// Minimum interval between published phase transitions for in-flight
-    /// model-load progress. Keeps steadily-progressing backends from
-    /// re-rendering every view observing ``activityPhase`` on every poll tick.
-    /// The first emission in a load cycle and the terminal (≥ 1.0) emission
-    /// always publish regardless of this window.
-    var progressBridgeMinTransitionInterval: Duration = .milliseconds(250)
-
-    /// Timestamp of the most recent published phase transition from
-    /// ``applyModelLoadProgress``. `nil` means the next progress change will
-    /// publish immediately (either because no progress has been published yet
-    /// in this load cycle or a fresh cycle just began).
-    @ObservationIgnored
-    var lastProgressTransitionInstant: ContinuousClock.Instant?
     var lastPressureLevel: MemoryPressureLevel = .nominal
     private var isSynchronizingSelection = false
     var isRestoringSession = false
@@ -513,6 +506,33 @@ public final class ChatViewModel {
 
         let firstRunKey = "\(BaseChatConfiguration.shared.bundleIdentifier).hasCompletedFirstLaunch"
         self.isFirstRun = !UserDefaults.standard.bool(forKey: firstRunKey)
+
+        let coordinator = ModelLoadCoordinator(inferenceService: inferenceService)
+        self.loadCoordinator = coordinator
+        coordinator.onTransitionPhase = { [weak self] phase in
+            self?.transitionPhase(to: phase) ?? false
+        }
+        coordinator.onSurfaceError = { [weak self] message in
+            self?.errorMessage = message
+        }
+        coordinator.onClearError = { [weak self] in
+            self?.errorMessage = nil
+        }
+        coordinator.onSetSelectedPromptTemplate = { [weak self] template in
+            self?.selectedPromptTemplate = template
+        }
+        coordinator.onInvalidateTokenCaches = { [weak self] in
+            self?.invalidateTokenCaches()
+        }
+        coordinator.isRestoringSession = { [weak self] in
+            self?.isRestoringSession ?? false
+        }
+        coordinator.currentActivityPhase = { [weak self] in
+            self?.activityPhase ?? .idle
+        }
+        coordinator.currentLoadPlanEnvironment = { [weak self] in
+            self?.loadPlanEnvironment ?? .current
+        }
     }
 
     /// Injects the persistence provider. Call once from the view layer

--- a/Sources/BaseChatUI/ViewModels/ModelLoadCoordinator.swift
+++ b/Sources/BaseChatUI/ViewModels/ModelLoadCoordinator.swift
@@ -1,0 +1,324 @@
+import Foundation
+import BaseChatCore
+import BaseChatInference
+
+// MARK: - LoadIntent
+
+/// The two kinds of load request that can be dispatched to the coordinator.
+enum LoadIntent {
+    case localModel(ModelInfo)
+    case cloudEndpoint(APIEndpoint)
+}
+
+// MARK: - ModelLoadCoordinator
+
+/// Owns the "latest-wins with cancellation" model-load state machine extracted
+/// from `ChatViewModel` (phase 3 of #329).
+///
+/// The coordinator is `@MainActor` but NOT `@Observable` — it holds no
+/// SwiftUI-observed state of its own. All observable side-effects are routed
+/// back to `ChatViewModel` through the callback seams set at construction.
+///
+/// ## Race safety
+///
+/// The wrapping-add generation counter (`latestLoadIntentGeneration &+= 1`) and
+/// the "guard-before-proceed" pattern at every suspension point reproduce the
+/// same defense-in-depth strategy that was in `ChatViewModel` before extraction:
+///
+/// - This layer cancels superseded async tasks before they reach `InferenceService`.
+/// - `InferenceService` suppresses any stale completion that does reach it via its
+///   own monotonic `LoadRequestToken`.
+@MainActor
+final class ModelLoadCoordinator {
+
+    // MARK: - Seams (set by ChatViewModel at init)
+
+    /// Forwards to `ChatViewModel.transitionPhase(to:)`. Returns `true` if the
+    /// transition was accepted (matches `transitionPhase`'s own return value).
+    var onTransitionPhase: (BackendActivityPhase) -> Bool = { _ in false }
+
+    /// Forwards to setting `ChatViewModel.errorMessage` to a non-nil string.
+    var onSurfaceError: (String) -> Void = { _ in }
+
+    /// Clears `ChatViewModel.errorMessage` (sets it to `nil`).
+    var onClearError: () -> Void = {}
+
+    /// Forwards to setting `ChatViewModel.selectedPromptTemplate`.
+    var onSetSelectedPromptTemplate: (PromptTemplate) -> Void = { _ in }
+
+    /// Forwards to `ChatViewModel.invalidateTokenCaches()`.
+    var onInvalidateTokenCaches: () -> Void = {}
+
+    /// Returns `ChatViewModel.isRestoringSession`.
+    var isRestoringSession: () -> Bool = { false }
+
+    /// Returns `ChatViewModel.activityPhase`.
+    var currentActivityPhase: () -> BackendActivityPhase = { .idle }
+
+    /// Returns the `ModelLoadPlan.Environment` to use for local-model load plans.
+    var currentLoadPlanEnvironment: () -> ModelLoadPlan.Environment = { .current }
+
+    // MARK: - State
+
+    /// Polling interval for the model-load progress bridge task that mirrors
+    /// `inferenceService.modelLoadProgress` into the view model's `activityPhase`.
+    /// Tests may override this to a small value for deterministic timing.
+    var progressBridgePollInterval: Duration = .milliseconds(50)
+
+    /// Minimum interval between published phase transitions for in-flight
+    /// model-load progress. Keeps steadily-progressing backends from
+    /// re-rendering every view observing `activityPhase` on every poll tick.
+    /// The first emission in a load cycle and the terminal (≥ 1.0) emission
+    /// always publish regardless of this window.
+    var progressBridgeMinTransitionInterval: Duration = .milliseconds(250)
+
+    /// Timestamp of the most recent published phase transition from
+    /// `applyModelLoadProgress`. `nil` means the next progress change will
+    /// publish immediately (either because no progress has been published yet
+    /// in this load cycle or a fresh cycle just began).
+    var lastProgressTransitionInstant: ContinuousClock.Instant?
+
+    /// The currently running coordinated load task, if any.
+    var coordinatedLoadTask: Task<Void, Never>?
+
+    /// Monotonic generation counter. Incremented (with wrapping) each time a
+    /// new load intent supersedes the previous one, allowing stale async
+    /// continuations to detect they are no longer current.
+    var latestLoadIntentGeneration: UInt64 = 0
+
+    // MARK: - Dependencies (injected by ChatViewModel)
+
+    private let inferenceService: InferenceService
+
+    // MARK: - Init
+
+    init(inferenceService: InferenceService) {
+        self.inferenceService = inferenceService
+    }
+
+    // MARK: - Public Interface (called from ChatViewModel facade)
+
+    /// Dispatches a load for the given intent. The newest dispatch always wins;
+    /// any older in-flight coordinated load is cancelled and invalidated.
+    func dispatchLoad(_ intent: LoadIntent) {
+        let generation = nextLoadIntentGeneration(cancelInFlightTask: true)
+        coordinatedLoadTask = Task { [weak self] in
+            await self?.performLoad(intent, generation: generation)
+        }
+    }
+
+    /// Cancels any in-flight coordinated load and (optionally) resets the
+    /// activity phase back to `.idle`. Called from `unloadModel()` and
+    /// `handleMemoryPressure()` on the VM.
+    func invalidatePendingLoadIntent(resetActivityPhase: Bool = false) {
+        _ = nextLoadIntentGeneration(cancelInFlightTask: true)
+        if resetActivityPhase, case .modelLoading = currentActivityPhase() {
+            _ = onTransitionPhase(.idle)
+        }
+    }
+
+    // MARK: - Load Entry Points (called from ChatViewModel for non-dispatch paths)
+
+    func loadLocalModel(_ model: ModelInfo, generation: UInt64?) async {
+        guard isCurrentLoadIntentGeneration(generation) else { return }
+
+        let requestedContext = model.detectedContextLength ?? 8_192
+        let plan: ModelLoadPlan
+        switch model.modelType {
+        case .foundation:
+            plan = ModelLoadPlan.systemManaged(requestedContextSize: requestedContext)
+        case .gguf:
+            plan = ModelLoadPlan.compute(
+                for: model,
+                requestedContextSize: requestedContext,
+                strategy: .mappable,
+                environment: currentLoadPlanEnvironment()
+            )
+        case .mlx:
+            plan = ModelLoadPlan.compute(
+                for: model,
+                requestedContextSize: requestedContext,
+                strategy: .resident,
+                environment: currentLoadPlanEnvironment()
+            )
+        }
+
+        switch plan.verdict {
+        case .deny:
+            setLoadErrorIfCurrent(
+                loadPlanDenyMessage(for: plan, model: model),
+                generation: generation
+            )
+            return
+        case .warn:
+            Log.inference.warning(
+                "Proceeding with tight-fit model load: \(model.name) — \(String(describing: plan.reasons))"
+            )
+        case .allow:
+            break
+        }
+
+        // Auto-detect prompt template from GGUF metadata before loading.
+        if let detected = model.detectedPromptTemplate,
+           isCurrentLoadIntentGeneration(generation) {
+            onSetSelectedPromptTemplate(detected)
+            Log.inference.info("Auto-detected prompt template: \(detected.rawValue)")
+        }
+
+        guard beginLoadUIState(generation: generation) else { return }
+        let bridge = Task { @MainActor [weak self] in
+            await self?.observeModelLoadProgress(generation: generation)
+        }
+        defer {
+            bridge.cancel()
+            endLoadUIState(generation: generation)
+        }
+
+        do {
+            try await inferenceService.loadModel(from: model, plan: plan)
+        } catch is CancellationError {
+            return
+        } catch {
+            setLoadErrorIfCurrent("Failed to load model: \(error.localizedDescription)", generation: generation)
+        }
+    }
+
+    func loadCloudEndpointInternal(_ endpoint: APIEndpoint, generation: UInt64?) async {
+        guard beginLoadUIState(generation: generation) else { return }
+        let bridge = Task { @MainActor [weak self] in
+            await self?.observeModelLoadProgress(generation: generation)
+        }
+        defer {
+            bridge.cancel()
+            endLoadUIState(generation: generation)
+        }
+
+        do {
+            try await inferenceService.loadCloudBackend(from: endpoint)
+        } catch is CancellationError {
+            return
+        } catch {
+            setLoadErrorIfCurrent("Failed to connect: \(error.localizedDescription)", generation: generation)
+        }
+    }
+
+    // MARK: - Generation Counter
+
+    @discardableResult
+    func nextLoadIntentGeneration(cancelInFlightTask: Bool) -> UInt64 {
+        latestLoadIntentGeneration &+= 1
+        if cancelInFlightTask {
+            coordinatedLoadTask?.cancel()
+            coordinatedLoadTask = nil
+        }
+        return latestLoadIntentGeneration
+    }
+
+    // MARK: - Private Helpers
+
+    private func performLoad(_ intent: LoadIntent, generation: UInt64?) async {
+        switch intent {
+        case .localModel(let model):
+            await loadLocalModel(model, generation: generation)
+        case .cloudEndpoint(let endpoint):
+            await loadCloudEndpointInternal(endpoint, generation: generation)
+        }
+    }
+
+    func isCurrentLoadIntentGeneration(_ generation: UInt64?) -> Bool {
+        guard let generation else { return true }
+        return generation == latestLoadIntentGeneration
+    }
+
+    private func beginLoadUIState(generation: UInt64?) -> Bool {
+        guard isCurrentLoadIntentGeneration(generation) else { return false }
+        onClearError()
+        lastProgressTransitionInstant = nil
+        _ = onTransitionPhase(.modelLoading(progress: inferenceService.modelLoadProgress))
+        return true
+    }
+
+    /// Mirrors `inferenceService.modelLoadProgress` into `activityPhase` for
+    /// the duration of a model load. Polls instead of using
+    /// `withObservationTracking` so cancellation is reliable — observation
+    /// continuations don't resume on `Task.cancel()`, which makes them
+    /// deadlock-prone for a long-running mirror like this.
+    ///
+    /// The bridge only writes when the load generation is still current AND
+    /// `activityPhase` is still `.modelLoading`, so any late wake-up after
+    /// `endLoadUIState` has flipped the phase to `.idle` is a no-op.
+    private func observeModelLoadProgress(generation: UInt64?) async {
+        while !Task.isCancelled {
+            applyModelLoadProgress(generation: generation)
+            do {
+                try await Task.sleep(for: progressBridgePollInterval)
+            } catch {
+                // Sleep throws on cancel; one final apply ensures the latest
+                // value is published before the bridge exits.
+                applyModelLoadProgress(generation: generation)
+                return
+            }
+        }
+    }
+
+    private func applyModelLoadProgress(generation: UInt64?) {
+        guard isCurrentLoadIntentGeneration(generation) else { return }
+        guard case .modelLoading(let current) = currentActivityPhase() else { return }
+        let snapshot = inferenceService.modelLoadProgress
+        guard current != snapshot else { return }
+
+        // Terminal progress (>= 1.0) and the first emission after a new load
+        // cycle bypass the throttle so the progress UI feels immediate at the
+        // start and lands cleanly at 100% before the phase flips to .idle.
+        let isTerminal = (snapshot ?? 0.0) >= 1.0
+        let now = ContinuousClock.now
+        if let last = lastProgressTransitionInstant,
+           !isTerminal,
+           now - last < progressBridgeMinTransitionInterval {
+            return
+        }
+
+        if onTransitionPhase(.modelLoading(progress: snapshot)) {
+            lastProgressTransitionInstant = now
+        }
+    }
+
+    private func endLoadUIState(generation: UInt64?) {
+        guard isCurrentLoadIntentGeneration(generation) else { return }
+        lastProgressTransitionInstant = nil
+        if case .modelLoading = currentActivityPhase() {
+            _ = onTransitionPhase(.idle)
+        }
+    }
+
+    private func setLoadErrorIfCurrent(_ message: String, generation: UInt64?) {
+        guard isCurrentLoadIntentGeneration(generation) else { return }
+        onSurfaceError(message)
+    }
+
+    /// Translates a denied plan's primary `Reason` into a user-visible message.
+    ///
+    /// Picks the first `.insufficientResident` or `.insufficientKVCache` as the
+    /// primary reason; clamp reasons (info-only) are not surfaced. Falls back to
+    /// the legacy shape when no primary reason is present.
+    private func loadPlanDenyMessage(for plan: ModelLoadPlan, model: ModelInfo) -> String {
+        let primary = plan.reasons.first { reason in
+            switch reason {
+            case .insufficientResident, .insufficientKVCache: return true
+            default: return false
+            }
+        }
+        switch primary {
+        case .insufficientResident(let required, let available):
+            return "This model (\(Self.formatBytes(required))) is too large for available memory (\(Self.formatBytes(available))). Try a smaller quantisation."
+        case .insufficientKVCache(let required, let available):
+            return "Model weights fit, but the requested context window doesn't (\(Self.formatBytes(required)) needed vs \(Self.formatBytes(available)) available). Try reducing the context size or closing other apps."
+        default:
+            return "This model (\(model.fileSizeFormatted)) may be too large for this device. Try a smaller quantisation."
+        }
+    }
+
+    private static func formatBytes(_ bytes: UInt64) -> String {
+        ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts the "latest-wins with cancellation" model-load state machine from `ChatViewModel` into a new `ModelLoadCoordinator` class (`Sources/BaseChatUI/ViewModels/ModelLoadCoordinator.swift`)
- Moves five stored properties — `coordinatedLoadTask`, `latestLoadIntentGeneration`, `progressBridgePollInterval`, `progressBridgeMinTransitionInterval`, `lastProgressTransitionInstant` — from the VM to the coordinator
- Moves all private load-orchestration methods (`performLoad`, `loadLocalModel`, `loadCloudEndpointInternal`, `beginLoadUIState`, `endLoadUIState`, `observeModelLoadProgress`, `applyModelLoadProgress`, `setLoadErrorIfCurrent`, `loadPlanDenyMessage`, `formatBytes`, `nextLoadIntentGeneration`, `isCurrentLoadIntentGeneration`, `invalidatePendingLoadIntent`) to the coordinator
- Moves `LoadIntent` enum out of `ChatViewModel` and into `ModelLoadCoordinator.swift`
- `ChatViewModel+ModelLoading.swift` becomes a thin facade: `dispatchSelectedLoad`, `loadSelectedModel`, `loadCloudEndpoint`, and `unloadModel` forward to the coordinator; `invalidateTokenCaches()` still called on the VM
- Coordinator wires back to the VM through six typed callbacks (`onTransitionPhase`, `onSurfaceError`, `onClearError`, `onSetSelectedPromptTemplate`, `onInvalidateTokenCaches`, `isRestoringSession`, `currentActivityPhase`, `currentLoadPlanEnvironment`)
- Forwarding computed vars for `progressBridgePollInterval` and `progressBridgeMinTransitionInterval` on `ChatViewModel` keep all existing test code unmodified
- Race safety preserved exactly: same wrapping-add `&+=` semantics, same guard-before-proceed pattern at every suspension point

Closes #354

## Test plan

- [ ] `swift test --filter BaseChatCoreTests --disable-default-traits` — 0 failures
- [ ] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 0 failures
- [ ] `swift test --filter BaseChatUITests --disable-default-traits` — 0 failures (450 tests)
- [ ] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 0 failures
- [ ] `ChatViewModelLoadProgressBridgeTests` — all 5 bridge/throttle tests pass; `vm.progressBridgePollInterval` and `vm.progressBridgeMinTransitionInterval` still writable via forwarding vars
- [ ] `LoadDispatchCoordinationTests` — rapid-toggle, stale-completion, and memory-pressure-preempt tests all pass
- [ ] No new public API surface introduced; no existing public API removed

## Release Note

This is a pure internal refactor with no public behaviour change. The public facade methods (`dispatchSelectedLoad`, `loadSelectedModel`, `loadCloudEndpoint`, `unloadModel`, `isLoading`) remain identical. No changelog entry is needed.