### PR TITLE
feat(example): Share + Action Extension recipes (App Group handoff)

### DIFF
--- a/Example/BaseChatDemo.xcodeproj/project.pbxproj
+++ b/Example/BaseChatDemo.xcodeproj/project.pbxproj
@@ -46,6 +46,13 @@
 		BF0026000000000000000000 /* SetReminderIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10022000000000000000000 /* SetReminderIntent.swift */; };
 		BF0027000000000000000000 /* AppIntentToolsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10023000000000000000000 /* AppIntentToolsView.swift */; };
 		BF0028000000000000000000 /* BaseChatAppIntents in Frameworks */ = {isa = PBXBuildFile; productRef = F30008000000000000000000 /* BaseChatAppIntents */; };
+		BF0030000000000000000000 /* PendingSharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10030000000000000000000 /* PendingSharePayload.swift */; };
+		BF0031000000000000000000 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10031000000000000000000 /* ShareViewController.swift */; };
+		BF0032000000000000000000 /* PendingSharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10030000000000000000000 /* PendingSharePayload.swift */; };
+		BF0033000000000000000000 /* ActionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10034000000000000000000 /* ActionViewController.swift */; };
+		BF0034000000000000000000 /* PendingSharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10030000000000000000000 /* PendingSharePayload.swift */; };
+		BF0036000000000000000000 /* BaseChatDemoShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = F10037000000000000000000 /* BaseChatDemoShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		BF0037000000000000000000 /* BaseChatDemoActionExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = F10038000000000000000000 /* BaseChatDemoActionExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,6 +62,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = C10001000000000000000000;
 			remoteInfo = BaseChatDemo;
+		};
+		C22001000000000000000000 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D10001000000000000000000 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C12001000000000000000000;
+			remoteInfo = BaseChatDemoShareExtension;
+		};
+		C23001000000000000000000 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D10001000000000000000000 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C13001000000000000000000;
+			remoteInfo = BaseChatDemoActionExtension;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -93,6 +114,15 @@
 		F10021000000000000000000 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F10022000000000000000000 /* SetReminderIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Intents/SetReminderIntent.swift; sourceTree = "<group>"; };
 		F10023000000000000000000 /* AppIntentToolsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntentToolsView.swift; sourceTree = "<group>"; };
+		F10030000000000000000000 /* PendingSharePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingSharePayload.swift; sourceTree = "<group>"; };
+		F10031000000000000000000 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
+		F10032000000000000000000 /* ShareExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ShareExtension.entitlements; sourceTree = "<group>"; };
+		F10033000000000000000000 /* ShareExtensionInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = ShareExtensionInfo.plist; sourceTree = "<group>"; };
+		F10034000000000000000000 /* ActionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionViewController.swift; sourceTree = "<group>"; };
+		F10035000000000000000000 /* ActionExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ActionExtension.entitlements; sourceTree = "<group>"; };
+		F10036000000000000000000 /* ActionExtensionInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = ActionExtensionInfo.plist; sourceTree = "<group>"; };
+		F10037000000000000000000 /* BaseChatDemoShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = BaseChatDemoShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		F10038000000000000000000 /* BaseChatDemoActionExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = BaseChatDemoActionExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -118,7 +148,36 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B12002000000000000000000 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B13002000000000000000000 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		B10003000000000000000000 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				BF0036000000000000000000 /* BaseChatDemoShareExtension.appex in Embed App Extensions */,
+				BF0037000000000000000000 /* BaseChatDemoActionExtension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXGroup section */
 		A00001000000000000000000 = {
@@ -156,8 +215,39 @@
 				F10020000000000000000000 /* InboundPayloadEnvelope.swift */,
 				F10022000000000000000000 /* SetReminderIntent.swift */,
 				F10023000000000000000000 /* AppIntentToolsView.swift */,
+				A02001000000000000000000 /* Extensions */,
 			);
 			path = BaseChatDemo;
+			sourceTree = "<group>";
+		};
+		A02001000000000000000000 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				F10030000000000000000000 /* PendingSharePayload.swift */,
+				A02002000000000000000000 /* ShareExtension */,
+				A02003000000000000000000 /* ActionExtension */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		A02002000000000000000000 /* ShareExtension */ = {
+			isa = PBXGroup;
+			children = (
+				F10031000000000000000000 /* ShareViewController.swift */,
+				F10032000000000000000000 /* ShareExtension.entitlements */,
+				F10033000000000000000000 /* ShareExtensionInfo.plist */,
+			);
+			path = ShareExtension;
+			sourceTree = "<group>";
+		};
+		A02003000000000000000000 /* ActionExtension */ = {
+			isa = PBXGroup;
+			children = (
+				F10034000000000000000000 /* ActionViewController.swift */,
+				F10035000000000000000000 /* ActionExtension.entitlements */,
+				F10036000000000000000000 /* ActionExtensionInfo.plist */,
+			);
+			path = ActionExtension;
 			sourceTree = "<group>";
 		};
 		A00003000000000000000000 /* Products */ = {
@@ -165,6 +255,8 @@
 			children = (
 				F10003000000000000000000 /* BaseChatDemo.app */,
 				F11002000000000000000000 /* BaseChatDemoUITests.xctest */,
+				F10037000000000000000000 /* BaseChatDemoShareExtension.appex */,
+				F10038000000000000000000 /* BaseChatDemoActionExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -202,10 +294,13 @@
 			buildPhases = (
 				B10001000000000000000000 /* Sources */,
 				B10002000000000000000000 /* Frameworks */,
+				B10003000000000000000000 /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				D22001000000000000000000 /* PBXTargetDependency */,
+				D23001000000000000000000 /* PBXTargetDependency */,
 			);
 			name = BaseChatDemo;
 			packageProductDependencies = (
@@ -220,6 +315,42 @@
 			productName = BaseChatDemo;
 			productReference = F10003000000000000000000 /* BaseChatDemo.app */;
 			productType = "com.apple.product-type.application";
+		};
+		C12001000000000000000000 /* BaseChatDemoShareExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E22001000000000000000000 /* Build configuration list for PBXNativeTarget "BaseChatDemoShareExtension" */;
+			buildPhases = (
+				B12001000000000000000000 /* Sources */,
+				B12002000000000000000000 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BaseChatDemoShareExtension;
+			packageProductDependencies = (
+			);
+			productName = BaseChatDemoShareExtension;
+			productReference = F10037000000000000000000 /* BaseChatDemoShareExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		C13001000000000000000000 /* BaseChatDemoActionExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E23001000000000000000000 /* Build configuration list for PBXNativeTarget "BaseChatDemoActionExtension" */;
+			buildPhases = (
+				B13001000000000000000000 /* Sources */,
+				B13002000000000000000000 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BaseChatDemoActionExtension;
+			packageProductDependencies = (
+			);
+			productName = BaseChatDemoActionExtension;
+			productReference = F10038000000000000000000 /* BaseChatDemoActionExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 		C11001000000000000000000 /* BaseChatDemoUITests */ = {
 			isa = PBXNativeTarget;
@@ -268,6 +399,8 @@
 			projectRoot = "";
 			targets = (
 				C10001000000000000000000 /* BaseChatDemo */,
+				C12001000000000000000000 /* BaseChatDemoShareExtension */,
+				C13001000000000000000000 /* BaseChatDemoActionExtension */,
 				C11001000000000000000000 /* BaseChatDemoUITests */,
 			);
 		};
@@ -298,6 +431,7 @@
 				BF0023000000000000000000 /* InboundPayloadEnvelope.swift in Sources */,
 				BF0026000000000000000000 /* SetReminderIntent.swift in Sources */,
 				BF0027000000000000000000 /* AppIntentToolsView.swift in Sources */,
+				BF0030000000000000000000 /* PendingSharePayload.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -319,6 +453,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B12001000000000000000000 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF0032000000000000000000 /* PendingSharePayload.swift in Sources */,
+				BF0031000000000000000000 /* ShareViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B13001000000000000000000 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF0034000000000000000000 /* PendingSharePayload.swift in Sources */,
+				BF0033000000000000000000 /* ActionViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -326,6 +478,16 @@
 			isa = PBXTargetDependency;
 			target = C10001000000000000000000 /* BaseChatDemo */;
 			targetProxy = C21001000000000000000000 /* PBXContainerItemProxy */;
+		};
+		D22001000000000000000000 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C12001000000000000000000 /* BaseChatDemoShareExtension */;
+			targetProxy = C22001000000000000000000 /* PBXContainerItemProxy */;
+		};
+		D23001000000000000000000 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C13001000000000000000000 /* BaseChatDemoActionExtension */;
+			targetProxy = C23001000000000000000000 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -558,6 +720,112 @@
 			};
 			name = Release;
 		};
+		E12001000000000000000000 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "BaseChatDemo/Extensions/ShareExtension/ShareExtension.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = "BaseChatDemo/Extensions/ShareExtension/ShareExtensionInfo.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.basechatkit.demo.share-extension;
+				PRODUCT_NAME = BaseChatDemoShareExtension;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		E12002000000000000000000 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "BaseChatDemo/Extensions/ShareExtension/ShareExtension.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = "BaseChatDemo/Extensions/ShareExtension/ShareExtensionInfo.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.basechatkit.demo.share-extension;
+				PRODUCT_NAME = BaseChatDemoShareExtension;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		E13001000000000000000000 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "BaseChatDemo/Extensions/ActionExtension/ActionExtension.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = "BaseChatDemo/Extensions/ActionExtension/ActionExtensionInfo.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.basechatkit.demo.action-extension;
+				PRODUCT_NAME = BaseChatDemoActionExtension;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		E13002000000000000000000 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "BaseChatDemo/Extensions/ActionExtension/ActionExtension.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = "BaseChatDemo/Extensions/ActionExtension/ActionExtensionInfo.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.basechatkit.demo.action-extension;
+				PRODUCT_NAME = BaseChatDemoActionExtension;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -584,6 +852,24 @@
 			buildConfigurations = (
 				E11001000000000000000000 /* Debug */,
 				E11002000000000000000000 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E22001000000000000000000 /* Build configuration list for PBXNativeTarget "BaseChatDemoShareExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E12001000000000000000000 /* Debug */,
+				E12002000000000000000000 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E23001000000000000000000 /* Build configuration list for PBXNativeTarget "BaseChatDemoActionExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E13001000000000000000000 /* Debug */,
+				E13002000000000000000000 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/BaseChatDemo.xcodeproj/project.pbxproj
+++ b/Example/BaseChatDemo.xcodeproj/project.pbxproj
@@ -51,8 +51,8 @@
 		BF0032000000000000000000 /* PendingSharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10030000000000000000000 /* PendingSharePayload.swift */; };
 		BF0033000000000000000000 /* ActionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10034000000000000000000 /* ActionViewController.swift */; };
 		BF0034000000000000000000 /* PendingSharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10030000000000000000000 /* PendingSharePayload.swift */; };
-		BF0036000000000000000000 /* BaseChatDemoShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = F10037000000000000000000 /* BaseChatDemoShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		BF0037000000000000000000 /* BaseChatDemoActionExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = F10038000000000000000000 /* BaseChatDemoActionExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		BF0036000000000000000000 /* BaseChatDemoShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = F10037000000000000000000 /* BaseChatDemoShareExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		BF0037000000000000000000 /* BaseChatDemoActionExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = F10038000000000000000000 /* BaseChatDemoActionExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -481,11 +481,13 @@
 		};
 		D22001000000000000000000 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
+			platformFilter = ios;
 			target = C12001000000000000000000 /* BaseChatDemoShareExtension */;
 			targetProxy = C22001000000000000000000 /* PBXContainerItemProxy */;
 		};
 		D23001000000000000000000 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
+			platformFilter = ios;
 			target = C13001000000000000000000 /* BaseChatDemoActionExtension */;
 			targetProxy = C23001000000000000000000 /* PBXContainerItemProxy */;
 		};

--- a/Example/BaseChatDemo/BaseChatDemoApp.swift
+++ b/Example/BaseChatDemo/BaseChatDemoApp.swift
@@ -252,6 +252,17 @@ struct BaseChatDemoApp: App {
             .onOpenURL { url in
                 handleOpenURL(url)
             }
+            // Drain a staged share payload as soon as the SwiftData container
+            // is ready. This covers the cold-launch race where scenePhase
+            // fires .active before the container task completes. The `.task`
+            // modifier lives on the inner View (not on `WindowGroup`, which
+            // is a `Scene`).
+            .task(id: modelContainer != nil ? 1 : 0) {
+                guard modelContainer != nil, let staged = stagedSharePayload else { return }
+                stagedSharePayload = nil
+                guard let pendingPayload = pendingPayload(from: staged) else { return }
+                await chatViewModel.ingestPendingPayload(pendingPayload, intent: .newSession(preset: nil))
+            }
         }
         #if os(macOS)
         .defaultSize(width: 900, height: 700)
@@ -260,15 +271,6 @@ struct BaseChatDemoApp: App {
             if newPhase == .active {
                 checkForPendingSharePayload()
             }
-        }
-        // Drain a staged share payload as soon as the SwiftData container is
-        // ready. This covers the cold-launch race where scenePhase fires
-        // .active before the container task completes.
-        .task(id: modelContainer != nil ? 1 : 0) {
-            guard modelContainer != nil, let staged = stagedSharePayload else { return }
-            stagedSharePayload = nil
-            guard let pendingPayload = pendingPayload(from: staged) else { return }
-            await chatViewModel.ingestPendingPayload(pendingPayload, intent: .newSession(preset: nil))
         }
     }
 

--- a/Example/BaseChatDemo/BaseChatDemoApp.swift
+++ b/Example/BaseChatDemo/BaseChatDemoApp.swift
@@ -9,6 +9,8 @@ import BaseChatTools
 
 @main
 struct BaseChatDemoApp: App {
+    @Environment(\.scenePhase) private var scenePhase
+
     @State private var chatViewModel: ChatViewModel
     @State private var modelManagementViewModel: ModelManagementViewModel
     @State private var sessionManager = SessionManagerViewModel()
@@ -30,6 +32,12 @@ struct BaseChatDemoApp: App {
     /// cold-launch window where the SwiftData container is still being
     /// built. ``DemoContentView`` drains it once persistence is wired.
     @State private var pendingPayloadBuffer = PendingPayloadBuffer()
+
+    /// Staged payload from the Share Extension or Action Extension, read out
+    /// of App Group storage on each foreground transition.  When the SwiftData
+    /// container is ready the payload is ingested immediately; otherwise it
+    /// waits here until the container `Task` completes.
+    @State private var stagedSharePayload: PendingSharePayload?
 
     init() {
         let testing = CommandLine.arguments.contains("--uitesting")
@@ -248,6 +256,20 @@ struct BaseChatDemoApp: App {
         #if os(macOS)
         .defaultSize(width: 900, height: 700)
         #endif
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active {
+                checkForPendingSharePayload()
+            }
+        }
+        // Drain a staged share payload as soon as the SwiftData container is
+        // ready. This covers the cold-launch race where scenePhase fires
+        // .active before the container task completes.
+        .task(id: modelContainer != nil ? 1 : 0) {
+            guard modelContainer != nil, let staged = stagedSharePayload else { return }
+            stagedSharePayload = nil
+            guard let pendingPayload = pendingPayload(from: staged) else { return }
+            await chatViewModel.ingestPendingPayload(pendingPayload, intent: .newSession(preset: nil))
+        }
     }
 
     // MARK: - Inbound payload handoff
@@ -285,6 +307,52 @@ struct BaseChatDemoApp: App {
             Task {
                 await pendingPayloadBuffer.store(payload)
             }
+        }
+    }
+
+    // MARK: - Share / Action Extension handoff
+
+    /// Reads and clears any ``PendingSharePayload`` written by the Share or
+    /// Action Extension from the App Group container.
+    ///
+    /// Called on every foreground transition (`.onChange(of: scenePhase)`).
+    /// When the SwiftData container is ready the payload is passed to
+    /// ``ChatViewModel/ingestPendingPayload(_:intent:)`` immediately;
+    /// otherwise it is stored in ``stagedSharePayload`` and picked up by the
+    /// `.task(id:)` modifier once the container completes.
+    private func checkForPendingSharePayload() {
+        guard let defaults = UserDefaults(suiteName: DemoAppGroup.identifier),
+              let data = defaults.data(forKey: DemoAppGroup.pendingShareKey),
+              let sharePayload = try? JSONDecoder().decode(PendingSharePayload.self, from: data) else {
+            return
+        }
+        // Remove before ingesting so a crash during ingest doesn't replay.
+        defaults.removeObject(forKey: DemoAppGroup.pendingShareKey)
+
+        if modelContainer != nil {
+            guard let payload = pendingPayload(from: sharePayload) else { return }
+            Task { @MainActor in
+                await chatViewModel.ingestPendingPayload(payload, intent: .newSession(preset: nil))
+            }
+        } else {
+            // Container still initialising — stage for the .task(id:) drain.
+            stagedSharePayload = sharePayload
+        }
+    }
+
+    /// Converts a ``PendingSharePayload`` (pure Foundation, extension-safe)
+    /// into a ``PendingPayload`` (BaseChatUI) for handoff to the view model.
+    private func pendingPayload(from share: PendingSharePayload) -> PendingPayload? {
+        switch share.kind {
+        case .text:
+            guard let text = share.text, !text.isEmpty else { return nil }
+            return .text(text)
+        case .url:
+            guard let urlString = share.urlString, let url = URL(string: urlString) else { return nil }
+            return .url(url)
+        case .image:
+            guard let data = share.imageData else { return nil }
+            return .image(data, mimeType: share.imageMimeType ?? "image/png")
         }
     }
 

--- a/Example/BaseChatDemo/Extensions/ActionExtension/ActionExtension.entitlements
+++ b/Example/BaseChatDemo/Extensions/ActionExtension/ActionExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.basechatkit.demo</string>
+	</array>
+</dict>
+</plist>

--- a/Example/BaseChatDemo/Extensions/ActionExtension/ActionExtensionInfo.plist
+++ b/Example/BaseChatDemo/Extensions/ActionExtension/ActionExtensionInfo.plist
@@ -2,6 +2,24 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>BaseChat Action</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/Example/BaseChatDemo/Extensions/ActionExtension/ActionExtensionInfo.plist
+++ b/Example/BaseChatDemo/Extensions/ActionExtension/ActionExtensionInfo.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationSupportsText</key>
+				<true/>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+			</dict>
+			<key>NSExtensionServiceRoleType</key>
+			<string>NSExtensionServiceRoleTypeEditor</string>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.ui-services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ActionViewController</string>
+	</dict>
+</dict>
+</plist>

--- a/Example/BaseChatDemo/Extensions/ActionExtension/ActionViewController.swift
+++ b/Example/BaseChatDemo/Extensions/ActionExtension/ActionViewController.swift
@@ -1,0 +1,78 @@
+import UIKit
+import UniformTypeIdentifiers
+
+// App Group constants — mirror DemoAppGroup (host app). Duplicated because
+// the extension cannot import InboundPayloadEnvelope (BaseChatInference dep).
+private let kAppGroupID = "group.com.basechatkit.demo"
+private let kPendingKey = "bck.pending-share"
+
+/// Action Extension principal class — "Summarise selection" recipe.
+///
+/// Captures selected text (or a URL) from the host app, serialises it as a
+/// ``PendingSharePayload`` into the shared App Group container, and completes
+/// the request. The host app ingests the payload on next foreground
+/// activation via ``BaseChatDemoApp/checkForPendingSharePayload()``.
+///
+/// ## Usage
+///
+/// Users invoke the extension via the Action sheet in any app that exposes
+/// selected text (Safari Reader, Notes, Mail, etc.). The extension writes the
+/// selection and immediately completes — no UI is shown. The next time the
+/// user switches to BaseChat Demo, the selection is opened in a new session
+/// seeded with the text, ready for the model to summarise.
+///
+/// ## No inference in the extension
+///
+/// This file imports nothing from BaseChatKit. The only non-system dependency
+/// is ``PendingSharePayload``.
+class ActionViewController: UIViewController {
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        Task { @MainActor in
+            await handleItems()
+        }
+    }
+
+    private func handleItems() async {
+        let items = (extensionContext?.inputItems as? [NSExtensionItem]) ?? []
+        let payload = await extractPayload(from: items)
+
+        if let payload,
+           let defaults = UserDefaults(suiteName: kAppGroupID),
+           let data = try? JSONEncoder().encode(payload) {
+            defaults.set(data, forKey: kPendingKey)
+        }
+
+        extensionContext?.completeRequest(returningItems: nil)
+    }
+
+    // MARK: - Item extraction
+
+    // Action extensions receive selected text or URLs. Text wins over URL
+    // because the typical "summarise selection" recipe captures prose.
+    private func extractPayload(from items: [NSExtensionItem]) async -> PendingSharePayload? {
+        for item in items {
+            for provider in (item.attachments ?? []) {
+                if let payload = await loadText(from: provider) { return payload }
+                if let payload = await loadURL(from: provider) { return payload }
+            }
+        }
+        return nil
+    }
+
+    private func loadText(from provider: NSItemProvider) async -> PendingSharePayload? {
+        guard provider.hasItemConformingToTypeIdentifier(UTType.plainText.identifier) else { return nil }
+        guard let text = try? await provider.loadItem(forTypeIdentifier: UTType.plainText.identifier) as? String,
+              !text.isEmpty else { return nil }
+        return PendingSharePayload(kind: .text, text: text, source: "actionExtension")
+    }
+
+    private func loadURL(from provider: NSItemProvider) async -> PendingSharePayload? {
+        guard provider.hasItemConformingToTypeIdentifier(UTType.url.identifier) else { return nil }
+        guard let url = try? await provider.loadItem(forTypeIdentifier: UTType.url.identifier) as? URL else {
+            return nil
+        }
+        return PendingSharePayload(kind: .url, urlString: url.absoluteString, source: "actionExtension")
+    }
+}

--- a/Example/BaseChatDemo/Extensions/ActionExtension/ActionViewController.swift
+++ b/Example/BaseChatDemo/Extensions/ActionExtension/ActionViewController.swift
@@ -1,10 +1,9 @@
 import UIKit
 import UniformTypeIdentifiers
 
-// App Group constants — mirror DemoAppGroup (host app). Duplicated because
-// the extension cannot import InboundPayloadEnvelope (BaseChatInference dep).
-private let kAppGroupID = "group.com.basechatkit.demo"
-private let kPendingKey = "bck.pending-share"
+// App Group constants come from `DemoSharedAppGroup` in
+// `PendingSharePayload.swift`, which is compiled into both the host app
+// and this extension — single source of truth, no string drift.
 
 /// Action Extension principal class — "Summarise selection" recipe.
 ///
@@ -39,9 +38,13 @@ class ActionViewController: UIViewController {
         let payload = await extractPayload(from: items)
 
         if let payload,
-           let defaults = UserDefaults(suiteName: kAppGroupID),
+           let defaults = UserDefaults(suiteName: DemoSharedAppGroup.identifier),
            let data = try? JSONEncoder().encode(payload) {
-            defaults.set(data, forKey: kPendingKey)
+            defaults.set(data, forKey: DemoSharedAppGroup.pendingShareKey)
+            // Force a flush before the extension is suspended. The host app
+            // can wake within milliseconds of `completeRequest`, so we want
+            // the write committed before we hand control back.
+            defaults.synchronize()
         }
 
         extensionContext?.completeRequest(returningItems: nil)

--- a/Example/BaseChatDemo/Extensions/PendingSharePayload.swift
+++ b/Example/BaseChatDemo/Extensions/PendingSharePayload.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Codable payload written to the App Group container by Share and Action
+/// Extensions and drained by the host app on the next foreground transition.
+///
+/// This type is intentionally **pure Foundation** — no BaseChatKit dependency
+/// — so it can be compiled into both the host app and the lightweight
+/// extension targets, which must stay under the iOS extension memory budget.
+///
+/// ## Wire format
+///
+/// Extensions write a JSON-encoded `PendingSharePayload` to:
+/// - App Group: `group.com.basechatkit.demo`
+/// - Key: `bck.pending-share`
+///
+/// The host app reads it in ``BaseChatDemoApp/checkForPendingSharePayload()``
+/// and converts it to a ``PendingPayload`` before calling
+/// ``ChatViewModel/ingestPendingPayload(_:intent:)``.
+///
+/// ## Payload priority
+///
+/// If the extension finds multiple item types, it picks the best one in this
+/// order: URL > plain text > image.  Only one payload is queued per extension
+/// invocation.
+struct PendingSharePayload: Codable, Sendable {
+
+    /// The flavour of content the extension captured.
+    enum Kind: String, Codable {
+        case text
+        case url
+        case image
+    }
+
+    /// The flavour of content this payload carries.
+    var kind: Kind
+
+    /// Plain-text body — populated when `kind == .text`.
+    var text: String?
+
+    /// Absolute string of the shared URL — populated when `kind == .url`.
+    var urlString: String?
+
+    /// Raw image bytes — populated when `kind == .image`.
+    var imageData: Data?
+
+    /// MIME type for `imageData`; defaults to `"image/png"` at the read site
+    /// when absent.
+    var imageMimeType: String?
+
+    /// Entry point that produced this payload.
+    ///
+    /// - `"shareExtension"`: iOS/macOS Share sheet
+    /// - `"actionExtension"`: iOS Action sheet ("Summarise selection")
+    var source: String
+}

--- a/Example/BaseChatDemo/Extensions/PendingSharePayload.swift
+++ b/Example/BaseChatDemo/Extensions/PendingSharePayload.swift
@@ -10,8 +10,8 @@ import Foundation
 /// ## Wire format
 ///
 /// Extensions write a JSON-encoded `PendingSharePayload` to:
-/// - App Group: `group.com.basechatkit.demo`
-/// - Key: `bck.pending-share`
+/// - App Group: ``DemoSharedAppGroup/identifier``
+/// - Key: ``DemoSharedAppGroup/pendingShareKey``
 ///
 /// The host app reads it in ``BaseChatDemoApp/checkForPendingSharePayload()``
 /// and converts it to a ``PendingPayload`` before calling
@@ -19,9 +19,11 @@ import Foundation
 ///
 /// ## Payload priority
 ///
-/// If the extension finds multiple item types, it picks the best one in this
-/// order: URL > plain text > image.  Only one payload is queued per extension
-/// invocation.
+/// If an extension finds multiple item types it queues only one payload per
+/// invocation. The exact priority is determined by the producing extension:
+/// the Share Extension prefers `URL > text > image`, while the Action
+/// Extension prefers `text > URL` (its typical use case is "summarise
+/// selection", which is prose-first).
 struct PendingSharePayload: Codable, Sendable {
 
     /// The flavour of content the extension captured.
@@ -35,21 +37,35 @@ struct PendingSharePayload: Codable, Sendable {
     var kind: Kind
 
     /// Plain-text body — populated when `kind == .text`.
-    var text: String?
+    var text: String? = nil
 
     /// Absolute string of the shared URL — populated when `kind == .url`.
-    var urlString: String?
+    var urlString: String? = nil
 
     /// Raw image bytes — populated when `kind == .image`.
-    var imageData: Data?
+    var imageData: Data? = nil
 
     /// MIME type for `imageData`; defaults to `"image/png"` at the read site
     /// when absent.
-    var imageMimeType: String?
+    var imageMimeType: String? = nil
 
     /// Entry point that produced this payload.
     ///
     /// - `"shareExtension"`: iOS/macOS Share sheet
     /// - `"actionExtension"`: iOS Action sheet ("Summarise selection")
     var source: String
+}
+
+/// App Group constants shared between the host app and the Share/Action
+/// extensions. The host app's `DemoAppGroup` enum re-exports the same
+/// identifiers — keep the two in sync (the constants live here so the
+/// extension targets, which can't import host-app types, still see them).
+enum DemoSharedAppGroup {
+    /// App Group identifier — must match the entitlement in
+    /// `BaseChatDemo.entitlements`, `ShareExtension.entitlements`, and
+    /// `ActionExtension.entitlements`.
+    static let identifier = "group.com.basechatkit.demo"
+
+    /// `UserDefaults` key the extensions write to and the host app drains.
+    static let pendingShareKey = "bck.pending-share"
 }

--- a/Example/BaseChatDemo/Extensions/ShareExtension/ShareExtension.entitlements
+++ b/Example/BaseChatDemo/Extensions/ShareExtension/ShareExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.basechatkit.demo</string>
+	</array>
+</dict>
+</plist>

--- a/Example/BaseChatDemo/Extensions/ShareExtension/ShareExtensionInfo.plist
+++ b/Example/BaseChatDemo/Extensions/ShareExtension/ShareExtensionInfo.plist
@@ -2,6 +2,24 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>BaseChat Share</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/Example/BaseChatDemo/Extensions/ShareExtension/ShareExtensionInfo.plist
+++ b/Example/BaseChatDemo/Extensions/ShareExtension/ShareExtensionInfo.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationSupportsText</key>
+				<true/>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
+				<integer>1</integer>
+			</dict>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
+	</dict>
+</dict>
+</plist>

--- a/Example/BaseChatDemo/Extensions/ShareExtension/ShareViewController.swift
+++ b/Example/BaseChatDemo/Extensions/ShareExtension/ShareViewController.swift
@@ -1,0 +1,86 @@
+import UIKit
+import UniformTypeIdentifiers
+
+// App Group constants — canonical values live in DemoAppGroup (host app).
+// Duplicated here because the extension cannot import InboundPayloadEnvelope
+// (which depends on BaseChatInference). Keep in sync manually.
+private let kAppGroupID = "group.com.basechatkit.demo"
+private let kPendingKey = "bck.pending-share"
+
+/// Share Extension principal class.
+///
+/// Reads the first recognisable item from the extension context
+/// (URL > plain text > image), serialises it as a ``PendingSharePayload``
+/// into the shared App Group container, and completes the request.
+///
+/// The host app drains the payload on the next foreground activation —
+/// see ``BaseChatDemoApp/checkForPendingSharePayload()``. No inference
+/// runs inside the extension; it is a write-only relay.
+///
+/// ## Memory budget
+///
+/// This class imports nothing from BaseChatKit. The only non-system
+/// dependency is ``PendingSharePayload``, a plain Codable struct.
+/// Image payloads are PNG-encoded and stored as `Data` in App Group
+/// `UserDefaults`; callers that share large images should be aware of
+/// the 4 MB `UserDefaults` write limit. For images larger than that,
+/// write the data to a file in the App Group container and store only
+/// the path.
+class ShareViewController: UIViewController {
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        Task { @MainActor in
+            await handleItems()
+        }
+    }
+
+    private func handleItems() async {
+        let items = (extensionContext?.inputItems as? [NSExtensionItem]) ?? []
+        let payload = await extractPayload(from: items)
+
+        if let payload,
+           let defaults = UserDefaults(suiteName: kAppGroupID),
+           let data = try? JSONEncoder().encode(payload) {
+            defaults.set(data, forKey: kPendingKey)
+        }
+
+        extensionContext?.completeRequest(returningItems: nil)
+    }
+
+    // MARK: - Item extraction
+
+    // Tries providers in priority order: URL → plain text → image.
+    private func extractPayload(from items: [NSExtensionItem]) async -> PendingSharePayload? {
+        for item in items {
+            for provider in (item.attachments ?? []) {
+                if let payload = await loadURL(from: provider) { return payload }
+                if let payload = await loadText(from: provider) { return payload }
+                if let payload = await loadImage(from: provider) { return payload }
+            }
+        }
+        return nil
+    }
+
+    private func loadURL(from provider: NSItemProvider) async -> PendingSharePayload? {
+        guard provider.hasItemConformingToTypeIdentifier(UTType.url.identifier) else { return nil }
+        guard let url = try? await provider.loadItem(forTypeIdentifier: UTType.url.identifier) as? URL else {
+            return nil
+        }
+        return PendingSharePayload(kind: .url, urlString: url.absoluteString, source: "shareExtension")
+    }
+
+    private func loadText(from provider: NSItemProvider) async -> PendingSharePayload? {
+        guard provider.hasItemConformingToTypeIdentifier(UTType.plainText.identifier) else { return nil }
+        guard let text = try? await provider.loadItem(forTypeIdentifier: UTType.plainText.identifier) as? String,
+              !text.isEmpty else { return nil }
+        return PendingSharePayload(kind: .text, text: text, source: "shareExtension")
+    }
+
+    private func loadImage(from provider: NSItemProvider) async -> PendingSharePayload? {
+        guard provider.hasItemConformingToTypeIdentifier(UTType.image.identifier) else { return nil }
+        guard let image = try? await provider.loadItem(forTypeIdentifier: UTType.image.identifier) as? UIImage,
+              let data = image.pngData() else { return nil }
+        return PendingSharePayload(kind: .image, imageData: data, imageMimeType: "image/png", source: "shareExtension")
+    }
+}

--- a/Example/BaseChatDemo/Extensions/ShareExtension/ShareViewController.swift
+++ b/Example/BaseChatDemo/Extensions/ShareExtension/ShareViewController.swift
@@ -1,11 +1,9 @@
 import UIKit
 import UniformTypeIdentifiers
 
-// App Group constants — canonical values live in DemoAppGroup (host app).
-// Duplicated here because the extension cannot import InboundPayloadEnvelope
-// (which depends on BaseChatInference). Keep in sync manually.
-private let kAppGroupID = "group.com.basechatkit.demo"
-private let kPendingKey = "bck.pending-share"
+// App Group constants come from `DemoSharedAppGroup` in
+// `PendingSharePayload.swift`, which is compiled into both the host app
+// and this extension — single source of truth, no string drift.
 
 /// Share Extension principal class.
 ///
@@ -40,9 +38,13 @@ class ShareViewController: UIViewController {
         let payload = await extractPayload(from: items)
 
         if let payload,
-           let defaults = UserDefaults(suiteName: kAppGroupID),
+           let defaults = UserDefaults(suiteName: DemoSharedAppGroup.identifier),
            let data = try? JSONEncoder().encode(payload) {
-            defaults.set(data, forKey: kPendingKey)
+            defaults.set(data, forKey: DemoSharedAppGroup.pendingShareKey)
+            // Force a flush before the extension is suspended. The host app
+            // can wake within milliseconds of `completeRequest`, so we want
+            // the write committed before we hand control back.
+            defaults.synchronize()
         }
 
         extensionContext?.completeRequest(returningItems: nil)

--- a/Example/BaseChatDemo/Intents/InboundPayloadEnvelope.swift
+++ b/Example/BaseChatDemo/Intents/InboundPayloadEnvelope.swift
@@ -43,4 +43,6 @@ struct InboundPayloadEnvelope: Codable, Sendable {
 enum DemoAppGroup {
     static let identifier = "group.com.basechatkit.demo"
     static let inboundKey = "bck.inbound"
+    /// Key written by the Share Extension and Action Extension.
+    static let pendingShareKey = "bck.pending-share"
 }

--- a/Example/BaseChatDemo/Intents/InboundPayloadEnvelope.swift
+++ b/Example/BaseChatDemo/Intents/InboundPayloadEnvelope.swift
@@ -40,6 +40,13 @@ struct InboundPayloadEnvelope: Codable, Sendable {
 /// App Group identifier shared between the intent (writer) and the
 /// app's `.onOpenURL` handler (reader). Centralised so renaming stays
 /// in one place.
+///
+/// The literal values here intentionally mirror ``DemoSharedAppGroup``
+/// (in `Extensions/PendingSharePayload.swift`). They're duplicated rather
+/// than re-exported because this file is also compiled into the
+/// `BaseChatDemoUITests` target, which doesn't link the extension-shared
+/// `PendingSharePayload.swift`. If you rename either constant, update
+/// the other.
 enum DemoAppGroup {
     static let identifier = "group.com.basechatkit.demo"
     static let inboundKey = "bck.inbound"

--- a/Example/README.md
+++ b/Example/README.md
@@ -28,6 +28,18 @@ The helper auto-selects an available simulator destination. If you need to pin o
 - Cloud API endpoint management
 - Multi-session chat with auto-rename
 - Model download and storage management
+- Share Extension + Action Extension handoff via App Group (see `Extensions/`)
+
+### Share & Action Extensions
+
+The demo includes two iOS app extensions that hand content into a new chat session:
+
+- **BaseChatDemoShareExtension** — activated from the system Share sheet. Accepts text, URLs, and images.
+- **BaseChatDemoActionExtension** — activated from the system action row. Accepts text and URLs.
+
+Both extensions write a `PendingSharePayload` to an App Group `UserDefaults` key. The host app drains it on the next foreground transition and calls `ChatViewModel.ingestPendingPayload(_:intent:)` to open a pre-filled session.
+
+See `docs/share-action-extension-recipe.md` for the full integration guide.
 
 ## Focused Examples
 

--- a/docs/share-action-extension-recipe.md
+++ b/docs/share-action-extension-recipe.md
@@ -1,0 +1,169 @@
+# Share & Action Extension Recipe (App Group handoff)
+
+This guide explains how BaseChatDemo wires a Share Extension and an Action Extension to hand content into a new `ChatViewModel` session without linking BaseChatKit inside the extension.
+
+## Architecture overview
+
+```
+┌─────────────────────────┐         UserDefaults (App Group)
+│  Share / Action Extension│ ──────► key: "bck.pending-share"
+│  (pure Foundation)       │         value: PendingSharePayload (JSON)
+└─────────────────────────┘
+           ↑ writes, then completeRequest()
+
+┌─────────────────────────┐ .onChange(of: scenePhase == .active)
+│  BaseChatDemo (host app) │ ──reads──► PendingSharePayload
+│                          │ ──────────► PendingPayload (BaseChatUI)
+│  ChatViewModel           │ ──────────► ingestPendingPayload(_:intent:)
+└─────────────────────────┘
+```
+
+The key isolation boundary is `PendingSharePayload` — a pure Foundation `Codable` struct compiled into all three targets (host app, Share Extension, Action Extension). Extensions cannot link BaseChatKit (App Extensions must not import frameworks with `@main`/`App` conformances), so this thin shared type is the handoff contract.
+
+## File map
+
+```
+Example/BaseChatDemo/Extensions/
+├── PendingSharePayload.swift          # Shared Codable (no BCK deps)
+├── ShareExtension/
+│   ├── ShareViewController.swift      # UIViewController principal class
+│   ├── ShareExtension.entitlements    # App Group entitlement
+│   └── ShareExtensionInfo.plist       # NSExtension config
+└── ActionExtension/
+    ├── ActionViewController.swift     # UIViewController principal class
+    ├── ActionExtension.entitlements   # App Group entitlement
+    └── ActionExtensionInfo.plist      # NSExtension config
+```
+
+Host-app changes live in `BaseChatDemoApp.swift` (`checkForPendingSharePayload`, `pendingPayload(from:)`, `.onChange(of: scenePhase)`, `.task(id:)`).
+
+## Entitlement checklist
+
+All three targets — the host app and both extensions — must share the same App Group identifier in their entitlements:
+
+```xml
+<!-- *.entitlements -->
+<key>com.apple.security.application-groups</key>
+<array>
+    <string>group.com.basechatkit.demo</string>
+</array>
+```
+
+`BaseChatDemo.entitlements` already had this from the App Intents path (#442). Each extension gets its own `.entitlements` file with the same group.
+
+## PendingSharePayload
+
+```swift
+// Extensions/PendingSharePayload.swift — pure Foundation, no BCK deps.
+// Compiled into: BaseChatDemo, BaseChatDemoShareExtension, BaseChatDemoActionExtension.
+struct PendingSharePayload: Codable, Sendable {
+    enum Kind: String, Codable { case text, url, image }
+
+    var kind: Kind
+    var text: String?
+    var urlString: String?
+    var imageData: Data?
+    var imageMimeType: String?
+    var source: String   // "shareExtension" | "actionExtension"
+}
+```
+
+Extensions write this to the App Group and complete immediately — no inference happens inside an extension.
+
+## Extension write pattern
+
+```swift
+// ShareViewController.swift (same pattern for ActionViewController)
+private func submitAndComplete(payload: PendingSharePayload) {
+    guard let data = try? JSONEncoder().encode(payload),
+          let defaults = UserDefaults(suiteName: "group.com.basechatkit.demo") else {
+        extensionContext?.completeRequest(returningItems: nil)
+        return
+    }
+    defaults.set(data, forKey: "bck.pending-share")
+    defaults.synchronize()
+    extensionContext?.completeRequest(returningItems: nil)
+}
+```
+
+`defaults.synchronize()` flushes the write before the extension process is suspended — important because the host app may wake within milliseconds.
+
+## Host-app drain pattern
+
+```swift
+// BaseChatDemoApp.swift
+
+.onChange(of: scenePhase) { _, newPhase in
+    if newPhase == .active {
+        checkForPendingSharePayload()
+    }
+}
+.task(id: modelContainer != nil ? 1 : 0) {
+    // Handles the cold-launch race: scenePhase fires .active before
+    // the SwiftData container task completes.
+    guard modelContainer != nil, let staged = stagedSharePayload else { return }
+    stagedSharePayload = nil
+    guard let payload = pendingPayload(from: staged) else { return }
+    await chatViewModel.ingestPendingPayload(payload, intent: .newSession(preset: nil))
+}
+
+private func checkForPendingSharePayload() {
+    guard let defaults = UserDefaults(suiteName: DemoAppGroup.identifier),
+          let data = defaults.data(forKey: DemoAppGroup.pendingShareKey),
+          let sharePayload = try? JSONDecoder().decode(PendingSharePayload.self, from: data) else {
+        return
+    }
+    // Remove before ingesting — crash-safe: won't replay on next launch.
+    defaults.removeObject(forKey: DemoAppGroup.pendingShareKey)
+
+    if modelContainer != nil {
+        guard let payload = pendingPayload(from: sharePayload) else { return }
+        Task { @MainActor in
+            await chatViewModel.ingestPendingPayload(payload, intent: .newSession(preset: nil))
+        }
+    } else {
+        // Container still initialising — stage for .task(id:) drain.
+        stagedSharePayload = sharePayload
+    }
+}
+```
+
+## Cold-launch race
+
+The two-stage pattern (`stagedSharePayload` + `.task(id:)`) handles the race where:
+
+1. The user taps in the Share sheet → extension writes to App Group → extension completes.
+2. iOS cold-launches the host app.
+3. `scenePhase` fires `.active` **before** the async `ModelContainer` task finishes.
+4. `checkForPendingSharePayload` reads the payload but finds `modelContainer == nil`.
+5. The payload is stored in `stagedSharePayload`.
+6. `modelContainer` is set → `.task(id: 1)` fires → payload is drained.
+
+## App Group key separation
+
+| Key | Written by | Consumed by |
+|-----|-----------|-------------|
+| `bck.inbound` | `AskBaseChatDemoIntent` (App Intent) | `handleOpenURL` via `basechatdemo://ingest` |
+| `bck.pending-share` | Share Extension / Action Extension | `checkForPendingSharePayload` on foreground |
+
+Using separate keys prevents the two paths from clobbering each other.
+
+## Extension point IDs
+
+| Extension | Info.plist point ID | Platform |
+|-----------|----------------------|----------|
+| Share | `com.apple.share-services` | iOS (also valid on macOS via Catalyst) |
+| Action | `com.apple.ui-services` | iOS only |
+
+The extensions are iOS-only Xcode targets (`SDKROOT = iphoneos`). The host-app Embed App Extensions build phase uses `platformFilter = ios` so macOS builds are unaffected.
+
+## Adapting this pattern for your own app
+
+1. Add an App Group to your app's entitlements (Signing & Capabilities → App Groups).
+2. Copy `PendingSharePayload.swift` into your project; adjust fields as needed.
+3. Add Share / Action Extension targets and add the same App Group entitlement.
+4. In each extension, write a JSON-encoded `PendingSharePayload` to the shared `UserDefaults` key and call `completeRequest`.
+5. In your app's `WindowGroup`, add `.onChange(of: scenePhase)` and drain on `.active`.
+6. Pass the payload to `chatViewModel.ingestPendingPayload(_:intent:)`.
+
+For the `intent` parameter, `.newSession(preset: nil)` opens a fresh chat. Pass a `SessionPreset` if you want the session pre-configured (system prompt, model, temperature).


### PR DESCRIPTION
## Summary

Closes #440.

Adds iOS Share Extension and Action Extension targets to BaseChatDemo, demonstrating the App Group handoff pattern for pre-filling a new `ChatViewModel` session without linking BaseChatKit inside the extension.

## Architecture

The key isolation boundary is `PendingSharePayload` — a pure Foundation `Codable` compiled into all three targets (host app + both extensions). Extensions write to App Group key `bck.pending-share`; the host app drains on foreground via `.onChange(of: scenePhase)` + a `.task(id:)` for the cold-launch race.

## What ships

- `Extensions/PendingSharePayload.swift` — pure Foundation shared type (no BCK deps)
- `BaseChatDemoShareExtension` — Share sheet extension accepting text, URL, image
- `BaseChatDemoActionExtension` — Action row extension accepting text, URL
- `BaseChatDemoApp` — `checkForPendingSharePayload()` + `pendingPayload(from:)` drain helpers wired to scenePhase
- `DemoAppGroup.pendingShareKey` constant (separate from `bck.inbound` App Intent key)
- Xcode project: two iOS-only `app-extension` targets, Sources/Frameworks/Embed build phases, entitlements, Info.plists, Debug+Release configs
- `docs/share-action-extension-recipe.md` — integration guide (entitlement checklist, isolation boundary, cold-launch race, adapting to your own app)
- `Example/README.md` — Extensions section added

## Release Note

### Share & Action Extension recipe for iOS handoff

Adds two iOS app extension targets to BaseChatDemo showing how to pipe content from the system Share sheet or action row into a new BaseChatKit chat session. Extensions are intentionally thin: they write a `PendingSharePayload` to an App Group `UserDefaults` key and complete immediately — no inference happens inside the extension sandbox. The host app drains the payload on the next foreground transition and hands it to `ChatViewModel.ingestPendingPayload(_:intent:)`.

```swift
// In your App body:
.onChange(of: scenePhase) { _, newPhase in
    if newPhase == .active { checkForPendingSharePayload() }
}
```

A companion `.task(id:)` modifier handles the cold-launch race where `scenePhase` fires `.active` before the SwiftData container finishes initialising. See `docs/share-action-extension-recipe.md` for the full integration guide.