### PR TITLE
fix(inference): replace fixed holdback in ThinkingParser with suffix-prefix check

### DIFF
--- a/Sources/BaseChatInference/ThinkingBlockFilter.swift
+++ b/Sources/BaseChatInference/ThinkingBlockFilter.swift
@@ -46,13 +46,21 @@ public struct ThinkingParser {
             }
         }
 
-        // Hold back bytes that could be the start of a partial open or close tag.
-        // Size = max(open.count, close.count) to handle either partial tag.
-        let holdback = markers.holdback
-        if buffer.count > holdback {
-            let safeCount = buffer.count - holdback
-            let confirmed = String(buffer.prefix(safeCount))
-            buffer = String(buffer.suffix(holdback))
+        // Hold back only the longest suffix of the buffer that could be a
+        // non-empty prefix of the next marker, preventing premature emission of
+        // partial tags while flushing everything else immediately.
+        let nextMarker = depth > 0 ? markers.close : markers.open
+        let maxCheck = min(buffer.count, nextMarker.count - 1)
+        var holdLength = 0
+        for length in stride(from: maxCheck, through: 1, by: -1) {
+            if nextMarker.hasPrefix(String(buffer.suffix(length))) {
+                holdLength = length
+                break
+            }
+        }
+        if buffer.count > holdLength {
+            let confirmed = String(buffer.prefix(buffer.count - holdLength))
+            buffer = holdLength > 0 ? String(buffer.suffix(holdLength)) : ""
             if !confirmed.isEmpty {
                 events.append(depth > 0 ? .thinkingToken(confirmed) : .token(confirmed))
             }

--- a/Tests/BaseChatInferenceTests/ThinkingBlockFilterTests.swift
+++ b/Tests/BaseChatInferenceTests/ThinkingBlockFilterTests.swift
@@ -26,8 +26,8 @@ final class ThinkingBlockFilterTests: XCTestCase {
     func test_passthrough_noTags_returnsAllAsVisible() {
         var parser = ThinkingParser()
         let events = parser.process("Hello, world!")
-        // Holdback: qwen3 markers max("</think>".count=8, "<think>".count=7) = 8 chars held
-        // The string is 13 chars; 5 are flushed immediately. finalize() releases the rest.
+        // No '<' in "Hello, world!" so no suffix can be a prefix of "<think>".
+        // All 13 chars are emitted immediately; finalize() is a no-op.
         let finalEvents = parser.finalize()
         let allEvents = events + finalEvents
 
@@ -161,7 +161,7 @@ final class ThinkingBlockFilterTests: XCTestCase {
 
     func test_partialOpenTagAtStreamEnd_flushedByFinalize() {
         var parser = ThinkingParser()
-        // Feed exactly the holdback window — it should be held back during process()
+        // "<think" is a prefix of "<think>" so the entire 6 chars are held during process()
         let events = parser.process("<think")
         // finalize() must flush the partial tag as .token (still depth 0, no complete tag seen)
         let finalEvents = parser.finalize()
@@ -180,20 +180,20 @@ final class ThinkingBlockFilterTests: XCTestCase {
 
     func test_visibleBeforePartialTag_emittedImmediately() {
         var parser = ThinkingParser()
-        // Feed a chunk with content longer than holdback followed by a partial tag.
-        // The confirmed prefix must be emitted as .token; the partial tag held back.
+        // "Hello world! " has no suffix that's a prefix of "<think>", so it's emitted
+        // immediately. "<think" is a prefix of "<think>" and is held back.
         let events = parser.process("Hello world! <think")
         let finalEvents = parser.finalize()
         let allEvents = events + finalEvents
 
         let visible = collectVisible(allEvents)
         XCTAssertTrue(visible.hasPrefix("Hello"),
-            "Content confirmed before the holdback window must be emitted as .token")
+            "Content before the partial tag must be emitted as .token immediately")
         XCTAssertTrue(visible.contains("<think"),
             "The incomplete tag should be flushed by finalize() as visible text")
 
-        // Sabotage check: if the holdback were 0, the partial tag would be emitted
-        // immediately and could corrupt subsequent processing.
+        // Sabotage check: if the holdback were disabled entirely, the partial tag
+        // would be emitted immediately and could corrupt subsequent processing.
     }
 
     // MARK: - Stray close tag in visible mode (regression for PR #472)


### PR DESCRIPTION
## Summary

- `ThinkingParser.process()` used a fixed-size holdback (`max(open.count, close.count)` bytes). Short visible tokens like `"answer"` (6 chars) were smaller than the qwen3 holdback (8), so they sat in the buffer until the next token arrived and were split across chunks.
- This broke `maxOutputTokens` semantics when `ThinkingParser` was active: the limit fired on `"an"` instead of `"answer"`, and `finalize()` could flush the remainder past the cap.
- New algorithm: hold back only the longest suffix of the buffer that is a non-empty prefix of the next marker. Visible text with no `<` gets holdback 0 and emits immediately; partial tags are still held correctly.

## Release Note

**ThinkingParser no longer splits short visible tokens at chunk boundaries** — the fixed-size holdback (`max(open, close)` bytes) was replaced with a suffix-prefix check that only holds back characters that could genuinely start the next marker. This fixes `maxOutputTokens` enforcement when thinking blocks are active: the limit now fires on whole tokens rather than mid-split fragments.

## Test plan

- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 903 passed, 0 failures (all `ThinkingBlockFilterTests` and `ThinkingParserEdgeCaseTests` green)
- [x] `swift test --filter BaseChatBackendsTests --traits MLX,Llama` — 240 + 103 = 343 passed, 0 failures (previously 2 failures in `MLXBackendThinkingTests.test_outputTokenCount_doesNotIncludeThinkingTokens`)
- [x] Full CI suite (`BaseChatCoreTests`, `BaseChatInferenceTests`, `BaseChatUITests`, `BaseChatBackendsTests`) — all green
- [x] `BaseChatE2ETests` + `OllamaE2ETests` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)