### PR TITLE
feat(fuzz): add seven deferred detectors with DetectorContract

### DIFF
--- a/Sources/BaseChatFuzz/Detectors/ContextExhaustionSilentDetector.swift
+++ b/Sources/BaseChatFuzz/Detectors/ContextExhaustionSilentDetector.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Inspired by e9ba9d1 — `InferenceError.contextExhausted` firing even when
+/// the prompt + requested output comfortably fits in the model's context
+/// window. The detector flags records whose error description indicates a
+/// context-exhaustion refusal.
+///
+/// The "false trigger" guard (prompt token estimate < contextLimit * 0.5)
+/// is deliberately disabled today. The `RunRecord` does not carry a
+/// per-request prompt-token count. Until that field lands, we flag every
+/// context-exhausted error — false positives are acceptable at `.flaky`
+/// severity and the calibration corpus will filter legitimate exhaustions.
+///
+/// Ships at `.flaky` severity. Promotion to `.confirmed` requires the
+/// calibration corpus + FP/TP gating planned in W2.C phase 2.
+public struct ContextExhaustionSilentDetector: Detector {
+    public let id = "context-exhaustion-silent"
+    public let humanName = "Silent context-exhaustion false trigger"
+    public let inspiredBy = "e9ba9d1 — context-exhausted misfire"
+
+    /// Canonical fragment from `InferenceError.contextExhausted`'s
+    /// `errorDescription`. Matched case-insensitively.
+    static let errorNeedle = "exceeds context window"
+
+    public init() {}
+
+    public func inspect(_ r: RunRecord) -> [Finding] {
+        guard let err = r.error else { return [] }
+        guard err.lowercased().contains(Self.errorNeedle) else { return [] }
+
+        // TODO: wire prompt-token estimate + contextLimit comparison. Once
+        // `ConfigSnapshot` / `PromptSnapshot` carries a token budget, gate
+        // this positive with `promptTokens < contextLimit / 2` to filter
+        // legitimate exhaustions.
+        return [Finding(
+            detectorId: id,
+            subCheck: "context-exhausted-fired",
+            severity: .flaky,
+            trigger: "error=\"\(err.prefix(120))\"",
+            modelId: r.model.id
+        )]
+    }
+}

--- a/Sources/BaseChatFuzz/Detectors/Detector.swift
+++ b/Sources/BaseChatFuzz/Detectors/Detector.swift
@@ -12,6 +12,13 @@ public enum DetectorRegistry {
         ThinkingClassificationDetector(),
         LoopingDetector(),
         EmptyOutputAfterWorkDetector(),
+        TemplateTokenLeakDetector(),
+        MemoryGrowthDetector(),
+        KVCollisionDetector(),
+        EmptyVisibleAfterThinkDetector(),
+        RaceStallDetector(),
+        ContextExhaustionSilentDetector(),
+        TimeoutDetector(),
     ]
 
     public static func resolve(_ filter: Set<String>?) -> [any Detector] {

--- a/Sources/BaseChatFuzz/Detectors/EmptyVisibleAfterThinkDetector.swift
+++ b/Sources/BaseChatFuzz/Detectors/EmptyVisibleAfterThinkDetector.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Inspired by 0d3c206 — the `hasVisibleContent` bug where a message with
+/// only thinking content was treated as "has content" and the empty visible
+/// string was rendered as a blank bubble. Catches the inverse of the
+/// `EmptyOutputAfterWorkDetector`: the model *did* produce raw tokens and
+/// *did* produce thinking, but the visible rendering is empty.
+///
+/// Today's `rendered` field mirrors the user-visible string. #499 may
+/// deprecate it in parallel; once that lands, swap the check to
+/// `r.raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty` —
+/// functionally equivalent while the `rendered` field still exists.
+///
+/// Ships at `.flaky` severity. Promotion to `.confirmed` requires the
+/// calibration corpus + FP/TP gating planned in W2.C phase 2.
+public struct EmptyVisibleAfterThinkDetector: Detector {
+    public let id = "empty-visible-after-think"
+    public let humanName = "Empty visible output after thinking"
+    public let inspiredBy = "0d3c206 — hasVisibleContent bug"
+
+    public init() {}
+
+    public func inspect(_ r: RunRecord) -> [Finding] {
+        guard r.phase == "done",
+              !r.raw.isEmpty,
+              !r.thinkingRaw.isEmpty,
+              r.rendered.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return [] }
+
+        return [Finding(
+            detectorId: id,
+            subCheck: "visible-empty",
+            severity: .flaky,
+            trigger: "thinking=\(r.thinkingRaw.count)B rendered=empty",
+            modelId: r.model.id
+        )]
+    }
+}

--- a/Sources/BaseChatFuzz/Detectors/KVCollisionDetector.swift
+++ b/Sources/BaseChatFuzz/Detectors/KVCollisionDetector.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Inspired by 18710d2 — KV-cache collisions that surface as
+/// `Decode failed during generation` after a prior stop. The canonical
+/// shape: user cancels mid-decode, the cache pointer is left dangling,
+/// the next turn trips the same error.
+///
+/// Today's harness is single-turn, so the "prior stop event in the same
+/// session" condition collapses to: error string matches AND the record
+/// itself records a stop (stopReason == "userStop" or phase == "stopped").
+/// Multi-turn support arrives in #492; this detector will pick up the
+/// richer session context automatically once events span turns.
+///
+/// Ships at `.flaky` severity. Promotion to `.confirmed` requires the
+/// calibration corpus + FP/TP gating planned in W2.C phase 2.
+public struct KVCollisionDetector: Detector {
+    public let id = "kv-collision"
+    public let humanName = "KV-cache decode collision"
+    public let inspiredBy = "18710d2 — KV-collision on stop-then-resume"
+
+    /// Case-insensitive substring that marks the canonical llama.cpp decode
+    /// failure observed post-collision. Kept narrow to avoid matching
+    /// natural-language echoes of the phrase.
+    static let errorNeedle = "decode failed during generation"
+
+    public init() {}
+
+    public func inspect(_ r: RunRecord) -> [Finding] {
+        guard let err = r.error else { return [] }
+        let lower = err.lowercased()
+        guard lower.contains(Self.errorNeedle) else { return [] }
+
+        // A naturally occurring error echo is unlikely in `error`, but guard
+        // against a record that only *almost* matches (e.g., "Decode failed"
+        // without the "during generation" tail) — we require the full phrase.
+        guard r.phase == "stopped" || r.stopReason == "userStop" || r.stopReason == "error"
+        else { return [] }
+
+        return [Finding(
+            detectorId: id,
+            subCheck: "decode-after-stop",
+            severity: .flaky,
+            trigger: "phase=\(r.phase) stopReason=\(r.stopReason ?? "nil")",
+            modelId: r.model.id
+        )]
+    }
+}

--- a/Sources/BaseChatFuzz/Detectors/MemoryGrowthDetector.swift
+++ b/Sources/BaseChatFuzz/Detectors/MemoryGrowthDetector.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Inspired by 04c3f4f — iOS jetsam. Flags two shapes of memory pathology
+/// that the harness can observe without hooking into the allocator:
+///
+/// 1. A memory-related error string (`memory`, `OOM`, `jetsam`, etc.) fires
+///    during generation. This path is always enabled.
+/// 2. Peak resident bytes exceed `beforeBytes` by more than a model-declared
+///    budget by a factor of `growthFactor`. This path is behind a TODO —
+///    the record carries `MemorySnapshot.beforeBytes`/`peakBytes` today but
+///    there is no `declaredBudget` field yet.
+///
+/// Ships at `.flaky` severity. Promotion to `.confirmed` requires the
+/// calibration corpus + FP/TP gating planned in W2.C phase 2.
+public struct MemoryGrowthDetector: Detector {
+    public let id = "memory-growth"
+    public let humanName = "Memory growth / OOM"
+    public let inspiredBy = "04c3f4f — iOS jetsam"
+
+    /// Case-insensitive substrings that signal a memory-related error.
+    static let errorNeedles: [String] = [
+        "memory",
+        "oom",
+        "out of memory",
+        "jetsam",
+        "mach_vm",
+        "malloc",
+    ]
+
+    public init() {}
+
+    public func inspect(_ r: RunRecord) -> [Finding] {
+        var findings: [Finding] = []
+
+        // 1. Error-string path — always enabled.
+        if let err = r.error {
+            let lower = err.lowercased()
+            if let hit = Self.errorNeedles.first(where: { lower.contains($0) }) {
+                findings.append(.init(
+                    detectorId: id,
+                    subCheck: "memory-error",
+                    severity: .flaky,
+                    trigger: "err-needle=\(hit)",
+                    modelId: r.model.id
+                ))
+            }
+        }
+
+        // 2. Growth-budget path.
+        // TODO: wire memory capture in a follow-up. The declared-budget
+        // comparison requires a per-model memory budget field on
+        // `ModelSnapshot` / `ConfigSnapshot` that doesn't exist yet. Until
+        // then, this branch stays disabled to avoid speculative thresholds.
+        _ = r.memory.beforeBytes
+        _ = r.memory.peakBytes
+
+        return findings
+    }
+}

--- a/Sources/BaseChatFuzz/Detectors/RaceStallDetector.swift
+++ b/Sources/BaseChatFuzz/Detectors/RaceStallDetector.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Inspired by 8d6b013 — stop-while-decoding races that leave the stream
+/// producer in a stalled state, no error, no tokens, forever. Fires when:
+///
+/// - `phase == "stalled"` (the harness's explicit stall signal), OR
+/// - `firstTokenMs > 60_000` AND `error == nil` (no first token after a
+///   full minute and no failure recorded).
+///
+/// Tie-break: the second branch uses strict `>`, so `firstTokenMs == 60_000`
+/// is NOT a stall — 60 seconds flat is the outer edge of what a genuine
+/// cold-start model load can take on a chilled laptop.
+///
+/// Ships at `.flaky` severity. Promotion to `.confirmed` requires the
+/// calibration corpus + FP/TP gating planned in W2.C phase 2.
+public struct RaceStallDetector: Detector {
+    public let id = "race-stall"
+    public let humanName = "Stream stall / race"
+    public let inspiredBy = "8d6b013 — stop-while-decoding races"
+
+    /// Upper bound on a "legitimate" first-token latency. Anything past this
+    /// with no error is stall-shaped rather than slow-shaped.
+    public let firstTokenStallMs: Double
+
+    public init(firstTokenStallMs: Double = 60_000) {
+        self.firstTokenStallMs = firstTokenStallMs
+    }
+
+    public func inspect(_ r: RunRecord) -> [Finding] {
+        var findings: [Finding] = []
+
+        if r.phase == "stalled" {
+            findings.append(.init(
+                detectorId: id,
+                subCheck: "phase-stalled",
+                severity: .flaky,
+                trigger: "phase=stalled totalMs=\(Int(r.timing.totalMs))",
+                modelId: r.model.id
+            ))
+        }
+
+        if let first = r.timing.firstTokenMs,
+           first > firstTokenStallMs,
+           r.error == nil {
+            findings.append(.init(
+                detectorId: id,
+                subCheck: "first-token-timeout",
+                severity: .flaky,
+                trigger: "firstTokenMs>\(Int(firstTokenStallMs))",
+                modelId: r.model.id
+            ))
+        }
+
+        return findings
+    }
+}

--- a/Sources/BaseChatFuzz/Detectors/TemplateTokenLeakDetector.swift
+++ b/Sources/BaseChatFuzz/Detectors/TemplateTokenLeakDetector.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Inspired by c9cac45 — Phi-4 detected as ChatML. When template
+/// auto-detection picks the wrong family, raw chat-template delimiters
+/// (ChatML `<|im_start|>`, Llama `[INST]`, Gemma `<start_of_turn>`, etc.)
+/// leak into the visible output instead of being consumed by the tokenizer.
+///
+/// Ships at `.flaky` severity — promotion to `.confirmed` requires the
+/// calibration corpus + FP/TP gating planned in W2.C phase 2.
+public struct TemplateTokenLeakDetector: Detector {
+    public let id = "template-token-leak"
+    public let humanName = "Chat-template token leak"
+    public let inspiredBy = "c9cac45 — Phi-4 detected as ChatML"
+
+    /// Literal delimiters representative of popular chat templates. Substring
+    /// match is sufficient; these strings are long enough to avoid natural-
+    /// language collisions outside of deliberate discussion of tokenizers.
+    static let templateFragments: [String] = [
+        "<|im_start|>",
+        "<|im_end|>",
+        "<|eot_id|>",
+        "<|begin_of_text|>",
+        "<|end_of_text|>",
+        "<|start_header_id|>",
+        "<|end_header_id|>",
+        "<start_of_turn>",
+        "<end_of_turn>",
+        "[INST]",
+        "[/INST]",
+    ]
+
+    public init() {}
+
+    public func inspect(_ r: RunRecord) -> [Finding] {
+        // Adversarial guard: Markdown code fences or inline-code backticks
+        // are legitimate ways to discuss template tokens (documentation,
+        // tokenizer tutorials). Strip fenced blocks and inline-code spans
+        // before scanning so prose about `<|im_start|>` doesn't fire.
+        let scannable = Self.stripCodeSpans(r.raw)
+
+        var findings: [Finding] = []
+        var seen: Set<String> = []
+        for fragment in Self.templateFragments {
+            guard !seen.contains(fragment),
+                  scannable.contains(fragment)
+            else { continue }
+            seen.insert(fragment)
+            findings.append(.init(
+                detectorId: id,
+                subCheck: "template-fragment",
+                severity: .flaky,
+                trigger: fragment,
+                modelId: r.model.id
+            ))
+        }
+        return findings
+    }
+
+    /// Removes triple-backtick fenced blocks and single-backtick spans so
+    /// literal template delimiters discussed as documentation do not trip
+    /// the detector. Best-effort — an unterminated fence drops everything
+    /// after it, which is the conservative choice for a false-positive
+    /// guard.
+    static func stripCodeSpans(_ s: String) -> String {
+        var out = ""
+        out.reserveCapacity(s.count)
+        var inFence = false
+        var inInline = false
+        var i = s.startIndex
+        while i < s.endIndex {
+            // Triple-backtick fence toggle.
+            if !inInline, s[i...].hasPrefix("```") {
+                inFence.toggle()
+                i = s.index(i, offsetBy: 3)
+                continue
+            }
+            // Inline-code backtick toggle (only when not inside a fence).
+            if !inFence, s[i] == "`" {
+                inInline.toggle()
+                i = s.index(after: i)
+                continue
+            }
+            if !inFence, !inInline {
+                out.append(s[i])
+            }
+            i = s.index(after: i)
+        }
+        return out
+    }
+}

--- a/Sources/BaseChatFuzz/Detectors/TimeoutDetector.swift
+++ b/Sources/BaseChatFuzz/Detectors/TimeoutDetector.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Inspired by the generic "anomaly catch-all" bucket. The intended design
+/// flags records whose `totalMs` exceeds 5× the rolling median for the same
+/// model+config window (last 20 records). That requires per-detector mutable
+/// state, which the current `Detector` protocol (Sendable, stateless
+/// `inspect`) does not support.
+///
+/// Ships with a crude fallback: any record whose `totalMs` exceeds 60s is
+/// flagged. This is intentionally conservative — real long-running cloud
+/// calls routinely blow past 60s, so false positives are expected, and
+/// the calibration corpus + FP/TP gating (W2.C phase 2) is what will make
+/// the real windowed detector useful.
+///
+/// FIXME: needs window history — see issue #489. Move to a stateful actor
+/// once the Detector protocol grows a registry-level state slot, or emit
+/// findings from a post-run aggregator that owns the history.
+///
+/// Ships at `.flaky` severity.
+public struct TimeoutDetector: Detector {
+    public let id = "timeout"
+    public let humanName = "Wall-clock timeout outlier"
+    public let inspiredBy = "generic anomaly catch-all"
+
+    /// Fallback fixed threshold used until windowed-median support lands.
+    public let fallbackThresholdMs: Double
+
+    public init(fallbackThresholdMs: Double = 60_000) {
+        self.fallbackThresholdMs = fallbackThresholdMs
+    }
+
+    public func inspect(_ r: RunRecord) -> [Finding] {
+        guard r.timing.totalMs > fallbackThresholdMs else { return [] }
+        return [Finding(
+            detectorId: id,
+            subCheck: "totalMs-over-threshold",
+            severity: .flaky,
+            trigger: "totalMs=\(Int(r.timing.totalMs)) threshold=\(Int(fallbackThresholdMs))",
+            modelId: r.model.id
+        )]
+    }
+}

--- a/Tests/BaseChatFuzzTests/DetectorContractTests.swift
+++ b/Tests/BaseChatFuzzTests/DetectorContractTests.swift
@@ -18,10 +18,13 @@ private enum ContractRecord {
         thinkingCompleteCount: Int = 0,
         phase: String = "done",
         totalMs: Double = 0,
+        firstTokenMs: Double? = nil,
         error: String? = nil,
         markers: RunRecord.MarkerSnapshot? = .init(open: "<think>", close: "</think>"),
         userPrompt: String = "what is two plus two?",
-        stopReason: String? = "naturalStop"
+        stopReason: String? = "naturalStop",
+        memoryBefore: UInt64? = nil,
+        memoryPeak: UInt64? = nil
     ) -> RunRecord {
         RunRecord(
             runId: "contract-fixture",
@@ -60,8 +63,8 @@ private enum ContractRecord {
             thinkingParts: thinkingParts,
             thinkingCompleteCount: thinkingCompleteCount,
             templateMarkers: markers,
-            memory: .init(beforeBytes: nil, peakBytes: nil, afterBytes: nil),
-            timing: .init(firstTokenMs: nil, totalMs: totalMs, tokensPerSec: nil),
+            memory: .init(beforeBytes: memoryBefore, peakBytes: memoryPeak, afterBytes: nil),
+            timing: .init(firstTokenMs: firstTokenMs, totalMs: totalMs, tokensPerSec: nil),
             phase: phase,
             error: error,
             stopReason: stopReason
@@ -369,5 +372,486 @@ final class EmptyOutputAfterWorkContractTests: XCTestCase {
     }
     func test_adversarial() {
         DetectorContractAsserter.assertAdversarial(EmptyOutputAfterWorkContract.self)
+    }
+}
+
+// MARK: - TemplateTokenLeakDetector contract
+
+enum TemplateTokenLeakContract: DetectorContract {
+    static var detector: any Detector { TemplateTokenLeakDetector() }
+
+    /// Positive: ChatML `<|im_start|>` delimiter leaks into raw output —
+    /// the canonical Phi-4-detected-as-ChatML shape.
+    static var positiveFixture: RunRecord {
+        let leaked = "<|im_start|>assistant\nThe answer is 4.<|im_end|>"
+        return ContractRecord.make(rendered: leaked, raw: leaked)
+    }
+
+    /// Negative: plain prose with no template fragments anywhere.
+    static var negativeFixture: RunRecord {
+        let prose = "The answer is four. Two and two make four in standard arithmetic."
+        return ContractRecord.make(rendered: prose, raw: prose)
+    }
+
+    /// Boundary: a single delimiter (`[INST]`) at the very start of the
+    /// raw stream. Tests the regex-anchor behaviour — any substring match
+    /// must fire, regardless of position. Ten inspections must yield the
+    /// same finding.
+    static var boundaryFixture: RunRecord {
+        let leak = "[INST] You are a helpful assistant. [/INST] ok"
+        return ContractRecord.make(rendered: leak, raw: leak)
+    }
+
+    /// Adversarial: a Markdown code block quoting the literal `<|im_start|>`
+    /// token. This is legitimate documentation prose — a naive substring
+    /// scanner would false-positive. The detector strips fenced and
+    /// inline-code spans before scanning.
+    static var adversarialFixture: RunRecord {
+        let doc = """
+        ChatML uses the `<|im_start|>` and `<|im_end|>` tokens to delimit
+        turns. Here is an example:
+
+        ```
+        <|im_start|>user
+        hello
+        <|im_end|>
+        ```
+
+        Most tokenizers consume these silently.
+        """
+        return ContractRecord.make(
+            rendered: doc,
+            raw: doc,
+            userPrompt: "explain chatml delimiters"
+        )
+    }
+}
+
+final class TemplateTokenLeakContractTests: XCTestCase {
+    func test_positive() {
+        DetectorContractAsserter.assertPositive(TemplateTokenLeakContract.self)
+    }
+    func test_negative() {
+        DetectorContractAsserter.assertNegative(TemplateTokenLeakContract.self)
+    }
+    func test_boundary() {
+        DetectorContractAsserter.assertBoundary(TemplateTokenLeakContract.self)
+    }
+    func test_adversarial() {
+        DetectorContractAsserter.assertAdversarial(TemplateTokenLeakContract.self)
+    }
+}
+
+// MARK: - MemoryGrowthDetector contract
+
+enum MemoryGrowthContract: DetectorContract {
+    static var detector: any Detector { MemoryGrowthDetector() }
+
+    /// Positive: backend surfaced a memory-related error. The growth-budget
+    /// branch is disabled today; the error-string path is what fires.
+    static var positiveFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "",
+            raw: "",
+            phase: "error",
+            error: "Metal allocation failed: out of memory",
+            stopReason: "error"
+        )
+    }
+
+    /// Negative: normal completion, no error.
+    static var negativeFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "The answer is 4.",
+            raw: "The answer is 4.",
+            totalMs: 500
+        )
+    }
+
+    /// Boundary: an error whose text contains a memory needle in its exact
+    /// lowercased form. Ten inspections must produce the same fingerprint.
+    static var boundaryFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "",
+            raw: "",
+            phase: "error",
+            error: "jetsam killed process",
+            stopReason: "error"
+        )
+    }
+
+    /// Adversarial: a non-memory error that happens to mention bytes — the
+    /// detector must NOT fire on token-count or byte-limit discussions.
+    static var adversarialFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "",
+            raw: "",
+            phase: "error",
+            error: "invalid UTF-8 byte sequence at offset 42",
+            stopReason: "error"
+        )
+    }
+}
+
+final class MemoryGrowthContractTests: XCTestCase {
+    func test_positive() {
+        DetectorContractAsserter.assertPositive(MemoryGrowthContract.self)
+    }
+    func test_negative() {
+        DetectorContractAsserter.assertNegative(MemoryGrowthContract.self)
+    }
+    func test_boundary() {
+        DetectorContractAsserter.assertBoundary(MemoryGrowthContract.self)
+    }
+    func test_adversarial() {
+        DetectorContractAsserter.assertAdversarial(MemoryGrowthContract.self)
+    }
+}
+
+// MARK: - KVCollisionDetector contract
+
+enum KVCollisionContract: DetectorContract {
+    static var detector: any Detector { KVCollisionDetector() }
+
+    /// Positive: the canonical llama.cpp post-stop decode failure — error
+    /// text matches AND the record records a stop.
+    static var positiveFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "",
+            raw: "",
+            phase: "stopped",
+            error: "Decode failed during generation",
+            stopReason: "userStop"
+        )
+    }
+
+    /// Negative: ordinary successful completion — no error at all.
+    static var negativeFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "The answer is 4.",
+            raw: "The answer is 4.",
+            totalMs: 500
+        )
+    }
+
+    /// Boundary: the error text matches exactly AND stopReason is `error`
+    /// (not `userStop`). The detector accepts either indicator, so this
+    /// must fire; determinism means ten inspections produce the same hit.
+    static var boundaryFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "",
+            raw: "",
+            phase: "error",
+            error: "Decode failed during generation",
+            stopReason: "error"
+        )
+    }
+
+    /// Adversarial: the model's output itself *renders* the phrase "decode
+    /// failed during generation" as natural-language text (e.g., an agent
+    /// explaining errors to a user). The `error` field stays nil, so the
+    /// detector must not fire.
+    static var adversarialFixture: RunRecord {
+        let echo = "A common llama.cpp error reads: \"Decode failed during generation\". It typically indicates a KV-cache mismatch."
+        return ContractRecord.make(
+            rendered: echo,
+            raw: echo,
+            phase: "done",
+            stopReason: "naturalStop"
+        )
+    }
+}
+
+final class KVCollisionContractTests: XCTestCase {
+    func test_positive() {
+        DetectorContractAsserter.assertPositive(KVCollisionContract.self)
+    }
+    func test_negative() {
+        DetectorContractAsserter.assertNegative(KVCollisionContract.self)
+    }
+    func test_boundary() {
+        DetectorContractAsserter.assertBoundary(KVCollisionContract.self)
+    }
+    func test_adversarial() {
+        DetectorContractAsserter.assertAdversarial(KVCollisionContract.self)
+    }
+}
+
+// MARK: - EmptyVisibleAfterThinkDetector contract
+
+enum EmptyVisibleAfterThinkContract: DetectorContract {
+    static var detector: any Detector { EmptyVisibleAfterThinkDetector() }
+
+    /// Positive: model thought, emitted tokens, rendered is whitespace —
+    /// the classic `hasVisibleContent` bug shape.
+    static var positiveFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "   \n   ",
+            raw: "<think>reasoning here</think>",
+            thinkingRaw: "reasoning here",
+            thinkingParts: ["reasoning here"],
+            thinkingCompleteCount: 1,
+            phase: "done"
+        )
+    }
+
+    /// Negative: model thought AND produced visible output — rendered is
+    /// non-empty, so nothing to flag.
+    static var negativeFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "The answer is 4.",
+            raw: "<think>compute</think>The answer is 4.",
+            thinkingRaw: "compute",
+            thinkingParts: ["compute"],
+            thinkingCompleteCount: 1,
+            phase: "done"
+        )
+    }
+
+    /// Boundary: rendered is exactly one whitespace character with raw and
+    /// thinking both non-empty. The trim check MUST flag this; ten
+    /// inspections return the same finding.
+    static var boundaryFixture: RunRecord {
+        ContractRecord.make(
+            rendered: " ",
+            raw: "<think>x</think>",
+            thinkingRaw: "x",
+            thinkingParts: ["x"],
+            thinkingCompleteCount: 1,
+            phase: "done"
+        )
+    }
+
+    /// Adversarial: empty rendering but empty thinking too — this is the
+    /// `EmptyOutputAfterWorkDetector`'s territory, not ours. The detector
+    /// must stay silent because `thinkingRaw` is empty.
+    static var adversarialFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "",
+            raw: "",
+            thinkingRaw: "",
+            phase: "done",
+            totalMs: 10_000
+        )
+    }
+}
+
+final class EmptyVisibleAfterThinkContractTests: XCTestCase {
+    func test_positive() {
+        DetectorContractAsserter.assertPositive(EmptyVisibleAfterThinkContract.self)
+    }
+    func test_negative() {
+        DetectorContractAsserter.assertNegative(EmptyVisibleAfterThinkContract.self)
+    }
+    func test_boundary() {
+        DetectorContractAsserter.assertBoundary(EmptyVisibleAfterThinkContract.self)
+    }
+    func test_adversarial() {
+        DetectorContractAsserter.assertAdversarial(EmptyVisibleAfterThinkContract.self)
+    }
+}
+
+// MARK: - RaceStallDetector contract
+
+enum RaceStallContract: DetectorContract {
+    static var detector: any Detector { RaceStallDetector() }
+
+    /// Positive: the harness recorded `phase = "stalled"` — unambiguous
+    /// stream-stall signal.
+    static var positiveFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "",
+            raw: "",
+            phase: "stalled",
+            totalMs: 120_000,
+            stopReason: "unknown"
+        )
+    }
+
+    /// Negative: fast first token, normal completion — nothing to flag.
+    static var negativeFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "The answer is 4.",
+            raw: "The answer is 4.",
+            phase: "done",
+            totalMs: 800,
+            firstTokenMs: 120
+        )
+    }
+
+    /// Boundary: `firstTokenMs == 60_000` exactly. The detector's tie-break
+    /// rule is strict-greater — 60_000 flat is NOT a stall — so ten
+    /// inspections must return zero findings. The fixture also has
+    /// phase=done, so the stalled-phase branch stays quiet.
+    static var boundaryFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "The answer is 4.",
+            raw: "The answer is 4.",
+            phase: "done",
+            totalMs: 65_000,
+            firstTokenMs: 60_000
+        )
+    }
+
+    /// Adversarial: a genuinely slow cold-start (45s to first token). The
+    /// detector must not fire — legitimate model warm-up is slow but not
+    /// stalled.
+    static var adversarialFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "The answer is 4.",
+            raw: "The answer is 4.",
+            phase: "done",
+            totalMs: 46_000,
+            firstTokenMs: 45_000
+        )
+    }
+}
+
+final class RaceStallContractTests: XCTestCase {
+    func test_positive() {
+        DetectorContractAsserter.assertPositive(RaceStallContract.self)
+    }
+    func test_negative() {
+        DetectorContractAsserter.assertNegative(RaceStallContract.self)
+    }
+    func test_boundary() {
+        DetectorContractAsserter.assertBoundary(RaceStallContract.self)
+    }
+    func test_adversarial() {
+        DetectorContractAsserter.assertAdversarial(RaceStallContract.self)
+    }
+}
+
+// MARK: - ContextExhaustionSilentDetector contract
+
+enum ContextExhaustionSilentContract: DetectorContract {
+    static var detector: any Detector { ContextExhaustionSilentDetector() }
+
+    /// Positive: the canonical `InferenceError.contextExhausted` error
+    /// description. Today the detector has no prompt-token estimate to
+    /// gate on, so any occurrence of this error fires.
+    static var positiveFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "",
+            raw: "",
+            phase: "error",
+            error: "Prompt (120 tokens) plus requested output (256 tokens) exceeds context window (8192 tokens).",
+            stopReason: "error"
+        )
+    }
+
+    /// Negative: normal successful completion, no error.
+    static var negativeFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "The answer is 4.",
+            raw: "The answer is 4.",
+            totalMs: 500
+        )
+    }
+
+    /// Boundary: the error message matches exactly, with no trailing text.
+    /// Ten inspections must yield the same finding.
+    static var boundaryFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "",
+            raw: "",
+            phase: "error",
+            error: "…exceeds context window…",
+            stopReason: "error"
+        )
+    }
+
+    /// Adversarial: a different error that mentions "context" but not the
+    /// canonical phrase. Must not fire — we match only the exhaustion
+    /// description.
+    static var adversarialFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "",
+            raw: "",
+            phase: "error",
+            error: "Failed to initialize context with size 8192",
+            stopReason: "error"
+        )
+    }
+}
+
+final class ContextExhaustionSilentContractTests: XCTestCase {
+    func test_positive() {
+        DetectorContractAsserter.assertPositive(ContextExhaustionSilentContract.self)
+    }
+    func test_negative() {
+        DetectorContractAsserter.assertNegative(ContextExhaustionSilentContract.self)
+    }
+    func test_boundary() {
+        DetectorContractAsserter.assertBoundary(ContextExhaustionSilentContract.self)
+    }
+    func test_adversarial() {
+        DetectorContractAsserter.assertAdversarial(ContextExhaustionSilentContract.self)
+    }
+}
+
+// MARK: - TimeoutDetector contract
+
+enum TimeoutContract: DetectorContract {
+    static var detector: any Detector { TimeoutDetector() }
+
+    /// Positive: totalMs well over the 60s fallback.
+    static var positiveFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "eventually",
+            raw: "eventually",
+            phase: "done",
+            totalMs: 180_000
+        )
+    }
+
+    /// Negative: a fast run, nowhere near the threshold.
+    static var negativeFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "ok",
+            raw: "ok",
+            phase: "done",
+            totalMs: 500
+        )
+    }
+
+    /// Boundary: totalMs == 60_000 exactly. The detector's comparison is
+    /// strict-greater, so this must NOT fire and must return the same
+    /// (empty) findings across ten inspections.
+    static var boundaryFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "ok",
+            raw: "ok",
+            phase: "done",
+            totalMs: 60_000
+        )
+    }
+
+    /// Adversarial: a long legitimate generation (55s) — still under the
+    /// crude fallback threshold. The real windowed-median design would be
+    /// needed to distinguish outliers from slow-but-valid runs; until
+    /// then, the detector stays silent.
+    static var adversarialFixture: RunRecord {
+        ContractRecord.make(
+            rendered: "a long, thoughtful response",
+            raw: "a long, thoughtful response",
+            phase: "done",
+            totalMs: 55_000
+        )
+    }
+}
+
+final class TimeoutContractTests: XCTestCase {
+    func test_positive() {
+        DetectorContractAsserter.assertPositive(TimeoutContract.self)
+    }
+    func test_negative() {
+        DetectorContractAsserter.assertNegative(TimeoutContract.self)
+    }
+    func test_boundary() {
+        DetectorContractAsserter.assertBoundary(TimeoutContract.self)
+    }
+    func test_adversarial() {
+        DetectorContractAsserter.assertAdversarial(TimeoutContract.self)
     }
 }


### PR DESCRIPTION
## Summary

Backfills the seven detectors enumerated in the original fuzzer design
(issue #489). Each one is tied to a real-bug commit, ships at `.flaky`
severity, and carries a four-case `DetectorContract` fixture set
(positive, negative, boundary, adversarial) per the pattern that landed
in #539.

| Detector | Inspired by |
|---|---|
| `TemplateTokenLeakDetector` | `c9cac45` — Phi-4 detected as ChatML |
| `MemoryGrowthDetector` | `04c3f4f` — iOS jetsam |
| `KVCollisionDetector` | `18710d2` — decode-after-stop |
| `EmptyVisibleAfterThinkDetector` | `0d3c206` — `hasVisibleContent` bug |
| `RaceStallDetector` | `8d6b013` — stop-while-decoding races |
| `ContextExhaustionSilentDetector` | `e9ba9d1` — context-exhausted misfire |
| `TimeoutDetector` | generic anomaly catch-all |

All seven are appended to `DetectorRegistry.all` (existing order preserved).

### Stubbed positives (missing record fields)

Three detectors ship with scoped TODOs because the fields they need
are not on `RunRecord` today:

- **MemoryGrowth** — growth-budget branch is disabled. The error-string
  branch (memory/OOM/jetsam needle) is always enabled. Needs a
  per-model memory budget field on `ModelSnapshot`/`ConfigSnapshot`.
- **ContextExhaustionSilent** — the false-trigger guard
  (`promptTokens < contextLimit / 2`) is disabled; for now any
  `InferenceError.contextExhausted` fires. Needs a prompt-token
  estimate on the record.
- **Timeout** — ships with a crude `totalMs > 60s` fallback instead of
  the intended rolling-median. `Detector` is a `Sendable` protocol with
  a non-mutating `inspect`, so per-detector window history needs a
  registry-level state slot or a post-run aggregator. Flagged with a
  `// FIXME: needs window history` comment.

All three are called out in the commit message and the detector
docstrings.

## Sabotage evidence

Disabled `TemplateTokenLeakDetector.inspect` (returned `[]`), confirmed
red:

```
/Tests/BaseChatFuzzTests/DetectorContractTests.swift:432: error:
-[BaseChatFuzzTests.TemplateTokenLeakContractTests test_positive] :
XCTAssertFalse failed - TemplateTokenLeakContract positive fixture
must produce at least one finding for detector template-token-leak
Test Case ... test_positive failed (0.010 seconds).
```

Reverted, re-ran — green.

Repeated the cycle for `RaceStallDetector` (second detector sampled):

```
/Tests/BaseChatFuzzTests/DetectorContractTests.swift:712: error:
-[BaseChatFuzzTests.RaceStallContractTests test_positive] :
XCTAssertFalse failed - RaceStallContract positive fixture must produce
at least one finding for detector race-stall
Test Case ... test_positive failed (0.301 seconds).
```

Reverted, re-ran — green.

## Test plan

- [x] `swift test --filter BaseChatFuzzTests --disable-default-traits` — 103 tests, all pass
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 204 tests, all pass
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 833 tests, all pass
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 450 tests, all pass
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 154 tests, all pass
- [x] Sabotage cycle for `TemplateTokenLeakDetector` (red → revert → green)
- [x] Sabotage cycle for `RaceStallDetector` (red → revert → green)

`#538` `BackgroundDownloadIntegrationTests` SIGABRT flake did **not**
hit locally on this run.

## Release Note

**Seven new fuzz detectors** — the harness now covers chat-template leaks, memory growth, KV-collision crashes, empty-visible-after-thinking, race stalls, silent context-exhaustion, and wall-clock timeouts. Each ships at flaky severity against the DetectorContract pattern (#539), with four-case fixtures (positive, negative, boundary, adversarial). Calibration-corpus FP/TP gating is still pending before any detector promotes to confirmed. Closes #489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)