### PR TITLE
refactor(backends): promote SSEPayloadHandler.extractToken to extractEvents

### DIFF
--- a/Sources/BaseChatBackends/SSECloudBackend.swift
+++ b/Sources/BaseChatBackends/SSECloudBackend.swift
@@ -178,8 +178,26 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
     /// The default implementation delegates to ``payloadHandler``.
     /// Subclasses may override for additional processing, but providing a
     /// custom ``SSEPayloadHandler`` at init is the preferred approach.
+    ///
+    /// - Important: Prefer ``extractEvents(from:)`` — this hook is retained
+    ///   so existing subclasses continue to compile during the #604 / #605
+    ///   migration and will be removed once they finish.
+    // TODO: remove once ClaudeBackend / OpenAIBackend migrate to
+    // `extractEvents(from:)` and no subclass overrides this hook.
     open func extractToken(from payload: String) -> String? {
         payloadHandler.extractToken(from: payload)
+    }
+
+    /// Maps an SSE JSON payload to zero or more generation events.
+    ///
+    /// The default implementation forwards to ``payloadHandler``'s
+    /// ``SSEPayloadHandler/extractEvents(from:)``. The base
+    /// ``parseResponseStream(bytes:continuation:)`` loop iterates the
+    /// returned events and injects ``GenerationEvent/thinkingComplete``
+    /// on the first non-thinking-token event after one or more
+    /// thinking-token events, so handlers stay stateless.
+    open func extractEvents(from payload: String) -> [GenerationEvent] {
+        payloadHandler.extractEvents(from: payload)
     }
 
     /// Extracts token usage from an SSE JSON payload.
@@ -423,11 +441,36 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
         continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
     ) async throws {
         let tokenStream = SSEStreamParser.parse(bytes: bytes, limits: effectiveSSEStreamLimits)
+        // Tracks whether the last emitted content event was a
+        // `.thinkingToken`. When the next payload produces a `.token` (plain
+        // text), we inject a single `.thinkingComplete` so downstream
+        // consumers see the reasoning block close exactly once, even for
+        // field-based wire formats (Claude `thinking_delta`, OpenAI
+        // `reasoning_content`) where the boundary is implicit.
+        var wasThinking = false
         for try await payload in tokenStream {
             if Task.isCancelled { break }
 
-            if let token = extractToken(from: payload) {
-                continuation.yield(.token(token))
+            for event in extractEvents(from: payload) {
+                switch event {
+                case .thinkingToken:
+                    wasThinking = true
+                    continuation.yield(event)
+                case .thinkingComplete:
+                    // Handler emitted the boundary itself (e.g. an inline-
+                    // tag backend using `ThinkingParser`). Clear the flag
+                    // so we don't double-emit on the next `.token`.
+                    wasThinking = false
+                    continuation.yield(event)
+                case .token:
+                    if wasThinking {
+                        continuation.yield(.thinkingComplete)
+                        wasThinking = false
+                    }
+                    continuation.yield(event)
+                default:
+                    continuation.yield(event)
+                }
             }
 
             if let usage = extractUsage(from: payload) {

--- a/Sources/BaseChatInference/Services/SSEStreamParser.swift
+++ b/Sources/BaseChatInference/Services/SSEStreamParser.swift
@@ -123,9 +123,49 @@ public enum SSEStreamError: Error, Equatable {
 ///
 /// Each cloud backend provides its own implementation to extract tokens,
 /// usage, stream-end signals, and errors from the provider's JSON format.
+///
+/// ## Event-level routing
+///
+/// ``extractEvents(from:)`` is the primary entry point: it maps one SSE
+/// payload to zero or more ``GenerationEvent`` values. This lets a single
+/// chunk surface ``GenerationEvent/token(_:)``, ``GenerationEvent/thinkingToken(_:)``,
+/// or ``GenerationEvent/thinkingComplete`` as the provider's wire format
+/// requires, without forcing the base class to reinterpret a raw string.
+///
+/// The default implementation wraps the legacy ``extractToken(from:)``
+/// result into `[.token(...)]`, so existing conformers keep compiling
+/// unchanged. New conformers should implement ``extractEvents(from:)``
+/// directly and leave ``extractToken(from:)`` as a no-op.
 public protocol SSEPayloadHandler: Sendable {
     /// Extracts a text token from a JSON payload, or `nil` if not a token event.
+    ///
+    /// - Important: Prefer ``extractEvents(from:)`` for new conformers. This
+    ///   method is preserved for backwards compatibility and will be removed
+    ///   once the remaining cloud backends (`ClaudeBackend`, `OpenAIBackend`)
+    ///   migrate to event-level routing.
+    // TODO: remove once #604 (Claude thinking_delta) and #605 (OpenAI
+    // reasoning_content) migrate to `extractEvents(from:)`.
     func extractToken(from payload: String) -> String?
+
+    /// Maps a single SSE JSON payload to zero or more generation events.
+    ///
+    /// Returning multiple events from one payload lets a handler distinguish
+    /// thinking/reasoning deltas from regular text deltas natively. For
+    /// lifecycle-style `.thinkingComplete` events that cannot be derived
+    /// from a single chunk (e.g. OpenAI's `reasoning_content` → `content`
+    /// transition), the `SSECloudBackend` base loop injects the event on
+    /// the first non-thinking-token event that follows one or more
+    /// thinking-token events, so handlers can stay stateless.
+    ///
+    /// Handlers that already know they are at a reasoning-block boundary
+    /// (e.g. an inline-tag parser using `ThinkingParser`) may emit
+    /// ``GenerationEvent/thinkingComplete`` themselves; the base loop's
+    /// flag tracking is idempotent and will not duplicate the event.
+    ///
+    /// The default implementation wraps ``extractToken(from:)`` so existing
+    /// handlers continue to work. Override for any handler that needs to
+    /// classify thinking vs. text deltas.
+    func extractEvents(from payload: String) -> [GenerationEvent]
 
     /// Extracts token usage from a JSON payload, or `nil` if not a usage event.
     func extractUsage(from payload: String) -> (promptTokens: Int?, completionTokens: Int?)?
@@ -135,6 +175,19 @@ public protocol SSEPayloadHandler: Sendable {
 
     /// Extracts an error from a JSON payload, or `nil` if not an error event.
     func extractStreamError(from payload: String) -> Error?
+}
+
+extension SSEPayloadHandler {
+    /// Default implementation that wraps ``extractToken(from:)`` into a
+    /// single-element `[.token(...)]` array, preserving the old protocol's
+    /// behaviour for handlers that have not yet migrated to event-level
+    /// routing.
+    public func extractEvents(from payload: String) -> [GenerationEvent] {
+        if let token = extractToken(from: payload) {
+            return [.token(token)]
+        }
+        return []
+    }
 }
 
 package struct SSEStreamParser {
@@ -273,11 +326,32 @@ package struct SSEStreamParser {
             let task = Task {
                 do {
                     let sseStream = parse(bytes: bytes, limits: limits)
+                    var wasThinking = false
                     for try await payload in sseStream {
                         if Task.isCancelled { break }
 
-                        if let token = handler.extractToken(from: payload) {
-                            continuation.yield(.token(token))
+                        for event in handler.extractEvents(from: payload) {
+                            // Lifecycle: inject a single `.thinkingComplete`
+                            // when the stream transitions from a thinking-
+                            // token run back to a plain token. Handlers that
+                            // emit `.thinkingComplete` themselves clear the
+                            // flag before reaching here, so no duplicate.
+                            switch event {
+                            case .thinkingToken:
+                                wasThinking = true
+                                continuation.yield(event)
+                            case .thinkingComplete:
+                                wasThinking = false
+                                continuation.yield(event)
+                            case .token:
+                                if wasThinking {
+                                    continuation.yield(.thinkingComplete)
+                                    wasThinking = false
+                                }
+                                continuation.yield(event)
+                            default:
+                                continuation.yield(event)
+                            }
                         }
 
                         if let usage = handler.extractUsage(from: payload),

--- a/Tests/BaseChatBackendsTests/SSEExtractEventsTests.swift
+++ b/Tests/BaseChatBackendsTests/SSEExtractEventsTests.swift
@@ -1,0 +1,287 @@
+import Testing
+import Foundation
+@testable import BaseChatBackends
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+// MARK: - Helpers
+
+/// Creates a `URLSession` whose traffic is intercepted by `MockURLProtocol`.
+private func makeMockSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+/// Formats a single SSE data line from a JSON string.
+private func sseData(_ json: String) -> Data {
+    Data("data: \(json)\n\n".utf8)
+}
+
+// MARK: - Event-emitting payload handlers
+
+/// Legacy-style handler that only implements `extractToken` and relies on the
+/// protocol's default `extractEvents` wrapper to surface `.token` events.
+private struct LegacyTokenHandler: SSEPayloadHandler {
+    var token: @Sendable (String) -> String?
+    init(token: @escaping @Sendable (String) -> String? = { _ in nil }) {
+        self.token = token
+    }
+    func extractToken(from payload: String) -> String? { token(payload) }
+    func extractUsage(from payload: String) -> (promptTokens: Int?, completionTokens: Int?)? { nil }
+    func isStreamEnd(_ payload: String) -> Bool { false }
+    func extractStreamError(from payload: String) -> Error? { nil }
+}
+
+/// Modern handler that implements `extractEvents` directly to classify
+/// thinking vs. plain token deltas.
+private struct EventEmittingHandler: SSEPayloadHandler {
+    var events: @Sendable (String) -> [GenerationEvent]
+    init(events: @escaping @Sendable (String) -> [GenerationEvent] = { _ in [] }) {
+        self.events = events
+    }
+    func extractToken(from payload: String) -> String? { nil }
+    func extractEvents(from payload: String) -> [GenerationEvent] { events(payload) }
+    func extractUsage(from payload: String) -> (promptTokens: Int?, completionTokens: Int?)? { nil }
+    func isStreamEnd(_ payload: String) -> Bool { false }
+    func extractStreamError(from payload: String) -> Error? { nil }
+}
+
+// MARK: - Minimal concrete backend for tests
+
+private final class TestExtractEventsBackend: SSECloudBackend, @unchecked Sendable {
+    override var backendName: String { "TestExtractEvents" }
+
+    override var capabilities: BackendCapabilities {
+        BackendCapabilities(
+            supportedParameters: [.temperature],
+            maxContextTokens: 4096,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: false,
+            supportsToolCalling: false,
+            supportsStructuredOutput: false,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: true,
+            memoryStrategy: .external,
+            maxOutputTokens: 4096,
+            supportsStreaming: true,
+            isRemote: true
+        )
+    }
+
+    override func buildRequest(
+        prompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig
+    ) throws -> URLRequest {
+        guard let baseURL else {
+            throw CloudBackendError.invalidURL("No base URL configured")
+        }
+        var request = URLRequest(url: baseURL.appendingPathComponent("stream"))
+        request.httpMethod = "POST"
+        return request
+    }
+}
+
+// MARK: - Tests
+
+@Suite("SSEPayloadHandler.extractEvents routing", .serialized)
+struct SSEExtractEventsTests {
+
+    private func makeBackend(handler: any SSEPayloadHandler) -> (TestExtractEventsBackend, URL) {
+        let session = makeMockSession()
+        let backend = TestExtractEventsBackend(
+            defaultModelName: "extract-events-test",
+            urlSession: session,
+            payloadHandler: handler
+        )
+        let baseURL = URL(string: "https://extract-events-\(UUID().uuidString).test")!
+        backend.configure(baseURL: baseURL, apiKey: "test", modelName: "extract-events-test")
+        return (backend, baseURL.appendingPathComponent("stream"))
+    }
+
+    private func loadBackend(_ backend: TestExtractEventsBackend) async throws {
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+    }
+
+    // MARK: - (a) Default-shim covers legacy extractToken-only handlers
+
+    /// A handler that only implements the legacy ``SSEPayloadHandler/extractToken(from:)``
+    /// method — never overriding ``extractEvents(from:)`` — must keep working
+    /// unchanged. The protocol's default `extractEvents` wraps the token into
+    /// a single-element `[.token(...)]` array so the base parse loop sees the
+    /// same token it used to see.
+    @Test func legacyHandler_defaultExtractEvents_yieldsTokenEvents() async throws {
+        let handler = LegacyTokenHandler(token: { payload in
+            payload.hasPrefix("T:") ? String(payload.dropFirst(2)) : nil
+        })
+        let (backend, url) = makeBackend(handler: handler)
+
+        let chunks: [Data] = [
+            sseData("T:hello"),
+            sseData("T:world"),
+        ]
+        MockURLProtocol.stub(url: url, response: .sse(chunks: chunks, statusCode: 200))
+
+        try await loadBackend(backend)
+        let stream = try backend.generate(prompt: "x", systemPrompt: nil, config: GenerationConfig())
+
+        var tokens: [String] = []
+        for try await event in stream.events {
+            if case .token(let t) = event { tokens.append(t) }
+        }
+
+        #expect(tokens == ["hello", "world"],
+                "Default extractEvents must wrap the legacy extractToken result into [.token(...)]")
+    }
+
+    // MARK: - (b) Thinking → token transition injects .thinkingComplete exactly once
+
+    /// When a handler emits one or more ``GenerationEvent/thinkingToken(_:)``
+    /// events followed by a plain ``GenerationEvent/token(_:)``, the base
+    /// ``SSECloudBackend/parseResponseStream(bytes:continuation:)`` loop must
+    /// inject a single ``GenerationEvent/thinkingComplete`` at the boundary.
+    /// The injected event must sit between the final thinking token and the
+    /// first plain token, and must not repeat if further plain tokens follow.
+    @Test func thinkingToTokenTransition_injectsThinkingCompleteOnce() async throws {
+        let handler = EventEmittingHandler(events: { payload in
+            switch payload {
+            case "THINK:pondering":
+                return [.thinkingToken("pondering")]
+            case "THINK:more":
+                return [.thinkingToken("more")]
+            case "TOKEN:answer":
+                return [.token("answer")]
+            case "TOKEN:continued":
+                return [.token("continued")]
+            default:
+                return []
+            }
+        })
+        let (backend, url) = makeBackend(handler: handler)
+
+        let chunks: [Data] = [
+            sseData("THINK:pondering"),
+            sseData("THINK:more"),
+            sseData("TOKEN:answer"),
+            sseData("TOKEN:continued"),
+        ]
+        MockURLProtocol.stub(url: url, response: .sse(chunks: chunks, statusCode: 200))
+
+        try await loadBackend(backend)
+        let stream = try backend.generate(prompt: "x", systemPrompt: nil, config: GenerationConfig())
+
+        var events: [GenerationEvent] = []
+        for try await event in stream.events {
+            events.append(event)
+        }
+
+        // Expected exact sequence: two thinking tokens, one thinkingComplete
+        // injected by the base loop, then two plain tokens.
+        let expected: [GenerationEvent] = [
+            .thinkingToken("pondering"),
+            .thinkingToken("more"),
+            .thinkingComplete,
+            .token("answer"),
+            .token("continued"),
+        ]
+        #expect(events == expected,
+                "Base loop must inject exactly one .thinkingComplete at the thinking→token boundary; got \(events)")
+
+        // Extra pin: no duplicates.
+        let completes = events.filter { if case .thinkingComplete = $0 { return true } else { return false } }
+        #expect(completes.count == 1,
+                ".thinkingComplete must appear exactly once across the whole stream")
+    }
+
+    // MARK: - (c) Handler-emitted .thinkingComplete is not double-injected
+
+    /// A handler that already emits ``GenerationEvent/thinkingComplete``
+    /// itself (e.g. an inline-tag backend using `ThinkingParser`) must not
+    /// get a second duplicate injected by the base loop. The internal
+    /// `wasThinking` flag must clear when the handler's explicit event
+    /// passes through.
+    @Test func handlerEmitsThinkingComplete_baseLoopDoesNotDuplicate() async throws {
+        let handler = EventEmittingHandler(events: { payload in
+            switch payload {
+            case "THINK:pondering":
+                return [.thinkingToken("pondering")]
+            case "THINK:DONE":
+                // Handler emits its own explicit close — e.g. ThinkingParser
+                // saw the `</think>` closing tag.
+                return [.thinkingComplete]
+            case "TOKEN:answer":
+                return [.token("answer")]
+            default:
+                return []
+            }
+        })
+        let (backend, url) = makeBackend(handler: handler)
+
+        let chunks: [Data] = [
+            sseData("THINK:pondering"),
+            sseData("THINK:DONE"),
+            sseData("TOKEN:answer"),
+        ]
+        MockURLProtocol.stub(url: url, response: .sse(chunks: chunks, statusCode: 200))
+
+        try await loadBackend(backend)
+        let stream = try backend.generate(prompt: "x", systemPrompt: nil, config: GenerationConfig())
+
+        var events: [GenerationEvent] = []
+        for try await event in stream.events {
+            events.append(event)
+        }
+
+        let expected: [GenerationEvent] = [
+            .thinkingToken("pondering"),
+            .thinkingComplete,
+            .token("answer"),
+        ]
+        #expect(events == expected,
+                "Handler-emitted .thinkingComplete must not be duplicated by the base loop; got \(events)")
+
+        let completes = events.filter { if case .thinkingComplete = $0 { return true } else { return false } }
+        #expect(completes.count == 1,
+                ".thinkingComplete must appear exactly once when the handler emits it explicitly")
+    }
+
+    // MARK: - (d) Multiple events per payload — one chunk, several events
+
+    /// A single SSE payload can return multiple events. This is the whole
+    /// point of the protocol change: a chunk that carries both reasoning
+    /// and visible text (some providers do this) gets classified natively,
+    /// without the base loop needing to stitch state together from two
+    /// separate payloads.
+    @Test func singlePayload_multipleEvents_allPassThroughInOrder() async throws {
+        let handler = EventEmittingHandler(events: { payload in
+            guard payload == "BOTH" else { return [] }
+            return [.thinkingToken("thought"), .token("visible")]
+        })
+        let (backend, url) = makeBackend(handler: handler)
+
+        let chunks: [Data] = [
+            sseData("BOTH"),
+        ]
+        MockURLProtocol.stub(url: url, response: .sse(chunks: chunks, statusCode: 200))
+
+        try await loadBackend(backend)
+        let stream = try backend.generate(prompt: "x", systemPrompt: nil, config: GenerationConfig())
+
+        var events: [GenerationEvent] = []
+        for try await event in stream.events {
+            events.append(event)
+        }
+
+        // Within the single payload: thinkingToken first, then the base loop
+        // injects .thinkingComplete because the next event is .token, then
+        // the .token itself.
+        let expected: [GenerationEvent] = [
+            .thinkingToken("thought"),
+            .thinkingComplete,
+            .token("visible"),
+        ]
+        #expect(events == expected,
+                "Multiple events in one payload must preserve order and boundary injection; got \(events)")
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `extractEvents(from:) -> [GenerationEvent]` to `SSEPayloadHandler`, with a default implementation that wraps the legacy `extractToken(from:)` result into `[.token(...)]`. Every existing conformer (`OpenAIPayloadHandler`, `ClaudePayloadHandler`, `OllamaPayloadHandler`, test-only handlers) keeps compiling without touching their source.
- Moves the `.thinkingComplete` lifecycle injection into `SSECloudBackend.parseResponseStream` (and the mirror helper in `SSEStreamParser.streamEvents`): a single `wasThinking` flag fires `.thinkingComplete` the first time a non-thinking-token event follows one or more thinking tokens. Handlers that emit `.thinkingComplete` themselves (inline-tag backends using `ThinkingParser`) clear the flag on pass-through, so the base loop never double-emits.
- Unblocks #604 (Claude `thinking_delta`) and #605 (OpenAI `reasoning_content`): each can classify its wire format into `.thinkingToken` / `.token` without duplicating SSE plumbing.

The `extractToken` protocol method and the `SSECloudBackend.extractToken` hook are left in place with a `TODO` pointing at #604/#605 — they get removed once those two migrate to `extractEvents`. `OllamaBackend` already overrides `parseResponseStream` end-to-end and is unaffected.

## Test plan

New `SSEExtractEventsTests` (Swift Testing, `BaseChatBackendsTests`) pins the contract:
- [x] Legacy handler that only implements `extractToken` still yields `.token` via the default shim.
- [x] Thinking → token transition injects `.thinkingComplete` exactly once, in the right slot.
- [x] Handler that emits `.thinkingComplete` itself is not duplicated by the base loop.
- [x] Single payload returning `[.thinkingToken, .token]` preserves order with boundary injection.
- [x] Sabotage check: deleted the `.thinkingComplete` injection branch → 3 of 4 tests failed; reverted.
- [x] Full CI suites pass locally: `BaseChatCoreTests`, `BaseChatInferenceTests`, `BaseChatInferenceSwiftTestingTests`, `BaseChatUITests`, `BaseChatBackendsTests`.

## Release Note

**SSE payload handlers can now emit multiple generation events per chunk** — the new `SSEPayloadHandler.extractEvents(from:)` API lets cloud backend payload handlers map one SSE payload to zero or more `GenerationEvent` values, and `SSECloudBackend`'s stream loop tracks a single `wasThinking` flag that injects `.thinkingComplete` exactly once at the boundary between reasoning and visible text. The legacy `extractToken(from:)` method keeps a default shim so every existing conformer compiles unchanged; it will be removed once the Claude and OpenAI backends migrate. This unblocks cross-provider thinking/reasoning routing (#604, #605) without forcing each backend to duplicate the SSE plumbing.

Closes #606.