### PR TITLE
feat(openai): forward prefill_progress SSE events from compatible upstream servers

### DIFF
--- a/Sources/BaseChatBackends/OpenAIBackend.swift
+++ b/Sources/BaseChatBackends/OpenAIBackend.swift
@@ -179,6 +179,9 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         var request = URLRequest(url: completionsURL)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if config.streamPrefillProgress {
+            request.setValue("true", forHTTPHeaderField: "X-BaseChat-Prefill-Progress")
+        }
 
         if let apiKey = resolveAPIKey(), !apiKey.isEmpty {
             request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
@@ -239,6 +242,15 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         do {
             for try await payload in tokenStream {
                 if Task.isCancelled { break }
+
+                if let progress = Self.parsePrefillProgress(from: payload) {
+                    continuation.yield(.prefillProgress(
+                        nPast: progress.nPast,
+                        nTotal: progress.nTotal,
+                        tokensPerSecond: progress.tokensPerSecond
+                    ))
+                    continue
+                }
 
                 // Reasoning delta: emit as thinkingToken, keep the block open.
                 if let reasoning = Self.parseReasoningDelta(from: payload) {
@@ -530,6 +542,43 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         return (prompt, completion)
     }
 
+    struct PrefillProgress {
+        let nPast: Int
+        let nTotal: Int
+        let tokensPerSecond: Double
+    }
+
+    static func parsePrefillProgress(from json: String) -> PrefillProgress? {
+        guard let data = json.data(using: .utf8) else {
+            return nil
+        }
+        let parsed: [String: Any]
+        do {
+            guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return nil
+            }
+            parsed = object
+        } catch {
+            return nil
+        }
+        guard let nPast = parsed["n_past"] as? Int,
+              let nTotal = parsed["n_total"] as? Int else {
+            return nil
+        }
+        let tokensPerSecond: Double
+        if let value = parsed["tokens_per_second"] as? Double {
+            tokensPerSecond = value
+        } else if let value = parsed["tokens_per_second"] as? Int {
+            tokensPerSecond = Double(value)
+        } else {
+            return nil
+        }
+        return PrefillProgress(
+            nPast: nPast,
+            nTotal: nTotal,
+            tokensPerSecond: tokensPerSecond
+        )
+    }
+
 }
 #endif
-

--- a/Sources/BaseChatFuzz/EventRecorder.swift
+++ b/Sources/BaseChatFuzz/EventRecorder.swift
@@ -53,6 +53,12 @@ public struct EventRecorder: Sendable {
             for try await event in stream.events {
                 let t = start.duration(to: ContinuousClock.now).seconds
                 switch event {
+                case .prefillProgress(let nPast, let nTotal, let tokensPerSecond):
+                    events.append(.init(
+                        t: t,
+                        kind: "prefillProgress",
+                        v: "\(nPast)/\(nTotal)@\(tokensPerSecond)"
+                    ))
                 case .token(let text):
                     if firstTokenAt == nil { firstTokenAt = ContinuousClock.now }
                     raw += text

--- a/Sources/BaseChatInference/Models/GenerationEvent.swift
+++ b/Sources/BaseChatInference/Models/GenerationEvent.swift
@@ -4,6 +4,14 @@
 /// future structured output without breaking the `InferenceBackend`
 /// contract again.
 public enum GenerationEvent: Sendable, Equatable {
+    /// Progress update while the backend is evaluating prompt tokens before the
+    /// first generated content token is available.
+    ///
+    /// `nPast` is how many prompt tokens have been evaluated so far, `nTotal`
+    /// is the total prompt-token count for this request, and
+    /// `tokensPerSecond` is the backend-reported prompt-eval throughput.
+    case prefillProgress(nPast: Int, nTotal: Int, tokensPerSecond: Double)
+
     /// A fragment of generated text (typically one token).
     case token(String)
 

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -94,6 +94,14 @@ public struct GenerationConfig: Sendable, Codable {
     /// have not implemented JSON-mode wiring yet, silently ignore this flag.
     public var jsonMode: Bool
 
+    /// Opt-in for backend-specific prefill-progress streaming extensions.
+    ///
+    /// When `true`, OpenAI-compatible backends add
+    /// `X-BaseChat-Prefill-Progress: true` so compatible servers can emit
+    /// `prefill_progress` SSE updates before the first content token.
+    /// Defaults to `false` for OpenAI wire compatibility.
+    public var streamPrefillProgress: Bool
+
     /// Raw GBNF grammar string to constrain sampling.
     ///
     /// Honored by backends reporting `BackendCapabilities.supportsGrammarConstrainedSampling == true`.
@@ -148,7 +156,7 @@ public struct GenerationConfig: Sendable, Codable {
     /// - Only honoured by `MLXBackend`; other backends ignore this field.
     public var yieldEveryNTokens: Int = 8
 
-    @available(*, deprecated, message: "Use init(temperature:topP:repeatPenalty:topK:typicalP:minP:repetitionPenalty:seed:maxOutputTokens:tools:toolChoice:maxThinkingTokens:jsonMode:thinkingMarkers:maxToolIterations:grammar:yieldEveryNTokens:) instead.")
+    @available(*, deprecated, message: "Use init(temperature:topP:repeatPenalty:topK:typicalP:minP:repetitionPenalty:seed:maxOutputTokens:tools:toolChoice:maxThinkingTokens:jsonMode:streamPrefillProgress:thinkingMarkers:maxToolIterations:grammar:yieldEveryNTokens:) instead.")
     public init(
         temperature: Float = 0.7,
         topP: Float = 0.9,
@@ -164,6 +172,7 @@ public struct GenerationConfig: Sendable, Codable {
         toolChoice: ToolChoice = .auto,
         maxThinkingTokens: Int? = nil,
         jsonMode: Bool = false,
+        streamPrefillProgress: Bool = false,
         thinkingMarkers: ThinkingMarkers? = nil,
         maxToolIterations: Int = 10,
         grammar: String? = nil,
@@ -183,6 +192,7 @@ public struct GenerationConfig: Sendable, Codable {
         self.toolChoice = toolChoice
         self.maxThinkingTokens = maxThinkingTokens
         self.jsonMode = jsonMode
+        self.streamPrefillProgress = streamPrefillProgress
         self.thinkingMarkers = thinkingMarkers
         self.maxToolIterations = max(1, maxToolIterations)
         self.grammar = grammar
@@ -203,6 +213,7 @@ public struct GenerationConfig: Sendable, Codable {
         toolChoice: ToolChoice = .auto,
         maxThinkingTokens: Int? = nil,
         jsonMode: Bool = false,
+        streamPrefillProgress: Bool = false,
         thinkingMarkers: ThinkingMarkers? = nil,
         maxToolIterations: Int = 10,
         grammar: String? = nil,
@@ -221,6 +232,7 @@ public struct GenerationConfig: Sendable, Codable {
         self.toolChoice = toolChoice
         self.maxThinkingTokens = maxThinkingTokens
         self.jsonMode = jsonMode
+        self.streamPrefillProgress = streamPrefillProgress
         self.thinkingMarkers = thinkingMarkers
         self.maxToolIterations = max(1, maxToolIterations)
         self.grammar = grammar
@@ -233,6 +245,7 @@ public struct GenerationConfig: Sendable, Codable {
         case temperature, topP, repeatPenalty, maxTokens, topK, typicalP, maxOutputTokens
         case tools, toolChoice, maxThinkingTokens, jsonMode, maxToolIterations, grammar
         case yieldEveryNTokens
+        case streamPrefillProgress
         case minP, repetitionPenalty, seed
     }
 
@@ -252,6 +265,7 @@ public struct GenerationConfig: Sendable, Codable {
         toolChoice = (try c.decodeIfPresent(ToolChoice.self, forKey: .toolChoice)) ?? .auto
         maxThinkingTokens = try c.decodeIfPresent(Int.self, forKey: .maxThinkingTokens)
         jsonMode = (try c.decodeIfPresent(Bool.self, forKey: .jsonMode)) ?? false
+        streamPrefillProgress = (try c.decodeIfPresent(Bool.self, forKey: .streamPrefillProgress)) ?? false
         // maxToolIterations landed after the original shape; default to 10 when absent and
         // clamp any persisted zero/negative value to the minimum of 1.
         let decodedIterations = (try c.decodeIfPresent(Int.self, forKey: .maxToolIterations)) ?? 10
@@ -282,6 +296,7 @@ public struct GenerationConfig: Sendable, Codable {
         try c.encode(toolChoice, forKey: .toolChoice)
         try c.encodeIfPresent(maxThinkingTokens, forKey: .maxThinkingTokens)
         try c.encode(jsonMode, forKey: .jsonMode)
+        try c.encode(streamPrefillProgress, forKey: .streamPrefillProgress)
         try c.encode(maxToolIterations, forKey: .maxToolIterations)
         try c.encodeIfPresent(grammar, forKey: .grammar)
         try c.encode(yieldEveryNTokens, forKey: .yieldEveryNTokens)

--- a/Sources/BaseChatInference/Services/GenerationStreamConsumer.swift
+++ b/Sources/BaseChatInference/Services/GenerationStreamConsumer.swift
@@ -16,6 +16,9 @@ public struct GenerationStreamConsumer: Sendable {
     /// Processes a single generation event and returns the action the caller should take.
     public mutating func handle(_ event: GenerationEvent) -> StreamAction {
         switch event {
+        case .prefillProgress:
+            return .ignore
+
         case .token(let text):
             return .appendText(text)
 

--- a/Sources/BaseChatInference/Services/ToolCallLoopOrchestrator.swift
+++ b/Sources/BaseChatInference/Services/ToolCallLoopOrchestrator.swift
@@ -571,7 +571,7 @@ public struct ToolCallLoopOrchestrator: Sendable {
                     calls.append(call)
                 case .usage(let p, let c):
                     continuation.yield(.usage(prompt: p, completion: c))
-                case .thinkingToken, .thinkingComplete, .thinkingSignature,
+                case .prefillProgress, .thinkingToken, .thinkingComplete, .thinkingSignature,
                      .toolLoopLimitReached, .toolResult, .kvCacheReuse,
                      .diagnosticThrottle:
                     // Reasoning, KV-cache hints, and diagnostic events are

--- a/Sources/BaseChatTools/ScenarioRunner.swift
+++ b/Sources/BaseChatTools/ScenarioRunner.swift
@@ -84,7 +84,7 @@ public final class ScenarioRunner {
                 case .toolCall(let call):
                     turnToolCalls.append(call)
                     logger?.append(.toolCall(scenarioId: scenario.id, name: call.toolName, arguments: call.arguments))
-                case .usage, .thinkingToken, .thinkingComplete, .thinkingSignature:
+                case .prefillProgress, .usage, .thinkingToken, .thinkingComplete, .thinkingSignature:
                     continue
                 case .toolResult, .toolLoopLimitReached:
                     // ScenarioRunner calls backend.generate() directly and owns

--- a/Tests/BaseChatBackendsTests/CloudThinkingTokenTests.swift
+++ b/Tests/BaseChatBackendsTests/CloudThinkingTokenTests.swift
@@ -45,6 +45,7 @@ private func categorise(_ event: GenerationEvent) -> EventCategory? {
     case .diagnosticThrottle: return nil
     case .thinkingSignature: return nil
     case .toolCallStart, .toolCallArgumentsDelta: return nil
+    case .prefillProgress: return nil
     }
 }
 

--- a/Tests/BaseChatBackendsTests/OpenAICompatEndpointTests.swift
+++ b/Tests/BaseChatBackendsTests/OpenAICompatEndpointTests.swift
@@ -163,6 +163,52 @@ struct OpenAICompatEndpointTests {
         #expect(usage?.completionTokens == 1)
     }
 
+    @Test func compat_prefillProgress_eventsEmitAndPreserveOrdering() async throws {
+        let (backend, url) = makeCompatBackend(modelName: "test-model")
+        defer { MockURLProtocol.unstub(url: url) }
+
+        let prefill1 = Data("""
+        event: prefill_progress
+        data: {"n_past":1024,"n_total":4096,"tokens_per_second":280.0}
+
+        """.utf8)
+        let prefill2 = Data("""
+        event: prefill_progress
+        data: {"n_past":3072,"n_total":4096,"tokens_per_second":300.5}
+
+        """.utf8)
+        let prefillFinal = Data("""
+        event: prefill_progress
+        data: {"n_past":4096,"n_total":4096,"tokens_per_second":295.0}
+
+        """.utf8)
+        let token = sseData("""
+        {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1234567890,"model":"test-model","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}
+        """)
+        MockURLProtocol.stub(
+            url: url,
+            response: .sse(chunks: [prefill1, prefill2, prefillFinal, token, sseDone], statusCode: 200)
+        )
+
+        try await loadBackend(backend)
+        let stream = try backend.generate(
+            prompt: "Hello",
+            systemPrompt: nil,
+            config: GenerationConfig(streamPrefillProgress: true)
+        )
+
+        var events: [GenerationEvent] = []
+        for try await event in stream.events {
+            events.append(event)
+        }
+
+        #expect(events.count == 4)
+        #expect(events[0] == .prefillProgress(nPast: 1024, nTotal: 4096, tokensPerSecond: 280.0))
+        #expect(events[1] == .prefillProgress(nPast: 3072, nTotal: 4096, tokensPerSecond: 300.5))
+        #expect(events[2] == .prefillProgress(nPast: 4096, nTotal: 4096, tokensPerSecond: 295.0))
+        #expect(events[3] == .token("Hello"))
+    }
+
     /// Ollama versions before 0.4.0 do not support `stream_options` and silently
     /// ignore it. The final chunk has no `usage` field. OpenAIBackend should handle
     /// this gracefully (lastUsage stays nil).
@@ -319,6 +365,56 @@ struct OpenAICompatEndpointTests {
 
         // max_tokens should be present
         #expect(json["max_tokens"] != nil)
+    }
+
+    @Test func requestHeaders_prefillProgressOptIn_isOffByDefault() async throws {
+        let (backend, url) = makeCompatBackend(modelName: "test-model")
+        defer { MockURLProtocol.unstub(url: url) }
+
+        let chunks: [Data] = [
+            sseData("""
+            {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1234567890,"model":"test-model","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}
+            """),
+            sseDone,
+        ]
+
+        MockURLProtocol.stub(url: url, response: .sse(chunks: chunks, statusCode: 200))
+
+        try await loadBackend(backend)
+        let stream = try backend.generate(
+            prompt: "Hello",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+        for try await _ in stream.events { }
+
+        let captured = MockURLProtocol.capturedRequests.last(where: { $0.url == url })
+        #expect(captured?.value(forHTTPHeaderField: "X-BaseChat-Prefill-Progress") == nil)
+    }
+
+    @Test func requestHeaders_prefillProgressOptIn_setsHeader() async throws {
+        let (backend, url) = makeCompatBackend(modelName: "test-model")
+        defer { MockURLProtocol.unstub(url: url) }
+
+        let chunks: [Data] = [
+            sseData("""
+            {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1234567890,"model":"test-model","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}
+            """),
+            sseDone,
+        ]
+
+        MockURLProtocol.stub(url: url, response: .sse(chunks: chunks, statusCode: 200))
+
+        try await loadBackend(backend)
+        let stream = try backend.generate(
+            prompt: "Hello",
+            systemPrompt: nil,
+            config: GenerationConfig(streamPrefillProgress: true)
+        )
+        for try await _ in stream.events { }
+
+        let captured = MockURLProtocol.capturedRequests.last(where: { $0.url == url })
+        #expect(captured?.value(forHTTPHeaderField: "X-BaseChat-Prefill-Progress") == "true")
     }
 
     /// INCOMPATIBILITY DOCUMENTED: OpenAIBackend sends `stream_options`

--- a/Tests/BaseChatBackendsTests/OpenAICompatEndpointTests.swift
+++ b/Tests/BaseChatBackendsTests/OpenAICompatEndpointTests.swift
@@ -207,6 +207,20 @@ struct OpenAICompatEndpointTests {
         #expect(events[1] == .prefillProgress(nPast: 3072, nTotal: 4096, tokensPerSecond: 300.5))
         #expect(events[2] == .prefillProgress(nPast: 4096, nTotal: 4096, tokensPerSecond: 295.0))
         #expect(events[3] == .token("Hello"))
+
+        // Contract (issue #746): the prefill_progress event immediately preceding
+        // the first content token must satisfy nPast == nTotal. UI observers
+        // rely on this equality to flip from "evaluating prompt" to "generating".
+        let firstTokenIndex = events.firstIndex(where: { if case .token = $0 { true } else { false } })
+        let lastPrefillBeforeToken = events
+            .prefix(firstTokenIndex ?? events.count)
+            .last(where: { if case .prefillProgress = $0 { true } else { false } })
+        guard case let .prefillProgress(nPast: boundaryNPast, nTotal: boundaryNTotal, tokensPerSecond: _) = lastPrefillBeforeToken else {
+            Issue.record("Expected at least one prefill_progress event before the first content token")
+            return
+        }
+        #expect(boundaryNPast == boundaryNTotal,
+                "Final prefill_progress before generation must report nPast == nTotal")
     }
 
     /// Ollama versions before 0.4.0 do not support `stream_options` and silently

--- a/Tests/BaseChatBackendsTests/OpenAIResponsesBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/OpenAIResponsesBackendTests.swift
@@ -67,7 +67,8 @@ final class OpenAIResponsesBackendTests: XCTestCase {
         case .usage: return .usage
         case .toolCall, .toolResult, .toolLoopLimitReached, .kvCacheReuse,
              .diagnosticThrottle, .thinkingSignature,
-             .toolCallStart, .toolCallArgumentsDelta:
+             .toolCallStart, .toolCallArgumentsDelta,
+             .prefillProgress:
             return nil
         }
     }

--- a/Tests/BaseChatCoreTests/SwiftTestingAuditTest.swift
+++ b/Tests/BaseChatCoreTests/SwiftTestingAuditTest.swift
@@ -70,7 +70,7 @@ final class SwiftTestingAuditTest: XCTestCase {
         "BaseChatBackendsTests/CloudErrorSanitizerTests.swift": 23,
         "BaseChatBackendsTests/CloudThinkingTokenTests.swift": 8,
         "BaseChatBackendsTests/OllamaBackendTests.swift": 66,
-        "BaseChatBackendsTests/OpenAICompatEndpointTests.swift": 17,
+        "BaseChatBackendsTests/OpenAICompatEndpointTests.swift": 20,
         "BaseChatBackendsTests/SecureBytesTests.swift": 10,
         "BaseChatBackendsTests/SSEExtractEventsTests.swift": 5,
     ]

--- a/Tests/BaseChatInferenceTests/GenerationConfigTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationConfigTests.swift
@@ -31,6 +31,11 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertFalse(config.jsonMode)
     }
 
+    func test_defaultInit_streamPrefillProgress_isFalse() {
+        let config = GenerationConfig()
+        XCTAssertFalse(config.streamPrefillProgress)
+    }
+
     // MARK: - Custom Init
 
     func test_customInit_propagatesAllValues() {
@@ -80,6 +85,12 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertTrue(config.jsonMode)
     }
 
+    func test_streamPrefillProgress_isMutable() {
+        var config = GenerationConfig()
+        config.streamPrefillProgress = true
+        XCTAssertTrue(config.streamPrefillProgress)
+    }
+
     // MARK: - Mock Backend Captures maxOutputTokens
 
     func test_mockBackend_capturesMaxOutputTokens() async throws {
@@ -122,6 +133,11 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertEqual(config.seed, 42)
     }
 
+    func test_customInit_propagatesStreamPrefillProgress() {
+        let config = GenerationConfig(streamPrefillProgress: true)
+        XCTAssertTrue(config.streamPrefillProgress)
+    }
+
     func test_minP_isMutable() {
         var config = GenerationConfig()
         config.minP = 0.1
@@ -147,6 +163,7 @@ final class GenerationConfigTests: XCTestCase {
         original.minP = 0.07
         original.repetitionPenalty = 1.3
         original.seed = 9_999_999_999  // exceeds UInt32 to assert UInt64 storage
+        original.streamPrefillProgress = true
 
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(GenerationConfig.self, from: data)
@@ -154,6 +171,7 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertEqual(decoded.minP, 0.07)
         XCTAssertEqual(decoded.repetitionPenalty, 1.3)
         XCTAssertEqual(decoded.seed, 9_999_999_999)
+        XCTAssertTrue(decoded.streamPrefillProgress)
     }
 
     func test_codableDecode_legacyPayload_omittingParityKnobs() throws {
@@ -176,5 +194,6 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertNil(decoded.minP)
         XCTAssertNil(decoded.repetitionPenalty)
         XCTAssertNil(decoded.seed)
+        XCTAssertFalse(decoded.streamPrefillProgress)
     }
 }

--- a/Tests/BaseChatInferenceTests/ToolCallContractTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolCallContractTests.swift
@@ -200,6 +200,7 @@ final class ToolCallContractTests: XCTestCase {
         var toolCalls: [ToolCall] = []
         for try await event in stream.events {
             switch event {
+            case .prefillProgress: break
             case .token(let text): tokens.append(text)
             case .toolCall(let call): toolCalls.append(call)
             case .usage: break
@@ -271,6 +272,7 @@ final class ToolCallContractTests: XCTestCase {
         var toolCalls: [ToolCall] = []
         for try await event in stream.events {
             switch event {
+            case .prefillProgress: break
             case .token(let t): tokens.append(t)
             case .toolCall(let c): toolCalls.append(c)
             case .usage: break


### PR DESCRIPTION
## Summary

Adds opt-in passthrough of upstream `prefill_progress` SSE events through the `OpenAIBackend` path, plus the public `GenerationEvent.prefillProgress` event case, so cooperating servers (e.g. a future `BaseChatServer` proxy) can stream prompt-evaluation progress to UIs that want to show \"evaluating prompt 70%\" before the first token.

**Scope:** OpenAI-compatible *forwarding* only. No backend in this PR emits `prefill_progress` from a real local model — Llama / MLX / Foundation are unchanged. The motivating UX (5–30s prefill on long-context local models) is unblocked once one of those backends produces the event; this PR is the wire format and consumer plumbing.

### What's wired

- `GenerationConfig.streamPrefillProgress: Bool = false` (opt-in, Codable round-tripped)
- `OpenAIBackend` sets `X-BaseChat-Prefill-Progress: true` when opted in
- New static `OpenAIBackend.parsePrefillProgress(from:)` consumes upstream `event: prefill_progress` SSE chunks
- `GenerationEvent.prefillProgress(nPast:nTotal:tokensPerSecond:)` enum case
- Consumers updated: `GenerationStreamConsumer` (`.ignore`), `ToolCallLoopOrchestrator`, `ScenarioRunner`, `EventRecorder`

### Tests

Cloud wire format (CloudSaaS trait, not in default CI):

- `compat_prefillProgress_eventsEmitAndPreserveOrdering` — three-event sequence preserves order; final-before-token contract asserts `nPast == nTotal`
- `requestHeaders_prefillProgressOptIn_isOffByDefault` / `_setsHeader` — header gating

CI-default trait:

- `GenerationConfigTests.test_defaultInit_streamPrefillProgress_isFalse`
- `GenerationConfigTests.test_streamPrefillProgress_isMutable`

## Known follow-ups (intentionally out of scope)

- **Producer wiring for local backends.** Llama / MLX / Foundation should emit `prefill_progress` during real prompt evaluation. Tracking #746.
- **Cancellation responsiveness.** `Task.isCancelled` is checked per iteration, but a stalled upstream connection still has to surface the cancel through `URLSession.AsyncBytes`. Worth revisiting once a real local producer exists and we can measure the worst case.
- **CloudSaaS in CI.** The wire-format tests live behind `#if CloudSaaS`, which isn't in default CI traits. The contract is unverified by the green checkmark on this PR. Adding a CloudSaaS-traited CI step is a separate decision (compile-time cost vs. coverage).

## Release Note

Adds an opt-in `GenerationConfig.streamPrefillProgress` flag plus a new `GenerationEvent.prefillProgress(nPast:nTotal:tokensPerSecond:)` case. When enabled, `OpenAIBackend` adds an `X-BaseChat-Prefill-Progress: true` request header and forwards `prefill_progress` SSE events from compatible upstream servers, so chat UIs can show prompt-evaluation progress before the first generated token. Off by default for OpenAI wire compatibility. Producer support for local backends (Llama, MLX, Foundation) tracks separately.

## Validation

- `swift test --filter BaseChatBackendsTests --disable-default-traits` (CI default — passes)
- `swift test --filter BaseChatBackendsTests --disable-default-traits --traits CloudSaaS` (75 tests, 13 suites — passes)
- `swift test --filter BaseChatInferenceTests --disable-default-traits` (passes)

Closes #746 (forwarding scope). Refs #758.