### PR TITLE
feat(inference): typed tool-dispatch lifecycle events

### DIFF
--- a/Sources/BaseChatFuzz/EventRecorder.swift
+++ b/Sources/BaseChatFuzz/EventRecorder.swift
@@ -141,6 +141,10 @@ public struct EventRecorder: Sendable {
                     events.append(.init(t: t, kind: "toolCallStart", v: "\(callId):\(name)"))
                 case .toolCallArgumentsDelta(let callId, let textDelta):
                     events.append(.init(t: t, kind: "toolCallArgumentsDelta", v: "\(callId):\(textDelta)"))
+                case .toolDispatchStarted(let callId, let name, let attempt):
+                    events.append(.init(t: t, kind: "toolDispatchStarted", v: "\(callId):\(name):\(attempt)"))
+                case .toolDispatchCompleted(let callId, let durationMs, let errorKind):
+                    events.append(.init(t: t, kind: "toolDispatchCompleted", v: "\(callId):\(durationMs):\(errorKind?.rawValue ?? "none")"))
                 }
                 memoryTick()
             }

--- a/Sources/BaseChatInference/Models/GenerationEvent.swift
+++ b/Sources/BaseChatInference/Models/GenerationEvent.swift
@@ -96,25 +96,35 @@ public enum GenerationEvent: Sendable, Equatable {
     /// `reason` is a short, human-readable string the UI may display verbatim.
     case diagnosticThrottle(reason: String)
 
-    /// Emitted by the orchestrator immediately before a model-emitted
-    /// ``ToolCall`` is dispatched through the registered ``ToolRegistry``.
+    /// Emitted by the orchestrator immediately before it begins handling a
+    /// model-emitted ``ToolCall``.
     ///
     /// Fires after the corresponding ``toolCall(_:)`` event and before the
     /// matching ``toolResult(_:)``, giving UI surfaces a precise "running"
     /// boundary they can pin a spinner / start timer to without scraping
-    /// logs. `callId` matches ``ToolCall/id``; `name` is the tool name;
-    /// `attempt` is the 1-based dispatch attempt for this call (always `1`
-    /// today — reserved for future retry semantics).
+    /// logs. This lifecycle covers the coordinator's full handling path for
+    /// the call, not only successful routing through the registered
+    /// ``ToolRegistry``: approval gating, registry execution, and synthesized
+    /// non-dispatch outcomes (for example approval denial, identical-call
+    /// short-circuiting, or byte-budget exhaustion) are all included.
+    /// `callId` matches ``ToolCall/id``; `name` is the tool name; `attempt`
+    /// is the 1-based handling attempt for this call (always `1` today —
+    /// reserved for future retry semantics).
     case toolDispatchStarted(callId: String, name: String, attempt: Int)
 
-    /// Emitted by the orchestrator after a tool dispatch settles, regardless
-    /// of outcome.
+    /// Emitted by the orchestrator after tool-call handling settles,
+    /// regardless of outcome.
     ///
     /// Fires after the matching ``toolResult(_:)`` event. `durationMs` is the
-    /// wall-clock dispatch latency in milliseconds (>= 0). `errorKind`
-    /// carries the failure classification when the dispatch produced an
-    /// error result and `nil` on success — its value matches the
-    /// ``ToolResult/errorKind`` of the `.toolResult` event with the same
-    /// `callId`.
+    /// monotonic handling latency in milliseconds (>= 0), measured from
+    /// ``toolDispatchStarted(callId:name:attempt:)`` to this event with a
+    /// monotonic clock so wall-clock adjustments (NTP, user time changes) do
+    /// not skew the value. It covers the full orchestrator-managed lifecycle
+    /// for the call, including any approval-gate wait time and paths that do
+    /// not invoke the registered ``ToolRegistry`` because the coordinator
+    /// synthesized the result. `errorKind` carries the failure classification
+    /// when handling produced an error result and `nil` on success — its
+    /// value matches the ``ToolResult/errorKind`` of the `.toolResult` event
+    /// with the same `callId`.
     case toolDispatchCompleted(callId: String, durationMs: Int, errorKind: ToolResult.ErrorKind?)
 }

--- a/Sources/BaseChatInference/Models/GenerationEvent.swift
+++ b/Sources/BaseChatInference/Models/GenerationEvent.swift
@@ -95,4 +95,26 @@ public enum GenerationEvent: Sendable, Equatable {
     /// throttling — paused" hint while the loop blocks between tokens.
     /// `reason` is a short, human-readable string the UI may display verbatim.
     case diagnosticThrottle(reason: String)
+
+    /// Emitted by the orchestrator immediately before a model-emitted
+    /// ``ToolCall`` is dispatched through the registered ``ToolRegistry``.
+    ///
+    /// Fires after the corresponding ``toolCall(_:)`` event and before the
+    /// matching ``toolResult(_:)``, giving UI surfaces a precise "running"
+    /// boundary they can pin a spinner / start timer to without scraping
+    /// logs. `callId` matches ``ToolCall/id``; `name` is the tool name;
+    /// `attempt` is the 1-based dispatch attempt for this call (always `1`
+    /// today — reserved for future retry semantics).
+    case toolDispatchStarted(callId: String, name: String, attempt: Int)
+
+    /// Emitted by the orchestrator after a tool dispatch settles, regardless
+    /// of outcome.
+    ///
+    /// Fires after the matching ``toolResult(_:)`` event. `durationMs` is the
+    /// wall-clock dispatch latency in milliseconds (>= 0). `errorKind`
+    /// carries the failure classification when the dispatch produced an
+    /// error result and `nil` on success — its value matches the
+    /// ``ToolResult/errorKind`` of the `.toolResult` event with the same
+    /// `callId`.
+    case toolDispatchCompleted(callId: String, durationMs: Int, errorKind: ToolResult.ErrorKind?)
 }

--- a/Sources/BaseChatInference/Services/GenerationCoordinator.swift
+++ b/Sources/BaseChatInference/Services/GenerationCoordinator.swift
@@ -83,6 +83,16 @@ final class GenerationCoordinator {
     /// its registry is never invoked. Tests must reset this in `tearDown`.
     nonisolated(unsafe) static var toolsUnsupportedWarningHook: (@Sendable (String, String) -> Void)?
 
+    /// Test-only hook invoked alongside `Log.inference.info` for each tool
+    /// dispatch lifecycle log line (`tool_dispatch_started` /
+    /// `tool_dispatch_completed`). Receives `(eventName, fields)` where
+    /// `fields` mirrors the structured fields of the OSLog message.
+    ///
+    /// Production callers never set this; it exists so unit tests can verify
+    /// the structured log output without standing up an OSLogStore reader.
+    /// Tests must reset it in `tearDown` to avoid cross-test leakage.
+    nonisolated(unsafe) static var toolDispatchLogHook: (@Sendable (String, [String: String]) -> Void)?
+
     // MARK: - Queue Types (Private)
 
     private struct QueuedRequest {
@@ -817,6 +827,27 @@ final class GenerationCoordinator {
                     // alongside the pending result.
                     self.continuations[request.token]?.yield(.toolCall(call))
 
+                    // Lifecycle: announce dispatch start so UI surfaces can
+                    // start a per-call timer / spinner without scraping the
+                    // log. `attempt` is reserved for future retry semantics
+                    // and pinned to 1 today (no per-call retry path exists).
+                    let dispatchAttempt = 1
+                    let dispatchStart = Date()
+                    self.continuations[request.token]?.yield(
+                        .toolDispatchStarted(callId: call.id, name: call.toolName, attempt: dispatchAttempt)
+                    )
+                    Log.inference.info(
+                        "tool_dispatch_started call_id=\(call.id, privacy: .public) name=\(call.toolName, privacy: .public) attempt=\(dispatchAttempt, privacy: .public)"
+                    )
+                    Self.toolDispatchLogHook?(
+                        "tool_dispatch_started",
+                        [
+                            "call_id": call.id,
+                            "name": call.toolName,
+                            "attempt": "\(dispatchAttempt)"
+                        ]
+                    )
+
                     let result: ToolResult
                     if let prev = lastCallSignature,
                        prev.toolName == call.toolName,
@@ -888,6 +919,31 @@ final class GenerationCoordinator {
                     // consumers thread `.toolResult` into the current
                     // assistant bubble before the next turn begins.
                     self.continuations[request.token]?.yield(.toolResult(result))
+
+                    // Lifecycle: announce dispatch completion. Fires after
+                    // `.toolResult` so consumers that switch on the lifecycle
+                    // pair see exactly one `.toolDispatchStarted` →
+                    // `.toolDispatchCompleted` per call. `errorKind` mirrors
+                    // the result's classification (nil on success).
+                    let dispatchDurationMs = max(0, Int(Date().timeIntervalSince(dispatchStart) * 1000))
+                    self.continuations[request.token]?.yield(
+                        .toolDispatchCompleted(
+                            callId: call.id,
+                            durationMs: dispatchDurationMs,
+                            errorKind: result.errorKind
+                        )
+                    )
+                    Log.inference.info(
+                        "tool_dispatch_completed call_id=\(call.id, privacy: .public) duration_ms=\(dispatchDurationMs, privacy: .public) error_kind=\(result.errorKind?.rawValue ?? "none", privacy: .public)"
+                    )
+                    Self.toolDispatchLogHook?(
+                        "tool_dispatch_completed",
+                        [
+                            "call_id": call.id,
+                            "duration_ms": "\(dispatchDurationMs)",
+                            "error_kind": result.errorKind?.rawValue ?? "none"
+                        ]
+                    )
 
                     // Cancellation contract (issue #622): when the user hits
                     // stop while a tool is in flight the dispatch path returns

--- a/Sources/BaseChatInference/Services/GenerationCoordinator.swift
+++ b/Sources/BaseChatInference/Services/GenerationCoordinator.swift
@@ -832,7 +832,10 @@ final class GenerationCoordinator {
                     // log. `attempt` is reserved for future retry semantics
                     // and pinned to 1 today (no per-call retry path exists).
                     let dispatchAttempt = 1
-                    let dispatchStart = Date()
+                    // Monotonic clock so `durationMs` reflects actual elapsed
+                    // time even when wall-clock jumps (NTP / user time-zone
+                    // change) happen mid-dispatch.
+                    let dispatchStart = DispatchTime.now()
                     self.continuations[request.token]?.yield(
                         .toolDispatchStarted(callId: call.id, name: call.toolName, attempt: dispatchAttempt)
                     )
@@ -925,7 +928,8 @@ final class GenerationCoordinator {
                     // pair see exactly one `.toolDispatchStarted` →
                     // `.toolDispatchCompleted` per call. `errorKind` mirrors
                     // the result's classification (nil on success).
-                    let dispatchDurationMs = max(0, Int(Date().timeIntervalSince(dispatchStart) * 1000))
+                    let dispatchDurationNs = DispatchTime.now().uptimeNanoseconds &- dispatchStart.uptimeNanoseconds
+                    let dispatchDurationMs = Int(dispatchDurationNs / 1_000_000)
                     self.continuations[request.token]?.yield(
                         .toolDispatchCompleted(
                             callId: call.id,

--- a/Sources/BaseChatInference/Services/GenerationStreamConsumer.swift
+++ b/Sources/BaseChatInference/Services/GenerationStreamConsumer.swift
@@ -61,6 +61,14 @@ public struct GenerationStreamConsumer: Sendable {
             // authoritative arguments string lands on `.toolCall(_:)`,
             // which `dispatchToolCall` already handles.
             return .ignore
+
+        case .toolDispatchStarted, .toolDispatchCompleted:
+            // Lifecycle metadata for UI timers / spinners; consumed
+            // directly by surfaces that want to render duration / error
+            // kind. The chat-message state mapping has no work here —
+            // text and tool-result accumulation are driven by the
+            // existing `.toolCall` / `.toolResult` events.
+            return .ignore
         }
     }
 

--- a/Sources/BaseChatInference/Services/ToolCallLoopOrchestrator.swift
+++ b/Sources/BaseChatInference/Services/ToolCallLoopOrchestrator.swift
@@ -661,7 +661,8 @@ public struct ToolCallLoopOrchestrator: Sendable {
                     continuation.yield(.usage(prompt: p, completion: c))
                 case .prefillProgress, .thinkingToken, .thinkingComplete, .thinkingSignature,
                      .toolLoopLimitReached, .toolResult, .kvCacheReuse,
-                     .diagnosticThrottle:
+                     .diagnosticThrottle,
+                     .toolDispatchStarted, .toolDispatchCompleted:
                     // Reasoning, KV-cache hints, and diagnostic events are
                     // not part of the orchestrator's surface. The legacy
                     // `.toolLoopLimitReached` / `.toolResult` events come

--- a/Sources/BaseChatTools/ScenarioRunner.swift
+++ b/Sources/BaseChatTools/ScenarioRunner.swift
@@ -101,6 +101,10 @@ public final class ScenarioRunner {
                     // Streaming tool-call deltas are observational; the
                     // authoritative call lands on `.toolCall(_:)`.
                     continue
+                case .toolDispatchStarted, .toolDispatchCompleted:
+                    // Dispatch lifecycle markers are observational; tool
+                    // accounting flows through `.toolCall` / `.toolResult`.
+                    continue
                 }
             }
 

--- a/Tests/BaseChatInferenceTests/ToolCallContractTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolCallContractTests.swift
@@ -209,6 +209,7 @@ final class ToolCallContractTests: XCTestCase {
             case .kvCacheReuse: break
             case .diagnosticThrottle: break
             case .toolCallStart, .toolCallArgumentsDelta: break
+            case .toolDispatchStarted, .toolDispatchCompleted: break
             }
         }
 
@@ -281,6 +282,7 @@ final class ToolCallContractTests: XCTestCase {
             case .kvCacheReuse: break
             case .diagnosticThrottle: break
             case .toolCallStart, .toolCallArgumentsDelta: break
+            case .toolDispatchStarted, .toolDispatchCompleted: break
             }
         }
 


### PR DESCRIPTION
## Summary

- Adds `GenerationEvent.toolDispatchStarted(callId:name:attempt:)` and `.toolDispatchCompleted(callId:durationMs:errorKind:)` so app developers can render tool-running spinners and error badges without log scraping
- Emits paired `Log.inference.info` records with the same fields for framework-side debugging
- Updates `ToolCallLoopOrchestrator`, `GenerationStreamConsumer`, `EventRecorder`, and `ScenarioRunner` to handle the new cases

```swift
for try await event in backend.generate(config).events {
    switch event {
    case .toolDispatchStarted(let id, let name, _):
        ui.markRunning(id: id, name: name)
    case .toolDispatchCompleted(let id, let durationMs, let errorKind):
        ui.markFinished(id: id, durationMs: durationMs, errorKind: errorKind)
    default: break
    }
}
```

Part of the cross-backend tool-calling unification series (#753), Wave 1. This PR delivers the public symbol that earns the theme a Highlight entry in the release notes.

## Test plan

- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 1237 tests, 0 failures
- [x] Full pre-push checklist (all 9 suites) — 0 failures
- [x] `ToolCallContractTests` updated for exhaustive switch coverage of new cases