### PR TITLE
chore(ci): add sabotage-evidence section to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,18 @@
 <!-- How was this tested? Which test targets cover it? -->
 <!-- Note: BaseChatCoreTests and BaseChatUITests run in CI. Hardware-dependent tests (BaseChatBackendsTests, BaseChatE2ETests) run locally. -->
 
+## Sabotage evidence (regression-test PRs only)
+
+<!-- For any PR adding a regression test: temporarily revert the fix / break the
+     code path under test, confirm the new test goes RED, then re-apply the fix
+     and confirm GREEN. Paste the diff and red-run log (or link to a comment
+     that contains them). Exempt: pure refactors, docs-only PRs, dep bumps. -->
+
+- [ ] N/A (not a regression-test PR)
+- [ ] Reverted the fix / broke the path under test
+- [ ] Confirmed the new test went RED (log pasted or linked below)
+- [ ] Re-applied the fix and confirmed GREEN
+
 ## Checklist
 
 - [ ] Tests added or updated for new behaviour


### PR DESCRIPTION
## What does this change?

Adds a required "Sabotage evidence" section to `.github/pull_request_template.md` for any PR that adds a regression test. Exempt: pure refactors, docs-only PRs, dependency bumps.

## Motivation

CLAUDE.md lays out the "break the code, confirm red, revert" practice as a project convention, but it's enforced by memory and vibe rather than by review. The fuzzer super-session (#487–#501) ships a lot of regression tests where a vacuously-passing test would silently mask a real bug — #498 defer-flush, #490 replay 2/3 gate, #491 shrink monotonicity, and #488 detector contracts are all high-risk.

Closes #502.

## Release Note

N/A

## Testing

Template-only change; rendered locally by opening this PR and confirming the new section appears.

## Sabotage evidence (regression-test PRs only)

- [x] N/A (not a regression-test PR)

## Checklist

- [x] Tests added or updated for new behaviour — N/A, template-only
- [x] Public API changes have \`///\` doc comments — N/A
- [x] No hardcoded secrets, API keys, or personal data
- [x] Breaking change? — no

🤖 Generated with [Claude Code](https://claude.com/claude-code)