### PR TITLE
feat(backends): introduce BackendRegistrar protocol and per-backend register hooks

### DIFF
--- a/Sources/BaseChatBackends/BackendRegistrar.swift
+++ b/Sources/BaseChatBackends/BackendRegistrar.swift
@@ -1,0 +1,14 @@
+import BaseChatInference
+
+/// A unit of backend registration that can be folded over to bootstrap an
+/// `InferenceService`. Conforming types own a single backend family
+/// (MLX, Llama, Foundation, Cloud) and register their factories and
+/// supported model types on the supplied service.
+///
+/// `register(with:)` must be a no-op when its trait is disabled — never a
+/// missing-symbol link error. Trait gates live inside the function body,
+/// not at file scope, so consumers can call any registrar regardless of
+/// build configuration.
+public protocol BackendRegistrar {
+    @MainActor static func register(with service: InferenceService)
+}

--- a/Sources/BaseChatBackends/CloudBackends.swift
+++ b/Sources/BaseChatBackends/CloudBackends.swift
@@ -1,0 +1,35 @@
+import BaseChatInference
+
+public enum CloudBackends: BackendRegistrar {
+    @MainActor
+    public static func register(with service: InferenceService) {
+        #if CloudSaaS
+        PinnedSessionDelegate.loadDefaultPins()
+        #endif
+
+        service.registerCloudBackendFactory { provider in
+            switch provider {
+            #if CloudSaaS
+            case .claude:                     return ClaudeBackend()
+            case .openAI, .lmStudio, .custom: return OpenAIBackend()
+            case .openAIResponses:            return OpenAIResponsesBackend()
+            #endif
+            #if Ollama
+            // FIXME(#714): expected deprecation warning until the next major
+            // release flips `Ollama` out of default traits. This internal
+            // registration is the supported migration path consumers are
+            // pointed at — silencing the warning here would defeat the
+            // signal it sends to direct callers of `OllamaBackend()`.
+            case .ollama:                     return OllamaBackend()
+            #endif
+            default: return nil
+            }
+        }
+
+        // Declare every provider this build can actually serve — depends on
+        // which of `Ollama` / `CloudSaaS` traits is enabled.
+        for provider in APIProvider.availableInBuild {
+            service.declareSupport(for: provider)
+        }
+    }
+}

--- a/Sources/BaseChatBackends/CloudBackends.swift
+++ b/Sources/BaseChatBackends/CloudBackends.swift
@@ -3,6 +3,11 @@ import BaseChatInference
 public enum CloudBackends: BackendRegistrar {
     @MainActor
     public static func register(with service: InferenceService) {
+        // Honour the BackendRegistrar contract: registration is a no-op when
+        // every trait this registrar covers is disabled. Without this gate
+        // we'd attach an always-nil factory and contradict the protocol
+        // docstring.
+        #if CloudSaaS || Ollama
         #if CloudSaaS
         PinnedSessionDelegate.loadDefaultPins()
         #endif
@@ -31,5 +36,6 @@ public enum CloudBackends: BackendRegistrar {
         for provider in APIProvider.availableInBuild {
             service.declareSupport(for: provider)
         }
+        #endif
     }
 }

--- a/Sources/BaseChatBackends/DefaultBackends.swift
+++ b/Sources/BaseChatBackends/DefaultBackends.swift
@@ -78,69 +78,22 @@ public enum DefaultBackends {
 
     // MARK: - Registration
 
+    /// The default registrar fold. Order is significant only for
+    /// `CloudBackends`, which calls `PinnedSessionDelegate.loadDefaultPins()`
+    /// and must run before any URLSession factory. Local backends are
+    /// independent.
+    @MainActor
+    public static let registrars: [any BackendRegistrar.Type] = [
+        CloudBackends.self,
+        MLXBackends.self,
+        LlamaBackends.self,
+        FoundationBackends.self,
+    ]
+
     @MainActor
     public static func register(with service: InferenceService) {
-        #if CloudSaaS
-        PinnedSessionDelegate.loadDefaultPins()
-        #endif
-
-        service.registerBackendFactory { modelType in
-            switch modelType {
-            #if MLX
-            case .mlx: return MLXBackend()
-            #endif
-            #if canImport(FoundationModels)
-            case .foundation:
-                if #available(iOS 26, macOS 26, *) {
-                    return FoundationBackend()
-                } else {
-                    return nil
-                }
-            #endif
-            #if Llama
-            case .gguf: return LlamaBackend()
-            #endif
-            default: return nil
-            }
-        }
-
-        // Declare which local model types this build can handle so the service
-        // can answer capability queries without instantiating any backend.
-        #if MLX
-        service.declareSupport(for: .mlx)
-        #endif
-        #if canImport(FoundationModels)
-        if #available(iOS 26, macOS 26, *) {
-            service.declareSupport(for: .foundation)
-        }
-        #endif
-        #if Llama
-        service.declareSupport(for: .gguf)
-        #endif
-
-        service.registerCloudBackendFactory { provider in
-            switch provider {
-            #if CloudSaaS
-            case .claude:                     return ClaudeBackend()
-            case .openAI, .lmStudio, .custom: return OpenAIBackend()
-            case .openAIResponses:            return OpenAIResponsesBackend()
-            #endif
-            #if Ollama
-            // FIXME(#714): expected deprecation warning until the next major
-            // release flips `Ollama` out of default traits. This internal
-            // registration is the supported migration path consumers are
-            // pointed at — silencing the warning here would defeat the
-            // signal it sends to direct callers of `OllamaBackend()`.
-            case .ollama:                     return OllamaBackend()
-            #endif
-            default: return nil
-            }
-        }
-
-        // Declare every provider this build can actually serve — depends on
-        // which of `Ollama` / `CloudSaaS` traits is enabled.
-        for provider in APIProvider.availableInBuild {
-            service.declareSupport(for: provider)
+        for registrar in registrars {
+            registrar.register(with: service)
         }
     }
 }

--- a/Sources/BaseChatBackends/FoundationBackends.swift
+++ b/Sources/BaseChatBackends/FoundationBackends.swift
@@ -1,0 +1,24 @@
+import BaseChatInference
+
+public enum FoundationBackends: BackendRegistrar {
+    @MainActor
+    public static func register(with service: InferenceService) {
+        #if canImport(FoundationModels)
+        service.registerBackendFactory { modelType in
+            switch modelType {
+            case .foundation:
+                if #available(iOS 26, macOS 26, *) {
+                    return FoundationBackend()
+                } else {
+                    return nil
+                }
+            default:
+                return nil
+            }
+        }
+        if #available(iOS 26, macOS 26, *) {
+            service.declareSupport(for: .foundation)
+        }
+        #endif
+    }
+}

--- a/Sources/BaseChatBackends/LlamaBackends.swift
+++ b/Sources/BaseChatBackends/LlamaBackends.swift
@@ -1,0 +1,16 @@
+import BaseChatInference
+
+public enum LlamaBackends: BackendRegistrar {
+    @MainActor
+    public static func register(with service: InferenceService) {
+        #if Llama
+        service.registerBackendFactory { modelType in
+            switch modelType {
+            case .gguf: return LlamaBackend()
+            default:    return nil
+            }
+        }
+        service.declareSupport(for: .gguf)
+        #endif
+    }
+}

--- a/Sources/BaseChatBackends/MLXBackends.swift
+++ b/Sources/BaseChatBackends/MLXBackends.swift
@@ -1,0 +1,16 @@
+import BaseChatInference
+
+public enum MLXBackends: BackendRegistrar {
+    @MainActor
+    public static func register(with service: InferenceService) {
+        #if MLX
+        service.registerBackendFactory { modelType in
+            switch modelType {
+            case .mlx: return MLXBackend()
+            default:   return nil
+            }
+        }
+        service.declareSupport(for: .mlx)
+        #endif
+    }
+}

--- a/Tests/BaseChatBackendsTests/DefaultBackendsTests.swift
+++ b/Tests/BaseChatBackendsTests/DefaultBackendsTests.swift
@@ -131,3 +131,169 @@ final class DefaultBackendsTests: XCTestCase {
     // Note: MLX backend tests require Xcode's Metal toolchain and cannot
     // run under `swift test`. Test MLX through the Xcode scheme instead.
 }
+
+// MARK: - Registrar Tests (no hardware required)
+
+/// Asserts that each per-backend registrar declares the right `ModelType` /
+/// `APIProvider` support, and that `DefaultBackends.register(with:)` is
+/// equivalent to invoking the four registrars explicitly.
+///
+/// Runs without hardware: factory closures are appended but never executed,
+/// so `registeredBackendSnapshot()` only reflects `declareSupport` calls.
+///
+/// ## Sabotage-verify spec
+///
+/// To confirm these tests actually catch drift, temporarily edit the production
+/// code as below and re-run — each edit must produce a failure:
+///
+/// 1. **Drop a local declareSupport.** In `MLXBackends.swift` comment out
+///    `service.declareSupport(for: .mlx)`. With `--traits MLX`,
+///    `test_mlxRegistrar_declaresMLX` must fail.
+/// 2. **Drop a cloud declareSupport.** In `CloudBackends.swift` comment out
+///    the `for provider in APIProvider.availableInBuild { ... }` loop. With
+///    `--traits CloudSaaS` or `--traits Ollama`,
+///    `test_cloudRegistrar_declaresAvailableProviders` must fail.
+/// 3. **Drop a registrar from the fold.** In `DefaultBackends.swift` remove
+///    `LlamaBackends.self` from `registrars`. With `--traits Llama`,
+///    `test_defaultRegister_equalsExplicitFold` must fail on `localModelTypes`
+///    mismatch.
+///
+/// Restore each edit before committing.
+@MainActor
+final class DefaultBackendsRegistrarTests: XCTestCase {
+
+    // MARK: - Per-registrar declarations
+
+    func test_mlxRegistrar_declaresMLX() {
+        let service = InferenceService()
+        MLXBackends.register(with: service)
+        let snapshot = service.registeredBackendSnapshot()
+        #if MLX
+        XCTAssertTrue(snapshot.localModelTypes.contains(.mlx),
+                      "MLXBackends.register must declareSupport(for: .mlx) when MLX trait is enabled")
+        #else
+        XCTAssertFalse(snapshot.localModelTypes.contains(.mlx),
+                       "MLXBackends.register must be a no-op when MLX trait is disabled")
+        #endif
+    }
+
+    func test_llamaRegistrar_declaresGGUF() {
+        let service = InferenceService()
+        LlamaBackends.register(with: service)
+        let snapshot = service.registeredBackendSnapshot()
+        #if Llama
+        XCTAssertTrue(snapshot.localModelTypes.contains(.gguf),
+                      "LlamaBackends.register must declareSupport(for: .gguf) when Llama trait is enabled")
+        #else
+        XCTAssertFalse(snapshot.localModelTypes.contains(.gguf),
+                       "LlamaBackends.register must be a no-op when Llama trait is disabled")
+        #endif
+    }
+
+    func test_foundationRegistrar_declaresFoundationWhenAvailable() {
+        let service = InferenceService()
+        FoundationBackends.register(with: service)
+        let snapshot = service.registeredBackendSnapshot()
+        #if canImport(FoundationModels)
+        if #available(iOS 26, macOS 26, *) {
+            XCTAssertTrue(snapshot.localModelTypes.contains(.foundation),
+                          "FoundationBackends.register must declareSupport(for: .foundation) on supported OS versions")
+        } else {
+            XCTAssertFalse(snapshot.localModelTypes.contains(.foundation),
+                           "FoundationBackends.register must skip declareSupport on unsupported OS versions")
+        }
+        #else
+        XCTAssertFalse(snapshot.localModelTypes.contains(.foundation),
+                       "FoundationBackends.register must be a no-op without FoundationModels SDK")
+        #endif
+    }
+
+    func test_cloudRegistrar_declaresAvailableProviders() {
+        let service = InferenceService()
+        CloudBackends.register(with: service)
+        let snapshot = service.registeredBackendSnapshot()
+        XCTAssertEqual(snapshot.cloudProviders, Set(APIProvider.availableInBuild),
+                       "CloudBackends.register must declare every provider in APIProvider.availableInBuild")
+    }
+
+    // MARK: - Equivalence
+
+    func test_defaultRegister_equalsExplicitFold() {
+        let viaFacade = InferenceService()
+        DefaultBackends.register(with: viaFacade)
+
+        let viaExplicit = InferenceService()
+        // Explicit list — independent of `DefaultBackends.registrars` so a
+        // drop from that list surfaces here as a snapshot mismatch.
+        CloudBackends.register(with: viaExplicit)
+        MLXBackends.register(with: viaExplicit)
+        LlamaBackends.register(with: viaExplicit)
+        FoundationBackends.register(with: viaExplicit)
+
+        XCTAssertEqual(
+            viaFacade.registeredBackendSnapshot(),
+            viaExplicit.registeredBackendSnapshot(),
+            "DefaultBackends.register must match an explicit fold over all four BackendRegistrars."
+        )
+    }
+
+    func test_localRegistrars_declareDisjointModelTypes() {
+        let mlxService = InferenceService()
+        MLXBackends.register(with: mlxService)
+
+        let llamaService = InferenceService()
+        LlamaBackends.register(with: llamaService)
+
+        let foundationService = InferenceService()
+        FoundationBackends.register(with: foundationService)
+
+        let mlx = mlxService.registeredBackendSnapshot().localModelTypes
+        let llama = llamaService.registeredBackendSnapshot().localModelTypes
+        let foundation = foundationService.registeredBackendSnapshot().localModelTypes
+
+        XCTAssertTrue(mlx.intersection(llama).isEmpty,
+                      "MLX and Llama registrars must declare disjoint model types — overlap: \(mlx.intersection(llama))")
+        XCTAssertTrue(mlx.intersection(foundation).isEmpty,
+                      "MLX and Foundation registrars must declare disjoint model types — overlap: \(mlx.intersection(foundation))")
+        XCTAssertTrue(llama.intersection(foundation).isEmpty,
+                      "Llama and Foundation registrars must declare disjoint model types — overlap: \(llama.intersection(foundation))")
+    }
+}
+
+// MARK: - Cloud Pin Loading (CloudSaaS only)
+
+#if CloudSaaS
+/// Verifies `CloudBackends.register(with:)` loads default certificate pins
+/// before any URLSession factory could be exercised. The `_defaultPinsLoaded`
+/// guard makes `loadDefaultPins()` idempotent across multiple calls but the
+/// **first** call must originate from the registrar — not from the lazy
+/// initializer of `URLSessionProvider._pinned`. If a future refactor moves
+/// the call out of `CloudBackends.register`, this asserts surfaces it.
+@MainActor
+final class CloudBackendsPinLoadingTests: XCTestCase {
+
+    override func setUp() async throws {
+        try await super.setUp()
+        PinnedSessionDelegate.resetDefaultPinsForTesting()
+        // Clear any pins set by a prior test in the same process.
+        for host in ["api.anthropic.com", "api.openai.com"] {
+            PinnedSessionDelegate.pinnedHosts[host] = nil
+        }
+    }
+
+    func test_register_populatesDefaultPinsForKnownHosts() {
+        XCTAssertNil(PinnedSessionDelegate.pinnedHosts["api.anthropic.com"],
+                     "Pre-condition: pins must be cleared")
+        XCTAssertNil(PinnedSessionDelegate.pinnedHosts["api.openai.com"],
+                     "Pre-condition: pins must be cleared")
+
+        let service = InferenceService()
+        CloudBackends.register(with: service)
+
+        XCTAssertEqual(PinnedSessionDelegate.pinnedHosts["api.anthropic.com"]?.count, 2,
+                       "CloudBackends.register must populate Anthropic pins (intermediate + root)")
+        XCTAssertEqual(PinnedSessionDelegate.pinnedHosts["api.openai.com"]?.count, 2,
+                       "CloudBackends.register must populate OpenAI pins (intermediate + root)")
+    }
+}
+#endif

--- a/Tests/BaseChatBackendsTests/DefaultBackendsTests.swift
+++ b/Tests/BaseChatBackendsTests/DefaultBackendsTests.swift
@@ -290,10 +290,14 @@ final class CloudBackendsPinLoadingTests: XCTestCase {
         let service = InferenceService()
         CloudBackends.register(with: service)
 
-        XCTAssertEqual(PinnedSessionDelegate.pinnedHosts["api.anthropic.com"]?.count, 2,
-                       "CloudBackends.register must populate Anthropic pins (intermediate + root)")
-        XCTAssertEqual(PinnedSessionDelegate.pinnedHosts["api.openai.com"]?.count, 2,
-                       "CloudBackends.register must populate OpenAI pins (intermediate + root)")
+        // At-least-2 instead of exactly-2: pin rotation procedures legitimately
+        // add backup pins (temporarily during a swap, or permanently). The
+        // invariant we're asserting is "the registrar populated pins for these
+        // hosts before any URLSession could fire", not the bundled pin count.
+        XCTAssertGreaterThanOrEqual(PinnedSessionDelegate.pinnedHosts["api.anthropic.com"]?.count ?? 0, 2,
+                                    "CloudBackends.register must populate Anthropic pins (at minimum: intermediate + root)")
+        XCTAssertGreaterThanOrEqual(PinnedSessionDelegate.pinnedHosts["api.openai.com"]?.count ?? 0, 2,
+                                    "CloudBackends.register must populate OpenAI pins (at minimum: intermediate + root)")
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- Splits `DefaultBackends.register` into four focused registrars (`MLXBackends`, `LlamaBackends`, `FoundationBackends`, `CloudBackends`) conforming to a new `BackendRegistrar` protocol. `DefaultBackends.register` becomes a fold over `DefaultBackends.registrars` — single-call API preserved, no consumer migration required.
- Adds equivalence + per-registrar declaration tests with a sabotage-verify spec in the test docstring. All three sabotage edits were exercised locally and confirmed to fail their respective tests, then reverted.
- Each registrar is unconditionally `public` at file scope; trait gates live inside the function body so a disabled trait produces a no-op rather than a missing-symbol link error.

## Why
First step in a planned BCK rearchitecting: enables explicit per-backend composition for apps and contributors, gives MLX/Llama/Cloud agents non-overlapping edit surfaces in `BaseChatBackends`, and sets up the v2.0 `BaseChatUIModelManagement` peel without any breaking change today. Cross-cutting types are introduced in one PR; per-backend bodies follow the same shape Swift contributors already know from `DefaultBackends`.

The existing `DefaultBackends.register(with:)` API is unchanged — it now delegates to the four registrars in order (cloud first, since `CloudBackends` calls `PinnedSessionDelegate.loadDefaultPins()` and must run before any URLSession factory).

## Note on `URLSessionProvider.swift`
The companion plan flagged `URLSessionProvider.swift` as a drive-by trait-gate candidate. On inspection the file is *already* correctly gated at the property level (`#if CloudSaaS` for the pinned variants, `#if Ollama || CloudSaaS` for the unpinned variants); the always-public `networkDisabled` kill-switch is intentionally ungated because it's referenced from `CloudBackendError.swift` (always compiled). Adding a whole-file gate would break that public API. Left as-is.

## Test plan
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 236 tests
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 1,166 tests
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits` — 69 tests
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 529 tests
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 98 tests
- [x] `swift test --filter BaseChatTestSupportTests --disable-default-traits` — 13 tests
- [x] `swift build --traits CloudSaaS,Ollama,MLX,Llama` — full prod-trait compile
- [x] `swift build --traits CloudSaaS,Ollama,MLX,Llama,MCP,MCPBuiltinCatalog` — full matrix compile
- [x] `swift test --filter "DefaultBackendsRegistrarTests|CloudBackendsPinLoadingTests" --traits CloudSaaS` — pin-loading invariant verified
- [x] `swift test --filter DefaultBackendsRegistrarTests --traits Ollama` — Ollama-only path verified
- [x] Sabotage-verify spec exercised: dropping `service.declareSupport(for: .mlx)` from `MLXBackends`, dropping the `availableInBuild` loop from `CloudBackends`, and removing `LlamaBackends.self` from `DefaultBackends.registrars` each cause their respective tests to fail. All edits reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)