### PR TITLE
test(backends): hardware-gated E2E for LlamaBackend with thinking GGUF

### DIFF
--- a/Tests/BaseChatE2ETests/LlamaThinkingE2ETests.swift
+++ b/Tests/BaseChatE2ETests/LlamaThinkingE2ETests.swift
@@ -1,0 +1,223 @@
+#if Llama
+import XCTest
+import BaseChatCore
+import BaseChatInference
+import BaseChatTestSupport
+@testable import BaseChatBackends
+
+/// Hardware-gated end-to-end test for `LlamaBackend` driving a real thinking-capable
+/// GGUF (Qwen3-0.6B-Instruct-Q4_K_M or similar). Verifies the full
+/// `LlamaGenerationDriver` thinking-parser pipeline: per-token decode -> ThinkingParser
+/// -> `.thinkingToken` / `.thinkingComplete` events -> visible `.token` events.
+///
+/// All thinking-token tests in CI use `MockInferenceBackend`, which bypasses the real
+/// `LlamaGenerationDriver` integration with `ThinkingParser`. A regression in the C-API
+/// token decode loop or in the parser wiring would only be caught manually — this test
+/// exercises that path on hardware.
+///
+/// # Sabotage check
+///
+/// Removing `markers:` from `LlamaGenerationDriver.run()` (i.e. forcing the parser
+/// off in `LlamaBackend.swift` where `markers: config.thinkingMarkers` is passed)
+/// must fail this test. Specifically:
+///
+/// - `thinkingTokenCount` would drop to 0 (no `.thinkingToken` events)
+/// - `thinkingCompleteCount` would drop to 0
+/// - `visibleText` would contain raw `<think>` / `</think>` tags
+///
+/// Any one of those assertions failing is the regression signal.
+///
+/// # Hardware & trait gating
+///
+/// - `#if Llama` — only compiled when the Llama trait is enabled (Apple Silicon).
+/// - `XCTSkipUnless(HardwareRequirements.isAppleSilicon)` — Metal + llama.cpp.
+/// - `XCTSkipUnless(HardwareRequirements.isPhysicalDevice)` — simulator lacks Metal.
+/// - Skipped when no thinking-capable GGUF is available on disk. The canonical path
+///   is `~/Library/Caches/BaseChatKit/test-models/qwen3-thinking.gguf`. As a fallback
+///   the test falls back to `HardwareRequirements.findGGUFModel()` (any GGUF in
+///   `~/Documents/Models/`) and then probes the model — a non-thinking GGUF will
+///   skip rather than fail.
+///
+/// `BaseChatE2ETests` does not run in CI (see `ci.yml`); this test exists for
+/// developer pre-push verification only. See `Tests/BaseChatE2ETests/README.md`
+/// for instructions on provisioning the test model.
+@MainActor
+final class LlamaThinkingE2ETests: XCTestCase {
+
+    private var backend: LlamaBackend!
+    private var modelURL: URL!
+
+    // MARK: - Setup / Teardown
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        try XCTSkipUnless(HardwareRequirements.isAppleSilicon,
+                          "LlamaBackend requires Apple Silicon (arm64)")
+        try XCTSkipUnless(HardwareRequirements.isPhysicalDevice,
+                          "LlamaBackend requires Metal (unavailable in simulator)")
+
+        guard let url = Self.locateThinkingGGUF() else {
+            throw XCTSkip(
+                "No thinking-capable GGUF found. Place a Qwen3 (or other ChatML "
+                + "thinking) model at ~/Library/Caches/BaseChatKit/test-models/qwen3-thinking.gguf "
+                + "or in ~/Documents/Models/. See Tests/BaseChatE2ETests/README.md."
+            )
+        }
+        modelURL = url
+
+        backend = LlamaBackend()
+        // Qwen3-class reasoning on a step-by-step prompt routinely emits 1k+
+        // thinking tokens before closing `</think>`; load with a roomy context
+        // so a single test request can hold the prompt + reasoning + visible
+        // answer without tripping the context-exhaustion preflight.
+        try await backend.loadModel(from: url, plan: .testStub(effectiveContextSize: 4096))
+    }
+
+    override func tearDown() async throws {
+        if let backend {
+            await backend.unloadAndWait()
+        }
+        backend = nil
+        modelURL = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Locates a candidate thinking-capable GGUF on disk. Prefers the canonical
+    /// thinking cache path; falls back to any GGUF in `~/Documents/Models/` so
+    /// developers who already have a Qwen3 fixture there don't need to duplicate it.
+    private static func locateThinkingGGUF() -> URL? {
+        let fm = FileManager.default
+
+        // Canonical path documented in Tests/BaseChatE2ETests/README.md.
+        if let home = ProcessInfo.processInfo.environment["HOME"] {
+            let canonical = URL(fileURLWithPath: home)
+                .appendingPathComponent("Library/Caches/BaseChatKit/test-models/qwen3-thinking.gguf")
+            if fm.fileExists(atPath: canonical.path) {
+                return canonical
+            }
+        }
+
+        // Fallback: any GGUF the existing Llama E2E suite already discovered.
+        return HardwareRequirements.findGGUFModel()
+    }
+
+    /// Prompt that reliably provokes chain-of-thought on Qwen3-class reasoning models.
+    /// Mirrors the issue's recommendation ("What is 17 × 23? Think step by step.").
+    private static let reasoningPrompt = "What is 17 × 23? Think step by step."
+
+    // MARK: - Test
+
+    /// Asserts the full thinking pipeline:
+    /// - at least one `.thinkingToken` event
+    /// - exactly one `.thinkingComplete` event before the first visible `.token`
+    /// - non-empty visible output
+    /// - visible output does NOT contain raw `<think>` / `</think>` tags
+    ///   (the parser must strip them — leaking tags is a hard regression signal).
+    ///
+    /// Skips (rather than fails) when the discovered GGUF is not actually a
+    /// thinking model: a non-Qwen3 fallback can satisfy `findGGUFModel()` but
+    /// emits no `<think>` block, which would make assertions vacuous.
+    func testLlamaBackend_thinkingGGUF_emitsThinkingEventsBeforeVisibleOutput() async throws {
+        // ChatML formatting is required — LlamaBackend does not apply chat templates.
+        // The Qwen3 family expects ChatML wrapping; `PromptTemplate.chatML.thinkingMarkers`
+        // resolves to `.qwen3` (`<think>` / `</think>`), which the backend forwards to
+        // `LlamaGenerationDriver` via `config.thinkingMarkers`.
+        let formattedPrompt = PromptTemplate.chatML.format(
+            messages: [(role: "user", content: Self.reasoningPrompt)],
+            systemPrompt: nil
+        )
+        // Qwen3-4B-class models routinely emit >1k tokens of reasoning on a
+        // step-by-step arithmetic prompt before producing visible output.
+        // 3072 leaves room for the prompt (~30 tokens) plus a long reasoning
+        // trace plus a non-empty visible answer inside the 4096-token context.
+        let config = GenerationConfig(
+            temperature: 0.3,
+            maxOutputTokens: 3072,
+            thinkingMarkers: PromptTemplate.chatML.thinkingMarkers
+        )
+
+        let stream = try backend.generate(
+            prompt: formattedPrompt,
+            systemPrompt: nil,
+            config: config
+        )
+
+        var thinkingTokenCount = 0
+        var thinkingCompleteCount = 0
+        var firstTokenAfterThinkingComplete: Bool?
+        var visibleText = ""
+        var sawFirstVisibleToken = false
+
+        for try await event in stream.events {
+            switch event {
+            case .thinkingToken:
+                thinkingTokenCount += 1
+                if sawFirstVisibleToken {
+                    XCTFail("Received .thinkingToken after visible .token — reasoning must precede visible output (model: \(modelURL.lastPathComponent))")
+                }
+            case .thinkingComplete:
+                thinkingCompleteCount += 1
+                if !sawFirstVisibleToken {
+                    firstTokenAfterThinkingComplete = true
+                }
+            case .token(let text):
+                visibleText += text
+                sawFirstVisibleToken = true
+                if firstTokenAfterThinkingComplete == nil {
+                    firstTokenAfterThinkingComplete = false
+                }
+            default:
+                continue
+            }
+        }
+
+        // Non-thinking GGUFs (e.g. smollm2) trip `findGGUFModel()` but do not emit
+        // `<think>...</think>`. Skip rather than fail so this test stays actionable
+        // for developers without a Qwen3 fixture handy.
+        try XCTSkipIf(
+            thinkingTokenCount == 0,
+            "GGUF '\(modelURL.lastPathComponent)' did not emit any .thinkingToken events. "
+            + "This test requires a thinking-capable model (e.g. Qwen3). See "
+            + "Tests/BaseChatE2ETests/README.md for the canonical fixture."
+        )
+
+        XCTAssertGreaterThan(
+            thinkingTokenCount,
+            0,
+            "Thinking GGUF must emit at least one .thinkingToken (model: \(modelURL.lastPathComponent))"
+        )
+        XCTAssertEqual(
+            thinkingCompleteCount,
+            1,
+            "Exactly one .thinkingComplete event must fire (got \(thinkingCompleteCount), model: \(modelURL.lastPathComponent))"
+        )
+        XCTAssertEqual(
+            firstTokenAfterThinkingComplete,
+            true,
+            ".thinkingComplete must fire before the first visible .token (model: \(modelURL.lastPathComponent))"
+        )
+        XCTAssertFalse(
+            visibleText.isEmpty,
+            "Thinking model must still emit a visible response (model: \(modelURL.lastPathComponent))"
+        )
+
+        // Parser regression check: `LlamaGenerationDriver` must strip the literal
+        // marker tokens out of visible output. If `markers:` is not threaded through
+        // to the driver, raw `<think>` / `</think>` would surface here — that is the
+        // primary signal this test is designed to catch.
+        XCTAssertFalse(
+            visibleText.contains("<think>"),
+            "Visible output must not contain raw <think> tag — ThinkingParser failed to strip it "
+            + "(model: \(modelURL.lastPathComponent), output prefix: \(visibleText.prefix(200)))"
+        )
+        XCTAssertFalse(
+            visibleText.contains("</think>"),
+            "Visible output must not contain raw </think> tag — ThinkingParser failed to strip it "
+            + "(model: \(modelURL.lastPathComponent), output prefix: \(visibleText.prefix(200)))"
+        )
+    }
+}
+#endif

--- a/Tests/BaseChatE2ETests/README.md
+++ b/Tests/BaseChatE2ETests/README.md
@@ -1,0 +1,82 @@
+# BaseChatE2ETests
+
+Hardware-gated end-to-end tests. **These do not run in CI** (`.github/workflows/ci.yml`
+runs only the mock-friendly suites). They exist for developer pre-push verification
+and skip cleanly when the required hardware/fixtures are missing.
+
+Each test guards itself with one of:
+
+- `XCTSkipUnless(HardwareRequirements.isAppleSilicon)` — Metal / llama.cpp tests.
+- `XCTSkipUnless(HardwareRequirements.isPhysicalDevice)` — simulator lacks Metal.
+- `XCTSkipUnless(HardwareRequirements.hasOllamaServer)` — Ollama-driven tests.
+- A direct fixture-path probe (e.g. `LlamaThinkingE2ETests`).
+
+## Running
+
+```bash
+# All E2E tests; most will skip when their fixture / server isn't present.
+swift test --filter BaseChatE2ETests --disable-default-traits
+
+# Targeted: just the Llama thinking pipeline.
+swift test --filter BaseChatE2ETests/LlamaThinkingE2ETests --disable-default-traits
+
+# Llama-trait-gated tests (Apple Silicon required).
+swift test --filter BaseChatE2ETests --traits Llama
+```
+
+## Test fixtures
+
+### GGUF models (`LlamaE2ETests`, `LlamaBackendLoadSerializationCharacterizationE2ETests`)
+
+Place any quantized GGUF >= 50 MB in `~/Documents/Models/`. The first matching file is
+picked up by `HardwareRequirements.findGGUFModel()`. SmolLM2 or Qwen2.5 fixtures are
+sufficient for non-thinking tests.
+
+### Thinking GGUF (`LlamaThinkingE2ETests`)
+
+`LlamaThinkingE2ETests` exercises the `LlamaGenerationDriver` thinking-parser
+integration, so it needs a model that actually emits `<think>...</think>` blocks.
+The Qwen3 family is the canonical fixture (Qwen3-0.6B is the smallest and runs on
+machines with as little as 8 GB RAM).
+
+**Canonical path** (preferred):
+
+```
+~/Library/Caches/BaseChatKit/test-models/qwen3-thinking.gguf
+```
+
+The test also falls back to any GGUF discovered by `findGGUFModel()` in
+`~/Documents/Models/` and skips cleanly when the discovered model does not emit
+thinking tokens (e.g. when it picks up a non-Qwen3 fixture).
+
+**Recommended download** — Qwen3-0.6B-Instruct-GGUF (Q4_K_M quant is ~440 MB):
+
+```bash
+mkdir -p ~/Library/Caches/BaseChatKit/test-models
+curl -L \
+  "https://huggingface.co/Qwen/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q4_K_M.gguf" \
+  -o ~/Library/Caches/BaseChatKit/test-models/qwen3-thinking.gguf
+```
+
+> **Note:** verify the exact file name on HuggingFace before downloading — the Qwen
+> team occasionally renames quants. Any Qwen3 GGUF that emits `<think>` blocks works;
+> the test does not depend on a specific quant or size.
+
+### MLX models (`ModelSelectionE2ETests`, etc.)
+
+Place an MLX snapshot directory (containing `config.json`, `*.safetensors`, and a
+tokenizer file) under `~/Documents/Models/`. `HardwareRequirements.findMLXModelDirectory()`
+discovers it.
+
+### Ollama (`OllamaE2ETests`, `OllamaThinkingE2ETests`, `OllamaToolCallingE2ETests`)
+
+Run Ollama locally:
+
+```bash
+brew install ollama
+ollama serve &
+ollama pull qwen3.5:4b   # for thinking tests
+ollama pull llama3.2:3b  # for general tests
+```
+
+The tests skip automatically when `localhost:11434` is unreachable.


### PR DESCRIPTION
## Summary

- Adds `Tests/BaseChatE2ETests/LlamaThinkingE2ETests.swift` — a hardware-gated E2E test that drives `LlamaBackend` against a real Qwen3-class thinking GGUF and asserts `.thinkingToken` / `.thinkingComplete` events fire before visible `.token` events, and that the visible output contains no raw `<think>` / `</think>` tags.
- Adds `Tests/BaseChatE2ETests/README.md` documenting fixture provisioning for the full E2E suite (GGUF, MLX, Ollama).
- Closes #483.

## Why this test exists

All thinking-token tests in CI use `MockInferenceBackend`, which bypasses the real `LlamaGenerationDriver` <-> `ThinkingParser` integration. A regression in the C-API token decode loop or in how `markers:` is wired through `LlamaBackend.swift` -> `LlamaGenerationDriver.run(markers:)` would only be caught manually. This test exercises that path on hardware.

The sabotage check is documented in the test file: removing `markers:` from the `LlamaGenerationDriver.run()` call must fail this test (no `.thinkingToken` events, no `.thinkingComplete`, raw `<think>` tags leaking into visible output).

## CI behavior

`BaseChatE2ETests` does not run in CI per `ci.yml` — this is purely additive for developer / local pre-push verification. The test skips cleanly when:

- not on Apple Silicon
- not on a physical device (simulator lacks Metal)
- no GGUF found at the canonical path (`~/Library/Caches/BaseChatKit/test-models/qwen3-thinking.gguf`) or in `~/Documents/Models/`
- the discovered GGUF doesn't actually emit `<think>` blocks (e.g. the suite picks up smollm2 from a shared `Models/` directory)

## Verification

Locally on Apple Silicon with a Qwen3-4B GGUF symlinked to the canonical path:

```
swift test --filter LlamaThinkingE2ETests --traits Llama
# Test Suite 'LlamaThinkingE2ETests' passed at 2026-04-25 17:57:26.437.
# Executed 1 test, with 0 failures (0 unexpected) in 76.138 seconds.
```

Without the symlink (test falls back to smollm2 in `~/Documents/Models/`):
```
# Test Case '...' skipped: GGUF 'smollm2-135m-instruct.Q4_K_M.gguf' did not emit any .thinkingToken events.
```

Without `--traits Llama` (CI mode):
```
swift test --filter BaseChatE2ETests --disable-default-traits
# Executed 51 tests, 0 failures — new test compiled out via #if Llama.
```

## Notes for review

- The README points at HuggingFace `Qwen/Qwen3-0.6B-GGUF` as the canonical model. **Please confirm the exact filename** (`Qwen3-0.6B-Q4_K_M.gguf`) on the HF mirror — quant filenames occasionally drift. Any Qwen3 GGUF that emits `<think>` works; the test does not pin a specific quant.
- The test loads with `effectiveContextSize: 4096` and `maxOutputTokens: 3072`. Qwen3-class models routinely emit 1k+ thinking tokens on a step-by-step prompt before producing visible output; smaller budgets cause the test to terminate mid-`<think>` block. Qwen3-0.6B should fit comfortably; a future move to that smaller fixture may let us reduce the budgets.

## Test plan

- [x] `swift test --filter BaseChatE2ETests --disable-default-traits` passes (skips cleanly without Llama trait)
- [x] `swift test --filter LlamaThinkingE2ETests --traits Llama` passes with Qwen3-4B at the canonical path
- [x] Test skips cleanly when only a non-thinking GGUF (smollm2) is available