### PR TITLE
fix(fuzz): preserve partial thinking buffer on stream throw

### DIFF
--- a/Sources/BaseChatFuzz/EventRecorder.swift
+++ b/Sources/BaseChatFuzz/EventRecorder.swift
@@ -79,13 +79,20 @@ public struct EventRecorder: Sendable {
                 }
                 memoryTick()
             }
-            // Flush any unterminated thinking buffer (orphan — detector will catch)
-            if !thinkingBuffer.isEmpty {
-                thinkingParts.append(thinkingBuffer)
-            }
         } catch {
             phase = "failed"
             errorString = String(describing: error)
+        }
+
+        // Flush any unterminated thinking buffer so that a throw mid-thinking-block
+        // (network drop, KV decode error, OOM) still preserves the partial reasoning
+        // trace in `thinkingParts`. Without this, detectors like
+        // `unbalanced-thinking-events` and the `looping` thinking-loop sub-check go
+        // blind on mid-stream failures. On the success path the buffer is already
+        // drained by the last `.thinkingComplete`, so this is a no-op.
+        if !thinkingBuffer.isEmpty {
+            thinkingParts.append(thinkingBuffer)
+            thinkingBuffer = ""
         }
 
         let totalMs = start.duration(to: ContinuousClock.now).milliseconds

--- a/Tests/BaseChatFuzzTests/EventRecorderTests.swift
+++ b/Tests/BaseChatFuzzTests/EventRecorderTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import BaseChatFuzz
+import BaseChatInference
+
+@MainActor
+final class EventRecorderTests: XCTestCase {
+
+    /// A stream that throws mid-thinking-block must still surface the partial
+    /// reasoning it accumulated since the last `.thinkingComplete`. Without
+    /// this, detectors that rely on `thinkingRaw`/`thinkingParts` go blind on
+    /// mid-stream failures (network drop, KV decode error, OOM) — they see a
+    /// clean capture even though the model emitted and the harness saw real
+    /// reasoning content right up to the error.
+    func test_consume_flushesPartialThinkingBuffer_onMidStreamThrow() async {
+        struct FuzzError: Error, Equatable { let message: String }
+
+        let stream = GenerationStream(AsyncThrowingStream<GenerationEvent, Error> { continuation in
+            continuation.yield(.thinkingToken("partial-a"))
+            continuation.yield(.thinkingToken("partial-b"))
+            continuation.finish(throwing: FuzzError(message: "simulated mid-stream drop"))
+        })
+
+        let capture = await EventRecorder().consume(stream)
+
+        XCTAssertEqual(capture.phase, "failed", "phase must reflect the thrown error")
+        XCTAssertNotNil(capture.error, "error string must be populated on throw")
+        XCTAssertEqual(capture.stopReason, "error", "stopReason classifies a throw as 'error'")
+        XCTAssertEqual(
+            capture.thinkingParts,
+            ["partial-apartial-b"],
+            "partial thinking buffer must be flushed into thinkingParts on throw"
+        )
+        XCTAssertEqual(
+            capture.thinkingRaw,
+            "partial-apartial-b",
+            "thinkingRaw must retain every thinking token seen before the throw"
+        )
+        XCTAssertEqual(capture.thinkingCompleteCount, 0, "no thinkingComplete event was emitted")
+    }
+
+    /// Sanity check the success path: when `.thinkingComplete` drains the
+    /// buffer, the post-loop flush is a no-op — no duplicate entries, no
+    /// empty strings.
+    func test_consume_successPath_doesNotDuplicateCompletedThinkingBlock() async {
+        let stream = GenerationStream(AsyncThrowingStream<GenerationEvent, Error> { continuation in
+            continuation.yield(.thinkingToken("hello "))
+            continuation.yield(.thinkingToken("world"))
+            continuation.yield(.thinkingComplete)
+            continuation.yield(.token("response"))
+            continuation.finish()
+        })
+
+        let capture = await EventRecorder().consume(stream)
+
+        XCTAssertEqual(capture.phase, "done")
+        XCTAssertNil(capture.error)
+        XCTAssertEqual(capture.thinkingParts, ["hello world"])
+        XCTAssertEqual(capture.thinkingCompleteCount, 1)
+        XCTAssertEqual(capture.raw, "response")
+    }
+}


### PR DESCRIPTION
Closes #498.

## Problem

`EventRecorder.consume(_:maxOutputTokens:)` flushed `thinkingBuffer` into `thinkingParts` only inside the `do` block, after the `for try await` loop completed successfully. When the stream threw mid-thinking-block (network drop, KV decode error, OOM), every `.thinkingToken` accumulated since the last `.thinkingComplete` was silently lost. `RunRecord` then showed `phase=failed` with a clean capture even though the backend emitted and streamed real reasoning text — blinding the `unbalanced-thinking-events` detector and the `looping` thinking-loop sub-check to mid-stream failures.

## Fix

Move the orphan-buffer flush out of the `do` block so it runs unconditionally after `do/catch`, on both success and failure paths. The flush is idempotent: `.thinkingComplete` drains the buffer on the success path, so the post-catch flush is a no-op there. `thinkingBuffer` is a `String`, so one `append` is enough — no per-token structure to preserve.

Kept the diff surgical: `EventRecorder.swift` + new `EventRecorderTests.swift`. `FuzzRunner.swift`, `RunRecord.swift`, and the detectors are untouched per the Track B guardrail.

## Sabotage evidence

With the fix reverted locally (removing the post-`catch` flush block):

```
Test Case '-[BaseChatFuzzTests.EventRecorderTests test_consume_flushesPartialThinkingBuffer_onMidStreamThrow]' started.
/Users/roryford/.../Tests/BaseChatFuzzTests/EventRecorderTests.swift:28: error: -[BaseChatFuzzTests.EventRecorderTests test_consume_flushesPartialThinkingBuffer_onMidStreamThrow] : XCTAssertEqual failed: ("[]") is not equal to ("["partial-apartial-b"]") - partial thinking buffer must be flushed into thinkingParts on throw
Test Case '-[BaseChatFuzzTests.EventRecorderTests test_consume_flushesPartialThinkingBuffer_onMidStreamThrow]' failed (0.198 seconds).
Test Case '-[BaseChatFuzzTests.EventRecorderTests test_consume_successPath_doesNotDuplicateCompletedThinkingBlock]' passed (0.000 seconds).
	 Executed 2 tests, with 1 failure (0 unexpected) in 0.198 (0.199) seconds
```

Exact sabotage diff (what was reverted to produce the red):

```diff
         } catch {
             phase = "failed"
             errorString = String(describing: error)
         }

-        // Flush any unterminated thinking buffer so that a throw mid-thinking-block
-        // (network drop, KV decode error, OOM) still preserves the partial reasoning
-        // trace in `thinkingParts`. Without this, detectors like
-        // `unbalanced-thinking-events` and the `looping` thinking-loop sub-check go
-        // blind on mid-stream failures. On the success path the buffer is already
-        // drained by the last `.thinkingComplete`, so this is a no-op.
-        if !thinkingBuffer.isEmpty {
-            thinkingParts.append(thinkingBuffer)
-            thinkingBuffer = ""
-        }
-
         let totalMs = start.duration(to: ContinuousClock.now).milliseconds
```

The success-path test (`test_consume_successPath_doesNotDuplicateCompletedThinkingBlock`) correctly kept passing during sabotage — confirming the regression test isolates the throw-path behavior rather than the success path. Sabotage reverted; full suite green before push.

## Pre-push

All four CI suites plus the Fuzz suite ran locally against this branch:

- `BaseChatCoreTests`: 204 executed, 4 skipped, 0 failures
- `BaseChatInferenceTests`: 69 suites / all green (the #538 `BackgroundDownloadIntegrationTests` flake did not reproduce locally)
- `BaseChatUITests`: 450 executed, 0 failures
- `BaseChatBackendsTests`: 154 executed, 0 failures
- `BaseChatFuzzTests`: 60 executed, 0 failures (includes the 2 new tests)

## Notes

Chose an unconditional post-`catch` flush over the `defer` pattern suggested in the brief. Reason: `defer` runs at scope exit, but `return Capture(...)` evaluates its arguments (copying `thinkingParts` by value into the Capture) *before* the defer runs. A defer that mutates `thinkingParts` therefore never reaches the returned Capture. The post-`catch` inline flush is semantically identical on both paths and doesn't have the evaluation-order trap. Only `EventRecorder.swift` and `Tests/BaseChatFuzzTests/EventRecorderTests.swift` changed — `FuzzRunner.swift` / `RunRecord.swift` / detectors untouched per the Track B guardrail.

## Release Note

**Preserve partial fuzzer thinking content on stream errors** — `EventRecorder` previously dropped every `.thinkingToken` accumulated since the last `.thinkingComplete` if the stream threw mid-block. Detectors like `unbalanced-thinking-events` and `thinking-loop` became blind to mid-stream failures. The buffer is now flushed unconditionally after the do/catch, so failed captures carry the full reasoning trace the model emitted before the error.