### PR TITLE
feat(inference): represent parallel tool-call batches in GenerationEvent

### DIFF
--- a/Sources/BaseChatFuzz/EventRecorder.swift
+++ b/Sources/BaseChatFuzz/EventRecorder.swift
@@ -89,6 +89,10 @@ public struct EventRecorder: Sendable {
                     // fuzz scenarios can pin its presence/absence without
                     // affecting reasoning text accumulation.
                     events.append(.init(t: t, kind: "thinkingSignature", v: signature))
+                case .toolCallStart(let callId, let name):
+                    events.append(.init(t: t, kind: "toolCallStart", v: "\(callId):\(name)"))
+                case .toolCallArgumentsDelta(let callId, let textDelta):
+                    events.append(.init(t: t, kind: "toolCallArgumentsDelta", v: "\(callId):\(textDelta)"))
                 }
                 memoryTick()
             }

--- a/Sources/BaseChatInference/Models/GenerationEvent.swift
+++ b/Sources/BaseChatInference/Models/GenerationEvent.swift
@@ -18,6 +18,25 @@ public enum GenerationEvent: Sendable, Equatable {
     /// call and feeding a ``ToolResult`` back into the conversation.
     case toolCall(ToolCall)
 
+    /// Streaming start of a tool call. `callId` matches ``ToolCall/id`` of the
+    /// corresponding ``toolCall(_:)`` event later in this round; `name` is
+    /// final (no `.toolCallNameDelta` exists — providers emit name up front).
+    ///
+    /// Backends only emit this when
+    /// ``BackendCapabilities/streamsToolCallArguments`` is `true`. Backends
+    /// that produce whole calls (MLX inline parser, Ollama non-streaming)
+    /// skip start/delta and emit only ``toolCall(_:)``.
+    ///
+    /// Contract: `callId` is non-empty, unique within a turn, and matches
+    /// the id of the ``toolCall(_:)`` event that closes this stream.
+    case toolCallStart(callId: String, name: String)
+
+    /// JSON-arguments fragment for an in-flight call, emitted in
+    /// concatenation order. Consumers may attempt forgiving partial-JSON
+    /// parsing for progressive UI; the authoritative arguments string lands
+    /// on the final ``toolCall(_:)`` event.
+    case toolCallArgumentsDelta(callId: String, textDelta: String)
+
     /// A fragment of model reasoning (inside a thinking block). Streamed during generation.
     case thinkingToken(String)
 

--- a/Sources/BaseChatInference/Protocols/BackendCapabilities.swift
+++ b/Sources/BaseChatInference/Protocols/BackendCapabilities.swift
@@ -99,6 +99,19 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
     /// `GenerationConfig.thinkingMarkers`, which is a per-request runtime hint.
     public let supportsThinking: Bool
 
+    /// True when the backend emits ``GenerationEvent/toolCallStart(callId:name:)``
+    /// and ``GenerationEvent/toolCallArgumentsDelta(callId:textDelta:)`` before
+    /// each ``GenerationEvent/toolCall(_:)``. Cloud streaming backends set
+    /// `true`; local inline-parser backends and non-streaming HTTP backends
+    /// set `false`.
+    public let streamsToolCallArguments: Bool
+
+    /// True when the backend can emit multiple ``GenerationEvent/toolCall(_:)``
+    /// events in one generation round (parallel batch). Single-call backends
+    /// and small local models that only reliably emit one call at a time set
+    /// `false`.
+    public let supportsParallelToolCalls: Bool
+
     /// Parameters the UI should present controls for.
     public var visibleParameters: [GenerationParameter] {
         GenerationParameter.allCases.filter { supportedParameters.contains($0) }
@@ -120,7 +133,9 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         isRemote: Bool = false,
         supportsKVCachePersistence: Bool = false,
         supportsGrammarConstrainedSampling: Bool = false,
-        supportsThinking: Bool = false
+        supportsThinking: Bool = false,
+        streamsToolCallArguments: Bool = false,
+        supportsParallelToolCalls: Bool = false
     ) {
         self.supportedParameters = supportedParameters
         self.maxContextTokens = maxContextTokens
@@ -138,6 +153,8 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         self.supportsKVCachePersistence = supportsKVCachePersistence
         self.supportsGrammarConstrainedSampling = supportsGrammarConstrainedSampling
         self.supportsThinking = supportsThinking
+        self.streamsToolCallArguments = streamsToolCallArguments
+        self.supportsParallelToolCalls = supportsParallelToolCalls
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -157,6 +174,8 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         case supportsKVCachePersistence
         case supportsGrammarConstrainedSampling
         case supportsThinking
+        case streamsToolCallArguments
+        case supportsParallelToolCalls
     }
 
     public init(from decoder: Decoder) throws {
@@ -177,6 +196,8 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         supportsKVCachePersistence = (try c.decodeIfPresent(Bool.self, forKey: .supportsKVCachePersistence)) ?? false
         supportsGrammarConstrainedSampling = (try c.decodeIfPresent(Bool.self, forKey: .supportsGrammarConstrainedSampling)) ?? false
         supportsThinking = (try c.decodeIfPresent(Bool.self, forKey: .supportsThinking)) ?? false
+        streamsToolCallArguments = (try c.decodeIfPresent(Bool.self, forKey: .streamsToolCallArguments)) ?? false
+        supportsParallelToolCalls = (try c.decodeIfPresent(Bool.self, forKey: .supportsParallelToolCalls)) ?? false
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -197,5 +218,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         try c.encode(supportsKVCachePersistence, forKey: .supportsKVCachePersistence)
         try c.encode(supportsGrammarConstrainedSampling, forKey: .supportsGrammarConstrainedSampling)
         try c.encode(supportsThinking, forKey: .supportsThinking)
+        try c.encode(streamsToolCallArguments, forKey: .streamsToolCallArguments)
+        try c.encode(supportsParallelToolCalls, forKey: .supportsParallelToolCalls)
     }
 }

--- a/Sources/BaseChatInference/Services/GenerationStreamConsumer.swift
+++ b/Sources/BaseChatInference/Services/GenerationStreamConsumer.swift
@@ -49,6 +49,15 @@ public struct GenerationStreamConsumer: Sendable {
             // a "paused — device throttling" badge observe the raw event
             // upstream instead of going through the action mapping.
             return .ignore
+
+        case .toolCallStart, .toolCallArgumentsDelta:
+            // Streaming tool-call deltas are observed by UI surfaces
+            // upstream (rendering an in-flight call card). The
+            // GenerationStreamConsumer drives chat-message text/thinking
+            // state and has nothing to do for the deltas — the
+            // authoritative arguments string lands on `.toolCall(_:)`,
+            // which `dispatchToolCall` already handles.
+            return .ignore
         }
     }
 

--- a/Sources/BaseChatInference/Services/ToolCallLoopOrchestrator.swift
+++ b/Sources/BaseChatInference/Services/ToolCallLoopOrchestrator.swift
@@ -83,6 +83,17 @@ public enum ToolLoopEvent: Sendable, Equatable {
     /// forwarded — agentic callers care about the visible output.
     case token(String)
 
+    /// Streaming start of a tool call (forwarded verbatim from
+    /// ``GenerationEvent/toolCallStart(callId:name:)``). Only emitted by
+    /// backends whose
+    /// ``BackendCapabilities/streamsToolCallArguments`` is `true`.
+    case toolCallStart(callId: String, name: String)
+
+    /// Streaming JSON-arguments fragment (forwarded verbatim from
+    /// ``GenerationEvent/toolCallArgumentsDelta(callId:textDelta:)``). The
+    /// authoritative arguments string lands on ``toolCall(_:)``.
+    case toolCallArgumentsDelta(callId: String, textDelta: String)
+
     /// The model has requested a tool call. Emitted *before* dispatch so UIs
     /// can render the call in flight. The orchestrator dispatches the call
     /// itself; the host does not need to act.
@@ -174,6 +185,25 @@ public enum ToolLoopError: Error, Sendable, Equatable {
 /// For multi-tool agents, prefer ``init(backend:registry:policy:)`` — the
 /// orchestrator routes each call through ``ToolRegistry/dispatch(_:)`` which
 /// looks up the right executor by name.
+///
+/// ## Parallel batch dispatch
+///
+/// When a single generation round emits more than one ``ToolCall``, the
+/// orchestrator dispatches the batch in parallel via `withTaskGroup` only
+/// when *every* executor in the batch returns
+/// ``ToolExecutor/supportsConcurrentDispatch`` == `true`. Otherwise it falls
+/// back to the sequential dispatch path that has always been the contract,
+/// preserving ``ToolRegistry``'s reentrancy semantics for tools with shared
+/// state.
+///
+/// Result order in the next-turn prompt is deterministic: results are sorted
+/// by their batch-emission index before being appended, regardless of which
+/// executor finishes first. KV-cache prefix reuse depends on stable
+/// post-tool prompt prefixes, so this ordering is load-bearing.
+///
+/// Cancellation propagates through the task group: a cancelled consumer or
+/// step-timeout drains in-flight executors and stops the backend without
+/// emitting late ``ToolLoopEvent/toolResult(_:)`` events.
 ///
 /// ## Example
 /// ```swift
@@ -359,18 +389,63 @@ public struct ToolCallLoopOrchestrator: Sendable {
                 }
             }
 
-            // Dispatch each call sequentially, forwarding the result before the
-            // next one runs. Sequential dispatch matches GenerationCoordinator's
-            // existing contract — parallel dispatch is a richer feature that
-            // belongs on a future explicit policy knob, not a default.
-            var resultsAppendix = ""
-            for call in outcome.toolCalls {
-                if Task.isCancelled {
+            // Dispatch the batch. Single-call rounds always go through the
+            // sequential path (no behaviour change). Multi-call rounds opt
+            // into `withTaskGroup` parallel dispatch only when every
+            // executor in the batch returns
+            // `ToolExecutor.supportsConcurrentDispatch == true`; otherwise
+            // we fall back to sequential to preserve ToolRegistry's
+            // reentrancy contract for tools with shared state.
+            //
+            // Result order in the next prompt is deterministic and matches
+            // batch-emission order — KV-cache prefix reuse depends on a
+            // stable post-tool prompt prefix.
+            //
+            // TODO(#753): MLX integration test for parallel multi-call output
+            // — exercising tools with `supportsConcurrentDispatch == true`
+            // against a real local model and asserting deterministic result
+            // order.
+            let results: [ToolResult]
+            if outcome.toolCalls.count <= 1 {
+                var sequential: [ToolResult] = []
+                sequential.reserveCapacity(outcome.toolCalls.count)
+                for call in outcome.toolCalls {
+                    if Task.isCancelled {
+                        continuation.finish()
+                        return
+                    }
+                    let result = await dispatcher.dispatch(call)
+                    continuation.yield(.toolResult(result))
+                    sequential.append(result)
+                }
+                results = sequential
+            } else if await dispatcher.canDispatchConcurrently(outcome.toolCalls) {
+                let parallelOutcome = await dispatchParallel(
+                    calls: outcome.toolCalls,
+                    continuation: continuation
+                )
+                if parallelOutcome.cancelled {
                     continuation.finish()
                     return
                 }
-                let result = await dispatcher.dispatch(call)
-                continuation.yield(.toolResult(result))
+                results = parallelOutcome.results
+            } else {
+                var sequential: [ToolResult] = []
+                sequential.reserveCapacity(outcome.toolCalls.count)
+                for call in outcome.toolCalls {
+                    if Task.isCancelled {
+                        continuation.finish()
+                        return
+                    }
+                    let result = await dispatcher.dispatch(call)
+                    continuation.yield(.toolResult(result))
+                    sequential.append(result)
+                }
+                results = sequential
+            }
+
+            var resultsAppendix = ""
+            for (call, result) in zip(outcome.toolCalls, results) {
                 resultsAppendix += "\n\nTool '\(call.toolName)' result: \(result.content)\n"
             }
 
@@ -379,6 +454,58 @@ public struct ToolCallLoopOrchestrator: Sendable {
 
         continuation.yield(.stepLimitReached(steps: step))
         continuation.finish()
+    }
+
+    // MARK: - Parallel dispatch
+
+    private struct ParallelOutcome: Sendable {
+        let results: [ToolResult]
+        let cancelled: Bool
+    }
+
+    /// Dispatches `calls` concurrently via `withTaskGroup`, yields
+    /// ``ToolLoopEvent/toolResult(_:)`` events sorted by batch index, and
+    /// returns the results in batch-emission order.
+    ///
+    /// Determinism note: tasks complete in arbitrary order, but we collect
+    /// `(idx, ToolResult)` pairs and sort by `idx` before yielding so the
+    /// next-turn prompt prefix stays stable. KV-cache prefix reuse depends
+    /// on this — see the type-level "Parallel batch dispatch" section.
+    private func dispatchParallel(
+        calls: [ToolCall],
+        continuation: AsyncThrowingStream<ToolLoopEvent, Error>.Continuation
+    ) async -> ParallelOutcome {
+        let dispatcher = self.dispatcher
+        let collected: [(Int, ToolResult)] = await withTaskGroup(
+            of: (Int, ToolResult).self
+        ) { group in
+            defer { group.cancelAll() }
+            for (idx, call) in calls.enumerated() {
+                group.addTask {
+                    let result = await dispatcher.dispatch(call)
+                    return (idx, result)
+                }
+            }
+            var out: [(Int, ToolResult)] = []
+            out.reserveCapacity(calls.count)
+            for await pair in group {
+                out.append(pair)
+            }
+            return out
+        }
+
+        if Task.isCancelled {
+            return ParallelOutcome(results: [], cancelled: true)
+        }
+
+        let sorted = collected.sorted { $0.0 < $1.0 }
+        var results: [ToolResult] = []
+        results.reserveCapacity(sorted.count)
+        for (_, result) in sorted {
+            continuation.yield(.toolResult(result))
+            results.append(result)
+        }
+        return ParallelOutcome(results: results, cancelled: false)
     }
 
     /// Reads one round of events from the backend stream, optionally bounded
@@ -428,6 +555,10 @@ public struct ToolCallLoopOrchestrator: Sendable {
                 switch event {
                 case .token(let text):
                     continuation.yield(.token(text))
+                case .toolCallStart(let callId, let name):
+                    continuation.yield(.toolCallStart(callId: callId, name: name))
+                case .toolCallArgumentsDelta(let callId, let textDelta):
+                    continuation.yield(.toolCallArgumentsDelta(callId: callId, textDelta: textDelta))
                 case .toolCall(let call):
                     continuation.yield(.toolCall(call))
                     calls.append(call)
@@ -475,6 +606,37 @@ public struct ToolCallLoopOrchestrator: Sendable {
                 return await Self.dispatchSingle(executor: executor, call: call)
             case .registry(let registry):
                 return await registry.dispatch(call)
+            }
+        }
+
+        /// Returns `true` when every executor that would handle one of
+        /// `calls` has opted into concurrent dispatch.
+        ///
+        /// - Single-executor dispatcher: every call routes to the same
+        ///   executor, so the answer is just that executor's flag.
+        /// - Registry dispatcher: each call resolves to a (possibly
+        ///   different) executor by name. The lookup is performed under
+        ///   MainActor since ``ToolRegistry`` is MainActor-isolated.
+        ///   Calls that resolve to no executor (unknown tool) are
+        ///   considered non-concurrent — the dispatch will produce an
+        ///   `unknownTool` error result and we don't want to short-circuit
+        ///   that through a parallel path.
+        func canDispatchConcurrently(_ calls: [ToolCall]) async -> Bool {
+            switch self {
+            case .singleExecutor(let executor):
+                return executor.supportsConcurrentDispatch
+            case .registry(let registry):
+                return await MainActor.run {
+                    for call in calls {
+                        guard let executor = registry.executor(for: call.toolName) else {
+                            return false
+                        }
+                        if !executor.supportsConcurrentDispatch {
+                            return false
+                        }
+                    }
+                    return true
+                }
             }
         }
 

--- a/Sources/BaseChatInference/Services/ToolExecutor.swift
+++ b/Sources/BaseChatInference/Services/ToolExecutor.swift
@@ -110,6 +110,20 @@ public protocol ToolExecutor: Sendable {
     /// (case-insensitive).
     var definition: ToolDefinition { get }
 
+    /// Whether this executor is safe to dispatch concurrently with itself or
+    /// with other tools in the same batch.
+    ///
+    /// Default `false` (sequential dispatch). Override `true` for stateless
+    /// executors — HTTP fetches, pure computations, read-only filesystem.
+    ///
+    /// ``ToolCallLoopOrchestrator`` consults this flag when a generation
+    /// round produces more than one ``ToolCall``: parallel dispatch via
+    /// `withTaskGroup` is used only when *every* executor in the batch opts
+    /// in. If any returns `false`, the orchestrator falls back to sequential
+    /// dispatch — preserving the registry's reentrancy contract for tools
+    /// with shared state.
+    var supportsConcurrentDispatch: Bool { get }
+
     /// Whether this tool needs explicit per-call user approval before the
     /// orchestrator dispatches it.
     ///
@@ -143,6 +157,10 @@ extension ToolExecutor {
     /// Default: read-only tool, no approval needed. Side-effecting tools
     /// override to `true`.
     public var requiresApproval: Bool { false }
+
+    /// Default: sequential dispatch. Stateless executors should override
+    /// to `true` to opt into parallel batch dispatch.
+    public var supportsConcurrentDispatch: Bool { false }
 }
 
 // MARK: - TypedToolExecutor

--- a/Sources/BaseChatInference/Services/ToolRegistry.swift
+++ b/Sources/BaseChatInference/Services/ToolRegistry.swift
@@ -200,6 +200,18 @@ public protocol JSONSchemaValidating: Sendable {
         return result
     }
 
+    /// Returns the registered executor for `toolName` (case-insensitive),
+    /// or `nil` when no tool is registered under that name.
+    ///
+    /// Used by ``ToolCallLoopOrchestrator`` to read
+    /// ``ToolExecutor/supportsConcurrentDispatch`` on every executor in a
+    /// batch before deciding whether to dispatch the batch in parallel.
+    /// The lookup does not mutate the registry and does not increment the
+    /// in-flight counter.
+    public func executor(for toolName: String) -> (any ToolExecutor)? {
+        tools[toolName.lowercased()]
+    }
+
     /// Returns the registered executor's ``ToolExecutor/requiresApproval``
     /// flag, or `false` when no tool is registered under `toolName`.
     ///

--- a/Sources/BaseChatTestSupport/MockInferenceBackend.swift
+++ b/Sources/BaseChatTestSupport/MockInferenceBackend.swift
@@ -60,6 +60,31 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
     /// back to the flat ``tokensToYield`` property.
     public var tokensToYieldPerTurn: [[String]] = []
 
+    /// A scripted streaming tool-call event the mock can emit before the
+    /// authoritative ``GenerationEvent/toolCall(_:)``. Mirrors what cloud
+    /// streaming backends produce for backends that flip
+    /// ``BackendCapabilities/streamsToolCallArguments``.
+    public enum ScriptedToolCallDelta: Sendable {
+        /// `.toolCallStart(callId:name:)` event.
+        case start(callId: String, name: String)
+        /// `.toolCallArgumentsDelta(callId:textDelta:)` event.
+        case delta(callId: String, textDelta: String)
+        /// Authoritative `.toolCall(_:)` event that closes a streamed call.
+        case call(ToolCall)
+    }
+
+    /// Scripted streaming tool-call delta sequence per turn. When a turn's
+    /// inner array is non-empty, it takes precedence over the per-turn
+    /// `(scriptedToolCallsPerTurn, tokensToYieldPerTurn)` for tool-call
+    /// emission: events fire in the order listed. Visible-text tokens for
+    /// that turn still come from ``tokensToYieldPerTurn`` at the matching
+    /// index.
+    ///
+    /// Use this to drive tests that exercise the streaming-delta path —
+    /// e.g. asserting the orchestrator forwards `.toolCallStart` /
+    /// `.toolCallArgumentsDelta` verbatim before the closing `.toolCall`.
+    public var scriptedToolCallDeltasPerTurn: [[ScriptedToolCallDelta]] = []
+
     // Track calls
     public var loadModelCallCount = 0
     public var generateCallCount = 0
@@ -118,6 +143,12 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
         // front so successive generate() calls drive different turns.
         let toolCalls: [ToolCall]
         let tokens: [String]
+        let deltaSequence: [ScriptedToolCallDelta]
+        if !scriptedToolCallDeltasPerTurn.isEmpty {
+            deltaSequence = scriptedToolCallDeltasPerTurn.removeFirst()
+        } else {
+            deltaSequence = []
+        }
         if !scriptedToolCallsPerTurn.isEmpty {
             toolCalls = scriptedToolCallsPerTurn.removeFirst()
             if !tokensToYieldPerTurn.isEmpty {
@@ -127,7 +158,11 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
             }
         } else {
             toolCalls = scriptedToolCalls
-            tokens = tokensToYield
+            if !tokensToYieldPerTurn.isEmpty {
+                tokens = tokensToYieldPerTurn.removeFirst()
+            } else {
+                tokens = tokensToYield
+            }
         }
 
         let thinkingTokens = thinkingTokensToYield
@@ -174,9 +209,23 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
                     continuation.yield(.token(token))
                 }
                 if !Task.isCancelled {
-                    for call in toolCalls {
-                        if Task.isCancelled { break }
-                        continuation.yield(.toolCall(call))
+                    if !deltaSequence.isEmpty {
+                        for entry in deltaSequence {
+                            if Task.isCancelled { break }
+                            switch entry {
+                            case .start(let callId, let name):
+                                continuation.yield(.toolCallStart(callId: callId, name: name))
+                            case .delta(let callId, let textDelta):
+                                continuation.yield(.toolCallArgumentsDelta(callId: callId, textDelta: textDelta))
+                            case .call(let call):
+                                continuation.yield(.toolCall(call))
+                            }
+                        }
+                    } else {
+                        for call in toolCalls {
+                            if Task.isCancelled { break }
+                            continuation.yield(.toolCall(call))
+                        }
                     }
                 }
                 self.isGenerating = false

--- a/Sources/BaseChatTestSupport/MockInferenceBackend.swift
+++ b/Sources/BaseChatTestSupport/MockInferenceBackend.swift
@@ -141,6 +141,12 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
         isGenerating = true
         // Per-turn scripting takes precedence when configured. Pop from the
         // front so successive generate() calls drive different turns.
+        //
+        // When this turn has a non-empty delta sequence it takes precedence
+        // for tool-call emission, so we must NOT also pop
+        // `scriptedToolCallsPerTurn` for this turn — otherwise mixing both
+        // queues silently desyncs future turns. Tokens for the turn still
+        // come from `tokensToYieldPerTurn` at the matching index.
         let toolCalls: [ToolCall]
         let tokens: [String]
         let deltaSequence: [ScriptedToolCallDelta]
@@ -149,7 +155,16 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
         } else {
             deltaSequence = []
         }
-        if !scriptedToolCallsPerTurn.isEmpty {
+        if !deltaSequence.isEmpty {
+            // Delta sequence drives tool calls this turn; leave the
+            // scriptedToolCallsPerTurn queue untouched.
+            toolCalls = []
+            if !tokensToYieldPerTurn.isEmpty {
+                tokens = tokensToYieldPerTurn.removeFirst()
+            } else {
+                tokens = tokensToYield
+            }
+        } else if !scriptedToolCallsPerTurn.isEmpty {
             toolCalls = scriptedToolCallsPerTurn.removeFirst()
             if !tokensToYieldPerTurn.isEmpty {
                 tokens = tokensToYieldPerTurn.removeFirst()

--- a/Sources/BaseChatTools/ScenarioRunner.swift
+++ b/Sources/BaseChatTools/ScenarioRunner.swift
@@ -97,6 +97,10 @@ public final class ScenarioRunner {
                     // Advisory pause signal from the orchestrator; scenarios
                     // are deterministic replays so we just keep accumulating.
                     continue
+                case .toolCallStart, .toolCallArgumentsDelta:
+                    // Streaming tool-call deltas are observational; the
+                    // authoritative call lands on `.toolCall(_:)`.
+                    continue
                 }
             }
 

--- a/Tests/BaseChatBackendsTests/CloudThinkingTokenTests.swift
+++ b/Tests/BaseChatBackendsTests/CloudThinkingTokenTests.swift
@@ -44,6 +44,7 @@ private func categorise(_ event: GenerationEvent) -> EventCategory? {
     case .kvCacheReuse: return nil
     case .diagnosticThrottle: return nil
     case .thinkingSignature: return nil
+    case .toolCallStart, .toolCallArgumentsDelta: return nil
     }
 }
 

--- a/Tests/BaseChatBackendsTests/OllamaToolCallLiveReplayTests.swift
+++ b/Tests/BaseChatBackendsTests/OllamaToolCallLiveReplayTests.swift
@@ -188,6 +188,11 @@ final class OllamaToolCallLiveReplayTests: XCTestCase {
                     // Cooperative thermal pause — informational only;
                     // raw backend replay neither emits nor projects it.
                     break
+                case .toolCallStart, .toolCallArgumentsDelta:
+                    // Streaming tool-call deltas are projected only by
+                    // backends that opt into `streamsToolCallArguments`;
+                    // the live Ollama replay parses whole calls.
+                    break
                 }
             }
 

--- a/Tests/BaseChatInferenceTests/GenerationCoordinatorToolLoopTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationCoordinatorToolLoopTests.swift
@@ -86,6 +86,60 @@ final class GenerationCoordinatorToolLoopTests: XCTestCase {
         ToolCall(id: id, toolName: name, arguments: arguments)
     }
 
+    // MARK: - Streaming tool-call deltas (#621)
+
+    func test_streamingToolCallDeltas_forwardedThroughCoordinatorStream() async throws {
+        // Backend emits start → delta → delta → toolCall in one turn,
+        // then a quiet final turn. The coordinator must forward the
+        // streaming-delta GenerationEvents verbatim — they are not
+        // reasoning/diagnostic events the coordinator should swallow.
+        let executor = RecordingExecutor(name: "get_weather") { _ in
+            ToolResult(callId: "", content: "sunny", errorKind: nil)
+        }
+        let registry = ToolRegistry()
+        registry.register(executor)
+
+        let call = makeCall(id: "sd-1", name: "get_weather", arguments: #"{"city":"Rome"}"#)
+        provider.backend.scriptedToolCallDeltasPerTurn = [
+            [
+                .start(callId: "sd-1", name: "get_weather"),
+                .delta(callId: "sd-1", textDelta: #"{"city"#),
+                .delta(callId: "sd-1", textDelta: #"":"Rome"}"#),
+                .call(call),
+            ],
+            [],
+        ]
+        provider.backend.tokensToYieldPerTurn = [[], ["bye"]]
+
+        let coordinator = makeCoordinator(registry: registry)
+        let (_, stream) = try coordinator.enqueue(
+            messages: [("user", "weather?")],
+            maxOutputTokens: 32
+        )
+
+        let events = try await collectEvents(stream)
+
+        let starts = events.compactMap { e -> (String, String)? in
+            if case .toolCallStart(let id, let name) = e { return (id, name) }
+            return nil
+        }
+        let deltas = events.compactMap { e -> (String, String)? in
+            if case .toolCallArgumentsDelta(let id, let d) = e { return (id, d) }
+            return nil
+        }
+        XCTAssertEqual(starts.count, 1)
+        XCTAssertEqual(starts.first?.0, "sd-1")
+        XCTAssertEqual(starts.first?.1, "get_weather")
+        XCTAssertEqual(deltas.map(\.1), [#"{"city"#, #"":"Rome"}"#])
+
+        // Authoritative call still lands.
+        let toolCalls = events.compactMap { e -> ToolCall? in
+            if case .toolCall(let c) = e { return c } else { return nil }
+        }
+        XCTAssertEqual(toolCalls.count, 1)
+        XCTAssertEqual(toolCalls.first?.id, "sd-1")
+    }
+
     // MARK: - End-to-end dispatch
 
     func test_toolCall_dispatchesThroughRegistry_andSurfacesResult() async throws {

--- a/Tests/BaseChatInferenceTests/ToolCallContractTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolCallContractTests.swift
@@ -207,6 +207,7 @@ final class ToolCallContractTests: XCTestCase {
             case .toolResult, .toolLoopLimitReached: break
             case .kvCacheReuse: break
             case .diagnosticThrottle: break
+            case .toolCallStart, .toolCallArgumentsDelta: break
             }
         }
 
@@ -277,6 +278,7 @@ final class ToolCallContractTests: XCTestCase {
             case .toolResult, .toolLoopLimitReached: break
             case .kvCacheReuse: break
             case .diagnosticThrottle: break
+            case .toolCallStart, .toolCallArgumentsDelta: break
             }
         }
 

--- a/Tests/BaseChatInferenceTests/ToolCallLoopOrchestratorTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolCallLoopOrchestratorTests.swift
@@ -265,6 +265,393 @@ final class ToolCallLoopOrchestratorTests: XCTestCase {
         XCTAssertEqual(unwrapped.callId, "c-9")
     }
 
+    // MARK: - Parallel dispatch fixtures
+
+    /// Test executor that gates `execute(arguments:)` on a per-call
+    /// continuation. Lets tests assert all N calls have *entered* execute()
+    /// before any is allowed to *return*. Stateless from the orchestrator's
+    /// point of view — `supportsConcurrentDispatch` is configurable.
+    @MainActor
+    private final class BlockingToolExecutor: ToolExecutor, @unchecked Sendable {
+        let definition: ToolDefinition
+        let supportsConcurrentDispatch: Bool
+
+        /// Continuations keyed by the unique tag the test injects via
+        /// `ToolCall.arguments` (we use a `{"tag":"..."}` JSON shape). The
+        /// test resolves a continuation to release that one in-flight call.
+        private var gates: [String: CheckedContinuation<String, Never>] = [:]
+
+        /// Tags that have entered `execute()` but not yet been released.
+        /// Surface for the test to spin on.
+        private(set) var enteredTags: Set<String> = []
+
+        /// Tags in the order their executions finished. Used by the
+        /// reverse-completion-order test to assert determinism of the
+        /// next-prompt assembly.
+        private(set) var completedTagsInOrder: [String] = []
+
+        init(name: String, supportsConcurrentDispatch: Bool) {
+            self.definition = ToolDefinition(name: name, description: "blocking", parameters: .object([:]))
+            self.supportsConcurrentDispatch = supportsConcurrentDispatch
+        }
+
+        func release(tag: String, with content: String) {
+            guard let cont = gates.removeValue(forKey: tag) else { return }
+            cont.resume(returning: content)
+        }
+
+        nonisolated func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+            // Pull the tag from the arguments — `{"tag":"..."}`.
+            var tag = ""
+            if case .object(let dict) = arguments,
+               case .string(let s) = dict["tag"] {
+                tag = s
+            }
+            let capturedTag = tag
+            let content: String = await withCheckedContinuation { (cont: CheckedContinuation<String, Never>) in
+                Task { @MainActor [capturedTag] in
+                    self.enteredTags.insert(capturedTag)
+                    self.gates[capturedTag] = cont
+                }
+            }
+            await MainActor.run { [capturedTag] in
+                self.completedTagsInOrder.append(capturedTag)
+            }
+            return ToolResult(callId: "", content: content, errorKind: nil)
+        }
+    }
+
+    /// Sequential-only executor that records the order in which `execute()`
+    /// is entered. Used to assert sequential semantics on the fallback path.
+    @MainActor
+    private final class RecordingSequentialExecutor: ToolExecutor, @unchecked Sendable {
+        let definition: ToolDefinition
+        let supportsConcurrentDispatch: Bool
+        private(set) var enteredTagsInOrder: [String] = []
+
+        init(name: String, supportsConcurrentDispatch: Bool = false) {
+            self.definition = ToolDefinition(name: name, description: "sequential", parameters: .object([:]))
+            self.supportsConcurrentDispatch = supportsConcurrentDispatch
+        }
+
+        nonisolated func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+            var tag = ""
+            if case .object(let dict) = arguments, case .string(let s) = dict["tag"] {
+                tag = s
+            }
+            let capturedTag = tag
+            await MainActor.run { [capturedTag] in
+                self.enteredTagsInOrder.append(capturedTag)
+            }
+            return ToolResult(callId: "", content: "ok-\(capturedTag)", errorKind: nil)
+        }
+    }
+
+    // MARK: - Parallel dispatch tests (#621)
+
+    func test_parallelDispatch_whenAllExecutorsSupportConcurrent_runsConcurrently() async throws {
+        let backend = makeBackend()
+        let calls = (0..<3).map { i in
+            ToolCall(id: "p-\(i)", toolName: "blocker", arguments: #"{"tag":"t\#(i)"}"#)
+        }
+        backend.scriptedToolCallsPerTurn = [calls, []]
+        backend.tokensToYieldPerTurn = [[], ["done"]]
+
+        let executor = BlockingToolExecutor(name: "blocker", supportsConcurrentDispatch: true)
+        let registry = ToolRegistry()
+        registry.register(executor)
+
+        let orchestrator = ToolCallLoopOrchestrator(
+            backend: backend,
+            registry: registry,
+            policy: ToolCallLoopPolicy(maxSteps: 4)
+        )
+
+        let stream = orchestrator.run(
+            initialPrompt: "go",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        let consumer = Task {
+            try await self.collect(stream)
+        }
+
+        // Wait until all three calls have entered execute() concurrently —
+        // the assertion is that all three enter before any returns. Spin
+        // bounded.
+        let deadline = ContinuousClock.now.advanced(by: .seconds(2))
+        while await executor.enteredTags.count < 3 && ContinuousClock.now < deadline {
+            await Task.yield()
+        }
+        let entered = await executor.enteredTags
+        XCTAssertEqual(entered, Set(["t0", "t1", "t2"]), "all three calls must be in flight together; got: \(entered)")
+        let completedSoFar = await executor.completedTagsInOrder
+        XCTAssertTrue(completedSoFar.isEmpty, "no executor should have completed yet")
+
+        // Release in arbitrary order. Sequence must still finish cleanly.
+        await executor.release(tag: "t1", with: "r1")
+        await executor.release(tag: "t0", with: "r0")
+        await executor.release(tag: "t2", with: "r2")
+
+        let events = try await consumer.value
+
+        // Three .toolResult events fire. The exact emission order matches
+        // batch-emission order (t0,t1,t2) — see preservesBatchOrder test.
+        let resultCount = events.filter { if case .toolResult = $0 { return true } else { return false } }.count
+        XCTAssertEqual(resultCount, 3)
+    }
+
+    func test_parallelDispatch_preservesBatchOrderInResults() async throws {
+        let backend = makeBackend()
+        let calls = (0..<3).map { i in
+            ToolCall(id: "ord-\(i)", toolName: "blocker", arguments: #"{"tag":"t\#(i)"}"#)
+        }
+        backend.scriptedToolCallsPerTurn = [calls, []]
+        backend.tokensToYieldPerTurn = [[], ["done"]]
+
+        let executor = BlockingToolExecutor(name: "blocker", supportsConcurrentDispatch: true)
+        let registry = ToolRegistry()
+        registry.register(executor)
+
+        let orchestrator = ToolCallLoopOrchestrator(
+            backend: backend,
+            registry: registry,
+            policy: ToolCallLoopPolicy(maxSteps: 4)
+        )
+
+        let stream = orchestrator.run(
+            initialPrompt: "go",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        let consumer = Task { try await self.collect(stream) }
+
+        // Wait for all three to enter execute() concurrently.
+        let deadline = ContinuousClock.now.advanced(by: .seconds(2))
+        while await executor.enteredTags.count < 3 && ContinuousClock.now < deadline {
+            await Task.yield()
+        }
+
+        // Release in REVERSE batch order — completion order (t2, t1, t0)
+        // diverges from emission order (t0, t1, t2). The orchestrator must
+        // still yield .toolResult / build the prompt appendix in batch
+        // order.
+        await executor.release(tag: "t2", with: "r2")
+        await executor.release(tag: "t1", with: "r1")
+        await executor.release(tag: "t0", with: "r0")
+
+        let events = try await consumer.value
+
+        // Sabotage check pivot: change the dispatchParallel sort to
+        // descending and this assertion flips.
+        let resultCallIds = events.compactMap { e -> String? in
+            if case .toolResult(let r) = e { return r.callId } else { return nil }
+        }
+        XCTAssertEqual(resultCallIds, ["ord-0", "ord-1", "ord-2"], "results must surface in batch-emission order, not completion order")
+
+        // The next-turn prompt must concatenate results in batch order too.
+        let lastPrompt = backend.lastPrompt ?? ""
+        let r0Range = lastPrompt.range(of: "result: r0")
+        let r1Range = lastPrompt.range(of: "result: r1")
+        let r2Range = lastPrompt.range(of: "result: r2")
+        XCTAssertNotNil(r0Range)
+        XCTAssertNotNil(r1Range)
+        XCTAssertNotNil(r2Range)
+        if let r0 = r0Range?.lowerBound, let r1 = r1Range?.lowerBound, let r2 = r2Range?.lowerBound {
+            XCTAssertLessThan(r0, r1, "prompt must list r0 before r1")
+            XCTAssertLessThan(r1, r2, "prompt must list r1 before r2")
+        }
+    }
+
+    func test_parallelDispatch_fallsBackToSequential_whenOneExecutorOptsOut() async throws {
+        let backend = makeBackend()
+        let calls = [
+            ToolCall(id: "a", toolName: "alpha", arguments: #"{"tag":"a"}"#),
+            ToolCall(id: "b", toolName: "beta",  arguments: #"{"tag":"b"}"#),
+            ToolCall(id: "c", toolName: "gamma", arguments: #"{"tag":"c"}"#),
+        ]
+        backend.scriptedToolCallsPerTurn = [calls, []]
+        backend.tokensToYieldPerTurn = [[], ["done"]]
+
+        let alpha = RecordingSequentialExecutor(name: "alpha", supportsConcurrentDispatch: true)
+        // beta opts out — single dissenter forces sequential dispatch for
+        // the whole batch.
+        let beta  = RecordingSequentialExecutor(name: "beta",  supportsConcurrentDispatch: false)
+        let gamma = RecordingSequentialExecutor(name: "gamma", supportsConcurrentDispatch: true)
+
+        let registry = ToolRegistry()
+        registry.register(alpha)
+        registry.register(beta)
+        registry.register(gamma)
+
+        let orchestrator = ToolCallLoopOrchestrator(
+            backend: backend,
+            registry: registry,
+            policy: ToolCallLoopPolicy(maxSteps: 4)
+        )
+
+        let events = try await collect(orchestrator.run(
+            initialPrompt: "go",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+
+        // Sequential dispatch enters executors strictly in batch order.
+        XCTAssertEqual(alpha.enteredTagsInOrder, ["a"])
+        XCTAssertEqual(beta.enteredTagsInOrder, ["b"])
+        XCTAssertEqual(gamma.enteredTagsInOrder, ["c"])
+
+        let resultIds = events.compactMap { e -> String? in
+            if case .toolResult(let r) = e { return r.callId } else { return nil }
+        }
+        XCTAssertEqual(resultIds, ["a", "b", "c"])
+    }
+
+    func test_parallelDispatch_cancellation_dropsLateResults() async throws {
+        let backend = makeBackend()
+        let calls = (0..<3).map { i in
+            ToolCall(id: "x-\(i)", toolName: "blocker", arguments: #"{"tag":"t\#(i)"}"#)
+        }
+        backend.scriptedToolCallsPerTurn = [calls, []]
+        backend.tokensToYieldPerTurn = [[], ["done"]]
+
+        let executor = BlockingToolExecutor(name: "blocker", supportsConcurrentDispatch: true)
+        let registry = ToolRegistry()
+        registry.register(executor)
+
+        let orchestrator = ToolCallLoopOrchestrator(
+            backend: backend,
+            registry: registry,
+            policy: ToolCallLoopPolicy(maxSteps: 4)
+        )
+
+        let stream = orchestrator.run(
+            initialPrompt: "go",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        // Drain the toolCall events but break before any results land.
+        let consumer = Task { () -> [ToolLoopEvent] in
+            var seen: [ToolLoopEvent] = []
+            do {
+                for try await event in stream {
+                    seen.append(event)
+                    if case .toolCall = event {
+                        if seen.filter({ if case .toolCall = $0 { return true } else { return false } }).count >= 3 {
+                            // Got all three .toolCall events. Drop the
+                            // stream — the parallel dispatch is now in
+                            // flight. onTermination cancels the driver.
+                            break
+                        }
+                    }
+                }
+            } catch {
+                // Expected during cancellation.
+            }
+            return seen
+        }
+
+        // Wait for all three executors to enter execute() so cancellation
+        // hits the in-flight task group.
+        let deadline = ContinuousClock.now.advanced(by: .seconds(2))
+        while await executor.enteredTags.count < 3 && ContinuousClock.now < deadline {
+            await Task.yield()
+        }
+        let enteredCount = await executor.enteredTags.count
+        XCTAssertEqual(enteredCount, 3)
+
+        // Consumer drops the stream. Cancellation propagates into the task
+        // group. Now release one of the executors — this would normally
+        // produce a .toolResult, but the consumer is gone and the
+        // orchestrator's parallel path checks Task.isCancelled before
+        // yielding anything.
+        let observed = try await consumer.value
+        await executor.release(tag: "t0", with: "late")
+        await executor.release(tag: "t1", with: "late")
+        await executor.release(tag: "t2", with: "late")
+
+        // No .toolResult events were observed by the consumer.
+        let toolResults = observed.filter { if case .toolResult = $0 { return true } else { return false } }
+        XCTAssertEqual(toolResults.count, 0, "no .toolResult should have leaked after cancellation; saw: \(observed)")
+    }
+
+    // MARK: - Streaming delta forwarding
+
+    func test_streamingDeltas_forwardedThroughOrchestrator() async throws {
+        let backend = makeBackend()
+        // Backend emits two streamed calls in a single turn:
+        //   start(c1) → delta(c1,'{"a"') → delta(c1,':1}') → call(c1)
+        //   start(c2) → delta(c2,'{"b":2}') → call(c2)
+        // then a quiet final turn with one visible token.
+        let call1 = ToolCall(id: "c1", toolName: "first",  arguments: #"{"a":1}"#)
+        let call2 = ToolCall(id: "c2", toolName: "second", arguments: #"{"b":2}"#)
+        backend.scriptedToolCallDeltasPerTurn = [
+            [
+                .start(callId: "c1", name: "first"),
+                .delta(callId: "c1", textDelta: #"{"a"#),
+                .delta(callId: "c1", textDelta: #"":1}"#),
+                .call(call1),
+                .start(callId: "c2", name: "second"),
+                .delta(callId: "c2", textDelta: #"{"b":2}"#),
+                .call(call2),
+            ],
+            [],
+        ]
+        backend.tokensToYieldPerTurn = [[], ["bye"]]
+
+        let executor = ScriptedExecutor(name: "first") { _ in
+            ToolResult(callId: "", content: "ok-1", errorKind: nil)
+        }
+        let executor2 = ScriptedExecutor(name: "second") { _ in
+            ToolResult(callId: "", content: "ok-2", errorKind: nil)
+        }
+        let registry = ToolRegistry()
+        registry.register(executor)
+        registry.register(executor2)
+
+        let orchestrator = ToolCallLoopOrchestrator(
+            backend: backend,
+            registry: registry,
+            policy: ToolCallLoopPolicy(maxSteps: 4)
+        )
+
+        let events = try await collect(orchestrator.run(
+            initialPrompt: "go",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+
+        // Pull the streaming-delta events in the order they appeared.
+        let streamShape: [ToolLoopEvent] = events.compactMap { e in
+            switch e {
+            case .toolCallStart, .toolCallArgumentsDelta, .toolCall:
+                return e
+            default:
+                return nil
+            }
+        }
+
+        XCTAssertEqual(streamShape.count, 7, "must forward 5 deltas + 2 .toolCalls verbatim")
+        XCTAssertEqual(streamShape[0], .toolCallStart(callId: "c1", name: "first"))
+        XCTAssertEqual(streamShape[1], .toolCallArgumentsDelta(callId: "c1", textDelta: #"{"a"#))
+        XCTAssertEqual(streamShape[2], .toolCallArgumentsDelta(callId: "c1", textDelta: #"":1}"#))
+        if case .toolCall(let c) = streamShape[3] {
+            XCTAssertEqual(c.id, "c1")
+        } else {
+            XCTFail("event 3 must be .toolCall(c1)")
+        }
+        XCTAssertEqual(streamShape[4], .toolCallStart(callId: "c2", name: "second"))
+        XCTAssertEqual(streamShape[5], .toolCallArgumentsDelta(callId: "c2", textDelta: #"{"b":2}"#))
+        if case .toolCall(let c) = streamShape[6] {
+            XCTAssertEqual(c.id, "c2")
+        } else {
+            XCTFail("event 6 must be .toolCall(c2)")
+        }
+    }
+
     // MARK: - Registry init
 
     func test_registryInit_routesByToolName() async throws {

--- a/Tests/BaseChatInferenceTests/ToolCallLoopOrchestratorTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolCallLoopOrchestratorTests.swift
@@ -634,7 +634,11 @@ final class ToolCallLoopOrchestratorTests: XCTestCase {
             }
         }
 
-        XCTAssertEqual(streamShape.count, 7, "must forward 5 deltas + 2 .toolCalls verbatim")
+        XCTAssertEqual(
+            streamShape.count,
+            7,
+            "must forward 2 .toolCallStart + 3 .toolCallArgumentsDelta + 2 .toolCall events verbatim"
+        )
         XCTAssertEqual(streamShape[0], .toolCallStart(callId: "c1", name: "first"))
         XCTAssertEqual(streamShape[1], .toolCallArgumentsDelta(callId: "c1", textDelta: #"{"a"#))
         XCTAssertEqual(streamShape[2], .toolCallArgumentsDelta(callId: "c1", textDelta: #"":1}"#))


### PR DESCRIPTION
## Summary
- Adds `.toolCallStart` and `.toolCallArgumentsDelta` to `GenerationEvent` for streaming tool-call deltas (#436 prerequisite).
- `ToolCallLoopOrchestrator` dispatches multi-call rounds via `withTaskGroup` when every executor opts in via the new `ToolExecutor.supportsConcurrentDispatch` (default `false` — sequential semantics preserved).
- Result order in the next-turn prompt is preserved by batch-index sort, regardless of completion order, to keep prefix-cache reuse stable.
- Two new `BackendCapabilities` flags: `streamsToolCallArguments` and `supportsParallelToolCalls`. Cloud backends flip these in the follow-up PR.

## Why this shape (post persona review)
- `case toolCall(ToolCall)` retained as the universal call-complete event — proposed `toolCallEnd` / `toolCallBatch` were rejected as redundant by all three reviewers (consumer ordering trap; backends can be wrong; orchestrator can derive the batch internally).
- Streaming deltas are opt-in per backend (`streamsToolCallArguments`) — MLX inline parser and non-streaming Ollama can't emit honest character-granularity deltas.
- Parallel dispatch is opt-in per executor (`supportsConcurrentDispatch`) — preserves `ToolRegistry` reentrancy contract for tools with shared state.

## Test plan
- Unit: parallel dispatch concurrency, batch-order result determinism, sequential fallback when an executor opts out, cancellation drops late results, streaming delta forwarding.
- Sabotage check ran (and removed) on the batch-order sort path — confirmed `test_parallelDispatch_preservesBatchOrderInResults` fails when sort goes descending.
- All six CI suites green locally with `--disable-default-traits`.

Closes #621.