### PR TITLE
feat(inference): add ToolApprovalGate protocol for per-call tool approval

### DIFF
--- a/Sources/BaseChatInference/Models/InboundPayload.swift
+++ b/Sources/BaseChatInference/Models/InboundPayload.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// A unified handoff envelope for prompts arriving from outside the normal
+/// compose bar — deep links, App Intents, Share / Action Extensions, etc.
+///
+/// `InboundPayload` is the single shape the chat view model drains on
+/// ingest, regardless of which entry point produced it. This keeps
+/// launch-time wiring symmetric: every inbound source serialises itself
+/// into a payload, the app writes it into a pending buffer, and the view
+/// model ingests it once persistence is ready.
+///
+/// ## Forward compatibility
+///
+/// ``attachments`` carries ``MessagePart`` values so richer inputs
+/// (images, files) can ride alongside the prompt without changing the
+/// API shape. Today only App Intent and deep-link flows populate this
+/// struct; Share Extension support (tracked by #440) and Action Extension
+/// support (#441) will reuse the same type when they land.
+///
+/// The struct is intentionally storage-agnostic. Callers persist it
+/// through whatever transport suits the caller — App Group
+/// `UserDefaults`, pasteboard JSON, or a file in a shared container —
+/// and hand the decoded value to the view model.
+public struct InboundPayload: Sendable {
+
+    /// Where this payload originated.
+    ///
+    /// Used for logging attribution and, when a source needs
+    /// source-specific handling (e.g. suppressing the model picker on an
+    /// intent-driven launch), for branching in the view model.
+    public enum Source: Sendable {
+
+        /// The payload came from a custom URL scheme (`basechatdemo://…`).
+        case deepLink
+
+        /// The payload came from an `AppIntent` invocation (Siri, Spotlight,
+        /// Shortcuts).
+        case appIntent
+
+        /// The payload came from a Share Extension.
+        case shareExtension
+    }
+
+    /// The prompt text to inject as the next user turn.
+    public var prompt: String
+
+    /// Additional parts to accompany the prompt.
+    ///
+    /// Intended to carry ``MessagePart`` values such as images or tool
+    /// results that must arrive together with the prompt. Defaults to an
+    /// empty array for text-only payloads.
+    public var attachments: [MessagePart]
+
+    /// Where the payload came from.
+    public var source: Source
+
+    /// Creates an inbound payload.
+    ///
+    /// - Parameters:
+    ///   - prompt: The prompt text to inject.
+    ///   - attachments: Forward-compatible list of additional parts
+    ///     (default empty).
+    ///   - source: The entry point that produced this payload.
+    public init(prompt: String, attachments: [MessagePart] = [], source: Source) {
+        self.prompt = prompt
+        self.attachments = attachments
+        self.source = source
+    }
+}

--- a/Sources/BaseChatInference/Services/GenerationCoordinator.swift
+++ b/Sources/BaseChatInference/Services/GenerationCoordinator.swift
@@ -516,7 +516,13 @@ final class GenerationCoordinator {
     /// continuation untouched *except* for `.toolCall(_:)` events, which
     /// are intercepted when a registry is present:
     ///
-    /// 1. The call is dispatched via `toolRegistry.dispatch(_:)`.
+    /// 1. The finalized ``ToolCall`` is passed to ``toolApprovalGate``. On
+    ///    ``ToolApprovalDecision/approved`` the call is dispatched via
+    ///    `toolRegistry.dispatch(_:)`; on ``ToolApprovalDecision/denied(reason:)``
+    ///    a synthetic ``ToolResult`` with
+    ///    ``ToolResult/ErrorKind/permissionDenied`` is produced in place of
+    ///    a real dispatch, and the loop continues to the next turn so the
+    ///    model can acknowledge the refusal.
     /// 2. A `.toolResult(_:)` event is emitted so UIs can render the
     ///    outcome alongside the call.
     /// 3. The `(call, result)` pair is appended to the tool-aware history

--- a/Sources/BaseChatInference/Services/GenerationCoordinator.swift
+++ b/Sources/BaseChatInference/Services/GenerationCoordinator.swift
@@ -36,6 +36,18 @@ final class GenerationCoordinator {
     /// downstream wiring; the actual dispatch site lands in wave 2 Agent D.
     let toolRegistry: ToolRegistry?
 
+    /// Gate consulted before dispatching every ``ToolCall`` through
+    /// ``toolRegistry``. Defaults to ``AutoApproveGate`` so hosts that have
+    /// not opted into per-call approval see unchanged behaviour.
+    ///
+    /// The gate is invoked on the *finalized* ``ToolCall`` — streaming
+    /// argument deltas are merged by the backend before the coordinator
+    /// observes the call event. On ``ToolApprovalDecision/denied(reason:)``
+    /// the coordinator synthesises a ``ToolResult`` with
+    /// ``ToolResult/ErrorKind/permissionDenied`` and continues the stream
+    /// rather than cancelling generation.
+    let toolApprovalGate: any ToolApprovalGate
+
     // MARK: - Test Seam
 
     /// Test-only hook invoked alongside `Log.inference.warning` when
@@ -80,10 +92,12 @@ final class GenerationCoordinator {
 
     nonisolated init(
         thermalStateProvider: @Sendable @escaping () -> ProcessInfo.ThermalState = { ProcessInfo.processInfo.thermalState },
-        toolRegistry: ToolRegistry? = nil
+        toolRegistry: ToolRegistry? = nil,
+        toolApprovalGate: any ToolApprovalGate = AutoApproveGate()
     ) {
         self.thermalStateProvider = thermalStateProvider
         self.toolRegistry = toolRegistry
+        self.toolApprovalGate = toolApprovalGate
     }
 
     // MARK: - Generation (Non-Queued)
@@ -606,7 +620,26 @@ final class GenerationCoordinator {
                             errorKind: .permanent
                         )
                     } else {
-                        result = await toolRegistry!.dispatch(call)
+                        // User-approval gate: invoked on the finalized ToolCall,
+                        // after the repeat / byte-budget guards (which both
+                        // synthesize their own results without touching the
+                        // registry). On `.denied` we emit a `.permissionDenied`
+                        // ToolResult and continue the loop — the backend sees a
+                        // structured refusal and the model usually apologises
+                        // and asks what to do next.
+                        switch await toolApprovalGate.approve(call) {
+                        case .approved:
+                            result = await toolRegistry!.dispatch(call)
+                        case .denied(let reason):
+                            Log.inference.info(
+                                "GenerationCoordinator: tool '\(call.toolName, privacy: .public)' denied by ToolApprovalGate"
+                            )
+                            result = ToolResult(
+                                callId: call.id,
+                                content: reason ?? "user denied tool execution",
+                                errorKind: .permissionDenied
+                            )
+                        }
                     }
 
                     toolResultByteTotal += result.content.utf8.count

--- a/Sources/BaseChatInference/Services/InferenceService.swift
+++ b/Sources/BaseChatInference/Services/InferenceService.swift
@@ -290,9 +290,30 @@ public final class InferenceService {
     /// conversation before the next turn. See `GenerationConfig.tools` and
     /// `GenerationConfig.toolChoice` for per-request wire-level control, and
     /// `GenerationConfig.maxToolIterations` for the per-request loop cap.
+    ///
+    /// The tool approval gate defaults to ``AutoApproveGate`` — every tool
+    /// call dispatches without prompting. Use
+    /// ``init(toolRegistry:toolApprovalGate:)`` to install a custom gate
+    /// (e.g. a UI-driven approval sheet).
     public nonisolated init(toolRegistry: ToolRegistry) {
         self.lifecycle = ModelLifecycleCoordinator()
         self.generation = GenerationCoordinator(toolRegistry: toolRegistry)
+    }
+
+    /// Creates the service with a pre-populated ``ToolRegistry`` and a
+    /// custom ``ToolApprovalGate``.
+    ///
+    /// The gate is consulted before every ``ToolCall`` is dispatched. When
+    /// the gate returns ``ToolApprovalDecision/denied(reason:)`` the
+    /// coordinator synthesises a ``ToolResult`` with
+    /// ``ToolResult/ErrorKind/permissionDenied`` and continues the stream
+    /// — generation is not cancelled.
+    public nonisolated init(toolRegistry: ToolRegistry, toolApprovalGate: any ToolApprovalGate) {
+        self.lifecycle = ModelLifecycleCoordinator()
+        self.generation = GenerationCoordinator(
+            toolRegistry: toolRegistry,
+            toolApprovalGate: toolApprovalGate
+        )
     }
 
     /// The ``ToolRegistry`` this service dispatches through, or `nil` when

--- a/Sources/BaseChatInference/Services/ToolApprovalGate.swift
+++ b/Sources/BaseChatInference/Services/ToolApprovalGate.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+// MARK: - ToolApprovalDecision
+
+/// The outcome of asking a ``ToolApprovalGate`` whether a specific
+/// ``ToolCall`` should be executed.
+///
+/// Hosts that need more structure than a boolean (e.g. surfacing the denial
+/// reason back into the conversation so the model can recover) pair the
+/// decision with an optional user-provided ``denied(reason:)`` message.
+public enum ToolApprovalDecision: Sendable, Equatable {
+
+    /// The caller authorises the ``ToolCall`` to proceed. The generation
+    /// coordinator dispatches the call through the ``ToolRegistry`` as usual.
+    case approved
+
+    /// The caller refuses the ``ToolCall``. The generation coordinator
+    /// synthesises a ``ToolResult`` with
+    /// ``ToolResult/ErrorKind/permissionDenied`` carrying `reason` (or a
+    /// default denial string when `nil`) and continues the stream so the
+    /// model can acknowledge the refusal.
+    case denied(reason: String?)
+}
+
+// MARK: - ToolApprovalGate
+
+/// A policy that decides whether a ``ToolCall`` emitted by the model should
+/// actually execute.
+///
+/// Gate is invoked on the *finalized* ``ToolCall`` after streaming arguments
+/// have been assembled. See #436 for the streaming-delta contract that
+/// precedes this hook — deltas are merged into a single call before the
+/// gate sees it, so conformers never receive a partial payload.
+///
+/// The default conformer is ``AutoApproveGate``, which preserves the
+/// pre-gate behaviour of dispatching every call unconditionally. Hosts that
+/// need a user-approval sheet, a permission scope check, or an allow-list
+/// supply their own conformer via ``InferenceService/init(toolRegistry:toolApprovalGate:)``.
+///
+/// ## Denial semantics
+///
+/// When ``approve(_:)`` returns ``ToolApprovalDecision/denied(reason:)`` the
+/// generation coordinator does **not** cancel the stream. Instead it emits a
+/// synthetic ``GenerationEvent/toolResult(_:)`` with
+/// ``ToolResult/ErrorKind/permissionDenied`` so the backend sees a
+/// structured failure and the model can recover gracefully on the next turn.
+/// This matches how other ``ToolResult/ErrorKind`` values flow through the
+/// loop and keeps the denial path symmetric with executor failures.
+///
+/// ## Concurrency
+///
+/// The gate is invoked once per ``ToolCall`` from within the generation
+/// coordinator's MainActor-isolated dispatch loop. Conformers are free to
+/// suspend — e.g. to present a UI sheet and await a user tap — without
+/// blocking other generations; the queue drains one request at a time.
+public protocol ToolApprovalGate: Sendable {
+
+    /// Decides whether `call` should execute.
+    ///
+    /// - Parameter call: The finalized ``ToolCall``. `id`, `toolName`, and
+    ///   `arguments` are all populated — never a streaming fragment.
+    /// - Returns: ``ToolApprovalDecision/approved`` to dispatch through the
+    ///   registry, or ``ToolApprovalDecision/denied(reason:)`` to
+    ///   short-circuit with a synthesised `permissionDenied` result.
+    func approve(_ call: ToolCall) async -> ToolApprovalDecision
+}
+
+// MARK: - AutoApproveGate
+
+/// The default ``ToolApprovalGate`` — approves every call without prompting.
+///
+/// This preserves the behaviour ``InferenceService`` had before the gate
+/// protocol existed, so callers who do not opt into per-call approval see
+/// no change. UI-layer conformers (landed in PR 3) replace this with a
+/// user-driven approval queue.
+public struct AutoApproveGate: ToolApprovalGate {
+
+    public init() {}
+
+    public func approve(_ call: ToolCall) async -> ToolApprovalDecision {
+        .approved
+    }
+}

--- a/Tests/BaseChatInferenceTests/GenerationCoordinatorApprovalTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationCoordinatorApprovalTests.swift
@@ -1,0 +1,190 @@
+import XCTest
+import os
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Integration tests for the ``ToolApprovalGate`` + ``GenerationCoordinator``
+/// interaction at the full-stream level.
+///
+/// Distinct from ``ToolApprovalGateTests`` in that these exercise stream
+/// continuation behaviour — specifically that a denial does NOT cancel the
+/// active request, the coordinator proceeds to the model's next turn, and
+/// the synthesised ``ToolResult`` flows through as a normal event.
+@MainActor
+final class GenerationCoordinatorApprovalTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private final class FixedGate: ToolApprovalGate, @unchecked Sendable {
+        let decision: ToolApprovalDecision
+        init(_ decision: ToolApprovalDecision) { self.decision = decision }
+        func approve(_ call: ToolCall) async -> ToolApprovalDecision { decision }
+    }
+
+    /// Dummy executor — asserts it is never reached on the deny path.
+    @MainActor
+    private final class FailIfInvokedExecutor: ToolExecutor, @unchecked Sendable {
+        let definition: ToolDefinition
+        private(set) var wasInvoked = false
+        init(name: String) {
+            self.definition = ToolDefinition(name: name, description: "should not run")
+        }
+        nonisolated func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+            await MainActor.run { self.wasInvoked = true }
+            return ToolResult(callId: "", content: "UNEXPECTED", errorKind: nil)
+        }
+    }
+
+    private var provider: FakeGenerationContextProvider!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        provider = FakeGenerationContextProvider()
+    }
+
+    override func tearDown() async throws {
+        provider = nil
+        try await super.tearDown()
+    }
+
+    private func collectEvents(_ stream: GenerationStream) async throws -> [GenerationEvent] {
+        var events: [GenerationEvent] = []
+        for try await event in stream.events {
+            events.append(event)
+        }
+        return events
+    }
+
+    // MARK: - Deny path — synthesised ToolResult
+
+    func test_denyPath_synthesisesPermissionDeniedResult_andStreamContinues() async throws {
+        // Turn 1: model emits a single tool call. Turn 2: model emits plain
+        // text and the loop exits. The gate denies the call so no executor
+        // runs, a `.permissionDenied` ToolResult is synthesised, and the
+        // coordinator must still run turn 2 (assertions on the follow-up
+        // tokens would not be observable if the stream was cancelled).
+        let executor = FailIfInvokedExecutor(name: "get_weather")
+        let registry = ToolRegistry()
+        registry.register(executor)
+
+        provider.backend.scriptedToolCallsPerTurn = [
+            [ToolCall(id: "c-1", toolName: "get_weather", arguments: #"{"city":"Rome"}"#)],
+            [],
+        ]
+        provider.backend.tokensToYieldPerTurn = [
+            [],
+            ["I", " cannot", " check", " the", " weather."],
+        ]
+
+        let coordinator = GenerationCoordinator(
+            toolRegistry: registry,
+            toolApprovalGate: FixedGate(.denied(reason: "user blocked this tool"))
+        )
+        coordinator.provider = provider
+
+        let (_, stream) = try coordinator.enqueue(
+            messages: [("user", "weather in Rome?")],
+            maxOutputTokens: 64
+        )
+        let events = try await collectEvents(stream)
+
+        // Executor must NOT have been hit.
+        XCTAssertFalse(executor.wasInvoked, "deny path must short-circuit before the registry")
+
+        // Exactly one synthesised ToolResult with .permissionDenied.
+        let results = events.compactMap { event -> ToolResult? in
+            if case .toolResult(let r) = event { return r } else { return nil }
+        }
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.errorKind, .permissionDenied)
+        XCTAssertEqual(results.first?.callId, "c-1")
+        XCTAssertEqual(results.first?.content, "user blocked this tool")
+
+        // Model continued past the denial: turn 2's visible tokens must have
+        // flowed through the stream, proving it wasn't cancelled.
+        // Sabotage-verify: deleting the `self.continuations[...].yield(.toolResult(result))`
+        // emission in GenerationCoordinator.runToolDispatchLoop empties the
+        // `results` array above and this test fails. Verified, reverted.
+        let tokens = events.compactMap { event -> String? in
+            if case .token(let t) = event { return t } else { return nil }
+        }
+        XCTAssertEqual(
+            tokens.joined(),
+            "I cannot check the weather.",
+            "stream must continue to the next turn after a denial"
+        )
+    }
+
+    func test_denyPath_streamTerminatesCleanly_noError() async throws {
+        // Stream must complete via a normal `.done` phase, not `.failed`.
+        let executor = FailIfInvokedExecutor(name: "go")
+        let registry = ToolRegistry()
+        registry.register(executor)
+
+        provider.backend.scriptedToolCallsPerTurn = [
+            [ToolCall(id: "c-1", toolName: "go", arguments: "{}")],
+            [],
+        ]
+        provider.backend.tokensToYieldPerTurn = [[], ["done"]]
+
+        let coordinator = GenerationCoordinator(
+            toolRegistry: registry,
+            toolApprovalGate: FixedGate(.denied(reason: nil))
+        )
+        coordinator.provider = provider
+
+        let (_, stream) = try coordinator.enqueue(
+            messages: [("user", "go")],
+            maxOutputTokens: 8
+        )
+        _ = try await collectEvents(stream)
+
+        // `.done` is the terminal phase for a successfully-completed run.
+        // `.failed(...)` would indicate the denial cancelled the stream,
+        // which is explicitly NOT what the coordinator does.
+        XCTAssertEqual(stream.phase, .done, "deny must not fail the stream; got \(stream.phase)")
+    }
+
+    // MARK: - Multiple tool calls within one request
+
+    func test_denyThenApprove_eachCallGoesThroughGate() async throws {
+        // Two sequential tool calls (different arguments so no repeat
+        // short-circuit). Gate denies both — the second call must still hit
+        // the gate, proving the gate is consulted per-call and not cached.
+        let executor = FailIfInvokedExecutor(name: "query")
+        let registry = ToolRegistry()
+        registry.register(executor)
+
+        provider.backend.scriptedToolCallsPerTurn = [
+            [ToolCall(id: "c-1", toolName: "query", arguments: #"{"q":"a"}"#)],
+            [ToolCall(id: "c-2", toolName: "query", arguments: #"{"q":"b"}"#)],
+            [],
+        ]
+        provider.backend.tokensToYieldPerTurn = [[], [], ["ok"]]
+
+        final class CountingGate: ToolApprovalGate {
+            private let state = OSAllocatedUnfairLock<Int>(initialState: 0)
+            var count: Int { state.withLock { $0 } }
+            func approve(_ call: ToolCall) async -> ToolApprovalDecision {
+                state.withLock { $0 += 1 }
+                return .denied(reason: "no")
+            }
+        }
+        let gate = CountingGate()
+
+        let coordinator = GenerationCoordinator(
+            toolRegistry: registry,
+            toolApprovalGate: gate
+        )
+        coordinator.provider = provider
+
+        let (_, stream) = try coordinator.enqueue(
+            messages: [("user", "go")],
+            maxOutputTokens: 8
+        )
+        _ = try await collectEvents(stream)
+
+        XCTAssertEqual(gate.count, 2, "gate must be consulted for every tool call, including denied ones")
+        XCTAssertFalse(executor.wasInvoked)
+    }
+}

--- a/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
+++ b/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
@@ -43,7 +43,7 @@ final class SilentCatchAuditTest: XCTestCase {
         // the substring `try?` inside `Regis‑try?`. No `try?` call site is present
         // on either line; the audit's substring scan is not AST-aware.
         "BaseChatInference/Services/GenerationCoordinator.swift:let toolRegistry: ToolRegistry?",
-        "BaseChatInference/Services/GenerationCoordinator.swift:toolRegistry: ToolRegistry? = nil",
+        "BaseChatInference/Services/GenerationCoordinator.swift:toolRegistry: ToolRegistry? = nil,",
         "BaseChatInference/Services/InferenceService.swift:public var toolRegistry: ToolRegistry? {",
         // JSONSchemaValue uses the standard "try-each-type-in-order" decoder pattern for
         // heterogeneous JSON. Each `try?` is bound to a named constant and the result is

--- a/Tests/BaseChatInferenceTests/ToolApprovalGateTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolApprovalGateTests.swift
@@ -1,0 +1,228 @@
+import XCTest
+import os
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Unit tests for ``ToolApprovalGate`` and its interaction with
+/// ``GenerationCoordinator`` at the single-call level.
+///
+/// These tests exercise just the gate-to-dispatch chokepoint: one tool call
+/// per test, so approve/deny paths can be isolated from the broader
+/// tool-dispatch loop assertions (iteration caps, repeat short-circuit,
+/// byte budgets) covered in ``GenerationCoordinatorToolLoopTests``.
+@MainActor
+final class ToolApprovalGateTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Records every call the gate sees so assertions can inspect the
+    /// finalized ``ToolCall`` payload. Decision is configurable at
+    /// construction time; default is ``ToolApprovalDecision/approved``.
+    ///
+    /// The recorder uses a simple lock so mutations are safe when the gate
+    /// is invoked off the MainActor (today it always is on MainActor, but
+    /// the protocol does not require it).
+    final class RecordingGate: ToolApprovalGate {
+        // OSAllocatedUnfairLock is the async-safe variant; NSLock is not
+        // callable from Swift-6 async contexts.
+        private let state = OSAllocatedUnfairLock<[ToolCall]>(initialState: [])
+        private let decision: ToolApprovalDecision
+
+        init(decision: ToolApprovalDecision = .approved) {
+            self.decision = decision
+        }
+
+        var observedCalls: [ToolCall] {
+            state.withLock { $0 }
+        }
+
+        func approve(_ call: ToolCall) async -> ToolApprovalDecision {
+            state.withLock { $0.append(call) }
+            return decision
+        }
+    }
+
+    /// Executor that counts invocations so tests can confirm the registry
+    /// was (or was not) dispatched through.
+    @MainActor
+    private final class CountingExecutor: ToolExecutor, @unchecked Sendable {
+        let definition: ToolDefinition
+        private(set) var callCount = 0
+
+        init(name: String) {
+            self.definition = ToolDefinition(name: name, description: "counting")
+        }
+
+        nonisolated func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+            await MainActor.run { self.callCount += 1 }
+            return ToolResult(callId: "", content: "ok", errorKind: nil)
+        }
+    }
+
+    private var provider: FakeGenerationContextProvider!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        provider = FakeGenerationContextProvider()
+    }
+
+    override func tearDown() async throws {
+        provider = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func collectEvents(_ stream: GenerationStream) async throws -> [GenerationEvent] {
+        var events: [GenerationEvent] = []
+        for try await event in stream.events {
+            events.append(event)
+        }
+        return events
+    }
+
+    /// Builds a coordinator wired for a single tool-call + terminating turn.
+    /// The executor emits `c-1` on turn 1, nothing on turn 2 (loop exits).
+    private func makeSingleCallSetup(
+        gate: any ToolApprovalGate
+    ) -> (coordinator: GenerationCoordinator, executor: CountingExecutor) {
+        let executor = CountingExecutor(name: "get_weather")
+        let registry = ToolRegistry()
+        registry.register(executor)
+
+        provider.backend.scriptedToolCallsPerTurn = [
+            [ToolCall(id: "c-1", toolName: "get_weather", arguments: #"{"city":"Rome"}"#)],
+            [],
+        ]
+        provider.backend.tokensToYieldPerTurn = [[], ["ok"]]
+
+        let coordinator = GenerationCoordinator(
+            toolRegistry: registry,
+            toolApprovalGate: gate
+        )
+        coordinator.provider = provider
+        return (coordinator, executor)
+    }
+
+    // MARK: - Approved path
+
+    func test_approvedPath_invokesRegistryDispatch() async throws {
+        let gate = RecordingGate(decision: .approved)
+        let (coordinator, executor) = makeSingleCallSetup(gate: gate)
+
+        let (_, stream) = try coordinator.enqueue(
+            messages: [("user", "weather?")],
+            maxOutputTokens: 16
+        )
+        _ = try await collectEvents(stream)
+
+        XCTAssertEqual(executor.callCount, 1, "approved path must dispatch through the registry")
+        XCTAssertEqual(gate.observedCalls.count, 1, "gate must be consulted once per call")
+    }
+
+    // MARK: - Denied path
+
+    func test_deniedPath_skipsRegistryDispatch() async throws {
+        let gate = RecordingGate(decision: .denied(reason: "not now"))
+        let (coordinator, executor) = makeSingleCallSetup(gate: gate)
+
+        let (_, stream) = try coordinator.enqueue(
+            messages: [("user", "weather?")],
+            maxOutputTokens: 16
+        )
+        _ = try await collectEvents(stream)
+
+        // Sabotage-verify: flipping the `.denied` branch in
+        // GenerationCoordinator to fall through to
+        // `result = await toolRegistry!.dispatch(call)` makes callCount == 1
+        // and this assertion fails. Verified locally, reverted before commit.
+        XCTAssertEqual(executor.callCount, 0, "denied path must NOT reach the registry")
+        XCTAssertEqual(gate.observedCalls.count, 1, "gate must still be consulted on deny")
+    }
+
+    func test_deniedPath_emitsPermissionDeniedResult() async throws {
+        let reason = "the user said no"
+        let gate = RecordingGate(decision: .denied(reason: reason))
+        let (coordinator, _) = makeSingleCallSetup(gate: gate)
+
+        let (_, stream) = try coordinator.enqueue(
+            messages: [("user", "weather?")],
+            maxOutputTokens: 16
+        )
+        let events = try await collectEvents(stream)
+
+        let results = events.compactMap { event -> ToolResult? in
+            if case .toolResult(let r) = event { return r } else { return nil }
+        }
+        let denied = try XCTUnwrap(results.first, "denial must still surface a ToolResult event")
+        XCTAssertEqual(denied.errorKind, .permissionDenied)
+        XCTAssertEqual(denied.content, reason)
+        XCTAssertEqual(denied.callId, "c-1", "callId must match the original ToolCall")
+    }
+
+    func test_deniedPath_withNilReason_usesDefaultString() async throws {
+        let gate = RecordingGate(decision: .denied(reason: nil))
+        let (coordinator, _) = makeSingleCallSetup(gate: gate)
+
+        let (_, stream) = try coordinator.enqueue(
+            messages: [("user", "weather?")],
+            maxOutputTokens: 16
+        )
+        let events = try await collectEvents(stream)
+
+        let results = events.compactMap { event -> ToolResult? in
+            if case .toolResult(let r) = event { return r } else { return nil }
+        }
+        let denied = try XCTUnwrap(results.first)
+        XCTAssertEqual(denied.errorKind, .permissionDenied)
+        XCTAssertFalse(denied.content.isEmpty, "default denial string must be non-empty so the model has context")
+    }
+
+    // MARK: - Finalized-ToolCall contract
+
+    func test_gateReceivesFinalizedToolCall() async throws {
+        // Assert the gate sees a fully-populated call: non-empty toolName,
+        // stable id, and complete arguments payload. This pins the
+        // finalized-call contract mentioned in the protocol doc.
+        let gate = RecordingGate(decision: .approved)
+        let (coordinator, _) = makeSingleCallSetup(gate: gate)
+
+        let (_, stream) = try coordinator.enqueue(
+            messages: [("user", "weather?")],
+            maxOutputTokens: 16
+        )
+        _ = try await collectEvents(stream)
+
+        let observed = try XCTUnwrap(gate.observedCalls.first)
+        XCTAssertFalse(observed.toolName.isEmpty, "finalized ToolCall must carry a non-empty toolName")
+        XCTAssertEqual(observed.id, "c-1", "finalized ToolCall must carry the stable backend-assigned id")
+        XCTAssertEqual(observed.arguments, #"{"city":"Rome"}"#, "arguments must be the fully-assembled payload, not a fragment")
+    }
+
+    // MARK: - AutoApproveGate default
+
+    func test_autoApproveGate_isDefault_andApproves() async throws {
+        // Build a coordinator with no gate override and confirm dispatch
+        // still happens — source compat guarantee.
+        let executor = CountingExecutor(name: "t")
+        let registry = ToolRegistry()
+        registry.register(executor)
+
+        provider.backend.scriptedToolCallsPerTurn = [
+            [ToolCall(id: "c-1", toolName: "t", arguments: "{}")],
+            [],
+        ]
+        provider.backend.tokensToYieldPerTurn = [[], ["done"]]
+
+        let coordinator = GenerationCoordinator(toolRegistry: registry)
+        coordinator.provider = provider
+
+        let (_, stream) = try coordinator.enqueue(
+            messages: [("user", "go")],
+            maxOutputTokens: 8
+        )
+        _ = try await collectEvents(stream)
+
+        XCTAssertEqual(executor.callCount, 1, "AutoApproveGate must be the default and approve unconditionally")
+    }
+}

--- a/Tests/BaseChatInferenceTests/ToolApprovalPerfTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolApprovalPerfTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import BaseChatInference
+
+/// Regression guard for the ``AutoApproveGate`` hot path.
+///
+/// This is not a micro-benchmark — the budget is deliberately generous
+/// (500 ms for 1000 sequential approvals). The purpose is to catch a
+/// future regression that accidentally adds heavy work (I/O, logging, an
+/// actor hop) into ``AutoApproveGate/approve(_:)``. The gate is invoked
+/// once per ``ToolCall`` inside the generation loop, so any non-trivial
+/// overhead compounds across long agentic runs.
+@MainActor
+final class ToolApprovalPerfTests: XCTestCase {
+
+    func testPerf_autoApprove_thousandCalls() {
+        let gate = AutoApproveGate()
+        // Pre-build the calls outside `measure { }` so the harness only
+        // times the gate invocations themselves, not fixture setup. Per
+        // CLAUDE.md perf guidelines, all fixtures must be ready before the
+        // measure block.
+        let calls: [ToolCall] = (0..<1000).map { idx in
+            ToolCall(
+                id: "c-\(idx)",
+                toolName: "noop",
+                arguments: #"{"i":\#(idx)}"#
+            )
+        }
+
+        measure {
+            let clock = ContinuousClock()
+            let start = clock.now
+
+            // Run the approval loop synchronously via a blocking task so
+            // `measure { }` can time it. `AutoApproveGate.approve` is an
+            // `async` method but never suspends, so this completes
+            // eagerly on the current actor.
+            let expectation = expectation(description: "approvals complete")
+            Task { @MainActor in
+                for call in calls {
+                    _ = await gate.approve(call)
+                }
+                expectation.fulfill()
+            }
+            wait(for: [expectation], timeout: 5.0)
+
+            let elapsed = clock.now - start
+            // Generous headroom — 500 ms for 1000 calls is ~500 µs/call,
+            // well above what the direct enum return should ever take.
+            // This surfaces regressions like an accidental log call or
+            // lock acquisition without tripping on CI jitter.
+            XCTAssertLessThan(
+                elapsed,
+                .milliseconds(500),
+                "AutoApproveGate hot path regressed: \(elapsed) for 1000 calls"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `ToolApprovalGate`, a `Sendable` protocol consulted by `GenerationCoordinator` before every `ToolCall` dispatches through the `ToolRegistry`. The default conformer is `AutoApproveGate` — existing callers see no behaviour change.

On `.denied(reason:)` the coordinator synthesises a `ToolResult` with `ErrorKind.permissionDenied` (carrying the reason) and continues the stream; generation is **not** cancelled. The model sees a structured refusal on its next turn and recovers gracefully.

Also ships `InboundPayload`, the unified handoff envelope for AppIntent / deep-link / Share-Extension ingest. Not consumed yet — laid down so PR 4 is a pure composition change.

## Files touched

- `Sources/BaseChatInference/Services/ToolApprovalGate.swift` (new) — protocol + `ToolApprovalDecision` + `AutoApproveGate`
- `Sources/BaseChatInference/Models/InboundPayload.swift` (new) — PR 4 foundation
- `Sources/BaseChatInference/Services/GenerationCoordinator.swift` — gate invocation before `ToolRegistry.dispatch`
- `Sources/BaseChatInference/Services/InferenceService.swift` — new `init(toolRegistry:toolApprovalGate:)`; existing inits preserved
- `Tests/BaseChatInferenceTests/ToolApprovalGateTests.swift` (new) — 6 tests
- `Tests/BaseChatInferenceTests/GenerationCoordinatorApprovalTests.swift` (new) — 3 tests
- `Tests/BaseChatInferenceTests/ToolApprovalPerfTests.swift` (new) — 1 perf guard
- `Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift` — allowlist entry updated (trailing comma changed on the existing `Regis‑try?` false-positive line)

## Stack context

This is **PR 2 of 4** in the launch-ready-demo stack:

- **PR 1** (merged as #652) — `feat(tools): SampleRepoSearchTool + reference tool wiring`
- **PR 2** (this one) — `ToolApprovalGate` protocol + `GenerationCoordinator` integration + `InboundPayload`
- **PR 3** (next, closes #437) — `ToolInvocationView` + `UIToolApprovalGate` MainActor conformer + flagship empty-state prompt
- **PR 4** — `AskBaseChatDemo` AppIntent consuming `InboundPayload`

Deliberately no UI-layer code and no AppIntent wiring beyond the `InboundPayload` struct.

## Upstream dependency note

The [plan](../.claude/plans/this-is-a-good-mossy-firefly.md) flagged `#622` (cancellation contract for in-flight tool execution) as a dependency. After implementation review: the synthesised-`ToolResult` approach taken here **does not** require #622. We short-circuit in the coordinator *before* `registry.dispatch` is called, so there is no in-flight tool execution to cancel on deny. #622 becomes relevant only if a future revision wants to support cancelling a long-running tool when the user changes their mind mid-execution — not in scope here.

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 213 pass
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — **994 pass** (+10 new)
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits` — 69 pass
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 458 pass
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 135 pass
- [x] `swift test --filter BaseChatToolsTests --disable-default-traits` — 36 pass
- [x] `xcodebuild … -scheme BaseChatDemo -destination 'platform=macOS' … build` — BUILD SUCCEEDED
- [x] `SilentCatchAuditTest` green after allowlist update for the `Regis‑try?` false positive
- [x] Sabotage-verified `test_deniedPath_skipsRegistryDispatch` (flipped the `.denied` branch to fall through — test failed as expected, reverted)
- [x] Sabotage-verified `test_denyPath_synthesisesPermissionDeniedResult_andStreamContinues` (deleted the synthesised-`ToolResult` yield — test failed as expected, reverted)
- [x] `Package.resolved` drift from `--disable-default-traits` reverted before commit (issue #600)

## Follow-ups noted during implementation

None that fall outside the stack. Potential future work if #622 lands: support cancellation-on-deny for long-running tools (today the gate is consulted before dispatch, so there is no running tool to cancel).