### PR TITLE
ci: add release provenance rehearsal

### DIFF
--- a/.github/workflows/release-provenance-rehearsal.yml
+++ b/.github/workflows/release-provenance-rehearsal.yml
@@ -17,26 +17,28 @@ permissions:
 jobs:
   rehearsal:
     name: Rehearse release dependency + SBOM generation
-    runs-on: ubuntu-latest
+    # Mirrors release-provenance.yml: SwiftPM trait flags are required to
+    # rehearse the release metadata path without pulling default ML traits.
+    runs-on: macos-15
     steps:
       - name: Checkout PR commit
         uses: actions/checkout@v6
 
-      - name: Set up Swift
-        uses: SwiftyLab/setup-swift@v1.13.0
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
         with:
-          swift-version: "6.1"
+          xcode-version: "26.3"
 
       - name: Verify Swift toolchain matches Package.swift tools-version
         run: ./scripts/check-swift-toolchain.sh
 
       - name: Resolve packages
-        run: swift package resolve
+        run: swift package --disable-default-traits resolve
 
       - name: Snapshot dependency tree
         run: |
           mkdir -p artifacts
-          swift package show-dependencies --format json \
+          swift package --disable-default-traits show-dependencies --format json \
             > artifacts/dependency-tree.json
           python3 -c '
           import json

--- a/.github/workflows/release-provenance-rehearsal.yml
+++ b/.github/workflows/release-provenance-rehearsal.yml
@@ -31,12 +31,12 @@ jobs:
         run: ./scripts/check-swift-toolchain.sh
 
       - name: Resolve packages
-        run: swift package --disable-default-traits resolve
+        run: swift package resolve --disable-default-traits
 
       - name: Snapshot dependency tree
         run: |
           mkdir -p artifacts
-          swift package --disable-default-traits show-dependencies --format json \
+          swift package show-dependencies --disable-default-traits --format json \
             > artifacts/dependency-tree.json
           python3 -c '
           import json

--- a/.github/workflows/release-provenance-rehearsal.yml
+++ b/.github/workflows/release-provenance-rehearsal.yml
@@ -58,7 +58,8 @@ jobs:
           assert bom["specVersion"] == "1.5", "specVersion mismatch"
           assert isinstance(bom["components"], list), "components not a list"
           assert len(bom["components"]) > 0, "no components"
-          print(f"SBOM ok: {len(bom[\"components\"])} components")
+          component_count = len(bom["components"])
+          print(f"SBOM ok: {component_count} components")
           '
 
       - name: Persist rehearsal artifacts

--- a/.github/workflows/release-provenance-rehearsal.yml
+++ b/.github/workflows/release-provenance-rehearsal.yml
@@ -1,0 +1,67 @@
+name: Release Provenance Rehearsal (read-only)
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/release-provenance.yml"
+      - ".github/workflows/release-provenance-rehearsal.yml"
+      - "scripts/generate-sbom.sh"
+      - "scripts/check-swift-toolchain.sh"
+      - "Package.swift"
+      - "Package.resolved"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  rehearsal:
+    name: Rehearse release dependency + SBOM generation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR commit
+        uses: actions/checkout@v6
+
+      - name: Set up Swift
+        uses: SwiftyLab/setup-swift@v1.13.0
+        with:
+          swift-version: "6.1"
+
+      - name: Verify Swift toolchain matches Package.swift tools-version
+        run: ./scripts/check-swift-toolchain.sh
+
+      - name: Resolve packages
+        run: swift package --disable-default-traits resolve
+
+      - name: Snapshot dependency tree
+        run: |
+          mkdir -p artifacts
+          swift package --disable-default-traits show-dependencies --format json \
+            > artifacts/dependency-tree.json
+          python3 -c '
+          import json
+          tree = json.load(open("artifacts/dependency-tree.json"))
+          assert isinstance(tree, dict), "dependency tree is not an object"
+          assert "name" in tree, "dependency tree missing root name"
+          print("Dependency tree json shape OK")
+          '
+
+      - name: Generate CycloneDX SBOM
+        run: |
+          ./scripts/generate-sbom.sh --output artifacts/sbom.cdx.json
+          python3 -c '
+          import json
+          bom = json.load(open("artifacts/sbom.cdx.json"))
+          assert bom["bomFormat"] == "CycloneDX", "bomFormat mismatch"
+          assert bom["specVersion"] == "1.5", "specVersion mismatch"
+          assert isinstance(bom["components"], list), "components not a list"
+          assert len(bom["components"]) > 0, "no components"
+          print(f"SBOM ok: {len(bom[\"components\"])} components")
+          '
+
+      - name: Persist rehearsal artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-provenance-rehearsal-${{ github.sha }}
+          path: artifacts/
+          retention-days: 14

--- a/.github/workflows/release-provenance-rehearsal.yml
+++ b/.github/workflows/release-provenance-rehearsal.yml
@@ -31,12 +31,12 @@ jobs:
         run: ./scripts/check-swift-toolchain.sh
 
       - name: Resolve packages
-        run: swift package resolve --disable-default-traits
+        run: swift package resolve
 
       - name: Snapshot dependency tree
         run: |
           mkdir -p artifacts
-          swift package show-dependencies --disable-default-traits --format json \
+          swift package show-dependencies --format json \
             > artifacts/dependency-tree.json
           python3 -c '
           import json

--- a/.github/workflows/release-provenance.yml
+++ b/.github/workflows/release-provenance.yml
@@ -75,12 +75,12 @@ jobs:
       # Package.resolved is the canonical source of truth; we only run resolve
       # to populate .build for the dependency tree dump.
       - name: Resolve packages
-        run: swift package resolve --disable-default-traits
+        run: swift package resolve
 
       - name: Snapshot dependency tree
         run: |
           mkdir -p artifacts
-          swift package show-dependencies --disable-default-traits --format json \
+          swift package show-dependencies --format json \
             > artifacts/dependency-tree.json
           # Sanity: tree must be non-trivial (we have direct deps).
           test "$(wc -c < artifacts/dependency-tree.json)" -gt 100

--- a/.github/workflows/release-provenance.yml
+++ b/.github/workflows/release-provenance.yml
@@ -66,7 +66,10 @@ jobs:
         # hygiene matters extra here since this workflow signs artifacts.
         uses: SwiftyLab/setup-swift@v1.13.0
         with:
-          swift-version: "6.0"
+          swift-version: "6.1"
+
+      - name: Verify Swift toolchain matches Package.swift tools-version
+        run: ./scripts/check-swift-toolchain.sh
 
       # Resolve dependencies so `swift package show-dependencies` has data.
       # Package.resolved is the canonical source of truth; we only run resolve

--- a/.github/workflows/release-provenance.yml
+++ b/.github/workflows/release-provenance.yml
@@ -98,7 +98,8 @@ jobs:
           assert bom["bomFormat"] == "CycloneDX", "bomFormat mismatch"
           assert bom["specVersion"] == "1.5", "specVersion mismatch"
           assert len(bom["components"]) > 0, "no components"
-          print(f"SBOM ok: {len(bom[\"components\"])} components")
+          component_count = len(bom["components"])
+          print(f"SBOM ok: {component_count} components")
           '
 
       - name: Attest SBOM build provenance

--- a/.github/workflows/release-provenance.yml
+++ b/.github/workflows/release-provenance.yml
@@ -42,7 +42,12 @@ permissions:
 jobs:
   provenance:
     name: Generate SBOM + provenance attestations
-    runs-on: ubuntu-latest
+    # The package uses SwiftPM traits. Ubuntu Swift 6.1.3 can parse the package
+    # but does not accept trait flags on metadata-only `swift package` commands,
+    # which forces default traits and resolves an incompatible ML dependency
+    # graph. Releases are rare, so use the same macOS/Xcode family as CI for
+    # correctness over a small release-time cost increase.
+    runs-on: macos-15
     steps:
       - name: Checkout tagged commit
         uses: actions/checkout@v6
@@ -61,12 +66,10 @@ jobs:
             echo "name=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Set up Swift
-        # Pinned to a tagged release (not @latest or @main) — supply-chain
-        # hygiene matters extra here since this workflow signs artifacts.
-        uses: SwiftyLab/setup-swift@v1.13.0
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
         with:
-          swift-version: "6.1"
+          xcode-version: "26.3"
 
       - name: Verify Swift toolchain matches Package.swift tools-version
         run: ./scripts/check-swift-toolchain.sh
@@ -75,12 +78,12 @@ jobs:
       # Package.resolved is the canonical source of truth; we only run resolve
       # to populate .build for the dependency tree dump.
       - name: Resolve packages
-        run: swift package resolve
+        run: swift package --disable-default-traits resolve
 
       - name: Snapshot dependency tree
         run: |
           mkdir -p artifacts
-          swift package show-dependencies --format json \
+          swift package --disable-default-traits show-dependencies --format json \
             > artifacts/dependency-tree.json
           # Sanity: tree must be non-trivial (we have direct deps).
           test "$(wc -c < artifacts/dependency-tree.json)" -gt 100

--- a/.github/workflows/release-provenance.yml
+++ b/.github/workflows/release-provenance.yml
@@ -75,12 +75,12 @@ jobs:
       # Package.resolved is the canonical source of truth; we only run resolve
       # to populate .build for the dependency tree dump.
       - name: Resolve packages
-        run: swift package --disable-default-traits resolve
+        run: swift package resolve --disable-default-traits
 
       - name: Snapshot dependency tree
         run: |
           mkdir -p artifacts
-          swift package --disable-default-traits show-dependencies --format json \
+          swift package show-dependencies --disable-default-traits --format json \
             > artifacts/dependency-tree.json
           # Sanity: tree must be non-trivial (we have direct deps).
           test "$(wc -c < artifacts/dependency-tree.json)" -gt 100

--- a/scripts/check-swift-toolchain.sh
+++ b/scripts/check-swift-toolchain.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+tools_line=$(head -n 1 Package.swift)
+tools_version=$(printf '%s\n' "$tools_line" | sed -E 's|^//[[:space:]]*swift-tools-version:[[:space:]]*([0-9]+\.[0-9]+).*|\1|')
+if ! [[ "$tools_version" =~ ^[0-9]+\.[0-9]+$ ]]; then
+  echo "Could not parse swift-tools-version from first line of Package.swift: $tools_line"
+  exit 1
+fi
+
+swift_version_full=$(swift -version | head -n 1)
+if command -v xcrun >/dev/null 2>&1; then
+  xcrun_swift_version=$(xcrun swift -version 2>/dev/null | head -n 1 || true)
+  if [[ -n "$xcrun_swift_version" ]]; then
+    swift_version_full="$xcrun_swift_version"
+  fi
+fi
+
+swift_version=$(printf '%s\n' "$swift_version_full" | sed -E 's|.*Swift version ([0-9]+\.[0-9]+).*|\1|')
+if ! [[ "$swift_version" =~ ^[0-9]+\.[0-9]+$ ]]; then
+  echo "Could not parse Swift major.minor from: $swift_version_full"
+  exit 1
+fi
+
+tools_major=${tools_version%.*}; tools_minor=${tools_version#*.}
+swift_major=${swift_version%.*}; swift_minor=${swift_version#*.}
+if (( tools_major > swift_major )) || { (( tools_major == swift_major )) && (( tools_minor > swift_minor )); }; then
+  echo "::error::Package.swift requires swift-tools-version $tools_version but runner has Swift $swift_version. Lower swift-tools-version or upgrade the pinned toolchain."
+  exit 1
+fi
+
+echo "swift-tools-version=$tools_version OK against runner Swift $swift_version"


### PR DESCRIPTION
## Summary
- aligned `.github/workflows/release-provenance.yml` with the SwiftPM 6.1 toolchain required by `Package.swift`.
- added a reusable toolchain guard script (`scripts/check-swift-toolchain.sh`) and run it before SwiftPM metadata commands in the high-privilege release provenance workflow.
- added a separate read-only workflow (`.github/workflows/release-provenance-rehearsal.yml`) for PR/workflow_dispatch rehearsal of package resolve, dependency tree generation, SBOM generation, and JSON-shape validation.
- moved release provenance and rehearsal metadata commands to `macos-15` + Xcode 26.3 because Ubuntu Swift 6.1.3 rejected SwiftPM trait flags on metadata-only package commands, and removing traits resolved the incompatible default ML dependency graph.

## Validation
- `actionlint` (pass)
- `bash -n scripts/check-swift-toolchain.sh scripts/generate-sbom.sh` (pass)
- `./scripts/check-swift-toolchain.sh` (pass)
- `swift package --disable-default-traits resolve` (pass on macOS/Xcode path)
- `swift package --disable-default-traits show-dependencies --format json` + Python JSON-shape assertion (pass)
- `./scripts/generate-sbom.sh --output ...` + Python JSON-shape assertion (pass)
- GitHub check: `Release Provenance Rehearsal (read-only)` (pass)

## Release-permission safety notes
- high-privilege permissions (`contents: write`, `id-token: write`, `attestations: write`) remain only in `release-provenance.yml` for actual release behavior.
- rehearsal workflow has `permissions: contents: read` and performs no release upload, no attestation, and no write actions.
- PR-triggered validation is isolated in the separate read-only workflow, not mixed into the privileged release job.

## Maintainer decisions / follow-ups
- macOS is intentionally used here for correctness; releases are infrequent, so the small release-time cost increase is preferable to release-time provenance failure.
- action SHA pinning for privileged actions is intentionally deferred to a follow-up hardening pass.
