### PR TITLE
feat(server): trait-gate BaseChatServer + add Package.resolved budget guardrail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,8 @@ jobs:
       # - --disable-default-traits skips MLX (default-enabled) to avoid metallib
       #   crashes in CI — Metal shaders are only compiled by Xcode.
       # - BaseChatBackendsTests without traits runs only CI-safe cloud/SSE tests.
+      # - Server tests run in the sibling `server-tests` job behind a paths
+      #   filter so Hummingbird only compiles when server code changes.
       # Local-only coverage:
       # - Run `swift test --filter BaseChatBackendsTests --traits MLX,Llama` on
       #   Apple Silicon for MLX/llama.cpp paths.
@@ -242,12 +244,12 @@ jobs:
       # Swift Testing must stay isolated — mixing XCTest + Swift Testing in one
       # swift test process triggers a libmalloc double-free SIGABRT (see
       # SwiftTestingAuditTest, #681).
-      - name: Test — XCTest suites (Core + Runtime + PersistenceSwiftData + UI + UIModelManagement + MCP + Backends + TestSupport + AppIntents + Server)
+      - name: Test — XCTest suites (Core + Runtime + PersistenceSwiftData + UI + UIModelManagement + MCP + Backends + TestSupport + AppIntents)
         id: test-xctest-suites
         timeout-minutes: 12
         env:
           BASECHAT_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-xctest-suites.log
-        run: scripts/test.sh --filter BaseChatCoreTests --filter BaseChatRuntimeTests --filter BaseChatPersistenceSwiftDataTests --filter BaseChatUITests --filter BaseChatUIModelManagementTests --filter BaseChatMCPTests --filter BaseChatBackendsTests --filter BaseChatTestSupportTests --filter BaseChatAppIntentsTests --filter BaseChatServerTests --disable-default-traits --skip-update
+        run: scripts/test.sh --filter BaseChatCoreTests --filter BaseChatRuntimeTests --filter BaseChatPersistenceSwiftDataTests --filter BaseChatUITests --filter BaseChatUIModelManagementTests --filter BaseChatMCPTests --filter BaseChatBackendsTests --filter BaseChatTestSupportTests --filter BaseChatAppIntentsTests --disable-default-traits --skip-update
 
       # BaseChatInferenceTests isolates its UserDefaults-backed migration tests
       # with per-instance suite names, and HuggingFaceServiceTests scopes
@@ -310,3 +312,142 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
           path: test-diagnostics/
+
+  # Server tests are split out of the per-PR mega-batch because the
+  # Hummingbird transitive graph (~18 extra pins, swift-nio + NIOSSL +
+  # BoringSSL + AsyncHTTPClient + ContainersPreview + Configuration) added
+  # ~250s to the build step when it shipped unconditionally. The Server trait
+  # peels Hummingbird out of the default-trait build so only this job pays
+  # the compile cost — and only when server code or the dep graph changes.
+  server-tests:
+    runs-on: macos-15  # match the `test` job runner so cache keys collide
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # paths-filter needs the parent commit to diff against on `push` events;
+          # `pull_request` works with the default shallow clone.
+          fetch-depth: 2
+
+      - name: Detect server-relevant changes
+        id: server-changed
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            server:
+              - 'Sources/BaseChatServer*/**'
+              - 'Tests/BaseChatServerTests/**'
+              - 'Package.swift'
+              - 'Package.resolved'
+              - '.github/workflows/ci.yml'
+              - 'scripts/test.sh'
+
+      - name: Select Xcode
+        if: steps.server-changed.outputs.server == 'true'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.3"
+
+      - name: Cache SwiftPM build
+        if: steps.server-changed.outputs.server == 'true'
+        uses: actions/cache@v5
+        with:
+          # Same path/key shape as the `test` job — both jobs share the same
+          # SwiftPM dep tarball cache so we don't re-download the graph twice
+          # per workflow run.
+          path: |
+            .build/artifacts
+            .build/checkouts
+            .build/repositories
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
+            ${{ runner.os }}-${{ runner.arch }}-spm-
+
+      - name: Verify Swift toolchain matches Package.swift tools-version
+        if: steps.server-changed.outputs.server == 'true'
+        run: |
+          set -euo pipefail
+          tools_line=$(head -n 1 Package.swift)
+          tools_version=$(printf '%s\n' "$tools_line" | sed -E 's|^//[[:space:]]*swift-tools-version:[[:space:]]*([0-9]+\.[0-9]+).*|\1|')
+          if ! [[ "$tools_version" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "Could not parse swift-tools-version from first line of Package.swift: $tools_line"
+            exit 1
+          fi
+          swift_version_full=$(xcrun swift -version | head -n 1)
+          swift_version=$(printf '%s\n' "$swift_version_full" | sed -E 's|.*Swift version ([0-9]+\.[0-9]+).*|\1|')
+          if ! [[ "$swift_version" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "Could not parse Swift major.minor from: $swift_version_full"
+            exit 1
+          fi
+          tools_major=${tools_version%.*}; tools_minor=${tools_version#*.}
+          swift_major=${swift_version%.*}; swift_minor=${swift_version#*.}
+          if (( tools_major > swift_major )) || { (( tools_major == swift_major )) && (( tools_minor > swift_minor )); }; then
+            echo "::error::Package.swift requires swift-tools-version $tools_version but runner has Swift $swift_version. Lower swift-tools-version or upgrade the pinned Xcode."
+            exit 1
+          fi
+          echo "swift-tools-version=$tools_version OK against runner Swift $swift_version"
+
+      - name: Test — Server suite (Server trait)
+        id: test-server
+        if: steps.server-changed.outputs.server == 'true'
+        timeout-minutes: 12
+        env:
+          BASECHAT_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-server.log
+        run: scripts/test.sh --filter BaseChatServerTests --disable-default-traits --traits Server --skip-update
+
+      - name: Stage test diagnostics
+        if: failure() && steps.server-changed.outputs.server == 'true'
+        run: |
+          mkdir -p test-diagnostics
+          {
+            echo "run-id=${{ github.run_id }}"
+            echo "run-attempt=${{ github.run_attempt }}"
+            echo "job=server-tests"
+            echo "test-server-failed=${{ steps.test-server.outcome == 'failure' }}"
+          } > test-diagnostics/failed-steps.txt
+
+      - name: Upload test diagnostics on failure
+        if: failure() && steps.server-changed.outputs.server == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: xcresult-server-${{ github.run_attempt }}
+          if-no-files-found: ignore
+          retention-days: 7
+          path: test-diagnostics/
+
+  # Guards against silent dependency-graph explosions like the one that
+  # prompted the BaseChatServer trait-gating work (Package.resolved went
+  # 20 → 38 pins in a single PR). Adds friction proportional to dep weight:
+  # 1–2 pins is fine, anything more requires the `deps-ok` label as a
+  # deliberate sign-off captured in the PR's history.
+  dep-budget:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        # fetch-depth: 0 is required because `git diff base...HEAD` walks
+        # back to the merge base, which can be arbitrarily deep on a
+        # long-lived branch. The paths-filter style fetch-depth: 2 is only
+        # enough for the parent commit on push events.
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check Package.resolved pin delta
+        run: |
+          set -euo pipefail
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          new=$(git diff "origin/${{ github.base_ref }}...HEAD" -- Package.resolved | grep -c '^+.*"identity"' || true)
+          echo "PR adds $new new package pin(s)."
+          if [ "$new" -gt 2 ]; then
+            if echo '${{ toJSON(github.event.pull_request.labels.*.name) }}' | grep -q 'deps-ok'; then
+              echo "::notice::PR adds $new new pins; 'deps-ok' label present, allowing."
+              exit 0
+            fi
+            echo "::error::PR adds $new new package pins (limit: 2). Either reduce the dep additions or add the 'deps-ok' label to the PR with a justification in the description."
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## Unreleased
+
+### Highlights
+
+#### Trait-gate BaseChatServer to recover default-build wall-time
+
+The `BaseChatServer` (OpenAI-compatible HTTP) target and its `Hummingbird`
+transitive dependency graph (swift-nio + NIOSSL + BoringSSL + AsyncHTTPClient)
+are now gated behind a new `Server` SwiftPM trait, off by default. The previous
+release inadvertently doubled per-PR CI wall time by adding ~18 transitive
+package pins to the default build graph; this restores the prior baseline.
+
+```bash
+swift test --filter BaseChatServerTests --disable-default-traits --traits Server
+swift run --traits Server BaseChatServer
+```
+
+**BREAKING CHANGE:** consumers that depend on `BaseChatServerCore` as a library
+or run the `BaseChatServer` executable must now pass `--traits Server` (or list
+`Server` in their consumer manifest's `.package(... traits: [...])`). Without
+the trait, the targets still build but the executable prints a no-op message
+and exits cleanly — no Hummingbird symbols are linked.
+
+See [#TBD].
+
+### Features
+
+- **ci:** add `Package.resolved` budget check that fails PRs adding >2 new pins unless labeled `deps-ok` (prevents future silent dep-graph regressions)
+
 ## [0.14.5](https://github.com/roryford/BaseChatKit/compare/v0.14.4...v0.14.5) (2026-05-02)
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ or run the `BaseChatServer` executable must now pass `--traits Server` (or list
 the trait, the targets still build but the executable prints a no-op message
 and exits cleanly — no Hummingbird symbols are linked.
 
-See [#TBD].
+See [#946].
 
 ### Features
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ swift test --filter BaseChatMCPTests --disable-default-traits
 swift test --filter BaseChatBackendsTests --disable-default-traits
 swift test --filter BaseChatTestSupportTests --disable-default-traits
 swift test --filter BaseChatAppIntentsTests --disable-default-traits
-swift test --filter BaseChatServerTests --disable-default-traits
+swift test --filter BaseChatServerTests --disable-default-traits --traits Server
 
 # Apple Silicon only — MLX mock tests + llama.cpp
 swift test --filter BaseChatBackendsTests --traits MLX,Llama

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "f7868b87f41797950571c24bf99b4d3a7cdcd1197f4ac8ec7812a23e142a05ea",
+  "originHash" : "eb4f4f4a7750a20bcaf66862338ca7b1143f9ca15169390f38aa13b3240387f2",
   "pins" : [
-    {
-      "identity" : "async-http-client",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/async-http-client.git",
-      "state" : {
-        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
-        "version" : "1.33.1"
-      }
-    },
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
@@ -17,15 +8,6 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "hummingbird",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/hummingbird-project/hummingbird.git",
-      "state" : {
-        "revision" : "a2ed0a0294de56e18ba55344eafc801a7a385a90",
-        "version" : "2.22.0"
       }
     },
     {
@@ -56,15 +38,6 @@
       }
     },
     {
-      "identity" : "swift-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-algorithms.git",
-      "state" : {
-        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
-        "version" : "1.2.1"
-      }
-    },
-    {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
@@ -83,15 +56,6 @@
       }
     },
     {
-      "identity" : "swift-async-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-async-algorithms.git",
-      "state" : {
-        "revision" : "9d349bcc328ac3c31ce40e746b5882742a0d1272",
-        "version" : "1.1.3"
-      }
-    },
-    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
@@ -101,30 +65,12 @@
       }
     },
     {
-      "identity" : "swift-certificates",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-certificates.git",
-      "state" : {
-        "revision" : "bde8ca32a096825dfce37467137c903418c1893d",
-        "version" : "1.19.1"
-      }
-    },
-    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
         "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "swift-configuration",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-configuration.git",
-      "state" : {
-        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
-        "version" : "1.2.0"
       }
     },
     {
@@ -146,33 +92,6 @@
       }
     },
     {
-      "identity" : "swift-distributed-tracing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-distributed-tracing.git",
-      "state" : {
-        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
-        "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "swift-http-structured-headers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-structured-headers.git",
-      "state" : {
-        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
-        "version" : "1.7.0"
-      }
-    },
-    {
-      "identity" : "swift-http-types",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-types.git",
-      "state" : {
-        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
-        "version" : "1.5.1"
-      }
-    },
-    {
       "identity" : "swift-huggingface",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-huggingface.git",
@@ -191,24 +110,6 @@
       }
     },
     {
-      "identity" : "swift-log",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log.git",
-      "state" : {
-        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
-        "version" : "1.12.0"
-      }
-    },
-    {
-      "identity" : "swift-metrics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-metrics.git",
-      "state" : {
-        "revision" : "d51c8d13fa366eec807eedb4e37daa60ff5bfdd5",
-        "version" : "2.10.1"
-      }
-    },
-    {
       "identity" : "swift-nio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
@@ -218,66 +119,12 @@
       }
     },
     {
-      "identity" : "swift-nio-extras",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-extras.git",
-      "state" : {
-        "revision" : "5a48717e29f62cb8326d6d42e46b562ca93847a6",
-        "version" : "1.34.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-http2",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-http2.git",
-      "state" : {
-        "revision" : "81cc18264f92cd307ff98430f89372711d4f6fe9",
-        "version" : "1.43.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-ssl",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-ssl.git",
-      "state" : {
-        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
-        "version" : "2.37.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-transport-services",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-transport-services.git",
-      "state" : {
-        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
-        "version" : "1.28.0"
-      }
-    },
-    {
       "identity" : "swift-numerics",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics",
+      "location" : "https://github.com/apple/swift-numerics.git",
       "state" : {
         "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
         "version" : "1.1.1"
-      }
-    },
-    {
-      "identity" : "swift-service-context",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-service-context.git",
-      "state" : {
-        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-service-lifecycle",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
-      "state" : {
-        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
-        "version" : "2.11.0"
       }
     },
     {
@@ -301,7 +148,7 @@
     {
       "identity" : "swift-system",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system.git",
+      "location" : "https://github.com/apple/swift-system",
       "state" : {
         "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
         "version" : "1.6.4"

--- a/Package.swift
+++ b/Package.swift
@@ -39,6 +39,7 @@ let package = Package(
         .trait(name: "MCP", description: "Enable the BaseChatMCP module and MCP client surface."),
         .trait(name: "MCPBuiltinCatalog", description: "Enable BaseChatMCP's built-in catalog descriptors."),
         .trait(name: "Voice", description: "Enable the BaseChatVoice speech I/O spike and voice composer UI."),
+        .trait(name: "Server", description: "Enable BaseChatServer (OpenAI-compatible HTTP server) and its Hummingbird dependency."),
         // Fuzz is intentionally NOT a default trait. Enabling it adds BaseChatBackends
         // (and transitively LlamaSwift) to fuzz-chat, which conflicts with the MLX
         // integration test targets in the auto-generated Xcode scheme. Run the fuzzer via
@@ -404,9 +405,12 @@ let package = Package(
             name: "BaseChatServerCore",
             dependencies: [
                 "BaseChatInference",
-                .product(name: "Hummingbird", package: "hummingbird"),
+                .product(name: "Hummingbird", package: "hummingbird", condition: .when(traits: ["Server"])),
             ],
-            path: "Sources/BaseChatServerCore"
+            path: "Sources/BaseChatServerCore",
+            swiftSettings: [
+                .define("Server", .when(traits: ["Server"])),
+            ]
         ),
         .target(
             name: "BaseChatServerBackends",
@@ -423,6 +427,7 @@ let package = Package(
                 .define("Ollama", .when(traits: ["Ollama"])),
                 .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
                 .define("HuggingFace", .when(traits: ["HuggingFace"])),
+                .define("Server", .when(traits: ["Server"])),
             ]
         ),
         .executableTarget(
@@ -439,6 +444,7 @@ let package = Package(
                 .define("Ollama", .when(traits: ["Ollama"])),
                 .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
                 .define("HuggingFace", .when(traits: ["HuggingFace"])),
+                .define("Server", .when(traits: ["Server"])),
             ]
         ),
         .testTarget(
@@ -448,7 +454,10 @@ let package = Package(
                 "BaseChatServerBackends",
                 "BaseChatInference",
                 "BaseChatTestSupport",
-                .product(name: "HummingbirdTesting", package: "hummingbird"),
+                .product(name: "HummingbirdTesting", package: "hummingbird", condition: .when(traits: ["Server"])),
+            ],
+            swiftSettings: [
+                .define("Server", .when(traits: ["Server"])),
             ]
         ),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ BaseChatUI  ──────>  BaseChatPersistenceSwiftData  ─────�
 - **BaseChatHuggingFace** *(trait: `HuggingFace`, default-on)* — HuggingFace Hub search plus background download / validation services.
 - **BaseChatAnyLanguageModelBridge** *(trait: `AnyLanguageModel`, default-off)* — Thin `InferenceBackend` adapter over HuggingFace's `AnyLanguageModel`.
 - **BaseChatVoice** — Optional speech-recognition / synthesis adapters and voice composer UI. Depends on `BaseChatUI` so hosts can opt in without adding a back-edge into the base chat surface.
-- **BaseChatServer** — OpenAI-compatible HTTP server executable for exposing a selected `BaseChatInference` backend over `/v1/chat/completions`.
+- **BaseChatServer** *(trait: `Server`, default-off)* — OpenAI-compatible HTTP server executable for exposing a selected `BaseChatInference` backend over `/v1/chat/completions`. Server targets are trait-gated; add `--traits Server` to `swift run`/`swift build`/`swift test` commands when working with `BaseChatServer`.
 
 ## Quick Start
 
@@ -198,11 +198,11 @@ scripts/test.sh --filter BaseChatMCPTests --disable-default-traits --traits MCPB
 
 ### 2.2 BaseChatServer
 
-`BaseChatServer` runs an OpenAI-compatible local HTTP surface backed by BaseChatKit inference. Build it without default traits for the CI-safe/core server surface:
+`BaseChatServer` runs an OpenAI-compatible local HTTP surface backed by BaseChatKit inference. The server target and its `Hummingbird` dependency are trait-gated behind `Server` (default-off), so add `--traits Server` to every build/run/test command:
 
 ```bash
-swift build --product BaseChatServer --disable-default-traits --traits Ollama
-swift run --disable-default-traits --traits Ollama BaseChatServer -- \
+swift build --product BaseChatServer --disable-default-traits --traits Server,Ollama
+swift run --disable-default-traits --traits Server,Ollama BaseChatServer -- \
   --backend ollama --model llama3.2 --host 127.0.0.1 --port 8080 \
   --api-key local-dev --cors-origin http://localhost:3000 --metrics
 ```

--- a/Sources/BaseChatServer/main.swift
+++ b/Sources/BaseChatServer/main.swift
@@ -1,3 +1,4 @@
+#if Server
 import ArgumentParser
 import BaseChatServerBackends
 import BaseChatServerCore
@@ -22,3 +23,14 @@ struct BaseChatServerCommand: AsyncParsableCommand {
         try await app.run()
     }
 }
+#else
+// Stub entry point when the `Server` trait is disabled. Building the
+// executable still requires a `@main`; this prints a clear "trait not
+// enabled" message instead of pulling Hummingbird into the default build.
+@main
+struct BaseChatServerDisabled {
+    static func main() {
+        print("BaseChatServer was built without the `Server` trait. Re-build with `--traits Server` to enable.")
+    }
+}
+#endif

--- a/Sources/BaseChatServerBackends/ServerCommandOptions.swift
+++ b/Sources/BaseChatServerBackends/ServerCommandOptions.swift
@@ -1,3 +1,4 @@
+#if Server
 import ArgumentParser
 import BaseChatServerCore
 import Foundation
@@ -94,3 +95,5 @@ package struct ServerCommandOptions: ParsableArguments, Sendable {
         )
     }
 }
+
+#endif

--- a/Sources/BaseChatServerBackends/TraitAwareServerBackendProvider.swift
+++ b/Sources/BaseChatServerBackends/TraitAwareServerBackendProvider.swift
@@ -1,3 +1,4 @@
+#if Server
 import ArgumentParser
 import BaseChatBackends
 import BaseChatInference
@@ -184,3 +185,5 @@ package actor TraitAwareServerBackendProvider: ServerBackendProvider {
         #endif
     }
 }
+
+#endif

--- a/Sources/BaseChatServerCore/AsyncSemaphore.swift
+++ b/Sources/BaseChatServerCore/AsyncSemaphore.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 package actor AsyncSemaphore {
@@ -39,3 +40,5 @@ package actor AsyncSemaphore {
         waiters.removeFirst().resume(throwing: CancellationError())
     }
 }
+
+#endif

--- a/Sources/BaseChatServerCore/ChatCompletionsAdapter.swift
+++ b/Sources/BaseChatServerCore/ChatCompletionsAdapter.swift
@@ -1,3 +1,4 @@
+#if Server
 import BaseChatInference
 import Foundation
 
@@ -745,3 +746,5 @@ package struct ChatCompletionEventMapper: Sendable {
         }
     }
 }
+
+#endif

--- a/Sources/BaseChatServerCore/ServerApp.swift
+++ b/Sources/BaseChatServerCore/ServerApp.swift
@@ -1,3 +1,4 @@
+#if Server
 import BaseChatInference
 import Foundation
 import Hummingbird
@@ -229,3 +230,5 @@ package struct ServerApp: Sendable {
         }
     }
 }
+
+#endif

--- a/Sources/BaseChatServerCore/ServerBackendProvider.swift
+++ b/Sources/BaseChatServerCore/ServerBackendProvider.swift
@@ -1,3 +1,4 @@
+#if Server
 import BaseChatInference
 import Foundation
 
@@ -23,3 +24,5 @@ package struct UnavailableServerBackendProvider: ServerBackendProvider {
         throw ServerError.backendUnavailable("No server backend has been configured yet.")
     }
 }
+
+#endif

--- a/Sources/BaseChatServerCore/ServerConfiguration.swift
+++ b/Sources/BaseChatServerCore/ServerConfiguration.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 package struct ServerConfiguration: Equatable, Sendable {
@@ -27,3 +28,5 @@ package struct ServerConfiguration: Equatable, Sendable {
         self.metricsEnabled = metricsEnabled
     }
 }
+
+#endif

--- a/Sources/BaseChatServerCore/ServerError.swift
+++ b/Sources/BaseChatServerCore/ServerError.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 package enum ServerError: Error, Equatable, Sendable, CustomStringConvertible {
@@ -14,3 +15,5 @@ package enum ServerError: Error, Equatable, Sendable, CustomStringConvertible {
         }
     }
 }
+
+#endif

--- a/Sources/BaseChatServerCore/ServerHTTPResponses.swift
+++ b/Sources/BaseChatServerCore/ServerHTTPResponses.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 import Hummingbird
 
@@ -46,3 +47,5 @@ package func errorResponse(
 ) -> Response {
     jsonResponse(ChatCompletionErrorEnvelope(message: message, type: type, code: code), status: status)
 }
+
+#endif

--- a/Sources/BaseChatServerCore/ServerMetrics.swift
+++ b/Sources/BaseChatServerCore/ServerMetrics.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 package struct ServerMetricsSnapshot: Equatable, Sendable {
@@ -77,3 +78,5 @@ package struct ServerMetrics: Sendable {
         storage.mutate { $0.failures += 1 }
     }
 }
+
+#endif

--- a/Tests/BaseChatServerTests/AsyncSemaphoreTests.swift
+++ b/Tests/BaseChatServerTests/AsyncSemaphoreTests.swift
@@ -1,3 +1,4 @@
+#if Server
 @testable import BaseChatServerCore
 import XCTest
 
@@ -96,3 +97,5 @@ private actor ConcurrencyCounter {
         current -= 1
     }
 }
+
+#endif

--- a/Tests/BaseChatServerTests/BaseChatServerCLITests.swift
+++ b/Tests/BaseChatServerTests/BaseChatServerCLITests.swift
@@ -1,3 +1,4 @@
+#if Server
 @testable import BaseChatServerCore
 @testable import BaseChatServerBackends
 import ArgumentParser
@@ -132,3 +133,5 @@ final class TraitAwareServerBackendProviderTests: XCTestCase {
         XCTAssertEqual(models, ["mlx-community/example", "Models/example"])
     }
 }
+
+#endif

--- a/Tests/BaseChatServerTests/BaseChatServerSmokeTests.swift
+++ b/Tests/BaseChatServerTests/BaseChatServerSmokeTests.swift
@@ -1,3 +1,4 @@
+#if Server
 @testable import BaseChatServerCore
 import BaseChatInference
 import BaseChatTestSupport
@@ -490,3 +491,5 @@ private struct FailingChatAdapter: ChatCompletionsAdapter {
         }
     }
 }
+
+#endif

--- a/Tests/BaseChatServerTests/ChatCompletionsAdapterTests.swift
+++ b/Tests/BaseChatServerTests/ChatCompletionsAdapterTests.swift
@@ -1,3 +1,4 @@
+#if Server
 @testable import BaseChatServerCore
 import BaseChatInference
 import BaseChatTestSupport
@@ -285,3 +286,5 @@ private final class CapturingBackend: InferenceBackend, @unchecked Sendable {
     func stopGeneration() {}
     func unloadModel() { isModelLoaded = false }
 }
+
+#endif

--- a/Tests/BaseChatServerTests/OpenAIJSONGoldenSupport.swift
+++ b/Tests/BaseChatServerTests/OpenAIJSONGoldenSupport.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 import XCTest
 
@@ -190,3 +191,5 @@ enum JSONValue: Codable, Equatable {
         }
     }
 }
+
+#endif

--- a/Tests/BaseChatServerTests/OpenAIJSONGoldenTests.swift
+++ b/Tests/BaseChatServerTests/OpenAIJSONGoldenTests.swift
@@ -1,3 +1,4 @@
+#if Server
 @testable import BaseChatServerCore
 import XCTest
 
@@ -173,3 +174,5 @@ final class OpenAIJSONGoldenTests: XCTestCase {
         XCTAssertEqual(chunk.usage?.totalTokens, 12)
     }
 }
+
+#endif

--- a/Tests/BaseChatServerTests/ServerBackendProviderTests.swift
+++ b/Tests/BaseChatServerTests/ServerBackendProviderTests.swift
@@ -1,3 +1,4 @@
+#if Server
 @testable import BaseChatServerCore
 import BaseChatTestSupport
 import XCTest
@@ -38,3 +39,5 @@ final class ServerBackendProviderTests: XCTestCase {
         XCTAssertEqual(provider.backendRequests, [ServerBackendRequest(model: "beta")])
     }
 }
+
+#endif

--- a/Tests/BaseChatServerTests/ServerConfigurationTests.swift
+++ b/Tests/BaseChatServerTests/ServerConfigurationTests.swift
@@ -1,3 +1,4 @@
+#if Server
 @testable import BaseChatServerCore
 import XCTest
 
@@ -34,3 +35,5 @@ final class ServerConfigurationTests: XCTestCase {
         XCTAssertTrue(configuration.metricsEnabled)
     }
 }
+
+#endif

--- a/Tests/BaseChatServerTests/ServerMetricsAndErrorTests.swift
+++ b/Tests/BaseChatServerTests/ServerMetricsAndErrorTests.swift
@@ -1,3 +1,4 @@
+#if Server
 @testable import BaseChatServerCore
 import XCTest
 
@@ -75,3 +76,5 @@ final class ServerMetricsAndErrorTests: XCTestCase {
         XCTAssertEqual(app.metrics.snapshot(), ServerMetricsSnapshot())
     }
 }
+
+#endif

--- a/Tests/BaseChatServerTests/ServerTestDoubles.swift
+++ b/Tests/BaseChatServerTests/ServerTestDoubles.swift
@@ -1,3 +1,4 @@
+#if Server
 @testable import BaseChatServerCore
 import BaseChatInference
 import BaseChatTestSupport
@@ -99,3 +100,5 @@ enum ServerTestBackendFactory {
         return backend
     }
 }
+
+#endif

--- a/docs/plans/744-basechatserver.md
+++ b/docs/plans/744-basechatserver.md
@@ -285,3 +285,13 @@ All four resolved.
 2. ~~`BaseChatServerCore` public vs `package`~~ → **`package`**. Premature `public` is a one-way door; promote when the menubar embedding ask (#807) materializes.
 3. ~~`--parallel` flag in v1~~ → **dropped**. Cargo-cult surface; reintroduce with cloud/Ollama pass-through in v2.
 4. ~~`/v1/models` shape~~ → **loaded model only**. Disk-scanning pulls in filesystem flake; route handlers wired against `InferenceService` (not a captured backend reference) keep v2 multi-model migration clean.
+
+---
+
+## Post-merge update (2026-05-02)
+
+`BaseChatServer` was put behind a new `Server` SwiftPM trait (off by default)
+in PR #TBD after the initial release inadvertently doubled per-PR CI wall
+time. The architectural pattern is unchanged; only the build-graph membership
+was scoped down. See `Package.swift` `traits:` block and `#if Server` guards
+in `Sources/BaseChatServer*/`.

--- a/docs/plans/744-basechatserver.md
+++ b/docs/plans/744-basechatserver.md
@@ -291,7 +291,7 @@ All four resolved.
 ## Post-merge update (2026-05-02)
 
 `BaseChatServer` was put behind a new `Server` SwiftPM trait (off by default)
-in PR #TBD after the initial release inadvertently doubled per-PR CI wall
+in PR #946 after the initial release inadvertently doubled per-PR CI wall
 time. The architectural pattern is unchanged; only the build-graph membership
 was scoped down. See `Package.swift` `traits:` block and `#if Server` guards
 in `Sources/BaseChatServer*/`.


### PR DESCRIPTION
## Summary

Per-PR CI roughly **doubled** (~290s → ~590s) after `64f1d57 feat(server): add OpenAI-compatible BaseChatServer` merged. Root cause: the new `Hummingbird` dep transitively pulled swift-nio + NIOSSL + BoringSSL + AsyncHTTPClient + ContainersPreview + Configuration into the default build graph (`Package.resolved` went from 20 → 38 pins, +90% in one PR), and the build step alone jumped from ~120s to **369s**.

This PR does two things in one cut:

1. **Fixes the regression** by trait-gating `BaseChatServer*` targets + the `Hummingbird`/`HummingbirdTesting` deps behind a new `Server` SwiftPM trait (off by default), mirroring the existing `HuggingFace` / `AnyLanguageModel` pattern. Server tests move to a path-filtered CI job that only runs when server code, `Package.swift`, or `Package.resolved` changes.
2. **Prevents recurrence** with a new `dep-budget` CI job that fails the PR if `Package.resolved` adds more than 2 new pins, with a `deps-ok` label as the override. Forces a deliberate sign-off whenever someone wants to bring in a heavy dep.

Expected outcome: typical PR CI returns to the pre-server baseline of ~290s. PRs touching server code pay the Hummingbird build (~3 min added) but in a parallel job, so wall-clock is unchanged.

## Worker checklist (3 workers, sequential foundation + 2 parallel polish)

- [x] **Worker 1** — `Package.swift` trait + `#if Server` guards on 11 source + 10 test files + `CLAUDE.md` test-command update (commit `6ef4396`). All 5 trait-combo gates green: trait-OFF compiled 0 Hummingbird files, trait-ON compiled 116, server tests gated to 0 when off / 48 passing when on.
- [x] **Worker 3** — `README.md` + `CHANGELOG.md` (Prisma-format Release Note in new `## Unreleased` section) + `docs/plans/744-basechatserver.md` post-merge note (commit `8ea0c6e`).
- [x] **Worker 2** — `ci.yml`: drop server filter from mega-batch, add path-filtered `server-tests` job (reuses cache), add `dep-budget` job (commit `e0c850a`).

## Notes

- **Not a build error for old usage.** `Sources/BaseChatServer/main.swift` got an `#else` no-op `@main` stub so the executable still links without the trait — `swift run BaseChatServer` (without `--traits Server`) builds, prints `"BaseChatServer was built without the Server trait..."`, and exits cleanly. Reflected in README + CHANGELOG language.
- **Two pre-existing trait gaps surfaced during exploration but are out of scope** — `BaseChatMCP` and `BaseChatVoice` declare traits that aren't actually compile-gated (the targets build unconditionally). Worth a follow-up `chore: actually trait-gate MCP` PR using the same pattern as this work. Deliberately not bundled to keep this PR focused on the regression.
- **CHANGELOG and `docs/plans/744-basechatserver.md` contain `#TBD` placeholders** for this PR's number — will swap in once assigned.
- **Pin delta vs main = 0**, so this PR does NOT trip its own `dep-budget` guardrail. No `deps-ok` label needed.

## Test plan

- [ ] CI's `test` job (mega-batch) wall-clock returns toward ~290s (was ~590s on `main`).
- [ ] CI's new `server-tests` job runs and passes.
- [ ] CI's new `dep-budget` job runs and reports `0 new pins`.
- [ ] After merge, throwaway test PR adding a heavy dep confirms `dep-budget` blocks until `deps-ok` label is added.

BREAKING CHANGE: BaseChatServer is no longer in the default build. Consumers must add `--traits Server` to `swift build`/`swift run`/`swift test` invocations that exercise the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)