### PR TITLE
test(ollama): add thinking-specific E2E tests and OLLAMA_TEST_MODEL env override

### DIFF
--- a/Sources/BaseChatTestSupport/HardwareRequirements.swift
+++ b/Sources/BaseChatTestSupport/HardwareRequirements.swift
@@ -65,13 +65,20 @@ public enum HardwareRequirements {
 
     /// Returns an Ollama model name, preferring one in the given parameter size range.
     ///
-    /// Queries `/api/tags` synchronously. Prefers models whose `parameter_size`
-    /// falls in `preferredSizeRange` (e.g. "7.2B" → 7.2). Falls back to the
-    /// first available model if none match the range. Returns `nil` only if the
+    /// Queries `/api/tags` synchronously. If the `OLLAMA_TEST_MODEL` environment
+    /// variable is set AND names a model that is installed locally, that name
+    /// wins — CI / local runs can pin to a specific fast model without having to
+    /// edit test code. Otherwise prefers models whose `parameter_size` falls in
+    /// `preferredSizeRange` (e.g. "7.2B" → 7.2). Falls back to the first
+    /// available model if none match the range. Returns `nil` only if the
     /// server is unreachable or has no models.
     public static func findOllamaModel(preferredSizeRange: ClosedRange<Double> = 6.5...9.0) -> String? {
         guard let models = fetchOllamaModels() else { return nil }
-        return selectOllamaModel(from: models, preferredSizeRange: preferredSizeRange)
+        return selectOllamaModel(
+            from: models,
+            preferredSizeRange: preferredSizeRange,
+            environment: ProcessInfo.processInfo.environment
+        )
     }
 
     /// Returns the first installed Ollama model whose name contains `substring`,
@@ -99,10 +106,26 @@ public enum HardwareRequirements {
 
     /// Selects the best model from a pre-fetched Ollama model list.
     /// Extracted from `findOllamaModel` for testability.
+    ///
+    /// When `environment` carries `OLLAMA_TEST_MODEL` and the named model is in
+    /// `models`, that name is returned. Otherwise falls through to the existing
+    /// size-based selection logic. Pass an explicit `environment` dictionary
+    /// (e.g. `["OLLAMA_TEST_MODEL": "llama3.1:8b"]`) from tests to avoid
+    /// depending on the real process environment.
     static func selectOllamaModel(
         from models: [[String: Any]],
-        preferredSizeRange: ClosedRange<Double> = 6.5...9.0
+        preferredSizeRange: ClosedRange<Double> = 6.5...9.0,
+        environment: [String: String] = [:]
     ) -> String? {
+        if let override = environment["OLLAMA_TEST_MODEL"], !override.isEmpty {
+            for model in models {
+                if let name = model["name"] as? String, name == override {
+                    return name
+                }
+            }
+            // Override was set but not installed — fall through rather than
+            // returning nil so the suite still runs against whatever is there.
+        }
         for model in models {
             guard let name = model["name"] as? String,
                   let details = model["details"] as? [String: Any],

--- a/Tests/BaseChatE2ETests/OllamaE2ETests.swift
+++ b/Tests/BaseChatE2ETests/OllamaE2ETests.swift
@@ -143,4 +143,231 @@ final class OllamaE2ETests: XCTestCase {
         XCTAssertTrue(backend.capabilities.supportsSystemPrompt)
         XCTAssertEqual(backend.backendName, "Ollama")
     }
+
+    // MARK: - Thinking-specific E2E Tests
+
+    /// Prompt that reliably provokes chain-of-thought on reasoning models.
+    private static let reasoningPrompt = """
+    Solve this carefully: a train leaves station A at 3pm travelling 60 mph, \
+    and another leaves station B at 4pm travelling 80 mph toward it. The \
+    stations are 300 miles apart. At what time do they meet?
+    """
+
+    /// Drives a probe generation to classify the selected model as thinking or
+    /// non-thinking by checking whether any `.thinkingToken` event arrives
+    /// before the first `.token`. Returns `true` when the model emits thinking.
+    ///
+    /// Uses a short `maxOutputTokens` budget so the probe terminates quickly
+    /// even for chatty models.
+    private func probeModelEmitsThinking() async throws -> Bool {
+        let config = GenerationConfig(
+            temperature: 0.3,
+            maxOutputTokens: 64
+        )
+        let stream = try backend.generate(
+            prompt: Self.reasoningPrompt,
+            systemPrompt: nil,
+            config: config
+        )
+        var sawThinking = false
+        for try await event in stream.events {
+            switch event {
+            case .thinkingToken:
+                sawThinking = true
+            case .token:
+                // First visible token — we've classified the model.
+                return sawThinking
+            default:
+                continue
+            }
+        }
+        // Stream finished without ever emitting a visible token. If we saw
+        // thinking first, still classify as thinking; otherwise the probe is
+        // inconclusive and we treat the model as non-thinking.
+        return sawThinking
+    }
+
+    /// Test A — Thinking models must emit `.thinkingToken` events and fire
+    /// exactly one `.thinkingComplete` before the first visible `.token`.
+    func testThinkingModel_emitsThinkingEventsBeforeVisibleOutput() async throws {
+        let config = GenerationConfig(temperature: 0.3)
+        let stream = try backend.generate(
+            prompt: Self.reasoningPrompt,
+            systemPrompt: nil,
+            config: config
+        )
+
+        var thinkingTokenCount = 0
+        var thinkingCompleteCount = 0
+        var firstTokenAfterThinkingComplete: Bool?
+        var visibleText = ""
+        var sawFirstVisibleToken = false
+
+        for try await event in stream.events {
+            switch event {
+            case .thinkingToken:
+                thinkingTokenCount += 1
+                if sawFirstVisibleToken {
+                    XCTFail("Received .thinkingToken after visible .token — reasoning must precede visible output on this backend")
+                }
+            case .thinkingComplete:
+                thinkingCompleteCount += 1
+                // If a visible token arrives next, record the ordering.
+                if !sawFirstVisibleToken {
+                    firstTokenAfterThinkingComplete = true
+                }
+            case .token(let text):
+                visibleText += text
+                sawFirstVisibleToken = true
+                if firstTokenAfterThinkingComplete == nil {
+                    firstTokenAfterThinkingComplete = false
+                }
+            default:
+                continue
+            }
+        }
+
+        try XCTSkipIf(
+            thinkingTokenCount == 0,
+            "selected model '\(modelName!)' does not produce thinking tokens — skipping thinking-specific assertions"
+        )
+
+        XCTAssertEqual(
+            thinkingCompleteCount,
+            1,
+            "Exactly one .thinkingComplete event must fire (got \(thinkingCompleteCount), model: \(modelName!))"
+        )
+        XCTAssertEqual(
+            firstTokenAfterThinkingComplete,
+            true,
+            ".thinkingComplete must fire before the first visible .token (model: \(modelName!))"
+        )
+        XCTAssertFalse(
+            visibleText.isEmpty,
+            "Thinking model must still emit a visible response (model: \(modelName!))"
+        )
+    }
+
+    /// Test B — `maxThinkingTokens=0` must suppress reasoning while still
+    /// producing visible output.
+    ///
+    // FIXME(P4): This test will fail until OllamaBackend sends `think: false`
+    // when maxThinkingTokens == 0. The `BCK_P4_READY` env gate effectively
+    // skips this test until the P4 wiring lands; removing the gate is the
+    // one-line follow-up that activates the assertion.
+    func testThinkingModel_maxThinkingTokensZero_suppressesReasoning() async throws {
+        try XCTSkipIf(
+            ProcessInfo.processInfo.environment["BCK_P4_READY"] == nil,
+            "BCK_P4_READY not set — OllamaBackend does not yet forward `think: false` to Ollama; remove this guard once P4 lands"
+        )
+
+        // Probe first with a fresh stream — classify the selected model.
+        let isThinkingModel = try await probeModelEmitsThinking()
+        try XCTSkipIf(
+            !isThinkingModel,
+            "selected model '\(modelName!)' does not produce thinking tokens — maxThinkingTokens=0 assertion is vacuous"
+        )
+
+        let config = GenerationConfig(
+            temperature: 0.3,
+            maxOutputTokens: nil,
+            maxThinkingTokens: 0
+        )
+        let stream = try backend.generate(
+            prompt: Self.reasoningPrompt,
+            systemPrompt: nil,
+            config: config
+        )
+
+        var thinkingTokenCount = 0
+        var thinkingCompleteCount = 0
+        var visibleText = ""
+
+        for try await event in stream.events {
+            switch event {
+            case .thinkingToken:
+                thinkingTokenCount += 1
+            case .thinkingComplete:
+                thinkingCompleteCount += 1
+            case .token(let text):
+                visibleText += text
+            default:
+                continue
+            }
+        }
+
+        XCTAssertEqual(
+            thinkingTokenCount,
+            0,
+            "maxThinkingTokens=0 must suppress every .thinkingToken event (got \(thinkingTokenCount), model: \(modelName!))"
+        )
+        XCTAssertEqual(
+            thinkingCompleteCount,
+            0,
+            "maxThinkingTokens=0 must fire zero .thinkingComplete events (got \(thinkingCompleteCount), model: \(modelName!))"
+        )
+        XCTAssertFalse(
+            visibleText.isEmpty,
+            "Visible response must still arrive when reasoning is suppressed (model: \(modelName!))"
+        )
+    }
+
+    /// Test C — `maxThinkingTokens=5` must cap reasoning emission; OllamaBackend
+    /// drops thinking chunks once `thinkingTokenCount >= limit`, so only the
+    /// first few lines survive.
+    func testThinkingModel_maxThinkingTokensCapped_limitsReasoning() async throws {
+        // Probe first to classify the model.
+        let isThinkingModel = try await probeModelEmitsThinking()
+        try XCTSkipIf(
+            !isThinkingModel,
+            "selected model '\(modelName!)' does not produce thinking tokens — cap assertion is vacuous"
+        )
+
+        let config = GenerationConfig(
+            temperature: 0.3,
+            maxOutputTokens: nil,
+            maxThinkingTokens: 5
+        )
+        let stream = try backend.generate(
+            prompt: Self.reasoningPrompt,
+            systemPrompt: nil,
+            config: config
+        )
+
+        var thinkingTokenCount = 0
+        var thinkingCompleteCount = 0
+        var visibleText = ""
+
+        for try await event in stream.events {
+            switch event {
+            case .thinkingToken:
+                thinkingTokenCount += 1
+            case .thinkingComplete:
+                thinkingCompleteCount += 1
+            case .token(let text):
+                visibleText += text
+            default:
+                continue
+            }
+        }
+
+        // Allow generous headroom over the cap — OllamaBackend counts per
+        // NDJSON line, so the observed count hovers near but rarely exceeds the
+        // limit by more than a handful. 20 is well above 5 and well below what
+        // an uncapped run would produce for this prompt.
+        XCTAssertLessThan(
+            thinkingTokenCount,
+            20,
+            "maxThinkingTokens=5 must meaningfully cap reasoning emission (got \(thinkingTokenCount), model: \(modelName!))"
+        )
+        XCTAssertEqual(
+            thinkingCompleteCount,
+            1,
+            "Exactly one .thinkingComplete event must fire even when capped (got \(thinkingCompleteCount), model: \(modelName!))"
+        )
+        XCTAssertFalse(
+            visibleText.isEmpty,
+            "Capped thinking must not starve visible output (model: \(modelName!))"
+        )
+    }
 }

--- a/Tests/BaseChatInferenceTests/HardwareRequirementsOllamaTests.swift
+++ b/Tests/BaseChatInferenceTests/HardwareRequirementsOllamaTests.swift
@@ -91,4 +91,74 @@ final class HardwareRequirementsOllamaTests: XCTestCase {
         let result = HardwareRequirements.selectOllamaModel(from: models)
         XCTAssertEqual(result, "mistral:7b")
     }
+
+    // MARK: - OLLAMA_TEST_MODEL env override
+
+    func test_ollamaTestModelEnv_overridesSizeBasedSelection() {
+        // Without the override the 7.2B model wins; with the override pinning
+        // the 13B model, selection honours the env var.
+        let models = [
+            model(name: "mistral:7b", parameterSize: "7.2B"),
+            model(name: "llama3:13b", parameterSize: "13.0B"),
+        ]
+        let result = HardwareRequirements.selectOllamaModel(
+            from: models,
+            environment: ["OLLAMA_TEST_MODEL": "llama3:13b"]
+        )
+        XCTAssertEqual(result, "llama3:13b")
+    }
+
+    func test_ollamaTestModelEnv_pinsOutOfRangeModel() {
+        // The override names a 3B model that the default range would skip.
+        let models = [
+            model(name: "phi:3b", parameterSize: "3.0B"),
+            model(name: "llama3.1:8b", parameterSize: "8.0B"),
+        ]
+        let result = HardwareRequirements.selectOllamaModel(
+            from: models,
+            environment: ["OLLAMA_TEST_MODEL": "phi:3b"]
+        )
+        XCTAssertEqual(result, "phi:3b")
+    }
+
+    func test_ollamaTestModelEnv_notInstalled_fallsThrough() {
+        // Override is set but the named model is not installed — fall through
+        // to the size-based selection rather than returning nil so the suite
+        // still runs.
+        let models = [
+            model(name: "llama3.1:8b", parameterSize: "8.0B"),
+        ]
+        let result = HardwareRequirements.selectOllamaModel(
+            from: models,
+            environment: ["OLLAMA_TEST_MODEL": "not-installed:latest"]
+        )
+        XCTAssertEqual(result, "llama3.1:8b")
+    }
+
+    func test_ollamaTestModelEnv_emptyValue_ignored() {
+        // Treat empty-string as "unset" so `OLLAMA_TEST_MODEL=""` doesn't fall
+        // into the override branch and skip size-based selection.
+        let models = [
+            model(name: "mistral:7b", parameterSize: "7.2B"),
+            model(name: "llama3:13b", parameterSize: "13.0B"),
+        ]
+        let result = HardwareRequirements.selectOllamaModel(
+            from: models,
+            environment: ["OLLAMA_TEST_MODEL": ""]
+        )
+        XCTAssertEqual(result, "mistral:7b")
+    }
+
+    func test_ollamaTestModelEnv_absent_usesSizeBased() {
+        // No override key at all — unchanged size-based behaviour.
+        let models = [
+            model(name: "mistral:7b", parameterSize: "7.2B"),
+            model(name: "llama3:13b", parameterSize: "13.0B"),
+        ]
+        let result = HardwareRequirements.selectOllamaModel(
+            from: models,
+            environment: [:]
+        )
+        XCTAssertEqual(result, "mistral:7b")
+    }
 }


### PR DESCRIPTION
## Summary

Adds three thinking-specific E2E tests to `OllamaE2ETests` and an `OLLAMA_TEST_MODEL` environment-variable override so CI / local runs can pin the Ollama suite to a specific model.

### Per-test intent

- **`testThinkingModel_emitsThinkingEventsBeforeVisibleOutput`** — pins the contract that thinking models emit `.thinkingToken` events, fire `.thinkingComplete` exactly once, and produce that complete event **before** any visible `.token`. Non-thinking models self-classify via the probe and `XCTSkipIf` cleanly.
- **`testThinkingModel_maxThinkingTokensZero_suppressesReasoning`** — verifies that `maxThinkingTokens=0` produces zero `.thinkingToken` events, zero `.thinkingComplete` events, and still yields visible output. Gated behind `BCK_P4_READY` because the current OllamaBackend does not yet forward `think: false` to Ollama (P4 work, tracked via the `FIXME(P4)` comment in the test body). Removing the gate is the one-line follow-up once P4 lands.
- **`testThinkingModel_maxThinkingTokensCapped_limitsReasoning`** — pins `maxThinkingTokens=5` to meaningfully cap the number of `.thinkingToken` events (< 20 for the reasoning prompt used), while still producing exactly one `.thinkingComplete` and non-empty visible output.

All three dynamically classify the selected model as thinking vs non-thinking via a short probe run, so the suite stays green whether you point it at `gemma4:e4b` (thinking) or `llama3.1:8b` (non-thinking).

### Env override rationale + usage

`selectOllamaModel` defaults to picking a 6.5–9.0B model by parameter size. On a dev machine with both `gemma4:e4b` (8B thinking, ~80s per test) and `llama3.1:8b` (8B non-thinking, ~5s per test) installed, whichever wins the default scan is (a) unstable and (b) dramatically changes test duration. Running:

```bash
OLLAMA_TEST_MODEL=llama3.1:8b swift test --filter OllamaE2ETests --disable-default-traits
```

pins the suite to the fast non-thinking model for routine pre-push; omit the variable to run against whatever the default picks. If the override names a model that is not installed, selection falls through to the existing size-based logic so the suite still runs.

### Scope

No production code changes. All edits are in test support (`HardwareRequirements`) or test files. `OllamaBackend` is untouched.

## Test plan

- [x] New unit tests in `HardwareRequirementsOllamaTests` — 6 new tests covering override-honoured, out-of-range override, fall-through when override not installed, empty-string treated as unset, absent key, plus all 8 pre-existing tests still green. Sabotage-verified: stubbed `selectOllamaModel` to ignore the override and observed the two override-honoured tests fail; the three fall-through tests correctly still passed.
- [x] `testThinkingModel_emitsThinkingEventsBeforeVisibleOutput` — ran against `gemma4:e4b` and passed (78.877s). Ran against `llama3.1:8b` and correctly skipped.
- [x] `testThinkingModel_maxThinkingTokensZero_suppressesReasoning` — skipped under both models because `BCK_P4_READY` gate is in place (by design until P4 ships).
- [x] `testThinkingModel_maxThinkingTokensCapped_limitsReasoning` — ran against `gemma4:e4b` and passed (102.192s). Ran against `llama3.1:8b` and correctly skipped.
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 204 tests, 4 skipped, 0 failures
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 846 tests, 0 failures (includes the 6 new env-override unit tests)
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 450 tests, 0 failures
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 166 tests, 1 skipped, 0 failures

**Sabotage limits.** E2E test sabotage was skipped — each run is 80–100s against a real model, and mutating the live OllamaBackend source to force a failure would either ship broken code or slow iteration to a crawl. The equivalent shape (event counts, ordering) is already covered by fixture-based tests in `OllamaBackendTests` where sabotage is cheap.

## Release Note

New `OLLAMA_TEST_MODEL` environment variable lets teams pin the Ollama E2E suite to a specific installed model without editing test code. Useful when local models include both fast non-thinking variants and slow reasoning models: set `OLLAMA_TEST_MODEL=llama3.1:8b` for ~30-second pre-push smoke runs, unset it to exercise whatever the default size-based selection picks. When the named model is not installed, selection falls through to the existing behaviour so the suite still runs.

Three new thinking-specific E2E tests in `OllamaE2ETests` now pin the `.thinkingToken` / `.thinkingComplete` event contract against a live Ollama server. Each test classifies the selected model as thinking or non-thinking dynamically and skips gracefully on non-thinking models, so the suite stays green regardless of which model `ollama pull` last fetched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)