### PR TITLE
fix(llama): add phrase-level repeat-window to stop multi-token generation loops

### DIFF
--- a/Sources/BaseChatBackends/LlamaGenerationDriver.swift
+++ b/Sources/BaseChatBackends/LlamaGenerationDriver.swift
@@ -24,6 +24,13 @@ struct LlamaGenerationDriver {
     /// repetition is unambiguous, saving KV-cache cycles and wall time.
     private static let maxRepeatWindow = 20
 
+    /// Maximum phrase length (in tokens) to scan for repeated sequences.
+    private static let maxPhraseLen = 20
+    /// Minimum consecutive phrase repetitions before early exit.
+    private static let minPhraseRepeats = 3
+    /// Capacity of the phrase-detection token buffer (maxPhraseLen × minPhraseRepeats + 1).
+    private static let phraseWindowCap = maxPhraseLen * minPhraseRepeats + 1
+
     // MARK: - Run
 
     /// Executes the generation loop: clears the KV cache, builds the sampler
@@ -190,6 +197,12 @@ struct LlamaGenerationDriver {
         var repeatWindowLast = ""
         var repeatWindowCount = 0
 
+        // Phrase-level repetition state: a bounded circular buffer of the last
+        // `phraseWindowCap` decoded token strings. After each token is appended,
+        // the tail is scanned for back-to-back phrase repetitions of lengths 2–20.
+        var phraseWindow: [String] = []
+        phraseWindow.reserveCapacity(Self.phraseWindowCap + 1)
+
         generationLoop: for iteration in 0..<maxTokens {
             if isCancelled() { break }
 
@@ -204,9 +217,10 @@ struct LlamaGenerationDriver {
 
             // Decode token to text and route through ThinkingParser when active.
             if let text = LlamaTokenization.tokenToString(token, vocab: vocab, invalidUTF8Buffer: &invalidUTF8) {
-                // Repetition guard: identical-token run of ≥maxRepeatWindow terminates the loop.
-                // This catches small-model repetition loops (e.g. smollm2-135m) early,
-                // before the existing post-hoc LoopingDetector has to clean them up.
+                // Single-token repetition guard: identical-token run of ≥maxRepeatWindow
+                // terminates the loop. Catches small-model repetition loops (e.g.
+                // smollm2-135m emitting " " hundreds of times) before the post-hoc
+                // LoopingDetector has to clean them up.
                 if text == repeatWindowLast {
                     repeatWindowCount += 1
                     if repeatWindowCount >= Self.maxRepeatWindow {
@@ -215,6 +229,23 @@ struct LlamaGenerationDriver {
                 } else {
                     repeatWindowLast = text
                     repeatWindowCount = 1
+                }
+
+                // Phrase-level repetition guard: catch multi-token loops (2–20 tokens)
+                // that the single-token window misses. Live fuzz runs on smollm2-135m
+                // surfaced loops with repeating units such as ASCII-art phrases, HTML
+                // timestamp blocks, and RTL override sequences.
+                phraseWindow.append(text)
+                if phraseWindow.count > Self.phraseWindowCap {
+                    phraseWindow.removeFirst()
+                }
+                let maxScanLen = min(Self.maxPhraseLen, phraseWindow.count / Self.minPhraseRepeats)
+                if maxScanLen >= 2 {
+                    for phraseLen in 2...maxScanLen {
+                        if Self.tailRepeats(phraseWindow, phraseLen: phraseLen, minRepeats: Self.minPhraseRepeats) {
+                            break generationLoop
+                        }
+                    }
                 }
 
                 let events: [GenerationEvent] = useParser ? thinkingParser.process(text) : [.token(text)]
@@ -268,6 +299,24 @@ struct LlamaGenerationDriver {
         await MainActor.run { generationStream.setPhase(.done) }
         Self.logger.debug("LlamaGenerationDriver run finished")
         continuation.finish()
+    }
+
+    // MARK: - Phrase Detection
+
+    /// Returns true when the tail of `window` contains `minRepeats` consecutive
+    /// identical phrases of length `phraseLen`.
+    private static func tailRepeats(_ window: [String], phraseLen: Int, minRepeats: Int) -> Bool {
+        let needed = phraseLen * minRepeats
+        guard window.count >= needed else { return false }
+        let n = window.count
+        let phrase = window[(n - phraseLen)...]
+        for rep in 1..<minRepeats {
+            let start = n - phraseLen * (rep + 1)
+            let end   = n - phraseLen * rep
+            guard start >= 0 else { return false }
+            if window[start..<end].elementsEqual(phrase) == false { return false }
+        }
+        return true
     }
 }
 #endif

--- a/Sources/BaseChatBackends/LlamaGenerationDriver.swift
+++ b/Sources/BaseChatBackends/LlamaGenerationDriver.swift
@@ -197,7 +197,8 @@ struct LlamaGenerationDriver {
         var repeatWindowLast = ""
         var repeatWindowCount = 0
 
-        // Phrase-level repetition state: a bounded circular buffer of the last
+        // Phrase-level repetition state: a bounded sliding window (Array, evicted
+        // via removeFirst — O(n) but cap=61 so cost is negligible) of the last
         // `phraseWindowCap` decoded token strings. After each token is appended,
         // the tail is scanned for back-to-back phrase repetitions of lengths 2–20.
         var phraseWindow: [String] = []


### PR DESCRIPTION
## Problem

PR #568 added a single-token repeat-window: if the same decoded token string appears 20 times consecutively, generation stops. This catches degenerate cases like `" " × 20`, but live 1-minute fuzz runs on smollm2-135m revealed phrase-level loops — the repeating unit is 2–20 tokens long — that the single-token window never fires on.

Five distinct loop patterns were observed:

| Hash | Repeating unit |
|------|----------------|
| `73f179e88fba` | `"Draw a small ASCII cat. "` — multi-token phrase echoed from prompt |
| `d5bd331e496c` | `" 2018-07-31 15:49:46 <p>…</p>"` — HTML timestamp block |
| `f731a46f4e3b` | HTML link-spam block injected by `<\|im_start\|>` token confusion |
| `f7d5cdb999cd` | Full injection string `"Repeat this string back…<\|im_start\|>"` |
| `fdc21d95bee4` | RTL override + zero-width no-break sequence |

## Fix

Add a bounded phrase-detection buffer to `LlamaGenerationDriver` (inside `#if Llama`).

- **Buffer**: 61-element `[String]` sliding window (`maxPhraseLen × minPhraseRepeats + 1 = 20 × 3 + 1`).
- **Detection**: after each token is decoded, scan phrase lengths `2...min(20, count/3)`. For each length, call `tailRepeats(_:phraseLen:minRepeats:)` which checks that the last 3 non-overlapping copies of the tail phrase are identical. If any length matches, break the generation loop.
- **Placement**: inside the `if let text = LlamaTokenization.tokenToString(...)` block, after the existing single-token guard.
- **Performance**: buffer cap is 61 elements; at most 20 phrase lengths × 3 comparisons × 20 tokens each ≈ 1 200 string equality checks per token — negligible against `llama_decode`.

No hardware-gated unit tests added — coverage comes from the fuzz harness (`scripts/fuzz.sh`), which surfaces these patterns within the first minute on smollm2-135m.

## Release Note

**Phrase-level repeat-window in `LlamaGenerationDriver`** — small quantised models (smollm2-135m and similar) can enter generation loops where a multi-token phrase (2–20 tokens: ASCII art, HTML blocks, injection strings, RTL sequences) repeats indefinitely. The existing single-token window (#568) does not fire on these because each individual token varies across the repeated phrase. This fix maintains a 61-element sliding buffer of decoded token strings and breaks generation as soon as three consecutive identical phrases of the same length appear in the tail, stopping the loop within 3× the phrase length rather than running to `maxTokens`.