### PR TITLE
ci: add focused security gate

### DIFF
--- a/.github/workflows/security-gates.yml
+++ b/.github/workflows/security-gates.yml
@@ -1,0 +1,76 @@
+name: Security gates
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "Sources/**"
+      - "Tests/**"
+      - "Package.swift"
+      - "Package.resolved"
+      - "scripts/test.sh"
+      - ".github/workflows/security-gates.yml"
+  push:
+    branches: [main]
+    paths:
+      - "Sources/**"
+      - "Tests/**"
+      - "Package.swift"
+      - "Package.resolved"
+      - "scripts/test.sh"
+      - ".github/workflows/security-gates.yml"
+
+concurrency:
+  group: security-gates-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  security-audits:
+    runs-on: macos-15
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.3"
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v5
+        with:
+          path: |
+            .build/artifacts
+            .build/checkouts
+            .build/repositories
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
+            ${{ runner.os }}-${{ runner.arch }}-spm-
+
+      - name: Validate Package.resolved is up to date
+        run: |
+          swift package resolve
+          git diff --exit-code Package.resolved || \
+            (echo "Package.resolved is stale — run 'swift package resolve' and commit the result." && exit 1)
+
+      - name: Test — TrafficBoundaryAuditTest
+        env:
+          RUN_SLOW_TESTS: "1"
+          BASECHAT_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-traffic-boundary-audit.log
+        run: scripts/test.sh --filter "BaseChatInferenceTests.TrafficBoundaryAuditTest" --disable-default-traits --skip-update --min-passed 1
+
+      - name: Test — MCPHardeningTests
+        env:
+          BASECHAT_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-mcp-hardening.log
+        run: scripts/test.sh --filter "BaseChatMCPTests.MCPHardeningTests" --disable-default-traits --skip-update --min-passed 1
+
+      - name: Test — PinnedSessionDelegateTests (CloudSaaS)
+        env:
+          BASECHAT_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-pinned-session-delegate.log
+        run: scripts/test.sh --filter "BaseChatBackendsTests.PinnedSessionDelegateTests" --disable-default-traits --traits CloudSaaS --skip-update --min-passed 1


### PR DESCRIPTION
## Summary
- add a dedicated `Security gates` workflow on macOS for lightweight post-remediation security coverage
- run `TrafficBoundaryAuditTest` (with `RUN_SLOW_TESTS=1`) so rule 5 package-manifest hygiene stays continuously enforced on PRs
- run focused MCP hardening and pinning regressions (`MCPHardeningTests`, `PinnedSessionDelegateTests` with `CloudSaaS` trait)
- include a `Package.resolved` freshness check in the same gate

## Validation
- `swift package resolve && git diff --exit-code Package.resolved`
- `RUN_SLOW_TESTS=1 scripts/test.sh --filter "BaseChatInferenceTests.TrafficBoundaryAuditTest" --disable-default-traits --skip-update --min-passed 1`
- `scripts/test.sh --filter "BaseChatMCPTests.MCPHardeningTests" --disable-default-traits --skip-update --min-passed 1`
- `scripts/test.sh --filter "BaseChatBackendsTests.PinnedSessionDelegateTests" --disable-default-traits --traits CloudSaaS --skip-update --min-passed 1`

## Dependencies
- No code dependency on #921-#926; this workflow targets security tests already present on `main`.
