### PR TITLE
feat: add native json mode request support

### DIFF
--- a/Sources/BaseChatBackends/ClaudeBackend.swift
+++ b/Sources/BaseChatBackends/ClaudeBackend.swift
@@ -35,6 +35,7 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             supportsSystemPrompt: true,
             supportsToolCalling: false,
             supportsStructuredOutput: true,
+            supportsNativeJSONMode: false,
             cancellationStyle: .cooperative,
             supportsTokenCounting: false,
             memoryStrategy: .external,

--- a/Sources/BaseChatBackends/FoundationBackend.swift
+++ b/Sources/BaseChatBackends/FoundationBackend.swift
@@ -79,6 +79,7 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
         supportsSystemPrompt: true,
         supportsToolCalling: false,
         supportsStructuredOutput: false,
+        supportsNativeJSONMode: false,
         cancellationStyle: .cooperative,
         supportsTokenCounting: false,
         memoryStrategy: .external,

--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -50,6 +50,7 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
             supportsSystemPrompt: true,
             supportsToolCalling: false,
             supportsStructuredOutput: false,
+            supportsNativeJSONMode: false,
             cancellationStyle: .explicit,
             supportsTokenCounting: true,
             memoryStrategy: .mappable,

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -59,6 +59,7 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         supportsSystemPrompt: true,
         supportsToolCalling: false,
         supportsStructuredOutput: false,
+        supportsNativeJSONMode: false,
         cancellationStyle: .cooperative,
         supportsTokenCounting: true,
         memoryStrategy: .resident,

--- a/Sources/BaseChatBackends/OllamaBackend.swift
+++ b/Sources/BaseChatBackends/OllamaBackend.swift
@@ -65,6 +65,7 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
             supportsSystemPrompt: true,
             supportsToolCalling: false,
             supportsStructuredOutput: false,
+            supportsNativeJSONMode: true,
             cancellationStyle: .cooperative,
             supportsTokenCounting: false,
             memoryStrategy: .external,
@@ -216,6 +217,9 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
             "options": options,
             "keep_alive": keepAlive,
         ]
+        if config.jsonMode {
+            body["format"] = "json"
+        }
         if let think = thinkDirective {
             body["think"] = think
         }

--- a/Sources/BaseChatBackends/OpenAIBackend.swift
+++ b/Sources/BaseChatBackends/OpenAIBackend.swift
@@ -47,6 +47,7 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             supportsSystemPrompt: true,
             supportsToolCalling: false,
             supportsStructuredOutput: true,
+            supportsNativeJSONMode: true,
             cancellationStyle: .cooperative,
             supportsTokenCounting: false,
             memoryStrategy: .external,
@@ -92,7 +93,7 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             messages.append(["role": "user", "content": prompt])
         }
 
-        let body: [String: Any] = [
+        var body: [String: Any] = [
             "model": modelName,
             "messages": messages,
             "stream": true,
@@ -101,6 +102,9 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             "top_p": config.topP,
             "max_tokens": config.maxOutputTokens ?? 2048
         ]
+        if config.jsonMode {
+            body["response_format"] = ["type": "json_object"]
+        }
 
         var request = URLRequest(url: completionsURL)
         request.httpMethod = "POST"

--- a/Sources/BaseChatInference/Protocols/BackendCapabilities.swift
+++ b/Sources/BaseChatInference/Protocols/BackendCapabilities.swift
@@ -64,6 +64,9 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
     /// Whether the backend supports structured (JSON schema) output.
     public let supportsStructuredOutput: Bool
 
+    /// Whether the backend supports a native JSON-object generation mode.
+    public let supportsNativeJSONMode: Bool
+
     /// How the backend handles generation cancellation.
     public let cancellationStyle: CancellationStyle
 
@@ -89,6 +92,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         supportsSystemPrompt: Bool = true,
         supportsToolCalling: Bool = false,
         supportsStructuredOutput: Bool = false,
+        supportsNativeJSONMode: Bool = false,
         cancellationStyle: CancellationStyle = .cooperative,
         supportsTokenCounting: Bool = false,
         memoryStrategy: MemoryStrategy = .resident,
@@ -102,11 +106,62 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         self.supportsSystemPrompt = supportsSystemPrompt
         self.supportsToolCalling = supportsToolCalling
         self.supportsStructuredOutput = supportsStructuredOutput
+        self.supportsNativeJSONMode = supportsNativeJSONMode
         self.cancellationStyle = cancellationStyle
         self.supportsTokenCounting = supportsTokenCounting
         self.memoryStrategy = memoryStrategy
         self.maxOutputTokens = maxOutputTokens
         self.supportsStreaming = supportsStreaming
         self.isRemote = isRemote
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case supportedParameters
+        case maxContextTokens
+        case maxOutputTokens
+        case requiresPromptTemplate
+        case supportsSystemPrompt
+        case supportsStreaming
+        case supportsToolCalling
+        case supportsStructuredOutput
+        case supportsNativeJSONMode
+        case cancellationStyle
+        case supportsTokenCounting
+        case memoryStrategy
+        case isRemote
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        supportedParameters = try c.decode(Set<GenerationParameter>.self, forKey: .supportedParameters)
+        maxContextTokens = try c.decode(Int32.self, forKey: .maxContextTokens)
+        maxOutputTokens = try c.decode(Int.self, forKey: .maxOutputTokens)
+        requiresPromptTemplate = try c.decode(Bool.self, forKey: .requiresPromptTemplate)
+        supportsSystemPrompt = try c.decode(Bool.self, forKey: .supportsSystemPrompt)
+        supportsStreaming = try c.decode(Bool.self, forKey: .supportsStreaming)
+        supportsToolCalling = try c.decode(Bool.self, forKey: .supportsToolCalling)
+        supportsStructuredOutput = try c.decode(Bool.self, forKey: .supportsStructuredOutput)
+        supportsNativeJSONMode = (try c.decodeIfPresent(Bool.self, forKey: .supportsNativeJSONMode)) ?? false
+        cancellationStyle = try c.decode(CancellationStyle.self, forKey: .cancellationStyle)
+        supportsTokenCounting = try c.decode(Bool.self, forKey: .supportsTokenCounting)
+        memoryStrategy = try c.decode(MemoryStrategy.self, forKey: .memoryStrategy)
+        isRemote = try c.decode(Bool.self, forKey: .isRemote)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(supportedParameters, forKey: .supportedParameters)
+        try c.encode(maxContextTokens, forKey: .maxContextTokens)
+        try c.encode(maxOutputTokens, forKey: .maxOutputTokens)
+        try c.encode(requiresPromptTemplate, forKey: .requiresPromptTemplate)
+        try c.encode(supportsSystemPrompt, forKey: .supportsSystemPrompt)
+        try c.encode(supportsStreaming, forKey: .supportsStreaming)
+        try c.encode(supportsToolCalling, forKey: .supportsToolCalling)
+        try c.encode(supportsStructuredOutput, forKey: .supportsStructuredOutput)
+        try c.encode(supportsNativeJSONMode, forKey: .supportsNativeJSONMode)
+        try c.encode(cancellationStyle, forKey: .cancellationStyle)
+        try c.encode(supportsTokenCounting, forKey: .supportsTokenCounting)
+        try c.encode(memoryStrategy, forKey: .memoryStrategy)
+        try c.encode(isRemote, forKey: .isRemote)
     }
 }

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -53,13 +53,19 @@ public struct GenerationConfig: Sendable, Codable {
     /// added.
     public var maxThinkingTokens: Int?
 
+    /// Requests backend-specific JSON-object-only generation for this call.
+    ///
+    /// Defaults to `false`. Backends that do not support structured output, or
+    /// have not implemented JSON-mode wiring yet, silently ignore this flag.
+    public var jsonMode: Bool
+
     /// Thinking markers for this request's model/template, or nil if the model does not emit
     /// reasoning blocks. Set by the caller when the selected `PromptTemplate` has
     /// `thinkingMarkers != nil`. Backends use this to activate `ThinkingParser`; backends that
     /// do not support thinking ignore it.
     public var thinkingMarkers: ThinkingMarkers?
 
-    @available(*, deprecated, message: "Use init(temperature:topP:repeatPenalty:topK:typicalP:maxOutputTokens:) instead.")
+    @available(*, deprecated, message: "Use init(temperature:topP:repeatPenalty:topK:typicalP:maxOutputTokens:tools:toolChoice:maxThinkingTokens:jsonMode:thinkingMarkers:) instead.")
     public init(
         temperature: Float = 0.7,
         topP: Float = 0.9,
@@ -71,6 +77,7 @@ public struct GenerationConfig: Sendable, Codable {
         tools: [ToolDefinition] = [],
         toolChoice: ToolChoice = .auto,
         maxThinkingTokens: Int? = nil,
+        jsonMode: Bool = false,
         thinkingMarkers: ThinkingMarkers? = nil
     ) {
         self.temperature = temperature
@@ -83,6 +90,7 @@ public struct GenerationConfig: Sendable, Codable {
         self.tools = tools
         self.toolChoice = toolChoice
         self.maxThinkingTokens = maxThinkingTokens
+        self.jsonMode = jsonMode
         self.thinkingMarkers = thinkingMarkers
     }
 
@@ -96,6 +104,7 @@ public struct GenerationConfig: Sendable, Codable {
         tools: [ToolDefinition] = [],
         toolChoice: ToolChoice = .auto,
         maxThinkingTokens: Int? = nil,
+        jsonMode: Bool = false,
         thinkingMarkers: ThinkingMarkers? = nil
     ) {
         self.temperature = temperature
@@ -108,6 +117,7 @@ public struct GenerationConfig: Sendable, Codable {
         self.tools = tools
         self.toolChoice = toolChoice
         self.maxThinkingTokens = maxThinkingTokens
+        self.jsonMode = jsonMode
         self.thinkingMarkers = thinkingMarkers
     }
 
@@ -115,7 +125,7 @@ public struct GenerationConfig: Sendable, Codable {
 
     private enum CodingKeys: String, CodingKey {
         case temperature, topP, repeatPenalty, maxTokens, topK, typicalP, maxOutputTokens
-        case tools, toolChoice, maxThinkingTokens
+        case tools, toolChoice, maxThinkingTokens, jsonMode
     }
 
     public init(from decoder: Decoder) throws {
@@ -128,10 +138,11 @@ public struct GenerationConfig: Sendable, Codable {
         topK = try c.decodeIfPresent(Int32.self, forKey: .topK)
         typicalP = try c.decodeIfPresent(Float.self, forKey: .typicalP)
         maxOutputTokens = try c.decodeIfPresent(Int.self, forKey: .maxOutputTokens)
-        // New fields added in v0.10; absent from payloads serialised before their introduction.
+        // New fields added after the original shape; absent from older payloads.
         tools = (try c.decodeIfPresent([ToolDefinition].self, forKey: .tools)) ?? []
         toolChoice = (try c.decodeIfPresent(ToolChoice.self, forKey: .toolChoice)) ?? .auto
         maxThinkingTokens = try c.decodeIfPresent(Int.self, forKey: .maxThinkingTokens)
+        jsonMode = (try c.decodeIfPresent(Bool.self, forKey: .jsonMode)) ?? false
         // thinkingMarkers is a per-request runtime hint; it is not persisted.
         thinkingMarkers = nil
     }
@@ -148,6 +159,7 @@ public struct GenerationConfig: Sendable, Codable {
         try c.encode(tools, forKey: .tools)
         try c.encode(toolChoice, forKey: .toolChoice)
         try c.encodeIfPresent(maxThinkingTokens, forKey: .maxThinkingTokens)
+        try c.encode(jsonMode, forKey: .jsonMode)
     }
 }
 

--- a/Sources/BaseChatInference/Services/GenerationCoordinator.swift
+++ b/Sources/BaseChatInference/Services/GenerationCoordinator.swift
@@ -88,7 +88,8 @@ final class GenerationCoordinator {
         topP: Float = 0.9,
         repeatPenalty: Float = 1.1,
         maxOutputTokens: Int? = 2048,
-        maxThinkingTokens: Int? = nil
+        maxThinkingTokens: Int? = nil,
+        jsonMode: Bool = false
     ) throws -> GenerationStream {
         guard let backend = provider?.currentBackend else {
             throw InferenceError.inferenceFailure("No model loaded")
@@ -98,7 +99,8 @@ final class GenerationCoordinator {
             temperature: temperature,
             topP: topP,
             repeatPenalty: repeatPenalty,
-            maxOutputTokens: maxOutputTokens
+            maxOutputTokens: maxOutputTokens,
+            jsonMode: jsonMode
         )
         config.maxThinkingTokens = maxThinkingTokens
 
@@ -260,6 +262,7 @@ final class GenerationCoordinator {
         repeatPenalty: Float = 1.1,
         maxOutputTokens: Int? = 2048,
         maxThinkingTokens: Int? = nil,
+        jsonMode: Bool = false,
         priority: GenerationPriority = .normal,
         sessionID: UUID? = nil
     ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
@@ -283,7 +286,8 @@ final class GenerationCoordinator {
             temperature: temperature,
             topP: topP,
             repeatPenalty: repeatPenalty,
-            maxOutputTokens: maxOutputTokens
+            maxOutputTokens: maxOutputTokens,
+            jsonMode: jsonMode
         )
         config.maxThinkingTokens = maxThinkingTokens
 
@@ -358,7 +362,8 @@ final class GenerationCoordinator {
                     topP: next.config.topP,
                     repeatPenalty: next.config.repeatPenalty,
                     maxOutputTokens: next.config.maxOutputTokens,
-                    maxThinkingTokens: next.config.maxThinkingTokens
+                    maxThinkingTokens: next.config.maxThinkingTokens,
+                    jsonMode: next.config.jsonMode
                 )
 
                 for try await event in backendStream.events {

--- a/Sources/BaseChatInference/Services/GenerationCoordinator.swift
+++ b/Sources/BaseChatInference/Services/GenerationCoordinator.swift
@@ -30,6 +30,17 @@ final class GenerationCoordinator {
     /// non-isolated so it is safe under Swift 6 strict concurrency.
     private let thermalStateProvider: @Sendable () -> ProcessInfo.ThermalState
 
+    // MARK: - Test Seam
+
+    /// Test-only hook invoked alongside `Log.inference.warning` when
+    /// `jsonMode=true` is requested on a backend whose capabilities report
+    /// `supportsNativeJSONMode == false`. Receives `(backendTypeName, message)`.
+    ///
+    /// Production callers never set this; it exists so unit tests can verify
+    /// the silent-ignore warning is emitted without standing up an OSLogStore
+    /// reader. Tests must reset it in `tearDown` to avoid cross-test leakage.
+    nonisolated(unsafe) static var jsonModeUnsupportedWarningHook: (@Sendable (String, String) -> Void)?
+
     // MARK: - Queue Types (Private)
 
     private struct QueuedRequest {
@@ -93,6 +104,19 @@ final class GenerationCoordinator {
     ) throws -> GenerationStream {
         guard let backend = provider?.currentBackend else {
             throw InferenceError.inferenceFailure("No model loaded")
+        }
+
+        // Single pre-dispatch chokepoint for the native-JSON-mode capability
+        // check. Backends without native JSON-mode support silently ignore
+        // the flag and return plain text, so we warn once per request here
+        // rather than in each backend. Callers can branch on
+        // `backend.capabilities.supportsNativeJSONMode` programmatically to
+        // suppress the warning by not setting the flag in the first place.
+        if jsonMode && !backend.capabilities.supportsNativeJSONMode {
+            let backendType = String(describing: type(of: backend))
+            let message = "GenerationCoordinator: jsonMode=true requested but \(backendType) does not support native JSON mode (capabilities.supportsNativeJSONMode == false); the flag will be ignored and the response will be plain text. Check `backend.capabilities.supportsNativeJSONMode` before setting `config.jsonMode`."
+            Log.inference.warning("\(message, privacy: .public)")
+            Self.jsonModeUnsupportedWarningHook?(backendType, message)
         }
 
         var config = GenerationConfig(

--- a/Sources/BaseChatInference/Services/InferenceService.swift
+++ b/Sources/BaseChatInference/Services/InferenceService.swift
@@ -175,7 +175,8 @@ public final class InferenceService {
         topP: Float = 0.9,
         repeatPenalty: Float = 1.1,
         maxOutputTokens: Int? = 2048,
-        maxThinkingTokens: Int? = nil
+        maxThinkingTokens: Int? = nil,
+        jsonMode: Bool = false
     ) throws -> GenerationStream {
         ensureProviderWired()
         return try generation.generate(
@@ -185,7 +186,8 @@ public final class InferenceService {
             topP: topP,
             repeatPenalty: repeatPenalty,
             maxOutputTokens: maxOutputTokens,
-            maxThinkingTokens: maxThinkingTokens
+            maxThinkingTokens: maxThinkingTokens,
+            jsonMode: jsonMode
         )
     }
 
@@ -203,6 +205,7 @@ public final class InferenceService {
         repeatPenalty: Float = 1.1,
         maxOutputTokens: Int? = 2048,
         maxThinkingTokens: Int? = nil,
+        jsonMode: Bool = false,
         priority: GenerationPriority = .normal,
         sessionID: UUID? = nil
     ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
@@ -215,6 +218,7 @@ public final class InferenceService {
             repeatPenalty: repeatPenalty,
             maxOutputTokens: maxOutputTokens,
             maxThinkingTokens: maxThinkingTokens,
+            jsonMode: jsonMode,
             priority: priority,
             sessionID: sessionID
         )

--- a/Tests/BaseChatBackendsTests/BackendCapabilitiesContractTests.swift
+++ b/Tests/BaseChatBackendsTests/BackendCapabilitiesContractTests.swift
@@ -44,6 +44,15 @@ final class BackendCapabilitiesContractTests: XCTestCase {
                       "OpenAIBackend supports structured output via json_schema")
     }
 
+    func test_backends_nativeJSONModeCapabilities() {
+        XCTAssertFalse(ClaudeBackend().capabilities.supportsNativeJSONMode,
+                       "ClaudeBackend does not advertise a dedicated native JSON mode")
+        XCTAssertTrue(OpenAIBackend().capabilities.supportsNativeJSONMode,
+                      "OpenAIBackend supports response_format json_object")
+        XCTAssertTrue(OllamaBackend().capabilities.supportsNativeJSONMode,
+                      "OllamaBackend supports format=json")
+    }
+
     // MARK: - Local backends
 
 #if Llama
@@ -64,6 +73,15 @@ final class BackendCapabilitiesContractTests: XCTestCase {
         XCTAssertFalse(LlamaBackend().capabilities.supportsToolCalling,
                        "LlamaBackend does not support tool calling natively")
     }
+
+    func test_llamaBackend_doesNotSupportNativeJSONMode() throws {
+        try XCTSkipUnless(HardwareRequirements.isPhysicalDevice,
+                          "LlamaBackend requires Metal (unavailable in simulator)")
+        try XCTSkipUnless(HardwareRequirements.isAppleSilicon,
+                          "LlamaBackend requires Apple Silicon")
+        XCTAssertFalse(LlamaBackend().capabilities.supportsNativeJSONMode,
+                       "LlamaBackend does not expose a native JSON mode")
+    }
 #endif
 
 #if MLX
@@ -72,6 +90,8 @@ final class BackendCapabilitiesContractTests: XCTestCase {
                           "MLXBackend requires Apple Silicon")
         XCTAssertFalse(MLXBackend().capabilities.isRemote,
                        "MLXBackend runs on-device — isRemote must be false")
+        XCTAssertFalse(MLXBackend().capabilities.supportsNativeJSONMode,
+                       "MLXBackend does not expose a native JSON mode")
     }
 #endif
 
@@ -86,6 +106,12 @@ final class BackendCapabilitiesContractTests: XCTestCase {
     func test_foundationBackend_doesNotSupportToolCalling() {
         XCTAssertFalse(FoundationBackend().capabilities.supportsToolCalling,
                        "FoundationBackend does not expose tool calling in this version")
+    }
+
+    @available(iOS 26, macOS 26, *)
+    func test_foundationBackend_doesNotSupportNativeJSONMode() {
+        XCTAssertFalse(FoundationBackend().capabilities.supportsNativeJSONMode,
+                       "FoundationBackend does not expose a native JSON mode in this version")
     }
 #endif
 }

--- a/Tests/BaseChatBackendsTests/OllamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/OllamaBackendTests.swift
@@ -118,6 +118,36 @@ struct OllamaBackendTests {
         #expect(!OllamaBackend().capabilities.requiresPromptTemplate)
     }
 
+    @Test func capabilities_supportsNativeJSONMode() {
+        #expect(OllamaBackend().capabilities.supportsNativeJSONMode)
+    }
+
+    @Test func buildRequest_jsonModeEnabled_addsFormat() throws {
+        let (backend, _) = makeConfiguredBackend()
+        let request = try backend.buildRequest(
+            prompt: "hello",
+            systemPrompt: nil,
+            config: GenerationConfig(jsonMode: true)
+        )
+
+        let body = try #require(request.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        #expect(json["format"] as? String == "json")
+    }
+
+    @Test func buildRequest_jsonModeDisabled_omitsFormat() throws {
+        let (backend, _) = makeConfiguredBackend()
+        let request = try backend.buildRequest(
+            prompt: "hello",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        let body = try #require(request.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        #expect(json["format"] == nil)
+    }
+
     // MARK: - Streaming
 
     @Test func streaming_yieldsTokens() async throws {

--- a/Tests/BaseChatBackendsTests/OpenAIBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/OpenAIBackendTests.swift
@@ -35,6 +35,10 @@ final class OpenAIBackendTests: XCTestCase {
         XCTAssertTrue(backend.capabilities.supportsSystemPrompt)
     }
 
+    func test_capabilities_supportsNativeJSONMode() {
+        XCTAssertTrue(OpenAIBackend().capabilities.supportsNativeJSONMode)
+    }
+
     // MARK: - Model Lifecycle
 
     func test_loadModel_withoutConfiguration_throws() async {
@@ -133,6 +137,45 @@ final class OpenAIBackendTests: XCTestCase {
                      "plan.effectiveContextSize must not appear in the request body")
         XCTAssertNil(json["context_size"],
                      "plan.effectiveContextSize must not appear in the request body")
+    }
+
+    func test_buildRequest_jsonModeEnabled_addsResponseFormat() throws {
+        let backend = OpenAIBackend()
+        backend.configure(
+            baseURL: URL(string: "https://api.openai.com")!,
+            apiKey: "sk-test",
+            modelName: "gpt-4o-mini"
+        )
+
+        let request = try backend.buildRequest(
+            prompt: "hello",
+            systemPrompt: nil,
+            config: GenerationConfig(jsonMode: true)
+        )
+        let body = try XCTUnwrap(request.httpBody)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let responseFormat = try XCTUnwrap(json["response_format"] as? [String: Any])
+
+        XCTAssertEqual(responseFormat["type"] as? String, "json_object")
+    }
+
+    func test_buildRequest_jsonModeDisabled_omitsResponseFormat() throws {
+        let backend = OpenAIBackend()
+        backend.configure(
+            baseURL: URL(string: "https://api.openai.com")!,
+            apiKey: "sk-test",
+            modelName: "gpt-4o-mini"
+        )
+
+        let request = try backend.buildRequest(
+            prompt: "hello",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+        let body = try XCTUnwrap(request.httpBody)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+        XCTAssertNil(json["response_format"])
     }
 
     // MARK: - Token Extraction (indirect via SSE + JSON)
@@ -311,4 +354,3 @@ extension OpenAIBackendTests {
         BackendContractChecks.assertAllInvariants { OpenAIBackend() }
     }
 }
-

--- a/Tests/BaseChatInferenceTests/BackendCapabilitiesTests.swift
+++ b/Tests/BaseChatInferenceTests/BackendCapabilitiesTests.swift
@@ -65,6 +65,7 @@ final class BackendCapabilitiesTests: XCTestCase {
 
         XCTAssertFalse(caps.supportsToolCalling)
         XCTAssertFalse(caps.supportsStructuredOutput)
+        XCTAssertFalse(caps.supportsNativeJSONMode)
         XCTAssertEqual(caps.cancellationStyle, .cooperative)
         XCTAssertFalse(caps.supportsTokenCounting)
     }
@@ -79,6 +80,7 @@ final class BackendCapabilitiesTests: XCTestCase {
             supportsSystemPrompt: true,
             supportsToolCalling: true,
             supportsStructuredOutput: true,
+            supportsNativeJSONMode: true,
             cancellationStyle: .explicit,
             supportsTokenCounting: true
         )
@@ -89,6 +91,7 @@ final class BackendCapabilitiesTests: XCTestCase {
         XCTAssertTrue(caps.supportsSystemPrompt)
         XCTAssertTrue(caps.supportsToolCalling)
         XCTAssertTrue(caps.supportsStructuredOutput)
+        XCTAssertTrue(caps.supportsNativeJSONMode)
         XCTAssertEqual(caps.cancellationStyle, .explicit)
         XCTAssertTrue(caps.supportsTokenCounting)
     }
@@ -224,6 +227,7 @@ final class BackendCapabilitiesTests: XCTestCase {
             supportsSystemPrompt: true,
             supportsToolCalling: true,
             supportsStructuredOutput: true,
+            supportsNativeJSONMode: true,
             cancellationStyle: .cooperative,
             supportsTokenCounting: false,
             memoryStrategy: .external,
@@ -235,6 +239,7 @@ final class BackendCapabilitiesTests: XCTestCase {
         XCTAssertEqual(caps.maxOutputTokens, 8192)
         XCTAssertTrue(caps.supportsStreaming)
         XCTAssertTrue(caps.isRemote)
+        XCTAssertTrue(caps.supportsNativeJSONMode)
     }
 
     func test_fullInitializer_newFieldsDefaultValues() {
@@ -251,6 +256,7 @@ final class BackendCapabilitiesTests: XCTestCase {
         XCTAssertEqual(caps.maxOutputTokens, 4096)
         XCTAssertTrue(caps.supportsStreaming)
         XCTAssertFalse(caps.isRemote)
+        XCTAssertFalse(caps.supportsNativeJSONMode)
     }
 
     // MARK: - Codable round-trip
@@ -263,6 +269,7 @@ final class BackendCapabilitiesTests: XCTestCase {
             supportsSystemPrompt: true,
             supportsToolCalling: true,
             supportsStructuredOutput: true,
+            supportsNativeJSONMode: true,
             cancellationStyle: .cooperative,
             supportsTokenCounting: false,
             memoryStrategy: .external,
@@ -279,6 +286,7 @@ final class BackendCapabilitiesTests: XCTestCase {
         XCTAssertEqual(decoded.maxOutputTokens, 16_384)
         XCTAssertTrue(decoded.supportsStreaming)
         XCTAssertTrue(decoded.isRemote)
+        XCTAssertTrue(decoded.supportsNativeJSONMode)
     }
 
     func test_codable_roundTrip_allMemoryStrategies() throws {
@@ -315,6 +323,7 @@ final class BackendCapabilitiesTests: XCTestCase {
             "supportsStreaming": true,
             "supportsToolCalling": true,
             "supportsStructuredOutput": true,
+            "supportsNativeJSONMode": true,
             "cancellationStyle": "cooperative",
             "supportsTokenCounting": true,
             "memoryStrategy": "external",
@@ -335,10 +344,34 @@ final class BackendCapabilitiesTests: XCTestCase {
         XCTAssertTrue(decoded.supportsStreaming)
         XCTAssertTrue(decoded.supportsToolCalling)
         XCTAssertTrue(decoded.supportsStructuredOutput)
+        XCTAssertTrue(decoded.supportsNativeJSONMode)
         XCTAssertEqual(decoded.cancellationStyle, .cooperative)
         XCTAssertTrue(decoded.supportsTokenCounting)
         XCTAssertEqual(decoded.memoryStrategy, .external)
         XCTAssertFalse(decoded.isRemote)
+    }
+
+    func test_codable_missingSupportsNativeJSONMode_defaultsFalse() throws {
+        let json = """
+        {
+            "supportedParameters": ["temperature"],
+            "maxContextTokens": 4096,
+            "maxOutputTokens": 2048,
+            "requiresPromptTemplate": false,
+            "supportsSystemPrompt": true,
+            "supportsStreaming": true,
+            "supportsToolCalling": false,
+            "supportsStructuredOutput": false,
+            "cancellationStyle": "cooperative",
+            "supportsTokenCounting": false,
+            "memoryStrategy": "resident",
+            "isRemote": false
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(BackendCapabilities.self, from: json)
+
+        XCTAssertFalse(decoded.supportsNativeJSONMode)
     }
 
     // MARK: - PromptAssembler reads contextWindowSize from capabilities
@@ -378,6 +411,7 @@ final class BackendCapabilitiesTests: XCTestCase {
         XCTAssertTrue(caps.supportsSystemPrompt)
         XCTAssertFalse(caps.supportsToolCalling)
         XCTAssertFalse(caps.supportsStructuredOutput)
+        XCTAssertFalse(caps.supportsNativeJSONMode)
         XCTAssertEqual(caps.cancellationStyle, .cooperative)
         XCTAssertFalse(caps.supportsTokenCounting)
         XCTAssertEqual(caps.memoryStrategy, .resident)

--- a/Tests/BaseChatInferenceTests/GenerationConfigTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationConfigTests.swift
@@ -26,6 +26,11 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertEqual(config.maxOutputTokens, 2048)
     }
 
+    func test_defaultInit_jsonMode() {
+        let config = GenerationConfig()
+        XCTAssertFalse(config.jsonMode)
+    }
+
     // MARK: - Custom Init
 
     func test_customInit_propagatesAllValues() {
@@ -33,13 +38,15 @@ final class GenerationConfigTests: XCTestCase {
             temperature: 1.2,
             topP: 0.95,
             repeatPenalty: 1.5,
-            maxOutputTokens: 2048
+            maxOutputTokens: 2048,
+            jsonMode: true
         )
 
         XCTAssertEqual(config.temperature, 1.2, accuracy: 0.001)
         XCTAssertEqual(config.topP, 0.95, accuracy: 0.001)
         XCTAssertEqual(config.repeatPenalty, 1.5, accuracy: 0.001)
         XCTAssertEqual(config.maxOutputTokens, 2048)
+        XCTAssertTrue(config.jsonMode)
     }
 
     func test_customInit_partialOverride() {
@@ -65,6 +72,12 @@ final class GenerationConfigTests: XCTestCase {
         var config = GenerationConfig()
         config.maxOutputTokens = 512
         XCTAssertEqual(config.maxOutputTokens, 512)
+    }
+
+    func test_jsonMode_isMutable() {
+        var config = GenerationConfig()
+        config.jsonMode = true
+        XCTAssertTrue(config.jsonMode)
     }
 
     // MARK: - Mock Backend Captures maxOutputTokens

--- a/Tests/BaseChatInferenceTests/GenerationCoordinatorTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationCoordinatorTests.swift
@@ -53,6 +53,18 @@ final class GenerationCoordinatorTests: XCTestCase {
 
     // MARK: - Queue overflow
 
+    func test_generate_jsonMode_forwardsToBackend() async throws {
+        let stream = try coordinator.generate(
+            messages: [("user", "Return JSON")],
+            jsonMode: true
+        )
+
+        for try await _ in stream.events {}
+
+        let config = try XCTUnwrap(provider.backend.lastConfig)
+        XCTAssertTrue(config.jsonMode)
+    }
+
     func test_enqueue_overQueueDepth_throwsQueueFullError() throws {
         // Saturate the coordinator: one active plus eight queued is the hard cap
         // (maxQueueDepth == 8 counts queued requests only).

--- a/Tests/BaseChatInferenceTests/GenerationCoordinatorTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationCoordinatorTests.swift
@@ -65,6 +65,101 @@ final class GenerationCoordinatorTests: XCTestCase {
         XCTAssertTrue(config.jsonMode)
     }
 
+    // MARK: - jsonMode silent-ignore warning (PR #615 review fix)
+
+    /// When `jsonMode=true` is passed and the active backend reports
+    /// `supportsNativeJSONMode == false`, the coordinator must emit a warning
+    /// before dispatching so callers have a signal that the flag is being
+    /// ignored. The test observes the warning via an internal hook; real
+    /// traffic also goes to `Log.inference.warning`, which OSLog renders to
+    /// Console.app.
+    ///
+    /// Sabotage check: deleting the warning branch in `GenerationCoordinator.generate`
+    /// leaves `captured` empty and this assertion fails.
+    func test_generate_jsonMode_unsupportedBackend_emitsWarning() async throws {
+        // MockInferenceBackend defaults to supportsNativeJSONMode == false.
+        let captured = WarningCapture()
+        GenerationCoordinator.jsonModeUnsupportedWarningHook = { backendType, message in
+            captured.record(backendType: backendType, message: message)
+        }
+        defer { GenerationCoordinator.jsonModeUnsupportedWarningHook = nil }
+
+        let stream = try coordinator.generate(
+            messages: [("user", "Return JSON")],
+            jsonMode: true
+        )
+        for try await _ in stream.events {}
+
+        let entries = captured.snapshot()
+        XCTAssertEqual(entries.count, 1, "warning must fire exactly once per request")
+        let first = try XCTUnwrap(entries.first)
+        XCTAssertEqual(first.backendType, "MockInferenceBackend",
+                       "warning must name the active backend type")
+        XCTAssertTrue(first.message.contains("jsonMode=true"),
+                      "warning message must mention the flag")
+        XCTAssertTrue(first.message.contains("supportsNativeJSONMode"),
+                      "warning must reference the capability flag so callers can check it programmatically")
+
+        // Silent-ignore must remain silent in the failure sense: the backend
+        // still receives the flag; the warning is additive, not blocking.
+        let config = try XCTUnwrap(provider.backend.lastConfig)
+        XCTAssertTrue(config.jsonMode)
+    }
+
+    /// When `jsonMode=false`, the warning must never fire regardless of the
+    /// backend's capability. This guards against a future regression that
+    /// accidentally flips the condition.
+    func test_generate_jsonModeFalse_neverWarns() async throws {
+        let captured = WarningCapture()
+        GenerationCoordinator.jsonModeUnsupportedWarningHook = { backendType, message in
+            captured.record(backendType: backendType, message: message)
+        }
+        defer { GenerationCoordinator.jsonModeUnsupportedWarningHook = nil }
+
+        let stream = try coordinator.generate(
+            messages: [("user", "Return plain")],
+            jsonMode: false
+        )
+        for try await _ in stream.events {}
+
+        XCTAssertTrue(captured.snapshot().isEmpty,
+                      "warning must not fire when jsonMode is disabled")
+    }
+
+    /// When the backend DOES support native JSON mode, the warning must not
+    /// fire. Simulated here by swapping in a capability set with
+    /// `supportsNativeJSONMode = true`.
+    func test_generate_jsonMode_supportedBackend_noWarning() async throws {
+        let captured = WarningCapture()
+        GenerationCoordinator.jsonModeUnsupportedWarningHook = { backendType, message in
+            captured.record(backendType: backendType, message: message)
+        }
+        defer { GenerationCoordinator.jsonModeUnsupportedWarningHook = nil }
+
+        provider.backend.capabilities = BackendCapabilities(
+            supportedParameters: [.temperature],
+            maxContextTokens: 4096,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsToolCalling: false,
+            supportsStructuredOutput: true,
+            supportsNativeJSONMode: true,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: false
+        )
+
+        let stream = try coordinator.generate(
+            messages: [("user", "Return JSON")],
+            jsonMode: true
+        )
+        for try await _ in stream.events {}
+
+        XCTAssertTrue(captured.snapshot().isEmpty,
+                      "warning must not fire when the backend supports native JSON mode")
+        let config = try XCTUnwrap(provider.backend.lastConfig)
+        XCTAssertTrue(config.jsonMode)
+    }
+
     func test_enqueue_overQueueDepth_throwsQueueFullError() throws {
         // Saturate the coordinator: one active plus eight queued is the hard cap
         // (maxQueueDepth == 8 counts queued requests only).
@@ -700,6 +795,33 @@ final class GenerationCoordinatorTests: XCTestCase {
         // generation.
         XCTAssertFalse(coord.isGenerating)
         XCTAssertNil(coord.provider as? SlowFakeProvider)
+    }
+}
+
+// MARK: - Warning capture (PR #615 review fix)
+
+/// Thread-safe collector for the `jsonModeUnsupportedWarningHook` on
+/// `GenerationCoordinator`. The hook is `@Sendable` and may fire from any
+/// isolation; an `NSLock` keeps recorded entries race-free without
+/// introducing actor hops into the test.
+private final class WarningCapture: @unchecked Sendable {
+    struct Entry {
+        let backendType: String
+        let message: String
+    }
+    private let lock = NSLock()
+    private var entries: [Entry] = []
+
+    func record(backendType: String, message: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        entries.append(Entry(backendType: backendType, message: message))
+    }
+
+    func snapshot() -> [Entry] {
+        lock.lock()
+        defer { lock.unlock() }
+        return entries
     }
 }
 

--- a/Tests/BaseChatInferenceTests/InferenceServiceQueueTests.swift
+++ b/Tests/BaseChatInferenceTests/InferenceServiceQueueTests.swift
@@ -26,6 +26,7 @@ final class InferenceServiceQueueTests: XCTestCase {
         /// Each call to generate() appends a continuation here. Tests release
         /// tokens by calling `release(at:tokens:)` or `releaseAll()`.
         var gates: [AsyncThrowingStream<GenerationEvent, Error>.Continuation] = []
+        var receivedConfigs: [GenerationConfig] = []
         var generateCallCount = 0
         var stopCallCount = 0
 
@@ -39,6 +40,7 @@ final class InferenceServiceQueueTests: XCTestCase {
             config: GenerationConfig
         ) throws -> GenerationStream {
             generateCallCount += 1
+            receivedConfigs.append(config)
             isGenerating = true
             let stream = AsyncThrowingStream<GenerationEvent, Error> { [weak self] continuation in
                 self?.gates.append(continuation)
@@ -167,6 +169,35 @@ final class InferenceServiceQueueTests: XCTestCase {
             }
         }
         XCTAssertEqual(collected, ["b"])
+    }
+
+    func test_enqueue_jsonMode_survivesQueueHandoff() async throws {
+        let (service, mock) = makeService()
+
+        let (_, firstStream) = try service.enqueue(
+            messages: [("user", "first")],
+            jsonMode: false,
+            priority: .normal
+        )
+        let (_, secondStream) = try service.enqueue(
+            messages: [("user", "second")],
+            jsonMode: true,
+            priority: .normal
+        )
+
+        await Task.yield()
+        mock.release(at: 0, tokens: ["a"])
+        for try await _ in firstStream.events {}
+
+        let firstConfig = try XCTUnwrap(mock.receivedConfigs.first)
+        XCTAssertFalse(firstConfig.jsonMode)
+
+        await Task.yield()
+        mock.release(at: 1, tokens: ["b"])
+        for try await _ in secondStream.events {}
+
+        XCTAssertEqual(mock.receivedConfigs.count, 2)
+        XCTAssertTrue(mock.receivedConfigs[1].jsonMode)
     }
 
     // MARK: - 3. Priority: userInitiated jumps ahead
@@ -763,4 +794,3 @@ final class InferenceServiceQueueTests: XCTestCase {
         }
     }
 }
-

--- a/Tests/BaseChatInferenceTests/ToolCallContractTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolCallContractTests.swift
@@ -133,7 +133,7 @@ final class ToolCallContractTests: XCTestCase {
     }
 
     func test_generationConfig_existingProperties_unaffected() throws {
-        // Adding tools/toolChoice fields must not break existing serialised GenerationConfig values.
+        // Adding tools/toolChoice/jsonMode fields must not break existing serialised GenerationConfig values.
         let config = GenerationConfig(temperature: 0.8, topP: 0.95, maxOutputTokens: 512)
 
         let encoded = try JSONEncoder().encode(config)
@@ -145,11 +145,26 @@ final class ToolCallContractTests: XCTestCase {
         // Defaults must survive the round-trip
         XCTAssertTrue(decoded.tools.isEmpty)
         XCTAssertEqual(decoded.toolChoice, .auto)
+        XCTAssertFalse(decoded.jsonMode)
+    }
+
+    func test_generationConfig_roundTrips_jsonMode() throws {
+        let config = GenerationConfig(
+            temperature: 0.8,
+            topP: 0.95,
+            maxOutputTokens: 512,
+            jsonMode: true
+        )
+
+        let encoded = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: encoded)
+
+        XCTAssertTrue(decoded.jsonMode)
     }
 
     func test_generationConfig_decodesLegacyJSON_withoutToolsOrToolChoice() throws {
-        // Payloads serialised before the tools/toolChoice fields were introduced must
-        // decode successfully, falling back to the canonical defaults ([] and .auto).
+        // Payloads serialised before the tools/toolChoice/jsonMode fields were introduced must
+        // decode successfully, falling back to the canonical defaults ([] / .auto / false).
         // Sabotage check: using `decode` instead of `decodeIfPresent` in init(from:)
         // causes a keyNotFound DecodingError here.
         let legacyJSON = """
@@ -161,6 +176,7 @@ final class ToolCallContractTests: XCTestCase {
         XCTAssertEqual(decoded.temperature, 0.7, accuracy: 0.001)
         XCTAssertTrue(decoded.tools.isEmpty, "Missing 'tools' key must default to []")
         XCTAssertEqual(decoded.toolChoice, .auto, "Missing 'toolChoice' key must default to .auto")
+        XCTAssertFalse(decoded.jsonMode, "Missing 'jsonMode' key must default to false")
     }
 
     // MARK: - MockInferenceBackend emits scripted tool calls


### PR DESCRIPTION
## Summary
- add `GenerationConfig.jsonMode` and thread it through direct and queued generation APIs
- add `BackendCapabilities.supportsNativeJSONMode` with backward-compatible decoding
- honor `jsonMode` in OpenAI-compatible and Ollama request bodies while leaving unsupported backends as no-ops
- add inference and backend coverage for config serialization, queue handoff, capability reporting, and request body mapping

## Testing
- swift test --filter BaseChatInferenceTests --disable-default-traits
- swift test --filter BaseChatBackendsTests --disable-default-traits

## Release Note
**Add native JSON mode request support** — BaseChatKit now exposes a per-request `jsonMode` flag that survives direct and queued generation paths, advertises native JSON-object capability separately from broader structured output, and maps that flag to OpenAI-compatible and Ollama wire formats where supported. This gives callers a backend-agnostic way to request JSON-only responses without branching on backend type, while unsupported backends continue to ignore the hint safely.

## Review fixes

- **Silent-ignore warning** (commit `d3db1c1`): when `config.jsonMode = true` is sent to a backend whose capabilities report `supportsNativeJSONMode == false` (Claude, Llama, MLX, Foundation today), the request used to fall through silently and the caller got plain text with no signal. `GenerationCoordinator.generate(...)` now emits `Log.inference.warning(...)` once per such request, naming the backend type and pointing at the capability flag so callers can branch on `backend.capabilities.supportsNativeJSONMode` programmatically.
- Placed at the single pre-dispatch chokepoint in `GenerationCoordinator` so one log statement covers the direct and queued generation paths and all current and future backends — keeping backends themselves agnostic of the capability check, which matches the PR's original intent.
- A small `@Sendable` test seam (`GenerationCoordinator.jsonModeUnsupportedWarningHook`) lets unit tests observe the warning without standing up an `OSLogStore` reader. Three new tests in `GenerationCoordinatorTests` cover: unsupported backend emits the warning exactly once and still forwards the flag; `jsonMode=false` never warns; native-JSON-mode-supporting backends never warn.
