### PR TITLE
docs(security): SECURITY.md + THREAT_MODEL.md + indexed CONTRIBUTING

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,42 @@
+# BaseChatKit CODEOWNERS
+#
+# This file declares ownership for security-sensitive paths so that PRs
+# touching them automatically request review from the listed owners.
+#
+# Tracking: https://github.com/roryford/BaseChatKit/issues/729 (Phase 5 of #714).
+#
+# NOTE: With a single human maintainer (@roryford), required-Code-Owner-review
+# is decorative — the sole owner authoring a PR cannot self-approve a Code
+# Owner review even when branch protection requires it. This file is being
+# landed first so that the moment a second reviewer joins, the rules are
+# already in place; the second owner can be added in a one-line edit and
+# the security-reviewer slot will start gating PRs immediately.
+
+# Default fallback — every change pings the maintainer.
+*                                                  @roryford
+
+# Cloud backends and SSE transport — credential handling, TLS, request integrity.
+/Sources/BaseChatBackends/Claude*                  @roryford
+/Sources/BaseChatBackends/OpenAI*                  @roryford
+/Sources/BaseChatBackends/SSECloud*                @roryford
+/Sources/BaseChatBackends/PinnedSession*           @roryford
+/Sources/BaseChatBackends/DNSRebindingGuard*       @roryford
+
+# Macros plugin — executes at compile time in any consumer's build.
+/Sources/BaseChatMacrosPlugin/**                   @roryford
+
+# Build manifest — trait/dependency surface review.
+/Package.swift                                     @roryford
+
+# Network-isolation and traffic-boundary regression tests.
+/Tests/**/TrafficBoundaryAuditTest.swift           @roryford
+/Tests/**/LocalOnlyNetworkIsolation*.swift         @roryford
+
+# Build-mode CI lane and helper script.
+/.github/workflows/build-modes.yml                 @roryford
+/scripts/build-modes.sh                            @roryford
+
+# Security-facing documentation.
+/.github/SECURITY.md                               @roryford
+/SECURITY.md                                       @roryford
+/docs/THREAT_MODEL.md                              @roryford

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,55 +1,21 @@
 # Security Policy
 
-## Supported Versions
+The canonical security policy for BaseChatKit lives at the repository root:
 
-| Version | Supported |
-|---------|-----------|
-| 0.2.x   | Yes       |
-| < 0.2   | No        |
+- [`SECURITY.md`](../SECURITY.md) — supported versions, supported build modes,
+  reporting a vulnerability, cryptography at rest, and pending mitigations.
+- [`docs/THREAT_MODEL.md`](../docs/THREAT_MODEL.md) — the engineering-honest threat
+  model: assets, trust boundaries, mitigation enforcement table, and known
+  non-mitigations.
 
-## Reporting a Vulnerability
+This file remains as a redirect because GitHub looks for `SECURITY.md` in `.github/`,
+the repository root, and `docs/` — keeping a copy here ensures the **Security** tab
+surface in the GitHub UI continues to render after the canonical doc moved to the
+root.
 
-**Please do not open public issues for security vulnerabilities.**
+## Reporting
 
-Report vulnerabilities through [GitHub Security Advisories](https://github.com/roryford/BaseChatKit/security/advisories/new). This keeps the discussion private until a fix is available.
+Use [GitHub Security Advisories](https://github.com/roryford/BaseChatKit/security/advisories/new)
+for private disclosure. **Do not** open public issues for security-impacting bugs.
 
-Please include:
-
-- A description of the vulnerability
-- Steps to reproduce
-- Affected versions
-- Any potential mitigations you've identified
-
-## Response Timeline
-
-| Step | Target |
-|------|--------|
-| Acknowledge report | 48 hours |
-| Triage and severity assessment | 5 business days |
-| Patch release | 30 days |
-
-We may adjust timelines for complex issues, but will keep you informed of progress.
-
-## Scope
-
-The following areas are considered in-scope for security reports:
-
-- **Credential handling** — API key storage, Keychain usage, key exposure in logs or memory
-- **Network security** — certificate pinning, TLS validation, request integrity
-- **Input validation** — prompt injection, path traversal, malformed model responses
-- **Local data** — SwiftData persistence, conversation export, temporary files
-
-## Out of Scope
-
-- Vulnerabilities in upstream dependencies (report these to the relevant project)
-- Attacks requiring physical access to the device
-- Local denial-of-service (e.g., loading a model that exhausts memory)
-- Social engineering
-
-## Acknowledgement
-
-We credit reporters in the release notes for confirmed vulnerabilities, unless you prefer to remain anonymous. Let us know your preference when reporting.
-
-## Disclosure Policy
-
-We follow coordinated disclosure. Once a fix is released, we publish a security advisory with full details. We ask reporters to wait until the advisory is published before disclosing publicly.
+Full policy: [`SECURITY.md` § Reporting a vulnerability](../SECURITY.md#reporting-a-vulnerability).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,30 @@
 # Contributing to BaseChatKit
 
-Thank you for your interest in contributing. This guide covers everything you need to get started.
+Thank you for your interest in contributing.
 
-## Getting Started
+This guide is **indexed by change type** — find the section that matches the change
+you're making and follow the gates listed there. Cross-references point at
+[CLAUDE.md](CLAUDE.md), the authoritative dev reference, rather than duplicating it.
+
+## Table of contents
+
+- [Getting started](#getting-started)
+- [Pre-push checklist](#pre-push-checklist) — run **every** time, regardless of
+  change type
+- [Adding a new backend](#adding-a-new-backend)
+- [Adding a UI view](#adding-a-ui-view)
+- [Adding a dependency](#adding-a-dependency)
+- [Adding a network feature](#adding-a-network-feature)
+- [Adding a macro](#adding-a-macro)
+- [Adding a setting / configuration flag](#adding-a-setting--configuration-flag)
+- [Commit style](#commit-style)
+- [Pull request process](#pull-request-process)
+- [PR hygiene](#pr-hygiene)
+- [Reporting bugs](#reporting-bugs)
+- [Reporting security vulnerabilities](#reporting-security-vulnerabilities)
+- [License](#license)
+
+## Getting started
 
 ```bash
 git clone https://github.com/roryford/BaseChatKit.git
@@ -11,111 +33,240 @@ swift build
 swift test
 ```
 
-`swift build` will resolve package dependencies on first run. `BaseChatBackends` pulls in MLX xcframeworks, so the initial fetch may take a moment.
+`swift build` resolves package dependencies on first run. `BaseChatBackends` pulls in
+MLX and llama.cpp xcframeworks under default traits, so the initial fetch may take a
+moment.
 
-## Project Structure
+The trait set defaults to `MLX, Llama` (the offline build mode) — see
+[SECURITY.md § Supported Build Modes](SECURITY.md#supported-build-modes) for the
+four blessed configurations and what each one guarantees.
 
-| Target | Purpose |
-|--------|---------|
-| **BaseChatCore** | Models, protocols, and services. No ML dependencies. This is the integration point for all backends and custom extensions. |
-| **BaseChatBackends** | Concrete inference backend implementations: MLX, llama.cpp, Apple Foundation Models, and cloud APIs. Depends on heavy binary deps; requires Apple Silicon for MLX. |
-| **BaseChatUI** | SwiftUI views and view models. Depends only on BaseChatCore — keeps the UI layer decoupled from ML runtimes. |
-| **BaseChatTestSupport** | Shared mocks, fakes, and test helpers. Depended on by all test targets. |
+For repo-developer build-mode workflow (Xcode trait limitations, common mistakes,
+the `#warning` stub mechanism), see [CLAUDE.md](CLAUDE.md).
 
-## Running Tests
+## Pre-push checklist
 
-Test targets fall into two groups:
-
-### No special hardware required
-
-These run on any Mac (including Intel) and in CI:
+**Run before every push.** CI is macOS-only with a 10× billing multiplier; each
+failed push wastes ~25 billed minutes.
 
 ```bash
-swift test --filter BaseChatCoreTests
-swift test --filter BaseChatUITests
+swift test --filter BaseChatCoreTests --disable-default-traits \
+  && swift test --filter BaseChatInferenceTests --disable-default-traits \
+  && swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits \
+  && swift test --filter BaseChatUITests --disable-default-traits \
+  && swift test --filter BaseChatUIModelManagementTests --disable-default-traits \
+  && swift test --filter BaseChatMCPTests --disable-default-traits \
+  && swift test --filter BaseChatBackendsTests --disable-default-traits \
+  && swift test --filter BaseChatTestSupportTests --disable-default-traits \
+  && swift test --filter BaseChatAppIntentsTests --disable-default-traits
 ```
 
-### Requires Apple Silicon / real device
+Never push based on a subset passing. After rebasing, always re-run the full suite —
+conflicts can silently break tests that compiled fine before.
 
-These targets link against MLX xcframeworks or exercise on-device models and will not build or run correctly on Intel Macs or simulators:
-
-- **BaseChatBackendsTests** — MLXBackend, LlamaBackend, FoundationBackend
-- **BaseChatE2ETests** — Full generation round-trips against real backends
-
-Run them on Apple Silicon:
+When changing the behaviour of any function or type, grep the entire `Tests/`
+directory for references — not just the obvious test file:
 
 ```bash
-swift test --filter BaseChatBackendsTests
-swift test --filter BaseChatE2ETests
+grep -r "functionOrTypeName" Tests/
 ```
 
-### Example app UI tests
+See [CLAUDE.md](CLAUDE.md) for the canonical test conventions, hardware constraints,
+and the `withKnownIssue` policy.
 
-When debugging `BaseChatDemoUITests`, prefer the fast rerun loop instead of repeating full `xcodebuild test` runs:
+## Adding a new backend
 
-```bash
-scripts/example-ui-tests.sh build-for-testing
-scripts/example-ui-tests.sh test-without-building -only-testing:BaseChatDemoUITests/ChatFlowUITests/testEmptyStateShowsWelcome
-```
+A backend is anything that conforms to `InferenceBackend` and gets registered with
+`InferenceService`.
 
-- `build-for-testing` does the expensive compile once.
-- `test-without-building` reuses that build for targeted reruns.
-- The helper auto-selects a real available simulator destination instead of hardcoding stale device names. Use `xcrun simctl list devices available` plus `--destination 'platform=iOS Simulator,id=<SIMULATOR_ID>'` if you want to pin a specific simulator.
+1. **Pick the right trait** for the file. The four trait gates are:
+   - `MLX` — Apple Silicon MLX backend.
+   - `Llama` — llama.cpp / GGUF.
+   - `Ollama` — self-hosted HTTP (in defaults today; opt-in next major).
+   - `CloudSaaS` — third-party SaaS (Claude, OpenAI). Off by default.
 
-Run the full sweep only when needed:
+   Wrap the backend file's contents in `#if <Trait>` so it does not compile in
+   modes that exclude it.
 
-```bash
-scripts/example-ui-tests.sh test
-```
+2. **Register via `DefaultBackends.register(with:)`** rather than calling backend
+   constructors from app code. The registration helper handles trait gating and
+   default-backend wiring; direct constructor calls bypass that and emit
+   deprecation warnings.
 
-To run everything at once on a capable machine:
+3. **Update `APIProvider.availableInBuild`** so the UI provider picker doesn't
+   list a backend whose code isn't linked. Match the existing `#if` gating.
 
-```bash
-swift test
-```
+4. **Add tests in `BaseChatBackendsTests`** with the matching `#if <Trait>` so
+   they don't run in trait sets that exclude the backend.
 
-### Hardware gate helpers
+5. **HTTP I/O goes through `URLSessionProvider`.** Direct `URLSession.shared` use
+   is banned by `TrafficBoundaryAuditTest` Rule 1. If your backend speaks HTTP,
+   it must use `URLSessionProvider` so the runtime kill-switch
+   (`URLSessionProvider.networkDisabled`) covers it.
 
-Tests that need specific hardware use `XCTSkipUnless` with flags from `HardwareRequirements` (in `BaseChatTestSupport`):
+6. **Hostname literals** (`https://api.example.com`) are allowlisted per file by
+   the audit's Rule 3 (`allowedHostnameFiles`). If your backend introduces a new
+   hostname, add the *file* to the allowlist with a justification comment — not
+   the hostname itself, and never inline-suppress the rule.
 
-| Flag | When `true` |
-|------|-------------|
-| `HardwareRequirements.isAppleSilicon` | Running on arm64 (Apple Silicon) |
-| `HardwareRequirements.isPhysicalDevice` | Running on a real device, not the iOS Simulator |
-| `HardwareRequirements.hasFoundationModels` | Running on macOS 26+ / iOS 26+ (does not check Apple Intelligence) |
+7. **Run before pushing:**
+   ```bash
+   swift test --filter BaseChatBackendsTests --disable-default-traits
+   swift test --filter BaseChatInferenceTests --disable-default-traits   # for the audit
+   ```
+   On Apple Silicon, also run `--traits MLX,Llama` so the actual hardware-bound
+   tests execute.
 
-Tests also check `FoundationBackend.isAvailable` for Apple Intelligence availability, which is distinct from the OS version check (the user may not have Apple Intelligence enabled).
+See [SECURITY.md § Supported Build Modes](SECURITY.md#supported-build-modes) and
+[docs/THREAT_MODEL.md § B1 Network ↔ device](docs/THREAT_MODEL.md#b1-network--device)
+for the security context.
 
-Use these at the top of `setUp()` or individual test methods:
+## Adding a UI view
 
-```swift
-override func setUp() async throws {
-    try await super.setUp()
-    try XCTSkipUnless(HardwareRequirements.isAppleSilicon, "Requires Apple Silicon")
-    try XCTSkipUnless(HardwareRequirements.isPhysicalDevice, "Metal unavailable in simulator")
-}
-```
+UI lives in `BaseChatUI` and (for model-management surfaces) `BaseChatUIModelManagement`.
 
-## Adding a New Backend
+1. **Don't `import BaseChatBackends` from UI.** This is enforced by
+   `TrafficBoundaryAuditTest` Rule 6 (import-graph layering) — the back-edge
+   would close a dependency cycle. UI consumes inference via
+   `BaseChatInference`'s service protocols.
 
-1. Implement the `InferenceBackend` protocol (defined in `Sources/BaseChatCore`).
-2. If your backend wraps a C or Objective-C library, mark the class `@unchecked Sendable`. Swift cannot verify the thread-safety invariants of C-backed state, so you are responsible for enforcing them manually (typically with a serial dispatch queue or actor isolation boundary).
-3. Register your backend with `InferenceService.registerBackendFactory(_:)` at startup.
-4. Add unit tests in `BaseChatBackendsTests` (or `BaseChatCoreTests` if the logic lives in Core). Hardware-gated tests belong in `BaseChatE2ETests`.
+2. **Cloud-config UI** (anything that talks to `APIEndpoint`, lists API providers,
+   or reads/writes Keychain entries) goes behind `#if Ollama || CloudSaaS`. In
+   the offline build mode, the cloud-config UI compiles out entirely.
 
-See existing backends in `Sources/BaseChatBackends` for reference implementations.
+3. **Pasteboard writes** must use `localOnly: true` or be added to the
+   `privacyAPIAllowlist` with an explicit justification entry. Default
+   `UIPasteboard.general` writes broadcast via Continuity — see
+   `TrafficBoundaryAuditTest` Rule 4.
 
-## Coding Conventions
+4. **Run before pushing:**
+   ```bash
+   swift test --filter BaseChatUITests --disable-default-traits
+   swift test --filter BaseChatUIModelManagementTests --disable-default-traits
+   ```
 
-- **Concurrency** — use async/await throughout. Do not introduce Combine publishers or callback-based APIs.
-- **Observable state** — mark view models and services that publish state with `@MainActor`. Use `@Observable` (the macro from Observation framework), not `ObservableObject`/`@Published`.
-- **Persistence** — use SwiftData. Do not introduce CoreData.
-- **Comments** — omit comments unless the logic is genuinely non-obvious. The code should be readable without them. When a comment is warranted, explain *why*, not *what*.
-- **Formatting** — follow the existing indentation (4-space, no tabs). There is no enforced formatter in CI yet; match the surrounding code.
+For the UI / framework / host-app trust boundary, see
+[docs/THREAT_MODEL.md § B5](docs/THREAT_MODEL.md#b5-ui--framework--host-application).
 
-## Commit Style
+## Adding a dependency
 
-This project uses [Conventional Commits](https://www.conventionalcommits.org/). Release Please reads these to determine version bumps and generate the changelog automatically.
+A new SwiftPM dependency, a new binary xcframework, or a version bump to an existing
+dependency.
+
+1. **Pick a trait gate.** If the dependency only matters for one backend or
+   feature, gate the `.product(...)` entry with `condition: .when(traits: [...])`.
+   Always-on dependencies need a justification in the PR body.
+
+2. **`Package.resolved`** updates are procurement-relevant. The PR description
+   should call out any change to `Package.resolved` so downstream consumers can
+   match it against their own pin policies.
+
+3. **Binary dependencies** (xcframeworks): note that there is no SHA-256 checksum
+   pin today, only revision pinning. Tracked under
+   [#714](https://github.com/roryford/BaseChatKit/issues/714) Phase 5 — flag the
+   PR for security review.
+
+4. **SwiftPM plugins** (`.buildToolPlugin`, `.commandPlugin`) are **banned** by
+   `TrafficBoundaryAuditTest` Rule 5. Plugins run at build time with full
+   filesystem + network access; adding one requires explicit security review and
+   an audit allowlist update.
+
+5. **`unsafeFlags` and `linkedFramework("Network")` / `linkedFramework("CFNetwork")`**
+   are banned by the same audit rule. Don't try to work around it.
+
+6. **Run before pushing:**
+   ```bash
+   swift test --filter BaseChatInferenceTests --disable-default-traits
+   ```
+
+See [docs/THREAT_MODEL.md § B3 Build time ↔ run time](docs/THREAT_MODEL.md#b3-build-time--run-time).
+
+## Adding a network feature
+
+A new HTTP client, a new endpoint, a new request shape — anything that crosses the
+network boundary.
+
+1. **`URLSession` use is allowlisted per-file** by the audit's Rule 1
+   (`networkIOAllowlist`). New network code goes in an existing allowlisted file
+   when possible. Adding a *file* to the allowlist requires reviewer sign-off —
+   the cap is intentionally low.
+
+2. **Hostname literals** (`https?://[host]…`) are allowlisted by Rule 3. UI and
+   Inference source must not contain hostname literals; cloud backend files do.
+
+3. **All HTTP traffic must route through `URLSessionProvider`** so the runtime
+   kill-switch (`URLSessionProvider.networkDisabled`) covers it.
+
+4. **SSE responses** must consume through `SSEStreamParser` with the default
+   `SSEStreamLimits` (or a justified narrower override). Don't bypass the bounds.
+
+5. **Cloud error bodies** must run through `CloudErrorSanitizer.sanitize(_:host:)`
+   before surfacing to the UI or `Log.*`.
+
+6. **Run before pushing:**
+   ```bash
+   swift test --filter BaseChatBackendsTests --disable-default-traits
+   swift test --filter BaseChatInferenceTests --disable-default-traits
+   swift test --filter BaseChatTestSupportTests --disable-default-traits
+   ```
+
+See [SECURITY.md § Supported Build Modes](SECURITY.md#supported-build-modes) for
+trait-mode behaviour and
+[docs/THREAT_MODEL.md § Network exfiltration](docs/THREAT_MODEL.md#network-exfiltration).
+
+## Adding a macro
+
+Macros live in `Sources/BaseChatMacrosPlugin/`. They run at build time with full
+shell privileges, so the rules are tighter:
+
+1. **Banned in macro source:** `Foundation.URLSession`, `Process()`, `posix_spawn`.
+   Audit Rule 2 catches these.
+
+2. **Macro output** must be covered by a snapshot test so a future change to the
+   macro doesn't silently rewrite generated source.
+
+3. The macro plugin sandbox is on the Phase 5 roadmap
+   ([#714](https://github.com/roryford/BaseChatKit/issues/714)). Until then, every
+   macro change gets a manual security review.
+
+4. **Run before pushing:**
+   ```bash
+   swift test --disable-default-traits   # exercises macro tests under all suites
+   ```
+
+See [docs/THREAT_MODEL.md § Build-time exfiltration via macros](docs/THREAT_MODEL.md#build-time-exfiltration-via-macros).
+
+## Adding a setting / configuration flag
+
+A new `BaseChatConfiguration` field, a new `@Environment` injection point, or a new
+trait.
+
+1. **Runtime configuration → `BaseChatConfiguration`.** Document the default in
+   the field's doc comment.
+
+2. **Build-time configuration → a new trait.** Add it to the `traits:` list in
+   `Package.swift` with a one-line description. The audit's Rule 7 will
+   immediately reject any `#if` typo against the new trait.
+
+3. **If the flag affects a documented guarantee** (e.g. fail-closed behaviour,
+   pinning policy, file-protection class), update
+   [SECURITY.md § Supported Build Modes](SECURITY.md#supported-build-modes) and
+   [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md) in the same PR.
+
+4. **README impact:** if the flag changes how a consumer chooses a build mode,
+   update the README's build-mode decision table too.
+
+5. **Run before pushing:**
+   ```bash
+   swift test --filter BaseChatCoreTests --disable-default-traits
+   swift test --filter BaseChatInferenceTests --disable-default-traits
+   ```
+
+## Commit style
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/).
+Release Please reads commit messages to determine version bumps and to generate the
+changelog.
 
 ```
 feat: add streaming cancellation to FoundationBackend
@@ -126,46 +277,74 @@ chore: update mlx-swift-lm to 2.31.0
 docs: clarify TokenizerProvider fallback behaviour
 ```
 
-| Type | Version bump |
-|------|-------------|
-| `feat` | MINOR (`0.x.0`) |
-| `fix` | PATCH (`0.0.x`) |
-| `BREAKING CHANGE:` in footer | MAJOR (`x.0.0`) |
-| everything else | no release |
+| Type                            | Version bump      |
+|---------------------------------|-------------------|
+| `feat`                          | MINOR (`0.x.0`)   |
+| `fix`                           | PATCH (`0.0.x`)   |
+| `BREAKING CHANGE:` in footer    | MAJOR (`x.0.0`)   |
+| `chore`, `docs`, `test`, `perf` | no release        |
 
-PR titles must follow the same format — CI enforces this.
+PR titles must follow the same format — CI enforces this via `commitlint`.
 
-Add a body when the *why* needs explanation. Do not describe what the diff already shows.
+Add a body when the *why* needs explanation. Don't restate what the diff already
+shows.
 
 ```
 fix: prevent context overflow when system prompt exceeds budget
 
-The trimMessages fallback path returned an empty array when the system
-prompt alone exceeded maxTokens. Always return at least the last user
-message so generation has something to work with.
+The trimMessages fallback returned an empty array when the system prompt
+alone exceeded maxTokens. Always return at least the last user message so
+generation has something to work with.
 ```
 
-## Pull Request Process
+## Pull request process
 
-- Keep PRs focused on a single concern. Unrelated fixes belong in separate PRs.
-- Add tests for new behaviour. If you are fixing a bug, add a test that fails before your fix and passes after.
-- E2E tests that require Apple Silicon are acceptable without CI coverage — note the hardware requirement in the PR description.
-- Update the relevant section of the README if your change affects the public API or integration steps.
-- Request review from a maintainer. PRs are merged once at least one approval is received and all CI checks pass.
+1. **Branch off `main`.** Direct pushes to `main` are blocked.
+2. **Open a PR via `gh`:** `gh pr create --title "feat: ..." --body "..."`.
+3. **Don't pass `--auto` or `--merge`.** Merges require human approval.
+4. **Report the PR URL** so the maintainer can review.
+5. **Wait for CI** before flagging "ready to merge". CI runs every CI-safe test
+   suite listed in the [Pre-push checklist](#pre-push-checklist).
 
-## Reporting Bugs
+The maintainer merges PRs once at least one approval is received and CI is green.
 
-Open a GitHub Issue and select the **Bug Report** template. Include:
+## PR hygiene
 
-- A minimal reproduction case
-- The platform and OS version (e.g. macOS 15.4, Apple M3)
-- The Swift and Xcode versions (`swift --version`, `xcodebuild -version`)
-- Relevant log output
+CI is macOS-only and runs ~5 minutes per push. Each unnecessary PR or issue costs
+real money and reviewer attention.
 
-## Feature Requests
+- **One feature = one PR**, even when it touches multiple backends. A change like
+  "tool calling" or "thinking budget" should land as one PR with a backend
+  checklist in the body, not five PRs.
+- **Tests and docs ship in the feature PR.** Don't open standalone `test:` or
+  `docs:` PRs for in-flight work — they cost CI minutes and invent merge
+  conflicts. Standalone `test:` / `docs:` PRs are appropriate only for already-
+  shipped features.
+- **Single-file PRs are a smell.** Check whether there's a sibling PR you could
+  batch into.
+- **Don't open follow-up issues for "while I'm here" cleanups.** Fold them into
+  the current PR or leave a `// TODO:` in the code. The issue tracker is for
+  things that need cross-session memory **and** external visibility.
 
-Open a GitHub Issue and select the **Feature Request** template. Describe the problem you are solving, not just the solution you have in mind.
+For the full PR-hygiene rationale, see [CLAUDE.md § Issue & PR hygiene](CLAUDE.md).
+
+## Reporting bugs
+
+Open a GitHub issue using the **Bug Report** template. Include:
+
+- A minimal reproduction case.
+- Platform and OS version (e.g. macOS 15.4, Apple M3).
+- Swift and Xcode versions (`swift --version`, `xcodebuild -version`).
+- Relevant log output.
+
+Don't open public issues for security-impacting bugs — see the next section.
+
+## Reporting security vulnerabilities
+
+Use [GitHub Security Advisories](https://github.com/roryford/BaseChatKit/security/advisories/new)
+for private disclosure. Full policy in [SECURITY.md](SECURITY.md#reporting-a-vulnerability).
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE) that covers this project.
+By contributing, you agree that your contributions will be licensed under the
+[MIT License](LICENSE) that covers this project.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,275 @@
+# Security Policy
+
+BaseChatKit (BCK) is a Swift package for building local-first and cloud-optional chat
+interfaces on Apple platforms. This document describes:
+
+- [Supported versions](#supported-versions) — what gets security fixes.
+- [Supported build modes](#supported-build-modes) — what each build mode guarantees,
+  what enforces the guarantee, and what is explicitly **not** guaranteed.
+- [Reporting a vulnerability](#reporting-a-vulnerability) — how to disclose privately.
+- [Cryptography at rest](#cryptography-at-rest) — what the framework does with secrets and
+  user data on disk.
+- [Pending mitigations](#pending-mitigations) — known gaps with linked tracking issues.
+
+For the full threat model (assets, trust boundaries, mitigations, and known
+non-mitigations), see [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md). The DocC article
+[Security Model](Sources/BaseChatCore/BaseChatCore.docc/Articles/SecurityModel.md)
+covers the in-source mitigations (transport pinning, SSRF gating, error sanitisation,
+SSE bounds, download path validation) at API granularity.
+
+## Supported Versions
+
+BCK is pre-1.0. Only the most recent minor release receives security fixes. Earlier
+minors are end-of-life on the day a new minor ships.
+
+| Version       | Status                          |
+|---------------|---------------------------------|
+| `0.12.x`      | Supported (security + bug fix)  |
+| `0.11.x`      | Supported until `0.13.0`        |
+| `< 0.11`      | End-of-life                     |
+
+When BCK reaches `1.0.0`, this table will switch to a longer support window.
+
+## Supported Build Modes
+
+BCK ships four pre-blessed build modes, gated by Swift package traits. Each row of
+the table below names exactly what is guaranteed for that mode and what enforces the
+guarantee. Consumers in regulated verticals can compile the package in `offline` or
+`ollama` mode and have a mechanically-checked guarantee that no SaaS-cloud code is
+linked into the binary.
+
+| Mode      | Default? | Traits enabled                | Backends linked                 |
+|-----------|----------|-------------------------------|---------------------------------|
+| `offline` | No       | `MLX`, `Llama`                | MLX, llama.cpp, Foundation      |
+| `ollama`  | **Yes**  | `MLX`, `Llama`, `Ollama`      | + Ollama HTTP client            |
+| `saas`    | No       | `MLX`, `Llama`, `CloudSaaS`   | + Claude, OpenAI                |
+| `full`    | No       | all of the above              | every backend BCK ships         |
+
+The default trait set today is `MLX, Llama` (per `Package.swift`). `Ollama` is in the
+default-trait set in the **Quick Start** examples; it moves to opt-in in the next
+major. `CloudSaaS` is opt-in today.
+
+### Consumer manifest snippets
+
+#### `offline` — local-only, no networking
+
+```swift
+.package(
+    url: "https://github.com/roryford/BaseChatKit.git",
+    from: "0.12.0",
+    traits: [
+        .trait(name: "MLX"),
+        .trait(name: "Llama"),
+    ]
+)
+```
+
+**Guarantees** (enforced by [`TrafficBoundaryAuditTest`](Tests/BaseChatInferenceTests/TrafficBoundaryAuditTest.swift)
+and the import-graph rule in the same audit):
+
+- No `Sources/BaseChatBackends/Cloud/*` symbols are reachable.
+- No `OllamaBackend`, `ClaudeBackend`, or `OpenAIBackend` is registered.
+- No hostname literal pointing to `api.openai.com`, `api.anthropic.com`,
+  or any third-party SaaS endpoint is reachable from app code.
+
+**Not guaranteed:**
+
+- A compromised toolchain or `Package.resolved` swap could swap source files; the audit
+  only inspects what's checked in.
+- `MLX` and `Llama` may still resolve **DNS** at startup if a host app calls
+  HuggingFace search; the BCK API only resolves DNS via `URLSessionProvider`, which is
+  not invoked from offline backends.
+- A jailbroken device, rooted simulator, or hostile consumer-app code can bypass the
+  framework's process-internal checks.
+
+#### `ollama` — self-hosted / private datacenter
+
+```swift
+.package(
+    url: "https://github.com/roryford/BaseChatKit.git",
+    from: "0.12.0",
+    traits: [
+        .trait(name: "MLX"),
+        .trait(name: "Llama"),
+        .trait(name: "Ollama"),
+    ]
+)
+```
+
+Same `offline` guarantees, plus:
+
+- HTTP traffic is permitted only via `URLSessionProvider`, which honours the runtime
+  kill-switch `URLSessionProvider.networkDisabled`.
+- `OllamaBackend` is the only HTTP-speaking backend present in the binary; no SaaS
+  cloud code is linked.
+
+**Not guaranteed:**
+
+- BCK does not pin Ollama server certificates by default. If your deployment requires
+  pinning, set `PinnedSessionDelegate.pinnedHosts["your.ollama.host"] = [...]` at
+  startup.
+- BCK does not validate the *content* the Ollama server returns — prompt-injection
+  via tool output, retrieved documents, or model-card metadata is the host app's
+  responsibility.
+
+#### `saas` — full cloud
+
+```swift
+.package(
+    url: "https://github.com/roryford/BaseChatKit.git",
+    from: "0.12.0",
+    traits: [
+        .trait(name: "MLX"),
+        .trait(name: "Llama"),
+        .trait(name: "CloudSaaS"),
+    ]
+)
+```
+
+`saas` adds Claude and OpenAI backends. Pinning is **on by default** for both
+hosts — the framework fails closed if no pin matches. See the
+[Security Model](Sources/BaseChatCore/BaseChatCore.docc/Articles/SecurityModel.md#transport-security)
+DocC article for the SPKI pin set.
+
+#### `full` — every backend
+
+```swift
+.package(
+    url: "https://github.com/roryford/BaseChatKit.git",
+    from: "0.12.0",
+    traits: [
+        .trait(name: "MLX"),
+        .trait(name: "Llama"),
+        .trait(name: "Ollama"),
+        .trait(name: "CloudSaaS"),
+    ]
+)
+```
+
+`full` is the maximum-surface developer build. Use it for development; pick a
+narrower mode for shipping production binaries.
+
+### What enforces each guarantee
+
+| Mechanism                                                                                                                | Enforces                                                                                                            |
+|--------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| [`TrafficBoundaryAuditTest`](Tests/BaseChatInferenceTests/TrafficBoundaryAuditTest.swift)                                | Rule classes 1–7: `URLSession` import allowlist, C interop / dynamic dispatch ban, hostname literals allowlist, privacy-API allowlist, `Package.swift` hygiene, import-graph layering, trait-name validity. |
+| [`DenyAllURLProtocolTests`](Tests/BaseChatTestSupportTests/DenyAllURLProtocolTests.swift) and [`URLSessionProviderNetworkDisabledTests`](Tests/BaseChatBackendsTests/URLSessionProviderNetworkDisabledTests.swift) | Runtime network isolation: when `networkDisabled` is set, every URL request fails closed.                          |
+| `#if Ollama` / `#if CloudSaaS` conditional compilation in `Sources/BaseChatBackends/`                                    | Trait-gated backend code is not compiled into the binary if the trait is absent.                                    |
+| `--disable-default-traits` swift test invocations in CI (see [`.github/workflows/ci.yml`](.github/workflows/ci.yml))      | At least one CI job exercises the offline trait set on every PR; signature regressions surface as compile errors.   |
+
+There is currently no separate `scripts/build-modes.sh` — that consolidation is tracked
+under the umbrella ([#714](https://github.com/roryford/BaseChatKit/issues/714)) and will
+be added when the build-mode CI matrix lands.
+
+### Explicit non-guarantees
+
+The following are **not** in scope for any build mode. Treat them as host-app
+responsibility:
+
+- **Compromised toolchain** — a malicious Swift compiler or build plugin can re-add
+  network code regardless of BCK's source-level audit.
+- **Rooted / jailbroken device** — code injected into the host process can do anything.
+- **Malicious consumer-app code** — BCK protects its own boundaries, not the host
+  app's.
+- **Side-channel timing attacks** — token-by-token streaming inherently leaks
+  generation pace.
+- **OS-level memory-mapped logs** — `os_log` redaction is a contract with the
+  Console UI, not a hardware boundary; sysdiagnose or `log collect --private` recover
+  redacted strings if invoked with elevated entitlements.
+- **GGUF / safetensors weight tampering** — model-file integrity is the user's
+  responsibility (typically via HuggingFace's signed manifest, which BCK does not
+  yet verify; see [#367](https://github.com/roryford/BaseChatKit/issues/367)).
+
+## Reporting a Vulnerability
+
+Report suspected vulnerabilities through
+[GitHub Security Advisories](https://github.com/roryford/BaseChatKit/security/advisories/new).
+This keeps the discussion private until a fix is ready. Please **do not** open public
+issues for security-impacting bugs.
+
+Include:
+
+- A description of the vulnerability and impact.
+- Steps to reproduce.
+- Affected versions (the `0.12.x` baseline plus any earlier minor you've reproduced
+  on).
+- Any potential mitigations or workarounds you've identified.
+
+### Response timeline
+
+| Step                            | Target           |
+|---------------------------------|------------------|
+| Acknowledge report              | 48 hours         |
+| Triage and severity assessment  | 5 business days  |
+| Patch release                   | 30 days          |
+
+Complex issues may extend the timeline. We will keep you informed of progress and
+credit reporters in the release notes for confirmed vulnerabilities unless you ask
+for anonymity.
+
+### Disclosure policy
+
+We follow coordinated disclosure: once a fix is released, a security advisory with
+full details is published. We ask reporters to wait until the advisory is published
+before disclosing publicly.
+
+There is no bug bounty programme today.
+
+## Cryptography at Rest
+
+| Asset                              | Mechanism                                                                                                                                |
+|------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| API keys                           | System Keychain, `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`, **not** synced via iCloud Keychain. Per-endpoint UUID accounts.         |
+| SwiftData store (chat history)     | `NSFileProtection.completeUntilFirstUserAuthentication` (default) on iOS / iPadOS / tvOS / watchOS. Opt in to `.complete` via `BaseChatConfiguration.fileProtectionClass`. |
+| Model weights                      | Plain files under `modelsDirectory`. Path-traversal validation runs at filename ingest (`DownloadableModel.validate(fileName:)`). No content-integrity check today. |
+| In-flight TLS                      | SPKI-pinned for `api.openai.com` and `api.anthropic.com`; pluggable via `PinnedSessionDelegate.pinnedHosts` for custom hosts.            |
+
+BCK is **not** FIPS-validated. The Apple Keychain and Apple's `Security.framework` use
+CoreCrypto, which has FIPS-140-3 validations on supported OS versions, but BCK does
+not pin to or verify those validations at runtime.
+
+For deployments that need stricter at-rest sealing, set
+`BaseChatConfiguration.shared.fileProtectionClass = .complete` and ship background
+work that is robust to a locked device.
+
+## Pending Mitigations
+
+The following are known gaps with tracking issues. Each is listed in
+[docs/THREAT_MODEL.md](docs/THREAT_MODEL.md) under "Known non-mitigations":
+
+- **Macro plugin sandbox** — SwiftPM `.buildToolPlugin` / `.commandPlugin` declarations
+  are banned by the audit, but `Sources/BaseChatMacrosPlugin/` runs at build time with
+  full filesystem and network access. Tracked under
+  [#714](https://github.com/roryford/BaseChatKit/issues/714) Phase 5.
+- **xcframework checksum pinning** — `llama.swift` and `mlx-swift` xcframeworks are
+  pulled by SwiftPM with `Package.resolved` revision pinning but no SHA-256 binary
+  checksum. Tracked under [#714](https://github.com/roryford/BaseChatKit/issues/714)
+  Phase 5.
+- **GGUF signed-manifest verification** — model weights downloaded from HuggingFace
+  are not signature-verified.
+  [#367](https://github.com/roryford/BaseChatKit/issues/367).
+- **Build-provenance attestation** — no SLSA-style attestation. Tracked under
+  [#714](https://github.com/roryford/BaseChatKit/issues/714) Phase 5.
+- **Secure Enclave / key zeroization** — API keys are read into Swift `String` for
+  request signing and rely on ARC + zeroing-on-free behaviour from
+  Foundation/Security.framework. Tracked under
+  [#714](https://github.com/roryford/BaseChatKit/issues/714) Phase 5.
+- **SBOM** — no Software Bill of Materials is published. Tracked under
+  [#714](https://github.com/roryford/BaseChatKit/issues/714) Phase 5.
+- **FIPS validation** — see Cryptography at Rest above. No commitment to a FIPS-only
+  build path.
+
+For the complete breakdown — including how each gap maps onto a procurement-team
+checklist — see [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md).
+
+## Cross-references
+
+- [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md) — full threat model.
+- [Security Model](Sources/BaseChatCore/BaseChatCore.docc/Articles/SecurityModel.md) —
+  in-source DocC article on transport, SSRF, Keychain, error sanitisation, SSE bounds,
+  download validation.
+- [CONTRIBUTING.md](CONTRIBUTING.md) — contributor guide indexed by change type.
+  Each change-type section lists the security-relevant gates.
+- [README.md](README.md) — quick-start, build-mode decision table, and feature
+  overview.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -1,0 +1,319 @@
+# BaseChatKit Threat Model
+
+This document is the engineering-honest companion to [SECURITY.md](../SECURITY.md). Where
+SECURITY.md is the customer-facing summary ("what BCK guarantees, who it's for, what to
+do with a vulnerability"), this document is the line-by-line procurement checklist:
+what is enforced, what is **not** enforced, and which CI mechanism or open issue maps
+to each row.
+
+The format is deliberate: every "X is enforced by Y" claim links to the actual file or
+workflow. Every "X is not mitigated" row names the tracking issue (or explains why an
+item is permanently out of scope).
+
+For a higher-level narrative — and the corresponding DocC API surface — see the
+[Security Model](../Sources/BaseChatCore/BaseChatCore.docc/Articles/SecurityModel.md)
+article.
+
+## Audience and scope
+
+BCK targets **integrators building Apple-platform chat applications**. The threat
+model covers everything BCK ships in source form: the Swift modules, the test infra,
+the trait gates, and the documented configuration surface. It does **not** cover host
+application code, third-party model weights, or operating-system primitives BCK
+relies on (Keychain, file protection, `URLSession`, MLX, llama.cpp).
+
+Build modes — `offline`, `ollama`, `saas`, `full` — are summarised in
+[SECURITY.md](../SECURITY.md#supported-build-modes). This document references them
+where the threat surface differs by mode.
+
+## Assets
+
+What BCK is trying to protect, in priority order:
+
+1. **API keys.** Stored in Keychain with
+   `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`. Compromise of an API key gives an
+   attacker billable access to a third-party SaaS account; the key may also have
+   organisation-scoped read access to provider chat history.
+2. **Message history.** Stored as SwiftData rows on disk. Chat content frequently
+   contains personally-identifiable information, work-confidential prompts, source
+   code, and pasted credentials.
+3. **Model files.** Multi-gigabyte GGUF / safetensors files on disk. Theft of a
+   downloaded model weight is rarely high-impact (the same weights are usually
+   public on HuggingFace), but tampering — replacing a weight with a backdoored
+   one — can cause the chat UI to render attacker-chosen output.
+4. **Conversation KV-cache residue.** The llama.cpp and MLX backends retain
+   per-session KV state for the lifetime of the load. A second user inheriting the
+   same `LlamaBackend` instance can in principle observe earlier conversation
+   tokens via timing or memory inspection. (Single-user devices, BCK's primary
+   target, mostly defang this.)
+5. **Build-time secrets.** Developer dotfiles, `Package.resolved` URLs, and macro
+   plugin source. A macro plugin runs at build time with the dev shell's full
+   privileges; an attacker who lands a malicious macro can read `~/.ssh`, the
+   user's keychain, environment variables, and so on.
+
+## Trust boundaries
+
+BCK distinguishes the following boundaries. Each subsection summarises what is
+considered hostile on the far side and what BCK validates as data crosses.
+
+### B1. Network ↔ device
+
+- **Hostile side:** the network. Includes not only the public internet but any
+  device-local interface that resolves to a non-loopback IP (LAN, VPN, AirPlay,
+  printer subnet, AWS metadata service `169.254.169.254`).
+- **What crosses:** outbound HTTP requests to cloud LLM providers and Ollama; SSE
+  responses; HuggingFace search/download metadata.
+- **Mitigations enforced today:**
+  - SPKI-pinned TLS for `api.openai.com`, `api.anthropic.com` (default pin set
+    populates from `PinnedSessionDelegate.loadDefaultPins()`; both hosts fail
+    closed).
+  - SSRF gate in `APIEndpoint.validate()` rejects RFC1918 / link-local / metadata
+    IPs and unsupported URL schemes before persistence.
+  - All outbound requests route through `URLSessionProvider`, which honours the
+    runtime kill-switch `URLSessionProvider.networkDisabled`.
+  - SSE streams bounded by `SSEStreamLimits` (event ≤ 1 MB, total ≤ 50 MB,
+    rate ≤ 5,000 events/sec).
+  - Error bodies sanitised by `CloudErrorSanitizer.sanitize(_:host:)` before
+    surfacing to the UI or `Log.*`.
+- **Not mitigated:** DNS rebinding (validation runs at endpoint persist time, not
+  request time); user-installed MITM root CAs (corporate proxies, jailbreak
+  tweaks); compromised pinning trust store.
+
+### B2. Disk ↔ process
+
+- **Hostile side:** another app or another local user with disk access. On iOS this
+  requires Data Protection bypass (jailbreak); on macOS, another user account or a
+  locally-installed signed app the user trusts.
+- **What crosses:** SwiftData store reads/writes; Keychain reads/writes; model
+  file reads.
+- **Mitigations enforced today:**
+  - SwiftData store sealed with
+    `NSFileProtection.completeUntilFirstUserAuthentication` (default; opt-in
+    `.complete`).
+  - Keychain items use the no-iCloud-sync access class.
+  - `BaseChatBootstrap.reapOrphanedKeychainItems(in:)` sweeps orphaned Keychain
+    entries on startup.
+  - Filename validation (`DownloadableModel.validate(fileName:)`) rejects path
+    traversal at ingest; `modelsDirectory` placement enforces a
+    `.standardized.path` prefix check.
+  - 24-hour stale-temp sweep in `BackgroundDownloadManager.cleanupStaleTempFiles()`.
+- **Not mitigated:** macOS at-rest encryption is FileVault (out-of-process); BCK
+  does no extra sealing on macOS. KV-cache residue (asset 4) is not zeroed on
+  session switch (see [#714](https://github.com/roryford/BaseChatKit/issues/714)
+  Phase 5).
+
+### B3. Build time ↔ run time
+
+- **Hostile side:** an attacker who has landed a commit, a Package.resolved swap,
+  or a malicious upstream dependency.
+- **What crosses:** SwiftPM dependency resolution; macro plugin execution; binary
+  xcframework downloads.
+- **Mitigations enforced today:**
+  - `Package.swift` hygiene rules (Rule 5 of `TrafficBoundaryAuditTest`):
+    `linkedFramework("Network")`, `linkedFramework("CFNetwork")`, `unsafeFlags`,
+    and `.buildToolPlugin` / `.commandPlugin` declarations are banned in
+    `Package.swift` and caught at PR time.
+  - Trait-gate sanity (Rule 7): every `#if` token in `Sources/` must match a
+    declared trait, so a typo cannot silently include backend code.
+  - C interop ban (Rule 2): `@_silgen_name`, `@_cdecl`, `dlopen`, `dlsym`,
+    `NSClassFromString`, `Process(`, `posix_spawn`, etc. are banned across
+    `Sources/` (with one narrow `Process(` allowlist for the Fuzz CLI).
+- **Not mitigated:** xcframework checksum pinning (binary deps pulled by revision,
+  not SHA-256); macro plugin sandbox (`Sources/BaseChatMacrosPlugin/` has full
+  filesystem + network access at build time); SLSA-style build provenance; SBOM.
+  All tracked under [#714](https://github.com/roryford/BaseChatKit/issues/714)
+  Phase 5.
+
+### B4. User content ↔ model
+
+- **Hostile side:** the user (in a multi-tenant deployment) or any input source the
+  model treats as text — pasted documents, retrieved tool output, web snippets.
+- **What crosses:** user prompts, tool-call results, retrieved RAG content,
+  pasted clipboard contents.
+- **Mitigations enforced today:**
+  - `PromptTemplate` strips structural special tokens (`<|im_start|>`, `[INST]`,
+    `<|eot_id|>`, etc.) from user content per template family.
+- **Not mitigated:** semantic prompt injection. **BaseChatKit does not solve
+  prompt injection.** System prompts are not a security boundary; tool calls and
+  retrieved content are untrusted from the model's perspective. See the
+  [Security Model](../Sources/BaseChatCore/BaseChatCore.docc/Articles/SecurityModel.md#prompt-injection-explicit-disclaimer)
+  article for guidance.
+
+### B5. UI / framework ↔ host application
+
+- **Hostile side:** consumer-app code that links BCK. BCK protects its own
+  invariants (Keychain access patterns, kill-switch honour, audit allowlists), not
+  the host app's.
+- **What crosses:** dependency-injection points (`InferenceService`,
+  `ChatViewModel.inferenceService`, `BaseChatConfiguration.shared`); SwiftData
+  schemas; closure injection points (`apiConfiguration` view-builder on
+  `ChatView`).
+- **Mitigations enforced today:** import-graph audit (Rule 6) ensures BCK's own
+  modules cannot regress (UI cannot import Backends; Inference cannot import Core
+  or Backends); `package`-visibility on `ChatViewModel.inferenceService`
+  prevents leaking the full `InferenceService` API on the public boundary.
+- **Not mitigated:** consumer apps that subclass, swizzle, or otherwise bypass
+  BCK's APIs. BCK is a library, not a sandbox.
+
+## Threats considered
+
+For each named threat: what it is, what mitigates it (with link), and gaps.
+
+### Network exfiltration
+
+- **Threat:** A SaaS-cloud backend, a misconfigured HTTP client, or a future code
+  change quietly exfiltrates conversation content to an unintended host.
+- **Mitigations:** All HTTP traffic must route through `URLSessionProvider`
+  ([`Sources/BaseChatBackends/URLSessionProvider.swift`](../Sources/BaseChatBackends/URLSessionProvider.swift)).
+  The audit's hostname-literal rule (Rule 3) keeps endpoint URLs out of UI/Inference
+  source files. The runtime `DenyAllURLProtocol`
+  ([`Sources/BaseChatTestSupport/DenyAllURLProtocol.swift`](../Sources/BaseChatTestSupport/DenyAllURLProtocol.swift))
+  is registered on default + ephemeral configurations in tests, exercising every
+  backend in the offline build mode.
+- **Gaps:** None outstanding for in-tree code. Out-of-tree consumer code is the
+  host app's responsibility.
+
+### Disk theft (lost / stolen device)
+
+- **Threat:** Unattended device with the SwiftData store readable.
+- **Mitigations:** `NSFileProtection.completeUntilFirstUserAuthentication`
+  (default) seals the store after device reboot until first unlock. Opt in to
+  `.complete` for stricter behaviour at the cost of background-task availability.
+- **Gaps:** macOS uses FileVault for at-rest sealing; BCK does no extra work
+  there. iCloud Keychain sync is disabled at the API level (Keychain access
+  class), so a recovered iCloud backup does not include API keys.
+
+### Process memory inspection
+
+- **Threat:** A debugger, a corrupt log dump, or a memory-mapped log harvests
+  prompts, keys, or KV-cache state from the running process.
+- **Mitigations:** API keys read just-in-time (no stored properties);
+  `Log.*` calls use `privacy: .private` for credentials/prompts and `.public`
+  only for stable identifiers (host, file name, OSStatus).
+- **Gaps:** `os_log` `.private` is enforced by Console redaction, not memory
+  protection. Sysdiagnose with elevated entitlements recovers redacted strings.
+  Key zeroization on free is not implemented;
+  see [#714](https://github.com/roryford/BaseChatKit/issues/714) Phase 5.
+
+### Supply chain
+
+- **Threat:** A compromised dependency adds network code, runs malicious code at
+  build time, or replaces a model weight.
+- **Mitigations:** `Package.swift` hygiene audit (Rule 5) blocks
+  `linkedFramework("Network")`, `unsafeFlags`, and SwiftPM plugin declarations.
+  Trait-gate sanity (Rule 7) catches typos before they let unintended code
+  through.
+- **Gaps:** xcframework checksum pinning, macro plugin sandbox, build-provenance
+  attestation, SBOM. All tracked under
+  [#714](https://github.com/roryford/BaseChatKit/issues/714) Phase 5. Model
+  weight signature verification:
+  [#367](https://github.com/roryford/BaseChatKit/issues/367).
+
+### Unintended local network leaks
+
+- **Threat:** mDNS/Bonjour announces a chat session to the local network; a
+  CloudKit container accidentally syncs message rows; Handoff broadcasts the
+  current chat to nearby devices.
+- **Mitigations:** Audit Rule 4 bans `CloudKitDatabase`, `NSUbiquitous*`,
+  `NSUserActivity` Handoff, `UIPasteboard.general` writes without `localOnly`,
+  and `FileProtectionType.none` from `Sources/`. Each finding requires an
+  explicit fingerprint entry with justification.
+- **Gaps:** The audit is a source grep — a host app can still call any of these
+  APIs. BCK does not whitelist them at runtime.
+
+### Build-time exfiltration via macros
+
+- **Threat:** A macro plugin under `Sources/BaseChatMacrosPlugin/` reads developer
+  secrets at build time and exfiltrates them.
+- **Mitigations:** Audit Rule 2 bans `Foundation.URLSession`, `Process()`,
+  `posix_spawn` from macro source until a sandbox is in place.
+- **Gaps:** The audit is a static check; a sufficiently motivated attacker can
+  obfuscate. Macro plugin sandbox is on the Phase 5 roadmap
+  ([#714](https://github.com/roryford/BaseChatKit/issues/714)).
+
+### `os_log` content escape via sysdiagnose
+
+- **Threat:** `Log.*` calls with `privacy: .public` accidentally include user
+  content; `log collect --private` on macOS recovers `.private` content with
+  developer entitlement.
+- **Mitigations:** Convention is `.private` for any user content, prompts, or
+  credentials; `.public` only for stable identifiers.
+- **Gaps:** Convention is enforced by code review, not by the audit. Adding a
+  static-grep rule for `%{public}` near a `String` interpolation of user content
+  is an open item.
+
+## Mitigations summary table
+
+The procurement view: which mitigation, which mechanism, where it lives.
+
+| Mitigation                                          | Enforced by                                                                                              | Run when?                       |
+|-----------------------------------------------------|----------------------------------------------------------------------------------------------------------|---------------------------------|
+| Network I/O imports allowlist                       | `TrafficBoundaryAuditTest` Rule 1                                                                        | Every PR (CI: `BaseChatInferenceTests`) |
+| C interop / dynamic dispatch ban                    | `TrafficBoundaryAuditTest` Rule 2                                                                        | Every PR                         |
+| Hostname literal allowlist                          | `TrafficBoundaryAuditTest` Rule 3                                                                        | Every PR                         |
+| Privacy-sensitive Apple API allowlist               | `TrafficBoundaryAuditTest` Rule 4                                                                        | Every PR                         |
+| `Package.swift` hygiene                             | `TrafficBoundaryAuditTest` Rule 5                                                                        | Every PR                         |
+| Import-graph layering                               | `TrafficBoundaryAuditTest` Rule 6                                                                        | Every PR                         |
+| Trait-gate sanity                                   | `TrafficBoundaryAuditTest` Rule 7                                                                        | Every PR                         |
+| Runtime network kill-switch                         | `URLSessionProvider.networkDisabled` + `DenyAllURLProtocolTests`                                         | Every PR                         |
+| Cloud TLS pinning fail-closed                       | `PinnedSessionDelegate` (defaults populated for `api.openai.com`, `api.anthropic.com`)                   | Every cloud HTTP request         |
+| SSRF gate at endpoint persist                       | `APIEndpoint.validate()`                                                                                 | UI form submit + programmatic    |
+| SSE stream bounds                                   | `SSEStreamParser` + `SSEStreamLimits.default`                                                            | Every SSE response               |
+| Cloud error sanitisation                            | `CloudErrorSanitizer.sanitize(_:host:)`                                                                  | Every cloud error path           |
+| Path-traversal validation at filename ingest        | `DownloadableModel.validate(fileName:)` + `modelsDirectory` `.standardized.path` prefix check            | Manifest parse + download start  |
+| Stale temp sweep                                    | `BackgroundDownloadManager.cleanupStaleTempFiles()`                                                      | App launch                       |
+| Keychain orphan reaper                              | `BaseChatBootstrap.reapOrphanedKeychainItems(in:)` (gated by `keychainReaperEnabled`)                    | App launch                       |
+| At-rest sealing (iOS / iPadOS / tvOS / watchOS)     | `ModelContainerFactory.makeContainer(...)` applies `BaseChatConfiguration.fileProtectionClass`           | Container creation               |
+| Prompt structural sanitisation                      | `PromptTemplate` (per-format special-token strip)                                                        | Every user message interpolation |
+
+## Known non-mitigations
+
+The honest list. Each item is either deferred to a tracked issue or explicitly out of
+scope.
+
+### Deferred (tracked under [#714](https://github.com/roryford/BaseChatKit/issues/714) Phase 5 unless noted)
+
+- **Macro plugin sandbox.** `Sources/BaseChatMacrosPlugin/` runs at build time with
+  full filesystem + network access. Audit Rule 2 currently bans network primitives
+  by static grep; a sandbox is the long-term fix.
+- **xcframework checksum pinning.** `llama.swift` and `mlx-swift` xcframeworks are
+  pinned by SwiftPM revision. Binary checksum pinning would defend against a
+  compromised release tarball.
+- **Build-provenance attestation.** No SLSA-style attestation today.
+- **Secure Enclave / FIPS / key zeroization.** API keys are read into Swift `String`
+  for request signing; relying on ARC + Foundation/Security.framework zeroing on
+  free.
+- **SBOM.** No published Software Bill of Materials.
+- **GGUF signed-manifest verification.** Tracked separately at
+  [#367](https://github.com/roryford/BaseChatKit/issues/367).
+- **Reproducible builds.** Not validated.
+
+### Explicitly out of scope
+
+- **MDM / managed-app-config.** BCK does not parse managed-app-config plists; host
+  apps that need MDM-driven configuration must wrap `BaseChatConfiguration`
+  themselves.
+- **Model-bundling recipes.** Shipping a model bundled inside the app binary is
+  technically possible but not documented or supported.
+- **DYLD_INTERPOSE socket shims.** A library cannot defend against a host-process
+  `DYLD_INSERT_LIBRARIES` attack; this is an OS-trust problem.
+- **Physical-access and social-engineering attacks.** Stolen device with PIN,
+  phishing for an API key, etc.
+- **Local denial-of-service** (e.g. loading a model that exhausts memory). The
+  framework reports memory pressure (`ModelLoadPlan` + denial policies) but cannot
+  prevent a host app from forcing a heavyweight load.
+- **Vulnerabilities in upstream dependencies.** Report those directly to the
+  upstream project (mlx-swift, llama.swift, swift-transformers, etc.).
+
+## Cross-references
+
+- [SECURITY.md](../SECURITY.md) — disclosure policy, supported versions, build-mode
+  guarantees.
+- [Security Model](../Sources/BaseChatCore/BaseChatCore.docc/Articles/SecurityModel.md)
+  — DocC article covering in-source mitigations at API granularity.
+- [`TrafficBoundaryAuditTest`](../Tests/BaseChatInferenceTests/TrafficBoundaryAuditTest.swift)
+  — the source-grep audit referenced throughout.
+- [`DenyAllURLProtocol`](../Sources/BaseChatTestSupport/DenyAllURLProtocol.swift)
+  — the runtime network-isolation canary.
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — contributor change-type index. Every
+  change-type section names the security gates that apply.


### PR DESCRIPTION
Make BaseChatKit's security posture legible to integrators and contributors.

- **`SECURITY.md`** (new, repo root) — supported versions, supported build modes (`offline` / `ollama` / `saas` / `full`) with a guarantee + enforcement table, private vulnerability reporting, cryptography-at-rest summary, and a pending-mitigations list linked to tracking issues. `.github/SECURITY.md` becomes a redirect so the GitHub Security tab continues to render.
- **`docs/THREAT_MODEL.md`** (new) — the engineering-honest companion: assets, trust boundaries, line-by-line mitigation enforcement table with links to actual files/workflows, and known non-mitigations with tracking issue references.
- **`CONTRIBUTING.md`** (rewrite) — restructured to be indexed by change type (adding a backend, UI view, dependency, network feature, macro, setting), with cross-references to CLAUDE.md instead of duplicating it.

Closes #736

🤖 Generated with [Claude Code](https://claude.com/claude-code)