### PR TITLE
ci: cut per-PR macOS minutes via build-modes + fuzz-pr cache

### DIFF
--- a/.github/workflows/build-modes.yml
+++ b/.github/workflows/build-modes.yml
@@ -11,6 +11,18 @@ name: Build modes + binary symbol audit
 #    on-demand trigger — it only fires when a PR actually edits trait-gated
 #    source, Package.swift, or this workflow's own configuration. Doc-only
 #    PRs and unrelated source edits don't trigger it.
+#  - **PR vs schedule matrix split.** On `pull_request`, the matrix runs only
+#    `[saas, full]`; on `schedule` (and `workflow_dispatch`) it runs all four
+#    `[offline, ollama, saas, full]`. Rationale: `full` enables the strict
+#    trait superset (`MLX,Llama,Ollama,CloudSaaS`) so any compile-time
+#    regression that the offline or ollama legs would catch also breaks the
+#    full leg — running them on every qualifying PR is duplicate macos-15
+#    spend. `saas` is retained on PRs because it carries a CloudSaaS-only
+#    test step (`BaseChatBackendsTests --traits CloudSaaS`) that is real
+#    signal not covered by ci.yml. The full 4-mode build+audit matrix
+#    continues nightly so the procurement-evidence requirement (90-day
+#    per-mode artifacts) is unchanged. Saves ~28 macos-min per qualifying PR
+#    (2 legs × ~14 min wall instead of 4).
 #  - All four modes run on `macos-15` (10x billing): the package depends on
 #    `os` (Apple-only) and SwiftUI throughout `BaseChatUI`/
 #    `BaseChatUIModelManagement`, so a Linux compile leg is structurally
@@ -55,7 +67,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mode: [offline, ollama, saas, full]
+        # On PRs: only saas + full. `full` is a strict trait superset that
+        # catches every compile-time regression the offline/ollama legs would;
+        # `saas` carries a CloudSaaS-only test slice not covered by ci.yml.
+        # On schedule/workflow_dispatch: all four modes for the procurement-
+        # evidence artifact set. See the cost-discipline block at the top.
+        mode: ${{ github.event_name == 'pull_request' && fromJSON('["saas", "full"]') || fromJSON('["offline", "ollama", "saas", "full"]') }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/fuzz-pr.yml
+++ b/.github/workflows/fuzz-pr.yml
@@ -38,17 +38,27 @@ jobs:
           xcode-version: "26.3"
 
       - name: Cache SwiftPM build
+        # Key is intentionally aligned with ci.yml's `xcode-26.3-spm-…` so this
+        # job and the per-PR ci.yml job on the same PR share the SwiftPM
+        # artifact cache (notably the prebuilt llama.cpp xcframework). Whichever
+        # job runs first warms the cache for the other. The legacy
+        # `xcode-26.3-fuzz-spm-` prefix is retained as a restore-key so existing
+        # caches still match during the transition.
+        # `.build/debug` is excluded for the same reason ci.yml excludes it:
+        # SwiftPM module fingerprints embed absolute paths + compiler timestamps,
+        # so restored object files are invalidated on every fresh ephemeral
+        # runner — caching it produces 0 incremental savings and wastes the
+        # 10 GB per-repo cache quota.
         uses: actions/cache@v5
         with:
           path: |
             .build/artifacts
             .build/checkouts
             .build/repositories
-            .build/debug
-          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-fuzz-spm-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-fuzz-spm-
             ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-fuzz-spm-
 
       # MockInferenceBackend + ChaosBackend do not need MLX or Llama, but the
       # fuzz-chat executable's dependency graph pulls `BaseChatBackends` in.


### PR DESCRIPTION
## Summary

Two structural CI changes that cut macos-15 (10× billing) consumption per PR.

- **`build-modes.yml`: trim PR matrix to `[saas, full]`; keep all four `[offline, ollama, saas, full]` on the nightly cron.** The `full` mode is a strict trait superset (`MLX,Llama,Ollama,CloudSaaS`) that catches every compile-time regression the offline/ollama legs would. The `saas` leg is retained on PRs because it carries a `CloudSaaS`-only test step (`BaseChatBackendsTests --traits CloudSaaS`) that is real signal not covered by `ci.yml`. The full 4-mode build+audit matrix continues nightly so the procurement-evidence requirement is unchanged. Recent PR-triggered runs took ~14 min wall × 4 legs of macos-15; trimming to 2 legs saves ~28 macos-min on every qualifying PR.
- **`fuzz-pr.yml`: align cache key with `ci.yml`, drop `.build/debug` from cached paths.** Today fuzz-pr's cache key is `xcode-26.3-fuzz-spm-…` while ci.yml's is `xcode-26.3-spm-…`, so the two macos jobs on the same PR rebuild from cold. Aligning the primary key lets fuzz-pr restore the SwiftPM artifacts ci.yml just produced. `.build/debug` is dropped because ci.yml already documented that caching it produces 0 incremental savings on ephemeral runners and wastes the 10 GB per-repo quota. Recent fuzz-pr runs were ~76s of which ~70s was SwiftPM rebuild; expect that to drop substantially when the cache is shared.

Net per-PR macOS savings on a typical qualifying PR (touches `Sources/BaseChatBackends/**`): roughly 30 macos-15-minutes (10× billed = 300 min equivalent).

## Test plan

- [ ] CI runs green on this PR.
- [ ] Confirm `build-modes.yml` PR job runs 2 matrix legs (saas + full), not 4.
- [ ] Confirm a follow-up PR's `fuzz-pr` run hits the shared cache (look for `Cache restored from key:` line referencing the `xcode-26.3-spm-` prefix).
- [ ] Sanity-check that the next nightly `build-modes` schedule still runs all four modes by inspecting `gh run list --workflow build-modes.yml --event schedule --limit 1` after the next 05:30 UTC tick.