### PR TITLE
perf(ci): skip Package.resolved verify step when deps unchanged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # paths-filter needs the parent commit to diff against on `push` events;
+          # `pull_request` works with the default shallow clone.
+          fetch-depth: 2
+
+      - name: Detect dependency-graph changes
+        id: deps-changed
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            deps:
+              - 'Package.swift'
+              - 'Package.resolved'
 
       - name: Select Xcode
         id: setup-xcode
@@ -63,6 +76,10 @@ jobs:
         # Was a separate `resolve-check` job on its own macos-15 runner; folding
         # it into `test` removes one 10×-billed runner per PR and eliminates the
         # second queue wait that `needs: [resolve-check]` imposed.
+        # Gated on the deps-changed filter: Package.resolved can only go stale
+        # when Package.swift is edited, so skipping when neither file changed
+        # avoids ~47s of wasted resolve work on the typical PR (~15% of total CI).
+        if: steps.deps-changed.outputs.deps == 'true'
         run: |
           swift package resolve
           git diff --exit-code Package.resolved || \
@@ -81,9 +98,10 @@ jobs:
       #   Apple Silicon for MLX/llama.cpp paths.
       # - Run `swift test --filter BaseChatE2ETests` on physical hardware.
 
-      # --skip-update: the Verify step above already ran `swift package resolve`,
-      # so the dependency graph is up to date. Without this flag, every `swift
-      # build`/`swift test` invocation re-contacts every git remote (~10-15s).
+      # --skip-update: Package.resolved pins every dependency, so the graph is
+      # already up to date (the Verify step re-confirms this when deps changed).
+      # Without this flag, every `swift build`/`swift test` invocation re-contacts
+      # every git remote (~10-15s).
       - name: Build
         run: swift build --build-tests --disable-default-traits --skip-update
 


### PR DESCRIPTION
## Summary

The \"Verify Package.resolved is up to date\" CI step runs `swift package resolve` plus `git diff --exit-code Package.resolved` on every CI invocation, taking **~47s**. On the typical PR nothing in the dependency graph has changed, so this work is wasted.

This PR gates the step on a `dorny/paths-filter@v3` output that flips to `true` only when `Package.swift` or `Package.resolved` is in the diff. Net effect: ~15% of total CI wall-clock saved on the typical PR, no behavior change on the (rare) PRs that bump deps.

## Why it's safe

`Package.resolved` is a lockfile — it can only go stale when `Package.swift` changes. The gate only suppresses the staleness check when **neither** file changed in the diff, so any PR that touches `Package.swift` (the only way to introduce staleness) still triggers the full verify.

`paths-filter@v3` handles both event types this workflow uses:
- `pull_request` against `main` — diffs PR head against PR base.
- `push` to `main` — diffs HEAD against HEAD~1 (we set `fetch-depth: 2` on checkout so the parent is available).

## Test plan

- [x] `actionlint .github/workflows/ci.yml` clean
- [x] `python3 -c \"import yaml; yaml.safe_load(...)\"` passes
- [ ] On this PR (no Package.* changes), confirm the \"Verify Package.resolved is up to date\" step shows `skipped` in the run
- [ ] Confirm the rest of CI still passes
- [ ] (Manual, future) On a PR that does bump `Package.swift`, confirm the step runs and catches a stale lockfile