### PR TITLE
feat(backends): reuse MLX KV cache prefixes across turns

### DIFF
--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -275,6 +275,12 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
     ///    and shrink prompt-only state safely for text-only models.
     /// 3. Future `mlx-swift-lm` bumps must rerun the MLX KV-cache integration and
     ///    performance suite before this contract is trusted unchanged.
+    ///
+    /// Marked `@MainActor` because every MLX call here (`copy()`, `eval`,
+    /// `state` slicing, `trim`) shares the same single-threaded GPU scheduler
+    /// as `ModelContainer.generate()`; running off-main risks racy crashes /
+    /// cache corruption.
+    @MainActor
     private static func capturePromptCacheSnapshot(
         from cache: MLXPromptCache,
         promptTokens: [Int]
@@ -282,10 +288,16 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         guard !promptTokens.isEmpty, isSupportedPromptCache(cache.value) else {
             return nil
         }
+        // Early-exit if the surrounding generation task was cancelled — `copy()`
+        // and `eval` materialise full prompt-prefix tensors per layer, which is
+        // expensive enough to be worth skipping when a reset/unload already
+        // invalidated the snapshot we'd be writing.
+        if Task.isCancelled { return nil }
 
         var layers: [CachedLayerState] = []
         layers.reserveCapacity(cache.value.count)
         for original in cache.value {
+            if Task.isCancelled { return nil }
             guard original.offset >= promptTokens.count else {
                 return nil
             }
@@ -345,6 +357,7 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             if layer.state.isEmpty {
                 guard let target = target as? KVCacheSimple else { return false }
                 target.offset = layer.offset
+                target.metaState = layer.metaState
             } else {
                 target.state = layer.state.map { $0[.ellipsis] }
                 target.metaState = layer.metaState
@@ -799,7 +812,12 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                     self.withStateLock {
                         self._promptCacheWriteToken &+= 1
                         let snapshotWriteToken = self._promptCacheWriteToken
-                        let snapshotTask = Task<Void, Never> { [weak self] in
+                        // The snapshot must capture on `@MainActor`: every MLX
+                        // call inside `capturePromptCacheSnapshot` (copy/eval/
+                        // slicing/trim) shares the single-threaded GPU scheduler
+                        // with `ModelContainer.generate`. Running it on a free
+                        // executor would race the next generation's compute.
+                        let snapshotTask = Task<Void, Never> { @MainActor [weak self] in
                             let snapshot = Self.capturePromptCacheSnapshot(
                                 from: cache,
                                 promptTokens: promptTokenIds

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -19,6 +19,18 @@ import BaseChatInference
 /// Requires real Apple Silicon hardware — does not work in iOS Simulator.
 public final class MLXBackend: InferenceBackend, @unchecked Sendable {
 
+    private struct CachedLayerState {
+        let cacheTypeName: String
+        let offset: Int
+        let state: [MLXArray]
+        let metaState: [String]
+    }
+
+    private struct PromptCacheSnapshot {
+        let promptTokens: [Int]
+        let layers: [CachedLayerState]
+    }
+
     // MARK: - Logging
 
     private static let logger = Logger(
@@ -54,22 +66,7 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
 
     // MARK: - Capabilities
 
-    public let capabilities = BackendCapabilities(
-        supportedParameters: [.temperature, .topP, .repeatPenalty],
-        maxContextTokens: 8192,
-        requiresPromptTemplate: false,
-        supportsSystemPrompt: true,
-        supportsToolCalling: true,
-        supportsStructuredOutput: false,
-        supportsNativeJSONMode: false,
-        cancellationStyle: .cooperative,
-        supportsTokenCounting: true,
-        memoryStrategy: .resident,
-        maxOutputTokens: 4096,
-        supportsStreaming: true,
-        isRemote: false,
-        supportsThinking: true
-    )
+    public let capabilities: BackendCapabilities
 
     // MARK: - Private
 
@@ -94,6 +91,21 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
     /// overrides this — see the generate path below.
     /// Access only under `stateLock`.
     private var _autoDetectedThinkingMarkers: ThinkingMarkers?
+    /// Cached prompt KV state for longest-common-prefix reuse on the next turn.
+    /// Access only under `stateLock`.
+    private var _promptCacheSnapshot: PromptCacheSnapshot?
+    /// Snapshot capture still materializing after the previous turn finished.
+    /// Access only under `stateLock`.
+    private var _pendingPromptCacheSnapshotTask: Task<Void, Never>?
+    /// Monotonic token used to invalidate stale post-finish snapshot writes.
+    /// Access only under `stateLock`.
+    private var _promptCacheWriteToken: UInt64 = 0
+    /// Whether the currently loaded model/config is eligible for prompt-cache reuse.
+    /// Access only under `stateLock`.
+    private var _kvCacheReuseEligible = false
+    /// Tracks whether a real MLX model load initialized the runtime in this process.
+    /// Access only under `stateLock`.
+    private var _hasInitializedRuntime = false
 
     // MARK: - Load Progress
 
@@ -110,6 +122,8 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
     /// Policy controlling MLX's GPU buffer cache size. See `MLXCachePolicy`.
     /// Defaults to `.auto`, which picks a sensible value based on device RAM.
     public let cachePolicy: MLXCachePolicy
+    /// Safe-first rollout flag for prompt KV-cache reuse.
+    public let enableKVCacheReuse: Bool
 
     // MARK: - Test seams
 
@@ -122,8 +136,29 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
 
     // MARK: - Init
 
-    public init(cachePolicy: MLXCachePolicy = .auto) {
+    public init(
+        cachePolicy: MLXCachePolicy = .auto,
+        enableKVCacheReuse: Bool = false
+    ) {
         self.cachePolicy = cachePolicy
+        self.enableKVCacheReuse = enableKVCacheReuse
+        self.capabilities = BackendCapabilities(
+            supportedParameters: [.temperature, .topP, .repeatPenalty],
+            maxContextTokens: 8192,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsToolCalling: true,
+            supportsStructuredOutput: false,
+            supportsNativeJSONMode: false,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: true,
+            memoryStrategy: .resident,
+            maxOutputTokens: 4096,
+            supportsStreaming: true,
+            isRemote: false,
+            supportsKVCachePersistence: enableKVCacheReuse,
+            supportsThinking: true
+        )
     }
 
     // MARK: - Architecture Allowlist
@@ -213,6 +248,119 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             return true
         }
         return false
+    }
+
+    private static func longestCommonPrefixLength(_ lhs: [Int], _ rhs: [Int]) -> Int {
+        zip(lhs, rhs).prefix(while: { $0 == $1 }).count
+    }
+
+    private func invalidatePromptCacheLocked() {
+        _pendingPromptCacheSnapshotTask?.cancel()
+        _pendingPromptCacheSnapshotTask = nil
+        _promptCacheSnapshot = nil
+        _promptCacheWriteToken &+= 1
+    }
+
+    private static func isSupportedPromptCache(_ caches: [any KVCache]) -> Bool {
+        !caches.isEmpty && caches.allSatisfy { $0 is KVCacheSimple }
+    }
+
+    /// Captures prompt-only KV state for the next turn.
+    ///
+    /// Contract assumptions taken from the currently pinned `mlx-swift-lm`:
+    /// 1. `LanguageModel.prepare(_:cache:windowSize:)` consumes any cached prefix
+    ///    from the front of the prepared prompt and only evaluates the remaining
+    ///    suffix, so restored caches must be paired with the uncached prompt tail.
+    /// 2. `KVCacheSimple.copy()/state/metaState/trim(_:)` are sufficient to clone
+    ///    and shrink prompt-only state safely for text-only models.
+    /// 3. Future `mlx-swift-lm` bumps must rerun the MLX KV-cache integration and
+    ///    performance suite before this contract is trusted unchanged.
+    private static func capturePromptCacheSnapshot(
+        from cache: MLXPromptCache,
+        promptTokens: [Int]
+    ) -> PromptCacheSnapshot? {
+        guard !promptTokens.isEmpty, isSupportedPromptCache(cache.value) else {
+            return nil
+        }
+
+        var layers: [CachedLayerState] = []
+        layers.reserveCapacity(cache.value.count)
+        for original in cache.value {
+            guard original.offset >= promptTokens.count else {
+                return nil
+            }
+
+            if original.state.isEmpty {
+                layers.append(
+                    CachedLayerState(
+                        cacheTypeName: String(describing: type(of: original)),
+                        offset: promptTokens.count,
+                        state: [],
+                        metaState: original.metaState
+                    )
+                )
+                continue
+            }
+
+            let copy = original.copy()
+            eval([copy])
+
+            let excess = copy.offset - promptTokens.count
+            if excess > 0 {
+                guard copy.isTrimmable, copy.trim(excess) == excess else {
+                    return nil
+                }
+            }
+
+            let state = copy.state.map { $0[.ellipsis] }
+            eval(state)
+            layers.append(
+                CachedLayerState(
+                    cacheTypeName: String(describing: type(of: copy)),
+                    offset: copy.offset,
+                    state: state,
+                    metaState: copy.metaState
+                )
+            )
+        }
+        return PromptCacheSnapshot(promptTokens: promptTokens, layers: layers)
+    }
+
+    private static func restorePromptCache(
+        _ snapshot: PromptCacheSnapshot,
+        into cache: MLXPromptCache,
+        reusedPromptTokenCount: Int
+    ) -> Bool {
+        guard reusedPromptTokenCount > 0,
+              cache.value.count == snapshot.layers.count,
+              isSupportedPromptCache(cache.value) else {
+            return false
+        }
+
+        for (index, layer) in snapshot.layers.enumerated() {
+            var target = cache.value[index]
+            guard String(describing: type(of: target)) == layer.cacheTypeName else {
+                return false
+            }
+            if layer.state.isEmpty {
+                guard let target = target as? KVCacheSimple else { return false }
+                target.offset = layer.offset
+            } else {
+                target.state = layer.state.map { $0[.ellipsis] }
+                target.metaState = layer.metaState
+            }
+
+            guard target.offset >= reusedPromptTokenCount else { return false }
+            let excess = target.offset - reusedPromptTokenCount
+            if excess > 0 {
+                guard target.isTrimmable, target.trim(excess) == excess else {
+                    return false
+                }
+            }
+        }
+
+        eval(cache.value)
+        return true
     }
 
     // MARK: - Thinking-Marker Auto-Discovery
@@ -318,10 +466,14 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             }
             let detectedDialect = MLXToolDialect.detect(at: url)
             let detectedThinkingMarkers = Self.detectThinkingMarkers(at: url)
+            let kvCacheReuseEligible = enableKVCacheReuse && !Self.requiresVLMFactory(at: url)
             withStateLock {
                 _modelContainer = container
                 _dialect = detectedDialect
                 _autoDetectedThinkingMarkers = detectedThinkingMarkers
+                invalidatePromptCacheLocked()
+                _kvCacheReuseEligible = kvCacheReuseEligible
+                _hasInitializedRuntime = true
             }
             // Apply the cache policy after loadModelContainer succeeds. Doing
             // this *after* the load (rather than before) keeps it inside the
@@ -360,7 +512,15 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         systemPrompt: String?,
         config: GenerationConfig
     ) throws -> GenerationStream {
-        let modelContainer: any MLXModelContainerProtocol = try withStateLock {
+        let (
+            modelContainer,
+            pendingSnapshotTask,
+            kvCacheReuseEligible
+        ): (
+            any MLXModelContainerProtocol,
+            Task<Void, Never>?,
+            Bool
+        ) = try withStateLock {
             guard _isModelLoaded, let container = _modelContainer else {
                 throw InferenceError.inferenceFailure("No model loaded")
             }
@@ -368,7 +528,7 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 throw InferenceError.alreadyGenerating
             }
             _isGenerating = true
-            return container
+            return (container, _pendingPromptCacheSnapshotTask, _kvCacheReuseEligible)
         }
         Self.logger.debug("MLX generate started")
 
@@ -430,10 +590,10 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             return base + toolBlock
         }()
 
-        // All messages are encoded as plain [String: String] dictionaries because
-        // MLXModelContainerProtocol.generate(messages:) requires [[String: String]].
-        // For Qwen 2.5 tool history, tool calls are text-encoded into content fields
-        // using the same <tool_call>…</tool_call> format the model emits.
+        // All messages are encoded as plain [String: String] dictionaries before the
+        // container applies the tokenizer's chat template. For Qwen 2.5 tool history,
+        // tool calls are text-encoded into content fields using the same
+        // <tool_call>…</tool_call> format the model emits.
         let messages: [[String: String]] = {
             var msgs: [[String: String]] = []
             if let sp = effectiveSystemPrompt, !sp.isEmpty {
@@ -459,7 +619,6 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
 
         let task = Task { @MainActor [weak self, generationStream] in
             defer {
-                self?.withStateLock { self?._isGenerating = false }
                 Self.logger.debug("MLX generate finished")
             }
 
@@ -502,8 +661,48 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 var thinkingTokenCount = 0
                 var thinkingLimitReached = false
 
+                let preparedInput = try await modelContainer.prepare(messages: messages)
+                let cache = try await modelContainer.makeCache(parameters: generateConfig)
+                var generationInput = preparedInput
+                let promptTokenIds: [Int]? = if kvCacheReuseEligible {
+                    preparedInput.promptTokenIds
+                } else {
+                    nil
+                }
+                if kvCacheReuseEligible, let pendingSnapshotTask {
+                    await pendingSnapshotTask.value
+                }
+                let resolvedSnapshot: PromptCacheSnapshot? =
+                    if kvCacheReuseEligible, let self {
+                        self.withStateLock { self._promptCacheSnapshot }
+                    } else {
+                        nil
+                    }
+
+                if kvCacheReuseEligible,
+                   let snapshot = resolvedSnapshot,
+                   let promptTokenIds,
+                   Self.isSupportedPromptCache(cache.value),
+                   promptTokenIds.count > 1 {
+                    let commonPrefixLen = Self.longestCommonPrefixLength(
+                        promptTokenIds,
+                        snapshot.promptTokens
+                    )
+                    let reuseLen = min(commonPrefixLen, promptTokenIds.count - 1)
+                    if reuseLen > 0,
+                       Self.restorePromptCache(
+                        snapshot,
+                        into: cache,
+                        reusedPromptTokenCount: reuseLen
+                       ) {
+                        generationInput = preparedInput.suffix(from: reuseLen)
+                        continuation.yield(.kvCacheReuse(promptTokensReused: reuseLen))
+                    }
+                }
+
                 let mlxStream = try await modelContainer.generate(
-                    messages: messages,
+                    input: generationInput,
+                    cache: cache,
                     parameters: generateConfig
                 )
                 // Inserts a brief cooperative yield every N tokens so sustained MLX
@@ -585,8 +784,41 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 for event in thinkingParser.finalize() {
                     continuation.yield(event)
                 }
+                let snapshotInputs: (MLXPromptCache, [Int])? =
+                    if kvCacheReuseEligible, !Task.isCancelled, let promptTokenIds {
+                        (cache, promptTokenIds)
+                    } else {
+                        nil
+                    }
+
+                if let self {
+                    self.withStateLock { self._isGenerating = false }
+                }
                 await MainActor.run { generationStream.setPhase(.done) }
+                if let self, let (cache, promptTokenIds) = snapshotInputs {
+                    self.withStateLock {
+                        self._promptCacheWriteToken &+= 1
+                        let snapshotWriteToken = self._promptCacheWriteToken
+                        let snapshotTask = Task<Void, Never> { [weak self] in
+                            let snapshot = Self.capturePromptCacheSnapshot(
+                                from: cache,
+                                promptTokens: promptTokenIds
+                            )
+                            guard let self else { return }
+                            self.withStateLock {
+                                guard self._promptCacheWriteToken == snapshotWriteToken else { return }
+                                self._promptCacheSnapshot = snapshot
+                                self._pendingPromptCacheSnapshotTask = nil
+                            }
+                        }
+                        self._pendingPromptCacheSnapshotTask = snapshotTask
+                    }
+                }
+                continuation.finish()
             } catch {
+                if let self {
+                    self.withStateLock { self._isGenerating = false }
+                }
                 if !Task.isCancelled {
                     Self.logger.error("MLX generation error: \(error)")
                     await MainActor.run { generationStream.setPhase(.failed(error.localizedDescription)) }
@@ -594,14 +826,16 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                     return
                 }
                 await MainActor.run { generationStream.setPhase(.done) }
+                continuation.finish()
             }
-            continuation.finish()
         }
 
         withStateLock { self._generationTask = task }
 
-        continuation.onTermination = { @Sendable _ in
-            task.cancel()
+        continuation.onTermination = { @Sendable termination in
+            if case .cancelled = termination {
+                task.cancel()
+            }
         }
 
         return generationStream
@@ -617,7 +851,18 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         withStateLock {
             _modelContainer = container
             _isModelLoaded = true
+            invalidatePromptCacheLocked()
+            _kvCacheReuseEligible = enableKVCacheReuse
+            _hasInitializedRuntime = false
         }
+    }
+
+    func _hasPromptCacheSnapshotForTesting() -> Bool {
+        withStateLock { _promptCacheSnapshot != nil || _pendingPromptCacheSnapshotTask != nil }
+    }
+
+    func _isPromptCacheSnapshotReadyForTesting() -> Bool {
+        withStateLock { _promptCacheSnapshot != nil && _pendingPromptCacheSnapshotTask == nil }
     }
 
     /// Test-only seam: forces the auto-detected thinking markers to a specific
@@ -640,17 +885,12 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
 
     public func unloadModel() {
         stopGeneration()
-        // Capture whether we actually had a loaded container *before* clearing
-        // state. We use this to decide whether to call Memory.clearCache()
-        // below — touching MLX's Memory namespace requires the metallib to be
-        // resident in the process, which is only true after a successful
-        // model load. Calling clearCache() on a never-loaded backend (e.g.
-        // from BackendContractChecks.assertAllInvariants) trips a "Failed to
-        // load default metallib" error under `swift test`, because the
-        // metallib is only compiled by Xcode and isn't present in the SwiftPM
-        // build output.
-        let hadContainer: Bool = withStateLock {
-            let had = _modelContainer != nil
+        // Only touch MLX's Memory namespace after a real model load has
+        // initialized the runtime in this process. Injected test doubles do not
+        // compile the metallib, so clearing the cache after `_inject(...)`
+        // would trip the same failure this guard exists to avoid.
+        let hadInitializedRuntime: Bool = withStateLock {
+            let had = _hasInitializedRuntime
             _modelContainer = nil
             _isModelLoaded = false
             _isGenerating = false
@@ -658,9 +898,12 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             _toolAwareHistory = nil
             _dialect = .unknown
             _autoDetectedThinkingMarkers = nil
+            invalidatePromptCacheLocked()
+            _kvCacheReuseEligible = false
+            _hasInitializedRuntime = false
             return had
         }
-        if hadContainer {
+        if hadInitializedRuntime {
             Memory.clearCache()
         }
         Self.logger.info("MLX backend unloaded")
@@ -676,6 +919,16 @@ extension MLXBackend: ConversationHistoryReceiver {
             // Clear any previously stored tool-aware history so the simpler path takes
             // effect when the orchestrator calls the non-tool-aware setter.
             _toolAwareHistory = nil
+        }
+    }
+}
+
+extension MLXBackend {
+    public func resetConversation() {
+        withStateLock {
+            _conversationHistory = []
+            _toolAwareHistory = nil
+            invalidatePromptCacheLocked()
         }
     }
 }
@@ -698,7 +951,7 @@ extension MLXBackend: ToolCallingHistoryReceiver {
 
 extension MLXBackend {
     /// Encodes a ``ToolAwareHistoryEntry`` into a plain `[String: String]` message
-    /// compatible with `MLXModelContainerProtocol.generate(messages:)`.
+    /// compatible with MLX chat-template preparation.
     ///
     /// For the Qwen 2.5 dialect:
     /// - Assistant entries with `toolCalls` have the calls serialised as

--- a/Sources/BaseChatBackends/MLXModelContainerProtocol.swift
+++ b/Sources/BaseChatBackends/MLXModelContainerProtocol.swift
@@ -1,28 +1,93 @@
 #if MLX
 import MLXLMCommon
 
+struct MLXPreparedInput: @unchecked Sendable {
+    private let value: LMInput?
+    private let promptTokenIdsOverride: [Int]?
+
+    init(_ value: LMInput) {
+        self.value = value
+        self.promptTokenIdsOverride = nil
+    }
+
+    init(promptTokenIds: [Int]) {
+        self.value = nil
+        self.promptTokenIdsOverride = promptTokenIds
+    }
+
+    var lmInput: LMInput {
+        guard let value else {
+            preconditionFailure("Test-only MLXPreparedInput has no LMInput payload")
+        }
+        return value
+    }
+
+    var promptTokenIds: [Int] {
+        promptTokenIdsOverride ?? lmInput.text.tokens.asArray(Int.self)
+    }
+
+    func suffix(from reusedPromptTokenCount: Int) -> MLXPreparedInput {
+        guard reusedPromptTokenCount > 0 else { return self }
+        if let value {
+            let remainingText = value.text[text: reusedPromptTokenCount...]
+            return MLXPreparedInput(
+                LMInput(text: remainingText, image: value.image, video: value.video)
+            )
+        }
+        return MLXPreparedInput(promptTokenIds: Array(promptTokenIds.dropFirst(reusedPromptTokenCount)))
+    }
+}
+
+struct MLXPromptCache: @unchecked Sendable {
+    let value: [any KVCache]
+
+    init(_ value: [any KVCache]) {
+        self.value = value
+    }
+}
+
 /// Abstraction over `ModelContainer` so `MLXBackend` can be tested without real hardware.
 ///
-/// The single `generate` method encapsulates both input preparation and token streaming,
-/// keeping the non-Sendable `LMInput` as an internal implementation detail of the
-/// concrete `ModelContainer` conformance. This lets test mocks return token streams
-/// without touching the Metal GPU stack.
+/// `LMInput` and `[KVCache]` are wrapped so `MLXBackend` can own prompt preparation,
+/// cache creation, prefix reuse, and token streaming while the concrete
+/// `ModelContainer` conformance keeps the underlying MLX types off the public API.
 protocol MLXModelContainerProtocol: Sendable {
-    /// Prepares messages and generates a token stream.
+    func prepare(messages: [[String: String]]) async throws -> MLXPreparedInput
+    func makeCache(parameters: GenerateParameters) async throws -> MLXPromptCache
     func generate(
-        messages: [[String: String]],
+        input: MLXPreparedInput,
+        cache: MLXPromptCache?,
         parameters: GenerateParameters
     ) async throws -> AsyncStream<Generation>
 }
 
-// Make the real ModelContainer conform, handling prepare() internally.
 extension ModelContainer: MLXModelContainerProtocol {
+    func prepare(messages: [[String: String]]) async throws -> MLXPreparedInput {
+        let input = try await prepare(input: .init(messages: messages))
+        return MLXPreparedInput(input)
+    }
+
+    func makeCache(parameters: GenerateParameters) async throws -> MLXPromptCache {
+        await perform { context in
+            MLXPromptCache(context.model.newCache(parameters: parameters))
+        }
+    }
+
     func generate(
-        messages: [[String: String]],
+        input: MLXPreparedInput,
+        cache: MLXPromptCache?,
         parameters: GenerateParameters
     ) async throws -> AsyncStream<Generation> {
-        let input = try await prepare(input: .init(messages: messages))
-        return try await generate(input: input, parameters: parameters, wiredMemoryTicket: nil)
+        try await perform(nonSendable: (input.lmInput, cache?.value)) { context, values in
+            let (input, cache) = values
+            return try MLXLMCommon.generate(
+                input: input,
+                cache: cache,
+                parameters: parameters,
+                context: context,
+                wiredMemoryTicket: nil
+            )
+        }
     }
 }
 #endif

--- a/Sources/BaseChatTestSupport/MockMLXModelContainer.swift
+++ b/Sources/BaseChatTestSupport/MockMLXModelContainer.swift
@@ -17,6 +17,14 @@ public struct SendableLMInput: @unchecked Sendable {
     }
 }
 
+public struct SendableKVCacheList: @unchecked Sendable {
+    public let value: [any KVCache]
+
+    public init(_ value: [any KVCache]) {
+        self.value = value
+    }
+}
+
 // MARK: - MockMLXModelContainer
 
 /// Fake model container for unit-testing `MLXBackend` generation without hardware.
@@ -50,39 +58,85 @@ public final class MockMLXModelContainer: @unchecked Sendable {
     /// are exercising and assert the backend hands compatible messages along.
     public var simulatedChatTemplate: String?
 
+    /// Prepared prompt-token batches returned by successive `prepare` calls.
+    ///
+    /// When empty, the mock synthesizes a small token sequence from the message count.
+    public var preparedTokenBatches: [[Int]] = []
+
+    /// Factory used to create the explicit cache passed to generation.
+    public var cacheFactory: @Sendable () -> [any KVCache] = { [KVCacheSimple()] }
+
+    /// Extra tail tokens the mock appends to the cache during generation to model
+    /// completion tokens extending beyond the prompt.
+    public var simulatedCacheCompletionTokenCount = 0
+
     // MARK: - Observation
 
-    /// Number of times `generate(messages:parameters:)` was called.
+    /// Number of times prepared generation was called.
     public private(set) var generateCallCount = 0
 
-    /// Last messages passed to `generate`.
+    /// Number of times `prepare(messages:)` was called.
+    public private(set) var prepareCallCount = 0
+
+    /// Number of times `makeCache(parameters:)` was called.
+    public private(set) var makeCacheCallCount = 0
+
+    /// Last messages passed to `prepare`.
     public private(set) var lastMessages: [[String: String]]?
 
-    /// Last `GenerateParameters` value passed to `generate`. Useful for asserting
+    /// Last `GenerateParameters` value passed to generation. Useful for asserting
     /// that `MLXBackend` forwards `temperature` / `topP` / `topK` / `minP` /
     /// `repetitionPenalty` from the caller's `GenerationConfig`.
     public private(set) var lastParameters: GenerateParameters?
 
+    /// Last prepared prompt-token batch returned by `prepare`.
+    public private(set) var lastPreparedTokenIds: [Int]?
+
+    /// Cache offsets observed at the start of generation.
+    public private(set) var lastInitialCacheOffsets: [Int]?
+
     public init() {}
 
-    // MARK: - Protocol-shaped method (consumed by BaseChatBackendsTests conformance)
+    // MARK: - Public helpers consumed by BaseChatBackendsTests conformance
 
-    public func generate(
-        messages: [[String: String]],
+    public func prepareForGeneration(
+        messages: [[String: String]]
+    ) async throws -> [Int] {
+        prepareCallCount += 1
+        lastMessages = messages
+
+        let promptTokens: [Int]
+        if !preparedTokenBatches.isEmpty {
+            promptTokens = preparedTokenBatches.removeFirst()
+        } else {
+            promptTokens = Array(1 ... max(messages.count, 1))
+        }
+        lastPreparedTokenIds = promptTokens
+        return promptTokens
+    }
+
+    public func makeCacheForGeneration(parameters: GenerateParameters) -> [any KVCache] {
+        makeCacheCallCount += 1
+        return cacheFactory()
+    }
+
+    public func generatePreparedInput(
+        promptTokenIds: [Int],
+        cache: SendableKVCacheList?,
         parameters: GenerateParameters
     ) async throws -> AsyncStream<Generation> {
         generateCallCount += 1
-        lastMessages = messages
         lastParameters = parameters
-        // Tokenizer-apply failures throw before any token is yielded — that is
-        // the failure mode `MLXBackend` sees when a template is missing or the
-        // message set is rejected by the chat template.
+        lastInitialCacheOffsets = cache?.value.map(\.offset)
         if let error = simulatedTokenizerApplyFailure { throw error }
         if let error = generateError { throw error }
 
         let tokens = tokensToYield
+        let cache = cache
+        let promptTokenCount = promptTokenIds.count
+        let completionTokenCount = simulatedCacheCompletionTokenCount
         return AsyncStream { continuation in
-            let producerTask = Task {
+            let producerTask = Task { [tokens, cache, promptTokenCount, completionTokenCount] in
                 for token in tokens {
                     if Task.isCancelled {
                         continuation.finish()
@@ -91,12 +145,23 @@ public final class MockMLXModelContainer: @unchecked Sendable {
                     continuation.yield(.chunk(token))
                     await Task.yield()
                 }
+                if let cache {
+                    let totalTokenCount = promptTokenCount + completionTokenCount
+                    for layer in cache.value {
+                        Self.setCacheOffset(layer, tokenCount: totalTokenCount)
+                    }
+                }
                 continuation.finish()
             }
             continuation.onTermination = { _ in
                 producerTask.cancel()
             }
         }
+    }
+
+    private static func setCacheOffset(_ cache: any KVCache, tokenCount: Int) {
+        guard let cache = cache as? KVCacheSimple else { return }
+        cache.offset = max(tokenCount, 0)
     }
 }
 #endif

--- a/TESTING.md
+++ b/TESTING.md
@@ -167,6 +167,33 @@ Place your MLX snapshot in either location. The harness scans all immediate subd
 
 The suite calls `XCTSkip` and is marked skipped — CI sees a green pass, not a failure. You only need a local fixture when you're actively working on `BaseChatMLXIntegrationTests` or `MLXBackend`.
 
+### MLX KV-cache reuse regression checks
+
+Issue #749's prompt-cache reuse path has an extra validation bar beyond "still generates text":
+
+1. **Correctness** — warm second-turn output must match the cold path under deterministic settings.
+2. **Real cache hit** — the warm path must emit `GenerationEvent.kvCacheReuse(...)`.
+3. **Measured improvement** — warm second-turn TTFT must materially beat the cold path for a long shared prefix.
+
+The Xcode-only suite lives in `BaseChatMLXIntegrationTests/MLXKVPersistenceIntegrationTests.swift`. Run it with:
+
+```bash
+xcodebuild test -scheme BaseChatKit-Package \
+  -only-testing:BaseChatMLXIntegrationTests/MLXKVPersistenceIntegrationTests \
+  -destination 'platform=macOS'
+```
+
+When bumping `mlx-swift-lm` or `mlx-swift`, rerun both MLX integration targets before trusting the update:
+
+```bash
+xcodebuild test -scheme BaseChatKit-Package \
+  -only-testing:BaseChatMLXIntegrationTests/MLXModelE2ETests \
+  -only-testing:BaseChatMLXIntegrationTests/MLXKVPersistenceIntegrationTests \
+  -destination 'platform=macOS'
+```
+
+If the fixture model is VLM/MoE-only, the KV-cache suite skips by design — v1 reuse is intentionally scoped to text-only MLX models.
+
 ---
 
 ## Feature Coverage Matrix

--- a/Tests/BaseChatBackendsTests/MLXBackendGenerationTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXBackendGenerationTests.swift
@@ -8,7 +8,28 @@ import BaseChatTestSupport
 
 // Conform MockMLXModelContainer to the internal protocol in this test target,
 // where both the internal protocol and the public mock type are visible.
-extension MockMLXModelContainer: MLXModelContainerProtocol {}
+extension MockMLXModelContainer: MLXModelContainerProtocol {
+    public func prepare(messages: [[String : String]]) async throws -> MLXPreparedInput {
+        let promptTokenIds = try await prepareForGeneration(messages: messages)
+        return MLXPreparedInput(promptTokenIds: promptTokenIds)
+    }
+
+    public func makeCache(parameters: GenerateParameters) async throws -> MLXPromptCache {
+        MLXPromptCache(makeCacheForGeneration(parameters: parameters))
+    }
+
+    public func generate(
+        input: MLXPreparedInput,
+        cache: MLXPromptCache?,
+        parameters: GenerateParameters
+    ) async throws -> AsyncStream<Generation> {
+        try await generatePreparedInput(
+            promptTokenIds: input.promptTokenIds,
+            cache: cache.map { SendableKVCacheList($0.value) },
+            parameters: parameters
+        )
+    }
+}
 
 /// Unit tests for `MLXBackend.generate()` using `MockMLXModelContainer`.
 ///
@@ -88,6 +109,233 @@ final class MLXBackendGenerationTests: XCTestCase {
 
         // Sabotage check: setting maxOutputTokens = 100 yields all 10 tokens,
         // causing the count assertion to fail.
+    }
+
+    func test_generate_reusesPromptCachePrefixOnMatchingTurn() async throws {
+        let mock = MockMLXModelContainer()
+        mock.tokensToYield = ["ok"]
+        mock.preparedTokenBatches = [
+            [11, 12, 13, 14],
+            [11, 12, 13, 14, 15],
+        ]
+
+        let backend = MLXBackend(enableKVCacheReuse: true)
+        backend._inject(mock)
+
+        _ = try await collectAllEvents(from: try backend.generate(
+            prompt: "first",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+
+        let secondStream = try backend.generate(
+            prompt: "second",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+        let secondEvents = try await collectAllEvents(from: secondStream)
+        let reuseCounts = secondEvents.compactMap { event -> Int? in
+            if case .kvCacheReuse(let count) = event { return count }
+            return nil
+        }
+
+        XCTAssertEqual(reuseCounts, [4],
+            "Second turn should emit kvCacheReuse for the shared 4-token prompt prefix")
+        XCTAssertEqual(mock.lastInitialCacheOffsets, [4],
+            "Generation should resume from the restored prefix length, not from a cold cache")
+
+        // Sabotage check: disabling enableKVCacheReuse or clearing _promptCacheSnapshot
+        // before the second turn makes reuseCounts empty and the cache offset 0.
+    }
+
+    func test_generate_withReuseDisabled_doesNotPersistPromptSnapshot() async throws {
+        let mock = MockMLXModelContainer()
+        mock.tokensToYield = ["ok"]
+        mock.preparedTokenBatches = [[16, 17, 18, 19]]
+
+        let backend = MLXBackend(enableKVCacheReuse: false)
+        backend._inject(mock)
+
+        XCTAssertFalse(backend._hasPromptCacheSnapshotForTesting())
+        _ = try await collectAllEvents(from: try backend.generate(
+            prompt: "first",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+
+        XCTAssertFalse(
+            backend._hasPromptCacheSnapshotForTesting(),
+            "Default-off reuse must not retain prompt-cache state between turns"
+        )
+
+        // Sabotage check: capturing snapshots unconditionally leaves a retained
+        // prompt snapshot here and fails the final assertion.
+    }
+
+    func test_generate_reusesOnlySharedPrefixAfterPromptDivergence() async throws {
+        let mock = MockMLXModelContainer()
+        mock.tokensToYield = ["ok"]
+        mock.preparedTokenBatches = [
+            [21, 22, 23, 24],
+            [21, 22, 99, 100],
+        ]
+
+        let backend = MLXBackend(enableKVCacheReuse: true)
+        backend._inject(mock)
+
+        _ = try await collectAllEvents(from: try backend.generate(
+            prompt: "first",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+
+        let secondEvents = try await collectAllEvents(from: try backend.generate(
+            prompt: "second",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+        let reuseCounts = secondEvents.compactMap { event -> Int? in
+            if case .kvCacheReuse(let count) = event { return count }
+            return nil
+        }
+
+        XCTAssertEqual(reuseCounts, [2],
+            "Only the shared head of the prompt should be reused after divergence")
+        XCTAssertEqual(mock.lastInitialCacheOffsets, [2],
+            "Restored cache should be trimmed to the shared-prefix length before generation")
+
+        // Sabotage check: changing the second prepared token batch to start with
+        // [21, 99, ...] drops reuse to 1 and fails the assertions.
+    }
+
+    func test_generate_unsupportedCacheShapeBypassesReuseAndClearsSnapshot() async throws {
+        let mock = MockMLXModelContainer()
+        mock.tokensToYield = ["ok"]
+        mock.preparedTokenBatches = [
+            [31, 32, 33, 34],
+            [31, 32, 33, 34, 35],
+            [31, 32, 33, 34, 35, 36],
+        ]
+
+        let backend = MLXBackend(enableKVCacheReuse: true)
+        backend._inject(mock)
+
+        _ = try await collectAllEvents(from: try backend.generate(
+            prompt: "first",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+
+        mock.cacheFactory = { [RotatingKVCache(maxSize: 32)] }
+        let secondEvents = try await collectAllEvents(from: try backend.generate(
+            prompt: "second",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+        let secondReuseCounts = secondEvents.compactMap { event -> Int? in
+            if case .kvCacheReuse(let count) = event { return count }
+            return nil
+        }
+
+        XCTAssertTrue(secondReuseCounts.isEmpty,
+            "Unsupported cache families must bypass prompt-cache restore")
+        XCTAssertEqual(mock.lastInitialCacheOffsets, [0],
+            "Unsupported cache families should start from a cold cache")
+
+        mock.cacheFactory = { [KVCacheSimple()] }
+        let thirdEvents = try await collectAllEvents(from: try backend.generate(
+            prompt: "third",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+        let thirdReuseCounts = thirdEvents.compactMap { event -> Int? in
+            if case .kvCacheReuse(let count) = event { return count }
+            return nil
+        }
+
+        XCTAssertTrue(thirdReuseCounts.isEmpty,
+            "A turn that bypasses reuse must clear the prior snapshot rather than keeping stale state")
+        XCTAssertEqual(mock.lastInitialCacheOffsets, [0],
+            "After an unsupported turn the next request should still begin cold")
+
+        // Sabotage check: if unsupported caches leave the old snapshot intact, the
+        // third turn reuses 4+ tokens and both assertions fail.
+    }
+
+    func test_resetConversation_invalidatesPromptCache() async throws {
+        let mock = MockMLXModelContainer()
+        mock.tokensToYield = ["ok"]
+        mock.preparedTokenBatches = [
+            [41, 42, 43, 44],
+            [41, 42, 43, 44, 45],
+        ]
+
+        let backend = MLXBackend(enableKVCacheReuse: true)
+        backend._inject(mock)
+
+        _ = try await collectAllEvents(from: try backend.generate(
+            prompt: "first",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+
+        backend.resetConversation()
+
+        let secondEvents = try await collectAllEvents(from: try backend.generate(
+            prompt: "second",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+        let reuseCounts = secondEvents.compactMap { event -> Int? in
+            if case .kvCacheReuse(let count) = event { return count }
+            return nil
+        }
+
+        XCTAssertTrue(reuseCounts.isEmpty,
+            "resetConversation must invalidate any cached prompt prefix")
+        XCTAssertEqual(mock.lastInitialCacheOffsets, [0],
+            "After resetConversation the next turn should start from a cold cache")
+
+        // Sabotage check: removing the resetConversation() call restores a 4-token hit.
+    }
+
+    func test_generate_offsetOnlyMockRestoresPromptLengthAfterPriorCompletionTail() async throws {
+        let mock = MockMLXModelContainer()
+        mock.tokensToYield = ["ok"]
+        mock.simulatedCacheCompletionTokenCount = 3
+        mock.preparedTokenBatches = [
+            [51, 52, 53, 54],
+            [51, 52, 53, 54, 55],
+        ]
+
+        let backend = MLXBackend(enableKVCacheReuse: true)
+        backend._inject(mock)
+
+        _ = try await collectAllEvents(from: try backend.generate(
+            prompt: "first",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+
+        let secondEvents = try await collectAllEvents(from: try backend.generate(
+            prompt: "second",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+        let reuseCounts = secondEvents.compactMap { event -> Int? in
+            if case .kvCacheReuse(let count) = event { return count }
+            return nil
+        }
+
+        XCTAssertEqual(reuseCounts, [4],
+            "Only prompt tokens, not the simulated completion tail, should be restorable on the next turn")
+        XCTAssertEqual(mock.lastInitialCacheOffsets, [4],
+            "Even on the offset-only mock path, restore should clamp back to the prompt length before reuse")
+
+        // Sabotage check: if the restore path keeps the simulated 3-token completion
+        // tail, lastInitialCacheOffsets becomes 7 and fails this assertion. The
+        // real tensor-state trim/copy path is covered by the Xcode-only MLX
+        // integration suite, not this CI-safe mock.
     }
 
     // MARK: - test_generate_cancellation

--- a/Tests/BaseChatBackendsTests/MLXBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXBackendTests.swift
@@ -41,6 +41,11 @@ final class MLXBackendTests: XCTestCase {
         XCTAssertEqual(MLXBackend().capabilities.maxContextTokens, 8192)
     }
 
+    func test_capabilities_supportsKVCachePersistence_onlyWhenEnabled() {
+        XCTAssertFalse(MLXBackend().capabilities.supportsKVCachePersistence)
+        XCTAssertTrue(MLXBackend(enableKVCacheReuse: true).capabilities.supportsKVCachePersistence)
+    }
+
     // MARK: - Lifecycle (no hardware gate)
 
     func test_generate_beforeLoad_throws() {
@@ -55,6 +60,13 @@ final class MLXBackendTests: XCTestCase {
 
     func test_stopGeneration_beforeLoad_doesNotCrash() {
         MLXBackend().stopGeneration()
+    }
+
+    func test_unloadModel_afterMockInjection_doesNotCrash() {
+        let backend = MLXBackend(enableKVCacheReuse: true)
+        backend._inject(MockMLXModelContainer())
+        backend.unloadModel()
+        XCTAssertFalse(backend.isModelLoaded)
     }
 
     // MARK: - Hardware-gated

--- a/Tests/BaseChatMLXIntegrationTests/MLXKVPersistenceIntegrationTests.swift
+++ b/Tests/BaseChatMLXIntegrationTests/MLXKVPersistenceIntegrationTests.swift
@@ -1,0 +1,371 @@
+#if MLX
+import XCTest
+import BaseChatCore
+import BaseChatInference
+import BaseChatTestSupport
+@testable import BaseChatBackends
+
+/// Real-model validation for MLX KV-cache prefix reuse.
+///
+/// These tests are Xcode-only for the same reason as `MLXModelE2ETests`: MLX's
+/// Metal shader library is not built by `swift test`. The suite is intentionally
+/// hardware-gated and fixture-gated, and skips rather than failing when no
+/// eligible local MLX text model is available.
+@MainActor
+final class MLXKVPersistenceIntegrationTests: XCTestCase {
+
+    private var modelURL: URL!
+    private var loadedBackends: [MLXBackend] = []
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        try XCTSkipUnless(HardwareRequirements.isAppleSilicon, "Requires Apple Silicon")
+        try XCTSkipUnless(HardwareRequirements.hasMetalDevice, "Requires Metal GPU")
+
+        guard let mlxDir = HardwareRequirements.findMLXModelDirectory() else {
+            throw XCTSkip(
+                "No loadable MLX model found on disk. Install a local MLX snapshot with config.json, tokenizer, and safetensors weights."
+            )
+        }
+        try XCTSkipIf(
+            MLXBackend.requiresVLMFactory(at: mlxDir),
+            "KV-cache reuse v1 is intentionally limited to text-only MLX models; VLM/MoE fixtures are out of scope."
+        )
+        modelURL = mlxDir
+    }
+
+    override func tearDown() async throws {
+        for backend in loadedBackends.reversed() {
+            backend.unloadModel()
+        }
+        loadedBackends.removeAll()
+        modelURL = nil
+        try await super.tearDown()
+    }
+
+    private struct TimedGenerationResult {
+        let text: String
+        let events: [GenerationEvent]
+        let firstTokenLatency: Duration
+    }
+
+    private struct SecondTurnSample {
+        let firstTurnText: String
+        let secondTurn: TimedGenerationResult
+    }
+
+    private let longSharedPrefixPrompt = Array(
+        repeating: "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu.",
+        count: 90
+    ).joined(separator: " ")
+
+    private let followUpPrompt = "Using the earlier context only, answer with exactly the single word READY."
+    private let performanceSampleCount = 5
+
+    private var deterministicConfig: GenerationConfig {
+        GenerationConfig(
+            temperature: 0.0,
+            topP: 1.0,
+            repeatPenalty: 1.0,
+            seed: 749,
+            maxOutputTokens: 12,
+            maxThinkingTokens: 0
+        )
+    }
+
+    private var performanceConfig: GenerationConfig {
+        GenerationConfig(
+            temperature: 0.0,
+            topP: 1.0,
+            repeatPenalty: 1.0,
+            seed: 749,
+            maxOutputTokens: 1,
+            maxThinkingTokens: 0
+        )
+    }
+
+    private func loadBackend(enableReuse: Bool) async throws -> MLXBackend {
+        let backend = MLXBackend(enableKVCacheReuse: enableReuse)
+        try await backend.loadModel(from: modelURL, plan: .testStub(effectiveContextSize: 2048))
+        loadedBackends.append(backend)
+        return backend
+    }
+
+    private func generateTimed(
+        on backend: MLXBackend,
+        prompt: String,
+        systemPrompt: String? = nil,
+        config: GenerationConfig
+    ) async throws -> TimedGenerationResult {
+        let stream = try backend.generate(
+            prompt: prompt,
+            systemPrompt: systemPrompt,
+            config: config
+        )
+
+        let clock = ContinuousClock()
+        let start = clock.now
+        var firstTokenLatency: Duration?
+        var text = ""
+        var events: [GenerationEvent] = []
+
+        for try await event in stream.events {
+            events.append(event)
+            if case .token(let chunk) = event {
+                if firstTokenLatency == nil {
+                    firstTokenLatency = clock.now - start
+                }
+                text += chunk
+            }
+        }
+
+        return TimedGenerationResult(
+            text: text,
+            events: events,
+            firstTokenLatency: try XCTUnwrap(
+                firstTokenLatency,
+                "Generation must emit at least one visible token"
+            )
+        )
+    }
+
+    private func runSecondTurnSample(
+        on backend: MLXBackend,
+        config: GenerationConfig
+    ) async throws -> SecondTurnSample {
+        backend.resetConversation()
+
+        let firstTurn = try await generateTimed(
+            on: backend,
+            prompt: longSharedPrefixPrompt,
+            config: config
+        )
+        XCTAssertFalse(firstTurn.text.isEmpty, "Turn 1 must produce text so the follow-up history is well formed")
+
+        backend.setConversationHistory([
+            ("user", longSharedPrefixPrompt),
+            ("assistant", firstTurn.text),
+            ("user", followUpPrompt),
+        ])
+
+        let secondTurn = try await generateTimed(
+            on: backend,
+            prompt: followUpPrompt,
+            config: config
+        )
+        return SecondTurnSample(firstTurnText: firstTurn.text, secondTurn: secondTurn)
+    }
+
+    private func warmRuntime(on backend: MLXBackend) async throws {
+        backend.resetConversation()
+        _ = try await generateTimed(
+            on: backend,
+            prompt: "Reply with exactly READY.",
+            config: performanceConfig
+        )
+        backend.resetConversation()
+    }
+
+    private func waitForIdle(_ backend: MLXBackend, timeoutSeconds: Int = 5) async throws {
+        let deadline = ContinuousClock.now + .seconds(timeoutSeconds)
+        while backend.isGenerating, ContinuousClock.now < deadline {
+            await Task.yield()
+        }
+        XCTAssertFalse(backend.isGenerating, "Backend should have stopped generating before the next turn begins")
+    }
+
+    private func firstReuseCount(in events: [GenerationEvent]) -> Int? {
+        for event in events {
+            if case .kvCacheReuse(let count) = event {
+                return count
+            }
+        }
+        return nil
+    }
+
+    private func durationSeconds(_ duration: Duration) -> Double {
+        let components = duration.components
+        return Double(components.seconds) + Double(components.attoseconds) / 1_000_000_000_000_000_000
+    }
+
+    private func median(_ values: [Double]) -> Double {
+        let sorted = values.sorted()
+        let middle = sorted.count / 2
+        if sorted.count.isMultiple(of: 2) {
+            return (sorted[middle - 1] + sorted[middle]) / 2
+        }
+        return sorted[middle]
+    }
+
+    func test_kvCacheReuse_deterministicWarmSecondTurn_matchesColdSecondTurn() async throws {
+        let warmBackend = try await loadBackend(enableReuse: true)
+        let warmSample = try await runSecondTurnSample(on: warmBackend, config: deterministicConfig)
+
+        let warmReuse = try XCTUnwrap(
+            firstReuseCount(in: warmSample.secondTurn.events),
+            "Warm second turn must emit .kvCacheReuse or this correctness test is vacuous"
+        )
+        XCTAssertGreaterThan(warmReuse, 0, "Warm path must reuse a non-zero prompt prefix")
+
+        warmBackend.unloadModel()
+
+        let coldBackend = try await loadBackend(enableReuse: false)
+        coldBackend.setConversationHistory([
+            ("user", longSharedPrefixPrompt),
+            ("assistant", warmSample.firstTurnText),
+            ("user", followUpPrompt),
+        ])
+        let coldTurn2 = try await generateTimed(
+            on: coldBackend,
+            prompt: followUpPrompt,
+            config: deterministicConfig
+        )
+
+        XCTAssertNil(
+            firstReuseCount(in: coldTurn2.events),
+            "Disabling reuse must remove the kvCacheReuse hit for the same follow-up prompt"
+        )
+        XCTAssertEqual(
+            warmSample.secondTurn.text,
+            coldTurn2.text,
+            "Greedy second-turn output must match between warm and cold paths; otherwise cache restore changed the model result"
+        )
+
+        // Sabotage check: disabling the restore path (or shifting the reused prompt
+        // positions) removes the reuse hit or changes the cold/warm output equality.
+    }
+
+    func test_kvCacheReuse_cancelledSecondTurnPreservesCompletedSnapshot() async throws {
+        let backend = try await loadBackend(enableReuse: true)
+
+        backend.resetConversation()
+        let firstTurn = try await generateTimed(
+            on: backend,
+            prompt: longSharedPrefixPrompt,
+            config: deterministicConfig
+        )
+        XCTAssertFalse(firstTurn.text.isEmpty)
+
+        let sharedHistory = [
+            ("user", longSharedPrefixPrompt),
+            ("assistant", firstTurn.text),
+            ("user", followUpPrompt),
+        ]
+        backend.setConversationHistory(sharedHistory)
+
+        let cancelledStream = try backend.generate(
+            prompt: followUpPrompt,
+            systemPrompt: nil,
+            config: performanceConfig
+        )
+        for try await event in cancelledStream.events {
+            if case .token = event {
+                break
+            }
+        }
+        try await waitForIdle(backend)
+
+        backend.setConversationHistory(sharedHistory)
+        let retriedTurn = try await generateTimed(
+            on: backend,
+            prompt: followUpPrompt,
+            config: performanceConfig
+        )
+
+        let reuse = try XCTUnwrap(
+            firstReuseCount(in: retriedTurn.events),
+            "Retrying after a cancelled second turn must still hit the prior completed snapshot"
+        )
+        XCTAssertGreaterThan(reuse, 0)
+
+        // Sabotage check: clearing the stored prompt snapshot on cancellation removes
+        // the retry-path reuse hit and makes this assertion fail.
+    }
+
+    func test_kvCacheReuse_warmSecondTurnImprovesTTFTByAtLeast2x() async throws {
+        let warmBackend = try await loadBackend(enableReuse: true)
+        try await warmRuntime(on: warmBackend)
+        var warmSamples: [Double] = []
+        for _ in 0..<performanceSampleCount {
+            let result = try await runSecondTurnSample(on: warmBackend, config: performanceConfig)
+            let reuse = try XCTUnwrap(
+                firstReuseCount(in: result.secondTurn.events),
+                "Warm-path performance sample must emit .kvCacheReuse to prove the cache actually hit"
+            )
+            XCTAssertGreaterThan(reuse, 0)
+            warmSamples.append(durationSeconds(result.secondTurn.firstTokenLatency))
+        }
+        warmBackend.unloadModel()
+
+        let coldBackend = try await loadBackend(enableReuse: false)
+        try await warmRuntime(on: coldBackend)
+        var coldSamples: [Double] = []
+        for _ in 0..<performanceSampleCount {
+            let result = try await runSecondTurnSample(on: coldBackend, config: performanceConfig)
+            XCTAssertNil(firstReuseCount(in: result.secondTurn.events))
+            coldSamples.append(durationSeconds(result.secondTurn.firstTokenLatency))
+        }
+
+        let warmMedian = median(warmSamples)
+        let coldMedian = median(coldSamples)
+        let improvement = coldMedian / warmMedian
+
+        XCTAssertGreaterThan(
+            improvement,
+            2.0,
+            "Warm second-turn TTFT should improve by >2x over cold prefill for a long shared prefix (cold median: \(coldMedian)s, warm median: \(warmMedian)s)"
+        )
+
+        // Sabotage check: disabling `enableKVCacheReuse` (or preventing the cache
+        // snapshot from being restored) collapses the improvement ratio toward 1x.
+    }
+
+    func test_kvCacheReuse_missPathOverheadStaysNearColdBaseline() async throws {
+        let reuseBackend = try await loadBackend(enableReuse: true)
+        let unrelatedPrompt = "This is an unrelated prompt with no reusable prefix."
+        let config = performanceConfig
+        try await warmRuntime(on: reuseBackend)
+
+        var reuseMissSamples: [Double] = []
+        for _ in 0..<performanceSampleCount {
+            reuseBackend.resetConversation()
+            let miss = try await generateTimed(
+                on: reuseBackend,
+                prompt: unrelatedPrompt,
+                config: config
+            )
+            XCTAssertNil(firstReuseCount(in: miss.events))
+            reuseMissSamples.append(durationSeconds(miss.firstTokenLatency))
+        }
+        reuseBackend.unloadModel()
+
+        let coldBackend = try await loadBackend(enableReuse: false)
+        try await warmRuntime(on: coldBackend)
+        var coldSamples: [Double] = []
+        for _ in 0..<performanceSampleCount {
+            coldBackend.resetConversation()
+            let cold = try await generateTimed(
+                on: coldBackend,
+                prompt: unrelatedPrompt,
+                config: config
+            )
+            XCTAssertNil(firstReuseCount(in: cold.events))
+            coldSamples.append(durationSeconds(cold.firstTokenLatency))
+        }
+
+        let reuseMissMedian = median(reuseMissSamples)
+        let coldMedian = median(coldSamples)
+        let overheadRatio = reuseMissMedian / coldMedian
+
+        XCTAssertLessThan(
+            overheadRatio,
+            1.25,
+            "Reuse-enabled miss path should stay within 25% of the cold baseline (miss median: \(reuseMissMedian)s, cold median: \(coldMedian)s)"
+        )
+
+        // Sabotage check: adding expensive restore work on zero-prefix misses pushes
+        // the miss path well above the cold baseline and fails the ratio assertion.
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add an opt-in MLX KV-cache reuse path that restores longest-common-prefix prompt state for eligible text-only models
- capture prompt-only snapshots after successful turns, skip retention when reuse is disabled, and guard post-finish snapshot writes against stale state
- add CI-safe MLX regressions plus Xcode-only real-model coverage for correctness, cancellation, miss-path cost, and second-turn TTFT improvement

## Testing
- swift test --filter BaseChatInferenceTests --disable-default-traits
- swift test --filter BaseChatBackendsTests --disable-default-traits
- swift test --filter BaseChatBackendsTests --traits MLX
- xcodebuild test -scheme BaseChatKit-Package -disableAutomaticPackageResolution -only-testing:BaseChatMLXIntegrationTests/MLXKVPersistenceIntegrationTests -destination "platform=macOS"

Closes #749