### PR TITLE
chore(ci): MockBackend lock, audit allowlist, workflow hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,33 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
             ${{ runner.os }}-${{ runner.arch }}-spm-
 
+      - name: Verify Swift toolchain matches Package.swift tools-version
+        # The runner's Xcode (pinned above) ships a specific Swift version. If
+        # `swift-tools-version` in Package.swift exceeds that, `swift package
+        # resolve` and every subsequent build will fail with a confusing error.
+        # Catch the mismatch here with a clear message naming both versions.
+        run: |
+          set -euo pipefail
+          tools_line=$(head -n 1 Package.swift)
+          tools_version=$(printf '%s\n' "$tools_line" | sed -E 's|^//[[:space:]]*swift-tools-version:[[:space:]]*([0-9]+\.[0-9]+).*|\1|')
+          if ! [[ "$tools_version" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "Could not parse swift-tools-version from first line of Package.swift: $tools_line"
+            exit 1
+          fi
+          swift_version_full=$(xcrun swift -version | head -n 1)
+          swift_version=$(printf '%s\n' "$swift_version_full" | sed -E 's|.*Swift version ([0-9]+\.[0-9]+).*|\1|')
+          if ! [[ "$swift_version" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "Could not parse Swift major.minor from: $swift_version_full"
+            exit 1
+          fi
+          tools_major=${tools_version%.*}; tools_minor=${tools_version#*.}
+          swift_major=${swift_version%.*}; swift_minor=${swift_version#*.}
+          if (( tools_major > swift_major )) || { (( tools_major == swift_major )) && (( tools_minor > swift_minor )); }; then
+            echo "::error::Package.swift requires swift-tools-version $tools_version but runner has Swift $swift_version. Lower swift-tools-version or upgrade the pinned Xcode."
+            exit 1
+          fi
+          echo "swift-tools-version=$tools_version OK against runner Swift $swift_version"
+
       - name: Verify Package.resolved is up to date
         # Was a separate `resolve-check` job on its own macos-15 runner; folding
         # it into `test` removes one 10×-billed runner per PR and eliminates the
@@ -121,7 +148,38 @@ jobs:
       # execution avoids that and `--parallel` would still need a UI-test-only
       # carve-out, which negates most of the speedup anyway.
       - name: Test — XCTest suites (Core + UI + Backends + Inference + TestSupport)
+        timeout-minutes: 25
         run: scripts/test.sh --filter BaseChatCoreTests --filter BaseChatUITests --filter BaseChatBackendsTests --filter BaseChatInferenceTests --filter BaseChatTestSupportTests --disable-default-traits --skip-update
 
       - name: Test — Inference (Swift Testing, isolated process)
+        timeout-minutes: 25
         run: scripts/test.sh --filter BaseChatInferenceSwiftTestingTests --disable-default-traits --skip-update
+
+      - name: Stage test diagnostics
+        # scripts/test.sh writes full captured output to $TMPDIR/test_output.txt
+        # but $TMPDIR on macOS runners is a per-process /var/folders path that
+        # actions/upload-artifact cannot reliably address. Copy into the
+        # workspace so the upload step below can find it. Each test step
+        # overwrites this file, so on failure it holds the failing step's log.
+        if: failure()
+        run: |
+          mkdir -p test-diagnostics
+          if [ -n "${TMPDIR:-}" ] && [ -f "${TMPDIR}/test_output.txt" ]; then
+            cp "${TMPDIR}/test_output.txt" test-diagnostics/test_output.txt
+          fi
+          # Best-effort: copy any xcresult bundles a future xcodebuild step
+          # might have produced under DerivedData.
+          find "${HOME}/Library/Developer/Xcode/DerivedData" -type d -name "*.xcresult" -maxdepth 6 2>/dev/null \
+            | while read -r r; do cp -R "$r" test-diagnostics/ || true; done
+
+      - name: Upload test diagnostics on failure
+        # swift test does not produce .xcresult bundles, so we upload whatever
+        # diagnostics the failing step left behind (captured stdout/stderr,
+        # plus any xcresult bundles if they exist).
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: xcresult-${{ github.run_attempt }}
+          if-no-files-found: ignore
+          retention-days: 7
+          path: test-diagnostics/

--- a/Package.swift
+++ b/Package.swift
@@ -158,7 +158,12 @@ let package = Package(
                 "BaseChatTestSupport",
                 "BaseChatMacrosPlugin",
                 .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
-            ]
+            ],
+            // SilentCatchAuditTest reads `silent_catch_allowlist.txt` directly
+            // from its on-disk source location via `#filePath`, so we don't
+            // need to bundle it into the test binary — just tell SwiftPM to
+            // ignore it when collecting resources.
+            exclude: ["silent_catch_allowlist.txt"]
         ),
         // Swift Testing suites split from BaseChatInferenceTests to prevent a
         // libmalloc double-free SIGABRT that occurs when XCTest and Swift Testing

--- a/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
+++ b/Tests/BaseChatInferenceTests/SilentCatchAuditTest.swift
@@ -8,7 +8,7 @@ import XCTest
 /// kinds of offences:
 ///
 /// 1. `try?` used as an unobserved error swallow. Any line containing
-///    `try?` is captured and checked against ``allowlist``.
+///    `try?` is captured and checked against the allowlist.
 ///
 /// 2. Empty `catch { }` blocks. A catch block is considered empty when,
 ///    after the opening `catch { ... {` on one line, the next non-blank,
@@ -16,13 +16,22 @@ import XCTest
 ///    `catch {}` forms are detected directly.
 ///
 /// Both categories use the same `"relative/path.swift:<trimmed line>"`
-/// fingerprint format and are checked against the same ``allowlist``.
+/// fingerprint format and are checked against the same allowlist.
 ///
-/// Adding a new swallow: if the `try?` or empty catch is a legitimate
-/// optional conversion (e.g., `guard let x = try? Decoder.decode(...)`)
-/// or an intentional best-effort cleanup, append its fingerprint to
-/// ``allowlist``. If it's an unobserved error that should be surfaced,
-/// route it through ``DiagnosticsService.record(_:)`` instead.
+/// ## Allowlist
+///
+/// Approved exceptions live in `silent_catch_allowlist.txt`, sitting next
+/// to this file. The format is one fingerprint per line; `#`-prefixed
+/// lines and blank lines are ignored. Adding a new swallow: if the
+/// `try?` or empty catch is a legitimate optional conversion (e.g.,
+/// `guard let x = try? Decoder.decode(...)`) or an intentional
+/// best-effort cleanup, append its fingerprint to that file with a brief
+/// `#` comment explaining why. If it's an unobserved error that should be
+/// surfaced, route it through ``DiagnosticsService.record(_:)`` instead.
+///
+/// Externalising the list (PR refactoring out a hard-coded `Set<String>`)
+/// means refactor PRs no longer have to touch this test file to add a
+/// reviewed exception — they edit `silent_catch_allowlist.txt`.
 ///
 /// Limitation: the empty-catch detector is line-based, not AST-based,
 /// so nested `catch` inside interpolated strings or multi-line
@@ -31,205 +40,22 @@ import XCTest
 /// catches drift immediately.
 final class SilentCatchAuditTest: XCTestCase {
 
-    /// Exact-match allowlist of `try?` call sites that existed when this
-    /// audit test was added and have been reviewed as either (a) benign
-    /// optional conversions or (b) existing Task.sleep call sites that
-    /// deliberately ignore cancellation. Format: `"relative/path.swift:<trimmed line>"`.
-    ///
-    /// DO NOT add entries to make a failing test pass without human review.
-    private static let allowlist: Set<String> = [
-        // BaseChatInference
-        // False positive: `ToolRegistry?` as an optional type annotation contains
-        // the substring `try?` inside `Regis‑try?`. No `try?` call site is present
-        // on either line; the audit's substring scan is not AST-aware.
-        "BaseChatInference/Services/GenerationCoordinator.swift:let toolRegistry: ToolRegistry?",
-        "BaseChatInference/Services/GenerationCoordinator.swift:toolRegistry: ToolRegistry? = nil,",
-        "BaseChatInference/Services/InferenceService.swift:public var toolRegistry: ToolRegistry? {",
-        "BaseChatInference/Services/InferenceService.swift:toolRegistry: ToolRegistry? = nil,",
-        // JSONSchemaValue uses the standard "try-each-type-in-order" decoder pattern for
-        // heterogeneous JSON. Each `try?` is bound to a named constant and the result is
-        // used immediately; there is no silent discard — the next branch handles the miss.
-        "BaseChatInference/Models/ToolTypes.swift:} else if let b = try? container.decode(Bool.self) {",
-        "BaseChatInference/Models/ToolTypes.swift:} else if let n = try? container.decode(Double.self) {",
-        "BaseChatInference/Models/ToolTypes.swift:} else if let s = try? container.decode(String.self) {",
-        "BaseChatInference/Models/ToolTypes.swift:} else if let arr = try? container.decode([JSONSchemaValue].self) {",
-        "BaseChatInference/Models/ModelInfo.swift:guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),",
-        "BaseChatInference/Models/ModelInfo.swift:if let metadata = try? GGUFMetadataReader.readMetadata(from: url) {",
-        "BaseChatInference/Models/ModelInfo.swift:guard let contents = try? fileManager.contentsOfDirectory(",
-        "BaseChatInference/Models/ModelInfo.swift:let values = try? fileURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])",
-        "BaseChatInference/Services/BackgroundDownloadManager.swift:try? FileManager.default.removeItem(at: tempURL)",
-        // Best-effort temp-file cleanup before throwing a path-traversal error; the removal
-        // failure is irrelevant since the download is already being rejected.
-        "BaseChatInference/Services/BackgroundDownloadManager+URLSessionDelegate.swift:try? FileManager.default.removeItem(at: tempURL)",
-        // File-based persistence helpers: reading optional data whose absence is expected
-        // (no pending downloads or no resume data), decoding optional JSON (corrupt file
-        // falls back to empty dict), and best-effort cleanup of stale/consumed files.
-        "BaseChatInference/Services/BackgroundDownloadManager.swift:guard let data = try? Data(contentsOf: url) else { return nil }",
-        "BaseChatInference/Services/BackgroundDownloadManager.swift:try? FileManager.default.removeItem(at: url)",
-        "BaseChatInference/Services/BackgroundDownloadManager.swift:guard let data = try? Data(contentsOf: pendingMetadataFileURL) else { return nil }",
-        "BaseChatInference/Services/BackgroundDownloadManager.swift:return try? JSONDecoder().decode([String: [String: String]].self, from: data)",
-        "BaseChatInference/Services/BackgroundDownloadManager.swift:try? FileManager.default.removeItem(at: resumeDataFileURL(for: id))",
-        "BaseChatInference/Services/BackgroundDownloadManager.swift:guard let contents = try? FileManager.default.contentsOfDirectory(",
-        "BaseChatInference/Services/DownloadFileValidator.swift:guard let handle = try? FileHandle(forReadingFrom: fileURL) else {",
-        "BaseChatInference/Services/DownloadFileValidator.swift:guard let headerData = try? handle.read(upToCount: 4), headerData.count == 4 else {",
-        "BaseChatInference/Services/GGUFMetadataReader.swift:guard let handle = try? FileHandle(forReadingFrom: url) else { return false }",
-        "BaseChatInference/Services/ModelStorageService.swift:guard let contents = try? fileManager.contentsOfDirectory(",
-        // Same best-effort directory walk one level deeper for HF-namespaced MLX
-        // layouts (Models/<org>/<model>/). An unreadable namespace dir is just
-        // skipped — we move on to the next entry rather than failing the whole scan.
-        "BaseChatInference/Services/ModelStorageService.swift:guard let nestedContents = try? fileManager.contentsOfDirectory(",
-
-        // BaseChatCore
-        // File-protection hardening: enumerating the store directory to locate
-        // SQLite WAL sidecars is best-effort. If the directory read fails
-        // (permissions race, parent unmounted), we skip sidecar protection and
-        // the main store is still protected — the error is not actionable.
-        "BaseChatCore/ModelContainerFactory.swift:guard let entries = try? fm.contentsOfDirectory(atPath: directory.path) else {",
-
-        // BaseChatBackends
-        "BaseChatBackends/ClaudeBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],",
-        // parseEventType / parseThinkingDelta: SSE payload probes. Malformed
-        // JSON is a non-event (ignore the payload) — same pattern as parseToken.
-        "BaseChatBackends/ClaudeBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {",
-        "BaseChatBackends/OllamaBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {",
-        "BaseChatBackends/OllamaBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],",
-        // /api/show thinking-detection probe: best-effort optimization that skips
-        // the 2048-token reserve on non-thinking models. Failures are logged at
-        // info level and fall through to `isThinkingModel = false`, which is the
-        // same safe default we'd pick if the endpoint didn't exist (older Ollama).
-        "BaseChatBackends/OllamaBackend.swift:self.isThinkingModel = (try? await detectThinkingCapability()) ?? false",
-        "BaseChatBackends/OllamaBackend.swift:guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {",
-        "BaseChatBackends/OpenAIBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],",
-        "BaseChatBackends/SSECloudBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],",
-        // MLXBackend.validateArchitecture: best-effort read of the MLX model's
-        // `config.json`. A missing/unreadable/malformed config is not fatal here
-        // — we deliberately fall through so mlx-swift-lm's own load path produces
-        // the real diagnostic (missing weights, malformed directory, etc.) rather
-        // than masking it with a false architecture error.
-        "BaseChatBackends/MLXBackend.swift:guard let data = try? Data(contentsOf: configURL),",
-        "BaseChatBackends/MLXBackend.swift:let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {",
-        // MLXBackend.effectiveSystemPrompt (Qwen tool-block builder): the
-        // `tool.parameters` round-trip through Encoder→JSONObject is a
-        // shape-conversion probe so the parameters merge into the surrounding
-        // [String: Any] tools array. The else-branch falls back to an empty
-        // schema, which is the documented Qwen behaviour for parameterless
-        // tools — failure here is functionally indistinguishable from a tool
-        // declaring no parameters.
-        "BaseChatBackends/MLXBackend.swift:if let paramsData = try? JSONEncoder().encode(tool.parameters),",
-        "BaseChatBackends/MLXBackend.swift:let paramsObj = try? JSONSerialization.jsonObject(with: paramsData) {",
-        // Same builder, outer wrap: serialising the assembled tools array into
-        // pretty-printed JSON for the <tools> block. On failure we emit "[]",
-        // which the Qwen template tolerates (model gets an empty tool list and
-        // declines to call). The visible-quality regression is acceptable
-        // versus throwing during prompt assembly.
-        "BaseChatBackends/MLXBackend.swift:if let data = try? JSONSerialization.data(withJSONObject: toolObjects, options: [.prettyPrinted]),",
-        // MLXBackend tool-call history encoding: model previously emitted a
-        // tool call whose arguments JSON is now being replayed in the chat
-        // history. If the original payload no longer parses (corrupted on the
-        // way back through the buffer), substitute an empty-args dict — this
-        // matches what the model itself would have produced for a no-arg
-        // tool, and the audit-trail content already passed validation when
-        // first emitted.
-        "BaseChatBackends/MLXBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) {",
-        // Re-serialising the same call object into a <tool_call> block. If
-        // the round-trip fails (the parsed dictionary is not JSON-encodable),
-        // we drop this single call from the rendered history rather than
-        // failing the whole prompt — the if-let `data`/`jsonStr` guard
-        // ensures only successfully-encoded calls are appended.
-        "BaseChatBackends/MLXBackend.swift:if let data = try? JSONSerialization.data(withJSONObject: callObj),",
-
-        // MLXToolCallParser.parseToolCall: defensive JSON parse of the buffered
-        // payload between <tool_call>…</tool_call>. Models routinely emit
-        // malformed payloads (truncated, partial Unicode, mid-token streaming);
-        // returning `nil` here lets the caller silently skip this block —
-        // the same way the SSE backends drop unparseable event payloads.
-        "BaseChatBackends/MLXToolCallParser.swift:let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],",
-        // Re-serialising parsed `arguments` dict back into a JSON string for
-        // ToolCall.arguments. If serialisation fails, we substitute "{}" —
-        // a parameterless call is the safest fallback when the wire format
-        // is uninterpretable, and the typed-tool executor will surface a
-        // schema mismatch if the tool actually requires args.
-        "BaseChatBackends/MLXToolCallParser.swift:if let serialised = try? JSONSerialization.data(withJSONObject: argsDict),",
-
-        // MLXToolDialect.detect: best-effort probe of the model dir's
-        // `config.json` to classify the tool dialect. A missing/unreadable
-        // config maps to `.unknown` (tool calling is a no-op), per the
-        // function's documented contract — same shape as MLXBackend's
-        // architecture validator above.
-        "BaseChatBackends/MLXToolDialect.swift:guard let data = try? Data(contentsOf: configURL),",
-        "BaseChatBackends/MLXToolDialect.swift:let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]",
-
-        // BaseChatFuzz — SessionScript resource loader uses the "try-each-shape-in-order"
-        // decoder pattern: each `try?` is a shape probe (single-object vs. array of scripts).
-        // When both shape probes miss, SessionScript.loadAll writes an explicit stderr
-        // diagnostic on the next line. The Data(contentsOf:) swallow is a benign
-        // skip-this-resource case — the loader continues with the remaining scripts.
-        "BaseChatFuzz/SessionScript.swift:guard let data = try? Data(contentsOf: url) else { continue }",
-        "BaseChatFuzz/SessionScript.swift:if let one = try? decoder.decode(SessionScript.self, from: data) {",
-        "BaseChatFuzz/SessionScript.swift:if let many = try? decoder.decode([SessionScript].self, from: data) {",
-
-        // BaseChatFuzz/Scenarios — ScenarioTestBackend pauses mid-thinking to give
-        // cancel/retry scenarios a deterministic window. The sleep is best-effort:
-        // if the Task is cancelled during the pause, we deliberately fall through
-        // to the post-thinking emit check (which honours Task.isCancelled on its
-        // own) rather than observing the CancellationError.
-        "BaseChatFuzz/Scenarios/ScenarioTestBackend.swift:try? await Task.sleep(for: pause)",
-
-        // BaseChatUI — Task.sleep cancellation is intentionally ignored;
-        // parser/rendering fallbacks are benign optional conversions.
-        "BaseChatUI/ViewModels/ModelManagementViewModel.swift:try? await Task.sleep(for: .milliseconds(500))",
-        "BaseChatUI/Views/Chat/AssistantMarkdownView.swift:if let parsed = try? AttributedString(",
-        "BaseChatUI/Views/Chat/TypingIndicatorView.swift:try? await Task.sleep(for: .milliseconds(400))",
-        // False positive: `toolRegistry?` optional chain contains the substring
-        // `try?` inside `Regis‑try?`. No `try?` call site is present on this
-        // line; the audit's substring scan is not AST-aware.
-        "BaseChatUI/ViewModels/GenerationCoordinator.swift:let registeredTools = inferenceService.toolRegistry?.definitions ?? []",
-
-        // BaseChatTestSupport — test-only helpers, not production paths.
-        // withTimeout deadline task: Task.sleep cancellation is intentionally swallowed so
-        // the deadline fires immediately when the parent task is cancelled, rather than
-        // propagating CancellationError and racing with the operation task's resume path.
-        "BaseChatTestSupport/TestHelpers.swift:try? await Task.sleep(for: timeout)",
-        "BaseChatTestSupport/TestHelpers.swift:try? FileManager.default.removeItem(at: url)",
-        "BaseChatTestSupport/SlowMockBackend.swift:try? await Task.sleep(for: delay)",
-        "BaseChatTestSupport/PerceivedLatencyBackend.swift:try? await Task.sleep(for: ttft)",
-        "BaseChatTestSupport/PerceivedLatencyBackend.swift:try? await Task.sleep(for: delay)",
-        "BaseChatTestSupport/ChaosBackend.swift:try? await Task.sleep(for: delay)",
-        "BaseChatTestSupport/ChaosBackend.swift:try? await Task.sleep(for: stallDuration)",
-        "BaseChatTestSupport/HardwareRequirements.swift:let configData = try? Data(contentsOf: configURL),",
-        "BaseChatTestSupport/HardwareRequirements.swift:let json = try? JSONSerialization.jsonObject(with: configData) as? [String: Any],",
-        "BaseChatTestSupport/HardwareRequirements.swift:let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],",
-        "BaseChatTestSupport/HardwareRequirements.swift:if let containers = try? fm.contentsOfDirectory(",
-        "BaseChatTestSupport/HardwareRequirements.swift:guard let contents = try? fm.contentsOfDirectory(",
-        "BaseChatTestSupport/HardwareRequirements.swift:guard let files = try? fileManager.contentsOfDirectory(",
-        "BaseChatTestSupport/HardwareRequirements.swift:let values = try? candidate.resourceValues(",
-
-        // Empty `catch { }` blocks. These are best-effort reads whose
-        // partial result is still useful; swallowing the error is
-        // intentional and the remaining behaviour is correct.
-        //
-        // ClaudeBackend.readErrorBody: we're assembling an error body
-        // for a log message after the upstream request already failed.
-        // A truncated body is better than crashing the error handler.
-        "BaseChatBackends/ClaudeBackend.swift:} catch {",
-
-        // BaseChatTools — bck-tools CLI harness. Two benign catches:
-        //   - TranscriptLogger.deinit can't propagate a close() failure and
-        //     the file is about to be reaped with the process anyway.
-        //   - NowTool.EmptyArgs.init(from:) probes the keyed container so
-        //     it accepts both `{}` and `null`; a missing container is a
-        //     valid zero-argument payload and not an error condition.
-        "BaseChatTools/TranscriptLogger.swift:} catch {",
-        "BaseChatTools/ReferenceTools/NowTool.swift:} catch {",
-        // SampleRepoSearchTool walks the sandbox directory skipping files it
-        // cannot read (binary data with a text extension, permission races,
-        // non-UTF-8 encodings). Surfacing these as errors would make a noisy
-        // search tool that fails on a single bad file instead of returning
-        // the matches it did find. Mirrors the pattern in BackgroundDownloadManager
-        // and ModelStorageService for directory walkers.
-        "BaseChatTools/ReferenceTools/SampleRepoSearchTool.swift:let values = try? url.resourceValues(forKeys: Set(keys))",
-        "BaseChatTools/ReferenceTools/SampleRepoSearchTool.swift:guard let contents = try? String(contentsOf: url, encoding: .utf8) else { continue }",
-    ]
+    /// Lazily loaded set of approved fingerprints from
+    /// `silent_catch_allowlist.txt`. The file lives next to this test
+    /// source file; we resolve it via `#filePath` so it works under both
+    /// `swift test` and `xcodebuild test` without requiring the resource
+    /// to be bundled into the test target.
+    private static let allowlist: Set<String> = {
+        do {
+            return try loadAllowlist()
+        } catch {
+            // Fall back to an empty allowlist; the test will then fail
+            // loudly with the file-loading error reported alongside the
+            // first offender.
+            XCTFail("Failed to load silent_catch_allowlist.txt: \(error)")
+            return []
+        }
+    }()
 
     func test_sourcesDirectoryContainsNoUnapprovedSilentSwallows() throws {
         let sourcesURL = try Self.locateSourcesDirectory()
@@ -274,7 +100,7 @@ final class SilentCatchAuditTest: XCTestCase {
                 .joined(separator: "\n")
             XCTFail("""
                 Unapproved silent error swallows found in Sources/.
-                Route these through DiagnosticsService.record(_:) or add the fingerprint to SilentCatchAuditTest.allowlist with reviewer sign-off.
+                Route these through DiagnosticsService.record(_:) or add the fingerprint to Tests/BaseChatInferenceTests/silent_catch_allowlist.txt with reviewer sign-off.
 
                 \(formatted)
                 """)
@@ -286,12 +112,49 @@ final class SilentCatchAuditTest: XCTestCase {
         if !stale.isEmpty {
             let formatted = stale.sorted().joined(separator: "\n  ")
             XCTFail("""
-                SilentCatchAuditTest.allowlist has stale entries that no longer exist in Sources/.
+                silent_catch_allowlist.txt has stale entries that no longer exist in Sources/.
                 Remove them:
 
                   \(formatted)
                 """)
         }
+    }
+
+    // MARK: - Allowlist loading
+
+    /// Reads `silent_catch_allowlist.txt` from beside this source file
+    /// and returns the set of approved fingerprints. Blank lines and
+    /// lines whose first non-whitespace character is `#` are skipped.
+    /// Each remaining line is trimmed of trailing whitespace only —
+    /// leading whitespace is preserved because some fingerprints embed
+    /// indentation-significant tokens.
+    static func loadAllowlist(filePath: StaticString = #filePath) throws -> Set<String> {
+        let url = allowlistURL(filePath: filePath)
+        let content = try String(contentsOf: url, encoding: .utf8)
+        var entries: Set<String> = []
+        for rawLine in content.components(separatedBy: "\n") {
+            // Strip trailing CR (handles CRLF files) and trailing
+            // whitespace introduced by editors.
+            var line = rawLine
+            if line.hasSuffix("\r") { line.removeLast() }
+            while let last = line.last, last == " " || last == "\t" {
+                line.removeLast()
+            }
+            // Skip blank lines.
+            let leading = line.drop(while: { $0 == " " || $0 == "\t" })
+            if leading.isEmpty { continue }
+            // Skip comment lines (first non-whitespace char is `#`).
+            if leading.first == "#" { continue }
+            entries.insert(line)
+        }
+        return entries
+    }
+
+    /// URL of `silent_catch_allowlist.txt` next to this test source file.
+    private static func allowlistURL(filePath: StaticString = #filePath) -> URL {
+        URL(fileURLWithPath: "\(filePath)")
+            .deletingLastPathComponent()
+            .appendingPathComponent("silent_catch_allowlist.txt")
     }
 
     // MARK: - Helpers

--- a/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
+++ b/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
@@ -1,0 +1,251 @@
+# SilentCatchAuditTest — approved exceptions.
+#
+# Exact-match allowlist of `try?` call sites and empty `catch { }` blocks
+# that have been reviewed as either (a) benign optional conversions or
+# (b) intentional best-effort cleanup / Task.sleep cancellation swallows.
+#
+# Format: one fingerprint per line, of the form
+#   <relative path under Sources/>:<trimmed source line>
+#
+# - Empty lines and `#`-prefixed lines are ignored.
+# - Entries must match the audit's fingerprint EXACTLY (the line content
+#   is the trimmed source line, not a regex).
+# - Sort entries roughly by target/file so diffs stay reviewable, but the
+#   audit does not rely on order.
+#
+# DO NOT add entries to make a failing test pass without human review.
+# If the `try?` or empty catch is genuinely an unobserved error that
+# should be surfaced, route it through `DiagnosticsService.record(_:)`
+# instead of allowlisting it here.
+
+# ---------------------------------------------------------------------------
+# BaseChatInference
+# ---------------------------------------------------------------------------
+
+# False positive: `ToolRegistry?` as an optional type annotation contains
+# the substring `try?` inside `Regis-try?`. No `try?` call site is present
+# on either line; the audit's substring scan is not AST-aware.
+BaseChatInference/Services/GenerationCoordinator.swift:let toolRegistry: ToolRegistry?
+BaseChatInference/Services/GenerationCoordinator.swift:toolRegistry: ToolRegistry? = nil,
+BaseChatInference/Services/InferenceService.swift:public var toolRegistry: ToolRegistry? {
+BaseChatInference/Services/InferenceService.swift:toolRegistry: ToolRegistry? = nil,
+
+# JSONSchemaValue uses the standard "try-each-type-in-order" decoder pattern for
+# heterogeneous JSON. Each `try?` is bound to a named constant and the result is
+# used immediately; there is no silent discard — the next branch handles the miss.
+BaseChatInference/Models/ToolTypes.swift:} else if let b = try? container.decode(Bool.self) {
+BaseChatInference/Models/ToolTypes.swift:} else if let n = try? container.decode(Double.self) {
+BaseChatInference/Models/ToolTypes.swift:} else if let s = try? container.decode(String.self) {
+BaseChatInference/Models/ToolTypes.swift:} else if let arr = try? container.decode([JSONSchemaValue].self) {
+
+BaseChatInference/Models/ModelInfo.swift:guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),
+BaseChatInference/Models/ModelInfo.swift:if let metadata = try? GGUFMetadataReader.readMetadata(from: url) {
+BaseChatInference/Models/ModelInfo.swift:guard let contents = try? fileManager.contentsOfDirectory(
+BaseChatInference/Models/ModelInfo.swift:let values = try? fileURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+
+BaseChatInference/Services/BackgroundDownloadManager.swift:try? FileManager.default.removeItem(at: tempURL)
+
+# Best-effort temp-file cleanup before throwing a path-traversal error; the removal
+# failure is irrelevant since the download is already being rejected.
+BaseChatInference/Services/BackgroundDownloadManager+URLSessionDelegate.swift:try? FileManager.default.removeItem(at: tempURL)
+
+# File-based persistence helpers: reading optional data whose absence is expected
+# (no pending downloads or no resume data), decoding optional JSON (corrupt file
+# falls back to empty dict), and best-effort cleanup of stale/consumed files.
+BaseChatInference/Services/BackgroundDownloadManager.swift:guard let data = try? Data(contentsOf: url) else { return nil }
+BaseChatInference/Services/BackgroundDownloadManager.swift:try? FileManager.default.removeItem(at: url)
+BaseChatInference/Services/BackgroundDownloadManager.swift:guard let data = try? Data(contentsOf: pendingMetadataFileURL) else { return nil }
+BaseChatInference/Services/BackgroundDownloadManager.swift:return try? JSONDecoder().decode([String: [String: String]].self, from: data)
+BaseChatInference/Services/BackgroundDownloadManager.swift:try? FileManager.default.removeItem(at: resumeDataFileURL(for: id))
+BaseChatInference/Services/BackgroundDownloadManager.swift:guard let contents = try? FileManager.default.contentsOfDirectory(
+
+BaseChatInference/Services/DownloadFileValidator.swift:guard let handle = try? FileHandle(forReadingFrom: fileURL) else {
+BaseChatInference/Services/DownloadFileValidator.swift:guard let headerData = try? handle.read(upToCount: 4), headerData.count == 4 else {
+BaseChatInference/Services/GGUFMetadataReader.swift:guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
+BaseChatInference/Services/ModelStorageService.swift:guard let contents = try? fileManager.contentsOfDirectory(
+
+# Same best-effort directory walk one level deeper for HF-namespaced MLX
+# layouts (Models/<org>/<model>/). An unreadable namespace dir is just
+# skipped — we move on to the next entry rather than failing the whole scan.
+BaseChatInference/Services/ModelStorageService.swift:guard let nestedContents = try? fileManager.contentsOfDirectory(
+
+# ---------------------------------------------------------------------------
+# BaseChatCore
+# ---------------------------------------------------------------------------
+
+# File-protection hardening: enumerating the store directory to locate
+# SQLite WAL sidecars is best-effort. If the directory read fails
+# (permissions race, parent unmounted), we skip sidecar protection and
+# the main store is still protected — the error is not actionable.
+BaseChatCore/ModelContainerFactory.swift:guard let entries = try? fm.contentsOfDirectory(atPath: directory.path) else {
+
+# ---------------------------------------------------------------------------
+# BaseChatBackends
+# ---------------------------------------------------------------------------
+
+BaseChatBackends/ClaudeBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+# parseEventType / parseThinkingDelta: SSE payload probes. Malformed
+# JSON is a non-event (ignore the payload) — same pattern as parseToken.
+BaseChatBackends/ClaudeBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+BaseChatBackends/OllamaBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+BaseChatBackends/OllamaBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+
+# /api/show thinking-detection probe: best-effort optimization that skips
+# the 2048-token reserve on non-thinking models. Failures are logged at
+# info level and fall through to `isThinkingModel = false`, which is the
+# same safe default we'd pick if the endpoint didn't exist (older Ollama).
+BaseChatBackends/OllamaBackend.swift:self.isThinkingModel = (try? await detectThinkingCapability()) ?? false
+BaseChatBackends/OllamaBackend.swift:guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+
+BaseChatBackends/OpenAIBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+BaseChatBackends/SSECloudBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+
+# MLXBackend.validateArchitecture: best-effort read of the MLX model's
+# `config.json`. A missing/unreadable/malformed config is not fatal here
+# — we deliberately fall through so mlx-swift-lm's own load path produces
+# the real diagnostic (missing weights, malformed directory, etc.) rather
+# than masking it with a false architecture error.
+BaseChatBackends/MLXBackend.swift:guard let data = try? Data(contentsOf: configURL),
+BaseChatBackends/MLXBackend.swift:let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+
+# MLXBackend.effectiveSystemPrompt (Qwen tool-block builder): the
+# `tool.parameters` round-trip through Encoder→JSONObject is a
+# shape-conversion probe so the parameters merge into the surrounding
+# [String: Any] tools array. The else-branch falls back to an empty
+# schema, which is the documented Qwen behaviour for parameterless
+# tools — failure here is functionally indistinguishable from a tool
+# declaring no parameters.
+BaseChatBackends/MLXBackend.swift:if let paramsData = try? JSONEncoder().encode(tool.parameters),
+BaseChatBackends/MLXBackend.swift:let paramsObj = try? JSONSerialization.jsonObject(with: paramsData) {
+
+# Same builder, outer wrap: serialising the assembled tools array into
+# pretty-printed JSON for the <tools> block. On failure we emit "[]",
+# which the Qwen template tolerates (model gets an empty tool list and
+# declines to call). The visible-quality regression is acceptable
+# versus throwing during prompt assembly.
+BaseChatBackends/MLXBackend.swift:if let data = try? JSONSerialization.data(withJSONObject: toolObjects, options: [.prettyPrinted]),
+
+# MLXBackend tool-call history encoding: model previously emitted a
+# tool call whose arguments JSON is now being replayed in the chat
+# history. If the original payload no longer parses (corrupted on the
+# way back through the buffer), substitute an empty-args dict — this
+# matches what the model itself would have produced for a no-arg
+# tool, and the audit-trail content already passed validation when
+# first emitted.
+BaseChatBackends/MLXBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) {
+
+# Re-serialising the same call object into a <tool_call> block. If
+# the round-trip fails (the parsed dictionary is not JSON-encodable),
+# we drop this single call from the rendered history rather than
+# failing the whole prompt — the if-let `data`/`jsonStr` guard
+# ensures only successfully-encoded calls are appended.
+BaseChatBackends/MLXBackend.swift:if let data = try? JSONSerialization.data(withJSONObject: callObj),
+
+# MLXToolCallParser.parseToolCall: defensive JSON parse of the buffered
+# payload between <tool_call>…</tool_call>. Models routinely emit
+# malformed payloads (truncated, partial Unicode, mid-token streaming);
+# returning `nil` here lets the caller silently skip this block —
+# the same way the SSE backends drop unparseable event payloads.
+BaseChatBackends/MLXToolCallParser.swift:let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+
+# Re-serialising parsed `arguments` dict back into a JSON string for
+# ToolCall.arguments. If serialisation fails, we substitute "{}" —
+# a parameterless call is the safest fallback when the wire format
+# is uninterpretable, and the typed-tool executor will surface a
+# schema mismatch if the tool actually requires args.
+BaseChatBackends/MLXToolCallParser.swift:if let serialised = try? JSONSerialization.data(withJSONObject: argsDict),
+
+# MLXToolDialect.detect: best-effort probe of the model dir's
+# `config.json` to classify the tool dialect. A missing/unreadable
+# config maps to `.unknown` (tool calling is a no-op), per the
+# function's documented contract — same shape as MLXBackend's
+# architecture validator above.
+BaseChatBackends/MLXToolDialect.swift:guard let data = try? Data(contentsOf: configURL),
+BaseChatBackends/MLXToolDialect.swift:let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+
+# ---------------------------------------------------------------------------
+# BaseChatFuzz
+# ---------------------------------------------------------------------------
+
+# SessionScript resource loader uses the "try-each-shape-in-order"
+# decoder pattern: each `try?` is a shape probe (single-object vs. array of scripts).
+# When both shape probes miss, SessionScript.loadAll writes an explicit stderr
+# diagnostic on the next line. The Data(contentsOf:) swallow is a benign
+# skip-this-resource case — the loader continues with the remaining scripts.
+BaseChatFuzz/SessionScript.swift:guard let data = try? Data(contentsOf: url) else { continue }
+BaseChatFuzz/SessionScript.swift:if let one = try? decoder.decode(SessionScript.self, from: data) {
+BaseChatFuzz/SessionScript.swift:if let many = try? decoder.decode([SessionScript].self, from: data) {
+
+# ScenarioTestBackend pauses mid-thinking to give cancel/retry scenarios a
+# deterministic window. The sleep is best-effort: if the Task is cancelled
+# during the pause, we deliberately fall through to the post-thinking emit
+# check (which honours Task.isCancelled on its own) rather than observing
+# the CancellationError.
+BaseChatFuzz/Scenarios/ScenarioTestBackend.swift:try? await Task.sleep(for: pause)
+
+# ---------------------------------------------------------------------------
+# BaseChatUI
+# ---------------------------------------------------------------------------
+
+# Task.sleep cancellation is intentionally ignored;
+# parser/rendering fallbacks are benign optional conversions.
+BaseChatUI/ViewModels/ModelManagementViewModel.swift:try? await Task.sleep(for: .milliseconds(500))
+BaseChatUI/Views/Chat/AssistantMarkdownView.swift:if let parsed = try? AttributedString(
+BaseChatUI/Views/Chat/TypingIndicatorView.swift:try? await Task.sleep(for: .milliseconds(400))
+
+# False positive: `toolRegistry?` optional chain contains the substring
+# `try?` inside `Regis-try?`. No `try?` call site is present on this
+# line; the audit's substring scan is not AST-aware.
+BaseChatUI/ViewModels/GenerationCoordinator.swift:let registeredTools = inferenceService.toolRegistry?.definitions ?? []
+
+# ---------------------------------------------------------------------------
+# BaseChatTestSupport — test-only helpers, not production paths.
+# ---------------------------------------------------------------------------
+
+# withTimeout deadline task: Task.sleep cancellation is intentionally swallowed so
+# the deadline fires immediately when the parent task is cancelled, rather than
+# propagating CancellationError and racing with the operation task's resume path.
+BaseChatTestSupport/TestHelpers.swift:try? await Task.sleep(for: timeout)
+BaseChatTestSupport/TestHelpers.swift:try? FileManager.default.removeItem(at: url)
+BaseChatTestSupport/SlowMockBackend.swift:try? await Task.sleep(for: delay)
+BaseChatTestSupport/PerceivedLatencyBackend.swift:try? await Task.sleep(for: ttft)
+BaseChatTestSupport/PerceivedLatencyBackend.swift:try? await Task.sleep(for: delay)
+BaseChatTestSupport/ChaosBackend.swift:try? await Task.sleep(for: delay)
+BaseChatTestSupport/ChaosBackend.swift:try? await Task.sleep(for: stallDuration)
+BaseChatTestSupport/HardwareRequirements.swift:let configData = try? Data(contentsOf: configURL),
+BaseChatTestSupport/HardwareRequirements.swift:let json = try? JSONSerialization.jsonObject(with: configData) as? [String: Any],
+BaseChatTestSupport/HardwareRequirements.swift:let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+BaseChatTestSupport/HardwareRequirements.swift:if let containers = try? fm.contentsOfDirectory(
+BaseChatTestSupport/HardwareRequirements.swift:guard let contents = try? fm.contentsOfDirectory(
+BaseChatTestSupport/HardwareRequirements.swift:guard let files = try? fileManager.contentsOfDirectory(
+BaseChatTestSupport/HardwareRequirements.swift:let values = try? candidate.resourceValues(
+
+# ---------------------------------------------------------------------------
+# Empty `catch { }` blocks.
+# ---------------------------------------------------------------------------
+# These are best-effort reads whose partial result is still useful;
+# swallowing the error is intentional and the remaining behaviour is
+# correct.
+
+# ClaudeBackend.readErrorBody: we're assembling an error body for a log
+# message after the upstream request already failed. A truncated body is
+# better than crashing the error handler.
+BaseChatBackends/ClaudeBackend.swift:} catch {
+
+# BaseChatTools — bck-tools CLI harness. Two benign catches:
+#   - TranscriptLogger.deinit can't propagate a close() failure and the
+#     file is about to be reaped with the process anyway.
+#   - NowTool.EmptyArgs.init(from:) probes the keyed container so it
+#     accepts both `{}` and `null`; a missing container is a valid
+#     zero-argument payload and not an error condition.
+BaseChatTools/TranscriptLogger.swift:} catch {
+BaseChatTools/ReferenceTools/NowTool.swift:} catch {
+
+# SampleRepoSearchTool walks the sandbox directory skipping files it
+# cannot read (binary data with a text extension, permission races,
+# non-UTF-8 encodings). Surfacing these as errors would make a noisy
+# search tool that fails on a single bad file instead of returning
+# the matches it did find. Mirrors the pattern in BackgroundDownloadManager
+# and ModelStorageService for directory walkers.
+BaseChatTools/ReferenceTools/SampleRepoSearchTool.swift:let values = try? url.resourceValues(forKeys: Set(keys))
+BaseChatTools/ReferenceTools/SampleRepoSearchTool.swift:guard let contents = try? String(contentsOf: url, encoding: .utf8) else { continue }


### PR DESCRIPTION
## Summary

Two CI hardening fixes batched into one PR. Each was implemented and sabotage-verified by a separate worker.

> **Rebased note**: this PR originally had a third commit fixing a `MockInferenceBackend.stopCallCount` race. That same race was independently identified and landed on `main` as part of PR #760 between when the worker fixed it and when this PR was opened. After rebasing onto current `main`, that commit was redundant (identical code change, only comment text differed) and dropped.

### 1. Externalized `SilentCatchAuditTest` allowlist (`6e6fe8a`)

The audit's allowlist of approved `try?` exceptions was inline in `SilentCatchAuditTest.swift`, so every refactor that touched a `try?` re-tripped the audit and landed red on `main` (24% of recent CI test failures, including `46eae2e`'s scramble fix).

- 72 fingerprint entries moved verbatim into `Tests/BaseChatInferenceTests/silent_catch_allowlist.txt`.
- Matching semantics unchanged: exact match against `<relative path>:<trimmed line>`.
- `Package.swift` excludes the file from bundling — the test reads it from `#filePath`-relative source.
- `XCTFail` if the file fails to load (no silent-passing fallback).
- Sabotage-verified both ways: a fresh `try?` in `Sources/` triggers the audit failure; adding the matching fingerprint to the file restores green.

A future `scripts/silent-catch-allowlist-suggest.sh` to print fresh additions in paste-ready format would be nice but was deferred — the audit's existing failure output already prints exactly the line you'd paste in.

### 2. `.github/workflows/ci.yml` hardening (`433fb97`)

Three additive changes — none affect passing builds, only diagnose failures and prevent runaway billing:

- **Toolchain sanity check** (`ci.yml:78-103`): parses `swift-tools-version` from `Package.swift` line 1 and the runner's swift major.minor from `xcrun swift -version`; fails with a clear `::error::` if tools-version exceeds runner Swift. Catches the `6.3` vs `6.2.4` drift that produced 14 of the recent `resolve-check` failures.
- **Per-step `timeout-minutes: 25`** on both consolidated test steps (the `XCTest suites` batch and the isolated Swift Testing run). A hung `swift test` would otherwise burn the full 6h GitHub cap (~60h effective billing at 10× macOS multiplier).
- **Failure artifact upload** (end of test job): two-step stage-then-upload (because `$TMPDIR` on macOS runners is a per-process path that `actions/upload-artifact` can't address directly). Captures `scripts/test.sh`'s `test_output.txt` and any DerivedData `*.xcresult`. `actions/upload-artifact@v7`, `if: failure()`, `retention-days: 7`, `if-no-files-found: ignore`.

Rebased onto PR #756's consolidated test structure — original commit had per-step timeouts on the pre-#756 split-out steps; resolved by applying timeouts to the new consolidated `XCTest suites` and Swift Testing steps. No `--parallel` flag added (PR #756 explicitly removed it for the same UserDefaults-leak reason PR #761 fixed).

## Test plan

- [x] Local pre-push suite (Core, Inference XCTest, Inference SwiftTesting, UI, Backends, TestSupport) — all pass on the combined branch (pre-rebase)
- [x] SilentCatchAudit: forward + inverse sabotage both fired correctly
- [x] `actionlint` clean
- [x] Toolchain check logic smoke-tested (correctly OK at tools=6.1 / Swift 6.3; fails at tools=6.4 / Swift 6.3)
- [ ] CI green on rebased branch (running)

## Out of scope

- WithTimeout overhead budget — separately landed in PR #685.
- The two highest-volume CI flakes (UserDefaults injection + concurrency-group fallback) — landed in PR #761.
- MockInferenceBackend stopCallCount race — landed in PR #760.
- `changelog-lint.yml` / `actionlint.yml` / `security-scans.yml` concurrency groups have a similar but lower-stakes shape; deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)