### PR TITLE
fix(ollama): preserve reasoning model thinking content

### DIFF
--- a/Sources/BaseChatBackends/OllamaBackend.swift
+++ b/Sources/BaseChatBackends/OllamaBackend.swift
@@ -134,8 +134,20 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
     /// Applies the same ``SSEStreamLimits`` caps as the SSE parser so a
     /// hostile Ollama-compatible server cannot exhaust memory with oversized
     /// lines, total volume, or an event flood.
+    ///
+    /// Reasoning models (qwen3, qwen3.5:4b, deepseek-r1) surface chain-of-thought
+    /// tokens in a separate `thinking` field — `message.thinking` on the
+    /// `/api/chat` endpoint and top-level `thinking` on `/api/generate`. We
+    /// emit ``GenerationEvent/thinkingToken(_:)`` while a line carries
+    /// non-empty thinking, and ``GenerationEvent/thinkingComplete`` exactly
+    /// once — either on the transition from "thinking was non-empty" to
+    /// "thinking is now empty", or on `"done":true` when a thinking
+    /// accumulator is still open. ``GenerationConfig/maxThinkingTokens``
+    /// caps reasoning emission; once exceeded subsequent thinking content is
+    /// dropped and only visible ``GenerationEvent/token(_:)`` events continue.
     public override func parseResponseStream(
         bytes: URLSession.AsyncBytes,
+        config: GenerationConfig,
         continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
     ) async throws {
         let limits = effectiveSSEStreamLimits
@@ -143,6 +155,12 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
         var totalBytes = 0
         var rateWindowStart = ContinuousClock.now
         var rateWindowCount = 0
+
+        // Tracks whether we've emitted any thinking content on this stream,
+        // so we know when to fire the single .thinkingComplete event.
+        var thinkingOpen = false
+        var thinkingTokenCount = 0
+        let thinkingLimit = config.maxThinkingTokens
 
         func noteEventYielded() throws {
             let now = ContinuousClock.now
@@ -157,6 +175,51 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
             }
         }
 
+        func handleLine(_ line: String) throws {
+            guard let parsed = Self.parseLine(line) else { return }
+
+            // Route thinking field (if any) first so downstream consumers see
+            // reasoning before visible content for a given NDJSON record.
+            if let thinking = parsed.thinking, !thinking.isEmpty {
+                if let limit = thinkingLimit, thinkingTokenCount >= limit {
+                    // Cap reached — drop this thinking chunk silently.
+                } else {
+                    try noteEventYielded()
+                    continuation.yield(.thinkingToken(thinking))
+                    thinkingOpen = true
+                    // Count each thinking-bearing NDJSON line as one "token"
+                    // for cap purposes. Ollama ships whole-blob thinking per
+                    // line rather than per-token, so this matches the
+                    // coarser grain of the wire format.
+                    thinkingTokenCount += 1
+                }
+            } else if thinkingOpen {
+                // Transition from thinking → content. Fire .thinkingComplete
+                // exactly once on the first empty-thinking line we see after
+                // any non-empty thinking was emitted.
+                try noteEventYielded()
+                continuation.yield(.thinkingComplete)
+                thinkingOpen = false
+            }
+
+            if let content = parsed.content, !content.isEmpty {
+                try noteEventYielded()
+                continuation.yield(.token(content))
+            }
+
+            if parsed.done {
+                // Ollama can terminate with `"done":true` while thinking is
+                // still the only content emitted (e.g. reasoning model hits
+                // num_predict mid-think). Flush .thinkingComplete so
+                // downstream consumers don't leave the thinking block open.
+                if thinkingOpen {
+                    try noteEventYielded()
+                    continuation.yield(.thinkingComplete)
+                    thinkingOpen = false
+                }
+            }
+        }
+
         for try await byte in bytes {
             if Task.isCancelled { break }
 
@@ -167,10 +230,8 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
 
             if byte == UInt8(ascii: "\n") {
                 if !lineBuffer.isEmpty {
-                    if let line = String(data: lineBuffer, encoding: .utf8),
-                       let token = Self.extractToken(from: line) {
-                        try noteEventYielded()
-                        continuation.yield(.token(token))
+                    if let line = String(data: lineBuffer, encoding: .utf8) {
+                        try handleLine(line)
                     }
                     lineBuffer.removeAll(keepingCapacity: true)
                 }
@@ -184,10 +245,16 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
 
         // Flush any final line without a trailing newline.
         if !lineBuffer.isEmpty,
-           let line = String(data: lineBuffer, encoding: .utf8),
-           let token = Self.extractToken(from: line) {
+           let line = String(data: lineBuffer, encoding: .utf8) {
+            try handleLine(line)
+        }
+
+        // Safety net: if the stream ends while thinking is still "open"
+        // (no done-chunk, no empty-thinking transition), still close it out
+        // so consumers don't hang in a thinking-only state.
+        if thinkingOpen {
             try noteEventYielded()
-            continuation.yield(.token(token))
+            continuation.yield(.thinkingComplete)
         }
     }
 
@@ -226,29 +293,90 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
 
     // MARK: - NDJSON Parsing
 
-    /// Extracts the assistant content token from an Ollama `/api/chat` NDJSON line.
+    /// Decoded shape of a single Ollama NDJSON record.
+    ///
+    /// Ollama's two endpoints carry data in different places:
+    /// - `/api/chat` streams put content in `message.content` and reasoning in
+    ///   `message.thinking`.
+    /// - `/api/generate` (non-chat) uses top-level `response` and top-level
+    ///   `thinking`.
+    /// `parseLine` normalises both shapes; consumers read `content` and
+    /// `thinking` without caring which endpoint produced the line.
+    struct ParsedLine {
+        var content: String?
+        var thinking: String?
+        var done: Bool
+    }
+
+    /// Parses a single Ollama NDJSON line into a normalised shape.
+    ///
+    /// Returns `nil` for malformed lines so the stream parser can skip them
+    /// the same way it historically skipped unparseable JSON.
+    static func parseLine(_ json: String) -> ParsedLine? {
+        guard let data = json.data(using: .utf8),
+              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+
+        let done = (parsed["done"] as? Bool) ?? false
+
+        var content: String?
+        var thinking: String?
+
+        if let message = parsed["message"] as? [String: Any] {
+            // `/api/chat` shape.
+            content = message["content"] as? String
+            thinking = message["thinking"] as? String
+        }
+
+        // `/api/generate` shape — top-level `response` and `thinking`. If both
+        // `message.content` and top-level `response` are present (shouldn't
+        // happen in practice), chat-shape wins because it arrived first.
+        if content == nil, let response = parsed["response"] as? String {
+            content = response
+        }
+        if thinking == nil, let topThinking = parsed["thinking"] as? String {
+            thinking = topThinking
+        }
+
+        return ParsedLine(content: content, thinking: thinking, done: done)
+    }
+
+    /// Extracts the assistant content token from an Ollama NDJSON line.
     ///
     /// Ollama streaming format (one JSON object per line, no `data:` prefix):
     /// ```json
     /// {"model":"llama3","message":{"role":"assistant","content":"Hello"},"done":false}
     /// ```
     /// Final chunk has `"done":true` and empty or absent content — we skip it.
+    ///
+    /// This method only surfaces visible content; reasoning-model `thinking`
+    /// fields are handled inline by ``parseResponseStream(bytes:config:continuation:)``
+    /// so they can be emitted as ``GenerationEvent/thinkingToken(_:)`` with
+    /// proper ``GenerationEvent/thinkingComplete`` bracketing. Kept for the
+    /// ``SSEPayloadHandler`` protocol conformance and external callers.
     static func extractToken(from json: String) -> String? {
-        guard let data = json.data(using: .utf8),
-              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return nil
-        }
-
+        guard let parsed = parseLine(json) else { return nil }
         // Skip the final "done" chunk.
-        if let done = parsed["done"] as? Bool, done { return nil }
+        if parsed.done { return nil }
+        guard let content = parsed.content, !content.isEmpty else { return nil }
+        return content
+    }
 
-        guard let message = parsed["message"] as? [String: Any],
-              let content = message["content"] as? String,
-              !content.isEmpty else {
+    /// Extracts reasoning content from an Ollama NDJSON line, if any.
+    ///
+    /// Returns `nil` when the line carries no `thinking` field or an empty
+    /// one. Exposed for symmetry with ``extractToken(from:)``; streaming
+    /// callers use the inline logic in
+    /// ``parseResponseStream(bytes:config:continuation:)`` to bracket
+    /// thinking emissions with ``GenerationEvent/thinkingComplete``.
+    static func extractThinking(from json: String) -> String? {
+        guard let parsed = parseLine(json),
+              let thinking = parsed.thinking,
+              !thinking.isEmpty else {
             return nil
         }
-
-        return content
+        return thinking
     }
 
     /// Extracts an error message from an Ollama error response body.

--- a/Sources/BaseChatBackends/SSECloudBackend.swift
+++ b/Sources/BaseChatBackends/SSECloudBackend.swift
@@ -361,7 +361,7 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
                     guard let self else {
                         throw CloudBackendError.backendDeallocated
                     }
-                    try await self.parseResponseStream(bytes: bytes, continuation: continuation)
+                    try await self.parseResponseStream(bytes: bytes, config: config, continuation: continuation)
 
                     await MainActor.run { streamBox.value?.setPhase(.done) }
                     continuation.finish()
@@ -391,6 +391,22 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
     // MARK: - Stream Parsing
 
     /// Parses the HTTP response byte stream into generation events.
+    ///
+    /// The default implementation forwards to the config-less overload so
+    /// existing subclasses (OpenAI, Claude) keep working unchanged. Subclasses
+    /// that need the active ``GenerationConfig`` during parsing (e.g. Ollama
+    /// needs ``GenerationConfig/maxThinkingTokens`` to cap reasoning output)
+    /// override this method directly.
+    open func parseResponseStream(
+        bytes: URLSession.AsyncBytes,
+        config: GenerationConfig,
+        continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
+    ) async throws {
+        try await parseResponseStream(bytes: bytes, continuation: continuation)
+    }
+
+    /// Legacy overload retained for backward compatibility with subclasses
+    /// that don't need access to the active ``GenerationConfig``.
     ///
     /// The default implementation uses SSE format via ``SSEStreamParser``.
     /// Subclasses override for NDJSON (Ollama) or other wire formats.

--- a/Tests/BaseChatBackendsTests/OllamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/OllamaBackendTests.swift
@@ -343,6 +343,191 @@ struct OllamaBackendTests {
     @Test func extractToken_malformedJSON_returnsNil() {
         #expect(OllamaBackend.extractToken(from: "not json") == nil)
     }
+
+    // MARK: - Thinking field (issue #487)
+
+    /// Reasoning models (qwen3, qwen3.5:4b, deepseek-r1) emit chain-of-thought in
+    /// a separate `thinking` field on the `/api/chat` endpoint. The backend
+    /// must surface these as `.thinkingToken` events and close with
+    /// `.thinkingComplete` when thinking transitions back to empty.
+    @Test func streaming_chatEndpoint_thinkingFieldEmitsThinkingEvents() async throws {
+        let (backend, chatURL) = makeConfiguredBackend()
+        try await loadBackend(backend)
+
+        let chunks: [Data] = [
+            ndjsonLine(#"{"message":{"role":"assistant","thinking":"Reasoning step 1","content":""},"done":false}"#),
+            ndjsonLine(#"{"message":{"role":"assistant","thinking":"","content":"answer"},"done":true}"#),
+        ]
+        MockURLProtocol.stub(url: chatURL, response: .sse(chunks: chunks, statusCode: 200))
+        defer { MockURLProtocol.unstub(url: chatURL) }
+
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: .init())
+        var events: [GenerationEvent] = []
+        for try await event in stream.events { events.append(event) }
+
+        // Ordering: .thinkingToken → .thinkingComplete → .token
+        let thinkingTokens = events.compactMap { event -> String? in
+            if case .thinkingToken(let t) = event { return t } else { return nil }
+        }
+        let tokens = events.compactMap { event -> String? in
+            if case .token(let t) = event { return t } else { return nil }
+        }
+        let completeCount = events.filter {
+            if case .thinkingComplete = $0 { return true } else { return false }
+        }.count
+
+        #expect(thinkingTokens == ["Reasoning step 1"])
+        #expect(tokens == ["answer"])
+        #expect(completeCount == 1)
+
+        // Verify event ordering: thinkingToken precedes thinkingComplete precedes token.
+        var sawThinking = false
+        var sawComplete = false
+        for event in events {
+            switch event {
+            case .thinkingToken:
+                #expect(!sawComplete, "thinkingToken must precede thinkingComplete")
+                sawThinking = true
+            case .thinkingComplete:
+                #expect(sawThinking, "thinkingComplete must follow at least one thinkingToken")
+                sawComplete = true
+            case .token:
+                #expect(sawComplete, "visible token must follow thinkingComplete")
+            default: break
+            }
+        }
+    }
+
+    /// `/api/generate` surfaces reasoning at top-level `thinking` rather than
+    /// under `message.thinking`. The backend must handle both endpoint shapes.
+    @Test func streaming_generateEndpoint_topLevelThinkingEmitsThinkingEvents() async throws {
+        let (backend, chatURL) = makeConfiguredBackend()
+        try await loadBackend(backend)
+
+        let chunks: [Data] = [
+            ndjsonLine(#"{"response":"","thinking":"Thinking...","done":false}"#),
+            ndjsonLine(#"{"response":"answer","thinking":"","done":true}"#),
+        ]
+        MockURLProtocol.stub(url: chatURL, response: .sse(chunks: chunks, statusCode: 200))
+        defer { MockURLProtocol.unstub(url: chatURL) }
+
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: .init())
+        var events: [GenerationEvent] = []
+        for try await event in stream.events { events.append(event) }
+
+        let thinkingTokens = events.compactMap { event -> String? in
+            if case .thinkingToken(let t) = event { return t } else { return nil }
+        }
+        let tokens = events.compactMap { event -> String? in
+            if case .token(let t) = event { return t } else { return nil }
+        }
+        let completeCount = events.filter {
+            if case .thinkingComplete = $0 { return true } else { return false }
+        }.count
+
+        #expect(thinkingTokens == ["Thinking..."])
+        #expect(tokens == ["answer"])
+        #expect(completeCount == 1)
+    }
+
+    /// Actual #487 repro: reasoning model exhausts `num_predict` entirely in
+    /// `<think>` and Ollama returns a single line with `done:true`,
+    /// `done_reason:length`, non-empty `thinking`, and empty `response`.
+    /// Previously dropped on the floor — users saw a blank message.
+    @Test func streaming_thinkingOnly_thenDone_flushesThinkingComplete() async throws {
+        let (backend, chatURL) = makeConfiguredBackend()
+        try await loadBackend(backend)
+
+        let chunks: [Data] = [
+            ndjsonLine(#"{"response":"","thinking":"entire reasoning","done":true,"done_reason":"length"}"#),
+        ]
+        MockURLProtocol.stub(url: chatURL, response: .sse(chunks: chunks, statusCode: 200))
+        defer { MockURLProtocol.unstub(url: chatURL) }
+
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: .init())
+        var events: [GenerationEvent] = []
+        for try await event in stream.events { events.append(event) }
+
+        let thinkingTokens = events.compactMap { event -> String? in
+            if case .thinkingToken(let t) = event { return t } else { return nil }
+        }
+        let completeCount = events.filter {
+            if case .thinkingComplete = $0 { return true } else { return false }
+        }.count
+
+        #expect(thinkingTokens == ["entire reasoning"])
+        #expect(completeCount == 1)
+    }
+
+    /// `config.maxThinkingTokens` caps reasoning emission so a runaway
+    /// reasoning model doesn't flood the UI. Lines with thinking beyond the
+    /// cap are dropped; visible content still flows through.
+    @Test func streaming_maxThinkingTokens_capsEmission() async throws {
+        let (backend, chatURL) = makeConfiguredBackend()
+        try await loadBackend(backend)
+
+        // 5 thinking-bearing lines, then transition to visible answer.
+        let chunks: [Data] = [
+            ndjsonLine(#"{"message":{"role":"assistant","thinking":"t1","content":""},"done":false}"#),
+            ndjsonLine(#"{"message":{"role":"assistant","thinking":"t2","content":""},"done":false}"#),
+            ndjsonLine(#"{"message":{"role":"assistant","thinking":"t3","content":""},"done":false}"#),
+            ndjsonLine(#"{"message":{"role":"assistant","thinking":"t4","content":""},"done":false}"#),
+            ndjsonLine(#"{"message":{"role":"assistant","thinking":"t5","content":""},"done":false}"#),
+            ndjsonLine(#"{"message":{"role":"assistant","thinking":"","content":"answer"},"done":true}"#),
+        ]
+        MockURLProtocol.stub(url: chatURL, response: .sse(chunks: chunks, statusCode: 200))
+        defer { MockURLProtocol.unstub(url: chatURL) }
+
+        var config = GenerationConfig()
+        config.maxThinkingTokens = 2
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: config)
+        var events: [GenerationEvent] = []
+        for try await event in stream.events { events.append(event) }
+
+        let thinkingTokens = events.compactMap { event -> String? in
+            if case .thinkingToken(let t) = event { return t } else { return nil }
+        }
+        let tokens = events.compactMap { event -> String? in
+            if case .token(let t) = event { return t } else { return nil }
+        }
+
+        // Only the first 2 thinking chunks emit; t3, t4, t5 are dropped.
+        #expect(thinkingTokens == ["t1", "t2"])
+        #expect(tokens == ["answer"])
+    }
+
+    // MARK: - NDJSON parseLine
+
+    @Test func parseLine_chatThinking() {
+        let json = #"{"message":{"role":"assistant","thinking":"reasoning","content":"hi"},"done":false}"#
+        let parsed = try? #require(OllamaBackend.parseLine(json))
+        #expect(parsed?.thinking == "reasoning")
+        #expect(parsed?.content == "hi")
+        #expect(parsed?.done == false)
+    }
+
+    @Test func parseLine_generateTopLevelThinking() {
+        let json = #"{"response":"answer","thinking":"reasoning","done":true}"#
+        let parsed = try? #require(OllamaBackend.parseLine(json))
+        #expect(parsed?.thinking == "reasoning")
+        #expect(parsed?.content == "answer")
+        #expect(parsed?.done == true)
+    }
+
+    @Test func extractThinking_returnsThinkingField() {
+        let json = #"{"response":"","thinking":"reasoning","done":false}"#
+        #expect(OllamaBackend.extractThinking(from: json) == "reasoning")
+    }
+
+    @Test func extractThinking_emptyThinking_returnsNil() {
+        let json = #"{"response":"hi","thinking":"","done":false}"#
+        #expect(OllamaBackend.extractThinking(from: json) == nil)
+    }
+
+    @Test func extractThinking_noThinkingField_returnsNil() {
+        let json = #"{"message":{"role":"assistant","content":"hi"},"done":false}"#
+        #expect(OllamaBackend.extractThinking(from: json) == nil)
+    }
 }
 
 // MARK: - OllamaModelListService Tests


### PR DESCRIPTION
## What does this change?

`OllamaBackend` dropped the `thinking` NDJSON field emitted by reasoning
models (qwen3, qwen3.5:4b, deepseek-r1). Users waiting 30–100s for a
reasoning response saw a blank assistant bubble because `extractToken`
only read `message.content`. This PR surfaces reasoning through
`.thinkingToken` and `.thinkingComplete` events in the same shape the
MLX and Llama backends produce, and caps emission with
`config.maxThinkingTokens`.

## Motivation

Closes #487. Discovered by the chat-fuzzer's first smoke run against a
real Ollama server:

```
↑ flaky [empty-output-after-work/silent-empty] hash=fa567e41a546 :: totalMs=99877 raw.empty thinkingRaw.empty error=nil
```

Direct curl confirmed Ollama returns the reasoning in a separate field:

```
$ curl -s http://localhost:11434/api/generate -d '{"model":"qwen3.5:4b","prompt":"hello","stream":false,"options":{"num_predict":50}}'
{"response":"","thinking":"Thinking Process:\n…","done":true,"done_reason":"length",…}
```

## Release Note

**Preserve Ollama reasoning content** — OllamaBackend dropped the `thinking` NDJSON field on reasoning models (qwen3, deepseek-r1), leaving users staring at empty 30–100s responses. The backend now emits `.thinkingToken` and `.thinkingComplete` events in the same shape MLX and Llama produce, respects `config.maxThinkingTokens`, and ships regression fixtures for both the `/api/generate` and `/api/chat` shapes. Discovered by the fuzzer's first smoke run.

## Testing

- `swift test --filter OllamaBackendTests --disable-default-traits` — 36 passing (8 new).
- All four CI suites run locally: `BaseChatCoreTests` (204), `BaseChatInferenceTests` (69), `BaseChatUITests` (450), `BaseChatBackendsTests` (97). All green.
- New fixtures in `Tests/BaseChatBackendsTests/OllamaBackendTests.swift`:
  - `streaming_chatEndpoint_thinkingFieldEmitsThinkingEvents` — `/api/chat` shape.
  - `streaming_generateEndpoint_topLevelThinkingEmitsThinkingEvents` — `/api/generate` shape.
  - `streaming_thinkingOnly_thenDone_flushesThinkingComplete` — the actual #487 repro (done-with-only-thinking-no-response).
  - `streaming_maxThinkingTokens_capsEmission` — cap enforcement.
  - `parseLine_*`, `extractThinking_*` — NDJSON helper unit tests.

The live-daemon `OllamaE2ETests` were not modified (per brief). With this fix applied, the qwen3.5:4b suite that previously emitted empty responses should now surface thinking content; leaving that verification to the maintainer.

## Sabotage evidence (regression-test PRs only)

- [x] Reverted the fix / broke the path under test
- [x] Confirmed the new test went RED (log pasted below)
- [x] Re-applied the fix and confirmed GREEN

**Sabotage diff:**

```diff
--- a/Sources/BaseChatBackends/OllamaBackend.swift
+++ b/Sources/BaseChatBackends/OllamaBackend.swift
@@
         if thinking == nil, let topThinking = parsed["thinking"] as? String {
             thinking = topThinking
         }

+        // SABOTAGE: drop thinking to re-introduce the #487 bug.
+        thinking = nil
+
         return ParsedLine(content: content, thinking: thinking, done: done)
```

**Red run (7 failing tests, 11 issues — all in the newly added coverage):**

```
✘ streaming_chatEndpoint_thinkingFieldEmitsThinkingEvents — (thinkingTokens → []) == ["Reasoning step 1"]
✘ streaming_chatEndpoint_thinkingFieldEmitsThinkingEvents — (completeCount → 0) == 1
✘ streaming_chatEndpoint_thinkingFieldEmitsThinkingEvents — sawComplete expected true
✘ streaming_generateEndpoint_topLevelThinkingEmitsThinkingEvents — (thinkingTokens → []) == ["Thinking..."]
✘ streaming_generateEndpoint_topLevelThinkingEmitsThinkingEvents — (completeCount → 0) == 1
✘ streaming_thinkingOnly_thenDone_flushesThinkingComplete — (thinkingTokens → []) == ["entire reasoning"]
✘ streaming_thinkingOnly_thenDone_flushesThinkingComplete — (completeCount → 0) == 1
✘ streaming_maxThinkingTokens_capsEmission — (thinkingTokens → []) == ["t1", "t2"]
✘ parseLine_chatThinking — (parsed?.thinking → nil) == "reasoning"
✘ parseLine_generateTopLevelThinking — (parsed?.thinking → nil) == "reasoning"
✘ extractThinking_returnsThinkingField — (OllamaBackend.extractThinking(from: json) → nil) == "reasoning"
✘ Test run with 36 tests in 2 suites failed after 8.251 seconds with 11 issues.
```

After reverting the sabotage, all 36 tests pass in 8.485s.

## Checklist

- [x] Tests added or updated for new behaviour
- [x] Public API changes have `///` doc comments
- [x] No hardcoded secrets, API keys, or personal data
- [ ] Breaking change? No. `SSECloudBackend.parseResponseStream(bytes:continuation:)` is retained as an `open` method; the new `parseResponseStream(bytes:config:continuation:)` defaults to calling the old one, so OpenAI and Claude subclasses require no changes.

## Implementation notes

- **Event-emission strategy:** Rather than wrap Ollama's whole-blob `thinking` field in synthetic `<think>`/`</think>` tags and route through `ThinkingParser`, `parseResponseStream` emits `.thinkingToken` / `.thinkingComplete` directly. `ThinkingParser` is designed for streaming-across-chunks tag detection (MLX/Llama decode one token at a time); Ollama NDJSON gives us a complete thinking blob per line, so the parser's tag-straddling state machine would be misapplied. The downstream event sequence matches MLX/Llama exactly.
- **Transport plumbing:** `SSECloudBackend.parseResponseStream` gained a `config:` parameter to thread `GenerationConfig` into parsing. A zero-argument-shape overload is preserved so unchanged subclasses (OpenAI, Claude) still work without modification. Ollama is the only subclass that overrides parsing today.
- **One unusual observation:** Ollama's `/api/generate` terminator sometimes emits a single NDJSON line with `done:true`, non-empty `thinking`, and empty `response`. The "thinkingOnly + done" fixture covers that case: we flush `.thinkingComplete` on `done:true` when thinking is still open so consumers don't hang in a thinking-only state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)