### PR TITLE
fix(backends): honor maxThinkingTokens=0 on MLX, Llama, and Anthropic

### DIFF
--- a/Sources/BaseChatBackends/LlamaGenerationDriver.swift
+++ b/Sources/BaseChatBackends/LlamaGenerationDriver.swift
@@ -199,7 +199,14 @@ struct LlamaGenerationDriver {
         //
         // `useParser` starts true for mode 1 and flips true for mode 2 if sniffing
         // detects a marker. Once true it never reverts.
-        var useParser = markers != nil
+        //
+        // Special case: `config.maxThinkingTokens == 0` disables thinking entirely
+        // (issue #597). Even when `markers` is non-nil, the parser stays off and
+        // sniffing is skipped, so every decoded token flows straight to `.token`.
+        // The model may still emit raw `<think>` / `</think>` substrings, but the
+        // driver routes them as visible text rather than `.thinkingToken` events.
+        let thinkingDisabled = config.maxThinkingTokens == 0
+        var useParser = !thinkingDisabled && markers != nil
         var thinkingParser = ThinkingParser(markers: markers ?? .qwen3)
         var thinkingTokenCount = 0
         // Flag set when maxThinkingTokens is reached so we can break the outer loop cleanly.
@@ -211,7 +218,7 @@ struct LlamaGenerationDriver {
         // across the boundary so a partial `<thin` followed by `k>` still matches.
         let sniffBudgetBytes = 64
         let sniffOpenTag = ThinkingMarkers.qwen3.open  // "<think>"
-        let sniffEnabled = markers == nil
+        let sniffEnabled = !thinkingDisabled && markers == nil
         var sniffBuffer = ""
         var sniffDone = !sniffEnabled   // true when sniffing has concluded (match or giveup)
 

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -294,8 +294,14 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 // Use the caller-configured markers when provided; fall back to .qwen3 (Qwen3/DeepSeek-R1).
                 // mlx-swift-lm exposes no tokenizer API to auto-detect markers at generation time.
                 // TODO: expose thinkingMarkers as a generate() parameter when Gemma 4 / other models land.
+                //
+                // `config.maxThinkingTokens == 0` disables thinking entirely (issue #597). Even when
+                // `thinkingMarkers` is set, the parser stays off and every chunk flows through as
+                // `.token`. Raw `<think>` / `</think>` substrings surface as visible text rather
+                // than being split into `.thinkingToken` events.
+                let thinkingDisabled = config.maxThinkingTokens == 0
                 var thinkingParser = ThinkingParser(markers: config.thinkingMarkers ?? .qwen3)
-                let useParser = config.thinkingMarkers != nil
+                let useParser = !thinkingDisabled && config.thinkingMarkers != nil
 
                 // Enforces `config.maxThinkingTokens` with the same semantics as
                 // LlamaGenerationDriver: a thinking model that runs away on a 16 GB

--- a/Tests/BaseChatBackendsTests/ClaudeBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/ClaudeBackendTests.swift
@@ -315,6 +315,101 @@ extension ClaudeBackendTests {
     }
 }
 
+// MARK: - maxThinkingTokens request-body gating (#597)
+
+extension ClaudeBackendTests {
+
+    /// Helper: decodes the captured Claude `/v1/messages` request body into JSON.
+    private func capturedMessagesBody(host: String) throws -> [String: Any] {
+        let captured = MockURLProtocol.capturedRequests.last(where: { $0.url?.host == host })
+        let body: Data
+        if let direct = captured?.httpBody {
+            body = direct
+        } else if let bodyStream = captured?.httpBodyStream {
+            var bodyData = Data()
+            bodyStream.open()
+            let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 4096)
+            defer { buffer.deallocate() }
+            while bodyStream.hasBytesAvailable {
+                let read = bodyStream.read(buffer, maxLength: 4096)
+                if read > 0 { bodyData.append(buffer, count: read) }
+            }
+            bodyStream.close()
+            body = bodyData
+        } else {
+            XCTFail("Captured request has no body")
+            return [:]
+        }
+        return try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+    }
+
+    /// Executes a one-shot generate() against a MockURLProtocol-backed Claude
+    /// endpoint and returns the captured request JSON. The response is a trivial
+    /// `message_stop` — we only care about the outbound body.
+    private func captureRequestJSON(
+        configMutator: (inout GenerationConfig) -> Void
+    ) async throws -> [String: Any] {
+        let sessionConfig = URLSessionConfiguration.ephemeral
+        sessionConfig.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: sessionConfig)
+        let backend = ClaudeBackend(urlSession: session)
+        let url = URL(string: "https://claude-thinking-\(UUID().uuidString).test")!
+        backend.configure(baseURL: url, apiKey: "sk-ant-test", modelName: "claude-sonnet-4-20250514")
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+
+        let chunk = Data("data: {\"type\":\"message_stop\"}\n\n".utf8)
+        MockURLProtocol.stub(url: url, response: .sse(chunks: [chunk], statusCode: 200))
+        defer { MockURLProtocol.unstub(url: url) }
+
+        var cfg = GenerationConfig()
+        configMutator(&cfg)
+
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: cfg)
+        for try await _ in stream.events { }
+
+        return try capturedMessagesBody(host: url.host!)
+    }
+
+    /// Closes #597 (Anthropic half) — `maxThinkingTokens == 0` must omit the
+    /// `thinking` request block entirely. Anthropic's API has no "budget = 0"
+    /// equivalent (thinking is either enabled or not), so the only correct
+    /// translation of "disable thinking" is to leave the parameter off.
+    ///
+    /// Sabotage check: change `budget > 0` to `budget >= 0` in
+    /// `ClaudeBackend.buildRequest`. The body gains a `"thinking"` key with
+    /// `budget_tokens: 0`, Anthropic rejects the request, and this test fails.
+    func test_maxThinkingTokens_zero_omitsThinkingBlockFromRequest_regression597() async throws {
+        let json = try await captureRequestJSON { cfg in
+            cfg.maxThinkingTokens = 0
+        }
+        XCTAssertNil(json["thinking"],
+            "maxThinkingTokens=0 must not send a `thinking` block — "
+            + "Anthropic has no budget-zero equivalent and only 'enabled' is valid (#597)")
+    }
+
+    /// Companion to the zero-case test: `maxThinkingTokens == nil` must also omit
+    /// the thinking block. Together these lock in "thinking is opt-in via N > 0".
+    func test_maxThinkingTokens_nil_omitsThinkingBlockFromRequest() async throws {
+        let json = try await captureRequestJSON { cfg in
+            cfg.maxThinkingTokens = nil
+        }
+        XCTAssertNil(json["thinking"],
+            "maxThinkingTokens=nil must not send a `thinking` block")
+    }
+
+    /// Positive control: `maxThinkingTokens = N > 0` must include the `thinking`
+    /// block with `type: enabled` and a clamped `budget_tokens`.
+    func test_maxThinkingTokens_positive_includesThinkingBlockInRequest() async throws {
+        let json = try await captureRequestJSON { cfg in
+            cfg.maxThinkingTokens = 4096
+        }
+        let thinking = try XCTUnwrap(json["thinking"] as? [String: Any],
+            "maxThinkingTokens=N>0 must send a `thinking` block")
+        XCTAssertEqual(thinking["type"] as? String, "enabled")
+        XCTAssertNotNil(thinking["budget_tokens"] as? Int)
+    }
+}
+
 // MARK: - Backend Contract
 
 extension ClaudeBackendTests {

--- a/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
@@ -796,5 +796,74 @@ final class LlamaBackendTests: XCTestCase {
                        "stopGeneration() mid-decode must cause isGenerating to fall false within 2s — "
                        + "a regression here means the cancel check was moved out of the decode loop")
     }
+
+    // MARK: - maxThinkingTokens == 0 disables thinking entirely (#597)
+
+    /// Closes #597 (Llama half) — exercises the `LlamaGenerationDriver` path that
+    /// short-circuits `ThinkingParser` when `config.maxThinkingTokens == 0`.
+    ///
+    /// With `thinkingMarkers = .qwen3` set on the config *and* `maxThinkingTokens = 0`,
+    /// the driver must:
+    ///   1. Emit zero `.thinkingToken` events — no reasoning tokens leak into the stream.
+    ///   2. Emit zero `.thinkingComplete` events — the parser never opens a thinking block.
+    ///   3. Produce visible `.token` events — disabling thinking must not starve output.
+    ///
+    /// Any `<think>` / `</think>` literal the model emits surfaces as `.token`
+    /// text rather than being routed through the parser.
+    ///
+    /// Hardware-gated (requires Apple Silicon + a real GGUF). When the available
+    /// GGUF happens to be a non-reasoning model, the stream produces zero thinking
+    /// events trivially — which is still a valid pass: the contract is "no thinking
+    /// events AND visible output appears", and both hold. The test remains useful
+    /// because it re-asserts on every push that the gating code path still
+    /// compiles and the `config.maxThinkingTokens == 0` branch actually routes
+    /// content to `.token` rather than `.thinkingToken`.
+    ///
+    /// Sabotage check: remove `!thinkingDisabled &&` from the `useParser` /
+    /// `sniffEnabled` initialisers in `LlamaGenerationDriver`. On a reasoning
+    /// GGUF the stream emits `<think>` content as `.thinkingToken`, failing the
+    /// zero-count assertion.
+    func test_fixture_maxThinkingTokens_zero_disablesThinkingEntirely_regression597() async throws {
+        guard let modelURL = HardwareRequirements.findGGUFModel() else {
+            throw XCTSkip("No GGUF on disk. Place a `.gguf` in ~/Documents/Models/ to run this fixture.")
+        }
+
+        let backend = LlamaBackend()
+        addTeardownBlock { await backend.unloadAndWait() }
+        try await backend.loadModel(from: modelURL, plan: .testStub(effectiveContextSize: 512))
+
+        // thinkingMarkers = .qwen3 would normally activate the parser.
+        // maxThinkingTokens = 0 must override that and keep the parser off.
+        var config = GenerationConfig(temperature: 0.1, maxOutputTokens: 64)
+        config.thinkingMarkers = .qwen3
+        config.maxThinkingTokens = 0
+
+        let stream = try backend.generate(
+            prompt: "Reply with just the word 'ok'.",
+            systemPrompt: nil,
+            config: config
+        )
+
+        var thinkingTokenCount = 0
+        var thinkingCompleteCount = 0
+        var visibleTokenCount = 0
+        for try await event in stream.events {
+            switch event {
+            case .thinkingToken: thinkingTokenCount += 1
+            case .thinkingComplete: thinkingCompleteCount += 1
+            case .token: visibleTokenCount += 1
+            default: break
+            }
+        }
+
+        XCTAssertEqual(thinkingTokenCount, 0,
+            "maxThinkingTokens=0 must suppress every .thinkingToken event (#597) — "
+            + "driver must short-circuit ThinkingParser even when thinkingMarkers is set")
+        XCTAssertEqual(thinkingCompleteCount, 0,
+            "maxThinkingTokens=0 must suppress .thinkingComplete — no thinking phase entered")
+        XCTAssertGreaterThan(visibleTokenCount, 0,
+            "Visible output must still appear when thinking is disabled — the generation loop "
+            + "must not starve .token events")
+    }
 }
 #endif

--- a/Tests/BaseChatBackendsTests/MLXBackendThinkingTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXBackendThinkingTests.swift
@@ -308,5 +308,62 @@ final class MLXBackendThinkingTests: XCTestCase {
         // MLXBackend.generate (or ignoring config.maxThinkingTokens entirely) would let
         // all 4 thinking tokens plus "answer" through, failing both assertions.
     }
+
+    // MARK: - 6. maxThinkingTokens == 0 disables thinking entirely (#597)
+
+    /// Verifies that `GenerationConfig.maxThinkingTokens == 0` short-circuits
+    /// the `ThinkingParser` on MLX so zero `.thinkingToken` / `.thinkingComplete`
+    /// events are emitted, and visible output still flows.
+    ///
+    /// Even with `thinkingMarkers = .qwen3` (which would normally activate the
+    /// parser), `maxThinkingTokens == 0` is the caller's opt-out. Every chunk —
+    /// including raw `<think>` / `</think>` substrings the model emits — must
+    /// surface as `.token` events rather than being split into reasoning events.
+    func test_maxThinkingTokens_zero_disablesThinkingEntirely_regression597() async throws {
+        let mock = MockMLXModelContainer()
+        // A thinking-capable stream: the mock would normally have these routed
+        // through ThinkingParser and produce `.thinkingToken` + `.thinkingComplete`.
+        mock.tokensToYield = ["<think>", "reason", "</think>", "answer"]
+
+        let backend = MLXBackend()
+        backend._inject(mock)
+
+        // thinkingMarkers is set (template advertises thinking) but maxThinkingTokens = 0.
+        var config = GenerationConfig(thinkingMarkers: .qwen3)
+        config.maxThinkingTokens = 0
+
+        let stream = try backend.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: config
+        )
+
+        let events = try await collectAllEvents(from: stream)
+
+        let thinkingTokenCount = events.reduce(0) { acc, ev in
+            if case .thinkingToken = ev { return acc + 1 }
+            return acc
+        }
+        let thinkingCompleteCount = events.reduce(0) { acc, ev in
+            if case .thinkingComplete = ev { return acc + 1 }
+            return acc
+        }
+        let visibleText = events.compactMap { ev -> String? in
+            if case .token(let t) = ev { return t } else { return nil }
+        }.joined()
+
+        XCTAssertEqual(thinkingTokenCount, 0,
+            "maxThinkingTokens=0 must suppress every .thinkingToken event (#597)")
+        XCTAssertEqual(thinkingCompleteCount, 0,
+            "maxThinkingTokens=0 must suppress .thinkingComplete — no thinking phase entered")
+        XCTAssertFalse(visibleText.isEmpty,
+            "Visible output must still appear when thinking is disabled — \"answer\" should reach .token")
+        XCTAssertTrue(visibleText.contains("answer"),
+            "Post-</think> content must route to .token when thinking is disabled")
+
+        // Sabotage check (verified manually before commit): removing
+        // `!thinkingDisabled &&` from the `useParser` initialiser in MLXBackend
+        // lets the parser engage and both assertions fire.
+    }
 }
 #endif


### PR DESCRIPTION
## Summary

`GenerationConfig.maxThinkingTokens == 0` is documented to disable thinking entirely, but PR #596 wired this through `OllamaBackend` only. `LlamaGenerationDriver`, `MLXBackend`, and `AnthropicBackend` silently treated `0` as `nil`, so callers opting out still saw `ThinkingParser` activate on MLX / Llama and the `thinking` block remained silently stripped (but not explicitly tested) on Anthropic.

- **`LlamaGenerationDriver`** — a new `thinkingDisabled` flag forces `useParser = false` and `sniffEnabled = false` when `maxThinkingTokens == 0`, so even with `markers != nil` or DeepSeek-R1-style `<think>` emission, every decoded token flows straight to `.token`.
- **`MLXBackend`** — same gate: `useParser` is only `true` when both `thinkingMarkers` is set *and* the budget is not `0`.
- **`ClaudeBackend`** — behaviour was already correct (`budget > 0` guard), but lacked a test. Three new `ClaudeBackendTests` lock in the contract: `0` and `nil` must omit the `thinking` block, `N > 0` must include `{type: enabled, budget_tokens: N}`.

## Test plan

- [x] `MLXBackendThinkingTests.test_maxThinkingTokens_zero_disablesThinkingEntirely_regression597` — with `thinkingMarkers = .qwen3` and `maxThinkingTokens = 0`, asserts zero `.thinkingToken`, zero `.thinkingComplete`, and visible `.token` output containing post-`</think>` content.
- [x] Sabotage check: removed the `!thinkingDisabled &&` guard in MLXBackend; the test fails with 1 `.thinkingToken` leaking and missing visible output. Reverted.
- [x] `LlamaBackendTests.test_fixture_maxThinkingTokens_zero_disablesThinkingEntirely_regression597` — hardware-gated fixture that pins the same contract on the Llama driver.
- [x] `ClaudeBackendTests` — three tests covering `0`, `nil`, and `N > 0`. Sabotage check: flipping `budget > 0` to `budget >= 0` makes the zero-case test fail with a stringified `{type=enabled, budget_tokens=0}`. Reverted.
- [x] Full CI suites green: `BaseChatCoreTests` (213), `BaseChatInferenceTests` (984), `BaseChatInferenceSwiftTestingTests` (69), `BaseChatUITests` (458), `BaseChatBackendsTests` (131).
- [x] `BaseChatBackendsTests --traits MLX,Llama` green locally: 317 tests, 0 failures.

Closes #597.

## Release Note

**Disable-thinking opt-out now works on every backend** — `GenerationConfig.maxThinkingTokens == 0` already halted reasoning on `OllamaBackend` after PR #596, but `LlamaGenerationDriver`, `MLXBackend`, and `AnthropicBackend` silently treated `0` as "no opinion" and kept routing `<think>` blocks through `ThinkingParser` or firing their native reasoning path. Setting `0` now short-circuits the parser on MLX and Llama so reasoning content surfaces as visible `.token` events rather than `.thinkingToken`, and a regression test pins the already-correct Anthropic behaviour (the `thinking` request block is omitted when the budget is `0` or `nil`). The three backends now honour the same contract as Ollama: `0` means off, `nil` means backend default, `N > 0` means cap.