### PR TITLE
feat(inference): tool-call loop orchestrator, output size policy, registry reentrancy contract

### DIFF
--- a/Sources/BaseChatInference/Models/ToolOutputPolicy.swift
+++ b/Sources/BaseChatInference/Models/ToolOutputPolicy.swift
@@ -42,8 +42,10 @@ import Foundation
 ///   UTF-8 boundary and the suffix (default `"... [truncated]"`) is
 ///   appended. Use when partial output is genuinely useful, e.g. log
 ///   tails.
-/// - ``OversizeAction/allow``: no enforcement. Debug only — disables the
-///   safety net.
+/// - ``OversizeAction/allow``: no enforcement for *successful* results.
+///   Already-errored results whose content overflows are still trimmed
+///   (the registry never re-classifies an existing error). Debug only —
+///   disables the safety net for happy-path responses.
 ///
 /// ## Example
 ///
@@ -61,8 +63,12 @@ public struct ToolOutputPolicy: Sendable, Equatable {
     /// result's ``ToolResult/content``.
     ///
     /// Defaults to `32_768` (~8K tokens). The byte count is measured via
-    /// `String.utf8.count` after the executor returns.
-    public var maxBytes: Int
+    /// `String.utf8.count` after the executor returns. Negative values
+    /// are clamped to `0` at the property setter so a misconfigured host
+    /// can't accidentally invert the policy and reject every result.
+    public var maxBytes: Int {
+        didSet { if maxBytes < 0 { maxBytes = 0 } }
+    }
 
     /// What to do when a result exceeds ``maxBytes``.
     public var onOversize: OversizeAction
@@ -71,6 +77,8 @@ public struct ToolOutputPolicy: Sendable, Equatable {
     ///
     /// - Parameters:
     ///   - maxBytes: Permitted UTF-8 byte ceiling. Defaults to `32_768`.
+    ///     Negative values are clamped to `0` (every successful result
+    ///     becomes oversize and is handled per ``onOversize``).
     ///   - onOversize: Action when the ceiling is exceeded. Defaults to
     ///     ``OversizeAction/rejectWithError`` so oversize results surface
     ///     as a recognisable error rather than silently disappearing.
@@ -78,7 +86,7 @@ public struct ToolOutputPolicy: Sendable, Equatable {
         maxBytes: Int = 32_768,
         onOversize: OversizeAction = .rejectWithError
     ) {
-        self.maxBytes = maxBytes
+        self.maxBytes = max(0, maxBytes)
         self.onOversize = onOversize
     }
 }
@@ -105,8 +113,11 @@ public enum OversizeAction: Sendable, Equatable {
     /// emitting just the suffix truncated to fit. Don't configure that.
     case truncate(suffix: String)
 
-    /// No enforcement — pass the result through unchanged. Intended for
-    /// debug builds and tests; production hosts should keep the default
-    /// ``rejectWithError`` policy.
+    /// No oversize enforcement for successful results — pass them
+    /// through unchanged. Already-errored results whose content
+    /// overflows ``ToolOutputPolicy/maxBytes`` are still trimmed by the
+    /// registry; this case never re-classifies an existing error.
+    /// Intended for debug builds and tests; production hosts should
+    /// keep the default ``rejectWithError`` policy.
     case allow
 }

--- a/Sources/BaseChatInference/Models/ToolOutputPolicy.swift
+++ b/Sources/BaseChatInference/Models/ToolOutputPolicy.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+// MARK: - ToolOutputPolicy
+
+/// Bounds the size of a ``ToolResult/content`` payload before it flows back
+/// into the next generation turn.
+///
+/// Tool outputs ride in the conversation history as plain message text. A
+/// 40 KB JSON dump from a single tool call easily exceeds the next turn's
+/// budget on local models with 8K-token windows, causing silent truncation
+/// at the prompt-assembly layer or, on the simulator, an out-of-memory
+/// crash. ``ToolOutputPolicy`` makes the size limit explicit and gives the
+/// host three options for handling oversize results.
+///
+/// The default ``maxBytes`` of `32_768` corresponds to roughly 8K tokens —
+/// enough to round-trip a typical structured tool response without ever
+/// approaching the context budget on a 32K-context model.
+///
+/// ## Tuning ``maxBytes``
+///
+/// - **Keep the default (32 KB)** for tools that return short, structured
+///   data: weather lookups, calculator output, search-result summaries,
+///   small DB queries. The default leaves comfortable headroom for the
+///   user prompt, system prompt, and assistant reply on local 8K–32K
+///   context models.
+/// - **Raise it (e.g. 256 KB)** for tools that return long file reads,
+///   page contents, or transcripts. Pair the bump with a backend that
+///   has a 128K+ context window — Claude, GPT-4-turbo, Gemini Pro, etc.
+///   Raising it on a local 8K-context model will silently push earlier
+///   turns out of the prompt window.
+/// - **Lower it (e.g. 4 KB)** when chaining many tools per turn — each
+///   result eats budget, so capping at 4 KB per call keeps the loop
+///   producing readable transcripts.
+///
+/// Pair the policy with ``OversizeAction``:
+///
+/// - ``OversizeAction/rejectWithError`` (default): the result is replaced
+///   with an ``ToolResult/ErrorKind/invalidArguments`` error so the model
+///   can self-correct (ask for a smaller slice, narrow the query, etc.).
+///   This is the safe default — no data silently disappears.
+/// - ``OversizeAction/truncate(suffix:)``: the result is trimmed at a
+///   UTF-8 boundary and the suffix (default `"... [truncated]"`) is
+///   appended. Use when partial output is genuinely useful, e.g. log
+///   tails.
+/// - ``OversizeAction/allow``: no enforcement. Debug only — disables the
+///   safety net.
+///
+/// ## Example
+///
+/// ```swift
+/// let registry = ToolRegistry()
+/// registry.outputPolicy = ToolOutputPolicy(
+///     maxBytes: 65_536,
+///     onOversize: .truncate(suffix: "\n... [truncated for context budget]")
+/// )
+/// registry.register(fileReadTool)
+/// ```
+public struct ToolOutputPolicy: Sendable, Equatable {
+
+    /// Maximum permitted size, in UTF-8 bytes, of a successful tool
+    /// result's ``ToolResult/content``.
+    ///
+    /// Defaults to `32_768` (~8K tokens). The byte count is measured via
+    /// `String.utf8.count` after the executor returns.
+    public var maxBytes: Int
+
+    /// What to do when a result exceeds ``maxBytes``.
+    public var onOversize: OversizeAction
+
+    /// Creates a policy.
+    ///
+    /// - Parameters:
+    ///   - maxBytes: Permitted UTF-8 byte ceiling. Defaults to `32_768`.
+    ///   - onOversize: Action when the ceiling is exceeded. Defaults to
+    ///     ``OversizeAction/rejectWithError`` so oversize results surface
+    ///     as a recognisable error rather than silently disappearing.
+    public init(
+        maxBytes: Int = 32_768,
+        onOversize: OversizeAction = .rejectWithError
+    ) {
+        self.maxBytes = maxBytes
+        self.onOversize = onOversize
+    }
+}
+
+// MARK: - OversizeAction
+
+/// How ``ToolRegistry`` should react when a tool result's UTF-8 byte
+/// length exceeds ``ToolOutputPolicy/maxBytes``.
+public enum OversizeAction: Sendable, Equatable {
+
+    /// Replace the result with a
+    /// ``ToolResult/ErrorKind/invalidArguments`` failure whose content
+    /// describes the overflow. The model sees the error and can retry
+    /// with a narrower argument (smaller slice, tighter filter).
+    case rejectWithError
+
+    /// Trim ``ToolResult/content`` to a valid UTF-8 boundary and append
+    /// `suffix`. The total byte count after trim + suffix is guaranteed
+    /// not to exceed ``ToolOutputPolicy/maxBytes`` — the trimmer reserves
+    /// room for the suffix bytes before slicing the original payload.
+    ///
+    /// Trade-off: when the suffix is longer than ``ToolOutputPolicy/maxBytes``
+    /// itself (a degenerate configuration), the trimmer falls back to
+    /// emitting just the suffix truncated to fit. Don't configure that.
+    case truncate(suffix: String)
+
+    /// No enforcement — pass the result through unchanged. Intended for
+    /// debug builds and tests; production hosts should keep the default
+    /// ``rejectWithError`` policy.
+    case allow
+}

--- a/Sources/BaseChatInference/Services/ToolCallLoopOrchestrator.swift
+++ b/Sources/BaseChatInference/Services/ToolCallLoopOrchestrator.swift
@@ -1,0 +1,534 @@
+import Foundation
+
+// MARK: - ToolCallLoopPolicy
+
+/// Bounds and heuristics that govern how a ``ToolCallLoopOrchestrator``
+/// drives the generate → tool-call → execute → feed-result → generate loop.
+///
+/// Defaults err on the safe side for agent-style chat: a small step budget,
+/// no wall-clock cap (callers wrap the whole stream in their own timeout if
+/// they need one), and a 3-step identical-call window for cycle detection.
+///
+/// ## Example
+/// ```swift
+/// let policy = ToolCallLoopPolicy(
+///     maxSteps: 6,
+///     perStepTimeout: .seconds(30),
+///     loopDetectionWindow: 3
+/// )
+/// let orchestrator = ToolCallLoopOrchestrator(
+///     backend: backend,
+///     executor: dispatcher,
+///     policy: policy
+/// )
+/// ```
+public struct ToolCallLoopPolicy: Sendable {
+
+    /// Hard upper bound on `(generate, dispatch)` rounds in one ``ToolCallLoopOrchestrator/run(initialPrompt:systemPrompt:config:)``
+    /// invocation. When the cap is hit the orchestrator emits
+    /// ``ToolLoopEvent/stepLimitReached(steps:)`` and finishes.
+    ///
+    /// Defaults to `8`. Values `<= 0` are silently clamped to `1` — a zero
+    /// budget would never let the loop start and is never the intent.
+    public var maxSteps: Int
+
+    /// Optional wall-clock cap applied to each `generate(...)` round.
+    ///
+    /// `nil` (default) disables the per-step timer. When set, the orchestrator
+    /// races each backend call against `Task.sleep(for:)` and surfaces a
+    /// ``ToolLoopError/stepTimedOut(step:)`` when the timer wins. Tool
+    /// execution is *not* covered — executors enforce their own deadlines and
+    /// surface ``ToolResult/ErrorKind/timeout`` directly.
+    public var perStepTimeout: Duration?
+
+    /// Number of trailing `(toolName, arguments)` pairs that must be identical
+    /// for the loop-detection heuristic to fire.
+    ///
+    /// On a hit the orchestrator emits ``ToolLoopEvent/loopDetected(toolName:)``
+    /// and finishes. Defaults to `3`. Values `<= 1` disable the heuristic
+    /// entirely (a single tool call by itself is never a cycle).
+    public var loopDetectionWindow: Int
+
+    /// Creates a loop policy.
+    ///
+    /// - Parameters:
+    ///   - maxSteps: Step budget. Clamped to `1...`. Defaults to `8`.
+    ///   - perStepTimeout: Optional wall-clock cap per generate round. Defaults to `nil`.
+    ///   - loopDetectionWindow: N identical consecutive `(name, args)` pairs that
+    ///     trigger ``ToolLoopEvent/loopDetected(toolName:)``. Values `<= 1` disable
+    ///     the heuristic. Defaults to `3`.
+    public init(
+        maxSteps: Int = 8,
+        perStepTimeout: Duration? = nil,
+        loopDetectionWindow: Int = 3
+    ) {
+        self.maxSteps = max(1, maxSteps)
+        self.perStepTimeout = perStepTimeout
+        self.loopDetectionWindow = loopDetectionWindow
+    }
+}
+
+// MARK: - ToolLoopEvent
+
+/// Events emitted by ``ToolCallLoopOrchestrator/run(initialPrompt:systemPrompt:config:)``.
+///
+/// Mirrors a subset of ``GenerationEvent`` plus three orchestrator-only
+/// terminal events. Callers consume the stream until it finishes; the last
+/// event is always one of ``finished``, ``stepLimitReached(steps:)`` or
+/// ``loopDetected(toolName:)`` unless the stream throws.
+public enum ToolLoopEvent: Sendable, Equatable {
+
+    /// A fragment of visible text emitted by the model (forwarded verbatim
+    /// from ``GenerationEvent/token(_:)``). Thinking-block tokens are not
+    /// forwarded — agentic callers care about the visible output.
+    case token(String)
+
+    /// The model has requested a tool call. Emitted *before* dispatch so UIs
+    /// can render the call in flight. The orchestrator dispatches the call
+    /// itself; the host does not need to act.
+    case toolCall(ToolCall)
+
+    /// The result of a tool the orchestrator dispatched. Emitted *after*
+    /// dispatch, before the next generate round. Forwards
+    /// ``ToolResult/ErrorKind`` semantics unchanged from the executor.
+    case toolResult(ToolResult)
+
+    /// Token usage reported by the backend (cloud only today). Emitted as
+    /// it arrives, possibly multiple times across the loop's rounds.
+    case usage(prompt: Int, completion: Int)
+
+    /// The policy step budget was hit before the model produced a non-tool
+    /// turn. Terminal — no further events follow.
+    case stepLimitReached(steps: Int)
+
+    /// The cycle heuristic fired: the last
+    /// ``ToolCallLoopPolicy/loopDetectionWindow`` `(toolName, arguments)`
+    /// pairs were identical. Terminal — no further events follow.
+    case loopDetected(toolName: String)
+
+    /// The model produced a turn without emitting any tool call.
+    /// Terminal — no further events follow.
+    case finished
+}
+
+// MARK: - ToolLoopError
+
+/// Errors thrown into the ``ToolCallLoopOrchestrator/run(initialPrompt:systemPrompt:config:)``
+/// stream when the loop cannot continue.
+public enum ToolLoopError: Error, Sendable, Equatable {
+
+    /// A `generate(...)` round exceeded ``ToolCallLoopPolicy/perStepTimeout``.
+    /// The associated value is the 1-indexed step number that timed out.
+    case stepTimedOut(step: Int)
+}
+
+// MARK: - ToolCallLoopOrchestrator
+
+/// Drives an agent-style generate → tool-call → execute → feed-result → generate
+/// loop on top of a single ``InferenceBackend`` and a ``ToolExecutor`` (or a
+/// ``ToolRegistry`` of executors).
+///
+/// The orchestrator is intentionally a separate, lower-level public API — it
+/// does **not** replace ``InferenceService``. Use it when you want a thin
+/// agentic harness without the queue, persistence, or
+/// ``GenerationCoordinator`` plumbing.
+///
+/// ## Lifecycle
+///
+/// 1. Caller invokes ``run(initialPrompt:systemPrompt:config:)``.
+/// 2. Orchestrator runs `backend.generate(...)`, forwarding ``GenerationEvent/token(_:)``,
+///    ``GenerationEvent/usage(prompt:completion:)``, and ``GenerationEvent/toolCall(_:)``
+///    events to the caller.
+/// 3. On the *first* tool call in a round, the orchestrator collects all tool
+///    calls emitted during that round, then dispatches each via the executor.
+///    A ``ToolLoopEvent/toolResult(_:)`` is emitted per result.
+/// 4. The result content is appended to the next prompt verbatim and a new
+///    `generate(...)` round runs.
+/// 5. When a round produces no tool calls, the orchestrator emits
+///    ``ToolLoopEvent/finished``.
+/// 6. If ``ToolCallLoopPolicy/maxSteps`` is exceeded, it emits
+///    ``ToolLoopEvent/stepLimitReached(steps:)``.
+/// 7. If the last ``ToolCallLoopPolicy/loopDetectionWindow`` `(name, args)`
+///    pairs are identical, it emits ``ToolLoopEvent/loopDetected(toolName:)``.
+///
+/// ## Cancellation
+///
+/// Cancellation propagates through the consuming task — when the caller
+/// cancels its iteration, the orchestrator's internal driver task observes
+/// ``Swift/Task/isCancelled`` and calls ``InferenceBackend/stopGeneration()``
+/// on the backend. No further events fire after cancellation.
+///
+/// ## Prompt formatting
+///
+/// The orchestrator concatenates tool results into the next prompt as
+/// `"\n\nTool '<name>' result: <content>\n"` — the lowest-common-denominator
+/// shape that drives the ``MockInferenceBackend`` test fixtures and works as a
+/// portable default. Production callers that want richer formatting (e.g. a
+/// proper `tool` role threaded through ``ToolCallingHistoryReceiver``) should
+/// use ``GenerationCoordinator`` instead, which knows how to feed a structured
+/// transcript back into backends that support it.
+///
+/// ## Multi-tool dispatch
+///
+/// The single-executor initializer covers the simple case of a single tool.
+/// For multi-tool agents, prefer ``init(backend:registry:policy:)`` — the
+/// orchestrator routes each call through ``ToolRegistry/dispatch(_:)`` which
+/// looks up the right executor by name.
+///
+/// ## Example
+/// ```swift
+/// let orchestrator = ToolCallLoopOrchestrator(
+///     backend: backend,
+///     registry: registry,
+///     policy: ToolCallLoopPolicy(maxSteps: 6)
+/// )
+/// for try await event in orchestrator.run(
+///     initialPrompt: "What's the weather in Rome?",
+///     systemPrompt: nil,
+///     config: GenerationConfig()
+/// ) {
+///     switch event {
+///     case .token(let t): print(t, terminator: "")
+///     case .finished, .stepLimitReached, .loopDetected: break
+///     default: break
+///     }
+/// }
+/// ```
+public struct ToolCallLoopOrchestrator: Sendable {
+
+    private let backend: any InferenceBackend
+    private let dispatcher: Dispatcher
+    private let policy: ToolCallLoopPolicy
+
+    /// Creates an orchestrator driven by a single ``ToolExecutor``.
+    ///
+    /// Every model-emitted ``ToolCall`` is routed to `executor` regardless of
+    /// the call's ``ToolCall/toolName``. Use this initializer when you have
+    /// exactly one tool, or when a host-built dispatcher already wraps a
+    /// multi-tool registry behind a single executor surface.
+    ///
+    /// - Parameters:
+    ///   - backend: The backend that produces tokens and tool calls.
+    ///   - executor: Receives every dispatched call.
+    ///   - policy: Loop bounds. Defaults to ``ToolCallLoopPolicy/init(maxSteps:perStepTimeout:loopDetectionWindow:)``.
+    public init(
+        backend: any InferenceBackend,
+        executor: any ToolExecutor,
+        policy: ToolCallLoopPolicy = .init()
+    ) {
+        self.backend = backend
+        self.dispatcher = .singleExecutor(executor)
+        self.policy = policy
+    }
+
+    /// Creates an orchestrator driven by a ``ToolRegistry``.
+    ///
+    /// Each ``ToolCall`` is dispatched through ``ToolRegistry/dispatch(_:)`` so
+    /// the registry handles name lookup, JSON parsing, schema validation
+    /// (when configured), and ``ToolResult/ErrorKind`` classification.
+    ///
+    /// - Parameters:
+    ///   - backend: The backend that produces tokens and tool calls.
+    ///   - registry: Multi-tool registry the orchestrator dispatches through.
+    ///   - policy: Loop bounds. Defaults to ``ToolCallLoopPolicy/init(maxSteps:perStepTimeout:loopDetectionWindow:)``.
+    public init(
+        backend: any InferenceBackend,
+        registry: ToolRegistry,
+        policy: ToolCallLoopPolicy = .init()
+    ) {
+        self.backend = backend
+        self.dispatcher = .registry(registry)
+        self.policy = policy
+    }
+
+    // MARK: - run
+
+    /// Streams the loop's events.
+    ///
+    /// The returned stream produces ``ToolLoopEvent`` values until the loop
+    /// terminates with ``ToolLoopEvent/finished``,
+    /// ``ToolLoopEvent/stepLimitReached(steps:)``, or
+    /// ``ToolLoopEvent/loopDetected(toolName:)``. Errors thrown by the backend
+    /// or by the per-step timeout are forwarded into the stream.
+    ///
+    /// Cancellation: when the consumer cancels its iteration, the orchestrator
+    /// calls ``InferenceBackend/stopGeneration()`` on `backend` and finishes
+    /// the stream without emitting further events.
+    ///
+    /// - Parameters:
+    ///   - initialPrompt: First user-visible prompt.
+    ///   - systemPrompt: Optional system prompt forwarded on every round.
+    ///   - config: Sampling configuration. Forwarded verbatim each round —
+    ///     callers that want a different `tools` list per round should construct
+    ///     a fresh orchestrator.
+    public func run(
+        initialPrompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig
+    ) -> AsyncThrowingStream<ToolLoopEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let driver = Task {
+                await self.drive(
+                    initialPrompt: initialPrompt,
+                    systemPrompt: systemPrompt,
+                    config: config,
+                    continuation: continuation
+                )
+            }
+            continuation.onTermination = { [backend] _ in
+                driver.cancel()
+                // The consumer dropped the stream (cancellation, break, or
+                // natural finish). Telling the backend to stop here is a
+                // best-effort no-op when generation has already completed
+                // and a real cancel when it hasn't — matches the
+                // InferenceBackend.stopGeneration() contract.
+                backend.stopGeneration()
+            }
+        }
+    }
+
+    // MARK: - Driver
+
+    private func drive(
+        initialPrompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig,
+        continuation: AsyncThrowingStream<ToolLoopEvent, Error>.Continuation
+    ) async {
+        var prompt = initialPrompt
+        var step = 0
+        var recentCalls: [CallSignature] = []
+
+        while step < policy.maxSteps {
+            if Task.isCancelled {
+                continuation.finish()
+                return
+            }
+            step += 1
+
+            let stream: GenerationStream
+            do {
+                stream = try backend.generate(
+                    prompt: prompt,
+                    systemPrompt: systemPrompt,
+                    config: config
+                )
+            } catch {
+                continuation.finish(throwing: error)
+                return
+            }
+
+            let outcome: RoundOutcome
+            do {
+                outcome = try await consume(
+                    stream: stream,
+                    step: step,
+                    continuation: continuation
+                )
+            } catch {
+                continuation.finish(throwing: error)
+                return
+            }
+
+            if outcome.cancelled {
+                continuation.finish()
+                return
+            }
+
+            if outcome.toolCalls.isEmpty {
+                continuation.yield(.finished)
+                continuation.finish()
+                return
+            }
+
+            // Loop detection: track the last N (name, args) pairs across the
+            // whole conversation. If the trailing window of `loopDetectionWindow`
+            // pairs is identical, fire and finish.
+            for call in outcome.toolCalls {
+                recentCalls.append(CallSignature(name: call.toolName, arguments: call.arguments))
+                if recentCalls.count > policy.loopDetectionWindow {
+                    recentCalls.removeFirst(recentCalls.count - policy.loopDetectionWindow)
+                }
+                if policy.loopDetectionWindow > 1,
+                   recentCalls.count == policy.loopDetectionWindow,
+                   let first = recentCalls.first,
+                   recentCalls.allSatisfy({ $0 == first }) {
+                    continuation.yield(.loopDetected(toolName: first.name))
+                    continuation.finish()
+                    return
+                }
+            }
+
+            // Dispatch each call sequentially, forwarding the result before the
+            // next one runs. Sequential dispatch matches GenerationCoordinator's
+            // existing contract — parallel dispatch is a richer feature that
+            // belongs on a future explicit policy knob, not a default.
+            var resultsAppendix = ""
+            for call in outcome.toolCalls {
+                if Task.isCancelled {
+                    continuation.finish()
+                    return
+                }
+                let result = await dispatcher.dispatch(call)
+                continuation.yield(.toolResult(result))
+                resultsAppendix += "\n\nTool '\(call.toolName)' result: \(result.content)\n"
+            }
+
+            prompt = prompt + resultsAppendix
+        }
+
+        continuation.yield(.stepLimitReached(steps: step))
+        continuation.finish()
+    }
+
+    /// Reads one round of events from the backend stream, optionally bounded
+    /// by ``ToolCallLoopPolicy/perStepTimeout``. Forwards tokens, usage, and
+    /// tool-call events as they arrive and returns the collected tool calls
+    /// (empty when the round ended without one).
+    private func consume(
+        stream: GenerationStream,
+        step: Int,
+        continuation: AsyncThrowingStream<ToolLoopEvent, Error>.Continuation
+    ) async throws -> RoundOutcome {
+        if let timeout = policy.perStepTimeout {
+            return try await withThrowingTaskGroup(of: RoundOutcome?.self) { group in
+                let backend = self.backend
+                group.addTask {
+                    try await Self.consumeOnce(
+                        stream: stream,
+                        continuation: continuation
+                    )
+                }
+                group.addTask {
+                    try await Task.sleep(for: timeout)
+                    backend.stopGeneration()
+                    throw ToolLoopError.stepTimedOut(step: step)
+                }
+                defer { group.cancelAll() }
+                guard let first = try await group.next() else {
+                    return RoundOutcome(toolCalls: [], cancelled: true)
+                }
+                return first ?? RoundOutcome(toolCalls: [], cancelled: true)
+            }
+        } else {
+            return try await Self.consumeOnce(stream: stream, continuation: continuation)
+        }
+    }
+
+    private static func consumeOnce(
+        stream: GenerationStream,
+        continuation: AsyncThrowingStream<ToolLoopEvent, Error>.Continuation
+    ) async throws -> RoundOutcome {
+        var calls: [ToolCall] = []
+        do {
+            for try await event in stream.events {
+                if Task.isCancelled {
+                    return RoundOutcome(toolCalls: [], cancelled: true)
+                }
+                switch event {
+                case .token(let text):
+                    continuation.yield(.token(text))
+                case .toolCall(let call):
+                    continuation.yield(.toolCall(call))
+                    calls.append(call)
+                case .usage(let p, let c):
+                    continuation.yield(.usage(prompt: p, completion: c))
+                case .thinkingToken, .thinkingComplete, .thinkingSignature,
+                     .toolLoopLimitReached, .toolResult, .kvCacheReuse,
+                     .diagnosticThrottle:
+                    // Reasoning, KV-cache hints, and diagnostic events are
+                    // not part of the orchestrator's surface. The legacy
+                    // `.toolLoopLimitReached` / `.toolResult` events come
+                    // from the in-service GenerationCoordinator path; this
+                    // orchestrator emits its own equivalents.
+                    continue
+                }
+            }
+        } catch is CancellationError {
+            return RoundOutcome(toolCalls: [], cancelled: true)
+        }
+        return RoundOutcome(toolCalls: calls, cancelled: false)
+    }
+
+    // MARK: - Internals
+
+    private struct CallSignature: Equatable, Sendable {
+        let name: String
+        let arguments: String
+    }
+
+    private struct RoundOutcome: Sendable {
+        let toolCalls: [ToolCall]
+        let cancelled: Bool
+    }
+
+    /// Internal sum type so the orchestrator can take either a bare
+    /// ``ToolExecutor`` (issue #443 spec) or a ``ToolRegistry`` (multi-tool
+    /// reality) without exposing two separate run paths.
+    private enum Dispatcher: Sendable {
+        case singleExecutor(any ToolExecutor)
+        case registry(ToolRegistry)
+
+        func dispatch(_ call: ToolCall) async -> ToolResult {
+            switch self {
+            case .singleExecutor(let executor):
+                return await Self.dispatchSingle(executor: executor, call: call)
+            case .registry(let registry):
+                return await registry.dispatch(call)
+            }
+        }
+
+        private static func dispatchSingle(
+            executor: any ToolExecutor,
+            call: ToolCall
+        ) async -> ToolResult {
+            // Mirror the subset of ToolRegistry.dispatch's contract that
+            // applies to a single executor: parse JSON arguments, invoke the
+            // executor, classify thrown errors as `.permanent` (or `.cancelled`
+            // when the surrounding task was cancelled), and stamp callId.
+            let parsed: JSONSchemaValue
+            if call.arguments.isEmpty {
+                parsed = .object([:])
+            } else if let data = call.arguments.data(using: .utf8) {
+                do {
+                    parsed = try JSONDecoder().decode(JSONSchemaValue.self, from: data)
+                } catch {
+                    return ToolResult(
+                        callId: call.id,
+                        content: "arguments are not valid JSON: \(error)",
+                        errorKind: .invalidArguments
+                    )
+                }
+            } else {
+                return ToolResult(
+                    callId: call.id,
+                    content: "arguments are not valid JSON: non-UTF8 payload",
+                    errorKind: .invalidArguments
+                )
+            }
+
+            do {
+                let raw = try await executor.execute(arguments: parsed)
+                if Task.isCancelled {
+                    return ToolResult(
+                        callId: call.id,
+                        content: "cancelled by user",
+                        errorKind: .cancelled
+                    )
+                }
+                return ToolResult(callId: call.id, content: raw.content, errorKind: raw.errorKind)
+            } catch is CancellationError {
+                return ToolResult(callId: call.id, content: "cancelled by user", errorKind: .cancelled)
+            } catch {
+                if Task.isCancelled {
+                    return ToolResult(callId: call.id, content: "cancelled by user", errorKind: .cancelled)
+                }
+                return ToolResult(
+                    callId: call.id,
+                    content: String(describing: error),
+                    errorKind: .permanent
+                )
+            }
+        }
+    }
+}

--- a/Sources/BaseChatInference/Services/ToolRegistry.swift
+++ b/Sources/BaseChatInference/Services/ToolRegistry.swift
@@ -50,12 +50,57 @@ public protocol JSONSchemaValidating: Sendable {
 /// an actor would force a hop on every dispatch for no benefit. The executor's
 /// async `execute` call may still suspend off the main actor inside its own
 /// implementation.
+///
+/// ## Reentrancy
+///
+/// MainActor isolation serialises *entry* into ``register(_:)``,
+/// ``unregister(name:)``, and ``dispatch(_:)``, but `await
+/// executor.execute(arguments:)` inside ``dispatch(_:)`` suspends the
+/// current task. While that suspension is in flight, another MainActor
+/// caller can enter the registry and mutate the tool table — register
+/// a replacement, unregister the in-flight tool, swap the validator, or
+/// adjust the ``outputPolicy``.
+///
+/// The dispatch contract is:
+///
+/// > ``ToolRegistry`` captures the executor at dispatch entry. Registry
+/// > mutations during a suspended dispatch do not affect that dispatch's
+/// > outcome — the originally-resolved executor runs to completion.
+/// > Subsequent dispatches see the mutated state.
+///
+/// Concretely:
+///
+/// - The executor is looked up exactly once, at the top of ``dispatch(_:)``.
+///   The local `executor` reference holds the value; later table mutations
+///   on the same name do not retarget it.
+/// - The ``outputPolicy`` and ``validator`` references are also captured
+///   into local constants at dispatch entry, so a mid-flight policy swap
+///   only affects subsequent dispatches.
+/// - Snapshots taken from ``definitions`` reflect whatever state the
+///   table is in when the snapshot is read. Mid-dispatch mutations are
+///   visible immediately — the registry doesn't hide the change, it
+///   merely refuses to retarget the in-flight call.
+///
+/// As an observability hook, ``unregister(name:)`` emits a warning when
+/// it drops a tool that has at least one dispatch in flight. The
+/// in-flight dispatch still completes against the originally-resolved
+/// executor; the warning exists so ad-hoc registry juggling is visible
+/// in the inference log.
 @MainActor public final class ToolRegistry {
 
     // MARK: Storage
 
     /// Keyed on the lowercased tool name for case-insensitive lookup.
     private var tools: [String: any ToolExecutor] = [:]
+
+    /// In-flight dispatch counter, keyed on the lowercased tool name.
+    ///
+    /// Incremented at the top of ``dispatch(_:)`` once the executor has
+    /// been resolved, decremented in `defer`. ``unregister(name:)``
+    /// reads this to decide whether to log the
+    /// "unregistering while dispatch is in flight" warning. The counter
+    /// is single-threaded — every mutator hops the MainActor first.
+    private var dispatchesInFlight: [String: Int] = [:]
 
     // MARK: Configuration
 
@@ -66,6 +111,19 @@ public protocol JSONSchemaValidating: Sendable {
     /// concrete ``JSONSchemaValidator`` (or any other ``JSONSchemaValidating``
     /// conformer) so failures come back as ``ToolResult/ErrorKind/invalidArguments``.
     public var validator: (any JSONSchemaValidating)? = nil
+
+    /// Size policy applied to tool results before they are returned from
+    /// ``dispatch(_:)``.
+    ///
+    /// Defaults to ``ToolOutputPolicy``'s default — 32 KB
+    /// (``OversizeAction/rejectWithError``). See ``ToolOutputPolicy`` for
+    /// guidance on when to raise the ceiling (long file reads on
+    /// large-context backends) versus keep the default.
+    ///
+    /// The policy is captured into a local constant at dispatch entry, so
+    /// changing it mid-dispatch only affects subsequent dispatches —
+    /// matching the reentrancy contract on the registry itself.
+    public var outputPolicy: ToolOutputPolicy = ToolOutputPolicy()
 
     // MARK: - Init
 
@@ -104,8 +162,20 @@ public protocol JSONSchemaValidating: Sendable {
     }
 
     /// Removes a tool by name. No-op when the name is not registered.
+    ///
+    /// When the named tool has at least one in-flight dispatch, this method
+    /// logs an observability warning before removing the entry. The
+    /// in-flight dispatch still completes against the executor that was
+    /// resolved at its entry point — see the type-level "Reentrancy"
+    /// section.
     public func unregister(name: String) {
-        tools.removeValue(forKey: name.lowercased())
+        let key = name.lowercased()
+        if let inFlight = dispatchesInFlight[key], inFlight > 0 {
+            Log.inference.warning(
+                "ToolRegistry: unregistering '\(name, privacy: .public)' while a dispatch for that tool is in flight; the in-flight dispatch will complete with the originally-resolved executor"
+            )
+        }
+        tools.removeValue(forKey: key)
     }
 
     /// Returns `true` when a tool is registered under `name` (case-insensitive).
@@ -180,6 +250,24 @@ public protocol JSONSchemaValidating: Sendable {
             )
         }
 
+        // Capture mutable configuration into local constants so a mid-flight
+        // mutation of `outputPolicy`/`validator` does not retarget this
+        // dispatch. See the type-level "Reentrancy" section.
+        let policy = outputPolicy
+        let activeValidator = validator
+
+        // Track this dispatch as in-flight so unregister(name:) can emit an
+        // observability warning if the registry is mutated mid-dispatch.
+        dispatchesInFlight[key, default: 0] += 1
+        defer {
+            let remaining = (dispatchesInFlight[key] ?? 1) - 1
+            if remaining <= 0 {
+                dispatchesInFlight.removeValue(forKey: key)
+            } else {
+                dispatchesInFlight[key] = remaining
+            }
+        }
+
         // 2. Parse the raw argument JSON.
         let parsedArguments: JSONSchemaValue
         if call.arguments.isEmpty {
@@ -207,8 +295,8 @@ public protocol JSONSchemaValidating: Sendable {
         }
 
         // 3. Optional schema validation (wave 2 wiring).
-        if let validator,
-           let message = validator.validateAgainst(executor.definition.parameters, value: parsedArguments) {
+        if let activeValidator,
+           let message = activeValidator.validateAgainst(executor.definition.parameters, value: parsedArguments) {
             return ToolResult(
                 callId: call.id,
                 content: "arguments failed schema validation: \(message)",
@@ -216,7 +304,8 @@ public protocol JSONSchemaValidating: Sendable {
             )
         }
 
-        // 4. Execute and stamp callId.
+        // 4. Execute, stamp callId, and apply the size policy.
+        let outcome: ToolResult
         do {
             let raw = try await executor.execute(arguments: parsedArguments)
             // If the surrounding task was cancelled but the executor returned
@@ -230,7 +319,7 @@ public protocol JSONSchemaValidating: Sendable {
                     errorKind: .cancelled
                 )
             }
-            return ToolResult(
+            outcome = ToolResult(
                 callId: call.id,
                 content: raw.content,
                 errorKind: raw.errorKind
@@ -260,5 +349,127 @@ public protocol JSONSchemaValidating: Sendable {
                 errorKind: .permanent
             )
         }
+
+        return Self.applyOutputPolicy(policy, to: outcome)
+    }
+
+    // MARK: - Output policy
+
+    /// Applies ``outputPolicy`` to a finalized ``ToolResult``.
+    ///
+    /// Behaviour:
+    ///
+    /// - Successful results that fit within ``ToolOutputPolicy/maxBytes``
+    ///   pass through unchanged.
+    /// - Successful results that exceed the ceiling are rejected,
+    ///   truncated, or allowed according to ``ToolOutputPolicy/onOversize``.
+    /// - Already-errored results bypass the ``OversizeAction`` switch:
+    ///   re-classifying a `.permanent` error as `.invalidArguments` would
+    ///   confuse the model's retry logic, so oversize error content is
+    ///   simply truncated to ``ToolOutputPolicy/maxBytes`` while
+    ///   preserving the original ``ToolResult/errorKind``. Error messages
+    ///   that overflow the budget are pathological enough that the
+    ///   trimmed payload is always more useful than a hard reject.
+    /// - ``OversizeAction/allow`` skips the ceiling entirely (debug only).
+    static func applyOutputPolicy(
+        _ policy: ToolOutputPolicy,
+        to result: ToolResult
+    ) -> ToolResult {
+        let byteLength = result.content.utf8.count
+        if byteLength <= policy.maxBytes {
+            return result
+        }
+
+        // Already-errored results: keep the original errorKind, just trim.
+        if result.errorKind != nil {
+            return ToolResult(
+                callId: result.callId,
+                content: truncateUTF8(result.content, toByteLimit: policy.maxBytes),
+                errorKind: result.errorKind
+            )
+        }
+
+        switch policy.onOversize {
+        case .allow:
+            return result
+
+        case .rejectWithError:
+            return ToolResult(
+                callId: result.callId,
+                content: "output exceeds maxBytes (\(byteLength) > \(policy.maxBytes))",
+                errorKind: .invalidArguments
+            )
+
+        case .truncate(let suffix):
+            let suffixBytes = suffix.utf8.count
+            // Degenerate: suffix alone overflows the budget. Fall back to a
+            // best-effort truncation of the suffix itself so we still emit
+            // something within the byte limit.
+            if suffixBytes >= policy.maxBytes {
+                return ToolResult(
+                    callId: result.callId,
+                    content: truncateUTF8(suffix, toByteLimit: policy.maxBytes),
+                    errorKind: nil
+                )
+            }
+            let bodyBudget = policy.maxBytes - suffixBytes
+            let trimmed = truncateUTF8(result.content, toByteLimit: bodyBudget)
+            return ToolResult(
+                callId: result.callId,
+                content: trimmed + suffix,
+                errorKind: nil
+            )
+        }
+    }
+
+    /// Trims `string` so its UTF-8 byte length is `<= byteLimit` without
+    /// splitting a multi-byte codepoint.
+    ///
+    /// Walks back from the limit until we find a byte that begins a UTF-8
+    /// scalar (i.e. is not a continuation byte `0b10xxxxxx`). Cheap and
+    /// boundary-safe for any Swift `String`.
+    static func truncateUTF8(_ string: String, toByteLimit byteLimit: Int) -> String {
+        if byteLimit <= 0 { return "" }
+        let utf8 = string.utf8
+        if utf8.count <= byteLimit { return string }
+
+        var endIndex = utf8.index(utf8.startIndex, offsetBy: byteLimit)
+        // Walk back past continuation bytes (10xxxxxx) so we don't slice
+        // mid-codepoint. The leading byte of any valid UTF-8 scalar has
+        // top bits 0xxxxxxx, 110xxxxx, 1110xxxx, or 11110xxx — never
+        // 10xxxxxx.
+        while endIndex > utf8.startIndex {
+            let byte = utf8[utf8.index(before: endIndex)]
+            if (byte & 0b1100_0000) == 0b1000_0000 {
+                endIndex = utf8.index(before: endIndex)
+            } else {
+                // The byte before endIndex is a leading byte. We need to
+                // confirm the scalar starting there fits entirely within
+                // the limit; if not, drop it.
+                let leadingIndex = utf8.index(before: endIndex)
+                let leading = utf8[leadingIndex]
+                let scalarLength: Int
+                if leading & 0b1000_0000 == 0 {
+                    scalarLength = 1
+                } else if leading & 0b1110_0000 == 0b1100_0000 {
+                    scalarLength = 2
+                } else if leading & 0b1111_0000 == 0b1110_0000 {
+                    scalarLength = 3
+                } else if leading & 0b1111_1000 == 0b1111_0000 {
+                    scalarLength = 4
+                } else {
+                    // Malformed leading byte — treat as 1 to make progress.
+                    scalarLength = 1
+                }
+                let scalarEnd = utf8.index(leadingIndex, offsetBy: scalarLength)
+                if scalarEnd <= endIndex {
+                    endIndex = scalarEnd
+                } else {
+                    endIndex = leadingIndex
+                }
+                break
+            }
+        }
+        return String(decoding: utf8[utf8.startIndex..<endIndex], as: UTF8.self)
     }
 }

--- a/Sources/BaseChatInference/Services/ToolRegistry.swift
+++ b/Sources/BaseChatInference/Services/ToolRegistry.swift
@@ -370,7 +370,9 @@ public protocol JSONSchemaValidating: Sendable {
     ///   preserving the original ``ToolResult/errorKind``. Error messages
     ///   that overflow the budget are pathological enough that the
     ///   trimmed payload is always more useful than a hard reject.
-    /// - ``OversizeAction/allow`` skips the ceiling entirely (debug only).
+    /// - ``OversizeAction/allow`` skips the ceiling only for non-errored
+    ///   oversize results; already-errored results are still trimmed as
+    ///   described above (debug only).
     static func applyOutputPolicy(
         _ policy: ToolOutputPolicy,
         to result: ToolResult

--- a/Tests/BaseChatInferenceTests/GenerationCoordinatorToolLoopTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationCoordinatorToolLoopTests.swift
@@ -261,6 +261,12 @@ final class GenerationCoordinatorToolLoopTests: XCTestCase {
             ToolResult(callId: "", content: giantContent, errorKind: nil)
         }
         let registry = ToolRegistry()
+        // The registry's default `ToolOutputPolicy` (32 KB rejectWithError)
+        // would short-circuit the 1 MiB payload at dispatch exit. This test
+        // covers the *coordinator's* byte-budget guard, which lives one
+        // layer up — opt out of registry enforcement so the giant payload
+        // still flows through.
+        registry.outputPolicy = ToolOutputPolicy(maxBytes: .max, onOversize: .allow)
         registry.register(executor)
 
         provider.backend.scriptedToolCallsPerTurn = [

--- a/Tests/BaseChatInferenceTests/ToolCallLoopOrchestratorTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolCallLoopOrchestratorTests.swift
@@ -1,0 +1,303 @@
+import XCTest
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Unit tests for ``ToolCallLoopOrchestrator`` (issue #443).
+///
+/// Coverage:
+/// - happy path: single-tool round-trip then a final text turn
+/// - step-limit cap: scripts more tool turns than the policy allows
+/// - loop detection: identical `(name, args)` repeated `loopDetectionWindow` times
+/// - cancellation: drop the consumer mid-stream and assert the backend was stopped
+/// - tool-error propagation: executor throws → result carries `.permanent`
+@MainActor
+final class ToolCallLoopOrchestratorTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Minimal executor whose handler is supplied at construction time.
+    private struct ScriptedExecutor: ToolExecutor {
+        let definition: ToolDefinition
+        let handler: @Sendable (JSONSchemaValue) async throws -> ToolResult
+
+        init(
+            name: String = "any_tool",
+            handler: @escaping @Sendable (JSONSchemaValue) async throws -> ToolResult
+        ) {
+            self.definition = ToolDefinition(name: name, description: "scripted", parameters: .object([:]))
+            self.handler = handler
+        }
+
+        func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+            try await handler(arguments)
+        }
+    }
+
+    private func makeBackend() -> MockInferenceBackend {
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        return backend
+    }
+
+    private func collect(
+        _ stream: AsyncThrowingStream<ToolLoopEvent, Error>
+    ) async throws -> [ToolLoopEvent] {
+        var events: [ToolLoopEvent] = []
+        for try await event in stream {
+            events.append(event)
+        }
+        return events
+    }
+
+    // MARK: - Happy path
+
+    func test_singleToolThenFinalText_emitsExpectedSequence() async throws {
+        let backend = makeBackend()
+        backend.scriptedToolCallsPerTurn = [
+            [ToolCall(id: "c-1", toolName: "any_tool", arguments: #"{"x":1}"#)],
+            [],
+        ]
+        backend.tokensToYieldPerTurn = [
+            [],
+            ["Hello", " world"],
+        ]
+
+        let executor = ScriptedExecutor { _ in
+            ToolResult(callId: "", content: "ok", errorKind: nil)
+        }
+
+        let orchestrator = ToolCallLoopOrchestrator(
+            backend: backend,
+            executor: executor,
+            policy: ToolCallLoopPolicy(maxSteps: 4)
+        )
+
+        let events = try await collect(orchestrator.run(
+            initialPrompt: "hi",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+
+        // Expected sequence: .toolCall → .toolResult → .token("Hello")
+        // → .token(" world") → .finished
+        XCTAssertEqual(events.count, 5, "events: \(events)")
+        guard case .toolCall(let call) = events[0] else {
+            return XCTFail("first event must be .toolCall, got \(events[0])")
+        }
+        XCTAssertEqual(call.id, "c-1")
+        XCTAssertEqual(call.toolName, "any_tool")
+
+        guard case .toolResult(let result) = events[1] else {
+            return XCTFail("second event must be .toolResult, got \(events[1])")
+        }
+        XCTAssertEqual(result.callId, "c-1")
+        XCTAssertEqual(result.content, "ok")
+        XCTAssertNil(result.errorKind)
+
+        XCTAssertEqual(events[2], .token("Hello"))
+        XCTAssertEqual(events[3], .token(" world"))
+        XCTAssertEqual(events[4], .finished)
+
+        // The orchestrator must have re-prompted with the result content
+        // appended verbatim — sabotage check pivot.
+        XCTAssertEqual(backend.generateCallCount, 2)
+        XCTAssertNotNil(backend.lastPrompt)
+        XCTAssertTrue(
+            backend.lastPrompt?.contains("Tool 'any_tool' result: ok") == true,
+            "second-turn prompt must contain the appended tool result; got: \(backend.lastPrompt ?? "nil")"
+        )
+    }
+
+    // MARK: - Step limit
+
+    func test_stepLimitReached_whenScriptExceedsBudget() async throws {
+        let backend = makeBackend()
+        // Five distinct tool turns, but maxSteps = 3 → loop must terminate
+        // with .stepLimitReached(steps: 3) before the fourth turn runs.
+        backend.scriptedToolCallsPerTurn = (0..<5).map { idx in
+            [ToolCall(id: "c-\(idx)", toolName: "spam", arguments: #"{"i":\#(idx)}"#)]
+        }
+        backend.tokensToYieldPerTurn = Array(repeating: [], count: 5)
+
+        let executor = ScriptedExecutor(name: "spam") { _ in
+            ToolResult(callId: "", content: "ok", errorKind: nil)
+        }
+
+        let orchestrator = ToolCallLoopOrchestrator(
+            backend: backend,
+            executor: executor,
+            policy: ToolCallLoopPolicy(maxSteps: 3, loopDetectionWindow: 99)
+        )
+
+        let events = try await collect(orchestrator.run(
+            initialPrompt: "go",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+
+        guard case .stepLimitReached(let steps) = events.last else {
+            return XCTFail("last event must be .stepLimitReached, got \(events)")
+        }
+        XCTAssertEqual(steps, 3)
+        XCTAssertEqual(backend.generateCallCount, 3)
+    }
+
+    // MARK: - Loop detection
+
+    func test_loopDetected_firesOnIdenticalCallsRepeated() async throws {
+        let backend = makeBackend()
+        let identical = ToolCall(id: "c", toolName: "spin", arguments: #"{"k":1}"#)
+        backend.scriptedToolCallsPerTurn = [
+            [identical], [identical], [identical], [identical], [identical],
+        ]
+        backend.tokensToYieldPerTurn = Array(repeating: [], count: 5)
+
+        let executor = ScriptedExecutor(name: "spin") { _ in
+            ToolResult(callId: "", content: "ok", errorKind: nil)
+        }
+
+        let orchestrator = ToolCallLoopOrchestrator(
+            backend: backend,
+            executor: executor,
+            policy: ToolCallLoopPolicy(maxSteps: 10, loopDetectionWindow: 3)
+        )
+
+        let events = try await collect(orchestrator.run(
+            initialPrompt: "go",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+
+        guard case .loopDetected(let toolName) = events.last else {
+            return XCTFail("last event must be .loopDetected, got \(events)")
+        }
+        XCTAssertEqual(toolName, "spin")
+        // Loop must have fired on the third identical call — the third
+        // generate() round produced the third identical signature, so the
+        // backend was invoked exactly three times.
+        XCTAssertEqual(backend.generateCallCount, 3)
+    }
+
+    // MARK: - Cancellation
+
+    func test_cancellation_propagatesStopGeneration_andHaltsEvents() async throws {
+        let backend = makeBackend()
+        // Long token stream so the cancellation has time to land.
+        backend.tokensToYield = (0..<1_000).map { "tok\($0) " }
+
+        let executor = ScriptedExecutor { _ in
+            ToolResult(callId: "", content: "ok", errorKind: nil)
+        }
+
+        let orchestrator = ToolCallLoopOrchestrator(
+            backend: backend,
+            executor: executor,
+            policy: ToolCallLoopPolicy(maxSteps: 4)
+        )
+
+        let stream = orchestrator.run(
+            initialPrompt: "go",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        let consumer = Task {
+            var seen = 0
+            for try await _ in stream {
+                seen += 1
+                if seen >= 1 { break }
+            }
+            return seen
+        }
+
+        // Wait for the consumer to break out, which fires the stream's
+        // onTermination handler (driver.cancel + backend.stopGeneration).
+        _ = try await consumer.value
+
+        // onTermination is asynchronous; spin briefly until the stop count
+        // moves. Tight bound — under 100 ms in practice.
+        let deadline = ContinuousClock.now.advanced(by: .milliseconds(500))
+        while backend.stopCallCount == 0 && ContinuousClock.now < deadline {
+            await Task.yield()
+        }
+
+        XCTAssertGreaterThanOrEqual(
+            backend.stopCallCount,
+            1,
+            "backend.stopGeneration() must be invoked when the consumer drops the stream"
+        )
+    }
+
+    // MARK: - Tool error propagation
+
+    func test_executorThrows_resultClassifiedAsPermanent() async throws {
+        struct Boom: Error {}
+
+        let backend = makeBackend()
+        backend.scriptedToolCallsPerTurn = [
+            [ToolCall(id: "c-9", toolName: "boom", arguments: "{}")],
+            [],
+        ]
+        backend.tokensToYieldPerTurn = [[], ["done"]]
+
+        let executor = ScriptedExecutor(name: "boom") { _ in
+            throw Boom()
+        }
+
+        let orchestrator = ToolCallLoopOrchestrator(
+            backend: backend,
+            executor: executor,
+            policy: ToolCallLoopPolicy(maxSteps: 4)
+        )
+
+        let events = try await collect(orchestrator.run(
+            initialPrompt: "go",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+
+        let result = events.compactMap { event -> ToolResult? in
+            if case .toolResult(let r) = event { return r } else { return nil }
+        }.first
+
+        let unwrapped = try XCTUnwrap(result, "orchestrator must surface a .toolResult after the executor throws")
+        XCTAssertEqual(unwrapped.errorKind, .permanent)
+        XCTAssertEqual(unwrapped.callId, "c-9")
+    }
+
+    // MARK: - Registry init
+
+    func test_registryInit_routesByToolName() async throws {
+        let backend = makeBackend()
+        backend.scriptedToolCallsPerTurn = [
+            [ToolCall(id: "c-r", toolName: "registered", arguments: "{}")],
+            [],
+        ]
+        backend.tokensToYieldPerTurn = [[], ["bye"]]
+
+        let registry = ToolRegistry()
+        registry.register(ScriptedExecutor(name: "registered") { _ in
+            ToolResult(callId: "", content: "from-registry", errorKind: nil)
+        })
+
+        let orchestrator = ToolCallLoopOrchestrator(
+            backend: backend,
+            registry: registry,
+            policy: ToolCallLoopPolicy(maxSteps: 4)
+        )
+
+        let events = try await collect(orchestrator.run(
+            initialPrompt: "go",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+
+        let result = events.compactMap { event -> ToolResult? in
+            if case .toolResult(let r) = event { return r } else { return nil }
+        }.first
+
+        let unwrapped = try XCTUnwrap(result)
+        XCTAssertEqual(unwrapped.content, "from-registry")
+        XCTAssertEqual(unwrapped.callId, "c-r")
+    }
+}

--- a/Tests/BaseChatInferenceTests/ToolOutputPolicyTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolOutputPolicyTests.swift
@@ -174,4 +174,19 @@ final class ToolOutputPolicyTests: XCTestCase {
         XCTAssertNil(result.errorKind)
         XCTAssertEqual(result.content, "{\"answer\":42}")
     }
+
+    // MARK: - negative maxBytes is clamped to 0
+
+    func test_negativeMaxBytes_isClampedToZero_atInit() {
+        // Negative values would otherwise make every successful result oversize
+        // and produce confusing "exceeds maxBytes (5 > -1)" diagnostics.
+        let policy = ToolOutputPolicy(maxBytes: -1, onOversize: .rejectWithError)
+        XCTAssertEqual(policy.maxBytes, 0)
+    }
+
+    func test_negativeMaxBytes_isClampedToZero_onSetterMutation() {
+        var policy = ToolOutputPolicy(maxBytes: 1024)
+        policy.maxBytes = -100
+        XCTAssertEqual(policy.maxBytes, 0)
+    }
 }

--- a/Tests/BaseChatInferenceTests/ToolOutputPolicyTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolOutputPolicyTests.swift
@@ -1,0 +1,177 @@
+import XCTest
+@testable import BaseChatInference
+
+/// Tests for ``ToolOutputPolicy`` enforcement at the ``ToolRegistry`` dispatch
+/// boundary.
+///
+/// Coverage:
+/// - rejection (the default action) replaces oversize content with an
+///   `.invalidArguments` error and embeds the byte counts in the message
+/// - truncation trims at a UTF-8 boundary and appends the suffix; total
+///   byte count stays at-or-below `maxBytes`
+/// - allow passes oversize content through unchanged
+/// - exact-boundary content passes through unchanged
+/// - multi-byte codepoints (CJK, emoji) never split mid-scalar
+/// - already-errored results bypass the action switch and are simply trimmed
+@MainActor
+final class ToolOutputPolicyTests: XCTestCase {
+
+    // MARK: Fixtures
+
+    /// Executor that returns a caller-supplied content string verbatim.
+    private struct FixedContentExecutor: ToolExecutor {
+        let definition: ToolDefinition
+        let content: String
+        let kind: ToolResult.ErrorKind?
+
+        init(name: String = "echo", content: String, kind: ToolResult.ErrorKind? = nil) {
+            self.definition = ToolDefinition(name: name, description: "echo", parameters: .object([:]))
+            self.content = content
+            self.kind = kind
+        }
+
+        func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+            ToolResult(callId: "", content: content, errorKind: kind)
+        }
+    }
+
+    private func makeCall(name: String = "echo") -> ToolCall {
+        ToolCall(id: "call-1", toolName: name, arguments: "{}")
+    }
+
+    // MARK: - rejectWithError
+
+    func test_oversizeContent_isRejected_withInvalidArgumentsKind_byDefault() async {
+        let registry = ToolRegistry()
+        registry.outputPolicy = ToolOutputPolicy(maxBytes: 16, onOversize: .rejectWithError)
+        let payload = String(repeating: "a", count: 64)
+        registry.register(FixedContentExecutor(content: payload))
+
+        let result = await registry.dispatch(makeCall())
+
+        XCTAssertEqual(result.errorKind, .invalidArguments)
+        XCTAssertTrue(result.content.contains("output exceeds maxBytes"))
+        XCTAssertTrue(result.content.contains("64"))
+        XCTAssertTrue(result.content.contains("16"))
+        XCTAssertEqual(result.callId, "call-1")
+    }
+
+    // MARK: - truncate
+
+    func test_oversizeContent_isTruncatedAndSuffixed_underTruncatePolicy() async {
+        let registry = ToolRegistry()
+        let suffix = "...[t]"
+        registry.outputPolicy = ToolOutputPolicy(
+            maxBytes: 32,
+            onOversize: .truncate(suffix: suffix)
+        )
+        let payload = String(repeating: "a", count: 200)
+        registry.register(FixedContentExecutor(content: payload))
+
+        let result = await registry.dispatch(makeCall())
+
+        XCTAssertNil(result.errorKind)
+        XCTAssertLessThanOrEqual(result.content.utf8.count, 32)
+        XCTAssertTrue(result.content.hasSuffix(suffix))
+        // Body bytes = maxBytes - suffix bytes = 32 - 6 = 26 'a's followed by suffix.
+        XCTAssertEqual(result.content, String(repeating: "a", count: 26) + suffix)
+    }
+
+    func test_truncatePolicy_respectsMultiByteUTF8Boundary_emoji() async {
+        let registry = ToolRegistry()
+        // Each rocket emoji is 4 UTF-8 bytes. With maxBytes = 10 and a 0-byte
+        // suffix budget (suffix = ""), two whole emojis (8 bytes) must fit;
+        // the third would push us to 12 bytes — drop it.
+        let suffix = ""
+        registry.outputPolicy = ToolOutputPolicy(
+            maxBytes: 10,
+            onOversize: .truncate(suffix: suffix)
+        )
+        let payload = String(repeating: "🚀", count: 5)
+        registry.register(FixedContentExecutor(content: payload))
+
+        let result = await registry.dispatch(makeCall())
+
+        XCTAssertNil(result.errorKind)
+        XCTAssertLessThanOrEqual(result.content.utf8.count, 10)
+        // Must round down to a whole codepoint count — never slice mid-emoji.
+        XCTAssertEqual(result.content, "🚀🚀")
+    }
+
+    func test_truncatePolicy_respectsMultiByteUTF8Boundary_cjk() async {
+        let registry = ToolRegistry()
+        // CJK characters are 3 UTF-8 bytes each. With maxBytes = 8 and an
+        // empty suffix, two characters (6 bytes) fit, the third would
+        // overflow.
+        registry.outputPolicy = ToolOutputPolicy(
+            maxBytes: 8,
+            onOversize: .truncate(suffix: "")
+        )
+        registry.register(FixedContentExecutor(content: "你好世界"))
+
+        let result = await registry.dispatch(makeCall())
+
+        XCTAssertNil(result.errorKind)
+        XCTAssertLessThanOrEqual(result.content.utf8.count, 8)
+        XCTAssertEqual(result.content, "你好")
+    }
+
+    // MARK: - allow
+
+    func test_allowPolicy_passesOversizeContentThrough() async {
+        let registry = ToolRegistry()
+        registry.outputPolicy = ToolOutputPolicy(maxBytes: 8, onOversize: .allow)
+        let payload = String(repeating: "z", count: 200)
+        registry.register(FixedContentExecutor(content: payload))
+
+        let result = await registry.dispatch(makeCall())
+
+        XCTAssertNil(result.errorKind)
+        XCTAssertEqual(result.content, payload)
+    }
+
+    // MARK: - exact boundary
+
+    func test_contentExactlyAtMaxBytes_passesThroughUnchanged() async {
+        let registry = ToolRegistry()
+        registry.outputPolicy = ToolOutputPolicy(maxBytes: 32, onOversize: .rejectWithError)
+        let payload = String(repeating: "x", count: 32)
+        registry.register(FixedContentExecutor(content: payload))
+
+        let result = await registry.dispatch(makeCall())
+
+        XCTAssertNil(result.errorKind)
+        XCTAssertEqual(result.content, payload)
+        XCTAssertEqual(result.content.utf8.count, 32)
+    }
+
+    // MARK: - errored results bypass action switch
+
+    func test_alreadyErroredResult_isTruncated_notReclassified() async {
+        let registry = ToolRegistry()
+        registry.outputPolicy = ToolOutputPolicy(maxBytes: 16, onOversize: .rejectWithError)
+        let big = String(repeating: "e", count: 200)
+        registry.register(FixedContentExecutor(content: big, kind: .permanent))
+
+        let result = await registry.dispatch(makeCall())
+
+        // The original errorKind is preserved; the policy doesn't reclassify
+        // an existing error as .invalidArguments.
+        XCTAssertEqual(result.errorKind, .permanent)
+        XCTAssertLessThanOrEqual(result.content.utf8.count, 16)
+        XCTAssertEqual(result.content, String(repeating: "e", count: 16))
+    }
+
+    // MARK: - default policy is permissive enough for typical results
+
+    func test_defaultPolicy_passesSmallSuccessfulResultUnchanged() async {
+        let registry = ToolRegistry()
+        // No outputPolicy override — exercise the type's default.
+        registry.register(FixedContentExecutor(content: "{\"answer\":42}"))
+
+        let result = await registry.dispatch(makeCall())
+
+        XCTAssertNil(result.errorKind)
+        XCTAssertEqual(result.content, "{\"answer\":42}")
+    }
+}

--- a/Tests/BaseChatInferenceTests/ToolRegistryReentrancyTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolRegistryReentrancyTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+@testable import BaseChatInference
+
+/// Integration tests for ``ToolRegistry``'s reentrancy contract:
+/// dispatches resolve their executor exactly once at entry, and registry
+/// mutations during a suspended dispatch do not retarget the in-flight call.
+@MainActor
+final class ToolRegistryReentrancyTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Executor that sleeps for a configurable duration before returning a
+    /// caller-supplied marker. Sleep is short enough to keep CI snappy; the
+    /// suspension is what the tests rely on, not the wall-clock time.
+    private struct SlowMarkerExecutor: ToolExecutor {
+        let definition: ToolDefinition
+        let marker: String
+        let sleep: Duration
+
+        init(name: String, marker: String, sleep: Duration = .milliseconds(150)) {
+            self.definition = ToolDefinition(name: name, description: "marker", parameters: .object([:]))
+            self.marker = marker
+            self.sleep = sleep
+        }
+
+        func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+            try await Task.sleep(for: sleep)
+            return ToolResult(callId: "", content: marker, errorKind: nil)
+        }
+    }
+
+    /// Fast executor used as the post-mutation replacement.
+    private struct FastMarkerExecutor: ToolExecutor {
+        let definition: ToolDefinition
+        let marker: String
+
+        init(name: String, marker: String) {
+            self.definition = ToolDefinition(name: name, description: "marker", parameters: .object([:]))
+            self.marker = marker
+        }
+
+        func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+            ToolResult(callId: "", content: marker, errorKind: nil)
+        }
+    }
+
+    private func makeCall(name: String, id: String = "call-1") -> ToolCall {
+        ToolCall(id: id, toolName: name, arguments: "{}")
+    }
+
+    // MARK: - Mid-dispatch register replaces the executor for *future* dispatches
+
+    func test_midDispatchRegister_doesNotRetargetInflightDispatch() async throws {
+        let registry = ToolRegistry()
+        let slowA = SlowMarkerExecutor(name: "weather", marker: "A-result")
+        registry.register(slowA)
+
+        // Kick off the slow dispatch in a child task. It will suspend inside
+        // execute(arguments:) for ~150 ms, giving us a window to mutate.
+        let call = makeCall(name: "weather", id: "first")
+        let firstTask = Task { @MainActor in
+            await registry.dispatch(call)
+        }
+
+        // Yield, then mutate the registry mid-flight. A short sleep guarantees
+        // the dispatch has already entered the suspension before we swap.
+        try await Task.sleep(for: .milliseconds(20))
+        registry.register(FastMarkerExecutor(name: "weather", marker: "B-result"))
+
+        let firstAwaited = await firstTask.value
+        XCTAssertEqual(firstAwaited.content, "A-result")
+        XCTAssertNil(firstAwaited.errorKind)
+
+        // The second dispatch sees the post-mutation table.
+        let second = await registry.dispatch(makeCall(name: "weather", id: "second"))
+        XCTAssertEqual(second.content, "B-result")
+        XCTAssertNil(second.errorKind)
+    }
+
+    // MARK: - Mid-dispatch unregister still completes the in-flight call
+
+    func test_midDispatchUnregister_inflightDispatchCompletes_secondDispatchIsUnknown() async throws {
+        let registry = ToolRegistry()
+        registry.register(SlowMarkerExecutor(name: "weather", marker: "A-result"))
+
+        let call = makeCall(name: "weather", id: "first")
+        let firstTask = Task { @MainActor in
+            await registry.dispatch(call)
+        }
+
+        try await Task.sleep(for: .milliseconds(20))
+        // The unregister-while-in-flight path emits a Log.inference.warning;
+        // we verify behaviour, not the log line.
+        registry.unregister(name: "weather")
+
+        let firstAwaited = await firstTask.value
+        XCTAssertEqual(firstAwaited.content, "A-result")
+        XCTAssertNil(firstAwaited.errorKind)
+
+        let second = await registry.dispatch(makeCall(name: "weather", id: "second"))
+        XCTAssertEqual(second.errorKind, .unknownTool)
+    }
+
+    // MARK: - definitions snapshot reflects the post-mutation state mid-dispatch
+
+    func test_definitionsSnapshot_takenMidDispatch_reflectsPostMutationState() async throws {
+        let registry = ToolRegistry()
+        registry.register(SlowMarkerExecutor(name: "weather", marker: "A-result"))
+
+        let call = makeCall(name: "weather", id: "first")
+        let firstTask = Task { @MainActor in
+            await registry.dispatch(call)
+        }
+
+        try await Task.sleep(for: .milliseconds(20))
+
+        // Snapshot reflects the *current* table, even though a dispatch is
+        // suspended against an entry that's about to be replaced.
+        let beforeReplacement = registry.definitions.map(\.name)
+        XCTAssertEqual(beforeReplacement, ["weather"])
+
+        registry.register(FastMarkerExecutor(name: "calculator", marker: "calc"))
+        registry.unregister(name: "weather")
+
+        let afterMutation = registry.definitions.map(\.name)
+        XCTAssertEqual(afterMutation, ["calculator"])
+
+        // The in-flight dispatch still completes against the original
+        // executor — the mutation is visible to readers but doesn't
+        // retarget the call.
+        let firstAwaited = await firstTask.value
+        XCTAssertEqual(firstAwaited.content, "A-result")
+    }
+}

--- a/Tests/BaseChatInferenceTests/ToolRegistryReentrancyTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolRegistryReentrancyTests.swift
@@ -9,24 +9,66 @@ final class ToolRegistryReentrancyTests: XCTestCase {
 
     // MARK: - Fixtures
 
-    /// Executor that sleeps for a configurable duration before returning a
-    /// caller-supplied marker. Sleep is short enough to keep CI snappy; the
-    /// suspension is what the tests rely on, not the wall-clock time.
-    private struct SlowMarkerExecutor: ToolExecutor {
+    /// Executor that signals when it enters its sleep, then waits for an
+    /// explicit "release" signal before returning. Synchronisation goes
+    /// through `AsyncStream` continuations so the test never depends on
+    /// wall-clock scheduling — `entered` fires as soon as the executor is
+    /// suspended, and the executor only resumes after the test sends a
+    /// value on `release`.
+    private struct GatedMarkerExecutor: ToolExecutor {
         let definition: ToolDefinition
         let marker: String
-        let sleep: Duration
+        let entered: AsyncStream<Void>.Continuation
+        let release: AsyncStream<Void>
 
-        init(name: String, marker: String, sleep: Duration = .milliseconds(150)) {
+        init(
+            name: String,
+            marker: String,
+            entered: AsyncStream<Void>.Continuation,
+            release: AsyncStream<Void>
+        ) {
             self.definition = ToolDefinition(name: name, description: "marker", parameters: .object([:]))
             self.marker = marker
-            self.sleep = sleep
+            self.entered = entered
+            self.release = release
         }
 
         func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
-            try await Task.sleep(for: sleep)
+            entered.yield()
+            // Wait until the test releases us. Using AsyncStream.first(where:)
+            // gives us a deterministic suspension point we can resume on
+            // demand, with no fixed sleep.
+            for await _ in release { break }
             return ToolResult(callId: "", content: marker, errorKind: nil)
         }
+    }
+
+    /// Builds a paired (executor, releaser, enteredSignal) trio for use
+    /// across the tests. The releaser closure is what unblocks the
+    /// executor once mid-dispatch mutations are in place.
+    private func makeGatedExecutor(
+        name: String,
+        marker: String
+    ) -> (executor: GatedMarkerExecutor, release: () -> Void, entered: AsyncStream<Void>) {
+        let (enteredStream, enteredCont) = AsyncStream.makeStream(of: Void.self)
+        let (releaseStream, releaseCont) = AsyncStream.makeStream(of: Void.self)
+        let executor = GatedMarkerExecutor(
+            name: name,
+            marker: marker,
+            entered: enteredCont,
+            release: releaseStream
+        )
+        let release = {
+            releaseCont.yield()
+            releaseCont.finish()
+        }
+        return (executor, release, enteredStream)
+    }
+
+    /// Awaits the executor's "I'm suspended" signal so the caller knows
+    /// it's safe to mutate the registry without racing the dispatch.
+    private func awaitEntered(_ entered: AsyncStream<Void>) async {
+        for await _ in entered { return }
     }
 
     /// Fast executor used as the post-mutation replacement.
@@ -52,21 +94,24 @@ final class ToolRegistryReentrancyTests: XCTestCase {
 
     func test_midDispatchRegister_doesNotRetargetInflightDispatch() async throws {
         let registry = ToolRegistry()
-        let slowA = SlowMarkerExecutor(name: "weather", marker: "A-result")
-        registry.register(slowA)
+        let (gatedA, releaseA, enteredA) = makeGatedExecutor(name: "weather", marker: "A-result")
+        registry.register(gatedA)
 
-        // Kick off the slow dispatch in a child task. It will suspend inside
-        // execute(arguments:) for ~150 ms, giving us a window to mutate.
+        // Kick off the gated dispatch in a child task. It signals when it
+        // enters the suspension and waits for `releaseA()` to resume.
         let call = makeCall(name: "weather", id: "first")
         let firstTask = Task { @MainActor in
             await registry.dispatch(call)
         }
 
-        // Yield, then mutate the registry mid-flight. A short sleep guarantees
-        // the dispatch has already entered the suspension before we swap.
-        try await Task.sleep(for: .milliseconds(20))
+        // Wait for the executor's "entered" signal, then mutate the registry
+        // mid-flight. No wall-clock sleep — `awaitEntered` returns the moment
+        // the executor suspends.
+        await awaitEntered(enteredA)
         registry.register(FastMarkerExecutor(name: "weather", marker: "B-result"))
 
+        // Now release the in-flight executor so it can complete.
+        releaseA()
         let firstAwaited = await firstTask.value
         XCTAssertEqual(firstAwaited.content, "A-result")
         XCTAssertNil(firstAwaited.errorKind)
@@ -81,17 +126,19 @@ final class ToolRegistryReentrancyTests: XCTestCase {
 
     func test_midDispatchUnregister_inflightDispatchCompletes_secondDispatchIsUnknown() async throws {
         let registry = ToolRegistry()
-        registry.register(SlowMarkerExecutor(name: "weather", marker: "A-result"))
+        let (gated, release, entered) = makeGatedExecutor(name: "weather", marker: "A-result")
+        registry.register(gated)
 
         let call = makeCall(name: "weather", id: "first")
         let firstTask = Task { @MainActor in
             await registry.dispatch(call)
         }
 
-        try await Task.sleep(for: .milliseconds(20))
+        await awaitEntered(entered)
         // The unregister-while-in-flight path emits a Log.inference.warning;
         // we verify behaviour, not the log line.
         registry.unregister(name: "weather")
+        release()
 
         let firstAwaited = await firstTask.value
         XCTAssertEqual(firstAwaited.content, "A-result")
@@ -105,14 +152,15 @@ final class ToolRegistryReentrancyTests: XCTestCase {
 
     func test_definitionsSnapshot_takenMidDispatch_reflectsPostMutationState() async throws {
         let registry = ToolRegistry()
-        registry.register(SlowMarkerExecutor(name: "weather", marker: "A-result"))
+        let (gated, release, entered) = makeGatedExecutor(name: "weather", marker: "A-result")
+        registry.register(gated)
 
         let call = makeCall(name: "weather", id: "first")
         let firstTask = Task { @MainActor in
             await registry.dispatch(call)
         }
 
-        try await Task.sleep(for: .milliseconds(20))
+        await awaitEntered(entered)
 
         // Snapshot reflects the *current* table, even though a dispatch is
         // suspended against an entry that's about to be replaced.
@@ -124,6 +172,8 @@ final class ToolRegistryReentrancyTests: XCTestCase {
 
         let afterMutation = registry.definitions.map(\.name)
         XCTAssertEqual(afterMutation, ["calculator"])
+
+        release()
 
         // The in-flight dispatch still completes against the original
         // executor — the mutation is visible to readers but doesn't


### PR DESCRIPTION
## Summary

Three closely-related additions to `BaseChatInference` shipped together:

- **#443** — `ToolCallLoopOrchestrator`: a public, generic agent-loop driver (generate → tool-call → execute → feed-result → generate) operating directly on `InferenceBackend` + `ToolExecutor` (or `ToolRegistry`). Cancellation, step budget, per-step timeout, and identical-call loop detection are built in. `InferenceService` is unchanged.
- **#628** — `ToolOutputPolicy`: explicit size policy on `ToolRegistry` (default `maxBytes: 32_768`, `.rejectWithError`) applied at dispatch exit. Truncation is UTF-8-boundary-safe; already-errored results are trimmed (not reclassified) when oversize.
- **#631** — `ToolRegistry` reentrancy contract documented; observability warning when `unregister` runs while a dispatch for that name is in flight; integration tests prove the in-flight dispatch keeps the originally-resolved executor while subsequent dispatches see the mutated state.

## Changes

**New**
- `Sources/BaseChatInference/Services/ToolCallLoopOrchestrator.swift`
- `Sources/BaseChatInference/Models/ToolOutputPolicy.swift`
- `Tests/BaseChatInferenceTests/ToolCallLoopOrchestratorTests.swift` (6 tests)
- `Tests/BaseChatInferenceTests/ToolOutputPolicyTests.swift` (8 tests)
- `Tests/BaseChatInferenceTests/ToolRegistryReentrancyTests.swift` (3 tests)

**Edited**
- `Sources/BaseChatInference/Services/ToolRegistry.swift` — `outputPolicy` field, in-flight counter + warning on `unregister`-during-dispatch, "Reentrancy" DocC section
- `Tests/BaseChatInferenceTests/GenerationCoordinatorToolLoopTests.swift` — opt one pre-existing 1 MiB byte-budget test out of registry enforcement (set `outputPolicy = ToolOutputPolicy(maxBytes: .max, onOversize: .allow)`) so it continues to exercise the coordinator's guard rather than tripping the new default registry policy

## Notable design choices

- **Orchestrator API**: provides both `init(backend:executor:policy:)` and `init(backend:registry:policy:)` so single-tool callers stay simple while multi-tool callers route through `ToolRegistry`. Tool-result threading is the lowest-common-denominator string append (`"\n\nTool '<name>' result: <content>\n"`); DocC notes that callers wanting a structured `tool` role should use `GenerationCoordinator` instead.
- **Per-step timeout**: surfaces as a dedicated `ToolLoopError.stepTimedOut(step:)` thrown into the stream; orchestrator also calls `backend.stopGeneration()` on timeout.
- **Output policy on errored results**: `OversizeAction` only applies to successful results; already-errored results are simply trimmed to `maxBytes` while preserving the original `errorKind`. Prevents re-classifying `.permanent` as `.invalidArguments` purely for size reasons.
- **Reentrancy warning** uses a `[String: Int]` in-flight counter on `ToolRegistry` (single-threaded — all entry points are `@MainActor`-isolated).

## Test plan

- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 1145 tests, 0 failures
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 228 tests, 0 failures
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 501 tests, 0 failures
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 13 tests, 0 failures
- [x] `swift test --filter BaseChatTestSupportTests --disable-default-traits` — 3 tests, 0 failures
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits` — 69 tests, 0 failures
- [x] Sabotage check performed on `test_loopDetected_firesOnIdenticalCallsRepeated` (orchestrator) and on the policy gate in `ToolOutputPolicyTests`; both failed when the relevant branch was disabled, then restored.

## Release notes

### Tool-call loop orchestrator

Adds `ToolCallLoopOrchestrator`, a reusable agent-loop primitive in `BaseChatInference`. Drives generate → tool-call → execute → feed-result → generate with a configurable `ToolCallLoopPolicy` (max steps, per-step timeout, identical-call loop detection window). Streams tokens, tool calls, and tool results through a single `AsyncThrowingStream<ToolLoopEvent, Error>`; `Task.cancel()` propagates to `backend.stopGeneration()` and stops cleanly with no post-cancellation events. Existing `InferenceService` is unchanged.

\`\`\`swift
let orchestrator = ToolCallLoopOrchestrator(
    backend: backend,
    registry: registry,
    policy: ToolCallLoopPolicy(maxSteps: 8, loopDetectionWindow: 3)
)
for try await event in orchestrator.run(initialPrompt: "...", systemPrompt: nil, config: config) {
    switch event {
    case .token(let s):       print(s, terminator: "")
    case .toolCall(let call): print("→", call.toolName)
    case .toolResult(let r):  print("←", r.content.prefix(64))
    case .stepLimitReached, .loopDetected, .finished, .usage: break
    }
}
\`\`\`

Closes #443.

### ToolOutputPolicy — size limits at the registry

Adds `ToolOutputPolicy` on `ToolRegistry`. Tool results larger than `maxBytes` (default 32 KiB ≈ 8K tokens) are rejected with `.invalidArguments` so the model can self-correct, truncated with a configurable suffix, or allowed through unbounded — the host picks per `OversizeAction`. Truncation is UTF-8-boundary-safe; already-errored results are trimmed (not reclassified) when oversize.

\`\`\`swift
let registry = ToolRegistry(tools: [...])
registry.outputPolicy = ToolOutputPolicy(
    maxBytes: 65_536,
    onOversize: .truncate(suffix: "\n... [truncated]")
)
\`\`\`

Closes #628.

### ToolRegistry reentrancy contract

Documents and tests `ToolRegistry`'s reentrancy semantics: a dispatch in flight retains the originally-resolved executor across `await` suspensions even when the registry is mutated; subsequent dispatches see the mutated state. `unregister` now logs a warning when called while a dispatch for that name is in flight (observability only — does not block).

Closes #631.

🤖 Generated with [Claude Code](https://claude.com/claude-code)