### PR TITLE
refactor: explicit autoLoad on SessionManagerViewModel.configure (phase 1.0 follow-up)

### DIFF
--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Messages.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Messages.swift
@@ -135,12 +135,16 @@ extension ChatViewModel {
 
     /// Stops an in-progress generation.
     ///
-    /// Cancellation is synchronous — the task tear-down and inference-side
-    /// stop happen immediately. The trailing persistence save (capturing
-    /// whatever streamed into the last assistant message before cancel) is
-    /// dispatched on a `Task` so the sync surface stays unchanged for the
-    /// many call sites that fire-and-forget this method (toolbar buttons,
-    /// session-switch teardown, scenePhase handlers).
+    /// **Stays sync intentionally.** Cancellation itself is synchronous — the
+    /// task tear-down and inference-side stop happen immediately. The trailing
+    /// persistence save (capturing whatever streamed into the last assistant
+    /// message before cancel) is dispatched on a fire-and-forget `Task` so
+    /// the sync surface is preserved for the many sync call sites:
+    /// toolbar buttons, session-switch teardown, `scenePhase` handlers, and
+    /// `handleMemoryPressure()`. Converting this to `async throws` would
+    /// require every one of those sites to wrap in `Task { ... }` without
+    /// changing observable semantics. Keep sync; do not "fix" the
+    /// inconsistency in a future refactor.
     public func stopGeneration() {
         generationTask?.cancel()
         generationTask = nil

--- a/Sources/BaseChatUI/ViewModels/RuntimeConfiguration.swift
+++ b/Sources/BaseChatUI/ViewModels/RuntimeConfiguration.swift
@@ -10,10 +10,13 @@ extension ChatViewModel {
 
 extension SessionManagerViewModel {
     /// Preferred bootstrap path for apps that assemble shared services through
-    /// ``BaseChatRuntime``.
+    /// ``BaseChatRuntime``. Schedules the initial session load so the UI
+    /// matches pre-Phase-1.0 behavior. Direct callers of
+    /// ``configure(persistence:autoLoad:diagnostics:)`` must opt in explicitly.
     public func configure(runtime: BaseChatRuntime) {
         configure(
             persistence: runtime.persistence,
+            autoLoad: true,
             diagnostics: runtime.diagnostics
         )
     }

--- a/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
@@ -74,19 +74,32 @@ public final class SessionManagerViewModel {
 
     /// Injects the persistence provider. Call once from the view layer.
     ///
-    /// `configure` is intentionally synchronous so host bootstrap call sites
-    /// (which run from sync `init` paths in SwiftUI scene setup) can stay
-    /// simple. After Phase 1.0 the initial page load is async, so callers
-    /// must follow `configure` with an explicit `await loadSessions()` (or
-    /// rely on the first `createSession` to refresh the list). The session
-    /// list view also calls `loadSessions` from a `.task { }` modifier on
-    /// first appear, which keeps the on-screen UX unchanged for typical
-    /// hosts.
-    public func configure(persistence: ChatPersistenceProvider, diagnostics: DiagnosticsService? = nil) {
+    /// `autoLoad` is required (no default) so every call site makes an
+    /// explicit choice and the Phase 1.0 behavior change cannot be missed
+    /// silently:
+    ///
+    /// - `autoLoad: true` — schedules `Task { await loadSessions() }` so the
+    ///   session list populates immediately after configure. This is the
+    ///   pre-Phase-1.0 default behavior. Use it from production bootstrap
+    ///   paths (the `BaseChatRuntime` adapter does this for you).
+    /// - `autoLoad: false` — the caller is responsible for calling
+    ///   `await loadSessions()` (or relying on `SessionListView`'s
+    ///   `.task { }` modifier). **Always use this in tests.** The
+    ///   `autoLoad: true` Task is fire-and-forget and will trap SwiftData
+    ///   if the model container deallocates before the fetch runs, which
+    ///   is the typical test teardown shape.
+    public func configure(
+        persistence: ChatPersistenceProvider,
+        autoLoad: Bool,
+        diagnostics: DiagnosticsService? = nil
+    ) {
         guard self.persistence == nil else { return }
         self.persistence = persistence
         self.diagnostics = diagnostics
         Log.persistence.info("SessionManagerViewModel configured")
+        if autoLoad {
+            Task { await loadSessions() }
+        }
     }
 
     /// Creates a new session, inserts it, activates it, and returns it.

--- a/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
@@ -70,6 +70,15 @@ public final class SessionManagerViewModel {
     /// existing call sites that do not care about diagnostics keep working.
     public private(set) var diagnostics: DiagnosticsService?
 
+    /// Handle to the fire-and-forget `loadSessions()` Task scheduled by
+    /// `configure(persistence:autoLoad:diagnostics:)` when `autoLoad: true`.
+    ///
+    /// Production bootstrap paths can ignore this. Tests that exercise the
+    /// `autoLoad: true` path must `await autoLoadTask?.value` before tearing
+    /// down the model container — otherwise the in-flight fetch races
+    /// SwiftData teardown and traps with SIGSEGV.
+    public private(set) var autoLoadTask: Task<Void, Never>?
+
     public init() {}
 
     /// Injects the persistence provider. Call once from the view layer.
@@ -84,10 +93,13 @@ public final class SessionManagerViewModel {
     ///   paths (the `BaseChatRuntime` adapter does this for you).
     /// - `autoLoad: false` — the caller is responsible for calling
     ///   `await loadSessions()` (or relying on `SessionListView`'s
-    ///   `.task { }` modifier). **Always use this in tests.** The
+    ///   `.task { }` modifier). **Prefer this in tests.** The
     ///   `autoLoad: true` Task is fire-and-forget and will trap SwiftData
     ///   if the model container deallocates before the fetch runs, which
-    ///   is the typical test teardown shape.
+    ///   is the typical test teardown shape. Tests that must exercise the
+    ///   `autoLoad: true` path (e.g. covering the `configure(runtime:)`
+    ///   adapter) can `await autoLoadTask?.value` to drain the in-flight
+    ///   fetch before teardown.
     public func configure(
         persistence: ChatPersistenceProvider,
         autoLoad: Bool,
@@ -98,7 +110,9 @@ public final class SessionManagerViewModel {
         self.diagnostics = diagnostics
         Log.persistence.info("SessionManagerViewModel configured")
         if autoLoad {
-            Task { await loadSessions() }
+            autoLoadTask = Task { [weak self] in
+                await self?.loadSessions()
+            }
         }
     }
 

--- a/Sources/BaseChatUI/Views/Sidebar/SessionListView.swift
+++ b/Sources/BaseChatUI/Views/Sidebar/SessionListView.swift
@@ -83,11 +83,12 @@ public struct SessionListView: View {
         }
         .animation(.default, value: sessionManager.sessions.isEmpty)
         .task {
-            // After Phase 1.0 `loadSessions()` is async — `configure` no
-            // longer auto-fires it, so kick off the initial page load on
-            // first appear. `.task { }` fires once per identity and is
-            // cancelled if the view is torn down before completion, which
-            // matches the behaviour we want here.
+            // Hosts that configure with `autoLoad: false` (notably tests, but
+            // any caller that wants control of bootstrap timing) rely on this
+            // first-appear load. The `isEmpty` guard makes it a no-op when
+            // `configure(runtime:)` (or `autoLoad: true`) already populated
+            // the list — `.task` fires once per identity and is cancelled on
+            // teardown, which is the behaviour we want for either path.
             if sessionManager.sessions.isEmpty {
                 await sessionManager.loadSessions()
             }

--- a/Tests/BaseChatBackendsTests/CloudEndpointSelectionIntegrationTests.swift
+++ b/Tests/BaseChatBackendsTests/CloudEndpointSelectionIntegrationTests.swift
@@ -53,7 +53,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
         vm.configure(persistence: persistence)
 
         sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: persistence)
+        sessionManager.configure(persistence: persistence, autoLoad: false)
     }
 
     override func tearDown() {
@@ -112,7 +112,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
         service.registerCloudBackendFactory(cloudFactory)
         let viewModel = ChatViewModel(inferenceService: service)
         let persistence = SwiftDataPersistenceProvider(modelContext: context)
-        viewModel.configure(persistence: persistence)
+        viewModel.configure(persistence: persistence, autoLoad: false)
         return viewModel
     }
 
@@ -194,7 +194,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
             ConfiguringOpenAICloudBackend(urlSession: cloudSession!)
         }
         let persistence = SwiftDataPersistenceProvider(modelContext: context)
-        freshVM.configure(persistence: persistence)
+        freshVM.configure(persistence: persistence, autoLoad: false)
         try await makeSession(title: "Sabotage Chat")
         freshVM.selectedEndpoint = endpoint
         await freshVM.loadCloudEndpoint(endpoint)

--- a/Tests/BaseChatE2ETests/ChatTurnRoundTripE2ETests.swift
+++ b/Tests/BaseChatE2ETests/ChatTurnRoundTripE2ETests.swift
@@ -34,7 +34,7 @@ struct ChatTurnRoundTripE2ETests {
         vm.configure(persistence: persistence)
 
         sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: persistence)
+        sessionManager.configure(persistence: persistence, autoLoad: false)
     }
 
     // MARK: - Helpers

--- a/Tests/BaseChatE2ETests/LoopDetectionE2ETests.swift
+++ b/Tests/BaseChatE2ETests/LoopDetectionE2ETests.swift
@@ -32,7 +32,7 @@ struct LoopDetectionE2ETests {
         vm.configure(persistence: persistence)
 
         let sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: persistence)
+        sessionManager.configure(persistence: persistence, autoLoad: false)
         let session = try await sessionManager.createSession(title: "Test")
         sessionManager.activeSession = session
         await vm.switchToSession(session)

--- a/Tests/BaseChatE2ETests/ModelSelectionE2ETests.swift
+++ b/Tests/BaseChatE2ETests/ModelSelectionE2ETests.swift
@@ -45,7 +45,7 @@ final class ModelSelectionE2ETests {
         vm.configure(persistence: persistence)
 
         sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: persistence)
+        sessionManager.configure(persistence: persistence, autoLoad: false)
     }
 
     deinit {

--- a/Tests/BaseChatE2ETests/UserJourneyE2ETests.swift
+++ b/Tests/BaseChatE2ETests/UserJourneyE2ETests.swift
@@ -55,7 +55,7 @@ final class UserJourneyE2ETests {
         vm.configure(persistence: persistence)
 
         sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: persistence)
+        sessionManager.configure(persistence: persistence, autoLoad: false)
     }
 
     deinit {

--- a/Tests/BaseChatSnapshotTests/SidebarAndSheetControlTests.swift
+++ b/Tests/BaseChatSnapshotTests/SidebarAndSheetControlTests.swift
@@ -83,7 +83,7 @@ final class SidebarAndSheetControlTests: XCTestCase {
         let container = try makeInMemoryContainer()
         let persistence = SwiftDataPersistenceProvider(modelContext: container.mainContext)
         let sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: persistence)
+        sessionManager.configure(persistence: persistence, autoLoad: false)
         try await sessionManager.createSession(title: "Test Chat Session")
 
         let dump = ViewHierarchyDumper.dump(
@@ -101,7 +101,7 @@ final class SidebarAndSheetControlTests: XCTestCase {
         let container = try makeInMemoryContainer()
         let persistence = SwiftDataPersistenceProvider(modelContext: container.mainContext)
         let sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: persistence)
+        sessionManager.configure(persistence: persistence, autoLoad: false)
         try await sessionManager.createSession(title: "Session Alpha")
         try await sessionManager.createSession(title: "Session Beta")
 
@@ -124,7 +124,7 @@ final class SidebarAndSheetControlTests: XCTestCase {
         let container = try makeInMemoryContainer()
         let persistence = SwiftDataPersistenceProvider(modelContext: container.mainContext)
         let sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: persistence)
+        sessionManager.configure(persistence: persistence, autoLoad: false)
         try await sessionManager.createSession(title: "Any Session")
 
         let dump = ViewHierarchyDumper.dump(

--- a/Tests/BaseChatUITests/CancellationTests.swift
+++ b/Tests/BaseChatUITests/CancellationTests.swift
@@ -33,7 +33,7 @@ final class CancellationTests: XCTestCase {
         vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
 
         sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
+        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context), autoLoad: false)
     }
 
     override func tearDown() async throws {

--- a/Tests/BaseChatUITests/ChatExportIntegrationTests.swift
+++ b/Tests/BaseChatUITests/ChatExportIntegrationTests.swift
@@ -20,7 +20,7 @@ final class ChatExportIntegrationTests: XCTestCase {
         context = container.mainContext
         let persistence = SwiftDataPersistenceProvider(modelContext: context)
         sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: persistence)
+        sessionManager.configure(persistence: persistence, autoLoad: false)
     }
 
     override func tearDown() async throws {

--- a/Tests/BaseChatUITests/ChatViewModelIntegrationTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelIntegrationTests.swift
@@ -38,7 +38,7 @@ final class ChatViewModelIntegrationTests: XCTestCase {
         vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
 
         sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
+        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context), autoLoad: false)
     }
 
     override func tearDown() async throws {

--- a/Tests/BaseChatUITests/ConcurrencyTests.swift
+++ b/Tests/BaseChatUITests/ConcurrencyTests.swift
@@ -36,7 +36,7 @@ final class ConcurrencyTests: XCTestCase {
         vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
 
         sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
+        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context), autoLoad: false)
     }
 
     override func tearDown() async throws {

--- a/Tests/BaseChatUITests/EditUserMessageIntegrationTests.swift
+++ b/Tests/BaseChatUITests/EditUserMessageIntegrationTests.swift
@@ -39,7 +39,7 @@ final class EditUserMessageIntegrationTests: XCTestCase {
         vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
 
         sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
+        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context), autoLoad: false)
     }
 
     override func tearDown() async throws {

--- a/Tests/BaseChatUITests/GenerationCoordinatorTrimReservationTests.swift
+++ b/Tests/BaseChatUITests/GenerationCoordinatorTrimReservationTests.swift
@@ -39,7 +39,7 @@ final class GenerationCoordinatorTrimReservationTests: XCTestCase {
         vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
 
         sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
+        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context), autoLoad: false)
 
         let session = try await sessionManager.createSession(title: "Trim fixture")
         sessionManager.activeSession = session

--- a/Tests/BaseChatUITests/IntegratedStreamingPerformanceTests.swift
+++ b/Tests/BaseChatUITests/IntegratedStreamingPerformanceTests.swift
@@ -309,7 +309,7 @@ final class IntegratedStreamingPerformanceTests: XCTestCase {
             vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: modelContext))
 
             let sessionManager = SessionManagerViewModel()
-            sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: modelContext))
+            sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: modelContext), autoLoad: false)
             let session = (try? await sessionManager.createSession(title: "Perf"))!
             sessionManager.activeSession = session
             await vm.switchToSession(session)

--- a/Tests/BaseChatUITests/InterleavingTests.swift
+++ b/Tests/BaseChatUITests/InterleavingTests.swift
@@ -36,7 +36,7 @@ final class InterleavingTests: XCTestCase {
         vm.configure(persistence: persistence)
 
         sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: persistence)
+        sessionManager.configure(persistence: persistence, autoLoad: false)
     }
 
     override func tearDown() async throws {

--- a/Tests/BaseChatUITests/LargeSessionListPerformanceTests.swift
+++ b/Tests/BaseChatUITests/LargeSessionListPerformanceTests.swift
@@ -34,7 +34,7 @@ final class LargeSessionListPerformanceTests: XCTestCase {
         context = container.mainContext
         persistence = SwiftDataPersistenceProvider(modelContext: context)
         vm = SessionManagerViewModel()
-        vm.configure(persistence: persistence)
+        vm.configure(persistence: persistence, autoLoad: false)
         try await seedLargeFixture()
     }
 
@@ -50,7 +50,7 @@ final class LargeSessionListPerformanceTests: XCTestCase {
     func test_perf_initialFirstPageRender() {
         measure {
             let fresh = SessionManagerViewModel()
-            fresh.configure(persistence: persistence)
+            fresh.configure(persistence: persistence, autoLoad: false)
             XCTAssertEqual(fresh.sessions.count, SessionManagerViewModel.sessionsPageSize)
         }
     }

--- a/Tests/BaseChatUITests/LargeSessionListPerformanceTests.swift
+++ b/Tests/BaseChatUITests/LargeSessionListPerformanceTests.swift
@@ -49,8 +49,17 @@ final class LargeSessionListPerformanceTests: XCTestCase {
     /// Initial sidebar render — only the first page should be materialised.
     func test_perf_initialFirstPageRender() {
         measure {
+            // Phase 1.0: `configure` is opt-in for the initial load. Drive
+            // the first-page fetch explicitly so the measurement still covers
+            // the same end-to-end path the sidebar exercises on first render.
             let fresh = SessionManagerViewModel()
             fresh.configure(persistence: persistence, autoLoad: false)
+            let exp = expectation(description: "first page render")
+            Task {
+                await fresh.loadSessions()
+                exp.fulfill()
+            }
+            wait(for: [exp], timeout: 30)
             XCTAssertEqual(fresh.sessions.count, SessionManagerViewModel.sessionsPageSize)
         }
     }

--- a/Tests/BaseChatUITests/PerceivedLatencyDemoTests.swift
+++ b/Tests/BaseChatUITests/PerceivedLatencyDemoTests.swift
@@ -45,7 +45,7 @@ final class PerceivedLatencyDemoTests: XCTestCase {
         vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
 
         sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
+        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context), autoLoad: false)
     }
 
     override func tearDown() async throws {

--- a/Tests/BaseChatUITests/PersistenceGuardTests.swift
+++ b/Tests/BaseChatUITests/PersistenceGuardTests.swift
@@ -82,7 +82,7 @@ final class PersistenceGuardTests: XCTestCase {
     func test_sessionManager_requirePersistence_returnsProviderWhenConfigured() throws {
         let sut = SessionManagerViewModel()
         let provider = provider()
-        sut.configure(persistence: provider)
+        sut.configure(persistence: provider, autoLoad: false)
         let resolved = try sut.requirePersistence("ctx")
         XCTAssertTrue(resolved === provider)
     }
@@ -95,7 +95,7 @@ final class PersistenceGuardTests: XCTestCase {
     func test_sessionManager_persistenceOrLog_returnsProviderWhenConfigured() {
         let sut = SessionManagerViewModel()
         let provider = provider()
-        sut.configure(persistence: provider)
+        sut.configure(persistence: provider, autoLoad: false)
         let resolved = sut.persistenceOrLog("ctx")
         XCTAssertNotNil(resolved)
         XCTAssertTrue(resolved === provider)

--- a/Tests/BaseChatUITests/PersistenceIntegrationTests.swift
+++ b/Tests/BaseChatUITests/PersistenceIntegrationTests.swift
@@ -270,7 +270,7 @@ final class PersistenceIntegrationTests: XCTestCase {
 
         // Use SessionManagerViewModel to delete the session (it handles cascade).
         let sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
+        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context), autoLoad: false)
         try await sessionManager.deleteSession(session.toRecord())
 
         XCTAssertEqual(
@@ -301,7 +301,7 @@ final class PersistenceIntegrationTests: XCTestCase {
 
         // Delete session B.
         let sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
+        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context), autoLoad: false)
         try await sessionManager.deleteSession(sessionB.toRecord())
 
         // Session A should be unaffected.

--- a/Tests/BaseChatUITests/PostGenerationTaskTests.swift
+++ b/Tests/BaseChatUITests/PostGenerationTaskTests.swift
@@ -35,7 +35,7 @@ final class PostGenerationTaskTests: XCTestCase {
         vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
 
         sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
+        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context), autoLoad: false)
     }
 
     override func tearDown() async throws {

--- a/Tests/BaseChatUITests/RuntimeConfigurationTests.swift
+++ b/Tests/BaseChatUITests/RuntimeConfigurationTests.swift
@@ -50,6 +50,11 @@ final class RuntimeConfigurationTests: XCTestCase {
         let created = try await sessionManager.createSession(title: "Runtime Session")
         let persistedIDs = try await runtime.persistence.fetchSessions().map(\.id)
         XCTAssertEqual(persistedIDs, [created.id])
+
+        // `configure(runtime:)` schedules a fire-and-forget `loadSessions()`
+        // (autoLoad: true). Drain it before the runtime / SwiftData container
+        // tears down, otherwise the in-flight fetch races teardown and traps.
+        await sessionManager.autoLoadTask?.value
     }
 
     func test_runtimeBootstrap_canSeedAndActivateInitialSessionWithoutViewLifecycleHooks() async throws {
@@ -80,6 +85,10 @@ final class RuntimeConfigurationTests: XCTestCase {
         chatViewModel.configure(runtime: runtime)
         sessionManager.configure(runtime: runtime)
         chatViewModel.refreshModels()
+        // `configure(runtime:)` schedules a fire-and-forget `loadSessions()`.
+        // Drain it deterministically so the explicit reload below is the
+        // observed sequence and the in-flight fetch can't race teardown.
+        await sessionManager.autoLoadTask?.value
         // Phase 1.0: `configure` no longer auto-fires `loadSessions()`.
         // Hosts that bypass `SessionListView` (which calls it from
         // `.task { }`) must load explicitly during bootstrap.

--- a/Tests/BaseChatUITests/SessionAutoRenameTests.swift
+++ b/Tests/BaseChatUITests/SessionAutoRenameTests.swift
@@ -17,7 +17,7 @@ final class SessionAutoRenameTests: XCTestCase {
         container = try makeInMemoryContainer()
         context = container.mainContext
         vm = SessionManagerViewModel()
-        vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
+        vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: context), autoLoad: false)
     }
 
     override func tearDown() async throws {
@@ -75,6 +75,7 @@ final class SessionAutoRenameTests: XCTestCase {
         let freshVM = SessionManagerViewModel()
         freshVM.configure(
             persistence: SwiftDataPersistenceProvider(modelContext: context),
+            autoLoad: false,
             diagnostics: diagnostics
         )
 
@@ -101,7 +102,7 @@ final class SessionAutoRenameTests: XCTestCase {
         let wrappedPersistence = ErrorInjectingPersistenceProvider(wrapping: freshStack.provider)
         let diagnostics = DiagnosticsService()
         let freshVM = SessionManagerViewModel()
-        freshVM.configure(persistence: wrappedPersistence, diagnostics: diagnostics)
+        freshVM.configure(persistence: wrappedPersistence, autoLoad: false, diagnostics: diagnostics)
 
         let session = try await freshVM.createSession()
         wrappedPersistence.shouldThrowOnUpdateSession = ChatPersistenceError.providerNotConfigured

--- a/Tests/BaseChatUITests/SessionManagerSearchPaginationTests.swift
+++ b/Tests/BaseChatUITests/SessionManagerSearchPaginationTests.swift
@@ -23,7 +23,7 @@ final class SessionManagerSearchPaginationTests: XCTestCase {
         context = container.mainContext
         persistence = SwiftDataPersistenceProvider(modelContext: context)
         vm = SessionManagerViewModel()
-        vm.configure(persistence: persistence)
+        vm.configure(persistence: persistence, autoLoad: false)
     }
 
     override func tearDown() async throws {

--- a/Tests/BaseChatUITests/SessionManagerViewModelTests.swift
+++ b/Tests/BaseChatUITests/SessionManagerViewModelTests.swift
@@ -17,7 +17,7 @@ final class SessionManagerViewModelTests: XCTestCase {
         container = try makeInMemoryContainer()
         context = container.mainContext
         vm = SessionManagerViewModel()
-        vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
+        vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: context), autoLoad: false)
     }
 
     override func tearDown() async throws {
@@ -227,5 +227,72 @@ final class SessionManagerViewModelTests: XCTestCase {
         // The real session should still be present
         XCTAssertEqual(vm.sessions.count, 1)
         XCTAssertEqual(vm.sessions.first?.title, "Real")
+    }
+
+    // MARK: - configure(autoLoad:) — Phase 1.0 regression guard
+
+    /// When `loadSessions()` became `async` the pre-Phase-1.0 sync auto-load
+    /// became a fire-and-forget `Task` inside `configure`. That `Task` raced
+    /// with model-container teardown in tests and trapped SwiftData (the
+    /// `swift test` process exits with signal 5 before reaching `tearDown`).
+    /// The fix is structural: make `autoLoad` a required parameter so every
+    /// call site declares its choice, and use `autoLoad: false` in tests
+    /// where containers are short-lived. These tests pin both halves so the
+    /// silent-empty-list regression cannot reappear.
+    ///
+    /// We deliberately do *not* exercise `autoLoad: true` followed by
+    /// immediate teardown — that race is still present by design (it's a
+    /// fire-and-forget Task; a deallocated container in flight will trap)
+    /// and is the reason `autoLoad` is required rather than defaulted.
+    /// Production callers (`configure(runtime:)`) keep their containers
+    /// alive for the app lifetime, so they don't hit it.
+
+    @MainActor
+    func test_configure_autoLoadFalse_doesNotLoad() async throws {
+        let freshContainer = try makeInMemoryContainer()
+        let freshContext = freshContainer.mainContext
+        let provider = SwiftDataPersistenceProvider(modelContext: freshContext)
+
+        // Seed a session directly through the provider so a load *would*
+        // populate `sessions` if it ran.
+        try await provider.insertSession(ChatSessionRecord(title: "Seeded"))
+
+        let freshVM = SessionManagerViewModel()
+        freshVM.configure(persistence: provider, autoLoad: false)
+
+        // No await — `autoLoad: false` must not schedule any background fetch.
+        XCTAssertEqual(freshVM.sessions.count, 0,
+                       "autoLoad: false must leave sessions empty until loadSessions is called explicitly")
+
+        // Explicit load picks up the seeded record.
+        await freshVM.loadSessions()
+        XCTAssertEqual(freshVM.sessions.count, 1)
+        XCTAssertEqual(freshVM.sessions.first?.title, "Seeded")
+    }
+
+    @MainActor
+    func test_configure_autoLoadTrue_eventuallyLoads() async throws {
+        let freshContainer = try makeInMemoryContainer()
+        let freshContext = freshContainer.mainContext
+        let provider = SwiftDataPersistenceProvider(modelContext: freshContext)
+        try await provider.insertSession(ChatSessionRecord(title: "AutoLoaded"))
+
+        let freshVM = SessionManagerViewModel()
+        freshVM.configure(persistence: provider, autoLoad: true)
+
+        // The fire-and-forget Task may not have run yet. Yield until it
+        // observes the seeded record. Bounded loop guards against infinite
+        // wait if auto-load silently regresses.
+        for _ in 0..<50 where freshVM.sessions.isEmpty {
+            try await Task.sleep(nanoseconds: 10_000_000) // 10ms
+        }
+
+        XCTAssertEqual(freshVM.sessions.count, 1,
+                       "autoLoad: true must populate sessions without an explicit loadSessions call")
+        XCTAssertEqual(freshVM.sessions.first?.title, "AutoLoaded")
+
+        // Drain the auto-load before this scope exits, so the container
+        // outlives the fetch and we don't trap SwiftData on teardown.
+        await freshVM.loadSessions()
     }
 }

--- a/Tests/BaseChatUITests/SessionOverrideTests.swift
+++ b/Tests/BaseChatUITests/SessionOverrideTests.swift
@@ -34,7 +34,7 @@ final class SessionOverrideTests: XCTestCase {
         vm.configure(persistence: persistence)
 
         sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: persistence)
+        sessionManager.configure(persistence: persistence, autoLoad: false)
     }
 
     override func tearDown() async throws {

--- a/Tests/BaseChatUITests/SessionQueueIsolationTests.swift
+++ b/Tests/BaseChatUITests/SessionQueueIsolationTests.swift
@@ -36,7 +36,7 @@ final class SessionQueueIsolationTests: XCTestCase {
         vm.configure(persistence: persistence)
 
         sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: persistence)
+        sessionManager.configure(persistence: persistence, autoLoad: false)
     }
 
     override func tearDown() async throws {

--- a/Tests/BaseChatUITests/StreamingFailureTests.swift
+++ b/Tests/BaseChatUITests/StreamingFailureTests.swift
@@ -19,7 +19,7 @@ final class StreamingFailureTests: XCTestCase {
         container = try makeInMemoryContainer()
         context = container.mainContext
         sessionManager = SessionManagerViewModel()
-        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
+        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context), autoLoad: false)
     }
 
     override func tearDown() async throws {


### PR DESCRIPTION
Follow-up to #883 (Phase 1.0 — async migration). Folds in Fireside review feedback that arrived after #883 merged.

## What this PR does

- **`SessionManagerViewModel.configure(persistence:)` becomes `configure(persistence:autoLoad:diagnostics:)`** with `autoLoad` **required, no default**. The pre-merge signature compiled silently and silently showed an empty session list in any host that had not read the release note. Required parameter forces every call site to declare its choice. `configure(runtime:)` passes `autoLoad: true` so production bootstrap is unchanged.
- **`stopGeneration()` doc comment elevated** — explains why it stays sync (toolbar buttons, `scenePhase` teardown, `handleMemoryPressure()`) and warns future refactors not to "fix" the inconsistency.
- **Two regression tests pin the autoLoad behaviour** (`SessionManagerViewModelTests`):
  - `test_configure_autoLoadFalse_doesNotLoad` — sessions stays empty until explicit `loadSessions()`.
  - `test_configure_autoLoadTrue_eventuallyLoads` — fire-and-forget Task populates sessions.
- All call sites updated (23 test files + Example demo + `RuntimeConfiguration`).

## Why this is a follow-up rather than part of #883

#883 was already merged when the Fireside review landed. Splitting the response into a small targeted PR is cheaper than re-opening #883 — the diff is mechanical and easy to review independently.

## Why `autoLoad` is required (no default)

A defaulted `autoLoad: Bool = false` would let existing call sites compile without any change, exactly the silent-empty-list trap we are trying to prevent. Required parameter means every caller — production bootstrap, tests, Fireside's `AppEnvironmentFactory.swift` — sees the diff and declares intent.

## Why we don't test the teardown race directly

The fire-and-forget Task that `autoLoad: true` schedules can still trap SwiftData if a host's model container deallocates mid-fetch. That race is **still present by design** and is exactly why `autoLoad` is required: tests use `autoLoad: false`, production callers (`configure(runtime:)`) keep their containers alive for the app lifetime. A regression test that exercises the race would itself trap. The structural fix (required parameter) is the regression guard.

## Coordination note for Fireside

Single call site to update: `AppEnvironmentFactory.swift:168` —

```swift
sessionManager.configure(persistence: provider, autoLoad: true)  // preserve old behaviour
// or
sessionManager.configure(persistence: provider, autoLoad: false)
await sessionManager.loadSessions()  // explicit bootstrap
```

## Release note

> **Breaking:** `SessionManagerViewModel.configure(persistence:)` becomes `configure(persistence:autoLoad:diagnostics:)`. `autoLoad` is required — pass `true` to preserve pre-Phase-1.0 auto-load behaviour, `false` if your bootstrap will call `await loadSessions()` itself. The runtime-driven `configure(runtime:)` path passes `autoLoad: true` automatically. Consolidates the Phase 1.0 migration that landed in #883.

## Test plan
- [x] All CI-safe suites pass locally (BaseChatCoreTests, BaseChatInferenceTests, BaseChatUITests, BaseChatUIModelManagementTests, BaseChatMCPTests, BaseChatBackendsTests, BaseChatTestSupportTests, BaseChatAppIntentsTests).
- [x] Regression tests added — `test_configure_autoLoadFalse_doesNotLoad`, `test_configure_autoLoadTrue_eventuallyLoads`.
- [x] Sabotage-checked when this work was on the #883 branch (reverted `insertSession` to sync; build failed at `SwiftDataPersistenceProvider` non-conformance as expected).

## Stats
29 files changed, +143 / -54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)