### PR TITLE
fix(mlx): skip Gemma4 MoE inference test pending upstream broadcast fix

### DIFF
--- a/Tests/BaseChatMLXIntegrationTests/Gemma4MoESmokeTests.swift
+++ b/Tests/BaseChatMLXIntegrationTests/Gemma4MoESmokeTests.swift
@@ -56,6 +56,14 @@ final class Gemma4MoESmokeTests: XCTestCase {
     }
 
     func test_loadAndGenerate_producesNonEmptyResponse() async throws {
+        // FIXME: https://github.com/roryford/BaseChatKit/issues/802
+        // Upstream mlx-swift-lm 3.31.3 crashes with a fatal C++ broadcast-shape
+        // error ([broadcast_shapes] Shapes (20) and (39) cannot be broadcast)
+        // on the first generate call for this MoE model. The abort fires inside
+        // MLX's C++ runtime and cannot be caught by XCTExpectFailure, so we
+        // skip the inference step until the upstream fix lands.
+        throw XCTSkip("Skipped pending upstream mlx-swift-lm fix for Gemma4 MoE broadcast crash (issue #802)")
+
         let config = GenerationConfig(temperature: 0.3, maxOutputTokens: 32)
         let stream = try backend.generate(
             prompt: "Reply with exactly one word.",


### PR DESCRIPTION
## Summary

Adds `XCTSkip` to the inference step in `Gemma4MoESmokeTests` so the test no longer aborts the entire test process with an unrecoverable C++ crash.

## Problem

The first `backend.generate()` call for `mlx-community/gemma-4-26b-a4b-it-4bit` crashes with:

```
MLX/ErrorHandler.swift:343: Fatal error: [broadcast_shapes] Shapes (20) and (39) cannot be broadcast.
```

This fires deep inside MLX's C++ runtime (`ops.cpp:3952`) during the MoE forward pass. It is a process-level abort — it cannot be caught by `XCTExpectFailure`, `try/catch`, or any Swift error handler. The entire test process dies.

## Investigation

- No fix is available upstream: `mlx-swift-lm` 3.31.3 is the latest release, and the three commits beyond it on `main` are README-only.
- The Python mlx-lm issue [#1139](https://github.com/ml-explore/mlx-lm/issues/1139) / fix [#1141](https://github.com/ml-explore/mlx-lm/pull/1141) addresses `BatchKVCache` (server-batching path) — not directly applicable to the Swift single-request path, but related.
- The crash occurs during MoE forward pass, likely in the `SwitchGLU`/router computation within `mlx-swift-lm`'s `Gemma4.swift`. Shape `(20)` matches the 20-token prefill; `(39)` is an MLX-internal intermediate shape that doesn't map to a config dimension.
- `withKnownIssue` (Swift Testing API) doesn't apply here — this is `XCTestCase`. `XCTExpectFailure` can't catch process aborts. `XCTSkip` is the only safe option.

## What changes

- `setUp()` still runs fully — the VLM-factory routing assertions (`requiresVLMFactory`, model load, `isModelLoaded`) still execute on hardware with the model present.
- Only the `generate()` step is skipped.
- `// FIXME: https://github.com/roryford/BaseChatKit/issues/802` comment on the skip ensures it gets removed when the upstream fix ships.

## Release Note

No user-visible behavior change — test-only. No version bump needed.

Closes #802