### PR TITLE
feat: expose compiled backend build profiles

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -87,6 +87,8 @@ let package = Package(
             ],
             path: "Sources/BaseChatInference",
             swiftSettings: [
+                .define("MLX", .when(traits: ["MLX"])),
+                .define("Llama", .when(traits: ["Llama"])),
                 .define("Ollama", .when(traits: ["Ollama"])),
                 .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
             ]

--- a/README.md
+++ b/README.md
@@ -94,14 +94,15 @@ Add the targets you need:
 
 ### 2. Build modes
 
-BaseChatKit ships four pre-blessed build configurations keyed by use case. Backends are gated behind Swift package traits so consumers in regulated or air-gapped environments can compile out everything that touches the network.
+BaseChatKit ships four pre-blessed build profiles keyed by the network surface a binary exposes. Backends are gated behind Swift package traits so consumers in regulated or air-gapped environments can compile out everything that touches the network.
 
-| Use case | Build command | Backends available |
-|----------|---------------|--------------------|
-| Default consumer app | `swift build` | MLX, Llama, Ollama |
-| Regulated vertical (local-only, no networking) | `swift build --disable-default-traits --traits MLX,Llama` | MLX, Llama |
-| Self-hosted / private datacenter | `swift build --disable-default-traits --traits MLX,Llama,Ollama` | MLX, Llama, Ollama |
-| Full / SaaS-enabled | `swift build --traits MLX,Llama,Ollama,CloudSaaS` | MLX, Llama, Ollama, Claude, OpenAI |
+| Profile | Build command | Build profile at runtime | Remote providers compiled in |
+|---------|---------------|--------------------------|-----------------------------|
+| Default consumer app | `swift build` | `offline` | none |
+| Regulated vertical (local-only, no networking) | `swift build --disable-default-traits --traits MLX,Llama` | `offline` | none |
+| Self-hosted / private datacenter | `swift build --disable-default-traits --traits MLX,Llama,Ollama` | `selfHosted` | Ollama |
+| SaaS-only | `swift build --disable-default-traits --traits MLX,Llama,CloudSaaS` | `saas` | Claude, OpenAI-compatible |
+| Full / SaaS-enabled | `swift build --disable-default-traits --traits MLX,Llama,Ollama,CloudSaaS` | `full` | Ollama, Claude, OpenAI-compatible |
 
 Pass the matching set as `traits:` on your `.package(...)` entry to lock the configuration in a consumer manifest:
 
@@ -118,7 +119,33 @@ Pass the matching set as `traits:` on your `.package(...)` entry to lock the con
 )
 ```
 
-`CloudSaaS` is opt-in today. **`Ollama` is in the default trait set for the current minor release but moves to opt-in in the next major** — call sites that construct `OllamaBackend()` directly emit a deprecation warning pointing at this table. Route through `DefaultBackends.register(_:)` (which gates Ollama on the trait) or add `Ollama` explicitly to your manifest to silence it. See [#714](https://github.com/roryford/BaseChatKit/issues/714).
+`CloudSaaS` and `Ollama` are opt-in. `swift build` currently compiles the local-only `offline` profile (`MLX`, `Llama`, plus Foundation Models when the OS supports them).
+
+You can inspect the compiled contract at runtime without a custom shim:
+
+```swift
+import BaseChatInference
+
+let compiled = CompiledBackends.current
+
+switch compiled.buildProfile {
+case .offline:
+    // Hide cloud endpoint settings.
+    break
+case .selfHosted, .saas, .full:
+    break
+}
+
+if compiled.shouldPresentModelDownloads {
+    // Show the stock download browser / local-model onboarding.
+}
+
+if compiled.localModelTypes.contains(.mlx) {
+    // Surface MLX-specific copy.
+}
+```
+
+If you already depend on `BaseChatBackends`, the same data is also available via `DefaultBackends.compiledBackends`.
 
 ### 2.1 Optional MCP traits
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,14 +40,13 @@ linked into the binary.
 
 | Mode      | Default? | Traits enabled                | Backends linked                 |
 |-----------|----------|-------------------------------|---------------------------------|
-| `offline` | No       | `MLX`, `Llama`                | MLX, llama.cpp, Foundation      |
-| `ollama`  | **Yes**  | `MLX`, `Llama`, `Ollama`      | + Ollama HTTP client            |
+| `offline` | **Yes**  | `MLX`, `Llama`                | MLX, llama.cpp, Foundation      |
+| `ollama`  | No       | `MLX`, `Llama`, `Ollama`      | + Ollama HTTP client            |
 | `saas`    | No       | `MLX`, `Llama`, `CloudSaaS`   | + Claude, OpenAI                |
 | `full`    | No       | all of the above              | every backend BCK ships         |
 
-The default trait set today is `MLX, Llama` (per `Package.swift`). `Ollama` is in the
-default-trait set in the **Quick Start** examples; it moves to opt-in in the next
-major. `CloudSaaS` is opt-in today.
+The default trait set today is `MLX, Llama` (per `Package.swift`), which corresponds
+to the `offline` build profile. `Ollama` and `CloudSaaS` are both opt-in.
 
 ### Consumer manifest snippets
 

--- a/Sources/BaseChatBackends/DefaultBackends.swift
+++ b/Sources/BaseChatBackends/DefaultBackends.swift
@@ -11,36 +11,33 @@ public enum DefaultBackends {
 
     // MARK: - Static Capability Queries
 
+    /// The build/trait contract compiled into the current binary.
+    public static var compiledBackends: CompiledBackends { .current }
+
+    /// The current binary's runtime-visible build profile.
+    public static var buildProfile: BackendBuildProfile { compiledBackends.buildProfile }
+
+    /// The inference traits compiled into the current binary.
+    public static var enabledTraits: Set<BackendBuildTrait> { compiledBackends.traits }
+
     /// The local model types supported by this build, without requiring
     /// an `InferenceService` instance.
     ///
     /// Useful for static checks before service construction (e.g., in unit tests
     /// or feature-flag evaluation at app startup).
     public static var supportedModelTypes: Set<ModelType> {
-        var types: Set<ModelType> = []
-        #if MLX
-        types.insert(.mlx)
-        #endif
-        #if canImport(FoundationModels)
-        if #available(iOS 26, macOS 26, *) {
-            types.insert(.foundation)
-        }
-        #endif
-        #if Llama
-        types.insert(.gguf)
-        #endif
-        return types
+        compiledBackends.localModelTypes
     }
 
     /// Returns `true` if this build includes a backend for the given local model type.
     public static func canLoad(modelType: ModelType) -> Bool {
-        supportedModelTypes.contains(modelType)
+        compiledBackends.compatibility(for: modelType).isSupported
     }
 
     /// Returns `true` if this build includes a backend for the given API provider.
-    ///
-    /// All cloud API providers are always supported in `BaseChatBackends`.
-    public static func canLoad(provider: APIProvider) -> Bool { true }
+    public static func canLoad(provider: APIProvider) -> Bool {
+        compiledBackends.compatibility(for: provider).isSupported
+    }
 
     // MARK: - Pure Routing Helpers
 

--- a/Sources/BaseChatInference/Models/APIProvider.swift
+++ b/Sources/BaseChatInference/Models/APIProvider.swift
@@ -55,13 +55,6 @@ public enum APIProvider: String, Codable, CaseIterable, Identifiable, Sendable {
     /// it's data, not behaviour, and `ConversationRecords.selectedEndpointID`
     /// must be able to decode any case regardless of build flavour.
     public static var availableInBuild: [APIProvider] {
-        var result: [APIProvider] = []
-        #if CloudSaaS
-        result.append(contentsOf: [.claude, .openAI, .openAIResponses, .lmStudio, .custom])
-        #endif
-        #if Ollama
-        result.append(.ollama)
-        #endif
-        return result
+        CompiledBackends.current.orderedCloudProviders
     }
 }

--- a/Sources/BaseChatInference/Services/CompiledBackends.swift
+++ b/Sources/BaseChatInference/Services/CompiledBackends.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+/// Inference traits that materially change which backends a build can expose at
+/// runtime.
+public enum BackendBuildTrait: String, CaseIterable, Codable, Hashable, Sendable {
+    case mlx = "MLX"
+    case llama = "Llama"
+    case ollama = "Ollama"
+    case cloudSaaS = "CloudSaaS"
+}
+
+/// The network/profile posture of the current build.
+///
+/// This maps the trait combinations documented in README / SECURITY into a
+/// runtime-visible contract that host apps can switch over without reproducing
+/// SwiftPM trait logic in their own shims.
+public enum BackendBuildProfile: String, CaseIterable, Codable, Sendable {
+    /// No networked inference backends are compiled in.
+    case offline
+
+    /// Self-hosted / private-datacenter inference is compiled in via `Ollama`.
+    case selfHosted
+
+    /// SaaS providers are compiled in via `CloudSaaS`.
+    case saas
+
+    /// Both self-hosted and SaaS providers are compiled in.
+    case full
+}
+
+/// Describes which inference backends are compiled into the current binary
+/// before anything is registered on an `InferenceService`.
+///
+/// Use this when a host app needs to decide what UI to present at startup
+/// (e.g. whether to show a model-download flow or cloud-endpoint settings)
+/// without importing `BaseChatBackends` or constructing backend instances.
+public struct CompiledBackends: Sendable, Equatable {
+
+    /// The current binary's network/build profile.
+    public let buildProfile: BackendBuildProfile
+
+    /// Inference traits compiled into this binary.
+    public let traits: Set<BackendBuildTrait>
+
+    /// Local model types this build can load when registered.
+    public let localModelTypes: Set<ModelType>
+
+    /// Cloud / remote API providers this build can load when registered.
+    public let cloudProviders: Set<APIProvider>
+
+    public init(
+        buildProfile: BackendBuildProfile,
+        traits: Set<BackendBuildTrait>,
+        localModelTypes: Set<ModelType>,
+        cloudProviders: Set<APIProvider>
+    ) {
+        self.buildProfile = buildProfile
+        self.traits = traits
+        self.localModelTypes = localModelTypes
+        self.cloudProviders = cloudProviders
+    }
+
+    /// The local model types that have a downloadable artifact flow in the stock UI.
+    public var downloadableModelTypes: Set<ModelType> {
+        localModelTypes.intersection([.gguf, .mlx])
+    }
+
+    /// Whether any local inference backend is compiled in.
+    public var supportsLocalInference: Bool { !localModelTypes.isEmpty }
+
+    /// Whether any cloud / remote inference backend is compiled in.
+    public var supportsCloudInference: Bool { !cloudProviders.isEmpty }
+
+    /// Whether the stock "Download Models" affordance makes sense for this build.
+    public var shouldPresentModelDownloads: Bool { !downloadableModelTypes.isEmpty }
+
+    /// Whether the stock "Manage Cloud APIs" affordance makes sense for this build.
+    public var shouldPresentCloudAPIManagement: Bool { !cloudProviders.isEmpty }
+
+    /// Providers in the UI / registration order documented by BaseChatKit.
+    public var orderedCloudProviders: [APIProvider] {
+        [
+            .claude,
+            .openAI,
+            .openAIResponses,
+            .lmStudio,
+            .custom,
+            .ollama,
+        ]
+        .filter(cloudProviders.contains)
+    }
+
+    /// Returns whether the given local model type is compiled into this build.
+    public func compatibility(for modelType: ModelType) -> ModelCompatibilityResult {
+        if localModelTypes.contains(modelType) {
+            return .supported
+        }
+        return .unsupported(reason: unavailableReason(for: modelType))
+    }
+
+    /// Returns whether the given API provider is compiled into this build.
+    public func compatibility(for provider: APIProvider) -> ModelCompatibilityResult {
+        if cloudProviders.contains(provider) {
+            return .supported
+        }
+        return .unsupported(reason: unavailableReason(for: provider))
+    }
+
+    /// The compiled backend contract for the current binary.
+    public static let current = Self.detected()
+
+    private static func detected() -> Self {
+        var traits: Set<BackendBuildTrait> = []
+        var localModelTypes: Set<ModelType> = []
+        var cloudProviders: Set<APIProvider> = []
+
+        #if MLX
+        traits.insert(.mlx)
+        localModelTypes.insert(.mlx)
+        #endif
+
+        #if Llama
+        traits.insert(.llama)
+        localModelTypes.insert(.gguf)
+        #endif
+
+        #if canImport(FoundationModels)
+        if #available(iOS 26, macOS 26, *) {
+            localModelTypes.insert(.foundation)
+        }
+        #endif
+
+        #if Ollama
+        traits.insert(.ollama)
+        cloudProviders.insert(.ollama)
+        #endif
+
+        #if CloudSaaS
+        traits.insert(.cloudSaaS)
+        cloudProviders.formUnion([.claude, .openAI, .openAIResponses, .lmStudio, .custom])
+        #endif
+
+        return Self(
+            buildProfile: buildProfile(for: traits),
+            traits: traits,
+            localModelTypes: localModelTypes,
+            cloudProviders: cloudProviders
+        )
+    }
+
+    private static func buildProfile(for traits: Set<BackendBuildTrait>) -> BackendBuildProfile {
+        let hasOllama = traits.contains(.ollama)
+        let hasCloudSaaS = traits.contains(.cloudSaaS)
+
+        switch (hasOllama, hasCloudSaaS) {
+        case (false, false): return .offline
+        case (true, false): return .selfHosted
+        case (false, true): return .saas
+        case (true, true): return .full
+        }
+    }
+
+    private func unavailableReason(for modelType: ModelType) -> String {
+        switch modelType {
+        case .gguf:
+            return "GGUF models require the Llama trait in this build."
+        case .mlx:
+            return "MLX models require the MLX trait in this build."
+        case .foundation:
+            return "Apple Foundation Models require iOS 26 / macOS 26 or later."
+        }
+    }
+
+    private func unavailableReason(for provider: APIProvider) -> String {
+        switch provider {
+        case .ollama:
+            return "Ollama endpoints require the Ollama trait in this build."
+        case .openAI, .openAIResponses, .claude, .lmStudio, .custom:
+            return "Cloud API endpoints require the CloudSaaS trait in this build."
+        }
+    }
+}

--- a/Sources/BaseChatInference/Services/FrameworkCapabilityService.swift
+++ b/Sources/BaseChatInference/Services/FrameworkCapabilityService.swift
@@ -67,6 +67,10 @@ public final class FrameworkCapabilityService {
 
     // MARK: - Observable State
 
+    /// Backends compiled into this binary, independent of whether they have
+    /// been registered on the backing `InferenceService` yet.
+    public let compiledBackends: CompiledBackends
+
     /// Describes which backends are registered and available in this build.
     ///
     /// Updated whenever `refresh()` is called (typically after backend registration).
@@ -84,6 +88,7 @@ public final class FrameworkCapabilityService {
     /// to populate `enabledBackends`.
     public init(inferenceService: InferenceService) {
         self.inferenceService = inferenceService
+        self.compiledBackends = .current
         // Start with an empty snapshot; caller invokes refresh() after backend registration.
         self.enabledBackends = EnabledBackends()
     }

--- a/Sources/BaseChatUI/Views/Settings/GenerationSettingsView.swift
+++ b/Sources/BaseChatUI/Views/Settings/GenerationSettingsView.swift
@@ -16,6 +16,7 @@ public struct GenerationSettingsView<APIConfig: View>: View {
     @Environment(\.dismiss) private var dismiss
 
     private var features: BaseChatConfiguration.Features { BaseChatConfiguration.shared.features }
+    private var compiledBackends: CompiledBackends { .current }
 
     @AppStorage("showAdvancedSettings") private var showAdvancedSettings = false
     @State private var isAPIConfigPresented = false
@@ -167,7 +168,7 @@ public struct GenerationSettingsView<APIConfig: View>: View {
                         }
                     }
 
-                    if features.showCloudAPIManagement {
+                    if features.showCloudAPIManagement && compiledBackends.shouldPresentCloudAPIManagement {
                         Section("Cloud APIs") {
                             Button {
                                 isAPIConfigPresented = true

--- a/Sources/BaseChatUIModelManagement/Views/Models/DownloadableModelRow.swift
+++ b/Sources/BaseChatUIModelManagement/Views/Models/DownloadableModelRow.swift
@@ -19,8 +19,10 @@ public struct DownloadableModelRow: View {
         self.model = model
     }
 
-    /// Compatibility result for this model's type, or `.supported` when no
-    /// capability service is in the environment.
+    /// Resolves backend compatibility from the injected `FrameworkCapabilityService`
+    /// when one is in the environment; otherwise falls back to the compiled-backend
+    /// contract via `CompiledBackends.current.compatibility(for:)`, which can return
+    /// `.unsupported` for backends that were not compiled into the current build.
     private var backendCompatibility: ModelCompatibilityResult {
         capabilityService?.compatibility(for: model.modelType)
             ?? CompiledBackends.current.compatibility(for: model.modelType)

--- a/Sources/BaseChatUIModelManagement/Views/Models/DownloadableModelRow.swift
+++ b/Sources/BaseChatUIModelManagement/Views/Models/DownloadableModelRow.swift
@@ -20,9 +20,10 @@ public struct DownloadableModelRow: View {
     }
 
     /// Compatibility result for this model's type, or `.supported` when no
-    /// capability service is in the environment (backward-compatible fallback).
+    /// capability service is in the environment.
     private var backendCompatibility: ModelCompatibilityResult {
-        capabilityService?.compatibility(for: model.modelType) ?? .supported
+        capabilityService?.compatibility(for: model.modelType)
+            ?? CompiledBackends.current.compatibility(for: model.modelType)
     }
 
     public var body: some View {

--- a/Sources/BaseChatUIModelManagement/Views/Models/ModelManagementSheet.swift
+++ b/Sources/BaseChatUIModelManagement/Views/Models/ModelManagementSheet.swift
@@ -15,6 +15,7 @@ public struct ModelManagementSheet: View {
     #endif
 
     private var features: BaseChatConfiguration.Features { BaseChatConfiguration.shared.features }
+    private var compiledBackends: CompiledBackends { .current }
     private let initialTab: Tab
     private let recommendedModelIDs: Set<String>?
     private let recommendationTitle: String?
@@ -36,7 +37,7 @@ public struct ModelManagementSheet: View {
 
     private var availableTabs: [Tab] {
         var tabs: [Tab] = [.select]
-        if features.showModelDownload { tabs.append(.download) }
+        if features.showModelDownload && compiledBackends.shouldPresentModelDownloads { tabs.append(.download) }
         if features.showStorageTab { tabs.append(.storage) }
         return tabs
     }

--- a/Tests/BaseChatBackendsTests/DefaultBackendsCapabilityTests.swift
+++ b/Tests/BaseChatBackendsTests/DefaultBackendsCapabilityTests.swift
@@ -30,15 +30,22 @@ final class DefaultBackendsCapabilityTests: XCTestCase {
         }
     }
 
-    func test_canLoad_provider_alwaysTrue() {
-        // `DefaultBackends.canLoad(provider:)` reports static availability —
-        // it always returns `true` (provider data lives in BaseChatInference
-        // and is independent of trait gating). The actual factory may still
-        // return `nil` for a provider when its trait is disabled.
+    func test_canLoad_provider_matchesCompiledContract() {
+        let compiled = DefaultBackends.compiledBackends
         for provider in APIProvider.allCases {
-            XCTAssertTrue(DefaultBackends.canLoad(provider: provider),
-                          "Expected \(provider) to always be supported")
+            let expected = compiled.cloudProviders.contains(provider)
+            XCTAssertEqual(
+                DefaultBackends.canLoad(provider: provider),
+                expected,
+                "Expected \(provider) support to match the compiled contract"
+            )
         }
+    }
+
+    func test_compiledBackends_passthroughsMatchStaticQueries() {
+        XCTAssertEqual(DefaultBackends.buildProfile, DefaultBackends.compiledBackends.buildProfile)
+        XCTAssertEqual(DefaultBackends.enabledTraits, DefaultBackends.compiledBackends.traits)
+        XCTAssertEqual(DefaultBackends.supportedModelTypes, DefaultBackends.compiledBackends.localModelTypes)
     }
 
     // MARK: - register(with:) populates declareSupport

--- a/Tests/BaseChatInferenceTests/CompiledBackendsTests.swift
+++ b/Tests/BaseChatInferenceTests/CompiledBackendsTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import BaseChatInference
+
+final class CompiledBackendsTests: XCTestCase {
+
+    func test_current_profileMatchesTraits() {
+        let compiled = CompiledBackends.current
+
+        XCTAssertEqual(compiled.buildProfile, expectedProfile(for: compiled.traits))
+    }
+
+    func test_downloadableModelTypes_areSubsetOfLocalModelTypes() {
+        let compiled = CompiledBackends.current
+
+        XCTAssertTrue(compiled.downloadableModelTypes.isSubset(of: compiled.localModelTypes))
+        XCTAssertTrue(compiled.downloadableModelTypes.isSubset(of: [.gguf, .mlx]))
+    }
+
+    func test_presentationFlags_followCompiledSets() {
+        let compiled = CompiledBackends.current
+
+        XCTAssertEqual(compiled.shouldPresentModelDownloads, !compiled.downloadableModelTypes.isEmpty)
+        XCTAssertEqual(compiled.shouldPresentCloudAPIManagement, !compiled.cloudProviders.isEmpty)
+    }
+
+    func test_modelCompatibility_matchesCompiledLocalTypes() {
+        let compiled = CompiledBackends.current
+
+        for modelType in [ModelType.gguf, .mlx, .foundation] {
+            let expected = compiled.localModelTypes.contains(modelType)
+            XCTAssertEqual(compiled.compatibility(for: modelType).isSupported, expected)
+        }
+    }
+
+    func test_providerCompatibility_matchesCompiledProviders() {
+        let compiled = CompiledBackends.current
+
+        for provider in APIProvider.allCases {
+            let expected = compiled.cloudProviders.contains(provider)
+            XCTAssertEqual(compiled.compatibility(for: provider).isSupported, expected)
+        }
+    }
+
+    func test_apiProvider_availableInBuild_matchesCompiledBackends() {
+        let compiled = CompiledBackends.current
+
+        XCTAssertEqual(APIProvider.availableInBuild, compiled.orderedCloudProviders)
+    }
+
+    @MainActor
+    func test_frameworkCapabilityService_exposesCompiledBackends() {
+        let service = FrameworkCapabilityService(inferenceService: InferenceService())
+
+        XCTAssertEqual(service.compiledBackends, .current)
+    }
+
+    private func expectedProfile(for traits: Set<BackendBuildTrait>) -> BackendBuildProfile {
+        switch (traits.contains(.ollama), traits.contains(.cloudSaaS)) {
+        case (false, false): .offline
+        case (true, false): .selfHosted
+        case (false, true): .saas
+        case (true, true): .full
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a `CompiledBackends` runtime contract in `BaseChatInference` with build profile, enabled inference traits, compiled local model types, and compiled remote providers
- reuse that contract from `DefaultBackends`, `APIProvider.availableInBuild`, and `FrameworkCapabilityService` instead of keeping separate static trait logic
- gate stock presentation affordances (`Manage Cloud APIs`, download tab, download-row compatibility copy) off the compiled contract and update README / SECURITY docs

## Validation
- `swift test --filter BaseChatInferenceTests --disable-default-traits`
- `swift test --filter BaseChatBackendsTests --disable-default-traits`
- `swift test --filter BaseChatUIModelManagementTests --disable-default-traits`
- `swift test --filter BaseChatUITests.GenerationExtensionTests --disable-default-traits`
- `swift test --filter BaseChatUITests.ChatA11yContractTests --disable-default-traits`
- `swift test --filter CompiledBackendsTests --disable-default-traits --traits CloudSaaS`
- `swift test --filter CompiledBackendsTests --disable-default-traits --traits Ollama`
- `swift test --filter DefaultBackendsCapabilityTests --disable-default-traits --traits CloudSaaS`

## Notes
- kept this PR independent of the runtime-core work; no follow-up dependency was required for the compiled/runtime contract slice
- `swift test --filter BaseChatUITests --disable-default-traits` still hits the pre-existing `LargeSessionListPerformanceTests` / xctest 0-tests process failure, so validation used focused UI subsets instead