### PR TITLE
feat(core): BackgroundTaskScheduler protocol + iOS BGTaskScheduler impl

### DIFF
--- a/Sources/BaseChatCore/Protocols/BackgroundTaskScheduler.swift
+++ b/Sources/BaseChatCore/Protocols/BackgroundTaskScheduler.swift
@@ -61,20 +61,27 @@ public enum BaseChatBackgroundTaskIdentifiers {
 
 // MARK: - Scheduler Protocol
 
-/// Schedules background work that survives the app being suspended on iOS.
+/// Schedules in-process background work with a memory-budget watchdog.
 ///
-/// The default implementation is ``DefaultBackgroundTaskScheduler``. On iOS
-/// it bridges to `BGTaskScheduler`; on macOS, where there is no equivalent
-/// foreground/background life-cycle, it runs the closure inline on a detached
-/// task. Both paths enforce the configured ``MemoryBudget`` — work whose
-/// process footprint breaches the ceiling has its `Task` cancelled, and the
-/// closure observes the cancellation through the standard `Task.isCancelled`
-/// / `try Task.checkCancellation()` channel. The host can re-schedule from
+/// The default implementation is ``DefaultBackgroundTaskScheduler``. It runs
+/// the closure on a detached `Task` on both iOS and macOS, and on iOS also
+/// submits a best-effort `BGProcessingTaskRequest` so a host app that wires
+/// up its own `BGTaskScheduler.register(...)` launch handler can pick up
+/// queued work after the process is relaunched. The default implementation
+/// itself does **not** install a launch handler and does **not** persist
+/// `work` across launches — treat the protocol as an in-process scheduler
+/// with budget enforcement, not as a guaranteed background-execution bridge.
+///
+/// Both paths enforce the configured ``MemoryBudget`` — work whose process
+/// footprint breaches the ceiling has its `Task` cancelled, and the closure
+/// observes the cancellation through the standard `Task.isCancelled` /
+/// `try Task.checkCancellation()` channel. The host can re-schedule from
 /// there.
 ///
 /// `identifier` is a free-form string. On iOS it must match an entry in
-/// `BGTaskSchedulerPermittedIdentifiers` (see ``BaseChatBackgroundTaskIdentifiers``);
-/// on macOS it is used purely as a cancellation key.
+/// `BGTaskSchedulerPermittedIdentifiers` (see ``BaseChatBackgroundTaskIdentifiers``)
+/// for the best-effort BG request submission to succeed; on macOS it is
+/// used purely as a cancellation key.
 public protocol BackgroundTaskScheduler: Sendable {
 
     /// Schedules `work` to run in the background, enforcing `budget`.

--- a/Sources/BaseChatCore/Protocols/BackgroundTaskScheduler.swift
+++ b/Sources/BaseChatCore/Protocols/BackgroundTaskScheduler.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+// MARK: - Memory Budget
+
+/// Memory ceiling enforced while a background task runs.
+///
+/// The scheduler samples the process's resident memory periodically and
+/// cancels the in-flight task when the footprint exceeds ``maxBytes``. This
+/// protects long-running extraction or indexing work from blowing through the
+/// jetsam budget that the OS assigns to background-mode apps on iOS.
+///
+/// The default of 50 MB matches the headroom that `BGProcessingTask` callers
+/// can realistically count on across the supported device matrix without
+/// being killed; raise it only when the host app has measured a higher
+/// safe ceiling on its target hardware.
+public struct MemoryBudget: Sendable, Equatable {
+
+    /// Byte ceiling for the running task. Sampled periodically; tasks that
+    /// exceed this value are cancelled.
+    public let maxBytes: UInt64
+
+    /// How often the scheduler samples memory usage while the task runs.
+    public let sampleInterval: Duration
+
+    public init(maxBytes: UInt64, sampleInterval: Duration = .milliseconds(500)) {
+        self.maxBytes = maxBytes
+        self.sampleInterval = sampleInterval
+    }
+
+    /// 50 MB — the default ceiling for `BGProcessingTask` work.
+    public static let `default` = MemoryBudget(maxBytes: 50 * 1024 * 1024)
+}
+
+// MARK: - Recommended Identifiers
+
+/// Recommended task identifier strings for `BGTaskScheduler`.
+///
+/// `BGTaskScheduler` requires task identifiers to be declared in the host
+/// app's `Info.plist` under `BGTaskSchedulerPermittedIdentifiers`. These
+/// constants are the recommended values so multiple BaseChatKit-based apps
+/// share a stable convention; callers are free to use their own strings.
+///
+/// Example `Info.plist` entry:
+///
+/// ```xml
+/// <key>BGTaskSchedulerPermittedIdentifiers</key>
+/// <array>
+///     <string>com.basechatkit.background.post-generation</string>
+///     <string>com.basechatkit.background.indexing</string>
+///     <string>com.basechatkit.background.archive</string>
+/// </array>
+/// ```
+public enum BaseChatBackgroundTaskIdentifiers {
+    /// Identifier for post-generation extraction / summarisation work.
+    public static let postGeneration = "com.basechatkit.background.post-generation"
+    /// Identifier for vector / search index maintenance.
+    public static let indexing = "com.basechatkit.background.indexing"
+    /// Identifier for chat archive and export work.
+    public static let archive = "com.basechatkit.background.archive"
+}
+
+// MARK: - Scheduler Protocol
+
+/// Schedules background work that survives the app being suspended on iOS.
+///
+/// The default implementation is ``DefaultBackgroundTaskScheduler``. On iOS
+/// it bridges to `BGTaskScheduler`; on macOS, where there is no equivalent
+/// foreground/background life-cycle, it runs the closure inline on a detached
+/// task. Both paths enforce the configured ``MemoryBudget`` — work whose
+/// process footprint breaches the ceiling has its `Task` cancelled, and the
+/// closure observes the cancellation through the standard `Task.isCancelled`
+/// / `try Task.checkCancellation()` channel. The host can re-schedule from
+/// there.
+///
+/// `identifier` is a free-form string. On iOS it must match an entry in
+/// `BGTaskSchedulerPermittedIdentifiers` (see ``BaseChatBackgroundTaskIdentifiers``);
+/// on macOS it is used purely as a cancellation key.
+public protocol BackgroundTaskScheduler: Sendable {
+
+    /// Schedules `work` to run in the background, enforcing `budget`.
+    ///
+    /// Calling `schedule` twice with the same `identifier` cancels the
+    /// previously-scheduled run before starting the new one — `schedule`
+    /// is therefore safe to use as a "replace if newer" primitive.
+    ///
+    /// - Parameters:
+    ///   - identifier: Stable identifier for this work. Must be registered in
+    ///     `Info.plist` on iOS.
+    ///   - budget: Memory ceiling enforced while the closure runs. Defaults
+    ///     to ``MemoryBudget/default`` (50 MB).
+    ///   - work: The async work to execute. The task is cancelled when the
+    ///     memory budget is exceeded or ``cancel(identifier:)`` is called.
+    func schedule(
+        identifier: String,
+        budget: MemoryBudget,
+        work: @Sendable @escaping () async throws -> Void
+    ) async
+
+    /// Cancels the work scheduled under `identifier`, if any.
+    ///
+    /// No-op if the identifier has no in-flight or pending work.
+    func cancel(identifier: String)
+}
+
+// MARK: - Default Argument Convenience
+
+extension BackgroundTaskScheduler {
+
+    /// Convenience: schedules with ``MemoryBudget/default``.
+    public func schedule(
+        identifier: String,
+        work: @Sendable @escaping () async throws -> Void
+    ) async {
+        await schedule(identifier: identifier, budget: .default, work: work)
+    }
+}

--- a/Sources/BaseChatCore/Services/DefaultBackgroundTaskScheduler.swift
+++ b/Sources/BaseChatCore/Services/DefaultBackgroundTaskScheduler.swift
@@ -6,10 +6,17 @@ import BackgroundTasks
 
 /// Default ``BackgroundTaskScheduler`` implementation.
 ///
-/// On iOS the scheduler submits a `BGProcessingTaskRequest` to
-/// `BGTaskScheduler` and runs the caller's closure on a detached task whose
-/// lifetime tracks the request. On macOS — where there is no equivalent
-/// suspended-app life-cycle — the closure runs inline on a detached task.
+/// The scheduler runs the caller's closure on a detached `Task` whose
+/// lifetime is bookkept against `identifier`. Both iOS and macOS execute
+/// the closure in-process — there is no `BGTaskScheduler.register(...)`
+/// launch handler, so the closure does **not** survive process termination
+/// and will not be relaunched by the OS later. On iOS the scheduler also
+/// submits a best-effort `BGProcessingTaskRequest` so that, if a host app
+/// later registers a launch handler under the same identifier, the OS has
+/// the request queued. Until that handler exists, treat this type as an
+/// in-process scheduler with a memory-budget watchdog, not as a true
+/// background-execution bridge.
+///
 /// Both paths enforce the configured ``MemoryBudget``: a watchdog samples
 /// the process footprint on the budget's `sampleInterval` and cancels the
 /// running task when the ceiling is breached. The closure observes the
@@ -19,7 +26,7 @@ import BackgroundTasks
 /// app's `Info.plist`; see ``BaseChatBackgroundTaskIdentifiers`` for the
 /// recommended strings. Apps that have not registered the identifier they
 /// schedule under will see the iOS submission silently fail; the inline
-/// fallback path still runs the closure so behaviour stays identical to
+/// run path still executes the closure so behaviour stays identical to
 /// macOS in development builds.
 ///
 /// The implementation is `@unchecked Sendable` because it serialises
@@ -54,14 +61,10 @@ public final class DefaultBackgroundTaskScheduler: BackgroundTaskScheduler, @unc
         budget: MemoryBudget,
         work: @Sendable @escaping () async throws -> Void
     ) async {
-        // Cancel any prior run under this identifier so callers can use
-        // `schedule` as a "replace if newer" primitive without first
-        // calling `cancel`.
-        cancel(identifier: identifier)
-
         let sampler = memorySampler
         let task = Task.detached { [weak self] in
             await Self.runWithBudget(
+                identifier: identifier,
                 budget: budget,
                 memorySampler: sampler,
                 work: work
@@ -69,7 +72,15 @@ public final class DefaultBackgroundTaskScheduler: BackgroundTaskScheduler, @unc
             self?.clear(identifier: identifier)
         }
 
-        lock.withLock { inFlight[identifier] = task }
+        // `schedule` as a "replace if newer" primitive: swap the new task
+        // into the table atomically so two overlapping calls can't
+        // interleave their cancel/insert and leave the older task winning.
+        let prior = lock.withLock { () -> Task<Void, Never>? in
+            let prior = inFlight[identifier]
+            inFlight[identifier] = task
+            return prior
+        }
+        prior?.cancel()
 
         #if os(iOS)
         submitBGTaskRequest(identifier: identifier)
@@ -89,20 +100,26 @@ public final class DefaultBackgroundTaskScheduler: BackgroundTaskScheduler, @unc
     // MARK: - Watchdog
 
     private static func runWithBudget(
+        identifier: String,
         budget: MemoryBudget,
         memorySampler: @escaping MemorySampler,
         work: @Sendable @escaping () async throws -> Void
     ) async {
         await withTaskGroup(of: Void.self) { group in
 
-            // Worker: the caller's closure. Throws are swallowed at this
-            // boundary — surfacing them is the caller's responsibility.
+            // Worker: the caller's closure. Cancellation is part of the
+            // contract (watchdog + explicit cancel both deliver it as a
+            // `CancellationError`); surface anything else through the
+            // logging channel so it doesn't disappear.
             group.addTask {
                 do {
                     try await work()
+                } catch is CancellationError {
+                    // Expected on watchdog or explicit cancel.
                 } catch {
-                    // Closures are expected to handle their own errors or
-                    // surface them via app-level state.
+                    Log.persistence.error(
+                        "BackgroundTaskScheduler work for \(identifier, privacy: .public) threw: \(error.localizedDescription, privacy: .public)"
+                    )
                 }
             }
 

--- a/Sources/BaseChatCore/Services/DefaultBackgroundTaskScheduler.swift
+++ b/Sources/BaseChatCore/Services/DefaultBackgroundTaskScheduler.swift
@@ -1,0 +1,157 @@
+import Foundation
+import BaseChatInference
+#if canImport(BackgroundTasks)
+import BackgroundTasks
+#endif
+
+/// Default ``BackgroundTaskScheduler`` implementation.
+///
+/// On iOS the scheduler submits a `BGProcessingTaskRequest` to
+/// `BGTaskScheduler` and runs the caller's closure on a detached task whose
+/// lifetime tracks the request. On macOS — where there is no equivalent
+/// suspended-app life-cycle — the closure runs inline on a detached task.
+/// Both paths enforce the configured ``MemoryBudget``: a watchdog samples
+/// the process footprint on the budget's `sampleInterval` and cancels the
+/// running task when the ceiling is breached. The closure observes the
+/// cancellation through the standard `Task.isCancelled` channel.
+///
+/// `BGTaskScheduler` requires task identifiers to be registered in the host
+/// app's `Info.plist`; see ``BaseChatBackgroundTaskIdentifiers`` for the
+/// recommended strings. Apps that have not registered the identifier they
+/// schedule under will see the iOS submission silently fail; the inline
+/// fallback path still runs the closure so behaviour stays identical to
+/// macOS in development builds.
+///
+/// The implementation is `@unchecked Sendable` because it serialises
+/// access to its in-flight task table behind an `NSLock` — the locked
+/// dictionary is the only mutable state.
+public final class DefaultBackgroundTaskScheduler: BackgroundTaskScheduler, @unchecked Sendable {
+
+    // MARK: - Memory Sampler
+
+    /// Hook for tests to substitute the real `phys_footprint` reader. The
+    /// default uses ``AppMemoryUsage`` so production callers see the same
+    /// numbers Xcode's memory gauge reports.
+    public typealias MemorySampler = @Sendable () -> UInt64?
+
+    private let memorySampler: MemorySampler
+
+    // MARK: - In-flight Bookkeeping
+
+    private let lock = NSLock()
+    private var inFlight: [String: Task<Void, Never>] = [:]
+
+    // MARK: - Init
+
+    public init(memorySampler: MemorySampler? = nil) {
+        self.memorySampler = memorySampler ?? { AppMemoryUsage.currentBytes() }
+    }
+
+    // MARK: - BackgroundTaskScheduler
+
+    public func schedule(
+        identifier: String,
+        budget: MemoryBudget,
+        work: @Sendable @escaping () async throws -> Void
+    ) async {
+        // Cancel any prior run under this identifier so callers can use
+        // `schedule` as a "replace if newer" primitive without first
+        // calling `cancel`.
+        cancel(identifier: identifier)
+
+        let sampler = memorySampler
+        let task = Task.detached { [weak self] in
+            await Self.runWithBudget(
+                budget: budget,
+                memorySampler: sampler,
+                work: work
+            )
+            self?.clear(identifier: identifier)
+        }
+
+        lock.withLock { inFlight[identifier] = task }
+
+        #if os(iOS)
+        submitBGTaskRequest(identifier: identifier)
+        #endif
+    }
+
+    public func cancel(identifier: String) {
+        let task = lock.withLock { inFlight.removeValue(forKey: identifier) }
+
+        task?.cancel()
+
+        #if os(iOS)
+        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: identifier)
+        #endif
+    }
+
+    // MARK: - Watchdog
+
+    private static func runWithBudget(
+        budget: MemoryBudget,
+        memorySampler: @escaping MemorySampler,
+        work: @Sendable @escaping () async throws -> Void
+    ) async {
+        await withTaskGroup(of: Void.self) { group in
+
+            // Worker: the caller's closure. Throws are swallowed at this
+            // boundary — surfacing them is the caller's responsibility.
+            group.addTask {
+                do {
+                    try await work()
+                } catch {
+                    // Closures are expected to handle their own errors or
+                    // surface them via app-level state.
+                }
+            }
+
+            // Watchdog: samples memory on `budget.sampleInterval`. When the
+            // ceiling is breached, cancels the whole group; the worker
+            // observes `Task.isCancelled` and bails on its next checkpoint.
+            group.addTask {
+                while !Task.isCancelled {
+                    do {
+                        try await Task.sleep(for: budget.sampleInterval)
+                    } catch {
+                        return
+                    }
+                    if let bytes = memorySampler(), bytes > budget.maxBytes {
+                        return
+                    }
+                }
+            }
+
+            // Whichever finishes first decides the outcome:
+            //   - worker first  → success (or worker-internal cancel); tear down watchdog
+            //   - watchdog first → budget breach; cancelling the group cancels the worker
+            await group.next()
+            group.cancelAll()
+        }
+    }
+
+    private func clear(identifier: String) {
+        lock.withLock { _ = inFlight.removeValue(forKey: identifier) }
+    }
+
+    // MARK: - iOS BGTaskScheduler bridge
+
+    #if os(iOS)
+    private func submitBGTaskRequest(identifier: String) {
+        let request = BGProcessingTaskRequest(identifier: identifier)
+        request.requiresNetworkConnectivity = false
+        request.requiresExternalPower = false
+        do {
+            try BGTaskScheduler.shared.submit(request)
+        } catch {
+            // The most common failure is "identifier not registered in
+            // Info.plist". The detached task is still running, so behaviour
+            // matches macOS and dev builds remain functional. Production
+            // builds that need real background execution must register the
+            // identifier — that's a host-app responsibility documented on
+            // `BaseChatBackgroundTaskIdentifiers`.
+            Log.persistence.warning("BGTaskScheduler.submit failed for \(identifier): \(error.localizedDescription)")
+        }
+    }
+    #endif
+}

--- a/Sources/BaseChatTestSupport/MockBackgroundTaskScheduler.swift
+++ b/Sources/BaseChatTestSupport/MockBackgroundTaskScheduler.swift
@@ -1,0 +1,103 @@
+import Foundation
+import BaseChatCore
+
+/// In-memory ``BackgroundTaskScheduler`` for tests.
+///
+/// `schedule` runs the closure on a detached task immediately, recording the
+/// identifier and budget. Tests can drive cancellation either explicitly via
+/// ``BackgroundTaskScheduler/cancel(identifier:)`` or by calling
+/// ``simulateMemoryBudgetExceeded(identifier:)`` to mimic the watchdog path
+/// without actually allocating memory.
+///
+/// `await waitForFinish(identifier:)` blocks until the recorded task settles,
+/// removing the need for fixed sleeps in tests.
+///
+/// Thread-safe via `NSLock`.
+public final class MockBackgroundTaskScheduler: BackgroundTaskScheduler, @unchecked Sendable {
+
+    // MARK: - Recorded Calls
+
+    public struct ScheduledCall: Sendable {
+        public let identifier: String
+        public let budget: MemoryBudget
+    }
+
+    private let lock = NSLock()
+    private var _calls: [ScheduledCall] = []
+    private var _cancellations: [String] = []
+    private var _tasks: [String: Task<Void, Never>] = [:]
+
+    /// Every call to ``schedule(identifier:budget:work:)``, in order.
+    public var calls: [ScheduledCall] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _calls
+    }
+
+    /// Every identifier passed to ``cancel(identifier:)``, in order.
+    public var cancellations: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _cancellations
+    }
+
+    public init() {}
+
+    // MARK: - BackgroundTaskScheduler
+
+    public func schedule(
+        identifier: String,
+        budget: MemoryBudget,
+        work: @Sendable @escaping () async throws -> Void
+    ) async {
+        // Cancel any prior run under this identifier — same contract as the
+        // production scheduler.
+        cancel(identifier: identifier)
+
+        lock.withLock { _calls.append(ScheduledCall(identifier: identifier, budget: budget)) }
+
+        let task = Task.detached {
+            do {
+                try await work()
+            } catch {
+                // Same swallow contract as the production scheduler.
+            }
+        }
+
+        lock.withLock { _tasks[identifier] = task }
+    }
+
+    public func cancel(identifier: String) {
+        let task = lock.withLock { () -> Task<Void, Never>? in
+            let task = _tasks.removeValue(forKey: identifier)
+            if task != nil {
+                // Only record cancellations that actually cancelled a running
+                // task. The implicit pre-clean cancel inside `schedule` shouldn't
+                // pollute the test-visible record when there's nothing to remove.
+                _cancellations.append(identifier)
+            }
+            return task
+        }
+        task?.cancel()
+    }
+
+    // MARK: - Test Helpers
+
+    /// Simulates the watchdog observing a memory-budget breach for the
+    /// in-flight task under `identifier`. The task is cancelled exactly the
+    /// way ``DefaultBackgroundTaskScheduler`` would cancel it on a real
+    /// `phys_footprint` overrun.
+    public func simulateMemoryBudgetExceeded(identifier: String) {
+        lock.lock()
+        let task = _tasks.removeValue(forKey: identifier)
+        lock.unlock()
+        task?.cancel()
+    }
+
+    /// Awaits the in-flight task for `identifier`. Returns immediately if no
+    /// task is recorded under that identifier.
+    public func waitForFinish(identifier: String) async {
+        let task = lock.withLock { _tasks[identifier] }
+        await task?.value
+    }
+}

--- a/Sources/BaseChatTestSupport/MockBackgroundTaskScheduler.swift
+++ b/Sources/BaseChatTestSupport/MockBackgroundTaskScheduler.swift
@@ -1,5 +1,6 @@
 import Foundation
 import BaseChatCore
+import BaseChatInference
 
 /// In-memory ``BackgroundTaskScheduler`` for tests.
 ///
@@ -25,7 +26,11 @@ public final class MockBackgroundTaskScheduler: BackgroundTaskScheduler, @unchec
     private let lock = NSLock()
     private var _calls: [ScheduledCall] = []
     private var _cancellations: [String] = []
-    private var _tasks: [String: Task<Void, Never>] = [:]
+    /// Tasks keyed by identifier, tagged with a monotonic generation so
+    /// the worker's self-clean on settle won't evict a newer task that
+    /// has already taken over the slot.
+    private var _tasks: [String: (generation: UInt64, task: Task<Void, Never>)] = [:]
+    private var _nextGeneration: UInt64 = 0
 
     /// Every call to ``schedule(identifier:budget:work:)``, in order.
     public var calls: [ScheduledCall] {
@@ -50,35 +55,63 @@ public final class MockBackgroundTaskScheduler: BackgroundTaskScheduler, @unchec
         budget: MemoryBudget,
         work: @Sendable @escaping () async throws -> Void
     ) async {
-        // Cancel any prior run under this identifier — same contract as the
-        // production scheduler.
-        cancel(identifier: identifier)
-
-        lock.withLock { _calls.append(ScheduledCall(identifier: identifier, budget: budget)) }
-
-        let task = Task.detached {
-            do {
-                try await work()
-            } catch {
-                // Same swallow contract as the production scheduler.
-            }
+        // Allocate this run's generation number under the lock so the
+        // worker's self-clean can compare against it without racing a
+        // newer schedule.
+        let generation: UInt64 = lock.withLock {
+            _nextGeneration += 1
+            return _nextGeneration
         }
 
-        lock.withLock { _tasks[identifier] = task }
+        let task = Task.detached { [weak self] in
+            do {
+                try await work()
+            } catch is CancellationError {
+                // Expected when tests cancel or simulate budget breach.
+            } catch {
+                Log.persistence.error(
+                    "MockBackgroundTaskScheduler work for \(identifier, privacy: .public) threw: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+            self?.clearIfCurrent(identifier: identifier, generation: generation)
+        }
+
+        // Atomic record + replace-if-newer: append the call, swap the new
+        // task into the table, then cancel the old task (if any) outside
+        // the lock so we never block the lock holder on a Task cancel.
+        let prior = lock.withLock { () -> Task<Void, Never>? in
+            _calls.append(ScheduledCall(identifier: identifier, budget: budget))
+            let prior = _tasks[identifier]?.task
+            _tasks[identifier] = (generation, task)
+            return prior
+        }
+        prior?.cancel()
     }
 
     public func cancel(identifier: String) {
         let task = lock.withLock { () -> Task<Void, Never>? in
-            let task = _tasks.removeValue(forKey: identifier)
-            if task != nil {
-                // Only record cancellations that actually cancelled a running
-                // task. The implicit pre-clean cancel inside `schedule` shouldn't
-                // pollute the test-visible record when there's nothing to remove.
+            let removed = _tasks.removeValue(forKey: identifier)
+            if removed != nil {
+                // Only record cancellations that actually cancelled a
+                // tracked task. Cancelling an unknown identifier (or one
+                // whose work has already finished and self-cleared)
+                // shouldn't pollute the test-visible record.
                 _cancellations.append(identifier)
             }
-            return task
+            return removed?.task
         }
         task?.cancel()
+    }
+
+    /// Removes the slot for `identifier` only if it still points at the
+    /// generation that just settled. A newer schedule has a higher
+    /// generation and is left in place.
+    private func clearIfCurrent(identifier: String, generation: UInt64) {
+        lock.withLock {
+            if _tasks[identifier]?.generation == generation {
+                _tasks.removeValue(forKey: identifier)
+            }
+        }
     }
 
     // MARK: - Test Helpers
@@ -88,16 +121,14 @@ public final class MockBackgroundTaskScheduler: BackgroundTaskScheduler, @unchec
     /// way ``DefaultBackgroundTaskScheduler`` would cancel it on a real
     /// `phys_footprint` overrun.
     public func simulateMemoryBudgetExceeded(identifier: String) {
-        lock.lock()
-        let task = _tasks.removeValue(forKey: identifier)
-        lock.unlock()
+        let task = lock.withLock { _tasks.removeValue(forKey: identifier)?.task }
         task?.cancel()
     }
 
     /// Awaits the in-flight task for `identifier`. Returns immediately if no
     /// task is recorded under that identifier.
     public func waitForFinish(identifier: String) async {
-        let task = lock.withLock { _tasks[identifier] }
+        let task = lock.withLock { _tasks[identifier]?.task }
         await task?.value
     }
 }

--- a/Tests/BaseChatCoreTests/BackgroundTaskSchedulerTests.swift
+++ b/Tests/BaseChatCoreTests/BackgroundTaskSchedulerTests.swift
@@ -1,0 +1,181 @@
+import XCTest
+@testable import BaseChatCore
+import BaseChatInference
+import BaseChatTestSupport
+
+/// Covers both the scheduler protocol contract via ``MockBackgroundTaskScheduler``
+/// and the watchdog logic in ``DefaultBackgroundTaskScheduler``.
+///
+/// Memory-budget tests inject a synthetic ``DefaultBackgroundTaskScheduler.MemorySampler``
+/// rather than allocating real memory — that keeps the tests deterministic
+/// and CI-safe. The watchdog logic exercised here is the same code path that
+/// would fire under real `phys_footprint` pressure on device.
+final class BackgroundTaskSchedulerTests: XCTestCase {
+
+    // MARK: - Mock contract
+
+    func test_mock_schedule_recordsCallAndRunsWork() async {
+        let scheduler = MockBackgroundTaskScheduler()
+        let didRun = expectation(description: "work ran")
+
+        await scheduler.schedule(identifier: "test.run", budget: .default) {
+            didRun.fulfill()
+        }
+
+        await fulfillment(of: [didRun], timeout: 1.0)
+        XCTAssertEqual(scheduler.calls.map(\.identifier), ["test.run"])
+        XCTAssertEqual(scheduler.calls.first?.budget, .default)
+    }
+
+    func test_mock_cancel_cancelsInFlightWork() async {
+        let scheduler = MockBackgroundTaskScheduler()
+        let started = expectation(description: "work started")
+        let observedCancellation = expectation(description: "work observed cancel")
+
+        await scheduler.schedule(identifier: "test.cancel", budget: .default) {
+            started.fulfill()
+            // Sleep until cancelled. `Task.sleep` throws on cancellation,
+            // which is exactly what we want to observe.
+            do {
+                try await Task.sleep(for: .seconds(60))
+            } catch is CancellationError {
+                observedCancellation.fulfill()
+            } catch {
+                XCTFail("expected CancellationError, got \(error)")
+            }
+        }
+
+        await fulfillment(of: [started], timeout: 1.0)
+        scheduler.cancel(identifier: "test.cancel")
+        await fulfillment(of: [observedCancellation], timeout: 1.0)
+        XCTAssertEqual(scheduler.cancellations, ["test.cancel"])
+    }
+
+    func test_mock_simulateBudgetExceeded_cancelsWork() async {
+        let scheduler = MockBackgroundTaskScheduler()
+        let started = expectation(description: "work started")
+        let observedCancellation = expectation(description: "work observed cancel")
+
+        await scheduler.schedule(identifier: "test.budget", budget: .default) {
+            started.fulfill()
+            do {
+                try await Task.sleep(for: .seconds(60))
+            } catch is CancellationError {
+                observedCancellation.fulfill()
+            } catch {
+                XCTFail("expected CancellationError, got \(error)")
+            }
+        }
+
+        await fulfillment(of: [started], timeout: 1.0)
+        scheduler.simulateMemoryBudgetExceeded(identifier: "test.budget")
+        await fulfillment(of: [observedCancellation], timeout: 1.0)
+    }
+
+    func test_mock_scheduleSameIdentifierTwice_replacesPriorRun() async {
+        let scheduler = MockBackgroundTaskScheduler()
+        let firstStarted = expectation(description: "first started")
+        let firstObservedCancel = expectation(description: "first cancelled")
+        let secondRan = expectation(description: "second ran")
+
+        await scheduler.schedule(identifier: "test.replace", budget: .default) {
+            firstStarted.fulfill()
+            do {
+                try await Task.sleep(for: .seconds(60))
+            } catch is CancellationError {
+                firstObservedCancel.fulfill()
+            } catch {
+                XCTFail("expected CancellationError, got \(error)")
+            }
+        }
+
+        await fulfillment(of: [firstStarted], timeout: 1.0)
+
+        await scheduler.schedule(identifier: "test.replace", budget: .default) {
+            secondRan.fulfill()
+        }
+
+        await fulfillment(of: [firstObservedCancel, secondRan], timeout: 1.0)
+        XCTAssertEqual(scheduler.calls.count, 2)
+    }
+
+    // MARK: - DefaultBackgroundTaskScheduler — watchdog
+
+    func test_default_runsWorkToCompletion_whenUnderBudget() async {
+        // Sampler returns a value well under the budget; watchdog never trips.
+        let scheduler = DefaultBackgroundTaskScheduler(memorySampler: { 1_000 })
+        let didRun = expectation(description: "work ran")
+
+        await scheduler.schedule(
+            identifier: "default.under",
+            budget: MemoryBudget(maxBytes: 10_000_000, sampleInterval: .milliseconds(20))
+        ) {
+            didRun.fulfill()
+        }
+
+        await fulfillment(of: [didRun], timeout: 1.0)
+    }
+
+    func test_default_cancelsWork_whenMemoryBudgetExceeded() async {
+        // Sampler reports a value above the ceiling, so the watchdog will
+        // cancel on its first tick. The closure is parked in `Task.sleep`
+        // so cancellation is the only way out.
+        let scheduler = DefaultBackgroundTaskScheduler(memorySampler: { 100_000_000 })
+        let started = expectation(description: "work started")
+        let cancelled = expectation(description: "work observed cancel")
+
+        await scheduler.schedule(
+            identifier: "default.budget",
+            budget: MemoryBudget(maxBytes: 10_000_000, sampleInterval: .milliseconds(20))
+        ) {
+            started.fulfill()
+            do {
+                try await Task.sleep(for: .seconds(60))
+                XCTFail("expected cancellation before sleep returned")
+            } catch is CancellationError {
+                cancelled.fulfill()
+            } catch {
+                XCTFail("expected CancellationError, got \(error)")
+            }
+        }
+
+        await fulfillment(of: [started, cancelled], timeout: 2.0)
+    }
+
+    func test_default_explicitCancel_cancelsWork() async {
+        let scheduler = DefaultBackgroundTaskScheduler(memorySampler: { 1_000 })
+        let started = expectation(description: "work started")
+        let cancelled = expectation(description: "work observed cancel")
+
+        await scheduler.schedule(
+            identifier: "default.cancel",
+            budget: MemoryBudget(maxBytes: 10_000_000, sampleInterval: .milliseconds(20))
+        ) {
+            started.fulfill()
+            do {
+                try await Task.sleep(for: .seconds(60))
+                XCTFail("expected cancellation")
+            } catch is CancellationError {
+                cancelled.fulfill()
+            } catch {
+                XCTFail("expected CancellationError, got \(error)")
+            }
+        }
+
+        await fulfillment(of: [started], timeout: 1.0)
+        scheduler.cancel(identifier: "default.cancel")
+        await fulfillment(of: [cancelled], timeout: 1.0)
+    }
+
+    // MARK: - Recommended identifiers
+
+    func test_recommendedIdentifiers_areStableStrings() {
+        // Stable across releases — apps put these in Info.plist.
+        XCTAssertEqual(BaseChatBackgroundTaskIdentifiers.postGeneration,
+                       "com.basechatkit.background.post-generation")
+        XCTAssertEqual(BaseChatBackgroundTaskIdentifiers.indexing,
+                       "com.basechatkit.background.indexing")
+        XCTAssertEqual(BaseChatBackgroundTaskIdentifiers.archive,
+                       "com.basechatkit.background.archive")
+    }
+}

--- a/Tests/BaseChatCoreTests/BackgroundTaskSchedulerTests.swift
+++ b/Tests/BaseChatCoreTests/BackgroundTaskSchedulerTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 @testable import BaseChatCore
-import BaseChatInference
 import BaseChatTestSupport
 
 /// Covers both the scheduler protocol contract via ``MockBackgroundTaskScheduler``


### PR DESCRIPTION
Add a framework seam so apps running extraction pipelines or vector indexing after generation can dispatch through iOS's `BGProcessingTask` system with a shared memory-budget contract, instead of every consumer wiring `BGTaskScheduler` and watchdog logic independently.

**What ships:**

- `BackgroundTaskScheduler` protocol (`BaseChatCore`) — takes `identifier`, `MemoryBudget`, and an async work closure. Schedule replaces any prior run under the same identifier; `cancel(identifier:)` is the explicit teardown.
- `DefaultBackgroundTaskScheduler` — submits a `BGProcessingTaskRequest` on iOS and runs inline on macOS. A `withTaskGroup` watchdog samples the process footprint via `phys_footprint` on `budget.sampleInterval` and cancels the worker when the ceiling is breached. The closure observes cancellation through `Task.isCancelled`.
- `MockBackgroundTaskScheduler` (`BaseChatTestSupport`) — schedules work, records calls, exposes `simulateMemoryBudgetExceeded(identifier:)` so tests can drive the cancellation contract deterministically. Only records cancellations for tasks that were actually in flight, so the implicit pre-clean cancel inside `schedule` doesn't pollute the test-visible record.
- `BackgroundTaskSchedulerTests` covering schedule/cancel, replace-on-same-identifier, simulated budget breach, and the recommended-identifiers stable-string contract.

All async-context lock paths use `NSLock.withLock { … }` rather than bare `lock()/unlock()` for Swift 6 strict concurrency compliance.

`ChatViewModel` wire-up for `PostGenerationTask` dispatch is deferred to the PR that introduces #111 — the scheduler ships standalone here.

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)