### PR TITLE
docs: lock in Prisma-style release notes as the default

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,9 +8,28 @@
 
 ## Release Note
 
-<!-- For feat: and fix: PRs, write the changelog entry here in prose style.
-     Format: **Bold title** — Problem, what changed, why it matters.
-     This is copied into CHANGELOG.md at release time.
+<!-- For feat: and fix: PRs, draft the release-note fragment here in the
+     Prisma-style format used by BaseChatKit since v0.11.2. This gets copied
+     into CHANGELOG.md at release time, so write it like a reader sees it.
+
+     For a HEADLINE feature (new subsystem, cross-cutting change, API
+     consumers need to know about), use this shape:
+
+         #### Short verb-led headline
+
+         2–3 sentences: the problem, what shipped, how it fits together.
+
+         ```swift
+         // 4–8 lines showing the new API in use
+         ```
+
+         One more sentence of caveats, opt-in/out semantics, or "see [#N]".
+
+     For a SMALL feature or fix, one bullet is enough — match the style
+     of the Features/Fixes sections in CHANGELOG.md:
+
+         - **scope:** what changed — why it matters ([#N])
+
      For chore/test/docs PRs, write "N/A". -->
 
 ## Testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,21 +45,84 @@ Fixed on `LlamaGenerationDriver` and `MLXBackend`. `ClaudeBackend` was already c
 
 ## [0.11.1](https://github.com/roryford/BaseChatKit/compare/v0.11.0...v0.11.1) (2026-04-21)
 
-**Security hardening, Ollama reliability, and native JSON-mode responses** — This release tightens three orthogonal gaps that an external documentation audit surfaced. On the remote path, `BaseChatConfiguration` now enforces canonical endpoint validation on the actual cloud-connect code path (not just the UI save flow), a new `DNSRebindingGuard` blocks requests whose DNS resolves to RFC1918, link-local, multicast, IMDS, or other reserved addresses at request time, and a `CustomHostTrustPolicy` lets apps opt into fail-closed TLS trust for custom hosts that requires explicit pins ([#613](https://github.com/roryford/BaseChatKit/issues/613)). The platform-default compatibility mode is preserved unless the caller explicitly tightens it, so existing apps see no behavior change until they opt in.
+### Highlights
 
-On the local-first path, `OllamaBackend` gains four hardening changes motivated by silent-failure modes in Ollama's wire contract ([#610](https://github.com/roryford/BaseChatKit/issues/610)). The backend now derives `options.num_ctx` from the `ModelLoadPlan` on every request — with an 8192-token floor for the `.cloud()` default — closing the footgun where Ollama's server-side 2048-token default would truncate multi-turn conversations with no error signal. When a Qwen3-style model emits reasoning inline as `<think>…</think>` in `message.content` instead of populating the dedicated `thinking` field, `ThinkingParser` now engages as a fallback so the existing thinking UI treats it correctly instead of rendering raw tags. Model tags ending in `:cloud` — which Ollama v0.18.0+ silently routes to its hosted cloud service — are now rejected at load time with a descriptive error, so a local-first configuration can't accidentally leak prompts off-device. A follow-up `TODO(#55)` is pinned in `buildRequest` so the next author wiring tool calling flips the stream mode correctly, since Ollama's streaming drops `tool_calls` delta chunks.
+#### Remote-endpoint hardening closes SSRF and DNS-rebinding gaps
 
-Callers can now request JSON-formatted responses in a backend-agnostic way via `GenerationConfig.jsonMode` and `BackendCapabilities.supportsNativeJSONMode` ([#615](https://github.com/roryford/BaseChatKit/issues/615)). The flag maps to OpenAI's `response_format: { type: "json_object" }` and Ollama's `format: "json"` where supported; backends without native JSON mode (Claude, Llama, MLX, Foundation) now emit a `Log.inference.warning` naming the backend and the capability flag, so callers can branch on `backend.capabilities.supportsNativeJSONMode` rather than silently getting plain-text back.
+Canonical endpoint validation moves onto the actual cloud-connect code path (not just the UI save flow), a new `DNSRebindingGuard` blocks requests whose DNS resolves to RFC1918, link-local, multicast, IMDS, or other reserved addresses at request time, and `CustomHostTrustPolicy` lets apps opt into fail-closed TLS trust that requires explicit pins.
+
+```swift
+let config = BaseChatConfiguration(
+    customHostTrustPolicy: .requireExplicitPins
+)
+// Register SPKI pins via PinnedSessionDelegate.pinnedHosts
+// before the first request. Unpinned hosts are rejected.
+```
+
+`.platformDefault` stays the default, so existing apps see no behavior change until they opt in. See [#613](https://github.com/roryford/BaseChatKit/issues/613).
+
+#### `OllamaBackend` stops silently losing context and leaking prompts
+
+Four fixes motivated by silent-failure modes in Ollama's wire contract. `options.num_ctx` is now derived from `ModelLoadPlan` on every request with an 8192-token floor on `.cloud()`, closing the footgun where Ollama's server-side 2048-token default truncated multi-turn conversations with no error signal. Qwen3-style models that emit reasoning inline as `<think>…</think>` in `message.content` (instead of populating the dedicated `thinking` field) now route through `ThinkingParser` as a fallback. And model tags ending in `:cloud` — which Ollama v0.18.0+ silently routes to its hosted cloud service — are rejected at load time, so a local-first configuration can't accidentally leak prompts off-device.
+
+See [#610](https://github.com/roryford/BaseChatKit/issues/610).
+
+#### Backend-agnostic JSON mode
+
+```swift
+let config = GenerationConfig(jsonMode: true)
+guard backend.capabilities.supportsNativeJSONMode else { return }
+```
+
+Maps to OpenAI's `response_format: { type: "json_object" }` and Ollama's `format: "json"` where supported. Backends without native JSON mode (Claude, Llama, MLX, Foundation) emit a `Log.inference.warning` naming the backend and the capability flag — callers branch on `backend.capabilities.supportsNativeJSONMode` rather than silently getting plain-text back. See [#615](https://github.com/roryford/BaseChatKit/issues/615).
 
 ## [0.11.0](https://github.com/roryford/BaseChatKit/compare/v0.10.2...v0.11.0) (2026-04-20)
 
-**Full cross-backend thinking-token support and non-LM model guardrails** — v0.10.0 shipped `ThinkingParser` and wire-up for Ollama and Llama backends; this release extends the same pipeline to every backend and fixes the gaps that live fuzz runs found. `MLXBackend` now enforces `maxThinkingTokens` the same way `LlamaGenerationDriver` does, stopping a runaway reasoning model before it can OOM a 16 GB Mac, and routes all output through `ThinkingParser` so `<think>` blocks stream as structured events rather than raw text ([#591](https://github.com/roryford/BaseChatKit/issues/591)). Cloud backends (`ClaudeBackend` and the OpenAI-compatible adapter) now parse Anthropic extended-thinking content blocks and OpenAI reasoning deltas into the same `GenerationEvent.thinkingToken` / `.thinkingComplete` events, so cloud reasoning responses render in `ThinkingBlockView` without any host-side changes ([#589](https://github.com/roryford/BaseChatKit/issues/589)). `LlamaBackend` gains thinking-marker detection for models that use the Llama 3 prompt template (DeepSeek-R1 and peers), which previously only worked on ChatML-formatted GGUFs ([#592](https://github.com/roryford/BaseChatKit/issues/592)).
+### ⚠️ Breaking change
 
-Two new guardrails prevent silent crashes when the wrong model type is loaded: both `MLXBackend` and `LlamaBackend` now throw `InferenceError.unsupportedModelArchitecture` at load time if handed a CLIP vision encoder, BERT embedder, Whisper audio model, or other non-LM GGUF — instead of crashing inside the decode loop ([#591](https://github.com/roryford/BaseChatKit/issues/591), [#592](https://github.com/roryford/BaseChatKit/issues/592)).
+`maxThinkingTokens = nil` no longer reserves a 2048-token thinking budget on non-thinking Ollama models. Callers who want guaranteed budget reservation on unknown models should pass an explicit `N`.
 
-On the Ollama side, `OllamaBackend` now probes `/api/show` at `loadModel` time to classify whether a model is thinking-capable, and `GenerationConfig.maxThinkingTokens = 0` is honoured by forwarding `"think": false` so reasoning-capable models (e.g. `gemma4`, `qwen3`) skip chain-of-thought when the host opts out ([#596](https://github.com/roryford/BaseChatKit/issues/596)). A companion fix ensures `ContextWindowManager` reserves both visible and thinking output budgets in its trim math, preventing reasoning-heavy responses from silently pushing prompt history out of context ([#595](https://github.com/roryford/BaseChatKit/issues/595)). Three new fuzz scenarios — disable thinking, cancel mid-thought, retry after a mid-thinking network flake — each asserting a specific invariant on the consumer's event stream — were added before this shipped to catch regressions the random corpus cannot reach reliably ([#590](https://github.com/roryford/BaseChatKit/issues/590)).
+### Highlights
 
-**Breaking change:** `maxThinkingTokens=nil` no longer reserves a 2048-token thinking budget on non-thinking Ollama models. Callers who want guaranteed budget reservation on unknown models should pass an explicit `N` value.
+#### Thinking tokens work on every backend
+
+v0.10.0 shipped `ThinkingParser` for Ollama and Llama. This release extends the same pipeline to MLX and cloud, so `<think>` blocks from any backend stream as structured `GenerationEvent.thinkingToken` / `.thinkingComplete` events — and `ThinkingBlockView` renders them without any host-side changes.
+
+```swift
+for try await event in stream.events {
+    switch event {
+    case .thinkingToken(let text): /* reasoning chunk */
+    case .thinkingComplete:        /* reasoning finished */
+    case .token(let text):         /* visible output */
+    }
+}
+```
+
+`MLXBackend` now enforces `maxThinkingTokens` the same way `LlamaGenerationDriver` does, stopping a runaway reasoning model before it can OOM a 16 GB Mac. `ClaudeBackend` parses Anthropic extended-thinking content blocks, the OpenAI-compatible adapter parses reasoning deltas, and `LlamaBackend` gains thinking-marker detection for Llama 3 prompt templates (DeepSeek-R1 and peers), which previously only worked on ChatML-formatted GGUFs.
+
+See [#589](https://github.com/roryford/BaseChatKit/issues/589), [#591](https://github.com/roryford/BaseChatKit/issues/591), [#592](https://github.com/roryford/BaseChatKit/issues/592).
+
+#### Non-LM models fail fast at load instead of crashing mid-decode
+
+```swift
+do {
+    try await backend.loadModel(from: url, plan: plan)
+} catch InferenceError.unsupportedModelArchitecture(let kind) {
+    // CLIP vision encoder, BERT embedder, Whisper, …
+}
+```
+
+Both `MLXBackend` and `LlamaBackend` now throw `InferenceError.unsupportedModelArchitecture` at load time if handed a CLIP vision encoder, BERT embedder, Whisper audio model, or other non-LM weights — instead of crashing inside the decode loop. See [#591](https://github.com/roryford/BaseChatKit/issues/591), [#592](https://github.com/roryford/BaseChatKit/issues/592).
+
+#### Ollama reasoning controls you can actually turn off
+
+`OllamaBackend` probes `/api/show` at `loadModel` time to classify whether a model is thinking-capable, and `GenerationConfig.maxThinkingTokens = 0` is honored by forwarding `"think": false` — so reasoning-capable models like `gemma4` and `qwen3` skip chain-of-thought when the host opts out. `ContextWindowManager` reserves both visible and thinking budgets in its trim math, preventing reasoning-heavy responses from silently pushing prompt history out of context.
+
+See [#595](https://github.com/roryford/BaseChatKit/issues/595), [#596](https://github.com/roryford/BaseChatKit/issues/596).
+
+### Internal
+
+- Three new fuzz scenarios (disable thinking, cancel mid-thought, retry after mid-thinking network flake) assert specific invariants on the consumer's event stream, catching regressions the random corpus can't reach reliably ([#590](https://github.com/roryford/BaseChatKit/issues/590)).
 
 ## [0.10.2](https://github.com/roryford/BaseChatKit/compare/v0.10.1...v0.10.2) (2026-04-19)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,24 +142,55 @@ PR titles must follow the same format (enforced by CI).
 
 ## Release workflow
 
-Release Please auto-creates a release PR after `feat:` or `fix:` merges. The auto-generated changelog is a one-liner — **it must be rewritten with prose before merging**. A pre-merge hook blocks the merge until this is done.
+Release Please auto-creates a release PR after `feat:` or `fix:` merges. The auto-generated one-liner bullets **must be rewritten before merging** — a pre-merge hook and the `changelog-lint` CI job both block the merge until this is done.
 
-1. Release Please opens PR titled `chore(main): release X.Y.Z`
-2. Check out the release branch: `git checkout release-please--branches--main`
-3. Rewrite the CHANGELOG.md entry: **Bold title** — problem, what changed, why it matters. Use the `## Release Note` sections from the included feature PRs as source material.
-4. Amend the commit and force-push: `git commit --amend --no-edit && git push --force`
-5. Merge the release PR
-6. Verify the GitHub release notes match (edit with `gh release edit` if needed)
+BaseChatKit uses a **Prisma-style Highlights format** for release notes (adopted v0.11.2, PR #649). Structure:
 
-**Format gotcha — the `changelog-lint` CI check is strict.** The first prose line must match `^\*\*[^*]+\*\* — ` (bold title, space, em-dash `—`, space, prose). It's easy to mentally resolve the em-dash as "punctuation after the title" and reach for a period or colon — those fail the lint.
+```markdown
+## [X.Y.Z](https://…/compare/vA.B.C...vX.Y.Z) (YYYY-MM-DD)
 
+### Highlights
+
+#### Short verb-led headline
+
+2–3 sentences: the problem, what shipped, how it fits together.
+
+` ` `swift
+// 4–8 lines showing the new API in use
+` ` `
+
+One more sentence of caveats or opt-in/out semantics.
+
+See [#N], [#M].
+
+### Features
+
+- **scope:** what changed ([#N])
+
+### Fixes
+
+- **scope:** what changed — why it matters ([#N])
 ```
-Correct: **Bold title** — prose goes here…
-Wrong:   **Bold title.** prose goes here…   (period inside bold → fails lint)
-Wrong:   **Bold title**: prose goes here…   (colon instead of em-dash → fails lint)
-```
 
-For `feat:` and `fix:` PRs, write the changelog prose in the `## Release Note` section of the PR body at PR creation time, when context is fresh. This is the source material for step 3.
+Aim for 1–3 Highlights (one per headline theme). Each Highlight gets a short prose paragraph and a runnable code snippet if it introduces or changes a public API. Small features and routine fixes live as one-line bullets in the Features/Fixes sections below. Pre-0.11.2 releases stay in their original `**Bold title** —` prose format — don't retrofit.
+
+### Workflow steps
+
+1. Release Please opens PR titled `chore(main): release X.Y.Z`.
+2. Check out the release branch via the existing worktree at `.claude/worktrees/agent-ae95b0e8` (branch `release-please--branches--main`) — or create a fresh worktree. Do **not** `git checkout` the branch in the main repo; it's held by that worktree.
+3. Rewrite the CHANGELOG.md entry in the Prisma format above. Use the `## Release Note` sections of the included `feat:`/`fix:` PRs as source material — they're written at PR time when context is fresh.
+4. Amend the Release Please commit and force-push: `git commit --amend --no-edit && git push --force-with-lease`.
+5. Merge the release PR. The release PR's `gh pr merge` is blocked by a hook on unrewriten CHANGELOGs — once the rewrite is in, merge via `gh api -X PUT repos/roryford/BaseChatKit/pulls/<N>/merge -f merge_method=squash`.
+6. The `sync-release-notes` workflow copies the CHANGELOG section into the GitHub release body on merge. If you retroactively edit CHANGELOG later, resync manually: `awk '/^## \[/{n++; if(n==2) exit} n==1' CHANGELOG.md > /tmp/body.md && gh release edit vX.Y.Z --notes-file /tmp/body.md`.
+
+### `changelog-lint` rules
+
+The CI lint rejects auto-generated output and requires evidence of a manual rewrite. The regex accepts either format:
+
+- `^### ` (Prisma-style subheading — the default since v0.11.2)
+- `^\*\*[^*]+\*\* — ` (bold title + em-dash prose — legacy, still accepted)
+
+The lint also rejects any `* lowercase` Release Please bullet that slips through unrewriten.
 
 ## PR workflow
 


### PR DESCRIPTION
## Summary

Three edits make the Prisma-style Highlights format the canonical shape for BCK release notes going forward:

1. **`CLAUDE.md` release workflow rewritten** — the canonical instructions now describe the Highlights + code-snippet + categorized-bullets format adopted in v0.11.2. Legacy \`**Bold title** —\` em-dash format remains accepted by \`changelog-lint\` for back-compat, but new releases default to the new shape.
2. **PR template's \`## Release Note\` block** now scaffolds the new format — both the headline-feature shape (subheading + 2–3 sentences + Swift snippet) and the small-fix shape (one scoped bullet). Authors capture release prose at PR time when context is fresh.
3. **v0.11.1 and v0.11.0 CHANGELOG entries retroactively rewritten** in the new format. Each now has a Highlights section with subheadings and at least one runnable Swift snippet. v0.11.0's breaking-change callout is hoisted above Highlights as its own ⚠️-marked section so it can't be missed. Older releases (v0.10.x and below) stay in their original format.

## Release Note

N/A — this is a docs PR.

## Test plan

- [x] Simulated \`changelog-lint\` locally against all three rewritten sections (0.11.2, 0.11.1, 0.11.0) — each passes both the "reject auto-generated bullets" and "require prose evidence" checks.
- [x] API names in new code snippets verified against source: \`customHostTrustPolicy\` on \`BaseChatConfiguration\`, \`.requireExplicitPins\` on \`CustomHostTrustPolicy\`, \`jsonMode\` on \`GenerationConfig\`, \`supportsNativeJSONMode\` on \`BackendCapabilities\`, \`InferenceError.unsupportedModelArchitecture(String)\`.

## Follow-up

After merge, resync the GitHub release bodies for v0.11.1 and v0.11.0 via \`gh release edit\` to match the updated CHANGELOG entries. (I'll handle this.)