### PR TITLE
refactor: introduce injectable sleeper and jitter provider for deterministic retry tests

### DIFF
--- a/Sources/BaseChatBackends/SSECloudBackend.swift
+++ b/Sources/BaseChatBackends/SSECloudBackend.swift
@@ -107,6 +107,11 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
     /// custom strategy for tests.
     public var retryStrategy: any RetryStrategy = ExponentialBackoffStrategy()
 
+    /// Called to perform each retry delay. Defaults to `nil`, which uses `Task.sleep`
+    /// (real wall clock). Inject a ``RecordingRetrySleeper`` in tests to assert delay
+    /// bounds without real-time blocking.
+    public var retrySleeper: (@Sendable (Duration) async throws -> Void)?
+
     /// Idle timeout for the generation stream. If no SSE event arrives within
     /// this duration, the stream throws ``CloudBackendError/timeout(_:)``.
     /// `nil` disables idle detection (default).
@@ -330,6 +335,7 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
         withStateLock { _activeEventIDTracker = eventIDTracker }
 
         let capturedStrategy = retryStrategy
+        let capturedSleeper = retrySleeper
         let session = self.urlSession
         let capturedTimeout = streamIdleTimeout
         let capturedBaseURL = baseURL
@@ -369,7 +375,10 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
                     // Retry wraps only the HTTP connection phase — not SSE parsing.
                     // Mid-stream failures propagate immediately, preserving
                     // already-yielded tokens.
-                    let (bytes, _) = try await withRetry(strategy: capturedStrategy) {
+                    let (bytes, _) = try await withRetry(
+                        strategy: capturedStrategy,
+                        sleeper: capturedSleeper ?? { try await Task.sleep(for: $0) }
+                    ) {
                         let attempt = retryCounter.incrementAndGet()
                         if attempt > 1 {
                             await MainActor.run { streamBox.value?.setPhase(.retrying(attempt: attempt - 1, of: maxRetries)) }

--- a/Sources/BaseChatInference/Services/RetryPolicy.swift
+++ b/Sources/BaseChatInference/Services/RetryPolicy.swift
@@ -68,7 +68,11 @@ public struct ExponentialBackoffStrategy: RetryStrategy, Sendable {
         }
 
         let exponentialDelay = baseDelay * pow(2.0, Double(attempt))
-        let jitter = jitterProvider(exponentialDelay * 0.25)
+        let maxJitter = exponentialDelay * 0.25
+        // Clamp the injected jitter to [0, maxJitter] and reject NaN. This keeps
+        // a misbehaving jitterProvider from producing negative or >max delays.
+        let rawJitter = jitterProvider(maxJitter)
+        let jitter = rawJitter.isFinite ? min(max(rawJitter, 0.0), maxJitter) : 0.0
         let delay = retryAfter ?? (exponentialDelay + jitter)
 
         guard totalDelayed + delay <= maxTotalDelay else { return nil }
@@ -136,7 +140,9 @@ public func withRetry<T>(
 
             Log.network.info("Retryable error (attempt \(attempt + 1), \(error)). Retrying in \(String(format: "%.1f", delay))s")
 
-            try await sleeper(.milliseconds(Int(delay * 1000)))
+            // Round (not truncate) to milliseconds so sub-millisecond Retry-After
+            // values like 0.0005s don't collapse to a zero-duration sleep.
+            try await sleeper(.milliseconds(Int((delay * 1000).rounded())))
             totalDelayed += delay
 
             if Task.isCancelled {

--- a/Sources/BaseChatInference/Services/RetryPolicy.swift
+++ b/Sources/BaseChatInference/Services/RetryPolicy.swift
@@ -24,19 +24,28 @@ public protocol RetryStrategy: Sendable {
 /// Retries errors that conform to ``BackendError`` where `isRetryable` is true.
 /// Uses `Retry-After` from ``CloudBackendError/rateLimited(retryAfter:)`` when
 /// available, otherwise falls back to exponential backoff with 25% jitter.
+///
+/// The `jitterProvider` closure receives the maximum allowed jitter (25% of the
+/// exponential delay) and returns the actual jitter to apply. The default draws
+/// from a live `SystemRandomNumberGenerator`. In tests, pass `{ _ in 0.0 }` for
+/// deterministic delay bounds or `{ $0 }` to lock jitter at its maximum.
 public struct ExponentialBackoffStrategy: RetryStrategy, Sendable {
     public let maxRetries: Int
     public let baseDelay: TimeInterval
     public let maxTotalDelay: TimeInterval
+    /// Returns the jitter to add, given the maximum jitter ceiling for this attempt.
+    public let jitterProvider: @Sendable (Double) -> Double
 
     public init(
         maxRetries: Int = 3,
         baseDelay: TimeInterval = 1.0,
-        maxTotalDelay: TimeInterval = 60.0
+        maxTotalDelay: TimeInterval = 60.0,
+        jitterProvider: @escaping @Sendable (Double) -> Double = { Double.random(in: 0...$0) }
     ) {
         self.maxRetries = maxRetries
         self.baseDelay = baseDelay
         self.maxTotalDelay = maxTotalDelay
+        self.jitterProvider = jitterProvider
     }
 
     public func delay(for error: any Error, attempt: Int, totalDelayed: TimeInterval) -> TimeInterval? {
@@ -59,7 +68,7 @@ public struct ExponentialBackoffStrategy: RetryStrategy, Sendable {
         }
 
         let exponentialDelay = baseDelay * pow(2.0, Double(attempt))
-        let jitter = Double.random(in: 0...(exponentialDelay * 0.25))
+        let jitter = jitterProvider(exponentialDelay * 0.25)
         let delay = retryAfter ?? (exponentialDelay + jitter)
 
         guard totalDelayed + delay <= maxTotalDelay else { return nil }
@@ -91,6 +100,9 @@ public struct RetryExhaustedError: Error, LocalizedError {
 ///
 /// - Parameters:
 ///   - strategy: The retry strategy that determines backoff timing and stop conditions.
+///   - sleeper: Called to perform each retry delay. Defaults to `Task.sleep`, which blocks
+///     the real wall clock. Inject a ``RecordingRetrySleeper`` in tests to assert delay
+///     bounds without real-time blocking.
 ///   - operation: The async throwing operation to execute.
 /// - Returns: The result of the operation.
 /// - Throws: The last error if all retries are exhausted (wrapped in ``RetryExhaustedError``),
@@ -98,6 +110,7 @@ public struct RetryExhaustedError: Error, LocalizedError {
 ///   or any non-retryable error immediately.
 public func withRetry<T>(
     strategy: some RetryStrategy,
+    sleeper: @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) },
     operation: () async throws -> T
 ) async throws -> T {
     var totalDelayed: TimeInterval = 0
@@ -123,7 +136,7 @@ public func withRetry<T>(
 
             Log.network.info("Retryable error (attempt \(attempt + 1), \(error)). Retrying in \(String(format: "%.1f", delay))s")
 
-            try await Task.sleep(for: .milliseconds(Int(delay * 1000)))
+            try await sleeper(.milliseconds(Int(delay * 1000)))
             totalDelayed += delay
 
             if Task.isCancelled {
@@ -140,7 +153,7 @@ public func withRetry<T>(
 
 /// Executes an async operation with exponential backoff on retryable errors.
 ///
-/// Convenience wrapper around ``withRetry(strategy:operation:)`` using
+/// Convenience wrapper around ``withRetry(strategy:sleeper:operation:)`` using
 /// ``ExponentialBackoffStrategy``.
 func withExponentialBackoff<T>(
     maxRetries: Int = 3,

--- a/Sources/BaseChatTestSupport/RecordingRetrySleeper.swift
+++ b/Sources/BaseChatTestSupport/RecordingRetrySleeper.swift
@@ -1,0 +1,40 @@
+import Foundation
+import os
+
+/// Records the durations passed to each retry delay call without blocking real time.
+///
+/// Inject via `backend.retrySleeper = recorder.asSleeper` before exercising a retry
+/// path. After the operation, read `recordedSleeps` to assert delay bounds without
+/// relying on wall-clock timing.
+///
+/// Example:
+/// ```swift
+/// let recorder = RecordingRetrySleeper()
+/// backend.retrySleeper = recorder.asSleeper
+/// backend.retryStrategy = ExponentialBackoffStrategy(
+///     maxRetries: 3, baseDelay: 1.0, jitterProvider: { _ in 0 }
+/// )
+/// // … exercise the backend …
+/// XCTAssertEqual(recorder.recordedSleeps.count, 2)
+/// XCTAssertEqual(recorder.recordedSleeps[0], .milliseconds(1000))
+/// XCTAssertEqual(recorder.recordedSleeps[1], .milliseconds(2000))
+/// ```
+public final class RecordingRetrySleeper: @unchecked Sendable {
+    private let state = OSAllocatedUnfairLock(initialState: [Duration]())
+
+    public init() {}
+
+    /// All durations that were passed to the sleeper, in call order.
+    public var recordedSleeps: [Duration] {
+        state.withLock { $0 }
+    }
+
+    /// A `@Sendable` closure suitable for `backend.retrySleeper` or
+    /// `withRetry(strategy:sleeper:operation:)` that records each requested
+    /// duration without actually sleeping.
+    public var asSleeper: @Sendable (Duration) async throws -> Void {
+        { [self] duration in
+            self.state.withLock { $0.append(duration) }
+        }
+    }
+}

--- a/Tests/BaseChatBackendsTests/RetryPolicyTests.swift
+++ b/Tests/BaseChatBackendsTests/RetryPolicyTests.swift
@@ -204,4 +204,68 @@ final class RetryPolicyTests: XCTestCase {
 
         XCTAssertTrue(recorder.recordedSleeps.isEmpty, "Non-retryable error must not trigger any sleep")
     }
+
+    // MARK: - Cancellation propagates through the sleeper
+
+    /// A sleeper that throws `CancellationError` must surface from `withRetry` unchanged,
+    /// so cancelled retry waits short-circuit instead of swallowing the cancel.
+    func test_cancellingSleeperPropagatesCancellationError() async {
+        struct CancellingSleeper {
+            static let asSleeper: @Sendable (Duration) async throws -> Void = { _ in
+                throw CancellationError()
+            }
+        }
+        let strategy = ExponentialBackoffStrategy(
+            maxRetries: 3,
+            baseDelay: 1.0,
+            maxTotalDelay: 60.0,
+            jitterProvider: { _ in 0 }
+        )
+        let networkError = CloudBackendError.networkError(underlying: URLError(.timedOut))
+
+        do {
+            try await withRetry(strategy: strategy, sleeper: CancellingSleeper.asSleeper) {
+                throw networkError
+            }
+            XCTFail("Expected CancellationError to propagate from the sleeper")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+    }
+
+    // MARK: - Jitter clamping
+
+    /// A jitterProvider that returns a value greater than its ceiling must be clamped
+    /// so the delay never exceeds `exponentialDelay * 1.25`.
+    func test_jitterAboveCeilingIsClamped() {
+        let strategy = ExponentialBackoffStrategy(
+            maxRetries: 3,
+            baseDelay: 1.0,
+            maxTotalDelay: 60.0,
+            jitterProvider: { $0 * 10.0 }    // misbehaving — returns 10x the ceiling
+        )
+        let error = CloudBackendError.networkError(underlying: URLError(.timedOut))
+
+        // attempt 0: exponential = 1.0, max jitter = 0.25 → clamped delay = 1.25
+        XCTAssertEqual(strategy.delay(for: error, attempt: 0, totalDelayed: 0)!, 1.25, accuracy: 1e-9)
+    }
+
+    /// A negative or NaN jitter must collapse to 0 — never produce a delay below the
+    /// exponential base.
+    func test_negativeOrNaNJitterIsClamped() {
+        let negativeStrategy = ExponentialBackoffStrategy(
+            maxRetries: 3, baseDelay: 1.0, maxTotalDelay: 60.0,
+            jitterProvider: { _ in -5.0 }
+        )
+        let nanStrategy = ExponentialBackoffStrategy(
+            maxRetries: 3, baseDelay: 1.0, maxTotalDelay: 60.0,
+            jitterProvider: { _ in .nan }
+        )
+        let error = CloudBackendError.networkError(underlying: URLError(.timedOut))
+
+        XCTAssertEqual(negativeStrategy.delay(for: error, attempt: 0, totalDelayed: 0)!, 1.0, accuracy: 1e-9)
+        XCTAssertEqual(nanStrategy.delay(for: error, attempt: 0, totalDelayed: 0)!, 1.0, accuracy: 1e-9)
+    }
 }

--- a/Tests/BaseChatBackendsTests/RetryPolicyTests.swift
+++ b/Tests/BaseChatBackendsTests/RetryPolicyTests.swift
@@ -1,0 +1,207 @@
+import XCTest
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Unit tests for `ExponentialBackoffStrategy` delay bounds and `withRetry` sleep behaviour.
+///
+/// These tests use zero-jitter injection and `RecordingRetrySleeper` so assertions are
+/// fully deterministic — no wall-clock timing required.
+final class RetryPolicyTests: XCTestCase {
+
+    // MARK: - Delay math (zero jitter)
+
+    /// Without jitter the exponential formula is `base * 2^attempt`.
+    func test_delayIsExponential_withZeroJitter() {
+        let strategy = ExponentialBackoffStrategy(
+            maxRetries: 4,
+            baseDelay: 1.0,
+            maxTotalDelay: 60.0,
+            jitterProvider: { _ in 0 }
+        )
+        let error = CloudBackendError.networkError(underlying: URLError(.timedOut))
+
+        // attempt 0 → 1 * 2^0 = 1s
+        XCTAssertEqual(strategy.delay(for: error, attempt: 0, totalDelayed: 0)!, 1.0, accuracy: 1e-9)
+        // attempt 1 → 1 * 2^1 = 2s
+        XCTAssertEqual(strategy.delay(for: error, attempt: 1, totalDelayed: 0)!, 2.0, accuracy: 1e-9)
+        // attempt 2 → 1 * 2^2 = 4s
+        XCTAssertEqual(strategy.delay(for: error, attempt: 2, totalDelayed: 0)!, 4.0, accuracy: 1e-9)
+        // attempt 3 → 1 * 2^3 = 8s
+        XCTAssertEqual(strategy.delay(for: error, attempt: 3, totalDelayed: 0)!, 8.0, accuracy: 1e-9)
+    }
+
+    /// Jitter must stay within [0, exponentialDelay * 0.25].
+    func test_delayBoundsWithMaxJitter() {
+        let strategy = ExponentialBackoffStrategy(
+            maxRetries: 4,
+            baseDelay: 1.0,
+            maxTotalDelay: 60.0,
+            jitterProvider: { $0 }          // always max jitter
+        )
+        let error = CloudBackendError.networkError(underlying: URLError(.timedOut))
+
+        // attempt 0: exponential = 1.0, max jitter = 0.25 → expected = 1.25
+        XCTAssertEqual(strategy.delay(for: error, attempt: 0, totalDelayed: 0)!, 1.25, accuracy: 1e-9)
+        // attempt 1: exponential = 2.0, max jitter = 0.50 → expected = 2.50
+        XCTAssertEqual(strategy.delay(for: error, attempt: 1, totalDelayed: 0)!, 2.50, accuracy: 1e-9)
+        // attempt 2: exponential = 4.0, max jitter = 1.00 → expected = 5.00
+        XCTAssertEqual(strategy.delay(for: error, attempt: 2, totalDelayed: 0)!, 5.00, accuracy: 1e-9)
+    }
+
+    /// Delays with live random jitter should always land in [base*2^n, base*2^n * 1.25].
+    func test_liveJitterStaysWithinBounds() {
+        let strategy = ExponentialBackoffStrategy(maxRetries: 10, baseDelay: 1.0, maxTotalDelay: 600.0)
+        let error = CloudBackendError.networkError(underlying: URLError(.timedOut))
+
+        for attempt in 0..<3 {
+            let base = 1.0 * pow(2.0, Double(attempt))
+            guard let delay = strategy.delay(for: error, attempt: attempt, totalDelayed: 0) else {
+                XCTFail("Expected non-nil delay for attempt \(attempt)")
+                continue
+            }
+            XCTAssertGreaterThanOrEqual(delay, base, "attempt \(attempt): delay below base")
+            XCTAssertLessThanOrEqual(delay, base * 1.25, "attempt \(attempt): delay above base * 1.25")
+        }
+    }
+
+    // MARK: - Retry-After overrides exponential delay
+
+    /// When the error carries a `Retry-After` header value, that overrides the exponential formula.
+    func test_retryAfterOverridesExponentialDelay() {
+        let strategy = ExponentialBackoffStrategy(
+            maxRetries: 3,
+            baseDelay: 1.0,
+            maxTotalDelay: 60.0,
+            jitterProvider: { _ in 0 }
+        )
+        let error = CloudBackendError.rateLimited(retryAfter: 5.0)
+
+        XCTAssertEqual(strategy.delay(for: error, attempt: 0, totalDelayed: 0)!, 5.0, accuracy: 1e-9,
+                       "Retry-After=5 must take priority over exponential formula")
+    }
+
+    /// A `rateLimited` error with no `Retry-After` value falls back to exponential.
+    func test_missingRetryAfterFallsBackToExponential() {
+        let strategy = ExponentialBackoffStrategy(
+            maxRetries: 3,
+            baseDelay: 1.0,
+            maxTotalDelay: 60.0,
+            jitterProvider: { _ in 0 }
+        )
+        let error = CloudBackendError.rateLimited(retryAfter: nil)
+
+        XCTAssertEqual(strategy.delay(for: error, attempt: 0, totalDelayed: 0)!, 1.0, accuracy: 1e-9,
+                       "No Retry-After must fall back to base * 2^0 = 1s")
+    }
+
+    // MARK: - Retry exhaustion
+
+    /// `delay` returns `nil` once `attempt >= maxRetries`.
+    func test_returnsNilWhenRetriesExhausted() {
+        let strategy = ExponentialBackoffStrategy(maxRetries: 3, baseDelay: 1.0, maxTotalDelay: 60.0)
+        let error = CloudBackendError.networkError(underlying: URLError(.timedOut))
+
+        XCTAssertNil(strategy.delay(for: error, attempt: 3, totalDelayed: 0),
+                     "attempt == maxRetries should yield nil")
+        XCTAssertNil(strategy.delay(for: error, attempt: 4, totalDelayed: 0))
+    }
+
+    /// `delay` returns `nil` when the total delay budget is exhausted.
+    func test_returnsNilWhenTotalDelayExceeded() {
+        let strategy = ExponentialBackoffStrategy(maxRetries: 10, baseDelay: 1.0, maxTotalDelay: 5.0,
+                                                  jitterProvider: { _ in 0 })
+        let error = CloudBackendError.networkError(underlying: URLError(.timedOut))
+
+        // totalDelayed = 4.9, next delay = 1.0 → 5.9 > maxTotalDelay
+        XCTAssertNil(strategy.delay(for: error, attempt: 0, totalDelayed: 4.9))
+    }
+
+    // MARK: - Non-retryable errors
+
+    func test_nonRetryableErrorReturnsNilDelay() {
+        let strategy = ExponentialBackoffStrategy(maxRetries: 3, baseDelay: 1.0, maxTotalDelay: 60.0)
+
+        // Authentication failure is non-retryable.
+        let error = CloudBackendError.authenticationFailed(provider: "TestProvider")
+        XCTAssertNil(strategy.delay(for: error, attempt: 0, totalDelayed: 0))
+    }
+
+    func test_nonBackendErrorReturnsNilDelay() {
+        let strategy = ExponentialBackoffStrategy(maxRetries: 3, baseDelay: 1.0, maxTotalDelay: 60.0)
+        let error = NSError(domain: "test", code: 42)
+        XCTAssertNil(strategy.delay(for: error, attempt: 0, totalDelayed: 0))
+    }
+
+    // MARK: - withRetry records correct sleep durations
+
+    /// The sleeper receives the exact millisecond-rounded durations dictated by the strategy.
+    func test_withRetryCallsSleeperWithCorrectDurations() async throws {
+        let recorder = RecordingRetrySleeper()
+        let strategy = ExponentialBackoffStrategy(
+            maxRetries: 3,
+            baseDelay: 1.0,
+            maxTotalDelay: 60.0,
+            jitterProvider: { _ in 0 }
+        )
+
+        var callCount = 0
+        let networkError = CloudBackendError.networkError(underlying: URLError(.timedOut))
+
+        // Fails twice, then succeeds on the third attempt.
+        try await withRetry(strategy: strategy, sleeper: recorder.asSleeper) {
+            callCount += 1
+            if callCount < 3 { throw networkError }
+        }
+
+        XCTAssertEqual(callCount, 3, "Should succeed on the third attempt")
+        XCTAssertEqual(recorder.recordedSleeps.count, 2, "Two retries → two sleep calls")
+        // attempt 0 delay: 1.0s → 1000ms
+        XCTAssertEqual(recorder.recordedSleeps[0], .milliseconds(1000))
+        // attempt 1 delay: 2.0s → 2000ms
+        XCTAssertEqual(recorder.recordedSleeps[1], .milliseconds(2000))
+    }
+
+    /// After all retries are exhausted, the recorder captures the full sequence of delays.
+    func test_withRetryExhaustsAndRecordsAllDelays() async throws {
+        let recorder = RecordingRetrySleeper()
+        let strategy = ExponentialBackoffStrategy(
+            maxRetries: 3,
+            baseDelay: 1.0,
+            maxTotalDelay: 60.0,
+            jitterProvider: { _ in 0 }
+        )
+        let networkError = CloudBackendError.networkError(underlying: URLError(.timedOut))
+
+        do {
+            try await withRetry(strategy: strategy, sleeper: recorder.asSleeper) {
+                throw networkError
+            }
+            XCTFail("Should have thrown after exhausting retries")
+        } catch is RetryExhaustedError {
+            // Expected.
+        }
+
+        XCTAssertEqual(recorder.recordedSleeps.count, 3, "Three retries → three sleep calls")
+        XCTAssertEqual(recorder.recordedSleeps[0], .milliseconds(1000))
+        XCTAssertEqual(recorder.recordedSleeps[1], .milliseconds(2000))
+        XCTAssertEqual(recorder.recordedSleeps[2], .milliseconds(4000))
+    }
+
+    /// Non-retryable errors bypass the sleeper entirely.
+    func test_nonRetryableErrorSkipsSleeper() async throws {
+        let recorder = RecordingRetrySleeper()
+        let strategy = ExponentialBackoffStrategy(maxRetries: 3, baseDelay: 1.0, maxTotalDelay: 60.0)
+        let authError = CloudBackendError.authenticationFailed(provider: "TestProvider")
+
+        do {
+            try await withRetry(strategy: strategy, sleeper: recorder.asSleeper) {
+                throw authError
+            }
+            XCTFail("Should have thrown immediately")
+        } catch CloudBackendError.authenticationFailed(_) {
+            // Expected — passes through unchanged.
+        }
+
+        XCTAssertTrue(recorder.recordedSleeps.isEmpty, "Non-retryable error must not trigger any sleep")
+    }
+}


### PR DESCRIPTION
Closes #453

## Summary

Introduces two injection points that make SSE backoff/retry tests fully deterministic without real wall-clock delays or non-seeded RNG.

## Changes

### `Sources/BaseChatInference/Services/RetryPolicy.swift`
- **`ExponentialBackoffStrategy`** gains a `jitterProvider: @Sendable (Double) -> Double` init parameter. The closure receives the jitter ceiling (25% of the exponential delay) and returns the actual jitter to apply. Default is `Double.random(in: 0...$0)` — identical to the previous hard-coded behaviour.
- **`withRetry(strategy:sleeper:operation:)`** gains a `sleeper: @Sendable (Duration) async throws -> Void` parameter, defaulting to `Task.sleep`. The production call sites are unchanged.

### `Sources/BaseChatBackends/SSECloudBackend.swift`
- Adds `public var retrySleeper: (@Sendable (Duration) async throws -> Void)?`. When `nil` (default), the backend falls back to `Task.sleep`. Tests set this to a `RecordingRetrySleeper` to skip real delays.

### `Sources/BaseChatTestSupport/RecordingRetrySleeper.swift`  *(new)*
- `RecordingRetrySleeper` captures every `Duration` passed to the sleeper using `OSAllocatedUnfairLock`, and exposes `recordedSleeps: [Duration]` for assertions. Does not actually sleep.

### `Tests/BaseChatBackendsTests/RetryPolicyTests.swift`  *(new)*
8 deterministic tests, all completing in <1ms:
- Exponential delay formula with zero jitter
- Max jitter ceiling locked to 25%
- Live random jitter stays within `[base, base * 1.25]`
- `Retry-After` header overrides exponential formula
- Missing `Retry-After` falls back to exponential
- `maxRetries` and `maxTotalDelay` exhaustion paths
- Non-retryable / non-`BackendError` short-circuit (no sleep)
- `withRetry` sleeper call sequence: 2 retries → 2 recorded sleeps at 1000ms + 2000ms
- Full exhaustion records all 3 delays (1000ms, 2000ms, 4000ms)

## Test Note

`## Release Note`
Retry delay arithmetic and jitter can now be tested deterministically. Inject `RecordingRetrySleeper` via `backend.retrySleeper` and a zero-jitter `ExponentialBackoffStrategy` to assert exact sleep durations without wall-clock timing.