### PR TITLE
docs(inference): document ToolExecutor atomicity contract

### DIFF
--- a/Sources/BaseChatInference/Services/ToolExecutor.swift
+++ b/Sources/BaseChatInference/Services/ToolExecutor.swift
@@ -41,6 +41,18 @@ import Foundation
 /// discarded and never flows into the transcript. The model sees the error
 /// description, not the partial output.
 ///
+/// The throw path is classified as ``ToolResult/ErrorKind/permanent``
+/// (not ``ToolResult/ErrorKind/transient``) by design: an uncategorised
+/// thrown `Error` is the "I don't know what went wrong" escape hatch, and
+/// labelling it retry-safe would push agents into loops on permanent
+/// failures (logic bugs, schema mismatches, auth denials) that no amount of
+/// retrying will fix. Executors that *know* a failure is retriable must
+/// return an explicit ``ToolResult/init(callId:content:errorKind:)`` with
+/// ``ToolResult/ErrorKind/transient`` instead of throwing — same rule for
+/// ``ToolResult/ErrorKind/timeout``, ``ToolResult/ErrorKind/rateLimited``,
+/// ``ToolResult/ErrorKind/cancelled``, and the other specific kinds.
+/// Throwing is the last-resort catch-all, not a retry signal.
+///
 /// Practical consequences:
 ///
 /// - If your tool streams and you want to preserve what you got before
@@ -49,6 +61,10 @@ import Foundation
 ///   a successful ``ToolResult`` whose ``ToolResult/content`` contains the
 ///   buffered prefix plus a description of why collection stopped, rather
 ///   than throwing.
+/// - If the failure is transient (disk I/O hiccup, dropped connection,
+///   rate-limit response), return
+///   `ToolResult(callId: "", content: "...", errorKind: .transient)` rather
+///   than throwing — this tells the orchestrator the call is safe to retry.
 /// - Do not rely on side-effects (written files, DB rows, API calls) to
 ///   communicate partial progress to later turns — the orchestrator only
 ///   sees the returned ``ToolResult``.
@@ -66,7 +82,10 @@ public protocol ToolExecutor: Sendable {
     /// The returned ``ToolResult/callId`` may be empty — ``ToolRegistry``
     /// stamps the correct id from the incoming ``ToolCall`` before returning
     /// the result to the caller. Thrown errors are caught by the registry and
-    /// turned into ``ToolResult/ErrorKind/permanent`` results.
+    /// turned into ``ToolResult/ErrorKind/permanent`` results; to signal a
+    /// retriable failure, return a ``ToolResult`` with an explicit
+    /// ``ToolResult/ErrorKind/transient`` (or another specific kind) instead
+    /// of throwing.
     ///
     /// This call is **atomic** — see the protocol-level ``ToolExecutor``
     /// documentation. Partial work accumulated before a throw is discarded

--- a/Sources/BaseChatInference/Services/ToolExecutor.swift
+++ b/Sources/BaseChatInference/Services/ToolExecutor.swift
@@ -23,6 +23,37 @@ import Foundation
 /// ``TypedToolExecutor`` to wrap a strongly-typed Swift handler — the adapter
 /// handles JSON encode/decode on both sides so the handler signature stays
 /// free of `JSONSchemaValue`.
+///
+/// ## Atomicity
+///
+/// `execute(arguments:)` is **atomic** from the orchestrator's point of view:
+/// the registry observes exactly one outcome per call — either a fully-formed
+/// ``ToolResult`` returned from the function, or a thrown error. There is no
+/// partial-emission channel. Executors that perform streaming or multi-step
+/// work (streaming file reads, subprocess pipes, streamed HTTP responses,
+/// multi-RPC transactions) MUST buffer that work internally and only return a
+/// single complete ``ToolResult`` once the work has succeeded.
+///
+/// When an executor throws mid-work, ``ToolRegistry/dispatch(_:)`` records a
+/// ``ToolResult`` with ``ToolResult/ErrorKind/permanent`` and
+/// `String(describing: error)` as the content. Any in-flight state the
+/// executor had accumulated — bytes read, chunks processed, rows fetched — is
+/// discarded and never flows into the transcript. The model sees the error
+/// description, not the partial output.
+///
+/// Practical consequences:
+///
+/// - If your tool streams and you want to preserve what you got before
+///   failing, aggregate into a local buffer and only throw after you have
+///   decided to abandon that buffer. If the partial result is useful, return
+///   a successful ``ToolResult`` whose ``ToolResult/content`` contains the
+///   buffered prefix plus a description of why collection stopped, rather
+///   than throwing.
+/// - Do not rely on side-effects (written files, DB rows, API calls) to
+///   communicate partial progress to later turns — the orchestrator only
+///   sees the returned ``ToolResult``.
+/// - A future extension may add an explicit partial-content channel; until
+///   then, this atomic request/response shape is the contract.
 public protocol ToolExecutor: Sendable {
 
     /// The JSON-Schema contract exposed to the model and the ``ToolRegistry``
@@ -36,6 +67,11 @@ public protocol ToolExecutor: Sendable {
     /// stamps the correct id from the incoming ``ToolCall`` before returning
     /// the result to the caller. Thrown errors are caught by the registry and
     /// turned into ``ToolResult/ErrorKind/permanent`` results.
+    ///
+    /// This call is **atomic** — see the protocol-level ``ToolExecutor``
+    /// documentation. Partial work accumulated before a throw is discarded
+    /// by the orchestrator; aggregate internally and only throw once you
+    /// have decided to abandon the buffer.
     func execute(arguments: JSONSchemaValue) async throws -> ToolResult
 }
 
@@ -66,6 +102,17 @@ public protocol ToolExecutor: Sendable {
 /// the raw ``ToolCall/arguments`` string is classified as
 /// ``ToolResult/ErrorKind/invalidArguments`` at the registry boundary before
 /// this adapter sees it.
+///
+/// ## Atomicity
+///
+/// The adapter is inherently atomic: the handler's `Result` is JSON-encoded
+/// exactly once **after** the handler returns normally. If the handler throws,
+/// nothing is encoded and no ``ToolResult`` is produced — the error bubbles to
+/// ``ToolRegistry/dispatch(_:)`` which records a
+/// ``ToolResult/ErrorKind/permanent`` result with the error description and
+/// discards any work the handler had performed. See the ``ToolExecutor``
+/// protocol's Atomicity section for the full contract; handlers that perform
+/// streaming or multi-step work should buffer internally before returning.
 public struct TypedToolExecutor<Arguments: Decodable & Sendable, Result: Encodable & Sendable>: ToolExecutor {
 
     public let definition: ToolDefinition

--- a/Tests/BaseChatInferenceTests/ToolRegistryTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolRegistryTests.swift
@@ -267,11 +267,12 @@ final class ToolRegistryTests: XCTestCase {
         let call = ToolCall(id: "call-atomic", toolName: "partial", arguments: "{}")
         let result = await registry.dispatch(call)
 
-        // Registry classifies thrown executor errors as .permanent today.
-        // If the registry's classification ever changes (e.g. to .transient
-        // per #630's original draft), update this assertion in lockstep —
-        // the contract the test is locking in is "thrown-error kind + error
-        // description + no partial state", not the specific enum case.
+        // Thrown executor errors classify as .permanent by design: an
+        // uncategorised throw is the catch-all escape hatch, and marking it
+        // retry-safe would loop agents on real permanent failures (logic
+        // bugs, schema mismatches, auth denials). Executors that know their
+        // failure is retriable must return a ToolResult with .transient
+        // explicitly — see the ToolExecutor atomicity DocC note.
         XCTAssertEqual(result.errorKind, .permanent)
         XCTAssertEqual(result.callId, "call-atomic")
         XCTAssertTrue(

--- a/Tests/BaseChatInferenceTests/ToolRegistryTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolRegistryTests.swift
@@ -214,6 +214,90 @@ final class ToolRegistryTests: XCTestCase {
         XCTAssertTrue(result.content.contains("boom-message"), "Content should include the error description. Got: \(result.content)")
     }
 
+    // MARK: - dispatch: atomicity contract (#630)
+
+    /// Executor that performs visible "partial work" into a caller-owned
+    /// buffer before throwing. Locks in the ``ToolExecutor`` atomicity
+    /// contract: no partial state reaches the ``ToolResult``; only the thrown
+    /// error description is surfaced to the orchestrator.
+    private final class PartialWorkExecutor: ToolExecutor, @unchecked Sendable {
+        struct MidFlightError: Error, CustomStringConvertible {
+            var description: String { "disk io failed after 2 chunks" }
+        }
+
+        let definition: ToolDefinition
+        /// Shared buffer the executor "emits into" during work. Tests read
+        /// this to confirm the executor did accumulate state before throwing
+        /// — and that the registry dropped it.
+        let partialBuffer: PartialBuffer
+
+        init(name: String, buffer: PartialBuffer) {
+            self.definition = ToolDefinition(name: name, description: "partial", parameters: .object([:]))
+            self.partialBuffer = buffer
+        }
+
+        func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+            // Simulate streaming work by appending chunks to the buffer and
+            // then failing — exactly the shape the contract forbids exposing
+            // to the orchestrator.
+            await partialBuffer.append("chunk-1")
+            await partialBuffer.append("chunk-2")
+            throw MidFlightError()
+        }
+    }
+
+    /// Async-safe accumulator used by ``PartialWorkExecutor``. An actor is
+    /// the simplest way to make the "caller-owned buffer" pattern concurrent
+    /// without reaching for locks.
+    private actor PartialBuffer {
+        private(set) var chunks: [String] = []
+        func append(_ chunk: String) { chunks.append(chunk) }
+        func snapshot() -> [String] { chunks }
+    }
+
+    func test_executorAtomicity_partialWorkDiscarded_onThrow() async {
+        // Given an executor that accumulates state into a side-channel buffer
+        // and then throws mid-work, the orchestrator must see only the
+        // thrown-error ToolResult — no partial content leaks into the
+        // transcript via ``ToolResult/content``.
+        let registry = ToolRegistry()
+        let buffer = PartialBuffer()
+        registry.register(PartialWorkExecutor(name: "partial", buffer: buffer))
+
+        let call = ToolCall(id: "call-atomic", toolName: "partial", arguments: "{}")
+        let result = await registry.dispatch(call)
+
+        // Registry classifies thrown executor errors as .permanent today.
+        // If the registry's classification ever changes (e.g. to .transient
+        // per #630's original draft), update this assertion in lockstep —
+        // the contract the test is locking in is "thrown-error kind + error
+        // description + no partial state", not the specific enum case.
+        XCTAssertEqual(result.errorKind, .permanent)
+        XCTAssertEqual(result.callId, "call-atomic")
+        XCTAssertTrue(
+            result.content.contains("disk io failed after 2 chunks"),
+            "Error description must surface in ToolResult.content. Got: \(result.content)"
+        )
+
+        // The executor definitely accumulated partial state — confirm the
+        // side-channel buffer saw both chunks. This proves the test is
+        // actually exercising the "work happened before the throw" path and
+        // not silently skipping it.
+        let seen = await buffer.snapshot()
+        XCTAssertEqual(seen, ["chunk-1", "chunk-2"])
+
+        // None of the partial state must have leaked into the ToolResult
+        // that the orchestrator records in the transcript.
+        XCTAssertFalse(
+            result.content.contains("chunk-1"),
+            "Partial chunk leaked into ToolResult.content: \(result.content)"
+        )
+        XCTAssertFalse(
+            result.content.contains("chunk-2"),
+            "Partial chunk leaked into ToolResult.content: \(result.content)"
+        )
+    }
+
     // MARK: - dispatch: happy path
 
     func test_typedExecutor_happyPath_roundTrip() async throws {


### PR DESCRIPTION
Closes #630.

## Summary

Adds a DocC **Atomicity** section to the `ToolExecutor` protocol and a reinforcing note on `TypedToolExecutor`. Locks in the current request/response contract: `execute(arguments:)` is atomic from the orchestrator's point of view — executors that stream or perform multi-step work MUST buffer internally and only return a single complete `ToolResult`; thrown errors discard any in-flight state.

- Protocol-level doc spells out the contract, what `ToolRegistry.dispatch` does on a throw (records `ToolResult(errorKind: .permanent, content: String(describing: error))`), and practical guidance for streaming tools (aggregate into a buffer; if a partial prefix is useful, return success with it rather than throwing).
- `TypedToolExecutor` doc notes the adapter is inherently atomic because the handler's `Result` is JSON-encoded exactly once after the handler returns normally.
- Method-level doc on `execute(arguments:)` cross-references the protocol-level section.

Chose Option B from the issue (docs-only contract for v1). An explicit partial-content channel can follow when a real use case emerges — the method-level doc leaves the door open.

## Test

New `test_executorAtomicity_partialWorkDiscarded_onThrow` in `ToolRegistryTests`:

- Constructs a `PartialWorkExecutor` whose `execute(arguments:)` appends two chunks into an actor-owned `PartialBuffer` and then throws a `MidFlightError` with a distinct description.
- Dispatches via `ToolRegistry` and asserts:
  - `result.errorKind == .permanent` (matching the current `ToolRegistry.dispatch` classification — see note below)
  - `result.content` contains the error description
  - The side-channel buffer confirms both chunks _were_ written (proving the "work happened before the throw" path is actually exercised)
  - Neither chunk string appears in `result.content` — partial state was discarded by the orchestrator

Sabotage check performed locally: changing the error description to include `chunk-1 chunk-2` fires both leak-detection assertions as expected. Reverted before commit.

## Contract classification note

The acceptance criterion on #630 mentions `.transient`, but `ToolRegistry.dispatch` today classifies thrown executor errors as `.permanent` (see `ToolRegistry.swift:198-204`). The test asserts `.permanent` (current behavior) with an inline comment explaining how to update it if the classification ever changes — the contract this PR is locking in is "thrown-error kind + error description surfaced + no partial state leaks," not the specific enum case. If you'd rather retune the classification to `.transient` as part of this PR, flag it on review and I'll pair it with a one-line change in `ToolRegistry.dispatch`.

## Test plan

- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 1017/1017 passing
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits` — 69/69 passing
- [x] Sabotage check on the new test confirms it fails when partial state leaks

No behavior change, no release note needed (`docs:` commit).