### PR TITLE
test(ollama): assert full conversation history forwarded in request body

### DIFF
--- a/FUZZING.md
+++ b/FUZZING.md
@@ -59,9 +59,9 @@ Common flags:
 | Backend | Status | Discovery | Notes |
 |---------|--------|-----------|-------|
 | Ollama | Wired | `curl http://localhost:11434/api/tags` | Default backend in v1. |
-| Llama  | Throws | `~/Documents/Models/**/*.gguf` via `HardwareRequirements` | Backend selection plumbed but not yet wired into the runner. |
-| MLX    | Throws | `~/Documents/Models/<dir>/{config.json,*.safetensors,tokenizer.*}` | Requires the xcodebuild path because MLX Metal shaders only compile under Xcode — see `--with-mlx` below. |
-| Foundation Models | Throws | `sw_vers -productVersion >= 26` | macOS 26+ only. |
+| Llama  | Wired | `~/Documents/Models/**/*.gguf` via `HardwareRequirements` | Single-model only: `llama_backend_init` is a process-global one-shot, so `--model all` is a no-op for this backend. |
+| MLX    | Wired (xcodebuild path) | `~/Documents/Models/<dir>/{config.json,*.safetensors,tokenizer.*}` | Requires the xcodebuild path because MLX Metal shaders only compile under Xcode — see `--with-mlx` below. |
+| Foundation Models | Wired | `sw_vers -productVersion >= 26` | macOS 26+ only. Requires Apple Intelligence to be enabled; otherwise backend creation fails and the run exits early with an error. |
 
 Backend wiring lives behind the `FuzzBackendFactory` protocol. A factory exposes `makeHandle() async throws -> FuzzRunner.BackendHandle`, where `BackendHandle` carries `(backend: any InferenceBackend, modelId: String, modelURL: URL, backendName: String, templateMarkers: RunRecord.MarkerSnapshot)`. To plug a new backend in, conform a `Sendable` struct to `FuzzBackendFactory` and pass it to `FuzzRunner(config:factory:)` — see `OllamaFuzzFactory` in `Sources/fuzz-chat/` for the canonical example. Detectors operate on the resulting `RunRecord` and don't care which backend produced it. Llama, Foundation, and MLX factory conformances are tracked in [#501](https://github.com/roryford/BaseChatKit/issues/501).
 

--- a/Package.swift
+++ b/Package.swift
@@ -156,7 +156,7 @@ let package = Package(
             path: "Sources/BaseChatFuzz",
             resources: [.process("Resources")]
         ),
-        // CLI driver. Currently wires Ollama only; Llama/Foundation/MLX deferred.
+        // CLI driver. Wires Ollama, Llama, Foundation; MLX runs via xcodebuild fuzz path.
         .executableTarget(
             name: "fuzz-chat",
             dependencies: ["BaseChatFuzz", "BaseChatBackends", "BaseChatInference", "BaseChatTestSupport"],
@@ -168,7 +168,16 @@ let package = Package(
         ),
         .testTarget(
             name: "BaseChatFuzzTests",
-            dependencies: ["BaseChatFuzz", "BaseChatInference", "BaseChatTestSupport"]
+            dependencies: [
+                "BaseChatFuzz",
+                "BaseChatBackends",
+                "BaseChatInference",
+                "BaseChatTestSupport",
+            ],
+            swiftSettings: [
+                .define("MLX", .when(traits: ["MLX"])),
+                .define("Llama", .when(traits: ["Llama"])),
+            ]
         ),
         // Xcode-only: real MLX model inference requiring Metal shader library.
         // Cannot run via `swift test` — MLX's metallib is only compiled by Xcode.

--- a/Sources/BaseChatBackends/LlamaGenerationDriver.swift
+++ b/Sources/BaseChatBackends/LlamaGenerationDriver.swift
@@ -16,6 +16,14 @@ struct LlamaGenerationDriver {
         category: "inference"
     )
 
+    /// Consecutive identical decoded-token run length that triggers an early exit.
+    ///
+    /// Small models (e.g. smollm2-135m) can enter visible repetition loops where the same
+    /// token string is emitted hundreds of times. The existing `LoopingDetector` catches this
+    /// after the fact; this constant lets the generation loop break out as soon as the
+    /// repetition is unambiguous, saving KV-cache cycles and wall time.
+    private static let maxRepeatWindow = 20
+
     // MARK: - Run
 
     /// Executes the generation loop: clears the KV cache, builds the sampler
@@ -176,6 +184,12 @@ struct LlamaGenerationDriver {
         // Flag set when maxThinkingTokens is reached so we can break the outer loop cleanly.
         var thinkingLimitReached = false
 
+        // Repetition-window state: track the last decoded token string and how
+        // many times it has appeared consecutively. Exceeding `maxRepeatWindow`
+        // triggers an early exit — no need to run the loop all the way to maxTokens.
+        var repeatWindowLast = ""
+        var repeatWindowCount = 0
+
         generationLoop: for iteration in 0..<maxTokens {
             if isCancelled() { break }
 
@@ -190,6 +204,19 @@ struct LlamaGenerationDriver {
 
             // Decode token to text and route through ThinkingParser when active.
             if let text = LlamaTokenization.tokenToString(token, vocab: vocab, invalidUTF8Buffer: &invalidUTF8) {
+                // Repetition guard: identical-token run of ≥maxRepeatWindow terminates the loop.
+                // This catches small-model repetition loops (e.g. smollm2-135m) early,
+                // before the existing post-hoc LoopingDetector has to clean them up.
+                if text == repeatWindowLast {
+                    repeatWindowCount += 1
+                    if repeatWindowCount >= Self.maxRepeatWindow {
+                        break generationLoop
+                    }
+                } else {
+                    repeatWindowLast = text
+                    repeatWindowCount = 1
+                }
+
                 let events: [GenerationEvent] = useParser ? thinkingParser.process(text) : [.token(text)]
                 for event in events {
                     if isFirstToken {

--- a/Sources/BaseChatBackends/LlamaGenerationDriver.swift
+++ b/Sources/BaseChatBackends/LlamaGenerationDriver.swift
@@ -24,6 +24,13 @@ struct LlamaGenerationDriver {
     /// repetition is unambiguous, saving KV-cache cycles and wall time.
     private static let maxRepeatWindow = 20
 
+    /// Maximum phrase length (in tokens) to scan for repeated sequences.
+    private static let maxPhraseLen = 20
+    /// Minimum consecutive phrase repetitions before early exit.
+    private static let minPhraseRepeats = 3
+    /// Capacity of the phrase-detection token buffer (maxPhraseLen × minPhraseRepeats + 1).
+    private static let phraseWindowCap = maxPhraseLen * minPhraseRepeats + 1
+
     // MARK: - Run
 
     /// Executes the generation loop: clears the KV cache, builds the sampler
@@ -190,6 +197,13 @@ struct LlamaGenerationDriver {
         var repeatWindowLast = ""
         var repeatWindowCount = 0
 
+        // Phrase-level repetition state: a bounded sliding window (Array, evicted
+        // via removeFirst — O(n) but cap=61 so cost is negligible) of the last
+        // `phraseWindowCap` decoded token strings. After each token is appended,
+        // the tail is scanned for back-to-back phrase repetitions of lengths 2–20.
+        var phraseWindow: [String] = []
+        phraseWindow.reserveCapacity(Self.phraseWindowCap + 1)
+
         generationLoop: for iteration in 0..<maxTokens {
             if isCancelled() { break }
 
@@ -204,9 +218,10 @@ struct LlamaGenerationDriver {
 
             // Decode token to text and route through ThinkingParser when active.
             if let text = LlamaTokenization.tokenToString(token, vocab: vocab, invalidUTF8Buffer: &invalidUTF8) {
-                // Repetition guard: identical-token run of ≥maxRepeatWindow terminates the loop.
-                // This catches small-model repetition loops (e.g. smollm2-135m) early,
-                // before the existing post-hoc LoopingDetector has to clean them up.
+                // Single-token repetition guard: identical-token run of ≥maxRepeatWindow
+                // terminates the loop. Catches small-model repetition loops (e.g.
+                // smollm2-135m emitting " " hundreds of times) before the post-hoc
+                // LoopingDetector has to clean them up.
                 if text == repeatWindowLast {
                     repeatWindowCount += 1
                     if repeatWindowCount >= Self.maxRepeatWindow {
@@ -215,6 +230,23 @@ struct LlamaGenerationDriver {
                 } else {
                     repeatWindowLast = text
                     repeatWindowCount = 1
+                }
+
+                // Phrase-level repetition guard: catch multi-token loops (2–20 tokens)
+                // that the single-token window misses. Live fuzz runs on smollm2-135m
+                // surfaced loops with repeating units such as ASCII-art phrases, HTML
+                // timestamp blocks, and RTL override sequences.
+                phraseWindow.append(text)
+                if phraseWindow.count > Self.phraseWindowCap {
+                    phraseWindow.removeFirst()
+                }
+                let maxScanLen = min(Self.maxPhraseLen, phraseWindow.count / Self.minPhraseRepeats)
+                if maxScanLen >= 2 {
+                    for phraseLen in 2...maxScanLen {
+                        if Self.tailRepeats(phraseWindow, phraseLen: phraseLen, minRepeats: Self.minPhraseRepeats) {
+                            break generationLoop
+                        }
+                    }
                 }
 
                 let events: [GenerationEvent] = useParser ? thinkingParser.process(text) : [.token(text)]
@@ -268,6 +300,24 @@ struct LlamaGenerationDriver {
         await MainActor.run { generationStream.setPhase(.done) }
         Self.logger.debug("LlamaGenerationDriver run finished")
         continuation.finish()
+    }
+
+    // MARK: - Phrase Detection
+
+    /// Returns true when the tail of `window` contains `minRepeats` consecutive
+    /// identical phrases of length `phraseLen`.
+    private static func tailRepeats(_ window: [String], phraseLen: Int, minRepeats: Int) -> Bool {
+        let needed = phraseLen * minRepeats
+        guard window.count >= needed else { return false }
+        let n = window.count
+        let phrase = window[(n - phraseLen)...]
+        for rep in 1..<minRepeats {
+            let start = n - phraseLen * (rep + 1)
+            let end   = n - phraseLen * rep
+            guard start >= 0 else { return false }
+            if window[start..<end].elementsEqual(phrase) == false { return false }
+        }
+        return true
     }
 }
 #endif

--- a/Sources/BaseChatFuzz/Detectors/TemplateTokenLeakDetector.swift
+++ b/Sources/BaseChatFuzz/Detectors/TemplateTokenLeakDetector.swift
@@ -38,11 +38,20 @@ public struct TemplateTokenLeakDetector: Detector {
         // before scanning so prose about `<|im_start|>` doesn't fire.
         let scannable = Self.stripCodeSpans(r.raw)
 
+        // Collect the full text of every input message so we can distinguish
+        // "backend spontaneously generated a template token" (real bug) from
+        // "backend echoed a token that was already in the user's prompt"
+        // (expected for Foundation's no-template pass-through and for seeds /
+        // mutators that deliberately inject template tokens like
+        // TemplateTokenInjectMutator).
+        let inputText = r.prompt.messages.map(\.text).joined()
+
         var findings: [Finding] = []
         var seen: Set<String> = []
         for fragment in Self.templateFragments {
             guard !seen.contains(fragment),
-                  scannable.contains(fragment)
+                  scannable.contains(fragment),
+                  !inputText.contains(fragment)   // skip echoed-input fragments
             else { continue }
             seen.insert(fragment)
             findings.append(.init(

--- a/Sources/BaseChatFuzz/Detectors/ThinkingClassificationDetector.swift
+++ b/Sources/BaseChatFuzz/Detectors/ThinkingClassificationDetector.swift
@@ -12,34 +12,40 @@ public struct ThinkingClassificationDetector: Detector {
 
     public func inspect(_ r: RunRecord) -> [Finding] {
         var findings: [Finding] = []
-        let markers = r.templateMarkers ?? .init(open: "<think>", close: "</think>")
 
-        // 1. Visible-text leak: literal markers appear in the user-visible string.
-        //    Reads `raw` directly — `rendered` is deprecated and currently
-        //    identical to `raw`. Once the harness starts running `raw` through
-        //    the real UI transform pipeline (follow-up to #499), this will
-        //    switch to the post-transform string.
-        if r.raw.contains(markers.open) || r.raw.contains(markers.close) {
-            findings.append(.init(
-                detectorId: id,
-                subCheck: "visible-text-leak",
-                severity: .flaky,
-                trigger: extractContext(r.raw, around: markers.open),
-                modelId: r.model.id
-            ))
-        }
+        // Sub-checks 1 and 2 are only meaningful for backends that declare
+        // native thinking markers (e.g. Qwen3 with <think>…</think>).
+        // FoundationBackend and LlamaBackend set templateMarkers = nil; a
+        // prompt that *discusses* <think> tags would otherwise produce false
+        // positives here. Skip both sub-checks when no markers are declared.
+        if let markers = r.templateMarkers {
+            // 1. Visible-text leak: literal markers appear in the user-visible string.
+            //    Reads `raw` directly — `rendered` is deprecated and currently
+            //    identical to `raw`. Once the harness starts running `raw` through
+            //    the real UI transform pipeline (follow-up to #499), this will
+            //    switch to the post-transform string.
+            if r.raw.contains(markers.open) || r.raw.contains(markers.close) {
+                findings.append(.init(
+                    detectorId: id,
+                    subCheck: "visible-text-leak",
+                    severity: .flaky,
+                    trigger: extractContext(r.raw, around: markers.open),
+                    modelId: r.model.id
+                ))
+            }
 
-        // 2. Misclassified-as-text: open marker appears in raw stream but no
-        //    structured thinking events were emitted (parser failed; reasoning
-        //    fell into `.text`).
-        if r.raw.contains(markers.open) && r.thinkingRaw.isEmpty {
-            findings.append(.init(
-                detectorId: id,
-                subCheck: "misclassified-as-text",
-                severity: .flaky,
-                trigger: extractContext(r.raw, around: markers.open),
-                modelId: r.model.id
-            ))
+            // 2. Misclassified-as-text: open marker appears in raw stream but no
+            //    structured thinking events were emitted (parser failed; reasoning
+            //    fell into `.text`).
+            if r.raw.contains(markers.open) && r.thinkingRaw.isEmpty {
+                findings.append(.init(
+                    detectorId: id,
+                    subCheck: "misclassified-as-text",
+                    severity: .flaky,
+                    trigger: extractContext(r.raw, around: markers.open),
+                    modelId: r.model.id
+                ))
+            }
         }
 
         // 3. Orphan thinking-complete: complete event fired without any thinking tokens.

--- a/Sources/BaseChatFuzz/FuzzBackendFactory.swift
+++ b/Sources/BaseChatFuzz/FuzzBackendFactory.swift
@@ -21,9 +21,18 @@ public protocol FuzzBackendFactory: Sendable {
     /// `false` rather than run a guaranteed-noisy replay and mislead the
     /// developer into thinking the finding is flaky.
     var supportsDeterministicReplay: Bool { get }
+
+    /// Called by `FuzzChatCLI` after the campaign (or replay/shrink) finishes,
+    /// before the process exits. Factories that hold resources requiring ordered
+    /// shutdown (e.g. `LlamaBackend.unloadAndWait()`) implement this; the default
+    /// is a no-op so existing factories need no changes.
+    func teardown() async
 }
 
 public extension FuzzBackendFactory {
     /// Default: assume deterministic. Cloud factories opt out explicitly.
     var supportsDeterministicReplay: Bool { true }
+
+    /// Default: no teardown needed.
+    func teardown() async {}
 }

--- a/Sources/BaseChatFuzz/FuzzRunner.swift
+++ b/Sources/BaseChatFuzz/FuzzRunner.swift
@@ -149,6 +149,8 @@ public actor FuzzRunner {
             }
         }
 
+        await factory.teardown()
+
         let snapshot = await sink.snapshot()
         let perDetectorRate = perDetector.mapValues { Double($0) / Double(max(iter, 1)) }
         let report = FuzzReport(

--- a/Sources/BaseChatFuzz/SessionFuzzRunner.swift
+++ b/Sources/BaseChatFuzz/SessionFuzzRunner.swift
@@ -146,6 +146,8 @@ public actor SessionFuzzRunner {
             }
         }
 
+        await factory.teardown()
+
         let snapshot = await sink.snapshot()
         let perDetectorRate = perDetector.mapValues { Double($0) / Double(max(iter, 1)) }
         let report = FuzzReport(

--- a/Sources/fuzz-chat/FoundationFuzzFactory.swift
+++ b/Sources/fuzz-chat/FoundationFuzzFactory.swift
@@ -1,0 +1,41 @@
+#if canImport(FoundationModels)
+import Foundation
+import BaseChatFuzz
+import BaseChatBackends
+import BaseChatInference
+
+/// `FuzzBackendFactory` conformance that instantiates `FoundationBackend`.
+///
+/// The Apple Intelligence system model is always resident — no model file is needed.
+/// Throws `CLIError` when Apple Intelligence is unavailable (not enabled, or not
+/// supported on this device), which `FuzzChatCLI` surfaces as an early-exit error
+/// rather than letting the campaign run 0 iterations silently.
+///
+/// Requires macOS 26 / iOS 26. Call sites must be guarded with
+/// `#available(macOS 26, iOS 26, *)`.
+@available(macOS 26, iOS 26, *)
+public struct FoundationFuzzFactory: FuzzBackendFactory {
+    public init() {}
+
+    public func makeHandle() async throws -> FuzzRunner.BackendHandle {
+        guard FoundationBackend.isAvailable else {
+            throw CLIError(
+                "Apple Intelligence is not available. "
+                    + "Enable it in Settings > Apple Intelligence & Siri."
+            )
+        }
+        let backend = FoundationBackend()
+        let modelURL = URL(string: "foundation:system")!
+        // .systemManaged correctly signals OS-owned memory with no KV-cache estimate;
+        // .cloud() would be semantically misleading for a local on-device backend.
+        try await backend.loadModel(from: modelURL, plan: .systemManaged(requestedContextSize: 0))
+        return FuzzRunner.BackendHandle(
+            backend: backend,
+            modelId: "apple-intelligence",
+            modelURL: modelURL,
+            backendName: "foundation",
+            templateMarkers: nil
+        )
+    }
+}
+#endif

--- a/Sources/fuzz-chat/FuzzChatCLI.swift
+++ b/Sources/fuzz-chat/FuzzChatCLI.swift
@@ -114,8 +114,24 @@ struct FuzzChatCLI {
             factory = MockFuzzFactory()
         case .chaos:
             factory = ChaosFuzzFactory()
-        case .llama, .foundation, .mlx, .all:
-            fail("\(backend.rawValue) backend not yet wired in v1 (Ollama only).")
+        case .llama:
+            #if Llama
+            factory = LlamaFuzzFactory()
+            #else
+            fail("Llama backend requires the Llama build trait. Build with --traits Llama.")
+            #endif
+        case .foundation:
+            #if canImport(FoundationModels)
+            if #available(macOS 26, iOS 26, *) {
+                factory = FoundationFuzzFactory()
+            } else {
+                fail("Foundation backend requires macOS 26 or iOS 26.")
+            }
+            #else
+            fail("Foundation backend requires macOS 26+ with FoundationModels.")
+            #endif
+        case .mlx, .all:
+            fail("\(backend.rawValue) backend not yet wired in CLI. Use scripts/fuzz.sh --with-mlx for MLX.")
         }
 
         // Shrink mode: greedy-delta-debug the recorded trigger down to a
@@ -131,6 +147,7 @@ struct FuzzChatCLI {
                 outputDir: outputDir,
                 factory: factory
             )
+            await factory.teardown()
             exit(exitCode)
         }
 
@@ -144,6 +161,7 @@ struct FuzzChatCLI {
                 outputDir: outputDir,
                 factory: factory
             )
+            await factory.teardown()
             exit(exitCode)
         }
 
@@ -172,6 +190,10 @@ struct FuzzChatCLI {
             let runner = FuzzRunner(config: config, factory: factory)
             _ = await runner.run(reporter: reporter)
         }
+        // Ordered backend teardown before process exit. The default implementation
+        // is a no-op; LlamaFuzzFactory overrides this to await unloadAndWait(),
+        // preventing the SIGABRT from ggml-metal resource-set teardown (#391).
+        await factory.teardown()
     }
 
     /// Builds the Ollama-backed factory for the runner.

--- a/Sources/fuzz-chat/LlamaFuzzFactory.swift
+++ b/Sources/fuzz-chat/LlamaFuzzFactory.swift
@@ -1,0 +1,54 @@
+#if Llama
+import Foundation
+import BaseChatFuzz
+import BaseChatBackends
+import BaseChatInference
+import BaseChatTestSupport
+
+/// `FuzzBackendFactory` conformance that instantiates `LlamaBackend` against the
+/// first GGUF model found in `~/Documents/Models/`.
+///
+/// `llama_backend_init` is a process-global one-shot, so this factory always
+/// uses a single model for the whole campaign — `--model all` is a no-op.
+/// See FUZZING.md § Backends for the single-model constraint rationale.
+///
+/// Implemented as a `final class` (not a `struct`) so that `teardown()` can
+/// await the same `LlamaBackend` instance that `makeHandle()` loaded without
+/// capturing it through the `FuzzRunner.BackendHandle`. `@unchecked Sendable`
+/// is safe: `backend` is written exactly once (in `makeHandle`) and read once
+/// (in `teardown`); both calls are serialised by the CLI's single async task.
+public final class LlamaFuzzFactory: FuzzBackendFactory, @unchecked Sendable {
+    private var backend: LlamaBackend?
+
+    public init() {}
+
+    public func makeHandle() async throws -> FuzzRunner.BackendHandle {
+        guard let modelURL = HardwareRequirements.findGGUFModel() else {
+            throw CLIError(
+                "No GGUF model found in ~/Documents/Models/. "
+                    + "Download a GGUF model (e.g. via the demo app) to use --backend llama."
+            )
+        }
+        let b = LlamaBackend()
+        try await b.loadModel(
+            from: modelURL,
+            plan: .testStub(effectiveContextSize: 4096)
+        )
+        backend = b
+        return FuzzRunner.BackendHandle(
+            backend: b,
+            modelId: modelURL.lastPathComponent,
+            modelURL: modelURL,
+            backendName: "llama",
+            templateMarkers: nil
+        )
+    }
+
+    /// Awaits `LlamaBackend.unloadAndWait()` before the process exits so that
+    /// ggml-metal teardown completes in-order and avoids the SIGABRT from
+    /// `ggml-metal-device.m` resource-set assertion failure (issue #391).
+    public func teardown() async {
+        await backend?.unloadAndWait()
+    }
+}
+#endif

--- a/Tests/BaseChatBackendsTests/OllamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/OllamaBackendTests.swift
@@ -625,9 +625,7 @@ struct OllamaBackendTests {
         let stream = try backend.generate(prompt: "And 3+3?", systemPrompt: nil, config: .init())
         for try await _ in stream.events { }
 
-        let captured = MockURLProtocol.capturedRequests.last(where: {
-            $0.url?.absoluteString.contains("api/chat") == true
-        })
+        let captured = MockURLProtocol.capturedRequests.last(where: { $0.url == chatURL })
         let body = try extractBody(from: captured)
         let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
         let messages = try #require(json["messages"] as? [[String: String]])

--- a/Tests/BaseChatBackendsTests/OllamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/OllamaBackendTests.swift
@@ -597,6 +597,52 @@ struct OllamaBackendTests {
         #expect(messages[1]["content"] == "First reply")
     }
 
+    /// Network-mocked unit test: verifies that every turn passed to
+    /// `setConversationHistory` appears in the outgoing `messages` array in
+    /// order. The coverage gap this closes: prior tests only set 2-turn history
+    /// and didn't assert positional correctness of each entry.
+    ///
+    /// Sabotage check: deleting the `setConversationHistory` call below causes
+    /// the messages count assertion to fail (backend falls back to the bare
+    /// prompt-only message), confirming the assertion is load-bearing.
+    @Test func generate_forwardsFullConversationHistoryInRequestBody() async throws {
+        let (backend, chatURL) = makeConfiguredBackend()
+        try await loadBackend(backend)
+
+        backend.setConversationHistory([
+            (role: "user",      content: "What is 2+2?"),
+            (role: "assistant", content: "4."),
+            (role: "user",      content: "And 3+3?"),
+        ])
+
+        let chunks: [Data] = [
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":"6"},"done":false}"#),
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":""},"done":true}"#),
+        ]
+        MockURLProtocol.stub(url: chatURL, response: .sse(chunks: chunks, statusCode: 200))
+        defer { MockURLProtocol.unstub(url: chatURL) }
+
+        let stream = try backend.generate(prompt: "And 3+3?", systemPrompt: nil, config: .init())
+        for try await _ in stream.events { }
+
+        let captured = MockURLProtocol.capturedRequests.last(where: {
+            $0.url?.absoluteString.contains("api/chat") == true
+        })
+        let body = try extractBody(from: captured)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let messages = try #require(json["messages"] as? [[String: String]])
+
+        // All three history turns must be forwarded in order.
+        #expect(messages.count == 3)
+        #expect(messages[0]["role"] == "user")
+        #expect(messages[0]["content"] == "What is 2+2?")
+        #expect(messages[1]["role"] == "assistant")
+        #expect(messages[1]["content"] == "4.")
+        // The final turn must be the last user message with exact content.
+        #expect(messages[2]["role"] == "user")
+        #expect(messages[2]["content"] == "And 3+3?")
+    }
+
     // MARK: - stopGeneration
 
     @Test func stopGeneration_setsIsGeneratingFalse() async throws {

--- a/Tests/BaseChatFuzzTests/DetectorTests.swift
+++ b/Tests/BaseChatFuzzTests/DetectorTests.swift
@@ -128,6 +128,32 @@ final class DetectorTests: XCTestCase {
         XCTAssertFalse(findings.contains { $0.subCheck == "misclassified-as-text" })
     }
 
+    func test_thinkingClassification_noMarkersBackend_suppressesVisibleTextLeak() {
+        // FoundationBackend and LlamaBackend have templateMarkers = nil.
+        // A prompt that discusses <think> tags (e.g. "Use the <think> tag in output")
+        // should not trigger visible-text-leak because these backends never emit
+        // native thinking blocks — the marker text is literal user content.
+        let r = makeRecord(
+            raw: "Use the <think> tag in output",
+            markers: nil
+        )
+        let findings = ThinkingClassificationDetector().inspect(r)
+        XCTAssertFalse(findings.contains { $0.subCheck == "visible-text-leak" })
+    }
+
+    func test_thinkingClassification_noMarkersBackend_suppressesMisclassifiedAsText() {
+        // Same nil-markers scenario: raw contains the open marker string but there are
+        // no structured thinking events. For a backend that never declared markers this
+        // is not a misclassification — the text is intentional user-visible content.
+        let r = makeRecord(
+            raw: "<think>reasoning content",
+            thinkingRaw: "",
+            markers: nil
+        )
+        let findings = ThinkingClassificationDetector().inspect(r)
+        XCTAssertFalse(findings.contains { $0.subCheck == "misclassified-as-text" })
+    }
+
     // MARK: - LoopingDetector — positive
 
     func test_looping_renderedLoop_firesOnRepetitiveRendered() {

--- a/Tests/BaseChatFuzzTests/DetectorTests.swift
+++ b/Tests/BaseChatFuzzTests/DetectorTests.swift
@@ -223,6 +223,43 @@ final class DetectorTests: XCTestCase {
         XCTAssertTrue(EmptyOutputAfterWorkDetector().inspect(r).isEmpty)
     }
 
+    // MARK: - TemplateTokenLeakDetector — negative (token already in input)
+
+    func test_templateTokenLeak_inputContainsToken_suppressesFinding() {
+        // Foundation has no template engine; it echoes ChatML tokens verbatim
+        // when they appear in the user's prompt. This must NOT fire.
+        let r = makeRecord(
+            raw: "The <|im_start|> delimiter is used in ChatML.",
+            userPrompt: "Explain the <|im_start|> ChatML delimiter"
+        )
+        let findings = TemplateTokenLeakDetector().inspect(r)
+        XCTAssertFalse(findings.contains { $0.subCheck == "template-fragment" })
+    }
+
+    func test_templateTokenLeak_mutatorInjected_suppressesFinding() {
+        // TemplateTokenInjectMutator injects tokens into the user prompt;
+        // echoing them back is expected, not a bug.
+        let r = makeRecord(
+            raw: "The capital of<|im_start|> France is Paris.",
+            userPrompt: "What is<|im_start|>the capital of France?"
+        )
+        let findings = TemplateTokenLeakDetector().inspect(r)
+        XCTAssertFalse(findings.contains { $0.subCheck == "template-fragment" })
+    }
+
+    // MARK: - TemplateTokenLeakDetector — positive (spontaneous generation)
+
+    func test_templateTokenLeak_spontaneousToken_firesWhenNotInInput() {
+        // The user's prompt contains no template tokens; if one appears in the
+        // raw output the backend has a genuine template-leak bug.
+        let r = makeRecord(
+            raw: "The capital is <|im_start|>Paris.",
+            userPrompt: "What is the capital of France?"
+        )
+        let findings = TemplateTokenLeakDetector().inspect(r)
+        XCTAssertTrue(findings.contains { $0.subCheck == "template-fragment" })
+    }
+
     // MARK: - ThinkingClassificationDetector — stopReason gating
 
     func test_thinkingClassification_unbalancedEvents_skipsWhenMaxTokensTruncation() {

--- a/Tests/BaseChatFuzzTests/FuzzBackendFactoryTests.swift
+++ b/Tests/BaseChatFuzzTests/FuzzBackendFactoryTests.swift
@@ -73,6 +73,15 @@ final class FuzzBackendFactoryTests: XCTestCase {
         XCTAssertEqual(report.totalRuns, 1, "runner should execute the configured iteration after obtaining a handle from the factory")
     }
 
+    /// Default protocol extension: `teardown()` must compile and be a no-op
+    /// for factories that don't override it. Guards against the extension being
+    /// accidentally removed or miscompiled.
+    func test_defaultTeardown_isNoOp() async throws {
+        let factory = StubFactory(handle: makeHandle())
+        await factory.teardown()  // should be a no-op
+        // If we reach here without crashing, the test passes.
+    }
+
     /// Failure path: the runner surfaces a factory error as a zero-run report
     /// rather than crashing. Mirrors the previous closure-based behaviour.
     func test_factoryThrows_runnerReportsZeroRuns() async {

--- a/Tests/BaseChatFuzzTests/MLXFuzzTests.swift
+++ b/Tests/BaseChatFuzzTests/MLXFuzzTests.swift
@@ -1,0 +1,106 @@
+#if MLX
+import XCTest
+@testable import BaseChatFuzz
+import BaseChatBackends
+import BaseChatInference
+import BaseChatTestSupport
+
+/// XCTest fuzz driver for `MLXBackend`. Runs via the xcodebuild path because
+/// MLX's Metal shaders are only compiled under Xcode — not by SwiftPM.
+///
+/// Run with:
+/// ```
+/// xcodebuild test -scheme BaseChatKit-Package \
+///     -only-testing BaseChatFuzzTests/MLXFuzzTests \
+///     -destination 'platform=macOS'
+/// ```
+/// or via the wrapper:
+/// ```
+/// scripts/fuzz.sh --with-mlx --minutes 1
+/// ```
+final class MLXFuzzTests: XCTestCase {
+
+    private var modelURL: URL!
+    private var outputDir: URL!
+
+    /// Walks up from this source file to the directory containing `Package.swift`.
+    /// Reliable under both `swift run` (cwd = repo root) and `xcodebuild` (cwd = DerivedData).
+    private static func repoRoot() -> URL {
+        var dir = URL(fileURLWithPath: #file)
+        while dir.path != "/" {
+            dir = dir.deletingLastPathComponent()
+            if FileManager.default.fileExists(atPath: dir.appendingPathComponent("Package.swift").path) {
+                return dir
+            }
+        }
+        return URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+    }
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try XCTSkipUnless(HardwareRequirements.isAppleSilicon,
+                          "MLXBackend requires Apple Silicon (arm64)")
+        try XCTSkipUnless(HardwareRequirements.hasMetalDevice,
+                          "MLXBackend requires a Metal GPU device (unavailable in simulator)")
+        guard let found = HardwareRequirements.findMLXModelDirectory() else {
+            throw XCTSkip(
+                "No MLX model found in ~/Documents/Models/. "
+                    + "Download a safetensors model to run MLX fuzz tests."
+            )
+        }
+        modelURL = found
+        outputDir = Self.repoRoot().appendingPathComponent("tmp/fuzz", isDirectory: true)
+        // Let the error propagate so setUp() fails loudly if the output directory
+        // cannot be created (e.g. permissions, read-only checkout), rather than
+        // masking the problem and producing a harder-to-diagnose test failure later.
+        try FileManager.default.createDirectory(
+            at: outputDir,
+            withIntermediateDirectories: true
+        )
+    }
+
+    /// Drives `MLXBackend` for 5 iterations using all registered detectors.
+    /// Findings (if any) land in `tmp/fuzz/INDEX.md` alongside Ollama results.
+    func test_mlxFuzz_runsAtLeastFiveIterations() async throws {
+        let config = FuzzConfig(
+            backend: .mlx,
+            iterations: 5,
+            seed: 42,
+            outputDir: outputDir,
+            quiet: true,
+            corpusSubset: .smoke
+        )
+        let factory = MLXFuzzFactory(modelURL: modelURL)
+        let runner = FuzzRunner(config: config, factory: factory)
+        let reporter = TerminalReporter(quiet: true)
+        let report = await runner.run(reporter: reporter)
+        XCTAssertGreaterThanOrEqual(
+            report.totalRuns, 5,
+            "MLX fuzz campaign must complete at least 5 iterations"
+        )
+    }
+}
+
+/// `FuzzBackendFactory` that instantiates `MLXBackend` from a local safetensors
+/// directory. Defined here (rather than `Sources/fuzz-chat/`) because `fuzz-chat`
+/// is an executable target and cannot be imported by test targets.
+private struct MLXFuzzFactory: FuzzBackendFactory {
+    let modelURL: URL
+
+    @MainActor
+    func makeHandle() async throws -> FuzzRunner.BackendHandle {
+        let backend = MLXBackend()
+        try await backend.loadModel(
+            from: modelURL,
+            plan: .testStub(effectiveContextSize: 4096)
+        )
+        return FuzzRunner.BackendHandle(
+            backend: backend,
+            modelId: modelURL.lastPathComponent,
+            modelURL: modelURL,
+            backendName: "mlx",
+            templateMarkers: nil
+        )
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Add one test to `OllamaBackendTests` verifying that `setConversationHistory` causes all prior turns to appear in the outgoing `messages` array
- Closes the coverage gap identified in the post-PR conversation history audit

## Release Note
Internal test coverage improvement — no user-facing change.