### PR TITLE
feat(mcp): add v1.1 follow-up polish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,9 @@ jobs:
       # - Run `swift test --filter BaseChatBackendsTests --traits MLX,Llama` on
       #   Apple Silicon for MLX/llama.cpp paths.
       # - Run `swift test --filter BaseChatE2ETests` on physical hardware.
+      # - MCP E2E stays out of per-PR CI; nightly-slow-tests runs the
+      #   RUN_MCP_E2E-gated streamable-HTTP smoke with a narrow filter so
+      #   npx/network-backed subprocess tests remain local-only.
 
       # --skip-update: Package.resolved pins every dependency, so the graph is
       # already up to date (the Verify step re-confirms this when deps changed).

--- a/.github/workflows/nightly-slow-tests.yml
+++ b/.github/workflows/nightly-slow-tests.yml
@@ -4,9 +4,12 @@ name: Nightly slow tests
 #  - LargeSessionListPerformanceTests — XCTMeasure perf baselines (~65s)
 #  - IntegratedStreamingPerformanceTests — full pipeline TTFT/cadence/E2E baselines (~20s)
 #  - TrafficBoundaryAuditTest — source-tree boundary audit (~50s)
+#  - BaseChatMCPE2ESmokeTests — explicitly gated MCP streamable-HTTP E2E smoke
 # These are gated by RUN_SLOW_TESTS=1 in their setUp; the main `ci.yml`
 # job leaves that unset so they skip there. Local `swift test` runs them
-# unconditionally (CI is also unset locally).
+# unconditionally (CI is also unset locally). MCP E2E remains separately gated
+# by RUN_MCP_E2E=1 and a narrow smoke filter so npx/network subprocess tests do
+# not run here.
 
 on:
   schedule:
@@ -71,6 +74,13 @@ jobs:
           BASECHAT_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-traffic-boundary-audit.log
         run: scripts/test.sh --filter "BaseChatInferenceTests.TrafficBoundaryAuditTest" --disable-default-traits --skip-update --min-passed 1
 
+      - name: Test — MCP streamable HTTP E2E smoke
+        id: test-mcp-e2e-smoke
+        env:
+          RUN_MCP_E2E: "1"
+          BASECHAT_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-mcp-e2e-smoke.log
+        run: scripts/test.sh --filter "BaseChatMCPE2ESmokeTests" --disable-default-traits --skip-update --min-passed 1
+
       - name: Stage test diagnostics
         # Mirrors ci.yml: each step writes to a unique workspace log path so
         # diagnostics from earlier failures are preserved.
@@ -79,6 +89,7 @@ jobs:
           LARGE_SESSION_LIST_FAILED: ${{ steps.test-large-session-list.outcome == 'failure' }}
           INTEGRATED_STREAMING_FAILED: ${{ steps.test-integrated-streaming.outcome == 'failure' }}
           TRAFFIC_BOUNDARY_AUDIT_FAILED: ${{ steps.test-traffic-boundary-audit.outcome == 'failure' }}
+          MCP_E2E_SMOKE_FAILED: ${{ steps.test-mcp-e2e-smoke.outcome == 'failure' }}
         run: |
           mkdir -p test-diagnostics
           {
@@ -88,6 +99,7 @@ jobs:
             echo "large-session-list-failed=${LARGE_SESSION_LIST_FAILED}"
             echo "integrated-streaming-failed=${INTEGRATED_STREAMING_FAILED}"
             echo "traffic-boundary-audit-failed=${TRAFFIC_BOUNDARY_AUDIT_FAILED}"
+            echo "mcp-e2e-smoke-failed=${MCP_E2E_SMOKE_FAILED}"
           } > test-diagnostics/failed-steps.txt
 
       - name: Upload test diagnostics on failure

--- a/Example/BaseChatDemo/ConnectedServicesView.swift
+++ b/Example/BaseChatDemo/ConnectedServicesView.swift
@@ -210,11 +210,7 @@ struct ConnectedServiceSnapshot {
             }
         }()
         if isConnected {
-            // "X of Y enabled" when the cap is biting; otherwise just "X tools".
-            if foundationModelsCapActive, enabledToolCount < toolCount {
-                return "\(stateText) · \(enabledToolCount) of \(toolCount) tools enabled"
-            }
-            return "\(stateText) · \(toolCount) tools"
+            return "\(stateText) · \(enabledToolCount) of \(toolCount) tools enabled"
         }
         return stateText
     }

--- a/Example/BaseChatDemo/MCP/DemoMCPCoordinator.swift
+++ b/Example/BaseChatDemo/MCP/DemoMCPCoordinator.swift
@@ -147,6 +147,7 @@ final class DemoMCPCoordinator {
                         snapshot.authorizationRequest = nil
                     }
                 }
+                await self.refreshAdvertisedToolNames(foundationActive: foundationActive)
             } catch let mcpError as MCPError {
                 await MainActor.run {
                     self.updateSnapshot(descriptor.id) { snapshot in
@@ -191,6 +192,7 @@ final class DemoMCPCoordinator {
                     snapshot.authorizationRequest = nil
                 }
             }
+            await self.refreshAdvertisedToolNames(foundationActive: self.isFoundationModelsActive())
         }
     }
 
@@ -274,6 +276,7 @@ final class DemoMCPCoordinator {
                 snapshot.isConnected = true
             }
         }
+        await refreshAdvertisedToolNames(foundationActive: foundationActive)
     }
 
     private func enabledCount(
@@ -283,6 +286,33 @@ final class DemoMCPCoordinator {
     ) async -> Int {
         guard foundationActive else { return totalCount }
         return await source.foundationModelsEnabledNames().count
+    }
+
+    private func refreshAdvertisedToolNames(foundationActive: Bool) async {
+        guard foundationActive else {
+            toolRegistry.advertisedToolNames = nil
+            return
+        }
+
+        var allMCPToolNames: Set<String> = []
+        var enabledMCPToolNames: Set<String> = []
+        for source in sourcesByID.values {
+            let currentNames = await source.currentToolNames()
+            allMCPToolNames.formUnion(currentNames.map { $0.lowercased() })
+            let enabledNames = await source.foundationModelsEnabledNames()
+            enabledMCPToolNames.formUnion(enabledNames.map { $0.lowercased() })
+        }
+
+        guard allMCPToolNames.isEmpty == false else {
+            toolRegistry.advertisedToolNames = nil
+            return
+        }
+
+        let nonMCPToolNames = toolRegistry.definitions
+            .map(\.name)
+            .filter { allMCPToolNames.contains($0.lowercased()) == false }
+            .map { $0.lowercased() }
+        toolRegistry.advertisedToolNames = Set(nonMCPToolNames).union(enabledMCPToolNames)
     }
 
     /// Re-runs the per-server enabled-count projection using the current

--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ If you already depend on `BaseChatBackends`, the same data is also available via
 Quick checks:
 
 ```bash
-swift test --filter BaseChatMCPTests --disable-default-traits
-swift test --filter BaseChatMCPTests --disable-default-traits --traits MCPBuiltinCatalog
+scripts/test.sh --filter BaseChatMCPTests --disable-default-traits --skip-update
+scripts/test.sh --filter BaseChatMCPTests --disable-default-traits --traits MCPBuiltinCatalog --skip-update
 ```
 
 ### 2.2 BaseChatServer

--- a/Sources/BaseChatInference/Models/ToolTypes.swift
+++ b/Sources/BaseChatInference/Models/ToolTypes.swift
@@ -208,7 +208,7 @@ public struct ToolResult: Sendable, Codable, Equatable, Hashable {
     ///   failure — no registered executor matched the call name, so the tool
     ///   never ran. `.notFound` is a *runtime* failure — the executor ran but the
     ///   resource it looked for (file, record, URL) did not exist.
-    public enum ErrorKind: String, Sendable, Codable, Equatable, Hashable {
+    public enum ErrorKind: String, Sendable, Codable, Equatable, Hashable, CaseIterable {
         /// Arguments did not parse as JSON or failed schema validation.
         /// Indicates a model-side formatting error; feeding the error back lets
         /// the model self-correct on the next turn.
@@ -238,6 +238,33 @@ public struct ToolResult: Sendable, Codable, Equatable, Hashable {
         /// No registered executor matched the call name — dispatch failed before execution.
         /// Distinct from ``notFound``, which fires inside a running executor.
         case unknownTool
+
+        /// User-facing, localizable summary for presentation surfaces.
+        ///
+        /// This deliberately does not replace ``rawValue``: raw values remain
+        /// the stable wire/persistence vocabulary, while this string is for UI.
+        public var localizedDescription: String {
+            switch self {
+            case .invalidArguments:
+                return String(localized: "tool.error.invalidArguments", defaultValue: "The tool couldn't understand those details.")
+            case .permissionDenied:
+                return String(localized: "tool.error.permissionDenied", defaultValue: "Permission is required to use this tool.")
+            case .notFound:
+                return String(localized: "tool.error.notFound", defaultValue: "The requested item couldn't be found.")
+            case .timeout:
+                return String(localized: "tool.error.timeout", defaultValue: "The tool took too long to respond.")
+            case .rateLimited:
+                return String(localized: "tool.error.rateLimited", defaultValue: "The tool is temporarily rate limited.")
+            case .cancelled:
+                return String(localized: "tool.error.cancelled", defaultValue: "The tool call was cancelled.")
+            case .transient:
+                return String(localized: "tool.error.transient", defaultValue: "The tool hit a temporary problem.")
+            case .permanent:
+                return String(localized: "tool.error.permanent", defaultValue: "The tool couldn't complete this request.")
+            case .unknownTool:
+                return String(localized: "tool.error.unknownTool", defaultValue: "This tool isn't available.")
+            }
+        }
     }
 
     /// The ``ToolCall/id`` this result corresponds to.

--- a/Sources/BaseChatInference/Services/ToolRegistry.swift
+++ b/Sources/BaseChatInference/Services/ToolRegistry.swift
@@ -141,6 +141,16 @@ public protocol JSONSchemaValidating: Sendable {
     /// matching the reentrancy contract on the registry itself.
     public var outputPolicy: ToolOutputPolicy = ToolOutputPolicy()
 
+    /// Optional allow-list for tools that should be advertised to the active
+    /// backend. Dispatch remains available for every registered tool; this
+    /// only narrows the definitions passed in `GenerationConfig.tools`.
+    public var advertisedToolNames: Set<String>? {
+        get { advertisedToolNameKeys }
+        set { advertisedToolNameKeys = newValue.map { Set($0.map { $0.lowercased() }) } }
+    }
+
+    private var advertisedToolNameKeys: Set<String>?
+
     // MARK: - Init
 
     /// Creates a registry pre-populated with the supplied tools.
@@ -211,15 +221,37 @@ public protocol JSONSchemaValidating: Sendable {
     /// For local backends (3B–8B instruct models), keep this list at or below
     /// 5 entries — see README "Tool Calling" section.
     public var definitions: [ToolDefinition] {
-        let result = tools.values
-            .map(\.definition)
-            .sorted { $0.name < $1.name }
+        let result = sortedDefinitions()
         #if DEBUG
         if result.count > 5 {
             print("[BaseChatKit] ⚠️ \(result.count) tools in this request. Local backends (3B–8B) degrade beyond ~5 — see README Tool Calling section.")
         }
         #endif
         return result
+    }
+
+    /// Registered tool definitions after applying ``advertisedToolNames``.
+    ///
+    /// Use this for model-facing `GenerationConfig.tools` when a host needs to
+    /// hide a subset for a backend-specific policy while keeping dispatch
+    /// available for in-flight or previously-advertised calls.
+    public var advertisedDefinitions: [ToolDefinition] {
+        let allDefinitions = sortedDefinitions()
+        let result = advertisedToolNameKeys.map { keys in
+            allDefinitions.filter { keys.contains($0.name.lowercased()) }
+        } ?? allDefinitions
+        #if DEBUG
+        if result.count > 5 {
+            print("[BaseChatKit] ⚠️ \(result.count) tools in this request. Local backends (3B–8B) degrade beyond ~5 — see README Tool Calling section.")
+        }
+        #endif
+        return result
+    }
+
+    private func sortedDefinitions() -> [ToolDefinition] {
+        tools.values
+            .map(\.definition)
+            .sorted { $0.name < $1.name }
     }
 
     /// Returns the registered executor for `toolName` (case-insensitive),

--- a/Sources/BaseChatMCP/MCPToolSource.swift
+++ b/Sources/BaseChatMCP/MCPToolSource.swift
@@ -59,9 +59,10 @@ public final class MCPToolSource: @unchecked Sendable {
     /// Returns the currently-registered tools whose JSON Schemas are compatible
     /// with Apple's Foundation Models tool surface.
     ///
-    /// Foundation Models rejects schemas that use `oneOf`, `$ref`, or whose
+    /// Foundation Models rejects schemas that use composition keywords
+    /// (`oneOf`, `anyOf`, `allOf`), `$ref`, nullable type unions, or whose
     /// nesting exceeds a small depth. This query returns the namespaced names
-    /// of tools whose schemas pass all three checks, sorted alphabetically.
+    /// of tools whose schemas pass those conservative checks, sorted alphabetically.
     ///
     /// "Deep nesting" is defined as the maximum depth of nested `object`
     /// (`properties`) or `array` (`items`) descents within the schema.
@@ -81,6 +82,12 @@ public final class MCPToolSource: @unchecked Sendable {
             .filter { isFoundationModelsCompatible($0.inputSchema, maxDepth: maxDepth) }
             .map(\.namespacedName)
             .sorted()
+    }
+
+    /// Alias for ``foundationModelsCompatibleNames(maxDepth:)`` using the
+    /// issue-tracker wording: names compatible under `maxDepth`.
+    public func foundationModelsCompatibleNames(under maxDepth: Int) async -> [String] {
+        await foundationModelsCompatibleNames(maxDepth: maxDepth)
     }
 
     /// Returns the subset of currently-registered tools that should be exposed
@@ -545,8 +552,9 @@ private func normalizedNamespace(_ namespace: String?) -> String? {
 
 // MARK: - Foundation Models schema compatibility
 
-/// Returns `true` when `schema` contains no `oneOf`, no `$ref`, and no nested
-/// `object`/`array` chain deeper than `maxDepth` levels.
+/// Returns `true` when `schema` avoids Foundation Models-incompatible JSON
+/// Schema constructs and no nested `object`/`array` chain is deeper than
+/// `maxDepth` levels.
 ///
 /// Internal so tests in the same module can exercise edge cases directly.
 internal func isFoundationModelsCompatible(_ schema: JSONSchemaValue, maxDepth: Int) -> Bool {
@@ -560,19 +568,19 @@ internal func isFoundationModelsCompatible(_ schema: JSONSchemaValue, maxDepth: 
 ///
 /// **Strategy** (PR #797 review fix): the walker visits *every* JSON Schema
 /// keyword that can carry a subschema, not just `properties`/`items`, so the
-/// rejection rules (`oneOf`, `anyOf`, `$ref`) are evaluated at every nesting
-/// level the author can construct — including those hidden inside composition
-/// keywords like `allOf`, `not`, `additionalProperties`, or `$defs`.
+/// rejection rules (`oneOf`, `anyOf`, `allOf`, `$ref`, and type unions) are
+/// evaluated at every nesting level the author can construct — including those
+/// hidden inside `not`, `additionalProperties`, or `$defs`.
 ///
 /// Two flavours of recursion:
 /// - **Depth-advancing** edges (`properties`, `items`, `prefixItems`,
 ///   `additionalProperties`, `patternProperties`, `unevaluatedProperties`,
 ///   `unevaluatedItems`, `contains`, `propertyNames`): each edge counts as one
 ///   level of user-facing object/array nesting and contributes to `maxDepth`.
-/// - **Transparent** composition edges (`allOf`, `not`, `if`/`then`/`else`,
-///   `$defs`, `definitions`, `dependentSchemas`): these compose constraints
-///   over the *current* node, so they don't add user-facing depth — but we
-///   still recurse so a nested `oneOf` can't smuggle past the filter.
+/// - **Transparent** composition edges (`not`, `if`/`then`/`else`, `$defs`,
+///   `definitions`, `dependentSchemas`): these compose constraints over the
+///   *current* node, so they don't add user-facing depth — but we still recurse
+///   so a nested unsupported keyword can't smuggle past the filter.
 private func schemaDepthIfCompatible(
     _ schema: JSONSchemaValue,
     currentDepth: Int,
@@ -588,6 +596,10 @@ private func schemaDepthIfCompatible(
         // anyOf is also not in Apple's accepted vocabulary; reject it for symmetry
         // since it's structurally the same hazard as oneOf.
         if object["anyOf"] != nil { return nil }
+        if object["allOf"] != nil { return nil }
+        // JSON Schema encodes nullable unions as `type: ["string", "null"]`.
+        // Foundation Models expects a single concrete type, so reject any union.
+        if case .array? = object["type"] { return nil }
 
         var deepest = currentDepth
 
@@ -650,14 +662,6 @@ private func schemaDepthIfCompatible(
         }
 
         // --- Transparent composition edges --------------------------------
-        // `allOf: [schema, ...]` — composes constraints over THIS node, no depth bump.
-        if case .array(let allOf)? = object["allOf"] {
-            for child in allOf {
-                guard let d = schemaDepthIfCompatible(child, currentDepth: currentDepth, maxDepth: maxDepth)
-                else { return nil }
-                deepest = max(deepest, d)
-            }
-        }
         // `not: schema`, `if`/`then`/`else: schema` — single composition schemas.
         for key in ["not", "if", "then", "else"] {
             if let value = object[key], case .object = value {

--- a/Sources/BaseChatUI/ViewModels/GenerationCoordinator.swift
+++ b/Sources/BaseChatUI/ViewModels/GenerationCoordinator.swift
@@ -226,7 +226,7 @@ final class GenerationCoordinator {
             // them. Without this, tools registered on `InferenceService.toolRegistry`
             // are never advertised to the backend and the model — correctly —
             // refuses to call something it doesn't know about.
-            let registeredTools = inferenceService.toolRegistry?.definitions ?? []
+            let registeredTools = inferenceService.toolRegistry?.advertisedDefinitions ?? []
 
             let (token, stream) = try inferenceService.enqueue(
                 structuredMessages: history,

--- a/Sources/BaseChatUI/Views/Chat/ToolErrorPresentation.swift
+++ b/Sources/BaseChatUI/Views/Chat/ToolErrorPresentation.swift
@@ -1,0 +1,64 @@
+import Foundation
+import BaseChatInference
+
+/// UI-only presentation metadata for failed tool results.
+public struct ToolErrorPresentation: Sendable, Equatable {
+    public struct ReauthenticationCTA: Sendable, Equatable {
+        public let actionID: String
+        public let label: String
+        public let message: String
+        public let serviceName: String
+
+        public init(actionID: String, label: String, message: String, serviceName: String) {
+            self.actionID = actionID
+            self.label = label
+            self.message = message
+            self.serviceName = serviceName
+        }
+    }
+
+    public let summary: String
+    public let reauthenticationCTA: ReauthenticationCTA?
+
+    public init(errorKind: ToolResult.ErrorKind?, toolName: String?) {
+        guard let errorKind else {
+            self.summary = String(localized: "tool.error.generic", defaultValue: "The tool call failed.")
+            self.reauthenticationCTA = nil
+            return
+        }
+
+        self.summary = errorKind.localizedDescription
+        if errorKind == .permissionDenied, let toolName, toolName.isEmpty == false {
+            let serviceName = Self.serviceName(from: toolName)
+            self.reauthenticationCTA = ReauthenticationCTA(
+                actionID: "mcp.reauthenticate.\(Self.serviceKey(from: toolName))",
+                label: String(localized: "tool.error.permissionDenied.signIn", defaultValue: "Tap to sign in"),
+                message: String(
+                    localized: "tool.error.permissionDenied.connected",
+                    defaultValue: "\(serviceName) isn't connected. Tap to sign in."
+                ),
+                serviceName: serviceName
+            )
+        } else {
+            self.reauthenticationCTA = nil
+        }
+    }
+
+    private static func serviceKey(from toolName: String) -> String {
+        if let namespaceRange = toolName.range(of: "__") {
+            return String(toolName[..<namespaceRange.lowerBound])
+        }
+        return toolName
+    }
+
+    private static func serviceName(from toolName: String) -> String {
+        let key = serviceKey(from: toolName)
+        return key
+            .split(whereSeparator: { $0 == "_" || $0 == "-" || $0 == "." })
+            .map { word in
+                let lower = word.lowercased()
+                return lower.prefix(1).uppercased() + lower.dropFirst()
+            }
+            .joined(separator: " ")
+    }
+}

--- a/Sources/BaseChatUI/Views/Chat/ToolInvocationView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ToolInvocationView.swift
@@ -63,18 +63,24 @@ public struct ToolInvocationView: View {
     /// Only read when ``state`` is ``State/pendingApproval``.
     public var onDeny: ((String?) -> Void)?
 
+    /// Invoked when the user taps a permission-denied re-authentication CTA.
+    /// Only shown for failed results whose presentation metadata includes a CTA.
+    public var onReauthenticate: ((ToolErrorPresentation.ReauthenticationCTA) -> Void)?
+
     public init(
         part: MessagePart,
         state: State,
         pairedResult: ToolResult? = nil,
         onApprove: (() -> Void)? = nil,
-        onDeny: ((String?) -> Void)? = nil
+        onDeny: ((String?) -> Void)? = nil,
+        onReauthenticate: ((ToolErrorPresentation.ReauthenticationCTA) -> Void)? = nil
     ) {
         self.part = part
         self.state = state
         self.pairedResult = pairedResult
         self.onApprove = onApprove
         self.onDeny = onDeny
+        self.onReauthenticate = onReauthenticate
     }
 
     public var body: some View {
@@ -185,7 +191,7 @@ public struct ToolInvocationView: View {
 
     private func failedView(call: ToolCall?, result: ToolResult?) -> some View {
         let toolName = call?.toolName ?? "tool"
-        let kindLabel = result?.errorKind.map { $0.rawValue } ?? "failed"
+        let presentation = ToolErrorPresentation(errorKind: result?.errorKind, toolName: call?.toolName)
         return DisclosureGroup {
             VStack(alignment: .leading, spacing: 6) {
                 if let call {
@@ -200,9 +206,20 @@ public struct ToolInvocationView: View {
                     Text("Error")
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
+                    Text(presentation.summary)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
                     Text(result.content)
                         .font(.caption.monospaced())
                         .textSelection(.enabled)
+                }
+                if let cta = presentation.reauthenticationCTA {
+                    Button(cta.message) {
+                        onReauthenticate?(cta)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .accessibilityIdentifier("tool-error-reauth-button")
                 }
             }
             .padding(.top, 4)
@@ -213,7 +230,7 @@ public struct ToolInvocationView: View {
                 Text(toolName)
                     .font(.caption.monospaced())
                     .foregroundStyle(.secondary)
-                Text(kindLabel)
+                Text(presentation.summary)
                     .font(.caption2)
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)

--- a/TESTING.md
+++ b/TESTING.md
@@ -83,24 +83,21 @@ UI automation tests that launch the real Example app in a simulator and drive it
 ### Running tests
 
 ```bash
-# CI-safe local gate (no hardware required). Keep BaseChatMCPTests in this
-# batch; its network-facing coverage uses MockURLProtocol and does not opt in
-# to BaseChatMCPE2ETests.
+# CI-safe local gate (no hardware required). Two-invocation shape mirrors CI —
+# see CLAUDE.md Pre-push checklist for the rationale.
 scripts/test.sh --filter BaseChatCoreTests --filter BaseChatRuntimeTests \
   --filter BaseChatPersistenceSwiftDataTests --filter BaseChatUITests \
   --filter BaseChatUIModelManagementTests --filter BaseChatMCPTests \
-  --filter BaseChatBackendsTests --filter BaseChatTestSupportTests \
-  --filter BaseChatAppIntentsTests --disable-default-traits --skip-update
+  --filter BaseChatBackendsTests --filter BaseChatInferenceTests \
+  --filter BaseChatTestSupportTests --filter BaseChatAppIntentsTests \
+  --filter BaseChatServerTests --disable-default-traits --skip-update
 
-scripts/test.sh --filter BaseChatInferenceTests \
-  --disable-default-traits --skip-update --parallel
-
-# Swift Testing runs in a separate process to avoid mixed-runner crashes.
+# Swift Testing runs in a separate process to avoid mixed-runner crashes (#681).
+# Do NOT add --parallel to BaseChatInferenceTests — the UserDefaults.standard
+# race in test_autoSelectFirstRunModel_* and download-tests legacy-key reads
+# causes non-deterministic failures (issue #910).
 scripts/test.sh --filter BaseChatInferenceSwiftTestingTests \
   --disable-default-traits --skip-update
-
-# Targeted MCP CI-safe slice.
-scripts/test.sh --filter BaseChatMCPTests --disable-default-traits --skip-update
 
 # Apple Silicon only
 swift test --filter BaseChatBackendsTests --traits MLX,Llama

--- a/TESTING.md
+++ b/TESTING.md
@@ -72,7 +72,7 @@ UI automation tests that launch the real Example app in a simulator and drive it
 | `BaseChatInferenceSwiftTestingTests` | Unit | Yes | None | Swift Testing |
 | `BaseChatUITests` | Integration | Yes | None | XCTest |
 | `BaseChatMCPTests` | Unit, Integration | Yes | None | XCTest |
-| `BaseChatMCPE2ETests` | E2E (subprocess smoke) | No (requires `RUN_MCP_E2E=1` and `npx`) | npx + network | XCTest |
+| `BaseChatMCPE2ETests` | E2E (explicit opt-in smoke) | Nightly smoke only (requires `RUN_MCP_E2E=1`) | `EverythingServerSmokeTests` also needs npx + network | XCTest |
 | `BaseChatServerTests` | Unit, Integration | Yes | None | XCTest |
 | `BaseChatBackendsTests` | Unit, E2E | Partial | MLX/Llama need Apple Silicon | Mixed |
 | `BaseChatTestSupportTests` | Unit | Yes | None | XCTest |
@@ -83,15 +83,24 @@ UI automation tests that launch the real Example app in a simulator and drive it
 ### Running tests
 
 ```bash
-# CI-safe (no hardware required)
-swift test --filter BaseChatCoreTests --disable-default-traits
-swift test --filter BaseChatInferenceTests --disable-default-traits
-swift test --filter BaseChatInferenceSwiftTestingTests --disable-default-traits
-swift test --filter BaseChatUITests --disable-default-traits
-swift test --filter BaseChatMCPTests --disable-default-traits
-swift test --filter BaseChatServerTests --disable-default-traits
-swift test --filter BaseChatBackendsTests --disable-default-traits   # cloud/SSE tests only
-swift test --filter BaseChatTestSupportTests --disable-default-traits
+# CI-safe local gate (no hardware required). Keep BaseChatMCPTests in this
+# batch; its network-facing coverage uses MockURLProtocol and does not opt in
+# to BaseChatMCPE2ETests.
+scripts/test.sh --filter BaseChatCoreTests --filter BaseChatRuntimeTests \
+  --filter BaseChatPersistenceSwiftDataTests --filter BaseChatUITests \
+  --filter BaseChatUIModelManagementTests --filter BaseChatMCPTests \
+  --filter BaseChatBackendsTests --filter BaseChatTestSupportTests \
+  --filter BaseChatAppIntentsTests --disable-default-traits --skip-update
+
+scripts/test.sh --filter BaseChatInferenceTests \
+  --disable-default-traits --skip-update --parallel
+
+# Swift Testing runs in a separate process to avoid mixed-runner crashes.
+scripts/test.sh --filter BaseChatInferenceSwiftTestingTests \
+  --disable-default-traits --skip-update
+
+# Targeted MCP CI-safe slice.
+scripts/test.sh --filter BaseChatMCPTests --disable-default-traits --skip-update
 
 # Apple Silicon only
 swift test --filter BaseChatBackendsTests --traits MLX,Llama
@@ -100,12 +109,17 @@ swift test --filter BaseChatBackendsTests --traits MLX,Llama
 swift test --filter BaseChatE2ETests --disable-default-traits
 
 # MCP built-in catalog descriptors (trait-gated metadata tests)
-swift test --filter BaseChatMCPTests --disable-default-traits --traits MCPBuiltinCatalog
+scripts/test.sh --filter BaseChatMCPTests --disable-default-traits --traits MCPBuiltinCatalog --skip-update
 
-# MCP end-to-end smoke tests against a real subprocess server (explicit opt-in only).
-# Requires npx on PATH and network access to download @modelcontextprotocol/server-everything.
-# The EverythingServerSmokeTests class skips automatically unless RUN_MCP_E2E=1.
-RUN_MCP_E2E=1 swift test --filter BaseChatMCPE2ETests --disable-default-traits
+# MCP end-to-end smoke tests are explicit opt-in only.
+# Nightly runs the streamable-HTTP smoke; keep the filter narrow so the
+# npx/network-backed EverythingServerSmokeTests suite does not run by default.
+RUN_MCP_E2E=1 scripts/test.sh --filter BaseChatMCPE2ESmokeTests \
+  --disable-default-traits --skip-update --min-passed 1
+
+# Full subprocess E2E, local only: requires npx on PATH and network access to
+# download @modelcontextprotocol/server-everything.
+RUN_MCP_E2E=1 swift test --filter EverythingServerSmokeTests --disable-default-traits
 
 # Xcode-only — real MLX model inference (requires local MLX fixture; see below)
 # Cannot run via swift test; MLX Metal shaders are only compiled by Xcode.

--- a/Tests/BaseChatInferenceTests/ToolRegistryTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolRegistryTests.swift
@@ -124,6 +124,24 @@ final class ToolRegistryTests: XCTestCase {
         XCTAssertEqual(names, ["alpha", "mango", "zebra"])
     }
 
+    func test_advertisedDefinitions_applyCaseInsensitiveAllowListWithoutBlockingDispatch() async {
+        let registry = ToolRegistry()
+        registry.register(makeWeatherExecutor(name: "mcp_alpha"))
+        registry.register(makeWeatherExecutor(name: "app_status"))
+        registry.register(makeWeatherExecutor(name: "mcp_zebra"))
+
+        registry.advertisedToolNames = ["MCP_ALPHA", "app_status"]
+
+        XCTAssertEqual(registry.advertisedDefinitions.map(\.name), ["app_status", "mcp_alpha"])
+        XCTAssertEqual(registry.definitions.map(\.name), ["app_status", "mcp_alpha", "mcp_zebra"])
+
+        let hiddenResult = await registry.dispatch(
+            ToolCall(id: "call-hidden", toolName: "mcp_zebra", arguments: #"{"city":"Paris"}"#)
+        )
+        XCTAssertEqual(hiddenResult.errorKind, nil)
+        XCTAssertTrue(hiddenResult.content.contains("Sunny in Paris"))
+    }
+
     func test_register_override_replacesExistingTool() async {
         let registry = ToolRegistry()
 

--- a/Tests/BaseChatInferenceTests/ToolResultErrorKindTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolResultErrorKindTests.swift
@@ -25,6 +25,26 @@ final class ToolResultErrorKindTests: XCTestCase {
         }
     }
 
+    func test_allErrorKinds_haveLocalizedUserFacingDescriptions() {
+        let expected: [ToolResult.ErrorKind: String] = [
+            .invalidArguments: "The tool couldn't understand those details.",
+            .permissionDenied: "Permission is required to use this tool.",
+            .notFound: "The requested item couldn't be found.",
+            .timeout: "The tool took too long to respond.",
+            .rateLimited: "The tool is temporarily rate limited.",
+            .cancelled: "The tool call was cancelled.",
+            .transient: "The tool hit a temporary problem.",
+            .permanent: "The tool couldn't complete this request.",
+            .unknownTool: "This tool isn't available.",
+        ]
+
+        XCTAssertEqual(ToolResult.ErrorKind.allCases.count, 9)
+        for kind in ToolResult.ErrorKind.allCases {
+            XCTAssertEqual(kind.localizedDescription, expected[kind], "missing localized description for \(kind.rawValue)")
+            XCTAssertNotEqual(kind.localizedDescription, kind.rawValue)
+        }
+    }
+
     func test_successResult_encodesWithoutErrorKind() throws {
         let result = ToolResult(callId: "c", content: "ok")
         let encoded = try JSONEncoder().encode(result)

--- a/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
+++ b/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
@@ -220,7 +220,7 @@ BaseChatUI/Views/Chat/ExportButton.swift:try? FileManager.default.removeItem(at:
 # False positive: `toolRegistry?` optional chain contains the substring
 # `try?` inside `Regis-try?`. No `try?` call site is present on this
 # line; the audit's substring scan is not AST-aware.
-BaseChatUI/ViewModels/GenerationCoordinator.swift:let registeredTools = inferenceService.toolRegistry?.definitions ?? []
+BaseChatUI/ViewModels/GenerationCoordinator.swift:let registeredTools = inferenceService.toolRegistry?.advertisedDefinitions ?? []
 
 # ---------------------------------------------------------------------------
 # BaseChatTestSupport — test-only helpers, not production paths.

--- a/Tests/BaseChatMCPTests/MCPFoundationModelsCompatibilityTests.swift
+++ b/Tests/BaseChatMCPTests/MCPFoundationModelsCompatibilityTests.swift
@@ -44,11 +44,34 @@ final class MCPFoundationModelsCompatibilityTests: XCTestCase {
         XCTAssertFalse(isFoundationModelsCompatible(schema, maxDepth: 4))
     }
 
+    func test_allOfSchemaIsRejected() {
+        let schema = JSONSchemaValue.object([
+            "allOf": .array([
+                .object(["type": .string("object")]),
+            ]),
+        ])
+        XCTAssertFalse(isFoundationModelsCompatible(schema, maxDepth: 4))
+    }
+
     func test_refSchemaIsRejected() {
         let schema = JSONSchemaValue.object([
             "type": .string("object"),
             "properties": .object([
                 "user": .object(["$ref": .string("#/definitions/User")]),
+            ]),
+        ])
+        XCTAssertFalse(isFoundationModelsCompatible(schema, maxDepth: 4))
+    }
+
+    func test_nullableTypeUnionIsRejected() {
+        // JSON Schema represents nullable fields as a type union. Foundation
+        // Models accepts a single concrete type, so keep MCP schemas conservative.
+        let schema = JSONSchemaValue.object([
+            "type": .string("object"),
+            "properties": .object([
+                "nickname": .object([
+                    "type": .array([.string("string"), .string("null")]),
+                ]),
             ]),
         ])
         XCTAssertFalse(isFoundationModelsCompatible(schema, maxDepth: 4))
@@ -97,8 +120,9 @@ final class MCPFoundationModelsCompatibilityTests: XCTestCase {
             ]),
         ])
         XCTAssertFalse(isFoundationModelsCompatible(schema, maxDepth: 4))
-        // Sabotage check: removing the `allOf` traversal in the walker would
-        // let this slip through.
+        // Sabotage check: allowing `allOf` traversal instead of rejecting the
+        // keyword outright would let this shape depend on a composition feature
+        // Foundation Models cannot decode.
     }
 
     func test_refHiddenInsideAdditionalPropertiesIsRejected() {
@@ -197,6 +221,17 @@ final class MCPFoundationModelsCompatibilityTests: XCTestCase {
             ("ref_tool", .object([
                 "$ref": .string("#/defs/Foo"),
             ])),
+            ("allof_tool", .object([
+                "allOf": .array([.object(["type": .string("object")])]),
+            ])),
+            ("nullable_tool", .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "value": .object([
+                        "type": .array([.string("string"), .string("null")]),
+                    ]),
+                ]),
+            ])),
             ("flat_array", .object([
                 "type": .string("object"),
                 "properties": .object([
@@ -209,7 +244,7 @@ final class MCPFoundationModelsCompatibilityTests: XCTestCase {
         ])
         try await source.refreshTools()
 
-        let compatible = await source.foundationModelsCompatibleNames(maxDepth: 4)
+        let compatible = await source.foundationModelsCompatibleNames(under: 4)
         XCTAssertEqual(compatible, ["flat_array", "simple"])
     }
 

--- a/Tests/BaseChatUITests/ConsumerRuntimeHarnessTests.swift
+++ b/Tests/BaseChatUITests/ConsumerRuntimeHarnessTests.swift
@@ -196,6 +196,41 @@ final class ConsumerRuntimeHarnessTests: XCTestCase {
         XCTAssertEqual(executor.callCount, 1)
         XCTAssertEqual(harness!.chatViewModel.messages.last?.content, "Tool complete")
     }
+
+    func test_toolRegistry_advertisedDefinitionsLimitBackendConfigWithoutUnregisteringTools() async throws {
+        let backend = MockInferenceBackend(
+            capabilities: BackendCapabilities(
+                supportedParameters: [.temperature, .topP, .repeatPenalty],
+                maxContextTokens: 4096,
+                supportsToolCalling: true
+            )
+        )
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["Done"]
+
+        let visible = CountingExecutor(name: "visible_tool")
+        let hidden = CountingExecutor(name: "hidden_tool")
+        let registry = ToolRegistry()
+        registry.register(visible)
+        registry.register(hidden)
+        registry.advertisedToolNames = ["visible_tool"]
+
+        harness = try ConsumerRuntimeHarness(
+            inferenceService: InferenceService(
+                backend: backend,
+                name: "RuntimeToolMock",
+                toolRegistry: registry
+            )
+        )
+
+        _ = try await harness!.createAndActivateSession(title: "Tool Session")
+        harness!.chatViewModel.inputText = "Check runtime tools"
+
+        await harness!.chatViewModel.sendMessage()
+
+        XCTAssertEqual(backend.lastConfig?.tools.map(\.name), ["visible_tool"])
+        XCTAssertTrue(registry.contains(name: "hidden_tool"))
+    }
 }
 
 @MainActor

--- a/Tests/BaseChatUITests/ToolInvocationViewTests.swift
+++ b/Tests/BaseChatUITests/ToolInvocationViewTests.swift
@@ -92,6 +92,47 @@ final class ToolInvocationViewTests: XCTestCase {
         _ = try view.inspect().find(viewWithAccessibilityIdentifier: "tool-invocation-failed-tool")
     }
 
+    func test_errorPresentation_exposesLocalizedSummariesForEveryKind() {
+        for kind in ToolResult.ErrorKind.allCases {
+            let presentation = ToolErrorPresentation(errorKind: kind, toolName: "docs__search")
+            XCTAssertEqual(presentation.summary, kind.localizedDescription)
+        }
+    }
+
+    func test_permissionDeniedPresentation_exposesReauthenticationCTA() throws {
+        let presentation = ToolErrorPresentation(errorKind: .permissionDenied, toolName: "notion__search")
+
+        let cta = try XCTUnwrap(presentation.reauthenticationCTA)
+        XCTAssertEqual(cta.serviceName, "Notion")
+        XCTAssertEqual(cta.label, "Tap to sign in")
+        XCTAssertEqual(cta.message, "Notion isn't connected. Tap to sign in.")
+        XCTAssertEqual(cta.actionID, "mcp.reauthenticate.notion")
+    }
+
+    func test_nonPermissionDeniedPresentation_hasNoReauthenticationCTA() {
+        let presentation = ToolErrorPresentation(errorKind: .timeout, toolName: "notion__search")
+
+        XCTAssertNil(presentation.reauthenticationCTA)
+    }
+
+    func test_failedPermissionDenied_withPairedCall_rendersReauthenticationCTA() throws {
+        let call = ToolCall(id: "c1", toolName: "notion__search", arguments: "{}")
+        let result = ToolResult(callId: "c1", content: "authorization required", errorKind: .permissionDenied)
+        var tappedCTA: ToolErrorPresentation.ReauthenticationCTA?
+        let view = ToolInvocationView(
+            part: .toolCall(call),
+            state: .failed,
+            pairedResult: result,
+            onReauthenticate: { tappedCTA = $0 }
+        )
+
+        _ = try view.inspect().find(viewWithAccessibilityIdentifier: "tool-error-reauth-button")
+        let button = try view.inspect().find(button: "Notion isn't connected. Tap to sign in.")
+        try button.tap()
+
+        XCTAssertEqual(tappedCTA?.actionID, "mcp.reauthenticate.notion")
+    }
+
     func test_approveButton_invokesOnApproveClosure() throws {
         var approved = false
         let view = ToolInvocationView(


### PR DESCRIPTION
## Summary
- add Foundation Models compatibility filtering for MCP tool schemas
- cap Foundation-advertised MCP tools to 16 while preserving dispatch for hidden tools
- add ToolResult error presentation strings and permission-denied re-auth CTA metadata/UI
- document and integrate BaseChatMCPTests in CI-safe test guidance, with nightly MCP smoke kept gated

## Tests
- scripts/test.sh --filter BaseChatInferenceTests --filter BaseChatMCPTests --filter BaseChatUITests --filter BaseChatUIModelManagementTests --disable-default-traits --skip-update
- git diff --check

Tracks #792.