### PR TITLE
refactor: extract internal ports (SamplerPresetStore, BenchmarkCache, EndpointStore) (phase 1.2.3)

### DIFF
--- a/Example/BaseChatDemo/BaseChatDemoApp.swift
+++ b/Example/BaseChatDemo/BaseChatDemoApp.swift
@@ -219,6 +219,8 @@ struct BaseChatDemoApp: App {
                     .environment(chatViewModel)
                     .environment(modelManagementViewModel)
                     .environment(sessionManager)
+                    .environment(\.samplerPresetStore, runtime.samplerPresetStore)
+                    .environment(\.endpointStore, runtime.endpointStore)
                     #if os(macOS)
                     .frame(minWidth: 600, minHeight: 400)
                     #endif
@@ -351,6 +353,7 @@ struct BaseChatDemoApp: App {
 
         chatViewModel.configure(runtime: runtime)
         sessionManager.configure(runtime: runtime)
+        modelManagementViewModel.benchmarkCache = runtime.benchmarkCache
         chatViewModel.onFirstMessage = { [inferenceService] session, text in
             Task { @MainActor in
                 while chatViewModel.isGenerating {

--- a/Example/Examples/MinimalExample/MinimalExampleApp.swift
+++ b/Example/Examples/MinimalExample/MinimalExampleApp.swift
@@ -48,12 +48,15 @@ struct MinimalExampleApp: App {
         let downloadManager = BackgroundDownloadManager()
         let huggingFaceService = HuggingFaceService()
 
-        _chatViewModel = State(initialValue: vm)
-        _sessionManager = State(initialValue: sessionManager)
-        _modelManagement = State(initialValue: ModelManagementViewModel(
+        let modelManagement = ModelManagementViewModel(
             huggingFaceService: huggingFaceService,
             downloadManager: downloadManager
-        ))
+        )
+        modelManagement.benchmarkCache = runtime.benchmarkCache
+
+        _chatViewModel = State(initialValue: vm)
+        _sessionManager = State(initialValue: sessionManager)
+        _modelManagement = State(initialValue: modelManagement)
     }
 
     var body: some Scene {
@@ -62,6 +65,8 @@ struct MinimalExampleApp: App {
                 .environment(chatViewModel)
                 .environment(sessionManager)
                 .environment(modelManagement)
+                .environment(\.samplerPresetStore, runtime.samplerPresetStore)
+                .environment(\.endpointStore, runtime.endpointStore)
                 .task {
                     // SwiftData fetches and the initial model load run here
                     // rather than in App.init(): the @MainActor work below

--- a/Sources/BaseChatCore/BaseChatRuntime.swift
+++ b/Sources/BaseChatCore/BaseChatRuntime.swift
@@ -29,6 +29,9 @@ public final class BaseChatRuntime {
     public let diagnostics: DiagnosticsService
     public let modelContainer: ModelContainer
     public let persistence: SwiftDataPersistenceProvider
+    public let samplerPresetStore: SwiftDataSamplerPresetStore
+    public let benchmarkCache: SwiftDataBenchmarkCache
+    public let endpointStore: SwiftDataEndpointStore
 
     public var modelContext: ModelContext { modelContainer.mainContext }
 
@@ -53,7 +56,11 @@ public final class BaseChatRuntime {
             self.modelContainer = resolvedModelContainer
 
             self.diagnostics = diagnostics
-            self.persistence = SwiftDataPersistenceProvider(modelContext: resolvedModelContainer.mainContext)
+            let mainContext = resolvedModelContainer.mainContext
+            self.persistence = SwiftDataPersistenceProvider(modelContext: mainContext)
+            self.samplerPresetStore = SwiftDataSamplerPresetStore(modelContext: mainContext)
+            self.benchmarkCache = SwiftDataBenchmarkCache(modelContext: mainContext)
+            self.endpointStore = SwiftDataEndpointStore(modelContext: mainContext)
         } catch {
             BaseChatConfiguration.shared = previousConfiguration
             throw error

--- a/Sources/BaseChatCore/InferenceService+APIEndpoint.swift
+++ b/Sources/BaseChatCore/InferenceService+APIEndpoint.swift
@@ -22,7 +22,9 @@ extension APIEndpoint {
             provider: provider,
             baseURL: baseURL,
             modelName: modelName,
-            keychainAccount: keychainAccount
+            keychainAccount: keychainAccount,
+            createdAt: createdAt,
+            isEnabled: isEnabled
         )
     }
 }

--- a/Sources/BaseChatCore/Models/APIEndpointRecord+RichValidation.swift
+++ b/Sources/BaseChatCore/Models/APIEndpointRecord+RichValidation.swift
@@ -1,0 +1,66 @@
+import Foundation
+import BaseChatInference
+
+extension APIEndpointRecord {
+
+    /// Rich validation that returns the specific ``APIEndpointValidationReason``
+    /// when an endpoint URL is rejected, mirroring `APIEndpoint.validate()`.
+    ///
+    /// Both forms delegate to ``PrivateIPClassifier`` so the blocked-range
+    /// rules live in one place. Use this overload when the UI needs to surface
+    /// *why* an endpoint is rejected; use ``validate()`` (the throwing form on
+    /// `BaseChatInference`) when a pass/fail answer is sufficient.
+    public func validateBaseURL() -> Result<Void, APIEndpointValidationReason> {
+        let trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            return .failure(.emptyURL)
+        }
+
+        guard let url = URL(string: trimmed),
+              let scheme = url.scheme?.lowercased(),
+              url.host() != nil else {
+            return .failure(.malformedURL)
+        }
+
+        guard scheme == "http" || scheme == "https" else {
+            return .failure(.unsupportedScheme(scheme))
+        }
+
+        if PrivateIPClassifier.isLocalhostURL(url) {
+            return .success(())
+        }
+
+        if scheme != "https" {
+            return .failure(.insecureScheme)
+        }
+
+        if let reason = Self.classifyDisallowedPrivateHost(url) {
+            return .failure(reason)
+        }
+
+        return .success(())
+    }
+
+    /// `true` when ``validateBaseURL()`` returns `.success`.
+    public var isValid: Bool {
+        if case .success = validateBaseURL() { return true }
+        return false
+    }
+
+    private static func classifyDisallowedPrivateHost(_ url: URL) -> APIEndpointValidationReason? {
+        guard let rawHost = url.host()?.lowercased() else { return nil }
+        let host = rawHost.hasSuffix(".") ? String(rawHost.dropLast()) : rawHost
+
+        guard let category = PrivateIPClassifier.classifyIPLiteral(host) else {
+            return nil
+        }
+
+        switch category {
+        case .privateHost:        return .privateHost
+        case .linkLocalHost:      return .linkLocalHost
+        case .ipv6UniqueLocal:    return .ipv6UniqueLocal
+        case .ipv4MappedLoopback: return .ipv4MappedLoopback
+        case .multicastReserved:  return .multicastReserved
+        }
+    }
+}

--- a/Sources/BaseChatCore/Protocols/BenchmarkCache.swift
+++ b/Sources/BaseChatCore/Protocols/BenchmarkCache.swift
@@ -1,0 +1,24 @@
+import Foundation
+import BaseChatInference
+
+/// Storage-neutral port for persisting per-model benchmark results.
+///
+/// Replaces the public `ModelManagementViewModel.modelContext: ModelContext?`
+/// property — host code now injects a ``BenchmarkCache`` (typically
+/// ``SwiftDataBenchmarkCache`` over the app's main context) and the view model
+/// reads/upserts via the port instead of executing SwiftData fetches itself.
+///
+/// Entries are keyed by the model's file name (e.g. `"model.Q4_K_M.gguf"`),
+/// matching the existing ``ModelBenchmarkCache`` SwiftData schema. The port
+/// trafficks in ``ModelBenchmarkResult`` value types — the SwiftData `@Model`
+/// never escapes the impl.
+@MainActor
+public protocol BenchmarkCache: AnyObject, Sendable {
+
+    /// Fetches every cached benchmark result keyed by model file name.
+    func fetchAll() async throws -> [String: ModelBenchmarkResult]
+
+    /// Stores a benchmark result for the given model file name, replacing any
+    /// previous entry for the same file.
+    func upsert(modelFileName: String, result: ModelBenchmarkResult) async throws
+}

--- a/Sources/BaseChatCore/Protocols/EndpointStore.swift
+++ b/Sources/BaseChatCore/Protocols/EndpointStore.swift
@@ -1,0 +1,52 @@
+import Foundation
+import BaseChatInference
+
+/// Errors produced by ``EndpointStore`` implementations.
+public enum EndpointStoreError: Error, LocalizedError, Sendable, Equatable {
+    case endpointNotFound(UUID)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .endpointNotFound(id):
+            return "API endpoint not found: \(id.uuidString)"
+        }
+    }
+}
+
+/// Storage-neutral port for cloud API endpoint CRUD.
+///
+/// Replaces the direct `@Query(\APIEndpoint.createdAt)` access in
+/// `APIConfigurationView` and the `modelContext.insert/save/delete` calls
+/// scattered across the endpoint editor flows
+/// (`APIEndpointEditorView`, `RemoteServerConfigSheet`). The default
+/// implementation is ``SwiftDataEndpointStore``.
+///
+/// All methods are `async throws` at the surface and traffic in
+/// ``APIEndpointRecord`` value types — the SwiftData `@Model` never escapes
+/// the impl.
+///
+/// Keychain lifecycle is **not** the store's responsibility: API keys live in
+/// the system Keychain, keyed by the endpoint's id. The store deletes the
+/// endpoint row; callers delete the matching Keychain item via
+/// `KeychainService.delete(account:)`.
+@MainActor
+public protocol EndpointStore: AnyObject, Sendable {
+
+    /// Fetches every persisted endpoint, ordered most-recently-created first.
+    func fetchEndpoints() async throws -> [APIEndpointRecord]
+
+    /// Inserts a new endpoint.
+    func insertEndpoint(_ record: APIEndpointRecord) async throws
+
+    /// Updates an existing endpoint, identified by ``APIEndpointRecord/id``.
+    ///
+    /// - Throws: ``EndpointStoreError/endpointNotFound(_:)`` when the endpoint
+    ///   does not exist.
+    func updateEndpoint(_ record: APIEndpointRecord) async throws
+
+    /// Deletes an endpoint by id.
+    ///
+    /// - Throws: ``EndpointStoreError/endpointNotFound(_:)`` when the endpoint
+    ///   does not exist.
+    func deleteEndpoint(_ id: UUID) async throws
+}

--- a/Sources/BaseChatCore/Protocols/SamplerPresetStore.swift
+++ b/Sources/BaseChatCore/Protocols/SamplerPresetStore.swift
@@ -1,0 +1,40 @@
+import Foundation
+import BaseChatInference
+
+/// Errors produced by ``SamplerPresetStore`` implementations.
+public enum SamplerPresetStoreError: Error, LocalizedError, Sendable, Equatable {
+    case presetNotFound(UUID)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .presetNotFound(id):
+            return "Sampler preset not found: \(id.uuidString)"
+        }
+    }
+}
+
+/// Storage-neutral port for sampler-preset CRUD.
+///
+/// Replaces the direct `@Query(\SamplerPreset.createdAt)` access in
+/// `SamplerPresetPickerView`, so UI layers no longer reach through SwiftData
+/// to read or write preset rows. The default implementation is
+/// ``SwiftDataSamplerPresetStore``.
+///
+/// All methods are `async throws` at the surface and traffic in
+/// ``SamplerPresetRecord`` value types — the SwiftData `@Model` never escapes
+/// the impl.
+@MainActor
+public protocol SamplerPresetStore: AnyObject, Sendable {
+
+    /// Fetches every persisted preset, ordered most-recently-created first.
+    func fetchPresets() async throws -> [SamplerPresetRecord]
+
+    /// Inserts a new preset.
+    func insertPreset(_ record: SamplerPresetRecord) async throws
+
+    /// Deletes a preset by id.
+    ///
+    /// - Throws: ``SamplerPresetStoreError/presetNotFound(_:)`` when the preset
+    ///   does not exist.
+    func deletePreset(_ id: UUID) async throws
+}

--- a/Sources/BaseChatCore/Services/SwiftDataBenchmarkCache.swift
+++ b/Sources/BaseChatCore/Services/SwiftDataBenchmarkCache.swift
@@ -1,0 +1,40 @@
+import Foundation
+import BaseChatInference
+import SwiftData
+
+/// Default ``BenchmarkCache`` backed by SwiftData.
+///
+/// Operates on the ``ModelContext`` injected at init time, hiding the
+/// SwiftData ``ModelBenchmarkCache`` `@Model` behind a value-typed port.
+@MainActor
+public final class SwiftDataBenchmarkCache: BenchmarkCache {
+
+    private let modelContext: ModelContext
+
+    public init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    public func fetchAll() async throws -> [String: ModelBenchmarkResult] {
+        let entries = try modelContext.fetch(FetchDescriptor<ModelBenchmarkCache>())
+        var result: [String: ModelBenchmarkResult] = [:]
+        result.reserveCapacity(entries.count)
+        for entry in entries {
+            result[entry.modelFileName] = entry.toResult()
+        }
+        return result
+    }
+
+    public func upsert(modelFileName: String, result: ModelBenchmarkResult) async throws {
+        // Remove any stale entry for this file name before inserting the fresh
+        // result. Mirrors the upsert semantics that previously lived inline in
+        // `ModelManagementViewModel.runBenchmark(for:)`.
+        let needle = modelFileName
+        let existing = try modelContext.fetch(FetchDescriptor<ModelBenchmarkCache>(
+            predicate: #Predicate { $0.modelFileName == needle }
+        ))
+        existing.forEach { modelContext.delete($0) }
+        modelContext.insert(ModelBenchmarkCache(modelFileName: modelFileName, result: result))
+        try modelContext.save()
+    }
+}

--- a/Sources/BaseChatCore/Services/SwiftDataEndpointStore.swift
+++ b/Sources/BaseChatCore/Services/SwiftDataEndpointStore.swift
@@ -1,0 +1,68 @@
+import Foundation
+import BaseChatInference
+import SwiftData
+
+/// Default ``EndpointStore`` backed by SwiftData.
+///
+/// Operates on the ``ModelContext`` injected at init time, converting between
+/// ``BaseChatSchemaV3/APIEndpoint`` `@Model` rows and
+/// ``APIEndpointRecord`` value types at the boundary.
+@MainActor
+public final class SwiftDataEndpointStore: EndpointStore {
+
+    private let modelContext: ModelContext
+
+    public init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    public func fetchEndpoints() async throws -> [APIEndpointRecord] {
+        let descriptor = FetchDescriptor<APIEndpoint>(
+            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+        )
+        return try modelContext.fetch(descriptor).map { $0.record }
+    }
+
+    public func insertEndpoint(_ record: APIEndpointRecord) async throws {
+        let endpoint = APIEndpoint(
+            name: record.name,
+            provider: record.provider,
+            baseURL: record.baseURL,
+            modelName: record.modelName
+        )
+        endpoint.id = record.id
+        endpoint.createdAt = record.createdAt
+        endpoint.isEnabled = record.isEnabled
+        modelContext.insert(endpoint)
+        try modelContext.save()
+    }
+
+    public func updateEndpoint(_ record: APIEndpointRecord) async throws {
+        guard let endpoint = try fetchSwiftDataEndpoint(id: record.id) else {
+            throw EndpointStoreError.endpointNotFound(record.id)
+        }
+        endpoint.name = record.name
+        endpoint.provider = record.provider
+        endpoint.baseURL = record.baseURL
+        endpoint.modelName = record.modelName
+        endpoint.isEnabled = record.isEnabled
+        try modelContext.save()
+    }
+
+    public func deleteEndpoint(_ id: UUID) async throws {
+        guard let endpoint = try fetchSwiftDataEndpoint(id: id) else {
+            throw EndpointStoreError.endpointNotFound(id)
+        }
+        modelContext.delete(endpoint)
+        try modelContext.save()
+    }
+
+    // MARK: - Private
+
+    private func fetchSwiftDataEndpoint(id: UUID) throws -> APIEndpoint? {
+        let descriptor = FetchDescriptor<APIEndpoint>(
+            predicate: #Predicate { $0.id == id }
+        )
+        return try modelContext.fetch(descriptor).first
+    }
+}

--- a/Sources/BaseChatCore/Services/SwiftDataSamplerPresetStore.swift
+++ b/Sources/BaseChatCore/Services/SwiftDataSamplerPresetStore.swift
@@ -1,0 +1,63 @@
+import Foundation
+import BaseChatInference
+import SwiftData
+
+/// Default ``SamplerPresetStore`` backed by SwiftData.
+///
+/// Operates on the ``ModelContext`` injected at init time, converting between
+/// ``BaseChatSchemaV3/SamplerPreset`` `@Model` rows and ``SamplerPresetRecord``
+/// value types at the boundary.
+@MainActor
+public final class SwiftDataSamplerPresetStore: SamplerPresetStore {
+
+    private let modelContext: ModelContext
+
+    public init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    public func fetchPresets() async throws -> [SamplerPresetRecord] {
+        let descriptor = FetchDescriptor<SamplerPreset>(
+            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+        )
+        return try modelContext.fetch(descriptor).map { $0.toRecord() }
+    }
+
+    public func insertPreset(_ record: SamplerPresetRecord) async throws {
+        let preset = SamplerPreset(
+            name: record.name,
+            temperature: record.temperature,
+            topP: record.topP,
+            repeatPenalty: record.repeatPenalty
+        )
+        preset.id = record.id
+        preset.createdAt = record.createdAt
+        modelContext.insert(preset)
+        try modelContext.save()
+    }
+
+    public func deletePreset(_ id: UUID) async throws {
+        let descriptor = FetchDescriptor<SamplerPreset>(
+            predicate: #Predicate { $0.id == id }
+        )
+        guard let preset = try modelContext.fetch(descriptor).first else {
+            throw SamplerPresetStoreError.presetNotFound(id)
+        }
+        modelContext.delete(preset)
+        try modelContext.save()
+    }
+}
+
+extension SamplerPreset {
+    /// Converts a SwiftData model to a plain record.
+    func toRecord() -> SamplerPresetRecord {
+        SamplerPresetRecord(
+            id: id,
+            name: name,
+            temperature: temperature,
+            topP: topP,
+            repeatPenalty: repeatPenalty,
+            createdAt: createdAt
+        )
+    }
+}

--- a/Sources/BaseChatInference/Models/APIEndpointRecord.swift
+++ b/Sources/BaseChatInference/Models/APIEndpointRecord.swift
@@ -14,6 +14,8 @@ public struct APIEndpointRecord: Sendable, Hashable, Identifiable {
     public var baseURL: String
     public var modelName: String
     public var keychainAccount: String
+    public var createdAt: Date
+    public var isEnabled: Bool
 
     public init(
         id: UUID = UUID(),
@@ -21,7 +23,9 @@ public struct APIEndpointRecord: Sendable, Hashable, Identifiable {
         provider: APIProvider,
         baseURL: String? = nil,
         modelName: String? = nil,
-        keychainAccount: String? = nil
+        keychainAccount: String? = nil,
+        createdAt: Date = Date(),
+        isEnabled: Bool = true
     ) {
         self.id = id
         self.name = name
@@ -29,5 +33,7 @@ public struct APIEndpointRecord: Sendable, Hashable, Identifiable {
         self.baseURL = baseURL ?? provider.defaultBaseURL
         self.modelName = modelName ?? provider.defaultModelName
         self.keychainAccount = keychainAccount ?? id.uuidString
+        self.createdAt = createdAt
+        self.isEnabled = isEnabled
     }
 }

--- a/Sources/BaseChatInference/Models/SamplerPresetRecord.swift
+++ b/Sources/BaseChatInference/Models/SamplerPresetRecord.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Plain-data snapshot of a saved sampler preset, decoupled from any specific
+/// storage backend.
+///
+/// `BaseChatCore` provides the SwiftData `@Model SamplerPreset` that maps to
+/// this record; UI flows traffic in records so they don't need a SwiftData
+/// dependency on the read or write path.
+public struct SamplerPresetRecord: Sendable, Hashable, Identifiable {
+    public var id: UUID
+    public var name: String
+    public var temperature: Float
+    public var topP: Float
+    public var repeatPenalty: Float
+    public var createdAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        name: String,
+        temperature: Float = 0.7,
+        topP: Float = 0.9,
+        repeatPenalty: Float = 1.1,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.temperature = temperature
+        self.topP = topP
+        self.repeatPenalty = repeatPenalty
+        self.createdAt = createdAt
+    }
+}

--- a/Sources/BaseChatUI/Views/Settings/SamplerPresetPickerView.swift
+++ b/Sources/BaseChatUI/Views/Settings/SamplerPresetPickerView.swift
@@ -1,21 +1,23 @@
 import SwiftUI
-import SwiftData
 import BaseChatCore
 import BaseChatInference
 
-/// Picker and management UI for sampler presets within GenerationSettingsView.
+/// Picker and management UI for sampler presets within `GenerationSettingsView`.
+///
+/// Reads and writes presets through a ``SamplerPresetStore`` injected via the
+/// SwiftUI environment (typically from `BaseChatRuntime.samplerPresetStore`).
+/// The view does not import SwiftData — the store is the only persistence
+/// surface visible to the UI.
 public struct SamplerPresetPickerView: View {
 
     @Environment(ChatViewModel.self) private var viewModel
-    @Environment(\.modelContext) private var modelContext
+    @Environment(\.samplerPresetStore) private var presetStore
 
-    @Query(sort: \SamplerPreset.createdAt, order: .reverse)
-    private var presets: [SamplerPreset]
-
+    @State private var presets: [SamplerPresetRecord] = []
     @State private var showSaveAlert = false
     @State private var newPresetName = ""
     @State private var showDeleteConfirmation = false
-    @State private var presetToDelete: SamplerPreset?
+    @State private var presetToDelete: SamplerPresetRecord?
 
     public init() {}
 
@@ -61,11 +63,12 @@ public struct SamplerPresetPickerView: View {
                 Label("Save Current as Preset", systemImage: "plus.circle")
             }
         }
+        .task { await refresh() }
         .alert("Save Preset", isPresented: $showSaveAlert) {
             TextField("Preset name", text: $newPresetName)
             Button("Cancel", role: .cancel) {}
             Button("Save") {
-                saveCurrentAsPreset()
+                Task { await saveCurrentAsPreset() }
             }
             .disabled(newPresetName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         } message: {
@@ -75,7 +78,7 @@ public struct SamplerPresetPickerView: View {
             Button("Cancel", role: .cancel) { presetToDelete = nil }
             Button("Delete", role: .destructive) {
                 if let preset = presetToDelete {
-                    deletePreset(preset)
+                    Task { await deletePreset(preset) }
                 }
                 presetToDelete = nil
             }
@@ -86,45 +89,64 @@ public struct SamplerPresetPickerView: View {
         }
     }
 
-    private func applyPreset(_ preset: SamplerPreset) {
+    // MARK: - Actions
+
+    private func applyPreset(_ preset: SamplerPresetRecord) {
         viewModel.temperature = preset.temperature
         viewModel.topP = preset.topP
         viewModel.repeatPenalty = preset.repeatPenalty
     }
 
-    private func saveCurrentAsPreset() {
+    private func refresh() async {
+        guard let presetStore else { return }
+        do {
+            presets = try await presetStore.fetchPresets()
+        } catch {
+            Log.persistence.error("Failed to fetch sampler presets: \(error)")
+        }
+    }
+
+    private func saveCurrentAsPreset() async {
+        guard let presetStore else { return }
         let name = newPresetName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !name.isEmpty else { return }
 
-        let preset = SamplerPreset(
+        let record = SamplerPresetRecord(
             name: name,
             temperature: viewModel.temperature,
             topP: viewModel.topP,
             repeatPenalty: viewModel.repeatPenalty
         )
-        modelContext.insert(preset)
-
         do {
-            try modelContext.save()
+            try await presetStore.insertPreset(record)
+            await refresh()
         } catch {
             Log.persistence.error("Failed to save preset: \(error)")
         }
     }
 
-    private func deletePreset(_ preset: SamplerPreset) {
-        modelContext.delete(preset)
+    private func deletePreset(_ preset: SamplerPresetRecord) async {
+        guard let presetStore else { return }
         do {
-            try modelContext.save()
+            try await presetStore.deletePreset(preset.id)
+            await refresh()
         } catch {
             Log.persistence.error("Failed to delete preset: \(error)")
         }
     }
 }
 
-#Preview("Sampler Presets") {
-    Form {
-        SamplerPresetPickerView()
+// MARK: - Environment plumbing
+
+private struct SamplerPresetStoreKey: EnvironmentKey {
+    static let defaultValue: (any SamplerPresetStore)? = nil
+}
+
+extension EnvironmentValues {
+    /// Injection point for the ``SamplerPresetStore`` consumed by
+    /// ``SamplerPresetPickerView``.
+    public var samplerPresetStore: (any SamplerPresetStore)? {
+        get { self[SamplerPresetStoreKey.self] }
+        set { self[SamplerPresetStoreKey.self] = newValue }
     }
-    .environment(ChatViewModel())
-    .modelContainer(for: SamplerPreset.self, inMemory: true)
 }

--- a/Sources/BaseChatUIModelManagement/ViewModels/ModelManagementViewModel.swift
+++ b/Sources/BaseChatUIModelManagement/ViewModels/ModelManagementViewModel.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Observation
-import SwiftData
 import BaseChatCore
 import BaseChatInference
 
@@ -76,11 +75,13 @@ public final class ModelManagementViewModel {
     /// ``runBenchmark(for:)`` call and pre-loaded from ``ModelBenchmarkCache`` on context injection.
     public private(set) var benchmarkResults: [String: ModelBenchmarkResult] = [:]
 
-    /// SwiftData context for persisting benchmark results. Set by the host view on appear.
+    /// Storage-neutral cache for benchmark results. Set by host code at app
+    /// startup (typically `BaseChatRuntime.benchmarkCache`).
     ///
-    /// Assigning this property immediately loads any previously cached results from
-    /// ``ModelBenchmarkCache``, so UI can show historical data without re-running benchmarks.
-    public var modelContext: ModelContext? {
+    /// Assigning this property immediately loads any previously cached results
+    /// so UI can show historical data without re-running benchmarks. Replaces
+    /// the previous public `modelContext: ModelContext?` SwiftData leak.
+    public var benchmarkCache: (any BenchmarkCache)? {
         didSet { loadCachedBenchmarkResults() }
     }
 
@@ -482,16 +483,9 @@ public final class ModelManagementViewModel {
             let result = try await runner.runBenchmark(for: model)
             benchmarkResults[model.fileName] = result
             Log.inference.info("Benchmark complete for \(model.name): \(result.tier.label)")
-            if let ctx = modelContext {
-                // Upsert: remove any stale entry for this file name before inserting the fresh result.
-                let fileName = model.fileName
+            if let cache = benchmarkCache {
                 do {
-                    let existing = try ctx.fetch(FetchDescriptor<ModelBenchmarkCache>(
-                        predicate: #Predicate { $0.modelFileName == fileName }
-                    ))
-                    existing.forEach { ctx.delete($0) }
-                    ctx.insert(ModelBenchmarkCache(modelFileName: fileName, result: result))
-                    try ctx.save()
+                    try await cache.upsert(modelFileName: model.fileName, result: result)
                 } catch {
                     Log.persistence.warning("Failed to persist benchmark result for \(model.name): \(error.localizedDescription)")
                     diagnostics?.record(.benchmarkCacheUnavailable(reason: error.localizedDescription))
@@ -503,17 +497,18 @@ public final class ModelManagementViewModel {
     }
 
     private func loadCachedBenchmarkResults() {
-        guard let ctx = modelContext else { return }
-        let entries: [ModelBenchmarkCache]
-        do {
-            entries = try ctx.fetch(FetchDescriptor<ModelBenchmarkCache>())
-        } catch {
-            Log.persistence.warning("Failed to load cached benchmark results: \(error.localizedDescription)")
-            diagnostics?.record(.benchmarkCacheUnavailable(reason: error.localizedDescription))
-            return
-        }
-        for entry in entries {
-            benchmarkResults[entry.modelFileName] = entry.toResult()
+        guard let cache = benchmarkCache else { return }
+        Task { [weak self] in
+            do {
+                let entries = try await cache.fetchAll()
+                guard let self else { return }
+                for (fileName, result) in entries {
+                    self.benchmarkResults[fileName] = result
+                }
+            } catch {
+                Log.persistence.warning("Failed to load cached benchmark results: \(error.localizedDescription)")
+                self?.diagnostics?.record(.benchmarkCacheUnavailable(reason: error.localizedDescription))
+            }
         }
     }
 

--- a/Sources/BaseChatUIModelManagement/Views/Models/ModelManagementSheet.swift
+++ b/Sources/BaseChatUIModelManagement/Views/Models/ModelManagementSheet.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import SwiftData
 import BaseChatCore
 import BaseChatInference
 import BaseChatUI
@@ -161,5 +160,4 @@ public struct ModelManagementSheet: View {
     ModelManagementSheet()
         .environment(ChatViewModel())
         .environment(ModelManagementViewModel())
-        .modelContainer(try! ModelContainerFactory.makeInMemoryContainer())
 }

--- a/Sources/BaseChatUIModelManagement/Views/Settings/APIConfigurationView.swift
+++ b/Sources/BaseChatUIModelManagement/Views/Settings/APIConfigurationView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 #if Ollama || CloudSaaS
-import SwiftData
 import BaseChatCore
 import BaseChatInference
 #endif
@@ -8,8 +7,12 @@ import BaseChatInference
 /// Main settings view for managing cloud API endpoints.
 ///
 /// Presented as a sheet from `GenerationSettingsView`. Lists all configured
-/// `APIEndpoint` entries with swipe-to-delete, and offers an "Add Endpoint"
-/// button that presents `APIEndpointEditorView`.
+/// endpoints with swipe-to-delete, and offers an "Add Endpoint" button that
+/// presents `APIEndpointEditorView`.
+///
+/// Endpoint reads and writes go through the ``EndpointStore`` injected via
+/// the SwiftUI environment (typically `BaseChatRuntime.endpointStore`); the
+/// view itself does not import SwiftData.
 ///
 /// The type itself is **always public** — even when neither `Ollama` nor
 /// `CloudSaaS` traits are enabled — so that consumer migration code like
@@ -21,15 +24,13 @@ public struct APIConfigurationView: View {
 
     #if Ollama || CloudSaaS
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.modelContext) private var modelContext
+    @Environment(\.endpointStore) private var endpointStore
 
-    @Query(sort: \APIEndpoint.createdAt, order: .reverse)
-    private var endpoints: [APIEndpoint]
-
+    @State private var endpoints: [APIEndpointRecord] = []
     @State private var showAddSheet = false
-    @State private var endpointToEdit: APIEndpoint?
+    @State private var endpointToEdit: APIEndpointRecord?
     @State private var showDeleteConfirmation = false
-    @State private var endpointToDelete: APIEndpoint?
+    @State private var endpointToDelete: APIEndpointRecord?
     #endif
 
     public init() {}
@@ -88,17 +89,18 @@ public struct APIConfigurationView: View {
                     Button("Done") { dismiss() }
                 }
             }
-            .sheet(isPresented: $showAddSheet) {
+            .task { await refresh() }
+            .sheet(isPresented: $showAddSheet, onDismiss: { Task { await refresh() } }) {
                 APIEndpointEditorView(endpoint: nil)
             }
-            .sheet(item: $endpointToEdit) { endpoint in
+            .sheet(item: $endpointToEdit, onDismiss: { Task { await refresh() } }) { endpoint in
                 APIEndpointEditorView(endpoint: endpoint)
             }
             .alert("Delete Endpoint", isPresented: $showDeleteConfirmation) {
                 Button("Cancel", role: .cancel) { endpointToDelete = nil }
                 Button("Delete", role: .destructive) {
                     if let endpoint = endpointToDelete {
-                        deleteEndpoint(endpoint)
+                        Task { await deleteEndpoint(endpoint) }
                     }
                     endpointToDelete = nil
                 }
@@ -117,19 +119,31 @@ public struct APIConfigurationView: View {
     }
 
     #if Ollama || CloudSaaS
-    private func deleteEndpoint(_ endpoint: APIEndpoint) {
+    private func refresh() async {
+        guard let endpointStore else { return }
+        do {
+            endpoints = try await endpointStore.fetchEndpoints()
+        } catch {
+            Log.persistence.error("Failed to fetch endpoints: \(error)")
+        }
+    }
+
+    private func deleteEndpoint(_ endpoint: APIEndpointRecord) async {
+        guard let endpointStore else { return }
+
         // Best-effort Keychain cleanup: if the Keychain delete fails we still
-        // remove the SwiftData record, because leaving the endpoint in the UI
-        // with a dangling key is worse than a potential orphaned Keychain item.
+        // remove the endpoint row, because leaving the endpoint in the UI with
+        // a dangling key is worse than a potential orphaned Keychain item.
         // The failure is logged by KeychainService for diagnostics.
         do {
-            try endpoint.deleteAPIKey()
+            try KeychainService.delete(account: endpoint.keychainAccount)
         } catch {
             Log.persistence.warning("Failed to delete API key from Keychain: \(error.localizedDescription)")
         }
-        modelContext.delete(endpoint)
+
         do {
-            try modelContext.save()
+            try await endpointStore.deleteEndpoint(endpoint.id)
+            await refresh()
         } catch {
             Log.persistence.error("Failed to delete endpoint: \(error)")
         }
@@ -142,6 +156,5 @@ public struct APIConfigurationView: View {
 #if Ollama || CloudSaaS
 #Preview("API Configuration") {
     APIConfigurationView()
-        .modelContainer(for: APIEndpoint.self, inMemory: true)
 }
 #endif

--- a/Sources/BaseChatUIModelManagement/Views/Settings/APIEndpointDraftValidator.swift
+++ b/Sources/BaseChatUIModelManagement/Views/Settings/APIEndpointDraftValidator.swift
@@ -2,6 +2,9 @@ import BaseChatCore
 import BaseChatInference
 
 /// Validates in-progress endpoint edits against BaseChatKit's canonical endpoint policy.
+///
+/// Drafts are validated through ``APIEndpointRecord/validateBaseURL()`` so the
+/// editor doesn't materialise a SwiftData `@Model` just to reuse the policy.
 enum APIEndpointDraftValidator {
     static func validate(
         provider: APIProvider,
@@ -10,12 +13,12 @@ enum APIEndpointDraftValidator {
     ) -> Result<Void, APIEndpointValidationReason> {
         let trimmedURL = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedModel = modelName.trimmingCharacters(in: .whitespacesAndNewlines)
-        let endpoint = APIEndpoint(
+        let record = APIEndpointRecord(
             name: provider.rawValue,
             provider: provider,
             baseURL: trimmedURL.isEmpty ? nil : trimmedURL,
             modelName: trimmedModel.isEmpty ? nil : trimmedModel
         )
-        return endpoint.validate()
+        return record.validateBaseURL()
     }
 }

--- a/Sources/BaseChatUIModelManagement/Views/Settings/APIEndpointEditorView.swift
+++ b/Sources/BaseChatUIModelManagement/Views/Settings/APIEndpointEditorView.swift
@@ -3,17 +3,20 @@ import SwiftUI
 import BaseChatCore
 import BaseChatInference
 
-/// Editor for creating or editing an `APIEndpoint`.
+/// Editor for creating or editing an ``APIEndpointRecord``.
 ///
 /// When `endpoint` is `nil`, creates a new endpoint on save.
 /// When editing, populates fields from the existing endpoint.
 /// Provider selection dynamically updates the base URL and model defaults.
+///
+/// Reads and writes go through the ``EndpointStore`` injected via the SwiftUI
+/// environment. The view does not import SwiftData.
 public struct APIEndpointEditorView: View {
 
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.modelContext) private var modelContext
+    @Environment(\.endpointStore) private var endpointStore
 
-    public let endpoint: APIEndpoint? // nil = creating new
+    public let endpoint: APIEndpointRecord? // nil = creating new
 
     @State private var name: String = ""
     @State private var provider: APIProvider = .openAI
@@ -24,7 +27,7 @@ public struct APIEndpointEditorView: View {
 
     private var isEditing: Bool { endpoint != nil }
 
-    public init(endpoint: APIEndpoint?) {
+    public init(endpoint: APIEndpointRecord?) {
         self.endpoint = endpoint
     }
 
@@ -103,7 +106,7 @@ public struct APIEndpointEditorView: View {
                     Button("Cancel") { dismiss() }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Save") { save() }
+                    Button("Save") { Task { await save() } }
                         .disabled(
                             name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                             || modelName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -139,7 +142,12 @@ public struct APIEndpointEditorView: View {
         }
     }
 
-    private func save() {
+    private func save() async {
+        guard let endpointStore else {
+            validationError = "Endpoint store is not configured."
+            return
+        }
+
         let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedName.isEmpty else { return }
 
@@ -160,18 +168,18 @@ public struct APIEndpointEditorView: View {
         }
 
         validationError = nil
-        var createdEndpoint: APIEndpoint?
 
         if let endpoint {
-            // Update existing
-            endpoint.name = trimmedName
-            endpoint.provider = provider
-            endpoint.baseURL = trimmedURL.isEmpty ? provider.defaultBaseURL : trimmedURL
-            endpoint.modelName = resolvedModelName
+            // Update existing record
+            var updated = endpoint
+            updated.name = trimmedName
+            updated.provider = provider
+            updated.baseURL = trimmedURL.isEmpty ? provider.defaultBaseURL : trimmedURL
+            updated.modelName = resolvedModelName
 
             if !apiKey.isEmpty {
                 do {
-                    try endpoint.setAPIKey(apiKey)
+                    try KeychainService.store(key: apiKey, account: updated.keychainAccount)
                 } catch {
                     // `KeychainError.localizedDescription` already reads as a
                     // complete sentence (e.g. "Couldn't store the API key in
@@ -180,41 +188,44 @@ public struct APIEndpointEditorView: View {
                     return
                 }
             }
+
+            do {
+                try await endpointStore.updateEndpoint(updated)
+                dismiss()
+            } catch {
+                validationError = error.localizedDescription.isEmpty
+                    ? "Failed to save the endpoint configuration."
+                    : error.localizedDescription
+            }
         } else {
-            // Create new
-            let newEndpoint = APIEndpoint(
+            // Create a new record
+            let newRecord = APIEndpointRecord(
                 name: trimmedName,
                 provider: provider,
                 baseURL: trimmedURL.isEmpty ? nil : trimmedURL,
                 modelName: resolvedModelName
             )
-            modelContext.insert(newEndpoint)
-            createdEndpoint = newEndpoint
 
             if !apiKey.isEmpty {
                 do {
-                    try newEndpoint.setAPIKey(apiKey)
+                    try KeychainService.store(key: apiKey, account: newRecord.keychainAccount)
                 } catch {
-                    modelContext.delete(newEndpoint)
-                    // `KeychainError.localizedDescription` already reads as a
-                    // complete sentence (e.g. "Couldn't store the API key in
-                    // the Keychain: The device appears to be locked…").
                     validationError = error.localizedDescription
                     return
                 }
             }
-        }
 
-        do {
-            try modelContext.save()
-            dismiss()
-        } catch {
-            if let createdEndpoint {
-                modelContext.delete(createdEndpoint)
+            do {
+                try await endpointStore.insertEndpoint(newRecord)
+                dismiss()
+            } catch {
+                // Best-effort cleanup of the just-stored Keychain item if the
+                // row insert fails — leaves no orphan.
+                try? KeychainService.delete(account: newRecord.keychainAccount)
+                validationError = error.localizedDescription.isEmpty
+                    ? "Failed to save the endpoint configuration."
+                    : error.localizedDescription
             }
-            validationError = error.localizedDescription.isEmpty
-                ? "Failed to save the endpoint configuration."
-                : error.localizedDescription
         }
     }
 }
@@ -223,7 +234,5 @@ public struct APIEndpointEditorView: View {
 
 #Preview("Add Endpoint") {
     APIEndpointEditorView(endpoint: nil)
-        .modelContainer(for: APIEndpoint.self, inMemory: true)
 }
 #endif
-

--- a/Sources/BaseChatUIModelManagement/Views/Settings/APIEndpointRow.swift
+++ b/Sources/BaseChatUIModelManagement/Views/Settings/APIEndpointRow.swift
@@ -1,18 +1,19 @@
 import SwiftUI
 import BaseChatCore
+import BaseChatInference
 
-/// A row displaying a summary of an `APIEndpoint` configuration.
+/// A row displaying a summary of an ``APIEndpointRecord`` configuration.
 ///
 /// Shows the endpoint name, provider badge, model name, and a
-/// ready/incomplete status indicator based on `endpoint.validate()`.
-/// When the endpoint is invalid, the specific
-/// ``APIEndpointValidationReason`` is surfaced as a subtitle so the user
-/// knows what to fix.
+/// ready/incomplete status indicator based on
+/// ``APIEndpointRecord/validateBaseURL()``. When the endpoint is invalid,
+/// the specific ``APIEndpointValidationReason`` is surfaced as a subtitle
+/// so the user knows what to fix.
 public struct APIEndpointRow: View {
 
-    public let endpoint: APIEndpoint
+    public let endpoint: APIEndpointRecord
 
-    public init(endpoint: APIEndpoint) {
+    public init(endpoint: APIEndpointRecord) {
         self.endpoint = endpoint
     }
 
@@ -36,7 +37,7 @@ public struct APIEndpointRow: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
-                switch endpoint.validate() {
+                switch endpoint.validateBaseURL() {
                 case .success:
                     Label("Ready", systemImage: "checkmark.circle.fill")
                         .font(.caption)
@@ -48,7 +49,7 @@ public struct APIEndpointRow: View {
                 }
             }
 
-            if case .failure(let reason) = endpoint.validate(),
+            if case .failure(let reason) = endpoint.validateBaseURL(),
                let description = reason.errorDescription {
                 Text(description)
                     .font(.caption2)
@@ -65,7 +66,7 @@ public struct APIEndpointRow: View {
 
     /// Voice-over status string: "Ready" or the specific failure reason.
     private var accessibilityStatus: String {
-        switch endpoint.validate() {
+        switch endpoint.validateBaseURL() {
         case .success:
             return "Ready"
         case .failure(let reason):
@@ -79,10 +80,10 @@ public struct APIEndpointRow: View {
 #Preview("Endpoint Row") {
     List {
         APIEndpointRow(
-            endpoint: APIEndpoint(name: "My OpenAI", provider: .openAI)
+            endpoint: APIEndpointRecord(name: "My OpenAI", provider: .openAI)
         )
         APIEndpointRow(
-            endpoint: APIEndpoint(name: "Local Ollama", provider: .ollama)
+            endpoint: APIEndpointRecord(name: "Local Ollama", provider: .ollama)
         )
     }
 }

--- a/Sources/BaseChatUIModelManagement/Views/Settings/EndpointStoreEnvironment.swift
+++ b/Sources/BaseChatUIModelManagement/Views/Settings/EndpointStoreEnvironment.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+import BaseChatCore
+
+/// Injection point for the ``EndpointStore`` consumed by
+/// ``APIConfigurationView``, ``APIEndpointEditorView``, and
+/// ``RemoteServerConfigSheet``.
+///
+/// Declared unconditionally (not behind the `Ollama` / `CloudSaaS` traits) so
+/// host apps can wire `runtime.endpointStore` via `.environment(\.endpointStore, …)`
+/// without per-trait `#if`s at the call site. The endpoint editor views
+/// themselves remain trait-gated; they no-op (render `EmptyView`) when the
+/// traits are off, regardless of whether a store is injected.
+private struct EndpointStoreKey: EnvironmentKey {
+    static let defaultValue: (any EndpointStore)? = nil
+}
+
+extension EnvironmentValues {
+    public var endpointStore: (any EndpointStore)? {
+        get { self[EndpointStoreKey.self] }
+        set { self[EndpointStoreKey.self] = newValue }
+    }
+}

--- a/Sources/BaseChatUIModelManagement/Views/Settings/RemoteServerConfigSheet.swift
+++ b/Sources/BaseChatUIModelManagement/Views/Settings/RemoteServerConfigSheet.swift
@@ -6,25 +6,26 @@ import BaseChatInference
 /// Sheet for manually configuring a remote inference server connection.
 ///
 /// Lets users enter a server URL, optional API key, and backend type for a
-/// remote inference endpoint.
+/// remote inference endpoint. Persists through the ``EndpointStore`` injected
+/// via the SwiftUI environment; the view does not import SwiftData.
 ///
 /// ## Usage
 ///
 /// ```swift
 /// .sheet(isPresented: $showRemoteConfig) {
-///     RemoteServerConfigSheet { endpoint in
-///         // use endpoint
+///     RemoteServerConfigSheet { record in
+///         // use record
 ///     }
-///     .modelContext(container.mainContext)
+///     .environment(\.endpointStore, runtime.endpointStore)
 /// }
 /// ```
 public struct RemoteServerConfigSheet: View {
 
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.modelContext) private var modelContext
+    @Environment(\.endpointStore) private var endpointStore
 
-    /// Called when the user saves the configuration, passing the created endpoint.
-    public var onSave: ((APIEndpoint) -> Void)?
+    /// Called when the user saves the configuration, passing the created record.
+    public var onSave: ((APIEndpointRecord) -> Void)?
 
     @State private var serverURL: String = ""
     @State private var apiKey: String = ""
@@ -32,7 +33,7 @@ public struct RemoteServerConfigSheet: View {
     @State private var backendType: BackendType = .openAICompatible
     @State private var errorMessage: String?
 
-    public init(onSave: ((APIEndpoint) -> Void)? = nil) {
+    public init(onSave: ((APIEndpointRecord) -> Void)? = nil) {
         self.onSave = onSave
     }
 
@@ -80,7 +81,7 @@ public struct RemoteServerConfigSheet: View {
                     Button("Cancel") { dismiss() }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Save") { save() }
+                    Button("Save") { Task { await save() } }
                         .disabled(!isValid)
                 }
             }
@@ -158,7 +159,12 @@ public struct RemoteServerConfigSheet: View {
         return false
     }
 
-    private func save() {
+    private func save() async {
+        guard let endpointStore else {
+            errorMessage = "Endpoint store is not configured."
+            return
+        }
+
         let trimmedURL = serverURL.trimmingCharacters(in: .whitespacesAndNewlines)
         let resolvedModel = modelName.trimmingCharacters(in: .whitespacesAndNewlines)
             .nonEmpty ?? backendType.apiProvider.defaultModelName
@@ -175,20 +181,18 @@ public struct RemoteServerConfigSheet: View {
             break
         }
 
-        let endpoint = APIEndpoint(
+        let record = APIEndpointRecord(
             name: "\(backendType.rawValue) — \(resolvedModel)",
             provider: backendType.apiProvider,
             baseURL: trimmedURL,
             modelName: resolvedModel
         )
-        modelContext.insert(endpoint)
 
         let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmedKey.isEmpty {
             do {
-                try endpoint.setAPIKey(trimmedKey)
+                try KeychainService.store(key: trimmedKey, account: record.keychainAccount)
             } catch {
-                modelContext.delete(endpoint)
                 // `KeychainError.localizedDescription` already reads as a
                 // complete sentence — don't prepend another "Could not save…"
                 // prefix and double the wording.
@@ -198,10 +202,14 @@ public struct RemoteServerConfigSheet: View {
         }
 
         do {
-            try modelContext.save()
-            onSave?(endpoint)
+            try await endpointStore.insertEndpoint(record)
+            onSave?(record)
             dismiss()
         } catch {
+            // Best-effort Keychain cleanup if the row insert fails.
+            if !trimmedKey.isEmpty {
+                try? KeychainService.delete(account: record.keychainAccount)
+            }
             errorMessage = error.localizedDescription.isEmpty
                 ? "Failed to save the server configuration."
                 : error.localizedDescription
@@ -217,7 +225,5 @@ private extension String {
 
 #Preview("Remote Server Config") {
     RemoteServerConfigSheet()
-        .modelContainer(for: APIEndpoint.self, inMemory: true)
 }
 #endif
-

--- a/Tests/BaseChatCoreTests/SwiftDataBenchmarkCacheTests.swift
+++ b/Tests/BaseChatCoreTests/SwiftDataBenchmarkCacheTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+import SwiftData
+@testable import BaseChatCore
+import BaseChatInference
+import BaseChatTestSupport
+
+@MainActor
+final class SwiftDataBenchmarkCacheTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+    private var cache: SwiftDataBenchmarkCache!
+
+    override func setUp() async throws {
+        container = try makeInMemoryContainer()
+        context = ModelContext(container)
+        cache = SwiftDataBenchmarkCache(modelContext: context)
+    }
+
+    override func tearDown() async throws {
+        cache = nil
+        context = nil
+        container = nil
+    }
+
+    // MARK: - Fetch
+
+    func test_fetchAll_emptyStore_returnsEmpty() async throws {
+        let entries = try await cache.fetchAll()
+        XCTAssertTrue(entries.isEmpty)
+    }
+
+    func test_upsertThenFetch_roundTripsResult() async throws {
+        let result = ModelBenchmarkResult(
+            tier: .balanced,
+            tokensPerSecond: 42.5,
+            memoryBytes: 1_024_000,
+            measuredAt: Date(timeIntervalSince1970: 1_000)
+        )
+
+        try await cache.upsert(modelFileName: "model.gguf", result: result)
+
+        let entries = try await cache.fetchAll()
+        XCTAssertEqual(entries.count, 1)
+        let fetched = try XCTUnwrap(entries["model.gguf"])
+        XCTAssertEqual(fetched.tier, .balanced)
+        XCTAssertEqual(fetched.tokensPerSecond, 42.5)
+        XCTAssertEqual(fetched.memoryBytes, 1_024_000)
+        XCTAssertEqual(fetched.measuredAt, Date(timeIntervalSince1970: 1_000))
+    }
+
+    // MARK: - Upsert semantics
+
+    func test_upsert_replacesPreviousEntryForSameFileName() async throws {
+        let initial = ModelBenchmarkResult(tier: .minimal, tokensPerSecond: 5.0)
+        try await cache.upsert(modelFileName: "phi-mini.gguf", result: initial)
+
+        let updated = ModelBenchmarkResult(tier: .capable, tokensPerSecond: 80.0)
+        try await cache.upsert(modelFileName: "phi-mini.gguf", result: updated)
+
+        let entries = try await cache.fetchAll()
+        XCTAssertEqual(entries.count, 1)
+        let fetched = try XCTUnwrap(entries["phi-mini.gguf"])
+        XCTAssertEqual(fetched.tier, .capable)
+        XCTAssertEqual(fetched.tokensPerSecond, 80.0)
+
+        // Storage-level assertion: upsert must not leave stale rows behind.
+        // fetchAll() coalesces by key in its dictionary return, so a duplicate
+        // row would still produce a one-entry dictionary — checking the
+        // underlying row count is the only way to detect the leak.
+        let allRows = try context.fetch(FetchDescriptor<ModelBenchmarkCache>())
+        XCTAssertEqual(allRows.count, 1, "Upsert must not accumulate stale rows for the same key.")
+    }
+
+    func test_upsert_doesNotAffectOtherFiles() async throws {
+        let alpha = ModelBenchmarkResult(tier: .fast, tokensPerSecond: 10.0)
+        let beta = ModelBenchmarkResult(tier: .capable, tokensPerSecond: 50.0)
+
+        try await cache.upsert(modelFileName: "alpha.gguf", result: alpha)
+        try await cache.upsert(modelFileName: "beta.gguf", result: beta)
+
+        let entries = try await cache.fetchAll()
+        XCTAssertEqual(entries.count, 2)
+        XCTAssertEqual(entries["alpha.gguf"]?.tier, .fast)
+        XCTAssertEqual(entries["beta.gguf"]?.tier, .capable)
+    }
+}

--- a/Tests/BaseChatCoreTests/SwiftDataEndpointStoreTests.swift
+++ b/Tests/BaseChatCoreTests/SwiftDataEndpointStoreTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+import SwiftData
+@testable import BaseChatCore
+import BaseChatInference
+import BaseChatTestSupport
+
+@MainActor
+final class SwiftDataEndpointStoreTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+    private var store: SwiftDataEndpointStore!
+
+    override func setUp() async throws {
+        container = try makeInMemoryContainer()
+        context = ModelContext(container)
+        store = SwiftDataEndpointStore(modelContext: context)
+    }
+
+    override func tearDown() async throws {
+        store = nil
+        context = nil
+        container = nil
+    }
+
+    // MARK: - Insert + fetch
+
+    func test_fetchEndpoints_emptyStore_returnsEmpty() async throws {
+        let endpoints = try await store.fetchEndpoints()
+        XCTAssertTrue(endpoints.isEmpty)
+    }
+
+    func test_insertEndpoint_persistsAllFields() async throws {
+        let record = APIEndpointRecord(
+            name: "My OpenAI",
+            provider: .openAI,
+            baseURL: "https://api.openai.com/v1",
+            modelName: "gpt-4o-mini"
+        )
+
+        try await store.insertEndpoint(record)
+
+        let endpoints = try await store.fetchEndpoints()
+        XCTAssertEqual(endpoints.count, 1)
+        let fetched = try XCTUnwrap(endpoints.first)
+        XCTAssertEqual(fetched.id, record.id)
+        XCTAssertEqual(fetched.name, "My OpenAI")
+        XCTAssertEqual(fetched.provider, .openAI)
+        XCTAssertEqual(fetched.baseURL, "https://api.openai.com/v1")
+        XCTAssertEqual(fetched.modelName, "gpt-4o-mini")
+        XCTAssertTrue(fetched.isEnabled)
+        XCTAssertEqual(fetched.keychainAccount, record.id.uuidString)
+    }
+
+    func test_fetchEndpoints_returnsMostRecentFirst() async throws {
+        let earliest = APIEndpointRecord(name: "A", provider: .openAI, createdAt: Date(timeIntervalSince1970: 100))
+        let middle = APIEndpointRecord(name: "B", provider: .ollama, createdAt: Date(timeIntervalSince1970: 200))
+        let newest = APIEndpointRecord(name: "C", provider: .claude, createdAt: Date(timeIntervalSince1970: 300))
+
+        try await store.insertEndpoint(earliest)
+        try await store.insertEndpoint(middle)
+        try await store.insertEndpoint(newest)
+
+        let endpoints = try await store.fetchEndpoints()
+        XCTAssertEqual(endpoints.map(\.name), ["C", "B", "A"])
+    }
+
+    // MARK: - Update
+
+    func test_updateEndpoint_persistsFieldChanges() async throws {
+        let original = APIEndpointRecord(name: "Original", provider: .openAI)
+        try await store.insertEndpoint(original)
+
+        var updated = original
+        updated.name = "Renamed"
+        updated.modelName = "gpt-4o"
+        updated.isEnabled = false
+        try await store.updateEndpoint(updated)
+
+        let endpoints = try await store.fetchEndpoints()
+        XCTAssertEqual(endpoints.count, 1)
+        let fetched = try XCTUnwrap(endpoints.first)
+        XCTAssertEqual(fetched.name, "Renamed")
+        XCTAssertEqual(fetched.modelName, "gpt-4o")
+        XCTAssertFalse(fetched.isEnabled)
+    }
+
+    func test_updateEndpoint_unknownID_throwsEndpointNotFound() async throws {
+        let bogus = APIEndpointRecord(id: UUID(), name: "Ghost", provider: .openAI)
+
+        do {
+            try await store.updateEndpoint(bogus)
+            XCTFail("Expected endpointNotFound error")
+        } catch let error as EndpointStoreError {
+            XCTAssertEqual(error, .endpointNotFound(bogus.id))
+        }
+    }
+
+    // MARK: - Delete
+
+    func test_deleteEndpoint_removesRow() async throws {
+        let record = APIEndpointRecord(name: "ToRemove", provider: .ollama)
+        try await store.insertEndpoint(record)
+
+        try await store.deleteEndpoint(record.id)
+
+        let remaining = try await store.fetchEndpoints()
+        XCTAssertTrue(remaining.isEmpty)
+    }
+
+    func test_deleteEndpoint_unknownID_throwsEndpointNotFound() async throws {
+        let bogusID = UUID()
+
+        do {
+            try await store.deleteEndpoint(bogusID)
+            XCTFail("Expected endpointNotFound error")
+        } catch let error as EndpointStoreError {
+            XCTAssertEqual(error, .endpointNotFound(bogusID))
+        }
+    }
+
+    func test_deleteEndpoint_doesNotAffectOthers() async throws {
+        let kept = APIEndpointRecord(name: "Keeper", provider: .openAI)
+        let removed = APIEndpointRecord(name: "Goner", provider: .ollama)
+        try await store.insertEndpoint(kept)
+        try await store.insertEndpoint(removed)
+
+        try await store.deleteEndpoint(removed.id)
+
+        let endpoints = try await store.fetchEndpoints()
+        XCTAssertEqual(endpoints.map(\.id), [kept.id])
+    }
+
+    // MARK: - Record validation hoist
+
+    func test_record_validateBaseURL_acceptsHTTPSEndpoint() {
+        let record = APIEndpointRecord(name: "Cloud", provider: .openAI, baseURL: "https://api.openai.com/v1")
+        if case .failure = record.validateBaseURL() {
+            XCTFail("https://api.openai.com/v1 should validate")
+        }
+    }
+
+    func test_record_validateBaseURL_rejectsPrivateHost() {
+        let record = APIEndpointRecord(name: "Internal", provider: .custom, baseURL: "https://10.0.0.5/v1")
+        guard case .failure(let reason) = record.validateBaseURL() else {
+            XCTFail("Expected validation failure for 10.0.0.5")
+            return
+        }
+        XCTAssertEqual(reason, .privateHost)
+    }
+
+    func test_record_validateBaseURL_acceptsLoopbackOverHTTP() {
+        let record = APIEndpointRecord(name: "Local", provider: .ollama, baseURL: "http://localhost:11434")
+        if case .failure = record.validateBaseURL() {
+            XCTFail("loopback should validate over plain HTTP")
+        }
+    }
+
+    func test_record_validateBaseURL_rejectsInsecureRemoteScheme() {
+        let record = APIEndpointRecord(name: "Insecure", provider: .custom, baseURL: "http://api.example.com/v1")
+        guard case .failure(let reason) = record.validateBaseURL() else {
+            XCTFail("Expected validation failure for http remote")
+            return
+        }
+        XCTAssertEqual(reason, .insecureScheme)
+    }
+}

--- a/Tests/BaseChatCoreTests/SwiftDataSamplerPresetStoreTests.swift
+++ b/Tests/BaseChatCoreTests/SwiftDataSamplerPresetStoreTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+import SwiftData
+@testable import BaseChatCore
+import BaseChatInference
+import BaseChatTestSupport
+
+@MainActor
+final class SwiftDataSamplerPresetStoreTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+    private var store: SwiftDataSamplerPresetStore!
+
+    override func setUp() async throws {
+        container = try makeInMemoryContainer()
+        context = ModelContext(container)
+        store = SwiftDataSamplerPresetStore(modelContext: context)
+    }
+
+    override func tearDown() async throws {
+        store = nil
+        context = nil
+        container = nil
+    }
+
+    // MARK: - Insert + fetch
+
+    func test_fetchPresets_emptyStore_returnsEmpty() async throws {
+        let presets = try await store.fetchPresets()
+        XCTAssertTrue(presets.isEmpty)
+    }
+
+    func test_insertPreset_persistsAllFields() async throws {
+        let record = SamplerPresetRecord(
+            name: "Precise",
+            temperature: 0.2,
+            topP: 0.85,
+            repeatPenalty: 1.05
+        )
+
+        try await store.insertPreset(record)
+
+        let presets = try await store.fetchPresets()
+        XCTAssertEqual(presets.count, 1)
+        let fetched = try XCTUnwrap(presets.first)
+        XCTAssertEqual(fetched.id, record.id)
+        XCTAssertEqual(fetched.name, "Precise")
+        XCTAssertEqual(fetched.temperature, 0.2, accuracy: 0.001)
+        XCTAssertEqual(fetched.topP, 0.85, accuracy: 0.001)
+        XCTAssertEqual(fetched.repeatPenalty, 1.05, accuracy: 0.001)
+    }
+
+    func test_fetchPresets_returnsMostRecentFirst() async throws {
+        let earliest = SamplerPresetRecord(name: "A", createdAt: Date(timeIntervalSince1970: 100))
+        let middle = SamplerPresetRecord(name: "B", createdAt: Date(timeIntervalSince1970: 200))
+        let newest = SamplerPresetRecord(name: "C", createdAt: Date(timeIntervalSince1970: 300))
+
+        try await store.insertPreset(earliest)
+        try await store.insertPreset(middle)
+        try await store.insertPreset(newest)
+
+        let presets = try await store.fetchPresets()
+        XCTAssertEqual(presets.map(\.name), ["C", "B", "A"])
+    }
+
+    // MARK: - Delete
+
+    func test_deletePreset_removesRow() async throws {
+        let record = SamplerPresetRecord(name: "ToRemove")
+        try await store.insertPreset(record)
+
+        try await store.deletePreset(record.id)
+
+        let remaining = try await store.fetchPresets()
+        XCTAssertTrue(remaining.isEmpty)
+    }
+
+    func test_deletePreset_unknownID_throwsPresetNotFound() async throws {
+        let bogusID = UUID()
+
+        do {
+            try await store.deletePreset(bogusID)
+            XCTFail("Expected presetNotFound error")
+        } catch let error as SamplerPresetStoreError {
+            XCTAssertEqual(error, .presetNotFound(bogusID))
+        }
+    }
+
+    func test_deletePreset_doesNotAffectOthers() async throws {
+        let kept = SamplerPresetRecord(name: "Keeper")
+        let removed = SamplerPresetRecord(name: "Goner")
+        try await store.insertPreset(kept)
+        try await store.insertPreset(removed)
+
+        try await store.deletePreset(removed.id)
+
+        let presets = try await store.fetchPresets()
+        XCTAssertEqual(presets.map(\.id), [kept.id])
+    }
+}

--- a/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
+++ b/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
@@ -351,3 +351,14 @@ BaseChatBackends/LlamaToolCallParser.swift:guard let data = try? JSONSerializati
 # "session not active" error to the user; the route is reclaimed regardless.
 # Mirrors the pattern in Apple's own AVAudioSession sample code.
 BaseChatVoice/Services/VoiceAudioSessionCoordinator.swift:try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+
+# ---------------------------------------------------------------------------
+# BaseChatUIModelManagement — endpoint editor rollback
+# ---------------------------------------------------------------------------
+
+# Best-effort Keychain cleanup when the EndpointStore insert fails after a
+# Keychain key was just stored. Throwing here would obscure the real error
+# (the failed row insert), so we swallow the cleanup failure — leaving an
+# orphan Keychain item that the bootstrap reaper will sweep on next launch.
+BaseChatUIModelManagement/Views/Settings/APIEndpointEditorView.swift:try? KeychainService.delete(account: newRecord.keychainAccount)
+BaseChatUIModelManagement/Views/Settings/RemoteServerConfigSheet.swift:try? KeychainService.delete(account: record.keychainAccount)


### PR DESCRIPTION
## Summary

Phase 1.2 sub-step 3 of the runtime ports refactor (see `docs/plans/runtime-ports-phase-1-2.md`, lines 360–369). Closes the remaining `@Query` / public `ModelContext` leaks listed in the plan's Background section (lines 86–95):

- **`SamplerPresetStore`** replaces the direct `@Query(\SamplerPreset.createdAt)` in `SamplerPresetPickerView`. Adds `SamplerPresetRecord` to `BaseChatInference` for the value-typed boundary.
- **`BenchmarkCache`** replaces the public `ModelManagementViewModel.modelContext: ModelContext?` property. The VM now exposes `benchmarkCache: (any BenchmarkCache)?` instead, and host apps inject `runtime.benchmarkCache`. The view model no longer imports SwiftData.
- **`EndpointStore`** replaces direct SwiftData access in `APIConfigurationView`, `APIEndpointEditorView`, and `RemoteServerConfigSheet`. Each view consumes the store via `@Environment(\.endpointStore)`. The endpoint row, draft validator, and remote-server save callback all switch to `APIEndpointRecord`.

`BaseChatRuntime` exposes default SwiftData implementations for all three so host apps don't need to construct stores themselves.

## Records at the boundary

Per the plan's principle 3, every port traffics in records, never `@Model` types.

- `SamplerPresetRecord` — new, in `BaseChatInference`.
- `APIEndpointRecord` — gains `createdAt` and `isEnabled` to cover the UI's sort/filter needs (additive — defaulted parameters keep all existing call sites source-compatible).
- The richer `Result<Void, APIEndpointValidationReason>` validator is hoisted onto `APIEndpointRecord` (in `BaseChatCore`) so endpoint rows can render reasons without materialising a SwiftData `@Model`.

## Out of scope

`ChatViewModel.availableEndpoints: [APIEndpoint]` and the demo app's `@Query<APIEndpoint>` cloud-endpoint feed remain on the `@Model` — that path is part of the broader `ConversationRuntime` extraction (sub-step 5) and stays untouched here.

Per the plan's coordination protocol exception (lines 562–569), this PR ships without Fireside review: these stores close `@Query`/`ModelContext` leaks Fireside does not consume.

## Test plan

- [x] New `SwiftDataSamplerPresetStoreTests` (6 cases), `SwiftDataBenchmarkCacheTests` (4 cases), and `SwiftDataEndpointStoreTests` (12 cases) cover CRUD, ordering, upsert-dedup row counts, error mapping, and the hoisted record validator.
- [x] Sabotage-checked all three stores. Each sabotage produced failures and was reverted:
  - `SwiftDataSamplerPresetStore.insertPreset` — skip insert+save → `test_insertPreset_persistsAllFields` fails (expected count 1, got 0).
  - `SwiftDataBenchmarkCache.upsert` — skip stale-row delete → tightened `test_upsert_replacesPreviousEntryForSameFileName` (added direct row-count assertion against the SwiftData store) fails.
  - `SwiftDataEndpointStore.updateEndpoint` — skip field updates and save → `test_updateEndpoint_persistsFieldChanges` fails on three assertions.
- [x] Full pre-push checklist (9 CI-safe suites) passes locally with 0 failures: `BaseChatCoreTests`, `BaseChatInferenceTests`, `BaseChatInferenceSwiftTestingTests`, `BaseChatUITests`, `BaseChatUIModelManagementTests`, `BaseChatMCPTests`, `BaseChatBackendsTests`, `BaseChatTestSupportTests`, `BaseChatAppIntentsTests`.
- [x] Builds clean with `--disable-default-traits` and with `--traits Ollama,CloudSaaS`.
- [x] `SilentCatchAuditTest` allowlist updated for the two new best-effort `try? KeychainService.delete(account:)` rollback paths in the editor flows.
- [x] `TrafficBoundaryAuditTest` passes with no allowlist changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)