### PR TITLE
feat(example): register basechatdemo URL scheme + attachments envelope

### DIFF
--- a/Example/BaseChatDemo.xcodeproj/project.pbxproj
+++ b/Example/BaseChatDemo.xcodeproj/project.pbxproj
@@ -39,6 +39,10 @@
 		BF0019000000000000000000 /* DemoScenarioCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10017000000000000000000 /* DemoScenarioCard.swift */; };
 		BF0021000000000000000000 /* ConnectedServicesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10018000000000000000000 /* ConnectedServicesView.swift */; };
 		BF0022000000000000000000 /* DemoMCPCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10019000000000000000000 /* DemoMCPCoordinator.swift */; };
+		BF0023000000000000000000 /* InboundPayloadEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10020000000000000000000 /* InboundPayloadEnvelope.swift */; };
+		BF1010000000000000000000 /* InboundPayloadEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10020000000000000000000 /* InboundPayloadEnvelope.swift */; };
+		BF1011000000000000000000 /* InboundPayloadEnvelopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11011000000000000000000 /* InboundPayloadEnvelopeTests.swift */; };
+		BF1012000000000000000000 /* BaseChatInference in Frameworks */ = {isa = PBXBuildFile; productRef = F30007000000000000000000 /* BaseChatInference */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -80,7 +84,9 @@
 		F10016000000000000000000 /* DemoScenarioRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scenarios/DemoScenarioRunner.swift; sourceTree = "<group>"; };
 		F10017000000000000000000 /* DemoScenarioCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scenarios/DemoScenarioCard.swift; sourceTree = "<group>"; };
 		F10018000000000000000000 /* ConnectedServicesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedServicesView.swift; sourceTree = "<group>"; };
-		F10019000000000000000000 /* DemoMCPCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoMCPCoordinator.swift; sourceTree = "<group>"; };
+		F10019000000000000000000 /* DemoMCPCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCP/DemoMCPCoordinator.swift; sourceTree = "<group>"; };
+		F10020000000000000000000 /* InboundPayloadEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Intents/InboundPayloadEnvelope.swift; sourceTree = "<group>"; };
+		F11011000000000000000000 /* InboundPayloadEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboundPayloadEnvelopeTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -101,6 +107,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BF1012000000000000000000 /* BaseChatInference in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -138,6 +145,7 @@
 				F10017000000000000000000 /* DemoScenarioCard.swift */,
 				F10018000000000000000000 /* ConnectedServicesView.swift */,
 				F10019000000000000000000 /* DemoMCPCoordinator.swift */,
+				F10020000000000000000000 /* InboundPayloadEnvelope.swift */,
 			);
 			path = BaseChatDemo;
 			sourceTree = "<group>";
@@ -170,6 +178,7 @@
 				F11008000000000000000000 /* ToolApprovalUITests.swift */,
 				F11009000000000000000000 /* AppIntentUITests.swift */,
 				F11010000000000000000000 /* DemoScenarioUITests.swift */,
+				F11011000000000000000000 /* InboundPayloadEnvelopeTests.swift */,
 			);
 			path = BaseChatDemoUITests;
 			sourceTree = "<group>";
@@ -214,6 +223,9 @@
 				D21001000000000000000000 /* PBXTargetDependency */,
 			);
 			name = BaseChatDemoUITests;
+			packageProductDependencies = (
+				F30007000000000000000000 /* BaseChatInference */,
+			);
 			productName = BaseChatDemoUITests;
 			productReference = F11002000000000000000000 /* BaseChatDemoUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
@@ -272,6 +284,7 @@
 				BF0019000000000000000000 /* DemoScenarioCard.swift in Sources */,
 				BF0021000000000000000000 /* ConnectedServicesView.swift in Sources */,
 				BF0022000000000000000000 /* DemoMCPCoordinator.swift in Sources */,
+				BF0023000000000000000000 /* InboundPayloadEnvelope.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -288,6 +301,8 @@
 				BF1007000000000000000000 /* ToolApprovalUITests.swift in Sources */,
 				BF1008000000000000000000 /* AppIntentUITests.swift in Sources */,
 				BF1009000000000000000000 /* DemoScenarioUITests.swift in Sources */,
+				BF1010000000000000000000 /* InboundPayloadEnvelope.swift in Sources */,
+				BF1011000000000000000000 /* InboundPayloadEnvelopeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -429,6 +444,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = BaseChatDemo/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -463,6 +479,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = BaseChatDemo/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -597,6 +614,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F20001000000000000000000 /* XCLocalSwiftPackageReference ".." */;
 			productName = BaseChatUIModelManagement;
+		};
+		F30007000000000000000000 /* BaseChatInference */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F20001000000000000000000 /* XCLocalSwiftPackageReference ".." */;
+			productName = BaseChatInference;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Example/BaseChatDemo.xcodeproj/project.pbxproj
+++ b/Example/BaseChatDemo.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		F10019000000000000000000 /* DemoMCPCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCP/DemoMCPCoordinator.swift; sourceTree = "<group>"; };
 		F10020000000000000000000 /* InboundPayloadEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Intents/InboundPayloadEnvelope.swift; sourceTree = "<group>"; };
 		F11011000000000000000000 /* InboundPayloadEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboundPayloadEnvelopeTests.swift; sourceTree = "<group>"; };
+		F10021000000000000000000 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -137,6 +138,7 @@
 				F10009000000000000000000 /* AskBaseChatDemoIntent.swift */,
 				F10010000000000000000000 /* BaseChatDemoShortcuts.swift */,
 				F10011000000000000000000 /* BaseChatDemo.entitlements */,
+				F10021000000000000000000 /* Info.plist */,
 				F10012000000000000000000 /* WriteFileTool.swift */,
 				F10013000000000000000000 /* DemoScenario.swift */,
 				F10014000000000000000000 /* DemoScenarios.swift */,

--- a/Example/BaseChatDemo/BaseChatDemoApp.swift
+++ b/Example/BaseChatDemo/BaseChatDemoApp.swift
@@ -270,6 +270,7 @@ struct BaseChatDemoApp: App {
 
         let payload = InboundPayload(
             prompt: envelope.prompt,
+            attachments: envelope.attachments,
             source: decodeSource(envelope.source)
         )
 

--- a/Example/BaseChatDemo/Info.plist
+++ b/Example/BaseChatDemo/Info.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>com.basechatkit.demo.deeplink</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>basechatdemo</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Example/BaseChatDemo/Intents/AskBaseChatDemoIntent.swift
+++ b/Example/BaseChatDemo/Intents/AskBaseChatDemoIntent.swift
@@ -1,5 +1,6 @@
 import AppIntents
 import Foundation
+import BaseChatInference
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -48,17 +49,23 @@ public struct AskBaseChatDemoIntent: AppIntent {
     @MainActor
     public func perform() async throws -> some IntentResult {
         // Serialize to App Group storage so the main app can retrieve the
-        // payload after the scheme-deep-link hits. We encode a minimal
-        // envelope rather than the full `InboundPayload` struct because
-        // `InboundPayload` is not `Codable` — attachments carry
-        // `MessagePart` values that already have their own
-        // persistence-oriented codable story we don't need here.
+        // payload after the scheme-deep-link hits. The envelope carries
+        // both the prompt and the attachments array so that future
+        // intents (or Share / Action Extensions on #440 / #441) can
+        // propagate `MessagePart` payloads (images, files, tool results)
+        // end-to-end on the same code path. `MessagePart` is `Codable`,
+        // so we round-trip attachments verbatim rather than introducing
+        // a wire-format-specific shape.
         //
-        // TODO(#440, #441): Share / Action Extensions need attachments.
-        // When those land, extend `InboundPayloadEnvelope` with an
-        // `attachments: [MessagePart]` field (or an envelope-specific
-        // codable shape) so images and files ride alongside the prompt.
-        let envelope = InboundPayloadEnvelope(prompt: prompt, source: "appIntent")
+        // The `prompt`-only intent shipped here keeps `attachments`
+        // empty; the envelope contract is in place so a follow-up
+        // surface that produces attachments doesn't need a second
+        // App Group key.
+        let envelope = InboundPayloadEnvelope(
+            prompt: prompt,
+            attachments: [],
+            source: "appIntent"
+        )
         if let defaults = UserDefaults(suiteName: DemoAppGroup.identifier) {
             if let encoded = try? JSONEncoder().encode(envelope) {
                 defaults.set(encoded, forKey: DemoAppGroup.inboundKey)
@@ -69,20 +76,13 @@ public struct AskBaseChatDemoIntent: AppIntent {
         // is responsible for actually draining the App Group defaults —
         // this intent only signals that a payload is waiting.
         //
-        // NOTE: The `basechatdemo` scheme is **not** registered in the
-        // demo's auto-generated Info.plist. In production the
-        // `open(URL)` call below silently fails and the app never
-        // receives `.onOpenURL`. The intent still opens the app via
-        // `openAppWhenRun = true`, but without the URL delivery the
-        // payload sits unread in App Group defaults.
-        //
-        // UI-test runs bypass this gap by seeding the pending buffer
-        // with `--uitesting-ingest-prompt` launch args (see
-        // `BaseChatDemoApp.uiTestingSeededPayload()`). Hosts wanting
-        // real AppIntent delivery must add `CFBundleURLTypes` to the
-        // app's Info.plist (requires dropping `GENERATE_INFOPLIST_FILE`
-        // or overriding via build settings that support structured
-        // plist values).
+        // The `basechatdemo` scheme is registered in the demo's
+        // `Info.plist` via the `CFBundleURLTypes` key, merged into the
+        // auto-generated plist. The merge is driven by setting both
+        // `GENERATE_INFOPLIST_FILE = YES` and `INFOPLIST_FILE =
+        // BaseChatDemo/Info.plist` in the target's build settings —
+        // Xcode unions the two so scene-manifest auto-generation keeps
+        // working alongside the explicit URL types.
         let url = URL(string: "basechatdemo://ingest")!
         #if canImport(UIKit)
         await UIApplication.shared.open(url, options: [:])
@@ -94,23 +94,7 @@ public struct AskBaseChatDemoIntent: AppIntent {
     }
 }
 
-/// JSON envelope written to App Group defaults.
-///
-/// Defined alongside the intent so both the write (here) and the read
-/// (in `BaseChatDemoApp.onOpenURL`) share one shape. Codable rather than
-/// piggybacking on `InboundPayload` because the struct carries
-/// non-Codable attachments — we keep this envelope text-only today and
-/// can add an `attachments: [MessagePart]` field later when a richer
-/// source starts using it.
-struct InboundPayloadEnvelope: Codable, Sendable {
-    var prompt: String
-    var source: String
-}
-
-/// App Group identifier shared between the intent (writer) and the
-/// app's `.onOpenURL` handler (reader). Centralised so renaming stays
-/// in one place.
-enum DemoAppGroup {
-    static let identifier = "group.com.basechatkit.demo"
-    static let inboundKey = "bck.inbound"
-}
+// `InboundPayloadEnvelope` and `DemoAppGroup` live in
+// `InboundPayloadEnvelope.swift` so the UITest target can compile the
+// envelope's wire-format contract test without pulling the rest of
+// this file (which depends on `AppIntents`/`UIKit`/`AppKit`).

--- a/Example/BaseChatDemo/Intents/InboundPayloadEnvelope.swift
+++ b/Example/BaseChatDemo/Intents/InboundPayloadEnvelope.swift
@@ -1,0 +1,46 @@
+import Foundation
+import BaseChatInference
+
+/// JSON envelope written to App Group defaults by the intent (writer)
+/// and read back by ``BaseChatDemoApp/handleOpenURL(_:)`` (reader).
+///
+/// Carries the prompt and the ``MessagePart`` attachments verbatim —
+/// `MessagePart` is itself `Codable`, so the envelope round-trips
+/// images, tool calls, and tool results without bespoke serialisation.
+/// Future inbound surfaces (Share / Action Extensions on #440 / #441)
+/// can populate ``attachments`` and have them ferry through to
+/// ``ChatViewModel/ingest(_:)`` end-to-end.
+///
+/// The ``attachments`` field decodes with a default-empty fallback so
+/// envelopes written before the field existed still decode without
+/// migration.
+struct InboundPayloadEnvelope: Codable, Sendable {
+    var prompt: String
+    var attachments: [MessagePart]
+    var source: String
+
+    init(prompt: String, attachments: [MessagePart] = [], source: String) {
+        self.prompt = prompt
+        self.attachments = attachments
+        self.source = source
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case prompt, attachments, source
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.prompt = try container.decode(String.self, forKey: .prompt)
+        self.attachments = try container.decodeIfPresent([MessagePart].self, forKey: .attachments) ?? []
+        self.source = try container.decode(String.self, forKey: .source)
+    }
+}
+
+/// App Group identifier shared between the intent (writer) and the
+/// app's `.onOpenURL` handler (reader). Centralised so renaming stays
+/// in one place.
+enum DemoAppGroup {
+    static let identifier = "group.com.basechatkit.demo"
+    static let inboundKey = "bck.inbound"
+}

--- a/Example/BaseChatDemo/MCP/DemoMCPCoordinator.swift
+++ b/Example/BaseChatDemo/MCP/DemoMCPCoordinator.swift
@@ -1,3 +1,4 @@
+import Foundation
 import BaseChatInference
 
 #if canImport(BaseChatMCP)

--- a/Example/BaseChatDemoUITests/InboundPayloadEnvelopeTests.swift
+++ b/Example/BaseChatDemoUITests/InboundPayloadEnvelopeTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+import BaseChatInference
+
+/// Unit-level coverage for the App Group envelope written by
+/// ``AskBaseChatDemoIntent`` and read back by ``BaseChatDemoApp``.
+///
+/// The envelope file (`InboundPayloadEnvelope.swift`) is compiled into
+/// both the demo app target and this UITests bundle so the wire-format
+/// contract — prompt + attachments + source — can be exercised without
+/// driving Shortcuts or launching the demo. The contract matters
+/// because `MessagePart` attachments must survive the JSON round trip
+/// or attachments dropped by the writer would silently disappear from
+/// the user message that ``ChatViewModel/ingest(_:)`` seeds.
+final class InboundPayloadEnvelopeTests: XCTestCase {
+
+    func test_envelope_roundTripsPromptAndSource() throws {
+        let envelope = InboundPayloadEnvelope(
+            prompt: "summarize this article",
+            attachments: [],
+            source: "appIntent"
+        )
+
+        let data = try JSONEncoder().encode(envelope)
+        let decoded = try JSONDecoder().decode(InboundPayloadEnvelope.self, from: data)
+
+        XCTAssertEqual(decoded.prompt, "summarize this article")
+        XCTAssertEqual(decoded.source, "appIntent")
+        XCTAssertTrue(decoded.attachments.isEmpty)
+    }
+
+    func test_envelope_roundTripsAttachmentsEndToEnd() throws {
+        // Cover all `MessagePart` cases that an Action / Share Extension
+        // could plausibly hand off: text alongside the prompt, an inline
+        // image, and a reasoning block. If any case fails to round-trip
+        // through the App Group envelope, attachments dropped silently
+        // by the writer would surface here.
+        let attachments: [MessagePart] = [
+            .text("relevant context"),
+            .image(data: Data([0x89, 0x50, 0x4E, 0x47]), mimeType: "image/png"),
+            .thinking("model reasoning carried verbatim", signature: "sig-abc"),
+        ]
+        let envelope = InboundPayloadEnvelope(
+            prompt: "act on the attached payload",
+            attachments: attachments,
+            source: "shareExtension"
+        )
+
+        let data = try JSONEncoder().encode(envelope)
+        let decoded = try JSONDecoder().decode(InboundPayloadEnvelope.self, from: data)
+
+        XCTAssertEqual(decoded.prompt, "act on the attached payload")
+        XCTAssertEqual(decoded.source, "shareExtension")
+        XCTAssertEqual(decoded.attachments, attachments)
+    }
+
+    func test_envelope_decodesLegacyShapeWithoutAttachmentsField() throws {
+        // PR #666 shipped an envelope with only `prompt` + `source` — any
+        // payload sitting in App Group defaults from a previous build
+        // must continue to decode rather than panicking on a missing key.
+        let legacyJSON = #"{"prompt":"hello","source":"appIntent"}"#.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(InboundPayloadEnvelope.self, from: legacyJSON)
+
+        XCTAssertEqual(decoded.prompt, "hello")
+        XCTAssertEqual(decoded.source, "appIntent")
+        XCTAssertTrue(decoded.attachments.isEmpty)
+    }
+
+    func test_envelope_emitsAttachmentsKeyWhenNonEmpty() throws {
+        // Pin the wire format: a non-empty `attachments` array must
+        // serialise under the literal key `"attachments"` so the reader
+        // in `BaseChatDemoApp.handleOpenURL(_:)` (and any future
+        // out-of-process consumer) can find it.
+        let envelope = InboundPayloadEnvelope(
+            prompt: "p",
+            attachments: [.text("a")],
+            source: "appIntent"
+        )
+
+        let data = try JSONEncoder().encode(envelope)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+
+        XCTAssertNotNil(object?["attachments"])
+        XCTAssertEqual((object?["attachments"] as? [Any])?.count, 1)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #676.

PR #666 shipped the `AskBaseChatDemoIntent` AppIntent, but the `basechatdemo://ingest` URL scheme it opens was never registered in the demo app's Info.plist. Production Shortcuts / Siri / Spotlight invocations silently dropped the deep-link delivery — only `AppIntentUITests` worked, and that bypasses the AppIntent infrastructure entirely via `--uitesting-ingest-prompt`. The same PR also dropped `InboundPayload.attachments` before they reached `.onOpenURL`, so any future surface that produced `MessagePart` payloads (Share / Action Extensions on #440 / #441) would have lost them at the App Group boundary.

This change folds both fixes into one PR.

### URL scheme registration

I went with **Option 2** (issue's terminology): a partial `Example/BaseChatDemo/Info.plist` declaring `CFBundleURLTypes`, wired in via the `INFOPLIST_FILE` build setting while keeping `GENERATE_INFOPLIST_FILE = YES`. Xcode unions the two so scene-manifest auto-generation continues alongside the explicit URL types.

Why not Option 1 — Xcode only recognises a fixed list of `INFOPLIST_KEY_*` settings (string/bool keys); `CFBundleURLTypes` is a structured array of dicts and is not on that list, so `INFOPLIST_KEY_CFBundleURLTypes` does not exist as a recognised injection point.

Why this works where #666's worker reverted — judging from the issue notes, the prior attempt likely disabled `GENERATE_INFOPLIST_FILE` and supplied a fully manual plist. That breaks SwiftUI scene-manifest auto-generation and other defaults. The merge-mode (both settings on, partial plist) gives you both. I verified the merge actually happens by reading the built `Info.plist` out of the bundle on each platform (see Verification below).

### Attachments envelope

Extracted `InboundPayloadEnvelope` and `DemoAppGroup` into their own file (`Intents/InboundPayloadEnvelope.swift`) — the envelope file is compiled into both the demo app target AND the UITest bundle so the round-trip contract can be unit-tested without driving Shortcuts.

The envelope now carries `attachments: [MessagePart]`. `MessagePart` is already `Codable`, so the round trip preserves images, tool calls, and tool results verbatim. The decoder treats the field as optional so envelopes written before this change still decode — important for any payload sitting in App Group defaults from a previous build.

`BaseChatDemoApp.handleOpenURL` now passes `envelope.attachments` through to the constructed `InboundPayload`, closing the writer-to-reader gap end-to-end.

### Drive-by fixes (required to validate this PR)

`main` was already broken on the demo Xcode build before this branch — these had to come along to verify anything:

- `Example/BaseChatDemo/MCP/DemoMCPCoordinator.swift` was missing `import Foundation`, failing on `UUID` references.
- The pbxproj entry for the same file pointed at a flat path (`DemoMCPCoordinator.swift`) instead of `MCP/DemoMCPCoordinator.swift`, so the build couldn't even find the input.

Both regressions trace to the file move in commit `0bf189a` (PR #790).

## Verification

### Builds
- `xcodebuild build -destination 'platform=macOS'` — `** BUILD SUCCEEDED **`
- `xcodebuild build -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'` — `** BUILD SUCCEEDED **`

### macOS scene / Info.plist sanity
Read the built `Info.plist` out of the macOS `.app` bundle:

- `CFBundleURLTypes` present, contains `basechatdemo` under `CFBundleURLSchemes`.
- `UIApplicationSceneManifest` still present (`UIApplicationSupportsMultipleScenes = true`, empty `UISceneConfigurations` — the SwiftUI `App` protocol path).
- `LSMinimumSystemVersion = 15.0`, `UILaunchScreen`, orientations — all auto-generated keys preserved.

`lsregister -dump | grep -A3 basechatdemo:` confirms macOS Launch Services has registered `BaseChatDemo.app` as the `basechatdemo:` handler with `roles: Viewer`. Production AppIntent invocations now actually open the app.

### Tests
- `BaseChatDemoUITests/InboundPayloadEnvelopeTests` — 4 tests pass:
  - `test_envelope_roundTripsPromptAndSource`
  - `test_envelope_roundTripsAttachmentsEndToEnd`
  - `test_envelope_decodesLegacyShapeWithoutAttachmentsField`
  - `test_envelope_emitsAttachmentsKeyWhenNonEmpty`
- Sabotage-verified the round-trip test by replacing `decodeIfPresent` with `[]` and confirming `test_envelope_roundTripsAttachmentsEndToEnd` failed; restored.
- `BaseChatDemoUITests/AppIntentUITests` — still passes (cold-launch handoff unchanged).

### Pre-push CI suite (all green)
- `BaseChatCoreTests` — 236 tests
- `BaseChatInferenceTests` — 1166 tests
- `BaseChatInferenceSwiftTestingTests` — 69 tests
- `BaseChatUITests` — 437 tests
- `BaseChatUIModelManagementTests` — 94 tests
- `BaseChatMCPTests` — 88+ tests
- `BaseChatBackendsTests` — 98 tests
- `BaseChatTestSupportTests` — 13 tests

## Test plan

- [x] Demo builds on macOS (`xcodebuild ... -destination 'platform=macOS'`)
- [x] Demo builds on iOS Simulator
- [x] Built macOS Info.plist contains both `CFBundleURLTypes` and `UIApplicationSceneManifest`
- [x] Built iOS Info.plist contains both `CFBundleURLTypes` and `UIApplicationSceneManifest`
- [x] `lsregister` confirms macOS scheme registration
- [x] `InboundPayloadEnvelopeTests` — 4 passes, sabotage-verified
- [x] `AppIntentUITests` — no regression
- [x] Full pre-push CI suite passes locally

## Release Note

The demo app now registers `basechatdemo://` in its Info.plist via a build-time merge that preserves SwiftUI scene-manifest auto-generation on iOS and macOS, so AppIntent invocations from Shortcuts / Siri / Spotlight reach `.onOpenURL` in production rather than dying silently at the URL-scheme dispatch. The App Group envelope now ferries `InboundPayload.attachments` end-to-end, so future inbound surfaces (Share / Action Extensions on #440 / #441) can propagate `MessagePart` payloads — images, tool calls, tool results — without losing them at the writer/reader boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)