### PR TITLE
fix(fuzz): gate thinking-classification sub-checks on declared template markers

### DIFF
--- a/Sources/BaseChatFuzz/Detectors/ThinkingClassificationDetector.swift
+++ b/Sources/BaseChatFuzz/Detectors/ThinkingClassificationDetector.swift
@@ -12,34 +12,40 @@ public struct ThinkingClassificationDetector: Detector {
 
     public func inspect(_ r: RunRecord) -> [Finding] {
         var findings: [Finding] = []
-        let markers = r.templateMarkers ?? .init(open: "<think>", close: "</think>")
 
-        // 1. Visible-text leak: literal markers appear in the user-visible string.
-        //    Reads `raw` directly — `rendered` is deprecated and currently
-        //    identical to `raw`. Once the harness starts running `raw` through
-        //    the real UI transform pipeline (follow-up to #499), this will
-        //    switch to the post-transform string.
-        if r.raw.contains(markers.open) || r.raw.contains(markers.close) {
-            findings.append(.init(
-                detectorId: id,
-                subCheck: "visible-text-leak",
-                severity: .flaky,
-                trigger: extractContext(r.raw, around: markers.open),
-                modelId: r.model.id
-            ))
-        }
+        // Sub-checks 1 and 2 are only meaningful for backends that declare
+        // native thinking markers (e.g. Qwen3 with <think>…</think>).
+        // FoundationBackend and LlamaBackend set templateMarkers = nil; a
+        // prompt that *discusses* <think> tags would otherwise produce false
+        // positives here. Skip both sub-checks when no markers are declared.
+        if let markers = r.templateMarkers {
+            // 1. Visible-text leak: literal markers appear in the user-visible string.
+            //    Reads `raw` directly — `rendered` is deprecated and currently
+            //    identical to `raw`. Once the harness starts running `raw` through
+            //    the real UI transform pipeline (follow-up to #499), this will
+            //    switch to the post-transform string.
+            if r.raw.contains(markers.open) || r.raw.contains(markers.close) {
+                findings.append(.init(
+                    detectorId: id,
+                    subCheck: "visible-text-leak",
+                    severity: .flaky,
+                    trigger: extractContext(r.raw, around: markers.open),
+                    modelId: r.model.id
+                ))
+            }
 
-        // 2. Misclassified-as-text: open marker appears in raw stream but no
-        //    structured thinking events were emitted (parser failed; reasoning
-        //    fell into `.text`).
-        if r.raw.contains(markers.open) && r.thinkingRaw.isEmpty {
-            findings.append(.init(
-                detectorId: id,
-                subCheck: "misclassified-as-text",
-                severity: .flaky,
-                trigger: extractContext(r.raw, around: markers.open),
-                modelId: r.model.id
-            ))
+            // 2. Misclassified-as-text: open marker appears in raw stream but no
+            //    structured thinking events were emitted (parser failed; reasoning
+            //    fell into `.text`).
+            if r.raw.contains(markers.open) && r.thinkingRaw.isEmpty {
+                findings.append(.init(
+                    detectorId: id,
+                    subCheck: "misclassified-as-text",
+                    severity: .flaky,
+                    trigger: extractContext(r.raw, around: markers.open),
+                    modelId: r.model.id
+                ))
+            }
         }
 
         // 3. Orphan thinking-complete: complete event fired without any thinking tokens.

--- a/Tests/BaseChatFuzzTests/DetectorTests.swift
+++ b/Tests/BaseChatFuzzTests/DetectorTests.swift
@@ -128,6 +128,32 @@ final class DetectorTests: XCTestCase {
         XCTAssertFalse(findings.contains { $0.subCheck == "misclassified-as-text" })
     }
 
+    func test_thinkingClassification_noMarkersBackend_suppressesVisibleTextLeak() {
+        // FoundationBackend and LlamaBackend have templateMarkers = nil.
+        // A prompt that discusses <think> tags (e.g. "Use the <think> tag in output")
+        // should not trigger visible-text-leak because these backends never emit
+        // native thinking blocks — the marker text is literal user content.
+        let r = makeRecord(
+            raw: "Use the <think> tag in output",
+            markers: nil
+        )
+        let findings = ThinkingClassificationDetector().inspect(r)
+        XCTAssertFalse(findings.contains { $0.subCheck == "visible-text-leak" })
+    }
+
+    func test_thinkingClassification_noMarkersBackend_suppressesMisclassifiedAsText() {
+        // Same nil-markers scenario: raw contains the open marker string but there are
+        // no structured thinking events. For a backend that never declared markers this
+        // is not a misclassification — the text is intentional user-visible content.
+        let r = makeRecord(
+            raw: "<think>reasoning content",
+            thinkingRaw: "",
+            markers: nil
+        )
+        let findings = ThinkingClassificationDetector().inspect(r)
+        XCTAssertFalse(findings.contains { $0.subCheck == "misclassified-as-text" })
+    }
+
     // MARK: - LoopingDetector — positive
 
     func test_looping_renderedLoop_firesOnRepetitiveRendered() {


### PR DESCRIPTION
## Summary

Fixes false-positive `visible-text-leak` and `misclassified-as-text` findings from `ThinkingClassificationDetector` against `FoundationBackend` and `LlamaBackend` when a prompt discusses `<think>` tags.

- Added an `if let markers = r.templateMarkers` guard wrapping sub-checks 1 and 2; both sub-checks are skipped entirely when the backend declares no template markers.
- Removed the `?? .init(open: "<think>", close: "</think>")` fallback — it was the root cause of false positives, silently treating every backend as a thinking-capable backend.
- Sub-checks 3 (orphan-thinking-complete) and 4 (unbalanced-thinking-events) are unchanged; they gate on `thinkingCompleteCount` / `thinkingRaw` which are always empty for non-thinking backends.
- Added two new negative tests: `test_thinkingClassification_noMarkersBackend_suppressesVisibleTextLeak` and `test_thinkingClassification_noMarkersBackend_suppressesMisclassifiedAsText`.
- Sabotage verified: reverting to the original unconditional logic causes both new tests to fail with `XCTAssertFalse failed`.

Closes #562.

## Release Note

**Thinking-classification detector false positives on non-thinking backends** — `ThinkingClassificationDetector` was incorrectly firing `visible-text-leak` and `misclassified-as-text` against `FoundationBackend` and `LlamaBackend` whenever a fuzz prompt mentioned `<think>` tags in its text. These backends never emit native thinking blocks; they report `templateMarkers = nil` in their `FuzzRunner.BackendHandle`. The detector now gates both sub-checks on the backend having declared markers, so prompts that merely discuss `<think>` syntax no longer produce noise in fuzz reports for non-reasoning backends.