### PR TITLE
refactor(fuzz): deprecate RunRecord.rendered and route detectors through raw

### DIFF
--- a/Sources/BaseChatFuzz/Detectors/EmptyOutputAfterWorkDetector.swift
+++ b/Sources/BaseChatFuzz/Detectors/EmptyOutputAfterWorkDetector.swift
@@ -32,7 +32,7 @@ public struct EmptyOutputAfterWorkDetector: Detector {
         guard r.phase == "done",
               r.error == nil,
               r.timing.totalMs >= workThresholdMs,
-              r.rendered.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              r.raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
               r.thinkingRaw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         else {
             return []

--- a/Sources/BaseChatFuzz/Detectors/LoopingDetector.swift
+++ b/Sources/BaseChatFuzz/Detectors/LoopingDetector.swift
@@ -4,7 +4,7 @@ import BaseChatInference
 /// Inspired by qwen3.5:4b looping inside `<think>` blocks until `maxOutputTokens`
 /// exhausts. Runs `RepetitionDetector.looksLikeLooping` over both the visible
 /// stream and the thinking buffer separately — the thinking-side loop leaves
-/// `rendered` empty, which a rendered-only check would miss.
+/// `raw` empty, which a raw-only check would miss.
 public struct LoopingDetector: Detector {
     public let id = "looping"
     public let humanName = "Repetition / loop"
@@ -15,12 +15,14 @@ public struct LoopingDetector: Detector {
     public func inspect(_ r: RunRecord) -> [Finding] {
         var findings: [Finding] = []
 
-        if r.rendered.count >= 100, RepetitionDetector.looksLikeLooping(r.rendered) {
+        // Sub-check id stays `rendered-loop` for dedup stability across the
+        // existing on-disk sink — the name predates `rendered`'s deprecation.
+        if r.raw.count >= 100, RepetitionDetector.looksLikeLooping(r.raw) {
             findings.append(.init(
                 detectorId: id,
                 subCheck: "rendered-loop",
                 severity: .flaky,
-                trigger: String(r.rendered.suffix(120)),
+                trigger: String(r.raw.suffix(120)),
                 modelId: r.model.id
             ))
         }

--- a/Sources/BaseChatFuzz/Detectors/ThinkingClassificationDetector.swift
+++ b/Sources/BaseChatFuzz/Detectors/ThinkingClassificationDetector.swift
@@ -15,12 +15,16 @@ public struct ThinkingClassificationDetector: Detector {
         let markers = r.templateMarkers ?? .init(open: "<think>", close: "</think>")
 
         // 1. Visible-text leak: literal markers appear in the user-visible string.
-        if r.rendered.contains(markers.open) || r.rendered.contains(markers.close) {
+        //    Reads `raw` directly — `rendered` is deprecated and currently
+        //    identical to `raw`. Once the harness starts running `raw` through
+        //    the real UI transform pipeline (follow-up to #499), this will
+        //    switch to the post-transform string.
+        if r.raw.contains(markers.open) || r.raw.contains(markers.close) {
             findings.append(.init(
                 detectorId: id,
                 subCheck: "visible-text-leak",
                 severity: .flaky,
-                trigger: extractContext(r.rendered, around: markers.open),
+                trigger: extractContext(r.raw, around: markers.open),
                 modelId: r.model.id
             ))
         }

--- a/Sources/BaseChatFuzz/RunRecord.swift
+++ b/Sources/BaseChatFuzz/RunRecord.swift
@@ -17,6 +17,12 @@ public struct RunRecord: Codable, Sendable, Equatable {
     public var prompt: PromptSnapshot
     public var events: [EventSnapshot]
     public var raw: String
+    /// Historical duplicate of `raw` — retained for one release cycle so external
+    /// record consumers can migrate off it without a hard break. `FuzzRunner` and
+    /// `Replayer` still populate it from `capture.raw`; detectors now read `raw`
+    /// directly. Tracked for removal once the "real UI-transform rendering" path
+    /// is wired up (see follow-up issue).
+    @available(*, deprecated, message: "use raw; rendered will be removed in a later release")
     public var rendered: String
     public var thinkingRaw: String
     public var thinkingParts: [String]

--- a/Tests/BaseChatFuzzTests/DetectorContractTests.swift
+++ b/Tests/BaseChatFuzzTests/DetectorContractTests.swift
@@ -54,8 +54,11 @@ private enum ContractRecord {
                 messages: [.init(role: "user", text: userPrompt)]
             ),
             events: [],
-            raw: raw,
-            rendered: rendered,
+            // `rendered` is deprecated (always a duplicate of `raw` in
+            // production). Mirror the two so contract fixtures that set only
+            // `rendered:` still exercise detectors that now read `raw`.
+            raw: raw.isEmpty ? rendered : raw,
+            rendered: rendered.isEmpty ? raw : rendered,
             thinkingRaw: thinkingRaw,
             thinkingParts: thinkingParts,
             thinkingCompleteCount: thinkingCompleteCount,
@@ -159,12 +162,15 @@ enum ThinkingClassificationContract: DetectorContract {
         )
     }
 
-    /// Negative: proper separation — thinking content stays in `thinkingRaw`,
-    /// rendered carries only the user-visible answer, complete event balances.
+    /// Negative: the backend stripped markers from the stream and surfaced
+    /// thinking tokens via structured events. `raw` carries only the
+    /// user-visible answer, `thinkingRaw` captures reasoning, and the complete
+    /// event balances. Pre-#499 this fixture relied on `rendered` diverging
+    /// from `raw` to avoid `visible-text-leak`; detectors now read `raw`
+    /// directly, so the fixture must keep markers out of `raw` itself.
     static var negativeFixture: RunRecord {
         ContractRecord.make(
-            rendered: "The answer is 4.",
-            raw: "<think>two plus two</think>The answer is 4.",
+            raw: "The answer is 4.",
             thinkingRaw: "two plus two",
             thinkingParts: ["two plus two"],
             thinkingCompleteCount: 1

--- a/Tests/BaseChatFuzzTests/DetectorTests.swift
+++ b/Tests/BaseChatFuzzTests/DetectorTests.swift
@@ -50,8 +50,12 @@ final class DetectorTests: XCTestCase {
                 messages: [.init(role: "user", text: userPrompt)]
             ),
             events: [],
-            raw: raw,
-            rendered: rendered,
+            // `rendered` is deprecated (always a duplicate of `raw` in
+            // production). Mirror it when only one of the two is set so legacy
+            // test call sites passing `rendered:` still drive the detectors,
+            // which now read `raw`.
+            raw: raw.isEmpty ? rendered : raw,
+            rendered: rendered.isEmpty ? raw : rendered,
             thinkingRaw: thinkingRaw,
             thinkingParts: thinkingParts,
             thinkingCompleteCount: thinkingCompleteCount,
@@ -98,9 +102,11 @@ final class DetectorTests: XCTestCase {
     }
 
     func test_thinkingClassification_properThinkingEvents_producesNoFindings() {
+        // Backends that surface thinking via structured events strip markers
+        // out of `raw` itself — post-#499, detectors read `raw` directly, so
+        // keeping markers out of `raw` is the correct negative shape.
         let r = makeRecord(
-            rendered: "final answer",
-            raw: "<think>reason</think>final answer",
+            raw: "final answer",
             thinkingRaw: "reason",
             thinkingParts: ["reason"],
             thinkingCompleteCount: 1


### PR DESCRIPTION
## Summary

Closes #499. `FuzzRunner.runSingle` has always populated `RunRecord.rendered` from `capture.raw` verbatim, which made two `ThinkingClassificationDetector` sub-checks (`visible-text-leak`, `misclassified-as-text`) redundant and prevented the harness from catching UI-layer rendering bugs.

This PR takes the cheap path per the issue brief:

- `RunRecord.rendered` is annotated `@available(*, deprecated, message: "use raw; rendered will be removed in a later release")`. One release cycle of migration window for any external record consumers before removal.
- `ThinkingClassificationDetector`, `LoopingDetector`, and `EmptyOutputAfterWorkDetector` now read `r.raw` where they previously read `r.rendered`. Sub-check ids are unchanged (`visible-text-leak`, `misclassified-as-text`, `rendered-loop`, `silent-empty`) so the on-disk findings sink's dedup hashes stay stable across the transition.
- Production populators (`FuzzRunner.runSingle`, `Replayer`) still write `rendered: capture.raw` on every emitted record — on-disk `RunRecord` shape is unchanged; the field round-trips through `Codable` as before.
- Test fixtures updated: both `DetectorTests.makeRecord` and `DetectorContractTests.ContractRecord.make` mirror `rendered` <-> `raw` when only one is passed, so legacy call sites keep driving the detectors. Two fixtures that relied on `rendered != raw` to be negative (`ThinkingClassificationContract.negativeFixture`, `test_thinkingClassification_properThinkingEvents_producesNoFindings`) were rewritten to keep markers out of `raw` — the correct post-deprecation shape for a negative.

The follow-up "right path" — assembling `rendered` by running `MessagePart.text` through the real `BaseChatUI` Markdown + code-fence pipeline so the harness can fuzz UI-layer rendering bugs — is tracked as #543.

## Sabotage-equivalent evidence

A standard sabotage flip (restore a sub-check to read `rendered`) wouldn't flip any test red because `rendered == raw` today. The brief specified the alternative: verify the `@available(*, deprecated)` annotation actually emits warnings on internal reads of the stored property. From `swift build --target BaseChatFuzz`:

```
Sources/BaseChatFuzz/RunRecord.swift:69:14: warning: 'rendered' is deprecated: use raw; rendered will be removed in a later release
 67 |         self.events = events
 68 |         self.raw = raw
 69 |         self.rendered = rendered
    |              `- warning: 'rendered' is deprecated: use raw; rendered will be removed in a later release

Sources/BaseChatFuzz/RunRecord.swift:101:14: warning: 'rendered' is deprecated: use raw; rendered will be removed in a later release
 99 |         self.events = try c.decode([EventSnapshot].self, forKey: .events)
100 |         self.raw = try c.decode(String.self, forKey: .raw)
101 |         self.rendered = try c.decode(String.self, forKey: .rendered)
    |              `- warning: 'rendered' is deprecated: use raw; rendered will be removed in a later release
```

Kept intentionally — they are self-documenting reminders that the field still needs populating for on-disk record validity until #543 lands the real renderer. `Package.swift` does not set `-warnings-as-errors`, so they don't fail the build. Call sites outside `RunRecord` (e.g., `FuzzRunner.runSingle`'s `rendered: capture.raw` argument) don't trigger the warning because `rendered:` is an init parameter label rather than a direct read of the deprecated property.

## Test plan

- [x] `swift test --filter BaseChatFuzzTests --disable-default-traits` — 75 tests pass (including all four contract suites and the `DetectorTests` unit coverage)
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 204 passing, 4 skipped
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 69 passing
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 450 passing
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 97 passing
- [x] `swift build --target BaseChatFuzz` — succeeds, emits the two expected `@available(deprecated)` warnings shown above

## Release Note

**Deprecate `RunRecord.rendered`** — the field was always populated from `raw`, making two `ThinkingClassificationDetector` sub-checks (`visible-text-leak`, `misclassified-as-text`) redundant and preventing the harness from catching UI-layer rendering bugs. This PR deprecates the field with a one-release migration window; detectors now read `raw`. A follow-up issue (#543) tracks the "right" path: assembling `rendered` through the real Markdown/code-fence pipeline so the harness can fuzz the UI rendering layer too. Closes #499.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)