### PR TITLE
docs(claude-md): rewrite pre-push checklist to mirror CI's 2-invocation shape

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,13 +127,80 @@ When Apple ships a new major OS each September, bump both minimums by one and re
 
 ## Pre-push checklist
 
-Before pushing any branch, run all CI-safe test suites locally and confirm zero failures:
+Before pushing any branch, run all CI-safe test suites locally and confirm zero failures. Use the **same two-invocation shape CI uses** (`.github/workflows/ci.yml`) — running each suite as a separate `swift test` call pays the build-graph + git-remote + test-bundle-link cost 9× instead of 2× and is ~4–5× slower for identical coverage.
 
 ```bash
-swift test --filter BaseChatCoreTests --disable-default-traits && swift test --filter BaseChatInferenceTests --disable-default-traits && swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits && swift test --filter BaseChatUITests --disable-default-traits && swift test --filter BaseChatUIModelManagementTests --disable-default-traits && swift test --filter BaseChatMCPTests --disable-default-traits && swift test --filter BaseChatBackendsTests --disable-default-traits && swift test --filter BaseChatTestSupportTests --disable-default-traits && swift test --filter BaseChatAppIntentsTests --disable-default-traits
+# 1. XCTest suites — single invocation, all filters at once
+scripts/test.sh --filter BaseChatCoreTests --filter BaseChatUITests \
+  --filter BaseChatUIModelManagementTests --filter BaseChatMCPTests \
+  --filter BaseChatBackendsTests --filter BaseChatInferenceTests \
+  --filter BaseChatTestSupportTests --filter BaseChatAppIntentsTests \
+  --disable-default-traits --skip-update
+
+# 2. Swift Testing — must run in a separate process (XCTest+Swift Testing
+#    in one process triggers a libmalloc SIGABRT — see #681)
+scripts/test.sh --filter BaseChatInferenceSwiftTestingTests \
+  --disable-default-traits --skip-update
 ```
 
+`--skip-update` skips the per-invocation git-remote contact for every dependency (Package.resolved already pins the graph). Drop it only if you've just edited Package.swift.
+
 Never push based on a subset passing. After rebasing, always re-run the full suite before pushing — conflicts can silently break tests that compiled fine before.
+
+### Strong-machine variant: run both invocations concurrently
+
+The two invocations are separate processes — the libmalloc SIGABRT only triggers when XCTest + Swift Testing share a single process (issue #681). On a multi-core machine you can pre-build once and run them in parallel:
+
+```bash
+swift build --build-tests --disable-default-traits
+
+(scripts/test.sh \
+   --filter BaseChatCoreTests --filter BaseChatUITests \
+   --filter BaseChatUIModelManagementTests --filter BaseChatMCPTests \
+   --filter BaseChatBackendsTests --filter BaseChatInferenceTests \
+   --filter BaseChatTestSupportTests --filter BaseChatAppIntentsTests \
+   --disable-default-traits --skip-update) &
+XCTEST_PID=$!
+
+(TMPDIR=/tmp/bck-st-$$ mkdir -p /tmp/bck-st-$$ && \
+ TMPDIR=/tmp/bck-st-$$ scripts/test.sh \
+   --filter BaseChatInferenceSwiftTestingTests \
+   --disable-default-traits --skip-update) &
+ST_PID=$!
+
+wait $XCTEST_PID; XCTEST_RC=$?
+wait $ST_PID;     ST_RC=$?
+[[ $XCTEST_RC -eq 0 && $ST_RC -eq 0 ]] || { echo "FAILED (XCTest=$XCTEST_RC, SwiftTesting=$ST_RC)"; exit 1; }
+```
+
+Per-shell `TMPDIR` keeps `scripts/test.sh`'s `test_output.txt` from clobbering. Wall-clock ≈ max(batch1, batch2) instead of sum.
+
+Within-batch parallelism (`--parallel`) is still blocked by the `UserDefaults.standard` race in `test_autoSelectFirstRunModel_*` and download-tests legacy-key reads — see issue #756 / the follow-up issue tracking the fix.
+
+### Spike gate (bounded changes only)
+
+For changes scoped to a single module or a CI-fix push where you've already validated the rest, you may run only the affected slice:
+
+```bash
+swift build --build-tests --disable-default-traits   # cheap compile gate
+scripts/test.sh --filter <OnlyAffectedSuite> --disable-default-traits --skip-update
+```
+
+This is a **spike gate**, not the pre-push gate. Use it only when:
+- The diff touches one module (e.g. only `BaseChatBackends`), AND
+- You've run the full suite once already on this branch and the change since then is bounded (e.g. fixing a CI failure, addressing a single review comment).
+
+The full two-invocation gate above is mandatory before the **final push** of a branch and after any rebase.
+
+### Trait-combo build sweep (only when needed)
+
+A full-traits build is needed only when a PR adds/modifies a switched enum in a trait-gated file (per past incidents where default-trait build missed CloudSaaS/Ollama-gated cases):
+
+```bash
+swift build --build-tests --traits MLX,Llama,MCPBuiltinCatalog,Ollama,CloudSaaS,HuggingFace
+```
+
+Skip it for pure logic/test changes that don't touch enum surfaces.
 
 When changing behavior of any function or type, grep for ALL test references across the entire `Tests/` directory, not just the obvious test file. Behavior changes require updating every test that asserts on the old behavior:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,7 +175,7 @@ wait $ST_PID;     ST_RC=$?
 
 Per-shell `TMPDIR` keeps `scripts/test.sh`'s `test_output.txt` from clobbering. Wall-clock ≈ max(batch1, batch2) instead of sum.
 
-Within-batch parallelism (`--parallel`) is still blocked by the `UserDefaults.standard` race in `test_autoSelectFirstRunModel_*` and download-tests legacy-key reads — see issue #756 / the follow-up issue tracking the fix.
+Within-batch parallelism (`--parallel`) is still blocked by the `UserDefaults.standard` race in `test_autoSelectFirstRunModel_*` and download-tests legacy-key reads — tracked in issue #910.
 
 ### Spike gate (bounded changes only)
 


### PR DESCRIPTION
## Summary

- Replaces the 9-call `swift test --filter X` chain in CLAUDE.md's pre-push checklist with the same 2-invocation shape CI uses (`.github/workflows/ci.yml:190-200`). Each separate `swift test` call re-validates the build graph, contacts every git remote, and re-links the test bundle — measured locally at ~4–5× CI's wall-clock for identical coverage.
- Adds a **strong-machine variant** that pre-builds once and runs the XCTest batch + Swift Testing batch concurrently in separate shells with isolated TMPDIRs. Wall-clock ≈ max(batch1, batch2) instead of sum.
- Adds a **spike gate** sanctioning the slice-only build+test pattern for bounded CI-fix pushes — the full 2-invocation gate is still mandatory before the final push and after any rebase.
- Adds a **trait-combo build sweep** section so we only pay that cost when adding/modifying switched enums in trait-gated files (matches the lesson from past CloudSaaS/Ollama trait-conditional regressions).
- Cross-references issue #910 — the `UserDefaults.standard` race that currently blocks `swift test --parallel` and which, once fixed, would unlock another ~2× within-batch.

The two-process split (XCTest filters in one call, Swift Testing in a second) is **load-bearing**, not stylistic — mixing the two harnesses in a single process triggers a libmalloc SIGABRT (issue #681). The 9-call chain split was just habit.

## Why this matters

Per-PR macOS CI billing is 10× and each failed push costs ~25 billed minutes. Local pre-push is the gate that prevents that — but if the local gate is so slow the team avoids running it, it doesn't gate anything. Making the local gate match CI's shape (and feel) closes that gap.

Concrete numbers from the most recent worker dispatch:
- Old 9-call chain: ~25 min wall-clock for the full pre-push gate
- New 2-call shape: ~5–6 min (matches CI test job)
- Strong-machine parallel-shells variant: estimated 3–4 min
- Plus issue #910 (parallel-XCTest unlock): ~2 min

## Test plan

- [ ] Reviewer reads the rewritten "Pre-push checklist" section in CLAUDE.md.
- [ ] Spot-check the parallel-shells script for shell-quoting / TMPDIR-isolation correctness.
- [ ] Confirm cross-reference to #681 (libmalloc SIGABRT) and #910 (UserDefaults race) lands the reader on the right context.

No code changes, no CI behavior changes — docs-only.