### PR TITLE
perf(ci): cheaper CI runs — drop redundant build, batch tests, tighten paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ on:
       - "Package.swift"
       - "Package.resolved"
       - ".github/workflows/ci.yml"
-      - "scripts/**"
+      - "scripts/test.sh"
+      - "scripts/example-ui-tests.sh"
   pull_request:
     branches: [main]
     paths:
@@ -18,7 +19,8 @@ on:
       - "Package.swift"
       - "Package.resolved"
       - ".github/workflows/ci.yml"
-      - "scripts/**"
+      - "scripts/test.sh"
+      - "scripts/example-ui-tests.sh"
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -69,6 +71,7 @@ jobs:
             .build/repositories
           key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
           restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-fuzz-spm-${{ hashFiles('Package.resolved') }}
             ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
             ${{ runner.os }}-${{ runner.arch }}-spm-
 
@@ -102,20 +105,23 @@ jobs:
       # already up to date (the Verify step re-confirms this when deps changed).
       # Without this flag, every `swift build`/`swift test` invocation re-contacts
       # every git remote (~10-15s).
-      - name: Build
-        run: swift build --build-tests --disable-default-traits --skip-update
+      #
+      # The XCTest batch below compiles the test bundle on first invocation,
+      # so a separate `swift build --build-tests` step would be duplicate work.
 
-      # Core + UI + Backends share a process. Inference is split across two
-      # invocations because mixing its XCTest + Swift Testing suites in one
-      # process triggers a libmalloc SIGABRT (see BaseChatInferenceSwiftTestingTests).
-      - name: Test — Core + UI + Backends
-        run: scripts/test.sh --filter BaseChatCoreTests --filter BaseChatUITests --filter BaseChatBackendsTests --disable-default-traits --skip-update
+      # All XCTest-only suites run in one process. Swift Testing must stay
+      # isolated — mixing XCTest + Swift Testing in one swift test process
+      # triggers a libmalloc double-free SIGABRT (see SwiftTestingAuditTest, #681).
+      #
+      # Do NOT add --parallel here. swift test --parallel launches each XCTest
+      # in a separate process, but UserDefaults.standard is keyed by bundle ID
+      # and persists to the same on-disk plist across processes — so tests that
+      # touch UserDefaults race across worker processes (see #756, the
+      # ChatViewModelTests.test_autoSelectFirstRunModel_* pair). Serial XCTest
+      # execution avoids that and `--parallel` would still need a UI-test-only
+      # carve-out, which negates most of the speedup anyway.
+      - name: Test — XCTest suites (Core + UI + Backends + Inference + TestSupport)
+        run: scripts/test.sh --filter BaseChatCoreTests --filter BaseChatUITests --filter BaseChatBackendsTests --filter BaseChatInferenceTests --filter BaseChatTestSupportTests --disable-default-traits --skip-update
 
-      - name: Test — Inference (XCTest)
-        run: scripts/test.sh --filter BaseChatInferenceTests --disable-default-traits --skip-update --parallel
-
-      - name: Test — Inference (Swift Testing)
+      - name: Test — Inference (Swift Testing, isolated process)
         run: scripts/test.sh --filter BaseChatInferenceSwiftTestingTests --disable-default-traits --skip-update
-
-      - name: Test — TestSupport
-        run: scripts/test.sh --filter BaseChatTestSupportTests --disable-default-traits --skip-update

--- a/.github/workflows/fuzz-pr.yml
+++ b/.github/workflows/fuzz-pr.yml
@@ -12,7 +12,7 @@ on:
   pull_request:
     paths:
       - "Sources/**"
-      - "Tests/**"
+      - "Tests/BaseChatFuzzTests/**"
       - "Package.swift"
       - "Package.resolved"
       - ".github/fuzz-allowlist.json"


### PR DESCRIPTION
## Summary

Four focused edits to `ci.yml` and `fuzz-pr.yml` that reduce macOS CI billed minutes without changing coverage. Rough savings at current PR volume: **~3,500–4,500 macOS-min/week** (10× billing multiplier on macOS runners makes each saved minute count for ten).

### Edits

- **Drop redundant `swift build --build-tests` step.** The first `swift test` invocation compiles the test bundle anyway, so the separate build step was duplicate work on every CI run.

- **Collapse four sequential `scripts/test.sh` invocations into two.** One XCTest-only batch (Core + UI + Backends + Inference + TestSupport) and one isolated Swift Testing run for `BaseChatInferenceSwiftTestingTests`. The XCTest-vs-Swift-Testing process boundary is preserved because mixing the two harnesses in one `swift test` invocation triggers a libmalloc double-free SIGABRT (see `Tests/BaseChatCoreTests/SwiftTestingAuditTest.swift` and issue #681). `BaseChatTestSupportTests` contains zero `@Suite`/`@Test` annotations, so folding it into the XCTest batch is safe.

- **Tighten `ci.yml` path filters.** Replace the broad `scripts/**` with `scripts/test.sh` and `scripts/example-ui-tests.sh` (applied to both `push` and `pull_request` triggers). Edits to unrelated scripts (`fuzz.sh`, `clean-leaked-test-artifacts.sh`, etc.) no longer trigger the full CI matrix.

- **Tighten `fuzz-pr.yml` path filters and add cache fallback in `ci.yml`.** Narrow `fuzz-pr.yml` from `Tests/**` to `Tests/BaseChatFuzzTests/**` so non-fuzz test edits don't fire fuzz CI. In `ci.yml`, add the fuzz workflow's cache key as the first `restore-keys:` fallback so CI can inherit the warm `.build/artifacts` xcframework cache that `fuzz-pr.yml` already populates on PRs.

### What was rejected: `--parallel`

An earlier revision of this PR added `--parallel` to the consolidated XCTest step. CI failed with a single `ChatViewModelTests.test_autoSelectFirstRunModel_selectsFoundation` failure. Root cause: `swift test --parallel` launches each XCTest in a separate process, but the two `test_autoSelectFirstRunModel_*` tests both touch `UserDefaults.standard.<bundle>.hasCompletedFirstLaunch`, which is backed by an on-disk plist shared across processes. Under parallel execution, the two workers race on that key. Confined to `--parallel` mode (which is why main has been green) and not worth a UI-test-only carve-out — that would re-introduce the third step we just removed and erase most of the speedup. Final shape runs both consolidated steps serially.

The pre-existing UserDefaults-shared-state pattern in those tests is a latent issue independent of this PR (it would also bite anyone running `--parallel` locally). Tracked separately; not fixed here.

## Test plan

- [x] `actionlint` clean on both `ci.yml` and `fuzz-pr.yml`
- [x] Local sanity: `scripts/test.sh --filter BaseChatCoreTests --filter BaseChatUITests --filter BaseChatBackendsTests --filter BaseChatInferenceTests --filter BaseChatTestSupportTests --disable-default-traits --skip-update` runs 1865 passed, 5 skipped, 0 failed in ~70s on Apple Silicon
- [x] Local sanity: `scripts/test.sh --filter BaseChatInferenceSwiftTestingTests --disable-default-traits --skip-update` runs 70 passed, 0 failed
- [x] Verified `Tests/BaseChatTestSupportTests/` contains zero `@Suite`/`@Test` annotations (safe to add to XCTest batch)
- [x] Verified `Tests/BaseChatFuzzTests/` exists at the path used in the new `fuzz-pr.yml` filter
- [ ] CI green on this PR
- [ ] Fuzz-PR CI behaves correctly (this PR touches `.github/workflows/fuzz-pr.yml`, which is in the fuzz-pr trigger list, so fuzz CI should still fire on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)