### PR TITLE
test: harden tool-capability, cancel-latency, and withKnownIssue policy

### DIFF
--- a/.github/workflows/known-issue-lint.yml
+++ b/.github/workflows/known-issue-lint.yml
@@ -1,0 +1,97 @@
+name: Known-Issue Lint
+
+# Enforces the `withKnownIssue` policy from CLAUDE.md:
+#
+#   "withKnownIssue is test debt, not a fix. Every use must have a
+#    `// FIXME: <issue URL>` comment on the line above. Remove the wrapper
+#    in the same PR that fixes the underlying bug."
+#
+# The lint walks every Swift test file, finds each `withKnownIssue(` call,
+# and fails when the immediately preceding non-blank line is not a
+# `// FIXME:` comment containing a URL or issue reference. Documentation
+# strings inside TESTING.md / CLAUDE.md are excluded.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "Tests/**"
+      - "Sources/**"
+      - ".github/workflows/known-issue-lint.yml"
+  push:
+    branches: [main]
+    paths:
+      - "Tests/**"
+      - "Sources/**"
+      - ".github/workflows/known-issue-lint.yml"
+
+concurrency:
+  group: known-issue-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  known-issue-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify every withKnownIssue has a // FIXME link above it
+        run: |
+          set -euo pipefail
+
+          # Search Swift sources for `withKnownIssue(` and capture file:line
+          # for each occurrence. `-n` keeps line numbers; `-H` keeps filenames
+          # even when only one file matches; `--include` keeps the search
+          # tight on Swift sources only.
+          mapfile -t hits < <(grep -RHn --include='*.swift' \
+            -E '\bwithKnownIssue\(' Tests Sources 2>/dev/null || true)
+
+          if [ ${#hits[@]} -eq 0 ]; then
+            echo "✓ No withKnownIssue usages found."
+            exit 0
+          fi
+
+          echo "Found ${#hits[@]} withKnownIssue usage(s); verifying each has a // FIXME link above…"
+          echo ""
+
+          violations=0
+          for hit in "${hits[@]}"; do
+            file="${hit%%:*}"
+            rest="${hit#*:}"
+            line_no="${rest%%:*}"
+
+            # Walk upward past blank/whitespace-only lines and find the first
+            # non-blank line. That line must be a `// FIXME:` comment.
+            prev=$((line_no - 1))
+            while [ "$prev" -gt 0 ]; do
+              prev_content=$(sed -n "${prev}p" "$file")
+              if [[ -n "$(echo "$prev_content" | tr -d '[:space:]')" ]]; then
+                break
+              fi
+              prev=$((prev - 1))
+            done
+
+            if [ "$prev" -le 0 ]; then
+              prev_content=""
+            fi
+
+            if echo "$prev_content" | grep -qE '^\s*//\s*FIXME:.*(https?://|#[0-9]+)'; then
+              # Compliant: FIXME comment with either a URL or a #NNN issue ref.
+              continue
+            fi
+
+            violations=$((violations + 1))
+            echo "::error file=$file,line=$line_no::withKnownIssue at $file:$line_no lacks a '// FIXME: <issue URL or #N>' comment on the line above."
+            echo "  Found above: ${prev_content:-<top of file>}"
+            echo ""
+          done
+
+          if [ "$violations" -gt 0 ]; then
+            echo ""
+            echo "::error::$violations withKnownIssue usage(s) violate the policy in CLAUDE.md."
+            echo "::error::Add a '// FIXME: <issue URL>' comment on the line directly above each usage,"
+            echo "::error::or remove the withKnownIssue wrapper if the underlying bug is fixed."
+            exit 1
+          fi
+
+          echo "✓ All ${#hits[@]} withKnownIssue usage(s) have a tracking // FIXME link."

--- a/Sources/BaseChatInference/Services/GenerationCoordinator.swift
+++ b/Sources/BaseChatInference/Services/GenerationCoordinator.swift
@@ -73,6 +73,16 @@ final class GenerationCoordinator {
     /// reader. Tests must reset it in `tearDown` to avoid cross-test leakage.
     nonisolated(unsafe) static var jsonModeUnsupportedWarningHook: (@Sendable (String, String) -> Void)?
 
+    /// Test-only hook invoked alongside `Log.inference.warning` when a request
+    /// passes `tools` to a backend whose capabilities report
+    /// `supportsToolCalling == false`. Receives `(backendTypeName, message)`.
+    ///
+    /// Mirrors `jsonModeUnsupportedWarningHook`. The motivation is the same:
+    /// tools are silently dropped on incapable backends, and without a signal
+    /// the model spins on "I cannot access tools" while the host wonders why
+    /// its registry is never invoked. Tests must reset this in `tearDown`.
+    nonisolated(unsafe) static var toolsUnsupportedWarningHook: (@Sendable (String, String) -> Void)?
+
     // MARK: - Queue Types (Private)
 
     private struct QueuedRequest {
@@ -399,11 +409,24 @@ final class GenerationCoordinator {
         priority: GenerationPriority = .normal,
         sessionID: UUID? = nil
     ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
-        guard provider?.currentBackend != nil, provider?.isBackendLoaded == true else {
+        guard let backend = provider?.currentBackend, provider?.isBackendLoaded == true else {
             throw InferenceError.inferenceFailure("No model loaded")
         }
         guard requestQueue.count < maxQueueDepth else {
             throw InferenceError.inferenceFailure("Generation queue is full")
+        }
+
+        // Capability gate for tool calling. Mirrors the jsonMode warning at the
+        // top of `generate(messages:)`: tools passed to a backend that reports
+        // `supportsToolCalling == false` are silently dropped on the wire,
+        // and the model loops on "I cannot access tools" while the host's
+        // registry never sees the call. Warn once at enqueue time so the
+        // signal is loud and the failure mode is diagnosable.
+        if !tools.isEmpty && !backend.capabilities.supportsToolCalling {
+            let backendType = String(describing: type(of: backend))
+            let message = "GenerationCoordinator: \(tools.count) tool(s) passed to enqueue() but \(backendType) reports capabilities.supportsToolCalling == false; tools will be ignored on the wire and tool calls will never be dispatched. Check `backend.capabilities.supportsToolCalling` before passing tools, or load a tool-capable backend."
+            Log.inference.warning("\(message, privacy: .public)")
+            Self.toolsUnsupportedWarningHook?(backendType, message)
         }
 
         let token = GenerationRequestToken(rawValue: nextGenerationToken.rawValue + 1)

--- a/Sources/BaseChatInference/Services/GenerationCoordinator.swift
+++ b/Sources/BaseChatInference/Services/GenerationCoordinator.swift
@@ -424,7 +424,8 @@ final class GenerationCoordinator {
         // signal is loud and the failure mode is diagnosable.
         if !tools.isEmpty && !backend.capabilities.supportsToolCalling {
             let backendType = String(describing: type(of: backend))
-            let message = "GenerationCoordinator: \(tools.count) tool(s) passed to enqueue() but \(backendType) reports capabilities.supportsToolCalling == false; tools will be ignored on the wire and tool calls will never be dispatched. Check `backend.capabilities.supportsToolCalling` before passing tools, or load a tool-capable backend."
+            let toolWord = tools.count == 1 ? "tool" : "tools"
+            let message = "GenerationCoordinator: \(tools.count) \(toolWord) passed to enqueue() but \(backendType) reports capabilities.supportsToolCalling == false; tools will be ignored on the wire and tool calls will never be dispatched. Check `backend.capabilities.supportsToolCalling` before passing tools, or load a tool-capable backend."
             Log.inference.warning("\(message, privacy: .public)")
             Self.toolsUnsupportedWarningHook?(backendType, message)
         }

--- a/Tests/BaseChatInferenceTests/GenerationCoordinatorTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationCoordinatorTests.swift
@@ -160,6 +160,95 @@ final class GenerationCoordinatorTests: XCTestCase {
         XCTAssertTrue(config.jsonMode)
     }
 
+    // MARK: - Tool-capability silent-ignore warning
+
+    /// When `tools` are passed to `enqueue` and the active backend reports
+    /// `supportsToolCalling == false`, the coordinator must emit a warning so
+    /// callers have a signal that the registry will never see a dispatch.
+    /// Mirrors the jsonMode silent-ignore warning above.
+    ///
+    /// Sabotage check: deleting the warning branch in `GenerationCoordinator.enqueue`
+    /// leaves `captured` empty and this assertion fails.
+    func test_enqueue_toolsOnUnsupportedBackend_emitsWarning() async throws {
+        // MockInferenceBackend defaults to supportsToolCalling == false.
+        let captured = WarningCapture()
+        GenerationCoordinator.toolsUnsupportedWarningHook = { backendType, message in
+            captured.record(backendType: backendType, message: message)
+        }
+        defer { GenerationCoordinator.toolsUnsupportedWarningHook = nil }
+
+        let tool = ToolDefinition(
+            name: "get_weather",
+            description: "Lookup the weather for a city"
+        )
+        let (_, stream) = try coordinator.enqueue(
+            messages: [("user", "What's the weather?")],
+            tools: [tool]
+        )
+        for try await _ in stream.events {}
+
+        let entries = captured.snapshot()
+        XCTAssertEqual(entries.count, 1, "warning must fire exactly once per enqueue")
+        let first = try XCTUnwrap(entries.first)
+        XCTAssertEqual(first.backendType, "MockInferenceBackend",
+                       "warning must name the active backend type")
+        XCTAssertTrue(first.message.contains("supportsToolCalling"),
+                      "warning must reference the capability flag so callers can check it programmatically")
+        XCTAssertTrue(first.message.contains("1 tool"),
+                      "warning should mention how many tools were passed")
+    }
+
+    /// When no tools are passed, the warning must never fire regardless of
+    /// the backend's capability — guards against a future regression that
+    /// flips the condition to `tools.isEmpty`.
+    func test_enqueue_noTools_neverWarns() async throws {
+        let captured = WarningCapture()
+        GenerationCoordinator.toolsUnsupportedWarningHook = { backendType, message in
+            captured.record(backendType: backendType, message: message)
+        }
+        defer { GenerationCoordinator.toolsUnsupportedWarningHook = nil }
+
+        let (_, stream) = try coordinator.enqueue(messages: [("user", "hi")])
+        for try await _ in stream.events {}
+
+        XCTAssertTrue(captured.snapshot().isEmpty,
+                      "warning must not fire when no tools are passed")
+    }
+
+    /// When the backend supports tool calling, the warning must not fire
+    /// even if the request includes tools.
+    func test_enqueue_toolsOnSupportedBackend_noWarning() async throws {
+        let captured = WarningCapture()
+        GenerationCoordinator.toolsUnsupportedWarningHook = { backendType, message in
+            captured.record(backendType: backendType, message: message)
+        }
+        defer { GenerationCoordinator.toolsUnsupportedWarningHook = nil }
+
+        provider.backend.capabilities = BackendCapabilities(
+            supportedParameters: [.temperature],
+            maxContextTokens: 4096,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsToolCalling: true,
+            supportsStructuredOutput: false,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: false
+        )
+
+        let tool = ToolDefinition(
+            name: "get_weather",
+            description: "Lookup the weather for a city"
+        )
+        let (_, stream) = try coordinator.enqueue(
+            messages: [("user", "weather?")],
+            tools: [tool]
+        )
+        for try await _ in stream.events {}
+
+        XCTAssertTrue(captured.snapshot().isEmpty,
+                      "warning must not fire when the backend supports tool calling")
+    }
+
     func test_enqueue_overQueueDepth_throwsQueueFullError() throws {
         // Saturate the coordinator: one active plus eight queued is the hard cap
         // (maxQueueDepth == 8 counts queued requests only).
@@ -331,6 +420,56 @@ final class GenerationCoordinatorTests: XCTestCase {
         XCTAssertNotEqual(freshStream.phase, .queued, "new request must start running after stop")
         coord.stopGeneration()
         do { for try await _ in freshStream.events {} } catch { /* cancel error OK */ }
+    }
+
+    // MARK: - Cancel latency contract
+
+    /// `stopGenerationAndWait()` must return promptly even when the backend
+    /// is mid-token with a long per-token delay. The orchestrator's defer
+    /// block awaits `activeTask?.value`, so any failure to propagate cancel
+    /// through the producer task makes this method hang for the full token
+    /// delay — a real-world wedge where the user taps stop, the UI looks
+    /// responsive, and the C-level inference keeps running until the next
+    /// natural boundary.
+    ///
+    /// This test pins the contract at coordinator level: with a 60-second
+    /// per-token delay, stop-and-wait must complete within a 2-second
+    /// wall-clock budget. The deadline is generous enough to ride out CI
+    /// scheduling jitter on a busy macOS runner without being so loose that
+    /// a real regression sneaks through.
+    ///
+    /// This test pins the *contract* (prompt return), not the mechanism.
+    /// SlowMockBackend has three cancellation paths — `task.cancel()` from
+    /// `cancelGeneration`, the in-loop `Task.isCancelled` guards, and
+    /// `continuation.onTermination` — and any one of them is sufficient to
+    /// honour the contract. A future change that breaks all three would
+    /// trip this test; breaking one is caught by the dedicated tests for
+    /// each path elsewhere in this file.
+    func test_stopGenerationAndWait_returnsPromptly_evenWithLongTokenDelay() async throws {
+        let backend = SlowMockBackend(tokenCount: 1, delayMilliseconds: 60_000)
+        let slowProvider = SlowFakeProvider(backend: backend)
+        let coord = GenerationCoordinator()
+        coord.provider = slowProvider
+
+        let (_, _) = try coord.enqueue(messages: [("user", "long")], priority: .normal)
+
+        // Yield once so the orchestrator's drainQueue() spawns its Task and
+        // the producer enters its first 60s sleep before we ask to stop.
+        // Without this, stop-and-wait could race ahead of the producer's
+        // launch and pass for the wrong reason.
+        try await Task.sleep(for: .milliseconds(50))
+
+        let start = ContinuousClock.now
+        await coord.stopGenerationAndWait()
+        let elapsed = ContinuousClock.now - start
+
+        XCTAssertLessThan(
+            elapsed, .seconds(2),
+            "stopGenerationAndWait() must return within 2s even when the backend is mid-token; " +
+            "elapsed=\(elapsed). A larger delta indicates cancellation is not propagating to the producer task " +
+            "and the orchestrator is awaiting the natural token boundary instead."
+        )
+        XCTAssertFalse(coord.isGenerating)
     }
 
     // MARK: - discardRequests(notMatching:)

--- a/Tests/BaseChatInferenceTests/GenerationCoordinatorTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationCoordinatorTests.swift
@@ -432,26 +432,23 @@ final class GenerationCoordinatorTests: XCTestCase {
     /// responsive, and the C-level inference keeps running until the next
     /// natural boundary.
     ///
-    /// This test pins the contract at coordinator level: with a 60-second
-    /// per-token delay, stop-and-wait must complete within a 2-second
-    /// wall-clock budget. The deadline is generous enough to ride out CI
+    /// This test pins the *contract* (prompt return), not the mechanism:
+    /// with a 60-second per-token delay, stop-and-wait must complete within
+    /// a 2-second wall-clock budget — generous enough to ride out CI
     /// scheduling jitter on a busy macOS runner without being so loose that
-    /// a real regression sneaks through.
-    ///
-    /// This test pins the *contract* (prompt return), not the mechanism.
-    /// SlowMockBackend has three cancellation paths — `task.cancel()` from
-    /// `cancelGeneration`, the in-loop `Task.isCancelled` guards, and
-    /// `continuation.onTermination` — and any one of them is sufficient to
-    /// honour the contract. A future change that breaks all three would
-    /// trip this test; breaking one is caught by the dedicated tests for
-    /// each path elsewhere in this file.
+    /// a real regression sneaks through. SlowMockBackend has three
+    /// cancellation paths — `task.cancel()` from `cancelGeneration`, the
+    /// in-loop `Task.isCancelled` guards, and `continuation.onTermination`
+    /// — and any one of them is sufficient to honour the contract. A future
+    /// change that breaks all three would trip this test; breaking one is
+    /// caught by the dedicated tests for each path elsewhere in this file.
     func test_stopGenerationAndWait_returnsPromptly_evenWithLongTokenDelay() async throws {
         let backend = SlowMockBackend(tokenCount: 1, delayMilliseconds: 60_000)
         let slowProvider = SlowFakeProvider(backend: backend)
         let coord = GenerationCoordinator()
         coord.provider = slowProvider
 
-        let (_, _) = try coord.enqueue(messages: [("user", "long")], priority: .normal)
+        _ = try coord.enqueue(messages: [("user", "long")], priority: .normal)
 
         // Yield once so the orchestrator's drainQueue() spawns its Task and
         // the producer enters its first 60s sleep before we ask to stop.


### PR DESCRIPTION
## Summary

Three risk-focused additions surfaced from a deep audit of where the test suite + docs let real bugs through. Each closes a path where a regression could ship and CI would still be green.

### 1. Tool-capability silent-ignore warning
Today, four backends (`Claude`, `OpenAI`, `Foundation`, `Llama`) report `supportsToolCalling: false` but `GenerationCoordinator.enqueue` accepts a `tools:` array unconditionally and forwards it through. A host that registers a `ToolRegistry` and routes through one of those backends sees: tools never dispatched, model loops on "I cannot access tools," no log, no error. This mirrors the existing `jsonMode` silent-ignore warning at the top of `generate(messages:)` — same shape, same `WarningCapture` test pattern, same internal hook (`toolsUnsupportedWarningHook`).

### 2. Cancel-latency contract test
`stopGenerationAndWait()` awaits `activeTask?.value`, so any failure to propagate cancel through to the producer task makes the call hang for the natural token boundary. New test pins the public contract: with a 60s-per-token backend, stop-and-wait must return within 2s. Catches the "cancel button works, C-level inference keeps running" wedge described in the audit.

The test exercises the contract, not a single mechanism — `SlowMockBackend` has three redundant cancel paths (`task.cancel()` from `cancelGeneration`, in-loop `Task.isCancelled` guards, `continuation.onTermination`). Breaking all three at once trips this test; breaking any one is caught by dedicated tests already in the file.

### 3. `withKnownIssue` policy lint
`CLAUDE.md` says every `withKnownIssue` needs a `// FIXME: <url or #N>` on the line above. There was no enforcement. New Ubuntu workflow (`known-issue-lint.yml`) greps every `*.swift` in `Sources/` and `Tests/`, walks back over blank lines, and fails the build when the FIXME is missing or lacks a URL/issue ref. Currently zero violations — the lint is preventative.

### Dropped from audit (#3 in the prior message): export round-trip
`ChatExportService` is a one-way human-readable exporter by design — no parser, no metadata, no escaping. There is no contract to round-trip against. Existing tests already cover the realistic risks (special characters, unicode, null bytes, very long content, empty title). Inventing a "round-trip" test for an exporter that doesn't claim invertibility would be cargo-cult test debt. No change here.

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` (221 tests, 0 failures)
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` (1103 tests, 0 failures — including 4 new tests)
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits`
- [x] `swift test --filter BaseChatUITests --disable-default-traits` (498 tests, 0 failures)
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits`
- [x] `swift test --filter BaseChatTestSupportTests --disable-default-traits`
- [x] Sabotage check #1: replacing the warning condition with `if false && …` makes `test_enqueue_toolsOnUnsupportedBackend_emitsWarning` fail (verified locally)
- [x] `actionlint .github/workflows/known-issue-lint.yml` clean
- [x] Lint logic verified on a synthetic file with one compliant + one violating + one `#NNN`-form `withKnownIssue` — produced exactly one violation, two OKs.

## Audit follow-ups not in this PR

The deep audit surfaced four more risks worth tracking but out of scope here: parametric backend-conformance suite, cancel-during-stream / model-swap-mid-stream adversarial concurrency tests, on-disk schema-migration coverage, and a suite-wide skip/`XCTSkipIf` inventory. Happy to file these on an existing tracking umbrella rather than open new issues per the issue-hygiene guidance in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)