### PR TITLE
fix(llama): env-gate the n_gpu_layers=0 TEMP in LlamaModelLoader

### DIFF
--- a/Sources/BaseChatBackends/LlamaModelLoader.swift
+++ b/Sources/BaseChatBackends/LlamaModelLoader.swift
@@ -102,12 +102,19 @@ final class LlamaModelLoader: @unchecked Sendable {
         #if targetEnvironment(simulator)
         modelParams.n_gpu_layers = 0   // Metal not reliable in simulator
         #else
-        // TEMP for 26B MoE on a 24 GB Mac running other heavy processes: pure
-        // CPU (mmap-paged). The Metal command-buffer cannot allocate ~10 GB of
-        // partial weights when system headroom is < ~6 GB. CPU-only proves the
-        // model decodes; we'll bump back toward 99 once memory pressure eases
-        // and the load-time hw.memsize policy lands.
-        modelParams.n_gpu_layers = 0
+        // Default: offload all layers to Metal. CPU-only is ~8× slower for
+        // even a 4B model (measured 2.28 s vs 0.28 s on `test_countTokens_…`
+        // against Qwen3-4B-Q4_K_M on M5/24 GB).
+        //
+        // Escape hatch for memory-constrained loads of very large MoE models:
+        // when the Metal command-buffer cannot allocate enough partial
+        // weights, set `LLAMA_FORCE_CPU_ONLY=1` to force CPU (mmap-paged)
+        // execution. Documented in `docs/LLAMA_CONTRACT.md`.
+        if ProcessInfo.processInfo.environment["LLAMA_FORCE_CPU_ONLY"] == "1" {
+            modelParams.n_gpu_layers = 0
+        } else {
+            modelParams.n_gpu_layers = 99  // Offload all layers to Metal
+        }
         #endif
 
         // Wire up the progress callback when a handler is installed.

--- a/docs/LLAMA_CONTRACT.md
+++ b/docs/LLAMA_CONTRACT.md
@@ -53,7 +53,7 @@ changes before merging.
 | Failure modes | None. |
 
 **Fields set by `LlamaBackend`:**
-- `n_gpu_layers = 0` in simulator (Metal unreliable); `99` otherwise (offload all layers).
+- `n_gpu_layers = 0` in simulator (Metal unreliable); `99` otherwise (offload all layers). On non-simulator hosts, setting `LLAMA_FORCE_CPU_ONLY=1` in the process environment forces `n_gpu_layers = 0` for memory-constrained loads of very large MoE models that cannot fit their Metal partial-weight buffers — the default `99` is ~8× faster on a 4B GGUF (measured 2.28 s vs 0.28 s on `test_countTokens_…` against Qwen3-4B-Q4_K_M, M5/24 GB).
 - `progress_callback` / `progress_callback_user_data`: set when a load-progress handler is installed. The callback fires on the loader thread; `LlamaBackend` bridges to async Swift via an unstructured `Task`. The `Unmanaged` retain on `ProgressCallbackContext` is released in a `defer` block after `llama_model_load_from_file` returns, so the C callback cannot fire after that point.
 
 ### `llama_model_load_from_file`


### PR DESCRIPTION
## TL;DR

`Sources/BaseChatBackends/LlamaModelLoader.swift:107` hardcodes `n_gpu_layers = 0` for all non-simulator GGUF loads. The TEMP comment cites a 26B MoE on a 24 GB Mac. The original symptom is **not reproducible today**, the cost is ~8x on every Llama load, and `Gemma4MoESmokeTests` (the only test that exercises the 26B MoE) actually lives in `BaseChatMLXIntegrationTests`, not the Llama suite. Default to `n_gpu_layers=99`; keep an `LLAMA_FORCE_CPU_ONLY=1` env-var escape hatch.

## Reconstructed incident

The TEMP was introduced in #791 (`chore: split non-MCP changes out of #790`) on 2026-04-26 — a chore PR that explicitly carved `LlamaModelLoader`, `ModelLoadCoordinator`, and `Gemma4MoESmokeTests` out of the MCP rollout #790. The PR body is a one-paragraph "extracts unrelated changes" note, with no incident description.

The only contemporaneous evidence:
- Inline comment: *"TEMP for 26B MoE on a 24 GB Mac running other heavy processes: pure CPU (mmap-paged). The Metal command-buffer cannot allocate ~10 GB of partial weights when system headroom is < ~6 GB."*
- The companion `Gemma4MoESmokeTests` from #791 targets `mlx-community/gemma-4-26b-a4b-it-4bit` — i.e. the **MLX** path, not Llama. The MoE crash that drove that test (issue #802, deferred per memory `project_v0121_2026_04.md`) is `MLX/ErrorHandler.swift` `[broadcast_shapes]` — unrelated to Metal command-buffer allocation.
- The 26B MoE GGUF (`gemma-4-26B-A4B-it-UD-Q4_K_M.gguf`) on disk is not referenced by any test fixture.

PR #937 ("test: per-class process isolation script") flagged this line directly: it observed the `regression519` test running hot at 200–500% CPU in `ggml_graph_compute → ggml_gemv_q4_K_*` and pinned the cause to the hardcoded `n_gpu_layers=0`.

Memory entries cited: `project_modelloadplan_v090_2026_04.md` (ModelLoadPlan does not currently surface a `gpuLayerCount`), `project_v0121_2026_04.md` (#802 MoE crash is MLX-side), `project_llama_stability_2026_04.md`, `feedback_agent_diagnosis.md`.

## Current-state findings

I tried both models on this M5 / 24 GB host with `n_gpu_layers=99`:

| Model | Result with GPU |
|-------|-----------------|
| `Qwen_Qwen3-4B-Q4_K_M.gguf` | Loads cleanly. MTL0 compute = 301.75 MiB. Test passes in 0.276 s. |
| `gemma-4-26B-A4B-it-UD-Q4_K_M.gguf` (the original MoE) | **Loads cleanly.** MTL0 compute = 521.62 MiB, MTL0 KV = 200 MiB. Test passes in 17.13 s. |

The original Metal-allocation symptom does not reproduce. Either macOS / llama.cpp have changed since the TEMP, or the host configuration that triggered it is no longer typical.

`ModelLoadPlan` (#419 / v0.9.0) does not expose a `gpuLayerCount` field — its `Outcome` only carries effective context size and verdict/reasons. Routing GPU-layer choice through `ModelLoadPlan` would require expanding its public API. That's option C in the plan, and it's overkill for this fix.

## Perf delta

Single-test measurement against `Qwen_Qwen3-4B-Q4_K_M.gguf`, `LlamaBackendTests.test_countTokens_withLoadedModel_returnsPlausibleCount`:

| Config | Test time | MTL0 compute buffer | Wall clock |
|--------|-----------|--------------------:|-----------:|
| `n_gpu_layers = 0` (current) | 2.281 s | 0 MiB | 7.96 s |
| `n_gpu_layers = 99` (this PR) | 0.276 s | 301.75 MiB | 2.00 s |

**~8.3x faster test execution, ~4x faster wall clock.** Across the ~15 Llama-touching test classes that each call `loadModel`, this compounds to minutes. PR #937 already attributed the "Llama suite deadlock" to this very line.

## Chosen option — B (env-gate)

I picked **option B** over option A (full revert) because the original incident, even if not reproducible on my host, is a plausible OOM scenario worth keeping a one-line escape hatch for. Option C (route through `ModelLoadPlan`) was rejected because `ModelLoadPlan` does not currently expose `gpuLayerCount`, and the brief was explicit not to expand its surface for this.

## Diff (plain English)

- `Sources/BaseChatBackends/LlamaModelLoader.swift`: replace the hardcoded `modelParams.n_gpu_layers = 0` (with multi-line TEMP comment) with `if ProcessInfo.processInfo.environment["LLAMA_FORCE_CPU_ONLY"] == "1" { 0 } else { 99 }`. Simulator branch unchanged (`0`, Metal unreliable).
- `docs/LLAMA_CONTRACT.md`: rewrite the `n_gpu_layers` bullet under `llama_model_default_params` to document the env-var override and the perf delta.

## Validation

- Targeted test against Qwen3-4B passes with `n_gpu_layers=99` (0.276 s) and with `LLAMA_FORCE_CPU_ONLY=1` (1.572 s — confirms env-var path is wired correctly, MTL0 buffer = 0).
- 26B MoE GGUF loads cleanly on GPU on 24 GB Mac.
- `swift build --build-tests --disable-default-traits --traits Llama` clean.

Per the brief, I deliberately did **not** run the full Llama suite or the cross-target pre-push gate — this PR is a draft for maintainer review.