### PR TITLE
fix: opt in local model discovery and standardize pin hashing

### DIFF
--- a/Example/BaseChatDemo.xcodeproj/project.pbxproj
+++ b/Example/BaseChatDemo.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		BF0001000000000000000000 /* BaseChatDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10001000000000000000000 /* BaseChatDemoApp.swift */; };
 		BF0002000000000000000000 /* DemoContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10002000000000000000000 /* DemoContentView.swift */; };
-		BF0003000000000000000000 /* BaseChatCore in Frameworks */ = {isa = PBXBuildFile; productRef = F30001000000000000000000 /* BaseChatCore */; };
+		BF0003000000000000000000 /* BaseChatPersistenceSwiftData in Frameworks */ = {isa = PBXBuildFile; productRef = F30001000000000000000000 /* BaseChatPersistenceSwiftData */; };
 		BF0004000000000000000000 /* BaseChatUI in Frameworks */ = {isa = PBXBuildFile; productRef = F30002000000000000000000 /* BaseChatUI */; };
 		BF0005000000000000000000 /* BaseChatBackends in Frameworks */ = {isa = PBXBuildFile; productRef = F30003000000000000000000 /* BaseChatBackends */; };
 		BF0006000000000000000000 /* BaseChatTools in Frameworks */ = {isa = PBXBuildFile; productRef = F30004000000000000000000 /* BaseChatTools */; };
@@ -135,7 +135,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF0003000000000000000000 /* BaseChatCore in Frameworks */,
+				BF0003000000000000000000 /* BaseChatPersistenceSwiftData in Frameworks */,
 				BF0004000000000000000000 /* BaseChatUI in Frameworks */,
 				BF0021000000000000000000 /* BaseChatUIModelManagement in Frameworks */,
 				BF0005000000000000000000 /* BaseChatBackends in Frameworks */,
@@ -312,7 +312,7 @@
 			);
 			name = BaseChatDemo;
 			packageProductDependencies = (
-				F30001000000000000000000 /* BaseChatCore */,
+				F30001000000000000000000 /* BaseChatPersistenceSwiftData */,
 				F30002000000000000000000 /* BaseChatUI */,
 				F30006000000000000000000 /* BaseChatUIModelManagement */,
 				F30003000000000000000000 /* BaseChatBackends */,
@@ -897,10 +897,10 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		F30001000000000000000000 /* BaseChatCore */ = {
+		F30001000000000000000000 /* BaseChatPersistenceSwiftData */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = F20001000000000000000000 /* XCLocalSwiftPackageReference ".." */;
-			productName = BaseChatCore;
+			productName = BaseChatPersistenceSwiftData;
 		};
 		F30002000000000000000000 /* BaseChatUI */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Example/BaseChatDemo.xcodeproj/project.pbxproj
+++ b/Example/BaseChatDemo.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		BF0005000000000000000000 /* BaseChatBackends in Frameworks */ = {isa = PBXBuildFile; productRef = F30003000000000000000000 /* BaseChatBackends */; };
 		BF0006000000000000000000 /* BaseChatTools in Frameworks */ = {isa = PBXBuildFile; productRef = F30004000000000000000000 /* BaseChatTools */; };
 		BF0020000000000000000000 /* BaseChatMCP in Frameworks */ = {isa = PBXBuildFile; productRef = F30005000000000000000000 /* BaseChatMCP */; };
-		BF0021000000000000000000 /* BaseChatUIModelManagement in Frameworks */ = {isa = PBXBuildFile; productRef = F30006000000000000000000 /* BaseChatUIModelManagement */; };
+		BF0021100000000000000000 /* BaseChatUIModelManagement in Frameworks */ = {isa = PBXBuildFile; productRef = F30006000000000000000000 /* BaseChatUIModelManagement */; };
 		BF0007000000000000000000 /* DemoTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10004000000000000000000 /* DemoTools.swift */; };
 		BF0008000000000000000000 /* ChatEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10005000000000000000000 /* ChatEmptyStateView.swift */; };
 		BF0009000000000000000000 /* ToolApprovalSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10006000000000000000000 /* ToolApprovalSheet.swift */; };
@@ -48,7 +48,7 @@
 		BF0027000000000000000000 /* AppIntentToolsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10023000000000000000000 /* AppIntentToolsView.swift */; };
 		BF0029000000000000000000 /* DemoNowTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10024000000000000000000 /* DemoNowTool.swift */; };
 		BF0028000000000000000000 /* BaseChatAppIntents in Frameworks */ = {isa = PBXBuildFile; productRef = F30008000000000000000000 /* BaseChatAppIntents */; };
-		BF0029000000000000000000 /* BaseChatVoice in Frameworks */ = {isa = PBXBuildFile; productRef = F30009000000000000000000 /* BaseChatVoice */; };
+		BF0029100000000000000000 /* BaseChatVoice in Frameworks */ = {isa = PBXBuildFile; productRef = F30009000000000000000000 /* BaseChatVoice */; };
 		BF0030000000000000000000 /* PendingSharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10030000000000000000000 /* PendingSharePayload.swift */; };
 		BF0031000000000000000000 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10031000000000000000000 /* ShareViewController.swift */; };
 		BF0032000000000000000000 /* PendingSharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10030000000000000000000 /* PendingSharePayload.swift */; };
@@ -137,12 +137,12 @@
 			files = (
 				BF0003000000000000000000 /* BaseChatPersistenceSwiftData in Frameworks */,
 				BF0004000000000000000000 /* BaseChatUI in Frameworks */,
-				BF0021000000000000000000 /* BaseChatUIModelManagement in Frameworks */,
+				BF0021100000000000000000 /* BaseChatUIModelManagement in Frameworks */,
 				BF0005000000000000000000 /* BaseChatBackends in Frameworks */,
 				BF0006000000000000000000 /* BaseChatTools in Frameworks */,
 				BF0020000000000000000000 /* BaseChatMCP in Frameworks */,
 				BF0028000000000000000000 /* BaseChatAppIntents in Frameworks */,
-				BF0029000000000000000000 /* BaseChatVoice in Frameworks */,
+				BF0029100000000000000000 /* BaseChatVoice in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/BaseChatDemo/BaseChatDemoApp.swift
+++ b/Example/BaseChatDemo/BaseChatDemoApp.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 import SwiftData
-import BaseChatCore
+import BaseChatPersistenceSwiftData
 import BaseChatInference
 import BaseChatUI
 import BaseChatUIModelManagement
@@ -17,7 +17,7 @@ struct BaseChatDemoApp: App {
     @State private var chatViewModel: ChatViewModel
     @State private var modelManagementViewModel: ModelManagementViewModel
     @State private var sessionManager = SessionManagerViewModel()
-    @State private var runtime: BaseChatRuntime?
+    @State private var runtime: BaseChatBootstrap?
     private let inferenceService: InferenceService
     private let toolRegistry: ToolRegistry
     private let sandboxRoot: URL
@@ -352,7 +352,7 @@ struct BaseChatDemoApp: App {
 
     @MainActor
     private func installRuntime(using container: ModelContainer) {
-        let runtime = try! BaseChatRuntime(
+        let runtime = try! BaseChatBootstrap(
             configuration: runtimeConfiguration,
             inferenceService: inferenceService,
             makeModelContainer: { container }

--- a/Example/BaseChatDemo/DemoContentView.swift
+++ b/Example/BaseChatDemo/DemoContentView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 import SwiftData
-import BaseChatCore
+import BaseChatPersistenceSwiftData
 import BaseChatInference
 import BaseChatUI
 import BaseChatUIModelManagement

--- a/Example/BaseChatDemo/DemoTools.swift
+++ b/Example/BaseChatDemo/DemoTools.swift
@@ -1,5 +1,4 @@
 import Foundation
-import BaseChatCore
 import BaseChatInference
 import BaseChatTools
 
@@ -142,9 +141,10 @@ enum DemoToolRoot {
         ("docs/architecture.md", """
         # Architecture Overview
 
-        BaseChatKit has five public targets:
+        BaseChatKit exposes these core products:
         - BaseChatInference — protocols and orchestration.
-        - BaseChatCore — SwiftData persistence.
+        - BaseChatRuntime — persistence-free runtime services and ports.
+        - BaseChatPersistenceSwiftData — SwiftData persistence and bootstrap.
         - BaseChatBackends — MLX, llama.cpp, Foundation, and cloud backends.
         - BaseChatUI — SwiftUI views and view models.
         - BaseChatTools — reference tools and the fuzzing harness.

--- a/Example/Examples/BaseChatExamples.xcodeproj/project.pbxproj
+++ b/Example/Examples/BaseChatExamples.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		09C86A21537F0ED2862D66ED /* MinimalExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA4C42C4D0FB1CD0ECBDA84 /* MinimalExampleApp.swift */; };
 		34606F73E74AAFC63E24F59A /* MinimalContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37540D69A62A294DAAD7FC1 /* MinimalContentView.swift */; };
-		40C7626D4A44DD1D18F0A1BF /* BaseChatCore in Frameworks */ = {isa = PBXBuildFile; productRef = 35D03E318932E0724E391E54 /* BaseChatCore */; };
+		40C7626D4A44DD1D18F0A1BF /* BaseChatPersistenceSwiftData in Frameworks */ = {isa = PBXBuildFile; productRef = 35D03E318932E0724E391E54 /* BaseChatPersistenceSwiftData */; };
 		5B0A9E6C1A2B3C4D5E6F7081 /* BaseChatUIModelManagement in Frameworks */ = {isa = PBXBuildFile; productRef = 1A2B3C4D5E6F708192A3B4C5 /* BaseChatUIModelManagement */; };
 		6F9A1CA5CA7FF16DB36A5861 /* BaseChatUI in Frameworks */ = {isa = PBXBuildFile; productRef = 4C28E08B212DBDD057CE27CF /* BaseChatUI */; };
 		79E6928B6CE7E3461758C5D9 /* MinimalExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA4C42C4D0FB1CD0ECBDA84 /* MinimalExampleApp.swift */; };
@@ -17,7 +17,7 @@
 		9784B251D853FA597B206D29 /* BaseChatBackends in Frameworks */ = {isa = PBXBuildFile; productRef = 56CCAAB5544541CD79EE64CD /* BaseChatBackends */; };
 		9B8A7C6D5E4F302918273645 /* BaseChatUIModelManagement in Frameworks */ = {isa = PBXBuildFile; productRef = 6D5E4F302918273645564738 /* BaseChatUIModelManagement */; };
 		A19A3DAEB85A136F8D62D31D /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 365ABBF494EF2955A53C327F /* README.md */; };
-		A336FC431FF118C880002B21 /* BaseChatCore in Frameworks */ = {isa = PBXBuildFile; productRef = DE250A4FF8082BF6714FE36C /* BaseChatCore */; };
+		A336FC431FF118C880002B21 /* BaseChatPersistenceSwiftData in Frameworks */ = {isa = PBXBuildFile; productRef = DE250A4FF8082BF6714FE36C /* BaseChatPersistenceSwiftData */; };
 		A9BB32CEAF191F5FF101B54C /* BaseChatBackends in Frameworks */ = {isa = PBXBuildFile; productRef = 7A5841AF39A6AB3B5022006D /* BaseChatBackends */; };
 		D2930E9046EADB459A40EA45 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 365ABBF494EF2955A53C327F /* README.md */; };
 		EFA072F50C91195B4A338E8C /* BaseChatUI in Frameworks */ = {isa = PBXBuildFile; productRef = 5D2764E94034C1EB5E482F75 /* BaseChatUI */; };
@@ -37,7 +37,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				40C7626D4A44DD1D18F0A1BF /* BaseChatCore in Frameworks */,
+				40C7626D4A44DD1D18F0A1BF /* BaseChatPersistenceSwiftData in Frameworks */,
 				EFA072F50C91195B4A338E8C /* BaseChatUI in Frameworks */,
 				9784B251D853FA597B206D29 /* BaseChatBackends in Frameworks */,
 				5B0A9E6C1A2B3C4D5E6F7081 /* BaseChatUIModelManagement in Frameworks */,
@@ -48,7 +48,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A336FC431FF118C880002B21 /* BaseChatCore in Frameworks */,
+				A336FC431FF118C880002B21 /* BaseChatPersistenceSwiftData in Frameworks */,
 				6F9A1CA5CA7FF16DB36A5861 /* BaseChatUI in Frameworks */,
 				A9BB32CEAF191F5FF101B54C /* BaseChatBackends in Frameworks */,
 				9B8A7C6D5E4F302918273645 /* BaseChatUIModelManagement in Frameworks */,
@@ -111,7 +111,7 @@
 			);
 			name = MinimalExample_iOS;
 			packageProductDependencies = (
-				DE250A4FF8082BF6714FE36C /* BaseChatCore */,
+				DE250A4FF8082BF6714FE36C /* BaseChatPersistenceSwiftData */,
 				4C28E08B212DBDD057CE27CF /* BaseChatUI */,
 				7A5841AF39A6AB3B5022006D /* BaseChatBackends */,
 				6D5E4F302918273645564738 /* BaseChatUIModelManagement */,
@@ -134,7 +134,7 @@
 			);
 			name = MinimalExample_macOS;
 			packageProductDependencies = (
-				35D03E318932E0724E391E54 /* BaseChatCore */,
+				35D03E318932E0724E391E54 /* BaseChatPersistenceSwiftData */,
 				5D2764E94034C1EB5E482F75 /* BaseChatUI */,
 				56CCAAB5544541CD79EE64CD /* BaseChatBackends */,
 				1A2B3C4D5E6F708192A3B4C5 /* BaseChatUIModelManagement */,
@@ -463,9 +463,9 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		35D03E318932E0724E391E54 /* BaseChatCore */ = {
+		35D03E318932E0724E391E54 /* BaseChatPersistenceSwiftData */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = BaseChatCore;
+			productName = BaseChatPersistenceSwiftData;
 		};
 		1A2B3C4D5E6F708192A3B4C5 /* BaseChatUIModelManagement */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -491,9 +491,9 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = BaseChatBackends;
 		};
-		DE250A4FF8082BF6714FE36C /* BaseChatCore */ = {
+		DE250A4FF8082BF6714FE36C /* BaseChatPersistenceSwiftData */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = BaseChatCore;
+			productName = BaseChatPersistenceSwiftData;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Example/Examples/MinimalExample/MinimalExampleApp.swift
+++ b/Example/Examples/MinimalExample/MinimalExampleApp.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 import SwiftData
-import BaseChatCore
+import BaseChatPersistenceSwiftData
 import BaseChatInference
 import BaseChatUI
 import BaseChatUIModelManagement
@@ -11,11 +11,11 @@ import BaseChatHuggingFace
 
 /// The simplest possible BaseChatKit app with runtime-first bootstrap.
 ///
-/// This assembles a ``BaseChatRuntime``, registers the built-in backends,
+/// This assembles a ``BaseChatBootstrap``, registers the built-in backends,
 /// and presents the standard chat + model-management surfaces.
 @main
 struct MinimalExampleApp: App {
-    private let runtime: BaseChatRuntime
+    private let runtime: BaseChatBootstrap
     @State private var chatViewModel: ChatViewModel
     @State private var sessionManager: SessionManagerViewModel
     @State private var modelManagement: ModelManagementViewModel
@@ -27,7 +27,7 @@ struct MinimalExampleApp: App {
         // detached `.task` (see BaseChatDemoApp): SwiftData container setup
         // (schema compilation + SQLite open) can stall the first frame for
         // several seconds when done on the main thread.
-        let runtime = try! BaseChatRuntime(
+        let runtime = try! BaseChatBootstrap(
             configuration: BaseChatConfiguration(
                 appName: "Minimal Chat",
                 bundleIdentifier: "com.basechatkit.minimal-example"

--- a/Example/Examples/MinimalExample/README.md
+++ b/Example/Examples/MinimalExample/README.md
@@ -2,7 +2,7 @@
 
 The simplest possible BaseChatKit app. Demonstrates the bare minimum setup:
 
-- Create a `BaseChatRuntime` at startup
+- Create a `BaseChatBootstrap` at startup
 - Register backends with `DefaultBackends.register(with:)`
 - Configure a `ChatViewModel` and `SessionManagerViewModel` from the runtime
 - Present `ChatView` with environment wiring

--- a/Example/Examples/project.yml
+++ b/Example/Examples/project.yml
@@ -19,7 +19,7 @@ targets:
       - MinimalExample
     dependencies:
       - package: BaseChatKit
-        product: BaseChatCore
+        product: BaseChatPersistenceSwiftData
       - package: BaseChatKit
         product: BaseChatUI
       - package: BaseChatKit

--- a/Package.resolved
+++ b/Package.resolved
@@ -119,6 +119,15 @@
       }
     },
     {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",

--- a/Package.resolved
+++ b/Package.resolved
@@ -119,15 +119,6 @@
       }
     },
     {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics",
-      "state" : {
-        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
-        "version" : "1.1.1"
-      }
-    },
-    {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",

--- a/Package.swift
+++ b/Package.swift
@@ -491,7 +491,7 @@ let package = Package(
                 "BaseChatInference",
             ],
             path: "Sources/BaseChatTools",
-            exclude: ["Scenarios/built-in/README.md", "README.md"],
+            exclude: ["README.md"],
             resources: [
                 .copy("Scenarios/built-in"),
             ]

--- a/Sources/BaseChatBackends/PinnedSessionDelegate.swift
+++ b/Sources/BaseChatBackends/PinnedSessionDelegate.swift
@@ -185,12 +185,9 @@ final class PinnedSessionDelegate: NSObject, URLSessionDelegate {
 
         var seenHashes: [String] = []
         for certificate in certChain {
-            guard let publicKey = SecCertificateCopyKey(certificate),
-                  let publicKeyData = SecKeyCopyExternalRepresentation(publicKey, nil) as Data? else {
+            guard let base64Hash = Self.spkiHashBase64(for: certificate) else {
                 continue
             }
-            let hash = sha256(data: publicKeyData)
-            let base64Hash = hash.base64EncodedString()
             seenHashes.append(base64Hash)
 
             if expectedPins.contains(base64Hash) {
@@ -205,7 +202,117 @@ final class PinnedSessionDelegate: NSObject, URLSessionDelegate {
 
     // MARK: - Helpers
 
-    private func sha256(data: Data) -> Data {
+    static func spkiHashBase64(for certificate: SecCertificate) -> String? {
+        guard let publicKey = SecCertificateCopyKey(certificate),
+              let rawKeyData = SecKeyCopyExternalRepresentation(publicKey, nil) as Data?,
+              let attributes = SecKeyCopyAttributes(publicKey) as? [CFString: Any],
+              let keyType = attributes[kSecAttrKeyType] as? String,
+              let keySize = attributes[kSecAttrKeySizeInBits] as? Int,
+              let spki = spkiDER(rawPublicKey: rawKeyData, keyType: keyType, keySizeInBits: keySize) else {
+            return nil
+        }
+        return sha256(data: spki).base64EncodedString()
+    }
+
+    static func spkiDER(rawPublicKey: Data, keyType: String, keySizeInBits: Int) -> Data? {
+        let algorithmIdentifier: Data
+        if keyType == (kSecAttrKeyTypeRSA as String) {
+            algorithmIdentifier = derSequence(
+                concat(derObjectIdentifier([1, 2, 840, 113549, 1, 1, 1]), derNull())
+            )
+        } else if keyType == (kSecAttrKeyTypeECSECPrimeRandom as String) {
+            guard let curveOID = ecCurveOID(keySizeInBits: keySizeInBits) else {
+                return nil
+            }
+            algorithmIdentifier = derSequence(
+                concat(derObjectIdentifier([1, 2, 840, 10045, 2, 1]), curveOID)
+            )
+        } else {
+            return nil
+        }
+
+        return derSequence(concat(algorithmIdentifier, derBitString(rawPublicKey)))
+    }
+
+    private static func ecCurveOID(keySizeInBits: Int) -> Data? {
+        switch keySizeInBits {
+        case 256:
+            return derObjectIdentifier([1, 2, 840, 10045, 3, 1, 7])
+        case 384:
+            return derObjectIdentifier([1, 3, 132, 0, 34])
+        case 521:
+            return derObjectIdentifier([1, 3, 132, 0, 35])
+        default:
+            return nil
+        }
+    }
+
+    private static func derSequence(_ content: Data) -> Data {
+        derTLV(tag: 0x30, content: content)
+    }
+
+    private static func derBitString(_ content: Data) -> Data {
+        derTLV(tag: 0x03, content: concat(Data([0x00]), content))
+    }
+
+    private static func derNull() -> Data {
+        Data([0x05, 0x00])
+    }
+
+    private static func derObjectIdentifier(_ components: [UInt64]) -> Data {
+        precondition(components.count >= 2, "OID requires at least two components")
+        precondition(components[0] <= 2, "OID first component must be 0, 1, or 2")
+        precondition(components[1] <= 39 || components[0] == 2, "OID second component out of range")
+
+        var body = Data([UInt8(components[0] * 40 + components[1])])
+        for component in components.dropFirst(2) {
+            body.append(contentsOf: derBase128(component))
+        }
+        return derTLV(tag: 0x06, content: body)
+    }
+
+    private static func derBase128(_ value: UInt64) -> [UInt8] {
+        var remaining = value
+        var bytes = [UInt8(remaining & 0x7F)]
+        remaining >>= 7
+        while remaining > 0 {
+            bytes.append(UInt8(remaining & 0x7F) | 0x80)
+            remaining >>= 7
+        }
+        return Array(bytes.reversed())
+    }
+
+    private static func derTLV(tag: UInt8, content: Data) -> Data {
+        var data = Data([tag])
+        data.append(derLength(content.count))
+        data.append(content)
+        return data
+    }
+
+    private static func derLength(_ length: Int) -> Data {
+        precondition(length >= 0, "DER length cannot be negative")
+        if length < 0x80 {
+            return Data([UInt8(length)])
+        }
+
+        var value = length
+        var bytes: [UInt8] = []
+        while value > 0 {
+            bytes.append(UInt8(value & 0xFF))
+            value >>= 8
+        }
+        return Data([0x80 | UInt8(bytes.count)] + Array(bytes.reversed()))
+    }
+
+    private static func concat(_ parts: Data...) -> Data {
+        var data = Data()
+        for part in parts {
+            data.append(part)
+        }
+        return data
+    }
+
+    private static func sha256(data: Data) -> Data {
         var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
         data.withUnsafeBytes { buffer in
             _ = CC_SHA256(buffer.baseAddress, CC_LONG(data.count), &hash)

--- a/Sources/BaseChatInference/Security/SecureEnclaveKeyManager.swift
+++ b/Sources/BaseChatInference/Security/SecureEnclaveKeyManager.swift
@@ -199,10 +199,9 @@ public final class SecureEnclaveKeyManager: @unchecked Sendable {
         if findStatus == errSecSuccess, let existing = keyRef {
             return existing as! SecKey // swiftlint:disable:this force_cast
         }
-        // errSecMissingEntitlement (-34018) means the process is not entitled to
-        // access the Keychain (e.g. unsigned swift test runner).  Treat as
-        // unavailable so callers degrade gracefully rather than crashing.
-        if findStatus == -34018 { throw SecureEnclaveError.notAvailable }
+        if Self.isUnavailableKeychainStatus(findStatus) {
+            throw SecureEnclaveError.notAvailable
+        }
 
         // Generate a new SE-resident P-256 private key.
         var accessError: Unmanaged<CFError>?
@@ -231,11 +230,8 @@ public final class SecureEnclaveKeyManager: @unchecked Sendable {
         var keyGenError: Unmanaged<CFError>?
         guard let privateKey = SecKeyCreateRandomKey(keyAttributes as CFDictionary, &keyGenError) else {
             let cfErr = keyGenError?.takeRetainedValue()
-            // errSecMissingEntitlement (-34018): process is not entitled to add keys
-            // to the Keychain (e.g. unsigned swift test runner or macOS App Sandbox
-            // without the necessary keychain-access-group entitlement). Treat as
-            // unavailable so callers degrade gracefully.
-            if let code = cfErr.map({ CFErrorGetCode($0) }), code == -34018 {
+            if let code = cfErr.map({ OSStatus(CFErrorGetCode($0)) }),
+               Self.isUnavailableKeychainStatus(code) {
                 throw SecureEnclaveError.notAvailable
             }
             let msg = cfErr.map { ($0 as Error).localizedDescription }
@@ -252,7 +248,9 @@ public final class SecureEnclaveKeyManager: @unchecked Sendable {
             kSecValueRef as String: privateKey,
         ]
         let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
-        if addStatus == -34018 { throw SecureEnclaveError.notAvailable }
+        if Self.isUnavailableKeychainStatus(addStatus) {
+            throw SecureEnclaveError.notAvailable
+        }
         // errSecDuplicateItem is fine — another thread beat us; load the
         // key that's already there.
         if addStatus == errSecDuplicateItem {
@@ -264,5 +262,9 @@ public final class SecureEnclaveKeyManager: @unchecked Sendable {
         }
 
         return privateKey
+    }
+
+    private static func isUnavailableKeychainStatus(_ status: OSStatus) -> Bool {
+        status == errSecMissingEntitlement || status == errSecInteractionNotAllowed
     }
 }

--- a/Sources/BaseChatTestSupport/HardwareRequirements.swift
+++ b/Sources/BaseChatTestSupport/HardwareRequirements.swift
@@ -173,9 +173,10 @@ public enum HardwareRequirements {
 
     /// Scans common model directories for a loadable local MLX model directory.
     ///
-    /// Searches:
-    /// 1. `~/Documents/Models/` (default `ModelStorageService` location)
-    /// 2. App container `Documents/Models/` directories
+    /// To avoid unbounded walks through user model folders during routine test
+    /// runs, common-directory discovery is opt-in. Set `MLX_TEST_MODEL` or pass
+    /// `nameContains` to select a specific fixture, or set
+    /// `BASECHAT_DISCOVER_LOCAL_MODELS=1` to allow fallback discovery.
     ///
     /// When `MLX_TEST_MODEL` is set, the first directory whose path contains that
     /// value wins. Otherwise falls back to `nameContains`, then to the first
@@ -184,7 +185,20 @@ public enum HardwareRequirements {
         nameContains substring: String? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> URL? {
-        findMLXModelDirectory(
+        if let override = directFilesystemModelOverride(
+            environment["MLX_TEST_MODEL"],
+            isValid: { isValidMLXDirectory($0, fileManager: .default) }
+        ) {
+            return override
+        }
+        guard shouldDiscoverLocalModels(
+            environment: environment,
+            selectorKey: "MLX_TEST_MODEL",
+            nameContains: substring
+        ) else {
+            return nil
+        }
+        return findMLXModelDirectory(
             in: modelSearchDirectories(fileManager: .default),
             nameContains: substring,
             environment: environment,
@@ -247,9 +261,10 @@ public enum HardwareRequirements {
 
     /// Scans common model directories for a loadable `.gguf` file.
     ///
-    /// Searches the same `Documents/Models/` locations as `findMLXModelDirectory`,
-    /// including one nested directory level for manually grouped files such as
-    /// `~/Documents/Models/qwen/model.gguf`.
+    /// To avoid unbounded walks through user model folders during routine test
+    /// runs, common-directory discovery is opt-in. Set `LLAMA_TEST_MODEL` or pass
+    /// `nameContains` to select a specific fixture, or set
+    /// `BASECHAT_DISCOVER_LOCAL_MODELS=1` to allow fallback discovery.
     ///
     /// When `LLAMA_TEST_MODEL` is set, the first GGUF whose path contains that
     /// value wins. Otherwise falls back to `nameContains`, then to the first
@@ -258,7 +273,20 @@ public enum HardwareRequirements {
         nameContains substring: String? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> URL? {
-        findGGUFModel(
+        if let override = directFilesystemModelOverride(
+            environment["LLAMA_TEST_MODEL"],
+            isValid: { isValidGGUFModel($0) }
+        ) {
+            return override
+        }
+        guard shouldDiscoverLocalModels(
+            environment: environment,
+            selectorKey: "LLAMA_TEST_MODEL",
+            nameContains: substring
+        ) else {
+            return nil
+        }
+        return findGGUFModel(
             in: modelSearchDirectories(fileManager: .default),
             nameContains: substring,
             environment: environment,
@@ -410,6 +438,27 @@ public enum HardwareRequirements {
         guard !selector.isEmpty else { return nil }
         guard selector.lowercased() != "all" else { return nil }
         return selector
+    }
+
+    private static func shouldDiscoverLocalModels(
+        environment: [String: String],
+        selectorKey: String,
+        nameContains substring: String?
+    ) -> Bool {
+        if normalizedModelSelector(environment[selectorKey]) != nil { return true }
+        if normalizedModelSelector(substring) != nil { return true }
+        return environment["BASECHAT_DISCOVER_LOCAL_MODELS"] == "1"
+    }
+
+    private static func directFilesystemModelOverride(
+        _ selector: String?,
+        isValid: (URL) -> Bool
+    ) -> URL? {
+        guard let selector = normalizedModelSelector(selector) else { return nil }
+        let expanded = (selector as NSString).expandingTildeInPath
+        let url = URL(fileURLWithPath: expanded)
+        guard url.isFileURL, expanded.contains("/") else { return nil }
+        return isValid(url) ? url : nil
     }
 
     private static func appendGGUFModel(

--- a/Tests/BaseChatBackendsTests/BackendCapabilitiesContractTests.swift
+++ b/Tests/BaseChatBackendsTests/BackendCapabilitiesContractTests.swift
@@ -95,13 +95,13 @@ final class BackendCapabilitiesContractTests: XCTestCase {
                        "LlamaBackend runs on-device — isRemote must be false")
     }
 
-    func test_llamaBackend_doesNotSupportToolCalling() throws {
+    func test_llamaBackend_supportsToolCalling() throws {
         try XCTSkipUnless(HardwareRequirements.isPhysicalDevice,
                           "LlamaBackend requires Metal (unavailable in simulator)")
         try XCTSkipUnless(HardwareRequirements.isAppleSilicon,
                           "LlamaBackend requires Apple Silicon")
-        XCTAssertFalse(LlamaBackend().capabilities.supportsToolCalling,
-                       "LlamaBackend does not support tool calling natively")
+        XCTAssertTrue(LlamaBackend().capabilities.supportsToolCalling,
+                      "LlamaBackend advertises tool calling for Gemma 4 and parser-backed local tool-call formats")
     }
 
     func test_llamaBackend_doesNotSupportNativeJSONMode() throws {

--- a/Tests/BaseChatBackendsTests/LlamaEmbeddingBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaEmbeddingBackendTests.swift
@@ -8,7 +8,8 @@ import BaseChatTestSupport
 ///
 /// Resolution order (first hit wins):
 ///   1. `BCK_EMBEDDING_MODEL_PATH` env var — explicit override for live-fire runs
-///   2. `~/Documents/Models/*.gguf` containing "embed"/"embedding"/"bge"/"minilm"/"nomic"/"jina"
+///   2. `~/Documents/Models/*.gguf` containing "embed"/"embedding"/"bge"/"minilm"/"nomic"/"jina",
+///      only when `BASECHAT_DISCOVER_LOCAL_MODELS=1` opts into local discovery
 ///
 /// Returns `nil` when nothing is found, in which case the calling test should
 /// `XCTSkipUnless` the URL — embedding tests cannot synthesize a valid GGUF on
@@ -23,6 +24,9 @@ enum EmbeddingTestModelLocator {
             if FileManager.default.fileExists(atPath: url.path) {
                 return url
             }
+        }
+        guard env["BASECHAT_DISCOVER_LOCAL_MODELS"] == "1" else {
+            return nil
         }
 
         let fm = FileManager.default

--- a/Tests/BaseChatBackendsTests/PinnedSessionDelegateTests.swift
+++ b/Tests/BaseChatBackendsTests/PinnedSessionDelegateTests.swift
@@ -1,6 +1,7 @@
 #if CloudSaaS
 import XCTest
 import CommonCrypto
+import Security
 import BaseChatInference
 @testable import BaseChatBackends
 
@@ -27,6 +28,28 @@ final class PinnedSessionDelegateTests: XCTestCase {
         XCTAssertEqual(base64, "LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ=",
                         "SHA-256 of 'hello' should match known base64 hash. "
                         + "Note: this validates the same algorithm the delegate uses.")
+    }
+
+    func test_spkiDER_wrapsP256KeyToStandardSPKIHash() {
+        let rawWE1Key = Data(base64Encoded: "BG/NOv5nV0dMIQOFQMJHXbtYRw9AwVwXhcYZN+fVfO2GS5uB2dcaE6UKA/iYxMbonv8QWY8sJpj15iYluw8C+lY=")!
+        let spki = PinnedSessionDelegate.spkiDER(
+            rawPublicKey: rawWE1Key,
+            keyType: kSecAttrKeyTypeECSECPrimeRandom as String,
+            keySizeInBits: 256
+        )
+
+        XCTAssertEqual(spki.map(Self.sha256Base64), "kIdp6NNEd8wsugYyyIYFsi1ylMCED3hZbSR8ZFsa/A4=")
+    }
+
+    func test_spkiDER_wrapsP384KeyToStandardSPKIHash() {
+        let rawGTSRootR4Key = Data(base64Encoded: "BPN0c6doi2CuQ7g1xYEwe0tJnfvBYc7m3ka9a9VhGDWuQN1z94mRMFrrPO6FfKJAdjupxrhH2CrnkpFqc+mxcjmfKZ+imNNfXliGZQ+hhGUG0dyLycdzyIxqL+XEq9Edig==")!
+        let spki = PinnedSessionDelegate.spkiDER(
+            rawPublicKey: rawGTSRootR4Key,
+            keyType: kSecAttrKeyTypeECSECPrimeRandom as String,
+            keySizeInBits: 384
+        )
+
+        XCTAssertEqual(spki.map(Self.sha256Base64), "mEflZT5enoR1FuXLgYYGqnVEoZvmf9c2bVBpiOjYQ0c=")
     }
 
     // MARK: - Bypass Hosts
@@ -427,6 +450,14 @@ final class PinnedSessionDelegateTests: XCTestCase {
             error: nil,
             sender: StubChallengeSender()
         )
+    }
+
+    private static func sha256Base64(_ data: Data) -> String {
+        var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        data.withUnsafeBytes { buffer in
+            _ = CC_SHA256(buffer.baseAddress, CC_LONG(data.count), &hash)
+        }
+        return Data(hash).base64EncodedString()
     }
 }
 

--- a/Tests/BaseChatInferenceTests/HardwareRequirementsGGUFTests.swift
+++ b/Tests/BaseChatInferenceTests/HardwareRequirementsGGUFTests.swift
@@ -57,6 +57,12 @@ final class HardwareRequirementsGGUFTests: XCTestCase {
         XCTAssertEqual(result?.standardizedFileURL.path, alpha.standardizedFileURL.path)
     }
 
+    func test_publicFindGGUFModel_withoutOptInDoesNotScanDefaultDirectories() {
+        let result = HardwareRequirements.findGGUFModel(environment: [:])
+
+        XCTAssertNil(result)
+    }
+
     func test_isValidGGUFModel_rejectsDirectoriesAndTinyFiles() {
         let directory = tempDirectory.appendingPathComponent("fake.gguf", isDirectory: true)
         try? fm.createDirectory(at: directory, withIntermediateDirectories: true)

--- a/Tests/BaseChatInferenceTests/HardwareRequirementsMLXTests.swift
+++ b/Tests/BaseChatInferenceTests/HardwareRequirementsMLXTests.swift
@@ -109,6 +109,22 @@ final class HardwareRequirementsMLXTests: XCTestCase {
         XCTAssertEqual(result?.standardizedFileURL.path, alpha.standardizedFileURL.path)
     }
 
+    func test_publicFindMLXModelDirectory_acceptsDirectPathOverride() {
+        createValidMLXDirectory(at: tempDirectory)
+
+        let result = HardwareRequirements.findMLXModelDirectory(
+            environment: ["MLX_TEST_MODEL": tempDirectory.path]
+        )
+
+        XCTAssertEqual(result?.standardizedFileURL.path, tempDirectory.standardizedFileURL.path)
+    }
+
+    func test_publicFindMLXModelDirectory_withoutOptInDoesNotScanDefaultDirectories() {
+        let result = HardwareRequirements.findMLXModelDirectory(environment: [:])
+
+        XCTAssertNil(result)
+    }
+
     private func createValidMLXDirectory(at directory: URL) {
         try? fm.createDirectory(at: directory, withIntermediateDirectories: true)
         createFile("config.json", in: directory, contents: #"{"model_type":"llama"}"#)

--- a/Tests/BaseChatUIModelManagementTests/ModelManagementSheetLogicTests.swift
+++ b/Tests/BaseChatUIModelManagementTests/ModelManagementSheetLogicTests.swift
@@ -207,7 +207,11 @@ final class ModelManagementSheetLogicTests: XCTestCase {
     }
 
     func test_managementViewModel_storageInfo() {
-        let vm = ModelManagementViewModel()
+        let vm = ModelManagementViewModel(
+            modelStorage: ModelStorageService(
+                baseDirectory: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            )
+        )
         // totalStorageUsed should return a formatted string even if no models exist.
         XCTAssertFalse(vm.totalStorageUsed.isEmpty, "Storage display should never be empty")
         XCTAssertFalse(vm.modelsDirectoryPath.isEmpty, "Models directory path should never be empty")
@@ -396,10 +400,15 @@ final class ModelManagementSheetLogicTests: XCTestCase {
     #if canImport(AppKit)
     private func hostedSheetFittingSize(for tab: ModelManagementSheet.Tab) -> CGSize {
         let (vm, _) = makeViewModelWithMock()
+        let modelManagement = ModelManagementViewModel(
+            modelStorage: ModelStorageService(
+                baseDirectory: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            )
+        )
         let controller = NSHostingController(
             rootView: ModelManagementSheet(initialTab: tab)
                 .environment(vm)
-                .environment(ModelManagementViewModel())
+                .environment(modelManagement)
         )
 
         _ = controller.view

--- a/Tests/BaseChatUIModelManagementTests/ModelManagementViewModelTests.swift
+++ b/Tests/BaseChatUIModelManagementTests/ModelManagementViewModelTests.swift
@@ -237,9 +237,9 @@ final class ModelManagementViewModelTests: XCTestCase {
     }
 
     func test_isModelDownloaded_checksStorage() {
-        // With default ModelStorageService and a model that doesn't exist on disk,
-        // isModelDownloaded should return false.
-        let vm = ModelManagementViewModel()
+        let isolated = makeIsolatedModelStorage()
+        defer { try? FileManager.default.removeItem(at: isolated.directory) }
+        let vm = ModelManagementViewModel(modelStorage: isolated.service)
 
         let model = DownloadableModel(
             repoID: "test/nonexistent",

--- a/Tests/BaseChatUITests/RuntimeConfigurationTests.swift
+++ b/Tests/BaseChatUITests/RuntimeConfigurationTests.swift
@@ -26,8 +26,13 @@ final class RuntimeConfigurationTests: XCTestCase {
             makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
         )
 
+        let modelsDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RuntimeConfigurationTests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: modelsDirectory) }
+
         let chatViewModel = ChatViewModel(
             inferenceService: runtime.inferenceService,
+            modelStorage: ModelStorageService(baseDirectory: modelsDirectory),
             userDefaults: defaults
         )
         let sessionManager = SessionManagerViewModel()
@@ -77,8 +82,13 @@ final class RuntimeConfigurationTests: XCTestCase {
             makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
         )
 
+        let modelsDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RuntimeBootstrapTests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: modelsDirectory) }
+
         let chatViewModel = ChatViewModel(
             inferenceService: runtime.inferenceService,
+            modelStorage: ModelStorageService(baseDirectory: modelsDirectory),
             userDefaults: defaults
         )
         let sessionManager = SessionManagerViewModel()

--- a/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
+++ b/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
@@ -48,13 +48,16 @@ final class ViewModelEdgeCaseTests: XCTestCase {
     /// failures without also lying about what storage actually does.
     private func makeViewModelWithPersistence(
         mock: MockInferenceBackend = MockInferenceBackend()
-    ) throws -> (ChatViewModel, MockInferenceBackend, ErrorInjectingPersistenceProvider) {
+        ) throws -> (ChatViewModel, MockInferenceBackend, ErrorInjectingPersistenceProvider) {
         mock.isModelLoaded = true
         let service = InferenceService(backend: mock, name: "Mock")
+        let modelsDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ViewModelEdgeCaseTests-\(UUID().uuidString)")
+        addTeardownBlock { try? FileManager.default.removeItem(at: modelsDirectory) }
         let vm = ChatViewModel(
             inferenceService: service,
             deviceCapability: DeviceCapabilityService(physicalMemory: 16 * oneGB),
-            modelStorage: ModelStorageService(),
+            modelStorage: ModelStorageService(baseDirectory: modelsDirectory),
             memoryPressure: MemoryPressureHandler()
         )
         let stack = try InMemoryPersistenceHarness.make()


### PR DESCRIPTION
## Summary
- opt local model discovery into the hardware and capability checks used by runtime and model-management flows
- standardize pin hashing between the secure enclave key manager and pinned session delegate, with focused regression coverage
- make changelog lint always report results in CI

## Testing
- Not run (not requested)