### PR TITLE
test: deflake regenerate-cancel-midstream race in ConversationRuntimeTests

### DIFF
--- a/Sources/BaseChatTestSupport/MockInferenceBackend.swift
+++ b/Sources/BaseChatTestSupport/MockInferenceBackend.swift
@@ -110,6 +110,23 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
     private var activeContinuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation?
     private let continuationLock = NSLock()
 
+    /// Optional per-token emission gate. When non-nil, the mock awaits
+    /// ``TokenEmissionGate/waitForAdvance()`` BEFORE yielding each visible
+    /// token in `tokens`. The test drives token emission deterministically
+    /// by calling ``TokenEmissionGate/advance()`` once per token it wants
+    /// to release. This eliminates the race in cancel-mid-stream tests
+    /// where the unbounded AsyncStream buffer can otherwise contain the
+    /// terminal `streamFinished(.stop)` event before the test's cancel
+    /// call has propagated.
+    public var tokenEmissionGate: TokenEmissionGate?
+
+    /// Optional per-tool-delta emission gate. Same shape as
+    /// ``tokenEmissionGate``: when non-nil, the mock awaits
+    /// ``TokenEmissionGate/waitForAdvance()`` BEFORE yielding each entry
+    /// of ``scriptedToolCallDeltasPerTurn``. Used by cancel-between-deltas
+    /// contract tests.
+    public var toolDeltaEmissionGate: TokenEmissionGate?
+
     public init(capabilities: BackendCapabilities = BackendCapabilities(
         supportedParameters: [.temperature, .topP, .repeatPenalty],
         maxContextTokens: 4096,
@@ -221,12 +238,20 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
                 }
                 for token in tokens {
                     if Task.isCancelled { break }
+                    if let gate = self.tokenEmissionGate {
+                        await gate.waitForAdvance()
+                        if Task.isCancelled { break }
+                    }
                     continuation.yield(.token(token))
                 }
                 if !Task.isCancelled {
                     if !deltaSequence.isEmpty {
                         for entry in deltaSequence {
                             if Task.isCancelled { break }
+                            if let gate = self.toolDeltaEmissionGate {
+                                await gate.waitForAdvance()
+                                if Task.isCancelled { break }
+                            }
                             switch entry {
                             case .start(let callId, let name):
                                 continuation.yield(.toolCallStart(callId: callId, name: name))
@@ -293,5 +318,57 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
 
     public func setStructuredHistory(_ messages: [StructuredMessage]) {
         lastReceivedStructuredHistory = messages
+    }
+}
+
+/// Test-only gate that pauses ``MockInferenceBackend`` token emission until
+/// the test explicitly releases the next token.
+///
+/// Used to deflake cancel-mid-stream tests where the unbounded AsyncStream
+/// buffer used by `MockInferenceBackend` would otherwise contain the
+/// terminal `streamFinished(.stop)` event before the test's cancel call
+/// can propagate. By gating token emission, the test can:
+///
+/// 1. Release token 1.
+/// 2. Wait until it observes the corresponding `tokenEmitted` from
+///    `runtime.events`.
+/// 3. Issue cancel — guaranteed to land BEFORE token 2 enters the buffer.
+/// 4. (Optionally release further tokens, which the mock's
+///    `Task.isCancelled` check then drops.)
+public actor TokenEmissionGate {
+    private var pendingPermits: Int = 0
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    public init() {}
+
+    /// Suspends the caller until ``advance()`` issues a permit.
+    public func waitForAdvance() async {
+        if pendingPermits > 0 {
+            pendingPermits -= 1
+            return
+        }
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            waiters.append(cont)
+        }
+    }
+
+    /// Issues one permit. If a waiter is already suspended, resumes it;
+    /// otherwise the permit is buffered for the next ``waitForAdvance()``.
+    public func advance() {
+        if !waiters.isEmpty {
+            let cont = waiters.removeFirst()
+            cont.resume()
+        } else {
+            pendingPermits += 1
+        }
+    }
+
+    /// Resumes every pending waiter. Useful in test teardown to ensure
+    /// the mock's emission task can finish even when the test no longer
+    /// cares about additional tokens.
+    public func release() {
+        let pending = waiters
+        waiters.removeAll()
+        for cont in pending { cont.resume() }
     }
 }

--- a/Tests/BaseChatCoreTests/ConversationRuntimeTests.swift
+++ b/Tests/BaseChatCoreTests/ConversationRuntimeTests.swift
@@ -1196,8 +1196,22 @@ final class ConversationRuntimeTests: XCTestCase {
         // stream drains fully, store.messages[assistant].content == "one two"
         // (both tokens), and `sawCancelled` remains false — both XCTAssert
         // calls would fail.
+        //
+        // Determinism: ConversationRuntime.events is a single-consumer
+        // unbounded stream. The previous shape used two separate iterators
+        // (one to trigger cancel, one to wait for streamFinished) and let
+        // the mock fire all tokens into the unbounded buffer before cancel
+        // had a chance to land — which sometimes produced
+        // `.streamFinished(.stop)` instead of `.streamFinished(.cancelled)`.
+        // We now drive the mock's token emission via a `TokenEmissionGate`
+        // and drain `runtime.events` from a single task. Token 1 is released
+        // first; token 2 is released only after we observe `.tokenEmitted`
+        // and issue cancel — by which point the runtime's drain loop sees
+        // `cancelled = true` on its next iteration and breaks.
         let mock = MockInferenceBackend()
         mock.tokensToYield = ["one", " two"]
+        let gate = TokenEmissionGate()
+        mock.tokenEmissionGate = gate
         let (runtime, store, _, _) = makeRuntime(mock: mock)
 
         let sessionID = UUID()
@@ -1208,37 +1222,50 @@ final class ConversationRuntimeTests: XCTestCase {
 
         let handle = try await runtime.regenerate(RegenerateInput(sessionID: sessionID))
 
-        // Cancel after the first token.
-        let cancelTask = Task { @MainActor [runtime] in
+        // Single-consumer drain. We trigger cancel inline the moment we
+        // observe the first `.tokenEmitted`, then continue draining until
+        // the terminal `.streamFinished` arrives.
+        var sawCancelled = false
+        let drain = Task { @MainActor [runtime] in
+            var cancelled = false
             for await event in runtime.events {
-                if case .tokenEmitted = event {
-                    await runtime.cancel(handle)
+                switch event {
+                case .tokenEmitted:
+                    if !cancelled {
+                        cancelled = true
+                        await runtime.cancel(handle)
+                        // Release the gate so the mock's emission task can
+                        // observe its own `Task.isCancelled` (or yield the
+                        // remaining tokens, which the runtime drops because
+                        // it has already broken out of its drain loop).
+                        await gate.release()
+                    }
+                case .streamFinished(_, let reason):
+                    if reason == .cancelled { sawCancelled = true }
+                    return
+                default:
                     break
                 }
             }
         }
-        await cancelTask.value
 
-        // Wait for the terminal event.
-        var sawCancelled = false
-        let waitTask = Task { @MainActor [runtime] in
-            for await event in runtime.events {
-                if case .streamFinished(_, .cancelled) = event {
-                    sawCancelled = true
-                    return
-                }
-                if case .streamFinished = event { return }
-            }
-        }
+        // Release token 1 to start the stream flowing.
+        await gate.advance()
+
+        // Bound the wait so a regression cannot hang CI for the full XCTest
+        // default timeout. 5 s is generous; happy-path is sub-50ms.
         _ = try? await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask { await waitTask.value }
+            group.addTask { await drain.value }
             group.addTask {
                 try await Task.sleep(for: .seconds(5))
-                waitTask.cancel()
+                drain.cancel()
             }
             try await group.next()
             group.cancelAll()
         }
+        // Always release pending waiters so the mock's emission task does
+        // not strand if the test bailed out via the timeout branch.
+        await gate.release()
 
         XCTAssertTrue(sawCancelled, "Cancel propagates to .streamFinished(reason: .cancelled)")
         // User message present; old assistant gone; partial assistant may exist.

--- a/Tests/BaseChatInferenceTests/ToolCallStreamingContractTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolCallStreamingContractTests.swift
@@ -350,8 +350,12 @@ final class ToolCallStreamingContractTests: XCTestCase {
         backend.isModelLoaded = true
 
         // Script the backend to emit a start, two deltas, and then the
-        // authoritative call. The collector task cancels the stream before
-        // reaching the .call event.
+        // authoritative call. The mock pauses on `toolDeltaEmissionGate`
+        // before each entry, which lets us cancel BEFORE `.call` is
+        // yielded into the buffer. Without the gate, the mock would fire
+        // all four entries synchronously into the unbounded AsyncStream
+        // continuation; the collector's break-on-first-delta would race
+        // the buffered `.call` into the residual drain.
         let call = ToolCall(id: "c5", toolName: "partial", arguments: #"{"k":"v"}"#)
         backend.scriptedToolCallDeltasPerTurn = [[
             .start(callId: "c5", name: "partial"),
@@ -360,6 +364,8 @@ final class ToolCallStreamingContractTests: XCTestCase {
             .call(call),
         ]]
         backend.tokensToYield = []
+        let gate = TokenEmissionGate()
+        backend.toolDeltaEmissionGate = gate
 
         let provider = FakeGenerationContextProvider(backend: backend)
         let coordinator = GenerationCoordinator()
@@ -370,18 +376,18 @@ final class ToolCallStreamingContractTests: XCTestCase {
             maxOutputTokens: 32
         )
 
-        var collectedEvents: [GenerationEvent] = []
-
-        // Cancel the stream the moment we observe the first delta (i.e. after
-        // start but before .call). Collect in a separate task so we can act
-        // mid-stream without blocking.
+        // Collect events from a single consumer. Release one delta-gate
+        // permit at a time:
+        //   - Permit 1 → `.start` flows through.
+        //   - Permit 2 → first `.delta` flows; collector breaks here.
+        // After cancel, we release the gate so the mock's emission task
+        // can wake from its wait, observe `Task.isCancelled` (set by
+        // `stopGeneration()`), and exit without yielding `.call`.
         let collector = Task<[GenerationEvent], Never> {
             var events: [GenerationEvent] = []
             do {
                 for try await event in stream.events {
                     events.append(event)
-                    // Stop after we've seen the first delta — we're now past the
-                    // start and before the authoritative call.
                     if case .toolCallArgumentsDelta = event { break }
                 }
             } catch {
@@ -390,24 +396,20 @@ final class ToolCallStreamingContractTests: XCTestCase {
             return events
         }
 
-        // Wait for the collector to consume the first delta, then cancel.
-        collectedEvents = await collector.value
+        // Drive the script forward: `.start` then first `.delta`. Any
+        // further entries stay behind the gate until we explicitly
+        // advance again or release.
+        await gate.advance() // .start
+        await gate.advance() // first .delta — collector will break
 
-        // Use `stopGenerationAndWait()` instead of `stopGeneration()` so the
-        // dispatch task fully unwinds (defer block finishes the continuation)
-        // before we read residual events. Without this await there is a race
-        // under parallel test load: the dispatch loop can yield `.call` after
-        // the consumer broke out of its for-await but before `Task.isCancelled`
-        // is observed inside the loop. We're testing the contract that *no
-        // `.toolCall` reaches the consumer* once the consumer-visible stream
-        // has been cancelled — awaiting the task makes that ordering
-        // deterministic regardless of test parallelism.
-        await coordinator.stopGenerationAndWait()
+        let collectedEvents = await collector.value
+        coordinator.stopGeneration()
+        // Wake the mock so it observes cancellation and exits. Anything
+        // it yields after `stopGeneration()` is dropped because
+        // `stopGeneration()` finished the continuation.
+        await gate.release()
 
         // Gather any remaining events that leaked through after cancellation.
-        // After `stopGenerationAndWait()` the continuation has already been
-        // finished, so this either returns immediately with an empty array or
-        // throws CancellationError (caught below).
         let residual = Task<[GenerationEvent], Never> {
             var events: [GenerationEvent] = []
             do {


### PR DESCRIPTION
## Summary

Deflakes `test_regenerate_cancelMidStream_partialContentPersists` (a phase 1.2.5 ConversationRuntime test from PR #902) and its sibling `test_cancellationAfterStart_doesNotSynthesizePartialCall` in `ToolCallStreamingContractTests`. Both shared the same root cause and have been blocking PRs #902, #905, #908, #909.

### Failure rate before fix

Measured locally with `swift test --skip-build --filter ... --disable-default-traits`:

- `test_regenerate_cancelMidStream_partialContentPersists`: **8/50 failed** (16%)
- `test_cancellationAfterStart_doesNotSynthesizePartialCall`: **2/50 failed** (4%)

### Race description

Both tests used a two-task event-stream consumption pattern: one task watched `runtime.events` (or `stream.events`) for the first `.tokenEmitted` / `.toolCallArgumentsDelta`, called `runtime.cancel(handle)` / `coordinator.stopGeneration()`, and broke out; a second task then drained for the terminal event. The mock's `AsyncStream` continuation has an unbounded buffer, so `MockInferenceBackend` could yield every scripted token (and the terminal `streamFinished(.stop)`) into the buffer before the cancel-trigger task even saw the first event. The first iterator would observe `.stop`, the second wait would too, and `sawCancelled` stayed `false`.

### Fix shape

`Sources/BaseChatTestSupport/MockInferenceBackend.swift`:
- New `TokenEmissionGate` actor (semaphore-style permit + waiter queue).
- `tokenEmissionGate` and `toolDeltaEmissionGate` opt-in properties on `MockInferenceBackend`. When set, the mock awaits a permit before each scripted token / tool-call delta.

`Tests/BaseChatCoreTests/ConversationRuntimeTests.swift`:
- Single-consumer drain. The drain task issues `runtime.cancel(handle)` and `gate.release()` inline the moment it observes `.tokenEmitted`, then keeps draining until `.streamFinished` arrives.
- 5-second task-group timeout bound so a regression cannot hang CI for the XCTest default.

`Tests/BaseChatInferenceTests/ToolCallStreamingContractTests.swift`:
- Same gate-driven approach: explicit `gate.advance()` per scripted entry, then `gate.release()` after `coordinator.stopGeneration()` so the mock can wake and exit.

No production-code changes — the fix is entirely in test infrastructure.

### Pass rate after fix

Both tests: **100/100 pass** locally, multiple runs.

### Sabotage check

Temporarily changed `Sources/BaseChatCore/Services/ConversationRuntime.swift:870` from `reason = .cancelled` to `reason = .stop` (the load-bearing path the test exercises): **0/30 pass**, confirming the fix preserves the assertion's signal. Restored before commit.

### Sibling test status

Fixed. Same root cause (unbounded buffer beats cancel propagation), same fix shape (deterministic gate).

## Test plan
- [x] 100/100 deterministic for both tests with `--skip-build`
- [x] Sabotage check: 0/30 with reason flipped to `.stop`
- [x] Pre-push gate batch 1 (XCTest, 8 filters): 2457/2457 passed
- [x] Pre-push gate batch 2 (Swift Testing): 84/84 passed