### PR TITLE
feat(inference): capability routing — per-request capability requirements + RouterBackend

### DIFF
--- a/Sources/BaseChatInference/Models/GenerationCapabilityRequirement.swift
+++ b/Sources/BaseChatInference/Models/GenerationCapabilityRequirement.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// A capability a request requires of whichever backend serves it.
+///
+/// Used by ``GenerationConfig/requiredCapabilities`` and ``RouterBackend``
+/// to fail fast when no wired backend can satisfy a request, and to dispatch
+/// the request to a child backend that can.
+///
+/// New requirements should map onto an existing ``BackendCapabilities`` flag
+/// rather than introducing a parallel system. The mapping lives in
+/// ``BackendCapabilities/satisfies(_:)``.
+public enum GenerationCapabilityRequirement: Sendable, Hashable, Codable {
+    /// The backend must support tool/function calling
+    /// (``BackendCapabilities/supportsToolCalling``).
+    case toolCalling
+
+    /// The backend must support structured (JSON-schema) output
+    /// (``BackendCapabilities/supportsStructuredOutput``).
+    case structuredOutput
+
+    /// The backend must support a native JSON-object generation mode
+    /// (``BackendCapabilities/supportsNativeJSONMode``).
+    case jsonMode
+
+    /// The backend must emit thinking events
+    /// (``BackendCapabilities/supportsThinking``).
+    case thinking
+
+    /// The backend must support grammar-constrained sampling
+    /// (``BackendCapabilities/supportsGrammarConstrainedSampling``).
+    case grammarConstrainedSampling
+
+    /// The backend must be capable of emitting multiple tool calls per turn
+    /// (``BackendCapabilities/supportsParallelToolCalls``).
+    case parallelToolCalls
+
+    /// The backend must stream tool-call arguments
+    /// (``BackendCapabilities/streamsToolCallArguments``).
+    case streamingToolCalls
+
+    /// The backend must persist KV cache state across consecutive
+    /// `generate()` calls (``BackendCapabilities/supportsKVCachePersistence``).
+    case kvCachePersistence
+
+    /// The backend's effective context window must be at least `tokens` wide.
+    case minContextTokens(Int)
+}
+
+extension BackendCapabilities {
+    /// Whether this capability set satisfies a single requirement.
+    public func satisfies(_ requirement: GenerationCapabilityRequirement) -> Bool {
+        switch requirement {
+        case .toolCalling:                return supportsToolCalling
+        case .structuredOutput:           return supportsStructuredOutput
+        case .jsonMode:                   return supportsNativeJSONMode
+        case .thinking:                   return supportsThinking
+        case .grammarConstrainedSampling: return supportsGrammarConstrainedSampling
+        case .parallelToolCalls:          return supportsParallelToolCalls
+        case .streamingToolCalls:         return streamsToolCallArguments
+        case .kvCachePersistence:         return supportsKVCachePersistence
+        case .minContextTokens(let n):    return contextWindowSize >= n
+        }
+    }
+
+    /// Whether this capability set satisfies every requirement in the set.
+    public func satisfies(_ requirements: Set<GenerationCapabilityRequirement>) -> Bool {
+        requirements.allSatisfy { satisfies($0) }
+    }
+
+    /// Subset of `requirements` that this capability set fails to satisfy.
+    /// Used for diagnostic error messages when routing fails.
+    public func unsatisfied(
+        from requirements: Set<GenerationCapabilityRequirement>
+    ) -> Set<GenerationCapabilityRequirement> {
+        Set(requirements.filter { !satisfies($0) })
+    }
+}

--- a/Sources/BaseChatInference/Models/GenerationCapabilityRequirement.swift
+++ b/Sources/BaseChatInference/Models/GenerationCapabilityRequirement.swift
@@ -44,6 +44,25 @@ public enum GenerationCapabilityRequirement: Sendable, Hashable, Codable {
 
     /// The backend's effective context window must be at least `tokens` wide.
     case minContextTokens(Int)
+
+    /// Stable sort key for diagnostic ordering. Logged error payloads need a
+    /// deterministic order so test assertions and log diffs stay stable across
+    /// runs — the underlying `Set` storage iterates in insertion-dependent
+    /// order. Not part of the public API contract; the case names happen to
+    /// match `String(describing:)` today but callers should not rely on that.
+    var sortKey: String {
+        switch self {
+        case .toolCalling:                return "1.toolCalling"
+        case .structuredOutput:           return "2.structuredOutput"
+        case .jsonMode:                   return "3.jsonMode"
+        case .thinking:                   return "4.thinking"
+        case .grammarConstrainedSampling: return "5.grammarConstrainedSampling"
+        case .parallelToolCalls:          return "6.parallelToolCalls"
+        case .streamingToolCalls:         return "7.streamingToolCalls"
+        case .kvCachePersistence:         return "8.kvCachePersistence"
+        case .minContextTokens(let n):    return "9.minContextTokens.\(n)"
+        }
+    }
 }
 
 extension BackendCapabilities {

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -156,7 +156,17 @@ public struct GenerationConfig: Sendable, Codable {
     /// - Only honoured by `MLXBackend`; other backends ignore this field.
     public var yieldEveryNTokens: Int = 8
 
-    @available(*, deprecated, message: "Use init(temperature:topP:repeatPenalty:topK:typicalP:minP:repetitionPenalty:seed:maxOutputTokens:tools:toolChoice:maxThinkingTokens:jsonMode:streamPrefillProgress:thinkingMarkers:maxToolIterations:grammar:yieldEveryNTokens:) instead.")
+    /// Capabilities the backend serving this request must provide.
+    ///
+    /// Empty (the default) means any wired backend may serve the request —
+    /// preserves the existing zero-config behaviour. When non-empty, ``RouterBackend``
+    /// dispatches to the first child whose ``BackendCapabilities`` satisfy every
+    /// requirement; backends used directly may use this for fail-fast validation.
+    /// Independent of ``tools`` / ``grammar`` / ``jsonMode`` — those are
+    /// per-request payloads; this is a per-request *contract*.
+    public var requiredCapabilities: Set<GenerationCapabilityRequirement> = []
+
+    @available(*, deprecated, message: "Use init(temperature:topP:repeatPenalty:topK:typicalP:minP:repetitionPenalty:seed:maxOutputTokens:tools:toolChoice:maxThinkingTokens:jsonMode:streamPrefillProgress:thinkingMarkers:maxToolIterations:grammar:yieldEveryNTokens:requiredCapabilities:) instead.")
     public init(
         temperature: Float = 0.7,
         topP: Float = 0.9,
@@ -217,7 +227,8 @@ public struct GenerationConfig: Sendable, Codable {
         thinkingMarkers: ThinkingMarkers? = nil,
         maxToolIterations: Int = 10,
         grammar: String? = nil,
-        yieldEveryNTokens: Int = 8
+        yieldEveryNTokens: Int = 8,
+        requiredCapabilities: Set<GenerationCapabilityRequirement> = []
     ) {
         self.temperature = temperature
         self.topP = topP
@@ -237,6 +248,7 @@ public struct GenerationConfig: Sendable, Codable {
         self.maxToolIterations = max(1, maxToolIterations)
         self.grammar = grammar
         self.yieldEveryNTokens = yieldEveryNTokens
+        self.requiredCapabilities = requiredCapabilities
     }
 
     // MARK: Codable
@@ -247,6 +259,7 @@ public struct GenerationConfig: Sendable, Codable {
         case yieldEveryNTokens
         case streamPrefillProgress
         case minP, repetitionPenalty, seed
+        case requiredCapabilities
     }
 
     public init(from decoder: Decoder) throws {
@@ -280,6 +293,12 @@ public struct GenerationConfig: Sendable, Codable {
         minP = try c.decodeIfPresent(Float.self, forKey: .minP)
         repetitionPenalty = try c.decodeIfPresent(Float.self, forKey: .repetitionPenalty)
         seed = try c.decodeIfPresent(UInt64.self, forKey: .seed)
+        // requiredCapabilities is a per-request runtime contract; landed after
+        // the original shape, so older payloads decode to an empty set.
+        requiredCapabilities = (try c.decodeIfPresent(
+            Set<GenerationCapabilityRequirement>.self,
+            forKey: .requiredCapabilities
+        )) ?? []
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -303,6 +322,9 @@ public struct GenerationConfig: Sendable, Codable {
         try c.encodeIfPresent(minP, forKey: .minP)
         try c.encodeIfPresent(repetitionPenalty, forKey: .repetitionPenalty)
         try c.encodeIfPresent(seed, forKey: .seed)
+        if !requiredCapabilities.isEmpty {
+            try c.encode(requiredCapabilities, forKey: .requiredCapabilities)
+        }
     }
 }
 

--- a/Sources/BaseChatInference/Services/InferenceError.swift
+++ b/Sources/BaseChatInference/Services/InferenceError.swift
@@ -24,6 +24,11 @@ public enum InferenceError: LocalizedError {
     /// Thrown by backends when `config.grammar != nil` but the backend does not support
     /// grammar-constrained sampling. `isRetryable` is `false`.
     case unsupportedGrammar(reason: String)
+    /// Thrown by ``RouterBackend`` when no wired child backend satisfies every
+    /// requirement in ``GenerationConfig/requiredCapabilities``. The associated
+    /// value lists the unsatisfied requirements (across all children — i.e. the
+    /// requirements no child could meet) so the host can surface a fix-it message.
+    case noBackendSatisfiesRequirements([GenerationCapabilityRequirement])
 
     public var errorDescription: String? {
         switch self {
@@ -47,6 +52,9 @@ public enum InferenceError: LocalizedError {
             return "Unsupported model architecture: \(arch). This backend only supports chat/instruct language models."
         case .unsupportedGrammar(let reason):
             return "Grammar-constrained sampling not supported: \(reason)"
+        case .noBackendSatisfiesRequirements(let unmet):
+            let names = unmet.map { String(describing: $0) }.joined(separator: ", ")
+            return "No wired backend satisfies the request's required capabilities: \(names)."
         }
     }
 
@@ -61,7 +69,8 @@ public enum InferenceError: LocalizedError {
             return true
         case .modelNotFound, .modelLoadFailed, .inferenceFailure,
              .memoryInsufficient, .generationError, .contextExhausted,
-             .unsupportedModelArchitecture, .unsupportedGrammar:
+             .unsupportedModelArchitecture, .unsupportedGrammar,
+             .noBackendSatisfiesRequirements:
             return false
         }
     }

--- a/Sources/BaseChatInference/Services/InferenceError.swift
+++ b/Sources/BaseChatInference/Services/InferenceError.swift
@@ -53,6 +53,9 @@ public enum InferenceError: LocalizedError {
         case .unsupportedGrammar(let reason):
             return "Grammar-constrained sampling not supported: \(reason)"
         case .noBackendSatisfiesRequirements(let unmet):
+            if unmet.isEmpty {
+                return "No wired backend satisfies the request's required capabilities."
+            }
             let names = unmet.map { String(describing: $0) }.joined(separator: ", ")
             return "No wired backend satisfies the request's required capabilities: \(names)."
         }

--- a/Sources/BaseChatInference/Services/RouterBackend.swift
+++ b/Sources/BaseChatInference/Services/RouterBackend.swift
@@ -11,11 +11,11 @@ import Foundation
 /// Lifecycle delegation is intentionally narrow:
 ///
 /// - `loadModel(from:plan:)` is **not** routed by capability — picking a
-///   model is the host's job. ``RouterBackend`` itself does not advertise a
-///   loaded model. Use ``InferenceService`` (which holds one backend per
-///   model type) for load orchestration; reach for ``RouterBackend`` only
-///   when a single conceptual session multiplexes across already-loaded
-///   children.
+///   model is the host's job. ``RouterBackend`` itself does not load or
+///   identify a single model; `isModelLoaded` reflects whether any child is
+///   loaded. Use ``InferenceService`` (which holds one backend per model
+///   type) for load orchestration; reach for ``RouterBackend`` only when a
+///   single conceptual session multiplexes across already-loaded children.
 /// - `stopGeneration()` and `unloadModel()` fan out to every child — a
 ///   request may be in flight on the most recently picked child, but other
 ///   children may also have state from previous calls.
@@ -32,6 +32,14 @@ public final class RouterBackend: InferenceBackend, @unchecked Sendable {
     public let children: [any InferenceBackend]
 
     public init(children: [any InferenceBackend]) {
+        // An empty router would produce a `.noBackendSatisfiesRequirements([])`
+        // error on every `generate(...)` call — surfacing that at the wiring
+        // site (host code that built the router) is far easier to debug than
+        // having every request fail later with an empty diagnostic payload.
+        precondition(
+            !children.isEmpty,
+            "RouterBackend requires at least one child backend"
+        )
         self.children = children
     }
 
@@ -122,14 +130,22 @@ public final class RouterBackend: InferenceBackend, @unchecked Sendable {
     }
 
     /// Picks the first child whose capabilities satisfy `requirements`.
+    ///
+    /// Loaded children are preferred — if any loaded child satisfies, that
+    /// one wins. Only when no loaded child can serve does the router fall
+    /// back to an unloaded child that satisfies (so the error surfaces as
+    /// "no model loaded" from the chosen backend, not as a routing failure).
     /// Public so hosts can do a dry-run check before issuing a request.
     public func selectBackend(
         for requirements: Set<GenerationCapabilityRequirement>
     ) -> (any InferenceBackend)? {
-        guard !requirements.isEmpty else {
-            return children.first
+        let predicate: (any InferenceBackend) -> Bool = requirements.isEmpty
+            ? { _ in true }
+            : { $0.capabilities.satisfies(requirements) }
+        if let loaded = children.first(where: { $0.isModelLoaded && predicate($0) }) {
+            return loaded
         }
-        return children.first { $0.capabilities.satisfies(requirements) }
+        return children.first(where: predicate)
     }
 
     public func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
@@ -157,7 +173,9 @@ public final class RouterBackend: InferenceBackend, @unchecked Sendable {
             // partial coverage (every child fails some requirement, but no single
             // requirement is unmet by every child) — rare, but guards against
             // returning an empty diagnostic.
-            let payload = unmet.isEmpty ? Array(requirements) : Array(unmet)
+            let unsorted = unmet.isEmpty ? Array(requirements) : Array(unmet)
+            // Sort for deterministic logs/diffs — `Set` iteration order is unstable.
+            let payload = unsorted.sorted { $0.sortKey < $1.sortKey }
             throw InferenceError.noBackendSatisfiesRequirements(payload)
         }
         return try chosen.generate(

--- a/Sources/BaseChatInference/Services/RouterBackend.swift
+++ b/Sources/BaseChatInference/Services/RouterBackend.swift
@@ -1,0 +1,189 @@
+import Foundation
+
+/// Composes a list of child backends and dispatches each `generate(...)` call
+/// to the first child whose ``BackendCapabilities`` satisfy the request's
+/// ``GenerationConfig/requiredCapabilities``.
+///
+/// Useful for "small local for classification, larger local or remote for
+/// reasoning" wiring without per-app glue. Single child per request — the
+/// router does not fan out, retry across children, or load-balance.
+///
+/// Lifecycle delegation is intentionally narrow:
+///
+/// - `loadModel(from:plan:)` is **not** routed by capability — picking a
+///   model is the host's job. ``RouterBackend`` itself does not advertise a
+///   loaded model. Use ``InferenceService`` (which holds one backend per
+///   model type) for load orchestration; reach for ``RouterBackend`` only
+///   when a single conceptual session multiplexes across already-loaded
+///   children.
+/// - `stopGeneration()` and `unloadModel()` fan out to every child — a
+///   request may be in flight on the most recently picked child, but other
+///   children may also have state from previous calls.
+/// - `resetConversation()` fans out for the same reason.
+///
+/// `capabilities` is the **union** of every child's capabilities (per-flag
+/// OR; numeric maxima taken). This is the correct surface for a UI that
+/// asks "can the runtime as a whole do X?" — for a per-request question
+/// the right answer comes from `GenerationConfig.requiredCapabilities` and
+/// the dispatch performed in `generate(...)`.
+public final class RouterBackend: InferenceBackend, @unchecked Sendable {
+    /// Children, in priority order. The first child satisfying a request's
+    /// requirements is chosen.
+    public let children: [any InferenceBackend]
+
+    public init(children: [any InferenceBackend]) {
+        self.children = children
+    }
+
+    public var isModelLoaded: Bool {
+        // Any child with a loaded model means the runtime can serve a
+        // request that it can satisfy.
+        children.contains { $0.isModelLoaded }
+    }
+
+    public var isGenerating: Bool {
+        children.contains { $0.isGenerating }
+    }
+
+    public var capabilities: BackendCapabilities {
+        // Union semantics — see type doc-comment for why this surface is the
+        // right answer for "can the runtime as a whole do X?".
+        guard let first = children.first?.capabilities else {
+            return BackendCapabilities()
+        }
+        var supportedParameters = first.supportedParameters
+        var maxContextTokens = first.maxContextTokens
+        var maxOutputTokens = first.maxOutputTokens
+        var requiresPromptTemplate = first.requiresPromptTemplate
+        var supportsSystemPrompt = first.supportsSystemPrompt
+        var supportsStreaming = first.supportsStreaming
+        var supportsToolCalling = first.supportsToolCalling
+        var supportsStructuredOutput = first.supportsStructuredOutput
+        var supportsNativeJSONMode = first.supportsNativeJSONMode
+        var cancellationStyle = first.cancellationStyle
+        var supportsTokenCounting = first.supportsTokenCounting
+        var memoryStrategy = first.memoryStrategy
+        var isRemote = first.isRemote
+        var supportsKVCachePersistence = first.supportsKVCachePersistence
+        var supportsGrammarConstrainedSampling = first.supportsGrammarConstrainedSampling
+        var supportsThinking = first.supportsThinking
+        var streamsToolCallArguments = first.streamsToolCallArguments
+        var supportsParallelToolCalls = first.supportsParallelToolCalls
+
+        for child in children.dropFirst() {
+            let c = child.capabilities
+            supportedParameters.formUnion(c.supportedParameters)
+            maxContextTokens = max(maxContextTokens, c.maxContextTokens)
+            maxOutputTokens = max(maxOutputTokens, c.maxOutputTokens)
+            // `requiresPromptTemplate` is a per-backend rule. The union answer
+            // is "the runtime can serve at least one backend that *doesn't*
+            // require a template" — false beats true.
+            requiresPromptTemplate = requiresPromptTemplate && c.requiresPromptTemplate
+            supportsSystemPrompt = supportsSystemPrompt || c.supportsSystemPrompt
+            supportsStreaming = supportsStreaming || c.supportsStreaming
+            supportsToolCalling = supportsToolCalling || c.supportsToolCalling
+            supportsStructuredOutput = supportsStructuredOutput || c.supportsStructuredOutput
+            supportsNativeJSONMode = supportsNativeJSONMode || c.supportsNativeJSONMode
+            // Pick the more permissive cancellation style — cooperative beats
+            // explicit because callers can always stop a cooperative backend
+            // by cancelling the Task.
+            if c.cancellationStyle == .cooperative { cancellationStyle = .cooperative }
+            supportsTokenCounting = supportsTokenCounting || c.supportsTokenCounting
+            // Memory strategy: keep `external` if any child is external (cloud
+            // path is available); otherwise prefer `mappable` over `resident`.
+            memoryStrategy = mergedMemoryStrategy(memoryStrategy, c.memoryStrategy)
+            isRemote = isRemote || c.isRemote
+            supportsKVCachePersistence = supportsKVCachePersistence || c.supportsKVCachePersistence
+            supportsGrammarConstrainedSampling = supportsGrammarConstrainedSampling || c.supportsGrammarConstrainedSampling
+            supportsThinking = supportsThinking || c.supportsThinking
+            streamsToolCallArguments = streamsToolCallArguments || c.streamsToolCallArguments
+            supportsParallelToolCalls = supportsParallelToolCalls || c.supportsParallelToolCalls
+        }
+        return BackendCapabilities(
+            supportedParameters: supportedParameters,
+            maxContextTokens: maxContextTokens,
+            requiresPromptTemplate: requiresPromptTemplate,
+            supportsSystemPrompt: supportsSystemPrompt,
+            supportsToolCalling: supportsToolCalling,
+            supportsStructuredOutput: supportsStructuredOutput,
+            supportsNativeJSONMode: supportsNativeJSONMode,
+            cancellationStyle: cancellationStyle,
+            supportsTokenCounting: supportsTokenCounting,
+            memoryStrategy: memoryStrategy,
+            maxOutputTokens: maxOutputTokens,
+            supportsStreaming: supportsStreaming,
+            isRemote: isRemote,
+            supportsKVCachePersistence: supportsKVCachePersistence,
+            supportsGrammarConstrainedSampling: supportsGrammarConstrainedSampling,
+            supportsThinking: supportsThinking,
+            streamsToolCallArguments: streamsToolCallArguments,
+            supportsParallelToolCalls: supportsParallelToolCalls
+        )
+    }
+
+    /// Picks the first child whose capabilities satisfy `requirements`.
+    /// Public so hosts can do a dry-run check before issuing a request.
+    public func selectBackend(
+        for requirements: Set<GenerationCapabilityRequirement>
+    ) -> (any InferenceBackend)? {
+        guard !requirements.isEmpty else {
+            return children.first
+        }
+        return children.first { $0.capabilities.satisfies(requirements) }
+    }
+
+    public func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
+        // Loading is not a routing decision — the host owns model selection.
+        // Surface as a config error so the wrong call site is obvious in tests.
+        throw InferenceError.inferenceFailure(
+            "RouterBackend does not load models — load each child backend before composing the router."
+        )
+    }
+
+    public func generate(
+        prompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig
+    ) throws -> GenerationStream {
+        let requirements = config.requiredCapabilities
+        guard let chosen = selectBackend(for: requirements) else {
+            // Compute the union of unsatisfied requirements across all children
+            // so the error names exactly which capabilities the wired set lacks.
+            // A requirement appears in the result only if no child satisfies it.
+            let unmet = requirements.filter { req in
+                children.allSatisfy { !$0.capabilities.satisfies(req) }
+            }
+            // Fall back to the full requirement list when the failure is per-child
+            // partial coverage (every child fails some requirement, but no single
+            // requirement is unmet by every child) — rare, but guards against
+            // returning an empty diagnostic.
+            let payload = unmet.isEmpty ? Array(requirements) : Array(unmet)
+            throw InferenceError.noBackendSatisfiesRequirements(payload)
+        }
+        return try chosen.generate(
+            prompt: prompt,
+            systemPrompt: systemPrompt,
+            config: config
+        )
+    }
+
+    public func stopGeneration() {
+        for child in children { child.stopGeneration() }
+    }
+
+    public func unloadModel() {
+        for child in children { child.unloadModel() }
+    }
+
+    public func resetConversation() {
+        for child in children { child.resetConversation() }
+    }
+
+    private func mergedMemoryStrategy(_ a: MemoryStrategy, _ b: MemoryStrategy) -> MemoryStrategy {
+        // Preference order for "the most permissive" runtime memory profile:
+        // external (no local footprint) → mappable (paged) → resident (full RAM).
+        if a == .external || b == .external { return .external }
+        if a == .mappable || b == .mappable { return .mappable }
+        return .resident
+    }
+}

--- a/Tests/BaseChatInferenceTests/ErrorDescriptionTests.swift
+++ b/Tests/BaseChatInferenceTests/ErrorDescriptionTests.swift
@@ -61,6 +61,7 @@ final class ErrorDescriptionTests: XCTestCase {
             .memoryInsufficient(required: 8_589_934_592, available: 4_294_967_296),
             .alreadyGenerating,
             .generationError("token limit"),
+            .noBackendSatisfiesRequirements([.toolCalling]),
         ]
 
         for error in cases {

--- a/Tests/BaseChatInferenceTests/ErrorDescriptionTests.swift
+++ b/Tests/BaseChatInferenceTests/ErrorDescriptionTests.swift
@@ -71,6 +71,15 @@ final class ErrorDescriptionTests: XCTestCase {
         }
     }
 
+    func test_noBackendSatisfiesRequirements_emptyPayload_hasGenericMessage() {
+        // Empty payload must not produce a dangling colon. Constructed defensively
+        // even though `RouterBackend` always sends at least one requirement.
+        let error = InferenceError.noBackendSatisfiesRequirements([])
+        let desc = error.errorDescription!
+        XCTAssertFalse(desc.contains(":"), "Empty payload should not produce dangling colon: \(desc)")
+        XCTAssertFalse(desc.isEmpty)
+    }
+
     func test_memoryInsufficient_calculatesMB() {
         let required: UInt64 = 8 * 1024 * 1024   // 8 MB
         let available: UInt64 = 4 * 1024 * 1024   // 4 MB

--- a/Tests/BaseChatInferenceTests/RouterBackendTests.swift
+++ b/Tests/BaseChatInferenceTests/RouterBackendTests.swift
@@ -1,0 +1,274 @@
+import XCTest
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Tests for ``RouterBackend`` and ``GenerationConfig.requiredCapabilities``.
+final class RouterBackendTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Capabilities for a small backend that cannot do tools, structured
+    /// output, thinking, or grammar — represents a tiny local model.
+    private func minimalCaps(maxContext: Int32 = 2048) -> BackendCapabilities {
+        BackendCapabilities(
+            supportedParameters: [.temperature],
+            maxContextTokens: maxContext,
+            supportsToolCalling: false,
+            supportsStructuredOutput: false,
+            supportsThinking: false,
+            streamsToolCallArguments: false,
+            supportsParallelToolCalls: false
+        )
+    }
+
+    /// Capabilities for a large backend that supports tool calling, JSON mode,
+    /// thinking, and a wide context — represents a frontier remote model.
+    private func capableCaps(maxContext: Int32 = 32_000) -> BackendCapabilities {
+        BackendCapabilities(
+            supportedParameters: [.temperature, .topP],
+            maxContextTokens: maxContext,
+            supportsToolCalling: true,
+            supportsStructuredOutput: true,
+            supportsNativeJSONMode: true,
+            supportsThinking: true,
+            streamsToolCallArguments: true,
+            supportsParallelToolCalls: true
+        )
+    }
+
+    private func loaded(_ caps: BackendCapabilities) -> MockInferenceBackend {
+        let mock = MockInferenceBackend(capabilities: caps)
+        mock.isModelLoaded = true
+        return mock
+    }
+
+    private func consumeAll(_ stream: GenerationStream) async throws -> [GenerationEvent] {
+        var events: [GenerationEvent] = []
+        for try await event in stream.events { events.append(event) }
+        return events
+    }
+
+    // MARK: - GenerationCapabilityRequirement satisfies()
+
+    func test_satisfies_toolCalling_matchesFlag() {
+        XCTAssertTrue(capableCaps().satisfies(.toolCalling))
+        XCTAssertFalse(minimalCaps().satisfies(.toolCalling))
+    }
+
+    func test_satisfies_minContextTokens_acceptsAtThreshold() {
+        let caps = minimalCaps(maxContext: 4096)
+        XCTAssertTrue(caps.satisfies(.minContextTokens(4096)))
+        XCTAssertTrue(caps.satisfies(.minContextTokens(2000)))
+        XCTAssertFalse(caps.satisfies(.minContextTokens(8000)))
+    }
+
+    func test_satisfies_setRequiresAllRequirements() {
+        let caps = capableCaps()
+        XCTAssertTrue(caps.satisfies([.toolCalling, .thinking]))
+        XCTAssertFalse(minimalCaps().satisfies([.toolCalling, .thinking]))
+    }
+
+    func test_unsatisfied_listsOnlyMissingRequirements() {
+        let unmet = minimalCaps().unsatisfied(from: [.toolCalling, .minContextTokens(1000)])
+        // 2048 >= 1000 → minContextTokens satisfied; toolCalling missing.
+        XCTAssertEqual(unmet, [.toolCalling])
+    }
+
+    // MARK: - GenerationConfig
+
+    func test_generationConfig_requiredCapabilities_defaultsEmpty() {
+        let config = GenerationConfig()
+        XCTAssertTrue(config.requiredCapabilities.isEmpty)
+    }
+
+    func test_generationConfig_requiredCapabilities_propagates() {
+        let config = GenerationConfig(requiredCapabilities: [.toolCalling, .thinking])
+        XCTAssertEqual(config.requiredCapabilities, [.toolCalling, .thinking])
+    }
+
+    func test_generationConfig_codable_roundTripsRequiredCapabilities() throws {
+        let original = GenerationConfig(requiredCapabilities: [.toolCalling, .minContextTokens(8000)])
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: data)
+        XCTAssertEqual(decoded.requiredCapabilities, original.requiredCapabilities)
+    }
+
+    func test_generationConfig_codable_olderPayloadsDecodeToEmptySet() throws {
+        // Older serialised configs lack the field entirely; the decoder must
+        // tolerate the absence rather than failing. Build the legacy payload by
+        // encoding a default config and stripping `requiredCapabilities`.
+        let defaultEncoded = try JSONEncoder().encode(GenerationConfig())
+        var dict = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: defaultEncoded) as? [String: Any]
+        )
+        dict.removeValue(forKey: "requiredCapabilities")
+        let stripped = try JSONSerialization.data(withJSONObject: dict)
+        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: stripped)
+        XCTAssertTrue(decoded.requiredCapabilities.isEmpty)
+    }
+
+    // MARK: - RouterBackend.selectBackend
+
+    func test_selectBackend_emptyRequirements_picksFirstChild() {
+        let small = loaded(minimalCaps())
+        let large = loaded(capableCaps())
+        let router = RouterBackend(children: [small, large])
+        XCTAssertTrue(router.selectBackend(for: []) === small)
+    }
+
+    func test_selectBackend_picksFirstSatisfyingChildInOrder() {
+        let small = loaded(minimalCaps())
+        let large = loaded(capableCaps())
+        let router = RouterBackend(children: [small, large])
+        let chosen = router.selectBackend(for: [.toolCalling])
+        XCTAssertTrue(chosen === large)
+    }
+
+    func test_selectBackend_returnsNilWhenNoChildSatisfies() {
+        let small = loaded(minimalCaps())
+        let other = loaded(minimalCaps(maxContext: 1024))
+        let router = RouterBackend(children: [small, other])
+        XCTAssertNil(router.selectBackend(for: [.toolCalling]))
+    }
+
+    // MARK: - RouterBackend.generate dispatch
+
+    func test_generate_dispatchesToFirstSatisfyingChild() async throws {
+        let small = loaded(minimalCaps())
+        small.tokensToYield = ["small"]
+        let large = loaded(capableCaps())
+        large.tokensToYield = ["large"]
+        let router = RouterBackend(children: [small, large])
+
+        let stream = try router.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: GenerationConfig(requiredCapabilities: [.toolCalling])
+        )
+        let events = try await consumeAll(stream)
+
+        XCTAssertEqual(small.generateCallCount, 0)
+        XCTAssertEqual(large.generateCallCount, 1)
+        XCTAssertEqual(events, [.token("large")])
+    }
+
+    func test_generate_emptyRequirements_picksFirstChildEvenIfWeaker() async throws {
+        let small = loaded(minimalCaps())
+        small.tokensToYield = ["small"]
+        let large = loaded(capableCaps())
+        large.tokensToYield = ["large"]
+        let router = RouterBackend(children: [small, large])
+
+        let stream = try router.generate(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+        let events = try await consumeAll(stream)
+
+        XCTAssertEqual(small.generateCallCount, 1)
+        XCTAssertEqual(large.generateCallCount, 0)
+        XCTAssertEqual(events, [.token("small")])
+    }
+
+    func test_generate_throwsWhenNoChildSatisfies() throws {
+        let small = loaded(minimalCaps())
+        let other = loaded(minimalCaps())
+        let router = RouterBackend(children: [small, other])
+        let config = GenerationConfig(requiredCapabilities: [.toolCalling, .thinking])
+
+        XCTAssertThrowsError(
+            try router.generate(prompt: "hi", systemPrompt: nil, config: config)
+        ) { error in
+            guard case let InferenceError.noBackendSatisfiesRequirements(unmet) = error else {
+                XCTFail("expected .noBackendSatisfiesRequirements, got \(error)")
+                return
+            }
+            XCTAssertEqual(Set(unmet), [.toolCalling, .thinking])
+        }
+        XCTAssertEqual(small.generateCallCount, 0)
+        XCTAssertEqual(other.generateCallCount, 0)
+    }
+
+    func test_generate_satisfiableBetweenChildren_butNoSingleChildSatisfies_throws() throws {
+        // Child A has tool calling but small context; Child B has wide context
+        // but no tool calling. A request asking for both must fail — the router
+        // does not split a single request across children.
+        let toolBackend = loaded(BackendCapabilities(
+            maxContextTokens: 1024,
+            supportsToolCalling: true
+        ))
+        let wideBackend = loaded(BackendCapabilities(
+            maxContextTokens: 32_000,
+            supportsToolCalling: false
+        ))
+        let router = RouterBackend(children: [toolBackend, wideBackend])
+        let config = GenerationConfig(requiredCapabilities: [
+            .toolCalling,
+            .minContextTokens(8000)
+        ])
+        XCTAssertThrowsError(
+            try router.generate(prompt: "hi", systemPrompt: nil, config: config)
+        )
+    }
+
+    // MARK: - Lifecycle fan-out
+
+    func test_stopGeneration_fansOutToAllChildren() {
+        let a = loaded(minimalCaps())
+        let b = loaded(capableCaps())
+        let router = RouterBackend(children: [a, b])
+        router.stopGeneration()
+        XCTAssertEqual(a.stopCallCount, 1)
+        XCTAssertEqual(b.stopCallCount, 1)
+    }
+
+    func test_unloadModel_fansOutToAllChildren() {
+        let a = loaded(minimalCaps())
+        let b = loaded(capableCaps())
+        let router = RouterBackend(children: [a, b])
+        router.unloadModel()
+        XCTAssertEqual(a.unloadCallCount, 1)
+        XCTAssertEqual(b.unloadCallCount, 1)
+        XCTAssertFalse(router.isModelLoaded)
+    }
+
+    func test_resetConversation_fansOutToAllChildren() {
+        let a = loaded(minimalCaps())
+        let b = loaded(capableCaps())
+        let router = RouterBackend(children: [a, b])
+        router.resetConversation()
+        XCTAssertEqual(a.resetConversationCallCount, 1)
+        XCTAssertEqual(b.resetConversationCallCount, 1)
+    }
+
+    func test_loadModel_throws_loadingIsNotARoutingDecision() async {
+        let a = loaded(minimalCaps())
+        let router = RouterBackend(children: [a])
+        do {
+            try await router.loadModel(from: URL(fileURLWithPath: "/dev/null"), plan: ModelLoadPlan.testStub())
+            XCTFail("expected throw")
+        } catch let InferenceError.inferenceFailure(message) {
+            XCTAssertTrue(message.contains("RouterBackend"))
+        } catch {
+            XCTFail("expected InferenceError.inferenceFailure, got \(error)")
+        }
+    }
+
+    // MARK: - Capability union
+
+    func test_capabilities_unionsToolCallingFlags() {
+        let small = loaded(minimalCaps())
+        let large = loaded(capableCaps())
+        let router = RouterBackend(children: [small, large])
+        XCTAssertTrue(router.capabilities.supportsToolCalling)
+        XCTAssertTrue(router.capabilities.supportsThinking)
+    }
+
+    func test_capabilities_takesMaxContext() {
+        let small = loaded(minimalCaps(maxContext: 2048))
+        let large = loaded(capableCaps(maxContext: 32_000))
+        let router = RouterBackend(children: [small, large])
+        XCTAssertEqual(router.capabilities.maxContextTokens, 32_000)
+    }
+}

--- a/Tests/BaseChatInferenceTests/RouterBackendTests.swift
+++ b/Tests/BaseChatInferenceTests/RouterBackendTests.swift
@@ -131,6 +131,27 @@ final class RouterBackendTests: XCTestCase {
         XCTAssertNil(router.selectBackend(for: [.toolCalling]))
     }
 
+    func test_selectBackend_prefersLoadedChildOverUnloadedSatisfier() {
+        // Unloaded large is listed first; the loaded second-place child should
+        // win so callers don't get routed to a backend that will immediately
+        // fail with "no model loaded".
+        let unloadedLarge = MockInferenceBackend(capabilities: capableCaps())
+        unloadedLarge.isModelLoaded = false
+        let loadedLarge = loaded(capableCaps())
+        let router = RouterBackend(children: [unloadedLarge, loadedLarge])
+        XCTAssertTrue(router.selectBackend(for: [.toolCalling]) === loadedLarge)
+    }
+
+    func test_selectBackend_fallsBackToUnloadedWhenNoLoadedChildSatisfies() {
+        // Only an unloaded child can satisfy — pick it so the failure surfaces
+        // as a load-time error from the backend rather than an opaque routing nil.
+        let loadedSmall = loaded(minimalCaps())
+        let unloadedLarge = MockInferenceBackend(capabilities: capableCaps())
+        unloadedLarge.isModelLoaded = false
+        let router = RouterBackend(children: [loadedSmall, unloadedLarge])
+        XCTAssertTrue(router.selectBackend(for: [.toolCalling]) === unloadedLarge)
+    }
+
     // MARK: - RouterBackend.generate dispatch
 
     func test_generate_dispatchesToFirstSatisfyingChild() async throws {


### PR DESCRIPTION
## Summary

Bundled rollout of two cooperating issues from the tool-calling umbrella (#753).
One alone would have no consumer or input — they ship as a single PR.

- **#439**: per-request capability requirements on `GenerationConfig`
- **#438**: `RouterBackend` that dispatches each request across children by capability

## What ships

### `GenerationConfig.requiredCapabilities`

```swift
let config = GenerationConfig(
    requiredCapabilities: [.toolCalling, .minContextTokens(8_000)]
)
```

Each `GenerationCapabilityRequirement` case maps onto an existing
`BackendCapabilities` flag — no parallel system. The new field defaults
to an empty set, so existing call sites are unaffected. Codable
round-trips, and older payloads decode to an empty set.

### `RouterBackend`

```swift
let router = RouterBackend(children: [smallLocal, capableCloud])
let stream = try router.generate(
    prompt: prompt,
    systemPrompt: nil,
    config: GenerationConfig(requiredCapabilities: [.toolCalling])
)
```

The router walks `children` in priority order and picks the first whose
`BackendCapabilities.satisfies(requirements)` is `true`. When no child
qualifies it throws `InferenceError.noBackendSatisfiesRequirements`
listing the missing capabilities. Single child per request — the router
does not fan out, retry across children, or load-balance.

Lifecycle ops (`stopGeneration`, `unloadModel`, `resetConversation`)
fan out to every child. `loadModel` is rejected — picking a model is the
host's job; reach for `RouterBackend` only when a single conceptual
session multiplexes across already-loaded children.

`capabilities` returns the union of children's capabilities so a UI can
ask "can the runtime as a whole do X?". Per-request the right answer
comes from `requiredCapabilities` and the dispatch in `generate(...)`.

## Release Note

### Highlights

#### Per-request capability routing

Requests can now declare what they need from a backend (tool calling,
thinking, grammar-constrained sampling, a minimum context window) on
the `GenerationConfig` itself. The new `RouterBackend` composes a list
of children and dispatches each request to the first one that can serve
it — useful for "small local for classification, larger local or remote
for reasoning" wiring without per-app glue.

```swift
let router = RouterBackend(children: [smallLocal, capableCloud])
let config = GenerationConfig(
    requiredCapabilities: [.toolCalling, .minContextTokens(8_000)]
)
let stream = try router.generate(prompt: prompt, systemPrompt: nil, config: config)
```

`requiredCapabilities` defaults to an empty set, so existing call sites
keep working unchanged. When no wired backend satisfies a request the
router throws `InferenceError.noBackendSatisfiesRequirements` listing
the missing capabilities. See [#438], [#439], [#753].

### Features

- **inference:** per-request `requiredCapabilities` on `GenerationConfig` ([#439])
- **inference:** `RouterBackend` composes children and dispatches by capability ([#438])

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits`
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` (includes new `RouterBackendTests`)
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits`
- [x] `swift test --filter BaseChatUITests --disable-default-traits`
- [x] `swift test --filter BaseChatUIModelManagementTests --disable-default-traits`
- [x] `swift test --filter BaseChatMCPTests --disable-default-traits`
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits`
- [x] `swift test --filter BaseChatTestSupportTests --disable-default-traits`
- [x] `swift test --filter BaseChatAppIntentsTests --disable-default-traits`
- [x] Sabotage check: stripping the requirement filter in `selectBackend` causes 5 router tests to fail; reverted.

Closes #438
Closes #439
Tracking: #753

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review pass (product engineer)

Reviewed end to end against the umbrella's PR-D scope and the product-engineer lens (API ergonomics, failure-mode quality, discoverability, naming, test depth, release-note clarity).

**Findings — no code changes.** The implementation is honest:

- `GenerationCapabilityRequirement` cases map 1:1 onto existing `BackendCapabilities` flags; no parallel system. The parameterised `.minContextTokens(Int)` case is the only one that doesn't reduce to a flag, and that's the right shape — context size is a quantitative requirement, not a flag.
- `RouterBackend.selectBackend(for:)` is exposed publicly so a host can do a dry-run check before calling `generate`, not just discover via thrown error mid-stream.
- `loadModel` deliberately rejects with a clear `inferenceFailure` message — matches the doc-comment's stance that model selection is the host's job.
- `BackendCapabilities` union semantics are documented at the type level (per-flag OR; numeric maxima taken; `requiresPromptTemplate` deliberately false-beats-true).
- `noBackendSatisfiesRequirements` payload computes the *unsatisfied* set across all children, not just a copy of the request — gives the host enough to render a fix-it message. Falls back to the full requirement list only when the failure is partial-coverage (every child fails some, no single requirement fails everywhere) — guards against an empty diagnostic.
- Codable backwards-compat is real: the `older payload decodes to empty set` test reconstructs a legacy payload by stripping the field from a serialised default, not just asserting the default.
- Tests cover the satisfiable-across-children-but-no-single-child guard — the right product contract for a router that does *not* split a single request.

**Open questions (not blockers):**

- `noBackendSatisfiesRequirements`'s error description prints requirements via `String(describing:)` which renders enum cases like `minContextTokens(1000)`. Readable for a developer log, ugly for an end-user surface. If a future host wants to render this in UI, a `humanDescription` helper on `GenerationCapabilityRequirement` would help — left out of scope here.
- Demo coverage: `Example/` does not yet show a router wiring. Could be a follow-up if the maintainer wants a "small local + remote fallback" scenario in the demo picker.

