### PR TITLE
refactor: add PromptContextProvider port + passive merge pipeline (phase 1.2.2)

### DIFF
--- a/Sources/BaseChatCore/Services/PromptContextPipeline.swift
+++ b/Sources/BaseChatCore/Services/PromptContextPipeline.swift
@@ -1,0 +1,75 @@
+import Foundation
+import BaseChatInference
+
+/// Composes a list of ``PromptContextProvider``s into a single sorted
+/// ``[PromptSlot]`` for prompt assembly.
+///
+/// The pipeline is a passive merge: it asks each registered provider for its
+/// slots, concatenates the results, and sorts by
+/// ``PromptSlotPosition/sortIndex(messageCount:)``. Provider errors propagate
+/// out of ``assemble(messageCount:)`` and abort assembly — the pipeline does
+/// not return a partial result.
+///
+/// Providers are queried sequentially in registration order. Concurrent fan-out
+/// would invent ordering risk for ties (positions that share a sort index rely
+/// on the input array's order to remain stable across runs); the sequential
+/// hop is cheap because providers are typically I/O-light.
+///
+/// ## Topology
+///
+/// `PromptContextPipeline` is the slot-merge layer. It does not perform budget
+/// allocation, token counting, or message trimming — that work belongs to
+/// `PromptAssembler` (in `BaseChatInference`). Consumers that want a richer
+/// aggregate (Fireside's `ContextContribution` with `realCost` accounting) keep
+/// that aggregate in their own module. BCK ships the boundary primitive here.
+///
+/// ## Example
+///
+/// ```swift
+/// let pipeline = PromptContextPipeline(providers: [
+///     systemPromptProvider,
+///     loreProvider,
+///     retrievalProvider,
+/// ])
+/// let slots = try await pipeline.assemble(messageCount: history.count)
+/// ```
+///
+/// > Note: Phase 1.2 sub-step 2 ships the use case in isolation; sub-step 5
+/// > wires it into `ConversationRuntime`.
+public final class PromptContextPipeline: Sendable {
+    private let providers: [any PromptContextProvider]
+
+    /// Creates a pipeline that queries `providers` in registration order.
+    ///
+    /// - Parameter providers: The providers to compose. An empty array is a
+    ///   valid pipeline that always returns `[]`.
+    public init(providers: [any PromptContextProvider]) {
+        self.providers = providers
+    }
+
+    /// Asks each registered provider for its slots, concatenates the results,
+    /// and returns them sorted by
+    /// ``PromptSlotPosition/sortIndex(messageCount:)``.
+    ///
+    /// - Parameter messageCount: The conversation message count at assembly
+    ///   time. Forwarded verbatim to every provider so that
+    ///   ``PromptSlotPosition/atDepth(_:)`` can compute its sort index against
+    ///   the same baseline the consumer is about to render against.
+    /// - Returns: All contributed slots, sorted top-to-bottom (lowest sort
+    ///   index first). Slots whose positions tie keep their concatenation
+    ///   order — this is whatever `Array.sorted(by:)` gives, which is stable
+    ///   on the standard library implementation BCK targets.
+    /// - Throws: Whatever a provider throws. The pipeline aborts immediately
+    ///   on the first failure and does not return a partial result.
+    public func assemble(messageCount: Int) async throws -> [PromptSlot] {
+        var merged: [PromptSlot] = []
+        for provider in providers {
+            let contribution = try await provider.contributeSlots(messageCount: messageCount)
+            merged.append(contentsOf: contribution)
+        }
+        return merged.sorted { lhs, rhs in
+            lhs.position.sortIndex(messageCount: messageCount) <
+                rhs.position.sortIndex(messageCount: messageCount)
+        }
+    }
+}

--- a/Sources/BaseChatInference/Protocols/PromptContextProvider.swift
+++ b/Sources/BaseChatInference/Protocols/PromptContextProvider.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// A source of prompt context slots for assembly into a generation request.
+///
+/// Conformers contribute slots based on conversation state; ``PromptContextPipeline``
+/// (in `BaseChatCore`) composes multiple providers into a single sorted
+/// ``[PromptSlot]``.
+///
+/// This is a low-level boundary primitive. Consumers that need richer aggregate
+/// types (budget accounting, cost tracking) layer those on top in their own
+/// modules — see Fireside's `ContextContribution` for prior art.
+///
+/// > Note: This protocol is distinct from the internal `GenerationContextProvider`,
+/// > which is a `@MainActor`-bound, `AnyObject`-constrained model-state provider
+/// > used by `GenerationCoordinator` to read backend / template state. The two
+/// > do not overlap and should not be merged.
+public protocol PromptContextProvider: Sendable {
+    /// Slots to inject into the next prompt.
+    ///
+    /// - Parameter messageCount: The conversation message count at assembly time.
+    ///   Enables ``PromptSlotPosition/atDepth(_:)`` to compute its sort index.
+    /// - Returns: The slots this provider contributes for the upcoming turn.
+    /// - Throws: Errors propagate to ``PromptContextPipeline`` and abort assembly;
+    ///   surfaces that need partial-failure semantics compose at the use-case
+    ///   layer instead.
+    func contributeSlots(messageCount: Int) async throws -> [PromptSlot]
+}

--- a/Sources/BaseChatInference/Services/PromptSlot.swift
+++ b/Sources/BaseChatInference/Services/PromptSlot.swift
@@ -77,7 +77,11 @@ extension PromptSlotPosition {
     /// topOfHistory (2) is the highest history position.
     /// atDepth(n): larger n means higher placement (further from latest turn), so smaller index.
     /// bottomOfHistory sits just above the last message; inline follows all messages.
-    func sortIndex(messageCount: Int) -> Int {
+    ///
+    /// Widened to `public` in Phase 1.2 sub-step 2 so that `PromptContextPipeline`
+    /// (in `BaseChatCore`) can use this comparator to merge `[PromptSlot]` from
+    /// multiple `PromptContextProvider`s.
+    public func sortIndex(messageCount: Int) -> Int {
         switch self {
         case .systemPreamble:   return 0
         case .contextSetup:     return 1

--- a/Tests/BaseChatCoreTests/PromptContextPipelineTests.swift
+++ b/Tests/BaseChatCoreTests/PromptContextPipelineTests.swift
@@ -1,0 +1,203 @@
+import XCTest
+@testable import BaseChatCore
+@testable import BaseChatInference
+
+/// Phase 1.2 sub-step 2 — coverage for the passive-merge use case.
+///
+/// Each test exercises a single behavioural property: provider count,
+/// per-provider order independence, error propagation, tie-breaking, and
+/// `messageCount` plumbing. Sabotage notes per test were verified locally
+/// (temporarily breaking the assertion target made the test fail) and removed
+/// before commit, per CLAUDE.md test conventions.
+final class PromptContextPipelineTests: XCTestCase {
+
+    // MARK: - Fakes
+
+    /// In-test conformer that returns a fixed slot list. Records the
+    /// `messageCount` it was called with so tests can assert plumbing.
+    private struct FakeProvider: PromptContextProvider {
+        let slots: [PromptSlot]
+        let receivedCount: SendableBox<Int?>
+
+        init(slots: [PromptSlot], receivedCount: SendableBox<Int?> = .init(nil)) {
+            self.slots = slots
+            self.receivedCount = receivedCount
+        }
+
+        func contributeSlots(messageCount: Int) async throws -> [PromptSlot] {
+            receivedCount.value = messageCount
+            return slots
+        }
+    }
+
+    /// Provider that always throws. Used to assert error propagation.
+    private struct ThrowingProvider: PromptContextProvider {
+        struct Boom: Error, Equatable {}
+        func contributeSlots(messageCount: Int) async throws -> [PromptSlot] {
+            throw Boom()
+        }
+    }
+
+    /// `Sendable` reference cell for capturing call arguments out of a
+    /// `Sendable` provider value type. The test runs single-threaded, so a
+    /// plain class with a mutable property is safe under `@unchecked`.
+    private final class SendableBox<T>: @unchecked Sendable {
+        var value: T
+        init(_ value: T) { self.value = value }
+    }
+
+    // MARK: - Helpers
+
+    private func slot(
+        id: String,
+        position: PromptSlotPosition,
+        content: String = "x"
+    ) -> PromptSlot {
+        PromptSlot(
+            id: id,
+            content: content,
+            position: position,
+            label: id
+        )
+    }
+
+    // MARK: - Tests
+
+    func test_singleProvider_returnsItsSlotsSortedByPosition() async throws {
+        let bottom = slot(id: "bottom", position: .bottomOfHistory)
+        let top = slot(id: "top", position: .systemPreamble)
+        let middle = slot(id: "middle", position: .contextSetup)
+
+        let provider = FakeProvider(slots: [bottom, top, middle])
+        let pipeline = PromptContextPipeline(providers: [provider])
+
+        let result = try await pipeline.assemble(messageCount: 3)
+
+        XCTAssertEqual(result.map(\.id), ["top", "middle", "bottom"])
+    }
+
+    func test_multipleProviders_concatenateAndSortByPosition() async throws {
+        let p1 = FakeProvider(slots: [
+            slot(id: "p1-bottom", position: .bottomOfHistory),
+            slot(id: "p1-system", position: .systemPreamble),
+        ])
+        let p2 = FakeProvider(slots: [
+            slot(id: "p2-context", position: .contextSetup),
+            slot(id: "p2-inline", position: .inline),
+        ])
+
+        let pipeline = PromptContextPipeline(providers: [p1, p2])
+        let result = try await pipeline.assemble(messageCount: 5)
+
+        XCTAssertEqual(
+            result.map(\.id),
+            ["p1-system", "p2-context", "p1-bottom", "p2-inline"]
+        )
+    }
+
+    func test_providerOrder_doesNotAffectFinalOrderWhenPositionsDisagree() async throws {
+        let pA = FakeProvider(slots: [slot(id: "system", position: .systemPreamble)])
+        let pB = FakeProvider(slots: [slot(id: "context", position: .contextSetup)])
+
+        let resultAB = try await PromptContextPipeline(providers: [pA, pB])
+            .assemble(messageCount: 2)
+        let resultBA = try await PromptContextPipeline(providers: [pB, pA])
+            .assemble(messageCount: 2)
+
+        XCTAssertEqual(resultAB.map(\.id), ["system", "context"])
+        XCTAssertEqual(resultBA.map(\.id), ["system", "context"])
+    }
+
+    func test_emptyProvider_returnsUnionOfOthers() async throws {
+        let empty = FakeProvider(slots: [])
+        let real = FakeProvider(slots: [
+            slot(id: "a", position: .systemPreamble),
+            slot(id: "b", position: .contextSetup),
+        ])
+
+        let pipeline = PromptContextPipeline(providers: [empty, real, empty])
+        let result = try await pipeline.assemble(messageCount: 0)
+
+        XCTAssertEqual(result.map(\.id), ["a", "b"])
+    }
+
+    func test_emptyPipeline_returnsEmpty() async throws {
+        let pipeline = PromptContextPipeline(providers: [])
+        let result = try await pipeline.assemble(messageCount: 7)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func test_providerThrows_pipelinePropagatesAndDoesNotReturnPartial() async {
+        let before = FakeProvider(slots: [slot(id: "before", position: .systemPreamble)])
+        let throwing = ThrowingProvider()
+        let after = FakeProvider(slots: [slot(id: "after", position: .inline)])
+
+        let pipeline = PromptContextPipeline(providers: [before, throwing, after])
+
+        do {
+            _ = try await pipeline.assemble(messageCount: 1)
+            XCTFail("expected pipeline to throw")
+        } catch let error as ThrowingProvider.Boom {
+            // Expected: the specific error from the failing provider propagates.
+            _ = error
+        } catch {
+            XCTFail("expected ThrowingProvider.Boom; got \(error)")
+        }
+    }
+
+    func test_positionTieBreak_isStableInProviderOrder() async throws {
+        // Two slots at the same position from a single provider should keep
+        // their input-array order. `Array.sorted(by:)` is documented stable
+        // on Swift 5+, but the brief says to lock the actual behaviour rather
+        // than over-specify.
+        let p1 = FakeProvider(slots: [
+            slot(id: "p1-first", position: .contextSetup),
+            slot(id: "p1-second", position: .contextSetup),
+        ])
+        let p2 = FakeProvider(slots: [
+            slot(id: "p2-first", position: .contextSetup),
+        ])
+
+        let pipeline = PromptContextPipeline(providers: [p1, p2])
+        let result = try await pipeline.assemble(messageCount: 3)
+
+        XCTAssertEqual(
+            result.map(\.id),
+            ["p1-first", "p1-second", "p2-first"]
+        )
+    }
+
+    func test_messageCount_flowsToProviders() async throws {
+        let captureA = SendableBox<Int?>(nil)
+        let captureB = SendableBox<Int?>(nil)
+
+        let pA = FakeProvider(slots: [], receivedCount: captureA)
+        let pB = FakeProvider(slots: [], receivedCount: captureB)
+
+        let pipeline = PromptContextPipeline(providers: [pA, pB])
+        _ = try await pipeline.assemble(messageCount: 42)
+
+        XCTAssertEqual(captureA.value, 42)
+        XCTAssertEqual(captureB.value, 42)
+    }
+
+    func test_messageCount_drivesAtDepthSortIndex() async throws {
+        // `.atDepth(n)` sorts as `2 + (messageCount - n)`. For mc=10, n=1 sorts
+        // higher than n=9 (closer to the latest turn). The sort must be re-run
+        // against the messageCount the caller passes in, not a cached value.
+        let provider = FakeProvider(slots: [
+            slot(id: "deep", position: .atDepth(9)),
+            slot(id: "shallow", position: .atDepth(1)),
+        ])
+
+        let pipeline = PromptContextPipeline(providers: [provider])
+        let result = try await pipeline.assemble(messageCount: 10)
+
+        // sortIndex with mc=10: deep -> 2 + (10-9) = 3; shallow -> 2 + (10-1) = 11.
+        // So `deep` precedes `shallow`.
+        XCTAssertEqual(result.map(\.id), ["deep", "shallow"])
+    }
+}
+
+// `PromptSlot` is `Identifiable` but not `Equatable` in BCK today; tests above
+// compare on `id` only, which is enough for the assertions made here.

--- a/docs/plans/runtime-ports-phase-1-2.md
+++ b/docs/plans/runtime-ports-phase-1-2.md
@@ -46,7 +46,7 @@ BCK is a **library with a reference runtime, not a runtime with ports.**
 This stance is load-bearing for everything below; if it changes the
 whole plan changes.
 
-- BCK ships ports (`MessageStore`, `SessionStore`, `GenerationContextProvider`,
+- BCK ships ports (`MessageStore`, `SessionStore`, `PromptContextProvider`,
   etc.) and a reference use case (`ConversationRuntime`) that composes
   them into a turn loop.
 - `ConversationRuntime` is **optional**. Demo and ChatbotUI-iOS adopt
@@ -58,7 +58,7 @@ whole plan changes.
   consumers (Fireside) get a different, narrower contract.
 - `ContextContribution` as an aggregate value type lives in the
   consumer (Fireside has `[PromptSlot] + realCost`). BCK ships
-  `PromptSlot` (already does), the `GenerationContextProvider` port,
+  `PromptSlot` (already does), the new `PromptContextProvider` port,
   and `PromptContextPipeline` as a passive merge over `[PromptSlot]`.
   No competing aggregate type in BCK.
 
@@ -88,7 +88,7 @@ is settled — see `MessageStore post-write hooks` below. Fireside's
 the turn-orchestrator layer, see Fireside appendix); the hook ships as
 a low-level primitive available to consumers who want it.
 
-After 1.2.1: `GenerationContextProvider` re-export + `PromptContextPipeline`
+After 1.2.1: `PromptContextProvider` port + `PromptContextPipeline`
 passive-merge use case (1.2.2 — no new value type ships). Then
 `ConversationRuntime` extraction as the optional reference use case at
 1.2.5. Phase 1.2 sub-steps 3 (internal port cleanups) and 4
@@ -114,7 +114,7 @@ hosted in Inference). The Phase 1.0 work (#883, #885) formalised the
 async surface across the persistence and command boundary; Phase 1.1
 (#886) extracted session-list orchestration into a service with an
 event stream. What remains is the broader port extraction
-(`MessageStore`, `GenerationContextProvider`, `ConversationRuntime`,
+(`MessageStore`, `PromptContextProvider`, `ConversationRuntime`,
 etc.) and the physical target split (`BaseChatRuntime` /
 `BaseChatPersistenceSwiftData` / delete `BaseChatCore`).
 
@@ -208,7 +208,7 @@ class rename and the new target arrive together.
 | 3 | **Records at the boundary.** | `ChatSessionRecord`, `ChatMessageRecord`, `APIEndpointRecord` already live in Inference. Every port traffics in records, not `@Model` types. |
 | 4 | **Events out, commands in.** | Use cases expose `AsyncSequence<Event>` for state changes and `async throws` commands for actions. UI adapters subscribe and republish — no closure-bag wiring across boundaries. |
 | 5 | **Secrets and network policy stay out of runtime.** | Keychain, `URLSession`, trust delegates, OAuth live in Inference (where they already are) or in adapters. |
-| 6 | **Context injection is a first-class port.** | Fireside needs a structured way to supply story/memory/profile context. `GenerationContextProvider` already exists in Inference — runtime exposes a port that wraps it. |
+| 6 | **Context injection is a first-class port.** | Fireside needs a structured way to supply story/memory/profile context. `PromptContextProvider` is the new slot-contributor port introduced in Phase 1.2 sub-step 2; consumers conform and the runtime composes them via `PromptContextPipeline`. |
 | 7 | **Ports are async at the use-case surface, sync at the implementation.** | `ChatPersistenceProvider` is already `async throws` (#883); the rule still applies to every new port added in Phase 1.2. SwiftData `ModelContext` is `@MainActor`-bound; `async` at the boundary lets the use case yield without blocking. |
 
 ## Proposed runtime surface
@@ -224,7 +224,7 @@ class rename and the new target arrive together.
 | `BenchmarkCache` | `ModelManagementViewModel.modelContext: ModelContext?` |
 | `ModelCatalog` | `ModelManagementViewModel`'s direct disk inspection |
 | `TitleGenerator` | `SessionManagerViewModel.generateTitle` calling `InferenceService` directly |
-| `GenerationContextProvider` (re-exported) | already exists in Inference — runtime exposes it |
+| `PromptContextProvider` | new — the slot-contributor port for context assembly. (Distinct from the internal `GenerationContextProvider` in `BaseChatInference`, which is a `@MainActor`-bound model-state provider used by `GenerationCoordinator` — that protocol stays internal and unchanged.) |
 | `ToolSource` | generalises today's `MCPToolSource` pattern |
 
 `ChatPersistenceProvider` is split into `SessionStore` + `MessageStore`.
@@ -288,7 +288,7 @@ Use cases compose ports into a turn loop or other workflow. They are
 | `SessionListService` | ✅ shipped (#886, `Sources/BaseChatUI/ViewModels/SessionListService.swift`) | `SessionManagerViewModel`'s CRUD/search/pagination/title generation | `AsyncStream<SessionListEvent>` + commands |
 | `ConversationRuntime` | forward-looking, **optional reference** | `ChatViewModel`'s send/cancel/regenerate/edit/branch logic, `GenerationCoordinator` (UI-side), `ModelLoadCoordinator` | `AsyncSequence<ConversationEvent>` + commands |
 | `ModelManagementService` | forward-looking | `ModelManagementViewModel`'s discovery/download/delete/benchmark | `AsyncSequence<ModelCatalogEvent>` + commands |
-| `PromptContextPipeline` | forward-looking | new — passive merge over `[PromptSlot]` from registered `GenerationContextProvider`s | `[PromptSlot]` |
+| `PromptContextPipeline` | ✅ shipped (#TBD, sub-step 2; `Sources/BaseChatCore/Services/PromptContextPipeline.swift`) | new — passive merge over `[PromptSlot]` from registered `PromptContextProvider`s | `[PromptSlot]` |
 
 #### `ConversationEvent` cases
 
@@ -434,16 +434,22 @@ review.
    store. Hook signature settled per Fireside's reply — no further
    co-design needed before opening the PR.
 
-2. **`GenerationContextProvider` re-export + `PromptContextPipeline`
-   passive-merge use case.** Re-exports the existing
-   `GenerationContextProvider` port from `BaseChatRuntime` and adds a
-   passive merge use case that takes `[PromptSlot]` from each
-   registered provider, sorts by `position`, and returns the assembled
-   list. **No new value type** — `[PromptSlot]` is the boundary
-   primitive (already in BCK). Consumers that want a richer aggregate
-   (Fireside's `ContextContribution` with budget accounting and
-   `realCost`) keep that aggregate in their own module. LOC budget:
-   ~250.
+2. **`PromptContextProvider` port + `PromptContextPipeline` passive-merge
+   use case.** Introduces `PromptContextProvider` as a new public
+   protocol in `BaseChatInference` (`Sendable`, no `@MainActor` pin,
+   bare `messageCount: Int` argument; throws propagate). Pairs it with
+   `PromptContextPipeline` in `BaseChatCore` — a passive merge use case
+   that asks each registered provider for slots, concatenates, sorts by
+   `PromptSlotPosition.sortIndex(messageCount:)`, and returns the
+   assembled `[PromptSlot]`. **No new value type** — `[PromptSlot]` is
+   the boundary primitive (already in BCK). The new protocol is
+   deliberately named to avoid colliding with the existing internal
+   `GenerationContextProvider` (`@MainActor`-bound, `AnyObject`-constrained
+   model-state provider used by `GenerationCoordinator`); they have
+   different shapes, different consumers, and live alongside each
+   other. Consumers that want a richer aggregate (Fireside's
+   `ContextContribution` with budget accounting and `realCost`) keep
+   that aggregate in their own module. LOC budget: ~250.
 
 3. ✅ **Internal port cleanups: `SamplerPresetStore`, `BenchmarkCache`,
    `EndpointStore`** — in review as #890. Kills the remaining `@Query`
@@ -518,7 +524,7 @@ Before tagging 1.0:
 - ChatbotUI-iOS builds against the new graph without local patching.
 - Fireside replaces its custom bootstrap with `BaseChatRuntime` +
   custom `MessageStore` / `SessionStore` impls.
-- `GenerationContextProvider` port shape is locked at the end of Phase
+- `PromptContextProvider` port shape is locked at the end of Phase
   1.2 and treated as a stable contract for the remainder of the pre-1.0
   window. The boundary primitive is `[PromptSlot]` (already in BCK).
   Fireside's `GraphSlotFormatter` outputs continue to be wrapped in
@@ -584,11 +590,12 @@ BCK changes:
 - `ChatPersistenceProvider` splits into `SessionStore` + `MessageStore`.
 - `MessageStorePostWriteHook` protocol introduced as a low-level
   primitive.
-- `GenerationContextProvider` re-exported from `BaseChatRuntime`;
-  `PromptContextPipeline` passive-merge use case introduced over
-  `[PromptSlot]`. **No competing `ContextContribution` aggregate
-  ships from BCK** — Fireside's existing aggregate in `FiresideMemory`
-  remains the source of truth on the consumer side.
+- `PromptContextProvider` introduced as a new public port in
+  `BaseChatInference`; `PromptContextPipeline` passive-merge use case
+  introduced over `[PromptSlot]` in `BaseChatCore` (will move to
+  `BaseChatRuntime` in Phase 2). **No competing `ContextContribution`
+  aggregate ships from BCK** — Fireside's existing aggregate in
+  `FiresideMemory` remains the source of truth on the consumer side.
 - `ConversationRuntime` ships as the **optional reference** use case,
   with the `ConversationEvent` surface enumerated above.
 
@@ -608,7 +615,7 @@ than the earlier draft of this plan implied.
   graph extraction has the wrong unit of work for it.
 - **Not migrating**: `GraphSlotFormatter` outputs stay in Fireside's
   `ContextContribution` aggregate. Fireside conforms to BCK's
-  `GenerationContextProvider` port returning `[PromptSlot]`; the
+  `PromptContextProvider` port returning `[PromptSlot]`; the
   surrounding budget accounting and `realCost` tracking remain in
   `FiresideMemory`. No retrofit required.
 - **Not migrating**: `StoryStore.send(_:)` continues to drive


### PR DESCRIPTION
## Summary

Phase 1.2 sub-step 2 of the runtime ports refactor (per #889 / #894).

- Introduces `PromptContextProvider` as a new **public** protocol in `BaseChatInference` — `Sendable`, no `@MainActor` pin, bare `messageCount: Int` argument; throws propagate.
- Adds `PromptContextPipeline` in `BaseChatCore` — a passive-merge use case that asks each registered provider for slots, concatenates, sorts by `PromptSlotPosition.sortIndex(messageCount:)`, and returns the assembled `[PromptSlot]`.
- No new aggregate value type ships from BCK — `[PromptSlot]` is the boundary primitive. Consumers that want richer accounting (Fireside's `ContextContribution` with `realCost`) keep that aggregate in their own module.
- Plan-doc correction: 9 references in `docs/plans/runtime-ports-phase-1-2.md` updated from `GenerationContextProvider` (re-exported) to `PromptContextProvider` (new).

## Why a new protocol, not a re-export

The plan's earlier framing — "re-export the existing `GenerationContextProvider`" — was based on a misread. The existing `GenerationContextProvider` in `Sources/BaseChatInference/Protocols/GenerationContextProvider.swift` is a `@MainActor`-bound, `AnyObject`-constrained **internal** model-state provider whose sole conformer is `InferenceService` (it surfaces `currentBackend` / `isBackendLoaded` / `selectedPromptTemplate` to `GenerationCoordinator`). It has nothing to do with slot contribution.

The slot-contributor port simply didn't exist. This PR introduces it under the `PromptContextProvider` name to pair naturally with `PromptContextPipeline` and avoid the collision. The two protocols have different shapes, different consumers, and live alongside. The plan doc now calls this out explicitly in the Ports table.

## Touch points outside the new files

- `PromptSlotPosition.sortIndex(messageCount:)` widened from internal to **public** so `PromptContextPipeline` (in `BaseChatCore`) can reuse the existing comparator. No call-site changes required — same comparator.
- `docs/plans/runtime-ports-phase-1-2.md` rewritten in 9 locations (Stance, Background, principle #6, Ports table, Use cases table, sub-step description, acceptance criterion, Fireside appendix). Two remaining `GenerationContextProvider` mentions are explicit clarifications that the internal protocol stays put.

## Test plan

- [x] `BaseChatCoreTests` — 9 new `PromptContextPipelineTests` cases pass:
  - Single provider returns its slots, sorted by position.
  - Multiple providers concatenate and sort; provider order does not affect final order when positions disagree.
  - Empty provider returns the union of others.
  - Empty pipeline returns empty.
  - Provider throws → pipeline propagates the exact error and does not return a partial result.
  - Position tie-breaking is stable in concatenation order (locks the actual `Array.sorted(by:)` behaviour).
  - `messageCount` flows verbatim to every provider.
  - `messageCount` drives `atDepth(_:)` sort indices (mc=10, n=1 sorts after n=9).
- [x] Per-test sabotage checks (verified locally, reverted before commit):
  - Skip the sort → 3 tests fail.
  - Skip provider iteration → 8 tests fail (only `test_emptyPipeline_returnsEmpty` correctly still passes since `[]` is correct there).
  - Hardcode `messageCount=0` → `test_messageCount_flowsToProviders` fails.
  - Swallow provider errors with `try?` → `test_providerThrows_pipelinePropagatesAndDoesNotReturnPartial` fails.
  - Reverse provider iteration → `test_positionTieBreak_isStableInProviderOrder` fails.
- [x] Full CI-safe pre-push suite green: `BaseChatCoreTests`, `BaseChatInferenceTests`, `BaseChatInferenceSwiftTestingTests`, `BaseChatUITests`, `BaseChatUIModelManagementTests`, `BaseChatMCPTests`, `BaseChatBackendsTests`, `BaseChatTestSupportTests`, `BaseChatAppIntentsTests`.

## Out of scope

- Wiring `PromptContextPipeline` into `BaseChatRuntime` — sub-step 5 (`ConversationRuntime` extraction) does that.
- Conforming `InferenceService` or any existing type to the new protocol — providers will be wired in by `ConversationRuntime` consumers (demo, ChatbotUI-iOS) and by Fireside in the same window.
- Touching the existing internal `GenerationContextProvider` — out of scope by explicit decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)