### PR TITLE
docs(traits): document trait-split migration (Phase 2C of #714)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,35 @@ Add the targets you need:
 ])
 ```
 
-### 2. Configure at app startup
+### 2. Build modes
+
+BaseChatKit ships four pre-blessed build configurations keyed by use case. Backends are gated behind Swift package traits so consumers in regulated or air-gapped environments can compile out everything that touches the network.
+
+| Use case | Build command | Backends available |
+|----------|---------------|--------------------|
+| Default consumer app | `swift build` | MLX, Llama, Ollama |
+| Regulated vertical (local-only, no networking) | `swift build --disable-default-traits --traits MLX,Llama` | MLX, Llama |
+| Self-hosted / private datacenter | `swift build --disable-default-traits --traits MLX,Llama,Ollama` | MLX, Llama, Ollama |
+| Full / SaaS-enabled | `swift build --traits MLX,Llama,Ollama,CloudSaaS` | MLX, Llama, Ollama, Claude, OpenAI |
+
+Pass the matching set as `traits:` on your `.package(...)` entry to lock the configuration in a consumer manifest:
+
+```swift
+.package(
+    url: "https://github.com/roryford/BaseChatKit.git",
+    from: "0.11.0",
+    traits: [
+        .trait(name: "MLX"),
+        .trait(name: "Llama"),
+        .trait(name: "Ollama"),       // remove for local-only builds
+        .trait(name: "CloudSaaS"),    // add to enable Claude / OpenAI
+    ]
+)
+```
+
+`CloudSaaS` is opt-in today. **`Ollama` is in the default trait set for the current minor release but moves to opt-in in the next major** — call sites that construct `OllamaBackend()` directly emit a deprecation warning pointing at this table. Route through `DefaultBackends.register(_:)` (which gates Ollama on the trait) or add `Ollama` explicitly to your manifest to silence it. See [#714](https://github.com/roryford/BaseChatKit/issues/714).
+
+### 3. Configure at app startup
 
 ```swift
 import BaseChatCore
@@ -140,7 +168,7 @@ struct MyApp: App {
 }
 ```
 
-### 3. Wire up the UI
+### 4. Wire up the UI
 
 ```swift
 struct ContentView: View {

--- a/Sources/BaseChatBackends/DefaultBackends.swift
+++ b/Sources/BaseChatBackends/DefaultBackends.swift
@@ -124,6 +124,9 @@ public enum DefaultBackends {
             case .openAI, .lmStudio, .custom: return OpenAIBackend()
             #endif
             #if Ollama
+            // FIXME(#714): expected deprecation warning until Phase 2D moves
+            // `Ollama` out of default traits — this internal registration is
+            // the supported migration path consumers are pointed at.
             case .ollama:                     return OllamaBackend()
             #endif
             default: return nil

--- a/Sources/BaseChatBackends/DefaultBackends.swift
+++ b/Sources/BaseChatBackends/DefaultBackends.swift
@@ -124,9 +124,11 @@ public enum DefaultBackends {
             case .openAI, .lmStudio, .custom: return OpenAIBackend()
             #endif
             #if Ollama
-            // FIXME(#714): expected deprecation warning until Phase 2D moves
-            // `Ollama` out of default traits — this internal registration is
-            // the supported migration path consumers are pointed at.
+            // FIXME(#714): expected deprecation warning until the next major
+            // release flips `Ollama` out of default traits. This internal
+            // registration is the supported migration path consumers are
+            // pointed at — silencing the warning here would defeat the
+            // signal it sends to direct callers of `OllamaBackend()`.
             case .ollama:                     return OllamaBackend()
             #endif
             default: return nil

--- a/Sources/BaseChatBackends/OllamaBackend.swift
+++ b/Sources/BaseChatBackends/OllamaBackend.swift
@@ -67,6 +67,7 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
     /// ``URLSessionProvider/networkDisabled`` is set, the underlying property
     /// access traps. Use ``makeChecked(urlSession:)`` for a throwing variant
     /// that surfaces the kill-switch as a recoverable error.
+    @available(*, deprecated, message: "Ollama remains in default traits this minor; in the next major it moves to opt-in. Add the `Ollama` trait to your .package(...) entry, or register via DefaultBackends.register(_:). See README 'Build modes' and #714.")
     public init(urlSession: URLSession? = nil) {
         super.init(
             defaultModelName: "llama3.2",
@@ -77,6 +78,7 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
 
     /// Throwing factory that propagates ``URLSessionProvider/networkDisabled``
     /// as ``CloudBackendError/networkDisabled`` instead of trapping.
+    @available(*, deprecated, message: "Ollama remains in default traits this minor; in the next major it moves to opt-in. Add the `Ollama` trait to your .package(...) entry, or register via DefaultBackends.register(_:). See README 'Build modes' and #714.")
     public static func makeChecked(urlSession: URLSession? = nil) throws -> OllamaBackend {
         let session: URLSession
         if let urlSession {

--- a/Sources/bck-tools/main.swift
+++ b/Sources/bck-tools/main.swift
@@ -207,6 +207,9 @@ func makeBackend(cli: CLI, scenario: Scenario, model: String) async throws -> an
         return MockFactory.make(for: scenario)
     case .ollama:
         #if Ollama
+        // FIXME(#714): expected deprecation warning until Phase 2D moves
+        // `Ollama` out of default traits. bck-tools is internal infrastructure
+        // that intentionally exercises the trait-gated init directly.
         let backend = OllamaBackend()
         backend.configure(baseURL: cli.ollamaBaseURL, modelName: model)
         try await backend.loadModel(from: cli.ollamaBaseURL, plan: .cloud())

--- a/Sources/bck-tools/main.swift
+++ b/Sources/bck-tools/main.swift
@@ -207,9 +207,10 @@ func makeBackend(cli: CLI, scenario: Scenario, model: String) async throws -> an
         return MockFactory.make(for: scenario)
     case .ollama:
         #if Ollama
-        // FIXME(#714): expected deprecation warning until Phase 2D moves
-        // `Ollama` out of default traits. bck-tools is internal infrastructure
-        // that intentionally exercises the trait-gated init directly.
+        // FIXME(#714): expected deprecation warning until the next major
+        // release flips `Ollama` out of default traits. bck-tools is internal
+        // infrastructure that intentionally exercises the trait-gated init
+        // directly.
         let backend = OllamaBackend()
         backend.configure(baseURL: cli.ollamaBaseURL, modelName: model)
         try await backend.loadModel(from: cli.ollamaBaseURL, plan: .cloud())

--- a/Sources/fuzz-chat/OllamaFuzzFactory.swift
+++ b/Sources/fuzz-chat/OllamaFuzzFactory.swift
@@ -32,6 +32,9 @@ public struct OllamaFuzzFactory: FuzzBackendFactory {
         guard let model = hintedModel ?? models.first else {
             throw CLIError("No Ollama model installed. Pull one with: ollama pull qwen3.5:4b")
         }
+        // FIXME(#714): expected deprecation warning until Phase 2D moves
+        // `Ollama` out of default traits. The fuzz harness is internal
+        // infrastructure that exercises the trait-gated init directly.
         let backend = OllamaBackend()
         backend.configure(baseURL: baseURL, modelName: model)
         try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())

--- a/Sources/fuzz-chat/OllamaFuzzFactory.swift
+++ b/Sources/fuzz-chat/OllamaFuzzFactory.swift
@@ -32,9 +32,10 @@ public struct OllamaFuzzFactory: FuzzBackendFactory {
         guard let model = hintedModel ?? models.first else {
             throw CLIError("No Ollama model installed. Pull one with: ollama pull qwen3.5:4b")
         }
-        // FIXME(#714): expected deprecation warning until Phase 2D moves
-        // `Ollama` out of default traits. The fuzz harness is internal
-        // infrastructure that exercises the trait-gated init directly.
+        // FIXME(#714): expected deprecation warning until the next major
+        // release flips `Ollama` out of default traits. The fuzz harness
+        // is internal infrastructure that exercises the trait-gated init
+        // directly.
         let backend = OllamaBackend()
         backend.configure(baseURL: baseURL, modelName: model)
         try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())


### PR DESCRIPTION
## Summary

Phase 2C of #714 — see #720. Adds the migration artifacts for the Ollama / CloudSaaS trait split that landed in #724:

- **Deprecation annotations** on `OllamaBackend.init(urlSession:)` and `OllamaBackend.makeChecked(urlSession:)` warning consumers that `Ollama` will move to opt-in in the next major. The file is `#if Ollama`-gated, so the warning only fires for the audience that actually has the trait enabled.
- **README "Build modes" section** with a use-case-keyed decision table (default / regulated-local / datacenter / full) and a concrete `.package(... traits: ...)` example.
- **Internal-caller `// FIXME(#714):` markers** in `DefaultBackends.register(_:)`, `bck-tools/main.swift`, and `fuzz-chat/OllamaFuzzFactory.swift` — these are infrastructure that intentionally exercises the trait-gated init and the warning is expected until Phase 2D replaces it with trait-gated unavailability.

Closes part of #714. Full migration prose lives in the Release Note block below for the next release-rewrite step to pick up.

## Test plan

- [x] `swift build` (defaults) — succeeds; three expected deprecation warnings on tagged internal callers.
- [x] `swift build --disable-default-traits --traits MLX,Llama` — succeeds.
- [x] `swift build --disable-default-traits --traits MLX,Llama,Ollama` — succeeds.
- [x] `swift build --traits MLX,Llama,Ollama,CloudSaaS` — succeeds.
- [x] `BaseChatCoreTests` — pass (214 tests, 4 skipped).
- [x] `BaseChatInferenceSwiftTestingTests` — pass (69 tests).
- [x] `BaseChatUITests` — pass.
- [x] `BaseChatBackendsTests` — pass (75 tests, 1 skipped).
- [x] `BaseChatTestSupportTests` — pass.
- [ ] `BaseChatInferenceTests` — pre-existing failure in `SilentCatchAuditTest` flagging MLX `try?` fingerprints unrelated to this PR (verified by stashing the PR's changes; same failure on the parent commit). Not introduced here.

## Release Note

### Highlights

#### Trait-split migration: Ollama deprecation cycle starts now

The Ollama and Claude / OpenAI backends are now split behind Swift package traits so consumers in regulated or air-gapped environments can compile out everything that touches the network. `Ollama` ships in the default trait set this minor for backwards compatibility; **in the next major it moves to opt-in** alongside the already-opt-in `CloudSaaS` trait. Direct call sites of `OllamaBackend()` now emit a deprecation warning pointing at the new README "Build modes" table.

```swift
.package(
    url: "https://github.com/roryford/BaseChatKit.git",
    from: "0.11.0",
    traits: [
        .trait(name: "MLX"),
        .trait(name: "Llama"),
        .trait(name: "Ollama"),       // remove for local-only builds
        .trait(name: "CloudSaaS"),    // add to enable Claude / OpenAI
    ]
)
```

Routing backend registration through `DefaultBackends.register(_:)` continues to work and will be the supported migration path: it gates Ollama on the trait so consumers do not need to touch their existing call sites today. See README "Build modes" for the four pre-blessed configurations (default / regulated-local / datacenter / full) and the build commands that match each one.

See [#714], [#720], [#724].

### Features

- **traits:** add README "Build modes" section with use-case-keyed decision table and consumer `.package(...)` example ([#720])

### Deprecations

- **traits:** `OllamaBackend.init(urlSession:)` and `OllamaBackend.makeChecked(urlSession:)` are now deprecated — Ollama moves to opt-in in the next major, route through `DefaultBackends.register(_:)` or add the `Ollama` trait explicitly to your manifest ([#720])

🤖 Generated with [Claude Code](https://claude.com/claude-code)