### PR TITLE
fix(inference): reject GGUF files without magic-bytes header in discovery

### DIFF
--- a/Sources/BaseChatInference/Models/ModelInfo.swift
+++ b/Sources/BaseChatInference/Models/ModelInfo.swift
@@ -82,6 +82,14 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
     public init?(ggufURL url: URL) {
         guard url.pathExtension.lowercased() == "gguf" else { return nil }
 
+        // Reject files that don't carry the GGUF magic header — covers:
+        //   - leaked test-fixture stubs (e.g. 15-byte ASCII placeholders, see
+        //     `scripts/clean-leaked-test-artifacts.sh`)
+        //   - downloads truncated before the first 4 bytes were written
+        //   - companion files some HF repos ship with a .gguf extension but no
+        //     header (rare, but cheap to filter)
+        guard GGUFMetadataReader.isValidGGUF(at: url) else { return nil }
+
         let fileManager = FileManager.default
         guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),
               let size = attributes[.size] as? UInt64 else {

--- a/Tests/BaseChatInferenceTests/ModelInfoTests.swift
+++ b/Tests/BaseChatInferenceTests/ModelInfoTests.swift
@@ -18,12 +18,25 @@ final class ModelInfoTests: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: - Helpers
+
+    /// Writes a minimal fixture with a real GGUF magic-bytes header padded to the requested size.
+    /// The first 4 bytes are `[0x47, 0x47, 0x55, 0x46]` so the file passes
+    /// `GGUFMetadataReader.isValidGGUF(at:)` without needing a full GGUF structure.
+    @discardableResult
+    private func writeGGUFFixture(at url: URL, totalSize: Int = 1024) throws -> URL {
+        precondition(totalSize >= 4, "GGUF fixture must be at least 4 bytes for the magic header")
+        var data = Data([0x47, 0x47, 0x55, 0x46])
+        data.append(Data(repeating: 0, count: totalSize - 4))
+        try data.write(to: url)
+        return url
+    }
+
     // MARK: - GGUF Initializer
 
     func test_ggufInit_validFile_createsModelInfo() throws {
         let fileURL = tempDirectory.appendingPathComponent("test-model.Q4_K_M.gguf")
-        let data = Data(repeating: 0, count: 1024)
-        try data.write(to: fileURL)
+        try writeGGUFFixture(at: fileURL, totalSize: 1024)
 
         let model = ModelInfo(ggufURL: fileURL)
 
@@ -32,6 +45,26 @@ final class ModelInfoTests: XCTestCase {
         XCTAssertEqual(model?.modelType, .gguf)
         XCTAssertEqual(model?.fileSize, 1024)
         XCTAssertEqual(model?.url, fileURL)
+    }
+
+    func test_ggufInit_rejectsFileWithoutMagicBytes() throws {
+        // 15-byte ASCII placeholder — mirrors the leaked test-fixture shape documented in
+        // `scripts/clean-leaked-test-artifacts.sh`. Before the fix these surfaced as fake
+        // ~1 KB entries in the model picker.
+        let fileURL = tempDirectory.appendingPathComponent("stub-\(UUID().uuidString).gguf")
+        try "not-a-real-gguf".data(using: .utf8)!.write(to: fileURL)
+
+        XCTAssertNil(
+            ModelInfo(ggufURL: fileURL),
+            "ModelInfo(ggufURL:) must reject files without GGUF magic"
+        )
+    }
+
+    func test_ggufInit_acceptsFileWithMagicBytes() throws {
+        let fileURL = tempDirectory.appendingPathComponent("real-\(UUID().uuidString).gguf")
+        try Data([0x47, 0x47, 0x55, 0x46] + Array(repeating: UInt8(0), count: 16)).write(to: fileURL)
+
+        XCTAssertNotNil(ModelInfo(ggufURL: fileURL))
     }
 
     func test_ggufInit_nonGgufExtension_returnsNil() throws {
@@ -204,7 +237,7 @@ final class ModelInfoTests: XCTestCase {
 
     func test_ggufInit_sameFile_producesStableID() throws {
         let fileURL = tempDirectory.appendingPathComponent("stable-id-test.gguf")
-        try Data(repeating: 0, count: 64).write(to: fileURL)
+        try writeGGUFFixture(at: fileURL, totalSize: 64)
 
         let first = try XCTUnwrap(ModelInfo(ggufURL: fileURL))
         let second = try XCTUnwrap(ModelInfo(ggufURL: fileURL))
@@ -227,8 +260,8 @@ final class ModelInfoTests: XCTestCase {
     func test_differentFiles_produceDifferentIDs() throws {
         let fileA = tempDirectory.appendingPathComponent("model-a.gguf")
         let fileB = tempDirectory.appendingPathComponent("model-b.gguf")
-        try Data(repeating: 0, count: 64).write(to: fileA)
-        try Data(repeating: 0, count: 64).write(to: fileB)
+        try writeGGUFFixture(at: fileA, totalSize: 64)
+        try writeGGUFFixture(at: fileB, totalSize: 64)
 
         let a = try XCTUnwrap(ModelInfo(ggufURL: fileA))
         let b = try XCTUnwrap(ModelInfo(ggufURL: fileB))
@@ -238,7 +271,7 @@ final class ModelInfoTests: XCTestCase {
 
     func test_stableID_isVersion5UUID() throws {
         let fileURL = tempDirectory.appendingPathComponent("v5-check.gguf")
-        try Data(repeating: 0, count: 64).write(to: fileURL)
+        try writeGGUFFixture(at: fileURL, totalSize: 64)
 
         let model = try XCTUnwrap(ModelInfo(ggufURL: fileURL))
         let uuidString = model.id.uuidString
@@ -253,8 +286,7 @@ final class ModelInfoTests: XCTestCase {
 
     func test_displayName_stripsGgufExtension() throws {
         let fileURL = tempDirectory.appendingPathComponent("model-name.Q4_K_M.gguf")
-        let data = Data(repeating: 0, count: 64)
-        try data.write(to: fileURL)
+        try writeGGUFFixture(at: fileURL, totalSize: 64)
 
         let model = ModelInfo(ggufURL: fileURL)
 

--- a/Tests/BaseChatInferenceTests/ModelStorageServiceTests.swift
+++ b/Tests/BaseChatInferenceTests/ModelStorageServiceTests.swift
@@ -41,11 +41,17 @@ final class ModelStorageServiceTests: XCTestCase {
 
     /// Creates a temporary GGUF file inside the models directory with a UUID-based name.
     /// Returns the file URL. The file is tracked for tearDown cleanup.
+    ///
+    /// The first 4 bytes are the GGUF magic header (`0x47 0x47 0x55 0x46`) so the file
+    /// passes `ModelInfo(ggufURL:)`'s magic-bytes gate. The rest is filler padding out
+    /// to `size`.
     @discardableResult
     private func createGgufFile(named prefix: String = "test", size: Int = 1024) throws -> URL {
+        precondition(size >= 4, "GGUF fixture must be at least 4 bytes for the magic header")
         let fileName = "\(prefix)-\(UUID().uuidString).gguf"
         let url = service.modelsDirectory.appendingPathComponent(fileName)
-        let data = Data(repeating: 0xAA, count: size)
+        var data = Data([0x47, 0x47, 0x55, 0x46])
+        data.append(Data(repeating: 0xAA, count: size - 4))
         try data.write(to: url)
         createdURLs.append(url)
         return url

--- a/Tests/BaseChatUITests/GenerationViewModelTests.swift
+++ b/Tests/BaseChatUITests/GenerationViewModelTests.swift
@@ -54,11 +54,16 @@ final class ChatViewModelTests: XCTestCase {
     }
 
     /// Creates a fake .gguf file in the scratch models directory and returns its URL.
+    ///
+    /// The first 4 bytes are the GGUF magic header (`0x47 0x47 0x55 0x46`) so the
+    /// fixture passes `ModelInfo(ggufURL:)`'s magic-bytes gate during discovery.
     @discardableResult
     private func createFakeGGUF(named fileName: String, sizeBytes: Int = 1024) throws -> URL {
+        precondition(sizeBytes >= 4, "GGUF fixture must be at least 4 bytes for the magic header")
         try FileManager.default.createDirectory(at: modelsDirectory, withIntermediateDirectories: true)
         let fileURL = modelsDirectory.appendingPathComponent(fileName)
-        let data = Data(repeating: 0, count: sizeBytes)
+        var data = Data([0x47, 0x47, 0x55, 0x46])
+        data.append(Data(repeating: 0, count: sizeBytes - 4))
         try data.write(to: fileURL)
         return fileURL
     }

--- a/Tests/BaseChatUITests/ModelManagementViewModelTests.swift
+++ b/Tests/BaseChatUITests/ModelManagementViewModelTests.swift
@@ -294,7 +294,10 @@ final class ModelManagementViewModelTests: XCTestCase {
 
         let fileName = "imported-\(UUID().uuidString).gguf"
         let sourceURL = tempDir.appendingPathComponent(fileName)
-        try Data(repeating: 0xAB, count: 4096).write(to: sourceURL)
+        // Prepend GGUF magic header so import passes ModelInfo(ggufURL:)'s magic-bytes gate.
+        var fixture = Data([0x47, 0x47, 0x55, 0x46])
+        fixture.append(Data(repeating: 0xAB, count: 4096 - 4))
+        try fixture.write(to: sourceURL)
 
         let imported = try vm.importModel(from: sourceURL)
         let importedURL = URL(fileURLWithPath: vm.modelsDirectoryPath).appendingPathComponent(fileName)


### PR DESCRIPTION
## Summary

`ModelInfo(ggufURL:)` accepted any file with a `.gguf` extension, so 1 KB stub files surfaced in the model picker as fake entries. This came up as a live user observation ("many model entries of 1KB" in the picker on dev machines) — the same leak `scripts/clean-leaked-test-artifacts.sh` has been hammering manually.

The infrastructure to validate GGUF files already exists: `GGUFMetadataReader.isValidGGUF(at:)` reads the first 4 bytes and checks against `[0x47, 0x47, 0x55, 0x46]` ("GGUF"). The fix is one extra guard in the GGUF initializer — `ModelStorageService.discoverModels()` inherits the filter for free, so the picker now rejects leaked test stubs, truncated downloads, and any `.gguf`-extensioned companion file without a real header.

## What changed

- `Sources/BaseChatInference/Models/ModelInfo.swift`: add `guard GGUFMetadataReader.isValidGGUF(at: url) else { return nil }` to `init?(ggufURL:)`, after the extension check and before reading file attributes.
- Test fixtures updated: `ModelStorageServiceTests.createGgufFile` and `ModelInfoTests` now emit the real magic header (`0x47 0x47 0x55 0x46`) padded to the requested size so they continue to pass the gate.
- Two new tests in `ModelInfoTests` lock the contract: `test_ggufInit_rejectsFileWithoutMagicBytes` (15-byte ASCII placeholder → nil, mirroring the real leak shape) and `test_ggufInit_acceptsFileWithMagicBytes` (real header → non-nil).

Scope is deliberately tight: only the GGUF init changes. `discoverModels`, `DownloadFileValidator`, and the cleanup script are untouched.

## Release note

### Highlights

#### Discovery rejects non-GGUF `.gguf` files

Leaked test fixtures and truncated downloads that carried a `.gguf` extension but no real header used to appear in the model picker as 1 KB phantom entries. `ModelInfo(ggufURL:)` now requires the GGUF magic header (`0x47 0x47 0x55 0x46`) before constructing a model, so `refreshModels()` becomes self-healing — the picker filters these files out automatically instead of relying on `scripts/clean-leaked-test-artifacts.sh`.

` ` `swift
// Rejected: empty .gguf stubs, partial downloads, companion files
ModelInfo(ggufURL: stubURL) // → nil

// Accepted: files whose first 4 bytes are "GGUF"
ModelInfo(ggufURL: realURL) // → ModelInfo(modelType: .gguf, ...)
` ` `

No API change; purely a behaviour tightening on the discovery path.

## Test plan

- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` → 1076 tests, 0 failures
- [x] New `test_ggufInit_rejectsFileWithoutMagicBytes` asserts the fix
- [x] New `test_ggufInit_acceptsFileWithMagicBytes` confirms the happy path still works

Generated with [Claude Code](https://claude.com/claude-code)