### PR TITLE
fix(fuzz): Ollama trait gap + empty-arg expansion + thinking-loop guard

### DIFF
--- a/Sources/BaseChatUI/ViewModels/GenerationCoordinator.swift
+++ b/Sources/BaseChatUI/ViewModels/GenerationCoordinator.swift
@@ -380,6 +380,11 @@ final class GenerationCoordinator {
                                 self.onMutateMessage(messageID) { msg in
                                     Self.writeThinkingPartialText(displayed, into: &msg)
                                 }
+                                if consumer.shouldStopForLoop(content: thinkingAccumulator) {
+                                    self.inferenceService.stopGeneration()
+                                    self.onSetErrorMessage("Generation stopped: the model appears to be looping in its reasoning.")
+                                    break eventLoop
+                                }
                             }
 
                         case .recordThinkingSignature(let signature):

--- a/Sources/fuzz-chat/FuzzChatCLI.swift
+++ b/Sources/fuzz-chat/FuzzChatCLI.swift
@@ -110,14 +110,14 @@ struct FuzzChatCLI {
         let factory: any FuzzBackendFactory
         switch backend {
         case .ollama:
-            #if Fuzz
+            #if Fuzz && Ollama
             do {
                 factory = try Self.makeOllamaFactory(modelHint: modelHint)
             } catch {
                 fail(String(describing: error))
             }
             #else
-            fail("Ollama backend requires the Fuzz build trait. Run via: scripts/fuzz.sh")
+            fail("Ollama backend requires the Fuzz and Ollama build traits. Run via: scripts/fuzz.sh")
             #endif
         case .mock:
             factory = MockFuzzFactory()
@@ -206,7 +206,7 @@ struct FuzzChatCLI {
         await factory.teardown()
     }
 
-    #if Fuzz
+    #if Fuzz && Ollama
     /// Builds the Ollama-backed factory for the runner.
     ///
     /// - When `modelHint` is `nil` or `"all"`: enumerates every installed Ollama

--- a/Tests/BaseChatUITests/ChatViewModelLoopDetectionTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelLoopDetectionTests.swift
@@ -61,6 +61,34 @@ final class ChatViewModelLoopDetectionTests: XCTestCase {
         XCTAssertNil(vm.errorMessage, "No error should be set when loop detection is disabled")
     }
 
+    // MARK: - Thinking buffer loop detection (unit test on consumer)
+
+    /// Verifies that `shouldStopForLoop` fires on `thinkingAccumulator` content,
+    /// mirroring the guard that already exists for the visible-text accumulator.
+    /// Caught by fuzz finding 748815b0da2e (qwen3.5:4b, looping/thinking-loop).
+    func test_thinkingAccumulator_loopDetection_firesOnRepetitiveContent() {
+        var consumer = GenerationStreamConsumer(loopDetectionEnabled: true)
+
+        // Build a repetitive thinking accumulator: a 25-char phrase repeated 12 times
+        // gives 300 chars, well above the 100-char 2x-detection threshold.
+        let chunk = "This is a thinking loop. "
+        let thinkingAccumulator = String(repeating: chunk, count: 12)
+
+        // Sabotage check: with loopDetectionEnabled=false the guard must NOT fire.
+        consumer.loopDetectionEnabled = false
+        XCTAssertFalse(
+            consumer.shouldStopForLoop(content: thinkingAccumulator),
+            "shouldStopForLoop must return false when loop detection is disabled"
+        )
+
+        // Real assertion: with detection enabled the repetitive content must trip the guard.
+        consumer.loopDetectionEnabled = true
+        XCTAssertTrue(
+            consumer.shouldStopForLoop(content: thinkingAccumulator),
+            "shouldStopForLoop must return true for repetitive thinking content"
+        )
+    }
+
     // MARK: - Normal output not stopped
 
     func test_normalOutput_completesWithoutStopping() async {

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # scripts/fuzz.sh — Run the BaseChatFuzz harness with a friendly preflight.
 #
-# Default behaviour (no args): runs `swift run --traits Fuzz,MLX,Llama fuzz-chat --minutes 5` against
+# Default behaviour (no args): runs `swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat --minutes 5` against
 # Ollama. Discovers which backends are usable and prints a one-line summary
 # before kicking off the harness. Forwards all CLI args straight through to
 # `fuzz-chat`, with one local extension:
@@ -22,15 +22,15 @@ for arg in "$@"; do
         --with-mlx) WITH_MLX=1 ;;
         -h|--help)
             cd "$PACKAGE_DIR"
-            echo "scripts/fuzz.sh — wrapper around \`swift run --traits Fuzz,MLX,Llama fuzz-chat\`"
+            echo "scripts/fuzz.sh — wrapper around \`swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat\`"
             echo ""
             echo "Local flags:"
             echo "  --with-mlx   Also run the MLX XCTest fuzz suite via xcodebuild"
             echo "  -h, --help   Show this help and forward to fuzz-chat -h"
             echo ""
-            echo "Forwarding to: swift run --traits Fuzz,MLX,Llama fuzz-chat -h"
+            echo "Forwarding to: swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat -h"
             echo "─────────────────────────────────────────────────────────────"
-            swift run --traits Fuzz,MLX,Llama fuzz-chat -h || true
+            swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat -h || true
             exit 0
             ;;
         *) FORWARDED_ARGS+=("$arg") ;;
@@ -81,7 +81,7 @@ fi
 
 # ── Default budget: 5 minutes if the caller passed no time/iteration flag. ───
 HAS_BUDGET=0
-for arg in "${FORWARDED_ARGS[@]:-}"; do
+for arg in "${FORWARDED_ARGS[@]+"${FORWARDED_ARGS[@]}"}"; do
     case "$arg" in
         --minutes|--minutes=*|--iterations|--iterations=*|--single)
             HAS_BUDGET=1 ;;
@@ -89,17 +89,17 @@ for arg in "${FORWARDED_ARGS[@]:-}"; do
 done
 
 if [[ $HAS_BUDGET -eq 0 ]]; then
-    FORWARDED_ARGS=("--minutes" "5" "${FORWARDED_ARGS[@]:-}")
+    FORWARDED_ARGS=("--minutes" "5" "${FORWARDED_ARGS[@]+"${FORWARDED_ARGS[@]}"}")
 fi
 
 cd "$PACKAGE_DIR"
 
 echo ""
-echo "Running: swift run --traits Fuzz,MLX,Llama fuzz-chat ${FORWARDED_ARGS[*]:-}"
+echo "Running: swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat ${FORWARDED_ARGS[*]+"${FORWARDED_ARGS[*]}"}"
 echo ""
 
 set +e
-swift run --traits Fuzz,MLX,Llama fuzz-chat "${FORWARDED_ARGS[@]:-}"
+swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat "${FORWARDED_ARGS[@]+"${FORWARDED_ARGS[@]}"}"
 SWIFT_EXIT=$?
 set -e
 


### PR DESCRIPTION
## Summary

Three bugs, all introduced by the Ollama/CloudSaaS trait split that landed in v0.11.3 (#724), plus a live loop-guard gap surfaced by today's fuzz run.

### Commit 1 — `fix(fuzz): add Ollama trait to fuzz.sh + fix empty-arg expansion`

**`FuzzChatCLI.swift` trait mismatch.** `OllamaFuzzFactory` is gated `#if Fuzz && Ollama` but its call site (`makeOllamaFactory` and the `.ollama` switch case) was only guarded by `#if Fuzz`. With the Ollama trait absent from the build, the compiler couldn't find `OllamaFuzzFactory` and the binary never built.

**`scripts/fuzz.sh` missing `Ollama` trait.** The script invoked `swift run --traits Fuzz,MLX,Llama`. Since `Ollama` was removed from default traits in the same split, the Ollama backend path was never reachable at runtime even when Ollama was running locally.

**`scripts/fuzz.sh` blank argument.** `"${FORWARDED_ARGS[@]:-}"` on an empty array expands to a single empty string. `fuzz-chat` saw the blank token as an unknown argument and exited 2. Fixed with `"${FORWARDED_ARGS[@]+"${FORWARDED_ARGS[@]}"}"`  — the `+` form expands to nothing when the array is empty.

### Commit 2 — `fix(inference): extend loop guard to thinking buffer`

`GenerationCoordinator` already calls `consumer.shouldStopForLoop(content:)` on the visible content accumulator and breaks the event loop when a rendered-loop fires. The identical check was never applied to `thinkingAccumulator`. A model looping inside its `<think>` block runs to token-budget exhaustion without the guard firing.

Added `shouldStopForLoop(content: thinkingAccumulator)` in the `.appendThinkingText` batcher-flush block, mirroring the existing rendered-loop check. Caught by the fuzz harness: finding `748815b0da2e` (`qwen3.5:4b`, `looping/thinking-loop`).

New test: `test_thinkingAccumulator_loopDetection_firesOnRepetitiveContent` in `ChatViewModelLoopDetectionTests` — all 4 tests in the suite pass.

## Test plan

- [x] `swift test --filter BaseChatUITests.ChatViewModelLoopDetectionTests --disable-default-traits` — 4/4 pass
- [x] `scripts/fuzz.sh` — builds cleanly, runs 5-minute Ollama campaign, exits 0
- [ ] CI: `BaseChatUITests` + full suite

Closes fuzz finding `748815b0da2e`.