### PR TITLE
ci: add read-only workflow permissions

### DIFF
--- a/.github/workflows/build-modes.yml
+++ b/.github/workflows/build-modes.yml
@@ -61,6 +61,9 @@ concurrency:
   group: build-modes-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   macos-build-and-audit:
     name: ${{ matrix.mode }} (macOS build + audit)

--- a/.github/workflows/changelog-lint.yml
+++ b/.github/workflows/changelog-lint.yml
@@ -8,6 +8,9 @@ concurrency:
   group: changelog-lint-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changelog-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: macos-15  # Apple Silicon (arm64) standard runner to reduce spend

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -14,6 +14,9 @@ name: Fuzz (nightly)
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   fuzz:
     runs-on: [self-hosted, macos, arm64]

--- a/.github/workflows/fuzz-pr.yml
+++ b/.github/workflows/fuzz-pr.yml
@@ -23,6 +23,9 @@ concurrency:
   group: fuzz-pr-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   fuzz:
     runs-on: macos-15

--- a/.github/workflows/fuzz-weekly.yml
+++ b/.github/workflows/fuzz-weekly.yml
@@ -13,6 +13,9 @@ name: Fuzz (weekly rotation)
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   fuzz:
     runs-on: [self-hosted, macos, arm64]

--- a/.github/workflows/known-issue-lint.yml
+++ b/.github/workflows/known-issue-lint.yml
@@ -29,6 +29,9 @@ concurrency:
   group: known-issue-lint-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   known-issue-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-slow-tests.yml
+++ b/.github/workflows/nightly-slow-tests.yml
@@ -23,6 +23,9 @@ concurrency:
   group: nightly-slow-tests
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   slow:
     runs-on: macos-15

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -8,6 +8,7 @@ on:
       - "Tests/**"
       - "Package.swift"
       - "Package.resolved"
+      - ".github/workflows/security-scans.yml"
   push:
     branches: [main]
     paths:
@@ -15,6 +16,7 @@ on:
       - "Tests/**"
       - "Package.swift"
       - "Package.resolved"
+      - ".github/workflows/security-scans.yml"
 
 concurrency:
   group: security-${{ github.event_name }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
Implements PR 2 scope (`ci: tighten workflow permissions and self-triggers`):
- Adds top-level `permissions: contents: read` to read-only workflows:
  - `.github/workflows/ci.yml`
  - `.github/workflows/build-modes.yml`
  - `.github/workflows/fuzz-pr.yml`
  - `.github/workflows/fuzz-nightly.yml`
  - `.github/workflows/fuzz-weekly.yml`
  - `.github/workflows/nightly-slow-tests.yml`
  - `.github/workflows/known-issue-lint.yml`
  - `.github/workflows/changelog-lint.yml`
- Adds self-trigger paths to `.github/workflows/security-scans.yml` so edits to that workflow run Security Scans.

## Validation
- `actionlint -color` (pass)
- GPT-5.3-Codex reviewer pass: no fixes required
- Inspected final diff to confirm only scoped workflow edits.

## Safety / Non-goals
- No branch protection or ruleset settings were changed.
- No changes to `release-provenance.yml`.
- No changes to Dependency Review `continue-on-error` or TruffleHog pinning.
