### PR TITLE
docs(fuzz): add backend fixture coverage matrix (#503)

### DIFF
--- a/FUZZING.md
+++ b/FUZZING.md
@@ -219,3 +219,119 @@ These are wired but not yet implemented. Day-one issues will be filed for each.
 - **`BackendDriver` protocol** — promote `FuzzRunner.BackendProvider` from a closure to a protocol once a second backend is wired ([#496](https://github.com/roryford/BaseChatKit/issues/496)).
 
 The fuzzer does not run in CI by design — it's a pre-release activity, not a gate.
+
+---
+
+## Backend fixture coverage — audit 2026-04-19
+
+Rationale: [#487](https://github.com/roryford/BaseChatKit/issues/487) — OllamaBackend silently dropped `message.thinking` because `OllamaBackendTests` had zero fixtures with that field. This matrix audits which protocol fields every backend has a fixture for and which it does not, so each `no` cell becomes a tracked follow-up rather than a latent "surfaced-by-the-fuzzer" bug. Source: [#503](https://github.com/roryford/BaseChatKit/issues/503).
+
+**Legend.** `yes` — a fixture in `Tests/BaseChatBackendsTests/` asserts the field's behaviour. `no` — no fixture anywhere in the test tree exercises the field. `partial` — a fixture touches the field but does not cover the variants called out in the gap issue. Cells marked `n/a` apply when the field is structurally impossible on that backend (e.g. GGUF chat templates on Claude).
+
+### Ollama
+
+| Backend | Field | Fixture exists? | Test file / line | Gap issue |
+|---|---|---|---|---|
+| Ollama | `/api/chat` NDJSON happy path | yes | `OllamaBackendTests.swift:101` (`streaming_yieldsTokens`) | — |
+| Ollama | `message.content` extraction | yes | `OllamaBackendTests.swift:328` (`extractToken_parsesContent`) | — |
+| Ollama | `message.thinking` field | no | — | [#487](https://github.com/roryford/BaseChatKit/issues/487) |
+| Ollama | `done_reason` variants (`stop`/`length`/`load`/`unload`) | no | — | [#507](https://github.com/roryford/BaseChatKit/issues/507) |
+| Ollama | `eval_count` / `eval_duration` usage stats | no | — | [#508](https://github.com/roryford/BaseChatKit/issues/508) |
+| Ollama | NDJSON mid-line byte split | no | — | [#509](https://github.com/roryford/BaseChatKit/issues/509) |
+| Ollama | `/api/generate` legacy endpoint shape | no | — | [#510](https://github.com/roryford/BaseChatKit/issues/510) |
+| Ollama | SSE stream limits (size / event rate) | no | — | [#511](https://github.com/roryford/BaseChatKit/issues/511) |
+| Ollama | `Retry-After` header non-numeric variants | partial[^1] | `OllamaBackendTests.swift:230` (`rateLimitError_429`) | [#512](https://github.com/roryford/BaseChatKit/issues/512) |
+| Ollama | 404 / 500 / 429 error paths | yes | `OllamaBackendTests.swift:189` / `:210` / `:230` | — |
+| Ollama | system prompt in request body | yes | `OllamaBackendTests.swift:125` (`streaming_withSystemPrompt_includesInMessages`) | — |
+| Ollama | conversation history serialisation | yes | `OllamaBackendTests.swift:286` (`conversationHistory_usedInMessages`) | — |
+| Ollama | malformed NDJSON line handling | yes | `OllamaBackendTests.swift:168` (`streaming_malformedLine_skipped`) | — |
+
+[^1]: Only `Retry-After: "0"` is fixtured; RFC 7231 HTTP-date form and non-trivial integer seconds are not.
+
+### MLX
+
+| Backend | Field | Fixture exists? | Test file / line | Gap issue |
+|---|---|---|---|---|
+| MLX | qwen3 thinking markers | yes | `MLXBackendThinkingTests.swift:59` (`test_thinkingTokensEmittedSeparatelyFromVisibleTokens`) | — |
+| MLX | deepseek-r1 thinking markers | partial[^2] | `MLXBackendThinkingTests.swift:59` | — |
+| MLX | custom / gpt-oss / gemma4 markers | no | — | [#513](https://github.com/roryford/BaseChatKit/issues/513) |
+| MLX | `maxThinkingTokens` cap | no | — | [#514](https://github.com/roryford/BaseChatKit/issues/514) |
+| MLX | `maxOutputTokens` with thinking active | yes | `MLXBackendThinkingTests.swift:123` (`test_outputTokenCount_doesNotIncludeThinkingTokens`) | — |
+| MLX | no thinking events when markers nil | yes | `MLXBackendThinkingTests.swift:166` (`test_noThinkingEvents_whenMarkersNotSet`) | — |
+| MLX | token yield happy path | yes | `MLXBackendGenerationTests.swift:38` (`test_generate_yieldsInjectedTokens`) | — |
+| MLX | cancellation via stream termination | yes | `MLXBackendGenerationTests.swift:95` (`test_generate_cancellation`) | — |
+| MLX | generate-error propagation | yes | `MLXBackendGenerationTests.swift:141` (`test_generate_generateThrows_propagatesError`) | — |
+| MLX | stop_reason variants (`.maxTokens` / EOS / cancel) | no | — | [#515](https://github.com/roryford/BaseChatKit/issues/515) |
+| MLX | chat-template detection (missing `tokenizer_config.json`) | no | — | [#516](https://github.com/roryford/BaseChatKit/issues/516) |
+| MLX | tool-call deltas (`<tool_call>` tags) | no | — | [#517](https://github.com/roryford/BaseChatKit/issues/517) |
+| MLX | `capabilities` surface | yes | `MLXBackendTests.swift:28`-`:42` | — |
+
+[^2]: DeepSeek-R1 uses the same `<think>/</think>` tags as Qwen3, so the qwen3 fixture effectively covers the token-shape. No fixture distinguishes the two at the template-detection layer.
+
+### Llama
+
+| Backend | Field | Fixture exists? | Test file / line | Gap issue |
+|---|---|---|---|---|
+| Llama | init / capabilities / context size | yes | `LlamaBackendTests.swift:32`-`:54` | — |
+| Llama | loadModel invalid path | yes | `LlamaBackendTests.swift:58` (`test_loadModel_invalidPath_throws`) | — |
+| Llama | loadModel empty GGUF | yes | `LlamaBackendTests.swift:78` (`test_loadModel_emptyFile_throws`) | — |
+| Llama | plan-clamp honoured | yes | `LlamaBackendTests.swift:389` (`test_loadModel_fromPlan_clampRespected...`) | — |
+| Llama | concurrent `stopGeneration` thread-safety | yes | `LlamaBackendTests.swift:229` | — |
+| Llama | stop-then-regenerate (KV cache clear) | yes | `LlamaBackendTests.swift:257` (`...regression390`) | — |
+| Llama | GGUF chat-template variants (ChatML / Llama3 / Gemma / Gemma4 / Mistral) | no | — | [#518](https://github.com/roryford/BaseChatKit/issues/518) |
+| Llama | EOS token variants (`</s>` / `<|eot_id|>` / multi-EOG Gemma) | no | — | [#519](https://github.com/roryford/BaseChatKit/issues/519) |
+| Llama | `n_batch` boundary (N, N+1, contextSize±1) | no | — | [#520](https://github.com/roryford/BaseChatKit/issues/520) |
+| Llama | `llama_decode` error paths (prompt / generation) | no | — | [#521](https://github.com/roryford/BaseChatKit/issues/521) |
+| Llama | `stopGeneration` fired mid-`llama_decode` | no | — | [#522](https://github.com/roryford/BaseChatKit/issues/522) |
+| Llama | tokenizer heuristic fallback | yes | `LlamaBackendTests.swift:438`-`:459` | — |
+| Llama | `countTokens` without model throws | yes | `LlamaBackendTests.swift:468` | — |
+| Llama | memory-pressure auto-stop | yes | `LlamaBackendMemoryPressureTests.swift` (full file) | — |
+| Llama | Llama-serialized load characterisation | yes | `LlamaBackendLoadSerializationCharacterizationTests.swift` (full file) | — |
+
+### Foundation
+
+| Backend | Field | Fixture exists? | Test file / line | Gap issue |
+|---|---|---|---|---|
+| Foundation | init + capabilities | yes | `FoundationBackendUnitTests.swift:132` (`test_capabilities_hasCorrectValues`) | — |
+| Foundation | generate before load throws | yes | `FoundationBackendUnitTests.swift:44` | — |
+| Foundation | unload clears state / idempotent | yes | `FoundationBackendUnitTests.swift:64` / `:76` | — |
+| Foundation | resetConversation preserves isModelLoaded | yes | `FoundationBackendUnitTests.swift:94` / `:105` | — |
+| Foundation | `isAvailable` is readable | yes | `FoundationBackendUnitTests.swift:122` | — |
+| Foundation | probe session not retained as active | yes | `FoundationBackendUnitTests.swift:183` (hardware-gated) | — |
+| Foundation | stop resets session | yes | `FoundationBackendUnitTests.swift:213` (hardware-gated) | — |
+| Foundation | `GenerationOptions.topP/topK/seed/repeatPenalty` passthrough | no | — | [#523](https://github.com/roryford/BaseChatKit/issues/523) |
+| Foundation | `SystemLanguageModel.Availability` variant handling | no | — | [#524](https://github.com/roryford/BaseChatKit/issues/524) |
+| Foundation | cancellation timing mid-partial | no | — | [#525](https://github.com/roryford/BaseChatKit/issues/525) |
+| Foundation | structured content-part types (non-monotonic diff) | no | — | [#526](https://github.com/roryford/BaseChatKit/issues/526) |
+| Foundation | temperature passthrough | partial[^3] | `FoundationBackendUnitTests.swift:148` | — |
+
+[^3]: Capability test asserts `.temperature` is in `supportedParameters` but no fixture drives a non-default value end-to-end.
+
+### Claude
+
+| Backend | Field | Fixture exists? | Test file / line | Gap issue |
+|---|---|---|---|---|
+| Claude | `text_delta` token extraction | yes | `SSEPayloadReplayTests.swift:45` (`test_claude_realStreamingResponse_extractsTokens`) | — |
+| Claude | `message_start` prompt-token usage | yes | `SSEPayloadReplayTests.swift:74` | — |
+| Claude | `message_delta` completion-token usage | yes | `SSEPayloadReplayTests.swift:84` | — |
+| Claude | usage accumulation across events | yes | `SSEPayloadReplayTests.swift:125` (`test_claude_usageAccumulation_acrossEvents`) | — |
+| Claude | `message_stop` isStreamEnd | yes | `SSEPayloadReplayTests.swift:91` | — |
+| Claude | SSE `error` event extraction (`overloaded_error`) | yes | `SSEPayloadReplayTests.swift:101` (`test_claude_errorEvent_extractsError`) | — |
+| Claude | 401/403 authentication failure | yes | `ClaudeBackendTests.swift:41` (`test_loadModel_withoutAPIKey_throws`) | — |
+| Claude | conversation history in request body | yes | `ClaudeBackendTests.swift:141` | — |
+| Claude | keychain-backed configure path | yes | `ClaudeBackendTests.swift:238` | — |
+| Claude | stopGeneration mid-stream | yes | `ClaudeBackendTests.swift:198` | — |
+| Claude | `thinking` / `thinking_delta` content blocks | no | — | [#527](https://github.com/roryford/BaseChatKit/issues/527) |
+| Claude | `tool_use` streaming (`input_json_delta`) | no | — | [#528](https://github.com/roryford/BaseChatKit/issues/528) |
+| Claude | `citations_delta` handling | no | — | [#529](https://github.com/roryford/BaseChatKit/issues/529) |
+| Claude | `stop_reason` variants (`refusal` / `max_tokens` / `stop_sequence`) | partial[^4] | `SSEPayloadReplayTests.swift:57` | [#530](https://github.com/roryford/BaseChatKit/issues/530) |
+| Claude | rate-limit error body shape + `anthropic-ratelimit-*` headers | partial[^5] | `ClaudeBackendTests.swift` (no body, only status) | [#531](https://github.com/roryford/BaseChatKit/issues/531) |
+| Claude | interleaved content blocks (text + tool_use + thinking) | no | — | [#532](https://github.com/roryford/BaseChatKit/issues/532) |
+| Claude | GGUF chat-template variants | n/a | — | — |
+
+[^4]: Only `stop_reason: end_turn` is fixtured (implicitly, via the happy-path payload). `refusal`, `max_tokens`, `stop_sequence`, and `tool_use` are never driven.
+[^5]: 429 is driven with empty body and `Retry-After: "0"` only. Structured Anthropic error body and the `anthropic-ratelimit-tokens-reset` header are not exercised.
+
+### Summary
+
+26 gap issues opened (#507–#532): 6 Ollama, 5 MLX, 5 Llama, 4 Foundation, 6 Claude. Each row above with a `no` or `partial` verdict links to the tracking issue. Re-run this audit whenever a new protocol field lands, or when a backend source file's public surface changes meaningfully.


### PR DESCRIPTION
## What does this change?

Adds a "Backend fixture coverage" section to `FUZZING.md` with a per-backend matrix (Ollama / MLX / Llama / Foundation / Claude) mapping every protocol field I could identify to `yes` / `no` / `partial` / `n/a`, with the test file+line for each `yes` and a tracking issue for each `no`/`partial`.

## Motivation

[#487](https://github.com/roryford/BaseChatKit/issues/487) shipped a silently-broken code path (OllamaBackend dropping `message.thinking`) because `OllamaBackendTests` had zero fixtures with a `thinking` field. That was a symptom, not a one-off — this audit proves the scope goes beyond Ollama and turns every gap into a tracked follow-up.

Closes #503.

## Release Note

N/A (docs-only).

## Testing

N/A — documentation and issue-filing only. No code paths touched. Sabotage evidence box checked below because this PR changes no behaviour.

## Gap issues opened (26)

| Backend | Issues |
|---|---|
| Ollama | [#507](https://github.com/roryford/BaseChatKit/issues/507) [#508](https://github.com/roryford/BaseChatKit/issues/508) [#509](https://github.com/roryford/BaseChatKit/issues/509) [#510](https://github.com/roryford/BaseChatKit/issues/510) [#511](https://github.com/roryford/BaseChatKit/issues/511) [#512](https://github.com/roryford/BaseChatKit/issues/512) |
| MLX | [#513](https://github.com/roryford/BaseChatKit/issues/513) [#514](https://github.com/roryford/BaseChatKit/issues/514) [#515](https://github.com/roryford/BaseChatKit/issues/515) [#516](https://github.com/roryford/BaseChatKit/issues/516) [#517](https://github.com/roryford/BaseChatKit/issues/517) |
| Llama | [#518](https://github.com/roryford/BaseChatKit/issues/518) [#519](https://github.com/roryford/BaseChatKit/issues/519) [#520](https://github.com/roryford/BaseChatKit/issues/520) [#521](https://github.com/roryford/BaseChatKit/issues/521) [#522](https://github.com/roryford/BaseChatKit/issues/522) |
| Foundation | [#523](https://github.com/roryford/BaseChatKit/issues/523) [#524](https://github.com/roryford/BaseChatKit/issues/524) [#525](https://github.com/roryford/BaseChatKit/issues/525) [#526](https://github.com/roryford/BaseChatKit/issues/526) |
| Claude | [#527](https://github.com/roryford/BaseChatKit/issues/527) [#528](https://github.com/roryford/BaseChatKit/issues/528) [#529](https://github.com/roryford/BaseChatKit/issues/529) [#530](https://github.com/roryford/BaseChatKit/issues/530) [#531](https://github.com/roryford/BaseChatKit/issues/531) [#532](https://github.com/roryford/BaseChatKit/issues/532) |

All 26 carry the `enhancement` label and each includes: why-it-matters (untested code path), a concrete fixture shape (JSON / Swift snippet), and the target test file.

## Checklist

- [x] No code changes — sabotage evidence N/A (docs-only PR)
- [x] Public API changes have `///` doc comments (no API changes)
- [x] No hardcoded secrets, API keys, or personal data
- [ ] Breaking change? No.