### PR TITLE
fix: reserve maxThinkingTokens in ContextWindowManager trim math

### DIFF
--- a/Sources/BaseChatInference/Services/ContextWindowManager.swift
+++ b/Sources/BaseChatInference/Services/ContextWindowManager.swift
@@ -5,28 +5,27 @@ import Foundation
 /// Uses a simple character-count heuristic (~4 chars per token) for estimation.
 /// A real tokenizer can replace this in a future cycle.
 ///
-/// ## Reservation policy (audit as of 2026-04-20)
+/// ## Reservation policy (audit as of 2026-04-20, updated post-#587 fix)
 ///
-/// Today the trim budget is computed as
+/// The trim budget is computed as
 /// `available = maxTokens - systemPromptTokens - responseBuffer`, where
-/// `responseBuffer` is a **caller-supplied constant** (default `512`). The manager
-/// itself has no knowledge of ``GenerationConfig`` — in particular it does not see
-/// ``GenerationConfig/maxOutputTokens`` or ``GenerationConfig/maxThinkingTokens``
-/// and therefore cannot size the reservation to the real per-request limits.
+/// `responseBuffer` is supplied by the caller. The manager itself has no
+/// knowledge of ``GenerationConfig`` — callers derive the buffer from the
+/// config before calling in.
 ///
-/// ### Per-caller reservation today
+/// ### Per-caller reservation (post issue #587)
 ///
-/// - `BaseChatUI.GenerationCoordinator` passes a hardcoded `responseBuffer: 512`
-///   (see `Sources/BaseChatUI/ViewModels/GenerationCoordinator.swift`). This value
-///   is independent of both `maxOutputTokens` and `maxThinkingTokens`.
-/// - `BaseChatInference.PromptAssembler` uses the same hardcoded default of `512`
-///   when no `responseBuffer` is supplied.
-/// - `BaseChatInference.GenerationCoordinator.exactPreflightAndTrim` performs a
-///   second pass with an exact tokenizer and uses `config.maxOutputTokens ?? 2048`
-///   as its reservation. **It does not fold in `config.maxThinkingTokens`.** With
-///   P4 semantics where thinking tokens are produced in-context before visible
-///   tokens (see Ollama backend note below), this underestimates how much of the
-///   context window the model will actually consume.
+/// - `BaseChatUI.GenerationCoordinator` derives `responseBuffer` from
+///   `maxOutputTokens() ?? 2048` + `maxThinkingTokens() ?? 0`, wired up from
+///   `ChatViewModel.maxOutputTokens` / `maxThinkingTokens` host-facing settings.
+/// - `BaseChatInference.PromptAssembler` still uses a hardcoded default of `512`
+///   when no `responseBuffer` is supplied — that default only governs callers
+///   that don't pass their own value (tests, diagnostic tooling). Production
+///   callers all supply an explicit buffer.
+/// - `BaseChatInference.GenerationCoordinator.exactPreflightAndTrim` reserves
+///   `(config.maxOutputTokens ?? 2048) + (config.maxThinkingTokens ?? 0)`.
+///   `nil` on `maxThinkingTokens` reserves **zero** rather than a default slice
+///   — see "Default policy" below.
 /// - `BaseChatBackends.OllamaBackend` reserves thinking budget at the wire layer
 ///   by sending `num_predict = (maxOutputTokens ?? 2048) + (maxThinkingTokens ??
 ///   2048)`. That keeps the server from cutting a reasoning model off mid-think,
@@ -36,48 +35,26 @@ import Foundation
 ///   trimming, which happens upstream in the coordinator.
 /// - MLX and Foundation backends ignore `maxThinkingTokens` entirely.
 ///
-/// ### Is `maxThinkingTokens` included in the reservation today?
+/// ### Default policy for `maxThinkingTokens == nil`
 ///
-/// **No, at every layer that matters for context safety.** The UI coordinator's
-/// hardcoded `512` happens to cover a small chain-of-thought (≤ ~2 KB), but a
-/// reasoning model emitting a long think block can push the observed context
-/// usage past `maxTokens` even when `exactPreflightAndTrim` says the prompt fits.
-/// That's a silent truncation / OOB-read risk rather than a crash, because
-/// thinking tokens don't feed back into the prompt on subsequent turns — but
-/// within a single turn they consume KV slots that the trim math doesn't reserve.
+/// A `nil` value is treated as "no client-side cap" rather than "substitute a
+/// default reservation". The reservation contribution from thinking is `0`
+/// when the caller doesn't set an explicit `N`. Rationale: reserving a
+/// non-zero default would silently eat N tokens of every prompt even on
+/// non-thinking models where the reservation never gets used — principle of
+/// least surprise. Callers driving a reasoning model should set
+/// `maxThinkingTokens: N` explicitly; the trim math then reserves `N`
+/// tokens so there is headroom for the reasoning block alongside the visible
+/// response.
 ///
-/// ### Required changes for P4 (`maxThinkingTokens: nil | 0 | N`)
+/// ### Remaining gaps (tracked separately from #587)
 ///
-/// P4 changes the public semantics of `GenerationConfig.maxThinkingTokens`:
-/// `nil` = backend default, `0` = disable thinking (Ollama sends `think: false`),
-/// `N` = explicit cap. With an explicit cap published by the host, the trim
-/// math should reserve it so the prompt is trimmed aggressively enough to leave
-/// room for the full advertised visible + thinking output.
-///
-/// Specific gaps to close in P4 (or a follow-up ticket):
-///
-/// - `BaseChatInference.GenerationCoordinator.exactPreflightAndTrim`: reserve
-///   `maxOutput + (config.maxThinkingTokens ?? 0)` instead of `maxOutput` alone.
-///   A `nil` value means "use the backend default" — substitute whatever the
-///   backend advertises (see below) rather than treating it as zero.
-/// - `BaseChatUI.GenerationCoordinator`: derive `responseBuffer` from
-///   `config.maxOutputTokens + (config.maxThinkingTokens ?? 0)` (clamped to the
-///   context size) instead of the hardcoded `512`. Alternatively add an overload
-///   to ``ContextWindowManager/trimMessages(_:systemPrompt:maxTokens:responseBuffer:tokenizer:)``
-///   that takes a `GenerationConfig` and derives the buffer internally.
-/// - ``BackendCapabilities``: publish a `defaultMaxThinkingTokens` so the
-///   coordinator can substitute a per-backend sane value when the host passes
-///   `nil` (Ollama uses `2048` implicitly in `buildRequest`; mirror that here).
-/// - `BaseChatBackends.OllamaBackend.buildRequest`: when `maxThinkingTokens == 0`,
-///   send `think: false` on the wire and drop the thinking component from
-///   `num_predict` (this is the P4 core change).
-///
-/// None of the above is a ship-blocker for P4 — the current math over-reserves
-/// for most requests via the hardcoded `512`, so the observable symptom is
-/// "reasoning models lose a few turns of history sooner than they needed to"
-/// rather than a crash. But once the host publishes explicit thinking caps, the
-/// trim math should honour them for correctness and to prevent silent truncation
-/// on long-reasoning prompts. Follow-up tracked as issue #587.
+/// - ``BackendCapabilities`` still has no `defaultMaxThinkingTokens`. When
+///   that lands, coordinators can substitute a per-backend value when the
+///   host passes `nil` (Ollama uses `2048` implicitly in `buildRequest`).
+/// - P4 introduces `maxThinkingTokens == 0` semantics (Ollama sends
+///   `think: false` and drops the thinking component from `num_predict`).
+///   Tracked on the upcoming Ollama PR.
 public enum ContextWindowManager {
 
     /// Estimates the token count of a string.

--- a/Sources/BaseChatInference/Services/GenerationCoordinator.swift
+++ b/Sources/BaseChatInference/Services/GenerationCoordinator.swift
@@ -87,18 +87,20 @@ final class GenerationCoordinator {
         temperature: Float = 0.7,
         topP: Float = 0.9,
         repeatPenalty: Float = 1.1,
-        maxOutputTokens: Int? = 2048
+        maxOutputTokens: Int? = 2048,
+        maxThinkingTokens: Int? = nil
     ) throws -> GenerationStream {
         guard let backend = provider?.currentBackend else {
             throw InferenceError.inferenceFailure("No model loaded")
         }
 
-        let config = GenerationConfig(
+        var config = GenerationConfig(
             temperature: temperature,
             topP: topP,
             repeatPenalty: repeatPenalty,
             maxOutputTokens: maxOutputTokens
         )
+        config.maxThinkingTokens = maxThinkingTokens
 
         // Exact-count pre-flight: backends that conform to TokenCountingBackend
         // expose the real tokenizer. Use it to verify the assembled prompt fits
@@ -177,7 +179,20 @@ final class GenerationCoordinator {
         maxTrimAttempts: Int = 20
     ) throws -> ExactPreflightResult {
         let contextSize = Int(backend.capabilities.maxContextTokens)
-        let maxOutput = config.maxOutputTokens ?? 2048
+        // Reserve context for both visible output and (optionally) thinking output.
+        //
+        // Rationale for `?? 0` on the thinking side (not `?? 2048`): the public
+        // semantics of `maxThinkingTokens` today are "cap reasoning output; nil
+        // means no client-side cap." Reserving a fixed slice of the context
+        // window for thinking by default would silently eat that many tokens
+        // from every prompt — including on non-thinking models where it has no
+        // effect on runtime behaviour. Principle of least surprise: only
+        // reserve what the caller explicitly asked for. Callers who know they
+        // are driving a reasoning model can opt in by setting
+        // `maxThinkingTokens: N`, which then becomes the trim reservation.
+        let visibleReserve = config.maxOutputTokens ?? 2048
+        let thinkingReserve = config.maxThinkingTokens ?? 0
+        let maxOutput = visibleReserve + thinkingReserve
         let template = provider?.selectedPromptTemplate ?? .chatML
 
         var workingMessages = messages
@@ -244,6 +259,7 @@ final class GenerationCoordinator {
         topP: Float = 0.9,
         repeatPenalty: Float = 1.1,
         maxOutputTokens: Int? = 2048,
+        maxThinkingTokens: Int? = nil,
         priority: GenerationPriority = .normal,
         sessionID: UUID? = nil
     ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
@@ -263,12 +279,13 @@ final class GenerationCoordinator {
         stream.setPhase(.queued)
         continuations[token] = continuation
 
-        let config = GenerationConfig(
+        var config = GenerationConfig(
             temperature: temperature,
             topP: topP,
             repeatPenalty: repeatPenalty,
             maxOutputTokens: maxOutputTokens
         )
+        config.maxThinkingTokens = maxThinkingTokens
 
         let request = QueuedRequest(
             token: token,
@@ -340,7 +357,8 @@ final class GenerationCoordinator {
                     temperature: next.config.temperature,
                     topP: next.config.topP,
                     repeatPenalty: next.config.repeatPenalty,
-                    maxOutputTokens: next.config.maxOutputTokens
+                    maxOutputTokens: next.config.maxOutputTokens,
+                    maxThinkingTokens: next.config.maxThinkingTokens
                 )
 
                 for try await event in backendStream.events {

--- a/Sources/BaseChatInference/Services/InferenceService.swift
+++ b/Sources/BaseChatInference/Services/InferenceService.swift
@@ -174,7 +174,8 @@ public final class InferenceService {
         temperature: Float = 0.7,
         topP: Float = 0.9,
         repeatPenalty: Float = 1.1,
-        maxOutputTokens: Int? = 2048
+        maxOutputTokens: Int? = 2048,
+        maxThinkingTokens: Int? = nil
     ) throws -> GenerationStream {
         ensureProviderWired()
         return try generation.generate(
@@ -183,7 +184,8 @@ public final class InferenceService {
             temperature: temperature,
             topP: topP,
             repeatPenalty: repeatPenalty,
-            maxOutputTokens: maxOutputTokens
+            maxOutputTokens: maxOutputTokens,
+            maxThinkingTokens: maxThinkingTokens
         )
     }
 
@@ -200,6 +202,7 @@ public final class InferenceService {
         topP: Float = 0.9,
         repeatPenalty: Float = 1.1,
         maxOutputTokens: Int? = 2048,
+        maxThinkingTokens: Int? = nil,
         priority: GenerationPriority = .normal,
         sessionID: UUID? = nil
     ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
@@ -211,6 +214,7 @@ public final class InferenceService {
             topP: topP,
             repeatPenalty: repeatPenalty,
             maxOutputTokens: maxOutputTokens,
+            maxThinkingTokens: maxThinkingTokens,
             priority: priority,
             sessionID: sessionID
         )

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -251,6 +251,29 @@ public final class ChatViewModel {
         get { sessionController.repeatPenalty }
         set { sessionController.repeatPenalty = newValue }
     }
+    /// Cap on visible response tokens for each generation.
+    ///
+    /// Feeds two places:
+    /// - The trim math in ``GenerationCoordinator`` reserves this many tokens
+    ///   of the context window so the prompt is trimmed enough to leave room
+    ///   for the response (see issue #587).
+    /// - Forwarded to ``InferenceService/enqueue(...)`` as `maxOutputTokens`,
+    ///   which backends enforce as their generation cap.
+    ///
+    /// Defaults to `2048`. Set `nil` to leave generation uncapped (the client
+    /// trim math then falls back to the same `2048` reservation).
+    public var maxOutputTokens: Int? = 2048
+
+    /// Cap on reasoning tokens for each generation.
+    ///
+    /// Only reasoning-capable backends (MLX thinking models, Llama with thinking
+    /// markers, Ollama with `think: true`) enforce this. `nil` means "no
+    /// client-side cap" and reserves **zero** thinking tokens in the trim
+    /// budget — set an explicit `N` when driving a reasoning model so the
+    /// prompt is trimmed aggressively enough to leave room for the full
+    /// advertised visible + thinking output. See issue #587.
+    public var maxThinkingTokens: Int? = nil
+
     /// Minimum interval between batched UI updates during streaming (~30 fps by default).
     public var streamingUpdateInterval: Duration = .milliseconds(33)
     /// Maximum characters to buffer before forcing a UI flush during streaming.
@@ -552,6 +575,8 @@ public final class ChatViewModel {
         genCoordinator.systemPrompt = { [weak self] in self?.systemPrompt ?? "" }
         genCoordinator.systemPromptContext = { [weak self] in self?.systemPromptContext ?? [:] }
         genCoordinator.contextMaxTokens = { [weak self] in self?.contextMaxTokens ?? 2048 }
+        genCoordinator.maxOutputTokens = { [weak self] in self?.maxOutputTokens ?? 2048 }
+        genCoordinator.maxThinkingTokens = { [weak self] in self?.maxThinkingTokens }
         genCoordinator.temperature = { [weak self] in self?.temperature ?? 0.7 }
         genCoordinator.topP = { [weak self] in self?.topP ?? 0.9 }
         genCoordinator.repeatPenalty = { [weak self] in self?.repeatPenalty ?? 1.0 }

--- a/Sources/BaseChatUI/ViewModels/GenerationCoordinator.swift
+++ b/Sources/BaseChatUI/ViewModels/GenerationCoordinator.swift
@@ -74,6 +74,20 @@ final class GenerationCoordinator {
     /// Returns the current max token budget.
     var contextMaxTokens: () -> Int = { 2048 }
 
+    /// Returns the configured cap on visible output tokens, or `nil` for "no explicit cap".
+    ///
+    /// Wired from `ChatViewModel.maxOutputTokens`. Used by ``trimMessages`` to
+    /// reserve context for the model's response so the prompt is trimmed
+    /// aggressively enough to leave room for it.
+    var maxOutputTokens: () -> Int? = { 2048 }
+
+    /// Returns the configured cap on reasoning tokens, or `nil` for "no explicit cap".
+    ///
+    /// Wired from `ChatViewModel.maxThinkingTokens`. A `nil` value means the
+    /// trim math reserves zero thinking tokens — see issue #587 for why this
+    /// is opt-in rather than a backend default.
+    var maxThinkingTokens: () -> Int? = { nil }
+
     /// Returns the current temperature setting.
     var temperature: () -> Float = { 0.7 }
 
@@ -207,11 +221,21 @@ final class GenerationCoordinator {
             // messages carry over between generation cycles.
             let cachingTokenizer: TokenizerProvider = reusableCachingTokenizer()
 
+            // Reserve context for the model's visible response and (optionally)
+            // its reasoning tokens. `maxThinkingTokens == nil` reserves zero
+            // rather than a default slice so non-thinking models don't silently
+            // lose 2048 tokens of prompt to a reservation they won't use. See
+            // issue #587 and the reservation-policy memo on
+            // ``ContextWindowManager`` for the full rationale.
+            let visibleReserve = maxOutputTokens() ?? 2048
+            let thinkingReserve = maxThinkingTokens() ?? 0
+            let responseBuffer = visibleReserve + thinkingReserve
+
             let trimmed = ContextWindowManager.trimMessages(
                 allMessages,
                 systemPrompt: effectiveSystemPrompt,
                 maxTokens: contextMaxTokens(),
-                responseBuffer: 512,
+                responseBuffer: responseBuffer,
                 tokenizer: cachingTokenizer
             )
             let history: [(role: String, content: String)] = trimmed.map {
@@ -224,6 +248,8 @@ final class GenerationCoordinator {
                 temperature: temperature(),
                 topP: topP(),
                 repeatPenalty: repeatPenalty(),
+                maxOutputTokens: maxOutputTokens(),
+                maxThinkingTokens: maxThinkingTokens(),
                 priority: .userInitiated,
                 sessionID: activeSessionID()
             )

--- a/Tests/BaseChatInferenceTests/GenerationCoordinatorTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationCoordinatorTests.swift
@@ -583,6 +583,83 @@ final class GenerationCoordinatorTests: XCTestCase {
                        "three count rounds expected: 2 over-budget, 1 under-budget")
     }
 
+    // MARK: - Exact preflight: maxThinkingTokens reservation (issue #587)
+
+    /// `exactPreflightAndTrim` must fold `config.maxThinkingTokens` into the
+    /// reservation so reasoning-model prompts are trimmed aggressively enough
+    /// to leave room for both the visible response and the thinking block.
+    ///
+    /// Scenario:
+    ///   contextSize = 1000, maxOutput = 100, maxThinking = 200.
+    ///   Reserved = 300, so the prompt budget is 700.
+    ///   First countTokens returns 800 → over budget → trim.
+    ///   Second countTokens returns 650 → fits → generate.
+    ///
+    /// Sabotage check: if the reservation ignored `maxThinkingTokens`, the
+    /// first count (800) would fit within (1000 - 100) = 900 and no trim
+    /// would happen — `countTokensCalled` would be 1 and the backend would
+    /// receive the full two-message history.
+    func test_exactPreflightAndTrim_reservesVisiblePlusThinking() async throws {
+        let tcBackend = TokenCountingMockBackend(contextSize: 1000)
+        tcBackend.countTokensResponses = [800, 650]
+        tcBackend.tokensToYield = ["ok"]
+        let tcProvider = TokenCountingFakeProvider(backend: tcBackend)
+
+        let coord = GenerationCoordinator()
+        coord.provider = tcProvider
+
+        let stream = try coord.generate(
+            messages: [
+                (role: "user", content: "oldest — will be trimmed"),
+                (role: "user", content: "latest — will be kept"),
+            ],
+            maxOutputTokens: 100,
+            maxThinkingTokens: 200
+        )
+        for try await _ in stream.events {}
+
+        XCTAssertEqual(tcBackend.countTokensCalled, 2,
+                       "Two count calls expected: first over budget (800+300>1000), "
+                       + "second under after trim (650+300≤1000).")
+        XCTAssertEqual(tcBackend.generateCallCount, 1,
+                       "generate must be called exactly once after the trim round succeeds")
+    }
+
+    /// `exactPreflightAndTrim` must treat `maxThinkingTokens = nil` as a
+    /// zero-token reservation rather than substituting a default (e.g. 2048).
+    ///
+    /// Scenario:
+    ///   contextSize = 1000, maxOutput = 100, maxThinking = nil.
+    ///   Reserved = 100, so the prompt budget is 900.
+    ///   First countTokens returns 800 → fits → generate without trimming.
+    ///
+    /// Sabotage check: if nil were substituted with a 2048 default, the
+    /// reserve would be 2148 (exceeding the 1000-token context), available
+    /// would go negative, and `exactPreflightAndTrim` would throw
+    /// `contextExhausted`. The test would surface as a thrown error rather
+    /// than a successful `generateCallCount == 1`.
+    func test_exactPreflightAndTrim_thinkingNilDoesNotOverReserve() async throws {
+        let tcBackend = TokenCountingMockBackend(contextSize: 1000)
+        tcBackend.countTokensResponses = [800]
+        tcBackend.tokensToYield = ["ok"]
+        let tcProvider = TokenCountingFakeProvider(backend: tcBackend)
+
+        let coord = GenerationCoordinator()
+        coord.provider = tcProvider
+
+        let stream = try coord.generate(
+            messages: [(role: "user", content: "fits without thinking reserve")],
+            maxOutputTokens: 100,
+            maxThinkingTokens: nil
+        )
+        for try await _ in stream.events {}
+
+        XCTAssertEqual(tcBackend.countTokensCalled, 1,
+                       "Only one count call expected — the prompt fits within 1000 - 100 = 900.")
+        XCTAssertEqual(tcBackend.generateCallCount, 1,
+                       "generate must succeed without trimming when thinking reserve is zero.")
+    }
+
     // MARK: - Provider teardown safety
 
     /// Deallocating the provider mid-stream must not crash the coordinator.

--- a/Tests/BaseChatUITests/GenerationCoordinatorTrimReservationTests.swift
+++ b/Tests/BaseChatUITests/GenerationCoordinatorTrimReservationTests.swift
@@ -1,0 +1,141 @@
+@preconcurrency import XCTest
+import SwiftData
+@testable import BaseChatUI
+@testable import BaseChatCore
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Regression tests for issue #587 — the UI `GenerationCoordinator` previously
+/// hardcoded `responseBuffer: 512` when calling `ContextWindowManager.trimMessages`.
+/// That value ignored both `ChatViewModel.maxOutputTokens` and
+/// `ChatViewModel.maxThinkingTokens`, so thinking-heavy models could silently
+/// truncate older prompt history once reasoning output exceeded ~2 KB.
+///
+/// These tests pin the new behaviour: the reservation is derived from
+/// `maxOutputTokens() + (maxThinkingTokens() ?? 0)` and is forwarded to the
+/// backend via `InferenceService.enqueue`.
+@MainActor
+final class GenerationCoordinatorTrimReservationTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+    private var vm: ChatViewModel!
+    private var sessionManager: SessionManagerViewModel!
+    private var mock: MockInferenceBackend!
+    private var sessionID: UUID!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        container = try makeInMemoryContainer()
+        context = container.mainContext
+
+        mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.tokensToYield = ["ok"]
+
+        let service = InferenceService(backend: mock, name: "MockTrim")
+        vm = ChatViewModel(inferenceService: service)
+        vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
+
+        sessionManager = SessionManagerViewModel()
+        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
+
+        let session = try sessionManager.createSession(title: "Trim fixture")
+        sessionManager.activeSession = session
+        vm.switchToSession(session)
+        sessionID = session.id
+    }
+
+    override func tearDown() async throws {
+        vm = nil
+        sessionManager = nil
+        mock = nil
+        context = nil
+        container = nil
+        try await super.tearDown()
+    }
+
+    /// Black-box: the UI coordinator must forward `ChatViewModel.maxOutputTokens`
+    /// to the backend instead of relying on the `InferenceService.enqueue`
+    /// default of `2048`. Sabotage-verified by temporarily setting the
+    /// hardcode back in the coordinator — `mock.lastConfig?.maxOutputTokens`
+    /// then reports `2048` (the enqueue default) and this assertion fails.
+    func test_uiGenerationCoordinator_forwardsMaxOutputTokens() async throws {
+        vm.maxOutputTokens = 100
+        vm.maxThinkingTokens = nil
+
+        vm.inputText = "hi"
+        await vm.sendMessage()
+
+        let config = try XCTUnwrap(mock.lastConfig, "Backend should have received a config")
+        XCTAssertEqual(config.maxOutputTokens, 100,
+                       "ChatViewModel.maxOutputTokens must propagate to the backend, "
+                       + "not the 2048 enqueue default.")
+    }
+
+    /// Black-box: the UI coordinator must forward `ChatViewModel.maxThinkingTokens`
+    /// through `enqueue` into `GenerationConfig.maxThinkingTokens` so downstream
+    /// backends (Ollama, Llama, MLX) can honour the cap.
+    func test_uiGenerationCoordinator_forwardsMaxThinkingTokens() async throws {
+        vm.maxOutputTokens = 256
+        vm.maxThinkingTokens = 128
+
+        vm.inputText = "hi"
+        await vm.sendMessage()
+
+        let config = try XCTUnwrap(mock.lastConfig)
+        XCTAssertEqual(config.maxThinkingTokens, 128,
+                       "ChatViewModel.maxThinkingTokens must flow through to GenerationConfig.")
+    }
+
+    /// Black-box: the UI coordinator must NOT hardcode `responseBuffer: 512`.
+    /// Verified by setting `maxOutputTokens` to a value far above 512 and
+    /// asserting that it, not 512, drives the trim decision.
+    ///
+    /// Scenario: context = 100 tokens, maxOutputTokens = 90, system prompt empty.
+    /// - With the fix: `responseBuffer = 90 + 0 = 90` → only 10 tokens for prompt
+    ///   → the trimmer keeps at most a couple of short messages.
+    /// - Pre-fix (`responseBuffer: 512`): `available = 100 - 0 - 512 = -412 ≤ 0`
+    ///   → the trimmer returns just the single last-user message.
+    ///
+    /// So the PRE-fix branch keeps exactly 1 message; the POST-fix branch keeps
+    /// more than 1. Asserting `count >= 2` distinguishes the two.
+    ///
+    /// Sabotage check: restoring the hardcoded `responseBuffer: 512` in the
+    /// UI `GenerationCoordinator` forces `available <= 0`, the trimmer
+    /// returns only the latest user message, and this assertion fails.
+    func test_uiGenerationCoordinator_noLongerHardcodes512() async throws {
+        vm.contextMaxTokens = 100
+        vm.maxOutputTokens = 90
+        vm.maxThinkingTokens = 0
+
+        // Seed a history of short messages. Each is roughly 5–7 tokens under
+        // the heuristic tokenizer (~4 chars / token). With a 10-token budget
+        // the trimmer should keep the newest ~1–2 entries — but crucially
+        // **more than 0 history entries from the seed** are kept in addition
+        // to the new user message. The pre-fix 512 hardcode forces
+        // `available <= 0`, which returns just the last user message.
+        var msgs: [ChatMessageRecord] = []
+        for i in 0..<6 {
+            msgs.append(ChatMessageRecord(role: .user, content: "q\(i)pad", sessionID: sessionID))
+            msgs.append(ChatMessageRecord(role: .assistant, content: "r\(i)pad", sessionID: sessionID))
+        }
+        vm.messages = msgs
+
+        mock.lastReceivedHistory = nil
+        vm.inputText = "hi"
+        await vm.sendMessage()
+
+        let trimmed = try XCTUnwrap(mock.lastReceivedHistory,
+                                    "Mock backend should have received a trimmed history")
+
+        XCTAssertGreaterThanOrEqual(
+            trimmed.count, 2,
+            "With responseBuffer derived from maxOutputTokens=90 (not a 512 hardcode), "
+            + "available = 100 - 0 - 90 = 10 tokens is enough to keep more than one message. "
+            + "The pre-fix 512 hardcode would force available <= 0, trimming to just the "
+            + "single last user message. Count was \(trimmed.count)."
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Closes #587. Prerequisite to the upcoming P4 Ollama `think:false` / `maxThinkingTokens` semantic change — safe to land standalone because the pre-fix UI hardcode over-reserved in practice.

## Root cause

`ContextWindowManager.trimMessages` takes a caller-supplied `responseBuffer` reserve. Two callers fed it stale values that ignored `GenerationConfig.maxThinkingTokens`:

- `BaseChatInference.GenerationCoordinator.exactPreflightAndTrim` reserved `config.maxOutputTokens ?? 2048` only.
- `BaseChatUI.GenerationCoordinator` passed a hardcoded `responseBuffer: 512`, ignoring both `maxOutputTokens` and `maxThinkingTokens`.

Full audit in the DocC memo at the top of `Sources/BaseChatInference/Services/ContextWindowManager.swift` (landed in PR #590).

## Fix

Both call sites now derive the buffer as:

```swift
let visibleReserve = config.maxOutputTokens ?? 2048
let thinkingReserve = config.maxThinkingTokens ?? 0
let responseBuffer = visibleReserve + thinkingReserve
```

The audit memo inside `ContextWindowManager` is updated to match the new reality.

## Semantic decision: `?? 0` for `maxThinkingTokens`, not `?? 2048`

`nil` is treated as "no client-side cap" rather than substituting a 2048 default. Reserving a non-zero default would silently eat N tokens of every prompt — including on non-thinking models where the reservation never gets used. Principle of least surprise: only reserve what the caller explicitly asked for. Callers driving a reasoning model set `maxThinkingTokens: N` explicitly; the trim math then reserves `N` tokens. The rationale is also pinned in an inline comment inside `exactPreflightAndTrim` for future maintainers.

## Plumbing

- `InferenceService.generate` / `enqueue` gain `maxThinkingTokens: Int? = nil` (additive, non-breaking default).
- `ChatViewModel` exposes `maxOutputTokens: Int? = 2048` and `maxThinkingTokens: Int? = nil` as host-facing settings.
- UI `GenerationCoordinator` reads both through new read-seams and forwards them to `enqueue`.

## Test plan

Three new tests covering both call sites, each sabotage-verified:

- [x] `test_exactPreflightAndTrim_reservesVisiblePlusThinking` — `contextSize=1000, maxOutput=100, maxThinking=200` → reserve is 300, first count over budget triggers a trim. Sabotage (drop thinking from reserve): first count fits inside 1000 - 100 = 900 so no trim happens → `countTokensCalled` is 1 not 2 → fails.
- [x] `test_exactPreflightAndTrim_thinkingNilDoesNotOverReserve` — `maxThinking=nil` with the same 1000-context, 100-output, 800-prompt shape fits without trimming. Sabotage (`?? 2048`): reserve becomes 2148, available goes negative, `contextExhausted` is thrown → fails.
- [x] `test_uiGenerationCoordinator_forwardsMaxOutputTokens` + `test_uiGenerationCoordinator_noLongerHardcodes512` — black-box tests via `ChatViewModel` + `MockInferenceBackend`. The first asserts `mock.lastConfig?.maxOutputTokens == 100` when `ChatViewModel.maxOutputTokens = 100`. The second sets `contextMaxTokens=100, maxOutputTokens=90` so the new math keeps >=2 messages while the pre-fix 512 hardcode would trim to the single last user message. Sabotage (restore 512 hardcode): second test fails with count=1. Sabotage (drop forwarding of `maxOutputTokens`): first test fails because the backend sees 2048.
- [x] Extra forwarding test (`test_uiGenerationCoordinator_forwardsMaxThinkingTokens`) pins that `ChatViewModel.maxThinkingTokens` flows into `GenerationConfig.maxThinkingTokens`.

## Existing test fallout

None — existing tests pass explicit `responseBuffer:` values to `trimMessages` directly, and `exactPreflightAndTrim` tests did not set `maxThinkingTokens`, so the new default of `nil → 0` matches their prior behaviour.

## Pre-push suites

All green locally:

- BaseChatCoreTests — pass
- BaseChatInferenceTests — pass
- BaseChatInferenceSwiftTestingTests — pass
- BaseChatUITests — pass
- BaseChatBackendsTests — pass

## Release Note

**Thinking-model context safety** — `ContextWindowManager` trim math now reserves both visible and (when explicitly set) thinking output budgets, so reasoning-heavy responses no longer silently push earlier prompt history out of context within a single turn. Host apps can drive the new behaviour via `ChatViewModel.maxOutputTokens` and `ChatViewModel.maxThinkingTokens`, and by passing `maxThinkingTokens:` into `InferenceService.generate` / `enqueue` directly. `nil` on the thinking side means "no cap, reserve nothing" so non-thinking callers are unaffected.