### PR TITLE
feat(demo): tool-call error scenarios — invalid args, rate-limit retry, MCP failure

### DIFF
--- a/Example/BaseChatDemo.xcodeproj/project.pbxproj
+++ b/Example/BaseChatDemo.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		BF1008000000000000000000 /* AppIntentUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11009000000000000000000 /* AppIntentUITests.swift */; };
 		BF1009000000000000000000 /* DemoScenarioUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11010000000000000000000 /* DemoScenarioUITests.swift */; };
 		BF0014000000000000000000 /* WriteFileTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10012000000000000000000 /* WriteFileTool.swift */; };
+		BF0040000000000000000000 /* FailureDemoTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10040000000000000000000 /* FailureDemoTools.swift */; };
 		BF0015000000000000000000 /* DemoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10013000000000000000000 /* DemoScenario.swift */; };
 		BF0016000000000000000000 /* DemoScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10014000000000000000000 /* DemoScenarios.swift */; };
 		BF0017000000000000000000 /* DemoScenarios+Scripts.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10015000000000000000000 /* DemoScenarios+Scripts.swift */; };
@@ -102,6 +103,7 @@
 		F11009000000000000000000 /* AppIntentUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntentUITests.swift; sourceTree = "<group>"; };
 		F11010000000000000000000 /* DemoScenarioUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoScenarioUITests.swift; sourceTree = "<group>"; };
 		F10012000000000000000000 /* WriteFileTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteFileTool.swift; sourceTree = "<group>"; };
+		F10040000000000000000000 /* FailureDemoTools.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailureDemoTools.swift; sourceTree = "<group>"; };
 		F10013000000000000000000 /* DemoScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scenarios/DemoScenario.swift; sourceTree = "<group>"; };
 		F10014000000000000000000 /* DemoScenarios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scenarios/DemoScenarios.swift; sourceTree = "<group>"; };
 		F10015000000000000000000 /* DemoScenarios+Scripts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Scenarios/DemoScenarios+Scripts.swift"; sourceTree = "<group>"; };
@@ -205,6 +207,7 @@
 				F10011000000000000000000 /* BaseChatDemo.entitlements */,
 				F10021000000000000000000 /* Info.plist */,
 				F10012000000000000000000 /* WriteFileTool.swift */,
+				F10040000000000000000000 /* FailureDemoTools.swift */,
 				F10013000000000000000000 /* DemoScenario.swift */,
 				F10014000000000000000000 /* DemoScenarios.swift */,
 				F10015000000000000000000 /* DemoScenarios+Scripts.swift */,

--- a/Example/BaseChatDemo.xcodeproj/project.pbxproj
+++ b/Example/BaseChatDemo.xcodeproj/project.pbxproj
@@ -417,6 +417,7 @@
 				BF0001000000000000000000 /* BaseChatDemoApp.swift in Sources */,
 				BF0002000000000000000000 /* DemoContentView.swift in Sources */,
 				BF0007000000000000000000 /* DemoTools.swift in Sources */,
+				BF0040000000000000000000 /* FailureDemoTools.swift in Sources */,
 				BF0008000000000000000000 /* ChatEmptyStateView.swift in Sources */,
 				BF0009000000000000000000 /* ToolApprovalSheet.swift in Sources */,
 				BF0010000000000000000000 /* ToolPolicyView.swift in Sources */,

--- a/Example/BaseChatDemo/DemoTools.swift
+++ b/Example/BaseChatDemo/DemoTools.swift
@@ -22,7 +22,7 @@ enum DemoTools {
         "list_dir",
         "sample_repo_search",
         "write_file"
-    ]
+    ] + FailureDemoTools.names
 
     /// Registers the full reference toolset on `registry`.
     ///
@@ -45,6 +45,7 @@ enum DemoTools {
         registry.register(ListDirTool.makeExecutor(root: root))
         registry.register(SampleRepoSearchTool.makeExecutor(root: root))
         registry.register(WriteFileTool.makeExecutor(root: root))
+        FailureDemoTools.register(on: registry)
     }
 
     /// Restores `registry` to the baseline tool set.

--- a/Example/BaseChatDemo/FailureDemoTools.swift
+++ b/Example/BaseChatDemo/FailureDemoTools.swift
@@ -7,10 +7,10 @@ import BaseChatInference
 /// These exist purely so the empty-state scenario picker can show the
 /// framework's error story (invalid args, transient rate limits, MCP
 /// failures) end-to-end. Production code should not use them — the
-/// fakeRateLimited tool is intentionally non-deterministic and the
-/// fakeMCPLookup tool always fails.
+/// fakeRateLimited tool is stateful (failing on the first call and
+/// succeeding thereafter) and the fakeMCPLookup tool always fails.
 ///
-/// All three are registered alongside the baseline reference tools by
+/// Both are registered alongside the baseline reference tools by
 /// ``DemoTools/register(on:root:)`` so the scripted scenarios can dispatch
 /// them without bespoke `configure` closures.
 enum FailureDemoTools {
@@ -85,6 +85,24 @@ enum FakeRateLimitedTool {
         let state: CallState
 
         func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+            // Validate arguments first so malformed input always returns the
+            // canonical `.invalidArguments` ErrorKind, regardless of which
+            // attempt this is. Otherwise the first call would mask decode
+            // failures behind `.rateLimited`, and later calls would throw
+            // (which `ToolRegistry` classifies as `.permanent`) — neither
+            // matches the "invalid args" demo story.
+            let args: Args
+            do {
+                let data = try JSONEncoder().encode(arguments)
+                args = try JSONDecoder().decode(Args.self, from: data)
+            } catch {
+                return ToolResult(
+                    callId: "",
+                    content: "invalid arguments: \(error.localizedDescription)",
+                    errorKind: .invalidArguments
+                )
+            }
+
             let attempt = await state.recordCall()
             if attempt == 1 {
                 return ToolResult(
@@ -94,8 +112,6 @@ enum FakeRateLimitedTool {
                 )
             }
 
-            let data = try JSONEncoder().encode(arguments)
-            let args = try JSONDecoder().decode(Args.self, from: data)
             let result = Result(
                 result: "Lookup for '\(args.query)' succeeded.",
                 attempt: attempt

--- a/Example/BaseChatDemo/FailureDemoTools.swift
+++ b/Example/BaseChatDemo/FailureDemoTools.swift
@@ -1,0 +1,162 @@
+import Foundation
+import BaseChatInference
+
+/// Demo-only tools that exercise the unified `ToolResult.ErrorKind`
+/// classification + retry behaviour from the orchestration loop.
+///
+/// These exist purely so the empty-state scenario picker can show the
+/// framework's error story (invalid args, transient rate limits, MCP
+/// failures) end-to-end. Production code should not use them — the
+/// fakeRateLimited tool is intentionally non-deterministic and the
+/// fakeMCPLookup tool always fails.
+///
+/// All three are registered alongside the baseline reference tools by
+/// ``DemoTools/register(on:root:)`` so the scripted scenarios can dispatch
+/// them without bespoke `configure` closures.
+enum FailureDemoTools {
+
+    /// Names of the tools registered by ``register(on:)``. Mirrors
+    /// ``DemoTools/baselineNames`` so the scenario runner's reset-to-defaults
+    /// path drops them between scenarios.
+    static let names: [String] = [
+        "fakeRateLimited",
+        "fakeMCPLookup"
+    ]
+
+    /// Registers the failure-path tools on `registry`.
+    @MainActor
+    static func register(on registry: ToolRegistry) {
+        registry.register(FakeRateLimitedTool.makeExecutor())
+        registry.register(FakeMCPLookupTool.makeExecutor())
+    }
+}
+
+// MARK: - FakeRateLimitedTool
+
+/// Stateful demo tool that fails with `.rateLimited` on the first call and
+/// succeeds on every subsequent call.
+///
+/// Used by the `rate-limited-retry` scenario to demonstrate the orchestrator
+/// feeding a transient error back to the model so it can retry within the
+/// same turn (governed by `GenerationConfig.maxToolIterations`).
+enum FakeRateLimitedTool {
+
+    struct Args: Decodable, Sendable {
+        let query: String
+    }
+
+    struct Result: Encodable, Sendable {
+        let result: String
+        let attempt: Int
+    }
+
+    static func makeExecutor() -> any ToolExecutor {
+        let definition = ToolDefinition(
+            name: "fakeRateLimited",
+            description: "Fetches a fact about the supplied query. Occasionally rate-limits — when it returns a rateLimited error, retry the same call to recover.",
+            parameters: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "query": .object([
+                        "type": .string("string"),
+                        "description": .string("Subject to look up.")
+                    ])
+                ]),
+                "required": .array([.string("query")])
+            ])
+        )
+        return RateLimitedExecutor(definition: definition, state: CallState())
+    }
+
+    /// Mutable counter shared between calls. Wrapped in an actor so the demo
+    /// tool stays Sendable without leaning on locks.
+    actor CallState {
+        private var calls: Int = 0
+
+        /// Returns the post-increment call count (1-indexed).
+        func recordCall() -> Int {
+            calls += 1
+            return calls
+        }
+    }
+
+    private struct RateLimitedExecutor: ToolExecutor {
+        let definition: ToolDefinition
+        let state: CallState
+
+        func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+            let attempt = await state.recordCall()
+            if attempt == 1 {
+                return ToolResult(
+                    callId: "",
+                    content: "rate limit exceeded — retry shortly",
+                    errorKind: .rateLimited
+                )
+            }
+
+            let data = try JSONEncoder().encode(arguments)
+            let args = try JSONDecoder().decode(Args.self, from: data)
+            let result = Result(
+                result: "Lookup for '\(args.query)' succeeded.",
+                attempt: attempt
+            )
+            let encoded = try JSONEncoder().encode(result)
+            return ToolResult(
+                callId: "",
+                content: String(data: encoded, encoding: .utf8) ?? "",
+                errorKind: nil
+            )
+        }
+    }
+}
+
+// MARK: - FakeMCPLookupTool
+
+/// Demo tool that always fails with `.transient`, simulating an MCP transport
+/// failure (server unreachable, tool not found, etc.).
+///
+/// TODO: replace with MCPError mapping once PR-E (`MCPErrorMapping`) merges.
+/// The PR-E follow-up will swap this for a real MCP tool source whose
+/// transport error is mapped through the canonical mapping helper, but the
+/// scenario must build and run on the current `main` branch — emitting a
+/// hand-rolled `.transient` keeps the demo functional in the meantime.
+enum FakeMCPLookupTool {
+
+    struct Args: Decodable, Sendable {
+        let path: String
+    }
+
+    static func makeExecutor() -> any ToolExecutor {
+        let definition = ToolDefinition(
+            name: "fakeMCPLookup",
+            description: "Looks up a path on a remote MCP service. The remote server is currently unreachable in the demo — call once and report the failure rather than looping.",
+            parameters: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "path": .object([
+                        "type": .string("string"),
+                        "description": .string("Resource path on the MCP service.")
+                    ])
+                ]),
+                "required": .array([.string("path")])
+            ])
+        )
+        return MCPLookupExecutor(definition: definition)
+    }
+
+    private struct MCPLookupExecutor: ToolExecutor {
+        let definition: ToolDefinition
+
+        func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+            // TODO: replace with MCPError mapping once PR-E merges. Until then
+            // we emit `.transient` directly so the scenario shows the
+            // orchestrator's "tool failed, here's the error context" path
+            // without depending on PR-E's not-yet-landed `MCPErrorMapping`.
+            return ToolResult(
+                callId: "",
+                content: "MCP transport failure: connection refused",
+                errorKind: .transient
+            )
+        }
+    }
+}

--- a/Example/BaseChatDemo/Scenarios/DemoScenarios+Scripts.swift
+++ b/Example/BaseChatDemo/Scenarios/DemoScenarios+Scripts.swift
@@ -57,6 +57,44 @@ extension DemoScenarios {
                 ])
             ]
 
+        case invalidArgsRecover.id:
+            // First call divides by zero — CalcTool returns `.invalidArguments`.
+            // Orchestrator threads the error back; the model recovers with a
+            // valid divisor on the second turn before producing prose.
+            return [
+                .toolCall(name: "calc", arguments: #"{"a":100,"op":"/","b":0}"#),
+                .toolCall(name: "calc", arguments: #"{"a":100,"op":"/","b":4}"#),
+                .tokens([
+                    "Dividing ", "by ", "zero ", "isn't ", "defined, ",
+                    "but ", "100 ÷ 4 ", "is ", "25."
+                ])
+            ]
+
+        case rateLimitedRetry.id:
+            // Same call twice — the demo tool's first invocation returns
+            // `.rateLimited`; the second succeeds. Both calls carry identical
+            // arguments to mirror what a well-behaved retry looks like.
+            return [
+                .toolCall(name: "fakeRateLimited", arguments: #"{"query":"BaseChatKit"}"#),
+                .toolCall(name: "fakeRateLimited", arguments: #"{"query":"BaseChatKit"}"#),
+                .tokens([
+                    "The ", "first ", "call ", "was ", "rate-limited, ",
+                    "but ", "the ", "retry ", "succeeded."
+                ])
+            ]
+
+        case mcpToolFailure.id:
+            // Single call — the demo tool always returns `.transient`. The
+            // model reports the failure rather than looping (the tool's
+            // description tells it not to retry).
+            return [
+                .toolCall(name: "fakeMCPLookup", arguments: #"{"path":"/projects/scout"}"#),
+                .tokens([
+                    "The ", "MCP ", "lookup ", "failed: ", "the ",
+                    "remote ", "server ", "is ", "unreachable."
+                ])
+            ]
+
         default:
             return fallbackTurns
         }

--- a/Example/BaseChatDemo/Scenarios/DemoScenarios.swift
+++ b/Example/BaseChatDemo/Scenarios/DemoScenarios.swift
@@ -52,8 +52,52 @@ enum DemoScenarios {
         configure: nil
     )
 
+    static let invalidArgsRecover = DemoScenario(
+        id: "invalid-args-recover",
+        title: "Recover from bad args",
+        blurb: "Tempts a divide-by-zero. The tool returns invalidArguments and the model retries with corrected inputs.",
+        systemImage: "exclamationmark.arrow.triangle.2.circlepath",
+        prompt: "Use the calculator to divide 100 by 0, then try a similar division you can actually answer.",
+        expectedTools: ["calc"],
+        autoSend: true,
+        accessibilityID: "demo-card-invalid-args-recover",
+        configure: nil
+    )
+
+    static let rateLimitedRetry = DemoScenario(
+        id: "rate-limited-retry",
+        title: "Retry through a rate limit",
+        blurb: "First call returns rateLimited; the model sees the error and retries the same call within one turn.",
+        systemImage: "hourglass.tophalf.filled",
+        prompt: "Use fakeRateLimited to look up 'BaseChatKit' and report the result it returns.",
+        expectedTools: ["fakeRateLimited"],
+        autoSend: true,
+        accessibilityID: "demo-card-rate-limited-retry",
+        configure: nil
+    )
+
+    static let mcpToolFailure = DemoScenario(
+        id: "mcp-tool-failure",
+        title: "Surface an MCP failure",
+        blurb: "An MCP-style tool fails transiently. The model receives the error and tells the user what went wrong.",
+        systemImage: "bolt.horizontal.icloud",
+        prompt: "Call fakeMCPLookup for the path '/projects/scout' and tell me what happened.",
+        expectedTools: ["fakeMCPLookup"],
+        autoSend: true,
+        accessibilityID: "demo-card-mcp-tool-failure",
+        configure: nil
+    )
+
     /// Order matches card display order on the empty state.
-    static let all: [DemoScenario] = [tipCalc, worldClock, workspaceSearch, journalWrite]
+    static let all: [DemoScenario] = [
+        tipCalc,
+        worldClock,
+        workspaceSearch,
+        journalWrite,
+        invalidArgsRecover,
+        rateLimitedRetry,
+        mcpToolFailure
+    ]
 
     static func scenario(id: String) -> DemoScenario? {
         all.first { $0.id == id }


### PR DESCRIPTION
## Summary

- Adds three error-path demo scenarios: `invalidArgsRecover`, `rateLimitedRetry`, `mcpToolFailure`
- New `FailureDemoTools.swift` with `FakeRateLimitedTool` (stateful, fails once then succeeds) and `FakeMCPLookupTool` (always returns `.transient`)
- Makes the framework's `ErrorKind` classification and orchestrator retry behavior visible to developers evaluating BaseChatKit without requiring a live backend

Note: `mcpToolFailure` stubs the `.transient` error directly until PR #848 (`feat(mcp): map MCPError to ToolResult.ErrorKind`) merges; no functional dependency on that PR.

Part of the cross-backend tool-calling unification series (#753), Wave 1.

## Test plan

- [x] Full pre-push checklist (all 9 suites) — 0 failures (no framework changes)
- [ ] Manual: build `BaseChatDemo`, run all three new scenarios in the demo picker, confirm model recovers and produces a meaningful response in each