### PR TITLE
fix: gate fuzz-chat backends on Fuzz trait and declare BaseChatTools resources

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a44830f46120a6c3108ff93418db8e9529723e5dd91a1a4ba616c9585f13c7c2",
+  "originHash" : "ce68ec635a0706f2d6b283799b73438436025427fbc97d5dbd4cfd4ec13a2236",
   "pins" : [
     {
       "identity" : "eventsource",

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,11 @@ let package = Package(
         .default(enabledTraits: ["MLX", "Llama"]),
         .trait(name: "MLX", description: "Enable the MLX inference backend (requires Apple Silicon)"),
         .trait(name: "Llama", description: "Enable the llama.cpp (GGUF) inference backend"),
+        // Fuzz is intentionally NOT a default trait. Enabling it adds BaseChatBackends
+        // (and transitively LlamaSwift) to fuzz-chat, which conflicts with the MLX
+        // integration test targets in the auto-generated Xcode scheme. Run the fuzzer via
+        // scripts/fuzz.sh, which passes --traits Fuzz,MLX,Llama explicitly.
+        .trait(name: "Fuzz", description: "Enable real inference backends in fuzz-chat (Ollama, Llama, Foundation). Required by scripts/fuzz.sh; not needed for swift test or xcodebuild test."),
     ],
     dependencies: [
         .package(url: "https://github.com/ml-explore/mlx-swift.git", from: "0.31.3"),
@@ -166,13 +171,22 @@ let package = Package(
             resources: [.process("Resources")]
         ),
         // CLI driver. Wires Ollama, Llama, Foundation; MLX runs via xcodebuild fuzz path.
+        // BaseChatBackends is conditional on the Fuzz trait to avoid a llama.framework
+        // copy conflict with BaseChatMLXIntegrationTests in the auto-generated Xcode scheme.
+        // Use scripts/fuzz.sh (which passes --traits Fuzz,MLX,Llama) to run the fuzzer.
         .executableTarget(
             name: "fuzz-chat",
-            dependencies: ["BaseChatFuzz", "BaseChatBackends", "BaseChatInference", "BaseChatTestSupport"],
+            dependencies: [
+                "BaseChatFuzz",
+                "BaseChatInference",
+                "BaseChatTestSupport",
+                .target(name: "BaseChatBackends", condition: .when(traits: ["Fuzz"])),
+            ],
             path: "Sources/fuzz-chat",
             swiftSettings: [
                 .define("MLX", .when(traits: ["MLX"])),
                 .define("Llama", .when(traits: ["Llama"])),
+                .define("Fuzz", .when(traits: ["Fuzz"])),
             ]
         ),
         .testTarget(
@@ -199,7 +213,11 @@ let package = Package(
             dependencies: [
                 "BaseChatInference",
             ],
-            path: "Sources/BaseChatTools"
+            path: "Sources/BaseChatTools",
+            exclude: ["Scenarios/built-in/README.md", "README.md"],
+            resources: [
+                .copy("Scenarios/built-in"),
+            ]
         ),
         .executableTarget(
             name: "bck-tools",

--- a/Sources/fuzz-chat/FoundationFuzzFactory.swift
+++ b/Sources/fuzz-chat/FoundationFuzzFactory.swift
@@ -1,4 +1,4 @@
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && Fuzz
 import Foundation
 import BaseChatFuzz
 import BaseChatBackends

--- a/Sources/fuzz-chat/FuzzChatCLI.swift
+++ b/Sources/fuzz-chat/FuzzChatCLI.swift
@@ -1,8 +1,10 @@
 import Foundation
 import BaseChatFuzz
-import BaseChatBackends
 import BaseChatInference
 import BaseChatTestSupport
+#if Fuzz
+import BaseChatBackends
+#endif
 
 @main
 @MainActor
@@ -105,30 +107,34 @@ struct FuzzChatCLI {
         let factory: any FuzzBackendFactory
         switch backend {
         case .ollama:
+            #if Fuzz
             do {
                 factory = try Self.makeOllamaFactory(modelHint: modelHint)
             } catch {
                 fail(String(describing: error))
             }
+            #else
+            fail("Ollama backend requires the Fuzz build trait. Run via: scripts/fuzz.sh")
+            #endif
         case .mock:
             factory = MockFuzzFactory()
         case .chaos:
             factory = ChaosFuzzFactory()
         case .llama:
-            #if Llama
+            #if Llama && Fuzz
             factory = LlamaFuzzFactory()
             #else
-            fail("Llama backend requires the Llama build trait. Build with --traits Llama.")
+            fail("Llama backend requires the Fuzz and Llama build traits. Run via: scripts/fuzz.sh")
             #endif
         case .foundation:
-            #if canImport(FoundationModels)
+            #if canImport(FoundationModels) && Fuzz
             if #available(macOS 26, iOS 26, *) {
                 factory = FoundationFuzzFactory()
             } else {
                 fail("Foundation backend requires macOS 26 or iOS 26.")
             }
             #else
-            fail("Foundation backend requires macOS 26+ with FoundationModels.")
+            fail("Foundation backend requires macOS 26+ with FoundationModels and the Fuzz build trait. Run via: scripts/fuzz.sh")
             #endif
         case .mlx, .all:
             fail("\(backend.rawValue) backend not yet wired in CLI. Use scripts/fuzz.sh --with-mlx for MLX.")
@@ -196,6 +202,7 @@ struct FuzzChatCLI {
         await factory.teardown()
     }
 
+    #if Fuzz
     /// Builds the Ollama-backed factory for the runner.
     ///
     /// - When `modelHint` is `nil` or `"all"`: enumerates every installed Ollama
@@ -231,6 +238,7 @@ struct FuzzChatCLI {
         let children: [any FuzzBackendFactory] = sorted.map { OllamaFuzzFactory(modelHint: $0) }
         return RotatingFuzzFactory(children: children)
     }
+    #endif
 
     /// Drives the Replayer and maps its `Outcome` to an exit code + summary line.
     /// Exit codes match the issue brief:
@@ -362,7 +370,7 @@ struct FuzzChatCLI {
         let lines = [
             "fuzz-chat — chat anomaly fuzzer",
             "",
-            "Usage: swift run fuzz-chat [options]",
+            "Usage: swift run --traits Fuzz,MLX,Llama fuzz-chat [options]",
             "",
             "Options:",
             "  --backend ollama|mock|chaos|llama|foundation|mlx|all   default: ollama",

--- a/Sources/fuzz-chat/LlamaFuzzFactory.swift
+++ b/Sources/fuzz-chat/LlamaFuzzFactory.swift
@@ -1,4 +1,4 @@
-#if Llama
+#if Llama && Fuzz
 import Foundation
 import BaseChatFuzz
 import BaseChatBackends

--- a/Sources/fuzz-chat/OllamaFuzzFactory.swift
+++ b/Sources/fuzz-chat/OllamaFuzzFactory.swift
@@ -1,3 +1,4 @@
+#if Fuzz
 import Foundation
 import BaseChatFuzz
 import BaseChatBackends
@@ -46,3 +47,4 @@ public struct OllamaFuzzFactory: FuzzBackendFactory {
         )
     }
 }
+#endif

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -126,7 +126,7 @@ echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "  FUZZ SUMMARY"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-printf "  swift run --traits Fuzz,MLX,Llama fuzz-chat exit:   %d\n" "$SWIFT_EXIT"
+printf "  fuzz-chat exit:             %d\n" "$SWIFT_EXIT"
 if [[ $WITH_MLX -eq 1 ]]; then
     printf "  xcodebuild MLXFuzzTests:    %d\n" "$MLX_EXIT"
 fi

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # scripts/fuzz.sh — Run the BaseChatFuzz harness with a friendly preflight.
 #
-# Default behaviour (no args): runs `swift run fuzz-chat --minutes 5` against
+# Default behaviour (no args): runs `swift run --traits Fuzz,MLX,Llama fuzz-chat --minutes 5` against
 # Ollama. Discovers which backends are usable and prints a one-line summary
 # before kicking off the harness. Forwards all CLI args straight through to
 # `fuzz-chat`, with one local extension:
@@ -22,15 +22,15 @@ for arg in "$@"; do
         --with-mlx) WITH_MLX=1 ;;
         -h|--help)
             cd "$PACKAGE_DIR"
-            echo "scripts/fuzz.sh — wrapper around \`swift run fuzz-chat\`"
+            echo "scripts/fuzz.sh — wrapper around \`swift run --traits Fuzz,MLX,Llama fuzz-chat\`"
             echo ""
             echo "Local flags:"
             echo "  --with-mlx   Also run the MLX XCTest fuzz suite via xcodebuild"
             echo "  -h, --help   Show this help and forward to fuzz-chat -h"
             echo ""
-            echo "Forwarding to: swift run fuzz-chat -h"
+            echo "Forwarding to: swift run --traits Fuzz,MLX,Llama fuzz-chat -h"
             echo "─────────────────────────────────────────────────────────────"
-            swift run fuzz-chat -h || true
+            swift run --traits Fuzz,MLX,Llama fuzz-chat -h || true
             exit 0
             ;;
         *) FORWARDED_ARGS+=("$arg") ;;
@@ -95,11 +95,11 @@ fi
 cd "$PACKAGE_DIR"
 
 echo ""
-echo "Running: swift run fuzz-chat ${FORWARDED_ARGS[*]:-}"
+echo "Running: swift run --traits Fuzz,MLX,Llama fuzz-chat ${FORWARDED_ARGS[*]:-}"
 echo ""
 
 set +e
-swift run fuzz-chat "${FORWARDED_ARGS[@]:-}"
+swift run --traits Fuzz,MLX,Llama fuzz-chat "${FORWARDED_ARGS[@]:-}"
 SWIFT_EXIT=$?
 set -e
 
@@ -126,7 +126,7 @@ echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "  FUZZ SUMMARY"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-printf "  swift run fuzz-chat exit:   %d\n" "$SWIFT_EXIT"
+printf "  swift run --traits Fuzz,MLX,Llama fuzz-chat exit:   %d\n" "$SWIFT_EXIT"
 if [[ $WITH_MLX -eq 1 ]]; then
     printf "  xcodebuild MLXFuzzTests:    %d\n" "$MLX_EXIT"
 fi


### PR DESCRIPTION
## Summary

- Fixes the `xcodebuild test -only-testing BaseChatMLXIntegrationTests` build failure introduced when `fuzz-chat` was added to the package — all 7 MLX integration tests now pass against a real model
- Eliminates the `BaseChatTools` unhandled-resource build warning and bundles the built-in scenario JSON files for future `Bundle.module` access

## Changes

### `Fuzz` package trait (Package.swift, fuzz-chat sources, scripts/fuzz.sh)

The auto-generated `BaseChatKit-Package` Xcode scheme builds all products, including `fuzz-chat`. Because `fuzz-chat` unconditionally depended on `BaseChatBackends` (which links `LlamaSwift` when the default `Llama` trait is active), both `fuzz-chat` and `BaseChatMLXIntegrationTests` tried to copy `llama.framework` to the same `Build/Products/Debug/Frameworks/` directory. Xcode 26's strict build system treats this as a hard error.

**Fix**: a new non-default `Fuzz` trait gates `fuzz-chat`'s `BaseChatBackends` dependency. Without `Fuzz`, `fuzz-chat` compiles but links no inference backend — it still supports `--backend mock` and `--backend chaos`. Source files are guarded:

| File | Guard |
|------|-------|
| `OllamaFuzzFactory.swift` | `#if Fuzz` |
| `LlamaFuzzFactory.swift` | `#if Llama && Fuzz` |
| `FoundationFuzzFactory.swift` | `#if canImport(FoundationModels) && Fuzz` |
| `FuzzChatCLI.swift` | `#if Fuzz` around import + ollama/llama/foundation cases |

`scripts/fuzz.sh` passes `--traits Fuzz,MLX,Llama` explicitly, so the fuzzer retains full backend support.

### `BaseChatTools` resource declaration (Package.swift)

`Sources/BaseChatTools/Scenarios/built-in/*.json` were unhandled by SPM, producing a warning on every build. `ScenarioLoader.builtInDirectory()` intentionally uses `currentDirectoryPath` (not `Bundle.module`) for dev/CLI use, so the files were accessible at runtime in typical usage. The resource declaration eliminates the warning and bundles the JSON files for `Bundle.module` access if the loading strategy changes in future. Both READMEs are excluded; the `built-in/` directory is declared as `.copy`.

## Test plan

- [x] `swift build --target fuzz-chat --disable-default-traits --traits MLX,Llama` — compiles without `Fuzz`, no errors
- [x] `swift build --target fuzz-chat --disable-default-traits --traits Fuzz,MLX,Llama` — compiles with full backends
- [x] `xcodebuild test -scheme BaseChatKit-Package -only-testing BaseChatMLXIntegrationTests -destination 'platform=macOS'` — 7/7 pass (Meta-Llama-3.1-8B-Instruct-4bit)
- [x] `swift build --target BaseChatTools` — no unhandled-file warning
- [x] Full CI suite (`BaseChatCoreTests`, `BaseChatInferenceTests`, `BaseChatInferenceSwiftTestingTests`, `BaseChatUITests`, `BaseChatBackendsTests` all `--disable-default-traits`) — 0 failures

## Release Note

Fixes a `"Multiple commands produce llama.framework"` build error that prevented `xcodebuild test -only-testing BaseChatMLXIntegrationTests` from running on Xcode 26. Also silences the `BaseChatTools` unhandled-resource build warning and bundles scenario JSON files. No API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)