### PR TITLE
refactor(ui): consolidate persistence guard into requirePersistence helper

### DIFF
--- a/Sources/BaseChatUI/Internal/PersistenceGuard.swift
+++ b/Sources/BaseChatUI/Internal/PersistenceGuard.swift
@@ -1,0 +1,112 @@
+import Foundation
+import BaseChatCore
+import BaseChatInference
+
+// MARK: - Persistence guard helpers
+//
+// View models in this module repeatedly check `persistence != nil` before
+// touching the configured `ChatPersistenceProvider`. The two helpers below
+// centralize that check so call sites stop reinventing the same `guard let
+// persistence else { Log.persistence.warning(...); return/throw }` block.
+//
+// - `requirePersistence(_:)` is for code paths that propagate a missing
+//   provider as a `ChatPersistenceError.providerNotConfigured` to the caller.
+// - `persistenceOrLog(_:)` is for code paths that no-op (returning early) when
+//   persistence is unavailable — typically `loadMessages`-style read-or-skip
+//   methods.
+//
+// Both helpers log via `Log.persistence` and include `#fileID:#line` so the
+// emitted warning still points back at the calling method even though the
+// guard itself lives here.
+
+@inline(__always)
+private func logMissingPersistence(
+    _ context: String,
+    fileID: StaticString,
+    line: UInt
+) {
+    // The OSLog macro captures interpolated arguments in an escaping closure,
+    // so we materialise the context string before handing it off rather than
+    // passing an `@autoclosure` parameter through the interpolation directly.
+    Log.persistence.warning(
+        "\(context, privacy: .public) called before persistence was configured (\(fileID, privacy: .public):\(line, privacy: .public))"
+    )
+}
+
+extension SessionController {
+    func requirePersistence(
+        _ context: @autoclosure () -> String,
+        fileID: StaticString = #fileID,
+        line: UInt = #line
+    ) throws -> ChatPersistenceProvider {
+        guard let persistence else {
+            logMissingPersistence(context(), fileID: fileID, line: line)
+            throw ChatPersistenceError.providerNotConfigured
+        }
+        return persistence
+    }
+
+    func persistenceOrLog(
+        _ context: @autoclosure () -> String,
+        fileID: StaticString = #fileID,
+        line: UInt = #line
+    ) -> ChatPersistenceProvider? {
+        guard let persistence else {
+            logMissingPersistence(context(), fileID: fileID, line: line)
+            return nil
+        }
+        return persistence
+    }
+}
+
+extension SessionManagerViewModel {
+    func requirePersistence(
+        _ context: @autoclosure () -> String,
+        fileID: StaticString = #fileID,
+        line: UInt = #line
+    ) throws -> ChatPersistenceProvider {
+        guard let persistence else {
+            logMissingPersistence(context(), fileID: fileID, line: line)
+            throw ChatPersistenceError.providerNotConfigured
+        }
+        return persistence
+    }
+
+    func persistenceOrLog(
+        _ context: @autoclosure () -> String,
+        fileID: StaticString = #fileID,
+        line: UInt = #line
+    ) -> ChatPersistenceProvider? {
+        guard let persistence else {
+            logMissingPersistence(context(), fileID: fileID, line: line)
+            return nil
+        }
+        return persistence
+    }
+}
+
+extension ChatViewModel {
+    func requirePersistence(
+        _ context: @autoclosure () -> String,
+        fileID: StaticString = #fileID,
+        line: UInt = #line
+    ) throws -> ChatPersistenceProvider {
+        guard let persistence else {
+            logMissingPersistence(context(), fileID: fileID, line: line)
+            throw ChatPersistenceError.providerNotConfigured
+        }
+        return persistence
+    }
+
+    func persistenceOrLog(
+        _ context: @autoclosure () -> String,
+        fileID: StaticString = #fileID,
+        line: UInt = #line
+    ) -> ChatPersistenceProvider? {
+        guard let persistence else {
+            logMissingPersistence(context(), fileID: fileID, line: line)
+            return nil
+        }
+        return persistence
+    }
+}

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Ingest.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Ingest.swift
@@ -37,10 +37,7 @@ extension ChatViewModel {
             "ChatViewModel.ingest source=\(String(describing: payload.source), privacy: .public) prompt chars=\(payload.prompt.count, privacy: .public)"
         )
 
-        guard let persistence else {
-            Log.ui.warning("ChatViewModel.ingest called before persistence was configured")
-            return
-        }
+        guard let persistence = persistenceOrLog("ingest") else { return }
 
         // Create and activate a fresh session so the ingested prompt starts
         // its own conversation rather than landing in whichever chat was

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+IngestPendingPayload.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+IngestPendingPayload.swift
@@ -183,12 +183,7 @@ extension ChatViewModel {
         _ payload: PendingPayload,
         preset: IngestionPreset?
     ) async {
-        guard let persistence else {
-            Log.ui.warning(
-                "ChatViewModel.ingestPendingPayload(.newSession) called before persistence was configured"
-            )
-            return
-        }
+        guard let persistence = persistenceOrLog("ingestPendingPayload(.newSession)") else { return }
 
         // Pre-resolve the system prompt so the new session is inserted
         // with the preset already applied — avoids a second persistence

--- a/Sources/BaseChatUI/ViewModels/SessionController.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionController.swift
@@ -66,10 +66,7 @@ final class SessionController {
         session.updatedAt = date
         activeSession = session
 
-        guard let persistence else {
-            Log.persistence.warning("touchActiveSessionUpdatedAt called before persistence was configured")
-            return
-        }
+        guard let persistence = persistenceOrLog("touchActiveSessionUpdatedAt") else { return }
 
         do {
             try persistence.updateSession(session)
@@ -85,10 +82,7 @@ final class SessionController {
         selectedEndpointID: UUID?
     ) throws {
         guard var session = activeSession else { return }
-        guard let persistence else {
-            Log.persistence.warning("saveSettingsToSession called before persistence was configured")
-            throw ChatPersistenceError.providerNotConfigured
-        }
+        let persistence = try requirePersistence("saveSettingsToSession")
         session.temperature = temperature
         session.topP = topP
         session.repeatPenalty = repeatPenalty
@@ -103,10 +97,7 @@ final class SessionController {
     }
 
     func loadMessages() {
-        guard let persistence else {
-            Log.persistence.warning("loadMessages called before persistence was configured — messages will not load")
-            return
-        }
+        guard let persistence = persistenceOrLog("loadMessages") else { return }
         guard let sessionID = activeSessionID else {
             messages = []
             hasOlderMessages = false
@@ -163,10 +154,7 @@ final class SessionController {
     }
 
     func saveMessage(_ message: ChatMessageRecord) throws {
-        guard let persistence else {
-            Log.persistence.warning("saveMessage called before persistence was configured — message will not be persisted")
-            return
-        }
+        guard let persistence = persistenceOrLog("saveMessage") else { return }
         do {
             try persistence.updateMessage(message)
         } catch ChatPersistenceError.messageNotFound {
@@ -175,26 +163,17 @@ final class SessionController {
     }
 
     func updateMessage(_ message: ChatMessageRecord) throws {
-        guard let persistence else {
-            Log.persistence.warning("updateMessage called before persistence was configured — message will not be updated")
-            return
-        }
+        guard let persistence = persistenceOrLog("updateMessage") else { return }
         try persistence.updateMessage(message)
     }
 
     func deleteMessage(_ message: ChatMessageRecord) throws {
-        guard let persistence else {
-            Log.persistence.warning("deleteMessage called before persistence was configured — message will not be deleted")
-            return
-        }
+        guard let persistence = persistenceOrLog("deleteMessage") else { return }
         try persistence.deleteMessage(message.id)
     }
 
     func deleteMessages(for sessionID: UUID) throws {
-        guard let persistence else {
-            Log.persistence.warning("deleteMessages called before persistence was configured — messages will not be deleted")
-            return
-        }
+        guard let persistence = persistenceOrLog("deleteMessages") else { return }
         try persistence.deleteMessages(for: sessionID)
     }
 }

--- a/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
@@ -63,7 +63,7 @@ public final class SessionManagerViewModel {
     /// their most recent matching message.
     public private(set) var messageMatchSessions: [ChatSessionRecord] = []
 
-    private var persistence: ChatPersistenceProvider?
+    var persistence: ChatPersistenceProvider?
 
     /// Optional diagnostics sink for non-fatal operational failures
     /// (e.g., auto-rename inference errors). Inject via `configure` so
@@ -91,10 +91,7 @@ public final class SessionManagerViewModel {
     /// manually tapped a row.
     @discardableResult
     public func createSession(title: String = "New Chat") throws -> ChatSessionRecord {
-        guard let persistence else {
-            Log.persistence.warning("createSession called before persistence was configured")
-            throw ChatPersistenceError.providerNotConfigured
-        }
+        let persistence = try requirePersistence("createSession")
         let record = ChatSessionRecord(title: title)
         try persistence.insertSession(record)
         loadSessions()
@@ -104,10 +101,7 @@ public final class SessionManagerViewModel {
 
     /// Deletes a session and all its messages.
     public func deleteSession(_ session: ChatSessionRecord) throws {
-        guard let persistence else {
-            Log.persistence.warning("deleteSession called before persistence was configured")
-            throw ChatPersistenceError.providerNotConfigured
-        }
+        let persistence = try requirePersistence("deleteSession")
         try persistence.deleteSession(session.id)
 
         if activeSession?.id == session.id {
@@ -119,10 +113,7 @@ public final class SessionManagerViewModel {
 
     /// Renames a session.
     public func renameSession(_ session: ChatSessionRecord, title: String) throws {
-        guard let persistence else {
-            Log.persistence.warning("renameSession called before persistence was configured")
-            throw ChatPersistenceError.providerNotConfigured
-        }
+        let persistence = try requirePersistence("renameSession")
         var updated = session
         updated.title = title
         updated.updatedAt = Date()
@@ -262,9 +253,7 @@ public final class SessionManagerViewModel {
     /// ``sessions``; this method does not mutate VM state directly so tests
     /// can assert on raw page contents.
     public func fetchSessionsPage(offset: Int, limit: Int) throws -> [ChatSessionRecord] {
-        guard let persistence else {
-            throw ChatPersistenceError.providerNotConfigured
-        }
+        let persistence = try requirePersistence("fetchSessionsPage")
         return try persistence.fetchSessions(offset: offset, limit: limit)
     }
 

--- a/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
@@ -63,7 +63,7 @@ public final class SessionManagerViewModel {
     /// their most recent matching message.
     public private(set) var messageMatchSessions: [ChatSessionRecord] = []
 
-    var persistence: ChatPersistenceProvider?
+    private(set) var persistence: ChatPersistenceProvider?
 
     /// Optional diagnostics sink for non-fatal operational failures
     /// (e.g., auto-rename inference errors). Inject via `configure` so

--- a/Tests/BaseChatUITests/PersistenceGuardTests.swift
+++ b/Tests/BaseChatUITests/PersistenceGuardTests.swift
@@ -1,0 +1,139 @@
+@preconcurrency import XCTest
+import SwiftData
+@testable import BaseChatUI
+@testable import BaseChatCore
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Coverage for the `requirePersistence` / `persistenceOrLog` helpers added in
+/// `Sources/BaseChatUI/Internal/PersistenceGuard.swift`. Twelve cases — three
+/// holding types (`SessionController`, `SessionManagerViewModel`,
+/// `ChatViewModel`) crossed with two helpers and the configured / not-configured
+/// states — keep the helper from regressing as new call sites adopt it.
+@MainActor
+final class PersistenceGuardTests: XCTestCase {
+
+    private var container: ModelContainer!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        container = try makeInMemoryContainer()
+    }
+
+    override func tearDown() async throws {
+        container = nil
+        try await super.tearDown()
+    }
+
+    private func provider() -> ChatPersistenceProvider {
+        SwiftDataPersistenceProvider(modelContext: container.mainContext)
+    }
+
+    // MARK: - SessionController
+
+    func test_sessionController_requirePersistence_throwsWhenNil() {
+        let sut = SessionController()
+        XCTAssertThrowsError(try sut.requirePersistence("ctx")) { error in
+            switch error {
+            case ChatPersistenceError.providerNotConfigured:
+                break
+            default:
+                XCTFail("Expected providerNotConfigured, got \(error)")
+            }
+        }
+    }
+
+    func test_sessionController_requirePersistence_returnsProviderWhenConfigured() throws {
+        let sut = SessionController()
+        let provider = provider()
+        sut.persistence = provider
+        let resolved = try sut.requirePersistence("ctx")
+        XCTAssertTrue(resolved === provider)
+    }
+
+    func test_sessionController_persistenceOrLog_returnsNilWhenNil() {
+        let sut = SessionController()
+        XCTAssertNil(sut.persistenceOrLog("ctx"))
+    }
+
+    func test_sessionController_persistenceOrLog_returnsProviderWhenConfigured() {
+        let sut = SessionController()
+        let provider = provider()
+        sut.persistence = provider
+        let resolved = sut.persistenceOrLog("ctx")
+        XCTAssertNotNil(resolved)
+        XCTAssertTrue(resolved === provider)
+    }
+
+    // MARK: - SessionManagerViewModel
+
+    func test_sessionManager_requirePersistence_throwsWhenNil() {
+        let sut = SessionManagerViewModel()
+        XCTAssertThrowsError(try sut.requirePersistence("ctx")) { error in
+            switch error {
+            case ChatPersistenceError.providerNotConfigured:
+                break
+            default:
+                XCTFail("Expected providerNotConfigured, got \(error)")
+            }
+        }
+    }
+
+    func test_sessionManager_requirePersistence_returnsProviderWhenConfigured() throws {
+        let sut = SessionManagerViewModel()
+        let provider = provider()
+        sut.configure(persistence: provider)
+        let resolved = try sut.requirePersistence("ctx")
+        XCTAssertTrue(resolved === provider)
+    }
+
+    func test_sessionManager_persistenceOrLog_returnsNilWhenNil() {
+        let sut = SessionManagerViewModel()
+        XCTAssertNil(sut.persistenceOrLog("ctx"))
+    }
+
+    func test_sessionManager_persistenceOrLog_returnsProviderWhenConfigured() {
+        let sut = SessionManagerViewModel()
+        let provider = provider()
+        sut.configure(persistence: provider)
+        let resolved = sut.persistenceOrLog("ctx")
+        XCTAssertNotNil(resolved)
+        XCTAssertTrue(resolved === provider)
+    }
+
+    // MARK: - ChatViewModel
+
+    func test_chatViewModel_requirePersistence_throwsWhenNil() {
+        let sut = ChatViewModel(inferenceService: InferenceService(backend: MockInferenceBackend(), name: "Mock"))
+        XCTAssertThrowsError(try sut.requirePersistence("ctx")) { error in
+            switch error {
+            case ChatPersistenceError.providerNotConfigured:
+                break
+            default:
+                XCTFail("Expected providerNotConfigured, got \(error)")
+            }
+        }
+    }
+
+    func test_chatViewModel_requirePersistence_returnsProviderWhenConfigured() throws {
+        let sut = ChatViewModel(inferenceService: InferenceService(backend: MockInferenceBackend(), name: "Mock"))
+        let provider = provider()
+        sut.configure(persistence: provider)
+        let resolved = try sut.requirePersistence("ctx")
+        XCTAssertTrue(resolved === provider)
+    }
+
+    func test_chatViewModel_persistenceOrLog_returnsNilWhenNil() {
+        let sut = ChatViewModel(inferenceService: InferenceService(backend: MockInferenceBackend(), name: "Mock"))
+        XCTAssertNil(sut.persistenceOrLog("ctx"))
+    }
+
+    func test_chatViewModel_persistenceOrLog_returnsProviderWhenConfigured() {
+        let sut = ChatViewModel(inferenceService: InferenceService(backend: MockInferenceBackend(), name: "Mock"))
+        let provider = provider()
+        sut.configure(persistence: provider)
+        let resolved = sut.persistenceOrLog("ctx")
+        XCTAssertNotNil(resolved)
+        XCTAssertTrue(resolved === provider)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `requirePersistence(_:)` (throws) and `persistenceOrLog(_:)` (returns Optional) helpers to `SessionController`, `SessionManagerViewModel`, and `ChatViewModel`
- Replaces 12 hand-rolled guard blocks; centralizes log channel (`Log.persistence`) and error type
- Logs include `#fileID:#line` so warnings still attribute to the calling method
- Two truly-silent sites (`SessionController.loadOlderMessages`, `SessionManagerViewModel.loadSessions`) and Optional-question-mark accesses (`autoRenameSession`, `autoGenerateTitle`) intentionally unchanged
- `SessionManagerViewModel.fetchSessionsPage` now logs on the missing-persistence path (it was previously silent before throwing)
- `SessionManagerViewModel.persistence` widened from `private` to internal so the helper extension in `Internal/PersistenceGuard.swift` can read it

## Plan deviations / classification corrections
- Plan classified `ChatViewModel+Ingest.swift:40` and `ChatViewModel+IngestPendingPayload.swift:186` as throwing — both functions are `async` (not `async throws`) so they were treated as `persistenceOrLog` returns
- Plan referenced `SessionController:195` / `:229` as Optional-question-mark accesses; the file ends at line 200 and contains no such accesses. The Optional-question-mark sites the plan was likely thinking of live in `SessionManagerViewModel.swift` (`autoRenameSession:195`, `autoGenerateTitle:229`) and were left alone as instructed
- 12 sites refactored, not 14 (the two non-existent SessionController sites accounted for the difference)

## Test plan
- [x] `BaseChatUITests` pass (529 tests including new `PersistenceGuardTests` × 12)
- [x] `BaseChatCoreTests` / `BaseChatInferenceTests` / `BaseChatInferenceSwiftTestingTests` / `BaseChatBackendsTests` / `BaseChatTestSupportTests` all pass
- [x] `SilentCatchAuditTest` still passes (no new `try?` introduced — verified by grep)
- [x] Sabotage check: swapped throw to `.sessionNotFound` → 3 throwsWhenNil tests failed; reverted

Plan: `/Users/roryford/.claude/plans/pull-main-keep-looking-starry-panda.md` (Worker B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)