### PR TITLE
fix(test): handle diagnosticThrottle in trait-gated switch statements

### DIFF
--- a/Tests/BaseChatBackendsTests/CloudThinkingTokenTests.swift
+++ b/Tests/BaseChatBackendsTests/CloudThinkingTokenTests.swift
@@ -42,6 +42,7 @@ private func categorise(_ event: GenerationEvent) -> EventCategory? {
     case .toolResult: return nil
     case .toolLoopLimitReached: return nil
     case .kvCacheReuse: return nil
+    case .diagnosticThrottle: return nil
     }
 }
 

--- a/Tests/BaseChatBackendsTests/OllamaToolCallLiveReplayTests.swift
+++ b/Tests/BaseChatBackendsTests/OllamaToolCallLiveReplayTests.swift
@@ -184,6 +184,10 @@ final class OllamaToolCallLiveReplayTests: XCTestCase {
                     break
                 case .kvCacheReuse:
                     break
+                case .diagnosticThrottle:
+                    // Cooperative thermal pause — informational only;
+                    // raw backend replay neither emits nor projects it.
+                    break
                 }
             }
 


### PR DESCRIPTION
## Summary

PR #766 added `GenerationEvent.diagnosticThrottle(reason:)` for cooperative thermal pauses but missed two test switches that became non-exhaustive once the relevant traits are enabled. The result blocks \`swift test --traits CloudSaaS,MLX,Llama,Ollama\`.

- \`CloudThinkingTokenTests.categorise(_:)\` projects events into a test-local \`EventCategory\` enum; new case returns \`nil\` to match the other no-op cases.
- \`OllamaToolCallLiveReplayTests\` inner switch over recorded events — raw backend replay neither emits nor projects diagnosticThrottle, so the case is a documented \`break\` alongside the other no-op cases.

No behavior change.

## Test plan

- [x] \`swift test --traits CloudSaaS,MLX,Llama,Ollama --filter "CloudThinkingTokenTests|OllamaToolCallLiveReplayTests"\` — all 6 tests pass.
- [x] \`swift test --filter BaseChatBackendsTests --disable-default-traits\` — 75 tests, 1 skipped, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)