### PR TITLE
feat(inference): ToolRegistry, TypedToolExecutor, and ToolResult.errorKind taxonomy

### DIFF
--- a/Sources/BaseChatInference/Models/ToolTypes.swift
+++ b/Sources/BaseChatInference/Models/ToolTypes.swift
@@ -176,6 +176,33 @@ public struct ToolCall: Sendable, Codable, Equatable, Hashable {
 /// into its final response.
 public struct ToolResult: Sendable, Codable, Equatable, Hashable {
 
+    /// Categorises why a tool call failed.
+    ///
+    /// ``ToolResult/errorKind`` is `nil` on success. When non-`nil` it classifies
+    /// the failure so backends, orchestrators, and UI surfaces can decide whether
+    /// to retry, surface a permission prompt, feed the error back to the model,
+    /// or abort the loop. The string raw values are stable on the wire.
+    public enum ErrorKind: String, Sendable, Codable, Equatable, Hashable {
+        /// Arguments did not parse as JSON or failed schema validation.
+        case invalidArguments
+        /// The caller lacks permission to run the tool (user denied, missing scope).
+        case permissionDenied
+        /// A resource referenced by the tool (file, record, URL) does not exist.
+        case notFound
+        /// The tool exceeded its time budget.
+        case timeout
+        /// The tool or an underlying service applied back-pressure.
+        case rateLimited
+        /// The tool execution was cancelled by the caller.
+        case cancelled
+        /// A transient failure — safe to retry without changing inputs.
+        case transient
+        /// A permanent failure — retrying with the same inputs will not help.
+        case permanent
+        /// The tool name did not match any registered executor.
+        case unknownTool
+    }
+
     /// The ``ToolCall/id`` this result corresponds to.
     public let callId: String
 
@@ -184,22 +211,73 @@ public struct ToolResult: Sendable, Codable, Equatable, Hashable {
     /// For structured data, JSON-encode it before assigning.
     public let content: String
 
+    /// Failure classification, or `nil` on success.
+    ///
+    /// Use this to drive retry/abort decisions in the orchestration loop and
+    /// to render friendlier error messages in UI. The legacy boolean
+    /// ``isError`` flag is derived from this field.
+    public let errorKind: ErrorKind?
+
     /// `true` when the tool execution failed.
     ///
+    /// Computed from ``errorKind`` — `errorKind != nil` means the call failed.
     /// Backends that support error context (e.g. OpenAI) surface this flag
     /// so the model can reason about the failure and potentially retry.
-    public let isError: Bool
+    public var isError: Bool { errorKind != nil }
 
     /// Creates a tool result.
     ///
     /// - Parameters:
     ///   - callId: The ``ToolCall/id`` this result belongs to.
     ///   - content: The tool's output string.
-    ///   - isError: Whether the execution failed. Defaults to `false`.
-    public init(callId: String, content: String, isError: Bool = false) {
+    ///   - errorKind: Failure classification, or `nil` on success. Defaults to `nil`.
+    public init(callId: String, content: String, errorKind: ErrorKind? = nil) {
         self.callId = callId
         self.content = content
-        self.isError = isError
+        self.errorKind = errorKind
+    }
+
+    /// Legacy initializer retained for backwards compatibility.
+    ///
+    /// Maps `isError == true` to ``ErrorKind/permanent`` and `isError == false`
+    /// to `nil`. New code should pass an explicit ``ErrorKind`` via the primary
+    /// initializer so the failure class is preserved on the wire.
+    @available(*, deprecated, renamed: "init(callId:content:errorKind:)")
+    public init(callId: String, content: String, isError: Bool) {
+        self.callId = callId
+        self.content = content
+        self.errorKind = isError ? .permanent : nil
+    }
+
+    // MARK: Codable
+
+    private enum CodingKeys: String, CodingKey {
+        case callId, content, errorKind, isError
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        callId = try c.decode(String.self, forKey: .callId)
+        content = try c.decode(String.self, forKey: .content)
+        // errorKind is authoritative when present. Otherwise fall back to the
+        // legacy `isError` boolean: true → .permanent, false → nil. This lets
+        // pre-v4 persisted ToolResults decode into the new shape without loss.
+        if let kind = try c.decodeIfPresent(ErrorKind.self, forKey: .errorKind) {
+            errorKind = kind
+        } else if let legacyIsError = try c.decodeIfPresent(Bool.self, forKey: .isError) {
+            errorKind = legacyIsError ? .permanent : nil
+        } else {
+            errorKind = nil
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(callId, forKey: .callId)
+        try c.encode(content, forKey: .content)
+        try c.encodeIfPresent(errorKind, forKey: .errorKind)
+        // `isError` is intentionally NOT encoded — it is derived from errorKind
+        // and emitting it would put two sources of truth on the wire.
     }
 }
 

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -65,7 +65,22 @@ public struct GenerationConfig: Sendable, Codable {
     /// do not support thinking ignore it.
     public var thinkingMarkers: ThinkingMarkers?
 
-    @available(*, deprecated, message: "Use init(temperature:topP:repeatPenalty:topK:typicalP:maxOutputTokens:tools:toolChoice:maxThinkingTokens:jsonMode:thinkingMarkers:) instead.")
+    /// Maximum number of tool-call iterations permitted inside a single
+    /// generation request.
+    ///
+    /// When the coordinator detects a ``ToolCall`` in the stream it dispatches
+    /// the call, appends the ``ToolResult``, and re-prompts the model. Each
+    /// round trip is one "iteration". This cap bounds runaway tool-call loops
+    /// where a misbehaving model keeps requesting tools without finalising a
+    /// user-visible response.
+    ///
+    /// Defaults to `10`. Values `<= 0` are silently clamped to `1` — a zero
+    /// budget would prevent any tool dispatch at all and is never the intent.
+    public var maxToolIterations: Int {
+        didSet { if maxToolIterations < 1 { maxToolIterations = 1 } }
+    }
+
+    @available(*, deprecated, message: "Use init(temperature:topP:repeatPenalty:topK:typicalP:maxOutputTokens:tools:toolChoice:maxThinkingTokens:jsonMode:thinkingMarkers:maxToolIterations:) instead.")
     public init(
         temperature: Float = 0.7,
         topP: Float = 0.9,
@@ -78,7 +93,8 @@ public struct GenerationConfig: Sendable, Codable {
         toolChoice: ToolChoice = .auto,
         maxThinkingTokens: Int? = nil,
         jsonMode: Bool = false,
-        thinkingMarkers: ThinkingMarkers? = nil
+        thinkingMarkers: ThinkingMarkers? = nil,
+        maxToolIterations: Int = 10
     ) {
         self.temperature = temperature
         self.topP = topP
@@ -92,6 +108,7 @@ public struct GenerationConfig: Sendable, Codable {
         self.maxThinkingTokens = maxThinkingTokens
         self.jsonMode = jsonMode
         self.thinkingMarkers = thinkingMarkers
+        self.maxToolIterations = max(1, maxToolIterations)
     }
 
     public init(
@@ -105,7 +122,8 @@ public struct GenerationConfig: Sendable, Codable {
         toolChoice: ToolChoice = .auto,
         maxThinkingTokens: Int? = nil,
         jsonMode: Bool = false,
-        thinkingMarkers: ThinkingMarkers? = nil
+        thinkingMarkers: ThinkingMarkers? = nil,
+        maxToolIterations: Int = 10
     ) {
         self.temperature = temperature
         self.topP = topP
@@ -119,13 +137,14 @@ public struct GenerationConfig: Sendable, Codable {
         self.maxThinkingTokens = maxThinkingTokens
         self.jsonMode = jsonMode
         self.thinkingMarkers = thinkingMarkers
+        self.maxToolIterations = max(1, maxToolIterations)
     }
 
     // MARK: Codable
 
     private enum CodingKeys: String, CodingKey {
         case temperature, topP, repeatPenalty, maxTokens, topK, typicalP, maxOutputTokens
-        case tools, toolChoice, maxThinkingTokens, jsonMode
+        case tools, toolChoice, maxThinkingTokens, jsonMode, maxToolIterations
     }
 
     public init(from decoder: Decoder) throws {
@@ -143,6 +162,10 @@ public struct GenerationConfig: Sendable, Codable {
         toolChoice = (try c.decodeIfPresent(ToolChoice.self, forKey: .toolChoice)) ?? .auto
         maxThinkingTokens = try c.decodeIfPresent(Int.self, forKey: .maxThinkingTokens)
         jsonMode = (try c.decodeIfPresent(Bool.self, forKey: .jsonMode)) ?? false
+        // maxToolIterations landed after the original shape; default to 10 when absent and
+        // clamp any persisted zero/negative value to the minimum of 1.
+        let decodedIterations = (try c.decodeIfPresent(Int.self, forKey: .maxToolIterations)) ?? 10
+        maxToolIterations = max(1, decodedIterations)
         // thinkingMarkers is a per-request runtime hint; it is not persisted.
         thinkingMarkers = nil
     }
@@ -160,6 +183,7 @@ public struct GenerationConfig: Sendable, Codable {
         try c.encode(toolChoice, forKey: .toolChoice)
         try c.encodeIfPresent(maxThinkingTokens, forKey: .maxThinkingTokens)
         try c.encode(jsonMode, forKey: .jsonMode)
+        try c.encode(maxToolIterations, forKey: .maxToolIterations)
     }
 }
 

--- a/Sources/BaseChatInference/Services/GenerationCoordinator.swift
+++ b/Sources/BaseChatInference/Services/GenerationCoordinator.swift
@@ -30,6 +30,12 @@ final class GenerationCoordinator {
     /// non-isolated so it is safe under Swift 6 strict concurrency.
     private let thermalStateProvider: @Sendable () -> ProcessInfo.ThermalState
 
+    /// Optional registry used to dispatch model-emitted ``ToolCall`` events.
+    ///
+    /// Stored here in wave 1 so the coordinator's init surface is stable for
+    /// downstream wiring; the actual dispatch site lands in wave 2 Agent D.
+    let toolRegistry: ToolRegistry?
+
     // MARK: - Test Seam
 
     /// Test-only hook invoked alongside `Log.inference.warning` when
@@ -73,9 +79,11 @@ final class GenerationCoordinator {
     // MARK: - Initializers
 
     nonisolated init(
-        thermalStateProvider: @Sendable @escaping () -> ProcessInfo.ThermalState = { ProcessInfo.processInfo.thermalState }
+        thermalStateProvider: @Sendable @escaping () -> ProcessInfo.ThermalState = { ProcessInfo.processInfo.thermalState },
+        toolRegistry: ToolRegistry? = nil
     ) {
         self.thermalStateProvider = thermalStateProvider
+        self.toolRegistry = toolRegistry
     }
 
     // MARK: - Generation (Non-Queued)
@@ -395,6 +403,7 @@ final class GenerationCoordinator {
                     if case .token = event, next.stream.phase != .streaming {
                         next.stream.setPhase(.streaming)
                     }
+                    // wave 2 dispatches via toolRegistry here
                     self.continuations[next.token]?.yield(event)
                 }
 

--- a/Sources/BaseChatInference/Services/ToolExecutor.swift
+++ b/Sources/BaseChatInference/Services/ToolExecutor.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+// MARK: - ToolExecutor
+
+/// A runtime-executable tool definition.
+///
+/// Conformers pair a ``ToolDefinition`` (the JSON-Schema contract the model
+/// sees) with an `execute(arguments:)` hook that runs the tool and returns a
+/// ``ToolResult``. Executors are stored in a ``ToolRegistry`` and dispatched
+/// by the orchestration loop when the model emits a ``ToolCall``.
+///
+/// ## Arguments type
+///
+/// The protocol intentionally takes ``JSONSchemaValue`` — not a raw `String`
+/// — so adapter layers (MCP bridges, AppIntents, macro-generated tools) can
+/// hand a structured, already-parsed argument tree to the executor without
+/// re-serialising through a string. ``ToolRegistry/dispatch(_:)`` handles the
+/// `String`→`JSONSchemaValue` parse at the registry boundary.
+///
+/// ## Typed adapter
+///
+/// Most callers do not implement this protocol directly. Use
+/// ``TypedToolExecutor`` to wrap a strongly-typed Swift handler — the adapter
+/// handles JSON encode/decode on both sides so the handler signature stays
+/// free of `JSONSchemaValue`.
+public protocol ToolExecutor: Sendable {
+
+    /// The JSON-Schema contract exposed to the model and the ``ToolRegistry``
+    /// lookup key. ``ToolDefinition/name`` must be unique within a registry
+    /// (case-insensitive).
+    var definition: ToolDefinition { get }
+
+    /// Executes the tool with already-parsed JSON arguments.
+    ///
+    /// The returned ``ToolResult/callId`` may be empty — ``ToolRegistry``
+    /// stamps the correct id from the incoming ``ToolCall`` before returning
+    /// the result to the caller. Thrown errors are caught by the registry and
+    /// turned into ``ToolResult/ErrorKind/permanent`` results.
+    func execute(arguments: JSONSchemaValue) async throws -> ToolResult
+}
+
+// MARK: - TypedToolExecutor
+
+/// Generic adapter that exposes a strongly-typed Swift handler as a
+/// ``ToolExecutor``.
+///
+/// The adapter owns three responsibilities:
+/// 1. Decode the incoming ``JSONSchemaValue`` into `Arguments` via `JSONDecoder`.
+/// 2. Call the handler.
+/// 3. Encode the handler's `Result` as a JSON string and wrap it in a ``ToolResult``.
+///
+/// ```swift
+/// struct WeatherArgs: Decodable, Sendable { let city: String }
+/// struct WeatherResult: Encodable, Sendable { let summary: String; let celsius: Double }
+///
+/// let weather = TypedToolExecutor<WeatherArgs, WeatherResult>(
+///     definition: ToolDefinition(name: "get_weather", description: "Returns weather.", parameters: schema)
+/// ) { args in
+///     WeatherResult(summary: "Sunny", celsius: 22.0)
+/// }
+/// registry.register(weather)
+/// ```
+///
+/// Decode or encode failures throw — ``ToolRegistry/dispatch(_:)`` catches them
+/// and returns a ``ToolResult/ErrorKind/permanent`` result. Malformed JSON in
+/// the raw ``ToolCall/arguments`` string is classified as
+/// ``ToolResult/ErrorKind/invalidArguments`` at the registry boundary before
+/// this adapter sees it.
+public struct TypedToolExecutor<Arguments: Decodable & Sendable, Result: Encodable & Sendable>: ToolExecutor {
+
+    public let definition: ToolDefinition
+
+    private let handler: @Sendable (Arguments) async throws -> Result
+
+    /// Creates a typed executor.
+    ///
+    /// - Parameters:
+    ///   - definition: The tool contract exposed to the model. ``ToolDefinition/parameters``
+    ///     should describe the JSON shape of `Arguments`.
+    ///   - handler: Runs the tool. Thrown errors become ``ToolResult/ErrorKind/permanent``
+    ///     results at the registry layer.
+    public init(
+        definition: ToolDefinition,
+        handler: @Sendable @escaping (Arguments) async throws -> Result
+    ) {
+        self.definition = definition
+        self.handler = handler
+    }
+
+    public func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+        // Route through Data so we don't need a bespoke bridge between
+        // JSONSchemaValue and arbitrary Decodable types — Foundation already
+        // handles the decode perfectly via the standard JSON path.
+        let argsData = try JSONEncoder().encode(arguments)
+        let decoded = try JSONDecoder().decode(Arguments.self, from: argsData)
+        let result = try await handler(decoded)
+
+        let resultData = try JSONEncoder().encode(result)
+        // Prefer a UTF-8 string so the model receives readable JSON rather than
+        // base64. JSON encoders always emit valid UTF-8, so the force is safe.
+        let content = String(data: resultData, encoding: .utf8) ?? ""
+
+        // callId is intentionally empty here — ToolRegistry.dispatch stamps the
+        // correct id from the incoming ToolCall before returning to the caller.
+        return ToolResult(callId: "", content: content, errorKind: nil)
+    }
+}

--- a/Sources/BaseChatInference/Services/ToolRegistry.swift
+++ b/Sources/BaseChatInference/Services/ToolRegistry.swift
@@ -1,0 +1,193 @@
+import Foundation
+
+// MARK: - JSONSchemaValidating (wave 2 hook)
+
+/// Validates a parsed JSON argument payload against a ``JSONSchemaValue``
+/// schema.
+///
+/// ``ToolRegistry`` depends on this protocol rather than the concrete
+/// ``JSONSchemaValidator`` struct so tests can inject a stub and wave-2 wiring
+/// can evolve without breaking ABI. The production conformer is
+/// ``JSONSchemaValidator`` (see `JSONSchemaValidator.swift`); it returns the
+/// richer ``JSONSchemaValidator/ValidationFailure`` internally and adapts it to
+/// the `String?` shape here so the registry stays protocol-friendly.
+public protocol JSONSchemaValidating: Sendable {
+
+    /// Returns `nil` when `value` satisfies `schema`, or a human-readable
+    /// error description when it does not.
+    func validate(_ value: JSONSchemaValue, against schema: JSONSchemaValue) -> String?
+}
+
+// MARK: - ToolRegistry
+
+/// Main-actor store of ``ToolExecutor`` instances keyed by case-insensitive
+/// tool name.
+///
+/// The registry is the single dispatch seam between the generation loop and
+/// user-registered tools. It handles:
+///
+/// - case-insensitive name lookup (with a warning when the model casing
+///   differs from registration)
+/// - JSON parsing of the raw ``ToolCall/arguments`` string into
+///   ``JSONSchemaValue``
+/// - optional schema validation (wave 2 wires an injected
+///   ``JSONSchemaValidating`` implementation)
+/// - stamping ``ToolResult/callId`` from the incoming call
+/// - classifying lookup / parse / throw failures into
+///   ``ToolResult/ErrorKind`` values
+///
+/// ## Isolation
+///
+/// ``ToolRegistry`` is deliberately `@MainActor final class`, not an `actor`.
+/// The coordinator that drives it is MainActor-isolated; making the registry
+/// an actor would force a hop on every dispatch for no benefit. The executor's
+/// async `execute` call may still suspend off the main actor inside its own
+/// implementation.
+@MainActor public final class ToolRegistry {
+
+    // MARK: Storage
+
+    /// Keyed on the lowercased tool name for case-insensitive lookup.
+    private var tools: [String: any ToolExecutor] = [:]
+
+    // MARK: Configuration
+
+    /// Optional validator used to check parsed arguments against
+    /// ``ToolDefinition/parameters``.
+    ///
+    /// Wave 1 leaves this `nil` — dispatch skips validation. Wave 2 injects a
+    /// concrete ``JSONSchemaValidator`` (or any other ``JSONSchemaValidating``
+    /// conformer) so failures come back as ``ToolResult/ErrorKind/invalidArguments``.
+    public var validator: (any JSONSchemaValidating)? = nil
+
+    // MARK: - Init
+
+    /// Creates a registry pre-populated with the supplied tools.
+    ///
+    /// Each tool is registered in order, so later entries override earlier
+    /// ones on name collision (with the same override warning emitted from
+    /// ``register(_:)``).
+    public init(tools: [any ToolExecutor] = []) {
+        for tool in tools {
+            register(tool)
+        }
+    }
+
+    // MARK: - Registration
+
+    /// Registers a tool, replacing any existing tool with the same name.
+    ///
+    /// Names are compared case-insensitively. Overrides log a warning so
+    /// accidental collisions during ad-hoc tool wiring are visible in the
+    /// inference log.
+    public func register(_ tool: any ToolExecutor) {
+        let key = tool.definition.name.lowercased()
+        if tools[key] != nil {
+            Log.inference.warning(
+                "ToolRegistry: overriding existing tool '\(tool.definition.name, privacy: .public)'"
+            )
+        }
+        tools[key] = tool
+    }
+
+    /// Removes a tool by name. No-op when the name is not registered.
+    public func unregister(name: String) {
+        tools.removeValue(forKey: name.lowercased())
+    }
+
+    /// Returns `true` when a tool is registered under `name` (case-insensitive).
+    public func contains(name: String) -> Bool {
+        tools[name.lowercased()] != nil
+    }
+
+    /// All registered tool definitions, sorted by name for stable diffs / tests.
+    public var definitions: [ToolDefinition] {
+        tools.values
+            .map(\.definition)
+            .sorted { $0.name < $1.name }
+    }
+
+    // MARK: - Dispatch
+
+    /// Resolves `call.toolName` to an executor, parses its arguments, runs
+    /// the tool, and returns a stamped ``ToolResult``.
+    ///
+    /// Dispatch classifies failures as follows:
+    /// - Unknown tool → ``ToolResult/ErrorKind/unknownTool``
+    /// - Malformed argument JSON → ``ToolResult/ErrorKind/invalidArguments``
+    /// - Schema validation failure (when ``validator`` is set) →
+    ///   ``ToolResult/ErrorKind/invalidArguments``
+    /// - Executor throws → ``ToolResult/ErrorKind/permanent`` with
+    ///   `String(describing: error)` as the content
+    ///
+    /// The returned ``ToolResult/callId`` always matches the incoming
+    /// ``ToolCall/id``, regardless of what the executor returned.
+    public func dispatch(_ call: ToolCall) async -> ToolResult {
+        // 1. Case-insensitive lookup with a mismatch warning.
+        let key = call.toolName.lowercased()
+        guard let executor = tools[key] else {
+            return ToolResult(
+                callId: call.id,
+                content: "Unknown tool '\(call.toolName)'",
+                errorKind: .unknownTool
+            )
+        }
+        if executor.definition.name != call.toolName {
+            Log.inference.warning(
+                "ToolRegistry: case-insensitive match for '\(call.toolName, privacy: .public)' (registered as '\(executor.definition.name, privacy: .public)')"
+            )
+        }
+
+        // 2. Parse the raw argument JSON.
+        let parsedArguments: JSONSchemaValue
+        if call.arguments.isEmpty {
+            // Empty string is a common "no arguments" signal from backends
+            // that don't emit `{}` — treat it as an empty object rather than
+            // failing the call before it reaches the executor.
+            parsedArguments = .object([:])
+        } else {
+            guard let data = call.arguments.data(using: .utf8) else {
+                return ToolResult(
+                    callId: call.id,
+                    content: "arguments are not valid JSON: non-UTF8 payload",
+                    errorKind: .invalidArguments
+                )
+            }
+            do {
+                parsedArguments = try JSONDecoder().decode(JSONSchemaValue.self, from: data)
+            } catch {
+                return ToolResult(
+                    callId: call.id,
+                    content: "arguments are not valid JSON: \(error)",
+                    errorKind: .invalidArguments
+                )
+            }
+        }
+
+        // 3. Optional schema validation (wave 2 wiring).
+        if let validator,
+           let message = validator.validate(parsedArguments, against: executor.definition.parameters) {
+            return ToolResult(
+                callId: call.id,
+                content: "arguments failed schema validation: \(message)",
+                errorKind: .invalidArguments
+            )
+        }
+
+        // 4. Execute and stamp callId.
+        do {
+            let raw = try await executor.execute(arguments: parsedArguments)
+            return ToolResult(
+                callId: call.id,
+                content: raw.content,
+                errorKind: raw.errorKind
+            )
+        } catch {
+            return ToolResult(
+                callId: call.id,
+                content: String(describing: error),
+                errorKind: .permanent
+            )
+        }
+    }
+}

--- a/Tests/BaseChatInferenceTests/GenerationConfigToolIterationsTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationConfigToolIterationsTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import BaseChatInference
+
+/// Tests for the ``GenerationConfig/maxToolIterations`` budget introduced
+/// alongside ``ToolRegistry`` in wave 1.
+final class GenerationConfigToolIterationsTests: XCTestCase {
+
+    // MARK: - Default value
+
+    func test_default_is10() {
+        let config = GenerationConfig()
+        XCTAssertEqual(config.maxToolIterations, 10)
+    }
+
+    func test_customValue_isPreserved() {
+        let config = GenerationConfig(maxToolIterations: 3)
+        XCTAssertEqual(config.maxToolIterations, 3)
+    }
+
+    // MARK: - Clamp
+
+    func test_zero_initArgument_clampedToOne() {
+        let config = GenerationConfig(maxToolIterations: 0)
+        XCTAssertEqual(config.maxToolIterations, 1)
+    }
+
+    func test_negative_initArgument_clampedToOne() {
+        let config = GenerationConfig(maxToolIterations: -5)
+        XCTAssertEqual(config.maxToolIterations, 1)
+    }
+
+    func test_assignmentAfterInit_clampedToOne() {
+        var config = GenerationConfig()
+        config.maxToolIterations = -1
+        XCTAssertEqual(config.maxToolIterations, 1)
+    }
+
+    // MARK: - Codable round-trip
+
+    func test_roundTrip_preservesCustomValue() throws {
+        let config = GenerationConfig(maxToolIterations: 4)
+        let encoded = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: encoded)
+        XCTAssertEqual(decoded.maxToolIterations, 4)
+    }
+
+    func test_roundTrip_preservesDefault() throws {
+        let config = GenerationConfig()
+        let encoded = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: encoded)
+        XCTAssertEqual(decoded.maxToolIterations, 10)
+    }
+
+    func test_legacyPayload_withoutField_defaultsTo10() throws {
+        // Payloads serialised before maxToolIterations was added must still
+        // decode with the canonical default.
+        let legacy = """
+        {"temperature":0.7,"topP":0.9,"repeatPenalty":1.1,"maxTokens":512,"tools":[],"toolChoice":{"type":"auto"},"jsonMode":false}
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: legacy)
+
+        XCTAssertEqual(decoded.maxToolIterations, 10)
+    }
+
+    func test_legacyPayload_withZeroField_clampedTo1() throws {
+        // Defensive: a persisted zero (e.g. from a pre-release build) should
+        // still yield loop-viable semantics after decode.
+        let legacy = #"{"temperature":0.7,"topP":0.9,"repeatPenalty":1.1,"maxTokens":512,"tools":[],"toolChoice":{"type":"auto"},"jsonMode":false,"maxToolIterations":0}"#.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: legacy)
+
+        XCTAssertEqual(decoded.maxToolIterations, 1)
+    }
+}

--- a/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
+++ b/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
@@ -39,6 +39,11 @@ final class SilentCatchAuditTest: XCTestCase {
     /// DO NOT add entries to make a failing test pass without human review.
     private static let allowlist: Set<String> = [
         // BaseChatInference
+        // False positive: `ToolRegistry?` as an optional type annotation contains
+        // the substring `try?` inside `Regis‑try?`. No `try?` call site is present
+        // on either line; the audit's substring scan is not AST-aware.
+        "BaseChatInference/Services/GenerationCoordinator.swift:let toolRegistry: ToolRegistry?",
+        "BaseChatInference/Services/GenerationCoordinator.swift:toolRegistry: ToolRegistry? = nil",
         // JSONSchemaValue uses the standard "try-each-type-in-order" decoder pattern for
         // heterogeneous JSON. Each `try?` is bound to a named constant and the result is
         // used immediately; there is no silent discard — the next branch handles the miss.

--- a/Tests/BaseChatInferenceTests/ToolCallContractTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolCallContractTests.swift
@@ -61,13 +61,14 @@ final class ToolCallContractTests: XCTestCase {
     }
 
     func test_toolResult_roundTrips_error() throws {
-        let result = ToolResult(callId: "call-2", content: "City not found", isError: true)
+        let result = ToolResult(callId: "call-2", content: "City not found", errorKind: .notFound)
 
         let encoded = try JSONEncoder().encode(result)
         let decoded = try JSONDecoder().decode(ToolResult.self, from: encoded)
 
-        // Sabotage check: defaulting `isError` to `false` in the init causes this to fail
+        // Sabotage check: defaulting `errorKind` to `nil` in the init causes this to fail
         XCTAssertTrue(decoded.isError)
+        XCTAssertEqual(decoded.errorKind, .notFound)
         XCTAssertEqual(decoded.content, "City not found")
     }
 

--- a/Tests/BaseChatInferenceTests/ToolRegistryTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolRegistryTests.swift
@@ -1,0 +1,261 @@
+import XCTest
+@testable import BaseChatInference
+
+/// Tests for the ``ToolRegistry`` dispatch surface introduced alongside the
+/// ``ToolExecutor`` protocol in wave 1.
+///
+/// Coverage:
+/// - register/contains/unregister lifecycle
+/// - case-insensitive name lookup
+/// - dispatch → unknown tool / invalid JSON / thrown-error / happy-path
+/// - register overrides (with warning) and `definitions` sort order
+@MainActor
+final class ToolRegistryTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private struct CityArgs: Decodable, Sendable, Equatable {
+        let city: String
+    }
+
+    private struct WeatherResult: Codable, Sendable, Equatable {
+        let summary: String
+        let celsius: Double
+    }
+
+    private func makeWeatherExecutor(
+        name: String = "get_weather"
+    ) -> TypedToolExecutor<CityArgs, WeatherResult> {
+        TypedToolExecutor(
+            definition: ToolDefinition(
+                name: name,
+                description: "Returns weather for a city.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "city": .object(["type": .string("string")])
+                    ]),
+                    "required": .array([.string("city")])
+                ])
+            )
+        ) { args in
+            WeatherResult(summary: "Sunny in \(args.city)", celsius: 22.0)
+        }
+    }
+
+    /// Minimal raw-protocol executor that records the payload it was called
+    /// with. Lets us assert dispatch passes through the parsed JSONSchemaValue
+    /// unchanged without routing through TypedToolExecutor.
+    private final class RecordingExecutor: ToolExecutor, @unchecked Sendable {
+        let definition: ToolDefinition
+        var lastArguments: JSONSchemaValue?
+
+        init(name: String) {
+            self.definition = ToolDefinition(name: name, description: "record", parameters: .object([:]))
+        }
+
+        func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+            lastArguments = arguments
+            return ToolResult(callId: "", content: "ok", errorKind: nil)
+        }
+    }
+
+    /// Executor that always throws. Drives the `.permanent` classification path.
+    private struct ThrowingExecutor: ToolExecutor {
+        struct Boom: Error, CustomStringConvertible { var description: String { "boom-message" } }
+        let definition: ToolDefinition
+
+        init(name: String) {
+            self.definition = ToolDefinition(name: name, description: "throws", parameters: .object([:]))
+        }
+
+        func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+            throw Boom()
+        }
+    }
+
+    // MARK: - register / contains / unregister
+
+    func test_register_then_containsExactName() {
+        let registry = ToolRegistry()
+        registry.register(makeWeatherExecutor(name: "get_weather"))
+        XCTAssertTrue(registry.contains(name: "get_weather"))
+    }
+
+    func test_contains_isCaseInsensitive() {
+        let registry = ToolRegistry()
+        registry.register(makeWeatherExecutor(name: "GetWeather"))
+        XCTAssertTrue(registry.contains(name: "getweather"))
+        XCTAssertTrue(registry.contains(name: "GETWEATHER"))
+    }
+
+    func test_unregister_removesTool() async {
+        let registry = ToolRegistry()
+        registry.register(makeWeatherExecutor(name: "get_weather"))
+        registry.unregister(name: "get_weather")
+        XCTAssertFalse(registry.contains(name: "get_weather"))
+
+        let result = await registry.dispatch(
+            ToolCall(id: "call-1", toolName: "get_weather", arguments: #"{"city":"Paris"}"#)
+        )
+        XCTAssertEqual(result.errorKind, .unknownTool)
+    }
+
+    func test_init_withTools_registersAll() {
+        let registry = ToolRegistry(tools: [
+            makeWeatherExecutor(name: "alpha"),
+            makeWeatherExecutor(name: "bravo")
+        ])
+        XCTAssertTrue(registry.contains(name: "alpha"))
+        XCTAssertTrue(registry.contains(name: "bravo"))
+    }
+
+    // MARK: - definitions
+
+    func test_definitions_returnsSortedByName() {
+        let registry = ToolRegistry()
+        registry.register(makeWeatherExecutor(name: "zebra"))
+        registry.register(makeWeatherExecutor(name: "alpha"))
+        registry.register(makeWeatherExecutor(name: "mango"))
+
+        let names = registry.definitions.map(\.name)
+        // Sabotage check: returning tools.values.map directly (no sort) makes
+        // this fail because Dictionary iteration order is unstable.
+        XCTAssertEqual(names, ["alpha", "mango", "zebra"])
+    }
+
+    func test_register_override_replacesExistingTool() async {
+        let registry = ToolRegistry()
+
+        let first = TypedToolExecutor<CityArgs, WeatherResult>(
+            definition: ToolDefinition(name: "get_weather", description: "v1", parameters: .object([:]))
+        ) { _ in WeatherResult(summary: "v1", celsius: 1.0) }
+
+        let second = TypedToolExecutor<CityArgs, WeatherResult>(
+            definition: ToolDefinition(name: "get_weather", description: "v2", parameters: .object([:]))
+        ) { _ in WeatherResult(summary: "v2", celsius: 2.0) }
+
+        registry.register(first)
+        registry.register(second)
+
+        let result = await registry.dispatch(
+            ToolCall(id: "call-o", toolName: "get_weather", arguments: #"{"city":"Paris"}"#)
+        )
+        XCTAssertEqual(result.errorKind, nil)
+        XCTAssertTrue(result.content.contains("v2"), "Override must win on dispatch. Got: \(result.content)")
+        XCTAssertFalse(result.content.contains("v1"))
+    }
+
+    // MARK: - dispatch: unknown tool
+
+    func test_unknownTool_returnsUnknownToolKind() async {
+        let registry = ToolRegistry()
+        let call = ToolCall(id: "call-42", toolName: "nonexistent", arguments: "{}")
+
+        let result = await registry.dispatch(call)
+
+        // Sabotage check: force the lookup to always resolve makes this fail.
+        XCTAssertEqual(result.errorKind, .unknownTool)
+        XCTAssertEqual(result.callId, "call-42")
+        XCTAssertTrue(result.content.contains("nonexistent"))
+    }
+
+    // MARK: - dispatch: case-insensitive lookup
+
+    func test_dispatch_resolvesCaseInsensitively() async {
+        let registry = ToolRegistry()
+        registry.register(makeWeatherExecutor(name: "GetWeather"))
+
+        let result = await registry.dispatch(
+            ToolCall(id: "c1", toolName: "getweather", arguments: #"{"city":"Rome"}"#)
+        )
+        XCTAssertEqual(result.errorKind, nil)
+        XCTAssertEqual(result.callId, "c1")
+        XCTAssertTrue(result.content.contains("Rome"))
+    }
+
+    // MARK: - dispatch: malformed JSON
+
+    func test_malformedArguments_returnsInvalidArguments() async {
+        let registry = ToolRegistry()
+        registry.register(makeWeatherExecutor())
+
+        let call = ToolCall(id: "call-7", toolName: "get_weather", arguments: "not json {")
+        let result = await registry.dispatch(call)
+
+        XCTAssertEqual(result.errorKind, .invalidArguments)
+        XCTAssertEqual(result.callId, "call-7")
+        XCTAssertTrue(result.content.contains("not valid JSON"))
+    }
+
+    func test_emptyArguments_treatedAsEmptyObject() async {
+        let registry = ToolRegistry()
+        let recorder = RecordingExecutor(name: "record")
+        registry.register(recorder)
+
+        let result = await registry.dispatch(
+            ToolCall(id: "c", toolName: "record", arguments: "")
+        )
+        XCTAssertEqual(result.errorKind, nil)
+        XCTAssertEqual(recorder.lastArguments, .object([:]))
+    }
+
+    // MARK: - dispatch: executor throws
+
+    func test_executorThrows_returnsPermanentWithDescription() async {
+        let registry = ToolRegistry()
+        registry.register(ThrowingExecutor(name: "bomb"))
+
+        let call = ToolCall(id: "call-b", toolName: "bomb", arguments: "{}")
+        let result = await registry.dispatch(call)
+
+        XCTAssertEqual(result.errorKind, .permanent)
+        XCTAssertEqual(result.callId, "call-b")
+        XCTAssertTrue(result.content.contains("boom-message"), "Content should include the error description. Got: \(result.content)")
+    }
+
+    // MARK: - dispatch: happy path
+
+    func test_typedExecutor_happyPath_roundTrip() async throws {
+        let registry = ToolRegistry()
+        registry.register(makeWeatherExecutor())
+
+        let call = ToolCall(
+            id: "call-hp",
+            toolName: "get_weather",
+            arguments: #"{"city":"London"}"#
+        )
+        let result = await registry.dispatch(call)
+
+        XCTAssertEqual(result.errorKind, nil)
+        XCTAssertEqual(result.callId, "call-hp")
+        // Content should be a JSON-encoded WeatherResult.
+        let payload = try JSONDecoder().decode(WeatherResult.self, from: Data(result.content.utf8))
+        XCTAssertEqual(payload.summary, "Sunny in London")
+        XCTAssertEqual(payload.celsius, 22.0, accuracy: 0.001)
+    }
+
+    func test_typedExecutor_malformedShape_returnsPermanent() async {
+        // JSON is valid but doesn't match CityArgs (missing "city"). The decode
+        // error is thrown out of `execute` and caught by dispatch as .permanent.
+        let registry = ToolRegistry()
+        registry.register(makeWeatherExecutor())
+
+        let call = ToolCall(
+            id: "call-x",
+            toolName: "get_weather",
+            arguments: #"{"wrong":"shape"}"#
+        )
+        let result = await registry.dispatch(call)
+
+        XCTAssertEqual(result.errorKind, .permanent)
+        XCTAssertEqual(result.callId, "call-x")
+    }
+
+    // MARK: - validator property
+
+    func test_validator_defaultsToNil() {
+        let registry = ToolRegistry()
+        XCTAssertNil(registry.validator)
+    }
+}

--- a/Tests/BaseChatInferenceTests/ToolResultErrorKindTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolResultErrorKindTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import BaseChatInference
+
+/// Tests for the ``ToolResult/ErrorKind`` taxonomy and the backwards-compat
+/// Codable path that accepts the legacy `isError` boolean.
+final class ToolResultErrorKindTests: XCTestCase {
+
+    // MARK: - ErrorKind round-trips
+
+    func test_allErrorKinds_roundTripThroughCodable() throws {
+        let allKinds: [ToolResult.ErrorKind] = [
+            .invalidArguments, .permissionDenied, .notFound, .timeout,
+            .rateLimited, .cancelled, .transient, .permanent, .unknownTool
+        ]
+        // Guard against someone adding a new case and forgetting to update the
+        // test exhaustively. 9 cases is the wave 1 contract.
+        XCTAssertEqual(allKinds.count, 9)
+
+        for kind in allKinds {
+            let result = ToolResult(callId: "c-\(kind.rawValue)", content: "x", errorKind: kind)
+            let encoded = try JSONEncoder().encode(result)
+            let decoded = try JSONDecoder().decode(ToolResult.self, from: encoded)
+            XCTAssertEqual(decoded.errorKind, kind, "round-trip failed for \(kind.rawValue)")
+            XCTAssertTrue(decoded.isError)
+        }
+    }
+
+    func test_successResult_encodesWithoutErrorKind() throws {
+        let result = ToolResult(callId: "c", content: "ok")
+        let encoded = try JSONEncoder().encode(result)
+        // Ensure `isError` is not emitted on the wire — it is purely derived.
+        let obj = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        XCTAssertNil(obj["errorKind"])
+        XCTAssertNil(obj["isError"], "isError must not be encoded — it is derived from errorKind")
+    }
+
+    // MARK: - Backwards-compat decode
+
+    func test_backwardsCompatDecode_isErrorTrue_mapsToPermanent() throws {
+        let legacy = #"{"callId":"x","content":"y","isError":true}"#.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(ToolResult.self, from: legacy)
+
+        // Sabotage check: removing the isError fallback branch in init(from:)
+        // makes this fail because errorKind will be nil.
+        XCTAssertEqual(decoded.errorKind, .permanent)
+        XCTAssertTrue(decoded.isError)
+        XCTAssertEqual(decoded.callId, "x")
+        XCTAssertEqual(decoded.content, "y")
+    }
+
+    func test_backwardsCompatDecode_isErrorFalse_mapsToNil() throws {
+        let legacy = #"{"callId":"x","content":"y","isError":false}"#.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(ToolResult.self, from: legacy)
+
+        XCTAssertNil(decoded.errorKind)
+        XCTAssertFalse(decoded.isError)
+    }
+
+    func test_decode_withNeitherField_defaultsToNil() throws {
+        let minimal = #"{"callId":"x","content":"y"}"#.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(ToolResult.self, from: minimal)
+
+        XCTAssertNil(decoded.errorKind)
+        XCTAssertFalse(decoded.isError)
+    }
+
+    func test_forwardCompatDecode_errorKindWinsOverLegacyIsError() throws {
+        // Both fields present — errorKind must take precedence so new servers
+        // sending both shapes do not silently downgrade to `.permanent`.
+        let mixed = #"{"callId":"x","content":"y","errorKind":"timeout","isError":true}"#.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(ToolResult.self, from: mixed)
+
+        XCTAssertEqual(decoded.errorKind, .timeout)
+        XCTAssertTrue(decoded.isError)
+    }
+
+    // MARK: - Deprecated initializer
+
+    func test_deprecatedInit_isErrorTrue_mapsToPermanent() {
+        // Intentionally exercise the deprecated initializer. `@available`
+        // deprecation warnings are expected; the initializer is retained for
+        // migration compatibility.
+        @available(*, deprecated)
+        func makeLegacy() -> ToolResult {
+            ToolResult(callId: "c", content: "x", isError: true)
+        }
+
+        let result = makeLegacy()
+        XCTAssertEqual(result.errorKind, .permanent)
+        XCTAssertTrue(result.isError)
+    }
+
+    func test_deprecatedInit_isErrorFalse_mapsToNil() {
+        @available(*, deprecated)
+        func makeLegacy() -> ToolResult {
+            ToolResult(callId: "c", content: "x", isError: false)
+        }
+
+        let result = makeLegacy()
+        XCTAssertNil(result.errorKind)
+        XCTAssertFalse(result.isError)
+    }
+
+    // MARK: - Equatable / Hashable
+
+    func test_resultsWithDifferentErrorKinds_areNotEqual() {
+        let a = ToolResult(callId: "c", content: "x", errorKind: .timeout)
+        let b = ToolResult(callId: "c", content: "x", errorKind: .permanent)
+        XCTAssertNotEqual(a, b)
+    }
+}


### PR DESCRIPTION
## Summary

Wave 1 of the tool-calling super-session: the runtime foundation that wave 2 (Agent D) will wire into the generation loop and that wave 2 (Agent C) will plug its `JSONSchemaValidating` conformer into.

- **`ToolExecutor` protocol** — takes `JSONSchemaValue` (not `String`). Keeps the door open for MCP bridges (#625) and AppIntent adapters (#620) that already hold a parsed argument tree.
- **`TypedToolExecutor<Arguments, Result>`** — generic adapter that JSON-encodes/decodes on both sides so user handlers stay strongly typed. Decoder failures surface as `.permanent` results at the registry boundary.
- **`ToolRegistry` (`@MainActor final class`)** — case-insensitive name lookup, override warnings via `Log.inference.warning`, stable-sorted `definitions`, and a `dispatch(_:)` that classifies failures into `unknownTool` / `invalidArguments` / `permanent`. `validator` property exists (`JSONSchemaValidating?`) but defaults to `nil` — wave 2 Agent C wires the concrete conformer.
- **`ToolResult.ErrorKind`** — 9-case taxonomy (`invalidArguments`, `permissionDenied`, `notFound`, `timeout`, `rateLimited`, `cancelled`, `transient`, `permanent`, `unknownTool`). `isError` is now a derived `Bool`; legacy `{"isError":true}` payloads decode to `.permanent` so pre-v4 persisted tool results keep working. The wire format drops `isError` (it's derived).
- **`GenerationConfig.maxToolIterations: Int = 10`** — clamp-to-≥1 at init, assignment (via `didSet`), and decode. Legacy payloads without the field get the default.
- **`GenerationCoordinator.toolRegistry`** — optional property added to init; dispatch wiring deferred to wave 2 Agent D, marked with a `// wave 2 dispatches via toolRegistry here` comment at the event-stream site.

Closes #618.
Closes #624.

## Sabotage-verified

- `ToolRegistryTests.test_unknownTool_returnsUnknownToolKind` — broke `dispatch` to always return `ok`; confirmed the test failed; restored.
- `ToolResultErrorKindTests.test_backwardsCompatDecode_isErrorTrue_mapsToPermanent` — commented out the legacy `isError` fallback branch in `ToolResult.init(from:)`; confirmed the test failed; restored.

## Test plan

- [x] `BaseChatCoreTests` — 204 tests pass
- [x] `BaseChatInferenceTests` — 935 tests pass (includes 14 ToolRegistry + 9 ErrorKind + 9 toolIterations)
- [x] `BaseChatInferenceSwiftTestingTests` — 69 tests pass
- [x] `BaseChatUITests` — 458 tests pass
- [x] `BaseChatBackendsTests` — 131 tests pass (default traits)
- [x] Package.resolved pin-drop reverted per project convention

## Surprises

- The `SilentCatchAuditTest` does a naive `line.contains("try?")` scan. `ToolRegistry?` as an optional type annotation contains the substring `try?` inside `Regis‑try?`, tripping the audit as a false positive on two lines in `GenerationCoordinator.swift`. Added two allowlist entries with a comment explaining the collision. No rename felt cleaner than letting a style audit veto a public API shape.
- An Agent C worktree is active in the same repo (JSONSchemaValidator.swift / JSONSchemaValidatorTests.swift). This PR adds the `JSONSchemaValidating` protocol surface that Agent C's concrete validator can adopt — aligned at the protocol boundary.

## Release Note

**Tool-calling runtime foundation** — BaseChatKit now ships the core primitives needed to run model-emitted tool calls end-to-end. A new `ToolRegistry` (MainActor-isolated, case-insensitive) dispatches `ToolCall`s to `ToolExecutor` conformers, `TypedToolExecutor<A, R>` adapts strongly-typed Swift handlers over the `JSONSchemaValue` boundary, and `ToolResult.ErrorKind` replaces the flat `isError` boolean with a 9-case failure taxonomy (retryable `transient`, fatal `permanent`, `permissionDenied`, `timeout`, etc.) — all while decoding legacy persisted payloads unchanged. `GenerationConfig.maxToolIterations` caps runaway tool loops at a default of 10. The wiring into the generation stream lands in the next wave; this PR is the stable surface that MCP bridges, AppIntent adapters, and the macro-generated `@ToolSchema` hook can all build against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)