### PR TITLE
ci: fold resolve-check, drop .build/debug cache, merge XCTest filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,26 +25,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  resolve-check:
-    runs-on: macos-15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "26.3"
-
-      - name: Verify Package.resolved is up to date
-        run: |
-          swift package resolve
-          git diff --exit-code Package.resolved || \
-            (echo "Package.resolved is stale — run 'swift package resolve' and commit the result." && exit 1)
-
   test:
     runs-on: macos-15  # Apple Silicon (arm64) standard runner to reduce spend
-    needs: [resolve-check]
 
     steps:
       - name: Checkout
@@ -61,15 +43,30 @@ jobs:
       - name: Cache SwiftPM build
         uses: actions/cache@v5
         with:
+          # .build/debug is intentionally excluded: SwiftPM module fingerprints
+          # embed absolute paths + compiler timestamps, so restored object files
+          # are invalidated on every fresh ephemeral runner. Caching .build/debug
+          # produced 0 incremental-build savings in practice and wasted the 10 GB
+          # per-repo cache quota. .build/artifacts holds the prebuilt llama.cpp
+          # xcframework (~100 MB, the real win); .build/checkouts + repositories
+          # save the per-dep clone phase.
           path: |
             .build/artifacts
             .build/checkouts
             .build/repositories
-            .build/debug
           key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
             ${{ runner.os }}-${{ runner.arch }}-spm-
+
+      - name: Verify Package.resolved is up to date
+        # Was a separate `resolve-check` job on its own macos-15 runner; folding
+        # it into `test` removes one 10×-billed runner per PR and eliminates the
+        # second queue wait that `needs: [resolve-check]` imposed.
+        run: |
+          swift package resolve
+          git diff --exit-code Package.resolved || \
+            (echo "Package.resolved is stale — run 'swift package resolve' and commit the result." && exit 1)
 
       # CI smoke profile (GitHub macOS Apple Silicon runners):
       # - Runs BaseChatCoreTests + BaseChatInferenceTests + BaseChatInferenceSwiftTestingTests
@@ -84,20 +81,20 @@ jobs:
       #   Apple Silicon for MLX/llama.cpp paths.
       # - Run `swift test --filter BaseChatE2ETests` on physical hardware.
 
+      # --skip-update: the Verify step above already ran `swift package resolve`,
+      # so the dependency graph is up to date. Without this flag, every `swift
+      # build`/`swift test` invocation re-contacts every git remote (~10-15s).
       - name: Build
-        run: swift build --build-tests --disable-default-traits
+        run: swift build --build-tests --disable-default-traits --skip-update
 
-      - name: Test — Core
-        run: scripts/test.sh --filter BaseChatCoreTests --disable-default-traits
+      # Core + UI + Backends share a process. Inference is split across two
+      # invocations because mixing its XCTest + Swift Testing suites in one
+      # process triggers a libmalloc SIGABRT (see BaseChatInferenceSwiftTestingTests).
+      - name: Test — Core + UI + Backends
+        run: scripts/test.sh --filter BaseChatCoreTests --filter BaseChatUITests --filter BaseChatBackendsTests --disable-default-traits --skip-update
 
       - name: Test — Inference (XCTest)
-        run: scripts/test.sh --filter BaseChatInferenceTests --disable-default-traits
+        run: scripts/test.sh --filter BaseChatInferenceTests --disable-default-traits --skip-update
 
       - name: Test — Inference (Swift Testing)
-        run: scripts/test.sh --filter BaseChatInferenceSwiftTestingTests --disable-default-traits
-
-      - name: Test — UI
-        run: scripts/test.sh --filter BaseChatUITests --disable-default-traits
-
-      - name: Test — Backends
-        run: scripts/test.sh --filter BaseChatBackendsTests --disable-default-traits
+        run: scripts/test.sh --filter BaseChatInferenceSwiftTestingTests --disable-default-traits --skip-update


### PR DESCRIPTION
## Summary

CI profiling showed the median successful run is ~5 min with two 10×-billed macos-15 runners per PR and ~25s of purely redundant overhead inside the test job. This PR targets the overhead without changing coverage.

**Expected median:** ~5 min → ~2:45, with one fewer macOS runner per PR.

## Changes

- **Fold `resolve-check` into `test`.** The separate job ran on its own macos-15 runner (10× billing) and forced `test` to wait for a *second* runner via `needs: [resolve-check]` — that sequential queue wait often added 2-5 minutes on top of its own ~90s run. The verify step is now one `run:` before Build.
- **Drop `.build/debug` from the SwiftPM cache.** A recent run (`24885140938`) had a primary cache hit yet still compiled all 1078 files from scratch in 109s. SwiftPM module fingerprints embed absolute paths / compiler timestamps that don't survive ephemeral runners, so `.build/debug` contributed **zero** incremental savings while consuming the 10 GB repo cache quota. Kept `.build/artifacts` (prebuilt llama.cpp xcframework — the real win) and `.build/checkouts`/`repositories`.
- **Pass `--skip-update` to Build + all test invocations.** The verify step is now the single authoritative `swift package resolve`; previously every Build/test step re-fetched every git remote for ~10-15s each.
- **Merge Core + UI + Backends into one `swift test` invocation.** Each `--filter` invocation costs ~5s of build-graph recheck. The Swift Testing SIGABRT caveat only applies to `BaseChatInference`, so its XCTest and Swift Testing filters stay split.

## Skipped for a follow-up

After seeing real timing numbers, consider:
- `--parallel` on the Inference-XCTest step (1016 cases currently serial; likely drops that step ~10-12s).
- Tune `ConcurrencyTests.test_sendWhileGenerating_secondSendProceeds` + `test_regenerateWhileGenerating_isGuarded` — 6.7s combined from `slowBackend.delayPerToken = .milliseconds(50) × 20 tokens`; 5 tokens would preserve coverage.

## Test plan

- [ ] CI green on this PR
- [ ] Median run duration drops ~2 min vs `main`
- [ ] `Verify Package.resolved is up to date` catches a deliberately stale Package.resolved (verified locally: running `swift test --disable-default-traits` without the guard rewrote Package.resolved to drop MLX/Llama pins, which the verify step would have rejected)
- [ ] Merged Core+UI+Backends filter runs all 912 XCTest + 136 Swift Testing cases — verified locally, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)