### PR TITLE
feat(mlx): route MoE Gemma 4 through MLXVLM factory

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -101,6 +101,12 @@ let package = Package(
                 .product(name: "MLX", package: "mlx-swift", condition: .when(traits: ["MLX"])),
                 .product(name: "MLXLLM", package: "mlx-swift-lm", condition: .when(traits: ["MLX"])),
                 .product(name: "MLXLMCommon", package: "mlx-swift-lm", condition: .when(traits: ["MLX"])),
+                // MLXVLM ships the MoE Gemma 4 decoder (Libraries/MLXVLM/Models/Gemma4.swift)
+                // that LLMModelFactory's Gemma4Text.swift lacks. MLXBackend sniffs config.json
+                // and routes models with `text_config.enable_moe_block == true` (e.g.
+                // mlx-community/gemma-4-26b-a4b-it-4bit) to VLMModelFactory.shared.loadContainer.
+                // See issue #752.
+                .product(name: "MLXVLM", package: "mlx-swift-lm", condition: .when(traits: ["MLX"])),
                 .product(name: "MLXHuggingFace", package: "mlx-swift-lm", condition: .when(traits: ["MLX"])),
                 .product(name: "Tokenizers", package: "swift-transformers", condition: .when(traits: ["MLX"])),
                 .product(name: "LlamaSwift", package: "llama.swift", condition: .when(traits: ["Llama"])),

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -3,6 +3,7 @@ import Foundation
 import MLX
 import MLXLLM
 import MLXLMCommon
+import MLXVLM
 import MLXHuggingFace
 import Tokenizers
 import os
@@ -173,6 +174,30 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         throw InferenceError.unsupportedModelArchitecture(reported)
     }
 
+    // MARK: - Factory Routing
+
+    /// Returns `true` when the model at `url` declares an MoE config that
+    /// `LLMModelFactory.Gemma4Model` can't handle today. Currently triggers on
+    /// `text_config.enable_moe_block == true` (Gemma 4 26B). Extend here if/when
+    /// other VLM-only LM architectures appear.
+    ///
+    /// Falls back to `false` (LLM factory) when config.json is missing/unreadable —
+    /// matches the same conservative default used by `validateArchitecture`. Dense
+    /// Gemma 4 models intentionally stay on the LLM factory so we don't pay the
+    /// memory cost of resident vision-tower weights.
+    static func requiresVLMFactory(at url: URL) -> Bool {
+        let configURL = url.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: configURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return false
+        }
+        if let textConfig = json["text_config"] as? [String: Any],
+           textConfig["enable_moe_block"] as? Bool == true {
+            return true
+        }
+        return false
+    }
+
     // MARK: - Model Lifecycle
 
     public func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
@@ -202,13 +227,33 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
 
         do {
             // Load from a local directory containing config.json + .safetensors.
-            // loadModelContainer(from:using:) is a free function from MLXLMCommon.
-            // #huggingFaceTokenizerLoader() (from MLXHuggingFace) adapts swift-transformers'
-            // AutoTokenizer to the TokenizerLoader protocol required by the new API.
-            let container: ModelContainer = try await loadModelContainer(
-                from: url,
-                using: #huggingFaceTokenizerLoader()
-            )
+            // We dispatch directly to either `LLMModelFactory.shared` or
+            // `VLMModelFactory.shared` rather than calling the registry-iterating
+            // free function `loadModelContainer(from:using:)`. Reason: the MoE
+            // Gemma 4 decoder lives only on the VLM side in mlx-swift-lm 3.31.3
+            // (`Libraries/MLXVLM/Models/Gemma4.swift`), so the registry walk
+            // would otherwise hand the 26B `gemma4` model to the dense
+            // `Gemma4Text.swift` LLM path and fail with "Unhandled keys
+            // [experts, router, …]". See issue #752. Dense Gemma 4 variants
+            // stay on the LLM factory — `requiresVLMFactory` only flags
+            // configs that explicitly declare `text_config.enable_moe_block`.
+            //
+            // `#huggingFaceTokenizerLoader()` (from MLXHuggingFace) adapts
+            // swift-transformers' `AutoTokenizer` to the `TokenizerLoader`
+            // protocol both factories accept.
+            let container: ModelContainer
+            if Self.requiresVLMFactory(at: url) {
+                Self.logger.info("MLX routing via VLMModelFactory (MoE / VLM-only architecture)")
+                container = try await VLMModelFactory.shared.loadContainer(
+                    from: url,
+                    using: #huggingFaceTokenizerLoader()
+                )
+            } else {
+                container = try await LLMModelFactory.shared.loadContainer(
+                    from: url,
+                    using: #huggingFaceTokenizerLoader()
+                )
+            }
             let detectedDialect = MLXToolDialect.detect(at: url)
             withStateLock {
                 _modelContainer = container

--- a/Tests/BaseChatBackendsTests/MLXBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXBackendTests.swift
@@ -152,6 +152,48 @@ final class MLXBackendTests: XCTestCase {
         addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
         XCTAssertNoThrow(try MLXBackend.validateArchitecture(at: dir))
     }
+
+    // MARK: - VLM Factory Routing (issue #752, no hardware gate)
+
+    func test_requiresVLMFactory_whenTextConfigEnablesMoE_returnsTrue() throws {
+        // mlx-community/gemma-4-26b-a4b-it-4bit ships
+        //   { "text_config": { "enable_moe_block": true, … } }
+        // and only loads correctly via VLMModelFactory in mlx-swift-lm 3.31.3.
+        // Sabotage check: flipping `requiresVLMFactory` to always return false
+        // makes this assertion fail (verified locally before commit).
+        let url = try writeTempConfig([
+            "text_config": ["enable_moe_block": true]
+        ])
+        XCTAssertTrue(MLXBackend.requiresVLMFactory(at: url))
+    }
+
+    func test_requiresVLMFactory_whenTextConfigOmitsMoE_returnsFalse() throws {
+        // Dense Gemma 4 variants (e.g. gemma-4-e4b-it-4bit) ship
+        //   { "text_config": { "enable_moe_block": false, … } }
+        // and must stay on LLMModelFactory to avoid loading vision-tower
+        // weights into resident memory.
+        let url = try writeTempConfig([
+            "text_config": ["enable_moe_block": false]
+        ])
+        XCTAssertFalse(MLXBackend.requiresVLMFactory(at: url))
+    }
+
+    func test_requiresVLMFactory_whenConfigHasNoTextConfig_returnsFalse() throws {
+        // Regular LLMs (qwen3, llama, mistral, …) have a flat config.json with
+        // no `text_config` block. They route through LLMModelFactory.
+        let url = try writeTempConfig(["model_type": "qwen3"])
+        XCTAssertFalse(MLXBackend.requiresVLMFactory(at: url))
+    }
+
+    func test_requiresVLMFactory_whenConfigMissing_returnsFalse() throws {
+        // Conservative fallback matches `validateArchitecture` — let the MLX
+        // load path produce the real diagnostic for missing config.json.
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("mlx-vlm-empty-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
+        XCTAssertFalse(MLXBackend.requiresVLMFactory(at: dir))
+    }
 }
 
 // MARK: - Backend Contract


### PR DESCRIPTION
## Summary

mlx-swift-lm 3.31.3 already ships an MoE-aware Gemma 4 decoder — but only on the VLM side (`Libraries/MLXVLM/Models/Gemma4.swift`, with the `Gemma4TextRouter` / `Gemma4TextExperts` modules and the `enable_moe_block`-gated `Gemma4TextDecoderLayer`). BCK previously depended only on `MLXLLM` / `MLXLMCommon` / `MLXHuggingFace`, so `VLMModelFactory` was never registered with `ModelFactoryRegistry`. The registry-iterating free function `loadModelContainer(from:using:)` therefore handed `mlx-community/gemma-4-26b-a4b-it-4bit` to the dense LLM `Gemma4Text.swift` path and failed with "Unhandled keys [experts, router, …]" — the crash in #752.

This PR adds an `MLX`-trait-conditional `MLXVLM` dependency to `BaseChatBackends` and a `config.json` sniff in `MLXBackend.requiresVLMFactory(at:)` that routes models declaring `text_config.enable_moe_block == true` to `VLMModelFactory.shared.loadContainer` directly. Dense Gemma 4 variants (e.g. `gemma-4-e4b-it-4bit`) stay on `LLMModelFactory.shared.loadContainer` so we don't pay the cost of resident vision-tower weights when we don't need them.

Closes #752.

## Test plan

- [x] `swift build --traits MLX,Llama` — clean (build succeeded in 451s, only pre-existing deprecation warnings in `LlamaTokenization.swift`).
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 214 tests, 4 skipped, 0 failures.
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 1085 tests, 0 failures.
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits` — 69 tests, 0 failures.
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 479 tests, 0 failures.
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 75 tests, 1 skipped, 0 failures (CI configuration).
- [x] `swift test --filter BaseChatTestSupportTests --disable-default-traits` — 13 tests, 0 failures.
- [x] `swift test --filter MLXBackendTests --traits MLX,Llama` — 23 tests, 1 skipped, 0 failures (includes the four new `requiresVLMFactory_*` tests).
- [x] Sabotage check: with `requiresVLMFactory` short-circuited to `return false`, `test_requiresVLMFactory_whenTextConfigEnablesMoE_returnsTrue` fails as expected; reverted.
- [ ] Note: the full `BaseChatBackendsTests --traits MLX,Llama` run hits a pre-existing `LlamaGrammarSamplerTests` C++ exception SIGABRT (`Unexpected empty grammar stack after accepting piece`). Verified on `main` with my changes stashed — same crash, unrelated to this PR. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)