### PR TITLE
refactor(inference): narrow KeychainService.sweep to package

### DIFF
--- a/Sources/BaseChatInference/Services/KeychainService.swift
+++ b/Sources/BaseChatInference/Services/KeychainService.swift
@@ -237,7 +237,7 @@ public enum KeychainService {
     /// the sweep — a single bad row should not prevent the rest from being
     /// reclaimed. Intended to be driven once at boot from ``BaseChatBootstrap``.
     @discardableResult
-    public static func sweep(validAccounts: Set<String>) -> Int {
+    package static func sweep(validAccounts: Set<String>) -> Int {
         let stored = allAccounts()
         guard !stored.isEmpty else {
             Log.security.info("KeychainService.sweep: namespace empty, nothing to reap")


### PR DESCRIPTION
## Summary

Follow-up to #932 (security API surface audit / closes #366).

`KeychainService.sweep(validAccounts:)` is only called from `BaseChatBootstrap.reapOrphanedKeychainItems` inside `BaseChatPersistenceSwiftData`. It's internal plumbing — host apps trigger reaping through the public `BaseChatBootstrap` API, not by calling `sweep` directly.

`package` keeps the cross-module call from `BaseChatPersistenceSwiftData` working while removing `sweep` from the public API surface.

## Test plan

- [x] `swift build --disable-default-traits` — clean
- [ ] `BaseChatInferenceTests` (KeychainServiceSweepTests uses `@testable import` so `package` is sufficient)