### PR TITLE
feat(inference): pause generation when ProcessInfo.thermalState reaches .critical

### DIFF
--- a/Sources/BaseChatFuzz/EventRecorder.swift
+++ b/Sources/BaseChatFuzz/EventRecorder.swift
@@ -81,6 +81,8 @@ public struct EventRecorder: Sendable {
                     events.append(.init(t: t, kind: "toolLoopLimitReached", v: "\(iterations)"))
                 case .kvCacheReuse(let tokens):
                     events.append(.init(t: t, kind: "kvCacheReuse", v: "\(tokens)"))
+                case .diagnosticThrottle(let reason):
+                    events.append(.init(t: t, kind: "diagnosticThrottle", v: reason))
                 }
                 memoryTick()
             }

--- a/Sources/BaseChatInference/Models/GenerationEvent.swift
+++ b/Sources/BaseChatInference/Models/GenerationEvent.swift
@@ -45,4 +45,13 @@ public enum GenerationEvent: Sendable, Equatable {
     /// from the previous turn. `promptTokensReused` is the number of prompt tokens
     /// whose KV state was preserved, saving their re-decode cost.
     case kvCacheReuse(promptTokensReused: Int)
+
+    /// Emitted by the orchestrator when generation has been paused for a
+    /// runtime-side condition (e.g. `ProcessInfo.thermalState == .critical`).
+    ///
+    /// Fired exactly once per pause cycle — on entry into the wait loop, not
+    /// on every re-check tick. UI surfaces can use this to show a "device
+    /// throttling — paused" hint while the loop blocks between tokens.
+    /// `reason` is a short, human-readable string the UI may display verbatim.
+    case diagnosticThrottle(reason: String)
 }

--- a/Sources/BaseChatInference/Services/GenerationCoordinator.swift
+++ b/Sources/BaseChatInference/Services/GenerationCoordinator.swift
@@ -30,6 +30,20 @@ final class GenerationCoordinator {
     /// non-isolated so it is safe under Swift 6 strict concurrency.
     private let thermalStateProvider: @Sendable () -> ProcessInfo.ThermalState
 
+    /// Sleep hook used by the per-token thermal-pause loop. Defaults to
+    /// `Task.sleep(for:)`. Tests override this to skip the real 2-second
+    /// re-check delay and to count how many times the loop slept.
+    ///
+    /// Throws `CancellationError` when the surrounding task is cancelled —
+    /// the caller propagates that to abort the wait loop alongside a
+    /// regular state transition.
+    private let thermalSleep: @Sendable (Duration) async throws -> Void
+
+    /// Re-check delay between thermal polls when generation is paused.
+    /// Pulled out so the test seam injects only the sleep behaviour, not
+    /// the cadence — keeps the production cadence in production code.
+    private static let thermalRecheckInterval: Duration = .seconds(2)
+
     /// Optional registry used to dispatch model-emitted ``ToolCall`` events.
     ///
     /// Stored here in wave 1 so the coordinator's init surface is stable for
@@ -92,10 +106,12 @@ final class GenerationCoordinator {
 
     nonisolated init(
         thermalStateProvider: @Sendable @escaping () -> ProcessInfo.ThermalState = { ProcessInfo.processInfo.thermalState },
+        thermalSleep: @Sendable @escaping (Duration) async throws -> Void = { try await Task.sleep(for: $0) },
         toolRegistry: ToolRegistry? = nil,
         toolApprovalGate: any ToolApprovalGate = AutoApproveGate()
     ) {
         self.thermalStateProvider = thermalStateProvider
+        self.thermalSleep = thermalSleep
         self.toolRegistry = toolRegistry
         self.toolApprovalGate = toolApprovalGate
     }
@@ -494,6 +510,52 @@ final class GenerationCoordinator {
         }
     }
 
+    // MARK: - Thermal pause
+
+    /// Cooperatively pauses the per-token loop while the device is in
+    /// `.critical` thermal state. Returns immediately when thermal state is
+    /// `.serious` or below, or when the surrounding task has been cancelled.
+    ///
+    /// Emits `GenerationEvent.diagnosticThrottle` exactly once per pause
+    /// cycle — on entry, before the first sleep — so UI surfaces can show
+    /// "device throttling — paused" without being spammed every re-check.
+    /// Generation resumes silently when thermal pressure drops; downstream
+    /// `.token` events resuming after the pause is the implicit "resumed"
+    /// signal.
+    private func pauseWhileThermalCritical(
+        token: GenerationRequestToken
+    ) async {
+        guard thermalStateProvider() == .critical else { return }
+
+        // Entry-only event: spamming the continuation on every re-check would
+        // bloat the stream and make UI debouncing harder. The event is fired
+        // once and the consumer keeps showing the throttle hint until the
+        // next regular event flows through.
+        self.continuations[token]?.yield(
+            .diagnosticThrottle(reason: "thermalState=.critical")
+        )
+        Log.inference.warning(
+            "GenerationCoordinator: pausing generation — ProcessInfo.thermalState == .critical"
+        )
+
+        while !Task.isCancelled {
+            do {
+                try await thermalSleep(Self.thermalRecheckInterval)
+            } catch {
+                // Sleep was cancelled — propagate by exiting the loop. The
+                // outer `for try await event in stream.events` will observe
+                // `Task.isCancelled` on its next iteration.
+                return
+            }
+            if thermalStateProvider() != .critical {
+                Log.inference.info(
+                    "GenerationCoordinator: thermal state dropped below .critical — resuming generation"
+                )
+                return
+            }
+        }
+    }
+
     // MARK: - Tool Dispatch Loop
 
     /// Upper bound on cumulative bytes of tool-result content that can be
@@ -592,6 +654,14 @@ final class GenerationCoordinator {
             var dispatchedInThisTurn: [(ToolCall, ToolResult)] = []
 
             for try await event in stream.events {
+                guard !Task.isCancelled else { return }
+
+                // Thermal gate (cooperative): if the device is in `.critical`
+                // thermal state, pause between tokens until pressure drops to
+                // `.serious` or below, or until the surrounding task is
+                // cancelled. This is a no-op on the hot path — one provider
+                // read per event when temperature is fine.
+                await pauseWhileThermalCritical(token: request.token)
                 guard !Task.isCancelled else { return }
 
                 if case .token = event, request.stream.phase != .streaming {

--- a/Sources/BaseChatInference/Services/GenerationStreamConsumer.swift
+++ b/Sources/BaseChatInference/Services/GenerationStreamConsumer.swift
@@ -39,6 +39,13 @@ public struct GenerationStreamConsumer: Sendable {
 
         case .kvCacheReuse:
             return .ignore
+
+        case .diagnosticThrottle:
+            // Throttle hints are advisory metadata; the consumer has no
+            // text/usage state to mutate. UI surfaces that want to render
+            // a "paused — device throttling" badge observe the raw event
+            // upstream instead of going through the action mapping.
+            return .ignore
         }
     }
 

--- a/Sources/BaseChatTools/ScenarioRunner.swift
+++ b/Sources/BaseChatTools/ScenarioRunner.swift
@@ -93,6 +93,10 @@ public final class ScenarioRunner {
                     continue
                 case .kvCacheReuse:
                     continue
+                case .diagnosticThrottle:
+                    // Advisory pause signal from the orchestrator; scenarios
+                    // are deterministic replays so we just keep accumulating.
+                    continue
                 }
             }
 

--- a/Tests/BaseChatInferenceTests/GenerationCoordinatorTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationCoordinatorTests.swift
@@ -643,6 +643,81 @@ final class GenerationCoordinatorTests: XCTestCase {
         )
     }
 
+    /// `stopGenerationAndWait()` must unwind cleanly while the per-token
+    /// loop is parked in the thermal-pause re-check loop — no deadlock,
+    /// no hang waiting for thermal state to drop. The pause loop bails on
+    /// `Task.isCancelled` and propagates `CancellationError` thrown by the
+    /// injected `thermalSleep` hook (the production default `Task.sleep(for:)`
+    /// throws on cancellation).
+    ///
+    /// We invoke `stopGenerationAndWait()` so the assertion fails fast if
+    /// the loop fails to observe cancellation: the await will simply hang
+    /// past the test's overall deadline, surfaced here as a 2s race timeout.
+    ///
+    /// Sabotage check: change `while !Task.isCancelled` in
+    /// `pauseWhileThermalCritical` to `while true` AND swallow the
+    /// `CancellationError` in the catch (e.g. `continue`). With both
+    /// guards removed the activeTask spins forever and the
+    /// `stopGenerationAndWait()` await never returns — the timeout race
+    /// returns `false` and the assertion fails.
+    func test_perTokenLoop_thermalPause_cancellationUnwindsCleanly() async throws {
+        // Provider always reports `.critical` so the pause loop would
+        // otherwise spin forever. Cancellation is the only exit.
+        let coord = GenerationCoordinator(
+            thermalStateProvider: { @Sendable in .critical },
+            thermalSleep: { @Sendable duration in
+                // Forward to the real sleep so the cooperative cancellation
+                // contract is exercised end-to-end. The duration is the
+                // production 2s cadence, but cancellation should fire the
+                // throw long before that.
+                try await Task.sleep(for: duration)
+            }
+        )
+        coord.provider = provider
+        provider.backend.tokensToYield = ["a", "b"]
+
+        let (_, stream) = try coord.enqueue(
+            messages: [("user", "hi")], priority: .normal
+        )
+
+        // Drain the stream until we see the throttle event, then trigger
+        // cancellation. We don't fully drain here — `stopGenerationAndWait`
+        // below is the real assertion that the activeTask unwinds.
+        var sawThrottle = false
+        for try await event in stream.events {
+            if case .diagnosticThrottle = event {
+                sawThrottle = true
+                break
+            }
+        }
+        XCTAssertTrue(
+            sawThrottle,
+            "pause loop must emit a throttle event before we cancel; otherwise the test isn't exercising the pause path"
+        )
+
+        // Race `stopGenerationAndWait()` against a 2s wall-clock deadline.
+        // If the pause loop ignores `Task.isCancelled` the wait hangs
+        // forever and the race returns `false`.
+        let unwoundCleanly = await withTaskGroup(of: Bool.self, returning: Bool.self) { group in
+            group.addTask {
+                await coord.stopGenerationAndWait()
+                return true
+            }
+            group.addTask {
+                try? await Task.sleep(for: .seconds(2))
+                return false
+            }
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
+
+        XCTAssertTrue(
+            unwoundCleanly,
+            "stopGenerationAndWait() must return promptly while the pause loop is parked — pause loop must observe Task.isCancelled and propagate the CancellationError thrown by thermalSleep"
+        )
+    }
+
     // MARK: - Exact preflight (TokenCountingBackend)
 
     /// When the backend fits within the context window on the first count,

--- a/Tests/BaseChatInferenceTests/GenerationCoordinatorTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationCoordinatorTests.swift
@@ -554,6 +554,95 @@ final class GenerationCoordinatorTests: XCTestCase {
         )
     }
 
+    // MARK: - Thermal pause (#745)
+
+    /// When the per-token loop sees `.critical` thermal state mid-stream, the
+    /// coordinator must pause via the injected sleep hook, re-check the
+    /// provider after each sleep, and resume cleanly when the state drops
+    /// below `.critical`. Exactly one `.diagnosticThrottle` event must be
+    /// emitted per pause cycle (not one per re-check tick).
+    ///
+    /// The test injects a deterministic provider that returns `.critical` for
+    /// the first two reads then `.nominal`, plus a sleep hook that records
+    /// each call instead of actually sleeping. This keeps the test in
+    /// real-time without any fixed delays.
+    ///
+    /// Sabotage check: deleting the `await pauseWhileThermalCritical(...)`
+    /// call inside the per-event loop drops the throttle-event count to 0
+    /// and the sleep-call count to 0; both assertions fail.
+    func test_perTokenLoop_criticalThermal_pausesAndEmitsSingleThrottleEvent() async throws {
+        // Provider script: `.critical, .critical, .nominal, .nominal, ...`
+        // Returning the same final state forever lets the second token's
+        // entry check flow through without another pause.
+        let thermalReads = ThermalReadCounter()
+        let states: [ProcessInfo.ThermalState] = [.critical, .critical, .nominal]
+
+        let sleepCalls = SleepCallCounter()
+
+        let coord = GenerationCoordinator(
+            thermalStateProvider: { @Sendable in
+                let idx = thermalReads.next()
+                return idx < states.count ? states[idx] : .nominal
+            },
+            thermalSleep: { @Sendable _ in
+                sleepCalls.bump()
+                // Yield to keep the cooperative-cancellation contract; do
+                // not actually sleep — the test must complete in well
+                // under the production 2-second cadence.
+                await Task.yield()
+            }
+        )
+        coord.provider = provider
+
+        provider.backend.tokensToYield = ["a", "b"]
+
+        let (_, stream) = try coord.enqueue(
+            messages: [("user", "hi")], priority: .normal
+        )
+
+        var tokens: [String] = []
+        var throttleEvents: [String] = []
+        for try await event in stream.events {
+            switch event {
+            case .token(let t):
+                tokens.append(t)
+            case .diagnosticThrottle(let reason):
+                throttleEvents.append(reason)
+            default:
+                break
+            }
+        }
+
+        XCTAssertEqual(tokens, ["a", "b"], "generation must complete after pause")
+        XCTAssertEqual(
+            throttleEvents.count, 1,
+            "exactly one .diagnosticThrottle event must be emitted per pause cycle, not per re-check"
+        )
+        XCTAssertTrue(
+            throttleEvents.first?.contains("critical") ?? false,
+            "throttle reason must reference the thermal state"
+        )
+        XCTAssertGreaterThanOrEqual(
+            sleepCalls.count, 1,
+            "loop must have slept at least once while waiting for thermal state to drop"
+        )
+        // First two reads were `.critical`, so the loop polls until the
+        // third read sees `.nominal`. That means at least two sleeps fired
+        // before resume — proves the loop didn't bail on the first re-check.
+        XCTAssertEqual(
+            sleepCalls.count, 2,
+            "loop must keep sleeping while state stays .critical and exit on the read that returns .nominal"
+        )
+        // Provider was read at least four times: once on entry to the
+        // pause for the first event (.critical), twice inside the
+        // re-check loop (.critical, .nominal), and at minimum once more
+        // for the second event's entry guard (.nominal → no pause).
+        XCTAssertGreaterThanOrEqual(
+            thermalReads.count, 4,
+            "provider must be polled on entry plus once per re-check tick"
+        )
+    }
+
     // MARK: - Exact preflight (TokenCountingBackend)
 
     /// When the backend fits within the context window on the first count,
@@ -822,6 +911,52 @@ private final class WarningCapture: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return entries
+    }
+}
+
+// MARK: - Thermal-pause test counters (#745)
+
+/// Records each invocation of the injected `thermalStateProvider` and
+/// returns a strictly increasing index, so the test script can drive the
+/// pause loop through `.critical → .critical → .nominal` without a stateful
+/// closure capture. Lock-protected because the provider is `@Sendable` and
+/// may be invoked off the test's MainActor isolation.
+private final class ThermalReadCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var index = 0
+
+    func next() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        let i = index
+        index += 1
+        return i
+    }
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return index
+    }
+}
+
+/// Counts calls to the injected `thermalSleep` hook so the test can
+/// assert how many re-check ticks the pause loop performed without
+/// burning real wall-clock time on `Task.sleep`.
+private final class SleepCallCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _count = 0
+
+    func bump() {
+        lock.lock()
+        defer { lock.unlock() }
+        _count += 1
+    }
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _count
     }
 }
 

--- a/Tests/BaseChatInferenceTests/ToolCallContractTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolCallContractTests.swift
@@ -206,6 +206,7 @@ final class ToolCallContractTests: XCTestCase {
             case .thinkingToken, .thinkingComplete: break
             case .toolResult, .toolLoopLimitReached: break
             case .kvCacheReuse: break
+            case .diagnosticThrottle: break
             }
         }
 
@@ -275,6 +276,7 @@ final class ToolCallContractTests: XCTestCase {
             case .thinkingToken, .thinkingComplete: break
             case .toolResult, .toolLoopLimitReached: break
             case .kvCacheReuse: break
+            case .diagnosticThrottle: break
             }
         }
 


### PR DESCRIPTION
## Summary

Closes #745. Part of umbrella #758.

Wires a cooperative thermal gate into `GenerationCoordinator.runToolDispatchLoop` so that under `.critical` thermal pressure the per-token loop parks on a 2-second re-check instead of letting the device thermally throttle generation into a slow crawl. Resumption is automatic when state drops to `.serious` or below, or when the surrounding task is cancelled.

- New `GenerationEvent.diagnosticThrottle(reason:)` case so UI surfaces can render a "device throttling — paused" hint. Emitted **once per pause cycle** (on entry, before the first sleep) — not on every re-check tick.
- New `thermalSleep` DI seam alongside the existing `thermalStateProvider` seam so unit tests can drive the pause loop deterministically without burning real wall-clock time. Production default is `Task.sleep(for:)`.
- One unit test (`test_perTokenLoop_criticalThermal_pausesAndEmitsSingleThrottleEvent`) drives the loop through `.critical → .critical → .nominal`, asserts exactly one throttle event was emitted, and counts both the sleep invocations and provider polls to prove the loop didn't bail on the first re-check. Sabotage check: deleting the `await pauseWhileThermalCritical(...)` call drops every assertion to zero.
- Exhaustive `switch` over `GenerationEvent` in `GenerationStreamConsumer`, `ScenarioRunner`, `EventRecorder`, and `ToolCallContractTests` gains matching cases. Existing `default`-fallthrough switches need no change.

The check fires on every event (one provider read per event when temperature is fine — cheap), so the existing `.background`-priority pre-flight thermal drop in `drainQueue` is unchanged and complementary.

## Release Note

`GenerationCoordinator` now pauses active generation when `ProcessInfo.thermalState` reaches `.critical` and resumes when it drops to `.serious` or below, instead of letting the device thermally throttle the per-token loop. UI surfaces can subscribe to the new `GenerationEvent.diagnosticThrottle(reason:)` event to render a "device throttling — paused" badge while the loop is parked. Pure-additive: existing switches over `GenerationEvent` that use `default:` need no change; the four exhaustive switches in this repo were updated in the same PR.

## Test plan

- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits --skip-update` — 1086 tests, 0 failures
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits --skip-update`
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits --skip-update`
- [x] `swift test --filter BaseChatUITests --disable-default-traits --skip-update`
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits --skip-update`
- [x] `swift test --filter BaseChatTestSupportTests --disable-default-traits --skip-update`
- [x] Sabotage check on the new test — deleting the `await pauseWhileThermalCritical(...)` call fails all five assertions on the new test as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)