### PR TITLE
feat(fuzz): add DetectorContract pattern and backfill existing detectors

### DIFF
--- a/Sources/BaseChatFuzz/Detectors/DetectorContract.swift
+++ b/Sources/BaseChatFuzz/Detectors/DetectorContract.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Per-detector regression contract. Four fixture cases — positive, negative,
+/// boundary, adversarial — keep detector logic honest: contract tests are
+/// independent of the calibration corpus, so a corpus regression can't
+/// silently mask a broken detector.
+///
+/// The adversarial case is what prevents a detector overfitting to its own
+/// fixture shape — it represents input that superficially resembles the bug
+/// class but should not fire (e.g., Markdown code fence tokens that look like
+/// chat-template fragments to a naive regex).
+public protocol DetectorContract {
+    /// The detector under test.
+    static var detector: any Detector { get }
+    /// A record the detector MUST flag.
+    static var positiveFixture: RunRecord { get }
+    /// A record the detector MUST NOT flag.
+    static var negativeFixture: RunRecord { get }
+    /// A record on the detector's threshold — must be deterministic
+    /// (10 consecutive inspections yield identical findings).
+    static var boundaryFixture: RunRecord { get }
+    /// A record that superficially resembles the bug class but should not
+    /// fire (e.g., Markdown code fence tokens that look like chat-template
+    /// fragments to a naive regex).
+    static var adversarialFixture: RunRecord { get }
+}

--- a/Sources/BaseChatFuzz/Detectors/EmptyOutputAfterWorkDetector.swift
+++ b/Sources/BaseChatFuzz/Detectors/EmptyOutputAfterWorkDetector.swift
@@ -10,7 +10,7 @@ import Foundation
 public struct EmptyOutputAfterWorkDetector: Detector {
     public let id = "empty-output-after-work"
     public let humanName = "Empty output after non-trivial work"
-    public let inspiredBy = "OllamaBackend.extractToken drops `thinking` field (qwen3.5:4b smoke)"
+    public let inspiredBy = "#487 — Ollama thinking-drop smoke finding"
 
     /// Time threshold above which a clean-but-empty completion is suspicious.
     /// Default raised to 8s to clear cold-start model loads (`ollama serve` first hit).

--- a/Sources/BaseChatFuzz/Detectors/LoopingDetector.swift
+++ b/Sources/BaseChatFuzz/Detectors/LoopingDetector.swift
@@ -8,7 +8,7 @@ import BaseChatInference
 public struct LoopingDetector: Detector {
     public let id = "looping"
     public let humanName = "Repetition / loop"
-    public let inspiredBy = "qwen3.5:4b loop-in-think (user_local_backend_env)"
+    public let inspiredBy = "PR #476 thinking-token work + longstanding looping-on-repetitive-prompts observation"
 
     public init() {}
 

--- a/Sources/BaseChatFuzz/Detectors/ThinkingClassificationDetector.swift
+++ b/Sources/BaseChatFuzz/Detectors/ThinkingClassificationDetector.swift
@@ -6,7 +6,7 @@ import Foundation
 public struct ThinkingClassificationDetector: Detector {
     public let id = "thinking-classification"
     public let humanName = "Thinking classification"
-    public let inspiredBy = "df94418, PR #476"
+    public let inspiredBy = "PR #476 thinking-token work"
 
     public init() {}
 

--- a/Tests/BaseChatFuzzTests/DetectorContractTests.swift
+++ b/Tests/BaseChatFuzzTests/DetectorContractTests.swift
@@ -1,0 +1,373 @@
+import XCTest
+@testable import BaseChatFuzz
+import BaseChatInference
+
+// MARK: - Shared fixture helper
+
+/// Builds a `RunRecord` with sensible defaults for contract fixtures. Kept
+/// private to the contract tests — `DetectorTests` has its own copy tuned for
+/// sub-check-by-sub-check unit assertions. Contract fixtures exercise the
+/// detector as a whole, so we keep fixture construction visually adjacent to
+/// each contract type.
+private enum ContractRecord {
+    static func make(
+        rendered: String = "",
+        raw: String = "",
+        thinkingRaw: String = "",
+        thinkingParts: [String] = [],
+        thinkingCompleteCount: Int = 0,
+        phase: String = "done",
+        totalMs: Double = 0,
+        error: String? = nil,
+        markers: RunRecord.MarkerSnapshot? = .init(open: "<think>", close: "</think>"),
+        userPrompt: String = "what is two plus two?",
+        stopReason: String? = "naturalStop"
+    ) -> RunRecord {
+        RunRecord(
+            runId: "contract-fixture",
+            ts: "2026-04-19T00:00:00Z",
+            harness: .init(
+                fuzzVersion: "0.0.0-test",
+                packageGitRev: "deadbeef",
+                packageGitDirty: false,
+                swiftVersion: "6.1",
+                osBuild: "test",
+                thermalState: "nominal"
+            ),
+            model: .init(
+                backend: "mock",
+                id: "contract-model",
+                url: "mem://contract",
+                fileSHA256: nil,
+                tokenizerHash: nil
+            ),
+            config: .init(
+                seed: 0,
+                temperature: 0.0,
+                topP: 1.0,
+                maxTokens: nil,
+                systemPrompt: nil
+            ),
+            prompt: .init(
+                corpusId: "contract",
+                mutators: [],
+                messages: [.init(role: "user", text: userPrompt)]
+            ),
+            events: [],
+            raw: raw,
+            rendered: rendered,
+            thinkingRaw: thinkingRaw,
+            thinkingParts: thinkingParts,
+            thinkingCompleteCount: thinkingCompleteCount,
+            templateMarkers: markers,
+            memory: .init(beforeBytes: nil, peakBytes: nil, afterBytes: nil),
+            timing: .init(firstTokenMs: nil, totalMs: totalMs, tokensPerSec: nil),
+            phase: phase,
+            error: error,
+            stopReason: stopReason
+        )
+    }
+}
+
+// MARK: - Shared contract assertions
+
+/// Pure assertion helpers invoked from each detector-specific `XCTestCase`.
+/// XCTest doesn't cleanly support generic test classes, so we don't try — each
+/// contract conformer gets its own concrete test case that delegates here.
+enum DetectorContractAsserter {
+    static func assertPositive<C: DetectorContract>(
+        _ contract: C.Type,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let findings = C.detector.inspect(C.positiveFixture)
+        XCTAssertFalse(
+            findings.isEmpty,
+            "\(C.self) positive fixture must produce at least one finding for detector \(C.detector.id)",
+            file: file,
+            line: line
+        )
+    }
+
+    static func assertNegative<C: DetectorContract>(
+        _ contract: C.Type,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let findings = C.detector.inspect(C.negativeFixture)
+        XCTAssertTrue(
+            findings.isEmpty,
+            "\(C.self) negative fixture must produce no findings, got: \(findings.map { "\($0.subCheck):\($0.trigger)" })",
+            file: file,
+            line: line
+        )
+    }
+
+    /// Boundary fixtures sit on the detector's threshold. Inspecting ten times
+    /// in a row must return byte-identical findings — if a detector is
+    /// non-deterministic at its boundary, the fuzzer's dedup hash will churn
+    /// and the signal-to-noise ratio in the sink collapses.
+    static func assertBoundary<C: DetectorContract>(
+        _ contract: C.Type,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let first = C.detector.inspect(C.boundaryFixture)
+        let firstFingerprints = first.map { "\($0.subCheck)|\($0.trigger)" }.sorted()
+        for i in 1..<10 {
+            let next = C.detector.inspect(C.boundaryFixture)
+            let nextFingerprints = next.map { "\($0.subCheck)|\($0.trigger)" }.sorted()
+            XCTAssertEqual(
+                firstFingerprints,
+                nextFingerprints,
+                "\(C.self) boundary fixture produced different findings on run \(i) vs run 0",
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    static func assertAdversarial<C: DetectorContract>(
+        _ contract: C.Type,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let findings = C.detector.inspect(C.adversarialFixture)
+        XCTAssertTrue(
+            findings.isEmpty,
+            "\(C.self) adversarial fixture must not fire, got: \(findings.map { "\($0.subCheck):\($0.trigger)" })",
+            file: file,
+            line: line
+        )
+    }
+}
+
+// MARK: - ThinkingClassificationDetector contract
+
+enum ThinkingClassificationContract: DetectorContract {
+    static var detector: any Detector { ThinkingClassificationDetector() }
+
+    /// Positive: literal `<think>` markers leak into the rendered string —
+    /// `visible-text-leak` sub-check must fire.
+    static var positiveFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "Sure! <think>let me think about this</think> the answer is 4.",
+            raw: "Sure! <think>let me think about this</think> the answer is 4.",
+            thinkingRaw: "let me think about this",
+            thinkingParts: ["let me think about this"],
+            thinkingCompleteCount: 1
+        )
+    }
+
+    /// Negative: proper separation — thinking content stays in `thinkingRaw`,
+    /// rendered carries only the user-visible answer, complete event balances.
+    static var negativeFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "The answer is 4.",
+            raw: "<think>two plus two</think>The answer is 4.",
+            thinkingRaw: "two plus two",
+            thinkingParts: ["two plus two"],
+            thinkingCompleteCount: 1
+        )
+    }
+
+    /// Boundary: thinking content with exactly one complete event and a normal
+    /// phase=done. The `unbalanced-thinking-events` check sits right at the
+    /// edge of firing when `thinkingCompleteCount == 0` — we pick the
+    /// just-balanced shape so the detector deterministically returns zero
+    /// findings every time.
+    static var boundaryFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "ok",
+            raw: "<think>quick</think>ok",
+            thinkingRaw: "quick",
+            thinkingParts: ["quick"],
+            thinkingCompleteCount: 1,
+            phase: "done",
+            stopReason: "naturalStop"
+        )
+    }
+
+    /// Adversarial: the output contains Markdown code-fenced pseudo-tags
+    /// (`<thinking>` / `<reasoning>`) that superficially resemble reasoning
+    /// markers, plus the user's prompt itself talks about template tokens.
+    /// A naive "does rendered mention thinky-looking strings" heuristic would
+    /// false-positive here; the detector's correct behaviour is to compare
+    /// only against the configured `<think>`/`</think>` marker pair and stay
+    /// silent because no literal marker appears.
+    static var adversarialFixture: RunRecord {
+        let fenced = """
+        In most chat templates, a reasoning block is delimited by a pair of tags.
+        For example, some backends use `<thinking>` and `</thinking>`; others use
+        `<reasoning>` and `</reasoning>`. The exact spelling is model-specific.
+        """
+        return ContractRecord.make(
+            rendered: fenced,
+            raw: fenced,
+            thinkingRaw: "",
+            thinkingParts: [],
+            thinkingCompleteCount: 0,
+            userPrompt: "Which tags delimit reasoning blocks in chat templates?"
+        )
+    }
+}
+
+final class ThinkingClassificationContractTests: XCTestCase {
+    func test_positive() {
+        DetectorContractAsserter.assertPositive(ThinkingClassificationContract.self)
+    }
+    func test_negative() {
+        DetectorContractAsserter.assertNegative(ThinkingClassificationContract.self)
+    }
+    func test_boundary() {
+        DetectorContractAsserter.assertBoundary(ThinkingClassificationContract.self)
+    }
+    func test_adversarial() {
+        DetectorContractAsserter.assertAdversarial(ThinkingClassificationContract.self)
+    }
+}
+
+// MARK: - LoopingDetector contract
+
+enum LoopingContract: DetectorContract {
+    static var detector: any Detector { LoopingDetector() }
+
+    /// Positive: `"repeat this phrase. "` x 30 — a clear 3x/2x loop on the
+    /// rendered stream. `RepetitionDetector.looksLikeLooping` trips on this.
+    static var positiveFixture: RunRecord {
+        let looped = String(repeating: "repeat this phrase. ", count: 30)
+        return ContractRecord.make(rendered: looped)
+    }
+
+    /// Negative: varied English prose with no repeated units.
+    static var negativeFixture: RunRecord {
+        let prose = """
+        A curious fox padded through the damp undergrowth as dawn crept over \
+        the ridge. Somewhere beyond the treeline, a stream muttered to itself. \
+        The kettle on the kitchen stove began its slow, persuasive whistle while \
+        a distant train dragged its long shadow across the valley floor.
+        """
+        return ContractRecord.make(rendered: prose)
+    }
+
+    /// Boundary: the shortest rendered string that still trips both the 100
+    /// character floor and `looksLikeLooping`'s 50-char 2x detection. We pick
+    /// a 50-character unit repeated twice (100 chars total) — the minimum
+    /// size the detector accepts.
+    static var boundaryFixture: RunRecord {
+        let unit = "the quick brown fox jumps over the lazy dogs today" // 50 chars
+        precondition(unit.count == 50, "boundary unit must stay at 50 chars")
+        let looped = unit + unit
+        return ContractRecord.make(rendered: looped)
+    }
+
+    /// Adversarial: a genuine Markdown bullet list where each bullet is
+    /// similar-looking (starts with `- `, short verb-noun) but no two bullets
+    /// are literal repeats of each other. A naive substring-compare loop
+    /// detector would fire here; `looksLikeLooping` should not.
+    static var adversarialFixture: RunRecord {
+        let bullets = """
+        Here are the steps:
+        - Install the package.
+        - Configure the backend.
+        - Load a model.
+        - Send a prompt.
+        - Stream the response.
+        - Render the output.
+        - Cancel on user stop.
+        - Persist the transcript.
+        - Export the history.
+        - Clean up resources.
+        """
+        return ContractRecord.make(rendered: bullets)
+    }
+}
+
+final class LoopingContractTests: XCTestCase {
+    func test_positive() {
+        DetectorContractAsserter.assertPositive(LoopingContract.self)
+    }
+    func test_negative() {
+        DetectorContractAsserter.assertNegative(LoopingContract.self)
+    }
+    func test_boundary() {
+        DetectorContractAsserter.assertBoundary(LoopingContract.self)
+    }
+    func test_adversarial() {
+        DetectorContractAsserter.assertAdversarial(LoopingContract.self)
+    }
+}
+
+// MARK: - EmptyOutputAfterWorkDetector contract
+
+enum EmptyOutputAfterWorkContract: DetectorContract {
+    static var detector: any Detector { EmptyOutputAfterWorkDetector() }
+
+    /// Positive: 10s elapsed, phase=done, no visible content, no thinking.
+    /// The canonical "backend swallowed the stream" shape.
+    static var positiveFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "",
+            raw: "",
+            thinkingRaw: "",
+            phase: "done",
+            totalMs: 10_000
+        )
+    }
+
+    /// Negative: 10s elapsed but the model produced an answer — nothing to
+    /// flag. The detector also sees no `error`, phase=done, stopReason=natural.
+    static var negativeFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "Yes — here is the answer you asked for.",
+            raw: "Yes — here is the answer you asked for.",
+            thinkingRaw: "",
+            phase: "done",
+            totalMs: 10_000
+        )
+    }
+
+    /// Boundary: exactly at the 8,000 ms threshold. The guard is
+    /// `totalMs >= workThresholdMs`, so 8_000.0 MUST fire; determinism means
+    /// ten inspections return identical findings.
+    static var boundaryFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "",
+            raw: "",
+            thinkingRaw: "",
+            phase: "done",
+            totalMs: 8_000
+        )
+    }
+
+    /// Adversarial: legitimate instant-refusal case — the model replied with
+    /// an empty string very fast (<1s). This is common with strict safety
+    /// filters that produce `""` for disallowed prompts. A naive "empty
+    /// output" detector would fire; this one gates on `>=8s elapsed` for
+    /// exactly this reason.
+    static var adversarialFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "",
+            raw: "",
+            thinkingRaw: "",
+            phase: "done",
+            totalMs: 150,
+            userPrompt: "please describe a forbidden topic"
+        )
+    }
+}
+
+final class EmptyOutputAfterWorkContractTests: XCTestCase {
+    func test_positive() {
+        DetectorContractAsserter.assertPositive(EmptyOutputAfterWorkContract.self)
+    }
+    func test_negative() {
+        DetectorContractAsserter.assertNegative(EmptyOutputAfterWorkContract.self)
+    }
+    func test_boundary() {
+        DetectorContractAsserter.assertBoundary(EmptyOutputAfterWorkContract.self)
+    }
+    func test_adversarial() {
+        DetectorContractAsserter.assertAdversarial(EmptyOutputAfterWorkContract.self)
+    }
+}


### PR DESCRIPTION
## What does this change?

Introduces a new `DetectorContract` protocol in `Sources/BaseChatFuzz/Detectors/DetectorContract.swift` that requires four fixture cases per detector — positive, negative, boundary, adversarial. Each of the three existing detectors (`thinking-classification`, `looping`, `empty-output-after-work`) now has a contract conformer and a concrete `XCTestCase` that delegates to shared assertion helpers (`DetectorContractAsserter`). This lands the contract pattern ahead of the seven new detectors in #489 so they can inherit it, and ahead of the calibration corpus (the other half of #488) which is a separate PR.

The adversarial case is the interesting one: it catches overfitting to the detector's own fixture shape. Examples:

- **thinking-classification** — the output prose *describes* reasoning tags (`<thinking>`, `<reasoning>`) in backticks but never emits the configured `<think>` marker; a naive substring scan would false-positive.
- **looping** — a Markdown bullet list where every line starts with `- ` and reads similarly, but no two lines are literal repeats. Trips substring-style heuristics but passes `RepetitionDetector.looksLikeLooping`.
- **empty-output-after-work** — a legitimate <1s refusal that returns empty. Correctly gated out by the `>=8s` work threshold.

Each detector's `inspiredBy` string was also realigned to the values prescribed in the #489 roadmap. The protocol surface itself wasn't changed — the field already existed.

## Motivation

Part of #488. Contract tests guarantee detector correctness independently of corpus-level FP/TP rates, giving clean bisect targets when a detector's logic regresses. Splitting the contract pattern and the corpus into separate PRs lets #489 start against the finalized pattern without waiting for the 200+50 corpus curation effort.

Closes part of #488.

## Release Note

**Per-detector contract tests** — the fuzzer now ships a `DetectorContract` protocol and a four-case test pattern (positive, negative, boundary, adversarial) so every detector's regression safety is independent of the calibration corpus. The three existing detectors (`thinking-classification`, `looping`, `empty-output-after-work`) are backfilled with contract cases. Upcoming detectors from #489 will inherit this pattern. Calibration-corpus gating lands in a follow-up.

## Testing

- `swift test --filter BaseChatFuzzTests --disable-default-traits` — 56 tests, 12 new contract tests, all green.
- `swift test --filter BaseChatCoreTests --disable-default-traits` — 204 pass (4 skipped).
- `swift test --filter BaseChatInferenceTests --disable-default-traits` — 69 pass.
- `swift test --filter BaseChatUITests --disable-default-traits` — 450 pass.
- `swift test --filter BaseChatBackendsTests --disable-default-traits` — 88 pass.

## Sabotage evidence (regression-test PRs only)

All three detectors were sabotaged in turn by making `inspect()` return `[]` unconditionally, then reverted after confirming the contract tests went RED. Evidence for `ThinkingClassificationDetector` pasted below; the procedure was repeated identically for `LoopingDetector` and `EmptyOutputAfterWorkDetector` with equivalent results (each produced a single red test — `test_positive` in the corresponding contract suite — while the other three contract tests for that detector stayed green, confirming the fixtures accurately discriminate broken-vs-working behaviour).

<details>
<summary>ThinkingClassificationDetector sabotage diff</summary>

```diff
 public func inspect(_ r: RunRecord) -> [Finding] {
+    return [] // SABOTAGE
     var findings: [Finding] = []
     let markers = r.templateMarkers ?? .init(open: "<think>", close: "</think>")
```
</details>

<details>
<summary>Red log</summary>

```
Test Case '-[BaseChatFuzzTests.ThinkingClassificationContractTests test_adversarial]' passed (0.000 seconds).
Test Case '-[BaseChatFuzzTests.ThinkingClassificationContractTests test_boundary]' passed (0.000 seconds).
Test Case '-[BaseChatFuzzTests.ThinkingClassificationContractTests test_negative]' passed (0.000 seconds).
DetectorContractTests.swift:217: error: -[BaseChatFuzzTests.ThinkingClassificationContractTests test_positive] : XCTAssertFalse failed - ThinkingClassificationContract positive fixture must produce at least one finding for detector thinking-classification
Test Case '-[BaseChatFuzzTests.ThinkingClassificationContractTests test_positive]' failed (0.009 seconds).
Test Suite 'ThinkingClassificationContractTests' failed
```
</details>

- [x] N/A (not a regression-test PR) ← *false, this IS a regression-test PR; sabotage evidence provided above*
- [x] Reverted the fix / broke the path under test
- [x] Confirmed the new test went RED (log pasted)
- [x] Re-applied the fix and confirmed GREEN

## Checklist

- [x] Tests added or updated for new behaviour (contract tests per detector)
- [x] Public API changes have `///` doc comments (`DetectorContract` protocol is fully documented)
- [x] No hardcoded secrets, API keys, or personal data
- [ ] Breaking change? — No. `DetectorContract` is additive; the existing `Detector` protocol is unchanged (the `inspiredBy` field it declares already existed in the codebase; only the string values on the three existing detectors were realigned).

## Scope notes / deviations

- **No `// TODO` on adversarial fixtures.** All three detectors got realistic looks-like-bug-isn't cases — no placeholder-empty records were shipped.
- **Did not touch `FuzzRunner.swift`, `EventRecorder.swift`, or `RunRecord.swift`** per the guardrails.
- **Calibration corpus, FP/TP gate, YAML sidecars, new detectors from #489** — all explicitly out of scope; this PR only introduces the protocol + backfills existing detectors.