### PR TITLE
feat(inference): local-capability contract types for grammar, KV cache, and embeddings (#663)

### DIFF
--- a/Sources/BaseChatInference/Protocols/BackendCapabilities.swift
+++ b/Sources/BaseChatInference/Protocols/BackendCapabilities.swift
@@ -80,6 +80,16 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
     /// All remote backends must also reflect this in their `memoryStrategy`.
     public let isRemote: Bool
 
+    /// If true, the backend reuses KV cache state across consecutive `generate()` calls in the
+    /// same model-loaded session — defined as calls between `loadModel()`, `resetConversation()`,
+    /// and `unloadModel()`. Transparent to callers; enables Track D.
+    public let supportsKVCachePersistence: Bool
+
+    /// If true, the backend honors `GenerationConfig.grammar` via sampler-level GBNF constraint
+    /// and the caller can rely on grammar-valid output. Backends reporting `false` (default) MUST
+    /// throw `InferenceError.unsupportedGrammar(reason:)` when `config.grammar != nil`.
+    public let supportsGrammarConstrainedSampling: Bool
+
     /// Parameters the UI should present controls for.
     public var visibleParameters: [GenerationParameter] {
         GenerationParameter.allCases.filter { supportedParameters.contains($0) }
@@ -98,7 +108,9 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         memoryStrategy: MemoryStrategy = .resident,
         maxOutputTokens: Int = 4096,
         supportsStreaming: Bool = true,
-        isRemote: Bool = false
+        isRemote: Bool = false,
+        supportsKVCachePersistence: Bool = false,
+        supportsGrammarConstrainedSampling: Bool = false
     ) {
         self.supportedParameters = supportedParameters
         self.maxContextTokens = maxContextTokens
@@ -113,6 +125,8 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         self.maxOutputTokens = maxOutputTokens
         self.supportsStreaming = supportsStreaming
         self.isRemote = isRemote
+        self.supportsKVCachePersistence = supportsKVCachePersistence
+        self.supportsGrammarConstrainedSampling = supportsGrammarConstrainedSampling
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -129,6 +143,8 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         case supportsTokenCounting
         case memoryStrategy
         case isRemote
+        case supportsKVCachePersistence
+        case supportsGrammarConstrainedSampling
     }
 
     public init(from decoder: Decoder) throws {
@@ -146,6 +162,8 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         supportsTokenCounting = try c.decode(Bool.self, forKey: .supportsTokenCounting)
         memoryStrategy = try c.decode(MemoryStrategy.self, forKey: .memoryStrategy)
         isRemote = try c.decode(Bool.self, forKey: .isRemote)
+        supportsKVCachePersistence = (try c.decodeIfPresent(Bool.self, forKey: .supportsKVCachePersistence)) ?? false
+        supportsGrammarConstrainedSampling = (try c.decodeIfPresent(Bool.self, forKey: .supportsGrammarConstrainedSampling)) ?? false
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -163,5 +181,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         try c.encode(supportsTokenCounting, forKey: .supportsTokenCounting)
         try c.encode(memoryStrategy, forKey: .memoryStrategy)
         try c.encode(isRemote, forKey: .isRemote)
+        try c.encode(supportsKVCachePersistence, forKey: .supportsKVCachePersistence)
+        try c.encode(supportsGrammarConstrainedSampling, forKey: .supportsGrammarConstrainedSampling)
     }
 }

--- a/Sources/BaseChatInference/Protocols/EmbeddingBackend.swift
+++ b/Sources/BaseChatInference/Protocols/EmbeddingBackend.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public protocol EmbeddingBackend: AnyObject, Sendable {
+    var isModelLoaded: Bool { get }
+    var dimensions: Int { get }
+    func loadModel(from url: URL) async throws
+    func embed(_ texts: [String]) async throws -> [[Float]]
+    func unloadModel()
+}
+
+public enum EmbeddingError: LocalizedError {
+    case modelNotLoaded
+    case dimensionMismatch(expected: Int, actual: Int)
+    case encodingFailed(underlying: Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .modelNotLoaded:
+            return "Embedding model is not loaded."
+        case .dimensionMismatch(let expected, let actual):
+            return "Dimension mismatch: expected \(expected), got \(actual)."
+        case .encodingFailed(let underlying):
+            return "Text encoding failed: \(underlying.localizedDescription)"
+        }
+    }
+}

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -59,6 +59,15 @@ public struct GenerationConfig: Sendable, Codable {
     /// have not implemented JSON-mode wiring yet, silently ignore this flag.
     public var jsonMode: Bool
 
+    /// Raw GBNF grammar string to constrain sampling.
+    ///
+    /// Honored by backends reporting `BackendCapabilities.supportsGrammarConstrainedSampling == true`.
+    /// Backends that see a non-nil grammar but do not support grammar sampling MUST throw
+    /// `InferenceError.unsupportedGrammar(reason:)` rather than silently ignore — silent fallback
+    /// would turn a guaranteed-valid expectation into an unchecked one.
+    /// Defaults to `nil` (no grammar constraint).
+    public var grammar: String?
+
     /// Thinking markers for this request's model/template, or nil if the model does not emit
     /// reasoning blocks. Set by the caller when the selected `PromptTemplate` has
     /// `thinkingMarkers != nil`. Backends use this to activate `ThinkingParser`; backends that
@@ -80,7 +89,7 @@ public struct GenerationConfig: Sendable, Codable {
         didSet { if maxToolIterations < 1 { maxToolIterations = 1 } }
     }
 
-    @available(*, deprecated, message: "Use init(temperature:topP:repeatPenalty:topK:typicalP:maxOutputTokens:tools:toolChoice:maxThinkingTokens:jsonMode:thinkingMarkers:maxToolIterations:) instead.")
+    @available(*, deprecated, message: "Use init(temperature:topP:repeatPenalty:topK:typicalP:maxOutputTokens:tools:toolChoice:maxThinkingTokens:jsonMode:thinkingMarkers:maxToolIterations:grammar:) instead.")
     public init(
         temperature: Float = 0.7,
         topP: Float = 0.9,
@@ -94,7 +103,8 @@ public struct GenerationConfig: Sendable, Codable {
         maxThinkingTokens: Int? = nil,
         jsonMode: Bool = false,
         thinkingMarkers: ThinkingMarkers? = nil,
-        maxToolIterations: Int = 10
+        maxToolIterations: Int = 10,
+        grammar: String? = nil
     ) {
         self.temperature = temperature
         self.topP = topP
@@ -109,6 +119,7 @@ public struct GenerationConfig: Sendable, Codable {
         self.jsonMode = jsonMode
         self.thinkingMarkers = thinkingMarkers
         self.maxToolIterations = max(1, maxToolIterations)
+        self.grammar = grammar
     }
 
     public init(
@@ -123,7 +134,8 @@ public struct GenerationConfig: Sendable, Codable {
         maxThinkingTokens: Int? = nil,
         jsonMode: Bool = false,
         thinkingMarkers: ThinkingMarkers? = nil,
-        maxToolIterations: Int = 10
+        maxToolIterations: Int = 10,
+        grammar: String? = nil
     ) {
         self.temperature = temperature
         self.topP = topP
@@ -138,13 +150,14 @@ public struct GenerationConfig: Sendable, Codable {
         self.jsonMode = jsonMode
         self.thinkingMarkers = thinkingMarkers
         self.maxToolIterations = max(1, maxToolIterations)
+        self.grammar = grammar
     }
 
     // MARK: Codable
 
     private enum CodingKeys: String, CodingKey {
         case temperature, topP, repeatPenalty, maxTokens, topK, typicalP, maxOutputTokens
-        case tools, toolChoice, maxThinkingTokens, jsonMode, maxToolIterations
+        case tools, toolChoice, maxThinkingTokens, jsonMode, maxToolIterations, grammar
     }
 
     public init(from decoder: Decoder) throws {
@@ -168,6 +181,7 @@ public struct GenerationConfig: Sendable, Codable {
         maxToolIterations = max(1, decodedIterations)
         // thinkingMarkers is a per-request runtime hint; it is not persisted.
         thinkingMarkers = nil
+        grammar = try c.decodeIfPresent(String.self, forKey: .grammar)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -184,6 +198,7 @@ public struct GenerationConfig: Sendable, Codable {
         try c.encodeIfPresent(maxThinkingTokens, forKey: .maxThinkingTokens)
         try c.encode(jsonMode, forKey: .jsonMode)
         try c.encode(maxToolIterations, forKey: .maxToolIterations)
+        try c.encodeIfPresent(grammar, forKey: .grammar)
     }
 }
 
@@ -236,6 +251,13 @@ public protocol InferenceBackend: AnyObject, Sendable {
 
     /// Generates a response from a prompt, streaming events as they are produced.
     /// Errors during generation are thrown into the stream.
+    ///
+    /// **KV cache reuse semantics.** KV state MAY be reused across consecutive `generate()` calls
+    /// in the same model-loaded session — defined as calls between `loadModel()`,
+    /// `resetConversation()`, and `unloadModel()`. Callers do not pass a session ID; sessionhood
+    /// is implicit in "no intervening reset." Backends reporting
+    /// `BackendCapabilities.supportsKVCachePersistence: true` MUST honor this semantic; backends
+    /// reporting `false` (default) MUST clear KV per call (current behavior).
     func generate(
         prompt: String,
         systemPrompt: String?,

--- a/Sources/BaseChatInference/Services/InferenceError.swift
+++ b/Sources/BaseChatInference/Services/InferenceError.swift
@@ -21,6 +21,9 @@ public enum InferenceError: LocalizedError {
     /// string read from the model (`model_type` in MLX config.json, `general.architecture`
     /// in a GGUF header, etc.) so UI can display it.
     case unsupportedModelArchitecture(String)
+    /// Thrown by backends when `config.grammar != nil` but the backend does not support
+    /// grammar-constrained sampling. `isRetryable` is `false`.
+    case unsupportedGrammar(reason: String)
 
     public var errorDescription: String? {
         switch self {
@@ -42,6 +45,8 @@ public enum InferenceError: LocalizedError {
             return "Prompt (\(promptTokens) tokens) plus requested output (\(maxOutputTokens) tokens) exceeds context window (\(contextSize) tokens)."
         case .unsupportedModelArchitecture(let arch):
             return "Unsupported model architecture: \(arch). This backend only supports chat/instruct language models."
+        case .unsupportedGrammar(let reason):
+            return "Grammar-constrained sampling not supported: \(reason)"
         }
     }
 
@@ -56,7 +61,7 @@ public enum InferenceError: LocalizedError {
             return true
         case .modelNotFound, .modelLoadFailed, .inferenceFailure,
              .memoryInsufficient, .generationError, .contextExhausted,
-             .unsupportedModelArchitecture:
+             .unsupportedModelArchitecture, .unsupportedGrammar:
             return false
         }
     }

--- a/Tests/BaseChatInferenceTests/BackendCapabilitiesContractTests.swift
+++ b/Tests/BaseChatInferenceTests/BackendCapabilitiesContractTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import BaseChatInference
+
+/// Contract tests for new `BackendCapabilities` flags introduced in #663.
+final class BackendCapabilitiesContractTests: XCTestCase {
+
+    // MARK: - supportsKVCachePersistence defaults to false
+
+    func test_supportsKVCachePersistence_defaultsFalse() {
+        let caps = BackendCapabilities()
+        XCTAssertFalse(caps.supportsKVCachePersistence)
+    }
+
+    // MARK: - supportsGrammarConstrainedSampling defaults to false
+
+    func test_supportsGrammarConstrainedSampling_defaultsFalse() {
+        let caps = BackendCapabilities()
+        XCTAssertFalse(caps.supportsGrammarConstrainedSampling)
+    }
+
+    // MARK: - Codable forward-compat: old JSON missing new keys defaults both to false
+
+    func test_codable_forwardCompat_missingNewKeys_defaultsToFalse() throws {
+        // This is the minimal valid BackendCapabilities payload from before #663.
+        let json = """
+        {
+            "supportedParameters": ["temperature"],
+            "maxContextTokens": 4096,
+            "maxOutputTokens": 2048,
+            "requiresPromptTemplate": false,
+            "supportsSystemPrompt": true,
+            "supportsStreaming": true,
+            "supportsToolCalling": false,
+            "supportsStructuredOutput": false,
+            "supportsNativeJSONMode": false,
+            "cancellationStyle": "cooperative",
+            "supportsTokenCounting": false,
+            "memoryStrategy": "resident",
+            "isRemote": false
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(BackendCapabilities.self, from: json)
+
+        XCTAssertFalse(decoded.supportsKVCachePersistence,
+                       "supportsKVCachePersistence must default to false for old payloads")
+        XCTAssertFalse(decoded.supportsGrammarConstrainedSampling,
+                       "supportsGrammarConstrainedSampling must default to false for old payloads")
+    }
+
+    // MARK: - Full round-trip with new flags set to true
+
+    func test_codable_roundTrip_newFlagsTrue() throws {
+        let caps = BackendCapabilities(
+            supportsKVCachePersistence: true,
+            supportsGrammarConstrainedSampling: true
+        )
+
+        let data = try JSONEncoder().encode(caps)
+        let decoded = try JSONDecoder().decode(BackendCapabilities.self, from: data)
+
+        XCTAssertTrue(decoded.supportsKVCachePersistence)
+        XCTAssertTrue(decoded.supportsGrammarConstrainedSampling)
+    }
+}

--- a/Tests/BaseChatInferenceTests/EmbeddingBackendProtocolTests.swift
+++ b/Tests/BaseChatInferenceTests/EmbeddingBackendProtocolTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import BaseChatInference
+
+// MARK: - Mock
+
+/// Inline mock conforming to `EmbeddingBackend` for protocol contract tests.
+private final class MockEmbeddingBackend: EmbeddingBackend, @unchecked Sendable {
+    var isModelLoaded: Bool = false
+    var dimensions: Int = 384
+
+    func loadModel(from url: URL) async throws {
+        isModelLoaded = true
+    }
+
+    func embed(_ texts: [String]) async throws -> [[Float]] {
+        guard isModelLoaded else { throw EmbeddingError.modelNotLoaded }
+        // Return a stub vector of the declared dimension for each input text.
+        return texts.map { _ in [Float](repeating: 0.1, count: dimensions) }
+    }
+
+    func unloadModel() {
+        isModelLoaded = false
+    }
+}
+
+// MARK: - Tests
+
+final class EmbeddingBackendProtocolTests: XCTestCase {
+
+    // MARK: - Protocol conformance / embed stub
+
+    func test_embed_returnsExpectedStubValue() async throws {
+        let backend = MockEmbeddingBackend()
+        try await backend.loadModel(from: URL(string: "file:///mock-embed")!)
+
+        let result = try await backend.embed(["hello"])
+
+        XCTAssertEqual(result.count, 1, "One input text should yield one embedding vector")
+        XCTAssertEqual(result[0].count, backend.dimensions,
+                       "Vector length must match the declared dimensions")
+        XCTAssertEqual(result[0].first ?? 0, 0.1, accuracy: 0.001)
+    }
+
+    func test_embed_multipleTexts_returnsMatchingCount() async throws {
+        let backend = MockEmbeddingBackend()
+        try await backend.loadModel(from: URL(string: "file:///mock-embed")!)
+
+        let texts = ["hello", "world", "foo"]
+        let result = try await backend.embed(texts)
+
+        XCTAssertEqual(result.count, texts.count)
+    }
+
+    // MARK: - EmbeddingError descriptions
+
+    func test_embeddingError_modelNotLoaded_hasNonNilDescription() {
+        let error = EmbeddingError.modelNotLoaded
+        XCTAssertNotNil(error.errorDescription)
+        XCTAssertFalse(error.errorDescription!.isEmpty)
+    }
+
+    func test_embeddingError_dimensionMismatch_hasNonNilDescription() {
+        let error = EmbeddingError.dimensionMismatch(expected: 384, actual: 512)
+        let desc = error.errorDescription
+        XCTAssertNotNil(desc)
+        XCTAssertTrue(desc!.contains("384"), "Should mention expected dimension")
+        XCTAssertTrue(desc!.contains("512"), "Should mention actual dimension")
+    }
+
+    func test_embeddingError_encodingFailed_hasNonNilDescription() {
+        let underlying = NSError(domain: "test", code: 42,
+                                 userInfo: [NSLocalizedDescriptionKey: "bad encoding"])
+        let error = EmbeddingError.encodingFailed(underlying: underlying)
+        let desc = error.errorDescription
+        XCTAssertNotNil(desc)
+        XCTAssertFalse(desc!.isEmpty)
+    }
+}

--- a/Tests/BaseChatInferenceTests/GenerationConfigGrammarTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationConfigGrammarTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import BaseChatInference
+
+/// Tests for `GenerationConfig.grammar` introduced in #663.
+final class GenerationConfigGrammarTests: XCTestCase {
+
+    // MARK: - Default
+
+    func test_grammar_defaultsToNil() {
+        let config = GenerationConfig()
+        XCTAssertNil(config.grammar)
+    }
+
+    // MARK: - Mutable
+
+    func test_grammar_isMutable() {
+        var config = GenerationConfig()
+        config.grammar = #"root ::= "hello" | "world""#
+        XCTAssertEqual(config.grammar, #"root ::= "hello" | "world""#)
+    }
+
+    // MARK: - Codable round-trip with grammar set
+
+    func test_codable_roundTrip_withGrammar() throws {
+        var config = GenerationConfig()
+        config.grammar = #"root ::= [a-z]+"#
+
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: data)
+
+        XCTAssertEqual(decoded.grammar, #"root ::= [a-z]+"#)
+    }
+
+    // MARK: - Codable backward-compat: absent grammar decodes as nil
+
+    func test_codable_roundTrip_withoutGrammar_decodesNil() throws {
+        // Encode a config without grammar (nil by default).
+        let config = GenerationConfig()
+        let data = try JSONEncoder().encode(config)
+
+        // Confirm the JSON does not contain the grammar key at all.
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertNil(json["grammar"], "grammar key should be absent when nil")
+
+        // Decode and assert nil.
+        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: data)
+        XCTAssertNil(decoded.grammar)
+    }
+}

--- a/Tests/BaseChatInferenceTests/InferenceErrorUnsupportedGrammarTests.swift
+++ b/Tests/BaseChatInferenceTests/InferenceErrorUnsupportedGrammarTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import BaseChatInference
+
+/// Tests for `InferenceError.unsupportedGrammar(reason:)` introduced in #663.
+final class InferenceErrorUnsupportedGrammarTests: XCTestCase {
+
+    // MARK: - errorDescription
+
+    func test_unsupportedGrammar_errorDescription_isNonNil() {
+        let error = InferenceError.unsupportedGrammar(reason: "GBNF sampling not implemented")
+        XCTAssertNotNil(error.errorDescription)
+    }
+
+    func test_unsupportedGrammar_errorDescription_containsReason() {
+        let reason = "GBNF sampling not implemented"
+        let error = InferenceError.unsupportedGrammar(reason: reason)
+        let desc = error.errorDescription!
+        XCTAssertTrue(desc.contains(reason),
+                      "errorDescription should include the reason string")
+    }
+
+    // MARK: - isRetryable
+
+    func test_unsupportedGrammar_isNotRetryable() {
+        let error = InferenceError.unsupportedGrammar(reason: "not supported")
+        XCTAssertFalse(error.isRetryable)
+    }
+}


### PR DESCRIPTION
Closes #663

## Summary

Types, flags, and doc comments only — zero behavior change at runtime.

- `GenerationConfig.grammar: String?` — GBNF grammar hint; Codable with nil default; backward-compat (absent key decodes as nil)
- `BackendCapabilities.supportsKVCachePersistence: Bool` — signals that the backend reuses KV state across consecutive `generate()` calls in a model-loaded session; default `false`
- `BackendCapabilities.supportsGrammarConstrainedSampling: Bool` — signals sampler-level GBNF support; default `false`
- `InferenceError.unsupportedGrammar(reason:)` — thrown when `config.grammar != nil` but the backend does not support grammar sampling; `isRetryable == false`
- `EmbeddingBackend` protocol + `EmbeddingError` enum (new file `Sources/BaseChatInference/Protocols/EmbeddingBackend.swift`)
- KV cache reuse semantics doc block appended to `InferenceBackend.generate(...)`

## Deviations from issue spec

1. **No `modelFingerprint: String` on `EmbeddingBackend`** — computing SHA-256 of a multi-GB model file synchronously at load time would block the caller for several seconds. Omitted; can be added as a lazy/async property in a follow-up if needed.
2. **No `GenerationEvent.kvCacheReuse` event** — adding a case to `GenerationEvent` requires updating 20+ exhaustive switches across the codebase. That belongs in the Track D implementation PR, not a contract-types-only PR.
3. **New `supportsGrammarConstrainedSampling` flag instead of repurposing `supportsStructuredOutput`** — OpenAI and Claude already report `supportsStructuredOutput: true` for JSON schema output, not GBNF. Conflating the two would create a semantic collision where cloud backends appear to support grammar sampling. A dedicated flag avoids the ambiguity with no migration cost (both default to `false`).

## Test plan

- [ ] `GenerationConfigGrammarTests` — grammar defaults nil, is mutable, Codable round-trip with and without grammar
- [ ] `BackendCapabilitiesContractTests` — new flags default false, old JSON payload missing new keys decodes with both false
- [ ] `InferenceErrorUnsupportedGrammarTests` — `unsupportedGrammar` has non-nil `errorDescription`, `isRetryable == false`
- [ ] `EmbeddingBackendProtocolTests` — inline `MockEmbeddingBackend` conformance, `embed(["hello"])` returns correct stub, `EmbeddingError.dimensionMismatch` has non-nil description
- [ ] `MockInferenceBackend` — no changes needed; all new `BackendCapabilities.init` parameters have defaults

CI suites verified locally:
```
swift test --filter BaseChatInferenceTests --disable-default-traits   # all pass
swift test --filter BaseChatBackendsTests --disable-default-traits    # all pass
```

## Release Note

### New local-capability contract types for grammar sampling, KV cache, and embeddings

Before this release, callers had no way to express GBNF grammar constraints, signal KV cache reuse support, or program against a common embedding backend interface. Three new primitives close those gaps without changing any runtime behavior — backends and callers can opt in incrementally.

```swift
// Grammar-constrained generation (honored by backends where supportsGrammarConstrainedSampling == true)
var config = GenerationConfig()
config.grammar = #"root ::= [a-z]+"#

// Check capabilities before using grammar
if backend.capabilities.supportsGrammarConstrainedSampling {
    let stream = try backend.generate(prompt: prompt, systemPrompt: nil, config: config)
} else {
    // backend will throw InferenceError.unsupportedGrammar(reason:)
}

// KV cache persistence flag (Track D opt-in)
let persistsKV = backend.capabilities.supportsKVCachePersistence

// Embedding backend protocol
final class MyEmbedder: EmbeddingBackend {
    var isModelLoaded: Bool = false
    var dimensions: Int = 384
    func loadModel(from url: URL) async throws { ... }
    func embed(_ texts: [String]) async throws -> [[Float]] { ... }
    func unloadModel() { ... }
}
```

All new fields default to `false`/`nil`, so existing serialized `BackendCapabilities` payloads decode correctly without a migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)