### PR TITLE
refactor(fuzz)!: replace BackendProvider closure with FuzzBackendFactory protocol

### DIFF
--- a/FUZZING.md
+++ b/FUZZING.md
@@ -61,7 +61,7 @@ Common flags:
 | MLX    | Throws | `~/Documents/Models/<dir>/{config.json,*.safetensors,tokenizer.*}` | Requires the xcodebuild path because MLX Metal shaders only compile under Xcode — see `--with-mlx` below. |
 | Foundation Models | Throws | `sw_vers -productVersion >= 26` | macOS 26+ only. |
 
-Backend wiring lives behind a closure rather than a protocol today. `FuzzRunner.BackendProvider` is `() async throws -> FuzzRunner.BackendHandle`, where `BackendHandle` carries `(backend: any InferenceBackend, modelId: String, modelURL: URL, backendName: String, templateMarkers: RunRecord.MarkerSnapshot)`. To plug a new backend in, build a closure that constructs and configures the backend, returns the handle, and pass it to `FuzzRunner(config:backendProvider:)` — see `FuzzChatCLI.makeOllamaHandle` for the canonical example. Detectors operate on the resulting `RunRecord` and don't care which backend produced it. Issue [#496](https://github.com/roryford/BaseChatKit/issues/496) tracks promoting the closure into a proper `BackendDriver` protocol once a second backend is wired.
+Backend wiring lives behind the `FuzzBackendFactory` protocol. A factory exposes `makeHandle() async throws -> FuzzRunner.BackendHandle`, where `BackendHandle` carries `(backend: any InferenceBackend, modelId: String, modelURL: URL, backendName: String, templateMarkers: RunRecord.MarkerSnapshot)`. To plug a new backend in, conform a `Sendable` struct to `FuzzBackendFactory` and pass it to `FuzzRunner(config:factory:)` — see `OllamaFuzzFactory` in `Sources/fuzz-chat/` for the canonical example. Detectors operate on the resulting `RunRecord` and don't care which backend produced it. Llama, Foundation, and MLX factory conformances are tracked in [#501](https://github.com/roryford/BaseChatKit/issues/501).
 
 ### MLX via xcodebuild
 
@@ -216,7 +216,7 @@ These are wired but not yet implemented. Day-one issues will be filed for each.
 - **`--shrink`** — minimise a failing prompt to the smallest input that still fires the detector.
 - **Multi-turn** — current harness fuzzes single-turn only; multi-turn would surface KV-collision and session-isolation bugs the single-turn path can't see.
 - **Slash command** — `/fuzz` shortcut to run `scripts/fuzz.sh` from inside Claude Code.
-- **`BackendDriver` protocol** — promote `FuzzRunner.BackendProvider` from a closure to a protocol once a second backend is wired ([#496](https://github.com/roryford/BaseChatKit/issues/496)).
+- **Multi-backend factory fleet** — `FuzzRunner` now accepts a `FuzzBackendFactory` protocol (landed via [#496](https://github.com/roryford/BaseChatKit/issues/496)). Ship `LlamaFuzzFactory`, `FoundationFuzzFactory`, and `MLXFuzzFactory` to feed `--backend all` ([#501](https://github.com/roryford/BaseChatKit/issues/501)).
 
 The fuzzer does not run in CI by design — it's a pre-release activity, not a gate.
 

--- a/Sources/BaseChatFuzz/FuzzBackendFactory.swift
+++ b/Sources/BaseChatFuzz/FuzzBackendFactory.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Produces `FuzzRunner.BackendHandle` values for the fuzz runner.
+///
+/// Factories are plain `Sendable` structs, which keeps them trivially unit-testable
+/// and lets multi-backend drivers (`#501 --model all`) iterate an array of them.
+/// The runner calls `makeHandle()` when it needs a backend — today once at the
+/// start of `run`, but future rotation/multi-turn modes may call it repeatedly.
+public protocol FuzzBackendFactory: Sendable {
+    /// Construct a fresh `BackendHandle`. Called once per fuzz iteration when
+    /// the runner needs a backend (e.g., rotation in #501, or first use today).
+    func makeHandle() async throws -> FuzzRunner.BackendHandle
+}

--- a/Sources/BaseChatFuzz/FuzzRunner.swift
+++ b/Sources/BaseChatFuzz/FuzzRunner.swift
@@ -3,11 +3,10 @@ import BaseChatInference
 
 /// Drives a fuzzing campaign: samples (corpus entry, config), drives `runSingle`
 /// for each iteration, runs detectors over the resulting `RunRecord`, and writes
-/// findings via `FindingsSink`. Backend instantiation is delegated to a closure
-/// so the engine stays free of MLX/Llama/Ollama dependencies.
+/// findings via `FindingsSink`. Backend instantiation is delegated to a
+/// `FuzzBackendFactory` so the engine stays free of MLX/Llama/Ollama
+/// dependencies.
 public actor FuzzRunner {
-
-    public typealias BackendProvider = @Sendable () async throws -> BackendHandle
 
     public struct BackendHandle: Sendable {
         public let backend: any InferenceBackend
@@ -32,7 +31,7 @@ public actor FuzzRunner {
     }
 
     private let config: FuzzConfig
-    private let provider: BackendProvider
+    private let factory: any FuzzBackendFactory
     private let sink: FindingsSink
     private let corpus: [CorpusEntry]
     private var rng: SeededRNG
@@ -41,9 +40,9 @@ public actor FuzzRunner {
     /// reshelling git+swift on every record (was 3 subprocess spawns each).
     private let harnessBaseline: RunRecord.HarnessSnapshot
 
-    public init(config: FuzzConfig, backendProvider: @escaping BackendProvider) {
+    public init(config: FuzzConfig, factory: any FuzzBackendFactory) {
         self.config = config
-        self.provider = backendProvider
+        self.factory = factory
         self.sink = FindingsSink(outputDir: config.outputDir)
         self.corpus = Corpus.load()
         self.rng = SeededRNG(seed: config.seed)
@@ -65,9 +64,9 @@ public actor FuzzRunner {
 
         let handle: BackendHandle
         do {
-            handle = try await provider()
+            handle = try await factory.makeHandle()
         } catch {
-            await reporter.error("Backend provider failed: \(error)")
+            await reporter.error("Backend factory failed: \(error)")
             return FuzzReport(totalRuns: 0, findings: [], dedupedCount: 0, perDetectorFlagRate: [:])
         }
 

--- a/Sources/fuzz-chat/FuzzChatCLI.swift
+++ b/Sources/fuzz-chat/FuzzChatCLI.swift
@@ -84,50 +84,17 @@ struct FuzzChatCLI {
             quiet: quiet
         )
 
-        let resolvedBackend = backend
-        let resolvedHint = modelHint
-        let provider: FuzzRunner.BackendProvider = { @Sendable in
-            try await Self.makeBackend(choice: resolvedBackend, modelHint: resolvedHint)
+        let factory: any FuzzBackendFactory
+        switch backend {
+        case .ollama:
+            factory = OllamaFuzzFactory(modelHint: modelHint)
+        case .llama, .foundation, .mlx, .all:
+            fail("\(backend.rawValue) backend not yet wired in v1 (Ollama only).")
         }
 
-        let runner = FuzzRunner(config: config, backendProvider: provider)
+        let runner = FuzzRunner(config: config, factory: factory)
         let reporter = TerminalReporter(quiet: quiet)
         _ = await runner.run(reporter: reporter)
-    }
-
-    static func makeBackend(choice: BackendChoice, modelHint: String?) async throws -> FuzzRunner.BackendHandle {
-        switch choice {
-        case .ollama:
-            return try await makeOllamaHandle(modelHint: modelHint)
-        case .llama, .foundation, .mlx, .all:
-            throw CLIError("\(choice.rawValue) backend not yet wired in v1 (Ollama only).")
-        }
-    }
-
-    @MainActor
-    static func makeOllamaHandle(modelHint: String?) async throws -> FuzzRunner.BackendHandle {
-        guard let models = HardwareRequirements.listOllamaModels() else {
-            throw CLIError("No Ollama server reachable at localhost:11434. Start with: ollama serve")
-        }
-        let hintedModel: String? = modelHint.flatMap { hint in
-            HardwareRequirements.findOllamaModel(nameContains: hint)
-        }
-        guard let model = hintedModel ?? models.first else {
-            throw CLIError("No Ollama model installed. Pull one with: ollama pull qwen3.5:4b")
-        }
-        let backend = OllamaBackend()
-        backend.configure(baseURL: URL(string: "http://localhost:11434")!, modelName: model)
-        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
-        // Ollama presents the model's emitted thinking via its native streaming;
-        // the canonical qwen3 markers are the right baseline for the detector.
-        let markers = RunRecord.MarkerSnapshot(open: "<think>", close: "</think>")
-        return FuzzRunner.BackendHandle(
-            backend: backend,
-            modelId: model,
-            modelURL: URL(string: "ollama:" + model)!,
-            backendName: "ollama",
-            templateMarkers: markers
-        )
     }
 
     static func printUsage() {

--- a/Sources/fuzz-chat/OllamaFuzzFactory.swift
+++ b/Sources/fuzz-chat/OllamaFuzzFactory.swift
@@ -1,0 +1,49 @@
+import Foundation
+import BaseChatFuzz
+import BaseChatBackends
+import BaseChatInference
+import BaseChatTestSupport
+
+/// `FuzzBackendFactory` conformance that instantiates a fresh `OllamaBackend`
+/// configured against a local Ollama server. Picks the first installed model
+/// whose name contains `modelHint`, or the first available model if no hint
+/// is given.
+///
+/// Lives in `Sources/fuzz-chat/` rather than `BaseChatFuzz` so the engine
+/// target stays free of `BaseChatBackends` (MLX/Llama) and `BaseChatTestSupport`
+/// dependencies. Lifts cleanly to a shared location once more factories land.
+public struct OllamaFuzzFactory: FuzzBackendFactory {
+    public let modelHint: String?
+    public let baseURL: URL
+
+    public init(modelHint: String?, baseURL: URL = URL(string: "http://localhost:11434")!) {
+        self.modelHint = modelHint
+        self.baseURL = baseURL
+    }
+
+    @MainActor
+    public func makeHandle() async throws -> FuzzRunner.BackendHandle {
+        guard let models = HardwareRequirements.listOllamaModels() else {
+            throw CLIError("No Ollama server reachable at \(baseURL.absoluteString). Start with: ollama serve")
+        }
+        let hintedModel: String? = modelHint.flatMap { hint in
+            HardwareRequirements.findOllamaModel(nameContains: hint)
+        }
+        guard let model = hintedModel ?? models.first else {
+            throw CLIError("No Ollama model installed. Pull one with: ollama pull qwen3.5:4b")
+        }
+        let backend = OllamaBackend()
+        backend.configure(baseURL: baseURL, modelName: model)
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+        // Ollama presents the model's emitted thinking via its native streaming;
+        // the canonical qwen3 markers are the right baseline for the detector.
+        let markers = RunRecord.MarkerSnapshot(open: "<think>", close: "</think>")
+        return FuzzRunner.BackendHandle(
+            backend: backend,
+            modelId: model,
+            modelURL: URL(string: "ollama:" + model)!,
+            backendName: "ollama",
+            templateMarkers: markers
+        )
+    }
+}

--- a/Tests/BaseChatFuzzTests/FuzzBackendFactoryTests.swift
+++ b/Tests/BaseChatFuzzTests/FuzzBackendFactoryTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+import BaseChatInference
+import BaseChatTestSupport
+@testable import BaseChatFuzz
+
+/// Verifies `FuzzRunner(config:factory:)` wires a `FuzzBackendFactory`
+/// conformance through to the first iteration and surfaces factory errors.
+final class FuzzBackendFactoryTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Minimal `FuzzBackendFactory` that returns a pre-built handle. Mirrors the
+    /// example in the issue brief — used by the happy-path test.
+    struct StubFactory: FuzzBackendFactory {
+        let handle: FuzzRunner.BackendHandle
+        func makeHandle() async throws -> FuzzRunner.BackendHandle { handle }
+    }
+
+    /// Throws instead of producing a handle — exercises the runner's error path.
+    struct FailingFactory: FuzzBackendFactory {
+        struct BoomError: Error, Equatable {}
+        func makeHandle() async throws -> FuzzRunner.BackendHandle {
+            throw BoomError()
+        }
+    }
+
+    private func makeConfig(outputDir: URL) -> FuzzConfig {
+        FuzzConfig(
+            backend: .ollama,
+            minutes: nil,
+            iterations: 1,
+            seed: 42,
+            modelHint: nil,
+            detectorFilter: nil,
+            outputDir: outputDir,
+            calibrate: false,
+            quiet: true
+        )
+    }
+
+    private func makeHandle() -> FuzzRunner.BackendHandle {
+        FuzzRunner.BackendHandle(
+            backend: MockInferenceBackend(),
+            modelId: "stub-model",
+            modelURL: URL(string: "stub:stub-model")!,
+            backendName: "stub",
+            templateMarkers: RunRecord.MarkerSnapshot(open: "<think>", close: "</think>")
+        )
+    }
+
+    private func makeTempOutputDir() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fuzz-factory-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    // MARK: - Tests
+
+    /// Happy path: the runner pulls a handle from the factory and runs at
+    /// least one iteration.
+    func test_factoryProducesHandle_runnerCompletesOneIteration() async {
+        let outputDir = makeTempOutputDir()
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+
+        let factory = StubFactory(handle: makeHandle())
+        let runner = FuzzRunner(config: makeConfig(outputDir: outputDir), factory: factory)
+        let reporter = TerminalReporter(quiet: true)
+
+        let report = await runner.run(reporter: reporter)
+
+        // One iteration ran => the factory was invoked and the handle wired through.
+        XCTAssertEqual(report.totalRuns, 1, "runner should execute the configured iteration after obtaining a handle from the factory")
+    }
+
+    /// Failure path: the runner surfaces a factory error as a zero-run report
+    /// rather than crashing. Mirrors the previous closure-based behaviour.
+    func test_factoryThrows_runnerReportsZeroRuns() async {
+        let outputDir = makeTempOutputDir()
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+
+        let runner = FuzzRunner(config: makeConfig(outputDir: outputDir), factory: FailingFactory())
+        let reporter = TerminalReporter(quiet: true)
+
+        let report = await runner.run(reporter: reporter)
+
+        XCTAssertEqual(report.totalRuns, 0, "runner must surface a factory error as a zero-run report")
+        XCTAssertTrue(report.findings.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

Promotes `FuzzRunner.BackendProvider` from a `@Sendable` closure to a `FuzzBackendFactory` protocol so:

- Future backend conformances (Llama, Foundation, MLX, cloud) are plain `Sendable` structs, trivially unit-testable.
- `#501 --backend all` can iterate an array of factories.
- `#492 multi-turn` can add a factory variant that hands back a service without rewriting the runner.
- The `@Sendable` closure dance on every instantiation goes away.

The existing Ollama path ships as `OllamaFuzzFactory`. It lives in `Sources/fuzz-chat/` rather than `Sources/BaseChatFuzz/` because the `BaseChatFuzz` library target deliberately depends only on `BaseChatInference` — it must not pull in `BaseChatBackends` (`OllamaBackend`) or `BaseChatTestSupport` (`HardwareRequirements`). Llama/Foundation/MLX factory conformances are out of scope and tracked under #501.

## Release Note

**Typed fuzz backend factories** — `FuzzRunner` now takes a `FuzzBackendFactory` protocol instead of a `BackendProvider` closure. The Ollama path ships as `OllamaFuzzFactory`; Llama/Foundation/MLX conformances will follow in #501. **BREAKING:** external callers of `FuzzRunner(config:backendProvider:)` must migrate to `FuzzRunner(config:factory:)` and wrap their closure in a struct conforming to `FuzzBackendFactory`. The `fuzz-chat` executable is updated in the same PR.

## Test plan

- [x] `swift test --filter BaseChatFuzzTests --disable-default-traits` — 46/46 pass, including the new `FuzzBackendFactoryTests` suite.
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 204 pass, 4 skipped.
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 69/69 pass.
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 450/450 pass.
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 88/88 pass.
- [x] `swift build --target fuzz-chat` — clean build.
- [x] Sabotage verified: swapped the happy-path stub to `throw` and confirmed `test_factoryProducesHandle_runnerCompletesOneIteration` fails with "0 is not equal to 1". Reverted.

Closes #496.

🤖 Generated with [Claude Code](https://claude.com/claude-code)