### PR TITLE
fix(ci): eliminate post-merge main-branch CI flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ on:
       - "scripts/**"
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/fuzz-pr.yml
+++ b/.github/workflows/fuzz-pr.yml
@@ -20,7 +20,7 @@ on:
       - "scripts/fuzz-ci-gate.sh"
 
 concurrency:
-  group: fuzz-pr-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: fuzz-pr-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+SessionManagement.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+SessionManagement.swift
@@ -108,8 +108,8 @@ extension ChatViewModel {
     /// calling this method.
     public func autoSelectFirstRunModel() {
         let key = "\(BaseChatConfiguration.shared.bundleIdentifier).hasCompletedFirstLaunch"
-        guard !UserDefaults.standard.bool(forKey: key) else { return }
-        UserDefaults.standard.set(true, forKey: key)
+        guard !userDefaults.bool(forKey: key) else { return }
+        userDefaults.set(true, forKey: key)
         isFirstRun = false
 
         if let customHandler = onFirstLaunch {

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -34,6 +34,11 @@ public final class ChatViewModel {
     let modelStorage: ModelStorageService
     let memoryPressure: MemoryPressureHandler
 
+    /// `UserDefaults` instance backing the first-run flag. Defaults to `.standard`
+    /// in production. Tests inject a unique-per-instance suite so `swift test --parallel`
+    /// runs cannot race on the shared `hasCompletedFirstLaunch` key.
+    let userDefaults: UserDefaults
+
     /// The UI-layer ``ToolApprovalGate`` that drives the per-call approval
     /// sheet. When `nil`, the underlying ``InferenceService`` uses its
     /// default ``AutoApproveGate`` — every tool call dispatches silently.
@@ -530,14 +535,16 @@ public final class ChatViewModel {
         inferenceService: InferenceService = InferenceService(),
         deviceCapability: DeviceCapabilityService = DeviceCapabilityService(),
         modelStorage: ModelStorageService = ModelStorageService(),
-        toolApprovalGate: UIToolApprovalGate? = nil
+        toolApprovalGate: UIToolApprovalGate? = nil,
+        userDefaults: UserDefaults = .standard
     ) {
         self.init(
             inferenceService: inferenceService,
             deviceCapability: deviceCapability,
             modelStorage: modelStorage,
             memoryPressure: MemoryPressureHandler(),
-            toolApprovalGate: toolApprovalGate
+            toolApprovalGate: toolApprovalGate,
+            userDefaults: userDefaults
         )
     }
 
@@ -546,17 +553,19 @@ public final class ChatViewModel {
         deviceCapability: DeviceCapabilityService = DeviceCapabilityService(),
         modelStorage: ModelStorageService = ModelStorageService(),
         memoryPressure: MemoryPressureHandler,
-        toolApprovalGate: UIToolApprovalGate? = nil
+        toolApprovalGate: UIToolApprovalGate? = nil,
+        userDefaults: UserDefaults = .standard
     ) {
         self.inferenceService = inferenceService
         self.deviceCapability = deviceCapability
         self.modelStorage = modelStorage
         self.memoryPressure = memoryPressure
         self.toolApprovalGate = toolApprovalGate
+        self.userDefaults = userDefaults
         self.sessionController = SessionController(selectedPromptTemplate: inferenceService.selectedPromptTemplate)
 
         let firstRunKey = "\(BaseChatConfiguration.shared.bundleIdentifier).hasCompletedFirstLaunch"
-        self.isFirstRun = !UserDefaults.standard.bool(forKey: firstRunKey)
+        self.isFirstRun = !userDefaults.bool(forKey: firstRunKey)
 
         let coordinator = ModelLoadCoordinator(inferenceService: inferenceService)
         self.loadCoordinator = coordinator

--- a/Tests/BaseChatUITests/GenerationViewModelTests.swift
+++ b/Tests/BaseChatUITests/GenerationViewModelTests.swift
@@ -17,6 +17,11 @@ final class ChatViewModelTests: XCTestCase {
     /// leaks into the user's real `<Documents>/Models` path (see #379).
     private nonisolated(unsafe) var scratchModelsDirectory: URL!
 
+    /// Per-instance UserDefaults suite — prevents parallel test runs from racing
+    /// on the global `hasCompletedFirstLaunch` key in `UserDefaults.standard`.
+    private nonisolated(unsafe) var suiteName: String!
+    private nonisolated(unsafe) var testDefaults: UserDefaults!
+
     /// Convenience to build a view model with controllable device memory.
     /// Uses a default InferenceService (no backend loaded).
     private func makeViewModel(ramGB: UInt64 = 16) -> ChatViewModel {
@@ -24,7 +29,8 @@ final class ChatViewModelTests: XCTestCase {
             inferenceService: InferenceService(),
             deviceCapability: DeviceCapabilityService(physicalMemory: ramGB * oneGB),
             modelStorage: ModelStorageService(baseDirectory: scratchModelsDirectory),
-            memoryPressure: MemoryPressureHandler()
+            memoryPressure: MemoryPressureHandler(),
+            userDefaults: testDefaults
         )
     }
 
@@ -39,7 +45,8 @@ final class ChatViewModelTests: XCTestCase {
             inferenceService: service,
             deviceCapability: DeviceCapabilityService(physicalMemory: ramGB * oneGB),
             modelStorage: ModelStorageService(baseDirectory: scratchModelsDirectory),
-            memoryPressure: MemoryPressureHandler()
+            memoryPressure: MemoryPressureHandler(),
+            userDefaults: testDefaults
         )
         // Set an active session so sendMessage/regenerate/edit don't bail out.
         vm.activeSession = ChatSessionRecord(title: "Test Session")
@@ -79,6 +86,8 @@ final class ChatViewModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
         scratchModelsDirectory = makeIsolatedModelsDirectory()
+        suiteName = "com.basechatkit.test.chatvm.\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)!
     }
 
     override func tearDown() async throws {
@@ -91,6 +100,11 @@ final class ChatViewModelTests: XCTestCase {
             try? FileManager.default.removeItem(at: dir)
         }
         scratchModelsDirectory = nil
+        if let suiteName {
+            testDefaults?.removePersistentDomain(forName: suiteName)
+        }
+        testDefaults = nil
+        suiteName = nil
     }
 
     // MARK: - test_init_defaultState
@@ -252,8 +266,8 @@ final class ChatViewModelTests: XCTestCase {
     // MARK: - test_autoSelectFirstRunModel_selectsFoundation
 
     func test_autoSelectFirstRunModel_selectsFoundation() {
-        // Clear the flag so autoSelectFirstRunModel treats this as first launch.
-        UserDefaults.standard.removeObject(forKey: "\(BaseChatConfiguration.shared.bundleIdentifier).hasCompletedFirstLaunch")
+        let firstRunKey = "\(BaseChatConfiguration.shared.bundleIdentifier).hasCompletedFirstLaunch"
+        // Per-instance suite starts empty — no need to clear; the flag is unset by construction.
 
         let vm = makeViewModel()
 
@@ -276,19 +290,17 @@ final class ChatViewModelTests: XCTestCase {
         } else {
             // Foundation not available on this OS -- autoSelect won't find it.
             // Verify it didn't crash and the flag was set.
-            XCTAssertTrue(UserDefaults.standard.bool(forKey: "\(BaseChatConfiguration.shared.bundleIdentifier).hasCompletedFirstLaunch"),
+            XCTAssertTrue(testDefaults.bool(forKey: firstRunKey),
                          "Flag should be set even if no foundation model available")
         }
-
-        // Clean up.
-        UserDefaults.standard.removeObject(forKey: "\(BaseChatConfiguration.shared.bundleIdentifier).hasCompletedFirstLaunch")
     }
 
     // MARK: - test_autoSelectFirstRunModel_doesNotRepeat
 
     func test_autoSelectFirstRunModel_doesNotRepeat() {
+        let firstRunKey = "\(BaseChatConfiguration.shared.bundleIdentifier).hasCompletedFirstLaunch"
         // Set the flag as if first launch already happened.
-        UserDefaults.standard.set(true, forKey: "\(BaseChatConfiguration.shared.bundleIdentifier).hasCompletedFirstLaunch")
+        testDefaults.set(true, forKey: firstRunKey)
 
         let vm = makeViewModel()
         vm.refreshModels()
@@ -296,9 +308,6 @@ final class ChatViewModelTests: XCTestCase {
 
         // Should NOT auto-select because the flag is already set.
         XCTAssertNil(vm.selectedModel, "Should not auto-select on subsequent launches")
-
-        // Clean up.
-        UserDefaults.standard.removeObject(forKey: "\(BaseChatConfiguration.shared.bundleIdentifier).hasCompletedFirstLaunch")
     }
 
     // MARK: - test_handleMemoryPressure_nominal_doesNotSetError


### PR DESCRIPTION
## Summary

Two targeted fixes that together address **100% of post-merge main-branch CI failures** observed in the last 200 CI runs (6 of 6 main-branch test failures). Triage backing this PR is in the conversation that produced it.

### 1. UserDefaults injection on `ChatViewModel` first-run flag (`15a57ff`)

`ChatViewModel.autoSelectFirstRunModel()` and the `isFirstRun` init read/write `UserDefaults.standard` keyed on `hasCompletedFirstLaunch`. Under `swift test --parallel`, `test_autoSelectFirstRunModel_selectsFoundation` and `test_refreshModels_*` race on that single key with sibling tests, producing flakes that have landed on `main` 3 times in the recent window.

Same pattern as PR #734 / commit `8a81196` (`BackgroundDownloadManager`). Adds `userDefaults: UserDefaults = .standard` to `ChatViewModel`'s init; production call sites unchanged. The test class creates a unique `UserDefaults(suiteName:)` in `setUp` and removes it in `tearDown`.

**Sabotage-verified**: leaking into `.standard` in `setUp` + reverting the production injection makes `test_autoSelectFirstRunModel_selectsFoundation` fail with the same assertion text seen in CI run 24924778132. Restoring both makes it pass.

### 2. CI concurrency-group fallback for push events (`86eb805`)

`.github/workflows/ci.yml` group key was `…-${{ pull_request.number || github.ref }}`. For PRs, `pull_request.number` is set — fine. For pushes to `main`, it falls through to `refs/heads/main`, so two consecutive pushes share a group and **the older one is cancelled in flight**. We've been silently losing post-merge `main` CI signal — confirmed on cancelled runs `24915908515` + `24915910106` (same SHA pushed twice within seconds, both cancelled).

One-line fix: change the fallback from `github.ref` to `github.run_id`, which is unique per run. PR runs are unaffected.

## Test plan

- [x] Sabotage check on `test_autoSelectFirstRunModel_selectsFoundation` (revert prod + leak `.standard` in `setUp` → fails as expected; restore → passes)
- [x] Pre-push suite locally (Core 214, Inference 1081, InferenceSwiftTesting 69, UITests 479, Backends 3, TestSupport 13) — all pass
- [x] `actionlint .github/workflows/ci.yml` clean
- [x] YAML parses

## Out of scope

The triage also surfaced these (separate PRs):
- `WithTimeoutTests:67` 50ms overhead budget too tight on cold runners
- `StopGenerationConcurrencyTests:56` `XCTAssertEqual(stopCallCount, 10)` may be stricter than contract
- Externalize `SilentCatchAuditTest` allowlist into a sibling file (24% of test failures)
- Workflow: `actions/upload-artifact: if: failure()` for `*.xcresult`; `swift-tools-version` vs runner Swift sanity check; per-step `timeout-minutes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)