### PR TITLE
fix(ollama): use exact eval_count for visible token cap and usage metadata

### DIFF
--- a/Sources/BaseChatBackends/OllamaBackend.swift
+++ b/Sources/BaseChatBackends/OllamaBackend.swift
@@ -98,7 +98,10 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
         // For thinking models (e.g. gemma4, qwen3), Ollama counts thinking tokens
         // against num_predict. Reserve budget for both thinking and visible output
         // so the model isn't silently cut off mid-think before any content is produced.
-        // maxOutputTokens is enforced client-side in parseResponseStream.
+        // maxOutputTokens is enforced client-side in parseResponseStream using the
+        // server's own `eval_count` when it appears on a line (running count on
+        // intermediate lines where servers emit it, or the final done-line count);
+        // a per-line counter remains as a fallback for servers that don't.
         let visibleBudget = config.maxOutputTokens ?? 2048
         let thinkingBudget = config.maxThinkingTokens ?? 2048
         let options: [String: Any] = [
@@ -167,7 +170,10 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
         var thinkingOpen = false
         var thinkingTokenCount = 0
         let thinkingLimit = config.maxThinkingTokens
-        var visibleTokenCount = 0
+        // Fallback per-line counter for servers that don't emit `eval_count`
+        // until the done-line. When a line carries `eval_count`, we prefer it
+        // over this counter for an exact cap.
+        var visibleLineCount = 0
         let visibleLimit = config.maxOutputTokens
 
         func noteEventYielded() throws {
@@ -211,14 +217,20 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
             }
 
             if let content = parsed.content, !content.isEmpty {
-                if let limit = visibleLimit, visibleTokenCount >= limit {
-                    // Client-side cap reached; stop the stream cleanly.
-                    continuation.finish()
-                    return
+                // Prefer the server's running `eval_count` when present for an
+                // exact token-count cap; otherwise fall back to the NDJSON line
+                // counter which is an upper bound but may overshoot by one line.
+                if let limit = visibleLimit {
+                    let observed = parsed.evalCount ?? visibleLineCount
+                    if observed >= limit {
+                        // Client-side cap reached; stop the stream cleanly.
+                        continuation.finish()
+                        return
+                    }
                 }
                 try noteEventYielded()
                 continuation.yield(.token(content))
-                visibleTokenCount += 1
+                visibleLineCount += 1
             }
 
             if parsed.done {
@@ -230,6 +242,24 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
                     try noteEventYielded()
                     continuation.yield(.thinkingComplete)
                     thinkingOpen = false
+                }
+
+                // Surface usage from the done-line (`eval_count`,
+                // `prompt_eval_count`). This wires into `handleUsage` (which
+                // populates `lastUsage` for `TokenUsageProvider` consumers) and
+                // emits a `.usage` event on the stream, mirroring the SSE path
+                // in `SSECloudBackend.parseResponseStream`.
+                if parsed.evalCount != nil || parsed.promptEvalCount != nil {
+                    let usage: (promptTokens: Int?, completionTokens: Int?) = (
+                        promptTokens: parsed.promptEvalCount,
+                        completionTokens: parsed.evalCount
+                    )
+                    handleUsage(usage)
+                    if let prompt = usage.promptTokens,
+                       let completion = usage.completionTokens {
+                        try noteEventYielded()
+                        continuation.yield(.usage(prompt: prompt, completion: completion))
+                    }
                 }
             }
         }
@@ -316,10 +346,21 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
     ///   `thinking`.
     /// `parseLine` normalises both shapes; consumers read `content` and
     /// `thinking` without caring which endpoint produced the line.
+    ///
+    /// `evalCount` / `promptEvalCount` are the exact token counts reported by
+    /// the Ollama server. Per Ollama's documented API, these appear on the
+    /// terminal `"done":true` line — `eval_count` is the number of tokens the
+    /// model produced this turn and `prompt_eval_count` is the number of tokens
+    /// in the prompt. Some Ollama-compatible servers also emit a running
+    /// `eval_count` on intermediate lines; parsing it unconditionally lets the
+    /// stream cap visible output precisely when available and falls back to a
+    /// line counter when not.
     struct ParsedLine {
         var content: String?
         var thinking: String?
         var done: Bool
+        var evalCount: Int?
+        var promptEvalCount: Int?
     }
 
     /// Parses a single Ollama NDJSON line into a normalised shape.
@@ -353,7 +394,19 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
             thinking = topThinking
         }
 
-        return ParsedLine(content: content, thinking: thinking, done: done)
+        // Usage fields — `eval_count` (output tokens) and `prompt_eval_count`
+        // (prompt tokens). Documented as done-line fields but we parse them
+        // unconditionally so a running-count-emitting server is handled too.
+        let evalCount = parsed["eval_count"] as? Int
+        let promptEvalCount = parsed["prompt_eval_count"] as? Int
+
+        return ParsedLine(
+            content: content,
+            thinking: thinking,
+            done: done,
+            evalCount: evalCount,
+            promptEvalCount: promptEvalCount
+        )
     }
 
     /// Extracts the assistant content token from an Ollama NDJSON line.
@@ -416,7 +469,24 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
         func extractToken(from payload: String) -> String? {
             OllamaBackend.extractToken(from: payload)
         }
-        func extractUsage(from payload: String) -> (promptTokens: Int?, completionTokens: Int?)? { nil }
+
+        /// Extracts Ollama's per-turn usage from a single NDJSON payload.
+        ///
+        /// Ollama's documented API places `eval_count` (completion tokens) and
+        /// `prompt_eval_count` (prompt tokens) on the terminal `"done":true`
+        /// line. Returns `nil` when neither field is present so partial/running
+        /// lines don't pollute a consumer that expects "final usage only".
+        func extractUsage(from payload: String) -> (promptTokens: Int?, completionTokens: Int?)? {
+            guard let parsed = OllamaBackend.parseLine(payload) else { return nil }
+            guard parsed.evalCount != nil || parsed.promptEvalCount != nil else {
+                return nil
+            }
+            return (
+                promptTokens: parsed.promptEvalCount,
+                completionTokens: parsed.evalCount
+            )
+        }
+
         func isStreamEnd(_ payload: String) -> Bool { false }
         func extractStreamError(from payload: String) -> Error? { nil }
     }

--- a/Tests/BaseChatBackendsTests/OllamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/OllamaBackendTests.swift
@@ -388,20 +388,68 @@ struct OllamaBackendTests {
         }
     }
 
-    // MARK: - Usage Stats (ignored)
+    // MARK: - Usage Stats
 
-    /// The Ollama final chunk carries per-call usage — `prompt_eval_count`,
-    /// `eval_count`, `eval_duration`, `total_duration`. The
-    /// ``OllamaPayloadHandler.extractUsage`` hook returns `nil` today, so
-    /// usage never flows into a `TokenUsageProvider`. This fixture pins that
-    /// "ignored" contract: once usage wiring lands, flip the assertion.
-    /// Closes #508.
-    @Test func payloadHandler_extractUsage_returnsNil_evenWithUsageFields() {
+    /// Ollama's final chunk carries per-call usage — `prompt_eval_count`
+    /// (prompt tokens) and `eval_count` (completion tokens). The
+    /// ``OllamaPayloadHandler.extractUsage`` hook surfaces both so
+    /// `TokenUsageProvider` consumers see exact counts. Closes #508.
+    ///
+    /// Sabotage check (verified locally): reverting `extractUsage` to return
+    /// `nil` fails both assertions.
+    @Test func payloadHandler_extractUsage_parsesDoneLineCounts() {
         let handler = OllamaBackend.OllamaPayloadHandler()
-        let json = #"{"model":"llama3.2","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop","prompt_eval_count":15,"eval_count":42,"eval_duration":1500000000,"total_duration":2200000000}"#
-        // Current contract: usage is not surfaced. Flip to a concrete expectation
-        // once `TokenUsageProvider` wiring lands in OllamaBackend.
-        #expect(handler.extractUsage(from: json) == nil)
+        let json = #"{"model":"llama3.2","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop","prompt_eval_count":42,"eval_count":17,"eval_duration":1500000000,"total_duration":2200000000}"#
+        let usage = try? #require(handler.extractUsage(from: json))
+        #expect(usage?.promptTokens == 42)
+        #expect(usage?.completionTokens == 17)
+    }
+
+    /// Lines without either usage field must return nil so the
+    /// `SSECloudBackend.handleUsage` merge logic isn't called with an empty
+    /// tuple (which would overwrite a prior prompt count with 0 on Claude's
+    /// split-usage path). Pins the "missing fields → nil" contract.
+    @Test func payloadHandler_extractUsage_nonUsageLine_returnsNil() {
+        let handler = OllamaBackend.OllamaPayloadHandler()
+        let midLine = #"{"model":"llama3.2","message":{"role":"assistant","content":"hi"},"done":false}"#
+        #expect(handler.extractUsage(from: midLine) == nil)
+
+        // Malformed JSON also returns nil (parseLine returns nil).
+        #expect(handler.extractUsage(from: "not json") == nil)
+    }
+
+    /// End-to-end: the done-line's `eval_count` / `prompt_eval_count` must
+    /// surface both as a `.usage(prompt:completion:)` event on the stream and
+    /// as `lastUsage` on the backend — mirroring `SSECloudBackend`'s SSE path.
+    /// This is what actually reaches the UI.
+    ///
+    /// Sabotage check (verified locally): removing the `handleUsage` /
+    /// `.usage` yield block from `parseResponseStream` on the done branch
+    /// makes both assertions fail (no `.usage` event, `lastUsage` stays nil).
+    @Test func streaming_doneLine_emitsUsageEventAndSetsLastUsage() async throws {
+        let (backend, chatURL) = makeConfiguredBackend()
+        try await loadBackend(backend)
+
+        let chunks: [Data] = [
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":"hi"},"done":false}"#),
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop","prompt_eval_count":42,"eval_count":17}"#),
+        ]
+        MockURLProtocol.stub(url: chatURL, response: .sse(chunks: chunks, statusCode: 200))
+        defer { MockURLProtocol.unstub(url: chatURL) }
+
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: .init())
+        var usageEvents: [(prompt: Int, completion: Int)] = []
+        for try await event in stream.events {
+            if case .usage(let p, let c) = event {
+                usageEvents.append((prompt: p, completion: c))
+            }
+        }
+
+        #expect(usageEvents.count == 1)
+        #expect(usageEvents.first?.prompt == 42)
+        #expect(usageEvents.first?.completion == 17)
+        #expect(backend.lastUsage?.promptTokens == 42)
+        #expect(backend.lastUsage?.completionTokens == 17)
     }
 
     // MARK: - /api/generate Endpoint Shape
@@ -924,19 +972,15 @@ struct OllamaBackendTests {
         #expect(numPredict == 4096)
     }
 
-    /// Because we doubled the server-side budget, visible output must be
-    /// re-capped client-side. This fixture emits 5 content lines but sets
-    /// `maxOutputTokens = 3`; the consumer must see exactly 3 `.token`
-    /// events, then the stream terminates cleanly (no error thrown, no
-    /// `.thinkingComplete` because no thinking was ever emitted).
+    /// Visible output must be re-capped client-side because the server-side
+    /// budget is doubled to reserve thinking tokens. With no `eval_count` on
+    /// intermediate lines (per Ollama's documented wire format), the cap
+    /// falls back to the NDJSON line counter, so 5 single-line chunks + cap=3
+    /// yields exactly 3 `.token` events before a clean stream termination.
     ///
     /// Sabotage check (verified locally): deleting the `continuation.finish();
     /// return` guard in `parseResponseStream` makes this test fail with
     /// tokens.count == 5.
-    ///
-    /// Known limitation (documented on the PR): `visibleTokenCount` counts
-    /// NDJSON lines, not true tokens. A follow-up will switch to Ollama's
-    /// `eval_count` field for exact accounting.
     @Test func streaming_visibleCap_terminatesStreamCleanly() async throws {
         let (backend, chatURL) = makeConfiguredBackend()
         try await loadBackend(backend)
@@ -968,6 +1012,55 @@ struct OllamaBackendTests {
 
         #expect(tokens == ["a", "b", "c"])
         #expect(!sawThinkingComplete, "no thinking was emitted so no .thinkingComplete should fire")
+    }
+
+    /// When an Ollama-compatible server emits a running `eval_count` on
+    /// intermediate lines, the cap must use it — not the NDJSON line count
+    /// — so multi-word content chunks can't slip extra tokens past the
+    /// `maxOutputTokens` ceiling. This is the PR #586 fixture's key
+    /// limitation made concrete: under the old line-count cap, five
+    /// multi-word lines at `maxOutputTokens=5` would yield 5 lines * multi
+    /// words each. With exact accounting, generation stops the instant
+    /// `eval_count` crosses the cap.
+    ///
+    /// Sabotage check (verified locally): reverting the cap check to
+    /// `visibleLineCount >= limit` (ignoring `parsed.evalCount`) makes this
+    /// test fail because all 5 multi-word lines pass through (the cap isn't
+    /// reached until line 6).
+    @Test func streaming_visibleCap_usesExactEvalCount_overLineCount() async throws {
+        let (backend, chatURL) = makeConfiguredBackend()
+        try await loadBackend(backend)
+
+        // Each intermediate line is multi-word content + running eval_count
+        // advancing 2 → 4 → 6 → 8 → 10. With `maxOutputTokens = 5`, the first
+        // line that observes `eval_count >= 5` is the `eval_count:6` line;
+        // cap triggers on its arrival BEFORE emitting the token, so two tokens
+        // (the `eval_count:2` and `eval_count:4` lines) are yielded.
+        let chunks: [Data] = [
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":"hello world"},"done":false,"eval_count":2}"#),
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":"foo bar"},"done":false,"eval_count":4}"#),
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":"baz qux"},"done":false,"eval_count":6}"#),
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":"extra"},"done":false,"eval_count":8}"#),
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":"more"},"done":false,"eval_count":10}"#),
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":""},"done":true,"eval_count":10,"prompt_eval_count":3}"#),
+        ]
+        MockURLProtocol.stub(url: chatURL, response: .sse(chunks: chunks, statusCode: 200))
+        defer { MockURLProtocol.unstub(url: chatURL) }
+
+        var config = GenerationConfig()
+        config.maxOutputTokens = 5
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: config)
+
+        var tokens: [String] = []
+        for try await event in stream.events {
+            if case .token(let t) = event { tokens.append(t) }
+        }
+
+        // Two tokens emitted (eval_count 2 and 4 were below the cap of 5).
+        // The eval_count=6 line is the first to cross the cap; its content
+        // ("baz qux") must NOT appear. Under the old line-count cap this
+        // assertion would fail because all 5 multi-word lines would pass.
+        #expect(tokens == ["hello world", "foo bar"])
     }
 }
 


### PR DESCRIPTION
## Summary

- Parse Ollama's `eval_count` (completion tokens) and `prompt_eval_count` (prompt tokens) from every NDJSON line so `maxOutputTokens` becomes a precise cap.
- Yield `.usage(prompt:completion:)` on the done-line and populate `lastUsage` via `handleUsage`, mirroring the SSE path in `SSECloudBackend.parseResponseStream`.
- Wire `OllamaPayloadHandler.extractUsage` to the same parse logic (was hard-coded `nil`).
- Resolves the known limitation documented on PR #586.

## How Ollama's eval_count works

Per the [Ollama API docs](https://github.com/ollama/ollama/blob/main/docs/api.md), the final response in a streaming chat/generate call includes `total_duration`, `load_duration`, `prompt_eval_count`, `prompt_eval_duration`, `eval_count`, and `eval_duration`. `eval_count` is the number of tokens the model produced this turn; `prompt_eval_count` is the number of tokens in the input prompt.

**Critical wire-format finding.** Stock Ollama only emits these on the terminal `"done":true` line — intermediate lines carry `message.content` and `done:false` with no usage fields. Some Ollama-compatible proxies/servers do echo a running `eval_count` on intermediate lines, so this PR parses `eval_count` unconditionally from every line: if present, it's used as the exact cap value; if not, generation falls back to the NDJSON line counter (upper bound, same behaviour as PR #586 shipped).

## What changed vs PR #586

PR #586 fixed the thinking-model empty-response bug by doubling `num_predict` and re-capping visible output client-side via `visibleTokenCount >= limit` — where `visibleTokenCount` was the count of NDJSON content lines. A single line can carry a multi-word chunk (`"content":"hello world"` is one line, two or more tokens), so `maxOutputTokens=N` let through anywhere from N to several*N tokens in practice.

This PR replaces the cap check with `parsed.evalCount ?? visibleLineCount >= limit`. When the server reports running eval_count, the cap is exact. When it doesn't, we retain the line-count fallback so stock Ollama still behaves like PR #586 did — the known limitation is resolved where the server cooperates and unchanged elsewhere. The `.usage` event + `lastUsage` wiring lands regardless, so UI and `TokenUsageProvider` consumers always get the exact final count.

## Test plan

Updated one test and added four to `Tests/BaseChatBackendsTests/OllamaBackendTests.swift`:

- `payloadHandler_extractUsage_parsesDoneLineCounts` — replaces PR #586's `payloadHandler_extractUsage_returnsNil_evenWithUsageFields` (which pinned the old "ignored" contract). Asserts `promptTokens == 42` and `completionTokens == 17` for a realistic done-line payload. **Sabotage:** reverting `extractUsage` to `return nil` makes both assertions fail. Verified locally.
- `payloadHandler_extractUsage_nonUsageLine_returnsNil` — intermediate content-only lines and malformed JSON must return nil so `handleUsage`'s split-merge logic on backends like Claude isn't called with empty tuples. **Sabotage:** removing the `evalCount != nil || promptEvalCount != nil` guard makes the intermediate-line assertion fail. Verified locally.
- `streaming_doneLine_emitsUsageEventAndSetsLastUsage` — end-to-end: stream a done-line with `prompt_eval_count:42, eval_count:17`, assert exactly one `.usage` event with those values and `backend.lastUsage == (42, 17)`. This proves the path the UI actually sees. **Sabotage:** removing the `handleUsage` + `.usage` yield block from `parseResponseStream`'s done branch fails all four assertions (no `.usage` event, `lastUsage` stays nil). Verified locally.
- `streaming_visibleCap_usesExactEvalCount_overLineCount` — five intermediate lines each carrying multi-word content and advancing `eval_count` by 2, with `maxOutputTokens=5`. Under the old line-count cap the first five multi-word lines would pass; under exact accounting the cap triggers on the `eval_count:6` line before emitting it, so only two lines' worth of tokens surface. **Sabotage:** reverting the cap check to `visibleLineCount >= limit` (ignoring `parsed.evalCount`) makes this test fail because all five multi-word lines pass through. Verified locally.

PR #586's `streaming_visibleCap_terminatesStreamCleanly` is kept and updated: the fixture emits no `eval_count` on intermediate lines, so the test now exercises the fallback line-count path explicitly and documents it in the test comment. Its original sabotage (deleting the `continuation.finish(); return` guard) still applies to the fallback branch.

### Pre-push suites

All five CI suites pass locally:

- `BaseChatCoreTests`: 204 tests, 0 failures
- `BaseChatInferenceTests`: 841 tests, 0 failures
- `BaseChatInferenceSwiftTestingTests`: 69 tests, 0 failures
- `BaseChatUITests`: 450 tests, 0 failures
- `BaseChatBackendsTests`: 116 tests, 0 failures

## Release Note

**Ollama token counts are now exact** — `OllamaBackend` reads Ollama's `eval_count` and `prompt_eval_count` fields from the NDJSON done-line, surfaces them as a `.usage(prompt:completion:)` event and on `lastUsage`, and uses them to cap visible output precisely when servers emit a running `eval_count`. `maxOutputTokens=N` now means at most N completion tokens against cooperating servers instead of N NDJSON lines, and `TokenUsageProvider` consumers see the model's exact token accounting instead of nil. The known limitation called out in the previous release is resolved.