### PR TITLE
feat(inference): add ThinkingMarkers presets and forModel(named:) lookup

### DIFF
--- a/Sources/BaseChatInference/Models/ThinkingMarkers.swift
+++ b/Sources/BaseChatInference/Models/ThinkingMarkers.swift
@@ -10,11 +10,57 @@ public struct ThinkingMarkers: Sendable, Equatable {
         self.close = close
     }
 
-    /// Qwen3 and DeepSeek-R1 inline thinking tags.
+    /// Qwen3, DeepSeek-R1 (and distillations), and QwQ inline thinking tags.
     public static let qwen3 = ThinkingMarkers(open: "<think>", close: "</think>")
+
+    /// Mistral Small 3.1 reasoning fine-tunes and Sky-T1 models, which emit
+    /// `<thinking>` / `</thinking>` instead of the Qwen-style `<think>` pair.
+    public static let mistralReasoning = ThinkingMarkers(open: "<thinking>", close: "</thinking>")
+
+    /// phi4-reasoning and some older Reflection variants that wrap their
+    /// chain-of-thought in `<reasoning>` / `</reasoning>`.
+    public static let phi4 = ThinkingMarkers(open: "<reasoning>", close: "</reasoning>")
+
+    /// Reflection-Llama 3.1 (and derivatives), which emits self-critique in
+    /// `<reflection>` / `</reflection>` blocks distinct from its `<thinking>` pass.
+    public static let reflection = ThinkingMarkers(open: "<reflection>", close: "</reflection>")
 
     /// Extensibility hook for custom model formats.
     public static func custom(open: String, close: String) -> ThinkingMarkers {
         ThinkingMarkers(open: open, close: close)
+    }
+
+    /// Returns the most-specific preset for a given model name via case-insensitive
+    /// substring match, or `nil` if no known family matches.
+    ///
+    /// Match precedence (most specific first):
+    /// - `reflection-llama` → `.reflection`
+    /// - `phi4` / `phi-4` → `.phi4`
+    /// - `qwen` / `deepseek` / `qwq` → `.qwen3`
+    /// - `mistral` / `sky-t1` → `.mistralReasoning`
+    ///
+    /// Generic `phi` matches fall through to `.phi4` only when no more-specific
+    /// family (e.g. `reflection-llama`) is present in the name. Unknown models
+    /// return `nil` so callers can opt out of thinking-tag filtering cleanly.
+    public static func forModel(named name: String) -> ThinkingMarkers? {
+        let lowered = name.lowercased()
+
+        // Most-specific matches first — `reflection-llama` wins over a bare
+        // `reflection` substring match, and `phi-4`/`phi4` wins over generic `phi`.
+        if lowered.contains("reflection-llama") {
+            return .reflection
+        }
+        if lowered.contains("phi4") || lowered.contains("phi-4") {
+            return .phi4
+        }
+
+        if lowered.contains("qwen") || lowered.contains("deepseek") || lowered.contains("qwq") {
+            return .qwen3
+        }
+        if lowered.contains("mistral") || lowered.contains("sky-t1") {
+            return .mistralReasoning
+        }
+
+        return nil
     }
 }

--- a/Sources/BaseChatInference/Models/ThinkingMarkers.swift
+++ b/Sources/BaseChatInference/Models/ThinkingMarkers.swift
@@ -39,9 +39,10 @@ public struct ThinkingMarkers: Sendable, Equatable {
     /// - `qwen` / `deepseek` / `qwq` → `.qwen3`
     /// - `mistral` / `sky-t1` → `.mistralReasoning`
     ///
-    /// Generic `phi` matches fall through to `.phi4` only when no more-specific
-    /// family (e.g. `reflection-llama`) is present in the name. Unknown models
-    /// return `nil` so callers can opt out of thinking-tag filtering cleanly.
+    /// Only `phi4` / `phi-4` map to `.phi4` — generic `phi` or other Phi
+    /// generations (e.g. `phi3`) are not thinking-model variants and return
+    /// `nil`. Unknown models likewise return `nil` so callers can opt out of
+    /// thinking-tag filtering cleanly.
     public static func forModel(named name: String) -> ThinkingMarkers? {
         let lowered = name.lowercased()
 

--- a/Tests/BaseChatInferenceTests/ThinkingMarkersPresetsTests.swift
+++ b/Tests/BaseChatInferenceTests/ThinkingMarkersPresetsTests.swift
@@ -1,0 +1,180 @@
+import XCTest
+@testable import BaseChatInference
+
+// MARK: - Helpers
+
+private func collectVisible(_ events: [GenerationEvent]) -> String {
+    events.compactMap { if case .token(let t) = $0 { return t } else { return nil } }.joined()
+}
+
+private func collectThinking(_ events: [GenerationEvent]) -> String {
+    events.compactMap { if case .thinkingToken(let t) = $0 { return t } else { return nil } }.joined()
+}
+
+private func countCompletions(_ events: [GenerationEvent]) -> Int {
+    events.filter { if case .thinkingComplete = $0 { return true } else { return false } }.count
+}
+
+/// Runs a single-block reasoning payload through a `ThinkingParser` parameterized
+/// by `markers` and returns the (thinking, visible, completion-count) tuple.
+private func runParser(_ markers: ThinkingMarkers, open: String, close: String) -> (thinking: String, visible: String, completions: Int) {
+    var parser = ThinkingParser(markers: markers)
+    let input = "\(open)reason\(close)answer"
+    let events = parser.process(input)
+    let final = parser.finalize()
+    let all = events + final
+    return (collectThinking(all), collectVisible(all), countCompletions(all))
+}
+
+/// Tests for the named `ThinkingMarkers` presets and the `forModel(named:)`
+/// lookup helper added in issue #603.
+final class ThinkingMarkersPresetsTests: XCTestCase {
+
+    // MARK: - Preset tag pairs
+
+    func test_mistralReasoning_tagsAreThinkingPair() {
+        XCTAssertEqual(ThinkingMarkers.mistralReasoning.open, "<thinking>")
+        XCTAssertEqual(ThinkingMarkers.mistralReasoning.close, "</thinking>")
+    }
+
+    func test_phi4_tagsAreReasoningPair() {
+        XCTAssertEqual(ThinkingMarkers.phi4.open, "<reasoning>")
+        XCTAssertEqual(ThinkingMarkers.phi4.close, "</reasoning>")
+    }
+
+    func test_reflection_tagsAreReflectionPair() {
+        XCTAssertEqual(ThinkingMarkers.reflection.open, "<reflection>")
+        XCTAssertEqual(ThinkingMarkers.reflection.close, "</reflection>")
+    }
+
+    // MARK: - End-to-end ThinkingParser with each preset
+
+    func test_mistralReasoning_parsesSingleBlock() {
+        let r = runParser(.mistralReasoning, open: "<thinking>", close: "</thinking>")
+        XCTAssertEqual(r.thinking, "reason",
+            "Content between <thinking>…</thinking> must be emitted as .thinkingToken")
+        XCTAssertEqual(r.visible, "answer",
+            "Content after </thinking> must be emitted as .token")
+        XCTAssertEqual(r.completions, 1,
+            "Exactly one .thinkingComplete event should fire on the 1→0 depth transition")
+
+        // Sabotage check: swapping `.mistralReasoning` for `.qwen3` makes the parser
+        // search for the `<think>` / `</think>` pair. Both are substrings of the
+        // `<thinking>` / `</thinking>` payload, so the parser consumes different
+        // ranges and the visible text becomes "ing>answer" — the XCTAssertEqual fails.
+    }
+
+    func test_phi4_parsesSingleBlock() {
+        let r = runParser(.phi4, open: "<reasoning>", close: "</reasoning>")
+        XCTAssertEqual(r.thinking, "reason")
+        XCTAssertEqual(r.visible, "answer")
+        XCTAssertEqual(r.completions, 1)
+    }
+
+    func test_reflection_parsesSingleBlock() {
+        let r = runParser(.reflection, open: "<reflection>", close: "</reflection>")
+        XCTAssertEqual(r.thinking, "reason")
+        XCTAssertEqual(r.visible, "answer")
+        XCTAssertEqual(r.completions, 1)
+    }
+
+    // MARK: - Holdback for each preset
+
+    func test_mistralReasoning_holdbackEquals11() {
+        // max("<thinking>".count=10, "</thinking>".count=11) = 11
+        XCTAssertEqual(ThinkingMarkers.mistralReasoning.holdback, 11)
+    }
+
+    func test_phi4_holdbackEquals12() {
+        // max("<reasoning>".count=11, "</reasoning>".count=12) = 12
+        XCTAssertEqual(ThinkingMarkers.phi4.holdback, 12)
+    }
+
+    func test_reflection_holdbackEquals13() {
+        // max("<reflection>".count=12, "</reflection>".count=13) = 13
+        XCTAssertEqual(ThinkingMarkers.reflection.holdback, 13)
+    }
+
+    // MARK: - Split-tag robustness for new presets
+
+    func test_mistralReasoning_splitOpenTagAcrossChunks() {
+        var parser = ThinkingParser(markers: .mistralReasoning)
+        let e1 = parser.process("<thin")
+        let e2 = parser.process("king>reason</thinking>answer")
+        let all = e1 + e2 + parser.finalize()
+        XCTAssertEqual(collectThinking(all), "reason",
+            "Split <thinking> open tag must reassemble across chunk boundary")
+        XCTAssertEqual(collectVisible(all), "answer")
+    }
+
+    // MARK: - forModel(named:) — family matches
+
+    func test_forModel_qwen3Match() {
+        XCTAssertEqual(ThinkingMarkers.forModel(named: "Qwen3-7B-Instruct"), .qwen3)
+        XCTAssertEqual(ThinkingMarkers.forModel(named: "deepseek-r1-distill-llama-8b"), .qwen3)
+        XCTAssertEqual(ThinkingMarkers.forModel(named: "QwQ-32B-Preview"), .qwen3)
+    }
+
+    func test_forModel_mistralReasoningMatch() {
+        XCTAssertEqual(ThinkingMarkers.forModel(named: "Mistral-Small-3.1-Reasoning"), .mistralReasoning)
+        XCTAssertEqual(ThinkingMarkers.forModel(named: "Sky-T1-32B-Preview"), .mistralReasoning)
+    }
+
+    func test_forModel_phi4Match() {
+        XCTAssertEqual(ThinkingMarkers.forModel(named: "phi4-reasoning"), .phi4)
+        XCTAssertEqual(ThinkingMarkers.forModel(named: "Phi-4-mini"), .phi4)
+    }
+
+    func test_forModel_reflectionMatch() {
+        XCTAssertEqual(ThinkingMarkers.forModel(named: "Reflection-Llama-3.1-70B"), .reflection)
+    }
+
+    // MARK: - forModel(named:) — case variants
+
+    func test_forModel_caseInsensitive() {
+        XCTAssertEqual(ThinkingMarkers.forModel(named: "QWEN3"), .qwen3)
+        XCTAssertEqual(ThinkingMarkers.forModel(named: "qwen3"), .qwen3)
+        XCTAssertEqual(ThinkingMarkers.forModel(named: "DeepSeek-R1"), .qwen3)
+        XCTAssertEqual(ThinkingMarkers.forModel(named: "MISTRAL-small"), .mistralReasoning)
+        XCTAssertEqual(ThinkingMarkers.forModel(named: "PHI-4"), .phi4)
+        XCTAssertEqual(ThinkingMarkers.forModel(named: "REFLECTION-LLAMA-3.1"), .reflection)
+    }
+
+    // MARK: - forModel(named:) — ambiguity precedence
+
+    func test_forModel_reflectionLlamaBeatsGenericLlama() {
+        // A bare "llama-3.1" name does not match any known family; only "reflection-llama"
+        // triggers the reflection preset.
+        XCTAssertNil(ThinkingMarkers.forModel(named: "llama-3.1-8b"))
+        XCTAssertEqual(ThinkingMarkers.forModel(named: "Reflection-Llama-3.1-70B"), .reflection)
+    }
+
+    func test_forModel_phi4BeatsGenericPhi() {
+        // "phi4" and "phi-4" map to .phi4. Generic "phi" or "phi3" is not a known thinking
+        // family and must return nil.
+        XCTAssertEqual(ThinkingMarkers.forModel(named: "phi4-reasoning"), .phi4)
+        XCTAssertEqual(ThinkingMarkers.forModel(named: "phi-4-mini"), .phi4)
+        XCTAssertNil(ThinkingMarkers.forModel(named: "phi3-medium"),
+            "Only phi4/phi-4 is a thinking model; generic 'phi' variants must not match")
+    }
+
+    func test_forModel_reflectionLlamaWinsOverPhi4Substring() {
+        // Contrived: a name containing both "reflection-llama" and "phi4" should resolve
+        // to .reflection because reflection-llama is checked first (most specific).
+        XCTAssertEqual(
+            ThinkingMarkers.forModel(named: "reflection-llama-phi4-merged"),
+            .reflection,
+            "When a name contains both markers, the more specific 'reflection-llama' match wins")
+
+        // Sabotage check: if the precedence were reversed, this would return .phi4.
+    }
+
+    // MARK: - forModel(named:) — unknown returns nil
+
+    func test_forModel_unknownReturnsNil() {
+        XCTAssertNil(ThinkingMarkers.forModel(named: "gpt-4o"))
+        XCTAssertNil(ThinkingMarkers.forModel(named: "claude-3-opus"))
+        XCTAssertNil(ThinkingMarkers.forModel(named: "gemma-2-27b"))
+        XCTAssertNil(ThinkingMarkers.forModel(named: ""))
+    }
+}


### PR DESCRIPTION
Closes #603.

## Summary

- Adds three new named `ThinkingMarkers` presets so backends can auto-filter reasoning tags for the most common non-Qwen model families:
  - `.mistralReasoning` — `<thinking>` / `</thinking>` (Mistral Small 3.1 reasoning, Sky-T1)
  - `.phi4` — `<reasoning>` / `</reasoning>` (phi4-reasoning, older Reflection variants)
  - `.reflection` — `<reflection>` / `</reflection>` (Reflection-Llama 3.1)
- Adds `ThinkingMarkers.forModel(named:)`, a case-insensitive substring lookup that returns the right preset (or `nil`) based on model-name fragments. Match precedence runs most-specific first (`reflection-llama` > `phi4`/`phi-4` > `qwen`/`deepseek`/`qwq` > `mistral`/`sky-t1`), so contrived names containing multiple markers resolve deterministically.
- Extends `ThinkingBlockFilterTests` coverage with a new `ThinkingMarkersPresetsTests` file: each preset gets an end-to-end `ThinkingParser` single-block test, a holdback assertion, and the Mistral preset additionally exercises split-tag reassembly across chunk boundaries. `forModel(named:)` is covered for exact family match, case variants, ambiguity precedence (reflection-llama vs llama, phi4 vs phi), and unknown-model `nil` return.

Existing callers (`ThinkingMarkers.qwen3`, `.custom`, `LlamaGenerationDriver`, the MLX backend thinking tests) are unchanged.

## Test plan

- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 1035 tests, 0 failures
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits` — 69 tests, 0 failures
- [x] Sabotage-checked the end-to-end preset tests by swapping `.mistralReasoning` for `.qwen3`; the visible-text assertion fails as expected.

## Release Note

### Features

- **inference:** new named `ThinkingMarkers` presets — `.mistralReasoning`, `.phi4`, `.reflection` — plus a `ThinkingMarkers.forModel(named:)` substring lookup so backends pointed at Mistral reasoning, Sky-T1, phi4-reasoning, or Reflection-Llama auto-filter their native thinking tags instead of leaking them into visible text.