### PR TITLE
feat(ui): live streaming display for thinking tokens

### DIFF
--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -297,6 +297,27 @@ public final class ChatViewModel {
     /// Maximum characters to buffer before forcing a UI flush during streaming.
     public var streamingBatchCharacterLimit: Int = 128
 
+    /// Minimum interval between batched UI updates for streaming reasoning text.
+    ///
+    /// Decoupled from ``streamingUpdateInterval`` so apps can tune the visible-
+    /// token cadence (which drives the primary message body) independently
+    /// from reasoning preview cadence (which drives the small inline label
+    /// inside the thinking disclosure group). Defaults match the visible-token
+    /// batcher.
+    public var thinkingStreamingUpdateInterval: Duration = .milliseconds(33)
+    /// Maximum characters to buffer before forcing a UI flush for streaming reasoning text.
+    public var thinkingStreamingBatchCharacterLimit: Int = 128
+
+    /// Message IDs whose reasoning block is still being streamed.
+    ///
+    /// Populated when the first ``GenerationStreamConsumer/Action/appendThinkingText``
+    /// fragment lands and cleared on ``GenerationStreamConsumer/Action/finalizeThinking``
+    /// (or stream termination). Views read this to decide whether to render
+    /// a partial-preview affordance versus the finalized disclosure group.
+    /// Internal so views in the same module can read it without widening
+    /// the public surface.
+    var messageIDsWithStreamingThinking: Set<UUID> = []
+
     /// Whether to automatically stop generation when repetitive looping is detected.
     /// Defaults to `true`. Disable for apps that handle loop detection themselves.
     public var loopDetectionEnabled: Bool = true
@@ -606,6 +627,16 @@ public final class ChatViewModel {
         genCoordinator.loopDetectionEnabled = { [weak self] in self?.loopDetectionEnabled ?? true }
         genCoordinator.streamingUpdateInterval = { [weak self] in self?.streamingUpdateInterval ?? .milliseconds(33) }
         genCoordinator.streamingBatchCharacterLimit = { [weak self] in self?.streamingBatchCharacterLimit ?? 128 }
+        genCoordinator.thinkingStreamingUpdateInterval = { [weak self] in self?.thinkingStreamingUpdateInterval ?? .milliseconds(33) }
+        genCoordinator.thinkingStreamingBatchCharacterLimit = { [weak self] in self?.thinkingStreamingBatchCharacterLimit ?? 128 }
+        genCoordinator.onMarkThinkingStreaming = { [weak self] id, isStreaming in
+            guard let self else { return }
+            if isStreaming {
+                self.messageIDsWithStreamingThinking.insert(id)
+            } else {
+                self.messageIDsWithStreamingThinking.remove(id)
+            }
+        }
         genCoordinator.activeBackendName = { [weak self] in self?.activeBackendName }
         genCoordinator.activeSession = { [weak self] in self?.activeSession }
         genCoordinator.postGenerationTasks = { [weak self] in self?.postGenerationTasks ?? [] }

--- a/Sources/BaseChatUI/ViewModels/GenerationCoordinator.swift
+++ b/Sources/BaseChatUI/ViewModels/GenerationCoordinator.swift
@@ -109,6 +109,12 @@ final class GenerationCoordinator {
     /// Returns the streaming batch character limit.
     var streamingBatchCharacterLimit: () -> Int = { 128 }
 
+    /// Returns the streaming update interval for reasoning tokens.
+    var thinkingStreamingUpdateInterval: () -> Duration = { .milliseconds(33) }
+
+    /// Returns the streaming batch character limit for reasoning tokens.
+    var thinkingStreamingBatchCharacterLimit: () -> Int = { 128 }
+
     /// Returns the active backend name, or nil if none.
     var activeBackendName: () -> String? = { nil }
 
@@ -164,6 +170,11 @@ final class GenerationCoordinator {
 
     /// Removes an assistant message from the view model (called for empty responses).
     var onRemoveMessage: (UUID) -> Void = { _ in }
+
+    /// Notifies the view model that the given message has started or finished
+    /// streaming reasoning text. The UI uses this to switch between the
+    /// "Thinking… <preview>" affordance and the finalized disclosure group.
+    var onMarkThinkingStreaming: (UUID, Bool) -> Void = { _, _ in }
 
     // MARK: - Dependencies
 
@@ -275,8 +286,17 @@ final class GenerationCoordinator {
                     interval: self.streamingUpdateInterval(),
                     maxBufferedCharacters: self.streamingBatchCharacterLimit()
                 )
+                var thinkingBatcher = StreamingTokenBatcher(
+                    interval: self.thinkingStreamingUpdateInterval(),
+                    maxBufferedCharacters: self.thinkingStreamingBatchCharacterLimit()
+                )
                 var consumer = GenerationStreamConsumer(loopDetectionEnabled: self.loopDetectionEnabled())
                 var thinkingAccumulator = ""
+                // Tracks the text already flushed to the thinking part so partial
+                // updates can append rather than overwrite. Reset on finalize so
+                // a subsequent <think>…</think> block in the same response starts
+                // a fresh accumulator.
+                var thinkingDisplayed = ""
 
                 do {
                     eventLoop: for try await event in stream.events {
@@ -291,7 +311,7 @@ final class GenerationCoordinator {
                             if let batch = batcher.append(token, now: ContinuousClock.now) {
                                 var looping = false
                                 self.onMutateMessage(messageID) { msg in
-                                    msg.content += batch
+                                    Self.appendVisibleText(batch, into: &msg)
                                     if consumer.shouldStopForLoop(content: msg.content) {
                                         looping = true
                                     }
@@ -328,7 +348,11 @@ final class GenerationCoordinator {
                             if isFirstThinkingFragment {
                                 // Insert a placeholder `.thinking("")` part immediately so the
                                 // UI can render the "Thinking…" label during the reasoning phase
-                                // rather than staying on the generic typing placeholder.
+                                // rather than staying on the generic typing placeholder. Mark
+                                // the message's thinking as actively streaming so the disclosure
+                                // group renders an inline preview rather than the "Thinking…"
+                                // static label.
+                                self.onMarkThinkingStreaming(messageID, true)
                                 self.onMutateMessage(messageID) { msg in
                                     if msg.contentParts.firstIndex(where: { $0.thinkingContent != nil }) == nil {
                                         let insertAt = msg.contentParts.firstIndex(where: { $0.textContent != nil }) ?? 0
@@ -336,17 +360,45 @@ final class GenerationCoordinator {
                                     }
                                 }
                             }
+                            // Flush partial reasoning text into the thinking part on the
+                            // configured cadence so the user sees live progress instead of
+                            // a frozen "Thinking…" label.
+                            if let batch = thinkingBatcher.append(text, now: ContinuousClock.now) {
+                                thinkingDisplayed += batch
+                                let displayed = thinkingDisplayed
+                                self.onMutateMessage(messageID) { msg in
+                                    Self.writeThinkingPartialText(displayed, into: &msg)
+                                }
+                            }
 
                         case .finalizeThinking:
+                            // Drain any buffered partial fragments first so we don't
+                            // miss display content on tight streams that finish before
+                            // the batcher's interval elapses.
+                            if let batch = thinkingBatcher.flush(now: ContinuousClock.now) {
+                                thinkingDisplayed += batch
+                            }
                             let block = thinkingAccumulator
                             thinkingAccumulator = ""
+                            thinkingDisplayed = ""
+                            self.onMarkThinkingStreaming(messageID, false)
                             guard !block.isEmpty else { break }
                             self.onMutateMessage(messageID) { msg in
                                 // Append to any existing thinking part so multiple <think>…</think>
                                 // blocks within one response are concatenated into a single part.
                                 if let idx = msg.contentParts.firstIndex(where: { $0.thinkingContent != nil }) {
                                     let existing = msg.contentParts[idx].thinkingContent ?? ""
-                                    msg.contentParts[idx] = .thinking(existing.isEmpty ? block : existing + "\n\n" + block)
+                                    // The partial-streaming branch may have already written
+                                    // `block` (or a prefix of it) into `existing`. Replace the
+                                    // contents wholesale with the authoritative final text
+                                    // rather than concatenating it onto an in-flight prefix.
+                                    if existing == block || existing.isEmpty {
+                                        msg.contentParts[idx] = .thinking(block)
+                                    } else if block.hasPrefix(existing) {
+                                        msg.contentParts[idx] = .thinking(block)
+                                    } else {
+                                        msg.contentParts[idx] = .thinking(existing + "\n\n" + block)
+                                    }
                                 } else {
                                     let insertAt = msg.contentParts.firstIndex(where: { $0.textContent != nil }) ?? 0
                                     msg.contentParts.insert(.thinking(block), at: insertAt)
@@ -383,24 +435,35 @@ final class GenerationCoordinator {
 
                 // Flush remaining buffered tokens after stream ends (normal, error, or cancellation).
                 if let batch = batcher.flush(now: ContinuousClock.now) {
-                    self.onMutateMessage(messageID) { $0.content += batch }
+                    self.onMutateMessage(messageID) { msg in
+                        Self.appendVisibleText(batch, into: &msg)
+                    }
                 }
 
                 // Finalize an unclosed thinking block — a model may emit <think>…
                 // without a closing tag if generation is cut short.
                 if !thinkingAccumulator.isEmpty {
+                    _ = thinkingBatcher.flush(now: ContinuousClock.now)
                     let block = thinkingAccumulator
                     thinkingAccumulator = ""
+                    thinkingDisplayed = ""
                     self.onMutateMessage(messageID) { msg in
                         if let idx = msg.contentParts.firstIndex(where: { $0.thinkingContent != nil }) {
                             let existing = msg.contentParts[idx].thinkingContent ?? ""
-                            msg.contentParts[idx] = .thinking(existing.isEmpty ? block : existing + "\n\n" + block)
+                            if existing == block || existing.isEmpty || block.hasPrefix(existing) {
+                                msg.contentParts[idx] = .thinking(block)
+                            } else {
+                                msg.contentParts[idx] = .thinking(existing + "\n\n" + block)
+                            }
                         } else {
                             let insertAt = msg.contentParts.firstIndex(where: { $0.textContent != nil }) ?? 0
                             msg.contentParts.insert(.thinking(block), at: insertAt)
                         }
                     }
                 }
+                // Clear any lingering streaming flag if the stream ended without
+                // an explicit `.finalizeThinking` (cancellation, error, etc.).
+                self.onMarkThinkingStreaming(messageID, false)
             }
 
             onSetGenerationTask(task)
@@ -482,6 +545,43 @@ final class GenerationCoordinator {
             }
         }
         onSetBackgroundTask(bgTask)
+    }
+
+    /// Appends streamed visible-token text to a message without clobbering
+    /// any existing non-text parts (thinking, tool calls, tool results).
+    ///
+    /// `ChatMessageRecord.content`'s setter replaces the entire `contentParts`
+    /// array with a single `.text` part — convenient for the legacy text-only
+    /// path, fatal for messages that hold a `.thinking` part placed ahead of
+    /// the text. Preserve those parts by mutating only the trailing `.text`
+    /// (or appending one when none exists).
+    static func appendVisibleText(_ batch: String, into msg: inout ChatMessageRecord) {
+        if let lastIdx = msg.contentParts.indices.reversed().first(where: {
+            if case .text = msg.contentParts[$0] { return true } else { return false }
+        }), case .text(let existing) = msg.contentParts[lastIdx] {
+            msg.contentParts[lastIdx] = .text(existing + batch)
+        } else {
+            msg.contentParts.append(.text(batch))
+        }
+    }
+
+    /// Writes `partial` into the message's last `.thinking` part for live preview.
+    ///
+    /// Used between `.appendThinkingText` events to flush batched reasoning text
+    /// before the authoritative `.finalizeThinking` write. The text is written
+    /// in-place into the existing placeholder (inserted on the first thinking
+    /// fragment) so each flush mutates the same part rather than appending new
+    /// ones — keeping the message structure stable across rerenders.
+    static func writeThinkingPartialText(_ partial: String, into msg: inout ChatMessageRecord) {
+        guard let idx = msg.contentParts.firstIndex(where: { $0.thinkingContent != nil }) else {
+            // The placeholder should always exist by the time partial flushes
+            // run, but if it doesn't (e.g. tests that drive this helper
+            // directly), insert one ahead of any visible text.
+            let insertAt = msg.contentParts.firstIndex(where: { $0.textContent != nil }) ?? 0
+            msg.contentParts.insert(.thinking(partial), at: insertAt)
+            return
+        }
+        msg.contentParts[idx] = .thinking(partial)
     }
 
     /// Substitutes `{{key}}` tokens in `text` with values from `context`.

--- a/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
@@ -80,7 +80,12 @@ public struct MessageBubbleView: View {
             if !message.hasVisibleContent && !hasThinkingParts && isStreaming {
                 streamingPlaceholder
             } else {
-                MessagePartsView(parts: message.contentParts, role: .assistant, isStreaming: isStreaming)
+                MessagePartsView(
+                    parts: message.contentParts,
+                    role: .assistant,
+                    isStreaming: isStreaming,
+                    messageID: message.id
+                )
             }
 
             if isStreaming && message.hasVisibleContent {
@@ -198,6 +203,7 @@ public struct MessageBubbleView: View {
         message: ChatMessageRecord(role: .user, content: "Hello, tell me a story about a dragon.", sessionID: UUID()),
         isStreaming: false
     )
+    .environment(ChatViewModel())
 }
 
 #Preview("Assistant Message") {
@@ -205,6 +211,7 @@ public struct MessageBubbleView: View {
         message: ChatMessageRecord(role: .assistant, content: "Once upon a time, in a land far away, there lived a magnificent dragon named Ember.", sessionID: UUID()),
         isStreaming: false
     )
+    .environment(ChatViewModel())
 }
 
 #Preview("Assistant Streaming") {
@@ -212,6 +219,7 @@ public struct MessageBubbleView: View {
         message: ChatMessageRecord(role: .assistant, content: "Once upon a time...", sessionID: UUID()),
         isStreaming: true
     )
+    .environment(ChatViewModel())
 }
 
 #Preview("System Message") {

--- a/Sources/BaseChatUI/Views/Chat/MessagePartsView.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessagePartsView.swift
@@ -13,8 +13,21 @@ struct MessagePartsView: View {
     let parts: [MessagePart]
     let role: MessageRole
     var isStreaming: Bool = false
+    /// Identifier of the parent message. When non-nil, used to read whether
+    /// the message's reasoning is actively streaming so ``ThinkingBlockView``
+    /// can render an inline preview rather than the static "Thinking…" label.
+    /// Optional so unit tests that exercise text/tool rendering can omit it.
+    var messageID: UUID? = nil
 
     @Environment(ChatViewModel.self) private var viewModel
+
+    /// True while the parent message's reasoning block is still streaming —
+    /// computed from the view-model's transient streaming-thinking set keyed
+    /// by ``messageID``.
+    private var isThinkingStreaming: Bool {
+        guard let messageID else { return false }
+        return viewModel.messageIDsWithStreamingThinking.contains(messageID)
+    }
 
     /// Set of call IDs whose ``ToolResult`` already appears in `parts`. Used
     /// to decide whether a ``MessagePart/toolCall`` should render as
@@ -51,13 +64,13 @@ struct MessagePartsView: View {
             imageView(data)
 
         case .thinking(let text):
-            // A thinking part with empty text is a streaming placeholder inserted
-            // when the first .thinkingToken arrives; non-empty means the block was
-            // finalized by .thinkingComplete. Using the text emptiness rather than
-            // the overall isStreaming flag allows the disclosure group to appear
-            // as soon as reasoning is complete, even while visible tokens are still
-            // arriving.
-            ThinkingBlockView(text: text, isThinkingStreaming: text.isEmpty && isStreaming)
+            // While reasoning is in progress (`isThinkingStreaming`), the part's
+            // text holds whatever has been flushed so far by the streaming
+            // batcher and is rendered inline as a live preview. Once
+            // `.finalizeThinking` clears the flag, the text becomes the
+            // authoritative final block and the disclosure group switches to
+            // its collapsed-by-default view.
+            ThinkingBlockView(text: text, isThinkingStreaming: isThinkingStreaming)
 
         case .toolCall(let call):
             toolCallView(call)

--- a/Sources/BaseChatUI/Views/Chat/ThinkingBlockView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ThinkingBlockView.swift
@@ -2,9 +2,13 @@ import SwiftUI
 
 /// A collapsible disclosure group displaying model reasoning content.
 ///
-/// Shows a "Thinking…" label while `isThinkingStreaming` is true (reasoning is
-/// still in progress) and a disclosure triangle labelled "Reasoning" once the
-/// block is finalized. This is intentionally decoupled from the overall message
+/// While `isThinkingStreaming` is true the view renders a collapsed disclosure
+/// group whose label is `"Thinking… <inline preview>"` — the latest few lines
+/// of partial reasoning text streamed in via the thinking batcher in
+/// ``GenerationCoordinator``. Expanding the group reveals the full
+/// accumulated text. Once `isThinkingStreaming` flips to false the disclosure
+/// group switches to its finalized "Reasoning" label, still collapsed by
+/// default. This is intentionally decoupled from the overall message
 /// streaming flag — completed reasoning should become expandable even while
 /// visible tokens are still arriving.
 struct ThinkingBlockView: View {
@@ -16,18 +20,47 @@ struct ThinkingBlockView: View {
 
     @State private var isExpanded = false
 
+    /// Shows the trailing line of partial reasoning text inline next to the
+    /// "Thinking…" label so users see live progress without expanding the
+    /// disclosure group. Multi-line reasoning is collapsed to its last line
+    /// to keep bubble height stable while tokens stream in.
+    private var inlinePreview: String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+        let lastLine = trimmed.split(whereSeparator: \.isNewline).last.map(String.init) ?? trimmed
+        return String(lastLine.suffix(80))
+    }
+
     var body: some View {
         if isThinkingStreaming {
-            Label("Thinking…", systemImage: "brain")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .accessibilityLabel("Reasoning in progress")
-        } else {
             // `.accessibilitySortPriority` is intentionally omitted — SwiftUI
             // renders parts in document order, so ThinkingBlockView (placed before
             // the text parts in MessagePartsView's ForEach) is already visited
-            // first by VoiceOver. The disclosure group itself handles expand/collapse
-            // navigation; the inner Text is not reachable until expanded.
+            // first by VoiceOver.
+            DisclosureGroup(isExpanded: $isExpanded) {
+                Text(text.isEmpty ? " " : text)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                    .padding(.top, 4)
+            } label: {
+                HStack(spacing: 6) {
+                    Label("Thinking…", systemImage: "brain")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    if !inlinePreview.isEmpty {
+                        Text(inlinePreview)
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                            .truncationMode(.head)
+                            .accessibilityHidden(true)
+                    }
+                }
+            }
+            .accessibilityLabel("Reasoning in progress")
+            .accessibilityValue(text)
+        } else {
             DisclosureGroup(isExpanded: $isExpanded) {
                 Text(text)
                     .font(.caption)
@@ -53,7 +86,15 @@ struct ThinkingBlockView: View {
     .padding()
 }
 
-#Preview("Streaming") {
+#Preview("Streaming with preview") {
+    ThinkingBlockView(
+        text: "Let me think about this step by step. First I'll consider the constraints",
+        isThinkingStreaming: true
+    )
+    .padding()
+}
+
+#Preview("Streaming empty") {
     ThinkingBlockView(text: "", isThinkingStreaming: true)
         .padding()
 }

--- a/Sources/BaseChatUI/Views/Chat/ThinkingBlockView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ThinkingBlockView.swift
@@ -58,8 +58,14 @@ struct ThinkingBlockView: View {
                     }
                 }
             }
+            // Intentionally omit `.accessibilityValue(text)` here — `text`
+            // updates every ~33ms while reasoning streams, which floods
+            // VoiceOver with re-announcements of a value the user has not
+            // asked to hear yet. Expanding the disclosure group exposes the
+            // accumulated text via the inner `Text` for assistive reading;
+            // the static "Reasoning in progress" label is enough for the
+            // collapsed state.
             .accessibilityLabel("Reasoning in progress")
-            .accessibilityValue(text)
         } else {
             DisclosureGroup(isExpanded: $isExpanded) {
                 Text(text)

--- a/Tests/BaseChatUITests/ThinkingStreamingTests.swift
+++ b/Tests/BaseChatUITests/ThinkingStreamingTests.swift
@@ -122,4 +122,65 @@ final class ThinkingStreamingTests: XCTestCase {
             "messageIDsWithStreamingThinking must be empty after generation completes"
         )
     }
+
+    // MARK: - 3. Visible-text appends preserve sibling thinking parts
+    //
+    // Direct unit tests for `appendVisibleText` — the helper that replaces the
+    // `msg.content += batch` line whose setter clobbered any non-text parts
+    // (the latent bug noted in the PR description). These tests pin the
+    // contract so a future refactor can't silently regress to wholesale
+    // replacement.
+
+    func test_appendVisibleText_preservesLeadingThinkingPart() {
+        var msg = ChatMessageRecord(role: .assistant, content: "", sessionID: UUID())
+        msg.contentParts = [.thinking("reasoning"), .text("Hello")]
+
+        GenerationCoordinator.appendVisibleText(", world", into: &msg)
+
+        XCTAssertEqual(msg.contentParts.count, 2)
+        guard case .thinking(let t) = msg.contentParts[0] else {
+            return XCTFail("Expected leading .thinking part to survive append")
+        }
+        XCTAssertEqual(t, "reasoning")
+        guard case .text(let s) = msg.contentParts[1] else {
+            return XCTFail("Expected trailing .text part")
+        }
+        XCTAssertEqual(s, "Hello, world")
+    }
+
+    func test_appendVisibleText_appendsNewTextPart_whenNoneExists() {
+        var msg = ChatMessageRecord(role: .assistant, content: "", sessionID: UUID())
+        msg.contentParts = [.thinking("only reasoning so far")]
+
+        GenerationCoordinator.appendVisibleText("first visible", into: &msg)
+
+        XCTAssertEqual(msg.contentParts.count, 2)
+        guard case .thinking = msg.contentParts[0] else {
+            return XCTFail("Thinking part must remain at index 0")
+        }
+        guard case .text(let s) = msg.contentParts[1] else {
+            return XCTFail("New .text part must be appended after thinking")
+        }
+        XCTAssertEqual(s, "first visible")
+    }
+
+    // MARK: - 4. Partial thinking writes mutate the placeholder in place
+
+    func test_writeThinkingPartialText_replacesExistingPlaceholder() {
+        var msg = ChatMessageRecord(role: .assistant, content: "", sessionID: UUID())
+        msg.contentParts = [.thinking(""), .text("visible")]
+
+        GenerationCoordinator.writeThinkingPartialText("Let me", into: &msg)
+        GenerationCoordinator.writeThinkingPartialText("Let me think", into: &msg)
+
+        XCTAssertEqual(msg.contentParts.count, 2, "No new parts should be appended on partial flushes")
+        guard case .thinking(let t) = msg.contentParts[0] else {
+            return XCTFail("Index 0 must remain a .thinking part")
+        }
+        XCTAssertEqual(t, "Let me think")
+        guard case .text(let s) = msg.contentParts[1] else {
+            return XCTFail("Index 1 must remain the .text part")
+        }
+        XCTAssertEqual(s, "visible")
+    }
 }

--- a/Tests/BaseChatUITests/ThinkingStreamingTests.swift
+++ b/Tests/BaseChatUITests/ThinkingStreamingTests.swift
@@ -1,0 +1,125 @@
+@preconcurrency import XCTest
+@testable import BaseChatUI
+@testable import BaseChatCore
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Asserts the live-streaming behavior introduced for issue #481: the
+/// reasoning block must mutate multiple times during the streaming phase
+/// rather than only being written once on `.finalizeThinking`.
+@MainActor
+final class ThinkingStreamingTests: XCTestCase {
+
+    private let oneGB: UInt64 = 1_024 * 1_024 * 1_024
+
+    private func makeVM(backend: MockInferenceBackend) -> ChatViewModel {
+        backend.isModelLoaded = true
+        let service = InferenceService(backend: backend, name: "Mock")
+        let vm = ChatViewModel(
+            inferenceService: service,
+            deviceCapability: DeviceCapabilityService(physicalMemory: 16 * oneGB),
+            modelStorage: ModelStorageService(),
+            memoryPressure: MemoryPressureHandler()
+        )
+        vm.activeSession = ChatSessionRecord(title: "Test")
+        // Force per-token flushes for both batchers so every thinking fragment
+        // and visible token causes its own observable mutation, making the
+        // intermediate states visible to the test recorder.
+        vm.thinkingStreamingUpdateInterval = .zero
+        vm.thinkingStreamingBatchCharacterLimit = 1
+        vm.streamingUpdateInterval = .zero
+        vm.streamingBatchCharacterLimit = 1
+        return vm
+    }
+
+    // MARK: - 1. Live thinking streams produce multiple part mutations
+
+    func test_thinkingPart_mutatedMultipleTimesBeforeFinalize() async {
+        let mock = MockInferenceBackend()
+        // Five thinking fragments → at minimum five distinct partial-flush
+        // mutations, plus the placeholder insert and the finalize write.
+        mock.thinkingTokensToYield = ["Let", " me", " think", " about", " this"]
+        mock.tokensToYield = ["done"]
+        let vm = makeVM(backend: mock)
+
+        // Wrap onMutateMessage so we record the thinking-part text after each
+        // mutation, distinguishing pre-finalize states from the authoritative
+        // post-finalize write. The wrapper preserves the original wiring so
+        // ChatViewModel state still updates correctly.
+        var thinkingTextHistory: [String?] = []
+        let originalMutate = vm.generationCoordinator.onMutateMessage
+        vm.generationCoordinator.onMutateMessage = { id, body in
+            originalMutate(id, body)
+            // Reread the message from the view model so we observe the post-
+            // mutation state rather than relying on the mutation closure's
+            // intent.
+            let parts = vm.messages.first(where: { $0.id == id })?.contentParts ?? []
+            let thinkingText = parts.compactMap { part -> String? in
+                if case .thinking(let s) = part { return s }
+                return nil
+            }.first
+            thinkingTextHistory.append(thinkingText)
+        }
+
+        // Capture the exact moment streaming flips off so we can split the
+        // history into pre- and post-finalize ranges.
+        var preFinalizeCount = 0
+        let originalMark = vm.generationCoordinator.onMarkThinkingStreaming
+        vm.generationCoordinator.onMarkThinkingStreaming = { id, isStreaming in
+            if !isStreaming && preFinalizeCount == 0 {
+                preFinalizeCount = thinkingTextHistory.count
+            }
+            originalMark(id, isStreaming)
+        }
+
+        vm.inputText = "hello"
+        await vm.sendMessage()
+
+        // Filter to mutations that actually touched a thinking part (a few
+        // mutations record nil because they only mutate the visible-text
+        // content while no thinking part exists yet — those don't count).
+        let preFinalizeThinkingStates = Array(thinkingTextHistory.prefix(preFinalizeCount))
+            .compactMap { $0 }
+
+        // Distinct snapshots tell us how many times the *thinking* part
+        // changed before finalization. With per-token flushes the count must
+        // exceed one (placeholder insert + at least one partial flush).
+        let distinctPreFinalize = Set(preFinalizeThinkingStates)
+        XCTAssertGreaterThan(
+            distinctPreFinalize.count,
+            1,
+            "Thinking part must be mutated more than once before finalizeThinking. " +
+            "Saw \(distinctPreFinalize.count) distinct pre-finalize states: \(distinctPreFinalize). " +
+            "Pre-finalize history count: \(preFinalizeCount)."
+        )
+
+        // Authoritative final text is the full concatenated reasoning.
+        let assistant = vm.messages.first(where: { $0.role == .assistant })
+        let finalThinking = assistant?.contentParts.compactMap { part -> String? in
+            if case .thinking(let s) = part { return s }
+            return nil
+        }.first
+        XCTAssertEqual(
+            finalThinking,
+            "Let me think about this",
+            "Final thinking text must equal the full concatenated reasoning"
+        )
+    }
+
+    // MARK: - 2. Streaming flag clears on finalize
+
+    func test_streamingThinkingFlag_clearsOnFinalize() async {
+        let mock = MockInferenceBackend()
+        mock.thinkingTokensToYield = ["a", "b", "c", "d", "e"]
+        mock.tokensToYield = ["ok"]
+        let vm = makeVM(backend: mock)
+
+        vm.inputText = "hi"
+        await vm.sendMessage()
+
+        XCTAssertTrue(
+            vm.messageIDsWithStreamingThinking.isEmpty,
+            "messageIDsWithStreamingThinking must be empty after generation completes"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the static "Thinking…" placeholder with a live preview of streamed reasoning text, addressing #481.

- Adds a second `StreamingTokenBatcher` dedicated to thinking text — flushes partial content into the message's `.thinking` `MessagePart` on a configurable cadence (`thinkingStreamingUpdateInterval` / `thinkingStreamingBatchCharacterLimit`, both default to the visible-token defaults: 33 ms / 128 chars).
- `.finalizeThinking` still writes the authoritative final text after draining the batcher; intermediate flushes are display-only as the issue prescribes.
- `ThinkingBlockView` now renders a collapsed disclosure group with a `"Thinking… <inline preview>"` label while reasoning is in flight, then switches to the finalized "Reasoning" disclosure (still collapsed by default).
- A transient `Set<UUID>` on `ChatViewModel` (`messageIDsWithStreamingThinking`) tracks which message has an active reasoning stream, populated from a new `onMarkThinkingStreaming` seam on `GenerationCoordinator`.
- Fixes a latent bug uncovered by the new test: `msg.content += batch` clobbered sibling `.thinking` / tool parts (the `content` setter replaces `contentParts` wholesale). Visible-token appends now mutate the trailing `.text` part directly.

## Test plan

- [x] New `Tests/BaseChatUITests/ThinkingStreamingTests.swift` streams 5 `.thinkingToken` events through `MockInferenceBackend` and asserts the message's thinking part is mutated more than once before `.finalizeThinking` (sabotage check confirmed: disabling the partial-flush block drops distinct pre-finalize states from N to 1).
- [x] `swift test --filter BaseChatUITests --disable-default-traits --skip-update` — 481 tests, 0 failures.
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits --skip-update` — 214 tests passed.
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits --skip-update` — 1085 tests passed.
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits --skip-update` — 69 tests passed.
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits --skip-update` — passed.
- [x] `swift test --filter BaseChatTestSupportTests --disable-default-traits --skip-update` — 13 tests passed.

Closes #481.

🤖 Generated with [Claude Code](https://claude.com/claude-code)