### PR TITLE
fix(tests): handle prefillProgress in Ollama-trait replay switch

### DIFF
--- a/Tests/BaseChatBackendsTests/OllamaToolCallLiveReplayTests.swift
+++ b/Tests/BaseChatBackendsTests/OllamaToolCallLiveReplayTests.swift
@@ -193,6 +193,8 @@ final class OllamaToolCallLiveReplayTests: XCTestCase {
                     // backends that opt into `streamsToolCallArguments`;
                     // the live Ollama replay parses whole calls.
                     break
+                case .prefillProgress:
+                    break
                 }
             }
 


### PR DESCRIPTION
## Summary

PR #804 added `GenerationEvent.prefillProgress` and #804's worker + my follow-up caught two CloudSaaS-trait switch gaps. A third one — `OllamaToolCallLiveReplayTests.swift:168` — was missed because verification only covered default + CloudSaaS traits, not `--traits Ollama`. Surfaced today by running the local Ollama E2E suite.

## Repro

```bash
swift test --filter OllamaE2ETests --disable-default-traits --traits Ollama
# error: switch must be exhaustive
#  note: add missing case: '.prefillProgress(...)'
```

## Fix

One-line `.prefillProgress: break` arm matching the existing pattern for events the live Ollama replay parses but doesn't project (`.thinkingToken`, `.toolCallStart`, etc.).

## Validation

- `swift build --build-tests` clean under every trait combination tried: default, `--traits Ollama`, `--traits MLX,Llama`, `--traits CloudSaaS`, and all-traits-on.
- `swift test --filter OllamaE2ETests --disable-default-traits --traits Ollama` — 10 tests / 6 real-inference / 88s test exec, all green against local `gemma4:e4b`/`llama3.1:8b`.
- `swift test --filter "BaseChatE2ETests\." --disable-default-traits` — 51 tests / 8 suites / 0.5s exec, green.

## Test plan

- [x] Default-trait build clean (CI path)
- [x] Ollama-trait build + E2E green
- [x] MLX,Llama-trait build clean
- [ ] CI green on this branch (auto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)