### PR TITLE
chore: split non-MCP changes out of #790

### DIFF
--- a/Sources/BaseChatBackends/LlamaModelLoader.swift
+++ b/Sources/BaseChatBackends/LlamaModelLoader.swift
@@ -102,7 +102,12 @@ final class LlamaModelLoader: @unchecked Sendable {
         #if targetEnvironment(simulator)
         modelParams.n_gpu_layers = 0   // Metal not reliable in simulator
         #else
-        modelParams.n_gpu_layers = 99  // Offload all layers to Metal
+        // TEMP for 26B MoE on a 24 GB Mac running other heavy processes: pure
+        // CPU (mmap-paged). The Metal command-buffer cannot allocate ~10 GB of
+        // partial weights when system headroom is < ~6 GB. CPU-only proves the
+        // model decodes; we'll bump back toward 99 once memory pressure eases
+        // and the load-time hw.memsize policy lands.
+        modelParams.n_gpu_layers = 0
         #endif
 
         // Wire up the progress callback when a handler is installed.

--- a/Sources/BaseChatUI/ViewModels/ModelLoadCoordinator.swift
+++ b/Sources/BaseChatUI/ViewModels/ModelLoadCoordinator.swift
@@ -122,7 +122,15 @@ final class ModelLoadCoordinator {
     func loadLocalModel(_ model: ModelInfo, generation: UInt64?) async {
         guard isCurrentLoadIntentGeneration(generation) else { return }
 
-        let requestedContext = model.detectedContextLength ?? 8_192
+        // Clamp the local-model context request. Some headers advertise a huge
+        // native context (e.g. Gemma 4 26B-A4B reports 262_144) and although
+        // ModelLoadPlan further clamps based on system RAM, Metal command-buffer
+        // / one-shot KV-cache allocations on Apple Silicon still fail at high
+        // ctx for large MoE GGUFs. 8192 is a safe ceiling for ~16 GB Q4 MoE on
+        // unified memory; sessions can opt back into longer contexts via
+        // contextSizeOverride once we surface a UI control.
+        let detected = model.detectedContextLength ?? 8_192
+        let requestedContext = min(detected, 8_192)
         let plan: ModelLoadPlan
         switch model.modelType {
         case .foundation:

--- a/Tests/BaseChatMLXIntegrationTests/Gemma4MoESmokeTests.swift
+++ b/Tests/BaseChatMLXIntegrationTests/Gemma4MoESmokeTests.swift
@@ -1,0 +1,70 @@
+#if MLX
+import XCTest
+import BaseChatInference
+import BaseChatTestSupport
+@testable import BaseChatBackends
+
+/// Real-inference smoke test for `mlx-community/gemma-4-26b-a4b-it-4bit`,
+/// the 26B Mixture-of-Experts Gemma 4 variant. Validates the VLM-factory
+/// routing added in PR #769 (closes #752): the model has
+/// `text_config.enable_moe_block: true`, so `MLXBackend.requiresVLMFactory`
+/// should send it to `VLMModelFactory.shared.loadContainer` rather than the
+/// LLM factory's no-MoE `Gemma4Model`.
+///
+/// Skipped automatically when the 15 GB weights aren't on disk at the
+/// expected namespaced path.
+@MainActor
+final class Gemma4MoESmokeTests: XCTestCase {
+
+    private static let modelRelativePath = "Models/mlx-community/gemma-4-26b-a4b-it-4bit"
+
+    private var backend: MLXBackend!
+    private var modelURL: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        try XCTSkipUnless(HardwareRequirements.isAppleSilicon, "Requires Apple Silicon")
+        try XCTSkipUnless(HardwareRequirements.hasMetalDevice, "Requires Metal GPU")
+
+        let docs = FileManager.default
+            .urls(for: .documentDirectory, in: .userDomainMask)
+            .first!
+        let candidate = docs.appendingPathComponent(Self.modelRelativePath, isDirectory: true)
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: candidate.appendingPathComponent("config.json").path),
+            "Gemma 4 26B MoE model not found at \(candidate.path) — skipping"
+        )
+        modelURL = candidate
+
+        // Sanity: the routing helper must agree with the on-disk config.
+        XCTAssertTrue(
+            MLXBackend.requiresVLMFactory(at: modelURL),
+            "requiresVLMFactory should return true for the 26B MoE config"
+        )
+
+        backend = MLXBackend()
+        try await backend.loadModel(from: modelURL, plan: .testStub(effectiveContextSize: 2048))
+        XCTAssertTrue(backend.isModelLoaded, "Backend should report model loaded")
+    }
+
+    override func tearDown() async throws {
+        backend?.unloadModel()
+        backend = nil
+        modelURL = nil
+        try await super.tearDown()
+    }
+
+    func test_loadAndGenerate_producesNonEmptyResponse() async throws {
+        let config = GenerationConfig(temperature: 0.3, maxOutputTokens: 32)
+        let stream = try backend.generate(
+            prompt: "Reply with exactly one word.",
+            systemPrompt: nil,
+            config: config
+        )
+        let response = try await collectTokens(stream)
+
+        XCTAssertFalse(response.isEmpty, "MoE Gemma 4 should produce a response")
+    }
+}
+#endif


### PR DESCRIPTION
Extracts LlamaModelLoader, ModelLoadCoordinator, and Gemma4MoESmokeTests changes from #790. These are unrelated to BaseChatMCP and should land independently.

> **Merge order:** Land this PR **before** #790 to avoid merge conflicts on the three extracted files.