### PR TITLE
perf(ci): batch security-audits' default-trait invocations

### DIFF
--- a/.github/workflows/security-gates.yml
+++ b/.github/workflows/security-gates.yml
@@ -59,16 +59,17 @@ jobs:
           git diff --exit-code Package.resolved || \
             (echo "Package.resolved is stale — run 'swift package resolve' and commit the result." && exit 1)
 
-      - name: Test — TrafficBoundaryAuditTest
+      # Two default-trait audits batched into one swift-test invocation so the
+      # SwiftPM build graph + test-bundle link is paid once instead of twice.
+      # Mirrors the mega-batch shape from ci.yml's `Test — XCTest suites` step.
+      # The CloudSaaS pinned-session audit below stays separate — its trait
+      # change forces a fresh resolve and can't share a build with these.
+      # Saves ~150s on every PR (Lever B of #953).
+      - name: Test — Traffic boundary + MCP hardening audits (batched)
         env:
           RUN_SLOW_TESTS: "1"
-          BASECHAT_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-traffic-boundary-audit.log
-        run: scripts/test.sh --filter "BaseChatInferenceTests.TrafficBoundaryAuditTest" --disable-default-traits --skip-update --min-passed 1
-
-      - name: Test — MCPHardeningTests
-        env:
-          BASECHAT_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-mcp-hardening.log
-        run: scripts/test.sh --filter "BaseChatMCPTests.MCPHardeningTests" --disable-default-traits --skip-update --min-passed 1
+          BASECHAT_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-traffic-boundary-and-mcp-hardening.log
+        run: scripts/test.sh --filter "BaseChatInferenceTests.TrafficBoundaryAuditTest" --filter "BaseChatMCPTests.MCPHardeningTests" --disable-default-traits --skip-update --min-passed 2
 
       - name: Test — PinnedSessionDelegateTests (CloudSaaS)
         env:


### PR DESCRIPTION
## Summary

Lever B of #953. Merges the first two sequential `swift test` invocations in the `security-audits` job (`TrafficBoundaryAuditTest` + `MCPHardeningTests`) into a single batched invocation so the SwiftPM build graph and test-bundle link are paid once instead of twice.

The third invocation (`PinnedSessionDelegateTests --traits CloudSaaS`) stays as its own step — the trait change forces a fresh resolve and it cannot share a build with the default-trait pair.

Mirrors the mega-batch shape from `ci.yml`'s `Test — XCTest suites` step (~line 250).

**Saving: ~150s on every PR.**

## Notes

- Preserved `RUN_SLOW_TESTS: "1"` env from the original `TrafficBoundaryAuditTest` step on the merged step.
- `--min-passed` bumped from `1` to `2` to honestly reflect that the merged invocation expects at least one test from each filter.
- `BASECHAT_TEST_OUTPUT_FILE` consolidated to `test-traffic-boundary-and-mcp-hardening.log`. No artifact-upload steps reference the old per-step log paths.

## Test plan

- [x] `actionlint .github/workflows/security-gates.yml` passes.
- [ ] CI runs the merged step on this PR — verify `Run swift test` reuses one build for both filters.
- [ ] Verify wall-clock for `security-audits` job drops by ~150s vs main.

Refs #953.