### PR TITLE
feat(mcp): map MCPError to ToolResult.ErrorKind

### DIFF
--- a/Sources/BaseChatMCP/MCPErrorMapping.swift
+++ b/Sources/BaseChatMCP/MCPErrorMapping.swift
@@ -1,0 +1,62 @@
+import Foundation
+import BaseChatInference
+
+/// Maps an ``MCPError`` to the framework's unified ``ToolResult/ErrorKind``.
+///
+/// Used by ``MCPToolExecutor`` (and any future MCP-aware dispatch site) so that
+/// MCP tool failures surface to backends and orchestrators with the same
+/// taxonomy as native tool errors. Without this mapping, MCP failures would be
+/// second-class citizens: the model would see only a string, not a typed
+/// failure class it can reason about.
+///
+/// The switch is intentionally exhaustive — there is no `default:` clause —
+/// so adding a new ``MCPError`` case forces a compile error here, prompting
+/// the author to choose the right ``ToolResult/ErrorKind`` rather than
+/// silently inheriting `.permanent`.
+package func errorKind(for error: MCPError) -> ToolResult.ErrorKind {
+    switch error {
+    case .toolNotFound:
+        return .unknownTool
+    case .requestTimeout:
+        return .timeout
+    case .cancelled:
+        return .cancelled
+    case .authorizationRequired,
+         .authorizationFailed,
+         .unauthorized:
+        return .permissionDenied
+    case .transportClosed,
+         .transportFailure,
+         .networkUnavailable,
+         .backgroundedDuringDispatch:
+        return .transient
+    case .protocolError(let code, _, _):
+        // JSON-RPC reserved error codes carry stable semantics:
+        //   -32601 Method not found  → caller named a tool the server doesn't expose
+        //   -32602 Invalid params    → arguments failed schema/type checking
+        // Anything else is a server-side failure with no recovery path the
+        // model can act on, so report it as permanent.
+        switch code {
+        case -32601:
+            return .unknownTool
+        case -32602:
+            return .invalidArguments
+        default:
+            return .permanent
+        }
+    case .unsupportedProtocolVersion,
+         .malformedMetadata,
+         .issuerMismatch,
+         .dcrFailed,
+         .ssrfBlocked,
+         .tooManyTools,
+         .oversizeContent,
+         .oversizeMessage,
+         .failed:
+        // No clean ErrorKind match exists for these — they are protocol or
+        // configuration-level failures that the model cannot recover from by
+        // adjusting its arguments. Treat as .permanent until PR-F introduces
+        // a richer taxonomy. Do NOT add a new ErrorKind case here.
+        return .permanent
+    }
+}

--- a/Sources/BaseChatMCP/MCPToolExecutor.swift
+++ b/Sources/BaseChatMCP/MCPToolExecutor.swift
@@ -69,7 +69,7 @@ public final class MCPToolExecutor: ToolExecutor, @unchecked Sendable {
             return ToolResult(
                 callId: "",
                 content: Self.sanitize(Self.message(for: error)),
-                errorKind: Self.errorKind(for: error)
+                errorKind: errorKind(for: error)
             )
         } catch {
             return ToolResult(callId: "", content: Self.sanitize(error.localizedDescription), errorKind: .permanent)
@@ -107,32 +107,6 @@ public final class MCPToolExecutor: ToolExecutor, @unchecked Sendable {
             if text.isEmpty == false { return text }
         }
         return jsonString(from: value)
-    }
-
-    private static func errorKind(for error: MCPError) -> ToolResult.ErrorKind {
-        switch error {
-        case .toolNotFound:
-            return .unknownTool
-        case .requestTimeout:
-            return .timeout
-        case .cancelled:
-            return .cancelled
-        case .authorizationRequired, .authorizationFailed, .unauthorized:
-            return .permissionDenied
-        case .transportClosed, .transportFailure, .networkUnavailable, .backgroundedDuringDispatch:
-            return .transient
-        case .protocolError(let code, _, _):
-            switch code {
-            case -32601:
-                return .unknownTool
-            case -32602:
-                return .invalidArguments
-            default:
-                return .permanent
-            }
-        default:
-            return .permanent
-        }
     }
 
     private static func message(for error: MCPError) -> String {

--- a/Tests/BaseChatMCPTests/MCPErrorMappingTests.swift
+++ b/Tests/BaseChatMCPTests/MCPErrorMappingTests.swift
@@ -126,33 +126,54 @@ final class MCPErrorMappingTests: XCTestCase {
 
     /// Forces a compile error if a new MCPError case is added without updating
     /// the mapping tests. Mirrors the exhaustive switch in MCPErrorMapping.swift.
+    ///
+    /// The switch has no `default:` clause, so adding a new ``MCPError`` case
+    /// breaks compilation here until a corresponding `errorKind(for:)` call is
+    /// added — the same compile-time pressure the production mapper relies on.
     func test_exhaustiveCaseCoverage_compileTimeMarker() {
-        let allCases: [MCPError] = [
-            .transportClosed,
-            .transportFailure(""),
-            .protocolError(code: 0, message: "", data: nil),
-            .requestTimeout,
-            .unsupportedProtocolVersion(server: "", client: ""),
-            .authorizationRequired(MCPAuthorizationRequest(serverID: UUID())),
-            .authorizationFailed(""),
-            .dcrFailed(""),
-            .malformedMetadata(""),
-            .issuerMismatch(expected: URL(string: "https://a")!, actual: URL(string: "https://b")!),
-            .ssrfBlocked(URL(string: "https://c")!),
-            .tooManyTools(0),
-            .toolNotFound(""),
-            .oversizeContent(0),
-            .oversizeMessage(0),
-            .networkUnavailable,
-            .unauthorized,
-            .failed(""),
-            .backgroundedDuringDispatch,
-            .cancelled
-        ]
-        for error in allCases {
-            // Just confirm the function returns a value for every case.
-            _ = errorKind(for: error)
+        let error: MCPError = .transportClosed
+
+        switch error {
+        case .transportClosed:
+            _ = errorKind(for: .transportClosed)
+        case .transportFailure(let message):
+            _ = errorKind(for: .transportFailure(message))
+        case .protocolError(let code, let message, let data):
+            _ = errorKind(for: .protocolError(code: code, message: message, data: data))
+        case .requestTimeout:
+            _ = errorKind(for: .requestTimeout)
+        case .unsupportedProtocolVersion(let server, let client):
+            _ = errorKind(for: .unsupportedProtocolVersion(server: server, client: client))
+        case .authorizationRequired(let request):
+            _ = errorKind(for: .authorizationRequired(request))
+        case .authorizationFailed(let reason):
+            _ = errorKind(for: .authorizationFailed(reason))
+        case .dcrFailed(let reason):
+            _ = errorKind(for: .dcrFailed(reason))
+        case .malformedMetadata(let reason):
+            _ = errorKind(for: .malformedMetadata(reason))
+        case .issuerMismatch(let expected, let actual):
+            _ = errorKind(for: .issuerMismatch(expected: expected, actual: actual))
+        case .ssrfBlocked(let url):
+            _ = errorKind(for: .ssrfBlocked(url))
+        case .tooManyTools(let count):
+            _ = errorKind(for: .tooManyTools(count))
+        case .toolNotFound(let toolName):
+            _ = errorKind(for: .toolNotFound(toolName))
+        case .oversizeContent(let size):
+            _ = errorKind(for: .oversizeContent(size))
+        case .oversizeMessage(let size):
+            _ = errorKind(for: .oversizeMessage(size))
+        case .networkUnavailable:
+            _ = errorKind(for: .networkUnavailable)
+        case .unauthorized:
+            _ = errorKind(for: .unauthorized)
+        case .failed(let reason):
+            _ = errorKind(for: .failed(reason))
+        case .backgroundedDuringDispatch:
+            _ = errorKind(for: .backgroundedDuringDispatch)
+        case .cancelled:
+            _ = errorKind(for: .cancelled)
         }
-        XCTAssertEqual(allCases.count, 20)
     }
 }

--- a/Tests/BaseChatMCPTests/MCPErrorMappingTests.swift
+++ b/Tests/BaseChatMCPTests/MCPErrorMappingTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import XCTest
+@testable import BaseChatMCP
+import BaseChatInference
+
+final class MCPErrorMappingTests: XCTestCase {
+
+    // MARK: - Direct case → ErrorKind mappings
+
+    func test_toolNotFound_mapsTo_unknownTool() {
+        XCTAssertEqual(errorKind(for: .toolNotFound("search")), .unknownTool)
+    }
+
+    func test_requestTimeout_mapsTo_timeout() {
+        XCTAssertEqual(errorKind(for: .requestTimeout), .timeout)
+    }
+
+    func test_cancelled_mapsTo_cancelled() {
+        XCTAssertEqual(errorKind(for: .cancelled), .cancelled)
+    }
+
+    func test_authorizationRequired_mapsTo_permissionDenied() {
+        let request = MCPAuthorizationRequest(serverID: UUID())
+        XCTAssertEqual(errorKind(for: .authorizationRequired(request)), .permissionDenied)
+    }
+
+    func test_authorizationFailed_mapsTo_permissionDenied() {
+        XCTAssertEqual(errorKind(for: .authorizationFailed("denied")), .permissionDenied)
+    }
+
+    func test_unauthorized_mapsTo_permissionDenied() {
+        XCTAssertEqual(errorKind(for: .unauthorized), .permissionDenied)
+    }
+
+    func test_transportClosed_mapsTo_transient() {
+        XCTAssertEqual(errorKind(for: .transportClosed), .transient)
+    }
+
+    func test_transportFailure_mapsTo_transient() {
+        XCTAssertEqual(errorKind(for: .transportFailure("boom")), .transient)
+    }
+
+    func test_networkUnavailable_mapsTo_transient() {
+        XCTAssertEqual(errorKind(for: .networkUnavailable), .transient)
+    }
+
+    func test_backgroundedDuringDispatch_mapsTo_transient() {
+        XCTAssertEqual(errorKind(for: .backgroundedDuringDispatch), .transient)
+    }
+
+    // MARK: - Protocol error code switch
+
+    func test_protocolError_methodNotFound_mapsTo_unknownTool() {
+        let error = MCPError.protocolError(code: -32601, message: "method not found", data: nil)
+        XCTAssertEqual(errorKind(for: error), .unknownTool)
+    }
+
+    func test_protocolError_invalidParams_mapsTo_invalidArguments() {
+        let error = MCPError.protocolError(code: -32602, message: "invalid params", data: nil)
+        XCTAssertEqual(errorKind(for: error), .invalidArguments)
+    }
+
+    func test_protocolError_internalError_mapsTo_permanent() {
+        let error = MCPError.protocolError(code: -32603, message: "internal error", data: nil)
+        XCTAssertEqual(errorKind(for: error), .permanent)
+    }
+
+    func test_protocolError_parseError_mapsTo_permanent() {
+        let error = MCPError.protocolError(code: -32700, message: "parse error", data: nil)
+        XCTAssertEqual(errorKind(for: error), .permanent)
+    }
+
+    func test_protocolError_invalidRequest_mapsTo_permanent() {
+        let error = MCPError.protocolError(code: -32600, message: "invalid request", data: nil)
+        XCTAssertEqual(errorKind(for: error), .permanent)
+    }
+
+    func test_protocolError_serverDefinedCode_mapsTo_permanent() {
+        let error = MCPError.protocolError(code: 1, message: "custom", data: nil)
+        XCTAssertEqual(errorKind(for: error), .permanent)
+    }
+
+    // MARK: - Permanent fallthrough cases
+
+    func test_unsupportedProtocolVersion_mapsTo_permanent() {
+        let error = MCPError.unsupportedProtocolVersion(server: "2025-03-26", client: "2024-11-05")
+        XCTAssertEqual(errorKind(for: error), .permanent)
+    }
+
+    func test_malformedMetadata_mapsTo_permanent() {
+        XCTAssertEqual(errorKind(for: .malformedMetadata("bad json")), .permanent)
+    }
+
+    func test_issuerMismatch_mapsTo_permanent() {
+        let expected = URL(string: "https://expected.example.com")!
+        let actual = URL(string: "https://actual.example.com")!
+        XCTAssertEqual(errorKind(for: .issuerMismatch(expected: expected, actual: actual)), .permanent)
+    }
+
+    func test_dcrFailed_mapsTo_permanent() {
+        XCTAssertEqual(errorKind(for: .dcrFailed("registration rejected")), .permanent)
+    }
+
+    func test_ssrfBlocked_mapsTo_permanent() {
+        let url = URL(string: "http://169.254.169.254/")!
+        XCTAssertEqual(errorKind(for: .ssrfBlocked(url)), .permanent)
+    }
+
+    func test_tooManyTools_mapsTo_permanent() {
+        XCTAssertEqual(errorKind(for: .tooManyTools(500)), .permanent)
+    }
+
+    func test_oversizeContent_mapsTo_permanent() {
+        XCTAssertEqual(errorKind(for: .oversizeContent(1_000_000)), .permanent)
+    }
+
+    func test_oversizeMessage_mapsTo_permanent() {
+        XCTAssertEqual(errorKind(for: .oversizeMessage(1_000_000)), .permanent)
+    }
+
+    func test_failed_mapsTo_permanent() {
+        XCTAssertEqual(errorKind(for: .failed("unspecified")), .permanent)
+    }
+
+    // MARK: - Coverage marker
+
+    /// Forces a compile error if a new MCPError case is added without updating
+    /// the mapping tests. Mirrors the exhaustive switch in MCPErrorMapping.swift.
+    func test_exhaustiveCaseCoverage_compileTimeMarker() {
+        let allCases: [MCPError] = [
+            .transportClosed,
+            .transportFailure(""),
+            .protocolError(code: 0, message: "", data: nil),
+            .requestTimeout,
+            .unsupportedProtocolVersion(server: "", client: ""),
+            .authorizationRequired(MCPAuthorizationRequest(serverID: UUID())),
+            .authorizationFailed(""),
+            .dcrFailed(""),
+            .malformedMetadata(""),
+            .issuerMismatch(expected: URL(string: "https://a")!, actual: URL(string: "https://b")!),
+            .ssrfBlocked(URL(string: "https://c")!),
+            .tooManyTools(0),
+            .toolNotFound(""),
+            .oversizeContent(0),
+            .oversizeMessage(0),
+            .networkUnavailable,
+            .unauthorized,
+            .failed(""),
+            .backgroundedDuringDispatch,
+            .cancelled
+        ]
+        for error in allCases {
+            // Just confirm the function returns a value for every case.
+            _ = errorKind(for: error)
+        }
+        XCTAssertEqual(allCases.count, 20)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `MCPErrorMapping.swift` with `package func errorKind(for: MCPError) -> ToolResult.ErrorKind`, closing the gap where MCP tool failures were second-class (raw throws) vs native tool errors (typed `ErrorKind`)
- Exhaustive `switch` with no `default` clause — adding a new `MCPError` case will produce a compile error, forcing an explicit mapping decision
- JSON-RPC reserved codes `-32601`/`-32602` mapped individually to `.unknownTool`/`.invalidArguments`; transport failures → `.transient`; auth failures → `.permissionDenied`
- Updates `MCPToolExecutor` to route failures through the new mapper

Part of the cross-backend tool-calling unification series (#753), Wave 1.

## Test plan

- [x] `swift test --filter BaseChatMCPTests --disable-default-traits` — all cases pass including new `MCPErrorMappingTests`
- [x] Full pre-push checklist (all 9 suites) — 0 failures
- [x] Sabotage verified: swapping 3 mapping pairs each caused the corresponding test to fail