### PR TITLE
feat: add vision attachments to mlx chat flow

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "822e7397ae96dd02d4248ee66c7529690c70da5f6ca71b458bed149c609f53de",
+  "originHash" : "612e8e5ee7beda53e681155a356a8fac4105a5450337d91c4442f2d558edca25",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -8,33 +8,6 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "llama.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattt/llama.swift",
-      "state" : {
-        "revision" : "71e4c6366087d7dc995b387a2cdf931399e1710c",
-        "version" : "2.8954.0"
-      }
-    },
-    {
-      "identity" : "mlx-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift.git",
-      "state" : {
-        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
-        "version" : "0.31.3"
-      }
-    },
-    {
-      "identity" : "mlx-swift-lm",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
-      "state" : {
-        "revision" : "1c05248bb0899e2a7a4962b84d319cf12f4e12aa",
-        "version" : "3.31.3"
       }
     },
     {
@@ -92,30 +65,12 @@
       }
     },
     {
-      "identity" : "swift-jinja",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-jinja.git",
-      "state" : {
-        "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
-        "version" : "2.3.5"
-      }
-    },
-    {
       "identity" : "swift-nio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
         "revision" : "558f24a4647193b5a0e2104031b71c55d31ff83a",
         "version" : "2.97.1"
-      }
-    },
-    {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics",
-      "state" : {
-        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
-        "version" : "1.1.1"
       }
     },
     {
@@ -146,15 +101,6 @@
       }
     },
     {
-      "identity" : "swift-transformers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-transformers",
-      "state" : {
-        "revision" : "b38443e44d93eca770f2eb68e2a4d0fa100f9aa2",
-        "version" : "1.3.0"
-      }
-    },
-    {
       "identity" : "viewinspector",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nalexn/ViewInspector",
@@ -170,15 +116,6 @@
       "state" : {
         "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
         "version" : "1.9.0"
-      }
-    },
-    {
-      "identity" : "yyjson",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ibireme/yyjson.git",
-      "state" : {
-        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
-        "version" : "0.12.0"
       }
     }
   ],

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ See [docs/SCOPE_DECISION.md](docs/SCOPE_DECISION.md) for the scoping rationale b
 ## Features
 
 - **Multiple inference backends** — GGUF (llama.cpp), MLX (Apple Silicon), Apple Foundation Models, OpenAI, Claude, Ollama, LM Studio, and custom OpenAI-compatible APIs
+- **Vision-aware attachments** — `ChatInputBar` surfaces image attachments only when the active backend reports vision support; text-only backends fail fast on image parts instead of silently dropping them
 - **Complete SwiftUI interface** — Chat view, session management, model browser, generation settings, export
 - **HuggingFace integration** — Search, browse, and download models directly from the Hub
 - **Background downloads** — iOS background transfer support with progress tracking and GGUF/MLX validation

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -1,4 +1,5 @@
 #if MLX
+import CoreImage
 import Foundation
 import MLX
 import MLXLLM
@@ -66,7 +67,28 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
 
     // MARK: - Capabilities
 
-    public let capabilities: BackendCapabilities
+    public var capabilities: BackendCapabilities {
+        withStateLock {
+            BackendCapabilities(
+                supportedParameters: [.temperature, .topP, .repeatPenalty],
+                maxContextTokens: 8192,
+                requiresPromptTemplate: false,
+                supportsSystemPrompt: true,
+                supportsToolCalling: true,
+                supportsStructuredOutput: false,
+                supportsNativeJSONMode: false,
+                cancellationStyle: .cooperative,
+                supportsTokenCounting: true,
+                memoryStrategy: .resident,
+                maxOutputTokens: 4096,
+                supportsStreaming: true,
+                isRemote: false,
+                supportsKVCachePersistence: enableKVCacheReuse,
+                supportsThinking: true,
+                supportsVision: _supportsVision
+            )
+        }
+    }
 
     // MARK: - Private
 
@@ -84,6 +106,9 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
     /// When non-nil this supersedes `_conversationHistory` for message building.
     /// Access only under `stateLock`.
     private var _toolAwareHistory: [ToolAwareHistoryEntry]?
+    /// Structured conversation history, including image parts for VLM turns.
+    /// Access only under `stateLock`.
+    private var _structuredHistory: [StructuredMessage]?
     /// Thinking-marker pair auto-detected from the loaded model's
     /// `tokenizer_config.json` chat template. `nil` when the model is not
     /// loaded, the chat template is missing, or no known marker pair was
@@ -106,6 +131,9 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
     /// Tracks whether a real MLX model load initialized the runtime in this process.
     /// Access only under `stateLock`.
     private var _hasInitializedRuntime = false
+    /// Whether the currently loaded MLX model accepts image inputs.
+    /// Access only under `stateLock`.
+    private var _supportsVision = false
 
     // MARK: - Load Progress
 
@@ -142,30 +170,14 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
     ) {
         self.cachePolicy = cachePolicy
         self.enableKVCacheReuse = enableKVCacheReuse
-        self.capabilities = BackendCapabilities(
-            supportedParameters: [.temperature, .topP, .repeatPenalty],
-            maxContextTokens: 8192,
-            requiresPromptTemplate: false,
-            supportsSystemPrompt: true,
-            supportsToolCalling: true,
-            supportsStructuredOutput: false,
-            supportsNativeJSONMode: false,
-            cancellationStyle: .cooperative,
-            supportsTokenCounting: true,
-            memoryStrategy: .resident,
-            maxOutputTokens: 4096,
-            supportsStreaming: true,
-            isRemote: false,
-            supportsKVCachePersistence: enableKVCacheReuse,
-            supportsThinking: true
-        )
     }
 
     // MARK: - Architecture Allowlist
 
     /// Canonical `model_type` values that `mlx-swift-lm`'s `LLMTypeRegistry.shared`
-    /// can serve as chat/instruct LMs. Anything outside this set — CLIP, SigLIP,
-    /// Whisper, BERT embeddings, Qwen2-VL vision encoders, etc. — is refused at
+    /// can serve as chat/instruct LMs. Anything outside this set (or the
+    /// VLM-specific set below) — CLIP, SigLIP, Whisper, BERT embeddings, etc. —
+    /// is refused at
     /// load time via `InferenceError.unsupportedModelArchitecture`.
     ///
     /// Sourced from `LLMTypeRegistry.shared` in mlx-swift-lm
@@ -189,6 +201,23 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         "afmoe", "jamba_3b", "mistral3", "apertus",
     ]
 
+    static let supportedVLMArchitectures: Set<String> = [
+        "paligemma", "qwen2_vl", "qwen2_5_vl", "qwen3_vl",
+        "qwen3_5", "qwen3_5_moe", "idefics3", "gemma3", "gemma4",
+        "smolvlm", "fastvlm", "llava_qwen2", "pixtral", "mistral3",
+        "lfm2_vl", "lfm2-vl", "glm_ocr",
+    ]
+
+    private static let normalizedSupportedArchitectures: Set<String> =
+        Set((supportedLMArchitectures.union(supportedVLMArchitectures)).map(normalizeArchitectureKey))
+
+    private static func normalizeArchitectureKey(_ value: String) -> String {
+        value.lowercased().unicodeScalars
+            .filter { CharacterSet.alphanumerics.contains($0) }
+            .map(String.init)
+            .joined()
+    }
+
     /// Reads `config.json` at `url` and throws
     /// `InferenceError.unsupportedModelArchitecture` if the declared `model_type`
     /// is not a chat/instruct LM. If `config.json` is missing or unreadable the
@@ -204,9 +233,10 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         }
 
         let modelType = (json["model_type"] as? String)?
-            .lowercased()
-            .trimmingCharacters(in: .whitespaces) ?? ""
-        if !modelType.isEmpty, supportedLMArchitectures.contains(modelType) {
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let normalizedModelType = normalizeArchitectureKey(modelType)
+        if !normalizedModelType.isEmpty,
+           normalizedSupportedArchitectures.contains(normalizedModelType) {
             return
         }
 
@@ -215,8 +245,8 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         // prefix matches the allowlist — this keeps older snapshots working.
         if let archs = json["architectures"] as? [String] {
             for arch in archs {
-                let normalized = arch.lowercased()
-                if Self.supportedLMArchitectures.contains(where: { normalized.hasPrefix($0) }) {
+                let normalized = normalizeArchitectureKey(arch)
+                if Self.normalizedSupportedArchitectures.contains(where: { normalized.hasPrefix($0) }) {
                     return
                 }
             }
@@ -228,16 +258,25 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
 
     // MARK: - Factory Routing
 
-    /// Returns `true` when the model at `url` declares an MoE config that
-    /// `LLMModelFactory.Gemma4Model` can't handle today. Currently triggers on
-    /// `text_config.enable_moe_block == true` (Gemma 4 26B). Extend here if/when
-    /// other VLM-only LM architectures appear.
+    /// Returns `true` when the model at `url` must load through the VLM factory.
+    ///
+    /// This covers both explicit multimodal models (`vision_config`) and the
+    /// Gemma 4 MoE path that only exists behind `VLMModelFactory` today.
     ///
     /// Falls back to `false` (LLM factory) when config.json is missing/unreadable —
     /// matches the same conservative default used by `validateArchitecture`. Dense
     /// Gemma 4 models intentionally stay on the LLM factory so we don't pay the
     /// memory cost of resident vision-tower weights.
     static func requiresVLMFactory(at url: URL) -> Bool {
+        do {
+            if try ModelCapabilityProbe.probe(modelDirectory: url).supportsVision {
+                return true
+            }
+        } catch {
+            Log.inference.info(
+                "MLX capability probe failed for \(url.lastPathComponent, privacy: .public); falling back to config.json routing (\(error.localizedDescription, privacy: .public))"
+            )
+        }
         let configURL = url.appendingPathComponent("config.json")
         guard let data = try? Data(contentsOf: configURL),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
@@ -263,6 +302,110 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
 
     private static func isSupportedPromptCache(_ caches: [any KVCache]) -> Bool {
         !caches.isEmpty && caches.allSatisfy { $0 is KVCacheSimple }
+    }
+
+    private static func chatRole(for role: String) -> Chat.Message.Role {
+        switch role {
+        case "assistant": .assistant
+        case "system": .system
+        case "tool": .tool
+        default: .user
+        }
+    }
+
+    private static func userInputImage(from data: Data, mimeType: String) throws -> UserInput.Image {
+        guard let image = CIImage(data: data) else {
+            throw InferenceError.inferenceFailure(
+                "Unsupported image attachment format (\(mimeType))."
+            )
+        }
+        return .ciImage(image)
+    }
+
+    private static func imageInputs(from parts: [MessagePart]) throws -> [UserInput.Image] {
+        try parts.compactMap { part in
+            guard case let .image(data, mimeType) = part else { return nil }
+            return try userInputImage(from: data, mimeType: mimeType)
+        }
+    }
+
+    private static func plainChatMessages(
+        history: [StructuredMessage],
+        systemPrompt: String?
+    ) throws -> [Chat.Message]? {
+        let containsImages = history.contains { message in
+            message.parts.contains { part in
+                if case .image = part { return true }
+                return false
+            }
+        }
+        guard containsImages else { return nil }
+
+        var messages: [Chat.Message] = []
+        if let systemPrompt, !systemPrompt.isEmpty {
+            messages.append(.system(systemPrompt))
+        }
+        for message in history {
+            messages.append(
+                Chat.Message(
+                    role: chatRole(for: message.role),
+                    content: message.textContent,
+                    images: try imageInputs(from: message.parts)
+                )
+            )
+        }
+        return messages
+    }
+
+    private static func toolAwareChatMessages(
+        structuredHistory: [StructuredMessage],
+        toolAwareHistory: [ToolAwareHistoryEntry],
+        systemPrompt: String?,
+        dialect: MLXToolDialect
+    ) throws -> [Chat.Message]? {
+        guard structuredHistory.contains(where: { message in
+            message.parts.contains { part in
+                if case .image = part { return true }
+                return false
+            }
+        }) else {
+            return nil
+        }
+
+        var messages: [Chat.Message] = []
+        if let systemPrompt, !systemPrompt.isEmpty {
+            messages.append(.system(systemPrompt))
+        }
+
+        let structuredImageParts = try structuredHistory.map { try imageInputs(from: $0.parts) }
+        for (index, entry) in toolAwareHistory.enumerated() {
+            let encoded = encodeToolAwareEntryAsText(entry, dialect: dialect)
+            let role = encoded["role"] ?? entry.role
+            let content = encoded["content"] ?? entry.content
+            let images = index < structuredImageParts.count ? structuredImageParts[index] : []
+            messages.append(
+                Chat.Message(
+                    role: chatRole(for: role),
+                    content: content,
+                    images: images
+                )
+            )
+        }
+
+        if toolAwareHistory.count < structuredHistory.count {
+            for (offset, structuredMessage) in structuredHistory.dropFirst(toolAwareHistory.count).enumerated() {
+                let images = structuredImageParts[toolAwareHistory.count + offset]
+                messages.append(
+                    Chat.Message(
+                        role: chatRole(for: structuredMessage.role),
+                        content: structuredMessage.textContent,
+                        images: images
+                    )
+                )
+            }
+        }
+
+        return messages
     }
 
     /// Captures prompt-only KV state for the next turn.
@@ -449,6 +592,16 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         await progressHandler?(0.0)
 
         do {
+            let supportsVision: Bool
+            do {
+                supportsVision = try ModelCapabilityProbe.probe(modelDirectory: url).supportsVision
+            } catch {
+                Log.inference.info(
+                    "MLX capability probe failed for \(url.lastPathComponent, privacy: .public); continuing with conservative vision defaults (\(error.localizedDescription, privacy: .public))"
+                )
+                supportsVision = false
+            }
+            let routeThroughVLMFactory = Self.requiresVLMFactory(at: url)
             // Load from a local directory containing config.json + .safetensors.
             // We dispatch directly to either `LLMModelFactory.shared` or
             // `VLMModelFactory.shared` rather than calling the registry-iterating
@@ -458,14 +611,14 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             // would otherwise hand the 26B `gemma4` model to the dense
             // `Gemma4Text.swift` LLM path and fail with "Unhandled keys
             // [experts, router, …]". See issue #752. Dense Gemma 4 variants
-            // stay on the LLM factory — `requiresVLMFactory` only flags
-            // configs that explicitly declare `text_config.enable_moe_block`.
+            // stay on the LLM factory unless the model also declares
+            // `vision_config` or `text_config.enable_moe_block`.
             //
             // `#huggingFaceTokenizerLoader()` (from MLXHuggingFace) adapts
             // swift-transformers' `AutoTokenizer` to the `TokenizerLoader`
             // protocol both factories accept.
             let container: ModelContainer
-            if Self.requiresVLMFactory(at: url) {
+            if routeThroughVLMFactory {
                 Self.logger.info("MLX routing via VLMModelFactory (MoE / VLM-only architecture)")
                 container = try await VLMModelFactory.shared.loadContainer(
                     from: url,
@@ -479,11 +632,12 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             }
             let detectedDialect = MLXToolDialect.detect(at: url)
             let detectedThinkingMarkers = Self.detectThinkingMarkers(at: url)
-            let kvCacheReuseEligible = enableKVCacheReuse && !Self.requiresVLMFactory(at: url)
+            let kvCacheReuseEligible = enableKVCacheReuse && !routeThroughVLMFactory
             withStateLock {
                 _modelContainer = container
                 _dialect = detectedDialect
                 _autoDetectedThinkingMarkers = detectedThinkingMarkers
+                _supportsVision = supportsVision
                 invalidatePromptCacheLocked()
                 _kvCacheReuseEligible = kvCacheReuseEligible
                 _hasInitializedRuntime = true
@@ -567,8 +721,8 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         // Build messages in chat format, using full conversation history when available
         // so multi-turn exchanges retain context. Falls back to the bare prompt when
         // setConversationHistory has not been called (e.g. direct unit-test calls).
-        let (conversationHistory, toolAwareHistory, dialect, autoDetectedMarkers) = withStateLock {
-            (_conversationHistory, _toolAwareHistory, _dialect, _autoDetectedThinkingMarkers)
+        let (conversationHistory, toolAwareHistory, structuredHistory, dialect, autoDetectedMarkers) = withStateLock {
+            (_conversationHistory, _toolAwareHistory, _structuredHistory, _dialect, _autoDetectedThinkingMarkers)
         }
 
         // For Qwen 2.5: serialize tool definitions into a <tools>…</tools> block
@@ -603,10 +757,30 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             return base + toolBlock
         }()
 
-        // All messages are encoded as plain [String: String] dictionaries before the
-        // container applies the tokenizer's chat template. For Qwen 2.5 tool history,
-        // tool calls are text-encoded into content fields using the same
-        // <tool_call>…</tool_call> format the model emits.
+        let chatMessages: [Chat.Message]? =
+            if let structuredHistory, !structuredHistory.isEmpty {
+                if let toolAwareHistory, !toolAwareHistory.isEmpty {
+                    try Self.toolAwareChatMessages(
+                        structuredHistory: structuredHistory,
+                        toolAwareHistory: toolAwareHistory,
+                        systemPrompt: effectiveSystemPrompt,
+                        dialect: dialect
+                    )
+                } else {
+                    try Self.plainChatMessages(
+                        history: structuredHistory,
+                        systemPrompt: effectiveSystemPrompt
+                    )
+                }
+            } else {
+                nil
+            }
+
+        // All non-vision messages are encoded as plain [String: String]
+        // dictionaries before the container applies the tokenizer's chat
+        // template. For Qwen 2.5 tool history, tool calls are text-encoded into
+        // content fields using the same <tool_call>…</tool_call> format the
+        // model emits.
         let messages: [[String: String]] = {
             var msgs: [[String: String]] = []
             if let sp = effectiveSystemPrompt, !sp.isEmpty {
@@ -674,7 +848,12 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 var thinkingTokenCount = 0
                 var thinkingLimitReached = false
 
-                let preparedInput = try await modelContainer.prepare(messages: messages)
+                let preparedInput =
+                    if let chatMessages {
+                        try await modelContainer.prepare(chat: SendableChatMessages(chatMessages))
+                    } else {
+                        try await modelContainer.prepare(messages: messages)
+                    }
                 let cache = try await modelContainer.makeCache(parameters: generateConfig)
                 var generationInput = preparedInput
                 let promptTokenIds: [Int]? = if kvCacheReuseEligible {
@@ -865,10 +1044,16 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
     /// without loading real model weights. Call this before `generate()`.
     ///
     /// Not part of the public API — visible to `BaseChatBackendsTests` via `@testable import`.
-    func _inject(_ container: any MLXModelContainerProtocol) {
+    func _inject(
+        _ container: any MLXModelContainerProtocol,
+        supportsVision: Bool = false,
+        dialect: MLXToolDialect = .unknown
+    ) {
         withStateLock {
             _modelContainer = container
             _isModelLoaded = true
+            _supportsVision = supportsVision
+            _dialect = dialect
             invalidatePromptCacheLocked()
             _kvCacheReuseEligible = enableKVCacheReuse
             _hasInitializedRuntime = false
@@ -914,8 +1099,10 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             _isGenerating = false
             _conversationHistory = []
             _toolAwareHistory = nil
+            _structuredHistory = nil
             _dialect = .unknown
             _autoDetectedThinkingMarkers = nil
+            _supportsVision = false
             invalidatePromptCacheLocked()
             _kvCacheReuseEligible = false
             _hasInitializedRuntime = false
@@ -946,8 +1133,17 @@ extension MLXBackend {
         withStateLock {
             _conversationHistory = []
             _toolAwareHistory = nil
+            _structuredHistory = nil
             invalidatePromptCacheLocked()
         }
+    }
+}
+
+// MARK: - StructuredHistoryReceiver
+
+extension MLXBackend: StructuredHistoryReceiver {
+    public func setStructuredHistory(_ messages: [StructuredMessage]) {
+        withStateLock { _structuredHistory = messages }
     }
 }
 

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -268,15 +268,31 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
     /// Gemma 4 models intentionally stay on the LLM factory so we don't pay the
     /// memory cost of resident vision-tower weights.
     static func requiresVLMFactory(at url: URL) -> Bool {
-        do {
-            if try ModelCapabilityProbe.probe(modelDirectory: url).supportsVision {
-                return true
+        requiresVLMFactory(at: url, precomputedCapabilities: nil)
+    }
+
+    /// Variant that accepts pre-computed capabilities to avoid re-reading
+    /// `config.json` when the caller already ran ``ModelCapabilityProbe``.
+    static func requiresVLMFactory(
+        at url: URL,
+        precomputedCapabilities capabilities: ModelCapabilities?
+    ) -> Bool {
+        // Fast path: vision was already detected by the caller's probe run.
+        if let capabilities {
+            if capabilities.supportsVision { return true }
+        } else {
+            do {
+                if try ModelCapabilityProbe.probe(modelDirectory: url).supportsVision {
+                    return true
+                }
+            } catch {
+                Log.inference.info(
+                    "MLX capability probe failed for \(url.lastPathComponent, privacy: .public); falling back to config.json routing (\(error.localizedDescription, privacy: .public))"
+                )
             }
-        } catch {
-            Log.inference.info(
-                "MLX capability probe failed for \(url.lastPathComponent, privacy: .public); falling back to config.json routing (\(error.localizedDescription, privacy: .public))"
-            )
         }
+        // MoE fallback: Gemma 4 26B ships `text_config.enable_moe_block = true`
+        // and its MoE decoder only exists in the VLM factory today.
         let configURL = url.appendingPathComponent("config.json")
         guard let data = try? Data(contentsOf: configURL),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
@@ -592,16 +608,19 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         await progressHandler?(0.0)
 
         do {
-            let supportsVision: Bool
+            // Probe once; both the vision flag and the factory-routing decision
+            // consume the same result so config.json is read only once here.
+            let probedCapabilities: ModelCapabilities?
             do {
-                supportsVision = try ModelCapabilityProbe.probe(modelDirectory: url).supportsVision
+                probedCapabilities = try ModelCapabilityProbe.probe(modelDirectory: url)
             } catch {
                 Log.inference.info(
                     "MLX capability probe failed for \(url.lastPathComponent, privacy: .public); continuing with conservative vision defaults (\(error.localizedDescription, privacy: .public))"
                 )
-                supportsVision = false
+                probedCapabilities = nil
             }
-            let routeThroughVLMFactory = Self.requiresVLMFactory(at: url)
+            let supportsVision = probedCapabilities?.supportsVision ?? false
+            let routeThroughVLMFactory = Self.requiresVLMFactory(at: url, precomputedCapabilities: probedCapabilities)
             // Load from a local directory containing config.json + .safetensors.
             // We dispatch directly to either `LLMModelFactory.shared` or
             // `VLMModelFactory.shared` rather than calling the registry-iterating

--- a/Sources/BaseChatBackends/MLXModelContainerProtocol.swift
+++ b/Sources/BaseChatBackends/MLXModelContainerProtocol.swift
@@ -46,6 +46,14 @@ struct MLXPromptCache: @unchecked Sendable {
     }
 }
 
+struct SendableChatMessages: @unchecked Sendable {
+    let value: [Chat.Message]
+
+    init(_ value: [Chat.Message]) {
+        self.value = value
+    }
+}
+
 /// Abstraction over `ModelContainer` so `MLXBackend` can be tested without real hardware.
 ///
 /// `LMInput` and `[KVCache]` are wrapped so `MLXBackend` can own prompt preparation,
@@ -53,6 +61,7 @@ struct MLXPromptCache: @unchecked Sendable {
 /// `ModelContainer` conformance keeps the underlying MLX types off the public API.
 protocol MLXModelContainerProtocol: Sendable {
     func prepare(messages: [[String: String]]) async throws -> MLXPreparedInput
+    func prepare(chat: SendableChatMessages) async throws -> MLXPreparedInput
     func makeCache(parameters: GenerateParameters) async throws -> MLXPromptCache
     func generate(
         input: MLXPreparedInput,
@@ -65,6 +74,13 @@ extension ModelContainer: MLXModelContainerProtocol {
     func prepare(messages: [[String: String]]) async throws -> MLXPreparedInput {
         let input = try await prepare(input: .init(messages: messages))
         return MLXPreparedInput(input)
+    }
+
+    func prepare(chat: SendableChatMessages) async throws -> MLXPreparedInput {
+        try await perform(nonSendable: chat.value) { context, chat in
+            let input = try await context.processor.prepare(input: .init(chat: chat))
+            return MLXPreparedInput(input)
+        }
     }
 
     func makeCache(parameters: GenerateParameters) async throws -> MLXPromptCache {

--- a/Sources/BaseChatInference/Protocols/BackendCapabilities.swift
+++ b/Sources/BaseChatInference/Protocols/BackendCapabilities.swift
@@ -99,6 +99,13 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
     /// `GenerationConfig.thinkingMarkers`, which is a per-request runtime hint.
     public let supportsThinking: Bool
 
+    /// If true, the backend can consume image parts in ``StructuredMessage`` history.
+    ///
+    /// UI surfaces use this to gate image-attachment affordances, and the
+    /// inference coordinator uses it to fail fast rather than silently dropping
+    /// image parts during flattening on text-only backends.
+    public let supportsVision: Bool
+
     /// True when the backend emits ``GenerationEvent/toolCallStart(callId:name:)``
     /// and ``GenerationEvent/toolCallArgumentsDelta(callId:textDelta:)`` before
     /// each ``GenerationEvent/toolCall(_:)``. Cloud streaming backends set
@@ -143,6 +150,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         supportsKVCachePersistence: Bool = false,
         supportsGrammarConstrainedSampling: Bool = false,
         supportsThinking: Bool = false,
+        supportsVision: Bool = false,
         streamsToolCallArguments: Bool = false,
         supportsParallelToolCalls: Bool = false
     ) {
@@ -162,6 +170,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         self.supportsKVCachePersistence = supportsKVCachePersistence
         self.supportsGrammarConstrainedSampling = supportsGrammarConstrainedSampling
         self.supportsThinking = supportsThinking
+        self.supportsVision = supportsVision
         self.streamsToolCallArguments = streamsToolCallArguments
         self.supportsParallelToolCalls = supportsParallelToolCalls
     }
@@ -183,6 +192,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         case supportsKVCachePersistence
         case supportsGrammarConstrainedSampling
         case supportsThinking
+        case supportsVision
         case streamsToolCallArguments
         case supportsParallelToolCalls
     }
@@ -205,6 +215,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         supportsKVCachePersistence = (try c.decodeIfPresent(Bool.self, forKey: .supportsKVCachePersistence)) ?? false
         supportsGrammarConstrainedSampling = (try c.decodeIfPresent(Bool.self, forKey: .supportsGrammarConstrainedSampling)) ?? false
         supportsThinking = (try c.decodeIfPresent(Bool.self, forKey: .supportsThinking)) ?? false
+        supportsVision = (try c.decodeIfPresent(Bool.self, forKey: .supportsVision)) ?? false
         streamsToolCallArguments = (try c.decodeIfPresent(Bool.self, forKey: .streamsToolCallArguments)) ?? false
         supportsParallelToolCalls = (try c.decodeIfPresent(Bool.self, forKey: .supportsParallelToolCalls)) ?? false
     }
@@ -227,6 +238,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         try c.encode(supportsKVCachePersistence, forKey: .supportsKVCachePersistence)
         try c.encode(supportsGrammarConstrainedSampling, forKey: .supportsGrammarConstrainedSampling)
         try c.encode(supportsThinking, forKey: .supportsThinking)
+        try c.encode(supportsVision, forKey: .supportsVision)
         try c.encode(streamsToolCallArguments, forKey: .streamsToolCallArguments)
         try c.encode(supportsParallelToolCalls, forKey: .supportsParallelToolCalls)
     }

--- a/Sources/BaseChatInference/Services/GenerationCoordinator.swift
+++ b/Sources/BaseChatInference/Services/GenerationCoordinator.swift
@@ -289,6 +289,11 @@ final class GenerationCoordinator {
         systemPrompt: String?,
         config: GenerationConfig
     ) throws -> GenerationStream {
+        if Self.containsImages(messages), !backend.capabilities.supportsVision {
+            throw InferenceError.inferenceFailure(
+                "Image attachments require a vision-capable backend. Load an MLX vision model before sending image parts."
+            )
+        }
         // Exact-count pre-flight: backends that conform to TokenCountingBackend
         // expose the real tokenizer. Use it to verify the assembled prompt fits
         // inside the context window before committing to the C-level decode.
@@ -358,6 +363,15 @@ final class GenerationCoordinator {
     /// Instance-level wrapper around the static flatten so call sites stay readable.
     private func flatten(_ messages: [StructuredMessage]) -> [(role: String, content: String)] {
         Self.flatten(messages)
+    }
+
+    private static func containsImages(_ messages: [StructuredMessage]) -> Bool {
+        messages.contains { message in
+            message.parts.contains { part in
+                if case .image = part { return true }
+                return false
+            }
+        }
     }
 
     /// Hands history to whichever receiver protocol the backend conforms to.

--- a/Sources/BaseChatInference/Services/RouterBackend.swift
+++ b/Sources/BaseChatInference/Services/RouterBackend.swift
@@ -75,6 +75,7 @@ public final class RouterBackend: InferenceBackend, @unchecked Sendable {
         var supportsKVCachePersistence = first.supportsKVCachePersistence
         var supportsGrammarConstrainedSampling = first.supportsGrammarConstrainedSampling
         var supportsThinking = first.supportsThinking
+        var supportsVision = first.supportsVision
         var streamsToolCallArguments = first.streamsToolCallArguments
         var supportsParallelToolCalls = first.supportsParallelToolCalls
 
@@ -104,6 +105,7 @@ public final class RouterBackend: InferenceBackend, @unchecked Sendable {
             supportsKVCachePersistence = supportsKVCachePersistence || c.supportsKVCachePersistence
             supportsGrammarConstrainedSampling = supportsGrammarConstrainedSampling || c.supportsGrammarConstrainedSampling
             supportsThinking = supportsThinking || c.supportsThinking
+            supportsVision = supportsVision || c.supportsVision
             streamsToolCallArguments = streamsToolCallArguments || c.streamsToolCallArguments
             supportsParallelToolCalls = supportsParallelToolCalls || c.supportsParallelToolCalls
         }
@@ -124,6 +126,7 @@ public final class RouterBackend: InferenceBackend, @unchecked Sendable {
             supportsKVCachePersistence: supportsKVCachePersistence,
             supportsGrammarConstrainedSampling: supportsGrammarConstrainedSampling,
             supportsThinking: supportsThinking,
+            supportsVision: supportsVision,
             streamsToolCallArguments: streamsToolCallArguments,
             supportsParallelToolCalls: supportsParallelToolCalls
         )

--- a/Sources/BaseChatTestSupport/ImageFixtures.swift
+++ b/Sources/BaseChatTestSupport/ImageFixtures.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Shared tiny image fixtures for multimodal and attachment tests.
+public enum ImageFixtures {
+    /// A valid 1×1 transparent PNG.
+    public static let oneByOnePNGData = Data(
+        base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z0ioAAAAASUVORK5CYII="
+    )!
+}

--- a/Sources/BaseChatTestSupport/MockMLXModelContainer.swift
+++ b/Sources/BaseChatTestSupport/MockMLXModelContainer.swift
@@ -84,6 +84,9 @@ public final class MockMLXModelContainer: @unchecked Sendable {
     /// Last messages passed to `prepare`.
     public private(set) var lastMessages: [[String: String]]?
 
+    /// Last structured chat messages passed to `prepare(chat:)`.
+    public private(set) var lastChatMessages: [Chat.Message]?
+
     /// Last `GenerateParameters` value passed to generation. Useful for asserting
     /// that `MLXBackend` forwards `temperature` / `topP` / `topK` / `minP` /
     /// `repetitionPenalty` from the caller's `GenerationConfig`.
@@ -104,12 +107,30 @@ public final class MockMLXModelContainer: @unchecked Sendable {
     ) async throws -> [Int] {
         prepareCallCount += 1
         lastMessages = messages
+        lastChatMessages = nil
 
         let promptTokens: [Int]
         if !preparedTokenBatches.isEmpty {
             promptTokens = preparedTokenBatches.removeFirst()
         } else {
             promptTokens = Array(1 ... max(messages.count, 1))
+        }
+        lastPreparedTokenIds = promptTokens
+        return promptTokens
+    }
+
+    public func prepareForGeneration(
+        chat: [Chat.Message]
+    ) async throws -> [Int] {
+        prepareCallCount += 1
+        lastChatMessages = chat
+        lastMessages = nil
+
+        let promptTokens: [Int]
+        if !preparedTokenBatches.isEmpty {
+            promptTokens = preparedTokenBatches.removeFirst()
+        } else {
+            promptTokens = Array(1 ... max(chat.count, 1))
         }
         lastPreparedTokenIds = promptTokens
         return promptTokens

--- a/Sources/BaseChatUI/BaseChatUI.docc/BaseChatUI.md
+++ b/Sources/BaseChatUI/BaseChatUI.docc/BaseChatUI.md
@@ -6,6 +6,8 @@ SwiftUI views and view models for building on-device and cloud-connected chat in
 
 BaseChatUI provides the view layer for BaseChatKit. It depends only on ``BaseChatCore`` — it has no knowledge of specific inference backends. Drop ``ChatView`` into your app and supply a ``ChatViewModel`` to get a fully-featured chat interface: streaming generation, model selection, and session management.
 
+`ChatInputBar` automatically exposes image attachments only when the active backend's ``BackendCapabilities/supportsVision`` flag is `true`. If a host routes image-bearing history to a text-only backend anyway, `GenerationCoordinator` fails fast rather than silently flattening the images away.
+
 ### Minimum wiring
 
 ```swift

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Ingest.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Ingest.swift
@@ -54,31 +54,11 @@ extension ChatViewModel {
         }
         await switchToSession(session)
 
-        // Seed the prompt and run it through the same path as the compose
-        // bar so loading checks, auto-title, and token accounting all stay
-        // consistent. Attachments ride along as `.text` neighbors — once
-        // richer parts (images, files) land via Share Extension support,
-        // the first user message already supports the shape.
+        // Seed the prompt and any attachments through the same draft path as
+        // the compose bar so loading checks, auto-title, and token accounting
+        // all stay consistent.
         inputText = payload.prompt
+        draftAttachments = payload.attachments
         await sendMessage()
-
-        // Attachments land as an update to the user message so any extra
-        // parts survive alongside the prompt without re-routing through
-        // `sendMessage()`, which only accepts a text body today.
-        if !payload.attachments.isEmpty,
-           let userMessage = messages.last(where: { $0.role == .user }) {
-            var updated = userMessage
-            updated.contentParts.append(contentsOf: payload.attachments)
-            do {
-                try await updateMessage(updated)
-                if let index = messages.firstIndex(where: { $0.id == userMessage.id }) {
-                    messages[index] = updated
-                }
-            } catch {
-                Log.persistence.warning(
-                    "ChatViewModel.ingest failed to persist attachments: \(error.localizedDescription)"
-                )
-            }
-        }
     }
 }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+IngestPendingPayload.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+IngestPendingPayload.swift
@@ -229,6 +229,7 @@ extension ChatViewModel {
         // bails out — but we keep the draft populated so the user can
         // pick a model and resend without retyping.
         inputText = body
+        draftAttachments = attachments
 
         guard isModelLoaded else {
             Log.ui.info(
@@ -238,43 +239,28 @@ extension ChatViewModel {
         }
 
         await sendMessage()
-
-        if !attachments.isEmpty,
-           let userMessage = messages.last(where: { $0.role == .user }) {
-            var updated = userMessage
-            updated.contentParts.append(contentsOf: attachments)
-            do {
-                try await updateMessage(updated)
-                if let index = messages.firstIndex(where: { $0.id == userMessage.id }) {
-                    messages[index] = updated
-                }
-            } catch {
-                Log.persistence.warning(
-                    "ingestPendingPayload failed to persist attachments: \(error.localizedDescription)"
-                )
-            }
-        }
     }
 
     @MainActor
     private func ingestByAppendingToDraft(_ payload: PendingPayload) {
-        let (body, _) = payload.intoMessageBody()
-        guard !body.isEmpty else { return }
+        let (body, attachments) = payload.intoMessageBody()
 
         if inputText.isEmpty {
             inputText = body
-        } else {
+        } else if !body.isEmpty {
             // Single newline between the existing draft and the appended
             // payload keeps multi-paragraph drafts readable without
             // collapsing the user's prior whitespace.
             inputText = inputText + "\n" + body
         }
+        draftAttachments.append(contentsOf: attachments)
     }
 
     @MainActor
     private func ingestAsDraft(_ payload: PendingPayload) {
-        let (body, _) = payload.intoMessageBody()
+        let (body, attachments) = payload.intoMessageBody()
         inputText = body
+        draftAttachments = attachments
     }
 
     @MainActor

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Messages.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Messages.swift
@@ -6,10 +6,11 @@ import BaseChatInference
 
 extension ChatViewModel {
 
-    /// Sends the current input as a user message and generates an assistant response.
+    /// Sends the current text and any staged attachments as a user message and generates an assistant response.
     public func sendMessage() async {
         let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty else { return }
+        let attachments = draftAttachments
+        guard !text.isEmpty || !attachments.isEmpty else { return }
 
         guard let activeSessionID else {
             errorMessage = "No active session. Create or select a session first."
@@ -23,10 +24,12 @@ extension ChatViewModel {
 
         errorMessage = nil
         inputText = ""
+        draftAttachments = []
         Log.ui.debug("User sent message")
 
         // Create and persist the user message.
-        let userMessage = ChatMessageRecord(role: .user, content: text, sessionID: activeSessionID)
+        let userParts = text.isEmpty ? attachments : [.text(text)] + attachments
+        let userMessage = ChatMessageRecord(role: .user, contentParts: userParts, sessionID: activeSessionID)
         messages.append(userMessage)
         do {
             try await saveMessage(userMessage)
@@ -46,7 +49,7 @@ extension ChatViewModel {
         }
 
         // Trigger auto-title on the first user message in this session.
-        if let session = activeSession, messages.filter({ $0.role == .user }).count == 1 {
+        if let session = activeSession, !text.isEmpty, messages.filter({ $0.role == .user }).count == 1 {
             await onFirstMessage?(session, text)
         }
 
@@ -96,7 +99,13 @@ extension ChatViewModel {
 
         // Update the edited message.
         let originalMessage = messages[index]
-        messages[index].content = newContent
+        let preservedNonTextParts = originalMessage.contentParts.filter { part in
+            if case .text = part { return false }
+            return true
+        }
+        messages[index].contentParts = newContent.isEmpty
+            ? preservedNonTextParts
+            : [.text(newContent)] + preservedNonTextParts
         do {
             try await updateMessage(messages[index])
         } catch {
@@ -244,5 +253,18 @@ extension ChatViewModel {
     /// Returns whether the given message is currently pinned.
     public func isMessagePinned(id messageID: UUID) -> Bool {
         pinnedMessageIDs.contains(messageID)
+    }
+
+    func stageDraftAttachment(_ part: MessagePart) {
+        draftAttachments.append(part)
+    }
+
+    func removeDraftAttachment(id index: Int) {
+        guard draftAttachments.indices.contains(index) else { return }
+        draftAttachments.remove(at: index)
+    }
+
+    func clearDraftAttachments() {
+        draftAttachments.removeAll()
     }
 }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+SessionManagement.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+SessionManagement.swift
@@ -49,6 +49,8 @@ extension ChatViewModel {
         }
 
         showUpgradeHint = false
+        inputText = ""
+        clearDraftAttachments()
         await loadMessages()
         updateContextEstimate()
         Log.ui.info("Switched to session: \(session.title, privacy: .private)")

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -148,6 +148,12 @@ public final class ChatViewModel {
     /// The user's current input text.
     public var inputText: String = ""
 
+    /// Rich parts staged in the compose bar but not yet sent.
+    ///
+    /// Today this is used for image attachments. The array stays typed as
+    /// ``MessagePart`` so future compose-bar parts can reuse the same draft path.
+    var draftAttachments: [MessagePart] = []
+
     /// Editable system prompt prepended to every generation.
     public var systemPrompt: String {
         get { sessionController.systemPrompt }
@@ -402,6 +408,14 @@ public final class ChatViewModel {
     /// Capabilities of the active backend, or `nil` if none loaded.
     public var backendCapabilities: BackendCapabilities? {
         inferenceService.capabilities
+    }
+
+    var hasDraftContent: Bool {
+        !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !draftAttachments.isEmpty
+    }
+
+    var supportsImageAttachments: Bool {
+        backendCapabilities?.supportsVision == true
     }
 
     public var activeBackendName: String? {

--- a/Sources/BaseChatUI/Views/Chat/ChatInputBar.swift
+++ b/Sources/BaseChatUI/Views/Chat/ChatInputBar.swift
@@ -1,17 +1,21 @@
 import SwiftUI
 import BaseChatCore
+import BaseChatInference
+import UniformTypeIdentifiers
 
 /// The text input bar at the bottom of the chat view.
 ///
-/// Shows a multiline text field with send/stop buttons. On compact size class
-/// (iPhone), a row of quick-action pills appears above the input for common
-/// prompts like "Continue" and "Describe scene".
+/// Shows a multiline text field with send/stop buttons plus an image-attachment
+/// affordance when the active backend reports vision support. On compact size
+/// class (iPhone), a row of quick-action pills appears above the input for
+/// common prompts like "Continue" and "Describe scene".
 public struct ChatInputBar: View {
 
     @Environment(ChatViewModel.self) private var viewModel
     @Environment(\.horizontalSizeClass) private var sizeClass
 
     @FocusState private var isInputFocused: Bool
+    @State private var isImageImporterPresented = false
 
     public init() {}
 
@@ -32,6 +36,10 @@ public struct ChatInputBar: View {
                 quickActionPills
             }
 
+            if !viewModel.draftAttachments.isEmpty {
+                draftAttachmentStrip
+            }
+
             HStack(alignment: .bottom, spacing: 8) {
                 TextField(inputPlaceholder, text: $viewModel.inputText, axis: .vertical)
                     .textFieldStyle(.plain)
@@ -45,6 +53,13 @@ public struct ChatInputBar: View {
                 actionButtons
             }
         }
+        .fileImporter(
+            isPresented: $isImageImporterPresented,
+            allowedContentTypes: [.image],
+            allowsMultipleSelection: false
+        ) { result in
+            handleImageImport(result)
+        }
         .padding(.horizontal)
         .padding(.vertical, 10)
     }
@@ -54,6 +69,10 @@ public struct ChatInputBar: View {
     @ViewBuilder
     private var actionButtons: some View {
         HStack(spacing: 4) {
+            if viewModel.supportsImageAttachments {
+                attachImageButton
+            }
+
             if showRegenerateButton {
                 Button {
                     Task {
@@ -81,6 +100,20 @@ public struct ChatInputBar: View {
             onSend: sendMessage,
             onStop: { viewModel.stopGeneration() }
         )
+    }
+
+    private var attachImageButton: some View {
+        Button {
+            isImageImporterPresented = true
+        } label: {
+            Image(systemName: "paperclip.circle.fill")
+                .font(.title2)
+                .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+        .disabled(!canAttachImage)
+        .accessibilityLabel("Attach image")
+        .help("Attach image")
     }
 
     // MARK: - Quick Action Pills
@@ -126,7 +159,14 @@ public struct ChatInputBar: View {
         && viewModel.isModelLoaded
         && !viewModel.isGenerating
         && !viewModel.isLoading
-        && !viewModel.inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        && viewModel.hasDraftContent
+    }
+
+    private var canAttachImage: Bool {
+        viewModel.activeSession != nil
+        && viewModel.isModelLoaded
+        && !viewModel.isGenerating
+        && !viewModel.isLoading
     }
 
     private var showRegenerateButton: Bool {
@@ -147,6 +187,93 @@ public struct ChatInputBar: View {
         Task {
             await viewModel.sendMessage()
         }
+    }
+
+    @ViewBuilder
+    private var draftAttachmentStrip: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(Array(viewModel.draftAttachments.enumerated()), id: \.offset) { index, part in
+                    draftAttachmentPreview(for: part, at: index)
+                }
+            }
+            .padding(.horizontal, 4)
+        }
+    }
+
+    @ViewBuilder
+    private func draftAttachmentPreview(for part: MessagePart, at index: Int) -> some View {
+        if case let .image(data, _) = part {
+            ZStack(alignment: .topTrailing) {
+                draftThumbnail(data: data)
+                    .frame(width: 72, height: 72)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+
+                Button {
+                    viewModel.removeDraftAttachment(id: index)
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.white, .black.opacity(0.7))
+                }
+                .buttonStyle(.plain)
+                .offset(x: 6, y: -6)
+                .accessibilityLabel("Remove attachment")
+            }
+            .padding(.trailing, 4)
+        }
+    }
+
+    @ViewBuilder
+    private func draftThumbnail(data: Data) -> some View {
+        #if os(iOS)
+        if let uiImage = UIImage(data: data) {
+            Image(uiImage: uiImage)
+                .resizable()
+                .scaledToFill()
+        }
+        #elseif os(macOS)
+        if let nsImage = NSImage(data: data) {
+            Image(nsImage: nsImage)
+                .resizable()
+                .scaledToFill()
+        }
+        #endif
+    }
+
+    private func handleImageImport(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            let accessed = url.startAccessingSecurityScopedResource()
+            defer {
+                if accessed {
+                    url.stopAccessingSecurityScopedResource()
+                }
+            }
+
+            do {
+                let data = try Data(contentsOf: url)
+                let mimeType = try resolvedImageMIMEType(for: url)
+                viewModel.stageDraftAttachment(.image(data: data, mimeType: mimeType))
+            } catch {
+                viewModel.surfaceError(error, kind: .configuration, context: "attaching image")
+            }
+
+        case .failure(let error):
+            viewModel.surfaceError(error, kind: .configuration, context: "attaching image")
+        }
+    }
+
+    private func resolvedImageMIMEType(for url: URL) throws -> String {
+        let values = try url.resourceValues(forKeys: [.contentTypeKey])
+        let contentType = values.contentType ?? UTType(filenameExtension: url.pathExtension)
+        guard let contentType,
+              contentType.conforms(to: .image),
+              let mimeType = contentType.preferredMIMEType else {
+            throw InferenceError.inferenceFailure("Unsupported image attachment type.")
+        }
+        return mimeType
     }
 }
 

--- a/Sources/BaseChatUI/Views/Chat/ChatInputBar.swift
+++ b/Sources/BaseChatUI/Views/Chat/ChatInputBar.swift
@@ -245,19 +245,37 @@ public struct ChatInputBar: View {
         switch result {
         case .success(let urls):
             guard let url = urls.first else { return }
+            // Resolve the MIME type synchronously while the security-scoped
+            // resource is open — resourceValues is a fast metadata-only call.
+            // The actual file read is dispatched to a background task so it
+            // never blocks the main thread on large images.
             let accessed = url.startAccessingSecurityScopedResource()
-            defer {
-                if accessed {
-                    url.stopAccessingSecurityScopedResource()
-                }
+            let mimeType: String
+            do {
+                mimeType = try resolvedImageMIMEType(for: url)
+            } catch {
+                if accessed { url.stopAccessingSecurityScopedResource() }
+                viewModel.surfaceError(error, kind: .configuration, context: "attaching image")
+                return
             }
 
-            do {
-                let data = try Data(contentsOf: url)
-                let mimeType = try resolvedImageMIMEType(for: url)
-                viewModel.stageDraftAttachment(.image(data: data, mimeType: mimeType))
-            } catch {
-                viewModel.surfaceError(error, kind: .configuration, context: "attaching image")
+            // Capture everything needed by the background task; the
+            // security-scoped resource remains open until the task releases it.
+            let capturedURL = url
+            let capturedMIMEType = mimeType
+            let capturedAccessed = accessed
+            Task {
+                defer {
+                    if capturedAccessed { capturedURL.stopAccessingSecurityScopedResource() }
+                }
+                do {
+                    let data = try await Task.detached(priority: .userInitiated) {
+                        try Data(contentsOf: capturedURL)
+                    }.value
+                    viewModel.stageDraftAttachment(.image(data: data, mimeType: capturedMIMEType))
+                } catch {
+                    viewModel.surfaceError(error, kind: .configuration, context: "attaching image")
+                }
             }
 
         case .failure(let error):

--- a/Tests/BaseChatBackendsTests/MLXBackendGenerationTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXBackendGenerationTests.swift
@@ -14,6 +14,11 @@ extension MockMLXModelContainer: MLXModelContainerProtocol {
         return MLXPreparedInput(promptTokenIds: promptTokenIds)
     }
 
+    public func prepare(chat: SendableChatMessages) async throws -> MLXPreparedInput {
+        let promptTokenIds = try await prepareForGeneration(chat: chat.value)
+        return MLXPreparedInput(promptTokenIds: promptTokenIds)
+    }
+
     public func makeCache(parameters: GenerateParameters) async throws -> MLXPromptCache {
         MLXPromptCache(makeCacheForGeneration(parameters: parameters))
     }
@@ -109,6 +114,96 @@ final class MLXBackendGenerationTests: XCTestCase {
 
         // Sabotage check: setting maxOutputTokens = 100 yields all 10 tokens,
         // causing the count assertion to fail.
+    }
+
+    func test_generate_withVisionHistory_preparesStructuredChat() async throws {
+        let mock = MockMLXModelContainer()
+        mock.tokensToYield = ["seen"]
+
+        let backend = MLXBackend()
+        backend._inject(mock, supportsVision: true)
+        backend.setStructuredHistory([
+            StructuredMessage(role: "user", parts: [
+                .text("Describe this image."),
+                .image(data: ImageFixtures.oneByOnePNGData, mimeType: "image/png"),
+            ])
+        ])
+
+        let stream = try backend.generate(
+            prompt: "fallback",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        let tokens = try await collectTokens(from: stream)
+
+        XCTAssertEqual(tokens, ["seen"])
+        XCTAssertEqual(mock.lastChatMessages?.count, 1)
+        XCTAssertEqual(mock.lastChatMessages?.first?.content, "Describe this image.")
+        XCTAssertEqual(mock.lastChatMessages?.first?.images.count, 1)
+        XCTAssertNil(mock.lastMessages, "Vision turns should go through UserInput(chat:) instead of text-only message dictionaries")
+    }
+
+    func test_generate_toolAwareVisionHistory_preservesOriginalImages() async throws {
+        let mock = MockMLXModelContainer()
+        mock.tokensToYield = ["ok"]
+
+        let backend = MLXBackend()
+        backend._inject(mock, supportsVision: true, dialect: .qwen25)
+        backend.setStructuredHistory([
+            StructuredMessage(role: "user", parts: [
+                .text("Please inspect this chart."),
+                .image(data: ImageFixtures.oneByOnePNGData, mimeType: "image/png"),
+            ])
+        ])
+        backend.setToolAwareHistory([
+            ToolAwareHistoryEntry(role: "user", content: "Please inspect this chart."),
+            ToolAwareHistoryEntry(
+                role: "assistant",
+                content: "",
+                toolCalls: [
+                    ToolCall(id: "call_1", toolName: "summarize_image", arguments: "{}")
+                ]
+            ),
+        ])
+
+        _ = try await collectTokens(from: try backend.generate(
+            prompt: "fallback",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        ))
+
+        XCTAssertEqual(mock.lastChatMessages?.count, 2)
+        XCTAssertEqual(mock.lastChatMessages?.first?.images.count, 1)
+        XCTAssertTrue(
+            mock.lastChatMessages?[1].content.contains("<tool_call>") == true,
+            "Tool-aware vision turns must keep the serialized tool call content while preserving the earlier image"
+        )
+    }
+
+    func test_generate_withVisionHistory_andSystemPrompt_prependsSystemChatMessage() async throws {
+        let mock = MockMLXModelContainer()
+        mock.tokensToYield = ["seen"]
+
+        let backend = MLXBackend()
+        backend._inject(mock, supportsVision: true)
+        backend.setStructuredHistory([
+            StructuredMessage(role: "user", parts: [
+                .text("Describe this image."),
+                .image(data: ImageFixtures.oneByOnePNGData, mimeType: "image/png"),
+            ])
+        ])
+
+        _ = try await collectTokens(from: try backend.generate(
+            prompt: "fallback",
+            systemPrompt: "You are a precise image analyst.",
+            config: GenerationConfig()
+        ))
+
+        XCTAssertEqual(mock.lastChatMessages?.count, 2)
+        XCTAssertEqual(mock.lastChatMessages?.first?.content, "You are a precise image analyst.")
+        XCTAssertEqual(mock.lastChatMessages?.first?.images.count, 0)
+        XCTAssertEqual(mock.lastChatMessages?[1].images.count, 1)
     }
 
     func test_generate_reusesPromptCachePrefixOnMatchingTurn() async throws {

--- a/Tests/BaseChatBackendsTests/MLXBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXBackendTests.swift
@@ -46,6 +46,10 @@ final class MLXBackendTests: XCTestCase {
         XCTAssertTrue(MLXBackend(enableKVCacheReuse: true).capabilities.supportsKVCachePersistence)
     }
 
+    func test_capabilities_supportsVision_falseBeforeLoad() {
+        XCTAssertFalse(MLXBackend().capabilities.supportsVision)
+    }
+
     // MARK: - Lifecycle (no hardware gate)
 
     func test_generate_beforeLoad_throws() {
@@ -117,6 +121,14 @@ final class MLXBackendTests: XCTestCase {
         XCTAssertNoThrow(try MLXBackend.validateArchitecture(at: url))
     }
 
+    func test_validateArchitecture_acceptsQwen25VL() throws {
+        let url = try writeTempConfig([
+            "model_type": "qwen2_5_vl",
+            "vision_config": ["hidden_size": 1]
+        ])
+        XCTAssertNoThrow(try MLXBackend.validateArchitecture(at: url))
+    }
+
     func test_validateArchitecture_acceptsLlamaViaArchitectures() throws {
         // HF repos that omit `model_type` but ship `architectures: ["LlamaForCausalLM"]`
         // must still pass — snake_case prefix match keeps older snapshots working.
@@ -175,6 +187,14 @@ final class MLXBackendTests: XCTestCase {
         // makes this assertion fail (verified locally before commit).
         let url = try writeTempConfig([
             "text_config": ["enable_moe_block": true]
+        ])
+        XCTAssertTrue(MLXBackend.requiresVLMFactory(at: url))
+    }
+
+    func test_requiresVLMFactory_whenVisionConfigPresent_returnsTrue() throws {
+        let url = try writeTempConfig([
+            "model_type": "qwen2_5_vl",
+            "vision_config": ["hidden_size": 1]
         ])
         XCTAssertTrue(MLXBackend.requiresVLMFactory(at: url))
     }

--- a/Tests/BaseChatInferenceTests/BackendCapabilitiesContractTests.swift
+++ b/Tests/BaseChatInferenceTests/BackendCapabilitiesContractTests.swift
@@ -26,6 +26,14 @@ final class BackendCapabilitiesContractTests: XCTestCase {
                        "supportsThinking must default to false so cloud backends remain source-compatible")
     }
 
+    // MARK: - supportsVision defaults to false
+
+    func test_supportsVision_defaultsFalse() {
+        let caps = BackendCapabilities()
+        XCTAssertFalse(caps.supportsVision,
+                       "supportsVision must default to false so text-only backends never advertise image input accidentally")
+    }
+
     // MARK: - Codable forward-compat: old JSON missing new keys defaults both to false
 
     func test_codable_forwardCompat_missingNewKeys_defaultsToFalse() throws {
@@ -56,6 +64,8 @@ final class BackendCapabilitiesContractTests: XCTestCase {
                        "supportsGrammarConstrainedSampling must default to false for old payloads")
         XCTAssertFalse(decoded.supportsThinking,
                        "supportsThinking must default to false for old payloads")
+        XCTAssertFalse(decoded.supportsVision,
+                       "supportsVision must default to false for old payloads")
     }
 
     // MARK: - Full round-trip with new flags set to true
@@ -64,7 +74,8 @@ final class BackendCapabilitiesContractTests: XCTestCase {
         let caps = BackendCapabilities(
             supportsKVCachePersistence: true,
             supportsGrammarConstrainedSampling: true,
-            supportsThinking: true
+            supportsThinking: true,
+            supportsVision: true
         )
 
         let data = try JSONEncoder().encode(caps)
@@ -73,5 +84,6 @@ final class BackendCapabilitiesContractTests: XCTestCase {
         XCTAssertTrue(decoded.supportsKVCachePersistence)
         XCTAssertTrue(decoded.supportsGrammarConstrainedSampling)
         XCTAssertTrue(decoded.supportsThinking)
+        XCTAssertTrue(decoded.supportsVision)
     }
 }

--- a/Tests/BaseChatInferenceTests/GenerationCoordinatorStructuredHistoryTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationCoordinatorStructuredHistoryTests.swift
@@ -124,4 +124,40 @@ final class GenerationCoordinatorStructuredHistoryTests: XCTestCase {
         XCTAssertEqual(observed[1].parts.first?.thinkingSignature, "sig_q",
             "Signatures must round-trip through the queue → tool-dispatch loop → backend without loss")
     }
+
+    func test_generate_imageHistory_withVisionCapability_preservesStructuredImageParts() async throws {
+        let backend = MockInferenceBackend(capabilities: BackendCapabilities(supportsVision: true))
+        provider = FakeGenerationContextProvider(backend: backend)
+        coordinator.provider = provider
+
+        let image = MessagePart.image(data: ImageFixtures.oneByOnePNGData, mimeType: "image/png")
+        let history: [StructuredMessage] = [
+            StructuredMessage(role: "user", parts: [
+                .text("describe"),
+                image,
+            ])
+        ]
+
+        let stream = try coordinator.generate(structuredMessages: history)
+        for try await _ in stream.events {}
+
+        XCTAssertEqual(backend.lastReceivedStructuredHistory?.first?.parts, [.text("describe"), image])
+        XCTAssertEqual(backend.lastReceivedHistory?.first?.content, "describe")
+    }
+
+    func test_generate_imageHistory_withoutVisionCapability_throws() {
+        let history: [StructuredMessage] = [
+            StructuredMessage(role: "user", parts: [
+                .text("describe"),
+                .image(data: ImageFixtures.oneByOnePNGData, mimeType: "image/png"),
+            ])
+        ]
+
+        XCTAssertThrowsError(try coordinator.generate(structuredMessages: history)) { error in
+            guard case InferenceError.inferenceFailure(let message) = error else {
+                return XCTFail("Expected image capability failure, got \(error)")
+            }
+            XCTAssertTrue(message.contains("vision-capable backend"))
+        }
+    }
 }

--- a/Tests/BaseChatUITests/ChatInputBarLogicTests.swift
+++ b/Tests/BaseChatUITests/ChatInputBarLogicTests.swift
@@ -43,7 +43,10 @@ final class ChatInputBarLogicTests: XCTestCase {
         && vm.isModelLoaded
         && !vm.isGenerating
         && !vm.isLoading
-        && !vm.inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        && (
+            !vm.inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !vm.draftAttachments.isEmpty
+        )
     }
 
     func test_canSend_falseWhenNoActiveSession() async {
@@ -77,6 +80,13 @@ final class ChatInputBarLogicTests: XCTestCase {
         let (vm, _) = makeViewModelWithMock()
         vm.inputText = "Hello"
         XCTAssertTrue(canSend(vm), "canSend should be true when session exists, model loaded, and input non-empty")
+    }
+
+    func test_canSend_trueWhenAttachmentOnlyDraftPresent() {
+        let mock = MockInferenceBackend(capabilities: BackendCapabilities(supportsVision: true))
+        let (vm, _) = makeViewModelWithMock(mock: mock)
+        vm.stageDraftAttachment(.image(data: Data([0x89, 0x50, 0x4E, 0x47]), mimeType: "image/png"))
+        XCTAssertTrue(canSend(vm), "canSend should allow attachment-only drafts on vision-capable backends")
     }
 
     func test_canSend_falseWhileLoading() {
@@ -205,6 +215,43 @@ final class ChatInputBarLogicTests: XCTestCase {
         await vm.sendMessage()
 
         XCTAssertEqual(vm.inputText, "", "Input text should be cleared after sending")
+    }
+
+    func test_sendMessage_attachmentOnlyPersistsImagePart() async {
+        let mock = MockInferenceBackend(capabilities: BackendCapabilities(supportsVision: true))
+        mock.tokensToYield = ["Done"]
+        let (vm, backend) = makeViewModelWithMock(mock: mock)
+        let image = MessagePart.image(data: ImageFixtures.oneByOnePNGData, mimeType: "image/png")
+        vm.stageDraftAttachment(image)
+
+        await vm.sendMessage()
+
+        XCTAssertTrue(vm.draftAttachments.isEmpty, "Draft attachments should be cleared after sending")
+        let userMessage = vm.messages.first(where: { $0.role == .user })
+        XCTAssertEqual(userMessage?.contentParts, [image])
+        XCTAssertEqual(backend.lastReceivedStructuredHistory?.first?.parts, [image])
+    }
+
+    func test_sendMessage_textAndAttachmentPreservesPartOrder() async {
+        let mock = MockInferenceBackend(capabilities: BackendCapabilities(supportsVision: true))
+        mock.tokensToYield = ["Done"]
+        let (vm, backend) = makeViewModelWithMock(mock: mock)
+        let image = MessagePart.image(data: ImageFixtures.oneByOnePNGData, mimeType: "image/png")
+        vm.inputText = "Describe this image"
+        vm.stageDraftAttachment(image)
+
+        await vm.sendMessage()
+
+        let expectedParts: [MessagePart] = [.text("Describe this image"), image]
+        let userMessage = vm.messages.first(where: { $0.role == .user })
+        XCTAssertEqual(userMessage?.contentParts, expectedParts)
+        XCTAssertEqual(backend.lastReceivedStructuredHistory?.first?.parts, expectedParts)
+    }
+
+    func test_supportsImageAttachments_reflectsBackendCapability() {
+        let mock = MockInferenceBackend(capabilities: BackendCapabilities(supportsVision: true))
+        let (vm, _) = makeViewModelWithMock(mock: mock)
+        XCTAssertTrue(vm.supportsImageAttachments)
     }
 
     // MARK: - Edge cases

--- a/Tests/BaseChatUITests/ChatViewModelIngestPendingPayloadTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelIngestPendingPayloadTests.swift
@@ -170,21 +170,42 @@ final class ChatViewModelIngestPendingPayloadTests: XCTestCase {
         await vm.switchToSession(session)
         vm.inputText = "should be replaced"
 
-        let imageData = Data([0x89, 0x50, 0x4E, 0x47]) // PNG magic bytes
+        let imageData = ImageFixtures.oneByOnePNGData
         await vm.ingestPendingPayload(
             .image(imageData, mimeType: "image/png"),
             intent: .draft
         )
 
-        // Image payloads don't carry a text body — the draft is cleared
-        // since attachment-only drafts can't be sent through the
-        // current compose-bar contract. The host is expected to show
-        // the staged image preview in its own UI.
+        // Image payloads don't carry a text body, so the draft text is cleared
+        // while the image itself is staged in the compose bar.
         XCTAssertEqual(vm.inputText, "")
+        XCTAssertEqual(
+            vm.draftAttachments,
+            [.image(data: imageData, mimeType: "image/png")]
+        )
 
         // No new messages should have been persisted.
         let messages = fetchMessages(for: session.id)
         XCTAssertTrue(messages.isEmpty)
+    }
+
+    func test_imagePayload_appendToActive_keepsDraftTextAndAddsAttachment() async {
+        let session = ChatSessionRecord(title: "Existing")
+        try? await vm.persistence?.insertSession(session)
+        await vm.switchToSession(session)
+        vm.inputText = "Please inspect this"
+
+        let imageData = ImageFixtures.oneByOnePNGData
+        await vm.ingestPendingPayload(
+            .image(imageData, mimeType: "image/png"),
+            intent: .appendToActive
+        )
+
+        XCTAssertEqual(vm.inputText, "Please inspect this")
+        XCTAssertEqual(vm.draftAttachments, [.image(data: imageData, mimeType: "image/png")])
+
+        let messages = fetchMessages(for: session.id)
+        XCTAssertTrue(messages.isEmpty, "Appending an image payload should stay in draft state until the user sends")
     }
 
     // MARK: - file × .newSession

--- a/Tests/BaseChatUITests/ChatViewModelIngestTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelIngestTests.swift
@@ -27,7 +27,7 @@ final class ChatViewModelIngestTests: XCTestCase {
         container = try makeInMemoryContainer()
         context = container.mainContext
 
-        mock = MockInferenceBackend()
+        mock = MockInferenceBackend(capabilities: BackendCapabilities(supportsVision: true))
         mock.isModelLoaded = true
         mock.tokensToYield = ["ack"]
 
@@ -83,7 +83,8 @@ final class ChatViewModelIngestTests: XCTestCase {
     }
 
     func test_ingest_attachmentsPreservedAsMessageParts() async {
-        let attachments: [MessagePart] = [.text("[extra note]")]
+        let image = MessagePart.image(data: ImageFixtures.oneByOnePNGData, mimeType: "image/png")
+        let attachments: [MessagePart] = [image]
         let payload = InboundPayload(
             prompt: "here is the prompt",
             attachments: attachments,
@@ -95,11 +96,31 @@ final class ChatViewModelIngestTests: XCTestCase {
         let userMessage = vm.messages.first(where: { $0.role == .user })
         XCTAssertNotNil(userMessage, "Ingest should seed a user message")
         XCTAssertEqual(
-            userMessage?.contentParts.count,
-            2,
-            "User message should carry the prompt plus the attachment part"
+            userMessage?.contentParts,
+            [.text("here is the prompt"), image],
+            "User message should carry the prompt plus the image attachment"
         )
-        XCTAssertEqual(userMessage?.contentParts.last, .text("[extra note]"))
+        XCTAssertEqual(vm.draftAttachments, [], "Ingested attachments should be consumed by sendMessage()")
+        XCTAssertEqual(mock.lastReceivedStructuredHistory?.first?.parts, [.text("here is the prompt"), image])
+    }
+
+    func test_switchToSession_clearsDraftAttachments() async throws {
+        let first = ChatSessionRecord(title: "First")
+        let second = ChatSessionRecord(title: "Second")
+        try await vm.persistence?.insertSession(first)
+        try await vm.persistence?.insertSession(second)
+        await vm.switchToSession(first)
+
+        vm.inputText = "staged"
+        vm.draftAttachments = [
+            .image(data: ImageFixtures.oneByOnePNGData, mimeType: "image/png")
+        ]
+
+        await vm.switchToSession(second)
+
+        XCTAssertEqual(vm.activeSession?.id, second.id)
+        XCTAssertEqual(vm.inputText, "")
+        XCTAssertTrue(vm.draftAttachments.isEmpty, "Session switches must drop staged attachments from the prior session")
     }
 
     // MARK: - Concurrency


### PR DESCRIPTION
## Summary
- add vision capability plumbing and image attachment support through the UI, inference, and MLX layers
- preserve image parts in MLX structured chat preparation, including sendability-safe vision input preparation and tool-aware history fixtures
- add shared image fixtures, broaden UI/inference/MLX coverage, and document the vision attachment contract

## Testing
- swift test --filter BaseChatInferenceTests --disable-default-traits
- swift test --filter BaseChatUITests --disable-default-traits
- swift test --filter BaseChatBackendsTests --disable-default-traits --traits MLX