### PR TITLE
feat(core): ConversationExportFormat protocol with markdown + JSONL

### DIFF
--- a/Sources/BaseChatCore/Services/ConversationExportFormat.swift
+++ b/Sources/BaseChatCore/Services/ConversationExportFormat.swift
@@ -1,0 +1,32 @@
+import Foundation
+import UniformTypeIdentifiers
+import BaseChatInference
+
+/// A pluggable serializer for chat conversations.
+///
+/// Apps can ship their own format by adopting this protocol — the framework
+/// provides ``MarkdownExportFormat`` and ``JSONLExportFormat`` out of the box.
+/// Tree-preserving export (branching history) is intentionally out of scope:
+/// `messages` is the linear active path. Apps that model branches should pass
+/// the materialised path their UI is currently displaying.
+public protocol ConversationExportFormat: Sendable {
+
+    /// File extension without the leading dot, e.g. `"md"` or `"jsonl"`.
+    var fileExtension: String { get }
+
+    /// Uniform Type Identifier used by `ShareLink` and the system share sheet
+    /// to pick a sensible default app for the exported file.
+    var contentType: UTType { get }
+
+    /// Serialises the session and its (linear) message history to bytes.
+    ///
+    /// - Parameters:
+    ///   - session: Storage-agnostic snapshot of the chat session.
+    ///   - messages: Messages in chronological order. The exporter is
+    ///     responsible for sorting; formats should not re-sort.
+    /// - Returns: Encoded file contents.
+    /// - Throws: Implementations only throw at serialization boundaries
+    ///   (e.g. JSON encoder failures). Format-internal invariants should not
+    ///   throw — Swift's type system enforces the input shape.
+    func export(session: ChatSessionRecord, messages: [ChatMessageRecord]) throws -> Data
+}

--- a/Sources/BaseChatCore/Services/ConversationExportFormat.swift
+++ b/Sources/BaseChatCore/Services/ConversationExportFormat.swift
@@ -22,8 +22,11 @@ public protocol ConversationExportFormat: Sendable {
     ///
     /// - Parameters:
     ///   - session: Storage-agnostic snapshot of the chat session.
-    ///   - messages: Messages in chronological order. The exporter is
-    ///     responsible for sorting; formats should not re-sort.
+    ///   - messages: Messages in chronological order. Callers are responsible
+    ///     for providing them in that order; formats should not re-sort.
+    ///     ``ConversationExporter``'s SwiftData overload relies on
+    ///     ``ChatPersistenceProvider/fetchMessages(for:)`` to sort, and the
+    ///     pure overload trusts whatever the caller passes.
     /// - Returns: Encoded file contents.
     /// - Throws: Implementations only throw at serialization boundaries
     ///   (e.g. JSON encoder failures). Format-internal invariants should not

--- a/Sources/BaseChatCore/Services/ConversationExporter.swift
+++ b/Sources/BaseChatCore/Services/ConversationExporter.swift
@@ -1,0 +1,161 @@
+import Foundation
+import UniformTypeIdentifiers
+import BaseChatInference
+
+/// A reference to a file written to disk that is suitable for sharing via
+/// SwiftUI's `ShareLink`.
+///
+/// `ShareLink` accepts `URL`, but a bare URL hides the suggested filename and
+/// content type from the share sheet's preview. Bundling them keeps the
+/// preview helpful and lets callers clean up the temp file when sharing
+/// completes.
+public struct ShareableFile: Sendable, Equatable {
+
+    /// On-disk location of the file. Typically inside `FileManager.default.temporaryDirectory`.
+    public let url: URL
+
+    /// Display name shown in the share sheet preview, including extension.
+    public let suggestedFilename: String
+
+    /// UTI used by the share sheet to pick handlers and icons.
+    public let contentType: UTType
+
+    public init(url: URL, suggestedFilename: String, contentType: UTType) {
+        self.url = url
+        self.suggestedFilename = suggestedFilename
+        self.contentType = contentType
+    }
+}
+
+/// Errors surfaced by ``ConversationExporter`` when the export pipeline
+/// trips at a system boundary (filesystem, persistence).
+public enum ConversationExportError: Error, Equatable {
+    case writeFailed(URL, String)
+}
+
+/// Exports a chat session through any ``ConversationExportFormat`` and
+/// returns a ``ShareableFile`` suitable for `ShareLink`.
+///
+/// Two ways to drive it:
+/// - ``export(session:messages:format:directory:)`` — caller already has the
+///   message list. Pure: no persistence dependency.
+/// - ``export(session:format:provider:directory:)`` — the exporter fetches
+///   the linear active path from a ``SwiftDataPersistenceProvider``. Use this
+///   when you have a SwiftData ``ChatSession`` in hand.
+///
+/// Files are written to a unique subdirectory of the system temporary
+/// directory by default; pass `directory:` to override (e.g. for tests or
+/// when targeting a sandboxed app group). The caller owns cleanup.
+public enum ConversationExporter {
+
+    // MARK: - Pure path (no persistence dependency)
+
+    /// Serialises `messages` via `format` and writes the result to disk.
+    public static func export(
+        session: ChatSessionRecord,
+        messages: [ChatMessageRecord],
+        format: ConversationExportFormat,
+        directory: URL? = nil
+    ) throws -> ShareableFile {
+        let data = try format.export(session: session, messages: messages)
+        let filename = sanitisedFilename(for: session, fileExtension: format.fileExtension)
+
+        let dir = try resolveDirectory(directory)
+        let fileURL = dir.appendingPathComponent(filename, isDirectory: false)
+
+        do {
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            throw ConversationExportError.writeFailed(fileURL, error.localizedDescription)
+        }
+
+        return ShareableFile(
+            url: fileURL,
+            suggestedFilename: filename,
+            contentType: format.contentType
+        )
+    }
+
+    // MARK: - SwiftData convenience
+
+    /// Loads the session's messages via `provider`, then writes the export.
+    ///
+    /// Uses the SwiftData ``ChatSession`` directly — `provider.fetchMessages`
+    /// returns the linear chronological history. Apps modelling branches
+    /// should call ``export(session:messages:format:directory:)`` with the
+    /// active path they have already materialised.
+    ///
+    /// `@MainActor` because ``ChatPersistenceProvider`` is `@MainActor`-isolated.
+    @MainActor
+    public static func export(
+        session: ChatSession,
+        format: ConversationExportFormat,
+        provider: ChatPersistenceProvider,
+        directory: URL? = nil
+    ) throws -> ShareableFile {
+        let messages = try provider.fetchMessages(for: session.id)
+        return try export(
+            session: session.record,
+            messages: messages,
+            format: format,
+            directory: directory
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Strips characters that don't survive `FileManager` round-trips on any
+    /// supported platform. Falls back to "chat" when the title is entirely
+    /// whitespace or filtered out.
+    static func sanitisedFilename(for session: ChatSessionRecord, fileExtension: String) -> String {
+        let stem = sanitiseStem(session.title)
+        return "\(stem).\(fileExtension)"
+    }
+
+    static func sanitiseStem(_ raw: String) -> String {
+        // Trim first so whitespace-only input (including \n/\t which would
+        // otherwise be replaced with _) falls back to "chat" cleanly.
+        let trimmedRaw = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedRaw.isEmpty {
+            return "chat"
+        }
+
+        // Slashes break path components; control characters break some
+        // share-sheet previews; colons break HFS+. Replace everything in
+        // one pass rather than chaining `replacingOccurrences`.
+        let banned: Set<Character> = ["/", "\\", ":", "*", "?", "\"", "<", ">", "|", "\n", "\r", "\t"]
+        let cleaned = trimmedRaw.unicodeScalars
+            .map { scalar -> Character in
+                let ch = Character(scalar)
+                if banned.contains(ch) { return "_" }
+                if scalar.value < 0x20 { return "_" }
+                return ch
+            }
+        var stem = String(cleaned).trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if stem.isEmpty {
+            stem = "chat"
+        }
+
+        // Cap length — APFS allows 255 UTF-8 bytes per path component, but
+        // share sheets truncate ugly long names. 80 chars is room enough for
+        // a meaningful title without dominating the preview.
+        if stem.count > 80 {
+            stem = String(stem.prefix(80))
+        }
+        return stem
+    }
+
+    private static func resolveDirectory(_ override: URL?) throws -> URL {
+        if let override {
+            try FileManager.default.createDirectory(at: override, withIntermediateDirectories: true)
+            return override
+        }
+        // Each export gets its own temp subdir so two exports of the same
+        // session don't clobber each other before the share sheet finishes.
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BaseChatKit-export-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+}

--- a/Sources/BaseChatCore/Services/ConversationExporter.swift
+++ b/Sources/BaseChatCore/Services/ConversationExporter.swift
@@ -106,11 +106,21 @@ public enum ConversationExporter {
 
     /// Strips characters that don't survive `FileManager` round-trips on any
     /// supported platform. Falls back to "chat" when the title is entirely
-    /// whitespace or filtered out.
+    /// whitespace or filtered out. The `fileExtension` is sanitised
+    /// independently — custom ``ConversationExportFormat`` adopters can return
+    /// arbitrary strings, so we never trust the value verbatim in a path
+    /// component.
     static func sanitisedFilename(for session: ChatSessionRecord, fileExtension: String) -> String {
         let stem = sanitiseStem(session.title)
-        return "\(stem).\(fileExtension)"
+        let ext = sanitiseFileExtension(fileExtension)
+        return "\(stem).\(ext)"
     }
+
+    /// Maximum stem length, measured in UTF-8 bytes. APFS allows 255 bytes per
+    /// path component; we leave headroom for the dot + extension and to keep
+    /// share-sheet previews readable. A scalar-by-scalar prefix below ensures
+    /// emoji and CJK characters never split mid-sequence.
+    private static let stemUTF8ByteLimit = 200
 
     static func sanitiseStem(_ raw: String) -> String {
         // Trim first so whitespace-only input (including \n/\t which would
@@ -137,13 +147,44 @@ public enum ConversationExporter {
             stem = "chat"
         }
 
-        // Cap length — APFS allows 255 UTF-8 bytes per path component, but
-        // share sheets truncate ugly long names. 80 chars is room enough for
-        // a meaningful title without dominating the preview.
-        if stem.count > 80 {
-            stem = String(stem.prefix(80))
-        }
+        // Cap by UTF-8 byte length, not grapheme count — an 80-emoji title is
+        // 320+ bytes and would blow past APFS's 255-byte path-component limit.
+        // Truncate Character-wise so we never split a multi-byte scalar.
+        stem = truncateToUTF8Bytes(stem, limit: stemUTF8ByteLimit)
         return stem
+    }
+
+    /// Restricts the extension to a conservative ASCII alphanumeric set so a
+    /// custom ``ConversationExportFormat`` can't slip `..`, a leading `.`, or
+    /// a path separator into the filename. Falls back to `"txt"` when the
+    /// caller's extension is empty or entirely outside the allowed set.
+    static func sanitiseFileExtension(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        let allowed = trimmed.unicodeScalars.filter { scalar in
+            (scalar.value >= 0x30 && scalar.value <= 0x39) || // 0-9
+                (scalar.value >= 0x41 && scalar.value <= 0x5A) || // A-Z
+                (scalar.value >= 0x61 && scalar.value <= 0x7A) // a-z
+        }
+        if allowed.isEmpty { return "txt" }
+        // Cap at 10 chars — `jsonl` is the longest built-in; leaving generous
+        // headroom for hypothetical custom formats without inviting abuse.
+        let capped = String(String.UnicodeScalarView(allowed.prefix(10)))
+        return capped
+    }
+
+    private static func truncateToUTF8Bytes(_ input: String, limit: Int) -> String {
+        if input.utf8.count <= limit { return input }
+        var out = ""
+        out.reserveCapacity(limit)
+        var bytes = 0
+        for character in input {
+            let charBytes = character.utf8.count
+            if bytes + charBytes > limit { break }
+            out.append(character)
+            bytes += charBytes
+        }
+        // Trim trailing whitespace introduced by truncation.
+        return out.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private static func resolveDirectory(_ override: URL?) throws -> URL {

--- a/Sources/BaseChatCore/Services/JSONLExportFormat.swift
+++ b/Sources/BaseChatCore/Services/JSONLExportFormat.swift
@@ -46,7 +46,12 @@ public struct JSONLExportFormat: ConversationExportFormat {
         iso.formatOptions = [.withInternetDateTime]
 
         var data = Data()
-        for message in messages {
+        // `ChatMessageRecord.content` only joins `.text` parts — thinking-only
+        // and tool-call-only messages would otherwise serialise as
+        // `"content":""`, which is misleading for downstream JSONL consumers
+        // (training pipelines especially). Skip them; expanding the wire
+        // shape to encode non-text parts is a follow-up.
+        for message in messages where message.hasVisibleContent {
             let line = Line(
                 role: message.role.rawValue,
                 content: message.content,

--- a/Sources/BaseChatCore/Services/JSONLExportFormat.swift
+++ b/Sources/BaseChatCore/Services/JSONLExportFormat.swift
@@ -1,0 +1,61 @@
+import Foundation
+import UniformTypeIdentifiers
+import BaseChatInference
+
+/// Built-in ``ConversationExportFormat`` that emits one JSON object per line.
+///
+/// Each line is a self-contained JSON record with `role`, `content`, and
+/// `timestamp` (ISO-8601). System messages are included so JSONL output can
+/// round-trip into training-data pipelines that expect them.
+///
+/// ```jsonl
+/// {"role":"user","content":"Hello","timestamp":"2026-04-27T10:00:00Z"}
+/// {"role":"assistant","content":"Hi","timestamp":"2026-04-27T10:00:01Z"}
+/// ```
+///
+/// The trailing newline after the last record is intentional — most JSONL
+/// readers treat a missing final newline as a truncated stream.
+public struct JSONLExportFormat: ConversationExportFormat {
+
+    public init() {}
+
+    public var fileExtension: String { "jsonl" }
+
+    // No system UTType for JSONL; .json is the closest semantic fit and
+    // keeps the share sheet from offering binary-only handlers.
+    public var contentType: UTType { .json }
+
+    /// Wire shape — keep tiny, stable, and Codable so apps can decode their
+    /// own exports without depending on internal record types.
+    private struct Line: Encodable {
+        let role: String
+        let content: String
+        let timestamp: String
+    }
+
+    public func export(session _: ChatSessionRecord, messages: [ChatMessageRecord]) throws -> Data {
+        let encoder = JSONEncoder()
+        // .sortedKeys for deterministic output — round-trip tests and
+        // diff-based snapshotting both rely on this.
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+
+        // Per-call formatter: ISO8601DateFormatter isn't Sendable, and the
+        // alternative (a global lock or static @MainActor) costs more than
+        // re-allocating it once per export.
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime]
+
+        var data = Data()
+        for message in messages {
+            let line = Line(
+                role: message.role.rawValue,
+                content: message.content,
+                timestamp: iso.string(from: message.timestamp)
+            )
+            let encoded = try encoder.encode(line)
+            data.append(encoded)
+            data.append(0x0A) // newline
+        }
+        return data
+    }
+}

--- a/Sources/BaseChatCore/Services/MarkdownExportFormat.swift
+++ b/Sources/BaseChatCore/Services/MarkdownExportFormat.swift
@@ -1,0 +1,68 @@
+import Foundation
+import UniformTypeIdentifiers
+import BaseChatInference
+
+/// Built-in ``ConversationExportFormat`` that renders a session as a Markdown
+/// document with a metadata header and one block per visible message.
+///
+/// Output shape:
+/// ```markdown
+/// # <session title>
+///
+/// *Exported: 2026-04-27T10:00:00Z*
+/// *Session created: 2026-04-26T09:30:00Z*
+///
+/// ---
+///
+/// **User:**
+///
+/// Hello
+///
+/// **Assistant:**
+///
+/// Hi there
+/// ```
+///
+/// System messages are omitted to match the share-sheet expectation (users
+/// rarely want to leak system prompts when forwarding a conversation). Apps
+/// that need them should ship a custom ``ConversationExportFormat``.
+public struct MarkdownExportFormat: ConversationExportFormat {
+
+    public init() {}
+
+    public var fileExtension: String { "md" }
+
+    // .text is the closest stable UTType — UTType.markdown only exists from
+    // macOS 26 / iOS 18, but we still target macOS 15 / iOS 18 (n-1). When
+    // macOS 27 lands and the floor moves, swap to `.markdown`.
+    public var contentType: UTType { .plainText }
+
+    public func export(session: ChatSessionRecord, messages: [ChatMessageRecord]) throws -> Data {
+        // Build a fresh formatter per call — ISO8601DateFormatter isn't Sendable,
+        // and the cost is negligible compared to the I/O the result drives.
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime]
+
+        var lines: [String] = []
+        lines.append("# \(session.title)")
+        lines.append("")
+        lines.append("*Exported: \(iso.string(from: Date()))*")
+        lines.append("*Session created: \(iso.string(from: session.createdAt))*")
+        lines.append("")
+        lines.append("---")
+        lines.append("")
+
+        for message in messages where message.role != .system {
+            let role = message.role == .user ? "User" : "Assistant"
+            lines.append("**\(role):**")
+            lines.append("")
+            lines.append(message.content)
+            lines.append("")
+        }
+
+        let joined = lines.joined(separator: "\n")
+        // String.data(using:) only returns nil for lossy conversions to a
+        // non-Unicode encoding — UTF-8 is total. Force-unwrap is safe.
+        return joined.data(using: .utf8)!
+    }
+}

--- a/Sources/BaseChatCore/Services/MarkdownExportFormat.swift
+++ b/Sources/BaseChatCore/Services/MarkdownExportFormat.swift
@@ -32,9 +32,9 @@ public struct MarkdownExportFormat: ConversationExportFormat {
 
     public var fileExtension: String { "md" }
 
-    // .text is the closest stable UTType — UTType.markdown only exists from
-    // macOS 26 / iOS 18, but we still target macOS 15 / iOS 18 (n-1). When
-    // macOS 27 lands and the floor moves, swap to `.markdown`.
+    // .plainText is the closest stable UTType — UTType.markdown only exists
+    // from macOS 26 / iOS 18, but we still target macOS 15 / iOS 18 (n-1).
+    // When macOS 27 lands and the floor moves, swap to `.markdown`.
     public var contentType: UTType { .plainText }
 
     public func export(session: ChatSessionRecord, messages: [ChatMessageRecord]) throws -> Data {
@@ -52,7 +52,12 @@ public struct MarkdownExportFormat: ConversationExportFormat {
         lines.append("---")
         lines.append("")
 
-        for message in messages where message.role != .system {
+        // Skip system prompts (privacy) and messages whose only parts are
+        // `.thinking` / `.toolCall` / non-text — `ChatMessageRecord.content`
+        // joins text parts only, so without the `hasVisibleContent` filter
+        // a thinking-only assistant turn would render as an empty
+        // `**Assistant:**` block.
+        for message in messages where message.role != .system && message.hasVisibleContent {
             let role = message.role == .user ? "User" : "Assistant"
             lines.append("**\(role):**")
             lines.append("")

--- a/Sources/BaseChatUI/Views/Chat/ExportButton.swift
+++ b/Sources/BaseChatUI/Views/Chat/ExportButton.swift
@@ -15,10 +15,10 @@ import BaseChatInference
 /// }
 /// ```
 ///
-/// The export runs synchronously when the user taps; for large sessions
-/// (>10k messages) a `Task` and a progress indicator may be more appropriate.
-/// We keep this synchronous because the dominant cost is `ShareLink`'s own
-/// sheet presentation, not the few-millisecond serialization.
+/// File generation is deferred to a user tap and the result is cached in
+/// `@State`; the toolbar `body` does no disk I/O. Apps that want richer error
+/// UX (banners, retry) should call ``ConversationExporter`` directly from a
+/// custom button action instead of using this convenience.
 public struct ExportButton<Format: ConversationExportFormat>: View {
 
     @Environment(ChatViewModel.self) private var viewModel
@@ -26,6 +26,11 @@ public struct ExportButton<Format: ConversationExportFormat>: View {
     private let format: Format
     private let label: String
     private let systemImage: String
+
+    /// Cached export — populated by a tap, cleared after sharing.
+    /// Keeping this in `@State` (not recomputed in `body`) is what prevents
+    /// the export pipeline from running on every SwiftUI invalidation.
+    @State private var pendingFile: PendingFile?
 
     /// - Parameters:
     ///   - format: The serializer. Use ``MarkdownExportFormat`` or
@@ -44,44 +49,61 @@ public struct ExportButton<Format: ConversationExportFormat>: View {
     }
 
     public var body: some View {
-        if let file = makeShareableFile() {
+        Button {
+            generate()
+        } label: {
+            Label(label, systemImage: systemImage)
+        }
+        .disabled(!hasExportableSession)
+        // `.sheet(item:)` only fires when `pendingFile` becomes non-nil — the
+        // file is written exactly once per tap. Auto-dismiss clears the
+        // state so the next tap regenerates with current messages.
+        .sheet(item: $pendingFile, onDismiss: cleanupPendingFile) { file in
             ShareLink(
-                item: file.url,
+                item: file.shareable.url,
                 subject: Text(viewModel.activeSession?.title ?? "Chat"),
                 message: Text("Exported from \(BaseChatConfiguration.shared.appName)"),
-                preview: SharePreview(file.suggestedFilename)
+                preview: SharePreview(file.shareable.suggestedFilename)
             ) {
-                Label(label, systemImage: systemImage)
+                Label("Share \(file.shareable.suggestedFilename)", systemImage: systemImage)
             }
-        } else {
-            // Disabled placeholder when there's nothing to export — keeps
-            // the toolbar layout stable across session switches.
-            Button {
-                // No-op
-            } label: {
-                Label(label, systemImage: systemImage)
-            }
-            .disabled(true)
+            .padding()
         }
     }
 
-    private func makeShareableFile() -> ShareableFile? {
-        guard let session = viewModel.activeSession else { return nil }
+    private var hasExportableSession: Bool {
+        viewModel.activeSession != nil && !viewModel.messages.isEmpty
+    }
+
+    private func generate() {
+        guard let session = viewModel.activeSession else { return }
         let messages = viewModel.messages
-        guard !messages.isEmpty else { return nil }
+        guard !messages.isEmpty else { return }
         do {
-            return try ConversationExporter.export(
+            let file = try ConversationExporter.export(
                 session: session,
                 messages: messages,
                 format: format
             )
+            pendingFile = PendingFile(shareable: file)
         } catch {
-            // Surfacing a banner from a SwiftUI computed body would loop
-            // through `@State`; log and fall back to a disabled button.
-            // Apps wanting richer error UX should call ``ConversationExporter``
-            // directly from a button action instead of using this convenience.
             Log.ui.error("Conversation export failed: \(error.localizedDescription)")
-            return nil
         }
+    }
+
+    private func cleanupPendingFile() {
+        // The exporter writes into a unique subdirectory of `tmp`; remove the
+        // whole directory so we don't leak the file once the share sheet
+        // closes. Best-effort: filesystem cleanup never blocks the user.
+        if let url = pendingFile?.shareable.url {
+            try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+        }
+        pendingFile = nil
+    }
+
+    /// Wraps ``ShareableFile`` with `Identifiable` so it drives `.sheet(item:)`.
+    private struct PendingFile: Identifiable {
+        let id = UUID()
+        let shareable: ShareableFile
     }
 }

--- a/Sources/BaseChatUI/Views/Chat/ExportButton.swift
+++ b/Sources/BaseChatUI/Views/Chat/ExportButton.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+import BaseChatCore
+import BaseChatInference
+
+/// Drop-in toolbar button that exports the active chat session via a
+/// ``ConversationExportFormat`` and presents the system share sheet.
+///
+/// Reads the active session and messages off `ChatViewModel` in the
+/// environment, so the button is a one-liner at the call site:
+///
+/// ```swift
+/// .toolbar {
+///     ExportButton(format: MarkdownExportFormat())
+///     ExportButton(format: JSONLExportFormat())
+/// }
+/// ```
+///
+/// The export runs synchronously when the user taps; for large sessions
+/// (>10k messages) a `Task` and a progress indicator may be more appropriate.
+/// We keep this synchronous because the dominant cost is `ShareLink`'s own
+/// sheet presentation, not the few-millisecond serialization.
+public struct ExportButton<Format: ConversationExportFormat>: View {
+
+    @Environment(ChatViewModel.self) private var viewModel
+
+    private let format: Format
+    private let label: String
+    private let systemImage: String
+
+    /// - Parameters:
+    ///   - format: The serializer. Use ``MarkdownExportFormat`` or
+    ///     ``JSONLExportFormat`` for the built-in formats, or pass a custom
+    ///     ``ConversationExportFormat`` from your app.
+    ///   - label: Visible text on the button. Defaults to "Export".
+    ///   - systemImage: SF Symbol name. Defaults to `square.and.arrow.up`.
+    public init(
+        format: Format,
+        label: String = "Export",
+        systemImage: String = "square.and.arrow.up"
+    ) {
+        self.format = format
+        self.label = label
+        self.systemImage = systemImage
+    }
+
+    public var body: some View {
+        if let file = makeShareableFile() {
+            ShareLink(
+                item: file.url,
+                subject: Text(viewModel.activeSession?.title ?? "Chat"),
+                message: Text("Exported from \(BaseChatConfiguration.shared.appName)"),
+                preview: SharePreview(file.suggestedFilename)
+            ) {
+                Label(label, systemImage: systemImage)
+            }
+        } else {
+            // Disabled placeholder when there's nothing to export — keeps
+            // the toolbar layout stable across session switches.
+            Button {
+                // No-op
+            } label: {
+                Label(label, systemImage: systemImage)
+            }
+            .disabled(true)
+        }
+    }
+
+    private func makeShareableFile() -> ShareableFile? {
+        guard let session = viewModel.activeSession else { return nil }
+        let messages = viewModel.messages
+        guard !messages.isEmpty else { return nil }
+        do {
+            return try ConversationExporter.export(
+                session: session,
+                messages: messages,
+                format: format
+            )
+        } catch {
+            // Surfacing a banner from a SwiftUI computed body would loop
+            // through `@State`; log and fall back to a disabled button.
+            // Apps wanting richer error UX should call ``ConversationExporter``
+            // directly from a button action instead of using this convenience.
+            Log.ui.error("Conversation export failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Tests/BaseChatCoreTests/ConversationExporterTests.swift
+++ b/Tests/BaseChatCoreTests/ConversationExporterTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+import SwiftData
+@testable import BaseChatCore
+import BaseChatInference
+import BaseChatTestSupport
+
+/// Tests for ``ConversationExporter`` — file output, filename sanitization,
+/// and the SwiftData-fetching convenience overload.
+///
+/// Classified integration where we drive the persistence harness, unit
+/// elsewhere.
+@MainActor
+final class ConversationExporterTests: XCTestCase {
+
+    private var stack: InMemoryPersistenceHarness.Stack!
+    private var tempDir: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        stack = try InMemoryPersistenceHarness.make()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ConversationExporterTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        stack = nil
+        if let tempDir, FileManager.default.fileExists(atPath: tempDir.path) {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        tempDir = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Pure path
+
+    func test_export_writesFileWithExpectedExtension() throws {
+        let session = ChatSessionRecord(title: "Hello")
+        let file = try ConversationExporter.export(
+            session: session,
+            messages: [ChatMessageRecord(role: .user, content: "hi", sessionID: session.id)],
+            format: MarkdownExportFormat(),
+            directory: tempDir
+        )
+
+        XCTAssertTrue(file.suggestedFilename.hasSuffix(".md"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: file.url.path))
+    }
+
+    func test_export_fileContentsMatchFormatOutput() throws {
+        let format = MarkdownExportFormat()
+        let session = ChatSessionRecord(title: "RoundTrip")
+        let messages = [
+            ChatMessageRecord(role: .user, content: "Q?", sessionID: session.id),
+            ChatMessageRecord(role: .assistant, content: "A!", sessionID: session.id)
+        ]
+
+        let file = try ConversationExporter.export(
+            session: session,
+            messages: messages,
+            format: format,
+            directory: tempDir
+        )
+
+        let onDisk = try Data(contentsOf: file.url)
+        let direct = try format.export(session: session, messages: messages)
+        XCTAssertEqual(onDisk, direct)
+    }
+
+    func test_export_returnsContentTypeFromFormat() throws {
+        let session = ChatSessionRecord(title: "ct")
+        let file = try ConversationExporter.export(
+            session: session,
+            messages: [],
+            format: JSONLExportFormat(),
+            directory: tempDir
+        )
+        XCTAssertEqual(file.contentType.identifier, "public.json")
+    }
+
+    // MARK: - Filename sanitization
+
+    func test_sanitiseStem_replacesPathSeparators() {
+        XCTAssertFalse(ConversationExporter.sanitiseStem("a/b\\c").contains("/"))
+        XCTAssertFalse(ConversationExporter.sanitiseStem("a/b\\c").contains("\\"))
+    }
+
+    func test_sanitiseStem_replacesControlCharacters() {
+        XCTAssertFalse(ConversationExporter.sanitiseStem("hello\nworld").contains("\n"))
+        XCTAssertFalse(ConversationExporter.sanitiseStem("hello\u{0007}bell").contains("\u{0007}"))
+    }
+
+    func test_sanitiseStem_fallsBackToChatWhenEmpty() {
+        XCTAssertEqual(ConversationExporter.sanitiseStem(""), "chat")
+        XCTAssertEqual(ConversationExporter.sanitiseStem("   \n\t  "), "chat")
+    }
+
+    func test_sanitiseStem_capsLength() {
+        let long = String(repeating: "x", count: 500)
+        XCTAssertEqual(ConversationExporter.sanitiseStem(long).count, 80)
+    }
+
+    func test_sanitisedFilename_appendsExtension() {
+        let session = ChatSessionRecord(title: "demo")
+        let name = ConversationExporter.sanitisedFilename(for: session, fileExtension: "jsonl")
+        XCTAssertEqual(name, "demo.jsonl")
+    }
+
+    // MARK: - SwiftData convenience overload
+
+    func test_export_viaPersistenceProvider_fetchesMessagesInOrder() throws {
+        let session = ChatSession(title: "Provider Path")
+        stack.context.insert(session)
+        try stack.context.save()
+
+        // Insert messages out of order to verify the exporter relies on
+        // the provider's chronological sort, not raw fetch order.
+        let later = ChatMessageRecord(
+            role: .assistant,
+            content: "second",
+            timestamp: Date(timeIntervalSinceReferenceDate: 100),
+            sessionID: session.id
+        )
+        let earlier = ChatMessageRecord(
+            role: .user,
+            content: "first",
+            timestamp: Date(timeIntervalSinceReferenceDate: 0),
+            sessionID: session.id
+        )
+        try stack.provider.insertMessage(later)
+        try stack.provider.insertMessage(earlier)
+
+        let file = try ConversationExporter.export(
+            session: session,
+            format: MarkdownExportFormat(),
+            provider: stack.provider,
+            directory: tempDir
+        )
+
+        let text = try String(contentsOf: file.url, encoding: .utf8)
+        let firstRange = try XCTUnwrap(text.range(of: "first"))
+        let secondRange = try XCTUnwrap(text.range(of: "second"))
+        XCTAssertLessThan(firstRange.lowerBound, secondRange.lowerBound)
+    }
+
+    func test_export_useDefaultDirectory_writesToTemp() throws {
+        // Exercise the nil-directory path so the temp-dir branch is covered.
+        let session = ChatSessionRecord(title: "tempy")
+        let file = try ConversationExporter.export(
+            session: session,
+            messages: [ChatMessageRecord(role: .user, content: "hi", sessionID: session.id)],
+            format: MarkdownExportFormat(),
+            directory: nil
+        )
+
+        XCTAssertTrue(
+            file.url.path.hasPrefix(FileManager.default.temporaryDirectory.path)
+                || file.url.path.hasPrefix("/private\(FileManager.default.temporaryDirectory.path)"),
+            "Expected default export to live under temp dir; got \(file.url.path)"
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: file.url.path))
+
+        // Caller owns cleanup; clean up so we don't leak fixtures.
+        try? FileManager.default.removeItem(at: file.url.deletingLastPathComponent())
+    }
+}

--- a/Tests/BaseChatCoreTests/ConversationExporterTests.swift
+++ b/Tests/BaseChatCoreTests/ConversationExporterTests.swift
@@ -95,9 +95,38 @@ final class ConversationExporterTests: XCTestCase {
         XCTAssertEqual(ConversationExporter.sanitiseStem("   \n\t  "), "chat")
     }
 
-    func test_sanitiseStem_capsLength() {
-        let long = String(repeating: "x", count: 500)
-        XCTAssertEqual(ConversationExporter.sanitiseStem(long).count, 80)
+    func test_sanitiseStem_capsByUTF8ByteLength() {
+        // ASCII: byte-count == grapheme-count, capped at 200 bytes.
+        let asciiLong = String(repeating: "x", count: 500)
+        XCTAssertEqual(ConversationExporter.sanitiseStem(asciiLong).utf8.count, 200)
+
+        // Multi-byte: 4-byte emoji must stay below the 200-byte ceiling and
+        // never split mid-scalar. 100 raccoons is 400 UTF-8 bytes raw.
+        let emojiLong = String(repeating: "🦊", count: 100)
+        let stem = ConversationExporter.sanitiseStem(emojiLong)
+        XCTAssertLessThanOrEqual(stem.utf8.count, 200)
+        // Re-decoding from UTF-8 must succeed — no truncation in the middle of a scalar.
+        let bytes = Data(stem.utf8)
+        XCTAssertEqual(String(data: bytes, encoding: .utf8), stem)
+    }
+
+    func test_sanitiseFileExtension_stripsPathTraversal() {
+        XCTAssertEqual(ConversationExporter.sanitiseFileExtension("../etc"), "etc")
+        XCTAssertEqual(ConversationExporter.sanitiseFileExtension("md/secret"), "mdsecret")
+        XCTAssertEqual(ConversationExporter.sanitiseFileExtension(".hidden"), "hidden")
+    }
+
+    func test_sanitiseFileExtension_fallsBackOnEmpty() {
+        XCTAssertEqual(ConversationExporter.sanitiseFileExtension(""), "txt")
+        XCTAssertEqual(ConversationExporter.sanitiseFileExtension("///"), "txt")
+        XCTAssertEqual(ConversationExporter.sanitiseFileExtension("..."), "txt")
+    }
+
+    func test_sanitisedFilename_doesNotEscapeDirectory() {
+        let session = ChatSessionRecord(title: "demo")
+        let name = ConversationExporter.sanitisedFilename(for: session, fileExtension: "../evil")
+        XCTAssertFalse(name.contains("/"))
+        XCTAssertFalse(name.contains(".."))
     }
 
     func test_sanitisedFilename_appendsExtension() {

--- a/Tests/BaseChatCoreTests/JSONLExportFormatTests.swift
+++ b/Tests/BaseChatCoreTests/JSONLExportFormatTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import BaseChatCore
+import BaseChatInference
+
+/// Unit tests for ``JSONLExportFormat``.
+final class JSONLExportFormatTests: XCTestCase {
+
+    private let sessionID = UUID()
+
+    private func makeRecord() -> ChatSessionRecord {
+        ChatSessionRecord(id: sessionID, title: "JSONL Session")
+    }
+
+    private func makeMessage(role: MessageRole, content: String, offset: TimeInterval = 0) -> ChatMessageRecord {
+        ChatMessageRecord(
+            role: role,
+            content: content,
+            timestamp: Date(timeIntervalSinceReferenceDate: 0).addingTimeInterval(offset),
+            sessionID: sessionID
+        )
+    }
+
+    /// Splits JSONL output into trimmed non-empty lines.
+    private func lines(of data: Data) throws -> [String] {
+        let text = try XCTUnwrap(String(data: data, encoding: .utf8))
+        return text.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+    }
+
+    func test_export_emitsOneJSONObjectPerMessage() throws {
+        let format = JSONLExportFormat()
+        let data = try format.export(
+            session: makeRecord(),
+            messages: [
+                makeMessage(role: .user, content: "a", offset: 0),
+                makeMessage(role: .assistant, content: "b", offset: 1),
+                makeMessage(role: .user, content: "c", offset: 2)
+            ]
+        )
+
+        let lines = try self.lines(of: data)
+        XCTAssertEqual(lines.count, 3)
+    }
+
+    func test_export_eachLineIsValidJSON() throws {
+        let format = JSONLExportFormat()
+        let data = try format.export(
+            session: makeRecord(),
+            messages: [
+                makeMessage(role: .user, content: "hello"),
+                makeMessage(role: .assistant, content: "world", offset: 1)
+            ]
+        )
+
+        for line in try lines(of: data) {
+            let lineData = try XCTUnwrap(line.data(using: .utf8))
+            // Throws if the line is not valid JSON — captured by XCTest as a failure.
+            let object = try JSONSerialization.jsonObject(with: lineData)
+            let dict = try XCTUnwrap(object as? [String: Any])
+            XCTAssertNotNil(dict["role"])
+            XCTAssertNotNil(dict["content"])
+            XCTAssertNotNil(dict["timestamp"])
+        }
+    }
+
+    func test_export_preservesRoleAndContentExactly() throws {
+        let format = JSONLExportFormat()
+        let data = try format.export(
+            session: makeRecord(),
+            messages: [makeMessage(role: .assistant, content: "the answer is 42")]
+        )
+
+        let lineData = try XCTUnwrap(try lines(of: data).first?.data(using: .utf8))
+        let dict = try XCTUnwrap(try JSONSerialization.jsonObject(with: lineData) as? [String: Any])
+        XCTAssertEqual(dict["role"] as? String, "assistant")
+        XCTAssertEqual(dict["content"] as? String, "the answer is 42")
+    }
+
+    func test_export_includesSystemMessages() throws {
+        // JSONL is a training-data format — system prompts must round-trip.
+        let format = JSONLExportFormat()
+        let data = try format.export(
+            session: makeRecord(),
+            messages: [
+                makeMessage(role: .system, content: "be concise"),
+                makeMessage(role: .user, content: "hi", offset: 1)
+            ]
+        )
+
+        let lines = try self.lines(of: data)
+        XCTAssertEqual(lines.count, 2)
+        let first = try XCTUnwrap(JSONSerialization.jsonObject(with: lines[0].data(using: .utf8)!) as? [String: Any])
+        XCTAssertEqual(first["role"] as? String, "system")
+    }
+
+    func test_export_handlesUnicodeContent() throws {
+        let format = JSONLExportFormat()
+        let payload = "café 漢字 🦊 \"quoted\" \\backslash newline\nin-content"
+        let data = try format.export(
+            session: makeRecord(),
+            messages: [makeMessage(role: .user, content: payload)]
+        )
+
+        let lines = try self.lines(of: data)
+        XCTAssertEqual(lines.count, 1, "An embedded \\n in content must remain escaped, not split the line")
+
+        let dict = try XCTUnwrap(JSONSerialization.jsonObject(with: lines[0].data(using: .utf8)!) as? [String: Any])
+        XCTAssertEqual(dict["content"] as? String, payload)
+    }
+
+    func test_export_emptyMessagesProducesEmptyData() throws {
+        let format = JSONLExportFormat()
+        let data = try format.export(session: makeRecord(), messages: [])
+        XCTAssertEqual(data.count, 0)
+    }
+
+    func test_export_endsWithNewline() throws {
+        let format = JSONLExportFormat()
+        let data = try format.export(
+            session: makeRecord(),
+            messages: [makeMessage(role: .user, content: "hi")]
+        )
+        XCTAssertEqual(data.last, 0x0A, "JSONL convention: every record (including the last) ends with \\n")
+    }
+
+    func test_format_metadata() {
+        let format = JSONLExportFormat()
+        XCTAssertEqual(format.fileExtension, "jsonl")
+        XCTAssertEqual(format.contentType.identifier, "public.json")
+    }
+}

--- a/Tests/BaseChatCoreTests/JSONLExportFormatTests.swift
+++ b/Tests/BaseChatCoreTests/JSONLExportFormatTests.swift
@@ -122,6 +122,28 @@ final class JSONLExportFormatTests: XCTestCase {
         XCTAssertEqual(data.last, 0x0A, "JSONL convention: every record (including the last) ends with \\n")
     }
 
+    func test_export_skipsMessagesWithoutVisibleContent() throws {
+        // A thinking-only or tool-only message has empty `.content`. Emitting
+        // `"content":""` would mislead training-data pipelines, so the JSONL
+        // export must drop these rows entirely.
+        let format = JSONLExportFormat()
+        let thinkingOnly = ChatMessageRecord(
+            role: .assistant,
+            contentParts: [.thinking("internal monologue")],
+            timestamp: Date(timeIntervalSinceReferenceDate: 0),
+            sessionID: sessionID
+        )
+        let visible = makeMessage(role: .user, content: "hi", offset: 1)
+
+        let data = try format.export(session: makeRecord(), messages: [thinkingOnly, visible])
+        let lines = try self.lines(of: data)
+        XCTAssertEqual(lines.count, 1, "Empty-content rows must be skipped, not encoded as content:\"\"")
+
+        let dict = try XCTUnwrap(JSONSerialization.jsonObject(with: lines[0].data(using: .utf8)!) as? [String: Any])
+        XCTAssertEqual(dict["role"] as? String, "user")
+        XCTAssertEqual(dict["content"] as? String, "hi")
+    }
+
     func test_format_metadata() {
         let format = JSONLExportFormat()
         XCTAssertEqual(format.fileExtension, "jsonl")

--- a/Tests/BaseChatCoreTests/MarkdownExportFormatTests.swift
+++ b/Tests/BaseChatCoreTests/MarkdownExportFormatTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+@testable import BaseChatCore
+import BaseChatInference
+
+/// Unit tests for ``MarkdownExportFormat`` — pure serialization, no SwiftData.
+final class MarkdownExportFormatTests: XCTestCase {
+
+    private let sessionID = UUID()
+
+    private func makeRecord(title: String = "Round Trip") -> ChatSessionRecord {
+        ChatSessionRecord(id: sessionID, title: title)
+    }
+
+    private func makeMessage(role: MessageRole, content: String, offset: TimeInterval = 0) -> ChatMessageRecord {
+        ChatMessageRecord(
+            role: role,
+            content: content,
+            timestamp: Date(timeIntervalSinceReferenceDate: 0).addingTimeInterval(offset),
+            sessionID: sessionID
+        )
+    }
+
+    func test_export_includesTitleHeader() throws {
+        let format = MarkdownExportFormat()
+        let data = try format.export(
+            session: makeRecord(title: "My Chat"),
+            messages: []
+        )
+
+        let text = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertTrue(text.hasPrefix("# My Chat\n"), "Markdown must start with H1 title; got: \(text)")
+    }
+
+    func test_export_includesExportTimestampInHeader() throws {
+        let format = MarkdownExportFormat()
+        let data = try format.export(
+            session: makeRecord(),
+            messages: []
+        )
+
+        let text = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertTrue(text.contains("*Exported:"), "Header must include export timestamp marker")
+        XCTAssertTrue(text.contains("*Session created:"), "Header must include session creation timestamp")
+    }
+
+    func test_export_rendersUserAndAssistantBlocks() throws {
+        let format = MarkdownExportFormat()
+        let data = try format.export(
+            session: makeRecord(),
+            messages: [
+                makeMessage(role: .user, content: "Hello"),
+                makeMessage(role: .assistant, content: "Hi there!", offset: 1)
+            ]
+        )
+
+        let text = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertTrue(text.contains("**User:**"))
+        XCTAssertTrue(text.contains("Hello"))
+        XCTAssertTrue(text.contains("**Assistant:**"))
+        XCTAssertTrue(text.contains("Hi there!"))
+    }
+
+    func test_export_omitsSystemMessages() throws {
+        let format = MarkdownExportFormat()
+        let data = try format.export(
+            session: makeRecord(),
+            messages: [
+                makeMessage(role: .system, content: "You are a helpful assistant"),
+                makeMessage(role: .user, content: "Hi", offset: 1)
+            ]
+        )
+
+        let text = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertFalse(text.contains("You are a helpful assistant"), "System content must not leak into Markdown export")
+        XCTAssertTrue(text.contains("Hi"))
+    }
+
+    func test_export_emptySessionStillProducesValidDocument() throws {
+        let format = MarkdownExportFormat()
+        let data = try format.export(
+            session: makeRecord(title: "Empty"),
+            messages: []
+        )
+
+        let text = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertTrue(text.contains("# Empty"))
+        XCTAssertTrue(text.contains("---"))
+        XCTAssertFalse(text.contains("**User:**"))
+        XCTAssertFalse(text.contains("**Assistant:**"))
+    }
+
+    func test_export_preservesUnicodeContent() throws {
+        let format = MarkdownExportFormat()
+        let data = try format.export(
+            session: makeRecord(),
+            messages: [makeMessage(role: .user, content: "café 漢字 🦊")]
+        )
+
+        let text = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertTrue(text.contains("café 漢字 🦊"))
+    }
+
+    func test_export_preservesMessageOrder() throws {
+        let format = MarkdownExportFormat()
+        let data = try format.export(
+            session: makeRecord(),
+            messages: [
+                makeMessage(role: .user, content: "first", offset: 0),
+                makeMessage(role: .assistant, content: "second", offset: 1),
+                makeMessage(role: .user, content: "third", offset: 2)
+            ]
+        )
+
+        let text = try XCTUnwrap(String(data: data, encoding: .utf8))
+        guard
+            let firstRange = text.range(of: "first"),
+            let secondRange = text.range(of: "second"),
+            let thirdRange = text.range(of: "third")
+        else {
+            XCTFail("All three messages must appear")
+            return
+        }
+        XCTAssertLessThan(firstRange.lowerBound, secondRange.lowerBound)
+        XCTAssertLessThan(secondRange.lowerBound, thirdRange.lowerBound)
+    }
+
+    func test_format_metadata() {
+        let format = MarkdownExportFormat()
+        XCTAssertEqual(format.fileExtension, "md")
+        // .plainText is the deliberate fallback while we still support
+        // macOS 15 where UTType.markdown isn't available.
+        XCTAssertEqual(format.contentType.identifier, "public.plain-text")
+    }
+}

--- a/Tests/BaseChatCoreTests/MarkdownExportFormatTests.swift
+++ b/Tests/BaseChatCoreTests/MarkdownExportFormatTests.swift
@@ -124,6 +124,29 @@ final class MarkdownExportFormatTests: XCTestCase {
         XCTAssertLessThan(secondRange.lowerBound, thirdRange.lowerBound)
     }
 
+    func test_export_skipsMessagesWithoutVisibleContent() throws {
+        // Thinking-only / tool-only messages have empty `.content` even
+        // though they're not "empty" semantically. The Markdown export must
+        // not emit a hollow `**Assistant:**` block for them.
+        let format = MarkdownExportFormat()
+        let thinkingOnly = ChatMessageRecord(
+            role: .assistant,
+            contentParts: [.thinking("internal monologue")],
+            timestamp: Date(timeIntervalSinceReferenceDate: 0),
+            sessionID: sessionID
+        )
+        let visible = makeMessage(role: .user, content: "Hi", offset: 1)
+
+        let data = try format.export(session: makeRecord(), messages: [thinkingOnly, visible])
+        let text = try XCTUnwrap(String(data: data, encoding: .utf8))
+
+        // Exactly one role block — the user one. No empty assistant block.
+        let assistantBlocks = text.components(separatedBy: "**Assistant:**").count - 1
+        XCTAssertEqual(assistantBlocks, 0, "Thinking-only assistant turn must not render an empty block")
+        XCTAssertTrue(text.contains("**User:**"))
+        XCTAssertFalse(text.contains("internal monologue"), "Thinking content must not leak into Markdown export")
+    }
+
     func test_format_metadata() {
         let format = MarkdownExportFormat()
         XCTAssertEqual(format.fileExtension, "md")

--- a/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
+++ b/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
@@ -211,6 +211,12 @@ BaseChatUIModelManagement/ViewModels/ModelManagementViewModel.swift:try? await T
 BaseChatUI/Views/Chat/AssistantMarkdownView.swift:if let parsed = try? AttributedString(
 BaseChatUI/Views/Chat/TypingIndicatorView.swift:try? await Task.sleep(for: .milliseconds(400))
 
+# Best-effort cleanup of the temp directory holding a just-shared export
+# file. The share sheet has dismissed; if the file is gone (user moved it,
+# AirDrop snapshotted it, race with reaper), the unlink is a no-op and
+# nothing actionable would come of surfacing the error.
+BaseChatUI/Views/Chat/ExportButton.swift:try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+
 # False positive: `toolRegistry?` optional chain contains the substring
 # `try?` inside `Regis-try?`. No `try?` call site is present on this
 # line; the audit's substring scan is not AST-aware.


### PR DESCRIPTION
Add a `ConversationExportFormat` protocol and built-in `MarkdownExportFormat` / `JSONLExportFormat` exporters to `BaseChatCore` so apps can offer conversation export without hand-rolling serialization. The framework owns the message model, so it should own the canonical export path.

`ConversationExporter` writes through any conforming format and returns a `ShareableFile` for `ShareLink`. `ExportButton` is a drop-in toolbar item shipped in `BaseChatUI`. Filename sanitisation falls back to `chat` for whitespace-only or empty titles, replaces banned path characters with `_`, and caps stem length at 80 chars.

Tests: `MarkdownExportFormatTests`, `JSONLExportFormatTests`, `ConversationExporterTests` — in-memory SwiftData per CLAUDE.md test conventions, sabotage-verified.

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)