### PR TITLE
feat(demo): ship working MCP server and tool-calling-via-MCP scenario

### DIFF
--- a/Example/BaseChatDemo.xcodeproj/project.pbxproj
+++ b/Example/BaseChatDemo.xcodeproj/project.pbxproj
@@ -893,6 +893,12 @@
 		F20001000000000000000000 /* XCLocalSwiftPackageReference ".." */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ..;
+			traits = (
+				MLX,
+				Llama,
+				HuggingFace,
+				MCPBuiltinCatalog,
+			);
 		};
 /* End XCLocalSwiftPackageReference section */
 

--- a/Example/BaseChatDemo/MCP/DemoMCPCoordinator.swift
+++ b/Example/BaseChatDemo/MCP/DemoMCPCoordinator.swift
@@ -36,17 +36,61 @@ final class DemoMCPCoordinator {
         self.client = MCPClient()
         self.isFoundationModelsActive = isFoundationModelsActive
 
-        #if MCPBuiltinCatalog
-        self.catalog = MCPCatalog.all
-        self.catalogHelpText = "No built-in entries available."
-        #else
-        self.catalog = []
-        self.catalogHelpText = "Enable the MCPBuiltinCatalog trait or provide custom server descriptors."
+        // Catalog composition rationale (PR #921 / `feat/demo-mcp-server`):
+        // - The MCPBuiltinCatalog trait is enabled in the demo's pbxproj so
+        //   `MCPCatalog.all` (Notion / Linear / GitHub) is non-empty out of
+        //   the box. These OAuth-gated entries are useful for users who have
+        //   accounts with those providers, but they aren't a no-config happy
+        //   path for someone just kicking the tyres.
+        // - To give every macOS user a working tap-to-connect server with
+        //   zero credentials, we prepend a stdio descriptor that launches
+        //   `@modelcontextprotocol/server-everything` via `npx`. The server
+        //   is the official MCP reference implementation and exposes an
+        //   `echo` tool the `mcp-echo` demo scenario calls. The descriptor
+        //   is gated to macOS because `MCPClient.makeTransport` rejects
+        //   stdio on every other platform.
+        var assembled: [MCPServerDescriptor] = []
+        #if os(macOS) && !targetEnvironment(macCatalyst)
+        assembled.append(Self.demoEchoDescriptor)
         #endif
+        #if MCPBuiltinCatalog
+        assembled.append(contentsOf: MCPCatalog.all)
+        #endif
+        self.catalog = assembled
+
+        if assembled.isEmpty {
+            self.catalogHelpText = "No services configured. Enable the MCPBuiltinCatalog trait or run on macOS to see the demo Echo server."
+        } else {
+            self.catalogHelpText = "Tap Connect on a service to start its session."
+        }
 
         for descriptor in catalog {
             snapshotsByID[descriptor.id] = .init()
         }
+    }
+
+    /// Stable UUID for the demo Echo descriptor — kept stable so the
+    /// scenario runner and the connect button refer to the same server
+    /// across launches, and so XCUITests can target it deterministically.
+    private static let demoEchoServerID = UUID(uuidString: "8E3F1F1B-0E69-4D8B-9D4D-7E2D2F2A8F11")!
+
+    /// macOS-only stdio descriptor for the official MCP "everything" server.
+    /// Pulled via `npx -y @modelcontextprotocol/server-everything`, which
+    /// requires Node.js on PATH but no credentials. Exposes an `echo` tool
+    /// the `mcp-echo` demo scenario invokes end-to-end through the MCP
+    /// tool bridge.
+    private static var demoEchoDescriptor: MCPServerDescriptor {
+        MCPServerDescriptor(
+            id: demoEchoServerID,
+            displayName: "Demo Echo (local, via npx)",
+            transport: .stdio(.npx(package: "@modelcontextprotocol/server-everything")),
+            authorization: .none,
+            toolNamespace: "everything",
+            resourceURL: nil,
+            dataDisclosure: "Launches the official MCP reference server locally over stdio. Requires Node.js (npx) on PATH. No credentials are sent off-device; tool arguments stay local to the spawned process.",
+            toolFilter: .allowAll,
+            approvalPolicy: .perCall
+        )
     }
 
     func startListenersIfNeeded() {

--- a/Example/BaseChatDemo/Scenarios/DemoScenarios+Scripts.swift
+++ b/Example/BaseChatDemo/Scenarios/DemoScenarios+Scripts.swift
@@ -95,6 +95,23 @@ extension DemoScenarios {
                 ])
             ]
 
+        case mcpEcho.id:
+            // Targets the namespaced name produced by `MCPToolSource` when the
+            // descriptor's `toolNamespace` is "everything" — the live tool
+            // surfaced by `@modelcontextprotocol/server-everything` after the
+            // user taps Connect. Under `--uitesting`, ScriptedBackend dispatches
+            // the same name; if the user hasn't connected, the registry
+            // returns `.notFound` and the model would normally apologise — but
+            // the scripted second turn goes straight to a confirmation summary
+            // so the demo recording stays predictable for XCUITests.
+            return [
+                .toolCall(name: "everything__echo", arguments: #"{"message":"Hello from BaseChatKit"}"#),
+                .tokens([
+                    "The ", "MCP ", "echo ", "server ", "replied: ",
+                    "'Hello ", "from ", "BaseChatKit'."
+                ])
+            ]
+
         default:
             return fallbackTurns
         }

--- a/Example/BaseChatDemo/Scenarios/DemoScenarios.swift
+++ b/Example/BaseChatDemo/Scenarios/DemoScenarios.swift
@@ -88,6 +88,25 @@ enum DemoScenarios {
         configure: nil
     )
 
+    static let mcpEcho = DemoScenario(
+        id: "mcp-echo",
+        // Calls a tool whose definition was discovered from a real MCP
+        // server (the official `@modelcontextprotocol/server-everything`),
+        // not from a hardcoded `ScriptedBackend` tool. Open Connected
+        // Services > "Demo Echo (local, via npx)" and tap Connect first;
+        // the registry binds `everything__echo` and the scenario routes
+        // through it. macOS-only because the underlying stdio transport
+        // is gated to macOS.
+        title: "Echo via an MCP server",
+        blurb: "Connect 'Demo Echo' in Connected Services first (macOS, requires npx). Then this scenario routes a tool call through the live MCP server.",
+        systemImage: "antenna.radiowaves.left.and.right",
+        prompt: "Use the everything echo tool to repeat back the message 'Hello from BaseChatKit'.",
+        expectedTools: ["everything__echo"],
+        autoSend: true,
+        accessibilityID: "demo-card-mcp-echo",
+        configure: nil
+    )
+
     /// Order matches card display order on the empty state.
     static let all: [DemoScenario] = [
         tipCalc,
@@ -96,7 +115,8 @@ enum DemoScenarios {
         journalWrite,
         invalidArgsRecover,
         rateLimitedRetry,
-        mcpToolFailure
+        mcpToolFailure,
+        mcpEcho
     ]
 
     static func scenario(id: String) -> DemoScenario? {


### PR DESCRIPTION
## Summary

The Example demo mounted the Connected Services sheet over an empty catalog (`MCPCatalog` is trait-gated, the trait was off), so a user tapping "MCP" landed on "No services configured" with no way to add a server. Tool calling itself worked end-to-end via the seven `ScriptedBackend` scenarios, but none demonstrated an *MCP-sourced* tool.

This PR gives the demo a real MCP happy path. On first launch the catalog now lists OAuth-gated providers (Notion / Linear / GitHub) plus, on macOS, a credential-free "Demo Echo (local, via npx)" entry. A new `mcp-echo` scenario card invokes a tool the live MCP server publishes.

## Approach: Option A + macOS-only stdio descriptor

I picked a hybrid of options A and B from the brief and walked away from the pure forms of each:

- **Pure Option A** — enabling `MCPBuiltinCatalog` populates the catalog with Notion / Linear / GitHub, but every entry requires an account + OAuth roundtrip, so it isn't a no-config happy path for first-time users just kicking the tyres.
- **Pure Option B** — wiring an in-process MCP server inside the Example target would have required either a new public init on `MCPToolSource` taking `listTools`/`callTool` closures, or a custom transport. Both are substantive changes to `Sources/BaseChatMCP/`, which the brief explicitly forbids.
- **Pure Option C** — `mcp-server-everything` over stdio is what `EverythingServerSmokeTests` uses; CLAUDE.md notes it has hung 28+ minutes in CI. That's a problem for tests, but irrelevant for an interactive demo where the user only spawns the server when they tap Connect.

The hybrid:

1. Enable the `MCPBuiltinCatalog` trait on the Example app's local Swift Package reference (`Example/BaseChatDemo.xcodeproj/project.pbxproj` — `traits = (...)` on the `XCLocalSwiftPackageReference`). The catalog is no longer empty by default.
2. Define a `Demo Echo (local, via npx)` descriptor locally in `DemoMCPCoordinator` (Example target only, *not* `Sources/BaseChatMCP/`). It uses `MCPStdioCommand.npx(package: "@modelcontextprotocol/server-everything")`, gated to `os(macOS)` because `MCPClient.makeTransport` rejects stdio elsewhere. No credentials, no remote service — just Node.js on PATH.
3. Add an `mcp-echo` scripted scenario whose tool call targets `everything__echo` (the namespaced name `MCPToolSource` produces for `toolNamespace: "everything"`). The blurb instructs the user to connect "Demo Echo" first so the registry binds the live MCP tool before the scripted backend dispatches the call.

`Sources/BaseChatMCP/` is untouched.

## What a user sees on first launch

Launching the demo and tapping the sidebar's **Connected Services** button now shows a populated list: "Demo Echo (local, via npx)" on macOS plus Notion / Linear / GitHub on every platform. Each row has a Connect button and a Data Use disclosure. The empty-state copy is updated for the unreachable case (BaseChatMCP not linked, or iOS without the trait): it now points at the trait flag and the macOS-only echo server rather than the previous bare "No services configured" message.

## Running the new scenario

On macOS with Node installed:

1. Open Connected Services from the sidebar.
2. Tap **Connect** next to "Demo Echo (local, via npx)" — the descriptor spawns `npx -y @modelcontextprotocol/server-everything` and the registry picks up its tools, namespaced under `everything__*`.
3. Open the **Demos** menu (or the empty-state cards) and pick **Echo via an MCP server**.
4. The scenario sends "Use the everything echo tool to repeat back the message 'Hello from BaseChatKit'." The scripted backend emits a `toolCall(name: "everything__echo", ...)` which the registry routes through the live MCP source, and the second scripted turn synthesises the assistant's confirmation.

In `--uitesting` runs, the same scripted turn fires whether or not the server is connected — keeping XCUITest recordings deterministic.

## Test plan

- [x] `swift build --build-tests --disable-default-traits`
- [x] `swift build --build-tests --traits MCPBuiltinCatalog`
- [x] `scripts/test.sh --filter BaseChatMCPTests --disable-default-traits --skip-update` — 143 passed
- [x] `scripts/test.sh --filter BaseChatMCPTests --disable-default-traits --traits MCPBuiltinCatalog --skip-update` — 150 passed
- [ ] Manual macOS run: tap Connect on "Demo Echo", run the `mcp-echo` scenario card

🤖 Generated with [Claude Code](https://claude.com/claude-code)