### PR TITLE
feat(inference): probe HF config.json for vision/audio capability before loading

### DIFF
--- a/Sources/BaseChatInference/Services/ModelCapabilityProbe.swift
+++ b/Sources/BaseChatInference/Services/ModelCapabilityProbe.swift
@@ -9,10 +9,14 @@ import Foundation
 /// are detected without a code change.
 public struct ModelCapabilities: Sendable, Equatable {
     /// True when `config.json` contains a top-level `vision_config` object.
+    /// An explicit JSON `null` does not count — the key must map to an object.
     public let supportsVision: Bool
     /// True when `config.json` contains a top-level `audio_config` object.
+    /// An explicit JSON `null` does not count — the key must map to an object.
     public let supportsAudio: Bool
-    /// `max_position_embeddings` (preferred) or `n_ctx` if present, else `nil`.
+    /// First non-nil of `max_position_embeddings`, `n_ctx`,
+    /// `text_config.max_position_embeddings`, or `text_config.n_ctx`.
+    /// `nil` when none of those keys are present (e.g. embedding-only models).
     public let contextLength: Int?
 
     public init(
@@ -77,10 +81,23 @@ public enum ModelCapabilityProbe {
         // audio_config keys are authoritative for the flags we expose today,
         // and parsing a second file we don't use would just be noise.
 
-        let supportsVision = config["vision_config"] != nil
-        let supportsAudio = config["audio_config"] != nil
+        // Use `is [String: Any]` rather than `!= nil`: JSONSerialization
+        // turns an explicit `"vision_config": null` into NSNull, which
+        // satisfies `!= nil` and would falsely report vision support. The
+        // transformers library only emits these keys as objects when the
+        // architecture actually has that modality, so requiring an object
+        // is both faithful to the format and robust to null sentinels.
+        let supportsVision = config["vision_config"] is [String: Any]
+        let supportsAudio = config["audio_config"] is [String: Any]
+        // Some VLMs (e.g. PaliGemma, LLaVA-NeXT) nest the language config
+        // under `text_config` and only expose `max_position_embeddings`
+        // there. Fall back to that nested key before giving up so the
+        // probe surfaces a context length for the common multimodal case.
+        let textConfig = config["text_config"] as? [String: Any]
         let contextLength = (config["max_position_embeddings"] as? Int)
             ?? (config["n_ctx"] as? Int)
+            ?? (textConfig?["max_position_embeddings"] as? Int)
+            ?? (textConfig?["n_ctx"] as? Int)
 
         return ModelCapabilities(
             supportsVision: supportsVision,

--- a/Sources/BaseChatInference/Services/ModelCapabilityProbe.swift
+++ b/Sources/BaseChatInference/Services/ModelCapabilityProbe.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Capabilities reported by a Hugging Face model's `config.json`.
+///
+/// Populated by ``ModelCapabilityProbe`` from on-disk JSON before the model
+/// is handed to a backend. The probe deliberately keys off durable, format-level
+/// signals (`vision_config`, `audio_config`, `max_position_embeddings`) rather
+/// than enumerating known `model_type` strings, so newly-released architectures
+/// are detected without a code change.
+public struct ModelCapabilities: Sendable, Equatable {
+    /// True when `config.json` contains a top-level `vision_config` object.
+    public let supportsVision: Bool
+    /// True when `config.json` contains a top-level `audio_config` object.
+    public let supportsAudio: Bool
+    /// `max_position_embeddings` (preferred) or `n_ctx` if present, else `nil`.
+    public let contextLength: Int?
+
+    public init(
+        supportsVision: Bool,
+        supportsAudio: Bool,
+        contextLength: Int?
+    ) {
+        self.supportsVision = supportsVision
+        self.supportsAudio = supportsAudio
+        self.contextLength = contextLength
+    }
+}
+
+/// Errors raised by ``ModelCapabilityProbe``.
+public enum ModelCapabilityProbeError: LocalizedError, Equatable {
+    case configNotFound(URL)
+    case invalidConfigJSON(URL)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .configNotFound(url):
+            return "config.json not found at \(url.path)"
+        case let .invalidConfigJSON(url):
+            return "config.json at \(url.path) is not a JSON object"
+        }
+    }
+}
+
+/// Reads a downloaded HF model directory and reports vision/audio capability
+/// plus context length without loading any weights.
+///
+/// Why this exists: backends (MLX in particular) need to choose between
+/// `LLMModelFactory` and `VLMModelFactory` before instantiating the model,
+/// and the UI wants to gate "attach image" affordances per-model. SwiftLM
+/// solves the routing problem with a hardcoded `model_type` allowlist that
+/// rots every time a new VLM ships; this probe instead inspects the durable
+/// JSON shape — `vision_config` / `audio_config` are emitted by the
+/// transformers library for any multimodal architecture, so detection
+/// extends to new models for free.
+public enum ModelCapabilityProbe {
+    /// Probes the model directory at `modelDirectory` and returns its capabilities.
+    ///
+    /// - Parameter modelDirectory: Directory containing a Hugging Face snapshot.
+    ///   Must include `config.json`. `preprocessor_config.json`, when present,
+    ///   is reserved for future multimodal-detail extraction and is not read today.
+    /// - Throws: ``ModelCapabilityProbeError`` if `config.json` is missing or malformed.
+    public static func probe(modelDirectory: URL) throws -> ModelCapabilities {
+        let configURL = modelDirectory.appendingPathComponent("config.json")
+        guard FileManager.default.fileExists(atPath: configURL.path) else {
+            throw ModelCapabilityProbeError.configNotFound(configURL)
+        }
+
+        let configData = try Data(contentsOf: configURL)
+        guard let config = try JSONSerialization.jsonObject(with: configData) as? [String: Any] else {
+            throw ModelCapabilityProbeError.invalidConfigJSON(configURL)
+        }
+
+        // Note: `preprocessor_config.json` lives alongside `config.json` for
+        // multimodal models and will be consumed by future revisions of this
+        // probe (e.g. to surface image-size or audio sample-rate hints). It is
+        // intentionally not read here — config.json's vision_config /
+        // audio_config keys are authoritative for the flags we expose today,
+        // and parsing a second file we don't use would just be noise.
+
+        let supportsVision = config["vision_config"] != nil
+        let supportsAudio = config["audio_config"] != nil
+        let contextLength = (config["max_position_embeddings"] as? Int)
+            ?? (config["n_ctx"] as? Int)
+
+        return ModelCapabilities(
+            supportsVision: supportsVision,
+            supportsAudio: supportsAudio,
+            contextLength: contextLength
+        )
+    }
+}

--- a/Tests/BaseChatInferenceTests/ModelCapabilityProbeTests.swift
+++ b/Tests/BaseChatInferenceTests/ModelCapabilityProbeTests.swift
@@ -143,6 +143,90 @@ final class ModelCapabilityProbeTests: XCTestCase {
         XCTAssertEqual(caps.contextLength, 8192)
     }
 
+    // MARK: - Null / non-object key handling
+
+    func testProbe_treatsExplicitNullVisionConfigAsAbsent() throws {
+        // JSONSerialization turns `"vision_config": null` into NSNull, which is
+        // `!= nil` and would falsely flag vision support if the probe just
+        // checked key presence. Real VLM configs emit an *object*, never null.
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        {
+            "model_type": "llama",
+            "max_position_embeddings": 8192,
+            "vision_config": null,
+            "audio_config": null
+        }
+        """#, to: dir)
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertFalse(caps.supportsVision)
+        XCTAssertFalse(caps.supportsAudio)
+        XCTAssertEqual(caps.contextLength, 8192)
+    }
+
+    func testProbe_treatsScalarVisionConfigAsAbsent() throws {
+        // Defensive: a malformed config.json that puts a scalar where an object
+        // is expected should not be treated as multimodal. Better to under-
+        // report capability than to mis-route a load through VLMModelFactory.
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        {
+            "model_type": "llama",
+            "vision_config": "broken",
+            "audio_config": 42
+        }
+        """#, to: dir)
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertFalse(caps.supportsVision)
+        XCTAssertFalse(caps.supportsAudio)
+    }
+
+    // MARK: - Nested text_config.max_position_embeddings
+
+    func testProbe_readsContextLengthFromNestedTextConfig() throws {
+        // PaliGemma-style layout: top-level config has no max_position_embeddings;
+        // the language model's context lives inside text_config. Without the
+        // fallback, the probe would return nil for these very common VLMs.
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        {
+            "model_type": "paligemma",
+            "vision_config": { "hidden_size": 1152 },
+            "text_config": {
+                "model_type": "gemma",
+                "max_position_embeddings": 8192
+            }
+        }
+        """#, to: dir)
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertTrue(caps.supportsVision)
+        XCTAssertEqual(caps.contextLength, 8192)
+    }
+
+    func testProbe_prefersTopLevelContextOverTextConfig() throws {
+        // When both are present, top-level wins — consistent with HF's own
+        // resolution order and with how mlx-swift-lm reads the config.
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        {
+            "model_type": "made_up_vlm",
+            "max_position_embeddings": 16384,
+            "vision_config": { "hidden_size": 1152 },
+            "text_config": { "max_position_embeddings": 4096 }
+        }
+        """#, to: dir)
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertEqual(caps.contextLength, 16384)
+    }
+
     // MARK: - Error paths
 
     func testProbe_throwsWhenConfigMissing() throws {

--- a/Tests/BaseChatInferenceTests/ModelCapabilityProbeTests.swift
+++ b/Tests/BaseChatInferenceTests/ModelCapabilityProbeTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+@testable import BaseChatInference
+
+/// Verifies that ``ModelCapabilityProbe`` detects vision/audio capability
+/// from the durable JSON keys (`vision_config`, `audio_config`,
+/// `max_position_embeddings`) rather than any model-type allowlist.
+///
+/// Each test writes a minimal `config.json` to a temp directory, probes it,
+/// and asserts the returned ``ModelCapabilities``. Fixtures are intentionally
+/// minimal — they capture only the keys the probe inspects so a future
+/// regression that starts depending on `model_type` (or any other field)
+/// fails here.
+final class ModelCapabilityProbeTests: XCTestCase {
+
+    // MARK: - Fixture helpers
+
+    private func makeFixtureDirectory() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ModelCapabilityProbeTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
+        return dir
+    }
+
+    private func writeConfig(_ json: String, to directory: URL, named name: String = "config.json") throws {
+        let url = directory.appendingPathComponent(name)
+        try json.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    // MARK: - LLM (text-only)
+
+    func testProbe_LLM_reportsNoVisionNoAudio() throws {
+        let dir = try makeFixtureDirectory()
+        // Plain LLM: no vision_config, no audio_config. Includes
+        // max_position_embeddings so contextLength surfaces.
+        try writeConfig(#"""
+        {
+            "model_type": "llama",
+            "hidden_size": 4096,
+            "max_position_embeddings": 8192
+        }
+        """#, to: dir)
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertFalse(caps.supportsVision)
+        XCTAssertFalse(caps.supportsAudio)
+        XCTAssertEqual(caps.contextLength, 8192)
+    }
+
+    // MARK: - VLM (vision)
+
+    func testProbe_VLM_reportsVision() throws {
+        let dir = try makeFixtureDirectory()
+        // VLM: presence of vision_config is the only durable signal we rely on.
+        // model_type is intentionally something the probe has never seen so the
+        // test fails if a hardcoded allowlist sneaks back in.
+        try writeConfig(#"""
+        {
+            "model_type": "made_up_vlm_2099",
+            "max_position_embeddings": 32768,
+            "vision_config": {
+                "hidden_size": 1152,
+                "num_hidden_layers": 27
+            }
+        }
+        """#, to: dir)
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertTrue(caps.supportsVision)
+        XCTAssertFalse(caps.supportsAudio)
+        XCTAssertEqual(caps.contextLength, 32768)
+    }
+
+    // MARK: - ALM (audio)
+
+    func testProbe_ALM_reportsAudio() throws {
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        {
+            "model_type": "made_up_alm_2099",
+            "max_position_embeddings": 4096,
+            "audio_config": {
+                "sampling_rate": 16000,
+                "num_mel_bins": 80
+            }
+        }
+        """#, to: dir)
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertFalse(caps.supportsVision)
+        XCTAssertTrue(caps.supportsAudio)
+        XCTAssertEqual(caps.contextLength, 4096)
+    }
+
+    // MARK: - Context length fallback
+
+    func testProbe_fallsBackToNCtxWhenMaxPositionEmbeddingsAbsent() throws {
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        {
+            "model_type": "gpt2",
+            "n_ctx": 1024
+        }
+        """#, to: dir)
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertEqual(caps.contextLength, 1024)
+    }
+
+    func testProbe_returnsNilContextWhenNeitherKeyPresent() throws {
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        { "model_type": "mystery" }
+        """#, to: dir)
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertNil(caps.contextLength)
+    }
+
+    // MARK: - preprocessor_config.json optional
+
+    func testProbe_succeedsWhenPreprocessorConfigPresent() throws {
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        {
+            "model_type": "made_up_vlm",
+            "max_position_embeddings": 8192,
+            "vision_config": { "hidden_size": 768 }
+        }
+        """#, to: dir)
+        try writeConfig(#"""
+        { "image_processor_type": "CLIPImageProcessor", "size": 224 }
+        """#, to: dir, named: "preprocessor_config.json")
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertTrue(caps.supportsVision)
+        XCTAssertEqual(caps.contextLength, 8192)
+    }
+
+    // MARK: - Error paths
+
+    func testProbe_throwsWhenConfigMissing() throws {
+        let dir = try makeFixtureDirectory()
+        XCTAssertThrowsError(try ModelCapabilityProbe.probe(modelDirectory: dir)) { error in
+            guard case ModelCapabilityProbeError.configNotFound = error else {
+                return XCTFail("expected configNotFound, got \(error)")
+            }
+        }
+    }
+
+    func testProbe_throwsWhenConfigIsNotAJSONObject() throws {
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"["not", "an", "object"]"#, to: dir)
+        XCTAssertThrowsError(try ModelCapabilityProbe.probe(modelDirectory: dir)) { error in
+            guard case ModelCapabilityProbeError.invalidConfigJSON = error else {
+                return XCTFail("expected invalidConfigJSON, got \(error)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `ModelCapabilityProbe` and `ModelCapabilities` in `BaseChatInference`. The probe reads a downloaded HF model's `config.json` and reports `supportsVision` / `supportsAudio` / `contextLength` **without** loading the model. This lets backends pre-route to `LLMModelFactory` vs `VLMModelFactory` and lets the UI gate "attach image" affordances per-model.

## Approach

Detection keys off **durable JSON shape**, not a hardcoded `model_type` allowlist:

- `supportsVision = config["vision_config"] != nil`
- `supportsAudio = config["audio_config"] != nil`
- `contextLength = config["max_position_embeddings"] ?? config["n_ctx"]`

This is the deliberate divergence from SwiftLM's `ModelArchitectureProbe.swift`, which enumerates `paligemma | qwen2_vl | gemma3 | …` and rots every time a new VLM ships. The `vision_config` / `audio_config` keys are emitted by the transformers library for any multimodal architecture, so detection extends to new models for free — a test fixture uses a deliberately fake `model_type` (`made_up_vlm_2099`) to lock that contract in.

`preprocessor_config.json` is documented as reserved for a future revision (image-size / sample-rate UI hints) and intentionally not read today — config.json is authoritative for the flags we expose.

```swift
let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
if caps.supportsVision { /* show image attach button */ }
```

## Scope

- **In:** the probe + 8 unit tests (LLM, VLM, ALM, n_ctx fallback, missing context key, preprocessor coexistence, missing config, malformed config).
- **Out:** wiring `MLXBackend` / `LlamaBackend` to actually consume the probe — intentional follow-up on the umbrella, keeps this PR small enough to review on its own.

## Test plan

- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — all 1093 inference tests pass (including the new 8).
- [x] Sabotage check: forced `supportsVision = false`, confirmed `testProbe_VLM_reportsVision` fails; restored.
- [x] Silent-catch audit (`SilentCatchAuditTest`) passes — no `try?` swallows introduced.

Refs #748, #758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)