### PR TITLE
feat(llama): Gemma 4 tool calling + GBNF schema pre-validator (#414, #609)

### DIFF
--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -50,7 +50,7 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
             maxContextTokens: ctxSize,
             requiresPromptTemplate: true,
             supportsSystemPrompt: true,
-            supportsToolCalling: false,
+            supportsToolCalling: true,
             supportsStructuredOutput: false,
             supportsNativeJSONMode: false,
             cancellationStyle: .explicit,

--- a/Sources/BaseChatBackends/LlamaGenerationDriver.swift
+++ b/Sources/BaseChatBackends/LlamaGenerationDriver.swift
@@ -288,6 +288,14 @@ struct LlamaGenerationDriver {
         // Flag set when maxThinkingTokens is reached so we can break the outer loop cleanly.
         var thinkingLimitReached = false
 
+        // Tool-call parser: active when the config carries at least one tool definition.
+        // Processes `.token` events from the thinking layer (or raw decoded text) and
+        // re-routes `<|tool_call>…<|end_of_turn>` / `<tool_call>…</tool_call>` blocks
+        // into `.toolCall` events. When no tools are configured the parser is skipped
+        // entirely — zero overhead on non-tool-calling generation paths.
+        let useToolParser = !config.tools.isEmpty
+        var toolCallParser = LlamaToolCallParser()
+
         // Repetition-window state: track the last decoded token string and how
         // many times it has appeared consecutively. Exceeding `maxRepeatWindow`
         // triggers an early exit — no need to run the loop all the way to maxTokens.
@@ -348,9 +356,27 @@ struct LlamaGenerationDriver {
 
                 // Build the list of events this token emits. Two paths, matching the
                 // two thinking-marker modes documented at the top of the loop:
-                let events: [GenerationEvent] = useParser
+                let thinkingEvents: [GenerationEvent] = useParser
                     ? thinkingParser.process(text)
                     : [.token(text)]
+
+                // Route `.token` events through the tool-call parser when active.
+                // Non-token events (.thinkingToken, .thinkingComplete) pass straight
+                // through — tool calls never appear inside thinking blocks.
+                let events: [GenerationEvent]
+                if useToolParser {
+                    var routed: [GenerationEvent] = []
+                    for ev in thinkingEvents {
+                        if case .token(let t) = ev {
+                            routed += toolCallParser.process(t)
+                        } else {
+                            routed.append(ev)
+                        }
+                    }
+                    events = routed
+                } else {
+                    events = thinkingEvents
+                }
 
                 for event in events {
                     if isFirstToken {
@@ -399,6 +425,11 @@ struct LlamaGenerationDriver {
         // false avoids yielding spurious events from an untouched parser.
         if useParser {
             for event in thinkingParser.finalize() {
+                continuation.yield(event)
+            }
+        }
+        if useToolParser {
+            for event in toolCallParser.finalize() {
                 continuation.yield(event)
             }
         }

--- a/Sources/BaseChatBackends/LlamaToolCallParser.swift
+++ b/Sources/BaseChatBackends/LlamaToolCallParser.swift
@@ -1,0 +1,248 @@
+#if Llama
+import Foundation
+import BaseChatInference
+
+/// Stateful, chunk-safe parser that extracts tool calls from Gemma 4 GGUF
+/// token streams produced by `LlamaGenerationDriver`.
+///
+/// ## Token format
+///
+/// Gemma 4 IT GGUF models emit tool invocations using special tokens:
+///
+/// ```
+/// <|tool_call>
+/// call:function_name{param1:<|"|>value<|"|>}
+/// <|end_of_turn>
+/// ```
+///
+/// `<|"|>` is Gemma 4's string-quoting special token; it is substituted with
+/// `"` before the call body is interpreted as a JSON-like object.
+///
+/// ## Fallback format
+///
+/// For tool-calling fine-tunes that deviate from the Gemma 4 native format
+/// and instead emit a JSON object between `<tool_call>` / `</tool_call>` tags
+/// (as used by Qwen and other models), the parser also accepts:
+///
+/// ```
+/// <tool_call>
+/// {"name": "function_name", "arguments": {"param": "value"}}
+/// </tool_call>
+/// ```
+///
+/// ## Chunk safety
+///
+/// Tags that straddle chunk boundaries are held back until the boundary is
+/// resolved, using the same prefix-hold strategy as `MLXToolCallParser` and
+/// `ThinkingParser`.
+///
+/// ## Usage
+///
+/// ```swift
+/// var parser = LlamaToolCallParser()
+/// for chunk in tokenStream {
+///     for event in parser.process(chunk) { … }
+/// }
+/// for event in parser.finalize() { … }
+/// ```
+struct LlamaToolCallParser: Sendable {
+
+    // MARK: - Tag constants
+
+    /// Gemma 4 native open token.
+    static let gemma4OpenTag = "<|tool_call>"
+    /// Gemma 4 turn-end token used to close a native tool call.
+    static let gemma4EndTurn = "<|end_of_turn>"
+    /// Gemma 4 string-quoting token substituted with `"` before parsing.
+    static let gemma4QuoteToken = "<|\"|>"
+
+    /// Standard JSON open tag (fallback for non-native tool-call fine-tunes).
+    static let jsonOpenTag  = "<tool_call>"
+    /// Standard JSON close tag.
+    static let jsonCloseTag = "</tool_call>"
+
+    // MARK: - State
+
+    private var buffer = ""
+    private var insideToolCall = false
+    private var callBuffer = ""
+    /// `true` when the open tag was the Gemma 4 native `<|tool_call>` form.
+    private var usingGemma4Format = false
+
+    // MARK: - Processing
+
+    /// Process a chunk of streamed text.
+    ///
+    /// - Parameter chunk: Raw token text as emitted by the generation loop.
+    /// - Returns: A (possibly empty) array of ``GenerationEvent`` values.
+    ///   Text outside tool-call delimiters is emitted as `.token` events;
+    ///   a complete call produces a `.toolCall` event.
+    mutating func process(_ chunk: String) -> [GenerationEvent] {
+        buffer += chunk
+        var events: [GenerationEvent] = []
+
+        while true {
+            if insideToolCall {
+                let closeTag = usingGemma4Format ? Self.gemma4EndTurn : Self.jsonCloseTag
+                if let range = buffer.range(of: closeTag) {
+                    callBuffer += String(buffer[..<range.lowerBound])
+                    buffer = String(buffer[range.upperBound...])
+                    if let event = parseCallBuffer(callBuffer) {
+                        events.append(event)
+                    }
+                    callBuffer = ""
+                    insideToolCall = false
+                } else {
+                    // Hold back partial close-tag suffix.
+                    let maxHold = min(buffer.count, closeTag.count - 1)
+                    var holdLen = 0
+                    for l in stride(from: maxHold, through: 1, by: -1) {
+                        if closeTag.hasPrefix(String(buffer.suffix(l))) {
+                            holdLen = l
+                            break
+                        }
+                    }
+                    if buffer.count > holdLen {
+                        callBuffer += String(buffer.prefix(buffer.count - holdLen))
+                        buffer = holdLen > 0 ? String(buffer.suffix(holdLen)) : ""
+                    }
+                    break
+                }
+            } else {
+                // Find the earliest of the two open-tag candidates.
+                let g4Range   = buffer.range(of: Self.gemma4OpenTag)
+                let jsonRange = buffer.range(of: Self.jsonOpenTag)
+
+                let (chosenRange, isGemma4): (Range<String.Index>?, Bool)
+                switch (g4Range, jsonRange) {
+                case let (g4?, json?) where g4.lowerBound <= json.lowerBound:
+                    (chosenRange, isGemma4) = (g4, true)
+                case let (g4?, json?) where g4.lowerBound > json.lowerBound:
+                    (chosenRange, isGemma4) = (json, false)
+                case (let g4?, nil):
+                    (chosenRange, isGemma4) = (g4, true)
+                case (nil, let json?):
+                    (chosenRange, isGemma4) = (json, false)
+                default:
+                    (chosenRange, isGemma4) = (nil, false)
+                }
+
+                if let range = chosenRange {
+                    let before = String(buffer[..<range.lowerBound])
+                    buffer = String(buffer[range.upperBound...])
+                    if !before.isEmpty {
+                        events.append(.token(before))
+                    }
+                    insideToolCall = true
+                    usingGemma4Format = isGemma4
+                } else {
+                    break
+                }
+            }
+        }
+
+        // Hold back partial open-tag suffix when not inside a call.
+        if !insideToolCall {
+            let candidates = [Self.gemma4OpenTag, Self.jsonOpenTag]
+            let maxTagLen  = candidates.map(\.count).max()! - 1
+            let maxCheck   = min(buffer.count, maxTagLen)
+            var holdLen    = 0
+            for candidate in candidates {
+                for l in stride(from: maxCheck, through: 1, by: -1) {
+                    if candidate.hasPrefix(String(buffer.suffix(l))) {
+                        holdLen = max(holdLen, l)
+                    }
+                }
+            }
+            if buffer.count > holdLen {
+                let confirmed = String(buffer.prefix(buffer.count - holdLen))
+                buffer = holdLen > 0 ? String(buffer.suffix(holdLen)) : ""
+                if !confirmed.isEmpty {
+                    events.append(.token(confirmed))
+                }
+            }
+        }
+
+        return events
+    }
+
+    /// Flush the held-back buffer at stream end.
+    ///
+    /// Call once after the generation loop finishes to emit any remaining
+    /// visible text. An incomplete (unclosed) tool-call block is discarded —
+    /// partial JSON cannot produce a valid `ToolCall`.
+    mutating func finalize() -> [GenerationEvent] {
+        var events: [GenerationEvent] = []
+        if !insideToolCall && !buffer.isEmpty {
+            events.append(.token(buffer))
+        }
+        buffer = ""
+        callBuffer = ""
+        insideToolCall = false
+        return events
+    }
+
+    // MARK: - Call body parsing
+
+    private func parseCallBuffer(_ raw: String) -> GenerationEvent? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if trimmed.hasPrefix("call:") {
+            return parseGemma4NativeCall(trimmed)
+        }
+        return parseJSONCall(trimmed)
+    }
+
+    /// Parses Gemma 4 native format: `call:name{param1:<|"|>val<|"|>}`.
+    ///
+    /// `<|"|>` is Gemma 4's string-quoting special token and is substituted
+    /// with `"` before the brace-delimited body is parsed as JSON.
+    private func parseGemma4NativeCall(_ raw: String) -> GenerationEvent? {
+        let body = String(raw.dropFirst("call:".count))
+        let substituted = body.replacingOccurrences(of: Self.gemma4QuoteToken, with: "\"")
+
+        guard let braceIndex = substituted.firstIndex(of: "{") else { return nil }
+        let name = String(substituted[..<braceIndex]).trimmingCharacters(in: .whitespaces)
+        guard !name.isEmpty else { return nil }
+
+        let jsonBody = String(substituted[braceIndex...])
+        let argsString = canonicalizedArguments(from: jsonBody) ?? "{}"
+        let id = "llama-\(name)-\(UUID().uuidString.prefix(8))"
+        return .toolCall(ToolCall(id: id, toolName: name, arguments: argsString))
+    }
+
+    /// Parses JSON fallback format: `{"name":"...","arguments":{...}}`.
+    private func parseJSONCall(_ json: String) -> GenerationEvent? {
+        guard let data = json.data(using: .utf8),
+              let obj  = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              let name = obj["name"] as? String, !name.isEmpty
+        else { return nil }
+
+        let argsString: String
+        if let argsDict = obj["arguments"] as? [String: Any],
+           let serialized = try? JSONSerialization.data(withJSONObject: argsDict),
+           let str = String(data: serialized, encoding: .utf8) {
+            argsString = str
+        } else if let rawStr = obj["arguments"] as? String {
+            argsString = rawStr
+        } else {
+            argsString = "{}"
+        }
+
+        let id = "llama-\(name)-\(UUID().uuidString.prefix(8))"
+        return .toolCall(ToolCall(id: id, toolName: name, arguments: argsString))
+    }
+
+    /// Round-trips `jsonBody` through `JSONSerialization` to canonicalize it.
+    /// Returns `nil` on parse failure; callers fall back to `"{}"`.
+    private func canonicalizedArguments(from jsonBody: String) -> String? {
+        guard let data = jsonBody.data(using: .utf8),
+              let obj  = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              let serialized = try? JSONSerialization.data(withJSONObject: obj),
+              let str = String(data: serialized, encoding: .utf8)
+        else { return nil }
+        return str
+    }
+}
+#endif

--- a/Sources/BaseChatBackends/LlamaToolCallParser.swift
+++ b/Sources/BaseChatBackends/LlamaToolCallParser.swift
@@ -194,10 +194,16 @@ struct LlamaToolCallParser: Sendable {
         return parseJSONCall(trimmed)
     }
 
-    /// Parses Gemma 4 native format: `call:name{param1:<|"|>val<|"|>}`.
+    /// Parses Gemma 4 native format: `call:name{param1:<|"|>val<|"|>,param2:42}`.
     ///
-    /// `<|"|>` is Gemma 4's string-quoting special token and is substituted
-    /// with `"` before the brace-delimited body is parsed as JSON.
+    /// The brace body uses **unquoted JSON-like keys** with values that are
+    /// either Gemma 4's `<|"|>...<|"|>` quoted-string token, or a bare
+    /// numeric / boolean / null literal. JSON itself requires quoted keys,
+    /// so the body cannot be handed to `JSONSerialization` directly — earlier
+    /// versions did, with the result that *every* native tool call fell back
+    /// to `arguments == "{}"`. The dedicated tokenizer below quotes keys and
+    /// (when needed) values, then round-trips through `JSONSerialization` for
+    /// canonicalisation.
     private func parseGemma4NativeCall(_ raw: String) -> GenerationEvent? {
         let body = String(raw.dropFirst("call:".count))
         let substituted = body.replacingOccurrences(of: Self.gemma4QuoteToken, with: "\"")
@@ -206,10 +212,114 @@ struct LlamaToolCallParser: Sendable {
         let name = String(substituted[..<braceIndex]).trimmingCharacters(in: .whitespaces)
         guard !name.isEmpty else { return nil }
 
-        let jsonBody = String(substituted[braceIndex...])
-        let argsString = canonicalizedArguments(from: jsonBody) ?? "{}"
+        let braceBody = String(substituted[braceIndex...])
+        let argsString = parseGemma4Arguments(braceBody) ?? "{}"
         let id = "llama-\(name)-\(UUID().uuidString.prefix(8))"
         return .toolCall(ToolCall(id: id, toolName: name, arguments: argsString))
+    }
+
+    /// Tokenises Gemma 4's `{key:value,key:value}` brace body into a JSON object.
+    ///
+    /// Returns the canonical JSON string on success, or `nil` on parse failure
+    /// so the caller can fall back to `"{}"` (the same behaviour the JSON
+    /// fallback path uses for malformed call bodies).
+    private func parseGemma4Arguments(_ braceBody: String) -> String? {
+        var trimmed = braceBody.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("{"), trimmed.hasSuffix("}") else { return nil }
+        trimmed.removeFirst()
+        trimmed.removeLast()
+        let inner = trimmed.trimmingCharacters(in: .whitespacesAndNewlines)
+        if inner.isEmpty {
+            return "{}"
+        }
+
+        var dict: [String: Any] = [:]
+        var idx = inner.startIndex
+        let end = inner.endIndex
+
+        while idx < end {
+            // Skip whitespace and stray commas between pairs.
+            while idx < end, inner[idx].isWhitespace || inner[idx] == "," {
+                idx = inner.index(after: idx)
+            }
+            if idx >= end { break }
+
+            // Read unquoted key up to the next `:`.
+            guard let colon = inner[idx...].firstIndex(of: ":") else { return nil }
+            let key = inner[idx..<colon].trimmingCharacters(in: .whitespaces)
+            guard !key.isEmpty else { return nil }
+            idx = inner.index(after: colon)
+
+            // Skip whitespace before the value.
+            while idx < end, inner[idx].isWhitespace {
+                idx = inner.index(after: idx)
+            }
+            if idx >= end { return nil }
+
+            // Read value: either a quoted string, or a bare literal up to the next comma.
+            let value: Any
+            if inner[idx] == "\"" {
+                // Quoted string: scan for the closing quote, honouring `\"` escapes.
+                var cursor = inner.index(after: idx)
+                var raw = ""
+                var escaped = false
+                while cursor < end {
+                    let ch = inner[cursor]
+                    if escaped {
+                        raw.append(ch)
+                        escaped = false
+                    } else if ch == "\\" {
+                        raw.append(ch)
+                        escaped = true
+                    } else if ch == "\"" {
+                        break
+                    } else {
+                        raw.append(ch)
+                    }
+                    cursor = inner.index(after: cursor)
+                }
+                guard cursor < end else { return nil } // unterminated string
+                idx = inner.index(after: cursor)
+                // Decode JSON escapes via JSONSerialization on a wrapped string.
+                if let data = "\"\(raw)\"".data(using: .utf8),
+                   let decoded = try? JSONSerialization.jsonObject(
+                       with: data, options: [.fragmentsAllowed]) as? String {
+                    value = decoded
+                } else {
+                    value = raw
+                }
+            } else {
+                // Bare literal — number, true, false, or null. Read up to next comma.
+                var cursor = idx
+                while cursor < end, inner[cursor] != "," {
+                    cursor = inner.index(after: cursor)
+                }
+                let literal = inner[idx..<cursor].trimmingCharacters(in: .whitespaces)
+                idx = cursor
+                guard !literal.isEmpty else { return nil }
+                if literal == "true" {
+                    value = true
+                } else if literal == "false" {
+                    value = false
+                } else if literal == "null" {
+                    value = NSNull()
+                } else if let intVal = Int(literal) {
+                    value = intVal
+                } else if let dblVal = Double(literal) {
+                    value = dblVal
+                } else {
+                    // Treat as a bare string when the model omits Gemma's quote token.
+                    value = literal
+                }
+            }
+
+            dict[key] = value
+        }
+
+        guard let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys]),
+              let str  = String(data: data, encoding: .utf8)
+        else { return nil }
+        return str
     }
 
     /// Parses JSON fallback format: `{"name":"...","arguments":{...}}`.
@@ -234,15 +344,5 @@ struct LlamaToolCallParser: Sendable {
         return .toolCall(ToolCall(id: id, toolName: name, arguments: argsString))
     }
 
-    /// Round-trips `jsonBody` through `JSONSerialization` to canonicalize it.
-    /// Returns `nil` on parse failure; callers fall back to `"{}"`.
-    private func canonicalizedArguments(from jsonBody: String) -> String? {
-        guard let data = jsonBody.data(using: .utf8),
-              let obj  = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
-              let serialized = try? JSONSerialization.data(withJSONObject: obj),
-              let str = String(data: serialized, encoding: .utf8)
-        else { return nil }
-        return str
-    }
 }
 #endif

--- a/Sources/BaseChatInference/Services/GBNFSchemaPreValidator.swift
+++ b/Sources/BaseChatInference/Services/GBNFSchemaPreValidator.swift
@@ -164,10 +164,25 @@ public struct GBNFSchemaPreValidator: Sendable {
             }
         }
 
-        // Recurse into `items` (array schema).
+        // Recurse into `items`. JSON Schema permits two shapes:
+        //   - a single sub-schema object (list validation), or
+        //   - an array of sub-schemas (tuple validation, draft-04 / 2019-09).
+        // Without the array branch, unsafe constructs nested inside a tuple-form
+        // `items` would bypass the pre-validator and reach the GBNF compiler.
         if let itemsValue = dict["items"] {
-            if let failure = validate(itemsValue, path: path + ["items"]) {
-                return failure
+            switch itemsValue {
+            case .object:
+                if let failure = validate(itemsValue, path: path + ["items"]) {
+                    return failure
+                }
+            case .array(let itemSchemas):
+                for (index, itemSchema) in itemSchemas.enumerated() {
+                    if let failure = validate(itemSchema, path: path + ["items", String(index)]) {
+                        return failure
+                    }
+                }
+            default:
+                break
             }
         }
 

--- a/Sources/BaseChatInference/Services/GBNFSchemaPreValidator.swift
+++ b/Sources/BaseChatInference/Services/GBNFSchemaPreValidator.swift
@@ -1,0 +1,183 @@
+import Foundation
+
+/// Pre-validates a ``JSONSchemaValue`` tool-parameter schema before
+/// handing it to the GBNF compiler in llama.cpp.
+///
+/// ## Why this exists
+///
+/// llama.cpp's GBNF compiler (`llama_sampler_init_grammar`) can SIGSEGV on
+/// certain JSON Schema constructs:
+///
+/// - `anyOf` / `oneOf` / `allOf` / `not` — combiners the GBNF IR cannot
+///   express as a regular grammar.
+/// - Nullable union types — `"type": ["string", "null"]` — produce an
+///   unbounded alternation that causes stack overflow in the GBNF compiler.
+/// - `exclusiveMinimum` / `exclusiveMaximum` — numeric bounds expressed as
+///   integers in Draft 2020-12 trigger a type-confusion path in the GBNF
+///   numeric rule builder.
+///
+/// ## CVE-2026-2069
+///
+/// A buffer overflow in `llama_grammar_advance_stack()` was disclosed in
+/// CVE-2026-2069. The fix landed in llama.cpp build b8774. The vendored
+/// xcframework (`mattt/llama.swift` 2.8772.0) wraps build b8772, which
+/// pre-dates the fix.
+///
+/// Until the vendor is bumped past b8773, callers **MUST** gate all GBNF
+/// use behind this pre-validator. The validation rules below reject the
+/// schema shapes that were confirmed to trigger the overflow in the CVE
+/// proof-of-concept.
+///
+/// When the vendor bumps to a post-CVE build (≥ b8774), re-audit the
+/// rules below and remove or relax any that are no longer necessary.
+/// See ``GBNFSchemaPreValidator/cveStatus`` for the pinned audit record.
+public struct GBNFSchemaPreValidator: Sendable {
+
+    // MARK: - CVE status
+
+    /// Structured audit record for CVE-2026-2069.
+    ///
+    /// When `isFixed` is `true`, the vendored llama.cpp build has been
+    /// confirmed post-patch and callers may reduce the strictness of schema
+    /// rules if desired. Until then, treat `isFixed == false` as "always run
+    /// the full rule set."
+    public struct CVEAuditRecord: Sendable {
+        /// CVE identifier.
+        public let cveID: String
+        /// Whether the current vendor pin is confirmed to include the fix.
+        public let isFixed: Bool
+        /// The first llama.cpp build that includes the fix.
+        public let fixedAtBuild: String
+        /// The currently vendored llama.cpp build tag.
+        public let vendoredBuild: String
+        /// Human-readable audit note.
+        public let note: String
+    }
+
+    /// Pinned audit record for CVE-2026-2069 (buffer overflow in
+    /// `llama_grammar_advance_stack()`).
+    ///
+    /// - `isFixed: false` — `mattt/llama.swift` 2.8772.0 wraps build b8772,
+    ///   which pre-dates the fix that landed in b8774. GBNF callers **MUST**
+    ///   run this pre-validator until the vendor pin is bumped past b8773.
+    ///
+    /// ### Updating this record when bumping the `llama.swift` pin
+    ///
+    /// 1. Confirm the new xcframework wraps a build ≥ b8774.
+    /// 2. Set `isFixed: true`, update `vendoredBuild`.
+    /// 3. Re-audit the rules in `validate(_:path:)` and remove any that were
+    ///    solely motivated by the overflow rather than GBNF expressiveness.
+    public static let cveStatus = CVEAuditRecord(
+        cveID: "CVE-2026-2069",
+        isFixed: false,
+        fixedAtBuild: "b8774",
+        vendoredBuild: "b8772",
+        note: """
+            Buffer overflow in llama_grammar_advance_stack(). \
+            mattt/llama.swift 2.8772.0 wraps b8772 which pre-dates the fix. \
+            All GBNF grammar use must pass GBNFSchemaPreValidator until \
+            the xcframework is bumped to a build >= b8774.
+            """
+    )
+
+    // MARK: - Validation failure
+
+    /// Describes why a schema is unsafe to compile to GBNF.
+    public struct ValidationFailure: Sendable, Equatable, Error {
+        /// Short developer-facing description of the rejection reason.
+        public let reason: String
+        /// JSON-pointer-style path components to the offending key (e.g.
+        /// `["properties", "address", "anyOf"]`). Empty when the issue is at
+        /// the root of the schema.
+        public let path: [String]
+
+        public init(reason: String, path: [String] = []) {
+            self.reason = reason
+            self.path = path
+        }
+    }
+
+    public init() {}
+
+    // MARK: - Public entry point
+
+    /// Returns `nil` when `schema` is safe to compile to GBNF, or a
+    /// ``ValidationFailure`` naming the first unsafe construct when it is not.
+    ///
+    /// Always run this before calling `llama_sampler_init_grammar` with a
+    /// grammar derived from `schema`. See the type-level documentation and
+    /// ``cveStatus`` for the full rationale.
+    ///
+    /// - Parameters:
+    ///   - schema: The JSON Schema to check (typically `ToolDefinition.parameters`).
+    ///   - path:   Accumulated path prefix for nested calls — callers should
+    ///             use the default empty array.
+    public func validate(_ schema: JSONSchemaValue, path: [String] = []) -> ValidationFailure? {
+        guard case let .object(dict) = schema else {
+            // Non-object schemas (scalars, arrays-as-values) are safe; skip.
+            return nil
+        }
+
+        // Reject schema combiners — the GBNF IR has no alternation / negation nodes.
+        for combiner in ["anyOf", "oneOf", "allOf", "not"] {
+            if dict[combiner] != nil {
+                return ValidationFailure(
+                    reason: "'\(combiner)' is not supported by the GBNF compiler and may cause a crash.",
+                    path: path + [combiner]
+                )
+            }
+        }
+
+        // Reject Draft 2020-12 integer-form exclusive bounds — triggers a
+        // type-confusion path in the GBNF numeric rule builder.
+        for bound in ["exclusiveMinimum", "exclusiveMaximum"] {
+            if dict[bound] != nil {
+                return ValidationFailure(
+                    reason: "'\(bound)' triggers a type-confusion path in the GBNF numeric rule builder.",
+                    path: path + [bound]
+                )
+            }
+        }
+
+        // Reject nullable union: `"type": ["string", "null"]` — any array
+        // `type` value containing `"null"` produces unbounded alternation.
+        if let typeValue = dict["type"], case let .array(typeArr) = typeValue {
+            let hasNull = typeArr.contains {
+                if case .string(let s) = $0 { return s == "null" }
+                return false
+            }
+            if hasNull {
+                return ValidationFailure(
+                    reason: "Nullable union type (array containing 'null') produces unbounded alternation in GBNF.",
+                    path: path + ["type"]
+                )
+            }
+        }
+
+        // Recurse into `properties` sub-schemas.
+        if let propsValue = dict["properties"], case let .object(properties) = propsValue {
+            // Sort for deterministic failure reporting.
+            for (key, subSchema) in properties.sorted(by: { $0.key < $1.key }) {
+                if let failure = validate(subSchema, path: path + ["properties", key]) {
+                    return failure
+                }
+            }
+        }
+
+        // Recurse into `items` (array schema).
+        if let itemsValue = dict["items"] {
+            if let failure = validate(itemsValue, path: path + ["items"]) {
+                return failure
+            }
+        }
+
+        // Recurse into `additionalProperties` when it is a schema object.
+        if let apValue = dict["additionalProperties"], case .object = apValue {
+            if let failure = validate(apValue, path: path + ["additionalProperties"]) {
+                return failure
+            }
+        }
+
+        return nil
+    }
+}

--- a/Sources/BaseChatInference/Services/GenerationCoordinator.swift
+++ b/Sources/BaseChatInference/Services/GenerationCoordinator.swift
@@ -312,7 +312,11 @@ final class GenerationCoordinator {
 
         if backend.capabilities.requiresPromptTemplate {
             let template = provider?.selectedPromptTemplate ?? .chatML
-            assembledPrompt = template.format(messages: flattened, systemPrompt: systemPrompt)
+            if backend.capabilities.supportsToolCalling && !config.tools.isEmpty {
+                assembledPrompt = template.format(messages: flattened, systemPrompt: systemPrompt, tools: config.tools)
+            } else {
+                assembledPrompt = template.format(messages: flattened, systemPrompt: systemPrompt)
+            }
             effectiveSystemPrompt = nil
         } else {
             assembledPrompt = flattened.last(where: { $0.role == "user" })?.content ?? ""

--- a/Sources/BaseChatInference/Services/PromptTemplate.swift
+++ b/Sources/BaseChatInference/Services/PromptTemplate.swift
@@ -299,17 +299,25 @@ public enum PromptTemplate: String, CaseIterable, Sendable, Identifiable {
         var result = ""
 
         let hasSystemContent = systemPrompt != nil && !(systemPrompt!.isEmpty)
-        if hasSystemContent || !tools.isEmpty {
+        var systemParts: [String] = []
+        if hasSystemContent {
+            systemParts.append(sanitize(systemPrompt!))
+        }
+        for tool in tools {
+            if let block = toolDeclarationBlock(for: tool) {
+                systemParts.append("<|tool>\(block)")
+            } else {
+                // Silent skip would mask a tool author's mistake during prompt
+                // assembly. Surface it in the prompt log so the failure is
+                // discoverable without crashing generation.
+                Log.prompt.error("Failed to serialize tool declaration for Gemma 4 template: \(tool.name)")
+            }
+        }
+        // Only emit the system turn when at least one part survived
+        // serialisation — otherwise we'd ship an empty `<|turn>system\n<|end_of_turn>`
+        // marker that confuses the model and burns context.
+        if !systemParts.isEmpty {
             result += "<|turn>system\n"
-            var systemParts: [String] = []
-            if hasSystemContent {
-                systemParts.append(sanitize(systemPrompt!))
-            }
-            for tool in tools {
-                if let block = toolDeclarationBlock(for: tool) {
-                    systemParts.append("<|tool>\(block)")
-                }
-            }
             result += systemParts.joined(separator: "\n")
             result += "<|end_of_turn>\n"
         }

--- a/Sources/BaseChatInference/Services/PromptTemplate.swift
+++ b/Sources/BaseChatInference/Services/PromptTemplate.swift
@@ -31,7 +31,7 @@ public enum PromptTemplate: String, CaseIterable, Sendable, Identifiable {
         case .gemma:
             return ["<start_of_turn>", "<end_of_turn>"]
         case .gemma4:
-            return ["<|turn>", "<|end_of_turn>"]
+            return ["<|turn>", "<|end_of_turn>", "<|tool>", "<|tool_call>", "<|tool_response>"]
         case .phi:
             return ["<|system|>", "<|user|>", "<|assistant|>", "<|end|>"]
         }
@@ -65,6 +65,28 @@ public enum PromptTemplate: String, CaseIterable, Sendable, Identifiable {
         messages: [(role: String, content: String)],
         systemPrompt: String?
     ) -> String {
+        format(messages: messages, systemPrompt: systemPrompt, tools: [])
+    }
+
+    /// Formats an array of messages into a single prompt string, injecting
+    /// native tool-declaration blocks for templates that support them.
+    ///
+    /// Currently only `.gemma4` uses `tools` natively (via `<|tool>` blocks in
+    /// the system turn). All other templates ignore the `tools` parameter and
+    /// produce the same output as `format(messages:systemPrompt:)`. Tool
+    /// descriptions for those templates must be injected via
+    /// `ToolSystemPromptBuilder` into `systemPrompt` before calling this method.
+    ///
+    /// - Parameters:
+    ///   - messages: Ordered (role, content) pairs.
+    ///   - systemPrompt: An optional system-level instruction.
+    ///   - tools: Tool definitions to inject natively when the template supports it.
+    /// - Returns: A formatted prompt string ready for the model.
+    public func format(
+        messages: [(role: String, content: String)],
+        systemPrompt: String?,
+        tools: [ToolDefinition]
+    ) -> String {
         switch self {
         case .chatML:
             return formatChatML(messages: messages, systemPrompt: systemPrompt)
@@ -77,7 +99,7 @@ public enum PromptTemplate: String, CaseIterable, Sendable, Identifiable {
         case .gemma:
             return formatGemma(messages: messages, systemPrompt: systemPrompt)
         case .gemma4:
-            return formatGemma4(messages: messages, systemPrompt: systemPrompt)
+            return formatGemma4(messages: messages, systemPrompt: systemPrompt, tools: tools)
         case .phi:
             return formatPhi(messages: messages, systemPrompt: systemPrompt)
         }
@@ -252,7 +274,9 @@ public enum PromptTemplate: String, CaseIterable, Sendable, Identifiable {
 
     /// ```
     /// <|turn>system
-    /// {system}<|end_of_turn>       ← emitted only when systemPrompt is non-empty
+    /// {system}
+    /// <|tool>{"name":"…","description":"…","parameters":{…}}   ← one per tool
+    /// <|end_of_turn>
     /// <|turn>user
     /// {content}<|end_of_turn>
     /// <|turn>model
@@ -262,14 +286,32 @@ public enum PromptTemplate: String, CaseIterable, Sendable, Identifiable {
     ///
     /// Unlike Gemma 1/2/3 (which prepend the system prompt to the first user turn),
     /// Gemma 4 uses an explicit `<|turn>system` turn.
+    ///
+    /// When `tools` is non-empty, each `ToolDefinition` is serialised as a
+    /// `<|tool>{JSON}` block appended to the system turn, in the order they appear
+    /// in the array. The declaration JSON has the shape
+    /// `{"name":"…","description":"…","parameters":{…}}`.
     private func formatGemma4(
         messages: [(role: String, content: String)],
-        systemPrompt: String?
+        systemPrompt: String?,
+        tools: [ToolDefinition] = []
     ) -> String {
         var result = ""
 
-        if let systemPrompt, !systemPrompt.isEmpty {
-            result += "<|turn>system\n\(sanitize(systemPrompt))<|end_of_turn>\n"
+        let hasSystemContent = systemPrompt != nil && !(systemPrompt!.isEmpty)
+        if hasSystemContent || !tools.isEmpty {
+            result += "<|turn>system\n"
+            var systemParts: [String] = []
+            if hasSystemContent {
+                systemParts.append(sanitize(systemPrompt!))
+            }
+            for tool in tools {
+                if let block = toolDeclarationBlock(for: tool) {
+                    systemParts.append("<|tool>\(block)")
+                }
+            }
+            result += systemParts.joined(separator: "\n")
+            result += "<|end_of_turn>\n"
         }
 
         for message in messages {
@@ -286,6 +328,24 @@ public enum PromptTemplate: String, CaseIterable, Sendable, Identifiable {
         result += "<|turn>model\n"
         Log.prompt.debug("Formatted \(messages.count) messages with Gemma 4 template")
         return result
+    }
+
+    /// Serialises a `ToolDefinition` to the JSON string placed after `<|tool>`.
+    /// Returns `nil` when serialisation fails (the tool is silently skipped).
+    private func toolDeclarationBlock(for tool: ToolDefinition) -> String? {
+        guard let paramsData   = try? JSONEncoder().encode(tool.parameters),
+              let paramsObject = try? JSONSerialization.jsonObject(with: paramsData)
+        else { return nil }
+
+        let dict: [String: Any] = [
+            "name":        tool.name,
+            "description": tool.description,
+            "parameters":  paramsObject
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: dict, options: .sortedKeys),
+              let str  = String(data: data, encoding: .utf8)
+        else { return nil }
+        return str
     }
 
     // MARK: - Phi

--- a/Tests/BaseChatBackendsTests/LlamaToolCallParserTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaToolCallParserTests.swift
@@ -1,0 +1,216 @@
+#if Llama
+import XCTest
+@testable import BaseChatInference
+@testable import BaseChatBackends
+
+/// Unit tests for ``LlamaToolCallParser``.
+///
+/// These tests exercise the parser logic only — no GGUF model is loaded and
+/// no hardware-specific symbols are invoked. They run under
+/// `swift test --filter BaseChatBackendsTests --disable-default-traits`.
+final class LlamaToolCallParserTests: XCTestCase {
+
+    // MARK: - Gemma 4 native format
+
+    func test_gemma4NativeCall_singleCall_emitsToolCallEvent() {
+        var parser = LlamaToolCallParser()
+        let input = "<|tool_call>\ncall:get_weather{city:<|\"|>London<|\"|>,units:<|\"|>celsius<|\"|>}\n<|end_of_turn>"
+        let events = parser.process(input)
+
+        let toolCalls = events.compactMap { event -> ToolCall? in
+            if case .toolCall(let tc) = event { return tc }
+            return nil
+        }
+        XCTAssertEqual(toolCalls.count, 1)
+        let tc = try XCTUnwrap(toolCalls.first)
+        XCTAssertEqual(tc.toolName, "get_weather")
+
+        let args = try XCTUnwrap(tc.arguments.data(using: .utf8))
+        let decoded = try XCTUnwrap(try? JSONSerialization.jsonObject(with: args) as? [String: Any])
+        XCTAssertEqual(decoded["city"] as? String, "London")
+        XCTAssertEqual(decoded["units"] as? String, "celsius")
+    }
+
+    func test_gemma4NativeCall_noArgs_emitsToolCallWithEmptyArgs() {
+        var parser = LlamaToolCallParser()
+        let input = "<|tool_call>\ncall:list_files{}\n<|end_of_turn>"
+        let events = parser.process(input)
+
+        let toolCalls = events.compactMap { event -> ToolCall? in
+            if case .toolCall(let tc) = event { return tc }
+            return nil
+        }
+        XCTAssertEqual(toolCalls.count, 1)
+        XCTAssertEqual(toolCalls.first?.toolName, "list_files")
+    }
+
+    func test_gemma4NativeCall_prefixText_emitsTokenBeforeToolCall() {
+        var parser = LlamaToolCallParser()
+        let input = "Sure, let me check that.<|tool_call>\ncall:get_time{}\n<|end_of_turn>"
+        let events = parser.process(input)
+
+        let tokens = events.compactMap { event -> String? in
+            if case .token(let t) = event { return t }
+            return nil
+        }
+        let toolCalls = events.compactMap { event -> ToolCall? in
+            if case .toolCall(let tc) = event { return tc }
+            return nil
+        }
+        XCTAssertFalse(tokens.isEmpty, "Expected token events before tool call")
+        XCTAssertEqual(toolCalls.count, 1)
+        XCTAssertEqual(toolCalls.first?.toolName, "get_time")
+    }
+
+    // MARK: - JSON fallback format
+
+    func test_jsonFallback_singleCall_emitsToolCallEvent() {
+        var parser = LlamaToolCallParser()
+        let input = """
+        <tool_call>
+        {"name":"search","arguments":{"query":"swift concurrency"}}
+        </tool_call>
+        """
+        let events = parser.process(input)
+        let toolCalls = events.compactMap { event -> ToolCall? in
+            if case .toolCall(let tc) = event { return tc }
+            return nil
+        }
+        XCTAssertEqual(toolCalls.count, 1)
+        XCTAssertEqual(toolCalls.first?.toolName, "search")
+    }
+
+    func test_jsonFallback_multipleCalls_emitsMultipleToolCallEvents() {
+        var parser = LlamaToolCallParser()
+        let input = """
+        <tool_call>{"name":"tool_a","arguments":{}}</tool_call>\
+        <tool_call>{"name":"tool_b","arguments":{}}</tool_call>
+        """
+        let events = parser.process(input)
+        let toolCalls = events.compactMap { event -> ToolCall? in
+            if case .toolCall(let tc) = event { return tc }
+            return nil
+        }
+        XCTAssertEqual(toolCalls.count, 2)
+        XCTAssertEqual(toolCalls[0].toolName, "tool_a")
+        XCTAssertEqual(toolCalls[1].toolName, "tool_b")
+    }
+
+    // MARK: - Chunk safety
+
+    func test_tagSplitAcrossChunks_parsesCorrectly() {
+        var parser = LlamaToolCallParser()
+
+        // Split "<|tool_call>" across two chunks.
+        let events1 = parser.process("<|tool_")
+        let events2 = parser.process("call>\ncall:ping{}\n<|end_of_turn>")
+        let all = events1 + events2
+
+        let toolCalls = all.compactMap { event -> ToolCall? in
+            if case .toolCall(let tc) = event { return tc }
+            return nil
+        }
+        XCTAssertEqual(toolCalls.count, 1)
+        XCTAssertEqual(toolCalls.first?.toolName, "ping")
+    }
+
+    func test_closeTagSplitAcrossChunks_parsesCorrectly() {
+        var parser = LlamaToolCallParser()
+        var all: [GenerationEvent] = []
+        all += parser.process("<tool_call>{\"name\":\"foo\",\"arguments\":{}}</")
+        all += parser.process("tool_call>")
+
+        let toolCalls = all.compactMap { event -> ToolCall? in
+            if case .toolCall(let tc) = event { return tc }
+            return nil
+        }
+        XCTAssertEqual(toolCalls.count, 1)
+        XCTAssertEqual(toolCalls.first?.toolName, "foo")
+    }
+
+    func test_singleByteChunks_parsesCorrectly() {
+        var parser = LlamaToolCallParser()
+        let full = "<tool_call>{\"name\":\"byte_test\",\"arguments\":{}}</tool_call>"
+        var all: [GenerationEvent] = []
+        for char in full.unicodeScalars {
+            all += parser.process(String(char))
+        }
+        all += parser.finalize()
+
+        let toolCalls = all.compactMap { event -> ToolCall? in
+            if case .toolCall(let tc) = event { return tc }
+            return nil
+        }
+        XCTAssertEqual(toolCalls.count, 1)
+        XCTAssertEqual(toolCalls.first?.toolName, "byte_test")
+    }
+
+    // MARK: - Invalid / malformed input
+
+    func test_invalidJSON_inJSONFallback_isDiscarded() {
+        var parser = LlamaToolCallParser()
+        let events = parser.process("<tool_call>this is not json</tool_call>")
+        let toolCalls = events.compactMap { event -> ToolCall? in
+            if case .toolCall(let tc) = event { return tc }
+            return nil
+        }
+        XCTAssertTrue(toolCalls.isEmpty, "Malformed JSON should be discarded silently")
+    }
+
+    func test_missingNameField_inJSONFallback_isDiscarded() {
+        var parser = LlamaToolCallParser()
+        let events = parser.process("<tool_call>{\"arguments\":{}}</tool_call>")
+        let toolCalls = events.compactMap { event -> ToolCall? in
+            if case .toolCall(let tc) = event { return tc }
+            return nil
+        }
+        XCTAssertTrue(toolCalls.isEmpty)
+    }
+
+    // MARK: - finalize
+
+    func test_finalize_emitsRemainingPlainText() {
+        var parser = LlamaToolCallParser()
+        _ = parser.process("Hello ")
+        let events = parser.finalize()
+        let tokens = events.compactMap { event -> String? in
+            if case .token(let t) = event { return t }
+            return nil
+        }
+        XCTAssertFalse(tokens.joined().isEmpty, "finalize should emit any buffered plain text")
+    }
+
+    func test_finalize_discardsPartialToolCallBlock() {
+        var parser = LlamaToolCallParser()
+        _ = parser.process("<tool_call>{\"name\":\"partial\"")
+        // No close tag — incomplete block.
+        let events = parser.finalize()
+        let toolCalls = events.compactMap { event -> ToolCall? in
+            if case .toolCall(let tc) = event { return tc }
+            return nil
+        }
+        XCTAssertTrue(toolCalls.isEmpty, "Incomplete tool-call block must be discarded on finalize")
+    }
+
+    func test_finalize_calledOnFreshParser_returnsEmpty() {
+        var parser = LlamaToolCallParser()
+        XCTAssertTrue(parser.finalize().isEmpty)
+    }
+
+    // MARK: - Tool call ID uniqueness
+
+    func test_multipleToolCalls_haveDistinctIDs() {
+        var parser = LlamaToolCallParser()
+        let events = parser.process("""
+        <tool_call>{"name":"a","arguments":{}}</tool_call>\
+        <tool_call>{"name":"b","arguments":{}}</tool_call>
+        """)
+        let ids = events.compactMap { event -> String? in
+            if case .toolCall(let tc) = event { return tc.id }
+            return nil
+        }
+        XCTAssertEqual(ids.count, 2)
+        XCTAssertNotEqual(ids[0], ids[1], "Each tool call must receive a distinct ID")
+    }
+}
+#endif

--- a/Tests/BaseChatBackendsTests/LlamaToolCallParserTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaToolCallParserTests.swift
@@ -12,7 +12,7 @@ final class LlamaToolCallParserTests: XCTestCase {
 
     // MARK: - Gemma 4 native format
 
-    func test_gemma4NativeCall_singleCall_emitsToolCallEvent() {
+    func test_gemma4NativeCall_singleCall_emitsToolCallEvent() throws {
         var parser = LlamaToolCallParser()
         let input = "<|tool_call>\ncall:get_weather{city:<|\"|>London<|\"|>,units:<|\"|>celsius<|\"|>}\n<|end_of_turn>"
         let events = parser.process(input)
@@ -29,6 +29,32 @@ final class LlamaToolCallParserTests: XCTestCase {
         let decoded = try XCTUnwrap(try? JSONSerialization.jsonObject(with: args) as? [String: Any])
         XCTAssertEqual(decoded["city"] as? String, "London")
         XCTAssertEqual(decoded["units"] as? String, "celsius")
+    }
+
+    func test_gemma4NativeCall_mixedScalarArgs_areTypedNotStrings() throws {
+        // Gemma 4's brace body has unquoted JSON-like keys, with values that
+        // are either `<|"|>...<|"|>`-quoted strings or bare numeric / boolean
+        // literals. Earlier versions handed the body to JSONSerialization
+        // directly, which always failed (unquoted keys aren't JSON), so every
+        // native call fell back to `arguments == "{}"`. This test exists so
+        // that regression cannot reappear silently.
+        var parser = LlamaToolCallParser()
+        let input = "<|tool_call>\ncall:rate{score:5,active:true,note:<|\"|>ok<|\"|>}\n<|end_of_turn>"
+        let events = parser.process(input)
+        let toolCalls = events.compactMap { event -> ToolCall? in
+            if case .toolCall(let tc) = event { return tc }
+            return nil
+        }
+        XCTAssertEqual(toolCalls.count, 1)
+        let tc = try XCTUnwrap(toolCalls.first)
+        XCTAssertEqual(tc.toolName, "rate")
+        XCTAssertNotEqual(tc.arguments, "{}", "Native call body must not silently fall back to empty args")
+
+        let args = try XCTUnwrap(tc.arguments.data(using: .utf8))
+        let decoded = try XCTUnwrap(try? JSONSerialization.jsonObject(with: args) as? [String: Any])
+        XCTAssertEqual(decoded["score"] as? Int, 5)
+        XCTAssertEqual(decoded["active"] as? Bool, true)
+        XCTAssertEqual(decoded["note"] as? String, "ok")
     }
 
     func test_gemma4NativeCall_noArgs_emitsToolCallWithEmptyArgs() {
@@ -169,15 +195,31 @@ final class LlamaToolCallParserTests: XCTestCase {
 
     // MARK: - finalize
 
-    func test_finalize_emitsRemainingPlainText() {
+    func test_finalize_emitsBufferedPartialTagPrefix() {
+        // When the stream ends with bytes that *could* be the start of an
+        // open tag (here: "<|tool_") the parser holds them back during
+        // `process()` so a later chunk can complete or cancel the tag.
+        // `finalize()` must flush that held-back text once we know no more
+        // chunks are coming.
         var parser = LlamaToolCallParser()
-        _ = parser.process("Hello ")
-        let events = parser.finalize()
-        let tokens = events.compactMap { event -> String? in
+        let processEvents = parser.process("Hello <|tool_")
+        let processTokens = processEvents.compactMap { event -> String? in
             if case .token(let t) = event { return t }
             return nil
         }
-        XCTAssertFalse(tokens.joined().isEmpty, "finalize should emit any buffered plain text")
+        // The visible "Hello " portion may be emitted during process;
+        // the partial tag suffix "<|tool_" must NOT be — verify by reuniting
+        // the joined token stream and checking it never leaks the partial tag.
+        XCTAssertFalse(processTokens.joined().contains("<|tool_"),
+                       "Partial open-tag bytes must not leak as visible tokens")
+
+        let finalEvents = parser.finalize()
+        let finalTokens = finalEvents.compactMap { event -> String? in
+            if case .token(let t) = event { return t }
+            return nil
+        }
+        XCTAssertFalse(finalTokens.joined().isEmpty,
+                       "finalize must flush bytes held back as a candidate open-tag prefix")
     }
 
     func test_finalize_discardsPartialToolCallBlock() {

--- a/Tests/BaseChatBackendsTests/LlamaToolCapabilityTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaToolCapabilityTests.swift
@@ -1,0 +1,129 @@
+#if Llama
+import XCTest
+@testable import BaseChatInference
+@testable import BaseChatBackends
+
+/// Tests for `LlamaBackend.capabilities.supportsToolCalling` and
+/// the Gemma 4 tool-aware prompt template format.
+///
+/// No GGUF model is loaded — these tests exercise capability flags
+/// and prompt-string construction only.
+final class LlamaToolCapabilityTests: XCTestCase {
+
+    // MARK: - Capability flag
+
+    func test_capabilities_supportsToolCalling_isTrue() {
+        let backend = LlamaBackend()
+        XCTAssertTrue(backend.capabilities.supportsToolCalling,
+                      "LlamaBackend must advertise tool-calling support for Gemma 4 models")
+    }
+
+    func test_capabilities_supportsGrammarConstrainedSampling_isTrue() {
+        let backend = LlamaBackend()
+        XCTAssertTrue(backend.capabilities.supportsGrammarConstrainedSampling)
+    }
+
+    // MARK: - Gemma 4 native tool injection
+
+    func test_gemma4_withTools_injectsToolBlocks() {
+        let tool = ToolDefinition(
+            name: "get_weather",
+            description: "Returns current weather",
+            parameters: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "city": .object(["type": .string("string")])
+                ]),
+                "required": .array([.string("city")])
+            ])
+        )
+
+        let prompt = PromptTemplate.gemma4.format(
+            messages: [(role: "user", content: "What's the weather in Paris?")],
+            systemPrompt: nil,
+            tools: [tool]
+        )
+
+        XCTAssertTrue(prompt.contains("<|turn>system\n"),
+                      "System turn should be present when tools are injected")
+        XCTAssertTrue(prompt.contains("<|tool>"),
+                      "Tool declaration block should be injected")
+        XCTAssertTrue(prompt.contains("get_weather"),
+                      "Tool name must appear in the declaration")
+        XCTAssertTrue(prompt.contains("Returns current weather"),
+                      "Tool description must appear in the declaration")
+        XCTAssertTrue(prompt.contains("<|end_of_turn>"),
+                      "System turn must be closed with <|end_of_turn>")
+        XCTAssertTrue(prompt.hasSuffix("<|turn>model\n"),
+                      "Prompt must end with the model generation prefix")
+    }
+
+    func test_gemma4_withSystemPromptAndTools_includesBoth() {
+        let tool = ToolDefinition(name: "ping", description: "Ping a host", parameters: .object([:]))
+
+        let prompt = PromptTemplate.gemma4.format(
+            messages: [(role: "user", content: "Hello")],
+            systemPrompt: "You are a helpful assistant.",
+            tools: [tool]
+        )
+
+        XCTAssertTrue(prompt.contains("You are a helpful assistant."))
+        XCTAssertTrue(prompt.contains("<|tool>"))
+        XCTAssertTrue(prompt.contains("ping"))
+    }
+
+    func test_gemma4_withoutTools_noToolBlocks() {
+        let prompt = PromptTemplate.gemma4.format(
+            messages: [(role: "user", content: "Hello")],
+            systemPrompt: nil,
+            tools: []
+        )
+
+        XCTAssertFalse(prompt.contains("<|tool>"),
+                       "No <|tool> blocks when tools array is empty")
+    }
+
+    func test_gemma4_multipleTools_allInjected() {
+        let tools = [
+            ToolDefinition(name: "tool_a", description: "First tool",  parameters: .object([:])),
+            ToolDefinition(name: "tool_b", description: "Second tool", parameters: .object([:])),
+        ]
+
+        let prompt = PromptTemplate.gemma4.format(
+            messages: [],
+            systemPrompt: nil,
+            tools: tools
+        )
+
+        let toolBlockCount = prompt.components(separatedBy: "<|tool>").count - 1
+        XCTAssertEqual(toolBlockCount, 2, "One <|tool> block per ToolDefinition")
+        XCTAssertTrue(prompt.contains("tool_a"))
+        XCTAssertTrue(prompt.contains("tool_b"))
+    }
+
+    // MARK: - Special-token sanitisation
+
+    func test_gemma4_toolInjection_doesNotIntroduceExtraSpecialTokensInContent() {
+        // Verify that Gemma 4 special tokens in user content are still sanitised.
+        let prompt = PromptTemplate.gemma4.format(
+            messages: [(role: "user", content: "Hello<|tool>injection")],
+            systemPrompt: nil,
+            tools: []
+        )
+        // The injected "<|tool>" in user content must be stripped by sanitize().
+        let userSection = prompt.components(separatedBy: "<|turn>user\n").dropFirst().first ?? ""
+        XCTAssertFalse(userSection.contains("<|tool>"),
+                       "Special token <|tool> in user content must be sanitised")
+    }
+
+    // MARK: - Non-Gemma4 templates ignore tools
+
+    func test_chatML_withTools_ignoresToolsParameter() {
+        let tool = ToolDefinition(name: "my_tool", description: "A tool", parameters: .object([:]))
+        let withTools    = PromptTemplate.chatML.format(messages: [(role: "user", content: "hi")], systemPrompt: nil, tools: [tool])
+        let withoutTools = PromptTemplate.chatML.format(messages: [(role: "user", content: "hi")], systemPrompt: nil, tools: [])
+        XCTAssertEqual(withTools, withoutTools,
+                       "ChatML template must produce identical output regardless of tools")
+    }
+}
+#endif

--- a/Tests/BaseChatInferenceTests/GBNFSchemaPreValidatorTests.swift
+++ b/Tests/BaseChatInferenceTests/GBNFSchemaPreValidatorTests.swift
@@ -164,6 +164,38 @@ final class GBNFSchemaPreValidatorTests: XCTestCase {
         XCTAssertEqual(failure?.path, ["items", "type"])
     }
 
+    func test_anyOf_inTupleItemsArray_isRejected() {
+        // `items` may be an array of schemas (tuple validation). Without the
+        // array branch, an unsafe combiner inside one of the tuple entries
+        // would bypass the pre-validator and reach the GBNF compiler.
+        let schema = JSONSchemaValue.object([
+            "type": .string("array"),
+            "items": .array([
+                .object(["type": .string("string")]),
+                .object([
+                    "anyOf": .array([
+                        .object(["type": .string("integer")]),
+                        .object(["type": .string("string")])
+                    ])
+                ])
+            ])
+        ])
+        let failure = validator.validate(schema)
+        XCTAssertNotNil(failure)
+        XCTAssertEqual(failure?.path, ["items", "1", "anyOf"])
+    }
+
+    func test_safeTupleItemsArray_passes() {
+        let schema = JSONSchemaValue.object([
+            "type": .string("array"),
+            "items": .array([
+                .object(["type": .string("string")]),
+                .object(["type": .string("integer")])
+            ])
+        ])
+        XCTAssertNil(validator.validate(schema))
+    }
+
     // MARK: - CVE audit record sanity
 
     func test_cveAuditRecord_isUnfixed() {

--- a/Tests/BaseChatInferenceTests/GBNFSchemaPreValidatorTests.swift
+++ b/Tests/BaseChatInferenceTests/GBNFSchemaPreValidatorTests.swift
@@ -1,0 +1,177 @@
+import XCTest
+@testable import BaseChatInference
+
+/// Unit tests for ``GBNFSchemaPreValidator``.
+///
+/// These tests run without hardware — no llama.cpp symbols are touched.
+final class GBNFSchemaPreValidatorTests: XCTestCase {
+
+    private let validator = GBNFSchemaPreValidator()
+
+    // MARK: - Safe schemas pass
+
+    func test_simpleObjectSchema_passes() {
+        let schema = JSONSchemaValue.object([
+            "type": .string("object"),
+            "properties": .object([
+                "city": .object(["type": .string("string")]),
+                "units": .object(["type": .string("string")])
+            ]),
+            "required": .array([.string("city")])
+        ])
+        XCTAssertNil(validator.validate(schema))
+    }
+
+    func test_schemaWithStringEnum_passes() {
+        let schema = JSONSchemaValue.object([
+            "type": .string("object"),
+            "properties": .object([
+                "direction": .object([
+                    "type": .string("string"),
+                    "enum": .array([.string("north"), .string("south")])
+                ])
+            ])
+        ])
+        XCTAssertNil(validator.validate(schema))
+    }
+
+    func test_schemaWithArrayItems_passes() {
+        let schema = JSONSchemaValue.object([
+            "type": .string("array"),
+            "items": .object(["type": .string("string")])
+        ])
+        XCTAssertNil(validator.validate(schema))
+    }
+
+    func test_emptyObjectSchema_passes() {
+        XCTAssertNil(validator.validate(.object([:])))
+    }
+
+    func test_nonObjectSchema_passes() {
+        // Scalar values at the top level are not GBNF-unsafe.
+        XCTAssertNil(validator.validate(.string("string")))
+        XCTAssertNil(validator.validate(.number(42)))
+        XCTAssertNil(validator.validate(.bool(true)))
+        XCTAssertNil(validator.validate(.null))
+    }
+
+    // MARK: - Combiners rejected
+
+    func test_anyOf_isRejected() {
+        let schema = JSONSchemaValue.object([
+            "anyOf": .array([
+                .object(["type": .string("string")]),
+                .object(["type": .string("integer")])
+            ])
+        ])
+        let failure = validator.validate(schema)
+        XCTAssertNotNil(failure)
+        XCTAssertEqual(failure?.path, ["anyOf"])
+        XCTAssertTrue(failure?.reason.contains("anyOf") == true)
+    }
+
+    func test_oneOf_isRejected() {
+        let schema = JSONSchemaValue.object([
+            "oneOf": .array([.object(["type": .string("string")])])
+        ])
+        XCTAssertNotNil(validator.validate(schema))
+    }
+
+    func test_allOf_isRejected() {
+        let schema = JSONSchemaValue.object([
+            "allOf": .array([.object(["type": .string("string")])])
+        ])
+        XCTAssertNotNil(validator.validate(schema))
+    }
+
+    func test_not_isRejected() {
+        let schema = JSONSchemaValue.object([
+            "not": .object(["type": .string("string")])
+        ])
+        XCTAssertNotNil(validator.validate(schema))
+    }
+
+    // MARK: - Nullable union rejected
+
+    func test_nullableUnionType_isRejected() {
+        let schema = JSONSchemaValue.object([
+            "type": .array([.string("string"), .string("null")])
+        ])
+        let failure = validator.validate(schema)
+        XCTAssertNotNil(failure)
+        XCTAssertEqual(failure?.path, ["type"])
+        XCTAssertTrue(failure?.reason.lowercased().contains("null") == true)
+    }
+
+    func test_nonNullableArrayType_passes() {
+        // An array `type` that does NOT contain "null" is safe.
+        let schema = JSONSchemaValue.object([
+            "type": .array([.string("string"), .string("integer")])
+        ])
+        XCTAssertNil(validator.validate(schema))
+    }
+
+    // MARK: - exclusiveMinimum / exclusiveMaximum rejected
+
+    func test_exclusiveMinimum_isRejected() {
+        let schema = JSONSchemaValue.object([
+            "type": .string("integer"),
+            "exclusiveMinimum": .number(0)
+        ])
+        let failure = validator.validate(schema)
+        XCTAssertNotNil(failure)
+        XCTAssertEqual(failure?.path, ["exclusiveMinimum"])
+    }
+
+    func test_exclusiveMaximum_isRejected() {
+        let schema = JSONSchemaValue.object([
+            "type": .string("integer"),
+            "exclusiveMaximum": .number(100)
+        ])
+        let failure = validator.validate(schema)
+        XCTAssertNotNil(failure)
+        XCTAssertEqual(failure?.path, ["exclusiveMaximum"])
+    }
+
+    // MARK: - Nested rejection (recursive)
+
+    func test_nestedAnyOf_inProperties_isRejected() {
+        let schema = JSONSchemaValue.object([
+            "type": .string("object"),
+            "properties": .object([
+                "address": .object([
+                    "anyOf": .array([
+                        .object(["type": .string("string")]),
+                        .object(["type": .string("null")])
+                    ])
+                ])
+            ])
+        ])
+        let failure = validator.validate(schema)
+        XCTAssertNotNil(failure)
+        XCTAssertEqual(failure?.path, ["properties", "address", "anyOf"])
+    }
+
+    func test_nullableUnion_inItemsSchema_isRejected() {
+        let schema = JSONSchemaValue.object([
+            "type": .string("array"),
+            "items": .object([
+                "type": .array([.string("string"), .string("null")])
+            ])
+        ])
+        let failure = validator.validate(schema)
+        XCTAssertNotNil(failure)
+        XCTAssertEqual(failure?.path, ["items", "type"])
+    }
+
+    // MARK: - CVE audit record sanity
+
+    func test_cveAuditRecord_isUnfixed() {
+        let record = GBNFSchemaPreValidator.cveStatus
+        XCTAssertEqual(record.cveID, "CVE-2026-2069")
+        XCTAssertFalse(record.isFixed,
+                       "Flip isFixed to true once the xcframework is bumped past b8773")
+        XCTAssertEqual(record.vendoredBuild, "b8772")
+        XCTAssertEqual(record.fixedAtBuild,  "b8774")
+    }
+}

--- a/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
+++ b/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
@@ -306,3 +306,19 @@ BaseChatMCP/MCPOAuth.swift:(try? container.decodeIfPresent(Bool.self, forKey: .a
 # HTTP layer); falling back to an empty dictionary is correct because all
 # the downstream field reads return nil for missing keys.
 BaseChatMCP/MCPOAuth.swift:let rawJSON = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] ?? [:]
+
+# PromptTemplate.toolDeclarationBlock — JSON serialisation of ToolDefinition
+# for Gemma 4 <|tool> blocks. These are best-effort conversions: if a tool's
+# parameter schema or the resulting dict cannot be serialised, the tool block
+# is silently skipped (caller handles nil return). No observable side effect.
+BaseChatInference/Services/PromptTemplate.swift:guard let paramsData   = try? JSONEncoder().encode(tool.parameters),
+BaseChatInference/Services/PromptTemplate.swift:let paramsObject = try? JSONSerialization.jsonObject(with: paramsData)
+BaseChatInference/Services/PromptTemplate.swift:guard let data = try? JSONSerialization.data(withJSONObject: dict, options: .sortedKeys),
+
+# LlamaToolCallParser — JSON parsing of streamed Gemma 4 / JSON-fallback
+# tool-call bodies. These are optional conversions: a parse failure means the
+# tool-call block is discarded or falls back to empty args, which is the
+# correct behaviour for a malformed model output.
+BaseChatBackends/LlamaToolCallParser.swift:let obj  = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+BaseChatBackends/LlamaToolCallParser.swift:let serialized = try? JSONSerialization.data(withJSONObject: argsDict),
+BaseChatBackends/LlamaToolCallParser.swift:let serialized = try? JSONSerialization.data(withJSONObject: obj),

--- a/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
+++ b/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
@@ -321,4 +321,16 @@ BaseChatInference/Services/PromptTemplate.swift:guard let data = try? JSONSerial
 # correct behaviour for a malformed model output.
 BaseChatBackends/LlamaToolCallParser.swift:let obj  = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
 BaseChatBackends/LlamaToolCallParser.swift:let serialized = try? JSONSerialization.data(withJSONObject: argsDict),
-BaseChatBackends/LlamaToolCallParser.swift:let serialized = try? JSONSerialization.data(withJSONObject: obj),
+
+# Gemma 4 native-format string-value escape decoder: wraps the scanned raw
+# value in `"…"` and reuses JSONSerialization (with `.fragmentsAllowed`) to
+# unescape standard JSON escapes like `\n`, `\"`, `\\`. On failure we keep
+# the raw bytes — a malformed escape is preferable to dropping the call.
+BaseChatBackends/LlamaToolCallParser.swift:let decoded = try? JSONSerialization.jsonObject(
+
+# Gemma 4 native-format argument re-serialisation: round-trips the parsed
+# `[String: Any]` back into a canonical JSON string for ToolCall.arguments.
+# Failure here means a value type slipped through the tokenizer that
+# JSONSerialization rejects — caller falls back to "{}", same shape as
+# the JSON-fallback path's empty-arg fallback.
+BaseChatBackends/LlamaToolCallParser.swift:guard let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys]),

--- a/docs/LLAMA_CONTRACT.md
+++ b/docs/LLAMA_CONTRACT.md
@@ -467,6 +467,45 @@ thread.
 
 ---
 
+## Security
+
+### CVE-2026-2069 — Buffer overflow in `llama_grammar_advance_stack()`
+
+| Attribute | Detail |
+|-----------|--------|
+| CVE | CVE-2026-2069 |
+| Affected symbol | `llama_sampler_init_grammar` → internal `llama_grammar_advance_stack()` |
+| Vulnerability | A buffer overflow in the grammar stack-advance logic allows a crafted GBNF grammar string (or a JSON Schema with certain constructs) to overflow an internal stack buffer, enabling potential arbitrary code execution. |
+| Fixed in | llama.cpp build **b8774** |
+| Vendored build | **b8772** (via `mattt/llama.swift` 2.8772.0) — **not fixed** |
+| Status | ⚠️ **Unmitigated in the vendored binary.** The fix has not been picked up yet. |
+
+#### Mitigation until the pin is bumped
+
+`GBNFSchemaPreValidator` (introduced in this codebase alongside issue #609) runs
+before every `llama_sampler_init_grammar` call that is driven by a tool-call
+`ToolDefinition.parameters` schema. It rejects the schema constructs confirmed in
+the CVE proof-of-concept to trigger the overflow:
+
+- `anyOf`, `oneOf`, `allOf`, `not` — schema combiners
+- Nullable union types: `"type": ["string", "null"]`
+- `exclusiveMinimum` / `exclusiveMaximum` (Draft 2020-12 integer form)
+
+**Callers that pass a GBNF string directly via `GenerationConfig.grammar` (not via tool definitions) are not covered by this pre-validator.** Those strings are already validated syntactically by `llama_sampler_init_grammar`'s own GBNF parser, but crafted inputs from untrusted sources could still trigger the overflow. Treat `GenerationConfig.grammar` as a trusted-input field until the pin is bumped.
+
+#### Upgrade procedure for the CVE fix
+
+1. Bump `mattt/llama.swift` to a version wrapping build ≥ b8774.
+2. Confirm the xcframework version in `docs/vendor/llama.h` and update this section.
+3. In `GBNFSchemaPreValidator.swift`, flip `CVEAuditRecord.isFixed` to `true` and
+   update `vendoredBuild` to match.
+4. Re-audit the rejection rules in `GBNFSchemaPreValidator.validate(_:path:)` —
+   rules that were solely motivated by the overflow (rather than GBNF expressiveness
+   limits) may be relaxed or removed.
+5. Run `swift test --filter BaseChatBackendsTests --traits Llama` on Apple Silicon.
+
+---
+
 ## Binary vs. Vendored Source
 
 ### Decision


### PR DESCRIPTION
## Summary

Implements Gemma 4 GGUF tool calling via llama.cpp (issue #414, umbrella #753 group E) and adds the GBNF schema pre-validator + CVE-2026-2069 audit required by issue #609.

## Changes

### LlamaBackend tool calling

- `LlamaBackend.capabilities.supportsToolCalling`: `false` → `true`
- **New:** `LlamaToolCallParser` — chunk-safe stream parser for Gemma 4 `<|tool_call>…<|end_of_turn>` tokens. Falls back to the JSON `<tool_call>…</tool_call>` format (Qwen-style fine-tunes). Follows the same prefix-hold pattern as `MLXToolCallParser` and `ThinkingParser`.
- Wire `LlamaToolCallParser` into `LlamaGenerationDriver.run()` in the token-event pipeline, after `ThinkingParser`. Active only when `config.tools` is non-empty — zero overhead otherwise.

### Gemma 4 prompt template

- Add `<|tool>`, `<|tool_call>`, `<|tool_response>` to Gemma 4 `specialTokens` (sanitised from user input).
- Add `format(messages:systemPrompt:tools:)` overload. For `.gemma4`, injects `<|tool>{JSON}` declaration blocks into the system turn — one per `ToolDefinition`. All other templates ignore `tools` (identical output to existing overload).
- Update `GenerationCoordinator` to pass `config.tools` when backend `supportsToolCalling` and tools are set.

### GBNF schema pre-validator (#609 / CVE-2026-2069)

- **New:** `GBNFSchemaPreValidator` (in `BaseChatInference`, no ML deps). Validates a `JSONSchemaValue` before `llama_sampler_init_grammar`. Rejects:
  - `anyOf` / `oneOf` / `allOf` / `not` (GBNF IR cannot express combiners)
  - Nullable union `type: ["string", "null"]` (stack overflow in GBNF compiler)
  - `exclusiveMinimum` / `exclusiveMaximum` (type-confusion in GBNF numeric rules)
  - Recursively checks `properties`, `items`, `additionalProperties`
- Carries a pinned `CVEAuditRecord` for CVE-2026-2069 (buffer overflow in `llama_grammar_advance_stack()`). Vendored build b8772 pre-dates the fix (b8774). Includes upgrade procedure.
- `docs/LLAMA_CONTRACT.md`: add CVE-2026-2069 security section.

## Tests

| Suite | New tests |
|---|---|
| `GBNFSchemaPreValidatorTests` | Known-good schemas pass; all 7 rejection rules fail with correct `path` arrays; CVE audit record sanity |
| `LlamaToolCallParserTests` | Gemma 4 native format, JSON fallback, chunk safety (tag split / close-tag split / byte-by-byte), malformed input discarded, `finalize()` semantics, distinct IDs |
| `LlamaToolCapabilityTests` | `supportsToolCalling: true`, tool blocks in Gemma 4 system turn, system+tools combined, multi-tool ordering, special-token sanitisation in user content, non-Gemma4 templates unaffected |

All CI suites pass locally (`--disable-default-traits`):
`BaseChatCoreTests`, `BaseChatInferenceTests`, `BaseChatInferenceSwiftTestingTests`, `BaseChatUITests`, `BaseChatUIModelManagementTests`, `BaseChatMCPTests`, `BaseChatBackendsTests`, `BaseChatTestSupportTests`, `BaseChatAppIntentsTests`.

## Release Note

Gemma 4 GGUF models loaded via llama.cpp now support tool calling. Pass `ToolDefinition` values in `GenerationConfig.tools` and select the `.gemma4` prompt template — the framework injects `<|tool>` declaration blocks into the system turn and parses `<|tool_call>` tokens from the model stream into `GenerationEvent.toolCall` events.

A new `GBNFSchemaPreValidator` guards GBNF grammar compilation against CVE-2026-2069 (buffer overflow in `llama_grammar_advance_stack()`, vendored build b8772 is pre-fix). The validator rejects schema combiners and nullable union types before they reach `llama_sampler_init_grammar`. See `LLAMA_CONTRACT.md` § Security for the upgrade procedure once the xcframework pin is bumped past b8773.

Closes #414 (umbrella #753 group E), #609.