### PR TITLE
feat(inference): heal orphan tool calls on session reload

### DIFF
--- a/Sources/BaseChatInference/Services/TranscriptHealer.swift
+++ b/Sources/BaseChatInference/Services/TranscriptHealer.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+/// Heals transcripts that contain orphan ``MessagePart/toolCall`` parts —
+/// tool invocations that never received a matching ``MessagePart/toolResult``.
+///
+/// Cloud APIs (OpenAI, Anthropic, Ollama) reject a follow-up turn whose
+/// history contains an unanswered ``ToolCall`` with `"missing tool_result for
+/// tool_use id …"`. Orphans appear when a process is killed mid-tool — the
+/// model emitted a tool call, the registry started executing, but the host
+/// terminated before the result was persisted. On the next session reload the
+/// transcript still references the call, the next user turn is sent to the
+/// API, and the request bounces.
+///
+/// Re-dispatching the original tool is unsafe: tools have side effects (file
+/// writes, HTTP POSTs, payments) and the previous attempt may have already
+/// completed those. Instead we synthesise a terminal ``ToolResult`` with
+/// ``ToolResult/ErrorKind/cancelled``, which lets the model acknowledge the
+/// gap and decide what to do next.
+///
+/// The healer is a value-only type with no state — it operates on
+/// ``ChatMessageRecord`` arrays (or raw ``MessagePart`` arrays for tests) and
+/// returns a new array with synthesised result parts inserted directly after
+/// each orphan call. Healing is idempotent: re-running it on an already-healed
+/// transcript is a no-op.
+public enum TranscriptHealer {
+    /// Synthesises terminal results for orphan ``MessagePart/toolCall`` parts in `records`.
+    ///
+    /// An orphan is a ``ToolCall`` whose ``ToolCall/id`` does not appear as the
+    /// ``ToolResult/callId`` of any ``MessagePart/toolResult`` part anywhere
+    /// in the transcript. For each orphan, a synthesised ``MessagePart/toolResult``
+    /// is appended to the same message's `contentParts` immediately after the
+    /// originating call. Messages without orphan calls are returned unchanged.
+    ///
+    /// The synthesised result carries:
+    /// - `callId` matching the orphan's ``ToolCall/id``
+    /// - `errorKind = .cancelled`
+    /// - A content string explaining the call was interrupted, including the
+    ///   original arguments string so the user (and the model) can see what
+    ///   was attempted.
+    public static func heal(_ records: [ChatMessageRecord]) -> [ChatMessageRecord] {
+        let resultIDs = collectResultCallIDs(from: records)
+        var healed: [ChatMessageRecord] = []
+        healed.reserveCapacity(records.count)
+        for record in records {
+            healed.append(healRecord(record, resultIDs: resultIDs))
+        }
+        return healed
+    }
+
+    /// Synthesises terminal results for orphan ``MessagePart/toolCall`` parts in a
+    /// single message's `contentParts`.
+    ///
+    /// `resultIDs` is the set of ``ToolResult/callId`` values present *anywhere*
+    /// in the transcript — orphans are determined transcript-wide, but
+    /// synthesised results are inserted into the same message that contains
+    /// the orphan call so persistence round-trips remain stable.
+    public static func healParts(
+        _ parts: [MessagePart],
+        resultIDs: Set<String>
+    ) -> [MessagePart] {
+        // Fast path: no tool calls at all means nothing to heal.
+        guard parts.contains(where: { $0.toolCallContent != nil }) else { return parts }
+
+        var healed: [MessagePart] = []
+        healed.reserveCapacity(parts.count)
+        // Track ids whose results already appear *within this message* — calls
+        // and their results frequently land in the same assistant turn, and we
+        // must not double-insert when a result is present in either the same
+        // record or elsewhere in the transcript.
+        var resolvedInThisMessage: Set<String> = []
+        for part in parts {
+            if case .toolResult(let r) = part {
+                resolvedInThisMessage.insert(r.callId)
+            }
+        }
+
+        for part in parts {
+            healed.append(part)
+            guard case .toolCall(let call) = part else { continue }
+            if resultIDs.contains(call.id) || resolvedInThisMessage.contains(call.id) {
+                continue
+            }
+            healed.append(.toolResult(synthesiseResult(for: call)))
+            // Mark resolved so a duplicate orphan call with the same id (rare
+            // but possible if a backend retried before the host crashed) gets
+            // exactly one synthesised result.
+            resolvedInThisMessage.insert(call.id)
+        }
+        return healed
+    }
+
+    // MARK: - Internal helpers
+
+    static func collectResultCallIDs(from records: [ChatMessageRecord]) -> Set<String> {
+        var ids: Set<String> = []
+        for record in records {
+            for part in record.contentParts {
+                if case .toolResult(let r) = part {
+                    ids.insert(r.callId)
+                }
+            }
+        }
+        return ids
+    }
+
+    static func healRecord(
+        _ record: ChatMessageRecord,
+        resultIDs: Set<String>
+    ) -> ChatMessageRecord {
+        let healedParts = healParts(record.contentParts, resultIDs: resultIDs)
+        if healedParts.count == record.contentParts.count {
+            return record
+        }
+        var copy = record
+        copy.contentParts = healedParts
+        return copy
+    }
+
+    static func synthesiseResult(for call: ToolCall) -> ToolResult {
+        ToolResult(
+            callId: call.id,
+            content: "Tool call was interrupted before completion. Original arguments: \(call.arguments)",
+            errorKind: .cancelled
+        )
+    }
+}

--- a/Sources/BaseChatUI/ViewModels/SessionController.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionController.swift
@@ -115,7 +115,13 @@ final class SessionController {
 
         do {
             let page = try persistence.fetchRecentMessages(for: sessionID, limit: Self.messagePageSize)
-            messages = page
+            // Heal orphan tool calls before exposing the transcript: a process
+            // killed mid-tool leaves a `.toolCall` part with no matching
+            // `.toolResult`, which cloud APIs reject on the next turn. The
+            // healer synthesises a `.cancelled` ToolResult for each orphan so
+            // the next request is well-formed without re-dispatching the
+            // (potentially side-effecting) original call. See issue #629.
+            messages = TranscriptHealer.heal(page)
             hasOlderMessages = page.count >= Self.messagePageSize
             Log.persistence.info("Loaded \(page.count) messages (hasOlder: \(self.hasOlderMessages))")
         } catch {

--- a/Tests/BaseChatInferenceTests/TranscriptHealerTests.swift
+++ b/Tests/BaseChatInferenceTests/TranscriptHealerTests.swift
@@ -1,0 +1,152 @@
+import XCTest
+@testable import BaseChatInference
+
+/// Unit tests for ``TranscriptHealer``. These cover the orphan-detection and
+/// synthesis logic in isolation — no SwiftData, no backends — so they pin the
+/// pure value-level contract independent of how the healer is wired into
+/// session reload.
+final class TranscriptHealerTests: XCTestCase {
+
+    private let sessionID = UUID()
+
+    // MARK: - Helpers
+
+    private func record(
+        role: MessageRole,
+        parts: [MessagePart]
+    ) -> ChatMessageRecord {
+        ChatMessageRecord(
+            role: role,
+            contentParts: parts,
+            sessionID: sessionID
+        )
+    }
+
+    private func toolCall(id: String, name: String = "search", args: String = "{\"q\":\"x\"}") -> ToolCall {
+        ToolCall(id: id, toolName: name, arguments: args)
+    }
+
+    // MARK: - heal(_:)
+
+    func test_heal_emptyTranscript_returnsEmpty() {
+        XCTAssertEqual(TranscriptHealer.heal([]).count, 0)
+    }
+
+    func test_heal_textOnlyTranscript_returnsUnchanged() {
+        let transcript: [ChatMessageRecord] = [
+            record(role: .user, parts: [.text("hi")]),
+            record(role: .assistant, parts: [.text("hello")])
+        ]
+        let healed = TranscriptHealer.heal(transcript)
+        XCTAssertEqual(healed, transcript)
+    }
+
+    func test_heal_pairedToolCallAndResult_returnsUnchanged() {
+        let call = toolCall(id: "call-1")
+        let result = ToolResult(callId: "call-1", content: "ok")
+        let transcript: [ChatMessageRecord] = [
+            record(role: .user, parts: [.text("look it up")]),
+            record(role: .assistant, parts: [.toolCall(call), .toolResult(result), .text("done")])
+        ]
+        let healed = TranscriptHealer.heal(transcript)
+        XCTAssertEqual(healed, transcript)
+    }
+
+    func test_heal_orphanCall_synthesisesCancelledResultRightAfterCall() {
+        let orphan = toolCall(id: "orphan-1", name: "writeFile", args: "{\"path\":\"/tmp/x\"}")
+        let transcript: [ChatMessageRecord] = [
+            record(role: .user, parts: [.text("write the file")]),
+            record(role: .assistant, parts: [.text("ok"), .toolCall(orphan)])
+        ]
+        let healed = TranscriptHealer.heal(transcript)
+
+        XCTAssertEqual(healed.count, 2)
+        XCTAssertEqual(healed[1].contentParts.count, 3)
+        // Synthesised result is the part immediately after the orphan call.
+        guard case .toolResult(let synth) = healed[1].contentParts[2] else {
+            XCTFail("Expected synthesised toolResult after orphan call")
+            return
+        }
+        XCTAssertEqual(synth.callId, "orphan-1")
+        XCTAssertEqual(synth.errorKind, .cancelled)
+        XCTAssertTrue(synth.content.contains("interrupted"))
+        XCTAssertTrue(
+            synth.content.contains("{\"path\":\"/tmp/x\"}"),
+            "Synthesised content must include the original arguments"
+        )
+        XCTAssertTrue(synth.isError)
+    }
+
+    /// Acceptance criterion: multiple orphans in one session each get their
+    /// own synthesised result, with each result keyed to the matching call id.
+    func test_heal_multipleOrphans_synthesisesOnePerCall() {
+        let a = toolCall(id: "orphan-A", name: "writeFile")
+        let b = toolCall(id: "orphan-B", name: "deleteFile")
+        let c = toolCall(id: "orphan-C", name: "send")
+        let transcript: [ChatMessageRecord] = [
+            record(role: .user, parts: [.text("do many things")]),
+            record(role: .assistant, parts: [.toolCall(a), .toolCall(b)]),
+            record(role: .user, parts: [.text("and one more")]),
+            record(role: .assistant, parts: [.toolCall(c)])
+        ]
+        let healed = TranscriptHealer.heal(transcript)
+
+        let synthesised = healed
+            .flatMap { $0.contentParts }
+            .compactMap { part -> ToolResult? in
+                if case .toolResult(let r) = part { return r }
+                return nil
+            }
+
+        XCTAssertEqual(Set(synthesised.map(\.callId)), ["orphan-A", "orphan-B", "orphan-C"])
+        XCTAssertTrue(synthesised.allSatisfy { $0.errorKind == .cancelled })
+        XCTAssertEqual(synthesised.count, 3, "Each orphan must get exactly one synthesised result")
+    }
+
+    func test_heal_onlySomeCallsAreOrphans_healsOnlyOrphans() {
+        let resolved = toolCall(id: "ok-1", name: "search")
+        let orphan = toolCall(id: "orphan-1", name: "writeFile")
+        let transcript: [ChatMessageRecord] = [
+            record(role: .assistant, parts: [
+                .toolCall(resolved),
+                .toolResult(ToolResult(callId: "ok-1", content: "found")),
+                .toolCall(orphan)
+            ])
+        ]
+        let healed = TranscriptHealer.heal(transcript)
+
+        // Original 3 parts + 1 synthesised result = 4
+        XCTAssertEqual(healed[0].contentParts.count, 4)
+        guard case .toolResult(let synth) = healed[0].contentParts[3] else {
+            XCTFail("Expected synthesised toolResult")
+            return
+        }
+        XCTAssertEqual(synth.callId, "orphan-1")
+        XCTAssertEqual(synth.errorKind, .cancelled)
+    }
+
+    /// Result for an orphan can sit in a *later* assistant turn — that still
+    /// counts as resolved and must not be double-synthesised.
+    func test_heal_resultInLaterMessage_isStillConsideredResolved() {
+        let call = toolCall(id: "split-1")
+        let result = ToolResult(callId: "split-1", content: "ok")
+        let transcript: [ChatMessageRecord] = [
+            record(role: .assistant, parts: [.toolCall(call)]),
+            record(role: .assistant, parts: [.toolResult(result)])
+        ]
+        let healed = TranscriptHealer.heal(transcript)
+        XCTAssertEqual(healed, transcript, "Result in a later message resolves the call")
+    }
+
+    /// Healing must be idempotent: running heal twice produces the same
+    /// transcript as running it once.
+    func test_heal_isIdempotent() {
+        let orphan = toolCall(id: "orphan-X")
+        let transcript: [ChatMessageRecord] = [
+            record(role: .assistant, parts: [.toolCall(orphan)])
+        ]
+        let once = TranscriptHealer.heal(transcript)
+        let twice = TranscriptHealer.heal(once)
+        XCTAssertEqual(once, twice)
+    }
+}

--- a/Tests/BaseChatUITests/TranscriptHealOnReloadIntegrationTests.swift
+++ b/Tests/BaseChatUITests/TranscriptHealOnReloadIntegrationTests.swift
@@ -1,0 +1,140 @@
+@preconcurrency import XCTest
+@testable import BaseChatUI
+@testable import BaseChatInference
+import BaseChatCore
+import BaseChatTestSupport
+
+/// Integration test for issue #629: a session whose persisted transcript
+/// contains a `.toolCall` part with no matching `.toolResult` (because the
+/// process was killed mid-tool) must be healed on session reload so that the
+/// next-turn cloud-API request is well-formed.
+///
+/// Uses real ``ChatViewModel`` + in-memory SwiftData persistence; the inference
+/// service has a mock backend that never actually runs. The pipeline under
+/// test is `persistence.insertMessage` → `vm.switchToSession` → `loadMessages`
+/// → `TranscriptHealer.heal` → `vm.messages`.
+@MainActor
+final class TranscriptHealOnReloadIntegrationTests: XCTestCase {
+
+    private var vm: ChatViewModel!
+    private var mock: MockInferenceBackend!
+    private var stack: InMemoryPersistenceHarness.Stack!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        let service = InferenceService(backend: mock, name: "MockHealReload")
+        vm = ChatViewModel(inferenceService: service)
+        stack = try InMemoryPersistenceHarness.make()
+        vm.configure(persistence: stack.provider)
+    }
+
+    override func tearDown() async throws {
+        vm = nil
+        mock = nil
+        stack = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeSession() -> ChatSessionRecord {
+        let session = ChatSessionRecord(title: "Heal-On-Reload")
+        try! stack.provider.insertSession(session)
+        return session
+    }
+
+    /// All `.toolCall` ids that have no matching `.toolResult` anywhere in the
+    /// transcript. The "valid cloud-API history payload" assertion in this
+    /// suite collapses to "this set is empty" — both Anthropic's and OpenAI's
+    /// validators reject any history with a non-empty version of this set.
+    private func orphanCallIDs(in records: [ChatMessageRecord]) -> Set<String> {
+        var calls: Set<String> = []
+        var results: Set<String> = []
+        for r in records {
+            for part in r.contentParts {
+                switch part {
+                case .toolCall(let c): calls.insert(c.id)
+                case .toolResult(let res): results.insert(res.callId)
+                default: break
+                }
+            }
+        }
+        return calls.subtracting(results)
+    }
+
+    // MARK: - Tests
+
+    func test_sessionReload_synthesisesResultForOrphanToolCall() throws {
+        let session = makeSession()
+        let userMsg = ChatMessageRecord(
+            role: .user,
+            content: "Write a file",
+            timestamp: Date(timeIntervalSince1970: 1000),
+            sessionID: session.id
+        )
+        let orphanCall = ToolCall(
+            id: "call-orphan-1",
+            toolName: "writeFile",
+            arguments: "{\"path\":\"/tmp/x\",\"contents\":\"hi\"}"
+        )
+        let assistantMsg = ChatMessageRecord(
+            role: .assistant,
+            contentParts: [.text("On it"), .toolCall(orphanCall)],
+            timestamp: Date(timeIntervalSince1970: 1001),
+            sessionID: session.id
+        )
+        try stack.provider.insertMessage(userMsg)
+        try stack.provider.insertMessage(assistantMsg)
+
+        // Sanity: the persisted transcript has an orphan before reload.
+        let preReload = try stack.provider.fetchMessages(for: session.id)
+        XCTAssertEqual(orphanCallIDs(in: preReload), ["call-orphan-1"])
+
+        // Reload via the ChatViewModel — this is the production code path.
+        vm.switchToSession(session)
+
+        // Acceptance: the in-memory transcript no longer has any orphans.
+        XCTAssertTrue(
+            orphanCallIDs(in: vm.messages).isEmpty,
+            "Reloaded transcript must not contain orphan tool calls — cloud APIs reject these"
+        )
+
+        // Acceptance: the synthesised result is present, marked .cancelled,
+        // and includes the original arguments.
+        let allParts = vm.messages.flatMap(\.contentParts)
+        let synthesised = allParts.compactMap { part -> ToolResult? in
+            if case .toolResult(let r) = part, r.callId == "call-orphan-1" { return r }
+            return nil
+        }
+        XCTAssertEqual(synthesised.count, 1, "Exactly one synthesised result for the orphan")
+        XCTAssertEqual(synthesised.first?.errorKind, .cancelled)
+        XCTAssertTrue(synthesised.first?.content.contains("interrupted") ?? false)
+        XCTAssertTrue(
+            synthesised.first?.content.contains("/tmp/x") ?? false,
+            "Synthesised content should reference the original arguments"
+        )
+    }
+
+    func test_sessionReload_doesNotTouchPairedToolCall() throws {
+        let session = makeSession()
+        let call = ToolCall(id: "paired-1", toolName: "search", arguments: "{}")
+        let result = ToolResult(callId: "paired-1", content: "ok")
+        let assistantMsg = ChatMessageRecord(
+            role: .assistant,
+            contentParts: [.toolCall(call), .toolResult(result), .text("done")],
+            timestamp: Date(timeIntervalSince1970: 1000),
+            sessionID: session.id
+        )
+        try stack.provider.insertMessage(assistantMsg)
+
+        vm.switchToSession(session)
+
+        XCTAssertEqual(vm.messages.count, 1)
+        XCTAssertEqual(
+            vm.messages[0].contentParts.count, 3,
+            "Already-resolved tool calls must not gain a synthesised result"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

On session reload, the persisted transcript may contain a `MessagePart.toolCall` with no matching `.toolResult` (process killed mid-tool, host crashed, etc.). Cloud APIs reject such histories on the next turn (`"missing tool_result for tool_use id X"`) and re-dispatching the original tool is unsafe — side effects may have already partially completed.

This adds a small value-only `TranscriptHealer` in `BaseChatInference` that scans a `[ChatMessageRecord]` for orphan tool calls and synthesises a terminal `ToolResult` with `errorKind: .cancelled` for each one, inserted directly after the originating call. The healer is idempotent — re-running on a healed transcript is a no-op.

It is wired into `SessionController.loadMessages()` so the in-memory transcript is healed once at load, before any next-turn request can leave the device. The synthesised result reads:

> Tool call was interrupted before completion. Original arguments: `<args>`

## Why a `TranscriptHealer` and not `GenerationCoordinator.prepareHistory`

The issue body suggested either site. The inference-tier `GenerationCoordinator` doesn't have a `prepareHistory` step today (history-trimming happens in `ContextWindowManager` and tool-aware history is built incrementally inside the dispatch loop). Healing at session-reload time is a single, deterministic shot that fixes the in-memory transcript before any backend ever sees it, and the value-typed helper has no orchestration concerns of its own.

## Acceptance criteria

- [x] Orphan-call detection in a small healer type (`TranscriptHealer.heal`)
- [x] Synthesised result marked `.cancelled` with the interrupted-context message
- [x] Integration test (`TranscriptHealOnReloadIntegrationTests`) seeds an orphan via the in-memory SwiftData provider, calls `vm.switchToSession`, and asserts the resulting transcript has zero orphans (which is exactly the precondition cloud APIs validate)
- [x] Unit test (`TranscriptHealerTests`) covers multiple orphans in one session each getting their own synthesised result, plus paired-call/idempotency/result-in-later-message edge cases

## Notes

- The existing `ToolResult.ErrorKind.cancelled` case (in `ToolTypes.swift`) was reused — no new error kinds were introduced. This stays clear of the cancellation-contract work in #622.
- Sabotage-checked locally: replacing `heal(_:)` with `return records` makes both integration tests fail; restored before committing.
- All six CI suites pass locally (`Core`, `Inference`, `InferenceSwiftTesting`, `UI`, `Backends`, `TestSupport`).

Closes #629

## Test plan

- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` (1107 tests, includes new `TranscriptHealerTests`)
- [x] `swift test --filter BaseChatUITests --disable-default-traits` (495 tests, includes new `TranscriptHealOnReloadIntegrationTests`)
- [x] Sabotage check: temporarily breaking the healer fails the integration tests