### PR TITLE
ci: preserve test diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,6 @@ jobs:
             .build/repositories
           key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-fuzz-spm-${{ hashFiles('Package.resolved') }}
             ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
             ${{ runner.os }}-${{ runner.arch }}-spm-
 
@@ -193,7 +192,10 @@ jobs:
       # swift test process triggers a libmalloc double-free SIGABRT (see
       # SwiftTestingAuditTest, #681).
       - name: Test — XCTest suites (Core + UI + UIModelManagement + MCP + Backends + TestSupport + AppIntents)
+        id: test-xctest-suites
         timeout-minutes: 12
+        env:
+          BASECHAT_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-xctest-suites.log
         run: scripts/test.sh --filter BaseChatCoreTests --filter BaseChatUITests --filter BaseChatUIModelManagementTests --filter BaseChatMCPTests --filter BaseChatBackendsTests --filter BaseChatTestSupportTests --filter BaseChatAppIntentsTests --disable-default-traits --skip-update
 
       # BaseChatInferenceTests isolates its UserDefaults-backed migration tests
@@ -204,30 +206,43 @@ jobs:
       # `if: always()` mirrors the Swift Testing step below so a failing batch
       # above still surfaces inference failures in the same run.
       - name: Test — Inference (XCTest, parallel)
+        id: test-inference-xctest
         if: always()
         timeout-minutes: 12
+        env:
+          BASECHAT_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-inference-xctest.log
         run: scripts/test.sh --filter BaseChatInferenceTests --disable-default-traits --skip-update --parallel
 
       # `if: always()` so a failing XCTest step still surfaces Swift Testing
       # failures in the same run — otherwise breakage in both harnesses costs
       # two re-push cycles to triage. The job still fails because step 1 failed.
       - name: Test — Inference (Swift Testing, isolated process)
+        id: test-inference-swift-testing
         if: always()
         timeout-minutes: 12
+        env:
+          BASECHAT_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-inference-swift-testing.log
         run: scripts/test.sh --filter BaseChatInferenceSwiftTestingTests --disable-default-traits --skip-update
 
       - name: Stage test diagnostics
-        # scripts/test.sh writes full captured output to $TMPDIR/test_output.txt
-        # but $TMPDIR on macOS runners is a per-process /var/folders path that
-        # actions/upload-artifact cannot reliably address. Copy into the
-        # workspace so the upload step below can find it. Each test step
-        # overwrites this file, so on failure it holds the failing step's log.
+        # Each test step writes to a unique workspace log path via
+        # BASECHAT_TEST_OUTPUT_FILE so `if: always()` follow-up steps cannot
+        # overwrite a previous failing step's diagnostics.
         if: failure()
+        env:
+          XCTEST_SUITES_FAILED: ${{ steps.test-xctest-suites.outcome == 'failure' }}
+          INFERENCE_XCTEST_FAILED: ${{ steps.test-inference-xctest.outcome == 'failure' }}
+          INFERENCE_SWIFT_TESTING_FAILED: ${{ steps.test-inference-swift-testing.outcome == 'failure' }}
         run: |
           mkdir -p test-diagnostics
-          if [ -n "${TMPDIR:-}" ] && [ -f "${TMPDIR}/test_output.txt" ]; then
-            cp "${TMPDIR}/test_output.txt" test-diagnostics/test_output.txt
-          fi
+          {
+            echo "run-id=${{ github.run_id }}"
+            echo "run-attempt=${{ github.run_attempt }}"
+            echo "job=test"
+            echo "xctest-suites-failed=${XCTEST_SUITES_FAILED}"
+            echo "inference-xctest-failed=${INFERENCE_XCTEST_FAILED}"
+            echo "inference-swift-testing-failed=${INFERENCE_SWIFT_TESTING_FAILED}"
+          } > test-diagnostics/failed-steps.txt
           # Best-effort: copy any xcresult bundles a future xcodebuild step
           # might have produced under DerivedData.
           find "${HOME}/Library/Developer/Xcode/DerivedData" -type d -name "*.xcresult" -maxdepth 6 2>/dev/null \

--- a/.github/workflows/nightly-slow-tests.yml
+++ b/.github/workflows/nightly-slow-tests.yml
@@ -4,7 +4,6 @@ name: Nightly slow tests
 #  - LargeSessionListPerformanceTests — XCTMeasure perf baselines (~65s)
 #  - IntegratedStreamingPerformanceTests — full pipeline TTFT/cadence/E2E baselines (~20s)
 #  - TrafficBoundaryAuditTest — source-tree boundary audit (~50s)
-#  - IntegratedStreamingPerformanceTests — full pipeline streaming baselines (#243)
 # These are gated by RUN_SLOW_TESTS=1 in their setUp; the main `ci.yml`
 # job leaves that unset so they skip there. Local `swift test` runs them
 # unconditionally (CI is also unset locally).
@@ -55,32 +54,41 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-spm-
 
       - name: Test — LargeSessionListPerformanceTests
-        run: scripts/test.sh --filter "BaseChatUITests.LargeSessionListPerformanceTests" --disable-default-traits --skip-update
+        id: test-large-session-list
+        env:
+          BASECHAT_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-large-session-list.log
+        run: scripts/test.sh --filter "BaseChatUITests.LargeSessionListPerformanceTests" --disable-default-traits --skip-update --min-passed 1
 
       - name: Test — IntegratedStreamingPerformanceTests
-        run: scripts/test.sh --filter "BaseChatUITests.IntegratedStreamingPerformanceTests" --disable-default-traits --skip-update
+        id: test-integrated-streaming
+        env:
+          BASECHAT_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-integrated-streaming.log
+        run: scripts/test.sh --filter "BaseChatUITests.IntegratedStreamingPerformanceTests" --disable-default-traits --skip-update --min-passed 1
 
       - name: Test — TrafficBoundaryAuditTest
-        run: scripts/test.sh --filter "BaseChatInferenceTests.TrafficBoundaryAuditTest" --disable-default-traits --skip-update
-
-      - name: Test — IntegratedStreamingPerformanceTests
-        # The test target lands in a follow-up PR (#243). Gate on its file
-        # existing so the nightly job doesn't fail with "no tests matched
-        # filter" between this workflow shipping and #243 merging.
-        if: ${{ hashFiles('**/IntegratedStreamingPerformanceTests*.swift') != '' }}
-        run: scripts/test.sh --filter "BaseChatUITests.IntegratedStreamingPerformanceTests" --disable-default-traits --skip-update
+        id: test-traffic-boundary-audit
+        env:
+          BASECHAT_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-traffic-boundary-audit.log
+        run: scripts/test.sh --filter "BaseChatInferenceTests.TrafficBoundaryAuditTest" --disable-default-traits --skip-update --min-passed 1
 
       - name: Stage test diagnostics
-        # Mirrors ci.yml: scripts/test.sh writes captured stdout/stderr to
-        # $TMPDIR/test_output.txt, but $TMPDIR on macOS runners is a per-process
-        # /var/folders path that actions/upload-artifact cannot reliably address.
-        # Copy into the workspace so the upload step can find it.
+        # Mirrors ci.yml: each step writes to a unique workspace log path so
+        # diagnostics from earlier failures are preserved.
         if: failure()
+        env:
+          LARGE_SESSION_LIST_FAILED: ${{ steps.test-large-session-list.outcome == 'failure' }}
+          INTEGRATED_STREAMING_FAILED: ${{ steps.test-integrated-streaming.outcome == 'failure' }}
+          TRAFFIC_BOUNDARY_AUDIT_FAILED: ${{ steps.test-traffic-boundary-audit.outcome == 'failure' }}
         run: |
           mkdir -p test-diagnostics
-          if [ -n "${TMPDIR:-}" ] && [ -f "${TMPDIR}/test_output.txt" ]; then
-            cp "${TMPDIR}/test_output.txt" test-diagnostics/test_output.txt
-          fi
+          {
+            echo "run-id=${{ github.run_id }}"
+            echo "run-attempt=${{ github.run_attempt }}"
+            echo "job=slow"
+            echo "large-session-list-failed=${LARGE_SESSION_LIST_FAILED}"
+            echo "integrated-streaming-failed=${INTEGRATED_STREAMING_FAILED}"
+            echo "traffic-boundary-audit-failed=${TRAFFIC_BOUNDARY_AUDIT_FAILED}"
+          } > test-diagnostics/failed-steps.txt
 
       - name: Upload test diagnostics on failure
         if: failure()

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -102,9 +102,9 @@ fi
 # Lines: "✔ Test foo() passed after N seconds."
 #        "✘ Test foo() failed after N seconds."
 #        "↩ Test foo() skipped after N seconds."
-st_passed=$(grep -c "^✔ Test .* passed after " "$OUTPUT_FILE" || true)
-st_failed=$(grep -c "^✘ Test .* failed after " "$OUTPUT_FILE" || true)
-st_skipped=$(grep -c "^↩ Test .* skipped after " "$OUTPUT_FILE" || true)
+st_passed=$(awk '/^✔ Test .* passed after / && $0 !~ /^✔ Test run / { count++ } END { print count + 0 }' "$OUTPUT_FILE")
+st_failed=$(awk '/^✘ Test .* failed after / && $0 !~ /^✘ Test run / { count++ } END { print count + 0 }' "$OUTPUT_FILE")
+st_skipped=$(awk '/^↩ Test .* skipped after / && $0 !~ /^↩ Test run / { count++ } END { print count + 0 }' "$OUTPUT_FILE")
 
 # Swift Testing suites: "◇ Suite "Name" started." vs "✔ Suite "Name" passed after N seconds."
 st_suites_started=$(grep '^◇ Suite "' "$OUTPUT_FILE" \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -31,7 +31,7 @@
 
 set -euo pipefail
 
-OUTPUT_FILE="${TMPDIR:-/tmp}/test_output.txt"
+OUTPUT_FILE="${BASECHAT_TEST_OUTPUT_FILE:-${TMPDIR:-/tmp}/test_output.txt}"
 PACKAGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
 # ── Arguments ────────────────────────────────────────────────────────────────
@@ -58,6 +58,7 @@ echo ""
 # swift PM writes build progress + error lines to stderr; test output to stdout.
 # We merge both so signal-crash lines (stderr) land alongside test lines (stdout).
 cd "$PACKAGE_DIR"
+mkdir -p "$(dirname "$OUTPUT_FILE")"
 set +e
 swift test "${SWIFT_ARGS[@]}" 2>&1 | tee "$OUTPUT_FILE"
 SWIFT_EXIT=${PIPESTATUS[0]}


### PR DESCRIPTION
## Summary
- Preserve per-step CI diagnostics by adding `BASECHAT_TEST_OUTPUT_FILE` support in `scripts/test.sh` (default behavior unchanged: `$TMPDIR/test_output.txt`).
- Update `ci.yml` test steps to write unique log files, then stage/upload all logs plus simple failed-step metadata so later `if: always()` steps cannot overwrite earlier failure diagnostics.
- Remove duplicate `IntegratedStreamingPerformanceTests` invocation from nightly slow tests.
- Add `--min-passed 1` guards to nightly slow test filters to fail clearly when filters go stale/rename.
- Fix `scripts/test.sh` Swift Testing counters so the harness summary line (`✔ Test run ... passed`) is not counted as a real passed test; this makes `--min-passed` catch zero-match filters.
- Clean one stale CI cache restore prefix (`xcode-26.3-fuzz-spm-*`) from `ci.yml` only.

## Validation
- `actionlint -color` ✅
- `bash -n scripts/test.sh` ✅
- `BASECHAT_TEST_OUTPUT_FILE=... scripts/test.sh --filter BaseChatTestSupportTests --disable-default-traits --skip-update --min-passed 1` ✅
- Zero-match guard: `BASECHAT_TEST_OUTPUT_FILE=... scripts/test.sh --filter DefinitelyNoSuchSuiteOrTest --disable-default-traits --skip-update --min-passed 1` -> nonzero ✅
- GPT-5.3-Codex reviewer pass: no fixes required ✅
