### PR TITLE
docs(plan): reframe phase 1.2 per Fireside reply (library + optional runtime)

### DIFF
--- a/docs/plans/runtime-ports-phase-1-2.md
+++ b/docs/plans/runtime-ports-phase-1-2.md
@@ -19,16 +19,54 @@ phase.
   - #886 — `SessionListService` extracted from `SessionManagerViewModel`;
     session-list orchestration uses the events-out / commands-in pattern
     with a 6-case `SessionListEvent` enum (Phase 1.1).
-- Open as a related artifact: this PR (the forward-looking plan), and
-  Fireside's `docs/architecture/runtime-decoupling-migration.md` RFC
-  pushing the same direction from the consumer side.
-- Left to ship: Phase 1.2 port extraction, Phase 2 physical target
+  - #889 — this plan doc landed as the forward-looking spec.
+- In review:
+  - #890 — `SamplerPresetStore` + `BenchmarkCache` + `EndpointStore`
+    internal port extraction (Phase 1.2 sub-step 3). Closes `@Query` /
+    public `ModelContext` leaks in the editor flows.
+  - #893 — `InferenceService` nonisolated wrappers (Phase 1.2 sub-step 4).
+    Prereq for sub-step 5 — adds `capabilitiesAsync` / `tokenizerAsync` /
+    `enqueueAsync` / `cancelAsync` for off-main composition.
+- Related artifact: Fireside's
+  `docs/architecture/runtime-decoupling-migration.md` RFC pushing the
+  same direction from the consumer side. Fireside's reply to this plan
+  (2026-04-29) drives the reframe in this revision — see "Stance" below
+  and the Fireside appendix.
+- Left to ship: Phase 1.2 sub-steps 1, 2, 5; Phase 2 physical target
   split.
 - Window: pre-1.0; one breaking changelog entry per phase, no shims.
 - Downstream consumers in view:
   - BaseChatKit demo app
   - ChatbotUI-iOS
   - Fireside
+
+## Stance
+
+BCK is a **library with a reference runtime, not a runtime with ports.**
+This stance is load-bearing for everything below; if it changes the
+whole plan changes.
+
+- BCK ships ports (`MessageStore`, `SessionStore`, `GenerationContextProvider`,
+  etc.) and a reference use case (`ConversationRuntime`) that composes
+  them into a turn loop.
+- `ConversationRuntime` is **optional**. Demo and ChatbotUI-iOS adopt
+  it; Fireside continues to drive its own turn loop (`StoryStore` →
+  eventual `TurnEngine`) directly against `InferenceService` and the
+  ports.
+- The `ConversationEvent` enum is the contract for `ConversationRuntime`
+  *users*, not a universal event surface. Direct `InferenceService`
+  consumers (Fireside) get a different, narrower contract.
+- `ContextContribution` as an aggregate value type lives in the
+  consumer (Fireside has `[PromptSlot] + realCost`). BCK ships
+  `PromptSlot` (already does), the `GenerationContextProvider` port,
+  and `PromptContextPipeline` as a passive merge over `[PromptSlot]`.
+  No competing aggregate type in BCK.
+
+Implications captured throughout the doc; the most consequential are
+that the "Fireside-gated" framing of sub-steps 1/2 changes shape (no
+adoption flip blocks BCK; design constraints from FS shape what BCK
+ships) and that `MessageStorePostWriteHook` is a low-level primitive,
+not the canonical attachment point for Fireside's `GraphExtractionService`.
 
 ## Picking this up in a new session
 
@@ -38,34 +76,32 @@ Live artifacts in priority order:
 - The shipped PRs above are the prior art for shape and naming. #886's
   worker report is the canonical source for the final `SessionListEvent`
   shape.
-- No other in-flight branches for this refactor. **v0.14.0** is the
-  baseline (current `main`).
+- In-flight branches for this refactor: #890 (sub-step 3) and #893
+  (sub-step 4). **v0.14.0** is the baseline (current `main`).
 - Repo: `roryford/BaseChatKit` (private). If picking up outside the
   working tree: `gh repo clone roryford/BaseChatKit && gh pr checkout <this-PR>`.
 
 **Next concrete action: Phase 1.2 sub-step 1 — `MessageStore` +
-`MessageStorePostWriteHook` + `SessionStore` split.** Co-design the
-hook signature with Fireside *before* writing the PR. Fireside's
-`GraphExtractionService` registration is the worked example that drives
-the protocol shape; landing the protocol without that review risks a
-v0.x churn cycle on a load-bearing surface.
-
-**Precondition before opening sub-step 1**: confirm Fireside's adoption
-of #883 + #885 + #886 has landed (the `configure(persistence:autoLoad:)`
-flip at `AppEnvironmentFactory.swift:168`, custom
-`ChatPersistenceProvider` impl signatures converted to `async throws`,
-stored `onFirstMessage` closures flipped to `async`). If their `main`
-is still on the pre-#883 surface, the BCK Phase 1.2 PR will block on
-their adoption rather than the other way around. Verify before drafting.
+`MessageStorePostWriteHook` + `SessionStore` split.** The hook signature
+is settled — see `MessageStore post-write hooks` below. Fireside's
+`GraphExtractionService` does *not* attach via this hook (it lives at
+the turn-orchestrator layer, see Fireside appendix); the hook ships as
+a low-level primitive available to consumers who want it.
 
 After 1.2.1: `GenerationContextProvider` re-export + `PromptContextPipeline`
-use case + `ContextContribution` value type (1.2.2 — locks the context
-contract for the rest of pre-1.0). Then internal port cleanups
-(`SamplerPresetStore`, `BenchmarkCache`, `EndpointStore`) at 1.2.3,
-`InferenceService` interaction prep at 1.2.4, and `ConversationRuntime`
-extraction at 1.2.5. Phase 2 is the physical target split:
-`BaseChatRuntime` and `BaseChatPersistenceSwiftData` targets created,
-`BaseChatCore` deleted.
+passive-merge use case (1.2.2 — no new value type ships). Then
+`ConversationRuntime` extraction as the optional reference use case at
+1.2.5. Phase 1.2 sub-steps 3 (internal port cleanups) and 4
+(`InferenceService` nonisolated wrappers) are already in review (#890,
+#893). Phase 2 is the physical target split: `BaseChatRuntime` and
+`BaseChatPersistenceSwiftData` targets created, `BaseChatCore` deleted.
+
+**No Fireside-adoption precondition.** The earlier draft of this plan
+gated 1.2.1 on Fireside flipping to the post-#883 surface. Fireside's
+2026-04-29 reply confirmed they consume BCK via a local SPM path
+reference and have zero custom `ChatPersistenceProvider` impls, zero
+`onFirstMessage` consumers, and no `SessionManagerViewModel` call sites
+at all. The flip was a no-op; the precondition is dropped.
 
 ## Background
 
@@ -200,11 +236,11 @@ selective implementation by hosts (Fireside) cheaper. `SessionListService`
 
 #### `MessageStore` post-write hooks
 
-`MessageStore` exposes a hook protocol so cross-cutting persistence
-concerns (graph extraction, indexing, audit) can attach without
-subclassing the store or wrapping it in a delegating impl. Hooks fire
-after the write commits, in registration order. Phase 1.2 sub-step 1
-ships this protocol alongside the `SessionStore` / `MessageStore` split.
+`MessageStore` exposes a hook protocol as a **low-level primitive** —
+not as the canonical attachment point for any specific consumer's
+cross-cutting concerns. Hooks fire after the write commits, in
+registration order. Phase 1.2 sub-step 1 ships this protocol alongside
+the `SessionStore` / `MessageStore` split.
 
 ```swift
 public protocol MessageStorePostWriteHook: Sendable {
@@ -223,30 +259,46 @@ public protocol MessageStore: Sendable {
 Hooks must not throw — a failing hook cannot roll back a committed
 write. Hook errors are logged via `Log.persistence.error` and otherwise
 swallowed; surfaces that need transactional guarantees compose at the
-use-case layer (`ConversationRuntime`) instead. Fireside's
-`GraphExtractionService` registers as a post-write hook at bootstrap
-time; no `MessageStore` subclass needed.
+use-case layer (`ConversationRuntime`, or the consumer's own
+orchestrator) instead.
+
+**Where Fireside's `GraphExtractionService` lives:** *not* on this
+hook. Fireside attaches extraction at the turn-orchestrator layer
+(`StoryStore` post-turn, eventually a `StoryTurnObserver` protocol on
+the Fireside side per their RFC). The natural extraction unit is a
+turn, not a message; the per-message hook fires twice per turn and
+doesn't surface the turn boundary. Shipping the hook as a low-level
+primitive keeps it available for consumers whose unit of work *is* the
+message (audit, indexing, debug logging) without overpromising it as
+the right seam for higher-level concerns.
 
 A symmetric `SessionStorePostWriteHook` is provided for completeness;
 no internal consumer uses it yet, so its shape is provisional until a
-host actually exercises it.
+host actually exercises it. Fireside's reply confirmed they have no
+planned consumer either.
 
 ### Use cases
+
+Use cases compose ports into a turn loop or other workflow. They are
+**optional** — consumers that prefer to drive the ports directly
+(Fireside) skip them.
 
 | Use case | Status | Absorbs | Surface |
 |----------|--------|---------|---------|
 | `SessionListService` | ✅ shipped (#886, `Sources/BaseChatUI/ViewModels/SessionListService.swift`) | `SessionManagerViewModel`'s CRUD/search/pagination/title generation | `AsyncStream<SessionListEvent>` + commands |
-| `ConversationRuntime` | forward-looking | `ChatViewModel`'s send/cancel/regenerate/edit/branch logic, `GenerationCoordinator` (UI-side), `ModelLoadCoordinator` | `AsyncSequence<ConversationEvent>` + commands |
+| `ConversationRuntime` | forward-looking, **optional reference** | `ChatViewModel`'s send/cancel/regenerate/edit/branch logic, `GenerationCoordinator` (UI-side), `ModelLoadCoordinator` | `AsyncSequence<ConversationEvent>` + commands |
 | `ModelManagementService` | forward-looking | `ModelManagementViewModel`'s discovery/download/delete/benchmark | `AsyncSequence<ModelCatalogEvent>` + commands |
-| `PromptContextPipeline` | forward-looking | new — composes `GenerationContextProvider` contributions | `[ContextContribution]` |
+| `PromptContextPipeline` | forward-looking | new — passive merge over `[PromptSlot]` from registered `GenerationContextProvider`s | `[PromptSlot]` |
 
 #### `ConversationEvent` cases
 
-The closure-bag → events transformation only works if the event surface
-is enumerated up front. The starter set below is the contract Phase 1.2
-must ship; cases may be added during `ConversationRuntime` extraction
-but cannot be removed or renamed without a coordinated breaking-change
-cycle with downstream consumers (Fireside).
+`ConversationEvent` is the contract for `ConversationRuntime` *users*
+(demo, ChatbotUI-iOS) — not a universal event surface. Direct
+`InferenceService` consumers (Fireside) drive the ports themselves and
+get a different, narrower contract documented under "Direct-inference
+contract" below.
+
+The starter set Phase 1.2 ships:
 
 ```swift
 public enum ConversationEvent: Sendable {
@@ -257,9 +309,9 @@ public enum ConversationEvent: Sendable {
     case streamFinished(messageID: ChatMessageRecord.ID, reason: FinishReason)
     case errorRaised(ConversationError)
 
-    // Context pipeline (Fireside hook points)
+    // Context pipeline (runtime hook points)
     case beforeContextAssembly(prompt: String, request: PromptContextRequest)
-    case contextAssembled(contributions: [ContextContribution])
+    case contextAssembled(slots: [PromptSlot])
     case afterGeneration(messageID: ChatMessageRecord.ID, finalText: String)
     case compressionTriggered(removed: [ChatMessageRecord.ID], reason: CompressionReason)
 
@@ -270,19 +322,35 @@ public enum ConversationEvent: Sendable {
 }
 ```
 
-`.beforeContextAssembly`, `.contextAssembled`, `.afterGeneration`, and
-`.compressionTriggered` are the integration points Fireside's
-story/memory pipeline composes against. They are load-bearing —
-removing or renaming any of them is a coordinated change with Fireside,
-not a unilateral rename. The other cases are BCK-internal and can
-evolve more freely.
+**Load-bearing for `ConversationRuntime`-using consumers**:
+`.beforeContextAssembly`, `.contextAssembled`, `.afterGeneration`,
+`.compressionTriggered`. Removing or renaming any of these is a
+coordinated breaking change. These bracket the two phases of generation
+that runtime-using consumers need to extend — context assembly and
+post-generation work — even when they don't drive their own turn loop.
+
+**Direct-inference contract** (Fireside): consumers who compose
+`InferenceService` + ports themselves, without using
+`ConversationRuntime`, get a narrower contract pinned to the events
+the underlying `GenerationStream` already provides:
+`.tokenEmitted` (the raw token stream, pre-thinking-block-filter),
+`.streamFinished`, and `.errorRaised`. These three are load-bearing
+for direct-inference consumers — they're how Fireside drives narrative
+streaming UI today. `.compressionTriggered` is also pinned for direct
+consumers when (and only when) the consumer asks BCK to manage
+compression; today Fireside drives its own compression and the case
+is informational.
+
+The two contracts overlap on `.compressionTriggered` and share the
+same `.tokenEmitted / .streamFinished / .errorRaised` shape — the
+difference is just which subset is pinned for which consumer posture.
 
 **Why 12 cases (not collapsed à la `SessionListEvent`).** #886 collapsed
 `.sessionInserted` into `.sessionsLoaded` because every insert was
 immediately followed by a list reload — the adapter ignored the first
 event and only acted on the second. That collapse pattern does not
 apply here: each `ConversationEvent` case represents a distinct
-observable transition that adapters and Fireside both need to act on
+observable transition that runtime-using adapters need to act on
 (start vs. finish of a stream is a UI-state phase change; tool-call
 request vs. approval vs. completion are three different user-facing
 moments; the four context-pipeline cases bracket two distinct phases
@@ -351,45 +419,48 @@ infrastructure can't lag.
 
 Inside the existing target structure, extract every remaining use case
 as a plain async/event class. Each PR moves one use case + its ports +
-its tests. Ordering is driven by Fireside's gating ports rather than
-"smallest blast radius first" — landing the load-bearing context and
-hook surfaces early lets Fireside migrate in parallel.
+its tests. Ordering: persistence ports first (sub-step 1) so downstream
+work has the new shape to depend on, then context (sub-step 2) and
+runtime (sub-step 5). Sub-steps 3 and 4 are independent and already in
+review.
 
 1. **`MessageStore` + `MessageStorePostWriteHook` + `SessionStore` split.**
    Splits `ChatPersistenceProvider` into the two per-port protocols and
-   ships the hook protocol alongside. Co-design the hook signature with
-   Fireside before the PR opens — `GraphExtractionService` is the
-   worked example. LOC budget: ~600–900, dominated by test fakes and
-   the persistence adapter implementing both new protocols against the
-   same SwiftData store.
+   ships the hook protocol alongside as a low-level primitive (see the
+   `MessageStore post-write hooks` section for the framing — Fireside's
+   `GraphExtractionService` does *not* attach via this hook). LOC
+   budget: ~600–900, dominated by test fakes and the persistence
+   adapter implementing both new protocols against the same SwiftData
+   store. Hook signature settled per Fireside's reply — no further
+   co-design needed before opening the PR.
 
 2. **`GenerationContextProvider` re-export + `PromptContextPipeline`
-   use case + `ContextContribution` value type.** Acceptance gate
-   triggers here — the `ContextContribution` shape locks for the rest
-   of pre-1.0. After this PR, any change to the context value type
-   requires a coordinated PR pair with Fireside, not a unilateral edit.
-   LOC budget: ~500.
+   passive-merge use case.** Re-exports the existing
+   `GenerationContextProvider` port from `BaseChatRuntime` and adds a
+   passive merge use case that takes `[PromptSlot]` from each
+   registered provider, sorts by `position`, and returns the assembled
+   list. **No new value type** — `[PromptSlot]` is the boundary
+   primitive (already in BCK). Consumers that want a richer aggregate
+   (Fireside's `ContextContribution` with budget accounting and
+   `realCost`) keep that aggregate in their own module. LOC budget:
+   ~250.
 
-3. **Internal port cleanups: `SamplerPresetStore`, `BenchmarkCache`,
-   `EndpointStore`.** Kills the remaining `@Query` / public
-   `ModelContext` leaks listed under Background. Lower priority than
-   1–2 because no downstream is gated on these surfaces; they exist to
-   close the CI-lint loop. May ship as one PR or three. LOC budget:
-   ~400 each.
+3. ✅ **Internal port cleanups: `SamplerPresetStore`, `BenchmarkCache`,
+   `EndpointStore`** — in review as #890. Kills the remaining `@Query`
+   / public `ModelContext` leaks listed under Background.
 
-4. **`InferenceService` interaction prep.** Add nonisolated wrappers
-   (or actor-isolated equivalents) for the operations runtime services
-   call from off-main contexts: `enqueue`, `tokenizer` access,
-   `capabilities` reads. Keeps `InferenceService` `@MainActor` for
-   view-binding but lets runtime services compose it without a per-call
-   hop. Prereq for sub-step 5. LOC budget: ~300.
+4. ✅ **`InferenceService` interaction prep** — in review as #893.
+   Adds `capabilitiesAsync` / `tokenizerAsync` / `enqueueAsync` /
+   `cancelAsync` nonisolated wrappers. Prereq for sub-step 5.
 
 5. **`ConversationRuntime` extraction.** Absorbs `ChatViewModel`'s
-   orchestration — the biggest PR in the phase. Closure-bag → events
-   transformation against the `ConversationEvent` surface above. LOC
-   budget per the original plan: ~4500–5000 vs. 3621 today; if any
-   single PR moves more than ~1500 LOC, split by sub-flow (send vs.
-   regenerate vs. edit) rather than landing one mega-PR.
+   orchestration into the **optional reference** runtime use case.
+   Closure-bag → events transformation against the `ConversationEvent`
+   surface above. Demo and ChatbotUI-iOS adopt; Fireside continues to
+   drive the ports directly. LOC budget per the original plan:
+   ~4500–5000 vs. 3621 today; if any single PR moves more than ~1500
+   LOC, split by sub-flow (send vs. regenerate vs. edit) rather than
+   landing one mega-PR.
 
 **Exit criterion**: no `@Observable` view model owns orchestration
 state. Every state change in UI flows through an event stream.
@@ -447,17 +518,21 @@ Before tagging 1.0:
 - ChatbotUI-iOS builds against the new graph without local patching.
 - Fireside replaces its custom bootstrap with `BaseChatRuntime` +
   custom `MessageStore` / `SessionStore` impls.
-- `GenerationContextProvider` port shape and `ContextContribution`
-  value type are locked at the end of Phase 1.2 and treated as a
-  stable contract for the remainder of the pre-1.0 window. Fireside's
-  `GraphSlotFormatter` outputs become formal `ContextContribution`
-  values without retrofitting. Any change to the `ContextContribution`
-  type after Phase 1.2 ships requires a coordinated PR pair across BCK
-  and Fireside, not a unilateral edit.
-- `MessageStorePostWriteHook` and the load-bearing `ConversationEvent`
-  cases (`.beforeContextAssembly`, `.contextAssembled`,
-  `.afterGeneration`, `.compressionTriggered`) ship in Phase 1.2 and
-  are similarly locked.
+- `GenerationContextProvider` port shape is locked at the end of Phase
+  1.2 and treated as a stable contract for the remainder of the pre-1.0
+  window. The boundary primitive is `[PromptSlot]` (already in BCK).
+  Fireside's `GraphSlotFormatter` outputs continue to be wrapped in
+  Fireside's own `ContextContribution` aggregate; BCK does not ship a
+  competing aggregate type. Any change to `PromptSlot` itself after
+  Phase 1.2 ships requires a coordinated PR pair across BCK and
+  Fireside.
+- `MessageStorePostWriteHook` ships in Phase 1.2 as a low-level
+  primitive. The load-bearing `ConversationEvent` cases for
+  runtime-using consumers (`.beforeContextAssembly`,
+  `.contextAssembled`, `.afterGeneration`, `.compressionTriggered`)
+  and the direct-inference contract (`.tokenEmitted`, `.streamFinished`,
+  `.errorRaised`, plus `.compressionTriggered` when applicable) are
+  pinned at the end of Phase 1.2.
 - Read-back test confirms a pre-refactor SwiftData store opens cleanly
   with no data loss.
 - No `@Observable` view model owns orchestration state.
@@ -507,25 +582,45 @@ doc.
 
 BCK changes:
 - `ChatPersistenceProvider` splits into `SessionStore` + `MessageStore`.
-- `MessageStorePostWriteHook` protocol introduced.
+- `MessageStorePostWriteHook` protocol introduced as a low-level
+  primitive.
 - `GenerationContextProvider` re-exported from `BaseChatRuntime`;
-  `PromptContextPipeline` use case introduced; `ContextContribution`
-  value type pinned.
-- `ConversationRuntime` ships with the `ConversationEvent` surface
-  enumerated above.
+  `PromptContextPipeline` passive-merge use case introduced over
+  `[PromptSlot]`. **No competing `ContextContribution` aggregate
+  ships from BCK** — Fireside's existing aggregate in `FiresideMemory`
+  remains the source of truth on the consumer side.
+- `ConversationRuntime` ships as the **optional reference** use case,
+  with the `ConversationEvent` surface enumerated above.
 
 Fireside changes (same window):
-- Replace Fireside's combined provider impl with separate `SessionStore`
-  + `MessageStore` impls.
-- Migrate `GraphExtractionService` from its current attachment mechanism
-  to `MessageStorePostWriteHook` registration at bootstrap.
-- Migrate `GraphSlotFormatter` outputs to formal `ContextContribution`
-  values; register as a `GenerationContextProvider` contributor through
-  `PromptContextPipeline`.
-- Migrate `StoryStore.send(_:)` from closure-callback orchestration to
-  `AsyncSequence<ConversationEvent>` consumption. The four load-bearing
-  cases are `.beforeContextAssembly`, `.contextAssembled`,
-  `.afterGeneration`, `.compressionTriggered`.
+
+The library-stance reframe means Fireside's adoption is much narrower
+than the earlier draft of this plan implied.
+
+- ✅ No-op: replace combined provider impl with separate `SessionStore`
+  + `MessageStore` impls. Fireside has no custom provider impl today;
+  this is automatic.
+- **Not migrating**: `GraphExtractionService` stays at the
+  turn-orchestrator layer (`StoryStore` post-turn / eventual
+  `StoryTurnObserver` per Fireside's RFC). It does *not* migrate to
+  `MessageStorePostWriteHook` registration. The hook is available if
+  Fireside wants it later for some other concern (audit, indexing);
+  graph extraction has the wrong unit of work for it.
+- **Not migrating**: `GraphSlotFormatter` outputs stay in Fireside's
+  `ContextContribution` aggregate. Fireside conforms to BCK's
+  `GenerationContextProvider` port returning `[PromptSlot]`; the
+  surrounding budget accounting and `realCost` tracking remain in
+  `FiresideMemory`. No retrofit required.
+- **Not migrating**: `StoryStore.send(_:)` continues to drive
+  `InferenceService` directly through the direct-inference contract
+  (`.tokenEmitted`, `.streamFinished`, `.errorRaised`). It does not
+  consume `ConversationEvent` via `ConversationRuntime`.
+- Optional later, on Fireside's timeline: if Fireside ever wants to
+  collapse `StoryStore`'s orchestration into BCK's `ConversationRuntime`,
+  the four load-bearing runtime events
+  (`.beforeContextAssembly`, `.contextAssembled`, `.afterGeneration`,
+  `.compressionTriggered`) are the integration points to hook against.
+  Not on the critical path for either side's pre-1.0 work.
 
 ### Phase 2 — physical target split
 
@@ -554,12 +649,16 @@ Fireside changes (same window):
   the BCK PR before the matching Fireside PR is ready breaks Fireside's
   `main`.
 - Port-shape changes (signatures, event cases, hook protocols,
-  `ContextContribution` shape) require a Fireside reviewer on the BCK
-  PR before merge.
-- The four load-bearing `ConversationEvent` cases and
-  `MessageStorePostWriteHook` are pinned to this appendix. Any
-  deviation is updated here in the same PR that introduces the
-  deviation — the plan is the source of truth, not Slack threads.
+  `PromptSlot` shape) require a Fireside reviewer on the BCK PR before
+  merge.
+- The two pinned event sets — runtime-using
+  (`.beforeContextAssembly`, `.contextAssembled`, `.afterGeneration`,
+  `.compressionTriggered`) and direct-inference (`.tokenEmitted`,
+  `.streamFinished`, `.errorRaised`, plus `.compressionTriggered` when
+  applicable) — and `MessageStorePostWriteHook` are pinned to this
+  appendix. Any deviation is updated here in the same PR that
+  introduces the deviation — the plan is the source of truth, not
+  Slack threads.
 - **Exception — internal-only port cleanups (Phase 1.2 sub-step 3).**
   `SamplerPresetStore`, `BenchmarkCache`, and `EndpointStore` close
   `@Query` / public `ModelContext` leaks that Fireside does not


### PR DESCRIPTION
## Summary

Reframes `docs/plans/runtime-ports-phase-1-2.md` to lock in the **library + optional runtime** stance after Fireside's 2026-04-29 reply to the plan. Docs-only.

## What changed and why

Three substantive reframes:

1. **Library + optional runtime stance.** BCK is a library with a reference runtime, not a runtime with ports. `ConversationRuntime` becomes the **optional reference** use case (demo + ChatbotUI-iOS adopt; Fireside continues to drive ports directly). The 12-case `ConversationEvent` enum is the contract for runtime-using consumers; direct-`InferenceService` consumers (Fireside) get a narrower contract pinned to `.tokenEmitted` / `.streamFinished` / `.errorRaised` (plus `.compressionTriggered` when applicable). Both contracts are documented and pinned in the appendix.

2. **`ContextContribution` not shipped from BCK.** Fireside already ships a `ContextContribution` aggregate in `FiresideMemory` (`[PromptSlot] + realCost`). Sub-step 2 drops the BCK aggregate to avoid a competing type; `PromptContextPipeline` becomes a passive merge over `[PromptSlot]` (already in BCK). Sub-step 2 LOC budget shrinks from ~500 to ~250.

3. **`MessageStorePostWriteHook` reframed as low-level primitive.** Fireside's `GraphExtractionService` does **not** attach via the hook — extraction operates at the turn level (`StoryStore` post-turn / eventual `StoryTurnObserver` per Fireside's RFC), not the per-message-write level. The hook ships for consumers whose unit of work is the message (audit, indexing, debug logging); explicitly not positioned as the canonical extraction seam.

Other edits:
- Drop the dead Fireside-adoption precondition. Fireside consumes BCK via SPM path-ref and has zero custom `ChatPersistenceProvider` impls, zero `onFirstMessage` consumers, and no `SessionManagerViewModel` call sites. The flip was a no-op.
- Status updated to list #890 (sub-step 3) and #893 (sub-step 4) in review.
- Fireside appendix Phase 1.2 section rewritten: most of what the earlier draft asked Fireside to do is now \"not migrating\" under the library stance.
- Coordination protocol updated to reference both pinned event sets and `PromptSlot` as the boundary primitive.

## Why merge this before opening sub-step 1

Sub-step 1 (`MessageStore` + hook) is currently held on this reframe — the original plan positioned the hook as Fireside's extraction attachment point, which Fireside's reply explicitly pushed back on. Once this lands, sub-step 1 is unblocked.

## Test plan

- [x] Docs-only; no code changes.
- [x] No orphan references — grepped `ContextContribution` (5 hits, all correctly framing it as Fireside-owned), `Fireside-gat` / `adoption` (only the explanatory paragraph that documents the reframe).
- [x] All forward-looking type names (`PromptContextRequest`, `ConversationError`, `FinishReason`, `CompressionReason`) appear inside the enum sample only — they ship with sub-step 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)