### PR TITLE
docs(foundation): document absence of thinking/reasoning surface

### DIFF
--- a/Sources/BaseChatBackends/FoundationBackend.swift
+++ b/Sources/BaseChatBackends/FoundationBackend.swift
@@ -12,6 +12,44 @@ import BaseChatInference
 /// is ignored; it simply creates a new session and verifies availability.
 ///
 /// Requires iOS 26+ / macOS 26+.
+///
+/// ## Thinking / reasoning support
+///
+/// BaseChatKit surfaces reasoning tokens from capable models via
+/// ``GenerationEvent/thinkingToken(_:)`` and ``GenerationEvent/thinkingComplete``.
+/// The Ollama and Llama backends emit these events today. **FoundationBackend
+/// does not**, because Apple's public FoundationModels SDK (Xcode 26.4,
+/// module version 1.4.34) exposes no reasoning/thinking surface at all:
+///
+/// - `LanguageModelSession.ResponseStream<String>.Snapshot` carries only
+///   `content: String.PartiallyGenerated` and `rawContent: GeneratedContent`.
+///   There is no reasoning field, no `thinking` channel, no parallel stream.
+/// - `LanguageModelSession.Response<Content>` exposes only `content`,
+///   `rawContent`, and `transcriptEntries` — no reasoning block.
+/// - `Transcript.Entry` is `instructions | prompt | toolCalls | toolOutput | response`.
+///   There is no `reasoning` / `thinking` / `chainOfThought` case.
+/// - `Transcript.Segment` is `text | structure` only.
+/// - `GenerationOptions` exposes only `sampling`, `temperature`,
+///   `maximumResponseTokens`. There is no `reasoningEffort`,
+///   `enableReasoning`, or reasoning-budget knob.
+/// - `SystemLanguageModel.UseCase` offers only `.general` and `.contentTagging`.
+/// - A case-insensitive search of the entire `FoundationModels.swiftinterface`
+///   for `reason|think|chainofthought|cot|scratchpad|deliberat|inner|monolog`
+///   returns zero hits outside `Availability.UnavailableReason` and
+///   `GenerationError.failureReason` (both unrelated to model reasoning).
+///
+/// In other words: whatever chain-of-thought Apple's on-device model performs
+/// happens opaquely inside the generator. The SDK returns only the final
+/// user-visible answer. There is nothing for this backend to map onto
+/// `.thinkingToken` or `.thinkingComplete`, and synthesising fake thinking
+/// events from the visible content would be misleading.
+///
+/// When Apple ships a reasoning surface (e.g. a `reasoning` case on
+/// `Transcript.Segment`, a `reasoningContent` field on `ResponseStream.Snapshot`,
+/// or a reasoning-enabled `UseCase`), this backend should be updated to emit
+/// `.thinkingToken` while reasoning is in flight and `.thinkingComplete`
+/// exactly once at the transition to visible content, matching the pattern
+/// already used by ``OllamaBackend``.
 @available(iOS 26, macOS 26, *)
 public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
 


### PR DESCRIPTION
## Summary

Audit-only PR. Apple's public `FoundationModels` SDK does not expose any reasoning/thinking surface, so `FoundationBackend` cannot emit `.thinkingToken` / `.thinkingComplete` the way `OllamaBackend` and `LlamaBackend` do. This PR records the audit findings as a docstring on `FoundationBackend` so the gap is explicit in-tree, not lurking as a silent TODO.

## Audit findings — what Apple exposes today

Inspected `FoundationModels.swiftinterface` in Xcode 26.4 / macOS 26.4 SDK (module version 1.4.34). The same file is shipped for arm64e-apple-ios, arm64e-apple-macos, and arm64e-apple-ios-macabi — they are API-identical.

| Surface | Fields | Reasoning? |
|---|---|---|
| `LanguageModelSession.ResponseStream<String>.Snapshot` | `content: String.PartiallyGenerated`, `rawContent: GeneratedContent` | No |
| `LanguageModelSession.Response<Content>` | `content`, `rawContent`, `transcriptEntries` | No |
| `Transcript.Entry` | `instructions` \| `prompt` \| `toolCalls` \| `toolOutput` \| `response` | No reasoning case |
| `Transcript.Segment` | `text` \| `structure` | No reasoning segment |
| `GenerationOptions` | `sampling`, `temperature`, `maximumResponseTokens` | No reasoning budget / effort knob |
| `SystemLanguageModel.UseCase` | `.general`, `.contentTagging` | No reasoning mode |

A case-insensitive grep of the entire 1503-line swiftinterface for `reason|think|chainofthought|cot|scratchpad|deliberat|inner|monolog` returns zero hits outside `Availability.UnavailableReason` and `GenerationError.failureReason`, both unrelated to model reasoning.

## Decision

Whatever chain-of-thought Apple's on-device model performs happens opaquely inside the generator. The SDK returns only the final user-visible answer, and synthesising fake `.thinkingToken` events from visible content would be misleading. This PR documents that formally on `FoundationBackend` as a docstring (not a standalone markdown file — docs stay co-located with code per the task brief). When Apple ships a reasoning surface, we flip the backend to emit `.thinkingToken` / `.thinkingComplete` matching the `OllamaBackend.parseResponseStream` pattern; the docstring records the pattern to follow.

## Test plan

- [x] Pure additive docstring — no behavior change, no new tests required
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 204 tests, 0 failures
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 837 tests, 0 failures
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 450 tests, 0 failures
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 107 tests, 0 failures
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits` — 69 tests, 0 failures

## Release Note

No user-visible change — docs-only PR, no version bump. For framework developers wondering why `FoundationBackend` is silent on thinking tokens while `OllamaBackend` and `LlamaBackend` emit them: Apple's public `FoundationModels` SDK (Xcode 26.4, module version 1.4.34) does not expose a reasoning or thinking channel on `ResponseStream.Snapshot`, `Transcript.Entry`, `Transcript.Segment`, `GenerationOptions`, or `SystemLanguageModel.UseCase`. Any chain-of-thought happens opaquely inside the generator, so there is nothing to map onto `GenerationEvent.thinkingToken` / `.thinkingComplete`. The audit is recorded as a docstring on `FoundationBackend` and will be revisited when Apple ships a reasoning surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)