### PR TITLE
feat(server): add OpenAI-compatible BaseChatServer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,12 +239,12 @@ jobs:
       # Swift Testing must stay isolated — mixing XCTest + Swift Testing in one
       # swift test process triggers a libmalloc double-free SIGABRT (see
       # SwiftTestingAuditTest, #681).
-      - name: Test — XCTest suites (Core + Runtime + PersistenceSwiftData + UI + UIModelManagement + MCP + Backends + TestSupport + AppIntents)
+      - name: Test — XCTest suites (Core + Runtime + PersistenceSwiftData + UI + UIModelManagement + MCP + Backends + TestSupport + AppIntents + Server)
         id: test-xctest-suites
         timeout-minutes: 12
         env:
           BASECHAT_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-xctest-suites.log
-        run: scripts/test.sh --filter BaseChatCoreTests --filter BaseChatRuntimeTests --filter BaseChatPersistenceSwiftDataTests --filter BaseChatUITests --filter BaseChatUIModelManagementTests --filter BaseChatMCPTests --filter BaseChatBackendsTests --filter BaseChatTestSupportTests --filter BaseChatAppIntentsTests --disable-default-traits --skip-update
+        run: scripts/test.sh --filter BaseChatCoreTests --filter BaseChatRuntimeTests --filter BaseChatPersistenceSwiftDataTests --filter BaseChatUITests --filter BaseChatUIModelManagementTests --filter BaseChatMCPTests --filter BaseChatBackendsTests --filter BaseChatTestSupportTests --filter BaseChatAppIntentsTests --filter BaseChatServerTests --disable-default-traits --skip-update
 
       # BaseChatInferenceTests isolates its UserDefaults-backed migration tests
       # with per-instance suite names, and HuggingFaceServiceTests scopes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ swift test --filter BaseChatMCPTests --disable-default-traits
 swift test --filter BaseChatBackendsTests --disable-default-traits
 swift test --filter BaseChatTestSupportTests --disable-default-traits
 swift test --filter BaseChatAppIntentsTests --disable-default-traits
+swift test --filter BaseChatServerTests --disable-default-traits
 
 # Apple Silicon only — MLX mock tests + llama.cpp
 swift test --filter BaseChatBackendsTests --traits MLX,Llama
@@ -140,6 +141,7 @@ scripts/test.sh --filter BaseChatCoreTests --filter BaseChatRuntimeTests \
   --filter BaseChatUIModelManagementTests --filter BaseChatMCPTests \
   --filter BaseChatBackendsTests --filter BaseChatInferenceTests \
   --filter BaseChatTestSupportTests --filter BaseChatAppIntentsTests \
+  --filter BaseChatServerTests \
   --disable-default-traits --skip-update
 
 # 2. Swift Testing — must run in a separate process (XCTest+Swift Testing
@@ -165,6 +167,7 @@ swift build --build-tests --disable-default-traits
    --filter BaseChatUIModelManagementTests --filter BaseChatMCPTests \
    --filter BaseChatBackendsTests --filter BaseChatInferenceTests \
    --filter BaseChatTestSupportTests --filter BaseChatAppIntentsTests \
+   --filter BaseChatServerTests \
    --disable-default-traits --skip-update) &
 XCTEST_PID=$!
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,40 +1,40 @@
 {
-  "originHash" : "b940eb6617f8fccaa9a4a6991cbac2d57f336a2885caf265bcdca6c001f7011a",
+  "originHash" : "486b9d1594363ae2a83975984db2cc4a72723d7cf4ef69ea843fcfc4e2536e2f",
   "pins" : [
     {
-      "identity" : "eventsource",
+      "identity" : "async-http-client",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattt/EventSource.git",
+      "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
-        "version" : "1.4.1"
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
       }
     },
     {
-      "identity" : "llama.swift",
+      "identity" : "hummingbird",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattt/llama.swift",
+      "location" : "https://github.com/hummingbird-project/hummingbird.git",
       "state" : {
-        "revision" : "532a35184730472b771ca54c21a83ab9f249fcdd",
-        "version" : "2.8989.0"
+        "revision" : "a2ed0a0294de56e18ba55344eafc801a7a385a90",
+        "version" : "2.22.0"
       }
     },
     {
-      "identity" : "mlx-swift",
+      "identity" : "swift-algorithms",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift.git",
+      "location" : "https://github.com/apple/swift-algorithms.git",
       "state" : {
-        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
-        "version" : "0.31.3"
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
       }
     },
     {
-      "identity" : "mlx-swift-lm",
+      "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "1c05248bb0899e2a7a4962b84d319cf12f4e12aa",
-        "version" : "3.31.3"
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
       }
     },
     {
@@ -47,6 +47,15 @@
       }
     },
     {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "9d349bcc328ac3c31ce40e746b5882742a0d1272",
+        "version" : "1.1.3"
+      }
+    },
+    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
@@ -56,12 +65,30 @@
       }
     },
     {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "bde8ca32a096825dfce37467137c903418c1893d",
+        "version" : "1.19.1"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
       }
     },
     {
@@ -83,21 +110,48 @@
       }
     },
     {
-      "identity" : "swift-huggingface",
+      "identity" : "swift-distributed-tracing",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-huggingface.git",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
       "state" : {
-        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
-        "version" : "0.9.0"
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
       }
     },
     {
-      "identity" : "swift-jinja",
+      "identity" : "swift-http-structured-headers",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
       "state" : {
-        "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
-        "version" : "2.3.5"
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
+      }
+    },
+    {
+      "identity" : "swift-metrics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-metrics.git",
+      "state" : {
+        "revision" : "d51c8d13fa366eec807eedb4e37daa60ff5bfdd5",
+        "version" : "2.10.1"
       }
     },
     {
@@ -110,12 +164,66 @@
       }
     },
     {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "5a48717e29f62cb8326d6d42e46b562ca93847a6",
+        "version" : "1.34.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "81cc18264f92cd307ff98430f89372711d4f6fe9",
+        "version" : "1.43.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+        "version" : "2.37.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
       "identity" : "swift-numerics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-numerics",
       "state" : {
         "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
         "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
       }
     },
     {
@@ -146,15 +254,6 @@
       }
     },
     {
-      "identity" : "swift-transformers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-transformers",
-      "state" : {
-        "revision" : "b38443e44d93eca770f2eb68e2a4d0fa100f9aa2",
-        "version" : "1.3.0"
-      }
-    },
-    {
       "identity" : "viewinspector",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nalexn/ViewInspector",
@@ -170,15 +269,6 @@
       "state" : {
         "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
         "version" : "1.9.0"
-      }
-    },
-    {
-      "identity" : "yyjson",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ibireme/yyjson.git",
-      "state" : {
-        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
-        "version" : "0.12.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "486b9d1594363ae2a83975984db2cc4a72723d7cf4ef69ea843fcfc4e2536e2f",
+  "originHash" : "f7868b87f41797950571c24bf99b4d3a7cdcd1197f4ac8ec7812a23e142a05ea",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -11,12 +11,48 @@
       }
     },
     {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/EventSource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
+      }
+    },
+    {
       "identity" : "hummingbird",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hummingbird-project/hummingbird.git",
       "state" : {
         "revision" : "a2ed0a0294de56e18ba55344eafc801a7a385a90",
         "version" : "2.22.0"
+      }
+    },
+    {
+      "identity" : "llama.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/llama.swift",
+      "state" : {
+        "revision" : "aa6f27ad1cf71bb262c21b81019809729e1b5998",
+        "version" : "2.8999.0"
+      }
+    },
+    {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift.git",
+      "state" : {
+        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
+        "version" : "0.31.3"
+      }
+    },
+    {
+      "identity" : "mlx-swift-lm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
+      "state" : {
+        "revision" : "1c05248bb0899e2a7a4962b84d319cf12f4e12aa",
+        "version" : "3.31.3"
       }
     },
     {
@@ -137,6 +173,24 @@
       }
     },
     {
+      "identity" : "swift-huggingface",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-huggingface.git",
+      "state" : {
+        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
+        "version" : "2.3.5"
+      }
+    },
+    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
@@ -254,6 +308,15 @@
       }
     },
     {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers",
+      "state" : {
+        "revision" : "b38443e44d93eca770f2eb68e2a4d0fa100f9aa2",
+        "version" : "1.3.0"
+      }
+    },
+    {
       "identity" : "viewinspector",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nalexn/ViewInspector",
@@ -269,6 +332,15 @@
       "state" : {
         "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
         "version" : "1.9.0"
+      }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,8 @@ let package = Package(
         .library(name: "BaseChatTools", targets: ["BaseChatTools"]),
         .executable(name: "bck-tools", targets: ["bck-tools"]),
         .library(name: "BaseChatAppIntents", targets: ["BaseChatAppIntents"]),
+        .library(name: "BaseChatServerCore", targets: ["BaseChatServerCore"]),
+        .executable(name: "BaseChatServer", targets: ["BaseChatServer"]),
     ],
     traits: [
         .default(enabledTraits: ["MLX", "Llama", "HuggingFace"]),
@@ -68,6 +70,8 @@ let package = Package(
         // ABI-compatible macro APIs for Swift 5.10 / 6.0 and builds fine on
         // Swift 6.1+. Do not bump beyond what the installed toolchain supports.
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0"..<"601.0.0"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
     ],
     targets: [
         // Macro compiler plugin: implements @ToolSchema. Runs at build time in
@@ -394,6 +398,57 @@ let package = Package(
             path: "Tests/BaseChatAnyLanguageModelBridgeTests",
             swiftSettings: [
                 .define("AnyLanguageModel", .when(traits: ["AnyLanguageModel"])),
+            ]
+        ),
+        .target(
+            name: "BaseChatServerCore",
+            dependencies: [
+                "BaseChatInference",
+                .product(name: "Hummingbird", package: "hummingbird"),
+            ],
+            path: "Sources/BaseChatServerCore"
+        ),
+        .target(
+            name: "BaseChatServerBackends",
+            dependencies: [
+                "BaseChatServerCore",
+                "BaseChatInference",
+                "BaseChatBackends",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ],
+            path: "Sources/BaseChatServerBackends",
+            swiftSettings: [
+                .define("MLX", .when(traits: ["MLX"])),
+                .define("Llama", .when(traits: ["Llama"])),
+                .define("Ollama", .when(traits: ["Ollama"])),
+                .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
+                .define("HuggingFace", .when(traits: ["HuggingFace"])),
+            ]
+        ),
+        .executableTarget(
+            name: "BaseChatServer",
+            dependencies: [
+                "BaseChatServerCore",
+                "BaseChatServerBackends",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ],
+            path: "Sources/BaseChatServer",
+            swiftSettings: [
+                .define("MLX", .when(traits: ["MLX"])),
+                .define("Llama", .when(traits: ["Llama"])),
+                .define("Ollama", .when(traits: ["Ollama"])),
+                .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
+                .define("HuggingFace", .when(traits: ["HuggingFace"])),
+            ]
+        ),
+        .testTarget(
+            name: "BaseChatServerTests",
+            dependencies: [
+                "BaseChatServerCore",
+                "BaseChatServerBackends",
+                "BaseChatInference",
+                "BaseChatTestSupport",
+                .product(name: "HummingbirdTesting", package: "hummingbird"),
             ]
         ),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ BaseChatUI  ──────>  BaseChatPersistenceSwiftData  ─────�
 - **BaseChatHuggingFace** *(trait: `HuggingFace`, default-on)* — HuggingFace Hub search plus background download / validation services.
 - **BaseChatAnyLanguageModelBridge** *(trait: `AnyLanguageModel`, default-off)* — Thin `InferenceBackend` adapter over HuggingFace's `AnyLanguageModel`.
 - **BaseChatVoice** — Optional speech-recognition / synthesis adapters and voice composer UI. Depends on `BaseChatUI` so hosts can opt in without adding a back-edge into the base chat surface.
+- **BaseChatServer** — OpenAI-compatible HTTP server executable for exposing a selected `BaseChatInference` backend over `/v1/chat/completions`.
 
 ## Quick Start
 
@@ -195,7 +196,22 @@ swift test --filter BaseChatMCPTests --disable-default-traits
 swift test --filter BaseChatMCPTests --disable-default-traits --traits MCPBuiltinCatalog
 ```
 
-### 2.2 Optional voice
+### 2.2 BaseChatServer
+
+`BaseChatServer` runs an OpenAI-compatible local HTTP surface backed by BaseChatKit inference. Build it without default traits for the CI-safe/core server surface:
+
+```bash
+swift build --product BaseChatServer --disable-default-traits --traits Ollama
+swift run --disable-default-traits --traits Ollama BaseChatServer -- \
+  --backend ollama --model llama3.2 --host 127.0.0.1 --port 8080 \
+  --api-key local-dev --cors-origin http://localhost:3000 --metrics
+```
+
+Point OpenAI-compatible clients at `http://127.0.0.1:8080/v1` and send `Authorization: Bearer local-dev`. The server exposes `GET /health`, `GET /v1/models`, `POST /v1/chat/completions`, streaming SSE when `stream: true`, and `GET /metrics` when `--metrics` is enabled. CORS is disabled by default; use `--cors-origin <origin>` for a single trusted browser origin or `--unsafe-cors` only for local development.
+
+Backend availability follows SwiftPM traits: MLX requires `--traits MLX` plus `--model-path` or `--model`, llama.cpp requires `--traits Llama` plus a GGUF `--model-path`, Ollama requires `--traits Ollama`, and Apple Foundation Models require macOS/iOS 26 at runtime. Cloud SaaS loading is intentionally not implemented in the v1 server.
+
+### 2.3 Optional voice
 
 `BaseChatVoice` is an opt-in module for speech input/output. It plugs into
 `ChatView` through the `composerAccessory:` seam, so `BaseChatUI` stays free of

--- a/Sources/BaseChatServer/main.swift
+++ b/Sources/BaseChatServer/main.swift
@@ -1,0 +1,24 @@
+import ArgumentParser
+import BaseChatServerBackends
+import BaseChatServerCore
+
+@main
+struct BaseChatServerCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "basechat-server",
+        abstract: "Run an OpenAI-compatible BaseChatKit inference server."
+    )
+
+    @OptionGroup
+    var options: ServerCommandOptions
+
+    mutating func run() async throws {
+        try options.validate()
+        let selection = options.backendSelection()
+        try selection.validate()
+        let serverConfiguration = options.serverConfiguration()
+        let provider = TraitAwareServerBackendProvider(selection: selection)
+        let app = ServerApp(configuration: serverConfiguration, backendProvider: provider)
+        try await app.run()
+    }
+}

--- a/Sources/BaseChatServerBackends/ServerCommandOptions.swift
+++ b/Sources/BaseChatServerBackends/ServerCommandOptions.swift
@@ -62,6 +62,15 @@ package struct ServerCommandOptions: ParsableArguments, Sendable {
         if unsafeCORS, corsOrigin != nil {
             throw ValidationError("--unsafe-cors cannot be combined with --cors-origin")
         }
+        if let origin = corsOrigin {
+            guard let url = URL(string: origin),
+                  let scheme = url.scheme, !scheme.isEmpty,
+                  let host = url.host, !host.isEmpty,
+                  !origin.contains("\r"), !origin.contains("\n") else {
+                throw ValidationError("--cors-origin must be a valid URL with scheme and host (e.g. https://example.com)")
+            }
+            _ = host // suppress unused warning
+        }
     }
 
     package func serverConfiguration() -> ServerConfiguration {
@@ -81,8 +90,7 @@ package struct ServerCommandOptions: ParsableArguments, Sendable {
             backend: backend,
             model: model,
             modelPath: modelPath,
-            ollamaBaseURL: ollamaBaseURL,
-            apiKey: apiKey
+            ollamaBaseURL: ollamaBaseURL
         )
     }
 }

--- a/Sources/BaseChatServerBackends/ServerCommandOptions.swift
+++ b/Sources/BaseChatServerBackends/ServerCommandOptions.swift
@@ -1,0 +1,88 @@
+import ArgumentParser
+import BaseChatServerCore
+import Foundation
+
+package struct ServerCommandOptions: ParsableArguments, Sendable {
+    @Option(help: "Host interface to bind.")
+    package var host = "127.0.0.1"
+
+    @Option(help: "Port to bind.")
+    package var port = 8080
+
+    @Option(help: "API key required by the server for incoming requests.")
+    package var apiKey: String?
+
+    @Option(help: "Maximum number of concurrent generation requests.")
+    package var parallel = 1
+
+    @Option(help: "Backend to load: mlx, llama, foundation, ollama, or cloud.")
+    package var backend: ServerBackendKind = .foundation
+
+    @Option(help: "Model name or identifier for the selected backend.")
+    package var model: String?
+
+    @Option(help: "Path to a local model file or directory.")
+    package var modelPath: String?
+
+    @Option(help: "Ollama server base URL.")
+    package var ollamaBaseURL = "http://localhost:11434"
+
+    @Flag(help: "Allow any CORS origin. Intended only for trusted local development.")
+    package var unsafeCORS = false
+
+    @Option(help: "Allowed CORS origin. Repeat server startup with --unsafe-cors only for development.")
+    package var corsOrigin: String?
+
+    @Flag(help: "Enable server metrics endpoints when HTTP routing is available.")
+    package var metrics = false
+
+    package init() {}
+
+    package static func == (lhs: ServerCommandOptions, rhs: ServerCommandOptions) -> Bool {
+        lhs.host == rhs.host
+            && lhs.port == rhs.port
+            && lhs.apiKey == rhs.apiKey
+            && lhs.parallel == rhs.parallel
+            && lhs.backend == rhs.backend
+            && lhs.model == rhs.model
+            && lhs.modelPath == rhs.modelPath
+            && lhs.ollamaBaseURL == rhs.ollamaBaseURL
+            && lhs.unsafeCORS == rhs.unsafeCORS
+            && lhs.corsOrigin == rhs.corsOrigin
+            && lhs.metrics == rhs.metrics
+    }
+
+    package func validate() throws {
+        guard (1...65_535).contains(port) else {
+            throw ValidationError("--port must be between 1 and 65535")
+        }
+        guard parallel > 0 else {
+            throw ValidationError("--parallel must be greater than zero")
+        }
+        if unsafeCORS, corsOrigin != nil {
+            throw ValidationError("--unsafe-cors cannot be combined with --cors-origin")
+        }
+    }
+
+    package func serverConfiguration() -> ServerConfiguration {
+        ServerConfiguration(
+            host: host,
+            port: port,
+            apiKey: apiKey,
+            parallelSlots: parallel,
+            unsafeCORS: unsafeCORS,
+            corsOrigin: corsOrigin,
+            metricsEnabled: metrics
+        )
+    }
+
+    package func backendSelection() -> ServerBackendSelection {
+        ServerBackendSelection(
+            backend: backend,
+            model: model,
+            modelPath: modelPath,
+            ollamaBaseURL: ollamaBaseURL,
+            apiKey: apiKey
+        )
+    }
+}

--- a/Sources/BaseChatServerBackends/TraitAwareServerBackendProvider.swift
+++ b/Sources/BaseChatServerBackends/TraitAwareServerBackendProvider.swift
@@ -17,20 +17,17 @@ package struct ServerBackendSelection: Equatable, Sendable {
     package var model: String?
     package var modelPath: String?
     package var ollamaBaseURL: String
-    package var apiKey: String?
 
     package init(
         backend: ServerBackendKind,
         model: String? = nil,
         modelPath: String? = nil,
-        ollamaBaseURL: String = APIProvider.ollama.defaultBaseURL,
-        apiKey: String? = nil
+        ollamaBaseURL: String = APIProvider.ollama.defaultBaseURL
     ) {
         self.backend = backend
         self.model = model
         self.modelPath = modelPath
         self.ollamaBaseURL = ollamaBaseURL
-        self.apiKey = apiKey
     }
 
     package func validate(compiledBackends: CompiledBackends = DefaultBackends.compiledBackends) throws {
@@ -72,9 +69,10 @@ package struct ServerBackendSelection: Equatable, Sendable {
     }
 }
 
-package struct TraitAwareServerBackendProvider: ServerBackendProvider {
-    package var selection: ServerBackendSelection
-    package var compiledBackends: CompiledBackends
+package actor TraitAwareServerBackendProvider: ServerBackendProvider {
+    package let selection: ServerBackendSelection
+    package let compiledBackends: CompiledBackends
+    private var cachedBackend: (any InferenceBackend)?
 
     package init(
         selection: ServerBackendSelection,
@@ -94,20 +92,27 @@ package struct TraitAwareServerBackendProvider: ServerBackendProvider {
     }
 
     package func backend(for request: ServerBackendRequest) async throws -> any InferenceBackend {
+        if let cached = cachedBackend {
+            return cached
+        }
+
         try selection.validate(compiledBackends: compiledBackends)
 
+        let backend: any InferenceBackend
         switch selection.backend {
         case .mlx:
-            return try await loadMLXBackend(modelOverride: request.model)
+            backend = try await loadMLXBackend(modelOverride: request.model)
         case .llama:
-            return try await loadLlamaBackend()
+            backend = try await loadLlamaBackend()
         case .foundation:
-            return try await loadFoundationBackend()
+            backend = try await loadFoundationBackend()
         case .ollama:
-            return try await loadOllamaBackend(modelOverride: request.model)
+            backend = try await loadOllamaBackend(modelOverride: request.model)
         case .cloud:
             throw ServerError.notImplemented("Cloud SaaS backend loading is not implemented for BaseChatServer v1; configure a local or self-hosted backend instead.")
         }
+        cachedBackend = backend
+        return backend
     }
 
     private func loadMLXBackend(modelOverride: String?) async throws -> any InferenceBackend {

--- a/Sources/BaseChatServerBackends/TraitAwareServerBackendProvider.swift
+++ b/Sources/BaseChatServerBackends/TraitAwareServerBackendProvider.swift
@@ -1,0 +1,181 @@
+import ArgumentParser
+import BaseChatBackends
+import BaseChatInference
+import BaseChatServerCore
+import Foundation
+
+package enum ServerBackendKind: String, CaseIterable, ExpressibleByArgument, Equatable, Sendable {
+    case mlx
+    case llama
+    case foundation
+    case ollama
+    case cloud
+}
+
+package struct ServerBackendSelection: Equatable, Sendable {
+    package var backend: ServerBackendKind
+    package var model: String?
+    package var modelPath: String?
+    package var ollamaBaseURL: String
+    package var apiKey: String?
+
+    package init(
+        backend: ServerBackendKind,
+        model: String? = nil,
+        modelPath: String? = nil,
+        ollamaBaseURL: String = APIProvider.ollama.defaultBaseURL,
+        apiKey: String? = nil
+    ) {
+        self.backend = backend
+        self.model = model
+        self.modelPath = modelPath
+        self.ollamaBaseURL = ollamaBaseURL
+        self.apiKey = apiKey
+    }
+
+    package func validate(compiledBackends: CompiledBackends = DefaultBackends.compiledBackends) throws {
+        switch backend {
+        case .mlx:
+            try requireLocal(.mlx, compiledBackends: compiledBackends)
+            guard modelPath != nil || model != nil else {
+                throw ServerError.invalidConfiguration("MLX backend requires --model-path for a local snapshot or --model for a model identifier.")
+            }
+        case .llama:
+            try requireLocal(.gguf, compiledBackends: compiledBackends)
+            guard modelPath != nil else {
+                throw ServerError.invalidConfiguration("Llama backend requires --model-path pointing to a .gguf file.")
+            }
+        case .foundation:
+            try requireLocal(.foundation, compiledBackends: compiledBackends)
+        case .ollama:
+            try requireProvider(.ollama, compiledBackends: compiledBackends)
+            guard URL(string: ollamaBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)) != nil else {
+                throw ServerError.invalidConfiguration("--ollama-base-url must be a valid URL.")
+            }
+        case .cloud:
+            throw ServerError.notImplemented("Cloud SaaS backend loading is not implemented for BaseChatServer v1; use mlx, llama, foundation, or ollama.")
+        }
+    }
+
+    private func requireLocal(_ modelType: ModelType, compiledBackends: CompiledBackends) throws {
+        let compatibility = compiledBackends.compatibility(for: modelType)
+        guard compatibility.isSupported else {
+            throw ServerError.backendUnavailable(compatibility.unavailableReason ?? "Backend is not available in this build.")
+        }
+    }
+
+    private func requireProvider(_ provider: APIProvider, compiledBackends: CompiledBackends) throws {
+        let compatibility = compiledBackends.compatibility(for: provider)
+        guard compatibility.isSupported else {
+            throw ServerError.backendUnavailable(compatibility.unavailableReason ?? "Backend is not available in this build.")
+        }
+    }
+}
+
+package struct TraitAwareServerBackendProvider: ServerBackendProvider {
+    package var selection: ServerBackendSelection
+    package var compiledBackends: CompiledBackends
+
+    package init(
+        selection: ServerBackendSelection,
+        compiledBackends: CompiledBackends = DefaultBackends.compiledBackends
+    ) {
+        self.selection = selection
+        self.compiledBackends = compiledBackends
+    }
+
+    package func listModels() async throws -> [String] {
+        switch selection.backend {
+        case .foundation:
+            return [ModelInfo.builtInFoundation.name]
+        case .ollama, .cloud, .mlx, .llama:
+            return [selection.model, selection.modelPath].compactMap { $0 }
+        }
+    }
+
+    package func backend(for request: ServerBackendRequest) async throws -> any InferenceBackend {
+        try selection.validate(compiledBackends: compiledBackends)
+
+        switch selection.backend {
+        case .mlx:
+            return try await loadMLXBackend(modelOverride: request.model)
+        case .llama:
+            return try await loadLlamaBackend()
+        case .foundation:
+            return try await loadFoundationBackend()
+        case .ollama:
+            return try await loadOllamaBackend(modelOverride: request.model)
+        case .cloud:
+            throw ServerError.notImplemented("Cloud SaaS backend loading is not implemented for BaseChatServer v1; configure a local or self-hosted backend instead.")
+        }
+    }
+
+    private func loadMLXBackend(modelOverride: String?) async throws -> any InferenceBackend {
+        #if MLX
+        let rawPath = selection.modelPath ?? modelOverride ?? selection.model
+        guard let rawPath else {
+            throw ServerError.invalidConfiguration("MLX backend requires --model-path for a local snapshot or --model for a model identifier.")
+        }
+        let url = URL(fileURLWithPath: rawPath).standardizedFileURL
+        guard let modelInfo = ModelInfo(mlxDirectory: url) else {
+            throw ServerError.invalidConfiguration("MLX model path must be a directory containing config.json and .safetensors files: \(url.path)")
+        }
+        let backend = MLXBackend()
+        let plan = ModelLoadPlan.compute(for: modelInfo, requestedContextSize: 4096, strategy: backend.capabilities.memoryStrategy)
+        guard plan.verdict != .deny else {
+            throw ServerError.invalidConfiguration("MLX model does not fit available memory at the requested context size.")
+        }
+        try await backend.loadModel(from: modelInfo.url, plan: plan)
+        return backend
+        #else
+        throw ServerError.backendUnavailable("MLX models require the MLX trait in this build.")
+        #endif
+    }
+
+    private func loadLlamaBackend() async throws -> any InferenceBackend {
+        #if Llama
+        guard let rawPath = selection.modelPath else {
+            throw ServerError.invalidConfiguration("Llama backend requires --model-path pointing to a .gguf file.")
+        }
+        let url = URL(fileURLWithPath: rawPath).standardizedFileURL
+        guard let modelInfo = ModelInfo(ggufURL: url) else {
+            throw ServerError.invalidConfiguration("Llama model path must point to a valid .gguf file: \(url.path)")
+        }
+        let backend = LlamaBackend()
+        let plan = ModelLoadPlan.compute(for: modelInfo, requestedContextSize: 4096, strategy: backend.capabilities.memoryStrategy)
+        guard plan.verdict != .deny else {
+            throw ServerError.invalidConfiguration("GGUF model does not fit available memory at the requested context size.")
+        }
+        try await backend.loadModel(from: modelInfo.url, plan: plan)
+        return backend
+        #else
+        throw ServerError.backendUnavailable("GGUF models require the Llama trait in this build.")
+        #endif
+    }
+
+    private func loadFoundationBackend() async throws -> any InferenceBackend {
+        #if canImport(FoundationModels)
+        if #available(iOS 26, macOS 26, *) {
+            let backend = FoundationBackend()
+            try await backend.loadModel(from: ModelInfo.builtInFoundation.url, plan: .cloud())
+            return backend
+        }
+        #endif
+        throw ServerError.backendUnavailable("Apple Foundation Models require iOS 26 / macOS 26 or later.")
+    }
+
+    private func loadOllamaBackend(modelOverride: String?) async throws -> any InferenceBackend {
+        #if Ollama
+        let modelName = modelOverride ?? selection.model ?? APIProvider.ollama.defaultModelName
+        guard let baseURL = URL(string: selection.ollamaBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            throw ServerError.invalidConfiguration("--ollama-base-url must be a valid URL.")
+        }
+        let backend = OllamaBackend()
+        backend.configure(baseURL: baseURL, modelName: modelName)
+        try await backend.loadModel(from: baseURL, plan: .cloud(requestedContextSize: 8192))
+        return backend
+        #else
+        throw ServerError.backendUnavailable("Ollama endpoints require the Ollama trait in this build.")
+        #endif
+    }
+}

--- a/Sources/BaseChatServerCore/AsyncSemaphore.swift
+++ b/Sources/BaseChatServerCore/AsyncSemaphore.swift
@@ -3,7 +3,7 @@ import Foundation
 package actor AsyncSemaphore {
     private let limit: Int
     private var available: Int
-    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var waiters: [CheckedContinuation<Void, Error>] = []
 
     package init(value: Int) {
         let sanitized = max(1, value)
@@ -11,14 +11,18 @@ package actor AsyncSemaphore {
         self.available = sanitized
     }
 
-    package func wait() async {
+    package func wait() async throws {
         if available > 0 {
             available -= 1
             return
         }
 
-        await withCheckedContinuation { continuation in
-            waiters.append(continuation)
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                waiters.append(continuation)
+            }
+        } onCancel: {
+            Task { await self.cancelFirstWaiter() }
         }
     }
 
@@ -28,5 +32,10 @@ package actor AsyncSemaphore {
         } else {
             waiters.removeFirst().resume()
         }
+    }
+
+    private func cancelFirstWaiter() {
+        guard !waiters.isEmpty else { return }
+        waiters.removeFirst().resume(throwing: CancellationError())
     }
 }

--- a/Sources/BaseChatServerCore/AsyncSemaphore.swift
+++ b/Sources/BaseChatServerCore/AsyncSemaphore.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+package actor AsyncSemaphore {
+    private let limit: Int
+    private var available: Int
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    package init(value: Int) {
+        let sanitized = max(1, value)
+        self.limit = sanitized
+        self.available = sanitized
+    }
+
+    package func wait() async {
+        if available > 0 {
+            available -= 1
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    package func signal() {
+        if waiters.isEmpty {
+            available = min(limit, available + 1)
+        } else {
+            waiters.removeFirst().resume()
+        }
+    }
+}

--- a/Sources/BaseChatServerCore/ChatCompletionsAdapter.swift
+++ b/Sources/BaseChatServerCore/ChatCompletionsAdapter.swift
@@ -1,0 +1,747 @@
+import BaseChatInference
+import Foundation
+
+package enum ChatCompletionRole: String, Codable, Equatable, Sendable {
+    case system
+    case developer
+    case user
+    case assistant
+    case tool
+}
+
+package struct ChatCompletionMessage: Codable, Equatable, Sendable {
+    package var role: ChatCompletionRole
+    package var content: String?
+    package var reasoningContent: String?
+    package var name: String?
+    package var toolCallID: String?
+    package var toolCalls: [ChatCompletionMessageToolCall]?
+
+    package init(
+        role: ChatCompletionRole,
+        content: String? = nil,
+        reasoningContent: String? = nil,
+        name: String? = nil,
+        toolCallID: String? = nil,
+        toolCalls: [ChatCompletionMessageToolCall]? = nil
+    ) {
+        self.role = role
+        self.content = content
+        self.reasoningContent = reasoningContent
+        self.name = name
+        self.toolCallID = toolCallID
+        self.toolCalls = toolCalls
+    }
+
+    package init(role: String, content: String) {
+        self.init(role: ChatCompletionRole(rawValue: role) ?? .user, content: content)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case role, content, name
+        case reasoningContent = "reasoning_content"
+        case toolCallID = "tool_call_id"
+        case toolCalls = "tool_calls"
+    }
+}
+
+package struct ChatCompletionRequest: Codable, Equatable, Sendable {
+    package var model: String
+    package var messages: [ChatCompletionMessage]
+    package var stream: Bool?
+    package var streamOptions: ChatCompletionStreamOptions?
+    package var temperature: Double?
+    package var topP: Double?
+    package var maxTokens: Int?
+    package var maxCompletionTokens: Int?
+    package var responseFormat: ChatCompletionResponseFormat?
+    package var tools: [ChatCompletionTool]?
+    package var toolChoice: ChatCompletionToolChoice?
+
+    package init(
+        model: String,
+        messages: [ChatCompletionMessage],
+        stream: Bool = false,
+        streamOptions: ChatCompletionStreamOptions? = nil,
+        temperature: Double? = nil,
+        topP: Double? = nil,
+        maxTokens: Int? = nil,
+        maxCompletionTokens: Int? = nil,
+        responseFormat: ChatCompletionResponseFormat? = nil,
+        tools: [ChatCompletionTool]? = nil,
+        toolChoice: ChatCompletionToolChoice? = nil
+    ) {
+        self.model = model
+        self.messages = messages
+        self.stream = stream
+        self.streamOptions = streamOptions
+        self.temperature = temperature
+        self.topP = topP
+        self.maxTokens = maxTokens
+        self.maxCompletionTokens = maxCompletionTokens
+        self.responseFormat = responseFormat
+        self.tools = tools
+        self.toolChoice = toolChoice
+    }
+
+    package var includesStreamUsage: Bool { streamOptions?.includeUsage == true }
+
+    private enum CodingKeys: String, CodingKey {
+        case model, messages, stream, temperature, tools
+        case streamOptions = "stream_options"
+        case topP = "top_p"
+        case maxTokens = "max_tokens"
+        case maxCompletionTokens = "max_completion_tokens"
+        case responseFormat = "response_format"
+        case toolChoice = "tool_choice"
+    }
+}
+
+package struct ChatCompletionStreamOptions: Codable, Equatable, Sendable {
+    package var includeUsage: Bool?
+
+    package init(includeUsage: Bool? = nil) {
+        self.includeUsage = includeUsage
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case includeUsage = "include_usage"
+    }
+}
+
+package struct ChatCompletionResponseFormat: Codable, Equatable, Sendable {
+    package enum FormatType: String, Codable, Equatable, Sendable {
+        case text
+        case jsonObject = "json_object"
+        case jsonSchema = "json_schema"
+    }
+
+    package struct JSONSchema: Codable, Equatable, Sendable {
+        package var name: String
+        package var description: String?
+        package var schema: JSONSchemaValue?
+        package var strict: Bool?
+
+        package init(name: String, description: String? = nil, schema: JSONSchemaValue? = nil, strict: Bool? = nil) {
+            self.name = name
+            self.description = description
+            self.schema = schema
+            self.strict = strict
+        }
+    }
+
+    package var type: FormatType
+    package var jsonSchema: JSONSchema?
+
+    package init(type: FormatType, jsonSchema: JSONSchema? = nil) {
+        self.type = type
+        self.jsonSchema = jsonSchema
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case jsonSchema = "json_schema"
+    }
+}
+
+package struct ChatCompletionTool: Codable, Equatable, Sendable {
+    package var type: String
+    package var function: ChatCompletionFunctionDefinition
+
+    package init(type: String = "function", function: ChatCompletionFunctionDefinition) {
+        self.type = type
+        self.function = function
+    }
+
+    package func toolDefinition() -> ToolDefinition? {
+        guard type == "function" else { return nil }
+        return ToolDefinition(
+            name: function.name,
+            description: function.description ?? "",
+            parameters: function.parameters ?? .object([:])
+        )
+    }
+}
+
+package struct ChatCompletionFunctionDefinition: Codable, Equatable, Sendable {
+    package var name: String
+    package var description: String?
+    package var parameters: JSONSchemaValue?
+    package var strict: Bool?
+
+    package init(name: String, description: String? = nil, parameters: JSONSchemaValue? = nil, strict: Bool? = nil) {
+        self.name = name
+        self.description = description
+        self.parameters = parameters
+        self.strict = strict
+    }
+}
+
+package enum ChatCompletionToolChoice: Codable, Equatable, Sendable {
+    case auto
+    case none
+    case required
+    case function(name: String)
+
+    package init(from decoder: Decoder) throws {
+        if let string = try? decoder.singleValueContainer().decode(String.self) {
+            switch string {
+            case "auto": self = .auto
+            case "none": self = .none
+            case "required": self = .required
+            default:
+                throw DecodingError.dataCorrupted(
+                    DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Unknown tool_choice '\(string)'")
+                )
+            }
+            return
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        guard type == "function" else {
+            throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Only function tool_choice objects are supported")
+        }
+        let function = try container.decode(FunctionChoice.self, forKey: .function)
+        self = .function(name: function.name)
+    }
+
+    package func encode(to encoder: Encoder) throws {
+        switch self {
+        case .auto:
+            var container = encoder.singleValueContainer()
+            try container.encode("auto")
+        case .none:
+            var container = encoder.singleValueContainer()
+            try container.encode("none")
+        case .required:
+            var container = encoder.singleValueContainer()
+            try container.encode("required")
+        case .function(let name):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("function", forKey: .type)
+            try container.encode(FunctionChoice(name: name), forKey: .function)
+        }
+    }
+
+    package func generationToolChoice() -> BaseChatInference.ToolChoice {
+        switch self {
+        case .auto: .auto
+        case .none: .none
+        case .required: .required
+        case .function(let name): .tool(name: name)
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey { case type, function }
+    private struct FunctionChoice: Codable, Equatable, Sendable { var name: String }
+}
+
+package struct ChatCompletionMessageToolCall: Codable, Equatable, Sendable {
+    package var id: String
+    package var type: String
+    package var function: ChatCompletionFunctionCall
+
+    package init(id: String, type: String = "function", function: ChatCompletionFunctionCall) {
+        self.id = id
+        self.type = type
+        self.function = function
+    }
+}
+
+package struct ChatCompletionFunctionCall: Codable, Equatable, Sendable {
+    package var name: String?
+    package var arguments: String?
+
+    package init(name: String? = nil, arguments: String? = nil) {
+        self.name = name
+        self.arguments = arguments
+    }
+}
+
+package struct ChatCompletionResponse: Codable, Equatable, Sendable {
+    package var id: String
+    package var object: String
+    package var created: Int
+    package var model: String
+    package var choices: [ChatCompletionChoice]
+    package var usage: ChatCompletionUsage?
+
+    package init(
+        id: String = "chatcmpl-placeholder",
+        object: String = "chat.completion",
+        created: Int = 0,
+        model: String,
+        choices: [ChatCompletionChoice] = [],
+        usage: ChatCompletionUsage? = nil
+    ) {
+        self.id = id
+        self.object = object
+        self.created = created
+        self.model = model
+        self.choices = choices
+        self.usage = usage
+    }
+
+    package init(id: String = "chatcmpl-placeholder", model: String, content: String = "") {
+        self.init(
+            id: id,
+            model: model,
+            choices: [ChatCompletionChoice(index: 0, message: ChatCompletionMessage(role: .assistant, content: content), finishReason: .stop)]
+        )
+    }
+
+    package var content: String {
+        choices.compactMap(\.message.content).joined()
+    }
+}
+
+package extension ChatCompletionResponse {
+    var contentText: String {
+        choices.first?.message.content ?? ""
+    }
+}
+
+package struct ChatCompletionChoice: Codable, Equatable, Sendable {
+    package var index: Int
+    package var message: ChatCompletionMessage
+    package var finishReason: ChatCompletionFinishReason?
+
+    package init(index: Int, message: ChatCompletionMessage, finishReason: ChatCompletionFinishReason? = nil) {
+        self.index = index
+        self.message = message
+        self.finishReason = finishReason
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case index, message
+        case finishReason = "finish_reason"
+    }
+}
+
+package struct ChatCompletionChunk: Codable, Equatable, Sendable {
+    package var id: String
+    package var object: String
+    package var created: Int
+    package var model: String
+    package var choices: [ChatCompletionChunkChoice]
+    package var usage: ChatCompletionUsage?
+
+    package init(
+        id: String,
+        object: String = "chat.completion.chunk",
+        created: Int,
+        model: String,
+        choices: [ChatCompletionChunkChoice],
+        usage: ChatCompletionUsage? = nil
+    ) {
+        self.id = id
+        self.object = object
+        self.created = created
+        self.model = model
+        self.choices = choices
+        self.usage = usage
+    }
+}
+
+package struct ChatCompletionChunkChoice: Codable, Equatable, Sendable {
+    package var index: Int
+    package var delta: ChatCompletionDelta
+    package var finishReason: ChatCompletionFinishReason?
+
+    package init(index: Int, delta: ChatCompletionDelta, finishReason: ChatCompletionFinishReason? = nil) {
+        self.index = index
+        self.delta = delta
+        self.finishReason = finishReason
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case index, delta
+        case finishReason = "finish_reason"
+    }
+}
+
+package struct ChatCompletionDelta: Codable, Equatable, Sendable {
+    package var role: ChatCompletionRole?
+    package var content: String?
+    package var reasoningContent: String?
+    package var toolCalls: [ChatCompletionDeltaToolCall]?
+
+    package init(
+        role: ChatCompletionRole? = nil,
+        content: String? = nil,
+        reasoningContent: String? = nil,
+        toolCalls: [ChatCompletionDeltaToolCall]? = nil
+    ) {
+        self.role = role
+        self.content = content
+        self.reasoningContent = reasoningContent
+        self.toolCalls = toolCalls
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case role, content
+        case reasoningContent = "reasoning_content"
+        case toolCalls = "tool_calls"
+    }
+}
+
+package struct ChatCompletionDeltaToolCall: Codable, Equatable, Sendable {
+    package var index: Int
+    package var id: String?
+    package var type: String?
+    package var function: ChatCompletionFunctionCall?
+
+    package init(index: Int, id: String? = nil, type: String? = nil, function: ChatCompletionFunctionCall? = nil) {
+        self.index = index
+        self.id = id
+        self.type = type
+        self.function = function
+    }
+}
+
+package enum ChatCompletionFinishReason: String, Codable, Equatable, Sendable {
+    case stop
+    case length
+    case toolCalls = "tool_calls"
+    case contentFilter = "content_filter"
+    case error
+}
+
+package struct ChatCompletionUsage: Codable, Equatable, Sendable {
+    package var promptTokens: Int
+    package var completionTokens: Int
+    package var totalTokens: Int
+
+    package init(promptTokens: Int, completionTokens: Int, totalTokens: Int? = nil) {
+        self.promptTokens = promptTokens
+        self.completionTokens = completionTokens
+        self.totalTokens = totalTokens ?? promptTokens + completionTokens
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case promptTokens = "prompt_tokens"
+        case completionTokens = "completion_tokens"
+        case totalTokens = "total_tokens"
+    }
+}
+
+package struct ChatCompletionErrorEnvelope: Codable, Equatable, Sendable {
+    package var error: ChatCompletionError
+
+    package init(error: ChatCompletionError) {
+        self.error = error
+    }
+
+    package init(message: String, type: String = "server_error", param: String? = nil, code: String? = nil) {
+        self.error = ChatCompletionError(message: message, type: type, param: param, code: code)
+    }
+
+    package static func from(_ error: Error) -> ChatCompletionErrorEnvelope {
+        if let serverError = error as? ServerError {
+            return ChatCompletionErrorEnvelope(message: serverError.description, type: "server_error")
+        }
+        return ChatCompletionErrorEnvelope(message: String(describing: error), type: "server_error")
+    }
+}
+
+package struct ChatCompletionError: Codable, Equatable, Sendable {
+    package var message: String
+    package var type: String
+    package var param: String?
+    package var code: String?
+
+    package init(message: String, type: String, param: String? = nil, code: String? = nil) {
+        self.message = message
+        self.type = type
+        self.param = param
+        self.code = code
+    }
+}
+
+package protocol ChatCompletionsAdapter: Sendable {
+    func generationConfig(for request: ChatCompletionRequest) throws -> GenerationConfig
+
+    func response(
+        for request: ChatCompletionRequest,
+        using backend: any InferenceBackend
+    ) async throws -> ChatCompletionResponse
+
+    func chunks(
+        for request: ChatCompletionRequest,
+        using backend: any InferenceBackend
+    ) throws -> AsyncThrowingStream<ChatCompletionChunk, Error>
+}
+
+extension ChatCompletionsAdapter {
+    package func generationConfig(for request: ChatCompletionRequest) throws -> GenerationConfig {
+        try DefaultChatCompletionsAdapter().generationConfig(for: request)
+    }
+
+    package func chunks(
+        for request: ChatCompletionRequest,
+        using backend: any InferenceBackend
+    ) throws -> AsyncThrowingStream<ChatCompletionChunk, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    let response = try await self.response(for: request, using: backend)
+                    let chunk = ChatCompletionChunk(
+                        id: response.id,
+                        created: response.created,
+                        model: response.model,
+                        choices: [ChatCompletionChunkChoice(index: 0, delta: ChatCompletionDelta(content: response.contentText), finishReason: .stop)],
+                        usage: response.usage
+                    )
+                    continuation.yield(chunk)
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { @Sendable _ in task.cancel() }
+        }
+    }
+}
+
+package struct DefaultChatCompletionsAdapter: ChatCompletionsAdapter {
+    package init() {}
+
+    package func generationConfig(for request: ChatCompletionRequest) throws -> GenerationConfig {
+        let tools = request.tools?.compactMap { $0.toolDefinition() } ?? []
+        let toolChoice = request.toolChoice?.generationToolChoice() ?? .auto
+        return GenerationConfig(
+            temperature: Float(request.temperature ?? 0.7),
+            topP: Float(request.topP ?? 0.9),
+            maxOutputTokens: request.maxCompletionTokens ?? request.maxTokens,
+            tools: tools,
+            toolChoice: toolChoice,
+            jsonMode: request.responseFormat?.type == .jsonObject || request.responseFormat?.type == .jsonSchema
+        )
+    }
+
+    package func response(
+        for request: ChatCompletionRequest,
+        using backend: any InferenceBackend
+    ) async throws -> ChatCompletionResponse {
+        let (prompt, systemPrompt) = promptParts(for: request)
+        let stream = try backend.generate(prompt: prompt, systemPrompt: systemPrompt, config: generationConfig(for: request))
+        let mapper = ChatCompletionEventMapper(id: completionID(), created: currentTimestamp(), model: request.model)
+        return try await mapper.response(from: stream.events)
+    }
+
+    package func chunks(
+        for request: ChatCompletionRequest,
+        using backend: any InferenceBackend
+    ) throws -> AsyncThrowingStream<ChatCompletionChunk, Error> {
+        let (prompt, systemPrompt) = promptParts(for: request)
+        let stream = try backend.generate(prompt: prompt, systemPrompt: systemPrompt, config: generationConfig(for: request))
+        let mapper = ChatCompletionEventMapper(id: completionID(), created: currentTimestamp(), model: request.model)
+        return mapper.chunks(from: stream.events, includeUsage: request.includesStreamUsage)
+    }
+
+    private func promptParts(for request: ChatCompletionRequest) -> (prompt: String, systemPrompt: String?) {
+        let systemPrompt = request.messages
+            .filter { $0.role == .system || $0.role == .developer }
+            .compactMap(\.content)
+            .joined(separator: "\n")
+        let prompt = request.messages
+            .filter { $0.role != .system && $0.role != .developer }
+            .map { message in
+                let content = message.content ?? ""
+                if message.role == .tool, let callID = message.toolCallID {
+                    return "tool(\(callID)): \(content)"
+                }
+                return "\(message.role.rawValue): \(content)"
+            }
+            .joined(separator: "\n")
+        return (prompt, systemPrompt.isEmpty ? nil : systemPrompt)
+    }
+
+    private func completionID() -> String { "chatcmpl-\(UUID().uuidString)" }
+    private func currentTimestamp() -> Int { Int(Date().timeIntervalSince1970) }
+}
+
+package struct ChatCompletionEventMapper: Sendable {
+    package var id: String
+    package var created: Int
+    package var model: String
+
+    package init(id: String, created: Int, model: String) {
+        self.id = id
+        self.created = created
+        self.model = model
+    }
+
+    package func response<S: AsyncSequence & Sendable>(from events: S) async throws -> ChatCompletionResponse where S.Element == GenerationEvent {
+        var state = Accumulator()
+        for try await event in events {
+            state.apply(event)
+        }
+        let message = ChatCompletionMessage(
+            role: .assistant,
+            content: state.content.isEmpty ? nil : state.content,
+            reasoningContent: state.reasoningContent.isEmpty ? nil : state.reasoningContent,
+            toolCalls: state.toolCalls.isEmpty ? nil : state.toolCalls
+        )
+        return ChatCompletionResponse(
+            id: id,
+            created: created,
+            model: model,
+            choices: [ChatCompletionChoice(index: 0, message: message, finishReason: state.finishReason)],
+            usage: state.usage
+        )
+    }
+
+    package func chunks<S: AsyncSequence & Sendable>(
+        from events: S,
+        includeUsage: Bool
+    ) -> AsyncThrowingStream<ChatCompletionChunk, Error> where S.Element == GenerationEvent {
+        AsyncThrowingStream { continuation in
+            let id = self.id
+            let created = self.created
+            let model = self.model
+            let task = Task {
+                var state = Accumulator()
+                continuation.yield(Self.chunk(id: id, created: created, model: model, delta: ChatCompletionDelta(role: .assistant)))
+                do {
+                    for try await event in events {
+                        switch event {
+                        case .token(let text):
+                            state.apply(event)
+                            continuation.yield(Self.chunk(id: id, created: created, model: model, delta: ChatCompletionDelta(content: text)))
+                        case .thinkingToken(let text):
+                            state.apply(event)
+                            continuation.yield(Self.chunk(id: id, created: created, model: model, delta: ChatCompletionDelta(reasoningContent: text)))
+                        case .toolCallStart(let callID, let name):
+                            let index = state.index(for: callID)
+                            state.apply(event)
+                            let toolCall = ChatCompletionDeltaToolCall(
+                                index: index,
+                                id: callID,
+                                type: "function",
+                                function: ChatCompletionFunctionCall(name: name)
+                            )
+                            continuation.yield(Self.chunk(id: id, created: created, model: model, delta: ChatCompletionDelta(toolCalls: [toolCall])))
+                        case .toolCallArgumentsDelta(let callID, let textDelta):
+                            let index = state.index(for: callID)
+                            state.apply(event)
+                            let toolCall = ChatCompletionDeltaToolCall(
+                                index: index,
+                                function: ChatCompletionFunctionCall(arguments: textDelta)
+                            )
+                            continuation.yield(Self.chunk(id: id, created: created, model: model, delta: ChatCompletionDelta(toolCalls: [toolCall])))
+                        case .toolCall(let call):
+                            let index = state.index(for: call.id)
+                            state.apply(event)
+                            let toolCall = ChatCompletionDeltaToolCall(
+                                index: index,
+                                id: call.id,
+                                type: "function",
+                                function: ChatCompletionFunctionCall(name: call.toolName, arguments: call.arguments)
+                            )
+                            continuation.yield(Self.chunk(id: id, created: created, model: model, delta: ChatCompletionDelta(toolCalls: [toolCall])))
+                        case .usage:
+                            state.apply(event)
+                        default:
+                            state.apply(event)
+                        }
+                    }
+                    continuation.yield(Self.chunk(
+                        id: id,
+                        created: created,
+                        model: model,
+                        delta: ChatCompletionDelta(),
+                        finishReason: state.finishReason
+                    ))
+                    if includeUsage, let usage = state.usage {
+                        continuation.yield(ChatCompletionChunk(
+                            id: id,
+                            created: created,
+                            model: model,
+                            choices: [],
+                            usage: usage
+                        ))
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { @Sendable _ in task.cancel() }
+        }
+    }
+
+    private static func chunk(
+        id: String,
+        created: Int,
+        model: String,
+        delta: ChatCompletionDelta,
+        finishReason: ChatCompletionFinishReason? = nil
+    ) -> ChatCompletionChunk {
+        ChatCompletionChunk(
+            id: id,
+            created: created,
+            model: model,
+            choices: [ChatCompletionChunkChoice(index: 0, delta: delta, finishReason: finishReason)]
+        )
+    }
+
+    private struct Accumulator: Sendable {
+        var content = ""
+        var reasoningContent = ""
+        var usage: ChatCompletionUsage?
+        var sawToolCall = false
+        var toolIndexes: [String: Int] = [:]
+        var toolCallNames: [String: String] = [:]
+        var toolCallArguments: [String: String] = [:]
+
+        var toolCalls: [ChatCompletionMessageToolCall] {
+            toolIndexes.sorted { $0.value < $1.value }.map { callID, _ in
+                ChatCompletionMessageToolCall(
+                    id: callID,
+                    function: ChatCompletionFunctionCall(
+                        name: toolCallNames[callID],
+                        arguments: toolCallArguments[callID] ?? ""
+                    )
+                )
+            }
+        }
+
+        var finishReason: ChatCompletionFinishReason { sawToolCall ? .toolCalls : .stop }
+
+        mutating func index(for callID: String) -> Int {
+            if let index = toolIndexes[callID] { return index }
+            let index = toolIndexes.count
+            toolIndexes[callID] = index
+            return index
+        }
+
+        mutating func apply(_ event: GenerationEvent) {
+            switch event {
+            case .token(let text):
+                content += text
+            case .thinkingToken(let text):
+                reasoningContent += text
+            case .usage(let prompt, let completion):
+                usage = ChatCompletionUsage(promptTokens: prompt, completionTokens: completion)
+            case .toolCallStart(let callID, let name):
+                _ = index(for: callID)
+                sawToolCall = true
+                toolCallNames[callID] = name
+                toolCallArguments[callID, default: ""] += ""
+            case .toolCallArgumentsDelta(let callID, let textDelta):
+                _ = index(for: callID)
+                sawToolCall = true
+                toolCallArguments[callID, default: ""] += textDelta
+            case .toolCall(let call):
+                _ = index(for: call.id)
+                sawToolCall = true
+                toolCallNames[call.id] = call.toolName
+                toolCallArguments[call.id] = call.arguments
+            default:
+                break
+            }
+        }
+    }
+}

--- a/Sources/BaseChatServerCore/ServerApp.swift
+++ b/Sources/BaseChatServerCore/ServerApp.swift
@@ -170,7 +170,10 @@ package struct ServerApp: Sendable {
                 try await generationGate.wait()
             } catch is CancellationError {
                 return
-            } catch {}
+            } catch {
+                // AsyncSemaphore.wait() only throws CancellationError; any other error is unexpected — abort the stream.
+                return
+            }
             metrics.recordGenerationStarted()
             var streamedTokenCount = 0
             do {

--- a/Sources/BaseChatServerCore/ServerApp.swift
+++ b/Sources/BaseChatServerCore/ServerApp.swift
@@ -12,11 +12,11 @@ package struct ServerHealth: Codable, Equatable, Sendable {
 }
 
 package struct ServerApp: Sendable {
-    package var configuration: ServerConfiguration
-    package var backendProvider: any ServerBackendProvider
-    package var adapter: any ChatCompletionsAdapter
-    package var metrics: ServerMetrics
-    package var generationGate: AsyncSemaphore
+    package let configuration: ServerConfiguration
+    package let backendProvider: any ServerBackendProvider
+    package let adapter: any ChatCompletionsAdapter
+    package let metrics: ServerMetrics
+    package let generationGate: AsyncSemaphore
 
     package init(
         configuration: ServerConfiguration = ServerConfiguration(),
@@ -53,7 +53,8 @@ package struct ServerApp: Sendable {
             } catch {
                 metrics.recordFailure()
                 metrics.recordRequestCompleted()
-                return errorResponse(String(describing: error), status: .internalServerError)
+                let envelope = ChatCompletionErrorEnvelope.from(error)
+                return errorResponse(envelope.error.message, status: .internalServerError)
             }
         }
 
@@ -70,13 +71,17 @@ package struct ServerApp: Sendable {
             } catch {
                 metrics.recordFailure()
                 metrics.recordRequestCompleted()
-                return errorResponse(String(describing: error), status: .internalServerError)
+                let envelope = ChatCompletionErrorEnvelope.from(error)
+                return errorResponse(envelope.error.message, status: .internalServerError)
             }
         }
 
         if configuration.metricsEnabled {
-            router.get("/metrics") { _, _ in
-                metricsResponse()
+            router.get("/metrics") { request, _ in
+                if let unauthorized = authorizationFailure(for: request) {
+                    return unauthorized
+                }
+                return metricsResponse()
             }
         }
 
@@ -110,7 +115,8 @@ package struct ServerApp: Sendable {
     private func authorizationFailure(for request: Request) -> Response? {
         guard let apiKey = configuration.apiKey, !apiKey.isEmpty else { return nil }
         let expected = "Bearer \(apiKey)"
-        guard request.headers[.authorization] == expected else {
+        let provided = request.headers[.authorization] ?? ""
+        guard constantTimeEqual(provided, expected) else {
             return errorResponse(
                 "Missing or invalid bearer token.",
                 status: .unauthorized,
@@ -121,12 +127,23 @@ package struct ServerApp: Sendable {
         return nil
     }
 
+    private func constantTimeEqual(_ a: String, _ b: String) -> Bool {
+        let aBytes = Array(a.utf8)
+        let bBytes = Array(b.utf8)
+        guard aBytes.count == bBytes.count else { return false }
+        return zip(aBytes, bBytes).reduce(0 as UInt8) { $0 | ($1.0 ^ $1.1) } == 0
+    }
+
     private func chatCompletionResponse(for request: ChatCompletionRequest) async throws -> Response {
         if request.stream == true {
             return try await streamingChatCompletionResponse(for: request)
         }
 
-        await generationGate.wait()
+        do {
+            try await generationGate.wait()
+        } catch is CancellationError {
+            return errorResponse("Request was cancelled.", status: .serviceUnavailable)
+        }
         metrics.recordGenerationStarted()
         do {
             let backend = try await backendProvider.backend(for: ServerBackendRequest(model: request.model))
@@ -149,7 +166,11 @@ package struct ServerApp: Sendable {
         headers[HTTPField.Name("X-Accel-Buffering")!] = "no"
 
         let body = ResponseBody { writer in
-            await generationGate.wait()
+            do {
+                try await generationGate.wait()
+            } catch is CancellationError {
+                return
+            } catch {}
             metrics.recordGenerationStarted()
             var streamedTokenCount = 0
             do {

--- a/Sources/BaseChatServerCore/ServerApp.swift
+++ b/Sources/BaseChatServerCore/ServerApp.swift
@@ -1,0 +1,207 @@
+import BaseChatInference
+import Foundation
+import Hummingbird
+import HTTPTypes
+
+package struct ServerHealth: Codable, Equatable, Sendable {
+    package var status: String
+
+    package init(status: String = "ok") {
+        self.status = status
+    }
+}
+
+package struct ServerApp: Sendable {
+    package var configuration: ServerConfiguration
+    package var backendProvider: any ServerBackendProvider
+    package var adapter: any ChatCompletionsAdapter
+    package var metrics: ServerMetrics
+    package var generationGate: AsyncSemaphore
+
+    package init(
+        configuration: ServerConfiguration = ServerConfiguration(),
+        backendProvider: any ServerBackendProvider = UnavailableServerBackendProvider(),
+        adapter: any ChatCompletionsAdapter = DefaultChatCompletionsAdapter(),
+        metrics: ServerMetrics = ServerMetrics()
+    ) {
+        self.configuration = configuration
+        self.backendProvider = backendProvider
+        self.adapter = adapter
+        self.metrics = metrics
+        self.generationGate = AsyncSemaphore(value: configuration.parallelSlots)
+    }
+
+    package func health() -> ServerHealth { ServerHealth() }
+
+    package func makeApplication() -> some ApplicationProtocol {
+        let router = Router()
+        router.add(middleware: corsMiddleware())
+
+        router.get("/health") { _, _ in
+            jsonResponse(health())
+        }
+
+        router.get("/v1/models") { request, _ in
+            if let unauthorized = authorizationFailure(for: request) {
+                return unauthorized
+            }
+            metrics.recordRequestStarted()
+            do {
+                let models = try await backendProvider.listModels()
+                metrics.recordRequestCompleted()
+                return jsonResponse(ModelsListResponse(models: models))
+            } catch {
+                metrics.recordFailure()
+                metrics.recordRequestCompleted()
+                return errorResponse(String(describing: error), status: .internalServerError)
+            }
+        }
+
+        router.post("/v1/chat/completions") { request, context in
+            if let unauthorized = authorizationFailure(for: request) {
+                return unauthorized
+            }
+            metrics.recordRequestStarted()
+            do {
+                let completionRequest = try await request.decode(as: ChatCompletionRequest.self, context: context)
+                let response = try await chatCompletionResponse(for: completionRequest)
+                metrics.recordRequestCompleted()
+                return response
+            } catch {
+                metrics.recordFailure()
+                metrics.recordRequestCompleted()
+                return errorResponse(String(describing: error), status: .internalServerError)
+            }
+        }
+
+        if configuration.metricsEnabled {
+            router.get("/metrics") { _, _ in
+                metricsResponse()
+            }
+        }
+
+        let appConfiguration = ApplicationConfiguration(
+            address: .hostname(configuration.host, port: configuration.port),
+            serverName: "BaseChatServer"
+        )
+        return Application(router: router, configuration: appConfiguration)
+    }
+
+    package func run() async throws {
+        try await makeApplication().runService()
+    }
+
+    private func corsMiddleware() -> CORSMiddleware<BasicRequestContext> {
+        let allowOrigin: CORSMiddleware<BasicRequestContext>.AllowOrigin
+        if configuration.unsafeCORS {
+            allowOrigin = .all
+        } else if let corsOrigin = configuration.corsOrigin {
+            allowOrigin = .custom(corsOrigin)
+        } else {
+            allowOrigin = .none
+        }
+        return CORSMiddleware(
+            allowOrigin: allowOrigin,
+            allowHeaders: [.authorization, .contentType, .accept, .origin],
+            allowMethods: [.get, .post, .options]
+        )
+    }
+
+    private func authorizationFailure(for request: Request) -> Response? {
+        guard let apiKey = configuration.apiKey, !apiKey.isEmpty else { return nil }
+        let expected = "Bearer \(apiKey)"
+        guard request.headers[.authorization] == expected else {
+            return errorResponse(
+                "Missing or invalid bearer token.",
+                status: .unauthorized,
+                type: "invalid_request_error",
+                code: "invalid_api_key"
+            )
+        }
+        return nil
+    }
+
+    private func chatCompletionResponse(for request: ChatCompletionRequest) async throws -> Response {
+        if request.stream == true {
+            return try await streamingChatCompletionResponse(for: request)
+        }
+
+        await generationGate.wait()
+        metrics.recordGenerationStarted()
+        do {
+            let backend = try await backendProvider.backend(for: ServerBackendRequest(model: request.model))
+            let response = try await adapter.response(for: request, using: backend)
+            await generationGate.signal()
+            metrics.recordGenerationCompleted(tokenCount: tokenCount(in: response.contentText))
+            return jsonResponse(response)
+        } catch {
+            await generationGate.signal()
+            metrics.recordGenerationFailed()
+            throw error
+        }
+    }
+
+    private func streamingChatCompletionResponse(for request: ChatCompletionRequest) async throws -> Response {
+        var headers = HTTPFields()
+        headers[.contentType] = "text/event-stream"
+        headers[.cacheControl] = "no-cache"
+        headers[.connection] = "keep-alive"
+        headers[HTTPField.Name("X-Accel-Buffering")!] = "no"
+
+        let body = ResponseBody { writer in
+            await generationGate.wait()
+            metrics.recordGenerationStarted()
+            var streamedTokenCount = 0
+            do {
+                let backend = try await backendProvider.backend(for: ServerBackendRequest(model: request.model))
+                let chunks = try adapter.chunks(for: request, using: backend)
+                let encoder = JSONEncoder()
+                for try await chunk in chunks {
+                    streamedTokenCount += tokenCount(in: chunk)
+                    let data = try encoder.encode(chunk)
+                    let line = String(decoding: data, as: UTF8.self)
+                    try await writer.write(ByteBuffer(string: "data: \(line)\n\n"))
+                }
+                try await writer.write(ByteBuffer(string: "data: [DONE]\n\n"))
+                metrics.recordGenerationCompleted(tokenCount: streamedTokenCount)
+                await generationGate.signal()
+            } catch {
+                metrics.recordGenerationFailed()
+                await generationGate.signal()
+                throw error
+            }
+        }
+
+        return Response(status: .ok, headers: headers, body: body)
+    }
+
+    private func metricsResponse() -> Response {
+        let snapshot = metrics.snapshot()
+        let body = """
+        # TYPE basechat_requests_total counter
+        basechat_requests_total \(snapshot.requests)
+        # TYPE basechat_generations_in_flight gauge
+        basechat_generations_in_flight \(snapshot.inFlightGenerations)
+        # TYPE basechat_completions_total counter
+        basechat_completions_total \(snapshot.completions)
+        # TYPE basechat_failures_total counter
+        basechat_failures_total \(snapshot.failures)
+        # TYPE basechat_tokens_total counter
+        basechat_tokens_total \(snapshot.tokens)
+
+        """
+        var headers = HTTPFields()
+        headers[.contentType] = "text/plain; version=0.0.4; charset=utf-8"
+        return Response(status: .ok, headers: headers, body: .init(byteBuffer: ByteBuffer(string: body)))
+    }
+
+    private func tokenCount(in content: String) -> Int {
+        content.split(whereSeparator: \.isWhitespace).count
+    }
+
+    private func tokenCount(in chunk: ChatCompletionChunk) -> Int {
+        chunk.choices.reduce(0) { count, choice in
+            count + tokenCount(in: choice.delta.content ?? "")
+        }
+    }
+}

--- a/Sources/BaseChatServerCore/ServerBackendProvider.swift
+++ b/Sources/BaseChatServerCore/ServerBackendProvider.swift
@@ -1,0 +1,25 @@
+import BaseChatInference
+import Foundation
+
+package struct ServerBackendRequest: Equatable, Sendable {
+    package var model: String?
+
+    package init(model: String? = nil) {
+        self.model = model
+    }
+}
+
+package protocol ServerBackendProvider: Sendable {
+    func listModels() async throws -> [String]
+    func backend(for request: ServerBackendRequest) async throws -> any InferenceBackend
+}
+
+package struct UnavailableServerBackendProvider: ServerBackendProvider {
+    package init() {}
+
+    package func listModels() async throws -> [String] { [] }
+
+    package func backend(for request: ServerBackendRequest) async throws -> any InferenceBackend {
+        throw ServerError.backendUnavailable("No server backend has been configured yet.")
+    }
+}

--- a/Sources/BaseChatServerCore/ServerConfiguration.swift
+++ b/Sources/BaseChatServerCore/ServerConfiguration.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+package struct ServerConfiguration: Equatable, Sendable {
+    package var host: String
+    package var port: Int
+    package var apiKey: String?
+    package var parallelSlots: Int
+    package var unsafeCORS: Bool
+    package var corsOrigin: String?
+    package var metricsEnabled: Bool
+
+    package init(
+        host: String = "127.0.0.1",
+        port: Int = 8080,
+        apiKey: String? = nil,
+        parallelSlots: Int = 1,
+        unsafeCORS: Bool = false,
+        corsOrigin: String? = nil,
+        metricsEnabled: Bool = false
+    ) {
+        self.host = host
+        self.port = port
+        self.apiKey = apiKey
+        self.parallelSlots = parallelSlots
+        self.unsafeCORS = unsafeCORS
+        self.corsOrigin = corsOrigin
+        self.metricsEnabled = metricsEnabled
+    }
+}

--- a/Sources/BaseChatServerCore/ServerError.swift
+++ b/Sources/BaseChatServerCore/ServerError.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+package enum ServerError: Error, Equatable, Sendable, CustomStringConvertible {
+    case backendUnavailable(String)
+    case invalidConfiguration(String)
+    case notImplemented(String)
+
+    package var description: String {
+        switch self {
+        case .backendUnavailable(let message),
+             .invalidConfiguration(let message),
+             .notImplemented(let message):
+            message
+        }
+    }
+}

--- a/Sources/BaseChatServerCore/ServerHTTPResponses.swift
+++ b/Sources/BaseChatServerCore/ServerHTTPResponses.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Hummingbird
+
+package struct ModelsListResponse: Codable, Equatable, Sendable {
+    package struct Model: Codable, Equatable, Sendable {
+        package var id: String
+        package var object: String
+
+        package init(id: String, object: String = "model") {
+            self.id = id
+            self.object = object
+        }
+    }
+
+    package var object: String
+    package var data: [Model]
+
+    package init(models: [String]) {
+        self.object = "list"
+        self.data = models.map { Model(id: $0) }
+    }
+}
+
+package func jsonResponse(
+    _ value: some Encodable,
+    status: HTTPResponse.Status = .ok
+) -> Response {
+    do {
+        let data = try JSONEncoder().encode(value)
+        var headers = HTTPFields()
+        headers[.contentType] = "application/json; charset=utf-8"
+        return Response(status: status, headers: headers, body: .init(byteBuffer: ByteBuffer(bytes: data)))
+    } catch {
+        let body = #"{"error":{"message":"Failed to encode server response.","type":"server_error","param":null,"code":"encoding_failed"}}"#
+        var headers = HTTPFields()
+        headers[.contentType] = "application/json; charset=utf-8"
+        return Response(status: .internalServerError, headers: headers, body: .init(byteBuffer: ByteBuffer(string: body)))
+    }
+}
+
+package func errorResponse(
+    _ message: String,
+    status: HTTPResponse.Status,
+    type: String = "server_error",
+    code: String? = nil
+) -> Response {
+    jsonResponse(ChatCompletionErrorEnvelope(message: message, type: type, code: code), status: status)
+}

--- a/Sources/BaseChatServerCore/ServerMetrics.swift
+++ b/Sources/BaseChatServerCore/ServerMetrics.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+package struct ServerMetricsSnapshot: Equatable, Sendable {
+    package var requests: Int
+    package var inFlightGenerations: Int
+    package var completions: Int
+    package var failures: Int
+    package var tokens: Int
+
+    package init(
+        requests: Int = 0,
+        inFlightGenerations: Int = 0,
+        completions: Int = 0,
+        failures: Int = 0,
+        tokens: Int = 0
+    ) {
+        self.requests = requests
+        self.inFlightGenerations = inFlightGenerations
+        self.completions = completions
+        self.failures = failures
+        self.tokens = tokens
+    }
+}
+
+package struct ServerMetrics: Sendable {
+    private final class Storage: @unchecked Sendable {
+        private let lock = NSLock()
+        private var snapshot = ServerMetricsSnapshot()
+
+        func read() -> ServerMetricsSnapshot {
+            lock.withLock { snapshot }
+        }
+
+        func mutate(_ body: (inout ServerMetricsSnapshot) -> Void) {
+            lock.withLock {
+                body(&snapshot)
+            }
+        }
+    }
+
+    private let storage: Storage
+
+    package init() {
+        self.storage = Storage()
+    }
+
+    package func snapshot() -> ServerMetricsSnapshot {
+        storage.read()
+    }
+
+    package func recordRequestStarted() {
+        storage.mutate { $0.requests += 1 }
+    }
+
+    package func recordRequestCompleted() {}
+
+    package func recordGenerationStarted() {
+        storage.mutate { $0.inFlightGenerations += 1 }
+    }
+
+    package func recordGenerationCompleted(tokenCount: Int = 0) {
+        storage.mutate {
+            $0.inFlightGenerations = max(0, $0.inFlightGenerations - 1)
+            $0.completions += 1
+            $0.tokens += tokenCount
+        }
+    }
+
+    package func recordGenerationFailed() {
+        storage.mutate {
+            $0.inFlightGenerations = max(0, $0.inFlightGenerations - 1)
+            $0.failures += 1
+        }
+    }
+
+    package func recordFailure() {
+        storage.mutate { $0.failures += 1 }
+    }
+}

--- a/TESTING.md
+++ b/TESTING.md
@@ -73,6 +73,7 @@ UI automation tests that launch the real Example app in a simulator and drive it
 | `BaseChatUITests` | Integration | Yes | None | XCTest |
 | `BaseChatMCPTests` | Unit, Integration | Yes | None | XCTest |
 | `BaseChatMCPE2ETests` | E2E (subprocess smoke) | No (requires `RUN_MCP_E2E=1` and `npx`) | npx + network | XCTest |
+| `BaseChatServerTests` | Unit, Integration | Yes | None | XCTest |
 | `BaseChatBackendsTests` | Unit, E2E | Partial | MLX/Llama need Apple Silicon | Mixed |
 | `BaseChatTestSupportTests` | Unit | Yes | None | XCTest |
 | `BaseChatE2ETests` | E2E | Yes | None (mock backends) | Swift Testing |
@@ -88,6 +89,7 @@ swift test --filter BaseChatInferenceTests --disable-default-traits
 swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits
 swift test --filter BaseChatUITests --disable-default-traits
 swift test --filter BaseChatMCPTests --disable-default-traits
+swift test --filter BaseChatServerTests --disable-default-traits
 swift test --filter BaseChatBackendsTests --disable-default-traits   # cloud/SSE tests only
 swift test --filter BaseChatTestSupportTests --disable-default-traits
 

--- a/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
+++ b/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
@@ -374,3 +374,13 @@ BaseChatUIModelManagement/Views/Settings/RemoteServerConfigSheet.swift:try? Keyc
 # A nil `candidates` produces an empty array via `?? []`, so `mmprojURL`
 # stays nil — the backend safely operates in text-only mode.
 BaseChatInference/Models/ModelInfo.swift:let candidates = (try? FileManager.default.contentsOfDirectory(
+
+# ---------------------------------------------------------------------------
+# BaseChatServerCore
+# ---------------------------------------------------------------------------
+
+# ChatCompletionToolChoice uses the standard "try-each-type-in-order" decoder
+# pattern: first probes for the string forms ("auto", "none", "required"),
+# then falls through to decode the object form {"type":"function",...}.
+# The `try?` is bound to a named constant; the else-branch handles the miss.
+BaseChatServerCore/ChatCompletionsAdapter.swift:if let string = try? decoder.singleValueContainer().decode(String.self) {

--- a/Tests/BaseChatServerTests/AsyncSemaphoreTests.swift
+++ b/Tests/BaseChatServerTests/AsyncSemaphoreTests.swift
@@ -1,0 +1,98 @@
+@testable import BaseChatServerCore
+import XCTest
+
+final class AsyncSemaphoreTests: XCTestCase {
+    func testInitClampsZeroToOne() {
+        let semaphore = AsyncSemaphore(value: 0)
+        // A limit-0 semaphore would deadlock on the first wait; clamping to 1 is the safe default.
+        // Verify by waiting immediately — if clamped to 1 this returns without suspending.
+        let expectation = XCTestExpectation(description: "wait returns without suspending")
+        Task {
+            try? await semaphore.wait()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func testSingleWaiterUnblockedBySignal() async throws {
+        let semaphore = AsyncSemaphore(value: 1)
+        // Drain the initial slot.
+        try await semaphore.wait()
+
+        let unblocked = XCTestExpectation(description: "waiter unblocked after signal")
+        Task {
+            try await semaphore.wait()
+            unblocked.fulfill()
+        }
+        // Give the task a chance to suspend before we signal.
+        try await Task.sleep(for: .milliseconds(50))
+        await semaphore.signal()
+
+        await fulfillment(of: [unblocked], timeout: 2)
+        // SABOTAGE: remove the signal() call above to verify the waiter stays blocked
+    }
+
+    func testAvailableNeverExceedsLimit() async {
+        let semaphore = AsyncSemaphore(value: 1)
+        // Signal without a prior wait — available should stay capped at limit (1).
+        for _ in 0..<5 {
+            await semaphore.signal()
+        }
+        // Verify by waiting twice — the second should block (no second slot was created).
+        let waited = XCTestExpectation(description: "first wait acquires slot")
+        Task {
+            try? await semaphore.wait()
+            waited.fulfill()
+        }
+        await fulfillment(of: [waited], timeout: 1)
+
+        // A second wait should not return immediately; it would block indefinitely if available > 1.
+        // We verify the cap indirectly: if available were > 1, the expectation below would fulfil instantly.
+        let shouldNotFulfil = XCTestExpectation(description: "second wait should stay queued")
+        shouldNotFulfil.isInverted = true
+        let second = Task {
+            try? await semaphore.wait()
+            shouldNotFulfil.fulfill()
+        }
+        await fulfillment(of: [shouldNotFulfil], timeout: 0.15)
+        second.cancel()
+    }
+
+    func testConcurrentWaitersAreBoundedByLimit() async throws {
+        let limit = 1
+        let semaphore = AsyncSemaphore(value: limit)
+        let recorder = ConcurrencyCounter()
+
+        // Launch three concurrent tasks, each entering and holding the semaphore briefly.
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<3 {
+                group.addTask {
+                    try? await semaphore.wait()
+                    await recorder.enter()
+                    try? await Task.sleep(for: .milliseconds(50))
+                    await recorder.leave()
+                    await semaphore.signal()
+                }
+            }
+        }
+
+        let maxObserved = await recorder.maxObserved
+        XCTAssertLessThanOrEqual(maxObserved, limit, "At most \(limit) tasks should hold the semaphore simultaneously")
+        // SABOTAGE: change AsyncSemaphore(value: limit) to AsyncSemaphore(value: 3) to verify the bound is enforced
+    }
+}
+
+private actor ConcurrencyCounter {
+    private var current = 0
+    private var max = 0
+    var maxObserved: Int { max }
+
+    func enter() {
+        current += 1
+        if current > max { max = current }
+    }
+
+    func leave() {
+        current -= 1
+    }
+}

--- a/Tests/BaseChatServerTests/BaseChatServerCLITests.swift
+++ b/Tests/BaseChatServerTests/BaseChatServerCLITests.swift
@@ -1,0 +1,121 @@
+@testable import BaseChatServerCore
+@testable import BaseChatServerBackends
+import ArgumentParser
+import BaseChatInference
+import XCTest
+
+final class BaseChatServerCLITests: XCTestCase {
+    func testParsesServerOptionsAndBuildsConfiguration() throws {
+        let options = try ServerCommandOptions.parse([
+            "--host", "0.0.0.0",
+            "--port", "9090",
+            "--api-key", "test-key",
+            "--parallel", "4",
+            "--backend", "ollama",
+            "--model", "llama3.2",
+            "--ollama-base-url", "http://127.0.0.1:11434",
+            "--cors-origin", "https://example.test",
+            "--metrics",
+        ])
+
+        XCTAssertEqual(options.host, "0.0.0.0")
+        XCTAssertEqual(options.port, 9090)
+        XCTAssertEqual(options.apiKey, "test-key")
+        XCTAssertEqual(options.parallel, 4)
+        XCTAssertEqual(options.backend, .ollama)
+        XCTAssertEqual(options.model, "llama3.2")
+        XCTAssertEqual(options.ollamaBaseURL, "http://127.0.0.1:11434")
+        XCTAssertTrue(options.metrics)
+
+        let configuration = options.serverConfiguration()
+        XCTAssertEqual(configuration.host, "0.0.0.0")
+        XCTAssertEqual(configuration.port, 9090)
+        XCTAssertEqual(configuration.apiKey, "test-key")
+        XCTAssertEqual(configuration.parallelSlots, 4)
+        XCTAssertEqual(configuration.corsOrigin, "https://example.test")
+        XCTAssertTrue(configuration.metricsEnabled)
+    }
+
+    func testRejectsInvalidPort() {
+        XCTAssertThrowsError(try ServerCommandOptions.parse(["--port", "70000"])) { error in
+            XCTAssertTrue(String(describing: error).contains("--port must be between 1 and 65535"))
+        }
+    }
+
+    func testRejectsUnsafeCORSWithSpecificOrigin() {
+        XCTAssertThrowsError(try ServerCommandOptions.parse(["--unsafe-cors", "--cors-origin", "https://example.test"])) { error in
+            XCTAssertTrue(String(describing: error).contains("--unsafe-cors cannot be combined with --cors-origin"))
+        }
+    }
+}
+
+final class TraitAwareServerBackendProviderTests: XCTestCase {
+    private let emptyBuild = CompiledBackends(
+        buildProfile: .offline,
+        traits: [],
+        localModelTypes: [],
+        cloudProviders: []
+    )
+
+    func testUnavailableTraitReportsMachineTestableError() {
+        let selection = ServerBackendSelection(backend: .llama, modelPath: "model.gguf")
+
+        XCTAssertThrowsError(try selection.validate(compiledBackends: emptyBuild)) { error in
+            XCTAssertEqual(error as? ServerError, .backendUnavailable("GGUF models require the Llama trait in this build."))
+        }
+    }
+
+    func testLlamaRequiresModelPathWhenTraitIsAvailable() {
+        let llamaBuild = CompiledBackends(
+            buildProfile: .offline,
+            traits: [.llama],
+            localModelTypes: [.gguf],
+            cloudProviders: []
+        )
+        let selection = ServerBackendSelection(backend: .llama)
+
+        XCTAssertThrowsError(try selection.validate(compiledBackends: llamaBuild)) { error in
+            XCTAssertEqual(error as? ServerError, .invalidConfiguration("Llama backend requires --model-path pointing to a .gguf file."))
+        }
+    }
+
+    func testOllamaSelectionValidatesWithoutNetwork() throws {
+        let ollamaBuild = CompiledBackends(
+            buildProfile: .selfHosted,
+            traits: [.ollama],
+            localModelTypes: [],
+            cloudProviders: [.ollama]
+        )
+        let selection = ServerBackendSelection(
+            backend: .ollama,
+            model: "llama3.2",
+            ollamaBaseURL: "http://localhost:11434"
+        )
+
+        XCTAssertNoThrow(try selection.validate(compiledBackends: ollamaBuild))
+    }
+
+    func testCloudBackendReturnsNotImplementedWithoutNetwork() async {
+        let provider = TraitAwareServerBackendProvider(
+            selection: ServerBackendSelection(backend: .cloud),
+            compiledBackends: emptyBuild
+        )
+
+        do {
+            _ = try await provider.backend(for: ServerBackendRequest())
+            XCTFail("Expected cloud backend to be deferred for v1")
+        } catch {
+            XCTAssertEqual(error as? ServerError, .notImplemented("Cloud SaaS backend loading is not implemented for BaseChatServer v1; use mlx, llama, foundation, or ollama."))
+        }
+    }
+
+    func testListModelsUsesConfiguredIdentifiersOnly() async throws {
+        let provider = TraitAwareServerBackendProvider(
+            selection: ServerBackendSelection(backend: .mlx, model: "mlx-community/example", modelPath: "Models/example"),
+            compiledBackends: emptyBuild
+        )
+
+        let models = try await provider.listModels()
+        XCTAssertEqual(models, ["mlx-community/example", "Models/example"])
+    }
+}

--- a/Tests/BaseChatServerTests/BaseChatServerCLITests.swift
+++ b/Tests/BaseChatServerTests/BaseChatServerCLITests.swift
@@ -47,6 +47,19 @@ final class BaseChatServerCLITests: XCTestCase {
             XCTAssertTrue(String(describing: error).contains("--unsafe-cors cannot be combined with --cors-origin"))
         }
     }
+
+    func testRejectsZeroParallel() {
+        // ArgumentParser calls validate() internally during parse — the error surfaces there.
+        XCTAssertThrowsError(try ServerCommandOptions.parse(["--parallel", "0"])) { error in
+            XCTAssertTrue(String(describing: error).contains("--parallel must be greater than zero"))
+        }
+    }
+
+    func testRejectsInvalidCORSOrigin() {
+        XCTAssertThrowsError(try ServerCommandOptions.parse(["--cors-origin", "not-a-url"])) { error in
+            XCTAssertTrue(String(describing: error).contains("--cors-origin must be a valid URL"))
+        }
+    }
 }
 
 final class TraitAwareServerBackendProviderTests: XCTestCase {

--- a/Tests/BaseChatServerTests/BaseChatServerSmokeTests.swift
+++ b/Tests/BaseChatServerTests/BaseChatServerSmokeTests.swift
@@ -46,7 +46,7 @@ final class BaseChatServerSmokeTests: XCTestCase {
         }
     }
 
-    func testBearerAuthProtectsAPIButExemptsHealthAndMetrics() async throws {
+    func testBearerAuthProtectsAPIButExemptsHealthOnly() async throws {
         let server = ServerApp(
             configuration: ServerConfiguration(apiKey: "secret", metricsEnabled: true),
             backendProvider: FakeBackendProvider(models: ["tiny"]),
@@ -57,21 +57,48 @@ final class BaseChatServerSmokeTests: XCTestCase {
         try await app.test(.router) { client in
             try await client.execute(uri: "/health", method: .get) { response in
                 XCTAssertEqual(response.status, .ok)
+                // SABOTAGE: change 401 → 200 assertion below to verify auth is enforced
             }
 
+            // /metrics now requires auth (P0-3 fix)
             try await client.execute(uri: "/metrics", method: .get) { response in
-                XCTAssertEqual(response.status, .ok)
+                XCTAssertEqual(response.status, .unauthorized)
+                XCTAssertTrue(
+                    response.headers[.contentType]?.contains("application/json") == true,
+                    "Error responses must carry application/json content type"
+                )
             }
 
             try await client.execute(uri: "/v1/models", method: .get) { response in
                 XCTAssertEqual(response.status, .unauthorized)
                 XCTAssertTrue(String(buffer: response.body).contains("invalid_api_key"))
+                XCTAssertTrue(
+                    response.headers[.contentType]?.contains("application/json") == true,
+                    "Error responses must carry application/json content type"
+                )
             }
 
             var headers = HTTPFields()
             headers[.authorization] = "Bearer secret"
             try await client.execute(uri: "/v1/models", method: .get, headers: headers) { response in
                 XCTAssertEqual(response.status, .ok)
+            }
+
+            // Unauthenticated POST to /v1/chat/completions must be rejected
+            let chatBody = try requestBody(ChatCompletionRequest(model: "tiny", messages: [.init(role: "user", content: "hi")]))
+            try await client.execute(uri: "/v1/chat/completions", method: .post, body: chatBody) { response in
+                XCTAssertEqual(response.status, .unauthorized)
+                XCTAssertTrue(
+                    response.headers[.contentType]?.contains("application/json") == true,
+                    "Error responses must carry application/json content type"
+                )
+            }
+
+            // Wrong token must also be rejected
+            var wrongHeaders = HTTPFields()
+            wrongHeaders[.authorization] = "Bearer wrong"
+            try await client.execute(uri: "/v1/chat/completions", method: .post, headers: wrongHeaders, body: chatBody) { response in
+                XCTAssertEqual(response.status, .unauthorized)
             }
         }
     }
@@ -154,6 +181,28 @@ final class BaseChatServerSmokeTests: XCTestCase {
 
         let maxObserved = await recorder.maxObserved
         XCTAssertEqual(maxObserved, 1)
+        // SABOTAGE: bump semaphore limit to 10 to verify gate is active
+    }
+
+    func testSemaphoreLimitsConcurrentStreamingChatCompletions() async throws {
+        let recorder = ConcurrencyRecorder()
+        let server = ServerApp(
+            configuration: ServerConfiguration(parallelSlots: 1),
+            backendProvider: FakeBackendProvider(models: ["tiny"]),
+            adapter: DelayedStreamingChatAdapter(recorder: recorder)
+        )
+        let app = server.makeApplication()
+
+        try await app.test(.router) { client in
+            let firstBody = try requestBody(ChatCompletionRequest(model: "tiny", messages: [], stream: true))
+            let secondBody = try requestBody(ChatCompletionRequest(model: "tiny", messages: [], stream: true))
+            async let first: Void = client.execute(uri: "/v1/chat/completions", method: .post, body: firstBody) { _ in () }
+            async let second: Void = client.execute(uri: "/v1/chat/completions", method: .post, body: secondBody) { _ in () }
+            _ = try await (first, second)
+        }
+
+        let maxObserved = await recorder.maxObserved
+        XCTAssertEqual(maxObserved, 1)
     }
 
     func testSSEHeadersAndDoneFrame() async throws {
@@ -167,13 +216,89 @@ final class BaseChatServerSmokeTests: XCTestCase {
             let body = try requestBody(ChatCompletionRequest(model: "tiny", messages: [], stream: true))
             try await client.execute(uri: "/v1/chat/completions", method: .post, body: body) { response in
                 XCTAssertEqual(response.status, .ok)
+                // SABOTAGE: change Content-Type assertion to "text/plain" to verify SSE type is set
                 XCTAssertEqual(response.headers[.contentType], "text/event-stream")
                 XCTAssertEqual(response.headers[.cacheControl], "no-cache")
                 XCTAssertEqual(response.headers[.connection], "keep-alive")
                 XCTAssertEqual(response.headers[HTTPField.Name("X-Accel-Buffering")!], "no")
+
                 let text = String(buffer: response.body)
-                XCTAssertTrue(text.contains("stream"))
                 XCTAssertTrue(text.contains("data: [DONE]"))
+
+                // Decode each non-DONE SSE data line as ChatCompletionChunk
+                let decoder = JSONDecoder()
+                let events = text.components(separatedBy: "\n\n")
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { $0.hasPrefix("data: ") && $0 != "data: [DONE]" }
+                    .compactMap { line -> ChatCompletionChunk? in
+                        let payload = line.dropFirst("data: ".count)
+                        return try? decoder.decode(ChatCompletionChunk.self, from: Data(payload.utf8))
+                    }
+
+                XCTAssertFalse(events.isEmpty, "Expected at least one decodable SSE chunk")
+                let contentTokens = events.compactMap { $0.choices.first?.delta.content }.joined()
+                XCTAssertTrue(contentTokens.contains("stream"), "Expected chunk content to contain the test token")
+
+                // The final non-DONE chunk must carry a finish_reason
+                XCTAssertEqual(events.last?.choices.first?.finishReason, .stop)
+            }
+        }
+    }
+
+    func testBackendFailureReturns500WithErrorEnvelope() async throws {
+        let server = ServerApp(
+            backendProvider: FakeBackendProvider(models: ["tiny"]),
+            adapter: FailingChatAdapter()
+        )
+        let app = server.makeApplication()
+
+        try await app.test(.router) { client in
+            let body = try requestBody(ChatCompletionRequest(model: "tiny", messages: [.init(role: "user", content: "hi")]))
+            try await client.execute(uri: "/v1/chat/completions", method: .post, body: body) { response in
+                // SABOTAGE: change status assertion to .ok to verify this test catches regressions
+                XCTAssertEqual(response.status, .internalServerError)
+                XCTAssertTrue(
+                    response.headers[.contentType]?.contains("application/json") == true,
+                    "Error responses must be JSON"
+                )
+                let envelope = try JSONDecoder().decode(
+                    ChatCompletionErrorEnvelope.self,
+                    from: Data(buffer: response.body)
+                )
+                XCTAssertFalse(envelope.error.message.isEmpty, "Error envelope must carry a non-empty message")
+            }
+        }
+    }
+
+    func testMalformedRequestBodyReturnsError() async throws {
+        let server = ServerApp(
+            backendProvider: FakeBackendProvider(models: ["tiny"]),
+            adapter: FixedChatAdapter()
+        )
+        let app = server.makeApplication()
+
+        try await app.test(.router) { client in
+            var headers = HTTPFields()
+            headers[.contentType] = "application/json"
+            let malformedBody = ByteBuffer(string: "not json")
+            try await client.execute(
+                uri: "/v1/chat/completions",
+                method: .post,
+                headers: headers,
+                body: malformedBody
+            ) { response in
+                XCTAssertNotEqual(response.status, .ok)
+                XCTAssertTrue(
+                    response.headers[.contentType]?.contains("application/json") == true,
+                    "Error responses must be JSON"
+                )
+                XCTAssertNoThrow(
+                    try JSONDecoder().decode(
+                        ChatCompletionErrorEnvelope.self,
+                        from: Data(buffer: response.body)
+                    ),
+                    "Malformed-body error must decode as ChatCompletionErrorEnvelope"
+                )
             }
         }
     }
@@ -243,11 +368,19 @@ private struct FixedStreamingChatAdapter: ChatCompletionsAdapter {
         using backend: any InferenceBackend
     ) throws -> AsyncThrowingStream<ChatCompletionChunk, Error> {
         AsyncThrowingStream { continuation in
+            // Content token chunk
             continuation.yield(ChatCompletionChunk(
                 id: "chatcmpl-test",
                 created: 0,
                 model: request.model,
                 choices: [ChatCompletionChunkChoice(index: 0, delta: ChatCompletionDelta(content: "stream"))]
+            ))
+            // Final stop chunk (matches the pattern used by ChatCompletionEventMapper)
+            continuation.yield(ChatCompletionChunk(
+                id: "chatcmpl-test",
+                created: 0,
+                model: request.model,
+                choices: [ChatCompletionChunkChoice(index: 0, delta: ChatCompletionDelta(), finishReason: .stop)]
             ))
             continuation.finish()
         }
@@ -293,6 +426,67 @@ private struct DelayedChatAdapter: ChatCompletionsAdapter {
     ) throws -> AsyncThrowingStream<ChatCompletionChunk, Error> {
         AsyncThrowingStream { continuation in
             continuation.finish()
+        }
+    }
+}
+
+private struct DelayedStreamingChatAdapter: ChatCompletionsAdapter {
+    let recorder: ConcurrencyRecorder
+
+    func generationConfig(for request: ChatCompletionRequest) throws -> GenerationConfig {
+        GenerationConfig()
+    }
+
+    func response(
+        for request: ChatCompletionRequest,
+        using backend: any InferenceBackend
+    ) async throws -> ChatCompletionResponse {
+        ChatCompletionResponse(id: "chatcmpl-delayed-stream", model: request.model, content: "done")
+    }
+
+    func chunks(
+        for request: ChatCompletionRequest,
+        using backend: any InferenceBackend
+    ) throws -> AsyncThrowingStream<ChatCompletionChunk, Error> {
+        let recorder = recorder
+        return AsyncThrowingStream { continuation in
+            let task = Task {
+                await recorder.enter()
+                try await Task.sleep(for: .milliseconds(100))
+                await recorder.leave()
+                continuation.yield(ChatCompletionChunk(
+                    id: "chatcmpl-delayed-stream",
+                    created: 0,
+                    model: request.model,
+                    choices: [ChatCompletionChunkChoice(index: 0, delta: ChatCompletionDelta(content: "done"), finishReason: .stop)]
+                ))
+                continuation.finish()
+            }
+            continuation.onTermination = { @Sendable _ in task.cancel() }
+        }
+    }
+}
+
+private struct FailingChatAdapter: ChatCompletionsAdapter {
+    struct GenerationFailure: Error {}
+
+    func generationConfig(for request: ChatCompletionRequest) throws -> GenerationConfig {
+        GenerationConfig()
+    }
+
+    func response(
+        for request: ChatCompletionRequest,
+        using backend: any InferenceBackend
+    ) async throws -> ChatCompletionResponse {
+        throw GenerationFailure()
+    }
+
+    func chunks(
+        for request: ChatCompletionRequest,
+        using backend: any InferenceBackend
+    ) throws -> AsyncThrowingStream<ChatCompletionChunk, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.finish(throwing: GenerationFailure())
         }
     }
 }

--- a/Tests/BaseChatServerTests/BaseChatServerSmokeTests.swift
+++ b/Tests/BaseChatServerTests/BaseChatServerSmokeTests.swift
@@ -1,0 +1,298 @@
+@testable import BaseChatServerCore
+import BaseChatInference
+import BaseChatTestSupport
+import Hummingbird
+import HummingbirdTesting
+import HTTPTypes
+import NIOCore
+import XCTest
+
+final class BaseChatServerSmokeTests: XCTestCase {
+    func testServerAppConstructsHealthPlaceholder() {
+        let configuration = ServerConfiguration(host: "localhost", port: 9090)
+        let app = ServerApp(configuration: configuration)
+
+        XCTAssertEqual(app.configuration.host, "localhost")
+        XCTAssertEqual(app.configuration.port, 9090)
+        XCTAssertEqual(app.health(), ServerHealth(status: "ok"))
+        XCTAssertEqual(app.metrics.snapshot(), ServerMetricsSnapshot())
+    }
+
+    func testRoutesReturnHealthModelsAndChatCompletion() async throws {
+        let app = ServerApp(
+            backendProvider: FakeBackendProvider(models: ["tiny"]),
+            adapter: FixedChatAdapter(content: "hello world")
+        ).makeApplication()
+
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/health", method: .get) { response in
+                XCTAssertEqual(response.status, .ok)
+                let health = try JSONDecoder().decode(ServerHealth.self, from: Data(buffer: response.body))
+                XCTAssertEqual(health, ServerHealth())
+            }
+
+            try await client.execute(uri: "/v1/models", method: .get) { response in
+                XCTAssertEqual(response.status, .ok)
+                let models = try JSONDecoder().decode(ModelsListResponse.self, from: Data(buffer: response.body))
+                XCTAssertEqual(models.data.map(\.id), ["tiny"])
+            }
+
+            let body = try requestBody(ChatCompletionRequest(model: "tiny", messages: [.init(role: "user", content: "hi")]))
+            try await client.execute(uri: "/v1/chat/completions", method: .post, body: body) { response in
+                XCTAssertEqual(response.status, .ok)
+                let completion = try JSONDecoder().decode(ChatCompletionResponse.self, from: Data(buffer: response.body))
+                XCTAssertEqual(completion.content, "hello world")
+            }
+        }
+    }
+
+    func testBearerAuthProtectsAPIButExemptsHealthAndMetrics() async throws {
+        let server = ServerApp(
+            configuration: ServerConfiguration(apiKey: "secret", metricsEnabled: true),
+            backendProvider: FakeBackendProvider(models: ["tiny"]),
+            adapter: FixedChatAdapter()
+        )
+        let app = server.makeApplication()
+
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/health", method: .get) { response in
+                XCTAssertEqual(response.status, .ok)
+            }
+
+            try await client.execute(uri: "/metrics", method: .get) { response in
+                XCTAssertEqual(response.status, .ok)
+            }
+
+            try await client.execute(uri: "/v1/models", method: .get) { response in
+                XCTAssertEqual(response.status, .unauthorized)
+                XCTAssertTrue(String(buffer: response.body).contains("invalid_api_key"))
+            }
+
+            var headers = HTTPFields()
+            headers[.authorization] = "Bearer secret"
+            try await client.execute(uri: "/v1/models", method: .get, headers: headers) { response in
+                XCTAssertEqual(response.status, .ok)
+            }
+        }
+    }
+
+    func testCORSDefaultsConfiguredOriginUnsafeWildcardAndPreflight() async throws {
+        try await ServerApp(
+            configuration: ServerConfiguration(corsOrigin: "https://example.com")
+        ).makeApplication().test(.router) { client in
+            var headers = HTTPFields()
+            headers[.origin] = "https://client.example"
+            try await client.execute(uri: "/health", method: .get, headers: headers) { response in
+                XCTAssertEqual(response.headers[.accessControlAllowOrigin], "https://example.com")
+            }
+
+            try await client.execute(uri: "/health", method: .options, headers: headers) { response in
+                XCTAssertEqual(response.status, .noContent)
+                XCTAssertEqual(response.headers[.accessControlAllowOrigin], "https://example.com")
+            }
+        }
+
+        try await ServerApp().makeApplication().test(.router) { client in
+            var headers = HTTPFields()
+            headers[.origin] = "https://client.example"
+            try await client.execute(uri: "/health", method: .get, headers: headers) { response in
+                XCTAssertNil(response.headers[.accessControlAllowOrigin])
+            }
+        }
+
+        try await ServerApp(
+            configuration: ServerConfiguration(unsafeCORS: true)
+        ).makeApplication().test(.router) { client in
+            var headers = HTTPFields()
+            headers[.origin] = "https://client.example"
+            try await client.execute(uri: "/health", method: .get, headers: headers) { response in
+                XCTAssertEqual(response.headers[.accessControlAllowOrigin], "*")
+            }
+        }
+    }
+
+    func testMetricsEndpointIsConditionalAndTracksCounters() async throws {
+        try await ServerApp().makeApplication().test(.router) { client in
+            try await client.execute(uri: "/metrics", method: .get) { response in
+                XCTAssertEqual(response.status, .notFound)
+            }
+        }
+
+        let server = ServerApp(
+            configuration: ServerConfiguration(metricsEnabled: true),
+            backendProvider: FakeBackendProvider(models: ["tiny"]),
+            adapter: FixedChatAdapter(content: "one two")
+        )
+        try await server.makeApplication().test(.router) { client in
+            let body = try requestBody(ChatCompletionRequest(model: "tiny", messages: []))
+            try await client.execute(uri: "/v1/chat/completions", method: .post, body: body)
+            try await client.execute(uri: "/metrics", method: .get) { response in
+                let text = String(buffer: response.body)
+                XCTAssertTrue(text.contains("basechat_requests_total 1"))
+                XCTAssertTrue(text.contains("basechat_completions_total 1"))
+                XCTAssertTrue(text.contains("basechat_tokens_total 2"))
+            }
+        }
+    }
+
+    func testSemaphoreLimitsConcurrentChatCompletions() async throws {
+        let recorder = ConcurrencyRecorder()
+        let server = ServerApp(
+            configuration: ServerConfiguration(parallelSlots: 1),
+            backendProvider: FakeBackendProvider(models: ["tiny"]),
+            adapter: DelayedChatAdapter(recorder: recorder)
+        )
+        let app = server.makeApplication()
+
+        try await app.test(.router) { client in
+            let firstBody = try requestBody(ChatCompletionRequest(model: "tiny", messages: []))
+            let secondBody = try requestBody(ChatCompletionRequest(model: "tiny", messages: []))
+            async let first: Void = client.execute(uri: "/v1/chat/completions", method: .post, body: firstBody) { _ in () }
+            async let second: Void = client.execute(uri: "/v1/chat/completions", method: .post, body: secondBody) { _ in () }
+            _ = try await (first, second)
+        }
+
+        let maxObserved = await recorder.maxObserved
+        XCTAssertEqual(maxObserved, 1)
+    }
+
+    func testSSEHeadersAndDoneFrame() async throws {
+        let server = ServerApp(
+            backendProvider: FakeBackendProvider(models: ["tiny"]),
+            adapter: FixedStreamingChatAdapter()
+        )
+        let app = server.makeApplication()
+
+        try await app.test(.router) { client in
+            let body = try requestBody(ChatCompletionRequest(model: "tiny", messages: [], stream: true))
+            try await client.execute(uri: "/v1/chat/completions", method: .post, body: body) { response in
+                XCTAssertEqual(response.status, .ok)
+                XCTAssertEqual(response.headers[.contentType], "text/event-stream")
+                XCTAssertEqual(response.headers[.cacheControl], "no-cache")
+                XCTAssertEqual(response.headers[.connection], "keep-alive")
+                XCTAssertEqual(response.headers[HTTPField.Name("X-Accel-Buffering")!], "no")
+                let text = String(buffer: response.body)
+                XCTAssertTrue(text.contains("stream"))
+                XCTAssertTrue(text.contains("data: [DONE]"))
+            }
+        }
+    }
+}
+
+private func requestBody(_ request: ChatCompletionRequest) throws -> ByteBuffer {
+    ByteBuffer(bytes: try JSONEncoder().encode(request))
+}
+
+private struct FakeBackendProvider: ServerBackendProvider {
+    let models: [String]
+    let backend = MockInferenceBackend()
+
+    func listModels() async throws -> [String] {
+        models
+    }
+
+    func backend(for request: ServerBackendRequest) async throws -> any InferenceBackend {
+        backend
+    }
+}
+
+private struct FixedChatAdapter: ChatCompletionsAdapter {
+    var content = "ok"
+
+    func generationConfig(for request: ChatCompletionRequest) throws -> GenerationConfig {
+        GenerationConfig()
+    }
+
+    func response(
+        for request: ChatCompletionRequest,
+        using backend: any InferenceBackend
+    ) async throws -> ChatCompletionResponse {
+        ChatCompletionResponse(id: "chatcmpl-test", model: request.model, content: content)
+    }
+
+    func chunks(
+        for request: ChatCompletionRequest,
+        using backend: any InferenceBackend
+    ) throws -> AsyncThrowingStream<ChatCompletionChunk, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.yield(ChatCompletionChunk(
+                id: "chatcmpl-test",
+                created: 0,
+                model: request.model,
+                choices: [ChatCompletionChunkChoice(index: 0, delta: ChatCompletionDelta(content: content))]
+            ))
+            continuation.finish()
+        }
+    }
+}
+
+private struct FixedStreamingChatAdapter: ChatCompletionsAdapter {
+    func generationConfig(for request: ChatCompletionRequest) throws -> GenerationConfig {
+        GenerationConfig()
+    }
+
+    func response(
+        for request: ChatCompletionRequest,
+        using backend: any InferenceBackend
+    ) async throws -> ChatCompletionResponse {
+        ChatCompletionResponse(id: "chatcmpl-test", model: request.model, content: "fallback")
+    }
+
+    func chunks(
+        for request: ChatCompletionRequest,
+        using backend: any InferenceBackend
+    ) throws -> AsyncThrowingStream<ChatCompletionChunk, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.yield(ChatCompletionChunk(
+                id: "chatcmpl-test",
+                created: 0,
+                model: request.model,
+                choices: [ChatCompletionChunkChoice(index: 0, delta: ChatCompletionDelta(content: "stream"))]
+            ))
+            continuation.finish()
+        }
+    }
+}
+
+private actor ConcurrencyRecorder {
+    private var current = 0
+    private var maxValue = 0
+
+    var maxObserved: Int { maxValue }
+
+    func enter() {
+        current += 1
+        maxValue = max(maxValue, current)
+    }
+
+    func leave() {
+        current -= 1
+    }
+}
+
+private struct DelayedChatAdapter: ChatCompletionsAdapter {
+    let recorder: ConcurrencyRecorder
+
+    func generationConfig(for request: ChatCompletionRequest) throws -> GenerationConfig {
+        GenerationConfig()
+    }
+
+    func response(
+        for request: ChatCompletionRequest,
+        using backend: any InferenceBackend
+    ) async throws -> ChatCompletionResponse {
+        await recorder.enter()
+        try await Task.sleep(for: .milliseconds(100))
+        await recorder.leave()
+        return ChatCompletionResponse(id: "chatcmpl-delayed", model: request.model, content: "done")
+    }
+
+    func chunks(
+        for request: ChatCompletionRequest,
+        using backend: any InferenceBackend
+    ) throws -> AsyncThrowingStream<ChatCompletionChunk, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.finish()
+        }
+    }
+}

--- a/Tests/BaseChatServerTests/ChatCompletionsAdapterTests.swift
+++ b/Tests/BaseChatServerTests/ChatCompletionsAdapterTests.swift
@@ -152,6 +152,54 @@ final class ChatCompletionsAdapterTests: XCTestCase {
         XCTAssertEqual(response.usage, ChatCompletionUsage(promptTokens: 5, completionTokens: 7))
     }
 
+    func testDecodesToolChoiceStringVariants() throws {
+        let autoJSON = #"{"model":"m","messages":[],"tool_choice":"auto"}"#
+        let noneJSON = #"{"model":"m","messages":[],"tool_choice":"none"}"#
+        let requiredJSON = #"{"model":"m","messages":[],"tool_choice":"required"}"#
+        let decoder = JSONDecoder()
+
+        let autoRequest = try decoder.decode(ChatCompletionRequest.self, from: Data(autoJSON.utf8))
+        let noneRequest = try decoder.decode(ChatCompletionRequest.self, from: Data(noneJSON.utf8))
+        let requiredRequest = try decoder.decode(ChatCompletionRequest.self, from: Data(requiredJSON.utf8))
+
+        XCTAssertEqual(autoRequest.toolChoice, .some(.auto))
+        XCTAssertEqual(noneRequest.toolChoice, .some(.none))
+        XCTAssertEqual(requiredRequest.toolChoice, .some(.required))
+    }
+
+    func testPromptAssemblyForMultiTurnConversation() async throws {
+        let request = ChatCompletionRequest(
+            model: "m",
+            messages: [
+                ChatCompletionMessage(role: .system, content: "You are helpful."),
+                ChatCompletionMessage(role: .user, content: "Hello"),
+                ChatCompletionMessage(role: .assistant, content: "Hi there!"),
+                ChatCompletionMessage(
+                    role: .tool,
+                    content: "42",
+                    toolCallID: "call_123"
+                ),
+                ChatCompletionMessage(role: .user, content: "Thanks")
+            ]
+        )
+
+        let adapter = DefaultChatCompletionsAdapter()
+        // Access promptParts via generationConfig indirectly — use the adapter's response
+        // with a fake backend to verify the prompt reaches the backend correctly.
+        let backend = CapturingBackend()
+        _ = try? await adapter.response(for: request, using: backend)
+
+        XCTAssertNotNil(backend.capturedSystemPrompt, "System message should be extracted as systemPrompt")
+        XCTAssertEqual(backend.capturedSystemPrompt, "You are helpful.")
+
+        let prompt = backend.capturedPrompt ?? ""
+        XCTAssertTrue(prompt.contains("user: Hello"), "User message should appear with role prefix")
+        XCTAssertTrue(prompt.contains("assistant: Hi there!"), "Assistant message should appear with role prefix")
+        XCTAssertTrue(prompt.contains("tool(call_123): 42"), "Tool message should include call ID")
+        XCTAssertTrue(prompt.contains("user: Thanks"), "Final user message should appear")
+        XCTAssertFalse(prompt.contains("You are helpful."), "System message should NOT appear in prompt")
+    }
+
     func testErrorEnvelopeRoundTrips() throws {
         let envelope = ChatCompletionErrorEnvelope(
             error: ChatCompletionError(message: "bad request", type: "invalid_request_error", param: "messages", code: "invalid")
@@ -200,6 +248,36 @@ private final class EventSequenceBackend: InferenceBackend, @unchecked Sendable 
             for event in events {
                 continuation.yield(event)
             }
+            continuation.finish()
+        })
+    }
+
+    func stopGeneration() {}
+    func unloadModel() { isModelLoaded = false }
+}
+
+private final class CapturingBackend: InferenceBackend, @unchecked Sendable {
+    var isModelLoaded = true
+    var isGenerating = false
+    var capabilities = BackendCapabilities(
+        supportedParameters: [.temperature, .topP],
+        maxContextTokens: 4096,
+        requiresPromptTemplate: false,
+        supportsSystemPrompt: true,
+        supportsToolCalling: false,
+        supportsStructuredOutput: false,
+        cancellationStyle: .cooperative,
+        supportsTokenCounting: false
+    )
+    private(set) var capturedPrompt: String?
+    private(set) var capturedSystemPrompt: String?
+
+    func loadModel(from url: URL, plan: ModelLoadPlan) async throws { isModelLoaded = true }
+
+    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> GenerationStream {
+        capturedPrompt = prompt
+        capturedSystemPrompt = systemPrompt
+        return GenerationStream(AsyncThrowingStream { continuation in
             continuation.finish()
         })
     }

--- a/Tests/BaseChatServerTests/ChatCompletionsAdapterTests.swift
+++ b/Tests/BaseChatServerTests/ChatCompletionsAdapterTests.swift
@@ -1,0 +1,209 @@
+@testable import BaseChatServerCore
+import BaseChatInference
+import BaseChatTestSupport
+import XCTest
+
+final class ChatCompletionsAdapterTests: XCTestCase {
+    func testDecodesOpenAIRequestShape() throws {
+        let json = #"""
+        {
+          "model": "local-model",
+          "messages": [
+            {"role": "system", "content": "Be terse."},
+            {"role": "user", "content": "Weather?"}
+          ],
+          "stream": true,
+          "stream_options": {"include_usage": true},
+          "temperature": 0.2,
+          "top_p": 0.8,
+          "max_tokens": 32,
+          "response_format": {"type": "json_object"},
+          "tools": [{
+            "type": "function",
+            "function": {
+              "name": "get_weather",
+              "description": "Get weather",
+              "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}
+            }
+          }],
+          "tool_choice": {"type": "function", "function": {"name": "get_weather"}}
+        }
+        """#.data(using: .utf8)!
+
+        let request = try JSONDecoder().decode(ChatCompletionRequest.self, from: json)
+
+        XCTAssertEqual(request.model, "local-model")
+        XCTAssertEqual(request.messages.map(\.role), [.system, .user])
+        XCTAssertEqual(request.stream, true)
+        XCTAssertEqual(request.streamOptions, ChatCompletionStreamOptions(includeUsage: true))
+        XCTAssertEqual(request.temperature, 0.2)
+        XCTAssertEqual(request.topP, 0.8)
+        XCTAssertEqual(request.maxTokens, 32)
+        XCTAssertEqual(request.responseFormat?.type, .jsonObject)
+        XCTAssertEqual(request.tools?.first?.function.name, "get_weather")
+        XCTAssertEqual(request.toolChoice, .function(name: "get_weather"))
+    }
+
+    func testMapsRequestToGenerationConfig() throws {
+        let request = ChatCompletionRequest(
+            model: "m",
+            messages: [ChatCompletionMessage(role: .user, content: "hi")],
+            temperature: 0.1,
+            topP: 0.2,
+            maxTokens: 12,
+            maxCompletionTokens: 10,
+            responseFormat: ChatCompletionResponseFormat(type: .jsonObject),
+            tools: [ChatCompletionTool(function: ChatCompletionFunctionDefinition(
+                name: "lookup",
+                description: "Lookup a value",
+                parameters: .object(["type": .string("object")])
+            ))],
+            toolChoice: .function(name: "lookup")
+        )
+
+        let config = try DefaultChatCompletionsAdapter().generationConfig(for: request)
+
+        XCTAssertEqual(config.temperature, 0.1, accuracy: 0.0001)
+        XCTAssertEqual(config.topP, 0.2, accuracy: 0.0001)
+        XCTAssertEqual(config.maxOutputTokens, 10)
+        XCTAssertEqual(config.tools, [ToolDefinition(name: "lookup", description: "Lookup a value", parameters: .object(["type": .string("object")]))])
+        if case .tool(let name) = config.toolChoice {
+            XCTAssertEqual(name, "lookup")
+        } else {
+            XCTFail("Expected named tool choice")
+        }
+        XCTAssertTrue(config.jsonMode)
+    }
+
+    func testTokenEventsMapToContentDeltaChunks() async throws {
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["Hel", "lo"]
+        let request = ChatCompletionRequest(model: "m", messages: [ChatCompletionMessage(role: .user, content: "hi")], stream: true)
+
+        let chunks = try await collect(try DefaultChatCompletionsAdapter().chunks(for: request, using: backend))
+
+        XCTAssertEqual(chunks.compactMap { $0.choices.first?.delta.content }, ["Hel", "lo"])
+        XCTAssertEqual(chunks.last?.choices.first?.finishReason, .stop)
+        XCTAssertEqual(backend.lastPrompt, "user: hi")
+    }
+
+    func testToolCallDeltasUseStableIndexes() async throws {
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = []
+        backend.scriptedToolCallDeltasPerTurn = [[
+            .start(callId: "call_b", name: "second"),
+            .delta(callId: "call_b", textDelta: "{\"b\":"),
+            .start(callId: "call_a", name: "first"),
+            .delta(callId: "call_a", textDelta: "{\"a\":1}"),
+            .delta(callId: "call_b", textDelta: "2}")
+        ]]
+        let request = ChatCompletionRequest(model: "m", messages: [ChatCompletionMessage(role: .user, content: "tools")], stream: true)
+
+        let chunks = try await collect(try DefaultChatCompletionsAdapter().chunks(for: request, using: backend))
+        let deltas = chunks.compactMap { $0.choices.first?.delta.toolCalls?.first }
+
+        XCTAssertEqual(deltas.map(\.index), [0, 0, 1, 1, 0])
+        XCTAssertEqual(deltas[0].id, "call_b")
+        XCTAssertEqual(deltas[2].id, "call_a")
+        XCTAssertEqual(chunks.last?.choices.first?.finishReason, .toolCalls)
+    }
+
+    func testUsageEventMapsToFinalUsageChunkWhenRequested() async throws {
+        let backend = EventSequenceBackend(events: [.token("ok"), .usage(prompt: 3, completion: 2)])
+        let request = ChatCompletionRequest(
+            model: "m",
+            messages: [ChatCompletionMessage(role: .user, content: "hi")],
+            stream: true,
+            streamOptions: ChatCompletionStreamOptions(includeUsage: true)
+        )
+
+        let chunks = try await collect(try DefaultChatCompletionsAdapter().chunks(for: request, using: backend))
+
+        XCTAssertEqual(chunks.last?.choices, [])
+        XCTAssertEqual(chunks.last?.usage, ChatCompletionUsage(promptTokens: 3, completionTokens: 2))
+    }
+
+    func testNonStreamResponseAssemblesContentReasoningToolCallsAndUsage() async throws {
+        let backend = EventSequenceBackend(events: [
+            .thinkingToken("think "),
+            .thinkingToken("hard"),
+            .token("Hello"),
+            .token(" world"),
+            .toolCallStart(callId: "call_1", name: "lookup"),
+            .toolCallArgumentsDelta(callId: "call_1", textDelta: "{\"q\":"),
+            .toolCallArgumentsDelta(callId: "call_1", textDelta: "\"swift\"}"),
+            .usage(prompt: 5, completion: 7)
+        ])
+        let request = ChatCompletionRequest(model: "m", messages: [ChatCompletionMessage(role: .user, content: "hi")])
+
+        let response = try await DefaultChatCompletionsAdapter().response(for: request, using: backend)
+
+        XCTAssertEqual(response.choices.first?.message.content, "Hello world")
+        XCTAssertEqual(response.choices.first?.message.reasoningContent, "think hard")
+        XCTAssertEqual(response.choices.first?.message.toolCalls, [
+            ChatCompletionMessageToolCall(
+                id: "call_1",
+                function: ChatCompletionFunctionCall(name: "lookup", arguments: "{\"q\":\"swift\"}")
+            )
+        ])
+        XCTAssertEqual(response.choices.first?.finishReason, .toolCalls)
+        XCTAssertEqual(response.usage, ChatCompletionUsage(promptTokens: 5, completionTokens: 7))
+    }
+
+    func testErrorEnvelopeRoundTrips() throws {
+        let envelope = ChatCompletionErrorEnvelope(
+            error: ChatCompletionError(message: "bad request", type: "invalid_request_error", param: "messages", code: "invalid")
+        )
+
+        let data = try JSONEncoder().encode(envelope)
+        let decoded = try JSONDecoder().decode(ChatCompletionErrorEnvelope.self, from: data)
+
+        XCTAssertEqual(decoded, envelope)
+        XCTAssertEqual(ChatCompletionErrorEnvelope.from(ServerError.invalidConfiguration("nope")).error.message, "nope")
+    }
+
+    private func collect(_ stream: AsyncThrowingStream<ChatCompletionChunk, Error>) async throws -> [ChatCompletionChunk] {
+        var chunks: [ChatCompletionChunk] = []
+        for try await chunk in stream {
+            chunks.append(chunk)
+        }
+        return chunks
+    }
+}
+
+private final class EventSequenceBackend: InferenceBackend, @unchecked Sendable {
+    var isModelLoaded = true
+    var isGenerating = false
+    var capabilities = BackendCapabilities(
+        supportedParameters: [.temperature, .topP, .repeatPenalty],
+        maxContextTokens: 4096,
+        requiresPromptTemplate: false,
+        supportsSystemPrompt: true,
+        supportsToolCalling: true,
+        supportsStructuredOutput: true,
+        cancellationStyle: .cooperative,
+        supportsTokenCounting: false
+    )
+    let events: [GenerationEvent]
+
+    init(events: [GenerationEvent]) {
+        self.events = events
+    }
+
+    func loadModel(from url: URL, plan: ModelLoadPlan) async throws { isModelLoaded = true }
+
+    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> GenerationStream {
+        let events = events
+        return GenerationStream(AsyncThrowingStream { continuation in
+            for event in events {
+                continuation.yield(event)
+            }
+            continuation.finish()
+        })
+    }
+
+    func stopGeneration() {}
+    func unloadModel() { isModelLoaded = false }
+}

--- a/Tests/BaseChatServerTests/OpenAIJSONGoldenSupport.swift
+++ b/Tests/BaseChatServerTests/OpenAIJSONGoldenSupport.swift
@@ -1,0 +1,192 @@
+import Foundation
+import XCTest
+
+enum OpenAIJSONGolden {
+    static let decoder = JSONDecoder()
+
+    static var encoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+
+    static func decode<T: Decodable>(_ type: T.Type, from json: String, file: StaticString = #filePath, line: UInt = #line) throws -> T {
+        do {
+            return try decoder.decode(T.self, from: Data(json.utf8))
+        } catch {
+            XCTFail("Failed to decode golden JSON: \(error)", file: file, line: line)
+            throw error
+        }
+    }
+
+    static func encode<T: Encodable>(_ value: T, file: StaticString = #filePath, line: UInt = #line) throws -> String {
+        do {
+            let data = try encoder.encode(value)
+            return String(decoding: data, as: UTF8.self)
+        } catch {
+            XCTFail("Failed to encode golden JSON: \(error)", file: file, line: line)
+            throw error
+        }
+    }
+}
+
+struct OpenAIChatRequestGolden: Codable, Equatable {
+    struct Message: Codable, Equatable {
+        var role: String
+        var content: String?
+        var toolCallID: String?
+        var toolCalls: [ToolCall]?
+
+        enum CodingKeys: String, CodingKey {
+            case role
+            case content
+            case toolCallID = "tool_call_id"
+            case toolCalls = "tool_calls"
+        }
+    }
+
+    struct ToolCall: Codable, Equatable {
+        struct Function: Codable, Equatable {
+            var name: String
+            var arguments: String
+        }
+
+        var id: String
+        var type: String
+        var function: Function
+    }
+
+    struct Tool: Codable, Equatable {
+        struct Function: Codable, Equatable {
+            var name: String
+            var description: String?
+            var parameters: JSONValue
+        }
+
+        var type: String
+        var function: Function
+    }
+
+    struct StreamOptions: Codable, Equatable {
+        var includeUsage: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case includeUsage = "include_usage"
+        }
+    }
+
+    var model: String
+    var messages: [Message]
+    var tools: [Tool]?
+    var stream: Bool?
+    var streamOptions: StreamOptions?
+
+    enum CodingKeys: String, CodingKey {
+        case model
+        case messages
+        case tools
+        case stream
+        case streamOptions = "stream_options"
+    }
+}
+
+struct OpenAIChatChunkGolden: Codable, Equatable {
+    struct Choice: Codable, Equatable {
+        struct Delta: Codable, Equatable {
+            struct ToolCall: Codable, Equatable {
+                struct Function: Codable, Equatable {
+                    var name: String?
+                    var arguments: String?
+                }
+
+                var index: Int
+                var id: String?
+                var type: String?
+                var function: Function?
+            }
+
+            var role: String?
+            var content: String?
+            var toolCalls: [ToolCall]?
+
+            enum CodingKeys: String, CodingKey {
+                case role
+                case content
+                case toolCalls = "tool_calls"
+            }
+        }
+
+        var index: Int
+        var delta: Delta
+        var finishReason: String?
+
+        enum CodingKeys: String, CodingKey {
+            case index
+            case delta
+            case finishReason = "finish_reason"
+        }
+    }
+
+    struct Usage: Codable, Equatable {
+        var promptTokens: Int
+        var completionTokens: Int
+        var totalTokens: Int
+
+        enum CodingKeys: String, CodingKey {
+            case promptTokens = "prompt_tokens"
+            case completionTokens = "completion_tokens"
+            case totalTokens = "total_tokens"
+        }
+    }
+
+    var id: String
+    var object: String
+    var created: Int
+    var model: String
+    var choices: [Choice]
+    var usage: Usage?
+}
+
+enum JSONValue: Codable, Equatable {
+    case object([String: JSONValue])
+    case array([JSONValue])
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case null
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([JSONValue].self) {
+            self = .array(value)
+        } else {
+            self = .object(try container.decode([String: JSONValue].self))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .object(let value):
+            try container.encode(value)
+        case .array(let value):
+            try container.encode(value)
+        case .string(let value):
+            try container.encode(value)
+        case .number(let value):
+            try container.encode(value)
+        case .bool(let value):
+            try container.encode(value)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+}

--- a/Tests/BaseChatServerTests/OpenAIJSONGoldenTests.swift
+++ b/Tests/BaseChatServerTests/OpenAIJSONGoldenTests.swift
@@ -1,6 +1,55 @@
+@testable import BaseChatServerCore
 import XCTest
 
 final class OpenAIJSONGoldenTests: XCTestCase {
+    func testNonStreamingChatCompletionResponseRoundTrips() throws {
+        let json = #"""
+        {
+          "id": "chatcmpl-abc123",
+          "object": "chat.completion",
+          "created": 1710000000,
+          "model": "demo-model",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "The answer is 42."
+              },
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 6,
+            "total_tokens": 16
+          }
+        }
+        """#
+
+        // Decode and verify the structure
+        let response = try JSONDecoder().decode(ChatCompletionResponse.self, from: Data(json.utf8))
+
+        XCTAssertEqual(response.id, "chatcmpl-abc123")
+        XCTAssertEqual(response.object, "chat.completion")
+        XCTAssertEqual(response.created, 1710000000)
+        XCTAssertEqual(response.model, "demo-model")
+        XCTAssertEqual(response.choices.count, 1)
+        XCTAssertEqual(response.choices.first?.message.role, .assistant)
+        XCTAssertEqual(response.choices.first?.message.content, "The answer is 42.")
+        XCTAssertEqual(response.choices.first?.finishReason, .stop)
+        XCTAssertEqual(response.usage?.promptTokens, 10)
+        XCTAssertEqual(response.usage?.completionTokens, 6)
+        XCTAssertEqual(response.usage?.totalTokens, 16)
+
+        // Verify round-trip fidelity via re-encode + re-decode
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let reencoded = try encoder.encode(response)
+        let roundTripped = try JSONDecoder().decode(ChatCompletionResponse.self, from: reencoded)
+        XCTAssertEqual(roundTripped, response)
+    }
+
     func testDecodesOpenAIRequestWithMessagesToolsAndStreamOptions() throws {
         let json = #"""
         {

--- a/Tests/BaseChatServerTests/OpenAIJSONGoldenTests.swift
+++ b/Tests/BaseChatServerTests/OpenAIJSONGoldenTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+
+final class OpenAIJSONGoldenTests: XCTestCase {
+    func testDecodesOpenAIRequestWithMessagesToolsAndStreamOptions() throws {
+        let json = #"""
+        {
+          "model": "demo-model",
+          "messages": [
+            { "role": "system", "content": "You are concise." },
+            { "role": "user", "content": "Weather in Paris?" }
+          ],
+          "tools": [
+            {
+              "type": "function",
+              "function": {
+                "name": "get_weather",
+                "description": "Return weather.",
+                "parameters": {
+                  "type": "object",
+                  "properties": {
+                    "city": { "type": "string" }
+                  },
+                  "required": ["city"]
+                }
+              }
+            }
+          ],
+          "stream": true,
+          "stream_options": { "include_usage": true }
+        }
+        """#
+
+        let request = try OpenAIJSONGolden.decode(OpenAIChatRequestGolden.self, from: json)
+
+        XCTAssertEqual(request.model, "demo-model")
+        XCTAssertEqual(request.messages.map(\.role), ["system", "user"])
+        XCTAssertEqual(request.messages.last?.content, "Weather in Paris?")
+        XCTAssertEqual(request.tools?.first?.type, "function")
+        XCTAssertEqual(request.tools?.first?.function.name, "get_weather")
+        XCTAssertEqual(request.stream, true)
+        XCTAssertEqual(request.streamOptions?.includeUsage, true)
+    }
+
+    func testTokenChunkJSONShape() throws {
+        let json = #"""
+        {
+          "id": "chatcmpl-test",
+          "object": "chat.completion.chunk",
+          "created": 1710000000,
+          "model": "demo-model",
+          "choices": [
+            { "index": 0, "delta": { "content": "Hel" }, "finish_reason": null }
+          ]
+        }
+        """#
+
+        let chunk = try OpenAIJSONGolden.decode(OpenAIChatChunkGolden.self, from: json)
+
+        XCTAssertEqual(chunk.object, "chat.completion.chunk")
+        XCTAssertEqual(chunk.choices.first?.delta.content, "Hel")
+        XCTAssertNil(chunk.choices.first?.finishReason)
+        XCTAssertNil(chunk.usage)
+    }
+
+    func testToolCallDeltaJSONShape() throws {
+        let json = #"""
+        {
+          "id": "chatcmpl-test",
+          "object": "chat.completion.chunk",
+          "created": 1710000000,
+          "model": "demo-model",
+          "choices": [
+            {
+              "index": 0,
+              "delta": {
+                "tool_calls": [
+                  {
+                    "index": 0,
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                      "name": "get_weather",
+                      "arguments": "{\"city\":"
+                    }
+                  }
+                ]
+              },
+              "finish_reason": null
+            }
+          ]
+        }
+        """#
+
+        let chunk = try OpenAIJSONGolden.decode(OpenAIChatChunkGolden.self, from: json)
+        let toolCall = chunk.choices.first?.delta.toolCalls?.first
+
+        XCTAssertEqual(toolCall?.index, 0)
+        XCTAssertEqual(toolCall?.id, "call_1")
+        XCTAssertEqual(toolCall?.type, "function")
+        XCTAssertEqual(toolCall?.function?.name, "get_weather")
+        XCTAssertEqual(toolCall?.function?.arguments, "{\"city\":")
+    }
+
+    func testUsageJSONShape() throws {
+        let json = #"""
+        {
+          "id": "chatcmpl-test",
+          "object": "chat.completion.chunk",
+          "created": 1710000000,
+          "model": "demo-model",
+          "choices": [],
+          "usage": {
+            "prompt_tokens": 7,
+            "completion_tokens": 5,
+            "total_tokens": 12
+          }
+        }
+        """#
+
+        let chunk = try OpenAIJSONGolden.decode(OpenAIChatChunkGolden.self, from: json)
+
+        XCTAssertEqual(chunk.usage?.promptTokens, 7)
+        XCTAssertEqual(chunk.usage?.completionTokens, 5)
+        XCTAssertEqual(chunk.usage?.totalTokens, 12)
+    }
+}

--- a/Tests/BaseChatServerTests/ServerBackendProviderTests.swift
+++ b/Tests/BaseChatServerTests/ServerBackendProviderTests.swift
@@ -1,0 +1,40 @@
+@testable import BaseChatServerCore
+import BaseChatTestSupport
+import XCTest
+
+final class ServerBackendProviderTests: XCTestCase {
+    func testUnavailableProviderListsNoModels() async throws {
+        let provider = UnavailableServerBackendProvider()
+
+        let models = try await provider.listModels()
+
+        XCTAssertEqual(models, [])
+    }
+
+    func testUnavailableProviderThrowsBackendUnavailable() async {
+        let provider = UnavailableServerBackendProvider()
+
+        do {
+            _ = try await provider.backend(for: ServerBackendRequest(model: "missing-model"))
+            XCTFail("Expected backend lookup to throw")
+        } catch let error as ServerError {
+            XCTAssertEqual(error, .backendUnavailable("No server backend has been configured yet."))
+            XCTAssertEqual(error.description, "No server backend has been configured yet.")
+        } catch {
+            XCTFail("Expected ServerError.backendUnavailable, got \(error)")
+        }
+    }
+
+    func testFakeProviderRecordsRequestsAndReturnsBackend() async throws {
+        let backend = MockInferenceBackend()
+        let provider = FakeServerBackendProvider(models: ["alpha", "beta"], backend: backend)
+
+        let models = try await provider.listModels()
+        let resolved = try await provider.backend(for: ServerBackendRequest(model: "beta"))
+
+        XCTAssertEqual(models, ["alpha", "beta"])
+        XCTAssertTrue(resolved is MockInferenceBackend)
+        XCTAssertEqual(provider.listModelsCallCount, 1)
+        XCTAssertEqual(provider.backendRequests, [ServerBackendRequest(model: "beta")])
+    }
+}

--- a/Tests/BaseChatServerTests/ServerConfigurationTests.swift
+++ b/Tests/BaseChatServerTests/ServerConfigurationTests.swift
@@ -1,0 +1,36 @@
+@testable import BaseChatServerCore
+import XCTest
+
+final class ServerConfigurationTests: XCTestCase {
+    func testDefaultsAreCISafeAndLocalOnly() {
+        let configuration = ServerConfiguration()
+
+        XCTAssertEqual(configuration.host, "127.0.0.1")
+        XCTAssertEqual(configuration.port, 8080)
+        XCTAssertNil(configuration.apiKey)
+        XCTAssertEqual(configuration.parallelSlots, 1)
+        XCTAssertFalse(configuration.unsafeCORS)
+        XCTAssertNil(configuration.corsOrigin)
+        XCTAssertFalse(configuration.metricsEnabled)
+    }
+
+    func testCustomValuesArePreserved() {
+        let configuration = ServerConfiguration(
+            host: "0.0.0.0",
+            port: 9090,
+            apiKey: "test-key",
+            parallelSlots: 4,
+            unsafeCORS: true,
+            corsOrigin: "https://example.test",
+            metricsEnabled: true
+        )
+
+        XCTAssertEqual(configuration.host, "0.0.0.0")
+        XCTAssertEqual(configuration.port, 9090)
+        XCTAssertEqual(configuration.apiKey, "test-key")
+        XCTAssertEqual(configuration.parallelSlots, 4)
+        XCTAssertTrue(configuration.unsafeCORS)
+        XCTAssertEqual(configuration.corsOrigin, "https://example.test")
+        XCTAssertTrue(configuration.metricsEnabled)
+    }
+}

--- a/Tests/BaseChatServerTests/ServerMetricsAndErrorTests.swift
+++ b/Tests/BaseChatServerTests/ServerMetricsAndErrorTests.swift
@@ -1,0 +1,77 @@
+@testable import BaseChatServerCore
+import XCTest
+
+final class ServerMetricsAndErrorTests: XCTestCase {
+    func testMetricsSnapshotStartsEmptyAndRecordsCounters() {
+        let metrics = ServerMetrics()
+
+        XCTAssertEqual(metrics.snapshot(), ServerMetricsSnapshot())
+
+        metrics.recordRequestStarted()
+        metrics.recordGenerationStarted()
+        metrics.recordGenerationCompleted(tokenCount: 12)
+        metrics.recordRequestCompleted()
+        metrics.recordFailure()
+
+        XCTAssertEqual(
+            metrics.snapshot(),
+            ServerMetricsSnapshot(
+                requests: 1,
+                inFlightGenerations: 0,
+                completions: 1,
+                failures: 1,
+                tokens: 12
+            )
+        )
+    }
+
+    func testMetricsFailureCompletesInFlightGeneration() {
+        let metrics = ServerMetrics()
+
+        metrics.recordGenerationStarted()
+        metrics.recordGenerationFailed()
+
+        XCTAssertEqual(metrics.snapshot().inFlightGenerations, 0)
+        XCTAssertEqual(metrics.snapshot().failures, 1)
+    }
+
+    func testServerErrorDescriptionsUseEnvelopeMessage() {
+        XCTAssertEqual(ServerError.backendUnavailable("backend missing").description, "backend missing")
+        XCTAssertEqual(ServerError.invalidConfiguration("bad port").description, "bad port")
+        XCTAssertEqual(ServerError.notImplemented("todo").description, "todo")
+    }
+
+    func testErrorEnvelopeEncodesOpenAIStyleErrorBody() throws {
+        let envelope = ChatCompletionErrorEnvelope(
+            message: "Missing or invalid bearer token.",
+            type: "invalid_request_error",
+            code: "invalid_api_key"
+        )
+
+        let data = try JSONEncoder().encode(envelope)
+        let decoded = try JSONDecoder().decode(ChatCompletionErrorEnvelope.self, from: data)
+
+        XCTAssertEqual(decoded.error.message, "Missing or invalid bearer token.")
+        XCTAssertEqual(decoded.error.type, "invalid_request_error")
+        XCTAssertNil(decoded.error.param)
+        XCTAssertEqual(decoded.error.code, "invalid_api_key")
+    }
+
+    func testServerAppKeepsInjectedSeams() {
+        let backendProvider = FakeServerBackendProvider(backend: ServerTestBackendFactory.loadedMock())
+        let adapter = FakeChatCompletionsAdapter()
+        let metrics = ServerMetrics()
+        let configuration = ServerConfiguration(host: "localhost", port: 9090, metricsEnabled: true)
+
+        let app = ServerApp(
+            configuration: configuration,
+            backendProvider: backendProvider,
+            adapter: adapter,
+            metrics: metrics
+        )
+
+        XCTAssertEqual(app.configuration, configuration)
+        XCTAssertEqual(app.health(), ServerHealth(status: "ok"))
+        XCTAssertEqual(app.metrics.snapshot(), ServerMetricsSnapshot())
+    }
+}

--- a/Tests/BaseChatServerTests/ServerTestDoubles.swift
+++ b/Tests/BaseChatServerTests/ServerTestDoubles.swift
@@ -1,0 +1,101 @@
+@testable import BaseChatServerCore
+import BaseChatInference
+import BaseChatTestSupport
+import Foundation
+
+final class FakeServerBackendProvider: ServerBackendProvider, @unchecked Sendable {
+    enum ProviderError: Error, Equatable {
+        case unavailable
+    }
+
+    var models: [String]
+    var backendResult: Result<any InferenceBackend, Error>
+    private(set) var listModelsCallCount = 0
+    private(set) var backendRequests: [ServerBackendRequest] = []
+
+    init(
+        models: [String] = ["fake-model"],
+        backend: any InferenceBackend = MockInferenceBackend()
+    ) {
+        self.models = models
+        self.backendResult = .success(backend)
+    }
+
+    init(models: [String] = [], backendError: Error = ProviderError.unavailable) {
+        self.models = models
+        self.backendResult = .failure(backendError)
+    }
+
+    func listModels() async throws -> [String] {
+        listModelsCallCount += 1
+        return models
+    }
+
+    func backend(for request: ServerBackendRequest) async throws -> any InferenceBackend {
+        backendRequests.append(request)
+        return try backendResult.get()
+    }
+}
+
+final class FakeChatCompletionsAdapter: ChatCompletionsAdapter, @unchecked Sendable {
+    var result: Result<ChatCompletionResponse, Error>
+    var chunkResult: Result<[ChatCompletionChunk], Error>
+    private(set) var requests: [ChatCompletionRequest] = []
+
+    init(response: ChatCompletionResponse = ChatCompletionResponse(model: "fake-model", content: "fake response")) {
+        self.result = .success(response)
+        self.chunkResult = .success([
+            ChatCompletionChunk(
+                id: response.id,
+                created: response.created,
+                model: response.model,
+                choices: [ChatCompletionChunkChoice(index: 0, delta: ChatCompletionDelta(content: response.content))]
+            )
+        ])
+    }
+
+    init(error: Error) {
+        self.result = .failure(error)
+        self.chunkResult = .failure(error)
+    }
+
+    func generationConfig(for request: ChatCompletionRequest) throws -> GenerationConfig {
+        GenerationConfig()
+    }
+
+    func response(
+        for request: ChatCompletionRequest,
+        using backend: any InferenceBackend
+    ) async throws -> ChatCompletionResponse {
+        requests.append(request)
+        return try result.get()
+    }
+
+    func chunks(
+        for request: ChatCompletionRequest,
+        using backend: any InferenceBackend
+    ) throws -> AsyncThrowingStream<ChatCompletionChunk, Error> {
+        requests.append(request)
+        let chunkResult = self.chunkResult
+        return AsyncThrowingStream { continuation in
+            switch chunkResult {
+            case .success(let chunks):
+                for chunk in chunks {
+                    continuation.yield(chunk)
+                }
+                continuation.finish()
+            case .failure(let error):
+                continuation.finish(throwing: error)
+            }
+        }
+    }
+}
+
+enum ServerTestBackendFactory {
+    static func loadedMock(tokens: [String] = ["Hello", " world"]) -> MockInferenceBackend {
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = tokens
+        return backend
+    }
+}


### PR DESCRIPTION
## Summary

Adds an optional **BaseChatServer** executable stack that exposes a local OpenAI-compatible HTTP API backed by any registered BCK inference backend (Ollama, Llama, MLX, Foundation, cloud SaaS).

New targets:
- **`BaseChatServerCore`** — `ServerApp`, `ChatCompletionsAdapter`, `AsyncSemaphore`, `ServerConfiguration`, `ServerMetrics`, `ServerHTTPResponses`, `ServerError`, `ServerBackendProvider` protocol
- **`BaseChatServerBackends`** — `TraitAwareServerBackendProvider` (actor, caches loaded backend), `ServerCommandOptions` (ArgumentParser)
- **`BaseChatServer`** — thin executable entry point

Routes exposed:
- `GET  /health` — liveness probe (always unauthenticated)
- `GET  /v1/models` — lists available model
- `POST /v1/chat/completions` — non-streaming and SSE streaming; OpenAI wire format
- `GET  /metrics` — request counts, in-flight generations, token totals (requires auth when `--api-key` is set)

Feature highlights:
- **Bearer auth** — constant-time token comparison; `--api-key` flag optional
- **CORS** — configurable origin or `*` via `--unsafe-cors`; preflight (`OPTIONS`) handled
- **SSE streaming** — chunked `text/event-stream`; `[DONE]` frame; thinking-token deltas mapped to `reasoning_content`
- **Concurrency gate** — `AsyncSemaphore` limits simultaneous generations; `--parallel N` flag; cancellation-safe (waiter drain on `Task` cancellation)
- **Trait-aware backend selection** — `--backend ollama|llama|mlx|foundation`; lazy load + per-process cache (no re-init of `LlamaBackend`)
- **Tool call support** — `tools`, `tool_choice` (object and string variants), `tool_calls` in response
- **Error safety** — internal errors never leak `String(describing:)` to callers; all 4xx/5xx responses are `application/json` `ChatCompletionErrorEnvelope`

Closes #744.

## Security notes

- Bearer token comparison uses zip+XOR accumulation (constant-time)
- `/metrics` requires auth when `--api-key` is configured
- `--cors-origin` validated for scheme+host well-formedness and CRLF rejection before reflection into headers
- Error responses sanitized through `ChatCompletionErrorEnvelope.from(_:)` — no internal paths or struct values exposed

## Tests

54 server tests, all CI-safe (in-process Hummingbird router, no network, no real models):

```bash
scripts/test.sh --filter BaseChatServerTests --disable-default-traits --skip-update
swift build --product BaseChatServer --disable-default-traits
```

Test coverage includes: auth (valid/invalid/missing token, all protected routes), SSE chunk decoding, semaphore concurrency (streaming + non-streaming), backend-failure → 500, malformed request body, `toolChoice` string variants, multi-turn prompt assembly, non-streaming golden round-trip, `--parallel 0` and invalid CORS rejection, `AsyncSemaphore` unit tests (zero-init clamp, signal-unblocks-waiter, concurrent-waiters-bounded).