### PR TITLE
feat(mcp): Foundation Models tool cap + schema filter

### DIFF
--- a/Example/BaseChatDemo/ConnectedServicesView.swift
+++ b/Example/BaseChatDemo/ConnectedServicesView.swift
@@ -10,8 +10,14 @@ struct ConnectedServicesView: View {
     @State private var coordinator: DemoMCPCoordinator
     @State private var pendingConnect: MCPServerDescriptor?
 
-    init(toolRegistry: ToolRegistry) {
-        _coordinator = State(initialValue: DemoMCPCoordinator(toolRegistry: toolRegistry))
+    init(
+        toolRegistry: ToolRegistry,
+        isFoundationModelsActive: @escaping () -> Bool = { false }
+    ) {
+        _coordinator = State(initialValue: DemoMCPCoordinator(
+            toolRegistry: toolRegistry,
+            isFoundationModelsActive: isFoundationModelsActive
+        ))
     }
 
     var body: some View {
@@ -128,6 +134,18 @@ struct ConnectedServicesView: View {
                     .lineLimit(3)
             }
 
+            if snapshot.foundationModelsCapActive,
+               snapshot.isConnected,
+               snapshot.enabledToolCount < snapshot.toolCount {
+                Label(
+                    "Apple Intelligence supports up to \(MCPToolFilter.foundationModelsToolCap) tools with simple schemas — extras are hidden until you switch to a different backend.",
+                    systemImage: "exclamationmark.shield"
+                )
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .accessibilityIdentifier("connected-service-cap-footnote-\(descriptor.id.uuidString)")
+            }
+
             DisclosureGroup("Data use") {
                 VStack(alignment: .leading, spacing: 6) {
                     Text(descriptor.dataDisclosure)
@@ -167,7 +185,18 @@ struct ConnectedServiceSnapshot {
     var state: MCPConnectionState = .idle
     var isConnected = false
     var isBusy = false
+    /// Total number of MCP tools registered for this server after the source's
+    /// own filter (allowList/denyList/maxToolCount) has been applied.
     var toolCount = 0
+    /// Number of tools currently surfaced to the active backend. When the
+    /// Foundation Models cap (D18 + D21) is biting, this drops below
+    /// ``toolCount`` and the UI shows "X of Y enabled" so users can see
+    /// the cap in action.
+    var enabledToolCount = 0
+    /// Mirror of `DemoMCPCoordinator.isFoundationModelsActive()` captured at
+    /// the most recent refresh. The view uses this to decide whether to
+    /// surface the cap explanation footnote.
+    var foundationModelsCapActive = false
     var errorMessage: String?
     var authorizationRequest: MCPAuthorizationRequest?
 
@@ -182,6 +211,10 @@ struct ConnectedServiceSnapshot {
             }
         }()
         if isConnected {
+            // "X of Y enabled" when the cap is biting; otherwise just "X tools".
+            if foundationModelsCapActive, enabledToolCount < toolCount {
+                return "\(stateText) · \(enabledToolCount) of \(toolCount) tools enabled"
+            }
             return "\(stateText) · \(toolCount) tools"
         }
         return stateText
@@ -195,8 +228,14 @@ struct ConnectedServicesView: View {
 
     let toolRegistry: ToolRegistry
 
-    init(toolRegistry: ToolRegistry) {
+    init(
+        toolRegistry: ToolRegistry,
+        isFoundationModelsActive: @escaping () -> Bool = { false }
+    ) {
         self.toolRegistry = toolRegistry
+        // Probe is captured but unused — there's no MCP surface to filter when
+        // BaseChatMCP isn't linked. Keeps call sites symmetrical.
+        _ = isFoundationModelsActive
     }
 
     var body: some View {

--- a/Example/BaseChatDemo/DemoContentView.swift
+++ b/Example/BaseChatDemo/DemoContentView.swift
@@ -91,7 +91,13 @@ struct DemoContentView: View {
                 .environment(viewModel)
         }
         .sheet(isPresented: $isConnectedServicesPresented) {
-            ConnectedServicesView(toolRegistry: toolRegistry)
+            // Probe the active backend by name. ``ModelLifecycleCoordinator``
+            // labels the Foundation Models backend "Apple"; matching that
+            // string keeps the demo independent of `import BaseChatBackends`.
+            ConnectedServicesView(
+                toolRegistry: toolRegistry,
+                isFoundationModelsActive: { viewModel.activeBackendName == "Apple" }
+            )
         }
         .sheet(isPresented: approvalSheetIsPresented) {
             if let call = viewModel.toolApprovalGate?.pending.first {

--- a/Example/BaseChatDemo/MCP/DemoMCPCoordinator.swift
+++ b/Example/BaseChatDemo/MCP/DemoMCPCoordinator.swift
@@ -81,7 +81,15 @@ final class DemoMCPCoordinator {
                 let source = try await client.connect(descriptor)
                 await source.register(in: toolRegistry)
                 let count = await source.currentToolNames().count
-                let enabledCount = await self.enabledCount(for: source, totalCount: count)
+                // Snapshot the probe once so the enabled-count calculation and the
+                // `foundationModelsCapActive` flag agree on the same backend state,
+                // even if the user switches models mid-await. (PR #797 review fix.)
+                let foundationActive = isFoundationModelsActive()
+                let enabledCount = await self.enabledCount(
+                    for: source,
+                    totalCount: count,
+                    foundationActive: foundationActive
+                )
                 await MainActor.run {
                     self.sourcesByID[descriptor.id] = source
                     self.updateSnapshot(descriptor.id) { snapshot in
@@ -90,7 +98,7 @@ final class DemoMCPCoordinator {
                         snapshot.state = .ready
                         snapshot.toolCount = count
                         snapshot.enabledToolCount = enabledCount
-                        snapshot.foundationModelsCapActive = self.isFoundationModelsActive()
+                        snapshot.foundationModelsCapActive = foundationActive
                         snapshot.errorMessage = nil
                         snapshot.authorizationRequest = nil
                     }
@@ -204,9 +212,16 @@ final class DemoMCPCoordinator {
 
     private func refreshToolCount(for serverID: UUID) async {
         guard let source = sourcesByID[serverID] else { return }
-        let toolCount = await source.currentToolNames().count
-        let enabledCount = await enabledCount(for: source, totalCount: toolCount)
+        // Snapshot the probe once and reuse it for both the enabled-count
+        // calculation and the snapshot flag, so they can't disagree if the
+        // active backend changes mid-await. (PR #797 review fix.)
         let foundationActive = isFoundationModelsActive()
+        let toolCount = await source.currentToolNames().count
+        let enabledCount = await enabledCount(
+            for: source,
+            totalCount: toolCount,
+            foundationActive: foundationActive
+        )
         await MainActor.run {
             self.updateSnapshot(serverID) { snapshot in
                 snapshot.toolCount = toolCount
@@ -217,8 +232,12 @@ final class DemoMCPCoordinator {
         }
     }
 
-    private func enabledCount(for source: MCPToolSource, totalCount: Int) async -> Int {
-        guard isFoundationModelsActive() else { return totalCount }
+    private func enabledCount(
+        for source: MCPToolSource,
+        totalCount: Int,
+        foundationActive: Bool
+    ) async -> Int {
+        guard foundationActive else { return totalCount }
         return await source.foundationModelsEnabledNames().count
     }
 

--- a/Example/BaseChatDemo/MCP/DemoMCPCoordinator.swift
+++ b/Example/BaseChatDemo/MCP/DemoMCPCoordinator.swift
@@ -1,3 +1,4 @@
+import Foundation
 import BaseChatInference
 
 #if canImport(BaseChatMCP)
@@ -20,9 +21,20 @@ final class DemoMCPCoordinator {
     let catalog: [MCPServerDescriptor]
     let catalogHelpText: String
 
-    init(toolRegistry: ToolRegistry) {
+    /// Probe used to decide whether the Foundation Models tool cap is biting.
+    /// When `true`, each per-server snapshot's `enabledToolCount` reflects only
+    /// the tools that pass ``MCPToolSource/foundationModelsEnabledNames(maxDepth:cap:)``
+    /// (schema-compatible, capped at ``MCPToolFilter/foundationModelsToolCap``).
+    /// When `false`, `enabledToolCount` mirrors `toolCount`.
+    var isFoundationModelsActive: () -> Bool
+
+    init(
+        toolRegistry: ToolRegistry,
+        isFoundationModelsActive: @escaping () -> Bool = { false }
+    ) {
         self.toolRegistry = toolRegistry
         self.client = MCPClient()
+        self.isFoundationModelsActive = isFoundationModelsActive
 
         #if MCPBuiltinCatalog
         self.catalog = MCPCatalog.all
@@ -69,6 +81,7 @@ final class DemoMCPCoordinator {
                 let source = try await client.connect(descriptor)
                 await source.register(in: toolRegistry)
                 let count = await source.currentToolNames().count
+                let enabledCount = await self.enabledCount(for: source, totalCount: count)
                 await MainActor.run {
                     self.sourcesByID[descriptor.id] = source
                     self.updateSnapshot(descriptor.id) { snapshot in
@@ -76,6 +89,8 @@ final class DemoMCPCoordinator {
                         snapshot.isConnected = true
                         snapshot.state = .ready
                         snapshot.toolCount = count
+                        snapshot.enabledToolCount = enabledCount
+                        snapshot.foundationModelsCapActive = self.isFoundationModelsActive()
                         snapshot.errorMessage = nil
                         snapshot.authorizationRequest = nil
                     }
@@ -119,6 +134,7 @@ final class DemoMCPCoordinator {
                     snapshot.isConnected = false
                     snapshot.state = .idle
                     snapshot.toolCount = 0
+                    snapshot.enabledToolCount = 0
                     snapshot.errorMessage = nil
                     snapshot.authorizationRequest = nil
                 }
@@ -160,6 +176,7 @@ final class DemoMCPCoordinator {
                 snapshot.isConnected = false
                 snapshot.isBusy = false
                 snapshot.toolCount = 0
+                snapshot.enabledToolCount = 0
             }
         case .error(let serverID, let error):
             updateSnapshot(serverID) { snapshot in
@@ -188,11 +205,32 @@ final class DemoMCPCoordinator {
     private func refreshToolCount(for serverID: UUID) async {
         guard let source = sourcesByID[serverID] else { return }
         let toolCount = await source.currentToolNames().count
+        let enabledCount = await enabledCount(for: source, totalCount: toolCount)
+        let foundationActive = isFoundationModelsActive()
         await MainActor.run {
             self.updateSnapshot(serverID) { snapshot in
                 snapshot.toolCount = toolCount
+                snapshot.enabledToolCount = enabledCount
+                snapshot.foundationModelsCapActive = foundationActive
                 snapshot.isConnected = true
             }
+        }
+    }
+
+    private func enabledCount(for source: MCPToolSource, totalCount: Int) async -> Int {
+        guard isFoundationModelsActive() else { return totalCount }
+        return await source.foundationModelsEnabledNames().count
+    }
+
+    /// Re-runs the per-server enabled-count projection using the current
+    /// `isFoundationModelsActive()` value. Call this when the active backend
+    /// changes (e.g., user picks a new model in Settings) so the
+    /// "X of Y enabled" labels stay in sync without waiting for a tools/list
+    /// refresh.
+    func refreshEnabledCounts() {
+        let serverIDs = Array(sourcesByID.keys)
+        for serverID in serverIDs {
+            Task { await refreshToolCount(for: serverID) }
         }
     }
 

--- a/Sources/BaseChatMCP/MCPToolSource.swift
+++ b/Sources/BaseChatMCP/MCPToolSource.swift
@@ -557,6 +557,22 @@ internal func isFoundationModelsCompatible(_ schema: JSONSchemaValue, maxDepth: 
 /// found (rejecting the whole schema); otherwise returns the maximum depth
 /// reached. The depth is "interesting" only as a guard against the recursive
 /// case — callers just look at `nil` vs `non-nil`.
+///
+/// **Strategy** (PR #797 review fix): the walker visits *every* JSON Schema
+/// keyword that can carry a subschema, not just `properties`/`items`, so the
+/// rejection rules (`oneOf`, `anyOf`, `$ref`) are evaluated at every nesting
+/// level the author can construct — including those hidden inside composition
+/// keywords like `allOf`, `not`, `additionalProperties`, or `$defs`.
+///
+/// Two flavours of recursion:
+/// - **Depth-advancing** edges (`properties`, `items`, `prefixItems`,
+///   `additionalProperties`, `patternProperties`, `unevaluatedProperties`,
+///   `unevaluatedItems`, `contains`, `propertyNames`): each edge counts as one
+///   level of user-facing object/array nesting and contributes to `maxDepth`.
+/// - **Transparent** composition edges (`allOf`, `not`, `if`/`then`/`else`,
+///   `$defs`, `definitions`, `dependentSchemas`): these compose constraints
+///   over the *current* node, so they don't add user-facing depth — but we
+///   still recurse so a nested `oneOf` can't smuggle past the filter.
 private func schemaDepthIfCompatible(
     _ schema: JSONSchemaValue,
     currentDepth: Int,
@@ -574,56 +590,107 @@ private func schemaDepthIfCompatible(
         if object["anyOf"] != nil { return nil }
 
         var deepest = currentDepth
-        // Descend into properties (nested objects) and items (nested arrays).
-        // Other keys (`type`, `description`, `required`, `enum`, etc.) are scalar
-        // metadata that can't contain further schema nodes.
+
+        // --- Depth-advancing edges ----------------------------------------
+        // `properties: { name: schema, ... }` — each property is one level deeper.
         if case .object(let properties)? = object["properties"] {
             for (_, child) in properties {
-                guard let childDepth = schemaDepthIfCompatible(
-                    child,
-                    currentDepth: currentDepth + 1,
-                    maxDepth: maxDepth
-                ) else { return nil }
-                deepest = max(deepest, childDepth)
+                guard let d = schemaDepthIfCompatible(child, currentDepth: currentDepth + 1, maxDepth: maxDepth)
+                else { return nil }
+                deepest = max(deepest, d)
             }
         }
+        // `patternProperties: { regex: schema }` — same shape as properties.
+        if case .object(let patterns)? = object["patternProperties"] {
+            for (_, child) in patterns {
+                guard let d = schemaDepthIfCompatible(child, currentDepth: currentDepth + 1, maxDepth: maxDepth)
+                else { return nil }
+                deepest = max(deepest, d)
+            }
+        }
+        // `additionalProperties` / `unevaluatedProperties`: bool form is a
+        // permissive flag (nothing to inspect); schema (object) form is a single
+        // nested schema, one level deeper.
+        for key in ["additionalProperties", "unevaluatedProperties"] {
+            if let value = object[key], case .object = value {
+                guard let d = schemaDepthIfCompatible(value, currentDepth: currentDepth + 1, maxDepth: maxDepth)
+                else { return nil }
+                deepest = max(deepest, d)
+            }
+        }
+        // `items` may be a single schema or an array of schemas (legacy tuple form).
         if let items = object["items"] {
-            // `items` may be a single schema or an array of schemas (tuple form).
-            switch items {
-            case .array(let tupleItems):
-                for child in tupleItems {
-                    guard let childDepth = schemaDepthIfCompatible(
-                        child,
-                        currentDepth: currentDepth + 1,
-                        maxDepth: maxDepth
-                    ) else { return nil }
-                    deepest = max(deepest, childDepth)
+            if case .array(let tuple) = items {
+                for child in tuple {
+                    guard let d = schemaDepthIfCompatible(child, currentDepth: currentDepth + 1, maxDepth: maxDepth)
+                    else { return nil }
+                    deepest = max(deepest, d)
                 }
-            default:
-                guard let childDepth = schemaDepthIfCompatible(
-                    items,
-                    currentDepth: currentDepth + 1,
-                    maxDepth: maxDepth
-                ) else { return nil }
-                deepest = max(deepest, childDepth)
+            } else if case .object = items {
+                guard let d = schemaDepthIfCompatible(items, currentDepth: currentDepth + 1, maxDepth: maxDepth)
+                else { return nil }
+                deepest = max(deepest, d)
             }
         }
+        // `prefixItems: [schema, ...]` — modern tuple form.
+        if case .array(let prefix)? = object["prefixItems"] {
+            for child in prefix {
+                guard let d = schemaDepthIfCompatible(child, currentDepth: currentDepth + 1, maxDepth: maxDepth)
+                else { return nil }
+                deepest = max(deepest, d)
+            }
+        }
+        // `contains` / `unevaluatedItems` / `propertyNames`: single nested schema, one level deeper.
+        for key in ["contains", "unevaluatedItems", "propertyNames"] {
+            if let value = object[key], case .object = value {
+                guard let d = schemaDepthIfCompatible(value, currentDepth: currentDepth + 1, maxDepth: maxDepth)
+                else { return nil }
+                deepest = max(deepest, d)
+            }
+        }
+
+        // --- Transparent composition edges --------------------------------
+        // `allOf: [schema, ...]` — composes constraints over THIS node, no depth bump.
+        if case .array(let allOf)? = object["allOf"] {
+            for child in allOf {
+                guard let d = schemaDepthIfCompatible(child, currentDepth: currentDepth, maxDepth: maxDepth)
+                else { return nil }
+                deepest = max(deepest, d)
+            }
+        }
+        // `not: schema`, `if`/`then`/`else: schema` — single composition schemas.
+        for key in ["not", "if", "then", "else"] {
+            if let value = object[key], case .object = value {
+                guard let d = schemaDepthIfCompatible(value, currentDepth: currentDepth, maxDepth: maxDepth)
+                else { return nil }
+                deepest = max(deepest, d)
+            }
+        }
+        // `$defs` / `definitions` / `dependentSchemas: { name: schema }` — named maps, no depth bump.
+        for key in ["$defs", "definitions", "dependentSchemas"] {
+            if case .object(let defs)? = object[key] {
+                for (_, child) in defs {
+                    guard let d = schemaDepthIfCompatible(child, currentDepth: currentDepth, maxDepth: maxDepth)
+                    else { return nil }
+                    deepest = max(deepest, d)
+                }
+            }
+        }
+
         return deepest
     case .array(let elements):
-        // A bare schema array (rare at the top level but allowed inside e.g.
-        // `prefixItems`) — descend without advancing depth, since we already
-        // counted the array container at the parent.
+        // A bare schema array — descend without advancing depth (the array
+        // container was already counted at the parent edge).
         var deepest = currentDepth
         for element in elements {
-            guard let childDepth = schemaDepthIfCompatible(
-                element,
-                currentDepth: currentDepth,
-                maxDepth: maxDepth
-            ) else { return nil }
-            deepest = max(deepest, childDepth)
+            guard let d = schemaDepthIfCompatible(element, currentDepth: currentDepth, maxDepth: maxDepth)
+            else { return nil }
+            deepest = max(deepest, d)
         }
         return deepest
     case .string, .number, .bool, .null:
+        // Includes `additionalProperties: true`/`false` (the bool form) — a
+        // permissive flag, not a nested schema.
         return currentDepth
     }
 }

--- a/Sources/BaseChatMCP/MCPToolSource.swift
+++ b/Sources/BaseChatMCP/MCPToolSource.swift
@@ -56,6 +56,54 @@ public final class MCPToolSource: @unchecked Sendable {
         await storage.currentToolNames()
     }
 
+    /// Returns the currently-registered tools whose JSON Schemas are compatible
+    /// with Apple's Foundation Models tool surface.
+    ///
+    /// Foundation Models rejects schemas that use `oneOf`, `$ref`, or whose
+    /// nesting exceeds a small depth. This query returns the namespaced names
+    /// of tools whose schemas pass all three checks, sorted alphabetically.
+    ///
+    /// "Deep nesting" is defined as the maximum depth of nested `object`
+    /// (`properties`) or `array` (`items`) descents within the schema.
+    /// `maxDepth: 4` accepts e.g. `{type:object, properties:{x:{type:array,
+    /// items:{type:object, properties:{y:{type:string}}}}}}` (depth 3) but
+    /// rejects schemas that nest one level deeper. Depth is measured from the
+    /// root schema (depth 1 = the root object), so a flat
+    /// `{type:object, properties:{x:{type:string}}}` is depth 2.
+    ///
+    /// - Parameter maxDepth: Maximum allowed schema nesting depth. Defaults to
+    ///   4, which empirically covers most well-formed MCP server tools while
+    ///   rejecting recursive or deeply-nested OpenAPI-style schemas that
+    ///   Foundation Models can't handle.
+    public func foundationModelsCompatibleNames(maxDepth: Int = 4) async -> [String] {
+        let tools = await storage.currentTools()
+        return tools
+            .filter { isFoundationModelsCompatible($0.inputSchema, maxDepth: maxDepth) }
+            .map(\.namespacedName)
+            .sorted()
+    }
+
+    /// Returns the subset of currently-registered tools that should be exposed
+    /// to Apple's Foundation Models backend in a given turn.
+    ///
+    /// Composes ``foundationModelsCompatibleNames(maxDepth:)`` with a hard cap
+    /// (defaulting to ``MCPToolFilter/foundationModelsToolCap``). When more
+    /// compatible tools exist than the cap allows, the lexicographically-first
+    /// `cap` names are returned — deterministic ordering keeps the UI's
+    /// "X of Y enabled" count stable across refreshes.
+    ///
+    /// - Parameters:
+    ///   - maxDepth: Forwarded to the schema-compatibility check.
+    ///   - cap: Maximum number of tools to return. Defaults to 16.
+    public func foundationModelsEnabledNames(
+        maxDepth: Int = 4,
+        cap: Int = MCPToolFilter.foundationModelsToolCap
+    ) async -> [String] {
+        let compatible = await foundationModelsCompatibleNames(maxDepth: maxDepth)
+        guard cap >= 0 else { return [] }
+        return Array(compatible.prefix(cap))
+    }
+
     @MainActor public func register(in registry: ToolRegistry) async {
         if await storage.isEmpty(), listTools != nil {
             do {
@@ -260,6 +308,10 @@ private actor MCPToolSourceStorage {
 
     func currentToolNames() -> [String] {
         executorsByStableKey.values.map(\.definition.name).sorted()
+    }
+
+    func currentTools() -> [MCPRemoteTool] {
+        Array(toolsByStableKey.values)
     }
 
     func replaceTools(
@@ -489,6 +541,91 @@ private func normalizedNamespace(_ namespace: String?) -> String? {
         .filter { !$0.isEmpty }
         .joined(separator: "_")
     return normalized.isEmpty ? nil : normalized
+}
+
+// MARK: - Foundation Models schema compatibility
+
+/// Returns `true` when `schema` contains no `oneOf`, no `$ref`, and no nested
+/// `object`/`array` chain deeper than `maxDepth` levels.
+///
+/// Internal so tests in the same module can exercise edge cases directly.
+internal func isFoundationModelsCompatible(_ schema: JSONSchemaValue, maxDepth: Int) -> Bool {
+    schemaDepthIfCompatible(schema, currentDepth: 1, maxDepth: maxDepth) != nil
+}
+
+/// Recursive walker. Returns `nil` the moment an unsupported construct is
+/// found (rejecting the whole schema); otherwise returns the maximum depth
+/// reached. The depth is "interesting" only as a guard against the recursive
+/// case — callers just look at `nil` vs `non-nil`.
+private func schemaDepthIfCompatible(
+    _ schema: JSONSchemaValue,
+    currentDepth: Int,
+    maxDepth: Int
+) -> Int? {
+    if currentDepth > maxDepth { return nil }
+
+    switch schema {
+    case .object(let object):
+        // Reject the constructs Foundation Models can't decode at any level.
+        if object["oneOf"] != nil { return nil }
+        if object["$ref"] != nil { return nil }
+        // anyOf is also not in Apple's accepted vocabulary; reject it for symmetry
+        // since it's structurally the same hazard as oneOf.
+        if object["anyOf"] != nil { return nil }
+
+        var deepest = currentDepth
+        // Descend into properties (nested objects) and items (nested arrays).
+        // Other keys (`type`, `description`, `required`, `enum`, etc.) are scalar
+        // metadata that can't contain further schema nodes.
+        if case .object(let properties)? = object["properties"] {
+            for (_, child) in properties {
+                guard let childDepth = schemaDepthIfCompatible(
+                    child,
+                    currentDepth: currentDepth + 1,
+                    maxDepth: maxDepth
+                ) else { return nil }
+                deepest = max(deepest, childDepth)
+            }
+        }
+        if let items = object["items"] {
+            // `items` may be a single schema or an array of schemas (tuple form).
+            switch items {
+            case .array(let tupleItems):
+                for child in tupleItems {
+                    guard let childDepth = schemaDepthIfCompatible(
+                        child,
+                        currentDepth: currentDepth + 1,
+                        maxDepth: maxDepth
+                    ) else { return nil }
+                    deepest = max(deepest, childDepth)
+                }
+            default:
+                guard let childDepth = schemaDepthIfCompatible(
+                    items,
+                    currentDepth: currentDepth + 1,
+                    maxDepth: maxDepth
+                ) else { return nil }
+                deepest = max(deepest, childDepth)
+            }
+        }
+        return deepest
+    case .array(let elements):
+        // A bare schema array (rare at the top level but allowed inside e.g.
+        // `prefixItems`) — descend without advancing depth, since we already
+        // counted the array container at the parent.
+        var deepest = currentDepth
+        for element in elements {
+            guard let childDepth = schemaDepthIfCompatible(
+                element,
+                currentDepth: currentDepth,
+                maxDepth: maxDepth
+            ) else { return nil }
+            deepest = max(deepest, childDepth)
+        }
+        return deepest
+    case .string, .number, .bool, .null:
+        return currentDepth
+    }
 }
 
 private extension MCPToolFilter {

--- a/Sources/BaseChatMCP/MCPTypes.swift
+++ b/Sources/BaseChatMCP/MCPTypes.swift
@@ -132,6 +132,13 @@ public struct MCPToolFilter: Sendable, Equatable, Hashable, Codable {
     }
 
     public static var allowAll: Self { .init(mode: .allowAll) }
+
+    /// Hard cap on the number of tools surfaced to Apple's Foundation Models
+    /// backend. Apple's on-device tool surface degrades sharply once the tool
+    /// list grows large — the model spends more of its context budget reciting
+    /// schemas than reasoning. 16 is the empirically-derived ceiling used by
+    /// ``MCPToolSource/foundationModelsEnabledNames(maxDepth:cap:)``.
+    public static let foundationModelsToolCap: Int = 16
 }
 
 public struct MCPClientConfiguration: Sendable {

--- a/Tests/BaseChatMCPTests/MCPFoundationModelsCompatibilityTests.swift
+++ b/Tests/BaseChatMCPTests/MCPFoundationModelsCompatibilityTests.swift
@@ -78,6 +78,96 @@ final class MCPFoundationModelsCompatibilityTests: XCTestCase {
         // would let depth5 slip through.
     }
 
+    // MARK: - D21 — composition keyword traversal (PR #797 review fix)
+    //
+    // Before the walker rewrite, these schemas slipped past the filter because
+    // it only descended into `properties` and `items`. Each test below would
+    // have returned `true` (compatible) under the old walker.
+
+    func test_oneOfHiddenInsideAllOfIsRejected() {
+        let schema = JSONSchemaValue.object([
+            "type": .string("object"),
+            "allOf": .array([
+                .object([
+                    "oneOf": .array([
+                        .object(["type": .string("string")]),
+                        .object(["type": .string("number")]),
+                    ]),
+                ]),
+            ]),
+        ])
+        XCTAssertFalse(isFoundationModelsCompatible(schema, maxDepth: 4))
+        // Sabotage check: removing the `allOf` traversal in the walker would
+        // let this slip through.
+    }
+
+    func test_refHiddenInsideAdditionalPropertiesIsRejected() {
+        let schema = JSONSchemaValue.object([
+            "type": .string("object"),
+            "additionalProperties": .object([
+                "$ref": .string("#/definitions/Foo"),
+            ]),
+        ])
+        XCTAssertFalse(isFoundationModelsCompatible(schema, maxDepth: 4))
+        // Sabotage check: removing the `additionalProperties` traversal would
+        // let this slip through.
+    }
+
+    func test_anyOfHiddenInsideNotIsRejected() {
+        let schema = JSONSchemaValue.object([
+            "type": .string("object"),
+            "not": .object([
+                "anyOf": .array([
+                    .object(["type": .string("string")]),
+                ]),
+            ]),
+        ])
+        XCTAssertFalse(isFoundationModelsCompatible(schema, maxDepth: 4))
+        // Sabotage check: removing the `not` traversal would let this slip through.
+    }
+
+    func test_oneOfHiddenInsidePrefixItemsIsRejected() {
+        let schema = JSONSchemaValue.object([
+            "type": .string("array"),
+            "prefixItems": .array([
+                .object([
+                    "oneOf": .array([
+                        .object(["type": .string("string")]),
+                    ]),
+                ]),
+            ]),
+        ])
+        XCTAssertFalse(isFoundationModelsCompatible(schema, maxDepth: 4))
+        // Sabotage check: removing the `prefixItems` traversal would let this slip through.
+    }
+
+    func test_refHiddenInsideDefsIsRejected() {
+        // `$defs` is the modern definitions container; a `$ref` inside should
+        // still be flagged even though `$defs` itself isn't user-facing nesting.
+        let schema = JSONSchemaValue.object([
+            "type": .string("object"),
+            "$defs": .object([
+                "User": .object([
+                    "$ref": .string("#/definitions/Foo"),
+                ]),
+            ]),
+        ])
+        XCTAssertFalse(isFoundationModelsCompatible(schema, maxDepth: 4))
+    }
+
+    func test_additionalPropertiesAsBoolIsAccepted() {
+        // The bool form is a permissive flag, not a schema. A flat object that
+        // also says `additionalProperties: true` should still pass — don't over-reject.
+        let schema = JSONSchemaValue.object([
+            "type": .string("object"),
+            "properties": .object([
+                "name": .object(["type": .string("string")]),
+            ]),
+            "additionalProperties": .bool(true),
+        ])
+        XCTAssertTrue(isFoundationModelsCompatible(schema, maxDepth: 4))
+    }
+
     func test_deeplyNestedArrayIsRejected() {
         // Array of array of array of array of array of object — depth 6.
         func arr(_ inner: JSONSchemaValue) -> JSONSchemaValue {

--- a/Tests/BaseChatMCPTests/MCPFoundationModelsCompatibilityTests.swift
+++ b/Tests/BaseChatMCPTests/MCPFoundationModelsCompatibilityTests.swift
@@ -1,0 +1,202 @@
+import Foundation
+import XCTest
+@testable import BaseChatMCP
+import BaseChatInference
+
+/// Tests for D18 (Foundation Models tool count cap) and D21 (schema-based
+/// compatibility filter). These are the predicates the demo (and host apps)
+/// use to narrow the MCP tool surface when Apple's on-device model is the
+/// active backend.
+@MainActor
+final class MCPFoundationModelsCompatibilityTests: XCTestCase {
+
+    // MARK: - D21 — schema compatibility predicate
+
+    func test_flatObjectSchemaIsCompatible() {
+        let schema = JSONSchemaValue.object([
+            "type": .string("object"),
+            "properties": .object([
+                "city": .object(["type": .string("string")]),
+            ]),
+            "required": .array([.string("city")]),
+        ])
+        XCTAssertTrue(isFoundationModelsCompatible(schema, maxDepth: 4))
+    }
+
+    func test_oneOfSchemaIsRejected() {
+        let schema = JSONSchemaValue.object([
+            "oneOf": .array([
+                .object(["type": .string("string")]),
+                .object(["type": .string("number")]),
+            ]),
+        ])
+        XCTAssertFalse(isFoundationModelsCompatible(schema, maxDepth: 4))
+        // Sabotage check: deleting the oneOf guard in
+        // schemaDepthIfCompatible would let this slip through.
+    }
+
+    func test_anyOfSchemaIsRejected() {
+        let schema = JSONSchemaValue.object([
+            "anyOf": .array([
+                .object(["type": .string("string")]),
+            ]),
+        ])
+        XCTAssertFalse(isFoundationModelsCompatible(schema, maxDepth: 4))
+    }
+
+    func test_refSchemaIsRejected() {
+        let schema = JSONSchemaValue.object([
+            "type": .string("object"),
+            "properties": .object([
+                "user": .object(["$ref": .string("#/definitions/User")]),
+            ]),
+        ])
+        XCTAssertFalse(isFoundationModelsCompatible(schema, maxDepth: 4))
+    }
+
+    func test_deeplyNestedObjectIsRejected() {
+        // wrap(inner) wraps `inner` in an object with a `properties.next: inner`
+        // edge — each wrap descends one level. Both `wrap` and the leaf are
+        // `.object` values, so each contributes one level to the depth count.
+        func wrap(_ inner: JSONSchemaValue) -> JSONSchemaValue {
+            .object([
+                "type": .string("object"),
+                "properties": .object(["next": inner]),
+            ])
+        }
+        // String leaf is a scalar (depth contribution = 1 at its position).
+        let leaf = JSONSchemaValue.object(["type": .string("string")])
+
+        // wrap^3(leaf) = root(1) -> next(2) -> next(3) -> leaf(4) → fits maxDepth 4.
+        let depth4 = wrap(wrap(wrap(leaf)))
+        XCTAssertTrue(isFoundationModelsCompatible(depth4, maxDepth: 4))
+
+        // wrap^4(leaf) = depth 5 → rejected.
+        let depth5 = wrap(wrap(wrap(wrap(leaf))))
+        XCTAssertFalse(isFoundationModelsCompatible(depth5, maxDepth: 4))
+        // Sabotage check: removing the `if currentDepth > maxDepth` guard
+        // would let depth5 slip through.
+    }
+
+    func test_deeplyNestedArrayIsRejected() {
+        // Array of array of array of array of array of object — depth 6.
+        func arr(_ inner: JSONSchemaValue) -> JSONSchemaValue {
+            .object([
+                "type": .string("array"),
+                "items": inner,
+            ])
+        }
+        let leaf = JSONSchemaValue.object(["type": .string("string")])
+        let deep = arr(arr(arr(arr(arr(leaf)))))
+        XCTAssertFalse(isFoundationModelsCompatible(deep, maxDepth: 4))
+    }
+
+    // MARK: - D21 — query on MCPToolSource
+
+    func test_foundationModelsCompatibleNamesFiltersIncompatibleSchemas() async {
+        let source = makeSource(toolSpecs: [
+            ("simple", .object([
+                "type": .string("object"),
+                "properties": .object(["q": .object(["type": .string("string")])]),
+            ])),
+            ("oneof_tool", .object([
+                "oneOf": .array([
+                    .object(["type": .string("string")]),
+                ]),
+            ])),
+            ("ref_tool", .object([
+                "$ref": .string("#/defs/Foo"),
+            ])),
+            ("flat_array", .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "items": .object([
+                        "type": .string("array"),
+                        "items": .object(["type": .string("string")]),
+                    ]),
+                ]),
+            ])),
+        ])
+        try? await source.refreshTools()
+
+        let compatible = await source.foundationModelsCompatibleNames(maxDepth: 4)
+        XCTAssertEqual(compatible, ["flat_array", "simple"])
+    }
+
+    // MARK: - D18 — cap composition
+
+    func test_foundationModelsEnabledNamesAppliesCap() async {
+        let manyNames = (0..<25).map { String(format: "tool_%02d", $0) }
+        let source = makeSource(
+            toolSpecs: manyNames.map { ($0, .object(["type": .string("object")])) },
+            // Loosen the source-level filter cap so the underlying refresh succeeds.
+            toolFilter: .init(mode: .allowAll, maxToolCount: 100)
+        )
+        try? await source.refreshTools()
+
+        // Default cap = 16.
+        let enabled = await source.foundationModelsEnabledNames()
+        XCTAssertEqual(enabled.count, 16)
+        XCTAssertEqual(enabled, Array(manyNames.sorted().prefix(16)))
+
+        // Custom cap respected.
+        let small = await source.foundationModelsEnabledNames(cap: 3)
+        XCTAssertEqual(small, Array(manyNames.sorted().prefix(3)))
+    }
+
+    func test_foundationModelsEnabledNamesIsIntersectedAndCapped() async {
+        // Mix of compatible and incompatible — cap chooses from the
+        // compatible-and-sorted set, never returning incompatible names.
+        var specs: [(String, JSONSchemaValue)] = []
+        for index in 0..<10 {
+            specs.append(("good_\(index)", .object(["type": .string("object")])))
+        }
+        for index in 0..<10 {
+            specs.append(("bad_\(index)", .object([
+                "oneOf": .array([.object(["type": .string("string")])]),
+            ])))
+        }
+        let source = makeSource(toolSpecs: specs, toolFilter: .init(mode: .allowAll, maxToolCount: 100))
+        try? await source.refreshTools()
+
+        let enabled = await source.foundationModelsEnabledNames(cap: 5)
+        XCTAssertEqual(enabled.count, 5)
+        for name in enabled {
+            XCTAssertTrue(name.hasPrefix("good_"), "\(name) leaked into the enabled set")
+        }
+        // Sabotage check: removing the .filter call in
+        // foundationModelsCompatibleNames would let the bad_ tools sort to
+        // the front and fail this check.
+    }
+
+    func test_capExposesPublicConstantOf16() {
+        XCTAssertEqual(MCPToolFilter.foundationModelsToolCap, 16)
+    }
+
+    // MARK: - Helpers
+
+    private func makeSource(
+        toolSpecs: [(name: String, schema: JSONSchemaValue)],
+        toolFilter: MCPToolFilter = .allowAll
+    ) -> MCPToolSource {
+        let toolsArray: [JSONSchemaValue] = toolSpecs.map { spec in
+            .object([
+                "name": .string(spec.name),
+                "description": .string("Test tool \(spec.name)"),
+                "inputSchema": spec.schema,
+            ])
+        }
+        return MCPToolSource(
+            serverID: UUID(),
+            displayName: "Docs",
+            capabilities: .init(),
+            toolNamespace: nil,
+            toolFilter: toolFilter,
+            approvalPolicy: .perCall,
+            listTools: {
+                .object(["tools": .array(toolsArray)])
+            },
+            callTool: { _, _ in nil }
+        )
+    }
+}

--- a/Tests/BaseChatMCPTests/MCPFoundationModelsCompatibilityTests.swift
+++ b/Tests/BaseChatMCPTests/MCPFoundationModelsCompatibilityTests.swift
@@ -183,7 +183,7 @@ final class MCPFoundationModelsCompatibilityTests: XCTestCase {
 
     // MARK: - D21 — query on MCPToolSource
 
-    func test_foundationModelsCompatibleNamesFiltersIncompatibleSchemas() async {
+    func test_foundationModelsCompatibleNamesFiltersIncompatibleSchemas() async throws {
         let source = makeSource(toolSpecs: [
             ("simple", .object([
                 "type": .string("object"),
@@ -207,7 +207,7 @@ final class MCPFoundationModelsCompatibilityTests: XCTestCase {
                 ]),
             ])),
         ])
-        try? await source.refreshTools()
+        try await source.refreshTools()
 
         let compatible = await source.foundationModelsCompatibleNames(maxDepth: 4)
         XCTAssertEqual(compatible, ["flat_array", "simple"])
@@ -215,14 +215,14 @@ final class MCPFoundationModelsCompatibilityTests: XCTestCase {
 
     // MARK: - D18 — cap composition
 
-    func test_foundationModelsEnabledNamesAppliesCap() async {
+    func test_foundationModelsEnabledNamesAppliesCap() async throws {
         let manyNames = (0..<25).map { String(format: "tool_%02d", $0) }
         let source = makeSource(
             toolSpecs: manyNames.map { ($0, .object(["type": .string("object")])) },
             // Loosen the source-level filter cap so the underlying refresh succeeds.
             toolFilter: .init(mode: .allowAll, maxToolCount: 100)
         )
-        try? await source.refreshTools()
+        try await source.refreshTools()
 
         // Default cap = 16.
         let enabled = await source.foundationModelsEnabledNames()
@@ -234,7 +234,7 @@ final class MCPFoundationModelsCompatibilityTests: XCTestCase {
         XCTAssertEqual(small, Array(manyNames.sorted().prefix(3)))
     }
 
-    func test_foundationModelsEnabledNamesIsIntersectedAndCapped() async {
+    func test_foundationModelsEnabledNamesIsIntersectedAndCapped() async throws {
         // Mix of compatible and incompatible — cap chooses from the
         // compatible-and-sorted set, never returning incompatible names.
         var specs: [(String, JSONSchemaValue)] = []
@@ -247,7 +247,7 @@ final class MCPFoundationModelsCompatibilityTests: XCTestCase {
             ])))
         }
         let source = makeSource(toolSpecs: specs, toolFilter: .init(mode: .allowAll, maxToolCount: 100))
-        try? await source.refreshTools()
+        try await source.refreshTools()
 
         let enabled = await source.foundationModelsEnabledNames(cap: 5)
         XCTAssertEqual(enabled.count, 5)


### PR DESCRIPTION
## Summary

Ships two cooperating bits of plumbing from umbrella #792 so apps can narrow the MCP tool surface when Apple's on-device Foundation Models backend is the active one. Both items target the same plumbing point — the place where MCP tools are enumerated for a generation request — so they ship together to avoid stranding the cap behind a missing filter or vice versa.

- **D18 — Tool count cap.** Adds `MCPToolFilter.foundationModelsToolCap = 16` (a public constant) and exposes the cap on `MCPToolSource` via the new `foundationModelsEnabledNames(maxDepth:cap:)` query. Demo's Connected Services sheet now shows "Connected · X of Y tools enabled" plus a footnote whenever the cap is biting.
- **D21 — Schema-based compatibility filter.** Adds `MCPToolSource.foundationModelsCompatibleNames(maxDepth:)` which returns the subset of currently-registered tools whose JSON Schemas don't use `oneOf`, `anyOf`, `$ref`, or nested `object`/`array` chains exceeding `maxDepth` (default `4`). Apple's tool surface rejects all four constructs. The chosen depth and rationale are documented in the doc comments and in `schemaDepthIfCompatible` (e.g. depth-1 = the root object; flat schemas are depth 2).

The cap composes with the compatibility filter — `foundationModelsEnabledNames` is "schema-compatible-then-truncated-to-cap, sorted lexicographically" so the demo's count is stable across `tools/list` refreshes.

`MCPToolFilter`'s existing `maxToolCount` (the throw-on-exceed source-level filter) is unchanged. The new APIs are additive and backend-detection is the host app's responsibility — the demo probes via `ChatViewModel.activeBackendName == \"Apple\"`, the label `ModelLifecycleCoordinator` assigns to `FoundationBackend`. This keeps `BaseChatMCP` free of any backend dependency.

## Refs

Refs #792 (D18, D21). The umbrella stays open — these are two checkboxes ticked on a list of nine. Still open from #792:

- D16 — Universal Links callback
- D19 — i18n + re-auth CTA
- D20 — DataDisclosureSheet first-run consent
- D23 — Memory-warning observer in `MCPClient`
- D27 — `scripts/test.sh` + nightly E2E CI
- `MCPApprovalSettingsView`, `CustomMCPServerSheet`, Info.plist AASA setup
- v2 architecture split
- Two-instance refresh race test

## Test plan

- [x] `swift test --filter BaseChatMCPTests --disable-default-traits` — 98 tests pass, including 10 new in `MCPFoundationModelsCompatibilityTests`
- [x] Full pre-push CI suite (Core, Inference, InferenceSwiftTesting, UI, UIModelManagement, MCP, Backends, TestSupport) — all green
- [x] Sabotage check — temporarily removed the `if currentDepth > maxDepth` guard in `schemaDepthIfCompatible` and confirmed `test_deeplyNestedObjectIsRejected` fails; restored before commit. Same applied to `oneOf` rejection in `test_oneOfSchemaIsRejected` and to the `.filter` call in `test_foundationModelsEnabledNamesIsIntersectedAndCapped`.
- [ ] Manual smoke in the demo with a real MCP server once an iOS 26 simulator with Apple Intelligence is available — the wiring is currently testable only via unit tests on the macOS hosts that lack Apple Intelligence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)