### PR TITLE
fix: require approval for AppIntent tools

### DIFF
--- a/Sources/BaseChatAppIntents/AppIntentToolExecutor.swift
+++ b/Sources/BaseChatAppIntents/AppIntentToolExecutor.swift
@@ -53,7 +53,29 @@ import AppIntents
 @available(iOS 26, macOS 26, *)
 public struct AppIntentToolExecutor<Intent: AppIntent & Decodable>: ToolExecutor {
 
+    /// Approval policy for AppIntent-backed tools.
+    ///
+    /// Use ``requiresUserApproval`` for side-effecting intents (the default),
+    /// and ``readOnlyAutoApprove`` only for deliberately read-only intents.
+    public enum ApprovalPolicy: Sendable {
+        /// Require an explicit ``ToolApprovalGate`` decision per call.
+        case requiresUserApproval
+
+        /// Skip approval prompts for read-only intents that are safe to run.
+        case readOnlyAutoApprove
+
+        var requiresApproval: Bool {
+            switch self {
+            case .requiresUserApproval:
+                true
+            case .readOnlyAutoApprove:
+                false
+            }
+        }
+    }
+
     public let definition: ToolDefinition
+    public let requiresApproval: Bool
 
     /// Creates an executor that exposes `intentType` as a model-callable tool.
     ///
@@ -62,12 +84,22 @@ public struct AppIntentToolExecutor<Intent: AppIntent & Decodable>: ToolExecutor
     ///   - description: Optional human-readable description shown to the
     ///     model. Defaults to the intent's ``AppIntent/title`` (resolved via
     ///     `String(localized:)`).
-    public init(_ intentType: Intent.Type, description: String? = nil) {
+    ///   - approvalPolicy: Approval behavior for this tool. Defaults to
+    ///     ``ApprovalPolicy/requiresUserApproval`` because AppIntents often
+    ///     trigger external side effects. Opt into
+    ///     ``ApprovalPolicy/readOnlyAutoApprove`` only for deliberately
+    ///     read-only intents.
+    public init(
+        _ intentType: Intent.Type,
+        description: String? = nil,
+        approvalPolicy: ApprovalPolicy = .requiresUserApproval
+    ) {
         let toolName = Self.canonicalName(for: intentType)
         let toolDescription = description ?? Self.defaultDescription(for: intentType)
         let parameters = JSONSchemaBuilder.schema(for: Intent.self) {
             Intent()
         }
+        self.requiresApproval = approvalPolicy.requiresApproval
         self.definition = ToolDefinition(
             name: toolName,
             description: toolDescription,

--- a/Sources/BaseChatAppIntents/BaseChatAppIntents.docc/BaseChatAppIntents.md
+++ b/Sources/BaseChatAppIntents/BaseChatAppIntents.docc/BaseChatAppIntents.md
@@ -43,6 +43,18 @@ inferenceService.toolRegistry = registry
 The model now sees `ask_base_chat_demo_intent` in its tool list and can
 invoke it whenever the conversation calls for it.
 
+`AppIntentToolExecutor` requires per-call approval by default. For explicitly
+read-only intents, opt out deliberately:
+
+```swift
+registry.register(
+    AppIntentToolExecutor(
+        AskBaseChatDemoIntent.self,
+        approvalPolicy: .readOnlyAutoApprove
+    )
+)
+```
+
 ## Decodable boilerplate
 
 AppIntents do not synthesise `Decodable` automatically because the

--- a/Tests/BaseChatAppIntentsTests/AppIntentToolExecutorTests.swift
+++ b/Tests/BaseChatAppIntentsTests/AppIntentToolExecutorTests.swift
@@ -384,8 +384,16 @@ final class AppIntentToolExecutorTests: XCTestCase {
         // executor in production.
         let executor: any ToolExecutor = AppIntentToolExecutor(GreetingIntent.self)
         XCTAssertEqual(executor.definition.name, "greeting_intent")
-        XCTAssertFalse(executor.requiresApproval, "default `requiresApproval` is false")
+        XCTAssertTrue(executor.requiresApproval, "AppIntent executors require approval by default")
         XCTAssertFalse(executor.supportsConcurrentDispatch, "default sequential dispatch")
+    }
+
+    func testReadOnlyApprovalPolicyCanOptOutOfPrompt() {
+        let executor: any ToolExecutor = AppIntentToolExecutor(
+            GreetingIntent.self,
+            approvalPolicy: .readOnlyAutoApprove
+        )
+        XCTAssertFalse(executor.requiresApproval, "read-only AppIntent tools can be deliberately auto-approved")
     }
 }
 


### PR DESCRIPTION
## Summary
- make AppIntentToolExecutor require approval by default by overriding requiresApproval
- add an explicit approvalPolicy enum with a deliberate read-only opt-out (`.readOnlyAutoApprove`)
- document the default and opt-out in BaseChatAppIntents DocC
- update/add AppIntent executor tests for default approval and opt-out behavior

## Testing
- `swift test --filter BaseChatAppIntentsTests --disable-default-traits --skip-update`
- `swift test --filter ToolApprovalGateTests --disable-default-traits --skip-update`
- `swift test --filter GenerationCoordinatorApprovalTests --disable-default-traits --skip-update`

## Migration note
AppIntentToolExecutor now requires approval by default. For intentionally read-only AppIntents, pass `approvalPolicy: .readOnlyAutoApprove` when constructing the executor.
