### PR TITLE
ci: make changelog lint always report

### DIFF
--- a/.github/workflows/changelog-lint.yml
+++ b/.github/workflows/changelog-lint.yml
@@ -3,10 +3,6 @@ name: Changelog Lint
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "CHANGELOG.md"
-      - ".release-please-manifest.json"
-      - "version.txt"
 
 concurrency:
   group: changelog-lint-${{ github.ref }}
@@ -14,13 +10,18 @@ concurrency:
 
 jobs:
   changelog-lint:
-    # Only run on Release Please PRs
-    if: startsWith(github.head_ref, 'release-please--branches--')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
+      - name: Skip validation for non-Release-Please PRs
+        if: ${{ !startsWith(github.head_ref, 'release-please--branches--') }}
+        run: |
+          echo "Non-Release-Please PR; changelog rewrite validation is not required."
+          echo "Passing changelog-lint to provide the required check context."
+
       - name: Check changelog entries are prose-style
+        if: ${{ startsWith(github.head_ref, 'release-please--branches--') }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary
- make `changelog-lint` workflow trigger on all PRs to `main` (remove path-filter deadlock risk)
- keep changelog enforcement only for Release Please branches (`release-please--branches--*`)
- add an explicit non-Release-Please no-op pass step with clear logging so the required context is always reported safely

## Validation
- `actionlint -color` (pass)
- `bash -n` syntax check for the inline changelog validation shell fragment (pass)
- inspected final diff for `.github/workflows/changelog-lint.yml`

## Required-check / ruleset rollout checklist (maintainer)
- [ ] Confirm this PR merged before tightening required checks
- [ ] Re-verify required contexts on a normal PR: `test` and `changelog-lint` both appear
- [ ] Re-verify Release Please PRs still enforce changelog prose validation
- [ ] Decide policy for `ci.yml` path filtering: today, workflow/docs-only PRs may not emit required `test` context because `CI` is path-filtered. Either:
  - [ ] add a small always-report policy/check-shape workflow/job and eventually require that, or
  - [ ] make `test` always report with a safe no-op shape for out-of-scope changes
- [ ] Apply branch protection/ruleset updates manually after above verification

> This worker did **not** mutate GitHub branch protection or rulesets in code or settings.
