### PR TITLE
refactor: extract SessionListService from SessionManagerViewModel (phase 1.1)

### DIFF
--- a/Sources/BaseChatUI/ViewModels/SessionListService.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionListService.swift
@@ -97,16 +97,23 @@ final class SessionListService: Sendable {
     /// Upper bound on sessions resolved when surfacing message-search hits.
     static let messageSearchSessionResolveCap: Int = 10_000
 
-    /// Async stream of state transitions for external observers (tests,
-    /// debugging tools, future runtime adapters). The adapter
-    /// (`SessionManagerViewModel`) does not consume this stream — it
-    /// installs a synchronous sink via ``setEventSink(_:)`` so state changes
-    /// land in observable state in the same actor hop as the command that
-    /// produced them.
+    /// Async stream of state transitions. The adapter
+    /// (`SessionManagerViewModel`) installs a synchronous sink via
+    /// ``setEventSink(_:)`` so state changes land in observable state in the
+    /// same actor hop as the command that produced them; the adapter also
+    /// runs a long-lived `Task` that drains this stream so its unbounded
+    /// buffer does not grow.
+    ///
+    /// `AsyncStream` is single-consumer by design: tests that drive the
+    /// service directly (no adapter attached) iterate this stream
+    /// themselves. Once an adapter is attached, the adapter's drain task
+    /// owns the consumer slot and external `for await` loops over
+    /// `service.events` will not observe events. Either drive the service
+    /// without an adapter or install your own sink via ``setEventSink(_:)``.
     ///
     /// Phase 1.2 will move the runtime off `@MainActor`; at that point the
-    /// adapter switches to consuming this stream from a long-lived `Task`
-    /// because cross-actor delivery cannot be synchronous.
+    /// adapter switches to consuming this stream from its drain `Task` (the
+    /// sink path becomes a cross-actor hazard) without changing this surface.
     let events: AsyncStream<SessionListEvent>
     private let continuation: AsyncStream<SessionListEvent>.Continuation
 
@@ -203,8 +210,10 @@ final class SessionListService: Sendable {
     }
 
     /// Loads the next page starting at `offset` and emits `.sessionsLoaded`.
-    /// No-op when persistence raises an error — the failure is logged and
-    /// surfaced as `.persistenceFailure`.
+    /// On persistence failure, emits an empty `.sessionsLoaded(_, hasMore: false, offset:)`
+    /// so the adapter clears `hasMoreSessions` (matching Phase 1.0 behaviour
+    /// where a transient page-load failure stopped further pagination), then
+    /// emits `.persistenceFailure` for diagnostics consumers.
     @MainActor
     func loadNextPage(offset: Int) async {
         do {
@@ -213,6 +222,10 @@ final class SessionListService: Sendable {
             emit(.sessionsLoaded(next, hasMore: hasMore, offset: offset))
         } catch {
             Log.persistence.error("Failed to load next sessions page: \(error)")
+            // Reset hasMoreSessions on the adapter so the failed offset is not
+            // retried automatically. Pre-Phase-1.1 behaviour; restoring it
+            // keeps the public surface source-compatible.
+            emit(.sessionsLoaded([], hasMore: false, offset: offset))
             emit(.persistenceFailure(error))
         }
     }

--- a/Sources/BaseChatUI/ViewModels/SessionListService.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionListService.swift
@@ -1,0 +1,425 @@
+import Foundation
+import BaseChatCore
+import BaseChatInference
+
+// MARK: - Event surface
+//
+// The service emits state transitions as events; the adapter
+// (`SessionManagerViewModel`) consumes them and re-publishes for SwiftUI.
+//
+// `.sessionInserted` from the Phase 0 spike (#878) was always paired with a
+// reload; it is collapsed into `.sessionsLoaded`. Adapters that need the new
+// record's identity get it from the `createSession(...)` return value.
+//
+// `.titleGenerated` carries both the session id and the resolved title so
+// the adapter does not need to re-fetch persistence to update its slot for
+// the renamed session — the subsequent `.sessionsLoaded` carries the full
+// page, but `.titleGenerated` lets observers react to the rename
+// independently (e.g., to surface a "renamed!" affordance).
+//
+// Adding cases later is allowed; renaming or removing is a coordinated
+// breaking change with downstream consumers.
+
+/// Events emitted by ``SessionListService``.
+public enum SessionListEvent: Sendable {
+    /// A page of sessions was loaded. Adapters either replace (`offset == 0`)
+    /// or append (`offset > 0`) based on the carried offset.
+    case sessionsLoaded([ChatSessionRecord], hasMore: Bool, offset: Int)
+
+    /// A session's title was changed (manual rename or auto-rename).
+    case sessionRenamed(UUID, title: String)
+
+    /// A session was deleted.
+    case sessionDeleted(UUID)
+
+    /// Search results changed. The full snapshot replaces previous state.
+    case searchResultsChanged(SearchResults)
+
+    /// An AI title was generated and persisted for a session.
+    case titleGenerated(UUID, title: String)
+
+    /// A persistence operation failed in a non-throwing path. Throwing
+    /// commands surface their error directly to the caller; this case carries
+    /// errors that occur inside event-driven loaders (initial load, next-page,
+    /// message search) where the caller has already returned.
+    case persistenceFailure(any Error)
+}
+
+/// Snapshot of search state emitted in ``SessionListEvent/searchResultsChanged(_:)``.
+public struct SearchResults: Sendable {
+    public let titleMatches: [ChatSessionRecord]
+    public let messageHitsBySession: [UUID: [MessageSearchHit]]
+    public let messageMatchSessions: [ChatSessionRecord]
+
+    public init(
+        titleMatches: [ChatSessionRecord],
+        messageHitsBySession: [UUID: [MessageSearchHit]],
+        messageMatchSessions: [ChatSessionRecord]
+    ) {
+        self.titleMatches = titleMatches
+        self.messageHitsBySession = messageHitsBySession
+        self.messageMatchSessions = messageMatchSessions
+    }
+
+    public static let empty = SearchResults(
+        titleMatches: [],
+        messageHitsBySession: [:],
+        messageMatchSessions: []
+    )
+}
+
+// MARK: - Service
+
+/// Owns session-list orchestration: CRUD, search, pagination, title generation.
+///
+/// Plain `final class` — not `@Observable`, not `@MainActor`-pinned at the
+/// type level. Internal state is `private`; all external state changes go out
+/// as events on ``events``. Commands are `async throws`.
+///
+/// `ChatPersistenceProvider`, `DiagnosticsService`, and `InferenceService` are
+/// `@MainActor`-isolated `Sendable` references. The service holds them as
+/// `let` references injected at init and hops to `@MainActor` on demand
+/// inside command bodies. This keeps `SessionListService` itself off the
+/// main actor while preserving the actor isolation the underlying ports
+/// require — and removes the `nonisolated(unsafe) var _persistence` smell
+/// the Phase 0 spike (#878) flagged.
+///
+/// Visibility is `internal` to `BaseChatUI`. Phase 1.2 may widen to
+/// `package`/`public` once the surface stabilises further.
+final class SessionListService: Sendable {
+
+    /// Default page size used when paginating the session list.
+    static let sessionsPageSize: Int = 50
+
+    /// Default cap on message search results per query.
+    static let messageSearchLimit: Int = 100
+
+    /// Upper bound on sessions resolved when surfacing message-search hits.
+    static let messageSearchSessionResolveCap: Int = 10_000
+
+    /// Async stream of state transitions for external observers (tests,
+    /// debugging tools, future runtime adapters). The adapter
+    /// (`SessionManagerViewModel`) does not consume this stream — it
+    /// installs a synchronous sink via ``setEventSink(_:)`` so state changes
+    /// land in observable state in the same actor hop as the command that
+    /// produced them.
+    ///
+    /// Phase 1.2 will move the runtime off `@MainActor`; at that point the
+    /// adapter switches to consuming this stream from a long-lived `Task`
+    /// because cross-actor delivery cannot be synchronous.
+    let events: AsyncStream<SessionListEvent>
+    private let continuation: AsyncStream<SessionListEvent>.Continuation
+
+    private let persistence: ChatPersistenceProvider
+    private let diagnostics: DiagnosticsService?
+
+    private let sinkBox = EventSinkBox()
+
+    init(
+        persistence: ChatPersistenceProvider,
+        diagnostics: DiagnosticsService? = nil
+    ) {
+        self.persistence = persistence
+        self.diagnostics = diagnostics
+        var cap: AsyncStream<SessionListEvent>.Continuation!
+        self.events = AsyncStream { cap = $0 }
+        self.continuation = cap
+    }
+
+    deinit {
+        continuation.finish()
+    }
+
+    /// Installs a synchronous sink invoked on every emitted event before the
+    /// event reaches ``events`` subscribers. The adapter uses this to mirror
+    /// state without an extra actor hop. Pass `nil` to remove the sink.
+    func setEventSink(_ sink: (@Sendable (SessionListEvent) -> Void)?) {
+        sinkBox.set(sink)
+    }
+
+    /// Emits an event: invokes the synchronous sink (if any) then yields to
+    /// the public `events` stream. Both delivery channels run synchronously
+    /// from the caller's executor — adapters that install a sink see state
+    /// applied before `emit` returns, which keeps the
+    /// `await command(); assert(state)` test pattern deterministic.
+    private func emit(_ event: SessionListEvent) {
+        sinkBox.invoke(event)
+        continuation.yield(event)
+    }
+
+    // MARK: - Commands
+
+    /// Creates a new session, persists it, and emits `.sessionsLoaded`.
+    ///
+    /// Commands are `@MainActor`-isolated for Phase 1.1: the underlying
+    /// `ChatPersistenceProvider` and `DiagnosticsService` are `@MainActor`-
+    /// bound, and isolating the command bodies on `@MainActor` keeps event
+    /// emission ordered with respect to the adapter's main-actor consumer
+    /// without needing a buffered AsyncStream barrier. Phase 1.2 step 5 lifts
+    /// `InferenceService` off main, at which point the command isolation
+    /// drops in tandem.
+    @MainActor
+    @discardableResult
+    func createSession(title: String = "New Chat") async throws -> ChatSessionRecord {
+        let record = ChatSessionRecord(title: title)
+        try await persistence.insertSession(record)
+        await emitFirstPage()
+        return record
+    }
+
+    /// Deletes a session and emits `.sessionDeleted` followed by `.sessionsLoaded`.
+    @MainActor
+    func deleteSession(_ id: UUID) async throws {
+        try await persistence.deleteSession(id)
+        emit(.sessionDeleted(id))
+        await emitFirstPage()
+    }
+
+    /// Renames a session and emits `.sessionRenamed` followed by `.sessionsLoaded`.
+    @MainActor
+    func renameSession(_ session: ChatSessionRecord, title: String) async throws {
+        var updated = session
+        updated.title = title
+        updated.updatedAt = Date()
+        try await persistence.updateSession(updated)
+        emit(.sessionRenamed(session.id, title: title))
+        await emitFirstPage()
+    }
+
+    // MARK: - Pagination
+
+    /// Loads page one and emits `.sessionsLoaded`.
+    @MainActor
+    func loadInitialPage() async {
+        await emitFirstPage()
+    }
+
+    /// Fetches a page of sessions without emitting an event. Mirrors the
+    /// previous `fetchSessionsPage` helper for tests that want to assert on
+    /// raw page contents without VM mutation.
+    @MainActor
+    func fetchPage(offset: Int, limit: Int) async throws -> [ChatSessionRecord] {
+        try await persistence.fetchSessions(offset: offset, limit: limit)
+    }
+
+    /// Loads the next page starting at `offset` and emits `.sessionsLoaded`.
+    /// No-op when persistence raises an error — the failure is logged and
+    /// surfaced as `.persistenceFailure`.
+    @MainActor
+    func loadNextPage(offset: Int) async {
+        do {
+            let next = try await persistence.fetchSessions(offset: offset, limit: Self.sessionsPageSize)
+            let hasMore = next.count == Self.sessionsPageSize
+            emit(.sessionsLoaded(next, hasMore: hasMore, offset: offset))
+        } catch {
+            Log.persistence.error("Failed to load next sessions page: \(error)")
+            emit(.persistenceFailure(error))
+        }
+    }
+
+    // MARK: - Search
+
+    /// Filters the provided sessions by title and emits `.searchResultsChanged`.
+    ///
+    /// The adapter passes its currently loaded `sessions` so the service does
+    /// not need to re-fetch persistence for a client-side filter.
+    @MainActor
+    func runTitleSearch(_ query: String, against sessions: [ChatSessionRecord]) {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            emit(.searchResultsChanged(.empty))
+            return
+        }
+        let matches = sessions.filter {
+            $0.title.range(of: trimmed, options: .caseInsensitive) != nil
+        }
+        emit(.searchResultsChanged(SearchResults(
+            titleMatches: matches,
+            messageHitsBySession: [:],
+            messageMatchSessions: []
+        )))
+    }
+
+    /// Runs a message-scope search via persistence and emits
+    /// `.searchResultsChanged`.
+    @MainActor
+    func runMessageSearch(_ query: String) async {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            emit(.searchResultsChanged(.empty))
+            return
+        }
+        do {
+            let hits = try await persistence.searchMessages(query: trimmed, limit: Self.messageSearchLimit)
+            var grouped: [UUID: [MessageSearchHit]] = [:]
+            grouped.reserveCapacity(hits.count)
+            // Preserve first occurrence order so recency-first ordering of
+            // hits maps directly onto recency-first ordering of sessions.
+            var orderedSessionIDs: [UUID] = []
+            for hit in hits {
+                if grouped[hit.sessionID] == nil {
+                    orderedSessionIDs.append(hit.sessionID)
+                }
+                grouped[hit.sessionID, default: []].append(hit)
+            }
+            let allSessions = try await persistence.fetchSessions(
+                offset: 0,
+                limit: Self.messageSearchSessionResolveCap
+            )
+            let byID = Dictionary(uniqueKeysWithValues: allSessions.map { ($0.id, $0) })
+            let matchSessions = orderedSessionIDs.compactMap { byID[$0] }
+            emit(.searchResultsChanged(SearchResults(
+                titleMatches: [],
+                messageHitsBySession: grouped,
+                messageMatchSessions: matchSessions
+            )))
+        } catch {
+            Log.persistence.error("Message search failed: \(error)")
+            emit(.searchResultsChanged(.empty))
+            emit(.persistenceFailure(error))
+        }
+    }
+
+    /// Clears search state and emits `.searchResultsChanged(.empty)`.
+    @MainActor
+    func clearSearch() {
+        emit(.searchResultsChanged(.empty))
+    }
+
+    // MARK: - Title generation
+
+    /// Generates a concise AI title for `firstMessage` by running a short
+    /// inference request. Returns `nil` when the model produces an empty
+    /// response. Throws the underlying inference error on failure.
+    @MainActor
+    func generateTitle(
+        from firstMessage: String,
+        using inferenceService: InferenceService
+    ) async throws -> String? {
+        let systemPrompt = "Generate a concise 3-5 word title for a conversation that starts with the following message. Reply with ONLY the title, no punctuation, no quotes."
+        let messages: [(role: String, content: String)] = [
+            (role: "user", content: firstMessage)
+        ]
+        let (_, stream) = try inferenceService.enqueue(
+            messages: messages,
+            systemPrompt: systemPrompt,
+            temperature: 0.3,
+            topP: 0.9,
+            repeatPenalty: 1.0,
+            priority: .background,
+            sessionID: nil
+        )
+        var result = ""
+        for try await event in stream.events {
+            if case .token(let text) = event {
+                result += text
+            }
+        }
+        let trimmed = result.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return trimmed.count > 50 ? String(trimmed.prefix(50)) : trimmed
+    }
+
+    /// Generates an AI title for the session and persists it. Only renames
+    /// sessions that are still named "New Chat". Inference and persistence
+    /// failures are recorded on diagnostics in distinct categories.
+    @MainActor
+    func autoRenameSession(
+        _ session: ChatSessionRecord,
+        firstMessage: String,
+        inferenceService: InferenceService
+    ) async {
+        guard session.title == "New Chat" else { return }
+        let title: String?
+        do {
+            title = try await generateTitle(from: firstMessage, using: inferenceService)
+        } catch {
+            Log.ui.warning("Title generation failed for session \(session.id): \(error.localizedDescription)")
+            await diagnostics?.record(.titleGenerationFailed(sessionID: session.id, reason: error.localizedDescription))
+            return
+        }
+        guard let title else { return }
+        var updated = session
+        updated.title = title
+        updated.updatedAt = Date()
+        do {
+            try await persistence.updateSession(updated)
+        } catch {
+            Log.persistence.warning("Failed to persist auto-rename for session \(session.id): \(error.localizedDescription)")
+            // Persistence failure is a distinct category from inference
+            // failure — different remediation (disk/store health vs.
+            // backend availability), so we surface it as its own case.
+            await diagnostics?.record(.sessionRenamePersistenceFailed(sessionID: session.id, reason: error.localizedDescription))
+            return
+        }
+        emit(.titleGenerated(session.id, title: title))
+        await emitFirstPage()
+    }
+
+    /// Auto-generates a session title from the first user message using a
+    /// 50-character word-boundary truncation. Fallback for callers without
+    /// inference. No-op when the session is no longer named "New Chat".
+    @MainActor
+    func autoGenerateTitle(for session: ChatSessionRecord, firstMessage: String) async {
+        guard session.title == "New Chat" else { return }
+        let maxLength = 50
+        var title = firstMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty else { return }
+        if title.count > maxLength {
+            let truncated = String(title.prefix(maxLength))
+            if let lastSpace = truncated.lastIndex(of: " ") {
+                title = String(truncated[truncated.startIndex..<lastSpace]) + "..."
+            } else {
+                title = truncated + "..."
+            }
+        }
+        var updated = session
+        updated.title = title
+        updated.updatedAt = Date()
+        do {
+            try await persistence.updateSession(updated)
+        } catch {
+            Log.persistence.error("Failed to auto-generate title: \(error)")
+            return
+        }
+        emit(.titleGenerated(session.id, title: title))
+        await emitFirstPage()
+    }
+
+    // MARK: - Internal helpers
+
+    /// Loads page one and emits `.sessionsLoaded` (or a failure event).
+    @MainActor
+    private func emitFirstPage() async {
+        do {
+            let page = try await persistence.fetchSessions(offset: 0, limit: Self.sessionsPageSize)
+            let hasMore = page.count == Self.sessionsPageSize
+            emit(.sessionsLoaded(page, hasMore: hasMore, offset: 0))
+        } catch {
+            Log.persistence.error("Failed to load sessions: \(error)")
+            emit(.sessionsLoaded([], hasMore: false, offset: 0))
+            emit(.persistenceFailure(error))
+        }
+    }
+}
+
+/// Holds the optional synchronous event sink. The adapter installs the sink
+/// from `@MainActor`; the service emits events from whatever isolation it is
+/// running on. Lock-protected so any future move of the service off-main
+/// (Phase 1.2) does not need to revisit this storage.
+private final class EventSinkBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var sink: (@Sendable (SessionListEvent) -> Void)?
+
+    func set(_ sink: (@Sendable (SessionListEvent) -> Void)?) {
+        lock.lock(); defer { lock.unlock() }
+        self.sink = sink
+    }
+
+    func invoke(_ event: SessionListEvent) {
+        lock.lock()
+        let current = sink
+        lock.unlock()
+        current?(event)
+    }
+}

--- a/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
@@ -130,9 +130,10 @@ public final class SessionManagerViewModel {
         // commands drop their `@MainActor` isolation. At that point the
         // sink path becomes a cross-actor hazard and the adapter switches
         // to consuming `service.events` from the long-lived consumer task
-        // below. Until then the consumer task drains the stream so it does
-        // not back up and so external `service.events` subscribers see the
-        // full surface even though the adapter does not rely on them.
+        // below. Until then the consumer task only drains the stream so its
+        // unbounded buffer does not grow — `AsyncStream` is single-consumer,
+        // so attaching an adapter and a parallel external `for await` over
+        // `service.events` would race for the same slot.
         let sink: @Sendable (SessionListEvent) -> Void = { [weak self] event in
             MainActor.assumeIsolated {
                 self?.apply(event)

--- a/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/SessionManagerViewModel.swift
@@ -12,62 +12,41 @@ public enum SessionSearchScope: String, CaseIterable, Hashable, Sendable {
 }
 
 /// Manages chat session CRUD operations and the session list.
+///
+/// Phase 1.1 of the runtime ports refactor split orchestration off into
+/// ``SessionListService``: this view model is now a thin `@Observable`
+/// `@MainActor` adapter that consumes the service's
+/// ``SessionListEvent`` stream and republishes state for SwiftUI. Mutation
+/// methods delegate to the service rather than running their own
+/// persistence + reload cycle — the `.sessionsLoaded` event coming back from
+/// the service is what updates ``sessions``.
 @Observable
 @MainActor
 public final class SessionManagerViewModel {
 
     /// Default page size used when paginating the session list.
-    public static let sessionsPageSize: Int = 50
+    public static let sessionsPageSize: Int = SessionListService.sessionsPageSize
 
     /// Default cap on message search results per query.
-    public static let messageSearchLimit: Int = 100
+    public static let messageSearchLimit: Int = SessionListService.messageSearchLimit
 
     /// Upper bound on sessions resolved when surfacing message-search hits.
-    /// Sessions beyond this count cannot be surfaced as a "matching session"
-    /// row even if their messages match — in practice the cap is well above
-    /// any realistic single-user history.
-    public static let messageSearchSessionResolveCap: Int = 10_000
+    public static let messageSearchSessionResolveCap: Int = SessionListService.messageSearchSessionResolveCap
 
-    /// All currently loaded sessions, sorted by most recently updated.
-    ///
-    /// Populated incrementally a page at a time. ``loadSessions()`` resets to
-    /// the first page; ``loadNextPage()`` appends the next page. There is no
-    /// path that fetches every session at once — the sidebar is paginated end
-    /// to end so it stays responsive past 1000+ sessions.
+    // MARK: - Published state
+
     public private(set) var sessions: [ChatSessionRecord] = []
-
-    /// `true` when more pages may be available beyond what's loaded.
     public private(set) var hasMoreSessions: Bool = false
-
-    /// The currently active session.
     public var activeSession: ChatSessionRecord?
 
-    // MARK: - Search
-
-    /// Current search scope. Defaults to titles.
     public var searchScope: SessionSearchScope = .titles
-
-    /// Live query string. The view layer is responsible for debouncing input
-    /// before reassigning this — the VM treats every set as authoritative.
     public var searchQuery: String = ""
 
-    /// Message-search hits indexed by session ID. Empty when scope is titles
-    /// or query is empty.
     public private(set) var messageHitsBySession: [UUID: [MessageSearchHit]] = [:]
-
-    /// Sessions matching the current title-scope query. Empty when scope is
-    /// messages or query is empty.
     public private(set) var titleMatches: [ChatSessionRecord] = []
-
-    /// Sessions surfaced by the most recent message-scope search, ordered by
-    /// their most recent matching message.
     public private(set) var messageMatchSessions: [ChatSessionRecord] = []
 
-    private(set) var persistence: ChatPersistenceProvider?
-
-    /// Optional diagnostics sink for non-fatal operational failures
-    /// (e.g., auto-rename inference errors). Inject via `configure` so
-    /// existing call sites that do not care about diagnostics keep working.
+    /// Optional diagnostics sink for non-fatal operational failures.
     public private(set) var diagnostics: DiagnosticsService?
 
     /// Handle to the fire-and-forget `loadSessions()` Task scheduled by
@@ -79,7 +58,27 @@ public final class SessionManagerViewModel {
     /// SwiftData teardown and traps with SIGSEGV.
     public private(set) var autoLoadTask: Task<Void, Never>?
 
+    // MARK: - Service wiring
+
+    private(set) var service: SessionListService?
+
+    // The consumer task is held in a `Sendable` box so `deinit`
+    // (nonisolated) can cancel it without hopping back to `@MainActor`.
+    // Reads/writes from `@MainActor` contexts (`configure`,
+    // `startConsumerTask`) go through the same box.
+    private let consumerTaskBox = ConsumerTaskBox()
+
+    /// Exposed for `PersistenceGuard` and call sites that need to assert
+    /// configuration. Reads through to the underlying service's persistence
+    /// reference (or `nil` when unconfigured).
+    var persistence: ChatPersistenceProvider? { _persistence }
+    private var _persistence: ChatPersistenceProvider?
+
     public init() {}
+
+    deinit {
+        consumerTaskBox.cancel()
+    }
 
     /// Injects the persistence provider. Call once from the view layer.
     ///
@@ -105,9 +104,12 @@ public final class SessionManagerViewModel {
         autoLoad: Bool,
         diagnostics: DiagnosticsService? = nil
     ) {
-        guard self.persistence == nil else { return }
-        self.persistence = persistence
+        guard self.service == nil else { return }
+        self._persistence = persistence
         self.diagnostics = diagnostics
+        let service = SessionListService(persistence: persistence, diagnostics: diagnostics)
+        self.service = service
+        startConsumerTask(for: service)
         Log.persistence.info("SessionManagerViewModel configured")
         if autoLoad {
             autoLoadTask = Task { [weak self] in
@@ -116,210 +118,160 @@ public final class SessionManagerViewModel {
         }
     }
 
-    /// Creates a new session, inserts it, activates it, and returns it.
-    ///
-    /// Setting `activeSession` to the new record ensures that
-    /// `onChange(of: sessionManager.activeSession)` fires in the host view so
-    /// `ChatViewModel.switchToSession(_:)` is called immediately. Without this,
-    /// callers that rely on the binding (e.g. `SessionListView`'s `List(selection:)`)
-    /// would leave the chat detail in a "No session selected" state until the user
-    /// manually tapped a row.
+    private func startConsumerTask(for service: SessionListService) {
+        // Phase 1.1 has every command isolated on `@MainActor`, so the
+        // synchronous sink installed here runs in the same actor hop as the
+        // command that produced the event. The adapter's observable state
+        // is therefore consistent the moment the command's `await` returns
+        // — no yield is required between `await vm.createSession(...)` and
+        // the assertion that follows.
+        //
+        // Phase 1.2 step 5 lifts `InferenceService` off main and the service
+        // commands drop their `@MainActor` isolation. At that point the
+        // sink path becomes a cross-actor hazard and the adapter switches
+        // to consuming `service.events` from the long-lived consumer task
+        // below. Until then the consumer task drains the stream so it does
+        // not back up and so external `service.events` subscribers see the
+        // full surface even though the adapter does not rely on them.
+        let sink: @Sendable (SessionListEvent) -> Void = { [weak self] event in
+            MainActor.assumeIsolated {
+                self?.apply(event)
+            }
+        }
+        service.setEventSink(sink)
+
+        consumerTaskBox.cancel()
+        let task = Task { @MainActor [weak self] in
+            for await _ in service.events {
+                if self == nil { return }
+            }
+        }
+        consumerTaskBox.set(task)
+    }
+
+    /// Mirrors a service event into observable state.
+    private func apply(_ event: SessionListEvent) {
+        switch event {
+        case let .sessionsLoaded(records, hasMore, offset):
+            if offset == 0 {
+                sessions = records
+            } else {
+                let existing = Set(sessions.map(\.id))
+                let unique = records.filter { !existing.contains($0.id) }
+                sessions.append(contentsOf: unique)
+            }
+            hasMoreSessions = hasMore
+
+        case let .sessionRenamed(id, title):
+            if let idx = sessions.firstIndex(where: { $0.id == id }) {
+                sessions[idx].title = title
+            }
+            if activeSession?.id == id {
+                activeSession?.title = title
+            }
+
+        case let .sessionDeleted(id):
+            if activeSession?.id == id {
+                activeSession = nil
+            }
+            sessions.removeAll { $0.id == id }
+
+        case let .searchResultsChanged(results):
+            titleMatches = results.titleMatches
+            messageHitsBySession = results.messageHitsBySession
+            messageMatchSessions = results.messageMatchSessions
+
+        case let .titleGenerated(id, title):
+            if let idx = sessions.firstIndex(where: { $0.id == id }) {
+                sessions[idx].title = title
+            }
+            if activeSession?.id == id {
+                activeSession?.title = title
+            }
+
+        case .persistenceFailure:
+            // Service has already logged; the adapter has nothing to publish.
+            // Surface points (banners, retry affordances) wire onto the same
+            // event in a future PR rather than ad-hoc state here.
+            break
+        }
+    }
+
+    // MARK: - Mutating commands
+
+    /// Creates a new session, activates it, and returns it.
     @discardableResult
     public func createSession(title: String = "New Chat") async throws -> ChatSessionRecord {
-        let persistence = try requirePersistence("createSession")
-        let record = ChatSessionRecord(title: title)
-        try await persistence.insertSession(record)
-        await loadSessions()
+        let service = try requireService("createSession")
+        let record = try await service.createSession(title: title)
         activeSession = record
         return record
     }
 
     /// Deletes a session and all its messages.
     public func deleteSession(_ session: ChatSessionRecord) async throws {
-        let persistence = try requirePersistence("deleteSession")
-        try await persistence.deleteSession(session.id)
-
-        if activeSession?.id == session.id {
-            activeSession = nil
-        }
-
-        await loadSessions()
+        let service = try requireService("deleteSession")
+        try await service.deleteSession(session.id)
     }
 
     /// Renames a session.
     public func renameSession(_ session: ChatSessionRecord, title: String) async throws {
-        let persistence = try requirePersistence("renameSession")
-        var updated = session
-        updated.title = title
-        updated.updatedAt = Date()
-        try await persistence.updateSession(updated)
-        await loadSessions()
+        let service = try requireService("renameSession")
+        try await service.renameSession(session, title: title)
     }
 
-    // MARK: - AI Auto-Rename
+    // MARK: - AI auto-rename
 
     /// Generates a concise session title by running a short inference request.
-    ///
-    /// Returns `nil` when the model produced an empty response. Throws the
-    /// underlying inference error on failure so callers can surface it to
-    /// `DiagnosticsService` instead of silently dropping it.
-    @MainActor
     public func generateTitle(
         from firstMessage: String,
         using inferenceService: InferenceService
     ) async throws -> String? {
-        let systemPrompt = "Generate a concise 3-5 word title for a conversation that starts with the following message. Reply with ONLY the title, no punctuation, no quotes."
-        let messages: [(role: String, content: String)] = [
-            (role: "user", content: firstMessage)
-        ]
-
-        let (_, stream) = try inferenceService.enqueue(
-            messages: messages,
-            systemPrompt: systemPrompt,
-            temperature: 0.3,
-            topP: 0.9,
-            repeatPenalty: 1.0,
-            priority: .background,
-            sessionID: nil
-        )
-        var result = ""
-        for try await event in stream.events {
-            if case .token(let text) = event {
-                result += text
-            }
-        }
-        let trimmed = result.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-        return trimmed.count > 50 ? String(trimmed.prefix(50)) : trimmed
+        let service = try requireService("generateTitle")
+        return try await service.generateTitle(from: firstMessage, using: inferenceService)
     }
 
     /// Generates an AI title for the session and saves it.
-    ///
-    /// Only renames sessions that are still named "New Chat". Failures
-    /// fall back to the existing title but are recorded on
-    /// `DiagnosticsService` so they can be surfaced to the user.
-    @MainActor
     public func autoRenameSession(
         _ session: ChatSessionRecord,
         firstMessage: String,
         inferenceService: InferenceService
     ) async {
-        guard session.title == "New Chat" else { return }
-        let title: String?
-        do {
-            title = try await generateTitle(from: firstMessage, using: inferenceService)
-        } catch {
-            Log.ui.warning("Title generation failed for session \(session.id): \(error.localizedDescription)")
-            diagnostics?.record(.titleGenerationFailed(sessionID: session.id, reason: error.localizedDescription))
-            return
-        }
-        guard let title else { return }
-        var updated = session
-        updated.title = title
-        updated.updatedAt = Date()
-        do {
-            try await persistence?.updateSession(updated)
-        } catch {
-            Log.persistence.warning("Failed to persist auto-rename for session \(session.id): \(error.localizedDescription)")
-            // Persistence failure is a distinct category from inference
-            // failure — different remediation (disk/store health vs.
-            // backend availability), so we surface it as its own case.
-            diagnostics?.record(.sessionRenamePersistenceFailed(sessionID: session.id, reason: error.localizedDescription))
-            return
-        }
-        await loadSessions()
+        guard let service else { return }
+        await service.autoRenameSession(session, firstMessage: firstMessage, inferenceService: inferenceService)
     }
 
     /// Auto-generates a session title from the first user message.
-    /// Only applies if the current title is "New Chat".
     public func autoGenerateTitle(for session: ChatSessionRecord, firstMessage: String) async {
-        guard session.title == "New Chat" else { return }
-
-        let maxLength = 50
-        var title = firstMessage.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        if title.count > maxLength {
-            let truncated = String(title.prefix(maxLength))
-            if let lastSpace = truncated.lastIndex(of: " ") {
-                title = String(truncated[truncated.startIndex..<lastSpace]) + "..."
-            } else {
-                title = truncated + "..."
-            }
-        }
-
-        guard !title.isEmpty else { return }
-        var updated = session
-        updated.title = title
-        updated.updatedAt = Date()
-        do {
-            try await persistence?.updateSession(updated)
-        } catch {
-            Log.persistence.error("Failed to auto-generate title: \(error)")
-        }
-        await loadSessions()
+        guard let service else { return }
+        await service.autoGenerateTitle(for: session, firstMessage: firstMessage)
     }
 
-    /// Reloads sessions from the persistence provider.
-    ///
-    /// Resets pagination and loads the first page. Mutations elsewhere in the
-    /// VM (create/delete/rename) call this to refresh the list — the caller's
-    /// expectation is "show me the freshest top of the list", which page 1
-    /// always satisfies.
+    // MARK: - Loading + pagination
+
+    /// Reloads sessions from the persistence provider (page one).
     public func loadSessions() async {
-        guard let persistence else { return }
-
-        do {
-            let firstPage = try await persistence.fetchSessions(offset: 0, limit: Self.sessionsPageSize)
-            sessions = firstPage
-            hasMoreSessions = firstPage.count == Self.sessionsPageSize
-        } catch {
-            Log.persistence.error("Failed to load sessions: \(error)")
-            sessions = []
-            hasMoreSessions = false
-        }
+        guard let service else { return }
+        await service.loadInitialPage()
     }
 
-    // MARK: - Pagination
-
-    /// Fetches a page of sessions from the persistence provider.
-    ///
-    /// Used by ``SessionListView`` to drive incremental loading as the user
-    /// scrolls. Caller is responsible for appending the result to
-    /// ``sessions``; this method does not mutate VM state directly so tests
-    /// can assert on raw page contents.
+    /// Fetches a page of sessions from the persistence provider without
+    /// mutating VM state. Tests assert on raw page contents.
     public func fetchSessionsPage(offset: Int, limit: Int) async throws -> [ChatSessionRecord] {
-        let persistence = try requirePersistence("fetchSessionsPage")
-        return try await persistence.fetchSessions(offset: offset, limit: limit)
+        let service = try requireService("fetchSessionsPage")
+        return try await service.fetchPage(offset: offset, limit: limit)
     }
 
     /// Appends the next page of sessions, if any, to ``sessions``.
-    ///
-    /// No-op when no more pages are available, when a search is active, or
-    /// when persistence is unconfigured.
     public func loadNextPage() async {
-        guard hasMoreSessions, persistence != nil else { return }
+        guard hasMoreSessions, let service else { return }
         let offset = sessions.count
-        do {
-            let next = try await fetchSessionsPage(offset: offset, limit: Self.sessionsPageSize)
-            // Defensive against duplicates if a concurrent insert raced the
-            // page boundary — keys are session IDs, so the dedupe is cheap.
-            let existing = Set(sessions.map(\.id))
-            let unique = next.filter { !existing.contains($0.id) }
-            sessions.append(contentsOf: unique)
-            hasMoreSessions = next.count == Self.sessionsPageSize
-        } catch {
-            Log.persistence.error("Failed to load next sessions page: \(error)")
-            hasMoreSessions = false
-        }
+        await service.loadNextPage(offset: offset)
     }
 
     // MARK: - Search
 
     /// Computes the visible session list given the current scope and query.
-    ///
-    /// Returns the unfiltered ``sessions`` list when no search is active.
-    /// Title scope filters in-memory; message scope returns sessions surfaced
-    /// by the most recent ``runMessageSearch(_:)`` call.
     public var displayedSessions: [ChatSessionRecord] {
         let trimmed = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return sessions }
@@ -345,66 +297,61 @@ public final class SessionManagerViewModel {
 
     /// Recomputes ``titleMatches`` against the currently loaded ``sessions``.
     public func runTitleSearch(_ query: String) {
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            titleMatches = []
-            return
-        }
-        titleMatches = sessions.filter {
-            $0.title.range(of: trimmed, options: .caseInsensitive) != nil
-        }
+        guard let service else { return }
+        service.runTitleSearch(query, against: sessions)
     }
 
     /// Runs a message-scope search via the persistence provider.
-    ///
-    /// Populates ``messageHitsBySession`` and ``messageMatchSessions``. The
-    /// result list is ordered by hit recency (most recent matching message
-    /// first), matching the rest of the sidebar's recency-first ordering.
     public func runMessageSearch(_ query: String) async {
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, let persistence else {
+        guard let service else {
             messageHitsBySession = [:]
             messageMatchSessions = []
             return
         }
-
-        do {
-            let hits = try await persistence.searchMessages(query: trimmed, limit: Self.messageSearchLimit)
-            var grouped: [UUID: [MessageSearchHit]] = [:]
-            grouped.reserveCapacity(hits.count)
-            // Preserve the first occurrence of each sessionID to keep
-            // recency ordering — `hits` is already newest-first.
-            var orderedSessionIDs: [UUID] = []
-            for hit in hits {
-                if grouped[hit.sessionID] == nil {
-                    orderedSessionIDs.append(hit.sessionID)
-                }
-                grouped[hit.sessionID, default: []].append(hit)
-            }
-            messageHitsBySession = grouped
-
-            // Resolve sessions for the surfaced IDs. We fetch up to
-            // `messageSearchSessionResolveCap` sessions so a hit in an
-            // unloaded page still gets its session row rendered — otherwise
-            // message search would silently miss matches deep in history.
-            let allSessions = try await persistence.fetchSessions(
-                offset: 0,
-                limit: Self.messageSearchSessionResolveCap
-            )
-            let byID = Dictionary(uniqueKeysWithValues: allSessions.map { ($0.id, $0) })
-            messageMatchSessions = orderedSessionIDs.compactMap { byID[$0] }
-        } catch {
-            Log.persistence.error("Message search failed: \(error)")
-            messageHitsBySession = [:]
-            messageMatchSessions = []
-        }
+        await service.runMessageSearch(query)
     }
 
     /// Clears search state and falls back to the unfiltered session list.
     public func clearSearch() {
         searchQuery = ""
-        titleMatches = []
-        messageHitsBySession = [:]
-        messageMatchSessions = []
+        service?.clearSearch()
+    }
+
+    // MARK: - Service guard
+
+    private func requireService(
+        _ context: @autoclosure () -> String,
+        fileID: StaticString = #fileID,
+        line: UInt = #line
+    ) throws -> SessionListService {
+        guard let service else {
+            let resolved = context()
+            Log.persistence.warning(
+                "\(resolved, privacy: .public) called before persistence was configured (\(fileID, privacy: .public):\(line, privacy: .public))"
+            )
+            throw ChatPersistenceError.providerNotConfigured
+        }
+        return service
+    }
+}
+
+/// Holds the consumer `Task` so a non-isolated `deinit` can cancel it
+/// without hopping back to `@MainActor`. The lock guards the single mutable
+/// reference; `Task.cancel()` is itself thread-safe.
+private final class ConsumerTaskBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var task: Task<Void, Never>?
+
+    func set(_ task: Task<Void, Never>) {
+        lock.lock(); defer { lock.unlock() }
+        self.task = task
+    }
+
+    func cancel() {
+        lock.lock()
+        let current = task
+        task = nil
+        lock.unlock()
+        current?.cancel()
     }
 }

--- a/Tests/BaseChatUITests/SessionListServiceTests.swift
+++ b/Tests/BaseChatUITests/SessionListServiceTests.swift
@@ -182,6 +182,39 @@ final class SessionListServiceTests: XCTestCase {
         XCTAssertEqual(records.count, 10)
     }
 
+    func test_loadNextPage_persistenceFailure_emitsResetThenFailure() async throws {
+        try await seedSessions(count: 5)
+        // Wrap the in-memory provider with an error injector so the next
+        // fetch throws. Using the default `fetchSessions(offset:limit:)`
+        // implementation (pages over `fetchSessions()`) means injecting on
+        // `shouldThrowOnFetchSessions` covers the pagination call too.
+        let injector = ErrorInjectingPersistenceProvider(wrapping: persistence)
+        injector.shouldThrowOnFetchSessions = ChatPersistenceError.providerNotConfigured
+        let service = SessionListService(persistence: injector)
+        let collector = EventCollector()
+        service.setEventSink(collector.sink)
+
+        await service.loadNextPage(offset: 50)
+
+        // Phase 1.0 behaviour: a failed page-load resets `hasMoreSessions`
+        // so the user is not stuck retrying. We restore that by emitting an
+        // empty `.sessionsLoaded(_, hasMore: false, offset:)` ahead of the
+        // diagnostic `.persistenceFailure`. Without the reset the adapter
+        // would still believe a next page exists.
+        let events = collector.snapshot()
+        XCTAssertEqual(events.count, 2,
+                       "Expected reset .sessionsLoaded then .persistenceFailure, got \(events)")
+        guard case let .sessionsLoaded(records, hasMore, offset) = events[0] else {
+            XCTFail("Expected .sessionsLoaded reset event, got \(events[0])"); return
+        }
+        XCTAssertEqual(records, [])
+        XCTAssertFalse(hasMore, "Failure must clear hasMore so the adapter stops paginating")
+        XCTAssertEqual(offset, 50, "Reset event must carry the failed offset, not 0")
+        guard case .persistenceFailure = events[1] else {
+            XCTFail("Expected .persistenceFailure second, got \(events[1])"); return
+        }
+    }
+
     func test_fetchPage_doesNotEmit() async throws {
         try await seedSessions(count: 5)
         let collector = attachCollector()

--- a/Tests/BaseChatUITests/SessionListServiceTests.swift
+++ b/Tests/BaseChatUITests/SessionListServiceTests.swift
@@ -1,0 +1,381 @@
+@preconcurrency import XCTest
+import SwiftData
+@testable import BaseChatUI
+@testable import BaseChatCore
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Phase 1.1 — covers ``SessionListService`` directly (no view model
+/// adapter), ensuring CRUD, search, pagination, and title generation behave
+/// against a real in-memory SwiftData store and that the `AsyncStream` event
+/// surface fires in the expected order.
+@MainActor
+final class SessionListServiceTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+    private var persistence: SwiftDataPersistenceProvider!
+    private var service: SessionListService!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        container = try makeInMemoryContainer()
+        context = container.mainContext
+        persistence = SwiftDataPersistenceProvider(modelContext: context)
+        service = SessionListService(persistence: persistence)
+    }
+
+    override func tearDown() async throws {
+        service = nil
+        persistence = nil
+        context = nil
+        container = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Drains events into an array via the synchronous sink. Tests assert
+    /// against the captured sequence after running commands.
+    private final class EventCollector: @unchecked Sendable {
+        private let lock = NSLock()
+        private(set) var events: [SessionListEvent] = []
+
+        var sink: @Sendable (SessionListEvent) -> Void {
+            { [self] event in
+                self.lock.lock(); defer { self.lock.unlock() }
+                self.events.append(event)
+            }
+        }
+
+        func snapshot() -> [SessionListEvent] {
+            lock.lock(); defer { lock.unlock() }
+            return events
+        }
+    }
+
+    private func attachCollector() -> EventCollector {
+        let collector = EventCollector()
+        service.setEventSink(collector.sink)
+        return collector
+    }
+
+    private func makeInferenceService(tokens: [String]) -> InferenceService {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.tokensToYield = tokens
+        return InferenceService(backend: mock, name: "Mock")
+    }
+
+    private func makeThrowingInferenceService() -> InferenceService {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.shouldThrowOnGenerate = InferenceError.inferenceFailure("Mock failure")
+        return InferenceService(backend: mock, name: "Mock")
+    }
+
+    // MARK: - CRUD
+
+    func test_createSession_persists_andEmitsSessionsLoaded() async throws {
+        let collector = attachCollector()
+
+        let record = try await service.createSession(title: "First")
+
+        XCTAssertEqual(record.title, "First")
+        let events = collector.snapshot()
+        // The contract: `.sessionsLoaded` carries the freshly persisted page.
+        // We do NOT emit `.sessionInserted` — the spike's collapse is
+        // asserted here so a future maintainer cannot quietly re-introduce
+        // the redundant event without breaking this test.
+        XCTAssertEqual(events.count, 1)
+        guard case let .sessionsLoaded(records, hasMore, offset) = events[0] else {
+            XCTFail("Expected .sessionsLoaded, got \(events[0])"); return
+        }
+        XCTAssertEqual(offset, 0)
+        XCTAssertFalse(hasMore)
+        XCTAssertEqual(records.map(\.id), [record.id])
+    }
+
+    func test_deleteSession_emitsSessionDeletedThenSessionsLoaded() async throws {
+        let record = try await service.createSession(title: "Doomed")
+        let collector = attachCollector()
+
+        try await service.deleteSession(record.id)
+
+        let events = collector.snapshot()
+        XCTAssertEqual(events.count, 2)
+        guard case let .sessionDeleted(id) = events[0], id == record.id else {
+            XCTFail("Expected .sessionDeleted(\(record.id)) first, got \(events[0])"); return
+        }
+        guard case let .sessionsLoaded(records, _, _) = events[1] else {
+            XCTFail("Expected .sessionsLoaded second, got \(events[1])"); return
+        }
+        XCTAssertEqual(records, [])
+    }
+
+    func test_deleteSession_throwsOnMissingSession_andEmitsNothing() async throws {
+        let collector = attachCollector()
+        let ghost = ChatSessionRecord(title: "Ghost")
+
+        do {
+            try await service.deleteSession(ghost.id)
+            XCTFail("Expected throw")
+        } catch {
+            guard case ChatPersistenceError.sessionNotFound = error else {
+                XCTFail("Expected sessionNotFound, got \(error)"); return
+            }
+        }
+        XCTAssertEqual(collector.snapshot().count, 0,
+                       "Throwing commands must not emit events on the failure path")
+    }
+
+    func test_renameSession_emitsSessionRenamedThenSessionsLoaded() async throws {
+        let record = try await service.createSession(title: "Original")
+        let collector = attachCollector()
+
+        try await service.renameSession(record, title: "Renamed")
+
+        let events = collector.snapshot()
+        XCTAssertEqual(events.count, 2)
+        guard case let .sessionRenamed(id, title) = events[0] else {
+            XCTFail("Expected .sessionRenamed first, got \(events[0])"); return
+        }
+        XCTAssertEqual(id, record.id)
+        XCTAssertEqual(title, "Renamed")
+        guard case let .sessionsLoaded(records, _, _) = events[1] else {
+            XCTFail("Expected .sessionsLoaded second, got \(events[1])"); return
+        }
+        XCTAssertEqual(records.first?.title, "Renamed")
+    }
+
+    // MARK: - Pagination
+
+    func test_loadInitialPage_emitsFirstPage() async throws {
+        try await seedSessions(count: 60)
+        let collector = attachCollector()
+
+        await service.loadInitialPage()
+
+        let events = collector.snapshot()
+        XCTAssertEqual(events.count, 1)
+        guard case let .sessionsLoaded(records, hasMore, offset) = events[0] else {
+            XCTFail("Expected .sessionsLoaded, got \(events[0])"); return
+        }
+        XCTAssertEqual(offset, 0)
+        XCTAssertTrue(hasMore)
+        XCTAssertEqual(records.count, SessionListService.sessionsPageSize)
+    }
+
+    func test_loadNextPage_emitsPageAtOffset() async throws {
+        try await seedSessions(count: 60)
+        let collector = attachCollector()
+
+        await service.loadNextPage(offset: SessionListService.sessionsPageSize)
+
+        let events = collector.snapshot()
+        XCTAssertEqual(events.count, 1)
+        guard case let .sessionsLoaded(records, hasMore, offset) = events[0] else {
+            XCTFail("Expected .sessionsLoaded, got \(events[0])"); return
+        }
+        XCTAssertEqual(offset, SessionListService.sessionsPageSize)
+        XCTAssertFalse(hasMore, "Final partial page must clear hasMore")
+        XCTAssertEqual(records.count, 10)
+    }
+
+    func test_fetchPage_doesNotEmit() async throws {
+        try await seedSessions(count: 5)
+        let collector = attachCollector()
+
+        let page = try await service.fetchPage(offset: 0, limit: 10)
+
+        XCTAssertEqual(page.count, 5)
+        XCTAssertEqual(collector.snapshot().count, 0,
+                       "fetchPage is the read-only helper; it must not emit")
+    }
+
+    // MARK: - Search
+
+    func test_runTitleSearch_emitsCaseInsensitiveMatches() async throws {
+        try await seedSessions(titles: ["Travel Plan", "Recipes", "TRAVEL guide"])
+        let all = try await persistence.fetchSessions()
+        let collector = attachCollector()
+
+        service.runTitleSearch("travel", against: all)
+
+        guard case let .searchResultsChanged(results) = collector.snapshot().last else {
+            XCTFail("Expected .searchResultsChanged, got \(collector.snapshot())"); return
+        }
+        XCTAssertEqual(Set(results.titleMatches.map(\.title)), ["Travel Plan", "TRAVEL guide"])
+        XCTAssertTrue(results.messageMatchSessions.isEmpty)
+    }
+
+    func test_runTitleSearch_emptyQueryEmitsEmpty() async throws {
+        let collector = attachCollector()
+        service.runTitleSearch(" ", against: [])
+        guard case let .searchResultsChanged(results) = collector.snapshot().last else {
+            XCTFail("Expected .searchResultsChanged"); return
+        }
+        XCTAssertTrue(results.titleMatches.isEmpty)
+    }
+
+    func test_runMessageSearch_emitsHitsAndResolvedSessions() async throws {
+        let s1 = try await service.createSession(title: "S1")
+        let s2 = try await service.createSession(title: "S2")
+        let s3 = try await service.createSession(title: "S3")
+        try await persistence.insertMessage(ChatMessageRecord(role: .user, content: "tell me about NEEDLE in haystack", sessionID: s1.id))
+        try await persistence.insertMessage(ChatMessageRecord(role: .user, content: "no match here", sessionID: s2.id))
+        try await persistence.insertMessage(ChatMessageRecord(role: .user, content: "more needle talk", sessionID: s3.id))
+        let collector = attachCollector()
+
+        await service.runMessageSearch("needle")
+
+        guard case let .searchResultsChanged(results) = collector.snapshot().last else {
+            XCTFail("Expected .searchResultsChanged"); return
+        }
+        XCTAssertEqual(Set(results.messageMatchSessions.map(\.id)), [s1.id, s3.id])
+        XCTAssertEqual(results.messageHitsBySession[s1.id]?.count, 1)
+        XCTAssertEqual(results.messageHitsBySession[s3.id]?.count, 1)
+        XCTAssertNil(results.messageHitsBySession[s2.id])
+    }
+
+    func test_clearSearch_emitsEmpty() {
+        let collector = attachCollector()
+        service.clearSearch()
+        guard case let .searchResultsChanged(results) = collector.snapshot().last else {
+            XCTFail("Expected .searchResultsChanged"); return
+        }
+        XCTAssertTrue(results.titleMatches.isEmpty)
+        XCTAssertTrue(results.messageMatchSessions.isEmpty)
+    }
+
+    // MARK: - Title generation
+
+    func test_autoRenameSession_emitsTitleGenerated_andReload() async throws {
+        let session = try await service.createSession()
+        let collector = attachCollector()
+        let inference = makeInferenceService(tokens: ["Travel", " Tips"])
+
+        await service.autoRenameSession(session, firstMessage: "How do I plan?", inferenceService: inference)
+
+        let events = collector.snapshot()
+        XCTAssertEqual(events.count, 2, "Expected .titleGenerated then .sessionsLoaded")
+        guard case let .titleGenerated(id, title) = events[0] else {
+            XCTFail("Expected .titleGenerated first, got \(events[0])"); return
+        }
+        XCTAssertEqual(id, session.id)
+        XCTAssertEqual(title, "Travel Tips")
+        guard case .sessionsLoaded = events[1] else {
+            XCTFail("Expected .sessionsLoaded second, got \(events[1])"); return
+        }
+    }
+
+    func test_autoRenameSession_inferenceFailure_recordsDiagnostic_emitsNothing() async throws {
+        let diagnostics = DiagnosticsService()
+        let service = SessionListService(persistence: persistence, diagnostics: diagnostics)
+        let session = try await service.createSession()
+        let collector = EventCollector()
+        service.setEventSink(collector.sink)
+        let inference = makeThrowingInferenceService()
+
+        await service.autoRenameSession(session, firstMessage: "Tell me", inferenceService: inference)
+
+        XCTAssertEqual(collector.snapshot().count, 0)
+        XCTAssertEqual(diagnostics.count, 1)
+        guard case .titleGenerationFailed = diagnostics.warnings.first?.error else {
+            XCTFail("Expected .titleGenerationFailed, got \(String(describing: diagnostics.warnings.first?.error))")
+            return
+        }
+    }
+
+    func test_autoRenameSession_skipsNonNewChatTitle() async throws {
+        let session = try await service.createSession(title: "Custom")
+        let collector = attachCollector()
+        let inference = makeInferenceService(tokens: ["Should", " Be", " Skipped"])
+
+        await service.autoRenameSession(session, firstMessage: "Hi", inferenceService: inference)
+
+        XCTAssertEqual(collector.snapshot().count, 0,
+                       "Non-default title must short-circuit before any emit")
+    }
+
+    func test_autoGenerateTitle_emitsTitleGenerated_andTruncatesAtWordBoundary() async throws {
+        let session = try await service.createSession()
+        let collector = attachCollector()
+
+        await service.autoGenerateTitle(
+            for: session,
+            firstMessage: "This is a really long message that should be truncated at a word boundary because it exceeds fifty characters"
+        )
+
+        let events = collector.snapshot()
+        guard case let .titleGenerated(_, title) = events.first else {
+            XCTFail("Expected .titleGenerated, got \(events)"); return
+        }
+        XCTAssertTrue(title.hasSuffix("..."))
+        XCTAssertLessThanOrEqual(title.count, 53)
+    }
+
+    // MARK: - AsyncStream surface
+
+    func test_eventsStream_observesEvents_inOrder() async throws {
+        // Verifies the public AsyncStream surface matches the synchronous
+        // sink. The adapter uses the sink today; runtime adapters in Phase
+        // 1.2 will use the stream.
+        let stream = service.events
+        let observerTask = Task { @MainActor () -> [SessionListEvent] in
+            var observed: [SessionListEvent] = []
+            for await event in stream {
+                observed.append(event)
+                // createSession emits one event; deleteSession emits two.
+                if observed.count >= 3 { break }
+            }
+            return observed
+        }
+        // Yield so the consumer Task is parked on `for await` before we emit.
+        await Task.yield()
+
+        let record = try await service.createSession(title: "Streamed")
+        try await service.deleteSession(record.id)
+
+        let observed = await observerTask.value
+        XCTAssertEqual(observed.count, 3)
+        guard case .sessionsLoaded = observed[0] else {
+            XCTFail("Expected createSession's .sessionsLoaded, got \(observed[0])"); return
+        }
+        guard case let .sessionDeleted(id) = observed[1] else {
+            XCTFail("Expected .sessionDeleted, got \(observed[1])"); return
+        }
+        XCTAssertEqual(id, record.id)
+        guard case .sessionsLoaded = observed[2] else {
+            XCTFail("Expected deleteSession's .sessionsLoaded, got \(observed[2])"); return
+        }
+    }
+
+    // MARK: - Seeding
+
+    private func seedSession(title: String, updatedAt: Date = Date()) async throws -> ChatSessionRecord {
+        let record = ChatSessionRecord(title: title, updatedAt: updatedAt)
+        try await persistence.insertSession(record)
+        return record
+    }
+
+    private func seedSessions(titles: [String], spacingSeconds: TimeInterval = 1) async throws {
+        let base = Date(timeIntervalSince1970: 1_000_000)
+        for (i, title) in titles.enumerated() {
+            try await persistence.insertSession(ChatSessionRecord(
+                title: title,
+                updatedAt: base.addingTimeInterval(Double(i) * spacingSeconds)
+            ))
+        }
+    }
+
+    private func seedSessions(count: Int) async throws {
+        let base = Date(timeIntervalSince1970: 1_000_000)
+        for i in 0..<count {
+            try await persistence.insertSession(ChatSessionRecord(
+                title: "S\(i)",
+                updatedAt: base.addingTimeInterval(Double(i))
+            ))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts session-list orchestration from `SessionManagerViewModel` into a new `SessionListService` (plain `final class Sendable`, async-throws commands, `AsyncStream<SessionListEvent>` for state).
- `SessionManagerViewModel` becomes an `@Observable @MainActor` adapter that consumes the service's events and re-publishes for SwiftUI.
- No public API change — view-model surface stays source-compatible.

## Why
This is **Phase 1.1** of the runtime ports refactor planned in #876. It validates the closure-bag → events transformation for **write paths**, which the Phase 0 spike (#878) could not do because mutations were sync. Phase 1.0 (#883) made commands `async throws`; this PR is the productionisation that proves the pattern scales before the bigger `ConversationRuntime` extraction in Phase 1.2.

Branch is based off `main` (post-#883). PR #885 (the `autoLoad` follow-up on the `refactor/phase-1-0-followup` branch) is in flight; whichever lands first, the other rebases. Both touch different shapes — this PR is the extraction; #885 is a `configure` signature change.

## Spike findings folded in
- Persistence passed at init — no `nonisolated(unsafe) var _persistence`.
- Adapter mutations go through `service.<command>(...)`. No eager-reload dual-write.
- `.sessionInserted` + `.sessionsLoaded` collapsed (the spike noted these were always paired). `createSession` returns the new record; the adapter sets `activeSession` from the return value.
- `.titleGenerated` event handles auto-rename cleanly. The diagnostics path still distinguishes `.titleGenerationFailed` from `.sessionRenamePersistenceFailed`.
- `InferenceService` main-actor coupling unchanged (Phase 1.2 step 5).

## Event surface

\`\`\`swift
public enum SessionListEvent: Sendable {
    case sessionsLoaded([ChatSessionRecord], hasMore: Bool, offset: Int)
    case sessionRenamed(UUID, title: String)
    case sessionDeleted(UUID)
    case searchResultsChanged(SearchResults)
    case titleGenerated(UUID, title: String)
    case persistenceFailure(any Error)
}
\`\`\`

Six cases (down from the spike's seven). \`offset\` was added to \`.sessionsLoaded\` so adapters can distinguish replace-vs-append without owning their own cursor.

## Service ownership decision

\`final class SessionListService: Sendable\` with persistence, diagnostics, and per-call inference injected at init or per-method. Rejected actor isolation because:

- \`ChatPersistenceProvider\` is \`@MainActor\`-bound; an actor would force \`await\` even for client-side filters that never touch the store.
- \`Sendable\` class with init injection composes cleanly: command bodies hop to \`@MainActor\` via the existing port isolation; \`SessionListService\` itself stays unpinned at the type level (matching the plan's principle 7).

## Phase 1.1 isolation seam (open question)

The plan says "use cases are not \`@MainActor\`-pinned at the type level" and "methods that hop into \`@MainActor\` ports hop on demand, with \`await\`." Strictly read, that means service methods are \`nonisolated\` and call \`await persistence.x()\` to hop.

In Phase 1.1 that breaks the \`await vm.createSession(...); XCTAssertEqual(vm.sessions.count, 1)\` test pattern: a long-lived consumer \`Task\` consuming an \`AsyncStream\` cannot drain synchronously relative to a returning command on the same actor — the test asserts before the consumer runs.

The shipped shape pins **command bodies** (not the type) on \`@MainActor\` and routes events through a synchronous sink the adapter installs at \`configure\`. The public \`AsyncStream<SessionListEvent>\` is also yielded so external observers (and Phase 1.2 cross-actor adapters) see the same surface; the adapter's long-lived consumer \`Task\` drains it. Phase 1.2 step 5 lifts \`InferenceService\` off main, the service drops \`@MainActor\` from command bodies, and the adapter switches to the AsyncStream path — no public API change required.

This is a deliberate Phase 1.1 ⇄ Phase 1.2 trade-off; flagging it explicitly so reviewers can push back before merge.

## LOC delta

| File | Before | After | Delta |
|---|---|---|---|
| \`SessionManagerViewModel.swift\` | 383 | 330 | −53 |
| \`SessionListService.swift\` (new) | 0 | 425 | +425 |
| \`SessionListServiceTests.swift\` (new) | 0 | 381 | +381 |
| **Net** | | | **+753** |

The plan budgeted ~+270 LOC based on the spike. The +753 here is mostly the new \`SessionListServiceTests\` (381 LOC, 16 tests) plus the explicit ownership/isolation docstrings on the service. Test coverage at the new boundary is the right place to spend LOC for a contract that's about to absorb \`ConversationRuntime\` in Phase 1.2.

## Test plan
- [x] Full CI-safe pre-push suite passes locally (124s wallclock for the full suite; only the pre-existing \`LargeSessionListPerformanceTests/test_perf_initialFirstPageRender\` failure on \`main\` remains, which is the subject of #885's followup).
- [x] \`SessionListServiceTests\` (new, 16 tests) covers CRUD, search, pagination, title generation, the synchronous-sink path, and the public \`AsyncStream\` surface directly against the service — no view model.
- [x] \`SessionManagerViewModelTests\` (15), \`SessionAutoRenameTests\` (8), \`SessionManagerSearchPaginationTests\` (13), \`PersistenceGuardTests\` (12) pass unchanged.
- [x] Sabotage check: temporarily emitted \`.sessionRenamed("SABOTAGE")\` in place of \`.sessionDeleted\` from \`deleteSession\`. \`test_deleteSession_emitsSessionDeletedThenSessionsLoaded\` correctly failed; reverted.

## Open questions

- **Isolation seam (above).** Reviewer call on whether the \`@MainActor\` per-command isolation is acceptable as a Phase 1.1 expedient or whether the plan should be adjusted.
- **\`persistenceFailure\` event surfacing.** The adapter currently logs and otherwise drops the event. Phase 1.2 will likely surface a UI banner / retry affordance — left as a no-op here rather than inventing a state shape that gets thrown away.
- **\`SessionListService\` visibility.** Currently \`internal\` to \`BaseChatUI\`. Phase 1.2 may widen to \`package\`/\`public\` once the surface stabilises further. Did not pre-emptively widen.