### PR TITLE
feat(inference): add Gemma 4 thinking markers to PromptTemplate

### DIFF
--- a/Sources/BaseChatInference/Models/ThinkingMarkers.swift
+++ b/Sources/BaseChatInference/Models/ThinkingMarkers.swift
@@ -25,6 +25,15 @@ public struct ThinkingMarkers: Sendable, Equatable {
     /// `<reflection>` / `</reflection>` blocks distinct from its `<thinking>` pass.
     public static let reflection = ThinkingMarkers(open: "<reflection>", close: "</reflection>")
 
+    /// Gemma 4 thinking fine-tunes, which wrap chain-of-thought in a dedicated
+    /// `<|turn>think\n` turn that closes with the standard `<|end_of_turn>` delimiter.
+    ///
+    /// The close marker collides with normal turn separators, but `ThinkingParser` is
+    /// only active when thinking mode is enabled — and a thinking block always appears
+    /// at the start of the model turn before any visible content — so the parser
+    /// correctly transitions to visible-text mode after the first `<|end_of_turn>`.
+    public static let gemma4 = ThinkingMarkers(open: "<|turn>think\n", close: "<|end_of_turn>")
+
     /// Extensibility hook for custom model formats.
     public static func custom(open: String, close: String) -> ThinkingMarkers {
         ThinkingMarkers(open: open, close: close)

--- a/Sources/BaseChatInference/Services/PromptTemplate.swift
+++ b/Sources/BaseChatInference/Services/PromptTemplate.swift
@@ -49,10 +49,9 @@ public enum PromptTemplate: String, CaseIterable, Sendable, Identifiable {
     /// Thinking markers for this template, or nil if the template does not emit reasoning blocks.
     public var thinkingMarkers: ThinkingMarkers? {
         switch self {
-        case .chatML: return .qwen3  // Qwen3, DeepSeek-R1 use ChatML format with <think> tags
-        // .gemma4 markers deferred — <|end_of_turn> as close marker needs verification
-        // against real Gemma 4 thinking weights before enabling.
-        default:      return nil
+        case .chatML:  return .qwen3   // Qwen3, DeepSeek-R1 use ChatML format with <think> tags
+        case .gemma4:  return .gemma4  // Gemma 4 thinking fine-tunes wrap CoT in <|turn>think\n
+        default:       return nil
         }
     }
 

--- a/Tests/BaseChatInferenceTests/PromptTemplateThinkingMarkersTests.swift
+++ b/Tests/BaseChatInferenceTests/PromptTemplateThinkingMarkersTests.swift
@@ -32,14 +32,17 @@ final class PromptTemplateThinkingMarkersTests: XCTestCase {
             "Llama 3 template does not emit reasoning blocks; thinkingMarkers must be nil")
     }
 
-    func test_gemma4_returnsNil() {
-        // Gemma 4 markers are deferred pending verification of real thinking weights.
-        // This test documents the *intentional* nil until that work lands.
-        XCTAssertNil(PromptTemplate.gemma4.thinkingMarkers,
-            "Gemma 4 thinking markers are deferred; thinkingMarkers must be nil until verified")
+    func test_gemma4_returnsGemma4Markers() {
+        let markers = PromptTemplate.gemma4.thinkingMarkers
+        XCTAssertNotNil(markers,
+            "Gemma 4 template must expose ThinkingMarkers for thinking fine-tunes")
+        XCTAssertEqual(markers?.open, "<|turn>think\n",
+            "Gemma 4 thinking open marker must be '<|turn>think\\n'")
+        XCTAssertEqual(markers?.close, "<|end_of_turn>",
+            "Gemma 4 thinking close marker must be '<|end_of_turn>'")
 
-        // Sabotage check: prematurely enabling gemma4 markers would cause this
-        // assertion to fail, alerting the team that the deferral comment was removed.
+        // Sabotage check: returning nil would disable thinking parsing for Gemma 4
+        // thinking-enabled models and this XCTAssertNotNil would fail.
     }
 
     // MARK: - ThinkingMarkers.qwen3 holdback

--- a/Tests/BaseChatInferenceTests/ThinkingMarkersPresetsTests.swift
+++ b/Tests/BaseChatInferenceTests/ThinkingMarkersPresetsTests.swift
@@ -177,4 +177,94 @@ final class ThinkingMarkersPresetsTests: XCTestCase {
         XCTAssertNil(ThinkingMarkers.forModel(named: "gemma-2-27b"))
         XCTAssertNil(ThinkingMarkers.forModel(named: ""))
     }
+
+    // MARK: - Gemma 4 preset tags
+
+    func test_gemma4_tagsAreCorrect() {
+        XCTAssertEqual(ThinkingMarkers.gemma4.open, "<|turn>think\n")
+        XCTAssertEqual(ThinkingMarkers.gemma4.close, "<|end_of_turn>")
+    }
+
+    func test_gemma4_holdbackEqualsCloseTagLength() {
+        // max("<|turn>think\n".count=13, "<|end_of_turn>".count=14) = 14
+        XCTAssertEqual(ThinkingMarkers.gemma4.holdback, 14)
+
+        // Sabotage check: using the open-tag length (13) instead of the close-tag
+        // length (14) would return 13 and this assertion would fail.
+    }
+
+    // MARK: - ThinkingParser end-to-end with .gemma4
+
+    func test_gemma4_parsesSingleBlock() {
+        let r = runParser(.gemma4, open: "<|turn>think\n", close: "<|end_of_turn>")
+        XCTAssertEqual(r.thinking, "reason",
+            "Content between Gemma 4 thinking markers must be emitted as .thinkingToken")
+        XCTAssertEqual(r.visible, "answer",
+            "Content after <|end_of_turn> must be emitted as .token")
+        XCTAssertEqual(r.completions, 1,
+            "Exactly one .thinkingComplete must fire on the 1→0 depth transition")
+
+        // Sabotage check: using .qwen3 markers instead would search for "<think>" /
+        // "</think>", miss the Gemma 4 open tag, and emit everything as visible text
+        // — r.visible would equal "<|turn>think\nreason<|end_of_turn>answer" and the
+        // thinkingToken assertion would fail.
+    }
+
+    func test_gemma4_splitOpenTagAcrossChunks() {
+        var parser = ThinkingParser(markers: .gemma4)
+        // Split "<|turn>think\n" across two chunks at a plausible boundary.
+        let e1 = parser.process("<|turn>")
+        let e2 = parser.process("think\nreason<|end_of_turn>answer")
+        let all = e1 + e2 + parser.finalize()
+
+        XCTAssertEqual(collectThinking(all), "reason",
+            "Split Gemma 4 open tag must reassemble across chunk boundary")
+        XCTAssertEqual(collectVisible(all), "answer",
+            "Visible content after close marker must be emitted correctly")
+        XCTAssertEqual(countCompletions(all), 1)
+
+        // Sabotage check: if the holdback did not cover the full open tag,
+        // "<|turn>" would be flushed as a visible token and the parser would
+        // never enter thinking mode — collectThinking would be empty.
+    }
+
+    func test_gemma4_splitCloseTagAcrossChunks() {
+        var parser = ThinkingParser(markers: .gemma4)
+        // Split "<|end_of_turn>" in the middle while in thinking mode.
+        let e1 = parser.process("<|turn>think\nreason<|end_of")
+        let e2 = parser.process("_turn>answer")
+        let all = e1 + e2 + parser.finalize()
+
+        XCTAssertEqual(collectThinking(all), "reason",
+            "Split Gemma 4 close tag must reassemble across chunk boundary")
+        XCTAssertEqual(collectVisible(all), "answer")
+        XCTAssertEqual(countCompletions(all), 1)
+    }
+
+    func test_gemma4_finalizeUnclosedBlock() {
+        var parser = ThinkingParser(markers: .gemma4)
+        let events = parser.process("<|turn>think\npartial thought")
+        let finalEvents = parser.finalize()
+        let all = events + finalEvents
+
+        XCTAssertTrue(collectThinking(all).contains("partial thought"),
+            "Unclosed Gemma 4 thinking block must be flushed as .thinkingToken by finalize()")
+        XCTAssertEqual(countCompletions(all), 0,
+            "An unclosed block must NOT emit .thinkingComplete")
+
+        // Sabotage check: if finalize() returned [] for a non-empty thinking buffer,
+        // the partial chain-of-thought would be silently dropped.
+    }
+
+    func test_gemma4_thinkingThenVisibleText() {
+        // Realistic Gemma 4 stream: thinking block followed by the model's answer.
+        var parser = ThinkingParser(markers: .gemma4)
+        let input = "<|turn>think\nI should add 2 and 2.<|end_of_turn>The answer is 4."
+        let events = parser.process(input)
+        let all = events + parser.finalize()
+
+        XCTAssertEqual(collectThinking(all), "I should add 2 and 2.")
+        XCTAssertEqual(collectVisible(all), "The answer is 4.")
+        XCTAssertEqual(countCompletions(all), 1)
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `ThinkingMarkers.gemma4` preset with open marker `<|turn>think\n` and close marker `<|end_of_turn>`, matching Gemma 4's turn-based format
- Wires `.gemma4` into `PromptTemplate.thinkingMarkers`, replacing the deferred `nil` case
- Updates `PromptTemplateThinkingMarkersTests` to assert the markers are now set (replacing the old deferral test)
- Adds 6 parser tests to `ThinkingMarkersPresetsTests` covering: tag verification, holdback computation, single-block parse, split open tag across chunks, split close tag across chunks, unclosed block finalize, and a realistic end-to-end stream

Closes #478

## Release Note

`PromptTemplate.gemma4.thinkingMarkers` now returns a `ThinkingMarkers` preset instead of `nil`. Gemma 4 thinking fine-tunes wrap chain-of-thought in a `<|turn>think\n` … `<|end_of_turn>` block. The parser handles split-tag chunk boundaries and streaming finalize correctly.

```swift
// ThinkingParser now handles Gemma 4 thinking streams correctly
let markers = PromptTemplate.gemma4.thinkingMarkers  // ThinkingMarkers.gemma4
var parser = ThinkingParser(markers: markers!)
let events = parser.process("<|turn>think\nmy reasoning<|end_of_turn>the answer")
// → [.thinkingToken("my reasoning"), .thinkingComplete, .token("the answer")]
```