### PR TITLE
ci: harden security scan coverage

### DIFF
--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -4,19 +4,25 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - ".github/**"
+      - "scripts/**"
+      - "docs/**"
+      - "Example/**"
       - "Sources/**"
       - "Tests/**"
       - "Package.swift"
       - "Package.resolved"
-      - ".github/workflows/security-scans.yml"
   push:
     branches: [main]
     paths:
+      - ".github/**"
+      - "scripts/**"
+      - "docs/**"
+      - "Example/**"
       - "Sources/**"
       - "Tests/**"
       - "Package.swift"
       - "Package.resolved"
-      - ".github/workflows/security-scans.yml"
 
 concurrency:
   group: security-${{ github.event_name }}-${{ github.ref }}
@@ -41,8 +47,8 @@ jobs:
       - name: Fail on newly introduced vulnerable dependencies
         # continue-on-error: the action exits non-zero when the repo's dependency
         # graph isn't enabled yet (requires one-time opt-in in repo Settings >
-        # Code security and analysis). Once enabled this will enforce correctly;
-        # until then we don't want it to block merges.
+        # Advanced Security > Dependency graph). Once enabled this should be
+        # switched to fail-closed by removing continue-on-error.
         continue-on-error: true
         uses: actions/dependency-review-action@v4
         with:
@@ -65,5 +71,7 @@ jobs:
       - name: Scan changed commits for leaked secrets
         uses: trufflesecurity/trufflehog@v3.95.2
         with:
+          # Pin the scanner image tag so the composite action doesn't pull latest.
+          version: v3.95.2
           # Keep signal high by failing only on verifiable active secrets.
           extra_args: --results=verified


### PR DESCRIPTION
## Summary
Implements PR 3 of the overnight CI/CD remediation plan.

### What changed
- `.github/workflows/security-scans.yml`
  - Broadened `pull_request` and `push` path filters to include:
    - `.github/**`
    - `scripts/**`
    - `docs/**`
    - `Example/**`
    - existing `Sources/**`, `Tests/**`, `Package.swift`, `Package.resolved`
  - Pinned TruffleHog scanner image via action input:
    - `uses: trufflesecurity/trufflehog@v3.95.2`
    - `with.version: v3.95.2`
  - Kept Dependency Review `continue-on-error: true` and clarified inline note that this should flip to fail-closed after repository Dependency Graph is enabled.

## Validation
- `actionlint` (pass)
- GPT-5.3-Codex reviewer pass: no fixes required
- Verified upstream action metadata for scanner pinning:
  - `trufflesecurity/trufflehog@v3.95.2` `action.yml` exposes `inputs.version` and defaults to `latest`; workflow now sets `version: v3.95.2`.

## Safety / scope checks
- ✅ No branch protection, rulesets, or repo settings were mutated.
- ✅ No release-provenance workflow changes.
- ✅ No diagnostics/nightly workflow changes.

## Dependency Review fail-closed blocker
`continue-on-error` intentionally remains until Dependency Graph is enabled at repository settings.

- [ ] Maintainer: enable **Dependency Graph** in repository settings (`Settings → Security → Advanced Security → Dependency graph`).
- [ ] Follow-up (after enabled): remove `continue-on-error: true` from `Dependency vulnerability review` to enforce fail-closed behavior.
