### PR TITLE
feat!: honor maxThinkingTokens=0 to disable thinking on Ollama, detect thinking models via /api/show

### DIFF
--- a/Sources/BaseChatBackends/OllamaBackend.swift
+++ b/Sources/BaseChatBackends/OllamaBackend.swift
@@ -25,6 +25,21 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
     /// Default is "30m" (30 minutes). Ollama's own default is "5m".
     public var keepAlive: String = "30m"
 
+    /// Whether the currently-loaded Ollama model advertises thinking/reasoning
+    /// capability. Detected once at `loadModel` time by probing `/api/show`
+    /// for `capabilities: ["thinking"]` or Jinja template markers
+    /// (`<think>`, `{{ if .Thinking }}`, etc.). Defaults to `false` when the
+    /// probe fails or the server returns an unexpected shape — detection is a
+    /// best-effort optimisation, never a blocker.
+    ///
+    /// Consumers: `buildRequest` uses this flag to decide whether
+    /// `maxThinkingTokens == nil` should reserve a 2048-token thinking budget
+    /// (thinking models only) and whether `maxThinkingTokens == 0` should
+    /// forward `"think": false` on the wire (thinking models only; Ollama
+    /// silently ignores the flag on non-thinking models but we omit it for
+    /// clean request bodies).
+    public private(set) var isThinkingModel: Bool = false
+
     // MARK: - Init
 
     /// Creates an Ollama backend.
@@ -68,8 +83,66 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
                 "No base URL configured. Call configure(baseURL:modelName:) first."
             )
         }
+
+        self.isThinkingModel = (try? await detectThinkingCapability()) ?? false
+
         setIsModelLoaded(true)
-        Log.inference.info("OllamaBackend configured for \(self.modelName, privacy: .public) at \(self.baseURL?.host() ?? "unknown", privacy: .public)")
+        Log.inference.info("OllamaBackend configured for \(self.modelName, privacy: .public) at \(self.baseURL?.host() ?? "unknown", privacy: .public) thinking=\(self.isThinkingModel, privacy: .public)")
+    }
+
+    /// Calls Ollama's `/api/show` endpoint and classifies the model as
+    /// thinking-capable or not.
+    ///
+    /// Detection prefers `capabilities: ["thinking", ...]` (surfaced by modern
+    /// Ollama releases) and falls back to scanning the Jinja `template` field
+    /// for `<think>`, `</think>`, or `{{ if .Thinking }}` markers that
+    /// reasoning models ship by convention.
+    ///
+    /// Returns `false` (not `nil`) on HTTP failures other than thrown network
+    /// errors so callers get a clean boolean; `throws` so internal bugs (bad
+    /// URL, serialization failure) still surface for the test harness.
+    private func detectThinkingCapability() async throws -> Bool {
+        guard let baseURL else { return false }
+        let showURL = baseURL.appendingPathComponent("api/show")
+
+        var request = URLRequest(url: showURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: ["model": modelName])
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await urlSession.data(for: request)
+        } catch {
+            Log.network.info("OllamaBackend /api/show probe failed (\(error.localizedDescription, privacy: .public)) — treating \(self.modelName, privacy: .public) as non-thinking")
+            return false
+        }
+
+        if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            Log.network.info("OllamaBackend /api/show returned HTTP \(http.statusCode, privacy: .public) for \(self.modelName, privacy: .public) — treating as non-thinking")
+            return false
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            Log.network.info("OllamaBackend /api/show returned non-JSON for \(self.modelName, privacy: .public) — treating as non-thinking")
+            return false
+        }
+
+        // Preferred: structured capabilities list.
+        if let caps = json["capabilities"] as? [String],
+           caps.contains(where: { $0.lowercased() == "thinking" }) {
+            return true
+        }
+
+        // Fallback: scan the template for thinking markers.
+        if let template = json["template"] as? String {
+            let markers = ["<think>", "</think>", "{{ if .Thinking }}", "{{if .Thinking}}"]
+            if markers.contains(where: { template.contains($0) }) {
+                return true
+            }
+        }
+
+        return false
     }
 
     // MARK: - Request Building
@@ -95,15 +168,39 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
             messages.append(["role": "user", "content": prompt])
         }
 
-        // For thinking models (e.g. gemma4, qwen3), Ollama counts thinking tokens
-        // against num_predict. Reserve budget for both thinking and visible output
-        // so the model isn't silently cut off mid-think before any content is produced.
-        // maxOutputTokens is enforced client-side in parseResponseStream using the
-        // server's own `eval_count` when it appears on a line (running count on
-        // intermediate lines where servers emit it, or the final done-line count);
-        // a per-line counter remains as a fallback for servers that don't.
+        // num_predict has to cover thinking + visible tokens together on
+        // Ollama. The three-state `maxThinkingTokens` semantics below map
+        // directly to the wire:
+        //
+        //   nil → default thinking reserve, *only* on known thinking models
+        //         (was unconditional pre-P4; non-thinking models no longer
+        //         over-provision 2048 unused tokens).
+        //   0   → explicitly disable thinking. Sends `think: false` on
+        //         thinking-capable models; non-thinking models omit the key
+        //         because Ollama treats it as a no-op there.
+        //   N>0 → explicit cap at N thinking tokens; `think` is omitted so
+        //         Ollama honours the model's per-request default and we stay
+        //         forward-compatible with future capability flags.
+        //
+        // Visible output is still re-capped client-side in
+        // parseResponseStream using the server's own `eval_count`, so an
+        // over-generous num_predict can never cause more visible tokens than
+        // `maxOutputTokens` to surface to the caller.
         let visibleBudget = config.maxOutputTokens ?? 2048
-        let thinkingBudget = config.maxThinkingTokens ?? 2048
+        let thinkingBudget: Int
+        let thinkDirective: Bool?
+        switch config.maxThinkingTokens {
+        case .some(0):
+            thinkingBudget = 0
+            thinkDirective = isThinkingModel ? false : nil
+        case .some(let n):
+            thinkingBudget = n
+            thinkDirective = nil
+        case nil:
+            thinkingBudget = isThinkingModel ? 2048 : 0
+            thinkDirective = nil
+        }
+
         let options: [String: Any] = [
             "temperature": config.temperature,
             "top_p": config.topP,
@@ -112,13 +209,16 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
             "num_predict": visibleBudget + thinkingBudget,
         ]
 
-        let body: [String: Any] = [
+        var body: [String: Any] = [
             "model": modelName,
             "messages": messages,
             "stream": true,
             "options": options,
             "keep_alive": keepAlive,
         ]
+        if let think = thinkDirective {
+            body["think"] = think
+        }
 
         var request = URLRequest(url: chatURL)
         request.httpMethod = "POST"

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -30,10 +30,27 @@ public struct GenerationConfig: Sendable, Codable {
     /// calling.  Defaults to ``ToolChoice/auto``.
     public var toolChoice: ToolChoice
 
-    /// Approximate cap on reasoning tokens. Counts thinkingToken events (≈ one per decoded token).
-    /// nil = no limit. Only enforced by LlamaGenerationDriver; MLX ignores this field.
-    /// Note: lives on GenerationConfig as a per-request hint. Will move to BackendCapabilities
-    /// when a backend-level thinking-capability flag is added.
+    /// Cap on reasoning (chain-of-thought) tokens for a single generation.
+    ///
+    /// - `nil` — no client-side cap. Backends reserve a default thinking budget
+    ///   only when the loaded model is known to be a thinking model (Ollama
+    ///   detects this via `/api/show`; Llama uses the prompt template's
+    ///   `thinkingMarkers`). Non-thinking models add no reservation.
+    /// - `0` — **disable thinking entirely.** On supporting backends (Ollama
+    ///   with thinking-capable models, MLX/Llama with reasoning GGUFs), this
+    ///   instructs the model to skip the reasoning phase and emit visible
+    ///   output directly. On non-thinking models this is a no-op.
+    /// - `N > 0` — cap thinking tokens at `N`; additional reasoning tokens are
+    ///   dropped. Visible output is still produced.
+    ///
+    /// See `OllamaBackend` for the wire-level mapping (`"think": false` when
+    /// `0`, `num_predict` reservation when `N`). `LlamaGenerationDriver` also
+    /// enforces the `N`-case cap; backends that do not honour the `0`-case
+    /// today may start the reasoning phase anyway — that's deferred work.
+    ///
+    /// Note: lives on GenerationConfig as a per-request hint. Will move to
+    /// BackendCapabilities when a backend-level thinking-capability flag is
+    /// added.
     public var maxThinkingTokens: Int?
 
     /// Thinking markers for this request's model/template, or nil if the model does not emit

--- a/Tests/BaseChatBackendsTests/OllamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/OllamaBackendTests.swift
@@ -35,8 +35,30 @@ struct OllamaBackendTests {
         return (backend, baseURL.appendingPathComponent("api/chat"))
     }
 
+    /// Returns both the `/api/chat` URL and the matching `/api/show` URL for
+    /// tests that want to stub the thinking-capability probe explicitly.
+    private func makeConfiguredBackendWithShow() -> (OllamaBackend, chatURL: URL, showURL: URL) {
+        let session = makeMockSession()
+        let backend = OllamaBackend(urlSession: session)
+        let baseURL = URL(string: "http://ollama-\(UUID().uuidString).test")!
+        backend.configure(baseURL: baseURL, modelName: "llama3.2")
+        return (
+            backend,
+            chatURL: baseURL.appendingPathComponent("api/chat"),
+            showURL: baseURL.appendingPathComponent("api/show")
+        )
+    }
+
     private func loadBackend(_ backend: OllamaBackend) async throws {
         try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+    }
+
+    /// Builds a minimal `/api/show` JSON response body with an explicit
+    /// `capabilities` array (and optional `template` for the fallback-path test).
+    private func apiShowBody(capabilities: [String], template: String? = nil) -> Data {
+        var obj: [String: Any] = ["capabilities": capabilities]
+        if let template { obj["template"] = template }
+        return try! JSONSerialization.data(withJSONObject: obj)
     }
 
     // MARK: - Init & State
@@ -941,12 +963,28 @@ struct OllamaBackendTests {
         #expect(numPredict == 150)
     }
 
-    /// When both caps are `nil` (default `GenerationConfig()`), each side
-    /// defaults to 2048, so `num_predict` must land on `4096`. Pins the
-    /// default-default arithmetic so a future refactor doesn't silently
-    /// shift the server-side ceiling.
-    @Test func generate_numPredict_bothCapsNil_defaultsTo4096() async throws {
-        let (backend, chatURL) = makeConfiguredBackend()
+    /// When both caps are `nil` (default `GenerationConfig()`) on a **thinking
+    /// model**, each side defaults to 2048, so `num_predict` must land on
+    /// `4096`. Pins the default-default arithmetic so a future refactor
+    /// doesn't silently shift the server-side ceiling.
+    ///
+    /// Post-P4 semantics: the 2048 thinking reservation is gated on the
+    /// `/api/show` probe detecting a thinking-capable model. Non-thinking
+    /// models land on 2048 (visible only) — see
+    /// `generate_numPredict_nonThinkingModel_skipsReservation` below.
+    @Test func generate_numPredict_bothCapsNil_thinkingModel_defaultsTo4096() async throws {
+        let (backend, chatURL, showURL) = makeConfiguredBackendWithShow()
+
+        // Thinking-capable `/api/show` so loadModel flips isThinkingModel=true.
+        MockURLProtocol.stub(
+            url: showURL,
+            response: .immediate(
+                data: apiShowBody(capabilities: ["completion", "thinking"]),
+                statusCode: 200
+            )
+        )
+        defer { MockURLProtocol.unstub(url: showURL) }
+
         try await loadBackend(backend)
 
         let chunks: [Data] = [
@@ -970,6 +1008,263 @@ struct OllamaBackendTests {
         let options = try #require(json["options"] as? [String: Any])
         let numPredict = try #require(options["num_predict"] as? Int)
         #expect(numPredict == 4096)
+    }
+
+    // MARK: - P4: /api/show thinking-model detection + maxThinkingTokens semantics
+
+    /// `/api/show` returning `capabilities: ["thinking"]` must flip
+    /// `isThinkingModel = true` and reserve the 2048-token thinking budget
+    /// when `maxThinkingTokens == nil`.
+    @Test func loadModel_detectsThinkingModel_fromCapabilities() async throws {
+        let (backend, chatURL, showURL) = makeConfiguredBackendWithShow()
+
+        MockURLProtocol.stub(
+            url: showURL,
+            response: .immediate(
+                data: apiShowBody(capabilities: ["completion", "thinking"]),
+                statusCode: 200
+            )
+        )
+        defer { MockURLProtocol.unstub(url: showURL) }
+
+        try await loadBackend(backend)
+        #expect(backend.isThinkingModel)
+
+        let chunks: [Data] = [
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":"ok"},"done":false}"#),
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":""},"done":true}"#),
+        ]
+        MockURLProtocol.stub(url: chatURL, response: .sse(chunks: chunks, statusCode: 200))
+        defer { MockURLProtocol.unstub(url: chatURL) }
+
+        var config = GenerationConfig()
+        config.maxOutputTokens = 100
+        config.maxThinkingTokens = nil
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: config)
+        for try await _ in stream.events { }
+
+        let captured = MockURLProtocol.capturedRequests.last(where: { $0.url == chatURL })
+        let body = try extractBody(from: captured)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let options = try #require(json["options"] as? [String: Any])
+        #expect((options["num_predict"] as? Int) == 100 + 2048)
+        // maxThinkingTokens=nil must NOT send a `think` directive (Ollama picks).
+        #expect(json["think"] == nil)
+    }
+
+    /// `/api/show` without `thinking` capability and without `<think>`
+    /// template markers must leave `isThinkingModel = false`, and
+    /// `maxThinkingTokens == nil` must then skip the 2048 reservation
+    /// entirely.
+    @Test func loadModel_detectsNonThinkingModel_skipsReservation() async throws {
+        let (backend, chatURL, showURL) = makeConfiguredBackendWithShow()
+
+        MockURLProtocol.stub(
+            url: showURL,
+            response: .immediate(
+                data: apiShowBody(
+                    capabilities: ["completion"],
+                    template: "{{ .System }}\n{{ .Prompt }}"
+                ),
+                statusCode: 200
+            )
+        )
+        defer { MockURLProtocol.unstub(url: showURL) }
+
+        try await loadBackend(backend)
+        #expect(!backend.isThinkingModel)
+
+        let chunks: [Data] = [
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":"ok"},"done":false}"#),
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":""},"done":true}"#),
+        ]
+        MockURLProtocol.stub(url: chatURL, response: .sse(chunks: chunks, statusCode: 200))
+        defer { MockURLProtocol.unstub(url: chatURL) }
+
+        var config = GenerationConfig()
+        config.maxOutputTokens = 100
+        config.maxThinkingTokens = nil
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: config)
+        for try await _ in stream.events { }
+
+        let captured = MockURLProtocol.capturedRequests.last(where: { $0.url == chatURL })
+        let body = try extractBody(from: captured)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let options = try #require(json["options"] as? [String: Any])
+        // visibleBudget only — no 2048 thinking reserve on non-thinking models.
+        #expect((options["num_predict"] as? Int) == 100)
+        #expect(json["think"] == nil)
+    }
+
+    /// Template-scan fallback: older Ollama builds omit `capabilities` but
+    /// ship a Jinja `template` containing `<think>` on reasoning models.
+    @Test func loadModel_detectsThinkingModel_fromTemplateMarkers() async throws {
+        let (backend, _, showURL) = makeConfiguredBackendWithShow()
+
+        let body = try JSONSerialization.data(withJSONObject: [
+            "template": "{{ .System }}\n{{ .Prompt }}\n<think>\n{{ .Response }}\n</think>"
+        ])
+        MockURLProtocol.stub(
+            url: showURL,
+            response: .immediate(data: body, statusCode: 200)
+        )
+        defer { MockURLProtocol.unstub(url: showURL) }
+
+        try await loadBackend(backend)
+        #expect(backend.isThinkingModel)
+    }
+
+    /// `maxThinkingTokens == 0` on a thinking model must send `"think": false`
+    /// and collapse `num_predict` to just the visible budget.
+    @Test func maxThinkingTokens_zero_sendsThinkFalse_onThinkingModel() async throws {
+        let (backend, chatURL, showURL) = makeConfiguredBackendWithShow()
+
+        MockURLProtocol.stub(
+            url: showURL,
+            response: .immediate(
+                data: apiShowBody(capabilities: ["thinking"]),
+                statusCode: 200
+            )
+        )
+        defer { MockURLProtocol.unstub(url: showURL) }
+
+        try await loadBackend(backend)
+
+        let chunks: [Data] = [
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":"ok"},"done":false}"#),
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":""},"done":true}"#),
+        ]
+        MockURLProtocol.stub(url: chatURL, response: .sse(chunks: chunks, statusCode: 200))
+        defer { MockURLProtocol.unstub(url: chatURL) }
+
+        var config = GenerationConfig()
+        config.maxOutputTokens = 100
+        config.maxThinkingTokens = 0
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: config)
+        for try await _ in stream.events { }
+
+        let captured = MockURLProtocol.capturedRequests.last(where: { $0.url == chatURL })
+        let body = try extractBody(from: captured)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let options = try #require(json["options"] as? [String: Any])
+        #expect((options["num_predict"] as? Int) == 100)
+        #expect((json["think"] as? Bool) == false)
+    }
+
+    /// `maxThinkingTokens == 0` on a non-thinking model must NOT send a
+    /// `think` key (Ollama's absent-default behaviour already matches intent,
+    /// and we keep the request body clean). `num_predict` collapses to
+    /// visible-only.
+    @Test func maxThinkingTokens_zero_omitsThink_onNonThinkingModel() async throws {
+        let (backend, chatURL, showURL) = makeConfiguredBackendWithShow()
+
+        MockURLProtocol.stub(
+            url: showURL,
+            response: .immediate(
+                data: apiShowBody(capabilities: ["completion"]),
+                statusCode: 200
+            )
+        )
+        defer { MockURLProtocol.unstub(url: showURL) }
+
+        try await loadBackend(backend)
+        #expect(!backend.isThinkingModel)
+
+        let chunks: [Data] = [
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":"ok"},"done":false}"#),
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":""},"done":true}"#),
+        ]
+        MockURLProtocol.stub(url: chatURL, response: .sse(chunks: chunks, statusCode: 200))
+        defer { MockURLProtocol.unstub(url: chatURL) }
+
+        var config = GenerationConfig()
+        config.maxOutputTokens = 100
+        config.maxThinkingTokens = 0
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: config)
+        for try await _ in stream.events { }
+
+        let captured = MockURLProtocol.capturedRequests.last(where: { $0.url == chatURL })
+        let body = try extractBody(from: captured)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let options = try #require(json["options"] as? [String: Any])
+        #expect((options["num_predict"] as? Int) == 100)
+        #expect(json["think"] == nil)
+    }
+
+    /// `maxThinkingTokens == N > 0` reserves exactly `N` thinking tokens on
+    /// top of the visible budget, regardless of whether the loaded model is
+    /// flagged as thinking-capable. No `think` directive is sent — we let
+    /// Ollama decide per model.
+    @Test func maxThinkingTokens_explicitN_reservesN_regardlessOfModel() async throws {
+        for thinkingCaps in [["thinking"], ["completion"]] {
+            let (backend, chatURL, showURL) = makeConfiguredBackendWithShow()
+
+            MockURLProtocol.stub(
+                url: showURL,
+                response: .immediate(
+                    data: apiShowBody(capabilities: thinkingCaps),
+                    statusCode: 200
+                )
+            )
+            defer { MockURLProtocol.unstub(url: showURL) }
+
+            try await loadBackend(backend)
+
+            let chunks: [Data] = [
+                ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":"ok"},"done":false}"#),
+                ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":""},"done":true}"#),
+            ]
+            MockURLProtocol.stub(url: chatURL, response: .sse(chunks: chunks, statusCode: 200))
+            defer { MockURLProtocol.unstub(url: chatURL) }
+
+            var config = GenerationConfig()
+            config.maxOutputTokens = 100
+            config.maxThinkingTokens = 50
+            let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: config)
+            for try await _ in stream.events { }
+
+            let captured = MockURLProtocol.capturedRequests.last(where: { $0.url == chatURL })
+            let body = try extractBody(from: captured)
+            let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let options = try #require(json["options"] as? [String: Any])
+            #expect((options["num_predict"] as? Int) == 150, "thinkingCaps=\(thinkingCaps)")
+            #expect(json["think"] == nil, "thinkingCaps=\(thinkingCaps)")
+        }
+    }
+
+    /// `/api/show` returning HTTP 404 (older Ollama without the endpoint)
+    /// must not throw — loadModel succeeds with `isThinkingModel = false`.
+    @Test func loadModel_apiShowFailure_defaultsToNonThinking_andDoesNotThrow() async throws {
+        let (backend, chatURL, showURL) = makeConfiguredBackendWithShow()
+
+        MockURLProtocol.stub(
+            url: showURL,
+            response: .immediate(data: Data("not found".utf8), statusCode: 404)
+        )
+        defer { MockURLProtocol.unstub(url: showURL) }
+
+        try await loadBackend(backend)
+        #expect(backend.isModelLoaded)
+        #expect(!backend.isThinkingModel)
+
+        let chunks: [Data] = [
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":"ok"},"done":false}"#),
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":""},"done":true}"#),
+        ]
+        MockURLProtocol.stub(url: chatURL, response: .sse(chunks: chunks, statusCode: 200))
+        defer { MockURLProtocol.unstub(url: chatURL) }
+
+        var config = GenerationConfig()
+        config.maxOutputTokens = 100
+        config.maxThinkingTokens = nil
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: config)
+        for try await _ in stream.events { }
+
+        let captured = MockURLProtocol.capturedRequests.last(where: { $0.url == chatURL })
+        let body = try extractBody(from: captured)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let options = try #require(json["options"] as? [String: Any])
+        #expect((options["num_predict"] as? Int) == 100)
     }
 
     /// Visible output must be re-capped client-side because the server-side

--- a/Tests/BaseChatE2ETests/OllamaE2ETests.swift
+++ b/Tests/BaseChatE2ETests/OllamaE2ETests.swift
@@ -250,17 +250,7 @@ final class OllamaE2ETests: XCTestCase {
 
     /// Test B — `maxThinkingTokens=0` must suppress reasoning while still
     /// producing visible output.
-    ///
-    // FIXME(P4): This test will fail until OllamaBackend sends `think: false`
-    // when maxThinkingTokens == 0. The `BCK_P4_READY` env gate effectively
-    // skips this test until the P4 wiring lands; removing the gate is the
-    // one-line follow-up that activates the assertion.
     func testThinkingModel_maxThinkingTokensZero_suppressesReasoning() async throws {
-        try XCTSkipIf(
-            ProcessInfo.processInfo.environment["BCK_P4_READY"] == nil,
-            "BCK_P4_READY not set — OllamaBackend does not yet forward `think: false` to Ollama; remove this guard once P4 lands"
-        )
-
         // Probe first with a fresh stream — classify the selected model.
         let isThinkingModel = try await probeModelEmitsThinking()
         try XCTSkipIf(

--- a/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
+++ b/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
@@ -82,6 +82,12 @@ final class SilentCatchAuditTest: XCTestCase {
         "BaseChatBackends/ClaudeBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {",
         "BaseChatBackends/OllamaBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {",
         "BaseChatBackends/OllamaBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],",
+        // /api/show thinking-detection probe: best-effort optimization that skips
+        // the 2048-token reserve on non-thinking models. Failures are logged at
+        // info level and fall through to `isThinkingModel = false`, which is the
+        // same safe default we'd pick if the endpoint didn't exist (older Ollama).
+        "BaseChatBackends/OllamaBackend.swift:self.isThinkingModel = (try? await detectThinkingCapability()) ?? false",
+        "BaseChatBackends/OllamaBackend.swift:guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {",
         "BaseChatBackends/OpenAIBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],",
         "BaseChatBackends/SSECloudBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],",
         // MLXBackend.validateArchitecture: best-effort read of the MLX model's


### PR DESCRIPTION
## Summary

The final P4 Ollama piece of BaseChatKit's thinking-model work. Three coordinated changes:

1. **`/api/show` thinking detection at loadModel time.** `OllamaBackend.loadModel` now posts `{\"model\": <name>}` to `/api/show` once and caches `isThinkingModel` for the backend's lifetime. Detection prefers the structured `capabilities: [\"thinking\", ...]` array (modern Ollama) and falls back to scanning the Jinja `template` field for `<think>`, `</think>`, or `{{ if .Thinking }}` markers. Failures (network error, HTTP 404, non-JSON) are non-fatal — we log a single `Log.network.info` warning and default to `isThinkingModel = false`.
2. **`maxThinkingTokens` wire-level semantics in `chat(...)`.** The budget block now branches on the three-state `maxThinkingTokens`, and on `0` against a thinking-capable model we attach `\"think\": false` to the request body so Ollama actually skips the reasoning phase. `num_predict` is collapsed to just the visible budget when thinking is disabled.
3. **Public doc rewrite.** `GenerationConfig.maxThinkingTokens` now documents the three-state contract (`nil` / `0` / `N > 0`) explicitly, including which backends honour which states.

The gated E2E test `testThinkingModel_maxThinkingTokensZero_suppressesReasoning` (PR #593) is unlocked by this change — both the `BCK_P4_READY` env guard and the `FIXME(P4)` comment are removed.

## Root cause / motivation

Pre-P4, `OllamaBackend` over-provisioned 2048 thinking tokens on every request regardless of model, and `maxThinkingTokens = 0` did nothing meaningful — Ollama supports `\"think\": false` to suppress reasoning on thinking models, but nothing in BaseChatKit wired it. Non-thinking models were losing ~half their `num_predict` budget to thinking that never happened.

## Semantic change table (new wire behaviour)

| `maxThinkingTokens` | Thinking model | Non-thinking model |
|---------------------|----------------|--------------------|
| `nil` | `num_predict = visible + 2048`, no `think` key | `num_predict = visible`, no `think` key |
| `0` | `num_predict = visible`, `\"think\": false` | `num_predict = visible`, no `think` key |
| `N > 0` | `num_predict = visible + N`, no `think` key | `num_predict = visible + N`, no `think` key |

Thinking-model detection is driven entirely by the `/api/show` probe; failures degrade to \"non-thinking\" with a single info-level log.

## Test plan

New unit tests in `OllamaBackendTests.swift` (all seven with sabotage-verified failure paths):

- [x] `loadModel_detectsThinkingModel_fromCapabilities` — sabotage: `return false` in the capabilities branch → test fails on `isThinkingModel == true` and `num_predict == 2148`
- [x] `loadModel_detectsNonThinkingModel_skipsReservation` — sabotage: unconditional `thinkingBudget = 2048` on `nil` → fails with `num_predict == 2148 vs 100`
- [x] `loadModel_detectsThinkingModel_fromTemplateMarkers` — sabotage: replace marker list with a junk token → fails on `isThinkingModel == false`
- [x] `maxThinkingTokens_zero_sendsThinkFalse_onThinkingModel` — sabotage: `thinkDirective = nil` in the `0` case → fails on `json[\"think\"] == nil`
- [x] `maxThinkingTokens_zero_omitsThink_onNonThinkingModel` — sabotage: `thinkDirective = false` unconditionally → fails on `json[\"think\"] == false`
- [x] `maxThinkingTokens_explicitN_reservesN_regardlessOfModel` — sabotage: gate `N` on `isThinkingModel` → fails on non-thinking iteration with `num_predict == 100 vs 150`
- [x] `loadModel_apiShowFailure_defaultsToNonThinking_andDoesNotThrow` — sabotage: make 404 path `return true` → fails on `!isThinkingModel` and `num_predict == 2148 vs 100`

### Existing test updated

- `generate_numPredict_bothCapsNil_defaultsTo4096` renamed to `generate_numPredict_bothCapsNil_thinkingModel_defaultsTo4096` and now stubs a thinking-capable `/api/show` response. The old test assumed `nil` unconditionally reserved 2048 thinking tokens; post-P4 that only holds on thinking-capable models, so we explicitly opt into that via the `/api/show` stub. The 4096 assertion is preserved. A sibling test (`loadModel_detectsNonThinkingModel_skipsReservation`) covers the non-thinking `num_predict = visibleBudget` case so we still pin both branches.

### Pre-push CI suites

| Suite | Result |
|-------|--------|
| `BaseChatCoreTests` | passed (204 tests, 4 skipped) |
| `BaseChatInferenceTests` | passed (848 tests — one pre-existing flake in `DownloadManagerTests.test_diskSpaceCheck_exactlyAtLimit` that's sensitive to disk-space jitter; re-runs pass individually; unrelated) |
| `BaseChatInferenceSwiftTestingTests` | passed (69 tests) |
| `BaseChatUITests` | passed (453 tests) |
| `BaseChatBackendsTests` | passed (123 tests, including 7 new P4 cases + `OllamaBackend` suite at 51 tests total) |

### E2E proof against live Ollama

`OLLAMA_TEST_MODEL=gemma4:e4b swift test --filter OllamaE2ETests --disable-default-traits` — all 9 tests pass including the previously-gated `testThinkingModel_maxThinkingTokensZero_suppressesReasoning`. Total wall time 232 s.

## Release Note

**Ollama thinking-model detection and disable-thinking flag** — `OllamaBackend` now probes Ollama's `/api/show` endpoint at `loadModel` time and classifies the model as thinking-capable via its reported `capabilities` array or Jinja template markers. `GenerationConfig.maxThinkingTokens = 0` is now honoured on supporting models: BaseChatKit forwards `\"think\": false` to Ollama so reasoning-capable models (e.g. `gemma4`, `qwen3`) skip the reasoning phase and emit visible output directly. `nil` no longer reserves 2048 thinking tokens on non-thinking models — a breaking change callers can opt out of by passing an explicit `N` value.