### PR TITLE
feat(fuzz): version RunRecord and document its schema

### DIFF
--- a/Sources/BaseChatFuzz/BaseChatFuzz.docc/RunRecordSchema.md
+++ b/Sources/BaseChatFuzz/BaseChatFuzz.docc/RunRecordSchema.md
@@ -1,0 +1,73 @@
+# Run Record Schema
+
+The on-disk contract for `record.json` written by the BaseChatFuzz harness.
+
+## Overview
+
+Every fuzz run that produces a finding is serialised as a ``RunRecord`` to
+`tmp/fuzz/findings/<detector>/<hash>/record.json`. These records are the
+de-facto API between the harness and every external tool that consumes its
+output — `--replay`, `--shrink`, triage UIs, and CI dashboards all decode the
+same JSON. A change to this shape is a change to a public protocol even though
+there is no Swift API boundary.
+
+To keep the contract honest, ``RunRecord`` carries an explicit
+``RunRecord/schemaVersion`` (current value: ``RunRecord/currentSchema``).
+Records that omit the field are treated as version `1` so existing on-disk
+captures decode unchanged. The ``RunRecord/validate(schemaVersion:)`` entry
+point throws on records written by a future, unknown version and emits a log
+warning when migrating an older version — consumers (starting with `--replay`
+in #490) call it before acting on a decoded record.
+
+## Field reference
+
+| Field | Type | Description / invariant |
+| --- | --- | --- |
+| `schemaVersion` | `Int` | Version of the on-disk shape this record was written with. Legacy records decode as `1`. |
+| `runId` | `String` | UUID for the single generation run. |
+| `ts` | `String` | ISO-8601 timestamp in UTC of run start. |
+| `harness` | `HarnessSnapshot` | `fuzzVersion`, git rev, swift/os build, thermal state at run time. |
+| `model` | `ModelSnapshot` | Backend name, model id, URL, optional `fileSHA256` and `tokenizerHash`. |
+| `config` | `ConfigSnapshot` | `seed`, `temperature`, `topP`, optional `maxTokens`, optional `systemPrompt`. |
+| `prompt` | `PromptSnapshot` | Corpus id, applied mutator list, message turns (role + text). |
+| `events` | `[EventSnapshot]` | Ordered stream of `{t, kind, v?}` observations. `t` is seconds since run start. |
+| `raw` | `String` | Raw backend output with think/tool markers intact. |
+| `rendered` | `String` | User-visible rendering of `raw` (stripped of reasoning). May be deprecated in a future version — see #499. |
+| `thinkingRaw` | `String` | Concatenation of all thinking-channel text. |
+| `thinkingParts` | `[String]` | Thinking deltas as a list, in stream order. |
+| `thinkingCompleteCount` | `Int` | Number of `thinkingComplete` events observed. |
+| `templateMarkers` | `MarkerSnapshot?` | The `{open, close}` reasoning markers the backend/template advertises; `nil` if none. |
+| `memory` | `MemorySnapshot` | `beforeBytes`, `peakBytes`, `afterBytes` — all optional; nil when the backend/platform can't measure. |
+| `timing` | `TimingSnapshot` | `firstTokenMs?`, `totalMs`, `tokensPerSec?`. `totalMs` is always present; TPS is derived only when both token counts and first-token time are known. |
+| `phase` | `String` | One of `started`, `streaming`, `done`, `failed`. Invariant: `phase == "failed"` ⇒ `error != nil`. |
+| `error` | `String?` | Human-readable error message when `phase == "failed"`; otherwise `nil`. |
+| `stopReason` | `String?` | Coarse stop classification: `naturalStop`, `maxTokens`, `userStop`, `error`, or `unknown`. Detectors gate on this to avoid false-positive findings caused by token-cap truncation. |
+
+## Evolving the schema
+
+Changes to the on-disk shape go through a three-step migration. The goal is
+that **every older record ever written remains decodable** and that a loader
+from an older build refuses (loudly) to consume a newer record rather than
+silently misinterpreting it.
+
+1. Bump ``RunRecord/currentSchema`` to the new integer and add the new/renamed
+   field(s) to the Swift struct.
+2. Extend the custom `init(from:)` with `decodeIfPresent ?? <legacy-default>`
+   for each added field so v1 records keep decoding cleanly. For renamed
+   fields, fall back to the old key when the new key is absent.
+3. Add a round-trip test covering the old version's JSON in
+   `RunRecordRoundTripTests` so the migration stays green forever.
+
+Removing a field requires the same three steps *plus* a deprecation cycle:
+leave the field in the struct for one minor release with a deprecation note,
+then remove it in the following minor release.
+
+## Topics
+
+### Core types
+
+- ``RunRecord``
+- ``RunRecord/currentSchema``
+- ``RunRecord/schemaVersion``
+- ``RunRecord/validate(schemaVersion:)``
+- ``RunRecord/SchemaError``

--- a/Sources/BaseChatFuzz/RunRecord.swift
+++ b/Sources/BaseChatFuzz/RunRecord.swift
@@ -1,6 +1,14 @@
 import Foundation
+import BaseChatInference
 
-public struct RunRecord: Codable, Sendable {
+public struct RunRecord: Codable, Sendable, Equatable {
+    /// Current `RunRecord` on-disk schema. Bump when the shape changes.
+    /// See `BaseChatFuzz.docc/RunRecordSchema.md` for the evolution procedure.
+    public static let currentSchema: Int = 1
+
+    /// Version of the on-disk shape this record was written with. Legacy records
+    /// without the field decode as `1` via `init(from:)` below.
+    public var schemaVersion: Int = Self.currentSchema
     public var runId: String
     public var ts: String
     public var harness: HarnessSnapshot
@@ -22,7 +30,104 @@ public struct RunRecord: Codable, Sendable {
     /// Detectors gate on this to avoid false positives from token-cap truncation.
     public var stopReason: String?
 
-    public struct HarnessSnapshot: Codable, Sendable {
+    public init(
+        schemaVersion: Int = RunRecord.currentSchema,
+        runId: String,
+        ts: String,
+        harness: HarnessSnapshot,
+        model: ModelSnapshot,
+        config: ConfigSnapshot,
+        prompt: PromptSnapshot,
+        events: [EventSnapshot],
+        raw: String,
+        rendered: String,
+        thinkingRaw: String,
+        thinkingParts: [String],
+        thinkingCompleteCount: Int,
+        templateMarkers: MarkerSnapshot? = nil,
+        memory: MemorySnapshot,
+        timing: TimingSnapshot,
+        phase: String,
+        error: String? = nil,
+        stopReason: String? = nil
+    ) {
+        self.schemaVersion = schemaVersion
+        self.runId = runId
+        self.ts = ts
+        self.harness = harness
+        self.model = model
+        self.config = config
+        self.prompt = prompt
+        self.events = events
+        self.raw = raw
+        self.rendered = rendered
+        self.thinkingRaw = thinkingRaw
+        self.thinkingParts = thinkingParts
+        self.thinkingCompleteCount = thinkingCompleteCount
+        self.templateMarkers = templateMarkers
+        self.memory = memory
+        self.timing = timing
+        self.phase = phase
+        self.error = error
+        self.stopReason = stopReason
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion
+        case runId, ts, harness, model, config, prompt, events, raw, rendered
+        case thinkingRaw, thinkingParts, thinkingCompleteCount, templateMarkers
+        case memory, timing, phase, error, stopReason
+    }
+
+    /// Decodes a record, defaulting `schemaVersion` to `1` when the field is
+    /// absent so legacy on-disk records round-trip cleanly.
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.schemaVersion = try c.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 1
+        self.runId = try c.decode(String.self, forKey: .runId)
+        self.ts = try c.decode(String.self, forKey: .ts)
+        self.harness = try c.decode(HarnessSnapshot.self, forKey: .harness)
+        self.model = try c.decode(ModelSnapshot.self, forKey: .model)
+        self.config = try c.decode(ConfigSnapshot.self, forKey: .config)
+        self.prompt = try c.decode(PromptSnapshot.self, forKey: .prompt)
+        self.events = try c.decode([EventSnapshot].self, forKey: .events)
+        self.raw = try c.decode(String.self, forKey: .raw)
+        self.rendered = try c.decode(String.self, forKey: .rendered)
+        self.thinkingRaw = try c.decode(String.self, forKey: .thinkingRaw)
+        self.thinkingParts = try c.decode([String].self, forKey: .thinkingParts)
+        self.thinkingCompleteCount = try c.decode(Int.self, forKey: .thinkingCompleteCount)
+        self.templateMarkers = try c.decodeIfPresent(MarkerSnapshot.self, forKey: .templateMarkers)
+        self.memory = try c.decode(MemorySnapshot.self, forKey: .memory)
+        self.timing = try c.decode(TimingSnapshot.self, forKey: .timing)
+        self.phase = try c.decode(String.self, forKey: .phase)
+        self.error = try c.decodeIfPresent(String.self, forKey: .error)
+        self.stopReason = try c.decodeIfPresent(String.self, forKey: .stopReason)
+    }
+
+    /// Errors surfaced by `validate(schemaVersion:)`.
+    public enum SchemaError: Error, Equatable, Sendable {
+        /// Raised when a record's `schemaVersion` exceeds `currentSchema` — the
+        /// loader is from an older build than the writer and cannot be trusted
+        /// to interpret the payload.
+        case unsupportedFutureSchema(Int)
+    }
+
+    /// Validates a decoded record's `schemaVersion`. Future versions throw;
+    /// older-than-current versions log a warning so callers know a migration
+    /// is being applied. The `--replay` loader (#490) will call this before
+    /// acting on a record.
+    public static func validate(schemaVersion v: Int) throws {
+        if v > currentSchema {
+            throw SchemaError.unsupportedFutureSchema(v)
+        }
+        if v < currentSchema {
+            Log.inference.warning(
+                "RunRecord: decoding legacy schemaVersion \(v, privacy: .public) (current is \(currentSchema, privacy: .public)); migration shim applied."
+            )
+        }
+    }
+
+    public struct HarnessSnapshot: Codable, Sendable, Equatable {
         public var fuzzVersion: String
         public var packageGitRev: String
         public var packageGitDirty: Bool
@@ -31,7 +136,7 @@ public struct RunRecord: Codable, Sendable {
         public var thermalState: String
     }
 
-    public struct ModelSnapshot: Codable, Sendable {
+    public struct ModelSnapshot: Codable, Sendable, Equatable {
         public var backend: String
         public var id: String
         public var url: String
@@ -39,7 +144,7 @@ public struct RunRecord: Codable, Sendable {
         public var tokenizerHash: String?
     }
 
-    public struct ConfigSnapshot: Codable, Sendable {
+    public struct ConfigSnapshot: Codable, Sendable, Equatable {
         public var seed: UInt64
         public var temperature: Float
         public var topP: Float
@@ -47,24 +152,24 @@ public struct RunRecord: Codable, Sendable {
         public var systemPrompt: String?
     }
 
-    public struct PromptSnapshot: Codable, Sendable {
+    public struct PromptSnapshot: Codable, Sendable, Equatable {
         public var corpusId: String
         public var mutators: [String]
         public var messages: [Message]
 
-        public struct Message: Codable, Sendable {
+        public struct Message: Codable, Sendable, Equatable {
             public var role: String
             public var text: String
         }
     }
 
-    public struct EventSnapshot: Codable, Sendable {
+    public struct EventSnapshot: Codable, Sendable, Equatable {
         public var t: Double
         public var kind: String
         public var v: String?
     }
 
-    public struct MarkerSnapshot: Codable, Sendable {
+    public struct MarkerSnapshot: Codable, Sendable, Equatable {
         public var open: String
         public var close: String
         public init(open: String, close: String) {
@@ -73,13 +178,13 @@ public struct RunRecord: Codable, Sendable {
         }
     }
 
-    public struct MemorySnapshot: Codable, Sendable {
+    public struct MemorySnapshot: Codable, Sendable, Equatable {
         public var beforeBytes: UInt64?
         public var peakBytes: UInt64?
         public var afterBytes: UInt64?
     }
 
-    public struct TimingSnapshot: Codable, Sendable {
+    public struct TimingSnapshot: Codable, Sendable, Equatable {
         public var firstTokenMs: Double?
         public var totalMs: Double
         public var tokensPerSec: Double?

--- a/Tests/BaseChatFuzzTests/RunRecordRoundTripTests.swift
+++ b/Tests/BaseChatFuzzTests/RunRecordRoundTripTests.swift
@@ -1,0 +1,135 @@
+import XCTest
+@testable import BaseChatFuzz
+
+final class RunRecordRoundTripTests: XCTestCase {
+
+    // MARK: - Fixture
+
+    /// Builds a fully-populated `RunRecord` with every optional field set so
+    /// encode→decode equality catches any codable gap (leaving a field `nil`
+    /// would let a missing `decode` go unnoticed).
+    private func fullyPopulatedRecord(schemaVersion: Int = RunRecord.currentSchema) -> RunRecord {
+        RunRecord(
+            schemaVersion: schemaVersion,
+            runId: "94a7b2e0-1234-5678-9abc-def012345678",
+            ts: "2026-04-19T12:34:56Z",
+            harness: .init(
+                fuzzVersion: "0.9.0",
+                packageGitRev: "abcdef0",
+                packageGitDirty: true,
+                swiftVersion: "6.1",
+                osBuild: "macOS-26A5279q",
+                thermalState: "nominal"
+            ),
+            model: .init(
+                backend: "ollama",
+                id: "qwen3.5:4b",
+                url: "http://localhost:11434",
+                fileSHA256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd",
+                tokenizerHash: "deadbeefcafef00d"
+            ),
+            config: .init(
+                seed: 12345,
+                temperature: 0.8,
+                topP: 0.95,
+                maxTokens: 512,
+                systemPrompt: "You are a helpful fuzz target."
+            ),
+            prompt: .init(
+                corpusId: "seed-001",
+                mutators: ["emoji-spray", "utf8-homoglyph"],
+                messages: [
+                    .init(role: "system", text: "You are a helpful fuzz target."),
+                    .init(role: "user", text: "what is two plus two?")
+                ]
+            ),
+            events: [
+                .init(t: 0.0, kind: "generationStart", v: nil),
+                .init(t: 0.12, kind: "delta", v: "four"),
+                .init(t: 0.34, kind: "generationEnd", v: "naturalStop")
+            ],
+            raw: "<think>trivial</think>four",
+            rendered: "four",
+            thinkingRaw: "trivial",
+            thinkingParts: ["triv", "ial"],
+            thinkingCompleteCount: 1,
+            templateMarkers: .init(open: "<think>", close: "</think>"),
+            memory: .init(beforeBytes: 1_024_000, peakBytes: 2_048_000, afterBytes: 1_536_000),
+            timing: .init(firstTokenMs: 87.5, totalMs: 342.1, tokensPerSec: 12.7),
+            phase: "done",
+            error: "illustrative-error-string",
+            stopReason: "naturalStop"
+        )
+    }
+
+    private func makeEncoder() -> JSONEncoder {
+        let enc = JSONEncoder()
+        enc.outputFormatting = [.sortedKeys]
+        return enc
+    }
+
+    // MARK: - Round trip
+
+    func test_encodeDecode_preservesEveryField() throws {
+        let record = fullyPopulatedRecord()
+        let data = try makeEncoder().encode(record)
+        let decoded = try JSONDecoder().decode(RunRecord.self, from: data)
+        XCTAssertEqual(record, decoded)
+    }
+
+    // MARK: - Legacy record (no schemaVersion key)
+
+    func test_legacyJSONWithoutSchemaVersion_decodesAsV1() throws {
+        // Encode a fully-populated record, then strip the `schemaVersion` key
+        // from the resulting JSON to simulate a record written before #497.
+        let record = fullyPopulatedRecord()
+        let data = try makeEncoder().encode(record)
+        var json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertNotNil(json["schemaVersion"], "fixture must include schemaVersion before we strip it")
+        json.removeValue(forKey: "schemaVersion")
+        let stripped = try JSONSerialization.data(withJSONObject: json, options: [.sortedKeys])
+
+        let decoded = try JSONDecoder().decode(RunRecord.self, from: stripped)
+
+        XCTAssertEqual(decoded.schemaVersion, 1)
+        // And the rest of the record must round-trip intact — the missing
+        // schemaVersion is the *only* tolerated difference.
+        var expected = record
+        expected.schemaVersion = 1
+        XCTAssertEqual(decoded, expected)
+    }
+
+    // MARK: - Future record (schemaVersion > currentSchema)
+
+    func test_futureSchemaVersion_validatorThrows() throws {
+        // A loader built today should refuse a record written by a future
+        // writer rather than silently misinterpret it.
+        XCTAssertThrowsError(try RunRecord.validate(schemaVersion: 99)) { error in
+            XCTAssertEqual(error as? RunRecord.SchemaError, .unsupportedFutureSchema(99))
+        }
+    }
+
+    func test_currentAndLegacyVersions_validatorAccepts() throws {
+        // Current passes silently; legacy passes with a log warning (not asserted here).
+        XCTAssertNoThrow(try RunRecord.validate(schemaVersion: RunRecord.currentSchema))
+        XCTAssertNoThrow(try RunRecord.validate(schemaVersion: 1))
+    }
+
+    // MARK: - Decoding a future-version payload still succeeds; validation is the gate
+
+    func test_decodingFutureVersionRecord_succeeds_butValidateRejects() throws {
+        // Encode, bump the schemaVersion key in the JSON, then decode.
+        let record = fullyPopulatedRecord()
+        let data = try makeEncoder().encode(record)
+        var json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        json["schemaVersion"] = 99
+        let futureData = try JSONSerialization.data(withJSONObject: json, options: [.sortedKeys])
+
+        let decoded = try JSONDecoder().decode(RunRecord.self, from: futureData)
+        XCTAssertEqual(decoded.schemaVersion, 99)
+
+        XCTAssertThrowsError(try RunRecord.validate(schemaVersion: decoded.schemaVersion)) { error in
+            XCTAssertEqual(error as? RunRecord.SchemaError, .unsupportedFutureSchema(99))
+        }
+    }
+}


### PR DESCRIPTION
## What does this change?

Versions `RunRecord` with `schemaVersion: Int = 1`, ships a migration shim so legacy records decode cleanly, adds a round-trip test, and documents the schema with a DocC page.

## Motivation

`record.json` is the de-facto API contract for #490 `--replay`, #491 `--shrink`, and any future external tool. Shipping replay against unversioned records bakes the lack-of-version into history. Adding the field now, with a `decodeIfPresent ?? 1` shim, is backward-compatible and cheap. Closes #497.

## Release Note

**Versioned fuzzer record format** — `RunRecord` now ships with a `schemaVersion` field and a documented schema (see DocC: *Run Record Schema*). Existing on-disk records decode unchanged via a migration shim. Future versions will migrate through the validator entry point.

## Testing

- New `RunRecordRoundTripTests` covers encode→decode equality, legacy-JSON-without-version decoding to v1, future-version rejection, and current/legacy validator acceptance (5 tests).
- All four CI suites pass locally (`BaseChatCoreTests`, `BaseChatInferenceTests`, `BaseChatUITests`, `BaseChatBackendsTests`), plus the full `BaseChatFuzzTests` suite (44 tests).

## Sabotage evidence (regression-test PRs only)

- [x] Reverted the round-trip equality assertion; confirmed `test_encodeDecode_preservesEveryField` went RED
- [x] Re-applied the assertion; confirmed GREEN

Sabotage diff:

```diff
-        XCTAssertEqual(record, decoded)
+        XCTAssertNotEqual(record, decoded) // SABOTAGE
```

Red log (abbreviated):

```
Test Case '-[BaseChatFuzzTests.RunRecordRoundTripTests test_encodeDecode_preservesEveryField]' started.
…/RunRecordRoundTripTests.swift:77: error: -[…test_encodeDecode_preservesEveryField] :
XCTAssertNotEqual failed: (… schemaVersion: 1, runId: "94a7b2e0-…" …) is equal to
(… schemaVersion: 1, runId: "94a7b2e0-…" …)
Test Case '-[…test_encodeDecode_preservesEveryField]' failed (0.190 seconds).
Test Suite 'RunRecordRoundTripTests' failed at 2026-04-19 12:47:25.
	 Executed 1 test, with 1 failure (0 unexpected) in 0.190 (0.190) seconds
```

After re-applying the assertion:

```
Test Case '-[…test_encodeDecode_preservesEveryField]' passed (0.000 seconds).
Test Suite 'RunRecordRoundTripTests' passed at 2026-04-19 12:47:35.
	 Executed 5 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
```

## Notes

- Adding an explicit `init(from:)` removes Swift's synthesised memberwise init, so a matching public initializer is provided with `schemaVersion` first (default `currentSchema`). Existing call sites in `FuzzRunner`, `DetectorTests`, and `FindingsSinkTests` already use labeled arguments and compile unchanged.
- `RunRecord` and all nested snapshot types now conform to `Equatable` (auto-synthesised — every field is `Equatable`-compatible).
- Did not wire the validator into a read path; that's #490's surface. No changes to `FuzzRunner.swift` init or the backend-provider closure, per guardrail.