### PR TITLE
perf(ci): move slow audit + perf baselines to nightly tier

### DIFF
--- a/.github/workflows/nightly-slow-tests.yml
+++ b/.github/workflows/nightly-slow-tests.yml
@@ -13,6 +13,13 @@ on:
     - cron: "30 4 * * *"
   workflow_dispatch:
 
+# A `workflow_dispatch` triggered while a scheduled run is still in flight
+# would race on the SwiftPM cache key and double-bill the macos-15 runner.
+# Cancel the in-flight run so only one is ever active.
+concurrency:
+  group: nightly-slow-tests
+  cancel-in-progress: true
+
 jobs:
   slow:
     runs-on: macos-15
@@ -46,3 +53,24 @@ jobs:
 
       - name: Test — TrafficBoundaryAuditTest
         run: scripts/test.sh --filter "BaseChatInferenceTests.TrafficBoundaryAuditTest" --disable-default-traits --skip-update
+
+      - name: Stage test diagnostics
+        # Mirrors ci.yml: scripts/test.sh writes captured stdout/stderr to
+        # $TMPDIR/test_output.txt, but $TMPDIR on macOS runners is a per-process
+        # /var/folders path that actions/upload-artifact cannot reliably address.
+        # Copy into the workspace so the upload step can find it.
+        if: failure()
+        run: |
+          mkdir -p test-diagnostics
+          if [ -n "${TMPDIR:-}" ] && [ -f "${TMPDIR}/test_output.txt" ]; then
+            cp "${TMPDIR}/test_output.txt" test-diagnostics/test_output.txt
+          fi
+
+      - name: Upload test diagnostics on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-slow-tests-diagnostics-${{ github.run_id }}
+          if-no-files-found: ignore
+          retention-days: 7
+          path: test-diagnostics/

--- a/.github/workflows/nightly-slow-tests.yml
+++ b/.github/workflows/nightly-slow-tests.yml
@@ -1,0 +1,48 @@
+name: Nightly slow tests
+
+# Runs the expensive tests excluded from per-PR CI:
+#  - LargeSessionListPerformanceTests — XCTMeasure perf baselines (~65s)
+#  - TrafficBoundaryAuditTest — source-tree boundary audit (~50s)
+# These are gated by RUN_SLOW_TESTS=1 in their setUp; the main `ci.yml`
+# job leaves that unset so they skip there. Local `swift test` runs them
+# unconditionally (CI is also unset locally).
+
+on:
+  schedule:
+    # 04:30 UTC daily — quiet window, before fuzz-nightly at 05:00 UTC.
+    - cron: "30 4 * * *"
+  workflow_dispatch:
+
+jobs:
+  slow:
+    runs-on: macos-15
+    timeout-minutes: 30
+    env:
+      RUN_SLOW_TESTS: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.3"
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v5
+        with:
+          path: |
+            .build/artifacts
+            .build/checkouts
+            .build/repositories
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
+            ${{ runner.os }}-${{ runner.arch }}-spm-
+
+      - name: Test — LargeSessionListPerformanceTests
+        run: scripts/test.sh --filter "BaseChatUITests.LargeSessionListPerformanceTests" --disable-default-traits --skip-update
+
+      - name: Test — TrafficBoundaryAuditTest
+        run: scripts/test.sh --filter "BaseChatInferenceTests.TrafficBoundaryAuditTest" --disable-default-traits --skip-update

--- a/Tests/BaseChatInferenceTests/TrafficBoundaryAuditTest.swift
+++ b/Tests/BaseChatInferenceTests/TrafficBoundaryAuditTest.swift
@@ -66,6 +66,16 @@ import XCTest
 /// of where `swift test` is invoked.
 final class TrafficBoundaryAuditTest: XCTestCase {
 
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // Source-tree walk + regex audit (~50s combined). Skipped in main CI to
+        // keep PR feedback fast; nightly job sets RUN_SLOW_TESTS=1. Always runs
+        // locally so contributors get the boundary-rule signal pre-push.
+        let env = ProcessInfo.processInfo.environment
+        try XCTSkipIf(env["CI"] == "true" && env["RUN_SLOW_TESTS"] != "1",
+                      "Source-tree audit — runs in nightly CI only. Set RUN_SLOW_TESTS=1 to force.")
+    }
+
     // MARK: - Allowlists
 
     /// Files where direct `URLSession`/`URLRequest`/`URLSessionConfiguration`

--- a/Tests/BaseChatUITests/LargeSessionListPerformanceTests.swift
+++ b/Tests/BaseChatUITests/LargeSessionListPerformanceTests.swift
@@ -25,6 +25,11 @@ final class LargeSessionListPerformanceTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
+        // Slow XCTMeasure baselines (~65s combined). Skipped in main CI to keep
+        // PR feedback fast; nightly job sets RUN_SLOW_TESTS=1. Always runs locally.
+        let env = ProcessInfo.processInfo.environment
+        try XCTSkipIf(env["CI"] == "true" && env["RUN_SLOW_TESTS"] != "1",
+                      "Slow perf baseline — runs in nightly CI only. Set RUN_SLOW_TESTS=1 to force.")
         container = try makeInMemoryContainer()
         context = container.mainContext
         persistence = SwiftDataPersistenceProvider(modelContext: context)


### PR DESCRIPTION
## Summary

PR-tier CI is dominated by 6 tests that don't gate behavioural correctness on a typical PR:

- `TrafficBoundaryAuditTest` (3 cases, **~50s** combined) — source-tree regex audit for banned APIs / hostname literals / privacy violations.
- `LargeSessionListPerformanceTests` (3 cases, **~65s** combined) — XCTMeasure baselines on a 1000-session, 50K-message SwiftData fixture.

Together they account for **~115s of the ~150s** test-execution phase on every PR — measured against the most recent green CI run (#24958071415: 6m26s total, 5m54s in the XCTest step).

This PR gates both suites behind `CI=true && RUN_SLOW_TESTS != 1` in `setUp` and adds a new `nightly-slow-tests.yml` workflow that sets `RUN_SLOW_TESTS=1`.

### Behaviour by environment

| Environment | `CI` | `RUN_SLOW_TESTS` | Result |
|---|---|---|---|
| Local `swift test` | unset | unset | **runs** (unchanged) |
| Pre-push checklist (CLAUDE.md) | unset | unset | **runs** (unchanged) |
| Main `ci.yml` | `true` | unset | **skips** |
| `nightly-slow-tests.yml` | `true` | `1` | **runs** |

Local verification:

- `swift test --filter TrafficBoundaryAuditTest` → 14 tests, 24s
- `CI=true swift test --filter TrafficBoundaryAuditTest` → 14 skipped, 0.005s
- `CI=true RUN_SLOW_TESTS=1 swift test ...` → runs normally

### Expected impact

Total per-PR CI: **6m26s → ~4m30s (~30% reduction)**, on top of PR #671's resolve-check fold-in.

The compile phase (~2m52s) is the next bottleneck — a separate audit found `BaseChatFuzz` (71 files) compiling unconditionally despite Fuzz being a non-default trait. That's a follow-up, not this PR.

## Test plan

- [x] Local: both suites run normally (`CI` unset)
- [x] `CI=true`: both suites skip instantly
- [x] `CI=true RUN_SLOW_TESTS=1`: forced run works
- [ ] CI green on this branch (will run on push)
- [ ] Manually trigger `nightly-slow-tests.yml` via `workflow_dispatch` post-merge to confirm green

🤖 Generated with [Claude Code](https://claude.com/claude-code)