### PR TITLE
test: add consumer runtime harness

### DIFF
--- a/Tests/BaseChatUITests/ConsumerRuntimeHarness.swift
+++ b/Tests/BaseChatUITests/ConsumerRuntimeHarness.swift
@@ -1,0 +1,103 @@
+import Foundation
+@testable import BaseChatUI
+@testable import BaseChatCore
+@testable import BaseChatInference
+
+@MainActor
+final class ConsumerRuntimeHarness {
+    enum Error: Swift.Error {
+        case userDefaultsSuiteAllocationFailed(String)
+    }
+
+    private static let repoRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+
+    let runtime: BaseChatRuntime
+    let chatViewModel: ChatViewModel
+    let sessionManager: SessionManagerViewModel
+    let userDefaults: UserDefaults
+    let modelsDirectory: URL
+
+    private let originalConfiguration: BaseChatConfiguration
+    private let userDefaultsSuiteName: String
+
+    init(
+        inferenceService: InferenceService,
+        toolApprovalGate: UIToolApprovalGate? = nil,
+        foundationModelProvider: (@MainActor () -> Bool)? = nil
+    ) throws {
+        let suiteName = "BaseChatConsumerRuntimeHarness-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            throw Error.userDefaultsSuiteAllocationFailed(suiteName)
+        }
+
+        let directory = try Self.makeModelsDirectory()
+        let configuration = BaseChatConfiguration(
+            appName: "Consumer Runtime Harness",
+            bundleIdentifier: "com.basechatkit.consumer-runtime-harness.\(UUID().uuidString)"
+        )
+
+        originalConfiguration = BaseChatConfiguration.shared
+        userDefaults = defaults
+        userDefaultsSuiteName = suiteName
+        modelsDirectory = directory
+        runtime = try BaseChatRuntime(
+            configuration: configuration,
+            inferenceService: inferenceService,
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+
+        let chatViewModel = ChatViewModel(
+            inferenceService: runtime.inferenceService,
+            modelStorage: ModelStorageService(baseDirectory: directory),
+            toolApprovalGate: toolApprovalGate,
+            userDefaults: defaults
+        )
+        chatViewModel.foundationModelProvider = foundationModelProvider
+        chatViewModel.configure(runtime: runtime)
+        self.chatViewModel = chatViewModel
+
+        let sessionManager = SessionManagerViewModel()
+        sessionManager.configure(runtime: runtime)
+        self.sessionManager = sessionManager
+    }
+
+    func cleanup() {
+        chatViewModel.stopGeneration()
+        runtime.inferenceService.unloadModel()
+        BaseChatConfiguration.shared = originalConfiguration
+        userDefaults.removePersistentDomain(forName: userDefaultsSuiteName)
+        try? FileManager.default.removeItem(at: modelsDirectory)
+    }
+
+    @discardableResult
+    func createAndActivateSession(title: String = "New Chat") throws -> ChatSessionRecord {
+        let session = try sessionManager.createSession(title: title)
+        switchToSession(session)
+        return session
+    }
+
+    func switchToSession(_ session: ChatSessionRecord) {
+        sessionManager.activeSession = session
+        chatViewModel.switchToSession(session)
+    }
+
+    func persistedMessages(for session: ChatSessionRecord) throws -> [ChatMessageRecord] {
+        try runtime.persistence.fetchMessages(for: session.id)
+    }
+
+    func persistedSessions() throws -> [ChatSessionRecord] {
+        try runtime.persistence.fetchSessions()
+    }
+
+    private static func makeModelsDirectory() throws -> URL {
+        let directory = repoRoot
+            .appendingPathComponent("tmp", isDirectory: true)
+            .appendingPathComponent("consumer-runtime-harness", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+}

--- a/Tests/BaseChatUITests/ConsumerRuntimeHarness.swift
+++ b/Tests/BaseChatUITests/ConsumerRuntimeHarness.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftData
 @testable import BaseChatUI
 @testable import BaseChatCore
 @testable import BaseChatInference
@@ -9,11 +10,6 @@ final class ConsumerRuntimeHarness {
         case userDefaultsSuiteAllocationFailed(String)
     }
 
-    private static let repoRoot = URL(fileURLWithPath: #filePath)
-        .deletingLastPathComponent()
-        .deletingLastPathComponent()
-        .deletingLastPathComponent()
-
     let runtime: BaseChatRuntime
     let chatViewModel: ChatViewModel
     let sessionManager: SessionManagerViewModel
@@ -23,45 +19,82 @@ final class ConsumerRuntimeHarness {
     private let originalConfiguration: BaseChatConfiguration
     private let userDefaultsSuiteName: String
 
-    init(
+    convenience init(
         inferenceService: InferenceService,
         toolApprovalGate: UIToolApprovalGate? = nil,
         foundationModelProvider: (@MainActor () -> Bool)? = nil
     ) throws {
+        try self.init(
+            inferenceService: inferenceService,
+            toolApprovalGate: toolApprovalGate,
+            foundationModelProvider: foundationModelProvider,
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+    }
+
+    /// Test-only initializer that lets a caller inject a throwing
+    /// `makeModelContainer` closure, which exercises the rollback/cleanup
+    /// path when bootstrap fails partway through.
+    init(
+        inferenceService: InferenceService,
+        toolApprovalGate: UIToolApprovalGate? = nil,
+        foundationModelProvider: (@MainActor () -> Bool)? = nil,
+        makeModelContainer: @MainActor () throws -> ModelContainer
+    ) throws {
+        // Capture the live configuration before any mutation so the catch path
+        // can roll BaseChatConfiguration.shared back to it untouched.
+        let originalConfiguration = BaseChatConfiguration.shared
+
         let suiteName = "BaseChatConsumerRuntimeHarness-\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
             throw Error.userDefaultsSuiteAllocationFailed(suiteName)
         }
 
-        let directory = try Self.makeModelsDirectory()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("consumer-runtime-harness-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
         let configuration = BaseChatConfiguration(
             appName: "Consumer Runtime Harness",
             bundleIdentifier: "com.basechatkit.consumer-runtime-harness.\(UUID().uuidString)"
         )
 
-        originalConfiguration = BaseChatConfiguration.shared
-        userDefaults = defaults
-        userDefaultsSuiteName = suiteName
-        modelsDirectory = directory
-        runtime = try BaseChatRuntime(
-            configuration: configuration,
-            inferenceService: inferenceService,
-            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
-        )
+        do {
+            let runtime = try BaseChatRuntime(
+                configuration: configuration,
+                inferenceService: inferenceService,
+                makeModelContainer: makeModelContainer
+            )
 
-        let chatViewModel = ChatViewModel(
-            inferenceService: runtime.inferenceService,
-            modelStorage: ModelStorageService(baseDirectory: directory),
-            toolApprovalGate: toolApprovalGate,
-            userDefaults: defaults
-        )
-        chatViewModel.foundationModelProvider = foundationModelProvider
-        chatViewModel.configure(runtime: runtime)
-        self.chatViewModel = chatViewModel
+            let chatViewModel = ChatViewModel(
+                inferenceService: runtime.inferenceService,
+                modelStorage: ModelStorageService(baseDirectory: directory),
+                toolApprovalGate: toolApprovalGate,
+                userDefaults: defaults
+            )
+            chatViewModel.foundationModelProvider = foundationModelProvider
+            chatViewModel.configure(runtime: runtime)
 
-        let sessionManager = SessionManagerViewModel()
-        sessionManager.configure(runtime: runtime)
-        self.sessionManager = sessionManager
+            let sessionManager = SessionManagerViewModel()
+            sessionManager.configure(runtime: runtime)
+
+            self.originalConfiguration = originalConfiguration
+            self.userDefaults = defaults
+            self.userDefaultsSuiteName = suiteName
+            self.modelsDirectory = directory
+            self.runtime = runtime
+            self.chatViewModel = chatViewModel
+            self.sessionManager = sessionManager
+        } catch {
+            // Bootstrap failed after we mutated process-wide state — the
+            // BaseChatRuntime initializer rolls BaseChatConfiguration.shared
+            // back itself, but we still own the UserDefaults suite + temp
+            // directory we allocated above.
+            BaseChatConfiguration.shared = originalConfiguration
+            defaults.removePersistentDomain(forName: suiteName)
+            try? FileManager.default.removeItem(at: directory)
+            throw error
+        }
     }
 
     func cleanup() {
@@ -90,14 +123,5 @@ final class ConsumerRuntimeHarness {
 
     func persistedSessions() throws -> [ChatSessionRecord] {
         try runtime.persistence.fetchSessions()
-    }
-
-    private static func makeModelsDirectory() throws -> URL {
-        let directory = repoRoot
-            .appendingPathComponent("tmp", isDirectory: true)
-            .appendingPathComponent("consumer-runtime-harness", isDirectory: true)
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        return directory
     }
 }

--- a/Tests/BaseChatUITests/ConsumerRuntimeHarnessTests.swift
+++ b/Tests/BaseChatUITests/ConsumerRuntimeHarnessTests.swift
@@ -97,6 +97,49 @@ final class ConsumerRuntimeHarnessTests: XCTestCase {
         )
     }
 
+    func test_init_throwingRuntime_restoresConfigurationAndCleansUp() throws {
+        let originalConfiguration = BaseChatConfiguration.shared
+        let tmp = FileManager.default.temporaryDirectory
+
+        // Snapshot any existing harness tmp dirs so we can prove this run
+        // didn't leak one.
+        let prefix = "consumer-runtime-harness-"
+        let before = (try? FileManager.default.contentsOfDirectory(atPath: tmp.path)) ?? []
+        let beforeHarnessDirs = Set(before.filter { $0.hasPrefix(prefix) })
+
+        let backend = MockInferenceBackend()
+        var makeModelContainerInvoked = false
+
+        XCTAssertThrowsError(
+            try ConsumerRuntimeHarness(
+                inferenceService: InferenceService(backend: backend, name: "RuntimeMock"),
+                makeModelContainer: {
+                    makeModelContainerInvoked = true
+                    throw URLError(.cannotOpenFile)
+                }
+            )
+        )
+
+        // Sanity check that we actually went down the makeModelContainer path
+        // before throwing — without this, the assertions below could pass
+        // trivially if the throwing closure had never been invoked.
+        XCTAssertTrue(makeModelContainerInvoked)
+
+        XCTAssertEqual(
+            BaseChatConfiguration.shared.bundleIdentifier,
+            originalConfiguration.bundleIdentifier,
+            "Failed harness construction must roll BaseChatConfiguration.shared back to the value held before init"
+        )
+
+        let after = (try? FileManager.default.contentsOfDirectory(atPath: tmp.path)) ?? []
+        let afterHarnessDirs = Set(after.filter { $0.hasPrefix(prefix) })
+        XCTAssertEqual(
+            afterHarnessDirs.subtracting(beforeHarnessDirs),
+            [],
+            "Failed harness construction must remove the temp models directory it created"
+        )
+    }
+
     func test_refreshModels_includesBuiltInFoundationWhenAvailable() throws {
         let backend = MockInferenceBackend()
         harness = try ConsumerRuntimeHarness(

--- a/Tests/BaseChatUITests/ConsumerRuntimeHarnessTests.swift
+++ b/Tests/BaseChatUITests/ConsumerRuntimeHarnessTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+@testable import BaseChatUI
+@testable import BaseChatCore
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+@MainActor
+final class ConsumerRuntimeHarnessTests: XCTestCase {
+    private var harness: ConsumerRuntimeHarness?
+
+    override func tearDown() async throws {
+        harness?.cleanup()
+        harness = nil
+        try await super.tearDown()
+    }
+
+    func test_sendStreamPersist_roundTripsThroughRuntimeBootstrap() async throws {
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["Hello", " from", " runtime"]
+
+        harness = try ConsumerRuntimeHarness(
+            inferenceService: InferenceService(backend: backend, name: "RuntimeMock")
+        )
+
+        let session = try harness!.createAndActivateSession(title: "Runtime Session")
+        harness!.chatViewModel.inputText = "What shipped in v1?"
+
+        await harness!.chatViewModel.sendMessage()
+
+        XCTAssertEqual(
+            harness!.chatViewModel.messages.map(\.content),
+            ["What shipped in v1?", "Hello from runtime"]
+        )
+        XCTAssertEqual(
+            try harness!.persistedMessages(for: session).map(\.content),
+            ["What shipped in v1?", "Hello from runtime"]
+        )
+        XCTAssertEqual(try harness!.persistedSessions().map(\.id), [session.id])
+    }
+
+    func test_stopGeneration_persistsPartialAssistantReply() async throws {
+        let backend = SlowMockBackend(tokenCount: 20, delayMilliseconds: 50)
+        backend.tokensToYield = (0..<20).map { "tok\($0) " }
+
+        harness = try ConsumerRuntimeHarness(
+            inferenceService: InferenceService(backend: backend, name: "RuntimeSlowMock")
+        )
+
+        let session = try harness!.createAndActivateSession(title: "Cancellation Session")
+        harness!.chatViewModel.inputText = "Tell me a story"
+        let sendTask = Task { @MainActor in
+            await self.harness?.chatViewModel.sendMessage()
+        }
+
+        await harness!.chatViewModel.awaitFirstToken()
+        harness!.chatViewModel.stopGeneration()
+        await sendTask.value
+
+        let assistant = try XCTUnwrap(harness!.chatViewModel.messages.last)
+        XCTAssertEqual(harness!.chatViewModel.messages.count, 2)
+        XCTAssertEqual(assistant.role, .assistant)
+        XCTAssertFalse(assistant.content.isEmpty)
+        XCTAssertNotEqual(assistant.content, backend.tokensToYield.joined())
+        XCTAssertEqual(try harness!.persistedMessages(for: session).count, 2)
+        XCTAssertEqual(try harness!.persistedMessages(for: session).last?.content, assistant.content)
+    }
+
+    func test_switchingSessions_reloadsPersistedTranscriptForEachSession() async throws {
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+
+        harness = try ConsumerRuntimeHarness(
+            inferenceService: InferenceService(backend: backend, name: "RuntimeMock")
+        )
+
+        let sessionA = try harness!.createAndActivateSession(title: "Session A")
+        backend.tokensToYield = ["Alpha", " reply"]
+        harness!.chatViewModel.inputText = "Alpha question"
+        await harness!.chatViewModel.sendMessage()
+
+        let sessionB = try harness!.createAndActivateSession(title: "Session B")
+        backend.tokensToYield = ["Beta", " reply"]
+        harness!.chatViewModel.inputText = "Beta question"
+        await harness!.chatViewModel.sendMessage()
+
+        harness!.switchToSession(sessionA)
+        XCTAssertEqual(
+            harness!.chatViewModel.messages.map(\.content),
+            ["Alpha question", "Alpha reply"]
+        )
+
+        harness!.switchToSession(sessionB)
+        XCTAssertEqual(
+            harness!.chatViewModel.messages.map(\.content),
+            ["Beta question", "Beta reply"]
+        )
+    }
+
+    func test_refreshModels_includesBuiltInFoundationWhenAvailable() throws {
+        let backend = MockInferenceBackend()
+        harness = try ConsumerRuntimeHarness(
+            inferenceService: InferenceService(backend: backend, name: "RuntimeMock"),
+            foundationModelProvider: { true }
+        )
+
+        harness!.chatViewModel.refreshModels()
+
+        XCTAssertEqual(harness!.chatViewModel.availableModels.count, 1)
+        XCTAssertEqual(harness!.chatViewModel.availableModels.first?.modelType, .foundation)
+    }
+
+    func test_toolRegistry_survivesRuntimeBootstrap_andAdvertisesDefinitionsToBackend() async throws {
+        let backend = MockInferenceBackend(
+            capabilities: BackendCapabilities(
+                supportedParameters: [.temperature, .topP, .repeatPenalty],
+                maxContextTokens: 4096,
+                supportsToolCalling: true
+            )
+        )
+        backend.isModelLoaded = true
+        backend.scriptedToolCallsPerTurn = [
+            [ToolCall(id: "tool-1", toolName: "lookup_status", arguments: "{}")],
+            [],
+        ]
+        backend.tokensToYieldPerTurn = [
+            [],
+            ["Tool", " complete"],
+        ]
+
+        let executor = CountingExecutor(name: "lookup_status")
+        let registry = ToolRegistry()
+        registry.register(executor)
+
+        harness = try ConsumerRuntimeHarness(
+            inferenceService: InferenceService(
+                backend: backend,
+                name: "RuntimeToolMock",
+                toolRegistry: registry
+            )
+        )
+
+        _ = try harness!.createAndActivateSession(title: "Tool Session")
+        harness!.chatViewModel.inputText = "Check runtime tools"
+
+        await harness!.chatViewModel.sendMessage()
+
+        XCTAssertEqual(backend.lastConfig?.tools.map(\.name), ["lookup_status"])
+        XCTAssertEqual(executor.callCount, 1)
+        XCTAssertEqual(harness!.chatViewModel.messages.last?.content, "Tool complete")
+    }
+}
+
+@MainActor
+private final class CountingExecutor: ToolExecutor, @unchecked Sendable {
+    let definition: ToolDefinition
+    private(set) var callCount = 0
+
+    init(name: String) {
+        definition = ToolDefinition(name: name, description: "counts runtime harness tool calls")
+    }
+
+    nonisolated func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+        await MainActor.run { self.callCount += 1 }
+        return ToolResult(callId: "", content: #"{"status":"ok"}"#, errorKind: nil)
+    }
+}


### PR DESCRIPTION
## Summary
- add a small consumer runtime harness that boots ChatViewModel and SessionManagerViewModel through BaseChatRuntime
- cover CI-safe consumer scenarios for send/stream/persist, cancellation, session switching, and model availability
- add a runtime-path regression test that keeps tool registry definitions wired through the injected InferenceService

## Testing
- swift test --filter ConsumerRuntimeHarnessTests --disable-default-traits
- swift test --filter 'BaseChatRuntimeTests|RuntimeConfigurationTests|ConsumerRuntimeHarnessTests' --disable-default-traits\n\n## Notes\n- Targets feat/runtime-core because BaseChatRuntime and configure(runtime:) have not landed on main yet (draft PR #866).