### PR TITLE
chore: spike session-list runtime + adapter pattern (do not merge)

### DIFF
--- a/Sources/BaseChatUI/ViewModels/SessionListService.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionListService.swift
@@ -1,0 +1,329 @@
+import Foundation
+import BaseChatCore
+import BaseChatInference
+
+// MARK: - Event surface
+
+/// Sendable events emitted by ``SessionListService``.
+///
+/// All state transitions surface here rather than being written directly to
+/// observable state — the adapter (``SessionManagerViewModel``) subscribes and
+/// mirrors them into its published properties.
+public enum SessionListEvent: Sendable {
+    case sessionsLoaded([ChatSessionRecord], hasMore: Bool)
+    case sessionInserted(ChatSessionRecord)
+    case sessionRenamed(UUID, title: String)
+    case sessionDeleted(UUID)
+    case searchResultsChanged(SearchResults)
+    case titleGenerated(UUID, title: String)
+    case persistenceFailure(any Error)
+}
+
+/// Snapshot of search state emitted in `.searchResultsChanged`.
+public struct SearchResults: Sendable {
+    public let titleMatches: [ChatSessionRecord]
+    public let messageHitsBySession: [UUID: [MessageSearchHit]]
+    public let messageMatchSessions: [ChatSessionRecord]
+
+    public static let empty = SearchResults(
+        titleMatches: [],
+        messageHitsBySession: [:],
+        messageMatchSessions: []
+    )
+}
+
+// MARK: - Service
+
+/// Orchestrates session CRUD and search. Plain class — no `@Observable`,
+/// no `@MainActor` pin on the type itself.
+///
+/// Commands are `@MainActor` because `ChatPersistenceProvider` is `@MainActor`-
+/// isolated and all callers already run on the main actor. The `async` on
+/// public commands is intentional: it signals that commands should be awaited
+/// (rather than fire-and-forget) and preserves the shape the plan describes for
+/// a future `BaseChatRuntime` target where commands *would* hop off main.
+///
+/// SPIKE NOTE (isolation seam): Because `ChatPersistenceProvider` is `@MainActor`
+/// and sync, moving any of these commands truly off-main would require either
+/// (a) making the persistence port async, or (b) wrapping the provider in a
+/// dedicated actor. The current shape validates event emission and adapter
+/// separation without that infrastructure change. See SPIKE FINDINGS in the PR.
+public final class SessionListService: Sendable {
+
+    public let events: AsyncStream<SessionListEvent>
+    private let continuation: AsyncStream<SessionListEvent>.Continuation
+
+    // `nonisolated(unsafe)` because the type is `Sendable` but the value is
+    // only ever written once (in `configure`) and read only from `@MainActor`
+    // contexts. Swift 6 strict concurrency requires the annotation when the
+    // stored property is mutated after init outside a concurrency domain.
+    nonisolated(unsafe) var _persistence: ChatPersistenceProvider?
+    nonisolated(unsafe) var _diagnostics: DiagnosticsService?
+
+    public static let sessionsPageSize: Int = 50
+    public static let messageSearchLimit: Int = 100
+    public static let messageSearchSessionResolveCap: Int = 10_000
+
+    public init() {
+        var cap: AsyncStream<SessionListEvent>.Continuation!
+        events = AsyncStream { cap = $0 }
+        continuation = cap
+    }
+
+    // MARK: - Configuration
+
+    /// Injects the persistence provider. Call once.
+    ///
+    /// Does NOT emit an initial load — the caller is responsible for calling
+    /// `loadInitialPage()` or `reloadSessionsSync()` after wiring up a consumer.
+    @MainActor
+    public func configure(persistence: ChatPersistenceProvider, diagnostics: DiagnosticsService? = nil) {
+        _persistence = persistence
+        _diagnostics = diagnostics
+    }
+
+    // MARK: - Commands
+
+    /// Creates a new session, persists it, and emits `.sessionInserted` then `.sessionsLoaded`.
+    @MainActor
+    @discardableResult
+    public func createSession(title: String = "New Chat") async throws -> ChatSessionRecord {
+        guard let persistence = _persistence else {
+            throw ChatPersistenceError.providerNotConfigured
+        }
+        let record = ChatSessionRecord(title: title)
+        try persistence.insertSession(record)
+        continuation.yield(.sessionInserted(record))
+        reloadSessionsSync()
+        return record
+    }
+
+    /// Deletes a session and emits `.sessionDeleted` then `.sessionsLoaded`.
+    @MainActor
+    public func deleteSession(_ id: UUID) async throws {
+        guard let persistence = _persistence else {
+            throw ChatPersistenceError.providerNotConfigured
+        }
+        try persistence.deleteSession(id)
+        continuation.yield(.sessionDeleted(id))
+        reloadSessionsSync()
+    }
+
+    /// Renames a session and emits `.sessionRenamed` then `.sessionsLoaded`.
+    @MainActor
+    public func renameSession(_ id: UUID, to title: String) async throws {
+        guard let persistence = _persistence else {
+            throw ChatPersistenceError.providerNotConfigured
+        }
+        let all = try persistence.fetchSessions()
+        guard let existing = all.first(where: { $0.id == id }) else {
+            throw ChatPersistenceError.sessionNotFound(id)
+        }
+        var updated = existing
+        updated.title = title
+        updated.updatedAt = Date()
+        try persistence.updateSession(updated)
+        continuation.yield(.sessionRenamed(id, title: title))
+        reloadSessionsSync()
+    }
+
+    /// Reloads page one and emits `.sessionsLoaded`.
+    @MainActor
+    public func loadInitialPage() async {
+        reloadSessionsSync()
+    }
+
+    /// Appends the next page if more are available and emits `.sessionsLoaded`.
+    ///
+    /// Callers pass the current count so the service doesn't need to own a
+    /// separate cursor — the adapter owns loaded count as part of observable state.
+    @MainActor
+    public func loadNextPage(currentCount: Int) async {
+        guard let persistence = _persistence else { return }
+        do {
+            let next = try persistence.fetchSessions(offset: currentCount, limit: Self.sessionsPageSize)
+            let hasMore = next.count == Self.sessionsPageSize
+            continuation.yield(.sessionsLoaded(next, hasMore: hasMore))
+        } catch {
+            Log.persistence.error("Failed to load next sessions page: \(error)")
+            continuation.yield(.persistenceFailure(error))
+        }
+    }
+
+    // MARK: - Search
+
+    /// Filters the provided sessions by title and emits `.searchResultsChanged`.
+    ///
+    /// The adapter passes its own `sessions` array so the service doesn't need
+    /// to re-fetch from persistence for a client-side filter.
+    public func runTitleSearch(_ query: String, against sessions: [ChatSessionRecord]) {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            continuation.yield(.searchResultsChanged(.empty))
+            return
+        }
+        let matches = sessions.filter {
+            $0.title.range(of: trimmed, options: .caseInsensitive) != nil
+        }
+        continuation.yield(.searchResultsChanged(SearchResults(
+            titleMatches: matches,
+            messageHitsBySession: [:],
+            messageMatchSessions: []
+        )))
+    }
+
+    /// Runs a message-scope search via persistence and emits `.searchResultsChanged`.
+    @MainActor
+    public func runMessageSearch(_ query: String) async {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let persistence = _persistence else {
+            continuation.yield(.searchResultsChanged(.empty))
+            return
+        }
+        do {
+            let hits = try persistence.searchMessages(query: trimmed, limit: Self.messageSearchLimit)
+            var grouped: [UUID: [MessageSearchHit]] = [:]
+            grouped.reserveCapacity(hits.count)
+            var orderedSessionIDs: [UUID] = []
+            for hit in hits {
+                if grouped[hit.sessionID] == nil { orderedSessionIDs.append(hit.sessionID) }
+                grouped[hit.sessionID, default: []].append(hit)
+            }
+            let allSessions = try persistence.fetchSessions(offset: 0, limit: Self.messageSearchSessionResolveCap)
+            let byID = Dictionary(uniqueKeysWithValues: allSessions.map { ($0.id, $0) })
+            let matchSessions = orderedSessionIDs.compactMap { byID[$0] }
+            continuation.yield(.searchResultsChanged(SearchResults(
+                titleMatches: [],
+                messageHitsBySession: grouped,
+                messageMatchSessions: matchSessions
+            )))
+        } catch {
+            Log.persistence.error("Message search failed: \(error)")
+            continuation.yield(.searchResultsChanged(.empty))
+            continuation.yield(.persistenceFailure(error))
+        }
+    }
+
+    /// Clears all search state and emits `.searchResultsChanged(.empty)`.
+    public func clearSearch() {
+        continuation.yield(.searchResultsChanged(.empty))
+    }
+
+    // MARK: - Title Generation
+
+    /// Generates an AI title for a session and emits `.titleGenerated` on success.
+    ///
+    /// Emits nothing (but logs) on inference or persistence failure.
+    ///
+    /// SPIKE NOTE: `InferenceService` is `@Observable @MainActor` so `enqueue`
+    /// is also `@MainActor`. The title-generation path doesn't escape main.
+    /// In a real `BaseChatRuntime` target the inference API would need an
+    /// actor-isolated or `Sendable` surface before this path could leave main.
+    @MainActor
+    public func autoRenameSession(
+        _ session: ChatSessionRecord,
+        firstMessage: String,
+        inferenceService: InferenceService
+    ) async {
+        guard session.title == "New Chat" else { return }
+        let title: String?
+        do {
+            title = try await generateTitle(from: firstMessage, using: inferenceService)
+        } catch {
+            Log.ui.warning("Title generation failed for session \(session.id): \(error.localizedDescription)")
+            _diagnostics?.record(.titleGenerationFailed(sessionID: session.id, reason: error.localizedDescription))
+            return
+        }
+        guard let title else { return }
+        guard let persistence = _persistence else { return }
+        var updated = session
+        updated.title = title
+        updated.updatedAt = Date()
+        do {
+            try persistence.updateSession(updated)
+            continuation.yield(.titleGenerated(session.id, title: title))
+            reloadSessionsSync()
+        } catch {
+            Log.persistence.warning("Failed to persist auto-rename for session \(session.id): \(error.localizedDescription)")
+            _diagnostics?.record(.sessionRenamePersistenceFailed(sessionID: session.id, reason: error.localizedDescription))
+        }
+    }
+
+    /// Truncates the first message to 50 chars and uses it as the session title.
+    ///
+    /// Fallback for callers without inference. Only applies when the session is
+    /// still named "New Chat".
+    @MainActor
+    public func autoGenerateTitle(for session: ChatSessionRecord, firstMessage: String) {
+        guard session.title == "New Chat" else { return }
+        let maxLength = 50
+        var title = firstMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty else { return }
+        if title.count > maxLength {
+            let truncated = String(title.prefix(maxLength))
+            if let lastSpace = truncated.lastIndex(of: " ") {
+                title = String(truncated[truncated.startIndex..<lastSpace]) + "..."
+            } else {
+                title = truncated + "..."
+            }
+        }
+        guard let persistence = _persistence else { return }
+        var updated = session
+        updated.title = title
+        updated.updatedAt = Date()
+        do {
+            try persistence.updateSession(updated)
+            continuation.yield(.titleGenerated(session.id, title: title))
+            reloadSessionsSync()
+        } catch {
+            Log.persistence.error("Failed to auto-generate title: \(error)")
+        }
+    }
+
+    // MARK: - Reload helper
+
+    // Safe to call synchronously because `ChatPersistenceProvider` is sync and
+    // `@MainActor`. Every call site is `@MainActor`-isolated.
+    @MainActor
+    func reloadSessionsSync() {
+        guard let persistence = _persistence else { return }
+        do {
+            let page = try persistence.fetchSessions(offset: 0, limit: Self.sessionsPageSize)
+            let hasMore = page.count == Self.sessionsPageSize
+            continuation.yield(.sessionsLoaded(page, hasMore: hasMore))
+        } catch {
+            Log.persistence.error("Failed to reload sessions: \(error)")
+            continuation.yield(.sessionsLoaded([], hasMore: false))
+            continuation.yield(.persistenceFailure(error))
+        }
+    }
+
+    // MARK: - Private title generation
+
+    @MainActor
+    private func generateTitle(
+        from firstMessage: String,
+        using inferenceService: InferenceService
+    ) async throws -> String? {
+        let systemPrompt = "Generate a concise 3-5 word title for a conversation that starts with the following message. Reply with ONLY the title, no punctuation, no quotes."
+        let messages: [(role: String, content: String)] = [
+            (role: "user", content: firstMessage)
+        ]
+        let (_, stream) = try inferenceService.enqueue(
+            messages: messages,
+            systemPrompt: systemPrompt,
+            temperature: 0.3,
+            topP: 0.9,
+            repeatPenalty: 1.0,
+            priority: .background,
+            sessionID: nil
+        )
+        var result = ""
+        for try await event in stream.events {
+            if case .token(let text) = event { result += text }
+        }
+        let trimmed = result.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return trimmed.count > 50 ? String(trimmed.prefix(50)) : trimmed
+    }
+}

--- a/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
@@ -11,29 +11,39 @@ public enum SessionSearchScope: String, CaseIterable, Hashable, Sendable {
     case messages
 }
 
-/// Manages chat session CRUD operations and the session list.
+/// Thin `@Observable` adapter over ``SessionListService``.
+///
+/// Owns only the published mirror of the service's state and a consumer
+/// `Task` that processes ``SessionListEvent`` values into those properties.
+/// All real orchestration lives in ``SessionListService``.
+///
+/// SPIKE NOTE on sync-command seam: The public API for `createSession`,
+/// `deleteSession`, and `renameSession` must be synchronous `throws` to keep
+/// existing call sites source-compatible. The adapter therefore calls persistence
+/// directly (we're already `@MainActor`, same isolation as the sync provider),
+/// emits the corresponding events to keep the service stream consistent, and then
+/// schedules a `loadInitialPage()` via the service so the full session list
+/// reloads. This means the sync commands bypass `SessionListService.createSession`
+/// etc. — the adapter is partially a forwarder and partially a direct caller. In
+/// a real `BaseChatRuntime` extraction the public surface would become `async
+/// throws` and the seam disappears entirely. For now this is the most faithful
+/// spike possible within the source-compat constraint.
 @Observable
 @MainActor
 public final class SessionManagerViewModel {
 
     /// Default page size used when paginating the session list.
-    public static let sessionsPageSize: Int = 50
+    public static let sessionsPageSize: Int = SessionListService.sessionsPageSize
 
     /// Default cap on message search results per query.
-    public static let messageSearchLimit: Int = 100
+    public static let messageSearchLimit: Int = SessionListService.messageSearchLimit
 
     /// Upper bound on sessions resolved when surfacing message-search hits.
-    /// Sessions beyond this count cannot be surfaced as a "matching session"
-    /// row even if their messages match — in practice the cap is well above
-    /// any realistic single-user history.
-    public static let messageSearchSessionResolveCap: Int = 10_000
+    public static let messageSearchSessionResolveCap: Int = SessionListService.messageSearchSessionResolveCap
+
+    // MARK: - Observable state (mirrors service events)
 
     /// All currently loaded sessions, sorted by most recently updated.
-    ///
-    /// Populated incrementally a page at a time. ``loadSessions()`` resets to
-    /// the first page; ``loadNextPage()`` appends the next page. There is no
-    /// path that fetches every session at once — the sidebar is paginated end
-    /// to end so it stays responsive past 1000+ sessions.
     public private(set) var sessions: [ChatSessionRecord] = []
 
     /// `true` when more pages may be available beyond what's loaded.
@@ -51,83 +61,88 @@ public final class SessionManagerViewModel {
     /// before reassigning this — the VM treats every set as authoritative.
     public var searchQuery: String = ""
 
-    /// Message-search hits indexed by session ID. Empty when scope is titles
-    /// or query is empty.
+    /// Message-search hits indexed by session ID.
     public private(set) var messageHitsBySession: [UUID: [MessageSearchHit]] = [:]
 
-    /// Sessions matching the current title-scope query. Empty when scope is
-    /// messages or query is empty.
+    /// Sessions matching the current title-scope query.
     public private(set) var titleMatches: [ChatSessionRecord] = []
 
-    /// Sessions surfaced by the most recent message-scope search, ordered by
-    /// their most recent matching message.
+    /// Sessions surfaced by the most recent message-scope search.
     public private(set) var messageMatchSessions: [ChatSessionRecord] = []
 
-    private(set) var persistence: ChatPersistenceProvider?
+    // MARK: - Passthrough accessors required by existing call sites
 
-    /// Optional diagnostics sink for non-fatal operational failures
-    /// (e.g., auto-rename inference errors). Inject via `configure` so
-    /// existing call sites that do not care about diagnostics keep working.
+    private(set) var persistence: ChatPersistenceProvider? {
+        get { service._persistenceAccessor }
+        set { /* write-path is configure(persistence:) only */ }
+    }
+
     public private(set) var diagnostics: DiagnosticsService?
 
-    public init() {}
+    // MARK: - Internal
+
+    // Exposed so `SessionListServiceTests` can reach the service directly.
+    let service: SessionListService
+    nonisolated(unsafe) private var eventConsumerTask: Task<Void, Never>?
+
+    public init() {
+        service = SessionListService()
+    }
+
+    deinit {
+        eventConsumerTask?.cancel()
+    }
+
+    // MARK: - Configuration
 
     /// Injects the persistence provider. Call once from the view layer.
     public func configure(persistence: ChatPersistenceProvider, diagnostics: DiagnosticsService? = nil) {
-        guard self.persistence == nil else { return }
-        self.persistence = persistence
+        guard service._persistenceAccessor == nil else { return }
         self.diagnostics = diagnostics
-        loadSessions()
+        service.configure(persistence: persistence, diagnostics: diagnostics)
+        startEventConsumer()
+        // Eager sync so `sessions` is populated before any async event processing.
+        reloadSessionsEagerly()
         Log.persistence.info("SessionManagerViewModel configured")
     }
 
+    // MARK: - Commands
+
     /// Creates a new session, inserts it, activates it, and returns it.
-    ///
-    /// Setting `activeSession` to the new record ensures that
-    /// `onChange(of: sessionManager.activeSession)` fires in the host view so
-    /// `ChatViewModel.switchToSession(_:)` is called immediately. Without this,
-    /// callers that rely on the binding (e.g. `SessionListView`'s `List(selection:)`)
-    /// would leave the chat detail in a "No session selected" state until the user
-    /// manually tapped a row.
     @discardableResult
     public func createSession(title: String = "New Chat") throws -> ChatSessionRecord {
-        let persistence = try requirePersistence("createSession")
+        let p = try requirePersistence("createSession")
         let record = ChatSessionRecord(title: title)
-        try persistence.insertSession(record)
-        loadSessions()
+        try p.insertSession(record)
+        // Reload eagerly so `sessions` is up to date for synchronous callers.
+        // The service also emits `.sessionsLoaded` via its event stream —
+        // the dual-write is a consequence of keeping a sync public API while
+        // routing through an async event stream. See SPIKE FINDINGS in the PR.
+        reloadSessionsEagerly()
         activeSession = record
         return record
     }
 
     /// Deletes a session and all its messages.
     public func deleteSession(_ session: ChatSessionRecord) throws {
-        let persistence = try requirePersistence("deleteSession")
-        try persistence.deleteSession(session.id)
-
-        if activeSession?.id == session.id {
-            activeSession = nil
-        }
-
-        loadSessions()
+        let p = try requirePersistence("deleteSession")
+        try p.deleteSession(session.id)
+        if activeSession?.id == session.id { activeSession = nil }
+        reloadSessionsEagerly()
     }
 
     /// Renames a session.
     public func renameSession(_ session: ChatSessionRecord, title: String) throws {
-        let persistence = try requirePersistence("renameSession")
+        let p = try requirePersistence("renameSession")
         var updated = session
         updated.title = title
         updated.updatedAt = Date()
-        try persistence.updateSession(updated)
-        loadSessions()
+        try p.updateSession(updated)
+        reloadSessionsEagerly()
     }
 
     // MARK: - AI Auto-Rename
 
-    /// Generates a concise session title by running a short inference request.
-    ///
-    /// Returns `nil` when the model produced an empty response. Throws the
-    /// underlying inference error on failure so callers can surface it to
-    /// `DiagnosticsService` instead of silently dropping it.
     @MainActor
     public func generateTitle(
         from firstMessage: String,
@@ -137,7 +152,6 @@ public final class SessionManagerViewModel {
         let messages: [(role: String, content: String)] = [
             (role: "user", content: firstMessage)
         ]
-
         let (_, stream) = try inferenceService.enqueue(
             messages: messages,
             systemPrompt: systemPrompt,
@@ -149,227 +163,154 @@ public final class SessionManagerViewModel {
         )
         var result = ""
         for try await event in stream.events {
-            if case .token(let text) = event {
-                result += text
-            }
+            if case .token(let text) = event { result += text }
         }
         let trimmed = result.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
         return trimmed.count > 50 ? String(trimmed.prefix(50)) : trimmed
     }
 
-    /// Generates an AI title for the session and saves it.
-    ///
-    /// Only renames sessions that are still named "New Chat". Failures
-    /// fall back to the existing title but are recorded on
-    /// `DiagnosticsService` so they can be surfaced to the user.
     @MainActor
     public func autoRenameSession(
         _ session: ChatSessionRecord,
         firstMessage: String,
         inferenceService: InferenceService
     ) async {
-        guard session.title == "New Chat" else { return }
-        let title: String?
-        do {
-            title = try await generateTitle(from: firstMessage, using: inferenceService)
-        } catch {
-            Log.ui.warning("Title generation failed for session \(session.id): \(error.localizedDescription)")
-            diagnostics?.record(.titleGenerationFailed(sessionID: session.id, reason: error.localizedDescription))
-            return
-        }
-        guard let title else { return }
-        var updated = session
-        updated.title = title
-        updated.updatedAt = Date()
-        do {
-            try persistence?.updateSession(updated)
-        } catch {
-            Log.persistence.warning("Failed to persist auto-rename for session \(session.id): \(error.localizedDescription)")
-            // Persistence failure is a distinct category from inference
-            // failure — different remediation (disk/store health vs.
-            // backend availability), so we surface it as its own case.
-            diagnostics?.record(.sessionRenamePersistenceFailed(sessionID: session.id, reason: error.localizedDescription))
-            return
-        }
-        loadSessions()
+        await service.autoRenameSession(session, firstMessage: firstMessage, inferenceService: inferenceService)
     }
 
-    /// Auto-generates a session title from the first user message.
-    /// Only applies if the current title is "New Chat".
     public func autoGenerateTitle(for session: ChatSessionRecord, firstMessage: String) {
-        guard session.title == "New Chat" else { return }
-
-        let maxLength = 50
-        var title = firstMessage.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        if title.count > maxLength {
-            let truncated = String(title.prefix(maxLength))
-            if let lastSpace = truncated.lastIndex(of: " ") {
-                title = String(truncated[truncated.startIndex..<lastSpace]) + "..."
-            } else {
-                title = truncated + "..."
-            }
-        }
-
-        guard !title.isEmpty else { return }
-        var updated = session
-        updated.title = title
-        updated.updatedAt = Date()
-        do {
-            try persistence?.updateSession(updated)
-        } catch {
-            Log.persistence.error("Failed to auto-generate title: \(error)")
-        }
-        loadSessions()
+        service.autoGenerateTitle(for: session, firstMessage: firstMessage)
+        reloadSessionsEagerly()
     }
 
-    /// Reloads sessions from the persistence provider.
-    ///
-    /// Resets pagination and loads the first page. Mutations elsewhere in the
-    /// VM (create/delete/rename) call this to refresh the list — the caller's
-    /// expectation is "show me the freshest top of the list", which page 1
-    /// always satisfies.
+    // MARK: - Load / Pagination
+
     public func loadSessions() {
-        guard let persistence else { return }
-
-        do {
-            let firstPage = try persistence.fetchSessions(offset: 0, limit: Self.sessionsPageSize)
-            sessions = firstPage
-            hasMoreSessions = firstPage.count == Self.sessionsPageSize
-        } catch {
-            Log.persistence.error("Failed to load sessions: \(error)")
-            sessions = []
-            hasMoreSessions = false
-        }
+        reloadSessionsEagerly()
+        // Also trigger the async service reload so the event stream stays in
+        // sync with any downstream consumers (e.g. views that bind to `service.events`).
+        service.reloadSessionsSync()
     }
 
-    // MARK: - Pagination
-
-    /// Fetches a page of sessions from the persistence provider.
-    ///
-    /// Used by ``SessionListView`` to drive incremental loading as the user
-    /// scrolls. Caller is responsible for appending the result to
-    /// ``sessions``; this method does not mutate VM state directly so tests
-    /// can assert on raw page contents.
     public func fetchSessionsPage(offset: Int, limit: Int) throws -> [ChatSessionRecord] {
-        let persistence = try requirePersistence("fetchSessionsPage")
-        return try persistence.fetchSessions(offset: offset, limit: limit)
+        guard let p = service._persistenceAccessor else {
+            throw ChatPersistenceError.providerNotConfigured
+        }
+        return try p.fetchSessions(offset: offset, limit: limit)
     }
 
-    /// Appends the next page of sessions, if any, to ``sessions``.
-    ///
-    /// No-op when no more pages are available, when a search is active, or
-    /// when persistence is unconfigured.
     public func loadNextPage() {
-        guard hasMoreSessions, persistence != nil else { return }
-        let offset = sessions.count
-        do {
-            let next = try fetchSessionsPage(offset: offset, limit: Self.sessionsPageSize)
-            // Defensive against duplicates if a concurrent insert raced the
-            // page boundary — keys are session IDs, so the dedupe is cheap.
-            let existing = Set(sessions.map(\.id))
-            let unique = next.filter { !existing.contains($0.id) }
-            sessions.append(contentsOf: unique)
-            hasMoreSessions = next.count == Self.sessionsPageSize
-        } catch {
-            Log.persistence.error("Failed to load next sessions page: \(error)")
-            hasMoreSessions = false
-        }
+        guard hasMoreSessions else { return }
+        let currentCount = sessions.count
+        Task { await service.loadNextPage(currentCount: currentCount) }
     }
 
     // MARK: - Search
 
-    /// Computes the visible session list given the current scope and query.
-    ///
-    /// Returns the unfiltered ``sessions`` list when no search is active.
-    /// Title scope filters in-memory; message scope returns sessions surfaced
-    /// by the most recent ``runMessageSearch(_:)`` call.
     public var displayedSessions: [ChatSessionRecord] {
         let trimmed = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return sessions }
         switch searchScope {
-        case .titles:
-            return titleMatches
-        case .messages:
-            return messageMatchSessions
+        case .titles: return titleMatches
+        case .messages: return messageMatchSessions
         }
     }
 
-    /// `true` when an active search produced no results.
     public var hasNoSearchResults: Bool {
         let trimmed = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
         switch searchScope {
-        case .titles:
-            return titleMatches.isEmpty
-        case .messages:
-            return messageMatchSessions.isEmpty
+        case .titles: return titleMatches.isEmpty
+        case .messages: return messageMatchSessions.isEmpty
         }
     }
 
-    /// Recomputes ``titleMatches`` against the currently loaded ``sessions``.
     public func runTitleSearch(_ query: String) {
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            titleMatches = []
-            return
-        }
-        titleMatches = sessions.filter {
-            $0.title.range(of: trimmed, options: .caseInsensitive) != nil
-        }
+        service.runTitleSearch(query, against: sessions)
     }
 
-    /// Runs a message-scope search via the persistence provider.
-    ///
-    /// Populates ``messageHitsBySession`` and ``messageMatchSessions``. The
-    /// result list is ordered by hit recency (most recent matching message
-    /// first), matching the rest of the sidebar's recency-first ordering.
     public func runMessageSearch(_ query: String) {
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, let persistence else {
-            messageHitsBySession = [:]
-            messageMatchSessions = []
-            return
-        }
-
-        do {
-            let hits = try persistence.searchMessages(query: trimmed, limit: Self.messageSearchLimit)
-            var grouped: [UUID: [MessageSearchHit]] = [:]
-            grouped.reserveCapacity(hits.count)
-            // Preserve the first occurrence of each sessionID to keep
-            // recency ordering — `hits` is already newest-first.
-            var orderedSessionIDs: [UUID] = []
-            for hit in hits {
-                if grouped[hit.sessionID] == nil {
-                    orderedSessionIDs.append(hit.sessionID)
-                }
-                grouped[hit.sessionID, default: []].append(hit)
-            }
-            messageHitsBySession = grouped
-
-            // Resolve sessions for the surfaced IDs. We fetch up to
-            // `messageSearchSessionResolveCap` sessions so a hit in an
-            // unloaded page still gets its session row rendered — otherwise
-            // message search would silently miss matches deep in history.
-            let allSessions = try persistence.fetchSessions(
-                offset: 0,
-                limit: Self.messageSearchSessionResolveCap
-            )
-            let byID = Dictionary(uniqueKeysWithValues: allSessions.map { ($0.id, $0) })
-            messageMatchSessions = orderedSessionIDs.compactMap { byID[$0] }
-        } catch {
-            Log.persistence.error("Message search failed: \(error)")
-            messageHitsBySession = [:]
-            messageMatchSessions = []
-        }
+        Task { await service.runMessageSearch(query) }
     }
 
-    /// Clears search state and falls back to the unfiltered session list.
     public func clearSearch() {
         searchQuery = ""
-        titleMatches = []
-        messageHitsBySession = [:]
-        messageMatchSessions = []
+        service.clearSearch()
     }
+
+    // MARK: - Eager reload
+
+    // Reads page one from persistence synchronously and updates `sessions`.
+    // Required so sync public commands (`createSession`, `deleteSession`, etc.)
+    // leave observable state consistent without waiting for the async event
+    // consumer. The service also emits `.sessionsLoaded` — this is an explicit
+    // dual-write, not a bug. See SPIKE FINDINGS for the architectural implication.
+    private func reloadSessionsEagerly() {
+        guard let p = service._persistenceAccessor else { return }
+        do {
+            let page = try p.fetchSessions(offset: 0, limit: Self.sessionsPageSize)
+            sessions = page
+            hasMoreSessions = page.count == Self.sessionsPageSize
+        } catch {
+            Log.persistence.error("Eager session reload failed: \(error)")
+        }
+    }
+
+    // MARK: - Event consumer
+
+    private func startEventConsumer() {
+        eventConsumerTask = Task { [weak self] in
+            guard let self else { return }
+            for await event in self.service.events {
+                await MainActor.run {
+                    self.apply(event)
+                }
+            }
+        }
+    }
+
+    private func apply(_ event: SessionListEvent) {
+        switch event {
+        case .sessionsLoaded(let page, let hasMore):
+            sessions = page
+            hasMoreSessions = hasMore
+
+        case .sessionInserted:
+            // Full reload follows every insert — handled by .sessionsLoaded.
+            break
+
+        case .sessionRenamed(let id, let title):
+            if let idx = sessions.firstIndex(where: { $0.id == id }) {
+                sessions[idx].title = title
+            }
+            if activeSession?.id == id { activeSession?.title = title }
+
+        case .sessionDeleted(let id):
+            sessions.removeAll { $0.id == id }
+
+        case .searchResultsChanged(let results):
+            titleMatches = results.titleMatches
+            messageHitsBySession = results.messageHitsBySession
+            messageMatchSessions = results.messageMatchSessions
+
+        case .titleGenerated(let id, let title):
+            if let idx = sessions.firstIndex(where: { $0.id == id }) {
+                sessions[idx].title = title
+            }
+            if activeSession?.id == id { activeSession?.title = title }
+
+        case .persistenceFailure:
+            // Logged at the service level — no additional action needed.
+            break
+        }
+    }
+}
+
+// MARK: - Internal accessor for persistence (needed by PersistenceGuard extension)
+
+extension SessionListService {
+    /// Read-only view of the stored persistence provider, used by the adapter
+    /// and the `PersistenceGuard` helpers on `SessionManagerViewModel`.
+    var _persistenceAccessor: ChatPersistenceProvider? { _persistence }
 }

--- a/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
@@ -83,6 +83,8 @@ public final class SessionManagerViewModel {
 
     // Exposed so `SessionListServiceTests` can reach the service directly.
     let service: SessionListService
+    // `nonisolated(unsafe)` required so deinit can cancel the task without
+    // a main-actor hop. Task.cancel() is concurrency-safe (it only sets a flag).
     nonisolated(unsafe) private var eventConsumerTask: Task<Void, Never>?
 
     public init() {

--- a/Tests/BaseChatUITests/SessionListServiceTests.swift
+++ b/Tests/BaseChatUITests/SessionListServiceTests.swift
@@ -1,0 +1,124 @@
+@preconcurrency import XCTest
+import SwiftData
+@testable import BaseChatUI
+@testable import BaseChatCore
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Integration tests exercising ``SessionListService`` directly, below the adapter layer.
+///
+/// These verify that the runtime-as-events pattern works: commands persist data
+/// and surface the expected ``SessionListEvent`` cases through `service.events`.
+@MainActor
+final class SessionListServiceTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+    private var service: SessionListService!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        container = try makeInMemoryContainer()
+        context = container.mainContext
+        service = SessionListService()
+        service.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
+        // No initial event is emitted by configure — the event stream starts
+        // empty. Tests collect only the events they trigger.
+    }
+
+    override func tearDown() async throws {
+        container = nil
+        context = nil
+        service = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Test 1: createSession emits .sessionInserted then .sessionsLoaded
+
+    func test_createSession_emitsInsertAndReload() async throws {
+        // Collect the next two events: the reload triggered after insert.
+        // The service emits .sessionInserted then triggers a reload which
+        // emits .sessionsLoaded — we want to see both.
+        let expectInserted = expectation(description: "sessionInserted received")
+        let expectLoaded = expectation(description: "sessionsLoaded received after insert")
+
+        var insertedRecord: ChatSessionRecord?
+        var loadedSessions: [ChatSessionRecord]?
+
+        let collector = Task { [service = service!] in
+            for await event in service.events {
+                switch event {
+                case .sessionInserted(let record):
+                    insertedRecord = record
+                    expectInserted.fulfill()
+                case .sessionsLoaded(let sessions, _):
+                    loadedSessions = sessions
+                    expectLoaded.fulfill()
+                    return
+                default:
+                    break
+                }
+            }
+        }
+
+        let created = try await service.createSession(title: "Spike Test")
+
+        await fulfillment(of: [expectInserted, expectLoaded], timeout: 2)
+        collector.cancel()
+
+        XCTAssertEqual(created.title, "Spike Test")
+        XCTAssertEqual(insertedRecord?.id, created.id, "sessionInserted should carry the new record")
+        XCTAssertEqual(loadedSessions?.count, 1)
+        XCTAssertEqual(loadedSessions?.first?.id, created.id)
+
+        // Sabotage check: if the service never yields .sessionInserted, the
+        // expectation times out. Verified by temporarily removing the
+        // `continuation.yield(.sessionInserted(record))` line in
+        // SessionListService.createSession and confirming test failure.
+    }
+
+    // MARK: - Test 2: runTitleSearch emits .searchResultsChanged
+
+    func test_runTitleSearch_emitsSearchResultsChanged() async throws {
+        // Start collecting events before seeding sessions, so we know when
+        // the seeds are complete and can then issue the search.
+        let expectSearch = expectation(description: "searchResultsChanged received")
+        var searchResults: SearchResults?
+
+        // We need to skip the 6 setup events (3× sessionInserted + 3× sessionsLoaded)
+        // before we see the search result. The collector below skips anything
+        // that isn't a searchResultsChanged so we don't need an exact count.
+        let collector = Task { [service = service!] in
+            for await event in service.events {
+                if case .searchResultsChanged(let results) = event {
+                    // Only report a non-empty result (the search, not the cleared state).
+                    if !results.titleMatches.isEmpty {
+                        searchResults = results
+                        expectSearch.fulfill()
+                        return
+                    }
+                }
+            }
+        }
+
+        // Seed three sessions. The async collector is already running.
+        _ = try await service.createSession(title: "Swift Concurrency")
+        _ = try await service.createSession(title: "SwiftUI Layout")
+        _ = try await service.createSession(title: "CoreData Migration")
+
+        // Now issue the search. Pass all sessions from persistence directly.
+        let allSessions = try service._persistenceAccessor!.fetchSessions()
+        service.runTitleSearch("Swift", against: allSessions)
+
+        await fulfillment(of: [expectSearch], timeout: 2)
+        collector.cancel()
+
+        let results = try XCTUnwrap(searchResults)
+        XCTAssertEqual(results.titleMatches.count, 2, "Should match 'Swift Concurrency' and 'SwiftUI Layout'")
+        XCTAssertTrue(results.titleMatches.allSatisfy { $0.title.contains("Swift") })
+
+        // Sabotage check: if runTitleSearch never yields a searchResultsChanged
+        // event, the expectation times out. Verified by temporarily removing
+        // the `continuation.yield(.searchResultsChanged(...))` call and confirming failure.
+    }
+}


### PR DESCRIPTION
## Summary

Spike validating the runtime-as-events + thin-@Observable-adapter pattern proposed in PR #876 (`docs/runtime-ports-refactor.md`) on one concrete slice: `SessionManagerViewModel` / `SessionListService`.

This PR **must not be merged**. It is a technical probe to answer whether the proposed architecture is achievable before the 7-phase refactor is approved.

---

## SPIKE FINDINGS

### Sync-port-via-async-use-case: did it work? Any awkward seams?

- **It works, but the async surface is cosmetic on this slice.** `ChatPersistenceProvider` is `@MainActor`-isolated and sync-throws. Every service command annotated `async` still runs synchronously on main — the `async` keyword just signals "this is a command you can await" without providing any actual concurrency benefit. No threads are freed; no work leaves main.
- **The critical seam is the sync-vs-async state gap.** The adapter's event consumer is a `Task` that processes events asynchronously. Any test (or view) that reads `sessions` synchronously after a mutation — e.g. `createSession()` then immediately checking `sessions.count` — sees stale state unless the VM also updates its state eagerly. This forced a dual-write pattern: the VM updates `sessions` eagerly (synchronously via `reloadSessionsEagerly()`) AND the service emits a `sessionsLoaded` event that the consumer will process later. The event stream and the observable state are briefly out of sync. In a full async-surfaced API (where `createSession` is `async throws`) the dual-write disappears.

### Event stream: how many event cases ended up needed?

- **7 cases** in `SessionListEvent`: `.sessionsLoaded`, `.sessionInserted`, `.sessionRenamed`, `.sessionDeleted`, `.searchResultsChanged`, `.titleGenerated`, `.persistenceFailure`.
- **`.sessionInserted` is almost a phantom case.** Every insert is immediately followed by a `.sessionsLoaded` reload, and the adapter ignores `.sessionInserted` in `apply()` (the reload does all the work). It exists for tests and potential future fine-grained consumers, but in practice it's always paired with a reload. This is a signal that insert-then-reload could be collapsed into a single `.sessionMutated` event.
- **`.searchResultsChanged` naturally bundles title + message results**, which avoids a race between two separate events. No cases wanted to be a command-response pair — `clearSearch()` is fire-and-forget with an immediate event, which is clean.

### Adapter LOC

- Original `SessionManagerViewModel.swift`: **375 LOC**
- New `SessionManagerViewModel.swift` (adapter): **316 LOC**
- New `SessionListService.swift` (orchestration): **329 LOC**
- `SessionListServiceTests.swift` (new): **124 LOC** (not counted against adapter delta)
- **Total LOC delta for source files: +270 LOC** (316 + 329 − 375). The adapter is slightly smaller than the original, but the total surface grew because the service is a new file. Comments and SPIKE NOTE markers inflate both files; in a real refactor those would be trimmed.

### Title generation: did it migrate cleanly?

- **Partially.** The `autoRenameSession` path (inference-backed) emits `.titleGenerated` cleanly and the adapter applies it via the event consumer. This is the "ideal shape."
- **`autoGenerateTitle` (sync, first-message truncation) required special handling.** Because its public contract must stay `func` (non-async), and because the adapter's event consumer is async, the sync path needed `reloadSessionsEagerly()` to keep `sessions` up to date for callers that check it synchronously. The dual-write comment in the adapter code documents this explicitly.
- **The deeper blocker for AI title generation:** `InferenceService` is `@Observable @MainActor`, meaning `enqueue(...)` is also `@MainActor`. Moving title generation off main requires the inference API itself to grow a non-main-actor surface — a prerequisite change that isn't in scope for the session-list spike but would be required before a `BaseChatRuntime` target could genuinely run orchestration off main.

### Verdict: would this scale to `ChatViewModel` (3,621 LOC across file + 9 extensions)?

**Conditionally yes, but three prerequisites must be resolved first:**

1. **Make public command APIs `async throws`.** The sync-vs-async dual-write anti-pattern (documented in `reloadSessionsEagerly()`) exists entirely because the original public API is synchronous. `ChatViewModel.sendMessage()` is already `async`, so the most expensive methods are already async. The remaining sync mutators (`clearMessages`, `switchToSession`, etc.) would need to become `async` to eliminate the dual-write. This is a BREAKING change.
2. **Resolve `InferenceService` main-actor coupling.** Title generation, model loading, and streaming all require `@MainActor` today. Until `InferenceService` grows a non-main-actor generation surface, the runtime services stay pinned to main and the `async` label is purely organizational.
3. **Accept a larger total LOC budget.** The session-list slice grew by ~270 LOC despite being a relatively simple 375-line class. `ChatViewModel` at 3,621 LOC would likely produce 4,500–5,000 LOC across the service + adapter split, plus tests. The split buys genuine testability improvements (the service is testable without a view model), but the LOC growth is real and should be planned for.

**Bottom line:** the pattern is achievable and produces better-isolated, more testable code. The event-stream shape works well. The main cost is resolving the sync/async seam — without that, the adapter ends up doing double-writes that undermine the "single source of truth" goal of the event stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)