### PR TITLE
test: strengthen regenerate guard assertion and isolate HuggingFace stubs

### DIFF
--- a/Sources/BaseChatTestSupport/SlowMockBackend.swift
+++ b/Sources/BaseChatTestSupport/SlowMockBackend.swift
@@ -11,7 +11,16 @@ public final class SlowMockBackend: InferenceBackend, @unchecked Sendable {
     private var _isGenerating = false
     private var _tokensToYield: [String] = []
     private var _delayPerToken: Duration = .milliseconds(50)
+    private var _generateCallCount = 0
     private let lifecycle = MockBackendLifecycle()
+
+    /// Number of times `generate(prompt:systemPrompt:config:)` has been invoked.
+    ///
+    /// Lets tests verify guards that should prevent re-entry into generation
+    /// (e.g. `regenerateLastResponse` short-circuiting while `isGenerating`).
+    public var generateCallCount: Int {
+        withStateLock { _generateCallCount }
+    }
 
     public var isModelLoaded: Bool {
         get { withStateLock { _isModelLoaded } }
@@ -67,6 +76,7 @@ public final class SlowMockBackend: InferenceBackend, @unchecked Sendable {
     ) throws -> GenerationStream {
         let (tokens, delay) = withStateLock {
             _isGenerating = true
+            _generateCallCount += 1
             return (_tokensToYield, _delayPerToken)
         }
 

--- a/Tests/BaseChatInferenceTests/HuggingFaceServiceTests.swift
+++ b/Tests/BaseChatInferenceTests/HuggingFaceServiceTests.swift
@@ -6,7 +6,6 @@ import HuggingFace
 final class HuggingFaceServiceTests: XCTestCase {
 
     private var service: HuggingFaceService!
-    private var stubbedURLs: [URL] = []
 
     override func setUp() {
         super.setUp()
@@ -64,30 +63,51 @@ final class HuggingFaceServiceTests: XCTestCase {
     }
 
     override func tearDown() {
-        for url in stubbedURLs {
-            MockURLProtocol.unstub(url: url)
-        }
-        stubbedURLs = []
         service = nil
         CuratedModel.all = []
         super.tearDown()
     }
 
+    /// Tracks per-test stub URLs so the test can `unstub` them in `defer`.
+    /// We avoid `MockURLProtocol.reset()` because parallel suites share
+    /// `MockURLProtocol`'s static stub registry; resetting would clobber
+    /// concurrently-running tests.
+    private struct MockHuggingFaceStubScope {
+        let service: HuggingFaceService
+        let stubbedURLs: [URL]
+
+        func unstubAll() {
+            for url in stubbedURLs {
+                MockURLProtocol.unstub(url: url)
+            }
+        }
+    }
+
+    /// Builds a `HuggingFaceService` whose `HubClient` is pinned to a unique
+    /// per-test hostname (`https://<uuid>.huggingface.test`). Stubs are
+    /// registered against that hostname only, so concurrent tests running
+    /// under `swift test --parallel` cannot collide on the global
+    /// `MockURLProtocol` stub registry.
     private func makeMockService(
         listResponseJSON: String = "[]",
         modelDetailsByRepoID: [String: String] = [:]
-    ) -> HuggingFaceService {
+    ) -> MockHuggingFaceStubScope {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [MockURLProtocol.self]
         let session = URLSession(configuration: configuration)
+
+        let uniqueHost = "\(UUID().uuidString.lowercased()).huggingface.test"
+        let hostURL = URL(string: "https://\(uniqueHost)")!
         let hubClient = HubClient(
             session: session,
-            host: URL(string: "https://huggingface.co")!,
+            host: hostURL,
             userAgent: "BaseChatKitTests/1.0",
             cache: nil
         )
 
-        let listURL = URL(string: "https://huggingface.co/api/models")!
+        var stubbedURLs: [URL] = []
+
+        let listURL = URL(string: "https://\(uniqueHost)/api/models")!
         MockURLProtocol.stub(
             url: listURL,
             response: .immediate(
@@ -99,7 +119,7 @@ final class HuggingFaceServiceTests: XCTestCase {
         stubbedURLs.append(listURL)
 
         for (repoID, json) in modelDetailsByRepoID {
-            let detailURL = URL(string: "https://huggingface.co/api/models/\(repoID)")!
+            let detailURL = URL(string: "https://\(uniqueHost)/api/models/\(repoID)")!
             MockURLProtocol.stub(
                 url: detailURL,
                 response: .immediate(
@@ -111,7 +131,10 @@ final class HuggingFaceServiceTests: XCTestCase {
             stubbedURLs.append(detailURL)
         }
 
-        return HuggingFaceService(hubClient: hubClient)
+        return MockHuggingFaceStubScope(
+            service: HuggingFaceService(hubClient: hubClient),
+            stubbedURLs: stubbedURLs
+        )
     }
 
     private func decodeModel(from json: String) throws -> Model {
@@ -396,15 +419,16 @@ final class HuggingFaceServiceTests: XCTestCase {
             }
             """
 
-        let service = makeMockService(
+        let scope = makeMockService(
             listResponseJSON: listResponse,
             modelDetailsByRepoID: [
                 mlxRepoID: mlxDetail,
                 ggufRepoID: ggufDetail,
             ]
         )
+        defer { scope.unstubAll() }
 
-        let results = try await service.searchModels(query: "gemma")
+        let results = try await scope.service.searchModels(query: "gemma")
 
         XCTAssertTrue(
             results.contains(where: { $0.repoID == ggufRepoID && $0.modelType == .gguf }),

--- a/Tests/BaseChatUITests/ConcurrencyTests.swift
+++ b/Tests/BaseChatUITests/ConcurrencyTests.swift
@@ -290,16 +290,47 @@ final class ConcurrencyTests: XCTestCase {
             await self.vm.sendMessage()
         }
 
-        // Wait for generation to start.
+        // Wait for generation to start AND for the first token to be streamed.
+        // `awaitGenerating(true)` flips when the VM enters the
+        // `waitingForFirstToken` phase, which can fire BEFORE the backend's
+        // generate() is actually invoked (the InferenceService queues the
+        // request). Waiting for the first token guarantees the backend has been
+        // called, so the `generateCallCount` assertion below is meaningful.
         await vm.awaitGenerating(true)
+        await vm.awaitFirstToken()
 
-        // Capture message count before regenerate attempt.
+        // Capture state before the regenerate attempt. The backend must have been
+        // invoked exactly once for the in-flight initial send. A guarded
+        // regenerateLastResponse should NOT trigger a second backend invocation.
+        //
+        // Asserting on messages.count alone is too weak: even without the guard,
+        // regenerateLastResponse removes the trailing empty assistant placeholder
+        // and re-appends a fresh one, netting zero change in count. The
+        // backend-call counter is the contract that actually catches re-entry.
+        XCTAssertEqual(slowBackend.generateCallCount, 1,
+            "Backend should have been called exactly once for the initial send")
         let messageCountBefore = vm.messages.count
+
+        // The guard contract: regenerateLastResponse() must short-circuit
+        // silently. That means:
+        //   1. The backend must not be called a second time.
+        //   2. The function must not enter its message-rewrite path
+        //      (which surfaces a persistence error when it tries to delete
+        //      the still-unpersisted streaming placeholder).
+        //
+        // Asserting on `messages.count` alone is too weak — even without the
+        // guard, the rewrite path tears down and restores the placeholder via
+        // its persistence-failure catch, netting zero change in count.
 
         // Attempt regeneration while generating -- should be silently skipped.
         await vm.regenerateLastResponse()
 
-        // Message count should not change because regenerate was guarded.
+        // Guard contract: no additional backend invocation, no observable
+        // error from a botched message-rewrite, and the message list unchanged.
+        XCTAssertEqual(slowBackend.generateCallCount, 1,
+            "regenerateLastResponse must not call the backend while isGenerating is true")
+        XCTAssertNil(vm.activeError,
+            "regenerateLastResponse must not surface an error while generating; an unguarded re-entry leaks a persistence error from attempting to delete the unpersisted streaming placeholder")
         XCTAssertEqual(vm.messages.count, messageCountBefore,
             "regenerateLastResponse should be a no-op while isGenerating is true")
 
@@ -316,5 +347,7 @@ final class ConcurrencyTests: XCTestCase {
         let lastAssistant = vm.messages.last { $0.role == .assistant }
         XCTAssertEqual(lastAssistant?.content, "regenerated",
             "regenerateLastResponse should work after generation finishes")
+        XCTAssertEqual(slowBackend.generateCallCount, 2,
+            "Post-completion regenerate should call the backend a second time")
     }
 }


### PR DESCRIPTION
## Summary

Two test-only fixes; no production code touched.

- **`test_regenerateWhileGenerating_isGuarded` was passing without the guard.** The terminal `XCTAssertEqual(vm.messages.count, ...)` netted unchanged across the unguarded path because the in-flight `regenerateLastResponse` removes the streaming placeholder, fails to delete the unpersisted message, and then restores the placeholder via the persistence-failure catch. Strengthen the assertion: track backend invocation count via a new `SlowMockBackend.generateCallCount` and assert `vm.activeError == nil`. Closes #860.
- **`HuggingFaceServiceTests` shared `MockURLProtocol`'s global stub registry**, which races under `swift test --parallel`. Migrate to per-test UUID hostnames (`https://<uuid>.huggingface.test`) so concurrent suites cannot collide. Pattern matches existing usage in `Tests/BaseChatBackendsTests/`. No production-code changes — `HubClient` already accepted a custom `host`. Closes #861.

#841 (flip `--parallel` on the inference CI step) is **not bundled here** — investigation found no isolated inference XCTest step exists; suites are batched at `ci.yml:192` with an explicit "Do NOT add --parallel here" guard tied to #756. Will leave a comment on #841.

## Sabotage-verify

- **#860**: with new assertions + guard intact → green; remove `isGenerating` guard → fails on `XCTAssertNil(vm.activeError)` with the leaked persistence error (`Message not found:`); restore guard → green. The `generateCallCount` assertion is belt-and-suspenders for the harder-to-reach scenario where the placeholder has been persisted.
- **#861**: serial run green; `--parallel` run green (1326 tests); flip an expected value in a migrated test → fails for the right reason (assertion, not race); restore → green.

## Test plan

- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits` — 1331 tests, 0 failures
- [x] `swift test --filter BaseChatInferenceTests --disable-default-traits --parallel` — green (validates the #861 migration)
- [x] `swift test --filter BaseChatTestSupportTests --disable-default-traits` — 16 tests, 0 failures
- [x] `swift test --filter BaseChatUITests.ConcurrencyTests/test_regenerateWhileGenerating_isGuarded --disable-default-traits` — green
- [x] `swift test --filter BaseChatCoreTests --disable-default-traits` — 282 tests, 0 failures
- [x] `swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits` — 83 tests, 0 failures
- [x] `swift test --filter BaseChatUIModelManagementTests --disable-default-traits` — 94 tests, 0 failures
- [x] `swift test --filter BaseChatMCPTests --disable-default-traits` — 130 tests, 0 failures
- [x] `swift test --filter BaseChatBackendsTests --disable-default-traits` — green
- [x] `swift test --filter BaseChatAppIntentsTests --disable-default-traits` — 11 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)