### PR TITLE
feat(inference): add BackendCapabilities.supportsThinking flag

### DIFF
--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -60,7 +60,8 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
             supportsStreaming: true,
             isRemote: false,
             supportsKVCachePersistence: true,
-            supportsGrammarConstrainedSampling: true
+            supportsGrammarConstrainedSampling: true,
+            supportsThinking: true
         )
     }
 

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -65,7 +65,8 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         memoryStrategy: .resident,
         maxOutputTokens: 4096,
         supportsStreaming: true,
-        isRemote: false
+        isRemote: false,
+        supportsThinking: true
     )
 
     // MARK: - Private

--- a/Sources/BaseChatInference/Protocols/BackendCapabilities.swift
+++ b/Sources/BaseChatInference/Protocols/BackendCapabilities.swift
@@ -89,6 +89,16 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
     /// and the caller can rely on grammar-valid output. Backends reporting `false` (default) MUST
     /// throw `InferenceError.unsupportedGrammar(reason:)` when `config.grammar != nil`.
     public let supportsGrammarConstrainedSampling: Bool
+
+    /// If true, the backend can emit ``GenerationEvent/thinkingToken(_:)`` and
+    /// ``GenerationEvent/thinkingComplete`` events for reasoning content. Consumers use this
+    /// static capability flag to gate thinking-related UI (reasoning disclosure group,
+    /// thinking budget slider) rather than inferring it from the active `PromptTemplate`.
+    ///
+    /// Defaults to `false` for source compatibility. Orthogonal to
+    /// `GenerationConfig.thinkingMarkers`, which is a per-request runtime hint.
+    public let supportsThinking: Bool
+
     /// Parameters the UI should present controls for.
     public var visibleParameters: [GenerationParameter] {
         GenerationParameter.allCases.filter { supportedParameters.contains($0) }
@@ -109,7 +119,8 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         supportsStreaming: Bool = true,
         isRemote: Bool = false,
         supportsKVCachePersistence: Bool = false,
-        supportsGrammarConstrainedSampling: Bool = false
+        supportsGrammarConstrainedSampling: Bool = false,
+        supportsThinking: Bool = false
     ) {
         self.supportedParameters = supportedParameters
         self.maxContextTokens = maxContextTokens
@@ -126,6 +137,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         self.isRemote = isRemote
         self.supportsKVCachePersistence = supportsKVCachePersistence
         self.supportsGrammarConstrainedSampling = supportsGrammarConstrainedSampling
+        self.supportsThinking = supportsThinking
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -144,6 +156,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         case isRemote
         case supportsKVCachePersistence
         case supportsGrammarConstrainedSampling
+        case supportsThinking
     }
 
     public init(from decoder: Decoder) throws {
@@ -163,6 +176,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         isRemote = try c.decode(Bool.self, forKey: .isRemote)
         supportsKVCachePersistence = (try c.decodeIfPresent(Bool.self, forKey: .supportsKVCachePersistence)) ?? false
         supportsGrammarConstrainedSampling = (try c.decodeIfPresent(Bool.self, forKey: .supportsGrammarConstrainedSampling)) ?? false
+        supportsThinking = (try c.decodeIfPresent(Bool.self, forKey: .supportsThinking)) ?? false
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -182,5 +196,6 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         try c.encode(isRemote, forKey: .isRemote)
         try c.encode(supportsKVCachePersistence, forKey: .supportsKVCachePersistence)
         try c.encode(supportsGrammarConstrainedSampling, forKey: .supportsGrammarConstrainedSampling)
+        try c.encode(supportsThinking, forKey: .supportsThinking)
     }
 }

--- a/Tests/BaseChatBackendsTests/BackendCapabilitiesContractTests.swift
+++ b/Tests/BaseChatBackendsTests/BackendCapabilitiesContractTests.swift
@@ -53,6 +53,22 @@ final class BackendCapabilitiesContractTests: XCTestCase {
                       "OllamaBackend supports format=json")
     }
 
+    // MARK: - supportsThinking
+
+    /// Cloud backends remain at the default `false` until their
+    /// thinking-event wiring is formalised through #604 / #605 / #598.
+    /// Even though `OpenAIBackend` and `ClaudeBackend` already plumb reasoning
+    /// deltas, the capability flag is the static, model-agnostic contract
+    /// callers rely on to gate reasoning UI — see issue #480.
+    func test_cloudBackends_doNotAdvertiseThinking() {
+        XCTAssertFalse(ClaudeBackend().capabilities.supportsThinking,
+                       "ClaudeBackend.supportsThinking stays false until #604 formalises the declaration")
+        XCTAssertFalse(OpenAIBackend().capabilities.supportsThinking,
+                       "OpenAIBackend.supportsThinking stays false until #605 formalises the declaration")
+        XCTAssertFalse(OllamaBackend().capabilities.supportsThinking,
+                       "OllamaBackend.supportsThinking stays false until #598 formalises the declaration")
+    }
+
     // MARK: - Local backends
 
 #if Llama
@@ -82,6 +98,18 @@ final class BackendCapabilitiesContractTests: XCTestCase {
         XCTAssertFalse(LlamaBackend().capabilities.supportsNativeJSONMode,
                        "LlamaBackend does not expose a native JSON mode")
     }
+
+    /// `LlamaGenerationDriver` already filters thinking markers and emits
+    /// `.thinkingToken` / `.thinkingComplete`, so the capability flag must
+    /// advertise it for consumers gating reasoning UI (#480).
+    func test_llamaBackend_supportsThinking() throws {
+        try XCTSkipUnless(HardwareRequirements.isPhysicalDevice,
+                          "LlamaBackend requires Metal (unavailable in simulator)")
+        try XCTSkipUnless(HardwareRequirements.isAppleSilicon,
+                          "LlamaBackend requires Apple Silicon")
+        XCTAssertTrue(LlamaBackend().capabilities.supportsThinking,
+                      "LlamaBackend emits thinking events via LlamaGenerationDriver — supportsThinking must be true")
+    }
 #endif
 
 #if MLX
@@ -92,6 +120,16 @@ final class BackendCapabilitiesContractTests: XCTestCase {
                        "MLXBackend runs on-device — isRemote must be false")
         XCTAssertFalse(MLXBackend().capabilities.supportsNativeJSONMode,
                        "MLXBackend does not expose a native JSON mode")
+    }
+
+    /// MLXBackend routes generation through `ThinkingParser` when
+    /// `config.thinkingMarkers` is set, emitting `.thinkingToken` /
+    /// `.thinkingComplete` events. Capability flag must reflect that (#480).
+    func test_mlxBackend_supportsThinking() throws {
+        try XCTSkipUnless(HardwareRequirements.isAppleSilicon,
+                          "MLXBackend requires Apple Silicon")
+        XCTAssertTrue(MLXBackend().capabilities.supportsThinking,
+                      "MLXBackend emits thinking events via ThinkingParser — supportsThinking must be true")
     }
 #endif
 
@@ -112,6 +150,14 @@ final class BackendCapabilitiesContractTests: XCTestCase {
     func test_foundationBackend_doesNotSupportNativeJSONMode() {
         XCTAssertFalse(FoundationBackend().capabilities.supportsNativeJSONMode,
                        "FoundationBackend does not expose a native JSON mode in this version")
+    }
+
+    /// FoundationBackend does not expose reasoning events today; it stays at
+    /// the default `false` until Foundation Models gain a thinking surface.
+    @available(iOS 26, macOS 26, *)
+    func test_foundationBackend_doesNotAdvertiseThinking() {
+        XCTAssertFalse(FoundationBackend().capabilities.supportsThinking,
+                       "FoundationBackend does not emit thinking events — supportsThinking must be false")
     }
 #endif
 }

--- a/Tests/BaseChatInferenceTests/BackendCapabilitiesContractTests.swift
+++ b/Tests/BaseChatInferenceTests/BackendCapabilitiesContractTests.swift
@@ -18,6 +18,14 @@ final class BackendCapabilitiesContractTests: XCTestCase {
         XCTAssertFalse(caps.supportsGrammarConstrainedSampling)
     }
 
+    // MARK: - supportsThinking defaults to false
+
+    func test_supportsThinking_defaultsFalse() {
+        let caps = BackendCapabilities()
+        XCTAssertFalse(caps.supportsThinking,
+                       "supportsThinking must default to false so cloud backends remain source-compatible")
+    }
+
     // MARK: - Codable forward-compat: old JSON missing new keys defaults both to false
 
     func test_codable_forwardCompat_missingNewKeys_defaultsToFalse() throws {
@@ -46,6 +54,8 @@ final class BackendCapabilitiesContractTests: XCTestCase {
                        "supportsKVCachePersistence must default to false for old payloads")
         XCTAssertFalse(decoded.supportsGrammarConstrainedSampling,
                        "supportsGrammarConstrainedSampling must default to false for old payloads")
+        XCTAssertFalse(decoded.supportsThinking,
+                       "supportsThinking must default to false for old payloads")
     }
 
     // MARK: - Full round-trip with new flags set to true
@@ -53,7 +63,8 @@ final class BackendCapabilitiesContractTests: XCTestCase {
     func test_codable_roundTrip_newFlagsTrue() throws {
         let caps = BackendCapabilities(
             supportsKVCachePersistence: true,
-            supportsGrammarConstrainedSampling: true
+            supportsGrammarConstrainedSampling: true,
+            supportsThinking: true
         )
 
         let data = try JSONEncoder().encode(caps)
@@ -61,5 +72,6 @@ final class BackendCapabilitiesContractTests: XCTestCase {
 
         XCTAssertTrue(decoded.supportsKVCachePersistence)
         XCTAssertTrue(decoded.supportsGrammarConstrainedSampling)
+        XCTAssertTrue(decoded.supportsThinking)
     }
 }


### PR DESCRIPTION
Resolves #480.

## Summary

Adds `supportsThinking: Bool` to `BackendCapabilities` so consumers can gate thinking-related UI (reasoning disclosure, thinking budget slider) on a static backend-level declaration rather than inferring it from the active `PromptTemplate`.

- New field defaults to `false` for source compatibility; Codable uses `decodeIfPresent ?? false` so pre-#480 payloads decode cleanly
- `LlamaBackend` and `MLXBackend` report `true` — both already emit `.thinkingToken` / `.thinkingComplete` via `LlamaGenerationDriver` / `ThinkingParser`
- Cloud backends (`OpenAIBackend`, `ClaudeBackend`, `OllamaBackend`, `FoundationBackend`, `SSECloudBackend`) stay at the default `false`; formalising their declarations is follow-up work tracked under #604 / #605 / #598

This flag is orthogonal to `GenerationConfig.thinkingMarkers`, which remains a per-request runtime hint.

## Test plan

- [x] `BackendCapabilitiesContractTests` in `BaseChatInferenceTests` — default, forward-compat decoding, round-trip
- [x] `BackendCapabilitiesContractTests` in `BaseChatBackendsTests` — asserts `true` for Llama/MLX, `false` for the four cloud/Foundation backends
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 1017 tests, 0 failures
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits` — 69 tests, 0 failures
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 136 tests, 0 failures

## Release Note

### Features

- **inference:** `BackendCapabilities` now exposes `supportsThinking: Bool` so apps can gate reasoning UI on backend capability rather than the active `PromptTemplate`. `LlamaBackend` and `MLXBackend` advertise `true`; cloud backends remain at the default `false` pending their per-vendor thinking wiring (#480).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>