### PR TITLE
fix: route MCP networking through shared boundary

### DIFF
--- a/Sources/BaseChatMCP/InternalMCPTransport.swift
+++ b/Sources/BaseChatMCP/InternalMCPTransport.swift
@@ -16,7 +16,7 @@ internal struct MCPTransportConfiguration: Sendable {
     let authorization: any MCPAuthorization
     let sseLimits: SSEStreamLimits
     let maxMessageBytes: Int
-    let session: URLSession
+    private let sessionProvider: @Sendable () throws -> URLSession
 
     init(
         endpoint: URL,
@@ -24,14 +24,33 @@ internal struct MCPTransportConfiguration: Sendable {
         authorization: any MCPAuthorization,
         sseLimits: SSEStreamLimits,
         maxMessageBytes: Int,
-        session: URLSession = .shared
+        session: URLSession
     ) {
         self.endpoint = endpoint
         self.headers = headers
         self.authorization = authorization
         self.sseLimits = sseLimits
         self.maxMessageBytes = maxMessageBytes
-        self.session = session
+        self.sessionProvider = { session }
+    }
+
+    init(
+        endpoint: URL,
+        headers: [String: String],
+        authorization: any MCPAuthorization,
+        sseLimits: SSEStreamLimits,
+        maxMessageBytes: Int
+    ) {
+        self.endpoint = endpoint
+        self.headers = headers
+        self.authorization = authorization
+        self.sseLimits = sseLimits
+        self.maxMessageBytes = maxMessageBytes
+        self.sessionProvider = MCPURLSessionFactory.throwingShared
+    }
+
+    func session() throws -> URLSession {
+        try sessionProvider()
     }
 }
 
@@ -69,7 +88,7 @@ internal actor MCPStreamableHTTPTransport: MCPTransport {
             request.setValue(header, forHTTPHeaderField: "Authorization")
         }
 
-        let (bytes, response) = try await configuration.session.bytes(for: request)
+        let (bytes, response) = try await configuration.session().bytes(for: request)
         guard let http = response as? HTTPURLResponse else {
             throw MCPError.transportFailure("Missing HTTP response")
         }
@@ -134,7 +153,7 @@ internal actor MCPStreamableHTTPTransport: MCPTransport {
             request.setValue(header, forHTTPHeaderField: "Authorization")
         }
 
-        let (data, response) = try await configuration.session.data(for: request)
+        let (data, response) = try await configuration.session().data(for: request)
         guard let http = response as? HTTPURLResponse else {
             throw MCPError.transportFailure("Missing HTTP response")
         }

--- a/Sources/BaseChatMCP/MCPOAuth.swift
+++ b/Sources/BaseChatMCP/MCPOAuth.swift
@@ -263,7 +263,7 @@ public actor MCPOAuthAuthorization: MCPAuthorization {
     private let redirectListener: any MCPOAuthRedirectListener
     private let tokenStore: MCPOAuthTokenStore
     private let random: @Sendable () -> Data
-    private let session: URLSession
+    private let sessionProvider: @Sendable () throws -> URLSession
     private let currentDate: @Sendable () -> Date
 
     // Optional event stream for surfacing scope downgrades and TOFU discovery events
@@ -289,7 +289,7 @@ public actor MCPOAuthAuthorization: MCPAuthorization {
         tokenStore: MCPOAuthTokenStore = .keychain,
         clock: any Clock<Duration> = ContinuousClock(),
         random: @escaping @Sendable () -> Data = { Data() },
-        session: URLSession = .shared,
+        session: URLSession? = nil,
         currentDate: @escaping @Sendable () -> Date = Date.init,
         eventContinuation: AsyncStream<MCPConnectionEvent>.Continuation? = nil
     ) {
@@ -299,7 +299,11 @@ public actor MCPOAuthAuthorization: MCPAuthorization {
         self.redirectListener = redirectListener
         self.tokenStore = tokenStore
         self.random = random
-        self.session = session
+        if let session {
+            self.sessionProvider = { session }
+        } else {
+            self.sessionProvider = MCPURLSessionFactory.throwingShared
+        }
         self.currentDate = currentDate
         self.eventContinuation = eventContinuation
         _ = clock
@@ -361,7 +365,7 @@ public actor MCPOAuthAuthorization: MCPAuthorization {
             request.httpMethod = "DELETE"
             request.setValue("Bearer \(managementToken)", forHTTPHeaderField: "Authorization")
             request.timeoutInterval = 5
-            _ = try await session.data(for: request)
+            _ = try await sessionProvider().data(for: request)
             Log.inference.info("MCPOAuthAuthorization: dynamic client deregistered for \(self.serverID)")
         } catch {
             Log.inference.warning("MCPOAuthAuthorization: client deregistration request failed (best-effort): \(error.localizedDescription)")
@@ -497,7 +501,7 @@ public actor MCPOAuthAuthorization: MCPAuthorization {
         } else {
             let resourceMetadataURL = Self.resourceMetadataURL(for: resourceURL)
             try enforceHTTPS(resourceMetadataURL, label: "resource metadata")
-            let (data, response) = try await session.data(for: URLRequest(url: resourceMetadataURL))
+            let (data, response) = try await sessionProvider().data(for: URLRequest(url: resourceMetadataURL))
             try requireSuccess(response: response, body: data, operation: "resource metadata discovery")
             let resourceMetadata = try decoder.decode(OAuthProtectedResourceMetadata.self, from: data)
             guard let candidateIssuers = resourceMetadata.authorizationServers, candidateIssuers.isEmpty == false else {
@@ -527,7 +531,7 @@ public actor MCPOAuthAuthorization: MCPAuthorization {
         let metadataURL = Self.authorizationMetadataURL(for: issuer)
         try enforceHTTPS(metadataURL, label: "authorization metadata")
         // Redirect cap: metadata fetches must not follow more than one redirect.
-        let (metadataData, metadataResponse) = try await session.data(
+        let (metadataData, metadataResponse) = try await sessionProvider().data(
             for: URLRequest(url: metadataURL),
             delegate: MCPRedirectCapDelegate()
         )
@@ -603,7 +607,7 @@ public actor MCPOAuthAuthorization: MCPAuthorization {
         request.httpBody = Self.formURLEncoded(parameters).data(using: .utf8)
 
         // Redirect cap: token exchanges must not follow more than one redirect.
-        let (data, response) = try await session.data(for: request, delegate: MCPRedirectCapDelegate())
+        let (data, response) = try await sessionProvider().data(for: request, delegate: MCPRedirectCapDelegate())
         guard let http = response as? HTTPURLResponse else {
             throw MCPError.transportFailure("Missing HTTP response during token exchange")
         }
@@ -776,7 +780,7 @@ public actor MCPOAuthAuthorization: MCPAuthorization {
 
             request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
 
-            let (data, response) = try await session.data(for: request)
+            let (data, response) = try await sessionProvider().data(for: request)
             try requireSuccess(response: response, body: data, operation: "dynamic client registration")
             let parsed = try JSONDecoder().decode(OAuthDynamicClientRegistrationResponse.self, from: data)
             guard parsed.clientID.isEmpty == false else {

--- a/Sources/BaseChatMCP/MCPURLSessionFactory.swift
+++ b/Sources/BaseChatMCP/MCPURLSessionFactory.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+internal enum MCPURLSessionFactory {
+    internal nonisolated(unsafe) static var networkDisabled: Bool = false
+
+    private static let sharedSession: URLSession = {
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = 300
+        configuration.timeoutIntervalForResource = 600
+        return URLSession(configuration: configuration)
+    }()
+
+    static func throwingShared() throws -> URLSession {
+        guard networkDisabled == false else {
+            throw MCPError.networkUnavailable
+        }
+        return sharedSession
+    }
+}

--- a/Tests/BaseChatMCPTests/AuthMCPOAuthAuthorizationTests.swift
+++ b/Tests/BaseChatMCPTests/AuthMCPOAuthAuthorizationTests.swift
@@ -6,6 +6,7 @@ import BaseChatTestSupport
 final class AuthMCPOAuthAuthorizationTests: XCTestCase {
     override func tearDown() {
         MockURLProtocol.reset()
+        MCPURLSessionFactory.networkDisabled = false
         super.tearDown()
     }
 
@@ -106,6 +107,108 @@ final class AuthMCPOAuthAuthorizationTests: XCTestCase {
         let body = requestBodyString(tokenRequests[0])
         XCTAssertTrue(body.contains("grant_type=refresh_token"))
         XCTAssertTrue(body.contains("refresh_token=refresh-123"))
+    }
+
+    func test_authorizationHeaderFailsWhenDefaultSessionBoundaryHasNetworkDisabled() async {
+        MCPURLSessionFactory.networkDisabled = true
+
+        let serverID = UUID()
+        let resourceURL = URL(string: "https://resource.example.com/mcp")!
+        let issuer = URL(string: "https://auth.example.com")!
+        let descriptor = makeDescriptor(issuer: issuer)
+        let tokenStore = MCPOAuthTokenStore.inMemory()
+        do {
+            try await tokenStore.write(
+                MCPOAuthTokens(
+                    accessToken: "expired",
+                    refreshToken: "refresh-123",
+                    expiresAt: Date().addingTimeInterval(-60),
+                    scopes: ["tools:read"],
+                    issuer: issuer
+                ),
+                serverID
+            )
+        } catch {
+            XCTFail("Unexpected token write failure: \(error)")
+            return
+        }
+
+        let authorization = MCPOAuthAuthorization(
+            descriptor: descriptor,
+            serverID: serverID,
+            resourceURL: resourceURL,
+            redirectListener: RedirectListenerMock { _ in
+                XCTFail("Redirect listener should not be used when network is disabled")
+                return URL(string: "basechat://oauth/callback?code=unused&state=unused")!
+            },
+            tokenStore: tokenStore
+        )
+
+        do {
+            _ = try await authorization.authorizationHeader(for: resourceURL)
+            XCTFail("Expected networkUnavailable")
+        } catch let error as MCPError {
+            XCTAssertEqual(error, .networkUnavailable)
+        } catch {
+            XCTFail("Expected MCPError.networkUnavailable, got \(error)")
+        }
+    }
+
+    func test_authorizationHeaderRefreshesWithInjectedSessionEvenWhenDefaultBoundaryDisabled() async throws {
+        MCPURLSessionFactory.networkDisabled = true
+
+        let serverID = UUID()
+        let resourceURL = URL(string: "https://resource.example.com/mcp")!
+        let issuer = URL(string: "https://auth.example.com")!
+        let metadataURL = URL(string: "https://auth.example.com/.well-known/oauth-authorization-server")!
+        let tokenEndpoint = URL(string: "https://auth.example.com/token")!
+        MockURLProtocol.stub(url: metadataURL, response: .immediate(data: Data(
+            """
+            {
+              "issuer": "https://auth.example.com",
+              "authorization_endpoint": "https://auth.example.com/authorize",
+              "token_endpoint": "https://auth.example.com/token"
+            }
+            """.utf8
+        ), statusCode: 200, headers: ["Content-Type": "application/json"]))
+        MockURLProtocol.stub(url: tokenEndpoint, response: .immediate(data: Data(
+            """
+            {
+              "access_token": "refreshed-token",
+              "expires_in": 3600,
+              "scope": "tools:read",
+              "token_type": "Bearer"
+            }
+            """.utf8
+        ), statusCode: 200, headers: ["Content-Type": "application/json"]))
+
+        let descriptor = makeDescriptor(issuer: issuer)
+        let tokenStore = MCPOAuthTokenStore.inMemory()
+        try await tokenStore.write(
+            MCPOAuthTokens(
+                accessToken: "expired",
+                refreshToken: "refresh-123",
+                expiresAt: Date().addingTimeInterval(-60),
+                scopes: ["tools:read"],
+                issuer: issuer
+            ),
+            serverID
+        )
+
+        let authorization = MCPOAuthAuthorization(
+            descriptor: descriptor,
+            serverID: serverID,
+            resourceURL: resourceURL,
+            redirectListener: RedirectListenerMock { _ in
+                XCTFail("Redirect listener should not be used for refresh")
+                return URL(string: "basechat://oauth/callback?code=unused&state=unused")!
+            },
+            tokenStore: tokenStore,
+            session: makeSession()
+        )
+
+        let header = try await authorization.authorizationHeader(for: resourceURL)
+        XCTAssertEqual(header, "Bearer refreshed-token")
     }
 
     func test_refreshTokenRotationPersistsReplacementRefreshToken() async throws {

--- a/Tests/BaseChatMCPTests/MCPStreamableHTTPTransportTests.swift
+++ b/Tests/BaseChatMCPTests/MCPStreamableHTTPTransportTests.swift
@@ -6,6 +6,7 @@ import BaseChatTestSupport
 final class MCPStreamableHTTPTransportTests: XCTestCase {
     override func tearDown() {
         MockURLProtocol.reset()
+        MCPURLSessionFactory.networkDisabled = false
         super.tearDown()
     }
 
@@ -130,6 +131,50 @@ final class MCPStreamableHTTPTransportTests: XCTestCase {
         XCTAssertEqual(unauthorizedCount, 1)
         // Sabotage: removing the 401-response branch in MCPStreamableHTTPTransport.send() that calls MCPAuthorization.handleUnauthorized() and retries the POST would leave unauthorizedCount at 0 and fail the XCTAssertEqual(unauthorizedCount, 1)
 
+        await transport.close()
+    }
+
+    func test_startFailsWhenDefaultSessionBoundaryHasNetworkDisabled() async {
+        MCPURLSessionFactory.networkDisabled = true
+
+        let transport = MCPStreamableHTTPTransport(configuration: .init(
+            endpoint: URL(string: "https://example.com/mcp")!,
+            headers: [:],
+            authorization: MCPNoAuthorization(),
+            sseLimits: .default,
+            maxMessageBytes: 2048
+        ))
+
+        do {
+            try await transport.start()
+            XCTFail("Expected networkUnavailable")
+        } catch let error as MCPError {
+            XCTAssertEqual(error, .networkUnavailable)
+        } catch {
+            XCTFail("Expected MCPError.networkUnavailable, got \(error)")
+        }
+    }
+
+    func test_injectedSessionBypassesDefaultSessionBoundary() async throws {
+        MCPURLSessionFactory.networkDisabled = true
+        let endpoint = URL(string: "https://example.com/mcp")!
+        let response = Data("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"ok\":true}}".utf8)
+        MockURLProtocol.stub(url: endpoint, response: .immediate(data: response, statusCode: 200, headers: ["Content-Type": "application/json"]))
+
+        let transport = MCPStreamableHTTPTransport(configuration: .init(
+            endpoint: endpoint,
+            headers: [:],
+            authorization: MCPNoAuthorization(),
+            sseLimits: .default,
+            maxMessageBytes: 2048,
+            session: makeSession()
+        ))
+
+        try await transport.send(Data("{\"jsonrpc\":\"2.0\",\"method\":\"ping\"}".utf8))
+
+        var iterator = transport.incomingMessages.makeAsyncIterator()
+        let first = try await iterator.next()
+        XCTAssertEqual(first, response)
         await transport.close()
     }
 


### PR DESCRIPTION
## Summary
- add a shared MCPURLSessionFactory seam for MCP HTTP/OAuth networking instead of direct URLSession.shared
- route MCPTransportConfiguration and MCPOAuthAuthorization through the factory by default while preserving explicit session injection for tests/callers
- wire disabled-network behavior through the seam (MCPError.networkUnavailable) and add targeted coverage for default-boundary and injected-session paths

## Tests
- swift test --filter BaseChatMCPTests --disable-default-traits --skip-update

## Risk
- Low: scoped to MCP transport/OAuth session construction and request entrypoints; no DNS redirect/rebinding logic changes in this PR.
