### PR TITLE
docs: add runtime ports refactor plan

### DIFF
--- a/Example/BaseChatDemo.xcodeproj/project.pbxproj
+++ b/Example/BaseChatDemo.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		BF1012000000000000000000 /* BaseChatInference in Frameworks */ = {isa = PBXBuildFile; productRef = F30007000000000000000000 /* BaseChatInference */; };
 		BF0026000000000000000000 /* SetReminderIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10022000000000000000000 /* SetReminderIntent.swift */; };
 		BF0027000000000000000000 /* AppIntentToolsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10023000000000000000000 /* AppIntentToolsView.swift */; };
+		BF0029000000000000000000 /* DemoNowTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10024000000000000000000 /* DemoNowTool.swift */; };
 		BF0028000000000000000000 /* BaseChatAppIntents in Frameworks */ = {isa = PBXBuildFile; productRef = F30008000000000000000000 /* BaseChatAppIntents */; };
 		BF0030000000000000000000 /* PendingSharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10030000000000000000000 /* PendingSharePayload.swift */; };
 		BF0031000000000000000000 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10031000000000000000000 /* ShareViewController.swift */; };
@@ -114,6 +115,7 @@
 		F10021000000000000000000 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F10022000000000000000000 /* SetReminderIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Intents/SetReminderIntent.swift; sourceTree = "<group>"; };
 		F10023000000000000000000 /* AppIntentToolsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntentToolsView.swift; sourceTree = "<group>"; };
+		F10024000000000000000000 /* DemoNowTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoNowTool.swift; sourceTree = "<group>"; };
 		F10030000000000000000000 /* PendingSharePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingSharePayload.swift; sourceTree = "<group>"; };
 		F10031000000000000000000 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		F10032000000000000000000 /* ShareExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ShareExtension.entitlements; sourceTree = "<group>"; };
@@ -215,6 +217,7 @@
 				F10020000000000000000000 /* InboundPayloadEnvelope.swift */,
 				F10022000000000000000000 /* SetReminderIntent.swift */,
 				F10023000000000000000000 /* AppIntentToolsView.swift */,
+				F10024000000000000000000 /* DemoNowTool.swift */,
 				A02001000000000000000000 /* Extensions */,
 			);
 			path = BaseChatDemo;
@@ -431,6 +434,7 @@
 				BF0023000000000000000000 /* InboundPayloadEnvelope.swift in Sources */,
 				BF0026000000000000000000 /* SetReminderIntent.swift in Sources */,
 				BF0027000000000000000000 /* AppIntentToolsView.swift in Sources */,
+				BF0029000000000000000000 /* DemoNowTool.swift in Sources */,
 				BF0030000000000000000000 /* PendingSharePayload.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -634,7 +638,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.12.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.basechatkit.demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -669,7 +673,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.12.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.basechatkit.demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -689,7 +693,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.12.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.basechatkit.demo.uitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -710,7 +714,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.12.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.basechatkit.demo.uitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;

--- a/Example/BaseChatDemo/ConnectedServicesView.swift
+++ b/Example/BaseChatDemo/ConnectedServicesView.swift
@@ -22,21 +22,20 @@ struct ConnectedServicesView: View {
 
     var body: some View {
         NavigationStack {
-            List {
+            Group {
                 if coordinator.catalog.isEmpty {
-                    Section("Connected Services") {
-                        Label(
-                            coordinator.catalogHelpText,
-                            systemImage: "exclamationmark.triangle"
-                        )
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                        .accessibilityIdentifier("connected-services-catalog-empty-message")
+                    ContentUnavailableView {
+                        Label("No services configured", systemImage: "link.badge.plus")
+                    } description: {
+                        Text(coordinator.catalogHelpText)
                     }
+                    .accessibilityIdentifier("connected-services-catalog-empty-message")
                 } else {
-                    Section("Connected Services") {
-                        ForEach(coordinator.catalog, id: \.id) { descriptor in
-                            serviceRow(for: descriptor)
+                    List {
+                        Section("Connected Services") {
+                            ForEach(coordinator.catalog, id: \.id) { descriptor in
+                                serviceRow(for: descriptor)
+                            }
                         }
                     }
                 }

--- a/Example/BaseChatDemo/DemoNowTool.swift
+++ b/Example/BaseChatDemo/DemoNowTool.swift
@@ -1,0 +1,55 @@
+import Foundation
+import BaseChatInference
+
+/// Demo-local replacement for ``NowTool`` that returns the real current time.
+///
+/// The shared reference tool intentionally returns a fixed fixture timestamp so
+/// end-to-end tests can distinguish a real tool call from hallucinated output.
+/// The demo app should feel live instead, so it uses this executor.
+enum DemoNowTool {
+
+    struct Args: Decodable, Sendable {
+        let timezone: String?
+    }
+
+    struct Result: Encodable, Sendable {
+        let timestamp: String
+        let timezone: String
+        let localTime: String
+    }
+
+    static func makeExecutor() -> TypedToolExecutor<Args, Result> {
+        let definition = ToolDefinition(
+            name: "now",
+            description: "Returns the current date and time. If the user asks for a place-specific time, pass an IANA timezone like 'Asia/Tokyo' when possible; never guess.",
+            parameters: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "timezone": .object([
+                        "type": .string("string"),
+                        "description": .string("Optional IANA timezone identifier, for example 'Asia/Tokyo'.")
+                    ])
+                ]),
+                "required": .array([])
+            ])
+        )
+
+        return TypedToolExecutor(definition: definition) { args in
+            let timeZone = args.timezone.flatMap(TimeZone.init(identifier:)) ?? .current
+            let clock = ISO8601DateFormatter()
+            clock.timeZone = timeZone
+
+            let localFormatter = DateFormatter()
+            localFormatter.locale = Locale(identifier: "en_US_POSIX")
+            localFormatter.timeZone = timeZone
+            localFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss zzz"
+
+            let now = Date()
+            return Result(
+                timestamp: clock.string(from: now),
+                timezone: timeZone.identifier,
+                localTime: localFormatter.string(from: now)
+            )
+        }
+    }
+}

--- a/Example/BaseChatDemo/DemoTools.swift
+++ b/Example/BaseChatDemo/DemoTools.swift
@@ -40,7 +40,7 @@ enum DemoTools {
         }
 
         registry.register(CalcTool.makeExecutor())
-        registry.register(NowTool.makeExecutor())
+        registry.register(DemoNowTool.makeExecutor())
         registry.register(ReadFileTool.makeExecutor(root: root))
         registry.register(ListDirTool.makeExecutor(root: root))
         registry.register(SampleRepoSearchTool.makeExecutor(root: root))

--- a/Sources/BaseChatUI/Views/Chat/MemoryIndicatorView.swift
+++ b/Sources/BaseChatUI/Views/Chat/MemoryIndicatorView.swift
@@ -5,7 +5,7 @@ import BaseChatInference
 /// Shows device memory pressure and RAM usage as a compact indicator in the chat toolbar.
 ///
 /// Mirrors the visual style of `ContextIndicatorView`: a small colored dot indicating
-/// pressure level, followed by a label showing current app memory usage and total device RAM.
+/// pressure level, followed by a label showing the current app memory footprint.
 ///
 /// Color coding follows the OS pressure levels:
 /// - Green (.nominal) — memory is comfortable
@@ -43,13 +43,15 @@ public struct MemoryIndicatorView: View {
         }
     }
 
-    /// Short label shown next to the dot. Shows "X / Y GB" when app usage is available,
-    /// otherwise just the device total.
+    /// Short label shown next to the dot. We deliberately avoid an "X / Y GB"
+    /// fraction because the numerator is this app's footprint while the
+    /// denominator is total device RAM, which users can misread as a system-wide
+    /// usage meter.
     private var compactLabel: String {
-        let totalGB = Double(physicalMemoryBytes) / (1024 * 1024 * 1024)
         if let used = appMemoryBytes {
-            return "\(AppMemoryUsage.format(used)) / \(String(format: "%.0f", totalGB)) GB"
+            return "App \(AppMemoryUsage.format(used))"
         }
+        let totalGB = Double(physicalMemoryBytes) / (1024 * 1024 * 1024)
         return String(format: "%.0f GB RAM", totalGB)
     }
 
@@ -91,6 +93,7 @@ public struct MemoryIndicatorView: View {
         lines.append("Device RAM: \(totalGB) GB")
         if let used = appMemoryBytes {
             lines.append("App footprint: \(AppMemoryUsage.format(used))")
+            lines.append("This is this app only, not total system memory in use.")
         }
         return lines.joined(separator: "\n")
     }

--- a/Sources/BaseChatUI/Views/Sidebar/SessionListView.swift
+++ b/Sources/BaseChatUI/Views/Sidebar/SessionListView.swift
@@ -54,6 +54,20 @@ public struct SessionListView: View {
                                 }
                                 .tint(.blue)
                             }
+                            .contextMenu {
+                                Button {
+                                    renameText = session.title
+                                    sessionToRename = session
+                                } label: {
+                                    Label("Rename", systemImage: "pencil")
+                                }
+
+                                Button(role: .destructive) {
+                                    sessionToDelete = session
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            }
                             .onAppear {
                                 // Trigger pagination only for the unfiltered list — search
                                 // results already pull from a wider window in the VM.

--- a/docs/plans/runtime-ports-refactor.md
+++ b/docs/plans/runtime-ports-refactor.md
@@ -8,6 +8,7 @@ argue with the architecture instead of reverse-engineering it from the diff.
 
 - Branch: `docs/runtime-ports-proposal`
 - Scope: architecture and migration plan only
+- Window: **pre-1.0** — break public API freely; no compatibility tail
 - Downstream consumers in view:
   - BaseChatKit demo app
   - ChatbotUI-iOS
@@ -19,280 +20,319 @@ BaseChatKit already has a strong inference boundary:
 
 - `BaseChatInference` is storage-free and backend-agnostic.
 - `BaseChatBackends` and `BaseChatMCP` depend on inference directly.
-- `ChatPersistenceProvider` already decouples chat/session persistence from
-  SwiftData for the main transcript flows.
+- `ChatPersistenceProvider` decouples session/message persistence from
+  SwiftData via storage-neutral records (`ChatSessionRecord`,
+  `ChatMessageRecord`, `APIEndpointRecord` — all hosted in
+  `BaseChatInference`).
 
 But the app/runtime boundary is still mixed across `BaseChatCore`,
-`BaseChatUI`, and `BaseChatUIModelManagement`:
+`BaseChatUI`, and `BaseChatUIModelManagement`. The concrete leaks:
 
-- some UI flows still know about SwiftData directly
-- app orchestration still lives in UI-owned view models
-- model management still exposes `ModelContext` for benchmark persistence
-- endpoint/settings flows still leak Core-era storage assumptions into
-  UI-facing APIs
+- `SamplerPresetPickerView` uses `@Query(sort: \SamplerPreset.createdAt)`
+  directly against the SwiftData `@Model`.
+- `ModelManagementViewModel.modelContext: ModelContext?` is a public
+  property that hands the SwiftData store to host code.
+- `APIConfigurationView` and `ModelManagementSheet` `import SwiftData`
+  for endpoint editor flows.
+- Application orchestration (`ChatViewModel`, `SessionManagerViewModel`,
+  `ModelManagementViewModel`) is intertwined with `@Observable`
+  presentation state. `ChatViewModel.swift:608–708` wires its coordinators
+  via ~50 closure callbacks — orchestration and presentation share
+  storage instead of communicating across a typed boundary.
 
-That shape is workable for the stock demo app, but it makes two other host
-styles harder than they should be:
+Three host shapes pay the cost:
 
-1. **ChatbotUI-iOS** wants mostly stock BCK behavior with a custom shell.
-2. **Fireside** wants to use BCK as a subsystem inside a story/memory runtime,
-   not adopt BCK's UI and persistence assumptions wholesale.
+1. **BaseChatKit demo app** — fine today, but cannot evolve without
+   pulling other consumers along.
+2. **ChatbotUI-iOS** — wants stock BCK behavior with a custom shell.
+3. **Fireside** — wants BCK as a subsystem inside a story/memory runtime.
+   Already integrates by importing `InferenceService` + `ChatPersistenceProvider`
+   directly and writing its own bootstrap; this works but inherits
+   `BaseChatCore`'s SwiftData surface unwillingly.
 
 ## What we are building
 
-A new runtime-centered package split:
+A runtime-centered package split. **Pre-1.0**, so this is a hard cut, not
+a deprecation cycle.
 
 ```text
-BaseChatInference
-  ^ used by BaseChatBackends, BaseChatMCP, BaseChatRuntime
-
-BaseChatRuntime
-  depends on BaseChatInference
-  owns application use cases + ports only
-
-BaseChatPersistenceSwiftData
-  depends on BaseChatRuntime
-  owns SwiftData schema, migrations, adapters, container/bootstrap helpers
-
-BaseChatUI
-  depends on BaseChatRuntime
-  owns SwiftUI views and thin presentation adapters
-
-BaseChatUIModelManagement
-  depends on BaseChatUI + BaseChatRuntime
-  owns optional model-management UI only
-
-BaseChatCore
-  temporary compatibility facade for one release cycle, then removed
+                    BaseChatInference
+                          ▲
+            ┌─────────────┼──────────────────┐
+            │             │                  │
+   BaseChatBackends  BaseChatMCP      BaseChatRuntime
+                                            ▲
+                          ┌─────────────────┼──────────────────┐
+                          │                 │                  │
+                BaseChatPersistence-   BaseChatUI    BaseChatUIModelManagement
+                   SwiftData               ▲                   │
+                                           └───────────────────┘
+                                                (one-way edge,
+                                                 already CI-enforced)
 ```
 
-The center of gravity moves from:
+The center of gravity moves from
+`ChatViewModel + SessionManagerViewModel + ModelContext-aware UI`
+to `BaseChatRuntime` use cases + ports, with UI as a presentation layer
+rather than the application layer.
 
-```text
-ChatViewModel + SessionManagerViewModel + ModelContext-aware UI
-```
+### Target naming
 
-to:
+- The existing `public final class BaseChatRuntime` in
+  `Sources/BaseChatCore/BaseChatRuntime.swift` is renamed to
+  `BaseChatBootstrap` (a file by that name already exists in the same
+  directory — it absorbs the rename).
+- The new target is `BaseChatRuntime`.
+- `BaseChatCore` is **deleted**, not deprecated. Its current contents
+  redistribute: persistence implementation → `BaseChatPersistenceSwiftData`,
+  storage-neutral helpers → `BaseChatRuntime`, intent protocols →
+  `BaseChatRuntime`. Host apps update their imports in one PR.
 
-```text
-BaseChatRuntime services + ports
-```
+### Where today's pieces land
 
-with UI acting as a presentation layer rather than the application layer.
+| Today | Lands in |
+|-------|----------|
+| `BaseChatCore` SwiftData `@Model` types + schema | `BaseChatPersistenceSwiftData` |
+| `SwiftDataPersistenceProvider` | `BaseChatPersistenceSwiftData` |
+| `ChatPersistenceProvider` protocol | `BaseChatRuntime` |
+| `BaseChatRuntime` (bootstrap class) | `BaseChatRuntime` (renamed `BaseChatBootstrap`) |
+| `ChatExportService` / `ConversationExporter` | `BaseChatRuntime` |
+| `ChatIntentAction` / `ChatSessionIntentHandler` | `BaseChatRuntime` |
+| `ChatViewModel` + extensions | `BaseChatUI` (thinned to ≤300 LOC) |
+| `SessionManagerViewModel` | `BaseChatUI` (thin adapter) |
+| `ModelLoadCoordinator` / `GenerationCoordinator` (UI-side) | `BaseChatRuntime` (renamed to avoid collision with Inference's `GenerationCoordinator`) |
+| `ModelManagementViewModel` | `BaseChatUIModelManagement` (thin adapter) |
+| `BaseChatBackends`, `BaseChatMCP`, `BaseChatTools`, `BaseChatAppIntents`, `BaseChatFuzz` | unchanged (still depend on Inference only) |
+| `BaseChatTestSupport` | split: Inference-only fakes stay; SwiftData harnesses move to a new `BaseChatPersistenceSwiftDataTestSupport` |
 
 ## Non-goals
 
-- No SwiftData schema redesign unless the refactor forces a narrowly-scoped one.
-- No expansion of `ChatViewModel` or `InferenceService` public API as a shortcut.
-- No giant "misc runtime" bucket that simply replaces the current `BaseChatCore`
-  overload with a new overload.
-- No permanent direct `SwiftData`, `@Query`, or `ModelContext` usage in
-  `BaseChatUI*` once the migration is complete.
+- No SwiftData schema redesign. `BaseChatSchemaV3` moves modules but
+  entity names (the persistence keys) stay identical.
+- No expansion of `InferenceService` public API as a shortcut.
+- No new "misc runtime" bucket — every type added to `BaseChatRuntime`
+  must be either a port, a use case, or a value type.
+- No deprecation cycle, no compat shims, no `@available(deprecated)`
+  re-exports. Pre-1.0 means clean cuts.
 
 ## Design principles
 
 | # | Principle | Why |
 |---|-----------|-----|
-| 1 | **Runtime owns use cases, not view state.** | Transcript/session/model orchestration should be reusable by the demo app, ChatbotUI-iOS, and Fireside. Focus state, scroll affordances, sheets, and draft text are UI concerns. |
-| 2 | **SwiftData stays behind adapters.** | `BaseChatRuntime` must not expose `ModelContext`, `@Model` types, `@Query`, or migration internals. |
-| 3 | **Prefer existing record/value types.** | `ChatSessionRecord`, `ChatMessageRecord`, and `APIEndpointRecord` already express the right direction: storage-neutral data at the boundary. |
-| 4 | **Additive migration first.** | The fastest way to break consumers is a big rename/delete wave. Land runtime and adapter surfaces first, then move call sites. |
-| 5 | **Secrets and network policy stay out of runtime.** | Keychain, `URLSession`, trust policy, OAuth, and remote process/network configuration belong in adapters. |
-| 6 | **Context injection is a first-class port.** | Fireside needs a structured way to supply story, memory, and profile context without forking the chat runtime. |
+| 1 | **Runtime owns use cases, not view state.** | Transcript/session/model orchestration must be reusable by any host. Focus state, scroll, sheets, draft text are UI concerns. |
+| 2 | **SwiftData stays behind adapters.** | `BaseChatRuntime` must not expose `ModelContext`, `@Model`, `@Query`, or migration internals. |
+| 3 | **Records at the boundary.** | `ChatSessionRecord`, `ChatMessageRecord`, `APIEndpointRecord` already live in Inference. Every port traffics in records, not `@Model` types. |
+| 4 | **Events out, commands in.** | Use cases expose `AsyncSequence<Event>` for state changes and `async throws` commands for actions. UI adapters subscribe and republish — no closure-bag wiring across boundaries. |
+| 5 | **Secrets and network policy stay out of runtime.** | Keychain, `URLSession`, trust delegates, OAuth live in Inference (where they already are) or in adapters. |
+| 6 | **Context injection is a first-class port.** | Fireside needs a structured way to supply story/memory/profile context. `GenerationContextProvider` already exists in Inference — runtime exposes a port that wraps it. |
+| 7 | **Ports are async at the use-case surface, sync at the implementation.** | `ChatPersistenceProvider` becomes `async throws` (SwiftData `ModelContext` is `@MainActor`-bound; `async` lets the use case yield without blocking). Pre-1.0 lets us break the existing sync signature without compat shims. |
 
 ## Proposed runtime surface
 
 ### Ports
 
-- `SessionStore`
-- `MessageStore` / `ConversationStore`
-- `EndpointStore`
-- `SamplerPresetStore`
-- `ModelCatalog`
-- `ModelDownloadCoordinator`
-- `BenchmarkCache`
-- `TitleGenerator`
-- `GenerationContextProvider` / `PromptContextContributor`
+| Port | Replaces today's leak |
+|------|-----------------------|
+| `SessionStore` | `ChatPersistenceProvider` session methods |
+| `MessageStore` | `ChatPersistenceProvider` message + search methods |
+| `EndpointStore` | `APIConfigurationView` direct SwiftData access |
+| `SamplerPresetStore` | `SamplerPresetPickerView`'s `@Query(SamplerPreset)` |
+| `BenchmarkCache` | `ModelManagementViewModel.modelContext: ModelContext?` |
+| `ModelCatalog` | `ModelManagementViewModel`'s direct disk inspection |
+| `TitleGenerator` | `SessionManagerViewModel.generateTitle` calling `InferenceService` directly |
+| `GenerationContextProvider` (re-exported) | already exists in Inference — runtime exposes it |
+| `ToolSource` | generalises today's `MCPToolSource` pattern |
+
+`ChatPersistenceProvider` is split into `SessionStore` + `MessageStore`.
+The combined provider was a v0.x convenience; per-port boundaries make
+selective implementation by hosts (Fireside) cheaper.
 
 ### Use cases
 
-- `ConversationRuntime`
-- `SessionListService`
-- `ModelManagementService`
-- `PromptContextPipeline`
+| Use case | Absorbs | Surface |
+|----------|---------|---------|
+| `ConversationRuntime` | `ChatViewModel`'s send/cancel/regenerate/edit/branch logic, `GenerationCoordinator` (UI-side), `ModelLoadCoordinator` | `AsyncSequence<ConversationEvent>` + commands |
+| `SessionListService` | `SessionManagerViewModel`'s CRUD/search/pagination/title generation | `AsyncSequence<SessionListEvent>` + commands |
+| `ModelManagementService` | `ModelManagementViewModel`'s discovery/download/delete/benchmark | `AsyncSequence<ModelCatalogEvent>` + commands |
+| `PromptContextPipeline` | new — composes `GenerationContextProvider` contributions | `[ContextContribution]` |
 
 ### Constraints
 
-- `BaseChatRuntime` stays SwiftUI-free and Observation-free.
-- Prefer `async/await`, `AsyncSequence`, and typed events over nested
-  observable state.
-- Runtime instances should be scene/window scoped, not hidden singletons.
+- `BaseChatRuntime` is SwiftUI-free, Observation-free, SwiftData-free.
+- Use cases are plain classes, not `@Observable`. Internal state is private.
+  External state changes are emitted as events.
+- Use cases are not `@MainActor`-pinned at the type level. Methods that
+  call into `@MainActor` ports (SwiftData) hop on demand.
+- Runtime instances are scene/window scoped, never singletons.
+- All public API on use cases is `async throws` for commands and
+  `AsyncSequence<Event>` for state.
 
-## Current coupling hotspots to remove early
+## Trait propagation
 
-1. **UI-owned orchestration**
-   - `ChatViewModel`
-   - `SessionManagerViewModel`
-   - `ModelManagementViewModel`
+`BaseChatRuntime` declares the same trait gates as `BaseChatUI` does today
+(`Ollama`, `CloudSaaS`). `EndpointStore` and `ModelManagementService` use
+`#if Ollama` / `#if CloudSaaS` where appropriate. `BaseChatPersistenceSwiftData`
+is untraited (schema is the same regardless of which backends are enabled).
 
-2. **SwiftData leakage in UI/model-management flows**
-   - direct `@Query`
-   - direct `ModelContext`
-   - benchmark cache persistence via `ModelManagementViewModel.modelContext`
+## Test-support partitioning
 
-3. **Core/storage-shaped types leaking into UI/runtime APIs**
-   - endpoint/settings flows that still assume SwiftData-backed Core models
+`BaseChatTestSupport` today depends on `BaseChatCore`. After the split:
 
-These are the first seams to attack because they determine whether the runtime
-is genuinely reusable or just a renamed copy of today's stack.
+- Inference-only fakes (`MockInferenceBackend`, `CharTokenizer`,
+  `ChaosBackend`, etc.) — stay in `BaseChatTestSupport`, depend only on
+  `BaseChatInference`.
+- SwiftData-backed harnesses (`InMemoryPersistenceHarness`,
+  `ErrorInjectingPersistenceProvider`, `MockBackgroundTaskScheduler`)
+  → new `BaseChatPersistenceSwiftDataTestSupport` target.
+- Runtime-port fakes (in-memory `SessionStore`, `MessageStore`, etc.)
+  → also in `BaseChatPersistenceSwiftDataTestSupport`, or a separate
+  `BaseChatRuntimeTestSupport` if it grows beyond ~5 fakes.
+
+This split happens in the same PR cycle as the production split — test
+infrastructure can't lag.
 
 ## Migration phases
 
-### Phase 0 — freeze behavior and add guardrails
+Three phases, all pre-1.0, no deprecation tail.
 
-- Write characterization coverage for:
-  - session CRUD, ordering, pagination
-  - message paging and search/snippet semantics
-  - model/endpoint selection restoration
-  - first-message auto-rename behavior
-- Add repo guardrails:
-  - no new `SwiftData` imports in `BaseChatUI*`
-  - no new `@Query` / `.modelContext` usage in UI targets
-  - no new UI-facing APIs that expose Core/storage-only types
+### Phase 0 — spike + characterization (in flight)
 
-### Phase 1 — define runtime contracts
+Spike: rewrite one slice (`SessionListService`) end-to-end in the
+proposed shape inside the existing target structure (no new targets).
+Validates:
 
-- Inventory current logic in:
-  - `ChatViewModel`
-  - `SessionManagerViewModel`
-  - `ModelManagementViewModel`
-  - `SessionController`
-  - model load/generation coordinators
-- Separate each path into:
-  - runtime orchestration
-  - persistence adapter work
-  - presentation-only state
-- Land the new contracts additively before moving behavior.
+- Sync-port-via-async-use-case actually works.
+- Event-stream pattern covers the surface cleanly.
+- Adapter LOC delta is meaningfully smaller than today.
+- Title generation can be migrated without special handling.
 
-### Phase 2 — create `BaseChatRuntime`
+Characterization coverage written alongside the spike:
 
-- Add the new target.
-- Move or re-home runtime-owned protocols into it.
-- Introduce runtime-facing endpoint/settings abstractions where UI still depends
-  on storage-shaped models.
-- Keep compatibility shims in `BaseChatCore`.
+- session CRUD, ordering, pagination
+- message paging and search/snippet semantics
+- model/endpoint selection restoration
+- first-message auto-rename
+- transcript send/cancel/regenerate
+- tool-call approval flow
 
-### Phase 3 — peel orchestration out of UI view models
+Repo guardrails added in the same PR cycle:
 
-- Extract transcript/session/send-cancel-regenerate/model-selection logic into
-  runtime services.
-- Extract session list CRUD/search/pagination/title generation into runtime.
-- Extract model discovery/search/download orchestration into runtime.
+- CI lint: no new `SwiftData` import in `BaseChatUI*`.
+- CI lint: no new `@Query` / `.modelContext` usage in UI targets.
+- CI lint: no new public API exposing `ModelContext` or `@Model` types.
 
-Deliverable: `BaseChatUI` and `BaseChatUIModelManagement` become thin adapters
-over runtime services instead of owning application logic.
+**Exit criterion**: spike PR demonstrates the pattern works. If the spike
+finds a blocker (event surface explodes, adapter not meaningfully thinner,
+title generation unmigratable) → revisit the plan. **No code moves to a
+new target until this gate passes.**
 
-### Phase 4 — create `BaseChatPersistenceSwiftData`
+### Phase 1 — orchestration extracted, targets unchanged
 
-- Move SwiftData assets out of `BaseChatCore`:
-  - persistence providers
-  - schema/model types
-  - migrations
-  - container/bootstrap helpers
-  - endpoint/preset/benchmark persistence adapters
-- Keep endpoint metadata separate from secret references.
-- Preserve stable Keychain identifier mapping throughout the move.
+Inside the existing target structure, extract every use case as a plain
+async/event class. Each PR moves one use case + its ports + its tests.
 
-### Phase 5 — remove direct SwiftData usage from UI packages
+Order — smallest blast radius first:
 
-- Replace direct `@Query`, `ModelContext`, and mutation of SwiftData models in:
-  - `BaseChatUI`
-  - `BaseChatUIModelManagement`
-- Route endpoints, presets, and benchmark persistence through runtime and
-  persistence ports.
+1. `SessionListService` (the spike, productionised)
+2. `SamplerPresetStore` + adapter (kills the `@Query` leak)
+3. `BenchmarkCache` + adapter (kills `modelContext` public surface)
+4. `ModelManagementService` (absorbs `ModelManagementViewModel`)
+5. `ConversationRuntime` (absorbs `ChatViewModel`'s orchestration; the
+   biggest PR — closure-bag → events transformation)
+6. `EndpointStore` + adapter (kills SwiftData imports in endpoint editor)
 
-### Phase 6 — migrate host apps
+Each PR keeps the public API of the corresponding view model
+source-compatible. UI adapters wrap the new use cases. Persistence stays
+in `BaseChatCore` for now.
 
-- Migrate the **BaseChatKit demo app** first using the stock composition path.
-- Validate **ChatbotUI-iOS** as the "mostly stock BCK, custom shell" consumer.
-- Validate **Fireside** as the "custom domain/runtime, BCK as subsystem"
-  consumer via context contributors and app-owned stores.
+`ChatPersistenceProvider` becomes `async throws` in the same PR cycle.
+Breaking change announced in the changelog as one entry, not per-method.
 
-### Phase 7 — compatibility cleanup
+**Exit criterion**: no `@Observable` view model owns orchestration
+state. Every state change in UI flows through an event stream.
 
-- Keep `BaseChatCore` as a deprecated facade for one release cycle.
-- Publish a migration guide with three recipes:
-  - stock UI app
-  - custom shell app
-  - runtime-only / domain-owned integration
-- Remove the facade only after parity and downstream adoption are proven.
+### Phase 2 — physical target split
 
-## Review feedback folded into this plan
+One PR — large, mostly mechanical. Creates `BaseChatRuntime` and
+`BaseChatPersistenceSwiftData` targets, redistributes
+`BaseChatCore`'s contents, deletes `BaseChatCore`. Updates host apps
+(demo, ChatbotUI-iOS, Fireside) in the same PR.
 
-### Architect
+Mechanical because Phase 1 has already done the architectural work —
+this PR is just `git mv`, import rewrites, and CI lint updates.
 
-- The refactor only counts if UI stops knowing SwiftData exists.
-- Do not turn `BaseChatRuntime` into a new junk drawer.
-- Remove storage-shaped endpoint/settings leakage early.
+CI lint additions:
 
-### DevEx
+- No `SwiftData` / `@Observable` / SwiftUI import in `BaseChatRuntime`.
+- No `URLSession` / Keychain in `BaseChatRuntime`.
+- `BaseChatUI` does not import `BaseChatPersistenceSwiftData`.
 
-- Keep the rollout additive.
-- Preserve a one-snippet quick start via a stock composition API/container.
-- Use `BaseChatCore` as a temporary compatibility umbrella rather than a hard cut.
+SwiftData entity-name migration: `@Model` types stay nested inside
+`BaseChatSchemaV3` enum, so SwiftData entity names (`ChatMessage`,
+`ChatSession`, etc.) are unaffected by the module move. A read-back test
+opens a v0.13.x-era store fixture and asserts data integrity.
 
-### QA
-
-- "It compiles" is not a sufficient success signal.
-- Add contract tests for each new runtime port and SwiftData adapter.
-- Use differential tests to compare old and new behavior during the migration.
-- Gate completion on demo app and downstream consumer smoke coverage.
-
-### Security
-
-- Keep raw secrets, Keychain APIs, `URLSession`, trust delegates, and remote
-  execution/network policy out of runtime.
-- Treat context injection as a trust boundary.
-- Preserve endpoint metadata vs secret separation through the migration.
-
-### Apple / Swift / AI platform review
-
-- Keep runtime SwiftUI-free and Observation-free.
-- Prefer async/evented APIs with thin `@Observable` presentation adapters.
-- Avoid hidden singletons; scope runtime to app or scene composition.
+**Exit criterion**: package graph matches the target diagram.
+`BaseChatCore` no longer exists in `Package.swift`.
 
 ## Acceptance criteria
 
-Before calling the refactor done:
+Before tagging 1.0:
 
-- Existing CI-safe suites still pass.
-- New runtime contract suites pass for fakes and SwiftData adapters.
-- Differential behavior checks pass across old vs new chat/session wiring.
-- Demo app smoke coverage passes.
-- ChatbotUI-iOS builds and passes agreed smoke flows without local patching.
-- Fireside proves story/memory/profile context injection via runtime ports.
-- Legacy persisted data opens without loss of sessions, messages, search
-  behavior, settings, or pinned-message semantics.
-- No meaningful regression in large-history pagination or search behavior.
+- All CI-safe suites pass.
+- Demo app passes its smoke coverage.
+- ChatbotUI-iOS builds against the new graph without local patching.
+- Fireside replaces its custom bootstrap with `BaseChatRuntime` +
+  custom `MessageStore`/`SessionStore` impls.
+- Read-back test confirms a pre-refactor SwiftData store opens cleanly
+  with no data loss.
+- No `@Observable` view model owns orchestration state.
+- No public runtime API exposes `ModelContext` or `@Model` types.
 
 ## Hard no-gos
 
 - No `SwiftData` or `ModelContext` in `BaseChatRuntime`.
 - No SwiftUI or `@Observable` in `BaseChatRuntime`.
-- No public runtime APIs that expose raw secret material.
-- No permanent dual path where UI uses both runtime ports and direct SwiftData.
-- No migration that relies on widening public API just to keep the refactor
-  moving.
+- No `URLSession` or Keychain in `BaseChatRuntime` (live in Inference
+  or backend adapters where they already are).
+- No public runtime APIs exposing raw secret material.
+- No closure-bag wiring across the runtime/UI boundary. Events out,
+  commands in, full stop.
+- No "while we're here" schema redesign.
 
-## Why this is worth doing
+## Risks & mitigations
 
-If this refactor succeeds:
+| Risk | Mitigation |
+|------|------------|
+| Closure-bag → event transformation explodes the event surface (~50 callbacks today) | Spike (Phase 0) measures this on the session-list slice before committing. Fail-fast gate. |
+| `ChatPersistenceProvider` going async breaks Fireside's existing custom impl | Coordinated with Fireside in same PR. Pre-1.0 = breakage is the rule, not the exception. |
+| SwiftData entity-name drift after module move | Entity names are simple class names, unaffected by module rename. Read-back test against pre-refactor fixture confirms. |
+| `InferenceService` already overlaps with the proposed runtime | Runtime is a thin layer *over* `InferenceService` + ports. Use cases compose existing services; they don't absorb them. |
+| Phase 1 PR sizes balloon (especially `ConversationRuntime`) | Per-use-case PRs with explicit LOC budget; if `ConversationRuntime` > 1500 LOC moved in one PR, split by sub-flow (send vs. regenerate vs. edit). |
 
-- the **demo app** remains the reference implementation
-- **ChatbotUI-iOS** gets a cleaner customization surface without forking BCK
-- **Fireside** can use BCK runtime/inference as a subsystem without inheriting
-  BCK's UI and persistence assumptions
+## Why this is worth doing now
 
-That is the architectural payoff: one runtime center, multiple host shapes,
-and less pressure to push app logic into UI modules just because those modules
-currently own the composition story.
+Pre-1.0 is the only window where this refactor is cheap. After 1.0:
+
+- `ChatPersistenceProvider`'s sync signature is locked.
+- `ModelManagementViewModel.modelContext` public surface is locked.
+- `BaseChatCore` as a target is locked.
+- Each future host integration calcifies the current shape.
+
+The codebase has evolved over 500 PRs and the shape has been trending
+toward this design through repeated decompositions (`InferenceService`
+split, `ChatViewModel` extractions, `BaseChatUIModelManagement` peel,
+storage-neutral records hoisted into Inference, `ChatPersistenceProvider`
+port). This refactor is the formalisation and completion of work
+already underway.
+
+If it succeeds:
+
+- **demo app** remains the reference implementation.
+- **ChatbotUI-iOS** gets a cleaner customization surface without forking BCK.
+- **Fireside** uses BCK runtime/inference as a subsystem without inheriting
+  BCK's UI and persistence assumptions.
+
+One runtime center, multiple host shapes, and no further pressure to
+push app logic into UI modules just because those modules currently
+own the composition story.

--- a/docs/plans/runtime-ports-refactor.md
+++ b/docs/plans/runtime-ports-refactor.md
@@ -195,16 +195,33 @@ infrastructure can't lag.
 
 Three phases, all pre-1.0, no deprecation tail.
 
-### Phase 0 — spike + characterization (in flight)
+### Phase 0 — spike + characterization (PR #878 — complete)
 
-Spike: rewrite one slice (`SessionListService`) end-to-end in the
-proposed shape inside the existing target structure (no new targets).
-Validates:
+Spike rewrote the session-list slice in the proposed shape. Findings:
 
-- Sync-port-via-async-use-case actually works.
-- Event-stream pattern covers the surface cleanly.
-- Adapter LOC delta is meaningfully smaller than today.
-- Title generation can be migrated without special handling.
+- **Observation flows validated.** Event consumption pattern works:
+  adapter `Task` consumes `AsyncStream<SessionListEvent>`, 7 event cases
+  cover the surface, no command-response pairs needed. Title generation
+  migrated cleanly via `.titleGenerated`. Search and pagination clean.
+- **Mutation flows NOT validated.** To keep the public `createSession` /
+  `deleteSession` / `renameSession` API source-compatible, the adapter
+  bypassed the service entirely on writes — calling persistence directly
+  and reloading eagerly. The service's mutation commands are dead code
+  in the spike. The closure-bag → events transformation is therefore
+  unproven for write paths until the public command surface becomes
+  `async throws`.
+- **LOC delta: +72%** (375 → 316 adapter + 329 service). Much of the
+  +270 is the dual-write redundancy (eager reload in adapter +
+  `.sessionsLoaded` from service). Going async-first kills the
+  redundancy.
+- **`InferenceService` main-actor coupling unaddressed.** Title
+  generation stays on main; the `async` surface is currently cosmetic.
+  Plan must specify the interaction model (per-call hop vs. nonisolated
+  wrappers) before `ConversationRuntime` extraction.
+- **Service ownership smell.** Spike used `nonisolated(unsafe) var
+  _persistence` because the type was marked `Sendable` with mutable
+  refs. Real implementation must pass persistence at init or be an
+  actor — don't propagate `nonisolated(unsafe)` across the runtime.
 
 Characterization coverage written alongside the spike:
 
@@ -221,32 +238,44 @@ Repo guardrails added in the same PR cycle:
 - CI lint: no new `@Query` / `.modelContext` usage in UI targets.
 - CI lint: no new public API exposing `ModelContext` or `@Model` types.
 
-**Exit criterion**: spike PR demonstrates the pattern works. If the spike
-finds a blocker (event surface explodes, adapter not meaningfully thinner,
-title generation unmigratable) → revisit the plan. **No code moves to a
-new target until this gate passes.**
+**Gate status**: passed with caveats. Direction confirmed; Phase 1 must
+treat async-command APIs and service ownership discipline as
+non-negotiable rather than open questions.
 
 ### Phase 1 — orchestration extracted, targets unchanged
 
 Inside the existing target structure, extract every use case as a plain
 async/event class. Each PR moves one use case + its ports + its tests.
 
-Order — smallest blast radius first:
+**Phase 1.0 — async migration (must come first).** One PR makes
+`ChatPersistenceProvider` `async throws` and changes the existing
+`SessionManagerViewModel` / `ChatViewModel` public command APIs to
+`async throws`. No new use cases yet. This unblocks every subsequent
+extraction and kills the dual-write seam the spike surfaced. Source-
+breaking; pre-1.0 means it ships as one breaking changelog entry.
 
-1. `SessionListService` (the spike, productionised)
-2. `SamplerPresetStore` + adapter (kills the `@Query` leak)
-3. `BenchmarkCache` + adapter (kills `modelContext` public surface)
-4. `ModelManagementService` (absorbs `ModelManagementViewModel`)
-5. `ConversationRuntime` (absorbs `ChatViewModel`'s orchestration; the
-   biggest PR — closure-bag → events transformation)
-6. `EndpointStore` + adapter (kills SwiftData imports in endpoint editor)
+**Phase 1.1 — productionise the spike.** Re-do the session-list
+extraction now that commands are `async throws`. Adapter goes through
+`service.createSession(...)` instead of bypassing it. Service stops
+needing `nonisolated(unsafe)` — persistence passes at init. Validates
+the mutation-flow side of the closure-bag → events transformation
+(which the spike did not).
 
-Each PR keeps the public API of the corresponding view model
-source-compatible. UI adapters wrap the new use cases. Persistence stays
-in `BaseChatCore` for now.
+**Phase 1.2 onward — remaining use cases**, smallest blast radius first:
 
-`ChatPersistenceProvider` becomes `async throws` in the same PR cycle.
-Breaking change announced in the changelog as one entry, not per-method.
+1. `SamplerPresetStore` + adapter (kills the `@Query` leak)
+2. `BenchmarkCache` + adapter (kills `modelContext` public surface)
+3. `ModelManagementService` (absorbs `ModelManagementViewModel`)
+4. `EndpointStore` + adapter (kills SwiftData imports in endpoint editor)
+5. **`InferenceService` interaction prep** — add nonisolated wrappers
+   (or actor-isolated equivalents) for the operations runtime services
+   call from off-main contexts. Specifically: `enqueue`, `tokenizer`
+   access, `capabilities` reads. Keeps `InferenceService` `@MainActor`
+   for view-binding but lets runtime services compose it without a
+   per-call hop.
+6. `ConversationRuntime` (absorbs `ChatViewModel`'s orchestration —
+   the biggest PR; closure-bag → events transformation; LOC budget
+   ~4,500–5,000 vs. 3,621 today). Item 5 is its prerequisite.
 
 **Exit criterion**: no `@Observable` view model owns orchestration
 state. Every state change in UI flows through an event stream.

--- a/docs/plans/runtime-ports-refactor.md
+++ b/docs/plans/runtime-ports-refactor.md
@@ -1,0 +1,298 @@
+# Plan — `BaseChatRuntime` / ports refactor
+
+This is a **plan document**, not implementation. It records the intended shape,
+migration order, and review constraints before code lands so reviewers can
+argue with the architecture instead of reverse-engineering it from the diff.
+
+## Status
+
+- Branch: `docs/runtime-ports-proposal`
+- Scope: architecture and migration plan only
+- Downstream consumers in view:
+  - BaseChatKit demo app
+  - ChatbotUI-iOS
+  - Fireside
+
+## Problem
+
+BaseChatKit already has a strong inference boundary:
+
+- `BaseChatInference` is storage-free and backend-agnostic.
+- `BaseChatBackends` and `BaseChatMCP` depend on inference directly.
+- `ChatPersistenceProvider` already decouples chat/session persistence from
+  SwiftData for the main transcript flows.
+
+But the app/runtime boundary is still mixed across `BaseChatCore`,
+`BaseChatUI`, and `BaseChatUIModelManagement`:
+
+- some UI flows still know about SwiftData directly
+- app orchestration still lives in UI-owned view models
+- model management still exposes `ModelContext` for benchmark persistence
+- endpoint/settings flows still leak Core-era storage assumptions into
+  UI-facing APIs
+
+That shape is workable for the stock demo app, but it makes two other host
+styles harder than they should be:
+
+1. **ChatbotUI-iOS** wants mostly stock BCK behavior with a custom shell.
+2. **Fireside** wants to use BCK as a subsystem inside a story/memory runtime,
+   not adopt BCK's UI and persistence assumptions wholesale.
+
+## What we are building
+
+A new runtime-centered package split:
+
+```text
+BaseChatInference
+  ^ used by BaseChatBackends, BaseChatMCP, BaseChatRuntime
+
+BaseChatRuntime
+  depends on BaseChatInference
+  owns application use cases + ports only
+
+BaseChatPersistenceSwiftData
+  depends on BaseChatRuntime
+  owns SwiftData schema, migrations, adapters, container/bootstrap helpers
+
+BaseChatUI
+  depends on BaseChatRuntime
+  owns SwiftUI views and thin presentation adapters
+
+BaseChatUIModelManagement
+  depends on BaseChatUI + BaseChatRuntime
+  owns optional model-management UI only
+
+BaseChatCore
+  temporary compatibility facade for one release cycle, then removed
+```
+
+The center of gravity moves from:
+
+```text
+ChatViewModel + SessionManagerViewModel + ModelContext-aware UI
+```
+
+to:
+
+```text
+BaseChatRuntime services + ports
+```
+
+with UI acting as a presentation layer rather than the application layer.
+
+## Non-goals
+
+- No SwiftData schema redesign unless the refactor forces a narrowly-scoped one.
+- No expansion of `ChatViewModel` or `InferenceService` public API as a shortcut.
+- No giant "misc runtime" bucket that simply replaces the current `BaseChatCore`
+  overload with a new overload.
+- No permanent direct `SwiftData`, `@Query`, or `ModelContext` usage in
+  `BaseChatUI*` once the migration is complete.
+
+## Design principles
+
+| # | Principle | Why |
+|---|-----------|-----|
+| 1 | **Runtime owns use cases, not view state.** | Transcript/session/model orchestration should be reusable by the demo app, ChatbotUI-iOS, and Fireside. Focus state, scroll affordances, sheets, and draft text are UI concerns. |
+| 2 | **SwiftData stays behind adapters.** | `BaseChatRuntime` must not expose `ModelContext`, `@Model` types, `@Query`, or migration internals. |
+| 3 | **Prefer existing record/value types.** | `ChatSessionRecord`, `ChatMessageRecord`, and `APIEndpointRecord` already express the right direction: storage-neutral data at the boundary. |
+| 4 | **Additive migration first.** | The fastest way to break consumers is a big rename/delete wave. Land runtime and adapter surfaces first, then move call sites. |
+| 5 | **Secrets and network policy stay out of runtime.** | Keychain, `URLSession`, trust policy, OAuth, and remote process/network configuration belong in adapters. |
+| 6 | **Context injection is a first-class port.** | Fireside needs a structured way to supply story, memory, and profile context without forking the chat runtime. |
+
+## Proposed runtime surface
+
+### Ports
+
+- `SessionStore`
+- `MessageStore` / `ConversationStore`
+- `EndpointStore`
+- `SamplerPresetStore`
+- `ModelCatalog`
+- `ModelDownloadCoordinator`
+- `BenchmarkCache`
+- `TitleGenerator`
+- `GenerationContextProvider` / `PromptContextContributor`
+
+### Use cases
+
+- `ConversationRuntime`
+- `SessionListService`
+- `ModelManagementService`
+- `PromptContextPipeline`
+
+### Constraints
+
+- `BaseChatRuntime` stays SwiftUI-free and Observation-free.
+- Prefer `async/await`, `AsyncSequence`, and typed events over nested
+  observable state.
+- Runtime instances should be scene/window scoped, not hidden singletons.
+
+## Current coupling hotspots to remove early
+
+1. **UI-owned orchestration**
+   - `ChatViewModel`
+   - `SessionManagerViewModel`
+   - `ModelManagementViewModel`
+
+2. **SwiftData leakage in UI/model-management flows**
+   - direct `@Query`
+   - direct `ModelContext`
+   - benchmark cache persistence via `ModelManagementViewModel.modelContext`
+
+3. **Core/storage-shaped types leaking into UI/runtime APIs**
+   - endpoint/settings flows that still assume SwiftData-backed Core models
+
+These are the first seams to attack because they determine whether the runtime
+is genuinely reusable or just a renamed copy of today's stack.
+
+## Migration phases
+
+### Phase 0 — freeze behavior and add guardrails
+
+- Write characterization coverage for:
+  - session CRUD, ordering, pagination
+  - message paging and search/snippet semantics
+  - model/endpoint selection restoration
+  - first-message auto-rename behavior
+- Add repo guardrails:
+  - no new `SwiftData` imports in `BaseChatUI*`
+  - no new `@Query` / `.modelContext` usage in UI targets
+  - no new UI-facing APIs that expose Core/storage-only types
+
+### Phase 1 — define runtime contracts
+
+- Inventory current logic in:
+  - `ChatViewModel`
+  - `SessionManagerViewModel`
+  - `ModelManagementViewModel`
+  - `SessionController`
+  - model load/generation coordinators
+- Separate each path into:
+  - runtime orchestration
+  - persistence adapter work
+  - presentation-only state
+- Land the new contracts additively before moving behavior.
+
+### Phase 2 — create `BaseChatRuntime`
+
+- Add the new target.
+- Move or re-home runtime-owned protocols into it.
+- Introduce runtime-facing endpoint/settings abstractions where UI still depends
+  on storage-shaped models.
+- Keep compatibility shims in `BaseChatCore`.
+
+### Phase 3 — peel orchestration out of UI view models
+
+- Extract transcript/session/send-cancel-regenerate/model-selection logic into
+  runtime services.
+- Extract session list CRUD/search/pagination/title generation into runtime.
+- Extract model discovery/search/download orchestration into runtime.
+
+Deliverable: `BaseChatUI` and `BaseChatUIModelManagement` become thin adapters
+over runtime services instead of owning application logic.
+
+### Phase 4 — create `BaseChatPersistenceSwiftData`
+
+- Move SwiftData assets out of `BaseChatCore`:
+  - persistence providers
+  - schema/model types
+  - migrations
+  - container/bootstrap helpers
+  - endpoint/preset/benchmark persistence adapters
+- Keep endpoint metadata separate from secret references.
+- Preserve stable Keychain identifier mapping throughout the move.
+
+### Phase 5 — remove direct SwiftData usage from UI packages
+
+- Replace direct `@Query`, `ModelContext`, and mutation of SwiftData models in:
+  - `BaseChatUI`
+  - `BaseChatUIModelManagement`
+- Route endpoints, presets, and benchmark persistence through runtime and
+  persistence ports.
+
+### Phase 6 — migrate host apps
+
+- Migrate the **BaseChatKit demo app** first using the stock composition path.
+- Validate **ChatbotUI-iOS** as the "mostly stock BCK, custom shell" consumer.
+- Validate **Fireside** as the "custom domain/runtime, BCK as subsystem"
+  consumer via context contributors and app-owned stores.
+
+### Phase 7 — compatibility cleanup
+
+- Keep `BaseChatCore` as a deprecated facade for one release cycle.
+- Publish a migration guide with three recipes:
+  - stock UI app
+  - custom shell app
+  - runtime-only / domain-owned integration
+- Remove the facade only after parity and downstream adoption are proven.
+
+## Review feedback folded into this plan
+
+### Architect
+
+- The refactor only counts if UI stops knowing SwiftData exists.
+- Do not turn `BaseChatRuntime` into a new junk drawer.
+- Remove storage-shaped endpoint/settings leakage early.
+
+### DevEx
+
+- Keep the rollout additive.
+- Preserve a one-snippet quick start via a stock composition API/container.
+- Use `BaseChatCore` as a temporary compatibility umbrella rather than a hard cut.
+
+### QA
+
+- "It compiles" is not a sufficient success signal.
+- Add contract tests for each new runtime port and SwiftData adapter.
+- Use differential tests to compare old and new behavior during the migration.
+- Gate completion on demo app and downstream consumer smoke coverage.
+
+### Security
+
+- Keep raw secrets, Keychain APIs, `URLSession`, trust delegates, and remote
+  execution/network policy out of runtime.
+- Treat context injection as a trust boundary.
+- Preserve endpoint metadata vs secret separation through the migration.
+
+### Apple / Swift / AI platform review
+
+- Keep runtime SwiftUI-free and Observation-free.
+- Prefer async/evented APIs with thin `@Observable` presentation adapters.
+- Avoid hidden singletons; scope runtime to app or scene composition.
+
+## Acceptance criteria
+
+Before calling the refactor done:
+
+- Existing CI-safe suites still pass.
+- New runtime contract suites pass for fakes and SwiftData adapters.
+- Differential behavior checks pass across old vs new chat/session wiring.
+- Demo app smoke coverage passes.
+- ChatbotUI-iOS builds and passes agreed smoke flows without local patching.
+- Fireside proves story/memory/profile context injection via runtime ports.
+- Legacy persisted data opens without loss of sessions, messages, search
+  behavior, settings, or pinned-message semantics.
+- No meaningful regression in large-history pagination or search behavior.
+
+## Hard no-gos
+
+- No `SwiftData` or `ModelContext` in `BaseChatRuntime`.
+- No SwiftUI or `@Observable` in `BaseChatRuntime`.
+- No public runtime APIs that expose raw secret material.
+- No permanent dual path where UI uses both runtime ports and direct SwiftData.
+- No migration that relies on widening public API just to keep the refactor
+  moving.
+
+## Why this is worth doing
+
+If this refactor succeeds:
+
+- the **demo app** remains the reference implementation
+- **ChatbotUI-iOS** gets a cleaner customization surface without forking BCK
+- **Fireside** can use BCK runtime/inference as a subsystem without inheriting
+  BCK's UI and persistence assumptions
+
+That is the architectural payoff: one runtime center, multiple host shapes,
+and less pressure to push app logic into UI modules just because those modules
+currently own the composition story.

--- a/docs/plans/runtime-ports-refactor.md
+++ b/docs/plans/runtime-ports-refactor.md
@@ -174,6 +174,38 @@ rather than the application layer.
 The combined provider was a v0.x convenience; per-port boundaries make
 selective implementation by hosts (Fireside) cheaper.
 
+#### `MessageStore` post-write hooks
+
+`MessageStore` exposes a hook protocol so cross-cutting persistence
+concerns (graph extraction, indexing, audit) can attach without
+subclassing the store or wrapping it in a delegating impl. Hooks fire
+after the write commits, in registration order.
+
+```swift
+public protocol MessageStorePostWriteHook: Sendable {
+    func messageDidWrite(
+        _ record: ChatMessageRecord,
+        in sessionID: ChatSessionRecord.ID
+    ) async
+}
+
+public protocol MessageStore: Sendable {
+    // CRUD + search methods (async throws) elided …
+    func addPostWriteHook(_ hook: any MessageStorePostWriteHook)
+}
+```
+
+Hooks must not throw — a failing hook cannot roll back a committed
+write. Hook errors are logged via `Log.persistence.error` and otherwise
+swallowed; surfaces that need transactional guarantees compose at the
+use-case layer (`ConversationRuntime`) instead. Fireside's
+`GraphExtractionService` registers as a post-write hook at bootstrap
+time; no `MessageStore` subclass needed.
+
+A symmetric `SessionStorePostWriteHook` is provided for completeness;
+no internal consumer uses it yet, so its shape is provisional until a
+host actually exercises it.
+
 ### Use cases
 
 | Use case | Absorbs | Surface |
@@ -182,6 +214,42 @@ selective implementation by hosts (Fireside) cheaper.
 | `SessionListService` | `SessionManagerViewModel`'s CRUD/search/pagination/title generation | `AsyncSequence<SessionListEvent>` + commands |
 | `ModelManagementService` | `ModelManagementViewModel`'s discovery/download/delete/benchmark | `AsyncSequence<ModelCatalogEvent>` + commands |
 | `PromptContextPipeline` | new — composes `GenerationContextProvider` contributions | `[ContextContribution]` |
+
+#### `ConversationEvent` cases
+
+The closure-bag → events transformation only works if the event surface
+is enumerated up front. The starter set below is the contract Phase 1.2
+must ship; cases may be added during `ConversationRuntime` extraction
+but cannot be removed or renamed without a coordinated breaking-change
+cycle with downstream consumers (Fireside).
+
+```swift
+public enum ConversationEvent: Sendable {
+    // Lifecycle
+    case messageInserted(ChatMessageRecord)
+    case streamStarted(messageID: ChatMessageRecord.ID)
+    case tokenEmitted(messageID: ChatMessageRecord.ID, delta: String)
+    case streamFinished(messageID: ChatMessageRecord.ID, reason: FinishReason)
+    case errorRaised(ConversationError)
+
+    // Context pipeline (Fireside hook points)
+    case beforeContextAssembly(prompt: String, request: PromptContextRequest)
+    case contextAssembled(contributions: [ContextContribution])
+    case afterGeneration(messageID: ChatMessageRecord.ID, finalText: String)
+    case compressionTriggered(removed: [ChatMessageRecord.ID], reason: CompressionReason)
+
+    // Tool calls
+    case toolCallRequested(ToolCall)
+    case toolCallApproved(ToolCall.ID)
+    case toolCallCompleted(ToolCall.ID, ToolResult)
+}
+```
+
+`.beforeContextAssembly`, `.afterGeneration`, and `.compressionTriggered`
+are the integration points Fireside's story/memory pipeline composes
+against. They are load-bearing — removing or renaming any of them is a
+coordinated change with Fireside, not a unilateral rename. The other
+cases are BCK-internal and can evolve more freely.
 
 ### Constraints
 
@@ -340,6 +408,17 @@ Before tagging 1.0:
 - ChatbotUI-iOS builds against the new graph without local patching.
 - Fireside replaces its custom bootstrap with `BaseChatRuntime` +
   custom `MessageStore`/`SessionStore` impls.
+- `GenerationContextProvider` port shape and `ContextContribution` value
+  type are locked at the end of Phase 1.2 and treated as a stable
+  contract for the remainder of the pre-1.0 window. Fireside's
+  `GraphSlotFormatter` outputs become formal `ContextContribution`
+  values without retrofitting. Any change to the `ContextContribution`
+  type after Phase 1.2 ships requires a coordinated PR pair across BCK
+  and Fireside, not a unilateral edit.
+- `MessageStorePostWriteHook` and the load-bearing `ConversationEvent`
+  cases (`.beforeContextAssembly`, `.contextAssembled`,
+  `.afterGeneration`, `.compressionTriggered`) ship in Phase 1.2 and
+  are similarly locked.
 - Read-back test confirms a pre-refactor SwiftData store opens cleanly
   with no data loss.
 - No `@Observable` view model owns orchestration state.
@@ -365,6 +444,61 @@ Before tagging 1.0:
 | SwiftData entity-name drift after module move | Entity names are simple class names, unaffected by module rename. Read-back test against pre-refactor fixture confirms. |
 | `InferenceService` already overlaps with the proposed runtime | Runtime is a thin layer *over* `InferenceService` + ports. Use cases compose existing services; they don't absorb them. |
 | Phase 1 PR sizes balloon (especially `ConversationRuntime`) | Per-use-case PRs with explicit LOC budget; if `ConversationRuntime` > 1500 LOC moved in one PR, split by sub-flow (send vs. regenerate vs. edit). |
+| BCK and Fireside invent parallel abstractions for the same problem | Fireside-migration checklist appendix below pins what changes in each repo per phase. Port-shape PRs require Fireside review before merge. |
+
+## Appendix — Fireside migration checklist
+
+Explicit coordination contract with Fireside (which has its own
+`docs/architecture/runtime-decoupling-migration.md` RFC pushing the same
+direction). This appendix is canonical: if BCK ships a phase that
+requires a Fireside change not listed here, the plan is wrong, not
+Fireside. Conversely, if Fireside lands a change that depends on a port
+shape not pinned here, that PR blocks until the appendix catches up.
+
+### Phase 1.0 — async migration
+
+BCK changes:
+- `ChatPersistenceProvider` methods → `async throws`.
+- Public sync mutators on `ChatViewModel` / `SessionManagerViewModel` → `async throws`.
+
+Fireside changes (same window):
+- Update Fireside's custom `ChatPersistenceProvider` impl signatures to `async throws`.
+- Wrap any sync call sites of the converted view-model mutators in `Task { await … }` or convert the call site to an `async` context.
+- No import rewrites required; `BaseChatCore` is still the import target.
+
+### Phase 1.2 — port extraction
+
+BCK changes:
+- `ChatPersistenceProvider` splits into `SessionStore` + `MessageStore`.
+- `MessageStorePostWriteHook` protocol introduced.
+- `GenerationContextProvider` re-exported from `BaseChatRuntime`; `PromptContextPipeline` use case introduced; `ContextContribution` value type pinned.
+- `ConversationRuntime` ships with the `ConversationEvent` surface enumerated above.
+
+Fireside changes (same window):
+- Replace Fireside's combined provider impl with separate `SessionStore` + `MessageStore` impls.
+- Migrate `GraphExtractionService` from its current attachment mechanism to `MessageStorePostWriteHook` registration at bootstrap.
+- Migrate `GraphSlotFormatter` outputs to formal `ContextContribution` values; register as a `GenerationContextProvider` contributor through `PromptContextPipeline`.
+- Migrate `StoryStore.send(_:)` from closure-callback orchestration to `AsyncSequence<ConversationEvent>` consumption. The four load-bearing cases are `.beforeContextAssembly`, `.contextAssembled`, `.afterGeneration`, `.compressionTriggered`.
+
+### Phase 2 — physical target split
+
+BCK changes:
+- `BaseChatCore` deleted.
+- `BaseChatRuntime` and `BaseChatPersistenceSwiftData` targets created.
+- `BaseChatBootstrap` (renamed) provides the host bootstrap.
+
+Fireside changes (same window):
+- Import rewrites:
+  - `import BaseChatCore` → `import BaseChatRuntime` for orchestration types and ports.
+  - `import BaseChatCore` → `import BaseChatPersistenceSwiftData` only if Fireside still uses the SwiftData persistence impl. If Fireside has fully replaced persistence with custom stores, the dependency on `BaseChatPersistenceSwiftData` can be dropped entirely.
+- Replace Fireside's custom bootstrap with `BaseChatBootstrap` configured with custom `MessageStore` / `SessionStore` instances.
+- Drop any inherited `@Model` type imports — they are no longer reachable through the public surface.
+
+### Coordination protocol
+
+- Each BCK PR in Phases 1.0–1.2 names the Fireside PR that consumes it (and vice versa). Both PRs land in the same review window; merging the BCK PR before the matching Fireside PR is ready breaks Fireside's `main`.
+- Port-shape changes (signatures, event cases, hook protocols, `ContextContribution` shape) require a Fireside reviewer on the BCK PR before merge.
+- The four load-bearing `ConversationEvent` cases and `MessageStorePostWriteHook` are pinned to this appendix. Any deviation is updated here in the same PR that introduces the deviation — the plan is the source of truth, not Slack threads.
 
 ## Why this is worth doing now
 

--- a/docs/plans/runtime-ports-refactor.md
+++ b/docs/plans/runtime-ports-refactor.md
@@ -4,6 +4,33 @@ This is a **plan document**, not implementation. It records the intended shape,
 migration order, and review constraints before code lands so reviewers can
 argue with the architecture instead of reverse-engineering it from the diff.
 
+## Picking this up in a new session
+
+Live artifacts in priority order:
+
+- **This document** — PR #876, branch `docs/runtime-ports-proposal`. The
+  plan. Read top to bottom.
+- **PR #878**, branch `spike/session-list-runtime-pattern` — the Phase 0
+  spike. Validated observation flows (event consumption, search, title
+  generation); bypassed the service for sync writes to keep API
+  source-compatible (mutation flows therefore unproven until Phase 1.0
+  lands). Findings folded into Phase 0 below.
+- No other in-flight branches for this refactor. **v0.13.2** is the
+  baseline (current `main`).
+- Repo: `roryford/BaseChatKit` (private). If picking up outside the
+  working tree: `gh repo clone roryford/BaseChatKit && gh pr checkout 876`.
+
+**Next concrete action: open Phase 1.0 as a PR.** Make
+`ChatPersistenceProvider` `async throws` and convert
+`SessionManagerViewModel` / `ChatViewModel` public command APIs to
+`async throws`. No new use cases. Single-purpose breaking change.
+Unblocks every subsequent extraction. Pre-1.0 means it ships as one
+breaking changelog entry; downstream consumers (Fireside) are
+coordinated via PR description.
+
+After Phase 1.0 lands: productionise the spike (Phase 1.1), then ports
+in the order listed under Phase 1.2.
+
 ## Status
 
 - Branch: `docs/runtime-ports-proposal`


### PR DESCRIPTION
## Summary
- add an in-repo architecture plan for the proposed `BaseChatRuntime` / ports refactor
- describe the target package graph, migration phases, and explicit non-goals
- fold architect, DevEx, QA, security, and Apple-platform review guidance into one proposal

## Why
This gives the runtime-centered refactor a reviewable design document before code moves across `BaseChatCore`, `BaseChatUI`, and `BaseChatUIModelManagement`. It also frames the migration around the three host shapes we care about: the BaseChatKit demo app, ChatbotUI-iOS, and Fireside.

## Notes
- docs-only change
- plan, not implementation