### PR TITLE
fix(tests): prevent MockURLProtocol crash on unregistered URLs in concurrent suites

### DIFF
--- a/Sources/BaseChatTestSupport/MockURLProtocol.swift
+++ b/Sources/BaseChatTestSupport/MockURLProtocol.swift
@@ -74,11 +74,16 @@ public final class MockURLProtocol: URLProtocol {
     /// Prefer this over ``reset()`` in test teardown — it cleans up only the
     /// current test's stub without clearing stubs registered by other suites
     /// that may be running concurrently.
+    ///
+    /// Also removes any captured requests for this URL so that
+    /// `capturedRequests` does not accumulate stale entries across tests.
     public static func unstub(url: URL) {
         lock.lock()
         defer { lock.unlock() }
-        stubs.removeValue(forKey: url.absoluteString)
-        stubSequences.removeValue(forKey: url.absoluteString)
+        let key = url.absoluteString
+        stubs.removeValue(forKey: key)
+        stubSequences.removeValue(forKey: key)
+        _capturedRequests.removeAll { $0.url?.absoluteString == key }
     }
 
     /// Removes all registered stubs and captured requests.
@@ -117,11 +122,12 @@ public final class MockURLProtocol: URLProtocol {
             }
         }
 
-        // If only one stub is registered, use it as a catch-all (common in tests).
-        if stubs.count == 1 {
-            return stubs.values.first
-        }
-
+        // No stub matched. Return nil so startLoading responds with a proper
+        // URLError rather than crashing or returning the wrong suite's response.
+        // The single-stub catch-all was removed because it caused cross-suite
+        // contamination when two serialized suites ran concurrently: Suite A's
+        // lone stub would intercept Suite B's requests and deliver the wrong
+        // response, leading to hangs or assertion failures.
         return nil
     }
 

--- a/Tests/BaseChatBackendsTests/OpenAICompatEndpointTests.swift
+++ b/Tests/BaseChatBackendsTests/OpenAICompatEndpointTests.swift
@@ -25,9 +25,9 @@ private let sseDone = Data("data: [DONE]\n\n".utf8)
 /// Creates an OpenAIBackend configured for a unique test URL.
 ///
 /// Each call uses a UUID-based hostname, so stubs from different tests
-/// never collide. We do NOT call `MockURLProtocol.reset()` here because
-/// that clears ALL global stubs and would corrupt concurrent test suites
-/// (e.g. CloudBackendSSETests) that also use MockURLProtocol.
+/// never collide. Tests must call `MockURLProtocol.unstub(url:)` in a
+/// `defer` block rather than `MockURLProtocol.reset()`, which would clear
+/// stubs registered by other suites running concurrently.
 private func makeOllamaBackend() -> (OpenAIBackend, URL) {
     let session = makeMockSession()
     let backend = OpenAIBackend(urlSession: session)
@@ -85,6 +85,7 @@ struct OpenAICompatEndpointTests {
 
     @Test func ollama_streaming_standardChunks() async throws {
         let (backend, url) = makeOllamaBackend()
+        defer { MockURLProtocol.unstub(url: url) }
 
         // Ollama's streaming format mirrors OpenAI's but includes an "ollama"
         // system_fingerprint and may omit some fields OpenAI includes.
@@ -130,6 +131,7 @@ struct OpenAICompatEndpointTests {
 
     @Test func ollama_streaming_withUsage() async throws {
         let (backend, url) = makeOllamaBackend()
+        defer { MockURLProtocol.unstub(url: url) }
 
         // Ollama supports stream_options.include_usage (added in 0.4.0).
         // Usage arrives in the final chunk, same as OpenAI.
@@ -165,6 +167,7 @@ struct OpenAICompatEndpointTests {
     /// this gracefully (lastUsage stays nil).
     @Test func ollama_streaming_withoutUsageSupport() async throws {
         let (backend, url) = makeOllamaBackend()
+        defer { MockURLProtocol.unstub(url: url) }
 
         let chunks: [Data] = [
             sseData("""
@@ -205,6 +208,7 @@ struct OpenAICompatEndpointTests {
     /// using OpenAI-compatible error format.
     @Test func ollama_error_modelNotFound() async throws {
         let (backend, url) = makeOllamaBackend()
+        defer { MockURLProtocol.unstub(url: url) }
 
         let body = Data("""
         {"error":{"message":"model 'nonexistent' not found, try pulling it first","type":"not_found","code":"model_not_found"}}
@@ -242,6 +246,7 @@ struct OpenAICompatEndpointTests {
     /// without authentication headers.
     @Test func ollama_noAuth_omitsAuthHeader() async throws {
         let (backend, url) = makeOllamaBackend()
+        defer { MockURLProtocol.unstub(url: url) }
 
         let chunks: [Data] = [
             sseData("""
@@ -275,6 +280,7 @@ struct OpenAICompatEndpointTests {
     /// OpenAI-compatible endpoint. Ollama accepts this format.
     @Test func requestFormat_containsExpectedFields() async throws {
         let (backend, url) = makeCompatBackend(modelName: "test-model")
+        defer { MockURLProtocol.unstub(url: url) }
 
         let chunks: [Data] = [
             sseData("""
@@ -319,6 +325,7 @@ struct OpenAICompatEndpointTests {
     /// version 0.4.0+. Older Ollama versions ignore it without erroring.
     @Test func requestFormat_containsStreamOptions() async throws {
         let (backend, url) = makeCompatBackend(modelName: "test-model")
+        defer { MockURLProtocol.unstub(url: url) }
 
         let chunks: [Data] = [
             sseData("""
@@ -352,6 +359,7 @@ struct OpenAICompatEndpointTests {
     /// which is essential for multi-turn conversations with Ollama.
     @Test func requestFormat_includesConversationHistory() async throws {
         let (backend, url) = makeCompatBackend(modelName: "llama3")
+        defer { MockURLProtocol.unstub(url: url) }
 
         let chunks: [Data] = [
             sseData("""


### PR DESCRIPTION
## Summary

- Removes the single-stub catch-all from `MockURLProtocol.findStub` that caused cross-suite contamination when two `.serialized` suites ran concurrently. Suite A's lone registered stub was being returned for Suite B's requests, delivering the wrong response and causing hangs or assertion failures in `CloudErrorSanitizer E2E (SSECloudBackend)` and `OpenAI-compat endpoints (Ollama)`.
- Adds missing `defer { MockURLProtocol.unstub(url: url) }` to all 8 tests in `OpenAICompatEndpointTests` — previously stubs were registered but never removed, letting them accumulate in global state across tests.
- Updates `MockURLProtocol.unstub(url:)` to also remove captured requests for the given URL so `capturedRequests` does not grow unboundedly across a test run.

## Root cause

`MockURLProtocol.findStub` had a fallback: if no URL-matched stub was found and exactly one stub was registered globally, it returned that lone stub as a catch-all. This was intended as a convenience for simple tests but backfires under concurrent execution:

1. Swift Testing runs `.serialized` suites from different files concurrently with each other (`.serialized` only serializes tests *within* a suite).
2. `CloudErrorSanitizerE2ETests` runs one test at a time, so it usually has exactly 1 stub active.
3. `OpenAICompatEndpointTests` — which never called `unstub` — had multiple stubs, but during setup of its first test there is a brief window with 0 stubs, and `canInit` returns `false`, so the request falls through to the real network and times out.
4. The catch-all then delivers the wrong SSE/error payload to the other suite's backend, causing unexpected error types or missing events that the test assertions treat as a hang.

The fix replaces the catch-all with a `return nil`, which causes `startLoading` to call `client?.urlProtocol(self, didFailWithError: URLError(.unsupportedURL))` — a clean test failure rather than a crash or deadlock.

## Test plan

- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` passes 3× consecutively with no crashes
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — no regressions
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — no regressions
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits` — no regressions
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — no regressions

## Release Note

**MockURLProtocol concurrent-suite crash** — Two Swift Testing suites (`CloudErrorSanitizer E2E` and `OpenAI-compat endpoints`) shared a global stub registry with a catch-all that returned the only registered stub when no URL match was found. Running the suites concurrently caused the wrong suite's stub to answer the other suite's HTTP request, producing hangs and assertion failures. Removed the catch-all, added stub cleanup (`defer { MockURLProtocol.unstub(url:) }`) to all tests that were missing it, and made `unstub` also remove captured requests for the given URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)