### PR TITLE
feat: verify model checksums when available

### DIFF
--- a/Sources/BaseChatHuggingFace/BackgroundDownloadManager+URLSessionDelegate.swift
+++ b/Sources/BaseChatHuggingFace/BackgroundDownloadManager+URLSessionDelegate.swift
@@ -88,7 +88,11 @@ extension BackgroundDownloadManager: URLSessionDownloadDelegate {
                         tempURL: tempURL
                     )
                 } else {
-                    try self.validateDownloadedFile(at: tempURL, modelType: model.modelType)
+                    try self.validateDownloadedFile(
+                        at: tempURL,
+                        modelType: model.modelType,
+                        expectedChecksum: context.expectedChecksum
+                    )
                     let destination = self.storageService.modelsDirectory.appendingPathComponent(model.fileName)
                     let resolvedDestination = destination.standardized
                     let resolvedModels = self.storageService.modelsDirectory.standardized

--- a/Sources/BaseChatHuggingFace/BackgroundDownloadManager.swift
+++ b/Sources/BaseChatHuggingFace/BackgroundDownloadManager.swift
@@ -86,11 +86,13 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
         let modelID: String
         let relativePath: String?
         let expectedBytes: Int64
+        let expectedChecksum: ModelFileChecksum?
     }
 
     private struct SnapshotFileMetadata: Codable, Sendable {
         let relativePath: String
         let sizeBytes: UInt64
+        let expectedChecksum: ModelFileChecksum?
     }
 
     private struct SnapshotProgress: Sendable {
@@ -260,7 +262,7 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
     /// - Throws: `HuggingFaceError.insufficientDiskSpace` if there isn't enough room.
     @MainActor @discardableResult
     public func startDownload(_ model: DownloadableModel, downloadURL: URL) async throws -> DownloadState {
-        try await startDownload(model, plan: .singleFile(url: downloadURL))
+        try await startDownload(model, plan: .singleFile(url: downloadURL, expectedChecksum: nil))
     }
 
     /// Starts a background download using a resolved download plan.
@@ -277,9 +279,9 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
         activeDownloads[model.id] = state
 
         switch plan {
-        case .singleFile(let url):
+        case .singleFile(let url, let expectedChecksum):
             Log.download.info("Starting single-file download for \(model.displayName) from \(url)")
-            try startSingleFileDownload(model: model, url: url)
+            try startSingleFileDownload(model: model, url: url, expectedChecksum: expectedChecksum)
         case .snapshot(let files):
             Log.download.info("Starting snapshot download for \(model.displayName) with \(files.count) files")
             try startSnapshotDownload(model: model, files: files)
@@ -357,7 +359,8 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
             let context = TaskContext(
                 modelID: model.id,
                 relativePath: nil,
-                expectedBytes: Int64(sizeBytes)
+                expectedBytes: Int64(sizeBytes),
+                expectedChecksum: nil
             )
             task.taskDescription = encodeTaskDescription(context)
             taskContexts[task.taskIdentifier] = context
@@ -389,7 +392,7 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
             return
         }
         do {
-            try startSingleFileDownload(model: model, url: url)
+            try startSingleFileDownload(model: model, url: url, expectedChecksum: nil)
         } catch {
             Log.download.error("Failed to start fresh retry download for \(model.id): \(error.localizedDescription)")
             activeDownloads[model.id]?.markFailed(error: error.localizedDescription)
@@ -514,19 +517,32 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
     ///   - fileURL: The temporary file location from URLSession.
     ///   - modelType: The expected model type.
     /// - Throws: `HuggingFaceError.invalidDownloadedFile` if validation fails.
-    public func validateDownloadedFile(at fileURL: URL, modelType: ModelType) throws {
-        try DownloadFileValidator().validate(at: fileURL, modelType: modelType)
+    public func validateDownloadedFile(
+        at fileURL: URL,
+        modelType: ModelType,
+        expectedChecksum: ModelFileChecksum? = nil
+    ) throws {
+        try DownloadFileValidator().validate(
+            at: fileURL,
+            modelType: modelType,
+            expectedChecksum: expectedChecksum
+        )
     }
 
     // MARK: - Download Coordination
 
     @MainActor
-    private func startSingleFileDownload(model: DownloadableModel, url: URL) throws {
+    private func startSingleFileDownload(
+        model: DownloadableModel,
+        url: URL,
+        expectedChecksum: ModelFileChecksum?
+    ) throws {
         let task = backgroundSession.downloadTask(with: url)
         let context = TaskContext(
             modelID: model.id,
             relativePath: nil,
-            expectedBytes: Int64(model.sizeBytes)
+            expectedBytes: Int64(model.sizeBytes),
+            expectedChecksum: expectedChecksum
         )
         task.taskDescription = encodeTaskDescription(context)
         taskContexts[task.taskIdentifier] = context
@@ -541,7 +557,13 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
         files: [ModelDownloadFile],
         stagingDirectory: URL
     ) {
-        let metadataFiles = files.map { SnapshotFileMetadata(relativePath: $0.relativePath, sizeBytes: $0.sizeBytes) }
+        let metadataFiles = files.map {
+            SnapshotFileMetadata(
+                relativePath: $0.relativePath,
+                sizeBytes: $0.sizeBytes,
+                expectedChecksum: $0.expectedChecksum
+            )
+        }
         snapshotDownloads[model.id] = SnapshotDownloadContext(
             stagingDirectory: stagingDirectory,
             files: Dictionary(uniqueKeysWithValues: metadataFiles.map { ($0.relativePath, $0) }),
@@ -570,7 +592,8 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
             let taskContext = TaskContext(
                 modelID: model.id,
                 relativePath: file.relativePath,
-                expectedBytes: Int64(file.sizeBytes)
+                expectedBytes: Int64(file.sizeBytes),
+                expectedChecksum: file.expectedChecksum
             )
             task.taskDescription = encodeTaskDescription(taskContext)
             taskContexts[task.taskIdentifier] = taskContext
@@ -582,7 +605,13 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
         // Persist before resuming so reconnect metadata is always in place.
         try savePendingDownload(
             model: model,
-            snapshotFiles: files.map { SnapshotFileMetadata(relativePath: $0.relativePath, sizeBytes: $0.sizeBytes) },
+            snapshotFiles: files.map {
+                SnapshotFileMetadata(
+                    relativePath: $0.relativePath,
+                    sizeBytes: $0.sizeBytes,
+                    expectedChecksum: $0.expectedChecksum
+                )
+            },
             stagingDirectoryName: stagingDirectory.lastPathComponent
         )
         for (task, _) in tasks {
@@ -632,7 +661,7 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
             }
         }
         // Legacy plain model-ID format (pre-JSON task descriptions).
-        return TaskContext(modelID: taskDescription, relativePath: nil, expectedBytes: 0)
+        return TaskContext(modelID: taskDescription, relativePath: nil, expectedBytes: 0, expectedChecksum: nil)
     }
 
     // internal: required by BackgroundDownloadManager+URLSessionDelegate.swift
@@ -717,6 +746,10 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
             try FileManager.default.removeItem(at: resolvedDestination)
         }
         try FileManager.default.moveItem(at: tempURL, to: resolvedDestination)
+        try DownloadFileValidator().validateChecksum(
+            at: resolvedDestination,
+            expectedChecksum: snapshot.files[relativePath]?.expectedChecksum
+        )
 
         let fileSize = (try FileManager.default.attributesOfItem(atPath: resolvedDestination.path)[.size] as? NSNumber)?.int64Value ?? snapshot.progressByFile[relativePath]?.expectedBytes ?? 0
         snapshot.completedFiles.insert(relativePath)

--- a/Sources/BaseChatHuggingFace/DownloadFileValidator.swift
+++ b/Sources/BaseChatHuggingFace/DownloadFileValidator.swift
@@ -1,5 +1,6 @@
 #if HuggingFace
 import BaseChatInference
+import CryptoKit
 import Foundation
 import os
 
@@ -18,8 +19,9 @@ struct DownloadFileValidator {
     /// - Parameters:
     ///   - fileURL: The file or directory to validate.
     ///   - modelType: The expected model type.
+    ///   - expectedChecksum: Expected digest to enforce when available.
     /// - Throws: `HuggingFaceError.invalidDownloadedFile` if validation fails.
-    func validate(at fileURL: URL, modelType: ModelType) throws {
+    func validate(at fileURL: URL, modelType: ModelType, expectedChecksum: ModelFileChecksum? = nil) throws {
         switch modelType {
         case .gguf:
             try validateGGUFFile(at: fileURL)
@@ -28,6 +30,7 @@ struct DownloadFileValidator {
         case .foundation:
             throw HuggingFaceError.invalidDownloadedFile(reason: "Foundation models cannot be downloaded")
         }
+        try validateChecksum(at: fileURL, expectedChecksum: expectedChecksum)
     }
 
     // MARK: - GGUF
@@ -96,6 +99,46 @@ struct DownloadFileValidator {
         guard hasSafetensors else {
             throw HuggingFaceError.invalidDownloadedFile(reason: "MLX model directory contains no .safetensors files")
         }
+    }
+
+    // MARK: - Checksum
+
+    func validateChecksum(at fileURL: URL, expectedChecksum: ModelFileChecksum?) throws {
+        guard let expectedChecksum else { return }
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            throw HuggingFaceError.invalidDownloadedFile(reason: "Downloaded file for checksum validation does not exist")
+        }
+
+        switch expectedChecksum.algorithm {
+        case .sha256:
+            let expected = expectedChecksum.hexDigest.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard expected.count == 64,
+                  expected.allSatisfy({ $0.isHexDigit }) else {
+                throw HuggingFaceError.invalidDownloadedFile(reason: "Expected SHA-256 checksum is malformed")
+            }
+
+            let actual = try sha256HexDigest(of: fileURL)
+            guard actual == expected else {
+                throw HuggingFaceError.invalidDownloadedFile(
+                    reason: "Checksum mismatch for \(fileURL.lastPathComponent): expected SHA-256 \(expected), got \(actual)"
+                )
+            }
+        }
+    }
+
+    private func sha256HexDigest(of fileURL: URL) throws -> String {
+        guard let handle = try? FileHandle(forReadingFrom: fileURL) else {
+            throw HuggingFaceError.invalidDownloadedFile(reason: "Cannot open downloaded file for checksum validation")
+        }
+        defer { handle.closeFile() }
+
+        var hasher = SHA256()
+        while true {
+            let chunk = try handle.read(upToCount: 65_536) ?? Data()
+            if chunk.isEmpty { break }
+            hasher.update(data: chunk)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
     }
 }
 #endif

--- a/Sources/BaseChatInference/Models/ModelDownloadPlan.swift
+++ b/Sources/BaseChatInference/Models/ModelDownloadPlan.swift
@@ -1,5 +1,21 @@
 import Foundation
 
+/// Supported digest algorithms for model download verification.
+public enum ModelFileChecksumAlgorithm: String, Sendable, Hashable, Codable {
+    case sha256
+}
+
+/// Expected checksum for a downloaded model file.
+public struct ModelFileChecksum: Sendable, Hashable, Codable {
+    public let algorithm: ModelFileChecksumAlgorithm
+    public let hexDigest: String
+
+    public init(algorithm: ModelFileChecksumAlgorithm, hexDigest: String) {
+        self.algorithm = algorithm
+        self.hexDigest = hexDigest
+    }
+}
+
 /// A single file that belongs to a model download.
 public struct ModelDownloadFile: Sendable, Hashable, Codable {
     /// Relative path inside the model snapshot directory.
@@ -8,16 +24,24 @@ public struct ModelDownloadFile: Sendable, Hashable, Codable {
     public let url: URL
     /// Expected file size in bytes, when known.
     public let sizeBytes: UInt64
+    /// Expected checksum for this file, when known.
+    public let expectedChecksum: ModelFileChecksum?
 
-    public init(relativePath: String, url: URL, sizeBytes: UInt64) {
+    public init(
+        relativePath: String,
+        url: URL,
+        sizeBytes: UInt64,
+        expectedChecksum: ModelFileChecksum? = nil
+    ) {
         self.relativePath = relativePath
         self.url = url
         self.sizeBytes = sizeBytes
+        self.expectedChecksum = expectedChecksum
     }
 }
 
 /// The concrete download work needed for a `DownloadableModel`.
 public enum ModelDownloadPlan: Sendable, Hashable {
-    case singleFile(url: URL)
+    case singleFile(url: URL, expectedChecksum: ModelFileChecksum? = nil)
     case snapshot(files: [ModelDownloadFile])
 }

--- a/Tests/BaseChatHuggingFaceTests/DownloadManagerTests.swift
+++ b/Tests/BaseChatHuggingFaceTests/DownloadManagerTests.swift
@@ -86,6 +86,41 @@ final class DownloadManagerTests: XCTestCase {
 
     // MARK: - GGUF Validation
 
+    func test_validateChecksum_expectedDigestMatches_passes() throws {
+        let fileURL = tempDirectory.appendingPathComponent("checksum-pass.bin")
+        try Data("hello".utf8).write(to: fileURL)
+
+        let expected = ModelFileChecksum(
+            algorithm: .sha256,
+            hexDigest: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        )
+        XCTAssertNoThrow(try DownloadFileValidator().validateChecksum(at: fileURL, expectedChecksum: expected))
+    }
+
+    func test_validateChecksum_expectedDigestMismatch_throws() throws {
+        let fileURL = tempDirectory.appendingPathComponent("checksum-fail.bin")
+        try Data("hello".utf8).write(to: fileURL)
+
+        let expected = ModelFileChecksum(
+            algorithm: .sha256,
+            hexDigest: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        )
+        XCTAssertThrowsError(
+            try DownloadFileValidator().validateChecksum(at: fileURL, expectedChecksum: expected)
+        ) { error in
+            guard case HuggingFaceError.invalidDownloadedFile(let reason) = error else {
+                return XCTFail("Expected invalidDownloadedFile for checksum mismatch, got: \(error)")
+            }
+            XCTAssertTrue(reason.contains("Checksum mismatch"), "Expected mismatch error, got: \(reason)")
+        }
+    }
+
+    func test_validateChecksum_missingExpectedDigest_skipsVerification() throws {
+        let fileURL = tempDirectory.appendingPathComponent("checksum-optional.bin")
+        try Data("tiny".utf8).write(to: fileURL)
+        XCTAssertNoThrow(try DownloadFileValidator().validateChecksum(at: fileURL, expectedChecksum: nil))
+    }
+
     func test_validateGGUFFile_validMagic() throws {
         // Create a temp file with valid GGUF magic bytes and realistic size (>1MB).
         let fileURL = tempDirectory.appendingPathComponent("valid.gguf")


### PR DESCRIPTION
## Summary
- add checksum metadata plumbing to ModelDownloadPlan and snapshot file metadata via ModelFileChecksum (SHA-256)
- verify checksums in DownloadFileValidator and enforce them in download completion paths when an expected digest is provided
- keep behavior unchanged for models/files without checksum metadata (verification is skipped)

## Tests
- swift test --filter BaseChatInferenceTests --disable-default-traits
- swift test --filter DownloadManagerTests

## Remaining work
- plumb expected SHA-256 values from Hugging Face file metadata or manifest sources into downloadPlan(for:)
- add signature or transparency verification layer (out of scope for this minimal PR)
