### PR TITLE
feat(ui): add ToolInvocationView and UIToolApprovalGate (closes #437)

### DIFF
--- a/Example/BaseChatDemo.xcodeproj/project.pbxproj
+++ b/Example/BaseChatDemo.xcodeproj/project.pbxproj
@@ -14,12 +14,16 @@
 		BF0005000000000000000000 /* BaseChatBackends in Frameworks */ = {isa = PBXBuildFile; productRef = F30003000000000000000000 /* BaseChatBackends */; };
 		BF0006000000000000000000 /* BaseChatTools in Frameworks */ = {isa = PBXBuildFile; productRef = F30004000000000000000000 /* BaseChatTools */; };
 		BF0007000000000000000000 /* DemoTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10004000000000000000000 /* DemoTools.swift */; };
+		BF0008000000000000000000 /* ChatEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10005000000000000000000 /* ChatEmptyStateView.swift */; };
+		BF0009000000000000000000 /* ToolApprovalSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10006000000000000000000 /* ToolApprovalSheet.swift */; };
+		BF0010000000000000000000 /* ToolPolicyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10007000000000000000000 /* ToolPolicyView.swift */; };
 		BF1001000000000000000000 /* ModelManagementUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11001000000000000000000 /* ModelManagementUITests.swift */; };
 		BF1002000000000000000000 /* UITestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11003000000000000000000 /* UITestHelpers.swift */; };
 		BF1003000000000000000000 /* ChatFlowUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11004000000000000000000 /* ChatFlowUITests.swift */; };
 		BF1004000000000000000000 /* SessionManagementUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11005000000000000000000 /* SessionManagementUITests.swift */; };
 		BF1005000000000000000000 /* SettingsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11006000000000000000000 /* SettingsUITests.swift */; };
 		BF1006000000000000000000 /* CloudAPIUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11007000000000000000000 /* CloudAPIUITests.swift */; };
+		BF1007000000000000000000 /* ToolApprovalUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11008000000000000000000 /* ToolApprovalUITests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -36,6 +40,9 @@
 		F10001000000000000000000 /* BaseChatDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseChatDemoApp.swift; sourceTree = "<group>"; };
 		F10002000000000000000000 /* DemoContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoContentView.swift; sourceTree = "<group>"; };
 		F10004000000000000000000 /* DemoTools.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoTools.swift; sourceTree = "<group>"; };
+		F10005000000000000000000 /* ChatEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatEmptyStateView.swift; sourceTree = "<group>"; };
+		F10006000000000000000000 /* ToolApprovalSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolApprovalSheet.swift; sourceTree = "<group>"; };
+		F10007000000000000000000 /* ToolPolicyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings/ToolPolicyView.swift; sourceTree = "<group>"; };
 		F10003000000000000000000 /* BaseChatDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BaseChatDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F11001000000000000000000 /* ModelManagementUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelManagementUITests.swift; sourceTree = "<group>"; };
 		F11002000000000000000000 /* BaseChatDemoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BaseChatDemoUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -44,6 +51,7 @@
 		F11005000000000000000000 /* SessionManagementUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagementUITests.swift; sourceTree = "<group>"; };
 		F11006000000000000000000 /* SettingsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsUITests.swift; sourceTree = "<group>"; };
 		F11007000000000000000000 /* CloudAPIUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudAPIUITests.swift; sourceTree = "<group>"; };
+		F11008000000000000000000 /* ToolApprovalUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolApprovalUITests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -84,6 +92,9 @@
 				F10001000000000000000000 /* BaseChatDemoApp.swift */,
 				F10002000000000000000000 /* DemoContentView.swift */,
 				F10004000000000000000000 /* DemoTools.swift */,
+				F10005000000000000000000 /* ChatEmptyStateView.swift */,
+				F10006000000000000000000 /* ToolApprovalSheet.swift */,
+				F10007000000000000000000 /* ToolPolicyView.swift */,
 			);
 			path = BaseChatDemo;
 			sourceTree = "<group>";
@@ -113,6 +124,7 @@
 				F11005000000000000000000 /* SessionManagementUITests.swift */,
 				F11006000000000000000000 /* SettingsUITests.swift */,
 				F11007000000000000000000 /* CloudAPIUITests.swift */,
+				F11008000000000000000000 /* ToolApprovalUITests.swift */,
 			);
 			path = BaseChatDemoUITests;
 			sourceTree = "<group>";
@@ -199,6 +211,9 @@
 				BF0001000000000000000000 /* BaseChatDemoApp.swift in Sources */,
 				BF0002000000000000000000 /* DemoContentView.swift in Sources */,
 				BF0007000000000000000000 /* DemoTools.swift in Sources */,
+				BF0008000000000000000000 /* ChatEmptyStateView.swift in Sources */,
+				BF0009000000000000000000 /* ToolApprovalSheet.swift in Sources */,
+				BF0010000000000000000000 /* ToolPolicyView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -212,6 +227,7 @@
 				BF1004000000000000000000 /* SessionManagementUITests.swift in Sources */,
 				BF1005000000000000000000 /* SettingsUITests.swift in Sources */,
 				BF1006000000000000000000 /* CloudAPIUITests.swift in Sources */,
+				BF1007000000000000000000 /* ToolApprovalUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/BaseChatDemo/BaseChatDemoApp.swift
+++ b/Example/BaseChatDemo/BaseChatDemoApp.swift
@@ -4,6 +4,7 @@ import BaseChatCore
 import BaseChatInference
 import BaseChatUI
 import BaseChatBackends
+import BaseChatTools
 
 @main
 struct BaseChatDemoApp: App {
@@ -43,11 +44,45 @@ struct BaseChatDemoApp: App {
         let toolRegistry = ToolRegistry()
         DemoTools.register(on: toolRegistry)
 
-        let inferenceService = InferenceService(toolRegistry: toolRegistry)
-        DefaultBackends.register(with: inferenceService)
-        self.inferenceService = inferenceService
+        let approvalGate = UIToolApprovalGate(policy: .askOncePerSession)
 
-        let vm = ChatViewModel(inferenceService: inferenceService)
+        let configuredService: InferenceService
+        #if DEBUG
+        if testing {
+            // Under --uitesting, swap in a ScriptedBackend so the approval UI
+            // can be exercised without live inference. Keeps this gated on
+            // the uitesting launch arg so production launches are unaffected.
+            let scripted = ScriptedBackend(turns: [
+                .toolCall(name: "sample_repo_search", arguments: #"{"query":"readme"}"#),
+                .tokens(["Here's ", "a ", "summary ", "of ", "your ", "workspace."])
+            ])
+            configuredService = InferenceService(
+                backend: scripted,
+                name: "ScriptedUITest",
+                modelName: "scripted-ui",
+                toolRegistry: toolRegistry,
+                toolApprovalGate: approvalGate
+            )
+        } else {
+            configuredService = InferenceService(
+                toolRegistry: toolRegistry,
+                toolApprovalGate: approvalGate
+            )
+            DefaultBackends.register(with: configuredService)
+        }
+        #else
+        configuredService = InferenceService(
+            toolRegistry: toolRegistry,
+            toolApprovalGate: approvalGate
+        )
+        DefaultBackends.register(with: configuredService)
+        #endif
+        self.inferenceService = configuredService
+
+        let vm = ChatViewModel(
+            inferenceService: configuredService,
+            toolApprovalGate: approvalGate
+        )
         vm.foundationModelProvider = {
             if #available(iOS 26, macOS 26, *) {
                 return FoundationBackend.isAvailable

--- a/Example/BaseChatDemo/ChatEmptyStateView.swift
+++ b/Example/BaseChatDemo/ChatEmptyStateView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+import BaseChatUI
+
+/// Flagship empty-state shown in the chat detail area when the active session
+/// has no messages yet.
+///
+/// The "Summarize the README files in my workspace." prompt drives the
+/// scripted repo-search tool, which exercises: thinking stream (if the model
+/// supports it) → tool call → approval sheet → tool result rendering →
+/// assistant synthesis. It's the single tap that takes a reviewer through the
+/// whole differentiator loop in one go.
+struct ChatEmptyStateView: View {
+
+    @Environment(ChatViewModel.self) private var viewModel
+
+    private static let flagshipPrompt = "Summarize the README files in my workspace."
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "sparkles.rectangle.stack")
+                .font(.system(size: 42))
+                .foregroundStyle(.tint)
+
+            Text("Try the flagship prompt")
+                .font(.headline)
+
+            Text("Kicks off thinking, a tool call for README summarisation, and an approval sheet — the full BaseChatKit loop in one tap.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 24)
+
+            Button {
+                sendFlagshipPrompt()
+            } label: {
+                Label(Self.flagshipPrompt, systemImage: "paperplane.fill")
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+            }
+            .buttonStyle(.borderedProminent)
+            .accessibilityIdentifier("flagship-prompt-button")
+            .disabled(!viewModel.isModelLoaded)
+        }
+        .padding(.vertical, 32)
+    }
+
+    private func sendFlagshipPrompt() {
+        viewModel.inputText = Self.flagshipPrompt
+        Task { await viewModel.sendMessage() }
+    }
+}

--- a/Example/BaseChatDemo/DemoContentView.swift
+++ b/Example/BaseChatDemo/DemoContentView.swift
@@ -17,6 +17,7 @@ struct DemoContentView: View {
     @State private var columnVisibility: NavigationSplitViewVisibility = .automatic
     @State private var preferredCompactColumn: NavigationSplitViewColumn = .detail
     @State private var isModelManagementPresented = false
+    @State private var isToolPolicyPresented = false
 
     let inferenceService: InferenceService
 
@@ -25,13 +26,20 @@ struct DemoContentView: View {
     var skipAutoModelLoad: Bool = false
 
     var body: some View {
-        NavigationSplitView(
+        // Read the gate's pending queue so SwiftUI observes changes and the
+        // `.sheet(item:)` binding below re-evaluates when a new approval
+        // is enqueued. Without this the binding's `get` closure is stale.
+        let _ = viewModel.toolApprovalGate?.pending.count
+
+        return NavigationSplitView(
             columnVisibility: $columnVisibility,
             preferredCompactColumn: $preferredCompactColumn
         ) {
             sidebar
         } detail: {
-            ChatView(showModelManagement: $isModelManagementPresented)
+            ChatView(showModelManagement: $isModelManagementPresented) {
+                ChatEmptyStateView()
+            }
                 .toolbar {
                     // .topBarLeading is iOS-only; macOS NavigationSplitView manages
                     // sidebar visibility via its own controls so this button is not
@@ -55,6 +63,22 @@ struct DemoContentView: View {
             ModelManagementSheet()
                 .environment(viewModel)
                 .environment(managementViewModel)
+        }
+        .sheet(isPresented: $isToolPolicyPresented) {
+            ToolPolicyView()
+                .environment(viewModel)
+        }
+        .sheet(isPresented: approvalSheetIsPresented) {
+            if let call = viewModel.toolApprovalGate?.pending.first {
+                ToolApprovalSheet(call: call)
+                    .environment(viewModel)
+            } else {
+                // Belt-and-braces: the binding only flips to `true` when
+                // ``pending.first`` exists, but a race during dismiss can
+                // leave the queue empty while the sheet closes. Emit a
+                // drop-down so we don't present an empty sheet shell.
+                Color.clear.frame(width: 1, height: 1)
+            }
         }
         .onAppear {
             if horizontalSizeClass == .compact {
@@ -193,6 +217,21 @@ struct DemoContentView: View {
                         .font(.caption)
                         .foregroundStyle(.red)
                 }
+
+                Button {
+                    isToolPolicyPresented = true
+                } label: {
+                    HStack {
+                        Label("Tool approval", systemImage: "checkmark.shield")
+                            .font(.caption)
+                        Spacer()
+                        Text(policyLabel(viewModel.toolApprovalPolicy))
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("sidebar-tool-policy-button")
             }
             .padding()
         }
@@ -226,4 +265,36 @@ struct DemoContentView: View {
         .automatic
         #endif
     }
+
+    /// Drives the presentation of the approval sheet off the gate's pending
+    /// queue. Kept as a computed `Binding<Bool>` so `@Observable` tracking on
+    /// the gate re-evaluates the binding whenever the queue mutates — a
+    /// `.sheet(item:)` binding with `Binding(get:set:)` would not re-read
+    /// without another observed property driving the re-render.
+    private var approvalSheetIsPresented: Binding<Bool> {
+        Binding(
+            get: { (viewModel.toolApprovalGate?.pending.first) != nil },
+            set: { newValue in
+                guard !newValue else { return }
+                // Drag-dismiss (iOS) is a dismiss without an explicit
+                // decision; treat it as a denial so the pending queue
+                // drains and the model recovers with a structured error.
+                if let first = viewModel.toolApprovalGate?.pending.first {
+                    viewModel.toolApprovalGate?.resolve(
+                        callId: first.id,
+                        with: .denied(reason: "dismissed")
+                    )
+                }
+            }
+        )
+    }
+
+    private func policyLabel(_ policy: UIToolApprovalGate.Policy) -> String {
+        switch policy {
+        case .alwaysAsk: return "Always ask"
+        case .askOncePerSession: return "Once / session"
+        case .autoApprove: return "Auto"
+        }
+    }
 }
+

--- a/Example/BaseChatDemo/Settings/ToolPolicyView.swift
+++ b/Example/BaseChatDemo/Settings/ToolPolicyView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+import BaseChatUI
+
+/// Picker for the demo's ``UIToolApprovalGate/Policy``.
+///
+/// Surfaced as a sheet from the sidebar. The three cases cover the common
+/// positions a host app takes on tool approval:
+/// - Always ask (most conservative — every call prompts)
+/// - Ask once per session (default — prompt once, trust subsequent calls)
+/// - Auto-approve (no sheet ever — useful for demos, scripted flows, and
+///   trusted environments)
+struct ToolPolicyView: View {
+
+    @Environment(ChatViewModel.self) private var viewModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Picker("Tool approval", selection: binding) {
+                        Text("Always ask").tag(UIToolApprovalGate.Policy.alwaysAsk)
+                        Text("Ask once per session").tag(UIToolApprovalGate.Policy.askOncePerSession)
+                        Text("Auto-approve").tag(UIToolApprovalGate.Policy.autoApprove)
+                    }
+                    .pickerStyle(.inline)
+                    .labelsHidden()
+                } footer: {
+                    Text("Controls whether the model's tool calls pause for your approval. Changes apply to the next tool call.")
+                }
+            }
+            .navigationTitle("Tool Approval")
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .accessibilityIdentifier("tool-policy-done-button")
+                }
+            }
+        }
+        .accessibilityIdentifier("tool-policy-sheet")
+    }
+
+    private var binding: Binding<UIToolApprovalGate.Policy> {
+        Binding(
+            get: { viewModel.toolApprovalPolicy },
+            set: { viewModel.toolApprovalPolicy = $0 }
+        )
+    }
+}

--- a/Example/BaseChatDemo/ToolApprovalSheet.swift
+++ b/Example/BaseChatDemo/ToolApprovalSheet.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+import BaseChatInference
+import BaseChatUI
+
+/// Modal sheet that drives ``UIToolApprovalGate`` one pending call at a time.
+///
+/// Observes `gate.pending` and presents the Approve/Deny surface whenever the
+/// queue has a front-of-line entry under ``UIToolApprovalGate/Policy/alwaysAsk``
+/// or the first request of a session under ``askOncePerSession``. Delegates
+/// rendering to ``ToolInvocationView`` so the visual contract matches what
+/// the finalised tool-call bubble shows in-thread.
+struct ToolApprovalSheet: View {
+
+    @Environment(ChatViewModel.self) private var viewModel
+    @Environment(\.dismiss) private var dismiss
+
+    let call: ToolCall
+
+    @State private var denyReason: String = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Approve tool call?")
+                .font(.headline)
+                .accessibilityIdentifier("approval-sheet-title")
+
+            // Inline call summary. We deliberately render the fields by hand
+            // rather than embedding ``ToolInvocationView`` in its
+            // `.pendingApproval` state, because that state introduces its
+            // own "Approve"/"Deny" buttons — XCUITest selectors would then
+            // match two hit-targets with the same label, and the system
+            // `.borderedProminent` button style sometimes swallows custom
+            // identifiers under `.sheet` presentation.
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 6) {
+                    Image(systemName: "wrench.and.screwdriver")
+                        .foregroundStyle(.secondary)
+                    Text(call.toolName)
+                        .font(.caption.monospaced())
+                        .fontWeight(.semibold)
+                }
+                Text(call.arguments)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+
+            TextField("Reason for denial (optional)", text: $denyReason)
+                .textFieldStyle(.roundedBorder)
+                .accessibilityIdentifier("approval-deny-reason-field")
+
+            HStack {
+                Button("Deny") {
+                    viewModel.toolApprovalGate?.resolve(
+                        callId: call.id,
+                        with: .denied(reason: denyReason.isEmpty ? nil : denyReason)
+                    )
+                    dismiss()
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("approval-sheet-deny-button")
+
+                Spacer()
+
+                Button("Approve") {
+                    viewModel.toolApprovalGate?.resolve(callId: call.id, with: .approved)
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("approval-sheet-approve-button")
+            }
+        }
+        .padding(20)
+        .frame(minWidth: 340)
+        .accessibilityIdentifier("approval-sheet")
+    }
+}

--- a/Example/BaseChatDemoUITests/ToolApprovalUITests.swift
+++ b/Example/BaseChatDemoUITests/ToolApprovalUITests.swift
@@ -1,0 +1,53 @@
+import XCTest
+
+/// Deterministic UI tests for the tool-approval flow surfaces.
+///
+/// Runs against the demo app launched with `--uitesting`, which swaps in a
+/// ``ScriptedBackend`` emitting a canned `.toolCall` for `sample_repo_search`.
+/// No live Ollama / MLX / cloud traffic.
+///
+/// Scope: verify that the flagship-prompt empty state renders and wires a
+/// hit-target. The downstream approval sheet + completed-bubble rendering
+/// is covered deterministically by ``UIToolApprovalGateTests`` and
+/// ``ToolInvocationViewTests`` at the XCTest level, where we can observe
+/// `@Observable` state changes directly. XCUITest's sheet-presentation
+/// timing is flaky under simulator in the `--uitesting` pathway and would
+/// add noise without adding information.
+final class ToolApprovalUITests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func test_flagshipPromptButton_rendersInEmptyState() {
+        let app = launchDemoApp()
+        openChatDetailIfNeeded(app: app)
+
+        XCTAssertTrue(
+            waitForChatInputReady(app: app, timeout: 20),
+            "Chat input should become hittable under --uitesting"
+        )
+
+        let flagshipButton = app.buttons["flagship-prompt-button"]
+        XCTAssertTrue(
+            flagshipButton.waitForExistence(timeout: 5),
+            "Flagship prompt button should render in the chat empty state"
+        )
+        XCTAssertTrue(
+            flagshipButton.isHittable,
+            "Flagship prompt button must be tappable for reviewers to exercise the tool loop"
+        )
+    }
+
+    func test_sidebarToolPolicyButton_isReachable() {
+        let app = launchDemoApp()
+
+        showSidebarIfNeeded(app: app)
+        let policyButton = app.buttons["sidebar-tool-policy-button"]
+        XCTAssertTrue(
+            policyButton.waitForExistence(timeout: 10),
+            "Tool-policy picker button should be reachable from the sidebar"
+        )
+    }
+}

--- a/Sources/BaseChatInference/Services/InferenceService.swift
+++ b/Sources/BaseChatInference/Services/InferenceService.swift
@@ -330,6 +330,25 @@ public final class InferenceService {
         self.generation = GenerationCoordinator()
         generation.provider = self
     }
+
+    /// Debug-only init that pre-loads a backend alongside a ``ToolRegistry``
+    /// and ``ToolApprovalGate``. Used by ``--uitesting`` launches in the
+    /// example app so the approval sheet can be exercised deterministically
+    /// against a ``ScriptedBackend``.
+    public init(
+        backend: any InferenceBackend,
+        name: String = "Mock",
+        modelName: String? = nil,
+        toolRegistry: ToolRegistry,
+        toolApprovalGate: any ToolApprovalGate = AutoApproveGate()
+    ) {
+        self.lifecycle = ModelLifecycleCoordinator(backend: backend, name: name, modelName: modelName)
+        self.generation = GenerationCoordinator(
+            toolRegistry: toolRegistry,
+            toolApprovalGate: toolApprovalGate
+        )
+        generation.provider = self
+    }
     #endif
 
     /// Ensures the generation coordinator has a reference to this service.

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+SessionManagement.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+SessionManagement.swift
@@ -23,6 +23,10 @@ extension ChatViewModel {
         // Discard any queued requests that belong to a different session.
         inferenceService.discardRequests(notMatching: session.id)
 
+        // Clear any still-pending tool approvals and the once-per-session
+        // latch so approvals from the prior session do not leak into this one.
+        toolApprovalGate?.resetForNewSession()
+
         // Cancel any in-flight post-generation background tasks from the prior session.
         backgroundTask?.cancel()
         backgroundTask = nil

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -34,6 +34,24 @@ public final class ChatViewModel {
     let modelStorage: ModelStorageService
     let memoryPressure: MemoryPressureHandler
 
+    /// The UI-layer ``ToolApprovalGate`` that drives the per-call approval
+    /// sheet. When `nil`, the underlying ``InferenceService`` uses its
+    /// default ``AutoApproveGate`` — every tool call dispatches silently.
+    ///
+    /// To wire an approval sheet, pass the same instance to both
+    /// ``InferenceService/init(toolRegistry:toolApprovalGate:)`` and this
+    /// view model's initializer. ``switchToSession(_:)`` forwards session
+    /// resets so per-session approvals do not leak across chats.
+    public let toolApprovalGate: UIToolApprovalGate?
+
+    /// Convenience accessor for the gate's policy. Get returns
+    /// ``UIToolApprovalGate/Policy/autoApprove`` when no gate was installed
+    /// (the effective behaviour without a gate); set is a no-op in that case.
+    public var toolApprovalPolicy: UIToolApprovalGate.Policy {
+        get { toolApprovalGate?.policy ?? .autoApprove }
+        set { toolApprovalGate?.policy = newValue }
+    }
+
     /// Test-only seam: overrides the system-memory source used by `ModelLoadPlan`
     /// when deciding whether a local model load should proceed. Production code
     /// leaves this at `.current`; tests assign a deterministic environment.
@@ -511,13 +529,15 @@ public final class ChatViewModel {
     public convenience init(
         inferenceService: InferenceService = InferenceService(),
         deviceCapability: DeviceCapabilityService = DeviceCapabilityService(),
-        modelStorage: ModelStorageService = ModelStorageService()
+        modelStorage: ModelStorageService = ModelStorageService(),
+        toolApprovalGate: UIToolApprovalGate? = nil
     ) {
         self.init(
             inferenceService: inferenceService,
             deviceCapability: deviceCapability,
             modelStorage: modelStorage,
-            memoryPressure: MemoryPressureHandler()
+            memoryPressure: MemoryPressureHandler(),
+            toolApprovalGate: toolApprovalGate
         )
     }
 
@@ -525,12 +545,14 @@ public final class ChatViewModel {
         inferenceService: InferenceService = InferenceService(),
         deviceCapability: DeviceCapabilityService = DeviceCapabilityService(),
         modelStorage: ModelStorageService = ModelStorageService(),
-        memoryPressure: MemoryPressureHandler
+        memoryPressure: MemoryPressureHandler,
+        toolApprovalGate: UIToolApprovalGate? = nil
     ) {
         self.inferenceService = inferenceService
         self.deviceCapability = deviceCapability
         self.modelStorage = modelStorage
         self.memoryPressure = memoryPressure
+        self.toolApprovalGate = toolApprovalGate
         self.sessionController = SessionController(selectedPromptTemplate: inferenceService.selectedPromptTemplate)
 
         let firstRunKey = "\(BaseChatConfiguration.shared.bundleIdentifier).hasCompletedFirstLaunch"

--- a/Sources/BaseChatUI/ViewModels/GenerationCoordinator.swift
+++ b/Sources/BaseChatUI/ViewModels/GenerationCoordinator.swift
@@ -301,11 +301,18 @@ final class GenerationCoordinator {
                                 msg.completionTokens = completion
                             }
 
-                        case .dispatchToolCall:
-                            // Tool execution is a host-app concern; ChatViewModel does not
-                            // implement a tool dispatch loop. Apps that need tool calling
-                            // should drive generation directly via InferenceService.
-                            break
+                        case .dispatchToolCall(let call):
+                            // Tool execution itself is a host-app concern; ChatViewModel does
+                            // not implement a tool dispatch loop. But the UI needs the call
+                            // persisted in contentParts so ``MessagePartsView`` can pair the
+                            // later ``.toolResult`` with the originating call (and render a
+                            // named "completed" disclosure instead of an opaque callId).
+                            // ``InferenceService.GenerationCoordinator`` dispatches through
+                            // its ``ToolRegistry`` and emits the result downstream; that
+                            // event lands on the ``appendToolResult`` branch below.
+                            self.onMutateMessage(messageID) { msg in
+                                msg.contentParts.append(.toolCall(call))
+                            }
 
                         case .appendThinkingText(let text):
                             let isFirstThinkingFragment = thinkingAccumulator.isEmpty

--- a/Sources/BaseChatUI/ViewModels/UIToolApprovalGate.swift
+++ b/Sources/BaseChatUI/ViewModels/UIToolApprovalGate.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Observation
+import BaseChatInference
+
+/// A ``ToolApprovalGate`` backed by a MainActor-isolated pending-approval queue
+/// that UI surfaces can observe and resolve.
+///
+/// The gate cooperates with ``ChatViewModel`` and the backing
+/// ``GenerationCoordinator``: when the model emits a ``ToolCall``, the
+/// coordinator awaits ``approve(_:)``. Depending on ``policy`` this either:
+/// - returns immediately (``Policy/autoApprove`` or the cached "already
+///   approved once" flag for ``Policy/askOncePerSession``), or
+/// - appends the call to ``pending`` and suspends until the view calls
+///   ``resolve(callId:with:)`` from the approval sheet's Approve/Deny buttons.
+///
+/// Because the gate is an `@Observable` class, SwiftUI views observing
+/// ``pending`` automatically re-render when a new call arrives or the queue
+/// drains.
+///
+/// ## Session boundary
+///
+/// The queue and the once-per-session latch are both cleared by
+/// ``resetForNewSession()``. ``ChatViewModel/switchToSession(_:)`` invokes
+/// this so an approval granted in one session doesn't silently carry over
+/// into another. Hosts that drive the gate directly (tests, non-UI apps)
+/// should call the same method when they swap sessions.
+@Observable
+@MainActor
+public final class UIToolApprovalGate: ToolApprovalGate {
+
+    // MARK: - Policy
+
+    /// How aggressively the gate should prompt the user for each ``ToolCall``.
+    ///
+    /// - ``alwaysAsk`` — every call requires explicit approval.
+    /// - ``askOncePerSession`` — the first call in a session requires
+    ///   approval; subsequent calls auto-approve until ``resetForNewSession()``.
+    /// - ``autoApprove`` — every call is approved silently.
+    public enum Policy: Sendable, CaseIterable {
+        case alwaysAsk
+        case askOncePerSession
+        case autoApprove
+    }
+
+    /// The current policy. Defaults to ``Policy/askOncePerSession`` — the
+    /// behaviour the demo ships with. Hosts can expose this via a settings
+    /// picker (see the Demo app's `ToolPolicyView`).
+    public var policy: Policy = .askOncePerSession
+
+    /// Calls awaiting a user decision, in arrival order. The first element
+    /// is what a single-row approval sheet should present.
+    public private(set) var pending: [ToolCall] = []
+
+    // MARK: - Private state
+
+    /// Waiters keyed by ``ToolCall/id``. A gate call appends to ``pending``
+    /// and stores its continuation here; ``resolve(callId:with:)`` pops the
+    /// matching entry and resumes.
+    ///
+    /// Marked `@ObservationIgnored` because mutating the dictionary would
+    /// otherwise trigger view re-renders on every resume — the queue is the
+    /// observable contract, the continuations are private plumbing.
+    @ObservationIgnored
+    private var waiters: [String: CheckedContinuation<ToolApprovalDecision, Never>] = [:]
+
+    /// Set to `true` after the first successful approval under
+    /// ``Policy/askOncePerSession``. Reset by ``resetForNewSession()``.
+    @ObservationIgnored
+    private var hasApprovedThisSession: Bool = false
+
+    // MARK: - Init
+
+    public init(policy: Policy = .askOncePerSession) {
+        self.policy = policy
+    }
+
+    // MARK: - ToolApprovalGate
+
+    /// Implements ``ToolApprovalGate/approve(_:)``.
+    ///
+    /// Actor hop: the protocol is `Sendable` and non-isolated, but this class
+    /// is `@MainActor`. Swift bridges the call via an implicit `await` so the
+    /// body runs on the main actor — the same actor the `@Observable` state
+    /// and SwiftUI view updates live on.
+    public func approve(_ call: ToolCall) async -> ToolApprovalDecision {
+        switch policy {
+        case .autoApprove:
+            return .approved
+
+        case .askOncePerSession where hasApprovedThisSession:
+            return .approved
+
+        case .alwaysAsk, .askOncePerSession:
+            return await awaitDecision(for: call)
+        }
+    }
+
+    // MARK: - View-facing API
+
+    /// Called by the approval sheet to resolve the front-of-queue approval.
+    ///
+    /// Pops the matching entry from ``pending``, resumes the awaiting
+    /// continuation, and — on ``ToolApprovalDecision/approved`` under
+    /// ``Policy/askOncePerSession`` — flips the once-per-session latch so
+    /// subsequent calls auto-approve.
+    ///
+    /// No-op if `callId` does not match a queued call (e.g. a stale sheet tap
+    /// after the call was resolved elsewhere).
+    public func resolve(callId: String, with decision: ToolApprovalDecision) {
+        guard let continuation = waiters.removeValue(forKey: callId) else { return }
+        pending.removeAll(where: { $0.id == callId })
+
+        if case .approved = decision, policy == .askOncePerSession {
+            hasApprovedThisSession = true
+        }
+
+        continuation.resume(returning: decision)
+    }
+
+    /// Clears the approval queue and the once-per-session latch so the next
+    /// call under ``Policy/askOncePerSession`` prompts again. Any still-queued
+    /// calls are denied with the reason "session reset" so their awaiting
+    /// continuations don't leak.
+    public func resetForNewSession() {
+        hasApprovedThisSession = false
+        let inFlight = waiters
+        waiters.removeAll()
+        pending.removeAll()
+        for (_, continuation) in inFlight {
+            continuation.resume(returning: .denied(reason: "session reset"))
+        }
+    }
+
+    // MARK: - Private helpers
+
+    private func awaitDecision(for call: ToolCall) async -> ToolApprovalDecision {
+        await withCheckedContinuation { continuation in
+            pending.append(call)
+            waiters[call.id] = continuation
+        }
+    }
+}

--- a/Sources/BaseChatUI/Views/Chat/ChatView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ChatView.swift
@@ -25,8 +25,27 @@ public struct ChatView: View {
     @State private var showClearConfirmation: Bool = false
     @State private var showAPIConfiguration: Bool = false
 
+    /// Optional replacement for the built-in "Send a message to start chatting."
+    /// placeholder shown when the session has no messages. Hosts pass a custom
+    /// view here to surface a flagship prompt button, first-run hints, etc.
+    private let customEmptyPlaceholder: AnyView?
+
     public init(showModelManagement: Binding<Bool>) {
         self._showModelManagement = showModelManagement
+        self.customEmptyPlaceholder = nil
+    }
+
+    /// Creates a ``ChatView`` with a host-supplied empty-state view rendered
+    /// when the active session has no messages.
+    ///
+    /// Use this overload to surface a curated prompt button, a first-run
+    /// tour, or any other call-to-action in place of the default placeholder.
+    public init<EmptyContent: View>(
+        showModelManagement: Binding<Bool>,
+        @ViewBuilder emptyState: () -> EmptyContent
+    ) {
+        self._showModelManagement = showModelManagement
+        self.customEmptyPlaceholder = AnyView(emptyState())
     }
 
     // MARK: - Body
@@ -367,12 +386,19 @@ public struct ChatView: View {
         .frame(maxHeight: .infinity)
     }
 
+    @ViewBuilder
     private var emptyPlaceholder: some View {
-        Text("Send a message to start chatting.")
-            .foregroundStyle(.tertiary)
-            .font(.body)
-            .frame(maxWidth: .infinity)
-            .padding(.top, 40)
+        if let customEmptyPlaceholder {
+            customEmptyPlaceholder
+                .frame(maxWidth: .infinity)
+                .padding(.top, 40)
+        } else {
+            Text("Send a message to start chatting.")
+                .foregroundStyle(.tertiary)
+                .font(.body)
+                .frame(maxWidth: .infinity)
+                .padding(.top, 40)
+        }
     }
 
     // MARK: - Toolbar Items

--- a/Sources/BaseChatUI/Views/Chat/MessagePartsView.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessagePartsView.swift
@@ -5,12 +5,35 @@ import BaseChatInference
 /// Renders an array of ``MessagePart`` values within a message bubble.
 ///
 /// Text parts are rendered inline (markdown for assistant, plain for user),
-/// images are shown as thumbnails, and thinking blocks show a collapsible
-/// disclosure group (or a streaming label while generation is in progress).
+/// images are shown as thumbnails, thinking blocks show a collapsible
+/// disclosure group (or a streaming label while generation is in progress),
+/// and tool calls/results are paired by ``ToolCall/id`` and handed to
+/// ``ToolInvocationView``.
 struct MessagePartsView: View {
     let parts: [MessagePart]
     let role: MessageRole
     var isStreaming: Bool = false
+
+    @Environment(ChatViewModel.self) private var viewModel
+
+    /// Set of call IDs whose ``ToolResult`` already appears in `parts`. Used
+    /// to decide whether a ``MessagePart/toolCall`` should render as
+    /// pendingApproval/running (no result yet) or completed/failed (result
+    /// landed).
+    private var resolvedResultIDs: Set<String> {
+        Set(parts.compactMap { part -> String? in
+            if case .toolResult(let r) = part { return r.callId }
+            return nil
+        })
+    }
+
+    /// Set of call IDs currently waiting on user approval. Observed via the
+    /// gate's `@Observable` `pending` array so toggling the approval sheet
+    /// re-renders this view.
+    private var pendingApprovalIDs: Set<String> {
+        guard let gate = viewModel.toolApprovalGate else { return [] }
+        return Set(gate.pending.map { $0.id })
+    }
 
     var body: some View {
         ForEach(Array(parts.enumerated()), id: \.offset) { _, part in
@@ -36,10 +59,57 @@ struct MessagePartsView: View {
             // arriving.
             ThinkingBlockView(text: text, isThinkingStreaming: text.isEmpty && isStreaming)
 
-        case .toolCall, .toolResult:
-            // Rendering is owned by #437. Silently skip for now so mixed-content
-            // messages still display their text/image/thinking parts.
-            EmptyView()
+        case .toolCall(let call):
+            toolCallView(call)
+
+        case .toolResult(let result):
+            // Emit the result inline only when there is no paired `.toolCall`
+            // above — that covers the case where the call part was trimmed out
+            // of history. Otherwise we've already rendered the completed
+            // disclosure on the toolCall branch and the matching result has
+            // been folded into it.
+            if !parts.contains(where: {
+                if case .toolCall(let c) = $0 { return c.id == result.callId }
+                return false
+            }) {
+                ToolInvocationView(
+                    part: .toolResult(result),
+                    state: result.errorKind == nil ? .completed : .failed
+                )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func toolCallView(_ call: ToolCall) -> some View {
+        if let matchingResult = parts.compactMap({ part -> ToolResult? in
+            if case .toolResult(let r) = part, r.callId == call.id { return r }
+            return nil
+        }).first {
+            // Completed: render a single completed/failed disclosure keyed
+            // by the call's tool name, with the paired result folded in.
+            let state: ToolInvocationView.State = matchingResult.errorKind == nil ? .completed : .failed
+            ToolInvocationView(
+                part: .toolCall(call),
+                state: state,
+                pairedResult: matchingResult
+            )
+        } else if pendingApprovalIDs.contains(call.id) {
+            ToolInvocationView(
+                part: .toolCall(call),
+                state: .pendingApproval,
+                onApprove: { [weak gate = viewModel.toolApprovalGate] in
+                    gate?.resolve(callId: call.id, with: .approved)
+                },
+                onDeny: { [weak gate = viewModel.toolApprovalGate] reason in
+                    gate?.resolve(callId: call.id, with: .denied(reason: reason))
+                }
+            )
+        } else {
+            ToolInvocationView(
+                part: .toolCall(call),
+                state: .running
+            )
         }
     }
 
@@ -80,4 +150,5 @@ struct MessagePartsView: View {
 
 #Preview("Text Only") {
     MessagePartsView(parts: [.text("Hello world")], role: .assistant)
+        .environment(ChatViewModel())
 }

--- a/Sources/BaseChatUI/Views/Chat/ToolInvocationView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ToolInvocationView.swift
@@ -1,0 +1,285 @@
+import SwiftUI
+import BaseChatInference
+
+/// Renders a single ``MessagePart/toolCall`` or ``MessagePart/toolResult``
+/// within a message bubble.
+///
+/// Four visual states are branched off the `MessagePart` case and the presence
+/// of a completed ``ToolResult``:
+/// - ``State/pendingApproval`` — tool-name chip + argument preview + Approve/Deny.
+/// - ``State/running`` — spinner while the tool executes.
+/// - ``State/completed`` — collapsed disclosure showing args + content.
+/// - ``State/failed`` — collapsed disclosure with the ``ToolResult/ErrorKind``
+///   chip.
+///
+/// This view is intentionally "dumb" — it takes the part and optional
+/// callback closures, never reaches into `@Environment` for a view model.
+/// The approval-queue wiring lives in ``UIToolApprovalGate`` and the host's
+/// ``ChatViewModel``; this view is just the visual shell they drive.
+///
+/// ## Accessibility identifiers
+///
+/// - Container: `tool-invocation-<state>-<toolName>` where state is one of
+///   `pending`, `running`, `completed`, `failed`.
+/// - Approve button: `approval-approve-button`.
+/// - Deny button: `approval-deny-button`.
+public struct ToolInvocationView: View {
+
+    /// Visual state the view should render.
+    ///
+    /// The caller decides which state applies based on whether the part is a
+    /// ``MessagePart/toolCall`` that still needs approval, is currently
+    /// running, or already has a matching ``MessagePart/toolResult`` paired
+    /// with it. Keeping the state explicit in the API makes the view unit
+    /// testable without having to fabricate the whole messages array.
+    public enum State: Sendable, Equatable {
+        case pendingApproval
+        case running
+        case completed
+        case failed
+    }
+
+    /// The part being rendered. Must be either ``MessagePart/toolCall`` or
+    /// ``MessagePart/toolResult`` — any other case renders as an empty view
+    /// so mixed-content bubbles degrade gracefully.
+    public let part: MessagePart
+
+    /// Optional paired ``ToolResult`` for ``State/completed`` / ``State/failed``
+    /// renders driven off a ``MessagePart/toolCall`` primary part. Supplying
+    /// the result alongside the call lets the disclosure group label with
+    /// the tool name while still surfacing the result body underneath.
+    public let pairedResult: ToolResult?
+
+    /// The visual state to render.
+    public let state: State
+
+    /// Invoked when the user taps Approve on a pending approval.
+    /// Only read when ``state`` is ``State/pendingApproval``.
+    public var onApprove: (() -> Void)?
+
+    /// Invoked when the user taps Deny on a pending approval. The optional
+    /// `String` carries an opt-in reason surfaced back to the model via the
+    /// synthesised ``ToolResult/ErrorKind/permissionDenied``.
+    /// Only read when ``state`` is ``State/pendingApproval``.
+    public var onDeny: ((String?) -> Void)?
+
+    public init(
+        part: MessagePart,
+        state: State,
+        pairedResult: ToolResult? = nil,
+        onApprove: (() -> Void)? = nil,
+        onDeny: ((String?) -> Void)? = nil
+    ) {
+        self.part = part
+        self.state = state
+        self.pairedResult = pairedResult
+        self.onApprove = onApprove
+        self.onDeny = onDeny
+    }
+
+    public var body: some View {
+        switch (part, state) {
+        case (.toolCall(let call), .pendingApproval):
+            pendingView(call: call)
+        case (.toolCall(let call), .running):
+            runningView(call: call)
+        case (.toolCall(let call), .completed):
+            // Completed pair: fold the paired result (if any) into the same
+            // disclosure labeled with the call's tool name.
+            completedCallView(call: call, result: pairedResult)
+        case (.toolCall(let call), .failed):
+            failedView(call: call, result: pairedResult)
+        case (.toolResult(let result), .completed):
+            completedCallView(call: nil, result: result)
+        case (.toolResult(let result), .failed):
+            failedView(call: nil, result: result)
+        default:
+            // Mixed-content bubbles should not crash if a caller supplies a
+            // text / image / thinking part by accident. Silently skip.
+            EmptyView()
+        }
+    }
+
+    // MARK: - States
+
+    private func pendingView(call: ToolCall) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: "wrench.and.screwdriver")
+                    .foregroundStyle(.secondary)
+                Text(call.toolName)
+                    .font(.caption.monospaced())
+                    .fontWeight(.semibold)
+            }
+            Text(argumentPreview(call.arguments))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+                .textSelection(.enabled)
+            HStack(spacing: 8) {
+                Button("Deny") { onDeny?(nil) }
+                    .buttonStyle(.bordered)
+                    .accessibilityIdentifier("approval-deny-button")
+                Button("Approve") { onApprove?() }
+                    .buttonStyle(.borderedProminent)
+                    .accessibilityIdentifier("approval-approve-button")
+            }
+        }
+        .padding(8)
+        .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 8))
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("tool-invocation-pending-\(call.toolName)")
+    }
+
+    private func runningView(call: ToolCall) -> some View {
+        HStack(spacing: 6) {
+            ProgressView()
+                .controlSize(.mini)
+            Text("calling ")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            + Text(call.toolName)
+                .font(.caption.monospaced())
+                .foregroundStyle(.secondary)
+            + Text("…")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(8)
+        .accessibilityIdentifier("tool-invocation-running-\(call.toolName)")
+    }
+
+    private func completedCallView(call: ToolCall?, result: ToolResult?) -> some View {
+        let toolName = call?.toolName ?? "tool"
+        return DisclosureGroup {
+            VStack(alignment: .leading, spacing: 6) {
+                if let call {
+                    Text("Arguments")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                    Text(call.arguments)
+                        .font(.caption.monospaced())
+                        .textSelection(.enabled)
+                }
+                if let result {
+                    Text("Result")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                    Text(result.content)
+                        .font(.caption.monospaced())
+                        .textSelection(.enabled)
+                }
+            }
+            .padding(.top, 4)
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "checkmark.circle")
+                    .foregroundStyle(.green)
+                Text(toolName)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityIdentifier("tool-invocation-completed-\(toolName)")
+    }
+
+    private func failedView(call: ToolCall?, result: ToolResult?) -> some View {
+        let toolName = call?.toolName ?? "tool"
+        let kindLabel = result?.errorKind.map { $0.rawValue } ?? "failed"
+        return DisclosureGroup {
+            VStack(alignment: .leading, spacing: 6) {
+                if let call {
+                    Text("Arguments")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                    Text(call.arguments)
+                        .font(.caption.monospaced())
+                        .textSelection(.enabled)
+                }
+                if let result {
+                    Text("Error")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                    Text(result.content)
+                        .font(.caption.monospaced())
+                        .textSelection(.enabled)
+                }
+            }
+            .padding(.top, 4)
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "exclamationmark.triangle")
+                    .foregroundStyle(.orange)
+                Text(toolName)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                Text(kindLabel)
+                    .font(.caption2)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(.orange.opacity(0.15), in: Capsule())
+                    .foregroundStyle(.orange)
+            }
+        }
+        .accessibilityIdentifier("tool-invocation-failed-\(toolName)")
+    }
+
+    // MARK: - Helpers
+
+    private func argumentPreview(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.count <= 80 { return trimmed }
+        return String(trimmed.prefix(80)) + "…"
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Pending") {
+    ToolInvocationView(
+        part: .toolCall(ToolCall(
+            id: "1",
+            toolName: "sample_repo_search",
+            arguments: #"{"query":"readme","limit":5}"#
+        )),
+        state: .pendingApproval,
+        onApprove: {},
+        onDeny: { _ in }
+    )
+    .padding()
+}
+
+#Preview("Running") {
+    ToolInvocationView(
+        part: .toolCall(ToolCall(
+            id: "2",
+            toolName: "sample_repo_search",
+            arguments: #"{"query":"readme"}"#
+        )),
+        state: .running
+    )
+    .padding()
+}
+
+#Preview("Completed") {
+    ToolInvocationView(
+        part: .toolResult(ToolResult(
+            callId: "3",
+            content: #"[{"path":"README.md","snippet":"Sample Workspace"}]"#
+        )),
+        state: .completed
+    )
+    .padding()
+}
+
+#Preview("Failed") {
+    ToolInvocationView(
+        part: .toolResult(ToolResult(
+            callId: "4",
+            content: "User denied execution.",
+            errorKind: .permissionDenied
+        )),
+        state: .failed
+    )
+    .padding()
+}

--- a/Tests/BaseChatUITests/ToolInvocationViewTests.swift
+++ b/Tests/BaseChatUITests/ToolInvocationViewTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+import SwiftUI
+import ViewInspector
+import BaseChatInference
+@testable import BaseChatUI
+
+/// Visual-contract tests for ``ToolInvocationView``. Each test renders the
+/// view against a fixture ``MessagePart`` and asserts the accessibility
+/// identifier that drives the XCUITest selectors. The view is dumb — no
+/// ``ChatViewModel`` environment required.
+@MainActor
+final class ToolInvocationViewTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func pendingCall(
+        id: String = "pending-1",
+        name: String = "sample_repo_search"
+    ) -> MessagePart {
+        .toolCall(ToolCall(
+            id: id,
+            toolName: name,
+            arguments: #"{"query":"readme","limit":5}"#
+        ))
+    }
+
+    private func runningCall(
+        id: String = "running-1",
+        name: String = "sample_repo_search"
+    ) -> MessagePart {
+        .toolCall(ToolCall(id: id, toolName: name, arguments: #"{"query":"x"}"#))
+    }
+
+    private func completedResult(
+        callId: String = "done-1"
+    ) -> MessagePart {
+        .toolResult(ToolResult(
+            callId: callId,
+            content: #"[{"path":"README.md","snippet":"Sample"}]"#
+        ))
+    }
+
+    private func failedResult(
+        callId: String = "failed-1"
+    ) -> MessagePart {
+        .toolResult(ToolResult(
+            callId: callId,
+            content: "denied",
+            errorKind: .permissionDenied
+        ))
+    }
+
+    // MARK: - Tests
+
+    func test_pendingApproval_exposesApproveAndDenyIdentifiers() throws {
+        let view = ToolInvocationView(
+            part: pendingCall(),
+            state: .pendingApproval,
+            onApprove: {},
+            onDeny: { _ in }
+        )
+        _ = try view.inspect().find(viewWithAccessibilityIdentifier: "tool-invocation-pending-sample_repo_search")
+        _ = try view.inspect().find(viewWithAccessibilityIdentifier: "approval-approve-button")
+        _ = try view.inspect().find(viewWithAccessibilityIdentifier: "approval-deny-button")
+    }
+
+    func test_running_exposesContainerIdentifier() throws {
+        let view = ToolInvocationView(part: runningCall(), state: .running)
+        _ = try view.inspect().find(viewWithAccessibilityIdentifier: "tool-invocation-running-sample_repo_search")
+    }
+
+    func test_completed_rendersResultContentUnderDisclosureIdentifier() throws {
+        // Result-only render path (e.g. trimmed history): identifier falls
+        // back to the literal "tool" segment since the original call is gone.
+        let view = ToolInvocationView(part: completedResult(), state: .completed)
+        _ = try view.inspect().find(viewWithAccessibilityIdentifier: "tool-invocation-completed-tool")
+    }
+
+    func test_completed_withPairedCall_usesToolNameInIdentifier() throws {
+        let call = ToolCall(id: "c1", toolName: "sample_repo_search", arguments: "{}")
+        let result = ToolResult(callId: "c1", content: "[]")
+        let view = ToolInvocationView(
+            part: .toolCall(call),
+            state: .completed,
+            pairedResult: result
+        )
+        _ = try view.inspect().find(viewWithAccessibilityIdentifier: "tool-invocation-completed-sample_repo_search")
+    }
+
+    func test_failed_rendersErrorKindIdentifier() throws {
+        let view = ToolInvocationView(part: failedResult(), state: .failed)
+        _ = try view.inspect().find(viewWithAccessibilityIdentifier: "tool-invocation-failed-tool")
+    }
+
+    func test_approveButton_invokesOnApproveClosure() throws {
+        var approved = false
+        let view = ToolInvocationView(
+            part: pendingCall(),
+            state: .pendingApproval,
+            onApprove: { approved = true },
+            onDeny: { _ in }
+        )
+        let button = try view.inspect().find(button: "Approve")
+        try button.tap()
+        XCTAssertTrue(approved, "Tapping Approve should invoke onApprove()")
+    }
+
+    func test_denyButton_invokesOnDenyWithNoReason() throws {
+        var denyReason: String?? = nil
+        let view = ToolInvocationView(
+            part: pendingCall(),
+            state: .pendingApproval,
+            onApprove: {},
+            onDeny: { reason in denyReason = .some(reason) }
+        )
+        let button = try view.inspect().find(button: "Deny")
+        try button.tap()
+        // onDeny called with nil reason from the inline Deny button.
+        XCTAssertNotNil(denyReason, "Deny button should invoke onDeny()")
+        XCTAssertNil(denyReason ?? "non-nil sentinel", "Inline Deny forwards nil reason")
+    }
+}

--- a/Tests/BaseChatUITests/UIToolApprovalGateTests.swift
+++ b/Tests/BaseChatUITests/UIToolApprovalGateTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+import BaseChatInference
+@testable import BaseChatUI
+
+/// Behavioural tests for ``UIToolApprovalGate``. These exercise the policy
+/// matrix (alwaysAsk / askOncePerSession / autoApprove), the session-reset
+/// boundary, and the continuation-based resolve hand-off the view layer
+/// uses to drive the approval sheet.
+@MainActor
+final class UIToolApprovalGateTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func call(id: String = "c1", name: String = "sample_repo_search") -> ToolCall {
+        ToolCall(id: id, toolName: name, arguments: "{}")
+    }
+
+    /// Kicks off `gate.approve(call)` on the main actor and returns the in-
+    /// flight task. Keeping the approve call inside an explicit Task makes the
+    /// actor isolation visible in the test and sidesteps the data-race
+    /// diagnostics `async let` would raise when bridging MainActor state.
+    private func startApprove(
+        _ gate: UIToolApprovalGate,
+        _ call: ToolCall
+    ) -> Task<ToolApprovalDecision, Never> {
+        Task { @MainActor in
+            await gate.approve(call)
+        }
+    }
+
+    /// Spin until the gate's `pending` queue has at least one entry or the
+    /// deadline elapses. `approve` appends synchronously on MainActor before
+    /// suspending, so a single `Task.yield()` loop is sufficient — the
+    /// deadline exists so a regression (e.g. append-after-suspend) fails loud
+    /// instead of hanging the test bed.
+    private func waitForPending(_ gate: UIToolApprovalGate, deadline: Date = .now + 1.0) async {
+        while gate.pending.isEmpty, Date() < deadline {
+            await Task.yield()
+        }
+    }
+
+    // MARK: - Policy: autoApprove
+
+    func test_autoApprove_returnsImmediately_withoutEnqueuing() async {
+        let gate = UIToolApprovalGate(policy: .autoApprove)
+
+        let decision = await gate.approve(call())
+        XCTAssertEqual(decision, .approved)
+        XCTAssertTrue(gate.pending.isEmpty, "autoApprove must not enqueue anything")
+    }
+
+    // MARK: - Policy: askOncePerSession
+
+    func test_askOncePerSession_secondCallSkipsPrompt() async {
+        let gate = UIToolApprovalGate(policy: .askOncePerSession)
+
+        let first = startApprove(gate, call(id: "c1"))
+        await waitForPending(gate)
+        gate.resolve(callId: "c1", with: .approved)
+        let firstDecision = await first.value
+        XCTAssertEqual(firstDecision, .approved)
+
+        // Second call must skip the queue entirely thanks to the latch.
+        // We await the result directly: with the latch set, approve() returns
+        // on the same scheduling turn without enqueueing. If the latch
+        // regresses the test hangs — which the CI watchdog surfaces as a
+        // failure rather than a passing run.
+        let secondResult = await gate.approve(call(id: "c2"))
+        XCTAssertEqual(secondResult, .approved)
+        XCTAssertTrue(gate.pending.isEmpty)
+    }
+
+    // MARK: - Session-reset boundary
+
+    func test_resetForNewSession_reopensPrompting() async {
+        let gate = UIToolApprovalGate(policy: .askOncePerSession)
+
+        let first = startApprove(gate, call(id: "c1"))
+        await waitForPending(gate)
+        gate.resolve(callId: "c1", with: .approved)
+        _ = await first.value
+
+        gate.resetForNewSession()
+
+        let second = startApprove(gate, call(id: "c2"))
+        await waitForPending(gate)
+        XCTAssertEqual(gate.pending.first?.id, "c2", "Reset must re-arm the queue")
+
+        gate.resolve(callId: "c2", with: .approved)
+        _ = await second.value
+    }
+
+    // MARK: - Policy: alwaysAsk
+
+    func test_alwaysAsk_queuesEveryCall() async {
+        let gate = UIToolApprovalGate(policy: .alwaysAsk)
+
+        let first = startApprove(gate, call(id: "c1"))
+        await waitForPending(gate)
+        gate.resolve(callId: "c1", with: .approved)
+        _ = await first.value
+
+        let second = startApprove(gate, call(id: "c2"))
+        await waitForPending(gate)
+        XCTAssertEqual(gate.pending.first?.id, "c2", "alwaysAsk must queue every call")
+        gate.resolve(callId: "c2", with: .approved)
+        _ = await second.value
+    }
+
+    // MARK: - Deny reason
+
+    func test_denyCarriesReason() async {
+        let gate = UIToolApprovalGate(policy: .alwaysAsk)
+
+        let task = startApprove(gate, call(id: "c1"))
+        await waitForPending(gate)
+        gate.resolve(callId: "c1", with: .denied(reason: "no"))
+        let result = await task.value
+        XCTAssertEqual(result, .denied(reason: "no"))
+    }
+
+    // MARK: - Observability
+
+    func test_pendingObservableChanges() async {
+        let gate = UIToolApprovalGate(policy: .alwaysAsk)
+        XCTAssertTrue(gate.pending.isEmpty)
+
+        let task = startApprove(gate, call(id: "obs-1"))
+        await waitForPending(gate)
+        XCTAssertEqual(gate.pending.count, 1)
+        XCTAssertEqual(gate.pending.first?.id, "obs-1")
+
+        gate.resolve(callId: "obs-1", with: .approved)
+        _ = await task.value
+        XCTAssertTrue(gate.pending.isEmpty, "Resolving must drain the queue")
+    }
+
+    // MARK: - Reset drains in-flight continuations
+
+    func test_resetForNewSession_deniesInFlightRequests() async {
+        let gate = UIToolApprovalGate(policy: .alwaysAsk)
+
+        let task = startApprove(gate, call(id: "leak"))
+        await waitForPending(gate)
+
+        gate.resetForNewSession()
+
+        let result = await task.value
+        // Reset must not leak the continuation. The task is resumed with a
+        // denial so the generation coordinator sees a structured failure
+        // rather than hanging forever.
+        guard case .denied = result else {
+            XCTFail("Reset should resume in-flight continuations with .denied")
+            return
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Plug the `MessagePartsView` tool-call hole with a real `ToolInvocationView` — four states (pendingApproval / running / completed / failed), accessibility identifiers on every interactive element, closure-based callbacks so the view stays dumb.
- Introduce `UIToolApprovalGate` — an `@Observable`, `@MainActor`-isolated `ToolApprovalGate` conformer that owns a pending-approval queue (`alwaysAsk` / `askOncePerSession` / `autoApprove` policies) with a session-reset boundary wired to `ChatViewModel.switchToSession`.
- Demo ships the flagship empty-state moment: one tap on "Summarize the README files in my workspace." drives thinking → sandboxed `sample_repo_search` tool → approval sheet → completed tool bubble → assistant synthesis.

## Stack context

PR 3 of 4. Closes #437. Depends on PR 1 (#652) and PR 2 (#657) — both already merged on `main`.

## What shipped

**Kit (`Sources/BaseChatUI`):**
- `Views/Chat/ToolInvocationView.swift` — public dumb view, four states, `tool-invocation-<state>-<toolName>` identifiers, SwiftUI previews per state.
- `ViewModels/UIToolApprovalGate.swift` — `@Observable` gate with continuation-backed queue, `resolve(callId:with:)`, `resetForNewSession()`, reason-carrying denial.
- `Views/Chat/MessagePartsView.swift` — pairs `.toolCall` / `.toolResult` parts by `ToolCall.id`; pending calls surface the approval-state render, paired calls render a completed/failed disclosure.
- `Views/Chat/ChatView.swift` — new optional `emptyState:` init overload so hosts can drop in a flagship prompt without forking the view.
- `ViewModels/ChatViewModel.swift` — `toolApprovalGate` property, `toolApprovalPolicy` accessor, init parameter; `switchToSession` forwards to `gate.resetForNewSession()`.
- `ViewModels/GenerationCoordinator.swift` — appends the emitted `.toolCall` part to the active assistant bubble so `MessagePartsView` can pair it with the later `.toolResult` (previously the call was silently dropped).

**Inference (`Sources/BaseChatInference`):**
- `Services/InferenceService.swift` — DEBUG-only init variant `init(backend:name:modelName:toolRegistry:toolApprovalGate:)` so `--uitesting` can inject a `ScriptedBackend` without losing tool dispatch.

**Demo (`Example/BaseChatDemo`):**
- `BaseChatDemoApp.swift` — installs a shared `UIToolApprovalGate` into both the `InferenceService` and the `ChatViewModel`; under `--uitesting` swaps in a `ScriptedBackend` emitting a canned `.toolCall` for `sample_repo_search`.
- `ChatEmptyStateView.swift` — flagship-prompt button (`flagship-prompt-button`). On tap sets `inputText` and calls `sendMessage()`.
- `ToolApprovalSheet.swift` — modal sheet observing `gate.pending.first`, with identified Approve / Deny buttons and an optional denial-reason field.
- `Settings/ToolPolicyView.swift` — picker bound to `ChatViewModel.toolApprovalPolicy`, surfaced from a sidebar button.
- `DemoContentView.swift` — wires empty-state override, approval sheet on `gate.pending`, and a sidebar row for the policy picker.

## Tests

- `Tests/BaseChatUITests/UIToolApprovalGateTests.swift` — 7 XCTests covering the policy matrix, session-reset boundary, deny-with-reason, pending-queue observability, and continuation cleanup on reset.
- `Tests/BaseChatUITests/ToolInvocationViewTests.swift` — 7 ViewInspector assertions over each visual state plus the paired-call identifier path.
- `Example/BaseChatDemoUITests/ToolApprovalUITests.swift` — two deterministic XCUITests (flagship-button visibility, sidebar policy button reachability). The original "tap Approve and assert completed bubble" test path fought simulator sheet-presentation timing under `.sheet(isPresented:)`; the deterministic XCTest-level coverage lives in the gate/view suites where `@Observable` state changes are observable directly. Worth revisiting with a macOS-only UITest scheme in a follow-up.

Sabotage verified on `test_askOncePerSession_secondCallSkipsPrompt` by commenting out the `hasApprovedThisSession = true` latch: the test then hangs (continuation leak rather than a deterministic failure with the simpler `await` pattern). Reverted after verification.

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 213 pass
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 994 pass
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits` — 69 pass
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 472 pass (+14 new)
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 135 pass
- [x] `swift test --filter BaseChatToolsTests --disable-default-traits` — 36 pass
- [x] `xcodebuild -scheme BaseChatDemo -destination 'platform=macOS' build` — succeeded
- [x] `scripts/example-ui-tests.sh build-for-testing && test-without-building -only-testing:BaseChatDemoUITests/ToolApprovalUITests` — succeeded
- [x] `git checkout Package.resolved` to undo `--disable-default-traits` drift before committing (#600)

## Release Note

Adds a first-class tool-invocation UI to `BaseChatUI` via `ToolInvocationView` — a public SwiftUI view that renders a `MessagePart.toolCall` / `.toolResult` across four visual states (pending approval, running, completed, failed) with accessibility identifiers and preview fixtures. `UIToolApprovalGate` lives alongside it as a drop-in `@Observable` `ToolApprovalGate` that hosts a pending-approval queue, supports three policies (`alwaysAsk`, `askOncePerSession`, `autoApprove`), and clears on `ChatViewModel.switchToSession`. The demo app ships the flagship empty-state moment: a curated prompt button drives thinking → sandboxed tool call → approval sheet → result in one tap. Closes #437.

```swift
let approvalGate = UIToolApprovalGate(policy: .askOncePerSession)
let inferenceService = InferenceService(
    toolRegistry: toolRegistry,
    toolApprovalGate: approvalGate
)
let chatViewModel = ChatViewModel(
    inferenceService: inferenceService,
    toolApprovalGate: approvalGate
)

// Drive the sheet from anywhere — the gate is @Observable:
.sheet(isPresented: .constant(chatViewModel.toolApprovalGate?.pending.first != nil)) {
    if let call = chatViewModel.toolApprovalGate?.pending.first {
        ToolInvocationView(
            part: .toolCall(call),
            state: .pendingApproval,
            onApprove: { chatViewModel.toolApprovalGate?.resolve(callId: call.id, with: .approved) },
            onDeny: { reason in chatViewModel.toolApprovalGate?.resolve(callId: call.id, with: .denied(reason: reason)) }
        )
    }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)