### PR TITLE
fix: isolate BackgroundDownloadIntegrationTests shared state to prevent double-free

### DIFF
--- a/Sources/BaseChatInference/Services/BackgroundDownloadManager.swift
+++ b/Sources/BaseChatInference/Services/BackgroundDownloadManager.swift
@@ -107,6 +107,15 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable {
     /// can read `storageService.modelsDirectory` when moving completed downloads.
     internal let storageService: ModelStorageService
 
+    /// Per-instance background session identifier.
+    ///
+    /// Stored rather than re-derived from `Self.sessionIdentifier` each time so that
+    /// tests can inject a unique identifier per test run. Reusing the same identifier
+    /// across two concurrent `BackgroundDownloadManager` instances causes the OS to
+    /// deliver delegate callbacks to a deallocated object — a double-free crash.
+    @ObservationIgnored
+    private let _sessionIdentifier: String
+
     /// Backing store for the lazily created background URL session.
     ///
     /// Kept as an optional so `deinit` can skip invalidation when the session
@@ -123,7 +132,7 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable {
     @ObservationIgnored
     private var backgroundSession: URLSession {
         if let existing = _backgroundSession { return existing }
-        let config = URLSessionConfiguration.background(withIdentifier: Self.sessionIdentifier)
+        let config = URLSessionConfiguration.background(withIdentifier: _sessionIdentifier)
         config.isDiscretionary = false
         config.sessionSendsLaunchEvents = true
         // Allow cellular for user-initiated downloads.
@@ -175,8 +184,21 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable {
 
     // MARK: - Init
 
-    public init(storageService: ModelStorageService = ModelStorageService()) {
+    /// Creates a new download manager.
+    ///
+    /// - Parameters:
+    ///   - storageService: Provides the models directory path. Defaults to a standard service.
+    ///   - sessionIdentifier: Background `URLSession` identifier. Defaults to the framework's
+    ///     canonical identifier derived from `BaseChatConfiguration`. Pass a unique value in
+    ///     tests to prevent OS-level session collisions between manager instances — reusing the
+    ///     same identifier while a previous instance is still being torn down causes the OS to
+    ///     deliver callbacks to a deallocated delegate, resulting in a double-free crash.
+    public init(
+        storageService: ModelStorageService = ModelStorageService(),
+        sessionIdentifier: String? = nil
+    ) {
         self.storageService = storageService
+        self._sessionIdentifier = sessionIdentifier ?? Self.sessionIdentifier
         super.init()
     }
 

--- a/Sources/BaseChatInference/Services/BackgroundDownloadManager.swift
+++ b/Sources/BaseChatInference/Services/BackgroundDownloadManager.swift
@@ -772,7 +772,9 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable {
         try data.write(to: tempURL, options: .atomic)
         if FileManager.default.fileExists(atPath: pendingMetadataFileURL.path) {
             // replaceItemAt atomically swaps tempURL into the destination, removing tempURL.
-            try FileManager.default.replaceItemAt(
+            // The returned URL is the final destination (always pendingMetadataFileURL here);
+            // we discard it because we already know the path.
+            _ = try FileManager.default.replaceItemAt(
                 pendingMetadataFileURL,
                 withItemAt: tempURL,
                 backupItemName: nil,

--- a/Tests/BaseChatInferenceTests/BackgroundDownloadIntegrationTests.swift
+++ b/Tests/BaseChatInferenceTests/BackgroundDownloadIntegrationTests.swift
@@ -13,6 +13,15 @@ final class BackgroundDownloadIntegrationTests: XCTestCase {
     private var manager: BackgroundDownloadManager!
     private var tempDirectory: URL!
 
+    // Unique per-test session identifier prevents OS-level URLSession collisions.
+    //
+    // URLSessionConfiguration.background sessions are keyed by identifier at the OS level.
+    // When two BackgroundDownloadManager instances share the same identifier and one is being
+    // torn down while the next test's manager is initialised, the OS can deliver delegate
+    // callbacks to the already-deallocated instance — a double-free (SIGABRT). A UUID suffix
+    // ensures each test gets a fresh, isolated session with no shared OS state.
+    private var testSessionIdentifier: String!
+
     // Per-test persistence directory derived from the manager's caches layout.
     private var persistenceDir: URL {
         let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
@@ -29,7 +38,8 @@ final class BackgroundDownloadIntegrationTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
-        manager = BackgroundDownloadManager()
+        testSessionIdentifier = "com.basechatkit.test.download.\(UUID().uuidString)"
+        manager = BackgroundDownloadManager(sessionIdentifier: testSessionIdentifier)
 
         tempDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("BackgroundDownloadIntegrationTests-\(UUID().uuidString)")
@@ -46,6 +56,7 @@ final class BackgroundDownloadIntegrationTests: XCTestCase {
         try? FileManager.default.removeItem(at: pendingMetadataURL)
 
         manager = nil
+        testSessionIdentifier = nil
         try await super.tearDown()
     }
 
@@ -370,7 +381,10 @@ final class BackgroundDownloadIntegrationTests: XCTestCase {
         try writePendingDownload(model)
 
         // A fresh manager starts with no active downloads.
-        let freshManager = BackgroundDownloadManager()
+        // Use a unique session identifier to avoid OS-level URLSession collisions with setUp's manager.
+        let freshManager = BackgroundDownloadManager(
+            sessionIdentifier: "com.basechatkit.test.download.\(UUID().uuidString)"
+        )
         XCTAssertNil(freshManager.activeDownloads[model.id], "No active downloads before reconnect")
 
         // reconnectBackgroundSession calls restorePendingDownloads internally.
@@ -383,8 +397,10 @@ final class BackgroundDownloadIntegrationTests: XCTestCase {
     }
 
     func test_reconnectBackgroundSession_restoresPendingMLXSnapshotMetadata() throws {
+        // Use a unique session identifier to avoid OS-level URLSession collisions with setUp's manager.
         let manager = BackgroundDownloadManager(
-            storageService: ModelStorageService(baseDirectory: tempDirectory)
+            storageService: ModelStorageService(baseDirectory: tempDirectory),
+            sessionIdentifier: "com.basechatkit.test.download.\(UUID().uuidString)"
         )
         let model = makeModel(
             repoID: "mlx-community/Test-4bit",

--- a/Tests/BaseChatInferenceTests/DownloadManagerTests.swift
+++ b/Tests/BaseChatInferenceTests/DownloadManagerTests.swift
@@ -13,7 +13,8 @@ final class DownloadManagerTests: XCTestCase {
             .appendingPathComponent("DownloadManagerTests-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
         manager = BackgroundDownloadManager(
-            storageService: ModelStorageService(baseDirectory: tempDirectory)
+            storageService: ModelStorageService(baseDirectory: tempDirectory),
+            sessionIdentifier: "com.basechatkit.test.download.\(UUID().uuidString)"
         )
     }
 
@@ -203,7 +204,9 @@ final class DownloadManagerTests: XCTestCase {
     // MARK: - Active Downloads Initial State
 
     func test_activeDownloads_initiallyEmpty() {
-        let freshManager = BackgroundDownloadManager()
+        let freshManager = BackgroundDownloadManager(
+            sessionIdentifier: "com.basechatkit.test.download.\(UUID().uuidString)"
+        )
         XCTAssertTrue(
             freshManager.activeDownloads.isEmpty,
             "A freshly created manager should have no active downloads"

--- a/Tests/BaseChatInferenceTests/ResumableDownloadTests.swift
+++ b/Tests/BaseChatInferenceTests/ResumableDownloadTests.swift
@@ -19,7 +19,8 @@ final class ResumableDownloadTests: XCTestCase {
         try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
 
         manager = BackgroundDownloadManager(
-            storageService: ModelStorageService(baseDirectory: tempDirectory)
+            storageService: ModelStorageService(baseDirectory: tempDirectory),
+            sessionIdentifier: "com.basechatkit.test.download.\(UUID().uuidString)"
         )
     }
 

--- a/Tests/BaseChatUITests/ModelManagementViewModelTests.swift
+++ b/Tests/BaseChatUITests/ModelManagementViewModelTests.swift
@@ -202,7 +202,9 @@ final class ModelManagementViewModelTests: XCTestCase {
 
         let vm = ModelManagementViewModel.live(
             huggingFaceService: mock,
-            downloadManager: BackgroundDownloadManager()
+            downloadManager: BackgroundDownloadManager(
+                sessionIdentifier: "com.basechatkit.test.download.\(UUID().uuidString)"
+            )
         )
         vm.searchQuery = "configured"
 
@@ -395,7 +397,9 @@ final class ModelManagementViewModelTests: XCTestCase {
     func test_downloadSync_removesFailedEntry_afterDisplayWindow() async {
         // Inject a failed DownloadState into the manager's activeDownloads so that the
         // sync loop picks it up and eventually sweeps it out of trackedDownloads.
-        let manager = BackgroundDownloadManager()
+        let manager = BackgroundDownloadManager(
+            sessionIdentifier: "com.basechatkit.test.download.\(UUID().uuidString)"
+        )
         let mock = MockHuggingFaceService()
 
         let model = DownloadableModel(


### PR DESCRIPTION
Fixes #538

## Summary

- `URLSessionConfiguration.background` sessions are keyed by identifier at the OS level. Two `BackgroundDownloadManager` instances sharing the same identifier (`com.basechatkit.modeldownload`) caused the OS to deliver delegate callbacks to the first instance while it was being torn down by the previous test — a libmalloc nano-zone double-free (`SIGABRT: freed pointer was not the last allocation`).
- Added a `sessionIdentifier` parameter to `BackgroundDownloadManager.init` (defaults to `Self.sessionIdentifier` in production — no behavior change for app code).
- Updated `setUp` to generate a unique UUID-suffixed identifier per test, ensuring each test gets a fully isolated OS-level background session.
- Applied the same unique-identifier pattern to two inline manager constructions in `test_reconnectBackgroundSession_restoresPendingDownloads` and `test_reconnectBackgroundSession_restoresPendingMLXSnapshotMetadata`.

## Test plan

- [ ] `swift test --filter BaseChatInferenceTests.BackgroundDownloadIntegrationTests --disable-default-traits` passes 5+ consecutive times without SIGABRT
- [ ] Full CI suite passes: `BaseChatCoreTests`, `BaseChatInferenceTests`, `BaseChatUITests`, `BaseChatBackendsTests` all green

## Release Note

**BackgroundDownloadIntegrationTests SIGABRT** — fixed a double-free crash that aborted the `BaseChatInferenceTests` suite whenever `test_startDownload_duplicateModel_doesNotAddTwice` ran back-to-back with another download test. The crash was caused by two `BackgroundDownloadManager` instances sharing the same OS-level `URLSession` background identifier: as one instance was torn down, the system delivered delegate callbacks to its already-freed memory. The fix adds a `sessionIdentifier` parameter to `BackgroundDownloadManager.init` (defaulting to the canonical production value) and uses a unique UUID-based identifier in each test, giving every test a fully isolated session with no shared OS state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)