### PR TITLE
fix(llama): add max-repeat-window early-exit to LlamaGenerationDriver

### DIFF
--- a/Sources/BaseChatBackends/LlamaGenerationDriver.swift
+++ b/Sources/BaseChatBackends/LlamaGenerationDriver.swift
@@ -16,6 +16,14 @@ struct LlamaGenerationDriver {
         category: "inference"
     )
 
+    /// Consecutive identical decoded-token run length that triggers an early exit.
+    ///
+    /// Small models (e.g. smollm2-135m) can enter visible repetition loops where the same
+    /// token string is emitted hundreds of times. The existing `LoopingDetector` catches this
+    /// after the fact; this constant lets the generation loop break out as soon as the
+    /// repetition is unambiguous, saving KV-cache cycles and wall time.
+    private static let maxRepeatWindow = 20
+
     // MARK: - Run
 
     /// Executes the generation loop: clears the KV cache, builds the sampler
@@ -176,6 +184,12 @@ struct LlamaGenerationDriver {
         // Flag set when maxThinkingTokens is reached so we can break the outer loop cleanly.
         var thinkingLimitReached = false
 
+        // Repetition-window state: track the last decoded token string and how
+        // many times it has appeared consecutively. Exceeding `maxRepeatWindow`
+        // triggers an early exit — no need to run the loop all the way to maxTokens.
+        var repeatWindowLast = ""
+        var repeatWindowCount = 0
+
         generationLoop: for iteration in 0..<maxTokens {
             if isCancelled() { break }
 
@@ -190,6 +204,19 @@ struct LlamaGenerationDriver {
 
             // Decode token to text and route through ThinkingParser when active.
             if let text = LlamaTokenization.tokenToString(token, vocab: vocab, invalidUTF8Buffer: &invalidUTF8) {
+                // Repetition guard: identical-token run of ≥maxRepeatWindow terminates the loop.
+                // This catches small-model repetition loops (e.g. smollm2-135m) early,
+                // before the existing post-hoc LoopingDetector has to clean them up.
+                if text == repeatWindowLast {
+                    repeatWindowCount += 1
+                    if repeatWindowCount >= Self.maxRepeatWindow {
+                        break generationLoop
+                    }
+                } else {
+                    repeatWindowLast = text
+                    repeatWindowCount = 1
+                }
+
                 let events: [GenerationEvent] = useParser ? thinkingParser.process(text) : [.token(text)]
                 for event in events {
                     if isFirstToken {


### PR DESCRIPTION
## Summary

- `LlamaGenerationDriver` now tracks a consecutive-identical-token counter inside the `if let text` decode block.
- When the same decoded string is emitted ≥ 20 times in a row the generation loop breaks via `break generationLoop`, and the existing `thinkingParser.finalize()` flush runs as normal.
- The threshold is a `private static let maxRepeatWindow = 20` at the struct level — no magic number inline.

## Motivation

Small models like `smollm2-135m` can enter tight repetition loops during fuzz runs. The post-hoc `LoopingDetector` catches these eventually, but generation was running all the way to `maxTokens` first, burning unnecessary KV-cache cycles and wall time. This guard breaks out as soon as the repetition is unambiguous (20 consecutive identical tokens).

## Test plan

- `LlamaGenerationDriver` is `#if Llama` gated — no hardware-independent unit tests are possible. The change is covered by the fuzz harness (`scripts/fuzz.sh`) against `smollm2-135m` in live runs.
- `BaseChatBackendsTests` (CI-safe, no hardware): 103/103 passed locally.
- No existing Llama unit test file for `LlamaGenerationDriver`; none created per project convention.

## Release Note

**Repetition early-exit in LlamaGenerationDriver** — small models (e.g. `smollm2-135m`) could enter identical-token loops that ran to `maxTokens`, wasting KV-cache and wall time. The generation loop now breaks after 20 consecutive identical tokens, letting `thinkingParser.finalize()` flush normally. This complements the existing post-hoc `LoopingDetector` by cutting runs short before they become expensive.

Closes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)