### PR TITLE
refactor!: make persistence and command APIs async throws (phase 1.0)

### DIFF
--- a/Example/BaseChatDemo/DemoContentView.swift
+++ b/Example/BaseChatDemo/DemoContentView.swift
@@ -121,6 +121,14 @@ struct DemoContentView: View {
             Task { @MainActor in
                 let hasPendingPayload = await pendingPayloadBuffer?.peek() != nil
 
+                // Phase 1.0: `configure(runtime:)` no longer auto-fires
+                // `loadSessions()`. Pull the first page here so the
+                // empty-state check below sees the actual persisted list,
+                // not the pre-load empty state. Safe to call alongside the
+                // sidebar's own `.task { }` load — main-actor serialisation
+                // makes the second call a no-op against the in-memory state.
+                await sessionManager.loadSessions()
+
                 if !hasPendingPayload && sessionManager.sessions.isEmpty {
                     do {
                         try await sessionManager.createSession()

--- a/Example/BaseChatDemo/DemoContentView.swift
+++ b/Example/BaseChatDemo/DemoContentView.swift
@@ -123,7 +123,7 @@ struct DemoContentView: View {
 
                 if !hasPendingPayload && sessionManager.sessions.isEmpty {
                     do {
-                        try sessionManager.createSession()
+                        try await sessionManager.createSession()
                     } catch {
                         viewModel.errorMessage = "Failed to create session: \(error.localizedDescription)"
                     }
@@ -177,7 +177,7 @@ struct DemoContentView: View {
                 // mid-stream, wiping the ingested reply. Only re-activate
                 // if the view model is currently on a different session.
                 if viewModel.activeSession?.id != session.id {
-                    viewModel.switchToSession(session)
+                    Task { await viewModel.switchToSession(session) }
                 }
             }
         }
@@ -189,7 +189,7 @@ struct DemoContentView: View {
             // user sees the wrong detail pane.
             guard let newSession else { return }
             if sessionManager.activeSession?.id != newSession.id {
-                sessionManager.loadSessions()
+                Task { await sessionManager.loadSessions() }
                 sessionManager.activeSession = newSession
             }
         }
@@ -319,10 +319,12 @@ struct DemoContentView: View {
     }
 
     private func createSession() {
-        do {
-            try sessionManager.createSession()
-        } catch {
-            viewModel.errorMessage = "Failed to create session: \(error.localizedDescription)"
+        Task {
+            do {
+                try await sessionManager.createSession()
+            } catch {
+                viewModel.errorMessage = "Failed to create session: \(error.localizedDescription)"
+            }
         }
     }
 

--- a/Example/BaseChatDemo/Scenarios/DemoScenarioRunner.swift
+++ b/Example/BaseChatDemo/Scenarios/DemoScenarioRunner.swift
@@ -37,11 +37,11 @@ enum DemoScenarioRunner {
         scenario.configure?(registry)
 
         do {
-            let session = try sessions.createSession(title: scenario.title)
+            let session = try await sessions.createSession(title: scenario.title)
             sessions.activeSession = session
             // Deterministic switch — don't wait on the onChange propagation
             // cycle in DemoContentView. See the sequence doc above.
-            chat.switchToSession(session)
+            await chat.switchToSession(session)
         } catch {
             chat.errorMessage = "Failed to start scenario: \(error.localizedDescription)"
             return

--- a/Example/Examples/MinimalExample/MinimalExampleApp.swift
+++ b/Example/Examples/MinimalExample/MinimalExampleApp.swift
@@ -77,10 +77,15 @@ struct MinimalExampleApp: App {
     private func bootstrapInitialSession() async {
         chatViewModel.refreshModels()
 
-        let initialSession = sessionManager.sessions.first ?? (try? sessionManager.createSession())
+        let initialSession: ChatSessionRecord?
+        if let existing = sessionManager.sessions.first {
+            initialSession = existing
+        } else {
+            initialSession = try? await sessionManager.createSession()
+        }
         if let initialSession {
             sessionManager.activeSession = initialSession
-            chatViewModel.switchToSession(initialSession)
+            await chatViewModel.switchToSession(initialSession)
             chatViewModel.dispatchSelectedLoad()
         }
     }

--- a/Example/Examples/MinimalExample/MinimalExampleApp.swift
+++ b/Example/Examples/MinimalExample/MinimalExampleApp.swift
@@ -76,6 +76,9 @@ struct MinimalExampleApp: App {
     @MainActor
     private func bootstrapInitialSession() async {
         chatViewModel.refreshModels()
+        // Phase 1.0: `configure` no longer auto-loads. Pull the first page
+        // here so an existing-session check sees the persisted list.
+        await sessionManager.loadSessions()
 
         let initialSession: ChatSessionRecord?
         if let existing = sessionManager.sessions.first {

--- a/Sources/BaseChatCore/Protocols/ChatPersistenceProvider.swift
+++ b/Sources/BaseChatCore/Protocols/ChatPersistenceProvider.swift
@@ -33,26 +33,26 @@ public protocol ChatPersistenceProvider: AnyObject, Sendable {
     /// Inserts a new chat session.
     ///
     /// - Throws: Storage errors from the underlying provider.
-    func insertSession(_ session: ChatSessionRecord) throws
+    func insertSession(_ session: ChatSessionRecord) async throws
 
     /// Updates an existing chat session.
     ///
     /// - Throws:
     ///   - ``ChatPersistenceError/sessionNotFound(_:)`` when the session does not exist.
     ///   - Storage errors from the underlying provider.
-    func updateSession(_ session: ChatSessionRecord) throws
+    func updateSession(_ session: ChatSessionRecord) async throws
 
     /// Deletes a chat session and all associated messages.
     ///
     /// - Throws:
     ///   - ``ChatPersistenceError/sessionNotFound(_:)`` when the session does not exist.
     ///   - Storage errors from the underlying provider.
-    func deleteSession(_ sessionID: UUID) throws
+    func deleteSession(_ sessionID: UUID) async throws
 
     /// Fetches all chat sessions sorted by most-recently-updated.
     ///
     /// - Throws: Storage errors from the underlying provider.
-    func fetchSessions() throws -> [ChatSessionRecord]
+    func fetchSessions() async throws -> [ChatSessionRecord]
 
     /// Fetches a page of chat sessions sorted by most-recently-updated.
     ///
@@ -64,7 +64,7 @@ public protocol ChatPersistenceProvider: AnyObject, Sendable {
     ///   - offset: Index of the first session to return (0-based).
     ///   - limit: Maximum number of sessions to return.
     /// - Throws: Storage errors from the underlying provider.
-    func fetchSessions(offset: Int, limit: Int) throws -> [ChatSessionRecord]
+    func fetchSessions(offset: Int, limit: Int) async throws -> [ChatSessionRecord]
 
     // MARK: - Search
 
@@ -79,33 +79,33 @@ public protocol ChatPersistenceProvider: AnyObject, Sendable {
     ///   - query: Substring to search for. Empty queries return no hits.
     ///   - limit: Maximum number of hits to return (UI default: 100).
     /// - Throws: Storage errors from the underlying provider.
-    func searchMessages(query: String, limit: Int) throws -> [MessageSearchHit]
+    func searchMessages(query: String, limit: Int) async throws -> [MessageSearchHit]
 
     // MARK: - Messages
 
     /// Inserts a new chat message.
     ///
     /// - Throws: Storage errors from the underlying provider.
-    func insertMessage(_ message: ChatMessageRecord) throws
+    func insertMessage(_ message: ChatMessageRecord) async throws
 
     /// Updates an existing chat message.
     ///
     /// - Throws:
     ///   - ``ChatPersistenceError/messageNotFound(_:)`` when the message does not exist.
     ///   - Storage errors from the underlying provider.
-    func updateMessage(_ message: ChatMessageRecord) throws
+    func updateMessage(_ message: ChatMessageRecord) async throws
 
     /// Deletes a chat message.
     ///
     /// - Throws:
     ///   - ``ChatPersistenceError/messageNotFound(_:)`` when the message does not exist.
     ///   - Storage errors from the underlying provider.
-    func deleteMessage(_ messageID: UUID) throws
+    func deleteMessage(_ messageID: UUID) async throws
 
     /// Fetches messages for a session in timestamp order.
     ///
     /// - Throws: Storage errors from the underlying provider.
-    func fetchMessages(for sessionID: UUID) throws -> [ChatMessageRecord]
+    func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord]
 
     /// Fetches the most recent messages for a session, up to `limit`.
     ///
@@ -113,7 +113,7 @@ public protocol ChatPersistenceProvider: AnyObject, Sendable {
     /// Use ``fetchMessages(for:before:limit:)`` to page backwards from a known timestamp.
     ///
     /// - Throws: Storage errors from the underlying provider.
-    func fetchRecentMessages(for sessionID: UUID, limit: Int) throws -> [ChatMessageRecord]
+    func fetchRecentMessages(for sessionID: UUID, limit: Int) async throws -> [ChatMessageRecord]
 
     /// Fetches messages older than `before` for a session, up to `limit`.
     ///
@@ -121,12 +121,12 @@ public protocol ChatPersistenceProvider: AnyObject, Sendable {
     /// Returns an empty array when no older messages exist.
     ///
     /// - Throws: Storage errors from the underlying provider.
-    func fetchMessages(for sessionID: UUID, before: Date, limit: Int) throws -> [ChatMessageRecord]
+    func fetchMessages(for sessionID: UUID, before: Date, limit: Int) async throws -> [ChatMessageRecord]
 
     /// Deletes all messages for a session.
     ///
     /// - Throws: Storage errors from the underlying provider.
-    func deleteMessages(for sessionID: UUID) throws
+    func deleteMessages(for sessionID: UUID) async throws
 }
 
 // MARK: - Default pagination implementations
@@ -134,21 +134,21 @@ public protocol ChatPersistenceProvider: AnyObject, Sendable {
 extension ChatPersistenceProvider {
 
     /// Default: fetches all messages then returns the last `limit`.
-    public func fetchRecentMessages(for sessionID: UUID, limit: Int) throws -> [ChatMessageRecord] {
-        let all = try fetchMessages(for: sessionID)
+    public func fetchRecentMessages(for sessionID: UUID, limit: Int) async throws -> [ChatMessageRecord] {
+        let all = try await fetchMessages(for: sessionID)
         return Array(all.suffix(limit))
     }
 
     /// Default: fetches all messages then filters to those before `before`.
-    public func fetchMessages(for sessionID: UUID, before: Date, limit: Int) throws -> [ChatMessageRecord] {
-        let all = try fetchMessages(for: sessionID)
+    public func fetchMessages(for sessionID: UUID, before: Date, limit: Int) async throws -> [ChatMessageRecord] {
+        let all = try await fetchMessages(for: sessionID)
         let older = all.filter { $0.timestamp < before }
         return Array(older.suffix(limit))
     }
 
     /// Default: pages over the full list returned by ``fetchSessions()``.
-    public func fetchSessions(offset: Int, limit: Int) throws -> [ChatSessionRecord] {
-        let all = try fetchSessions()
+    public func fetchSessions(offset: Int, limit: Int) async throws -> [ChatSessionRecord] {
+        let all = try await fetchSessions()
         guard offset < all.count else { return [] }
         let end = min(offset + limit, all.count)
         return Array(all[offset..<end])
@@ -157,7 +157,7 @@ extension ChatPersistenceProvider {
     /// Default: returns no hits. Providers that don't implement search opt
     /// out by inheriting this no-op rather than throwing — UI shows the
     /// "No results" empty state, which is the correct behaviour.
-    public func searchMessages(query: String, limit: Int) throws -> [MessageSearchHit] {
+    public func searchMessages(query: String, limit: Int) async throws -> [MessageSearchHit] {
         []
     }
 }

--- a/Sources/BaseChatCore/Services/ConversationExporter.swift
+++ b/Sources/BaseChatCore/Services/ConversationExporter.swift
@@ -92,8 +92,8 @@ public enum ConversationExporter {
         format: ConversationExportFormat,
         provider: ChatPersistenceProvider,
         directory: URL? = nil
-    ) throws -> ShareableFile {
-        let messages = try provider.fetchMessages(for: session.id)
+    ) async throws -> ShareableFile {
+        let messages = try await provider.fetchMessages(for: session.id)
         return try export(
             session: session.record,
             messages: messages,

--- a/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
+++ b/Sources/BaseChatCore/Services/SwiftDataPersistenceProvider.swift
@@ -27,7 +27,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
 
     // MARK: - Sessions
 
-    public func insertSession(_ record: ChatSessionRecord) throws {
+    public func insertSession(_ record: ChatSessionRecord) async throws {
         let session = ChatSession(title: record.title)
         session.id = record.id
         session.createdAt = record.createdAt
@@ -45,7 +45,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         try modelContext.save()
     }
 
-    public func updateSession(_ record: ChatSessionRecord) throws {
+    public func updateSession(_ record: ChatSessionRecord) async throws {
         guard let session = try fetchSwiftDataSession(id: record.id) else {
             throw ChatPersistenceError.sessionNotFound(record.id)
         }
@@ -63,23 +63,23 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         try modelContext.save()
     }
 
-    public func deleteSession(_ sessionID: UUID) throws {
+    public func deleteSession(_ sessionID: UUID) async throws {
         guard let session = try fetchSwiftDataSession(id: sessionID) else {
             throw ChatPersistenceError.sessionNotFound(sessionID)
         }
-        try deleteMessages(for: sessionID)
+        try await deleteMessages(for: sessionID)
         modelContext.delete(session)
         try modelContext.save()
     }
 
-    public func fetchSessions() throws -> [ChatSessionRecord] {
+    public func fetchSessions() async throws -> [ChatSessionRecord] {
         let descriptor = FetchDescriptor<ChatSession>(
             sortBy: [SortDescriptor(\.updatedAt, order: .reverse)]
         )
         return try modelContext.fetch(descriptor).map { $0.toRecord() }
     }
 
-    public func fetchSessions(offset: Int, limit: Int) throws -> [ChatSessionRecord] {
+    public func fetchSessions(offset: Int, limit: Int) async throws -> [ChatSessionRecord] {
         var descriptor = FetchDescriptor<ChatSession>(
             sortBy: [SortDescriptor(\.updatedAt, order: .reverse)]
         )
@@ -93,7 +93,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
 
     // MARK: - Search
 
-    public func searchMessages(query: String, limit: Int) throws -> [MessageSearchHit] {
+    public func searchMessages(query: String, limit: Int) async throws -> [MessageSearchHit] {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, limit > 0 else { return [] }
 
@@ -129,7 +129,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
 
     // MARK: - Messages
 
-    public func insertMessage(_ record: ChatMessageRecord) throws {
+    public func insertMessage(_ record: ChatMessageRecord) async throws {
         let message = ChatMessage(role: record.role, contentParts: record.contentParts, sessionID: record.sessionID)
         message.id = record.id
         message.timestamp = record.timestamp
@@ -139,7 +139,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         try modelContext.save()
     }
 
-    public func updateMessage(_ record: ChatMessageRecord) throws {
+    public func updateMessage(_ record: ChatMessageRecord) async throws {
         guard let message = try fetchSwiftDataMessage(id: record.id) else {
             throw ChatPersistenceError.messageNotFound(record.id)
         }
@@ -149,7 +149,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         try modelContext.save()
     }
 
-    public func deleteMessage(_ messageID: UUID) throws {
+    public func deleteMessage(_ messageID: UUID) async throws {
         guard let message = try fetchSwiftDataMessage(id: messageID) else {
             throw ChatPersistenceError.messageNotFound(messageID)
         }
@@ -157,7 +157,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         try modelContext.save()
     }
 
-    public func fetchMessages(for sessionID: UUID) throws -> [ChatMessageRecord] {
+    public func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
         let descriptor = FetchDescriptor<ChatMessage>(
             predicate: #Predicate { $0.sessionID == sessionID },
             sortBy: [SortDescriptor(\.timestamp)]
@@ -165,7 +165,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         return try modelContext.fetch(descriptor).map { $0.toRecord() }
     }
 
-    public func fetchRecentMessages(for sessionID: UUID, limit: Int) throws -> [ChatMessageRecord] {
+    public func fetchRecentMessages(for sessionID: UUID, limit: Int) async throws -> [ChatMessageRecord] {
         // Fetch newest-first, take `limit`, then reverse to ascending order.
         var descriptor = FetchDescriptor<ChatMessage>(
             predicate: #Predicate { $0.sessionID == sessionID },
@@ -176,7 +176,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         return results.reversed().map { $0.toRecord() }
     }
 
-    public func fetchMessages(for sessionID: UUID, before: Date, limit: Int) throws -> [ChatMessageRecord] {
+    public func fetchMessages(for sessionID: UUID, before: Date, limit: Int) async throws -> [ChatMessageRecord] {
         // Fetch messages older than `before`, newest-first, take `limit`, then reverse.
         var descriptor = FetchDescriptor<ChatMessage>(
             predicate: #Predicate { $0.sessionID == sessionID && $0.timestamp < before },
@@ -187,7 +187,7 @@ public final class SwiftDataPersistenceProvider: ChatPersistenceProvider {
         return results.reversed().map { $0.toRecord() }
     }
 
-    public func deleteMessages(for sessionID: UUID) throws {
+    public func deleteMessages(for sessionID: UUID) async throws {
         let descriptor = FetchDescriptor<ChatMessage>(
             predicate: #Predicate { $0.sessionID == sessionID }
         )

--- a/Sources/BaseChatTestSupport/ErrorInjectingPersistenceProvider.swift
+++ b/Sources/BaseChatTestSupport/ErrorInjectingPersistenceProvider.swift
@@ -39,66 +39,66 @@ public final class ErrorInjectingPersistenceProvider: ChatPersistenceProvider {
         self.wrapped = wrapped
     }
 
-    public func insertSession(_ session: ChatSessionRecord) throws {
+    public func insertSession(_ session: ChatSessionRecord) async throws {
         insertSessionCallCount += 1
         if let error = shouldThrowOnInsertSession { throw error }
-        try wrapped.insertSession(session)
+        try await wrapped.insertSession(session)
     }
 
-    public func updateSession(_ session: ChatSessionRecord) throws {
+    public func updateSession(_ session: ChatSessionRecord) async throws {
         updateSessionCallCount += 1
         if let error = shouldThrowOnUpdateSession { throw error }
-        try wrapped.updateSession(session)
+        try await wrapped.updateSession(session)
     }
 
-    public func deleteSession(_ sessionID: UUID) throws {
+    public func deleteSession(_ sessionID: UUID) async throws {
         deleteSessionCallCount += 1
-        try wrapped.deleteSession(sessionID)
+        try await wrapped.deleteSession(sessionID)
     }
 
-    public func fetchSessions() throws -> [ChatSessionRecord] {
+    public func fetchSessions() async throws -> [ChatSessionRecord] {
         fetchSessionsCallCount += 1
         if let error = shouldThrowOnFetchSessions { throw error }
-        return try wrapped.fetchSessions()
+        return try await wrapped.fetchSessions()
     }
 
-    public func insertMessage(_ message: ChatMessageRecord) throws {
+    public func insertMessage(_ message: ChatMessageRecord) async throws {
         insertMessageCallCount += 1
         if let error = shouldThrowOnInsertMessage { throw error }
-        try wrapped.insertMessage(message)
+        try await wrapped.insertMessage(message)
     }
 
-    public func updateMessage(_ message: ChatMessageRecord) throws {
+    public func updateMessage(_ message: ChatMessageRecord) async throws {
         updateMessageCallCount += 1
-        try wrapped.updateMessage(message)
+        try await wrapped.updateMessage(message)
     }
 
-    public func deleteMessage(_ messageID: UUID) throws {
+    public func deleteMessage(_ messageID: UUID) async throws {
         deleteMessageCallCount += 1
-        try wrapped.deleteMessage(messageID)
+        try await wrapped.deleteMessage(messageID)
     }
 
-    public func fetchMessages(for sessionID: UUID) throws -> [ChatMessageRecord] {
+    public func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
         fetchMessagesCallCount += 1
         if let error = shouldThrowOnFetchMessages { throw error }
-        return try wrapped.fetchMessages(for: sessionID)
+        return try await wrapped.fetchMessages(for: sessionID)
     }
 
-    public func fetchRecentMessages(for sessionID: UUID, limit: Int) throws -> [ChatMessageRecord] {
+    public func fetchRecentMessages(for sessionID: UUID, limit: Int) async throws -> [ChatMessageRecord] {
         fetchRecentMessagesCallCount += 1
         if let error = shouldThrowOnFetchMessages { throw error }
-        return try wrapped.fetchRecentMessages(for: sessionID, limit: limit)
+        return try await wrapped.fetchRecentMessages(for: sessionID, limit: limit)
     }
 
-    public func fetchMessages(for sessionID: UUID, before: Date, limit: Int) throws -> [ChatMessageRecord] {
+    public func fetchMessages(for sessionID: UUID, before: Date, limit: Int) async throws -> [ChatMessageRecord] {
         fetchMessagesBeforeCallCount += 1
         if let error = shouldThrowOnFetchMessages { throw error }
-        return try wrapped.fetchMessages(for: sessionID, before: before, limit: limit)
+        return try await wrapped.fetchMessages(for: sessionID, before: before, limit: limit)
     }
 
-    public func deleteMessages(for sessionID: UUID) throws {
+    public func deleteMessages(for sessionID: UUID) async throws {
         deleteMessagesCallCount += 1
         if let error = shouldThrowOnDeleteMessages { throw error }
-        try wrapped.deleteMessages(for: sessionID)
+        try await wrapped.deleteMessages(for: sessionID)
     }
 }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Ingest.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Ingest.swift
@@ -46,13 +46,13 @@ extension ChatViewModel {
         // deep-link) can still handoff cleanly.
         let session = ChatSessionRecord(title: "New Chat")
         do {
-            try persistence.insertSession(session)
+            try await persistence.insertSession(session)
         } catch {
             Log.persistence.error("ChatViewModel.ingest failed to insert session: \(error.localizedDescription)")
             surfaceError(error, kind: .persistence)
             return
         }
-        switchToSession(session)
+        await switchToSession(session)
 
         // Seed the prompt and run it through the same path as the compose
         // bar so loading checks, auto-title, and token accounting all stay
@@ -70,7 +70,7 @@ extension ChatViewModel {
             var updated = userMessage
             updated.contentParts.append(contentsOf: payload.attachments)
             do {
-                try updateMessage(updated)
+                try await updateMessage(updated)
                 if let index = messages.firstIndex(where: { $0.id == userMessage.id }) {
                     messages[index] = updated
                 }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+IngestPendingPayload.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+IngestPendingPayload.swift
@@ -193,7 +193,7 @@ extension ChatViewModel {
             systemPrompt: preset?.systemPrompt ?? ""
         )
         do {
-            try persistence.insertSession(session)
+            try await persistence.insertSession(session)
         } catch {
             Log.persistence.error(
                 "ChatViewModel.ingestPendingPayload failed to insert session: \(error.localizedDescription)"
@@ -201,7 +201,7 @@ extension ChatViewModel {
             surfaceError(error, kind: .persistence)
             return
         }
-        switchToSession(session)
+        await switchToSession(session)
 
         if let preset {
             applyPreset(preset)
@@ -210,7 +210,7 @@ extension ChatViewModel {
             // this, only the live VM state has the preset values and they
             // get lost when the session is reloaded.
             do {
-                try saveSettingsToSession()
+                try await saveSettingsToSession()
             } catch {
                 Log.persistence.warning(
                     "ingestPendingPayload failed to persist preset to session: \(error.localizedDescription)"
@@ -244,7 +244,7 @@ extension ChatViewModel {
             var updated = userMessage
             updated.contentParts.append(contentsOf: attachments)
             do {
-                try updateMessage(updated)
+                try await updateMessage(updated)
                 if let index = messages.firstIndex(where: { $0.id == userMessage.id }) {
                     messages[index] = updated
                 }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Messages.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Messages.swift
@@ -29,7 +29,7 @@ extension ChatViewModel {
         let userMessage = ChatMessageRecord(role: .user, content: text, sessionID: activeSessionID)
         messages.append(userMessage)
         do {
-            try saveMessage(userMessage)
+            try await saveMessage(userMessage)
         } catch {
             Log.persistence.error("Failed to save user message: \(error)")
             surfaceError(error, kind: .persistence)
@@ -39,7 +39,7 @@ extension ChatViewModel {
 
         // Update session timestamp.
         do {
-            try sessionController.touchActiveSessionUpdatedAt()
+            try await sessionController.touchActiveSessionUpdatedAt()
         } catch {
             Log.persistence.error("Failed to persist session timestamp: \(error)")
             surfaceError(error, kind: .persistence)
@@ -71,7 +71,7 @@ extension ChatViewModel {
 
         let removed = messages.remove(at: lastAssistantIndex)
         do {
-            try deleteMessage(removed)
+            try await deleteMessage(removed)
         } catch {
             Log.persistence.error("Failed to delete prior assistant message: \(error)")
             surfaceError(error, kind: .persistence)
@@ -98,7 +98,7 @@ extension ChatViewModel {
         let originalMessage = messages[index]
         messages[index].content = newContent
         do {
-            try updateMessage(messages[index])
+            try await updateMessage(messages[index])
         } catch {
             messages[index] = originalMessage
             Log.persistence.error("Failed to update edited message: \(error)")
@@ -115,7 +115,7 @@ extension ChatViewModel {
         messages.removeSubrange((index + 1)...)
         for msg in toRemove {
             do {
-                try deleteMessage(msg)
+                try await deleteMessage(msg)
             } catch {
                 Log.persistence.error("Failed to delete message during edit regeneration: \(error)")
                 surfaceError(error, kind: .persistence)
@@ -134,6 +134,13 @@ extension ChatViewModel {
     }
 
     /// Stops an in-progress generation.
+    ///
+    /// Cancellation is synchronous — the task tear-down and inference-side
+    /// stop happen immediately. The trailing persistence save (capturing
+    /// whatever streamed into the last assistant message before cancel) is
+    /// dispatched on a `Task` so the sync surface stays unchanged for the
+    /// many call sites that fire-and-forget this method (toolbar buttons,
+    /// session-switch teardown, scenePhase handlers).
     public func stopGeneration() {
         generationTask?.cancel()
         generationTask = nil
@@ -144,11 +151,14 @@ extension ChatViewModel {
         // Persist whatever has been generated so far.
         if let lastAssistant = messages.last(where: { $0.role == .assistant }),
            !lastAssistant.content.isEmpty {
-            do {
-                try saveMessage(lastAssistant)
-            } catch {
-                Log.persistence.error("Failed to persist partial assistant message: \(error)")
-                surfaceError(error, kind: .persistence)
+            Task { [weak self] in
+                guard let self else { return }
+                do {
+                    try await self.saveMessage(lastAssistant)
+                } catch {
+                    Log.persistence.error("Failed to persist partial assistant message: \(error)")
+                    self.surfaceError(error, kind: .persistence)
+                }
             }
         }
         Log.ui.debug("Generation stopped by user")
@@ -157,7 +167,7 @@ extension ChatViewModel {
     /// Clears all messages in the current session.
     ///
     /// Cancels any in-flight generation before clearing to avoid inconsistent UI state.
-    public func clearChat() {
+    public func clearChat() async {
         if isGenerating {
             stopGeneration()
         }
@@ -176,7 +186,7 @@ extension ChatViewModel {
         }
 
         do {
-            try deleteMessages(for: activeSessionID)
+            try await deleteMessages(for: activeSessionID)
             messages.removeAll()
             tokenCountCache.removeAll()
             hasOlderMessages = false
@@ -184,7 +194,7 @@ extension ChatViewModel {
             Log.ui.info("Chat cleared")
         } catch {
             Log.persistence.error("Failed to delete messages while clearing chat: \(error)")
-            loadMessages()
+            await loadMessages()
             tokenCountCache.removeAll()
             updateContextEstimate()
             surfaceError(error, kind: .persistence)
@@ -206,10 +216,10 @@ extension ChatViewModel {
     // MARK: - Message Pinning
 
     /// Marks a message as pinned, preserving it when history is trimmed to fit the context window.
-    public func pinMessage(id messageID: UUID) {
+    public func pinMessage(id messageID: UUID) async {
         pinnedMessageIDs.insert(messageID)
         do {
-            try saveSettingsToSession()
+            try await saveSettingsToSession()
         } catch {
             Log.persistence.error("Failed to save pinned message settings: \(error)")
             surfaceError(error, kind: .persistence)
@@ -217,10 +227,10 @@ extension ChatViewModel {
     }
 
     /// Removes the pin from a message.
-    public func unpinMessage(id messageID: UUID) {
+    public func unpinMessage(id messageID: UUID) async {
         pinnedMessageIDs.remove(messageID)
         do {
-            try saveSettingsToSession()
+            try await saveSettingsToSession()
         } catch {
             Log.persistence.error("Failed to save unpinned message settings: \(error)")
             surfaceError(error, kind: .persistence)

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Messages.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Messages.swift
@@ -47,7 +47,7 @@ extension ChatViewModel {
 
         // Trigger auto-title on the first user message in this session.
         if let session = activeSession, messages.filter({ $0.role == .user }).count == 1 {
-            onFirstMessage?(session, text)
+            await onFirstMessage?(session, text)
         }
 
         // Create an empty assistant message that will be streamed into.

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Persistence.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Persistence.swift
@@ -7,8 +7,8 @@ import BaseChatInference
 extension ChatViewModel {
 
     /// Loads the most recent page of messages for the active session.
-    func loadMessages() {
-        sessionController.loadMessages()
+    func loadMessages() async {
+        await sessionController.loadMessages()
     }
 
     /// Loads the next page of older messages and prepends them.
@@ -16,8 +16,8 @@ extension ChatViewModel {
     /// Returns the ID of the message that was previously first in the list,
     /// so the caller can restore scroll position to it after the prepend.
     @discardableResult
-    public func loadOlderMessages() -> UUID? {
-        sessionController.loadOlderMessages()
+    public func loadOlderMessages() async -> UUID? {
+        await sessionController.loadOlderMessages()
     }
 
     /// Persists a message via the persistence provider.
@@ -27,22 +27,22 @@ extension ChatViewModel {
     /// saved once from `stopGeneration()` and again at the end of
     /// `generateIntoMessage`). Treat it as an upsert at the view-model boundary so
     /// callers do not need to coordinate insert vs. update ownership.
-    func saveMessage(_ message: ChatMessageRecord) throws {
-        try sessionController.saveMessage(message)
+    func saveMessage(_ message: ChatMessageRecord) async throws {
+        try await sessionController.saveMessage(message)
     }
 
     /// Updates an existing message via the persistence provider.
-    func updateMessage(_ message: ChatMessageRecord) throws {
-        try sessionController.updateMessage(message)
+    func updateMessage(_ message: ChatMessageRecord) async throws {
+        try await sessionController.updateMessage(message)
     }
 
     /// Deletes a message via the persistence provider.
-    func deleteMessage(_ message: ChatMessageRecord) throws {
-        try sessionController.deleteMessage(message)
+    func deleteMessage(_ message: ChatMessageRecord) async throws {
+        try await sessionController.deleteMessage(message)
     }
 
     /// Deletes all messages for a session via the persistence provider.
-    func deleteMessages(for sessionID: UUID) throws {
-        try sessionController.deleteMessages(for: sessionID)
+    func deleteMessages(for sessionID: UUID) async throws {
+        try await sessionController.deleteMessages(for: sessionID)
     }
 }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+SessionManagement.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+SessionManagement.swift
@@ -7,7 +7,7 @@ import BaseChatInference
 extension ChatViewModel {
 
     /// Switches to a different chat session, loading its messages and settings.
-    public func switchToSession(_ session: ChatSessionRecord) {
+    public func switchToSession(_ session: ChatSessionRecord) async {
         // Stop any active generation for the old session.
         if isGenerating {
             stopGeneration()
@@ -49,14 +49,14 @@ extension ChatViewModel {
         }
 
         showUpgradeHint = false
-        loadMessages()
+        await loadMessages()
         updateContextEstimate()
         Log.ui.info("Switched to session: \(session.title, privacy: .private)")
     }
 
     /// Saves the current generation settings back to the active session.
-    func saveSettingsToSession() throws {
-        try sessionController.saveSettingsToSession(
+    func saveSettingsToSession() async throws {
+        try await sessionController.saveSettingsToSession(
             selectedModelID: selectedModel?.id,
             selectedEndpointID: selectedEndpoint?.id
         )
@@ -132,9 +132,9 @@ extension ChatViewModel {
     // MARK: - Lifecycle
 
     /// Saves all pending changes. Called on app background.
-    public func saveState() {
+    public func saveState() async {
         do {
-            try saveSettingsToSession()
+            try await saveSettingsToSession()
             Log.persistence.info("State saved on background")
         } catch {
             Log.persistence.error("Failed to save state on background: \(error)")

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -90,7 +90,7 @@ public final class ChatViewModel {
 
     /// Called when a session might need its title auto-generated.
     /// Set by the view layer to connect to SessionManagerViewModel.
-    public var onFirstMessage: (@MainActor (ChatSessionRecord, String) -> Void)?
+    public var onFirstMessage: (@MainActor (ChatSessionRecord, String) async -> Void)?
 
     // MARK: - First Run / Onboarding
 

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -701,7 +701,7 @@ public final class ChatViewModel {
             self?.updateContextEstimate()
         }
         genCoordinator.onSaveMessage = { [weak self] message in
-            try self?.saveMessage(message)
+            try await self?.saveMessage(message)
         }
         genCoordinator.onRemoveMessage = { [weak self] id in
             self?.messages.removeAll(where: { $0.id == id })

--- a/Sources/BaseChatUI/ViewModels/GenerationCoordinator.swift
+++ b/Sources/BaseChatUI/ViewModels/GenerationCoordinator.swift
@@ -166,7 +166,7 @@ final class GenerationCoordinator {
     var onUpdateContextEstimate: () -> Void = {}
 
     /// Persists a completed message.
-    var onSaveMessage: (ChatMessageRecord) throws -> Void = { _ in }
+    var onSaveMessage: (ChatMessageRecord) async throws -> Void = { _ in }
 
     /// Removes an assistant message from the view model (called for empty responses).
     var onRemoveMessage: (UUID) -> Void = { _ in }
@@ -520,7 +520,7 @@ final class GenerationCoordinator {
                 if !currentMessages[idx].hasVisibleContent && !hasThinkingContent {
                     onRemoveMessage(messageID)
                 } else {
-                    try onSaveMessage(currentMessages[idx])
+                    try await onSaveMessage(currentMessages[idx])
                 }
             } catch {
                 Log.persistence.error("Failed to persist assistant message: \(error)")

--- a/Sources/BaseChatUI/ViewModels/SessionController.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionController.swift
@@ -60,7 +60,7 @@ final class SessionController {
         )
     }
 
-    func touchActiveSessionUpdatedAt(_ date: Date = Date()) throws {
+    func touchActiveSessionUpdatedAt(_ date: Date = Date()) async throws {
         guard var session = activeSession else { return }
 
         session.updatedAt = date
@@ -69,7 +69,7 @@ final class SessionController {
         guard let persistence = persistenceOrLog("touchActiveSessionUpdatedAt") else { return }
 
         do {
-            try persistence.updateSession(session)
+            try await persistence.updateSession(session)
         } catch ChatPersistenceError.sessionNotFound {
             Log.persistence.warning(
                 "Active session was not yet persisted when updating session timestamp: \(session.id, privacy: .private)"
@@ -80,7 +80,7 @@ final class SessionController {
     func saveSettingsToSession(
         selectedModelID: UUID?,
         selectedEndpointID: UUID?
-    ) throws {
+    ) async throws {
         guard var session = activeSession else { return }
         let persistence = try requirePersistence("saveSettingsToSession")
         session.temperature = temperature
@@ -92,11 +92,11 @@ final class SessionController {
         session.promptTemplate = selectedPromptTemplate
         session.pinnedMessageIDs = pinnedMessageIDs
         session.updatedAt = Date()
-        try persistence.updateSession(session)
+        try await persistence.updateSession(session)
         activeSession = session
     }
 
-    func loadMessages() {
+    func loadMessages() async {
         guard let persistence = persistenceOrLog("loadMessages") else { return }
         guard let sessionID = activeSessionID else {
             messages = []
@@ -105,7 +105,7 @@ final class SessionController {
         }
 
         do {
-            let page = try persistence.fetchRecentMessages(for: sessionID, limit: Self.messagePageSize)
+            let page = try await persistence.fetchRecentMessages(for: sessionID, limit: Self.messagePageSize)
             // Heal orphan tool calls before exposing the transcript: a process
             // killed mid-tool leaves a `.toolCall` part with no matching
             // `.toolResult`, which cloud APIs reject on the next turn. The
@@ -123,7 +123,7 @@ final class SessionController {
     }
 
     @discardableResult
-    func loadOlderMessages() -> UUID? {
+    func loadOlderMessages() async -> UUID? {
         guard !isLoadingOlderMessages, hasOlderMessages else { return nil }
         guard let persistence else { return nil }
         guard let sessionID = activeSessionID else { return nil }
@@ -134,7 +134,7 @@ final class SessionController {
         defer { isLoadingOlderMessages = false }
 
         do {
-            let older = try persistence.fetchMessages(
+            let older = try await persistence.fetchMessages(
                 for: sessionID,
                 before: oldestTimestamp,
                 limit: Self.messagePageSize
@@ -153,27 +153,27 @@ final class SessionController {
         return anchorID
     }
 
-    func saveMessage(_ message: ChatMessageRecord) throws {
+    func saveMessage(_ message: ChatMessageRecord) async throws {
         guard let persistence = persistenceOrLog("saveMessage") else { return }
         do {
-            try persistence.updateMessage(message)
+            try await persistence.updateMessage(message)
         } catch ChatPersistenceError.messageNotFound {
-            try persistence.insertMessage(message)
+            try await persistence.insertMessage(message)
         }
     }
 
-    func updateMessage(_ message: ChatMessageRecord) throws {
+    func updateMessage(_ message: ChatMessageRecord) async throws {
         guard let persistence = persistenceOrLog("updateMessage") else { return }
-        try persistence.updateMessage(message)
+        try await persistence.updateMessage(message)
     }
 
-    func deleteMessage(_ message: ChatMessageRecord) throws {
+    func deleteMessage(_ message: ChatMessageRecord) async throws {
         guard let persistence = persistenceOrLog("deleteMessage") else { return }
-        try persistence.deleteMessage(message.id)
+        try await persistence.deleteMessage(message.id)
     }
 
-    func deleteMessages(for sessionID: UUID) throws {
+    func deleteMessages(for sessionID: UUID) async throws {
         guard let persistence = persistenceOrLog("deleteMessages") else { return }
-        try persistence.deleteMessages(for: sessionID)
+        try await persistence.deleteMessages(for: sessionID)
     }
 }

--- a/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
@@ -77,7 +77,11 @@ public final class SessionManagerViewModel {
         guard self.persistence == nil else { return }
         self.persistence = persistence
         self.diagnostics = diagnostics
-        loadSessions()
+        // Configure is sync to keep the host bootstrap call site simple.
+        // Kick off the initial page load on a Task so the surface stays
+        // non-async without losing the eager populate behaviour callers
+        // depend on. The loading state is observed via `sessions`.
+        Task { await loadSessions() }
         Log.persistence.info("SessionManagerViewModel configured")
     }
 
@@ -90,35 +94,35 @@ public final class SessionManagerViewModel {
     /// would leave the chat detail in a "No session selected" state until the user
     /// manually tapped a row.
     @discardableResult
-    public func createSession(title: String = "New Chat") throws -> ChatSessionRecord {
+    public func createSession(title: String = "New Chat") async throws -> ChatSessionRecord {
         let persistence = try requirePersistence("createSession")
         let record = ChatSessionRecord(title: title)
-        try persistence.insertSession(record)
-        loadSessions()
+        try await persistence.insertSession(record)
+        await loadSessions()
         activeSession = record
         return record
     }
 
     /// Deletes a session and all its messages.
-    public func deleteSession(_ session: ChatSessionRecord) throws {
+    public func deleteSession(_ session: ChatSessionRecord) async throws {
         let persistence = try requirePersistence("deleteSession")
-        try persistence.deleteSession(session.id)
+        try await persistence.deleteSession(session.id)
 
         if activeSession?.id == session.id {
             activeSession = nil
         }
 
-        loadSessions()
+        await loadSessions()
     }
 
     /// Renames a session.
-    public func renameSession(_ session: ChatSessionRecord, title: String) throws {
+    public func renameSession(_ session: ChatSessionRecord, title: String) async throws {
         let persistence = try requirePersistence("renameSession")
         var updated = session
         updated.title = title
         updated.updatedAt = Date()
-        try persistence.updateSession(updated)
-        loadSessions()
+        try await persistence.updateSession(updated)
+        await loadSessions()
     }
 
     // MARK: - AI Auto-Rename
@@ -183,7 +187,7 @@ public final class SessionManagerViewModel {
         updated.title = title
         updated.updatedAt = Date()
         do {
-            try persistence?.updateSession(updated)
+            try await persistence?.updateSession(updated)
         } catch {
             Log.persistence.warning("Failed to persist auto-rename for session \(session.id): \(error.localizedDescription)")
             // Persistence failure is a distinct category from inference
@@ -192,12 +196,12 @@ public final class SessionManagerViewModel {
             diagnostics?.record(.sessionRenamePersistenceFailed(sessionID: session.id, reason: error.localizedDescription))
             return
         }
-        loadSessions()
+        await loadSessions()
     }
 
     /// Auto-generates a session title from the first user message.
     /// Only applies if the current title is "New Chat".
-    public func autoGenerateTitle(for session: ChatSessionRecord, firstMessage: String) {
+    public func autoGenerateTitle(for session: ChatSessionRecord, firstMessage: String) async {
         guard session.title == "New Chat" else { return }
 
         let maxLength = 50
@@ -217,11 +221,11 @@ public final class SessionManagerViewModel {
         updated.title = title
         updated.updatedAt = Date()
         do {
-            try persistence?.updateSession(updated)
+            try await persistence?.updateSession(updated)
         } catch {
             Log.persistence.error("Failed to auto-generate title: \(error)")
         }
-        loadSessions()
+        await loadSessions()
     }
 
     /// Reloads sessions from the persistence provider.
@@ -230,11 +234,11 @@ public final class SessionManagerViewModel {
     /// VM (create/delete/rename) call this to refresh the list — the caller's
     /// expectation is "show me the freshest top of the list", which page 1
     /// always satisfies.
-    public func loadSessions() {
+    public func loadSessions() async {
         guard let persistence else { return }
 
         do {
-            let firstPage = try persistence.fetchSessions(offset: 0, limit: Self.sessionsPageSize)
+            let firstPage = try await persistence.fetchSessions(offset: 0, limit: Self.sessionsPageSize)
             sessions = firstPage
             hasMoreSessions = firstPage.count == Self.sessionsPageSize
         } catch {
@@ -252,20 +256,20 @@ public final class SessionManagerViewModel {
     /// scrolls. Caller is responsible for appending the result to
     /// ``sessions``; this method does not mutate VM state directly so tests
     /// can assert on raw page contents.
-    public func fetchSessionsPage(offset: Int, limit: Int) throws -> [ChatSessionRecord] {
+    public func fetchSessionsPage(offset: Int, limit: Int) async throws -> [ChatSessionRecord] {
         let persistence = try requirePersistence("fetchSessionsPage")
-        return try persistence.fetchSessions(offset: offset, limit: limit)
+        return try await persistence.fetchSessions(offset: offset, limit: limit)
     }
 
     /// Appends the next page of sessions, if any, to ``sessions``.
     ///
     /// No-op when no more pages are available, when a search is active, or
     /// when persistence is unconfigured.
-    public func loadNextPage() {
+    public func loadNextPage() async {
         guard hasMoreSessions, persistence != nil else { return }
         let offset = sessions.count
         do {
-            let next = try fetchSessionsPage(offset: offset, limit: Self.sessionsPageSize)
+            let next = try await fetchSessionsPage(offset: offset, limit: Self.sessionsPageSize)
             // Defensive against duplicates if a concurrent insert raced the
             // page boundary — keys are session IDs, so the dedupe is cheap.
             let existing = Set(sessions.map(\.id))
@@ -325,7 +329,7 @@ public final class SessionManagerViewModel {
     /// Populates ``messageHitsBySession`` and ``messageMatchSessions``. The
     /// result list is ordered by hit recency (most recent matching message
     /// first), matching the rest of the sidebar's recency-first ordering.
-    public func runMessageSearch(_ query: String) {
+    public func runMessageSearch(_ query: String) async {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, let persistence else {
             messageHitsBySession = [:]
@@ -334,7 +338,7 @@ public final class SessionManagerViewModel {
         }
 
         do {
-            let hits = try persistence.searchMessages(query: trimmed, limit: Self.messageSearchLimit)
+            let hits = try await persistence.searchMessages(query: trimmed, limit: Self.messageSearchLimit)
             var grouped: [UUID: [MessageSearchHit]] = [:]
             grouped.reserveCapacity(hits.count)
             // Preserve the first occurrence of each sessionID to keep
@@ -352,7 +356,7 @@ public final class SessionManagerViewModel {
             // `messageSearchSessionResolveCap` sessions so a hit in an
             // unloaded page still gets its session row rendered — otherwise
             // message search would silently miss matches deep in history.
-            let allSessions = try persistence.fetchSessions(
+            let allSessions = try await persistence.fetchSessions(
                 offset: 0,
                 limit: Self.messageSearchSessionResolveCap
             )

--- a/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
@@ -73,15 +73,19 @@ public final class SessionManagerViewModel {
     public init() {}
 
     /// Injects the persistence provider. Call once from the view layer.
+    ///
+    /// `configure` is intentionally synchronous so host bootstrap call sites
+    /// (which run from sync `init` paths in SwiftUI scene setup) can stay
+    /// simple. After Phase 1.0 the initial page load is async, so callers
+    /// must follow `configure` with an explicit `await loadSessions()` (or
+    /// rely on the first `createSession` to refresh the list). The session
+    /// list view also calls `loadSessions` from a `.task { }` modifier on
+    /// first appear, which keeps the on-screen UX unchanged for typical
+    /// hosts.
     public func configure(persistence: ChatPersistenceProvider, diagnostics: DiagnosticsService? = nil) {
         guard self.persistence == nil else { return }
         self.persistence = persistence
         self.diagnostics = diagnostics
-        // Configure is sync to keep the host bootstrap call site simple.
-        // Kick off the initial page load on a Task so the surface stays
-        // non-async without losing the eager populate behaviour callers
-        // depend on. The loading state is observed via `sessions`.
-        Task { await loadSessions() }
         Log.persistence.info("SessionManagerViewModel configured")
     }
 

--- a/Sources/BaseChatUI/Views/Chat/ChatView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ChatView.swift
@@ -136,7 +136,7 @@ public struct ChatView<APIConfig: View>: View {
         .alert("Clear Chat", isPresented: $showClearConfirmation) {
             Button("Cancel", role: .cancel) {}
             Button("Clear", role: .destructive) {
-                viewModel.clearChat()
+                Task { await viewModel.clearChat() }
             }
         } message: {
             Text("This will delete all messages in the current chat. This cannot be undone.")
@@ -533,10 +533,10 @@ public struct ChatView<APIConfig: View>: View {
     /// Loads the next page of older messages and scrolls back to the anchor
     /// so the viewport doesn't jump when content is prepended above.
     private func loadOlderAndRestore(proxy: ScrollViewProxy) {
-        guard let anchorID = viewModel.loadOlderMessages() else { return }
-        // Scroll back to the message that was at the top before prepend,
-        // keeping it at the top of the viewport to prevent visible jump.
-        DispatchQueue.main.async {
+        Task { @MainActor in
+            guard let anchorID = await viewModel.loadOlderMessages() else { return }
+            // Scroll back to the message that was at the top before prepend,
+            // keeping it at the top of the viewport to prevent visible jump.
             proxy.scrollTo(anchorID, anchor: .top)
         }
     }

--- a/Sources/BaseChatUI/Views/Chat/MessageActionMenu.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessageActionMenu.swift
@@ -47,7 +47,7 @@ public struct MessageActionMenuModifier: ViewModifier {
 
     private var pinButton: some View {
         Button {
-            viewModel.pinMessage(id: message.id)
+            Task { await viewModel.pinMessage(id: message.id) }
         } label: {
             Label("Pin", systemImage: "pin")
         }
@@ -55,7 +55,7 @@ public struct MessageActionMenuModifier: ViewModifier {
 
     private var unpinButton: some View {
         Button {
-            viewModel.unpinMessage(id: message.id)
+            Task { await viewModel.unpinMessage(id: message.id) }
         } label: {
             Label("Unpin", systemImage: "pin.slash")
         }

--- a/Sources/BaseChatUI/Views/Settings/GenerationSettingsView.swift
+++ b/Sources/BaseChatUI/Views/Settings/GenerationSettingsView.swift
@@ -197,11 +197,13 @@ public struct GenerationSettingsView<APIConfig: View>: View {
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") {
-                        do {
-                            try viewModel.saveSettingsToSession()
-                        } catch {
-                            Log.persistence.error("Failed to save settings from sheet: \(error)")
-                            viewModel.errorMessage = "Failed to save settings: \(error.localizedDescription)"
+                        Task {
+                            do {
+                                try await viewModel.saveSettingsToSession()
+                            } catch {
+                                Log.persistence.error("Failed to save settings from sheet: \(error)")
+                                viewModel.errorMessage = "Failed to save settings: \(error.localizedDescription)"
+                            }
                         }
                         dismiss()
                     }

--- a/Sources/BaseChatUI/Views/Sidebar/SessionListView.swift
+++ b/Sources/BaseChatUI/Views/Sidebar/SessionListView.swift
@@ -68,6 +68,16 @@ public struct SessionListView: View {
             }
         }
         .animation(.default, value: sessionManager.sessions.isEmpty)
+        .task {
+            // After Phase 1.0 `loadSessions()` is async — `configure` no
+            // longer auto-fires it, so kick off the initial page load on
+            // first appear. `.task { }` fires once per identity and is
+            // cancelled if the view is torn down before completion, which
+            // matches the behaviour we want here.
+            if sessionManager.sessions.isEmpty {
+                await sessionManager.loadSessions()
+            }
+        }
         .searchable(text: $searchText, prompt: "Search chats")
         .searchScopes($searchScope) {
             Text("Titles").tag(SessionSearchScope.titles)

--- a/Sources/BaseChatUI/Views/Sidebar/SessionListView.swift
+++ b/Sources/BaseChatUI/Views/Sidebar/SessionListView.swift
@@ -59,7 +59,7 @@ public struct SessionListView: View {
                                 // results already pull from a wider window in the VM.
                                 if searchText.isEmpty,
                                    session.id == sessionManager.sessions.last?.id {
-                                    sessionManager.loadNextPage()
+                                    Task { await sessionManager.loadNextPage() }
                                 }
                             }
                     }
@@ -90,10 +90,13 @@ public struct SessionListView: View {
             Button("Cancel", role: .cancel) { sessionToRename = nil }
             Button("Rename") {
                 if let session = sessionToRename {
-                    do {
-                        try sessionManager.renameSession(session, title: renameText)
-                    } catch {
-                        errorMessage = "Failed to rename session: \(error.localizedDescription)"
+                    let newTitle = renameText
+                    Task {
+                        do {
+                            try await sessionManager.renameSession(session, title: newTitle)
+                        } catch {
+                            errorMessage = "Failed to rename session: \(error.localizedDescription)"
+                        }
                     }
                 }
                 sessionToRename = nil
@@ -104,10 +107,12 @@ public struct SessionListView: View {
             set: { if !$0 { sessionToDelete = nil } }
         ), presenting: sessionToDelete) { session in
             Button("Delete", role: .destructive) {
-                do {
-                    try sessionManager.deleteSession(session)
-                } catch {
-                    errorMessage = "Failed to delete session: \(error.localizedDescription)"
+                Task {
+                    do {
+                        try await sessionManager.deleteSession(session)
+                    } catch {
+                        errorMessage = "Failed to delete session: \(error.localizedDescription)"
+                    }
                 }
                 sessionToDelete = nil
             }
@@ -189,7 +194,7 @@ public struct SessionListView: View {
         case .titles:
             vm.runTitleSearch(query)
         case .messages:
-            vm.runMessageSearch(query)
+            Task { await vm.runMessageSearch(query) }
         }
     }
 }

--- a/Tests/BaseChatBackendsTests/CloudEndpointSelectionIntegrationTests.swift
+++ b/Tests/BaseChatBackendsTests/CloudEndpointSelectionIntegrationTests.swift
@@ -85,10 +85,10 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
     }
 
     @discardableResult
-    private func makeSession(title: String = "Test") throws -> ChatSessionRecord {
-        let session = try sessionManager.createSession(title: title)
+    private func makeSession(title: String = "Test") async throws -> ChatSessionRecord {
+        let session = try await sessionManager.createSession(title: title)
         sessionManager.activeSession = session
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
         return session
     }
 
@@ -149,7 +149,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
         // https:// is required for non-localhost endpoints per endpoint validation.
         let uniqueHost = UUID().uuidString + ".invalid"
 
-        try makeSession(title: "Cloud Chat")
+        try await makeSession(title: "Cloud Chat")
         let endpoint = APIEndpoint(
             name: "Local LM Studio",
             provider: .lmStudio,
@@ -195,7 +195,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
         }
         let persistence = SwiftDataPersistenceProvider(modelContext: context)
         freshVM.configure(persistence: persistence)
-        try makeSession(title: "Sabotage Chat")
+        try await makeSession(title: "Sabotage Chat")
         freshVM.selectedEndpoint = endpoint
         await freshVM.loadCloudEndpoint(endpoint)
         freshVM.inputText = "Hi"
@@ -236,7 +236,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
 
     // MARK: - Session Persistence
 
-    func test_sessionRestoresSelectedEndpoint() throws {
+    func test_sessionRestoresSelectedEndpoint() async throws {
         let endpointA = APIEndpoint(
             name: "Endpoint A",
             provider: .ollama,
@@ -254,31 +254,31 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
         vm.setAvailableEndpoints([endpointA, endpointB])
 
         // Session A selects endpoint A.
-        try makeSession(title: "Session A")
+        try await makeSession(title: "Session A")
         vm.selectedEndpoint = endpointA
-        try vm.saveSettingsToSession()
+        try await vm.saveSettingsToSession()
 
         // Session B selects endpoint B.
-        let sessionB = try sessionManager.createSession(title: "Session B")
+        let sessionB = try await sessionManager.createSession(title: "Session B")
         sessionManager.activeSession = sessionB
-        vm.switchToSession(sessionB)
+        await vm.switchToSession(sessionB)
         vm.selectedEndpoint = endpointB
-        try vm.saveSettingsToSession()
+        try await vm.saveSettingsToSession()
 
         // Reload and switch back to session A — endpoint A should restore.
-        sessionManager.loadSessions()
+        await sessionManager.loadSessions()
         let freshA = try XCTUnwrap(sessionManager.sessions.first { $0.title == "Session A" })
         sessionManager.activeSession = freshA
-        vm.switchToSession(freshA)
+        await vm.switchToSession(freshA)
 
         XCTAssertEqual(vm.selectedEndpoint?.id, endpointA.id)
 
         // Sabotage: remove endpoint A from available endpoints and verify
         // the session restore clears the selection gracefully.
         vm.setAvailableEndpoints([endpointB])
-        sessionManager.loadSessions()
+        await sessionManager.loadSessions()
         let freshA2 = try XCTUnwrap(sessionManager.sessions.first { $0.title == "Session A" })
-        vm.switchToSession(freshA2)
+        await vm.switchToSession(freshA2)
         XCTAssertNil(vm.selectedEndpoint, "Endpoint not restored when removed from available endpoints")
     }
 
@@ -295,7 +295,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
         try persistEndpoint(endpoint)
         vm.setAvailableEndpoints([endpoint])
 
-        try makeSession(title: "Switch Test")
+        try await makeSession(title: "Switch Test")
 
         // Start with local model.
         vm.selectedModel = localModel
@@ -303,7 +303,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
         XCTAssertTrue(vm.isModelLoaded)
         XCTAssertNotNil(vm.selectedModel)
         XCTAssertNil(vm.selectedEndpoint)
-        try vm.saveSettingsToSession()
+        try await vm.saveSettingsToSession()
 
         // Switch to cloud endpoint.
         vm.selectedEndpoint = endpoint
@@ -311,12 +311,12 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
         XCTAssertTrue(vm.isModelLoaded)
         XCTAssertNil(vm.selectedModel, "Local model should be cleared when cloud endpoint is selected")
         XCTAssertNotNil(vm.selectedEndpoint)
-        try vm.saveSettingsToSession()
+        try await vm.saveSettingsToSession()
 
         // Reload and verify cloud endpoint was persisted.
-        sessionManager.loadSessions()
+        await sessionManager.loadSessions()
         let freshSession = try XCTUnwrap(sessionManager.sessions.first { $0.title == "Switch Test" })
-        vm.switchToSession(freshSession)
+        await vm.switchToSession(freshSession)
         XCTAssertEqual(vm.selectedEndpoint?.id, endpoint.id)
         XCTAssertNil(vm.selectedModel)
 
@@ -324,10 +324,10 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
         // the cloud endpoint from the session.
         vm.selectedModel = localModel
         XCTAssertNil(vm.selectedEndpoint, "Selecting local model should clear cloud endpoint")
-        try vm.saveSettingsToSession()
-        sessionManager.loadSessions()
+        try await vm.saveSettingsToSession()
+        await sessionManager.loadSessions()
         let freshSession2 = try XCTUnwrap(sessionManager.sessions.first { $0.title == "Switch Test" })
-        vm.switchToSession(freshSession2)
+        await vm.switchToSession(freshSession2)
         XCTAssertNil(vm.selectedEndpoint, "After saving with local model, endpoint should not restore")
     }
 

--- a/Tests/BaseChatBackendsTests/FoundationBackendUnitTests.swift
+++ b/Tests/BaseChatBackendsTests/FoundationBackendUnitTests.swift
@@ -573,7 +573,7 @@ final class FoundationBackendUnitTests: XCTestCase {
     /// caller observes `isGenerating == false` — needs a stub session so a test
     /// can interleave `continuation.yield(.token(...))` with `stopGeneration()`.
     /// #525 tracks adding that hook.
-    func test_stopGeneration_idempotent_synchronous_whenIdle() async {
+    func test_stopGeneration_idempotent_synchronous_whenIdle() {
         XCTAssertFalse(backend.isGenerating, "Precondition")
 
         // Synchronous: stopGeneration returns before the next statement runs.

--- a/Tests/BaseChatBackendsTests/FoundationBackendUnitTests.swift
+++ b/Tests/BaseChatBackendsTests/FoundationBackendUnitTests.swift
@@ -573,7 +573,7 @@ final class FoundationBackendUnitTests: XCTestCase {
     /// caller observes `isGenerating == false` — needs a stub session so a test
     /// can interleave `continuation.yield(.token(...))` with `stopGeneration()`.
     /// #525 tracks adding that hook.
-    func test_stopGeneration_idempotent_synchronous_whenIdle() {
+    func test_stopGeneration_idempotent_synchronous_whenIdle() async {
         XCTAssertFalse(backend.isGenerating, "Precondition")
 
         // Synchronous: stopGeneration returns before the next statement runs.

--- a/Tests/BaseChatBackendsTests/FoundationModelE2ETests.swift
+++ b/Tests/BaseChatBackendsTests/FoundationModelE2ETests.swift
@@ -48,8 +48,8 @@ final class FoundationModelE2ETests: XCTestCase {
 
         // Create and activate a session
         let record = ChatSessionRecord(title: "E2E Test")
-        try persistence.insertSession(record)
-        vm.switchToSession(record)
+        try await persistence.insertSession(record)
+        await vm.switchToSession(record)
 
         // Load the Foundation model
         let foundationModel = ModelInfo.builtInFoundation
@@ -139,9 +139,9 @@ final class FoundationModelE2ETests: XCTestCase {
         // Simulate a session switch mid-session, which calls resetConversation()
         // and clears FoundationBackend.session. generate() must still work.
         let secondSession = ChatSessionRecord(title: "Second Session")
-        try SwiftDataPersistenceProvider(modelContext: context).insertSession(secondSession)
+        try await SwiftDataPersistenceProvider(modelContext: context).insertSession(secondSession)
 
-        vm.switchToSession(secondSession)  // → resetConversation() → session = nil
+        await vm.switchToSession(secondSession)  // → resetConversation() → session = nil
 
         vm.inputText = "Reply with one word."
         await vm.sendMessage()

--- a/Tests/BaseChatCoreTests/BaseChatRuntimeTests.swift
+++ b/Tests/BaseChatCoreTests/BaseChatRuntimeTests.swift
@@ -69,7 +69,7 @@ final class BaseChatRuntimeTests: XCTestCase {
         )
     }
 
-    func test_init_wiresInferenceServicePersistenceAndContainerToTheSameInstances() throws {
+    func test_init_wiresInferenceServicePersistenceAndContainerToTheSameInstances() async throws {
         // Defends the post-construction wiring identity that the deleted
         // `Event`-callback ordering test used to defend: the runtime must
         // expose the *same* InferenceService instance the caller injected,
@@ -109,14 +109,14 @@ final class BaseChatRuntimeTests: XCTestCase {
         // must be reachable via the runtime's modelContainer.mainContext —
         // proof that both surfaces are wired to a single coherent store.
         let session = ChatSessionRecord(title: "Wiring Identity Probe")
-        try runtime.persistence.insertSession(session)
+        try await runtime.persistence.insertSession(session)
         let descriptor = FetchDescriptor<ChatSession>()
         let entitiesViaContainer = try runtime.modelContainer.mainContext.fetch(descriptor)
         XCTAssertTrue(entitiesViaContainer.contains(where: { $0.id == session.id }),
             "Session inserted via runtime.persistence must be visible through runtime.modelContainer.mainContext")
     }
 
-    func test_persistence_roundTripsSessionsThroughRuntimeProvider() throws {
+    func test_persistence_roundTripsSessionsThroughRuntimeProvider() async throws {
         let originalConfiguration = BaseChatConfiguration.shared
         defer { BaseChatConfiguration.shared = originalConfiguration }
 
@@ -129,8 +129,9 @@ final class BaseChatRuntimeTests: XCTestCase {
         )
         let session = ChatSessionRecord(title: "Runtime Session")
 
-        try runtime.persistence.insertSession(session)
+        try await runtime.persistence.insertSession(session)
 
-        XCTAssertEqual(try runtime.persistence.fetchSessions().map(\.id), [session.id])
+        let sessions = try await runtime.persistence.fetchSessions()
+        XCTAssertEqual(sessions.map(\.id), [session.id])
     }
 }

--- a/Tests/BaseChatCoreTests/ConversationExporterTests.swift
+++ b/Tests/BaseChatCoreTests/ConversationExporterTests.swift
@@ -137,7 +137,7 @@ final class ConversationExporterTests: XCTestCase {
 
     // MARK: - SwiftData convenience overload
 
-    func test_export_viaPersistenceProvider_fetchesMessagesInOrder() throws {
+    func test_export_viaPersistenceProvider_fetchesMessagesInOrder() async throws {
         let session = ChatSession(title: "Provider Path")
         stack.context.insert(session)
         try stack.context.save()
@@ -156,10 +156,10 @@ final class ConversationExporterTests: XCTestCase {
             timestamp: Date(timeIntervalSinceReferenceDate: 0),
             sessionID: session.id
         )
-        try stack.provider.insertMessage(later)
-        try stack.provider.insertMessage(earlier)
+        try await stack.provider.insertMessage(later)
+        try await stack.provider.insertMessage(earlier)
 
-        let file = try ConversationExporter.export(
+        let file = try await ConversationExporter.export(
             session: session,
             format: MarkdownExportFormat(),
             provider: stack.provider,

--- a/Tests/BaseChatCoreTests/SwiftDataPersistenceProviderSearchTests.swift
+++ b/Tests/BaseChatCoreTests/SwiftDataPersistenceProviderSearchTests.swift
@@ -29,33 +29,35 @@ final class SwiftDataPersistenceProviderSearchTests: XCTestCase {
 
     // MARK: - searchMessages
 
-    func test_searchMessages_returnsCaseInsensitiveMatches() throws {
+    func test_searchMessages_returnsCaseInsensitiveMatches() async throws {
         let session = ChatSessionRecord(title: "Search Test")
-        try provider.insertSession(session)
-        try provider.insertMessage(ChatMessageRecord(role: .user, content: "Tell me about DRAGONS in fantasy", sessionID: session.id))
-        try provider.insertMessage(ChatMessageRecord(role: .assistant, content: "Dragons are mythical creatures.", sessionID: session.id))
-        try provider.insertMessage(ChatMessageRecord(role: .user, content: "What about elves?", sessionID: session.id))
+        try await provider.insertSession(session)
+        try await provider.insertMessage(ChatMessageRecord(role: .user, content: "Tell me about DRAGONS in fantasy", sessionID: session.id))
+        try await provider.insertMessage(ChatMessageRecord(role: .assistant, content: "Dragons are mythical creatures.", sessionID: session.id))
+        try await provider.insertMessage(ChatMessageRecord(role: .user, content: "What about elves?", sessionID: session.id))
 
-        let hits = try provider.searchMessages(query: "dragon", limit: 100)
+        let hits = try await provider.searchMessages(query: "dragon", limit: 100)
 
         XCTAssertEqual(hits.count, 2, "Both messages mentioning 'dragon' (any case) should match")
         XCTAssertTrue(hits.allSatisfy { $0.snippet.localizedStandardContains("dragon") })
     }
 
-    func test_searchMessages_emptyQueryReturnsNoHits() throws {
+    func test_searchMessages_emptyQueryReturnsNoHits() async throws {
         let session = ChatSessionRecord(title: "Empty Query")
-        try provider.insertSession(session)
-        try provider.insertMessage(ChatMessageRecord(role: .user, content: "anything", sessionID: session.id))
+        try await provider.insertSession(session)
+        try await provider.insertMessage(ChatMessageRecord(role: .user, content: "anything", sessionID: session.id))
 
-        XCTAssertTrue(try provider.searchMessages(query: "", limit: 100).isEmpty)
-        XCTAssertTrue(try provider.searchMessages(query: "   ", limit: 100).isEmpty)
+        let emptyHits = try await provider.searchMessages(query: "", limit: 100)
+        XCTAssertTrue(emptyHits.isEmpty)
+        let whitespaceHits = try await provider.searchMessages(query: "   ", limit: 100)
+        XCTAssertTrue(whitespaceHits.isEmpty)
     }
 
-    func test_searchMessages_respectsLimit() throws {
+    func test_searchMessages_respectsLimit() async throws {
         let session = ChatSessionRecord(title: "Limit Test")
-        try provider.insertSession(session)
+        try await provider.insertSession(session)
         for i in 0..<25 {
-            try provider.insertMessage(ChatMessageRecord(
+            try await provider.insertMessage(ChatMessageRecord(
                 role: .user,
                 content: "needle row \(i)",
                 timestamp: Date(timeIntervalSince1970: Double(1_000 + i)),
@@ -63,19 +65,19 @@ final class SwiftDataPersistenceProviderSearchTests: XCTestCase {
             ))
         }
 
-        let hits = try provider.searchMessages(query: "needle", limit: 10)
+        let hits = try await provider.searchMessages(query: "needle", limit: 10)
         XCTAssertEqual(hits.count, 10, "Limit should cap result count")
     }
 
-    func test_searchMessages_snippetCentersOnMatchAndElides() throws {
+    func test_searchMessages_snippetCentersOnMatchAndElides() async throws {
         let session = ChatSessionRecord(title: "Snippet")
-        try provider.insertSession(session)
+        try await provider.insertSession(session)
         let prefix = String(repeating: "alpha ", count: 40)   // ~240 chars before
         let suffix = String(repeating: "omega ", count: 40)   // ~240 chars after
         let body = "\(prefix)NEEDLE\(suffix)"
-        try provider.insertMessage(ChatMessageRecord(role: .user, content: body, sessionID: session.id))
+        try await provider.insertMessage(ChatMessageRecord(role: .user, content: body, sessionID: session.id))
 
-        let hits = try provider.searchMessages(query: "needle", limit: 10)
+        let hits = try await provider.searchMessages(query: "needle", limit: 10)
         XCTAssertEqual(hits.count, 1)
         let hit = try XCTUnwrap(hits.first)
         XCTAssertTrue(hit.snippet.hasPrefix("…"), "Snippet should be elided on the left")
@@ -89,53 +91,55 @@ final class SwiftDataPersistenceProviderSearchTests: XCTestCase {
         XCTAssertEqual(String(matched).lowercased(), "needle")
     }
 
-    func test_searchMessages_sortsMostRecentFirst() throws {
+    func test_searchMessages_sortsMostRecentFirst() async throws {
         let session = ChatSessionRecord(title: "Sorted")
-        try provider.insertSession(session)
-        try provider.insertMessage(ChatMessageRecord(role: .user, content: "needle one",
+        try await provider.insertSession(session)
+        try await provider.insertMessage(ChatMessageRecord(role: .user, content: "needle one",
                                                     timestamp: Date(timeIntervalSince1970: 1_000), sessionID: session.id))
-        try provider.insertMessage(ChatMessageRecord(role: .user, content: "needle three",
+        try await provider.insertMessage(ChatMessageRecord(role: .user, content: "needle three",
                                                     timestamp: Date(timeIntervalSince1970: 3_000), sessionID: session.id))
-        try provider.insertMessage(ChatMessageRecord(role: .user, content: "needle two",
+        try await provider.insertMessage(ChatMessageRecord(role: .user, content: "needle two",
                                                     timestamp: Date(timeIntervalSince1970: 2_000), sessionID: session.id))
 
-        let hits = try provider.searchMessages(query: "needle", limit: 100)
+        let hits = try await provider.searchMessages(query: "needle", limit: 100)
         XCTAssertEqual(hits.map(\.snippet).map { $0.replacingOccurrences(of: "…", with: "") },
                        ["needle three", "needle two", "needle one"])
     }
 
-    func test_searchMessages_returnsNoHitsWhenQueryDoesNotMatch() throws {
+    func test_searchMessages_returnsNoHitsWhenQueryDoesNotMatch() async throws {
         let session = ChatSessionRecord(title: "Miss")
-        try provider.insertSession(session)
-        try provider.insertMessage(ChatMessageRecord(role: .user, content: "hello world", sessionID: session.id))
+        try await provider.insertSession(session)
+        try await provider.insertMessage(ChatMessageRecord(role: .user, content: "hello world", sessionID: session.id))
 
-        XCTAssertTrue(try provider.searchMessages(query: "absent", limit: 100).isEmpty)
+        let hits = try await provider.searchMessages(query: "absent", limit: 100)
+        XCTAssertTrue(hits.isEmpty)
     }
 
     // MARK: - fetchSessions(offset:limit:)
 
-    func test_fetchSessionsPage_returnsRequestedSlice() throws {
+    func test_fetchSessionsPage_returnsRequestedSlice() async throws {
         let base = Date(timeIntervalSince1970: 1_000_000)
         for i in 0..<10 {
             // Higher i = newer, so descending order = 9,8,7,...,0
-            try provider.insertSession(ChatSessionRecord(
+            try await provider.insertSession(ChatSessionRecord(
                 title: "S\(i)",
                 updatedAt: base.addingTimeInterval(Double(i))
             ))
         }
 
-        let firstPage = try provider.fetchSessions(offset: 0, limit: 4)
+        let firstPage = try await provider.fetchSessions(offset: 0, limit: 4)
         XCTAssertEqual(firstPage.map(\.title), ["S9", "S8", "S7", "S6"])
 
-        let secondPage = try provider.fetchSessions(offset: 4, limit: 4)
+        let secondPage = try await provider.fetchSessions(offset: 4, limit: 4)
         XCTAssertEqual(secondPage.map(\.title), ["S5", "S4", "S3", "S2"])
 
-        let lastPage = try provider.fetchSessions(offset: 8, limit: 4)
+        let lastPage = try await provider.fetchSessions(offset: 8, limit: 4)
         XCTAssertEqual(lastPage.map(\.title), ["S1", "S0"])
     }
 
-    func test_fetchSessionsPage_returnsEmptyBeyondEnd() throws {
-        try provider.insertSession(ChatSessionRecord(title: "only"))
-        XCTAssertTrue(try provider.fetchSessions(offset: 50, limit: 50).isEmpty)
+    func test_fetchSessionsPage_returnsEmptyBeyondEnd() async throws {
+        try await provider.insertSession(ChatSessionRecord(title: "only"))
+        let hits = try await provider.fetchSessions(offset: 50, limit: 50)
+        XCTAssertTrue(hits.isEmpty)
     }
 }

--- a/Tests/BaseChatCoreTests/SwiftDataPersistenceProviderTests.swift
+++ b/Tests/BaseChatCoreTests/SwiftDataPersistenceProviderTests.swift
@@ -30,7 +30,7 @@ final class SwiftDataPersistenceProviderTests: XCTestCase {
 
     // MARK: - Sessions
 
-    func test_insertSession_roundTripsAllFields() throws {
+    func test_insertSession_roundTripsAllFields() async throws {
         let modelID = UUID()
         let endpointID = UUID()
         let pinned: Set<UUID> = [UUID(), UUID()]
@@ -47,9 +47,9 @@ final class SwiftDataPersistenceProviderTests: XCTestCase {
             pinnedMessageIDs: pinned
         )
 
-        try provider.insertSession(record)
+        try await provider.insertSession(record)
 
-        let fetched = try provider.fetchSessions()
+        let fetched = try await provider.fetchSessions()
         XCTAssertEqual(fetched.count, 1)
         let first = fetched[0]
         XCTAssertEqual(first.id, record.id)
@@ -65,67 +65,75 @@ final class SwiftDataPersistenceProviderTests: XCTestCase {
         XCTAssertEqual(first.pinnedMessageIDs, pinned)
     }
 
-    func test_fetchSessions_ordersByUpdatedAtDescending() throws {
+    func test_fetchSessions_ordersByUpdatedAtDescending() async throws {
         let now = Date(timeIntervalSince1970: 1_000_000)
         let older = ChatSessionRecord(title: "Older", updatedAt: now)
         let newer = ChatSessionRecord(title: "Newer", updatedAt: now.addingTimeInterval(60))
         let middle = ChatSessionRecord(title: "Middle", updatedAt: now.addingTimeInterval(30))
 
-        try provider.insertSession(older)
-        try provider.insertSession(newer)
-        try provider.insertSession(middle)
+        try await provider.insertSession(older)
+        try await provider.insertSession(newer)
+        try await provider.insertSession(middle)
 
-        let fetched = try provider.fetchSessions()
+        let fetched = try await provider.fetchSessions()
         XCTAssertEqual(fetched.map(\.title), ["Newer", "Middle", "Older"])
     }
 
-    func test_updateSession_persistsFieldChanges() throws {
+    func test_updateSession_persistsFieldChanges() async throws {
         var record = ChatSessionRecord(title: "Before")
-        try provider.insertSession(record)
+        try await provider.insertSession(record)
 
         record.title = "After"
         record.systemPrompt = "new prompt"
         record.temperature = 0.9
         record.updatedAt = Date()
-        try provider.updateSession(record)
+        try await provider.updateSession(record)
 
-        let fetched = try provider.fetchSessions()
+        let fetched = try await provider.fetchSessions()
         XCTAssertEqual(fetched[0].title, "After")
         XCTAssertEqual(fetched[0].systemPrompt, "new prompt")
         XCTAssertEqual(fetched[0].temperature, 0.9)
     }
 
-    func test_updateSession_throwsWhenSessionMissing() {
+    func test_updateSession_throwsWhenSessionMissing() async throws {
         let record = ChatSessionRecord(title: "Ghost")
-        XCTAssertThrowsError(try provider.updateSession(record)) { error in
+        do {
+            try await provider.updateSession(record)
+            XCTFail("Expected updateSession to throw for missing session")
+        } catch {
             XCTAssertEqual(error as? ChatPersistenceError, .sessionNotFound(record.id))
         }
     }
 
-    func test_deleteSession_removesSessionAndItsMessages() throws {
+    func test_deleteSession_removesSessionAndItsMessages() async throws {
         let session = ChatSessionRecord(title: "To Delete")
-        try provider.insertSession(session)
-        try provider.insertMessage(ChatMessageRecord(role: .user, content: "hi", sessionID: session.id))
-        try provider.insertMessage(ChatMessageRecord(role: .assistant, content: "hello", sessionID: session.id))
+        try await provider.insertSession(session)
+        try await provider.insertMessage(ChatMessageRecord(role: .user, content: "hi", sessionID: session.id))
+        try await provider.insertMessage(ChatMessageRecord(role: .assistant, content: "hello", sessionID: session.id))
 
-        try provider.deleteSession(session.id)
+        try await provider.deleteSession(session.id)
 
-        XCTAssertEqual(try provider.fetchSessions().count, 0)
-        XCTAssertEqual(try provider.fetchMessages(for: session.id).count, 0)
+        let sessions = try await provider.fetchSessions()
+        XCTAssertEqual(sessions.count, 0)
+        let messages = try await provider.fetchMessages(for: session.id)
+        XCTAssertEqual(messages.count, 0)
     }
 
-    func test_deleteSession_throwsWhenSessionMissing() {
+    func test_deleteSession_throwsWhenSessionMissing() async throws {
         let ghost = UUID()
-        XCTAssertThrowsError(try provider.deleteSession(ghost)) { error in
+        do {
+            try await provider.deleteSession(ghost)
+            XCTFail("Expected deleteSession to throw for missing session")
+        } catch {
             XCTAssertEqual(error as? ChatPersistenceError, .sessionNotFound(ghost))
         }
     }
 
     // MARK: - Messages
 
-    func test_insertMessage_roundTripsAllFields() throws {
+    func test_insertMessage_roundTripsAllFields() async throws {
         let session = ChatSessionRecord(title: "Msg Test")
-        try provider.insertSession(session)
+        try await provider.insertSession(session)
         let record = ChatMessageRecord(
             role: .assistant,
             content: "answer",
@@ -134,9 +142,9 @@ final class SwiftDataPersistenceProviderTests: XCTestCase {
             completionTokens: 7
         )
 
-        try provider.insertMessage(record)
+        try await provider.insertMessage(record)
 
-        let fetched = try provider.fetchMessages(for: session.id)
+        let fetched = try await provider.fetchMessages(for: session.id)
         XCTAssertEqual(fetched.count, 1)
         XCTAssertEqual(fetched[0].id, record.id)
         XCTAssertEqual(fetched[0].role, .assistant)
@@ -145,25 +153,25 @@ final class SwiftDataPersistenceProviderTests: XCTestCase {
         XCTAssertEqual(fetched[0].completionTokens, 7)
     }
 
-    func test_fetchMessages_ordersByTimestampAscending() throws {
+    func test_fetchMessages_ordersByTimestampAscending() async throws {
         let session = ChatSessionRecord(title: "Order Test")
-        try provider.insertSession(session)
+        try await provider.insertSession(session)
         let base = Date(timeIntervalSince1970: 1_000)
         // Insert in reverse order to prove the fetch re-sorts.
-        try provider.insertMessage(ChatMessageRecord(role: .user, content: "C", timestamp: base.addingTimeInterval(20), sessionID: session.id))
-        try provider.insertMessage(ChatMessageRecord(role: .user, content: "A", timestamp: base, sessionID: session.id))
-        try provider.insertMessage(ChatMessageRecord(role: .user, content: "B", timestamp: base.addingTimeInterval(10), sessionID: session.id))
+        try await provider.insertMessage(ChatMessageRecord(role: .user, content: "C", timestamp: base.addingTimeInterval(20), sessionID: session.id))
+        try await provider.insertMessage(ChatMessageRecord(role: .user, content: "A", timestamp: base, sessionID: session.id))
+        try await provider.insertMessage(ChatMessageRecord(role: .user, content: "B", timestamp: base.addingTimeInterval(10), sessionID: session.id))
 
-        let fetched = try provider.fetchMessages(for: session.id)
+        let fetched = try await provider.fetchMessages(for: session.id)
         XCTAssertEqual(fetched.map(\.content), ["A", "B", "C"])
     }
 
-    func test_fetchRecentMessages_returnsTailInAscendingOrder() throws {
+    func test_fetchRecentMessages_returnsTailInAscendingOrder() async throws {
         let session = ChatSessionRecord(title: "Recent Test")
-        try provider.insertSession(session)
+        try await provider.insertSession(session)
         let base = Date(timeIntervalSince1970: 1_000)
         for i in 0..<5 {
-            try provider.insertMessage(ChatMessageRecord(
+            try await provider.insertMessage(ChatMessageRecord(
                 role: .user,
                 content: "m\(i)",
                 timestamp: base.addingTimeInterval(Double(i)),
@@ -171,16 +179,16 @@ final class SwiftDataPersistenceProviderTests: XCTestCase {
             ))
         }
 
-        let recent = try provider.fetchRecentMessages(for: session.id, limit: 3)
+        let recent = try await provider.fetchRecentMessages(for: session.id, limit: 3)
         XCTAssertEqual(recent.map(\.content), ["m2", "m3", "m4"])
     }
 
-    func test_fetchMessagesBefore_returnsOlderPageInAscendingOrder() throws {
+    func test_fetchMessagesBefore_returnsOlderPageInAscendingOrder() async throws {
         let session = ChatSessionRecord(title: "Before Test")
-        try provider.insertSession(session)
+        try await provider.insertSession(session)
         let base = Date(timeIntervalSince1970: 1_000)
         for i in 0..<5 {
-            try provider.insertMessage(ChatMessageRecord(
+            try await provider.insertMessage(ChatMessageRecord(
                 role: .user,
                 content: "m\(i)",
                 timestamp: base.addingTimeInterval(Double(i)),
@@ -190,56 +198,63 @@ final class SwiftDataPersistenceProviderTests: XCTestCase {
 
         // Anchor at m3's timestamp — expect m0, m1, m2 in ascending order.
         let cursor = base.addingTimeInterval(3)
-        let older = try provider.fetchMessages(for: session.id, before: cursor, limit: 10)
+        let older = try await provider.fetchMessages(for: session.id, before: cursor, limit: 10)
         XCTAssertEqual(older.map(\.content), ["m0", "m1", "m2"])
     }
 
-    func test_fetchMessagesBefore_returnsEmptyAtOldestCursor() throws {
+    func test_fetchMessagesBefore_returnsEmptyAtOldestCursor() async throws {
         let session = ChatSessionRecord(title: "Empty Before")
-        try provider.insertSession(session)
+        try await provider.insertSession(session)
         let base = Date(timeIntervalSince1970: 1_000)
-        try provider.insertMessage(ChatMessageRecord(role: .user, content: "first", timestamp: base, sessionID: session.id))
+        try await provider.insertMessage(ChatMessageRecord(role: .user, content: "first", timestamp: base, sessionID: session.id))
 
-        let older = try provider.fetchMessages(for: session.id, before: base, limit: 10)
+        let older = try await provider.fetchMessages(for: session.id, before: base, limit: 10)
         XCTAssertTrue(older.isEmpty)
     }
 
-    func test_updateMessage_throwsWhenMissing() {
+    func test_updateMessage_throwsWhenMissing() async throws {
         let ghost = ChatMessageRecord(role: .user, content: "ghost", sessionID: UUID())
-        XCTAssertThrowsError(try provider.updateMessage(ghost)) { error in
+        do {
+            try await provider.updateMessage(ghost)
+            XCTFail("Expected updateMessage to throw for missing message")
+        } catch {
             XCTAssertEqual(error as? ChatPersistenceError, .messageNotFound(ghost.id))
         }
     }
 
-    func test_deleteMessage_throwsWhenMissing() {
+    func test_deleteMessage_throwsWhenMissing() async throws {
         let ghost = UUID()
-        XCTAssertThrowsError(try provider.deleteMessage(ghost)) { error in
+        do {
+            try await provider.deleteMessage(ghost)
+            XCTFail("Expected deleteMessage to throw for missing message")
+        } catch {
             XCTAssertEqual(error as? ChatPersistenceError, .messageNotFound(ghost))
         }
     }
 
     /// The exact bug shape that silently nukes user data: a session-scoped
     /// delete that accidentally matches messages in other sessions.
-    func test_deleteMessages_doesNotCascadeAcrossSessions() throws {
+    func test_deleteMessages_doesNotCascadeAcrossSessions() async throws {
         let sessionA = ChatSessionRecord(title: "A")
         let sessionB = ChatSessionRecord(title: "B")
-        try provider.insertSession(sessionA)
-        try provider.insertSession(sessionB)
-        try provider.insertMessage(ChatMessageRecord(role: .user, content: "A1", sessionID: sessionA.id))
-        try provider.insertMessage(ChatMessageRecord(role: .user, content: "A2", sessionID: sessionA.id))
+        try await provider.insertSession(sessionA)
+        try await provider.insertSession(sessionB)
+        try await provider.insertMessage(ChatMessageRecord(role: .user, content: "A1", sessionID: sessionA.id))
+        try await provider.insertMessage(ChatMessageRecord(role: .user, content: "A2", sessionID: sessionA.id))
         let keptID = UUID()
-        try provider.insertMessage(ChatMessageRecord(id: keptID, role: .user, content: "B1", sessionID: sessionB.id))
+        try await provider.insertMessage(ChatMessageRecord(id: keptID, role: .user, content: "B1", sessionID: sessionB.id))
 
-        try provider.deleteMessages(for: sessionA.id)
+        try await provider.deleteMessages(for: sessionA.id)
 
-        XCTAssertEqual(try provider.fetchMessages(for: sessionA.id).count, 0)
-        let remaining = try provider.fetchMessages(for: sessionB.id)
+        let messagesA = try await provider.fetchMessages(for: sessionA.id)
+        XCTAssertEqual(messagesA.count, 0)
+        let remaining = try await provider.fetchMessages(for: sessionB.id)
         XCTAssertEqual(remaining.map(\.id), [keptID])
     }
 
     // MARK: - pinnedMessageIDs CSV parsing (model-level footgun)
 
-    func test_pinnedMessageIDs_parsesMalformedCSVAsEmpty() throws {
+    func test_pinnedMessageIDs_parsesMalformedCSVAsEmpty() async throws {
         // Bypass the provider to write a raw CSV value that a buggy migration
         // or corrupt store could produce, then verify the model's getter is
         // tolerant — empty set, no crash.
@@ -248,52 +263,52 @@ final class SwiftDataPersistenceProviderTests: XCTestCase {
         context.insert(session)
         try context.save()
 
-        let fetched = try provider.fetchSessions()
+        let fetched = try await provider.fetchSessions()
         XCTAssertEqual(fetched.count, 1)
         XCTAssertEqual(fetched[0].pinnedMessageIDs, [])
     }
 
-    func test_pinnedMessageIDs_parsesTrailingCommaWithoutThrowing() throws {
+    func test_pinnedMessageIDs_parsesTrailingCommaWithoutThrowing() async throws {
         let valid = UUID()
         let session = ChatSession(title: "Trailing Comma")
         session.pinnedMessageIDsRaw = "\(valid.uuidString),"
         context.insert(session)
         try context.save()
 
-        let fetched = try provider.fetchSessions()
+        let fetched = try await provider.fetchSessions()
         XCTAssertEqual(fetched[0].pinnedMessageIDs, [valid])
     }
 
-    func test_pinnedMessageIDs_filtersNonUUIDTokensMixedWithValid() throws {
+    func test_pinnedMessageIDs_filtersNonUUIDTokensMixedWithValid() async throws {
         let valid = UUID()
         let session = ChatSession(title: "Mixed")
         session.pinnedMessageIDsRaw = "garbage,\(valid.uuidString),more-garbage"
         context.insert(session)
         try context.save()
 
-        let fetched = try provider.fetchSessions()
+        let fetched = try await provider.fetchSessions()
         XCTAssertEqual(fetched[0].pinnedMessageIDs, [valid])
     }
 
-    func test_pinnedMessageIDs_emptyStringProducesEmptySet() throws {
+    func test_pinnedMessageIDs_emptyStringProducesEmptySet() async throws {
         let session = ChatSession(title: "Empty Raw")
         session.pinnedMessageIDsRaw = ""
         context.insert(session)
         try context.save()
 
-        let fetched = try provider.fetchSessions()
+        let fetched = try await provider.fetchSessions()
         XCTAssertEqual(fetched[0].pinnedMessageIDs, [])
     }
 
-    func test_pinnedMessageIDs_roundTripsThroughProvider() throws {
+    func test_pinnedMessageIDs_roundTripsThroughProvider() async throws {
         let pin = UUID()
         var record = ChatSessionRecord(title: "Pin", pinnedMessageIDs: [pin])
-        try provider.insertSession(record)
+        try await provider.insertSession(record)
 
         record.pinnedMessageIDs = [pin, UUID()]
-        try provider.updateSession(record)
+        try await provider.updateSession(record)
 
-        let fetched = try provider.fetchSessions()
+        let fetched = try await provider.fetchSessions()
         XCTAssertEqual(fetched[0].pinnedMessageIDs.count, 2)
         XCTAssertTrue(fetched[0].pinnedMessageIDs.contains(pin))
     }

--- a/Tests/BaseChatE2ETests/ChatTurnRoundTripE2ETests.swift
+++ b/Tests/BaseChatE2ETests/ChatTurnRoundTripE2ETests.swift
@@ -40,10 +40,10 @@ struct ChatTurnRoundTripE2ETests {
     // MARK: - Helpers
 
     @discardableResult
-    private func createAndActivateSession(title: String = "Test Chat") throws -> ChatSessionRecord {
-        let session = try sessionManager.createSession(title: title)
+    private func createAndActivateSession(title: String = "Test Chat") async throws -> ChatSessionRecord {
+        let session = try await sessionManager.createSession(title: title)
         sessionManager.activeSession = session
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
         return session
     }
 
@@ -59,7 +59,7 @@ struct ChatTurnRoundTripE2ETests {
 
     @Test("Single turn: user + assistant messages appear with correct content")
     func singleTurnRoundTrip() async throws {
-        let session = try createAndActivateSession()
+        let session = try await createAndActivateSession()
 
         mock.tokensToYield = ["Good", " morning"]
         vm.inputText = "Hello"
@@ -79,7 +79,7 @@ struct ChatTurnRoundTripE2ETests {
 
     @Test("Multi-turn: all 4 messages present and ordered")
     func multiTurnRoundTrip() async throws {
-        let session = try createAndActivateSession()
+        let session = try await createAndActivateSession()
 
         mock.tokensToYield = ["Reply", " one"]
         vm.inputText = "First"
@@ -105,7 +105,7 @@ struct ChatTurnRoundTripE2ETests {
 
     @Test("New session starts empty")
     func newSessionIsEmpty() async throws {
-        try createAndActivateSession(title: "Session A")
+        try await createAndActivateSession(title: "Session A")
 
         mock.tokensToYield = ["Alpha"]
         vm.inputText = "Question"
@@ -113,25 +113,25 @@ struct ChatTurnRoundTripE2ETests {
         #expect(vm.messages.count == 2)
 
         // Switch to a brand-new session
-        try createAndActivateSession(title: "Session B")
+        try await createAndActivateSession(title: "Session B")
 
         #expect(vm.messages.isEmpty, "New session should have no messages")
     }
 
     @Test("Switch back reloads messages from SwiftData")
     func switchBackReloadsMessages() async throws {
-        let sessionA = try createAndActivateSession(title: "Session A")
+        let sessionA = try await createAndActivateSession(title: "Session A")
 
         mock.tokensToYield = ["Alpha", " reply"]
         vm.inputText = "Alpha question"
         await vm.sendMessage()
 
         // Switch to session B
-        try createAndActivateSession(title: "Session B")
+        try await createAndActivateSession(title: "Session B")
         #expect(vm.messages.isEmpty)
 
         // Switch back to session A
-        vm.switchToSession(sessionA)
+        await vm.switchToSession(sessionA)
 
         #expect(vm.messages.count == 2, "Session A messages should reload")
         #expect(vm.messages[0].content == "Alpha question")
@@ -140,7 +140,7 @@ struct ChatTurnRoundTripE2ETests {
 
     @Test("Database persistence: direct ModelContext fetch matches")
     func databasePersistenceVerification() async throws {
-        let session = try createAndActivateSession()
+        let session = try await createAndActivateSession()
 
         mock.tokensToYield = ["Persisted", " response"]
         vm.inputText = "Persist me"

--- a/Tests/BaseChatE2ETests/LoopDetectionE2ETests.swift
+++ b/Tests/BaseChatE2ETests/LoopDetectionE2ETests.swift
@@ -24,7 +24,7 @@ struct LoopDetectionE2ETests {
 
     // MARK: - Helpers
 
-    private func makeVM(backend: MockInferenceBackend) throws -> ChatViewModel {
+    private func makeVM(backend: MockInferenceBackend) async throws -> ChatViewModel {
         backend.isModelLoaded = true
         let service = InferenceService(backend: backend, name: "Mock")
         let persistence = SwiftDataPersistenceProvider(modelContext: context)
@@ -33,9 +33,9 @@ struct LoopDetectionE2ETests {
 
         let sessionManager = SessionManagerViewModel()
         sessionManager.configure(persistence: persistence)
-        let session = try sessionManager.createSession(title: "Test")
+        let session = try await sessionManager.createSession(title: "Test")
         sessionManager.activeSession = session
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
 
         return vm
     }
@@ -47,7 +47,7 @@ struct LoopDetectionE2ETests {
         let repeatedChunk = "The world ended now. "
         let totalChunks = 200
         mock.tokensToYield = Array(repeating: repeatedChunk, count: totalChunks)
-        let vm = try makeVM(backend: mock)
+        let vm = try await makeVM(backend: mock)
 
         vm.inputText = "Hello"
         await vm.sendMessage()
@@ -87,7 +87,7 @@ struct LoopDetectionE2ETests {
         let repeatedChunk = "The world ended now. "
         let totalChunks = 200
         mock.tokensToYield = Array(repeating: repeatedChunk, count: totalChunks)
-        let vm = try makeVM(backend: mock)
+        let vm = try await makeVM(backend: mock)
         vm.loopDetectionEnabled = false
 
         vm.inputText = "Hello"
@@ -111,7 +111,7 @@ struct LoopDetectionE2ETests {
         let mock = MockInferenceBackend()
         let repeatedChunk = "The world ended now. "
         mock.tokensToYield = Array(repeating: repeatedChunk, count: 200)
-        let vm = try makeVM(backend: mock)
+        let vm = try await makeVM(backend: mock)
         let session = try #require(vm.activeSession)
 
         vm.inputText = "Hello"
@@ -121,7 +121,7 @@ struct LoopDetectionE2ETests {
         let partialContent = assistant.content
 
         // Reload the session to verify persistence round-trip.
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
 
         let reloaded = try #require(
             vm.messages.first(where: { $0.role == .assistant }),

--- a/Tests/BaseChatE2ETests/MemoryPressureUnloadE2ETests.swift
+++ b/Tests/BaseChatE2ETests/MemoryPressureUnloadE2ETests.swift
@@ -48,7 +48,7 @@ struct MemoryPressureUnloadE2ETests {
     /// 3. Pressure returns to nominal -> error clears.
     @Test func fullLifecycle_criticalUnloadsThenNominalRecovers() async {
         let handler = MemoryPressureHandler()
-        let (vm, mock, _) = makeViewModel(handler: handler)
+        let (vm, mock, _) = await makeViewModel(handler: handler)
 
         // --- Phase 1: Healthy state ---
         #expect(vm.inferenceService.isModelLoaded,
@@ -107,9 +107,9 @@ struct MemoryPressureUnloadE2ETests {
     // MARK: - Warning Does Not Unload
 
     /// Warning-level pressure should set an advisory error but NOT unload the model.
-    @Test func warningPressure_doesNotUnloadModel() {
+    @Test func warningPressure_doesNotUnloadModel() async {
         let handler = MemoryPressureHandler()
-        let (vm, mock, _) = makeViewModel(handler: handler)
+        let (vm, mock, _) = await makeViewModel(handler: handler)
 
         handler.pressureLevel = .warning
         vm.handleMemoryPressure()
@@ -180,9 +180,9 @@ struct MemoryPressureUnloadE2ETests {
 
     /// Pressure escalating from warning to critical should trigger unload on the
     /// critical transition, not on the initial warning.
-    @Test func escalation_warningThenCritical_unloadsOnCritical() {
+    @Test func escalation_warningThenCritical_unloadsOnCritical() async {
         let handler = MemoryPressureHandler()
-        let (vm, mock, _) = makeViewModel(handler: handler)
+        let (vm, mock, _) = await makeViewModel(handler: handler)
 
         // Step 1: warning -- no unload.
         handler.pressureLevel = .warning
@@ -204,9 +204,9 @@ struct MemoryPressureUnloadE2ETests {
     // MARK: - Repeated Critical Is Idempotent
 
     /// Calling handleMemoryPressure twice at critical level should only unload once.
-    @Test func repeatedCritical_unloadsOnlyOnce() {
+    @Test func repeatedCritical_unloadsOnlyOnce() async {
         let handler = MemoryPressureHandler()
-        let (vm, mock, _) = makeViewModel(handler: handler)
+        let (vm, mock, _) = await makeViewModel(handler: handler)
 
         handler.pressureLevel = .critical
         vm.handleMemoryPressure()
@@ -220,9 +220,9 @@ struct MemoryPressureUnloadE2ETests {
 
     /// The view model's `memoryPressureLevel` computed property should always
     /// reflect the handler's current state.
-    @Test func memoryPressureLevel_reflectsHandler() {
+    @Test func memoryPressureLevel_reflectsHandler() async {
         let handler = MemoryPressureHandler()
-        let (vm, _, _) = makeViewModel(handler: handler)
+        let (vm, _, _) = await makeViewModel(handler: handler)
 
         #expect(vm.memoryPressureLevel == .nominal)
 

--- a/Tests/BaseChatE2ETests/ModelSelectionE2ETests.swift
+++ b/Tests/BaseChatE2ETests/ModelSelectionE2ETests.swift
@@ -54,10 +54,10 @@ final class ModelSelectionE2ETests {
 
     // MARK: - Helpers
 
-    private func makeSession(title: String = "Test") throws -> ChatSessionRecord {
-        let session = try sessionManager.createSession(title: title)
+    private func makeSession(title: String = "Test") async throws -> ChatSessionRecord {
+        let session = try await sessionManager.createSession(title: title)
         sessionManager.activeSession = session
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
         return session
     }
 
@@ -131,7 +131,7 @@ final class ModelSelectionE2ETests {
 
     @Test("After loading, sendMessage generates a response")
     func selectLoadSend_producesResponse() async throws {
-        try makeSession()
+        try await makeSession()
 
         let model = ModelInfo(
             name: "Test GGUF",
@@ -260,7 +260,7 @@ final class ModelSelectionE2ETests {
     // MARK: - Session Persistence
 
     @Test("Selected model ID is persisted to session and restored on switch-back")
-    func sessionRestoresSelectedModel() throws {
+    func sessionRestoresSelectedModel() async throws {
         // Write two distinct GGUFs so each session can have a different model.
         try writeGGUF(named: "model-a.gguf")
         try writeGGUF(named: "model-b.gguf")
@@ -271,25 +271,25 @@ final class ModelSelectionE2ETests {
         let modelB = models[1]
 
         // Session A selects model A.
-        try makeSession(title: "Session A")
+        try await makeSession(title: "Session A")
         vm.selectedModel = modelA
-        try vm.saveSettingsToSession()
+        try await vm.saveSettingsToSession()
 
         // Session B selects model B.
-        let sessionB = try sessionManager.createSession(title: "Session B")
+        let sessionB = try await sessionManager.createSession(title: "Session B")
         sessionManager.activeSession = sessionB
-        vm.switchToSession(sessionB)
+        await vm.switchToSession(sessionB)
         vm.selectedModel = modelB
-        try vm.saveSettingsToSession()
+        try await vm.saveSettingsToSession()
 
         // Reload sessions from persistence so we have fresh records with the
         // saved selectedModelIDs (ChatSessionRecord is a value type).
-        sessionManager.loadSessions()
+        await sessionManager.loadSessions()
         let freshA = try #require(sessionManager.sessions.first { $0.title == "Session A" })
 
         // Switch back to session A using the fresh record — model A should restore.
         sessionManager.activeSession = freshA
-        vm.switchToSession(freshA)
+        await vm.switchToSession(freshA)
         #expect(vm.selectedModel?.id == modelA.id)
 
         // Sabotage: delete model A's file so availableModels drops it,
@@ -298,12 +298,12 @@ final class ModelSelectionE2ETests {
         try FileManager.default.removeItem(at: modelAURL)
         vm.refreshModels()
         let freshA2 = try #require(sessionManager.sessions.first { $0.title == "Session A" })
-        vm.switchToSession(freshA2)
+        await vm.switchToSession(freshA2)
         #expect(vm.selectedModel == nil, "Model not restored when not in availableModels")
     }
 
     @Test("Selected model survives refreshModels rescan (regression: random UUID bug)")
-    func selectedModel_survivesRefreshModels() throws {
+    func selectedModel_survivesRefreshModels() async throws {
         // This is the exact scenario that broke with random UUIDs:
         // select → save → refreshModels() rebuilds the list → selection must persist.
         try writeGGUF(named: "stable-id-test.gguf")
@@ -311,9 +311,9 @@ final class ModelSelectionE2ETests {
 
         let model = try #require(vm.availableModels.first)
         let originalID = model.id
-        try makeSession(title: "Stable ID Session")
+        try await makeSession(title: "Stable ID Session")
         vm.selectedModel = model
-        try vm.saveSettingsToSession()
+        try await vm.saveSettingsToSession()
 
         // refreshModels() re-discovers from disk — IDs must be stable.
         vm.refreshModels()
@@ -322,9 +322,9 @@ final class ModelSelectionE2ETests {
         #expect(vm.selectedModel?.id == originalID, "Model ID must be identical after rescan")
 
         // Also verify the session restore path after a rescan.
-        sessionManager.loadSessions()
+        await sessionManager.loadSessions()
         let freshSession = try #require(sessionManager.sessions.first { $0.title == "Stable ID Session" })
-        vm.switchToSession(freshSession)
+        await vm.switchToSession(freshSession)
         #expect(vm.selectedModel?.id == originalID, "Session restore must find the model after rescan")
     }
 }

--- a/Tests/BaseChatE2ETests/UserJourneyE2ETests.swift
+++ b/Tests/BaseChatE2ETests/UserJourneyE2ETests.swift
@@ -112,15 +112,15 @@ final class UserJourneyE2ETests {
 
         // 4. First session + first message — create a session, activate it,
         //    and send a message. User + assistant messages must persist.
-        let session = try sessionManager.createSession(title: "Day One")
+        let session = try await sessionManager.createSession(title: "Day One")
         sessionManager.activeSession = session
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
 
         // switchToSession resets selectedModel to match the session's
         // selectedModelID, which is still nil for a brand-new session.
         // Re-apply modelA and persist so the session records it.
         vm.selectedModel = modelA
-        try vm.saveSettingsToSession()
+        try await vm.saveSettingsToSession()
 
         backend.tokensToYield = ["Hi", " there"]
         vm.inputText = "Hello"
@@ -206,7 +206,7 @@ final class UserJourneyE2ETests {
         #expect(modelB.id != modelA.id)
 
         vm.selectedModel = modelB
-        try vm.saveSettingsToSession()
+        try await vm.saveSettingsToSession()
         await vm.loadSelectedModel()
         #expect(vm.isModelLoaded)
         #expect(vm.messages.count == 4, "Switching models must not drop conversation history")
@@ -265,13 +265,13 @@ final class UserJourneyE2ETests {
 
         // 9. Session persistence — reload sessions, grab the fresh record,
         //    and verify selectedModelID restored correctly to modelB.
-        sessionManager.loadSessions()
+        await sessionManager.loadSessions()
         let freshSession = try #require(sessionManager.sessions.first { $0.title == "Day One" })
         #expect(freshSession.selectedModelID == modelB.id)
 
         // Switching back through the fresh session record must re-resolve
         // modelB from availableModels (it's still on disk) and reload messages.
-        vm.switchToSession(freshSession)
+        await vm.switchToSession(freshSession)
         #expect(vm.selectedModel?.id == modelB.id)
         // All expected content anchors must round-trip through the reload.
         #expect(
@@ -293,7 +293,7 @@ final class UserJourneyE2ETests {
         // saveSettingsToSession actually reached the store in step 7 — not
         // just the in-memory sessions array that loadSessions() repopulates.
         //
-        // Sabotage verified: removing the `try vm.saveSettingsToSession()` call
+        // Sabotage verified: removing the `try await vm.saveSettingsToSession()` call
         // in step 7 causes the assertion below to fail with
         // `storedSessions.first?.selectedModelID == modelA.id` (or nil) instead
         // of modelB.id, confirming this assertion catches the real persistence

--- a/Tests/BaseChatInferenceTests/ToolApprovalPerfTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolApprovalPerfTests.swift
@@ -12,7 +12,7 @@ import XCTest
 @MainActor
 final class ToolApprovalPerfTests: XCTestCase {
 
-    func testPerf_autoApprove_thousandCalls() {
+    func testPerf_autoApprove_thousandCalls() async {
         let gate = AutoApproveGate()
         // Pre-build the calls outside `measure { }` so the harness only
         // times the gate invocations themselves, not fixture setup. Per

--- a/Tests/BaseChatInferenceTests/ToolApprovalPerfTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolApprovalPerfTests.swift
@@ -12,7 +12,7 @@ import XCTest
 @MainActor
 final class ToolApprovalPerfTests: XCTestCase {
 
-    func testPerf_autoApprove_thousandCalls() async {
+    func testPerf_autoApprove_thousandCalls() {
         let gate = AutoApproveGate()
         // Pre-build the calls outside `measure { }` so the harness only
         // times the gate invocations themselves, not fixture setup. Per

--- a/Tests/BaseChatSnapshotTests/SidebarAndSheetControlTests.swift
+++ b/Tests/BaseChatSnapshotTests/SidebarAndSheetControlTests.swift
@@ -79,12 +79,12 @@ final class SidebarAndSheetControlTests: XCTestCase {
 
     // MARK: - SessionListView: With Sessions
 
-    func test_sessionListView_withSessions_showsSessionRows() throws {
+    func test_sessionListView_withSessions_showsSessionRows() async throws {
         let container = try makeInMemoryContainer()
         let persistence = SwiftDataPersistenceProvider(modelContext: container.mainContext)
         let sessionManager = SessionManagerViewModel()
         sessionManager.configure(persistence: persistence)
-        try sessionManager.createSession(title: "Test Chat Session")
+        try await sessionManager.createSession(title: "Test Chat Session")
 
         let dump = ViewHierarchyDumper.dump(
             SessionListView()
@@ -97,13 +97,13 @@ final class SidebarAndSheetControlTests: XCTestCase {
         )
     }
 
-    func test_sessionListView_withSessions_showsList() throws {
+    func test_sessionListView_withSessions_showsList() async throws {
         let container = try makeInMemoryContainer()
         let persistence = SwiftDataPersistenceProvider(modelContext: container.mainContext)
         let sessionManager = SessionManagerViewModel()
         sessionManager.configure(persistence: persistence)
-        try sessionManager.createSession(title: "Session Alpha")
-        try sessionManager.createSession(title: "Session Beta")
+        try await sessionManager.createSession(title: "Session Alpha")
+        try await sessionManager.createSession(title: "Session Beta")
 
         let dump = ViewHierarchyDumper.dump(
             SessionListView()
@@ -120,12 +120,12 @@ final class SidebarAndSheetControlTests: XCTestCase {
         )
     }
 
-    func test_sessionListView_withSessions_containsSessionRowView() throws {
+    func test_sessionListView_withSessions_containsSessionRowView() async throws {
         let container = try makeInMemoryContainer()
         let persistence = SwiftDataPersistenceProvider(modelContext: container.mainContext)
         let sessionManager = SessionManagerViewModel()
         sessionManager.configure(persistence: persistence)
-        try sessionManager.createSession(title: "Any Session")
+        try await sessionManager.createSession(title: "Any Session")
 
         let dump = ViewHierarchyDumper.dump(
             SessionListView()

--- a/Tests/BaseChatUITests/CancellationTests.swift
+++ b/Tests/BaseChatUITests/CancellationTests.swift
@@ -50,10 +50,10 @@ final class CancellationTests: XCTestCase {
     // MARK: - Helpers
 
     @discardableResult
-    private func createAndActivateSession(title: String = "Test Chat") -> ChatSessionRecord {
-        let session = try! sessionManager.createSession(title: title)
+    private func createAndActivateSession(title: String = "Test Chat") async -> ChatSessionRecord {
+        let session = try! await sessionManager.createSession(title: title)
         sessionManager.activeSession = session
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
         return session
     }
 
@@ -86,7 +86,7 @@ final class CancellationTests: XCTestCase {
     // MARK: - Tests
 
     func test_stopGeneration_midStream_stopsTokenFlow() async throws {
-        createAndActivateSession()
+        await createAndActivateSession()
 
         try await sendAndStopMidStream()
 
@@ -102,7 +102,7 @@ final class CancellationTests: XCTestCase {
     }
 
     func test_stopGeneration_preservesPartialContent() async throws {
-        createAndActivateSession()
+        await createAndActivateSession()
 
         try await sendAndStopMidStream()
 
@@ -115,7 +115,7 @@ final class CancellationTests: XCTestCase {
     }
 
     func test_stopGeneration_thenRegenerate_thenReload_keepsSingleAssistantRow() async throws {
-        let session = createAndActivateSession()
+        let session = await createAndActivateSession()
 
         try await sendAndStopMidStream()
 
@@ -153,7 +153,7 @@ final class CancellationTests: XCTestCase {
             "Persistence should contain exactly one assistant row after regeneration"
         )
 
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
 
         XCTAssertEqual(vm.messages.count, 2, "Reload should restore only the visible user/assistant pair")
         let assistants = vm.messages.filter { $0.role == .assistant }
@@ -162,7 +162,7 @@ final class CancellationTests: XCTestCase {
     }
 
     func test_stopGeneration_thenSendAgain_works() async throws {
-        createAndActivateSession()
+        await createAndActivateSession()
 
         // First message: stop mid-generation
         try await sendAndStopMidStream(input: "First message")
@@ -185,12 +185,12 @@ final class CancellationTests: XCTestCase {
     }
 
     func test_clearChat_duringGeneration_stopsAndClears() async throws {
-        createAndActivateSession()
+        await createAndActivateSession()
 
         vm.inputText = "Hello"
         let sendTask = Task { await vm.sendMessage() }
         await vm.awaitGenerating(true)
-        vm.clearChat()
+        await vm.clearChat()
         await sendTask.value
 
         XCTAssertTrue(vm.messages.isEmpty, "Messages should be empty after clearChat")
@@ -198,7 +198,7 @@ final class CancellationTests: XCTestCase {
     }
 
     func test_unloadModel_duringGeneration_doesNotCrash() async throws {
-        createAndActivateSession()
+        await createAndActivateSession()
 
         slowBackend.tokensToYield = (0..<50).map { "t\($0) " }
         slowBackend.delayPerToken = .milliseconds(30)
@@ -217,7 +217,7 @@ final class CancellationTests: XCTestCase {
     }
 
     func test_switchModel_duringGeneration_doesNotCrash() async throws {
-        createAndActivateSession()
+        await createAndActivateSession()
 
         slowBackend.tokensToYield = (0..<50).map { "t\($0) " }
         slowBackend.delayPerToken = .milliseconds(30)
@@ -235,7 +235,7 @@ final class CancellationTests: XCTestCase {
     }
 
     func test_isGenerating_falseAfterCompletion() async {
-        createAndActivateSession()
+        await createAndActivateSession()
 
         slowBackend.tokensToYield = ["a", "b", "c"]
         slowBackend.delayPerToken = .milliseconds(10)

--- a/Tests/BaseChatUITests/ChatExportIntegrationTests.swift
+++ b/Tests/BaseChatUITests/ChatExportIntegrationTests.swift
@@ -51,10 +51,10 @@ final class ChatExportIntegrationTests: XCTestCase {
     private func createAndActivateSession(
         vm: ChatViewModel,
         title: String = "Test Chat"
-    ) throws -> ChatSessionRecord {
-        let session = try sessionManager.createSession(title: title)
+    ) async throws -> ChatSessionRecord {
+        let session = try await sessionManager.createSession(title: title)
         sessionManager.activeSession = session
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
         return session
     }
 
@@ -62,8 +62,8 @@ final class ChatExportIntegrationTests: XCTestCase {
 
     func test_multiTurnConversation_markdownExport_containsAllTurns() async throws {
         let backend = makeMockBackend(tokens: ["Hello", " there!"])
-        let vm = makeViewModel(backend: backend)
-        try createAndActivateSession(vm: vm, title: "Story Time")
+        let vm = await makeViewModel(backend: backend)
+        try await createAndActivateSession(vm: vm, title: "Story Time")
 
         // Turn 1
         vm.inputText = "Hi"
@@ -109,8 +109,8 @@ final class ChatExportIntegrationTests: XCTestCase {
 
     func test_multiTurnConversation_plaintextExport_containsAllTurns() async throws {
         let backend = makeMockBackend(tokens: ["I'm", " fine."])
-        let vm = makeViewModel(backend: backend)
-        try createAndActivateSession(vm: vm, title: "Casual Chat")
+        let vm = await makeViewModel(backend: backend)
+        try await createAndActivateSession(vm: vm, title: "Casual Chat")
 
         // Turn 1
         vm.inputText = "How are you?"
@@ -145,8 +145,8 @@ final class ChatExportIntegrationTests: XCTestCase {
 
     func test_export_sessionTitle_appearsInBothFormats() async throws {
         let backend = makeMockBackend(tokens: ["Noted."])
-        let vm = makeViewModel(backend: backend)
-        try createAndActivateSession(vm: vm, title: "Important Discussion")
+        let vm = await makeViewModel(backend: backend)
+        try await createAndActivateSession(vm: vm, title: "Important Discussion")
 
         vm.inputText = "Remember this"
         await vm.sendMessage()
@@ -170,10 +170,10 @@ final class ChatExportIntegrationTests: XCTestCase {
 
     // MARK: - Empty conversation export
 
-    func test_emptyConversation_exportsHeaderOnly() throws {
+    func test_emptyConversation_exportsHeaderOnly() async throws {
         let backend = makeMockBackend(tokens: [])
-        let vm = makeViewModel(backend: backend)
-        try createAndActivateSession(vm: vm, title: "Empty Session")
+        let vm = await makeViewModel(backend: backend)
+        try await createAndActivateSession(vm: vm, title: "Empty Session")
 
         // No messages sent
         let markdown = ChatExportService.export(

--- a/Tests/BaseChatUITests/ChatInputBarLogicTests.swift
+++ b/Tests/BaseChatUITests/ChatInputBarLogicTests.swift
@@ -46,15 +46,15 @@ final class ChatInputBarLogicTests: XCTestCase {
         && !vm.inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
-    func test_canSend_falseWhenNoActiveSession() {
-        let vm = makeViewModel()
+    func test_canSend_falseWhenNoActiveSession() async {
+        let vm = await makeViewModel()
         vm.inputText = "Hello"
         // No session, no model
         XCTAssertFalse(canSend(vm), "canSend should be false without an active session")
     }
 
-    func test_canSend_falseWhenNoModelLoaded() {
-        let vm = makeViewModel()
+    func test_canSend_falseWhenNoModelLoaded() async {
+        let vm = await makeViewModel()
         vm.activeSession = ChatSessionRecord(title: "Test")
         vm.inputText = "Hello"
         XCTAssertFalse(vm.isModelLoaded, "Precondition: no model loaded")
@@ -103,13 +103,13 @@ final class ChatInputBarLogicTests: XCTestCase {
         vm.activeSession == nil || !vm.isModelLoaded || vm.isLoading
     }
 
-    func test_textFieldDisabled_whenNoSession() {
-        let vm = makeViewModel()
+    func test_textFieldDisabled_whenNoSession() async {
+        let vm = await makeViewModel()
         XCTAssertTrue(isTextFieldDisabled(vm), "Text field should be disabled without a session")
     }
 
-    func test_textFieldDisabled_whenNoModel() {
-        let vm = makeViewModel()
+    func test_textFieldDisabled_whenNoModel() async {
+        let vm = await makeViewModel()
         vm.activeSession = ChatSessionRecord(title: "Test")
         XCTAssertTrue(isTextFieldDisabled(vm), "Text field should be disabled without a loaded model")
     }
@@ -179,8 +179,8 @@ final class ChatInputBarLogicTests: XCTestCase {
         vm.activeSession == nil || !vm.isModelLoaded || vm.isGenerating || vm.isLoading
     }
 
-    func test_quickActionDisabled_whenNoSession() {
-        let vm = makeViewModel()
+    func test_quickActionDisabled_whenNoSession() async {
+        let vm = await makeViewModel()
         XCTAssertTrue(isQuickActionDisabled(vm), "Quick actions should be disabled without a session")
     }
 

--- a/Tests/BaseChatUITests/ChatViewModelCacheLifecycleTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelCacheLifecycleTests.swift
@@ -33,7 +33,7 @@ final class ChatViewModelCacheLifecycleTests: XCTestCase {
     private func makeViewModel(
         handler: MemoryPressureHandler = MemoryPressureHandler(),
         mock: MockInferenceBackend = MockInferenceBackend()
-    ) -> (ChatViewModel, MockInferenceBackend, MemoryPressureHandler) {
+    ) async -> (ChatViewModel, MockInferenceBackend, MemoryPressureHandler) {
         mock.isModelLoaded = true
         let service = InferenceService(backend: mock, name: "CacheLifecycleMock")
         let vm = ChatViewModel(
@@ -46,7 +46,7 @@ final class ChatViewModelCacheLifecycleTests: XCTestCase {
         let session = ChatSession(title: "Cache Lifecycle")
         context.insert(session)
         try? context.save()
-        vm.switchToSession(session.toRecord())
+        await vm.switchToSession(session.toRecord())
         return (vm, mock, handler)
     }
 
@@ -56,7 +56,7 @@ final class ChatViewModelCacheLifecycleTests: XCTestCase {
     /// counts computed with the old tokenizer are not returned after a later
     /// model swap picks up the same message UUIDs.
     func test_unloadModel_clearsTokenCountCache() async {
-        let (vm, _, _) = makeViewModel()
+        let (vm, _, _) = await makeViewModel()
 
         // Populate the cache by sending a message.
         vm.inputText = "Cache population"
@@ -77,7 +77,7 @@ final class ChatViewModelCacheLifecycleTests: XCTestCase {
     /// also clear the cache, not just manual unloads.
     func test_memoryPressureCritical_clearsTokenCountCache() async {
         let handler = MemoryPressureHandler()
-        let (vm, _, _) = makeViewModel(handler: handler)
+        let (vm, _, _) = await makeViewModel(handler: handler)
 
         vm.inputText = "Memory pressure cache test"
         await vm.sendMessage()
@@ -99,7 +99,7 @@ final class ChatViewModelCacheLifecycleTests: XCTestCase {
     /// token count for that UUID must be dropped so the next
     /// `updateContextEstimate()` recomputes for the new content.
     func test_editMessage_invalidatesTokenCacheEntry() async {
-        let (vm, mock, _) = makeViewModel()
+        let (vm, mock, _) = await makeViewModel()
 
         // Send a user message and wait for the assistant reply.
         mock.tokensToYield = ["Hi"]

--- a/Tests/BaseChatUITests/ChatViewModelIngestPendingPayloadTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelIngestPendingPayloadTests.swift
@@ -134,8 +134,8 @@ final class ChatViewModelIngestPendingPayloadTests: XCTestCase {
     func test_urlPayload_appendToActive_appendsURLStringToDraft() async {
         // Seed a session and an existing draft.
         let session = ChatSessionRecord(title: "Existing")
-        try? vm.persistence?.insertSession(session)
-        vm.switchToSession(session)
+        try? await vm.persistence?.insertSession(session)
+        await vm.switchToSession(session)
         vm.inputText = "look at this"
 
         let url = URL(string: "https://example.com/article")!
@@ -152,8 +152,8 @@ final class ChatViewModelIngestPendingPayloadTests: XCTestCase {
 
     func test_urlPayload_appendToActive_emptyDraft_replacesWithURLString() async {
         let session = ChatSessionRecord(title: "Existing")
-        try? vm.persistence?.insertSession(session)
-        vm.switchToSession(session)
+        try? await vm.persistence?.insertSession(session)
+        await vm.switchToSession(session)
         vm.inputText = ""
 
         let url = URL(string: "https://example.com/article")!
@@ -166,8 +166,8 @@ final class ChatViewModelIngestPendingPayloadTests: XCTestCase {
 
     func test_imagePayload_draft_setsEmptyDraftWithoutSending() async {
         let session = ChatSessionRecord(title: "Existing")
-        try? vm.persistence?.insertSession(session)
-        vm.switchToSession(session)
+        try? await vm.persistence?.insertSession(session)
+        await vm.switchToSession(session)
         vm.inputText = "should be replaced"
 
         let imageData = Data([0x89, 0x50, 0x4E, 0x47]) // PNG magic bytes

--- a/Tests/BaseChatUITests/ChatViewModelIntegrationTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelIntegrationTests.swift
@@ -54,10 +54,10 @@ final class ChatViewModelIntegrationTests: XCTestCase {
 
     /// Creates a session, activates it, and returns it.
     @discardableResult
-    private func createAndActivateSession(title: String = "Test Chat") -> ChatSessionRecord {
-        let session = try! sessionManager.createSession(title: title)
+    private func createAndActivateSession(title: String = "Test Chat") async -> ChatSessionRecord {
+        let session = try! await sessionManager.createSession(title: title)
         sessionManager.activeSession = session
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
         return session
     }
 
@@ -81,7 +81,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
     // MARK: - Full Send → Persist Flow
 
     func test_sendMessage_persistsUserAndAssistantToDatabase() async {
-        let session = createAndActivateSession()
+        let session = await createAndActivateSession()
 
         vm.inputText = "What is Swift?"
         await vm.sendMessage()
@@ -104,11 +104,11 @@ final class ChatViewModelIntegrationTests: XCTestCase {
 
     func test_sendMessage_persistsSessionUpdatedAt() async throws {
         let provider = SwiftDataPersistenceProvider(modelContext: context)
-        var session = createAndActivateSession()
+        var session = await createAndActivateSession()
         let originalUpdatedAt = Date(timeIntervalSince1970: 1)
         session.updatedAt = originalUpdatedAt
-        try provider.updateSession(session)
-        vm.switchToSession(session)
+        try await provider.updateSession(session)
+        await vm.switchToSession(session)
 
         vm.inputText = "Update the timestamp"
         await vm.sendMessage()
@@ -124,7 +124,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
     // MARK: - Multi-Turn Conversation Persistence
 
     func test_multiTurnConversation_allMessagesPersisted() async {
-        let session = createAndActivateSession()
+        let session = await createAndActivateSession()
 
         // Turn 1
         mock.tokensToYield = ["Reply", " one"]
@@ -158,7 +158,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
 
     func test_switchSession_reloadsMessagesFromDatabase() async {
         // Create session A with messages
-        let sessionA = createAndActivateSession(title: "Session A")
+        let sessionA = await createAndActivateSession(title: "Session A")
         mock.tokensToYield = ["Alpha", " reply"]
         vm.inputText = "Alpha question"
         await vm.sendMessage()
@@ -166,7 +166,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
         XCTAssertEqual(vm.messages.count, 2)
 
         // Create session B with different messages
-        let sessionB = createAndActivateSession(title: "Session B")
+        let sessionB = await createAndActivateSession(title: "Session B")
         mock.tokensToYield = ["Beta", " reply"]
         vm.inputText = "Beta question"
         await vm.sendMessage()
@@ -175,14 +175,14 @@ final class ChatViewModelIntegrationTests: XCTestCase {
         XCTAssertEqual(vm.messages[0].content, "Beta question")
 
         // Switch back to session A — messages should reload from database
-        vm.switchToSession(sessionA)
+        await vm.switchToSession(sessionA)
 
         XCTAssertEqual(vm.messages.count, 2, "Session A should have 2 messages")
         XCTAssertEqual(vm.messages[0].content, "Alpha question", "Should reload session A's messages")
         XCTAssertEqual(vm.messages[1].content, "Alpha reply")
 
         // Switch to session B — verify its messages
-        vm.switchToSession(sessionB)
+        await vm.switchToSession(sessionB)
 
         XCTAssertEqual(vm.messages.count, 2, "Session B should have 2 messages")
         XCTAssertEqual(vm.messages[0].content, "Beta question", "Should reload session B's messages")
@@ -191,7 +191,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
     // MARK: - Clear Chat Deletes from Database
 
     func test_clearChat_deletesMessagesFromDatabase() async {
-        let session = createAndActivateSession()
+        let session = await createAndActivateSession()
 
         mock.tokensToYield = ["Reply"]
         vm.inputText = "Message 1"
@@ -202,7 +202,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
         let beforeCount = fetchMessages(for: session.id).count
         XCTAssertEqual(beforeCount, 4, "Should have 4 messages before clearing")
 
-        vm.clearChat()
+        await vm.clearChat()
 
         // Verify in-memory
         XCTAssertTrue(vm.messages.isEmpty)
@@ -215,7 +215,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
     // MARK: - Regenerate Persists New Response
 
     func test_regenerate_deletesOldAndPersistsNewResponse() async {
-        let session = createAndActivateSession()
+        let session = await createAndActivateSession()
 
         mock.tokensToYield = ["Original", " response"]
         vm.inputText = "Question"
@@ -240,7 +240,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
     // MARK: - Edit Message Persists Changes
 
     func test_editMessage_updatesAndRegeneratesInDatabase() async {
-        let session = createAndActivateSession()
+        let session = await createAndActivateSession()
 
         mock.tokensToYield = ["Original", " reply"]
         vm.inputText = "Original question"
@@ -261,14 +261,14 @@ final class ChatViewModelIntegrationTests: XCTestCase {
     // MARK: - Session Settings Persistence
 
     func test_saveSettingsToSession_persistsToDatabase() async {
-        let session = createAndActivateSession()
+        let session = await createAndActivateSession()
 
         vm.temperature = 1.5
         vm.topP = 0.8
         vm.repeatPenalty = 1.3
         vm.systemPrompt = "You are a pirate."
         vm.selectedPromptTemplate = .llama3
-        try! vm.saveSettingsToSession()
+        try! await vm.saveSettingsToSession()
 
         // Fetch session from database and verify
         let dbSessions = fetchSessions()
@@ -287,36 +287,36 @@ final class ChatViewModelIntegrationTests: XCTestCase {
         let defaultPromptTemplate = vm.selectedPromptTemplate
 
         // Session A with custom settings
-        createAndActivateSession(title: "Session A")
+        await createAndActivateSession(title: "Session A")
         vm.temperature = 0.3
         vm.systemPrompt = "Be concise."
         vm.selectedPromptTemplate = .llama3
-        try! vm.saveSettingsToSession()
+        try! await vm.saveSettingsToSession()
         let sessionA = vm.activeSession!
 
         // Session B with different settings
-        createAndActivateSession(title: "Session B")
+        await createAndActivateSession(title: "Session B")
         vm.temperature = 1.8
         vm.systemPrompt = "Be verbose."
         vm.selectedPromptTemplate = .mistral
-        try! vm.saveSettingsToSession()
+        try! await vm.saveSettingsToSession()
         let sessionB = vm.activeSession!
 
         // Switch to A — settings should restore
-        vm.switchToSession(sessionA)
+        await vm.switchToSession(sessionA)
         XCTAssertEqual(vm.temperature, 0.3, "Temperature should restore from session A")
         XCTAssertEqual(vm.systemPrompt, "Be concise.", "System prompt should restore from session A")
         XCTAssertEqual(vm.selectedPromptTemplate, .llama3, "Prompt template should restore from session A")
 
         // Switch to B — settings should restore
-        vm.switchToSession(sessionB)
+        await vm.switchToSession(sessionB)
         XCTAssertEqual(vm.temperature, 1.8, "Temperature should restore from session B")
         XCTAssertEqual(vm.systemPrompt, "Be verbose.", "System prompt should restore from session B")
         XCTAssertEqual(vm.selectedPromptTemplate, .mistral, "Prompt template should restore from session B")
 
         // Session C keeps the default template when it has never saved an override.
-        let sessionC = createAndActivateSession(title: "Session C")
-        vm.switchToSession(sessionC)
+        let sessionC = await createAndActivateSession(title: "Session C")
+        await vm.switchToSession(sessionC)
         XCTAssertEqual(
             vm.selectedPromptTemplate,
             defaultPromptTemplate,
@@ -331,7 +331,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
     /// The check fetches ALL `ChatMessage` rows (not scoped by session) to
     /// catch any phantom insert that might slip through.
     func test_emptyResponse_neverPersistedToDatabase() async {
-        let session = createAndActivateSession()
+        let session = await createAndActivateSession()
 
         mock.tokensToYield = []  // Empty stream — no tokens
         vm.inputText = "Anything"
@@ -359,7 +359,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
     // MARK: - Empty Generation Removes Placeholder
 
     func test_emptyGeneration_doesNotPersistPlaceholder() async {
-        let session = createAndActivateSession()
+        let session = await createAndActivateSession()
 
         mock.tokensToYield = []  // Empty — no tokens yielded
         vm.inputText = "Question"
@@ -378,7 +378,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
     // MARK: - Generation Error Does Not Corrupt Database
 
     func test_generationError_userMessageStillPersisted() async {
-        let session = createAndActivateSession()
+        let session = await createAndActivateSession()
 
         mock.shouldThrowOnGenerate = InferenceError.inferenceFailure("Simulated failure")
         vm.inputText = "Question before error"
@@ -395,7 +395,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
     // MARK: - Context Estimation Updates After Messages
 
     func test_contextEstimate_updatesAfterSendAndClear() async {
-        createAndActivateSession()
+        await createAndActivateSession()
 
         let baselineTokens = vm.contextUsedTokens
 
@@ -405,28 +405,28 @@ final class ChatViewModelIntegrationTests: XCTestCase {
 
         XCTAssertGreaterThan(vm.contextUsedTokens, baselineTokens, "Tokens should increase after sending")
 
-        vm.clearChat()
+        await vm.clearChat()
 
         XCTAssertEqual(vm.contextUsedTokens, baselineTokens, "Tokens should return to baseline after clearing")
     }
 
     // MARK: - Session Creation Through Manager
 
-    func test_sessionManager_createAndDelete_persistsCorrectly() throws {
+    func test_sessionManager_createAndDelete_persistsCorrectly() async throws {
         XCTAssertTrue(fetchSessions().isEmpty, "Should start with no sessions")
 
-        let session = try! sessionManager.createSession(title: "My Chat")
+        let session = try! await sessionManager.createSession(title: "My Chat")
         XCTAssertEqual(fetchSessions().count, 1)
         XCTAssertEqual(fetchSessions().first?.title, "My Chat")
 
-        try sessionManager.deleteSession(session)
+        try await sessionManager.deleteSession(session)
         XCTAssertTrue(fetchSessions().isEmpty, "Session should be deleted from database")
     }
 
     // MARK: - Delete Session Cascades to Messages
 
     func test_deleteSession_removesAllSessionMessages() async throws {
-        let session = createAndActivateSession()
+        let session = await createAndActivateSession()
 
         mock.tokensToYield = ["Reply"]
         vm.inputText = "Msg 1"
@@ -436,7 +436,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
 
         XCTAssertEqual(fetchMessages(for: session.id).count, 4)
 
-        try sessionManager.deleteSession(session)
+        try await sessionManager.deleteSession(session)
 
         XCTAssertEqual(fetchMessages(for: session.id).count, 0,
                        "All messages should be deleted when session is deleted")
@@ -445,20 +445,20 @@ final class ChatViewModelIntegrationTests: XCTestCase {
     // MARK: - Auto-Title Generation
 
     func test_autoTitle_setsSessionTitleFromFirstMessage() async {
-        let session = createAndActivateSession()
+        let session = await createAndActivateSession()
 
         // Wire up the onFirstMessage callback like the real app does
         vm.onFirstMessage = { [weak self] session, firstMessage in
-            self?.sessionManager.autoGenerateTitle(for: session, firstMessage: firstMessage)
+            await self?.sessionManager.autoGenerateTitle(for: session, firstMessage: firstMessage)
         }
 
         XCTAssertEqual(session.title, "Test Chat")
 
         // The session title is "Test Chat", not "New Chat", so autoGenerateTitle won't fire.
         // Create a fresh session with default title to test auto-title.
-        let newSession = try! sessionManager.createSession()  // Default title: "New Chat"
+        let newSession = try! await sessionManager.createSession()  // Default title: "New Chat"
         sessionManager.activeSession = newSession
-        vm.switchToSession(newSession)
+        await vm.switchToSession(newSession)
 
         mock.tokensToYield = ["Reply"]
         vm.inputText = "What is the meaning of life?"
@@ -474,7 +474,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
     // MARK: - Export After Persistence
 
     func test_exportChat_includesPersistedMessages() async {
-        createAndActivateSession(title: "Export Test")
+        await createAndActivateSession(title: "Export Test")
 
         mock.tokensToYield = ["The", " answer"]
         vm.inputText = "Tell me something"
@@ -489,7 +489,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
     // MARK: - Save State Persists Pending Changes
 
     func test_saveState_flushesPendingChanges() async {
-        createAndActivateSession()
+        await createAndActivateSession()
 
         mock.tokensToYield = ["Reply"]
         vm.inputText = "Question"
@@ -497,9 +497,9 @@ final class ChatViewModelIntegrationTests: XCTestCase {
 
         // Modify session settings and save
         vm.temperature = 0.1
-        try! vm.saveSettingsToSession()
+        try! await vm.saveSettingsToSession()
 
-        vm.saveState()
+        await vm.saveState()
 
         XCTAssertEqual(vm.activeSession?.temperature, 0.1, "saveState should flush pending changes")
     }

--- a/Tests/BaseChatUITests/ChatViewModelIntentDispatchTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelIntentDispatchTests.swift
@@ -10,7 +10,7 @@ final class ChatViewModelIntentDispatchTests: XCTestCase {
     // MARK: - Forwarding
 
     func test_dispatch_forwardsActionAndSessionID_toHandler() async throws {
-        let vm = makeViewModel()
+        let vm = await makeViewModel()
         let handler = MockChatSessionIntentHandler()
         vm.intentHandler = handler
 
@@ -25,7 +25,7 @@ final class ChatViewModelIntentDispatchTests: XCTestCase {
     }
 
     func test_dispatch_forwardsNilSessionID_whenNoActiveSession() async throws {
-        let vm = makeViewModel()
+        let vm = await makeViewModel()
         let handler = MockChatSessionIntentHandler()
         vm.intentHandler = handler
 
@@ -39,7 +39,7 @@ final class ChatViewModelIntentDispatchTests: XCTestCase {
     }
 
     func test_dispatch_forwardsEveryActionVerbatim() async throws {
-        let vm = makeViewModel()
+        let vm = await makeViewModel()
         let handler = MockChatSessionIntentHandler()
         vm.intentHandler = handler
 
@@ -59,7 +59,7 @@ final class ChatViewModelIntentDispatchTests: XCTestCase {
     // MARK: - No-op when handler is absent
 
     func test_dispatch_isNoOp_whenHandlerIsNil() async throws {
-        let vm = makeViewModel()
+        let vm = await makeViewModel()
         XCTAssertNil(vm.intentHandler)
 
         // Must not throw and must complete without observable effect.
@@ -70,7 +70,7 @@ final class ChatViewModelIntentDispatchTests: XCTestCase {
     // MARK: - Error propagation
 
     func test_dispatch_propagatesErrorFromHandler() async {
-        let vm = makeViewModel()
+        let vm = await makeViewModel()
         let handler = MockChatSessionIntentHandler()
         handler.errorToThrow = TestError.boom
         vm.intentHandler = handler

--- a/Tests/BaseChatUITests/ChatViewModelLoadPlanWiringTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelLoadPlanWiringTests.swift
@@ -65,7 +65,7 @@ final class ChatViewModelLoadPlanWiringTests: XCTestCase {
             availableMemoryBytes: { 32 * oneGB },
             physicalMemoryBytes: 32 * oneGB
         )
-        let (vm, backend) = makeViewModel(
+        let (vm, backend) = await makeViewModel(
             physicalMemory: 1 * oneGB,  // tiny — canLoadModel would reject
             planEnvironment: env
         )
@@ -88,7 +88,7 @@ final class ChatViewModelLoadPlanWiringTests: XCTestCase {
             availableMemoryBytes: { 128 * 1024 * 1024 },  // 128 MB available
             physicalMemoryBytes: 8 * oneGB
         )
-        let (vm, backend) = makeViewModel(
+        let (vm, backend) = await makeViewModel(
             physicalMemory: 8 * oneGB,
             planEnvironment: env
         )
@@ -118,7 +118,7 @@ final class ChatViewModelLoadPlanWiringTests: XCTestCase {
             availableMemoryBytes: { 32 * oneGB },
             physicalMemoryBytes: 32 * oneGB
         )
-        let (vm, backend) = makeViewModel(
+        let (vm, backend) = await makeViewModel(
             physicalMemory: 32 * oneGB,
             planEnvironment: env
         )
@@ -152,7 +152,7 @@ final class ChatViewModelLoadPlanWiringTests: XCTestCase {
             availableMemoryBytes: { 1 },  // hostile: 1 byte available
             physicalMemoryBytes: 1
         )
-        let (vm, backend) = makeViewModel(
+        let (vm, backend) = await makeViewModel(
             modelType: .foundation,
             physicalMemory: 1,
             planEnvironment: env

--- a/Tests/BaseChatUITests/ChatViewModelLoopDetectionTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelLoopDetectionTests.swift
@@ -29,7 +29,7 @@ final class ChatViewModelLoopDetectionTests: XCTestCase {
         // 20-char chunk repeated 30 times = 600 chars, well above thresholds
         let repeatedChunk = "The world ended now. "
         mock.tokensToYield = Array(repeating: repeatedChunk, count: 30)
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
 
         vm.inputText = "Hello"
         await vm.sendMessage()
@@ -47,7 +47,7 @@ final class ChatViewModelLoopDetectionTests: XCTestCase {
         let mock = MockInferenceBackend()
         let repeatedChunk = "The world ended now. "
         mock.tokensToYield = Array(repeating: repeatedChunk, count: 30)
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
         vm.loopDetectionEnabled = false
 
         vm.inputText = "Hello"
@@ -97,7 +97,7 @@ final class ChatViewModelLoopDetectionTests: XCTestCase {
             "The ", "quick ", "brown ", "fox ", "jumps ", "over ",
             "the ", "lazy ", "dog. ", "A ", "wonderful ", "sentence."
         ]
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
 
         vm.inputText = "Hello"
         await vm.sendMessage()

--- a/Tests/BaseChatUITests/ChatViewModelSystemPromptContextTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelSystemPromptContextTests.swift
@@ -27,7 +27,7 @@ final class ChatViewModelSystemPromptContextTests: XCTestCase {
     func test_systemPromptContext_substitutesTokens_beforeReachingBackend() async {
         let mock = MockInferenceBackend()
         mock.tokensToYield = ["ok"]
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
         vm.systemPrompt = "The assistant greets {{name}}."
         vm.systemPromptContext = ["name": "Alice"]
 
@@ -46,7 +46,7 @@ final class ChatViewModelSystemPromptContextTests: XCTestCase {
     func test_systemPromptContext_emptyDict_leavesPromptUnchanged() async {
         let mock = MockInferenceBackend()
         mock.tokensToYield = ["ok"]
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
         vm.systemPrompt = "Hello {{name}}."
         vm.systemPromptContext = [:]
 
@@ -65,7 +65,7 @@ final class ChatViewModelSystemPromptContextTests: XCTestCase {
     func test_systemPromptContext_missingKey_leavesTokenVerbatim() async {
         let mock = MockInferenceBackend()
         mock.tokensToYield = ["ok"]
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
         vm.systemPrompt = "Hello {{name}}, your role is {{role}}."
         vm.systemPromptContext = ["name": "Alice"] // role is intentionally absent
 
@@ -84,7 +84,7 @@ final class ChatViewModelSystemPromptContextTests: XCTestCase {
     func test_systemPromptContext_replacesAllOccurrencesOfSameToken() async {
         let mock = MockInferenceBackend()
         mock.tokensToYield = ["ok"]
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
         vm.systemPrompt = "{{name}} likes {{name}}'s coffee. {{name}} drinks it daily."
         vm.systemPromptContext = ["name": "Alice"]
 
@@ -103,7 +103,7 @@ final class ChatViewModelSystemPromptContextTests: XCTestCase {
     func test_systemPromptContext_doesNotRecursivelyExpandValues() async {
         let mock = MockInferenceBackend()
         mock.tokensToYield = ["ok"]
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
         vm.systemPrompt = "Hello {{first}}."
         // If substitution were recursive, "{{first}}" would expand to
         // "{{second}}" then to "Bob". Since we guarantee non-recursion, the
@@ -125,7 +125,7 @@ final class ChatViewModelSystemPromptContextTests: XCTestCase {
     func test_systemPromptContext_emptyStringValue_substitutesAsEmpty() async {
         let mock = MockInferenceBackend()
         mock.tokensToYield = ["ok"]
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
         vm.systemPrompt = "Persona: {{persona}}|end"
         vm.systemPromptContext = ["persona": ""]
 
@@ -189,7 +189,7 @@ final class ChatViewModelSystemPromptContextTests: XCTestCase {
     func test_systemPromptContext_mutationBetweenSends_appliesToSecondPrompt() async {
         let mock = MockInferenceBackend()
         mock.tokensToYield = ["ok", "ok"]
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
         vm.systemPrompt = "Talking to {{name}}."
         vm.systemPromptContext = ["name": "Alice"]
 

--- a/Tests/BaseChatUITests/ConcurrencyTests.swift
+++ b/Tests/BaseChatUITests/ConcurrencyTests.swift
@@ -53,10 +53,10 @@ final class ConcurrencyTests: XCTestCase {
     // MARK: - Helpers
 
     @discardableResult
-    private func createAndActivateSession(title: String = "Test Chat") -> ChatSessionRecord {
-        let session = try! sessionManager.createSession(title: title)
+    private func createAndActivateSession(title: String = "Test Chat") async -> ChatSessionRecord {
+        let session = try! await sessionManager.createSession(title: title)
         sessionManager.activeSession = session
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
         return session
     }
 
@@ -80,7 +80,7 @@ final class ConcurrencyTests: XCTestCase {
     /// Fire-and-forget 5 messages rapidly. Verify no crash, messages are non-empty,
     /// and isGenerating eventually becomes false.
     func test_rapidSendMessages_doesNotCrash() async throws {
-        createAndActivateSession()
+        await createAndActivateSession()
 
         // Fire 5 sends as concurrent tasks without awaiting each one.
         var tasks: [Task<Void, Never>] = []
@@ -117,7 +117,7 @@ final class ConcurrencyTests: XCTestCase {
     /// verifies that the resulting four messages — user₁, assistant₁, user₂,
     /// assistant₂ — have monotonically non-decreasing timestamps.
     func test_messages_maintainChronologicalOrder() async {
-        createAndActivateSession()
+        await createAndActivateSession()
 
         // Use a fast backend so message timestamps are as tight as possible.
         slowBackend.tokensToYield = ["reply"]
@@ -158,7 +158,7 @@ final class ConcurrencyTests: XCTestCase {
     /// still generating. sendMessage() does NOT guard against isGenerating, so the
     /// second send should also proceed and produce messages.
     func test_sendWhileGenerating_secondSendProceeds() async throws {
-        createAndActivateSession()
+        await createAndActivateSession()
 
         // 5 tokens is enough to keep the stream in-flight while the second send
         // races — the test asserts concurrency behavior, not token count.
@@ -199,12 +199,12 @@ final class ConcurrencyTests: XCTestCase {
     /// leak into session B's view.
     func test_switchSession_duringGeneration_noCorruption() async throws {
         // Set up session A.
-        let sessionA = createAndActivateSession(title: "Session A")
+        let sessionA = await createAndActivateSession(title: "Session A")
         slowBackend.tokensToYield = (0..<20).map { "alphaToken\($0) " }
         slowBackend.delayPerToken = .milliseconds(50)
 
         // Pre-populate session B with a known message using a fast backend.
-        let sessionB = try! sessionManager.createSession(title: "Session B")
+        let sessionB = try! await sessionManager.createSession(title: "Session B")
 
         // Start generation on session A.
         vm.inputText = "Alpha question"
@@ -217,7 +217,7 @@ final class ConcurrencyTests: XCTestCase {
 
         // Switch to session B mid-generation.
         sessionManager.activeSession = sessionB
-        vm.switchToSession(sessionB)
+        await vm.switchToSession(sessionB)
 
         // Session B should have no messages (it was freshly created).
         XCTAssertTrue(vm.messages.isEmpty,
@@ -253,7 +253,7 @@ final class ConcurrencyTests: XCTestCase {
 
         for i in 0..<10 {
             let task = Task { @MainActor in
-                _ = try! self.sessionManager.createSession(title: "Concurrent Session \(i)")
+                _ = try! await self.sessionManager.createSession(title: "Concurrent Session \(i)")
             }
             tasks.append(task)
         }
@@ -278,7 +278,7 @@ final class ConcurrencyTests: XCTestCase {
     /// regenerateLastResponse() guards with `guard !isGenerating else { return }`,
     /// so the regeneration should be silently skipped.
     func test_regenerateWhileGenerating_isGuarded() async throws {
-        createAndActivateSession()
+        await createAndActivateSession()
 
         // 5 tokens is enough to hold the stream open while the regenerate races.
         slowBackend.tokensToYield = (0..<5).map { "tok\($0) " }

--- a/Tests/BaseChatUITests/ConsumerRuntimeHarness.swift
+++ b/Tests/BaseChatUITests/ConsumerRuntimeHarness.swift
@@ -106,22 +106,22 @@ final class ConsumerRuntimeHarness {
     }
 
     @discardableResult
-    func createAndActivateSession(title: String = "New Chat") throws -> ChatSessionRecord {
-        let session = try sessionManager.createSession(title: title)
-        switchToSession(session)
+    func createAndActivateSession(title: String = "New Chat") async throws -> ChatSessionRecord {
+        let session = try await sessionManager.createSession(title: title)
+        await switchToSession(session)
         return session
     }
 
-    func switchToSession(_ session: ChatSessionRecord) {
+    func switchToSession(_ session: ChatSessionRecord) async {
         sessionManager.activeSession = session
-        chatViewModel.switchToSession(session)
+        await chatViewModel.switchToSession(session)
     }
 
-    func persistedMessages(for session: ChatSessionRecord) throws -> [ChatMessageRecord] {
-        try runtime.persistence.fetchMessages(for: session.id)
+    func persistedMessages(for session: ChatSessionRecord) async throws -> [ChatMessageRecord] {
+        try await runtime.persistence.fetchMessages(for: session.id)
     }
 
-    func persistedSessions() throws -> [ChatSessionRecord] {
-        try runtime.persistence.fetchSessions()
+    func persistedSessions() async throws -> [ChatSessionRecord] {
+        try await runtime.persistence.fetchSessions()
     }
 }

--- a/Tests/BaseChatUITests/ConsumerRuntimeHarnessTests.swift
+++ b/Tests/BaseChatUITests/ConsumerRuntimeHarnessTests.swift
@@ -23,7 +23,7 @@ final class ConsumerRuntimeHarnessTests: XCTestCase {
             inferenceService: InferenceService(backend: backend, name: "RuntimeMock")
         )
 
-        let session = try harness!.createAndActivateSession(title: "Runtime Session")
+        let session = try await harness!.createAndActivateSession(title: "Runtime Session")
         harness!.chatViewModel.inputText = "What shipped in v1?"
 
         await harness!.chatViewModel.sendMessage()
@@ -32,11 +32,13 @@ final class ConsumerRuntimeHarnessTests: XCTestCase {
             harness!.chatViewModel.messages.map(\.content),
             ["What shipped in v1?", "Hello from runtime"]
         )
+        let persistedContents = try await harness!.persistedMessages(for: session).map(\.content)
         XCTAssertEqual(
-            try harness!.persistedMessages(for: session).map(\.content),
+            persistedContents,
             ["What shipped in v1?", "Hello from runtime"]
         )
-        XCTAssertEqual(try harness!.persistedSessions().map(\.id), [session.id])
+        let persistedSessionIDs = try await harness!.persistedSessions().map(\.id)
+        XCTAssertEqual(persistedSessionIDs, [session.id])
     }
 
     func test_stopGeneration_persistsPartialAssistantReply() async throws {
@@ -47,7 +49,7 @@ final class ConsumerRuntimeHarnessTests: XCTestCase {
             inferenceService: InferenceService(backend: backend, name: "RuntimeSlowMock")
         )
 
-        let session = try harness!.createAndActivateSession(title: "Cancellation Session")
+        let session = try await harness!.createAndActivateSession(title: "Cancellation Session")
         harness!.chatViewModel.inputText = "Tell me a story"
         let sendTask = Task { @MainActor in
             await self.harness?.chatViewModel.sendMessage()
@@ -62,8 +64,9 @@ final class ConsumerRuntimeHarnessTests: XCTestCase {
         XCTAssertEqual(assistant.role, .assistant)
         XCTAssertFalse(assistant.content.isEmpty)
         XCTAssertNotEqual(assistant.content, backend.tokensToYield.joined())
-        XCTAssertEqual(try harness!.persistedMessages(for: session).count, 2)
-        XCTAssertEqual(try harness!.persistedMessages(for: session).last?.content, assistant.content)
+        let persistedMessages = try await harness!.persistedMessages(for: session)
+        XCTAssertEqual(persistedMessages.count, 2)
+        XCTAssertEqual(persistedMessages.last?.content, assistant.content)
     }
 
     func test_switchingSessions_reloadsPersistedTranscriptForEachSession() async throws {
@@ -74,23 +77,23 @@ final class ConsumerRuntimeHarnessTests: XCTestCase {
             inferenceService: InferenceService(backend: backend, name: "RuntimeMock")
         )
 
-        let sessionA = try harness!.createAndActivateSession(title: "Session A")
+        let sessionA = try await harness!.createAndActivateSession(title: "Session A")
         backend.tokensToYield = ["Alpha", " reply"]
         harness!.chatViewModel.inputText = "Alpha question"
         await harness!.chatViewModel.sendMessage()
 
-        let sessionB = try harness!.createAndActivateSession(title: "Session B")
+        let sessionB = try await harness!.createAndActivateSession(title: "Session B")
         backend.tokensToYield = ["Beta", " reply"]
         harness!.chatViewModel.inputText = "Beta question"
         await harness!.chatViewModel.sendMessage()
 
-        harness!.switchToSession(sessionA)
+        await harness!.switchToSession(sessionA)
         XCTAssertEqual(
             harness!.chatViewModel.messages.map(\.content),
             ["Alpha question", "Alpha reply"]
         )
 
-        harness!.switchToSession(sessionB)
+        await harness!.switchToSession(sessionB)
         XCTAssertEqual(
             harness!.chatViewModel.messages.map(\.content),
             ["Beta question", "Beta reply"]
@@ -183,7 +186,7 @@ final class ConsumerRuntimeHarnessTests: XCTestCase {
             )
         )
 
-        _ = try harness!.createAndActivateSession(title: "Tool Session")
+        _ = try await harness!.createAndActivateSession(title: "Tool Session")
         harness!.chatViewModel.inputText = "Check runtime tools"
 
         await harness!.chatViewModel.sendMessage()

--- a/Tests/BaseChatUITests/ContextEstimationIntegrationTests.swift
+++ b/Tests/BaseChatUITests/ContextEstimationIntegrationTests.swift
@@ -43,18 +43,18 @@ final class ContextEstimationIntegrationTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func createSession(title: String = "Context Test") -> ChatSession {
+    private func createSession(title: String = "Context Test") async -> ChatSession {
         let session = ChatSession(title: title)
         context.insert(session)
         try? context.save()
-        vm.switchToSession(session.toRecord())
+        await vm.switchToSession(session.toRecord())
         return session
     }
 
     // MARK: - Empty Conversation
 
-    func test_contextEstimation_emptyConversation() {
-        createSession()
+    func test_contextEstimation_emptyConversation() async {
+        await createSession()
 
         // With no messages and an empty system prompt, used tokens should be minimal.
         // The heuristic tokenizer returns max(1, text.count / 4) — empty string yields 1.
@@ -66,7 +66,7 @@ final class ContextEstimationIntegrationTests: XCTestCase {
     // MARK: - Single User Message
 
     func test_contextEstimation_singleUserMessage() async {
-        createSession()
+        await createSession()
 
         mock.tokensToYield = ["Hi"]
         vm.inputText = "Hello world"
@@ -84,7 +84,7 @@ final class ContextEstimationIntegrationTests: XCTestCase {
     // MARK: - Multi-Turn Conversation
 
     func test_contextEstimation_multiTurnConversation() async {
-        createSession()
+        await createSession()
 
         // Turn 1
         mock.tokensToYield = ["First", " reply"]
@@ -112,10 +112,10 @@ final class ContextEstimationIntegrationTests: XCTestCase {
     // MARK: - System Prompt Included
 
     func test_contextEstimation_withSystemPrompt() async {
-        let session = createSession()
+        let session = await createSession()
         session.systemPrompt = "You are a helpful assistant that provides concise answers."
 
-        vm.switchToSession(session.toRecord())
+        await vm.switchToSession(session.toRecord())
         let tokensWithSystemPrompt = vm.contextUsedTokens
 
         // The system prompt has ~56 characters → max(1, 56/4) = 14 tokens.
@@ -139,7 +139,7 @@ final class ContextEstimationIntegrationTests: XCTestCase {
     // MARK: - Token Cache Population
 
     func test_tokenCache_isPopulatedAfterEstimation() async {
-        createSession()
+        await createSession()
 
         mock.tokensToYield = ["Reply", " here"]
         vm.inputText = "Cache test message"
@@ -158,7 +158,7 @@ final class ContextEstimationIntegrationTests: XCTestCase {
     }
 
     func test_tokenCache_returnsSameResult_onSecondEstimation() async {
-        createSession()
+        await createSession()
 
         mock.tokensToYield = ["Cached", " reply"]
         vm.inputText = "Consistency check"
@@ -182,8 +182,8 @@ final class ContextEstimationIntegrationTests: XCTestCase {
 
     // MARK: - Context Percentage Calculation
 
-    func test_contextUsageRatio_atVariousFillLevels() {
-        createSession()
+    func test_contextUsageRatio_atVariousFillLevels() async {
+        await createSession()
 
         // With default contextMaxTokens (from backend: 4096) and no messages,
         // usage should be near zero.
@@ -204,8 +204,8 @@ final class ContextEstimationIntegrationTests: XCTestCase {
         XCTAssertEqual(vm.contextUsageRatio, 0.0, accuracy: 0.001, "Empty context should be 0.0")
     }
 
-    func test_contextUsageRatio_zeroMaxTokens_returnsZero() {
-        createSession()
+    func test_contextUsageRatio_zeroMaxTokens_returnsZero() async {
+        await createSession()
 
         vm.contextMaxTokens = 0
         vm.contextUsedTokens = 100
@@ -253,7 +253,7 @@ final class ContextEstimationIntegrationTests: XCTestCase {
         let session = ChatSession(title: "Vendor Test")
         context.insert(session)
         try? context.save()
-        vendorVM.switchToSession(session.toRecord())
+        await vendorVM.switchToSession(session.toRecord())
 
         tokenizingMock.tokensToYield = ["Reply"]
         vendorVM.inputText = "anything"
@@ -269,7 +269,7 @@ final class ContextEstimationIntegrationTests: XCTestCase {
     func test_contextEstimation_fallsBackToHeuristicWhenNoTokenizerVendor() async {
         // Standard MockInferenceBackend does NOT conform to TokenizerVendor.
         // Context estimation should use the heuristic.
-        createSession()
+        await createSession()
         mock.tokensToYield = ["Hi"]
         vm.inputText = "Hello world"
         await vm.sendMessage()

--- a/Tests/BaseChatUITests/EditUserMessageIntegrationTests.swift
+++ b/Tests/BaseChatUITests/EditUserMessageIntegrationTests.swift
@@ -54,10 +54,10 @@ final class EditUserMessageIntegrationTests: XCTestCase {
     // MARK: - Helpers
 
     @discardableResult
-    private func createAndActivateSession(title: String = "Test Chat") -> ChatSessionRecord {
-        let session = try! sessionManager.createSession(title: title)
+    private func createAndActivateSession(title: String = "Test Chat") async -> ChatSessionRecord {
+        let session = try! await sessionManager.createSession(title: title)
         sessionManager.activeSession = session
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
         return session
     }
 
@@ -80,7 +80,7 @@ final class EditUserMessageIntegrationTests: XCTestCase {
     // MARK: - Edit Updates Content In Memory
 
     func test_editMessage_updatesContentInMemory() async {
-        createAndActivateSession()
+        await createAndActivateSession()
 
         mock.tokensToYield = ["Original", " reply"]
         vm.inputText = "Original question"
@@ -104,7 +104,7 @@ final class EditUserMessageIntegrationTests: XCTestCase {
     // MARK: - Edit Persists To SwiftData
 
     func test_editMessage_persistsChangesToDatabase() async {
-        let session = createAndActivateSession()
+        let session = await createAndActivateSession()
 
         mock.tokensToYield = ["Original", " reply"]
         vm.inputText = "Before edit"
@@ -124,7 +124,7 @@ final class EditUserMessageIntegrationTests: XCTestCase {
     // MARK: - Edit Does Not Create Duplicate Messages
 
     func test_editMessage_doesNotCreateDuplicateMessages() async {
-        let session = createAndActivateSession()
+        let session = await createAndActivateSession()
 
         mock.tokensToYield = ["Reply", " one"]
         vm.inputText = "Question"
@@ -150,7 +150,7 @@ final class EditUserMessageIntegrationTests: XCTestCase {
     // MARK: - Edit Preserves Original Message ID
 
     func test_editMessage_preservesOriginalUserMessageID() async {
-        createAndActivateSession()
+        await createAndActivateSession()
 
         mock.tokensToYield = ["Reply"]
         vm.inputText = "Original"
@@ -168,7 +168,7 @@ final class EditUserMessageIntegrationTests: XCTestCase {
     // MARK: - Edit Removes Subsequent Messages And Regenerates
 
     func test_editMessage_removesSubsequentMessagesAndRegenerates() async {
-        let session = createAndActivateSession()
+        let session = await createAndActivateSession()
 
         // Build a 3-turn conversation (6 messages)
         mock.tokensToYield = ["Reply", " 1"]
@@ -206,7 +206,7 @@ final class EditUserMessageIntegrationTests: XCTestCase {
     // MARK: - Edit With Same Content Is Idempotent
 
     func test_editMessage_withSameContent_doesNotCorruptState() async {
-        let session = createAndActivateSession()
+        let session = await createAndActivateSession()
 
         mock.tokensToYield = ["Reply"]
         vm.inputText = "Question"
@@ -229,7 +229,7 @@ final class EditUserMessageIntegrationTests: XCTestCase {
     // MARK: - Edit Nonexistent Message Is No-Op
 
     func test_editMessage_withInvalidID_isNoOp() async {
-        let session = createAndActivateSession()
+        let session = await createAndActivateSession()
 
         mock.tokensToYield = ["Reply"]
         vm.inputText = "Question"

--- a/Tests/BaseChatUITests/GenerationCoordinatorTrimReservationTests.swift
+++ b/Tests/BaseChatUITests/GenerationCoordinatorTrimReservationTests.swift
@@ -41,9 +41,9 @@ final class GenerationCoordinatorTrimReservationTests: XCTestCase {
         sessionManager = SessionManagerViewModel()
         sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
 
-        let session = try sessionManager.createSession(title: "Trim fixture")
+        let session = try await sessionManager.createSession(title: "Trim fixture")
         sessionManager.activeSession = session
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
         sessionID = session.id
     }
 

--- a/Tests/BaseChatUITests/GenerationExtensionTests.swift
+++ b/Tests/BaseChatUITests/GenerationExtensionTests.swift
@@ -52,7 +52,7 @@ final class GenerationExtensionTests: XCTestCase {
         let mock = TokenTrackingMockBackend()
         mock.tokensToYield = ["Hello", " there"]
         mock.usageToReport = (promptTokens: 10, completionTokens: 5)
-        let vm = makeVM(rawBackend: mock)
+        let vm = await makeVM(rawBackend: mock)
 
         vm.inputText = "Hi"
         await vm.sendMessage()
@@ -74,7 +74,7 @@ final class GenerationExtensionTests: XCTestCase {
             (promptTokens: 10, completionTokens: 5),   // first generation
             (promptTokens: 20, completionTokens: 8),   // second generation
         ]
-        let vm = makeVM(rawBackend: mock)
+        let vm = await makeVM(rawBackend: mock)
 
         // First generation
         vm.inputText = "First question"
@@ -103,7 +103,7 @@ final class GenerationExtensionTests: XCTestCase {
     func test_tokenUsage_nilWhenBackendDoesNotProvide() async {
         let mock = MockInferenceBackend()
         mock.tokensToYield = ["Reply"]
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
 
         vm.inputText = "Hi"
         await vm.sendMessage()
@@ -126,7 +126,7 @@ final class GenerationExtensionTests: XCTestCase {
         let mock = MockInferenceBackend()
         mock.tokensToYield = ["Hello"]
         // Backend name must be "Apple" to trigger the hint.
-        let vm = makeVM(backend: mock, name: "Apple")
+        let vm = await makeVM(backend: mock, name: "Apple")
 
         var hintCallbackCalled = false
         vm.onUpgradeHintTriggered = { hintCallbackCalled = true }
@@ -146,7 +146,7 @@ final class GenerationExtensionTests: XCTestCase {
 
         let mock = MockInferenceBackend()
         mock.tokensToYield = ["Hello"]
-        let vm = makeVM(backend: mock, name: "Apple")
+        let vm = await makeVM(backend: mock, name: "Apple")
 
         vm.inputText = "Hi"
         await vm.sendMessage()
@@ -162,7 +162,7 @@ final class GenerationExtensionTests: XCTestCase {
 
         let mock = MockInferenceBackend()
         mock.tokensToYield = ["Hello"]
-        let vm = makeVM(backend: mock, name: "MLX")
+        let vm = await makeVM(backend: mock, name: "MLX")
 
         vm.inputText = "Hi"
         await vm.sendMessage()
@@ -178,7 +178,7 @@ final class GenerationExtensionTests: XCTestCase {
 
         let mock = MockInferenceBackend()
         mock.tokensToYield = ["First"]
-        let vm = makeVM(backend: mock, name: "Apple")
+        let vm = await makeVM(backend: mock, name: "Apple")
 
         // First message triggers the hint.
         vm.inputText = "Hi"
@@ -208,7 +208,7 @@ final class GenerationExtensionTests: XCTestCase {
 
         let mock = MockInferenceBackend()
         mock.tokensToYield = []  // Empty response
-        let vm = makeVM(backend: mock, name: "Apple")
+        let vm = await makeVM(backend: mock, name: "Apple")
 
         vm.inputText = "Hi"
         await vm.sendMessage()
@@ -228,7 +228,7 @@ final class GenerationExtensionTests: XCTestCase {
             requiresPromptTemplate: true,
             supportsSystemPrompt: false
         )
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
         // Set a very small context window.
         vm.contextMaxTokens = 100
 
@@ -262,7 +262,7 @@ final class GenerationExtensionTests: XCTestCase {
     func test_emptyResponse_removesAssistantPlaceholder() async {
         let mock = MockInferenceBackend()
         mock.tokensToYield = []  // Zero tokens
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
 
         vm.inputText = "Hello"
         await vm.sendMessage()
@@ -275,7 +275,7 @@ final class GenerationExtensionTests: XCTestCase {
     func test_nonEmptyResponse_persistsAssistantMessage() async {
         let mock = MockInferenceBackend()
         mock.tokensToYield = ["Hi"]
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
 
         vm.inputText = "Hello"
         await vm.sendMessage()
@@ -288,7 +288,7 @@ final class GenerationExtensionTests: XCTestCase {
     func test_streamingBatching_preservesAllTokensWhenFlushAtCompletion() async {
         let mock = MockInferenceBackend()
         mock.tokensToYield = ["A", "B", "C", "D", "E"]
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
         vm.streamingUpdateInterval = .seconds(60)
         vm.streamingBatchCharacterLimit = 10_000
 
@@ -308,7 +308,7 @@ final class GenerationExtensionTests: XCTestCase {
         // Emit enough single-char tokens to build chunk twice (120 chars total).
         let repeatedText = chunk + chunk
         mock.tokensToYield = repeatedText.map { String($0) }
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
         vm.loopDetectionEnabled = true
         // Use small batch limit so the batcher flushes frequently and detection runs.
         vm.streamingUpdateInterval = .zero
@@ -327,7 +327,7 @@ final class GenerationExtensionTests: XCTestCase {
     func test_isGenerating_falseAfterSuccessfulGeneration() async {
         let mock = MockInferenceBackend()
         mock.tokensToYield = ["Done"]
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
 
         XCTAssertFalse(vm.isGenerating, "isGenerating should be false before generation")
 
@@ -340,7 +340,7 @@ final class GenerationExtensionTests: XCTestCase {
     func test_isGenerating_falseAfterGenerationError() async {
         let mock = MockInferenceBackend()
         mock.shouldThrowOnGenerate = InferenceError.inferenceFailure("Boom")
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
 
         vm.inputText = "Go"
         await vm.sendMessage()
@@ -350,7 +350,7 @@ final class GenerationExtensionTests: XCTestCase {
 
     func test_isGenerating_falseAfterStreamError() async {
         let errorBackend = MidStreamErrorBackend()
-        let vm = makeVM(rawBackend: errorBackend)
+        let vm = await makeVM(rawBackend: errorBackend)
 
         vm.inputText = "Go"
         await vm.sendMessage()
@@ -363,7 +363,7 @@ final class GenerationExtensionTests: XCTestCase {
     func test_generationDidFinish_setsServiceIsGeneratingFalse() async {
         let mock = MockInferenceBackend()
         mock.tokensToYield = ["Token"]
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
 
         vm.inputText = "Test"
         await vm.sendMessage()
@@ -377,7 +377,7 @@ final class GenerationExtensionTests: XCTestCase {
     func test_generationDidFinish_calledEvenOnError() async {
         let mock = MockInferenceBackend()
         mock.shouldThrowOnGenerate = InferenceError.inferenceFailure("fail")
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
 
         vm.inputText = "Test"
         await vm.sendMessage()
@@ -393,7 +393,7 @@ final class GenerationExtensionTests: XCTestCase {
     func test_generationStartError_setsErrorMessage() async {
         let mock = MockInferenceBackend()
         mock.shouldThrowOnGenerate = InferenceError.inferenceFailure("backend exploded")
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
 
         vm.inputText = "Hello"
         await vm.sendMessage()
@@ -409,7 +409,7 @@ final class GenerationExtensionTests: XCTestCase {
 
     func test_streamError_setsErrorMessage() async {
         let errorBackend = MidStreamErrorBackend()
-        let vm = makeVM(rawBackend: errorBackend)
+        let vm = await makeVM(rawBackend: errorBackend)
 
         vm.inputText = "Hello"
         await vm.sendMessage()

--- a/Tests/BaseChatUITests/GenerationViewModelTests.swift
+++ b/Tests/BaseChatUITests/GenerationViewModelTests.swift
@@ -114,8 +114,8 @@ final class ChatViewModelTests: XCTestCase {
 
     // MARK: - test_init_defaultState
 
-    func test_init_defaultState() {
-        let vm = makeViewModel()
+    func test_init_defaultState() async {
+        let vm = await makeViewModel()
 
         XCTAssertTrue(vm.availableModels.isEmpty, "availableModels should be empty on init")
         XCTAssertNil(vm.selectedModel, "selectedModel should be nil on init")
@@ -129,11 +129,11 @@ final class ChatViewModelTests: XCTestCase {
 
     // MARK: - test_refreshModels_populatesAvailableModels
 
-    func test_refreshModels_populatesAvailableModels() throws {
+    func test_refreshModels_populatesAvailableModels() async throws {
         let url = try createFakeGGUF(named: "test-refresh-model.gguf")
         createdFiles.append(url)
 
-        let vm = makeViewModel()
+        let vm = await makeViewModel()
         vm.refreshModels()
 
         XCTAssertFalse(vm.availableModels.isEmpty, "availableModels should contain discovered models")
@@ -145,11 +145,11 @@ final class ChatViewModelTests: XCTestCase {
 
     // MARK: - test_refreshModels_clearsStaleSelection
 
-    func test_refreshModels_clearsStaleSelection() throws {
+    func test_refreshModels_clearsStaleSelection() async throws {
         let url = try createFakeGGUF(named: "test-stale-model.gguf")
         createdFiles.append(url)
 
-        let vm = makeViewModel()
+        let vm = await makeViewModel()
         vm.refreshModels()
 
         // Select the discovered model.
@@ -167,7 +167,7 @@ final class ChatViewModelTests: XCTestCase {
     // MARK: - test_loadSelectedModel_noSelection_setsError
 
     func test_loadSelectedModel_noSelection_setsError() async {
-        let vm = makeViewModel()
+        let vm = await makeViewModel()
         XCTAssertNil(vm.selectedModel)
 
         await vm.loadSelectedModel()
@@ -183,7 +183,7 @@ final class ChatViewModelTests: XCTestCase {
         // `ModelLoadPlan`, which reads `availableMemoryBytes` from an injected
         // environment — pin it low so the plan denies deterministically on any
         // host (the real CI box has far more RAM than the model's weights).
-        let vm = makeViewModel(ramGB: 4)
+        let vm = await makeViewModel(ramGB: 4)
         vm.loadPlanEnvironment = ModelLoadPlan.Environment(
             availableMemoryBytes: { 512 * 1024 * 1024 },  // 512 MB available
             physicalMemoryBytes: 4 * oneGB
@@ -210,7 +210,7 @@ final class ChatViewModelTests: XCTestCase {
     // MARK: - test_sendMessage_emptyInput_doesNothing
 
     func test_sendMessage_emptyInput_doesNothing() async {
-        let vm = makeViewModel()
+        let vm = await makeViewModel()
         vm.inputText = ""
 
         await vm.sendMessage()
@@ -222,7 +222,7 @@ final class ChatViewModelTests: XCTestCase {
     // MARK: - test_sendMessage_noModelLoaded_setsError
 
     func test_sendMessage_noModelLoaded_setsError() async {
-        let vm = makeViewModel()
+        let vm = await makeViewModel()
         vm.activeSession = ChatSessionRecord(title: "Test")
         vm.inputText = "Tell me a story"
 
@@ -263,18 +263,18 @@ final class ChatViewModelTests: XCTestCase {
 
         XCTAssertFalse(vm.messages.isEmpty, "Should have messages after sending")
 
-        vm.clearChat()
+        await vm.clearChat()
 
         XCTAssertTrue(vm.messages.isEmpty, "messages should be empty after clearChat")
     }
 
     // MARK: - test_autoSelectFirstRunModel_selectsFoundation
 
-    func test_autoSelectFirstRunModel_selectsFoundation() {
+    func test_autoSelectFirstRunModel_selectsFoundation() async {
         let firstRunKey = "\(BaseChatConfiguration.shared.bundleIdentifier).hasCompletedFirstLaunch"
         // Per-instance suite starts empty — no need to clear; the flag is unset by construction.
 
-        let vm = makeViewModel()
+        let vm = await makeViewModel()
 
         // Manually add a foundation model to available models
         // (refreshModels would check actual availability which may not be present in tests).
@@ -302,12 +302,12 @@ final class ChatViewModelTests: XCTestCase {
 
     // MARK: - test_autoSelectFirstRunModel_doesNotRepeat
 
-    func test_autoSelectFirstRunModel_doesNotRepeat() {
+    func test_autoSelectFirstRunModel_doesNotRepeat() async {
         let firstRunKey = "\(BaseChatConfiguration.shared.bundleIdentifier).hasCompletedFirstLaunch"
         // Set the flag as if first launch already happened.
         testDefaults.set(true, forKey: firstRunKey)
 
-        let vm = makeViewModel()
+        let vm = await makeViewModel()
         vm.refreshModels()
         vm.autoSelectFirstRunModel()
 
@@ -317,8 +317,8 @@ final class ChatViewModelTests: XCTestCase {
 
     // MARK: - test_handleMemoryPressure_nominal_doesNotSetError
 
-    func test_handleMemoryPressure_nominal_doesNotSetError() {
-        let vm = makeViewModel()
+    func test_handleMemoryPressure_nominal_doesNotSetError() async {
+        let vm = await makeViewModel()
 
         vm.handleMemoryPressure()
 
@@ -330,8 +330,8 @@ final class ChatViewModelTests: XCTestCase {
 
     // MARK: - test_deviceDescription_returnsNonEmpty
 
-    func test_deviceDescription_returnsNonEmpty() {
-        let vm = makeViewModel(ramGB: 16)
+    func test_deviceDescription_returnsNonEmpty() async {
+        let vm = await makeViewModel(ramGB: 16)
 
         XCTAssertFalse(vm.deviceDescription.isEmpty, "deviceDescription should not be empty")
         XCTAssertTrue(
@@ -342,8 +342,8 @@ final class ChatViewModelTests: XCTestCase {
 
     // MARK: - test_recommendedSize_returnsValidRecommendation
 
-    func test_recommendedSize_returnsValidRecommendation() {
-        let vm = makeViewModel(ramGB: 8)
+    func test_recommendedSize_returnsValidRecommendation() async {
+        let vm = await makeViewModel(ramGB: 8)
 
         let recommendation = vm.recommendedSize
         XCTAssertTrue(
@@ -356,8 +356,8 @@ final class ChatViewModelTests: XCTestCase {
 
     // MARK: - test_modelsDirectoryPath_returnsNonEmpty
 
-    func test_modelsDirectoryPath_returnsNonEmpty() {
-        let vm = makeViewModel()
+    func test_modelsDirectoryPath_returnsNonEmpty() async {
+        let vm = await makeViewModel()
 
         XCTAssertFalse(vm.modelsDirectoryPath.isEmpty, "modelsDirectoryPath should not be empty")
         // When a custom `baseDirectory:` is passed to ModelStorageService the
@@ -372,8 +372,8 @@ final class ChatViewModelTests: XCTestCase {
 
     // MARK: - test_backendCapabilities_nilWhenNoModel
 
-    func test_backendCapabilities_nilWhenNoModel() {
-        let vm = makeViewModel()
+    func test_backendCapabilities_nilWhenNoModel() async {
+        let vm = await makeViewModel()
         XCTAssertNil(vm.backendCapabilities, "backendCapabilities should be nil when no model loaded")
     }
 
@@ -655,7 +655,7 @@ final class ChatViewModelTests: XCTestCase {
 
         XCTAssertEqual(vm.messages.count, 4, "Precondition: should have 4 messages")
 
-        vm.clearChat()
+        await vm.clearChat()
 
         XCTAssertTrue(vm.messages.isEmpty, "All messages should be cleared")
     }

--- a/Tests/BaseChatUITests/IntegratedStreamingPerformanceTests.swift
+++ b/Tests/BaseChatUITests/IntegratedStreamingPerformanceTests.swift
@@ -75,7 +75,7 @@ final class IntegratedStreamingPerformanceTests: XCTestCase {
     /// **user-perceived** TTFT, which includes both backend latency and the
     /// `StreamingTokenBatcher` flush delay — exactly what regresses when
     /// either side slows down.
-    func testPerf_timeToFirstToken_realisticBackend() async {
+    func testPerf_timeToFirstToken_realisticBackend() {
         // Fixture: 32 short tokens are plenty to drive the first batch flush.
         // A 100 ms TTFT is the conservative midpoint of a real local-MLX run;
         // jitter is degenerate so per-iteration variance is bounded.
@@ -85,7 +85,7 @@ final class IntegratedStreamingPerformanceTests: XCTestCase {
             interToken: .milliseconds(20),
             tokens: tokens
         )
-        let harness = await makeHarness(backend: backend)
+        let harness = makeHarness(backend: backend)
 
         measure {
             let exp = expectation(description: "first character visible")
@@ -94,7 +94,7 @@ final class IntegratedStreamingPerformanceTests: XCTestCase {
             // empty assistant message (sendMessage appends a new one each call).
             vm.messages = vm.messages.filter { $0.role == .system }
             vm.inputText = "hello"
-            Task { @MainActor in
+            Task {
                 let send = Task { await vm.sendMessage() }
                 // Tight poll on the MainActor — `messages.last?.content` is
                 // mutated on the main actor by `onMutateMessage`, so any
@@ -124,7 +124,7 @@ final class IntegratedStreamingPerformanceTests: XCTestCase {
     /// Regressions that disable batching (gaps drop near zero with very high
     /// frequency) or that stall the batcher (gaps spike past 50 ms) both
     /// surface here.
-    func testPerf_streamingCadence_5KBResponse() async {
+    func testPerf_streamingCadence_5KBResponse() {
         let tokens = makeFiveKBTokenScript()
         // 8 ms per token gives ~4× the batcher's 33 ms tick: every batch
         // flush carries multiple tokens, exercising the realistic batching
@@ -134,14 +134,14 @@ final class IntegratedStreamingPerformanceTests: XCTestCase {
             interToken: .milliseconds(8),
             tokens: tokens
         )
-        let harness = await makeHarness(backend: backend)
+        let harness = makeHarness(backend: backend)
 
         measure {
             let exp = expectation(description: "stream completes")
             let vm = harness.vm
             vm.messages = vm.messages.filter { $0.role == .system }
             vm.inputText = "stream please"
-            Task { @MainActor in
+            Task {
                 let send = Task { await vm.sendMessage() }
                 var gaps: [Duration] = []
                 var lastChange = ContinuousClock.now
@@ -194,15 +194,15 @@ final class IntegratedStreamingPerformanceTests: XCTestCase {
     /// The backlog matters because a number of code paths iterate the active
     /// message array (context window trimming, scroll anchoring, persistence
     /// upserts) and grow O(n) with history length.
-    func testPerf_endToEndPipeline_withLargeBacklog() async {
+    func testPerf_endToEndPipeline_withLargeBacklog() {
         let tokens = makeFiveKBTokenScript()
         let backend = makeLatencyBackend(
             ttft: .milliseconds(50),
             interToken: .milliseconds(2),
             tokens: tokens
         )
-        let harness = await makeHarness(backend: backend)
-        await seedBacklog(in: harness, messageCount: 200)
+        let harness = makeHarness(backend: backend)
+        seedBacklog(in: harness, messageCount: 200)
 
         measure {
             let exp = expectation(description: "5KB stream end-to-end")
@@ -213,7 +213,7 @@ final class IntegratedStreamingPerformanceTests: XCTestCase {
             let seededIDs = Set(vm.messages.map(\.id))
             vm.messages = vm.messages.filter { seededIDs.contains($0.id) }
             vm.inputText = "tell me about the project"
-            Task { @MainActor in
+            Task {
                 await vm.sendMessage()
                 exp.fulfill()
             }
@@ -228,14 +228,14 @@ final class IntegratedStreamingPerformanceTests: XCTestCase {
     /// constant overhead. Compared against the end-to-end test, this lets a
     /// future regression be attributed to either the append/persist side or
     /// the streaming side.
-    func testPerf_messageAppend_at200MessageCount() async {
+    func testPerf_messageAppend_at200MessageCount() {
         let backend = makeLatencyBackend(
             ttft: .milliseconds(10),
             interToken: .milliseconds(2),
             tokens: ["A", "B", "C", "D"]
         )
-        let harness = await makeHarness(backend: backend)
-        await seedBacklog(in: harness, messageCount: 200)
+        let harness = makeHarness(backend: backend)
+        seedBacklog(in: harness, messageCount: 200)
         let seededIDs = Set(harness.vm.messages.map(\.id))
 
         measure {
@@ -243,7 +243,7 @@ final class IntegratedStreamingPerformanceTests: XCTestCase {
             let vm = harness.vm
             vm.messages = vm.messages.filter { seededIDs.contains($0.id) }
             vm.inputText = "ping"
-            Task { @MainActor in
+            Task {
                 await vm.sendMessage()
                 exp.fulfill()
             }
@@ -279,51 +279,68 @@ final class IntegratedStreamingPerformanceTests: XCTestCase {
         let session: ChatSessionRecord
     }
 
-    private func makeHarness(backend: PerceivedLatencyBackend) async -> Harness {
+    private func makeHarness(backend: PerceivedLatencyBackend) -> Harness {
         // `InferenceService(backend:name:)` treats the backend as already
         // loaded, but the backend itself enforces an `_isModelLoaded` guard
         // inside `generate()` — preload it here so tests don't deadlock on
-        // the guard throwing.
-        try? await backend.loadModel(
-            from: URL(fileURLWithPath: "/tmp/integratedperf"),
-            plan: .testStub(effectiveContextSize: 4096)
-        )
+        // the guard throwing. Bridge the async setup back to the sync test
+        // body via expectation so the test function can stay synchronous and
+        // run inside `measure { }` blocks without main-actor reentrancy.
+        let preload = expectation(description: "harness preload")
+        let backendCapture = backend
+        let modelContext = context!
+        nonisolated(unsafe) var harness: Harness!
+        Task {
+            try? await backendCapture.loadModel(
+                from: URL(fileURLWithPath: "/tmp/integratedperf"),
+                plan: .testStub(effectiveContextSize: 4096)
+            )
+            let service = InferenceService(backend: backendCapture, name: "IntegratedPerf")
+            let vm = ChatViewModel(inferenceService: service)
+            vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: modelContext))
 
-        let service = InferenceService(backend: backend, name: "IntegratedPerf")
-        let vm = ChatViewModel(inferenceService: service)
-        vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
-
-        let sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
-        let session = (try? await sessionManager.createSession(title: "Perf"))!
-        sessionManager.activeSession = session
-        await vm.switchToSession(session)
-        return Harness(vm: vm, backend: backend, session: session)
+            let sessionManager = SessionManagerViewModel()
+            sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: modelContext))
+            let session = (try? await sessionManager.createSession(title: "Perf"))!
+            sessionManager.activeSession = session
+            await vm.switchToSession(session)
+            harness = Harness(vm: vm, backend: backendCapture, session: session)
+            preload.fulfill()
+        }
+        wait(for: [preload], timeout: 30)
+        return harness
     }
 
     /// Seeds `messageCount` alternating user/assistant rows into the harness's
     /// active session, both in-memory on the VM and persisted via SwiftData.
     /// Done once before `measure { }` so the timed work is the next message,
     /// not the fixture build.
-    private func seedBacklog(in harness: Harness, messageCount: Int) async {
+    private func seedBacklog(in harness: Harness, messageCount: Int) {
         let sessionID = harness.session.id
         let base = Date(timeIntervalSince1970: 1_000_000)
-        for i in 0..<messageCount {
-            let role: MessageRole = i.isMultiple(of: 2) ? .user : .assistant
-            // ~80 chars each — enough body for context trimming and markdown
-            // rendering to be exercised, but small enough to keep fixture
-            // build reasonable.
-            let body = "Backlog message \(i): the quick brown fox jumps over the lazy dog every time."
-            let record = ChatMessageRecord(
-                role: role,
-                content: body,
-                timestamp: base.addingTimeInterval(Double(i)),
-                sessionID: sessionID
-            )
-            harness.vm.messages.append(record)
-            try? await SwiftDataPersistenceProvider(modelContext: context)
-                .insertMessage(record)
+        let exp = expectation(description: "seed backlog")
+        let modelContext = context!
+        let vm = harness.vm
+        Task {
+            let provider = SwiftDataPersistenceProvider(modelContext: modelContext)
+            for i in 0..<messageCount {
+                let role: MessageRole = i.isMultiple(of: 2) ? .user : .assistant
+                // ~80 chars each — enough body for context trimming and
+                // markdown rendering to be exercised, but small enough to
+                // keep fixture build reasonable.
+                let body = "Backlog message \(i): the quick brown fox jumps over the lazy dog every time."
+                let record = ChatMessageRecord(
+                    role: role,
+                    content: body,
+                    timestamp: base.addingTimeInterval(Double(i)),
+                    sessionID: sessionID
+                )
+                vm.messages.append(record)
+                try? await provider.insertMessage(record)
+            }
+            exp.fulfill()
         }
+        wait(for: [exp], timeout: 60)
     }
 
     /// Builds a token script whose total visible content size is approximately

--- a/Tests/BaseChatUITests/IntegratedStreamingPerformanceTests.swift
+++ b/Tests/BaseChatUITests/IntegratedStreamingPerformanceTests.swift
@@ -75,7 +75,7 @@ final class IntegratedStreamingPerformanceTests: XCTestCase {
     /// **user-perceived** TTFT, which includes both backend latency and the
     /// `StreamingTokenBatcher` flush delay — exactly what regresses when
     /// either side slows down.
-    func testPerf_timeToFirstToken_realisticBackend() {
+    func testPerf_timeToFirstToken_realisticBackend() async {
         // Fixture: 32 short tokens are plenty to drive the first batch flush.
         // A 100 ms TTFT is the conservative midpoint of a real local-MLX run;
         // jitter is degenerate so per-iteration variance is bounded.
@@ -85,7 +85,7 @@ final class IntegratedStreamingPerformanceTests: XCTestCase {
             interToken: .milliseconds(20),
             tokens: tokens
         )
-        let harness = makeHarness(backend: backend)
+        let harness = await makeHarness(backend: backend)
 
         measure {
             let exp = expectation(description: "first character visible")
@@ -124,7 +124,7 @@ final class IntegratedStreamingPerformanceTests: XCTestCase {
     /// Regressions that disable batching (gaps drop near zero with very high
     /// frequency) or that stall the batcher (gaps spike past 50 ms) both
     /// surface here.
-    func testPerf_streamingCadence_5KBResponse() {
+    func testPerf_streamingCadence_5KBResponse() async {
         let tokens = makeFiveKBTokenScript()
         // 8 ms per token gives ~4× the batcher's 33 ms tick: every batch
         // flush carries multiple tokens, exercising the realistic batching
@@ -134,7 +134,7 @@ final class IntegratedStreamingPerformanceTests: XCTestCase {
             interToken: .milliseconds(8),
             tokens: tokens
         )
-        let harness = makeHarness(backend: backend)
+        let harness = await makeHarness(backend: backend)
 
         measure {
             let exp = expectation(description: "stream completes")
@@ -194,15 +194,15 @@ final class IntegratedStreamingPerformanceTests: XCTestCase {
     /// The backlog matters because a number of code paths iterate the active
     /// message array (context window trimming, scroll anchoring, persistence
     /// upserts) and grow O(n) with history length.
-    func testPerf_endToEndPipeline_withLargeBacklog() {
+    func testPerf_endToEndPipeline_withLargeBacklog() async {
         let tokens = makeFiveKBTokenScript()
         let backend = makeLatencyBackend(
             ttft: .milliseconds(50),
             interToken: .milliseconds(2),
             tokens: tokens
         )
-        let harness = makeHarness(backend: backend)
-        seedBacklog(in: harness, messageCount: 200)
+        let harness = await makeHarness(backend: backend)
+        await seedBacklog(in: harness, messageCount: 200)
 
         measure {
             let exp = expectation(description: "5KB stream end-to-end")
@@ -228,14 +228,14 @@ final class IntegratedStreamingPerformanceTests: XCTestCase {
     /// constant overhead. Compared against the end-to-end test, this lets a
     /// future regression be attributed to either the append/persist side or
     /// the streaming side.
-    func testPerf_messageAppend_at200MessageCount() {
+    func testPerf_messageAppend_at200MessageCount() async {
         let backend = makeLatencyBackend(
             ttft: .milliseconds(10),
             interToken: .milliseconds(2),
             tokens: ["A", "B", "C", "D"]
         )
-        let harness = makeHarness(backend: backend)
-        seedBacklog(in: harness, messageCount: 200)
+        let harness = await makeHarness(backend: backend)
+        await seedBacklog(in: harness, messageCount: 200)
         let seededIDs = Set(harness.vm.messages.map(\.id))
 
         measure {
@@ -279,20 +279,15 @@ final class IntegratedStreamingPerformanceTests: XCTestCase {
         let session: ChatSessionRecord
     }
 
-    private func makeHarness(backend: PerceivedLatencyBackend) -> Harness {
+    private func makeHarness(backend: PerceivedLatencyBackend) async -> Harness {
         // `InferenceService(backend:name:)` treats the backend as already
         // loaded, but the backend itself enforces an `_isModelLoaded` guard
         // inside `generate()` — preload it here so tests don't deadlock on
         // the guard throwing.
-        let preload = expectation(description: "backend preload")
-        Task {
-            try? await backend.loadModel(
-                from: URL(fileURLWithPath: "/tmp/integratedperf"),
-                plan: .testStub(effectiveContextSize: 4096)
-            )
-            preload.fulfill()
-        }
-        wait(for: [preload], timeout: 5)
+        try? await backend.loadModel(
+            from: URL(fileURLWithPath: "/tmp/integratedperf"),
+            plan: .testStub(effectiveContextSize: 4096)
+        )
 
         let service = InferenceService(backend: backend, name: "IntegratedPerf")
         let vm = ChatViewModel(inferenceService: service)
@@ -300,9 +295,9 @@ final class IntegratedStreamingPerformanceTests: XCTestCase {
 
         let sessionManager = SessionManagerViewModel()
         sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
-        let session = (try? sessionManager.createSession(title: "Perf"))!
+        let session = (try? await sessionManager.createSession(title: "Perf"))!
         sessionManager.activeSession = session
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
         return Harness(vm: vm, backend: backend, session: session)
     }
 
@@ -310,7 +305,7 @@ final class IntegratedStreamingPerformanceTests: XCTestCase {
     /// active session, both in-memory on the VM and persisted via SwiftData.
     /// Done once before `measure { }` so the timed work is the next message,
     /// not the fixture build.
-    private func seedBacklog(in harness: Harness, messageCount: Int) {
+    private func seedBacklog(in harness: Harness, messageCount: Int) async {
         let sessionID = harness.session.id
         let base = Date(timeIntervalSince1970: 1_000_000)
         for i in 0..<messageCount {
@@ -326,7 +321,7 @@ final class IntegratedStreamingPerformanceTests: XCTestCase {
                 sessionID: sessionID
             )
             harness.vm.messages.append(record)
-            try? SwiftDataPersistenceProvider(modelContext: context)
+            try? await SwiftDataPersistenceProvider(modelContext: context)
                 .insertMessage(record)
         }
     }

--- a/Tests/BaseChatUITests/InterleavingTests.swift
+++ b/Tests/BaseChatUITests/InterleavingTests.swift
@@ -54,10 +54,10 @@ final class InterleavingTests: XCTestCase {
     // MARK: - Helpers
 
     @discardableResult
-    private func createAndActivateSession(title: String = "Test Chat") throws -> ChatSessionRecord {
-        let session = try sessionManager.createSession(title: title)
+    private func createAndActivateSession(title: String = "Test Chat") async throws -> ChatSessionRecord {
+        let session = try await sessionManager.createSession(title: title)
         sessionManager.activeSession = session
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
         return session
     }
 
@@ -71,7 +71,7 @@ final class InterleavingTests: XCTestCase {
     /// Stops mid-generation then immediately sends a second message.
     /// The first assistant reply should be partial; the second should complete fully.
     func test_stopGeneration_thenImmediateResend_completesSecondGeneration() async throws {
-        try createAndActivateSession()
+        try await createAndActivateSession()
 
         // Start first generation with the slow 20-token stream.
         vm.inputText = "first message"
@@ -125,7 +125,7 @@ final class InterleavingTests: XCTestCase {
     /// then generates on B. Verifies no tokens from A leak into B.
     func test_sessionSwitch_duringGeneration_noContentLeakage() async throws {
         // Session A: slow 20-token stream with identifiable tokens.
-        let sessionA = try createAndActivateSession(title: "Session A")
+        let sessionA = try await createAndActivateSession(title: "Session A")
         slowBackend.tokensToYield = (0..<20).map { "alpha\($0) " }
         slowBackend.delayPerToken = .milliseconds(50)
 
@@ -138,9 +138,9 @@ final class InterleavingTests: XCTestCase {
 
         // Create and switch to session B mid-stream.
         // switchToSession now explicitly stops generation and discards stale queue entries.
-        let sessionB = try sessionManager.createSession(title: "Session B")
+        let sessionB = try await sessionManager.createSession(title: "Session B")
         sessionManager.activeSession = sessionB
-        vm.switchToSession(sessionB)
+        await vm.switchToSession(sessionB)
 
         // Generation should be stopped and queue cleared after switch.
         XCTAssertFalse(vm.isGenerating, "isGenerating should be false after session switch stops generation")
@@ -173,12 +173,12 @@ final class InterleavingTests: XCTestCase {
             "Should remain on session B after A's generation finishes")
 
         // Verify persistence: session A has its user message.
-        let sessionAPersistedMessages = try persistence.fetchMessages(for: sessionA.id)
+        let sessionAPersistedMessages = try await persistence.fetchMessages(for: sessionA.id)
         XCTAssertTrue(sessionAPersistedMessages.contains { $0.role == .user && $0.content == "question for A" },
             "Session A should have its user message persisted")
 
         // Verify persistence: session B has a complete user + assistant turn.
-        let sessionBPersistedMessages = try persistence.fetchMessages(for: sessionB.id)
+        let sessionBPersistedMessages = try await persistence.fetchMessages(for: sessionB.id)
         let sessionBUser = sessionBPersistedMessages.filter { $0.role == .user }
         let sessionBAssistant = sessionBPersistedMessages.filter { $0.role == .assistant }
         XCTAssertEqual(sessionBUser.count, 1, "Session B should have 1 user message persisted")
@@ -193,7 +193,7 @@ final class InterleavingTests: XCTestCase {
     /// Verifies the old stream is cancelled cleanly, no orphaned assistant row
     /// survives, and the new model is loaded when the switch completes.
     func test_switchModel_midStream_cancelsAndReloads() async throws {
-        let session = try createAndActivateSession()
+        let session = try await createAndActivateSession()
 
         // Configure a long token stream so generation is still running when we switch.
         slowBackend.tokensToYield = (0..<40).map { "tok\($0) " }
@@ -242,7 +242,7 @@ final class InterleavingTests: XCTestCase {
         //    generation must not have been duplicated. There should be at most one
         //    assistant message in the session.
         let sessionID = session.id
-        let allMessages = try persistence.fetchMessages(for: sessionID)
+        let allMessages = try await persistence.fetchMessages(for: sessionID)
         let assistantRows = allMessages.filter { $0.role == .assistant }
         XCTAssertLessThanOrEqual(
             assistantRows.count, 1,
@@ -265,7 +265,7 @@ final class InterleavingTests: XCTestCase {
     /// Starts generation, stops it, then triggers a model reload.
     /// Verifies generation is stopped and the new model loads successfully.
     func test_rapidModelSwap_duringGeneration_stopsAndReloads() async throws {
-        try createAndActivateSession()
+        try await createAndActivateSession()
 
         // Start generation with slow tokens.
         vm.inputText = "Hello"

--- a/Tests/BaseChatUITests/LargeSessionListPerformanceTests.swift
+++ b/Tests/BaseChatUITests/LargeSessionListPerformanceTests.swift
@@ -35,7 +35,7 @@ final class LargeSessionListPerformanceTests: XCTestCase {
         persistence = SwiftDataPersistenceProvider(modelContext: context)
         vm = SessionManagerViewModel()
         vm.configure(persistence: persistence)
-        try seedLargeFixture()
+        try await seedLargeFixture()
     }
 
     override func tearDown() async throws {
@@ -57,25 +57,35 @@ final class LargeSessionListPerformanceTests: XCTestCase {
 
     /// Cost of advancing one page on scroll. With SwiftData's fetchOffset,
     /// this should stay flat regardless of where in the list the user scrolls.
-    func test_perf_paginationStep() {
+    func test_perf_paginationStep() async {
         // Pre-load to the same baseline as a real scroll session would.
-        vm.loadSessions()
+        await vm.loadSessions()
 
         measure {
             // Reset to the first page each iteration so the measurement is
             // independent — otherwise every iteration after the first would
             // be a no-op once the list is exhausted.
-            vm.loadSessions()
-            vm.loadNextPage()
-            vm.loadNextPage()
+            let exp = expectation(description: "pagination step")
+            Task { @MainActor in
+                await vm.loadSessions()
+                await vm.loadNextPage()
+                await vm.loadNextPage()
+                exp.fulfill()
+            }
+            wait(for: [exp], timeout: 30)
         }
     }
 
     /// End-to-end message search latency at 50K messages — the path users
     /// hit when they type into the search field with "Messages" scope.
-    func test_perf_messageSearchLatency() {
+    func test_perf_messageSearchLatency() async {
         measure {
-            vm.runMessageSearch("findme")
+            let exp = expectation(description: "message search")
+            Task { @MainActor in
+                await vm.runMessageSearch("findme")
+                exp.fulfill()
+            }
+            wait(for: [exp], timeout: 30)
             XCTAssertFalse(vm.messageMatchSessions.isEmpty,
                            "Fixture must seed at least one matching message")
         }
@@ -85,7 +95,7 @@ final class LargeSessionListPerformanceTests: XCTestCase {
 
     /// Seeds 1000 sessions and 50K messages, of which ~10 contain the
     /// "findme" needle so the search test always has work to do.
-    private func seedLargeFixture() throws {
+    private func seedLargeFixture() async throws {
         let base = Date(timeIntervalSince1970: 1_000_000)
         var sessionIDs: [UUID] = []
         sessionIDs.reserveCapacity(sessionCount)
@@ -94,7 +104,7 @@ final class LargeSessionListPerformanceTests: XCTestCase {
                 title: "Session \(i)",
                 updatedAt: base.addingTimeInterval(Double(i))
             )
-            try persistence.insertSession(record)
+            try await persistence.insertSession(record)
             sessionIDs.append(record.id)
         }
 
@@ -106,7 +116,7 @@ final class LargeSessionListPerformanceTests: XCTestCase {
                 let body = isNeedle
                     ? "Earlier we discussed findme as a topic worth revisiting."
                     : "Generic chat content for session \(i) message \(j)."
-                try persistence.insertMessage(ChatMessageRecord(
+                try await persistence.insertMessage(ChatMessageRecord(
                     role: j.isMultiple(of: 2) ? .user : .assistant,
                     content: body,
                     timestamp: base.addingTimeInterval(Double(i * messagesPerSession + j)),

--- a/Tests/BaseChatUITests/LargeSessionListPerformanceTests.swift
+++ b/Tests/BaseChatUITests/LargeSessionListPerformanceTests.swift
@@ -57,16 +57,21 @@ final class LargeSessionListPerformanceTests: XCTestCase {
 
     /// Cost of advancing one page on scroll. With SwiftData's fetchOffset,
     /// this should stay flat regardless of where in the list the user scrolls.
-    func test_perf_paginationStep() async {
+    func test_perf_paginationStep() {
         // Pre-load to the same baseline as a real scroll session would.
-        await vm.loadSessions()
+        let preload = expectation(description: "preload")
+        Task {
+            await vm.loadSessions()
+            preload.fulfill()
+        }
+        wait(for: [preload], timeout: 30)
 
         measure {
             // Reset to the first page each iteration so the measurement is
             // independent — otherwise every iteration after the first would
             // be a no-op once the list is exhausted.
             let exp = expectation(description: "pagination step")
-            Task { @MainActor in
+            Task {
                 await vm.loadSessions()
                 await vm.loadNextPage()
                 await vm.loadNextPage()
@@ -78,10 +83,10 @@ final class LargeSessionListPerformanceTests: XCTestCase {
 
     /// End-to-end message search latency at 50K messages — the path users
     /// hit when they type into the search field with "Messages" scope.
-    func test_perf_messageSearchLatency() async {
+    func test_perf_messageSearchLatency() {
         measure {
             let exp = expectation(description: "message search")
-            Task { @MainActor in
+            Task {
                 await vm.runMessageSearch("findme")
                 exp.fulfill()
             }

--- a/Tests/BaseChatUITests/LoadDispatchCoordinationTests.swift
+++ b/Tests/BaseChatUITests/LoadDispatchCoordinationTests.swift
@@ -197,7 +197,7 @@ final class LoadDispatchCoordinationTests: XCTestCase {
     func test_handleMemoryPressureCritical_preemptsPendingLoadAndSuppressesLateCompletion() async {
         let handler = MemoryPressureHandler()
         let backend = ControlledLoadBackend()
-        let vm = makeViewModel(handler: handler) { service in
+        let vm = await makeViewModel(handler: handler) { service in
             service.registerBackendFactory { modelType in
                 guard modelType == .gguf else { return nil }
                 return backend

--- a/Tests/BaseChatUITests/MemoryAndConcurrencyTests.swift
+++ b/Tests/BaseChatUITests/MemoryAndConcurrencyTests.swift
@@ -53,9 +53,9 @@ final class MemoryAndConcurrencyTests: XCTestCase {
     // MARK: - Test 1: Memory Pressure Warning Level
 
     /// Setting memory pressure to .warning should set an error message but NOT unload the model.
-    func test_handleMemoryPressure_warning_setsErrorButDoesNotUnload() {
+    func test_handleMemoryPressure_warning_setsErrorButDoesNotUnload() async {
         let handler = MemoryPressureHandler()
-        let (vm, mock, _) = makeViewModel(handler: handler)
+        let (vm, mock, _) = await makeViewModel(handler: handler)
 
         // Precondition: no error, model is loaded.
         XCTAssertNil(vm.errorMessage)
@@ -83,9 +83,9 @@ final class MemoryAndConcurrencyTests: XCTestCase {
     // MARK: - Test 2: Memory Pressure Critical Level
 
     /// Setting memory pressure to .critical should unload the model and set an error message.
-    func test_handleMemoryPressure_critical_unloadsModelAndSetsError() {
+    func test_handleMemoryPressure_critical_unloadsModelAndSetsError() async {
         let handler = MemoryPressureHandler()
-        let (vm, mock, _) = makeViewModel(handler: handler)
+        let (vm, mock, _) = await makeViewModel(handler: handler)
 
         // Precondition: model is loaded.
         XCTAssertTrue(mock.isModelLoaded)
@@ -111,9 +111,9 @@ final class MemoryAndConcurrencyTests: XCTestCase {
     // MARK: - Test 3: Memory Pressure Nominal After Critical
 
     /// After critical pressure clears back to nominal, the error message should be cleared.
-    func test_handleMemoryPressure_nominalAfterCritical_clearsError() {
+    func test_handleMemoryPressure_nominalAfterCritical_clearsError() async {
         let handler = MemoryPressureHandler()
-        let (vm, mock, _) = makeViewModel(handler: handler)
+        let (vm, mock, _) = await makeViewModel(handler: handler)
 
         // Transition to critical.
         handler.pressureLevel = .critical
@@ -134,9 +134,9 @@ final class MemoryAndConcurrencyTests: XCTestCase {
 
     /// handleMemoryPressure should only act when the level actually changes.
     /// Calling it twice with the same level should produce side effects only once.
-    func test_handleMemoryPressure_sameLevelTwice_onlyActsOnce() {
+    func test_handleMemoryPressure_sameLevelTwice_onlyActsOnce() async {
         let handler = MemoryPressureHandler()
-        let (vm, mock, _) = makeViewModel(handler: handler)
+        let (vm, mock, _) = await makeViewModel(handler: handler)
 
         // Transition to critical (first call).
         handler.pressureLevel = .critical
@@ -280,7 +280,7 @@ final class MemoryAndConcurrencyTests: XCTestCase {
         XCTAssertFalse(vm.messages.isEmpty, "Should have messages during generation")
 
         // Clear chat while generating.
-        vm.clearChat()
+        await vm.clearChat()
 
         XCTAssertFalse(vm.isGenerating,
             "isGenerating should be false after clearChat")
@@ -299,9 +299,9 @@ final class MemoryAndConcurrencyTests: XCTestCase {
     // MARK: - Memory Pressure Transition Tests (named variants)
 
     /// Critical pressure should unload the model; `inferenceService.isModelLoaded` becomes false.
-    func test_handleMemoryPressure_critical_unloadsModel() {
+    func test_handleMemoryPressure_critical_unloadsModel() async {
         let handler = MemoryPressureHandler()
-        let (vm, mock, _) = makeViewModel(handler: handler)
+        let (vm, mock, _) = await makeViewModel(handler: handler)
 
         // Precondition: model is loaded.
         XCTAssertTrue(vm.inferenceService.isModelLoaded,
@@ -322,9 +322,9 @@ final class MemoryAndConcurrencyTests: XCTestCase {
     }
 
     /// Warning pressure should set an error message but leave the model loaded.
-    func test_handleMemoryPressure_warning_setsErrorMessage() {
+    func test_handleMemoryPressure_warning_setsErrorMessage() async {
         let handler = MemoryPressureHandler()
-        let (vm, mock, _) = makeViewModel(handler: handler)
+        let (vm, mock, _) = await makeViewModel(handler: handler)
 
         handler.pressureLevel = .warning
         vm.handleMemoryPressure()
@@ -339,9 +339,9 @@ final class MemoryAndConcurrencyTests: XCTestCase {
 
     /// Calling `handleMemoryPressure()` twice with the same non-nominal level should
     /// only produce side effects on the first call; the second call is a no-op.
-    func test_handleMemoryPressure_sameLevel_doesNothing() {
+    func test_handleMemoryPressure_sameLevel_doesNothing() async {
         let handler = MemoryPressureHandler()
-        let (vm, _, _) = makeViewModel(handler: handler)
+        let (vm, _, _) = await makeViewModel(handler: handler)
 
         // Transition to warning — first call sets the error.
         handler.pressureLevel = .warning
@@ -359,9 +359,9 @@ final class MemoryAndConcurrencyTests: XCTestCase {
     }
 
     /// After warning sets an error, returning to nominal should clear the memory error.
-    func test_handleMemoryPressure_returnsToNominal_clearsMemoryError() {
+    func test_handleMemoryPressure_returnsToNominal_clearsMemoryError() async {
         let handler = MemoryPressureHandler()
-        let (vm, _, _) = makeViewModel(handler: handler)
+        let (vm, _, _) = await makeViewModel(handler: handler)
 
         // Step 1: transition to warning to set an error.
         handler.pressureLevel = .warning

--- a/Tests/BaseChatUITests/MultiThinkingBlockTests.swift
+++ b/Tests/BaseChatUITests/MultiThinkingBlockTests.swift
@@ -43,7 +43,7 @@ final class MultiThinkingBlockTests: XCTestCase {
         ]
         mock.signaturesPerThinkingBlock = ["sig_one", "sig_two"]
         mock.tokensToYield = ["done"]
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
 
         vm.inputText = "go"
         await vm.sendMessage()

--- a/Tests/BaseChatUITests/PaginationTests.swift
+++ b/Tests/BaseChatUITests/PaginationTests.swift
@@ -39,10 +39,10 @@ final class PaginationTests: XCTestCase {
     // MARK: - Helpers
 
     @discardableResult
-    private func makeSession() -> ChatSessionRecord {
+    private func makeSession() async -> ChatSessionRecord {
         let session = ChatSessionRecord(title: "Pagination Test")
-        try! persistence.insertSession(session)
-        vm.switchToSession(session)
+        try! await persistence.insertSession(session)
+        await vm.switchToSession(session)
         return session
     }
 
@@ -52,7 +52,7 @@ final class PaginationTests: XCTestCase {
         count: Int,
         sessionID: UUID,
         baseTime: Date = Date(timeIntervalSince1970: 1000)
-    ) -> [ChatMessageRecord] {
+    ) async -> [ChatMessageRecord] {
         var records: [ChatMessageRecord] = []
         for i in 0..<count {
             let msg = ChatMessageRecord(
@@ -61,7 +61,7 @@ final class PaginationTests: XCTestCase {
                 timestamp: baseTime.addingTimeInterval(Double(i)),
                 sessionID: sessionID
             )
-            try! persistence.insertMessage(msg)
+            try! await persistence.insertMessage(msg)
             records.append(msg)
         }
         return records
@@ -69,11 +69,11 @@ final class PaginationTests: XCTestCase {
 
     // MARK: - loadMessages
 
-    func test_loadMessages_loadsRecentPage() {
-        let session = makeSession()
-        let msgs = insertMessages(count: 10, sessionID: session.id)
+    func test_loadMessages_loadsRecentPage() async {
+        let session = await makeSession()
+        let msgs = await insertMessages(count: 10, sessionID: session.id)
 
-        vm.loadMessages()
+        await vm.loadMessages()
 
         XCTAssertEqual(vm.messages.count, 10)
         XCTAssertEqual(vm.messages.first?.content, msgs.first?.content)
@@ -81,22 +81,22 @@ final class PaginationTests: XCTestCase {
         XCTAssertFalse(vm.hasOlderMessages, "Fewer than pageSize messages means no older messages")
     }
 
-    func test_loadMessages_setsHasOlderMessages_whenFullPage() {
-        let session = makeSession()
-        insertMessages(count: ChatViewModel.messagePageSize, sessionID: session.id)
+    func test_loadMessages_setsHasOlderMessages_whenFullPage() async {
+        let session = await makeSession()
+        await insertMessages(count: ChatViewModel.messagePageSize, sessionID: session.id)
 
-        vm.loadMessages()
+        await vm.loadMessages()
 
         XCTAssertEqual(vm.messages.count, ChatViewModel.messagePageSize)
         XCTAssertTrue(vm.hasOlderMessages, "Full page should indicate older messages may exist")
     }
 
-    func test_loadMessages_setsHasOlderMessages_whenMoreThanPageSize() {
-        let session = makeSession()
+    func test_loadMessages_setsHasOlderMessages_whenMoreThanPageSize() async {
+        let session = await makeSession()
         let totalCount = ChatViewModel.messagePageSize + 20
-        insertMessages(count: totalCount, sessionID: session.id)
+        await insertMessages(count: totalCount, sessionID: session.id)
 
-        vm.loadMessages()
+        await vm.loadMessages()
 
         XCTAssertEqual(vm.messages.count, ChatViewModel.messagePageSize)
         XCTAssertTrue(vm.hasOlderMessages)
@@ -104,12 +104,12 @@ final class PaginationTests: XCTestCase {
         XCTAssertEqual(vm.messages.last?.content, "Message \(totalCount - 1)")
     }
 
-    func test_loadMessages_withNoSession_clearsState() {
+    func test_loadMessages_withNoSession_clearsState() async {
         vm.activeSession = nil
         vm.messages = [ChatMessageRecord(role: .user, content: "stale", sessionID: UUID())]
         vm.hasOlderMessages = true
 
-        vm.loadMessages()
+        await vm.loadMessages()
 
         XCTAssertTrue(vm.messages.isEmpty)
         XCTAssertFalse(vm.hasOlderMessages)
@@ -117,15 +117,15 @@ final class PaginationTests: XCTestCase {
 
     // MARK: - loadOlderMessages
 
-    func test_loadOlderMessages_prependsOlderPage() {
-        let session = makeSession()
+    func test_loadOlderMessages_prependsOlderPage() async {
+        let session = await makeSession()
         let totalCount = ChatViewModel.messagePageSize + 20
-        let msgs = insertMessages(count: totalCount, sessionID: session.id)
+        let msgs = await insertMessages(count: totalCount, sessionID: session.id)
 
-        vm.loadMessages()
+        await vm.loadMessages()
         XCTAssertEqual(vm.messages.count, ChatViewModel.messagePageSize)
 
-        let anchorID = vm.loadOlderMessages()
+        let anchorID = await vm.loadOlderMessages()
 
         XCTAssertEqual(vm.messages.count, totalCount)
         // Anchor should be the first message from the initial page (index 20 overall).
@@ -133,77 +133,77 @@ final class PaginationTests: XCTestCase {
         XCTAssertEqual(vm.messages.first?.content, "Message 0")
     }
 
-    func test_loadOlderMessages_returnsNil_whenNoOlderMessages() {
-        makeSession()
+    func test_loadOlderMessages_returnsNil_whenNoOlderMessages() async {
+        await makeSession()
 
-        let anchorID = vm.loadOlderMessages()
+        let anchorID = await vm.loadOlderMessages()
         XCTAssertNil(anchorID, "Should return nil when hasOlderMessages is false")
     }
 
-    func test_loadOlderMessages_setsHasOlderToFalse_whenPartialPage() {
-        let session = makeSession()
+    func test_loadOlderMessages_setsHasOlderToFalse_whenPartialPage() async {
+        let session = await makeSession()
         let totalCount = ChatViewModel.messagePageSize + 10
-        insertMessages(count: totalCount, sessionID: session.id)
+        await insertMessages(count: totalCount, sessionID: session.id)
 
-        vm.loadMessages()
+        await vm.loadMessages()
         XCTAssertTrue(vm.hasOlderMessages)
 
-        vm.loadOlderMessages()
+        await vm.loadOlderMessages()
 
         // Only 10 older messages were loaded, which is less than pageSize.
         XCTAssertFalse(vm.hasOlderMessages, "Partial page means no more older messages")
     }
 
-    func test_loadOlderMessages_setsHasOlderToFalse_whenFetchReturnsEmpty() {
-        let session = makeSession()
+    func test_loadOlderMessages_setsHasOlderToFalse_whenFetchReturnsEmpty() async {
+        let session = await makeSession()
         // Insert exactly messagePageSize -- heuristic says there may be more.
-        insertMessages(count: ChatViewModel.messagePageSize, sessionID: session.id)
+        await insertMessages(count: ChatViewModel.messagePageSize, sessionID: session.id)
 
-        vm.loadMessages()
+        await vm.loadMessages()
         XCTAssertTrue(vm.hasOlderMessages)
 
-        vm.loadOlderMessages()
+        await vm.loadOlderMessages()
 
         XCTAssertFalse(vm.hasOlderMessages)
     }
 
-    func test_loadOlderMessages_guardsAgainstConcurrentLoads() {
-        let session = makeSession()
+    func test_loadOlderMessages_guardsAgainstConcurrentLoads() async {
+        let session = await makeSession()
         let totalCount = ChatViewModel.messagePageSize + 20
-        insertMessages(count: totalCount, sessionID: session.id)
+        await insertMessages(count: totalCount, sessionID: session.id)
 
-        vm.loadMessages()
+        await vm.loadMessages()
 
         // Simulate isLoadingOlderMessages being true.
         vm.isLoadingOlderMessages = true
-        let anchorID = vm.loadOlderMessages()
+        let anchorID = await vm.loadOlderMessages()
         XCTAssertNil(anchorID, "Should not load while another load is in progress")
         XCTAssertEqual(vm.messages.count, ChatViewModel.messagePageSize, "Message count should not change")
 
         vm.isLoadingOlderMessages = false
     }
 
-    func test_loadOlderMessages_resetsLoadingFlag() {
-        let session = makeSession()
+    func test_loadOlderMessages_resetsLoadingFlag() async {
+        let session = await makeSession()
         let totalCount = ChatViewModel.messagePageSize + 20
-        insertMessages(count: totalCount, sessionID: session.id)
+        await insertMessages(count: totalCount, sessionID: session.id)
 
-        vm.loadMessages()
-        vm.loadOlderMessages()
+        await vm.loadMessages()
+        await vm.loadOlderMessages()
 
         XCTAssertFalse(vm.isLoadingOlderMessages, "Loading flag should be cleared after load completes")
     }
 
     // MARK: - clearChat resets pagination state
 
-    func test_clearChat_resetsHasOlderMessages() {
-        let session = makeSession()
-        insertMessages(count: ChatViewModel.messagePageSize + 10, sessionID: session.id)
+    func test_clearChat_resetsHasOlderMessages() async {
+        let session = await makeSession()
+        await insertMessages(count: ChatViewModel.messagePageSize + 10, sessionID: session.id)
 
-        vm.loadMessages()
+        await vm.loadMessages()
         XCTAssertTrue(vm.hasOlderMessages)
 
-        vm.clearChat()
+        await vm.clearChat()
 
         XCTAssertFalse(vm.hasOlderMessages)
         XCTAssertTrue(vm.messages.isEmpty)
@@ -211,26 +211,26 @@ final class PaginationTests: XCTestCase {
 
     // MARK: - Mock call tracking
 
-    func test_loadMessages_callsFetchRecentMessages() {
-        let session = makeSession()
-        insertMessages(count: 5, sessionID: session.id)
+    func test_loadMessages_callsFetchRecentMessages() async {
+        let session = await makeSession()
+        await insertMessages(count: 5, sessionID: session.id)
 
         // Reset count after switchToSession's loadMessages call.
         persistence.fetchRecentMessagesCallCount = 0
 
-        vm.loadMessages()
+        await vm.loadMessages()
 
         XCTAssertEqual(persistence.fetchRecentMessagesCallCount, 1)
     }
 
-    func test_loadOlderMessages_callsFetchMessagesBefore() {
-        let session = makeSession()
-        insertMessages(count: ChatViewModel.messagePageSize + 10, sessionID: session.id)
+    func test_loadOlderMessages_callsFetchMessagesBefore() async {
+        let session = await makeSession()
+        await insertMessages(count: ChatViewModel.messagePageSize + 10, sessionID: session.id)
 
-        vm.loadMessages()
+        await vm.loadMessages()
         persistence.fetchMessagesBeforeCallCount = 0
 
-        vm.loadOlderMessages()
+        await vm.loadOlderMessages()
 
         XCTAssertEqual(persistence.fetchMessagesBeforeCallCount, 1)
     }

--- a/Tests/BaseChatUITests/PerceivedLatencyDemoTests.swift
+++ b/Tests/BaseChatUITests/PerceivedLatencyDemoTests.swift
@@ -60,9 +60,9 @@ final class PerceivedLatencyDemoTests: XCTestCase {
     }
 
     func test_sendMessage_assemblesFullResponse_withRealisticLatency() async throws {
-        let session = try sessionManager.createSession(title: "Demo")
+        let session = try await sessionManager.createSession(title: "Demo")
         sessionManager.activeSession = session
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
 
         vm.inputText = "Greet me"
         await vm.sendMessage()

--- a/Tests/BaseChatUITests/PersistenceIntegrationTests.swift
+++ b/Tests/BaseChatUITests/PersistenceIntegrationTests.swift
@@ -43,11 +43,11 @@ final class PersistenceIntegrationTests: XCTestCase {
     // MARK: - Helpers
 
     @discardableResult
-    private func createSession(title: String = "Persistence Test") -> ChatSession {
+    private func createSession(title: String = "Persistence Test") async -> ChatSession {
         let session = ChatSession(title: title)
         context.insert(session)
         try? context.save()
-        vm.switchToSession(session.toRecord())
+        await vm.switchToSession(session.toRecord())
         return session
     }
 
@@ -73,7 +73,7 @@ final class PersistenceIntegrationTests: XCTestCase {
 
     // MARK: - loadMessages with No modelContext
 
-    func test_loadMessages_withNoModelContext_returnsEmpty() {
+    func test_loadMessages_withNoModelContext_returnsEmpty() async {
         // Create a VM without configuring modelContext.
         let service = InferenceService(backend: mock, name: "NoContext")
         let unconfiguredVM = ChatViewModel(inferenceService: service)
@@ -83,7 +83,7 @@ final class PersistenceIntegrationTests: XCTestCase {
         let session = ChatSession(title: "Test")
         unconfiguredVM.activeSession = session.toRecord()
 
-        unconfiguredVM.loadMessages()
+        await unconfiguredVM.loadMessages()
 
         XCTAssertTrue(
             unconfiguredVM.messages.isEmpty,
@@ -93,7 +93,7 @@ final class PersistenceIntegrationTests: XCTestCase {
 
     // MARK: - loadMessages with No activeSession
 
-    func test_loadMessages_withNoActiveSession_clearsMessages() {
+    func test_loadMessages_withNoActiveSession_clearsMessages() async {
         vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
 
         // Manually add a message to the in-memory messages array.
@@ -103,7 +103,7 @@ final class PersistenceIntegrationTests: XCTestCase {
 
         // Ensure no active session.
         vm.activeSession = nil
-        vm.loadMessages()
+        await vm.loadMessages()
 
         XCTAssertTrue(
             vm.messages.isEmpty,
@@ -113,8 +113,8 @@ final class PersistenceIntegrationTests: XCTestCase {
 
     // MARK: - loadMessages Fetches and Sorts by Timestamp
 
-    func test_loadMessages_fetchesAndSortsByTimestamp() {
-        let session = createSession()
+    func test_loadMessages_fetchesAndSortsByTimestamp() async {
+        let session = await createSession()
 
         // Insert messages with explicit timestamps out of order.
         let msg1 = ChatMessage(role: .user, content: "First", sessionID: session.id)
@@ -132,7 +132,7 @@ final class PersistenceIntegrationTests: XCTestCase {
         context.insert(msg2)
         try? context.save()
 
-        vm.loadMessages()
+        await vm.loadMessages()
 
         XCTAssertEqual(vm.messages.count, 3)
         XCTAssertEqual(vm.messages[0].content, "First", "Messages should be sorted by timestamp ascending")
@@ -142,11 +142,11 @@ final class PersistenceIntegrationTests: XCTestCase {
 
     // MARK: - saveMessage Inserts and Can Be Fetched Back
 
-    func test_saveMessage_insertsIntoContextAndFetchesBack() {
-        let session = createSession()
+    func test_saveMessage_insertsIntoContextAndFetchesBack() async {
+        let session = await createSession()
 
         let message = ChatMessage(role: .user, content: "Persisted message", sessionID: session.id)
-        try! vm.saveMessage(message.toRecord())
+        try! await vm.saveMessage(message.toRecord())
 
         let fetched = fetchMessages(for: session.id)
         XCTAssertEqual(fetched.count, 1)
@@ -155,13 +155,13 @@ final class PersistenceIntegrationTests: XCTestCase {
         XCTAssertEqual(fetched[0].sessionID, session.id)
     }
 
-    func test_saveMessage_multipleMessages_allPersisted() {
-        let session = createSession()
+    func test_saveMessage_multipleMessages_allPersisted() async {
+        let session = await createSession()
 
         let msg1 = ChatMessage(role: .user, content: "User msg", sessionID: session.id)
         let msg2 = ChatMessage(role: .assistant, content: "Assistant msg", sessionID: session.id)
-        try! vm.saveMessage(msg1.toRecord())
-        try! vm.saveMessage(msg2.toRecord())
+        try! await vm.saveMessage(msg1.toRecord())
+        try! await vm.saveMessage(msg2.toRecord())
 
         let fetched = fetchMessages(for: session.id)
         XCTAssertEqual(fetched.count, 2)
@@ -169,30 +169,30 @@ final class PersistenceIntegrationTests: XCTestCase {
 
     // MARK: - deleteMessage Removes from Context
 
-    func test_deleteMessage_removesFromContext() {
-        let session = createSession()
+    func test_deleteMessage_removesFromContext() async {
+        let session = await createSession()
 
         let message = ChatMessage(role: .user, content: "To be deleted", sessionID: session.id)
-        try! vm.saveMessage(message.toRecord())
+        try! await vm.saveMessage(message.toRecord())
         XCTAssertEqual(fetchMessages(for: session.id).count, 1)
 
-        try! vm.deleteMessage(message.toRecord())
+        try! await vm.deleteMessage(message.toRecord())
         XCTAssertEqual(
             fetchMessages(for: session.id).count, 0,
             "Message should be removed from the database after deletion"
         )
     }
 
-    func test_deleteMessage_onlyRemovesTargetMessage() {
-        let session = createSession()
+    func test_deleteMessage_onlyRemovesTargetMessage() async {
+        let session = await createSession()
 
         let msg1 = ChatMessage(role: .user, content: "Keep this", sessionID: session.id)
         let msg2 = ChatMessage(role: .assistant, content: "Delete this", sessionID: session.id)
-        try! vm.saveMessage(msg1.toRecord())
-        try! vm.saveMessage(msg2.toRecord())
+        try! await vm.saveMessage(msg1.toRecord())
+        try! await vm.saveMessage(msg2.toRecord())
         XCTAssertEqual(fetchMessages(for: session.id).count, 2)
 
-        try! vm.deleteMessage(msg2.toRecord())
+        try! await vm.deleteMessage(msg2.toRecord())
 
         let remaining = fetchMessages(for: session.id)
         XCTAssertEqual(remaining.count, 1)
@@ -203,7 +203,7 @@ final class PersistenceIntegrationTests: XCTestCase {
 
     func test_multiSessionIsolation_messagesDoNotBleed() async {
         // Session A
-        let sessionA = createSession(title: "Session A")
+        let sessionA = await createSession(title: "Session A")
         mock.tokensToYield = ["Alpha", " reply"]
         vm.inputText = "Alpha question"
         await vm.sendMessage()
@@ -212,7 +212,7 @@ final class PersistenceIntegrationTests: XCTestCase {
         XCTAssertEqual(sessionAMessages.count, 2)
 
         // Session B
-        let sessionB = createSession(title: "Session B")
+        let sessionB = await createSession(title: "Session B")
         mock.tokensToYield = ["Beta", " reply"]
         vm.inputText = "Beta question"
         await vm.sendMessage()
@@ -231,13 +231,13 @@ final class PersistenceIntegrationTests: XCTestCase {
     }
 
     func test_multiSessionIsolation_switchingReloadsCorrectMessages() async {
-        let sessionA = createSession(title: "Session A")
+        let sessionA = await createSession(title: "Session A")
         mock.tokensToYield = ["A", " response"]
         vm.inputText = "Question for A"
         await vm.sendMessage()
         XCTAssertEqual(vm.messages.count, 2)
 
-        let sessionB = createSession(title: "Session B")
+        let sessionB = await createSession(title: "Session B")
         mock.tokensToYield = ["B", " response"]
         vm.inputText = "Question for B"
         await vm.sendMessage()
@@ -245,12 +245,12 @@ final class PersistenceIntegrationTests: XCTestCase {
         XCTAssertEqual(vm.messages[0].content, "Question for B")
 
         // Switch back to A.
-        vm.switchToSession(sessionA.toRecord())
+        await vm.switchToSession(sessionA.toRecord())
         XCTAssertEqual(vm.messages.count, 2)
         XCTAssertEqual(vm.messages[0].content, "Question for A", "Switching should reload session A messages")
 
         // Switch to B.
-        vm.switchToSession(sessionB.toRecord())
+        await vm.switchToSession(sessionB.toRecord())
         XCTAssertEqual(vm.messages.count, 2)
         XCTAssertEqual(vm.messages[0].content, "Question for B", "Switching should reload session B messages")
     }
@@ -258,7 +258,7 @@ final class PersistenceIntegrationTests: XCTestCase {
     // MARK: - Cascade: Deleting a Session Handles Its Messages
 
     func test_deleteSession_removesAssociatedMessages() async throws {
-        let session = createSession(title: "Doomed Session")
+        let session = await createSession(title: "Doomed Session")
         mock.tokensToYield = ["Doomed", " reply"]
         vm.inputText = "Message in doomed session"
         await vm.sendMessage()
@@ -271,7 +271,7 @@ final class PersistenceIntegrationTests: XCTestCase {
         // Use SessionManagerViewModel to delete the session (it handles cascade).
         let sessionManager = SessionManagerViewModel()
         sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
-        try sessionManager.deleteSession(session.toRecord())
+        try await sessionManager.deleteSession(session.toRecord())
 
         XCTAssertEqual(
             fetchMessages(for: sessionID).count, 0,
@@ -285,13 +285,13 @@ final class PersistenceIntegrationTests: XCTestCase {
 
     func test_deleteSession_doesNotAffectOtherSessions() async throws {
         // Create session A with messages.
-        let sessionA = createSession(title: "Survivor")
+        let sessionA = await createSession(title: "Survivor")
         mock.tokensToYield = ["Survivor", " reply"]
         vm.inputText = "Survivor question"
         await vm.sendMessage()
 
         // Create session B with messages.
-        let sessionB = createSession(title: "Victim")
+        let sessionB = await createSession(title: "Victim")
         mock.tokensToYield = ["Victim", " reply"]
         vm.inputText = "Victim question"
         await vm.sendMessage()
@@ -302,7 +302,7 @@ final class PersistenceIntegrationTests: XCTestCase {
         // Delete session B.
         let sessionManager = SessionManagerViewModel()
         sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
-        try sessionManager.deleteSession(sessionB.toRecord())
+        try await sessionManager.deleteSession(sessionB.toRecord())
 
         // Session A should be unaffected.
         XCTAssertEqual(
@@ -317,34 +317,34 @@ final class PersistenceIntegrationTests: XCTestCase {
 
     // MARK: - Typed Record Field Round-Trips
 
-    func test_sessionRecord_promptTemplate_roundTrips() throws {
+    func test_sessionRecord_promptTemplate_roundTrips() async throws {
         let persistence = SwiftDataPersistenceProvider(modelContext: context)
         var record = ChatSessionRecord(title: "Template Test")
         record.promptTemplate = .llama3
-        try persistence.insertSession(record)
+        try await persistence.insertSession(record)
 
-        let fetched = try persistence.fetchSessions().first { $0.id == record.id }
+        let fetched = try await persistence.fetchSessions().first { $0.id == record.id }
         XCTAssertEqual(fetched?.promptTemplate, .llama3)
     }
 
-    func test_sessionRecord_pinnedMessageIDs_roundTrips() throws {
+    func test_sessionRecord_pinnedMessageIDs_roundTrips() async throws {
         let persistence = SwiftDataPersistenceProvider(modelContext: context)
         let pinA = UUID()
         let pinB = UUID()
         var record = ChatSessionRecord(title: "Pin Test")
         record.pinnedMessageIDs = [pinA, pinB]
-        try persistence.insertSession(record)
+        try await persistence.insertSession(record)
 
-        let fetched = try persistence.fetchSessions().first { $0.id == record.id }
+        let fetched = try await persistence.fetchSessions().first { $0.id == record.id }
         XCTAssertEqual(fetched?.pinnedMessageIDs, [pinA, pinB])
     }
 
-    func test_sessionRecord_defaults_roundTrip() throws {
+    func test_sessionRecord_defaults_roundTrip() async throws {
         let persistence = SwiftDataPersistenceProvider(modelContext: context)
         let record = ChatSessionRecord(title: "Defaults Test")
-        try persistence.insertSession(record)
+        try await persistence.insertSession(record)
 
-        let fetched = try persistence.fetchSessions().first { $0.id == record.id }
+        let fetched = try await persistence.fetchSessions().first { $0.id == record.id }
         XCTAssertNil(fetched?.promptTemplate)
         XCTAssertEqual(fetched?.pinnedMessageIDs, [])
     }

--- a/Tests/BaseChatUITests/PinMessageTests.swift
+++ b/Tests/BaseChatUITests/PinMessageTests.swift
@@ -27,12 +27,12 @@ final class PinMessageTests: XCTestCase {
     }
 
     @discardableResult
-    private func createSession(title: String = "Pin Test") -> ChatSessionRecord {
+    private func createSession(title: String = "Pin Test") async -> ChatSessionRecord {
         let session = ChatSession(title: title)
         context.insert(session)
         try? context.save()
         let record = session.toRecord()
-        vm.switchToSession(record)
+        await vm.switchToSession(record)
         return record
     }
 
@@ -45,59 +45,59 @@ final class PinMessageTests: XCTestCase {
 
     // MARK: - Tests
 
-    func test_pinMessage_addsToSet() {
-        createSession()
+    func test_pinMessage_addsToSet() async {
+        await createSession()
         let id = makeMessageID()
 
-        vm.pinMessage(id: id)
+        await vm.pinMessage(id: id)
 
         XCTAssertTrue(vm.isMessagePinned(id: id),
                       "isMessagePinned should return true after pinMessage")
     }
 
-    func test_unpinMessage_removesFromSet() {
-        createSession()
+    func test_unpinMessage_removesFromSet() async {
+        await createSession()
         let id = makeMessageID()
 
-        vm.pinMessage(id: id)
+        await vm.pinMessage(id: id)
         XCTAssertTrue(vm.isMessagePinned(id: id), "Precondition: message should be pinned")
 
-        vm.unpinMessage(id: id)
+        await vm.unpinMessage(id: id)
 
         XCTAssertFalse(vm.isMessagePinned(id: id),
                        "isMessagePinned should return false after unpinMessage")
     }
 
-    func test_pinMessage_idempotent() {
-        createSession()
+    func test_pinMessage_idempotent() async {
+        await createSession()
         let id = makeMessageID()
 
-        vm.pinMessage(id: id)
-        vm.pinMessage(id: id)
+        await vm.pinMessage(id: id)
+        await vm.pinMessage(id: id)
 
         XCTAssertEqual(vm.pinnedMessageIDs.count, 1,
                        "pinnedMessageIDs should contain exactly 1 entry after pinning the same message twice")
     }
 
-    func test_unpin_unpinnedMessage_doesNotCrash() {
-        createSession()
+    func test_unpin_unpinnedMessage_doesNotCrash() async {
+        await createSession()
         let id = makeMessageID()
 
-        vm.unpinMessage(id: id)
+        await vm.unpinMessage(id: id)
 
         XCTAssertFalse(vm.isMessagePinned(id: id),
                        "Message should remain unpinned after unpinMessage on a non-pinned message")
     }
 
-    func test_pinMultipleMessages_allPinned() {
-        createSession()
+    func test_pinMultipleMessages_allPinned() async {
+        await createSession()
         let id1 = makeMessageID(content: "First")
         let id2 = makeMessageID(content: "Second")
         let id3 = makeMessageID(content: "Third")
 
-        vm.pinMessage(id: id1)
-        vm.pinMessage(id: id2)
-        vm.pinMessage(id: id3)
+        await vm.pinMessage(id: id1)
+        await vm.pinMessage(id: id2)
+        await vm.pinMessage(id: id3)
 
         XCTAssertTrue(vm.isMessagePinned(id: id1), "msg1 should be pinned")
         XCTAssertTrue(vm.isMessagePinned(id: id2), "msg2 should be pinned")
@@ -106,16 +106,16 @@ final class PinMessageTests: XCTestCase {
                        "All 3 messages should appear in pinnedMessageIDs")
     }
 
-    func test_pinnedState_clearedOnSessionSwitch() {
-        createSession(title: "Session A")
+    func test_pinnedState_clearedOnSessionSwitch() async {
+        await createSession(title: "Session A")
         let idA = makeMessageID(content: "Message in A")
-        vm.pinMessage(id: idA)
+        await vm.pinMessage(id: idA)
         XCTAssertTrue(vm.isMessagePinned(id: idA), "Precondition: msgA should be pinned in session A")
 
         let sessionB = ChatSession(title: "Session B")
         context.insert(sessionB)
         try? context.save()
-        vm.switchToSession(sessionB.toRecord())
+        await vm.switchToSession(sessionB.toRecord())
 
         XCTAssertFalse(vm.pinnedMessageIDs.contains(idA),
                        "Pins from session A should not be visible after switching to session B")

--- a/Tests/BaseChatUITests/PinnedMessageIndicatorTests.swift
+++ b/Tests/BaseChatUITests/PinnedMessageIndicatorTests.swift
@@ -36,11 +36,11 @@ final class PinnedMessageIndicatorTests: XCTestCase {
     // MARK: - Helpers
 
     @discardableResult
-    private func createSession(title: String = "Pin Test") -> ChatSession {
+    private func createSession(title: String = "Pin Test") async -> ChatSession {
         let session = ChatSession(title: title)
         context.insert(session)
         try? context.save()
-        vm.switchToSession(session.toRecord())
+        await vm.switchToSession(session.toRecord())
         return session
     }
 
@@ -53,56 +53,56 @@ final class PinnedMessageIndicatorTests: XCTestCase {
 
     // MARK: - Tests
 
-    func test_isMessagePinned_falseBeforePin() {
-        createSession()
+    func test_isMessagePinned_falseBeforePin() async {
+        await createSession()
         let message = makeMessage()
 
         XCTAssertFalse(vm.isMessagePinned(id: message.id),
                        "A newly created message should not be pinned")
     }
 
-    func test_isMessagePinned_trueAfterPin() {
-        createSession()
+    func test_isMessagePinned_trueAfterPin() async {
+        await createSession()
         let message = makeMessage()
 
-        vm.pinMessage(id: message.id)
+        await vm.pinMessage(id: message.id)
 
         XCTAssertTrue(vm.isMessagePinned(id: message.id),
                       "isMessagePinned should return true after pinMessage")
     }
 
-    func test_isMessagePinned_falseAfterUnpin() {
-        createSession()
+    func test_isMessagePinned_falseAfterUnpin() async {
+        await createSession()
         let message = makeMessage()
 
-        vm.pinMessage(id: message.id)
+        await vm.pinMessage(id: message.id)
         XCTAssertTrue(vm.isMessagePinned(id: message.id), "Precondition: message should be pinned")
 
-        vm.unpinMessage(id: message.id)
+        await vm.unpinMessage(id: message.id)
 
         XCTAssertFalse(vm.isMessagePinned(id: message.id),
                        "isMessagePinned should return false after unpinMessage")
     }
 
-    func test_pinnedMessageIDs_persistedToSession() {
-        let session = createSession()
+    func test_pinnedMessageIDs_persistedToSession() async {
+        let session = await createSession()
         let message = makeMessage()
 
-        vm.pinMessage(id: message.id)
+        await vm.pinMessage(id: message.id)
 
         XCTAssertTrue(session.toRecord().pinnedMessageIDs.contains(message.id),
                       "After pinMessage, the session's pinnedMessageIDs should contain the message's id")
     }
 
-    func test_unpinnedMessage_removedFromSession() {
-        let session = createSession()
+    func test_unpinnedMessage_removedFromSession() async {
+        let session = await createSession()
         let message = makeMessage()
 
-        vm.pinMessage(id: message.id)
+        await vm.pinMessage(id: message.id)
         XCTAssertTrue(session.toRecord().pinnedMessageIDs.contains(message.id),
                       "Precondition: session should contain the pinned id")
 
-        vm.unpinMessage(id: message.id)
+        await vm.unpinMessage(id: message.id)
 
         XCTAssertFalse(session.toRecord().pinnedMessageIDs.contains(message.id),
                        "After unpinMessage, the session's pinnedMessageIDs should no longer contain the id")

--- a/Tests/BaseChatUITests/PostGenerationTaskTests.swift
+++ b/Tests/BaseChatUITests/PostGenerationTaskTests.swift
@@ -50,17 +50,17 @@ final class PostGenerationTaskTests: XCTestCase {
     // MARK: - Helpers
 
     @discardableResult
-    private func createAndActivateSession(title: String = "Test") -> ChatSessionRecord {
-        let session = try! sessionManager.createSession(title: title)
+    private func createAndActivateSession(title: String = "Test") async -> ChatSessionRecord {
+        let session = try! await sessionManager.createSession(title: title)
         sessionManager.activeSession = session
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
         return session
     }
 
     // MARK: - Basic Invocation
 
     func test_postGenerationTask_calledAfterGeneration() async {
-        createAndActivateSession()
+        await createAndActivateSession()
         let task = MockPostGenerationTask()
         vm.postGenerationTasks = [task]
 
@@ -74,7 +74,7 @@ final class PostGenerationTaskTests: XCTestCase {
     }
 
     func test_postGenerationTask_receivesCompletedMessage() async {
-        createAndActivateSession()
+        await createAndActivateSession()
         let task = MockPostGenerationTask()
         vm.postGenerationTasks = [task]
 
@@ -88,7 +88,7 @@ final class PostGenerationTaskTests: XCTestCase {
     }
 
     func test_postGenerationTask_receivesActiveSession() async {
-        let session = createAndActivateSession(title: "My Session")
+        let session = await createAndActivateSession(title: "My Session")
         let task = MockPostGenerationTask()
         vm.postGenerationTasks = [task]
 
@@ -102,7 +102,7 @@ final class PostGenerationTaskTests: XCTestCase {
     // MARK: - Execution Order
 
     func test_multiplePostGenerationTasks_runInRegistrationOrder() async {
-        createAndActivateSession()
+        await createAndActivateSession()
 
         let order = ActorBox<[Int]>([])
         let task1 = OrderCapturingTask(index: 1, box: order)
@@ -122,7 +122,7 @@ final class PostGenerationTaskTests: XCTestCase {
     // MARK: - Error Isolation
 
     func test_throwingTask_doesNotCancelSubsequentTasks() async {
-        createAndActivateSession()
+        await createAndActivateSession()
 
         struct TestError: Error {}
         let failingTask = MockPostGenerationTask()
@@ -141,7 +141,7 @@ final class PostGenerationTaskTests: XCTestCase {
     }
 
     func test_throwingTask_surfacesErrorInBackgroundTaskError() async {
-        createAndActivateSession()
+        await createAndActivateSession()
 
         struct TestError: Error, LocalizedError {
             var errorDescription: String? { "Background error" }
@@ -160,7 +160,7 @@ final class PostGenerationTaskTests: XCTestCase {
     }
 
     func test_successfulTask_doesNotSetBackgroundTaskError() async {
-        createAndActivateSession()
+        await createAndActivateSession()
 
         let task = MockPostGenerationTask()
         vm.postGenerationTasks = [task]
@@ -175,8 +175,8 @@ final class PostGenerationTaskTests: XCTestCase {
     // MARK: - Cancellation on Session Reset
 
     func test_postGenerationTask_cancelledOnSessionReset() async throws {
-        createAndActivateSession(title: "Session A")
-        let sessionB = try! sessionManager.createSession(title: "Session B")
+        await createAndActivateSession(title: "Session A")
+        let sessionB = try! await sessionManager.createSession(title: "Session B")
 
         let slowTask = MockPostGenerationTask()
         slowTask.runDelay = .seconds(10)  // Long enough to remain in-flight during session switch.
@@ -192,7 +192,7 @@ final class PostGenerationTaskTests: XCTestCase {
 
         // Background task is now running (slowTask sleeping for 10 s).
         // Switching session cancels it before quickTask gets a chance to run.
-        vm.switchToSession(sessionB)
+        await vm.switchToSession(sessionB)
 
         // Wait for the cancelled task to finish cooperatively — deterministic, no fixed sleep.
         await inflight?.value
@@ -203,7 +203,7 @@ final class PostGenerationTaskTests: XCTestCase {
     // MARK: - No Task Fired for Empty Response
 
     func test_postGenerationTask_notCalledForEmptyResponse() async {
-        createAndActivateSession()
+        await createAndActivateSession()
 
         let task = MockPostGenerationTask()
         vm.postGenerationTasks = [task]

--- a/Tests/BaseChatUITests/RuntimeConfigurationTests.swift
+++ b/Tests/BaseChatUITests/RuntimeConfigurationTests.swift
@@ -6,7 +6,7 @@ import XCTest
 @MainActor
 final class RuntimeConfigurationTests: XCTestCase {
 
-    func test_configureRuntime_wiresSharedPersistenceAndDiagnostics() throws {
+    func test_configureRuntime_wiresSharedPersistenceAndDiagnostics() async throws {
         let originalConfiguration = BaseChatConfiguration.shared
         defer { BaseChatConfiguration.shared = originalConfiguration }
 
@@ -47,11 +47,12 @@ final class RuntimeConfigurationTests: XCTestCase {
         XCTAssertTrue(managerPersistence === runtime.persistence)
         XCTAssertTrue(sessionManager.diagnostics === runtime.diagnostics)
 
-        let created = try sessionManager.createSession(title: "Runtime Session")
-        XCTAssertEqual(try runtime.persistence.fetchSessions().map(\.id), [created.id])
+        let created = try await sessionManager.createSession(title: "Runtime Session")
+        let persistedIDs = try await runtime.persistence.fetchSessions().map(\.id)
+        XCTAssertEqual(persistedIDs, [created.id])
     }
 
-    func test_runtimeBootstrap_canSeedAndActivateInitialSessionWithoutViewLifecycleHooks() throws {
+    func test_runtimeBootstrap_canSeedAndActivateInitialSessionWithoutViewLifecycleHooks() async throws {
         let originalConfiguration = BaseChatConfiguration.shared
         defer { BaseChatConfiguration.shared = originalConfiguration }
 
@@ -80,18 +81,24 @@ final class RuntimeConfigurationTests: XCTestCase {
         sessionManager.configure(runtime: runtime)
         chatViewModel.refreshModels()
 
-        let initialSession = sessionManager.sessions.first ?? (try? sessionManager.createSession())
-        guard let initialSession else {
+        let resolvedInitial: ChatSessionRecord?
+        if let existing = sessionManager.sessions.first {
+            resolvedInitial = existing
+        } else {
+            resolvedInitial = try? await sessionManager.createSession()
+        }
+        guard let initialSession = resolvedInitial else {
             XCTFail("Bootstrap should create or restore an initial session")
             return
         }
 
         sessionManager.activeSession = initialSession
-        chatViewModel.switchToSession(initialSession)
+        await chatViewModel.switchToSession(initialSession)
         chatViewModel.dispatchSelectedLoad()
 
         XCTAssertEqual(sessionManager.activeSession?.id, initialSession.id)
         XCTAssertEqual(chatViewModel.activeSession?.id, initialSession.id)
-        XCTAssertEqual(try runtime.persistence.fetchSessions().map(\.id), [initialSession.id])
+        let persistedIDs = try await runtime.persistence.fetchSessions().map(\.id)
+        XCTAssertEqual(persistedIDs, [initialSession.id])
     }
 }

--- a/Tests/BaseChatUITests/RuntimeConfigurationTests.swift
+++ b/Tests/BaseChatUITests/RuntimeConfigurationTests.swift
@@ -80,6 +80,10 @@ final class RuntimeConfigurationTests: XCTestCase {
         chatViewModel.configure(runtime: runtime)
         sessionManager.configure(runtime: runtime)
         chatViewModel.refreshModels()
+        // Phase 1.0: `configure` no longer auto-fires `loadSessions()`.
+        // Hosts that bypass `SessionListView` (which calls it from
+        // `.task { }`) must load explicitly during bootstrap.
+        await sessionManager.loadSessions()
 
         let resolvedInitial: ChatSessionRecord?
         if let existing = sessionManager.sessions.first {

--- a/Tests/BaseChatUITests/SessionAutoRenameTests.swift
+++ b/Tests/BaseChatUITests/SessionAutoRenameTests.swift
@@ -46,7 +46,7 @@ final class SessionAutoRenameTests: XCTestCase {
     // MARK: - Tests
 
     func test_autoRename_updatesSessionTitle() async {
-        let session = try! vm.createSession()
+        let session = try! await vm.createSession()
         XCTAssertEqual(session.title, "New Chat")
 
         let service = makeInferenceService(tokens: ["Travel", " Planning", " Tips"])
@@ -58,7 +58,7 @@ final class SessionAutoRenameTests: XCTestCase {
     }
 
     func test_autoRename_onError_keepsExistingTitle() async {
-        let session = try! vm.createSession()
+        let session = try! await vm.createSession()
         XCTAssertEqual(session.title, "New Chat")
 
         let service = makeThrowingInferenceService()
@@ -78,7 +78,7 @@ final class SessionAutoRenameTests: XCTestCase {
             diagnostics: diagnostics
         )
 
-        let session = try freshVM.createSession()
+        let session = try await freshVM.createSession()
         let service = makeThrowingInferenceService()
 
         await freshVM.autoRenameSession(session, firstMessage: "Tell me about dogs", inferenceService: service)
@@ -103,7 +103,7 @@ final class SessionAutoRenameTests: XCTestCase {
         let freshVM = SessionManagerViewModel()
         freshVM.configure(persistence: wrappedPersistence, diagnostics: diagnostics)
 
-        let session = try freshVM.createSession()
+        let session = try await freshVM.createSession()
         wrappedPersistence.shouldThrowOnUpdateSession = ChatPersistenceError.providerNotConfigured
 
         let service = makeInferenceService(tokens: ["Cooking", " Basics"])
@@ -123,7 +123,7 @@ final class SessionAutoRenameTests: XCTestCase {
     }
 
     func test_autoRename_truncatesLongTitle() async {
-        let session = try! vm.createSession()
+        let session = try! await vm.createSession()
 
         // 60-character title returned by the mock
         let longTitle = "This Is A Very Long Title That Definitely Exceeds Fifty Char"
@@ -139,7 +139,7 @@ final class SessionAutoRenameTests: XCTestCase {
     }
 
     func test_autoRename_trimsWhitespace() async {
-        let session = try! vm.createSession()
+        let session = try! await vm.createSession()
 
         let service = makeInferenceService(tokens: ["  My Title  \n"])
 
@@ -161,7 +161,7 @@ final class SessionAutoRenameTests: XCTestCase {
         mock.tokensToYield = ["Smart", " Home", " Setup"]
         let service = InferenceService(backend: mock, name: "Mock")
 
-        let session = try! vm.createSession()
+        let session = try! await vm.createSession()
         XCTAssertEqual(session.title, "New Chat")
 
         await vm.autoRenameSession(session, firstMessage: "How do I set up smart home devices?", inferenceService: service)
@@ -192,7 +192,7 @@ final class SessionAutoRenameTests: XCTestCase {
         _ = activeToken // silence unused-variable warning
 
         // Active slot is now occupied. The next enqueue will stay in requestQueue.
-        let session = try! vm.createSession()
+        let session = try! await vm.createSession()
 
         // Fire autoRenameSession in a background Task so it can call enqueue()
         // without blocking the main actor. We capture the task to cancel later.

--- a/Tests/BaseChatUITests/SessionManagerSearchPaginationTests.swift
+++ b/Tests/BaseChatUITests/SessionManagerSearchPaginationTests.swift
@@ -36,9 +36,9 @@ final class SessionManagerSearchPaginationTests: XCTestCase {
 
     // MARK: - Title search
 
-    func test_titleSearch_isCaseInsensitive() throws {
-        try seedSessions(titles: ["Travel Plan", "Recipes", "TRAVEL guide", "Other"])
-        vm.loadSessions()
+    func test_titleSearch_isCaseInsensitive() async throws {
+        try await seedSessions(titles: ["Travel Plan", "Recipes", "TRAVEL guide", "Other"])
+        await vm.loadSessions()
 
         vm.runTitleSearch("travel")
 
@@ -47,9 +47,9 @@ final class SessionManagerSearchPaginationTests: XCTestCase {
         XCTAssertTrue(vm.titleMatches.contains { $0.title == "TRAVEL guide" })
     }
 
-    func test_titleSearch_emptyQueryClearsMatches() throws {
-        try seedSessions(titles: ["A", "B"])
-        vm.loadSessions()
+    func test_titleSearch_emptyQueryClearsMatches() async throws {
+        try await seedSessions(titles: ["A", "B"])
+        await vm.loadSessions()
         vm.runTitleSearch("A")
         XCTAssertFalse(vm.titleMatches.isEmpty)
 
@@ -58,9 +58,9 @@ final class SessionManagerSearchPaginationTests: XCTestCase {
         XCTAssertTrue(vm.titleMatches.isEmpty)
     }
 
-    func test_titleSearch_preservesRecencyOrder() throws {
-        try seedSessions(titles: ["alpha old", "alpha new", "beta"], spacingSeconds: 60)
-        vm.loadSessions()
+    func test_titleSearch_preservesRecencyOrder() async throws {
+        try await seedSessions(titles: ["alpha old", "alpha new", "beta"], spacingSeconds: 60)
+        await vm.loadSessions()
 
         vm.runTitleSearch("alpha")
 
@@ -70,16 +70,16 @@ final class SessionManagerSearchPaginationTests: XCTestCase {
 
     // MARK: - Message search
 
-    func test_messageSearch_returnsSessionsWithMatchingMessages() throws {
-        let s1 = try seedSession(title: "S1")
-        let s2 = try seedSession(title: "S2")
-        let s3 = try seedSession(title: "S3")
-        try persistence.insertMessage(ChatMessageRecord(role: .user, content: "tell me about NEEDLE in haystack", sessionID: s1.id))
-        try persistence.insertMessage(ChatMessageRecord(role: .user, content: "no match here", sessionID: s2.id))
-        try persistence.insertMessage(ChatMessageRecord(role: .user, content: "more needle talk", sessionID: s3.id))
-        vm.loadSessions()
+    func test_messageSearch_returnsSessionsWithMatchingMessages() async throws {
+        let s1 = try await seedSession(title: "S1")
+        let s2 = try await seedSession(title: "S2")
+        let s3 = try await seedSession(title: "S3")
+        try await persistence.insertMessage(ChatMessageRecord(role: .user, content: "tell me about NEEDLE in haystack", sessionID: s1.id))
+        try await persistence.insertMessage(ChatMessageRecord(role: .user, content: "no match here", sessionID: s2.id))
+        try await persistence.insertMessage(ChatMessageRecord(role: .user, content: "more needle talk", sessionID: s3.id))
+        await vm.loadSessions()
 
-        vm.runMessageSearch("needle")
+        await vm.runMessageSearch("needle")
 
         XCTAssertEqual(Set(vm.messageMatchSessions.map(\.id)), [s1.id, s3.id])
         XCTAssertEqual(vm.messageHitsBySession[s1.id]?.count, 1)
@@ -87,23 +87,23 @@ final class SessionManagerSearchPaginationTests: XCTestCase {
         XCTAssertNil(vm.messageHitsBySession[s2.id])
     }
 
-    func test_messageSearch_emptyQueryClearsResults() throws {
-        let s1 = try seedSession(title: "S1")
-        try persistence.insertMessage(ChatMessageRecord(role: .user, content: "needle", sessionID: s1.id))
-        vm.runMessageSearch("needle")
+    func test_messageSearch_emptyQueryClearsResults() async throws {
+        let s1 = try await seedSession(title: "S1")
+        try await persistence.insertMessage(ChatMessageRecord(role: .user, content: "needle", sessionID: s1.id))
+        await vm.runMessageSearch("needle")
         XCTAssertFalse(vm.messageMatchSessions.isEmpty)
 
-        vm.runMessageSearch("")
+        await vm.runMessageSearch("")
 
         XCTAssertTrue(vm.messageMatchSessions.isEmpty)
         XCTAssertTrue(vm.messageHitsBySession.isEmpty)
     }
 
-    func test_messageSearch_snippetIsHighlightable() throws {
-        let s = try seedSession(title: "S")
-        try persistence.insertMessage(ChatMessageRecord(role: .user, content: "find the NEEDLE here", sessionID: s.id))
+    func test_messageSearch_snippetIsHighlightable() async throws {
+        let s = try await seedSession(title: "S")
+        try await persistence.insertMessage(ChatMessageRecord(role: .user, content: "find the NEEDLE here", sessionID: s.id))
 
-        vm.runMessageSearch("needle")
+        await vm.runMessageSearch("needle")
 
         let hit = try XCTUnwrap(vm.messageHitsBySession[s.id]?.first)
         XCTAssertTrue(String(hit.snippet[hit.matchRange]).localizedStandardContains("needle"))
@@ -111,17 +111,17 @@ final class SessionManagerSearchPaginationTests: XCTestCase {
 
     // MARK: - Display + empty state
 
-    func test_displayedSessions_fallsBackToFullListWhenQueryEmpty() throws {
-        try seedSessions(titles: ["a", "b", "c"])
-        vm.loadSessions()
+    func test_displayedSessions_fallsBackToFullListWhenQueryEmpty() async throws {
+        try await seedSessions(titles: ["a", "b", "c"])
+        await vm.loadSessions()
 
         XCTAssertEqual(vm.displayedSessions.count, 3)
         XCTAssertFalse(vm.hasNoSearchResults)
     }
 
-    func test_hasNoSearchResults_trueWhenTitleQueryMatchesNothing() throws {
-        try seedSessions(titles: ["alpha", "beta"])
-        vm.loadSessions()
+    func test_hasNoSearchResults_trueWhenTitleQueryMatchesNothing() async throws {
+        try await seedSessions(titles: ["alpha", "beta"])
+        await vm.loadSessions()
 
         vm.searchScope = .titles
         vm.searchQuery = "absent"
@@ -131,9 +131,9 @@ final class SessionManagerSearchPaginationTests: XCTestCase {
         XCTAssertTrue(vm.displayedSessions.isEmpty)
     }
 
-    func test_clearSearch_resetsToFullList() throws {
-        try seedSessions(titles: ["one", "two"])
-        vm.loadSessions()
+    func test_clearSearch_resetsToFullList() async throws {
+        try await seedSessions(titles: ["one", "two"])
+        await vm.loadSessions()
         vm.searchQuery = "one"
         vm.runTitleSearch("one")
         XCTAssertEqual(vm.titleMatches.count, 1)
@@ -147,45 +147,45 @@ final class SessionManagerSearchPaginationTests: XCTestCase {
 
     // MARK: - Pagination
 
-    func test_loadSessions_loadsFirstPageOnly() throws {
-        try seedSessions(count: 120, prefix: "S", spacingSeconds: 1)
+    func test_loadSessions_loadsFirstPageOnly() async throws {
+        try await seedSessions(count: 120, prefix: "S", spacingSeconds: 1)
 
-        vm.loadSessions()
+        await vm.loadSessions()
 
         XCTAssertEqual(vm.sessions.count, SessionManagerViewModel.sessionsPageSize)
         XCTAssertTrue(vm.hasMoreSessions, "Should signal more pages remain")
     }
 
-    func test_loadNextPage_appendsAndAdvancesCursor() throws {
-        try seedSessions(count: 130, prefix: "S", spacingSeconds: 1)
-        vm.loadSessions()
+    func test_loadNextPage_appendsAndAdvancesCursor() async throws {
+        try await seedSessions(count: 130, prefix: "S", spacingSeconds: 1)
+        await vm.loadSessions()
         XCTAssertEqual(vm.sessions.count, 50)
 
-        vm.loadNextPage()
+        await vm.loadNextPage()
         XCTAssertEqual(vm.sessions.count, 100)
         XCTAssertTrue(vm.hasMoreSessions)
 
-        vm.loadNextPage()
+        await vm.loadNextPage()
         XCTAssertEqual(vm.sessions.count, 130)
         XCTAssertFalse(vm.hasMoreSessions, "Final partial page must clear hasMoreSessions")
     }
 
-    func test_loadNextPage_isNoOpAtEnd() throws {
-        try seedSessions(count: 20, prefix: "S", spacingSeconds: 1)
-        vm.loadSessions()
+    func test_loadNextPage_isNoOpAtEnd() async throws {
+        try await seedSessions(count: 20, prefix: "S", spacingSeconds: 1)
+        await vm.loadSessions()
         XCTAssertEqual(vm.sessions.count, 20)
         XCTAssertFalse(vm.hasMoreSessions)
 
-        vm.loadNextPage()
+        await vm.loadNextPage()
         XCTAssertEqual(vm.sessions.count, 20)
     }
 
-    func test_fetchSessionsPage_returnsRequestedSliceWithoutMutatingVM() throws {
-        try seedSessions(count: 60, prefix: "S", spacingSeconds: 1)
-        vm.loadSessions()
+    func test_fetchSessionsPage_returnsRequestedSliceWithoutMutatingVM() async throws {
+        try await seedSessions(count: 60, prefix: "S", spacingSeconds: 1)
+        await vm.loadSessions()
         let snapshotCount = vm.sessions.count
 
-        let page = try vm.fetchSessionsPage(offset: 50, limit: 50)
+        let page = try await vm.fetchSessionsPage(offset: 50, limit: 50)
 
         XCTAssertEqual(page.count, 10)
         XCTAssertEqual(vm.sessions.count, snapshotCount, "Fetch helper must not mutate VM state")
@@ -193,26 +193,26 @@ final class SessionManagerSearchPaginationTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func seedSession(title: String, updatedAt: Date = Date()) throws -> ChatSessionRecord {
+    private func seedSession(title: String, updatedAt: Date = Date()) async throws -> ChatSessionRecord {
         let record = ChatSessionRecord(title: title, updatedAt: updatedAt)
-        try persistence.insertSession(record)
+        try await persistence.insertSession(record)
         return record
     }
 
-    private func seedSessions(titles: [String], spacingSeconds: TimeInterval = 1) throws {
+    private func seedSessions(titles: [String], spacingSeconds: TimeInterval = 1) async throws {
         let base = Date(timeIntervalSince1970: 1_000_000)
         for (i, title) in titles.enumerated() {
-            try persistence.insertSession(ChatSessionRecord(
+            try await persistence.insertSession(ChatSessionRecord(
                 title: title,
                 updatedAt: base.addingTimeInterval(Double(i) * spacingSeconds)
             ))
         }
     }
 
-    private func seedSessions(count: Int, prefix: String, spacingSeconds: TimeInterval) throws {
+    private func seedSessions(count: Int, prefix: String, spacingSeconds: TimeInterval) async throws {
         let base = Date(timeIntervalSince1970: 1_000_000)
         for i in 0..<count {
-            try persistence.insertSession(ChatSessionRecord(
+            try await persistence.insertSession(ChatSessionRecord(
                 title: "\(prefix)\(i)",
                 updatedAt: base.addingTimeInterval(Double(i) * spacingSeconds)
             ))

--- a/Tests/BaseChatUITests/SessionManagerViewModelTests.swift
+++ b/Tests/BaseChatUITests/SessionManagerViewModelTests.swift
@@ -30,8 +30,8 @@ final class SessionManagerViewModelTests: XCTestCase {
     // MARK: - Create
 
     @MainActor
-    func test_createSession_insertsIntoContext() {
-        let session = try! vm.createSession(title: "Test Session")
+    func test_createSession_insertsIntoContext() async {
+        let session = try! await vm.createSession(title: "Test Session")
 
         XCTAssertEqual(session.title, "Test Session")
         XCTAssertEqual(vm.sessions.count, 1)
@@ -39,16 +39,16 @@ final class SessionManagerViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_createSession_defaultTitle() {
-        let session = try! vm.createSession()
+    func test_createSession_defaultTitle() async {
+        let session = try! await vm.createSession()
         XCTAssertEqual(session.title, "New Chat")
     }
 
     @MainActor
-    func test_createSession_activatesSession() throws {
+    func test_createSession_activatesSession() async throws {
         XCTAssertNil(vm.activeSession, "Precondition: no session active before creation")
 
-        let session = try vm.createSession(title: "Auto-Activate Test")
+        let session = try await vm.createSession(title: "Auto-Activate Test")
 
         XCTAssertEqual(vm.activeSession?.id, session.id,
                        "createSession should activate the new session immediately")
@@ -60,18 +60,18 @@ final class SessionManagerViewModelTests: XCTestCase {
     // MARK: - Delete
 
     @MainActor
-    func test_deleteSession_removesSession() throws {
-        let session = try vm.createSession(title: "To Delete")
+    func test_deleteSession_removesSession() async throws {
+        let session = try await vm.createSession(title: "To Delete")
         XCTAssertEqual(vm.sessions.count, 1)
 
-        try vm.deleteSession(session)
+        try await vm.deleteSession(session)
 
         XCTAssertEqual(vm.sessions.count, 0)
     }
 
     @MainActor
-    func test_deleteSession_removesAssociatedMessages() throws {
-        let session = try vm.createSession()
+    func test_deleteSession_removesAssociatedMessages() async throws {
+        let session = try await vm.createSession()
 
         // Insert messages for this session
         let msg1 = ChatMessage(role: .user, content: "Hello", sessionID: session.id)
@@ -80,7 +80,7 @@ final class SessionManagerViewModelTests: XCTestCase {
         context.insert(msg2)
         try context.save()
 
-        try vm.deleteSession(session)
+        try await vm.deleteSession(session)
 
         // Verify messages are also deleted
         let sessionID = session.id
@@ -92,11 +92,11 @@ final class SessionManagerViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_deleteSession_clearsActiveIfDeleted() throws {
-        let session = try vm.createSession()
+    func test_deleteSession_clearsActiveIfDeleted() async throws {
+        let session = try await vm.createSession()
         vm.activeSession = session
 
-        try vm.deleteSession(session)
+        try await vm.deleteSession(session)
 
         XCTAssertNil(vm.activeSession)
     }
@@ -104,10 +104,10 @@ final class SessionManagerViewModelTests: XCTestCase {
     // MARK: - Rename
 
     @MainActor
-    func test_renameSession_updatesTitle() throws {
-        let session = try vm.createSession(title: "Original")
+    func test_renameSession_updatesTitle() async throws {
+        let session = try await vm.createSession(title: "Original")
 
-        try vm.renameSession(session, title: "Renamed")
+        try await vm.renameSession(session, title: "Renamed")
 
         let updated = vm.sessions.first { $0.id == session.id }
         XCTAssertEqual(updated?.title, "Renamed")
@@ -116,22 +116,22 @@ final class SessionManagerViewModelTests: XCTestCase {
     // MARK: - Auto-Generate Title
 
     @MainActor
-    func test_autoGenerateTitle_setsFromFirstMessage() {
-        let session = try! vm.createSession()
+    func test_autoGenerateTitle_setsFromFirstMessage() async {
+        let session = try! await vm.createSession()
         XCTAssertEqual(session.title, "New Chat")
 
-        vm.autoGenerateTitle(for: session, firstMessage: "Tell me about dragons")
+        await vm.autoGenerateTitle(for: session, firstMessage: "Tell me about dragons")
 
         let updated = vm.sessions.first { $0.id == session.id }
         XCTAssertEqual(updated?.title, "Tell me about dragons")
     }
 
     @MainActor
-    func test_autoGenerateTitle_truncatesAtWordBoundary() {
-        let session = try! vm.createSession()
+    func test_autoGenerateTitle_truncatesAtWordBoundary() async {
+        let session = try! await vm.createSession()
         let longMessage = "This is a really long message that should be truncated at a word boundary because it exceeds fifty characters"
 
-        vm.autoGenerateTitle(for: session, firstMessage: longMessage)
+        await vm.autoGenerateTitle(for: session, firstMessage: longMessage)
 
         let updated = vm.sessions.first { $0.id == session.id }!
         XCTAssertTrue(updated.title.count <= 53, "Title should be truncated (50 chars + '...')")
@@ -140,10 +140,10 @@ final class SessionManagerViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_autoGenerateTitle_skipsIfAlreadyNamed() {
-        let session = try! vm.createSession(title: "Custom Title")
+    func test_autoGenerateTitle_skipsIfAlreadyNamed() async {
+        let session = try! await vm.createSession(title: "Custom Title")
 
-        vm.autoGenerateTitle(for: session, firstMessage: "This should be ignored")
+        await vm.autoGenerateTitle(for: session, firstMessage: "This should be ignored")
 
         let updated = vm.sessions.first { $0.id == session.id }
         XCTAssertEqual(updated?.title, "Custom Title",
@@ -151,10 +151,10 @@ final class SessionManagerViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_autoGenerateTitle_handlesEmptyMessage() {
-        let session = try! vm.createSession()
+    func test_autoGenerateTitle_handlesEmptyMessage() async {
+        let session = try! await vm.createSession()
 
-        vm.autoGenerateTitle(for: session, firstMessage: "   ")
+        await vm.autoGenerateTitle(for: session, firstMessage: "   ")
 
         let updated = vm.sessions.first { $0.id == session.id }
         XCTAssertEqual(updated?.title, "New Chat",
@@ -164,12 +164,12 @@ final class SessionManagerViewModelTests: XCTestCase {
     // MARK: - Sort Order
 
     @MainActor
-    func test_sessions_sortedByUpdatedAtDescending() {
-        _ = try! vm.createSession(title: "Oldest")
-        _ = try! vm.createSession(title: "Middle")
-        _ = try! vm.createSession(title: "Newest")
+    func test_sessions_sortedByUpdatedAtDescending() async {
+        _ = try! await vm.createSession(title: "Oldest")
+        _ = try! await vm.createSession(title: "Middle")
+        _ = try! await vm.createSession(title: "Newest")
 
-        vm.loadSessions()
+        await vm.loadSessions()
 
         XCTAssertEqual(vm.sessions.count, 3)
         XCTAssertEqual(vm.sessions[0].title, "Newest")
@@ -180,9 +180,12 @@ final class SessionManagerViewModelTests: XCTestCase {
     // MARK: - Error Propagation
 
     @MainActor
-    func test_deleteSession_throwsOnMissingSession() {
+    func test_deleteSession_throwsOnMissingSession() async {
         let ghost = ChatSessionRecord(title: "Ghost")
-        XCTAssertThrowsError(try vm.deleteSession(ghost)) { error in
+        do {
+            try await vm.deleteSession(ghost)
+            XCTFail("Expected deleteSession to throw")
+        } catch {
             guard let persistError = error as? ChatPersistenceError,
                   case .sessionNotFound = persistError else {
                 XCTFail("Expected sessionNotFound, got \(error)")
@@ -192,9 +195,12 @@ final class SessionManagerViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_renameSession_throwsOnMissingSession() {
+    func test_renameSession_throwsOnMissingSession() async {
         let ghost = ChatSessionRecord(title: "Ghost")
-        XCTAssertThrowsError(try vm.renameSession(ghost, title: "New Name")) { error in
+        do {
+            try await vm.renameSession(ghost, title: "New Name")
+            XCTFail("Expected renameSession to throw")
+        } catch {
             guard let persistError = error as? ChatPersistenceError,
                   case .sessionNotFound = persistError else {
                 XCTFail("Expected sessionNotFound, got \(error)")
@@ -204,12 +210,19 @@ final class SessionManagerViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_deleteSession_throwDoesNotCorruptSessionList() throws {
-        let session = try vm.createSession(title: "Real")
+    func test_deleteSession_throwDoesNotCorruptSessionList() async throws {
+        let session = try await vm.createSession(title: "Real")
         let ghost = ChatSessionRecord(title: "Ghost")
         XCTAssertEqual(vm.sessions.count, 1)
 
-        XCTAssertThrowsError(try vm.deleteSession(ghost))
+        do {
+            try await vm.deleteSession(ghost)
+            XCTFail("Expected deleteSession to throw for ghost")
+        } catch {
+            // expected
+        }
+
+        _ = session
 
         // The real session should still be present
         XCTAssertEqual(vm.sessions.count, 1)

--- a/Tests/BaseChatUITests/SessionOverrideTests.swift
+++ b/Tests/BaseChatUITests/SessionOverrideTests.swift
@@ -56,13 +56,13 @@ final class SessionOverrideTests: XCTestCase {
         temperature: Float? = nil,
         topP: Float? = nil,
         repeatPenalty: Float? = nil
-    ) throws -> ChatSessionRecord {
-        var session = try sessionManager.createSession(title: title)
+    ) async throws -> ChatSessionRecord {
+        var session = try await sessionManager.createSession(title: title)
         session.temperature = temperature
         session.topP = topP
         session.repeatPenalty = repeatPenalty
         sessionManager.activeSession = session
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
         return session
     }
 
@@ -74,7 +74,7 @@ final class SessionOverrideTests: XCTestCase {
     // MARK: - Tests
 
     func test_customOverrides_passedToBackend() async throws {
-        try createAndActivateSession(
+        try await createAndActivateSession(
             title: "Custom",
             temperature: 0.3,
             topP: 0.5,
@@ -90,7 +90,7 @@ final class SessionOverrideTests: XCTestCase {
     }
 
     func test_noOverrides_usesDefaults() async throws {
-        try createAndActivateSession(title: "Default")
+        try await createAndActivateSession(title: "Default")
 
         await sendMessage()
 
@@ -102,7 +102,7 @@ final class SessionOverrideTests: XCTestCase {
 
     func test_switchBackToCustomSession_overridesStillApplied() async throws {
         // Session A: custom overrides
-        let sessionA = try createAndActivateSession(
+        let sessionA = try await createAndActivateSession(
             title: "Session A",
             temperature: 0.3,
             topP: 0.5,
@@ -112,7 +112,7 @@ final class SessionOverrideTests: XCTestCase {
         await sendMessage("From A first")
 
         // Session B: defaults
-        try createAndActivateSession(title: "Session B")
+        try await createAndActivateSession(title: "Session B")
 
         await sendMessage("From B")
 
@@ -122,7 +122,7 @@ final class SessionOverrideTests: XCTestCase {
         XCTAssertEqual(defaultConfig.repeatPenalty, 1.1, accuracy: 0.001)
 
         // Switch back to Session A
-        vm.switchToSession(sessionA)
+        await vm.switchToSession(sessionA)
 
         await sendMessage("From A again")
 

--- a/Tests/BaseChatUITests/SessionQueueIsolationTests.swift
+++ b/Tests/BaseChatUITests/SessionQueueIsolationTests.swift
@@ -54,10 +54,10 @@ final class SessionQueueIsolationTests: XCTestCase {
     // MARK: - Helpers
 
     @discardableResult
-    private func createAndActivateSession(title: String = "Test Chat") throws -> ChatSessionRecord {
-        let session = try sessionManager.createSession(title: title)
+    private func createAndActivateSession(title: String = "Test Chat") async throws -> ChatSessionRecord {
+        let session = try await sessionManager.createSession(title: title)
         sessionManager.activeSession = session
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
         return session
     }
 
@@ -65,7 +65,7 @@ final class SessionQueueIsolationTests: XCTestCase {
 
     /// Switching sessions discards queued requests belonging to the old session.
     func test_switchSession_discardsQueuedRequestsForOldSession() async throws {
-        let sessionA = try createAndActivateSession(title: "Session A")
+        let sessionA = try await createAndActivateSession(title: "Session A")
 
         // Enqueue a request scoped to session A.
         let (_, stream) = try vm.inferenceService.enqueue(
@@ -74,9 +74,9 @@ final class SessionQueueIsolationTests: XCTestCase {
         )
 
         // Create session B and switch to it.
-        let sessionB = try sessionManager.createSession(title: "Session B")
+        let sessionB = try await sessionManager.createSession(title: "Session B")
         sessionManager.activeSession = sessionB
-        vm.switchToSession(sessionB)
+        await vm.switchToSession(sessionB)
 
         // Session A's stream should terminate with an error because
         // discardRequests(notMatching:) cancelled it.
@@ -91,7 +91,7 @@ final class SessionQueueIsolationTests: XCTestCase {
 
     /// Active generation is cancelled when switching sessions.
     func test_switchSession_activeGeneration_cancelledOnSwitch() async throws {
-        try createAndActivateSession(title: "Session A")
+        try await createAndActivateSession(title: "Session A")
 
         // Start generation on session A.
         vm.inputText = "question for A"
@@ -102,9 +102,9 @@ final class SessionQueueIsolationTests: XCTestCase {
         XCTAssertTrue(vm.isGenerating, "Should be generating before switch")
 
         // Switch to session B — should stop generation.
-        let sessionB = try sessionManager.createSession(title: "Session B")
+        let sessionB = try await sessionManager.createSession(title: "Session B")
         sessionManager.activeSession = sessionB
-        vm.switchToSession(sessionB)
+        await vm.switchToSession(sessionB)
 
         XCTAssertFalse(vm.isGenerating, "isGenerating should be false after session switch")
 
@@ -113,7 +113,7 @@ final class SessionQueueIsolationTests: XCTestCase {
 
     /// stopGeneration drains the entire queue (active + queued).
     func test_stopGeneration_drainsEntireQueue() async throws {
-        try createAndActivateSession(title: "Test")
+        try await createAndActivateSession(title: "Test")
 
         // Start generation to make isGenerating true.
         vm.inputText = "first"
@@ -159,7 +159,7 @@ final class SessionQueueIsolationTests: XCTestCase {
 
     /// regenerateLastResponse is a no-op while generation is active (queue busy).
     func test_regenerateWhileQueued_isBlocked() async throws {
-        try createAndActivateSession(title: "Test")
+        try await createAndActivateSession(title: "Test")
 
         // Send a message and let it complete to have an assistant message to regenerate.
         slowBackend.tokensToYield = ["first", " reply"]

--- a/Tests/BaseChatUITests/StreamingFailureTests.swift
+++ b/Tests/BaseChatUITests/StreamingFailureTests.swift
@@ -39,10 +39,10 @@ final class StreamingFailureTests: XCTestCase {
     }
 
     @discardableResult
-    private func createAndActivateSession(vm: ChatViewModel, title: String = "Test Chat") -> ChatSessionRecord {
-        let session = try! sessionManager.createSession(title: title)
+    private func createAndActivateSession(vm: ChatViewModel, title: String = "Test Chat") async -> ChatSessionRecord {
+        let session = try! await sessionManager.createSession(title: title)
         sessionManager.activeSession = session
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
         return session
     }
 
@@ -61,8 +61,8 @@ final class StreamingFailureTests: XCTestCase {
             tokensBeforeError: ["Hello", " world"],
             errorToThrow: InferenceError.inferenceFailure("Simulated mid-stream failure")
         )
-        let vm = makeViewModel(backend: backend)
-        let session = createAndActivateSession(vm: vm)
+        let vm = await makeViewModel(backend: backend)
+        let session = await createAndActivateSession(vm: vm)
 
         vm.inputText = "Say hello"
         await vm.sendMessage()
@@ -89,8 +89,8 @@ final class StreamingFailureTests: XCTestCase {
             tokensBeforeError: ["Hello", " world"],
             errorToThrow: InferenceError.inferenceFailure("Simulated mid-stream failure")
         )
-        let vm = makeViewModel(backend: backend)
-        createAndActivateSession(vm: vm)
+        let vm = await makeViewModel(backend: backend)
+        await createAndActivateSession(vm: vm)
 
         vm.inputText = "Say hello"
         await vm.sendMessage()
@@ -110,8 +110,8 @@ final class StreamingFailureTests: XCTestCase {
         let backend = MockInferenceBackend()
         backend.isModelLoaded = true
         backend.tokensToYield = []
-        let vm = makeViewModel(backend: backend)
-        createAndActivateSession(vm: vm)
+        let vm = await makeViewModel(backend: backend)
+        await createAndActivateSession(vm: vm)
 
         vm.inputText = "Say something"
         await vm.sendMessage()
@@ -127,8 +127,8 @@ final class StreamingFailureTests: XCTestCase {
         let backend = MockInferenceBackend()
         backend.isModelLoaded = true
         backend.tokensToYield = ["OK"]
-        let vm = makeViewModel(backend: backend)
-        let session = createAndActivateSession(vm: vm)
+        let vm = await makeViewModel(backend: backend)
+        let session = await createAndActivateSession(vm: vm)
 
         vm.inputText = "Quick question"
         await vm.sendMessage()
@@ -152,9 +152,9 @@ final class StreamingFailureTests: XCTestCase {
         let backend = MockInferenceBackend()
         backend.isModelLoaded = true
         backend.tokensToYield = tokens
-        let vm = makeViewModel(backend: backend)
+        let vm = await makeViewModel(backend: backend)
         vm.loopDetectionEnabled = false
-        createAndActivateSession(vm: vm)
+        await createAndActivateSession(vm: vm)
 
         vm.inputText = "Generate a lot"
         await vm.sendMessage()
@@ -171,8 +171,8 @@ final class StreamingFailureTests: XCTestCase {
         let backend = MockInferenceBackend()
         backend.isModelLoaded = true
         backend.tokensToYield = ["Hello ", "\u{1F30D}", " caf\u{00E9}", " na\u{00EF}ve"]
-        let vm = makeViewModel(backend: backend)
-        createAndActivateSession(vm: vm)
+        let vm = await makeViewModel(backend: backend)
+        await createAndActivateSession(vm: vm)
 
         vm.inputText = "Unicode test"
         await vm.sendMessage()

--- a/Tests/BaseChatUITests/ThinkingStreamingTests.swift
+++ b/Tests/BaseChatUITests/ThinkingStreamingTests.swift
@@ -40,7 +40,7 @@ final class ThinkingStreamingTests: XCTestCase {
         // mutations, plus the placeholder insert and the finalize write.
         mock.thinkingTokensToYield = ["Let", " me", " think", " about", " this"]
         mock.tokensToYield = ["done"]
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
 
         // Wrap onMutateMessage so we record the thinking-part text after each
         // mutation, distinguishing pre-finalize states from the authoritative
@@ -112,7 +112,7 @@ final class ThinkingStreamingTests: XCTestCase {
         let mock = MockInferenceBackend()
         mock.thinkingTokensToYield = ["a", "b", "c", "d", "e"]
         mock.tokensToYield = ["ok"]
-        let vm = makeVM(backend: mock)
+        let vm = await makeVM(backend: mock)
 
         vm.inputText = "hi"
         await vm.sendMessage()

--- a/Tests/BaseChatUITests/TranscriptHealOnReloadIntegrationTests.swift
+++ b/Tests/BaseChatUITests/TranscriptHealOnReloadIntegrationTests.swift
@@ -39,9 +39,9 @@ final class TranscriptHealOnReloadIntegrationTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func makeSession() -> ChatSessionRecord {
+    private func makeSession() async -> ChatSessionRecord {
         let session = ChatSessionRecord(title: "Heal-On-Reload")
-        try! stack.provider.insertSession(session)
+        try! await stack.provider.insertSession(session)
         return session
     }
 
@@ -66,8 +66,8 @@ final class TranscriptHealOnReloadIntegrationTests: XCTestCase {
 
     // MARK: - Tests
 
-    func test_sessionReload_synthesisesResultForOrphanToolCall() throws {
-        let session = makeSession()
+    func test_sessionReload_synthesisesResultForOrphanToolCall() async throws {
+        let session = await makeSession()
         let userMsg = ChatMessageRecord(
             role: .user,
             content: "Write a file",
@@ -85,15 +85,15 @@ final class TranscriptHealOnReloadIntegrationTests: XCTestCase {
             timestamp: Date(timeIntervalSince1970: 1001),
             sessionID: session.id
         )
-        try stack.provider.insertMessage(userMsg)
-        try stack.provider.insertMessage(assistantMsg)
+        try await stack.provider.insertMessage(userMsg)
+        try await stack.provider.insertMessage(assistantMsg)
 
         // Sanity: the persisted transcript has an orphan before reload.
-        let preReload = try stack.provider.fetchMessages(for: session.id)
+        let preReload = try await stack.provider.fetchMessages(for: session.id)
         XCTAssertEqual(orphanCallIDs(in: preReload), ["call-orphan-1"])
 
         // Reload via the ChatViewModel — this is the production code path.
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
 
         // Acceptance: the in-memory transcript no longer has any orphans.
         XCTAssertTrue(
@@ -117,8 +117,8 @@ final class TranscriptHealOnReloadIntegrationTests: XCTestCase {
         )
     }
 
-    func test_sessionReload_doesNotTouchPairedToolCall() throws {
-        let session = makeSession()
+    func test_sessionReload_doesNotTouchPairedToolCall() async throws {
+        let session = await makeSession()
         let call = ToolCall(id: "paired-1", toolName: "search", arguments: "{}")
         let result = ToolResult(callId: "paired-1", content: "ok")
         let assistantMsg = ChatMessageRecord(
@@ -127,9 +127,9 @@ final class TranscriptHealOnReloadIntegrationTests: XCTestCase {
             timestamp: Date(timeIntervalSince1970: 1000),
             sessionID: session.id
         )
-        try stack.provider.insertMessage(assistantMsg)
+        try await stack.provider.insertMessage(assistantMsg)
 
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
 
         XCTAssertEqual(vm.messages.count, 1)
         XCTAssertEqual(

--- a/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
+++ b/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
@@ -65,11 +65,11 @@ final class ViewModelEdgeCaseTests: XCTestCase {
 
     // MARK: - saveSettingsToSession
 
-    func test_saveSettingsToSession_updatesSessionProperties() throws {
+    func test_saveSettingsToSession_updatesSessionProperties() async throws {
         let (vm, _, persistence) = try makeViewModelWithPersistence()
 
         let session = ChatSessionRecord(title: "Settings Test")
-        try persistence.insertSession(session)
+        try await persistence.insertSession(session)
 
         vm.activeSession = session
         vm.temperature = 0.3
@@ -78,7 +78,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         vm.systemPrompt = "Be concise."
         vm.selectedPromptTemplate = .llama3
 
-        try vm.saveSettingsToSession()
+        try await vm.saveSettingsToSession()
 
         let updated = vm.activeSession!
         XCTAssertEqual(updated.temperature!, 0.3, accuracy: 0.001,
@@ -93,19 +93,19 @@ final class ViewModelEdgeCaseTests: XCTestCase {
                        "Session promptTemplate should match view model value")
     }
 
-    func test_saveSettingsToSession_noActiveSession_isNoop() throws {
+    func test_saveSettingsToSession_noActiveSession_isNoop() async throws {
         let (vm, _, _) = try makeViewModelWithPersistence()
 
         // No active session — should not crash.
         vm.temperature = 0.5
-        try vm.saveSettingsToSession()
+        try await vm.saveSettingsToSession()
 
         XCTAssertNil(vm.activeSession, "activeSession should remain nil")
     }
 
     // MARK: - switchToSession
 
-    func test_switchToSession_loadsSessionSettings() throws {
+    func test_switchToSession_loadsSessionSettings() async throws {
         let (vm, _, _) = try makeViewModelWithPersistence()
 
         var sessionA = ChatSessionRecord(title: "Session A")
@@ -120,11 +120,11 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         sessionB.repeatPenalty = 1.3
         sessionB.systemPrompt = "Prompt B"
 
-        vm.switchToSession(sessionA)
+        await vm.switchToSession(sessionA)
         XCTAssertEqual(vm.temperature, 0.2, accuracy: 0.001)
         XCTAssertEqual(vm.systemPrompt, "Prompt A")
 
-        vm.switchToSession(sessionB)
+        await vm.switchToSession(sessionB)
         XCTAssertEqual(vm.temperature, 0.9, accuracy: 0.001,
                        "Temperature should reflect session B after switch")
         XCTAssertEqual(vm.topP, 0.95, accuracy: 0.001,
@@ -150,7 +150,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
 
         let sessionB = ChatSessionRecord(title: "Session B")
 
-        vm.switchToSession(sessionB)
+        await vm.switchToSession(sessionB)
 
         // Session B has no persisted messages, so messages should be empty.
         XCTAssertTrue(vm.messages.isEmpty,
@@ -160,7 +160,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
     func test_clearChat_whenPersistenceDeleteFails_reloadsPersistedMessages() async throws {
         let (vm, _, persistence) = try makeViewModelWithPersistence()
         let session = ChatSessionRecord(title: "Clear Chat Failure")
-        try persistence.insertSession(session)
+        try await persistence.insertSession(session)
         vm.activeSession = session
 
         vm.inputText = "Hello"
@@ -172,7 +172,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
             XCTFail("Expected an active session after sendMessage")
             return
         }
-        let expectedMessages = try persistence.fetchMessages(for: activeID)
+        let expectedMessages = try await persistence.fetchMessages(for: activeID)
         XCTAssertEqual(expectedMessages.count, 2, "Precondition: the chat should have persisted user and assistant messages")
 
         let deleteError = NSError(
@@ -182,11 +182,11 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         )
         persistence.shouldThrowOnDeleteMessages = deleteError
 
-        vm.clearChat()
+        await vm.clearChat()
 
         XCTAssertEqual(vm.messages.map(\.id), expectedMessages.map(\.id),
                        "clearChat should reload persisted messages when deletion fails")
-        let stillPersisted = try persistence.fetchMessages(for: activeID)
+        let stillPersisted = try await persistence.fetchMessages(for: activeID)
         XCTAssertEqual(stillPersisted.map(\.id), expectedMessages.map(\.id),
                        "Persistence should still contain the original messages after a failed clear")
         XCTAssertNotNil(vm.activeError, "activeError should be set when clear chat fails")
@@ -199,7 +199,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
 
     // MARK: - switchToSession model-selection restoration
 
-    func test_switchToSession_restoresSelectedModel_whenModelInList() throws {
+    func test_switchToSession_restoresSelectedModel_whenModelInList() async throws {
         let (vm, _, _) = try makeViewModelWithPersistence()
 
         vm.foundationModelProvider = { true }
@@ -214,7 +214,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         var session = ChatSessionRecord(title: "Model Restore Session")
         session.selectedModelID = foundationModel.id
 
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
 
         XCTAssertEqual(vm.selectedModel?.id, foundationModel.id,
             "selectedModel should be restored to the session's saved model when it exists in availableModels")
@@ -222,7 +222,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
             "Restored model should have the expected type")
     }
 
-    func test_switchToSession_clearsSelectedModel_whenModelNotInList() throws {
+    func test_switchToSession_clearsSelectedModel_whenModelNotInList() async throws {
         let (vm, _, _) = try makeViewModelWithPersistence()
 
         vm.foundationModelProvider = { true }
@@ -239,32 +239,32 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         var session = ChatSessionRecord(title: "Missing Model Session")
         session.selectedModelID = missingModelID
 
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
 
         XCTAssertNil(vm.selectedModel,
             "selectedModel should be cleared when session's model is not in availableModels")
     }
 
-    func test_saveSettingsToSession_persistsSelectedModelID() throws {
+    func test_saveSettingsToSession_persistsSelectedModelID() async throws {
         let (vm, _, persistence) = try makeViewModelWithPersistence()
 
         let model = ModelInfo.builtInFoundation
         let expectedID = model.id
 
         let session = ChatSessionRecord(title: "Persist Model Session")
-        try persistence.insertSession(session)
+        try await persistence.insertSession(session)
 
         vm.activeSession = session
         vm.selectedModel = model
 
-        try vm.saveSettingsToSession()
+        try await vm.saveSettingsToSession()
 
         XCTAssertEqual(vm.activeSession?.selectedModelID, expectedID,
             "saveSettingsToSession should persist the selected model's UUID to the session")
     }
 
-    func test_selectionMutualExclusion_selectingEndpoint_clearsModel() {
-        let vm = makeViewModel()
+    func test_selectionMutualExclusion_selectingEndpoint_clearsModel() async {
+        let vm = await makeViewModel()
         vm.selectedModel = ModelInfo.builtInFoundation
 
         let endpoint = APIEndpoint(name: "OpenAI", provider: .openAI)
@@ -274,8 +274,8 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         XCTAssertEqual(vm.selectedEndpoint?.id, endpoint.id)
     }
 
-    func test_selectionMutualExclusion_selectingModel_clearsEndpoint() {
-        let vm = makeViewModel()
+    func test_selectionMutualExclusion_selectingModel_clearsEndpoint() async {
+        let vm = await makeViewModel()
         let endpoint = APIEndpoint(name: "OpenAI", provider: .openAI)
         vm.selectedEndpoint = endpoint
 
@@ -285,7 +285,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         XCTAssertEqual(vm.selectedModel?.id, ModelInfo.builtInFoundation.id)
     }
 
-    func test_switchToSession_restoresSelectedEndpoint_whenEndpointExists() throws {
+    func test_switchToSession_restoresSelectedEndpoint_whenEndpointExists() async throws {
         let (vm, _, _) = try makeViewModelWithPersistence()
         let endpoint = APIEndpoint(name: "OpenAI", provider: .openAI)
         vm.setAvailableEndpoints([endpoint])
@@ -295,13 +295,13 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         session.selectedEndpointID = endpoint.id
         session.selectedModelID = ModelInfo.builtInFoundation.id
 
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
 
         XCTAssertEqual(vm.selectedEndpoint?.id, endpoint.id)
         XCTAssertNil(vm.selectedModel, "Endpoint restore should not leak prior model selection")
     }
 
-    func test_switchToSession_clearsSelectedEndpoint_whenEndpointMissing() throws {
+    func test_switchToSession_clearsSelectedEndpoint_whenEndpointMissing() async throws {
         let (vm, _, _) = try makeViewModelWithPersistence()
         let oldEndpoint = APIEndpoint(name: "Old", provider: .openAI)
         vm.setAvailableEndpoints([oldEndpoint])
@@ -310,47 +310,47 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         var session = ChatSessionRecord(title: "Missing Endpoint Session")
         session.selectedEndpointID = UUID()
 
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
 
         XCTAssertNil(vm.selectedEndpoint, "Missing endpoint should clear selectedEndpoint")
     }
 
-    func test_switchToSession_doesNotPersistNilSelectionWhenEndpointUnavailable() throws {
+    func test_switchToSession_doesNotPersistNilSelectionWhenEndpointUnavailable() async throws {
         let (vm, _, persistence) = try makeViewModelWithPersistence()
 
         let endpoint = APIEndpoint(name: "Delayed Endpoint", provider: .openAI)
         var session = ChatSessionRecord(title: "Deferred Endpoint Session")
         session.selectedEndpointID = endpoint.id
-        try persistence.insertSession(session)
+        try await persistence.insertSession(session)
         vm.activeSession = session
 
         vm.setAvailableEndpoints([])
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
 
         XCTAssertEqual(persistence.updateSessionCallCount, 0,
                        "switchToSession should not auto-persist settings while restoring")
-        let stored = try persistence.fetchSessions().first(where: { $0.id == session.id })
+        let stored = try await persistence.fetchSessions().first(where: { $0.id == session.id })
         XCTAssertEqual(stored?.selectedEndpointID, endpoint.id,
                        "Unresolved endpoint ID should remain persisted until user saves settings")
     }
 
-    func test_saveSettingsToSession_persistsSelectedEndpointID() throws {
+    func test_saveSettingsToSession_persistsSelectedEndpointID() async throws {
         let (vm, _, persistence) = try makeViewModelWithPersistence()
         let endpoint = APIEndpoint(name: "Claude", provider: .claude)
         vm.setAvailableEndpoints([endpoint])
 
         let session = ChatSessionRecord(title: "Persist Endpoint Session")
-        try persistence.insertSession(session)
+        try await persistence.insertSession(session)
         vm.activeSession = session
         vm.selectedEndpoint = endpoint
 
-        try vm.saveSettingsToSession()
+        try await vm.saveSettingsToSession()
 
         XCTAssertEqual(vm.activeSession?.selectedEndpointID, endpoint.id)
         XCTAssertNil(vm.activeSession?.selectedModelID, "Endpoint selection should clear model selection")
     }
 
-    func test_switchToSession_usesDefaultsForNilSettings() throws {
+    func test_switchToSession_usesDefaultsForNilSettings() async throws {
         let (vm, _, _) = try makeViewModelWithPersistence()
 
         let session = ChatSessionRecord(title: "Defaults Session")
@@ -359,7 +359,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         vm.topP = 0.1
         vm.repeatPenalty = 2.0
 
-        vm.switchToSession(session)
+        await vm.switchToSession(session)
 
         XCTAssertEqual(vm.temperature, 0.7, accuracy: 0.001,
                        "Should fall back to 0.7 default when session temperature is nil")


### PR DESCRIPTION
## Summary
- `ChatPersistenceProvider` protocol methods become `async throws`.
- Public sync mutators on `SessionManagerViewModel` and `ChatViewModel` become `async throws`.
- `SessionManagerViewModel.configure` gains a required `autoLoad: Bool` parameter (no default) so the Phase 1.0 behaviour change cannot be missed silently.
- All call sites and tests updated. No new types, no extractions, no compat shims.

## Why
This is **Phase 1.0** of the runtime ports refactor planned in #876. The Phase 0 spike (#878) showed that with sync command APIs, the proposed event-stream adapter has to dual-write (eager reload + later event consumption) to keep synchronous callers consistent — undermining the single-source-of-truth goal. Making the surface `async throws` is the prerequisite that makes every later phase clean.

## Scope discipline
- Single-purpose breaking change. Pre-1.0, so it ships as one breaking changelog entry.
- No new use cases, no port splits, no module moves, no `InferenceService` isolation changes — those are later phases.
- No deprecation shims. The sync signatures are deleted.

## Behaviour notes
- `stopGeneration()` stays synchronous on purpose. Cancellation itself is sync, and the trailing partial-message persist runs on a fire-and-forget Task. Many call sites (toolbar buttons, `scenePhase` teardown, `handleMemoryPressure()`) depend on the sync signature; converting it would force every one of those sites to wrap in `Task { ... }` without changing observable semantics. Doc-commented at the call site; do not "fix" the inconsistency in a future refactor.
- `ChatViewModel.onFirstMessage` widens from `(@MainActor (Session, String) -> Void)?` to `async -> Void` so consumers can call the new async `SessionManagerViewModel.autoGenerateTitle` without spawning a Task — matching the pattern in the `BuildingAChatUI` doc. **Stealth break for any consumer that stored the closure in a typed variable** — the closure type changes shape; see release note below.
- `SessionManagerViewModel.configure(persistence:autoLoad:diagnostics:)` — `autoLoad` is **required** (no default). `autoLoad: true` schedules a fire-and-forget `Task { await loadSessions() }`; `autoLoad: false` leaves the load to the caller (or to `SessionListView`'s `.task { }` modifier). This makes the Phase 1.0 behaviour change loud at every call site rather than silently turning the session list into an empty placeholder. `configure(runtime:)` passes `autoLoad: true` automatically so the production bootstrap path is unchanged.

## Fireside coordination checklist
The Fireside-side changes that consume this PR — for the parallel adoption PR.

| File | Change |
|------|--------|
| `AppEnvironmentFactory.swift:168` | Update `sessionManager.configure(persistence:)` to `sessionManager.configure(persistence:autoLoad:)`. Pass `autoLoad: true` if Fireside relies on the configure-time load, or `autoLoad: false` and add `await sessionManager.loadSessions()` to the bootstrap. |
| Custom `ChatPersistenceProvider` impl | Convert all method signatures to `async throws`. Compile errors flag every site. |
| Bootstrap sequence | Add `await sessionManager.loadSessions()` if `autoLoad: false` is chosen, otherwise no change. |
| `onFirstMessage` setter (if used) | Closure type is now `async -> Void` — drop any `@MainActor` annotation on the stored closure type. |

This matches the Fireside-migration appendix in #876.

## Release note

> **Breaking:** `ChatPersistenceProvider` and the public command APIs on `ChatViewModel` and `SessionManagerViewModel` are now `async throws`. Callers must `await` these methods and wrap them in `Task { ... }` from sync contexts.
>
> `SessionManagerViewModel.configure(persistence:)` becomes `configure(persistence:autoLoad:diagnostics:)`. `autoLoad` is required — pass `true` to preserve pre-Phase-1.0 behaviour, `false` if your bootstrap will call `await loadSessions()` itself. The runtime-driven `configure(runtime:)` path passes `autoLoad: true` automatically.
>
> `ChatViewModel.onFirstMessage` is now an `async` closure — consumers that stored the closure in a typed variable must update the closure signature (no `await` needed at the call site; the `await` is inside `ChatViewModel`).
>
> This is Phase 1.0 of the runtime ports refactor (#876).

## Test plan
- [x] All CI-safe suites pass locally (~58s wallclock for the full pre-push command).
- [x] Demo app builds (`xcodebuild -project Example/BaseChatDemo.xcodeproj -scheme BaseChatDemo`).
- [x] No new `withKnownIssue` introduced; no `assertionFailure`/`fatalError` added in recoverable paths.
- [x] Sabotage check: reverted `insertSession` on `ChatPersistenceProvider` from `async throws` to `throws`; build failed at `SwiftDataPersistenceProvider` non-conformance as expected; revert restored compilation.
- [x] Regression test for the empty-state race added (`SessionManagerViewModelTests.test_configure_autoLoadTrue_thenImmediateTeardown_doesNotTrap` and siblings) — guards the bug fix permanently rather than relying on the PR body's justification.

## Stats
72 files changed in the worker pass; the autoLoad / doc-comment / regression-test follow-up adds ~5 more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
