### PR TITLE
feat: add mmproj multimodal projector support to LlamaBackend

### DIFF
--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -43,6 +43,7 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
 
     public var capabilities: BackendCapabilities {
         let ctxSize = withStateLock { _effectiveContextSize }
+        let hasMMProj = withStateLock { _mmprojURL != nil }
         // MLX: KV cache reuse deferred — MLX manages its own context lifecycle via
         // MLXModelContainer and does not expose a KV-trim API.
         return BackendCapabilities(
@@ -61,7 +62,8 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
             isRemote: false,
             supportsKVCachePersistence: true,
             supportsGrammarConstrainedSampling: true,
-            supportsThinking: true
+            supportsThinking: true,
+            supportsVision: hasMMProj
         )
     }
 
@@ -87,6 +89,23 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
 
     /// Guarded by `stateLock`. Set by `setLoadProgressHandler(_:)` before each load.
     private var _loadProgressHandler: (@Sendable (Double) async -> Void)?
+
+    // MARK: - Multimodal Projector
+
+    /// URL of the mmproj companion file, set by ``MultimodalProjectorConfigurable`` before each load.
+    ///
+    /// Guarded by `stateLock`. Non-nil when a vision-capable model's projector is staged for load.
+    /// Cleared by ``unloadModel()``. When non-nil, ``capabilities`` advertises `supportsVision = true`.
+    ///
+    /// - Note: The bundled mattt/llama.swift 2.8772.0 (llama.cpp build b8772) does not expose
+    ///   the CLIP / mmproj C APIs (`clip.h`, `mtmd.h`). The URL is stored so `supportsVision`
+    ///   accurately reflects the projector's presence for model-selection UI; actual image token
+    ///   embedding will be wired when the xcframework is upgraded to a build that includes those headers.
+    private var _mmprojURL: URL?
+
+    /// Structured history set by ``StructuredHistoryReceiver``. Guarded by `stateLock`.
+    /// Used in ``generate(prompt:systemPrompt:config:)`` to detect image parts in the current turn.
+    private var _structuredHistory: [StructuredMessage] = []
 
     /// Owns the serialized model-load path and the C-level parameter/progress-callback bridging.
     private let modelLoader = LlamaModelLoader()
@@ -240,6 +259,28 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         }
         guard !withStateLock({ isGenerating }) else {
             throw InferenceError.alreadyGenerating
+        }
+
+        // Detect image parts in the current structured history.
+        // When an mmproj companion is staged, `supportsVision` is `true` so the
+        // coordinator routes image-bearing turns here. Actual multimodal decoding
+        // requires CLIP / mtmd C APIs not present in the bundled xcframework
+        // (mattt/llama.swift 2.8772.0, llama.cpp build b8772). Throw a clear,
+        // actionable error until a future xcframework upgrade adds those headers.
+        let history = withStateLock { _structuredHistory }
+        let hasImageParts = history.contains { msg in
+            msg.parts.contains {
+                if case .image = $0 { return true }
+                return false
+            }
+        }
+        if hasImageParts {
+            throw InferenceError.inferenceFailure(
+                "LlamaBackend: multimodal image inference is not yet available. "
+                + "The vendored llama.cpp xcframework (build b8772) does not include "
+                + "clip.h / mtmd.h. Upgrade the LlamaSwift dependency to a build that "
+                + "exposes those headers to enable image token embedding."
+            )
         }
 
         // Tokenize up front (pure vocab lookup — doesn't touch context KV
@@ -430,6 +471,27 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         }
     }
 
+    /// Zeros the KV tensor data in the active llama.cpp context.
+    ///
+    /// Unlike ``resetConversation()``, which passes `false` to
+    /// `llama_memory_clear` (metadata-only clear), this passes `true` to
+    /// write zeros into the underlying key and value matrices. This closes the
+    /// window during which prior-session KV tensors remain in process memory.
+    ///
+    /// The KV state cache pointer is also nil-ed so the next
+    /// ``generate(_:config:)`` call starts with a fresh context.
+    public func secureWipe() {
+        let capturedContext = withStateLock { () -> OpaquePointer? in
+            sessionKVState = nil
+            return context
+        }
+        if let ctx = capturedContext, let mem = llama_get_memory(ctx) {
+            // true = zero the actual KV tensor data (key + value matrices),
+            // not just the positional/sequence metadata.
+            llama_memory_clear(mem, true)
+        }
+    }
+
     public func unloadModel() {
         // Signal the decode loop to stop before acquiring stateLock. The atomic
         // write is visible to the background task immediately, so the loop can
@@ -455,6 +517,8 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         isGenerating = false
         sessionKVState = nil
         _autoDetectedThinkingMarkers = nil
+        _mmprojURL = nil
+        _structuredHistory = []
         stateLock.unlock()
 
         capturedTask?.cancel()
@@ -582,6 +646,30 @@ extension LlamaBackend: TokenCountingBackend {
             throw InferenceError.inferenceFailure("countTokens: llama_tokenize failed for text of length \(text.utf8.count)")
         }
         return text.isEmpty ? 0 : Int(count)
+    }
+}
+
+// MARK: - MultimodalProjectorConfigurable
+
+extension LlamaBackend: MultimodalProjectorConfigurable {
+    /// Stages the mmproj companion URL before the next ``loadModel(from:plan:)`` call.
+    ///
+    /// Called by ``ModelLifecycleCoordinator`` with ``ModelInfo/mmprojURL`` before loading.
+    /// When non-nil, ``capabilities`` advertises `supportsVision = true` so the coordinator
+    /// routes image-bearing turns to this backend. Actual image embedding requires a future
+    /// xcframework upgrade — see the comment on ``_mmprojURL``.
+    public func setMmprojURL(_ url: URL?) {
+        withStateLock { _mmprojURL = url }
+    }
+}
+
+// MARK: - StructuredHistoryReceiver
+
+extension LlamaBackend: StructuredHistoryReceiver {
+    /// Caches the structured conversation history so ``generate(prompt:systemPrompt:config:)``
+    /// can detect image parts and surface a clear error when they are present.
+    public func setStructuredHistory(_ messages: [StructuredMessage]) {
+        withStateLock { _structuredHistory = messages }
     }
 }
 #endif

--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -254,19 +254,14 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         // install. We only need to verify model is loaded up front — the
         // captured pointers are accessed through the re-read, not these
         // outer locals.
-        guard isModelLoaded, context != nil, vocab != nil, model != nil else {
-            throw InferenceError.inferenceFailure("No model loaded")
-        }
-        guard !withStateLock({ isGenerating }) else {
-            throw InferenceError.alreadyGenerating
-        }
-
-        // Detect image parts in the current structured history.
-        // When an mmproj companion is staged, `supportsVision` is `true` so the
-        // coordinator routes image-bearing turns here. Actual multimodal decoding
-        // requires CLIP / mtmd C APIs not present in the bundled xcframework
-        // (mattt/llama.swift 2.8772.0, llama.cpp build b8772). Throw a clear,
-        // actionable error until a future xcframework upgrade adds those headers.
+        // Reject image-bearing turns before any other state check so the caller
+        // gets the actionable xcframework-limitation message regardless of
+        // whether a model happens to be loaded. The check is independent of
+        // model state — it only inspects the structured history we cached
+        // from the coordinator. CLIP / mtmd C APIs are not present in the
+        // bundled xcframework (mattt/llama.swift 2.8772.0, llama.cpp build
+        // b8772); upgrading to a build that exposes clip.h / mtmd.h will
+        // unblock real image embedding.
         let history = withStateLock { _structuredHistory }
         let hasImageParts = history.contains { msg in
             msg.parts.contains {
@@ -281,6 +276,13 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
                 + "clip.h / mtmd.h. Upgrade the LlamaSwift dependency to a build that "
                 + "exposes those headers to enable image token embedding."
             )
+        }
+
+        guard isModelLoaded, context != nil, vocab != nil, model != nil else {
+            throw InferenceError.inferenceFailure("No model loaded")
+        }
+        guard !withStateLock({ isGenerating }) else {
+            throw InferenceError.alreadyGenerating
         }
 
         // Tokenize up front (pure vocab lookup — doesn't touch context KV
@@ -468,27 +470,6 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         // positional state is gone before the next turn decodes from position 0.
         if let ctx = capturedContext, let mem = llama_get_memory(ctx) {
             llama_memory_clear(mem, false)
-        }
-    }
-
-    /// Zeros the KV tensor data in the active llama.cpp context.
-    ///
-    /// Unlike ``resetConversation()``, which passes `false` to
-    /// `llama_memory_clear` (metadata-only clear), this passes `true` to
-    /// write zeros into the underlying key and value matrices. This closes the
-    /// window during which prior-session KV tensors remain in process memory.
-    ///
-    /// The KV state cache pointer is also nil-ed so the next
-    /// ``generate(_:config:)`` call starts with a fresh context.
-    public func secureWipe() {
-        let capturedContext = withStateLock { () -> OpaquePointer? in
-            sessionKVState = nil
-            return context
-        }
-        if let ctx = capturedContext, let mem = llama_get_memory(ctx) {
-            // true = zero the actual KV tensor data (key + value matrices),
-            // not just the positional/sequence metadata.
-            llama_memory_clear(mem, true)
         }
     }
 

--- a/Sources/BaseChatInference/Models/CuratedModel.swift
+++ b/Sources/BaseChatInference/Models/CuratedModel.swift
@@ -22,6 +22,12 @@ public struct CuratedModel: Identifiable, Sendable {
     public let contextSize: Int32
     public let promptTemplate: PromptTemplate
     public let description: String
+    /// Companion multimodal projector filename, if this is a vision-capable model.
+    ///
+    /// When non-nil, the download UI should fetch this file from the same ``repoID``
+    /// alongside ``fileName``. The coordinator passes the downloaded URL to the backend
+    /// via ``MultimodalProjectorConfigurable``.
+    public let mmprojFileName: String?
 
     public init(
         id: String,
@@ -33,7 +39,8 @@ public struct CuratedModel: Identifiable, Sendable {
         recommendedFor: Set<ModelSizeRecommendation>,
         contextSize: Int32,
         promptTemplate: PromptTemplate,
-        description: String
+        description: String,
+        mmprojFileName: String? = nil
     ) {
         self.id = id
         self.displayName = displayName
@@ -45,6 +52,7 @@ public struct CuratedModel: Identifiable, Sendable {
         self.contextSize = contextSize
         self.promptTemplate = promptTemplate
         self.description = description
+        self.mmprojFileName = mmprojFileName
     }
 
     /// The curated model list to display in model discovery UI.

--- a/Sources/BaseChatInference/Models/DownloadableModel.swift
+++ b/Sources/BaseChatInference/Models/DownloadableModel.swift
@@ -27,6 +27,11 @@ public struct DownloadableModel: Identifiable, Sendable, Hashable {
     public let promptTemplate: PromptTemplate?
     /// One-line description for UI.
     public let description: String?
+    /// Companion multimodal projector filename, if this is a vision-capable model.
+    ///
+    /// When non-nil, the download UI should fetch this file from the same ``repoID``
+    /// alongside ``fileName``. Mirrors ``CuratedModel/mmprojFileName`` for curated entries.
+    public let mmprojFileName: String?
 
     /// Human-readable size (e.g., "4.1 GB").
     public var sizeFormatted: String {
@@ -63,6 +68,7 @@ public struct DownloadableModel: Identifiable, Sendable, Hashable {
         self.isCurated = true
         self.promptTemplate = curated.promptTemplate
         self.description = curated.description
+        self.mmprojFileName = curated.mmprojFileName
     }
 
     // MARK: - Memberwise
@@ -76,7 +82,8 @@ public struct DownloadableModel: Identifiable, Sendable, Hashable {
         downloads: Int? = nil,
         isCurated: Bool = false,
         promptTemplate: PromptTemplate? = nil,
-        description: String? = nil
+        description: String? = nil,
+        mmprojFileName: String? = nil
     ) {
         self.id = "\(repoID)/\(fileName)"
         self.repoID = repoID
@@ -88,6 +95,7 @@ public struct DownloadableModel: Identifiable, Sendable, Hashable {
         self.isCurated = isCurated
         self.promptTemplate = promptTemplate
         self.description = description
+        self.mmprojFileName = mmprojFileName
     }
 }
 

--- a/Sources/BaseChatInference/Models/ModelInfo.swift
+++ b/Sources/BaseChatInference/Models/ModelInfo.swift
@@ -19,6 +19,17 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
     public let fileSize: UInt64
     public let modelType: ModelType
 
+    // MARK: - Multimodal
+
+    /// URL of the mmproj (multimodal projector) companion file, when present alongside the main GGUF.
+    ///
+    /// Populated automatically by ``init(ggufURL:)`` when a `mmproj*.gguf` sibling is found in
+    /// the same directory. Backends that conform to ``MultimodalProjectorConfigurable`` receive
+    /// this URL from ``ModelLifecycleCoordinator`` before ``InferenceBackend/loadModel(from:plan:)``.
+    ///
+    /// `nil` for text-only models and for non-GGUF model types.
+    public var mmprojURL: URL?
+
     // MARK: - GGUF Metadata (populated for .gguf models)
 
     /// The prompt template detected from GGUF metadata (chat template or architecture).
@@ -115,6 +126,22 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
 
         // Static tier estimate; may be upgraded by a benchmark result later.
         self.capabilityTier = ModelCapabilityTier.estimate(from: self)
+
+        // Auto-detect a companion mmproj file in the same directory.
+        // Only scans when the model filename does not start with "mmproj" so
+        // projector files don't try to find their own companion.
+        if !url.lastPathComponent.lowercased().hasPrefix("mmproj") {
+            let parentDir = url.deletingLastPathComponent()
+            let candidates = (try? FileManager.default.contentsOfDirectory(
+                at: parentDir,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )) ?? []
+            self.mmprojURL = candidates.first {
+                $0.lastPathComponent.lowercased().hasPrefix("mmproj") &&
+                $0.pathExtension.lowercased() == "gguf"
+            }
+        }
     }
 
     // MARK: - MLX Initializer
@@ -187,6 +214,7 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
         url: URL,
         fileSize: UInt64,
         modelType: ModelType,
+        mmprojURL: URL? = nil,
         detectedPromptTemplate: PromptTemplate? = nil,
         detectedContextLength: Int? = nil,
         modelArchitecture: String? = nil,
@@ -201,6 +229,7 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
         self.url = url
         self.fileSize = fileSize
         self.modelType = modelType
+        self.mmprojURL = mmprojURL
         self.detectedPromptTemplate = detectedPromptTemplate
         self.detectedContextLength = detectedContextLength
         self.modelArchitecture = modelArchitecture

--- a/Sources/BaseChatInference/Protocols/BackendOptInProtocols.swift
+++ b/Sources/BaseChatInference/Protocols/BackendOptInProtocols.swift
@@ -184,3 +184,18 @@ public protocol TokenCountingBackend: AnyObject {
     ///   or if tokenization fails (e.g., vocabulary is unavailable).
     func countTokens(_ text: String) throws -> Int
 }
+
+/// Adopted by local backends that support a multimodal projector (mmproj) companion file.
+///
+/// ``ModelLifecycleCoordinator`` calls ``setMmprojURL(_:)`` with the URL from
+/// ``ModelInfo/mmprojURL`` before each ``InferenceBackend/loadModel(from:plan:)`` call.
+/// Conformers that receive a non-nil URL should set ``BackendCapabilities/supportsVision``
+/// to `true` in their `capabilities` implementation.
+///
+/// - Note: Passing `nil` clears the projector, returning the backend to text-only mode.
+///   ``ModelLifecycleCoordinator`` always calls this before load so the projector state
+///   stays in sync with the loaded model file.
+public protocol MultimodalProjectorConfigurable: AnyObject {
+    /// Sets (or clears) the mmproj companion file URL for the next ``InferenceBackend/loadModel(from:plan:)`` call.
+    func setMmprojURL(_ url: URL?)
+}

--- a/Sources/BaseChatInference/Services/ModelLifecycleCoordinator.swift
+++ b/Sources/BaseChatInference/Services/ModelLifecycleCoordinator.swift
@@ -216,8 +216,10 @@ final class ModelLifecycleCoordinator {
         installProgressHandler(on: newBackend, for: request)
         do {
             let url = modelInfo.url
+            let mmprojURL = modelInfo.mmprojURL
             let dispatchPlan = effectivePlan
             try await Task.detached(priority: .userInitiated) {
+                (newBackend as? MultimodalProjectorConfigurable)?.setMmprojURL(mmprojURL)
                 try await newBackend.loadModel(from: url, plan: dispatchPlan)
             }.value
         } catch {
@@ -349,6 +351,10 @@ final class ModelLifecycleCoordinator {
 
     func resetConversation() {
         backend?.resetConversation()
+    }
+
+    func secureWipe() {
+        backend?.secureWipe()
     }
 
     // MARK: - Compatibility

--- a/Sources/BaseChatInference/Services/ModelLifecycleCoordinator.swift
+++ b/Sources/BaseChatInference/Services/ModelLifecycleCoordinator.swift
@@ -353,10 +353,6 @@ final class ModelLifecycleCoordinator {
         backend?.resetConversation()
     }
 
-    func secureWipe() {
-        backend?.secureWipe()
-    }
-
     // MARK: - Compatibility
 
     func compatibility(for modelType: ModelType) -> ModelCompatibilityResult {

--- a/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
@@ -948,5 +948,77 @@ final class LlamaBackendTests: XCTestCase {
         XCTAssertEqual(backend.tokenCount(long), HeuristicTokenizer.tokenCount(long),
                        "long-string fallback must match shared heuristic")
     }
+
+    // MARK: - Multimodal Projector (supportsVision)
+
+    func test_capabilities_supportsVision_withoutMmproj_isFalse() {
+        let backend = LlamaBackend()
+        XCTAssertFalse(backend.capabilities.supportsVision,
+                       "supportsVision must be false when no mmproj URL has been set")
+    }
+
+    func test_capabilities_supportsVision_afterSetMmprojURL_isTrue() {
+        let backend = LlamaBackend()
+        let fakeMMProj = URL(fileURLWithPath: "/nonexistent/mmproj-model.gguf")
+        backend.setMmprojURL(fakeMMProj)
+        XCTAssertTrue(backend.capabilities.supportsVision,
+                      "supportsVision must be true once a mmproj URL is staged")
+    }
+
+    func test_capabilities_supportsVision_afterClearingMmprojURL_isFalse() {
+        let backend = LlamaBackend()
+        backend.setMmprojURL(URL(fileURLWithPath: "/nonexistent/mmproj-model.gguf"))
+        backend.setMmprojURL(nil)
+        XCTAssertFalse(backend.capabilities.supportsVision,
+                       "supportsVision must revert to false after setMmprojURL(nil)")
+    }
+
+    func test_capabilities_supportsVision_afterUnload_isFalse() {
+        let backend = LlamaBackend()
+        backend.setMmprojURL(URL(fileURLWithPath: "/nonexistent/mmproj-model.gguf"))
+        backend.unloadModel()
+        XCTAssertFalse(backend.capabilities.supportsVision,
+                       "unloadModel() must clear the mmproj URL so supportsVision returns false")
+    }
+
+    func test_generate_withImageParts_throwsInferenceFailure() {
+        let backend = LlamaBackend()
+        // Stage an mmproj URL so the backend advertises supportsVision = true.
+        backend.setMmprojURL(URL(fileURLWithPath: "/nonexistent/mmproj-model.gguf"))
+
+        // Feed a structured history that contains an image part.
+        let imageData = Data([0xFF, 0xD8, 0xFF]) // JPEG magic bytes
+        let history: [StructuredMessage] = [
+            StructuredMessage(role: "user", parts: [
+                .text("Describe this image:"),
+                .image(data: imageData, mimeType: "image/jpeg")
+            ])
+        ]
+        backend.setStructuredHistory(history)
+
+        // generate() should throw immediately — no model is loaded, so we'll
+        // hit the "No model loaded" guard first. Force-load the check by
+        // injecting a model-loaded workaround is not possible without a real
+        // GGUF. We verify the image-part rejection in the integration path
+        // indirectly: the structured history is cached and the guard fires
+        // before `isModelLoaded` in the image check.
+        //
+        // To confirm the image guard message specifically, use a sabotage check:
+        // comment out the image-part throw and verify the test fails.
+        XCTAssertThrowsError(
+            try backend.generate(prompt: "Describe this image:", systemPrompt: nil, config: GenerationConfig())
+        ) { error in
+            guard let inferenceError = error as? InferenceError else {
+                XCTFail("Expected InferenceError, got \(error)")
+                return
+            }
+            if case .inferenceFailure = inferenceError {
+                // Expected — either "No model loaded" (model guard fires first on unloaded
+                // backend) or the xcframework-limitation message (model guard passes).
+            } else {
+                XCTFail("Expected inferenceFailure, got \(inferenceError)")
+            }
+        }
+    }
 }
 #endif

--- a/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
@@ -983,10 +983,8 @@ final class LlamaBackendTests: XCTestCase {
 
     func test_generate_withImageParts_throwsInferenceFailure() {
         let backend = LlamaBackend()
-        // Stage an mmproj URL so the backend advertises supportsVision = true.
         backend.setMmprojURL(URL(fileURLWithPath: "/nonexistent/mmproj-model.gguf"))
 
-        // Feed a structured history that contains an image part.
         let imageData = Data([0xFF, 0xD8, 0xFF]) // JPEG magic bytes
         let history: [StructuredMessage] = [
             StructuredMessage(role: "user", parts: [
@@ -996,28 +994,22 @@ final class LlamaBackendTests: XCTestCase {
         ]
         backend.setStructuredHistory(history)
 
-        // generate() should throw immediately — no model is loaded, so we'll
-        // hit the "No model loaded" guard first. Force-load the check by
-        // injecting a model-loaded workaround is not possible without a real
-        // GGUF. We verify the image-part rejection in the integration path
-        // indirectly: the structured history is cached and the guard fires
-        // before `isModelLoaded` in the image check.
-        //
-        // To confirm the image guard message specifically, use a sabotage check:
-        // comment out the image-part throw and verify the test fails.
+        // The image guard runs before the model-loaded guard so a caller hits
+        // the actionable xcframework-limitation message even when no model is
+        // loaded. Asserting on the message text proves we hit the image guard
+        // and not the generic "No model loaded" path.
         XCTAssertThrowsError(
             try backend.generate(prompt: "Describe this image:", systemPrompt: nil, config: GenerationConfig())
         ) { error in
-            guard let inferenceError = error as? InferenceError else {
-                XCTFail("Expected InferenceError, got \(error)")
+            guard let inferenceError = error as? InferenceError,
+                  case let .inferenceFailure(message) = inferenceError else {
+                XCTFail("Expected InferenceError.inferenceFailure, got \(error)")
                 return
             }
-            if case .inferenceFailure = inferenceError {
-                // Expected — either "No model loaded" (model guard fires first on unloaded
-                // backend) or the xcframework-limitation message (model guard passes).
-            } else {
-                XCTFail("Expected inferenceFailure, got \(inferenceError)")
-            }
+            XCTAssertTrue(message.contains("multimodal image inference is not yet available"),
+                          "expected image-guard message, got: \(message)")
+            XCTAssertTrue(message.contains("clip.h"),
+                          "error message must reference the missing headers so a developer knows the fix")
         }
     }
 }

--- a/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
+++ b/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
@@ -362,3 +362,15 @@ BaseChatVoice/Services/VoiceAudioSessionCoordinator.swift:try? AVAudioSession.sh
 # orphan Keychain item that the bootstrap reaper will sweep on next launch.
 BaseChatUIModelManagement/Views/Settings/APIEndpointEditorView.swift:try? KeychainService.delete(account: newRecord.keychainAccount)
 BaseChatUIModelManagement/Views/Settings/RemoteServerConfigSheet.swift:try? KeychainService.delete(account: record.keychainAccount)
+
+
+# ---------------------------------------------------------------------------
+# BaseChatInference — ModelInfo mmproj companion detection
+# ---------------------------------------------------------------------------
+
+# Best-effort directory scan when auto-detecting an mmproj companion file.
+# On first launch there may be no parent directory yet (new download target),
+# or the directory may be inaccessible due to sandbox restrictions.
+# A nil `candidates` produces an empty array via `?? []`, so `mmprojURL`
+# stays nil — the backend safely operates in text-only mode.
+BaseChatInference/Models/ModelInfo.swift:let candidates = (try? FileManager.default.contentsOfDirectory(


### PR DESCRIPTION
## Summary

Implements the scaffolding layer of issue #416 (Gemma 4 multimodal / mmproj support for LlamaBackend). Full image *inference* is blocked by the vendored xcframework (mattt/llama.swift 2.8772.0, llama.cpp build b8772) which does not expose `clip.h` / `mtmd.h`. This PR wires everything up to the C boundary so upgrading the xcframework in a future PR is the only remaining step.

## What changed

**New protocol — `MultimodalProjectorConfigurable`** (`BackendOptInProtocols.swift`)
Opt-in protocol for backends that accept an mmproj companion file. `ModelLifecycleCoordinator` calls `setMmprojURL` before each `loadModel` via an `as?` cast, so only conforming backends are affected.

**`ModelInfo.mmprojURL: URL?`**
Auto-detected in `init?(ggufURL:)` by scanning the parent directory for a `mmproj*.gguf` sibling (skipped when the GGUF filename itself starts with `mmproj` to avoid circular detection). Exposed via the memberwise init for testing.

**`CuratedModel.mmprojFileName: String?` / `DownloadableModel.mmprojFileName: String?`**
Optional companion filename for the download UI to fetch both the main GGUF and the projector from the same HuggingFace repo. Flows through `init(from curated:)` automatically.

**`LlamaBackend` changes**
- Conforms to `MultimodalProjectorConfigurable`: stores the URL under `stateLock`; `unloadModel()` clears it
- `capabilities` now returns `supportsVision: mmprojURL != nil`  
- Conforms to `StructuredHistoryReceiver`: caches structured history so `generate()` can detect image parts  
- `generate()` throws `InferenceError.inferenceFailure` with a clear xcframework-limitation message when images are present — prevents silent prompt corruption

## What's blocked

Actual image token embedding (calling `llama_clip_model_load`, `llava_eval_image_embed`, or the newer `mtmd_*` API) requires a future xcframework upgrade that includes those headers. The comment in `_mmprojURL` documents the exact blocker (build b8772).

## Tests

- `test_capabilities_supportsVision_withoutMmproj_isFalse`
- `test_capabilities_supportsVision_afterSetMmprojURL_isTrue`
- `test_capabilities_supportsVision_afterClearingMmprojURL_isFalse`
- `test_capabilities_supportsVision_afterUnload_isFalse`
- `test_generate_withImageParts_throwsInferenceFailure`

All 1249 `BaseChatInferenceTests` pass. `BaseChatCoreTests` (347), `BaseChatUITests` (476), `BaseChatMCPTests` (130) all green.

## Release Note

Adds mmproj multimodal projector scaffolding to LlamaBackend. Vision-capable GGUF models (e.g. Gemma 4) now have `supportsVision = true` in their capabilities when a companion `mmproj*.gguf` is present alongside the main GGUF. The download model types (`CuratedModel`, `DownloadableModel`) accept an optional `mmprojFileName` so the download UI can fetch both files. Image inference itself is blocked pending an xcframework upgrade to a build that exposes `clip.h` / `mtmd.h`; passing image parts currently throws a descriptive `InferenceError.inferenceFailure`.