### PR TITLE
feat(ui): ChatViewModel.ingestPendingPayload API for extension-driven sessions

### DIFF
--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+IngestPendingPayload.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+IngestPendingPayload.swift
@@ -1,0 +1,335 @@
+import Foundation
+import BaseChatCore
+import BaseChatInference
+
+// MARK: - PendingPayload
+
+/// Content handed to ``ChatViewModel/ingestPendingPayload(_:intent:)``
+/// from a host-app entry point such as a Share Extension, Action
+/// Extension, or App Intent.
+///
+/// Each case maps onto the message-part shape the chat surface already
+/// understands so the ingest path does not need a new wire format. Apps
+/// that already vend ``InboundPayload`` to ``ChatViewModel/ingest(_:)``
+/// continue to work — this API is the public seam for richer entry
+/// points that need to control session lifecycle (new vs. append vs.
+/// draft) without poking at internal state.
+public enum PendingPayload: Sendable {
+
+    /// Plain text — used as the user message body.
+    case text(String)
+
+    /// A URL — serialised into the user message body as its absolute
+    /// string. Hosts that want to attach link metadata should resolve
+    /// the URL themselves and pass the resulting prose as ``text``.
+    case url(URL)
+
+    /// An image, carried verbatim as a ``MessagePart/image`` part.
+    ///
+    /// `mimeType` defaults to `"image/png"` since most extension
+    /// pasteboards expose PNG; pass an explicit value for JPEG, HEIC,
+    /// etc.
+    case image(Data, mimeType: String = "image/png")
+
+    /// A file URL pointing at content the host has already staged
+    /// inside the app group. Today the file's path is rendered into
+    /// the user message body as text — this matches the existing
+    /// ``MessagePart`` surface, which has no file case yet. Image
+    /// files should use ``image(_:mimeType:)`` so they ride as image
+    /// parts.
+    case file(URL)
+}
+
+// MARK: - IngestionPreset
+
+/// Optional configuration applied when ``IngestionIntent/newSession``
+/// creates a fresh session.
+///
+/// Every field is optional — the view model only mutates the matching
+/// state when a value is provided, so partial presets layer cleanly on
+/// top of whatever the user already has selected. Hosts that don't
+/// need any preset can pass `nil` directly to
+/// ``IngestionIntent/newSession(preset:)``.
+///
+/// ## Model selection
+///
+/// ``modelID`` matches against ``ChatViewModel/availableModels`` by
+/// ``ModelInfo/id`` (UUID string) first, then by ``ModelInfo/name``.
+/// If no match is found the current selection is left untouched and a
+/// warning is logged — extensions that hand off before model discovery
+/// has run still get a usable session, just without a forced switch.
+public struct IngestionPreset: Sendable {
+
+    /// Identifier or name of the model to select for the new session.
+    public let modelID: String?
+
+    /// System prompt to install on the new session. Empty string is
+    /// treated as "clear the prompt".
+    public let systemPrompt: String?
+
+    /// Sampling temperature override. `nil` leaves the existing
+    /// session default in place.
+    public let temperature: Float?
+
+    /// Top-P override. `nil` leaves the existing session default in
+    /// place.
+    public let topP: Float?
+
+    /// Repeat-penalty override. `nil` leaves the existing session
+    /// default in place.
+    public let repeatPenalty: Float?
+
+    public init(
+        modelID: String? = nil,
+        systemPrompt: String? = nil,
+        temperature: Float? = nil,
+        topP: Float? = nil,
+        repeatPenalty: Float? = nil
+    ) {
+        self.modelID = modelID
+        self.systemPrompt = systemPrompt
+        self.temperature = temperature
+        self.topP = topP
+        self.repeatPenalty = repeatPenalty
+    }
+}
+
+// MARK: - IngestionIntent
+
+/// How a ``PendingPayload`` should be applied to ``ChatViewModel``.
+public enum IngestionIntent: Sendable {
+
+    /// Create a brand-new chat session, apply the optional preset, and
+    /// seed the payload as the first user message. When a model is
+    /// loaded the message is sent through the same path as the compose
+    /// bar; otherwise the message is left in the input draft so the
+    /// user can confirm after picking a model.
+    case newSession(preset: IngestionPreset?)
+
+    /// Append the payload onto whatever is currently in the input
+    /// draft of the active session. No send, no session creation —
+    /// this is for "add to current chat" affordances.
+    case appendToActive
+
+    /// Set the input draft to the payload's text but do not send it.
+    /// Use this for previewing payloads before the user commits.
+    case draft
+}
+
+// MARK: - ChatViewModel + ingestPendingPayload
+
+extension ChatViewModel {
+
+    /// Hands off content from a Share Extension, Action Extension, App
+    /// Intent, or other host-app entry point to BaseChatKit.
+    ///
+    /// This is the supported public seam for extension-driven session
+    /// creation. It composes existing public APIs on
+    /// ``ChatViewModel`` — session creation, message seeding,
+    /// generation — without exposing ``InferenceService`` to the host.
+    ///
+    /// The behaviour for each ``IngestionIntent`` is:
+    ///
+    /// - ``IngestionIntent/newSession(preset:)``: insert a new
+    ///   ``ChatSessionRecord`` via the configured persistence
+    ///   provider, switch to it, apply the preset (model selection,
+    ///   system prompt, sampler params), seed the payload as a user
+    ///   message, and run ``sendMessage()`` if a model is loaded.
+    ///   When no model is loaded the payload remains as
+    ///   ``inputText`` so the user can pick a model and send manually
+    ///   — this matches the compose-bar contract and avoids surfacing
+    ///   "no model loaded" errors as a launch-time failure.
+    /// - ``IngestionIntent/appendToActive``: append the payload onto
+    ///   the active session's input draft. No persistence write, no
+    ///   send.
+    /// - ``IngestionIntent/draft``: replace the input draft with the
+    ///   payload. No persistence write, no send.
+    ///
+    /// ## Requirements
+    ///
+    /// ``configure(persistence:)`` must have been called before
+    /// ``IngestionIntent/newSession(preset:)`` is used. Without
+    /// persistence the call no-ops after logging a warning. The two
+    /// non-persisting intents (``IngestionIntent/appendToActive``,
+    /// ``IngestionIntent/draft``) work without persistence.
+    ///
+    /// - Parameters:
+    ///   - payload: The content to ingest.
+    ///   - intent: How the payload should be applied to the view
+    ///     model.
+    @MainActor
+    public func ingestPendingPayload(
+        _ payload: PendingPayload,
+        intent: IngestionIntent
+    ) async {
+        Log.ui.info(
+            "ChatViewModel.ingestPendingPayload intent=\(String(describing: intent), privacy: .public) kind=\(payload.kindLabel, privacy: .public)"
+        )
+
+        switch intent {
+        case .newSession(let preset):
+            await ingestAsNewSession(payload, preset: preset)
+        case .appendToActive:
+            ingestByAppendingToDraft(payload)
+        case .draft:
+            ingestAsDraft(payload)
+        }
+    }
+
+    // MARK: - Per-intent helpers
+
+    @MainActor
+    private func ingestAsNewSession(
+        _ payload: PendingPayload,
+        preset: IngestionPreset?
+    ) async {
+        guard let persistence else {
+            Log.ui.warning(
+                "ChatViewModel.ingestPendingPayload(.newSession) called before persistence was configured"
+            )
+            return
+        }
+
+        // Pre-resolve the system prompt so the new session is inserted
+        // with the preset already applied — avoids a second persistence
+        // write when the only change is the system prompt.
+        let session = ChatSessionRecord(
+            title: "New Chat",
+            systemPrompt: preset?.systemPrompt ?? ""
+        )
+        do {
+            try persistence.insertSession(session)
+        } catch {
+            Log.persistence.error(
+                "ChatViewModel.ingestPendingPayload failed to insert session: \(error.localizedDescription)"
+            )
+            surfaceError(error, kind: .persistence)
+            return
+        }
+        switchToSession(session)
+
+        if let preset {
+            applyPreset(preset)
+        }
+
+        // Decompose the payload into a text body plus any rich parts
+        // that ride alongside as MessagePart attachments.
+        let (body, attachments) = payload.intoMessageBody()
+
+        // The input goes through `sendMessage()` so loading checks,
+        // auto-title, token accounting, and any post-generation tasks
+        // all stay consistent with the compose bar. When no model is
+        // loaded `sendMessage()` surfaces a configuration error and
+        // bails out — but we keep the draft populated so the user can
+        // pick a model and resend without retyping.
+        inputText = body
+
+        guard isModelLoaded else {
+            Log.ui.info(
+                "ingestPendingPayload deferring send — no model loaded; draft seeded"
+            )
+            return
+        }
+
+        await sendMessage()
+
+        if !attachments.isEmpty,
+           let userMessage = messages.last(where: { $0.role == .user }) {
+            var updated = userMessage
+            updated.contentParts.append(contentsOf: attachments)
+            do {
+                try updateMessage(updated)
+                if let index = messages.firstIndex(where: { $0.id == userMessage.id }) {
+                    messages[index] = updated
+                }
+            } catch {
+                Log.persistence.warning(
+                    "ingestPendingPayload failed to persist attachments: \(error.localizedDescription)"
+                )
+            }
+        }
+    }
+
+    @MainActor
+    private func ingestByAppendingToDraft(_ payload: PendingPayload) {
+        let (body, _) = payload.intoMessageBody()
+        guard !body.isEmpty else { return }
+
+        if inputText.isEmpty {
+            inputText = body
+        } else {
+            // Single newline between the existing draft and the appended
+            // payload keeps multi-paragraph drafts readable without
+            // collapsing the user's prior whitespace.
+            inputText = inputText + "\n" + body
+        }
+    }
+
+    @MainActor
+    private func ingestAsDraft(_ payload: PendingPayload) {
+        let (body, _) = payload.intoMessageBody()
+        inputText = body
+    }
+
+    @MainActor
+    private func applyPreset(_ preset: IngestionPreset) {
+        if let modelID = preset.modelID {
+            if let match = availableModels.first(where: { $0.id.uuidString == modelID })
+                ?? availableModels.first(where: { $0.name == modelID }) {
+                selectedModel = match
+            } else {
+                Log.ui.warning(
+                    "ingestPendingPayload preset.modelID=\(modelID, privacy: .public) not found in availableModels"
+                )
+            }
+        }
+        if let systemPrompt = preset.systemPrompt {
+            self.systemPrompt = systemPrompt
+        }
+        if let temperature = preset.temperature {
+            self.temperature = temperature
+        }
+        if let topP = preset.topP {
+            self.topP = topP
+        }
+        if let repeatPenalty = preset.repeatPenalty {
+            self.repeatPenalty = repeatPenalty
+        }
+    }
+}
+
+// MARK: - PendingPayload helpers
+
+private extension PendingPayload {
+
+    /// Short label used in logs so payload kind is visible without
+    /// leaking the actual content.
+    var kindLabel: String {
+        switch self {
+        case .text: return "text"
+        case .url: return "url"
+        case .image: return "image"
+        case .file: return "file"
+        }
+    }
+
+    /// Splits the payload into a text body for ``ChatViewModel/inputText``
+    /// and any rich ``MessagePart`` attachments that should ride
+    /// alongside the user message.
+    func intoMessageBody() -> (body: String, attachments: [MessagePart]) {
+        switch self {
+        case .text(let string):
+            return (string, [])
+        case .url(let url):
+            return (url.absoluteString, [])
+        case .image(let data, let mimeType):
+            return ("", [.image(data: data, mimeType: mimeType)])
+        case .file(let url):
+            // No file part exists in MessagePart yet (issue #441 will
+            // add one), so render the path as the message body. This
+            // is the same fallback used by the existing extension
+            // recipes and keeps the shape stable for callers.
+            return (url.path, [])
+        }
+    }
+}

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+IngestPendingPayload.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+IngestPendingPayload.swift
@@ -210,6 +210,17 @@ extension ChatViewModel {
 
         if let preset {
             applyPreset(preset)
+            // Persist the preset onto the session record so sampler params,
+            // selected model, and system prompt survive a relaunch — without
+            // this, only the live VM state has the preset values and they
+            // get lost when the session is reloaded.
+            do {
+                try saveSettingsToSession()
+            } catch {
+                Log.persistence.warning(
+                    "ingestPendingPayload failed to persist preset to session: \(error.localizedDescription)"
+                )
+            }
         }
 
         // Decompose the payload into a text body plus any rich parts

--- a/Tests/BaseChatUITests/ChatViewModelIngestPendingPayloadTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelIngestPendingPayloadTests.swift
@@ -98,13 +98,16 @@ final class ChatViewModelIngestPendingPayloadTests: XCTestCase {
         XCTAssertEqual(vm.topP, 0.5)
         XCTAssertEqual(vm.repeatPenalty, 1.25)
 
-        // The preset's system prompt is persisted on the new session row
-        // so a relaunch (which reloads systemPrompt from the session)
+        // The preset is persisted on the new session row so a relaunch
+        // (which reloads sampler params + system prompt from the session)
         // continues to see it.
         guard let activeSession = vm.activeSession else {
             return XCTFail("Expected an active session")
         }
         XCTAssertEqual(activeSession.systemPrompt, "You are a poet.")
+        XCTAssertEqual(activeSession.temperature, 0.42)
+        XCTAssertEqual(activeSession.topP, 0.5)
+        XCTAssertEqual(activeSession.repeatPenalty, 1.25)
     }
 
     func test_textPayload_newSession_withoutModelLoaded_seedsDraftWithoutSending() async {

--- a/Tests/BaseChatUITests/ChatViewModelIngestPendingPayloadTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelIngestPendingPayloadTests.swift
@@ -1,0 +1,239 @@
+@preconcurrency import XCTest
+import SwiftData
+@testable import BaseChatUI
+@testable import BaseChatCore
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Integration tests for ``ChatViewModel/ingestPendingPayload(_:intent:)``.
+///
+/// These exercise every payload × intent cell against a real in-memory
+/// SwiftData store and a ``MockInferenceBackend``. By classification
+/// these are integration tests (per CLAUDE.md) — they hit SwiftData
+/// end-to-end through the same persistence provider production uses.
+@MainActor
+final class ChatViewModelIngestPendingPayloadTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+    private var vm: ChatViewModel!
+    private var mock: MockInferenceBackend!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        container = try makeInMemoryContainer()
+        context = container.mainContext
+
+        mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.tokensToYield = ["ack"]
+
+        let service = InferenceService(backend: mock, name: "MockIngestPending")
+        vm = ChatViewModel(inferenceService: service)
+        vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
+    }
+
+    override func tearDown() async throws {
+        vm = nil
+        mock = nil
+        context = nil
+        container = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func fetchSessions() -> [ChatSession] {
+        let descriptor = FetchDescriptor<ChatSession>(
+            sortBy: [SortDescriptor(\.updatedAt, order: .reverse)]
+        )
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
+    private func fetchMessages(for sessionID: UUID) -> [ChatMessage] {
+        let descriptor = FetchDescriptor<ChatMessage>(
+            predicate: #Predicate { $0.sessionID == sessionID },
+            sortBy: [SortDescriptor(\.timestamp)]
+        )
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
+    // MARK: - text × .newSession
+
+    func test_textPayload_newSession_createsSessionAndSendsMessage() async {
+        XCTAssertTrue(fetchSessions().isEmpty)
+
+        await vm.ingestPendingPayload(
+            .text("draft an email"),
+            intent: .newSession(preset: nil)
+        )
+
+        let sessions = fetchSessions()
+        XCTAssertEqual(sessions.count, 1, "newSession should create exactly one session")
+        XCTAssertNotNil(vm.activeSession, "Active session should be set")
+
+        let messages = fetchMessages(for: vm.activeSession!.id)
+        XCTAssertGreaterThanOrEqual(messages.count, 1)
+        XCTAssertEqual(messages.first?.role, .user)
+        XCTAssertEqual(messages.first?.content, "draft an email")
+    }
+
+    func test_textPayload_newSession_appliesPreset() async {
+        let preset = IngestionPreset(
+            modelID: nil,
+            systemPrompt: "You are a poet.",
+            temperature: 0.42,
+            topP: 0.5,
+            repeatPenalty: 1.25
+        )
+
+        await vm.ingestPendingPayload(
+            .text("Compose a haiku."),
+            intent: .newSession(preset: preset)
+        )
+
+        XCTAssertEqual(vm.systemPrompt, "You are a poet.")
+        XCTAssertEqual(vm.temperature, 0.42)
+        XCTAssertEqual(vm.topP, 0.5)
+        XCTAssertEqual(vm.repeatPenalty, 1.25)
+
+        // The preset's system prompt is persisted on the new session row
+        // so a relaunch (which reloads systemPrompt from the session)
+        // continues to see it.
+        guard let activeSession = vm.activeSession else {
+            return XCTFail("Expected an active session")
+        }
+        XCTAssertEqual(activeSession.systemPrompt, "You are a poet.")
+    }
+
+    func test_textPayload_newSession_withoutModelLoaded_seedsDraftWithoutSending() async {
+        // Drive the lifecycle's view of "loaded" rather than poking the
+        // raw mock flag — the service's init(backend:) preloads the
+        // backend, so we have to unload to flip `vm.isModelLoaded`.
+        vm.inferenceService.unloadModel()
+        XCTAssertFalse(vm.isModelLoaded, "Precondition: no model loaded")
+
+        await vm.ingestPendingPayload(
+            .text("waiting for a model"),
+            intent: .newSession(preset: nil)
+        )
+
+        XCTAssertNotNil(vm.activeSession, "Session is still created")
+        XCTAssertEqual(vm.inputText, "waiting for a model", "Draft is preserved when no model is loaded")
+        // No user message should have been written: sendMessage() never ran.
+        let messages = fetchMessages(for: vm.activeSession!.id)
+        XCTAssertTrue(messages.isEmpty, "No messages persisted without an active model")
+    }
+
+    // MARK: - url × .appendToActive
+
+    func test_urlPayload_appendToActive_appendsURLStringToDraft() async {
+        // Seed a session and an existing draft.
+        let session = ChatSessionRecord(title: "Existing")
+        try? vm.persistence?.insertSession(session)
+        vm.switchToSession(session)
+        vm.inputText = "look at this"
+
+        let url = URL(string: "https://example.com/article")!
+        await vm.ingestPendingPayload(.url(url), intent: .appendToActive)
+
+        XCTAssertEqual(
+            vm.inputText,
+            "look at this\nhttps://example.com/article",
+            "URL should be appended after a newline"
+        )
+        // No new session should have been created.
+        XCTAssertEqual(fetchSessions().count, 1)
+    }
+
+    func test_urlPayload_appendToActive_emptyDraft_replacesWithURLString() async {
+        let session = ChatSessionRecord(title: "Existing")
+        try? vm.persistence?.insertSession(session)
+        vm.switchToSession(session)
+        vm.inputText = ""
+
+        let url = URL(string: "https://example.com/article")!
+        await vm.ingestPendingPayload(.url(url), intent: .appendToActive)
+
+        XCTAssertEqual(vm.inputText, "https://example.com/article")
+    }
+
+    // MARK: - image × .draft
+
+    func test_imagePayload_draft_setsEmptyDraftWithoutSending() async {
+        let session = ChatSessionRecord(title: "Existing")
+        try? vm.persistence?.insertSession(session)
+        vm.switchToSession(session)
+        vm.inputText = "should be replaced"
+
+        let imageData = Data([0x89, 0x50, 0x4E, 0x47]) // PNG magic bytes
+        await vm.ingestPendingPayload(
+            .image(imageData, mimeType: "image/png"),
+            intent: .draft
+        )
+
+        // Image payloads don't carry a text body — the draft is cleared
+        // since attachment-only drafts can't be sent through the
+        // current compose-bar contract. The host is expected to show
+        // the staged image preview in its own UI.
+        XCTAssertEqual(vm.inputText, "")
+
+        // No new messages should have been persisted.
+        let messages = fetchMessages(for: session.id)
+        XCTAssertTrue(messages.isEmpty)
+    }
+
+    // MARK: - file × .newSession
+
+    func test_filePayload_newSession_seedsFilePathAsMessage() async {
+        let fileURL = URL(fileURLWithPath: "/tmp/sample.txt")
+
+        await vm.ingestPendingPayload(
+            .file(fileURL),
+            intent: .newSession(preset: nil)
+        )
+
+        let sessions = fetchSessions()
+        XCTAssertEqual(sessions.count, 1)
+        guard let activeSession = vm.activeSession else {
+            return XCTFail("Expected an active session")
+        }
+
+        let messages = fetchMessages(for: activeSession.id)
+        XCTAssertGreaterThanOrEqual(messages.count, 1)
+        XCTAssertEqual(messages.first?.role, .user)
+        // File payloads currently render their path as the user message
+        // body — see PendingPayload.intoMessageBody().
+        XCTAssertEqual(messages.first?.content, "/tmp/sample.txt")
+    }
+
+    // MARK: - Without persistence
+
+    func test_newSession_withoutPersistence_noops() async {
+        let unconfigured = ChatViewModel(
+            inferenceService: InferenceService(backend: mock, name: "NoPersistence")
+        )
+        // Deliberately do NOT call configure(persistence:).
+
+        await unconfigured.ingestPendingPayload(
+            .text("nope"),
+            intent: .newSession(preset: nil)
+        )
+
+        XCTAssertNil(unconfigured.activeSession)
+        XCTAssertTrue(unconfigured.messages.isEmpty)
+    }
+
+    func test_draft_withoutPersistence_stillSetsInputText() async {
+        let unconfigured = ChatViewModel(
+            inferenceService: InferenceService(backend: mock, name: "NoPersistence")
+        )
+
+        await unconfigured.ingestPendingPayload(.text("hello"), intent: .draft)
+
+        // .draft does not require persistence — the host can wire it
+        // up before a SwiftData container is open.
+        XCTAssertEqual(unconfigured.inputText, "hello")
+    }
+}


### PR DESCRIPTION
## Summary

Adds a public seam on `ChatViewModel` so Share Extensions, Action Extensions, and AppIntents can hand off content without poking at internal state. The new API composes the existing public surface — `inferenceService` stays internal per CLAUDE.md.

```swift
public enum PendingPayload: Sendable {
    case text(String)
    case url(URL)
    case image(Data, mimeType: String = "image/png")
    case file(URL)
}

public struct IngestionPreset: Sendable {
    public let modelID: String?           // matches ModelInfo.id (UUID string) or .name
    public let systemPrompt: String?
    public let temperature: Float?
    public let topP: Float?
    public let repeatPenalty: Float?
}

public enum IngestionIntent: Sendable {
    case newSession(preset: IngestionPreset?)
    case appendToActive
    case draft
}

extension ChatViewModel {
    @MainActor
    public func ingestPendingPayload(_ payload: PendingPayload, intent: IngestionIntent) async
}
```

## Behaviour by intent

- **`.newSession`** — inserts a fresh `ChatSessionRecord` via the configured persistence provider, switches to it, applies the preset (model match-by-UUID-then-name, system prompt, sampler), seeds the payload as the next user message, and runs `sendMessage()` when a model is loaded. When no model is loaded the payload remains as `inputText` — matching the compose-bar contract.
- **`.appendToActive`** — concatenates the payload onto the current `inputText` (newline-separated when the draft is non-empty). No persistence write, no send.
- **`.draft`** — replaces `inputText` with the payload. Works without persistence so hosts can wire it up before the SwiftData container opens.

URL payloads serialise to their absolute string. File payloads render as their path (no `.file` `MessagePart` exists yet — issue #441 will introduce one). Image payloads ride as a `MessagePart.image` attachment alongside the user message; for `.draft` the input text is cleared since attachment-only drafts are not sendable through the current compose-bar contract.

## Test plan

- [x] New integration suite `ChatViewModelIngestPendingPayloadTests` covers each requested cell — text-newSession (with and without preset / model loaded), url-appendToActive (empty + populated draft), image-draft, file-newSession, plus persistence-not-configured no-op paths.
- [x] Sabotage check on the `appendToActive` path confirmed both URL append tests fail when the implementation is broken.
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 488 tests pass.
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 214 tests pass (4 skipped).
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 1085 tests pass.

Closes #442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)