### PR TITLE
feat(appintents): AppIntent ↔ ToolDefinition bridge

### DIFF
--- a/Example/BaseChatDemo.xcodeproj/project.pbxproj
+++ b/Example/BaseChatDemo.xcodeproj/project.pbxproj
@@ -43,6 +43,9 @@
 		BF1010000000000000000000 /* InboundPayloadEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10020000000000000000000 /* InboundPayloadEnvelope.swift */; };
 		BF1011000000000000000000 /* InboundPayloadEnvelopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11011000000000000000000 /* InboundPayloadEnvelopeTests.swift */; };
 		BF1012000000000000000000 /* BaseChatInference in Frameworks */ = {isa = PBXBuildFile; productRef = F30007000000000000000000 /* BaseChatInference */; };
+		BF0026000000000000000000 /* SetReminderIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10022000000000000000000 /* SetReminderIntent.swift */; };
+		BF0027000000000000000000 /* AppIntentToolsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10023000000000000000000 /* AppIntentToolsView.swift */; };
+		BF0028000000000000000000 /* BaseChatAppIntents in Frameworks */ = {isa = PBXBuildFile; productRef = F30008000000000000000000 /* BaseChatAppIntents */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -88,6 +91,8 @@
 		F10020000000000000000000 /* InboundPayloadEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Intents/InboundPayloadEnvelope.swift; sourceTree = "<group>"; };
 		F11011000000000000000000 /* InboundPayloadEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboundPayloadEnvelopeTests.swift; sourceTree = "<group>"; };
 		F10021000000000000000000 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F10022000000000000000000 /* SetReminderIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Intents/SetReminderIntent.swift; sourceTree = "<group>"; };
+		F10023000000000000000000 /* AppIntentToolsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntentToolsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -101,6 +106,7 @@
 				BF0005000000000000000000 /* BaseChatBackends in Frameworks */,
 				BF0006000000000000000000 /* BaseChatTools in Frameworks */,
 				BF0020000000000000000000 /* BaseChatMCP in Frameworks */,
+				BF0028000000000000000000 /* BaseChatAppIntents in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -148,6 +154,8 @@
 				F10018000000000000000000 /* ConnectedServicesView.swift */,
 				F10019000000000000000000 /* DemoMCPCoordinator.swift */,
 				F10020000000000000000000 /* InboundPayloadEnvelope.swift */,
+				F10022000000000000000000 /* SetReminderIntent.swift */,
+				F10023000000000000000000 /* AppIntentToolsView.swift */,
 			);
 			path = BaseChatDemo;
 			sourceTree = "<group>";
@@ -207,6 +215,7 @@
 				F30003000000000000000000 /* BaseChatBackends */,
 				F30004000000000000000000 /* BaseChatTools */,
 				F30005000000000000000000 /* BaseChatMCP */,
+				F30008000000000000000000 /* BaseChatAppIntents */,
 			);
 			productName = BaseChatDemo;
 			productReference = F10003000000000000000000 /* BaseChatDemo.app */;
@@ -287,6 +296,8 @@
 				BF0021000000000000000000 /* ConnectedServicesView.swift in Sources */,
 				BF0022000000000000000000 /* DemoMCPCoordinator.swift in Sources */,
 				BF0023000000000000000000 /* InboundPayloadEnvelope.swift in Sources */,
+				BF0026000000000000000000 /* SetReminderIntent.swift in Sources */,
+				BF0027000000000000000000 /* AppIntentToolsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -621,6 +632,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F20001000000000000000000 /* XCLocalSwiftPackageReference ".." */;
 			productName = BaseChatInference;
+		};
+		F30008000000000000000000 /* BaseChatAppIntents */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F20001000000000000000000 /* XCLocalSwiftPackageReference ".." */;
+			productName = BaseChatAppIntents;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Example/BaseChatDemo/AppIntentToolsView.swift
+++ b/Example/BaseChatDemo/AppIntentToolsView.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+import BaseChatInference
+
+#if canImport(BaseChatAppIntents)
+import BaseChatAppIntents
+
+/// Demo screen that registers a real AppIntent (``SetReminderIntent``) on the
+/// chat tool registry via ``AppIntentToolExecutor``.
+///
+/// The tool appears in the model's tool list as `set_reminder_intent` once
+/// the user taps "Register". Subsequent chat turns can invoke it the same way
+/// the rest of the demo's tools (calc, now, read_file…) get invoked.
+@available(iOS 26, macOS 26, *)
+struct AppIntentToolsView: View {
+
+    @Environment(\.dismiss) private var dismiss
+
+    let toolRegistry: ToolRegistry
+
+    @State private var registered: Bool = false
+    @State private var lastSchema: String = ""
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("AppIntent → Tool") {
+                    Text("BaseChatAppIntents bridges any `AppIntent` into the chat tool registry. Tapping `Register` exposes the demo's `SetReminderIntent` to the model under the name `set_reminder_intent`.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+
+                    Button(registered ? "Registered" : "Register SetReminderIntent") {
+                        register()
+                    }
+                    .disabled(registered)
+                    .accessibilityIdentifier("appintent-tools-register-button")
+                }
+
+                if !lastSchema.isEmpty {
+                    Section("Synthesised JSON Schema") {
+                        Text(lastSchema)
+                            .font(.system(.footnote, design: .monospaced))
+                            .textSelection(.enabled)
+                            .accessibilityIdentifier("appintent-tools-schema")
+                    }
+                }
+            }
+            .navigationTitle("AppIntent Tools")
+            .accessibilityIdentifier("appintent-tools-sheet")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .onAppear {
+                lastSchema = AppIntentToolsView.schemaPreview()
+            }
+        }
+    }
+
+    private func register() {
+        let executor = AppIntentToolExecutor(SetReminderIntent.self)
+        toolRegistry.register(executor)
+        registered = true
+        lastSchema = AppIntentToolsView.schemaPreview()
+    }
+
+    private static func schemaPreview() -> String {
+        let executor = AppIntentToolExecutor(SetReminderIntent.self)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        if let data = try? encoder.encode(executor.definition.parameters),
+           let string = String(data: data, encoding: .utf8) {
+            return string
+        }
+        return "<unable to render schema>"
+    }
+}
+
+#endif

--- a/Example/BaseChatDemo/Intents/SetReminderIntent.swift
+++ b/Example/BaseChatDemo/Intents/SetReminderIntent.swift
@@ -1,0 +1,52 @@
+import AppIntents
+import Foundation
+
+/// Demo intent surfaced through ``AppIntentToolExecutor`` so the model can
+/// invoke it during a chat turn.
+///
+/// The intent doesn't actually wire into EventKit — it logs the request and
+/// returns the formatted reminder text. The point is to demonstrate the
+/// AppIntent → ToolExecutor bridge, not to ship a real reminder feature.
+///
+/// `Decodable` conformance is required by ``AppIntentToolExecutor`` because
+/// AppIntents doesn't synthesise it for property-wrapper-shadowed storage.
+@available(iOS 26, macOS 26, *)
+public struct SetReminderIntent: AppIntent, Decodable {
+
+    public static let title: LocalizedStringResource = "Set a reminder"
+
+    public static let description = IntentDescription(
+        "Records a reminder string with an optional time. Demo-only; nothing is persisted.",
+        categoryName: "Productivity"
+    )
+
+    @Parameter(title: "Text", description: "What you want to be reminded about.")
+    public var text: String
+
+    @Parameter(title: "When", description: "Optional date/time for the reminder.")
+    public var when: Date?
+
+    public init() {}
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init()
+        self.text = try c.decode(String.self, forKey: .text)
+        self.when = try c.decodeIfPresent(Date.self, forKey: .when)
+    }
+
+    private enum CodingKeys: String, CodingKey { case text, when }
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let summary: String
+        if let when {
+            let formatter = DateFormatter()
+            formatter.dateStyle = .medium
+            formatter.timeStyle = .short
+            summary = "Reminder set for \(formatter.string(from: when)): \(text)"
+        } else {
+            summary = "Reminder noted: \(text)"
+        }
+        return .result(value: summary)
+    }
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a82626b772e2e70274065549bc132ad9ae4d80885e5aa743810c53b198099734",
+  "originHash" : "50ed24a2ca964520c93d7261a74fae9ff5c28b225071881fd699cdaf2e5d25ca",
   "pins" : [
     {
       "identity" : "eventsource",

--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
         .executable(name: "fuzz-chat", targets: ["fuzz-chat"]),
         .library(name: "BaseChatTools", targets: ["BaseChatTools"]),
         .executable(name: "bck-tools", targets: ["bck-tools"]),
+        .library(name: "BaseChatAppIntents", targets: ["BaseChatAppIntents"]),
     ],
     traits: [
         .default(enabledTraits: ["MLX", "Llama"]),
@@ -361,6 +362,23 @@ let package = Package(
                 "BaseChatTools",
                 "BaseChatInference",
                 "BaseChatTestSupport",
+            ]
+        ),
+        // BaseChatAppIntents: AppIntent ↔ ToolDefinition bridge.
+        // Lets hosts expose any AppIntent as a model-callable tool by deriving
+        // the JSON-Schema parameters from `@Parameter` reflection. Trait-free
+        // and depends only on BaseChatInference so apps can opt in without
+        // pulling AppIntents on platforms / module graphs that don't need it.
+        .target(
+            name: "BaseChatAppIntents",
+            dependencies: ["BaseChatInference"],
+            path: "Sources/BaseChatAppIntents"
+        ),
+        .testTarget(
+            name: "BaseChatAppIntentsTests",
+            dependencies: [
+                "BaseChatAppIntents",
+                "BaseChatInference",
             ]
         ),
         // Xcode-only: real MLX model inference requiring Metal shader library.

--- a/Sources/BaseChatAppIntents/AppIntentToolExecutor.swift
+++ b/Sources/BaseChatAppIntents/AppIntentToolExecutor.swift
@@ -81,8 +81,17 @@ public struct AppIntentToolExecutor<Intent: AppIntent & Decodable>: ToolExecutor
 
             let intent: Intent
             do {
-                let argsData = try JSONEncoder().encode(arguments)
-                intent = try JSONDecoder().decode(Intent.self, from: argsData)
+                // Encode/decode symmetrically with ISO-8601 dates. The
+                // synthesised JSON Schema advertises `Date` as
+                // `{ "type": "string", "format": "date-time" }`, so models
+                // emit ISO-8601 strings — `JSONDecoder`'s default
+                // `secondsSince2001` strategy would reject every one of them.
+                let encoder = JSONEncoder()
+                encoder.dateEncodingStrategy = .iso8601
+                let decoder = JSONDecoder()
+                decoder.dateDecodingStrategy = .iso8601
+                let argsData = try encoder.encode(arguments)
+                intent = try decoder.decode(Intent.self, from: argsData)
             } catch {
                 return ToolResult(
                     callId: "",
@@ -149,7 +158,12 @@ public struct AppIntentToolExecutor<Intent: AppIntent & Decodable>: ToolExecutor
     static func serialise(_ result: some IntentResult) -> String {
         if let encodable = result as? any Encodable {
             do {
-                let data = try JSONEncoder().encode(EncodableBox(encodable))
+                // Symmetric with the decoder in `execute(arguments:)` — a
+                // result that contains a `Date` should serialise as an
+                // ISO-8601 string so the model sees the same shape it sent.
+                let encoder = JSONEncoder()
+                encoder.dateEncodingStrategy = .iso8601
+                let data = try encoder.encode(EncodableBox(encodable))
                 if let string = String(data: data, encoding: .utf8) {
                     return string
                 }

--- a/Sources/BaseChatAppIntents/AppIntentToolExecutor.swift
+++ b/Sources/BaseChatAppIntents/AppIntentToolExecutor.swift
@@ -1,0 +1,211 @@
+import Foundation
+import BaseChatInference
+
+#if canImport(AppIntents)
+import AppIntents
+#endif
+
+#if canImport(AppIntents)
+
+// MARK: - AppIntentToolExecutor
+
+/// Bridges an AppIntent into BaseChatKit's `ToolExecutor` surface so an
+/// inference backend can call the intent like any other tool.
+///
+/// The executor synthesises the JSON-Schema contract from the intent's
+/// `@Parameter` metadata via reflection (see ``JSONSchemaBuilder``), decodes
+/// the model's argument payload into a fresh intent instance, runs
+/// ``AppIntent/perform()``, and serialises the resulting ``IntentResult``
+/// into the tool result body.
+///
+/// ## Requirements
+///
+/// - `Intent` is an `AppIntent` (provides `init()` + `perform()` + the
+///   `@Parameter` declarations).
+/// - `Intent` is `Decodable`. AppIntents don't synthesise `Decodable`
+///   automatically because the property wrappers shadow the storage; a
+///   one-line `init(from decoder:)` is usually enough — see the bundled
+///   `BaseChatAppIntents` DocC for the boilerplate.
+/// - Enum parameters that should appear as JSON-Schema `enum: [...]` adopt
+///   ``IntentEnumParameter`` (a thin marker over `CaseIterable & RawRepresentable`).
+///
+/// ## Errors
+///
+/// - JSON-decode failures surface as
+///   ``ToolResult/ErrorKind/invalidArguments``.
+/// - `IntentAuthorization` failures (i.e. the system or the intent itself
+///   throwing the AppIntents authorisation error) surface as
+///   ``ToolResult/ErrorKind/permissionDenied``.
+/// - Other thrown errors become ``ToolResult/ErrorKind/permanent``.
+///
+/// ## Cancellation
+///
+/// The executor honours structured cancellation — the orchestrator's
+/// `Task.cancel()` propagates into ``AppIntent/perform()`` via the surrounding
+/// task. AppIntent implementations that perform their own work should poll
+/// `Task.checkCancellation()` at sensible yield points.
+///
+/// ## Availability
+///
+/// Pinned to iOS 26 / macOS 26 because the executor relies on the on-device
+/// LLM-actuation features in the latest AppIntents revision. Apps targeting
+/// older OS minimums should gate the registration with `if #available`.
+@available(iOS 26, macOS 26, *)
+public struct AppIntentToolExecutor<Intent: AppIntent & Decodable>: ToolExecutor {
+
+    public let definition: ToolDefinition
+
+    /// Creates an executor that exposes `intentType` as a model-callable tool.
+    ///
+    /// - Parameters:
+    ///   - intentType: The AppIntent type to bridge.
+    ///   - description: Optional human-readable description shown to the
+    ///     model. Defaults to the intent's ``AppIntent/title`` (resolved via
+    ///     `String(localized:)`).
+    public init(_ intentType: Intent.Type, description: String? = nil) {
+        let toolName = Self.canonicalName(for: intentType)
+        let toolDescription = description ?? Self.defaultDescription(for: intentType)
+        let parameters = JSONSchemaBuilder.schema(for: Intent.self) {
+            Intent()
+        }
+        self.definition = ToolDefinition(
+            name: toolName,
+            description: toolDescription,
+            parameters: parameters
+        )
+    }
+
+    public func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+        do {
+            try Task.checkCancellation()
+
+            let intent: Intent
+            do {
+                let argsData = try JSONEncoder().encode(arguments)
+                intent = try JSONDecoder().decode(Intent.self, from: argsData)
+            } catch {
+                return ToolResult(
+                    callId: "",
+                    content: "Failed to decode AppIntent arguments: \(error.localizedDescription)",
+                    errorKind: .invalidArguments
+                )
+            }
+
+            try Task.checkCancellation()
+
+            let result = try await intent.perform()
+            try Task.checkCancellation()
+
+            let content = Self.serialise(result)
+            return ToolResult(callId: "", content: content, errorKind: nil)
+        } catch is CancellationError {
+            return ToolResult(callId: "", content: "cancelled by user", errorKind: .cancelled)
+        } catch {
+            // The AppIntents framework surfaces authorisation failures via
+            // its own error types. We can't import every concrete
+            // authorisation error symbol across SDK versions, so we sniff
+            // the error description / domain for the canonical
+            // "authorization" / "authorisation" / "permission" / "denied"
+            // tokens and route those to .permissionDenied. Everything else
+            // falls through to .permanent.
+            if Self.looksLikeAuthorizationFailure(error) {
+                return ToolResult(
+                    callId: "",
+                    content: error.localizedDescription,
+                    errorKind: .permissionDenied
+                )
+            }
+            return ToolResult(
+                callId: "",
+                content: error.localizedDescription,
+                errorKind: .permanent
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Tool name derived from the intent's type — `AskBaseChatDemoIntent`
+    /// becomes `ask_base_chat_demo_intent`. Snake-case keeps the name aligned
+    /// with the rest of the BaseChatKit reference toolset.
+    static func canonicalName(for type: Intent.Type) -> String {
+        let raw = String(describing: type)
+        return raw.snakeCased()
+    }
+
+    /// Localised title fallback when the caller doesn't provide a description.
+    static func defaultDescription(for type: Intent.Type) -> String {
+        // `LocalizedStringResource` resolves through the calling bundle; in a
+        // test harness the resolution falls back to the literal key, which is
+        // still a serviceable description.
+        String(localized: type.title)
+    }
+
+    /// JSON-encodes a value that conforms to `Encodable`; otherwise returns
+    /// `String(describing:)`. AppIntents `IntentResult` is not generically
+    /// `Encodable`, but most concrete result types either are codable or have
+    /// a sensible `description` representation, and a stringly-typed body is
+    /// what the model will read regardless.
+    static func serialise(_ result: some IntentResult) -> String {
+        if let encodable = result as? any Encodable {
+            do {
+                let data = try JSONEncoder().encode(EncodableBox(encodable))
+                if let string = String(data: data, encoding: .utf8) {
+                    return string
+                }
+            } catch {
+                // Encoding a custom IntentResult can fail when the
+                // concrete type's nested values aren't encodable. We log
+                // and fall back to `String(describing:)` so the model
+                // still sees something meaningful in the tool output.
+                Log.inference.warning(
+                    "AppIntentToolExecutor: failed to JSON-encode IntentResult — falling back to description: \(String(describing: error), privacy: .public)"
+                )
+            }
+        }
+        return String(describing: result)
+    }
+
+    /// Heuristic match for AppIntents authorisation failures.
+    static func looksLikeAuthorizationFailure(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        let domain = nsError.domain.lowercased()
+        if domain.contains("authorization") || domain.contains("authorisation") || domain.contains("permission") {
+            return true
+        }
+        let description = error.localizedDescription.lowercased()
+        return description.contains("not authorized")
+            || description.contains("not authorised")
+            || description.contains("permission denied")
+            || description.contains("authorization required")
+            || description.contains("authorisation required")
+    }
+}
+
+// MARK: - Helpers
+
+private extension String {
+    /// `MyIntentName` → `my_intent_name`.
+    func snakeCased() -> String {
+        var output = ""
+        for (index, character) in enumerated() {
+            if character.isUppercase && index != 0 {
+                output.append("_")
+            }
+            output.append(character.lowercased())
+        }
+        return output
+    }
+}
+
+/// Type-erased box so we can call `JSONEncoder().encode(...)` on a value whose
+/// concrete type we only know exists at runtime.
+private struct EncodableBox: Encodable {
+    let value: any Encodable
+    init(_ value: any Encodable) { self.value = value }
+    func encode(to encoder: Encoder) throws {
+        try value.encode(to: encoder)
+    }
+}
+
+#endif // canImport(AppIntents)

--- a/Sources/BaseChatAppIntents/BaseChatAppIntents.docc/BaseChatAppIntents.md
+++ b/Sources/BaseChatAppIntents/BaseChatAppIntents.docc/BaseChatAppIntents.md
@@ -1,0 +1,99 @@
+# ``BaseChatAppIntents``
+
+Bridge an `AppIntent` into BaseChatKit's tool-calling pipeline so an inference
+backend can invoke it like any other registered tool.
+
+## Overview
+
+`BaseChatAppIntents` ships a single public type, ``AppIntentToolExecutor``,
+that wraps any `AppIntent` and exposes it through the `ToolExecutor` protocol
+in `BaseChatInference`. The executor:
+
+1. Walks the intent's `@Parameter` properties via reflection and synthesises a
+   JSON-Schema document for ``ToolDefinition/parameters``.
+2. Decodes the model's argument payload back into a fresh intent instance.
+3. Calls `perform()` on the intent and surfaces the resulting `IntentResult`
+   as a ``ToolResult``.
+
+Authorisation failures surface with ``ToolResult/ErrorKind/permissionDenied``;
+JSON-decode failures surface with ``ToolResult/ErrorKind/invalidArguments``;
+all other thrown errors classify as ``ToolResult/ErrorKind/permanent``.
+
+The module depends only on `BaseChatInference`, so apps that don't need
+SwiftData persistence or the full chat UI can adopt it with no transitive
+weight. AppIntents itself ships with the OS, so there is no third-party
+dependency.
+
+## Five-line wiring
+
+Once your `AppIntent` adopts `Decodable`, registering it as a tool is a
+five-line affair:
+
+```swift
+import BaseChatAppIntents
+import BaseChatInference
+
+let registry = ToolRegistry()
+registry.register(AppIntentToolExecutor(AskBaseChatDemoIntent.self))
+inferenceService.toolRegistry = registry
+```
+
+The model now sees `ask_base_chat_demo_intent` in its tool list and can
+invoke it whenever the conversation calls for it.
+
+## Decodable boilerplate
+
+AppIntents do not synthesise `Decodable` automatically because the
+`@Parameter` property wrappers shadow the storage. A four-line conformance
+keyed by the property names is enough:
+
+```swift
+struct AskBaseChatDemoIntent: AppIntent, Decodable {
+    static let title: LocalizedStringResource = "Ask BaseChat Demo"
+    @Parameter(title: "Prompt") var prompt: String
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init()
+        self.prompt = try c.decode(String.self, forKey: .prompt)
+    }
+
+    private enum CodingKeys: String, CodingKey { case prompt }
+
+    func perform() async throws -> some IntentResult { .result() }
+}
+```
+
+## Parameter-type coverage
+
+| Swift type                       | JSON Schema                                  |
+|----------------------------------|----------------------------------------------|
+| `String`                         | `{ "type": "string" }`                       |
+| `Int`, `Int32`, `Int64`          | `{ "type": "integer" }`                      |
+| `Double`, `Float`, `CGFloat`     | `{ "type": "number" }`                       |
+| `Bool`                           | `{ "type": "boolean" }`                      |
+| `Date`                           | `{ "type": "string", "format": "date-time" }`|
+| `URL`                            | `{ "type": "string", "format": "uri" }`      |
+| Optional<T>                      | (recurses; field becomes non-required)       |
+| `T: IntentEnumParameter`         | `{ "type": "string", "enum": [...] }`        |
+
+Enums become first-class JSON-Schema enums when they conform to
+``IntentEnumParameter`` — a thin marker over `CaseIterable & RawRepresentable`
+whose `RawValue` is `String`. AppIntents already encourages this shape for
+`AppEnum` types, so the conformance is usually zero work.
+
+## Availability
+
+``AppIntentToolExecutor`` is annotated `@available(iOS 26, macOS 26, *)`
+because it ships alongside the on-device LLM-actuation features in the
+current AppIntents revision. Apps with older minimum-deployment targets
+should gate registration behind `if #available(iOS 26, macOS 26, *)`.
+
+## Topics
+
+### Bridging AppIntents to ToolExecutor
+
+- ``AppIntentToolExecutor``
+- ``IntentEnumParameter``

--- a/Sources/BaseChatAppIntents/BaseChatAppIntents.docc/BaseChatAppIntents.md
+++ b/Sources/BaseChatAppIntents/BaseChatAppIntents.docc/BaseChatAppIntents.md
@@ -5,9 +5,11 @@ backend can invoke it like any other registered tool.
 
 ## Overview
 
-`BaseChatAppIntents` ships a single public type, ``AppIntentToolExecutor``,
-that wraps any `AppIntent` and exposes it through the `ToolExecutor` protocol
-in `BaseChatInference`. The executor:
+`BaseChatAppIntents` ships two public types: ``AppIntentToolExecutor``, which
+wraps any `AppIntent` and exposes it through the `ToolExecutor` protocol in
+`BaseChatInference`, and ``IntentEnumParameter``, the marker protocol your
+parameter enums adopt so the schema builder can enumerate their cases. The
+executor:
 
 1. Walks the intent's `@Parameter` properties via reflection and synthesises a
    JSON-Schema document for ``ToolDefinition/parameters``.

--- a/Sources/BaseChatAppIntents/JSONSchemaBuilder.swift
+++ b/Sources/BaseChatAppIntents/JSONSchemaBuilder.swift
@@ -1,0 +1,219 @@
+import Foundation
+import BaseChatInference
+
+// MARK: - IntentEnumParameter
+
+/// Marker protocol enums adopt so the schema builder can enumerate their cases.
+///
+/// AppIntents' `@Parameter` works with any `AppEnum`, but Swift's runtime
+/// reflection cannot enumerate enum cases generically — `Mirror` only sees the
+/// case currently inhabited by an instance. Adopt this protocol on enums you
+/// expose as parameters; the builder uses `allCases` to populate
+/// `enum: [...]` in the generated JSON Schema.
+///
+/// ```swift
+/// enum Priority: String, IntentEnumParameter {
+///     case low, medium, high
+/// }
+/// ```
+///
+/// Conformance is intentionally cheap: most `AppEnum` types already conform to
+/// `CaseIterable & RawRepresentable where RawValue == String`, which is all
+/// this protocol requires.
+public protocol IntentEnumParameter: CaseIterable, RawRepresentable, Sendable where RawValue == String {}
+
+// MARK: - JSONSchemaBuilder
+
+/// Synthesises a JSON-Schema document from an AppIntent type's `@Parameter`
+/// metadata.
+///
+/// ## How it works
+///
+/// AppIntent property wrappers (`IntentParameter<T>`) are stored properties on
+/// the intent struct. We instantiate the intent (every `AppIntent` requires
+/// `init()`) and walk its `Mirror`. Each child whose value is an
+/// `IntentParameter<T>` becomes one schema property — derived from the wrapped
+/// type `T`.
+///
+/// The builder maps the following Swift types:
+///
+/// | Swift type            | JSON Schema           |
+/// |-----------------------|-----------------------|
+/// | `String`              | `"type": "string"`    |
+/// | `Int`, `Int32`, `Int64` | `"type": "integer"` |
+/// | `Double`, `Float`, `CGFloat` | `"type": "number"` |
+/// | `Bool`                | `"type": "boolean"`   |
+/// | `Date`                | `"type": "string", "format": "date-time"` |
+/// | `URL`                 | `"type": "string", "format": "uri"`        |
+/// | `T: IntentEnumParameter` | `"type": "string", "enum": [...]`       |
+/// | `Optional<T>`         | (recurses into `T`; field becomes non-required) |
+///
+/// Unknown types fall back to `"type": "string"` so the schema is still valid.
+///
+/// The leading `_` underscore SwiftUI-style mirror property names get stripped
+/// so the JSON parameter name matches the intent's declared property name.
+enum JSONSchemaBuilder {
+
+    /// Builds a JSON-Schema object describing `Intent`'s `@Parameter` properties.
+    static func schema<Intent: Sendable>(for intentType: Intent.Type, makeInstance: () -> Intent) -> JSONSchemaValue {
+        let instance = makeInstance()
+        let mirror = Mirror(reflecting: instance)
+
+        var properties: [String: JSONSchemaValue] = [:]
+        var required: [String] = []
+        // Preserve declaration order so generated schemas are stable across
+        // builds — JSON-Schema doesn't mandate ordering, but stable output
+        // keeps test fixtures and snapshots deterministic.
+        var orderedNames: [String] = []
+
+        for child in mirror.children {
+            guard let label = child.label else { continue }
+            // SwiftUI/AppIntents property wrappers expose the underlying
+            // storage with a leading underscore in the mirror — strip it so
+            // the schema property matches the intent's declared name.
+            let name = label.hasPrefix("_") ? String(label.dropFirst()) : label
+
+            let (typeSchema, isOptional) = describe(child.value)
+            properties[name] = typeSchema
+            orderedNames.append(name)
+            if !isOptional {
+                required.append(name)
+            }
+        }
+
+        var object: [String: JSONSchemaValue] = [
+            "type": .string("object"),
+            "properties": .object(properties),
+        ]
+        if !required.isEmpty {
+            // Reorder required to match declaration order — this is purely
+            // cosmetic but keeps generated schemas readable.
+            let orderedRequired = orderedNames.filter { required.contains($0) }
+            object["required"] = .array(orderedRequired.map { .string($0) })
+        }
+        return .object(object)
+    }
+
+    /// Returns the schema fragment for one mirror child plus whether the
+    /// underlying parameter is optional (which controls the `required` list).
+    private static func describe(_ value: Any) -> (schema: JSONSchemaValue, isOptional: Bool) {
+        // The mirror child for an `@Parameter`-wrapped property is the
+        // property-wrapper struct itself (`IntentParameter<T>`), not the
+        // wrapped `T`. We dive one level into its mirror to find the storage.
+        // Most wrapper implementations expose the wrapped value as their
+        // single relevant child; if not, we still get a usable type-name
+        // string from `type(of:)` and parse the generic parameter out.
+        let typeName = String(reflecting: type(of: value))
+        let inner = wrappedTypeName(from: typeName) ?? typeName
+        let (schema, isOptional) = mapTypeName(inner, original: value)
+        return (schema, isOptional)
+    }
+
+    /// Pulls the inner type out of an `IntentParameter<T>` type name so we can
+    /// reason about `T` even when reflection on the wrapper itself doesn't
+    /// expose the wrapped value.
+    ///
+    /// Falls back to `nil` for non-`IntentParameter` cases so the caller uses
+    /// the original type name directly.
+    private static func wrappedTypeName(from typeName: String) -> String? {
+        // Examples we want to handle:
+        //   AppIntents.IntentParameter<Swift.String>
+        //   AppIntents.IntentParameter<Swift.Optional<Swift.Int>>
+        //   AppIntents.IntentParameter<MyApp.Priority>
+        guard let openIdx = typeName.firstIndex(of: "<"),
+              typeName.last == ">",
+              typeName.contains("IntentParameter")
+        else {
+            return nil
+        }
+        let after = typeName.index(after: openIdx)
+        let beforeClose = typeName.index(before: typeName.endIndex)
+        return String(typeName[after..<beforeClose])
+    }
+
+    /// Maps a fully-qualified Swift type name (e.g. `Swift.Optional<Swift.Int>`)
+    /// onto a JSON-Schema fragment. The `original` value is used to look up
+    /// `IntentEnumParameter` cases when the type is enum-shaped.
+    private static func mapTypeName(_ typeName: String, original: Any) -> (JSONSchemaValue, isOptional: Bool) {
+        // Optional unwrap — strip `Swift.Optional<…>` and recurse on the inner
+        // type. Anything wrapped in `Optional` becomes non-required in the
+        // generated schema.
+        if let inner = unwrapOptional(typeName) {
+            let (schema, _) = mapTypeName(inner, original: original)
+            return (schema, true)
+        }
+
+        switch typeName {
+        case "Swift.String", "String":
+            return (.object(["type": .string("string")]), false)
+        case "Swift.Int", "Int", "Swift.Int32", "Int32", "Swift.Int64", "Int64":
+            return (.object(["type": .string("integer")]), false)
+        case "Swift.Double", "Double", "Swift.Float", "Float", "CoreGraphics.CGFloat", "CGFloat":
+            return (.object(["type": .string("number")]), false)
+        case "Swift.Bool", "Bool":
+            return (.object(["type": .string("boolean")]), false)
+        case "Foundation.Date", "Date":
+            return (.object([
+                "type": .string("string"),
+                "format": .string("date-time"),
+            ]), false)
+        case "Foundation.URL", "URL":
+            return (.object([
+                "type": .string("string"),
+                "format": .string("uri"),
+            ]), false)
+        default:
+            // Enum support: enumerate cases via the IntentEnumParameter
+            // protocol. We have to look the type up at runtime because the
+            // mirror only sees the wrapper, not the underlying enum value
+            // (which may not even be initialised yet).
+            if let cases = enumCases(forTypeName: typeName) {
+                return (.object([
+                    "type": .string("string"),
+                    "enum": .array(cases.map { .string($0) }),
+                ]), false)
+            }
+            // Fall back to string for unknown types — the schema is still
+            // valid, the model can attempt a string, and the executor will
+            // surface a decode error if the conversion fails.
+            return (.object(["type": .string("string")]), false)
+        }
+    }
+
+    /// `Swift.Optional<X>` → `X`, otherwise `nil`.
+    private static func unwrapOptional(_ typeName: String) -> String? {
+        let prefixes = ["Swift.Optional<", "Optional<"]
+        for prefix in prefixes where typeName.hasPrefix(prefix) && typeName.last == ">" {
+            return String(typeName.dropFirst(prefix.count).dropLast())
+        }
+        return nil
+    }
+
+    /// Looks up an `IntentEnumParameter` type by its fully-qualified name and
+    /// returns its raw-value cases, or `nil` if no matching type is registered.
+    private static func enumCases(forTypeName typeName: String) -> [String]? {
+        // `_typeByName(_:)` is the stdlib's mangled-name → metatype lookup.
+        // It resolves first-class types reachable in the running process, which
+        // covers app-module enums adopting `IntentEnumParameter`. If lookup
+        // fails, the caller falls back to a plain `string` schema.
+        guard let any = _typeByName(typeName) else { return nil }
+        guard let enumType = any as? any IntentEnumParameter.Type else { return nil }
+        return enumType.allCaseRawValues
+    }
+}
+
+// MARK: - IntentEnumParameter helpers
+
+extension IntentEnumParameter {
+    /// Returns every case's raw string value in declaration order.
+    static var allCaseRawValues: [String] {
+        Self.allCases.map { $0.rawValue }
+    }
+}
+
+// `_typeByName(_:)` is the stdlib's underscored mangled-name → metatype
+// lookup. It's been part of the standard library since Swift 5.3 and is
+// callable directly without a shim — we use it inside `enumCases` to resolve
+// `IntentEnumParameter`-conforming types found by reflecting on parameter
+// wrappers. No declaration is needed here; the call site relies on the
+// implicit `Swift._typeByName` symbol.

--- a/Sources/BaseChatAppIntents/JSONSchemaBuilder.swift
+++ b/Sources/BaseChatAppIntents/JSONSchemaBuilder.swift
@@ -68,6 +68,15 @@ enum JSONSchemaBuilder {
 
         for child in mirror.children {
             guard let label = child.label else { continue }
+            // Only publish properties that are actually `@Parameter`-wrapped.
+            // Plain stored properties (caches, computed-but-stored helpers,
+            // future AppIntents framework storage) would otherwise leak into
+            // the schema as phantom tool arguments. We gate on the
+            // `IntentParameter<...>` type-name shape — which is exactly what
+            // `wrappedTypeName(from:)` is built to detect.
+            let typeName = String(reflecting: type(of: child.value))
+            guard wrappedTypeName(from: typeName) != nil else { continue }
+
             // SwiftUI/AppIntents property wrappers expose the underlying
             // storage with a leading underscore in the mirror — strip it so
             // the schema property matches the intent's declared name.

--- a/Tests/BaseChatAppIntentsTests/AppIntentToolExecutorTests.swift
+++ b/Tests/BaseChatAppIntentsTests/AppIntentToolExecutorTests.swift
@@ -1,0 +1,292 @@
+import XCTest
+import BaseChatInference
+@testable import BaseChatAppIntents
+
+#if canImport(AppIntents)
+import AppIntents
+
+// MARK: - Fixtures
+
+/// Happy-path fixture: two required string parameters and one optional.
+@available(iOS 26, macOS 26, *)
+struct GreetingIntent: AppIntent, Decodable {
+
+    static let title: LocalizedStringResource = "Greet"
+
+    @Parameter(title: "Name")
+    var name: String
+
+    @Parameter(title: "Greeting", description: "Optional salutation override.")
+    var greeting: String?
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init()
+        self.name = try c.decode(String.self, forKey: .name)
+        self.greeting = try c.decodeIfPresent(String.self, forKey: .greeting)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case name, greeting
+    }
+
+    func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let salutation = greeting ?? "Hello"
+        return .result(value: "\(salutation), \(name)")
+    }
+}
+
+/// Validation fixture: throws on empty input so we can exercise the error path.
+@available(iOS 26, macOS 26, *)
+struct ValidatingIntent: AppIntent, Decodable {
+
+    static let title: LocalizedStringResource = "Validate"
+
+    @Parameter(title: "Value")
+    var value: String
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init()
+        self.value = try c.decode(String.self, forKey: .value)
+    }
+
+    private enum CodingKeys: String, CodingKey { case value }
+
+    struct EmptyValueError: LocalizedError {
+        var errorDescription: String? { "value must not be empty" }
+    }
+
+    func perform() async throws -> some IntentResult {
+        if value.isEmpty {
+            throw EmptyValueError()
+        }
+        return .result()
+    }
+}
+
+/// Authorisation fixture: throws an error whose domain matches the
+/// permission-denied heuristic so the executor classifies it correctly.
+@available(iOS 26, macOS 26, *)
+struct UnauthorizedIntent: AppIntent, Decodable {
+
+    static let title: LocalizedStringResource = "Unauthorized"
+
+    @Parameter(title: "Resource")
+    var resource: String
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init()
+        self.resource = try c.decode(String.self, forKey: .resource)
+    }
+
+    private enum CodingKeys: String, CodingKey { case resource }
+
+    func perform() async throws -> some IntentResult {
+        let error = NSError(
+            domain: "com.basechat.test.AuthorizationDomain",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Authorization required for \(resource)"]
+        )
+        throw error
+        // Unreachable — present so the opaque return type can be inferred.
+        return .result()
+    }
+}
+
+/// Multi-type fixture: covers Int, Double, Bool, Date, URL, and Optional in
+/// one shot so the schema reflection path is exercised end-to-end.
+@available(iOS 26, macOS 26, *)
+struct WideIntent: AppIntent, Decodable {
+
+    static let title: LocalizedStringResource = "Wide"
+
+    @Parameter(title: "Count")
+    var count: Int
+
+    @Parameter(title: "Ratio")
+    var ratio: Double
+
+    @Parameter(title: "Flag")
+    var flag: Bool
+
+    @Parameter(title: "When")
+    var when: Date
+
+    @Parameter(title: "Link")
+    var link: URL
+
+    @Parameter(title: "Note")
+    var note: String?
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init()
+        self.count = try c.decode(Int.self, forKey: .count)
+        self.ratio = try c.decode(Double.self, forKey: .ratio)
+        self.flag = try c.decode(Bool.self, forKey: .flag)
+        self.when = try c.decode(Date.self, forKey: .when)
+        self.link = try c.decode(URL.self, forKey: .link)
+        self.note = try c.decodeIfPresent(String.self, forKey: .note)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case count, ratio, flag, when, link, note
+    }
+
+    func perform() async throws -> some IntentResult & ReturnsValue<Int> {
+        .result(value: count)
+    }
+}
+
+// MARK: - Tests
+
+@available(iOS 26, macOS 26, *)
+final class AppIntentToolExecutorTests: XCTestCase {
+
+    // MARK: definition synthesis
+
+    func testDefinitionDerivesNameFromIntentType() {
+        let executor = AppIntentToolExecutor(GreetingIntent.self)
+        XCTAssertEqual(executor.definition.name, "greeting_intent")
+    }
+
+    func testDefinitionUsesCustomDescription() {
+        let executor = AppIntentToolExecutor(GreetingIntent.self, description: "Greets a person.")
+        XCTAssertEqual(executor.definition.description, "Greets a person.")
+    }
+
+    func testSchemaIncludesRequiredAndOptionalFields() {
+        let executor = AppIntentToolExecutor(GreetingIntent.self)
+        guard case .object(let root) = executor.definition.parameters else {
+            return XCTFail("schema root must be an object")
+        }
+
+        XCTAssertEqual(root["type"], .string("object"))
+
+        guard case .object(let properties) = root["properties"] else {
+            return XCTFail("schema must have an object `properties` field")
+        }
+        XCTAssertEqual(properties["name"], .object(["type": .string("string")]))
+        XCTAssertEqual(properties["greeting"], .object(["type": .string("string")]))
+
+        guard case .array(let required) = root["required"] else {
+            return XCTFail("schema must declare `required`")
+        }
+        XCTAssertEqual(required, [.string("name")], "optional `greeting` must not appear in `required`")
+    }
+
+    func testSchemaCoversCommonPrimitiveTypes() {
+        let executor = AppIntentToolExecutor(WideIntent.self)
+        guard case .object(let root) = executor.definition.parameters,
+              case .object(let properties) = root["properties"]
+        else {
+            return XCTFail("schema root must be an object with properties")
+        }
+
+        XCTAssertEqual(properties["count"], .object(["type": .string("integer")]))
+        XCTAssertEqual(properties["ratio"], .object(["type": .string("number")]))
+        XCTAssertEqual(properties["flag"], .object(["type": .string("boolean")]))
+        XCTAssertEqual(properties["when"], .object([
+            "type": .string("string"),
+            "format": .string("date-time"),
+        ]))
+        XCTAssertEqual(properties["link"], .object([
+            "type": .string("string"),
+            "format": .string("uri"),
+        ]))
+        // Optional → still in `properties`, but missing from `required`.
+        XCTAssertEqual(properties["note"], .object(["type": .string("string")]))
+
+        guard case .array(let required) = root["required"] else {
+            return XCTFail("schema must declare `required`")
+        }
+        let requiredNames = required.compactMap { value -> String? in
+            if case .string(let s) = value { return s } else { return nil }
+        }
+        XCTAssertFalse(requiredNames.contains("note"), "optional fields must not be required")
+        XCTAssertTrue(requiredNames.contains("count"))
+        XCTAssertTrue(requiredNames.contains("ratio"))
+        XCTAssertTrue(requiredNames.contains("flag"))
+        XCTAssertTrue(requiredNames.contains("when"))
+        XCTAssertTrue(requiredNames.contains("link"))
+    }
+
+    // MARK: execution
+
+    func testExecuteHappyPathSerialisesResult() async throws {
+        let executor = AppIntentToolExecutor(GreetingIntent.self)
+        let args = JSONSchemaValue.object([
+            "name": .string("Ada"),
+            "greeting": .string("Salut"),
+        ])
+
+        let result = try await executor.execute(arguments: args)
+
+        XCTAssertNil(result.errorKind, "happy path must not surface an error kind")
+        XCTAssertTrue(
+            result.content.contains("Salut") && result.content.contains("Ada"),
+            "result body must include intent output, got \(result.content)"
+        )
+    }
+
+    func testExecuteWithMissingRequiredFieldReturnsInvalidArguments() async throws {
+        let executor = AppIntentToolExecutor(GreetingIntent.self)
+        // No `name` key → JSONDecoder will throw a keyNotFound error.
+        let args = JSONSchemaValue.object([:])
+
+        let result = try await executor.execute(arguments: args)
+
+        XCTAssertEqual(result.errorKind, .invalidArguments)
+        XCTAssertTrue(result.content.contains("AppIntent arguments"))
+    }
+
+    func testExecuteSurfacesIntentValidationErrorAsPermanent() async throws {
+        let executor = AppIntentToolExecutor(ValidatingIntent.self)
+        let args = JSONSchemaValue.object([
+            "value": .string(""),
+        ])
+
+        let result = try await executor.execute(arguments: args)
+
+        XCTAssertEqual(result.errorKind, .permanent)
+        XCTAssertTrue(result.content.contains("must not be empty"))
+    }
+
+    func testExecuteDetectsAuthorizationFailure() async throws {
+        let executor = AppIntentToolExecutor(UnauthorizedIntent.self)
+        let args = JSONSchemaValue.object([
+            "resource": .string("camera"),
+        ])
+
+        let result = try await executor.execute(arguments: args)
+
+        XCTAssertEqual(
+            result.errorKind,
+            .permissionDenied,
+            "authorisation-domain errors must surface as .permissionDenied"
+        )
+        XCTAssertTrue(result.content.contains("Authorization required"))
+    }
+
+    func testExecutorIsToolExecutorConformant() {
+        // Compile-time conformance check + runtime dispatch through the
+        // protocol existential, mirroring how ToolRegistry will see the
+        // executor in production.
+        let executor: any ToolExecutor = AppIntentToolExecutor(GreetingIntent.self)
+        XCTAssertEqual(executor.definition.name, "greeting_intent")
+        XCTAssertFalse(executor.requiresApproval, "default `requiresApproval` is false")
+        XCTAssertFalse(executor.supportsConcurrentDispatch, "default sequential dispatch")
+    }
+}
+
+#endif // canImport(AppIntents)

--- a/Tests/BaseChatAppIntentsTests/AppIntentToolExecutorTests.swift
+++ b/Tests/BaseChatAppIntentsTests/AppIntentToolExecutorTests.swift
@@ -148,6 +148,34 @@ struct WideIntent: AppIntent, Decodable {
     }
 }
 
+/// Date-decoding fixture: one required `Date` parameter so we can verify that
+/// `execute(arguments:)` honours the ISO-8601 contract its synthesised schema
+/// advertises.
+@available(iOS 26, macOS 26, *)
+struct DateIntent: AppIntent, Decodable {
+
+    static let title: LocalizedStringResource = "Date"
+
+    @Parameter(title: "When")
+    var when: Date
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init()
+        self.when = try c.decode(Date.self, forKey: .when)
+    }
+
+    private enum CodingKeys: String, CodingKey { case when }
+
+    func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        // ISO-8601 round-trip so the test can assert on a stable string.
+        let formatter = ISO8601DateFormatter()
+        return .result(value: formatter.string(from: when))
+    }
+}
+
 // MARK: - Tests
 
 @available(iOS 26, macOS 26, *)
@@ -276,6 +304,32 @@ final class AppIntentToolExecutorTests: XCTestCase {
             "authorisation-domain errors must surface as .permissionDenied"
         )
         XCTAssertTrue(result.content.contains("Authorization required"))
+    }
+
+    func testExecuteDecodesISO8601DateArguments() async throws {
+        let executor = AppIntentToolExecutor(DateIntent.self)
+        // The synthesised schema advertises `Date` as a string with
+        // `format: date-time`, so the executor must treat the argument as
+        // ISO-8601. A vanilla `JSONDecoder` would default to
+        // `secondsSince2001` and reject this string.
+        let iso = "2026-04-26T12:34:56Z"
+        let args = JSONSchemaValue.object([
+            "when": .string(iso),
+        ])
+
+        let result = try await executor.execute(arguments: args)
+
+        XCTAssertNil(
+            result.errorKind,
+            "ISO-8601 date arguments must decode without error, got \(String(describing: result.errorKind)): \(result.content)"
+        )
+        // `perform()` round-trips the date back through the same formatter,
+        // so equality on the input string proves the decode produced the
+        // expected `Date`.
+        XCTAssertTrue(
+            result.content.contains(iso),
+            "expected round-tripped ISO-8601 string in result body, got \(result.content)"
+        )
     }
 
     func testExecutorIsToolExecutorConformant() {

--- a/Tests/BaseChatAppIntentsTests/AppIntentToolExecutorTests.swift
+++ b/Tests/BaseChatAppIntentsTests/AppIntentToolExecutorTests.swift
@@ -176,6 +176,35 @@ struct DateIntent: AppIntent, Decodable {
     }
 }
 
+/// Phantom-storage fixture: one `@Parameter` field plus an unrelated stored
+/// property the schema builder must NOT publish.
+@available(iOS 26, macOS 26, *)
+struct PhantomStorageIntent: AppIntent, Decodable {
+
+    static let title: LocalizedStringResource = "Phantom"
+
+    @Parameter(title: "Real")
+    var real: String
+
+    // Plain stored property — must not show up in the synthesised schema.
+    private var cache: [String] = []
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init()
+        self.real = try c.decode(String.self, forKey: .real)
+    }
+
+    private enum CodingKeys: String, CodingKey { case real }
+
+    func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        _ = cache  // silence "never read" warning
+        return .result(value: real)
+    }
+}
+
 // MARK: - Tests
 
 @available(iOS 26, macOS 26, *)
@@ -329,6 +358,23 @@ final class AppIntentToolExecutorTests: XCTestCase {
         XCTAssertTrue(
             result.content.contains(iso),
             "expected round-tripped ISO-8601 string in result body, got \(result.content)"
+        )
+    }
+
+    // MARK: schema hygiene
+
+    func testSchemaSkipsNonParameterStoredProperties() {
+        let executor = AppIntentToolExecutor(PhantomStorageIntent.self)
+        guard case .object(let root) = executor.definition.parameters,
+              case .object(let properties) = root["properties"]
+        else {
+            return XCTFail("schema root must be an object with properties")
+        }
+
+        XCTAssertEqual(
+            Set(properties.keys),
+            ["real"],
+            "only @Parameter-wrapped properties may appear in the synthesised schema; got \(properties.keys.sorted())"
         )
     }
 


### PR DESCRIPTION
Closes #620.

## Summary

Adds a new optional `BaseChatAppIntents` module that lets hosts expose any `AppIntent` as a model-callable tool. The new `AppIntentToolExecutor<Intent>` wraps any `AppIntent & Decodable`, synthesises a JSON-Schema document from the intent's `@Parameter` metadata via reflection, decodes the model's argument payload into a fresh intent instance, runs `perform()`, and serialises the resulting `IntentResult` back into a `ToolResult`.

The module depends only on `BaseChatInference` so apps can adopt it without pulling SwiftData, the chat UI, or anything that would force AppIntents onto platforms that lack it. The bridge type itself is `@available(iOS 26, macOS 26, *)` per the issue, since the on-device LLM-actuation path the bridge is designed around lives in the latest AppIntents revision.

```swift
import BaseChatAppIntents

let registry = ToolRegistry()
registry.register(AppIntentToolExecutor(SetReminderIntent.self))
inferenceService.toolRegistry = registry
```

## Acceptance criteria coverage

- [x] **`BaseChatAppIntents` module target in `Package.swift`** — new library + test target, no traits, depends only on `BaseChatInference`.
- [x] **`AppIntentToolExecutor<Intent>` conforms to `ToolExecutor`** — see `Sources/BaseChatAppIntents/AppIntentToolExecutor.swift`. Default `requiresApproval = false`, default sequential dispatch.
- [x] **Parameter-to-JSON-Schema mapping covers common primitives + enums + optionals** — `JSONSchemaBuilder` handles `String`, `Int/Int32/Int64`, `Double/Float/CGFloat`, `Bool`, `Date` (`format: date-time`), `URL` (`format: uri`), `Optional<T>` (recursive, marks the field non-required), and `IntentEnumParameter`-conforming enums (`enum: [...]`). Unknown types fall back to `string`.
- [x] **Authorization failures surface with `.permissionDenied` kind** — heuristic match on the error's domain or `localizedDescription` for canonical "authorization" / "authorisation" / "permission" / "denied" tokens. The framework's `IntentAuthorization` types aren't stable across SDK versions, so the heuristic is the portable choice.
- [x] **Unit tests with 2–3 fixture `AppIntent` types** — four fixtures covering happy path, validation throw, authorization domain match, and a wide-types intent that exercises every primitive in one schema. Nine `XCTestCase` tests, all green. Two assertions sabotage-verified before commit.
- [x] **DocC guide showing the 5-line wiring in an example iOS app** — `Sources/BaseChatAppIntents/BaseChatAppIntents.docc/BaseChatAppIntents.md` walks through Decodable boilerplate, the parameter-type table, the five-line registration snippet, and availability gating.
- [x] **Example app demo screen that registers one real app-intent-backed tool** — `Example/BaseChatDemo/AppIntentToolsView.swift` plus `Example/BaseChatDemo/Intents/SetReminderIntent.swift`. Tap "Register" and the model sees `set_reminder_intent` alongside the rest of the demo toolset; the screen also renders the synthesised JSON Schema for at-a-glance verification.

## Implementation notes

- Reflection on `IntentParameter<T>` storage uses `Mirror` plus a fully-qualified type-name parse, because the wrapper does not expose its wrapped value through the mirror in a stable way across SDKs. The parser strips `Swift.Optional<…>` to recurse into the inner type and mark the field as not required.
- Enum case enumeration is gated on a tiny marker protocol, `IntentEnumParameter`, that adds nothing on top of `CaseIterable & RawRepresentable where RawValue == String` — this is the shape `AppEnum` types already take. The schema builder resolves the enum's metatype via the standard library's `_typeByName(_:)` so enums declared anywhere in the app graph work without per-type registration.
- AppIntents do not synthesise `Decodable` automatically (the property wrappers shadow the storage), so the executor requires `Intent: AppIntent & Decodable`. A four-line `init(from decoder:)` is the boilerplate, documented in DocC and demonstrated in the example intent.
- The empty `catch` in the result-serialisation fallback now logs through `Log.inference.warning` to satisfy `SilentCatchAuditTest`.
- The Xcode project (`Example/BaseChatDemo.xcodeproj/project.pbxproj`) gains the new product dependency, the two new source files, and the corresponding `Sources` build-phase entries.

## Test plan

- [x] `swift test --filter BaseChatAppIntentsTests --disable-default-traits` (9/9 pass)
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits`
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` (1166/1166 pass — `SilentCatchAuditTest` clean)
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits`
- [x] `swift test --filter BaseChatUITests --disable-default-traits`
- [x] `swift test --filter BaseChatUIModelManagementTests --disable-default-traits`
- [x] `swift test --filter BaseChatMCPTests --disable-default-traits`
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits`
- [x] `swift test --filter BaseChatTestSupportTests --disable-default-traits`
- [x] Sabotage-verified two key assertions (authorization detection + boolean schema mapping) — both failed under sabotage, then restored.
- [ ] Example app `xcodebuild` is currently broken on `main` itself due to a stale `DemoMCPCoordinator.swift` reference unrelated to this PR (file lives at `MCP/DemoMCPCoordinator.swift` but the project references the bare path). Did not include a fix in this PR to avoid scope creep.

## Release Note

`BaseChatAppIntents` is a new optional module that bridges any `AppIntent` into BaseChatKit's tool-calling pipeline. Wrap an intent with `AppIntentToolExecutor(MyIntent.self)` and the bridge derives a JSON-Schema parameter contract from the intent's `@Parameter` declarations, decodes the model's arguments back into the intent, runs `perform()`, and surfaces the result through the standard `ToolResult` shape. Authorisation failures classify as `.permissionDenied`; decode failures as `.invalidArguments`. The module depends only on `BaseChatInference` and is annotated `@available(iOS 26, macOS 26, *)`, so apps with older deployment floors can opt in behind `if #available`.