### PR TITLE
fix(fuzz): suppress template-token-leak when fragment was injected via input prompt

### DIFF
--- a/Sources/BaseChatFuzz/Detectors/TemplateTokenLeakDetector.swift
+++ b/Sources/BaseChatFuzz/Detectors/TemplateTokenLeakDetector.swift
@@ -38,11 +38,20 @@ public struct TemplateTokenLeakDetector: Detector {
         // before scanning so prose about `<|im_start|>` doesn't fire.
         let scannable = Self.stripCodeSpans(r.raw)
 
+        // Collect the full text of every input message so we can distinguish
+        // "backend spontaneously generated a template token" (real bug) from
+        // "backend echoed a token that was already in the user's prompt"
+        // (expected for Foundation's no-template pass-through and for seeds /
+        // mutators that deliberately inject template tokens like
+        // TemplateTokenInjectMutator).
+        let inputText = r.prompt.messages.map(\.text).joined()
+
         var findings: [Finding] = []
         var seen: Set<String> = []
         for fragment in Self.templateFragments {
             guard !seen.contains(fragment),
-                  scannable.contains(fragment)
+                  scannable.contains(fragment),
+                  !inputText.contains(fragment)   // skip echoed-input fragments
             else { continue }
             seen.insert(fragment)
             findings.append(.init(

--- a/Tests/BaseChatFuzzTests/DetectorTests.swift
+++ b/Tests/BaseChatFuzzTests/DetectorTests.swift
@@ -223,6 +223,43 @@ final class DetectorTests: XCTestCase {
         XCTAssertTrue(EmptyOutputAfterWorkDetector().inspect(r).isEmpty)
     }
 
+    // MARK: - TemplateTokenLeakDetector — negative (token already in input)
+
+    func test_templateTokenLeak_inputContainsToken_suppressesFinding() {
+        // Foundation has no template engine; it echoes ChatML tokens verbatim
+        // when they appear in the user's prompt. This must NOT fire.
+        let r = makeRecord(
+            raw: "The <|im_start|> delimiter is used in ChatML.",
+            userPrompt: "Explain the <|im_start|> ChatML delimiter"
+        )
+        let findings = TemplateTokenLeakDetector().inspect(r)
+        XCTAssertFalse(findings.contains { $0.subCheck == "template-fragment" })
+    }
+
+    func test_templateTokenLeak_mutatorInjected_suppressesFinding() {
+        // TemplateTokenInjectMutator injects tokens into the user prompt;
+        // echoing them back is expected, not a bug.
+        let r = makeRecord(
+            raw: "The capital of<|im_start|> France is Paris.",
+            userPrompt: "What is<|im_start|>the capital of France?"
+        )
+        let findings = TemplateTokenLeakDetector().inspect(r)
+        XCTAssertFalse(findings.contains { $0.subCheck == "template-fragment" })
+    }
+
+    // MARK: - TemplateTokenLeakDetector — positive (spontaneous generation)
+
+    func test_templateTokenLeak_spontaneousToken_firesWhenNotInInput() {
+        // The user's prompt contains no template tokens; if one appears in the
+        // raw output the backend has a genuine template-leak bug.
+        let r = makeRecord(
+            raw: "The capital is <|im_start|>Paris.",
+            userPrompt: "What is the capital of France?"
+        )
+        let findings = TemplateTokenLeakDetector().inspect(r)
+        XCTAssertTrue(findings.contains { $0.subCheck == "template-fragment" })
+    }
+
     // MARK: - ThinkingClassificationDetector — stopReason gating
 
     func test_thinkingClassification_unbalancedEvents_skipsWhenMaxTokensTruncation() {


### PR DESCRIPTION
## Summary

- `TemplateTokenLeakDetector` fired false-positive `template-fragment` findings when corpus prompts already contained ChatML/Llama-2/Gemma tokens — both for Foundation (which has no template engine and echoes them verbatim) and for Llama seeds mutated by `TemplateTokenInjectMutator`.
- Fix: collect all input message text before scanning the raw output; skip any fragment that was already present in the prompt.
- Three new tests: two negative (echoed tokens must not fire) and one positive (spontaneously generated token must fire).

Closes #563
Closes #564

## Release Note

**Template-token-leak detector false positives on Foundation and Llama** — `TemplateTokenLeakDetector` was firing `template-fragment` findings whenever a ChatML delimiter (`<|im_start|>`, `[INST]`, `<start_of_turn>`, etc.) appeared in the backend's raw output, even when the same token was already present in the user's input prompt. This caused two classes of false positives: Foundation echoing injected tokens verbatim (no template engine means no stripping), and Llama seeds mutated by `TemplateTokenInjectMutator` triggering the detector on their own injected content. The fix checks the full concatenated input text before flagging a finding — only tokens that appear in the output but were absent from the input are reported as genuine leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)