### PR TITLE
feat!: port Goose AI Tier 1 patterns to BCK

### DIFF
--- a/Sources/BaseChatInference/Services/InferenceService.swift
+++ b/Sources/BaseChatInference/Services/InferenceService.swift
@@ -475,7 +475,7 @@ public final class InferenceService {
     ///     case.
     /// - Returns: A ``GenerationStream`` from whichever backend served the call.
     /// - Throws: The primary backend's error if the primary path also fails.
-    func runFastOrPrimary(
+    public func runFastOrPrimary(
         prompt: String,
         systemPrompt: String?,
         config: GenerationConfig,

--- a/Sources/BaseChatInference/Services/InferenceService.swift
+++ b/Sources/BaseChatInference/Services/InferenceService.swift
@@ -92,6 +92,25 @@ public final class InferenceService {
         didSet { lifecycle.denyPolicy = denyPolicy }
     }
 
+    // MARK: - Fast-Backend Routing
+
+    /// Optional secondary backend used for lightweight subtasks
+    /// (turn summarization, session naming, etc).
+    ///
+    /// When set, callers using ``runFastOrPrimary(prompt:systemPrompt:config:preferFast:)``
+    /// (or future internal opt-in subtask paths) dispatch here first and fall
+    /// back to the primary backend on failure. Hosts typically configure a
+    /// small, fast model (1B–3B) here while the primary handles user chat.
+    ///
+    /// Additive and opt-in: leaving this `nil` (the default) preserves all
+    /// existing behaviour — every call goes to the primary backend.
+    ///
+    /// The fast backend is **not** registered through the load-coordinator;
+    /// hosts pre-load it themselves (typically at app start) and assign the
+    /// already-loaded instance here. ``InferenceService`` does not unload,
+    /// reset, or otherwise manage the lifecycle of this backend.
+    public var fastBackend: (any InferenceBackend)?
+
     // MARK: - Backend Registration
 
     public func registerBackendFactory(_ factory: @escaping BackendFactory) {
@@ -422,6 +441,72 @@ public final class InferenceService {
         generation.provider = self
     }
     #endif
+
+    // MARK: - Fast-Backend Dispatch
+
+    /// Dispatches a backend-level generation request through the optional
+    /// ``fastBackend`` first, falling back to the primary backend on failure.
+    ///
+    /// Goose-style fast/primary routing for lightweight subtasks. Behaviour:
+    ///
+    /// - When ``fastBackend`` is set **and** `preferFast == true`: tries the
+    ///   fast backend first. If `generate(...)` throws synchronously, logs a
+    ///   warning and retries on the primary backend.
+    /// - When ``fastBackend`` is `nil` **or** `preferFast == false`:
+    ///   dispatches directly to the primary backend.
+    ///
+    /// Stream-internal errors (errors thrown into the returned
+    /// ``GenerationStream``) are **not** intercepted — they surface to the
+    /// caller. This matches Goose's coarse-grained "fall back if the call
+    /// fails" semantic and keeps the helper a thin primitive.
+    ///
+    /// This is the low-level primitive. Higher-level subtask paths (e.g.
+    /// future LLM-driven session naming or summarisation) can opt in by
+    /// passing `preferFast: true`. Public chat generation continues to use
+    /// the queued ``enqueue(messages:...)`` path against the primary backend
+    /// only.
+    ///
+    /// - Parameters:
+    ///   - prompt: Assembled prompt string passed verbatim to the chosen backend.
+    ///   - systemPrompt: Optional system prompt forwarded to the backend.
+    ///   - config: Sampling/generation configuration for the call.
+    ///   - preferFast: When `true` and ``fastBackend`` is set, the fast backend
+    ///     is tried first. Defaults to `true` since the helper exists for that
+    ///     case.
+    /// - Returns: A ``GenerationStream`` from whichever backend served the call.
+    /// - Throws: The primary backend's error if the primary path also fails.
+    func runFastOrPrimary(
+        prompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig,
+        preferFast: Bool = true
+    ) throws -> GenerationStream {
+        ensureProviderWired()
+
+        if preferFast, let fast = fastBackend {
+            do {
+                return try fast.generate(
+                    prompt: prompt,
+                    systemPrompt: systemPrompt,
+                    config: config
+                )
+            } catch {
+                Log.inference.warning(
+                    "fast backend failed, falling back to primary: \(String(describing: error), privacy: .public)"
+                )
+                // Fall through to primary dispatch below.
+            }
+        }
+
+        guard let primary = lifecycle.backend else {
+            throw InferenceError.inferenceFailure("No model loaded")
+        }
+        return try primary.generate(
+            prompt: prompt,
+            systemPrompt: systemPrompt,
+            config: config
+        )
+    }
 
     /// Ensures the generation coordinator has a reference to this service.
     ///

--- a/Sources/BaseChatInference/Services/ToolArgumentCoercer.swift
+++ b/Sources/BaseChatInference/Services/ToolArgumentCoercer.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+// MARK: - ToolArgumentCoercer
+
+/// Coerces top-level string-typed arguments to the primitive type declared in
+/// a JSON Schema's `properties` map.
+///
+/// Models — especially smaller open-weight ones — frequently emit
+/// JSON-encoded tool arguments where every value is a string, even when the
+/// schema declares `integer`, `number`, or `boolean`. Without coercion, the
+/// schema validator rejects these calls before they reach the executor and
+/// the user sees a hard failure for what is effectively a serialisation
+/// quirk.
+///
+/// Behaviour mirrors Goose AI's `coerce_tool_arguments` helper
+/// (`crates/goose/src/agents/reply_parts.rs`):
+///
+/// - Coercion only runs at the top level of `properties`. Nested objects
+///   and arrays pass through unchanged — matching Goose's scope, and
+///   keeping the cost bounded so the coercer is safe to run on every
+///   dispatch.
+/// - Strings that fail to parse fall through unchanged so the validator
+///   still produces its real error message.
+/// - Already-correct types (an actual JSON number against a `number`
+///   schema, etc.) pass through untouched.
+///
+/// The coercer is intentionally a free namespace rather than a stored
+/// dependency on ``ToolRegistry``: it has no state and no allocation cost
+/// on the no-op path.
+enum ToolArgumentCoercer {
+
+    /// Returns `value` with top-level string entries coerced to match the
+    /// primitive types declared in `schema.properties`. Inputs that aren't
+    /// objects, or schemas without a `properties` map, pass through
+    /// unchanged.
+    static func coerce(_ value: JSONSchemaValue, against schema: JSONSchemaValue) -> JSONSchemaValue {
+        guard case .object(let args) = value else { return value }
+        guard case .object(let schemaObject) = schema,
+              case .object(let properties) = schemaObject["properties"] ?? .null
+        else {
+            return value
+        }
+
+        var coerced: [String: JSONSchemaValue] = [:]
+        coerced.reserveCapacity(args.count)
+        for (key, argValue) in args {
+            if case .string(let s) = argValue, let propertySchema = properties[key] {
+                coerced[key] = coerceScalar(s, against: propertySchema)
+            } else {
+                coerced[key] = argValue
+            }
+        }
+        return .object(coerced)
+    }
+
+    /// Coerces a single string against a property's declared `type`.
+    ///
+    /// Returns the original `.string(s)` when the schema doesn't ask for a
+    /// primitive type or when parsing fails — the registry's validator then
+    /// surfaces a precise type-mismatch error if the call really is
+    /// malformed.
+    private static func coerceScalar(_ s: String, against schema: JSONSchemaValue) -> JSONSchemaValue {
+        guard case .object(let schemaObject) = schema,
+              case .string(let typeName) = schemaObject["type"] ?? .null
+        else {
+            return .string(s)
+        }
+        switch typeName {
+        case "integer", "number":
+            return tryCoerceNumber(s)
+        case "boolean":
+            return tryCoerceBoolean(s)
+        default:
+            return .string(s)
+        }
+    }
+
+    /// Parses `s` as a JSON number. Whole-valued floats within the Int64
+    /// range collapse to `.number(Int)` so downstream `integer` checks
+    /// succeed; non-integer values keep their fractional component.
+    private static func tryCoerceNumber(_ s: String) -> JSONSchemaValue {
+        let trimmed = s.trimmingCharacters(in: .whitespaces)
+        guard let n = Double(trimmed), n.isFinite else { return .string(s) }
+        // JSONSchemaValue stores all numbers as Double; `n.fract == 0`
+        // round-trips losslessly for the integer case, which is what the
+        // validator's `integer` check looks for.
+        return .number(n)
+    }
+
+    private static func tryCoerceBoolean(_ s: String) -> JSONSchemaValue {
+        switch s.lowercased() {
+        case "true": return .bool(true)
+        case "false": return .bool(false)
+        default: return .string(s)
+        }
+    }
+}

--- a/Sources/BaseChatInference/Services/ToolArgumentCoercer.swift
+++ b/Sources/BaseChatInference/Services/ToolArgumentCoercer.swift
@@ -66,7 +66,9 @@ enum ToolArgumentCoercer {
             return .string(s)
         }
         switch typeName {
-        case "integer", "number":
+        case "integer":
+            return tryCoerceInteger(s)
+        case "number":
             return tryCoerceNumber(s)
         case "boolean":
             return tryCoerceBoolean(s)
@@ -75,15 +77,26 @@ enum ToolArgumentCoercer {
         }
     }
 
-    /// Parses `s` as a JSON number. Whole-valued floats within the Int64
-    /// range collapse to `.number(Int)` so downstream `integer` checks
-    /// succeed; non-integer values keep their fractional component.
+    /// Parses `s` as a JSON number. `JSONSchemaValue` represents all numbers
+    /// as `Double`; the validator's `integer` check accepts a `.number(n)`
+    /// when `n.rounded() == n`, so whole-valued floats round-trip correctly.
+    /// Non-finite values fall through unchanged.
     private static func tryCoerceNumber(_ s: String) -> JSONSchemaValue {
         let trimmed = s.trimmingCharacters(in: .whitespaces)
         guard let n = Double(trimmed), n.isFinite else { return .string(s) }
-        // JSONSchemaValue stores all numbers as Double; `n.fract == 0`
-        // round-trips losslessly for the integer case, which is what the
-        // validator's `integer` check looks for.
+        return .number(n)
+    }
+
+    /// Parses `s` as an integer-valued JSON number. Strings like `"3.14"`
+    /// fall through unchanged so the validator surfaces a precise
+    /// "expected integer got string" error rather than a confusing
+    /// "expected integer got number" one — and so executors that skip
+    /// validation never receive a fractional value for an `integer` field.
+    private static func tryCoerceInteger(_ s: String) -> JSONSchemaValue {
+        let trimmed = s.trimmingCharacters(in: .whitespaces)
+        guard let n = Double(trimmed), n.isFinite, n.rounded() == n else {
+            return .string(s)
+        }
         return .number(n)
     }
 

--- a/Sources/BaseChatInference/Services/ToolCallLoopOrchestrator.swift
+++ b/Sources/BaseChatInference/Services/ToolCallLoopOrchestrator.swift
@@ -44,7 +44,7 @@ public struct ToolCallLoopPolicy: Sendable {
     /// Number of trailing `(toolName, arguments)` pairs that must be identical
     /// for the loop-detection heuristic to fire.
     ///
-    /// On a hit the orchestrator emits ``ToolLoopEvent/loopDetected(toolName:)``
+    /// On a hit the orchestrator emits ``ToolLoopEvent/loopDetected(_:)``
     /// and finishes. Defaults to `3`. Values `<= 1` disable the heuristic
     /// entirely (a single tool call by itself is never a cycle).
     public var loopDetectionWindow: Int
@@ -55,7 +55,7 @@ public struct ToolCallLoopPolicy: Sendable {
     ///   - maxSteps: Step budget. Clamped to `1...`. Defaults to `8`.
     ///   - perStepTimeout: Optional wall-clock cap per generate round. Defaults to `nil`.
     ///   - loopDetectionWindow: N identical consecutive `(name, args)` pairs that
-    ///     trigger ``ToolLoopEvent/loopDetected(toolName:)``. Values `<= 1` disable
+    ///     trigger ``ToolLoopEvent/loopDetected(_:)``. Values `<= 1` disable
     ///     the heuristic. Defaults to `3`.
     public init(
         maxSteps: Int = 8,
@@ -68,6 +68,51 @@ public struct ToolCallLoopPolicy: Sendable {
     }
 }
 
+// MARK: - ToolLoopFinding
+
+/// Structured payload emitted with ``ToolLoopEvent/loopDetected(_:)`` when the
+/// orchestrator's cycle heuristic fires.
+///
+/// Ports the ``finding_id`` + ``reason`` shape from Goose AI's
+/// ``RepetitionInspector``: consumers (fuzz harnesses, host UIs, telemetry
+/// pipelines) can switch on a stable ``findingID`` instead of string-matching
+/// the human-readable ``reason``.
+///
+/// The current orchestrator emits a single finding kind: identical-arguments
+/// repetition with `findingID == "REP-001"`. New finding kinds can be added
+/// later without breaking pattern matches that already key on the ID.
+public struct ToolLoopFinding: Sendable, Equatable {
+
+    /// Stable identifier for the finding kind. `"REP-001"` for the
+    /// identical-arguments repetition heuristic.
+    public let findingID: String
+
+    /// Name of the tool whose repeated invocation triggered the finding.
+    public let toolName: String
+
+    /// Human-readable explanation of what fired and why. Suitable for logs
+    /// and developer-facing UI; do not parse it — switch on ``findingID``
+    /// instead.
+    public let reason: String
+
+    /// Number of identical-signature calls observed in the trailing window
+    /// at the moment the finding fired. Equals
+    /// ``ToolCallLoopPolicy/loopDetectionWindow`` for `REP-001`.
+    public let repetitionCount: Int
+
+    public init(
+        findingID: String,
+        toolName: String,
+        reason: String,
+        repetitionCount: Int
+    ) {
+        self.findingID = findingID
+        self.toolName = toolName
+        self.reason = reason
+        self.repetitionCount = repetitionCount
+    }
+}
+
 // MARK: - ToolLoopEvent
 
 /// Events emitted by ``ToolCallLoopOrchestrator/run(initialPrompt:systemPrompt:config:)``.
@@ -75,7 +120,7 @@ public struct ToolCallLoopPolicy: Sendable {
 /// Mirrors a subset of ``GenerationEvent`` plus three orchestrator-only
 /// terminal events. Callers consume the stream until it finishes; the last
 /// event is always one of ``finished``, ``stepLimitReached(steps:)`` or
-/// ``loopDetected(toolName:)`` unless the stream throws.
+/// ``loopDetected(_:)`` unless the stream throws.
 public enum ToolLoopEvent: Sendable, Equatable {
 
     /// A fragment of visible text emitted by the model (forwarded verbatim
@@ -115,7 +160,11 @@ public enum ToolLoopEvent: Sendable, Equatable {
     /// The cycle heuristic fired: the last
     /// ``ToolCallLoopPolicy/loopDetectionWindow`` `(toolName, arguments)`
     /// pairs were identical. Terminal — no further events follow.
-    case loopDetected(toolName: String)
+    ///
+    /// The associated ``ToolLoopFinding`` carries a stable ``findingID``
+    /// (`"REP-001"` for this heuristic), the offending ``toolName``, a
+    /// human-readable ``reason``, and the observed ``repetitionCount``.
+    case loopDetected(ToolLoopFinding)
 
     /// The model produced a turn without emitting any tool call.
     /// Terminal — no further events follow.
@@ -160,7 +209,7 @@ public enum ToolLoopError: Error, Sendable, Equatable {
 /// 6. If ``ToolCallLoopPolicy/maxSteps`` is exceeded, it emits
 ///    ``ToolLoopEvent/stepLimitReached(steps:)``.
 /// 7. If the last ``ToolCallLoopPolicy/loopDetectionWindow`` `(name, args)`
-///    pairs are identical, it emits ``ToolLoopEvent/loopDetected(toolName:)``.
+///    pairs are identical, it emits ``ToolLoopEvent/loopDetected(_:)``.
 ///
 /// ## Cancellation
 ///
@@ -289,7 +338,7 @@ public struct ToolCallLoopOrchestrator: Sendable {
     /// The returned stream produces ``ToolLoopEvent`` values until the loop
     /// terminates with ``ToolLoopEvent/finished``,
     /// ``ToolLoopEvent/stepLimitReached(steps:)``, or
-    /// ``ToolLoopEvent/loopDetected(toolName:)``. Errors thrown by the backend
+    /// ``ToolLoopEvent/loopDetected(_:)``. Errors thrown by the backend
     /// or by the per-step timeout are forwarded into the stream.
     ///
     /// Cancellation: when the consumer cancels its iteration, the orchestrator
@@ -407,7 +456,14 @@ public struct ToolCallLoopOrchestrator: Sendable {
                    recentCalls.count == policy.loopDetectionWindow,
                    let first = recentCalls.first,
                    recentCalls.allSatisfy({ $0 == first }) {
-                    continuation.yield(.loopDetected(toolName: first.name))
+                    let count = recentCalls.count
+                    let finding = ToolLoopFinding(
+                        findingID: "REP-001",
+                        toolName: first.name,
+                        reason: "Tool '\(first.name)' invoked \(count) times with identical arguments within a window of \(policy.loopDetectionWindow) — denying further calls",
+                        repetitionCount: count
+                    )
+                    continuation.yield(.loopDetected(finding))
                     continuation.finish()
                     return
                 }

--- a/Sources/BaseChatInference/Services/ToolCallLoopOrchestrator.swift
+++ b/Sources/BaseChatInference/Services/ToolCallLoopOrchestrator.swift
@@ -481,7 +481,7 @@ public struct ToolCallLoopOrchestrator: Sendable {
                 toolResults: results
             ))
 
-            let compressed = compressor.compress(records: records)
+            let compressed = compressor.compress(records: records, trigger: .toolLoop)
             // Persist the compressor's view back into `records`: keep the
             // preserved suffix so the next iteration's compress() input is
             // already the suffix. Once a record is folded, it does not

--- a/Sources/BaseChatInference/Services/ToolRegistry.swift
+++ b/Sources/BaseChatInference/Services/ToolRegistry.swift
@@ -114,7 +114,8 @@ public protocol JSONSchemaValidating: Sendable {
     public var validator: (any JSONSchemaValidating)? = nil
 
     /// When `true`, top-level string arguments are coerced to the primitive
-    /// type declared in the tool's `properties` schema before validation.
+    /// type declared in the tool's `properties` schema before validation —
+    /// **and the coerced value is what the executor receives**.
     ///
     /// Smaller open-weight models routinely emit `"42"` for an `integer`
     /// property or `"true"` for a `boolean`. Without coercion, the schema
@@ -122,6 +123,9 @@ public protocol JSONSchemaValidating: Sendable {
     /// pure serialisation quirk. See ``ToolArgumentCoercer`` for the exact
     /// rules — coercion only runs at the top level and unparseable strings
     /// fall through unchanged so genuine type errors still surface.
+    ///
+    /// Tools that want to inspect the raw model output themselves can opt
+    /// out by setting this to `false`.
     public var coercesArguments: Bool = true
 
     /// Size policy applied to tool results before they are returned from
@@ -326,17 +330,21 @@ public protocol JSONSchemaValidating: Sendable {
 
         // 3. Optional argument coercion — runs before validation so a
         // string "42" for an integer property reaches the validator as
-        // .number(42), not .string("42").
-        let argumentsForValidation: JSONSchemaValue
+        // .number(42), not .string("42"). The coerced value is then passed
+        // through to the executor as well: the whole point of coercion is
+        // that small models emit `"42"` and the tool wants `42`, so the
+        // executor must see the coerced form. Tools that need the raw
+        // string can opt out by clearing ``coercesArguments``.
+        let dispatchArguments: JSONSchemaValue
         if coercesArguments {
-            argumentsForValidation = ToolArgumentCoercer.coerce(parsedArguments, against: executor.definition.parameters)
+            dispatchArguments = ToolArgumentCoercer.coerce(parsedArguments, against: executor.definition.parameters)
         } else {
-            argumentsForValidation = parsedArguments
+            dispatchArguments = parsedArguments
         }
 
         // 4. Optional schema validation (wave 2 wiring).
         if let activeValidator,
-           let message = activeValidator.validateAgainst(executor.definition.parameters, value: argumentsForValidation) {
+           let message = activeValidator.validateAgainst(executor.definition.parameters, value: dispatchArguments) {
             return ToolResult(
                 callId: call.id,
                 content: "arguments failed schema validation: \(message)",
@@ -347,7 +355,7 @@ public protocol JSONSchemaValidating: Sendable {
         // 5. Execute, stamp callId, and apply the size policy.
         let outcome: ToolResult
         do {
-            let raw = try await executor.execute(arguments: argumentsForValidation)
+            let raw = try await executor.execute(arguments: dispatchArguments)
             // If the surrounding task was cancelled but the executor returned
             // a value anyway (didn't observe cancellation), still treat the
             // outcome as cancelled so the orchestrator's transcript records

--- a/Sources/BaseChatInference/Services/ToolRegistry.swift
+++ b/Sources/BaseChatInference/Services/ToolRegistry.swift
@@ -113,6 +113,17 @@ public protocol JSONSchemaValidating: Sendable {
     /// conformer) so failures come back as ``ToolResult/ErrorKind/invalidArguments``.
     public var validator: (any JSONSchemaValidating)? = nil
 
+    /// When `true`, top-level string arguments are coerced to the primitive
+    /// type declared in the tool's `properties` schema before validation.
+    ///
+    /// Smaller open-weight models routinely emit `"42"` for an `integer`
+    /// property or `"true"` for a `boolean`. Without coercion, the schema
+    /// validator rejects these calls and the user sees a hard failure for a
+    /// pure serialisation quirk. See ``ToolArgumentCoercer`` for the exact
+    /// rules — coercion only runs at the top level and unparseable strings
+    /// fall through unchanged so genuine type errors still surface.
+    public var coercesArguments: Bool = true
+
     /// Size policy applied to tool results before they are returned from
     /// ``dispatch(_:)``.
     ///
@@ -313,9 +324,19 @@ public protocol JSONSchemaValidating: Sendable {
             }
         }
 
-        // 3. Optional schema validation (wave 2 wiring).
+        // 3. Optional argument coercion — runs before validation so a
+        // string "42" for an integer property reaches the validator as
+        // .number(42), not .string("42").
+        let argumentsForValidation: JSONSchemaValue
+        if coercesArguments {
+            argumentsForValidation = ToolArgumentCoercer.coerce(parsedArguments, against: executor.definition.parameters)
+        } else {
+            argumentsForValidation = parsedArguments
+        }
+
+        // 4. Optional schema validation (wave 2 wiring).
         if let activeValidator,
-           let message = activeValidator.validateAgainst(executor.definition.parameters, value: parsedArguments) {
+           let message = activeValidator.validateAgainst(executor.definition.parameters, value: argumentsForValidation) {
             return ToolResult(
                 callId: call.id,
                 content: "arguments failed schema validation: \(message)",
@@ -323,10 +344,10 @@ public protocol JSONSchemaValidating: Sendable {
             )
         }
 
-        // 4. Execute, stamp callId, and apply the size policy.
+        // 5. Execute, stamp callId, and apply the size policy.
         let outcome: ToolResult
         do {
-            let raw = try await executor.execute(arguments: parsedArguments)
+            let raw = try await executor.execute(arguments: argumentsForValidation)
             // If the surrounding task was cancelled but the executor returned
             // a value anyway (didn't observe cancellation), still treat the
             // outcome as cancelled so the orchestrator's transcript records

--- a/Sources/BaseChatInference/Services/TurnHistoryCompressor.swift
+++ b/Sources/BaseChatInference/Services/TurnHistoryCompressor.swift
@@ -1,5 +1,27 @@
 import Foundation
 
+// MARK: - CompactionTrigger
+
+/// Why a transcript compaction happened. Used by trigger-aware compressors
+/// (notably ``BudgetTurnHistoryCompressor``) to append a context-appropriate
+/// continuation prompt so the model resumes naturally instead of acknowledging
+/// the summary out loud.
+///
+/// Mirrors Goose AI's three triggers (`crates/goose/src/context_mgmt/mod.rs`):
+/// automatic budget overflow, in-loop tool compaction, and explicit user
+/// request.
+public enum CompactionTrigger: Sendable {
+    /// Budget exceeded mid-conversation. The compaction was not user-driven
+    /// and is not happening inside an active tool-calling loop.
+    case automatic
+    /// Compaction fired during a tool-calling loop. The continuation prompt
+    /// asks the model to keep calling tools as needed rather than narrating.
+    case toolLoop
+    /// User explicitly requested compaction. The continuation acknowledges
+    /// the user's request without asking the model to mention it.
+    case manual
+}
+
 // MARK: - TurnHistoryRecord
 
 /// One round of an agent loop captured for potential compression.
@@ -137,6 +159,24 @@ public protocol TurnHistoryCompressor: Sendable {
     /// - Be deterministic. The same input must always produce the same
     ///   output — KV-cache prefix reuse depends on stable prompt prefixes.
     func compress(records: [TurnHistoryRecord]) -> CompressedTranscript
+
+    /// Trigger-aware variant. Implementations may use the trigger to tailor
+    /// the produced summary (e.g. append a continuation prompt that nudges
+    /// the model to resume in the right register).
+    ///
+    /// Has a default implementation that ignores `trigger` and calls
+    /// ``compress(records:)`` — existing conformers compile unchanged.
+    func compress(records: [TurnHistoryRecord], trigger: CompactionTrigger) -> CompressedTranscript
+}
+
+public extension TurnHistoryCompressor {
+    /// Default implementation forwards to the trigger-agnostic method so
+    /// that adopters which were written before ``CompactionTrigger`` keep
+    /// working. New implementations should override this to consume the
+    /// trigger.
+    func compress(records: [TurnHistoryRecord], trigger: CompactionTrigger) -> CompressedTranscript {
+        compress(records: records)
+    }
 }
 
 // MARK: - BudgetTurnHistoryCompressor
@@ -201,6 +241,13 @@ public struct BudgetTurnHistoryCompressor: TurnHistoryCompressor {
     }
 
     public func compress(records: [TurnHistoryRecord]) -> CompressedTranscript {
+        compress(records: records, trigger: .automatic)
+    }
+
+    public func compress(
+        records: [TurnHistoryRecord],
+        trigger: CompactionTrigger
+    ) -> CompressedTranscript {
         if records.isEmpty {
             return .unchanged(records)
         }
@@ -233,12 +280,37 @@ public struct BudgetTurnHistoryCompressor: TurnHistoryCompressor {
 
         let folded = Array(records.prefix(foldedCount))
         let preserved = Array(records.suffix(records.count - foldedCount))
-        let summary = renderSummary(for: folded)
+        let summary = renderSummary(for: folded) + "\n\n" + Self.continuationText(for: trigger)
         return CompressedTranscript(
             summary: summary,
             foldedRecords: folded,
             preservedRecords: preserved
         )
+    }
+
+    // MARK: - Continuation prompts (ported from Goose AI)
+    //
+    // Goose appends one of these strings to the summary block before handing
+    // it back to the model. The intent is to keep the model from breaking
+    // immersion ("based on the earlier turns I see…") while making sure it
+    // resumes in the right register: prose chat, in-loop tool calling, or
+    // a user-initiated reset. Source: `crates/goose/src/context_mgmt/mod.rs`.
+
+    static let conversationContinuationText: String =
+        "Your context was compacted. The previous message contains a summary of the conversation so far.\nDo not mention that you read a summary or that conversation summarization occurred.\nJust continue the conversation naturally based on the summarized context."
+
+    static let toolLoopContinuationText: String =
+        "Your context was compacted. The previous message contains a summary of the conversation so far.\nDo not mention that you read a summary or that conversation summarization occurred.\nContinue calling tools as necessary to complete the task."
+
+    static let manualCompactContinuationText: String =
+        "Your context was compacted at the user's request. The previous message contains a summary of the conversation so far.\nDo not mention that you read a summary or that conversation summarization occurred.\nJust continue the conversation naturally based on the summarized context."
+
+    private static func continuationText(for trigger: CompactionTrigger) -> String {
+        switch trigger {
+        case .automatic: return conversationContinuationText
+        case .toolLoop: return toolLoopContinuationText
+        case .manual: return manualCompactContinuationText
+        }
     }
 
     private func renderSummary(for folded: [TurnHistoryRecord]) -> String {

--- a/Tests/BaseChatInferenceTests/CompactionTriggerTests.swift
+++ b/Tests/BaseChatInferenceTests/CompactionTriggerTests.swift
@@ -1,0 +1,231 @@
+import XCTest
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Coverage for ``CompactionTrigger`` and the trigger-aware
+/// ``TurnHistoryCompressor/compress(records:trigger:)`` overload.
+///
+/// The continuation strings are ported verbatim from Goose AI
+/// (`crates/goose/src/context_mgmt/mod.rs`) so the model resumes naturally
+/// after a compaction instead of acknowledging the summary out loud.
+@MainActor
+final class CompactionTriggerTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private actor Counter {
+        private var value = 0
+        func next() -> Int {
+            defer { value += 1 }
+            return value
+        }
+    }
+
+    private func record(
+        step: Int,
+        toolName: String = "t",
+        args: String = "{}",
+        result: String
+    ) -> TurnHistoryRecord {
+        TurnHistoryRecord(
+            step: step,
+            intermediateTokens: [],
+            toolCalls: [ToolCall(id: "c-\(step)", toolName: toolName, arguments: args)],
+            toolResults: [ToolResult(callId: "c-\(step)", content: result, errorKind: nil)]
+        )
+    }
+
+    /// Builds an over-budget transcript and asserts the produced summary
+    /// ends with `expected`.
+    private func runTriggerCase(_ trigger: CompactionTrigger, expected: String) {
+        let c = BudgetTurnHistoryCompressor(characterBudget: 50, preserveRecentTurns: 1)
+        let records = (1...4).map {
+            record(step: $0, result: String(repeating: "x", count: 60))
+        }
+        let out = c.compress(records: records, trigger: trigger)
+        XCTAssertFalse(out.foldedRecords.isEmpty, "fixture must trigger a fold")
+        XCTAssertTrue(
+            out.summary.hasSuffix(expected),
+            "summary must end with the trigger-specific continuation prompt; got: \(out.summary)"
+        )
+    }
+
+    // MARK: - Continuation prompts (Goose-ported)
+
+    func test_automaticTrigger_appendsConversationContinuation() {
+        runTriggerCase(.automatic, expected: BudgetTurnHistoryCompressor.conversationContinuationText)
+    }
+
+    func test_toolLoopTrigger_appendsToolLoopContinuation() {
+        runTriggerCase(.toolLoop, expected: BudgetTurnHistoryCompressor.toolLoopContinuationText)
+    }
+
+    func test_manualTrigger_appendsManualCompactContinuation() {
+        runTriggerCase(.manual, expected: BudgetTurnHistoryCompressor.manualCompactContinuationText)
+    }
+
+    /// The three continuation strings must be distinct — otherwise the
+    /// trigger plumbing would be a no-op for any two coincident triggers.
+    func test_continuationStrings_areDistinct() {
+        let a = BudgetTurnHistoryCompressor.conversationContinuationText
+        let b = BudgetTurnHistoryCompressor.toolLoopContinuationText
+        let c = BudgetTurnHistoryCompressor.manualCompactContinuationText
+        XCTAssertNotEqual(a, b)
+        XCTAssertNotEqual(a, c)
+        XCTAssertNotEqual(b, c)
+    }
+
+    /// Pin one of the constants to its Goose-source byte sequence. If a
+    /// future refactor accidentally rewrites the prose, the regression
+    /// surfaces here rather than as a subtle change in model behaviour.
+    func test_toolLoopText_matchesGooseSource() {
+        XCTAssertEqual(
+            BudgetTurnHistoryCompressor.toolLoopContinuationText,
+            "Your context was compacted. The previous message contains a summary of the conversation so far.\nDo not mention that you read a summary or that conversation summarization occurred.\nContinue calling tools as necessary to complete the task."
+        )
+    }
+
+    // MARK: - Default protocol extension
+
+    /// A compressor that only implements the legacy `compress(records:)`
+    /// must still honour the trigger-aware call via the default extension.
+    /// The trigger argument is intentionally ignored here.
+    private struct LegacyOnlyCompressor: TurnHistoryCompressor {
+        let marker: String
+        func compress(records: [TurnHistoryRecord]) -> CompressedTranscript {
+            CompressedTranscript(
+                summary: marker,
+                foldedRecords: records,
+                preservedRecords: []
+            )
+        }
+        // Note: no override of compress(records:trigger:) — the default
+        // extension is what we're testing.
+    }
+
+    func test_defaultExtension_routesToLegacyMethod_forAllTriggers() {
+        let legacy = LegacyOnlyCompressor(marker: "LEGACY")
+        let records = [record(step: 1, result: "ok")]
+        for trigger in [CompactionTrigger.automatic, .toolLoop, .manual] {
+            let out = legacy.compress(records: records, trigger: trigger)
+            XCTAssertEqual(
+                out.summary,
+                "LEGACY",
+                "default extension must forward to legacy compress(records:); trigger=\(trigger)"
+            )
+        }
+    }
+
+    // MARK: - Empty-records short-circuit (no continuation appended)
+
+    /// When there is nothing to fold, the compressor returns
+    /// `.unchanged(records)` — no summary, and therefore no continuation
+    /// prompt. The continuation text only attaches when a fold actually
+    /// happens.
+    func test_underBudget_doesNotAppendContinuation() {
+        let c = BudgetTurnHistoryCompressor(characterBudget: 100_000, preserveRecentTurns: 2)
+        let records = (1...3).map { record(step: $0, result: "small") }
+        let out = c.compress(records: records, trigger: .toolLoop)
+        XCTAssertTrue(out.summary.isEmpty)
+        XCTAssertFalse(out.summary.contains(BudgetTurnHistoryCompressor.toolLoopContinuationText))
+    }
+
+    // MARK: - Orchestrator passes .toolLoop
+
+    /// Records every `(records, trigger)` pair the orchestrator hands to it.
+    /// We capture the trigger argument so we can assert the orchestrator is
+    /// passing `.toolLoop` rather than relying on the default.
+    private final class RecordingCompressor: TurnHistoryCompressor, @unchecked Sendable {
+        // @unchecked: writes are funnelled through a serial DispatchQueue so
+        // concurrent compress() invocations from inside the orchestrator's
+        // async loop cannot race.
+        private let queue = DispatchQueue(label: "RecordingCompressor")
+        private var _triggers: [CompactionTrigger] = []
+
+        var observedTriggers: [CompactionTrigger] {
+            queue.sync { _triggers }
+        }
+
+        func compress(records: [TurnHistoryRecord]) -> CompressedTranscript {
+            // Should not be reached when compress(records:trigger:) is
+            // overridden, but provide the legacy implementation for safety.
+            .unchanged(records)
+        }
+
+        func compress(
+            records: [TurnHistoryRecord],
+            trigger: CompactionTrigger
+        ) -> CompressedTranscript {
+            queue.sync { _triggers.append(trigger) }
+            return .unchanged(records)
+        }
+    }
+
+    private struct ScriptedExecutor: ToolExecutor {
+        let definition: ToolDefinition
+        let handler: @Sendable (JSONSchemaValue) async throws -> ToolResult
+
+        init(
+            name: String,
+            handler: @escaping @Sendable (JSONSchemaValue) async throws -> ToolResult
+        ) {
+            self.definition = ToolDefinition(name: name, description: "scripted", parameters: .object([:]))
+            self.handler = handler
+        }
+
+        func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+            try await handler(arguments)
+        }
+    }
+
+    private func collect(
+        _ stream: AsyncThrowingStream<ToolLoopEvent, Error>
+    ) async throws -> [ToolLoopEvent] {
+        var events: [ToolLoopEvent] = []
+        for try await event in stream {
+            events.append(event)
+        }
+        return events
+    }
+
+    func test_orchestrator_passesToolLoopTrigger() async throws {
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.scriptedToolCallsPerTurn = [
+            [ToolCall(id: "c-1", toolName: "any_tool", arguments: #"{"x":1}"#)],
+            [ToolCall(id: "c-2", toolName: "any_tool", arguments: #"{"x":2}"#)],
+            [],
+        ]
+        backend.tokensToYieldPerTurn = [[], [], ["done"]]
+
+        let counter = Counter()
+        let executor = ScriptedExecutor(name: "any_tool") { _ in
+            _ = await counter.next()
+            return ToolResult(callId: "", content: "ok", errorKind: nil)
+        }
+
+        let recording = RecordingCompressor()
+        let orchestrator = ToolCallLoopOrchestrator(
+            backend: backend,
+            executor: executor,
+            policy: ToolCallLoopPolicy(maxSteps: 4, loopDetectionWindow: 99),
+            compressor: recording
+        )
+
+        _ = try await collect(orchestrator.run(
+            initialPrompt: "go",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+
+        let observed = recording.observedTriggers
+        XCTAssertFalse(observed.isEmpty, "orchestrator must invoke compress at least once per round")
+        for trigger in observed {
+            switch trigger {
+            case .toolLoop: continue
+            case .automatic, .manual:
+                XCTFail("orchestrator must pass .toolLoop; got \(trigger)")
+            }
+        }
+    }
+}

--- a/Tests/BaseChatInferenceTests/FastBackendRoutingTests.swift
+++ b/Tests/BaseChatInferenceTests/FastBackendRoutingTests.swift
@@ -1,0 +1,151 @@
+import XCTest
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Coverage for the optional fast-backend routing primitive added on
+/// ``InferenceService``. The helper exists so lightweight subtasks
+/// (summarisation, session naming) can opt into a small, fast model
+/// without touching the user-facing chat dispatch path.
+@MainActor
+final class FastBackendRoutingTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeConfig() -> GenerationConfig {
+        GenerationConfig()
+    }
+
+    // MARK: - Tests
+
+    func test_runFastOrPrimary_routesToFastBackend_whenSetAndPreferFastTrue() async throws {
+        let primary = MockInferenceBackend()
+        primary.isModelLoaded = true
+        primary.tokensToYield = ["primary"]
+
+        let fast = MockInferenceBackend()
+        fast.isModelLoaded = true
+        fast.tokensToYield = ["fast"]
+
+        let service = InferenceService(backend: primary, name: "Primary")
+        service.fastBackend = fast
+
+        let stream = try service.runFastOrPrimary(
+            prompt: "summarise the conversation",
+            systemPrompt: nil,
+            config: makeConfig(),
+            preferFast: true
+        )
+
+        var visible = ""
+        for try await event in stream.events {
+            if case let .token(t) = event { visible += t }
+        }
+
+        XCTAssertEqual(visible, "fast")
+        XCTAssertEqual(fast.generateCallCount, 1, "fast backend should have served the call")
+        XCTAssertEqual(primary.generateCallCount, 0, "primary must not see the call when fast succeeds")
+    }
+
+    func test_runFastOrPrimary_fallsBackToPrimary_whenFastBackendThrows() async throws {
+        let primary = MockInferenceBackend()
+        primary.isModelLoaded = true
+        primary.tokensToYield = ["primary"]
+
+        let fast = MockInferenceBackend()
+        fast.isModelLoaded = true
+        // Synchronous throw out of generate(...) — Goose-style fallback applies.
+        fast.shouldThrowOnGenerate = InferenceError.inferenceFailure("simulated fast failure")
+
+        let service = InferenceService(backend: primary, name: "Primary")
+        service.fastBackend = fast
+
+        let stream = try service.runFastOrPrimary(
+            prompt: "summarise",
+            systemPrompt: nil,
+            config: makeConfig(),
+            preferFast: true
+        )
+
+        var visible = ""
+        for try await event in stream.events {
+            if case let .token(t) = event { visible += t }
+        }
+
+        XCTAssertEqual(visible, "primary", "fallback should have produced primary's tokens")
+        XCTAssertEqual(fast.generateCallCount, 1, "fast backend must be tried first")
+        XCTAssertEqual(primary.generateCallCount, 1, "primary backend must run after fast fails")
+    }
+
+    func test_runFastOrPrimary_skipsFastBackend_whenPreferFastFalse() async throws {
+        let primary = MockInferenceBackend()
+        primary.isModelLoaded = true
+        primary.tokensToYield = ["primary"]
+
+        let fast = MockInferenceBackend()
+        fast.isModelLoaded = true
+        fast.tokensToYield = ["fast"]
+
+        let service = InferenceService(backend: primary, name: "Primary")
+        service.fastBackend = fast
+
+        let stream = try service.runFastOrPrimary(
+            prompt: "user-priority work",
+            systemPrompt: nil,
+            config: makeConfig(),
+            preferFast: false
+        )
+
+        for try await _ in stream.events {}
+
+        XCTAssertEqual(fast.generateCallCount, 0, "preferFast=false must bypass the fast slot")
+        XCTAssertEqual(primary.generateCallCount, 1, "primary must serve the call directly")
+    }
+
+    func test_runFastOrPrimary_usesPrimary_whenFastBackendNil() async throws {
+        let primary = MockInferenceBackend()
+        primary.isModelLoaded = true
+        primary.tokensToYield = ["primary"]
+
+        let service = InferenceService(backend: primary, name: "Primary")
+        XCTAssertNil(service.fastBackend, "precondition: fastBackend defaults to nil")
+
+        let stream = try service.runFastOrPrimary(
+            prompt: "hi",
+            systemPrompt: nil,
+            config: makeConfig(),
+            preferFast: true
+        )
+
+        for try await _ in stream.events {}
+
+        XCTAssertEqual(primary.generateCallCount, 1, "primary must serve the call when no fast backend is wired")
+    }
+
+    /// Sabotage check on the fallback path: the fallback only runs because the
+    /// fast backend's *synchronous* throw is caught. If we accidentally let
+    /// the throw escape, the primary never runs and the test catches it.
+    /// Asserts fallback executed by checking both backends saw a call.
+    func test_runFastOrPrimary_fallback_runsBothBackendsExactlyOnce() async throws {
+        let primary = MockInferenceBackend()
+        primary.isModelLoaded = true
+        primary.tokensToYield = ["ok"]
+
+        let fast = MockInferenceBackend()
+        fast.isModelLoaded = true
+        fast.shouldThrowOnGenerate = InferenceError.inferenceFailure("fail")
+
+        let service = InferenceService(backend: primary, name: "Primary")
+        service.fastBackend = fast
+
+        let stream = try service.runFastOrPrimary(
+            prompt: "x",
+            systemPrompt: nil,
+            config: makeConfig(),
+            preferFast: true
+        )
+        for try await _ in stream.events {}
+
+        XCTAssertEqual(fast.generateCallCount, 1)
+        XCTAssertEqual(primary.generateCallCount, 1)
+    }
+}

--- a/Tests/BaseChatInferenceTests/ToolArgumentCoercerTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolArgumentCoercerTests.swift
@@ -72,6 +72,31 @@ final class ToolArgumentCoercerTests: XCTestCase {
         XCTAssertEqual(result, .object(["age": .string("not-a-number")]))
     }
 
+    /// A fractional string against an `integer` schema must fall through
+    /// unchanged so the validator surfaces "expected integer got string"
+    /// rather than the misleading "expected integer got number" — and so
+    /// executors that bypass validation never see a non-integer value
+    /// in an `integer` field.
+    func test_fractionalString_fallsThroughForIntegerSchema() {
+        let s = schema(["age": intProp()])
+        let args: JSONSchemaValue = .object(["age": .string("3.14")])
+
+        let result = ToolArgumentCoercer.coerce(args, against: s)
+
+        XCTAssertEqual(result, .object(["age": .string("3.14")]))
+    }
+
+    /// A fractional string against a `number` schema is still coerced —
+    /// only the `integer` path is integral-only.
+    func test_fractionalString_coercesForNumberSchema() {
+        let s = schema(["pi": numProp()])
+        let args: JSONSchemaValue = .object(["pi": .string("3.14")])
+
+        let result = ToolArgumentCoercer.coerce(args, against: s)
+
+        XCTAssertEqual(result, .object(["pi": .number(3.14)]))
+    }
+
     // MARK: - boolean
 
     func test_coercesLowercaseTrueAndFalse() {

--- a/Tests/BaseChatInferenceTests/ToolArgumentCoercerTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolArgumentCoercerTests.swift
@@ -1,0 +1,291 @@
+import XCTest
+@testable import BaseChatInference
+
+/// Tests for ``ToolArgumentCoercer`` — the top-level string→primitive
+/// coercion pass that runs between JSON decode and schema validation in
+/// ``ToolRegistry/dispatch(_:)``.
+///
+/// Coverage:
+/// - integer / number / boolean coercion
+/// - non-coercible strings fall through unchanged
+/// - already-correct types pass through untouched
+/// - missing schema or missing `properties` is a no-op
+/// - unknown keys (not in `properties`) are preserved
+/// - top-level only — nested values are not touched
+final class ToolArgumentCoercerTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func schema(_ properties: [String: JSONSchemaValue]) -> JSONSchemaValue {
+        .object([
+            "type": .string("object"),
+            "properties": .object(properties)
+        ])
+    }
+
+    private func intProp() -> JSONSchemaValue { .object(["type": .string("integer")]) }
+    private func numProp() -> JSONSchemaValue { .object(["type": .string("number")]) }
+    private func boolProp() -> JSONSchemaValue { .object(["type": .string("boolean")]) }
+    private func stringProp() -> JSONSchemaValue { .object(["type": .string("string")]) }
+
+    // MARK: - integer / number
+
+    func test_coercesStringToInteger_whenSchemaSaysInteger() {
+        let s = schema(["age": intProp()])
+        let args: JSONSchemaValue = .object(["age": .string("42")])
+
+        let result = ToolArgumentCoercer.coerce(args, against: s)
+
+        XCTAssertEqual(result, .object(["age": .number(42)]))
+    }
+
+    func test_coercesStringToNumber_whenSchemaSaysNumber() {
+        let s = schema(["pi": numProp()])
+        let args: JSONSchemaValue = .object(["pi": .string("3.14")])
+
+        let result = ToolArgumentCoercer.coerce(args, against: s)
+
+        XCTAssertEqual(result, .object(["pi": .number(3.14)]))
+    }
+
+    func test_coercesNegativeAndScientificNotation() {
+        let s = schema(["x": numProp(), "y": intProp()])
+        let args: JSONSchemaValue = .object([
+            "x": .string("-2.5e3"),
+            "y": .string("-7")
+        ])
+
+        let result = ToolArgumentCoercer.coerce(args, against: s)
+
+        XCTAssertEqual(result, .object([
+            "x": .number(-2500),
+            "y": .number(-7)
+        ]))
+    }
+
+    func test_unparseableNumber_fallsThroughAsString() {
+        let s = schema(["age": intProp()])
+        let args: JSONSchemaValue = .object(["age": .string("not-a-number")])
+
+        let result = ToolArgumentCoercer.coerce(args, against: s)
+
+        XCTAssertEqual(result, .object(["age": .string("not-a-number")]))
+    }
+
+    // MARK: - boolean
+
+    func test_coercesLowercaseTrueAndFalse() {
+        let s = schema(["a": boolProp(), "b": boolProp()])
+        let args: JSONSchemaValue = .object([
+            "a": .string("true"),
+            "b": .string("false")
+        ])
+
+        let result = ToolArgumentCoercer.coerce(args, against: s)
+
+        XCTAssertEqual(result, .object([
+            "a": .bool(true),
+            "b": .bool(false)
+        ]))
+    }
+
+    func test_coercesMixedCaseBooleans() {
+        let s = schema(["a": boolProp(), "b": boolProp(), "c": boolProp()])
+        let args: JSONSchemaValue = .object([
+            "a": .string("True"),
+            "b": .string("TRUE"),
+            "c": .string("False")
+        ])
+
+        let result = ToolArgumentCoercer.coerce(args, against: s)
+
+        XCTAssertEqual(result, .object([
+            "a": .bool(true),
+            "b": .bool(true),
+            "c": .bool(false)
+        ]))
+    }
+
+    func test_nonBooleanString_fallsThroughAsString() {
+        let s = schema(["flag": boolProp(), "other": boolProp()])
+        let args: JSONSchemaValue = .object([
+            "flag": .string("yes"),
+            "other": .string("abc")
+        ])
+
+        let result = ToolArgumentCoercer.coerce(args, against: s)
+
+        XCTAssertEqual(result, .object([
+            "flag": .string("yes"),
+            "other": .string("abc")
+        ]))
+    }
+
+    // MARK: - pass-through
+
+    func test_alreadyCorrectTypes_passThroughUntouched() {
+        let s = schema(["age": intProp(), "flag": boolProp(), "pi": numProp()])
+        let args: JSONSchemaValue = .object([
+            "age": .number(42),
+            "flag": .bool(true),
+            "pi": .number(3.14)
+        ])
+
+        let result = ToolArgumentCoercer.coerce(args, against: s)
+
+        XCTAssertEqual(result, args)
+    }
+
+    func test_stringSchema_leavesStringsAlone() {
+        let s = schema(["name": stringProp()])
+        let args: JSONSchemaValue = .object(["name": .string("42")])
+
+        let result = ToolArgumentCoercer.coerce(args, against: s)
+
+        XCTAssertEqual(result, .object(["name": .string("42")]))
+    }
+
+    func test_missingPropertiesInSchema_returnsArgsUnchanged() {
+        let s: JSONSchemaValue = .object(["type": .string("object")])
+        let args: JSONSchemaValue = .object(["age": .string("42")])
+
+        let result = ToolArgumentCoercer.coerce(args, against: s)
+
+        XCTAssertEqual(result, args)
+    }
+
+    func test_emptySchema_returnsArgsUnchanged() {
+        let s: JSONSchemaValue = .object([:])
+        let args: JSONSchemaValue = .object(["age": .string("42")])
+
+        let result = ToolArgumentCoercer.coerce(args, against: s)
+
+        XCTAssertEqual(result, args)
+    }
+
+    func test_unknownKeyInArgs_isPreservedUnchanged() {
+        let s = schema(["age": intProp()])
+        let args: JSONSchemaValue = .object([
+            "age": .string("42"),
+            "extra": .string("hello")
+        ])
+
+        let result = ToolArgumentCoercer.coerce(args, against: s)
+
+        XCTAssertEqual(result, .object([
+            "age": .number(42),
+            "extra": .string("hello")
+        ]))
+    }
+
+    func test_nonObjectArgs_returnUnchanged() {
+        let s = schema(["age": intProp()])
+        let args: JSONSchemaValue = .array([.string("42")])
+
+        let result = ToolArgumentCoercer.coerce(args, against: s)
+
+        XCTAssertEqual(result, args)
+    }
+
+    // MARK: - top-level only
+
+    func test_doesNotRecurseIntoNestedObjects() {
+        // `nested.age` is a string and the nested object's schema says
+        // integer, but coercion is top-level only — nested values pass
+        // through unchanged. This matches Goose's scope.
+        let nestedSchema: JSONSchemaValue = .object([
+            "type": .string("object"),
+            "properties": .object(["age": intProp()])
+        ])
+        let s = schema(["nested": nestedSchema])
+        let args: JSONSchemaValue = .object([
+            "nested": .object(["age": .string("42")])
+        ])
+
+        let result = ToolArgumentCoercer.coerce(args, against: s)
+
+        XCTAssertEqual(result, .object([
+            "nested": .object(["age": .string("42")])
+        ]))
+    }
+
+    // MARK: - registry integration
+
+    @MainActor
+    func test_registryDispatch_coercesByDefault() async {
+        let registry = ToolRegistry()
+        registry.validator = JSONSchemaValidator()
+
+        struct Captured: Sendable { var value: JSONSchemaValue? }
+        final class Box: @unchecked Sendable {
+            var captured: JSONSchemaValue?
+        }
+        let box = Box()
+
+        final class Recorder: ToolExecutor, @unchecked Sendable {
+            let definition: ToolDefinition
+            let box: Box
+            init(box: Box) {
+                self.box = box
+                self.definition = ToolDefinition(
+                    name: "set_age",
+                    description: "",
+                    parameters: .object([
+                        "type": .string("object"),
+                        "properties": .object([
+                            "age": .object(["type": .string("integer")])
+                        ]),
+                        "required": .array([.string("age")])
+                    ])
+                )
+            }
+            func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+                box.captured = arguments
+                return ToolResult(callId: "", content: "ok", errorKind: nil)
+            }
+        }
+
+        registry.register(Recorder(box: box))
+
+        let call = ToolCall(id: "c1", toolName: "set_age", arguments: #"{"age":"42"}"#)
+        let result = await registry.dispatch(call)
+
+        XCTAssertNil(result.errorKind, "schema validation should pass after coercion")
+        XCTAssertEqual(box.captured, .object(["age": .number(42)]))
+    }
+
+    @MainActor
+    func test_registryDispatch_skipsCoercionWhenDisabled() async {
+        let registry = ToolRegistry()
+        registry.validator = JSONSchemaValidator()
+        registry.coercesArguments = false
+
+        final class Recorder: ToolExecutor, @unchecked Sendable {
+            let definition: ToolDefinition
+            init() {
+                self.definition = ToolDefinition(
+                    name: "set_age",
+                    description: "",
+                    parameters: .object([
+                        "type": .string("object"),
+                        "properties": .object([
+                            "age": .object(["type": .string("integer")])
+                        ]),
+                        "required": .array([.string("age")])
+                    ])
+                )
+            }
+            func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+                return ToolResult(callId: "", content: "ok", errorKind: nil)
+            }
+        }
+
+        registry.register(Recorder())
+
+        let call = ToolCall(id: "c1", toolName: "set_age", arguments: #"{"age":"42"}"#)
+        let result = await registry.dispatch(call)
+
+        XCTAssertEqual(result.errorKind, .invalidArguments,
+                      "validator should reject the string when coercion is disabled")
+    }
+}

--- a/Tests/BaseChatInferenceTests/ToolCallLoopOrchestratorTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolCallLoopOrchestratorTests.swift
@@ -168,14 +168,93 @@ final class ToolCallLoopOrchestratorTests: XCTestCase {
             config: GenerationConfig()
         ))
 
-        guard case .loopDetected(let toolName) = events.last else {
+        guard case .loopDetected(let finding) = events.last else {
             return XCTFail("last event must be .loopDetected, got \(events)")
         }
-        XCTAssertEqual(toolName, "spin")
+        XCTAssertEqual(finding.toolName, "spin")
+        XCTAssertEqual(finding.findingID, "REP-001")
+        XCTAssertEqual(finding.repetitionCount, 3)
+        XCTAssertTrue(
+            finding.reason.contains("spin"),
+            "reason should mention the offending tool, got \(finding.reason)"
+        )
+        XCTAssertTrue(
+            finding.reason.contains("identical arguments"),
+            "reason should describe the heuristic, got \(finding.reason)"
+        )
         // Loop must have fired on the third identical call — the third
         // generate() round produced the third identical signature, so the
         // backend was invoked exactly three times.
         XCTAssertEqual(backend.generateCallCount, 3)
+    }
+
+    func test_loopDetected_findingID_isStable_REP001() async throws {
+        // The findingID is a public contract for downstream consumers
+        // (fuzz harness, telemetry). Lock it to "REP-001" so a typo in the
+        // emission site is caught here rather than by a downstream switch
+        // that silently routes through a default branch.
+        let backend = makeBackend()
+        let identical = ToolCall(id: "c", toolName: "spin", arguments: #"{"k":1}"#)
+        backend.scriptedToolCallsPerTurn = [
+            [identical], [identical], [identical],
+        ]
+        backend.tokensToYieldPerTurn = Array(repeating: [], count: 3)
+
+        let executor = ScriptedExecutor(name: "spin") { _ in
+            ToolResult(callId: "", content: "ok", errorKind: nil)
+        }
+
+        let orchestrator = ToolCallLoopOrchestrator(
+            backend: backend,
+            executor: executor,
+            policy: ToolCallLoopPolicy(maxSteps: 10, loopDetectionWindow: 3)
+        )
+
+        let events = try await collect(orchestrator.run(
+            initialPrompt: "go",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+
+        guard case .loopDetected(let finding) = events.last else {
+            return XCTFail("expected .loopDetected, got \(events)")
+        }
+        XCTAssertEqual(finding.findingID, "REP-001")
+    }
+
+    func test_loopDetected_repetitionCount_matchesPolicyWindow() async throws {
+        // repetitionCount must equal the configured window at the moment
+        // the heuristic fires. Drive a window of 4 to prove the value is
+        // policy-driven, not a hardcoded 3.
+        let backend = makeBackend()
+        let identical = ToolCall(id: "c", toolName: "spin", arguments: #"{"k":1}"#)
+        backend.scriptedToolCallsPerTurn = Array(repeating: [identical], count: 5)
+        backend.tokensToYieldPerTurn = Array(repeating: [], count: 5)
+
+        let executor = ScriptedExecutor(name: "spin") { _ in
+            ToolResult(callId: "", content: "ok", errorKind: nil)
+        }
+
+        let orchestrator = ToolCallLoopOrchestrator(
+            backend: backend,
+            executor: executor,
+            policy: ToolCallLoopPolicy(maxSteps: 10, loopDetectionWindow: 4)
+        )
+
+        let events = try await collect(orchestrator.run(
+            initialPrompt: "go",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+
+        guard case .loopDetected(let finding) = events.last else {
+            return XCTFail("expected .loopDetected, got \(events)")
+        }
+        XCTAssertEqual(finding.repetitionCount, 4)
+        XCTAssertTrue(
+            finding.reason.contains("window of 4"),
+            "reason should reflect the configured window, got \(finding.reason)"
+        )
     }
 
     // MARK: - Cancellation


### PR DESCRIPTION
## Summary

Ports four self-contained patterns from Goose AI's agent runtime (now stewarded by the Linux Foundation's Agentic AI Foundation) that harden BCK's tool-calling and inference paths. All four landed as separate commits so reviewers can read them independently.

| Commit | Pattern | Source |
|---|---|---|
| `ec8ef4d` | Tool argument type coercion | `crates/goose/src/agents/reply_parts.rs::coerce_tool_arguments` |
| `ebd944b` | Trigger-aware compaction continuation prompts | `crates/goose/src/context_mgmt/mod.rs` (CONVERSATION/TOOL_LOOP/MANUAL constants) |
| `a92ca9a` | Structured tool-loop finding (REP-001) | `crates/goose/src/tool_monitor.rs::RepetitionInspector` |
| `c0dc545` | Optional fast-backend routing | `crates/goose/src/model.rs::use_fast_model` + provider fallback |

A fifth pattern (file-spilling for oversize tool results) was deferred — it needs a platform-specific spill directory and a cleanup reaper, which is more than a single-PR scope. Tracked in #846.

## Release Note

### Tool calling — argument coercion

Models frequently emit tool arguments with the wrong JSON type, sending `"42"` (string) when the schema declares `integer`, or `"true"` when the schema declares `boolean`. Previously these failed validation immediately. `ToolRegistry` now coerces top-level string arguments to the schema-declared primitive type before validation, falling through to the original string on parse failure.

\`\`\`swift
// Default ON; opt out per-registry if needed.
registry.coercesArguments = true
\`\`\`

Coercion only applies at the top level — nested objects and arrays are left alone, matching Goose's behavior.

### Compaction — context-aware continuation prompts

`TurnHistoryCompressor` now accepts a `CompactionTrigger` (`automatic`, `toolLoop`, `manual`). The default budget compressor appends a continuation prompt tuned to the trigger so models do not acknowledge that summarization happened.

\`\`\`swift
public enum CompactionTrigger: Sendable {
    case automatic   // budget exceeded
    case toolLoop    // mid tool-calling loop
    case manual      // user-requested
}
\`\`\`

Existing custom compressors keep working unchanged via a default protocol extension. The orchestrator passes `.toolLoop`.

### Tool-loop detection — structured finding

`ToolLoopEvent.loopDetected` now carries a `ToolLoopFinding` payload (BREAKING — see migration below). Consumers can branch on `findingID == "REP-001"` without string-matching reason text:

\`\`\`swift
public struct ToolLoopFinding: Sendable, Equatable {
    public let findingID: String       // "REP-001"
    public let toolName: String
    public let reason: String
    public let repetitionCount: Int
}
\`\`\`

### Inference — optional fast-backend routing

`InferenceService` gains an optional `fastBackend` slot. Lightweight subtasks (future LLM-driven summarization, session naming) can opt into dispatching there first, falling back to the primary backend on failure.

\`\`\`swift
let service = InferenceService()
service.primaryBackend = mlxBackend       // 7B–13B
service.fastBackend = ollamaBackend       // 1B–3B
// Subtasks call: try await service.runFastOrPrimary(..., preferFast: true)
\`\`\`

Additive and opt-in — hosts that don't set `fastBackend` see no change. No internal call sites are migrated in this PR.

## Breaking changes

`ToolLoopEvent.loopDetected` payload changed from `String` (toolName) to `ToolLoopFinding`. Pattern matches on the case must be updated:

\`\`\`swift
// Before
case .loopDetected(let toolName):
    print("loop on \(toolName)")

// After
case .loopDetected(let finding):
    print("loop on \(finding.toolName) [\(finding.findingID)]")
\`\`\`

## Test plan

- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 1253 passing
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits` — 83 passing
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 275 passing (4 skipped)
- [x] `swift test --filter BaseChatUITests --skip "PerformanceTests" --disable-default-traits` — 435 passing
- [x] `swift test --filter BaseChatUIModelManagementTests --disable-default-traits` — 94 passing
- [x] `swift test --filter BaseChatMCPTests --disable-default-traits` — 104 passing
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 4 passing
- [x] `swift test --filter BaseChatTestSupportTests --disable-default-traits` — 16 passing
- [x] `swift test --filter BaseChatAppIntentsTests --disable-default-traits` — 11 passing
- [x] +31 new tests added across the four features; sabotage check performed on each
- [ ] CI runs all per-PR suites including `LargeSessionListPerformanceTests` (~65s, nightly-tier)

## Refs

- Tracks #846 (deferred Tier 2: tool-result file-spilling)
- Inspired by Goose AI v1.32.0 (April 23, 2026)