### PR TITLE
feat(runtime): add bootstrap milestone stream

### DIFF
--- a/Sources/BaseChatCore/BaseChatRuntime.swift
+++ b/Sources/BaseChatCore/BaseChatRuntime.swift
@@ -20,9 +20,21 @@ import BaseChatInference
 /// `configure(persistence:)` — runtime support for custom stores is tracked
 /// separately.
 ///
-/// Adopters needing fine-grained progress signals during bootstrap (e.g. splash-screen UI,
-/// per-phase analytics) should construct the runtime on a background task and observe its
-/// returned properties; an `AsyncSequence` of bootstrap milestones is tracked in #872.
+///
+/// ### Splash-screen progress
+///
+/// Call ``build(configuration:inferenceService:diagnostics:makeModelContainer:)``
+/// instead of `init` when you want to drive a launch progress UI. That factory
+/// returns an `AsyncStream<RuntimeBootstrapMilestone>` you can iterate on the
+/// main actor while bootstrap runs concurrently in a sibling task:
+///
+/// ```swift
+/// let (milestones, runtimeTask) = BaseChatRuntime.build(configuration: config)
+/// for await milestone in milestones {
+///     splashProgress = milestone.fractionComplete
+/// }
+/// runtime = try await runtimeTask.value
+/// ```
 @MainActor
 public final class BaseChatRuntime {
 
@@ -66,5 +78,79 @@ public final class BaseChatRuntime {
             BaseChatConfiguration.shared = previousConfiguration
             throw error
         }
+    }
+
+    internal init(
+        inferenceService: InferenceService,
+        diagnostics: DiagnosticsService,
+        modelContainer: ModelContainer,
+        persistence: SwiftDataPersistenceProvider,
+        samplerPresetStore: SwiftDataSamplerPresetStore,
+        benchmarkCache: SwiftDataBenchmarkCache,
+        endpointStore: SwiftDataEndpointStore
+    ) {
+        self.inferenceService = inferenceService
+        self.diagnostics = diagnostics
+        self.modelContainer = modelContainer
+        self.persistence = persistence
+        self.samplerPresetStore = samplerPresetStore
+        self.benchmarkCache = benchmarkCache
+        self.endpointStore = endpointStore
+    }
+
+    public static func build(
+        configuration: BaseChatConfiguration,
+        inferenceService: InferenceService? = nil,
+        diagnostics: DiagnosticsService = DiagnosticsService(),
+        makeModelContainer: @MainActor @escaping () throws -> ModelContainer = { try ModelContainerFactory.makeContainer() }
+    ) -> (progress: AsyncStream<RuntimeBootstrapMilestone>, task: Task<BaseChatRuntime, any Error>) {
+        let (stream, continuation) = AsyncStream.makeStream(
+            of: RuntimeBootstrapMilestone.self,
+            bufferingPolicy: .unbounded
+        )
+
+        let task = Task { @MainActor [continuation] in
+            defer { continuation.finish() }
+
+            let previousConfiguration = BaseChatConfiguration.shared
+            do {
+                continuation.yield(.installingConfiguration)
+                BaseChatConfiguration.shared = configuration
+                await Task.yield()
+
+                continuation.yield(.resolvingInferenceService)
+                let resolvedService = inferenceService ?? InferenceService()
+                await Task.yield()
+
+                continuation.yield(.buildingModelContainer)
+                let container = try makeModelContainer()
+                await Task.yield()
+
+                continuation.yield(.wiringPersistence)
+                let mainContext = container.mainContext
+                let persistence = SwiftDataPersistenceProvider(modelContext: mainContext)
+                let samplerPresetStore = SwiftDataSamplerPresetStore(modelContext: mainContext)
+                let benchmarkCache = SwiftDataBenchmarkCache(modelContext: mainContext)
+                let endpointStore = SwiftDataEndpointStore(modelContext: mainContext)
+                await Task.yield()
+
+                continuation.yield(.complete)
+
+                return BaseChatRuntime(
+                    inferenceService: resolvedService,
+                    diagnostics: diagnostics,
+                    modelContainer: container,
+                    persistence: persistence,
+                    samplerPresetStore: samplerPresetStore,
+                    benchmarkCache: benchmarkCache,
+                    endpointStore: endpointStore
+                )
+            } catch {
+                BaseChatConfiguration.shared = previousConfiguration
+                throw error
+            }
+        }
+
+        return (stream, task)
     }
 }

--- a/Sources/BaseChatCore/RuntimeBootstrapMilestone.swift
+++ b/Sources/BaseChatCore/RuntimeBootstrapMilestone.swift
@@ -1,0 +1,34 @@
+/// Phases emitted during ``BaseChatRuntime`` bootstrap via
+/// ``BaseChatRuntime/build(configuration:inferenceService:diagnostics:makeModelContainer:)``.
+///
+/// Consumers drive splash-screen or launch-progress UI by iterating the
+/// `AsyncStream<RuntimeBootstrapMilestone>` returned alongside the in-flight
+/// bootstrap `Task`. Each case is emitted exactly once, in the order declared,
+/// before the stream finishes.
+public enum RuntimeBootstrapMilestone: Sendable, Hashable, CaseIterable, CustomStringConvertible {
+    case installingConfiguration
+    case resolvingInferenceService
+    case buildingModelContainer
+    case wiringPersistence
+    case complete
+
+    public var fractionComplete: Double {
+        switch self {
+        case .installingConfiguration: return 0.20
+        case .resolvingInferenceService: return 0.40
+        case .buildingModelContainer: return 0.70
+        case .wiringPersistence: return 0.90
+        case .complete: return 1.00
+        }
+    }
+
+    public var description: String {
+        switch self {
+        case .installingConfiguration: return "Installing configuration"
+        case .resolvingInferenceService: return "Resolving inference service"
+        case .buildingModelContainer: return "Building model container"
+        case .wiringPersistence: return "Wiring persistence"
+        case .complete: return "Complete"
+        }
+    }
+}

--- a/Tests/BaseChatCoreTests/RuntimeBootstrapMilestoneTests.swift
+++ b/Tests/BaseChatCoreTests/RuntimeBootstrapMilestoneTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+import SwiftData
+@testable import BaseChatCore
+@testable import BaseChatInference
+
+@MainActor
+final class RuntimeBootstrapMilestoneTests: XCTestCase {
+    func test_build_emitsMilestonesInDeclarationOrder() async throws {
+        let originalConfiguration = BaseChatConfiguration.shared
+        defer { BaseChatConfiguration.shared = originalConfiguration }
+
+        let (progress, task) = BaseChatRuntime.build(
+            configuration: BaseChatConfiguration(
+                appName: "Milestone Order",
+                bundleIdentifier: "com.basechatkit.milestone-tests.order.\(UUID().uuidString)"
+            ),
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+
+        var collected: [RuntimeBootstrapMilestone] = []
+        for await milestone in progress {
+            collected.append(milestone)
+        }
+        _ = try await task.value
+
+        XCTAssertEqual(collected, RuntimeBootstrapMilestone.allCases)
+    }
+
+    func test_build_completeMilestoneIsLast() async throws {
+        let originalConfiguration = BaseChatConfiguration.shared
+        defer { BaseChatConfiguration.shared = originalConfiguration }
+
+        let (progress, task) = BaseChatRuntime.build(
+            configuration: BaseChatConfiguration(
+                appName: "Complete Is Last",
+                bundleIdentifier: "com.basechatkit.milestone-tests.last.\(UUID().uuidString)"
+            ),
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+
+        var last: RuntimeBootstrapMilestone?
+        for await milestone in progress {
+            last = milestone
+        }
+        _ = try await task.value
+
+        XCTAssertEqual(last, .complete)
+    }
+
+    func test_build_streamFinishesWhenMakeModelContainerThrows() async throws {
+        let originalConfiguration = BaseChatConfiguration.shared
+        defer { BaseChatConfiguration.shared = originalConfiguration }
+
+        let (progress, task) = BaseChatRuntime.build(
+            configuration: BaseChatConfiguration(
+                appName: "Failure Stream",
+                bundleIdentifier: "com.basechatkit.milestone-tests.failure.\(UUID().uuidString)"
+            ),
+            makeModelContainer: { throw URLError(.cannotOpenFile) }
+        )
+
+        var collected: [RuntimeBootstrapMilestone] = []
+        for await milestone in progress {
+            collected.append(milestone)
+        }
+
+        XCTAssertFalse(collected.contains(.complete))
+
+        do {
+            _ = try await task.value
+            XCTFail("task.value should have thrown")
+        } catch {
+            XCTAssertTrue(error is URLError)
+        }
+    }
+
+    func test_build_throwingMakeModelContainer_restoresConfiguration() async throws {
+        let originalConfiguration = BaseChatConfiguration.shared
+        defer { BaseChatConfiguration.shared = originalConfiguration }
+
+        let (_, task) = BaseChatRuntime.build(
+            configuration: BaseChatConfiguration(
+                appName: "Rollback",
+                bundleIdentifier: "com.basechatkit.milestone-tests.rollback.\(UUID().uuidString)"
+            ),
+            makeModelContainer: { throw URLError(.cannotOpenFile) }
+        )
+
+        do { _ = try await task.value } catch {}
+
+        XCTAssertEqual(BaseChatConfiguration.shared.bundleIdentifier, originalConfiguration.bundleIdentifier)
+    }
+
+    func test_build_runtimeExposesInjectedInferenceServiceAndContainer() async throws {
+        let originalConfiguration = BaseChatConfiguration.shared
+        defer { BaseChatConfiguration.shared = originalConfiguration }
+
+        let injectedService = InferenceService()
+        let prebuiltContainer = try ModelContainerFactory.makeInMemoryContainer()
+
+        let (progress, task) = BaseChatRuntime.build(
+            configuration: BaseChatConfiguration(
+                appName: "Wiring Identity",
+                bundleIdentifier: "com.basechatkit.milestone-tests.wiring.\(UUID().uuidString)"
+            ),
+            inferenceService: injectedService,
+            makeModelContainer: { prebuiltContainer }
+        )
+
+        for await _ in progress {}
+        let runtime = try await task.value
+
+        XCTAssertTrue(runtime.inferenceService === injectedService)
+        XCTAssertTrue(runtime.modelContainer === prebuiltContainer)
+    }
+
+    func test_fractionComplete_isStrictlyIncreasing() {
+        let fractions = RuntimeBootstrapMilestone.allCases.map(\.fractionComplete)
+        for (index, fraction) in fractions.dropLast().enumerated() {
+            XCTAssertLessThan(fraction, fractions[index + 1])
+        }
+        XCTAssertEqual(fractions.last, 1.0)
+    }
+
+    func test_fractionComplete_isWithinUnitRange() {
+        for milestone in RuntimeBootstrapMilestone.allCases {
+            XCTAssertGreaterThanOrEqual(milestone.fractionComplete, 0.0)
+            XCTAssertLessThanOrEqual(milestone.fractionComplete, 1.0)
+        }
+    }
+
+    func test_build_persistenceRoundTrip() async throws {
+        let originalConfiguration = BaseChatConfiguration.shared
+        defer { BaseChatConfiguration.shared = originalConfiguration }
+
+        let (progress, task) = BaseChatRuntime.build(
+            configuration: BaseChatConfiguration(
+                appName: "Build Persistence",
+                bundleIdentifier: "com.basechatkit.milestone-tests.persistence.\(UUID().uuidString)"
+            ),
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+
+        for await _ in progress {}
+        let runtime = try await task.value
+
+        let session = ChatSessionRecord(title: "Milestone Build Session")
+        try await runtime.persistence.insertSession(session)
+
+        let fetched = try await runtime.persistence.fetchSessions()
+        XCTAssertTrue(fetched.contains(where: { $0.id == session.id }))
+    }
+}


### PR DESCRIPTION
## Summary
- add `RuntimeBootstrapMilestone` plus a non-blocking `BaseChatRuntime.build(...)` factory that returns progress and the runtime task
- keep the existing `BaseChatRuntime` initializer intact for backward compatibility
- add milestone ordering, rollback, and persistence round-trip coverage

## Testing
- swift test --filter BaseChatCoreTests --disable-default-traits *(347 tests, 1 unrelated flaky failure on first run; targeted reruns below passed)*
- swift test --filter RuntimeBootstrapMilestoneTests --disable-default-traits
- swift test --filter "ConversationRuntimeTests/test_regenerate_cancelMidStream_partialContentPersists" --disable-default-traits