### PR TITLE
test(inference): capability-flag enforcement — reject tools on non-tool-calling backends

### DIFF
--- a/Sources/BaseChatInference/Services/GenerationCoordinator.swift
+++ b/Sources/BaseChatInference/Services/GenerationCoordinator.swift
@@ -534,18 +534,19 @@ final class GenerationCoordinator {
             throw InferenceError.inferenceFailure("Generation queue is full")
         }
 
-        // Capability gate for tool calling. Mirrors the jsonMode warning at the
-        // top of `generate(messages:)`: tools passed to a backend that reports
-        // `supportsToolCalling == false` are silently dropped on the wire,
-        // and the model loops on "I cannot access tools" while the host's
-        // registry never sees the call. Warn once at enqueue time so the
-        // signal is loud and the failure mode is diagnosable.
+        // Capability gate for tool calling. A backend that reports
+        // `supportsToolCalling == false` has no wire path for tool definitions
+        // — they are silently dropped, and the model loops on "I cannot access
+        // tools" while the host's registry never sees the call. Reject the
+        // request up front with a clear error so the failure is diagnosable
+        // at the call site rather than manifesting as a silent no-op.
         if !tools.isEmpty && !backend.capabilities.supportsToolCalling {
             let backendType = String(describing: type(of: backend))
             let toolWord = tools.count == 1 ? "tool" : "tools"
             let message = "GenerationCoordinator: \(tools.count) \(toolWord) passed to enqueue() but \(backendType) reports capabilities.supportsToolCalling == false; tools will be ignored on the wire and tool calls will never be dispatched. Check `backend.capabilities.supportsToolCalling` before passing tools, or load a tool-capable backend."
             Log.inference.warning("\(message, privacy: .public)")
             Self.toolsUnsupportedWarningHook?(backendType, message)
+            throw InferenceError.inferenceFailure("Tools passed to a backend that does not support tool calling (\(backendType)); set capabilities.supportsToolCalling = true or remove tools from the request.")
         }
 
         let token = GenerationRequestToken(rawValue: nextGenerationToken.rawValue + 1)

--- a/Tests/BaseChatInferenceTests/CapabilityFlagEnforcementTests.swift
+++ b/Tests/BaseChatInferenceTests/CapabilityFlagEnforcementTests.swift
@@ -1,0 +1,169 @@
+import XCTest
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Tests that `GenerationCoordinator.enqueue()` enforces capability flags.
+///
+/// Coverage:
+/// - tools rejected (throw + warning) when backend reports `supportsToolCalling == false`
+/// - warning hook fires before the throw
+/// - empty-tools request succeeds on a non-tool-calling backend (no regression)
+/// - tools allowed when `supportsToolCalling == true`
+///
+/// The guard lives at the top of `enqueue(structuredMessages:...)`, immediately
+/// after the queue-depth check, so the throw is synchronous and happens before
+/// the request enters the queue.
+@MainActor
+final class CapabilityFlagEnforcementTests: XCTestCase {
+
+    // MARK: - Thread-safe warning collector
+
+    /// Thread-safe collector for warning hook invocations. The hook is
+    /// `@Sendable` so captured state must be protected against concurrent
+    /// writes even though, in practice, the coordinator fires the hook on
+    /// the same `@MainActor` isolation as `enqueue()`.
+    private final class WarningCollector: @unchecked Sendable {
+        private let lock = NSLock()
+        private(set) var entries: [(backendType: String, message: String)] = []
+
+        func record(backendType: String, message: String) {
+            lock.lock()
+            defer { lock.unlock() }
+            entries.append((backendType: backendType, message: message))
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private var provider: FakeGenerationContextProvider!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        provider = FakeGenerationContextProvider()
+    }
+
+    override func tearDown() async throws {
+        // Always clear the warning hook to avoid cross-test leakage.
+        GenerationCoordinator.toolsUnsupportedWarningHook = nil
+        provider = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeCoordinator() -> GenerationCoordinator {
+        let coordinator = GenerationCoordinator()
+        coordinator.provider = provider
+        return coordinator
+    }
+
+    private func makeNonToolCapableBackend() -> MockInferenceBackend {
+        let caps = BackendCapabilities(
+            supportedParameters: [.temperature],
+            maxContextTokens: 4096,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsToolCalling: false
+        )
+        let backend = MockInferenceBackend(capabilities: caps)
+        backend.isModelLoaded = true
+        return backend
+    }
+
+    private func makeNoopTool() -> ToolDefinition {
+        ToolDefinition(name: "noop", description: "test tool", parameters: .object([:]))
+    }
+
+    // MARK: - Tests
+
+    /// Passing a non-empty `tools` array to `enqueue()` when the active
+    /// backend reports `supportsToolCalling == false` must:
+    /// 1. Fire `toolsUnsupportedWarningHook` exactly once.
+    /// 2. Throw `InferenceError.inferenceFailure` synchronously before any
+    ///    stream is returned — tools must never silently no-op.
+    ///
+    /// Sabotage: if you comment out the `throw` at the end of the capability
+    /// guard in `GenerationCoordinator.enqueue(structuredMessages:...)`, this
+    /// test fails because `enqueue` returns a stream instead of throwing.
+    func test_tools_rejectedOnNonToolCallingBackend() throws {
+        let backend = makeNonToolCapableBackend()
+        provider = FakeGenerationContextProvider(backend: backend)
+        let coordinator = makeCoordinator()
+
+        let collector = WarningCollector()
+        GenerationCoordinator.toolsUnsupportedWarningHook = { backendType, message in
+            collector.record(backendType: backendType, message: message)
+        }
+
+        let tool = makeNoopTool()
+
+        XCTAssertThrowsError(
+            try coordinator.enqueue(
+                messages: [("user", "do something")],
+                tools: [tool]
+            )
+        ) { error in
+            guard case InferenceError.inferenceFailure(let msg) = error else {
+                XCTFail("Expected InferenceError.inferenceFailure, got \(error)")
+                return
+            }
+            XCTAssertTrue(
+                msg.contains("does not support tool calling"),
+                "Error message must describe the capability gap: \(msg)"
+            )
+        }
+
+        // The warning hook must have fired before the throw so the caller
+        // has a log trail even if they don't inspect the error message.
+        XCTAssertEqual(collector.entries.count, 1,
+                       "toolsUnsupportedWarningHook must fire exactly once")
+        XCTAssertEqual(collector.entries.first?.backendType, "MockInferenceBackend")
+    }
+
+    /// Passing `tools: []` (or not passing tools at all) to a non-tool-calling
+    /// backend must succeed — the capability guard only fires when tools are
+    /// actually provided.
+    func test_emptyTools_onNonToolCallingBackend_succeeds() async throws {
+        let backend = makeNonToolCapableBackend()
+        provider = FakeGenerationContextProvider(backend: backend)
+        let coordinator = makeCoordinator()
+
+        // No tools → enqueue must succeed and the stream must complete normally.
+        let (_, stream) = try coordinator.enqueue(
+            messages: [("user", "hello")],
+            tools: []
+        )
+
+        var tokens: [String] = []
+        for try await event in stream.events {
+            if case .token(let t) = event { tokens.append(t) }
+        }
+
+        XCTAssertFalse(tokens.isEmpty,
+                       "Generation should produce tokens when no tools are passed")
+    }
+
+    /// Passing tools to a backend that DOES support tool calling must not
+    /// throw — the guard must only block the incapable-backend path.
+    func test_tools_allowedOnToolCapableBackend() throws {
+        let caps = BackendCapabilities(
+            supportedParameters: [.temperature],
+            maxContextTokens: 4096,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsToolCalling: true
+        )
+        let backend = MockInferenceBackend(capabilities: caps)
+        backend.isModelLoaded = true
+        provider = FakeGenerationContextProvider(backend: backend)
+        let coordinator = makeCoordinator()
+
+        let tool = makeNoopTool()
+
+        // Must not throw; a valid stream token is returned.
+        let (_, _) = try coordinator.enqueue(
+            messages: [("user", "call the tool")],
+            tools: [tool]
+        )
+    }
+}

--- a/Tests/BaseChatInferenceTests/GenerationCoordinatorTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationCoordinatorTests.swift
@@ -163,13 +163,13 @@ final class GenerationCoordinatorTests: XCTestCase {
     // MARK: - Tool-capability silent-ignore warning
 
     /// When `tools` are passed to `enqueue` and the active backend reports
-    /// `supportsToolCalling == false`, the coordinator must emit a warning so
-    /// callers have a signal that the registry will never see a dispatch.
-    /// Mirrors the jsonMode silent-ignore warning above.
+    /// `supportsToolCalling == false`, the coordinator must emit a warning and
+    /// then throw `InferenceError.inferenceFailure` so callers have a clear
+    /// signal that the registry will never see a dispatch.
     ///
     /// Sabotage check: deleting the warning branch in `GenerationCoordinator.enqueue`
-    /// leaves `captured` empty and this assertion fails.
-    func test_enqueue_toolsOnUnsupportedBackend_emitsWarning() async throws {
+    /// leaves `captured` empty and the warning assertion fails.
+    func test_enqueue_toolsOnUnsupportedBackend_emitsWarningAndThrows() async throws {
         // MockInferenceBackend defaults to supportsToolCalling == false.
         let captured = WarningCapture()
         GenerationCoordinator.toolsUnsupportedWarningHook = { backendType, message in
@@ -181,11 +181,22 @@ final class GenerationCoordinatorTests: XCTestCase {
             name: "get_weather",
             description: "Lookup the weather for a city"
         )
-        let (_, stream) = try coordinator.enqueue(
-            messages: [("user", "What's the weather?")],
-            tools: [tool]
-        )
-        for try await _ in stream.events {}
+
+        // The coordinator must reject the request with a clear error before
+        // any stream is created — the warning fires, then the throw follows.
+        XCTAssertThrowsError(
+            try coordinator.enqueue(
+                messages: [("user", "What's the weather?")],
+                tools: [tool]
+            )
+        ) { error in
+            guard case InferenceError.inferenceFailure(let msg) = error else {
+                XCTFail("expected InferenceError.inferenceFailure, got \(error)")
+                return
+            }
+            XCTAssertTrue(msg.contains("does not support tool calling"),
+                          "error message must describe the capability gap: \(msg)")
+        }
 
         let entries = captured.snapshot()
         XCTAssertEqual(entries.count, 1, "warning must fire exactly once per enqueue")


### PR DESCRIPTION
## Summary

**Investigation finding:** Before this PR, passing `tools` to a backend with `supportsToolCalling == false` was **outcome (B) — silent pass-through**. `enqueue()` emitted a `Log.inference.warning` and called `toolsUnsupportedWarningHook`, then continued normally. The tools were forwarded to the backend's `generate()` call where they were silently ignored on the wire. The model would loop on "I cannot access tools" while the host's `ToolRegistry` never saw a dispatch.

**What shipped:**

- Added a `throw` at the end of the existing capability-warning block in `GenerationCoordinator.enqueue(structuredMessages:...)` (~5 LOC change). The warning still fires first (preserving the log trail), then `InferenceError.inferenceFailure` is thrown with a message that names the backend type and the fix.
- Guard location: `Sources/BaseChatInference/Services/GenerationCoordinator.swift`, inside the `if !tools.isEmpty && !backend.capabilities.supportsToolCalling` block, immediately after the existing `Log.inference.warning` / `toolsUnsupportedWarningHook` calls.
- New `CapabilityFlagEnforcementTests.swift` with three tests:
  - `test_tools_rejectedOnNonToolCallingBackend` — asserts the throw and that `toolsUnsupportedWarningHook` fires before it (sabotage: commenting the throw makes this fail)
  - `test_emptyTools_onNonToolCallingBackend_succeeds` — empty-tools path is unaffected
  - `test_tools_allowedOnToolCapableBackend` — `supportsToolCalling=true` path is unaffected
- Updated `test_enqueue_toolsOnUnsupportedBackend_emitsWarning` → renamed `…_emitsWarningAndThrows` in `GenerationCoordinatorTests.swift` to match the new behaviour (old test expected successful enqueue; new test asserts the throw + warning ordering).

## Test plan

- [ ] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 1273 tests, 0 failures (verified locally)
- [ ] Confirm `CapabilityFlagEnforcementTests` shows 3 passing tests in the run
- [ ] Confirm `test_enqueue_toolsOnUnsupportedBackend_emitsWarningAndThrows` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)