### PR TITLE
ci: drop Package.swift from build-modes PR trigger; keep Package.resolved

### DIFF
--- a/.github/workflows/build-modes.yml
+++ b/.github/workflows/build-modes.yml
@@ -9,8 +9,9 @@ name: Build modes + binary symbol audit
 #    burns macos-15 at 10x billing once per push; cloning that for four modes
 #    would 5x it. The `paths:` filter on pull_request below adds a *narrow*
 #    on-demand trigger — it only fires when a PR actually edits trait-gated
-#    source, Package.swift, or this workflow's own configuration. Doc-only
-#    PRs and unrelated source edits don't trigger it.
+#    source, Package.resolved (dep bumps), or this workflow's own configuration.
+#    Doc-only PRs, Package.swift-only edits (e.g. adding a non-backend target),
+#    and unrelated source changes don't trigger it.
 #  - **PR vs schedule matrix split.** On `pull_request`, the matrix runs only
 #    `[saas, full]`; on `schedule` (and `workflow_dispatch`) it runs all four
 #    `[offline, ollama, saas, full]`. Rationale: `full` enables the strict
@@ -44,9 +45,16 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - "Package.swift"
+      # Package.resolved only (not Package.swift): a dep-version bump can break
+      # trait-gated compilation (#if MLX / #if Llama / #if CloudSaaS), so it
+      # warrants the saas+full build check. Package.swift edits that affect trait
+      # defines always accompany backend source changes (listed below), so
+      # Package.swift alone is dropped — non-backend target additions and platform
+      # floor bumps don't affect trait-gated builds, and the nightly run catches
+      # any gap within 24 hours.
       - "Package.resolved"
       - "Sources/BaseChatBackends/**"
+      - "Sources/BaseChatServerBackends/**"
       - "Sources/BaseChatUI/Views/Settings/**"
       - "Sources/BaseChatUIModelManagement/Views/Settings/**"
       - "Sources/BaseChatInference/Models/APIProvider.swift"


### PR DESCRIPTION
## Summary

Removes `Package.swift` from the `build-modes.yml` PR `paths:` trigger while keeping `Package.resolved`.

**Rationale:**
- `Package.resolved` stays — a dep-version bump can silently break `#if MLX` / `#if Llama` / `#if CloudSaaS` compilation, so it warrants the saas+full build check on PRs.
- `Package.swift` is dropped — edits that actually affect trait-gated compilation (e.g. adding a new `swiftSettings .define()`) always accompany backend source changes, which are already in the `paths:` list. Pure Package.swift edits (adding a non-backend target like `BaseChatServer`, bumping platform floors) don't affect trait-gated builds. The nightly run covers any gap within 24 hours.

Also adds `Sources/BaseChatServerBackends/**` to future-proof the new server backend target.

**Cost saving:** eliminates the saas + full matrix (~24 macOS-min, ~2× billing) on PRs that only add non-backend targets or change Package.swift metadata. Identified after PR #939 triggered the build matrix solely due to adding the `BaseChatServer` target.

## Test plan
- [ ] Verify `actionlint` passes on this workflow change
- [ ] Confirm a future Package.swift-only PR does not trigger build-modes
- [ ] Confirm a Package.resolved-only PR (dep bump) still triggers build-modes