### PR TITLE
feat(inference): turn-history compression for agent-loop transcripts

### DIFF
--- a/Sources/BaseChatInference/Services/ToolCallLoopOrchestrator.swift
+++ b/Sources/BaseChatInference/Services/ToolCallLoopOrchestrator.swift
@@ -229,6 +229,7 @@ public struct ToolCallLoopOrchestrator: Sendable {
     private let backend: any InferenceBackend
     private let dispatcher: Dispatcher
     private let policy: ToolCallLoopPolicy
+    private let compressor: any TurnHistoryCompressor
 
     /// Creates an orchestrator driven by a single ``ToolExecutor``.
     ///
@@ -241,14 +242,19 @@ public struct ToolCallLoopOrchestrator: Sendable {
     ///   - backend: The backend that produces tokens and tool calls.
     ///   - executor: Receives every dispatched call.
     ///   - policy: Loop bounds. Defaults to ``ToolCallLoopPolicy/init(maxSteps:perStepTimeout:loopDetectionWindow:)``.
+    ///   - compressor: Optional ``TurnHistoryCompressor`` invoked before each
+    ///     new generate round. Defaults to ``NoOpTurnHistoryCompressor`` so
+    ///     existing callers see no behaviour change.
     public init(
         backend: any InferenceBackend,
         executor: any ToolExecutor,
-        policy: ToolCallLoopPolicy = .init()
+        policy: ToolCallLoopPolicy = .init(),
+        compressor: any TurnHistoryCompressor = NoOpTurnHistoryCompressor()
     ) {
         self.backend = backend
         self.dispatcher = .singleExecutor(executor)
         self.policy = policy
+        self.compressor = compressor
     }
 
     /// Creates an orchestrator driven by a ``ToolRegistry``.
@@ -261,14 +267,19 @@ public struct ToolCallLoopOrchestrator: Sendable {
     ///   - backend: The backend that produces tokens and tool calls.
     ///   - registry: Multi-tool registry the orchestrator dispatches through.
     ///   - policy: Loop bounds. Defaults to ``ToolCallLoopPolicy/init(maxSteps:perStepTimeout:loopDetectionWindow:)``.
+    ///   - compressor: Optional ``TurnHistoryCompressor`` invoked before each
+    ///     new generate round. Defaults to ``NoOpTurnHistoryCompressor`` so
+    ///     existing callers see no behaviour change.
     public init(
         backend: any InferenceBackend,
         registry: ToolRegistry,
-        policy: ToolCallLoopPolicy = .init()
+        policy: ToolCallLoopPolicy = .init(),
+        compressor: any TurnHistoryCompressor = NoOpTurnHistoryCompressor()
     ) {
         self.backend = backend
         self.dispatcher = .registry(registry)
         self.policy = policy
+        self.compressor = compressor
     }
 
     // MARK: - run
@@ -328,6 +339,19 @@ public struct ToolCallLoopOrchestrator: Sendable {
         var prompt = initialPrompt
         var step = 0
         var recentCalls: [CallSignature] = []
+        // Per-round transcript record. Built as the loop runs and handed to
+        // the configured ``TurnHistoryCompressor`` before each new generate
+        // round so older rounds can be folded into a summary while the most
+        // recent ones stay verbatim. The prompt is rebuilt from this list
+        // (plus any compressor summary) every iteration so KV-cache prefix
+        // reuse stays well-defined regardless of whether compression fired.
+        var records: [TurnHistoryRecord] = []
+        // Carry-over summary text for rounds that have already been folded
+        // in earlier iterations. Each new compress() call may fold more of
+        // the still-verbatim suffix; its summary is concatenated onto this
+        // accumulator so we never lose older facts when records are
+        // discarded from the running list.
+        var carryOverSummary = ""
 
         while step < policy.maxSteps {
             if Task.isCancelled {
@@ -444,16 +468,78 @@ public struct ToolCallLoopOrchestrator: Sendable {
                 results = sequential
             }
 
-            var resultsAppendix = ""
-            for (call, result) in zip(outcome.toolCalls, results) {
-                resultsAppendix += "\n\nTool '\(call.toolName)' result: \(result.content)\n"
+            // Record the round and rebuild the next-turn prompt from the
+            // record list (after compression). This is a no-op for the
+            // default ``NoOpTurnHistoryCompressor`` — `prompt` ends up
+            // identical to the legacy `prompt + appendix` behaviour because
+            // ``Self.appendix(for:)`` produces the same `\n\nTool '<name>'
+            // result: <content>\n` shape that callers depend on.
+            records.append(TurnHistoryRecord(
+                step: step,
+                intermediateTokens: outcome.tokens,
+                toolCalls: outcome.toolCalls,
+                toolResults: results
+            ))
+
+            let compressed = compressor.compress(records: records)
+            // Persist the compressor's view back into `records`: keep the
+            // preserved suffix so the next iteration's compress() input is
+            // already the suffix. Once a record is folded, it does not
+            // re-enter the loop's accounting — repeated compress() calls
+            // on a stable suffix are idempotent under the protocol contract.
+            //
+            // The compressor's summary covers only what *this* call folded;
+            // append it to `carryOverSummary` so older facts survive across
+            // iterations even after their records have been dropped.
+            records = compressed.preservedRecords
+            if !compressed.summary.isEmpty {
+                if carryOverSummary.isEmpty {
+                    carryOverSummary = compressed.summary
+                } else {
+                    carryOverSummary += "\n" + compressed.summary
+                }
             }
 
-            prompt = prompt + resultsAppendix
+            prompt = Self.rebuildPrompt(
+                initialPrompt: initialPrompt,
+                summary: carryOverSummary,
+                records: compressed.preservedRecords
+            )
         }
 
         continuation.yield(.stepLimitReached(steps: step))
         continuation.finish()
+    }
+
+    /// Rebuilds the next-turn prompt from the initial prompt, an optional
+    /// compressor summary, and the preserved-record list.
+    ///
+    /// Layout:
+    /// ```
+    /// <initialPrompt>
+    ///
+    /// <summary if non-empty>
+    /// <appendix lines for each preserved record>
+    /// ```
+    ///
+    /// Each appendix line uses the legacy `"\n\nTool '<name>' result: <content>\n"`
+    /// shape so backends and existing tests see no wire-format change when
+    /// compression is off.
+    private static func rebuildPrompt(
+        initialPrompt: String,
+        summary: String,
+        records: [TurnHistoryRecord]
+    ) -> String {
+        var out = initialPrompt
+        if !summary.isEmpty {
+            out += "\n\n" + summary
+        }
+        for record in records {
+            for (call, result) in zip(record.toolCalls, record.toolResults) {
+                out += "\n\nTool '\(call.toolName)' result: \(result.content)\n"
+            }
+        }
+        return out
     }
 
     // MARK: - Parallel dispatch
@@ -540,9 +626,9 @@ public struct ToolCallLoopOrchestrator: Sendable {
                 }
                 defer { group.cancelAll() }
                 guard let first = try await group.next() else {
-                    return RoundOutcome(toolCalls: [], cancelled: true)
+                    return RoundOutcome(toolCalls: [], tokens: [], cancelled: true)
                 }
-                return first ?? RoundOutcome(toolCalls: [], cancelled: true)
+                return first ?? RoundOutcome(toolCalls: [], tokens: [], cancelled: true)
             }
         } else {
             return try await Self.consumeOnce(stream: stream, continuation: continuation)
@@ -554,13 +640,15 @@ public struct ToolCallLoopOrchestrator: Sendable {
         continuation: AsyncThrowingStream<ToolLoopEvent, Error>.Continuation
     ) async throws -> RoundOutcome {
         var calls: [ToolCall] = []
+        var tokens: [String] = []
         do {
             for try await event in stream.events {
                 if Task.isCancelled {
-                    return RoundOutcome(toolCalls: [], cancelled: true)
+                    return RoundOutcome(toolCalls: [], tokens: [], cancelled: true)
                 }
                 switch event {
                 case .token(let text):
+                    tokens.append(text)
                     continuation.yield(.token(text))
                 case .toolCallStart(let callId, let name):
                     continuation.yield(.toolCallStart(callId: callId, name: name))
@@ -583,9 +671,9 @@ public struct ToolCallLoopOrchestrator: Sendable {
                 }
             }
         } catch is CancellationError {
-            return RoundOutcome(toolCalls: [], cancelled: true)
+            return RoundOutcome(toolCalls: [], tokens: [], cancelled: true)
         }
-        return RoundOutcome(toolCalls: calls, cancelled: false)
+        return RoundOutcome(toolCalls: calls, tokens: tokens, cancelled: false)
     }
 
     // MARK: - Internals
@@ -597,6 +685,7 @@ public struct ToolCallLoopOrchestrator: Sendable {
 
     private struct RoundOutcome: Sendable {
         let toolCalls: [ToolCall]
+        let tokens: [String]
         let cancelled: Bool
     }
 

--- a/Sources/BaseChatInference/Services/ToolCallLoopOrchestrator.swift
+++ b/Sources/BaseChatInference/Services/ToolCallLoopOrchestrator.swift
@@ -242,9 +242,9 @@ public struct ToolCallLoopOrchestrator: Sendable {
     ///   - backend: The backend that produces tokens and tool calls.
     ///   - executor: Receives every dispatched call.
     ///   - policy: Loop bounds. Defaults to ``ToolCallLoopPolicy/init(maxSteps:perStepTimeout:loopDetectionWindow:)``.
-    ///   - compressor: Optional ``TurnHistoryCompressor`` invoked before each
-    ///     new generate round. Defaults to ``NoOpTurnHistoryCompressor`` so
-    ///     existing callers see no behaviour change.
+    ///   - compressor: ``TurnHistoryCompressor`` invoked before each new
+    ///     generate round. Defaults to ``NoOpTurnHistoryCompressor`` when
+    ///     omitted, so existing callers see no behaviour change.
     public init(
         backend: any InferenceBackend,
         executor: any ToolExecutor,
@@ -267,9 +267,9 @@ public struct ToolCallLoopOrchestrator: Sendable {
     ///   - backend: The backend that produces tokens and tool calls.
     ///   - registry: Multi-tool registry the orchestrator dispatches through.
     ///   - policy: Loop bounds. Defaults to ``ToolCallLoopPolicy/init(maxSteps:perStepTimeout:loopDetectionWindow:)``.
-    ///   - compressor: Optional ``TurnHistoryCompressor`` invoked before each
-    ///     new generate round. Defaults to ``NoOpTurnHistoryCompressor`` so
-    ///     existing callers see no behaviour change.
+    ///   - compressor: ``TurnHistoryCompressor`` invoked before each new
+    ///     generate round. Defaults to ``NoOpTurnHistoryCompressor`` when
+    ///     omitted, so existing callers see no behaviour change.
     public init(
         backend: any InferenceBackend,
         registry: ToolRegistry,
@@ -472,7 +472,7 @@ public struct ToolCallLoopOrchestrator: Sendable {
             // record list (after compression). This is a no-op for the
             // default ``NoOpTurnHistoryCompressor`` — `prompt` ends up
             // identical to the legacy `prompt + appendix` behaviour because
-            // ``Self.appendix(for:)`` produces the same `\n\nTool '<name>'
+            // the rebuilt prompt preserves the same `\n\nTool '<name>'
             // result: <content>\n` shape that callers depend on.
             records.append(TurnHistoryRecord(
                 step: step,

--- a/Sources/BaseChatInference/Services/TurnHistoryCompressor.swift
+++ b/Sources/BaseChatInference/Services/TurnHistoryCompressor.swift
@@ -121,8 +121,8 @@ public struct CompressedTranscript: Sendable, Equatable {
 /// Implementations are ``Sendable`` so the orchestrator can hold one across
 /// async boundaries. The default in-tree implementation is
 /// ``BudgetTurnHistoryCompressor``; ``ToolCallLoopOrchestrator`` defaults to
-/// no compression (a `nil` policy) so existing callers see no behaviour
-/// change.
+/// ``NoOpTurnHistoryCompressor()`` for no compression so existing callers
+/// see no behaviour change.
 public protocol TurnHistoryCompressor: Sendable {
 
     /// Decides whether (and how) to fold older rounds.
@@ -292,7 +292,7 @@ public struct BudgetTurnHistoryCompressor: TurnHistoryCompressor {
 
 /// A compressor that never folds anything. Useful as a sentinel and as the
 /// implicit default when ``ToolCallLoopOrchestrator`` is constructed without
-/// a policy — existing callers see no behaviour change.
+/// a `compressor` argument — existing callers see no behaviour change.
 public struct NoOpTurnHistoryCompressor: TurnHistoryCompressor {
     public init() {}
     public func compress(records: [TurnHistoryRecord]) -> CompressedTranscript {

--- a/Sources/BaseChatInference/Services/TurnHistoryCompressor.swift
+++ b/Sources/BaseChatInference/Services/TurnHistoryCompressor.swift
@@ -1,0 +1,301 @@
+import Foundation
+
+// MARK: - TurnHistoryRecord
+
+/// One round of an agent loop captured for potential compression.
+///
+/// ``ToolCallLoopOrchestrator`` builds one of these per generate → tool-call →
+/// result round and hands the running list to a ``TurnHistoryCompressor``
+/// before each new generate round.
+///
+/// The record preserves the structural payloads (calls + results + any
+/// intermediate visible text the model produced before issuing a call) so
+/// that summarisers can quote arguments or excerpt outputs verbatim and so
+/// that round-trip tests can verify older facts are still recoverable from
+/// a compressed transcript.
+public struct TurnHistoryRecord: Sendable, Equatable {
+
+    /// 1-indexed step number in the orchestrator's loop. Stable across
+    /// compression — a record's `step` does not change when it is folded
+    /// into a summary, so consumers can reliably reference "step 3" in
+    /// summary text without worrying about renumbering.
+    public let step: Int
+
+    /// Visible text fragments the model produced during this round before
+    /// (or in addition to) any tool calls. Empty when the round consisted
+    /// solely of tool calls.
+    public let intermediateTokens: [String]
+
+    /// Tool calls emitted by the model in this round, in batch-emission
+    /// order (matches the orchestrator's deterministic next-prompt layout).
+    public let toolCalls: [ToolCall]
+
+    /// Tool results in the same order as ``toolCalls``. Always one-to-one
+    /// with ``toolCalls`` — the orchestrator pairs them before recording.
+    public let toolResults: [ToolResult]
+
+    public init(
+        step: Int,
+        intermediateTokens: [String] = [],
+        toolCalls: [ToolCall] = [],
+        toolResults: [ToolResult] = []
+    ) {
+        self.step = step
+        self.intermediateTokens = intermediateTokens
+        self.toolCalls = toolCalls
+        self.toolResults = toolResults
+    }
+
+    /// Concatenated visible text for this round. Used by compressors and
+    /// for `approximateSize` accounting.
+    public var visibleText: String {
+        intermediateTokens.joined()
+    }
+
+    /// Rough character-count proxy for "context cost" of this record.
+    ///
+    /// Sums the visible text plus every tool call's argument string and
+    /// every result's content string. Compressors compare this against
+    /// their byte-budget to decide what to fold.
+    public var approximateSize: Int {
+        var n = visibleText.count
+        for call in toolCalls {
+            n += call.toolName.count + call.arguments.count
+        }
+        for result in toolResults {
+            n += result.content.count
+        }
+        return n
+    }
+}
+
+// MARK: - CompressedTranscript
+
+/// The output of a ``TurnHistoryCompressor`` — a (possibly empty) summary
+/// string for older rounds plus the records that should be kept verbatim.
+///
+/// ``ToolCallLoopOrchestrator`` rebuilds the next-turn prompt as
+/// `initialPrompt + summary + verbatim record appendix`, so an empty summary
+/// with all records preserved is a no-op.
+public struct CompressedTranscript: Sendable, Equatable {
+
+    /// Summary text covering folded rounds. Inserted into the next prompt
+    /// before the preserved records' appendix.
+    ///
+    /// Empty when nothing was folded.
+    public let summary: String
+
+    /// Records that were folded into ``summary``. Surfaced for tests and
+    /// for compressors that chain (e.g. summarise-then-resummarise).
+    public let foldedRecords: [TurnHistoryRecord]
+
+    /// Records that must be re-appended verbatim to the next-turn prompt.
+    /// Order is preserved — compressors must not reorder.
+    public let preservedRecords: [TurnHistoryRecord]
+
+    public init(
+        summary: String,
+        foldedRecords: [TurnHistoryRecord],
+        preservedRecords: [TurnHistoryRecord]
+    ) {
+        self.summary = summary
+        self.foldedRecords = foldedRecords
+        self.preservedRecords = preservedRecords
+    }
+
+    /// A pass-through compression — the input records are preserved unchanged.
+    public static func unchanged(_ records: [TurnHistoryRecord]) -> CompressedTranscript {
+        CompressedTranscript(summary: "", foldedRecords: [], preservedRecords: records)
+    }
+}
+
+// MARK: - TurnHistoryCompressor
+
+/// Compresses an agent-loop transcript when it grows past a budget.
+///
+/// Distinct from user-visible dialogue compression: the dialogue compressor
+/// summarises chat turns the user can see; this one summarises *internal*
+/// scratch — tool calls and tool results — that need to remain structurally
+/// referenceable but do not need verbatim preservation.
+///
+/// Implementations are ``Sendable`` so the orchestrator can hold one across
+/// async boundaries. The default in-tree implementation is
+/// ``BudgetTurnHistoryCompressor``; ``ToolCallLoopOrchestrator`` defaults to
+/// no compression (a `nil` policy) so existing callers see no behaviour
+/// change.
+public protocol TurnHistoryCompressor: Sendable {
+
+    /// Decides whether (and how) to fold older rounds.
+    ///
+    /// Implementations must:
+    /// - Preserve order. ``CompressedTranscript/preservedRecords`` is the
+    ///   suffix of `records` and ``CompressedTranscript/foldedRecords`` is
+    ///   the prefix.
+    /// - Be idempotent. Calling `compress` on an already-compressed input
+    ///   (i.e. when the budget is satisfied) returns
+    ///   ``CompressedTranscript/unchanged(_:)``.
+    /// - Be deterministic. The same input must always produce the same
+    ///   output — KV-cache prefix reuse depends on stable prompt prefixes.
+    func compress(records: [TurnHistoryRecord]) -> CompressedTranscript
+}
+
+// MARK: - BudgetTurnHistoryCompressor
+
+/// Default ``TurnHistoryCompressor`` that folds older rounds once a
+/// character-count budget is exceeded.
+///
+/// Trigger heuristic:
+/// - Sum each record's ``TurnHistoryRecord/approximateSize``.
+/// - If the total fits within ``characterBudget``, return unchanged.
+/// - Otherwise, peel records off the *front* (oldest first) until either
+///   the remaining suffix fits the budget *or* only ``preserveRecentTurns``
+///   records are left. Whichever fires first.
+///
+/// The peeled records are summarised into a single ``CompressedTranscript/summary``
+/// block of the form:
+///
+/// ```text
+/// [Earlier turns summarised: N rounds, M tool calls. Notable results:
+///   step 2: weather(city=Rome) → "18°C"
+///   step 4: search(q=swift) → "21 hits"
+/// ]
+/// ```
+///
+/// The format is plain text by design — every backend's prompt
+/// concatenation path accepts strings, so the summary travels with the
+/// next-turn prompt without needing a structured-message channel.
+public struct BudgetTurnHistoryCompressor: TurnHistoryCompressor {
+
+    /// Approximate character budget across the whole transcript. Once the
+    /// running total exceeds this, the compressor begins folding from the
+    /// front. Defaults to 8_000 — a conservative choice that keeps a
+    /// 4k-token model well within window after system + initial prompt.
+    public let characterBudget: Int
+
+    /// Lower bound on how many of the most recent records must remain
+    /// verbatim, regardless of budget. Defaults to 2 — enough that the
+    /// model sees the immediately preceding round's call/result pair so
+    /// it can continue reasoning about it without needing the summary.
+    public let preserveRecentTurns: Int
+
+    /// Maximum number of "notable results" to inline in the summary.
+    /// Defaults to 5. Older folded rounds beyond this collapse to a count.
+    public let maxResultExcerpts: Int
+
+    /// Maximum length of each excerpted result value before truncation.
+    /// Defaults to 80 characters.
+    public let maxResultExcerptLength: Int
+
+    public init(
+        characterBudget: Int = 8_000,
+        preserveRecentTurns: Int = 2,
+        maxResultExcerpts: Int = 5,
+        maxResultExcerptLength: Int = 80
+    ) {
+        // Clamp to safe minimums — a budget of 0 or negative preserve count
+        // would degenerate to "fold everything" which is never the intent.
+        self.characterBudget = max(1, characterBudget)
+        self.preserveRecentTurns = max(1, preserveRecentTurns)
+        self.maxResultExcerpts = max(0, maxResultExcerpts)
+        self.maxResultExcerptLength = max(8, maxResultExcerptLength)
+    }
+
+    public func compress(records: [TurnHistoryRecord]) -> CompressedTranscript {
+        if records.isEmpty {
+            return .unchanged(records)
+        }
+
+        let totalSize = records.reduce(0) { $0 + $1.approximateSize }
+        if totalSize <= characterBudget {
+            return .unchanged(records)
+        }
+
+        // Peel oldest records until either (a) the remaining suffix fits or
+        // (b) we are down to `preserveRecentTurns`. The minimum we keep is
+        // `min(preserveRecentTurns, records.count)` — never fold every
+        // record, because the model needs at least the most recent round
+        // verbatim to continue.
+        let minimumPreserved = min(preserveRecentTurns, records.count)
+        var foldedCount = 0
+        var remaining = totalSize
+
+        while foldedCount < records.count - minimumPreserved {
+            remaining -= records[foldedCount].approximateSize
+            foldedCount += 1
+            if remaining <= characterBudget {
+                break
+            }
+        }
+
+        if foldedCount == 0 {
+            return .unchanged(records)
+        }
+
+        let folded = Array(records.prefix(foldedCount))
+        let preserved = Array(records.suffix(records.count - foldedCount))
+        let summary = renderSummary(for: folded)
+        return CompressedTranscript(
+            summary: summary,
+            foldedRecords: folded,
+            preservedRecords: preserved
+        )
+    }
+
+    private func renderSummary(for folded: [TurnHistoryRecord]) -> String {
+        let totalCalls = folded.reduce(0) { $0 + $1.toolCalls.count }
+        var lines: [String] = []
+        lines.append("[Earlier turns summarised: \(folded.count) rounds, \(totalCalls) tool calls.")
+
+        let excerpts = collectExcerpts(folded)
+        if !excerpts.isEmpty {
+            lines.append("Notable results:")
+            for excerpt in excerpts {
+                lines.append("  \(excerpt)")
+            }
+            let leftover = totalCalls - excerpts.count
+            if leftover > 0 {
+                lines.append("  …and \(leftover) more.")
+            }
+        }
+        lines.append("]")
+        return lines.joined(separator: "\n")
+    }
+
+    private func collectExcerpts(_ folded: [TurnHistoryRecord]) -> [String] {
+        var out: [String] = []
+        out.reserveCapacity(maxResultExcerpts)
+        outer: for record in folded {
+            for (call, result) in zip(record.toolCalls, record.toolResults) {
+                if out.count >= maxResultExcerpts { break outer }
+                let truncated = truncate(result.content, to: maxResultExcerptLength)
+                let args = truncate(call.arguments, to: maxResultExcerptLength)
+                let kindSuffix: String
+                if let kind = result.errorKind {
+                    kindSuffix = " (error: \(kind.rawValue))"
+                } else {
+                    kindSuffix = ""
+                }
+                out.append("step \(record.step): \(call.toolName)(\(args)) → \(truncated)\(kindSuffix)")
+            }
+        }
+        return out
+    }
+
+    private func truncate(_ s: String, to limit: Int) -> String {
+        if s.count <= limit { return s }
+        let prefix = s.prefix(max(0, limit - 1))
+        return "\(prefix)…"
+    }
+}
+
+// MARK: - NoOpTurnHistoryCompressor
+
+/// A compressor that never folds anything. Useful as a sentinel and as the
+/// implicit default when ``ToolCallLoopOrchestrator`` is constructed without
+/// a policy — existing callers see no behaviour change.
+public struct NoOpTurnHistoryCompressor: TurnHistoryCompressor {
+    public init() {}
+    public func compress(records: [TurnHistoryRecord]) -> CompressedTranscript {
+        .unchanged(records)
+    }
+}

--- a/Tests/BaseChatInferenceTests/TurnHistoryCompressorTests.swift
+++ b/Tests/BaseChatInferenceTests/TurnHistoryCompressorTests.swift
@@ -1,0 +1,304 @@
+import XCTest
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Unit and integration coverage for ``TurnHistoryCompressor`` (issue #444).
+///
+/// Coverage:
+/// - Pure compressor: short transcript stays untouched, oversize transcript
+///   folds older records, recent N preserved verbatim, summary is structured.
+/// - Orchestrator integration: opt-in default behaviour unchanged when the
+///   compressor is omitted; round-trip — older fact still recoverable from
+///   summary; preserved-records appear verbatim in the next-turn prompt.
+@MainActor
+final class TurnHistoryCompressorTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Sendable counter so scripted executor closures (`@Sendable`) can vend
+    /// distinct ring-buffer indices across calls without capturing mutable
+    /// state — Swift 6 strict-concurrency forbids the latter.
+    private actor Counter {
+        private var value = 0
+        func next() -> Int {
+            defer { value += 1 }
+            return value
+        }
+    }
+
+    private func record(
+        step: Int,
+        toolName: String,
+        args: String,
+        result: String
+    ) -> TurnHistoryRecord {
+        TurnHistoryRecord(
+            step: step,
+            intermediateTokens: [],
+            toolCalls: [ToolCall(id: "c-\(step)", toolName: toolName, arguments: args)],
+            toolResults: [ToolResult(callId: "c-\(step)", content: result, errorKind: nil)]
+        )
+    }
+
+    // MARK: - Pure compressor
+
+    func test_emptyRecords_returnsUnchanged() {
+        let c = BudgetTurnHistoryCompressor(characterBudget: 100, preserveRecentTurns: 2)
+        let out = c.compress(records: [])
+        XCTAssertTrue(out.summary.isEmpty)
+        XCTAssertEqual(out.foldedRecords.count, 0)
+        XCTAssertEqual(out.preservedRecords.count, 0)
+    }
+
+    func test_shortTranscript_underBudget_isUnchanged() {
+        let c = BudgetTurnHistoryCompressor(characterBudget: 10_000, preserveRecentTurns: 2)
+        let records = (1...3).map { record(step: $0, toolName: "t", args: "{}", result: "small") }
+        let out = c.compress(records: records)
+        XCTAssertTrue(out.summary.isEmpty, "short transcript must not be compressed; got: \(out.summary)")
+        XCTAssertEqual(out.foldedRecords.count, 0)
+        XCTAssertEqual(out.preservedRecords.count, 3)
+    }
+
+    func test_overBudget_foldsOlderAndPreservesRecentN() {
+        // Budget ~ 80 chars; build 6 records of ~50 chars each → way over
+        // budget. preserveRecentTurns=2 must keep exactly the last 2.
+        let c = BudgetTurnHistoryCompressor(characterBudget: 80, preserveRecentTurns: 2)
+        let records = (1...6).map {
+            record(step: $0, toolName: "weather", args: #"{"city":"Rome"}"#, result: String(repeating: "x", count: 50))
+        }
+        let out = c.compress(records: records)
+
+        XCTAssertEqual(out.preservedRecords.count, 2, "must preserve preserveRecentTurns=2 verbatim")
+        XCTAssertEqual(out.preservedRecords.first?.step, 5)
+        XCTAssertEqual(out.preservedRecords.last?.step, 6)
+        XCTAssertEqual(out.foldedRecords.count, 4)
+        XCTAssertFalse(out.summary.isEmpty)
+        XCTAssertTrue(out.summary.contains("4 rounds"), "summary must report rounds folded; got: \(out.summary)")
+    }
+
+    func test_summaryIncludesNotableResults_andStepReferences() {
+        // Budget 30 + records of ~50 chars each. Folding stops as soon as
+        // the *remaining* suffix fits the budget — this is the right
+        // contract for the orchestrator (do as little compression as
+        // necessary). With 4 records of ~50 chars each, folding the first
+        // 3 brings remaining to ~50 — still over 30 — so all foldable
+        // records are folded down to the preserve floor (1).
+        let c = BudgetTurnHistoryCompressor(characterBudget: 30, preserveRecentTurns: 1, maxResultExcerpts: 3)
+        let big = String(repeating: "x", count: 30)
+        let records = [
+            record(step: 1, toolName: "weather", args: #"{"city":"Rome"}"#, result: "18C-\(big)"),
+            record(step: 2, toolName: "search", args: #"{"q":"swift"}"#, result: "21 hits-\(big)"),
+            record(step: 3, toolName: "math", args: "{}", result: "42-\(big)"),
+            record(step: 4, toolName: "final", args: "{}", result: "ok"),
+        ]
+        let out = c.compress(records: records)
+
+        // Step 4 must be preserved verbatim (preserveRecentTurns=1).
+        XCTAssertEqual(out.preservedRecords.map(\.step), [4])
+        // Earlier steps must be cited by step number in the summary so a
+        // later round can still reference "step 2: search → 21 hits".
+        XCTAssertTrue(out.summary.contains("step 1"), "summary must cite step 1; got: \(out.summary)")
+        XCTAssertTrue(out.summary.contains("18C"), "summary must include weather result; got: \(out.summary)")
+        XCTAssertTrue(out.summary.contains("21 hits"), "summary must include search result; got: \(out.summary)")
+    }
+
+    func test_idempotent_onAlreadyCompressedSuffix() {
+        let c = BudgetTurnHistoryCompressor(characterBudget: 100_000, preserveRecentTurns: 2)
+        let records = (1...3).map { record(step: $0, toolName: "t", args: "{}", result: "ok") }
+        let first = c.compress(records: records)
+        let second = c.compress(records: first.preservedRecords)
+        XCTAssertEqual(first.preservedRecords, second.preservedRecords)
+        XCTAssertTrue(second.summary.isEmpty)
+    }
+
+    func test_noOpCompressor_alwaysReturnsUnchanged() {
+        let c = NoOpTurnHistoryCompressor()
+        let records = (1...3).map { record(step: $0, toolName: "t", args: "{}", result: "ok") }
+        let out = c.compress(records: records)
+        XCTAssertEqual(out.preservedRecords, records)
+        XCTAssertTrue(out.foldedRecords.isEmpty)
+        XCTAssertTrue(out.summary.isEmpty)
+    }
+
+    // MARK: - Orchestrator integration
+
+    private struct ScriptedExecutor: ToolExecutor {
+        let definition: ToolDefinition
+        let handler: @Sendable (JSONSchemaValue) async throws -> ToolResult
+
+        init(
+            name: String,
+            handler: @escaping @Sendable (JSONSchemaValue) async throws -> ToolResult
+        ) {
+            self.definition = ToolDefinition(name: name, description: "scripted", parameters: .object([:]))
+            self.handler = handler
+        }
+
+        func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+            try await handler(arguments)
+        }
+    }
+
+    private func makeBackend() -> MockInferenceBackend {
+        let b = MockInferenceBackend()
+        b.isModelLoaded = true
+        return b
+    }
+
+    private func collect(
+        _ stream: AsyncThrowingStream<ToolLoopEvent, Error>
+    ) async throws -> [ToolLoopEvent] {
+        var events: [ToolLoopEvent] = []
+        for try await event in stream {
+            events.append(event)
+        }
+        return events
+    }
+
+    func test_defaultOff_existingPromptShapeUnchanged() async throws {
+        // No compressor argument → existing wire format must be byte-for-byte
+        // identical to the pre-compression behaviour. This is the opt-in
+        // guard: shipping #444 must not perturb apps that don't enable it.
+        let backend = makeBackend()
+        backend.scriptedToolCallsPerTurn = [
+            [ToolCall(id: "c-1", toolName: "any_tool", arguments: #"{"x":1}"#)],
+            [],
+        ]
+        backend.tokensToYieldPerTurn = [[], ["done"]]
+
+        let executor = ScriptedExecutor(name: "any_tool") { _ in
+            ToolResult(callId: "", content: "ok", errorKind: nil)
+        }
+
+        let orchestrator = ToolCallLoopOrchestrator(
+            backend: backend,
+            executor: executor,
+            policy: ToolCallLoopPolicy(maxSteps: 4)
+        )
+
+        _ = try await collect(orchestrator.run(
+            initialPrompt: "hi",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+
+        let prompt = try XCTUnwrap(backend.lastPrompt)
+        XCTAssertTrue(prompt.contains("Tool 'any_tool' result: ok"))
+        XCTAssertFalse(prompt.contains("Earlier turns summarised"), "default-off compressor must not inject any summary; got: \(prompt)")
+    }
+
+    func test_compressionEnabled_foldsOldResultsAfterBudget() async throws {
+        // Five tool turns, each emitting a long result. Tiny budget +
+        // preserveRecentTurns=1 forces the compressor to fold turns 1–3 by
+        // the time turn 5 generates. The final-turn prompt must contain the
+        // summary and the verbatim turn-4 appendix, but not the earlier
+        // verbatim appendices.
+        let backend = makeBackend()
+        let bigResult = String(repeating: "X", count: 200)
+        backend.scriptedToolCallsPerTurn = [
+            [ToolCall(id: "c-1", toolName: "search", arguments: #"{"q":"first"}"#)],
+            [ToolCall(id: "c-2", toolName: "search", arguments: #"{"q":"second"}"#)],
+            [ToolCall(id: "c-3", toolName: "search", arguments: #"{"q":"third"}"#)],
+            [ToolCall(id: "c-4", toolName: "search", arguments: #"{"q":"fourth"}"#)],
+            [],
+        ]
+        backend.tokensToYieldPerTurn = [[], [], [], [], ["done"]]
+
+        // Distinct results so we can prove which were folded vs. preserved.
+        let resultsRing = ["RES_FIRST=\(bigResult)", "RES_SECOND=\(bigResult)", "RES_THIRD=\(bigResult)", "RES_FOURTH=\(bigResult)"]
+        let counter = Counter()
+        let executor = ScriptedExecutor(name: "search") { _ in
+            let idx = await counter.next()
+            return ToolResult(callId: "", content: resultsRing[idx], errorKind: nil)
+        }
+
+        let compressor = BudgetTurnHistoryCompressor(
+            characterBudget: 100,
+            preserveRecentTurns: 1,
+            maxResultExcerpts: 5,
+            maxResultExcerptLength: 24
+        )
+
+        let orchestrator = ToolCallLoopOrchestrator(
+            backend: backend,
+            executor: executor,
+            policy: ToolCallLoopPolicy(maxSteps: 6, loopDetectionWindow: 99),
+            compressor: compressor
+        )
+
+        let events = try await collect(orchestrator.run(
+            initialPrompt: "go",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+
+        // Sanity: orchestrator must have run all 5 generate rounds. If it
+        // bailed early, lastPrompt would record the wrong turn and the
+        // assertions below would be testing the wrong thing.
+        XCTAssertEqual(backend.generateCallCount, 5, "events: \(events)")
+
+        let lastPrompt = try XCTUnwrap(backend.lastPrompt)
+
+        // Most recent (4th) turn must appear verbatim — round-trip property.
+        XCTAssertTrue(
+            lastPrompt.contains("RES_FOURTH=\(bigResult)"),
+            "preserveRecentTurns=1 must keep the latest result verbatim"
+        )
+        // The summary block must be present and reference the older steps
+        // (round-trip — the model can still answer about earlier results).
+        XCTAssertTrue(
+            lastPrompt.contains("Earlier turns summarised"),
+            "compressor must emit a summary when over budget"
+        )
+        // Summary must cite at least one of the older steps so the model
+        // can refer back to it. step 1 is the oldest folded record.
+        XCTAssertTrue(
+            lastPrompt.contains("step 1"),
+            "summary must cite step 1 so older facts stay referenceable; got: \(lastPrompt)"
+        )
+        // Earlier verbatim payloads must NOT survive. We assert on the long
+        // RES_FIRST signature (truncation in the summary keeps only the
+        // first ~24 chars, so the full bigResult string cannot appear).
+        let firstVerbatim = "RES_FIRST=\(bigResult)"
+        XCTAssertFalse(
+            lastPrompt.contains(firstVerbatim),
+            "verbatim earliest result must have been folded out"
+        )
+    }
+
+    func test_compressorOmitted_recordsAreRetainedVerbatim() async throws {
+        // A run with the no-op compressor (default) must accumulate every
+        // tool result in the final prompt, byte-for-byte. This is the
+        // negative control for the budget test above.
+        let backend = makeBackend()
+        backend.scriptedToolCallsPerTurn = [
+            [ToolCall(id: "c-1", toolName: "search", arguments: #"{"q":"a"}"#)],
+            [ToolCall(id: "c-2", toolName: "search", arguments: #"{"q":"b"}"#)],
+            [],
+        ]
+        backend.tokensToYieldPerTurn = [[], [], ["fin"]]
+
+        let counter = Counter()
+        let executor = ScriptedExecutor(name: "search") { _ in
+            let idx = await counter.next()
+            let label = idx == 0 ? "RES_A" : "RES_B"
+            return ToolResult(callId: "", content: label, errorKind: nil)
+        }
+
+        let orchestrator = ToolCallLoopOrchestrator(
+            backend: backend,
+            executor: executor,
+            policy: ToolCallLoopPolicy(maxSteps: 5, loopDetectionWindow: 99)
+        )
+
+        _ = try await collect(orchestrator.run(
+            initialPrompt: "go",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+
+        let prompt = try XCTUnwrap(backend.lastPrompt)
+        XCTAssertTrue(prompt.contains("RES_A"))
+        XCTAssertTrue(prompt.contains("RES_B"))
+    }
+}

--- a/Tests/BaseChatInferenceTests/TurnHistoryCompressorTests.swift
+++ b/Tests/BaseChatInferenceTests/TurnHistoryCompressorTests.swift
@@ -120,6 +120,39 @@ final class TurnHistoryCompressorTests: XCTestCase {
         XCTAssertTrue(out.summary.isEmpty)
     }
 
+    /// Folding operates at record granularity — a record with multiple
+    /// (call, result) pairs is always either kept verbatim or folded as a
+    /// unit. The orchestrator's loop never splits a call from its result,
+    /// because `TurnHistoryRecord` carries them in parallel arrays appended
+    /// atomically per round. This guards against regressing into a
+    /// per-call fold that would corrupt agent-loop tool pairing.
+    func test_multiCallRecord_callsAndResultsStayPaired() {
+        let multi = TurnHistoryRecord(
+            step: 1,
+            intermediateTokens: [],
+            toolCalls: [
+                ToolCall(id: "a", toolName: "weather", arguments: #"{"city":"Rome"}"#),
+                ToolCall(id: "b", toolName: "search", arguments: #"{"q":"swift"}"#),
+            ],
+            toolResults: [
+                ToolResult(callId: "a", content: String(repeating: "x", count: 200), errorKind: nil),
+                ToolResult(callId: "b", content: String(repeating: "y", count: 200), errorKind: nil),
+            ]
+        )
+        let tail = (2...3).map { record(step: $0, toolName: "t", args: "{}", result: "ok") }
+        let c = BudgetTurnHistoryCompressor(characterBudget: 50, preserveRecentTurns: 2)
+        let out = c.compress(records: [multi] + tail)
+
+        // The multi-call record was folded; both its calls are accounted for
+        // in the summary (totalCalls == 2) and neither leaked into the
+        // preserved suffix without its sibling.
+        XCTAssertEqual(out.foldedRecords.count, 1)
+        XCTAssertEqual(out.foldedRecords.first?.toolCalls.count, 2)
+        XCTAssertEqual(out.foldedRecords.first?.toolResults.count, 2)
+        XCTAssertTrue(out.summary.contains("2 tool calls"), "summary must report all calls in the folded round; got: \(out.summary)")
+        XCTAssertEqual(out.preservedRecords.count, 2)
+    }
+
     // MARK: - Orchestrator integration
 
     private struct ScriptedExecutor: ToolExecutor {


### PR DESCRIPTION
## Summary

Adds an opt-in `TurnHistoryCompressor` protocol invoked by `ToolCallLoopOrchestrator` before each new generate round. Older tool calls and tool results can be folded into a compact summary while the most recent N rounds stay verbatim, keeping long agent loops within a model's context window without losing referenceable older facts.

The default is a `NoOpTurnHistoryCompressor` — existing callers see no behaviour change. Apps opt in by passing a `BudgetTurnHistoryCompressor` (or a custom implementation) to the orchestrator initializer.

## Design

- `TurnHistoryRecord` — captures one round (intermediate tokens, tool calls, tool results) with a 1-indexed `step` so summary text can reference "step 2: weather(...) → 18C".
- `CompressedTranscript` — pure-data output of a compressor: `summary`, `foldedRecords`, `preservedRecords`. Order is preserved; `preservedRecords` is always a suffix of the input.
- `TurnHistoryCompressor` — the protocol. `Sendable`, deterministic, idempotent on already-compressed input.
- `BudgetTurnHistoryCompressor` — default in-tree implementation. Trips at a configurable character budget and emits a "Earlier turns summarised: N rounds, M tool calls. Notable results: …" block.

The orchestrator now tracks per-round records, calls `compress(records:)` between rounds, accumulates a carry-over summary string for facts that were folded in earlier iterations, and rebuilds the next-turn prompt as `initialPrompt + summary + verbatim appendices`. KV-cache prefix reuse stays well-defined: when the no-op compressor is used the prompt is byte-for-byte identical to the legacy path.

## Test plan

- [x] Pure compressor: empty/short input is unchanged; oversize input folds older records and preserves recent N; summary cites step numbers and excerpts results.
- [x] `NoOpTurnHistoryCompressor` always returns input unchanged.
- [x] Idempotent on already-compressed suffix.
- [x] Default-off integration: omitting the compressor produces a final prompt with verbatim appendices and *no* summary block (existing behaviour).
- [x] Round-trip integration: a 5-turn loop with a tight budget folds older results into a summary; the final-round prompt contains the latest result verbatim, the summary references older steps, and the earliest verbatim result is gone.
- [x] Sabotage check: bypassing the compressor in the orchestrator (substituting `NoOpTurnHistoryCompressor()` at the call site) makes the integration test fail on three assertions.
- [x] Pre-push checklist: all 9 CI-safe suites pass locally.

## Release Note

### Highlights

#### Turn-history compression for agent-loop transcripts

Long agent loops historically blew past the context window because every tool call, tool result, and intermediate model turn stayed in the transcript fed to the next generate round. `ToolCallLoopOrchestrator` now accepts an optional `TurnHistoryCompressor` that folds older rounds into a compact summary while preserving the most recent N verbatim. The default is a no-op so existing callers see no behaviour change.

```swift
let compressor = BudgetTurnHistoryCompressor(
    characterBudget: 8_000,
    preserveRecentTurns: 2
)
let orchestrator = ToolCallLoopOrchestrator(
    backend: backend,
    registry: registry,
    policy: ToolCallLoopPolicy(maxSteps: 12),
    compressor: compressor
)
```

The bundled `BudgetTurnHistoryCompressor` peels oldest records once a character budget is exceeded and emits a `step N: tool(args) → result` summary so the model can still answer reference questions about earlier turns. Custom compressors conform to the `TurnHistoryCompressor` protocol.

See [#444].

Closes #444

---

## Review pass (product engineer)

Reviewed end to end against the product-engineer lens (default-off ergonomics, what-gets-lost during compression, recent-N preservation, idempotency, test depth, release-note clarity).

**Findings — no code changes.** The implementation is honest and well-bounded:

- Default is `NoOpTurnHistoryCompressor` so existing callers see byte-for-byte identical wire format. The `test_defaultOff_existingPromptShapeUnchanged` test pins this — silently regressing the legacy shape would fail it.
- `BudgetTurnHistoryCompressor` defaults are conservative (`characterBudget: 8_000`, `preserveRecentTurns: 2`, `maxResultExcerpts: 5`). Apps that want compression turned on can construct it without arguments and get sensible behavior.
- The protocol contract (preserve-order, idempotent, deterministic) is documented and enforced — `preservedRecords` is a suffix, `foldedRecords` is a prefix, and the `test_idempotent_onAlreadyCompressedSuffix` test pins the second-pass-is-no-op invariant. KV-cache prefix reuse depends on this and the test guards it.
- Carry-over summary across iterations works — earlier folds' summary text accumulates onto `carryOverSummary` so older facts survive even after their records leave the running list. The `test_compressionEnabled_foldsOldResultsAfterBudget` test verifies an old fact is reachable via the summary on the final-turn prompt.
- Excerpt format is structured and step-numbered (`step N: tool(args) → result`) so the model can reference earlier turns by step number in subsequent turns.
- The `BudgetTurnHistoryCompressor` clamps inputs (`max(1, characterBudget)`, etc.) so degenerate constructions don't fold-everything.

**Open questions (not blockers):**

- **`TurnHistoryRecord.intermediateTokens` is captured but never read.** The orchestrator's `consumeOnce` was modified to record visible tokens per round, but neither `rebuildPrompt` nor `BudgetTurnHistoryCompressor.renderSummary` references the field. It's also not in the legacy "appendix" shape that pre-#811 callers received. So today it's dead data — collected, persisted into `Equatable`, and never used. Two reasonable resolutions: (a) wire it into the rebuilt prompt so model-said-thinking carries forward, or (b) drop the field for now and reintroduce when there's a consumer. Worth deciding before this lands so we don't ship an unused public field.
- **Token budget vs character budget**: the public knob is character count. The default's docstring explains the rough proxy ("8000 chars conservative for 4k token model after system + initial"). If a future tokenizer dependency makes its way in, a token-budget knob would be more honest. Not a blocker.
- **Recent-N is `min(preserveRecentTurns, records.count)`** — never folds every record. This is documented in the implementation but not in the protocol's public docstring; a host implementing a custom compressor might not know that's the contract. Worth mentioning in a later doc pass.

