### PR TITLE
test(claude): add fixtures for thinking/tool_use/citations/stop_reason variants

### DIFF
--- a/Tests/BaseChatBackendsTests/ClaudeBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/ClaudeBackendTests.swift
@@ -252,6 +252,69 @@ extension ClaudeBackendTests {
     }
 }
 
+// MARK: - Rate-limit error shape (#531)
+
+extension ClaudeBackendTests {
+
+    /// Pins today's 429 handling: a structured Claude rate-limit body
+    /// (`{"type":"error","error":{"type":"rate_limit_error","message":"..."}}`)
+    /// plus the documented `anthropic-ratelimit-*` headers surface as
+    /// `CloudBackendError.rateLimited(retryAfter: 45)` from the `Retry-After`
+    /// header alone.
+    ///
+    /// FIXME(#531): once `anthropic-ratelimit-tokens-reset` is plumbed through,
+    /// flip to assert the structured reset time and the parsed error body message.
+    func test_rateLimit_anthropicErrorBody_surfacesRetryAfterOnly() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let backend = ClaudeBackend(urlSession: session)
+
+        // Disable retries so the first 429 propagates immediately, preserving
+        // the retryAfter we want to assert on.
+        backend.retryStrategy = ExponentialBackoffStrategy(maxRetries: 0)
+
+        let url = URL(string: "https://claude-ratelimit-\(UUID().uuidString).test")!
+        backend.configure(baseURL: url, apiKey: "sk-ant-test", modelName: "claude-sonnet-4-20250514")
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+
+        let body = Data(#"{"type":"error","error":{"type":"rate_limit_error","message":"Too many requests"}}"#.utf8)
+        let messagesURL = url.appendingPathComponent("v1/messages")
+        MockURLProtocol.stub(url: messagesURL, response: .immediate(
+            data: body,
+            statusCode: 429,
+            headers: [
+                "Retry-After": "45",
+                "anthropic-ratelimit-requests-remaining": "0",
+                "anthropic-ratelimit-tokens-remaining": "0",
+                "anthropic-ratelimit-tokens-reset": "2026-04-19T12:34:56Z"
+            ]
+        ))
+        defer { MockURLProtocol.unstub(url: messagesURL) }
+
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: GenerationConfig())
+
+        do {
+            for try await _ in stream.events { }
+            XCTFail("Expected rateLimited error")
+        } catch {
+            guard let cloud = extractCloudError(error) else {
+                XCTFail("Expected CloudBackendError, got \(error)")
+                return
+            }
+            guard case .rateLimited(let retryAfter) = cloud else {
+                XCTFail("Expected rateLimited, got \(cloud)")
+                return
+            }
+            // Today: only Retry-After is honoured. The structured body and the
+            // anthropic-ratelimit-* headers are discarded. Flipping this test
+            // is the signal that richer parsing landed.
+            XCTAssertEqual(retryAfter, 45,
+                           "Retry-After header must surface as the rateLimited retryAfter value")
+        }
+    }
+}
+
 // MARK: - Backend Contract
 
 extension ClaudeBackendTests {

--- a/Tests/BaseChatBackendsTests/SSEPayloadReplayTests.swift
+++ b/Tests/BaseChatBackendsTests/SSEPayloadReplayTests.swift
@@ -288,6 +288,206 @@ final class SSEPayloadReplayTests: XCTestCase {
         XCTAssertEqual(tokens, ["A", "B", "C"])
     }
 
+    // MARK: - Claude thinking blocks (#527)
+
+    /// Pins today's behaviour: Claude 3.7+ `thinking` / `thinking_delta` events are
+    /// silently dropped by `parseToken` because it only matches `text_delta`.
+    ///
+    /// FIXME(#527): when thinking support lands, flip these assertions to expect
+    /// `.thinkingToken("Let me reason...")` + `.thinkingComplete` before the
+    /// final `.token("Answer.")`.
+    func test_claude_thinkingBlocks_todayDropsThinkingContent() async throws {
+        let sseText = """
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me reason..."}}
+
+        data: {"type":"content_block_stop","index":0}
+
+        data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Answer."}}
+
+        data: {"type":"message_stop"}
+
+        """
+
+        let payloads = try await collectPayloads(from: sseText)
+        let handler = ClaudeBackend.payloadHandler
+        let tokens = payloads.compactMap { handler.extractToken(from: $0) }
+
+        // Contract-pinning: today only the text_delta survives; the thinking_delta
+        // is dropped. Flipping this assertion is the signal that the fix landed.
+        XCTAssertEqual(tokens, ["Answer."],
+                       "ClaudeBackend currently drops thinking_delta payloads — pin behaviour until #527 ships")
+
+        // Sanity: the thinking_delta payload *is* present in the stream, we're
+        // just not surfacing it. This guards against the mistake of fixing
+        // the test by removing the upstream event.
+        let thinkingPayload = payloads.first { $0.contains("thinking_delta") }
+        XCTAssertNotNil(thinkingPayload, "thinking_delta event should be in the raw SSE stream")
+        XCTAssertNil(handler.extractToken(from: thinkingPayload!),
+                     "thinking_delta must not leak into the token stream today")
+    }
+
+    // MARK: - Claude tool_use streaming (#528)
+
+    /// Pins today's contract: `content_block_start` with `type:tool_use` and
+    /// `input_json_delta` payloads produce no tokens. A refactor that widens
+    /// `content_block_delta` matching would leak tool-use JSON into visible output.
+    ///
+    /// FIXME(#528): once tool calling is wired, flip to assert structured
+    /// tool-call events (`.toolCallStart` / `.toolCallEnd`).
+    func test_claude_toolUseStreaming_todayProducesNoTokens() async throws {
+        let sseText = """
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01","name":"get_weather","input":{}}}
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"city\\":"}}
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\\"Paris\\"}"}}
+
+        data: {"type":"content_block_stop","index":0}
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":5}}
+
+        data: {"type":"message_stop"}
+
+        """
+
+        let payloads = try await collectPayloads(from: sseText)
+        let handler = ClaudeBackend.payloadHandler
+
+        // Every payload should return nil from extractToken — no token leakage.
+        for payload in payloads {
+            XCTAssertNil(handler.extractToken(from: payload),
+                         "tool_use / input_json_delta payloads must not yield tokens: \(payload)")
+        }
+
+        // Completion token count on the tool_use message_delta should still parse.
+        let messageDeltaPayload = payloads.first { $0.contains("\"type\":\"message_delta\"") }
+        XCTAssertNotNil(messageDeltaPayload)
+        let usage = handler.extractUsage(from: messageDeltaPayload!)
+        XCTAssertEqual(usage?.completionTokens, 5)
+
+        // message_stop terminates the stream.
+        let messageStop = payloads.first { $0.contains("\"type\":\"message_stop\"") }
+        XCTAssertNotNil(messageStop)
+        XCTAssertTrue(handler.isStreamEnd(messageStop!))
+    }
+
+    // MARK: - Claude citations_delta (#529)
+
+    /// Pins today's contract: `citations_delta` inside `content_block_delta`
+    /// is ignored. Only surrounding `text_delta` events yield tokens.
+    ///
+    /// FIXME(#529): once citation metadata is surfaced, flip to assert the
+    /// structured citation event between the two text tokens.
+    func test_claude_citationsDelta_todayIgnored() async throws {
+        let sseText = """
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Einstein said "}}
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"citations_delta","citation":{"type":"char_location","cited_text":"E=mc^2","document_index":0,"document_title":"Relativity"}}}
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"E=mc^2."}}
+
+        """
+
+        let payloads = try await collectPayloads(from: sseText)
+        let handler = ClaudeBackend.payloadHandler
+        let tokens = payloads.compactMap { handler.extractToken(from: $0) }
+
+        // Today: citation delta drops cleanly, text_deltas flow through in order.
+        XCTAssertEqual(tokens, ["Einstein said ", "E=mc^2."],
+                       "citations_delta must not interleave into the token stream")
+
+        // Citation payload exists but yields nothing.
+        let citationPayload = payloads.first { $0.contains("citations_delta") }
+        XCTAssertNotNil(citationPayload)
+        XCTAssertNil(handler.extractToken(from: citationPayload!),
+                     "citations_delta must not leak into the token stream today")
+    }
+
+    // MARK: - Claude stop_reason variants (#530)
+
+    /// Pins today's contract: non-`end_turn` stop reasons (`refusal`,
+    /// `max_tokens`, `stop_sequence`) are no-ops for the token path. Usage
+    /// still parses out the `output_tokens` value from every variant.
+    ///
+    /// FIXME(#530): once structured stream events carry the stop reason,
+    /// flip to assert `.stopped(.refusal)` / `.stopped(.maxTokens)` etc.
+    func test_claude_stopReasonVariants_todayParseUsageOnly() async throws {
+        let sseText = """
+        data: {"type":"message_delta","delta":{"stop_reason":"refusal"},"usage":{"output_tokens":3}}
+
+        data: {"type":"message_delta","delta":{"stop_reason":"max_tokens"},"usage":{"output_tokens":8192}}
+
+        data: {"type":"message_delta","delta":{"stop_reason":"stop_sequence","stop_sequence":"\\n\\nHuman:"},"usage":{"output_tokens":14}}
+
+        """
+
+        let payloads = try await collectPayloads(from: sseText)
+        let handler = ClaudeBackend.payloadHandler
+
+        // No tokens produced from any of the three message_delta events.
+        let tokens = payloads.compactMap { handler.extractToken(from: $0) }
+        XCTAssertEqual(tokens, [], "stop_reason variants must not leak into the token stream")
+
+        // But usage should extract cleanly for each variant.
+        let completionTokens = payloads.compactMap { handler.extractUsage(from: $0)?.completionTokens }
+        XCTAssertEqual(completionTokens, [3, 8192, 14],
+                       "Every variant must still surface completion token usage")
+
+        // None of these events is a stream terminator (no message_stop here).
+        for payload in payloads {
+            XCTAssertFalse(handler.isStreamEnd(payload),
+                           "message_delta must not be treated as stream end: \(payload)")
+        }
+    }
+
+    // MARK: - Claude interleaved content blocks (#532)
+
+    /// Pins the "flatten all text_deltas in order, regardless of `index`"
+    /// contract. Three interleaved blocks (text → tool_use → text) produce
+    /// exactly the two text tokens in order. The tool_use block's
+    /// `input_json_delta` is ignored.
+    ///
+    /// FIXME(#532): once structured block events are supported, flip to
+    /// `.token("First")`, `.toolCallStart/.toolCallEnd`, `.token("Second")`.
+    func test_claude_interleavedBlocks_todayFlattensTextInOrder() async throws {
+        let sseText = """
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"First"}}
+
+        data: {"type":"content_block_stop","index":0}
+
+        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01","name":"x","input":{}}}
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{}"}}
+
+        data: {"type":"content_block_stop","index":1}
+
+        data: {"type":"content_block_start","index":2,"content_block":{"type":"text","text":""}}
+
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"Second"}}
+
+        data: {"type":"content_block_stop","index":2}
+
+        data: {"type":"message_stop"}
+
+        """
+
+        let payloads = try await collectPayloads(from: sseText)
+        let handler = ClaudeBackend.payloadHandler
+        let tokens = payloads.compactMap { handler.extractToken(from: $0) }
+
+        // Two text_deltas survive, the tool_use input_json_delta is dropped.
+        XCTAssertEqual(tokens, ["First", "Second"],
+                       "Interleaved blocks must flatten text_deltas in order and drop tool_use json")
+    }
+
+    // MARK: - Existing tests
+
     func test_unicodeInTokens_preservedCorrectly() async throws {
         let sseText = """
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello \\ud83d\\ude00"}}


### PR DESCRIPTION
## Summary

Adds six fixture tests pinning the current `ClaudeBackend` SSE-parsing contract for scenarios that had no coverage before. Each test asserts today's (pre-fix) behaviour and carries a `FIXME(#issue)` comment so the upcoming fix PRs flip the assertion rather than authoring a new test from scratch.

- `test_claude_thinkingBlocks_todayDropsThinkingContent` — closes #527. `thinking` / `thinking_delta` payloads are silently dropped by `parseToken`.
- `test_claude_toolUseStreaming_todayProducesNoTokens` — closes #528. `content_block_start` with `tool_use` + `input_json_delta` payloads yield `nil`, guarding against a widened-matcher regression leaking tool JSON into visible output.
- `test_claude_citationsDelta_todayIgnored` — closes #529. `citations_delta` inside `content_block_delta` drops cleanly; surrounding `text_delta` events pass through.
- `test_claude_stopReasonVariants_todayParseUsageOnly` — closes #530. `refusal`, `max_tokens`, `stop_sequence` produce no tokens but each surfaces `output_tokens` usage. Catches usage regressions (sabotage-verified).
- `test_rateLimit_anthropicErrorBody_surfacesRetryAfterOnly` (in `ClaudeBackendTests.swift`) — closes #531. Structured Claude error body plus `anthropic-ratelimit-*` headers end up as `CloudBackendError.rateLimited(retryAfter: 45)` from the `Retry-After` header alone. Disables retries via `ExponentialBackoffStrategy(maxRetries: 0)` so the first 429 propagates.
- `test_claude_interleavedBlocks_todayFlattensTextInOrder` — closes #532. Three interleaved blocks (`text` → `tool_use` → `text`) flatten `text_delta`s in order and drop the `input_json_delta`.

All fixtures are in-memory via `MockURLProtocol` (UUID-scoped hostnames, no shared global state) or via direct `SSEStreamParser` + `ClaudeBackend.payloadHandler` invocation — no live Anthropic API calls.

## Method

- Sabotage-verified each assertion: temporarily widened `parseToken` to accept `thinking` / `partial_json` / `citation.cited_text` keys (three failures), then broke `parseUsage` output token arithmetic, then dropped the `Retry-After` header in `checkStatusCode`. All tests failed as intended. Reverted before committing.
- Did not modify `ClaudeBackend.swift` or `SSECloudBackend.swift`.
- No `XCTSkipIf` needed — everything the issues call out is currently observable without extending the backend surface.

## Test plan

- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 160 tests, 0 failures
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 204 tests, 0 failures
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 833 tests, 0 failures
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 450 tests, 0 failures

## Release Note

N/A — test-only change.

Closes #527
Closes #528
Closes #529
Closes #530
Closes #531
Closes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)