### PR TITLE
fix: revalidate MCP network destinations

### DIFF
--- a/Sources/BaseChatMCP/InternalMCPTransport.swift
+++ b/Sources/BaseChatMCP/InternalMCPTransport.swift
@@ -57,6 +57,7 @@ internal actor MCPStreamableHTTPTransport: MCPTransport {
     }
 
     private func startWithRetry(allowRetry: Bool) async throws {
+        try await MCPSSRFPolicy.validateTransportRequestURL(configuration.endpoint)
         var request = URLRequest(url: configuration.endpoint)
         request.httpMethod = "GET"
         request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
@@ -69,7 +70,13 @@ internal actor MCPStreamableHTTPTransport: MCPTransport {
             request.setValue(header, forHTTPHeaderField: "Authorization")
         }
 
-        let (bytes, response) = try await configuration.session.bytes(for: request)
+        let (bytes, response) = try await configuration.session.bytes(
+            for: request,
+            delegate: MCPRedirectCapDelegate(
+                maxRedirects: nil,
+                validator: MCPSSRFPolicy.validateTransportRedirectURL
+            )
+        )
         guard let http = response as? HTTPURLResponse else {
             throw MCPError.transportFailure("Missing HTTP response")
         }
@@ -121,6 +128,7 @@ internal actor MCPStreamableHTTPTransport: MCPTransport {
         if payload.count > configuration.maxMessageBytes {
             throw MCPError.oversizeMessage(payload.count)
         }
+        try await MCPSSRFPolicy.validateTransportRequestURL(configuration.endpoint)
 
         var request = URLRequest(url: configuration.endpoint)
         request.httpMethod = "POST"
@@ -134,7 +142,13 @@ internal actor MCPStreamableHTTPTransport: MCPTransport {
             request.setValue(header, forHTTPHeaderField: "Authorization")
         }
 
-        let (data, response) = try await configuration.session.data(for: request)
+        let (data, response) = try await configuration.session.data(
+            for: request,
+            delegate: MCPRedirectCapDelegate(
+                maxRedirects: nil,
+                validator: MCPSSRFPolicy.validateTransportRedirectURL
+            )
+        )
         guard let http = response as? HTTPURLResponse else {
             throw MCPError.transportFailure("Missing HTTP response")
         }

--- a/Sources/BaseChatMCP/MCPOAuth.swift
+++ b/Sources/BaseChatMCP/MCPOAuth.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import Security
 import CryptoKit
@@ -239,7 +240,17 @@ struct PKCEVerifier {
 
 /// Limits redirect chains to at most one hop to prevent SSRF-via-redirect attacks.
 final class MCPRedirectCapDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    private let maxRedirects: Int?
+    private let validator: @Sendable (URL) throws -> Void
     private var redirectCount = 0
+
+    init(
+        maxRedirects: Int? = 1,
+        validator: @escaping @Sendable (URL) throws -> Void = { _ in }
+    ) {
+        self.maxRedirects = maxRedirects
+        self.validator = validator
+    }
 
     func urlSession(
         _ session: URLSession,
@@ -249,8 +260,19 @@ final class MCPRedirectCapDelegate: NSObject, URLSessionTaskDelegate, @unchecked
         completionHandler: @escaping (URLRequest?) -> Void
     ) {
         redirectCount += 1
-        // Allow the first redirect; refuse subsequent ones.
-        completionHandler(redirectCount <= 1 ? request : nil)
+        if let nextURL = request.url {
+            do {
+                try validator(nextURL)
+            } catch {
+                completionHandler(nil)
+                return
+            }
+        }
+        if let maxRedirects {
+            completionHandler(redirectCount <= maxRedirects ? request : nil)
+        } else {
+            completionHandler(request)
+        }
     }
 }
 
@@ -306,7 +328,7 @@ public actor MCPOAuthAuthorization: MCPAuthorization {
     }
 
     public func authorizationHeader(for requestURL: URL) async throws -> String? {
-        try MCPSSRFPolicy.validateOAuthURL(requestURL, label: "oauth request")
+        try await MCPSSRFPolicy.validateOAuthRequestURL(requestURL, label: "oauth request")
         guard Self.isSameOrigin(lhs: requestURL, rhs: resourceURL) else {
             return nil
         }
@@ -320,7 +342,7 @@ public actor MCPOAuthAuthorization: MCPAuthorization {
 
     public func handleUnauthorized(statusCode: Int, body: Data) async throws -> AuthRetryDecision {
         _ = body
-        try MCPSSRFPolicy.validateOAuthURL(resourceURL, label: "resource")
+        try await MCPSSRFPolicy.validateOAuthRequestURL(resourceURL, label: "resource")
         guard statusCode == 401 || statusCode == 403 else {
             return .fail(.authorizationFailed("unexpected status \(statusCode)"))
         }
@@ -357,11 +379,18 @@ public actor MCPOAuthAuthorization: MCPAuthorization {
               let managementToken = registrationManagementToken else { return }
         // RFC 7592 — best-effort DELETE; never throws.
         do {
+            try await MCPSSRFPolicy.validateOAuthRequestURL(managementURI, label: "registration management")
             var request = URLRequest(url: managementURI)
             request.httpMethod = "DELETE"
             request.setValue("Bearer \(managementToken)", forHTTPHeaderField: "Authorization")
             request.timeoutInterval = 5
-            _ = try await session.data(for: request)
+            _ = try await session.data(
+                for: request,
+                delegate: MCPRedirectCapDelegate(
+                    maxRedirects: nil,
+                    validator: MCPSSRFPolicy.validateOAuthRedirectURL
+                )
+            )
             Log.inference.info("MCPOAuthAuthorization: dynamic client deregistered for \(self.serverID)")
         } catch {
             Log.inference.warning("MCPOAuthAuthorization: client deregistration request failed (best-effort): \(error.localizedDescription)")
@@ -497,7 +526,14 @@ public actor MCPOAuthAuthorization: MCPAuthorization {
         } else {
             let resourceMetadataURL = Self.resourceMetadataURL(for: resourceURL)
             try enforceHTTPS(resourceMetadataURL, label: "resource metadata")
-            let (data, response) = try await session.data(for: URLRequest(url: resourceMetadataURL))
+            try await MCPSSRFPolicy.validateOAuthRequestURL(resourceMetadataURL, label: "resource metadata")
+            let (data, response) = try await session.data(
+                for: URLRequest(url: resourceMetadataURL),
+                delegate: MCPRedirectCapDelegate(
+                    maxRedirects: nil,
+                    validator: MCPSSRFPolicy.validateOAuthRedirectURL
+                )
+            )
             try requireSuccess(response: response, body: data, operation: "resource metadata discovery")
             let resourceMetadata = try decoder.decode(OAuthProtectedResourceMetadata.self, from: data)
             guard let candidateIssuers = resourceMetadata.authorizationServers, candidateIssuers.isEmpty == false else {
@@ -526,10 +562,11 @@ public actor MCPOAuthAuthorization: MCPAuthorization {
 
         let metadataURL = Self.authorizationMetadataURL(for: issuer)
         try enforceHTTPS(metadataURL, label: "authorization metadata")
+        try await MCPSSRFPolicy.validateOAuthRequestURL(metadataURL, label: "authorization metadata")
         // Redirect cap: metadata fetches must not follow more than one redirect.
         let (metadataData, metadataResponse) = try await session.data(
             for: URLRequest(url: metadataURL),
-            delegate: MCPRedirectCapDelegate()
+            delegate: MCPRedirectCapDelegate(validator: MCPSSRFPolicy.validateOAuthRedirectURL)
         )
         try requireSuccess(response: metadataResponse, body: metadataData, operation: "authorization metadata discovery")
         let metadata = try decoder.decode(OAuthAuthorizationServerMetadata.self, from: metadataData)
@@ -596,6 +633,7 @@ public actor MCPOAuthAuthorization: MCPAuthorization {
         metadata: OAuthAuthorizationServerMetadata
     ) async throws -> MCPOAuthTokens {
         try enforceHTTPS(metadata.tokenEndpoint, label: "token endpoint")
+        try await MCPSSRFPolicy.validateOAuthRequestURL(metadata.tokenEndpoint, label: "token endpoint")
         var request = URLRequest(url: metadata.tokenEndpoint)
         request.httpMethod = "POST"
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
@@ -603,7 +641,10 @@ public actor MCPOAuthAuthorization: MCPAuthorization {
         request.httpBody = Self.formURLEncoded(parameters).data(using: .utf8)
 
         // Redirect cap: token exchanges must not follow more than one redirect.
-        let (data, response) = try await session.data(for: request, delegate: MCPRedirectCapDelegate())
+        let (data, response) = try await session.data(
+            for: request,
+            delegate: MCPRedirectCapDelegate(validator: MCPSSRFPolicy.validateOAuthRedirectURL)
+        )
         guard let http = response as? HTTPURLResponse else {
             throw MCPError.transportFailure("Missing HTTP response during token exchange")
         }
@@ -756,6 +797,7 @@ public actor MCPOAuthAuthorization: MCPAuthorization {
 
         do {
             try enforceHTTPS(registrationEndpoint, label: "registration endpoint")
+            try await MCPSSRFPolicy.validateOAuthRequestURL(registrationEndpoint, label: "registration endpoint")
             var request = URLRequest(url: registrationEndpoint)
             request.httpMethod = "POST"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -776,7 +818,13 @@ public actor MCPOAuthAuthorization: MCPAuthorization {
 
             request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
 
-            let (data, response) = try await session.data(for: request)
+            let (data, response) = try await session.data(
+                for: request,
+                delegate: MCPRedirectCapDelegate(
+                    maxRedirects: nil,
+                    validator: MCPSSRFPolicy.validateOAuthRedirectURL
+                )
+            )
             try requireSuccess(response: response, body: data, operation: "dynamic client registration")
             let parsed = try JSONDecoder().decode(OAuthDynamicClientRegistrationResponse.self, from: data)
             guard parsed.clientID.isEmpty == false else {
@@ -1019,6 +1067,8 @@ private func constantTimeEqual(_ a: String, _ b: String) -> Bool {
 // MARK: - MCPSSRFPolicy
 
 internal enum MCPSSRFPolicy {
+    nonisolated(unsafe) static var _resolverForTesting: ((String) async -> [String])? = nil
+
     static func validateTransportURL(_ url: URL) throws {
         guard let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" else {
             throw MCPError.transportFailure("MCP transport endpoint must use http(s)")
@@ -1037,6 +1087,26 @@ internal enum MCPSSRFPolicy {
             throw MCPError.authorizationFailed("Expected HTTPS \(label) URL")
         }
         try validateHostNotBlocked(url, wrap: { _ in .authorizationFailed("Expected host in \(label) URL") })
+    }
+
+    static func validateTransportRequestURL(_ url: URL) async throws {
+        try validateTransportURL(url)
+        try await validateResolvedHostNotBlocked(url)
+    }
+
+    static func validateOAuthRequestURL(_ url: URL, label: String) async throws {
+        try validateOAuthURL(url, label: label)
+        try await validateResolvedHostNotBlocked(url)
+    }
+
+    static func validateTransportRedirectURL(_ url: URL) throws {
+        try validateTransportURL(url)
+        try validateResolvedHostNotBlockedSynchronously(url)
+    }
+
+    static func validateOAuthRedirectURL(_ url: URL) throws {
+        try validateOAuthURL(url, label: "oauth redirect")
+        try validateResolvedHostNotBlockedSynchronously(url)
     }
 
     private static func validateHostNotBlocked(
@@ -1058,6 +1128,82 @@ internal enum MCPSSRFPolicy {
                 throw MCPError.ssrfBlocked(url)
             }
         }
+    }
+
+    private static func validateResolvedHostNotBlocked(_ url: URL) async throws {
+        guard PrivateIPClassifier.isLocalhostURL(url) == false else { return }
+        guard let host = normalizedHost(from: url) else {
+            throw MCPError.ssrfBlocked(url)
+        }
+        if PrivateIPClassifier.classifyIPLiteral(host) != nil {
+            throw MCPError.ssrfBlocked(url)
+        }
+        let addresses = await resolveHostname(host)
+        for address in addresses where PrivateIPClassifier.classifyIPLiteral(address) != nil {
+            throw MCPError.ssrfBlocked(url)
+        }
+    }
+
+    private static func validateResolvedHostNotBlockedSynchronously(_ url: URL) throws {
+        guard PrivateIPClassifier.isLocalhostURL(url) == false else { return }
+        guard let host = normalizedHost(from: url) else {
+            throw MCPError.ssrfBlocked(url)
+        }
+        if PrivateIPClassifier.classifyIPLiteral(host) != nil {
+            throw MCPError.ssrfBlocked(url)
+        }
+        let addresses = resolveHostnameSynchronously(host)
+        for address in addresses where PrivateIPClassifier.classifyIPLiteral(address) != nil {
+            throw MCPError.ssrfBlocked(url)
+        }
+    }
+
+    private static func normalizedHost(from url: URL) -> String? {
+        guard let host = url.host?.lowercased(), host.isEmpty == false else { return nil }
+        return host.hasSuffix(".") ? String(host.dropLast()) : host
+    }
+
+    private static func resolveHostname(_ hostname: String) async -> [String] {
+        if let override = _resolverForTesting {
+            return await override(hostname)
+        }
+        return await Task.detached(priority: .utility) {
+            resolveHostnameSynchronously(hostname)
+        }.value
+    }
+
+    private static func resolveHostnameSynchronously(_ hostname: String) -> [String] {
+        var hints = addrinfo()
+        hints.ai_family = AF_UNSPEC
+        hints.ai_socktype = SOCK_STREAM
+        hints.ai_flags = AI_ADDRCONFIG
+
+        var result: UnsafeMutablePointer<addrinfo>?
+        defer { freeaddrinfo(result) }
+
+        guard getaddrinfo(hostname, nil, &hints, &result) == 0, result != nil else {
+            return []
+        }
+
+        var addresses: [String] = []
+        var current = result
+        while let info = current {
+            var host = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+            if getnameinfo(
+                info.pointee.ai_addr,
+                info.pointee.ai_addrlen,
+                &host,
+                socklen_t(NI_MAXHOST),
+                nil,
+                0,
+                NI_NUMERICHOST
+            ) == 0 {
+                let nullIndex = host.firstIndex(of: 0) ?? host.endIndex
+                addresses.append(String(decoding: host[..<nullIndex].map { UInt8(bitPattern: $0) }, as: UTF8.self))
+            }
+            current = info.pointee.ai_next
+        }
+        return addresses
     }
 }
 

--- a/Tests/BaseChatMCPTests/AuthMCPOAuthAuthorizationTests.swift
+++ b/Tests/BaseChatMCPTests/AuthMCPOAuthAuthorizationTests.swift
@@ -6,6 +6,7 @@ import BaseChatTestSupport
 final class AuthMCPOAuthAuthorizationTests: XCTestCase {
     override func tearDown() {
         MockURLProtocol.reset()
+        MCPSSRFPolicy._resolverForTesting = nil
         super.tearDown()
     }
 
@@ -106,6 +107,79 @@ final class AuthMCPOAuthAuthorizationTests: XCTestCase {
         let body = requestBodyString(tokenRequests[0])
         XCTAssertTrue(body.contains("grant_type=refresh_token"))
         XCTAssertTrue(body.contains("refresh_token=refresh-123"))
+    }
+
+    func test_handleUnauthorizedRejectsTokenEndpointDNSRebinding() async throws {
+        let serverID = UUID()
+        let resourceURL = URL(string: "https://resource.example.com/mcp")!
+        let issuer = URL(string: "https://auth.example.com")!
+        let metadataURL = URL(string: "https://auth.example.com/.well-known/oauth-authorization-server")!
+        let tokenEndpoint = URL(string: "https://token.example.com/token")!
+
+        MCPSSRFPolicy._resolverForTesting = { host in
+            host == "token.example.com" ? ["169.254.169.254"] : ["93.184.216.34"]
+        }
+
+        MockURLProtocol.stub(url: metadataURL, response: .immediate(data: Data(
+            """
+            {
+              "issuer": "https://auth.example.com",
+              "authorization_endpoint": "https://auth.example.com/authorize",
+              "token_endpoint": "https://token.example.com/token"
+            }
+            """.utf8
+        ), statusCode: 200, headers: ["Content-Type": "application/json"]))
+        MockURLProtocol.stub(url: tokenEndpoint, response: .immediate(data: Data(
+            """
+            {
+              "access_token": "unexpected-token",
+              "expires_in": 3600,
+              "scope": "tools:read",
+              "token_type": "Bearer"
+            }
+            """.utf8
+        ), statusCode: 200, headers: ["Content-Type": "application/json"]))
+
+        let tokenStore = MCPOAuthTokenStore.inMemory()
+        try await tokenStore.write(
+            MCPOAuthTokens(
+                accessToken: "expired",
+                refreshToken: "refresh-123",
+                expiresAt: Date().addingTimeInterval(-60),
+                scopes: ["tools:read"],
+                issuer: issuer
+            ),
+            serverID
+        )
+
+        let authorization = MCPOAuthAuthorization(
+            descriptor: makeDescriptor(issuer: issuer),
+            serverID: serverID,
+            resourceURL: resourceURL,
+            redirectListener: RedirectListenerMock { _ in
+                XCTFail("Redirect listener should not be used when token endpoint is blocked")
+                return URL(string: "basechat://oauth/callback?code=unused&state=unused")!
+            },
+            tokenStore: tokenStore,
+            session: makeSession()
+        )
+
+        let decision = try await authorization.handleUnauthorized(statusCode: 401, body: Data())
+        switch decision {
+        case .retry:
+            XCTFail("Expected SSRF failure")
+        case .fail(let error):
+            guard case .ssrfBlocked(let blockedURL) = error else {
+                XCTFail("Expected ssrfBlocked, got \(error)")
+                return
+            }
+            XCTAssertEqual(blockedURL.absoluteString, "https://token.example.com/token")
+        }
+
+        XCTAssertNil(
+            MockURLProtocol.capturedRequests.first(where: { $0.url == tokenEndpoint }),
+            "Token request must be blocked before network dispatch"
+        )
     }
 
     func test_refreshTokenRotationPersistsReplacementRefreshToken() async throws {

--- a/Tests/BaseChatMCPTests/MCPHardeningTests.swift
+++ b/Tests/BaseChatMCPTests/MCPHardeningTests.swift
@@ -6,6 +6,7 @@ import BaseChatTestSupport
 final class MCPHardeningTests: XCTestCase {
     override func tearDown() {
         MockURLProtocol.reset()
+        MCPSSRFPolicy._resolverForTesting = nil
         super.tearDown()
     }
 
@@ -106,6 +107,41 @@ final class MCPHardeningTests: XCTestCase {
                 return
             }
             XCTAssertEqual(blockedURL.absoluteString, "https://169.254.169.254/token")
+        }
+    }
+
+    func test_ssrf_requestTimeValidation_blocksTransportDNSRebinding() async {
+        MCPSSRFPolicy._resolverForTesting = { host in
+            host == "example.com" ? ["169.254.169.254"] : ["93.184.216.34"]
+        }
+
+        await XCTAssertThrowsErrorAsync(
+            try await MCPSSRFPolicy.validateTransportRequestURL(URL(string: "https://example.com/mcp")!)
+        ) { error in
+            guard case .ssrfBlocked(let blockedURL) = error as? MCPError else {
+                XCTFail("Expected ssrfBlocked, got \(error)")
+                return
+            }
+            XCTAssertEqual(blockedURL.host, "example.com")
+        }
+    }
+
+    func test_ssrf_requestTimeValidation_blocksOAuthDNSRebinding() async {
+        MCPSSRFPolicy._resolverForTesting = { host in
+            host == "token.example.com" ? ["10.0.0.4"] : ["93.184.216.34"]
+        }
+
+        await XCTAssertThrowsErrorAsync(
+            try await MCPSSRFPolicy.validateOAuthRequestURL(
+                URL(string: "https://token.example.com/token")!,
+                label: "token endpoint"
+            )
+        ) { error in
+            guard case .ssrfBlocked(let blockedURL) = error as? MCPError else {
+                XCTFail("Expected ssrfBlocked, got \(error)")
+                return
+            }
+            XCTAssertEqual(blockedURL.host, "token.example.com")
         }
     }
 
@@ -317,6 +353,61 @@ final class MCPHardeningTests: XCTestCase {
         XCTAssertNotNil(firstResult, "First redirect should be followed")
         // Second redirect is refused — completionHandler called with nil.
         XCTAssertNil(secondResult, "Second redirect must be refused")
+    }
+
+    func test_ssrf_redirect_validation_blocksTransportDestination() {
+        let delegate = MCPRedirectCapDelegate(
+            maxRedirects: nil,
+            validator: MCPSSRFPolicy.validateTransportRedirectURL
+        )
+        let session = URLSession.shared
+        let fakeHTTPResponse = HTTPURLResponse(
+            url: URL(string: "https://api.example.com/mcp")!,
+            statusCode: 302,
+            httpVersion: nil,
+            headerFields: ["Location": "https://192.168.1.20/mcp"]
+        )!
+        let blockedRequest = URLRequest(url: URL(string: "https://192.168.1.20/mcp")!)
+        var result: URLRequest?
+
+        let exp = expectation(description: "redirect validation callback")
+        delegate.urlSession(
+            session,
+            task: session.dataTask(with: URLRequest(url: URL(string: "https://api.example.com/mcp")!)),
+            willPerformHTTPRedirection: fakeHTTPResponse,
+            newRequest: blockedRequest
+        ) { request in
+            result = request
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+        XCTAssertNil(result, "Redirect to private-resolving host must be blocked")
+    }
+
+    func test_ssrf_redirect_validation_blocksOAuthDestination() {
+        let delegate = MCPRedirectCapDelegate(validator: MCPSSRFPolicy.validateOAuthRedirectURL)
+        let session = URLSession.shared
+        let fakeHTTPResponse = HTTPURLResponse(
+            url: URL(string: "https://auth.example.com/token")!,
+            statusCode: 302,
+            httpVersion: nil,
+            headerFields: ["Location": "https://[fd00::1]/token"]
+        )!
+        let blockedRequest = URLRequest(url: URL(string: "https://[fd00::1]/token")!)
+        var result: URLRequest?
+
+        let exp = expectation(description: "oauth redirect validation callback")
+        delegate.urlSession(
+            session,
+            task: session.dataTask(with: URLRequest(url: URL(string: "https://auth.example.com/token")!)),
+            willPerformHTTPRedirection: fakeHTTPResponse,
+            newRequest: blockedRequest
+        ) { request in
+            result = request
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+        XCTAssertNil(result, "OAuth redirect to private-resolving host must be blocked")
     }
 
     func test_networkAndLifecycleObserversPlumbIntoConnectionState() async {

--- a/Tests/BaseChatMCPTests/MCPStreamableHTTPTransportTests.swift
+++ b/Tests/BaseChatMCPTests/MCPStreamableHTTPTransportTests.swift
@@ -6,6 +6,7 @@ import BaseChatTestSupport
 final class MCPStreamableHTTPTransportTests: XCTestCase {
     override func tearDown() {
         MockURLProtocol.reset()
+        MCPSSRFPolicy._resolverForTesting = nil
         super.tearDown()
     }
 
@@ -133,10 +134,51 @@ final class MCPStreamableHTTPTransportTests: XCTestCase {
         await transport.close()
     }
 
+    func test_sendBlocksDNSRebindingDestinationBeforeRequest() async {
+        let endpoint = URL(string: "https://example.com/mcp")!
+        MCPSSRFPolicy._resolverForTesting = { host in
+            host == "example.com" ? ["10.0.0.7"] : ["93.184.216.34"]
+        }
+
+        let transport = MCPStreamableHTTPTransport(configuration: .init(
+            endpoint: endpoint,
+            headers: [:],
+            authorization: MCPNoAuthorization(),
+            sseLimits: .default,
+            maxMessageBytes: 2048,
+            session: makeSession()
+        ))
+
+        await XCTAssertThrowsErrorAsync(
+            try await transport.send(Data("{\"jsonrpc\":\"2.0\",\"method\":\"ping\"}".utf8))
+        ) { error in
+            guard case .ssrfBlocked(let blockedURL) = error as? MCPError else {
+                XCTFail("Expected ssrfBlocked, got \(error)")
+                return
+            }
+            XCTAssertEqual(blockedURL.host, "example.com")
+        }
+        XCTAssertTrue(MockURLProtocol.capturedRequests.isEmpty)
+    }
+
     private func makeSession() -> URLSession {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [MockURLProtocol.self]
         return URLSession(configuration: configuration)
+    }
+}
+
+private func XCTAssertThrowsErrorAsync<T>(
+    _ expression: @autoclosure () async throws -> T,
+    _ handler: (Error) -> Void,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async {
+    do {
+        _ = try await expression()
+        XCTFail("Expected error", file: file, line: line)
+    } catch {
+        handler(error)
     }
 }
 


### PR DESCRIPTION
## Summary
- add request-time DNS/private-address validation for MCP streamable HTTP requests before each GET/POST dispatch
- harden OAuth runtime URL checks for resource metadata, authorization metadata, token, dynamic registration, and deregistration requests
- revalidate redirect destinations via MCPRedirectCapDelegate before following (blocked redirects fail closed)

## Dependency on #923
- This PR is based on origin/main and does not require #923 to merge first.
- If #923 lands first, this change should still apply cleanly (both touch MCP networking seams).

## Tests
- swift test --filter MCPHardeningTests --filter MCPStreamableHTTPTransportTests --filter AuthMCPOAuthAuthorizationTests --disable-default-traits --skip-update
- swift test --filter BaseChatMCPTests --disable-default-traits --skip-update

## Risks
- Added DNS resolution on request path may slightly increase latency per request.
- Redirects that resolve to blocked/private addresses now hard-fail instead of being followed.