### PR TITLE
refactor(inference): consolidate DEBUG InferenceService inits

### DIFF
--- a/Sources/BaseChatInference/Services/InferenceService.swift
+++ b/Sources/BaseChatInference/Services/InferenceService.swift
@@ -325,21 +325,22 @@ public final class InferenceService {
     }
 
     #if DEBUG
-    public init(backend: any InferenceBackend, name: String = "Mock", modelName: String? = nil) {
-        self.lifecycle = ModelLifecycleCoordinator(backend: backend, name: name, modelName: modelName)
-        self.generation = GenerationCoordinator()
-        generation.provider = self
-    }
-
-    /// Debug-only init that pre-loads a backend alongside a ``ToolRegistry``
-    /// and ``ToolApprovalGate``. Used by ``--uitesting`` launches in the
-    /// example app so the approval sheet can be exercised deterministically
-    /// against a ``ScriptedBackend``.
+    /// Debug-only init that pre-loads a backend, optionally alongside a
+    /// ``ToolRegistry`` and ``ToolApprovalGate``. Used by tests to drive a
+    /// mock backend, and by ``--uitesting`` launches in the example app so
+    /// the approval sheet can be exercised deterministically against a
+    /// ``ScriptedBackend``.
+    ///
+    /// When `toolRegistry` is `nil` (the default) the generation coordinator
+    /// is constructed without tool-calling wired in — matching the behaviour
+    /// every existing test suite relies on. Pass a non-nil registry to
+    /// enable tool dispatch; `toolApprovalGate` then gates each call and
+    /// defaults to ``AutoApproveGate`` so legacy callers see no change.
     public init(
         backend: any InferenceBackend,
         name: String = "Mock",
         modelName: String? = nil,
-        toolRegistry: ToolRegistry,
+        toolRegistry: ToolRegistry? = nil,
         toolApprovalGate: any ToolApprovalGate = AutoApproveGate()
     ) {
         self.lifecycle = ModelLifecycleCoordinator(backend: backend, name: name, modelName: modelName)

--- a/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
+++ b/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
@@ -45,6 +45,7 @@ final class SilentCatchAuditTest: XCTestCase {
         "BaseChatInference/Services/GenerationCoordinator.swift:let toolRegistry: ToolRegistry?",
         "BaseChatInference/Services/GenerationCoordinator.swift:toolRegistry: ToolRegistry? = nil,",
         "BaseChatInference/Services/InferenceService.swift:public var toolRegistry: ToolRegistry? {",
+        "BaseChatInference/Services/InferenceService.swift:toolRegistry: ToolRegistry? = nil,",
         // JSONSchemaValue uses the standard "try-each-type-in-order" decoder pattern for
         // heterogeneous JSON. Each `try?` is bound to a named constant and the result is
         // used immediately; there is no silent discard — the next branch handles the miss.


### PR DESCRIPTION
## Summary

Consolidates the two `#if DEBUG` initializers on `InferenceService` into a single signature. A reviewer on #662 flagged that the second init's parameters (`toolRegistry`, `toolApprovalGate`) can default-nil on the first — no reason to carry two overloads.

The consolidated init:

```swift
public init(
    backend: any InferenceBackend,
    name: String = "Mock",
    modelName: String? = nil,
    toolRegistry: ToolRegistry? = nil,
    toolApprovalGate: any ToolApprovalGate = AutoApproveGate()
)
```

`GenerationCoordinator.init` already accepts `toolRegistry: ToolRegistry? = nil` with an `AutoApproveGate()` default, so both code paths converge on the same coordinator construction — no branch is needed in `InferenceService`. Legacy callers (`InferenceService(backend:name:modelName:)`) continue to compile and behave identically.

## Stack context

Follow-up to #662 (ToolInvocationView + UIToolApprovalGate). Task #5 in the tool-approval follow-up list.

## What changed

- `Sources/BaseChatInference/Services/InferenceService.swift` — two DEBUG inits collapse into one; doc comment rewritten to cover both use cases.
- `Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift` — allowlist the new `toolRegistry: ToolRegistry? = nil,` line. The audit's substring scan matches `try?` inside `ToolRegistry?`; the same false positive is already allowlisted for `GenerationCoordinator.swift` and the `toolRegistry` getter.

## Test plan

- [x] `swift build` clean
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits`
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` (998 tests, 0 failures)
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits` (69 tests)
- [x] `swift test --filter BaseChatUITests --disable-default-traits`
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` (136 tests)
- [x] `swift test --filter BaseChatToolsTests --disable-default-traits` (36 tests)
- [x] `xcodebuild -project Example/BaseChatDemo.xcodeproj -scheme BaseChatDemo -destination 'platform=macOS' -configuration Debug build` — BUILD SUCCEEDED
- [x] Grepped all `InferenceService(backend:` call sites (~70 across `Tests/` + `Sources/BaseChatFuzz`); every caller uses the three-parameter form that's now the default-nil leading prefix — zero source changes required.

## Release note

No behaviour change. The two `#if DEBUG` initializers on `InferenceService` introduced in v0.11.2 collapse into a single signature with `toolRegistry` and `toolApprovalGate` defaulting to `nil` / `AutoApproveGate()` respectively. Legacy tests that call `InferenceService(backend:name:modelName:)` continue to compile and behave identically; UI-testing call sites that pass a registry + gate are likewise unaffected.

## Known CI noise

Main's CI currently fails `resolve-check` + `fuzz` with `Swift tools version 6.3.0 but the installed version is 6.2.4` (pre-existing `cb97d24`). This PR inherits the same failures — unrelated to the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)