### PR TITLE
chore(repo): add CODEOWNERS for security-sensitive paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,42 @@
+# BaseChatKit CODEOWNERS
+#
+# This file declares ownership for security-sensitive paths so that PRs
+# touching them automatically request review from the listed owners.
+#
+# Tracking: https://github.com/roryford/BaseChatKit/issues/729 (Phase 5 of #714).
+#
+# NOTE: With a single human maintainer (@roryford), required-Code-Owner-review
+# is decorative — the sole owner authoring a PR cannot self-approve a Code
+# Owner review even when branch protection requires it. This file is being
+# landed first so that the moment a second reviewer joins, the rules are
+# already in place; the second owner can be added in a one-line edit and
+# the security-reviewer slot will start gating PRs immediately.
+
+# Default fallback — every change pings the maintainer.
+*                                                  @roryford
+
+# Cloud backends and SSE transport — credential handling, TLS, request integrity.
+/Sources/BaseChatBackends/Claude*                  @roryford
+/Sources/BaseChatBackends/OpenAI*                  @roryford
+/Sources/BaseChatBackends/SSECloud*                @roryford
+/Sources/BaseChatBackends/PinnedSession*           @roryford
+/Sources/BaseChatBackends/DNSRebindingGuard*       @roryford
+
+# Macros plugin — executes at compile time in any consumer's build.
+/Sources/BaseChatMacrosPlugin/**                   @roryford
+
+# Build manifest — trait/dependency surface review.
+/Package.swift                                     @roryford
+
+# Network-isolation and traffic-boundary regression tests.
+/Tests/**/TrafficBoundaryAuditTest.swift           @roryford
+/Tests/**/LocalOnlyNetworkIsolation*.swift         @roryford
+
+# Build-mode CI lane and helper script.
+/.github/workflows/build-modes.yml                 @roryford
+/scripts/build-modes.sh                            @roryford
+
+# Security-facing documentation.
+/.github/SECURITY.md                               @roryford
+/SECURITY.md                                       @roryford
+/docs/THREAT_MODEL.md                              @roryford


### PR DESCRIPTION
Declare ownership for security-sensitive paths so PRs touching them automatically request review from the listed owners.

Covers cloud backends (Claude/OpenAI/SSE/PinnedSession/DNSRebindingGuard), the macros plugin (compile-time code execution), Package.swift, traffic-boundary and local-only network-isolation regression tests, the build-mode CI lane + helper script, and security-facing docs.

With a single human maintainer the required-Code-Owner-review rule is decorative — the sole owner authoring a PR cannot self-approve. Landing this file first means the moment a second reviewer joins, the security-reviewer slot starts gating PRs immediately via a one-line edit.

Branch-protection settings (required reviews, force-push prohibition, signed-commit requirement) need to be applied via repo settings UI — not in this PR. Issue #729 stays open until those land.

Refs #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)