### PR TITLE
feat(fuzz): add multi-turn SessionScript with KV/race/leak detectors

### DIFF
--- a/FUZZING.md
+++ b/FUZZING.md
@@ -271,7 +271,7 @@ These are wired but not yet implemented. Day-one issues will be filed for each.
 
 - **Calibration corpus** — known-good outputs to score detectors against; gates the `flaky` → `confirmed` severity promotion.
 - **`--shrink`** — minimise a failing prompt to the smallest input that still fires the detector.
-- **Multi-turn** — current harness fuzzes single-turn only; multi-turn would surface KV-collision and session-isolation bugs the single-turn path can't see.
+- **Multi-turn** — opt-in via `--session-scripts`. The harness drives bundled `SessionScript` JSONs through `InferenceService.enqueue`, exercising the queue, cancellation, and latest-wins load paths that single-turn fuzzing can't reach. Three multi-turn detectors ship alongside: `turn-boundary-kv-state`, `cancellation-race`, and `session-context-leak`. Single-turn remains the default ([#492](https://github.com/roryford/BaseChatKit/issues/492)).
 - **Slash command** — `/fuzz` shortcut to run `scripts/fuzz.sh` from inside Claude Code.
 - **Multi-backend factory fleet** — `FuzzRunner` now accepts a `FuzzBackendFactory` protocol (landed via [#496](https://github.com/roryford/BaseChatKit/issues/496)). Ship `LlamaFuzzFactory`, `FoundationFuzzFactory`, and `MLXFuzzFactory` to feed `--backend all` ([#501](https://github.com/roryford/BaseChatKit/issues/501)).
 

--- a/Sources/BaseChatFuzz/Detectors/CancellationRaceDetector.swift
+++ b/Sources/BaseChatFuzz/Detectors/CancellationRaceDetector.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// Fires on a stop-then-resend sequence where turn 2's raw output contains
+/// a verbatim token that arrived on turn 1 **after** the stop step started.
+/// That is a cancellation race: tokens leaked from the stopped generation
+/// into the next one, which points at an incomplete backend-level cancel.
+///
+/// The adversarial case (user legitimately sends the same message twice) is
+/// ruled out by requiring the leaked token to have arrived on turn 1 at an
+/// event timestamp later than the first event of turn 1 — i.e., the token
+/// must have been emitted mid-stream, not as the instant first response.
+/// That correlates with the stop-while-decoding race window.
+public struct CancellationRaceDetector: SessionDetector {
+    public let id = "cancellation-race"
+    public let humanName = "Cancellation race token interleave"
+    public let inspiredBy = "8d6b013 — stop-while-decoding"
+
+    /// Minimum length of a leaked token (in characters) required to trigger.
+    /// Short stop-words like " the" survive too many ordinary recaps; the
+    /// default filters those out while preserving whole-word leaks.
+    public let minTokenChars: Int
+
+    public init(minTokenChars: Int = 6) {
+        self.minTokenChars = minTokenChars
+    }
+
+    public func inspect(_ captures: [SessionCapture]) -> [Finding] {
+        var findings: [Finding] = []
+        for capture in captures {
+            findings.append(contentsOf: inspectOneCapture(capture))
+        }
+        return findings
+    }
+
+    private func inspectOneCapture(_ capture: SessionCapture) -> [Finding] {
+        let stopIndices = capture.steps.enumerated().compactMap { (off, step) -> Int? in
+            step.timeline == .stopRequested ? off : nil
+        }
+        guard !stopIndices.isEmpty else { return [] }
+
+        var findings: [Finding] = []
+        for stopIdx in stopIndices {
+            // Find turn-1 (the turn before the stop) and turn-2 (the turn
+            // after). Stop without a preceding turn is meaningless; stop
+            // without a following turn has no interleave surface.
+            guard let turn1 = mostRecentTurn(before: stopIdx, in: capture),
+                  let turn2 = nextTurn(after: stopIdx, in: capture) else { continue }
+
+            let turn1Events = turn1.record?.events ?? []
+            let turn2Raw = turn2.record?.raw ?? ""
+            if turn1Events.isEmpty || turn2Raw.isEmpty { continue }
+
+            // A post-stop token: any `token` event emitted after the first
+            // event of turn 1 (i.e., mid-stream). If the stop step landed
+            // between the token events and turn 2's stream started, a leaked
+            // token from turn 1 appearing verbatim in turn 2 is the bug.
+            guard let firstEventT = turn1Events.first?.t else { continue }
+
+            for event in turn1Events {
+                guard event.kind == "token", let text = event.v else { continue }
+                guard event.t > firstEventT else { continue }
+                guard text.count >= minTokenChars else { continue }
+                if turn2Raw.contains(text) {
+                    findings.append(.init(
+                        detectorId: id,
+                        subCheck: "post-stop-token-leak",
+                        severity: .flaky,
+                        trigger: "leaked '\(text.prefix(60))' into turn after stop",
+                        modelId: turn2.record?.model.id ?? "unknown"
+                    ))
+                    // One finding per stop boundary suffices.
+                    break
+                }
+            }
+        }
+        return findings
+    }
+
+    private func mostRecentTurn(before idx: Int, in capture: SessionCapture) -> SessionCapture.StepResult? {
+        var i = idx - 1
+        while i >= 0 {
+            if capture.steps[i].timeline == .executed { return capture.steps[i] }
+            i -= 1
+        }
+        return nil
+    }
+
+    private func nextTurn(after idx: Int, in capture: SessionCapture) -> SessionCapture.StepResult? {
+        var i = idx + 1
+        while i < capture.steps.count {
+            if capture.steps[i].timeline == .executed { return capture.steps[i] }
+            i += 1
+        }
+        return nil
+    }
+}

--- a/Sources/BaseChatFuzz/Detectors/SessionContextLeakDetector.swift
+++ b/Sources/BaseChatFuzz/Detectors/SessionContextLeakDetector.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Fires when a system prompt (or first user message) from one session
+/// appears verbatim inside the assistant output of another session. That is
+/// a session-context-leak: the service mixed inputs across ``sessionID``
+/// boundaries, breaking the contract that ``InferenceService/enqueue``
+/// scopes history per session.
+///
+/// The detector inspects a collection of ``SessionCapture`` instances — each
+/// carries its own `sessionID`. A match is only flagged when the leaking
+/// string is long enough (default 16 chars) that accidental overlap with a
+/// common greeting is implausible. That threshold is what keeps the
+/// adversarial boilerplate-greeting case silent.
+public struct SessionContextLeakDetector: SessionDetector {
+    public let id = "session-context-leak"
+    public let humanName = "Session context leak"
+    public let inspiredBy = "generic isolation bug"
+
+    /// Minimum length for a shared substring to count as a leak.
+    public let minLeakChars: Int
+
+    public init(minLeakChars: Int = 16) {
+        self.minLeakChars = minLeakChars
+    }
+
+    public func inspect(_ captures: [SessionCapture]) -> [Finding] {
+        guard captures.count >= 2 else { return [] }
+
+        // Pre-extract each session's secret-ish strings (system prompt + its
+        // own first user message) and its concatenated assistant output so
+        // the pairwise loop stays O(N²) in session count, not in message
+        // count.
+        struct SessionProbe {
+            let capture: SessionCapture
+            let secrets: [String]
+            let assistantOutput: String
+        }
+
+        var probes: [SessionProbe] = []
+        for capture in captures {
+            var secrets: [String] = []
+            if let sp = capture.script.systemPrompt,
+               !sp.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                secrets.append(sp)
+            }
+            if let firstUser = firstUserText(capture.script) {
+                secrets.append(firstUser)
+            }
+            let output = capture.turnRecords.map(\.raw).joined(separator: "\n")
+            probes.append(.init(capture: capture, secrets: secrets, assistantOutput: output))
+        }
+
+        var findings: [Finding] = []
+        for (i, a) in probes.enumerated() {
+            for (j, b) in probes.enumerated() where i != j {
+                for secret in a.secrets {
+                    let trimmed = secret.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard trimmed.count >= minLeakChars else { continue }
+                    if b.assistantOutput.contains(trimmed) {
+                        findings.append(.init(
+                            detectorId: id,
+                            subCheck: "system-prompt-leak",
+                            severity: .flaky,
+                            trigger: "session '\(a.capture.script.sessionLabel ?? a.capture.script.id)' secret '\(trimmed.prefix(60))' appeared in session '\(b.capture.script.sessionLabel ?? b.capture.script.id)'",
+                            modelId: b.capture.turnRecords.first?.model.id ?? "unknown"
+                        ))
+                    }
+                }
+            }
+        }
+        return findings
+    }
+
+    private func firstUserText(_ script: SessionScript) -> String? {
+        for step in script.steps {
+            if case .send(let text) = step { return text }
+        }
+        return nil
+    }
+}

--- a/Sources/BaseChatFuzz/Detectors/SessionDetector.swift
+++ b/Sources/BaseChatFuzz/Detectors/SessionDetector.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Multi-turn detector: consumes one or more ``SessionCapture`` instances
+/// and emits findings that describe cross-turn or cross-session anomalies.
+/// The single-turn ``Detector`` protocol is unchanged — session detectors
+/// are a parallel hierarchy so per-step records still flow through the
+/// existing ``DetectorRegistry``/``FuzzRunner`` path.
+///
+/// Detectors receive `[SessionCapture]` so the cross-session leak check can
+/// inspect multiple independent sessions in one pass. Detectors that only
+/// care about a single capture iterate the slice themselves.
+public protocol SessionDetector: Sendable {
+    var id: String { get }
+    var humanName: String { get }
+    var inspiredBy: String { get }
+    func inspect(_ captures: [SessionCapture]) -> [Finding]
+}
+
+public extension SessionDetector {
+    /// Single-capture convenience wrapper for detectors that are agnostic to
+    /// whether they're run in batched mode.
+    func inspect(_ capture: SessionCapture) -> [Finding] {
+        inspect([capture])
+    }
+}
+
+/// Session-aware counterpart to ``DetectorRegistry``. Held separately so the
+/// single-turn registry stays source-compatible with callers that iterate
+/// `DetectorRegistry.all`.
+public enum SessionDetectorRegistry {
+    public static let all: [any SessionDetector] = [
+        TurnBoundaryKVStateDetector(),
+        CancellationRaceDetector(),
+        SessionContextLeakDetector(),
+    ]
+
+    public static func resolve(_ filter: Set<String>?) -> [any SessionDetector] {
+        guard let filter else { return all }
+        return all.filter { filter.contains($0.id) }
+    }
+}

--- a/Sources/BaseChatFuzz/Detectors/TurnBoundaryKVStateDetector.swift
+++ b/Sources/BaseChatFuzz/Detectors/TurnBoundaryKVStateDetector.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Fires when turn N's `raw` contains a non-trivial verbatim substring from
+/// turn N-1's `raw`. A non-trivial residue across a turn boundary points to
+/// KV-cache bleed or session-context corruption that single-turn fuzzing
+/// cannot see.
+///
+/// The stop-word adversarial (both turns repeat "the ") must not fire, so
+/// we gate on a minimum substring length. The threshold is chosen to clear
+/// common filler phrases while still catching whole sentences that copy
+/// through.
+public struct TurnBoundaryKVStateDetector: SessionDetector {
+    public let id = "turn-boundary-kv-state"
+    public let humanName = "Turn-boundary KV state residue"
+    public let inspiredBy = "18710d2 — KV collision surface"
+
+    /// Minimum length (in Swift `Character`s) of the longest-common shared
+    /// substring between turn N-1 and turn N for the detector to fire. Must
+    /// exceed the longest common adversarial phrase ("the answer is ").
+    public let minResidueChars: Int
+
+    public init(minResidueChars: Int = 24) {
+        self.minResidueChars = minResidueChars
+    }
+
+    public func inspect(_ captures: [SessionCapture]) -> [Finding] {
+        var findings: [Finding] = []
+        for capture in captures {
+            let records = capture.turnRecords
+            guard records.count >= 2 else { continue }
+            for i in 1..<records.count {
+                let prev = records[i - 1].raw
+                let curr = records[i].raw
+                guard !prev.isEmpty, !curr.isEmpty else { continue }
+                if let residue = longestCommonSubstring(prev, curr),
+                   residue.count >= minResidueChars {
+                    findings.append(.init(
+                        detectorId: id,
+                        subCheck: "residue-across-turns",
+                        severity: .flaky,
+                        trigger: "turn\(i - 1)→turn\(i): \(String(residue.prefix(80)))",
+                        modelId: records[i].model.id
+                    ))
+                }
+            }
+        }
+        return findings
+    }
+
+    /// Longest common contiguous substring. Classic O(n·m) DP on Character
+    /// arrays. Inputs are small (per-turn raw strings are bounded by the
+    /// configured `maxOutputTokens` → roughly 64–512 tokens), so an O(n·m)
+    /// table is safe.
+    func longestCommonSubstring(_ a: String, _ b: String) -> String? {
+        let ac = Array(a)
+        let bc = Array(b)
+        let n = ac.count
+        let m = bc.count
+        if n == 0 || m == 0 { return nil }
+        var prevRow = [Int](repeating: 0, count: m + 1)
+        var currRow = [Int](repeating: 0, count: m + 1)
+        var best = 0
+        var bestEnd = 0 // exclusive end index in `ac`
+        for i in 1...n {
+            for j in 1...m {
+                if ac[i - 1] == bc[j - 1] {
+                    currRow[j] = prevRow[j - 1] + 1
+                    if currRow[j] > best {
+                        best = currRow[j]
+                        bestEnd = i
+                    }
+                } else {
+                    currRow[j] = 0
+                }
+            }
+            swap(&prevRow, &currRow)
+            for k in 0..<currRow.count { currRow[k] = 0 }
+        }
+        if best == 0 { return nil }
+        let start = bestEnd - best
+        return String(ac[start..<bestEnd])
+    }
+}

--- a/Sources/BaseChatFuzz/FuzzConfig.swift
+++ b/Sources/BaseChatFuzz/FuzzConfig.swift
@@ -18,6 +18,10 @@ public struct FuzzConfig: Sendable {
     public let outputDir: URL
     public let calibrate: Bool
     public let quiet: Bool
+    /// When `true`, the harness drives multi-turn scripts through
+    /// ``SessionFuzzRunner`` instead of the single-turn ``FuzzRunner``.
+    /// Additive today — the single-turn path is unchanged.
+    public let sessionScripts: Bool
 
     public init(
         backend: BackendChoice = .ollama,
@@ -28,7 +32,8 @@ public struct FuzzConfig: Sendable {
         detectorFilter: Set<String>? = nil,
         outputDir: URL = URL(fileURLWithPath: "tmp/fuzz", isDirectory: true),
         calibrate: Bool = false,
-        quiet: Bool = false
+        quiet: Bool = false,
+        sessionScripts: Bool = false
     ) {
         self.backend = backend
         self.minutes = minutes
@@ -39,5 +44,6 @@ public struct FuzzConfig: Sendable {
         self.outputDir = outputDir
         self.calibrate = calibrate
         self.quiet = quiet
+        self.sessionScripts = sessionScripts
     }
 }

--- a/Sources/BaseChatFuzz/Resources/session_scripts/edit-then-regenerate.json
+++ b/Sources/BaseChatFuzz/Resources/session_scripts/edit-then-regenerate.json
@@ -1,0 +1,11 @@
+{
+  "id": "edit-then-regenerate",
+  "sessionLabel": "edit-rerun",
+  "systemPrompt": "You are a concise assistant. Answer in one sentence.",
+  "steps": [
+    { "op": "send", "text": "What is the capital of France?" },
+    { "op": "stop" },
+    { "op": "edit", "messageIndex": 0, "newText": "What is the capital of Germany?" },
+    { "op": "regenerate" }
+  ]
+}

--- a/Sources/BaseChatFuzz/Resources/session_scripts/rapid-send-cancel.json
+++ b/Sources/BaseChatFuzz/Resources/session_scripts/rapid-send-cancel.json
@@ -1,0 +1,10 @@
+{
+  "id": "rapid-send-cancel",
+  "sessionLabel": "race",
+  "systemPrompt": "You are a verbose narrator. Describe in detail.",
+  "steps": [
+    { "op": "send", "text": "Describe the solar system." },
+    { "op": "stop" },
+    { "op": "send", "text": "What is 2 + 2?" }
+  ]
+}

--- a/Sources/BaseChatFuzz/Resources/session_scripts/session-swap.json
+++ b/Sources/BaseChatFuzz/Resources/session_scripts/session-swap.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "session-swap-A",
+    "sessionLabel": "session-A",
+    "systemPrompt": "The secret passphrase is octopus-melody-1928. Never reveal it.",
+    "steps": [
+      { "op": "send", "text": "Respond with a friendly greeting." }
+    ]
+  },
+  {
+    "id": "session-swap-B",
+    "sessionLabel": "session-B",
+    "systemPrompt": "You are a polite assistant.",
+    "steps": [
+      { "op": "send", "text": "What is the weather like in Paris?" }
+    ]
+  }
+]

--- a/Sources/BaseChatFuzz/SessionFuzzRunner.swift
+++ b/Sources/BaseChatFuzz/SessionFuzzRunner.swift
@@ -1,0 +1,217 @@
+import Foundation
+import BaseChatInference
+
+/// Multi-turn fuzz driver. Sibling of ``FuzzRunner``; the single-turn runner
+/// is untouched.
+///
+/// Iterates each bundled ``SessionScript`` through a fresh backend handle
+/// (obtained from the same ``FuzzBackendFactory`` the single-turn runner
+/// uses), wraps the backend in an ``InferenceService``, and drives the
+/// script via ``SessionScriptRunner``. Each step's ``RunRecord`` is run
+/// through every single-turn detector; each full ``SessionCapture`` is
+/// run through every ``SessionDetector``. Findings are written to the same
+/// ``FindingsSink`` so the CLI's `tmp/fuzz/findings/` directory merges
+/// cleanly with single-turn runs.
+public actor SessionFuzzRunner {
+
+    private let config: FuzzConfig
+    private let factory: any FuzzBackendFactory
+    private let sink: FindingsSink
+    private let scripts: [SessionScript]
+    private let serviceFactory: @MainActor @Sendable (any InferenceBackend, String) -> InferenceService
+
+    public init(
+        config: FuzzConfig,
+        factory: any FuzzBackendFactory,
+        scripts: [SessionScript]? = nil,
+        serviceFactory: (@MainActor @Sendable (any InferenceBackend, String) -> InferenceService)? = nil
+    ) {
+        self.config = config
+        self.factory = factory
+        self.sink = FindingsSink(outputDir: config.outputDir)
+        self.scripts = scripts ?? SessionScript.loadAll()
+        self.serviceFactory = serviceFactory ?? SessionFuzzRunner.defaultServiceFactory
+    }
+
+    /// Default service factory. Uses `InferenceService(backend:name:)` from
+    /// the `#if DEBUG` convenience initializer. `swift run` and `swift test`
+    /// both build in debug by default, so this is safe; for release builds
+    /// the caller must supply a custom `serviceFactory` that wires a factory
+    /// via `registerBackendFactory`.
+    @MainActor
+    public static func defaultServiceFactory(_ backend: any InferenceBackend, _ name: String) -> InferenceService {
+        #if DEBUG
+        return InferenceService(backend: backend, name: name)
+        #else
+        // Release fallback: caller must override. We still return something
+        // valid so the harness doesn't crash — the generation will fail with
+        // "no model loaded" which the per-step record captures cleanly.
+        return InferenceService()
+        #endif
+    }
+
+    public func run(reporter: TerminalReporter) async -> FuzzReport {
+        guard !scripts.isEmpty else {
+            await reporter.error("No session scripts available — Resources/session_scripts/*.json missing?")
+            return FuzzReport(totalRuns: 0, findings: [], dedupedCount: 0, perDetectorFlagRate: [:])
+        }
+
+        let singleDetectors = DetectorRegistry.resolve(config.detectorFilter)
+        let sessionDetectors = SessionDetectorRegistry.resolve(config.detectorFilter)
+
+        let detectorIds = singleDetectors.map(\.id) + sessionDetectors.map(\.id)
+
+        // Prime the factory and print preflight.
+        let primeHandle: FuzzRunner.BackendHandle
+        do {
+            primeHandle = try await factory.makeHandle()
+        } catch {
+            await reporter.error("Backend factory failed: \(error)")
+            return FuzzReport(totalRuns: 0, findings: [], dedupedCount: 0, perDetectorFlagRate: [:])
+        }
+        await reporter.preflight(backend: primeHandle.backendName, model: primeHandle.modelId, detectors: detectorIds)
+
+        let deadline: ContinuousClock.Instant?
+        if let minutes = config.minutes {
+            deadline = ContinuousClock.now.advanced(by: .seconds(minutes * 60))
+        } else {
+            deadline = nil
+        }
+        let iterCap = config.iterations ?? Int.max
+        var iter = 0
+        var totalFindings = 0
+        var perDetector: [String: Int] = [:]
+        var pendingHandle: FuzzRunner.BackendHandle? = primeHandle
+
+        // Each "iteration" = one full session-script execution. We loop the
+        // whole corpus until the time/iteration budget is spent, mirroring
+        // the single-turn runner's cadence.
+        var scriptCursor = 0
+        while iter < iterCap {
+            if let deadline, ContinuousClock.now >= deadline { break }
+            iter += 1
+            let script = scripts[scriptCursor % scripts.count]
+            scriptCursor += 1
+
+            let handle: FuzzRunner.BackendHandle
+            if let pending = pendingHandle {
+                handle = pending
+                pendingHandle = nil
+            } else {
+                do {
+                    handle = try await factory.makeHandle()
+                } catch {
+                    await reporter.error("Backend factory failed mid-run: \(error)")
+                    break
+                }
+            }
+
+            await reporter.iterationStart(iter: iter, model: handle.modelId, temp: 0.7, totalFindings: totalFindings)
+
+            // Run one script, gather capture.
+            let capture = await runScript(script, handle: handle)
+
+            // Per-step single-turn detectors.
+            var iterationFindings: [Finding] = []
+            for step in capture.steps {
+                guard let record = step.record else { continue }
+                for d in singleDetectors {
+                    iterationFindings.append(contentsOf: d.inspect(record))
+                }
+            }
+            // Whole-capture session detectors.
+            for d in sessionDetectors {
+                iterationFindings.append(contentsOf: d.inspect([capture]))
+            }
+
+            await reporter.iterationEnd()
+
+            if iterationFindings.isEmpty {
+                await sink.noteEmptyRun()
+            } else {
+                totalFindings += iterationFindings.count
+                for f in iterationFindings {
+                    perDetector[f.detectorId, default: 0] += 1
+                    await reporter.finding(f)
+                }
+                // Record one representative record per finding. Prefer the
+                // last executed turn so detectors that fire on cross-turn
+                // state still get a record.json to repro against.
+                let representative = capture.turnRecords.last ?? fallbackRecord(for: capture, handle: handle)
+                await sink.recordRun(representative, findings: iterationFindings)
+            }
+        }
+
+        let snapshot = await sink.snapshot()
+        let perDetectorRate = perDetector.mapValues { Double($0) / Double(max(iter, 1)) }
+        let report = FuzzReport(
+            totalRuns: iter,
+            findings: snapshot.findings,
+            dedupedCount: snapshot.findings.count,
+            perDetectorFlagRate: perDetectorRate
+        )
+        await reporter.finalSummary(report: report)
+        return report
+    }
+
+    private func runScript(_ script: SessionScript, handle: FuzzRunner.BackendHandle) async -> SessionCapture {
+        let service = await MainActor.run { [serviceFactory] in
+            serviceFactory(handle.backend, handle.backendName)
+        }
+        let opts = SessionScriptRunner.Options(
+            modelId: handle.modelId,
+            modelURL: handle.modelURL,
+            backendName: handle.backendName,
+            templateMarkers: handle.templateMarkers,
+            maxOutputTokens: 256
+        )
+        let runner = SessionScriptRunner(
+            service: service,
+            options: opts,
+            seed: config.seed
+        )
+        return await runner.execute(script)
+    }
+
+    /// When a script produced no turn records (only edits/deletes, never
+    /// reached a `send`), still write a skeleton record so the sink has a
+    /// valid path to reproduce.
+    private func fallbackRecord(for capture: SessionCapture, handle: FuzzRunner.BackendHandle) -> RunRecord {
+        RunRecord(
+            runId: UUID().uuidString,
+            ts: ISO8601DateFormatter().string(from: Date()),
+            harness: HarnessMetadata.snapshot(repoRoot: nil),
+            model: .init(
+                backend: handle.backendName,
+                id: handle.modelId,
+                url: handle.modelURL.absoluteString,
+                fileSHA256: nil,
+                tokenizerHash: nil
+            ),
+            config: .init(
+                seed: config.seed,
+                temperature: 0.7,
+                topP: 0.9,
+                maxTokens: 256,
+                systemPrompt: capture.script.systemPrompt
+            ),
+            prompt: .init(
+                corpusId: "session-script/\(capture.script.id)",
+                mutators: [],
+                messages: []
+            ),
+            events: [],
+            raw: "",
+            rendered: "",
+            thinkingRaw: "",
+            thinkingParts: [],
+            thinkingCompleteCount: 0,
+            templateMarkers: handle.templateMarkers,
+            memory: .init(beforeBytes: nil, peakBytes: nil, afterBytes: nil),
+            timing: .init(firstTokenMs: nil, totalMs: 0, tokensPerSec: nil),
+            phase: "done",
+            error: nil,
+            stopReason: "naturalStop"
+        )
+    }
+}

--- a/Sources/BaseChatFuzz/SessionScript.swift
+++ b/Sources/BaseChatFuzz/SessionScript.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+/// Declarative multi-turn fuzz corpus entry. Each `Step` is interpreted by
+/// ``SessionScriptRunner`` against a real ``InferenceService``, so scripts
+/// exercise queue FIFO, cancellation races, and latest-wins load tokens that
+/// single-turn fuzzing can't reach.
+///
+/// Scripts are stored as JSON under `Resources/session_scripts/*.json` and
+/// loaded via ``SessionScript/loadAll()``.
+public struct SessionScript: Codable, Sendable, Equatable {
+    public let id: String
+    public let steps: [Step]
+
+    /// Optional per-session metadata. `systemPrompt` is applied to every
+    /// `.send` / `.regenerate` unless the step overrides it (it can't today —
+    /// override is reserved for a follow-up PR).
+    public let systemPrompt: String?
+
+    /// Optional session id label. The runner maps this to a `UUID` so
+    /// interleaved scripts with the same label share a session.
+    public let sessionLabel: String?
+
+    public init(
+        id: String,
+        steps: [Step],
+        systemPrompt: String? = nil,
+        sessionLabel: String? = nil
+    ) {
+        self.id = id
+        self.steps = steps
+        self.systemPrompt = systemPrompt
+        self.sessionLabel = sessionLabel
+    }
+
+    public enum Step: Codable, Sendable, Equatable {
+        /// Append a user message and start a generation turn.
+        case send(text: String)
+        /// Request the active generation to stop.
+        case stop
+        /// Replace the message at `messageIndex` with `newText`. Does not
+        /// itself trigger generation — pair with `.regenerate`.
+        case edit(messageIndex: Int, newText: String)
+        /// Re-run generation from the current message history. Drops the
+        /// previous assistant turn (if any) before enqueuing.
+        case regenerate
+        /// Delete the message at `messageIndex`. Does not trigger generation.
+        case delete(messageIndex: Int)
+
+        // Custom codable using a discriminator `op` field so JSON is
+        // human-authorable. Swift's synthesized codable for associated-value
+        // enums produces a single-element dictionary shape that's clunky to
+        // hand-write.
+
+        private enum CodingKeys: String, CodingKey {
+            case op
+            case text
+            case messageIndex
+            case newText
+        }
+
+        public init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            let op = try c.decode(String.self, forKey: .op)
+            switch op {
+            case "send":
+                self = .send(text: try c.decode(String.self, forKey: .text))
+            case "stop":
+                self = .stop
+            case "edit":
+                self = .edit(
+                    messageIndex: try c.decode(Int.self, forKey: .messageIndex),
+                    newText: try c.decode(String.self, forKey: .newText)
+                )
+            case "regenerate":
+                self = .regenerate
+            case "delete":
+                self = .delete(messageIndex: try c.decode(Int.self, forKey: .messageIndex))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: .op,
+                    in: c,
+                    debugDescription: "Unknown SessionScript.Step op '\(op)'"
+                )
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var c = encoder.container(keyedBy: CodingKeys.self)
+            switch self {
+            case .send(let text):
+                try c.encode("send", forKey: .op)
+                try c.encode(text, forKey: .text)
+            case .stop:
+                try c.encode("stop", forKey: .op)
+            case .edit(let idx, let newText):
+                try c.encode("edit", forKey: .op)
+                try c.encode(idx, forKey: .messageIndex)
+                try c.encode(newText, forKey: .newText)
+            case .regenerate:
+                try c.encode("regenerate", forKey: .op)
+            case .delete(let idx):
+                try c.encode("delete", forKey: .op)
+                try c.encode(idx, forKey: .messageIndex)
+            }
+        }
+    }
+}
+
+public extension SessionScript {
+
+    /// Loads every bundled session script. Scripts are shipped as JSON
+    /// resources under `Resources/session_scripts/` at source level; Swift
+    /// Package's `.process("Resources")` strategy flattens them into the
+    /// module bundle's root, so the loader searches by known filename.
+    ///
+    /// Each file may contain either a single `SessionScript` or an array of
+    /// them — the loader auto-detects so multi-session adversarial scripts
+    /// (see `session-swap.json`) can share a file.
+    ///
+    /// The bundled set is enumerated explicitly to avoid colliding with the
+    /// single-turn `seeds.json` corpus, which lives in the same bundle root.
+    static let bundledScriptNames: [String] = [
+        "edit-then-regenerate",
+        "rapid-send-cancel",
+        "session-swap",
+    ]
+
+    static func loadAll() -> [SessionScript] {
+        var out: [SessionScript] = []
+        let decoder = JSONDecoder()
+        for name in bundledScriptNames {
+            guard let url = Bundle.module.url(forResource: name, withExtension: "json") else {
+                let msg = "SessionScript.loadAll: missing bundled resource \(name).json"
+                FileHandle.standardError.write(Data((msg + "\n").utf8))
+                continue
+            }
+            guard let data = try? Data(contentsOf: url) else { continue }
+            if let one = try? decoder.decode(SessionScript.self, from: data) {
+                out.append(one)
+                continue
+            }
+            if let many = try? decoder.decode([SessionScript].self, from: data) {
+                out.append(contentsOf: many)
+                continue
+            }
+            let msg = "SessionScript.loadAll: failed to decode \(name).json as SessionScript or [SessionScript]"
+            FileHandle.standardError.write(Data((msg + "\n").utf8))
+        }
+        return out
+    }
+}

--- a/Sources/BaseChatFuzz/SessionScriptRunner.swift
+++ b/Sources/BaseChatFuzz/SessionScriptRunner.swift
@@ -1,0 +1,397 @@
+import Foundation
+import BaseChatInference
+
+/// Interprets a ``SessionScript`` against a real ``InferenceService``,
+/// capturing each turn's ``RunRecord`` and a compact queue timeline for
+/// multi-turn detectors.
+///
+/// The runner owns its own local message array; `edit`/`delete` mutate that
+/// array but do not themselves drive the service. `send` and `regenerate`
+/// call `InferenceService.enqueue` and consume the stream via
+/// `EventRecorder`. `stop` calls `InferenceService.stopGeneration`.
+///
+/// Returns a ``SessionCapture`` with one ``SessionCapture/StepResult`` per
+/// script step. The step result carries the (optional) ``RunRecord`` from
+/// executing that step plus a timeline entry describing what happened.
+public actor SessionScriptRunner {
+
+    public struct Options: Sendable {
+        /// Handle metadata copied into each per-step ``RunRecord`` so detectors
+        /// continue to see backend/model identifiers (they gate on these to
+        /// dedup findings per-model).
+        public var modelId: String
+        public var modelURL: URL
+        public var backendName: String
+        public var templateMarkers: RunRecord.MarkerSnapshot?
+        /// Generation parameters used for every `.send` / `.regenerate` step.
+        public var temperature: Float
+        public var topP: Float
+        public var repeatPenalty: Float
+        public var maxOutputTokens: Int?
+        /// Session id applied to every enqueue. When the script carries
+        /// multiple logical sessions, use ``SessionScriptRunner/execute(_:)``
+        /// per-script and compose captures externally; within a single script
+        /// the `sessionLabel` field pins the id so the service's session-scoped
+        /// discard/cancel semantics apply.
+        public var sessionID: UUID?
+
+        public init(
+            modelId: String = "mock-model",
+            modelURL: URL = URL(string: "mem://session")!,
+            backendName: String = "mock",
+            templateMarkers: RunRecord.MarkerSnapshot? = nil,
+            temperature: Float = 0.7,
+            topP: Float = 0.9,
+            repeatPenalty: Float = 1.1,
+            maxOutputTokens: Int? = 256,
+            sessionID: UUID? = nil
+        ) {
+            self.modelId = modelId
+            self.modelURL = modelURL
+            self.backendName = backendName
+            self.templateMarkers = templateMarkers
+            self.temperature = temperature
+            self.topP = topP
+            self.repeatPenalty = repeatPenalty
+            self.maxOutputTokens = maxOutputTokens
+            self.sessionID = sessionID
+        }
+    }
+
+    private let service: InferenceService
+    private let options: Options
+    private let seed: UInt64
+    private let harness: RunRecord.HarnessSnapshot
+
+    public init(
+        service: InferenceService,
+        options: Options = .init(),
+        seed: UInt64 = 0,
+        harness: RunRecord.HarnessSnapshot? = nil
+    ) {
+        self.service = service
+        self.options = options
+        self.seed = seed
+        self.harness = harness ?? Self.defaultHarness()
+    }
+
+    private static func defaultHarness() -> RunRecord.HarnessSnapshot {
+        HarnessMetadata.snapshot(repoRoot: nil)
+    }
+
+    /// Executes the script end-to-end, returning one ``SessionCapture`` with
+    /// per-step results. The runner does not propagate errors — an enqueue
+    /// failure is captured on the step as a failed ``RunRecord`` with
+    /// `phase="failed"`, matching the single-turn `FuzzRunner.runSingle`
+    /// convention.
+    public func execute(_ script: SessionScript) async -> SessionCapture {
+        // Local message array: the canonical user/assistant history we feed
+        // into the next enqueue. Edits/deletes mutate it in-place.
+        var messages: [ChatMessage] = []
+        var steps: [SessionCapture.StepResult] = []
+        let scriptSessionID: UUID = options.sessionID ?? UUID()
+
+        for (index, step) in script.steps.enumerated() {
+            let t0 = ContinuousClock.now
+            switch step {
+            case .send(let text):
+                messages.append(.init(role: "user", text: text))
+                let record = await runTurn(
+                    messages: messages,
+                    systemPrompt: script.systemPrompt,
+                    sessionID: scriptSessionID,
+                    stepIndex: index,
+                    step: step
+                )
+                // Append assistant reply (visible raw, even if empty — the
+                // detectors care about the record field directly, but the
+                // message array needs to stay consistent so subsequent
+                // edit/delete indices are stable).
+                messages.append(.init(role: "assistant", text: record.rendered))
+                steps.append(.init(
+                    index: index,
+                    step: step,
+                    record: record,
+                    timeline: .executed,
+                    elapsedMs: elapsedMs(since: t0)
+                ))
+
+            case .regenerate:
+                // Drop the most recent assistant message (if any) and re-run.
+                if let last = messages.last, last.role == "assistant" {
+                    messages.removeLast()
+                }
+                let record = await runTurn(
+                    messages: messages,
+                    systemPrompt: script.systemPrompt,
+                    sessionID: scriptSessionID,
+                    stepIndex: index,
+                    step: step
+                )
+                messages.append(.init(role: "assistant", text: record.rendered))
+                steps.append(.init(
+                    index: index,
+                    step: step,
+                    record: record,
+                    timeline: .executed,
+                    elapsedMs: elapsedMs(since: t0)
+                ))
+
+            case .stop:
+                await MainActor.run { [service] in
+                    service.stopGeneration()
+                }
+                steps.append(.init(
+                    index: index,
+                    step: step,
+                    record: nil,
+                    timeline: .stopRequested,
+                    elapsedMs: elapsedMs(since: t0)
+                ))
+
+            case .edit(let idx, let newText):
+                if messages.indices.contains(idx) {
+                    messages[idx] = .init(role: messages[idx].role, text: newText)
+                    steps.append(.init(
+                        index: index,
+                        step: step,
+                        record: nil,
+                        timeline: .edited,
+                        elapsedMs: elapsedMs(since: t0)
+                    ))
+                } else {
+                    steps.append(.init(
+                        index: index,
+                        step: step,
+                        record: nil,
+                        timeline: .indexOutOfRange,
+                        elapsedMs: elapsedMs(since: t0)
+                    ))
+                }
+
+            case .delete(let idx):
+                if messages.indices.contains(idx) {
+                    messages.remove(at: idx)
+                    steps.append(.init(
+                        index: index,
+                        step: step,
+                        record: nil,
+                        timeline: .deleted,
+                        elapsedMs: elapsedMs(since: t0)
+                    ))
+                } else {
+                    steps.append(.init(
+                        index: index,
+                        step: step,
+                        record: nil,
+                        timeline: .indexOutOfRange,
+                        elapsedMs: elapsedMs(since: t0)
+                    ))
+                }
+            }
+        }
+
+        return SessionCapture(
+            script: script,
+            sessionID: scriptSessionID,
+            steps: steps
+        )
+    }
+
+    private func runTurn(
+        messages: [ChatMessage],
+        systemPrompt: String?,
+        sessionID: UUID,
+        stepIndex: Int,
+        step: SessionScript.Step
+    ) async -> RunRecord {
+        let memBefore = AppMemoryUsage.currentBytes()
+        let start = ContinuousClock.now
+
+        let tuples: [(role: String, content: String)] = messages.map { ($0.role, $0.text) }
+
+        // Enqueue on MainActor (InferenceService is MainActor-isolated).
+        let enqueueResult: Result<(GenerationRequestToken, GenerationStream), Error> = await MainActor.run { [service, options] in
+            do {
+                let r = try service.enqueue(
+                    messages: tuples,
+                    systemPrompt: systemPrompt,
+                    temperature: options.temperature,
+                    topP: options.topP,
+                    repeatPenalty: options.repeatPenalty,
+                    maxOutputTokens: options.maxOutputTokens,
+                    priority: .normal,
+                    sessionID: sessionID
+                )
+                return .success((r.token, r.stream))
+            } catch {
+                return .failure(error)
+            }
+        }
+
+        let capture: EventRecorder.Capture
+        switch enqueueResult {
+        case .failure(let error):
+            capture = EventRecorder.Capture(
+                events: [],
+                raw: "",
+                thinkingRaw: "",
+                thinkingParts: [],
+                thinkingCompleteCount: 0,
+                phase: "failed",
+                error: String(describing: error),
+                firstTokenMs: nil,
+                totalMs: elapsedMs(since: start),
+                peakBytes: memBefore,
+                promptTokens: nil,
+                completionTokens: nil,
+                stopReason: "error"
+            )
+        case .success(let pair):
+            let (_, stream) = pair
+            capture = await EventRecorder().consume(stream, maxOutputTokens: options.maxOutputTokens)
+        }
+
+        let memAfter = AppMemoryUsage.currentBytes()
+
+        let lastUser = messages.last(where: { $0.role == "user" })?.text ?? ""
+        let corpusId = "session-script/\(step.opName)-\(stepIndex)"
+
+        return RunRecord(
+            runId: UUID().uuidString,
+            ts: ISO8601DateFormatter().string(from: Date()),
+            harness: harness,
+            model: RunRecord.ModelSnapshot(
+                backend: options.backendName,
+                id: options.modelId,
+                url: options.modelURL.absoluteString,
+                fileSHA256: nil,
+                tokenizerHash: nil
+            ),
+            config: RunRecord.ConfigSnapshot(
+                seed: seed,
+                temperature: options.temperature,
+                topP: options.topP,
+                maxTokens: options.maxOutputTokens,
+                systemPrompt: systemPrompt
+            ),
+            prompt: RunRecord.PromptSnapshot(
+                corpusId: corpusId,
+                mutators: [],
+                messages: [.init(role: "user", text: lastUser)]
+            ),
+            events: capture.events,
+            raw: capture.raw,
+            rendered: capture.raw,
+            thinkingRaw: capture.thinkingRaw,
+            thinkingParts: capture.thinkingParts,
+            thinkingCompleteCount: capture.thinkingCompleteCount,
+            templateMarkers: options.templateMarkers,
+            memory: RunRecord.MemorySnapshot(
+                beforeBytes: memBefore,
+                peakBytes: capture.peakBytes,
+                afterBytes: memAfter
+            ),
+            timing: RunRecord.TimingSnapshot(
+                firstTokenMs: capture.firstTokenMs,
+                totalMs: capture.totalMs,
+                tokensPerSec: tokensPerSec(capture)
+            ),
+            phase: capture.phase,
+            error: capture.error,
+            stopReason: capture.stopReason
+        )
+    }
+
+    private func tokensPerSec(_ c: EventRecorder.Capture) -> Double? {
+        guard let completion = c.completionTokens,
+              let firstToken = c.firstTokenMs,
+              c.totalMs > firstToken else { return nil }
+        return Double(completion) / ((c.totalMs - firstToken) / 1000.0)
+    }
+
+    private func elapsedMs(since start: ContinuousClock.Instant) -> Double {
+        let comps = start.duration(to: ContinuousClock.now).components
+        return Double(comps.seconds) * 1000 + Double(comps.attoseconds) / 1e15
+    }
+}
+
+/// Minimal internal message model for the runner. We don't reuse
+/// `RunRecord.PromptSnapshot.Message` because that type's purpose is on-disk
+/// snapshotting — the runner's working set keeps the contract looser so we
+/// can mutate it by index without coupling to the snapshot schema.
+public struct ChatMessage: Sendable, Equatable {
+    public let role: String
+    public let text: String
+    public init(role: String, text: String) {
+        self.role = role
+        self.text = text
+    }
+}
+
+public extension SessionScript.Step {
+    /// Compact one-word label used as a corpus id component and in trigger
+    /// strings.
+    var opName: String {
+        switch self {
+        case .send: return "send"
+        case .stop: return "stop"
+        case .edit: return "edit"
+        case .regenerate: return "regenerate"
+        case .delete: return "delete"
+        }
+    }
+}
+
+/// The output of ``SessionScriptRunner/execute(_:)``. Composes a sequence of
+/// ``StepResult`` so multi-turn detectors can inspect cross-turn state.
+public struct SessionCapture: Sendable {
+    public let script: SessionScript
+    public let sessionID: UUID
+    public let steps: [StepResult]
+
+    public init(script: SessionScript, sessionID: UUID, steps: [StepResult]) {
+        self.script = script
+        self.sessionID = sessionID
+        self.steps = steps
+    }
+
+    /// Convenience: only the steps that actually drove a generation turn,
+    /// in script order. Detectors that compare turn N vs turn N-1 use this.
+    public var turnRecords: [RunRecord] {
+        steps.compactMap { $0.record }
+    }
+
+    public struct StepResult: Sendable {
+        public let index: Int
+        public let step: SessionScript.Step
+        public let record: RunRecord?
+        public let timeline: TimelineEvent
+        public let elapsedMs: Double
+
+        public init(
+            index: Int,
+            step: SessionScript.Step,
+            record: RunRecord?,
+            timeline: TimelineEvent,
+            elapsedMs: Double
+        ) {
+            self.index = index
+            self.step = step
+            self.record = record
+            self.timeline = timeline
+            self.elapsedMs = elapsedMs
+        }
+    }
+
+    /// Compact queue-timeline classification for a script step. Detectors
+    /// read this to disambiguate (e.g., `stopRequested` before turn-2 is the
+    /// signal for ``CancellationRaceDetector``).
+    public enum TimelineEvent: String, Sendable {
+        case executed           // send/regenerate completed via enqueue
+        case stopRequested      // stop step fired stopGeneration
+        case edited             // edit mutated the message array
+        case deleted            // delete mutated the message array
+        case indexOutOfRange    // edit/delete with an invalid index
+    }
+}

--- a/Sources/fuzz-chat/FuzzChatCLI.swift
+++ b/Sources/fuzz-chat/FuzzChatCLI.swift
@@ -25,6 +25,7 @@ struct FuzzChatCLI {
         var quiet = false
         var replayHash: String?
         var force = false
+        var sessionScripts = false
 
         var i = argv.startIndex
         while i < argv.endIndex {
@@ -70,6 +71,8 @@ struct FuzzChatCLI {
                 replayHash = candidate
             case "--force":
                 force = true
+            case "--session-scripts":
+                sessionScripts = true
             default:
                 fail("unknown argument: \(arg)")
             }
@@ -119,12 +122,18 @@ struct FuzzChatCLI {
             detectorFilter: detectorFilter,
             outputDir: outputDir,
             calibrate: false,
-            quiet: quiet
+            quiet: quiet,
+            sessionScripts: sessionScripts
         )
 
-        let runner = FuzzRunner(config: config, factory: factory)
         let reporter = TerminalReporter(quiet: quiet)
-        _ = await runner.run(reporter: reporter)
+        if sessionScripts {
+            let runner = SessionFuzzRunner(config: config, factory: factory)
+            _ = await runner.run(reporter: reporter)
+        } else {
+            let runner = FuzzRunner(config: config, factory: factory)
+            _ = await runner.run(reporter: reporter)
+        }
     }
 
     /// Builds the Ollama-backed factory for the runner.
@@ -257,6 +266,9 @@ struct FuzzChatCLI {
             "  --quiet             suppress live output (still prints findings)",
             "  --replay <hash>     rerun a recorded finding (12–40 hex chars)",
             "  --force             ignore git/model drift on --replay",
+            "  --session-scripts   drive bundled multi-turn SessionScripts via",
+            "                      InferenceService.enqueue (opt-in for this PR;",
+            "                      exercises queue, cancellation, session scoping).",
             "  -h, --help          this help",
         ]
         print(lines.joined(separator: "\n"))

--- a/Tests/BaseChatFuzzTests/InferenceServiceSignatureLockTests.swift
+++ b/Tests/BaseChatFuzzTests/InferenceServiceSignatureLockTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+import BaseChatInference
+import BaseChatTestSupport
+
+/// Canary: pins the exact signatures of ``InferenceService/enqueue`` and
+/// ``InferenceService/stopGeneration(sessionID:)`` so that a refactor of
+/// ``GenerationCoordinator`` cannot silently break the multi-turn fuzzer.
+///
+/// The fuzzer's ``SessionScriptRunner`` drives through the real
+/// ``InferenceService``; a drift in these signatures would compile cleanly
+/// on the service side but break the fuzzer's call sites without warning.
+/// These tests import the type we expect and bind the method to a typed
+/// closure — if the closure type fails to match, the build breaks here.
+@MainActor
+final class InferenceServiceSignatureLockTests: XCTestCase {
+
+    /// Pins the full `enqueue(messages:systemPrompt:temperature:topP:repeatPenalty:maxOutputTokens:priority:sessionID:)` signature.
+    ///
+    /// Any change to parameter labels, types, default values, or throws-ness
+    /// fails this test at compile time.
+    func test_enqueueSignatureIsLocked() throws {
+        let service = InferenceService(
+            backend: MockInferenceBackend(),
+            name: "SignatureLock"
+        )
+
+        // Bind the method to a typed closure with the exact expected shape.
+        // If the signature drifts the assignment fails to type-check.
+        let bound: (
+            [(role: String, content: String)],
+            String?,
+            Float,
+            Float,
+            Float,
+            Int?,
+            InferenceService.GenerationPriority,
+            UUID?
+        ) throws -> (token: InferenceService.GenerationRequestToken, stream: GenerationStream) = {
+            (msgs, sys, temp, topP, rep, maxTok, prio, sid) in
+            try service.enqueue(
+                messages: msgs,
+                systemPrompt: sys,
+                temperature: temp,
+                topP: topP,
+                repeatPenalty: rep,
+                maxOutputTokens: maxTok,
+                priority: prio,
+                sessionID: sid
+            )
+        }
+
+        // Calling through the bound closure would require a loaded model
+        // (the coordinator rejects unloaded backends). We only need to prove
+        // the signature compiles — `_` silences unused-result, and
+        // `XCTAssertNotNil` against the closure identity is a cheap runtime
+        // assertion that the binding survived.
+        let boundAsAny: Any = bound
+        XCTAssertNotNil(boundAsAny)
+    }
+
+    /// Pins ``stopGeneration()`` as a no-argument, non-throwing method.
+    /// (The service also offers `cancel(_:)` and `discardRequests(notMatching:)`
+    /// — each pinned separately so a rename on any of them is detectable.)
+    func test_stopGenerationSignatureIsLocked() {
+        let service = InferenceService(
+            backend: MockInferenceBackend(),
+            name: "SignatureLock"
+        )
+
+        // stopGeneration() takes zero args and returns Void.
+        let stop: () -> Void = service.stopGeneration
+        stop() // safe; no active generation.
+
+        // cancel(_:) takes a token, returns Void.
+        let cancel: (InferenceService.GenerationRequestToken) -> Void = service.cancel
+        XCTAssertNotNil(cancel as Any)
+
+        // discardRequests(notMatching:) takes a UUID, returns Void.
+        let discard: (UUID) -> Void = service.discardRequests(notMatching:)
+        XCTAssertNotNil(discard as Any)
+    }
+
+    /// The fuzzer also relies on the two public typealiases for backwards
+    /// compatibility. Pin them.
+    func test_publicTypeAliasesAreLocked() {
+        let priority: InferenceService.GenerationPriority = .normal
+        XCTAssertEqual(priority, .normal)
+        // The token type has no public initializer; verifying the type alias
+        // resolves and `rawValue` is publicly readable is enough.
+        let tokenType: InferenceService.GenerationRequestToken.Type = InferenceService.GenerationRequestToken.self
+        XCTAssertNotNil(tokenType as Any)
+    }
+}

--- a/Tests/BaseChatFuzzTests/SessionDetectorContractTests.swift
+++ b/Tests/BaseChatFuzzTests/SessionDetectorContractTests.swift
@@ -1,0 +1,348 @@
+import XCTest
+@testable import BaseChatFuzz
+
+// MARK: - Fixture helpers
+
+private enum SessionFixture {
+
+    /// Build a minimal ``RunRecord`` for a single turn inside a contract
+    /// fixture. `events` is a convenience over the full `EventSnapshot`
+    /// shape — callers pass `(t, kind, v)` tuples.
+    static func record(
+        raw: String,
+        events: [(Double, String, String?)] = [],
+        modelId: String = "contract-model"
+    ) -> RunRecord {
+        RunRecord(
+            runId: UUID().uuidString,
+            ts: "2026-04-19T00:00:00Z",
+            harness: .init(
+                fuzzVersion: "0.0.0-test",
+                packageGitRev: "deadbeef",
+                packageGitDirty: false,
+                swiftVersion: "6.1",
+                osBuild: "test",
+                thermalState: "nominal"
+            ),
+            model: .init(
+                backend: "mock",
+                id: modelId,
+                url: "mem://session-detector-contract",
+                fileSHA256: nil,
+                tokenizerHash: nil
+            ),
+            config: .init(
+                seed: 0,
+                temperature: 0.0,
+                topP: 1.0,
+                maxTokens: nil,
+                systemPrompt: nil
+            ),
+            prompt: .init(
+                corpusId: "contract",
+                mutators: [],
+                messages: []
+            ),
+            events: events.map { .init(t: $0.0, kind: $0.1, v: $0.2) },
+            raw: raw,
+            rendered: raw,
+            thinkingRaw: "",
+            thinkingParts: [],
+            thinkingCompleteCount: 0,
+            templateMarkers: nil,
+            memory: .init(beforeBytes: nil, peakBytes: nil, afterBytes: nil),
+            timing: .init(firstTokenMs: nil, totalMs: 0, tokensPerSec: nil),
+            phase: "done",
+            error: nil,
+            stopReason: "naturalStop"
+        )
+    }
+
+    /// A ``SessionCapture`` from a list of turn records plus an optional
+    /// stop step between turns N and N+1 for race fixtures.
+    static func capture(
+        id: String,
+        turns: [RunRecord],
+        stopAfterIndex: Int? = nil,
+        systemPrompt: String? = nil,
+        sessionLabel: String? = nil
+    ) -> SessionCapture {
+        var steps: [SessionCapture.StepResult] = []
+        var stepIndex = 0
+        for (i, r) in turns.enumerated() {
+            steps.append(.init(
+                index: stepIndex,
+                step: .send(text: ""),
+                record: r,
+                timeline: .executed,
+                elapsedMs: 0
+            ))
+            stepIndex += 1
+            if stopAfterIndex == i {
+                steps.append(.init(
+                    index: stepIndex,
+                    step: .stop,
+                    record: nil,
+                    timeline: .stopRequested,
+                    elapsedMs: 0
+                ))
+                stepIndex += 1
+            }
+        }
+        let script = SessionScript(
+            id: id,
+            steps: steps.map(\.step),
+            systemPrompt: systemPrompt,
+            sessionLabel: sessionLabel
+        )
+        return SessionCapture(
+            script: script,
+            sessionID: UUID(),
+            steps: steps
+        )
+    }
+}
+
+// MARK: - Shared assertion helpers (session variant)
+//
+// The session detectors ship a 4-case contract (positive / negative /
+// boundary / adversarial) mirroring the single-turn ``DetectorContract``
+// protocol. We don't reuse that exact protocol because its `detector`
+// associated type is `any Detector` (single-record), not `SessionDetector`.
+// The four-case discipline is preserved below with direct XCTest methods.
+
+private enum SessionContractAsserter {
+    static func assertEmpty(
+        _ findings: [Finding],
+        detectorId: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(findings.isEmpty,
+            "\(detectorId): expected no findings; got \(findings.map { "\($0.subCheck):\($0.trigger)" })",
+            file: file, line: line)
+    }
+
+    static func assertNonEmpty(
+        _ findings: [Finding],
+        detectorId: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertFalse(findings.isEmpty,
+            "\(detectorId): expected at least one finding; got none",
+            file: file, line: line)
+    }
+
+    static func assertDeterministic(
+        detector: any SessionDetector,
+        captures: [SessionCapture],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let first = detector.inspect(captures)
+        let firstFP = first.map { "\($0.subCheck)|\($0.trigger)" }.sorted()
+        for i in 1..<10 {
+            let next = detector.inspect(captures)
+            let nextFP = next.map { "\($0.subCheck)|\($0.trigger)" }.sorted()
+            XCTAssertEqual(firstFP, nextFP,
+                "boundary run \(i) differed from run 0 for detector \(detector.id)",
+                file: file, line: line)
+        }
+    }
+}
+
+// MARK: - TurnBoundaryKVStateDetector contract
+
+final class TurnBoundaryKVStateDetectorContractTests: XCTestCase {
+
+    private let detector = TurnBoundaryKVStateDetector()
+
+    func test_positive_verbatimResidueFromPriorTurnFires() {
+        // Turn 1 emits a sentence; turn 2 starts by copying that sentence
+        // verbatim, well above the 24-char threshold.
+        let shared = "The quick brown fox jumps over the lazy dog in the meadow."
+        let turn1 = SessionFixture.record(raw: shared)
+        let turn2 = SessionFixture.record(raw: shared + " Also, birds sing.")
+        let capture = SessionFixture.capture(id: "positive", turns: [turn1, turn2])
+        SessionContractAsserter.assertNonEmpty(detector.inspect([capture]), detectorId: detector.id)
+    }
+
+    func test_negative_independentOutputsDoNotFire() {
+        let turn1 = SessionFixture.record(raw: "Paris is the capital of France.")
+        let turn2 = SessionFixture.record(raw: "Tokyo sits on Honshu island.")
+        let capture = SessionFixture.capture(id: "neg", turns: [turn1, turn2])
+        SessionContractAsserter.assertEmpty(detector.inspect([capture]), detectorId: detector.id)
+    }
+
+    /// Boundary: shared substring is exactly `minResidueChars` long (24).
+    /// The guard is `>= minResidueChars` so it MUST fire; ten inspections
+    /// must return identical findings.
+    func test_boundary_deterministicAtThreshold() {
+        // 24 characters exactly. Must fire, must be deterministic.
+        let boundary = "abcdefghijklmnopqrstuvwx" // 24 chars
+        precondition(boundary.count == 24)
+        let turn1 = SessionFixture.record(raw: "prefix " + boundary + " suffix")
+        let turn2 = SessionFixture.record(raw: "unrelated " + boundary)
+        let capture = SessionFixture.capture(id: "boundary", turns: [turn1, turn2])
+        SessionContractAsserter.assertDeterministic(detector: detector, captures: [capture])
+        // Also assert it DOES fire (boundary is MUST-fire here).
+        XCTAssertFalse(detector.inspect([capture]).isEmpty)
+    }
+
+    /// Adversarial: both turns legitimately repeat the common short phrase
+    /// "the answer is ". Below the 24-char threshold — must stay silent.
+    func test_adversarial_commonStopWordPhraseDoesNotFire() {
+        let turn1 = SessionFixture.record(raw: "I believe the answer is 42.")
+        let turn2 = SessionFixture.record(raw: "Well, the answer is probably 7.")
+        let capture = SessionFixture.capture(id: "adv", turns: [turn1, turn2])
+        SessionContractAsserter.assertEmpty(detector.inspect([capture]), detectorId: detector.id)
+    }
+}
+
+// MARK: - CancellationRaceDetector contract
+
+final class CancellationRaceDetectorContractTests: XCTestCase {
+
+    private let detector = CancellationRaceDetector()
+
+    /// Positive: turn 1 streams several tokens; a stop fires; turn 2's raw
+    /// contains one of turn 1's post-stop tokens verbatim — a leak.
+    func test_positive_postStopTokenLeakFires() {
+        let turn1 = SessionFixture.record(
+            raw: "begin middlephrase end",
+            events: [
+                (0.0, "token", "begin "),
+                (0.5, "token", "middlephrase "),
+                (0.9, "token", "end"),
+            ]
+        )
+        let turn2 = SessionFixture.record(raw: "completely new response with middlephrase in it")
+        let capture = SessionFixture.capture(id: "race-pos", turns: [turn1, turn2], stopAfterIndex: 0)
+        let findings = detector.inspect([capture])
+        XCTAssertFalse(findings.isEmpty)
+    }
+
+    /// Negative: no stop step, turns are clean.
+    func test_negative_noStopMeansNoFiring() {
+        let turn1 = SessionFixture.record(
+            raw: "answer one",
+            events: [(0.0, "token", "answer "), (0.5, "token", "one")]
+        )
+        let turn2 = SessionFixture.record(raw: "entirely different second reply")
+        let capture = SessionFixture.capture(id: "race-neg", turns: [turn1, turn2], stopAfterIndex: nil)
+        let findings = detector.inspect([capture])
+        XCTAssertTrue(findings.isEmpty)
+    }
+
+    /// Boundary: stop exists, turn-1 has exactly one post-first-event token,
+    /// and that token (`raceword`) appears in turn 2. Ten inspections return
+    /// identical findings.
+    func test_boundary_deterministicAtSinglePostStopToken() {
+        let turn1 = SessionFixture.record(
+            raw: "hello raceword",
+            events: [
+                (0.0, "token", "hello "),
+                (0.4, "token", "raceword"),
+            ]
+        )
+        let turn2 = SessionFixture.record(raw: "a new answer with raceword embedded")
+        let capture = SessionFixture.capture(id: "race-boundary", turns: [turn1, turn2], stopAfterIndex: 0)
+
+        let first = detector.inspect([capture])
+        let firstFP = first.map { "\($0.subCheck)|\($0.trigger)" }.sorted()
+        for i in 1..<10 {
+            let next = detector.inspect([capture])
+            let nextFP = next.map { "\($0.subCheck)|\($0.trigger)" }.sorted()
+            XCTAssertEqual(firstFP, nextFP, "boundary run \(i) differed")
+        }
+        XCTAssertFalse(first.isEmpty, "boundary must fire")
+    }
+
+    /// Adversarial: the user intentionally sent the same message twice.
+    /// Turn 2's raw matches turn 1's raw (legitimate repetition), but no
+    /// `stopRequested` step exists — must NOT fire.
+    func test_adversarial_legitimateRepeatWithoutStopDoesNotFire() {
+        let sameReply = "The capital of France is Paris."
+        let turn1 = SessionFixture.record(
+            raw: sameReply,
+            events: [(0.0, "token", "The "), (0.3, "token", "capital of France is Paris.")]
+        )
+        let turn2 = SessionFixture.record(
+            raw: sameReply,
+            events: [(0.0, "token", "The "), (0.3, "token", "capital of France is Paris.")]
+        )
+        let capture = SessionFixture.capture(id: "race-adv", turns: [turn1, turn2], stopAfterIndex: nil)
+        XCTAssertTrue(detector.inspect([capture]).isEmpty)
+    }
+}
+
+// MARK: - SessionContextLeakDetector contract
+
+final class SessionContextLeakDetectorContractTests: XCTestCase {
+
+    private let detector = SessionContextLeakDetector()
+
+    /// Positive: session A has a distinctive system prompt; session B's
+    /// assistant output contains that system prompt verbatim.
+    func test_positive_crossSessionLeakFires() {
+        let secret = "The passphrase is octopus-melody-1928."
+        let aTurn = SessionFixture.record(raw: "Acknowledged.", modelId: "m")
+        let bTurn = SessionFixture.record(raw: "Sure — here's the answer. " + secret, modelId: "m")
+
+        let aCapture = SessionFixture.capture(id: "A", turns: [aTurn], systemPrompt: secret, sessionLabel: "A")
+        let bCapture = SessionFixture.capture(id: "B", turns: [bTurn], sessionLabel: "B")
+
+        let findings = detector.inspect([aCapture, bCapture])
+        XCTAssertFalse(findings.isEmpty)
+    }
+
+    /// Negative: two independent sessions with distinct prompts and outputs.
+    func test_negative_independentSessionsDoNotFire() {
+        let aTurn = SessionFixture.record(raw: "Sure, I'll help.", modelId: "m")
+        let bTurn = SessionFixture.record(raw: "Here's a new idea.", modelId: "m")
+        let a = SessionFixture.capture(id: "A", turns: [aTurn], systemPrompt: "Be concise about weather.", sessionLabel: "A")
+        let b = SessionFixture.capture(id: "B", turns: [bTurn], systemPrompt: "Be verbose about cooking.", sessionLabel: "B")
+        XCTAssertTrue(detector.inspect([a, b]).isEmpty)
+    }
+
+    /// Boundary: the secret is exactly `minLeakChars` long (16) and it
+    /// appears in the other session's output. Must fire, deterministically.
+    func test_boundary_deterministicAtExactThreshold() {
+        let secret = "abcdefghijklmnop" // 16 chars
+        precondition(secret.count == 16)
+        let aTurn = SessionFixture.record(raw: "hi", modelId: "m")
+        let bTurn = SessionFixture.record(raw: "answer: " + secret, modelId: "m")
+        let a = SessionFixture.capture(id: "A", turns: [aTurn], systemPrompt: secret, sessionLabel: "A")
+        let b = SessionFixture.capture(id: "B", turns: [bTurn], sessionLabel: "B")
+
+        let first = detector.inspect([a, b])
+        let firstFP = first.map { "\($0.subCheck)|\($0.trigger)" }.sorted()
+        for i in 1..<10 {
+            let next = detector.inspect([a, b])
+            let nextFP = next.map { "\($0.subCheck)|\($0.trigger)" }.sorted()
+            XCTAssertEqual(firstFP, nextFP, "boundary run \(i) differed")
+        }
+        XCTAssertFalse(first.isEmpty, "boundary must fire")
+    }
+
+    /// Adversarial: both sessions use a short boilerplate greeting
+    /// ("Hello!") that's below the threshold and naturally shows up in both
+    /// outputs. Must NOT fire.
+    func test_adversarial_boilerplateGreetingDoesNotFire() {
+        let greeting = "Hello!"
+        let a = SessionFixture.capture(
+            id: "A",
+            turns: [SessionFixture.record(raw: "Hello! How can I help?", modelId: "m")],
+            systemPrompt: greeting,
+            sessionLabel: "A"
+        )
+        let b = SessionFixture.capture(
+            id: "B",
+            turns: [SessionFixture.record(raw: "Hello! What's on your mind?", modelId: "m")],
+            systemPrompt: greeting,
+            sessionLabel: "B"
+        )
+        XCTAssertTrue(detector.inspect([a, b]).isEmpty)
+    }
+}

--- a/Tests/BaseChatFuzzTests/SessionScriptRunnerTests.swift
+++ b/Tests/BaseChatFuzzTests/SessionScriptRunnerTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+@testable import BaseChatFuzz
+import BaseChatInference
+import BaseChatTestSupport
+
+@MainActor
+final class SessionScriptRunnerTests: XCTestCase {
+
+    /// Builds a service backed by a `MockInferenceBackend` that yields the
+    /// given scripted reply. The `#if DEBUG` convenience initializer does
+    /// the heavy lifting so we don't have to wire a factory for each test.
+    private func makeService(replying tokens: [String] = ["ok"]) -> (InferenceService, MockInferenceBackend) {
+        let mock = MockInferenceBackend()
+        mock.tokensToYield = tokens
+        mock.isModelLoaded = true // bypass the explicit load step
+        let service = InferenceService(backend: mock, name: "SessionRunnerTest")
+        return (service, mock)
+    }
+
+    func test_sendStep_enqueuesAndCapturesRecord() async {
+        let (service, mock) = makeService(replying: ["hello", " there"])
+        let runner = SessionScriptRunner(
+            service: service,
+            options: .init(modelId: "mock-1"),
+            seed: 42
+        )
+        let script = SessionScript(
+            id: "basic-send",
+            steps: [.send(text: "hi")]
+        )
+        let capture = await runner.execute(script)
+
+        XCTAssertEqual(capture.steps.count, 1)
+        XCTAssertEqual(capture.steps[0].timeline, .executed)
+        let record = try? XCTUnwrap(capture.steps[0].record)
+        XCTAssertEqual(record?.raw, "hello there")
+        XCTAssertEqual(record?.model.id, "mock-1")
+        XCTAssertEqual(mock.generateCallCount, 1)
+    }
+
+    func test_stopStep_invokesStopGeneration() async {
+        let (service, mock) = makeService()
+        let runner = SessionScriptRunner(service: service)
+        let script = SessionScript(
+            id: "just-stop",
+            steps: [.stop]
+        )
+        let capture = await runner.execute(script)
+
+        XCTAssertEqual(capture.steps.count, 1)
+        XCTAssertEqual(capture.steps[0].timeline, .stopRequested)
+        XCTAssertNil(capture.steps[0].record)
+        XCTAssertEqual(mock.stopCallCount, 1)
+    }
+
+    func test_editStep_mutatesMessageArray_withoutGeneration() async {
+        let (service, mock) = makeService(replying: ["r1"])
+        let runner = SessionScriptRunner(service: service)
+        let script = SessionScript(
+            id: "edit-no-regen",
+            steps: [
+                .send(text: "original"),
+                .edit(messageIndex: 0, newText: "edited"),
+            ]
+        )
+        _ = await runner.execute(script)
+        // Edit alone should NOT trigger a second generate.
+        XCTAssertEqual(mock.generateCallCount, 1)
+    }
+
+    func test_regenerateStep_dropsAssistantAndEnqueuesAgain() async {
+        let (service, mock) = makeService(replying: ["first"])
+        let runner = SessionScriptRunner(service: service)
+        let script = SessionScript(
+            id: "regen",
+            steps: [
+                .send(text: "hello"),
+                .regenerate,
+            ]
+        )
+        _ = await runner.execute(script)
+        XCTAssertEqual(mock.generateCallCount, 2,
+            "regenerate must re-enqueue and produce a second generate() call")
+    }
+
+    func test_deleteWithInvalidIndex_emitsTimelineEvent() async {
+        let (service, _) = makeService()
+        let runner = SessionScriptRunner(service: service)
+        let script = SessionScript(
+            id: "bad-delete",
+            steps: [.delete(messageIndex: 999)]
+        )
+        let capture = await runner.execute(script)
+        XCTAssertEqual(capture.steps[0].timeline, .indexOutOfRange)
+    }
+
+    func test_stepOrdering_preservesScriptOrder() async {
+        let (service, _) = makeService(replying: ["hi"])
+        let runner = SessionScriptRunner(service: service)
+        let script = SessionScript(
+            id: "ordering",
+            steps: [
+                .send(text: "one"),
+                .stop,
+                .edit(messageIndex: 0, newText: "two"),
+                .regenerate,
+            ]
+        )
+        let capture = await runner.execute(script)
+        XCTAssertEqual(capture.steps.map(\.index), [0, 1, 2, 3])
+        XCTAssertEqual(capture.steps.map(\.timeline), [
+            .executed, .stopRequested, .edited, .executed,
+        ])
+    }
+
+    func test_turnRecords_filtersNonExecutedSteps() async {
+        let (service, _) = makeService(replying: ["r"])
+        let runner = SessionScriptRunner(service: service)
+        let script = SessionScript(
+            id: "filter",
+            steps: [.send(text: "a"), .edit(messageIndex: 0, newText: "b"), .regenerate]
+        )
+        let capture = await runner.execute(script)
+        XCTAssertEqual(capture.turnRecords.count, 2,
+            "only the two enqueue-producing steps should appear in turnRecords")
+    }
+}

--- a/Tests/BaseChatFuzzTests/SessionScriptTests.swift
+++ b/Tests/BaseChatFuzzTests/SessionScriptTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import BaseChatFuzz
+
+final class SessionScriptTests: XCTestCase {
+
+    func test_loadAll_returnsBundledScripts() {
+        let scripts = SessionScript.loadAll()
+        // We ship 3 named scripts — `session-swap.json` expands into 2 — so
+        // 4 scripts total.
+        XCTAssertGreaterThanOrEqual(scripts.count, 4,
+            "loadAll should return all bundled session scripts; got \(scripts.map(\.id))")
+        XCTAssertTrue(scripts.contains { $0.id == "edit-then-regenerate" })
+        XCTAssertTrue(scripts.contains { $0.id == "rapid-send-cancel" })
+        XCTAssertTrue(scripts.contains { $0.id == "session-swap-A" })
+        XCTAssertTrue(scripts.contains { $0.id == "session-swap-B" })
+    }
+
+    func test_editThenRegenerate_hasExpectedSteps() throws {
+        let scripts = SessionScript.loadAll()
+        guard let script = scripts.first(where: { $0.id == "edit-then-regenerate" }) else {
+            return XCTFail("edit-then-regenerate script missing")
+        }
+        XCTAssertEqual(script.steps.count, 4)
+        // Step 0 must be a `.send`; step 1 a `.stop`; step 2 an `.edit`;
+        // step 3 a `.regenerate`. The detector fixture tests rely on this
+        // exact ordering.
+        if case .send(let text) = script.steps[0] {
+            XCTAssertFalse(text.isEmpty)
+        } else { XCTFail("step 0 must be .send") }
+        XCTAssertEqual(script.steps[1], .stop)
+        if case .edit(let idx, let new) = script.steps[2] {
+            XCTAssertEqual(idx, 0)
+            XCTAssertFalse(new.isEmpty)
+        } else { XCTFail("step 2 must be .edit") }
+        XCTAssertEqual(script.steps[3], .regenerate)
+    }
+
+    func test_roundTrip_encodeDecode_preservesSteps() throws {
+        let original = SessionScript(
+            id: "rt",
+            steps: [
+                .send(text: "hi"),
+                .stop,
+                .edit(messageIndex: 0, newText: "hey"),
+                .regenerate,
+                .delete(messageIndex: 1),
+            ],
+            systemPrompt: "be brief",
+            sessionLabel: "lbl"
+        )
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(SessionScript.self, from: encoded)
+        XCTAssertEqual(original, decoded)
+    }
+
+    func test_unknownOp_throwsDecoding() {
+        let json = #"{"id":"x","steps":[{"op":"teleport"}]}"#
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(SessionScript.self, from: Data(json.utf8))
+        )
+    }
+
+    func test_opNameLabels() {
+        XCTAssertEqual(SessionScript.Step.send(text: "x").opName, "send")
+        XCTAssertEqual(SessionScript.Step.stop.opName, "stop")
+        XCTAssertEqual(SessionScript.Step.edit(messageIndex: 0, newText: "x").opName, "edit")
+        XCTAssertEqual(SessionScript.Step.regenerate.opName, "regenerate")
+        XCTAssertEqual(SessionScript.Step.delete(messageIndex: 0).opName, "delete")
+    }
+}

--- a/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
+++ b/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
@@ -82,6 +82,15 @@ final class SilentCatchAuditTest: XCTestCase {
         "BaseChatBackends/OpenAIBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],",
         "BaseChatBackends/SSECloudBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],",
 
+        // BaseChatFuzz — SessionScript resource loader uses the "try-each-shape-in-order"
+        // decoder pattern: each `try?` is a shape probe (single-object vs. array of scripts).
+        // When both shape probes miss, SessionScript.loadAll writes an explicit stderr
+        // diagnostic on the next line. The Data(contentsOf:) swallow is a benign
+        // skip-this-resource case — the loader continues with the remaining scripts.
+        "BaseChatFuzz/SessionScript.swift:guard let data = try? Data(contentsOf: url) else { continue }",
+        "BaseChatFuzz/SessionScript.swift:if let one = try? decoder.decode(SessionScript.self, from: data) {",
+        "BaseChatFuzz/SessionScript.swift:if let many = try? decoder.decode([SessionScript].self, from: data) {",
+
         // BaseChatUI — Task.sleep cancellation is intentionally ignored;
         // parser/rendering fallbacks are benign optional conversions.
         "BaseChatUI/ViewModels/ModelManagementViewModel.swift:try? await Task.sleep(for: .milliseconds(500))",


### PR DESCRIPTION
## Summary

Multi-turn fuzzing now drives bundled `SessionScript` JSON files through the real `InferenceService.enqueue`, exercising the queue, cancellation, and latest-wins load-token paths that single-turn fuzzing could not reach. Three new session-aware detectors land alongside, each with the four-case contract from #539: turn-boundary KV-state residue, cancellation-race token interleaving, and cross-session context leaks. A signature-lock test pins `enqueue` and `stopGeneration` against silent drift from future `GenerationCoordinator` refactors.

Closes #492.

## What changed

- **`SessionScript`** (`Sources/BaseChatFuzz/SessionScript.swift`) — declarative multi-turn corpus type. Steps: `.send`, `.stop`, `.edit`, `.regenerate`, `.delete`. Custom Codable with an `op` discriminator for human-authorable JSON.
- **`SessionScriptRunner`** (actor) — interprets a script against an `InferenceService`, calling `enqueue` for sends/regenerates, `stopGeneration` for stops, mutating a local messages array for edits/deletes. Returns a `SessionCapture` with one `StepResult` per step (record + timeline event).
- **`SessionFuzzRunner`** (sibling of `FuzzRunner`) — per-script iteration via `FuzzBackendFactory.makeHandle()`, service construction, step-level single-turn detectors + whole-capture session detectors. Writes to the same `FindingsSink` so the single-turn + multi-turn findings merge cleanly in `tmp/fuzz/findings/`.
- **Three new `SessionDetector`s** (`Detectors/SessionDetector.swift` + three detector files):
  - `turn-boundary-kv-state` — longest common substring between turn N-1 and N; fires at >=24 chars.
  - `cancellation-race` — searches turn N+1 raw for a post-stop token from turn N; fires when tokens leak across the stop boundary.
  - `session-context-leak` — pairwise search: does session A's system prompt (or first user message) appear verbatim in session B's output? Fires at >=16 chars.
- **Seed scripts** — three JSONs under `Resources/session_scripts/`: `edit-then-regenerate.json`, `rapid-send-cancel.json`, `session-swap.json` (two-session file).
- **CLI flag** — `--session-scripts` opts into the multi-turn path. Default stays single-turn. `FuzzConfig.sessionScripts` bool carries it through.
- **Signature-lock test** — `InferenceServiceSignatureLockTests` pins the exact shape of `enqueue(messages:systemPrompt:temperature:topP:repeatPenalty:maxOutputTokens:priority:sessionID:)`, `stopGeneration()`, `cancel(_:)`, and `discardRequests(notMatching:)`. Any rename or default-value change fails this at compile time.

## Sabotage evidence

Two detectors were sabotaged and confirmed red before reverting.

**TurnBoundaryKVStateDetector** — raised `minResidueChars` default from 24 to 9999:

\`\`\`diff
-    public init(minResidueChars: Int = 24) {
+    public init(minResidueChars: Int = 9999) {
\`\`\`

Red output:
\`\`\`
Test Case '-[...TurnBoundaryKVStateDetectorContractTests test_boundary_deterministicAtThreshold]' failed
  XCTAssertFalse failed
Test Case '-[...TurnBoundaryKVStateDetectorContractTests test_positive_verbatimResidueFromPriorTurnFires]' failed
  XCTAssertFalse failed - turn-boundary-kv-state: expected at least one finding; got none
 Executed 4 tests, with 2 failures
\`\`\`

Reverted; green.

**SessionContextLeakDetector** — early return \`[]\` before the leak scan:
\`\`\`
Test Case '-[...SessionContextLeakDetectorContractTests test_positive_crossSessionLeakFires]' failed
Test Case '-[...SessionContextLeakDetectorContractTests test_boundary_deterministicAtExactThreshold]' failed - boundary must fire
 Executed 4 tests, with 2 failures
\`\`\`

Reverted; green.

## Tests

- `SessionScriptTests` — 5 tests: loadAll, per-script step shapes, round-trip encode/decode, unknown-op decode throws, opName labels.
- `SessionScriptRunnerTests` — 7 tests, driven by `MockInferenceBackend`: send/stop/edit/regenerate/delete timeline + turn record filtering.
- `InferenceServiceSignatureLockTests` — 3 tests locking enqueue + stopGeneration + typealias surface.
- `SessionDetectorContractTests` — 12 tests (4 per new detector): positive / negative / boundary-deterministic / adversarial.

Four CI suites pass locally: BaseChatCoreTests (204), BaseChatInferenceTests (69), BaseChatUITests (450), BaseChatBackendsTests (97), plus BaseChatFuzzTests (130 after rebase).

## Scope / guardrails

- `FuzzRunner.runSingle` and its public surface are unchanged. Session-script dispatch is a sibling runner, gated behind the `--session-scripts` flag.
- `InferenceService` public API is untouched — no widenings, no new methods.
- `EventRecorder.swift` untouched.
- Replay/rotation code untouched.
- Session script corpus is a Swift-Package `.process("Resources")` child. The loader enumerates known filenames rather than introspecting a subdirectory because SPM flattens resource paths.

## Test plan

- [x] Four CI suites pass locally (macOS, arm64, --disable-default-traits)
- [x] Sabotage cycle: TurnBoundaryKVStateDetector + SessionContextLeakDetector (evidence above)
- [x] `swift run fuzz-chat --help` shows the new `--session-scripts` flag
- [ ] CI green on merge queue
- [ ] Post-merge: smoke-run `swift run fuzz-chat --session-scripts --iterations 10 --backend ollama` against a local Ollama server (deferred)

## Notes for reviewer

- Diff size: +1765 / -5 across 17 files.
- No `InferenceService` gaps surfaced — the existing `enqueue` + `stopGeneration` + `cancel` + `discardRequests` API covers everything the multi-turn harness needs.
- `#538` BackgroundDownloadIntegrationTests SIGABRT flake did NOT hit locally during this session.
- The session detectors use a parallel `SessionDetector` protocol rather than shoehorning multi-capture semantics into the existing `Detector` protocol. This keeps the single-turn registry stable and makes the multi-turn pipeline explicit.

## Release Note

**Multi-turn fuzzing via InferenceService** — the harness now drives scripted multi-step sessions through \`InferenceService.enqueue\`, exercising the queue, cancellation, and latest-wins load-token paths that single-turn fuzzing couldn't reach. Three new detectors cover turn-boundary KV-state residue, cancellation-race token interleaving, and cross-session context leaks — each with the four-case DetectorContract from #539. A signature-lock test pins \`enqueue\` against silent drift in \`GenerationCoordinator\`. Closes #492.