### PR TITLE
fix(test): declare BaseChatTools dependency on BaseChatE2ETests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -208,7 +208,7 @@ let package = Package(
         ),
         .testTarget(
             name: "BaseChatE2ETests",
-            dependencies: ["BaseChatBackends", "BaseChatUI", "BaseChatCore", "BaseChatInference", "BaseChatTestSupport"],
+            dependencies: ["BaseChatBackends", "BaseChatUI", "BaseChatCore", "BaseChatInference", "BaseChatTestSupport", "BaseChatTools"],
             swiftSettings: [
                 .define("MLX", .when(traits: ["MLX"])),
                 .define("Llama", .when(traits: ["Llama"])),


### PR DESCRIPTION
## Summary

\`Tests/BaseChatE2ETests/DemoScenarioOllamaE2ETests.swift\` imports \`BaseChatTools\` (under \`#if Ollama\`), but \`BaseChatE2ETests\`'s dependency list in \`Package.swift\` omits it. \`swift test\` linked successfully via a transitive path, so the gap stayed invisible — but \`xcodebuild test\` fails the link step, blocking the full \`BaseChatMLXIntegrationTests\` run from Xcode.

This was introduced in PR #710 (Demo Scenarios picker) which added the \`import BaseChatTools\` without updating the test target deps.

## Test plan

- [x] \`xcodebuild test -scheme BaseChatKit-Package -only-testing BaseChatMLXIntegrationTests -destination 'platform=macOS'\` — passes after fix; failed with \`Undefined symbol: BaseChatTools.SandboxResolver.resolve(...)\` etc. before fix.
- [x] \`swift test --filter OllamaE2ETests --traits Ollama\` — still passes (10 tests).
- [x] \`swift test --filter BaseChatE2ETests --traits MLX,Llama\` — still passes (13 tests, 2 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)