### PR TITLE
chore(inference): freeze tool-call enum vocabulary for 1.0

### DIFF
--- a/Sources/BaseChatInference/Models/GenerationEvent.swift
+++ b/Sources/BaseChatInference/Models/GenerationEvent.swift
@@ -3,6 +3,40 @@
 /// Replaces the raw `String` token stream to support usage reporting and
 /// future structured output without breaking the `InferenceBackend`
 /// contract again.
+///
+/// ## Vocabulary freeze (1.0)
+///
+/// The tool-call event vocabulary is locked as of the 1.0 release. Key design
+/// decisions recorded here for Wave 3 consumers:
+///
+/// ### Coordinator-emitted lifecycle events
+///
+/// ``toolDispatchStarted(callId:name:attempt:)`` and
+/// ``toolDispatchCompleted(callId:durationMs:errorKind:)`` are emitted by the
+/// **coordinator** (`GenerationCoordinator`), not by individual backends and not
+/// by ``ToolCallLoopOrchestrator`` (which silently drops these events — it has
+/// its own dispatch surface). Backends emit only ``toolCall(_:)`` (and, when
+/// streaming, ``toolCallStart(callId:name:)`` and
+/// ``toolCallArgumentsDelta(callId:textDelta:)``). Consumers driving generation
+/// through `InferenceService` / `GenerationCoordinator` that reconstruct
+/// timelines or present per-call spinners should key on these coordinator events,
+/// not on the backend streaming events.
+///
+/// ### `.toolCallNameDelta` is intentionally absent
+///
+/// There is no streaming name-delta event. Backends **must** emit the tool name
+/// up-front and complete in ``toolCallStart(callId:name:)`` and
+/// ``toolCall(_:)``. Grammar-constrained backends (Llama/Gemma-4 GBNF) are
+/// required to buffer output until the name token sequence is complete before
+/// emitting. This keeps consumers simple: the name is always final on first
+/// observation.
+///
+/// ### Source compatibility for pattern-match consumers
+///
+/// Adding new cases to this enum is source-breaking for exhaustive `switch`
+/// statements. Wave 3 test PRs that pattern-match `GenerationEvent` values
+/// **must** include a `default:` or `@unknown default:` arm, or be updated in
+/// the same PR that adds a new case.
 public enum GenerationEvent: Sendable, Equatable {
     /// Progress update while the backend is evaluating prompt tokens before the
     /// first generated content token is available.

--- a/Sources/BaseChatInference/Models/ToolTypes.swift
+++ b/Sources/BaseChatInference/Models/ToolTypes.swift
@@ -182,24 +182,61 @@ public struct ToolResult: Sendable, Codable, Equatable, Hashable {
     /// the failure so backends, orchestrators, and UI surfaces can decide whether
     /// to retry, surface a permission prompt, feed the error back to the model,
     /// or abort the loop. The string raw values are stable on the wire.
+    ///
+    /// ## Vocabulary freeze (1.0)
+    ///
+    /// All nine cases below are locked for the 1.0 release. Do not add, remove,
+    /// or rename cases without a BREAKING CHANGE commit footer — the raw values
+    /// are persisted and transmitted on the wire.
+    ///
+    /// ### Retryability distinctions
+    ///
+    /// - ``transient`` vs ``cancelled``: `.cancelled` means the user or system
+    ///   *explicitly stopped* the call — the model should not retry because
+    ///   cancellation was intentional. `.transient` means the tool infrastructure
+    ///   encountered a recoverable glitch (network blip, transient overload) and
+    ///   the model *may* retry the same call with the same arguments.
+    ///
+    /// - ``transient`` vs ``permanent``: `.permanent` means the failure is
+    ///   structural — retrying with the same inputs will not help (e.g., a
+    ///   configuration error, an unsupported operation). `.transient` is its
+    ///   retry-eligible counterpart for ephemeral infrastructure failures.
+    ///
+    /// ### Dispatch vs runtime distinctions
+    ///
+    /// - ``unknownTool`` vs ``notFound``: `.unknownTool` is a *dispatch-time*
+    ///   failure — no registered executor matched the call name, so the tool
+    ///   never ran. `.notFound` is a *runtime* failure — the executor ran but the
+    ///   resource it looked for (file, record, URL) did not exist.
     public enum ErrorKind: String, Sendable, Codable, Equatable, Hashable {
         /// Arguments did not parse as JSON or failed schema validation.
+        /// Indicates a model-side formatting error; feeding the error back lets
+        /// the model self-correct on the next turn.
         case invalidArguments
         /// The caller lacks permission to run the tool (user denied, missing scope).
+        /// Surface a permission prompt rather than retrying silently.
         case permissionDenied
-        /// A resource referenced by the tool (file, record, URL) does not exist.
+        /// The executor ran but a resource it needed (file, record, URL) was absent.
+        /// Distinct from ``unknownTool``, which fires before execution begins.
         case notFound
         /// The tool exceeded its time budget.
+        /// May be retried if the operation can be made faster or if the budget can be widened.
         case timeout
         /// The tool or an underlying service applied back-pressure.
+        /// Retry after a back-off delay; do not change the arguments.
         case rateLimited
-        /// The tool execution was cancelled by the caller.
+        /// The call was explicitly stopped by the user or system before it completed.
+        /// The model should not retry — cancellation was intentional, not a glitch.
         case cancelled
-        /// A transient failure — safe to retry without changing inputs.
+        /// A recoverable infrastructure failure (network blip, transient overload).
+        /// The model may retry the same call with the same arguments unchanged.
+        /// Distinct from ``cancelled`` (explicit stop) and ``permanent`` (structural failure).
         case transient
-        /// A permanent failure — retrying with the same inputs will not help.
+        /// A structural failure that retrying with the same inputs will not fix.
+        /// Report the error to the user; do not loop. Distinct from ``transient``.
         case permanent
-        /// The tool name did not match any registered executor.
+        /// No registered executor matched the call name — dispatch failed before execution.
+        /// Distinct from ``notFound``, which fires inside a running executor.
         case unknownTool
     }
 

--- a/Sources/BaseChatInference/Protocols/BackendCapabilities.swift
+++ b/Sources/BaseChatInference/Protocols/BackendCapabilities.swift
@@ -106,6 +106,15 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
     /// set `false`.
     public let streamsToolCallArguments: Bool
 
+    /// Whether the backend streams tool-call argument deltas incrementally.
+    /// Alias for ``streamsToolCallArguments`` with a clearer name.
+    ///
+    /// The original name `streamsToolCallArguments` is ambiguous — it could be
+    /// read as "streams the arguments as a whole". This alias makes the
+    /// incremental-delta semantics explicit. Both names refer to the same
+    /// capability and may be used interchangeably.
+    public var streamsToolCallArgumentDeltas: Bool { streamsToolCallArguments }
+
     /// True when the backend can emit multiple ``GenerationEvent/toolCall(_:)``
     /// events in one generation round (parallel batch). Single-call backends
     /// and small local models that only reliably emit one call at a time set


### PR DESCRIPTION
## Summary

- Locks down `ToolResult.ErrorKind` semantics with a vocabulary-freeze doc-comment block documenting the canonical distinctions between all 9 cases (transient vs cancelled, transient vs permanent, unknownTool vs notFound). Per-case `///` doc-comments added explaining the *why* for each.
- Records the `.toolCallNameDelta` absence decision in `GenerationEvent` doc-comments: backends must emit tool names up-front and complete; grammar-constrained backends (Llama/Gemma-4 GBNF) must buffer until the name sequence is complete before emitting. Also documents that `toolDispatchStarted`/`toolDispatchCompleted` are orchestrator-emitted, not backend-emitted.
- Adds `streamsToolCallArgumentDeltas: Bool` as a clearer-named alias for `streamsToolCallArguments` on `BackendCapabilities`. The original name is retained unchanged — additive only, non-breaking.

## Decisions made

| Decision | Outcome |
|---|---|
| Keep all 9 `ErrorKind` cases | Yes — all confirmed; no case removed or renamed |
| Add `.toolCallNameDelta` case to `GenerationEvent` | No — intentionally absent; name must be emitted up-front |
| `@frozen` on `ErrorKind` | Skipped — no project precedent (zero `@frozen` hits across `Sources/`) |
| Deprecate `streamsToolCallArguments` | No — additive alias only, original preserved |

## No behaviour change

This PR is doc-comments and one computed property alias. All existing behaviour is unchanged.

## Test plan

- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 0 failures
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 0 failures
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits` — 0 failures
- [x] `swift test --filter BaseChatUITests --disable-default-traits` — 0 failures
- [x] `swift test --filter BaseChatUIModelManagementTests --disable-default-traits` — 0 failures
- [x] `swift test --filter BaseChatMCPTests --disable-default-traits` — 0 failures
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — 0 failures
- [x] `swift test --filter BaseChatTestSupportTests --disable-default-traits` — 0 failures
- [x] `swift test --filter BaseChatAppIntentsTests --disable-default-traits` — 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)