### PR TITLE
feat(cloud): preserve thinking blocks across multi-turn Claude requests

### DIFF
--- a/Sources/BaseChatBackends/ClaudeBackend.swift
+++ b/Sources/BaseChatBackends/ClaudeBackend.swift
@@ -8,7 +8,7 @@ import BaseChatInference
 /// Streams completions from the Anthropic Messages API (`/v1/messages`).
 /// Handles Claude-specific SSE event types (`content_block_delta`, etc.)
 /// and authentication via `x-api-key` header.
-public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBackendKeychainConfigurable, @unchecked Sendable {
+public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBackendKeychainConfigurable, StructuredHistoryReceiver, @unchecked Sendable {
 
     // MARK: - Init
 
@@ -27,6 +27,24 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             urlSession: urlSession ?? URLSessionProvider.pinned,
             payloadHandler: ClaudePayloadHandler()
         )
+    }
+
+    // MARK: - Structured History
+
+    /// Structured replay history. Set by the coordinator when the caller
+    /// uses ``InferenceService/enqueue(structuredMessages:...)``; carries
+    /// the prior assistant turns' ``MessagePart/thinking(_:signature:)``
+    /// blocks so the request body can include them with their signatures
+    /// verbatim. Anthropic rejects multi-turn extended-thinking requests
+    /// that drop or alter the signature.
+    private var _structuredHistory: [StructuredMessage]?
+    public var structuredHistory: [StructuredMessage]? {
+        get { withStateLock { _structuredHistory } }
+        set { withStateLock { _structuredHistory = newValue } }
+    }
+
+    public func setStructuredHistory(_ messages: [StructuredMessage]) {
+        withStateLock { _structuredHistory = messages }
     }
 
     /// Throwing factory that propagates ``URLSessionProvider/networkDisabled``
@@ -97,8 +115,15 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
 
         let messagesURL = baseURL.appendingPathComponent("v1/messages")
 
-        let chatMessages: [[String: String]]
-        if let history = conversationHistory {
+        // Prefer the structured history when the coordinator provided one —
+        // it carries thinking blocks with signatures so multi-turn extended
+        // thinking replay works correctly. Fall back to the flattened
+        // (role, content) history for non-thinking conversations or callers
+        // using the legacy entry points.
+        let chatMessages: [[String: Any]]
+        if let structured = structuredHistory, !structured.isEmpty {
+            chatMessages = structured.map(Self.encodeMessageContent(for:))
+        } else if let history = conversationHistory {
             chatMessages = history.map { ["role": $0.role, "content": $0.content] }
         } else {
             chatMessages = [["role": "user", "content": prompt]]
@@ -143,6 +168,68 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         return request
     }
 
+    // MARK: - Structured Content Encoding
+
+    /// Encodes one ``StructuredMessage`` as an Anthropic Messages API
+    /// `messages[]` entry.
+    ///
+    /// - User turns collapse to a plain string `content` for simplicity —
+    ///   Anthropic accepts either a string or a structured array on user
+    ///   role.
+    /// - Assistant turns serialize to a structured `content` array. Thinking
+    ///   blocks are emitted **before** any text block, with their
+    ///   ``MessagePart/thinkingSignature`` carried verbatim. Anthropic's
+    ///   multi-turn extended-thinking contract requires the signature to
+    ///   match what the model emitted on the previous turn, so any
+    ///   thinking block missing a signature is dropped rather than sent
+    ///   with a blank one (which would 400).
+    /// - System / tool turns fall back to plain string content.
+    static func encodeMessageContent(for message: StructuredMessage) -> [String: Any] {
+        if message.role == "assistant" {
+            var blocks: [[String: Any]] = []
+
+            // Thinking blocks first — Anthropic requires thinking content to
+            // precede any text/tool_use within the same assistant turn.
+            for part in message.parts {
+                if case .thinking(let text, let signature) = part {
+                    // Signature-less thinking blocks (legacy persisted rows
+                    // that pre-date #604, or local backends like MLX/Llama
+                    // where Anthropic never issued one) are dropped from the
+                    // replay payload. Sending them blank would fail the
+                    // server-side signature check and 400 the request.
+                    guard let signature else { continue }
+                    blocks.append([
+                        "type": "thinking",
+                        "thinking": text,
+                        "signature": signature
+                    ])
+                }
+            }
+
+            // Then text. Concatenated into a single block to match how the
+            // model originally emitted its visible content.
+            let visible = message.textContent
+            if !visible.isEmpty {
+                blocks.append([
+                    "type": "text",
+                    "text": visible
+                ])
+            }
+
+            // An assistant turn with neither thinking nor text would 400.
+            // Emit a single empty text block in that pathological case so
+            // the wire shape is still valid and the server returns a normal
+            // error rather than a stream-level parse failure.
+            if blocks.isEmpty {
+                return ["role": "assistant", "content": ""]
+            }
+            return ["role": "assistant", "content": blocks]
+        }
+
+        // User and other roles: collapse to plain text.
+        return ["role": message.role, "content": message.textContent]
+    }
+
     /// Claude reports usage split across `message_start` (prompt) and
     /// `message_delta` (completion), so we merge incrementally.
     public override func handleUsage(_ usage: (promptTokens: Int?, completionTokens: Int?)) {
@@ -177,6 +264,13 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
     /// (text block start, token, usage, or terminal stop). Non-reasoning
     /// responses never fire `.thinkingComplete` because no thinking chunk was
     /// ever observed.
+    ///
+    /// Anthropic's extended-thinking blocks also carry an opaque
+    /// `signature` — required verbatim on multi-turn replay. We surface it
+    /// as ``GenerationEvent/thinkingSignature(_:)``, captured from either
+    /// the `content_block_start` payload or a nested
+    /// `signature_delta` (the path real production streams use today).
+    /// See #604.
     public override func parseResponseStream(
         bytes: URLSession.AsyncBytes,
         config: GenerationConfig,
@@ -200,6 +294,27 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             if Task.isCancelled { break }
 
             let eventType = Self.parseEventType(from: payload)
+
+            // Thinking-block start: opportunistically capture the signature
+            // if Anthropic shipped one inline on the start event. Real
+            // streams more commonly carry the signature on a later
+            // `signature_delta`, but a couple of beta endpoints attach it
+            // here, and the redundant emission is harmless — UI consumers
+            // overwrite stored signatures rather than appending.
+            if eventType == "content_block_start", let signature = Self.parseThinkingBlockStartSignature(from: payload) {
+                continuation.yield(.thinkingSignature(signature))
+                continue
+            }
+
+            // Signature delta inside the thinking block. This is the
+            // primary path Anthropic uses today for extended-thinking
+            // signatures — the field arrives via a `signature_delta`
+            // sub-type of `content_block_delta`. Surface it to the UI so
+            // multi-turn replay can preserve the exact bytes verbatim.
+            if eventType == "content_block_delta", let signature = Self.parseSignatureDelta(from: payload) {
+                continuation.yield(.thinkingSignature(signature))
+                continue
+            }
 
             // Thinking delta: emit as thinkingToken, keep the block open.
             if eventType == "content_block_delta", let thinking = Self.parseThinkingDelta(from: payload) {
@@ -313,6 +428,43 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             return nil
         }
         return parsed["type"] as? String
+    }
+
+    /// Extracts the `.signature` field from a thinking-block
+    /// `content_block_start` payload, when present.
+    ///
+    /// Shape: `{type:"content_block_start", content_block:{type:"thinking", signature:"..."}}`.
+    /// Returns `nil` for non-thinking blocks or starts that don't carry a
+    /// signature.
+    static func parseThinkingBlockStartSignature(from json: String) -> String? {
+        guard let data = json.data(using: .utf8),
+              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              parsed["type"] as? String == "content_block_start",
+              let block = parsed["content_block"] as? [String: Any],
+              block["type"] as? String == "thinking",
+              let signature = block["signature"] as? String,
+              !signature.isEmpty else {
+            return nil
+        }
+        return signature
+    }
+
+    /// Extracts the `.signature` from a `signature_delta` event nested
+    /// inside a `content_block_delta`. Anthropic emits the extended-thinking
+    /// signature via this path on most production responses.
+    ///
+    /// Shape: `{type:"content_block_delta", delta:{type:"signature_delta", signature:"..."}}`.
+    static func parseSignatureDelta(from json: String) -> String? {
+        guard let data = json.data(using: .utf8),
+              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              parsed["type"] as? String == "content_block_delta",
+              let delta = parsed["delta"] as? [String: Any],
+              delta["type"] as? String == "signature_delta",
+              let signature = delta["signature"] as? String,
+              !signature.isEmpty else {
+            return nil
+        }
+        return signature
     }
 
     /// Extracts the `.thinking` text from a `thinking_delta` content-block delta.

--- a/Sources/BaseChatBackends/OpenAIBackend.swift
+++ b/Sources/BaseChatBackends/OpenAIBackend.swift
@@ -106,6 +106,17 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             messages.append(["role": "system", "content": systemPrompt])
         }
         if let history = conversationHistory {
+            // Reasoning-model asymmetry: OpenAI-compatible providers (DeepSeek,
+            // o-series, hosted Qwen reasoning) deliver chain-of-thought via
+            // `reasoning_content` / `reasoning` deltas but **don't** require
+            // it on multi-turn replay — and most providers reject blocks they
+            // didn't emit. ``GenerationCoordinator`` already collapsed
+            // structured history to `(role, content)` text via
+            // ``StructuredMessage/textContent``, which drops `.thinking`
+            // parts. So thinking is informational only on this backend's
+            // replay path. Anthropic's multi-turn signature contract is
+            // handled by ``ClaudeBackend`` reading the structured history
+            // directly. (#604)
             messages.append(contentsOf: history.map { ["role": $0.role, "content": $0.content] })
         } else {
             messages.append(["role": "user", "content": prompt])

--- a/Sources/BaseChatFuzz/EventRecorder.swift
+++ b/Sources/BaseChatFuzz/EventRecorder.swift
@@ -83,6 +83,12 @@ public struct EventRecorder: Sendable {
                     events.append(.init(t: t, kind: "kvCacheReuse", v: "\(tokens)"))
                 case .diagnosticThrottle(let reason):
                     events.append(.init(t: t, kind: "diagnosticThrottle", v: reason))
+                case .thinkingSignature(let signature):
+                    // Provider-issued opaque token for multi-turn replay
+                    // (Anthropic extended thinking). Surface in the trace so
+                    // fuzz scenarios can pin its presence/absence without
+                    // affecting reasoning text accumulation.
+                    events.append(.init(t: t, kind: "thinkingSignature", v: signature))
                 }
                 memoryTick()
             }

--- a/Sources/BaseChatInference/Models/GenerationEvent.swift
+++ b/Sources/BaseChatInference/Models/GenerationEvent.swift
@@ -24,6 +24,20 @@ public enum GenerationEvent: Sendable, Equatable {
     /// Reasoning block complete (depth 1→0 transition). Finalize accumulated thinking content.
     case thinkingComplete
 
+    /// Provider-supplied opaque signature attached to the most recent
+    /// thinking block. Emitted by backends (Anthropic) whose APIs require
+    /// the signature verbatim on multi-turn replay.
+    ///
+    /// Fired between the block's `content_block_start` and the first
+    /// `content_block_delta`, before any ``thinkingToken`` events for the
+    /// same block. Consumers attach the signature to the in-flight
+    /// reasoning accumulator so it lands on the persisted
+    /// ``MessagePart/thinking(_:signature:)`` part once
+    /// ``thinkingComplete`` arrives. Backends without a signature concept
+    /// (MLX inline `<think>`, OpenAI `reasoning_content`, Llama) never
+    /// emit this event.
+    case thinkingSignature(String)
+
     /// The orchestrator terminated a tool-dispatch loop because the per-request
     /// iteration budget (``GenerationConfig/maxToolIterations``) was reached.
     ///

--- a/Sources/BaseChatInference/Models/MessagePart.swift
+++ b/Sources/BaseChatInference/Models/MessagePart.swift
@@ -18,11 +18,17 @@ import Foundation
 /// (see ``BaseChatSchemaV3``), so such rows decode correctly as their actual
 /// cases. The `.text` fallback remains as a safety net for genuinely
 /// malformed JSON until V5.
-public enum MessagePart: Codable, Hashable, Sendable {
+public enum MessagePart: Hashable, Sendable {
     case text(String)
     case image(data: Data, mimeType: String)
     /// Accumulated model reasoning. Excluded from context window (textContent returns nil).
-    case thinking(String)
+    ///
+    /// ``signature`` carries the provider-supplied opaque token that some
+    /// reasoning APIs (notably Anthropic's extended thinking) require verbatim
+    /// when the block is replayed in a multi-turn request. It is `nil` for
+    /// providers that don't issue one or for legacy persisted rows that
+    /// pre-date the field.
+    case thinking(String, signature: String? = nil)
     /// A tool invocation emitted by the model during generation.
     ///
     /// Persisted so that the conversation history preserves the full
@@ -33,15 +39,105 @@ public enum MessagePart: Codable, Hashable, Sendable {
     ///
     /// Excluded from ``textContent`` and from the accessibility label.
     case toolResult(ToolResult)
+}
 
-    // Pin the on-disk discriminator keys. Swift's synthesized Codable uses the
-    // case name by default; declaring CodingKeys explicitly makes the wire
-    // contract load-bearing and visible to reviewers. Renaming one of these
-    // raw values would silently strand every persisted row, so the
-    // `test_toolCall_codableRoundtrip` wire-format assertion in
-    // MessagePartToolCasesTests is the sentry that catches such drift.
+// MARK: - Codable
+
+extension MessagePart: Codable {
+
+    // Pin the on-disk discriminator keys. Renaming one of these raw values
+    // would silently strand every persisted row, so the wire-format
+    // assertions in MessagePartToolCasesTests / MessagePartThinkingTests are
+    // the sentries that catch such drift.
     private enum CodingKeys: String, CodingKey {
         case text, image, thinking, toolCall, toolResult
+    }
+
+    private enum ImageKeys: String, CodingKey {
+        case data, mimeType
+    }
+
+    /// Nested payload used for the `.thinking` discriminator.
+    ///
+    /// Encoded as a structured object so the optional ``signature`` (required
+    /// by Anthropic for extended-thinking replay) rides alongside the text
+    /// without overloading the discriminator key. Legacy persisted rows that
+    /// stored `.thinking` as a bare string still decode — see
+    /// ``init(from:)``.
+    private struct ThinkingPayload: Codable {
+        var text: String
+        var signature: String?
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let keys = container.allKeys
+        guard let key = keys.first else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: container.codingPath,
+                    debugDescription: "MessagePart: empty discriminator container"
+                )
+            )
+        }
+        if keys.count > 1 {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: container.codingPath,
+                    debugDescription: "MessagePart: multiple discriminator keys present (\(keys.map(\.rawValue).joined(separator: ",")))"
+                )
+            )
+        }
+        switch key {
+        case .text:
+            self = .text(try container.decode(String.self, forKey: .text))
+        case .image:
+            let nested = try container.nestedContainer(keyedBy: ImageKeys.self, forKey: .image)
+            let data = try nested.decode(Data.self, forKey: .data)
+            let mimeType = try nested.decode(String.self, forKey: .mimeType)
+            self = .image(data: data, mimeType: mimeType)
+        case .thinking:
+            // Accept both shapes:
+            //   legacy:  {"thinking": "text"}
+            //   current: {"thinking": {"text": "...", "signature": "..."}}
+            // Pre-#604 rows used the bare-string form. The structured object
+            // is the modern wire format; we attempt it first, then fall back
+            // to the bare string only on a type-mismatch error so genuine
+            // corruption still surfaces through the outer decoder.
+            do {
+                let payload = try container.decode(ThinkingPayload.self, forKey: .thinking)
+                self = .thinking(payload.text, signature: payload.signature)
+            } catch DecodingError.typeMismatch {
+                let raw = try container.decode(String.self, forKey: .thinking)
+                self = .thinking(raw, signature: nil)
+            }
+        case .toolCall:
+            self = .toolCall(try container.decode(ToolCall.self, forKey: .toolCall))
+        case .toolResult:
+            self = .toolResult(try container.decode(ToolResult.self, forKey: .toolResult))
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .text(let text):
+            try container.encode(text, forKey: .text)
+        case .image(let data, let mimeType):
+            var nested = container.nestedContainer(keyedBy: ImageKeys.self, forKey: .image)
+            try nested.encode(data, forKey: .data)
+            try nested.encode(mimeType, forKey: .mimeType)
+        case .thinking(let text, let signature):
+            // Always emit the structured object form; legacy readers in
+            // BaseChatSchemaV3 decode through the branch above. A nil
+            // signature is omitted to keep persisted rows compact for the
+            // common (non-Anthropic) case.
+            try container.encode(ThinkingPayload(text: text, signature: signature), forKey: .thinking)
+        case .toolCall(let call):
+            try container.encode(call, forKey: .toolCall)
+        case .toolResult(let result):
+            try container.encode(result, forKey: .toolResult)
+        }
     }
 }
 
@@ -54,7 +150,15 @@ extension MessagePart {
     }
 
     public var thinkingContent: String? {
-        if case .thinking(let t) = self { return t }
+        if case .thinking(let t, _) = self { return t }
+        return nil
+    }
+
+    /// The provider-supplied opaque signature attached to a `.thinking`
+    /// block, or `nil` for non-thinking parts and for thinking parts that
+    /// have no signature.
+    public var thinkingSignature: String? {
+        if case .thinking(_, let sig) = self { return sig }
         return nil
     }
 

--- a/Sources/BaseChatInference/Protocols/BackendOptInProtocols.swift
+++ b/Sources/BaseChatInference/Protocols/BackendOptInProtocols.swift
@@ -16,6 +16,71 @@ public protocol ConversationHistoryReceiver: AnyObject {
     func setConversationHistory(_ messages: [(role: String, content: String)])
 }
 
+/// One turn in a structured conversation history — a role plus an ordered
+/// list of ``MessagePart`` values.
+///
+/// This is the inference-layer companion to ``ChatMessageRecord``: it strips
+/// persistence-only fields (timestamp, sessionID, token counts) and exposes
+/// just what the generation pipeline needs to format prompts and serialize
+/// provider-specific request bodies. Crucially, ``parts`` retains
+/// ``MessagePart/thinking(_:signature:)`` blocks with their provider
+/// signatures intact so multi-turn replay against APIs that require the
+/// signature verbatim (Anthropic extended thinking) works on the second
+/// turn and beyond.
+///
+/// Text-only backends collapse a ``StructuredMessage`` back to
+/// `(role, content)` at their boundary — see
+/// ``GenerationCoordinator`` for the flattening rule (text parts joined,
+/// thinking parts dropped from the prompt).
+public struct StructuredMessage: Sendable, Hashable {
+
+    /// `"user"`, `"assistant"`, `"system"`, or `"tool"`.
+    public let role: String
+
+    /// Ordered content parts for this turn. May contain text, thinking
+    /// blocks (with optional signatures), images, and tool calls / results.
+    public let parts: [MessagePart]
+
+    public init(role: String, parts: [MessagePart]) {
+        self.role = role
+        self.parts = parts
+    }
+
+    /// Convenience constructor for a plain text turn.
+    public init(role: String, content: String) {
+        self.role = role
+        self.parts = [.text(content)]
+    }
+
+    /// Plain-text projection used by text-only backends. Concatenates every
+    /// `.text` part in order and drops every other part type.
+    ///
+    /// Thinking blocks are intentionally excluded: they would either be
+    /// double-counted against the context window or leak provider-internal
+    /// reasoning into prompts that the wire format does not natively
+    /// support. Backends that want to replay thinking adopt
+    /// ``StructuredHistoryReceiver`` instead and read ``parts`` directly.
+    public var textContent: String {
+        parts.compactMap(\.textContent).joined()
+    }
+}
+
+/// Adopted by backends that can consume the full structured conversation
+/// history — including thinking blocks with their provider signatures and
+/// tool call / result parts.
+///
+/// ``GenerationCoordinator`` calls this in addition to (not instead of)
+/// ``ConversationHistoryReceiver`` so backends can pick whichever shape
+/// matches their wire format. The Anthropic backend reads the structured
+/// form so it can serialize prior `thinking` content blocks with their
+/// `signature` verbatim — required for multi-turn extended-thinking
+/// requests. OpenAI-compatible reasoning APIs (DeepSeek, etc.) drop
+/// thinking on replay and continue to read the flattened
+/// ``ConversationHistoryReceiver`` form.
+public protocol StructuredHistoryReceiver: AnyObject {
+    func setStructuredHistory(_ messages: [StructuredMessage])
+}
+
 /// One entry in a tool-aware conversation history.
 ///
 /// Extends the plain `(role, content)` shape that ``ConversationHistoryReceiver``

--- a/Sources/BaseChatInference/Services/GenerationCoordinator.swift
+++ b/Sources/BaseChatInference/Services/GenerationCoordinator.swift
@@ -89,7 +89,11 @@ final class GenerationCoordinator {
         let token: GenerationRequestToken
         let priority: GenerationPriority
         let sessionID: UUID?
-        let messages: [(role: String, content: String)]
+        /// Structured conversation history. Carries thinking signatures and
+        /// tool parts intact so cloud backends with structured wire formats
+        /// (Anthropic) can replay them on multi-turn requests; text-only
+        /// backends collapse this to `(role, content)` at their boundary.
+        let messages: [StructuredMessage]
         let systemPrompt: String?
         let config: GenerationConfig
         let stream: GenerationStream
@@ -150,6 +154,35 @@ final class GenerationCoordinator {
         maxThinkingTokens: Int? = nil,
         jsonMode: Bool = false
     ) throws -> GenerationStream {
+        try generate(
+            structuredMessages: messages.map { StructuredMessage(role: $0.role, content: $0.content) },
+            systemPrompt: systemPrompt,
+            temperature: temperature,
+            topP: topP,
+            repeatPenalty: repeatPenalty,
+            maxOutputTokens: maxOutputTokens,
+            maxThinkingTokens: maxThinkingTokens,
+            jsonMode: jsonMode
+        )
+    }
+
+    /// Structured-message variant of ``generate(messages:...)``.
+    ///
+    /// Threads ``StructuredMessage`` (carrying ``MessagePart`` content
+    /// including thinking signatures) through to the backend boundary.
+    /// Backends adopting ``StructuredHistoryReceiver`` see the structured
+    /// form; text-only backends keep receiving the flattened `(role,
+    /// content)` shape via ``ConversationHistoryReceiver``.
+    func generate(
+        structuredMessages messages: [StructuredMessage],
+        systemPrompt: String? = nil,
+        temperature: Float = 0.7,
+        topP: Float = 0.9,
+        repeatPenalty: Float = 1.1,
+        maxOutputTokens: Int? = 2048,
+        maxThinkingTokens: Int? = nil,
+        jsonMode: Bool = false
+    ) throws -> GenerationStream {
         guard let backend = provider?.currentBackend else {
             throw InferenceError.inferenceFailure("No model loaded")
         }
@@ -176,56 +209,10 @@ final class GenerationCoordinator {
         )
         config.maxThinkingTokens = maxThinkingTokens
 
-        // Exact-count pre-flight: backends that conform to TokenCountingBackend
-        // expose the real tokenizer. Use it to verify the assembled prompt fits
-        // inside the context window before committing to the C-level decode.
-        // The heuristic guard inside LlamaBackend.generate() remains as a
-        // fast-path sanity check for obviously-too-large prompts, but this
-        // trim-and-retry loop is the definitive gate that prevents KV overflow.
-        if let counter = backend as? TokenCountingBackend,
-           backend.capabilities.requiresPromptTemplate {
-            let result = try exactPreflightAndTrim(
-                counter: counter,
-                backend: backend,
-                messages: messages,
-                systemPrompt: systemPrompt,
-                config: config
-            )
-            if let historyReceiver = backend as? ConversationHistoryReceiver {
-                // Pass the trimmed messages so the backend's own history buffer
-                // reflects what was actually sent in the prompt.
-                historyReceiver.setConversationHistory(result.trimmedMessages)
-            }
-            return try backend.generate(
-                prompt: result.prompt,
-                systemPrompt: nil,
-                config: config
-            )
-        }
-
-        // Non-TokenCountingBackend path: assemble prompt and forward.
-        // For backends that require a prompt template, messages are formatted
-        // into a single string. Otherwise the most recent user message is
-        // passed directly and the system prompt goes through a separate channel.
-        let assembledPrompt: String
-        let effectiveSystemPrompt: String?
-
-        if backend.capabilities.requiresPromptTemplate {
-            let template = provider?.selectedPromptTemplate ?? .chatML
-            assembledPrompt = template.format(messages: messages, systemPrompt: systemPrompt)
-            effectiveSystemPrompt = nil
-        } else {
-            assembledPrompt = messages.last(where: { $0.role == "user" })?.content ?? ""
-            effectiveSystemPrompt = systemPrompt
-        }
-
-        if let historyReceiver = backend as? ConversationHistoryReceiver {
-            historyReceiver.setConversationHistory(messages)
-        }
-
-        return try backend.generate(
-            prompt: assembledPrompt,
-            systemPrompt: effectiveSystemPrompt,
+        return try dispatchToBackend(
+            backend: backend,
+            messages: messages,
+            systemPrompt: systemPrompt,
             config: config
         )
     }
@@ -245,6 +232,19 @@ final class GenerationCoordinator {
         systemPrompt: String?,
         config: GenerationConfig
     ) throws -> GenerationStream {
+        try generateWithConfig(
+            structuredMessages: messages.map { StructuredMessage(role: $0.role, content: $0.content) },
+            systemPrompt: systemPrompt,
+            config: config
+        )
+    }
+
+    /// Structured-message variant of ``generateWithConfig(messages:...)``.
+    func generateWithConfig(
+        structuredMessages messages: [StructuredMessage],
+        systemPrompt: String?,
+        config: GenerationConfig
+    ) throws -> GenerationStream {
         guard let backend = provider?.currentBackend else {
             throw InferenceError.inferenceFailure("No model loaded")
         }
@@ -256,6 +256,35 @@ final class GenerationCoordinator {
             Self.jsonModeUnsupportedWarningHook?(backendType, message)
         }
 
+        return try dispatchToBackend(
+            backend: backend,
+            messages: messages,
+            systemPrompt: systemPrompt,
+            config: config
+        )
+    }
+
+    // MARK: - Backend dispatch (Private)
+
+    /// Common dispatch path shared by ``generate(structuredMessages:...)``
+    /// and ``generateWithConfig(structuredMessages:...)``.
+    ///
+    /// Performs the optional exact-token pre-flight + trim loop, hands the
+    /// structured history to ``StructuredHistoryReceiver`` adopters,
+    /// flattens to `(role, content)` for ``ConversationHistoryReceiver``
+    /// adopters, and finally invokes ``InferenceBackend/generate(...)``.
+    private func dispatchToBackend(
+        backend: InferenceBackend,
+        messages: [StructuredMessage],
+        systemPrompt: String?,
+        config: GenerationConfig
+    ) throws -> GenerationStream {
+        // Exact-count pre-flight: backends that conform to TokenCountingBackend
+        // expose the real tokenizer. Use it to verify the assembled prompt fits
+        // inside the context window before committing to the C-level decode.
+        // The heuristic guard inside LlamaBackend.generate() remains as a
+        // fast-path sanity check for obviously-too-large prompts, but this
+        // trim-and-retry loop is the definitive gate that prevents KV overflow.
         if let counter = backend as? TokenCountingBackend,
            backend.capabilities.requiresPromptTemplate {
             let result = try exactPreflightAndTrim(
@@ -265,9 +294,7 @@ final class GenerationCoordinator {
                 systemPrompt: systemPrompt,
                 config: config
             )
-            if let historyReceiver = backend as? ConversationHistoryReceiver {
-                historyReceiver.setConversationHistory(result.trimmedMessages)
-            }
+            installHistory(on: backend, structuredMessages: result.trimmedMessages)
             return try backend.generate(
                 prompt: result.prompt,
                 systemPrompt: nil,
@@ -275,20 +302,24 @@ final class GenerationCoordinator {
             )
         }
 
+        // Non-TokenCountingBackend path: assemble prompt and forward.
+        // For backends that require a prompt template, messages are formatted
+        // into a single string. Otherwise the most recent user message is
+        // passed directly and the system prompt goes through a separate channel.
+        let flattened = flatten(messages)
         let assembledPrompt: String
         let effectiveSystemPrompt: String?
+
         if backend.capabilities.requiresPromptTemplate {
             let template = provider?.selectedPromptTemplate ?? .chatML
-            assembledPrompt = template.format(messages: messages, systemPrompt: systemPrompt)
+            assembledPrompt = template.format(messages: flattened, systemPrompt: systemPrompt)
             effectiveSystemPrompt = nil
         } else {
-            assembledPrompt = messages.last(where: { $0.role == "user" })?.content ?? ""
+            assembledPrompt = flattened.last(where: { $0.role == "user" })?.content ?? ""
             effectiveSystemPrompt = systemPrompt
         }
 
-        if let historyReceiver = backend as? ConversationHistoryReceiver {
-            historyReceiver.setConversationHistory(messages)
-        }
+        installHistory(on: backend, structuredMessages: messages)
 
         return try backend.generate(
             prompt: assembledPrompt,
@@ -297,11 +328,44 @@ final class GenerationCoordinator {
         )
     }
 
+    /// Flattens ``StructuredMessage`` to the legacy `(role, content)` shape
+    /// for backends and helpers that operate on plain strings (prompt
+    /// templates, ``ConversationHistoryReceiver``).
+    ///
+    /// Thinking parts are dropped because they would either bloat the prompt
+    /// with provider-internal reasoning or fail validation on the
+    /// non-Anthropic providers that don't accept replayed thinking.
+    /// ``StructuredHistoryReceiver`` adopters read the unflattened form
+    /// directly to preserve thinking signatures.
+    private static func flatten(_ messages: [StructuredMessage]) -> [(role: String, content: String)] {
+        messages.map { (role: $0.role, content: $0.textContent) }
+    }
+
+    /// Instance-level wrapper around the static flatten so call sites stay readable.
+    private func flatten(_ messages: [StructuredMessage]) -> [(role: String, content: String)] {
+        Self.flatten(messages)
+    }
+
+    /// Hands history to whichever receiver protocol the backend conforms to.
+    ///
+    /// A backend may conform to both — ``StructuredHistoryReceiver`` is set
+    /// first so a backend that needs structured access (Anthropic) gets the
+    /// authoritative shape, and the flattened ``ConversationHistoryReceiver``
+    /// fallback is set afterwards for backends that only inspect strings.
+    private func installHistory(on backend: InferenceBackend, structuredMessages: [StructuredMessage]) {
+        if let structuredReceiver = backend as? StructuredHistoryReceiver {
+            structuredReceiver.setStructuredHistory(structuredMessages)
+        }
+        if let historyReceiver = backend as? ConversationHistoryReceiver {
+            historyReceiver.setConversationHistory(flatten(structuredMessages))
+        }
+    }
+
     // MARK: - Exact Pre-flight (Private)
 
     private struct ExactPreflightResult {
         let prompt: String
-        let trimmedMessages: [(role: String, content: String)]
+        let trimmedMessages: [StructuredMessage]
     }
 
     /// Counts tokens on the assembled prompt and trims the oldest non-system
@@ -314,7 +378,7 @@ final class GenerationCoordinator {
     private func exactPreflightAndTrim(
         counter: TokenCountingBackend,
         backend: InferenceBackend,
-        messages: [(role: String, content: String)],
+        messages: [StructuredMessage],
         systemPrompt: String?,
         config: GenerationConfig,
         maxTrimAttempts: Int = 20
@@ -340,7 +404,7 @@ final class GenerationCoordinator {
         var attempt = 0
 
         while true {
-            let prompt = template.format(messages: workingMessages, systemPrompt: systemPrompt)
+            let prompt = template.format(messages: Self.flatten(workingMessages), systemPrompt: systemPrompt)
             let promptTokens = try counter.countTokens(prompt)
 
             if promptTokens + maxOutput <= contextSize {
@@ -395,6 +459,46 @@ final class GenerationCoordinator {
 
     func enqueue(
         messages: [(role: String, content: String)],
+        systemPrompt: String? = nil,
+        temperature: Float = 0.7,
+        topP: Float = 0.9,
+        repeatPenalty: Float = 1.1,
+        maxOutputTokens: Int? = 2048,
+        maxThinkingTokens: Int? = nil,
+        jsonMode: Bool = false,
+        grammar: String? = nil,
+        tools: [ToolDefinition] = [],
+        toolChoice: ToolChoice = .auto,
+        maxToolIterations: Int = 10,
+        priority: GenerationPriority = .normal,
+        sessionID: UUID? = nil
+    ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
+        try enqueue(
+            structuredMessages: messages.map { StructuredMessage(role: $0.role, content: $0.content) },
+            systemPrompt: systemPrompt,
+            temperature: temperature,
+            topP: topP,
+            repeatPenalty: repeatPenalty,
+            maxOutputTokens: maxOutputTokens,
+            maxThinkingTokens: maxThinkingTokens,
+            jsonMode: jsonMode,
+            grammar: grammar,
+            tools: tools,
+            toolChoice: toolChoice,
+            maxToolIterations: maxToolIterations,
+            priority: priority,
+            sessionID: sessionID
+        )
+    }
+
+    /// Structured-message variant of ``enqueue(messages:...)``.
+    ///
+    /// Threads ``StructuredMessage`` (with thinking signatures and tool
+    /// parts intact) through the queue to the backend boundary. This is the
+    /// entry point used by ChatViewModel so prior-turn thinking blocks can
+    /// be replayed verbatim against APIs that require them (Anthropic).
+    func enqueue(
+        structuredMessages messages: [StructuredMessage],
         systemPrompt: String? = nil,
         temperature: Float = 0.7,
         topP: Float = 0.9,
@@ -670,7 +774,7 @@ final class GenerationCoordinator {
             }
 
             let stream = try self.generateWithConfig(
-                messages: currentMessages,
+                structuredMessages: currentMessages,
                 systemPrompt: request.systemPrompt,
                 config: request.config
             )
@@ -779,7 +883,7 @@ final class GenerationCoordinator {
             // Otherwise augment the tool-aware history with the tool-call +
             // tool-result pairs the model produced this turn, then loop.
             var nextHistory = toolAwareHistory ?? currentMessages.map {
-                ToolAwareHistoryEntry(role: $0.role, content: $0.content)
+                ToolAwareHistoryEntry(role: $0.role, content: $0.textContent)
             }
             nextHistory.append(
                 ToolAwareHistoryEntry(

--- a/Sources/BaseChatInference/Services/GenerationStreamConsumer.swift
+++ b/Sources/BaseChatInference/Services/GenerationStreamConsumer.swift
@@ -31,6 +31,9 @@ public struct GenerationStreamConsumer: Sendable {
         case .thinkingComplete:
             return .finalizeThinking
 
+        case .thinkingSignature(let signature):
+            return .recordThinkingSignature(signature)
+
         case .toolResult(let result):
             return .appendToolResult(result)
 
@@ -71,6 +74,12 @@ public struct GenerationStreamConsumer: Sendable {
         case appendThinkingText(String)
         /// Reasoning block complete — finalize and store the accumulated thinking content.
         case finalizeThinking
+        /// Provider attached an opaque signature to the in-flight thinking
+        /// block. Caller stashes it so the next ``finalizeThinking`` writes
+        /// a ``MessagePart/thinking(_:signature:)`` carrying the signature
+        /// verbatim, enabling multi-turn replay against APIs that require
+        /// it (Anthropic).
+        case recordThinkingSignature(String)
         /// Append a dispatched ``ToolResult`` to the current assistant message's parts.
         case appendToolResult(ToolResult)
         /// The orchestrator stopped the tool-dispatch loop because the

--- a/Sources/BaseChatInference/Services/InferenceService.swift
+++ b/Sources/BaseChatInference/Services/InferenceService.swift
@@ -191,6 +191,35 @@ public final class InferenceService {
         )
     }
 
+    /// Structured-message variant of ``generate(messages:...)``.
+    ///
+    /// Carries ``MessagePart`` content (including thinking blocks with
+    /// signatures) through to the backend boundary so cloud APIs that
+    /// require structured replay (Anthropic extended thinking) can
+    /// reconstruct prior turns without losing provider-supplied metadata.
+    public func generate(
+        structuredMessages messages: [StructuredMessage],
+        systemPrompt: String? = nil,
+        temperature: Float = 0.7,
+        topP: Float = 0.9,
+        repeatPenalty: Float = 1.1,
+        maxOutputTokens: Int? = 2048,
+        maxThinkingTokens: Int? = nil,
+        jsonMode: Bool = false
+    ) throws -> GenerationStream {
+        ensureProviderWired()
+        return try generation.generate(
+            structuredMessages: messages,
+            systemPrompt: systemPrompt,
+            temperature: temperature,
+            topP: topP,
+            repeatPenalty: repeatPenalty,
+            maxOutputTokens: maxOutputTokens,
+            maxThinkingTokens: maxThinkingTokens,
+            jsonMode: jsonMode
+        )
+    }
+
     // MARK: - Generation Queue
 
     /// Enqueues a generation request and returns a token + stream pair.
@@ -216,6 +245,46 @@ public final class InferenceService {
         ensureProviderWired()
         return try generation.enqueue(
             messages: messages,
+            systemPrompt: systemPrompt,
+            temperature: temperature,
+            topP: topP,
+            repeatPenalty: repeatPenalty,
+            maxOutputTokens: maxOutputTokens,
+            maxThinkingTokens: maxThinkingTokens,
+            jsonMode: jsonMode,
+            grammar: grammar,
+            tools: tools,
+            toolChoice: toolChoice,
+            maxToolIterations: maxToolIterations,
+            priority: priority,
+            sessionID: sessionID
+        )
+    }
+
+    /// Structured-message variant of ``enqueue(messages:...)``.
+    ///
+    /// Threads ``StructuredMessage`` through the queue so cloud backends
+    /// with structured wire formats (Anthropic) can replay prior assistant
+    /// turns including their thinking blocks and signatures verbatim.
+    public func enqueue(
+        structuredMessages messages: [StructuredMessage],
+        systemPrompt: String? = nil,
+        temperature: Float = 0.7,
+        topP: Float = 0.9,
+        repeatPenalty: Float = 1.1,
+        maxOutputTokens: Int? = 2048,
+        maxThinkingTokens: Int? = nil,
+        jsonMode: Bool = false,
+        grammar: String? = nil,
+        tools: [ToolDefinition] = [],
+        toolChoice: ToolChoice = .auto,
+        maxToolIterations: Int = 10,
+        priority: GenerationPriority = .normal,
+        sessionID: UUID? = nil
+    ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
+        ensureProviderWired()
+        return try generation.enqueue(
+            structuredMessages: messages,
             systemPrompt: systemPrompt,
             temperature: temperature,
             topP: topP,

--- a/Sources/BaseChatTestSupport/MockInferenceBackend.swift
+++ b/Sources/BaseChatTestSupport/MockInferenceBackend.swift
@@ -5,7 +5,7 @@ import BaseChatInference
 /// Configurable mock inference backend for testing.
 ///
 /// Shared across all test targets via the `BaseChatTestSupport` module.
-public final class MockInferenceBackend: InferenceBackend, ConversationHistoryReceiver, @unchecked Sendable {
+public final class MockInferenceBackend: InferenceBackend, ConversationHistoryReceiver, StructuredHistoryReceiver, @unchecked Sendable {
     public var isModelLoaded: Bool = false
     public var isGenerating: Bool = false
     public var capabilities: BackendCapabilities
@@ -13,6 +13,19 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
     // Configurable behavior
     public var tokensToYield: [String] = ["Hello", " world"]
     public var thinkingTokensToYield: [String] = []
+
+    /// Multi-block reasoning script. When non-empty this **takes precedence
+    /// over** ``thinkingTokensToYield``: each inner array is one reasoning
+    /// block, emitted as a sequence of `.thinkingToken` events followed by
+    /// a `.thinkingComplete`. Used by tests that exercise the multi-block
+    /// finalize path (#604: Anthropic emits one signature per block).
+    public var thinkingBlocksToYield: [[String]] = []
+
+    /// Optional signature to emit (via `.thinkingSignature`) immediately
+    /// after the thinking tokens of the block at index `i`. `nil` skips
+    /// emission for that block. Padded shorter than ``thinkingBlocksToYield``
+    /// is fine — missing entries are treated as `nil`.
+    public var signaturesPerThinkingBlock: [String?] = []
     public var shouldThrowOnGenerate: Error? = nil
     public var shouldThrowOnLoad: Error? = nil
 
@@ -128,13 +141,33 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
                 self.activeContinuation = nil
                 self.continuationLock.unlock()
             }
+            let multiBlocks = self.thinkingBlocksToYield
+            let signatures = self.signaturesPerThinkingBlock
             Task {
-                for t in thinkingTokens {
-                    if Task.isCancelled { break }
-                    continuation.yield(.thinkingToken(t))
-                }
-                if !thinkingTokens.isEmpty && !Task.isCancelled {
-                    continuation.yield(.thinkingComplete)
+                if !multiBlocks.isEmpty {
+                    // Multi-block reasoning script: each inner array is one
+                    // `<think>…</think>` round, separated by its own
+                    // `.thinkingComplete`. Lets tests assert the per-block
+                    // finalize → multi-`.thinking`-part contract.
+                    for (idx, block) in multiBlocks.enumerated() {
+                        for t in block {
+                            if Task.isCancelled { break }
+                            continuation.yield(.thinkingToken(t))
+                        }
+                        if Task.isCancelled { break }
+                        if idx < signatures.count, let sig = signatures[idx] {
+                            continuation.yield(.thinkingSignature(sig))
+                        }
+                        continuation.yield(.thinkingComplete)
+                    }
+                } else {
+                    for t in thinkingTokens {
+                        if Task.isCancelled { break }
+                        continuation.yield(.thinkingToken(t))
+                    }
+                    if !thinkingTokens.isEmpty && !Task.isCancelled {
+                        continuation.yield(.thinkingComplete)
+                    }
                 }
                 for token in tokens {
                     if Task.isCancelled { break }
@@ -187,5 +220,14 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
 
     public func setConversationHistory(_ messages: [(role: String, content: String)]) {
         lastReceivedHistory = messages
+    }
+
+    /// Last structured history the coordinator handed to this backend.
+    /// Tests assert on this to verify the structured threading path
+    /// preserves thinking signatures end-to-end (#482, #604).
+    public var lastReceivedStructuredHistory: [StructuredMessage]?
+
+    public func setStructuredHistory(_ messages: [StructuredMessage]) {
+        lastReceivedStructuredHistory = messages
     }
 }

--- a/Sources/BaseChatTools/ScenarioRunner.swift
+++ b/Sources/BaseChatTools/ScenarioRunner.swift
@@ -84,7 +84,7 @@ public final class ScenarioRunner {
                 case .toolCall(let call):
                     turnToolCalls.append(call)
                     logger?.append(.toolCall(scenarioId: scenario.id, name: call.toolName, arguments: call.arguments))
-                case .usage, .thinkingToken, .thinkingComplete:
+                case .usage, .thinkingToken, .thinkingComplete, .thinkingSignature:
                     continue
                 case .toolResult, .toolLoopLimitReached:
                     // ScenarioRunner calls backend.generate() directly and owns

--- a/Sources/BaseChatUI/ViewModels/GenerationCoordinator.swift
+++ b/Sources/BaseChatUI/ViewModels/GenerationCoordinator.swift
@@ -249,8 +249,12 @@ final class GenerationCoordinator {
                 responseBuffer: responseBuffer,
                 tokenizer: cachingTokenizer
             )
-            let history: [(role: String, content: String)] = trimmed.map {
-                (role: $0.role.rawValue, content: $0.content)
+            // Build structured history that carries thinking signatures
+            // through to backends with structured wire formats (Anthropic).
+            // Text-only backends collapse this back to (role, content) at
+            // their own boundary via ``StructuredMessage/textContent``.
+            let history: [StructuredMessage] = trimmed.map {
+                StructuredMessage(role: $0.role.rawValue, parts: $0.contentParts)
             }
 
             // Surface the registered tool definitions so the model can call
@@ -260,7 +264,7 @@ final class GenerationCoordinator {
             let registeredTools = inferenceService.toolRegistry?.definitions ?? []
 
             let (token, stream) = try inferenceService.enqueue(
-                messages: history,
+                structuredMessages: history,
                 systemPrompt: effectiveSystemPrompt,
                 temperature: temperature(),
                 topP: topP(),
@@ -297,6 +301,13 @@ final class GenerationCoordinator {
                 // a subsequent <think>…</think> block in the same response starts
                 // a fresh accumulator.
                 var thinkingDisplayed = ""
+                // Most recent provider-supplied signature for the in-flight
+                // reasoning block. Set by ``recordThinkingSignature`` actions
+                // (Anthropic emits via `signature_delta`); consumed by the
+                // next ``finalizeThinking`` so the persisted
+                // ``MessagePart/thinking`` carries the signature for
+                // multi-turn replay.
+                var pendingThinkingSignature: String?
 
                 do {
                     eventLoop: for try await event in stream.events {
@@ -348,16 +359,15 @@ final class GenerationCoordinator {
                             if isFirstThinkingFragment {
                                 // Insert a placeholder `.thinking("")` part immediately so the
                                 // UI can render the "Thinking…" label during the reasoning phase
-                                // rather than staying on the generic typing placeholder. Mark
-                                // the message's thinking as actively streaming so the disclosure
-                                // group renders an inline preview rather than the "Thinking…"
-                                // static label.
+                                // rather than staying on the generic typing placeholder. The
+                                // placeholder is the *most recent* thinking-shaped part —
+                                // partial flushes and the next finalize target it via
+                                // `lastIndex(where:)` so multiple thinking blocks within one
+                                // response stay separate. (#604: signatures are per-block.)
                                 self.onMarkThinkingStreaming(messageID, true)
                                 self.onMutateMessage(messageID) { msg in
-                                    if msg.contentParts.firstIndex(where: { $0.thinkingContent != nil }) == nil {
-                                        let insertAt = msg.contentParts.firstIndex(where: { $0.textContent != nil }) ?? 0
-                                        msg.contentParts.insert(.thinking(""), at: insertAt)
-                                    }
+                                    let insertAt = msg.contentParts.firstIndex(where: { $0.textContent != nil }) ?? msg.contentParts.endIndex
+                                    msg.contentParts.insert(.thinking(""), at: insertAt)
                                 }
                             }
                             // Flush partial reasoning text into the thinking part on the
@@ -371,6 +381,15 @@ final class GenerationCoordinator {
                                 }
                             }
 
+                        case .recordThinkingSignature(let signature):
+                            // Stash the provider-supplied signature; the next
+                            // `.finalizeThinking` writes it onto the in-flight
+                            // thinking part. Anthropic emits this between
+                            // `content_block_start` and the first `thinking_delta`,
+                            // so the placeholder may not exist yet — that's fine,
+                            // we apply at finalize time regardless of order.
+                            pendingThinkingSignature = signature
+
                         case .finalizeThinking:
                             // Drain any buffered partial fragments first so we don't
                             // miss display content on tight streams that finish before
@@ -379,29 +398,32 @@ final class GenerationCoordinator {
                                 thinkingDisplayed += batch
                             }
                             let block = thinkingAccumulator
+                            let signature = pendingThinkingSignature
                             thinkingAccumulator = ""
                             thinkingDisplayed = ""
+                            pendingThinkingSignature = nil
                             self.onMarkThinkingStreaming(messageID, false)
                             guard !block.isEmpty else { break }
                             self.onMutateMessage(messageID) { msg in
-                                // Append to any existing thinking part so multiple <think>…</think>
-                                // blocks within one response are concatenated into a single part.
-                                if let idx = msg.contentParts.firstIndex(where: { $0.thinkingContent != nil }) {
-                                    let existing = msg.contentParts[idx].thinkingContent ?? ""
-                                    // The partial-streaming branch may have already written
-                                    // `block` (or a prefix of it) into `existing`. Replace the
-                                    // contents wholesale with the authoritative final text
-                                    // rather than concatenating it onto an in-flight prefix.
-                                    if existing == block || existing.isEmpty {
-                                        msg.contentParts[idx] = .thinking(block)
-                                    } else if block.hasPrefix(existing) {
-                                        msg.contentParts[idx] = .thinking(block)
-                                    } else {
-                                        msg.contentParts[idx] = .thinking(existing + "\n\n" + block)
-                                    }
+                                // Each finalize creates a fresh part rather than
+                                // merging with prior thinking parts. This preserves
+                                // per-block signatures (Anthropic issues one per
+                                // `content_block_start{type:"thinking"}`) and keeps
+                                // multiple reasoning rounds within one response
+                                // visually distinct in MessagePartsView.
+                                //
+                                // The placeholder for the *current* block is the
+                                // last `.thinking` part in the array — partial
+                                // flushes have been writing into it. Convert that
+                                // placeholder to the final text + signature; if no
+                                // placeholder exists (e.g. signature arrived after
+                                // a synthetic finalize), insert one ahead of text.
+                                if let idx = msg.contentParts.lastIndex(where: { $0.thinkingContent != nil }),
+                                   msg.contentParts[idx].thinkingSignature == nil {
+                                    msg.contentParts[idx] = .thinking(block, signature: signature)
                                 } else {
-                                    let insertAt = msg.contentParts.firstIndex(where: { $0.textContent != nil }) ?? 0
-                                    msg.contentParts.insert(.thinking(block), at: insertAt)
+                                    let insertAt = msg.contentParts.firstIndex(where: { $0.textContent != nil }) ?? msg.contentParts.endIndex
+                                    msg.contentParts.insert(.thinking(block, signature: signature), at: insertAt)
                                 }
                             }
 
@@ -441,23 +463,23 @@ final class GenerationCoordinator {
                 }
 
                 // Finalize an unclosed thinking block — a model may emit <think>…
-                // without a closing tag if generation is cut short.
+                // without a closing tag if generation is cut short. Targets
+                // the *last* in-flight thinking part so previously finalized
+                // blocks (including their signatures) survive untouched.
                 if !thinkingAccumulator.isEmpty {
                     _ = thinkingBatcher.flush(now: ContinuousClock.now)
                     let block = thinkingAccumulator
+                    let signature = pendingThinkingSignature
                     thinkingAccumulator = ""
                     thinkingDisplayed = ""
+                    pendingThinkingSignature = nil
                     self.onMutateMessage(messageID) { msg in
-                        if let idx = msg.contentParts.firstIndex(where: { $0.thinkingContent != nil }) {
-                            let existing = msg.contentParts[idx].thinkingContent ?? ""
-                            if existing == block || existing.isEmpty || block.hasPrefix(existing) {
-                                msg.contentParts[idx] = .thinking(block)
-                            } else {
-                                msg.contentParts[idx] = .thinking(existing + "\n\n" + block)
-                            }
+                        if let idx = msg.contentParts.lastIndex(where: { $0.thinkingContent != nil }),
+                           msg.contentParts[idx].thinkingSignature == nil {
+                            msg.contentParts[idx] = .thinking(block, signature: signature)
                         } else {
-                            let insertAt = msg.contentParts.firstIndex(where: { $0.textContent != nil }) ?? 0
-                            msg.contentParts.insert(.thinking(block), at: insertAt)
+                            let insertAt = msg.contentParts.firstIndex(where: { $0.textContent != nil }) ?? msg.contentParts.endIndex
+                            msg.contentParts.insert(.thinking(block, signature: signature), at: insertAt)
                         }
                     }
                 }
@@ -573,7 +595,10 @@ final class GenerationCoordinator {
     /// fragment) so each flush mutates the same part rather than appending new
     /// ones — keeping the message structure stable across rerenders.
     static func writeThinkingPartialText(_ partial: String, into msg: inout ChatMessageRecord) {
-        guard let idx = msg.contentParts.firstIndex(where: { $0.thinkingContent != nil }) else {
+        // Target the most recent thinking part — that's the in-flight
+        // placeholder for the current reasoning block. Earlier blocks were
+        // already finalized and must not be mutated.
+        guard let idx = msg.contentParts.lastIndex(where: { $0.thinkingContent != nil }) else {
             // The placeholder should always exist by the time partial flushes
             // run, but if it doesn't (e.g. tests that drive this helper
             // directly), insert one ahead of any visible text.
@@ -581,7 +606,11 @@ final class GenerationCoordinator {
             msg.contentParts.insert(.thinking(partial), at: insertAt)
             return
         }
-        msg.contentParts[idx] = .thinking(partial)
+        // Preserve any signature already attached to this part — partial
+        // flushes only update the text. Signatures arrive separately and
+        // are written by the finalize path.
+        let signature = msg.contentParts[idx].thinkingSignature
+        msg.contentParts[idx] = .thinking(partial, signature: signature)
     }
 
     /// Substitutes `{{key}}` tokens in `text` with values from `context`.

--- a/Sources/BaseChatUI/Views/Chat/MessagePartsView.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessagePartsView.swift
@@ -63,7 +63,7 @@ struct MessagePartsView: View {
         case .image(let data, _):
             imageView(data)
 
-        case .thinking(let text):
+        case .thinking(let text, _):
             // While reasoning is in progress (`isThinkingStreaming`), the part's
             // text holds whatever has been flushed so far by the streaming
             // batcher and is rendered inline as a live preview. Once

--- a/Tests/BaseChatBackendsTests/ClaudeStructuredReplayTests.swift
+++ b/Tests/BaseChatBackendsTests/ClaudeStructuredReplayTests.swift
@@ -1,0 +1,248 @@
+#if CloudSaaS
+import XCTest
+import BaseChatInference
+import BaseChatTestSupport
+@testable import BaseChatBackends
+
+/// Tests for #604: structured multi-turn replay against the Anthropic
+/// Messages API. ``ClaudeBackend`` must:
+///
+/// 1. Read the structured history when one is supplied
+///    (``StructuredHistoryReceiver``), prefer it over the flattened
+///    `(role, content)` form.
+/// 2. Serialize prior assistant turns as a `content[]` array with thinking
+///    blocks **before** text blocks, signature carried verbatim.
+/// 3. Drop signature-less thinking blocks from the replay payload (sending
+///    a blank signature would 400 the request).
+final class ClaudeStructuredReplayTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeBackend() async throws -> (ClaudeBackend, URL) {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let backend = ClaudeBackend(urlSession: session)
+        let url = URL(string: "https://claude-structured-\(UUID().uuidString).test")!
+        backend.configure(baseURL: url, apiKey: "sk-ant-test", modelName: "claude-sonnet-4-5")
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+        return (backend, url)
+    }
+
+    private func extractRequestJSON(host: String?) throws -> [String: Any] {
+        let captured = MockURLProtocol.capturedRequests.last(where: { $0.url?.host == host })
+        let body: Data
+        if let direct = captured?.httpBody {
+            body = direct
+        } else if let stream = captured?.httpBodyStream {
+            var data = Data()
+            stream.open()
+            let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 4096)
+            defer { buffer.deallocate() }
+            while stream.hasBytesAvailable {
+                let read = stream.read(buffer, maxLength: 4096)
+                if read > 0 { data.append(buffer, count: read) }
+            }
+            stream.close()
+            body = data
+        } else {
+            throw NSError(domain: "test", code: 0, userInfo: [NSLocalizedDescriptionKey: "no body"])
+        }
+        return try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+    }
+
+    private func sseStub(url: URL) {
+        let chunk = Data("""
+            data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"ok"}}\n\ndata: {"type":"message_stop"}\n\n
+            """.utf8)
+        MockURLProtocol.stub(url: url, response: .sse(chunks: [chunk], statusCode: 200))
+    }
+
+    // MARK: - 1. Structured history with thinking + signature
+
+    /// Multi-turn conversation where the prior assistant turn has a
+    /// thinking block with a signature plus visible text. The request body
+    /// must serialize that turn as a structured `content[]` with thinking
+    /// **before** text and the signature preserved verbatim.
+    func test_buildRequest_priorAssistantTurnWithThinking_emitsStructuredContent() async throws {
+        let (backend, url) = try await makeBackend()
+        sseStub(url: url)
+        defer { MockURLProtocol.unstub(url: url) }
+
+        let signature = "sig_abc123_xyz_load_bearing"
+        backend.setStructuredHistory([
+            StructuredMessage(role: "user", content: "What is 2+2?"),
+            StructuredMessage(role: "assistant", parts: [
+                .thinking("The user is asking simple arithmetic.", signature: signature),
+                .text("The answer is 4."),
+            ]),
+            StructuredMessage(role: "user", content: "Now what is 5+5?"),
+        ])
+
+        let stream = try backend.generate(prompt: "Now what is 5+5?", systemPrompt: nil, config: GenerationConfig())
+        for try await _ in stream.events { }
+
+        let json = try extractRequestJSON(host: url.host)
+        let messages = try XCTUnwrap(json["messages"] as? [[String: Any]])
+        XCTAssertEqual(messages.count, 3, "All three turns must be replayed")
+
+        // Assistant turn: structured content array, thinking first, text second.
+        let assistantContent = try XCTUnwrap(messages[1]["content"] as? [[String: Any]],
+            "Assistant turn with a thinking block must serialize as a structured `content[]` array, not a string")
+        XCTAssertEqual(assistantContent.count, 2,
+            "Expect exactly two blocks: thinking + text (no extra wrapping)")
+
+        XCTAssertEqual(assistantContent[0]["type"] as? String, "thinking",
+            "Thinking block must come first — Anthropic rejects text-then-thinking ordering")
+        XCTAssertEqual(assistantContent[0]["thinking"] as? String, "The user is asking simple arithmetic.")
+        XCTAssertEqual(assistantContent[0]["signature"] as? String, signature,
+            "Signature must round-trip verbatim — Anthropic rejects mismatched signatures with HTTP 400")
+
+        XCTAssertEqual(assistantContent[1]["type"] as? String, "text")
+        XCTAssertEqual(assistantContent[1]["text"] as? String, "The answer is 4.")
+
+        // Sabotage check: if `encodeMessageContent` flattened the assistant
+        // turn back to a string, `messages[1]["content"]` would decode as
+        // `String` and the `[[String: Any]]` cast above would fail.
+    }
+
+    // MARK: - 2. User turn flattens to string content
+
+    func test_buildRequest_userTurn_flattensToStringContent() async throws {
+        let (backend, url) = try await makeBackend()
+        sseStub(url: url)
+        defer { MockURLProtocol.unstub(url: url) }
+
+        backend.setStructuredHistory([
+            StructuredMessage(role: "user", content: "Hello"),
+        ])
+        let stream = try backend.generate(prompt: "Hello", systemPrompt: nil, config: GenerationConfig())
+        for try await _ in stream.events { }
+
+        let json = try extractRequestJSON(host: url.host)
+        let messages = try XCTUnwrap(json["messages"] as? [[String: Any]])
+        XCTAssertEqual(messages[0]["content"] as? String, "Hello",
+            "User turns flatten to a plain string body — only assistant turns need the structured array form")
+    }
+
+    // MARK: - 3. Signature-less thinking is dropped
+
+    /// A `.thinking` part without a signature can't be replayed verbatim
+    /// (Anthropic checks the signature server-side). Rather than send a
+    /// blank signature and 400 the request, the encoder drops the block.
+    /// This is the path for cross-backend persistence: a thinking part
+    /// captured from MLX or Llama (which don't issue signatures) round-trips
+    /// the conversation without breaking the next Claude turn.
+    func test_buildRequest_priorAssistantTurnWithUnsignedThinking_dropsThinkingBlock() async throws {
+        let (backend, url) = try await makeBackend()
+        sseStub(url: url)
+        defer { MockURLProtocol.unstub(url: url) }
+
+        backend.setStructuredHistory([
+            StructuredMessage(role: "user", content: "Q1"),
+            StructuredMessage(role: "assistant", parts: [
+                .thinking("local-only reasoning, no signature", signature: nil),
+                .text("Visible answer."),
+            ]),
+            StructuredMessage(role: "user", content: "Q2"),
+        ])
+
+        let stream = try backend.generate(prompt: "Q2", systemPrompt: nil, config: GenerationConfig())
+        for try await _ in stream.events { }
+
+        let json = try extractRequestJSON(host: url.host)
+        let messages = try XCTUnwrap(json["messages"] as? [[String: Any]])
+        let assistantContent = try XCTUnwrap(messages[1]["content"] as? [[String: Any]])
+        XCTAssertEqual(assistantContent.count, 1,
+            "Unsigned thinking blocks are dropped from the replay payload — only text remains")
+        XCTAssertEqual(assistantContent[0]["type"] as? String, "text")
+        XCTAssertEqual(assistantContent[0]["text"] as? String, "Visible answer.")
+    }
+
+    // MARK: - 4. Structured history takes precedence over flattened history
+
+    func test_buildRequest_prefersStructuredHistory_overConversationHistory() async throws {
+        let (backend, url) = try await makeBackend()
+        sseStub(url: url)
+        defer { MockURLProtocol.unstub(url: url) }
+
+        // Set both — coordinator sets the flattened form too, but the
+        // structured form must win when present.
+        backend.setConversationHistory([
+            (role: "user", content: "OLD"),
+            (role: "assistant", content: "OLD-ANSWER"),
+        ])
+        backend.setStructuredHistory([
+            StructuredMessage(role: "user", content: "NEW"),
+            StructuredMessage(role: "assistant", content: "NEW-ANSWER"),
+        ])
+
+        let stream = try backend.generate(prompt: "ignored", systemPrompt: nil, config: GenerationConfig())
+        for try await _ in stream.events { }
+
+        let json = try extractRequestJSON(host: url.host)
+        let messages = try XCTUnwrap(json["messages"] as? [[String: Any]])
+        XCTAssertEqual(messages[0]["content"] as? String, "NEW",
+            "Structured history must override the legacy conversationHistory when both are set")
+    }
+
+    // MARK: - 5. Signature parsed from signature_delta SSE
+
+    func test_parseSignatureDelta_extractsSignatureFromDelta() {
+        let payload = #"{"type":"content_block_delta","delta":{"type":"signature_delta","signature":"sig_xyz"}}"#
+        XCTAssertEqual(ClaudeBackend.parseSignatureDelta(from: payload), "sig_xyz")
+
+        // Sabotage check: removing the type==signature_delta guard would
+        // make this return non-nil for thinking_delta payloads.
+        let thinkingPayload = #"{"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"...","signature":"oops"}}"#
+        XCTAssertNil(ClaudeBackend.parseSignatureDelta(from: thinkingPayload),
+            "thinking_delta is not a signature_delta — must not match")
+    }
+
+    func test_parseThinkingBlockStartSignature_extractsFromStart() {
+        let payload = #"{"type":"content_block_start","content_block":{"type":"thinking","signature":"sig_start"}}"#
+        XCTAssertEqual(ClaudeBackend.parseThinkingBlockStartSignature(from: payload), "sig_start")
+
+        let textStart = #"{"type":"content_block_start","content_block":{"type":"text"}}"#
+        XCTAssertNil(ClaudeBackend.parseThinkingBlockStartSignature(from: textStart))
+    }
+
+    // MARK: - 6. End-to-end: signature flows from SSE → emit ordering
+
+    /// A thinking block's `signature_delta` event must surface as a
+    /// ``GenerationEvent/thinkingSignature`` event in the parsed stream,
+    /// emitted before the matching ``thinkingComplete``.
+    func test_streamParse_emitsThinkingSignatureEvent() async throws {
+        let (backend, url) = try await makeBackend()
+        let chunks: [Data] = [
+            Data(#"data: {"type":"content_block_start","content_block":{"type":"thinking"}}"#.utf8) + Data("\n\n".utf8),
+            Data(#"data: {"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"reasoning"}}"#.utf8) + Data("\n\n".utf8),
+            Data(#"data: {"type":"content_block_delta","delta":{"type":"signature_delta","signature":"abc"}}"#.utf8) + Data("\n\n".utf8),
+            Data(#"data: {"type":"content_block_stop"}"#.utf8) + Data("\n\n".utf8),
+            Data(#"data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"answer"}}"#.utf8) + Data("\n\n".utf8),
+            Data(#"data: {"type":"message_stop"}"#.utf8) + Data("\n\n".utf8),
+        ]
+        MockURLProtocol.stub(url: url, response: .sse(chunks: chunks, statusCode: 200))
+        defer { MockURLProtocol.unstub(url: url) }
+
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: GenerationConfig())
+        var observed: [String] = []
+        for try await event in stream.events {
+            switch event {
+            case .thinkingToken(let t): observed.append("thinkingToken:\(t)")
+            case .thinkingSignature(let s): observed.append("signature:\(s)")
+            case .thinkingComplete: observed.append("thinkingComplete")
+            case .token(let t): observed.append("token:\(t)")
+            default: break
+            }
+        }
+        XCTAssertTrue(observed.contains("signature:abc"),
+            "Stream must surface signature_delta as `.thinkingSignature` so the UI can attach it to the persisted thinking part. Observed: \(observed)")
+        // Order check: the signature must arrive before thinkingComplete.
+        let sigIdx = observed.firstIndex(of: "signature:abc") ?? -1
+        let completeIdx = observed.firstIndex(of: "thinkingComplete") ?? -2
+        XCTAssertLessThan(sigIdx, completeIdx,
+            "Signature must precede thinkingComplete so the consumer has it before applying the finalize")
+    }
+}
+#endif

--- a/Tests/BaseChatBackendsTests/CloudThinkingTokenTests.swift
+++ b/Tests/BaseChatBackendsTests/CloudThinkingTokenTests.swift
@@ -43,6 +43,7 @@ private func categorise(_ event: GenerationEvent) -> EventCategory? {
     case .toolLoopLimitReached: return nil
     case .kvCacheReuse: return nil
     case .diagnosticThrottle: return nil
+    case .thinkingSignature: return nil
     }
 }
 

--- a/Tests/BaseChatBackendsTests/OllamaToolCallLiveReplayTests.swift
+++ b/Tests/BaseChatBackendsTests/OllamaToolCallLiveReplayTests.swift
@@ -172,7 +172,7 @@ final class OllamaToolCallLiveReplayTests: XCTestCase {
                     projected.append(ExpectedEvent(event: "toolCall", text: nil, tool_name: call.toolName, arguments_contains: nil, prompt: nil, completion: nil))
                 case .usage(let p, let c):
                     projected.append(ExpectedEvent(event: "usage", text: nil, tool_name: nil, arguments_contains: nil, prompt: p, completion: c))
-                case .thinkingToken, .thinkingComplete:
+                case .thinkingToken, .thinkingComplete, .thinkingSignature:
                     // Not exercised by tool-call fixtures; ignore for
                     // forward-compat with future thinking-in-tool-call
                     // captures.

--- a/Tests/BaseChatCoreTests/MessagePartThinkingSignatureTests.swift
+++ b/Tests/BaseChatCoreTests/MessagePartThinkingSignatureTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+import BaseChatInference
+
+/// Tests for #482 / #604: ``MessagePart/thinking(_:signature:)`` Codable
+/// round-trip with the new optional signature payload, multi-block
+/// ``ChatMessageRecord`` round-trip, and backward compatibility with the
+/// pre-#604 bare-string wire format.
+final class MessagePartThinkingSignatureTests: XCTestCase {
+
+    // MARK: - 1. Codable round-trip with signature
+
+    func test_thinking_withSignature_roundtripsViaJSON() throws {
+        let part: MessagePart = .thinking("reasoning text", signature: "sig_abc123")
+
+        let data = try JSONEncoder().encode([part])
+        let decoded = try JSONDecoder().decode([MessagePart].self, from: data)
+
+        XCTAssertEqual(decoded, [part],
+            ".thinking with a signature must survive JSON round-trip with the signature preserved verbatim")
+        XCTAssertEqual(decoded.first?.thinkingContent, "reasoning text")
+        XCTAssertEqual(decoded.first?.thinkingSignature, "sig_abc123")
+
+        // Sabotage check: encoding the signature into a typo'd field name
+        // (e.g. `sig` instead of `signature`) would round-trip to
+        // signature == nil and this assertion would fail.
+    }
+
+    func test_thinking_withoutSignature_roundtripsViaJSON() throws {
+        // Signature-less thinking is the common path for non-Anthropic
+        // backends (MLX inline `<think>`, OpenAI `reasoning_content`,
+        // Llama `<think>` tags). The encoder must omit `signature` from the
+        // payload rather than emit `"signature": null` so persisted JSON
+        // stays compact.
+        let part: MessagePart = .thinking("local reasoning", signature: nil)
+
+        let data = try JSONEncoder().encode([part])
+        let decoded = try JSONDecoder().decode([MessagePart].self, from: data)
+
+        XCTAssertEqual(decoded, [part])
+        XCTAssertEqual(decoded.first?.thinkingContent, "local reasoning")
+        XCTAssertNil(decoded.first?.thinkingSignature)
+    }
+
+    // MARK: - 2. Wire format pin — signature lives inside the thinking object
+
+    func test_thinking_wireFormat_signatureNestedUnderThinking() throws {
+        let part: MessagePart = .thinking("text", signature: "sig_xyz")
+        let data = try JSONEncoder().encode([part])
+        let json = try XCTUnwrap(String(data: data, encoding: .utf8))
+
+        // Pin the wire shape: `{"thinking": {"text": "...", "signature": "..."}}`.
+        // The key `signature` must appear nested under the `thinking`
+        // discriminator, not at the array element top level. A silent
+        // refactor that hoisted the signature out of the nested object
+        // would strand every persisted row.
+        XCTAssertTrue(json.contains(#""signature":"sig_xyz""#),
+            "Signature must be present in the wire payload. Saw: \(json)")
+        XCTAssertTrue(json.contains(#""text":"text""#),
+            "Thinking text must be encoded under the `text` key. Saw: \(json)")
+    }
+
+    // MARK: - 3. Legacy bare-string format still decodes
+
+    /// Pre-#604 persisted rows used the bare-string form
+    /// `{"thinking": "text"}`. Existing stores must continue to decode
+    /// without migration when the new optional signature lands.
+    func test_thinking_legacyBareStringForm_decodesAsThinkingWithNilSignature() throws {
+        let legacyJSON = #"[{"thinking":"old reasoning"}]"#
+        let data = Data(legacyJSON.utf8)
+
+        let decoded = try JSONDecoder().decode([MessagePart].self, from: data)
+
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded[0].thinkingContent, "old reasoning",
+            "Legacy bare-string `.thinking` rows must decode to the same text content")
+        XCTAssertNil(decoded[0].thinkingSignature,
+            "Legacy rows have no signature — must decode as nil rather than empty string or skipping")
+
+        // Sabotage check: removing the `DecodingError.typeMismatch` fallback
+        // in `MessagePart.init(from:)` would cause this decode to throw,
+        // stranding every pre-#604 thinking row.
+    }
+
+    // MARK: - 4. ChatMessageRecord with multiple thinking parts
+
+    func test_chatMessageRecord_multipleThinkingParts_encodeDecode() throws {
+        // Two distinct reasoning rounds within one assistant turn —
+        // backends that emit multiple `content_block_start{type:"thinking"}`
+        // events produce this shape. Each must keep its own signature.
+        let parts: [MessagePart] = [
+            .thinking("first round of thought", signature: "sig_1"),
+            .thinking("second round, different signature", signature: "sig_2"),
+            .text("Final visible answer."),
+        ]
+        let record = ChatMessageRecord(role: .assistant, contentParts: parts, sessionID: UUID())
+
+        // Round-trip via JSON to mirror what BaseChatSchemaV3.ChatMessage does.
+        let data = try JSONEncoder().encode(record.contentParts)
+        let decoded = try JSONDecoder().decode([MessagePart].self, from: data)
+
+        XCTAssertEqual(decoded.count, 3,
+            "Multiple thinking parts must encode and decode independently — no merging")
+        XCTAssertEqual(decoded[0].thinkingSignature, "sig_1")
+        XCTAssertEqual(decoded[1].thinkingSignature, "sig_2",
+            "Each thinking part keeps its own signature; signatures must not be coalesced or replaced")
+        XCTAssertEqual(decoded[2].textContent, "Final visible answer.")
+    }
+
+    // MARK: - 5. textContent excludes thinking even with signature
+
+    func test_textContent_returnsNil_forThinkingWithSignature() {
+        let part: MessagePart = .thinking("internal reasoning", signature: "sig")
+        XCTAssertNil(part.textContent,
+            ".textContent must remain nil regardless of whether a signature is attached")
+    }
+
+    // MARK: - 6. Equality respects the signature
+
+    func test_equality_signatureMismatch_partsAreUnequal() {
+        let a: MessagePart = .thinking("x", signature: "sig_1")
+        let b: MessagePart = .thinking("x", signature: "sig_2")
+        XCTAssertNotEqual(a, b,
+            "Two thinking parts with the same text but different signatures must compare unequal — " +
+            "Anthropic rejects mismatched signatures, so equality must be signature-aware")
+
+        let c: MessagePart = .thinking("x", signature: nil)
+        let d: MessagePart = .thinking("x", signature: "sig_1")
+        XCTAssertNotEqual(c, d, "nil vs non-nil signature is a real difference")
+    }
+}

--- a/Tests/BaseChatInferenceTests/GenerationCoordinatorStructuredHistoryTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationCoordinatorStructuredHistoryTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Tests for #482: ``GenerationCoordinator`` must thread
+/// ``StructuredMessage`` (carrying ``MessagePart`` content including
+/// thinking signatures) through to the backend boundary instead of
+/// flattening to `(role, content)` strings.
+@MainActor
+final class GenerationCoordinatorStructuredHistoryTests: XCTestCase {
+
+    private var provider: FakeGenerationContextProvider!
+    private var coordinator: GenerationCoordinator!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        provider = FakeGenerationContextProvider()
+        coordinator = GenerationCoordinator()
+        coordinator.provider = provider
+    }
+
+    override func tearDown() async throws {
+        await coordinator?.stopGenerationAndWait()
+        coordinator = nil
+        provider = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - 1. Structured messages reach the backend's StructuredHistoryReceiver
+
+    func test_generate_structuredMessages_reachStructuredReceiver() async throws {
+        let signature = "sig_load_bearing"
+        let history: [StructuredMessage] = [
+            StructuredMessage(role: "user", content: "Q1"),
+            StructuredMessage(role: "assistant", parts: [
+                .thinking("internal reasoning", signature: signature),
+                .text("answer"),
+            ]),
+            StructuredMessage(role: "user", content: "Q2"),
+        ]
+
+        let stream = try coordinator.generate(structuredMessages: history)
+        for try await _ in stream.events {}
+
+        let observed = try XCTUnwrap(provider.backend.lastReceivedStructuredHistory,
+            "Coordinator must invoke setStructuredHistory(...) on backends conforming to StructuredHistoryReceiver")
+        XCTAssertEqual(observed.count, 3)
+        XCTAssertEqual(observed[1].parts.count, 2)
+        XCTAssertEqual(observed[1].parts[0].thinkingContent, "internal reasoning")
+        XCTAssertEqual(observed[1].parts[0].thinkingSignature, signature,
+            "Signature must survive the trip from caller through coordinator to backend without being stripped")
+
+        // Sabotage check: removing `installHistory(...)`'s
+        // StructuredHistoryReceiver branch leaves
+        // lastReceivedStructuredHistory == nil and the XCTUnwrap above
+        // fails, surfacing a clear regression message.
+    }
+
+    // MARK: - 2. (role, content) entry still flattens to ConversationHistoryReceiver
+
+    func test_generate_legacyTupleEntry_setsBothFlattenedAndStructured() async throws {
+        let stream = try coordinator.generate(messages: [
+            ("user", "hello"),
+            ("assistant", "hi"),
+            ("user", "how are you?"),
+        ])
+        for try await _ in stream.events {}
+
+        // The legacy entry wraps each (role, content) into a single-text
+        // StructuredMessage and threads through the same pipeline. Both
+        // receiver protocols see the data so backends can pick whichever
+        // shape they prefer.
+        let structured = try XCTUnwrap(provider.backend.lastReceivedStructuredHistory)
+        XCTAssertEqual(structured.count, 3)
+        XCTAssertEqual(structured[0].textContent, "hello")
+
+        let flattened = try XCTUnwrap(provider.backend.lastReceivedHistory)
+        XCTAssertEqual(flattened.count, 3)
+        XCTAssertEqual(flattened[0].role, "user")
+        XCTAssertEqual(flattened[0].content, "hello")
+    }
+
+    // MARK: - 3. Flattened history drops thinking content
+
+    /// Backends that only conform to ``ConversationHistoryReceiver`` (every
+    /// non-Anthropic cloud / local backend today) get the flattened form.
+    /// Thinking parts must be excluded from that flattening so prompt text
+    /// doesn't leak provider-internal reasoning into requests that don't
+    /// support replayed thinking.
+    func test_flatten_dropsThinking_keepsTextOnly() async throws {
+        let history: [StructuredMessage] = [
+            StructuredMessage(role: "assistant", parts: [
+                .thinking("hidden reasoning", signature: "sig"),
+                .text("visible part"),
+            ]),
+        ]
+
+        let stream = try coordinator.generate(structuredMessages: history)
+        for try await _ in stream.events {}
+
+        let flattened = try XCTUnwrap(provider.backend.lastReceivedHistory)
+        XCTAssertEqual(flattened[0].content, "visible part",
+            "Flattened history must contain only the visible text content — thinking is dropped")
+        XCTAssertFalse(flattened[0].content.contains("hidden reasoning"),
+            "Thinking content must never appear in the flattened (role, content) form")
+    }
+
+    // MARK: - 4. enqueue threads structured form through the queue
+
+    func test_enqueue_structuredMessages_propagateToBackend() async throws {
+        let history: [StructuredMessage] = [
+            StructuredMessage(role: "user", parts: [.text("hello")]),
+            StructuredMessage(role: "assistant", parts: [
+                .thinking("think", signature: "sig_q"),
+                .text("hi"),
+            ]),
+            StructuredMessage(role: "user", parts: [.text("again")]),
+        ]
+        let (_, stream) = try coordinator.enqueue(structuredMessages: history)
+        for try await _ in stream.events {}
+
+        let observed = try XCTUnwrap(provider.backend.lastReceivedStructuredHistory)
+        XCTAssertEqual(observed.count, 3)
+        XCTAssertEqual(observed[1].parts.first?.thinkingSignature, "sig_q",
+            "Signatures must round-trip through the queue → tool-dispatch loop → backend without loss")
+    }
+}

--- a/Tests/BaseChatInferenceTests/ToolCallContractTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolCallContractTests.swift
@@ -203,7 +203,7 @@ final class ToolCallContractTests: XCTestCase {
             case .token(let text): tokens.append(text)
             case .toolCall(let call): toolCalls.append(call)
             case .usage: break
-            case .thinkingToken, .thinkingComplete: break
+            case .thinkingToken, .thinkingComplete, .thinkingSignature: break
             case .toolResult, .toolLoopLimitReached: break
             case .kvCacheReuse: break
             case .diagnosticThrottle: break
@@ -273,7 +273,7 @@ final class ToolCallContractTests: XCTestCase {
             case .token(let t): tokens.append(t)
             case .toolCall(let c): toolCalls.append(c)
             case .usage: break
-            case .thinkingToken, .thinkingComplete: break
+            case .thinkingToken, .thinkingComplete, .thinkingSignature: break
             case .toolResult, .toolLoopLimitReached: break
             case .kvCacheReuse: break
             case .diagnosticThrottle: break

--- a/Tests/BaseChatUITests/MultiThinkingBlockTests.swift
+++ b/Tests/BaseChatUITests/MultiThinkingBlockTests.swift
@@ -1,0 +1,74 @@
+@preconcurrency import XCTest
+@testable import BaseChatUI
+@testable import BaseChatCore
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Tests for #482 / #604: two ``GenerationEvent/thinkingComplete`` events
+/// on a single assistant turn must produce two distinct ``MessagePart/thinking``
+/// parts (not one concatenated). Per-block signatures must round-trip onto
+/// each part independently so the next replay against Anthropic carries the
+/// right pairing.
+@MainActor
+final class MultiThinkingBlockTests: XCTestCase {
+
+    private let oneGB: UInt64 = 1_024 * 1_024 * 1_024
+
+    private func makeVM(backend: MockInferenceBackend) -> ChatViewModel {
+        backend.isModelLoaded = true
+        let service = InferenceService(backend: backend, name: "Mock")
+        let vm = ChatViewModel(
+            inferenceService: service,
+            deviceCapability: DeviceCapabilityService(physicalMemory: 16 * oneGB),
+            modelStorage: ModelStorageService(),
+            memoryPressure: MemoryPressureHandler()
+        )
+        vm.activeSession = ChatSessionRecord(title: "Test")
+        // Force per-token flushes so partial-streaming writes happen on
+        // every event and the test sees deterministic ordering.
+        vm.thinkingStreamingUpdateInterval = .zero
+        vm.thinkingStreamingBatchCharacterLimit = 1
+        vm.streamingUpdateInterval = .zero
+        vm.streamingBatchCharacterLimit = 1
+        return vm
+    }
+
+    // MARK: - 1. Two finalize events → two thinking parts
+
+    func test_twoThinkingBlocks_produceTwoSeparateThinkingParts() async {
+        let mock = MockInferenceBackend()
+        mock.thinkingBlocksToYield = [
+            ["first ", "block"],
+            ["second ", "block"],
+        ]
+        mock.signaturesPerThinkingBlock = ["sig_one", "sig_two"]
+        mock.tokensToYield = ["done"]
+        let vm = makeVM(backend: mock)
+
+        vm.inputText = "go"
+        await vm.sendMessage()
+
+        let assistant = vm.messages.first(where: { $0.role == .assistant })
+        let thinkingParts = assistant?.contentParts.filter { $0.thinkingContent != nil } ?? []
+
+        XCTAssertEqual(thinkingParts.count, 2,
+            "Two .finalizeThinking events must produce two separate .thinking parts, not one concatenated. " +
+            "Saw \(thinkingParts.count) thinking parts: \(thinkingParts)")
+
+        XCTAssertEqual(thinkingParts[0].thinkingContent, "first block")
+        XCTAssertEqual(thinkingParts[1].thinkingContent, "second block")
+
+        // Per-block signatures must land on the matching parts — Anthropic
+        // requires them paired correctly on multi-turn replay.
+        XCTAssertEqual(thinkingParts[0].thinkingSignature, "sig_one",
+            "First block's signature must land on the first .thinking part")
+        XCTAssertEqual(thinkingParts[1].thinkingSignature, "sig_two",
+            "Second block's signature must land on the second .thinking part")
+
+        // Sabotage check: reverting the finalize branch to the old "merge
+        // into existing thinking part" behaviour would coalesce both blocks
+        // into a single part with text "first block\n\nsecond block" and
+        // only one signature — failing both the count and pairing
+        // assertions above.
+    }
+}

--- a/Tests/BaseChatUITests/ThinkingStreamingTests.swift
+++ b/Tests/BaseChatUITests/ThinkingStreamingTests.swift
@@ -55,7 +55,7 @@ final class ThinkingStreamingTests: XCTestCase {
             // intent.
             let parts = vm.messages.first(where: { $0.id == id })?.contentParts ?? []
             let thinkingText = parts.compactMap { part -> String? in
-                if case .thinking(let s) = part { return s }
+                if case .thinking(let s, _) = part { return s }
                 return nil
             }.first
             thinkingTextHistory.append(thinkingText)
@@ -96,7 +96,7 @@ final class ThinkingStreamingTests: XCTestCase {
         // Authoritative final text is the full concatenated reasoning.
         let assistant = vm.messages.first(where: { $0.role == .assistant })
         let finalThinking = assistant?.contentParts.compactMap { part -> String? in
-            if case .thinking(let s) = part { return s }
+            if case .thinking(let s, _) = part { return s }
             return nil
         }.first
         XCTAssertEqual(
@@ -138,7 +138,7 @@ final class ThinkingStreamingTests: XCTestCase {
         GenerationCoordinator.appendVisibleText(", world", into: &msg)
 
         XCTAssertEqual(msg.contentParts.count, 2)
-        guard case .thinking(let t) = msg.contentParts[0] else {
+        guard case .thinking(let t, _) = msg.contentParts[0] else {
             return XCTFail("Expected leading .thinking part to survive append")
         }
         XCTAssertEqual(t, "reasoning")
@@ -174,7 +174,7 @@ final class ThinkingStreamingTests: XCTestCase {
         GenerationCoordinator.writeThinkingPartialText("Let me think", into: &msg)
 
         XCTAssertEqual(msg.contentParts.count, 2, "No new parts should be appended on partial flushes")
-        guard case .thinking(let t) = msg.contentParts[0] else {
+        guard case .thinking(let t, _) = msg.contentParts[0] else {
             return XCTFail("Index 0 must remain a .thinking part")
         }
         XCTAssertEqual(t, "Let me think")


### PR DESCRIPTION
## Summary

Multi-turn replay of Anthropic extended-thinking conversations failed once the model produced any reasoning: `GenerationCoordinator` collapsed history to `(role, content)` strings before reaching the backend, so the per-block `signature` Anthropic requires verbatim was already gone by the time `ClaudeBackend.buildRequest` ran. This PR ships the prerequisite (#482) and the cloud replay (#604) together.

- **#482 (storage + coordinator):** `MessagePart.thinking` gains an optional `signature` via custom Codable (legacy `{"thinking":"text"}` rows decode unchanged — no migration). New `StructuredMessage` type and `StructuredHistoryReceiver` protocol thread `[MessagePart]` end-to-end. `ChatViewModel` creates a fresh `.thinking` part per `.finalizeThinking` event so per-block signatures don't get coalesced.
- **#604 (Claude replay):** `ClaudeBackend` adopts `StructuredHistoryReceiver`, captures signatures from `signature_delta` and `content_block_start` SSE payloads, and serializes prior assistant turns as Anthropic-shaped `content[]` arrays (thinking before text, signature verbatim). Unsigned thinking blocks (cross-backend persisted rows from MLX/Llama) are dropped from the replay rather than sent blank — Anthropic 400s on mismatched signatures.

```swift
// New StructuredMessage entry preserves thinking signatures end-to-end.
let history: [StructuredMessage] = [
    StructuredMessage(role: "user", content: "Q1"),
    StructuredMessage(role: "assistant", parts: [
        .thinking("internal reasoning", signature: "sig_abc123"),
        .text("answer"),
    ]),
    StructuredMessage(role: "user", content: "Q2"),
]
let (_, stream) = try inferenceService.enqueue(structuredMessages: history)
```

The legacy `(role, content)` entry points stay as a thin shim so existing callers (and many tests) keep working unchanged.

## Backend checklist

| Backend | Affected | Notes |
|---------|----------|-------|
| ClaudeBackend | yes | signature capture + structured replay (`buildRequest`, `parseResponseStream`) |
| OpenAIBackend | comment-only | reasoning_content is replay-asymmetric; flattened path is correct |
| OllamaBackend | unaffected | `ConversationHistoryReceiver` path collapses structured to text |
| MLXBackend | unaffected | same |
| LlamaBackend | unaffected | same |
| FoundationBackend | unaffected | same |

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 221 tests pass (incl. new `MessagePartThinkingSignatureTests`)
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 1107 tests pass (incl. new `GenerationCoordinatorStructuredHistoryTests`)
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits` — 69 tests pass
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 499 tests pass (incl. new `MultiThinkingBlockTests`)
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — passes
- [x] `swift test --filter BaseChatTestSupportTests --disable-default-traits` — 13 tests pass
- [x] `swift test --filter BaseChatBackendsTests --traits MLX,Llama,CloudSaaS,Ollama` (Apple Silicon) — 136 tests pass (incl. new `ClaudeStructuredReplayTests`)
- [x] Sabotage checks performed during dev: dropping signature from encode failed 3 codable tests; reverting `lastIndex` to `firstIndex` in finalize merged blocks and failed `MultiThinkingBlockTests`. Both reverted before commit.

Closes #604
Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)