### PR TITLE
ci: add bounded example and fuzz coverage

### DIFF
--- a/.github/workflows/example-ui-smoke.yml
+++ b/.github/workflows/example-ui-smoke.yml
@@ -1,0 +1,34 @@
+name: Example UI smoke (advisory)
+
+on:
+  schedule:
+    # Weekly Monday 06:15 UTC keeps macOS simulator spend bounded.
+    - cron: "15 6 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: advisory-example-ui-smoke
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: macos-15
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.3"
+
+      - name: Build Example app UI tests
+        run: scripts/example-ui-tests.sh build-for-testing
+
+      - name: Run Example UI smoke test
+        run: scripts/example-ui-tests.sh test-without-building -only-testing:BaseChatDemoUITests/ChatFlowUITests/testEmptyStateShowsWelcome

--- a/.github/workflows/fuzz-hosted-heartbeat.yml
+++ b/.github/workflows/fuzz-hosted-heartbeat.yml
@@ -1,0 +1,63 @@
+name: Fuzz hosted heartbeat (advisory)
+
+on:
+  schedule:
+    # Daily heartbeat on hosted runners; real Ollama tiers stay self-hosted/manual.
+    - cron: "35 6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: advisory-fuzz-hosted-heartbeat
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  heartbeat:
+    runs-on: macos-15
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.3"
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v5
+        with:
+          path: |
+            .build/artifacts
+            .build/checkouts
+            .build/repositories
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
+
+      - name: Run hosted fuzz heartbeat (mock + chaos)
+        run: |
+          swift run --disable-default-traits fuzz-chat \
+            --backend mock \
+            --iterations 80 \
+            --seed ${{ github.run_number }} \
+            --corpus-subset smoke \
+            --quiet
+          swift run --disable-default-traits fuzz-chat \
+            --backend chaos \
+            --iterations 80 \
+            --seed ${{ github.run_number }} \
+            --corpus-subset smoke \
+            --quiet
+
+      - name: Upload hosted heartbeat findings
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fuzz-hosted-heartbeat-findings-${{ github.run_id }}
+          path: tmp/fuzz/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/FUZZING.md
+++ b/FUZZING.md
@@ -332,7 +332,7 @@ Use it for regression testing after changes to tool-calling logic in `BaseChatTo
 
 ## CI tiers
 
-The fuzzer runs on three tiers so each PR pays a small, bounded cost and larger
+The fuzzer runs on four tiers so each PR pays a small, bounded cost and larger
 investments are scheduled rather than blocking merges.
 
 ### PR tier — `.github/workflows/fuzz-pr.yml`
@@ -368,6 +368,15 @@ The `expires` field is strict — past that date the PR job fails even if the ha
 - **Backend:** real Ollama `qwen3.5:4b`. The seed is derived from `github.run_number` so each nightly run samples a different slice of the mutator space.
 - **Gate:** the job fails if `tmp/fuzz/index.json` contains any `confirmed`-severity finding. `flaky`-severity findings are uploaded as artefacts and do not fail the build (they are leads, not regressions).
 - **Artefacts:** the full `tmp/fuzz/` tree uploads to `fuzz-nightly-findings-<run-id>` every run.
+
+### Hosted heartbeat tier — `.github/workflows/fuzz-hosted-heartbeat.yml`
+
+- **When:** daily schedule (`06:35 UTC`) and `workflow_dispatch`.
+- **Runner:** `macos-15` (GitHub-hosted).
+- **Budget:** bounded deterministic smoke campaigns: `--iterations 80` on `mock`, then `--iterations 80` on `chaos`.
+- **Backend:** `--backend mock` and `--backend chaos` only — no Ollama dependency and no self-hosted hardware.
+- **Gate:** advisory heartbeat only. The workflow is intentionally non-required; it is used to catch harness regressions/flakes between manual self-hosted runs.
+- **Artefacts:** uploads `tmp/fuzz/` to `fuzz-hosted-heartbeat-findings-<run-id>` on every run.
 
 ### Weekly tier — `.github/workflows/fuzz-weekly.yml`
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -77,7 +77,7 @@ UI automation tests that launch the real Example app in a simulator and drive it
 | `BaseChatTestSupportTests` | Unit | Yes | None | XCTest |
 | `BaseChatE2ETests` | E2E | Yes | None (mock backends) | Swift Testing |
 | `BaseChatMLXIntegrationTests` | E2E | No | Apple Silicon + Metal + local MLX model | XCTest |
-| `BaseChatDemoUITests` | XCUITest | No | Simulator | XCTest (XCUIApplication) |
+| `BaseChatDemoUITests` | XCUITest | Advisory only (`example-ui-smoke`) | Simulator | XCTest (XCUIApplication) |
 
 ### Running tests
 


### PR DESCRIPTION
## Summary
- add a scheduled + manual advisory Example UI smoke workflow (`example-ui-smoke.yml`) that runs one critical XCUITest flow via `scripts/example-ui-tests.sh`
- add a scheduled + manual advisory hosted fuzz heartbeat workflow (`fuzz-hosted-heartbeat.yml`) that runs bounded mock + chaos `fuzz-chat` campaigns on GitHub-hosted macOS
- document the new hosted heartbeat fuzz tier in `FUZZING.md` and mark Example UI coverage as advisory CI in `TESTING.md`

## Validation
- `actionlint -color` ✅
- `bash -n scripts/example-ui-tests.sh` ✅
- `swift run --disable-default-traits fuzz-chat --backend mock --iterations 3 --seed 1 --corpus-subset smoke --quiet` ✅
- `swift run --disable-default-traits fuzz-chat --backend chaos --iterations 3 --seed 1 --corpus-subset smoke --quiet` ✅
- GPT-5.3-Codex reviewer pass: no fixes required ✅

## Advisory / non-required note
These workflows are intentionally schedule + workflow_dispatch only and non-required for now to gather flake/runtime data before any required-check promotion.

## Skipped validation
- did not run full local Example XCUITest execution in this session to avoid long simulator runtime and cost; workflow commands were syntax/path validated and wired to the repo's existing script/test selector.
