### PR TITLE
feat: App Intents seam — ChatSessionIntent for Siri and Spotlight integration

### DIFF
--- a/Sources/BaseChatCore/Models/ChatIntentAction.swift
+++ b/Sources/BaseChatCore/Models/ChatIntentAction.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Vocabulary of high-level chat actions a host app may expose through Siri,
+/// Spotlight, or any other App Intents surface.
+///
+/// `BaseChatCore` deliberately does **not** import the `AppIntents` framework.
+/// Host apps own the bridge: they declare `AppIntent` structs and translate
+/// between the framework's representation and these cases. Keeping the
+/// vocabulary string- and enum-based lets the core stay free of OS framework
+/// dependencies while still defining a stable set of intents that downstream
+/// integrations can target.
+public enum ChatIntentAction: Sendable, Codable, Equatable {
+    /// Resume work in the most recent (or currently active) session.
+    case continueSession
+    /// Begin a brand-new chat session.
+    case startNewSession
+    /// Read the most recent assistant message back to the user.
+    case readLastMessage
+    /// Produce a short summary of the active session.
+    case summariseSession
+}
+
+/// Receives ``ChatIntentAction`` values dispatched from a host app's
+/// `AppIntent` bridge.
+///
+/// Hosts conform a coordinator (typically the same object that owns the
+/// `ChatViewModel`) and inject it via `ChatViewModel.intentHandler`. The
+/// view model forwards `dispatch(_:)` calls to ``handle(_:sessionID:)``
+/// with the currently active session, so a single intent payload can route
+/// to the correct chat without the bridge needing to know about session
+/// identifiers.
+public protocol ChatSessionIntentHandler: AnyObject, Sendable {
+    /// Performs the side effects associated with `action` for `sessionID`.
+    ///
+    /// - Parameters:
+    ///   - action: The high-level intent the user requested.
+    ///   - sessionID: The active session at dispatch time, or `nil` when
+    ///     no session is currently selected.
+    /// - Throws: Implementation-defined errors. The view model surfaces
+    ///   them to the caller of `dispatch(_:)` unchanged.
+    func handle(_ action: ChatIntentAction, sessionID: UUID?) async throws
+}

--- a/Sources/BaseChatTestSupport/MockChatSessionIntentHandler.swift
+++ b/Sources/BaseChatTestSupport/MockChatSessionIntentHandler.swift
@@ -1,0 +1,57 @@
+import Foundation
+import BaseChatCore
+
+/// Recording mock for ``ChatSessionIntentHandler``.
+///
+/// Captures every `(action, sessionID)` invocation in a thread-safe array
+/// so tests can assert on dispatch order without coordinating actor hops.
+/// Optionally throws a configured error from ``handle(_:sessionID:)`` when
+/// a test needs to exercise error propagation through `ChatViewModel.dispatch`.
+public final class MockChatSessionIntentHandler: ChatSessionIntentHandler, @unchecked Sendable {
+
+    /// One recorded invocation of ``handle(_:sessionID:)``.
+    public struct Invocation: Sendable, Equatable {
+        public let action: ChatIntentAction
+        public let sessionID: UUID?
+
+        public init(action: ChatIntentAction, sessionID: UUID?) {
+            self.action = action
+            self.sessionID = sessionID
+        }
+    }
+
+    private let lock = NSLock()
+    private var _invocations: [Invocation] = []
+
+    /// Error to throw on the next call to ``handle(_:sessionID:)``.
+    /// When `nil` (the default) the handler records and returns successfully.
+    public var errorToThrow: Error?
+
+    public init() {}
+
+    /// Snapshot of every invocation recorded so far, in order.
+    public var invocations: [Invocation] {
+        withLock { _invocations }
+    }
+
+    public func handle(_ action: ChatIntentAction, sessionID: UUID?) async throws {
+        let error: Error? = withLock {
+            _invocations.append(Invocation(action: action, sessionID: sessionID))
+            return errorToThrow
+        }
+
+        if let error {
+            throw error
+        }
+    }
+
+    /// NSLock helper kept non-async so the lock/unlock pair never crosses a
+    /// suspension point — `NSLock.lock()` is unavailable from async contexts
+    /// in the Swift 6 concurrency model. Mirrors the pattern used by
+    /// ``ChaosBackend``.
+    private func withLock<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
+    }
+}

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Intent.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Intent.swift
@@ -1,0 +1,23 @@
+import Foundation
+import BaseChatCore
+
+// MARK: - ChatViewModel + App Intents
+
+extension ChatViewModel {
+
+    /// Forwards an App Intents action to the configured ``intentHandler``.
+    ///
+    /// Hosts call this from their `AppIntent.perform()` implementations after
+    /// translating the framework-specific payload to a ``ChatIntentAction``.
+    /// The view model attaches the active session ID (if any) so the handler
+    /// can route the action to the correct chat without the bridge needing
+    /// session-aware logic.
+    ///
+    /// When no handler is installed the call is a no-op — apps that do not
+    /// ship App Intents simply leave ``intentHandler`` `nil`. Errors raised
+    /// by the handler propagate to the caller unchanged.
+    public func dispatch(_ action: ChatIntentAction) async throws {
+        guard let intentHandler else { return }
+        try await intentHandler.handle(action, sessionID: activeSessionID)
+    }
+}

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -399,6 +399,17 @@ public final class ChatViewModel {
     /// Default is `nil` (no-op — the hint banner is displayed by `ChatView`).
     public var onUpgradeHintTriggered: (@MainActor () -> Void)?
 
+    // MARK: - App Intents Bridge
+
+    /// Receives ``ChatIntentAction`` values forwarded from the host app's
+    /// App Intents bridge. Set by host apps that expose Siri / Spotlight
+    /// integrations; left `nil` when no such bridge exists.
+    ///
+    /// `BaseChatUI` deliberately does not import `AppIntents` — the handler
+    /// protocol defined in `BaseChatCore` keeps the seam framework-free.
+    /// See ``ChatViewModel/dispatch(_:)`` for the forwarding entry point.
+    public var intentHandler: (any ChatSessionIntentHandler)?
+
     // MARK: - Memory Indicator
 
     /// The current OS-level memory pressure level, forwarded from the handler.

--- a/Tests/BaseChatCoreTests/ChatIntentActionTests.swift
+++ b/Tests/BaseChatCoreTests/ChatIntentActionTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import BaseChatCore
+
+final class ChatIntentActionTests: XCTestCase {
+
+    // MARK: - Codable round-trip
+
+    func test_codable_roundTrips_continueSession() throws {
+        try assertRoundTrip(.continueSession)
+    }
+
+    func test_codable_roundTrips_startNewSession() throws {
+        try assertRoundTrip(.startNewSession)
+    }
+
+    func test_codable_roundTrips_readLastMessage() throws {
+        try assertRoundTrip(.readLastMessage)
+    }
+
+    func test_codable_roundTrips_summariseSession() throws {
+        try assertRoundTrip(.summariseSession)
+    }
+
+    /// Catches the case where a future contributor adds a case but forgets
+    /// to update the dispatch / persistence sites that assume the existing
+    /// vocabulary.
+    func test_codable_roundTrips_allCases() throws {
+        let allCases: [ChatIntentAction] = [
+            .continueSession,
+            .startNewSession,
+            .readLastMessage,
+            .summariseSession,
+        ]
+        for action in allCases {
+            try assertRoundTrip(action)
+        }
+    }
+
+    // MARK: - Equatable
+
+    func test_equatable_sameCase_isEqual() {
+        XCTAssertEqual(ChatIntentAction.continueSession, .continueSession)
+        XCTAssertEqual(ChatIntentAction.startNewSession, .startNewSession)
+        XCTAssertEqual(ChatIntentAction.readLastMessage, .readLastMessage)
+        XCTAssertEqual(ChatIntentAction.summariseSession, .summariseSession)
+    }
+
+    func test_equatable_differentCases_areNotEqual() {
+        XCTAssertNotEqual(ChatIntentAction.continueSession, .startNewSession)
+        XCTAssertNotEqual(ChatIntentAction.continueSession, .readLastMessage)
+        XCTAssertNotEqual(ChatIntentAction.continueSession, .summariseSession)
+        XCTAssertNotEqual(ChatIntentAction.startNewSession, .readLastMessage)
+        XCTAssertNotEqual(ChatIntentAction.startNewSession, .summariseSession)
+        XCTAssertNotEqual(ChatIntentAction.readLastMessage, .summariseSession)
+    }
+
+    // MARK: - Helpers
+
+    private func assertRoundTrip(
+        _ action: ChatIntentAction,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        let data = try encoder.encode(action)
+        let decoded = try decoder.decode(ChatIntentAction.self, from: data)
+        XCTAssertEqual(decoded, action, file: file, line: line)
+    }
+}

--- a/Tests/BaseChatUITests/ChatViewModelIntentDispatchTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelIntentDispatchTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+import BaseChatCore
+import BaseChatInference
+import BaseChatTestSupport
+@testable import BaseChatUI
+
+@MainActor
+final class ChatViewModelIntentDispatchTests: XCTestCase {
+
+    // MARK: - Forwarding
+
+    func test_dispatch_forwardsActionAndSessionID_toHandler() async throws {
+        let vm = makeViewModel()
+        let handler = MockChatSessionIntentHandler()
+        vm.intentHandler = handler
+
+        let session = ChatSessionRecord(title: "Routing")
+        vm.activeSession = session
+
+        try await vm.dispatch(.continueSession)
+
+        XCTAssertEqual(handler.invocations.count, 1)
+        XCTAssertEqual(handler.invocations.first?.action, .continueSession)
+        XCTAssertEqual(handler.invocations.first?.sessionID, session.id)
+    }
+
+    func test_dispatch_forwardsNilSessionID_whenNoActiveSession() async throws {
+        let vm = makeViewModel()
+        let handler = MockChatSessionIntentHandler()
+        vm.intentHandler = handler
+
+        XCTAssertNil(vm.activeSession)
+
+        try await vm.dispatch(.startNewSession)
+
+        XCTAssertEqual(handler.invocations.count, 1)
+        XCTAssertEqual(handler.invocations.first?.action, .startNewSession)
+        XCTAssertNil(handler.invocations.first?.sessionID)
+    }
+
+    func test_dispatch_forwardsEveryActionVerbatim() async throws {
+        let vm = makeViewModel()
+        let handler = MockChatSessionIntentHandler()
+        vm.intentHandler = handler
+
+        let actions: [ChatIntentAction] = [
+            .continueSession,
+            .startNewSession,
+            .readLastMessage,
+            .summariseSession,
+        ]
+        for action in actions {
+            try await vm.dispatch(action)
+        }
+
+        XCTAssertEqual(handler.invocations.map(\.action), actions)
+    }
+
+    // MARK: - No-op when handler is absent
+
+    func test_dispatch_isNoOp_whenHandlerIsNil() async throws {
+        let vm = makeViewModel()
+        XCTAssertNil(vm.intentHandler)
+
+        // Must not throw and must complete without observable effect.
+        try await vm.dispatch(.readLastMessage)
+        try await vm.dispatch(.summariseSession)
+    }
+
+    // MARK: - Error propagation
+
+    func test_dispatch_propagatesErrorFromHandler() async {
+        let vm = makeViewModel()
+        let handler = MockChatSessionIntentHandler()
+        handler.errorToThrow = TestError.boom
+        vm.intentHandler = handler
+
+        do {
+            try await vm.dispatch(.summariseSession)
+            XCTFail("Expected dispatch to rethrow the handler's error")
+        } catch let error as TestError {
+            XCTAssertEqual(error, .boom)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeViewModel() -> ChatViewModel {
+        let mock = MockInferenceBackend()
+        let service = InferenceService(backend: mock, name: "MockIntentDispatch")
+        return ChatViewModel(inferenceService: service)
+    }
+
+    private enum TestError: Error, Equatable {
+        case boom
+    }
+}


### PR DESCRIPTION
## Summary

Closes #117. Adds a framework-free seam in `BaseChatCore` so host apps can bridge their own `AppIntent` structs into the chat without dragging the `AppIntents` framework into the package.

- **`ChatIntentAction`** (`Sendable`, `Codable`, `Equatable`) — vocabulary of intents: `.continueSession`, `.startNewSession`, `.readLastMessage`, `.summariseSession`.
- **`ChatSessionIntentHandler`** protocol — `handle(_:sessionID:) async throws`. Hosts conform a coordinator and inject it.
- **`ChatViewModel.intentHandler`** stored property + **`dispatch(_:)`** extension — forwards the action with the currently active session ID; no-ops when no handler is installed.
- **`MockChatSessionIntentHandler`** in `BaseChatTestSupport` — thread-safe recording mock with `errorToThrow` for negative-path tests.

`grep -r "import AppIntents" Sources/` returns zero hits in this package — the host app owns the bridge. The stored property lives on `ChatViewModel` directly (Swift extensions can't add stored properties); only `dispatch(_:)` lives in the `ChatViewModel+Intent.swift` extension file, matching the existing `ChatViewModel+*.swift` convention.

## Why this shape

- Enum + protocol gives a stable, OS-version-independent contract that downstream apps can target without coupling to `AppIntents` specifics.
- `dispatch(_:)` attaches `activeSessionID` so the bridge stays session-unaware — the `AppIntent.perform()` site only has to translate parameters, not reach into chat state.
- The handler is `AnyObject & Sendable` so hosts can put it on the same coordinator that already owns the `ChatViewModel`.

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` (221 pass, 4 skipped)
- [x] `swift test --filter BaseChatUITests --disable-default-traits` (484 pass)
- [x] `swift test --filter BaseChatTestSupportTests --disable-default-traits` (13 pass)
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` (14 pass)
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits` (69 pass)
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` (3 pass — cloud only)
- [x] Sabotage: removing the `nil` guard in `dispatch(_:)` causes `test_dispatch_isNoOp_whenHandlerIsNil` to crash with a forced-unwrap fault (verified, then restored).
- [x] `grep -r "import AppIntents" Sources/` returns no matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)