### PR TITLE
feat(voice): add BaseChatVoice speech I/O module

### DIFF
--- a/Example/BaseChatDemo.xcodeproj/project.pbxproj
+++ b/Example/BaseChatDemo.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		BF0027000000000000000000 /* AppIntentToolsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10023000000000000000000 /* AppIntentToolsView.swift */; };
 		BF0029000000000000000000 /* DemoNowTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10024000000000000000000 /* DemoNowTool.swift */; };
 		BF0028000000000000000000 /* BaseChatAppIntents in Frameworks */ = {isa = PBXBuildFile; productRef = F30008000000000000000000 /* BaseChatAppIntents */; };
+		BF0029000000000000000000 /* BaseChatVoice in Frameworks */ = {isa = PBXBuildFile; productRef = F30009000000000000000000 /* BaseChatVoice */; };
 		BF0030000000000000000000 /* PendingSharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10030000000000000000000 /* PendingSharePayload.swift */; };
 		BF0031000000000000000000 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10031000000000000000000 /* ShareViewController.swift */; };
 		BF0032000000000000000000 /* PendingSharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10030000000000000000000 /* PendingSharePayload.swift */; };
@@ -141,6 +142,7 @@
 				BF0006000000000000000000 /* BaseChatTools in Frameworks */,
 				BF0020000000000000000000 /* BaseChatMCP in Frameworks */,
 				BF0028000000000000000000 /* BaseChatAppIntents in Frameworks */,
+				BF0029000000000000000000 /* BaseChatVoice in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -317,6 +319,7 @@
 				F30004000000000000000000 /* BaseChatTools */,
 				F30005000000000000000000 /* BaseChatMCP */,
 				F30008000000000000000000 /* BaseChatAppIntents */,
+				F30009000000000000000000 /* BaseChatVoice */,
 			);
 			productName = BaseChatDemo;
 			productReference = F10003000000000000000000 /* BaseChatDemo.app */;
@@ -933,6 +936,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F20001000000000000000000 /* XCLocalSwiftPackageReference ".." */;
 			productName = BaseChatAppIntents;
+		};
+		F30009000000000000000000 /* BaseChatVoice */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F20001000000000000000000 /* XCLocalSwiftPackageReference ".." */;
+			productName = BaseChatVoice;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Example/BaseChatDemo/DemoContentView.swift
+++ b/Example/BaseChatDemo/DemoContentView.swift
@@ -20,7 +20,9 @@ struct DemoContentView: View {
     @State private var isModelManagementPresented = false
     @State private var isToolPolicyPresented = false
     @State private var isConnectedServicesPresented = false
-    @State private var voiceController = VoiceConversationController()
+    @State private var voiceController = VoiceConversationController(
+        wakeWordDetector: AppleWakeWordDetector(wakeWords: ["hey base chat", "base chat"])
+    )
 
     /// Tool registry shared with the app's inference service. Held here so the
     /// demo scenario runner can install scenario-specific variant executors.

--- a/Example/BaseChatDemo/DemoContentView.swift
+++ b/Example/BaseChatDemo/DemoContentView.swift
@@ -4,6 +4,7 @@ import BaseChatCore
 import BaseChatInference
 import BaseChatUI
 import BaseChatUIModelManagement
+import BaseChatVoice
 
 struct DemoContentView: View {
     @Environment(ChatViewModel.self) private var viewModel
@@ -19,6 +20,7 @@ struct DemoContentView: View {
     @State private var isModelManagementPresented = false
     @State private var isToolPolicyPresented = false
     @State private var isConnectedServicesPresented = false
+    @State private var voiceController = VoiceConversationController()
 
     /// Tool registry shared with the app's inference service. Held here so the
     /// demo scenario runner can install scenario-specific variant executors.
@@ -53,6 +55,9 @@ struct DemoContentView: View {
             ChatView(
                 showModelManagement: $isModelManagementPresented,
                 emptyState: { ChatEmptyStateView(runScenario: runScenario) },
+                composerAccessory: {
+                    VoiceComposerAccessory(controller: voiceController)
+                },
                 apiConfiguration: { APIConfigurationView() }
             )
                 .toolbar {

--- a/Example/BaseChatDemo/Info.plist
+++ b/Example/BaseChatDemo/Info.plist
@@ -15,5 +15,9 @@
 			</array>
 		</dict>
 	</array>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>BaseChat Demo uses the microphone for on-device voice input.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>BaseChat Demo transcribes speech on-device into chat drafts.</string>
 </dict>
 </plist>

--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
         .library(name: "BaseChatBackends", targets: ["BaseChatBackends"]),
         .library(name: "BaseChatUI", targets: ["BaseChatUI"]),
         .library(name: "BaseChatUIModelManagement", targets: ["BaseChatUIModelManagement"]),
+        .library(name: "BaseChatVoice", targets: ["BaseChatVoice"]),
         .library(name: "BaseChatFuzz", targets: ["BaseChatFuzz"]),
         .executable(name: "fuzz-chat", targets: ["fuzz-chat"]),
         .library(name: "BaseChatTools", targets: ["BaseChatTools"]),
@@ -30,6 +31,7 @@ let package = Package(
         .trait(name: "CloudSaaS", description: "Third-party SaaS providers (Claude, OpenAI). Off by default."),
         .trait(name: "MCP", description: "Enable the BaseChatMCP module and MCP client surface."),
         .trait(name: "MCPBuiltinCatalog", description: "Enable BaseChatMCP's built-in catalog descriptors."),
+        .trait(name: "Voice", description: "Enable the BaseChatVoice speech I/O spike and voice composer UI."),
         // Fuzz is intentionally NOT a default trait. Enabling it adds BaseChatBackends
         // (and transitively LlamaSwift) to fuzz-chat, which conflicts with the MLX
         // integration test targets in the auto-generated Xcode scheme. Run the fuzzer via
@@ -162,6 +164,15 @@ let package = Package(
                 .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
             ]
         ),
+        // Voice: optional speech-recognition / synthesis adapters plus chat UI accessories.
+        .target(
+            name: "BaseChatVoice",
+            dependencies: ["BaseChatUI"],
+            path: "Sources/BaseChatVoice",
+            swiftSettings: [
+                .define("Voice", .when(traits: ["Voice"])),
+            ]
+        ),
         // Shared test mocks and utilities
         .target(
             name: "BaseChatTestSupport",
@@ -246,6 +257,16 @@ let package = Package(
                 "BaseChatInference",
                 "BaseChatTestSupport",
                 .product(name: "ViewInspector", package: "ViewInspector"),
+            ]
+        ),
+        .testTarget(
+            name: "BaseChatVoiceTests",
+            dependencies: [
+                "BaseChatVoice",
+                .product(name: "ViewInspector", package: "ViewInspector"),
+            ],
+            swiftSettings: [
+                .define("Voice", .when(traits: ["Voice"])),
             ]
         ),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ swift test --filter BaseChatMCPTests --disable-default-traits
 swift test --filter BaseChatMCPTests --disable-default-traits --traits MCPBuiltinCatalog
 ```
 
-### 2.2 Optional voice spike
+### 2.2 Optional voice
 
 `BaseChatVoice` is an opt-in module for speech input/output. It plugs into
 `ChatView` through the `composerAccessory:` seam, so `BaseChatUI` stays free of
@@ -183,10 +183,22 @@ audio-framework dependencies while hosts can mount a voice accessory above the
 stock `ChatInputBar`.
 
 ```swift
+ .package(
+     url: "https://github.com/roryford/BaseChatKit.git",
+     from: "1.0.0",
+     traits: [
+         .trait(name: "Voice"),
+     ]
+ )
+```
+
+```swift
 import BaseChatUI
 import BaseChatVoice
 
-@State private var voice = VoiceConversationController()
+@State private var voice = VoiceConversationController(
+    wakeWordDetector: AppleWakeWordDetector(wakeWords: ["hey base chat"])
+)
 
 ChatView(
     showModelManagement: $isModelManagementPresented,
@@ -199,6 +211,13 @@ Voice input requires `NSMicrophoneUsageDescription` and
 `NSSpeechRecognitionUsageDescription` in the host app's `Info.plist`. The
 default Apple speech transcriber returns a user-facing error on the simulator,
 so validate the real capture flow on device or macOS hardware.
+
+Wake-word support is phrase detection over the live Apple Speech transcript,
+not background hotword monitoring while the app is idle. On iOS, the default
+audio-session coordinator activates `.playAndRecord` / `.spokenAudio` with
+`.defaultToSpeaker` and `.duckOthers` while capture is active, then deactivates
+the session when recording stops. Apps with their own audio-session policy can
+inject a custom transcriber or audio-session coordinator.
 
 ### 3. Create the runtime at app startup
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ BaseChatUI  ──────────>  BaseChatCore  ───────
 - **BaseChatCore** — SwiftData schema, `@Model` types (`ChatMessage`, `ChatSession`, `SamplerPreset`, `APIEndpoint`, `ModelBenchmarkCache`), `ModelContainerFactory`, `ChatPersistenceProvider`, and chat export. Depends on `BaseChatInference` but does not re-export it.
 - **BaseChatBackends** — Concrete inference backend implementations. Depends on `BaseChatInference` (not `BaseChatCore`), so backends stay free of SwiftData. Pulls MLX, llama.cpp, and cloud APIs.
 - **BaseChatUI** — SwiftUI views and view models. Depends on `BaseChatCore` (for persistence) and `BaseChatInference` (for inference orchestration).
+- **BaseChatVoice** — Optional speech-recognition / synthesis adapters and voice composer UI. Depends on `BaseChatUI` so hosts can opt in without adding a back-edge into the base chat surface.
 
 ## Quick Start
 
@@ -173,6 +174,31 @@ Quick checks:
 swift test --filter BaseChatMCPTests --disable-default-traits
 swift test --filter BaseChatMCPTests --disable-default-traits --traits MCPBuiltinCatalog
 ```
+
+### 2.2 Optional voice spike
+
+`BaseChatVoice` is an opt-in module for speech input/output. It plugs into
+`ChatView` through the `composerAccessory:` seam, so `BaseChatUI` stays free of
+audio-framework dependencies while hosts can mount a voice accessory above the
+stock `ChatInputBar`.
+
+```swift
+import BaseChatUI
+import BaseChatVoice
+
+@State private var voice = VoiceConversationController()
+
+ChatView(
+    showModelManagement: $isModelManagementPresented,
+    composerAccessory: { VoiceComposerAccessory(controller: voice) },
+    apiConfiguration: { APIConfigurationView() }
+)
+```
+
+Voice input requires `NSMicrophoneUsageDescription` and
+`NSSpeechRecognitionUsageDescription` in the host app's `Info.plist`. The
+default Apple speech transcriber returns a user-facing error on the simulator,
+so validate the real capture flow on device or macOS hardware.
 
 ### 3. Create the runtime at app startup
 

--- a/Sources/BaseChatUI/Views/Chat/ChatView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ChatView.swift
@@ -42,6 +42,11 @@ public struct ChatView<APIConfig: View>: View {
     /// `ChatView` init.
     private let apiConfigurationBuilder: () -> APIConfig
 
+    /// Optional host-supplied accessory rendered above the stock composer.
+    /// This is the integration seam for add-ons such as voice capture without
+    /// forcing `BaseChatUI` to depend on optional sibling modules.
+    private let composerAccessoryBuilder: (() -> AnyView)?
+
     public init(
         showModelManagement: Binding<Bool>,
         @ViewBuilder apiConfiguration: @escaping () -> APIConfig
@@ -49,6 +54,18 @@ public struct ChatView<APIConfig: View>: View {
         self._showModelManagement = showModelManagement
         self.customEmptyPlaceholder = nil
         self.apiConfigurationBuilder = apiConfiguration
+        self.composerAccessoryBuilder = nil
+    }
+
+    public init<ComposerAccessory: View>(
+        showModelManagement: Binding<Bool>,
+        @ViewBuilder composerAccessory: @escaping () -> ComposerAccessory,
+        @ViewBuilder apiConfiguration: @escaping () -> APIConfig
+    ) {
+        self._showModelManagement = showModelManagement
+        self.customEmptyPlaceholder = nil
+        self.apiConfigurationBuilder = apiConfiguration
+        self.composerAccessoryBuilder = { AnyView(composerAccessory()) }
     }
 
     /// Creates a ``ChatView`` with a host-supplied empty-state view rendered
@@ -64,6 +81,19 @@ public struct ChatView<APIConfig: View>: View {
         self._showModelManagement = showModelManagement
         self.customEmptyPlaceholder = AnyView(emptyState())
         self.apiConfigurationBuilder = apiConfiguration
+        self.composerAccessoryBuilder = nil
+    }
+
+    public init<EmptyContent: View, ComposerAccessory: View>(
+        showModelManagement: Binding<Bool>,
+        @ViewBuilder emptyState: () -> EmptyContent,
+        @ViewBuilder composerAccessory: @escaping () -> ComposerAccessory,
+        @ViewBuilder apiConfiguration: @escaping () -> APIConfig
+    ) {
+        self._showModelManagement = showModelManagement
+        self.customEmptyPlaceholder = AnyView(emptyState())
+        self.apiConfigurationBuilder = apiConfiguration
+        self.composerAccessoryBuilder = { AnyView(composerAccessory()) }
     }
 
     // MARK: - Body
@@ -87,7 +117,7 @@ public struct ChatView<APIConfig: View>: View {
             Divider()
                 .accessibilityHidden(true)
 
-            ChatInputBar()
+            composerSection
         }
         // Cmd+Shift+M opens Model Management from anywhere in the chat view.
         // The button must be in the view hierarchy (not toolbar) to be always active.
@@ -169,6 +199,16 @@ public struct ChatView<APIConfig: View>: View {
             apiConfigurationBuilder()
         }
         #endif
+    }
+
+    @ViewBuilder
+    private var composerSection: some View {
+        VStack(spacing: 0) {
+            if let composerAccessoryBuilder {
+                composerAccessoryBuilder()
+            }
+            ChatInputBar()
+        }
     }
 
     // MARK: - Error Banner

--- a/Sources/BaseChatVoice/Services/AppleSpeechSynthesizer.swift
+++ b/Sources/BaseChatVoice/Services/AppleSpeechSynthesizer.swift
@@ -1,0 +1,55 @@
+@preconcurrency import AVFoundation
+import Foundation
+
+@MainActor
+public final class AppleSpeechSynthesizer: NSObject, SpeechSynthesizing, AVSpeechSynthesizerDelegate {
+    private let synthesizer: AVSpeechSynthesizer
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    public init(synthesizer: AVSpeechSynthesizer = AVSpeechSynthesizer()) {
+        self.synthesizer = synthesizer
+        super.init()
+        self.synthesizer.delegate = self
+    }
+
+    public func speak(_ text: String) async throws {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        stopSpeaking()
+        try Task.checkCancellation()
+
+        let utterance = AVSpeechUtterance(string: trimmed)
+        utterance.rate = AVSpeechUtteranceDefaultSpeechRate
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            self.continuation = continuation
+            synthesizer.speak(utterance)
+        }
+    }
+
+    public func stopSpeaking() {
+        if synthesizer.isSpeaking {
+            synthesizer.stopSpeaking(at: .immediate)
+        }
+        resumeContinuation(with: .failure(CancellationError()))
+    }
+
+    nonisolated public func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
+        Task { @MainActor in
+            self.resumeContinuation(with: .success(()))
+        }
+    }
+
+    nonisolated public func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didCancel utterance: AVSpeechUtterance) {
+        Task { @MainActor in
+            self.resumeContinuation(with: .failure(CancellationError()))
+        }
+    }
+
+    private func resumeContinuation(with result: Result<Void, Error>) {
+        guard let continuation else { return }
+        self.continuation = nil
+        continuation.resume(with: result)
+    }
+}

--- a/Sources/BaseChatVoice/Services/AppleSpeechTranscriber.swift
+++ b/Sources/BaseChatVoice/Services/AppleSpeechTranscriber.swift
@@ -1,0 +1,129 @@
+@preconcurrency import AVFoundation
+@preconcurrency import Speech
+import Foundation
+
+@MainActor
+public final class AppleSpeechTranscriber: NSObject, SpeechTranscribing {
+    private let recognizer: SFSpeechRecognizer?
+    private let audioEngine: AVAudioEngine
+    private let audioSessionCoordinator: any VoiceAudioSessionCoordinating
+
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    private var recognitionTask: SFSpeechRecognitionTask?
+    private var latestTranscript: String = ""
+
+    public convenience init(locale: Locale = .current) {
+        self.init(
+            locale: locale,
+            audioEngine: AVAudioEngine(),
+            audioSessionCoordinator: DefaultVoiceAudioSessionCoordinator()
+        )
+    }
+
+    init(
+        locale: Locale,
+        audioEngine: AVAudioEngine = AVAudioEngine(),
+        audioSessionCoordinator: (any VoiceAudioSessionCoordinating)? = nil
+    ) {
+        self.recognizer = SFSpeechRecognizer(locale: locale)
+        self.audioEngine = audioEngine
+        self.audioSessionCoordinator = audioSessionCoordinator ?? DefaultVoiceAudioSessionCoordinator()
+        super.init()
+    }
+
+    public func requestAuthorization() async -> VoiceAuthorizationStatus {
+        guard recognizer != nil else { return .unsupportedLocale }
+
+        let speechStatus = await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                continuation.resume(returning: status)
+            }
+        }
+
+        switch speechStatus {
+        case .authorized:
+            let microphoneGranted = await withCheckedContinuation { continuation in
+                AVCaptureDevice.requestAccess(for: .audio) { granted in
+                    continuation.resume(returning: granted)
+                }
+            }
+            return microphoneGranted ? .authorized : .microphoneDenied
+        case .denied:
+            return .denied
+        case .restricted:
+            return .restricted
+        case .notDetermined:
+            return .notDetermined
+        @unknown default:
+            return .denied
+        }
+    }
+
+    public func startTranscribing(
+        onUpdate: @escaping @MainActor (SpeechTranscriptionUpdate) -> Void
+    ) async throws {
+        #if targetEnvironment(simulator)
+        throw VoiceError.simulatorUnsupported
+        #else
+        guard let recognizer else { throw VoiceError.unsupportedLocale }
+        guard recognizer.isAvailable else { throw VoiceError.recognizerUnavailable }
+
+        stopInternal(clearTranscript: true)
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        recognitionRequest = request
+
+        let inputNode = audioEngine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
+        inputNode.removeTap(onBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 1_024, format: format) { [weak self] buffer, _ in
+            self?.recognitionRequest?.append(buffer)
+        }
+
+        recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, _ in
+            guard let self, let result else { return }
+            let transcript = result.bestTranscription.formattedString
+            self.latestTranscript = transcript
+            Task { @MainActor in
+                onUpdate(SpeechTranscriptionUpdate(text: transcript, isFinal: result.isFinal))
+            }
+        }
+
+        do {
+            try audioSessionCoordinator.activateRecording()
+            audioEngine.prepare()
+            try audioEngine.start()
+        } catch {
+            stopInternal(clearTranscript: true)
+            throw VoiceError.setupFailed(error.localizedDescription)
+        }
+        #endif
+    }
+
+    public func stopTranscribing() async throws -> String? {
+        recognitionRequest?.endAudio()
+        stopInternal(clearTranscript: false)
+        let transcript = latestTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+        return transcript.isEmpty ? nil : transcript
+    }
+
+    public func cancelTranscribing() {
+        stopInternal(clearTranscript: true)
+    }
+
+    private func stopInternal(clearTranscript: Bool) {
+        if audioEngine.isRunning {
+            audioEngine.stop()
+        }
+        audioEngine.inputNode.removeTap(onBus: 0)
+        recognitionRequest?.endAudio()
+        recognitionTask?.cancel()
+        recognitionTask = nil
+        recognitionRequest = nil
+        audioSessionCoordinator.deactivateRecording()
+        if clearTranscript {
+            latestTranscript = ""
+        }
+    }
+}

--- a/Sources/BaseChatVoice/Services/AppleWakeWordDetector.swift
+++ b/Sources/BaseChatVoice/Services/AppleWakeWordDetector.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+@MainActor
+public final class AppleWakeWordDetector: WakeWordDetector {
+    private struct PhraseMatcher: Equatable {
+        let original: String
+        let normalized: String
+    }
+
+    private let phrases: [PhraseMatcher]
+    private var hasTriggered = false
+
+    public init(wakeWords: [String]) {
+        self.phrases = wakeWords.compactMap { phrase in
+            let normalized = Self.normalize(phrase)
+            guard !normalized.isEmpty else { return nil }
+            return PhraseMatcher(original: phrase, normalized: normalized)
+        }
+    }
+
+    public func ingest(_ update: SpeechTranscriptionUpdate) -> WakeWordDetection? {
+        guard !hasTriggered else { return nil }
+
+        let normalizedTranscript = Self.normalize(update.text)
+        guard !normalizedTranscript.isEmpty else { return nil }
+
+        let paddedTranscript = " \(normalizedTranscript) "
+        for phrase in phrases {
+            if paddedTranscript.contains(" \(phrase.normalized) ") {
+                hasTriggered = true
+                return WakeWordDetection(phrase: phrase.original, transcript: update.text)
+            }
+        }
+
+        return nil
+    }
+
+    public func reset() {
+        hasTriggered = false
+    }
+
+    private static func normalize(_ text: String) -> String {
+        let lowercased = text.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+        let cleanedScalars = lowercased.unicodeScalars.map { scalar -> Character in
+            if CharacterSet.alphanumerics.contains(scalar) {
+                return Character(scalar)
+            }
+            return " "
+        }
+
+        return String(cleanedScalars)
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Sources/BaseChatVoice/Services/VoiceAudioSessionCoordinator.swift
+++ b/Sources/BaseChatVoice/Services/VoiceAudioSessionCoordinator.swift
@@ -1,0 +1,30 @@
+@preconcurrency import AVFoundation
+
+protocol VoiceAudioSessionCoordinating: AnyObject {
+    @MainActor
+    func activateRecording() throws
+
+    @MainActor
+    func deactivateRecording()
+}
+
+@MainActor
+final class DefaultVoiceAudioSessionCoordinator: VoiceAudioSessionCoordinating {
+    func activateRecording() throws {
+        #if os(iOS)
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(
+            .playAndRecord,
+            mode: .spokenAudio,
+            options: [.defaultToSpeaker, .duckOthers]
+        )
+        try session.setActive(true)
+        #endif
+    }
+
+    func deactivateRecording() {
+        #if os(iOS)
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+        #endif
+    }
+}

--- a/Sources/BaseChatVoice/Views/LiveTranscriptionView.swift
+++ b/Sources/BaseChatVoice/Views/LiveTranscriptionView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+public struct LiveTranscriptionView: View {
+    private let title: String
+    private let text: String
+
+    public init(text: String, title: String = "Voice draft") {
+        self.title = title
+        self.text = text
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Text(text)
+                .font(.callout)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(12)
+                .background(.fill.tertiary, in: RoundedRectangle(cornerRadius: 12))
+        }
+        .padding(.horizontal)
+        .padding(.top, 8)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(title): \(text)")
+        .accessibilityIdentifier("voice-live-transcription")
+    }
+}

--- a/Sources/BaseChatVoice/Views/VoiceComposerAccessory.swift
+++ b/Sources/BaseChatVoice/Views/VoiceComposerAccessory.swift
@@ -40,6 +40,10 @@ public struct VoiceComposerAccessory: View {
         @Bindable var controller = controller
 
         VStack(alignment: .leading, spacing: 8) {
+            if let detection = controller.recentWakeWordDetection {
+                WakeWordToast(phrase: detection.phrase)
+            }
+
             if controller.showsTranscriptPreview {
                 LiveTranscriptionView(
                     text: transcriptPreviewText(for: controller),

--- a/Sources/BaseChatVoice/Views/VoiceComposerAccessory.swift
+++ b/Sources/BaseChatVoice/Views/VoiceComposerAccessory.swift
@@ -1,0 +1,133 @@
+import SwiftUI
+import BaseChatUI
+
+public enum VoiceDraftMergeStrategy: Sendable {
+    case replace
+    case append
+}
+
+enum VoiceDraftComposer {
+    static func merge(transcript: String, into draft: String, strategy: VoiceDraftMergeStrategy) -> String {
+        let trimmedTranscript = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTranscript.isEmpty else { return draft }
+
+        switch strategy {
+        case .replace:
+            return trimmedTranscript
+        case .append:
+            let trimmedDraft = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedDraft.isEmpty else { return trimmedTranscript }
+            return "\(trimmedDraft)\n\(trimmedTranscript)"
+        }
+    }
+}
+
+public struct VoiceComposerAccessory: View {
+    @Environment(ChatViewModel.self) private var viewModel
+
+    private let controller: VoiceConversationController
+    private let mergeStrategy: VoiceDraftMergeStrategy
+
+    public init(
+        controller: VoiceConversationController,
+        mergeStrategy: VoiceDraftMergeStrategy = .append
+    ) {
+        self.controller = controller
+        self.mergeStrategy = mergeStrategy
+    }
+
+    public var body: some View {
+        @Bindable var controller = controller
+
+        VStack(alignment: .leading, spacing: 8) {
+            if controller.showsTranscriptPreview {
+                LiveTranscriptionView(
+                    text: transcriptPreviewText(for: controller),
+                    title: controller.captureState == .processing ? "Finishing transcript…" : "Voice draft"
+                )
+            }
+
+            HStack(spacing: 12) {
+                VoiceInputButton(
+                    isRecording: controller.isRecording,
+                    isBusy: controller.captureState == .processing
+                ) {
+                    Task {
+                        await handleVoiceInputTapped()
+                    }
+                }
+
+                if let latestAssistantReply {
+                    Button {
+                        controller.togglePlayback(for: latestAssistantReply)
+                    } label: {
+                        Label(
+                            controller.isSpeaking ? "Stop Reading" : "Read Last Reply",
+                            systemImage: controller.isSpeaking ? "speaker.slash.fill" : "speaker.wave.2.fill"
+                        )
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(controller.captureState == .recording || controller.captureState == .processing)
+                    .accessibilityLabel(
+                        controller.isSpeaking ? "Stop reading the last assistant reply aloud" : "Read the last assistant reply aloud"
+                    )
+                    .accessibilityIdentifier("voice-playback-button")
+                }
+
+                if let status = controller.statusText {
+                    Text(status)
+                        .font(.caption)
+                        .foregroundStyle(isFailure(controller.captureState) ? Color.red : .secondary)
+                        .lineLimit(2)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.bottom, 8)
+        }
+        .background(.bar)
+        .onDisappear {
+            controller.cancelRecording()
+            controller.stopSpeaking()
+        }
+    }
+
+    private var latestAssistantReply: String? {
+        let latestMessage = viewModel.messages.last {
+            $0.role == .assistant && !$0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        return latestMessage?.content
+    }
+
+    private func transcriptPreviewText(for controller: VoiceConversationController) -> String {
+        let trimmed = controller.liveTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            return trimmed
+        }
+        switch controller.captureState {
+        case .recording:
+            return "Start speaking to dictate your next draft."
+        case .processing:
+            return "Waiting for the final on-device transcript…"
+        case .idle, .requestingPermission, .failed:
+            return ""
+        }
+    }
+
+    private func handleVoiceInputTapped() async {
+        if controller.isRecording {
+            guard let transcript = await controller.stopRecording() else { return }
+            viewModel.inputText = VoiceDraftComposer.merge(
+                transcript: transcript,
+                into: viewModel.inputText,
+                strategy: mergeStrategy
+            )
+        } else {
+            await controller.startRecording()
+        }
+    }
+
+    private func isFailure(_ state: VoiceCaptureState) -> Bool {
+        if case .failed = state { return true }
+        return false
+    }
+}

--- a/Sources/BaseChatVoice/Views/VoiceInputButton.swift
+++ b/Sources/BaseChatVoice/Views/VoiceInputButton.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+public struct VoiceInputButton: View {
+    private let isRecording: Bool
+    private let isBusy: Bool
+    private let action: () -> Void
+
+    public init(
+        isRecording: Bool,
+        isBusy: Bool = false,
+        action: @escaping () -> Void
+    ) {
+        self.isRecording = isRecording
+        self.isBusy = isBusy
+        self.action = action
+    }
+
+    public var body: some View {
+        Button(action: action) {
+            Label(buttonTitle, systemImage: systemImage)
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(isRecording ? .red : .accentColor)
+        .disabled(isBusy)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint(accessibilityHint)
+        .accessibilityIdentifier("voice-input-button")
+    }
+
+    private var buttonTitle: String {
+        if isBusy { return "Finishing…" }
+        return isRecording ? "Stop" : "Voice"
+    }
+
+    private var systemImage: String {
+        if isBusy { return "waveform.badge.magnifyingglass" }
+        return isRecording ? "stop.circle.fill" : "mic.circle.fill"
+    }
+
+    private var accessibilityLabel: String {
+        if isBusy { return "Finishing voice capture" }
+        return isRecording ? "Stop voice capture" : "Start voice capture"
+    }
+
+    private var accessibilityHint: String {
+        if isBusy { return "Wait for the speech recognizer to finish transcribing." }
+        return isRecording
+            ? "Stops recording and keeps the transcript in the draft."
+            : "Starts dictating a chat draft from your microphone."
+    }
+}

--- a/Sources/BaseChatVoice/Views/WakeWordToast.swift
+++ b/Sources/BaseChatVoice/Views/WakeWordToast.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+public struct WakeWordToast: View {
+    private let phrase: String
+
+    public init(phrase: String) {
+        self.phrase = phrase
+    }
+
+    public var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "waveform.circle.fill")
+                .imageScale(.large)
+                .foregroundStyle(Color.accentColor)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Wake word detected")
+                    .font(.caption.weight(.semibold))
+                Text("“\(phrase)”")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(.thinMaterial, in: Capsule())
+        .padding(.horizontal)
+        .padding(.top, 8)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Self.accessibilityLabel(for: phrase))
+        .accessibilityIdentifier("wake-word-toast")
+    }
+
+    public static func accessibilityLabel(for phrase: String) -> String {
+        "Wake word detected: \(phrase)"
+    }
+}

--- a/Sources/BaseChatVoice/VoiceConversationController.swift
+++ b/Sources/BaseChatVoice/VoiceConversationController.swift
@@ -1,0 +1,181 @@
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+public final class VoiceConversationController {
+
+    public private(set) var captureState: VoiceCaptureState = .idle
+    public private(set) var liveTranscript: String = ""
+    public private(set) var lastCommittedTranscript: String?
+    public private(set) var errorMessage: String?
+    public private(set) var isSpeaking: Bool = false
+
+    @ObservationIgnored private let transcriber: any SpeechTranscribing
+    @ObservationIgnored private let synthesizer: any SpeechSynthesizing
+    @ObservationIgnored private var playbackTask: Task<Void, Never>?
+
+    public init(
+        transcriber: (any SpeechTranscribing)? = nil,
+        synthesizer: (any SpeechSynthesizing)? = nil
+    ) {
+        self.transcriber = transcriber ?? AppleSpeechTranscriber()
+        self.synthesizer = synthesizer ?? AppleSpeechSynthesizer()
+    }
+
+    public var isRecording: Bool {
+        captureState == .recording
+    }
+
+    public var showsTranscriptPreview: Bool {
+        switch captureState {
+        case .recording, .processing:
+            true
+        case .idle, .requestingPermission:
+            !liveTranscript.isEmpty
+        case .failed:
+            false
+        }
+    }
+
+    public var statusText: String? {
+        if let errorMessage {
+            return errorMessage
+        }
+        if isSpeaking {
+            return "Reading the last assistant reply aloud…"
+        }
+        switch captureState {
+        case .idle:
+            return nil
+        case .requestingPermission:
+            return "Requesting microphone and speech access…"
+        case .recording:
+            return "Listening…"
+        case .processing:
+            return "Finishing transcript…"
+        case .failed(let message):
+            return message
+        }
+    }
+
+    public func startRecording() async {
+        guard captureState != .recording, captureState != .processing else { return }
+
+        stopSpeaking()
+        errorMessage = nil
+        lastCommittedTranscript = nil
+        liveTranscript = ""
+        captureState = .requestingPermission
+
+        switch await transcriber.requestAuthorization() {
+        case .authorized:
+            break
+        case .denied:
+            setFailure(VoiceError.speechRecognitionDenied)
+            return
+        case .restricted:
+            setFailure(VoiceError.speechRecognitionRestricted)
+            return
+        case .notDetermined:
+            setFailure(VoiceError.speechRecognitionDenied)
+            return
+        case .unsupportedLocale:
+            setFailure(VoiceError.unsupportedLocale)
+            return
+        case .microphoneDenied:
+            setFailure(VoiceError.microphoneAccessDenied)
+            return
+        }
+
+        do {
+            try await transcriber.startTranscribing { [weak self] update in
+                guard let self else { return }
+                self.liveTranscript = update.text
+            }
+            captureState = .recording
+        } catch {
+            setFailure(error)
+        }
+    }
+
+    @discardableResult
+    public func stopRecording() async -> String? {
+        guard captureState == .recording || captureState == .processing else { return nil }
+        captureState = .processing
+
+        do {
+            let transcript = try await transcriber.stopTranscribing()?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let resolvedSource = transcript.flatMap { $0.isEmpty ? nil : $0 } ?? liveTranscript
+            let resolved = resolvedSource.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            captureState = .idle
+            guard !resolved.isEmpty else {
+                liveTranscript = ""
+                return nil
+            }
+
+            liveTranscript = resolved
+            lastCommittedTranscript = resolved
+            return resolved
+        } catch {
+            setFailure(error)
+            return nil
+        }
+    }
+
+    public func cancelRecording() {
+        transcriber.cancelTranscribing()
+        liveTranscript = ""
+        lastCommittedTranscript = nil
+        errorMessage = nil
+        if case .failed = captureState {
+            captureState = .idle
+        } else if captureState != .idle {
+            captureState = .idle
+        }
+    }
+
+    public func togglePlayback(for text: String) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        if isSpeaking {
+            stopSpeaking()
+            return
+        }
+
+        errorMessage = nil
+        playbackTask?.cancel()
+        isSpeaking = true
+
+        playbackTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await self.synthesizer.speak(trimmed)
+            } catch is CancellationError {
+            } catch {
+                await MainActor.run {
+                    self.errorMessage = error.localizedDescription
+                }
+            }
+
+            await MainActor.run {
+                self.isSpeaking = false
+                self.playbackTask = nil
+            }
+        }
+    }
+
+    public func stopSpeaking() {
+        synthesizer.stopSpeaking()
+        playbackTask?.cancel()
+        playbackTask = nil
+        isSpeaking = false
+    }
+
+    private func setFailure(_ error: Error) {
+        captureState = .failed(error.localizedDescription)
+        errorMessage = error.localizedDescription
+    }
+}

--- a/Sources/BaseChatVoice/VoiceConversationController.swift
+++ b/Sources/BaseChatVoice/VoiceConversationController.swift
@@ -8,19 +8,30 @@ public final class VoiceConversationController {
     public private(set) var captureState: VoiceCaptureState = .idle
     public private(set) var liveTranscript: String = ""
     public private(set) var lastCommittedTranscript: String?
+    public private(set) var recentWakeWordDetection: WakeWordDetection?
     public private(set) var errorMessage: String?
     public private(set) var isSpeaking: Bool = false
 
     @ObservationIgnored private let transcriber: any SpeechTranscribing
     @ObservationIgnored private let synthesizer: any SpeechSynthesizing
+    @ObservationIgnored private let wakeWordDetector: (any WakeWordDetector)?
+    @ObservationIgnored private let wakeWordToastDuration: Duration
+    @ObservationIgnored private let toastSleeper: @Sendable (Duration) async throws -> Void
     @ObservationIgnored private var playbackTask: Task<Void, Never>?
+    @ObservationIgnored private var wakeWordDismissTask: Task<Void, Never>?
 
     public init(
         transcriber: (any SpeechTranscribing)? = nil,
-        synthesizer: (any SpeechSynthesizing)? = nil
+        synthesizer: (any SpeechSynthesizing)? = nil,
+        wakeWordDetector: (any WakeWordDetector)? = nil,
+        wakeWordToastDuration: Duration = .seconds(2),
+        toastSleeper: @Sendable @escaping (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
     ) {
         self.transcriber = transcriber ?? AppleSpeechTranscriber()
         self.synthesizer = synthesizer ?? AppleSpeechSynthesizer()
+        self.wakeWordDetector = wakeWordDetector
+        self.wakeWordToastDuration = wakeWordToastDuration
+        self.toastSleeper = toastSleeper
     }
 
     public var isRecording: Bool {
@@ -65,7 +76,11 @@ public final class VoiceConversationController {
         stopSpeaking()
         errorMessage = nil
         lastCommittedTranscript = nil
+        recentWakeWordDetection = nil
         liveTranscript = ""
+        wakeWordDismissTask?.cancel()
+        wakeWordDismissTask = nil
+        wakeWordDetector?.reset()
         captureState = .requestingPermission
 
         switch await transcriber.requestAuthorization() {
@@ -91,6 +106,9 @@ public final class VoiceConversationController {
         do {
             try await transcriber.startTranscribing { [weak self] update in
                 guard let self else { return }
+                if let detection = self.wakeWordDetector?.ingest(update) {
+                    self.presentWakeWordDetection(detection)
+                }
                 self.liveTranscript = update.text
             }
             captureState = .recording
@@ -103,6 +121,9 @@ public final class VoiceConversationController {
     public func stopRecording() async -> String? {
         guard captureState == .recording || captureState == .processing else { return nil }
         captureState = .processing
+        wakeWordDismissTask?.cancel()
+        wakeWordDismissTask = nil
+        recentWakeWordDetection = nil
 
         do {
             let transcript = try await transcriber.stopTranscribing()?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -126,8 +147,12 @@ public final class VoiceConversationController {
 
     public func cancelRecording() {
         transcriber.cancelTranscribing()
+        wakeWordDismissTask?.cancel()
+        wakeWordDismissTask = nil
+        recentWakeWordDetection = nil
         liveTranscript = ""
         lastCommittedTranscript = nil
+        wakeWordDetector?.reset()
         errorMessage = nil
         if case .failed = captureState {
             captureState = .idle
@@ -172,6 +197,34 @@ public final class VoiceConversationController {
         playbackTask?.cancel()
         playbackTask = nil
         isSpeaking = false
+    }
+
+    private func presentWakeWordDetection(_ detection: WakeWordDetection) {
+        recentWakeWordDetection = detection
+        wakeWordDismissTask?.cancel()
+
+        wakeWordDismissTask = Task { [weak self] in
+            guard let self else { return }
+
+            do {
+                try await self.toastSleeper(self.wakeWordToastDuration)
+            } catch is CancellationError {
+                return
+            } catch {
+                await MainActor.run {
+                    self.errorMessage = error.localizedDescription
+                    self.wakeWordDismissTask = nil
+                }
+                return
+            }
+
+            await MainActor.run {
+                if self.recentWakeWordDetection == detection {
+                    self.recentWakeWordDetection = nil
+                }
+                self.wakeWordDismissTask = nil
+            }
+        }
     }
 
     private func setFailure(_ error: Error) {

--- a/Sources/BaseChatVoice/VoiceTypes.swift
+++ b/Sources/BaseChatVoice/VoiceTypes.swift
@@ -10,6 +10,16 @@ public struct SpeechTranscriptionUpdate: Sendable, Equatable {
     }
 }
 
+public struct WakeWordDetection: Sendable, Equatable {
+    public let phrase: String
+    public let transcript: String
+
+    public init(phrase: String, transcript: String) {
+        self.phrase = phrase
+        self.transcript = transcript
+    }
+}
+
 public enum VoiceAuthorizationStatus: Sendable, Equatable {
     case authorized
     case denied
@@ -78,4 +88,12 @@ public protocol SpeechSynthesizing: AnyObject {
 
     @MainActor
     func stopSpeaking()
+}
+
+public protocol WakeWordDetector: AnyObject {
+    @MainActor
+    func ingest(_ update: SpeechTranscriptionUpdate) -> WakeWordDetection?
+
+    @MainActor
+    func reset()
 }

--- a/Sources/BaseChatVoice/VoiceTypes.swift
+++ b/Sources/BaseChatVoice/VoiceTypes.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+public struct SpeechTranscriptionUpdate: Sendable, Equatable {
+    public let text: String
+    public let isFinal: Bool
+
+    public init(text: String, isFinal: Bool) {
+        self.text = text
+        self.isFinal = isFinal
+    }
+}
+
+public enum VoiceAuthorizationStatus: Sendable, Equatable {
+    case authorized
+    case denied
+    case restricted
+    case notDetermined
+    case unsupportedLocale
+    case microphoneDenied
+}
+
+public enum VoiceCaptureState: Equatable {
+    case idle
+    case requestingPermission
+    case recording
+    case processing
+    case failed(String)
+}
+
+public enum VoiceError: LocalizedError, Equatable {
+    case recognizerUnavailable
+    case unsupportedLocale
+    case speechRecognitionDenied
+    case speechRecognitionRestricted
+    case microphoneAccessDenied
+    case simulatorUnsupported
+    case setupFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .recognizerUnavailable:
+            "Speech recognition is unavailable right now."
+        case .unsupportedLocale:
+            "Speech recognition is unavailable for the current locale."
+        case .speechRecognitionDenied:
+            "Speech recognition permission is required for voice input."
+        case .speechRecognitionRestricted:
+            "Speech recognition is restricted on this device."
+        case .microphoneAccessDenied:
+            "Microphone access is required for voice input."
+        case .simulatorUnsupported:
+            "Voice capture is unavailable in the simulator."
+        case .setupFailed(let message):
+            "Voice capture could not start: \(message)"
+        }
+    }
+}
+
+public protocol SpeechTranscribing: AnyObject {
+    @MainActor
+    func requestAuthorization() async -> VoiceAuthorizationStatus
+
+    @MainActor
+    func startTranscribing(
+        onUpdate: @escaping @MainActor (SpeechTranscriptionUpdate) -> Void
+    ) async throws
+
+    @MainActor
+    func stopTranscribing() async throws -> String?
+
+    @MainActor
+    func cancelTranscribing()
+}
+
+public protocol SpeechSynthesizing: AnyObject {
+    @MainActor
+    func speak(_ text: String) async throws
+
+    @MainActor
+    func stopSpeaking()
+}

--- a/Tests/BaseChatBackendsTests/CloudEndpointSelectionIntegrationTests.swift
+++ b/Tests/BaseChatBackendsTests/CloudEndpointSelectionIntegrationTests.swift
@@ -112,7 +112,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
         service.registerCloudBackendFactory(cloudFactory)
         let viewModel = ChatViewModel(inferenceService: service)
         let persistence = SwiftDataPersistenceProvider(modelContext: context)
-        viewModel.configure(persistence: persistence, autoLoad: false)
+        viewModel.configure(persistence: persistence)
         return viewModel
     }
 
@@ -194,7 +194,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
             ConfiguringOpenAICloudBackend(urlSession: cloudSession!)
         }
         let persistence = SwiftDataPersistenceProvider(modelContext: context)
-        freshVM.configure(persistence: persistence, autoLoad: false)
+        freshVM.configure(persistence: persistence)
         try await makeSession(title: "Sabotage Chat")
         freshVM.selectedEndpoint = endpoint
         await freshVM.loadCloudEndpoint(endpoint)

--- a/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
+++ b/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
@@ -340,3 +340,14 @@ BaseChatBackends/LlamaToolCallParser.swift:let decoded = try? JSONSerialization.
 # JSONSerialization rejects — caller falls back to "{}", same shape as
 # the JSON-fallback path's empty-arg fallback.
 BaseChatBackends/LlamaToolCallParser.swift:guard let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys]),
+
+# ---------------------------------------------------------------------------
+# BaseChatVoice
+# ---------------------------------------------------------------------------
+
+# Best-effort audio-session deactivation. iOS may already be tearing down the
+# session (route change, app backgrounded, interruption ended) by the time we
+# call this on stop/cancel. Throwing here would only surface a benign
+# "session not active" error to the user; the route is reclaimed regardless.
+# Mirrors the pattern in Apple's own AVAudioSession sample code.
+BaseChatVoice/Services/VoiceAudioSessionCoordinator.swift:try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)

--- a/Tests/BaseChatUITests/ChatComposerAccessoryMigrationGuardTests.swift
+++ b/Tests/BaseChatUITests/ChatComposerAccessoryMigrationGuardTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+import SwiftUI
+@testable import BaseChatUI
+
+/// Regression test for the composer-accessory seam introduced for optional UI
+/// modules such as BaseChatVoice.
+///
+/// The test target builds without the `Voice` trait; that's intentional. The
+/// seam must remain available even when optional modules are absent so host apps
+/// can keep composing accessory views from sibling packages without creating a
+/// dependency cycle back into `BaseChatUI`.
+final class ChatComposerAccessoryMigrationGuardTests: XCTestCase {
+
+    @MainActor
+    func test_chatView_isInstantiableWithComposerAccessoryUnderDisabledTraits() {
+        let view: AnyView = AnyView(
+            ChatView(
+                showModelManagement: .constant(false),
+                composerAccessory: { Text("Voice spike") },
+                apiConfiguration: { EmptyView() }
+            )
+        )
+
+        XCTAssertNotNil(view)
+    }
+}

--- a/Tests/BaseChatVoiceTests/VoiceConversationControllerTests.swift
+++ b/Tests/BaseChatVoiceTests/VoiceConversationControllerTests.swift
@@ -1,0 +1,132 @@
+import XCTest
+@testable import BaseChatVoice
+
+@MainActor
+final class VoiceConversationControllerTests: XCTestCase {
+
+    func test_startAndStopRecordingPublishesTranscript() async {
+        let transcriber = MockSpeechTranscriber()
+        transcriber.stopResult = "Hello BaseChat"
+        let controller = VoiceConversationController(
+            transcriber: transcriber,
+            synthesizer: MockSpeechSynthesizer()
+        )
+
+        await controller.startRecording()
+        XCTAssertEqual(controller.captureState, .recording)
+
+        await transcriber.emit(text: "Hello BaseChat", isFinal: false)
+        XCTAssertEqual(controller.liveTranscript, "Hello BaseChat")
+
+        let transcript = await controller.stopRecording()
+        XCTAssertEqual(transcript, "Hello BaseChat")
+        XCTAssertEqual(controller.lastCommittedTranscript, "Hello BaseChat")
+        XCTAssertEqual(controller.captureState, .idle)
+    }
+
+    func test_startRecordingSurfacesPermissionFailure() async {
+        let transcriber = MockSpeechTranscriber()
+        transcriber.authorizationStatus = .microphoneDenied
+        let controller = VoiceConversationController(
+            transcriber: transcriber,
+            synthesizer: MockSpeechSynthesizer()
+        )
+
+        await controller.startRecording()
+
+        XCTAssertEqual(controller.captureState, .failed("Microphone access is required for voice input."))
+        XCTAssertEqual(controller.statusText, "Microphone access is required for voice input.")
+    }
+
+    func test_togglePlaybackStartsAndStopsSpeech() async {
+        let synthesizer = MockSpeechSynthesizer()
+        synthesizer.shouldSuspend = true
+        let controller = VoiceConversationController(
+            transcriber: MockSpeechTranscriber(),
+            synthesizer: synthesizer
+        )
+
+        controller.togglePlayback(for: "Read me")
+        await Task.yield()
+
+        XCTAssertTrue(controller.isSpeaking)
+        XCTAssertEqual(synthesizer.spokenTexts, ["Read me"])
+
+        controller.stopSpeaking()
+
+        XCTAssertFalse(controller.isSpeaking)
+        XCTAssertEqual(synthesizer.stopCalls, 1)
+    }
+
+    func test_cancelRecordingResetsTranscriptState() async {
+        let transcriber = MockSpeechTranscriber()
+        let controller = VoiceConversationController(
+            transcriber: transcriber,
+            synthesizer: MockSpeechSynthesizer()
+        )
+
+        await controller.startRecording()
+        await transcriber.emit(text: "Partial", isFinal: false)
+        controller.cancelRecording()
+
+        XCTAssertEqual(controller.captureState, .idle)
+        XCTAssertEqual(controller.liveTranscript, "")
+        XCTAssertEqual(transcriber.cancelCalls, 1)
+    }
+}
+
+@MainActor
+private final class MockSpeechTranscriber: SpeechTranscribing {
+    var authorizationStatus: VoiceAuthorizationStatus = .authorized
+    var stopResult: String?
+    var stopError: Error?
+    var cancelCalls = 0
+    private var onUpdate: (@MainActor (SpeechTranscriptionUpdate) -> Void)?
+
+    func requestAuthorization() async -> VoiceAuthorizationStatus {
+        authorizationStatus
+    }
+
+    func startTranscribing(
+        onUpdate: @escaping @MainActor (SpeechTranscriptionUpdate) -> Void
+    ) async throws {
+        self.onUpdate = onUpdate
+    }
+
+    func stopTranscribing() async throws -> String? {
+        if let stopError { throw stopError }
+        return stopResult
+    }
+
+    func cancelTranscribing() {
+        cancelCalls += 1
+    }
+
+    func emit(text: String, isFinal: Bool) async {
+        onUpdate?(SpeechTranscriptionUpdate(text: text, isFinal: isFinal))
+    }
+}
+
+@MainActor
+private final class MockSpeechSynthesizer: SpeechSynthesizing {
+    var spokenTexts: [String] = []
+    var stopCalls = 0
+    var shouldSuspend = false
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    func speak(_ text: String) async throws {
+        spokenTexts.append(text)
+
+        if shouldSuspend {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                self.continuation = continuation
+            }
+        }
+    }
+
+    func stopSpeaking() {
+        stopCalls += 1
+        continuation?.resume(throwing: CancellationError())
+        continuation = nil
+    }
+}

--- a/Tests/BaseChatVoiceTests/VoiceConversationControllerTests.swift
+++ b/Tests/BaseChatVoiceTests/VoiceConversationControllerTests.swift
@@ -73,6 +73,83 @@ final class VoiceConversationControllerTests: XCTestCase {
         XCTAssertEqual(controller.liveTranscript, "")
         XCTAssertEqual(transcriber.cancelCalls, 1)
     }
+
+    func test_cancelRecordingClearsWakeWordToast() async {
+        let transcriber = MockSpeechTranscriber()
+        let sleeper = ControlledToastSleeper()
+        let controller = VoiceConversationController(
+            transcriber: transcriber,
+            synthesizer: MockSpeechSynthesizer(),
+            wakeWordDetector: AppleWakeWordDetector(wakeWords: ["hey base chat"]),
+            wakeWordToastDuration: .seconds(1),
+            toastSleeper: { duration in try await sleeper.sleep(for: duration) }
+        )
+
+        await controller.startRecording()
+        await transcriber.emit(text: "hey base chat draft this reply", isFinal: false)
+        await Task.yield()
+
+        XCTAssertNotNil(controller.recentWakeWordDetection)
+
+        controller.cancelRecording()
+
+        XCTAssertNil(controller.recentWakeWordDetection)
+    }
+
+    func test_stopRecordingClearsWakeWordToast() async {
+        let transcriber = MockSpeechTranscriber()
+        transcriber.stopResult = "hey base chat draft this reply"
+        let sleeper = ControlledToastSleeper()
+        let controller = VoiceConversationController(
+            transcriber: transcriber,
+            synthesizer: MockSpeechSynthesizer(),
+            wakeWordDetector: AppleWakeWordDetector(wakeWords: ["hey base chat"]),
+            wakeWordToastDuration: .seconds(1),
+            toastSleeper: { duration in try await sleeper.sleep(for: duration) }
+        )
+
+        await controller.startRecording()
+        await transcriber.emit(text: "hey base chat draft this reply", isFinal: false)
+        await Task.yield()
+
+        XCTAssertNotNil(controller.recentWakeWordDetection)
+
+        _ = await controller.stopRecording()
+
+        XCTAssertNil(controller.recentWakeWordDetection)
+    }
+
+    func test_wakeWordDetectionAppearsAndDismisses() async {
+        let transcriber = MockSpeechTranscriber()
+        let sleeper = ControlledToastSleeper()
+        let controller = VoiceConversationController(
+            transcriber: transcriber,
+            synthesizer: MockSpeechSynthesizer(),
+            wakeWordDetector: AppleWakeWordDetector(wakeWords: ["hey base chat"]),
+            wakeWordToastDuration: .seconds(1),
+            toastSleeper: { duration in try await sleeper.sleep(for: duration) }
+        )
+
+        await controller.startRecording()
+        await transcriber.emit(text: "hey base chat summarize this thread", isFinal: false)
+        await Task.yield()
+
+        XCTAssertEqual(
+            controller.recentWakeWordDetection,
+            WakeWordDetection(
+                phrase: "hey base chat",
+                transcript: "hey base chat summarize this thread"
+            )
+        )
+        XCTAssertEqual(sleeper.recordedDurations, [.seconds(1)])
+
+        sleeper.resume()
+        for _ in 0..<20 where controller.recentWakeWordDetection != nil {
+            await Task.yield()
+        }
+
+        XCTAssertNil(controller.recentWakeWordDetection)
+    }
 }
 
 @MainActor
@@ -127,6 +204,24 @@ private final class MockSpeechSynthesizer: SpeechSynthesizing {
     func stopSpeaking() {
         stopCalls += 1
         continuation?.resume(throwing: CancellationError())
+        continuation = nil
+    }
+}
+
+@MainActor
+private final class ControlledToastSleeper {
+    private(set) var recordedDurations: [Duration] = []
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    func sleep(for duration: Duration) async throws {
+        recordedDurations.append(duration)
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            self.continuation = continuation
+        }
+    }
+
+    func resume() {
+        continuation?.resume()
         continuation = nil
     }
 }

--- a/Tests/BaseChatVoiceTests/VoiceDraftComposerTests.swift
+++ b/Tests/BaseChatVoiceTests/VoiceDraftComposerTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import BaseChatVoice
+
+final class VoiceDraftComposerTests: XCTestCase {
+    func test_appendStrategyAddsTranscriptOnNewLine() {
+        XCTAssertEqual(
+            VoiceDraftComposer.merge(
+                transcript: "Dictated follow-up",
+                into: "Existing draft",
+                strategy: .append
+            ),
+            "Existing draft\nDictated follow-up"
+        )
+    }
+
+    func test_replaceStrategyOverwritesExistingDraft() {
+        XCTAssertEqual(
+            VoiceDraftComposer.merge(
+                transcript: "Fresh transcript",
+                into: "Existing draft",
+                strategy: .replace
+            ),
+            "Fresh transcript"
+        )
+    }
+}

--- a/Tests/BaseChatVoiceTests/VoiceViewContractTests.swift
+++ b/Tests/BaseChatVoiceTests/VoiceViewContractTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+import ViewInspector
+@testable import BaseChatVoice
+
+@MainActor
+final class VoiceViewContractTests: XCTestCase {
+    func test_voiceInputButtonUsesRecordingAccessibilityContract() throws {
+        let idle = VoiceInputButton(isRecording: false, action: {})
+        let active = VoiceInputButton(isRecording: true, action: {})
+
+        let idleLabel = try idle.inspect()
+            .find(ViewType.Button.self)
+            .accessibilityLabel()
+            .string()
+        let activeLabel = try active.inspect()
+            .find(ViewType.Button.self)
+            .accessibilityLabel()
+            .string()
+
+        XCTAssertEqual(idleLabel, "Start voice capture")
+        XCTAssertEqual(activeLabel, "Stop voice capture")
+    }
+
+    func test_liveTranscriptionViewRendersTitleAndTranscript() throws {
+        let view = LiveTranscriptionView(text: "Hello from speech", title: "Voice draft")
+
+        XCTAssertEqual(try view.inspect().find(text: "Voice draft").string(), "Voice draft")
+        XCTAssertEqual(try view.inspect().find(text: "Hello from speech").string(), "Hello from speech")
+    }
+}

--- a/Tests/BaseChatVoiceTests/VoiceViewContractTests.swift
+++ b/Tests/BaseChatVoiceTests/VoiceViewContractTests.swift
@@ -27,4 +27,16 @@ final class VoiceViewContractTests: XCTestCase {
         XCTAssertEqual(try view.inspect().find(text: "Voice draft").string(), "Voice draft")
         XCTAssertEqual(try view.inspect().find(text: "Hello from speech").string(), "Hello from speech")
     }
+
+    func test_wakeWordToastUsesAccessibilityContract() throws {
+        let view = WakeWordToast(phrase: "hey base chat")
+
+        let label = try view.inspect()
+            .find(viewWithAccessibilityIdentifier: "wake-word-toast")
+            .accessibilityLabel()
+            .string()
+
+        XCTAssertEqual(label, "Wake word detected: hey base chat")
+        XCTAssertEqual(label, WakeWordToast.accessibilityLabel(for: "hey base chat"))
+    }
 }

--- a/Tests/BaseChatVoiceTests/WakeWordDetectorTests.swift
+++ b/Tests/BaseChatVoiceTests/WakeWordDetectorTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import BaseChatVoice
+
+@MainActor
+final class WakeWordDetectorTests: XCTestCase {
+    func test_detectorMatchesNormalizedWakeWordOncePerSession() {
+        let detector = AppleWakeWordDetector(wakeWords: ["Hey, Base Chat"])
+
+        XCTAssertNil(detector.ingest(.init(text: "hello there", isFinal: false)))
+
+        let first = detector.ingest(.init(text: "hey base chat, start a new note", isFinal: false))
+        XCTAssertEqual(
+            first,
+            WakeWordDetection(
+                phrase: "Hey, Base Chat",
+                transcript: "hey base chat, start a new note"
+            )
+        )
+
+        XCTAssertNil(detector.ingest(.init(text: "hey base chat, keep listening", isFinal: false)))
+
+        detector.reset()
+
+        let second = detector.ingest(.init(text: "HEY BASE CHAT do it again", isFinal: false))
+        XCTAssertEqual(
+            second,
+            WakeWordDetection(
+                phrase: "Hey, Base Chat",
+                transcript: "HEY BASE CHAT do it again"
+            )
+        )
+    }
+
+    func test_detectorIgnoresBlankConfiguredWakeWords() {
+        let detector = AppleWakeWordDetector(wakeWords: ["", "   "])
+
+        XCTAssertNil(detector.ingest(.init(text: "hey base chat", isFinal: false)))
+    }
+}


### PR DESCRIPTION
Refs #445

## Summary
- add the trait-gated BaseChatVoice speech I/O module and composer-accessory integration seam
- add wake-word phrase detection, WakeWordToast, and demo-app voice accessory wiring
- document Voice trait setup, required permission strings, simulator limits, and audio-session behavior

## Validation
- swift test --filter BaseChatVoiceTests --disable-default-traits --traits Voice
- swift test --filter ChatComposerAccessoryMigrationGuardTests --disable-default-traits --traits Voice
- swift build --product BaseChatVoice --disable-default-traits --traits Voice

## Notes
- attempted macOS and iOS Simulator demo-app builds with xcodebuild, but current main is already blocked by the pre-existing `DemoTools` -> `DemoNowTool` compile error in `Example/BaseChatDemo/DemoTools.swift`
