### PR TITLE
feat(claude): image content blocks for vision models

### DIFF
--- a/Sources/BaseChatBackends/ClaudeBackend.swift
+++ b/Sources/BaseChatBackends/ClaudeBackend.swift
@@ -90,9 +90,46 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             maxOutputTokens: 8192,
             supportsStreaming: true,
             isRemote: true,
+            // Vision is gated on the configured model name — Claude 3, 3.5,
+            // 3.7, and 4 families all accept images as content blocks; the
+            // Claude 2 family and `claude-instant-*` do not. The
+            // GenerationCoordinator's pre-flight reads this flag and rejects
+            // image attachments before we ever build a request body, so an
+            // outdated model name surfaces a clear "not vision-capable"
+            // error rather than a 400 from Anthropic.
+            supportsVision: Self.isVisionCapableModel(modelName),
             streamsToolCallArguments: true,
             supportsParallelToolCalls: true
         )
+    }
+
+    /// Anthropic's per-turn cap on inline base64 images. The Messages API
+    /// rejects more than this with HTTP 400. Surface a clear local error
+    /// instead so callers can prompt the user to drop attachments without
+    /// burning a round-trip.
+    static let maxImagesPerTurn: Int = 5
+
+    /// Returns `true` when `modelName` belongs to a Claude family that
+    /// accepts image content blocks. The matcher is intentionally
+    /// permissive — any name containing a vision-capable family token
+    /// counts, so dated-suffix variants (`claude-3-5-sonnet-20241022`) and
+    /// vendor aliases (`anthropic.claude-sonnet-4`) both light up.
+    static func isVisionCapableModel(_ modelName: String) -> Bool {
+        let lowered = modelName.lowercased()
+        // Explicit denylist: every Claude name that pre-dates vision support.
+        // These have to be rejected even when the broader `claude-*` match
+        // below would otherwise pass.
+        if lowered.contains("claude-2") || lowered.contains("claude-instant") {
+            return false
+        }
+        // Allowlist of vision-capable family tokens. Update when Anthropic
+        // ships a new family; the deny rules above fence off the legacy
+        // text-only models so a wildcard `claude-` match would be unsafe.
+        let visionFamilies = [
+            "claude-3", "claude-sonnet-4", "claude-opus-4", "claude-haiku-4",
+            "claude-4", "claude-sonnet-3", "claude-opus-3", "claude-haiku-3",
+        ]
+        return visionFamilies.contains(where: lowered.contains)
     }
 
     // MARK: - Tool-Aware Conversation History
@@ -156,13 +193,38 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         //      win over the structured/plain replay so the model sees the
         //      `tool_use` ↔ `tool_result` pairing it requires.
         //   2. structured history — carries thinking blocks with signatures
-        //      for multi-turn extended-thinking replay (#604).
+        //      for multi-turn extended-thinking replay (#604) and image
+        //      content blocks for vision turns.
         //   3. plain (role, content) history — legacy fallback.
         //   4. prompt-only single user turn.
         let chatMessages: [[String: Any]]
         if let toolHistory = snapshotToolHistory, !toolHistory.isEmpty {
             chatMessages = toolHistory.map(Self.encodeToolAwareEntry)
         } else if let structured = structuredHistory, !structured.isEmpty {
+            // Per-turn image cap: Anthropic rejects more than 5 inline
+            // base64 images on a single turn. Validate before serialising
+            // so the failure message names the offending turn rather than
+            // surfacing as an opaque HTTP 400 from Anthropic.
+            for message in structured {
+                let count = CloudImageEncoding.imageCount(in: message.parts)
+                if count > Self.maxImagesPerTurn {
+                    throw InferenceError.inferenceFailure(
+                        "Claude accepts at most \(Self.maxImagesPerTurn) images per message; this \(message.role) turn has \(count). Drop attachments and retry."
+                    )
+                }
+            }
+            // Vision pre-flight: if the configured model isn't vision-capable
+            // and the structured history carries any image, fail with a
+            // clear local error. (GenerationCoordinator already gates this
+            // path on `capabilities.supportsVision`, but the backend may be
+            // driven directly — e.g. the OpenAI-compat server — so keep the
+            // belt-and-suspenders check here.)
+            let totalImages = CloudImageEncoding.imageCount(in: structured)
+            if totalImages > 0, !Self.isVisionCapableModel(modelName) {
+                throw InferenceError.inferenceFailure(
+                    "Model \"\(modelName)\" does not support image input. Switch to a Claude 3, 3.5, 3.7, or 4 family model and retry."
+                )
+            }
             chatMessages = structured.map(Self.encodeMessageContent(for:))
         } else if let history = conversationHistory {
             chatMessages = history.map { ["role": $0.role, "content": $0.content] }
@@ -239,16 +301,22 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
     /// Encodes one ``StructuredMessage`` as an Anthropic Messages API
     /// `messages[]` entry.
     ///
-    /// - User turns collapse to a plain string `content` for simplicity —
-    ///   Anthropic accepts either a string or a structured array on user
-    ///   role.
+    /// - User turns collapse to a plain string `content` when they only
+    ///   carry text. When the turn carries one or more
+    ///   ``MessagePart/image(data:mimeType:)`` parts, the encoder emits a
+    ///   structured `content[]` with `image` blocks before any `text` block
+    ///   — the ordering Anthropic recommends so the model attends to the
+    ///   visual context first.
     /// - Assistant turns serialize to a structured `content` array. Thinking
     ///   blocks are emitted **before** any text block, with their
     ///   ``MessagePart/thinkingSignature`` carried verbatim. Anthropic's
     ///   multi-turn extended-thinking contract requires the signature to
     ///   match what the model emitted on the previous turn, so any
     ///   thinking block missing a signature is dropped rather than sent
-    ///   with a blank one (which would 400).
+    ///   with a blank one (which would 400). Image parts on an assistant
+    ///   turn are unusual but supported — the model never emits them, but
+    ///   round-tripping a persisted assistant row with an image attached
+    ///   should not crash the encoder.
     /// - System / tool turns fall back to plain string content.
     static func encodeMessageContent(for message: StructuredMessage) -> [String: Any] {
         if message.role == "assistant" {
@@ -272,6 +340,14 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
                 }
             }
 
+            // Image blocks (rare on assistant turns; supported for
+            // round-trip parity with persisted rows).
+            for part in message.parts {
+                if case .image(let data, let mimeType) = part {
+                    blocks.append(encodeImageBlock(data: data, mimeType: mimeType))
+                }
+            }
+
             // Then text. Concatenated into a single block to match how the
             // model originally emitted its visible content.
             let visible = message.textContent
@@ -292,8 +368,52 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             return ["role": "assistant", "content": blocks]
         }
 
-        // User and other roles: collapse to plain text.
+        // User and other roles. If any image parts are present, emit a
+        // structured content array with image blocks before the text block.
+        // Anthropic's vision examples lead with `image` then `text`; the
+        // model attends to images first when they precede the prompt.
+        let hasImage = message.parts.contains { part in
+            if case .image = part { return true }
+            return false
+        }
+        if message.role == "user", hasImage {
+            var blocks: [[String: Any]] = []
+            for part in message.parts {
+                if case .image(let data, let mimeType) = part {
+                    blocks.append(encodeImageBlock(data: data, mimeType: mimeType))
+                }
+            }
+            let text = message.textContent
+            if !text.isEmpty {
+                blocks.append(["type": "text", "text": text])
+            }
+            return ["role": "user", "content": blocks]
+        }
+
+        // System / tool / image-less user turns: collapse to plain text.
         return ["role": message.role, "content": message.textContent]
+    }
+
+    /// Encodes a single image part as an Anthropic content block:
+    /// `{type:"image", source:{type:"base64", media_type:..., data:...}}`.
+    ///
+    /// Falls back to `image/png` for unrecognised MIME types — Anthropic
+    /// rejects exotic media types with a 400, but in practice every
+    /// persisted image is one of the four supported formats. The lenient
+    /// fallback keeps a corrupt mime field from blocking the entire turn.
+    static func encodeImageBlock(data: Data, mimeType: String) -> [String: Any] {
+        let normalised = mimeType.lowercased()
+        let mediaType = CloudImageEncoding.anthropicSupportedMimeTypes.contains(normalised)
+            ? normalised
+            : "image/png"
+        return [
+            "type": "image",
+            "source": [
+                "type": "base64",
+                "media_type": mediaType,
+                "data": CloudImageEncoding.base64String(from: data),
+            ] as [String: Any],
+        ]
     }
 
     // MARK: - Tool Encoding

--- a/Sources/BaseChatBackends/Internal/CloudImageEncoding.swift
+++ b/Sources/BaseChatBackends/Internal/CloudImageEncoding.swift
@@ -1,0 +1,56 @@
+import Foundation
+import BaseChatInference
+
+/// Shared image-encoding helpers for cloud backends that send images as
+/// content blocks (Anthropic Messages API, OpenAI Chat Completions
+/// `image_url`, etc.).
+///
+/// Kept minimal on purpose — base64 encoding plus light validation. No
+/// resizing or re-encoding lives here today; if a future provider rejects
+/// large images we can layer that in without rewriting call sites.
+///
+/// Lane B (OpenAI image_url) shares this helper for the base64 string +
+/// per-turn cap. The cap value itself differs per provider: Anthropic
+/// rejects more than 5 images per turn, OpenAI tolerates more, so each
+/// caller passes its own ``maxImages``.
+enum CloudImageEncoding {
+
+    /// MIME types Anthropic's vision endpoint accepts. Matches the
+    /// `image/png`, `image/jpeg`, `image/gif`, `image/webp` allowlist
+    /// documented for the Messages API.
+    static let anthropicSupportedMimeTypes: Set<String> = [
+        "image/png",
+        "image/jpeg",
+        "image/jpg",
+        "image/gif",
+        "image/webp",
+    ]
+
+    /// Returns the base64-encoded payload for a `MessagePart.image` using
+    /// the same encoding both Anthropic and OpenAI expect (no line breaks,
+    /// no padding tweaks).
+    static func base64String(from data: Data) -> String {
+        data.base64EncodedString()
+    }
+
+    /// Counts every `.image` part across `messages`. Used by callers that
+    /// enforce a per-request image cap (Anthropic = 5 per *turn*, but the
+    /// caller decides whether the cap applies turn-by-turn or
+    /// across the whole request).
+    static func imageCount(in messages: [StructuredMessage]) -> Int {
+        messages.reduce(0) { acc, message in
+            acc + message.parts.reduce(0) { count, part in
+                if case .image = part { return count + 1 }
+                return count
+            }
+        }
+    }
+
+    /// Counts `.image` parts within a single turn.
+    static func imageCount(in parts: [MessagePart]) -> Int {
+        parts.reduce(0) { count, part in
+            if case .image = part { return count + 1 }
+            return count
+        }
+    }
+}

--- a/Tests/BaseChatBackendsTests/ClaudeImageInputTests.swift
+++ b/Tests/BaseChatBackendsTests/ClaudeImageInputTests.swift
@@ -1,0 +1,313 @@
+#if CloudSaaS
+import XCTest
+import BaseChatInference
+import BaseChatTestSupport
+@testable import BaseChatBackends
+
+/// Tests for #20 (part): image content blocks on the Anthropic Messages API.
+///
+/// `ClaudeBackend` must:
+///
+/// 1. Encode each ``MessagePart/image(data:mimeType:)`` part as a
+///    `{type:"image", source:{type:"base64", media_type:..., data:...}}`
+///    block on the request body.
+/// 2. Place image blocks **before** the matching text block on a user turn —
+///    Anthropic recommends this ordering so the model attends to the visual
+///    context first.
+/// 3. Reject requests that exceed the per-turn image cap before the round
+///    trip, with a message that names the offending count.
+/// 4. Reject image attachments when the configured model isn't vision-capable.
+/// 5. Advertise `supportsVision` based on the configured model name so
+///    GenerationCoordinator's pre-flight matches the wire-level behaviour.
+final class ClaudeImageInputTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeBackend(
+        modelName: String = "claude-sonnet-4-20250514"
+    ) async throws -> (ClaudeBackend, URL) {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let backend = ClaudeBackend(urlSession: session)
+        let url = URL(string: "https://claude-image-\(UUID().uuidString).test")!
+        backend.configure(baseURL: url, apiKey: "sk-ant-test", modelName: modelName)
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+        return (backend, url)
+    }
+
+    private func sseStub(url: URL) {
+        let chunk = Data("""
+            data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"ok"}}\n\ndata: {"type":"message_stop"}\n\n
+            """.utf8)
+        MockURLProtocol.stub(url: url, response: .sse(chunks: [chunk], statusCode: 200))
+    }
+
+    private func extractRequestJSON(host: String?) throws -> [String: Any] {
+        let captured = MockURLProtocol.capturedRequests.last(where: { $0.url?.host == host })
+        let body: Data
+        if let direct = captured?.httpBody {
+            body = direct
+        } else if let stream = captured?.httpBodyStream {
+            var data = Data()
+            stream.open()
+            let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 4096)
+            defer { buffer.deallocate() }
+            while stream.hasBytesAvailable {
+                let read = stream.read(buffer, maxLength: 4096)
+                if read > 0 { data.append(buffer, count: read) }
+            }
+            stream.close()
+            body = data
+        } else {
+            throw NSError(domain: "test", code: 0, userInfo: [NSLocalizedDescriptionKey: "no body"])
+        }
+        return try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+    }
+
+    /// 4-byte payload — the bytes are not a valid PNG, but the encoder
+    /// doesn't decode the data, it only base64-encodes it. Using a tiny
+    /// fixture keeps the test fast and the assertion exact.
+    private func fixtureImage(_ marker: UInt8) -> Data {
+        Data([0x89, 0x50, 0x4E, marker])
+    }
+
+    // MARK: - 1. Single image — encoded as a content block
+
+    func test_singleImage_emitsImageBlockBeforeText() async throws {
+        let (backend, url) = try await makeBackend()
+        sseStub(url: url)
+        defer { MockURLProtocol.unstub(url: url) }
+
+        let imageData = fixtureImage(0xAA)
+        backend.setStructuredHistory([
+            StructuredMessage(role: "user", parts: [
+                .image(data: imageData, mimeType: "image/png"),
+                .text("Describe this image."),
+            ]),
+        ])
+
+        let stream = try backend.generate(prompt: "Describe this image.", systemPrompt: nil, config: GenerationConfig())
+        for try await _ in stream.events { }
+
+        let json = try extractRequestJSON(host: url.host)
+        let messages = try XCTUnwrap(json["messages"] as? [[String: Any]])
+        let userContent = try XCTUnwrap(messages[0]["content"] as? [[String: Any]],
+            "Image-bearing user turn must serialize as a content[] array, not a string")
+        XCTAssertEqual(userContent.count, 2, "Expect exactly two blocks: image + text")
+
+        XCTAssertEqual(userContent[0]["type"] as? String, "image",
+            "Image block must come first — Anthropic recommends image-then-text ordering")
+        let source = try XCTUnwrap(userContent[0]["source"] as? [String: Any])
+        XCTAssertEqual(source["type"] as? String, "base64")
+        XCTAssertEqual(source["media_type"] as? String, "image/png")
+        XCTAssertEqual(source["data"] as? String, imageData.base64EncodedString(),
+            "Image bytes must round-trip as base64 verbatim")
+
+        XCTAssertEqual(userContent[1]["type"] as? String, "text")
+        XCTAssertEqual(userContent[1]["text"] as? String, "Describe this image.")
+    }
+
+    // MARK: - 2. Multiple images on one turn
+
+    func test_multipleImages_allEncoded_inOrder() async throws {
+        let (backend, url) = try await makeBackend()
+        sseStub(url: url)
+        defer { MockURLProtocol.unstub(url: url) }
+
+        let img1 = fixtureImage(0x01)
+        let img2 = fixtureImage(0x02)
+        let img3 = fixtureImage(0x03)
+        backend.setStructuredHistory([
+            StructuredMessage(role: "user", parts: [
+                .image(data: img1, mimeType: "image/png"),
+                .image(data: img2, mimeType: "image/jpeg"),
+                .image(data: img3, mimeType: "image/webp"),
+                .text("Compare these."),
+            ]),
+        ])
+
+        let stream = try backend.generate(prompt: "Compare these.", systemPrompt: nil, config: GenerationConfig())
+        for try await _ in stream.events { }
+
+        let json = try extractRequestJSON(host: url.host)
+        let messages = try XCTUnwrap(json["messages"] as? [[String: Any]])
+        let userContent = try XCTUnwrap(messages[0]["content"] as? [[String: Any]])
+        XCTAssertEqual(userContent.count, 4, "Three image blocks plus one text block")
+
+        let imageBlocks = userContent.prefix(3)
+        for block in imageBlocks {
+            XCTAssertEqual(block["type"] as? String, "image")
+        }
+        XCTAssertEqual((imageBlocks[0]["source"] as? [String: Any])?["media_type"] as? String, "image/png")
+        XCTAssertEqual((imageBlocks[1]["source"] as? [String: Any])?["media_type"] as? String, "image/jpeg")
+        XCTAssertEqual((imageBlocks[2]["source"] as? [String: Any])?["media_type"] as? String, "image/webp")
+
+        // Image data ordering must match the parts ordering — sabotage check:
+        // if the encoder reordered images, these byte-level matches would fail.
+        XCTAssertEqual((imageBlocks[0]["source"] as? [String: Any])?["data"] as? String, img1.base64EncodedString())
+        XCTAssertEqual((imageBlocks[1]["source"] as? [String: Any])?["data"] as? String, img2.base64EncodedString())
+        XCTAssertEqual((imageBlocks[2]["source"] as? [String: Any])?["data"] as? String, img3.base64EncodedString())
+
+        XCTAssertEqual(userContent[3]["type"] as? String, "text")
+        XCTAssertEqual(userContent[3]["text"] as? String, "Compare these.")
+    }
+
+    // MARK: - 3. Image + text mixed (no images on assistant turn)
+
+    func test_imageAndText_mixedHistory_assistantTurnUnaffected() async throws {
+        let (backend, url) = try await makeBackend()
+        sseStub(url: url)
+        defer { MockURLProtocol.unstub(url: url) }
+
+        let imageData = fixtureImage(0xBB)
+        backend.setStructuredHistory([
+            StructuredMessage(role: "user", parts: [
+                .image(data: imageData, mimeType: "image/png"),
+                .text("What is this?"),
+            ]),
+            StructuredMessage(role: "assistant", content: "It looks like a logo."),
+            StructuredMessage(role: "user", content: "Thanks."),
+        ])
+
+        let stream = try backend.generate(prompt: "Thanks.", systemPrompt: nil, config: GenerationConfig())
+        for try await _ in stream.events { }
+
+        let json = try extractRequestJSON(host: url.host)
+        let messages = try XCTUnwrap(json["messages"] as? [[String: Any]])
+        XCTAssertEqual(messages.count, 3)
+
+        // First turn: structured content with image + text.
+        XCTAssertNotNil(messages[0]["content"] as? [[String: Any]],
+            "Image-bearing user turn must serialize as a content[] array")
+
+        // Second turn: assistant text-only turn serialises as a structured
+        // content[] with a single text block — the existing
+        // ``encodeMessageContent`` contract for assistant turns.
+        let assistantContent = try XCTUnwrap(messages[1]["content"] as? [[String: Any]],
+            "Assistant turns serialise as content[] arrays (see ClaudeStructuredReplayTests)")
+        XCTAssertEqual(assistantContent.count, 1)
+        XCTAssertEqual(assistantContent[0]["type"] as? String, "text")
+        XCTAssertEqual(assistantContent[0]["text"] as? String, "It looks like a logo.")
+
+        // Third turn: text-only user turn collapses to the simple form.
+        XCTAssertEqual(messages[2]["content"] as? String, "Thanks.",
+            "Image-less user turns must keep the simple string content shape")
+    }
+
+    // MARK: - 4. > 5 images per turn errors out before the round trip
+
+    func test_moreThanFiveImagesPerTurn_throwsBeforeRequest() async throws {
+        let (backend, url) = try await makeBackend()
+        defer { MockURLProtocol.unstub(url: url) }
+
+        var parts: [MessagePart] = (0..<6).map { i in
+            .image(data: fixtureImage(UInt8(i)), mimeType: "image/png")
+        }
+        parts.append(.text("too many"))
+        backend.setStructuredHistory([StructuredMessage(role: "user", parts: parts)])
+
+        do {
+            let stream = try backend.generate(prompt: "too many", systemPrompt: nil, config: GenerationConfig())
+            for try await _ in stream.events { }
+            XCTFail("Should have thrown before opening the stream")
+        } catch let error as InferenceError {
+            guard case .inferenceFailure(let message) = error else {
+                XCTFail("Expected inferenceFailure, got \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("5"), "Error should name the cap: \(message)")
+            XCTAssertTrue(message.contains("6"), "Error should name the offending count: \(message)")
+        }
+    }
+
+    // MARK: - 5. Non-vision model rejects image input
+
+    func test_nonVisionModel_rejectsImageInput() async throws {
+        // `claude-2.1` predates vision support — image attachments must
+        // never be forwarded to it.
+        let (backend, url) = try await makeBackend(modelName: "claude-2.1")
+        defer { MockURLProtocol.unstub(url: url) }
+
+        backend.setStructuredHistory([
+            StructuredMessage(role: "user", parts: [
+                .image(data: fixtureImage(0xCC), mimeType: "image/png"),
+                .text("hi"),
+            ]),
+        ])
+
+        do {
+            let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: GenerationConfig())
+            for try await _ in stream.events { }
+            XCTFail("Should have thrown for non-vision model")
+        } catch let error as InferenceError {
+            guard case .inferenceFailure(let message) = error else {
+                XCTFail("Expected inferenceFailure, got \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("claude-2.1"), "Error should name the model: \(message)")
+            XCTAssertTrue(message.lowercased().contains("image"), "Error should mention images: \(message)")
+        }
+    }
+
+    // MARK: - 6. Capabilities flip with model name
+
+    func test_capabilities_supportsVision_reflectsModelName() {
+        let backend = ClaudeBackend()
+        backend.configure(
+            baseURL: URL(string: "https://api.anthropic.com")!,
+            apiKey: "x",
+            modelName: "claude-sonnet-4-20250514"
+        )
+        XCTAssertTrue(backend.capabilities.supportsVision,
+            "Claude 4 models must advertise vision support")
+
+        backend.configure(
+            baseURL: URL(string: "https://api.anthropic.com")!,
+            apiKey: "x",
+            modelName: "claude-3-5-sonnet-20241022"
+        )
+        XCTAssertTrue(backend.capabilities.supportsVision,
+            "Claude 3.5 models must advertise vision support")
+
+        backend.configure(
+            baseURL: URL(string: "https://api.anthropic.com")!,
+            apiKey: "x",
+            modelName: "claude-2.1"
+        )
+        XCTAssertFalse(backend.capabilities.supportsVision,
+            "Claude 2.x predates vision support — must not advertise it")
+
+        backend.configure(
+            baseURL: URL(string: "https://api.anthropic.com")!,
+            apiKey: "x",
+            modelName: "claude-instant-1.2"
+        )
+        XCTAssertFalse(backend.capabilities.supportsVision,
+            "Claude Instant predates vision support — must not advertise it")
+    }
+
+    // MARK: - 7. isVisionCapableModel — direct unit coverage
+
+    func test_isVisionCapableModel_classifierAcceptsKnownFamilies() {
+        XCTAssertTrue(ClaudeBackend.isVisionCapableModel("claude-3-haiku-20240307"))
+        XCTAssertTrue(ClaudeBackend.isVisionCapableModel("claude-3-5-sonnet-20241022"))
+        XCTAssertTrue(ClaudeBackend.isVisionCapableModel("claude-3-7-sonnet-20250219"))
+        XCTAssertTrue(ClaudeBackend.isVisionCapableModel("claude-sonnet-4-20250514"))
+        XCTAssertTrue(ClaudeBackend.isVisionCapableModel("claude-opus-4-1-20250805"))
+        // Vendor-prefixed aliases (Bedrock-style) should still match.
+        XCTAssertTrue(ClaudeBackend.isVisionCapableModel("anthropic.claude-sonnet-4"))
+    }
+
+    func test_isVisionCapableModel_classifierRejectsLegacyFamilies() {
+        XCTAssertFalse(ClaudeBackend.isVisionCapableModel("claude-2"))
+        XCTAssertFalse(ClaudeBackend.isVisionCapableModel("claude-2.1"))
+        XCTAssertFalse(ClaudeBackend.isVisionCapableModel("claude-instant-1"))
+        XCTAssertFalse(ClaudeBackend.isVisionCapableModel("claude-instant-1.2"))
+        // Unknown / future family that doesn't match any allowlisted token
+        // defaults to false — better to surface a clear error than to assume
+        // vision support and 400.
+        XCTAssertFalse(ClaudeBackend.isVisionCapableModel("some-other-model"))
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Wires `MessagePart.image(data:mimeType:)` through `ClaudeBackend` so Anthropic vision models receive images as `{type:"image", source:{type:"base64", media_type, data}}` content blocks on the Messages API.

Closes part of #20.

## What changed

- **Image content blocks.** Image-bearing user turns serialise as a structured `content[]` array with image blocks **before** the text block (Anthropic's recommended ordering — the model attends to images first). Text-only turns keep the legacy string content shape so the existing replay tests stay green.
- **Per-turn 5-image cap.** Enforced before the round trip — offending turns surface a local `InferenceError.inferenceFailure` naming the count, instead of relying on a 400 from upstream.
- **Vision capability gating.** `BackendCapabilities.supportsVision` flips with the configured model name. Claude 3, 3.5, 3.7, and 4 families advertise vision; Claude 2.x and `claude-instant-*` do not. `GenerationCoordinator` already gates image attachments on this flag, and the backend keeps a belt-and-suspenders check so direct callers (e.g. the OpenAI-compat server) get the same error.
- **Shared `CloudImageEncoding` helper.** Minimal base64 + per-message image counter at `Sources/BaseChatBackends/Internal/`, ready for Lane B (OpenAI `image_url`) to share without inventing a parallel helper. No resizing yet — kept deliberately small.

## Backend checklist

- [x] Claude — content blocks, 5-image cap, model-name vision gating
- [ ] OpenAI / Chat Completions — Lane B (parallel PR)
- [ ] MLX — already shipped (PR #904)
- [ ] Llama / Foundation — out of scope here

## Test plan

- [x] Single image → encoded as `image` block before the `text` block, base64 verbatim
- [x] Multiple images on one turn → ordering and media types preserved
- [x] Image + text mixed across multiple turns — only the image-bearing user turn uses structured content
- [x] More than 5 images per turn → throws `InferenceError.inferenceFailure` before the round trip
- [x] Non-vision model (`claude-2.1`, `claude-instant-1.2`) with images → throws with a message naming the model
- [x] `capabilities.supportsVision` flips correctly with `modelName`
- [x] `isVisionCapableModel` classifier — known families accepted, legacy / unknown rejected
- [x] Existing Claude tests unchanged (`ClaudeBackendTests`, `ClaudeStructuredReplayTests`, `ClaudeBackendToolCallingTests`, `ClaudeThinkingErrorPathTests`) — 279 tests still green
- [x] Pre-push gate: 2578 XCTest tests + 83 Swift Testing tests all pass locally

## Release Note

ClaudeBackend now forwards `MessagePart.image` parts as native Anthropic content blocks, so vision-capable Claude models (3, 3.5, 3.7, and 4 families) can answer about attached images. Non-vision models surface a clear local error, and the per-turn 5-image cap is enforced before the round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)