### PR TITLE
feat(mlx): enforce thinking budget, preflight model architecture, route output through ThinkingParser

### DIFF
--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -98,6 +98,71 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         self.cachePolicy = cachePolicy
     }
 
+    // MARK: - Architecture Allowlist
+
+    /// Canonical `model_type` values that `mlx-swift-lm`'s `LLMTypeRegistry.shared`
+    /// can serve as chat/instruct LMs. Anything outside this set — CLIP, SigLIP,
+    /// Whisper, BERT embeddings, Qwen2-VL vision encoders, etc. — is refused at
+    /// load time via `InferenceError.unsupportedModelArchitecture`.
+    ///
+    /// Sourced from `LLMTypeRegistry.shared` in mlx-swift-lm
+    /// (`Libraries/MLXLLM/LLMModelFactory.swift`). When mlx-swift-lm adds a new
+    /// LM architecture, update this list to match so the preflight doesn't reject
+    /// a freshly supported model.
+    static let supportedLMArchitectures: Set<String> = [
+        "mistral", "llama", "phi", "phi3", "phimoe",
+        "gemma", "gemma2", "gemma3", "gemma3_text", "gemma3n",
+        "qwen2", "qwen3", "qwen3_moe", "qwen3_next",
+        "qwen3_5", "qwen3_5_moe", "qwen3_5_text",
+        "minicpm", "starcoder2", "cohere", "openelm", "internlm2",
+        "deepseek_v3", "granite", "granitemoehybrid",
+        "mimo", "mimo_v2_flash", "minimax",
+        "glm4", "glm4_moe", "glm4_moe_lite",
+        "acereason", "falcon_h1", "bitnet", "smollm3",
+        "ernie4_5", "lfm2", "lfm2_moe",
+        "baichuan_m1", "exaone4", "gpt_oss",
+        "lille-130m", "olmoe", "olmo2", "olmo3",
+        "bailing_moe", "nanochat", "nemotron_h",
+        "afmoe", "jamba_3b", "mistral3", "apertus",
+    ]
+
+    /// Reads `config.json` at `url` and throws
+    /// `InferenceError.unsupportedModelArchitecture` if the declared `model_type`
+    /// is not a chat/instruct LM. If `config.json` is missing or unreadable the
+    /// check is a no-op — mlx-swift-lm's own load path will then surface the
+    /// real error (missing weights, malformed directory, etc.).
+    static func validateArchitecture(at url: URL) throws {
+        let configURL = url.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: configURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            // Missing / malformed config.json: let the MLX load path produce the
+            // real diagnostic rather than masking it with a false architecture error.
+            return
+        }
+
+        let modelType = (json["model_type"] as? String)?
+            .lowercased()
+            .trimmingCharacters(in: .whitespaces) ?? ""
+        if !modelType.isEmpty, supportedLMArchitectures.contains(modelType) {
+            return
+        }
+
+        // Some HF repos omit model_type but include an `architectures` array
+        // (e.g. ["LlamaForCausalLM"]). Accept the load if any entry's snake_case
+        // prefix matches the allowlist — this keeps older snapshots working.
+        if let archs = json["architectures"] as? [String] {
+            for arch in archs {
+                let normalized = arch.lowercased()
+                if Self.supportedLMArchitectures.contains(where: { normalized.hasPrefix($0) }) {
+                    return
+                }
+            }
+        }
+
+        let reported = modelType.isEmpty ? (json["architectures"] as? [String])?.joined(separator: ",") ?? "unknown" : modelType
+        throw InferenceError.unsupportedModelArchitecture(reported)
+    }
+
     // MARK: - Model Lifecycle
 
     public func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
@@ -107,6 +172,15 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         // here and kept for consistency with the protocol. Future work could honour
         // `plan.effectiveContextSize` to cap generation length.
         unloadModel()
+
+        // Preflight: refuse non-LM architectures up front so a CLIP/SigLIP/Whisper
+        // snapshot can't crash MLX mid-generation or silently produce garbage tokens.
+        // We read config.json directly rather than letting mlx-swift-lm attempt the
+        // load and fail — mlx-swift-lm's own error message ("unsupportedModelType")
+        // surfaces through `modelLoadFailed(underlying:)` and hides the root cause
+        // from the UI. Throwing `.unsupportedModelArchitecture` here makes the reason
+        // explicit and lets `ChatError` map it to `.selectModel`.
+        try Self.validateArchitecture(at: url)
 
         let progressHandler = withStateLock { _loadProgressHandler }
 
@@ -222,11 +296,20 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 var thinkingParser = ThinkingParser(markers: config.thinkingMarkers ?? .qwen3)
                 let useParser = config.thinkingMarkers != nil
 
+                // Enforces `config.maxThinkingTokens` with the same semantics as
+                // LlamaGenerationDriver: a thinking model that runs away on a 16 GB
+                // Mac can OOM mid-generation, so when the configured budget is hit
+                // we stop emitting further thinking tokens and break out of the
+                // MLX stream. Visible `.token` events are never counted toward
+                // this budget. See issue #550.
+                var thinkingTokenCount = 0
+                var thinkingLimitReached = false
+
                 let mlxStream = try await modelContainer.generate(
                     messages: messages,
                     parameters: generateConfig
                 )
-                for await generation in mlxStream {
+                outer: for await generation in mlxStream {
                     if Task.isCancelled { break }
                     if let text = generation.chunk {
                         for event in useParser ? thinkingParser.process(text) : [GenerationEvent.token(text)] {
@@ -241,7 +324,15 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                             // Only count visible output tokens toward maxOutputTokens limit
                             if case .token = event { outputTokenCount += 1 }
                             continuation.yield(event)
+                            if case .thinkingToken = event {
+                                thinkingTokenCount += 1
+                                if let limit = config.maxThinkingTokens, thinkingTokenCount >= limit {
+                                    thinkingLimitReached = true
+                                    break
+                                }
+                            }
                         }
+                        if thinkingLimitReached { break outer }
                         if let limit = outputLimit, outputTokenCount >= limit { break }
                     }
                 }

--- a/Sources/BaseChatInference/Models/ChatError.swift
+++ b/Sources/BaseChatInference/Models/ChatError.swift
@@ -65,6 +65,11 @@ public struct ChatError: Identifiable, Sendable {
                     // The conversation exceeds the model's context window.
                     // Prompt the user to switch to a model with a larger context.
                     recovery = .selectModel
+                case .unsupportedModelArchitecture:
+                    // The loaded model isn't a chat/instruct LM (vision encoder,
+                    // embeddings-only, etc.). The only recovery is picking a
+                    // different model.
+                    recovery = .selectModel
                 default:
                     recovery = .dismissOnly
                 }

--- a/Sources/BaseChatInference/Services/InferenceError.swift
+++ b/Sources/BaseChatInference/Services/InferenceError.swift
@@ -13,6 +13,14 @@ public enum InferenceError: LocalizedError {
     /// can trim history or reduce `maxOutputTokens` instead of seeing an
     /// opaque decode failure mid-stream once the KV cache runs out.
     case contextExhausted(promptTokens: Int, maxOutputTokens: Int, contextSize: Int)
+    /// Thrown by backends when the caller hands them a model whose architecture
+    /// cannot serve chat/instruct completions — e.g. a CLIP vision encoder, a
+    /// BERT embedding model, or a Whisper audio encoder. Callers should surface
+    /// this as a load-time error rather than letting the model crash or emit
+    /// garbage at generation time. The associated value is the raw architecture
+    /// string read from the model (`model_type` in MLX config.json, `general.architecture`
+    /// in a GGUF header, etc.) so UI can display it.
+    case unsupportedModelArchitecture(String)
 
     public var errorDescription: String? {
         switch self {
@@ -32,6 +40,8 @@ public enum InferenceError: LocalizedError {
             return "Generation error: \(message)"
         case .contextExhausted(let promptTokens, let maxOutputTokens, let contextSize):
             return "Prompt (\(promptTokens) tokens) plus requested output (\(maxOutputTokens) tokens) exceeds context window (\(contextSize) tokens)."
+        case .unsupportedModelArchitecture(let arch):
+            return "Unsupported model architecture: \(arch). This backend only supports chat/instruct language models."
         }
     }
 
@@ -45,7 +55,8 @@ public enum InferenceError: LocalizedError {
         case .alreadyGenerating:
             return true
         case .modelNotFound, .modelLoadFailed, .inferenceFailure,
-             .memoryInsufficient, .generationError, .contextExhausted:
+             .memoryInsufficient, .generationError, .contextExhausted,
+             .unsupportedModelArchitecture:
             return false
         }
     }

--- a/Tests/BaseChatBackendsTests/MLXBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXBackendTests.swift
@@ -76,6 +76,74 @@ final class MLXBackendTests: XCTestCase {
         // Full load→unload→verify is covered in BaseChatE2ETests on Apple Silicon.
         throw XCTSkip("Full load→unload cycle covered in BaseChatE2ETests on Apple Silicon")
     }
+
+    // MARK: - Architecture preflight (no hardware gate)
+
+    /// Writes a throwaway `config.json` into a temp directory so we can exercise
+    /// `MLXBackend.validateArchitecture` without invoking the real MLX load path
+    /// (which would trip the metallib guard in `swift test`).
+    private func writeTempConfig(_ json: [String: Any]) throws -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("mlx-arch-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let data = try JSONSerialization.data(withJSONObject: json)
+        try data.write(to: dir.appendingPathComponent("config.json"))
+        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
+        return dir
+    }
+
+    func test_validateArchitecture_acceptsQwen3() throws {
+        let url = try writeTempConfig(["model_type": "qwen3"])
+        XCTAssertNoThrow(try MLXBackend.validateArchitecture(at: url))
+    }
+
+    func test_validateArchitecture_acceptsLlamaViaArchitectures() throws {
+        // HF repos that omit `model_type` but ship `architectures: ["LlamaForCausalLM"]`
+        // must still pass — snake_case prefix match keeps older snapshots working.
+        let url = try writeTempConfig(["architectures": ["LlamaForCausalLM"]])
+        XCTAssertNoThrow(try MLXBackend.validateArchitecture(at: url))
+    }
+
+    func test_validateArchitecture_rejectsVisionEncoder() throws {
+        let url = try writeTempConfig(["model_type": "clip"])
+        XCTAssertThrowsError(try MLXBackend.validateArchitecture(at: url)) { error in
+            guard case InferenceError.unsupportedModelArchitecture(let arch) = error else {
+                return XCTFail("Expected .unsupportedModelArchitecture, got \(error)")
+            }
+            XCTAssertEqual(arch, "clip")
+        }
+        // Sabotage confirmation: adding "clip" to `supportedLMArchitectures`
+        // makes this assertion fail (no throw) — verified locally before commit.
+    }
+
+    func test_validateArchitecture_rejectsEmbeddings() throws {
+        let url = try writeTempConfig(["model_type": "bert"])
+        XCTAssertThrowsError(try MLXBackend.validateArchitecture(at: url)) { error in
+            guard case InferenceError.unsupportedModelArchitecture = error else {
+                return XCTFail("Expected .unsupportedModelArchitecture, got \(error)")
+            }
+        }
+    }
+
+    func test_validateArchitecture_rejectsVisionViaArchitectures() throws {
+        // `model_type` missing, `architectures` says CLIPModel — must still be refused.
+        let url = try writeTempConfig(["architectures": ["CLIPModel"]])
+        XCTAssertThrowsError(try MLXBackend.validateArchitecture(at: url)) { error in
+            guard case InferenceError.unsupportedModelArchitecture = error else {
+                return XCTFail("Expected .unsupportedModelArchitecture, got \(error)")
+            }
+        }
+    }
+
+    func test_validateArchitecture_missingConfigIsNoOp() throws {
+        // A directory with no config.json must not throw — the subsequent MLX load
+        // path will surface the real "missing config" diagnostic instead.
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("mlx-arch-empty-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
+        XCTAssertNoThrow(try MLXBackend.validateArchitecture(at: dir))
+    }
 }
 
 // MARK: - Backend Contract

--- a/Tests/BaseChatBackendsTests/MLXBackendThinkingTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXBackendThinkingTests.swift
@@ -272,34 +272,41 @@ final class MLXBackendThinkingTests: XCTestCase {
     /// the test is skipped with a pointer to the backend gap so the divergence is visible
     /// in the CI output rather than silently ignored.
     func test_maxThinkingTokens_terminatesGeneration_parity_with_llama() async throws {
-        // FIXME: unskip when MLXBackend honours config.maxThinkingTokens
-        // (tracked in https://github.com/roryford/BaseChatKit/issues/550).
-        //
-        // Target assertions, enabled once the backend fix lands:
-        //
-        //   let mock = MockMLXModelContainer()
-        //   mock.tokensToYield = ["<think>", "a", "b", "c", "d", "</think>", "answer"]
-        //   let backend = MLXBackend()
-        //   backend._inject(mock)
-        //   var config = GenerationConfig(thinkingMarkers: .qwen3)
-        //   config.maxThinkingTokens = 2
-        //   let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: config)
-        //   let events = try await collectAllEvents(from: stream)
-        //   let thinkingTokens = events.compactMap { ev -> String? in
-        //       if case .thinkingToken(let t) = ev { return t } else { return nil }
-        //   }
-        //   let visibleTokens = events.compactMap { ev -> String? in
-        //       if case .token(let t) = ev { return t } else { return nil }
-        //   }
-        //   XCTAssertLessThanOrEqual(thinkingTokens.count, 2)
-        //   XCTAssertFalse(visibleTokens.joined().contains("answer"))
-        //
-        // Sabotage check once unskipped: raising maxThinkingTokens to 10 would let every
-        // thinking token and the full "answer" token through, failing both assertions.
-        throw XCTSkip(
-            "MLXBackend does not yet enforce maxThinkingTokens; see issue #550 for the backend fix. " +
-            "Fixture lands today so the parity gap with LlamaGenerationDriver is documented."
+        let mock = MockMLXModelContainer()
+        // Feed more thinking tokens than the budget allows, then a visible "answer".
+        // With maxThinkingTokens=2 the backend should emit at most 2 .thinkingToken
+        // events and must terminate before the "answer" visible token is yielded.
+        mock.tokensToYield = ["<think>", "a", "b", "c", "d", "</think>", "answer"]
+
+        let backend = MLXBackend()
+        backend._inject(mock)
+
+        var config = GenerationConfig(thinkingMarkers: .qwen3)
+        config.maxThinkingTokens = 2
+
+        let stream = try backend.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: config
         )
+
+        let events = try await collectAllEvents(from: stream)
+
+        let thinkingTokens = events.compactMap { ev -> String? in
+            if case .thinkingToken(let t) = ev { return t } else { return nil }
+        }
+        let visibleTokens = events.compactMap { ev -> String? in
+            if case .token(let t) = ev { return t } else { return nil }
+        }
+
+        XCTAssertLessThanOrEqual(thinkingTokens.count, 2,
+            "maxThinkingTokens=2 must cap .thinkingToken events at 2, matching LlamaGenerationDriver")
+        XCTAssertFalse(visibleTokens.joined().contains("answer"),
+            "Generation must terminate before post-think visible tokens are emitted when the budget is exhausted")
+
+        // Sabotage confirmation: removing the `thinkingLimitReached` short-circuit in
+        // MLXBackend.generate (or ignoring config.maxThinkingTokens entirely) would let
+        // all 4 thinking tokens plus "answer" through, failing both assertions.
     }
 }
 #endif

--- a/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
+++ b/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
@@ -81,6 +81,13 @@ final class SilentCatchAuditTest: XCTestCase {
         "BaseChatBackends/OllamaBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],",
         "BaseChatBackends/OpenAIBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],",
         "BaseChatBackends/SSECloudBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],",
+        // MLXBackend.validateArchitecture: best-effort read of the MLX model's
+        // `config.json`. A missing/unreadable/malformed config is not fatal here
+        // — we deliberately fall through so mlx-swift-lm's own load path produces
+        // the real diagnostic (missing weights, malformed directory, etc.) rather
+        // than masking it with a false architecture error.
+        "BaseChatBackends/MLXBackend.swift:guard let data = try? Data(contentsOf: configURL),",
+        "BaseChatBackends/MLXBackend.swift:let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {",
 
         // BaseChatFuzz — SessionScript resource loader uses the "try-each-shape-in-order"
         // decoder pattern: each `try?` is a shape probe (single-object vs. array of scripts).


### PR DESCRIPTION
## Summary

- Enforce `config.maxThinkingTokens` in `MLXBackend.generate` so thinking models can't run away and OOM a 16 GB Mac (parity with `LlamaGenerationDriver`, closes #550).
- Add `InferenceError.unsupportedModelArchitecture(String)` and a preflight that reads `config.json` at load time; refuses any `model_type` not in mlx-swift-lm's `LLMTypeRegistry.shared` allowlist (CLIP, SigLIP, BERT, Whisper, Qwen-VL, …).
- Map the new error to `.selectModel` recovery in `ChatError`.
- ThinkingParser wiring audit — already correct in MLXBackend; no change needed.

## Root cause

1. **`maxThinkingTokens` (#550).** MLXBackend's generation loop yielded `.thinkingToken` events but never inspected `config.maxThinkingTokens`, so a thinking model that kept reasoning would run until the mlx-swift stream ended or `maxOutputTokens` was hit. On a 16 GB Mac this can OOM before either happens. `LlamaGenerationDriver` already enforces the same limit.
2. **Vision / embedding models.** MLXBackend accepted any URL with safetensors + a tokenizer. Handing it a CLIP encoder (`model_type: "clip"`) or a BERT embedder would either crash in mlx-swift-lm's own `unsupportedModelType`, or — worse — load something and emit garbage tokens mid-chat. The failure mode surfaced as an opaque `modelLoadFailed(underlying:)` with no actionable recovery.
3. **ThinkingParser audit.** MLXBackend already calls `thinkingParser.process(text)` when `config.thinkingMarkers` is set and `thinkingParser.finalize()` on completion (lines 222–257). This matches LlamaGenerationDriver's pattern. No change needed — the scope item dropped to a no-op.

## Fix

1. Mirror the Llama pattern: track `thinkingTokenCount`, break the outer `for await` with a `thinkingLimitReached` flag when `config.maxThinkingTokens` is reached.
2. Add `static func validateArchitecture(at:)` invoked before mlx-swift-lm's `loadModelContainer`. Reads `config.json`, extracts `model_type` (falling back to a snake_case prefix match against `architectures[]` for older HF snapshots that omit `model_type`), and throws `.unsupportedModelArchitecture` if not in the allowlist. Missing/malformed `config.json` is a no-op — mlx-swift-lm's own load path produces the real diagnostic.
3. `ChatError.fromError` maps the new case to `.selectModel` so UI prompts the user to pick a different model.

## Architecture allowlist decision

Sourced directly from `LLMTypeRegistry.shared` in mlx-swift-lm (`Libraries/MLXLLM/LLMModelFactory.swift`), which is the definitive list of model_types mlx-swift-lm can serve as chat/instruct LMs. Any time mlx-swift-lm adds a new LM architecture the allowlist should be extended to match — documented inline next to the set literal.

Permitted values: `mistral`, `llama`, `phi`, `phi3`, `phimoe`, `gemma`, `gemma2`, `gemma3`, `gemma3_text`, `gemma3n`, `qwen2`, `qwen3`, `qwen3_moe`, `qwen3_next`, `qwen3_5`, `qwen3_5_moe`, `qwen3_5_text`, `minicpm`, `starcoder2`, `cohere`, `openelm`, `internlm2`, `deepseek_v3`, `granite`, `granitemoehybrid`, `mimo`, `mimo_v2_flash`, `minimax`, `glm4`, `glm4_moe`, `glm4_moe_lite`, `acereason`, `falcon_h1`, `bitnet`, `smollm3`, `ernie4_5`, `lfm2`, `lfm2_moe`, `baichuan_m1`, `exaone4`, `gpt_oss`, `lille-130m`, `olmoe`, `olmo2`, `olmo3`, `bailing_moe`, `nanochat`, `nemotron_h`, `afmoe`, `jamba_3b`, `mistral3`, `apertus`.

Refused: everything else — most notably CLIP/SigLIP vision encoders, BERT-family embedders, Whisper audio encoders, Qwen-VL / Paligemma / Pixtral / LFM2-VL / Qwen3-VL visual-language models.

## Coordination with Llama worker

The `InferenceError` enum lives in `Sources/BaseChatInference/Services/InferenceError.swift`. No Llama-worker commit had landed there when this PR opened, so I added `case unsupportedModelArchitecture(String)` as the brief suggested. Llama worker should reuse the same case; the associated `String` is intentionally the raw architecture identifier (MLX's `model_type`, or GGUF's `general.architecture`) so both backends can round-trip into the same UI copy.

## Test plan

New and unskipped tests (all run via `swift test --traits MLX,Llama` on Apple Silicon; mock-driven, no Metal required):

- [x] `MLXBackendThinkingTests.test_maxThinkingTokens_terminatesGeneration_parity_with_llama` — previously `XCTSkip`'d for #550, now asserts that `maxThinkingTokens=2` caps `.thinkingToken` events at ≤ 2 and terminates before the post-think `"answer"` visible token. **Sabotage confirmed**: removing the `thinkingLimitReached` short-circuit made the test fail with 4 thinking tokens and `"answer"` leaking through.
- [x] `MLXBackendTests.test_validateArchitecture_acceptsQwen3` / `_acceptsLlamaViaArchitectures` — happy paths for both `model_type` and `architectures[]` entry points.
- [x] `MLXBackendTests.test_validateArchitecture_rejectsVisionEncoder` / `_rejectsEmbeddings` / `_rejectsVisionViaArchitectures` — `clip`, `bert`, and `CLIPModel` in `architectures[]` all throw `.unsupportedModelArchitecture`. **Sabotage confirmed**: early-returning from `validateArchitecture` made all three reject tests fail with "did not throw an error".
- [x] `MLXBackendTests.test_validateArchitecture_missingConfigIsNoOp` — absent `config.json` passes so mlx-swift-lm's own diagnostic can surface.

Full CI suites (local, Apple Silicon):

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 204 tests, 0 failures (4 skipped).
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 837 tests, 0 failures.
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits` — 69 tests, 0 failures.
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 450 tests, 0 failures.
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 166 tests, 0 failures.
- [x] `swift test --filter BaseChatBackendsTests --traits MLX,Llama` — full backends suite with hardware paths, 0 failures.

Also added two MLXBackend.swift fingerprints to `SilentCatchAuditTest.allowlist` — the `try? Data(contentsOf:)` and `try? JSONSerialization.jsonObject` in `validateArchitecture` are intentional best-effort reads (falling through to mlx-swift-lm's own diagnostic on any failure), documented with the same comment style as the surrounding entries.

## Release Note

**MLX thinking-budget + non-LM guardrails** — MLXBackend now enforces `GenerationConfig.maxThinkingTokens` the same way the Llama driver does, stopping a runaway reasoning model before it can OOM a 16 GB Mac. A load-time preflight also refuses non-chat architectures — if you hand the backend a CLIP vision encoder, a BERT embedder, or a Whisper audio model by mistake, you now get an `InferenceError.unsupportedModelArchitecture(String)` at load time instead of a crash (or worse, garbage tokens) mid-generation. The host app can surface this as `.selectModel` recovery so users can pick a different model. The allowlist tracks mlx-swift-lm's own `LLMTypeRegistry`, so every architecture that framework supports continues to load without change. Closes #550.

🤖 Generated with [Claude Code](https://claude.com/claude-code)