### PR TITLE
fix(ci): revert swift-tools-version to 6.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.1
 
 import PackageDescription
 


### PR DESCRIPTION
## Summary

- Reverts `swift-tools-version` from `6.3` → `6.1` in `Package.swift`

## Root cause

`cb97d24` bumped the tools version to 6.3 when fixing Swift 6.3 source-level warnings (`#file`→`#filePath`, `var`→`let`). Those fixes are valid and don't require a higher tools version — but the bump itself broke CI: Xcode 26.3 ships Swift **6.2.4**, not 6.3. No released Xcode carries a 6.3 toolchain yet.

Result: every branch rebased on main (including #665) fails `resolve-check` and `fuzz` with:

```
error: 'basechatkit': package 'basechatkit' is using Swift tools version 6.3.0
but the installed version is 6.2.4
```

The `setup-xcode@v1` step successfully selects Xcode 26.3.0 (build 17C529), but the Swift toolchain bundled with it is 6.2.4.

## Why 6.1 is safe

Nothing in `Package.swift` uses 6.3-specific `PackageDescription` APIs. All features in use — `swiftLanguageModes: [.v6]`, `.trait()`, `.when(traits:)` conditionals — are available from 6.0/6.1. The strict transitive-dependency enforcement noted in the `mlx-swift-lm` comment is a Swift toolchain behaviour, not a tools-version gate.

## Test plan

- [x] `swift package resolve` — clean
- [x] `swift build --build-tests --disable-default-traits` — Build complete (379 targets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)