### PR TITLE
feat(tools): add SampleRepoSearchTool and wire reference tools in demo

### DIFF
--- a/Example/BaseChatDemo.xcodeproj/project.pbxproj
+++ b/Example/BaseChatDemo.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		BF0003000000000000000000 /* BaseChatCore in Frameworks */ = {isa = PBXBuildFile; productRef = F30001000000000000000000 /* BaseChatCore */; };
 		BF0004000000000000000000 /* BaseChatUI in Frameworks */ = {isa = PBXBuildFile; productRef = F30002000000000000000000 /* BaseChatUI */; };
 		BF0005000000000000000000 /* BaseChatBackends in Frameworks */ = {isa = PBXBuildFile; productRef = F30003000000000000000000 /* BaseChatBackends */; };
+		BF0006000000000000000000 /* BaseChatTools in Frameworks */ = {isa = PBXBuildFile; productRef = F30004000000000000000000 /* BaseChatTools */; };
+		BF0007000000000000000000 /* DemoTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10004000000000000000000 /* DemoTools.swift */; };
 		BF1001000000000000000000 /* ModelManagementUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11001000000000000000000 /* ModelManagementUITests.swift */; };
 		BF1002000000000000000000 /* UITestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11003000000000000000000 /* UITestHelpers.swift */; };
 		BF1003000000000000000000 /* ChatFlowUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11004000000000000000000 /* ChatFlowUITests.swift */; };
@@ -33,6 +35,7 @@
 /* Begin PBXFileReference section */
 		F10001000000000000000000 /* BaseChatDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseChatDemoApp.swift; sourceTree = "<group>"; };
 		F10002000000000000000000 /* DemoContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoContentView.swift; sourceTree = "<group>"; };
+		F10004000000000000000000 /* DemoTools.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoTools.swift; sourceTree = "<group>"; };
 		F10003000000000000000000 /* BaseChatDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BaseChatDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F11001000000000000000000 /* ModelManagementUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelManagementUITests.swift; sourceTree = "<group>"; };
 		F11002000000000000000000 /* BaseChatDemoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BaseChatDemoUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -51,6 +54,7 @@
 				BF0003000000000000000000 /* BaseChatCore in Frameworks */,
 				BF0004000000000000000000 /* BaseChatUI in Frameworks */,
 				BF0005000000000000000000 /* BaseChatBackends in Frameworks */,
+				BF0006000000000000000000 /* BaseChatTools in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -79,6 +83,7 @@
 			children = (
 				F10001000000000000000000 /* BaseChatDemoApp.swift */,
 				F10002000000000000000000 /* DemoContentView.swift */,
+				F10004000000000000000000 /* DemoTools.swift */,
 			);
 			path = BaseChatDemo;
 			sourceTree = "<group>";
@@ -131,6 +136,7 @@
 				F30001000000000000000000 /* BaseChatCore */,
 				F30002000000000000000000 /* BaseChatUI */,
 				F30003000000000000000000 /* BaseChatBackends */,
+				F30004000000000000000000 /* BaseChatTools */,
 			);
 			productName = BaseChatDemo;
 			productReference = F10003000000000000000000 /* BaseChatDemo.app */;
@@ -192,6 +198,7 @@
 			files = (
 				BF0001000000000000000000 /* BaseChatDemoApp.swift in Sources */,
 				BF0002000000000000000000 /* DemoContentView.swift in Sources */,
+				BF0007000000000000000000 /* DemoTools.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -497,6 +504,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F20001000000000000000000 /* XCLocalSwiftPackageReference ".." */;
 			productName = BaseChatBackends;
+		};
+		F30004000000000000000000 /* BaseChatTools */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F20001000000000000000000 /* XCLocalSwiftPackageReference ".." */;
+			productName = BaseChatTools;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Example/BaseChatDemo/BaseChatDemoApp.swift
+++ b/Example/BaseChatDemo/BaseChatDemoApp.swift
@@ -40,7 +40,10 @@ struct BaseChatDemoApp: App {
         // Populate curated model recommendations
         CuratedModel.all = Self.curatedModels
 
-        let inferenceService = InferenceService()
+        let toolRegistry = ToolRegistry()
+        DemoTools.register(on: toolRegistry)
+
+        let inferenceService = InferenceService(toolRegistry: toolRegistry)
         DefaultBackends.register(with: inferenceService)
         self.inferenceService = inferenceService
 

--- a/Example/BaseChatDemo/DemoTools.swift
+++ b/Example/BaseChatDemo/DemoTools.swift
@@ -1,0 +1,161 @@
+import Foundation
+import BaseChatCore
+import BaseChatInference
+import BaseChatTools
+
+/// Composition root for the demo's tool layer.
+///
+/// Resolves an app-owned sandbox directory, seeds it with a small fixture
+/// "workspace" on first launch, and registers the reference toolset on a
+/// ``ToolRegistry``. The seeded fixture exists so the demo's hero tool
+/// (``SampleRepoSearchTool``) has something to search without the user
+/// having to drop their own files in.
+enum DemoTools {
+
+    /// Registers the full reference toolset on `registry`.
+    ///
+    /// Runs synchronously on the main actor because ``ToolRegistry`` is
+    /// MainActor-isolated. Seeding is idempotent — the on-disk fixture is
+    /// only written when absent, so repeated launches are cheap.
+    @MainActor
+    static func register(on registry: ToolRegistry, root: URL = DemoToolRoot.resolve()) {
+        do {
+            try DemoToolRoot.seedIfNeeded(at: root)
+        } catch {
+            // Fail open: the tools still work for files the user adds later,
+            // and the seed content is a nice-to-have rather than a contract.
+            Log.inference.warning("DemoTools: failed to seed fixture workspace at \(root.path, privacy: .public): \(String(describing: error), privacy: .public)")
+        }
+
+        registry.register(CalcTool.makeExecutor())
+        registry.register(NowTool.makeExecutor())
+        registry.register(ReadFileTool.makeExecutor(root: root))
+        registry.register(ListDirTool.makeExecutor(root: root))
+        registry.register(SampleRepoSearchTool.makeExecutor(root: root))
+    }
+}
+
+/// Resolves and seeds the demo's filesystem-tool sandbox.
+enum DemoToolRoot {
+
+    /// Returns the app-owned sandbox root. Creates the parent directory lazily.
+    static func resolve() -> URL {
+        let fm = FileManager.default
+        let base = (try? fm.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )) ?? fm.temporaryDirectory
+
+        let root = base
+            .appendingPathComponent("BaseChatDemo", isDirectory: true)
+            .appendingPathComponent("ToolRoot", isDirectory: true)
+
+        try? fm.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    /// Writes the bundled fixture workspace under `root` when it isn't there.
+    ///
+    /// The seed is keyed by a marker file; we do not diff contents across
+    /// launches. If the user edits or deletes a seeded file we respect their
+    /// choice — the marker prevents us from clobbering edits on the next
+    /// launch.
+    static func seedIfNeeded(at root: URL) throws {
+        let fm = FileManager.default
+        let marker = root.appendingPathComponent(".seeded", isDirectory: false)
+        if fm.fileExists(atPath: marker.path) { return }
+
+        try fm.createDirectory(at: root, withIntermediateDirectories: true)
+        for (path, contents) in Self.fixture {
+            let url = root.appendingPathComponent(path)
+            try fm.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try contents.write(to: url, atomically: true, encoding: .utf8)
+        }
+        try Data("1".utf8).write(to: marker)
+    }
+
+    private static let fixture: [(String, String)] = [
+        ("README.md", """
+        # Sample Workspace
+
+        This is a small fixture workspace the demo uses to showcase tool calling.
+        Ask the assistant to summarize the README files, search for a keyword,
+        or read a specific file — it will invoke the sandboxed filesystem tools.
+        """),
+        ("notes/ideas.md", """
+        # Product Ideas
+
+        - Offline-first note app with local embeddings.
+        - A CLI that replays a chat transcript through a different model.
+        - Voice memos transcribed via on-device speech, summarized at close of day.
+        - A fuzzer harness for long-context chat backends.
+        """),
+        ("notes/meeting-2026-04-15.md", """
+        # Planning meeting — April 15 2026
+
+        Attendees: Rory, Claude
+        Decisions:
+        - Ship tool-calling UI before 1.0.
+        - Defer voice module until post-launch.
+        - Unify deep-link / AppIntent / share-extension handoff behind InboundPayload.
+        """),
+        ("docs/architecture.md", """
+        # Architecture Overview
+
+        BaseChatKit has five public targets:
+        - BaseChatInference — protocols and orchestration.
+        - BaseChatCore — SwiftData persistence.
+        - BaseChatBackends — MLX, llama.cpp, Foundation, and cloud backends.
+        - BaseChatUI — SwiftUI views and view models.
+        - BaseChatTools — reference tools and the fuzzing harness.
+        """),
+        ("docs/tool-calling.md", """
+        # Tool Calling
+
+        Register a ToolExecutor on the ToolRegistry you pass to InferenceService.
+        The GenerationCoordinator dispatches ToolCall events through the registry
+        and threads the ToolResult back into the conversation.
+        """),
+        ("projects/scout/spec.md", """
+        # Scout — local research companion (draft)
+
+        Scout is a Mac-first agent app built on BaseChatKit. It surfaces:
+        - Filesystem tool calling with per-call approval.
+        - Live thinking streams from reasoning models.
+        - MCP server integration for third-party tools.
+        """),
+        ("projects/scout/roadmap.md", """
+        # Roadmap
+
+        - [ ] Tool approval UI
+        - [ ] MCP client
+        - [ ] Share Extension summarize-selection flow
+        - [ ] App Intents for Spotlight and Siri
+        """),
+        ("shopping-list.txt", """
+        milk
+        eggs
+        coffee
+        olive oil
+        """),
+        ("journal/2026-04-22.md", """
+        # 22 Apr 2026
+
+        Shipped the thinking-tokens super-session. 11 PRs merged, four reviews
+        came back in parallel, scope held. Next up: tool-calling demo in the
+        example app.
+        """),
+        ("journal/2026-04-23.md", """
+        # 23 Apr 2026
+
+        Pivoted on the demo strategy — instead of a third example app, we're
+        upgrading BaseChatDemo in place. Plan approved after PM / architect /
+        engineer / QA reviews.
+        """),
+    ]
+}

--- a/Sources/BaseChatTools/ReferenceTools/SampleRepoSearchTool.swift
+++ b/Sources/BaseChatTools/ReferenceTools/SampleRepoSearchTool.swift
@@ -1,0 +1,181 @@
+import Foundation
+import BaseChatInference
+
+/// Literal-substring search across text files inside a sandbox directory.
+///
+/// Intended as the "hero" reference tool for demos: the model asks a question
+/// about the contents of a folder, the tool returns a small set of matching
+/// lines, and the model synthesises an answer that cites the files. Unlike
+/// ``ReadFileTool`` / ``ListDirTool``, callers never pass a path — the search
+/// is always rooted at the configured sandbox and cannot escape it.
+///
+/// ## Policy
+///
+/// - Literal, case-insensitive substring match. No regex — keeps the contract
+///   obvious to the model and the cost bounded.
+/// - Walks only regular files with text extensions (`.md`, `.txt`, `.swift`,
+///   `.py`, `.js`, `.ts`, `.json`, `.yml`, `.yaml`). Hidden files skipped.
+/// - Caps matches per file and overall to keep the tool's output small enough
+///   for a single prompt iteration.
+public enum SampleRepoSearchTool {
+
+    public struct Args: Decodable, Sendable {
+        public let query: String
+        public let max_results: Int?
+    }
+
+    public struct Match: Codable, Sendable {
+        public let path: String
+        public let line: Int
+        public let snippet: String
+    }
+
+    public struct Result: Codable, Sendable {
+        public let matches: [Match]
+        public let truncated: Bool
+    }
+
+    /// Hard cap on total matches the tool will return regardless of caller request.
+    /// Set to keep single-turn tool output well under any reasonable context budget.
+    public static let maxMatchesHardCap = 100
+
+    /// Default match count when caller omits `max_results`.
+    public static let defaultMaxMatches = 20
+
+    /// Per-file match cap so one file cannot monopolise the result set.
+    public static let perFileMatchCap = 5
+
+    /// Extensions considered "text" — the walker skips everything else.
+    public static let textExtensions: Set<String> = [
+        "md", "txt", "swift", "py", "js", "ts", "json", "yml", "yaml",
+    ]
+
+    public static func makeExecutor(root: URL) -> any ToolExecutor {
+        let definition = ToolDefinition(
+            name: "sample_repo_search",
+            description: "Searches text files in the user's workspace for a literal, case-insensitive substring. Returns the matching files, line numbers, and the matching line. Use this whenever the user asks what's in their files; never guess.",
+            parameters: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "query": .object([
+                        "type": .string("string"),
+                        "description": .string("Substring to search for. Matched case-insensitively.")
+                    ]),
+                    "max_results": .object([
+                        "type": .string("integer"),
+                        "description": .string("Maximum number of matches to return. Defaults to 20, capped at 100.")
+                    ])
+                ]),
+                "required": .array([.string("query")])
+            ])
+        )
+        return SampleRepoSearchExecutor(definition: definition, root: root)
+    }
+
+    struct SampleRepoSearchExecutor: ToolExecutor {
+        let definition: ToolDefinition
+        let root: URL
+
+        func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+            let data = try JSONEncoder().encode(arguments)
+            let args = try JSONDecoder().decode(Args.self, from: data)
+
+            let trimmed = args.query.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                return ToolResult(
+                    callId: "",
+                    content: "query must not be empty",
+                    errorKind: .invalidArguments
+                )
+            }
+
+            let requested = args.max_results ?? defaultMaxMatches
+            let limit = max(1, min(requested, maxMatchesHardCap))
+
+            let fm = FileManager.default
+            guard fm.fileExists(atPath: root.path) else {
+                return ToolResult(
+                    callId: "",
+                    content: "sandbox root does not exist: \(root.path)",
+                    errorKind: .notFound
+                )
+            }
+
+            let (matches, truncated) = walk(root: root, needle: trimmed.lowercased(), limit: limit)
+            let result = Result(matches: matches, truncated: truncated)
+            let encoded = try JSONEncoder().encode(result)
+            return ToolResult(
+                callId: "",
+                content: String(data: encoded, encoding: .utf8) ?? "",
+                errorKind: nil
+            )
+        }
+
+        private func walk(root: URL, needle: String, limit: Int) -> (matches: [Match], truncated: Bool) {
+            let fm = FileManager.default
+            let rootPath = root.standardizedFileURL.path
+            let keys: [URLResourceKey] = [.isRegularFileKey, .isHiddenKey]
+
+            guard let enumerator = fm.enumerator(
+                at: root,
+                includingPropertiesForKeys: keys,
+                options: [.skipsHiddenFiles]
+            ) else {
+                return ([], false)
+            }
+
+            var matches: [Match] = []
+
+            while let url = enumerator.nextObject() as? URL {
+                let values = try? url.resourceValues(forKeys: Set(keys))
+                guard values?.isRegularFile == true else { continue }
+
+                // Reject symlinks (and any other path trickery) that resolve outside
+                // the sandbox root. Mirrors the containment contract in SandboxResolver
+                // so this tool cannot be used to read arbitrary files on the host.
+                let resolved = url.standardizedFileURL.resolvingSymlinksInPath().path
+                let containmentPrefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+                guard resolved == rootPath || resolved.hasPrefix(containmentPrefix) else { continue }
+
+                let ext = url.pathExtension.lowercased()
+                guard textExtensions.contains(ext) else { continue }
+
+                guard let contents = try? String(contentsOf: url, encoding: .utf8) else { continue }
+
+                let relativePath = relativize(url.standardizedFileURL.path, to: rootPath)
+
+                var perFile = 0
+                var lineNumber = 0
+                for line in contents.split(separator: "\n", omittingEmptySubsequences: false) {
+                    lineNumber += 1
+                    guard line.lowercased().contains(needle) else { continue }
+
+                    matches.append(Match(path: relativePath, line: lineNumber, snippet: trimSnippet(String(line))))
+                    perFile += 1
+
+                    if matches.count >= limit {
+                        return (matches, true)
+                    }
+                    if perFile >= perFileMatchCap { break }
+                }
+            }
+
+            return (matches, false)
+        }
+
+        private func relativize(_ path: String, to rootPath: String) -> String {
+            if path == rootPath { return "." }
+            let prefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+            if path.hasPrefix(prefix) {
+                return String(path.dropFirst(prefix.count))
+            }
+            return path
+        }
+
+        private func trimSnippet(_ line: String) -> String {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.count <= 200 { return trimmed }
+            return String(trimmed.prefix(200)) + "…"
+        }
+    }
+}

--- a/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
+++ b/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
@@ -158,6 +158,14 @@ final class SilentCatchAuditTest: XCTestCase {
         //     valid zero-argument payload and not an error condition.
         "BaseChatTools/TranscriptLogger.swift:} catch {",
         "BaseChatTools/ReferenceTools/NowTool.swift:} catch {",
+        // SampleRepoSearchTool walks the sandbox directory skipping files it
+        // cannot read (binary data with a text extension, permission races,
+        // non-UTF-8 encodings). Surfacing these as errors would make a noisy
+        // search tool that fails on a single bad file instead of returning
+        // the matches it did find. Mirrors the pattern in BackgroundDownloadManager
+        // and ModelStorageService for directory walkers.
+        "BaseChatTools/ReferenceTools/SampleRepoSearchTool.swift:let values = try? url.resourceValues(forKeys: Set(keys))",
+        "BaseChatTools/ReferenceTools/SampleRepoSearchTool.swift:guard let contents = try? String(contentsOf: url, encoding: .utf8) else { continue }",
     ]
 
     func test_sourcesDirectoryContainsNoUnapprovedSilentSwallows() throws {

--- a/Tests/BaseChatToolsTests/SampleRepoSearchToolTests.swift
+++ b/Tests/BaseChatToolsTests/SampleRepoSearchToolTests.swift
@@ -1,0 +1,232 @@
+import XCTest
+import BaseChatInference
+@testable import BaseChatTools
+
+final class SampleRepoSearchToolTests: XCTestCase {
+
+    func test_findsLiteralMatchAcrossFiles() async throws {
+        let sandbox = try makeTempSandbox(files: [
+            "alpha.md": "one two THREE\nfour Five six",
+            "beta.txt": "seven THREE eight",
+            "gamma.swift": "// no match here"
+        ])
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let executor = SampleRepoSearchTool.makeExecutor(root: sandbox)
+        let result = try await executor.execute(arguments: parseJSON(#"{"query":"three"}"#))
+        XCTAssertNil(result.errorKind)
+
+        let decoded = try decodeResult(result.content)
+        XCTAssertEqual(decoded.matches.count, 2, "expected one match per file; got \(decoded.matches)")
+        XCTAssertTrue(decoded.matches.contains { $0.path == "alpha.md" && $0.line == 1 })
+        XCTAssertTrue(decoded.matches.contains { $0.path == "beta.txt" && $0.line == 1 })
+        XCTAssertFalse(decoded.truncated)
+    }
+
+    func test_caseInsensitiveMatch() async throws {
+        let sandbox = try makeTempSandbox(files: ["file.md": "HELLO world"])
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let executor = SampleRepoSearchTool.makeExecutor(root: sandbox)
+        let result = try await executor.execute(arguments: parseJSON(#"{"query":"hello"}"#))
+        let decoded = try decodeResult(result.content)
+        XCTAssertEqual(decoded.matches.count, 1)
+        XCTAssertTrue(decoded.matches[0].snippet.contains("HELLO"))
+    }
+
+    func test_skipsBinaryAndUnsupportedExtensions() async throws {
+        let sandbox = try makeTempSandbox(files: [
+            "readme.md": "needle here",
+            "image.png": "needle",
+            "binary.dat": "needle"
+        ])
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let executor = SampleRepoSearchTool.makeExecutor(root: sandbox)
+        let result = try await executor.execute(arguments: parseJSON(#"{"query":"needle"}"#))
+        let decoded = try decodeResult(result.content)
+        XCTAssertEqual(decoded.matches.count, 1)
+        XCTAssertEqual(decoded.matches[0].path, "readme.md")
+    }
+
+    func test_recursesIntoSubdirectories() async throws {
+        let sandbox = try makeTempSandbox(files: [:])
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let subdir = sandbox.appendingPathComponent("notes", isDirectory: true)
+        try FileManager.default.createDirectory(at: subdir, withIntermediateDirectories: true)
+        try "hidden gem".write(to: subdir.appendingPathComponent("deep.md"), atomically: true, encoding: .utf8)
+
+        let executor = SampleRepoSearchTool.makeExecutor(root: sandbox)
+        let result = try await executor.execute(arguments: parseJSON(#"{"query":"gem"}"#))
+        let decoded = try decodeResult(result.content)
+        XCTAssertEqual(decoded.matches.count, 1)
+        XCTAssertEqual(decoded.matches[0].path, "notes/deep.md")
+    }
+
+    func test_truncatesAtLimit() async throws {
+        var files: [String: String] = [:]
+        for i in 0..<30 {
+            files["f\(i).md"] = "match line\n"
+        }
+        let sandbox = try makeTempSandbox(files: files)
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let executor = SampleRepoSearchTool.makeExecutor(root: sandbox)
+        let result = try await executor.execute(arguments: parseJSON(#"{"query":"match","max_results":5}"#))
+        let decoded = try decodeResult(result.content)
+        XCTAssertEqual(decoded.matches.count, 5)
+        XCTAssertTrue(decoded.truncated)
+    }
+
+    func test_perFileCapPreventsSingleFileMonopoly() async throws {
+        let heavy = (0..<20).map { "needle line \($0)" }.joined(separator: "\n")
+        let sandbox = try makeTempSandbox(files: [
+            "heavy.md": heavy,
+            "other.md": "needle once"
+        ])
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let executor = SampleRepoSearchTool.makeExecutor(root: sandbox)
+        let result = try await executor.execute(arguments: parseJSON(#"{"query":"needle","max_results":50}"#))
+        let decoded = try decodeResult(result.content)
+
+        let heavyCount = decoded.matches.filter { $0.path == "heavy.md" }.count
+        XCTAssertLessThanOrEqual(heavyCount, SampleRepoSearchTool.perFileMatchCap,
+                                 "heavy.md should be capped at \(SampleRepoSearchTool.perFileMatchCap)")
+        XCTAssertTrue(decoded.matches.contains { $0.path == "other.md" },
+                      "other.md must still appear after heavy.md hits the cap")
+    }
+
+    func test_emptyQueryRejected() async throws {
+        let sandbox = try makeTempSandbox(files: ["x.md": "content"])
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let executor = SampleRepoSearchTool.makeExecutor(root: sandbox)
+        let result = try await executor.execute(arguments: parseJSON(#"{"query":"   "}"#))
+        XCTAssertEqual(result.errorKind, .invalidArguments)
+    }
+
+    func test_missingRootReturnsNotFound() async throws {
+        let ghost = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bck-ghost-\(UUID().uuidString)", isDirectory: true)
+        let executor = SampleRepoSearchTool.makeExecutor(root: ghost)
+        let result = try await executor.execute(arguments: parseJSON(#"{"query":"anything"}"#))
+        XCTAssertEqual(result.errorKind, .notFound)
+    }
+
+    func test_maxResultsClampedToAtLeastOne() async throws {
+        let sandbox = try makeTempSandbox(files: [
+            "a.md": "needle one",
+            "b.md": "needle two",
+            "c.md": "needle three"
+        ])
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let executor = SampleRepoSearchTool.makeExecutor(root: sandbox)
+        let result = try await executor.execute(arguments: parseJSON(#"{"query":"needle","max_results":0}"#))
+        XCTAssertNil(result.errorKind)
+
+        let decoded = try decodeResult(result.content)
+        // With matches present, a zero request must still return at least one
+        // match — the tool clamps the request to 1 rather than returning empty.
+        XCTAssertGreaterThanOrEqual(decoded.matches.count, 1)
+    }
+
+    func test_maxResultsClampedToHardCap() async throws {
+        // Seed enough matches to exceed the hard cap. One match per file keeps
+        // us clear of the per-file cap.
+        var files: [String: String] = [:]
+        let needed = SampleRepoSearchTool.maxMatchesHardCap + 20
+        for i in 0..<needed {
+            files["file\(i).md"] = "needle line"
+        }
+        let sandbox = try makeTempSandbox(files: files)
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let executor = SampleRepoSearchTool.makeExecutor(root: sandbox)
+        let result = try await executor.execute(arguments: parseJSON(#"{"query":"needle","max_results":5000}"#))
+        let decoded = try decodeResult(result.content)
+        XCTAssertEqual(decoded.matches.count, SampleRepoSearchTool.maxMatchesHardCap)
+        XCTAssertTrue(decoded.truncated)
+    }
+
+    func test_longLineTrimmedToSnippetLimit() async throws {
+        // Single 500-character line containing the query. The tool should trim
+        // to 200 chars plus an ellipsis marker so we never blow the prompt budget.
+        let longLine = String(repeating: "abc needle xyz ", count: 40)
+        XCTAssertGreaterThan(longLine.count, 200)
+        let sandbox = try makeTempSandbox(files: ["long.md": longLine])
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let executor = SampleRepoSearchTool.makeExecutor(root: sandbox)
+        let result = try await executor.execute(arguments: parseJSON(#"{"query":"needle"}"#))
+        let decoded = try decodeResult(result.content)
+        XCTAssertEqual(decoded.matches.count, 1)
+        let snippet = decoded.matches[0].snippet
+        XCTAssertTrue(snippet.hasSuffix("…"), "expected trimmed snippet to end with ellipsis; got: \(snippet)")
+        XCTAssertLessThanOrEqual(snippet.count, 201)
+    }
+
+    func test_nonUtf8FileSkipped() async throws {
+        let sandbox = try makeTempSandbox(files: [:])
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        // 0xFF 0xFE alone is not valid UTF-8 — String(contentsOf:encoding:.utf8)
+        // will reject the file and the tool should skip it silently.
+        let bad = Data([0xFF, 0xFE, 0xFF, 0xFE, 0xFF])
+        try bad.write(to: sandbox.appendingPathComponent("garbage.txt"))
+
+        let executor = SampleRepoSearchTool.makeExecutor(root: sandbox)
+        let result = try await executor.execute(arguments: parseJSON(#"{"query":"anything"}"#))
+        XCTAssertNil(result.errorKind)
+        let decoded = try decodeResult(result.content)
+        XCTAssertEqual(decoded.matches.count, 0)
+    }
+
+    func test_symlinkEscapingSandboxIsSkipped() async throws {
+        let sandbox = try makeTempSandbox(files: ["inside.md": "no match inside"])
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        // Create the "secret" outside the sandbox. Its contents contain the
+        // needle we're searching for, so if the tool follows the symlink it
+        // will be visible in the results — and the test will catch it.
+        let outside = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bck-outside-\(UUID().uuidString).md")
+        try "needle secret".write(to: outside, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: outside) }
+
+        // Place a symlink under the sandbox pointing at the external file.
+        let link = sandbox.appendingPathComponent("escape.md")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outside)
+
+        let executor = SampleRepoSearchTool.makeExecutor(root: sandbox)
+        let result = try await executor.execute(arguments: parseJSON(#"{"query":"needle"}"#))
+        XCTAssertNil(result.errorKind)
+        let decoded = try decodeResult(result.content)
+        XCTAssertFalse(decoded.matches.contains { $0.path == "escape.md" },
+                       "symlink that escapes the sandbox must not be followed; got matches: \(decoded.matches)")
+        XCTAssertFalse(decoded.matches.contains { $0.snippet.contains("secret") },
+                       "external file's contents must not leak through the symlink")
+    }
+
+    // MARK: - Helpers
+
+    private func parseJSON(_ s: String) throws -> JSONSchemaValue {
+        try JSONDecoder().decode(JSONSchemaValue.self, from: Data(s.utf8))
+    }
+
+    private func decodeResult(_ content: String) throws -> SampleRepoSearchTool.Result {
+        try JSONDecoder().decode(SampleRepoSearchTool.Result.self, from: Data(content.utf8))
+    }
+
+    private func makeTempSandbox(files: [String: String]) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bck-search-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        for (name, content) in files {
+            try content.write(to: url.appendingPathComponent(name), atomically: true, encoding: .utf8)
+        }
+        return url
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `SampleRepoSearchTool` to `BaseChatTools/ReferenceTools/` — sandboxed literal-substring search, per-file and total match caps, symlink containment.
- Wires five reference tools (`Calc`, `Now`, `ReadFile`, `ListDir`, `SampleRepoSearch`) into `BaseChatDemo` via a new `DemoTools` composition root that seeds an idempotent fixture workspace under `~/Library/Application Support/BaseChatDemo/ToolRoot/` on first launch.
- Drops `HttpGetFixtureTool` from the demo roster (stays in the kit for tests).
- No user-visible UI yet — `MessagePartsView.swift:40` still renders `EmptyView()` for tool parts. That lands in PR 3.

## Stack context

First of a 4-PR stack to surface tool calling in the demo and close #437:
1. **This PR** — wire tools + hero tool
2. `ToolApprovalGate` protocol in `BaseChatInference`
3. `ToolInvocationView` + `UIToolApprovalGate` + flagship empty-state (closes #437)
4. `AskBaseChatDemo` AppIntent via unified `InboundPayload` handoff

## Test plan

- [x] `swift test --filter BaseChatToolsTests` — 36/36 pass (+13 new)
- [x] `swift test --filter SilentCatchAuditTest` — passes (2 allowlist entries added with rationale)
- [x] Full CI suite green locally (Core, Inference, InferenceSwiftTesting, UI, Backends)
- [x] `xcodebuild -project Example/BaseChatDemo.xcodeproj -scheme BaseChatDemo -destination 'platform=macOS' -configuration Debug build` — **BUILD SUCCEEDED**
- [x] Sabotage-verified: per-file cap and literal-match assertions
- [ ] Manual smoke after merge: launch demo, confirm `ToolRoot/` seeds, tools register without errors (visible in next PR's UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)