### PR TITLE
perf(mlx): yield briefly every N tokens to prevent WindowServer starvation

### DIFF
--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -103,6 +103,15 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
     /// Defaults to `.auto`, which picks a sensible value based on device RAM.
     public let cachePolicy: MLXCachePolicy
 
+    // MARK: - Test seams
+
+    /// Invoked in place of `Task.sleep(for: .microseconds(50))` at every
+    /// `yieldEveryNTokens`-th token during generation. Tests use this to count
+    /// yield occurrences deterministically without timing assertions.
+    ///
+    /// `nil` in production — the real microsecond sleep runs instead.
+    nonisolated(unsafe) static var _yieldHookForTesting: (@Sendable () async -> Void)?
+
     // MARK: - Init
 
     public init(cachePolicy: MLXCachePolicy = .auto) {
@@ -422,6 +431,13 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                     messages: messages,
                     parameters: generateConfig
                 )
+                // Inserts a brief cooperative yield every N tokens so sustained MLX
+                // generation doesn't starve WindowServer's GPU command queue and
+                // cause UI hitches in other apps. Mirrors the pattern in SwiftLM's
+                // `Server.swift` (50µs sleep every 8 tokens). Configurable via
+                // `GenerationConfig.yieldEveryNTokens`; `0` disables the yield.
+                let yieldEvery = config.yieldEveryNTokens
+                var completionTokenCount = 0
                 outer: for await generation in mlxStream {
                     if Task.isCancelled { break }
                     if let text = generation.chunk {
@@ -464,6 +480,19 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                         }
                         if thinkingLimitReached { break outer }
                         if let limit = outputLimit, outputTokenCount >= limit { break }
+
+                        // Per-chunk yield: count every MLX-emitted chunk (regardless
+                        // of whether it became a visible token, thinking token, or
+                        // got swallowed by the tool-call parser) so the cadence
+                        // tracks real generation work.
+                        completionTokenCount += 1
+                        if yieldEvery > 0 && completionTokenCount % yieldEvery == 0 {
+                            if let hook = MLXBackend._yieldHookForTesting {
+                                await hook()
+                            } else {
+                                try? await Task.sleep(for: .microseconds(50))
+                            }
+                        }
                     }
                 }
                 // Flush any bytes held back at tag-boundary buffers.

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -6,7 +6,14 @@ public struct GenerationConfig: Sendable, Codable {
     public var topP: Float
     public var repeatPenalty: Float
     @available(*, deprecated, renamed: "maxOutputTokens", message: "Use maxOutputTokens instead.")
-    public var maxTokens: Int32
+    public var maxTokens: Int32 {
+        get { _legacyMaxTokens }
+        set { _legacyMaxTokens = newValue }
+    }
+    /// Backing storage for the deprecated ``maxTokens`` field. Lives separately so the type's
+    /// own initializers and Codable conformance can read/write the legacy value without
+    /// tripping the deprecation warning. See PR #766 follow-up to #747.
+    @usableFromInline internal var _legacyMaxTokens: Int32 = 512
     public var topK: Int32?
     public var typicalP: Float?
 
@@ -122,7 +129,7 @@ public struct GenerationConfig: Sendable, Codable {
         self.temperature = temperature
         self.topP = topP
         self.repeatPenalty = repeatPenalty
-        self.maxTokens = maxTokens
+        self._legacyMaxTokens = maxTokens
         self.topK = topK
         self.typicalP = typicalP
         self.maxOutputTokens = maxOutputTokens
@@ -155,7 +162,6 @@ public struct GenerationConfig: Sendable, Codable {
         self.temperature = temperature
         self.topP = topP
         self.repeatPenalty = repeatPenalty
-        self.maxTokens = 512
         self.topK = topK
         self.typicalP = typicalP
         self.maxOutputTokens = maxOutputTokens
@@ -183,7 +189,8 @@ public struct GenerationConfig: Sendable, Codable {
         topP = try c.decode(Float.self, forKey: .topP)
         repeatPenalty = try c.decode(Float.self, forKey: .repeatPenalty)
         // maxTokens is deprecated; absent from payloads that never encoded it — fall back to 512.
-        maxTokens = (try c.decodeIfPresent(Int32.self, forKey: .maxTokens)) ?? 512
+        // We write to the backing store directly to avoid the deprecation warning on the property.
+        _legacyMaxTokens = (try c.decodeIfPresent(Int32.self, forKey: .maxTokens)) ?? 512
         topK = try c.decodeIfPresent(Int32.self, forKey: .topK)
         typicalP = try c.decodeIfPresent(Float.self, forKey: .typicalP)
         maxOutputTokens = try c.decodeIfPresent(Int.self, forKey: .maxOutputTokens)
@@ -208,7 +215,8 @@ public struct GenerationConfig: Sendable, Codable {
         try c.encode(temperature, forKey: .temperature)
         try c.encode(topP, forKey: .topP)
         try c.encode(repeatPenalty, forKey: .repeatPenalty)
-        try c.encode(maxTokens, forKey: .maxTokens)
+        // Encode the legacy `maxTokens` wire field for backwards-compatible payloads.
+        try c.encode(_legacyMaxTokens, forKey: .maxTokens)
         try c.encodeIfPresent(topK, forKey: .topK)
         try c.encodeIfPresent(typicalP, forKey: .typicalP)
         try c.encodeIfPresent(maxOutputTokens, forKey: .maxOutputTokens)

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -89,7 +89,19 @@ public struct GenerationConfig: Sendable, Codable {
         didSet { if maxToolIterations < 1 { maxToolIterations = 1 } }
     }
 
-    @available(*, deprecated, message: "Use init(temperature:topP:repeatPenalty:topK:typicalP:maxOutputTokens:tools:toolChoice:maxThinkingTokens:jsonMode:thinkingMarkers:maxToolIterations:grammar:) instead.")
+    /// Number of tokens between brief cooperative yields during MLX generation.
+    ///
+    /// Sustained MLX inference on Mac can starve WindowServer's GPU command
+    /// queue and cause hitches in other apps. To mitigate this, ``MLXBackend``
+    /// inserts a 50µs `Task.sleep` every `yieldEveryNTokens` tokens. The same
+    /// pattern is used in `SwiftLM/Server.swift`.
+    ///
+    /// - Defaults to `8` (one yield per ~8 tokens).
+    /// - `0` disables the yield entirely.
+    /// - Only honoured by `MLXBackend`; other backends ignore this field.
+    public var yieldEveryNTokens: Int = 8
+
+    @available(*, deprecated, message: "Use init(temperature:topP:repeatPenalty:topK:typicalP:maxOutputTokens:tools:toolChoice:maxThinkingTokens:jsonMode:thinkingMarkers:maxToolIterations:grammar:yieldEveryNTokens:) instead.")
     public init(
         temperature: Float = 0.7,
         topP: Float = 0.9,
@@ -104,7 +116,8 @@ public struct GenerationConfig: Sendable, Codable {
         jsonMode: Bool = false,
         thinkingMarkers: ThinkingMarkers? = nil,
         maxToolIterations: Int = 10,
-        grammar: String? = nil
+        grammar: String? = nil,
+        yieldEveryNTokens: Int = 8
     ) {
         self.temperature = temperature
         self.topP = topP
@@ -120,6 +133,7 @@ public struct GenerationConfig: Sendable, Codable {
         self.thinkingMarkers = thinkingMarkers
         self.maxToolIterations = max(1, maxToolIterations)
         self.grammar = grammar
+        self.yieldEveryNTokens = yieldEveryNTokens
     }
 
     public init(
@@ -135,7 +149,8 @@ public struct GenerationConfig: Sendable, Codable {
         jsonMode: Bool = false,
         thinkingMarkers: ThinkingMarkers? = nil,
         maxToolIterations: Int = 10,
-        grammar: String? = nil
+        grammar: String? = nil,
+        yieldEveryNTokens: Int = 8
     ) {
         self.temperature = temperature
         self.topP = topP
@@ -151,6 +166,7 @@ public struct GenerationConfig: Sendable, Codable {
         self.thinkingMarkers = thinkingMarkers
         self.maxToolIterations = max(1, maxToolIterations)
         self.grammar = grammar
+        self.yieldEveryNTokens = yieldEveryNTokens
     }
 
     // MARK: Codable
@@ -158,6 +174,7 @@ public struct GenerationConfig: Sendable, Codable {
     private enum CodingKeys: String, CodingKey {
         case temperature, topP, repeatPenalty, maxTokens, topK, typicalP, maxOutputTokens
         case tools, toolChoice, maxThinkingTokens, jsonMode, maxToolIterations, grammar
+        case yieldEveryNTokens
     }
 
     public init(from decoder: Decoder) throws {
@@ -182,6 +199,8 @@ public struct GenerationConfig: Sendable, Codable {
         // thinkingMarkers is a per-request runtime hint; it is not persisted.
         thinkingMarkers = nil
         grammar = try c.decodeIfPresent(String.self, forKey: .grammar)
+        // yieldEveryNTokens landed after the original shape; default to 8 when absent.
+        yieldEveryNTokens = (try c.decodeIfPresent(Int.self, forKey: .yieldEveryNTokens)) ?? 8
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -199,6 +218,7 @@ public struct GenerationConfig: Sendable, Codable {
         try c.encode(jsonMode, forKey: .jsonMode)
         try c.encode(maxToolIterations, forKey: .maxToolIterations)
         try c.encodeIfPresent(grammar, forKey: .grammar)
+        try c.encode(yieldEveryNTokens, forKey: .yieldEveryNTokens)
     }
 }
 

--- a/Tests/BaseChatBackendsTests/MLXBackendGenerationTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXBackendGenerationTests.swift
@@ -489,6 +489,56 @@ final class MLXBackendGenerationTests: XCTestCase {
         // failing the count == 3 assertion.
     }
 
+    /// Cancellation during the cooperative yield must not crash, must not leak
+    /// `CancellationError` to the consumer (the production sleep is `try?`'d),
+    /// and the next loop iteration's `Task.isCancelled` check must terminate
+    /// the stream cleanly.
+    ///
+    /// The hook substitutes for `Task.sleep`, so to model "cancellation while
+    /// the task is sleeping" we cancel the surrounding generation Task from
+    /// inside the hook itself — this exercises the same control-flow shape as
+    /// a real cancel arriving during the 50µs sleep.
+    func test_yieldEveryNTokens_cancellationDuringYield_terminatesCleanly() async throws {
+        let mock = MockMLXModelContainer()
+        mock.tokensToYield = Array(repeating: "x", count: 32)
+
+        let backend = MLXBackend()
+        backend._inject(mock)
+
+        // Cancel mid-generation from inside the yield hook. By the time the
+        // first yield fires (at chunk 4) we cancel via stopGeneration(), which
+        // cancels the underlying generation Task. The next iteration of the
+        // mlxStream `for await` should observe `Task.isCancelled` and break.
+        MLXBackend._yieldHookForTesting = { [weak backend] in
+            backend?.stopGeneration()
+        }
+        defer { MLXBackend._yieldHookForTesting = nil }
+
+        var config = GenerationConfig()
+        config.yieldEveryNTokens = 4
+        config.maxOutputTokens = 100
+
+        let stream = try backend.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: config
+        )
+
+        // Drain the stream — must complete without throwing, even though the
+        // surrounding task was cancelled mid-yield. The `try?` on the sleep
+        // (allowlisted in SilentCatchAuditTest) intentionally swallows any
+        // CancellationError so the for-await observes cancellation at the top
+        // of the next iteration.
+        let tokens = try await collectTokens(from: stream)
+
+        // Expect at most ~yieldEvery tokens to have been emitted before the
+        // cancel propagated. Strictly: no more than one full cadence past the
+        // cancel point. The point of the assertion is simply that we exited
+        // cleanly and didn't drain all 32 tokens.
+        XCTAssertLessThan(tokens.count, 32,
+            "Cancellation during yield must terminate the stream early")
+    }
+
     func test_sendableLMInput_wrapsAndUnwraps() throws {
         // This test verifies `SendableLMInput` at the type level: the wrapper must
         // satisfy Swift's `Sendable` requirement so the compiler allows cross-actor

--- a/Tests/BaseChatBackendsTests/MLXBackendGenerationTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXBackendGenerationTests.swift
@@ -407,6 +407,88 @@ final class MLXBackendGenerationTests: XCTestCase {
         // messages array and failing the count assertion.
     }
 
+    // MARK: - WindowServer yield cadence (#747)
+
+    /// Asserts the cooperative yield inserted to prevent WindowServer GPU-queue
+    /// starvation fires every `yieldEveryNTokens` MLX-emitted chunks. We replace
+    /// the production `Task.sleep(for: .microseconds(50))` with a counting hook
+    /// so the test is deterministic and free of timing assumptions. Setting
+    /// `yieldEveryNTokens = 0` must disable the yield entirely.
+    ///
+    /// `#if MLX` plus the existing mock-container path keep this test running
+    /// in CI without Metal — the production code path is identical, the test
+    /// just substitutes the sleep with a counter.
+    func test_yieldEveryNTokens_firesAtConfiguredCadence() async throws {
+        // Atomically counted from the @Sendable hook to satisfy strict-concurrency.
+        final class YieldCounter: @unchecked Sendable {
+            private let lock = NSLock()
+            private var _count = 0
+            func increment() {
+                lock.lock(); defer { lock.unlock() }
+                _count += 1
+            }
+            var count: Int {
+                lock.lock(); defer { lock.unlock() }
+                return _count
+            }
+        }
+
+        let counter = YieldCounter()
+        MLXBackend._yieldHookForTesting = { counter.increment() }
+        defer { MLXBackend._yieldHookForTesting = nil }
+
+        // Configured cadence: every 4 chunks. With 12 chunks emitted we expect
+        // exactly 3 yields (at 4, 8, 12). maxOutputTokens is set high enough
+        // that the limit doesn't truncate before the full chunk count.
+        let mock = MockMLXModelContainer()
+        mock.tokensToYield = Array(repeating: "x", count: 12)
+
+        let backend = MLXBackend()
+        backend._inject(mock)
+
+        var config = GenerationConfig()
+        config.yieldEveryNTokens = 4
+        config.maxOutputTokens = 100
+
+        let stream = try backend.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: config
+        )
+        _ = try await collectTokens(from: stream)
+
+        XCTAssertEqual(counter.count, 3,
+            "Yield must fire exactly every yieldEveryNTokens chunks (12 / 4 = 3)")
+
+        // Now verify yieldEveryNTokens = 0 disables the yield entirely.
+        let counter2 = YieldCounter()
+        MLXBackend._yieldHookForTesting = { counter2.increment() }
+
+        let mock2 = MockMLXModelContainer()
+        mock2.tokensToYield = Array(repeating: "x", count: 12)
+
+        let backend2 = MLXBackend()
+        backend2._inject(mock2)
+
+        var disabledConfig = GenerationConfig()
+        disabledConfig.yieldEveryNTokens = 0
+        disabledConfig.maxOutputTokens = 100
+
+        let stream2 = try backend2.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: disabledConfig
+        )
+        _ = try await collectTokens(from: stream2)
+
+        XCTAssertEqual(counter2.count, 0,
+            "yieldEveryNTokens = 0 must skip the cooperative yield entirely")
+
+        // Sabotage check: changing the modulo condition to `% (yieldEvery + 1)`
+        // in MLXBackend would yield 2 times for 12 chunks at cadence 4 (at 5, 10),
+        // failing the count == 3 assertion.
+    }
+
     func test_sendableLMInput_wrapsAndUnwraps() throws {
         // This test verifies `SendableLMInput` at the type level: the wrapper must
         // satisfy Swift's `Sendable` requirement so the compiler allows cross-actor

--- a/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
+++ b/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
@@ -141,6 +141,14 @@ BaseChatBackends/MLXBackend.swift:let parsed = try? JSONSerialization.jsonObject
 # ensures only successfully-encoded calls are appended.
 BaseChatBackends/MLXBackend.swift:if let data = try? JSONSerialization.data(withJSONObject: callObj),
 
+# 50µs cooperative yield inserted every N tokens to prevent
+# WindowServer GPU-queue starvation during sustained MLX generation
+# (see issue #747; mirrors SwiftLM/Server.swift). The sleep is
+# best-effort: if the generation Task is cancelled mid-yield we
+# intentionally fall through to the next loop iteration where
+# `Task.isCancelled` is checked, rather than observing CancellationError.
+BaseChatBackends/MLXBackend.swift:try? await Task.sleep(for: .microseconds(50))
+
 # MLXToolCallParser.parseToolCall: defensive JSON parse of the buffered
 # payload between <tool_call>…</tool_call>. Models routinely emit
 # malformed payloads (truncated, partial Unicode, mid-token streaming);


### PR DESCRIPTION
## Summary

- Insert a 50µs cooperative yield every N tokens inside `MLXBackend`'s generation loop so sustained MLX inference doesn't starve WindowServer's GPU command queue (and hitch other Mac apps). Mirrors the pattern in `SwiftLM/Server.swift`.
- Plumb a `GenerationConfig.yieldEveryNTokens` knob (default 8; `0` disables). Only `MLXBackend` honours it — Llama / Foundation / cloud backends don't share the contention.
- Add `MLXBackend._yieldHookForTesting` test seam so the unit test counts yield invocations deterministically without timing assertions.

Closes #747.

## Test plan

- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` (no `GenerationConfig` regression; new field round-trips through `Codable`).
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` (CI path — 75 tests pass).
- [x] `swift test --filter BaseChatBackendsTests --traits MLX` on Apple Silicon (118 tests pass; new test fires).
- [x] `swift test --filter BaseChatCoreTests / BaseChatUITests / BaseChatTestSupportTests / BaseChatInferenceSwiftTestingTests --disable-default-traits`.
- [x] Sabotage check: changing the modulo to `% (yieldEvery + 1)` fails the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)