### PR TITLE
ci: prune zombie schedules, surface Swift Testing failures, tighten timeouts

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -28,7 +28,9 @@ jobs:
 
       - name: Install actionlint
         id: install_actionlint
-        run: bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.7
+        # Pin the bootstrap script to the same release tag as the binary so a
+        # compromised `main` on rhysd/actionlint cannot swap the download URL.
+        run: bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.7/scripts/download-actionlint.bash) 1.7.7
 
       - name: Lint GitHub Actions workflows
         run: ${{ steps.install_actionlint.outputs.executable }} -color

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -26,16 +26,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "stable"
-
       - name: Install actionlint
-        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+        id: install_actionlint
+        run: bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.7
 
       - name: Lint GitHub Actions workflows
-        run: |
-          set -euo pipefail
-          ACTIONLINT_BIN="$(go env GOPATH)/bin/actionlint"
-          "$ACTIONLINT_BIN" -color
+        run: ${{ steps.install_actionlint.outputs.executable }} -color

--- a/.github/workflows/build-modes.yml
+++ b/.github/workflows/build-modes.yml
@@ -24,7 +24,9 @@ name: Build modes + binary symbol audit
 
 on:
   schedule:
-    # 05:30 UTC daily — after nightly-slow-tests (04:30) and fuzz-nightly (05:00).
+    # 05:30 UTC daily — after nightly-slow-tests (04:30). (fuzz-nightly
+    # previously held the 05:00 UTC slot but is now dispatch-only pending a
+    # self-hosted Apple-Silicon runner.)
     - cron: "30 5 * * *"
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,11 +188,15 @@ jobs:
       # execution avoids that and `--parallel` would still need a UI-test-only
       # carve-out, which negates most of the speedup anyway.
       - name: Test — XCTest suites (Core + UI + UIModelManagement + MCP + Backends + Inference + TestSupport)
-        timeout-minutes: 25
+        timeout-minutes: 12
         run: scripts/test.sh --filter BaseChatCoreTests --filter BaseChatUITests --filter BaseChatUIModelManagementTests --filter BaseChatMCPTests --filter BaseChatBackendsTests --filter BaseChatInferenceTests --filter BaseChatTestSupportTests --filter BaseChatAppIntentsTests --disable-default-traits --skip-update
 
+      # `if: always()` so a failing XCTest step still surfaces Swift Testing
+      # failures in the same run — otherwise breakage in both harnesses costs
+      # two re-push cycles to triage. The job still fails because step 1 failed.
       - name: Test — Inference (Swift Testing, isolated process)
-        timeout-minutes: 25
+        if: always()
+        timeout-minutes: 12
         run: scripts/test.sh --filter BaseChatInferenceSwiftTestingTests --disable-default-traits --skip-update
 
       - name: Stage test diagnostics

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -8,10 +8,10 @@ name: Fuzz (nightly)
 # with Ollama installed and `qwen3.5:4b` pulled. Until such a runner exists,
 # scheduled runs will sit in the queue — see FUZZING.md § CI tiers.
 
+# Schedule disabled: no `[self-hosted, macos, arm64]` runner is registered, so
+# scheduled runs queue for 24h and auto-cancel. Re-enable the cron once a
+# self-hosted Apple-Silicon runner is available (see FUZZING.md § CI tiers).
 on:
-  schedule:
-    # 05:00 UTC daily — quiet window, before the PR-tier traffic ramps.
-    - cron: "0 5 * * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/fuzz-weekly.yml
+++ b/.github/workflows/fuzz-weekly.yml
@@ -7,10 +7,10 @@ name: Fuzz (weekly rotation)
 # Requires a self-hosted runner labelled `[self-hosted, macos, arm64]`
 # with Ollama installed and at least one model pulled. See FUZZING.md § CI tiers.
 
+# Schedule disabled: no `[self-hosted, macos, arm64]` runner is registered, so
+# scheduled runs queue for 24h and auto-cancel. Re-enable the cron once a
+# self-hosted Apple-Silicon runner is available (see FUZZING.md § CI tiers).
 on:
-  schedule:
-    # 07:00 UTC Sunday — off-peak for most contributors.
-    - cron: "0 7 * * 0"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/nightly-slow-tests.yml
+++ b/.github/workflows/nightly-slow-tests.yml
@@ -11,7 +11,8 @@ name: Nightly slow tests
 
 on:
   schedule:
-    # 04:30 UTC daily — quiet window, before fuzz-nightly at 05:00 UTC.
+    # 04:30 UTC daily — quiet window. (fuzz-nightly's 05:00 UTC slot is
+    # currently dispatch-only pending a self-hosted Apple-Silicon runner.)
     - cron: "30 4 * * *"
   workflow_dispatch:
 

--- a/FUZZING.md
+++ b/FUZZING.md
@@ -362,7 +362,7 @@ The `expires` field is strict — past that date the PR job fails even if the ha
 
 ### Nightly tier — `.github/workflows/fuzz-nightly.yml`
 
-- **When:** every day at 05:00 UTC, plus `workflow_dispatch`.
+- **When:** `workflow_dispatch` only. The daily `05:00 UTC` cron was disabled until a self-hosted Apple-Silicon runner is provisioned — scheduled runs were queueing for 24h and auto-cancelling. Re-enable the `schedule:` block in `fuzz-nightly.yml` once a `[self-hosted, macos, arm64]` runner is registered.
 - **Runner:** `[self-hosted, macos, arm64]` — see [self-hosted runner requirements](#self-hosted-runner-requirements).
 - **Budget:** 10 wall-clock minutes.
 - **Backend:** real Ollama `qwen3.5:4b`. The seed is derived from `github.run_number` so each nightly run samples a different slice of the mutator space.
@@ -371,7 +371,7 @@ The `expires` field is strict — past that date the PR job fails even if the ha
 
 ### Weekly tier — `.github/workflows/fuzz-weekly.yml`
 
-- **When:** every Sunday at 07:00 UTC, plus `workflow_dispatch`.
+- **When:** `workflow_dispatch` only. The Sunday `07:00 UTC` cron was disabled alongside the nightly tier until a self-hosted Apple-Silicon runner is provisioned. Re-enable the `schedule:` block in `fuzz-weekly.yml` once a runner is registered.
 - **Runner:** `[self-hosted, macos, arm64]`.
 - **Budget:** 30 wall-clock minutes.
 - **Backend:** `--backend ollama --model all` — rotates through every installed Ollama model per iteration. This is the explicit sibling-coverage sweep; bugs that only fire on a non-default model surface here.


### PR DESCRIPTION
## Summary

Four small CI hygiene fixes bundled together — all YAML-only.

- **Disable zombie scheduled triggers on `fuzz-nightly.yml` and `fuzz-weekly.yml`.** Both require a self-hosted `[self-hosted, macos, arm64]` runner that does not currently exist. Daily/weekly scheduled runs queue for 24h and auto-cancel — every day. Removed the `schedule:` trigger; kept `workflow_dispatch:` so a maintainer can fire them manually once a runner is registered.
- **`if: always()` on the Swift Testing step in `ci.yml`.** Currently the second `swift test` step is skipped when the first XCTest step fails, so a PR with broken tests in both harnesses requires two re-push cycles to triage. With `if: always()` both failure sets surface in one run; the job still fails because step 1 failed.
- **Drop `timeout-minutes` from 25 → 12 on the two test steps.** Recent green runs finish in 4-5 min; 12 min is 3× headroom but kills hung runs ~2× faster.
- **Replace `setup-go + go install actionlint` with the upstream prebuilt binary downloader.** Saves ~20s of cold Go setup per actionlint run.

## Test plan

- [ ] CI runs green on this PR.
- [ ] Manually verify the actionlint workflow still detects an intentionally bad workflow change (sanity check the new install path actually executes the linter).
- [ ] Confirm fuzz-nightly / fuzz-weekly no longer auto-trigger by checking `gh run list --workflow fuzz-nightly.yml` 24h after merge.