### PR TITLE
fix: harden remote endpoint validation and trust policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ BaseChatKit provides a complete, production-ready chat UI with pluggable inferen
 - **Latest-wins model handoff** — racing model loads can't corrupt active state. If the user taps model A, then model B before A finishes, A is discarded and B wins deterministically.
 - **Memory admission and pressure handling** — `ModelLoadPlan` estimates resident + KV memory before a load commits and returns an `allow`/`warn`/`deny` verdict; `InferenceService.denyPolicy` decides whether to fail fast, warn and proceed, or hand off to a custom hook. The drop-in `ChatViewModel` stops generation and unloads the model on critical memory pressure.
 - **Mock backend for app-level testing** — `MockInferenceBackend` implements the full streaming contract so your app's tests can exercise BCK without loading a real model.
-- **Certificate pinning with fail-closed defaults** — `api.openai.com` and `api.anthropic.com` fail closed if pin sets are missing or empty, while custom hosts use platform trust unless you configure pins.
+- **Certificate pinning with fail-closed defaults** — `api.openai.com` and `api.anthropic.com` fail closed if pin sets are missing or empty; custom hosts use platform trust by default or can be hardened to fail-closed via `BaseChatConfiguration.shared.customHostTrustPolicy = .requireExplicitPins`.
 
 For the exact source-backed contract, see [docs/RELIABILITY.md](docs/RELIABILITY.md).
 See [docs/SCOPE_DECISION.md](docs/SCOPE_DECISION.md) for the scoping rationale behind BCK 0.6.0.
@@ -340,7 +340,7 @@ See the [Security Model](Sources/BaseChatCore/BaseChatCore.docc/Articles/Securit
 
 - API keys stored in Keychain with `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`
 - Keys read just-in-time from Keychain, never held as stored properties
-- Certificate pinning support via `PinnedSessionDelegate` — configure `pinnedHosts` with SPKI SHA-256 hashes; `api.openai.com` and `api.anthropic.com` fail closed if pin sets are missing/empty, while localhost and custom hosts retain existing bypass/default-trust behavior
+- Certificate pinning support via `PinnedSessionDelegate` — configure `pinnedHosts` with SPKI SHA-256 hashes; `api.openai.com` and `api.anthropic.com` fail closed if pin sets are missing/empty; custom hosts use platform trust by default or can be set to fail-closed via `BaseChatConfiguration.shared.customHostTrustPolicy = .requireExplicitPins`
 - HTTPS enforced for non-localhost endpoints
 - User content sanitised in prompt templates to prevent injection
 - Sensitive data uses `privacy: .private` in os.Logger calls

--- a/Sources/BaseChatBackends/DNSRebindingGuard.swift
+++ b/Sources/BaseChatBackends/DNSRebindingGuard.swift
@@ -1,0 +1,127 @@
+import Darwin
+import Foundation
+import BaseChatInference
+
+/// Request-layer mitigation for DNS rebinding attacks on remote endpoints.
+///
+/// `APIEndpoint.validate()` intentionally skips DNS resolution (it is called
+/// synchronously from SwiftUI forms and must stay fast). This guard fills that
+/// gap by resolving the hostname immediately before each outbound connection and
+/// rejecting any address in a private, link-local, or reserved range.
+///
+/// ## Threat model
+/// An attacker registers `evil.example.com` and configures it as a custom
+/// endpoint. Initially the domain resolves to a public IP that passes structural
+/// validation. After the user has saved the endpoint, the attacker points the DNS
+/// record at `169.254.169.254` (cloud IMDS) or `192.168.x.x` (LAN). On the next
+/// API call, without this guard, the request would silently reach the internal
+/// host. With this guard the connection is rejected before any bytes are sent.
+///
+/// ## Scope
+/// Applied to every outbound connection made by:
+/// - ``SSECloudBackend/generate(prompt:systemPrompt:config:)`` (OpenAI, Claude,
+///   Ollama, and custom backends)
+/// - ``OllamaModelListService/fetchModels(from:)`` (model-list fetches)
+/// - ``OllamaBackend/loadModel(from:plan:)`` (pre-flight thinking-capability probe)
+///
+/// Localhost URLs (`localhost`, `127.0.0.1`, `::1`) always bypass the guard —
+/// these are explicitly configured local servers, not DNS-resolved targets.
+public enum DNSRebindingGuard {
+
+    // MARK: - Testing seam
+
+    /// Overrides the hostname resolver used by ``validate(url:)``.
+    ///
+    /// `nil` (the default) uses the real `getaddrinfo` resolver. Set this in
+    /// tests to inject deterministic address lists without touching the network.
+    ///
+    /// - Warning: For testing only. Write this before any concurrent access.
+    nonisolated(unsafe) static var _resolverForTesting: ((String) async -> [String])? = nil
+
+    // MARK: - Public API
+
+    /// Validates that `url`'s hostname does not resolve to a blocked IP address.
+    ///
+    /// - Localhost URLs always pass (explicitly configured local servers).
+    /// - IP-literal URLs are checked immediately against ``PrivateIPClassifier``
+    ///   without a network round-trip (defense-in-depth; `APIEndpoint.validate()`
+    ///   should have already caught these, but we verify in case validation was bypassed).
+    /// - DNS hostnames are resolved; each returned address is checked.
+    ///
+    /// Throws ``CloudBackendError/blockedAddress(_:)`` if any resolved address falls
+    /// in a private, link-local, or reserved range. The error is non-retryable.
+    public static func validate(url: URL) async throws {
+        // Localhost is always allowed — it is an explicitly configured local server.
+        if PrivateIPClassifier.isLocalhostURL(url) { return }
+
+        guard let host = url.host() else { return }
+
+        // IP literals are checked immediately without DNS resolution.
+        if let category = PrivateIPClassifier.classifyIPLiteral(host) {
+            throw CloudBackendError.blockedAddress(
+                "IP address \(host) is in a blocked range (\(category))"
+            )
+        }
+
+        // DNS hostname — resolve and check every returned address.
+        let addresses = await resolveHostname(host)
+        for address in addresses {
+            if let category = PrivateIPClassifier.classifyIPLiteral(address) {
+                Log.network.error(
+                    "DNSRebindingGuard: blocked connection to \(host, privacy: .public) — resolved to \(address, privacy: .public) (\(category.description, privacy: .public))"
+                )
+                throw CloudBackendError.blockedAddress(
+                    "Hostname \(host) resolved to \(address), which is a \(category)"
+                )
+            }
+        }
+    }
+
+    // MARK: - DNS Resolution
+
+    /// Resolves `hostname` to a list of IP address strings using the system resolver.
+    ///
+    /// Runs `getaddrinfo` on a utility-priority background task to avoid blocking
+    /// the cooperative thread pool during the resolver round-trip.
+    /// Returns an empty array on resolution failure (network error, NXDOMAIN, etc.)
+    /// so the guard fails open for unresolvable names — the subsequent URLSession
+    /// connection will produce the appropriate network error itself.
+    private static func resolveHostname(_ hostname: String) async -> [String] {
+        if let override = _resolverForTesting {
+            return await override(hostname)
+        }
+
+        return await Task.detached(priority: .utility) {
+            var hints = addrinfo()
+            hints.ai_family = AF_UNSPEC
+            hints.ai_socktype = SOCK_STREAM
+            hints.ai_flags = AI_ADDRCONFIG
+
+            var result: UnsafeMutablePointer<addrinfo>?
+            defer { freeaddrinfo(result) }
+
+            guard getaddrinfo(hostname, nil, &hints, &result) == 0,
+                  result != nil else {
+                return []
+            }
+
+            var addresses: [String] = []
+            var current = result
+            while let info = current {
+                var host = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+                if getnameinfo(
+                    info.pointee.ai_addr,
+                    info.pointee.ai_addrlen,
+                    &host,
+                    socklen_t(NI_MAXHOST),
+                    nil, 0,
+                    NI_NUMERICHOST
+                ) == 0 {
+                    addresses.append(String(cString: host))
+                }
+                current = info.pointee.ai_next
+            }
+            return addresses
+        }.value
+    }
+}

--- a/Sources/BaseChatBackends/OllamaBackend.swift
+++ b/Sources/BaseChatBackends/OllamaBackend.swift
@@ -95,11 +95,15 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
 
     // Plan is informational for cloud backends.
     public override func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
-        guard baseURL != nil else {
+        guard let configuredBaseURL = baseURL else {
             throw CloudBackendError.invalidURL(
                 "No base URL configured. Call configure(baseURL:modelName:) first."
             )
         }
+
+        // Validate the configured host against DNS rebinding / SSRF before
+        // any network I/O fires — must run before /api/show probe below.
+        try await DNSRebindingGuard.validate(url: configuredBaseURL)
 
         // Ollama v0.18.0+ routes any model tag ending in `:cloud` to remote
         // inference (Ollama's hosted service) rather than the local server.

--- a/Sources/BaseChatBackends/OllamaModelListService.swift
+++ b/Sources/BaseChatBackends/OllamaModelListService.swift
@@ -60,6 +60,8 @@ public final class OllamaModelListService: Sendable {
     /// - Returns: An array of available models, sorted alphabetically by name.
     /// - Throws: ``CloudBackendError`` on HTTP or network failure.
     public func fetchModels(from baseURL: URL) async throws -> [RemoteModelInfo] {
+        try await DNSRebindingGuard.validate(url: baseURL)
+
         let tagsURL = baseURL.appendingPathComponent("api/tags")
         var request = URLRequest(url: tagsURL)
         request.httpMethod = "GET"

--- a/Sources/BaseChatBackends/PinnedSessionDelegate.swift
+++ b/Sources/BaseChatBackends/PinnedSessionDelegate.swift
@@ -6,7 +6,10 @@ import BaseChatInference
 ///
 /// Validates the server's leaf certificate SPKI (Subject Public Key Info) SHA-256
 /// hash against a set of known pins for Anthropic and OpenAI APIs. Connections to
-/// unknown hosts (custom endpoints) fall through to default trust evaluation.
+/// unknown hosts (custom endpoints) are governed by
+/// ``BaseChatConfiguration/customHostTrustPolicy``: the default
+/// (``.platformDefault``) falls through to OS trust evaluation; ``.requireExplicitPins``
+/// rejects any host without configured pins (fail-closed).
 /// Localhost hosts always bypass pinning.
 ///
 /// Pin rotation: when a provider rotates certificates, update the pin sets below.
@@ -143,10 +146,16 @@ final class PinnedSessionDelegate: NSObject, @preconcurrency URLSessionDelegate 
             }
         }
 
-        // If no pins are configured for a custom host, fall back to default trust.
+        // If no pins are configured for a custom host, apply the configured trust policy.
         guard let expectedPins = pins, !expectedPins.isEmpty else {
-            Log.network.warning("PinnedSessionDelegate: no pins configured for custom host \(host, privacy: .public). Falling back to default trust evaluation.")
-            completionHandler(.performDefaultHandling, nil)
+            switch BaseChatConfiguration.shared.customHostTrustPolicy {
+            case .platformDefault:
+                Log.network.warning("PinnedSessionDelegate: no pins configured for custom host \(host, privacy: .public). Falling back to default trust evaluation.")
+                completionHandler(.performDefaultHandling, nil)
+            case .requireExplicitPins:
+                Log.network.error("PinnedSessionDelegate: no certificate pins configured for custom host \(host, privacy: .public) and requireExplicitPins policy is active. Cancelling authentication challenge (fail-closed).")
+                completionHandler(.cancelAuthenticationChallenge, nil)
+            }
             return
         }
         

--- a/Sources/BaseChatBackends/SSECloudBackend.swift
+++ b/Sources/BaseChatBackends/SSECloudBackend.swift
@@ -309,6 +309,7 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
         let capturedStrategy = retryStrategy
         let session = self.urlSession
         let capturedTimeout = streamIdleTimeout
+        let capturedBaseURL = baseURL
 
         // The Task needs to set phases on the GenerationStream, but GenerationStream
         // wraps the stream (chicken-and-egg). Use a WeakBox that the Task captures;
@@ -334,6 +335,13 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
                 }
 
                 do {
+                    // DNS rebinding guard: verify the endpoint's hostname does not
+                    // resolve to a private/reserved address before connecting.
+                    // Runs outside the retry block — a blocked address is not retryable.
+                    if let url = capturedBaseURL {
+                        try await DNSRebindingGuard.validate(url: url)
+                    }
+
                     // Retry wraps only the HTTP connection phase — not SSE parsing.
                     // Mid-stream failures propagate immediately, preserving
                     // already-yielded tokens.

--- a/Sources/BaseChatCore/BaseChatSchemaV3.swift
+++ b/Sources/BaseChatCore/BaseChatSchemaV3.swift
@@ -330,12 +330,11 @@ public enum BaseChatSchemaV3: VersionedSchema {
 
         /// Checks if the URL points to a local server.
         ///
-        /// Only the explicit loopback literals are matched — broader `127.x.x.x`
-        /// and IPv4-mapped IPv6 loopback (`::ffff:127.0.0.1`) are intentionally
-        /// excluded because they are easy SSRF bypass vectors.
+        /// Delegates to ``PrivateIPClassifier/isLocalhostURL(_:)``. Only the three
+        /// explicit loopback literals (`localhost`, `127.0.0.1`, `::1`) match —
+        /// broader `127.x.x.x` and IPv4-mapped IPv6 loopback are excluded.
         static func isLocalhost(_ url: URL) -> Bool {
-            guard let host = url.host()?.lowercased() else { return false }
-            return host == "localhost" || host == "127.0.0.1" || host == "::1"
+            PrivateIPClassifier.isLocalhostURL(url)
         }
 
         /// Classifies a URL's host as pointing at a private, link-local, or
@@ -344,161 +343,28 @@ public enum BaseChatSchemaV3: VersionedSchema {
         ///
         /// Only IP literals are inspected. DNS names are not resolved — validation
         /// is called synchronously from SwiftUI settings forms and must stay fast.
-        /// DNS rebinding is therefore out of scope for this layer and should be
-        /// mitigated at the request layer (e.g. by pinning resolution or by
-        /// rejecting private IPs returned by `URLSession` host resolution) if a
-        /// deployment needs that guarantee.
+        /// DNS rebinding is mitigated at the request layer by
+        /// `BaseChatBackends.DNSRebindingGuard`, which resolves hostnames and
+        /// rejects connections to private/reserved addresses at connect time.
         ///
-        /// Blocked IPv4 ranges:
-        /// - `0.0.0.0/8` (non-routable "this host") → `.multicastReserved`
-        /// - `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` (RFC1918) → `.privateHost`
-        /// - `127.0.0.0/8` except `127.0.0.1` (alternate loopback encodings) → `.multicastReserved`
-        /// - `169.254.0.0/16` (link-local incl. AWS/GCP/Azure metadata at `169.254.169.254`) → `.linkLocalHost`
-        /// - `224.0.0.0/4` (multicast), `240.0.0.0/4` (reserved / future use) → `.multicastReserved`
-        ///
-        /// Blocked IPv6 ranges:
-        /// - `fc00::/7` (unique local addresses) → `.ipv6UniqueLocal`
-        /// - `fe80::/10` (link-local) → `.linkLocalHost`
-        /// - `::ffff:0:0/96` (IPv4-mapped; would otherwise bypass the IPv4 filter) → `.ipv4MappedLoopback`
+        /// Classification logic is shared with ``PrivateIPClassifier`` to ensure a
+        /// single source of truth for blocked IP ranges across both validation layers.
         static func classifyDisallowedPrivateHost(_ url: URL) -> APIEndpointValidationReason? {
             guard let rawHost = url.host()?.lowercased() else { return nil }
-
-            // FQDN form with a trailing dot (e.g. `192.168.1.1.`) resolves
-            // identically to the dotless form on every mainstream resolver, so
-            // treat it as equivalent for IP-literal classification. Without
-            // this, `https://192.168.1.1.` would bypass the private-range
-            // gate and reach a LAN host under HTTPS.
             let host = rawHost.hasSuffix(".") ? String(rawHost.dropLast()) : rawHost
 
-            if let octets = parseIPv4Literal(host) {
-                return classifyIPv4(octets)
+            guard let category = PrivateIPClassifier.classifyIPLiteral(host) else {
+                // DNS names pass through — request-layer guard handles them.
+                return nil
             }
 
-            if let words = parseIPv6Literal(host) {
-                return classifyIPv6(words)
+            switch category {
+            case .privateHost:        return .privateHost
+            case .linkLocalHost:      return .linkLocalHost
+            case .ipv6UniqueLocal:    return .ipv6UniqueLocal
+            case .ipv4MappedLoopback: return .ipv4MappedLoopback
+            case .multicastReserved:  return .multicastReserved
             }
-
-            // DNS names reach here. Do not resolve synchronously — return nil
-            // and rely on the HTTPS-required rule plus any higher-layer mitigation.
-            return nil
-        }
-
-        // MARK: IPv4
-
-        /// Parses a dotted-quad IPv4 literal into four octets.
-        ///
-        /// Returns `nil` for anything that isn't exactly four 0-255 components
-        /// (including shorthand forms like `127.1`, which `inet_aton` would accept
-        /// but modern URL parsers reject).
-        private static func parseIPv4Literal(_ host: String) -> [UInt8]? {
-            let parts = host.split(separator: ".", omittingEmptySubsequences: false)
-            guard parts.count == 4 else { return nil }
-            var octets: [UInt8] = []
-            octets.reserveCapacity(4)
-            for part in parts {
-                guard !part.isEmpty, part.allSatisfy(\.isASCII),
-                      let value = UInt16(part), value <= 255 else {
-                    return nil
-                }
-                octets.append(UInt8(value))
-            }
-            return octets
-        }
-
-        private static func classifyIPv4(_ octets: [UInt8]) -> APIEndpointValidationReason? {
-            let a = octets[0]
-            let b = octets[1]
-
-            // 10.0.0.0/8 — RFC1918
-            if a == 10 { return .privateHost }
-            // 172.16.0.0/12 — RFC1918
-            if a == 172 && (16...31).contains(b) { return .privateHost }
-            // 192.168.0.0/16 — RFC1918
-            if a == 192 && b == 168 { return .privateHost }
-            // 169.254.0.0/16 — link-local (AWS/GCP/Azure IMDS sits here)
-            if a == 169 && b == 254 { return .linkLocalHost }
-            // 0.0.0.0/8 — "this host" / any-address
-            if a == 0 { return .multicastReserved }
-            // 127.0.0.0/8 — loopback; the exact 127.0.0.1 is approved by
-            // isLocalhost before this helper is called, so any 127.x.x.x
-            // reaching here is an alternate loopback encoding.
-            if a == 127 { return .multicastReserved }
-            // 224.0.0.0/4 — multicast
-            if (224...239).contains(a) { return .multicastReserved }
-            // 240.0.0.0/4 — reserved / future use (includes 255.255.255.255 broadcast)
-            if a >= 240 { return .multicastReserved }
-
-            return nil
-        }
-
-        // MARK: IPv6
-
-        /// Parses an IPv6 literal (as returned by `URL.host()` — without the
-        /// surrounding brackets) into eight 16-bit words.
-        ///
-        /// Supports `::` zero-run compression and embedded IPv4 suffixes
-        /// (e.g. `::ffff:127.0.0.1`). Zone identifiers (`fe80::1%en0`) are
-        /// stripped before parsing.
-        private static func parseIPv6Literal(_ host: String) -> [UInt16]? {
-            // Strip IPv6 zone identifier if present.
-            let bare = host.split(separator: "%", maxSplits: 1).first.map(String.init) ?? host
-            guard bare.contains(":") else { return nil }
-
-            // Split on "::" which represents a run of zero words.
-            let doubleColonParts = bare.components(separatedBy: "::")
-            guard doubleColonParts.count <= 2 else { return nil }
-
-            func expand(_ segment: String) -> [UInt16]? {
-                if segment.isEmpty { return [] }
-                let groups = segment.split(separator: ":", omittingEmptySubsequences: false)
-                var words: [UInt16] = []
-                for (i, group) in groups.enumerated() {
-                    if group.contains(".") {
-                        // Embedded IPv4 — only legal as the last group.
-                        guard i == groups.count - 1,
-                              let v4 = parseIPv4Literal(String(group)) else { return nil }
-                        let high = (UInt16(v4[0]) << 8) | UInt16(v4[1])
-                        let low = (UInt16(v4[2]) << 8) | UInt16(v4[3])
-                        words.append(high)
-                        words.append(low)
-                    } else {
-                        guard !group.isEmpty, group.count <= 4,
-                              let value = UInt16(group, radix: 16) else { return nil }
-                        words.append(value)
-                    }
-                }
-                return words
-            }
-
-            let head = expand(doubleColonParts[0])
-            let tail = doubleColonParts.count == 2 ? expand(doubleColonParts[1]) : []
-            guard let headWords = head, let tailWords = tail else { return nil }
-
-            let total = headWords.count + tailWords.count
-            if doubleColonParts.count == 2 {
-                guard total <= 8 else { return nil }
-                let zeros = Array(repeating: UInt16(0), count: 8 - total)
-                return headWords + zeros + tailWords
-            } else {
-                guard total == 8 else { return nil }
-                return headWords
-            }
-        }
-
-        private static func classifyIPv6(_ words: [UInt16]) -> APIEndpointValidationReason? {
-            guard words.count == 8 else { return nil }
-
-            // fc00::/7 — unique local addresses (first 7 bits are 1111110).
-            if (words[0] & 0xfe00) == 0xfc00 { return .ipv6UniqueLocal }
-            // fe80::/10 — link-local (first 10 bits are 1111111010).
-            if (words[0] & 0xffc0) == 0xfe80 { return .linkLocalHost }
-            // ::ffff:0:0/96 — IPv4-mapped IPv6. Reject so mapped loopback /
-            // mapped RFC1918 can't bypass the IPv4 filter.
-            let isIPv4Mapped = words[0] == 0 && words[1] == 0 && words[2] == 0
-                && words[3] == 0 && words[4] == 0 && words[5] == 0xffff
-            if isIPv4Mapped { return .ipv4MappedLoopback }
-
-            return nil
         }
     }
 

--- a/Sources/BaseChatCore/InferenceService+APIEndpoint.swift
+++ b/Sources/BaseChatCore/InferenceService+APIEndpoint.swift
@@ -31,10 +31,13 @@ extension InferenceService {
 
     /// Loads a cloud API backend from a SwiftData `APIEndpoint`.
     ///
-    /// Convenience overload that converts the model to an `APIEndpointRecord`
-    /// before delegating to the storage-agnostic core API.
+    /// Convenience overload that validates the endpoint URL using the canonical
+    /// ``APIEndpoint/validate()`` check — blocking private/link-local SSRF targets,
+    /// insecure schemes, and malformed URLs — before converting to an
+    /// `APIEndpointRecord` and delegating to the storage-agnostic core API.
     @MainActor
     public func loadCloudBackend(from endpoint: APIEndpoint) async throws {
+        try endpoint.validate().get()
         try await loadCloudBackend(from: endpoint.record)
     }
 }

--- a/Sources/BaseChatInference/BaseChatConfiguration.swift
+++ b/Sources/BaseChatInference/BaseChatConfiguration.swift
@@ -74,6 +74,20 @@ public struct BaseChatConfiguration: Sendable {
     /// namespace independently and don't want their fixtures reaped.
     public var keychainReaperEnabled: Bool
 
+    /// Controls how ``PinnedSessionDelegate`` treats custom hosts that have no
+    /// pins configured in ``PinnedSessionDelegate/pinnedHosts``.
+    ///
+    /// - ``CustomHostTrustPolicy/platformDefault`` *(default)*: unknown hosts
+    ///   fall back to the OS trust evaluation, matching pre-existing behaviour.
+    /// - ``CustomHostTrustPolicy/requireExplicitPins``: connections to any
+    ///   non-localhost host without configured pins are **rejected** (fail-closed).
+    ///   Use this in security-sensitive deployments where all remote hosts must
+    ///   be explicitly allowlisted via `PinnedSessionDelegate.pinnedHosts`.
+    ///
+    /// Known production hosts (`api.openai.com`, `api.anthropic.com`) always
+    /// fail-closed regardless of this setting.
+    public var customHostTrustPolicy: CustomHostTrustPolicy
+
     public init(
         appName: String = "BaseChatKit",
         bundleIdentifier: String = "com.basechatkit",
@@ -81,7 +95,8 @@ public struct BaseChatConfiguration: Sendable {
         features: Features = Features(),
         fileProtectionClass: FileProtectionType? = .completeUntilFirstUserAuthentication,
         sseStreamLimits: SSEStreamLimits = .default,
-        keychainReaperEnabled: Bool = true
+        keychainReaperEnabled: Bool = true,
+        customHostTrustPolicy: CustomHostTrustPolicy = .platformDefault
     ) {
         self.appName = appName
         self.bundleIdentifier = bundleIdentifier
@@ -90,6 +105,7 @@ public struct BaseChatConfiguration: Sendable {
         self.fileProtectionClass = fileProtectionClass
         self.sseStreamLimits = sseStreamLimits
         self.keychainReaperEnabled = keychainReaperEnabled
+        self.customHostTrustPolicy = customHostTrustPolicy
     }
 
     // MARK: - Derived identifiers
@@ -220,5 +236,39 @@ extension BaseChatConfiguration {
             self.showCloudAPIManagement = showCloudAPIManagement
             self.showUpgradeHint = showUpgradeHint
         }
+    }
+}
+
+// MARK: - CustomHostTrustPolicy
+
+extension BaseChatConfiguration {
+
+    /// Determines how ``PinnedSessionDelegate`` handles TLS challenges from
+    /// custom hosts that have no pins configured in
+    /// ``PinnedSessionDelegate/pinnedHosts``.
+    ///
+    /// This policy does **not** affect known production hosts
+    /// (`api.openai.com`, `api.anthropic.com`) — those always fail-closed
+    /// when their pin sets are absent or empty. Localhost addresses
+    /// (`localhost`, `127.0.0.1`, `::1`) always bypass pinning entirely.
+    public enum CustomHostTrustPolicy: Sendable {
+
+        /// Unknown custom hosts fall back to the OS platform trust evaluation
+        /// when no pins are configured for them.
+        ///
+        /// This is the default. It matches pre-existing BaseChatKit behaviour
+        /// and is appropriate for most deployments where custom endpoints are
+        /// trusted via standard CA-signed certificates.
+        case platformDefault
+
+        /// Connections to custom hosts that have no configured pins are
+        /// **rejected** (fail-closed).
+        ///
+        /// Use this in security-sensitive deployments where every remote host
+        /// must be explicitly allowlisted by adding SPKI hashes to
+        /// ``PinnedSessionDelegate/pinnedHosts`` before the first request.
+        /// Any host without configured pins will have its authentication
+        /// challenge cancelled.
+        case requireExplicitPins
     }
 }

--- a/Sources/BaseChatInference/Models/APIEndpointRecord+Validation.swift
+++ b/Sources/BaseChatInference/Models/APIEndpointRecord+Validation.swift
@@ -7,8 +7,8 @@ extension APIEndpointRecord {
     /// Mirrors the policy defined in `APIEndpoint.validate()` (BaseChatCore) so
     /// that the `BaseChatInference` module cannot be bypassed by constructing an
     /// `APIEndpointRecord` directly — e.g. through programmatic injection —
-    /// without going through the SwiftData wrapper. Both implementations **must
-    /// stay in sync** whenever validation rules change.
+    /// without going through the SwiftData wrapper. Both validators delegate to
+    /// ``PrivateIPClassifier`` so the blocked-range rules live in one place.
     ///
     /// For the specific per-reason error description surfaced in UI, use
     /// `APIEndpoint.validate()` and `APIEndpointValidationReason` (BaseChatCore).
@@ -19,7 +19,7 @@ extension APIEndpointRecord {
         guard !trimmed.isEmpty,
               let url = URL(string: trimmed),
               let scheme = url.scheme?.lowercased(),
-              url.host() != nil else {
+              let rawHost = url.host()?.lowercased() else {
             throw CloudBackendError.invalidURL(baseURL)
         }
 
@@ -28,7 +28,7 @@ extension APIEndpointRecord {
         }
 
         // Loopback dev servers (e.g. Ollama, LM Studio) are allowed over plain HTTP.
-        if Self.isLocalhost(url) { return }
+        if PrivateIPClassifier.isLocalhostURL(url) { return }
 
         // Non-loopback must use HTTPS.
         guard scheme == "https" else {
@@ -36,108 +36,10 @@ extension APIEndpointRecord {
         }
 
         // Block SSRF pivots into private/link-local/reserved ranges even over HTTPS.
-        if Self.isDisallowedPrivateHost(url) {
-            throw CloudBackendError.invalidURL(baseURL)
-        }
-    }
-
-    // MARK: - Internal helpers (package-private for tests)
-
-    static func isLocalhost(_ url: URL) -> Bool {
-        guard let host = url.host()?.lowercased() else { return false }
-        return host == "localhost" || host == "127.0.0.1" || host == "::1"
-    }
-
-    static func isDisallowedPrivateHost(_ url: URL) -> Bool {
-        guard let rawHost = url.host()?.lowercased() else { return false }
         // Trailing-dot FQDN form resolves identically to the dotless form.
         let host = rawHost.hasSuffix(".") ? String(rawHost.dropLast()) : rawHost
-
-        if let octets = parseIPv4Literal(host) {
-            return classifyIPv4(octets)
+        if PrivateIPClassifier.classifyIPLiteral(host) != nil {
+            throw CloudBackendError.invalidURL(baseURL)
         }
-        if let words = parseIPv6Literal(host) {
-            return classifyIPv6(words)
-        }
-        return false
-    }
-
-    // MARK: - IPv4
-
-    private static func parseIPv4Literal(_ host: String) -> [UInt8]? {
-        let parts = host.split(separator: ".", omittingEmptySubsequences: false)
-        guard parts.count == 4 else { return nil }
-        var octets: [UInt8] = []
-        octets.reserveCapacity(4)
-        for part in parts {
-            guard !part.isEmpty, part.allSatisfy(\.isASCII),
-                  let value = UInt16(part), value <= 255 else { return nil }
-            octets.append(UInt8(value))
-        }
-        return octets
-    }
-
-    private static func classifyIPv4(_ octets: [UInt8]) -> Bool {
-        let a = octets[0], b = octets[1]
-        if a == 10 { return true }                            // 10.0.0.0/8 RFC1918
-        if a == 172 && (16...31).contains(b) { return true } // 172.16.0.0/12 RFC1918
-        if a == 192 && b == 168 { return true }              // 192.168.0.0/16 RFC1918
-        if a == 169 && b == 254 { return true }              // 169.254.0.0/16 link-local / IMDS
-        if a == 0 { return true }                            // 0.0.0.0/8 any-address
-        if a == 127 { return true }                          // 127.x.x.x alternate loopback
-        if a >= 224 { return true }                          // 224–255 multicast + reserved
-        return false
-    }
-
-    // MARK: - IPv6
-
-    private static func parseIPv6Literal(_ host: String) -> [UInt16]? {
-        let bare = host.split(separator: "%", maxSplits: 1).first.map(String.init) ?? host
-        guard bare.contains(":") else { return nil }
-
-        let doubleColonParts = bare.components(separatedBy: "::")
-        guard doubleColonParts.count <= 2 else { return nil }
-
-        func expand(_ segment: String) -> [UInt16]? {
-            if segment.isEmpty { return [] }
-            let groups = segment.split(separator: ":", omittingEmptySubsequences: false)
-            var words: [UInt16] = []
-            for (i, group) in groups.enumerated() {
-                if group.contains(".") {
-                    guard i == groups.count - 1,
-                          let v4 = parseIPv4Literal(String(group)) else { return nil }
-                    words.append((UInt16(v4[0]) << 8) | UInt16(v4[1]))
-                    words.append((UInt16(v4[2]) << 8) | UInt16(v4[3]))
-                } else {
-                    guard !group.isEmpty, group.count <= 4,
-                          let value = UInt16(group, radix: 16) else { return nil }
-                    words.append(value)
-                }
-            }
-            return words
-        }
-
-        let head = expand(doubleColonParts[0])
-        let tail = doubleColonParts.count == 2 ? expand(doubleColonParts[1]) : []
-        guard let headWords = head, let tailWords = tail else { return nil }
-
-        let total = headWords.count + tailWords.count
-        if doubleColonParts.count == 2 {
-            guard total <= 8 else { return nil }
-            return headWords + Array(repeating: 0, count: 8 - total) + tailWords
-        } else {
-            guard total == 8 else { return nil }
-            return headWords
-        }
-    }
-
-    private static func classifyIPv6(_ words: [UInt16]) -> Bool {
-        guard words.count == 8 else { return false }
-        if (words[0] & 0xfe00) == 0xfc00 { return true }  // fc00::/7 unique local
-        if (words[0] & 0xffc0) == 0xfe80 { return true }  // fe80::/10 link-local
-        // ::ffff:0:0/96 IPv4-mapped — reject wholesale to prevent IPv4-filter bypass.
-        let isIPv4Mapped = words[0] == 0 && words[1] == 0 && words[2] == 0
-            && words[3] == 0 && words[4] == 0 && words[5] == 0xffff
-        return isIPv4Mapped
     }
 }

--- a/Sources/BaseChatInference/Models/APIEndpointRecord+Validation.swift
+++ b/Sources/BaseChatInference/Models/APIEndpointRecord+Validation.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+extension APIEndpointRecord {
+
+    /// Validates the `baseURL` for structural correctness and SSRF safety.
+    ///
+    /// Mirrors the policy defined in `APIEndpoint.validate()` (BaseChatCore) so
+    /// that the `BaseChatInference` module cannot be bypassed by constructing an
+    /// `APIEndpointRecord` directly — e.g. through programmatic injection —
+    /// without going through the SwiftData wrapper. Both implementations **must
+    /// stay in sync** whenever validation rules change.
+    ///
+    /// For the specific per-reason error description surfaced in UI, use
+    /// `APIEndpoint.validate()` and `APIEndpointValidationReason` (BaseChatCore).
+    /// This method throws `CloudBackendError.invalidURL` for any rejection so
+    /// callers that only need a pass/fail answer do not need to import BaseChatCore.
+    func validate() throws {
+        let trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let url = URL(string: trimmed),
+              let scheme = url.scheme?.lowercased(),
+              url.host() != nil else {
+            throw CloudBackendError.invalidURL(baseURL)
+        }
+
+        guard scheme == "http" || scheme == "https" else {
+            throw CloudBackendError.invalidURL(baseURL)
+        }
+
+        // Loopback dev servers (e.g. Ollama, LM Studio) are allowed over plain HTTP.
+        if Self.isLocalhost(url) { return }
+
+        // Non-loopback must use HTTPS.
+        guard scheme == "https" else {
+            throw CloudBackendError.invalidURL(baseURL)
+        }
+
+        // Block SSRF pivots into private/link-local/reserved ranges even over HTTPS.
+        if Self.isDisallowedPrivateHost(url) {
+            throw CloudBackendError.invalidURL(baseURL)
+        }
+    }
+
+    // MARK: - Internal helpers (package-private for tests)
+
+    static func isLocalhost(_ url: URL) -> Bool {
+        guard let host = url.host()?.lowercased() else { return false }
+        return host == "localhost" || host == "127.0.0.1" || host == "::1"
+    }
+
+    static func isDisallowedPrivateHost(_ url: URL) -> Bool {
+        guard let rawHost = url.host()?.lowercased() else { return false }
+        // Trailing-dot FQDN form resolves identically to the dotless form.
+        let host = rawHost.hasSuffix(".") ? String(rawHost.dropLast()) : rawHost
+
+        if let octets = parseIPv4Literal(host) {
+            return classifyIPv4(octets)
+        }
+        if let words = parseIPv6Literal(host) {
+            return classifyIPv6(words)
+        }
+        return false
+    }
+
+    // MARK: - IPv4
+
+    private static func parseIPv4Literal(_ host: String) -> [UInt8]? {
+        let parts = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 4 else { return nil }
+        var octets: [UInt8] = []
+        octets.reserveCapacity(4)
+        for part in parts {
+            guard !part.isEmpty, part.allSatisfy(\.isASCII),
+                  let value = UInt16(part), value <= 255 else { return nil }
+            octets.append(UInt8(value))
+        }
+        return octets
+    }
+
+    private static func classifyIPv4(_ octets: [UInt8]) -> Bool {
+        let a = octets[0], b = octets[1]
+        if a == 10 { return true }                            // 10.0.0.0/8 RFC1918
+        if a == 172 && (16...31).contains(b) { return true } // 172.16.0.0/12 RFC1918
+        if a == 192 && b == 168 { return true }              // 192.168.0.0/16 RFC1918
+        if a == 169 && b == 254 { return true }              // 169.254.0.0/16 link-local / IMDS
+        if a == 0 { return true }                            // 0.0.0.0/8 any-address
+        if a == 127 { return true }                          // 127.x.x.x alternate loopback
+        if a >= 224 { return true }                          // 224–255 multicast + reserved
+        return false
+    }
+
+    // MARK: - IPv6
+
+    private static func parseIPv6Literal(_ host: String) -> [UInt16]? {
+        let bare = host.split(separator: "%", maxSplits: 1).first.map(String.init) ?? host
+        guard bare.contains(":") else { return nil }
+
+        let doubleColonParts = bare.components(separatedBy: "::")
+        guard doubleColonParts.count <= 2 else { return nil }
+
+        func expand(_ segment: String) -> [UInt16]? {
+            if segment.isEmpty { return [] }
+            let groups = segment.split(separator: ":", omittingEmptySubsequences: false)
+            var words: [UInt16] = []
+            for (i, group) in groups.enumerated() {
+                if group.contains(".") {
+                    guard i == groups.count - 1,
+                          let v4 = parseIPv4Literal(String(group)) else { return nil }
+                    words.append((UInt16(v4[0]) << 8) | UInt16(v4[1]))
+                    words.append((UInt16(v4[2]) << 8) | UInt16(v4[3]))
+                } else {
+                    guard !group.isEmpty, group.count <= 4,
+                          let value = UInt16(group, radix: 16) else { return nil }
+                    words.append(value)
+                }
+            }
+            return words
+        }
+
+        let head = expand(doubleColonParts[0])
+        let tail = doubleColonParts.count == 2 ? expand(doubleColonParts[1]) : []
+        guard let headWords = head, let tailWords = tail else { return nil }
+
+        let total = headWords.count + tailWords.count
+        if doubleColonParts.count == 2 {
+            guard total <= 8 else { return nil }
+            return headWords + Array(repeating: 0, count: 8 - total) + tailWords
+        } else {
+            guard total == 8 else { return nil }
+            return headWords
+        }
+    }
+
+    private static func classifyIPv6(_ words: [UInt16]) -> Bool {
+        guard words.count == 8 else { return false }
+        if (words[0] & 0xfe00) == 0xfc00 { return true }  // fc00::/7 unique local
+        if (words[0] & 0xffc0) == 0xfe80 { return true }  // fe80::/10 link-local
+        // ::ffff:0:0/96 IPv4-mapped — reject wholesale to prevent IPv4-filter bypass.
+        let isIPv4Mapped = words[0] == 0 && words[1] == 0 && words[2] == 0
+            && words[3] == 0 && words[4] == 0 && words[5] == 0xffff
+        return isIPv4Mapped
+    }
+}

--- a/Sources/BaseChatInference/Services/CloudBackendError.swift
+++ b/Sources/BaseChatInference/Services/CloudBackendError.swift
@@ -16,6 +16,10 @@ public enum CloudBackendError: LocalizedError {
     case backendDeallocated
     /// No events received within the idle timeout duration.
     case timeout(Duration)
+    /// The endpoint's hostname resolved to a private, link-local, or reserved
+    /// IP address at connect time, indicating a potential DNS rebinding attack.
+    /// The associated value describes which address triggered the block.
+    case blockedAddress(String)
 
     public var errorDescription: String? {
         switch self {
@@ -46,6 +50,8 @@ public enum CloudBackendError: LocalizedError {
                 return "No response received for \(totalMs)ms."
             }
             return "No response received for \(duration.components.seconds)s."
+        case .blockedAddress(let detail):
+            return "Connection blocked: the endpoint resolved to a private or reserved address. \(detail)"
         }
     }
 
@@ -55,7 +61,8 @@ public enum CloudBackendError: LocalizedError {
             return true
         case .serverError(let statusCode, _):
             return statusCode >= 500
-        case .invalidURL, .authenticationFailed, .parseError, .missingAPIKey, .backendDeallocated:
+        case .invalidURL, .authenticationFailed, .parseError, .missingAPIKey,
+             .backendDeallocated, .blockedAddress:
             return false
         }
     }

--- a/Sources/BaseChatInference/Services/ModelLifecycleCoordinator.swift
+++ b/Sources/BaseChatInference/Services/ModelLifecycleCoordinator.swift
@@ -239,9 +239,15 @@ final class ModelLifecycleCoordinator {
     }
 
     func loadCloudBackend(from endpoint: APIEndpointRecord) async throws {
+        // Validate before unloading the current model so a bad endpoint doesn't
+        // leave the user with no backend at all.
+        try endpoint.validate()
+
         unloadModel()
 
-        guard let url = URL(string: endpoint.baseURL) else {
+        // URL(string:) is guaranteed to succeed after validate(), but force-unwrap
+        // is avoided here in case of future trimming divergence.
+        guard let url = URL(string: endpoint.baseURL.trimmingCharacters(in: .whitespacesAndNewlines)) else {
             throw CloudBackendError.invalidURL(endpoint.baseURL)
         }
 

--- a/Sources/BaseChatInference/Utilities/PrivateIPClassifier.swift
+++ b/Sources/BaseChatInference/Utilities/PrivateIPClassifier.swift
@@ -1,0 +1,195 @@
+import Foundation
+
+/// Categories of blocked IP address ranges, used for SSRF and DNS rebinding mitigation.
+///
+/// Mirrors the IP-classification subset of ``APIEndpointValidationReason`` so that the
+/// identical policy can be enforced from both `BaseChatCore` (URL validation) and
+/// `BaseChatBackends` (DNS-resolved address checks) without duplicating the rules.
+public enum BlockedAddressCategory: Sendable, CustomStringConvertible {
+    /// RFC1918 private IPv4 range (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`).
+    case privateHost
+    /// Link-local range (IPv4 `169.254.0.0/16` or IPv6 `fe80::/10`).
+    /// Includes cloud instance-metadata services (AWS/GCP/Azure IMDS).
+    case linkLocalHost
+    /// IPv6 unique-local range (`fc00::/7`) — the IPv6 equivalent of RFC1918.
+    case ipv6UniqueLocal
+    /// IPv4-mapped IPv6 address (`::ffff:0:0/96`). Rejected wholesale so that
+    /// mapped loopback (`::ffff:127.0.0.1`) and mapped RFC1918 addresses cannot
+    /// bypass the IPv4 filter.
+    case ipv4MappedLoopback
+    /// Multicast or reserved IPv4 range (`0.0.0.0/8`, `127.0.0.0/8`,
+    /// `224.0.0.0/4`, `240.0.0.0/4`), or the IPv6 loopback address `::1`.
+    case multicastReserved
+
+    public var description: String {
+        switch self {
+        case .privateHost:       return "RFC1918 private address"
+        case .linkLocalHost:     return "link-local address"
+        case .ipv6UniqueLocal:   return "IPv6 unique-local address"
+        case .ipv4MappedLoopback: return "IPv4-mapped IPv6 address"
+        case .multicastReserved: return "multicast or reserved address"
+        }
+    }
+}
+
+/// Shared IP-address classification logic for SSRF / DNS-rebinding mitigation.
+///
+/// Used by:
+/// - `BaseChatCore.APIEndpoint.validate()` — structural URL validation at config time.
+/// - `BaseChatBackends.DNSRebindingGuard` — request-time check of DNS-resolved addresses.
+///
+/// Only IP literals are inspected. **DNS names are never resolved here.** Callers that
+/// need to guard against DNS rebinding must resolve the hostname first (e.g. via
+/// `getaddrinfo`) and then pass each resolved address to ``classifyIPLiteral(_:)``.
+public enum PrivateIPClassifier {
+
+    // MARK: - Localhost
+
+    /// Returns `true` if `url`'s host is an explicit loopback literal.
+    ///
+    /// Only the three literals `localhost`, `127.0.0.1`, and `::1` match —
+    /// broader `127.x.x.x` and IPv4-mapped IPv6 loopback are intentionally
+    /// excluded to prevent bypass via alternate encodings.
+    public static func isLocalhostURL(_ url: URL) -> Bool {
+        guard let host = url.host()?.lowercased() else { return false }
+        return host == "localhost" || host == "127.0.0.1" || host == "::1"
+    }
+
+    // MARK: - IP Literal Classification
+
+    /// Classifies an IP literal string as belonging to a blocked address range.
+    ///
+    /// Returns `nil` for:
+    /// - DNS names (not resolved here — return value is undefined for non-literals)
+    /// - Addresses in routable public ranges (allowed)
+    ///
+    /// > Important: Both `127.0.0.1` and `::1` are classified as
+    /// > ``BlockedAddressCategory/multicastReserved`` by this function.
+    /// > For URL-configuration validation, callers must apply ``isLocalhostURL(_:)``
+    /// > *before* calling this method so explicitly configured loopback servers remain
+    /// > accessible. For DNS-resolved addresses, loopback returned by a remote domain
+    /// > is always a rebinding attack and should be blocked unconditionally.
+    public static func classifyIPLiteral(_ rawAddress: String) -> BlockedAddressCategory? {
+        // Strip trailing dot — FQDN form (e.g. `192.168.1.1.`) resolves identically
+        // to the dotless form and would bypass classification without this.
+        let address = rawAddress.hasSuffix(".") ? String(rawAddress.dropLast()) : rawAddress
+
+        if let octets = parseIPv4Literal(address) {
+            return classifyIPv4(octets)
+        }
+        if let words = parseIPv6Literal(address) {
+            return classifyIPv6(words)
+        }
+        return nil
+    }
+
+    // MARK: - IPv4
+
+    /// Parses a dotted-quad IPv4 literal into four octets.
+    ///
+    /// Returns `nil` for non-literal inputs (DNS names, IPv6, shorthand forms like
+    /// `127.1` that some resolvers accept but modern URL parsers reject).
+    public static func parseIPv4Literal(_ host: String) -> [UInt8]? {
+        let parts = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 4 else { return nil }
+        var octets: [UInt8] = []
+        octets.reserveCapacity(4)
+        for part in parts {
+            guard !part.isEmpty, part.allSatisfy(\.isASCII),
+                  let value = UInt16(part), value <= 255 else {
+                return nil
+            }
+            octets.append(UInt8(value))
+        }
+        return octets
+    }
+
+    /// Classifies an IPv4 address (as four octets) into a blocked range, or returns
+    /// `nil` if the address is in a routable public range.
+    public static func classifyIPv4(_ octets: [UInt8]) -> BlockedAddressCategory? {
+        let a = octets[0]
+        let b = octets[1]
+
+        if a == 10 { return .privateHost }                           // 10.0.0.0/8 — RFC1918
+        if a == 172 && (16...31).contains(b) { return .privateHost } // 172.16.0.0/12 — RFC1918
+        if a == 192 && b == 168 { return .privateHost }              // 192.168.0.0/16 — RFC1918
+        if a == 169 && b == 254 { return .linkLocalHost }            // 169.254.0.0/16 — link-local (cloud IMDS)
+        if a == 0 { return .multicastReserved }                      // 0.0.0.0/8 — "this host"
+        // 127.0.0.0/8 — loopback (full /8, including 127.0.0.1).
+        // For URL validation, callers apply isLocalhostURL first so 127.0.0.1
+        // never reaches here. For DNS-resolved addresses, any 127.x.x.x is an attack.
+        if a == 127 { return .multicastReserved }
+        if (224...239).contains(a) { return .multicastReserved }     // 224.0.0.0/4 — multicast
+        if a >= 240 { return .multicastReserved }                    // 240.0.0.0/4 — reserved / broadcast
+        return nil
+    }
+
+    // MARK: - IPv6
+
+    /// Parses an IPv6 literal (as returned by `URL.host()` — without surrounding
+    /// brackets) into eight 16-bit words.
+    ///
+    /// Supports `::` zero-run compression and embedded IPv4 suffixes
+    /// (e.g. `::ffff:127.0.0.1`). Zone identifiers (`fe80::1%en0`) are stripped.
+    public static func parseIPv6Literal(_ host: String) -> [UInt16]? {
+        let bare = host.split(separator: "%", maxSplits: 1).first.map(String.init) ?? host
+        guard bare.contains(":") else { return nil }
+
+        let doubleColonParts = bare.components(separatedBy: "::")
+        guard doubleColonParts.count <= 2 else { return nil }
+
+        func expand(_ segment: String) -> [UInt16]? {
+            if segment.isEmpty { return [] }
+            let groups = segment.split(separator: ":", omittingEmptySubsequences: false)
+            var words: [UInt16] = []
+            for (i, group) in groups.enumerated() {
+                if group.contains(".") {
+                    guard i == groups.count - 1,
+                          let v4 = parseIPv4Literal(String(group)) else { return nil }
+                    words.append((UInt16(v4[0]) << 8) | UInt16(v4[1]))
+                    words.append((UInt16(v4[2]) << 8) | UInt16(v4[3]))
+                } else {
+                    guard !group.isEmpty, group.count <= 4,
+                          let value = UInt16(group, radix: 16) else { return nil }
+                    words.append(value)
+                }
+            }
+            return words
+        }
+
+        let head = expand(doubleColonParts[0])
+        let tail = doubleColonParts.count == 2 ? expand(doubleColonParts[1]) : []
+        guard let headWords = head, let tailWords = tail else { return nil }
+
+        let total = headWords.count + tailWords.count
+        if doubleColonParts.count == 2 {
+            guard total <= 8 else { return nil }
+            return headWords + Array(repeating: UInt16(0), count: 8 - total) + tailWords
+        } else {
+            guard total == 8 else { return nil }
+            return headWords
+        }
+    }
+
+    /// Classifies an IPv6 address (as eight 16-bit words) into a blocked range, or
+    /// returns `nil` if the address is in a routable public range.
+    public static func classifyIPv6(_ words: [UInt16]) -> BlockedAddressCategory? {
+        guard words.count == 8 else { return nil }
+
+        // ::1 — IPv6 loopback. Analogous to 127.0.0.0/8.
+        // For URL validation, callers apply isLocalhostURL first.
+        // For DNS-resolved addresses, ::1 from a remote domain is always an attack.
+        if words == [0, 0, 0, 0, 0, 0, 0, 1] { return .multicastReserved }
+
+        if (words[0] & 0xfe00) == 0xfc00 { return .ipv6UniqueLocal }  // fc00::/7 — unique local
+        if (words[0] & 0xffc0) == 0xfe80 { return .linkLocalHost }    // fe80::/10 — link-local
+
+        // ::ffff:0:0/96 — IPv4-mapped. Reject wholesale so that mapped loopback
+        // (::ffff:127.0.0.1) and mapped RFC1918 addresses bypass the IPv4 filter.
+        let isIPv4Mapped = words[0] == 0 && words[1] == 0 && words[2] == 0
+            && words[3] == 0 && words[4] == 0 && words[5] == 0xffff
+        if isIPv4Mapped { return .ipv4MappedLoopback }
+
+        return nil
+    }
+}

--- a/Sources/BaseChatUI/Views/Settings/APIEndpointDraftValidator.swift
+++ b/Sources/BaseChatUI/Views/Settings/APIEndpointDraftValidator.swift
@@ -1,0 +1,21 @@
+import BaseChatCore
+import BaseChatInference
+
+/// Validates in-progress endpoint edits against BaseChatKit's canonical endpoint policy.
+enum APIEndpointDraftValidator {
+    static func validate(
+        provider: APIProvider,
+        baseURL: String,
+        modelName: String
+    ) -> Result<Void, APIEndpointValidationReason> {
+        let trimmedURL = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedModel = modelName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let endpoint = APIEndpoint(
+            name: provider.rawValue,
+            provider: provider,
+            baseURL: trimmedURL.isEmpty ? nil : trimmedURL,
+            modelName: trimmedModel.isEmpty ? nil : trimmedModel
+        )
+        return endpoint.validate()
+    }
+}

--- a/Sources/BaseChatUI/Views/Settings/APIEndpointEditorView.swift
+++ b/Sources/BaseChatUI/Views/Settings/APIEndpointEditorView.swift
@@ -143,20 +143,30 @@ public struct APIEndpointEditorView: View {
         guard !trimmedName.isEmpty else { return }
 
         let trimmedURL = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedModelName = modelName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedModelName = trimmedModelName.isEmpty ? provider.defaultModelName : trimmedModelName
 
-        if let error = validateURL(trimmedURL) {
-            validationError = error
+        switch APIEndpointDraftValidator.validate(
+            provider: provider,
+            baseURL: trimmedURL,
+            modelName: resolvedModelName
+        ) {
+        case .failure(let reason):
+            validationError = reason.errorDescription
             return
+        case .success:
+            break
         }
 
         validationError = nil
+        var createdEndpoint: APIEndpoint?
 
         if let endpoint {
             // Update existing
             endpoint.name = trimmedName
             endpoint.provider = provider
             endpoint.baseURL = trimmedURL.isEmpty ? provider.defaultBaseURL : trimmedURL
-            endpoint.modelName = modelName.trimmingCharacters(in: .whitespacesAndNewlines)
+            endpoint.modelName = resolvedModelName
 
             if !apiKey.isEmpty {
                 do {
@@ -175,9 +185,10 @@ public struct APIEndpointEditorView: View {
                 name: trimmedName,
                 provider: provider,
                 baseURL: trimmedURL.isEmpty ? nil : trimmedURL,
-                modelName: modelName.isEmpty ? nil : modelName
+                modelName: resolvedModelName
             )
             modelContext.insert(newEndpoint)
+            createdEndpoint = newEndpoint
 
             if !apiKey.isEmpty {
                 do {
@@ -193,38 +204,17 @@ public struct APIEndpointEditorView: View {
             }
         }
 
-        try? modelContext.save()
-        dismiss()
-    }
-
-    /// Returns an error message if the URL is invalid, or `nil` if it passes validation.
-    private func validateURL(_ urlString: String) -> String? {
-        // Empty URL is allowed — the provider default will be used
-        guard !urlString.isEmpty else { return nil }
-
-        guard let url = URL(string: urlString),
-              let scheme = url.scheme?.lowercased(),
-              url.host != nil else {
-            return "Enter a valid URL (e.g. https://api.example.com)."
-        }
-
-        guard scheme == "http" || scheme == "https" else {
-            return "URL must use http:// or https://."
-        }
-
-        // Allow plain HTTP only for localhost / loopback addresses
-        if scheme == "http" {
-            let host = url.host?.lowercased() ?? ""
-            let isLocal = host == "localhost"
-                || host == "127.0.0.1"
-                || host == "::1"
-                || host.hasSuffix(".local")
-            if !isLocal {
-                return "Remote servers must use HTTPS. Plain HTTP is only allowed for localhost."
+        do {
+            try modelContext.save()
+            dismiss()
+        } catch {
+            if let createdEndpoint {
+                modelContext.delete(createdEndpoint)
             }
+            validationError = error.localizedDescription.isEmpty
+                ? "Failed to save the endpoint configuration."
+                : error.localizedDescription
         }
-
-        return nil
     }
 }
 

--- a/Sources/BaseChatUI/Views/Settings/RemoteServerConfigSheet.swift
+++ b/Sources/BaseChatUI/Views/Settings/RemoteServerConfigSheet.swift
@@ -107,7 +107,7 @@ public struct RemoteServerConfigSheet: View {
 
     private var connectionSection: some View {
         Section {
-            TextField("Server URL", text: $serverURL, prompt: Text("http://192.168.1.10:\(backendType.defaultPort)"))
+            TextField("Server URL", text: $serverURL, prompt: Text("http://localhost:\(backendType.defaultPort)"))
                 #if os(iOS)
                 .textInputAutocapitalization(.never)
                 .keyboardType(.URL)
@@ -145,19 +145,34 @@ public struct RemoteServerConfigSheet: View {
     // MARK: - Validation & Save
 
     private var isValid: Bool {
-        let trimmed = serverURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        return URL(string: trimmed)?.host != nil
+        let resolvedModel = modelName.trimmingCharacters(in: .whitespacesAndNewlines)
+            .nonEmpty ?? backendType.apiProvider.defaultModelName
+        if case .success = APIEndpointDraftValidator.validate(
+            provider: backendType.apiProvider,
+            baseURL: serverURL,
+            modelName: resolvedModel
+        ) {
+            return true
+        }
+        return false
     }
 
     private func save() {
         let trimmedURL = serverURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let _ = URL(string: trimmedURL)?.host else {
-            errorMessage = "Enter a valid server URL."
-            return
-        }
-
         let resolvedModel = modelName.trimmingCharacters(in: .whitespacesAndNewlines)
             .nonEmpty ?? backendType.apiProvider.defaultModelName
+
+        switch APIEndpointDraftValidator.validate(
+            provider: backendType.apiProvider,
+            baseURL: trimmedURL,
+            modelName: resolvedModel
+        ) {
+        case .failure(let reason):
+            errorMessage = reason.errorDescription
+            return
+        case .success:
+            break
+        }
 
         let endpoint = APIEndpoint(
             name: "\(backendType.rawValue) — \(resolvedModel)",

--- a/Tests/BaseChatBackendsTests/CloudEndpointSelectionIntegrationTests.swift
+++ b/Tests/BaseChatBackendsTests/CloudEndpointSelectionIntegrationTests.swift
@@ -145,13 +145,14 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
 
     func test_sendMessage_streamsCloudResponseViaMockURLProtocol() async throws {
         // UUID hostname isolates this stub from concurrently-running suites.
+        // https:// is required for non-localhost endpoints per endpoint validation.
         let uniqueHost = UUID().uuidString + ".invalid"
 
         try makeSession(title: "Cloud Chat")
         let endpoint = APIEndpoint(
             name: "Local LM Studio",
             provider: .lmStudio,
-            baseURL: "http://\(uniqueHost):1234",
+            baseURL: "https://\(uniqueHost):1234",
             modelName: "local-model"
         )
         try persistEndpoint(endpoint)
@@ -411,10 +412,11 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
                 probeOnLoad: true
             )
         }
+        // https:// is required for non-localhost endpoints per endpoint validation.
         let networkEndpoint = APIEndpoint(
             name: "Flaky Endpoint",
             provider: .ollama,
-            baseURL: "http://\(uniqueHost):11434",
+            baseURL: "https://\(uniqueHost):11434",
             modelName: "llama3.2"
         )
         let networkBaseURL = try XCTUnwrap(URL(string: networkEndpoint.baseURL))
@@ -446,6 +448,100 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
         await successVM.loadCloudEndpoint(networkEndpoint)
         XCTAssertTrue(successVM.isModelLoaded, "With successful stub, loading should succeed")
         MockURLProtocol.unstub(url: networkCompletionsURL)
+    }
+
+    // MARK: - SSRF / Endpoint Validation
+
+    func test_loadCloudEndpoint_privateIPv4_surfacesError() async {
+        let privateURLs = [
+            "https://192.168.1.100",
+            "https://10.0.0.1",
+            "https://172.20.0.1",
+        ]
+        for baseURL in privateURLs {
+            let privateVM = makeViewModel { [cloudSession] _ in
+                ConfiguringOpenAICloudBackend(urlSession: cloudSession!)
+            }
+            let endpoint = APIEndpoint(
+                name: "Private",
+                provider: .custom,
+                baseURL: baseURL,
+                modelName: "model"
+            )
+            await privateVM.loadCloudEndpoint(endpoint)
+
+            XCTAssertNotNil(
+                privateVM.errorMessage,
+                "Private IP \(baseURL) should surface an error"
+            )
+            XCTAssertFalse(privateVM.isModelLoaded)
+        }
+
+        // Sabotage: a valid public HTTPS endpoint must NOT be rejected.
+        let validVM = makeViewModel { [cloudSession] _ in
+            ConfiguringOpenAICloudBackend(urlSession: cloudSession!)
+        }
+        let validEndpoint = APIEndpoint(
+            name: "Valid",
+            provider: .ollama,
+            baseURL: "http://localhost:11434",
+            modelName: "model"
+        )
+        await validVM.loadCloudEndpoint(validEndpoint)
+        XCTAssertNil(validVM.errorMessage, "localhost should not be rejected")
+    }
+
+    func test_loadCloudEndpoint_linkLocalIMDS_surfacesError() async {
+        let imdsVM = makeViewModel { [cloudSession] _ in
+            ConfiguringOpenAICloudBackend(urlSession: cloudSession!)
+        }
+        let imdsEndpoint = APIEndpoint(
+            name: "IMDS",
+            provider: .custom,
+            baseURL: "https://169.254.169.254/latest/meta-data",
+            modelName: "model"
+        )
+        await imdsVM.loadCloudEndpoint(imdsEndpoint)
+
+        let errorMsg = imdsVM.errorMessage ?? ""
+        XCTAssertFalse(errorMsg.isEmpty, "Link-local IMDS address must surface an error")
+        XCTAssertFalse(imdsVM.isModelLoaded)
+    }
+
+    func test_loadCloudEndpoint_insecureRemoteScheme_surfacesError() async {
+        let insecureVM = makeViewModel { [cloudSession] _ in
+            ConfiguringOpenAICloudBackend(urlSession: cloudSession!)
+        }
+        let insecureEndpoint = APIEndpoint(
+            name: "Insecure",
+            provider: .custom,
+            baseURL: "http://api.example.com",
+            modelName: "model"
+        )
+        await insecureVM.loadCloudEndpoint(insecureEndpoint)
+
+        XCTAssertNotNil(insecureVM.errorMessage, "http:// remote endpoint must surface an error")
+        XCTAssertFalse(insecureVM.isModelLoaded)
+
+        // Sabotage: https:// against the same host must NOT be rejected at the
+        // validation layer (it may fail later for other reasons, but not URL validation).
+        let httpsVM = makeViewModel { [cloudSession] _ in
+            ConfiguringOpenAICloudBackend(urlSession: cloudSession!)
+        }
+        let httpsEndpoint = APIEndpoint(
+            name: "Secure",
+            provider: .custom,
+            baseURL: "https://api.example.com",
+            modelName: "model"
+        )
+        await httpsVM.loadCloudEndpoint(httpsEndpoint)
+        if let msg = httpsVM.errorMessage {
+            XCTAssertFalse(
+                msg.localizedCaseInsensitiveContains("scheme")
+                || msg.localizedCaseInsensitiveContains("http"),
+                "https:// must not fail URL-scheme validation, got: \(msg)"
+            )
+        }
     }
 }
 

--- a/Tests/BaseChatBackendsTests/DNSRebindingGuardTests.swift
+++ b/Tests/BaseChatBackendsTests/DNSRebindingGuardTests.swift
@@ -1,0 +1,219 @@
+import XCTest
+@testable import BaseChatBackends
+import BaseChatInference
+
+/// Tests for the DNS-rebinding mitigation implemented in ``DNSRebindingGuard``.
+///
+/// The guard is the request-layer complement to `APIEndpoint.validate()`: while
+/// validate() blocks IP-literal addresses at configuration time, this guard blocks
+/// domain names that resolve to private/reserved IPs at connect time.
+///
+/// Tests use the `_resolverForTesting` seam so no real DNS queries are issued.
+final class DNSRebindingGuardTests: XCTestCase {
+
+    // MARK: - Setup / Teardown
+
+    override func tearDown() {
+        // Always clear the testing seam so it doesn't bleed into other tests.
+        DNSRebindingGuard._resolverForTesting = nil
+        super.tearDown()
+    }
+
+    // MARK: - Localhost Bypass
+
+    func test_localhostURL_alwaysPasses() async throws {
+        // Sabotage check: removing the isLocalhostURL guard causes this to throw.
+        try await DNSRebindingGuard.validate(url: URL(string: "http://localhost:11434")!)
+    }
+
+    func test_127_0_0_1_URL_alwaysPasses() async throws {
+        try await DNSRebindingGuard.validate(url: URL(string: "http://127.0.0.1:8080")!)
+    }
+
+    func test_ipv6Loopback_URL_alwaysPasses() async throws {
+        try await DNSRebindingGuard.validate(url: URL(string: "http://[::1]:11434")!)
+    }
+
+    // MARK: - IP Literal Blocking (no DNS resolution needed)
+
+    func test_rfc1918_10_block_isBlocked() async {
+        await assertBlocked(url: "https://10.0.0.1/api")
+    }
+
+    func test_rfc1918_172_16_block_isBlocked() async {
+        await assertBlocked(url: "https://172.16.0.1/api")
+    }
+
+    func test_rfc1918_192_168_block_isBlocked() async {
+        await assertBlocked(url: "https://192.168.1.100/api")
+    }
+
+    func test_linkLocal_awsIMDS_isBlocked() async {
+        await assertBlocked(url: "https://169.254.169.254/latest/meta-data")
+    }
+
+    func test_multicast_isBlocked() async {
+        await assertBlocked(url: "https://224.0.0.1/api")
+    }
+
+    func test_reserved_240_block_isBlocked() async {
+        await assertBlocked(url: "https://240.0.0.1/api")
+    }
+
+    func test_ipv6UniqueLocal_isBlocked() async {
+        await assertBlocked(url: "https://[fd00::1]/api")
+    }
+
+    func test_ipv6LinkLocal_isBlocked() async {
+        await assertBlocked(url: "https://[fe80::1]/api")
+    }
+
+    func test_ipv4MappedIPv6_isBlocked() async {
+        await assertBlocked(url: "https://[::ffff:192.168.1.1]/api")
+    }
+
+    // MARK: - Public IP Literal Allowed
+
+    func test_publicIP_1_1_1_1_isAllowed() async throws {
+        // Cloudflare DNS — a well-known public address.
+        // Sabotage check: removing the nil-return path in classifyIPLiteral causes this to throw.
+        try await DNSRebindingGuard.validate(url: URL(string: "https://1.1.1.1/api")!)
+    }
+
+    func test_publicIP_8_8_8_8_isAllowed() async throws {
+        try await DNSRebindingGuard.validate(url: URL(string: "https://8.8.8.8/api")!)
+    }
+
+    // MARK: - DNS Resolution: Allowed Resolutions
+
+    func test_dnsName_resolvingToPublicIP_isAllowed() async throws {
+        DNSRebindingGuard._resolverForTesting = { _ in ["93.184.216.34"] } // example.com
+        try await DNSRebindingGuard.validate(url: URL(string: "https://api.example.com/v1")!)
+    }
+
+    func test_dnsName_resolvingToMultiplePublicIPs_isAllowed() async throws {
+        DNSRebindingGuard._resolverForTesting = { _ in ["93.184.216.34", "2606:2800:220:1:248:1893:25c8:1946"] }
+        try await DNSRebindingGuard.validate(url: URL(string: "https://api.example.com/v1")!)
+    }
+
+    func test_knownProductionHost_openAI_isAllowed() async throws {
+        // api.openai.com — certificate pinning also applies, but the guard should pass.
+        DNSRebindingGuard._resolverForTesting = { _ in ["104.18.6.192", "104.18.7.192"] }
+        try await DNSRebindingGuard.validate(url: URL(string: "https://api.openai.com/v1/chat/completions")!)
+    }
+
+    // MARK: - DNS Resolution: Blocked Resolutions (Rebinding Scenarios)
+
+    func test_dnsName_resolvingToPrivateIP_isBlocked() async {
+        DNSRebindingGuard._resolverForTesting = { _ in ["192.168.1.1"] }
+        await assertBlocked(url: "https://evil.example.com/api")
+    }
+
+    func test_dnsName_resolvingToLinkLocal_awsIMDS_isBlocked() async {
+        DNSRebindingGuard._resolverForTesting = { _ in ["169.254.169.254"] }
+        await assertBlocked(url: "https://rebind.attacker.com/api")
+    }
+
+    func test_dnsName_resolvingToLoopback_127_0_0_1_isBlocked() async {
+        // A non-localhost URL that resolves to loopback is a rebinding attack.
+        DNSRebindingGuard._resolverForTesting = { _ in ["127.0.0.1"] }
+        await assertBlocked(url: "https://evil.example.com/api")
+    }
+
+    func test_dnsName_resolvingToIPv6Loopback_isBlocked() async {
+        DNSRebindingGuard._resolverForTesting = { _ in ["::1"] }
+        await assertBlocked(url: "https://evil.example.com/api")
+    }
+
+    func test_dnsName_mixedResults_onePrivate_isBlocked() async {
+        // Even a single private address in a mixed result set should block.
+        // Sabotage check: requiring ALL addresses to be private (instead of ANY) causes
+        // this test to pass when it should not, missing the attack vector.
+        DNSRebindingGuard._resolverForTesting = { _ in ["93.184.216.34", "10.0.0.1"] }
+        await assertBlocked(url: "https://evil.example.com/api")
+    }
+
+    func test_dnsName_resolvingToIPv6UniqueLocal_isBlocked() async {
+        DNSRebindingGuard._resolverForTesting = { _ in ["fd12:3456:789a::1"] }
+        await assertBlocked(url: "https://evil.example.com/api")
+    }
+
+    // MARK: - Error Type
+
+    func test_blockedAddress_error_isNonRetryable() async {
+        DNSRebindingGuard._resolverForTesting = { _ in ["192.168.1.1"] }
+        do {
+            try await DNSRebindingGuard.validate(url: URL(string: "https://evil.example.com/api")!)
+            XCTFail("Expected blockedAddress error to be thrown")
+        } catch let error as CloudBackendError {
+            XCTAssertFalse(error.isRetryable,
+                           "blockedAddress errors must not be retried — the address is still private")
+            if case .blockedAddress = error {
+                // correct case
+            } else {
+                XCTFail("Expected .blockedAddress, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func test_blockedAddress_errorDescription_isNonEmpty() async {
+        DNSRebindingGuard._resolverForTesting = { _ in ["169.254.169.254"] }
+        do {
+            try await DNSRebindingGuard.validate(url: URL(string: "https://evil.example.com/api")!)
+            XCTFail("Expected error")
+        } catch let error as CloudBackendError {
+            XCTAssertNotNil(error.errorDescription)
+            XCTAssertFalse(error.errorDescription?.isEmpty ?? true)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    // MARK: - Resolution Failure (fail-open)
+
+    func test_unresolvedHostname_failsOpen() async throws {
+        // If DNS resolution fails (NXDOMAIN, network error), the guard fails open
+        // so the subsequent URLSession connection produces the right error.
+        DNSRebindingGuard._resolverForTesting = { _ in [] }
+        try await DNSRebindingGuard.validate(url: URL(string: "https://does-not-exist.invalid/api")!)
+    }
+
+    // MARK: - Helpers
+
+    private func assertBlocked(
+        url urlString: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async {
+        guard let url = URL(string: urlString) else {
+            XCTFail("Invalid test URL: \(urlString)", file: file, line: line)
+            return
+        }
+        do {
+            try await DNSRebindingGuard.validate(url: url)
+            XCTFail(
+                "Expected DNSRebindingGuard to block \(urlString) but it passed",
+                file: file,
+                line: line
+            )
+        } catch let error as CloudBackendError {
+            if case .blockedAddress = error {
+                // Expected — test passes.
+            } else {
+                XCTFail(
+                    "Expected .blockedAddress but got \(error) for \(urlString)",
+                    file: file,
+                    line: line
+                )
+            }
+        } catch {
+            XCTFail(
+                "Unexpected error type \(error) for \(urlString)",
+                file: file,
+                line: line
+            )
+        }
+    }
+}

--- a/Tests/BaseChatBackendsTests/PinnedSessionDelegateTests.swift
+++ b/Tests/BaseChatBackendsTests/PinnedSessionDelegateTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import CommonCrypto
+import BaseChatInference
 @testable import BaseChatBackends
 
 final class PinnedSessionDelegateTests: XCTestCase {
@@ -65,6 +66,117 @@ final class PinnedSessionDelegateTests: XCTestCase {
 
         await fulfillment(of: [expectation], timeout: 2.0)
         XCTAssertEqual(receivedDisposition, .performDefaultHandling)
+    }
+
+    // MARK: - Custom Host Trust Policy
+
+    func test_customHost_noPins_platformDefault_returnsDefaultHandling() async {
+        let savedPins = PinnedSessionDelegate.pinnedHosts
+        let savedConfig = BaseChatConfiguration.shared
+        PinnedSessionDelegate.pinnedHosts = [:]
+        BaseChatConfiguration.shared = BaseChatConfiguration(customHostTrustPolicy: .platformDefault)
+        defer {
+            PinnedSessionDelegate.pinnedHosts = savedPins
+            BaseChatConfiguration.shared = savedConfig
+        }
+
+        let delegate = PinnedSessionDelegate()
+        let challenge = makeChallenge(host: "custom.mycompany.com")
+
+        let expectation = XCTestExpectation(description: "completion called")
+        var receivedDisposition: URLSession.AuthChallengeDisposition?
+
+        delegate.urlSession(URLSession.shared, didReceive: challenge) { disposition, _ in
+            receivedDisposition = disposition
+            expectation.fulfill()
+        }
+
+        await fulfillment(of: [expectation], timeout: 2.0)
+        XCTAssertEqual(receivedDisposition, .performDefaultHandling,
+                       "platformDefault policy: custom host with no pins should fall back to OS trust")
+    }
+
+    func test_customHost_noPins_requireExplicitPins_cancelsChallenge() async {
+        let savedPins = PinnedSessionDelegate.pinnedHosts
+        let savedConfig = BaseChatConfiguration.shared
+        PinnedSessionDelegate.pinnedHosts = [:]
+        BaseChatConfiguration.shared = BaseChatConfiguration(customHostTrustPolicy: .requireExplicitPins)
+        defer {
+            PinnedSessionDelegate.pinnedHosts = savedPins
+            BaseChatConfiguration.shared = savedConfig
+        }
+
+        let delegate = PinnedSessionDelegate()
+        let challenge = makeChallenge(host: "custom.mycompany.com")
+
+        let expectation = XCTestExpectation(description: "completion called")
+        var receivedDisposition: URLSession.AuthChallengeDisposition?
+
+        delegate.urlSession(URLSession.shared, didReceive: challenge) { disposition, _ in
+            receivedDisposition = disposition
+            expectation.fulfill()
+        }
+
+        await fulfillment(of: [expectation], timeout: 2.0)
+        XCTAssertEqual(receivedDisposition, .cancelAuthenticationChallenge,
+                       "requireExplicitPins policy: custom host with no pins should fail-closed")
+    }
+
+    func test_customHost_withPins_requireExplicitPins_doesNotCancelBeforeTrustEval() async {
+        // When pins ARE configured for a custom host, the requireExplicitPins guard
+        // is satisfied and we proceed to trust evaluation (not an early cancel).
+        let savedPins = PinnedSessionDelegate.pinnedHosts
+        let savedConfig = BaseChatConfiguration.shared
+        PinnedSessionDelegate.pinnedHosts = ["custom.mycompany.com": Set(["somePinHash="])]
+        BaseChatConfiguration.shared = BaseChatConfiguration(customHostTrustPolicy: .requireExplicitPins)
+        defer {
+            PinnedSessionDelegate.pinnedHosts = savedPins
+            BaseChatConfiguration.shared = savedConfig
+        }
+
+        let delegate = PinnedSessionDelegate()
+        // Challenge with no server trust object — this triggers the missing-serverTrust cancel,
+        // which proves we passed the no-pins guard and reached trust evaluation.
+        let challenge = makeChallenge(host: "custom.mycompany.com")
+
+        let expectation = XCTestExpectation(description: "completion called")
+        var receivedDisposition: URLSession.AuthChallengeDisposition?
+
+        delegate.urlSession(URLSession.shared, didReceive: challenge) { disposition, _ in
+            receivedDisposition = disposition
+            expectation.fulfill()
+        }
+
+        await fulfillment(of: [expectation], timeout: 2.0)
+        // Disposition is .cancelAuthenticationChallenge because SecTrust is nil in the
+        // test challenge, NOT because of the no-pins guard. This confirms the policy
+        // does not short-circuit when pins are correctly configured.
+        XCTAssertEqual(receivedDisposition, .cancelAuthenticationChallenge,
+                       "With pins configured the no-pins guard is bypassed; challenge fails later at trust eval (nil SecTrust in test)")
+    }
+
+    func test_bypassHosts_ignoreTrustPolicy_requireExplicitPins() async {
+        // Localhost addresses must bypass pinning regardless of trust policy.
+        let savedConfig = BaseChatConfiguration.shared
+        BaseChatConfiguration.shared = BaseChatConfiguration(customHostTrustPolicy: .requireExplicitPins)
+        defer { BaseChatConfiguration.shared = savedConfig }
+
+        for host in ["localhost", "127.0.0.1", "::1"] {
+            let delegate = PinnedSessionDelegate()
+            let challenge = makeChallenge(host: host)
+
+            let exp = XCTestExpectation(description: "completion for \(host)")
+            var disposition: URLSession.AuthChallengeDisposition?
+
+            delegate.urlSession(URLSession.shared, didReceive: challenge) { d, _ in
+                disposition = d
+                exp.fulfill()
+            }
+
+            await fulfillment(of: [exp], timeout: 2.0)
+            XCTAssertEqual(disposition, .performDefaultHandling,
+                           "Bypass host \(host) must bypass pinning even under requireExplicitPins policy")
+        }
     }
     
     func test_requiredProductionHost_openAI_noPins_cancelsChallenge() async {

--- a/Tests/BaseChatInferenceTests/CloudBackendErrorTests.swift
+++ b/Tests/BaseChatInferenceTests/CloudBackendErrorTests.swift
@@ -71,6 +71,7 @@ final class CloudBackendErrorTests: XCTestCase {
             .streamInterrupted,
             .backendDeallocated,
             .timeout(.seconds(120)),
+            .blockedAddress("Hostname evil.com resolved to 10.0.0.1"),
         ]
 
         for error in errors {
@@ -94,6 +95,7 @@ final class CloudBackendErrorTests: XCTestCase {
             .streamInterrupted,
             .backendDeallocated,
             .timeout(.seconds(60)),
+            .blockedAddress("10.0.0.1"),
         ]
 
         for error in errors {
@@ -116,5 +118,27 @@ final class CloudBackendErrorTests: XCTestCase {
 
     func test_streamInterrupted_isRetryable() {
         XCTAssertTrue(CloudBackendError.streamInterrupted.isRetryable)
+    }
+
+    // MARK: - blockedAddress
+
+    func test_blockedAddress_isNotRetryable() {
+        // Sabotage check: adding blockedAddress to the retryable cases causes this to fail.
+        XCTAssertFalse(CloudBackendError.blockedAddress("10.0.0.1").isRetryable,
+                       "A blocked-address error must never be retried — the address is still private")
+    }
+
+    func test_blockedAddress_descriptionContainsDetail() {
+        let detail = "Hostname evil.example.com resolved to 192.168.1.1"
+        let error = CloudBackendError.blockedAddress(detail)
+        let description = error.errorDescription ?? ""
+        XCTAssertTrue(description.contains(detail),
+                      "errorDescription should contain the blocking detail: \(description)")
+    }
+
+    func test_allCases_includeBlockedAddress_haveNonEmptyDescription() {
+        let error = CloudBackendError.blockedAddress("test detail")
+        XCTAssertNotNil(error.errorDescription)
+        XCTAssertFalse(error.errorDescription?.isEmpty ?? true)
     }
 }

--- a/Tests/BaseChatInferenceTests/InferenceServiceTests.swift
+++ b/Tests/BaseChatInferenceTests/InferenceServiceTests.swift
@@ -153,6 +153,110 @@ final class InferenceServiceTests: XCTestCase {
         }
     }
 
+    // MARK: - loadCloudBackend endpoint validation (SSRF guard)
+
+    func test_loadCloudBackend_privateIPv4_throwsInvalidURL() async {
+        let service = InferenceService()
+        let cases = [
+            "https://192.168.1.100/api",
+            "https://10.0.0.1/api",
+            "https://172.20.0.1/api",
+        ]
+        for baseURL in cases {
+            let endpoint = APIEndpointRecord(name: "Private", provider: .custom, baseURL: baseURL)
+            do {
+                try await service.loadCloudBackend(from: endpoint)
+                XCTFail("Expected CloudBackendError.invalidURL for \(baseURL)")
+            } catch CloudBackendError.invalidURL {
+                // expected
+            } catch {
+                XCTFail("Expected CloudBackendError.invalidURL for \(baseURL), got \(error)")
+            }
+        }
+    }
+
+    func test_loadCloudBackend_linkLocalIPv4_throwsInvalidURL() async {
+        let service = InferenceService()
+        let endpoint = APIEndpointRecord(
+            name: "IMDS",
+            provider: .custom,
+            baseURL: "https://169.254.169.254/latest/meta-data"
+        )
+        do {
+            try await service.loadCloudBackend(from: endpoint)
+            XCTFail("Expected CloudBackendError.invalidURL for link-local address")
+        } catch CloudBackendError.invalidURL {
+            // expected
+        } catch {
+            XCTFail("Expected CloudBackendError.invalidURL, got \(error)")
+        }
+
+        // Sabotage: a public HTTPS endpoint should NOT be rejected at this stage.
+        let publicEndpoint = APIEndpointRecord(
+            name: "Public",
+            provider: .custom,
+            baseURL: "https://api.example.com"
+        )
+        do {
+            try await service.loadCloudBackend(from: publicEndpoint)
+        } catch CloudBackendError.invalidURL(let url) {
+            XCTFail("Public endpoint should not be rejected as invalid URL, got \(url)")
+        } catch {
+            // Other errors (no factory, etc.) are acceptable here — the point is
+            // the endpoint was NOT rejected as an invalid URL.
+        }
+    }
+
+    func test_loadCloudBackend_insecureRemoteScheme_throwsInvalidURL() async {
+        let service = InferenceService()
+        let endpoint = APIEndpointRecord(
+            name: "Insecure Remote",
+            provider: .custom,
+            baseURL: "http://api.example.com"
+        )
+        do {
+            try await service.loadCloudBackend(from: endpoint)
+            XCTFail("Expected CloudBackendError.invalidURL for http:// remote endpoint")
+        } catch CloudBackendError.invalidURL {
+            // expected
+        } catch {
+            XCTFail("Expected CloudBackendError.invalidURL, got \(error)")
+        }
+    }
+
+    func test_loadCloudBackend_localhostHTTP_isNotRejectedByURLValidation() async {
+        let service = InferenceService()
+        let endpoint = APIEndpointRecord(
+            name: "Local Ollama",
+            provider: .ollama,
+            baseURL: "http://localhost:11434"
+        )
+        do {
+            try await service.loadCloudBackend(from: endpoint)
+        } catch CloudBackendError.invalidURL(let url) {
+            XCTFail("Localhost http:// should not fail URL validation, got invalidURL(\(url))")
+        } catch {
+            // Other errors (no factory, etc.) are expected — localhost was accepted.
+        }
+    }
+
+    func test_loadCloudBackend_ipv6LinkLocal_throwsInvalidURL() async {
+        let service = InferenceService()
+        let endpoint = APIEndpointRecord(
+            name: "IPv6 Link-Local",
+            provider: .custom,
+            baseURL: "https://[fe80::1]/api"
+        )
+        do {
+            try await service.loadCloudBackend(from: endpoint)
+            XCTFail("Expected CloudBackendError.invalidURL for IPv6 link-local address")
+        } catch CloudBackendError.invalidURL {
+            // expected
+        } catch {
+            XCTFail("Expected CloudBackendError.invalidURL, got \(error)")
+        }
+    }
+
     func test_loadCloudBackend_noFactoryRegistered_throwsError() async {
         let service = InferenceService()
         let endpoint = APIEndpointRecord(name: "Ollama", provider: .ollama)

--- a/Tests/BaseChatInferenceTests/PrivateIPClassifierTests.swift
+++ b/Tests/BaseChatInferenceTests/PrivateIPClassifierTests.swift
@@ -1,0 +1,189 @@
+import XCTest
+@testable import BaseChatInference
+
+/// Tests for the shared IP-address classification logic in ``PrivateIPClassifier``.
+///
+/// These tests pin every blocked range and the allowed-public boundary so that a
+/// future change to `classifyIPv4` or `classifyIPv6` is immediately visible.
+/// They also cover ``PrivateIPClassifier/isLocalhostURL(_:)`` and the trailing-dot
+/// FQDN normalisation used for bypass prevention.
+final class PrivateIPClassifierTests: XCTestCase {
+
+    // MARK: - isLocalhostURL
+
+    func test_isLocalhostURL_localhost_isTrue() {
+        XCTAssertTrue(PrivateIPClassifier.isLocalhostURL(URL(string: "http://localhost:11434")!))
+    }
+
+    func test_isLocalhostURL_127_0_0_1_isTrue() {
+        XCTAssertTrue(PrivateIPClassifier.isLocalhostURL(URL(string: "http://127.0.0.1:8080")!))
+    }
+
+    func test_isLocalhostURL_ipv6Loopback_isTrue() {
+        XCTAssertTrue(PrivateIPClassifier.isLocalhostURL(URL(string: "http://[::1]:11434")!))
+    }
+
+    func test_isLocalhostURL_publicIP_isFalse() {
+        XCTAssertFalse(PrivateIPClassifier.isLocalhostURL(URL(string: "https://1.1.1.1")!))
+    }
+
+    func test_isLocalhostURL_privateIP_isFalse() {
+        XCTAssertFalse(PrivateIPClassifier.isLocalhostURL(URL(string: "https://192.168.1.1")!))
+    }
+
+    func test_isLocalhostURL_broadLoopback_127_0_0_2_isFalse() {
+        // Broader 127.x.x.x other than 127.0.0.1 must not be treated as localhost.
+        XCTAssertFalse(PrivateIPClassifier.isLocalhostURL(URL(string: "http://127.0.0.2:8080")!))
+    }
+
+    // MARK: - classifyIPLiteral: Allowed Addresses
+
+    func test_publicIP_1_1_1_1_isNil() {
+        XCTAssertNil(PrivateIPClassifier.classifyIPLiteral("1.1.1.1"))
+    }
+
+    func test_publicIP_8_8_8_8_isNil() {
+        XCTAssertNil(PrivateIPClassifier.classifyIPLiteral("8.8.8.8"))
+    }
+
+    func test_publicIP_93_184_216_34_isNil() {
+        XCTAssertNil(PrivateIPClassifier.classifyIPLiteral("93.184.216.34"))
+    }
+
+    func test_dnsName_returnsNil() {
+        // DNS names are not IP literals — they must not be classified here.
+        XCTAssertNil(PrivateIPClassifier.classifyIPLiteral("api.openai.com"))
+    }
+
+    // MARK: - classifyIPLiteral: RFC1918 Private Ranges
+
+    func test_rfc1918_10_0_0_0_isPrivate() {
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("10.0.0.0"), .privateHost)
+    }
+
+    func test_rfc1918_10_255_255_255_isPrivate() {
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("10.255.255.255"), .privateHost)
+    }
+
+    func test_rfc1918_172_16_0_0_isPrivate() {
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("172.16.0.0"), .privateHost)
+    }
+
+    func test_rfc1918_172_31_255_255_isPrivate() {
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("172.31.255.255"), .privateHost)
+    }
+
+    func test_rfc1918_172_32_0_0_isNil() {
+        // 172.32.x.x is outside RFC1918 — should be allowed.
+        XCTAssertNil(PrivateIPClassifier.classifyIPLiteral("172.32.0.0"))
+    }
+
+    func test_rfc1918_172_15_255_255_isNil() {
+        // 172.15.x.x is outside RFC1918 — should be allowed.
+        XCTAssertNil(PrivateIPClassifier.classifyIPLiteral("172.15.255.255"))
+    }
+
+    func test_rfc1918_192_168_0_0_isPrivate() {
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("192.168.0.0"), .privateHost)
+    }
+
+    func test_rfc1918_192_168_255_255_isPrivate() {
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("192.168.255.255"), .privateHost)
+    }
+
+    // MARK: - classifyIPLiteral: Link-Local
+
+    func test_linkLocal_169_254_0_0_isLinkLocal() {
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("169.254.0.0"), .linkLocalHost)
+    }
+
+    func test_linkLocal_awsIMDS_isLinkLocal() {
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("169.254.169.254"), .linkLocalHost)
+    }
+
+    func test_linkLocal_169_254_255_255_isLinkLocal() {
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("169.254.255.255"), .linkLocalHost)
+    }
+
+    func test_adjacent_169_253_x_isNil() {
+        XCTAssertNil(PrivateIPClassifier.classifyIPLiteral("169.253.255.255"))
+    }
+
+    // MARK: - classifyIPLiteral: Loopback and Reserved
+
+    func test_loopback_127_0_0_1_isMulticastReserved() {
+        // 127.0.0.1 IS blocked as a resolved address. Callers apply isLocalhostURL first
+        // for URL validation; DNS-resolved 127.0.0.1 from a remote domain is always an attack.
+        // Sabotage: changing `if a == 127 { return .multicastReserved }` to allow 127.0.0.1
+        // would cause this test to fail.
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("127.0.0.1"), .multicastReserved)
+    }
+
+    func test_loopback_127_0_0_2_isMulticastReserved() {
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("127.0.0.2"), .multicastReserved)
+    }
+
+    func test_zeroAddress_0_0_0_0_isMulticastReserved() {
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("0.0.0.0"), .multicastReserved)
+    }
+
+    func test_multicast_224_0_0_1_isMulticastReserved() {
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("224.0.0.1"), .multicastReserved)
+    }
+
+    func test_multicast_239_255_255_255_isMulticastReserved() {
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("239.255.255.255"), .multicastReserved)
+    }
+
+    func test_reserved_240_0_0_0_isMulticastReserved() {
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("240.0.0.0"), .multicastReserved)
+    }
+
+    func test_broadcast_255_255_255_255_isMulticastReserved() {
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("255.255.255.255"), .multicastReserved)
+    }
+
+    // MARK: - classifyIPLiteral: IPv6
+
+    func test_ipv6_loopback_isMulticastReserved() {
+        // ::1 resolved from DNS is an attack. isLocalhostURL handles the http://[::1] case.
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("::1"), .multicastReserved)
+    }
+
+    func test_ipv6_uniqueLocal_fd00_isBlocked() {
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("fd00::1"), .ipv6UniqueLocal)
+    }
+
+    func test_ipv6_uniqueLocal_fc00_isBlocked() {
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("fc00::1"), .ipv6UniqueLocal)
+    }
+
+    func test_ipv6_linkLocal_fe80_isBlocked() {
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("fe80::1"), .linkLocalHost)
+    }
+
+    func test_ipv6_linkLocal_withZoneID_isBlocked() {
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("fe80::1%en0"), .linkLocalHost)
+    }
+
+    func test_ipv6_mappedIPv4_192_168_isBlocked() {
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("::ffff:192.168.1.1"), .ipv4MappedLoopback)
+    }
+
+    func test_ipv6_publicAddress_2001_db8_isNil() {
+        // 2001:db8::/32 is documentation range, but not explicitly blocked.
+        XCTAssertNil(PrivateIPClassifier.classifyIPLiteral("2001:db8::1"))
+    }
+
+    // MARK: - Trailing Dot Normalisation (FQDN bypass prevention)
+
+    func test_trailingDot_privateIPv4_isBlocked() {
+        // `192.168.1.1.` resolves identically to `192.168.1.1` — must not bypass.
+        // Sabotage: removing the trailing-dot strip from classifyIPLiteral causes this to return nil.
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("192.168.1.1."), .privateHost)
+    }
+
+    func test_trailingDot_publicIP_isNil() {
+        XCTAssertNil(PrivateIPClassifier.classifyIPLiteral("1.1.1.1."))
+    }
+}

--- a/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
+++ b/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
@@ -119,7 +119,6 @@ final class SilentCatchAuditTest: XCTestCase {
         "BaseChatUI/ViewModels/ModelManagementViewModel.swift:try? await Task.sleep(for: .milliseconds(500))",
         "BaseChatUI/Views/Chat/AssistantMarkdownView.swift:if let parsed = try? AttributedString(",
         "BaseChatUI/Views/Chat/TypingIndicatorView.swift:try? await Task.sleep(for: .milliseconds(400))",
-        "BaseChatUI/Views/Settings/APIEndpointEditorView.swift:try? modelContext.save()",
 
         // BaseChatTestSupport — test-only helpers, not production paths.
         "BaseChatTestSupport/TestHelpers.swift:try? FileManager.default.removeItem(at: url)",

--- a/Tests/BaseChatUITests/APIConfigurationLogicTests.swift
+++ b/Tests/BaseChatUITests/APIConfigurationLogicTests.swift
@@ -103,6 +103,71 @@ final class APIConfigurationLogicTests: XCTestCase {
         XCTAssertFalse(trimmed.isEmpty)
     }
 
+    func test_draftValidation_acceptsLocalhostHTTP() {
+        switch APIEndpointDraftValidator.validate(
+            provider: .ollama,
+            baseURL: "http://localhost:11434",
+            modelName: "llama3.2"
+        ) {
+        case .success:
+            break
+        case .failure(let reason):
+            XCTFail("Expected localhost URL to pass canonical validation, got \(reason)")
+        }
+    }
+
+    func test_draftValidation_rejectsPrivateIPv4() {
+        switch APIEndpointDraftValidator.validate(
+            provider: .custom,
+            baseURL: "https://192.168.1.10",
+            modelName: "model"
+        ) {
+        case .success:
+            XCTFail("Expected RFC1918 address to be rejected")
+        case .failure(let reason):
+            XCTAssertEqual(reason, .privateHost)
+        }
+    }
+
+    func test_draftValidation_rejectsLinkLocalMetadataHost() {
+        switch APIEndpointDraftValidator.validate(
+            provider: .custom,
+            baseURL: "https://169.254.169.254",
+            modelName: "model"
+        ) {
+        case .success:
+            XCTFail("Expected IMDS address to be rejected")
+        case .failure(let reason):
+            XCTAssertEqual(reason, .linkLocalHost)
+        }
+    }
+
+    func test_draftValidation_rejectsRemoteHTTPDNSHost() {
+        switch APIEndpointDraftValidator.validate(
+            provider: .custom,
+            baseURL: "http://example.com",
+            modelName: "model"
+        ) {
+        case .success:
+            XCTFail("Expected remote HTTP endpoint to be rejected")
+        case .failure(let reason):
+            XCTAssertEqual(reason, .insecureScheme)
+        }
+    }
+
+    func test_draftValidation_emptyURLUsesProviderDefault() {
+        switch APIEndpointDraftValidator.validate(
+            provider: .openAI,
+            baseURL: "",
+            modelName: "gpt-4o-mini"
+        ) {
+        case .success:
+            break
+        case .failure(let reason):
+            XCTFail("Expected provider default URL to validate, got \(reason)")
+        }
+    }
+
     // MARK: - Provider switching populates defaults
 
     /// When the user switches providers in the editor (and is NOT editing an existing endpoint),


### PR DESCRIPTION
## Summary
- enforce canonical endpoint validation on the real cloud load/connect path before network use
- reuse the same endpoint policy in the API endpoint editor and remote server settings flows
- block DNS resolutions to private, link-local, IMDS, multicast, and other reserved addresses at request time
- add a configurable custom-host trust policy that can require explicit TLS pins for hardened deployments
- extend backend, inference, and UI tests for the new validation and trust behavior

## Testing
- swift test --filter BaseChatCoreTests --disable-default-traits
- swift test --filter BaseChatInferenceTests --disable-default-traits
- swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits
- swift test --filter BaseChatUITests --disable-default-traits
- swift test --filter BaseChatBackendsTests --disable-default-traits

## Review fixes
- `APIEndpointRecord+Validation.swift` no longer carries its own copy of `parseIPv4Literal` / `classifyIPv4` / `parseIPv6Literal` / `classifyIPv6`. The `validate()` method now delegates to `PrivateIPClassifier.isLocalhostURL(_:)` and `PrivateIPClassifier.classifyIPLiteral(_:)`, matching the BaseChatCore schema validator. The file shrinks from 143 lines to 45, and a future SSRF-bypass fix only needs to land in `PrivateIPClassifier`. All five CI suites pass.

## Release Note
**Harden remote endpoint security** — BaseChatKit now enforces endpoint validation on the actual cloud connection path, reuses the same policy in UI save flows, blocks requests whose DNS resolves to private or reserved addresses, and supports a fail-closed custom-host trust mode that requires explicit pins. These changes close policy-drift gaps that could previously allow unsafe remote endpoint configurations past UI or runtime checks while preserving the existing platform-default compatibility mode unless apps opt into stricter pinning for custom hosts.
