### PR TITLE
fix(ollama): reserve thinking budget so reasoning models emit visible content

### DIFF
--- a/Sources/BaseChatBackends/OllamaBackend.swift
+++ b/Sources/BaseChatBackends/OllamaBackend.swift
@@ -95,12 +95,18 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
             messages.append(["role": "user", "content": prompt])
         }
 
+        // For thinking models (e.g. gemma4, qwen3), Ollama counts thinking tokens
+        // against num_predict. Reserve budget for both thinking and visible output
+        // so the model isn't silently cut off mid-think before any content is produced.
+        // maxOutputTokens is enforced client-side in parseResponseStream.
+        let visibleBudget = config.maxOutputTokens ?? 2048
+        let thinkingBudget = config.maxThinkingTokens ?? 2048
         let options: [String: Any] = [
             "temperature": config.temperature,
             "top_p": config.topP,
             "top_k": config.topK.map { Int($0) } ?? 40,
             "repeat_penalty": config.repeatPenalty,
-            "num_predict": config.maxOutputTokens ?? 2048,
+            "num_predict": visibleBudget + thinkingBudget,
         ]
 
         let body: [String: Any] = [
@@ -161,6 +167,8 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
         var thinkingOpen = false
         var thinkingTokenCount = 0
         let thinkingLimit = config.maxThinkingTokens
+        var visibleTokenCount = 0
+        let visibleLimit = config.maxOutputTokens
 
         func noteEventYielded() throws {
             let now = ContinuousClock.now
@@ -203,8 +211,14 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
             }
 
             if let content = parsed.content, !content.isEmpty {
+                if let limit = visibleLimit, visibleTokenCount >= limit {
+                    // Client-side cap reached; stop the stream cleanly.
+                    continuation.finish()
+                    return
+                }
                 try noteEventYielded()
                 continuation.yield(.token(content))
+                visibleTokenCount += 1
             }
 
             if parsed.done {

--- a/Tests/BaseChatBackendsTests/OllamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/OllamaBackendTests.swift
@@ -855,6 +855,120 @@ struct OllamaBackendTests {
         let json = #"{"message":{"role":"assistant","content":"hi"},"done":false}"#
         #expect(OllamaBackend.extractThinking(from: json) == nil)
     }
+
+    // MARK: - num_predict Budget (thinking + visible)
+
+    /// Regression for the gemma4:e4b empty-response bug: Ollama counts
+    /// chain-of-thought tokens against `num_predict`, so a single budget of
+    /// `maxOutputTokens` was being fully consumed inside `<think>` on thinking
+    /// models, leaving zero budget for visible output. The fix splits the
+    /// server-side budget into `visibleBudget + thinkingBudget` and re-caps
+    /// visible output client-side in `parseResponseStream`.
+    ///
+    /// Sabotage check (verified locally): reverting the production change to
+    /// `"num_predict": config.maxOutputTokens ?? 2048` makes this test fail
+    /// with `num_predict == 100` instead of `150`.
+    @Test func generate_numPredict_equalsVisiblePlusThinkingBudget() async throws {
+        let (backend, chatURL) = makeConfiguredBackend()
+        try await loadBackend(backend)
+
+        let chunks: [Data] = [
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":"ok"},"done":false}"#),
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":""},"done":true}"#),
+        ]
+        MockURLProtocol.stub(url: chatURL, response: .sse(chunks: chunks, statusCode: 200))
+        defer { MockURLProtocol.unstub(url: chatURL) }
+
+        var config = GenerationConfig()
+        config.maxOutputTokens = 100
+        config.maxThinkingTokens = 50
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: config)
+        for try await _ in stream.events { }
+
+        let captured = MockURLProtocol.capturedRequests.last(where: { $0.url == chatURL })
+        let body = try extractBody(from: captured)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let options = try #require(json["options"] as? [String: Any])
+        let numPredict = try #require(options["num_predict"] as? Int)
+        #expect(numPredict == 150)
+    }
+
+    /// When both caps are `nil` (default `GenerationConfig()`), each side
+    /// defaults to 2048, so `num_predict` must land on `4096`. Pins the
+    /// default-default arithmetic so a future refactor doesn't silently
+    /// shift the server-side ceiling.
+    @Test func generate_numPredict_bothCapsNil_defaultsTo4096() async throws {
+        let (backend, chatURL) = makeConfiguredBackend()
+        try await loadBackend(backend)
+
+        let chunks: [Data] = [
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":"ok"},"done":false}"#),
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":""},"done":true}"#),
+        ]
+        MockURLProtocol.stub(url: chatURL, response: .sse(chunks: chunks, statusCode: 200))
+        defer { MockURLProtocol.unstub(url: chatURL) }
+
+        // GenerationConfig() ships maxOutputTokens = 2048 by default. Null it
+        // out so we exercise the `?? 2048` fallback on both sides.
+        var config = GenerationConfig()
+        config.maxOutputTokens = nil
+        config.maxThinkingTokens = nil
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: config)
+        for try await _ in stream.events { }
+
+        let captured = MockURLProtocol.capturedRequests.last(where: { $0.url == chatURL })
+        let body = try extractBody(from: captured)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let options = try #require(json["options"] as? [String: Any])
+        let numPredict = try #require(options["num_predict"] as? Int)
+        #expect(numPredict == 4096)
+    }
+
+    /// Because we doubled the server-side budget, visible output must be
+    /// re-capped client-side. This fixture emits 5 content lines but sets
+    /// `maxOutputTokens = 3`; the consumer must see exactly 3 `.token`
+    /// events, then the stream terminates cleanly (no error thrown, no
+    /// `.thinkingComplete` because no thinking was ever emitted).
+    ///
+    /// Sabotage check (verified locally): deleting the `continuation.finish();
+    /// return` guard in `parseResponseStream` makes this test fail with
+    /// tokens.count == 5.
+    ///
+    /// Known limitation (documented on the PR): `visibleTokenCount` counts
+    /// NDJSON lines, not true tokens. A follow-up will switch to Ollama's
+    /// `eval_count` field for exact accounting.
+    @Test func streaming_visibleCap_terminatesStreamCleanly() async throws {
+        let (backend, chatURL) = makeConfiguredBackend()
+        try await loadBackend(backend)
+
+        let chunks: [Data] = [
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":"a"},"done":false}"#),
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":"b"},"done":false}"#),
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":"c"},"done":false}"#),
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":"d"},"done":false}"#),
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":"e"},"done":false}"#),
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":""},"done":true}"#),
+        ]
+        MockURLProtocol.stub(url: chatURL, response: .sse(chunks: chunks, statusCode: 200))
+        defer { MockURLProtocol.unstub(url: chatURL) }
+
+        var config = GenerationConfig()
+        config.maxOutputTokens = 3
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: config)
+
+        var tokens: [String] = []
+        var sawThinkingComplete = false
+        for try await event in stream.events {
+            switch event {
+            case .token(let t): tokens.append(t)
+            case .thinkingComplete: sawThinkingComplete = true
+            default: break
+            }
+        }
+
+        #expect(tokens == ["a", "b", "c"])
+        #expect(!sawThinkingComplete, "no thinking was emitted so no .thinkingComplete should fire")
+    }
 }
 
 // MARK: - OllamaModelListService Tests


### PR DESCRIPTION
## Summary

- Split Ollama's `num_predict` into `visibleBudget + thinkingBudget` so thinking models (gemma4:e4b, qwen3.x, deepseek-r1) no longer exhaust their entire output budget inside `<think>` and return blank messages.
- Re-cap visible output client-side in `parseResponseStream` so the doubled server-side ceiling doesn't change user-observed token counts.

## Root cause

Ollama counts chain-of-thought tokens against `num_predict`. `OllamaBackend.chat(...)` was sending a single `num_predict = config.maxOutputTokens ?? 2048`, which meant a thinking model could burn its entire allotment inside the reasoning block and produce zero visible tokens. This regressed all four `OllamaE2ETests` the moment `gemma4:e4b` was installed locally, and matches the #487 repro pattern (done:true with only `thinking` populated).

## Fix

- In `chat(...)`: compute `visibleBudget = config.maxOutputTokens ?? 2048` and `thinkingBudget = config.maxThinkingTokens ?? 2048`, then send `num_predict = visibleBudget + thinkingBudget`.
- In `parseResponseStream(...)`: track `visibleTokenCount` against `config.maxOutputTokens` and `continuation.finish()` cleanly once the visible cap is hit, so user-observed output stays bounded even though the server is now allowed to produce more.

## Known limitation

`visibleTokenCount` counts NDJSON lines, not true tokens — a single line can carry multiple words. This is deliberate scope control: ship the thinking-budget fix standalone first. The next PR in this series will wire Ollama's done-line `eval_count` field for exact token accounting.

## Test plan

Three new tests added to `Tests/BaseChatBackendsTests/OllamaBackendTests.swift`:

- `generate_numPredict_equalsVisiblePlusThinkingBudget` — sets `maxOutputTokens=100, maxThinkingTokens=50`, asserts outgoing `options.num_predict == 150`.
- `generate_numPredict_bothCapsNil_defaultsTo4096` — sets both to `nil`, asserts `num_predict == 4096` (2048 + 2048), pinning the default-default arithmetic.
- `streaming_visibleCap_terminatesStreamCleanly` — fixture emits 5 content lines with `maxOutputTokens=3`, asserts exactly 3 `.token` events and a clean stream termination with no `.thinkingComplete` firing.

Sabotage-verified per CLAUDE.md: reverting `num_predict` to the old expression breaks both budget tests; deleting the client-side cap guard breaks the visible-cap test. Production code restored before commit.

All five CI suites pass locally:
- `BaseChatCoreTests`: 204 tests, 0 failures
- `BaseChatInferenceTests`: 837 tests, 0 failures
- `BaseChatInferenceSwiftTestingTests`: 69 tests, 0 failures
- `BaseChatUITests`: 450 tests, 0 failures
- `BaseChatBackendsTests`: 107 tests, 0 failures

No existing tests needed updates. The only `num_predict` hits in `Tests/` outside this file are prose mentions in doc comments (verified unchanged).

## Release Note

**Ollama thinking models emit visible content again** — Ollama counts chain-of-thought tokens against `num_predict`, so reasoning models such as `gemma4:e4b`, `qwen3.x`, and `deepseek-r1` were exhausting the entire output budget inside their `<think>` block and returning empty responses. `OllamaBackend` now reserves budget for both thinking and visible output (each defaulting to 2048) and re-caps visible output client-side, so users see the model's answer again without having to manually raise `maxOutputTokens`. A follow-up will switch the client-side cap from NDJSON line count to Ollama's exact `eval_count` for precise token accounting.