### PR TITLE
fix(test): inject UserDefaults into BackgroundDownloadManager to remove --parallel flake

### DIFF
--- a/Sources/BaseChatInference/Services/BackgroundDownloadManager.swift
+++ b/Sources/BaseChatInference/Services/BackgroundDownloadManager.swift
@@ -171,6 +171,17 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable {
     @ObservationIgnored
     private let tempScanDirectory: URL
 
+    /// `UserDefaults` instance used for the one-time legacy migration.
+    ///
+    /// Defaults to `.standard` so production behaviour is unchanged. Tests inject a
+    /// unique-per-instance suite (`UserDefaults(suiteName:)`) so that two managers
+    /// running in `swift test --parallel` cannot race on the same key — the legacy
+    /// pending-downloads key is a single global string that previously caused a
+    /// flake in `test_migrateFromUserDefaults_keepsUserDefaultsKeyOnWriteFailure`
+    /// when one suite's `set` interleaved with another's `removeObject`.
+    @ObservationIgnored
+    private let userDefaults: UserDefaults
+
     /// URL of the single JSON file that stores all pending-download metadata.
     private var pendingMetadataFileURL: URL {
         persistenceDirectory.appendingPathComponent("pending-downloads.json")
@@ -203,11 +214,19 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable {
     ///     tests to prevent OS-level session collisions between manager instances — reusing the
     ///     same identifier while a previous instance is still being torn down causes the OS to
     ///     deliver callbacks to a deallocated delegate, resulting in a double-free crash.
+    ///   - persistenceDirectory: Directory for the pending-downloads JSON and resume-data
+    ///     binary files. Tests inject a per-instance temporary directory.
+    ///   - tempScanDirectory: Directory scanned by the launch-time stale-temp sweep. Tests
+    ///     inject a per-instance temporary directory.
+    ///   - userDefaults: `UserDefaults` instance used for the one-time legacy migration.
+    ///     Defaults to `.standard`. Tests inject a per-instance suite so that parallel test
+    ///     runs cannot race on the shared `pendingDownloadsKey`.
     public init(
         storageService: ModelStorageService = ModelStorageService(),
         sessionIdentifier: String? = nil,
         persistenceDirectory: URL? = nil,
-        tempScanDirectory: URL? = nil
+        tempScanDirectory: URL? = nil,
+        userDefaults: UserDefaults = .standard
     ) {
         self.storageService = storageService
         self._sessionIdentifier = sessionIdentifier ?? Self.sessionIdentifier
@@ -219,6 +238,7 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable {
                 isDirectory: true
             )
         self.tempScanDirectory = tempScanDirectory ?? FileManager.default.temporaryDirectory
+        self.userDefaults = userDefaults
         super.init()
     }
 
@@ -1079,7 +1099,7 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable {
     /// a failed write leaves the data intact for the next launch to retry.
     // internal (not private) so unit tests can call it directly with @testable import.
     internal func migrateFromUserDefaults() {
-        let defaults = UserDefaults.standard
+        let defaults = self.userDefaults
         let pendingKey = BaseChatConfiguration.shared.pendingDownloadsKey
 
         // Migrate pending metadata — only when the new file doesn't already exist.

--- a/Tests/BaseChatInferenceTests/BackgroundDownloadIntegrationTests.swift
+++ b/Tests/BaseChatInferenceTests/BackgroundDownloadIntegrationTests.swift
@@ -27,6 +27,11 @@ final class BackgroundDownloadIntegrationTests: XCTestCase {
     // runs never share pending-downloads.json or resume-data files.
     private var persistenceDir: URL!
 
+    // Per-instance UserDefaults suite — prevents parallel test runs from racing on
+    // the global `pendingDownloadsKey` in `UserDefaults.standard`.
+    private var suiteName: String!
+    private var testDefaults: UserDefaults!
+
     private var pendingMetadataURL: URL {
         persistenceDir.appendingPathComponent("pending-downloads.json")
     }
@@ -40,10 +45,14 @@ final class BackgroundDownloadIntegrationTests: XCTestCase {
         persistenceDir = tempDirectory.appendingPathComponent("persistence")
         try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
 
+        suiteName = "com.basechatkit.test.downloads.\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)!
+
         manager = BackgroundDownloadManager(
             sessionIdentifier: testSessionIdentifier,
             persistenceDirectory: persistenceDir,
-            tempScanDirectory: tempDirectory
+            tempScanDirectory: tempDirectory,
+            userDefaults: testDefaults
         )
     }
 
@@ -51,10 +60,15 @@ final class BackgroundDownloadIntegrationTests: XCTestCase {
         if let tempDirectory {
             try? FileManager.default.removeItem(at: tempDirectory)
         }
+        if let suiteName {
+            testDefaults?.removePersistentDomain(forName: suiteName)
+        }
         tempDirectory = nil
         persistenceDir = nil
         manager = nil
         testSessionIdentifier = nil
+        testDefaults = nil
+        suiteName = nil
         try await super.tearDown()
     }
 
@@ -380,10 +394,12 @@ final class BackgroundDownloadIntegrationTests: XCTestCase {
 
         // A fresh manager starts with no active downloads.
         // Use a unique session identifier to avoid OS-level URLSession collisions with setUp's manager.
+        // Share the per-test UserDefaults suite so the second manager doesn't escape the isolation.
         let freshManager = BackgroundDownloadManager(
             sessionIdentifier: "com.basechatkit.test.download.\(UUID().uuidString)",
             persistenceDirectory: persistenceDir,
-            tempScanDirectory: tempDirectory
+            tempScanDirectory: tempDirectory,
+            userDefaults: testDefaults
         )
         XCTAssertNil(freshManager.activeDownloads[model.id], "No active downloads before reconnect")
 
@@ -398,11 +414,13 @@ final class BackgroundDownloadIntegrationTests: XCTestCase {
 
     func test_reconnectBackgroundSession_restoresPendingMLXSnapshotMetadata() throws {
         // Use a unique session identifier to avoid OS-level URLSession collisions with setUp's manager.
+        // Share the per-test UserDefaults suite so the second manager doesn't escape the isolation.
         let manager = BackgroundDownloadManager(
             storageService: ModelStorageService(baseDirectory: tempDirectory),
             sessionIdentifier: "com.basechatkit.test.download.\(UUID().uuidString)",
             persistenceDirectory: persistenceDir,
-            tempScanDirectory: tempDirectory
+            tempScanDirectory: tempDirectory,
+            userDefaults: testDefaults
         )
         let model = makeModel(
             repoID: "mlx-community/Test-4bit",

--- a/Tests/BaseChatInferenceTests/DownloadManagerTests.swift
+++ b/Tests/BaseChatInferenceTests/DownloadManagerTests.swift
@@ -7,14 +7,22 @@ final class DownloadManagerTests: XCTestCase {
     private var manager: BackgroundDownloadManager!
     private var tempDirectory: URL!
 
+    /// Per-instance UserDefaults suite — prevents parallel test runs from racing
+    /// on the global `pendingDownloadsKey` in `UserDefaults.standard`.
+    private var suiteName: String!
+    private var testDefaults: UserDefaults!
+
     override func setUp() async throws {
         try await super.setUp()
         tempDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("DownloadManagerTests-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        suiteName = "com.basechatkit.test.downloads.\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)!
         manager = BackgroundDownloadManager(
             storageService: ModelStorageService(baseDirectory: tempDirectory),
-            sessionIdentifier: "com.basechatkit.test.download.\(UUID().uuidString)"
+            sessionIdentifier: "com.basechatkit.test.download.\(UUID().uuidString)",
+            userDefaults: testDefaults
         )
     }
 
@@ -23,8 +31,13 @@ final class DownloadManagerTests: XCTestCase {
         if let tempDirectory {
             try? FileManager.default.removeItem(at: tempDirectory)
         }
+        if let suiteName {
+            testDefaults?.removePersistentDomain(forName: suiteName)
+        }
         tempDirectory = nil
         manager = nil
+        testDefaults = nil
+        suiteName = nil
         try await super.tearDown()
     }
 
@@ -205,7 +218,8 @@ final class DownloadManagerTests: XCTestCase {
 
     func test_activeDownloads_initiallyEmpty() {
         let freshManager = BackgroundDownloadManager(
-            sessionIdentifier: "com.basechatkit.test.download.\(UUID().uuidString)"
+            sessionIdentifier: "com.basechatkit.test.download.\(UUID().uuidString)",
+            userDefaults: testDefaults
         )
         XCTAssertTrue(
             freshManager.activeDownloads.isEmpty,

--- a/Tests/BaseChatInferenceTests/DownloadTempCleanupTests.swift
+++ b/Tests/BaseChatInferenceTests/DownloadTempCleanupTests.swift
@@ -18,14 +18,22 @@ final class DownloadTempCleanupTests: XCTestCase {
     /// Fresh manager per test — session identifier and scan directory are both unique.
     private var manager: BackgroundDownloadManager!
 
+    /// Per-instance UserDefaults suite — prevents parallel test runs from racing
+    /// on the global `pendingDownloadsKey` in `UserDefaults.standard`.
+    private var suiteName: String!
+    private var testDefaults: UserDefaults!
+
     override func setUp() async throws {
         try await super.setUp()
         tempScanDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("DownloadTempCleanupTests-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tempScanDir, withIntermediateDirectories: true)
+        suiteName = "com.basechatkit.test.downloads.\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)!
         manager = BackgroundDownloadManager(
             sessionIdentifier: "com.basechatkit.test.cleanup.\(UUID().uuidString)",
-            tempScanDirectory: tempScanDir
+            tempScanDirectory: tempScanDir,
+            userDefaults: testDefaults
         )
     }
 
@@ -33,8 +41,13 @@ final class DownloadTempCleanupTests: XCTestCase {
         if let tempScanDir {
             try? FileManager.default.removeItem(at: tempScanDir)
         }
+        if let suiteName {
+            testDefaults?.removePersistentDomain(forName: suiteName)
+        }
         tempScanDir = nil
         manager = nil
+        testDefaults = nil
+        suiteName = nil
         try await super.tearDown()
     }
 

--- a/Tests/BaseChatInferenceTests/ResumableDownloadTests.swift
+++ b/Tests/BaseChatInferenceTests/ResumableDownloadTests.swift
@@ -13,6 +13,11 @@ final class ResumableDownloadTests: XCTestCase {
     // Separate subdir for persistence so the blocker test can plant a file at this
     // path without destroying tempDirectory itself (which tearDown removes).
     private var persistenceDir: URL!
+    // Per-instance UserDefaults suite: parallel test runs would otherwise race on
+    // the global `pendingDownloadsKey` in `UserDefaults.standard` and cause flakes
+    // in `test_migrateFromUserDefaults_keepsUserDefaultsKeyOnWriteFailure`.
+    private var suiteName: String!
+    private var testDefaults: UserDefaults!
 
     override func setUp() async throws {
         try await super.setUp()
@@ -22,10 +27,14 @@ final class ResumableDownloadTests: XCTestCase {
         persistenceDir = tempDirectory.appendingPathComponent("persistence")
         try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
 
+        suiteName = "com.basechatkit.test.downloads.\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)!
+
         manager = BackgroundDownloadManager(
             storageService: ModelStorageService(baseDirectory: tempDirectory),
             sessionIdentifier: "com.basechatkit.test.download.\(UUID().uuidString)",
-            persistenceDirectory: persistenceDir
+            persistenceDirectory: persistenceDir,
+            userDefaults: testDefaults
         )
     }
 
@@ -33,9 +42,14 @@ final class ResumableDownloadTests: XCTestCase {
         if let tempDirectory {
             try? FileManager.default.removeItem(at: tempDirectory)
         }
+        if let suiteName {
+            testDefaults?.removePersistentDomain(forName: suiteName)
+        }
         tempDirectory = nil
         persistenceDir = nil
         manager = nil
+        testDefaults = nil
+        suiteName = nil
         try await super.tearDown()
     }
 
@@ -344,7 +358,8 @@ final class ResumableDownloadTests: XCTestCase {
         let pendingKey = BaseChatConfiguration.shared.pendingDownloadsKey
         let modelID = "test/migrate-model::migrate-model.gguf"
 
-        // Seed legacy UserDefaults data.
+        // Seed legacy UserDefaults data into the per-instance suite (not .standard)
+        // so parallel runs can't race on the shared key.
         let legacy: [String: [String: String]] = [
             modelID: [
                 "repoID": "test/migrate-model",
@@ -354,7 +369,7 @@ final class ResumableDownloadTests: XCTestCase {
                 "sizeBytes": "999",
             ]
         ]
-        UserDefaults.standard.set(legacy, forKey: pendingKey)
+        testDefaults.set(legacy, forKey: pendingKey)
 
         // Ensure the destination file does NOT already exist so the migration branch runs.
         let metadataURL = persistenceDir.appendingPathComponent("pending-downloads.json")
@@ -372,7 +387,7 @@ final class ResumableDownloadTests: XCTestCase {
 
         // The UserDefaults key must be gone after a successful write.
         XCTAssertNil(
-            UserDefaults.standard.dictionary(forKey: pendingKey),
+            testDefaults.dictionary(forKey: pendingKey),
             "UserDefaults key must be removed after a successful migration"
         )
     }
@@ -392,7 +407,9 @@ final class ResumableDownloadTests: XCTestCase {
                 "sizeBytes": "1",
             ]
         ]
-        UserDefaults.standard.set(legacy, forKey: pendingKey)
+        // Use the per-instance suite (not .standard) so parallel runs can't race
+        // on the shared key — that race was the source of the original CI flake.
+        testDefaults.set(legacy, forKey: pendingKey)
 
         // Block the write by placing a regular FILE where the persistence DIRECTORY should be,
         // so ensurePersistenceDirectory() and createDirectory() both fail.
@@ -404,7 +421,7 @@ final class ResumableDownloadTests: XCTestCase {
 
         // The UserDefaults key must still be present because the write failed.
         XCTAssertNotNil(
-            UserDefaults.standard.dictionary(forKey: pendingKey),
+            testDefaults.dictionary(forKey: pendingKey),
             "UserDefaults key must be preserved when the file write fails"
         )
 
@@ -413,8 +430,8 @@ final class ResumableDownloadTests: XCTestCase {
         // even on failure — causing this assertion to fail.
 
         // Clean up: remove the blocker file so tearDown can clean up tempDirectory.
+        // The suite itself is removed in tearDown via removePersistentDomain.
         try? FileManager.default.removeItem(at: persistenceDir)
-        UserDefaults.standard.removeObject(forKey: pendingKey)
     }
 
     // MARK: - deleteOrphanedResumeDataFiles


### PR DESCRIPTION
## Summary

Fixes the sporadic CI flake in `ResumableDownloadTests.test_migrateFromUserDefaults_keepsUserDefaultsKeyOnWriteFailure` that blocked PRs #710 and #716 (both merged with `--admin`).

`BackgroundDownloadManager.migrateFromUserDefaults()` reads/writes `UserDefaults.standard` keyed on the global `pendingDownloadsKey`. Under `swift test --parallel`, manager instances across the four download test suites race on that single key — one suite's `set` interleaves with another's `removeObject`, flipping the assertion.

PR #688 isolated the on-disk persistence directory per test but did not inject UserDefaults — this PR closes that gap.

- Adds `userDefaults: UserDefaults = .standard` to `BackgroundDownloadManager.init(...)`. Production call sites keep the default and are unchanged.
- `migrateFromUserDefaults()` now reads from `self.userDefaults` instead of `.standard`.
- Each download test class (`ResumableDownloadTests`, `BackgroundDownloadIntegrationTests`, `DownloadTempCleanupTests`, `DownloadManagerTests`) builds a unique `UserDefaults(suiteName:)` in `setUp` and removes the persistent domain in `tearDown`, so no two parallel managers share a backing store.
- The two tests in `ResumableDownloadTests` that wrote to `UserDefaults.standard` directly now use the injected `testDefaults` instance instead.
- The `*_doesNotWriteToUserDefaults` tests intentionally still assert against `UserDefaults.standard` — they verify that the production path never touches the global, which is exactly what we want.

## Test plan

- [x] `swift test --filter BaseChatInferenceTests --parallel --disable-default-traits` — exit 0 (1076 tests)
- [x] `ResumableDownloadTests/test_migrateFromUserDefaults_keepsUserDefaultsKeyOnWriteFailure --parallel` × 5 sequential runs — all exit 0
- [x] BaseChatCoreTests — 214 executed, 0 failures
- [x] BaseChatInferenceTests (sequential) — 1076 executed, 0 failures
- [x] BaseChatInferenceSwiftTestingTests — 69 tests in 7 suites passed
- [x] BaseChatUITests — 479 executed, 0 failures
- [x] BaseChatBackendsTests — 225 executed (1 skipped), 0 failures
- [x] BaseChatToolsTests — 36 executed, 0 failures
- [x] BaseChatTestSupportTests — 13 executed, 0 failures

## Scope guard

- Only `BackgroundDownloadManager.swift` in Sources is touched.
- The new init parameter has a default; verified no other Sources/Tests/Example callers break (`grep -rn "BackgroundDownloadManager("` covers all 13 sites).
- `BaseChatConfiguration.shared.pendingDownloadsKey` is unchanged — suite isolation is what makes the key test-safe.
- Did not touch trait config or workflow files (PR #724 is reviewing those).

🤖 Generated with [Claude Code](https://claude.com/claude-code)