### PR TITLE
test(security): SecureBytes zeroing assertion via DEBUG inspection seam

### DIFF
--- a/Sources/BaseChatBackends/SecureBytes.swift
+++ b/Sources/BaseChatBackends/SecureBytes.swift
@@ -29,8 +29,23 @@ final class SecureBytes: @unchecked Sendable {
         String(decoding: buffer, as: UTF8.self)
     }
 
+    #if DEBUG
+    /// Test-only inspection seam fired from `deinit` *after* `memset_s` has
+    /// run but *before* `deallocate`, so a test can observe whether the
+    /// buffer was actually zeroed. The closure receives an immutable view
+    /// of the still-valid backing buffer; capturing the pointer past the
+    /// closure's return is undefined behaviour. Compiled out of release
+    /// builds — production code paths are unchanged.
+    var _testingOnZeroed: ((UnsafeBufferPointer<UInt8>) -> Void)?
+    #endif
+
     deinit {
         _ = memset_s(buffer.baseAddress, buffer.count, 0, buffer.count)
+        #if DEBUG
+        if let probe = _testingOnZeroed {
+            probe(UnsafeBufferPointer(buffer))
+        }
+        #endif
         buffer.deallocate()
     }
 }

--- a/Tests/BaseChatBackendsTests/SecureBytesTests.swift
+++ b/Tests/BaseChatBackendsTests/SecureBytesTests.swift
@@ -34,6 +34,46 @@ struct SecureBytesTests {
         let secure = try #require(SecureBytes(key))
         #expect(secure.stringValue == key)
     }
+
+    #if DEBUG
+    /// Verifies that `deinit` actually wipes the backing buffer via `memset_s`.
+    /// Uses the `#if DEBUG` `_testingOnZeroed` seam to inspect the buffer
+    /// while it is still valid memory but after `memset_s` has run, immediately
+    /// before `deallocate`. If a future change accidentally drops `memset_s`
+    /// (or a compiler ever elides it), the snapshot will retain the original
+    /// plaintext and this assertion will fail.
+    @Test("deinit zeroes the backing buffer before deallocation")
+    func deinitZeroesBuffer() throws {
+        let key = "sk-secret-zeroing-probe-XYZ"
+        let expectedCount = key.utf8.count
+
+        // Captured by the deinit-fired probe; wrapped in a class so the
+        // closure can mutate it without violating Sendable/escaping rules.
+        final class Snapshot {
+            var bytes: [UInt8] = []
+            var fired = false
+        }
+        let snapshot = Snapshot()
+
+        // Scope the SecureBytes so it deinits at the end of the do-block.
+        do {
+            let secure = try #require(SecureBytes(key))
+            #expect(secure.stringValue == key)
+            secure._testingOnZeroed = { buffer in
+                snapshot.fired = true
+                snapshot.bytes = Array(buffer)
+            }
+        }
+
+        #expect(snapshot.fired, "deinit probe should have fired")
+        #expect(snapshot.bytes.count == expectedCount)
+        #expect(snapshot.bytes.allSatisfy { $0 == 0 }, "buffer must be zeroed by memset_s before deallocate")
+
+        // Belt-and-suspenders: the original plaintext must not survive.
+        let recovered = String(decoding: snapshot.bytes, as: UTF8.self)
+        #expect(recovered != key)
+    }
+    #endif
 }
 
 #if Ollama || CloudSaaS

--- a/Tests/BaseChatCoreTests/SwiftTestingAuditTest.swift
+++ b/Tests/BaseChatCoreTests/SwiftTestingAuditTest.swift
@@ -71,7 +71,7 @@ final class SwiftTestingAuditTest: XCTestCase {
         "BaseChatBackendsTests/CloudThinkingTokenTests.swift": 8,
         "BaseChatBackendsTests/OllamaBackendTests.swift": 66,
         "BaseChatBackendsTests/OpenAICompatEndpointTests.swift": 20,
-        "BaseChatBackendsTests/SecureBytesTests.swift": 10,
+        "BaseChatBackendsTests/SecureBytesTests.swift": 11,
         "BaseChatBackendsTests/SSEExtractEventsTests.swift": 5,
     ]
 


### PR DESCRIPTION
Add a DEBUG-only `_testingOnZeroed` callback on `SecureBytes`, fired from `deinit` *after* `memset_s` has run but *before* `deallocate`, so a test can observe whether the backing buffer was actually wiped. If a future change drops `memset_s` (or a compiler ever elides it), the snapshot retains the original plaintext and the assertion fails.

Compiled out of release builds — production code paths are unchanged. Sabotage-verified: temporarily removing the memset_s call makes the test fail.

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)