### PR TITLE
docs(claude-md): correct stale E2E test commands and wire AppIntents into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
       # carve-out, which negates most of the speedup anyway.
       - name: Test — XCTest suites (Core + UI + UIModelManagement + MCP + Backends + Inference + TestSupport)
         timeout-minutes: 25
-        run: scripts/test.sh --filter BaseChatCoreTests --filter BaseChatUITests --filter BaseChatUIModelManagementTests --filter BaseChatMCPTests --filter BaseChatBackendsTests --filter BaseChatInferenceTests --filter BaseChatTestSupportTests --disable-default-traits --skip-update
+        run: scripts/test.sh --filter BaseChatCoreTests --filter BaseChatUITests --filter BaseChatUIModelManagementTests --filter BaseChatMCPTests --filter BaseChatBackendsTests --filter BaseChatInferenceTests --filter BaseChatTestSupportTests --filter BaseChatAppIntentsTests --disable-default-traits --skip-update
 
       - name: Test — Inference (Swift Testing, isolated process)
         timeout-minutes: 25

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,18 +27,23 @@ swift test --filter BaseChatUIModelManagementTests --disable-default-traits
 swift test --filter BaseChatMCPTests --disable-default-traits
 swift test --filter BaseChatBackendsTests --disable-default-traits
 swift test --filter BaseChatTestSupportTests --disable-default-traits
+swift test --filter BaseChatAppIntentsTests --disable-default-traits
 
 # Apple Silicon only — MLX mock tests + llama.cpp
 swift test --filter BaseChatBackendsTests --traits MLX,Llama
 
-# Additional headless E2E coverage (mock backends; no special hardware)
-swift test --filter BaseChatE2ETests --disable-default-traits
+# Additional headless E2E coverage (mock backends; no special hardware).
+# The trailing `\.` anchor is required — bare `BaseChatE2ETests` matches no class names.
+swift test --filter "BaseChatE2ETests\." --disable-default-traits
 
 # MCP built-in catalog descriptors (trait-gated)
 swift test --filter BaseChatMCPTests --disable-default-traits --traits MCPBuiltinCatalog
 
-# MCP E2E — requires npx installed and network access
-RUN_MCP_E2E=1 swift test --filter BaseChatMCPE2ETests --disable-default-traits
+# MCP E2E — requires npx installed and network access.
+# The streamable-HTTP smoke is fast and stable; the everything-server smoke
+# (`EverythingServerSmokeTests`) has hung for 28+ minutes on `mcp-server-everything`
+# in past runs — filter to the streamable suite to avoid that path.
+RUN_MCP_E2E=1 swift test --filter BaseChatMCPE2ESmokeTests --disable-default-traits
 
 # Xcode-only — real MLX model inference (metallib required)
 # Cannot run via swift test; MLX Metal shaders are only compiled by Xcode.
@@ -48,8 +53,10 @@ xcodebuild test -scheme BaseChatKit-Package -only-testing BaseChatMLXIntegration
 scripts/example-ui-tests.sh build-for-testing
 scripts/example-ui-tests.sh test-without-building -only-testing:BaseChatDemoUITests/ChatFlowUITests/testEmptyStateShowsWelcome
 
-# Real Ollama server E2E (requires Ollama running at localhost:11434)
-swift test --filter OllamaE2ETests --disable-default-traits
+# Real Ollama server E2E (requires Ollama running at localhost:11434).
+# `--traits Ollama` is required — Ollama was dropped from default traits in v2.0,
+# so the bare `--disable-default-traits` invocation runs zero tests.
+swift test --filter OllamaE2ETests --disable-default-traits --traits Ollama
 
 # Fuzz harness — requires Ollama running at localhost:11434
 # The Fuzz trait gates real inference backends; without it, fuzz-chat builds mock-only.
@@ -123,7 +130,7 @@ When Apple ships a new major OS each September, bump both minimums by one and re
 Before pushing any branch, run all CI-safe test suites locally and confirm zero failures:
 
 ```bash
-swift test --filter BaseChatCoreTests --disable-default-traits && swift test --filter BaseChatInferenceTests --disable-default-traits && swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits && swift test --filter BaseChatUITests --disable-default-traits && swift test --filter BaseChatUIModelManagementTests --disable-default-traits && swift test --filter BaseChatMCPTests --disable-default-traits && swift test --filter BaseChatBackendsTests --disable-default-traits && swift test --filter BaseChatTestSupportTests --disable-default-traits
+swift test --filter BaseChatCoreTests --disable-default-traits && swift test --filter BaseChatInferenceTests --disable-default-traits && swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits && swift test --filter BaseChatUITests --disable-default-traits && swift test --filter BaseChatUIModelManagementTests --disable-default-traits && swift test --filter BaseChatMCPTests --disable-default-traits && swift test --filter BaseChatBackendsTests --disable-default-traits && swift test --filter BaseChatTestSupportTests --disable-default-traits && swift test --filter BaseChatAppIntentsTests --disable-default-traits
 ```
 
 Never push based on a subset passing. After rebasing, always re-run the full suite before pushing — conflicts can silently break tests that compiled fine before.
@@ -222,7 +229,7 @@ All changes go through PRs — direct pushes to `main` are blocked for everyone.
 4. Report the PR URL — the maintainer reviews and merges manually
 5. Do NOT pass `--auto` or `--merge` — merges require human approval
 
-CI must pass (`BaseChatCoreTests` + `BaseChatInferenceTests` + `BaseChatInferenceSwiftTestingTests` + `BaseChatUITests` + `BaseChatUIModelManagementTests` + `BaseChatMCPTests` + `BaseChatBackendsTests` + `BaseChatTestSupportTests`) before merge is allowed.
+CI must pass (`BaseChatCoreTests` + `BaseChatInferenceTests` + `BaseChatInferenceSwiftTestingTests` + `BaseChatUITests` + `BaseChatUIModelManagementTests` + `BaseChatMCPTests` + `BaseChatBackendsTests` + `BaseChatTestSupportTests` + `BaseChatAppIntentsTests`) before merge is allowed.
 
 `BaseChatBackendsTests` runs in CI without hardware traits — only cloud backend and SSE tests execute; MLX and Llama tests are excluded by `#if MLX`/`#if Llama` conditional compilation. Run with `--traits MLX,Llama` locally on Apple Silicon before merging backend changes. `BaseChatE2ETests` requires physical hardware and does not run in CI.
 


### PR DESCRIPTION
## Summary

Three of CLAUDE.md's documented E2E test commands silently broke after the v2.0 trait peel, and `BaseChatAppIntentsTests` (shipped in #798) was never added to the CI test run. This PR fixes both.

### Stale E2E commands

| Command | Why it was wrong | Fix |
|---|---|---|
| `swift test --filter BaseChatE2ETests --disable-default-traits` | Bare module name doesn't match any test class — runs zero tests | Anchor the filter with `\.` so it matches `BaseChatE2ETests.<Class>/<method>` |
| `swift test --filter OllamaE2ETests --disable-default-traits` | v2.0 dropped Ollama from default traits (#796), so the `--disable-default-traits` flavour leaves Ollama off and runs zero tests | Add `--traits Ollama` |
| `RUN_MCP_E2E=1 swift test --filter BaseChatMCPE2ETests --disable-default-traits` | Includes `EverythingServerSmokeTests` which spawns `mcp-server-everything` via npx and has hung indefinitely (28+ min) in practice | Filter to `BaseChatMCPE2ESmokeTests` (streamable HTTP smoke), with a comment explaining the gotcha |

I burned ~30 minutes today on the Ollama-trait one before working it out — including a hung swift-test process that needed SIGINT to clean up. The corrected commands are validated end-to-end against `main`: 51 mock-backend E2E tests + 10 Ollama E2E tests + 1 MCP smoke all green.

### AppIntents missing from CI

PR #798 added the `BaseChatAppIntentsTests` target but didn't wire it into:

- `scripts/test.sh` invocation in `.github/workflows/ci.yml`
- the per-suite list, pre-push checklist, and "CI must pass" gate documented in `CLAUDE.md`

So post-merge regressions in `BaseChatAppIntents` would not block PRs. This PR closes the gap.

## Test plan

- [x] Local pre-push run with the new pre-push command (now 9 suites incl. AppIntents) — 2228 tests, 0 failures
- [x] `swift test --filter "BaseChatE2ETests\." --disable-default-traits` — 51 tests pass
- [x] `swift test --filter OllamaE2ETests --disable-default-traits --traits Ollama` against live Ollama — 10 tests pass
- [x] `RUN_MCP_E2E=1 swift test --filter BaseChatMCPE2ESmokeTests --disable-default-traits` — 1 test pass
- [ ] CI on this PR validates the ci.yml change end-to-end

## Out of scope (flagged for follow-up)

The Llama/MLX test files in `Tests/BaseChatBackendsTests/` and `Tests/BaseChatE2ETests/` resolve their model directory by hand-rolling `FileManager.urls(for: .documentDirectory).appendingPathComponent("Models")` instead of going through `ModelStorageService().modelsDirectory` which respects `BaseChatConfiguration.shared.modelsDirectoryName`. If a user configures a non-default models directory name, those tests will silently miss it. Worth a small cleanup PR; not folded in here to keep this one strictly docs/CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)