### PR TITLE
fix(test): correct trait gate on CloudEndpointSelectionIntegrationTests

### DIFF
--- a/Tests/BaseChatBackendsTests/AllBackendsAcceptPlanTests.swift
+++ b/Tests/BaseChatBackendsTests/AllBackendsAcceptPlanTests.swift
@@ -1,4 +1,3 @@
-#if Ollama || CloudSaaS
 import XCTest
 import BaseChatInference
 import BaseChatTestSupport
@@ -44,6 +43,7 @@ final class AllBackendsAcceptPlanTests: XCTestCase {
 
     // MARK: - Cloud Backends
 
+    #if CloudSaaS
     func test_openAIBackendAcceptsPlan() async throws {
         let backend = OpenAIBackend()
         backend.configure(
@@ -73,7 +73,9 @@ final class AllBackendsAcceptPlanTests: XCTestCase {
             // Acceptable — the test's contract is the signature, not the outcome.
         }
     }
+    #endif
 
+    #if Ollama
     func test_ollamaBackendAcceptsPlan() async throws {
         let backend = OllamaBackend()
         backend.configure(
@@ -83,6 +85,7 @@ final class AllBackendsAcceptPlanTests: XCTestCase {
         try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
         XCTAssertTrue(backend.isModelLoaded)
     }
+    #endif
 
     // MARK: - Local Backends (hardware-gated)
 
@@ -131,4 +134,3 @@ final class AllBackendsAcceptPlanTests: XCTestCase {
         #endif
     }
 }
-#endif

--- a/Tests/BaseChatBackendsTests/BackendCapabilitiesContractTests.swift
+++ b/Tests/BaseChatBackendsTests/BackendCapabilitiesContractTests.swift
@@ -1,4 +1,3 @@
-#if Ollama || CloudSaaS
 import XCTest
 import BaseChatCore
 import BaseChatTestSupport
@@ -13,6 +12,7 @@ final class BackendCapabilitiesContractTests: XCTestCase {
 
     // MARK: - Remote backends
 
+    #if Ollama && CloudSaaS
     func test_cloudBackends_reportIsRemote() {
         XCTAssertTrue(ClaudeBackend().capabilities.isRemote,
                       "ClaudeBackend makes network calls — isRemote must be true")
@@ -21,9 +21,11 @@ final class BackendCapabilitiesContractTests: XCTestCase {
         XCTAssertTrue(OllamaBackend().capabilities.isRemote,
                       "OllamaBackend makes network calls — isRemote must be true")
     }
+    #endif
 
     // MARK: - Tool Calling
 
+    #if Ollama && CloudSaaS
     func test_cloudBackends_toolCallingCapabilities() {
         // Ollama advertises tool calling since Wave 2 dispatch wiring (PR #640)
         // — it emits OpenAI-compatible `tool_calls` over NDJSON and the
@@ -37,14 +39,18 @@ final class BackendCapabilitiesContractTests: XCTestCase {
         XCTAssertTrue(OllamaBackend().capabilities.supportsToolCalling,
                       "OllamaBackend advertises tool calling since Wave 2 dispatch wiring")
     }
+    #endif
 
+    #if CloudSaaS
     func test_cloudBackends_structuredOutputCapabilities() {
         XCTAssertTrue(ClaudeBackend().capabilities.supportsStructuredOutput,
                       "ClaudeBackend supports structured output")
         XCTAssertTrue(OpenAIBackend().capabilities.supportsStructuredOutput,
                       "OpenAIBackend supports structured output via json_schema")
     }
+    #endif
 
+    #if Ollama && CloudSaaS
     func test_backends_nativeJSONModeCapabilities() {
         XCTAssertFalse(ClaudeBackend().capabilities.supportsNativeJSONMode,
                        "ClaudeBackend does not advertise a dedicated native JSON mode")
@@ -53,6 +59,7 @@ final class BackendCapabilitiesContractTests: XCTestCase {
         XCTAssertTrue(OllamaBackend().capabilities.supportsNativeJSONMode,
                       "OllamaBackend supports format=json")
     }
+    #endif
 
     // MARK: - supportsThinking
 
@@ -61,6 +68,7 @@ final class BackendCapabilitiesContractTests: XCTestCase {
     /// Even though `OpenAIBackend` and `ClaudeBackend` already plumb reasoning
     /// deltas, the capability flag is the static, model-agnostic contract
     /// callers rely on to gate reasoning UI — see issue #480.
+    #if Ollama && CloudSaaS
     func test_cloudBackends_doNotAdvertiseThinking() {
         XCTAssertFalse(ClaudeBackend().capabilities.supportsThinking,
                        "ClaudeBackend.supportsThinking stays false until #604 formalises the declaration")
@@ -69,6 +77,7 @@ final class BackendCapabilitiesContractTests: XCTestCase {
         XCTAssertFalse(OllamaBackend().capabilities.supportsThinking,
                        "OllamaBackend.supportsThinking stays false until #598 formalises the declaration")
     }
+    #endif
 
     // MARK: - Local backends
 
@@ -162,4 +171,3 @@ final class BackendCapabilitiesContractTests: XCTestCase {
     }
 #endif
 }
-#endif

--- a/Tests/BaseChatBackendsTests/CloudEndpointSelectionIntegrationTests.swift
+++ b/Tests/BaseChatBackendsTests/CloudEndpointSelectionIntegrationTests.swift
@@ -1,4 +1,4 @@
-#if Ollama || CloudSaaS
+#if CloudSaaS
 import XCTest
 import SwiftData
 @testable import BaseChatBackends

--- a/Tests/BaseChatBackendsTests/MemoryStrategyBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/MemoryStrategyBackendTests.swift
@@ -1,4 +1,3 @@
-#if Ollama || CloudSaaS
 import XCTest
 @testable import BaseChatBackends
 import BaseChatCore
@@ -7,6 +6,7 @@ final class MemoryStrategyBackendTests: XCTestCase {
 
     // MARK: - Cloud Backends (no hardware needed)
 
+    #if CloudSaaS
     func test_openAIBackend_declaresExternalStrategy() {
         let backend = OpenAIBackend()
         XCTAssertEqual(backend.capabilities.memoryStrategy, .external)
@@ -16,6 +16,7 @@ final class MemoryStrategyBackendTests: XCTestCase {
         let backend = ClaudeBackend()
         XCTAssertEqual(backend.capabilities.memoryStrategy, .external)
     }
+    #endif
 
     // MARK: - Local Backends (hardware gated)
 
@@ -35,4 +36,3 @@ final class MemoryStrategyBackendTests: XCTestCase {
     }
     #endif
 }
-#endif


### PR DESCRIPTION
## Problem

Four `BaseChatBackendsTests` files had `#if Ollama || CloudSaaS` as their outer gate but referenced types (`OpenAIBackend`, `ClaudeBackend`) that are only declared under `#if CloudSaaS`. The package's default traits are `MLX, Llama, Ollama` — `CloudSaaS` is off by default — so `xcodebuild test -scheme BaseChatKit-Package -destination 'platform=macOS'` failed with:

```
CloudEndpointSelectionIntegrationTests.swift:558:26: error: cannot find type 'OpenAIBackend' in scope
CloudEndpointSelectionIntegrationTests.swift:612:26: error: cannot find type 'ClaudeBackend' in scope
```

This slipped through CI (`swift test --disable-default-traits`) because that flag turns Ollama off too, excluding all four files via the outer disjunction.

Pre-existing since the trait split (PR #724); not introduced by recent work.

## Fix

- **`CloudEndpointSelectionIntegrationTests.swift`** — `setUp` itself wires `ConfiguringOpenAICloudBackend`, so every test requires CloudSaaS. Tightened outer gate to `#if CloudSaaS`.
- **`AllBackendsAcceptPlanTests.swift`** — dropped outer gate; cloud tests wrapped `#if CloudSaaS`, Ollama test wrapped `#if Ollama`. Mock/local tests now compile unconditionally.
- **`BackendCapabilitiesContractTests.swift`** — dropped outer gate; per-test gates added matching actual type usage (`#if Ollama && CloudSaaS` for tests touching all remotes, `#if CloudSaaS` for Claude+OpenAI-only test).
- **`MemoryStrategyBackendTests.swift`** — dropped outer gate; cloud tests wrapped `#if CloudSaaS`; local backend tests already inner-gated and unaffected.

## Verified

- `swift build` (default traits: MLX,Llama,Ollama, no CloudSaaS) — succeeds, no "cannot find type" errors
- `swift test --filter BaseChatBackendsTests --disable-default-traits` — 80 tests, 0 failures (previously 75; 5 more tests now compile and run since `AllBackendsAcceptPlanTests` mock test no longer excluded)
- Full CI suite — 2216 XCTest + 123 swift-testing tests, 0 failures

Closes the `xcodebuild test` failure reported in the post-#776 test run.