### PR TITLE
refactor(fuzz): drop unnecessary @MainActor from fuzzer hot path

### DIFF
--- a/Sources/BaseChatFuzz/EventRecorder.swift
+++ b/Sources/BaseChatFuzz/EventRecorder.swift
@@ -28,7 +28,6 @@ public struct EventRecorder: Sendable {
 
     /// - Parameter maxOutputTokens: the cap requested in `GenerationConfig`, used to
     ///   classify the stop reason as `maxTokens` when the final usage report meets/exceeds it.
-    @MainActor
     public func consume(_ stream: GenerationStream, maxOutputTokens: Int? = nil) async -> Capture {
         let start = ContinuousClock.now
         var events: [RunRecord.EventSnapshot] = []

--- a/Sources/BaseChatFuzz/FuzzRunner.swift
+++ b/Sources/BaseChatFuzz/FuzzRunner.swift
@@ -161,7 +161,6 @@ public actor FuzzRunner {
         return report
     }
 
-    @MainActor
     private func runSingle(
         handle: BackendHandle,
         entry: CorpusEntry,

--- a/Sources/BaseChatFuzz/Replay/Replayer.swift
+++ b/Sources/BaseChatFuzz/Replay/Replayer.swift
@@ -267,7 +267,6 @@ public struct Replayer: Sendable {
     /// fresh `FuzzConfig` purely so the `ConfigSnapshot` emitted by this attempt
     /// carries the recorded seed; sampling is bypassed. The seed-plumbing sabotage
     /// test asserts this field is NOT silently replaced with a fresh seed.
-    @MainActor
     private func runOnce(
         handle: FuzzRunner.BackendHandle,
         record: RunRecord

--- a/Sources/BaseChatFuzz/SessionFuzzRunner.swift
+++ b/Sources/BaseChatFuzz/SessionFuzzRunner.swift
@@ -18,12 +18,15 @@ public actor SessionFuzzRunner {
     private let factory: any FuzzBackendFactory
     private let sink: FindingsSink
     private let scripts: [SessionScript]
+    /// `@MainActor` required: `InferenceService.init` is main-actor-isolated, so any
+    /// closure that constructs one must hop to main.
     private let serviceFactory: @MainActor @Sendable (any InferenceBackend, String) -> InferenceService
 
     public init(
         config: FuzzConfig,
         factory: any FuzzBackendFactory,
         scripts: [SessionScript]? = nil,
+        // @MainActor required: closure instantiates a @MainActor-isolated InferenceService.
         serviceFactory: (@MainActor @Sendable (any InferenceBackend, String) -> InferenceService)? = nil
     ) {
         self.config = config
@@ -38,6 +41,7 @@ public actor SessionFuzzRunner {
     /// both build in debug by default, so this is safe; for release builds
     /// the caller must supply a custom `serviceFactory` that wires a factory
     /// via `registerBackendFactory`.
+    // @MainActor required: constructs a @MainActor-isolated InferenceService.
     @MainActor
     public static func defaultServiceFactory(_ backend: any InferenceBackend, _ name: String) -> InferenceService {
         #if DEBUG

--- a/Sources/fuzz-chat/OllamaFuzzFactory.swift
+++ b/Sources/fuzz-chat/OllamaFuzzFactory.swift
@@ -21,7 +21,6 @@ public struct OllamaFuzzFactory: FuzzBackendFactory {
         self.baseURL = baseURL
     }
 
-    @MainActor
     public func makeHandle() async throws -> FuzzRunner.BackendHandle {
         guard let models = HardwareRequirements.listOllamaModels() else {
             throw CLIError("No Ollama server reachable at \(baseURL.absoluteString). Start with: ollama serve")


### PR DESCRIPTION
## Summary

`FuzzRunner.runSingle` and `EventRecorder.consume` were `@MainActor`-isolated for no discoverable reason. Every fuzz iteration was trapping into MainActor, paying an actor hop on each call and introducing the latent-deadlock risk flagged in architect review of the original harness. Neither function touches main-actor state: `GenerationStream.events` is `nonisolated`, backend `generate()` is not main-actor-bound, and `EventRecorder.consume` only manipulates locals while iterating a nonisolated `AsyncSequence`.

This PR is a pure narrowing — no function body changes, no widening of isolation anywhere in the tree.

## @MainActor audit

Full grep of `Sources/BaseChatFuzz/` and `Sources/fuzz-chat/`:

| Site | Verdict | Reason |
| --- | --- | --- |
| `FuzzRunner.runSingle` | **dropped** | calls `backend.generate()` (non-main, `AnyObject & Sendable`) and `EventRecorder.consume` (now non-main). |
| `EventRecorder.consume` | **dropped** | only local scope + iterates `GenerationStream.events` which is `public nonisolated let`. |
| `Replayer.runOnce` | **dropped** | same call chain as `runSingle`. |
| `OllamaFuzzFactory.makeHandle` | **dropped** | `OllamaBackend` is `@unchecked Sendable`, not `@MainActor`; `FuzzBackendFactory.makeHandle` is not main-actor in the protocol. |
| `SessionFuzzRunner.serviceFactory` (stored + init arg) | **kept** (commented) | closure constructs `@MainActor`-isolated `InferenceService`. |
| `SessionFuzzRunner.defaultServiceFactory` | **kept** (commented) | static factory that constructs `@MainActor`-isolated `InferenceService`. |
| `FuzzChatCLI` (`@main struct`) | **kept** | legitimate per issue brief. |

No `@MainActor` sites were found on `SessionScriptRunner` (it's an `actor`; it uses `await MainActor.run { … }` scoped to individual `InferenceService` calls, which is correct and untouched here).

## Sendable audit

None required. The compiler was satisfied by the drops alone: all captures already crossed actor boundaries via `Sendable` types (`BackendHandle` is `Sendable`, `CorpusEntry` / `RunRecord.HarnessSnapshot` are value types, `RunRecord` is `Sendable`).

## Sabotage evidence

Temporarily re-annotated a sibling actor-isolated helper with `@MainActor` to verify the type system still catches misuse:

```swift
// Sabotage: mark actor-isolated helper as @MainActor
@MainActor
private func currentHarnessSnapshot() -> RunRecord.HarnessSnapshot { … }
```

Compiler produced:

```
Sources/BaseChatFuzz/FuzzRunner.swift:123:31: error:
main actor-isolated instance method 'currentHarnessSnapshot()' cannot be called
from outside of the actor
```

Reverted. Full BaseChatFuzzTests suite (130 tests) passes pre- and post-drop; if the hop-removal had broken anything observable, the suite would have caught it.

## Perf smoke

```
swift run fuzz-chat --iterations 10 --seed 42
# → 10 iterations, 0 findings, ~60s total against live Ollama (llama3.1:8b + qwen3.5:4b rotated)
```

Per-iteration wall time is dominated by token generation (multi-second), so the actor-hop removal is invisible at this granularity. Architectural cleanup only, no regression.

## Diff size

5 files, +4/-4 net (4 annotation removals, 2 justification comments for `SessionFuzzRunner` survivors).

## Test plan

- [x] `swift test --filter BaseChatFuzzTests --disable-default-traits` — 130/130 pass
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 204/204 pass (4 skipped)
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 69/69 pass
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 450/450 pass
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 97/97 pass
- [x] `swift run fuzz-chat --iterations 10 --seed 42` — 10 iterations, 0 findings, no regression
- [x] Sabotage verification: re-added `@MainActor` to an actor-isolated helper; compiler errored as expected; reverted
- [x] #538 BackgroundDownloadIntegrationTests SIGABRT — **did not hit locally**

## Release Note

**Remove @MainActor from fuzzer hot path** — `FuzzRunner.runSingle` and `EventRecorder.consume` no longer trap into MainActor on every iteration. Neither needed main-thread isolation; the annotations caused avoidable actor hops and a latent deadlock risk flagged in the original harness review. The public surface is unchanged for all external callers. Closes #494.

Closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)