### PR TITLE
feat(inference): add minP, repetitionPenalty, seed for mlx-swift-lm parity

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -99,6 +99,7 @@ let package = Package(
             dependencies: [
                 "BaseChatInference",
                 .product(name: "MLX", package: "mlx-swift", condition: .when(traits: ["MLX"])),
+                .product(name: "MLXRandom", package: "mlx-swift", condition: .when(traits: ["MLX"])),
                 .product(name: "MLXLLM", package: "mlx-swift-lm", condition: .when(traits: ["MLX"])),
                 .product(name: "MLXLMCommon", package: "mlx-swift-lm", condition: .when(traits: ["MLX"])),
                 // MLXVLM ships the MoE Gemma 4 decoder (Libraries/MLXVLM/Models/Gemma4.swift)

--- a/Sources/BaseChatBackends/LlamaGenerationDriver.swift
+++ b/Sources/BaseChatBackends/LlamaGenerationDriver.swift
@@ -124,12 +124,16 @@ struct LlamaGenerationDriver {
         }
         defer { llama_sampler_free(sampler) }
 
-        if config.repeatPenalty > 1.0 {
+        // Prefer the explicit `repetitionPenalty` knob when callers supplied it; fall
+        // back to the legacy `repeatPenalty` field otherwise. Both flow through the
+        // same > 1.0 gate so a no-op penalty (1.0) skips the sampler chain.
+        let effectiveRepetitionPenalty = config.repetitionPenalty ?? config.repeatPenalty
+        if effectiveRepetitionPenalty > 1.0 {
             llama_sampler_chain_add(sampler, llama_sampler_init_penalties(
-                64,                    // last_n tokens to penalize
-                config.repeatPenalty,  // repeat penalty
-                0.0,                   // frequency penalty
-                0.0                    // presence penalty
+                64,                            // last_n tokens to penalize
+                effectiveRepetitionPenalty,    // repeat penalty
+                0.0,                           // frequency penalty
+                0.0                            // presence penalty
             ))
         }
 
@@ -163,10 +167,24 @@ struct LlamaGenerationDriver {
         if config.topP < 1.0 {
             llama_sampler_chain_add(sampler, llama_sampler_init_top_p(config.topP, 1))
         }
-        llama_sampler_chain_add(sampler, llama_sampler_init_min_p(0.05, 1))
+        // Honour `config.minP` when supplied; default to 0.05 for parity with prior behaviour.
+        let effectiveMinP = config.minP ?? 0.05
+        llama_sampler_chain_add(sampler, llama_sampler_init_min_p(effectiveMinP, 1))
         llama_sampler_chain_add(sampler, llama_sampler_init_temp(config.temperature))
 
-        llama_sampler_chain_add(sampler, llama_sampler_init_dist(UInt32.random(in: 0...UInt32.max)))
+        // Use the caller-supplied seed when available so consecutive runs with the same
+        // prompt + config produce identical token streams. `llama_sampler_init_dist`
+        // takes `uint32_t`, so we truncate the GenerationConfig's `UInt64` seed —
+        // collisions across the truncation boundary are not a correctness issue, only
+        // a slight loss of seed-space entropy. Falls back to a fresh random seed when
+        // the caller didn't request determinism.
+        let samplerSeed: UInt32
+        if let seed = config.seed {
+            samplerSeed = UInt32(truncatingIfNeeded: seed)
+        } else {
+            samplerSeed = UInt32.random(in: 0...UInt32.max)
+        }
+        llama_sampler_chain_add(sampler, llama_sampler_init_dist(samplerSeed))
 
         // MARK: Chunked prompt decode
 

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -4,6 +4,7 @@ import MLX
 import MLXLLM
 import MLXLMCommon
 import MLXVLM
+import MLXRandom
 import MLXHuggingFace
 import Tokenizers
 import os
@@ -317,10 +318,23 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         }
         Self.logger.debug("MLX generate started")
 
+        // Seed the MLX global RandomState before constructing GenerateParameters so the
+        // sampler's per-instance `RandomState()` (initialised from the default state)
+        // produces a deterministic token stream. `nil` skips seeding entirely — the
+        // process keeps whatever entropy MLX last picked up.
+        if let seed = config.seed {
+            MLXRandom.seed(seed)
+        }
+
+        // Honour `config.minP` and `config.repetitionPenalty` when set; fall back to the
+        // upstream defaults / `repeatPenalty` for callers that haven't migrated to the
+        // explicit knobs yet.
         let generateConfig = GenerateParameters(
             temperature: config.temperature,
             topP: config.topP,
-            repetitionPenalty: config.repeatPenalty
+            topK: Int(config.topK ?? 0),
+            minP: config.minP ?? 0.0,
+            repetitionPenalty: config.repetitionPenalty ?? config.repeatPenalty
         )
 
         // Build messages in chat format, using full conversation history when available

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -17,6 +17,34 @@ public struct GenerationConfig: Sendable, Codable {
     public var topK: Int32?
     public var typicalP: Float?
 
+    /// Min-p sampling threshold relative to the highest-probability token.
+    ///
+    /// An alternative to top-p that filters tokens by probability ratio rather than
+    /// cumulative mass. `nil` (the default) lets each backend apply its own value.
+    /// Mirrors `GenerateParameters.minP` in `mlx-swift-lm`. Honoured by ``MLXBackend``
+    /// and ``LlamaBackend``; backends that do not expose a min-p sampler ignore it.
+    public var minP: Float?
+
+    /// Repetition penalty applied to recently-generated tokens (1.0 = no penalty).
+    ///
+    /// Distinct from ``repeatPenalty`` only in shape — kept as a separate optional so
+    /// callers can leave it `nil` and inherit the backend's default behaviour. When
+    /// non-`nil` this value takes precedence over ``repeatPenalty`` for backends that
+    /// support an explicit knob (MLX, llama.cpp). Backends that do not expose a
+    /// repetition penalty (e.g. ``FoundationBackend``) ignore it.
+    public var repetitionPenalty: Float?
+
+    /// Deterministic sampling seed.
+    ///
+    /// When set, backends that expose a sampler seed (``MLXBackend``,
+    /// ``LlamaBackend``) initialise their RNG from this value so two runs with the
+    /// same prompt and config produce the same token stream. Backends that do not
+    /// expose a seed (``FoundationBackend``, cloud backends without a `seed` API
+    /// parameter) silently ignore it — a missing seed is never an error.
+    /// Stored as `UInt64` for parity with mlx-swift-lm; backends with smaller seed
+    /// types (e.g. llama.cpp's `uint32_t`) truncate.
+    public var seed: UInt64?
+
     /// Maximum number of tokens the model should generate in a single response.
     ///
     /// Cloud backends send this as their `max_tokens` API parameter.
@@ -108,7 +136,7 @@ public struct GenerationConfig: Sendable, Codable {
     /// - Only honoured by `MLXBackend`; other backends ignore this field.
     public var yieldEveryNTokens: Int = 8
 
-    @available(*, deprecated, message: "Use init(temperature:topP:repeatPenalty:topK:typicalP:maxOutputTokens:tools:toolChoice:maxThinkingTokens:jsonMode:thinkingMarkers:maxToolIterations:grammar:yieldEveryNTokens:) instead.")
+    @available(*, deprecated, message: "Use init(temperature:topP:repeatPenalty:topK:typicalP:minP:repetitionPenalty:seed:maxOutputTokens:tools:toolChoice:maxThinkingTokens:jsonMode:thinkingMarkers:maxToolIterations:grammar:yieldEveryNTokens:) instead.")
     public init(
         temperature: Float = 0.7,
         topP: Float = 0.9,
@@ -116,6 +144,9 @@ public struct GenerationConfig: Sendable, Codable {
         maxTokens: Int32,
         topK: Int32? = nil,
         typicalP: Float? = nil,
+        minP: Float? = nil,
+        repetitionPenalty: Float? = nil,
+        seed: UInt64? = nil,
         maxOutputTokens: Int? = 2048,
         tools: [ToolDefinition] = [],
         toolChoice: ToolChoice = .auto,
@@ -132,6 +163,9 @@ public struct GenerationConfig: Sendable, Codable {
         self._legacyMaxTokens = maxTokens
         self.topK = topK
         self.typicalP = typicalP
+        self.minP = minP
+        self.repetitionPenalty = repetitionPenalty
+        self.seed = seed
         self.maxOutputTokens = maxOutputTokens
         self.tools = tools
         self.toolChoice = toolChoice
@@ -149,6 +183,9 @@ public struct GenerationConfig: Sendable, Codable {
         repeatPenalty: Float = 1.1,
         topK: Int32? = nil,
         typicalP: Float? = nil,
+        minP: Float? = nil,
+        repetitionPenalty: Float? = nil,
+        seed: UInt64? = nil,
         maxOutputTokens: Int? = 2048,
         tools: [ToolDefinition] = [],
         toolChoice: ToolChoice = .auto,
@@ -164,6 +201,9 @@ public struct GenerationConfig: Sendable, Codable {
         self.repeatPenalty = repeatPenalty
         self.topK = topK
         self.typicalP = typicalP
+        self.minP = minP
+        self.repetitionPenalty = repetitionPenalty
+        self.seed = seed
         self.maxOutputTokens = maxOutputTokens
         self.tools = tools
         self.toolChoice = toolChoice
@@ -181,6 +221,7 @@ public struct GenerationConfig: Sendable, Codable {
         case temperature, topP, repeatPenalty, maxTokens, topK, typicalP, maxOutputTokens
         case tools, toolChoice, maxThinkingTokens, jsonMode, maxToolIterations, grammar
         case yieldEveryNTokens
+        case minP, repetitionPenalty, seed
     }
 
     public init(from decoder: Decoder) throws {
@@ -208,6 +249,11 @@ public struct GenerationConfig: Sendable, Codable {
         grammar = try c.decodeIfPresent(String.self, forKey: .grammar)
         // yieldEveryNTokens landed after the original shape; default to 8 when absent.
         yieldEveryNTokens = (try c.decodeIfPresent(Int.self, forKey: .yieldEveryNTokens)) ?? 8
+        // minP / repetitionPenalty / seed landed after the original shape; absent
+        // from older payloads, default to nil so the backend's own defaults apply.
+        minP = try c.decodeIfPresent(Float.self, forKey: .minP)
+        repetitionPenalty = try c.decodeIfPresent(Float.self, forKey: .repetitionPenalty)
+        seed = try c.decodeIfPresent(UInt64.self, forKey: .seed)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -227,6 +273,9 @@ public struct GenerationConfig: Sendable, Codable {
         try c.encode(maxToolIterations, forKey: .maxToolIterations)
         try c.encodeIfPresent(grammar, forKey: .grammar)
         try c.encode(yieldEveryNTokens, forKey: .yieldEveryNTokens)
+        try c.encodeIfPresent(minP, forKey: .minP)
+        try c.encodeIfPresent(repetitionPenalty, forKey: .repetitionPenalty)
+        try c.encodeIfPresent(seed, forKey: .seed)
     }
 }
 

--- a/Tests/BaseChatBackendsTests/LlamaSeedDeterminismTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaSeedDeterminismTests.swift
@@ -1,0 +1,105 @@
+#if Llama
+import XCTest
+@testable import BaseChatInference
+import BaseChatTestSupport
+@testable import BaseChatBackends
+
+/// Verifies that ``GenerationConfig/seed`` makes ``LlamaBackend`` token streams
+/// reproducible across runs. The driver feeds the seed into
+/// `llama_sampler_init_dist`, so two `generate()` calls with identical prompt /
+/// config / model state must produce the same token sequence.
+///
+/// Requires Apple Silicon and a real GGUF on disk — gated by
+/// ``HardwareRequirements`` and skipped otherwise.
+final class LlamaSeedDeterminismTests: XCTestCase {
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try XCTSkipUnless(HardwareRequirements.isPhysicalDevice,
+                          "LlamaBackend requires Metal (unavailable in simulator)")
+        try XCTSkipUnless(HardwareRequirements.isAppleSilicon,
+                          "LlamaBackend requires Apple Silicon")
+    }
+
+    /// Two generations with the same `seed` produce identical token streams.
+    ///
+    /// We collect the full visible token sequence for two consecutive runs against
+    /// the same loaded model. Under a correct seed implementation, `outputA == outputB`.
+    ///
+    /// Sabotage check: replace the seed plumbing in `LlamaGenerationDriver.run` with
+    /// `UInt32.random(in: 0...UInt32.max)` (the prior behaviour). The two runs will
+    /// diverge after the first sampled token and this assertion will fail.
+    func test_sameSeed_producesIdenticalOutput() async throws {
+        guard let modelURL = HardwareRequirements.findGGUFModel() else {
+            throw XCTSkip("No GGUF on disk. Place a `.gguf` in ~/Documents/Models/ to run this test.")
+        }
+
+        let backend = LlamaBackend()
+        addTeardownBlock { await backend.unloadAndWait() }
+        try await backend.loadModel(from: modelURL, plan: .testStub(effectiveContextSize: 512))
+
+        var config = GenerationConfig(temperature: 0.8, maxOutputTokens: 16)
+        config.seed = 42
+
+        let outputA = try await collectTokens(backend: backend, prompt: "List three colours:", config: config)
+        backend.resetConversation()
+        let outputB = try await collectTokens(backend: backend, prompt: "List three colours:", config: config)
+
+        XCTAssertFalse(outputA.isEmpty, "Seeded generation must produce at least one token")
+        XCTAssertEqual(outputA, outputB,
+                       "Identical seeds must produce identical token streams; "
+                     + "got A=\(outputA.debugDescription) B=\(outputB.debugDescription)")
+    }
+
+    /// Different seeds with non-zero temperature produce distinct outputs.
+    ///
+    /// This guards against the trivial implementation that ignores the seed and
+    /// always uses the same internal state — it would silently make the previous
+    /// test pass by emitting identical streams regardless of the seed value.
+    ///
+    /// Sabotage check: hardcode the seed in `LlamaGenerationDriver.run` to a constant
+    /// (e.g. `42`) instead of reading from `config.seed`. Both runs use the same
+    /// internal seed and this assertion will fail.
+    func test_differentSeeds_produceDifferentOutput() async throws {
+        guard let modelURL = HardwareRequirements.findGGUFModel() else {
+            throw XCTSkip("No GGUF on disk. Place a `.gguf` in ~/Documents/Models/ to run this test.")
+        }
+
+        let backend = LlamaBackend()
+        addTeardownBlock { await backend.unloadAndWait() }
+        try await backend.loadModel(from: modelURL, plan: .testStub(effectiveContextSize: 512))
+
+        var configA = GenerationConfig(temperature: 1.0, maxOutputTokens: 24)
+        configA.seed = 42
+        var configB = configA
+        configB.seed = 1337
+
+        let outputA = try await collectTokens(backend: backend, prompt: "Tell me a fact:", config: configA)
+        backend.resetConversation()
+        let outputB = try await collectTokens(backend: backend, prompt: "Tell me a fact:", config: configB)
+
+        XCTAssertFalse(outputA.isEmpty)
+        XCTAssertFalse(outputB.isEmpty)
+        XCTAssertNotEqual(outputA, outputB,
+                          "Different seeds at temperature=1.0 should diverge; "
+                        + "got matching streams: \(outputA.debugDescription)")
+    }
+
+    // MARK: - Helpers
+
+    private func collectTokens(
+        backend: LlamaBackend,
+        prompt: String,
+        config: GenerationConfig
+    ) async throws -> String {
+        let stream = try backend.generate(prompt: prompt, systemPrompt: nil, config: config)
+        var text = ""
+        for try await event in stream.events {
+            if case .token(let chunk) = event {
+                text += chunk
+            }
+        }
+        return text
+    }
+}
+#endif

--- a/Tests/BaseChatInferenceTests/GenerationConfigTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationConfigTests.swift
@@ -92,4 +92,89 @@ final class GenerationConfigTests: XCTestCase {
 
         XCTAssertEqual(backend.lastConfig?.maxOutputTokens, 1024)
     }
+
+    // MARK: - mlx-swift-lm parity knobs (#750)
+
+    func test_defaultInit_minP_isNil() {
+        let config = GenerationConfig()
+        XCTAssertNil(config.minP)
+    }
+
+    func test_defaultInit_repetitionPenalty_isNil() {
+        let config = GenerationConfig()
+        XCTAssertNil(config.repetitionPenalty)
+    }
+
+    func test_defaultInit_seed_isNil() {
+        let config = GenerationConfig()
+        XCTAssertNil(config.seed)
+    }
+
+    func test_customInit_propagatesParityKnobs() {
+        let config = GenerationConfig(
+            minP: 0.05,
+            repetitionPenalty: 1.2,
+            seed: 42
+        )
+
+        XCTAssertEqual(config.minP, 0.05)
+        XCTAssertEqual(config.repetitionPenalty, 1.2)
+        XCTAssertEqual(config.seed, 42)
+    }
+
+    func test_minP_isMutable() {
+        var config = GenerationConfig()
+        config.minP = 0.1
+        XCTAssertEqual(config.minP, 0.1)
+    }
+
+    func test_repetitionPenalty_isMutable() {
+        var config = GenerationConfig()
+        config.repetitionPenalty = 1.15
+        XCTAssertEqual(config.repetitionPenalty, 1.15)
+    }
+
+    func test_seed_isMutable() {
+        var config = GenerationConfig()
+        config.seed = 1337
+        XCTAssertEqual(config.seed, 1337)
+    }
+
+    // MARK: - Codable round-trip for parity knobs
+
+    func test_codableRoundtrip_preservesParityKnobs() throws {
+        var original = GenerationConfig(temperature: 0.5)
+        original.minP = 0.07
+        original.repetitionPenalty = 1.3
+        original.seed = 9_999_999_999  // exceeds UInt32 to assert UInt64 storage
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: data)
+
+        XCTAssertEqual(decoded.minP, 0.07)
+        XCTAssertEqual(decoded.repetitionPenalty, 1.3)
+        XCTAssertEqual(decoded.seed, 9_999_999_999)
+    }
+
+    func test_codableDecode_legacyPayload_omittingParityKnobs() throws {
+        // Older payloads that predate #750 do not carry minP/repetitionPenalty/seed.
+        // The decoder must default them to nil rather than throwing.
+        let legacyJSON = """
+        {
+            "temperature": 0.7,
+            "topP": 0.9,
+            "repeatPenalty": 1.1,
+            "tools": [],
+            "toolChoice": {"type": "auto"},
+            "jsonMode": false,
+            "maxToolIterations": 10
+        }
+        """
+        let data = try XCTUnwrap(legacyJSON.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: data)
+
+        XCTAssertNil(decoded.minP)
+        XCTAssertNil(decoded.repetitionPenalty)
+        XCTAssertNil(decoded.seed)
+    }
 }


### PR DESCRIPTION
## Summary

Audit `GenerationConfig` against upstream `mlx-swift-lm`'s `GenerateParameters` and the OpenAI API surface. Add the three sampling knobs callers reasonably want, plumb them through every backend that exposes a corresponding SDK surface, and add a Codable round-trip + a Llama seed-determinism test.

### Fields added (all optional, default `nil`)

- `minP: Float?` — min-p sampling threshold (parity with `GenerateParameters.minP`).
- `repetitionPenalty: Float?` — explicit companion to the legacy `repeatPenalty` field; takes precedence when set.
- `seed: UInt64?` — deterministic sampling for reproducibility.

### Backend plumbing

- [x] **MLXBackend** — calls `MLXRandom.seed(_:)` before constructing `GenerateParameters`; passes `minP`, `topK`, and `repetitionPenalty ?? repeatPenalty` through to the upstream sampler.
- [x] **LlamaBackend** — `min_p` is now driven by `config.minP` (default preserves prior 0.05); `llama_sampler_init_dist` consumes the seed (truncating UInt64 → uint32_t); penalties sampler reads `repetitionPenalty ?? repeatPenalty`.
- [x] **FoundationBackend** — Apple's `GenerationOptions` exposes only `temperature` / `maximumResponseTokens` / `sampling`. New fields are silently dropped on the floor — no log spam, no errors.
- [x] **Cloud backends** — no wire-level changes; cloud providers without a `seed` parameter ignore it.

### Tests

- Unit tests for default/custom init, mutation, and Codable round-trip including legacy payloads that omit the new fields.
- `LlamaSeedDeterminismTests` (Llama trait, hardware-gated): asserts identical seeds produce identical token streams and different seeds diverge at temperature 1.0.

### Compatibility

Codable decoder defaults the new fields to `nil` when absent, so any persisted `GenerationConfig` payload from before this change continues to round-trip cleanly. Existing callers that set `repeatPenalty` directly are unaffected — `repetitionPenalty` only takes precedence when explicitly non-`nil`.

Closes #750

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits`
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` (1090 tests pass)
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits` (69 tests pass)
- [x] `swift test --filter BaseChatUITests --disable-default-traits` (479 tests pass)
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits`
- [x] `swift test --filter BaseChatTestSupportTests --disable-default-traits`
- [x] `swift build --target BaseChatBackends --traits MLX,Llama` (clean)
- [x] `swift build --target BaseChatBackendsTests --traits MLX,Llama` (clean)
- [ ] Llama seed-determinism test on Apple Silicon with a real GGUF (gated by `HardwareRequirements.findGGUFModel()`; runs only when a model is present in `~/Documents/Models/`).