### PR TITLE
fix(openai): exclude jsonMode from Codable and add Ollama format key

### DIFF
--- a/Sources/BaseChatBackends/OpenAIBackend.swift
+++ b/Sources/BaseChatBackends/OpenAIBackend.swift
@@ -164,6 +164,10 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             "max_tokens": config.maxOutputTokens ?? 2048
         ]
         if config.jsonMode {
+            // OpenAI-native providers accept `response_format`; Ollama's
+            // OpenAI-compatible adapter looks for the legacy top-level
+            // `format: "json"` switch.
+            body["format"] = "json"
             body["response_format"] = ["type": "json_object"]
         }
 

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -90,7 +90,9 @@ public struct GenerationConfig: Sendable, Codable {
 
     /// Requests backend-specific JSON-object-only generation for this call.
     ///
-    /// Defaults to `false`. Backends that do not support structured output, or
+    /// Runtime-only flag: defaults to `false` and is intentionally excluded
+    /// from Codable persistence, matching other per-request hints like
+    /// ``thinkingMarkers``. Backends that do not support structured output, or
     /// have not implemented JSON-mode wiring yet, silently ignore this flag.
     public var jsonMode: Bool
 
@@ -255,7 +257,7 @@ public struct GenerationConfig: Sendable, Codable {
 
     private enum CodingKeys: String, CodingKey {
         case temperature, topP, repeatPenalty, maxTokens, topK, typicalP, maxOutputTokens
-        case tools, toolChoice, maxThinkingTokens, jsonMode, maxToolIterations, grammar
+        case tools, toolChoice, maxThinkingTokens, maxToolIterations, grammar
         case yieldEveryNTokens
         case streamPrefillProgress
         case minP, repetitionPenalty, seed
@@ -277,7 +279,9 @@ public struct GenerationConfig: Sendable, Codable {
         tools = (try c.decodeIfPresent([ToolDefinition].self, forKey: .tools)) ?? []
         toolChoice = (try c.decodeIfPresent(ToolChoice.self, forKey: .toolChoice)) ?? .auto
         maxThinkingTokens = try c.decodeIfPresent(Int.self, forKey: .maxThinkingTokens)
-        jsonMode = (try c.decodeIfPresent(Bool.self, forKey: .jsonMode)) ?? false
+        // jsonMode is a per-request runtime hint; persisted payloads always decode
+        // with the canonical default regardless of any legacy on-disk key.
+        jsonMode = false
         streamPrefillProgress = (try c.decodeIfPresent(Bool.self, forKey: .streamPrefillProgress)) ?? false
         // maxToolIterations landed after the original shape; default to 10 when absent and
         // clamp any persisted zero/negative value to the minimum of 1.
@@ -314,7 +318,6 @@ public struct GenerationConfig: Sendable, Codable {
         try c.encode(tools, forKey: .tools)
         try c.encode(toolChoice, forKey: .toolChoice)
         try c.encodeIfPresent(maxThinkingTokens, forKey: .maxThinkingTokens)
-        try c.encode(jsonMode, forKey: .jsonMode)
         try c.encode(streamPrefillProgress, forKey: .streamPrefillProgress)
         try c.encode(maxToolIterations, forKey: .maxToolIterations)
         try c.encodeIfPresent(grammar, forKey: .grammar)

--- a/Tests/BaseChatBackendsTests/OpenAIBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/OpenAIBackendTests.swift
@@ -140,7 +140,7 @@ final class OpenAIBackendTests: XCTestCase {
                      "plan.effectiveContextSize must not appear in the request body")
     }
 
-    func test_buildRequest_jsonModeEnabled_addsResponseFormat() throws {
+    func test_buildRequest_jsonModeEnabled_addsFormatAndResponseFormat() throws {
         let backend = OpenAIBackend()
         backend.configure(
             baseURL: URL(string: "https://api.openai.com")!,
@@ -155,12 +155,13 @@ final class OpenAIBackendTests: XCTestCase {
         )
         let body = try XCTUnwrap(request.httpBody)
         let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(json["format"] as? String, "json")
         let responseFormat = try XCTUnwrap(json["response_format"] as? [String: Any])
 
         XCTAssertEqual(responseFormat["type"] as? String, "json_object")
     }
 
-    func test_buildRequest_jsonModeDisabled_omitsResponseFormat() throws {
+    func test_buildRequest_jsonModeDisabled_omitsFormatAndResponseFormat() throws {
         let backend = OpenAIBackend()
         backend.configure(
             baseURL: URL(string: "https://api.openai.com")!,
@@ -176,6 +177,7 @@ final class OpenAIBackendTests: XCTestCase {
         let body = try XCTUnwrap(request.httpBody)
         let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
 
+        XCTAssertNil(json["format"])
         XCTAssertNil(json["response_format"])
     }
 

--- a/Tests/BaseChatInferenceTests/GenerationConfigTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationConfigTests.swift
@@ -85,6 +85,31 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertTrue(config.jsonMode)
     }
 
+    func test_codable_omitsJsonMode_evenWhenTrue() throws {
+        let config = GenerationConfig(jsonMode: true)
+
+        let data = try JSONEncoder().encode(config)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertNil(json["jsonMode"])
+    }
+
+    func test_codable_decode_resetsRuntimeOnlyJsonModeToFalse() throws {
+        let payload = """
+        {
+            "temperature": 0.7,
+            "topP": 0.9,
+            "repeatPenalty": 1.1,
+            "maxTokens": 512,
+            "jsonMode": true
+        }
+        """
+        let data = try XCTUnwrap(payload.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: data)
+
+        XCTAssertFalse(decoded.jsonMode)
+    }
+
     func test_streamPrefillProgress_isMutable() {
         var config = GenerationConfig()
         config.streamPrefillProgress = true
@@ -184,7 +209,6 @@ final class GenerationConfigTests: XCTestCase {
             "repeatPenalty": 1.1,
             "tools": [],
             "toolChoice": {"type": "auto"},
-            "jsonMode": false,
             "maxToolIterations": 10
         }
         """

--- a/Tests/BaseChatInferenceTests/ToolCallContractTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolCallContractTests.swift
@@ -134,7 +134,8 @@ final class ToolCallContractTests: XCTestCase {
     }
 
     func test_generationConfig_existingProperties_unaffected() throws {
-        // Adding tools/toolChoice/jsonMode fields must not break existing serialised GenerationConfig values.
+        // Adding tools/toolChoice plus the runtime-only jsonMode field must not
+        // break existing serialised GenerationConfig values.
         let config = GenerationConfig(temperature: 0.8, topP: 0.95, maxOutputTokens: 512)
 
         let encoded = try JSONEncoder().encode(config)
@@ -149,7 +150,7 @@ final class ToolCallContractTests: XCTestCase {
         XCTAssertFalse(decoded.jsonMode)
     }
 
-    func test_generationConfig_roundTrips_jsonMode() throws {
+    func test_generationConfig_codable_omitsRuntimeOnlyJsonMode() throws {
         let config = GenerationConfig(
             temperature: 0.8,
             topP: 0.95,
@@ -158,14 +159,17 @@ final class ToolCallContractTests: XCTestCase {
         )
 
         let encoded = try JSONEncoder().encode(config)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
         let decoded = try JSONDecoder().decode(GenerationConfig.self, from: encoded)
 
-        XCTAssertTrue(decoded.jsonMode)
+        XCTAssertNil(json["jsonMode"])
+        XCTAssertFalse(decoded.jsonMode)
     }
 
     func test_generationConfig_decodesLegacyJSON_withoutToolsOrToolChoice() throws {
-        // Payloads serialised before the tools/toolChoice/jsonMode fields were introduced must
-        // decode successfully, falling back to the canonical defaults ([] / .auto / false).
+        // Payloads serialised before the tools/toolChoice fields were introduced
+        // must decode successfully, falling back to the canonical defaults
+        // ([] / .auto / false for the runtime-only jsonMode flag).
         // Sabotage check: using `decode` instead of `decodeIfPresent` in init(from:)
         // causes a keyNotFound DecodingError here.
         let legacyJSON = """


### PR DESCRIPTION
## Summary

- Removes `jsonMode` from `GenerationConfig`'s `CodingKeys`, encoder, and decoder — treating it as a runtime-only per-request hint (matching `thinkingMarkers` semantics). Legacy payloads with a stale `"jsonMode": true` silently reset to `false` on decode; this is intentional and the right migration behavior.
- Adds `body["format"] = "json"` alongside `response_format` in `OpenAIBackend` when `jsonMode` is enabled. Ollama's OpenAI-compatible adapter requires the legacy top-level `format` key; native OpenAI providers use `response_format` only. Both keys are harmlessly ignored by the other provider.

## Test plan

- [x] `test_codable_omitsJsonMode_evenWhenTrue` — encoder no longer emits `"jsonMode"` key
- [x] `test_codable_decode_resetsRuntimeOnlyJsonModeToFalse` — legacy payloads with `"jsonMode": true` decode to `false`
- [x] `test_buildRequest_jsonModeEnabled_addsFormatAndResponseFormat` — both `format` and `response_format` present when enabled
- [x] `test_buildRequest_jsonModeDisabled_omitsFormatAndResponseFormat` — neither key present when disabled
- [x] `test_generationConfig_codable_omitsRuntimeOnlyJsonMode` — encode/decode contract updated
- [x] All CI-safe suites pass locally with `--disable-default-traits`

🤖 Generated with [Claude Code](https://claude.com/claude-code)