### PR TITLE
feat(ui): update MessageBubbleView accessibility labels for thinking parts

### DIFF
--- a/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
@@ -175,6 +175,8 @@ public struct MessageBubbleView: View {
     /// Builds the VoiceOver label for a chat message bubble.
     ///
     /// Format: `"<Role> said: <content>"` (e.g. `"Assistant said: Hello"`).
+    /// When the message contains thinking parts, appends `". Includes reasoning."` so
+    /// VoiceOver users know a reasoning block is available without having it read inline.
     /// Exposed so the accessibility contract can be asserted by tests without
     /// duplicating the string-building logic.
     public static func accessibilityLabel(for message: ChatMessageRecord) -> String {
@@ -183,7 +185,9 @@ public struct MessageBubbleView: View {
         case .assistant: "Assistant"
         case .system: "System"
         }
-        return "\(roleName) said: \(message.content)"
+        let base = "\(roleName) said: \(message.content)"
+        let hasThinking = message.contentParts.contains(where: { $0.thinkingContent != nil })
+        return hasThinking ? "\(base). Includes reasoning." : base
     }
 }
 

--- a/Sources/BaseChatUI/Views/Chat/ThinkingBlockView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ThinkingBlockView.swift
@@ -21,7 +21,13 @@ struct ThinkingBlockView: View {
             Label("Thinking…", systemImage: "brain")
                 .font(.caption)
                 .foregroundStyle(.secondary)
+                .accessibilityLabel("Reasoning in progress")
         } else {
+            // `.accessibilitySortPriority` is intentionally omitted — SwiftUI
+            // renders parts in document order, so ThinkingBlockView (placed before
+            // the text parts in MessagePartsView's ForEach) is already visited
+            // first by VoiceOver. The disclosure group itself handles expand/collapse
+            // navigation; the inner Text is not reachable until expanded.
             DisclosureGroup(isExpanded: $isExpanded) {
                 Text(text)
                     .font(.caption)
@@ -33,6 +39,8 @@ struct ThinkingBlockView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+            .accessibilityLabel("Reasoning")
+            .accessibilityHint(isExpanded ? "Double-tap to collapse." : "Double-tap to expand.")
         }
     }
 }

--- a/Tests/BaseChatUITests/ChatA11yContractTests.swift
+++ b/Tests/BaseChatUITests/ChatA11yContractTests.swift
@@ -25,9 +25,14 @@ final class ChatA11yContractTests: XCTestCase {
     /// to VoiceOver users. Kept in the test file (not imported from source) so
     /// a drive-by change to the source helper is caught by a failing assertion
     /// rather than quietly updating the "expected" side of the test.
+    ///
+    /// When `hasThinking` is `true`, `. Includes reasoning.` is appended so that
+    /// VoiceOver announces the presence of a reasoning block without reading its
+    /// contents inline.
     private func expectedMessageBubbleLabel(
         role: MessageRole,
-        content: String
+        content: String,
+        hasThinking: Bool = false
     ) -> String {
         let roleName: String
         switch role {
@@ -35,7 +40,8 @@ final class ChatA11yContractTests: XCTestCase {
         case .assistant: roleName = "Assistant"
         case .system: roleName = "System"
         }
-        return "\(roleName) said: \(content)"
+        let base = "\(roleName) said: \(content)"
+        return hasThinking ? "\(base). Includes reasoning." : base
     }
 
     private let sessionID = UUID()
@@ -125,6 +131,66 @@ final class ChatA11yContractTests: XCTestCase {
         XCTAssertEqual(
             MessageBubbleView.accessibilityLabel(for: system),
             expectedMessageBubbleLabel(role: .system, content: "Be concise")
+        )
+    }
+
+    func test_messageBubble_withThinkingParts_appendsIncludesReasoning() {
+        // A message whose contentParts include a .thinking block must announce
+        // reasoning presence so VoiceOver users know they can expand it.
+        let msg = ChatMessageRecord(
+            role: .assistant,
+            contentParts: [
+                .thinking("Let me reason about this."),
+                .text("The answer is 42.")
+            ],
+            sessionID: sessionID
+        )
+
+        let label = MessageBubbleView.accessibilityLabel(for: msg)
+
+        XCTAssertEqual(
+            label,
+            expectedMessageBubbleLabel(role: .assistant, content: "The answer is 42.", hasThinking: true),
+            "Label must append '. Includes reasoning.' when thinking parts are present"
+        )
+        XCTAssertTrue(
+            label.hasSuffix(". Includes reasoning."),
+            "Label must end with '. Includes reasoning.' suffix"
+        )
+    }
+
+    func test_messageBubble_withoutThinkingParts_doesNotAppendIncludesReasoning() {
+        // A plain text message must NOT have the reasoning suffix.
+        let msg = ChatMessageRecord(role: .assistant, content: "Just text.", sessionID: sessionID)
+
+        let label = MessageBubbleView.accessibilityLabel(for: msg)
+
+        XCTAssertFalse(
+            label.contains("Includes reasoning"),
+            "Label must not mention reasoning when no thinking parts are present"
+        )
+        XCTAssertEqual(
+            label,
+            expectedMessageBubbleLabel(role: .assistant, content: "Just text.", hasThinking: false)
+        )
+    }
+
+    // MARK: - Sabotage check for thinking-present label
+
+    func test_sabotage_thinkingPresentLabelDiffersFromPlainLabel() {
+        // Confirms that the thinking suffix actually changes the label — guards
+        // against a regression where the suffix is silently dropped.
+        let withThinking = ChatMessageRecord(
+            role: .assistant,
+            contentParts: [.thinking("some reasoning"), .text("answer")],
+            sessionID: sessionID
+        )
+        let withoutThinking = ChatMessageRecord(role: .assistant, content: "answer", sessionID: sessionID)
+
+        XCTAssertNotEqual(
+            MessageBubbleView.accessibilityLabel(for: withThinking),
+            MessageBubbleView.accessibilityLabel(for: withoutThinking),
+            "A message with thinking parts must produce a different label than one without"
         )
     }
 


### PR DESCRIPTION
Closes #485

## Summary

- `MessageBubbleView.accessibilityLabel(for:)` now appends `". Includes reasoning."` when the message contains any `.thinking` content parts, so VoiceOver users hear that a reasoning block exists without having its full content read inline.
- `ThinkingBlockView` gains `.accessibilityLabel("Reasoning")` on the disclosure group and a dynamic `.accessibilityHint` (`"Double-tap to expand."` / `"Double-tap to collapse."`) that reflects the current expand/collapse state. The streaming-only `Label("Thinking…")` gets `.accessibilityLabel("Reasoning in progress")`.
- VoiceOver navigation order is correct by construction: `ThinkingBlockView` is rendered before the text parts in `MessagePartsView`'s `ForEach`, so VoiceOver visits the reasoning disclosure group first.

## Changes

| File | What changed |
|------|--------------|
| `Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift` | `accessibilityLabel(for:)` checks `contentParts` for `.thinking` and appends suffix |
| `Sources/BaseChatUI/Views/Chat/ThinkingBlockView.swift` | Adds `accessibilityLabel` + `accessibilityHint` to `DisclosureGroup`; adds `accessibilityLabel` to streaming label |
| `Tests/BaseChatUITests/ChatA11yContractTests.swift` | 3 new tests: thinking-present, no-thinking, and sabotage check; `expectedMessageBubbleLabel` gains `hasThinking` parameter |

## Test plan

- [x] `swift test --filter BaseChatUITests --disable-default-traits` — all tests pass (0 failures)
- [x] New tests `test_messageBubble_withThinkingParts_appendsIncludesReasoning`, `test_messageBubble_withoutThinkingParts_doesNotAppendIncludesReasoning`, and `test_sabotage_thinkingPresentLabelDiffersFromPlainLabel` all pass
- [x] All pre-existing `ChatA11yContractTests` continue to pass

## Release Note

`MessageBubbleView.accessibilityLabel(for:)` now appends `". Includes reasoning."` when the message has thinking parts, and `ThinkingBlockView` exposes a proper `accessibilityLabel` / `accessibilityHint` pair so VoiceOver users can navigate to and expand reasoning blocks without having reasoning content read inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)