### PR TITLE
feat: thinking cross-cutting bundle — OpenAI Responses, Jinja marker discovery, MockMLX hooks

### DIFF
--- a/Sources/BaseChatBackends/DefaultBackends.swift
+++ b/Sources/BaseChatBackends/DefaultBackends.swift
@@ -67,6 +67,7 @@ public enum DefaultBackends {
         #if CloudSaaS
         case .claude:                     return "ClaudeBackend"
         case .openAI, .lmStudio, .custom: return "OpenAIBackend"
+        case .openAIResponses:            return "OpenAIResponsesBackend"
         #endif
         #if Ollama
         case .ollama:                     return "OllamaBackend"
@@ -122,6 +123,7 @@ public enum DefaultBackends {
             #if CloudSaaS
             case .claude:                     return ClaudeBackend()
             case .openAI, .lmStudio, .custom: return OpenAIBackend()
+            case .openAIResponses:            return OpenAIResponsesBackend()
             #endif
             #if Ollama
             // FIXME(#714): expected deprecation warning until the next major

--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -103,6 +103,13 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
     /// Guarded by `stateLock`. Non-nil after a successful prompt decode; nil after reset.
     private var sessionKVState: SessionKVState?
 
+    /// Thinking-marker pair auto-detected from the GGUF's `tokenizer.chat_template`.
+    /// `nil` when the model is not loaded, the chat template is missing, or no
+    /// known marker pair was found in the template. `GenerationConfig.thinkingMarkers`
+    /// always overrides this — see the generate path below.
+    /// Guarded by `stateLock`.
+    private var _autoDetectedThinkingMarkers: ThinkingMarkers?
+
     // MARK: - Memory Pressure
 
     /// Monitors OS-level memory pressure so the decode loop can be aborted before
@@ -203,6 +210,7 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
             self.vocab = loadedResources.vocab
             self.isModelLoaded = true
             self._effectiveContextSize = loadedResources.effectiveContextSize
+            self._autoDetectedThinkingMarkers = loadedResources.autoDetectedThinkingMarkers
             return true
         }
 
@@ -344,6 +352,10 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
             }
 
             let driver = LlamaGenerationDriver()
+            // Manual override beats auto-detection. When neither is present,
+            // markers stays nil and the driver skips ThinkingParser entirely.
+            let autoDetected = self.withStateLock { self._autoDetectedThinkingMarkers }
+            let resolvedMarkers = config.thinkingMarkers ?? autoDetected
             let kvCoherent = await driver.run(
                 context: context,
                 vocab: vocab,
@@ -351,7 +363,7 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
                 reuseLen: reuseLen,
                 maxTokens: maxTokens,
                 config: config,
-                markers: config.thinkingMarkers,
+                markers: resolvedMarkers,
                 isCancelled: {
                     Task.isCancelled || self.cancelled.load(ordering: .sequentiallyConsistent)
                 },
@@ -442,6 +454,7 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         isModelLoaded = false
         isGenerating = false
         sessionKVState = nil
+        _autoDetectedThinkingMarkers = nil
         stateLock.unlock()
 
         capturedTask?.cancel()

--- a/Sources/BaseChatBackends/LlamaGenerationDriver.swift
+++ b/Sources/BaseChatBackends/LlamaGenerationDriver.swift
@@ -54,7 +54,10 @@ struct LlamaGenerationDriver {
     ///   - config: Sampling parameters (temperature, topP, repeatPenalty).
     ///   - markers: Thinking markers for the active template, or nil to disable ThinkingParser.
     ///     When non-nil, `.thinkingToken` / `.thinkingComplete` events are emitted for reasoning
-    ///     content and `config.maxThinkingTokens` is enforced.
+    ///     content and `config.maxThinkingTokens` is enforced. When nil, every decoded chunk
+    ///     surfaces as a plain `.token` event — there is no longer a sniff-mode fallback that
+    ///     retroactively engages the parser on raw `<think>` substrings; auto-detection at
+    ///     load time replaced it.
     ///   - isCancelled: Closure that returns `true` when the caller has requested
     ///     cancellation (combines `Task.isCancelled` and the backend's `Atomic<Bool>`).
     ///   - generationStream: Stream whose phase is updated on the main actor.
@@ -255,46 +258,35 @@ struct LlamaGenerationDriver {
         var invalidUTF8: [CChar] = []
         var isFirstToken = true
 
-        // Thinking-marker handling has three modes:
+        // Thinking-marker handling has two modes:
         //
-        // 1. Eager — `markers != nil` (template advertises thinking). Every decoded
-        //    token flows through `ThinkingParser` from the first byte.
+        // 1. Eager — `markers != nil` (caller passed explicit markers, or the
+        //    backend auto-detected them from the GGUF chat template). Every
+        //    decoded token flows through `ThinkingParser` from the first byte.
         //
-        // 2. Sniff — `markers == nil` (template does NOT advertise thinking). A small
-        //    byte window is accumulated and scanned for `<think>`. If the marker
-        //    appears inside the budget, the captured prefix is replayed through a
-        //    fresh `ThinkingParser(.qwen3)` and the driver switches to eager mode for
-        //    the remainder of the stream. This catches DeepSeek-R1 GGUFs that use a
-        //    non-ChatML prompt template but still emit `<think>…</think>` content.
-        //
-        // 3. Passthrough — sniff budget exhausted without a marker. Every subsequent
-        //    token yields `.token` with no tag scanning, matching non-reasoning
-        //    models' fast path.
-        //
-        // `useParser` starts true for mode 1 and flips true for mode 2 if sniffing
-        // detects a marker. Once true it never reverts.
+        // 2. Disabled — `markers == nil`. The model does not advertise reasoning
+        //    blocks, so every token yields `.token` with no tag scanning. Raw
+        //    `<think>` substrings (if the model emits them anyway) surface as
+        //    visible text rather than `.thinkingToken` events. This matches
+        //    non-reasoning models' fast path. Removed in this change: an
+        //    earlier "sniff" mode that probed the first 64 bytes for `<think>`
+        //    and retroactively engaged the parser. Auto-detection at load time
+        //    (LlamaModelLoader.readChatTemplateMetadata) replaced it.
         //
         // Special case: `config.maxThinkingTokens == 0` disables thinking entirely
         // (issue #597). Even when `markers` is non-nil, the parser stays off and
-        // sniffing is skipped, so every decoded token flows straight to `.token`.
-        // The model may still emit raw `<think>` / `</think>` substrings, but the
-        // driver routes them as visible text rather than `.thinkingToken` events.
+        // every decoded token flows straight to `.token`. The model may still
+        // emit raw `<think>` / `</think>` substrings, but the driver routes
+        // them as visible text rather than `.thinkingToken` events.
         let thinkingDisabled = config.maxThinkingTokens == 0
-        var useParser = !thinkingDisabled && markers != nil
+        let useParser = !thinkingDisabled && markers != nil
+        // `ThinkingParser`'s initialiser requires a non-nil marker pair. When
+        // `useParser` is false the parser is never invoked, so the placeholder
+        // value is never observed.
         var thinkingParser = ThinkingParser(markers: markers ?? .qwen3)
         var thinkingTokenCount = 0
         // Flag set when maxThinkingTokens is reached so we can break the outer loop cleanly.
         var thinkingLimitReached = false
-
-        // Lazy-sniff state. Only consulted when `markers == nil` at entry.
-        // Buffer grows until either `<think>` is found or `sniffBudgetBytes` bytes
-        // have been seen without a match. The open-tag suffix needs to be kept
-        // across the boundary so a partial `<thin` followed by `k>` still matches.
-        let sniffBudgetBytes = 64
-        let sniffOpenTag = ThinkingMarkers.qwen3.open  // "<think>"
-        let sniffEnabled = !thinkingDisabled && markers == nil
-        var sniffBuffer = ""
-        var sniffDone = !sniffEnabled   // true when sniffing has concluded (match or giveup)
 
         // Repetition-window state: track the last decoded token string and how
         // many times it has appeared consecutively. Exceeding `maxRepeatWindow`
@@ -354,33 +346,11 @@ struct LlamaGenerationDriver {
                     }
                 }
 
-                // Build the list of events this token emits. Three paths, matching the
-                // three thinking-marker modes documented at the top of the loop:
-                var events: [GenerationEvent] = []
-                if useParser {
-                    events = thinkingParser.process(text)
-                } else if !sniffDone {
-                    sniffBuffer += text
-                    if sniffBuffer.contains(sniffOpenTag) {
-                        // Hit — replay the full sniff buffer through the parser so its
-                        // pre-<think> prefix yields `.token` events and the opening tag
-                        // opens a thinking block with the post-tag remainder streaming
-                        // as `.thinkingToken`.
-                        useParser = true
-                        sniffDone = true
-                        events = thinkingParser.process(sniffBuffer)
-                        sniffBuffer = ""
-                    } else if sniffBuffer.count >= sniffBudgetBytes {
-                        // Budget exhausted without a marker — flush as visible text and
-                        // stop sniffing for the remainder of the stream.
-                        events = [.token(sniffBuffer)]
-                        sniffBuffer = ""
-                        sniffDone = true
-                    }
-                    // else: still sniffing, emit nothing this iteration
-                } else {
-                    events = [.token(text)]
-                }
+                // Build the list of events this token emits. Two paths, matching the
+                // two thinking-marker modes documented at the top of the loop:
+                let events: [GenerationEvent] = useParser
+                    ? thinkingParser.process(text)
+                    : [.token(text)]
 
                 for event in events {
                     if isFirstToken {
@@ -422,13 +392,6 @@ struct LlamaGenerationDriver {
                 continuation.finish(throwing: InferenceError.inferenceFailure("Decode failed during generation"))
                 return false
             }
-        }
-
-        // Flush any unflushed sniffer bytes as visible text — the stream ended
-        // before the sniff budget was reached or a `<think>` was found.
-        if !sniffBuffer.isEmpty {
-            continuation.yield(.token(sniffBuffer))
-            sniffBuffer = ""
         }
 
         // Flush any bytes held back by the tag-boundary buffer. Only matters when

--- a/Sources/BaseChatBackends/LlamaModelLoader.swift
+++ b/Sources/BaseChatBackends/LlamaModelLoader.swift
@@ -29,6 +29,10 @@ final class LlamaModelLoader: @unchecked Sendable {
         let model: LlamaModelHandle
         let context: LlamaContextHandle
         let effectiveContextSize: Int32
+        /// Auto-detected thinking-marker pair sniffed from
+        /// `tokenizer.chat_template` GGUF metadata. `nil` when the metadata
+        /// is absent or no known marker pair appears in the template.
+        let autoDetectedThinkingMarkers: ThinkingMarkers?
         var vocab: OpaquePointer? { context.vocabPtr }
     }
 
@@ -177,10 +181,18 @@ final class LlamaModelLoader: @unchecked Sendable {
             vocab: llama_model_get_vocab(rawModel)
         )
 
+        // Sniff the GGUF's chat template for known thinking-marker pairs. A
+        // missing or empty template is fine — callers treat nil as "no
+        // auto-detected markers" and fall back to whatever the caller passes
+        // explicitly via `GenerationConfig.thinkingMarkers`.
+        let autoMarkers = Self.readChatTemplateMetadata(model: rawModel)
+            .flatMap { ThinkingMarkers.fromChatTemplate($0) }
+
         return LoadedResources(
             model: modelHandle,
             context: contextHandle,
-            effectiveContextSize: effectiveContextSize
+            effectiveContextSize: effectiveContextSize,
+            autoDetectedThinkingMarkers: autoMarkers
         )
     }
 
@@ -214,6 +226,33 @@ final class LlamaModelLoader: @unchecked Sendable {
     /// Returns true when `architecture` is on the non-LM denylist.
     static func isUnsupportedArchitecture(_ architecture: String) -> Bool {
         unsupportedArchitectures.contains(architecture.lowercased())
+    }
+
+    /// Reads `tokenizer.chat_template` from the loaded GGUF model's metadata.
+    ///
+    /// Returns `nil` when the key is absent or the metadata read fails.
+    /// Chat templates can be several KB of Jinja so we probe for the size
+    /// first, then allocate a correctly-sized buffer for the second call.
+    /// `llama_model_meta_val_str` returns the byte length the value would
+    /// require (excluding the null terminator) when the supplied buffer is
+    /// too small, or a negative value when the key is not present.
+    static func readChatTemplateMetadata(model: OpaquePointer) -> String? {
+        let key = "tokenizer.chat_template"
+        // Probe with a single-byte buffer to learn the required size. The
+        // function still returns the value's length even when the buffer
+        // can't fit it; a negative return means the key wasn't found.
+        var probe: [CChar] = [0]
+        let needed = probe.withUnsafeMutableBufferPointer { ptr in
+            llama_model_meta_val_str(model, key, ptr.baseAddress, ptr.count)
+        }
+        guard needed > 0 else { return nil }
+        // Allocate one extra byte for the null terminator.
+        var buffer = [CChar](repeating: 0, count: Int(needed) + 1)
+        let written = buffer.withUnsafeMutableBufferPointer { ptr in
+            llama_model_meta_val_str(model, key, ptr.baseAddress, ptr.count)
+        }
+        guard written > 0 else { return nil }
+        return String(cString: buffer)
     }
 
     /// Reads `general.architecture` from the loaded GGUF model's metadata.

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -87,6 +87,13 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
     /// When non-nil this supersedes `_conversationHistory` for message building.
     /// Access only under `stateLock`.
     private var _toolAwareHistory: [ToolAwareHistoryEntry]?
+    /// Thinking-marker pair auto-detected from the loaded model's
+    /// `tokenizer_config.json` chat template. `nil` when the model is not
+    /// loaded, the chat template is missing, or no known marker pair was
+    /// found in the template. `GenerationConfig.thinkingMarkers` always
+    /// overrides this — see the generate path below.
+    /// Access only under `stateLock`.
+    private var _autoDetectedThinkingMarkers: ThinkingMarkers?
 
     // MARK: - Load Progress
 
@@ -208,6 +215,51 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         return false
     }
 
+    // MARK: - Thinking-Marker Auto-Discovery
+
+    /// Reads `tokenizer_config.json` inside `url` and returns the best-matching
+    /// thinking-marker preset for the chat template it declares.
+    ///
+    /// Best-effort: a missing or unreadable `tokenizer_config.json`, or one
+    /// without a `chat_template` field, returns `nil`. The MLX tokenizer object
+    /// in `mlx-swift-lm` exposes the chat template through Hugging Face's
+    /// swift-transformers, but reaching it requires opening a `ModelContainer`
+    /// session — reading the on-disk JSON directly is faster and avoids
+    /// tying up the GPU during the load.
+    ///
+    /// - Parameter url: The model directory URL (same one passed to
+    ///   `MLXBackend.loadModel(from:plan:)`).
+    /// - Returns: The auto-detected ``ThinkingMarkers`` or `nil` if no known
+    ///   marker pair is present in the template.
+    static func detectThinkingMarkers(at url: URL) -> ThinkingMarkers? {
+        let configURL = url.appendingPathComponent("tokenizer_config.json")
+        guard let data = try? Data(contentsOf: configURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            // Missing / unreadable tokenizer_config.json is expected for some
+            // model layouts (older snapshots, partial downloads). Don't warn —
+            // callers explicitly opt out of thinking parsing when this is nil.
+            return nil
+        }
+
+        // `chat_template` is a single string for most HF tokenizers, but a
+        // small number of repos ship an array of `{name, template}` entries
+        // (multi-template configs). When that happens, sniff the first entry
+        // whose name is `default` (or the first entry overall).
+        let templateString: String? = {
+            if let s = json["chat_template"] as? String { return s }
+            if let arr = json["chat_template"] as? [[String: Any]] {
+                if let def = arr.first(where: { ($0["name"] as? String)?.lowercased() == "default" }),
+                   let s = def["template"] as? String {
+                    return s
+                }
+                if let s = arr.first?["template"] as? String { return s }
+            }
+            return nil
+        }()
+        guard let template = templateString else { return nil }
+        return ThinkingMarkers.fromChatTemplate(template)
+    }
+
     // MARK: - Model Lifecycle
 
     public func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
@@ -265,9 +317,11 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 )
             }
             let detectedDialect = MLXToolDialect.detect(at: url)
+            let detectedThinkingMarkers = Self.detectThinkingMarkers(at: url)
             withStateLock {
                 _modelContainer = container
                 _dialect = detectedDialect
+                _autoDetectedThinkingMarkers = detectedThinkingMarkers
             }
             // Apply the cache policy after loadModelContainer succeeds. Doing
             // this *after* the load (rather than before) keeps it inside the
@@ -340,8 +394,8 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         // Build messages in chat format, using full conversation history when available
         // so multi-turn exchanges retain context. Falls back to the bare prompt when
         // setConversationHistory has not been called (e.g. direct unit-test calls).
-        let (conversationHistory, toolAwareHistory, dialect) = withStateLock {
-            (_conversationHistory, _toolAwareHistory, _dialect)
+        let (conversationHistory, toolAwareHistory, dialect, autoDetectedMarkers) = withStateLock {
+            (_conversationHistory, _toolAwareHistory, _dialect, _autoDetectedThinkingMarkers)
         }
 
         // For Qwen 2.5: serialize tool definitions into a <tools>…</tools> block
@@ -414,17 +468,24 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 var outputTokenCount = 0
                 var isFirstToken = true
 
-                // Use the caller-configured markers when provided; fall back to .qwen3 (Qwen3/DeepSeek-R1).
-                // mlx-swift-lm exposes no tokenizer API to auto-detect markers at generation time.
-                // TODO: expose thinkingMarkers as a generate() parameter when Gemma 4 / other models land.
+                // Markers are resolved from two sources, manual-override first:
+                //   1. `config.thinkingMarkers` — caller's per-request override.
+                //   2. `autoDetectedMarkers` — sniffed from `tokenizer_config.json`'s
+                //      Jinja chat template at load time.
+                // If both are nil, the model does not advertise reasoning blocks and
+                // the parser stays off — raw `<think>` substrings (if the model emits
+                // them anyway) surface as visible `.token` text instead of being split
+                // into `.thinkingToken` events.
                 //
-                // `config.maxThinkingTokens == 0` disables thinking entirely (issue #597). Even when
-                // `thinkingMarkers` is set, the parser stays off and every chunk flows through as
-                // `.token`. Raw `<think>` / `</think>` substrings surface as visible text rather
-                // than being split into `.thinkingToken` events.
+                // `config.maxThinkingTokens == 0` disables thinking entirely (issue #597),
+                // overriding both sources above.
                 let thinkingDisabled = config.maxThinkingTokens == 0
-                var thinkingParser = ThinkingParser(markers: config.thinkingMarkers ?? .qwen3)
-                let useThinkingParser = !thinkingDisabled && config.thinkingMarkers != nil
+                let resolvedMarkers = config.thinkingMarkers ?? autoDetectedMarkers
+                let useThinkingParser = !thinkingDisabled && resolvedMarkers != nil
+                // ThinkingParser must always be initialized (its initializer can't take nil).
+                // When useThinkingParser is false the parser is never invoked, so the
+                // placeholder marker pair is never observed.
+                var thinkingParser = ThinkingParser(markers: resolvedMarkers ?? .qwen3)
 
                 // Instantiate the tool-call parser when tools are configured and the
                 // loaded model speaks a known tool-call dialect. The parser is a no-op
@@ -559,6 +620,15 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         }
     }
 
+    /// Test-only seam: forces the auto-detected thinking markers to a specific
+    /// value, simulating what the load path would have read from
+    /// `tokenizer_config.json`. Tests use this to verify that
+    /// `config.thinkingMarkers` correctly overrides auto-detection without
+    /// having to stage a real model directory.
+    func _injectAutoDetectedThinkingMarkers(_ markers: ThinkingMarkers?) {
+        withStateLock { _autoDetectedThinkingMarkers = markers }
+    }
+
     // MARK: - Control
 
     public func stopGeneration() {
@@ -587,6 +657,7 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             _conversationHistory = []
             _toolAwareHistory = nil
             _dialect = .unknown
+            _autoDetectedThinkingMarkers = nil
             return had
         }
         if hadContainer {

--- a/Sources/BaseChatBackends/OpenAIResponsesBackend.swift
+++ b/Sources/BaseChatBackends/OpenAIResponsesBackend.swift
@@ -1,0 +1,403 @@
+#if CloudSaaS
+import Foundation
+import os
+import BaseChatInference
+
+/// Cloud inference backend targeting OpenAI's Responses API
+/// (`POST /v1/responses`).
+///
+/// Unlike ``OpenAIBackend`` (Chat Completions), the Responses API is a
+/// named-event SSE stream that exposes reasoning summaries as first-class
+/// events:
+///
+/// ```
+/// event: response.output_item.added
+/// data: {"type":"response.output_item.added","item":{"type":"reasoning"}}
+///
+/// event: response.reasoning_summary_text.delta
+/// data: {"delta":"Let me think..."}
+///
+/// event: response.reasoning_summary_text.done
+/// data: {}
+///
+/// event: response.output_text.delta
+/// data: {"delta":"The answer is 42."}
+///
+/// event: response.completed
+/// data: {"response":{"usage":{"input_tokens":12,"output_tokens":8}}}
+/// ```
+///
+/// Reasoning summaries surface as ``GenerationEvent/thinkingToken(_:)``
+/// values, with a single ``GenerationEvent/thinkingComplete`` injected on
+/// the transition to visible output. This routing mirrors the convention
+/// used by ``ClaudeBackend`` and ``OpenAIBackend`` so consumers can stay
+/// agnostic of the wire format.
+///
+/// Usage:
+/// ```swift
+/// let backend = OpenAIResponsesBackend()
+/// backend.configure(
+///     baseURL: URL(string: "https://api.openai.com")!,
+///     apiKey: "sk-...",
+///     modelName: "gpt-5"
+/// )
+/// try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+/// let stream = try backend.generate(prompt: "Hello", systemPrompt: nil, config: .init())
+/// for try await event in stream.events {
+///     switch event {
+///     case .thinkingToken(let t): print("[reasoning]", t)
+///     case .token(let t): print(t, terminator: "")
+///     default: break
+///     }
+/// }
+/// ```
+public final class OpenAIResponsesBackend: SSECloudBackend, TokenUsageProvider, CloudBackendURLModelConfigurable, CloudBackendKeychainConfigurable, @unchecked Sendable {
+
+    // MARK: - Init
+
+    /// Creates an OpenAI Responses-API backend.
+    ///
+    /// - Parameter urlSession: Custom URLSession. Pass `nil` to use the
+    ///   default pinned session.
+    public init(urlSession: URLSession? = nil) {
+        super.init(
+            defaultModelName: "gpt-5",
+            urlSession: urlSession ?? URLSessionProvider.pinned,
+            // Payload handler is unused — this backend overrides
+            // `parseResponseStream` to walk the named-event stream directly.
+            // A no-op handler keeps the base class's compile-time contract.
+            payloadHandler: NoopPayloadHandler()
+        )
+    }
+
+    /// Throwing factory that propagates ``URLSessionProvider/networkDisabled``
+    /// as ``CloudBackendError/networkDisabled`` instead of trapping.
+    public static func makeChecked(urlSession: URLSession? = nil) throws -> OpenAIResponsesBackend {
+        let session: URLSession
+        if let urlSession {
+            session = urlSession
+        } else {
+            session = try URLSessionProvider.throwingPinned()
+        }
+        return OpenAIResponsesBackend(urlSession: session)
+    }
+
+    // MARK: - Subclass Hooks
+
+    public override var backendName: String { "OpenAIResponses" }
+
+    public override var capabilities: BackendCapabilities {
+        BackendCapabilities(
+            supportedParameters: [.temperature, .topP],
+            maxContextTokens: 200_000,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsToolCalling: false,
+            supportsStructuredOutput: true,
+            supportsNativeJSONMode: false,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: false,
+            memoryStrategy: .external,
+            maxOutputTokens: 16_384,
+            supportsStreaming: true,
+            isRemote: true,
+            supportsThinking: true
+        )
+    }
+
+    // MARK: - Model Lifecycle
+
+    public override func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
+        guard baseURL != nil else {
+            throw CloudBackendError.invalidURL(
+                "No base URL configured. Call configure(baseURL:apiKey:modelName:) first."
+            )
+        }
+        setIsModelLoaded(true)
+        Log.inference.info("OpenAI Responses backend configured for \(self.modelName, privacy: .public) at \(self.baseURL?.host() ?? "unknown", privacy: .public)")
+    }
+
+    // MARK: - Request Building
+
+    public override func buildRequest(
+        prompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig
+    ) throws -> URLRequest {
+        guard let baseURL else {
+            throw CloudBackendError.invalidURL("No base URL configured")
+        }
+
+        let responsesURL = baseURL.appendingPathComponent("v1/responses")
+
+        var input: [[String: String]] = []
+        if let systemPrompt, !systemPrompt.isEmpty {
+            input.append(["role": "system", "content": systemPrompt])
+        }
+        if let history = conversationHistory {
+            // The Responses API accepts the same `(role, content)` shape as
+            // Chat Completions for plain text turns; reasoning items are
+            // server-managed and not replayed by the client.
+            input.append(contentsOf: history.map { ["role": $0.role, "content": $0.content] })
+        } else {
+            input.append(["role": "user", "content": prompt])
+        }
+
+        var body: [String: Any] = [
+            "model": modelName,
+            "input": input,
+            "stream": true,
+            "temperature": config.temperature,
+            "top_p": config.topP,
+            "max_output_tokens": config.maxOutputTokens ?? 2048
+        ]
+
+        // Only request a reasoning summary when the caller asks for thinking
+        // output. Sending `reasoning` to non-reasoning models is rejected by
+        // the API, so we omit it unless the caller signals intent.
+        if config.maxThinkingTokens != nil {
+            body["reasoning"] = ["effort": "medium"]
+        }
+
+        var request = URLRequest(url: responsesURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        if let apiKey = resolveAPIKey(), !apiKey.isEmpty {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        Log.network.debug("OpenAI Responses request to \(responsesURL.absoluteString, privacy: .public) model=\(self.modelName, privacy: .public)")
+
+        return request
+    }
+
+    // MARK: - Stream Parsing
+
+    /// Parses the Responses-API named-event SSE stream.
+    ///
+    /// The stock ``SSEStreamParser`` discards `event:` lines, but the
+    /// Responses API distinguishes events purely by name (the data payload
+    /// is just `{"delta":"..."}` with no `type` field). We therefore walk
+    /// the byte stream ourselves, pairing each `event:` line with its
+    /// following `data:` line.
+    public override func parseResponseStream(
+        bytes: URLSession.AsyncBytes,
+        config: GenerationConfig,
+        continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
+    ) async throws {
+        let limits = effectiveSSEStreamLimits
+
+        var lineBuffer = Data()
+        var totalBytes = 0
+        var rateWindowStart = ContinuousClock.now
+        var rateWindowCount = 0
+
+        var currentEventName: String?
+
+        // Tracks whether any reasoning_summary delta has been emitted on
+        // this stream. We flush a single `.thinkingComplete` on the
+        // transition to visible content so consumers see a clean handoff.
+        var thinkingOpen = false
+
+        func noteEventYielded() throws {
+            let now = ContinuousClock.now
+            if now - rateWindowStart >= .seconds(1) {
+                rateWindowStart = now
+                rateWindowCount = 1
+                return
+            }
+            rateWindowCount += 1
+            if rateWindowCount > limits.maxEventsPerSecond {
+                throw SSEStreamError.eventRateExceeded(rateWindowCount)
+            }
+        }
+
+        func flushThinkingCompleteIfNeeded() throws {
+            if thinkingOpen {
+                try noteEventYielded()
+                continuation.yield(.thinkingComplete)
+                thinkingOpen = false
+            }
+        }
+
+        // Returns `true` if the caller should break out of the byte loop
+        // (terminal event observed).
+        func handleEvent(name: String, data: String) throws -> Bool {
+            // Match either `reasoning_summary_text` or `reasoning_summary`
+            // — providers vary on the exact suffix.
+            let isReasoningDelta = name == "response.reasoning_summary_text.delta"
+                || name == "response.reasoning_summary.delta"
+            let isReasoningDone = name == "response.reasoning_summary_text.done"
+                || name == "response.reasoning_summary.done"
+
+            if isReasoningDelta {
+                if let delta = Self.parseDelta(from: data), !delta.isEmpty {
+                    try noteEventYielded()
+                    continuation.yield(.thinkingToken(delta))
+                    thinkingOpen = true
+                }
+                return false
+            }
+
+            if isReasoningDone {
+                try flushThinkingCompleteIfNeeded()
+                return false
+            }
+
+            if name == "response.output_text.delta" {
+                if let delta = Self.parseDelta(from: data), !delta.isEmpty {
+                    try flushThinkingCompleteIfNeeded()
+                    try noteEventYielded()
+                    continuation.yield(.token(delta))
+                }
+                return false
+            }
+
+            if name == "response.completed" {
+                try flushThinkingCompleteIfNeeded()
+                if let usage = Self.parseUsage(from: data) {
+                    handleUsage(usage)
+                    if let prompt = usage.promptTokens,
+                       let completion = usage.completionTokens {
+                        continuation.yield(.usage(prompt: prompt, completion: completion))
+                    }
+                }
+                return true
+            }
+
+            if name == "response.error" {
+                let message = Self.parseErrorMessage(from: data) ?? "unknown error"
+                throw CloudBackendError.serverError(statusCode: 500, message: message)
+            }
+
+            // Unknown event names (e.g. `response.output_item.added`,
+            // `response.content_part.added`) are accepted silently — they
+            // carry structural metadata we don't need today.
+            return false
+        }
+
+        var iterator = bytes.makeAsyncIterator()
+        outer: while let byte = try await iterator.next() {
+            if Task.isCancelled { break }
+
+            totalBytes += 1
+            if totalBytes > limits.maxTotalBytes {
+                throw SSEStreamError.streamTooLarge(totalBytes)
+            }
+
+            if byte != UInt8(ascii: "\n") {
+                lineBuffer.append(byte)
+                if lineBuffer.count > limits.maxEventBytes {
+                    throw SSEStreamError.eventTooLarge(lineBuffer.count)
+                }
+                continue
+            }
+
+            let line: String
+            if let decoded = String(data: lineBuffer, encoding: .utf8) {
+                line = decoded.trimmingCharacters(in: .whitespaces)
+            } else {
+                Log.network.warning("OpenAIResponsesBackend: skipped \(lineBuffer.count)-byte line with invalid UTF-8")
+                lineBuffer.removeAll(keepingCapacity: true)
+                continue
+            }
+            lineBuffer.removeAll(keepingCapacity: true)
+
+            if line.isEmpty {
+                // Blank line marks event boundary; pending event is
+                // already paired with its data line by this point.
+                currentEventName = nil
+                continue
+            }
+
+            if line.hasPrefix("event:") {
+                currentEventName = String(line.dropFirst(6)).trimmingCharacters(in: .whitespaces)
+                continue
+            }
+
+            if line.hasPrefix("data:") {
+                let payload = String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+                guard let name = currentEventName else {
+                    // `data:` without a preceding `event:` — ignore. The
+                    // Responses API always names its events.
+                    continue
+                }
+                if try handleEvent(name: name, data: payload) {
+                    break outer
+                }
+            }
+            // `id:`, `retry:`, comment lines (`:`) are ignored.
+        }
+
+        try flushThinkingCompleteIfNeeded()
+    }
+
+    // MARK: - JSON Parsing
+
+    /// Extracts a `delta` string from a Responses-API event payload.
+    static func parseDelta(from json: String) -> String? {
+        guard let data = json.data(using: .utf8),
+              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return parsed["delta"] as? String
+    }
+
+    /// Extracts a usage tuple from a `response.completed` payload.
+    ///
+    /// Shape:
+    /// ```json
+    /// {"response":{"usage":{"input_tokens":12,"output_tokens":8}}}
+    /// ```
+    static func parseUsage(from json: String) -> (promptTokens: Int?, completionTokens: Int?)? {
+        guard let data = json.data(using: .utf8),
+              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        // The usage block can sit at the top level (`{"usage":{...}}`) or
+        // nested under `response` — accept either.
+        let usage: [String: Any]?
+        if let top = parsed["usage"] as? [String: Any] {
+            usage = top
+        } else if let response = parsed["response"] as? [String: Any],
+                  let nested = response["usage"] as? [String: Any] {
+            usage = nested
+        } else {
+            usage = nil
+        }
+        guard let usage else { return nil }
+        let prompt = usage["input_tokens"] as? Int ?? usage["prompt_tokens"] as? Int
+        let completion = usage["output_tokens"] as? Int ?? usage["completion_tokens"] as? Int
+        if prompt == nil && completion == nil { return nil }
+        return (prompt, completion)
+    }
+
+    /// Extracts an error message from a `response.error` payload.
+    static func parseErrorMessage(from json: String) -> String? {
+        guard let data = json.data(using: .utf8),
+              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        if let error = parsed["error"] as? [String: Any],
+           let message = error["message"] as? String {
+            return message
+        }
+        return parsed["message"] as? String
+    }
+
+    // MARK: - No-op payload handler
+
+    /// Placeholder handler — the base ``SSECloudBackend`` requires one at
+    /// init, but this backend overrides ``parseResponseStream`` so the
+    /// handler is never consulted.
+    private struct NoopPayloadHandler: SSEPayloadHandler {
+        func extractToken(from payload: String) -> String? { nil }
+        func extractUsage(from payload: String) -> (promptTokens: Int?, completionTokens: Int?)? { nil }
+        func isStreamEnd(_ payload: String) -> Bool { false }
+        func extractStreamError(from payload: String) -> Error? { nil }
+    }
+}
+#endif

--- a/Sources/BaseChatBackends/OpenAIResponsesBackend.swift
+++ b/Sources/BaseChatBackends/OpenAIResponsesBackend.swift
@@ -154,8 +154,10 @@ public final class OpenAIResponsesBackend: SSECloudBackend, TokenUsageProvider, 
 
         // Only request a reasoning summary when the caller asks for thinking
         // output. Sending `reasoning` to non-reasoning models is rejected by
-        // the API, so we omit it unless the caller signals intent.
-        if config.maxThinkingTokens != nil {
+        // the API, so we omit it unless the caller signals intent. A value
+        // of `0` is the documented "disable thinking entirely" sentinel
+        // (see `GenerationConfig.maxThinkingTokens`), so treat it like nil.
+        if let maxThinkingTokens = config.maxThinkingTokens, maxThinkingTokens > 0 {
             body["reasoning"] = ["effort": "medium"]
         }
 
@@ -202,7 +204,12 @@ public final class OpenAIResponsesBackend: SSECloudBackend, TokenUsageProvider, 
         // transition to visible content so consumers see a clean handoff.
         var thinkingOpen = false
 
-        func noteEventYielded() throws {
+        // Rate-limits every `data:` line received from the upstream,
+        // regardless of whether we yield a `GenerationEvent` for it. This
+        // closes the DoS hole where a hostile/buggy server could spam
+        // structural events (`response.output_item.added`, etc.) we ignore
+        // and bypass the per-stream cap entirely.
+        func noteDataLineReceived() throws {
             let now = ContinuousClock.now
             if now - rateWindowStart >= .seconds(1) {
                 rateWindowStart = now
@@ -215,9 +222,8 @@ public final class OpenAIResponsesBackend: SSECloudBackend, TokenUsageProvider, 
             }
         }
 
-        func flushThinkingCompleteIfNeeded() throws {
+        func flushThinkingCompleteIfNeeded() {
             if thinkingOpen {
-                try noteEventYielded()
                 continuation.yield(.thinkingComplete)
                 thinkingOpen = false
             }
@@ -235,7 +241,6 @@ public final class OpenAIResponsesBackend: SSECloudBackend, TokenUsageProvider, 
 
             if isReasoningDelta {
                 if let delta = Self.parseDelta(from: data), !delta.isEmpty {
-                    try noteEventYielded()
                     continuation.yield(.thinkingToken(delta))
                     thinkingOpen = true
                 }
@@ -243,21 +248,20 @@ public final class OpenAIResponsesBackend: SSECloudBackend, TokenUsageProvider, 
             }
 
             if isReasoningDone {
-                try flushThinkingCompleteIfNeeded()
+                flushThinkingCompleteIfNeeded()
                 return false
             }
 
             if name == "response.output_text.delta" {
                 if let delta = Self.parseDelta(from: data), !delta.isEmpty {
-                    try flushThinkingCompleteIfNeeded()
-                    try noteEventYielded()
+                    flushThinkingCompleteIfNeeded()
                     continuation.yield(.token(delta))
                 }
                 return false
             }
 
             if name == "response.completed" {
-                try flushThinkingCompleteIfNeeded()
+                flushThinkingCompleteIfNeeded()
                 if let usage = Self.parseUsage(from: data) {
                     handleUsage(usage)
                     if let prompt = usage.promptTokens,
@@ -319,6 +323,11 @@ public final class OpenAIResponsesBackend: SSECloudBackend, TokenUsageProvider, 
             }
 
             if line.hasPrefix("data:") {
+                // Count the line against the per-second cap before we look
+                // at the event name — unknown/ignored events still consume
+                // budget, otherwise an attacker could spam structural
+                // events we discard.
+                try noteDataLineReceived()
                 let payload = String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces)
                 guard let name = currentEventName else {
                     // `data:` without a preceding `event:` — ignore. The
@@ -332,7 +341,7 @@ public final class OpenAIResponsesBackend: SSECloudBackend, TokenUsageProvider, 
             // `id:`, `retry:`, comment lines (`:`) are ignored.
         }
 
-        try flushThinkingCompleteIfNeeded()
+        flushThinkingCompleteIfNeeded()
     }
 
     // MARK: - JSON Parsing

--- a/Sources/BaseChatInference/Models/APIProvider.swift
+++ b/Sources/BaseChatInference/Models/APIProvider.swift
@@ -1,6 +1,14 @@
 /// The cloud API provider type.
 public enum APIProvider: String, Codable, CaseIterable, Identifiable, Sendable {
     case openAI = "OpenAI"
+    /// OpenAI Responses API (`POST /v1/responses`).
+    ///
+    /// Distinguished from ``openAI`` (Chat Completions) because the wire
+    /// formats are incompatible: Responses uses named SSE events and surfaces
+    /// reasoning summaries as first-class deltas. Selecting this provider
+    /// routes through ``OpenAIResponsesBackend`` and emits
+    /// ``GenerationEvent/thinkingToken(_:)`` for the reasoning stream.
+    case openAIResponses = "OpenAI Responses"
     case claude = "Claude"
     case ollama = "Ollama"
     case lmStudio = "LM Studio"
@@ -11,7 +19,7 @@ public enum APIProvider: String, Codable, CaseIterable, Identifiable, Sendable {
     /// Default base URL for this provider.
     public var defaultBaseURL: String {
         switch self {
-        case .openAI: return "https://api.openai.com"
+        case .openAI, .openAIResponses: return "https://api.openai.com"
         case .claude: return "https://api.anthropic.com"
         case .ollama: return "http://localhost:11434"
         case .lmStudio: return "http://localhost:1234"
@@ -22,7 +30,7 @@ public enum APIProvider: String, Codable, CaseIterable, Identifiable, Sendable {
     /// Whether this provider requires an API key.
     public var requiresAPIKey: Bool {
         switch self {
-        case .openAI, .claude, .custom: return true
+        case .openAI, .openAIResponses, .claude, .custom: return true
         case .ollama, .lmStudio: return false
         }
     }
@@ -31,6 +39,7 @@ public enum APIProvider: String, Codable, CaseIterable, Identifiable, Sendable {
     public var defaultModelName: String {
         switch self {
         case .openAI: return "gpt-4o-mini"
+        case .openAIResponses: return "gpt-5"
         case .claude: return "claude-sonnet-4-6"
         case .ollama: return "llama3.2"
         case .lmStudio: return "local-model"
@@ -48,7 +57,7 @@ public enum APIProvider: String, Codable, CaseIterable, Identifiable, Sendable {
     public static var availableInBuild: [APIProvider] {
         var result: [APIProvider] = []
         #if CloudSaaS
-        result.append(contentsOf: [.claude, .openAI, .lmStudio, .custom])
+        result.append(contentsOf: [.claude, .openAI, .openAIResponses, .lmStudio, .custom])
         #endif
         #if Ollama
         result.append(.ollama)

--- a/Sources/BaseChatInference/Models/ThinkingMarkers.swift
+++ b/Sources/BaseChatInference/Models/ThinkingMarkers.swift
@@ -52,6 +52,18 @@ public struct ThinkingMarkers: Sendable, Equatable {
     /// generations (e.g. `phi3`) are not thinking-model variants and return
     /// `nil`. Unknown models likewise return `nil` so callers can opt out of
     /// thinking-tag filtering cleanly.
+    /// Returns the most-specific preset for a given Jinja chat-template string
+    /// by sniffing the open/close marker pairs the template references.
+    ///
+    /// Both halves of a pair (e.g. `<think>` and `</think>`) must appear for
+    /// that family to be returned. A template with neither pair returns `nil`,
+    /// letting backends opt out of thinking parsing on non-reasoning models.
+    /// See ``PromptTemplateDetector/detectThinkingMarkers(from:)`` for the full
+    /// precedence rules.
+    public static func fromChatTemplate(_ chatTemplate: String) -> ThinkingMarkers? {
+        PromptTemplateDetector.detectThinkingMarkers(from: chatTemplate)
+    }
+
     public static func forModel(named name: String) -> ThinkingMarkers? {
         let lowered = name.lowercased()
 

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -103,10 +103,22 @@ public struct GenerationConfig: Sendable, Codable {
     /// Defaults to `nil` (no grammar constraint).
     public var grammar: String?
 
-    /// Thinking markers for this request's model/template, or nil if the model does not emit
-    /// reasoning blocks. Set by the caller when the selected `PromptTemplate` has
-    /// `thinkingMarkers != nil`. Backends use this to activate `ThinkingParser`; backends that
-    /// do not support thinking ignore it.
+    /// Per-request override for the thinking-marker pair the backend should use
+    /// to split reasoning tokens from visible output.
+    ///
+    /// - `nil` — let the backend use whatever it auto-detected when the model
+    ///   was loaded (e.g. by reading the Jinja chat template from the GGUF or
+    ///   `tokenizer_config.json`). If the backend's auto-detection also
+    ///   returned `nil`, no thinking parsing happens — every chunk surfaces
+    ///   as a plain `.token` event.
+    /// - non-`nil` — overrides whatever the backend auto-detected. Use this
+    ///   when the caller knows better (e.g. a fine-tune that ships an empty
+    ///   chat template but still emits `<think>` blocks at runtime).
+    ///
+    /// Backends without thinking support (`BackendCapabilities.supportsThinking == false`)
+    /// silently ignore this field. There is no longer a hardcoded fallback to
+    /// `.qwen3` — if neither auto-detection nor the caller surfaces markers,
+    /// the parser stays off.
     public var thinkingMarkers: ThinkingMarkers?
 
     /// Maximum number of tool-call iterations permitted inside a single

--- a/Sources/BaseChatInference/Services/ModelLifecycleCoordinator.swift
+++ b/Sources/BaseChatInference/Services/ModelLifecycleCoordinator.swift
@@ -259,7 +259,7 @@ final class ModelLifecycleCoordinator {
         }
 
         switch endpoint.provider {
-        case .claude, .openAI, .custom:
+        case .claude, .openAI, .openAIResponses, .custom:
             guard let keychainConfigurable = newBackend as? CloudBackendKeychainConfigurable else {
                 throw InferenceError.inferenceFailure(
                     "Cloud backend \(type(of: newBackend)) must conform to CloudBackendKeychainConfigurable "

--- a/Sources/BaseChatInference/Services/PromptTemplateDetector.swift
+++ b/Sources/BaseChatInference/Services/PromptTemplateDetector.swift
@@ -53,6 +53,41 @@ struct PromptTemplateDetector {
         return .chatML
     }
 
+    /// Detects which `ThinkingMarkers` preset (if any) a Jinja chat template
+    /// advertises.
+    ///
+    /// Pure substring matching. Both halves of a marker pair must appear in
+    /// the template for that family to be returned — a stray `<think>` with no
+    /// closer is not a thinking template. Returns `nil` when no known pair
+    /// matches, signalling that the model does not emit reasoning blocks.
+    ///
+    /// Precedence (most specific first): qwen3 → mistralReasoning → phi4 →
+    /// reflection → gemma4. The first family whose tag pair appears in the
+    /// template wins, so a Frankenstein template that mentions multiple
+    /// pairs collapses to the most-Qwen-like one. That's deliberate — the
+    /// chat-template tags say what the model *emits*, and Qwen-style is the
+    /// default for the families we ship presets for.
+    static func detectThinkingMarkers(from chatTemplate: String) -> ThinkingMarkers? {
+        if chatTemplate.contains("<think>") && chatTemplate.contains("</think>") {
+            return .qwen3
+        }
+        if chatTemplate.contains("<thinking>") && chatTemplate.contains("</thinking>") {
+            return .mistralReasoning
+        }
+        if chatTemplate.contains("<reasoning>") && chatTemplate.contains("</reasoning>") {
+            return .phi4
+        }
+        if chatTemplate.contains("<reflection>") && chatTemplate.contains("</reflection>") {
+            return .reflection
+        }
+        // Gemma 4's thinking turn opens with `<|turn>think\n` and closes with the
+        // standard `<|end_of_turn>` delimiter; both must appear.
+        if chatTemplate.contains("<|turn>think\n") && chatTemplate.contains("<|end_of_turn>") {
+            return .gemma4
+        }
+        return nil
+    }
+
     /// Detects a prompt template from the GGUF `general.architecture` field.
     ///
     /// Maps known architecture identifiers to their canonical prompt formats.

--- a/Sources/BaseChatTestSupport/MockMLXModelContainer.swift
+++ b/Sources/BaseChatTestSupport/MockMLXModelContainer.swift
@@ -34,6 +34,22 @@ public final class MockMLXModelContainer: @unchecked Sendable {
     /// When set, `generate` throws this error instead of yielding tokens.
     public var generateError: Error?
 
+    /// Simulates a chat-template / tokenizer rejection at `apply_chat_template` time.
+    ///
+    /// When set, `generate(messages:parameters:)` throws this error before yielding
+    /// any token — modeling the failure mode where the loaded tokenizer either has
+    /// no chat template (`tokenizer_config.json` missing the `chat_template` field)
+    /// or the template rejects the supplied message set (e.g. missing
+    /// `<|assistant|>` marker, wrong role ordering). The error surfaces unwrapped
+    /// through `MLXBackend.generate`'s GenerationStream — see issue #551.
+    public var simulatedTokenizerApplyFailure: Error?
+
+    /// Optional stand-in for the tokenizer's `chat_template` field. The mock does
+    /// NOT itself apply a Jinja template — production MLXModelContainer does that
+    /// internally — but tests can set this to document which template shape they
+    /// are exercising and assert the backend hands compatible messages along.
+    public var simulatedChatTemplate: String?
+
     // MARK: - Observation
 
     /// Number of times `generate(messages:parameters:)` was called.
@@ -41,6 +57,11 @@ public final class MockMLXModelContainer: @unchecked Sendable {
 
     /// Last messages passed to `generate`.
     public private(set) var lastMessages: [[String: String]]?
+
+    /// Last `GenerateParameters` value passed to `generate`. Useful for asserting
+    /// that `MLXBackend` forwards `temperature` / `topP` / `topK` / `minP` /
+    /// `repetitionPenalty` from the caller's `GenerationConfig`.
+    public private(set) var lastParameters: GenerateParameters?
 
     public init() {}
 
@@ -52,6 +73,11 @@ public final class MockMLXModelContainer: @unchecked Sendable {
     ) async throws -> AsyncStream<Generation> {
         generateCallCount += 1
         lastMessages = messages
+        lastParameters = parameters
+        // Tokenizer-apply failures throw before any token is yielded — that is
+        // the failure mode `MLXBackend` sees when a template is missing or the
+        // message set is rejected by the chat template.
+        if let error = simulatedTokenizerApplyFailure { throw error }
         if let error = generateError { throw error }
 
         let tokens = tokensToYield

--- a/Tests/BaseChatBackendsTests/LlamaThinkingMarkerAutoDiscoveryTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaThinkingMarkerAutoDiscoveryTests.swift
@@ -1,0 +1,57 @@
+#if Llama
+import XCTest
+@testable import BaseChatInference
+@testable import BaseChatBackends
+import BaseChatTestSupport
+
+/// Auto-discovery tests for `LlamaBackend`'s thinking-marker plumbing.
+///
+/// The hardcoded `.qwen3` fallback in `LlamaGenerationDriver` was removed in
+/// favour of two cooperating sources of marker data:
+///
+///   1. `LlamaModelLoader.readChatTemplateMetadata` reads the GGUF's
+///      `tokenizer.chat_template` at load time and runs it through
+///      `ThinkingMarkers.fromChatTemplate` — the result is cached on the
+///      backend as `_autoDetectedThinkingMarkers`.
+///   2. `GenerationConfig.thinkingMarkers` always overrides the cached
+///      auto-detected value.
+///
+/// The pure-Swift mapping from chat template to marker preset is exercised by
+/// `PromptTemplateDetectorTests`; this file pins the integration on real GGUFs.
+final class LlamaThinkingMarkerAutoDiscoveryTests: XCTestCase {
+
+    /// When a real chat GGUF is available on disk, loading it through
+    /// `LlamaBackend` exercises `readChatTemplateMetadata` end-to-end. The
+    /// outcome depends on the model: a thinking-capable GGUF (DeepSeek-R1,
+    /// Qwen3, etc.) leaves `_autoDetectedThinkingMarkers` non-nil; a plain
+    /// chat model leaves it nil. Either is a valid pass — what matters is
+    /// that the load path runs the metadata-read code without throwing or
+    /// crashing on a real `llama_model_meta_val_str` call.
+    ///
+    /// Sabotage check: changing the metadata key in `readChatTemplateMetadata`
+    /// from `"tokenizer.chat_template"` to a typo would produce nil for every
+    /// model and silently regress a feature this fixture is meant to guard. A
+    /// stronger test would require staging a known reasoning GGUF, which we
+    /// can't do in CI; we accept the weaker smoke check here and rely on the
+    /// pure-Swift fingerprint tests in `PromptTemplateDetectorTests` for
+    /// per-family precision.
+    func test_loadModel_runsChatTemplateAutoDiscovery_withoutCrashing() async throws {
+        try XCTSkipUnless(HardwareRequirements.isAppleSilicon, "LlamaBackend requires Apple Silicon")
+        try XCTSkipUnless(HardwareRequirements.isPhysicalDevice, "LlamaBackend requires Metal (unavailable in simulator)")
+        guard let modelURL = HardwareRequirements.findGGUFModel() else {
+            throw XCTSkip("No chat GGUF available in ~/Documents/Models/ — skipping auto-discovery smoke test")
+        }
+
+        let backend = LlamaBackend()
+        addTeardownBlock { await backend.unloadAndWait() }
+        try await backend.loadModel(from: modelURL, plan: .testStub(effectiveContextSize: 512))
+
+        XCTAssertTrue(backend.isModelLoaded,
+                      "Load must succeed for the auto-discovery smoke check to be meaningful")
+        // We don't assert a specific marker value: most chat-only GGUFs have no
+        // thinking markers and will produce nil. The contract under test is
+        // "load doesn't crash on the metadata read"; a crash here would surface
+        // as a `try await loadModel` failure or a process-level abort.
+    }
+}
+#endif

--- a/Tests/BaseChatBackendsTests/MLXBackendGenerationTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXBackendGenerationTests.swift
@@ -325,8 +325,8 @@ final class MLXBackendGenerationTests: XCTestCase {
     /// dictionary array the backend hands to the container, unchanged.
     ///
     /// The full detection matrix (missing `tokenizer_config.json`, template without an
-    /// `<|assistant|>` marker) requires `MockMLXModelContainer` to expose a tokenizer
-    /// hook — tracked in #551 — and is gated by `XCTSkip` until that lands.
+    /// `<|assistant|>` marker) is now driven via `simulatedTokenizerApplyFailure`
+    /// on the mock container — see the two sibling tests below.
     func test_chatTemplate_messagesPassThroughUnchanged() async throws {
         let mock = MockMLXModelContainer()
         mock.tokensToYield = ["ok"]
@@ -361,12 +361,109 @@ final class MLXBackendGenerationTests: XCTestCase {
 
         // Sabotage check: reordering the msgs.append calls in MLXBackend.generate would
         // flip system and user positions, failing the first/last XCTAssertEquals.
+    }
 
-        // FIXME: extend this fixture with "missing chat template" and "template without
-        // <|assistant|> marker" branches once MockMLXModelContainer exposes tokenizer
-        // hooks (tracked in https://github.com/roryford/BaseChatKit/issues/551). The
-        // pass-through assertion above is the only observable slice at unit-test scope
-        // today — the full detection matrix is Metal-gated.
+    // MARK: - test_chatTemplate_missingTemplate_throwsModelLoadFailed
+
+    /// When the loaded tokenizer has no `chat_template` (e.g. `tokenizer_config.json`
+    /// missing the field, or the file itself absent in the model snapshot), the
+    /// MLX container raises an error from `apply_chat_template` *during generation*.
+    ///
+    /// Today `MLXBackend` does NOT wrap that error in `InferenceError.modelLoadFailed`
+    /// — `modelLoadFailed` is reserved for the `loadModel(...)` path. The error
+    /// surfaces unchanged through the GenerationStream's `try await events`. This
+    /// test pins the current behavior so the failure mode is visible and a future
+    /// structured-error change has a concrete fixture to update.
+    func test_chatTemplate_missingTemplate_throwsModelLoadFailed() async throws {
+        struct MissingChatTemplateError: Error, Equatable {
+            let detail = "tokenizer_config.json missing chat_template field"
+        }
+
+        let mock = MockMLXModelContainer()
+        mock.simulatedTokenizerApplyFailure = MissingChatTemplateError()
+        mock.simulatedChatTemplate = nil // documents the scenario
+
+        let backend = MLXBackend()
+        backend._inject(mock)
+
+        let stream = try backend.generate(
+            prompt: "hi",
+            systemPrompt: "You are helpful.",
+            config: GenerationConfig()
+        )
+
+        var caught: Error?
+        do {
+            for try await _ in stream.events {}
+        } catch {
+            caught = error
+        }
+
+        let unwrapped = try XCTUnwrap(caught,
+            "Stream must surface the tokenizer-apply error rather than completing silently")
+        // Today MLXBackend does not wrap mid-generation errors in `modelLoadFailed`;
+        // the underlying error propagates as-is. If a future change wraps these
+        // errors structurally, flip this assertion to match.
+        XCTAssertTrue(unwrapped is MissingChatTemplateError,
+            "Expected MissingChatTemplateError to propagate unchanged, got \(type(of: unwrapped))")
+
+        // Phase must be .failed so observers can react to the error.
+        let phase = await MainActor.run { stream.phase }
+        if case .failed = phase {
+            // Expected.
+        } else {
+            XCTFail("Expected stream phase .failed, got \(phase)")
+        }
+
+        // Sabotage check: clearing simulatedTokenizerApplyFailure makes the stream
+        // succeed and `caught` stays nil, failing the XCTUnwrap.
+    }
+
+    // MARK: - test_chatTemplate_noAssistantMarker_throwsStructuredError
+
+    /// When the chat template is present but malformed (e.g. it never emits an
+    /// `<|assistant|>` marker so the tokenizer has nowhere to start the model's
+    /// turn), `apply_chat_template` raises a different error class. Same surfacing
+    /// contract — propagated unchanged through the GenerationStream.
+    func test_chatTemplate_noAssistantMarker_throwsStructuredError() async throws {
+        struct NoAssistantMarkerError: Error, Equatable {
+            let detail = "chat template missing <|assistant|> marker"
+        }
+
+        let mock = MockMLXModelContainer()
+        mock.simulatedTokenizerApplyFailure = NoAssistantMarkerError()
+        // Document the malformed template the test is exercising.
+        mock.simulatedChatTemplate = "{% for message in messages %}{{ message.content }}{% endfor %}"
+
+        let backend = MLXBackend()
+        backend._inject(mock)
+
+        let stream = try backend.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        var caught: Error?
+        do {
+            for try await _ in stream.events {}
+        } catch {
+            caught = error
+        }
+
+        let unwrapped = try XCTUnwrap(caught,
+            "Stream must surface the malformed-template error")
+        XCTAssertTrue(unwrapped is NoAssistantMarkerError,
+            "Expected NoAssistantMarkerError to propagate unchanged, got \(type(of: unwrapped))")
+
+        // The mock must have observed the call before throwing — confirms the
+        // backend reached the container's generate path before the apply failed.
+        XCTAssertEqual(mock.generateCallCount, 1)
+        XCTAssertEqual(mock.lastMessages?.last?["role"], "user")
+
+        // Sabotage check: setting mock.simulatedTokenizerApplyFailure = nil lets
+        // the stream complete with the default tokens, leaving `caught` nil and
+        // failing the XCTUnwrap.
     }
 
     // MARK: - test_generate_usesConversationHistory

--- a/Tests/BaseChatBackendsTests/MLXBackendThinkingTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXBackendThinkingTests.swift
@@ -309,7 +309,116 @@ final class MLXBackendThinkingTests: XCTestCase {
         // all 4 thinking tokens plus "answer" through, failing both assertions.
     }
 
-    // MARK: - 6. maxThinkingTokens == 0 disables thinking entirely (#597)
+    // MARK: - 6. Auto-detected markers used when config.thinkingMarkers is nil (#479)
+
+    /// Closes #479 (MLX half) — the backend's auto-detected thinking markers are
+    /// used at generate time when `config.thinkingMarkers` is nil. The injection
+    /// helper `_injectAutoDetectedThinkingMarkers` simulates the load-time
+    /// `tokenizer_config.json` sniff that would otherwise populate the field.
+    func test_autoDetectedMarkers_engageParser_whenConfigMarkersAreNil() async throws {
+        let mock = MockMLXModelContainer()
+        mock.tokensToYield = ["<think>", "reason", "</think>", "answer"]
+
+        let backend = MLXBackend()
+        backend._inject(mock)
+        // Simulate what loadModel(from:plan:) would have detected from the
+        // model's tokenizer_config.json chat template.
+        backend._injectAutoDetectedThinkingMarkers(.qwen3)
+
+        // config.thinkingMarkers stays nil — the parser must engage from the
+        // auto-detected fallback.
+        let stream = try backend.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        let events = try await collectAllEvents(from: stream)
+        let thinkingTexts = events.compactMap { ev -> String? in
+            if case .thinkingToken(let t) = ev { return t } else { return nil }
+        }
+        XCTAssertTrue(thinkingTexts.joined().contains("reason"),
+            "Auto-detected markers must drive ThinkingParser when config.thinkingMarkers is nil")
+
+        // Sabotage check: removing the `?? autoDetectedMarkers` fallback in
+        // MLXBackend.generate would leave `useThinkingParser` false here and
+        // raw `<think>` would surface as `.token`, failing the assertion above.
+    }
+
+    /// Manual override beats auto-detection: the caller's `config.thinkingMarkers`
+    /// is honoured even when the backend already auto-detected a different family.
+    func test_configMarkers_overrideAutoDetected() async throws {
+        let mock = MockMLXModelContainer()
+        // The model emits phi4-style markers, NOT qwen3.
+        mock.tokensToYield = ["<reasoning>", "step1", "</reasoning>", "answer"]
+
+        let backend = MLXBackend()
+        backend._inject(mock)
+        // Auto-detection landed on .qwen3 (e.g. the chat template advertised
+        // <think>/</think>) — but the runtime stream uses <reasoning>/</reasoning>.
+        backend._injectAutoDetectedThinkingMarkers(.qwen3)
+
+        // Caller forces .phi4 to match the actual stream content.
+        var config = GenerationConfig()
+        config.thinkingMarkers = .phi4
+
+        let stream = try backend.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: config
+        )
+
+        let events = try await collectAllEvents(from: stream)
+        let thinkingTexts = events.compactMap { ev -> String? in
+            if case .thinkingToken(let t) = ev { return t } else { return nil }
+        }
+        XCTAssertTrue(thinkingTexts.joined().contains("step1"),
+            "config.thinkingMarkers (.phi4) must override the auto-detected .qwen3")
+
+        // The qwen3 markers never matched the stream, so if auto-detection had
+        // won we would see zero thinkingTokens and "step1" would surface as .token.
+    }
+
+    /// Both sources nil: parser stays off, raw `<think>` text reaches `.token`.
+    /// This is the behaviour that replaces the old hardcoded `.qwen3` fallback.
+    func test_noMarkers_anywhere_parserStaysOff() async throws {
+        let mock = MockMLXModelContainer()
+        mock.tokensToYield = ["<think>", "reason", "</think>", "answer"]
+
+        let backend = MLXBackend()
+        backend._inject(mock)
+        // Simulate "tokenizer_config.json said nothing about thinking" — the
+        // load path's nil result for a non-reasoning model.
+        backend._injectAutoDetectedThinkingMarkers(nil)
+
+        // Caller also leaves thinkingMarkers nil.
+        let stream = try backend.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        let events = try await collectAllEvents(from: stream)
+        let thinkingEvents = events.filter {
+            if case .thinkingToken = $0 { return true }
+            if case .thinkingComplete = $0 { return true }
+            return false
+        }
+        XCTAssertTrue(thinkingEvents.isEmpty,
+            "Both config.thinkingMarkers and auto-detected nil → parser must stay off")
+
+        let visibleText = events.compactMap { ev -> String? in
+            if case .token(let t) = ev { return t } else { return nil }
+        }.joined()
+        XCTAssertTrue(visibleText.contains("<think>"),
+            "Raw <think> must pass through as .token text when no markers are configured")
+
+        // Sabotage check: re-introducing `?? .qwen3` in MLXBackend.generate
+        // engages the parser here and routes `reason` to .thinkingToken,
+        // causing this assertion to fail.
+    }
+
+    // MARK: - 7. maxThinkingTokens == 0 disables thinking entirely (#597)
 
     /// Verifies that `GenerationConfig.maxThinkingTokens == 0` short-circuits
     /// the `ThinkingParser` on MLX so zero `.thinkingToken` / `.thinkingComplete`

--- a/Tests/BaseChatBackendsTests/OpenAIResponsesBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/OpenAIResponsesBackendTests.swift
@@ -292,5 +292,27 @@ final class OpenAIResponsesBackendTests: XCTestCase {
         XCTAssertNotNil(reasoning, "reasoning block must appear when maxThinkingTokens is set")
         XCTAssertEqual(reasoning?["effort"] as? String, "medium")
     }
+
+    /// `GenerationConfig.maxThinkingTokens == 0` is the documented "disable
+    /// thinking entirely" sentinel. The request body must omit the
+    /// `reasoning` block in that case so non-reasoning models aren't
+    /// erroneously forced into a reasoning response (and to match the
+    /// `nil` path).
+    func test_requestBody_maxThinkingTokensZero_omitsReasoningBlock() async throws {
+        let (backend, _) = makeBackend()
+        try await load(backend)
+
+        let request = try backend.buildRequest(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: GenerationConfig(maxThinkingTokens: 0)
+        )
+
+        let body = try JSONSerialization.jsonObject(with: request.httpBody!) as? [String: Any]
+        XCTAssertNil(
+            body?["reasoning"],
+            "maxThinkingTokens == 0 means 'disable thinking'; reasoning block must be omitted"
+        )
+    }
 }
 #endif

--- a/Tests/BaseChatBackendsTests/OpenAIResponsesBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/OpenAIResponsesBackendTests.swift
@@ -1,0 +1,296 @@
+#if CloudSaaS
+import XCTest
+import Foundation
+@testable import BaseChatBackends
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Tests the OpenAI Responses-API backend's named-event SSE parsing.
+///
+/// The Responses API distinguishes events by the `event:` line — the data
+/// payload itself is just a `delta` string with no type field — so the
+/// parser must walk `event:` + `data:` pairs rather than rely on the stock
+/// `SSEStreamParser` (which discards `event:` lines).
+final class OpenAIResponsesBackendTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Each test gets a unique mock URL so concurrent test runs cannot cross
+    /// stubs. `MockURLProtocol.unstub` in `tearDown` cleans up the entry
+    /// without flushing other tests' stubs.
+    private var mockURL: URL!
+    private var session: URLSession!
+
+    override func setUp() {
+        super.setUp()
+        mockURL = URL(string: "https://openai-responses-\(UUID().uuidString).test")!
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        session = URLSession(configuration: config)
+    }
+
+    override func tearDown() {
+        if let url = mockURL {
+            MockURLProtocol.unstub(url: url.appendingPathComponent("v1/responses"))
+        }
+        session = nil
+        mockURL = nil
+        super.tearDown()
+    }
+
+    private func makeBackend() -> (OpenAIResponsesBackend, URL) {
+        let backend = OpenAIResponsesBackend(urlSession: session)
+        backend.configure(baseURL: mockURL, apiKey: "sk-test", modelName: "gpt-5")
+        return (backend, mockURL.appendingPathComponent("v1/responses"))
+    }
+
+    private func load(_ backend: OpenAIResponsesBackend) async throws {
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+    }
+
+    /// Formats a named SSE event with its data payload.
+    private func sseEvent(_ name: String, data: String) -> Data {
+        Data("event: \(name)\ndata: \(data)\n\n".utf8)
+    }
+
+    private enum EventCategory: Equatable {
+        case thinkingToken(String)
+        case thinkingComplete
+        case token(String)
+        case usage
+    }
+
+    private func categorise(_ event: GenerationEvent) -> EventCategory? {
+        switch event {
+        case .thinkingToken(let t): return .thinkingToken(t)
+        case .thinkingComplete: return .thinkingComplete
+        case .token(let t): return .token(t)
+        case .usage: return .usage
+        case .toolCall, .toolResult, .toolLoopLimitReached, .kvCacheReuse,
+             .diagnosticThrottle, .thinkingSignature:
+            return nil
+        }
+    }
+
+    // MARK: - Tests
+
+    /// Reasoning summary deltas surface as `.thinkingToken`, and a single
+    /// `.thinkingComplete` is emitted on the transition to visible content.
+    func test_reasoningSummaryDeltas_emitThinkingTokensThenCompleteThenContent() async throws {
+        let (backend, url) = makeBackend()
+
+        let chunks: [Data] = [
+            sseEvent("response.output_item.added",
+                     data: #"{"type":"response.output_item.added","item":{"type":"reasoning"}}"#),
+            sseEvent("response.reasoning_summary_text.delta", data: #"{"delta":"Analysing"}"#),
+            sseEvent("response.reasoning_summary_text.delta", data: #"{"delta":" the prompt..."}"#),
+            sseEvent("response.output_text.delta", data: #"{"delta":"The answer"}"#),
+            sseEvent("response.output_text.delta", data: #"{"delta":" is 42."}"#),
+            sseEvent("response.completed",
+                     data: #"{"response":{"usage":{"input_tokens":20,"output_tokens":8}}}"#),
+        ]
+
+        MockURLProtocol.stub(url: url, response: .sse(chunks: chunks, statusCode: 200))
+
+        try await load(backend)
+        let stream = try backend.generate(
+            prompt: "What is the answer?",
+            systemPrompt: nil,
+            config: GenerationConfig(maxThinkingTokens: 4096)
+        )
+
+        var categories: [EventCategory] = []
+        for try await event in stream.events {
+            if let cat = categorise(event) { categories.append(cat) }
+        }
+
+        let contentEvents = categories.filter {
+            if case .usage = $0 { return false } else { return true }
+        }
+
+        XCTAssertEqual(contentEvents, [
+            .thinkingToken("Analysing"),
+            .thinkingToken(" the prompt..."),
+            .thinkingComplete,
+            .token("The answer"),
+            .token(" is 42."),
+        ], "Got: \(contentEvents)")
+
+        let completeCount = categories.filter { $0 == .thinkingComplete }.count
+        XCTAssertEqual(completeCount, 1, ".thinkingComplete must fire exactly once")
+    }
+
+    /// An explicit `response.reasoning_summary_text.done` event also flushes
+    /// `.thinkingComplete`, even before any visible content delta arrives.
+    func test_reasoningSummaryDoneEvent_emitsThinkingCompleteOnce() async throws {
+        let (backend, url) = makeBackend()
+
+        let chunks: [Data] = [
+            sseEvent("response.reasoning_summary_text.delta", data: #"{"delta":"Pondering"}"#),
+            sseEvent("response.reasoning_summary_text.done", data: "{}"),
+            sseEvent("response.output_text.delta", data: #"{"delta":"hi"}"#),
+            sseEvent("response.completed", data: "{}"),
+        ]
+
+        MockURLProtocol.stub(url: url, response: .sse(chunks: chunks, statusCode: 200))
+
+        try await load(backend)
+        let stream = try backend.generate(
+            prompt: "x",
+            systemPrompt: nil,
+            config: GenerationConfig(maxThinkingTokens: 1024)
+        )
+
+        var categories: [EventCategory] = []
+        for try await event in stream.events {
+            if let cat = categorise(event) { categories.append(cat) }
+        }
+
+        XCTAssertEqual(categories, [
+            .thinkingToken("Pondering"),
+            .thinkingComplete,
+            .token("hi"),
+        ])
+    }
+
+    /// Plain (non-reasoning) responses must never emit `.thinkingComplete`,
+    /// matching the behaviour of `OpenAIBackend` for non-reasoning models.
+    func test_emptyReasoning_noThinkingCompleteEmitted() async throws {
+        let (backend, url) = makeBackend()
+
+        let chunks: [Data] = [
+            sseEvent("response.output_text.delta", data: #"{"delta":"Hello"}"#),
+            sseEvent("response.output_text.delta", data: #"{"delta":" world"}"#),
+            sseEvent("response.completed",
+                     data: #"{"response":{"usage":{"input_tokens":4,"output_tokens":2}}}"#),
+        ]
+
+        MockURLProtocol.stub(url: url, response: .sse(chunks: chunks, statusCode: 200))
+
+        try await load(backend)
+        let stream = try backend.generate(
+            prompt: "Say hi",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        var sawThinking = false
+        var sawThinkingComplete = false
+        var tokens: [String] = []
+        for try await event in stream.events {
+            switch event {
+            case .token(let t): tokens.append(t)
+            case .thinkingToken: sawThinking = true
+            case .thinkingComplete: sawThinkingComplete = true
+            default: break
+            }
+        }
+
+        XCTAssertEqual(tokens, ["Hello", " world"])
+        XCTAssertFalse(sawThinking)
+        XCTAssertFalse(sawThinkingComplete,
+                       ".thinkingComplete must not fire when no reasoning was streamed")
+    }
+
+    /// `response.error` events are surfaced as a thrown error so callers see
+    /// the failure in their `for try await` loop.
+    func test_errorEvent_propagatesAsThrownError() async throws {
+        let (backend, url) = makeBackend()
+
+        let chunks: [Data] = [
+            sseEvent("response.output_text.delta", data: #"{"delta":"partial"}"#),
+            sseEvent("response.error",
+                     data: #"{"error":{"message":"upstream rejected the request"}}"#),
+        ]
+
+        MockURLProtocol.stub(url: url, response: .sse(chunks: chunks, statusCode: 200))
+
+        try await load(backend)
+        let stream = try backend.generate(
+            prompt: "x",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        var tokens: [String] = []
+        var thrownError: Error?
+        do {
+            for try await event in stream.events {
+                if case .token(let t) = event { tokens.append(t) }
+            }
+        } catch {
+            thrownError = error
+        }
+
+        XCTAssertEqual(tokens, ["partial"], "Tokens emitted before the error must reach the consumer")
+        XCTAssertNotNil(thrownError, "response.error must propagate as a thrown error")
+        if case .serverError(_, let message) = thrownError as? CloudBackendError {
+            XCTAssertTrue(message.contains("upstream rejected"),
+                          "Error message should carry the upstream detail; got: \(message)")
+        } else {
+            XCTFail("Expected CloudBackendError.serverError, got: \(String(describing: thrownError))")
+        }
+    }
+
+    /// The `response.reasoning_summary` (no `_text` suffix) variant is also
+    /// recognised — providers vary on the exact event-name suffix.
+    func test_alternativeEventName_reasoningSummary_alsoMapsToThinking() async throws {
+        let (backend, url) = makeBackend()
+
+        let chunks: [Data] = [
+            sseEvent("response.reasoning_summary.delta", data: #"{"delta":"Thinking..."}"#),
+            sseEvent("response.output_text.delta", data: #"{"delta":"done"}"#),
+            sseEvent("response.completed", data: "{}"),
+        ]
+
+        MockURLProtocol.stub(url: url, response: .sse(chunks: chunks, statusCode: 200))
+
+        try await load(backend)
+        let stream = try backend.generate(
+            prompt: "x",
+            systemPrompt: nil,
+            config: GenerationConfig(maxThinkingTokens: 512)
+        )
+
+        var categories: [EventCategory] = []
+        for try await event in stream.events {
+            if let cat = categorise(event) { categories.append(cat) }
+        }
+
+        XCTAssertEqual(categories, [
+            .thinkingToken("Thinking..."),
+            .thinkingComplete,
+            .token("done"),
+        ])
+    }
+
+    /// Request-body shape: the backend POSTs to `/v1/responses` with
+    /// `input` (not `messages`) and a `reasoning` block when the caller
+    /// passes a thinking budget.
+    func test_requestBody_targetsResponsesEndpointWithReasoningBlock() async throws {
+        let (backend, _) = makeBackend()
+        try await load(backend)
+
+        let request = try backend.buildRequest(
+            prompt: "hi",
+            systemPrompt: "you are helpful",
+            config: GenerationConfig(maxOutputTokens: 800, maxThinkingTokens: 2000)
+        )
+
+        XCTAssertEqual(request.url?.path, "/v1/responses")
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer sk-test")
+
+        let body = try JSONSerialization.jsonObject(with: request.httpBody!) as? [String: Any]
+        XCTAssertEqual(body?["model"] as? String, "gpt-5")
+        XCTAssertEqual(body?["stream"] as? Bool, true)
+        XCTAssertEqual(body?["max_output_tokens"] as? Int, 800)
+        XCTAssertNil(body?["messages"], "Responses API uses `input`, not `messages`")
+        XCTAssertNotNil(body?["input"] as? [[String: String]])
+
+        let reasoning = body?["reasoning"] as? [String: Any]
+        XCTAssertNotNil(reasoning, "reasoning block must appear when maxThinkingTokens is set")
+        XCTAssertEqual(reasoning?["effort"] as? String, "medium")
+    }
+}
+#endif

--- a/Tests/BaseChatInferenceTests/PromptTemplateDetectorTests.swift
+++ b/Tests/BaseChatInferenceTests/PromptTemplateDetectorTests.swift
@@ -55,6 +55,67 @@ final class PromptTemplateDetectorTests: XCTestCase {
         XCTAssertEqual(PromptTemplateDetector.detect(fromChatTemplate: template), .chatML)
     }
 
+    // MARK: - Thinking Marker Detection from Chat Template
+
+    func test_detectThinkingMarkers_qwen3Template() {
+        // Realistic Qwen3 chat template excerpt — both halves of the pair appear.
+        let template = "{% for m in messages %}{{ m.role }}: {{ m.content }}{% endfor %}<think>{{ thinking }}</think>"
+        XCTAssertEqual(PromptTemplateDetector.detectThinkingMarkers(from: template), .qwen3)
+    }
+
+    func test_detectThinkingMarkers_plainChatML_returnsNil() {
+        // Standard ChatML template — no thinking markers anywhere.
+        let template = "{% for m in messages %}<|im_start|>{{ m.role }}\n{{ m.content }}<|im_end|>\n{% endfor %}"
+        XCTAssertNil(PromptTemplateDetector.detectThinkingMarkers(from: template),
+                     "Plain ChatML must not be misidentified as a thinking model")
+    }
+
+    func test_detectThinkingMarkers_partialMatch_openWithoutClose_returnsNil() {
+        // `<think>` is present but `</think>` is missing — should NOT report .qwen3.
+        let template = "{{ messages[0].content }} <think>partial..."
+        XCTAssertNil(PromptTemplateDetector.detectThinkingMarkers(from: template),
+                     "An open tag with no closer must not match a marker family")
+    }
+
+    func test_detectThinkingMarkers_partialMatch_closeWithoutOpen_returnsNil() {
+        let template = "{{ messages[0].content }} </think>tail"
+        XCTAssertNil(PromptTemplateDetector.detectThinkingMarkers(from: template))
+    }
+
+    func test_detectThinkingMarkers_mistralReasoningTemplate() {
+        let template = "[INST] {{ content }} [/INST] <thinking>{{ reasoning }}</thinking>"
+        XCTAssertEqual(PromptTemplateDetector.detectThinkingMarkers(from: template), .mistralReasoning)
+    }
+
+    func test_detectThinkingMarkers_phi4Template() {
+        let template = "<|user|>\n{{ content }}<|end|>\n<|assistant|>\n<reasoning>{{ analysis }}</reasoning>"
+        XCTAssertEqual(PromptTemplateDetector.detectThinkingMarkers(from: template), .phi4)
+    }
+
+    func test_detectThinkingMarkers_reflectionTemplate() {
+        let template = "{{ content }}<reflection>{{ critique }}</reflection>"
+        XCTAssertEqual(PromptTemplateDetector.detectThinkingMarkers(from: template), .reflection)
+    }
+
+    func test_detectThinkingMarkers_gemma4Template() {
+        // Gemma 4's thinking turn signature: open marker is `<|turn>think\n`,
+        // close is the standard `<|end_of_turn>` delimiter.
+        let template = "<|turn>think\n{{ analysis }}<|end_of_turn>\n<|turn>model\n{{ content }}<|end_of_turn>"
+        XCTAssertEqual(PromptTemplateDetector.detectThinkingMarkers(from: template), .gemma4)
+    }
+
+    func test_detectThinkingMarkers_emptyTemplate_returnsNil() {
+        XCTAssertNil(PromptTemplateDetector.detectThinkingMarkers(from: ""))
+    }
+
+    // ThinkingMarkers.fromChatTemplate is the public entry point that delegates
+    // to the detector — pin one case to ensure the surface stays wired.
+    func test_thinkingMarkers_fromChatTemplate_publicSurface() {
+        let template = "<think>{{ x }}</think>"
+        XCTAssertEqual(ThinkingMarkers.fromChatTemplate(template), .qwen3)
+        XCTAssertNil(ThinkingMarkers.fromChatTemplate("plain text only"))
+    }
+
     // MARK: - Architecture Detection
 
     func test_detect_fromArchitecture_llama() {

--- a/Tests/BaseChatInferenceTests/ThinkingMarkerLeakRegressionTests.swift
+++ b/Tests/BaseChatInferenceTests/ThinkingMarkerLeakRegressionTests.swift
@@ -3,12 +3,11 @@ import XCTest
 
 /// Regression tests for the non-ChatML thinking-marker leak — DeepSeek-R1 GGUFs
 /// and similar reasoning models using the Llama3 prompt template still emit
-/// `<think>…</think>` blocks. `LlamaGenerationDriver` now runs a sniff window
-/// on top of `ThinkingParser`: when the active `PromptTemplate` reports
-/// `thinkingMarkers == nil`, the driver buffers the first 64 bytes of output
-/// and, if `<think>` appears, retroactively replays the buffer through a
-/// `ThinkingParser(.qwen3)`. This file pins the replay semantics — the same
-/// behaviour the driver relies on.
+/// `<think>…</think>` blocks. The driver originally ran a 64-byte sniff window
+/// at generate time; that has been replaced by load-time auto-detection
+/// (`LlamaModelLoader.readChatTemplateMetadata` + `ThinkingMarkers.fromChatTemplate`).
+/// These tests still pin the underlying `ThinkingParser` semantics that both
+/// the old sniff replay and the new explicit-markers path depend on.
 final class ThinkingMarkerLeakRegressionTests: XCTestCase {
 
     // MARK: - Helpers

--- a/Tests/BaseChatInferenceTests/TrafficBoundaryAuditTest.swift
+++ b/Tests/BaseChatInferenceTests/TrafficBoundaryAuditTest.swift
@@ -80,6 +80,7 @@ final class TrafficBoundaryAuditTest: XCTestCase {
         // endpoint goes through URLSessionProvider and lives here.
         "BaseChatBackends/ClaudeBackend.swift",
         "BaseChatBackends/OpenAIBackend.swift",
+        "BaseChatBackends/OpenAIResponsesBackend.swift",
         "BaseChatBackends/OllamaBackend.swift",
         "BaseChatBackends/OllamaModelListService.swift",
         "BaseChatBackends/SSECloudBackend.swift",

--- a/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
+++ b/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
@@ -100,6 +100,12 @@ BaseChatBackends/OllamaBackend.swift:guard let json = try? JSONSerialization.jso
 BaseChatBackends/OpenAIBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
 BaseChatBackends/SSECloudBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
 
+# parseDelta / parseUsage / parseErrorMessage: SSE payload probes for the
+# OpenAI Responses-API named-event stream. Malformed JSON on a probe is a
+# non-event — the parser ignores the payload, same pattern as the Chat
+# Completions handlers above.
+BaseChatBackends/OpenAIResponsesBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+
 # MLXBackend.validateArchitecture: best-effort read of the MLX model's
 # `config.json`. A missing/unreadable/malformed config is not fatal here
 # — we deliberately fall through so mlx-swift-lm's own load path produces

--- a/Tests/BaseChatMLXIntegrationTests/MLXModelE2ETests.swift
+++ b/Tests/BaseChatMLXIntegrationTests/MLXModelE2ETests.swift
@@ -165,6 +165,59 @@ final class MLXModelE2ETests: XCTestCase {
         XCTAssertTrue(backend.capabilities.supportsSystemPrompt)
         XCTAssertTrue(backend.capabilities.supportsTokenCounting)
     }
+
+    // MARK: - Stripped tokenizer fixture (#551)
+
+    /// Loading a model snapshot with `tokenizer_config.json` removed must surface
+    /// a structured error rather than crashing or hanging. The mock-container path
+    /// in `MLXBackendGenerationTests` covers the *generation*-time failure mode
+    /// (chat template missing); this E2E exercises the *load*-time path with a
+    /// real on-disk model directory, confirming `MLXBackend.loadModel` wraps the
+    /// underlying tokenizer error in `InferenceError.modelLoadFailed`.
+    func test_loadModel_strippedTokenizerConfig_throwsModelLoadFailed() async throws {
+        // Start from a clean backend so this test owns the load attempt.
+        backend.unloadModel()
+
+        // Copy the resolved model dir to a temp location and delete tokenizer_config.json.
+        let fm = FileManager.default
+        let stagingRoot = fm.temporaryDirectory
+            .appendingPathComponent("MLXStrippedFixture-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: stagingRoot, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: stagingRoot) }
+
+        let strippedURL = stagingRoot.appendingPathComponent(modelURL.lastPathComponent, isDirectory: true)
+        try fm.copyItem(at: modelURL, to: strippedURL)
+
+        let tokenizerConfig = strippedURL.appendingPathComponent("tokenizer_config.json")
+        guard fm.fileExists(atPath: tokenizerConfig.path) else {
+            throw XCTSkip("Source model has no tokenizer_config.json — cannot exercise the strip path")
+        }
+        try fm.removeItem(at: tokenizerConfig)
+
+        // Loading must throw modelLoadFailed (or a structurally-equivalent error).
+        var caught: Error?
+        do {
+            try await backend.loadModel(from: strippedURL, plan: .testStub(effectiveContextSize: 2048))
+        } catch {
+            caught = error
+        }
+
+        let unwrapped = try XCTUnwrap(caught,
+            "Loading a snapshot stripped of tokenizer_config.json must throw")
+
+        if case InferenceError.modelLoadFailed = unwrapped {
+            // Expected — MLXBackend.loadModel wraps the underlying tokenizer
+            // failure in modelLoadFailed before throwing.
+        } else {
+            XCTFail("Expected InferenceError.modelLoadFailed, got \(unwrapped)")
+        }
+
+        XCTAssertFalse(backend.isModelLoaded,
+            "isModelLoaded must remain false after a failed load")
+
+        // Sabotage check: skipping the `try fm.removeItem(at: tokenizerConfig)`
+        // call lets the load succeed and `caught` stays nil, failing the XCTUnwrap.
+    }
 }
 
 #endif

--- a/Tests/BaseChatUITests/APIConfigurationLogicTests.swift
+++ b/Tests/BaseChatUITests/APIConfigurationLogicTests.swift
@@ -52,8 +52,9 @@ final class APIConfigurationLogicTests: XCTestCase {
 
     func test_provider_allCases_containsAllProviders() {
         let cases = APIProvider.allCases
-        XCTAssertEqual(cases.count, 5, "Should have 5 providers")
+        XCTAssertEqual(cases.count, 6, "Should have 6 providers")
         XCTAssertTrue(cases.contains(.openAI))
+        XCTAssertTrue(cases.contains(.openAIResponses))
         XCTAssertTrue(cases.contains(.claude))
         XCTAssertTrue(cases.contains(.ollama))
         XCTAssertTrue(cases.contains(.lmStudio))
@@ -215,8 +216,8 @@ final class APIConfigurationLogicTests: XCTestCase {
         let requireKey = APIProvider.allCases.filter(\.requiresAPIKey)
         let noKey = APIProvider.allCases.filter { !$0.requiresAPIKey }
 
-        XCTAssertEqual(Set(requireKey), [.openAI, .claude, .custom],
-                       "Only OpenAI, Claude, and Custom should require API keys")
+        XCTAssertEqual(Set(requireKey), [.openAI, .openAIResponses, .claude, .custom],
+                       "Only OpenAI (Chat & Responses), Claude, and Custom should require API keys")
         XCTAssertEqual(Set(noKey), [.ollama, .lmStudio],
                        "Ollama and LM Studio should not require API keys")
     }


### PR DESCRIPTION
## Summary

One PR landing three coordinated thinking-related changes that all touch the same surface (thinking events, marker presets, MLX/Llama load paths). Per CLAUDE.md "one feature = one PR, even across backends," shipping these as a single PR keeps the cross-cutting types reviewed once and CI run once.

Closes #598, closes #479, closes #551.

### #598 — OpenAI Responses API → thinking events
New `OpenAIResponsesBackend: SSECloudBackend` targeting `POST /v1/responses`. Translates the named-event SSE stream (`response.reasoning_summary_text.delta` / `.done`, `response.output_text.delta`, `response.completed`, `response.error`) into `.thinkingToken` / `.thinkingComplete` / `.token` `GenerationEvent`s. Existing `OpenAIBackend` (Chat Completions) is untouched. Added `APIProvider.openAIResponses` as the natural switch point — Chat Completions and Responses wire formats are incompatible enough to warrant separate provider cases rather than a flag.

### #479 — MLX/Llama thinking markers (Jinja auto-discovery)
- `PromptTemplateDetector.detectThinkingMarkers(from:)` scans Jinja chat templates for `<think>`/`</think>`, `<thinking>`/`</thinking>`, `<reasoning>`/`</reasoning>`, `<reflection>`/`</reflection>`, and Gemma-style markers; returns the matching `ThinkingMarkers` preset or `nil`.
- `MLXBackend` reads `tokenizer_config.json`'s `chat_template` at load time and caches `_autoDetectedThinkingMarkers`. Generate-time resolves `config.thinkingMarkers ?? autoDetected`. Hardcoded `?? .qwen3` removed.
- `LlamaModelLoader` reads `tokenizer.chat_template` via the `llama_model_meta_val_str` C API and caches the auto-detected preset on `LlamaBackend`.
- **`LlamaGenerationDriver` sniff mode removed** — `nil` markers now means "no thinking parsing." Auto-detection at load time replaces it.
- `GenerationConfig.thinkingMarkers` doc rewritten: `nil` = use backend's auto-detected markers, otherwise no parsing; non-nil overrides auto-detection.

### #551 — MockMLXModelContainer hooks + thinking-E2E split
- `MockMLXModelContainer` gained `simulatedTokenizerApplyFailure: Error?`, `simulatedChatTemplate: String?`, and `lastParameters: GenerateParameters?`. Two new tests in `MLXBackendGenerationTests` cover the missing-template and no-`<|assistant|>`-marker branches that were previously `XCTSkip`-gated with the FIXME pointing at #551.
- `MLXModelE2ETests.test_loadModel_strippedTokenizerConfig_throwsModelLoadFailed` (Xcode-only `BaseChatMLXIntegrationTests`) copies a real model dir, deletes `tokenizer_config.json`, and asserts `InferenceError.modelLoadFailed`.
- E2E split itself was already done — `OllamaThinkingE2ETests.swift` and `LlamaThinkingE2ETests.swift` already isolate the thinking tests; no further file split needed (verified by grep).

### Implementation note (worker C)
When `MockMLXModelContainer.generate(...)` throws, the error currently propagates **unchanged** through the stream (`continuation.finish(throwing:)` in `MLXBackend.swift:532`); it is **not** rewrapped as `InferenceError.modelLoadFailed` (that wrap is reserved for the load path at `:290`). The two new tests pin the current behavior; the test name is a forward-looking misnomer with an inline comment so a future structured-error change has a concrete fixture to update.

## Test plan
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 228 tests, 0 failures
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 1138 tests, 0 failures
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits` — 69 tests, 0 failures
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 501 tests, 0 failures
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 80 tests, 0 failures
- [x] `swift test --filter BaseChatTestSupportTests --disable-default-traits` — 13 tests, 0 failures
- [x] Worker B locally: `--traits MLX,Llama` — 213 tests, 0 failures (4 skipped on missing GGUF)
- [x] Worker A locally: `--traits CloudSaaS` — 225 tests, 0 failures (includes 6 new `OpenAIResponsesBackendTests`)
- [x] Worker C sabotage-checked the new MockContainer-driven tests
- [ ] CI runs all six default-traits suites
- [ ] Reviewer to verify Apple-Silicon-only `--traits MLX,Llama` and `--traits CloudSaaS` runs locally before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)