### PR TITLE
fix(backends): prevent SIGTRAP when FoundationModels session reused after task cancel

### DIFF
--- a/Sources/BaseChatBackends/FoundationBackend.swift
+++ b/Sources/BaseChatBackends/FoundationBackend.swift
@@ -98,6 +98,17 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
     /// Tracks the system prompt used to create the current session, so we only
     /// recreate when the prompt actually changes.
     private var currentSystemPrompt: String?
+    /// True when the session has no in-flight `ResponseStream`.
+    ///
+    /// `LanguageModelSession` asserts (SIGTRAP) if `streamResponse()` is called
+    /// again before the previous `ResponseStream` has been fully consumed — i.e.
+    /// its `AsyncIterator.next()` returned `nil`.  When a generation Task is
+    /// cancelled mid-stream the iterator is dropped early, leaving the session in
+    /// a "dirty" state.  This flag tracks that: it is cleared to `false` just
+    /// before the streaming loop starts and restored to `true` only when the loop
+    /// exits naturally (not via cancellation).  `generate()` treats a dirty session
+    /// the same as a `nil` session and creates a fresh `LanguageModelSession`.
+    private var _sessionIsClean = true
 
     private func withStateLock<T>(_ body: () throws -> T) rethrows -> T {
         stateLock.lock()
@@ -127,15 +138,32 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
         withStateLock { _isModelLoaded = true }
     }
 
-    /// Cancels the active generation task without resetting `session` or
-    /// `currentSystemPrompt`.  Unlike `stopGeneration()`, this preserves session state
-    /// so tests can verify that a second `generate()` call reuses the same session.
+    /// Cancels the active generation task without calling `stopGeneration()`.
+    ///
+    /// Unlike `stopGeneration()`, this does NOT nil `session` or `currentSystemPrompt`
+    /// synchronously.  `_sessionIsClean` is left for the Task body to manage: the
+    /// cancelled Task will observe `Task.isCancelled` and leave `_sessionIsClean = false`
+    /// when its streaming loop exits early.
+    ///
+    /// Use this in tests that need to stop a generation without going through the full
+    /// `stopGeneration()` path.
     func _cancelTaskOnly() {
         let task = withStateLock { () -> Task<Void, Never>? in
             defer { generationTask = nil }
             return generationTask
         }
         task?.cancel()
+    }
+
+    /// Directly marks the session as dirty, simulating the state that results from a
+    /// cancelled generation Task dropping its `ResponseStream` iterator mid-stream.
+    ///
+    /// Use this in unit tests that need to drive the `generate()` "dirty session →
+    /// new LanguageModelSession" code path without racing against real Task scheduling.
+    /// Prefer this over `_cancelTaskOnly()` when the test goal is to verify that the
+    /// next `generate()` call creates a fresh session.
+    func _markSessionDirty() {
+        withStateLock { _sessionIsClean = false }
     }
 #endif
 
@@ -195,6 +223,7 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
             currentSystemPrompt = nil
             _isModelLoaded = false
             _isGenerating = false
+            _sessionIsClean = true
         }
         Self.logger.info("Foundation backend unloaded")
     }
@@ -216,8 +245,14 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
             _isGenerating = true
 
             // Reuse the existing session to preserve conversation history.
-            // Only recreate if the system prompt changed or no session exists.
-            let needsNewSession = session == nil || systemPrompt != currentSystemPrompt
+            // Recreate if: no session exists, the system prompt changed, or the
+            // previous generation was cancelled before its ResponseStream was fully
+            // consumed.  In the last case the session is "dirty" — LanguageModelSession
+            // asserts (SIGTRAP) if streamResponse() is called on a session whose
+            // previous ResponseStream iterator was dropped before returning nil.
+            let needsNewSession = session == nil
+                || systemPrompt != currentSystemPrompt
+                || !_sessionIsClean
             if needsNewSession {
                 if let systemPrompt, !systemPrompt.isEmpty {
                     session = LanguageModelSession(instructions: systemPrompt)
@@ -225,6 +260,7 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
                     session = LanguageModelSession()
                 }
                 currentSystemPrompt = systemPrompt
+                _sessionIsClean = true  // fresh session always starts clean
             }
 
             return session!
@@ -258,12 +294,27 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
                     options: options
                 )
 
+                // Mark the session as dirty before iterating.  If the Task is
+                // cancelled or the loop breaks early (e.g. output token limit) before
+                // the ResponseStream is fully consumed, the session will be considered
+                // dirty and generate() will create a fresh LanguageModelSession on the
+                // next call.  This prevents a SIGTRAP: LanguageModelSession asserts when
+                // streamResponse() is called again while the previous ResponseStream
+                // iterator was dropped before returning nil.
+                backend.withStateLock { backend._sessionIsClean = false }
+
                 let outputLimit = config.maxOutputTokens
                 var outputTokenCount = 0
                 var previousCount = 0
                 var isFirstToken = true
+                // Tracks whether the loop ran to natural completion (iterator returned
+                // nil) rather than exiting via break or CancellationError.
+                var streamExhausted = true
                 for try await partial in responseStream {
-                    if Task.isCancelled { break }
+                    if Task.isCancelled {
+                        streamExhausted = false
+                        break
+                    }
 
                     let currentText = partial.content
                     if currentText.count > previousCount {
@@ -281,10 +332,20 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
                             outputTokenCount += max(1, newContent.count / 3)
                             if outputTokenCount >= limit {
                                 Self.logger.info("Output token limit (\(limit)) reached")
+                                streamExhausted = false
                                 break
                             }
                         }
                     }
+                }
+
+                // Only mark the session clean when the ResponseStream was fully
+                // consumed (iterator returned nil).  Any early exit — task
+                // cancellation or output-token-limit break — leaves the iterator
+                // dropped mid-stream, which would cause LanguageModelSession to
+                // SIGTRAP on the next streamResponse() call.
+                if streamExhausted {
+                    backend.withStateLock { backend._sessionIsClean = true }
                 }
                 await MainActor.run { generationStream.setPhase(.done) }
             } catch {
@@ -317,6 +378,7 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
         withStateLock {
             session = nil
             currentSystemPrompt = nil
+            _sessionIsClean = true
         }
         Self.logger.info("Foundation conversation reset")
     }
@@ -335,6 +397,7 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
         withStateLock {
             session = nil
             currentSystemPrompt = nil
+            _sessionIsClean = true
         }
     }
 

--- a/Tests/BaseChatBackendsTests/FoundationBackendUnitTests.swift
+++ b/Tests/BaseChatBackendsTests/FoundationBackendUnitTests.swift
@@ -288,59 +288,62 @@ final class FoundationBackendUnitTests: XCTestCase {
 
     // MARK: - Session reuse for multi-turn context preservation
 
-    /// Verifies that consecutive `generate()` calls with the same `systemPrompt`
-    /// reuse the **same** `LanguageModelSession` object.
+    /// Verifies that a dirty session forces a **new** `LanguageModelSession`
+    /// on the next `generate()` call — even when the system prompt is unchanged.
     ///
-    /// `LanguageModelSession.streamResponse(to:)` accumulates turns inside the session,
-    /// which is how FoundationBackend provides multi-turn context to the model.
-    /// If a new session were created on every call, all prior conversation history
-    /// would be lost.
+    /// ## Why a new session is required after mid-stream cancellation
     ///
-    /// The test drives this path without real inference by:
-    ///   1. Forcing the backend into the loaded state via `_forceLoaded()`.
-    ///   2. Calling `generate()` to trigger the lazy session-creation branch.
-    ///   3. Cancelling via `_cancelTaskOnly()` — which does NOT reset the session,
-    ///      unlike `stopGeneration()` — so the session survives into the next call.
-    ///   4. Draining the stream so `isGenerating` resets before the second call.
-    ///   5. Calling `generate()` again with the same systemPrompt.
-    ///   6. Asserting object identity (`===`) on the captured session references.
+    /// `LanguageModelSession` asserts (SIGTRAP) if `streamResponse()` is called while
+    /// the previous `ResponseStream`'s iterator was dropped before returning `nil`
+    /// (i.e. the stream was abandoned mid-flight).  Cancelling the generation Task
+    /// causes the iterator to be dropped early, leaving the session in a "dirty" state.
+    /// `FoundationBackend` tracks this via `_sessionIsClean` and forces a fresh
+    /// `LanguageModelSession` on the next call, preventing the SIGTRAP.
     ///
-    /// Sabotage check: change the `needsNewSession` condition in `FoundationBackend.generate`
-    /// so it always creates a new session (e.g. `let needsNewSession = true`). The
-    /// `XCTAssert(session1 === session2)` assertion will fail because a new object is
-    /// allocated on every call. Remove the sabotage before committing.
-    func test_generate_reusesSameSession_whenSystemPromptUnchanged() async throws {
-        // These tests exercise internal session-management state. They do not run real
-        // inference, but they do instantiate LanguageModelSession — a macOS 26 type.
-        // The setUpWithError guard already enforces the OS floor, so no additional skip
-        // is needed here. We do still skip when Apple Intelligence is NOT available,
-        // because LanguageModelSession() may raise an error at creation time on devices
-        // where the model is absent.
-        //
-        // Note: on CI (no Apple Intelligence) this test is SKIPPED — the session-reuse
-        // logic is verified on a real device where LanguageModelSession can be created.
+    /// ## Why `_markSessionDirty()` rather than `_cancelTaskOnly()`
+    ///
+    /// On fast hardware the generation Task may complete on a background thread between
+    /// `generate()` returning and `_cancelTaskOnly()` being called.  If that happens
+    /// the Task sets `_sessionIsClean = true` (natural completion) — racing with any
+    /// flag write in `_cancelTaskOnly()`.  Using `_markSessionDirty()` sidesteps that
+    /// race: it directly drives the `_sessionIsClean = false` state that a
+    /// mid-stream cancellation would produce, without relying on Task scheduling order.
+    ///
+    /// Sabotage check: remove the `|| !_sessionIsClean` clause from the
+    /// `needsNewSession` condition in `FoundationBackend.generate`.  The
+    /// `XCTAssert(session1 !== session2)` assertion will fail because the dirty
+    /// session is reused, reproducing the original SIGTRAP.  Remove the sabotage
+    /// before committing.
+    ///
+    /// - Note: on CI (no Apple Intelligence) this test is SKIPPED — `LanguageModelSession`
+    ///   cannot be created without Apple Intelligence.
+    func test_generate_dirtySession_forcesNewSession() async throws {
         try XCTSkipUnless(
             FoundationBackend.isAvailable,
-            "LanguageModelSession cannot be created without Apple Intelligence — skipping session-reuse test"
+            "LanguageModelSession cannot be created without Apple Intelligence — skipping dirty-session test"
         )
 
         backend._forceLoaded()
 
-        // First call — creates the session lazily.
         let systemPrompt = "You are a helpful assistant."
         let stream1 = try backend.generate(prompt: "Hello", systemPrompt: systemPrompt, config: GenerationConfig())
 
-        // Capture the session before cancellation resets it (stopGeneration would nil it).
         let session1 = backend._session
         XCTAssertNotNil(session1, "First generate() must create a session")
-        XCTAssertEqual(backend._currentSystemPrompt, systemPrompt, "currentSystemPrompt must be set")
+        XCTAssertEqual(backend._currentSystemPrompt, systemPrompt)
 
-        // Cancel the task without resetting the session, then drain so isGenerating → false.
+        // Stop the active generation, then drain the stream so isGenerating → false.
         backend._cancelTaskOnly()
         for try await _ in stream1.events {}
         XCTAssertFalse(backend.isGenerating, "isGenerating must be false after stream drains")
 
-        // Second call — same systemPrompt → must reuse the same session object.
+        // Directly mark the session dirty — simulates the state left by a Task that was
+        // cancelled before its ResponseStream iterator returned nil.  This avoids the
+        // Task-scheduling race where a fast response completes before the cancel lands.
+        backend._markSessionDirty()
+
+        // Second call with the SAME systemPrompt — must allocate a NEW session because
+        // the session is dirty and calling streamResponse() on it would SIGTRAP.
         let stream2 = try backend.generate(prompt: "How are you?", systemPrompt: systemPrompt, config: GenerationConfig())
         let session2 = backend._session
         XCTAssertNotNil(session2, "Second generate() must have a session")
@@ -348,10 +351,60 @@ final class FoundationBackendUnitTests: XCTestCase {
         backend._cancelTaskOnly()
         for try await _ in stream2.events {}
 
+        // After marking dirty the session must have been replaced, not reused.
+        XCTAssert(
+            session1 !== session2,
+            "Dirty session must NOT be reused — a fresh LanguageModelSession is required "
+            + "to prevent SIGTRAP on the next streamResponse() call"
+        )
+    }
+
+    /// Verifies that consecutive `generate()` calls with the same `systemPrompt`
+    /// reuse the **same** `LanguageModelSession` object after a **clean** completion.
+    ///
+    /// `LanguageModelSession.streamResponse(to:)` accumulates turns inside the session,
+    /// which is how FoundationBackend provides multi-turn context to the model.
+    /// If a new session were created on every call, all prior conversation history
+    /// would be lost.
+    ///
+    /// Requires live Apple Intelligence because we must let the generation complete
+    /// naturally so the `ResponseStream` iterator returns `nil` and the session is
+    /// marked clean before the next call.
+    ///
+    /// Sabotage check: change the `needsNewSession` condition in `FoundationBackend.generate`
+    /// so it always creates a new session (e.g. `let needsNewSession = true`). The
+    /// `XCTAssert(session1 === session2)` assertion will fail because a new object is
+    /// allocated on every call. Remove the sabotage before committing.
+    func test_generate_reusesSameSession_afterCleanCompletion() async throws {
+        try XCTSkipUnless(
+            FoundationBackend.isAvailable,
+            "LanguageModelSession cannot be created without Apple Intelligence — skipping session-reuse test"
+        )
+
+        let url = URL(fileURLWithPath: "/dev/null")
+        try await backend.loadModel(from: url, plan: .testStub(effectiveContextSize: 4096))
+        XCTAssertTrue(backend.isModelLoaded, "Precondition: loadModel must succeed")
+
+        let systemPrompt = "Reply with exactly the word OK and nothing else."
+
+        // First call — let generation complete naturally (short prompt → quick response).
+        let stream1 = try backend.generate(prompt: "Say OK", systemPrompt: systemPrompt, config: GenerationConfig())
+        for try await _ in stream1.events {}  // drain to natural completion
+        let session1 = backend._session
+        XCTAssertNotNil(session1, "First generate() must create a session")
+
+        XCTAssertFalse(backend.isGenerating, "isGenerating must be false after natural completion")
+
+        // Second call — same systemPrompt, previous stream completed cleanly → reuse session.
+        let stream2 = try backend.generate(prompt: "What did you just say?", systemPrompt: systemPrompt, config: GenerationConfig())
+        for try await _ in stream2.events {}
+        let session2 = backend._session
+        XCTAssertNotNil(session2, "Second generate() must have a session")
+
         // The key invariant: same session object identity means conversation history was preserved.
         XCTAssert(
             session1 === session2,
-            "Session must be REUSED when systemPrompt is unchanged — object identity must match"
+            "Session must be REUSED after a clean completion when systemPrompt is unchanged"
         )
     }
 
@@ -363,36 +416,54 @@ final class FoundationBackendUnitTests: XCTestCase {
     /// a new session (accepting that prior conversation history is discarded in exchange
     /// for the correct persona).
     ///
+    /// The first generation must complete **cleanly** (not via `_cancelTaskOnly()`)
+    /// so the session is marked clean before the second call.  That way the session
+    /// recreation is caused solely by the prompt change and not by the dirty-session
+    /// guard, keeping the sabotage check precise.
+    ///
     /// Sabotage check: remove the `systemPrompt != currentSystemPrompt` clause from the
     /// `needsNewSession` condition in `FoundationBackend.generate`. The assertion
-    /// `XCTAssert(session1 !== session2)` will fail because the old session is reused
-    /// even though the prompt changed. Remove the sabotage before committing.
+    /// `XCTAssert(session1 !== session2)` will fail because the old clean session is
+    /// reused even though the prompt changed. Remove the sabotage before committing.
     func test_generate_createsNewSession_whenSystemPromptChanges() async throws {
         try XCTSkipUnless(
             FoundationBackend.isAvailable,
             "LanguageModelSession cannot be created without Apple Intelligence — skipping session-recreation test"
         )
 
-        backend._forceLoaded()
+        let url = URL(fileURLWithPath: "/dev/null")
+        try await backend.loadModel(from: url, plan: .testStub(effectiveContextSize: 4096))
+        XCTAssertTrue(backend.isModelLoaded, "Precondition: loadModel must succeed")
 
-        // First call with prompt "A".
-        let stream1 = try backend.generate(prompt: "Hello", systemPrompt: "Persona A", config: GenerationConfig())
+        // First call with prompt "A" — let generation complete naturally so the session
+        // is marked clean.  This ensures the second call's new session is triggered by
+        // the prompt change, not by the dirty-session guard.
+        let stream1 = try backend.generate(
+            prompt: "Say OK",
+            systemPrompt: "Reply with exactly the word OK and nothing else.",
+            config: GenerationConfig()
+        )
+        for try await _ in stream1.events {}  // drain to natural completion
         let session1 = backend._session
         XCTAssertNotNil(session1, "First generate() must create a session")
-        XCTAssertEqual(backend._currentSystemPrompt, "Persona A")
+        XCTAssertEqual(backend._currentSystemPrompt, "Reply with exactly the word OK and nothing else.")
 
-        backend._cancelTaskOnly()
-        for try await _ in stream1.events {}
-        XCTAssertFalse(backend.isGenerating, "isGenerating must be false after stream drains")
+        XCTAssertFalse(backend.isGenerating, "isGenerating must be false after natural completion")
 
-        // Second call with a DIFFERENT prompt "B" — must allocate a new session.
-        let stream2 = try backend.generate(prompt: "Hello", systemPrompt: "Persona B", config: GenerationConfig())
+        // Second call with a DIFFERENT system prompt — must allocate a new session.
+        let stream2 = try backend.generate(
+            prompt: "Say OK",
+            systemPrompt: "You are a pirate. Reply with exactly the word OK and nothing else.",
+            config: GenerationConfig()
+        )
+        for try await _ in stream2.events {}
         let session2 = backend._session
         XCTAssertNotNil(session2, "Second generate() must create a session")
-        XCTAssertEqual(backend._currentSystemPrompt, "Persona B", "currentSystemPrompt must update to new prompt")
-
-        backend._cancelTaskOnly()
-        for try await _ in stream2.events {}
+        XCTAssertEqual(
+            backend._currentSystemPrompt,
+            "You are a pirate. Reply with exactly the word OK and nothing else.",
+            "currentSystemPrompt must update to new prompt"
+        )
 
         // The key invariant: a different system prompt must produce a different session object.
         XCTAssert(


### PR DESCRIPTION
## Summary

- `LanguageModelSession` asserts (signal 5 / SIGTRAP) when `streamResponse()` is called while the previous `ResponseStream` iterator was dropped mid-stream — e.g. because the Swift Task that was iterating it was cancelled before `next()` returned `nil`.
- Introduces `_sessionIsClean: Bool` state in `FoundationBackend`: cleared before each streaming loop, restored only on natural completion, checked in `generate()` alongside the existing session-nil and prompt-change guards.
- A dirty session now triggers `needsNewSession = true`, allocating a fresh `LanguageModelSession` and preventing the SIGTRAP on the next `streamResponse()` call.

## Root cause

`FoundationBackend.generate()` creates a `Task` that iterates `activeSession.streamResponse(...)`. When `_cancelTaskOnly()` (or any external `task.cancel()`) is called, the `for try await` loop exits early — either via the `if Task.isCancelled { break }` guard or by `next()` throwing `CancellationError`. In either case the `ResponseStream.AsyncIterator` is dropped before `next()` returns `nil`, leaving the session in an undrained state. Calling `streamResponse()` on that same session again hits an internal assertion in FoundationModels.

## Fix

Added `_sessionIsClean: Bool` (default `true`) protected by the existing `stateLock`:

| Event | `_sessionIsClean` |
|-------|-------------------|
| New session created in `generate()` | `true` |
| Loop starts (before first `await next()`) | `false` |
| Loop exits naturally (`next()` → `nil`) | `true` |
| Loop exits early (cancel / break / error) | stays `false` |
| `stopGeneration()` / `unloadModel()` / `resetConversation()` | `true` (session is nil'd) |

`generate()` adds `|| !_sessionIsClean` to `needsNewSession`, allocating a fresh `LanguageModelSession` whenever the previous stream was not fully consumed.

## Test plan

- `test_generate_dirtySession_forcesNewSession` — calls `_markSessionDirty()` (new test helper that directly sets `_sessionIsClean = false`) then verifies the next `generate()` allocates a new session. Sabotage: remove `|| !_sessionIsClean` from `needsNewSession` → assertion fails.
- `test_generate_reusesSameSession_afterCleanCompletion` — lets generation complete naturally then verifies the session IS reused. Requires live Apple Intelligence; skipped on CI.
- `test_generate_createsNewSession_whenSystemPromptChanges` — updated to use clean completions so its sabotage check isolates the prompt-change clause precisely.
- All five CI suites green locally:
  - `BaseChatCoreTests` ✓
  - `BaseChatInferenceTests` ✓
  - `BaseChatInferenceSwiftTestingTests` ✓
  - `BaseChatUITests` ✓
  - `BaseChatBackendsTests` ✓ (no crash, no SIGTRAP)

## Release Note

**FoundationBackend SIGTRAP on session reuse after cancellation** — `LanguageModelSession` asserts when `streamResponse()` is called while the previous stream was abandoned mid-flight. A new `_sessionIsClean` guard in `generate()` detects this state and creates a fresh session, preventing the crash on any device with Apple Intelligence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)