### PR TITLE
fix: limit clipboard sync for copied chat text

### DIFF
--- a/Sources/BaseChatUI/Internal/ClipboardWriter.swift
+++ b/Sources/BaseChatUI/Internal/ClipboardWriter.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+#if os(iOS)
+import UIKit
+import UniformTypeIdentifiers
+#elseif os(macOS)
+import AppKit
+#endif
+
+enum ClipboardWriter {
+    #if os(iOS)
+    static let expirationInterval: TimeInterval = 120
+    #endif
+
+    static func copy(_ text: String) {
+        #if os(iOS)
+        UIPasteboard.general.setItems([[UTType.plainText.identifier: text]], options: pasteboardOptions())
+        #elseif os(macOS)
+        // AppKit pasteboard APIs do not expose local-only or expiration controls.
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        #endif
+    }
+
+    #if os(iOS)
+    static func pasteboardOptions(now: Date = Date()) -> [UIPasteboard.OptionsKey: Any] {
+        [
+            .localOnly: true,
+            .expirationDate: now.addingTimeInterval(expirationInterval),
+        ]
+    }
+    #endif
+}

--- a/Sources/BaseChatUI/Views/Chat/AssistantMarkdownView.swift
+++ b/Sources/BaseChatUI/Views/Chat/AssistantMarkdownView.swift
@@ -132,7 +132,7 @@ private struct AssistantCodeBlockView: View {
                 }
                 Spacer()
                 Button {
-                    copyToClipboard(code)
+                    ClipboardWriter.copy(code)
                 } label: {
                     Label("Copy", systemImage: "doc.on.doc")
                         .font(.caption)
@@ -153,14 +153,6 @@ private struct AssistantCodeBlockView: View {
         .background(.fill.quaternary, in: RoundedRectangle(cornerRadius: 10))
     }
 
-    private func copyToClipboard(_ text: String) {
-        #if os(iOS)
-        UIPasteboard.general.string = text
-        #elseif os(macOS)
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(text, forType: .string)
-        #endif
-    }
 }
 
 #Preview("Plain Text") {

--- a/Sources/BaseChatUI/Views/Chat/MessageActionMenu.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessageActionMenu.swift
@@ -63,7 +63,7 @@ public struct MessageActionMenuModifier: ViewModifier {
 
     private var copyButton: some View {
         Button {
-            copyToClipboard(message.content)
+            ClipboardWriter.copy(message.content)
         } label: {
             Label("Copy", systemImage: "doc.on.doc")
         }
@@ -118,17 +118,6 @@ public struct MessageActionMenuModifier: ViewModifier {
                 }
         }
         .presentationDetents([.medium, .large])
-    }
-
-    // MARK: - Clipboard
-
-    private func copyToClipboard(_ text: String) {
-        #if os(iOS)
-        UIPasteboard.general.string = text
-        #elseif os(macOS)
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(text, forType: .string)
-        #endif
     }
 }
 

--- a/Tests/BaseChatInferenceTests/TrafficBoundaryAuditTest.swift
+++ b/Tests/BaseChatInferenceTests/TrafficBoundaryAuditTest.swift
@@ -186,14 +186,10 @@ final class TrafficBoundaryAuditTest: XCTestCase {
     ///
     /// **Cap: 6 entries.**
     private static let privacyAPIAllowlist: Set<String> = [
-        // Justification: user-initiated copy of an assistant message to the
-        // clipboard. A regulated build should pair this with `localOnly = true`
-        // to keep content off Universal Clipboard / iCloud sync; tracked
-        // for follow-up alongside the THREAT_MODEL.md non-mitigations list.
-        "BaseChatUI/Views/Chat/AssistantMarkdownView.swift:UIPasteboard.general.string = text",
-        // Justification: same as above — copy-text affordance on the message
-        // action menu. Same follow-up applies.
-        "BaseChatUI/Views/Chat/MessageActionMenu.swift:UIPasteboard.general.string = text",
+        // Justification: user-initiated copy action in chat/code affordances.
+        // iOS uses local-only pasteboard entries with expiration; macOS lacks
+        // equivalent AppKit controls and remains best-effort global pasteboard.
+        "BaseChatUI/Internal/ClipboardWriter.swift:UIPasteboard.general.setItems([[UTType.plainText.identifier: text]], options: pasteboardOptions())",
     ]
 
     // MARK: - Test entry points

--- a/Tests/BaseChatUITests/ClipboardWriterTests.swift
+++ b/Tests/BaseChatUITests/ClipboardWriterTests.swift
@@ -1,0 +1,22 @@
+@preconcurrency import XCTest
+@testable import BaseChatUI
+
+#if os(iOS)
+@MainActor
+final class ClipboardWriterTests: XCTestCase {
+    func test_pasteboardOptions_useLocalOnlyAndExpiration() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+        let options = ClipboardWriter.pasteboardOptions(now: now)
+
+        XCTAssertEqual(options[.localOnly] as? Bool, true)
+        let expiration = options[.expirationDate] as? Date
+        XCTAssertNotNil(expiration)
+        XCTAssertEqual(
+            expiration?.timeIntervalSince1970,
+            now.addingTimeInterval(ClipboardWriter.expirationInterval).timeIntervalSince1970,
+            accuracy: 0.001
+        )
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add a shared `ClipboardWriter` helper for chat/code copy actions
- on iOS, write copied text with `UIPasteboard.setItems` using `.localOnly = true` and `.expirationDate`
- keep macOS copy behavior via `NSPasteboard.general` with a documented AppKit limitation
- route both copy call sites (`MessageActionMenu`, `AssistantMarkdownView`) through the helper
- tighten `TrafficBoundaryAuditTest` allowlist to the single reviewed helper callsite

## Tests
- `scripts/test.sh --filter TrafficBoundaryAuditTest --disable-default-traits --skip-update`
- `scripts/test.sh --filter AssistantMarkdownRenderingTests --disable-default-traits --skip-update`
- `scripts/test.sh --filter ClipboardWriterTests --disable-default-traits --skip-update` *(no matching tests on macOS; iOS-gated test)*

## Platform caveat
- AppKit does not provide local-only or expiration controls on `NSPasteboard`, so macOS remains best-effort global pasteboard behavior.