### PR TITLE
feat: adopt runtime bootstrap across UI examples

### DIFF
--- a/Example/BaseChatDemo/BaseChatDemoApp.swift
+++ b/Example/BaseChatDemo/BaseChatDemoApp.swift
@@ -14,29 +14,26 @@ struct BaseChatDemoApp: App {
     @State private var chatViewModel: ChatViewModel
     @State private var modelManagementViewModel: ModelManagementViewModel
     @State private var sessionManager = SessionManagerViewModel()
+    @State private var runtime: BaseChatRuntime?
     private let inferenceService: InferenceService
     private let toolRegistry: ToolRegistry
     private let sandboxRoot: URL
     private let pendingDemoScenarioID: String?
+    private let runtimeConfiguration: BaseChatConfiguration
 
     /// When `true`, the app was launched with `--uitesting` and should use
     /// an in-memory store, skip auto-model-load, and disable animations.
     private let isUITesting: Bool
 
-    // Created asynchronously in .task to avoid blocking App.init() — SwiftData
-    // container setup (schema compilation + SQLite open) can stall the first
-    // frame for several seconds when done on the main thread.
-    @State private var modelContainer: ModelContainer?
-
     /// Single-slot buffer for inbound payloads that land during the
-    /// cold-launch window where the SwiftData container is still being
-    /// built. ``DemoContentView`` drains it once persistence is wired.
+    /// cold-launch window where the runtime is still being assembled.
+    /// ``DemoContentView`` drains it after the runtime-backed persistence is ready.
     @State private var pendingPayloadBuffer = PendingPayloadBuffer()
 
     /// Staged payload from the Share Extension or Action Extension, read out
-    /// of App Group storage on each foreground transition.  When the SwiftData
-    /// container is ready the payload is ingested immediately; otherwise it
-    /// waits here until the container `Task` completes.
+    /// of App Group storage on each foreground transition. When the runtime is
+    /// ready the payload is ingested immediately; otherwise it waits here until
+    /// the bootstrap `Task` completes.
     @State private var stagedSharePayload: PendingSharePayload?
 
     init() {
@@ -59,10 +56,12 @@ struct BaseChatDemoApp: App {
             UserDefaults.standard.set(true, forKey: "showAdvancedSettings")
         }
         // Configure BaseChatKit for this app
-        BaseChatConfiguration.shared = BaseChatConfiguration(
+        let runtimeConfiguration = BaseChatConfiguration(
             appName: "BaseChat Demo",
             bundleIdentifier: "com.basechatkit.demo"
         )
+        self.runtimeConfiguration = runtimeConfiguration
+        BaseChatConfiguration.shared = runtimeConfiguration
 
         // Populate curated model recommendations
         CuratedModel.all = Self.curatedModels
@@ -210,12 +209,10 @@ struct BaseChatDemoApp: App {
     var body: some Scene {
         WindowGroup {
             Group {
-                if let container = modelContainer {
+                if let runtime {
                     DemoContentView(
-                        inferenceService: inferenceService,
                         toolRegistry: toolRegistry,
                         sandboxRoot: sandboxRoot,
-                        skipAutoModelLoad: isUITesting,
                         pendingPayloadBuffer: pendingPayloadBuffer,
                         pendingDemoScenarioID: pendingDemoScenarioID
                     )
@@ -225,7 +222,7 @@ struct BaseChatDemoApp: App {
                     #if os(macOS)
                     .frame(minWidth: 600, minHeight: 400)
                     #endif
-                    .modelContainer(container)
+                    .modelContainer(runtime.modelContainer)
                 } else {
                     ProgressView()
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -242,10 +239,12 @@ struct BaseChatDemoApp: App {
                                 await pendingPayloadBuffer.store(seeded)
                             }
 
-                            modelContainer = await Task.detached(priority: .userInitiated) {
+                            let container = await Task.detached(priority: .userInitiated) {
                                 let config = ModelConfiguration("BaseChatDemo", isStoredInMemoryOnly: testing)
                                 return try! ModelContainerFactory.makeContainer(configurations: [config])
                             }.value
+
+                            installRuntime(using: container)
                         }
                 }
             }
@@ -257,8 +256,8 @@ struct BaseChatDemoApp: App {
             // fires .active before the container task completes. The `.task`
             // modifier lives on the inner View (not on `WindowGroup`, which
             // is a `Scene`).
-            .task(id: modelContainer != nil ? 1 : 0) {
-                guard modelContainer != nil, let staged = stagedSharePayload else { return }
+            .task(id: runtime != nil ? 1 : 0) {
+                guard runtime != nil, let staged = stagedSharePayload else { return }
                 stagedSharePayload = nil
                 guard let pendingPayload = pendingPayload(from: staged) else { return }
                 await chatViewModel.ingestPendingPayload(pendingPayload, intent: .newSession(preset: nil))
@@ -301,7 +300,7 @@ struct BaseChatDemoApp: App {
         // If persistence is wired, ingest directly — otherwise hand off
         // to the buffer and let `DemoContentView` pick it up once mount
         // completes.
-        if modelContainer != nil {
+        if runtime != nil {
             Task { @MainActor in
                 await chatViewModel.ingest(payload)
             }
@@ -318,10 +317,10 @@ struct BaseChatDemoApp: App {
     /// Action Extension from the App Group container.
     ///
     /// Called on every foreground transition (`.onChange(of: scenePhase)`).
-    /// When the SwiftData container is ready the payload is passed to
+    /// When the runtime is ready the payload is passed to
     /// ``ChatViewModel/ingestPendingPayload(_:intent:)`` immediately;
     /// otherwise it is stored in ``stagedSharePayload`` and picked up by the
-    /// `.task(id:)` modifier once the container completes.
+    /// `.task(id:)` modifier once bootstrap completes.
     private func checkForPendingSharePayload() {
         guard let defaults = UserDefaults(suiteName: DemoAppGroup.identifier),
               let data = defaults.data(forKey: DemoAppGroup.pendingShareKey),
@@ -331,15 +330,54 @@ struct BaseChatDemoApp: App {
         // Remove before ingesting so a crash during ingest doesn't replay.
         defaults.removeObject(forKey: DemoAppGroup.pendingShareKey)
 
-        if modelContainer != nil {
+        if runtime != nil {
             guard let payload = pendingPayload(from: sharePayload) else { return }
             Task { @MainActor in
                 await chatViewModel.ingestPendingPayload(payload, intent: .newSession(preset: nil))
             }
         } else {
-            // Container still initialising — stage for the .task(id:) drain.
+            // Runtime still initialising — stage for the .task(id:) drain.
             stagedSharePayload = sharePayload
         }
+    }
+
+    @MainActor
+    private func installRuntime(using container: ModelContainer) {
+        let runtime = try! BaseChatRuntime(
+            configuration: runtimeConfiguration,
+            inferenceService: inferenceService,
+            makeModelContainer: { container }
+        )
+
+        chatViewModel.configure(runtime: runtime)
+        sessionManager.configure(runtime: runtime)
+        chatViewModel.onFirstMessage = { [inferenceService] session, text in
+            Task { @MainActor in
+                while chatViewModel.isGenerating {
+                    try? await Task.sleep(nanoseconds: 100_000_000)
+                }
+                await sessionManager.autoRenameSession(
+                    session,
+                    firstMessage: text,
+                    inferenceService: inferenceService
+                )
+            }
+        }
+
+        if !isUITesting {
+            chatViewModel.refreshModels()
+            chatViewModel.autoSelectFirstRunModel()
+
+            if chatViewModel.selectedModel == nil,
+               let foundation = chatViewModel.availableModels.first(where: { $0.modelType == .foundation }) {
+                chatViewModel.selectedModel = foundation
+            }
+
+            chatViewModel.dispatchSelectedLoad()
+            chatViewModel.startMemoryMonitoring()
+        }
+
+        self.runtime = runtime
     }
 
     /// Converts a ``PendingSharePayload`` (pure Foundation, extension-safe)

--- a/Example/BaseChatDemo/DemoContentView.swift
+++ b/Example/BaseChatDemo/DemoContentView.swift
@@ -4,7 +4,6 @@ import BaseChatCore
 import BaseChatInference
 import BaseChatUI
 import BaseChatUIModelManagement
-import BaseChatTools
 
 struct DemoContentView: View {
     @Environment(ChatViewModel.self) private var viewModel

--- a/Example/BaseChatDemo/DemoContentView.swift
+++ b/Example/BaseChatDemo/DemoContentView.swift
@@ -4,12 +4,12 @@ import BaseChatCore
 import BaseChatInference
 import BaseChatUI
 import BaseChatUIModelManagement
+import BaseChatTools
 
 struct DemoContentView: View {
     @Environment(ChatViewModel.self) private var viewModel
     @Environment(ModelManagementViewModel.self) private var managementViewModel
     @Environment(SessionManagerViewModel.self) private var sessionManager
-    @Environment(\.modelContext) private var modelContext
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     @Query(filter: #Predicate<APIEndpoint> { $0.isEnabled }, sort: \APIEndpoint.createdAt)
@@ -21,10 +21,8 @@ struct DemoContentView: View {
     @State private var isToolPolicyPresented = false
     @State private var isConnectedServicesPresented = false
 
-    let inferenceService: InferenceService
-
-    /// Tool registry shared with `inferenceService`. Held here so the demo
-    /// scenario runner can install scenario-specific variant executors.
+    /// Tool registry shared with the app's inference service. Held here so the
+    /// demo scenario runner can install scenario-specific variant executors.
     let toolRegistry: ToolRegistry
 
     /// Sandbox root the demo's filesystem tools resolve paths against. Held
@@ -32,17 +30,13 @@ struct DemoContentView: View {
     /// a stable temp directory the test harness can inspect.
     let sandboxRoot: URL
 
-    /// When `true`, the auto-model-load and related onAppear work is skipped
-    /// so that UI tests start from a deterministic empty state.
-    var skipAutoModelLoad: Bool = false
-
     /// Buffer holding any ``InboundPayload`` that arrived during the
-    /// cold-launch window, before persistence was wired. Drained once
-    /// the `onAppear` configuration completes.
+    /// cold-launch window, before the runtime finished bootstrapping.
+    /// Drained once the mounted view can safely hand off to `ChatViewModel`.
     var pendingPayloadBuffer: PendingPayloadBuffer?
 
     /// Optional demo-scenario ID supplied via `--bck-demo-scenario`. Resolved
-    /// to a ``DemoScenario`` and run after persistence is wired in `onAppear`.
+    /// to a ``DemoScenario`` and run after the runtime-backed persistence is ready.
     var pendingDemoScenarioID: String?
 
     var body: some View {
@@ -117,42 +111,7 @@ struct DemoContentView: View {
                 preferredCompactColumn = .detail
             }
 
-            let persistence = SwiftDataPersistenceProvider(modelContext: modelContext)
-            viewModel.configure(persistence: persistence)
-            sessionManager.configure(persistence: persistence)
             viewModel.setAvailableEndpoints(cloudEndpoints)
-
-            if !skipAutoModelLoad {
-                viewModel.refreshModels()
-                viewModel.autoSelectFirstRunModel()
-
-                // If no model was selected (e.g. first-run already fired before
-                // backends were configured), fall back to the Foundation model.
-                if viewModel.selectedModel == nil,
-                   let foundation = viewModel.availableModels.first(where: { $0.modelType == .foundation }) {
-                    viewModel.selectedModel = foundation
-                }
-
-                viewModel.startMemoryMonitoring()
-            }
-
-            sessionManager.loadSessions()
-
-            // Wire AI auto-rename: fires after the first user message in a session.
-            // We defer the rename call until generation finishes so the rename
-            // inference request does not compete with the active streaming reply.
-            viewModel.onFirstMessage = { [inferenceService] session, text in
-                Task { @MainActor in
-                    while viewModel.isGenerating {
-                        try? await Task.sleep(nanoseconds: 100_000_000)
-                    }
-                    await sessionManager.autoRenameSession(
-                        session,
-                        firstMessage: text,
-                        inferenceService: inferenceService
-                    )
-                }
-            }
 
             // Seed an empty session and/or drain any buffered payload.
             //
@@ -180,9 +139,7 @@ struct DemoContentView: View {
                 }
 
                 // Drain any payload that arrived during the cold-launch window
-                // where persistence was not yet wired. Runs after the
-                // `viewModel.configure(persistence:)` call above so the ingest
-                // path can safely create sessions.
+                // where the runtime was not ready yet.
                 if let pendingPayloadBuffer, let payload = await pendingPayloadBuffer.drain() {
                     await viewModel.ingest(payload)
                 }

--- a/Example/BaseChatDemoUITests/DemoScenarioUITests.swift
+++ b/Example/BaseChatDemoUITests/DemoScenarioUITests.swift
@@ -26,8 +26,8 @@ final class DemoScenarioUITests: XCTestCase {
         let app = launchDemoApp(scenario: nil)
         openChatDetailIfNeeded(app: app)
 
-        // The empty state requires an active session; createSession in
-        // DemoContentView.onAppear should have produced one. Wait for chat
+        // The empty state requires an active session; the launch bootstrap
+        // should have produced one before the detail view mounts. Wait for chat
         // input to be ready so we know the detail pane is mounted.
         XCTAssertTrue(waitForChatInputReady(app: app, timeout: 30))
 
@@ -45,7 +45,7 @@ final class DemoScenarioUITests: XCTestCase {
     func test_launchArg_bootsIntoScenarioWithoutCrashing() {
         // A bare smoke test for `--bck-demo-scenario`: the app must reach
         // chat-ready state under the launch arg, proving the scenario lookup
-        // + cold-launch hook in DemoContentView.onAppear didn't fail.
+        // + post-bootstrap cold-launch hook didn't fail.
         // Asserting on tool-call streaming is left to Layer 3 against a real
         // backend.
         let app = launchDemoApp(scenario: "tip-calc")

--- a/Example/BaseChatDemoUITests/SessionManagementUITests.swift
+++ b/Example/BaseChatDemoUITests/SessionManagementUITests.swift
@@ -27,7 +27,7 @@ final class SessionManagementUITests: XCTestCase {
     func testDefaultSessionExists() throws {
         showSidebarIfNeeded(app: app)
 
-        // The app creates a default session on first launch (see DemoContentView.onAppear).
+        // The app creates a default session during launch bootstrap.
         // Look for at least one session row — sessions have a title like "New Chat"
         // or a timestamp. We check for any cell in the list.
         let sessionCells = app.cells

--- a/Example/Examples/BaseChatExamples.xcodeproj/project.pbxproj
+++ b/Example/Examples/BaseChatExamples.xcodeproj/project.pbxproj
@@ -10,10 +10,12 @@
 		09C86A21537F0ED2862D66ED /* MinimalExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA4C42C4D0FB1CD0ECBDA84 /* MinimalExampleApp.swift */; };
 		34606F73E74AAFC63E24F59A /* MinimalContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37540D69A62A294DAAD7FC1 /* MinimalContentView.swift */; };
 		40C7626D4A44DD1D18F0A1BF /* BaseChatCore in Frameworks */ = {isa = PBXBuildFile; productRef = 35D03E318932E0724E391E54 /* BaseChatCore */; };
+		5B0A9E6C1A2B3C4D5E6F7081 /* BaseChatUIModelManagement in Frameworks */ = {isa = PBXBuildFile; productRef = 1A2B3C4D5E6F708192A3B4C5 /* BaseChatUIModelManagement */; };
 		6F9A1CA5CA7FF16DB36A5861 /* BaseChatUI in Frameworks */ = {isa = PBXBuildFile; productRef = 4C28E08B212DBDD057CE27CF /* BaseChatUI */; };
 		79E6928B6CE7E3461758C5D9 /* MinimalExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA4C42C4D0FB1CD0ECBDA84 /* MinimalExampleApp.swift */; };
 		958FF9C8DBB5C5C151DFF5D7 /* MinimalContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37540D69A62A294DAAD7FC1 /* MinimalContentView.swift */; };
 		9784B251D853FA597B206D29 /* BaseChatBackends in Frameworks */ = {isa = PBXBuildFile; productRef = 56CCAAB5544541CD79EE64CD /* BaseChatBackends */; };
+		9B8A7C6D5E4F302918273645 /* BaseChatUIModelManagement in Frameworks */ = {isa = PBXBuildFile; productRef = 6D5E4F302918273645564738 /* BaseChatUIModelManagement */; };
 		A19A3DAEB85A136F8D62D31D /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 365ABBF494EF2955A53C327F /* README.md */; };
 		A336FC431FF118C880002B21 /* BaseChatCore in Frameworks */ = {isa = PBXBuildFile; productRef = DE250A4FF8082BF6714FE36C /* BaseChatCore */; };
 		A9BB32CEAF191F5FF101B54C /* BaseChatBackends in Frameworks */ = {isa = PBXBuildFile; productRef = 7A5841AF39A6AB3B5022006D /* BaseChatBackends */; };
@@ -38,6 +40,7 @@
 				40C7626D4A44DD1D18F0A1BF /* BaseChatCore in Frameworks */,
 				EFA072F50C91195B4A338E8C /* BaseChatUI in Frameworks */,
 				9784B251D853FA597B206D29 /* BaseChatBackends in Frameworks */,
+				5B0A9E6C1A2B3C4D5E6F7081 /* BaseChatUIModelManagement in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -48,6 +51,7 @@
 				A336FC431FF118C880002B21 /* BaseChatCore in Frameworks */,
 				6F9A1CA5CA7FF16DB36A5861 /* BaseChatUI in Frameworks */,
 				A9BB32CEAF191F5FF101B54C /* BaseChatBackends in Frameworks */,
+				9B8A7C6D5E4F302918273645 /* BaseChatUIModelManagement in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -110,6 +114,7 @@
 				DE250A4FF8082BF6714FE36C /* BaseChatCore */,
 				4C28E08B212DBDD057CE27CF /* BaseChatUI */,
 				7A5841AF39A6AB3B5022006D /* BaseChatBackends */,
+				6D5E4F302918273645564738 /* BaseChatUIModelManagement */,
 			);
 			productName = MinimalExample_iOS;
 			productReference = 0B803E317BA994107EA819AE /* MinimalExample.app */;
@@ -132,6 +137,7 @@
 				35D03E318932E0724E391E54 /* BaseChatCore */,
 				5D2764E94034C1EB5E482F75 /* BaseChatUI */,
 				56CCAAB5544541CD79EE64CD /* BaseChatBackends */,
+				1A2B3C4D5E6F708192A3B4C5 /* BaseChatUIModelManagement */,
 			);
 			productName = MinimalExample_macOS;
 			productReference = 92BE324A993DAA5220792683 /* MinimalExample.app */;
@@ -461,6 +467,10 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = BaseChatCore;
 		};
+		1A2B3C4D5E6F708192A3B4C5 /* BaseChatUIModelManagement */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BaseChatUIModelManagement;
+		};
 		4C28E08B212DBDD057CE27CF /* BaseChatUI */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = BaseChatUI;
@@ -472,6 +482,10 @@
 		5D2764E94034C1EB5E482F75 /* BaseChatUI */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = BaseChatUI;
+		};
+		6D5E4F302918273645564738 /* BaseChatUIModelManagement */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BaseChatUIModelManagement;
 		};
 		7A5841AF39A6AB3B5022006D /* BaseChatBackends */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Example/Examples/MinimalExample/MinimalContentView.swift
+++ b/Example/Examples/MinimalExample/MinimalContentView.swift
@@ -4,8 +4,7 @@ import BaseChatUIModelManagement
 
 struct MinimalContentView: View {
     @Environment(ChatViewModel.self) private var viewModel
-    @Environment(SessionManagerViewModel.self) private var sessionManager
-
+    @Environment(ModelManagementViewModel.self) private var managementViewModel
     @State private var isModelManagementPresented = false
 
     var body: some View {
@@ -17,14 +16,8 @@ struct MinimalContentView: View {
                 .sheet(isPresented: $isModelManagementPresented) {
                     ModelManagementSheet()
                         .environment(viewModel)
+                        .environment(managementViewModel)
                 }
-        }
-        .onAppear {
-            viewModel.refreshModels()
-
-            if sessionManager.sessions.isEmpty {
-                _ = try? sessionManager.createSession()
-            }
         }
     }
 }

--- a/Example/Examples/MinimalExample/MinimalExampleApp.swift
+++ b/Example/Examples/MinimalExample/MinimalExampleApp.swift
@@ -1,18 +1,21 @@
 import SwiftUI
 import SwiftData
 import BaseChatCore
+import BaseChatInference
 import BaseChatUI
+import BaseChatUIModelManagement
 import BaseChatBackends
 
-/// The simplest possible BaseChatKit app — under 40 lines.
+/// The simplest possible BaseChatKit app with runtime-first bootstrap.
 ///
-/// This assembles a ``BaseChatRuntime``, registers all built-in backends,
-/// and presents the standard ChatView. No model curation, no custom UI.
+/// This assembles a ``BaseChatRuntime``, registers the built-in backends,
+/// and presents the standard chat + model-management surfaces.
 @main
 struct MinimalExampleApp: App {
     private let runtime: BaseChatRuntime
     @State private var chatViewModel: ChatViewModel
     @State private var sessionManager: SessionManagerViewModel
+    @State private var modelManagement: ModelManagementViewModel
 
     init() {
         let runtime = try! BaseChatRuntime(
@@ -33,11 +36,27 @@ struct MinimalExampleApp: App {
             return false
         }
         vm.configure(runtime: runtime)
-        _chatViewModel = State(initialValue: vm)
-
         let sessionManager = SessionManagerViewModel()
         sessionManager.configure(runtime: runtime)
+
+        vm.refreshModels()
+
+        let initialSession = sessionManager.sessions.first ?? (try? sessionManager.createSession())
+        if let initialSession {
+            sessionManager.activeSession = initialSession
+            vm.switchToSession(initialSession)
+            vm.dispatchSelectedLoad()
+        }
+
+        let downloadManager = BackgroundDownloadManager()
+        let huggingFaceService = HuggingFaceService()
+
+        _chatViewModel = State(initialValue: vm)
         _sessionManager = State(initialValue: sessionManager)
+        _modelManagement = State(initialValue: ModelManagementViewModel(
+            huggingFaceService: huggingFaceService,
+            downloadManager: downloadManager
+        ))
     }
 
     var body: some Scene {
@@ -45,6 +64,7 @@ struct MinimalExampleApp: App {
             MinimalContentView()
                 .environment(chatViewModel)
                 .environment(sessionManager)
+                .environment(modelManagement)
         }
         .modelContainer(runtime.modelContainer)
     }

--- a/Example/Examples/MinimalExample/README.md
+++ b/Example/Examples/MinimalExample/README.md
@@ -16,7 +16,7 @@ The simplest possible BaseChatKit app. Demonstrates the bare minimum setup:
 ## What to Look At
 
 - `MinimalExampleApp.swift` — app entry point and runtime assembly
-- `MinimalContentView.swift` — wraps `ChatView` with minimal model refresh / session seeding
+- `MinimalContentView.swift` — wraps `ChatView` with the thinnest possible shell
 
 ## Next Steps
 

--- a/README.md
+++ b/README.md
@@ -177,8 +177,10 @@ swift test --filter BaseChatMCPTests --disable-default-traits --traits MCPBuilti
 ```swift
 import SwiftData
 import BaseChatCore
+import BaseChatInference
 import BaseChatBackends
 import BaseChatUI
+import BaseChatUIModelManagement
 
 @main
 struct MyApp: App {
@@ -206,10 +208,19 @@ struct MyApp: App {
             return false
         }
         vm.configure(runtime: runtime)
+        vm.refreshModels()
         _chatViewModel = State(initialValue: vm)
 
         let sessionManager = SessionManagerViewModel()
         sessionManager.configure(runtime: runtime)
+
+        let initialSession = sessionManager.sessions.first ?? (try? sessionManager.createSession())
+        if let initialSession {
+            sessionManager.activeSession = initialSession
+            vm.switchToSession(initialSession)
+            vm.dispatchSelectedLoad()
+        }
+
         _sessionManager = State(initialValue: sessionManager)
 
         let downloadManager = BackgroundDownloadManager()
@@ -243,21 +254,24 @@ struct ContentView: View {
         NavigationSplitView {
             SessionListView()
         } detail: {
-            ChatView(showModelManagement: .constant(false))
-        }
-        .onAppear {
-            viewModel.refreshModels()
-
-            if sessionManager.sessions.isEmpty {
-                _ = try? sessionManager.createSession()
-            }
+            ChatView(
+                showModelManagement: .constant(false),
+                apiConfiguration: { APIConfigurationView() }
+            )
         }
         .onChange(of: sessionManager.activeSession) { _, session in
-            if let session { viewModel.switchToSession(session) }
+            guard let session, viewModel.activeSession?.id != session.id else { return }
+            viewModel.switchToSession(session)
+            viewModel.dispatchSelectedLoad()
         }
     }
 }
 ```
+
+If your app still late-binds persistence from `@Environment(\.modelContext)` in
+`.task`/`.onAppear`, move that work into `App.init()` with `BaseChatRuntime`.
+Keep `configure(persistence:)` for advanced cases that provide a custom
+`ChatPersistenceProvider`.
 
 ## Supported Model Types
 

--- a/Sources/BaseChatCore/BaseChatCore.docc/Articles/GettingStarted.md
+++ b/Sources/BaseChatCore/BaseChatCore.docc/Articles/GettingStarted.md
@@ -132,9 +132,11 @@ let chatViewModel = ChatViewModel(inferenceService: runtime.inferenceService)
 chatViewModel.configure(runtime: runtime)
 ```
 
-If you are supplying your own storage backend, create a
-``ModelContainerFactory`` container and wire it to
-``SwiftDataPersistenceProvider`` manually:
+If you need to construct the SwiftData container yourself — for example to
+share an existing container with another part of the host app, or to
+configure the schema explicitly — build the container with
+``ModelContainerFactory`` and wire it to ``SwiftDataPersistenceProvider``
+manually:
 
 ```swift
 let container = try ModelContainerFactory.makeContainer()
@@ -144,6 +146,12 @@ chatViewModel.configure(persistence: persistence)
 ```
 
 Use ``ModelContainerFactory/makeInMemoryContainer()`` in tests and SwiftUI previews.
+
+Adopters that want a non-SwiftData store (e.g. a network-backed or
+encrypted-blob store) should implement ``ChatPersistenceProvider`` directly
+and pass that instance to `chatViewModel.configure(persistence:)`. Runtime
+support for substituting the persistence layer through ``BaseChatRuntime``
+is tracked separately.
 
 ## Next Steps
 

--- a/Sources/BaseChatCore/BaseChatCore.docc/Articles/GettingStarted.md
+++ b/Sources/BaseChatCore/BaseChatCore.docc/Articles/GettingStarted.md
@@ -115,7 +115,26 @@ See ``ChatViewModel`` in `BaseChatUI` for the primary consumer.
 
 ## Persistence
 
-BaseChatKit persists sessions and messages through ``ChatPersistenceProvider``. The default implementation uses SwiftData. Create a ``ModelContainerFactory`` container and wire it to ``SwiftDataPersistenceProvider``:
+BaseChatKit persists sessions and messages through ``ChatPersistenceProvider``.
+For apps using the built-in SwiftData stack, prefer ``BaseChatRuntime`` so
+configuration, inference, the model container, and persistence come up
+together:
+
+```swift
+let runtime = try BaseChatRuntime(
+    configuration: BaseChatConfiguration(
+        appName: "MyApp",
+        bundleIdentifier: "com.example.myapp"
+    )
+)
+
+let chatViewModel = ChatViewModel(inferenceService: runtime.inferenceService)
+chatViewModel.configure(runtime: runtime)
+```
+
+If you are supplying your own storage backend, create a
+``ModelContainerFactory`` container and wire it to
+``SwiftDataPersistenceProvider`` manually:
 
 ```swift
 let container = try ModelContainerFactory.makeContainer()

--- a/Sources/BaseChatUI/BaseChatUI.docc/Articles/BuildingAChatUI.md
+++ b/Sources/BaseChatUI/BaseChatUI.docc/Articles/BuildingAChatUI.md
@@ -15,6 +15,7 @@ import BaseChatCore
 import BaseChatInference
 import BaseChatBackends
 import BaseChatUI
+import SwiftData
 import SwiftUI
 
 @main

--- a/Sources/BaseChatUI/BaseChatUI.docc/Articles/BuildingAChatUI.md
+++ b/Sources/BaseChatUI/BaseChatUI.docc/Articles/BuildingAChatUI.md
@@ -12,29 +12,51 @@ Create both view models at the app level and share the same `InferenceService` b
 
 ```swift
 import BaseChatCore
+import BaseChatInference
 import BaseChatBackends
 import BaseChatUI
 import SwiftUI
-import SwiftData
 
 @main
 struct MyApp: App {
-    let inferenceService = InferenceService()
+    let runtime: BaseChatRuntime
     let chatVM: ChatViewModel
-    let sessionVM = SessionManagerViewModel()
+    let sessionVM: SessionManagerViewModel
 
     init() {
-        BaseChatConfiguration.shared = BaseChatConfiguration(
-            appName: "MyApp",
-            bundleIdentifier: Bundle.main.bundleIdentifier ?? "com.example.myapp"
+        let runtime = try! BaseChatRuntime(
+            configuration: BaseChatConfiguration(
+                appName: "MyApp",
+                bundleIdentifier: Bundle.main.bundleIdentifier ?? "com.example.myapp"
+            )
         )
-        DefaultBackends.register(with: inferenceService)
-        chatVM = ChatViewModel(inferenceService: inferenceService)
+        self.runtime = runtime
+
+        DefaultBackends.register(with: runtime.inferenceService)
+
+        let chatVM = ChatViewModel(inferenceService: runtime.inferenceService)
+        chatVM.configure(runtime: runtime)
+        chatVM.refreshModels()
+        self.chatVM = chatVM
+
+        let sessionVM = SessionManagerViewModel()
+        sessionVM.configure(runtime: runtime)
+        let initialSession = sessionVM.sessions.first ?? (try? sessionVM.createSession())
+        if let initialSession {
+            sessionVM.activeSession = initialSession
+            chatVM.switchToSession(initialSession)
+            chatVM.dispatchSelectedLoad()
+        }
+        self.sessionVM = sessionVM
 
         // Connect session title generation to InferenceService
         chatVM.onFirstMessage = { session, firstMessage in
             Task { @MainActor in
-                await sessionVM.autoRenameSession(session, firstMessage: firstMessage, inferenceService: inferenceService)
+                await sessionVM.autoRenameSession(
+                    session,
+                    firstMessage: firstMessage,
+                    inferenceService: runtime.inferenceService
+                )
             }
         }
     }
@@ -45,7 +67,7 @@ struct MyApp: App {
                 .environment(chatVM)
                 .environment(sessionVM)
         }
-        .modelContainer(try! ModelContainerFactory.makeContainer())
+        .modelContainer(runtime.modelContainer)
     }
 }
 ```
@@ -56,25 +78,26 @@ struct MyApp: App {
 struct RootView: View {
     @Environment(ChatViewModel.self) var chatVM
     @Environment(SessionManagerViewModel.self) var sessionVM
-    @Environment(\.modelContext) var modelContext
 
     var body: some View {
         NavigationSplitView {
             SessionListView()
         } detail: {
-            ChatView()
+            ChatView(
+                showModelManagement: .constant(false),
+                apiConfiguration: { EmptyView() }
+            )
         }
-        .task {
-            let provider = SwiftDataPersistenceProvider(modelContext: modelContext)
-            sessionVM.configure(persistence: provider)
-            chatVM.configure(persistence: provider)
-            chatVM.refreshModels()
+        .onChange(of: sessionVM.activeSession) { _, newSession in
+            guard let newSession, chatVM.activeSession?.id != newSession.id else { return }
+            chatVM.switchToSession(newSession)
+            chatVM.dispatchSelectedLoad()
         }
     }
 }
 ```
 
-Both view models share the same ``SwiftDataPersistenceProvider`` instance so session records created by `SessionManagerViewModel` are immediately visible to `ChatViewModel`.
+Both view models share the same runtime-backed ``SwiftDataPersistenceProvider`` instance, so session records created by `SessionManagerViewModel` are immediately visible to `ChatViewModel`. The root view no longer has to late-bind persistence from `modelContext` on first appearance.
 
 ### Switching sessions
 

--- a/Sources/BaseChatUI/BaseChatUI.docc/BaseChatUI.md
+++ b/Sources/BaseChatUI/BaseChatUI.docc/BaseChatUI.md
@@ -10,23 +10,39 @@ BaseChatUI provides the view layer for BaseChatKit. It depends only on ``BaseCha
 
 ```swift
 import BaseChatCore
+import BaseChatInference
 import BaseChatBackends
 import BaseChatUI
 import SwiftUI
-import SwiftData
 
 @main
 struct MyApp: App {
-    let inferenceService = InferenceService()
+    let runtime: BaseChatRuntime
     let chatVM: ChatViewModel
 
     init() {
-        BaseChatConfiguration.shared = BaseChatConfiguration(
-            appName: "MyApp",
-            bundleIdentifier: Bundle.main.bundleIdentifier ?? "com.example.myapp"
+        let runtime = try! BaseChatRuntime(
+            configuration: BaseChatConfiguration(
+                appName: "MyApp",
+                bundleIdentifier: Bundle.main.bundleIdentifier ?? "com.example.myapp"
+            )
         )
-        DefaultBackends.register(with: inferenceService)
-        chatVM = ChatViewModel(inferenceService: inferenceService)
+        self.runtime = runtime
+
+        DefaultBackends.register(with: runtime.inferenceService)
+
+        let chatVM = ChatViewModel(inferenceService: runtime.inferenceService)
+        chatVM.configure(runtime: runtime)
+        chatVM.refreshModels()
+
+        let sessionVM = SessionManagerViewModel()
+        sessionVM.configure(runtime: runtime)
+        if let session = sessionVM.sessions.first ?? (try? sessionVM.createSession()) {
+            chatVM.switchToSession(session)
+            chatVM.dispatchSelectedLoad()
+        }
+
+        self.chatVM = chatVM
     }
 
     var body: some Scene {
@@ -34,7 +50,7 @@ struct MyApp: App {
             ContentView()
                 .environment(chatVM)
         }
-        .modelContainer(try! ModelContainerFactory.makeContainer())
+        .modelContainer(runtime.modelContainer)
     }
 }
 ```
@@ -46,7 +62,10 @@ struct ContentView: View {
     @Environment(ChatViewModel.self) var chatVM
 
     var body: some View {
-        ChatView()
+        ChatView(
+            showModelManagement: .constant(false),
+            apiConfiguration: { EmptyView() }
+        )
     }
 }
 ```

--- a/Sources/BaseChatUI/BaseChatUI.docc/BaseChatUI.md
+++ b/Sources/BaseChatUI/BaseChatUI.docc/BaseChatUI.md
@@ -13,6 +13,7 @@ import BaseChatCore
 import BaseChatInference
 import BaseChatBackends
 import BaseChatUI
+import SwiftData
 import SwiftUI
 
 @main

--- a/Sources/BaseChatUI/BaseChatUI.docc/Extensions/ChatViewModel.md
+++ b/Sources/BaseChatUI/BaseChatUI.docc/Extensions/ChatViewModel.md
@@ -52,6 +52,7 @@
 
 ### Initialization & Setup
 
+- ``configure(runtime:)``
 - ``configure(persistence:)``
 - ``refreshModels()``
 - ``loadSelectedModel()``

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Ingest.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Ingest.swift
@@ -17,9 +17,9 @@ extension ChatViewModel {
     ///
     /// ## Requirements
     ///
-    /// - ``configure(persistence:)`` must have been called. Otherwise this
-    ///   method no-ops after logging a warning — callers should buffer the
-    ///   payload until persistence is ready.
+    /// - ``configure(runtime:)`` or ``configure(persistence:)`` must have been
+    ///   called. Otherwise this method no-ops after logging a warning —
+    ///   callers should buffer the payload until persistence is ready.
     /// - A model or endpoint must be loaded; if not, the usual
     ///   "no model loaded" error surfaces via ``activeError`` and generation
     ///   is not started, matching the compose-bar contract.

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+IngestPendingPayload.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+IngestPendingPayload.swift
@@ -147,8 +147,8 @@ extension ChatViewModel {
     ///
     /// ## Requirements
     ///
-    /// ``configure(persistence:)`` must have been called before
-    /// ``IngestionIntent/newSession(preset:)`` is used. Without
+    /// ``configure(runtime:)`` or ``configure(persistence:)`` must have been
+    /// called before ``IngestionIntent/newSession(preset:)`` is used. Without
     /// persistence the call no-ops after logging a warning. The two
     /// non-persisting intents (``IngestionIntent/appendToActive``,
     /// ``IngestionIntent/draft``) work without persistence.

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -708,8 +708,9 @@ public final class ChatViewModel {
         }
     }
 
-    /// Injects the persistence provider. Call once from the view layer
-    /// after the storage backend is available.
+    /// Injects the persistence provider. Call once after the storage backend is
+    /// available, or prefer ``configure(runtime:)`` when bootstrapping through
+    /// ``BaseChatRuntime``.
     public func configure(persistence: ChatPersistenceProvider) {
         sessionController.configure(persistence: persistence)
     }

--- a/Tests/BaseChatUIModelManagementTests/RuntimeBootstrapMigrationGuardTests.swift
+++ b/Tests/BaseChatUIModelManagementTests/RuntimeBootstrapMigrationGuardTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+import SwiftUI
+@testable import BaseChatCore
+@testable import BaseChatInference
+@testable import BaseChatUI
+@testable import BaseChatUIModelManagement
+
+/// Compile-time guard for the README / MinimalExample runtime bootstrap path.
+///
+/// Host apps should be able to assemble `BaseChatRuntime`, configure the chat
+/// view models from it, and render `ChatView(apiConfiguration:)` without
+/// falling back to view-lifecycle persistence wiring.
+final class RuntimeBootstrapMigrationGuardTests: XCTestCase {
+
+    @MainActor
+    func test_runtimeBootstrap_chatViewCompositionCompiles() throws {
+        let originalConfiguration = BaseChatConfiguration.shared
+        defer { BaseChatConfiguration.shared = originalConfiguration }
+
+        let runtime = try BaseChatRuntime(
+            configuration: BaseChatConfiguration(
+                appName: "Runtime Bootstrap Guard",
+                bundleIdentifier: "com.basechatkit.runtime-bootstrap-guard"
+            ),
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+
+        let chatViewModel = ChatViewModel(inferenceService: runtime.inferenceService)
+        let sessionManager = SessionManagerViewModel()
+        chatViewModel.configure(runtime: runtime)
+        sessionManager.configure(runtime: runtime)
+
+        let view = AnyView(
+            ChatView(
+                showModelManagement: .constant(false),
+                apiConfiguration: { APIConfigurationView() }
+            )
+            .environment(chatViewModel)
+            .environment(sessionManager)
+        )
+
+        XCTAssertNotNil(view)
+    }
+}

--- a/Tests/BaseChatUITests/RuntimeConfigurationTests.swift
+++ b/Tests/BaseChatUITests/RuntimeConfigurationTests.swift
@@ -50,4 +50,48 @@ final class RuntimeConfigurationTests: XCTestCase {
         let created = try sessionManager.createSession(title: "Runtime Session")
         XCTAssertEqual(try runtime.persistence.fetchSessions().map(\.id), [created.id])
     }
+
+    func test_runtimeBootstrap_canSeedAndActivateInitialSessionWithoutViewLifecycleHooks() throws {
+        let originalConfiguration = BaseChatConfiguration.shared
+        defer { BaseChatConfiguration.shared = originalConfiguration }
+
+        let suiteName = "BaseChatRuntimeBootstrapTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to allocate isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let runtime = try BaseChatRuntime(
+            configuration: BaseChatConfiguration(
+                appName: "Bootstrap Tests",
+                bundleIdentifier: "com.basechatkit.runtime-ui-tests.bootstrap"
+            ),
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+
+        let chatViewModel = ChatViewModel(
+            inferenceService: runtime.inferenceService,
+            userDefaults: defaults
+        )
+        let sessionManager = SessionManagerViewModel()
+
+        chatViewModel.configure(runtime: runtime)
+        sessionManager.configure(runtime: runtime)
+        chatViewModel.refreshModels()
+
+        let initialSession = sessionManager.sessions.first ?? (try? sessionManager.createSession())
+        guard let initialSession else {
+            XCTFail("Bootstrap should create or restore an initial session")
+            return
+        }
+
+        sessionManager.activeSession = initialSession
+        chatViewModel.switchToSession(initialSession)
+        chatViewModel.dispatchSelectedLoad()
+
+        XCTAssertEqual(sessionManager.activeSession?.id, initialSession.id)
+        XCTAssertEqual(chatViewModel.activeSession?.id, initialSession.id)
+        XCTAssertEqual(try runtime.persistence.fetchSessions().map(\.id), [initialSession.id])
+    }
 }


### PR DESCRIPTION
## Summary
- move the common runtime/bootstrap work for the minimal example and demo app out of view lifecycle hooks and into runtime-first app assembly
- update README + DocC guidance to show the `BaseChatRuntime` path, initial session seeding, and migration away from late-bound `configure(persistence:)` usage
- add runtime bootstrap migration guards and keep example Xcode wiring building with `BaseChatUIModelManagement`

## Test plan
- [x] `swift test --filter 'BaseChatCoreTests\\.BaseChatRuntimeTests|BaseChatUITests\\.RuntimeConfigurationTests|BaseChatUIModelManagementTests\\.(APIConfigurationViewMigrationGuardTests|RuntimeBootstrapMigrationGuardTests)' --disable-default-traits`\n- [x] `xcodebuild -project Example/Examples/BaseChatExamples.xcodeproj -scheme MinimalExample_macOS -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`\n- [x] `xcodebuild -project Example/BaseChatDemo.xcodeproj -scheme BaseChatDemo -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`\n\n## Notes\n- Targeting `feat/runtime-core` because this branch depends on the new `BaseChatRuntime` + `configure(runtime:)` surface from PR #866.