### PR TITLE
perf(build): trait-gate @ToolSchema macro behind Macros trait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,9 @@ jobs:
       # - BaseChatBackendsTests without traits runs only CI-safe cloud/SSE tests.
       # - Server tests run in the sibling `server-tests` job behind a paths
       #   filter so Hummingbird only compiles when server code changes.
+      # - Macro tests run in the sibling `macros-tests` job behind a paths
+      #   filter so swift-syntax (~647 files) only compiles when macro
+      #   code changes.
       # Local-only coverage:
       # - Run `swift test --filter BaseChatBackendsTests --traits MLX,Llama` on
       #   Apple Silicon for MLX/llama.cpp paths.
@@ -413,6 +416,110 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: xcresult-server-${{ github.run_attempt }}
+          if-no-files-found: ignore
+          retention-days: 7
+          path: test-diagnostics/
+
+  # Macro plugin tests are split out of the per-PR mega-batch because the
+  # `@ToolSchema` macro plugin pulls swift-syntax (~647 source files) into the
+  # build graph. Trait-gated behind `Macros` (off by default) so the default
+  # `test` job skips the swift-syntax compile cost; this job picks them up
+  # only when macro code or the dep graph changes.
+  macros-tests:
+    runs-on: macos-15  # match the `test` job runner so cache keys collide
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # paths-filter needs the parent commit to diff against on `push` events;
+          # `pull_request` works with the default shallow clone.
+          fetch-depth: 2
+
+      - name: Detect macro-relevant changes
+        id: macros-changed
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            macros:
+              - 'Sources/BaseChatMacrosPlugin/**'
+              - 'Sources/BaseChatInference/Macros/**'
+              - 'Tests/BaseChatInferenceTests/ToolSchemaMacro*.swift'
+              - 'Package.swift'
+              - 'Package.resolved'
+              - '.github/workflows/ci.yml'
+              - 'scripts/test.sh'
+
+      - name: Select Xcode
+        if: steps.macros-changed.outputs.macros == 'true'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.3"
+
+      - name: Cache SwiftPM build
+        if: steps.macros-changed.outputs.macros == 'true'
+        uses: actions/cache@v5
+        with:
+          # Same path/key shape as the `test` job — both jobs share the same
+          # SwiftPM dep tarball cache so we don't re-download the graph twice
+          # per workflow run.
+          path: |
+            .build/artifacts
+            .build/checkouts
+            .build/repositories
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
+            ${{ runner.os }}-${{ runner.arch }}-spm-
+
+      - name: Verify Swift toolchain matches Package.swift tools-version
+        if: steps.macros-changed.outputs.macros == 'true'
+        run: |
+          set -euo pipefail
+          tools_line=$(head -n 1 Package.swift)
+          tools_version=$(printf '%s\n' "$tools_line" | sed -E 's|^//[[:space:]]*swift-tools-version:[[:space:]]*([0-9]+\.[0-9]+).*|\1|')
+          if ! [[ "$tools_version" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "Could not parse swift-tools-version from first line of Package.swift: $tools_line"
+            exit 1
+          fi
+          swift_version_full=$(xcrun swift -version | head -n 1)
+          swift_version=$(printf '%s\n' "$swift_version_full" | sed -E 's|.*Swift version ([0-9]+\.[0-9]+).*|\1|')
+          if ! [[ "$swift_version" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "Could not parse Swift major.minor from: $swift_version_full"
+            exit 1
+          fi
+          tools_major=${tools_version%.*}; tools_minor=${tools_version#*.}
+          swift_major=${swift_version%.*}; swift_minor=${swift_version#*.}
+          if (( tools_major > swift_major )) || { (( tools_major == swift_major )) && (( tools_minor > swift_minor )); }; then
+            echo "::error::Package.swift requires swift-tools-version $tools_version but runner has Swift $swift_version. Lower swift-tools-version or upgrade the pinned Xcode."
+            exit 1
+          fi
+          echo "swift-tools-version=$tools_version OK against runner Swift $swift_version"
+
+      - name: Test — @ToolSchema macro suite (Macros trait)
+        id: test-macros
+        if: steps.macros-changed.outputs.macros == 'true'
+        timeout-minutes: 12
+        env:
+          BASECHAT_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-macros.log
+        run: scripts/test.sh --filter ToolSchemaMacro --disable-default-traits --traits Macros --skip-update
+
+      - name: Stage test diagnostics
+        if: failure() && steps.macros-changed.outputs.macros == 'true'
+        run: |
+          mkdir -p test-diagnostics
+          {
+            echo "run-id=${{ github.run_id }}"
+            echo "run-attempt=${{ github.run_attempt }}"
+            echo "job=macros-tests"
+            echo "test-macros-failed=${{ steps.test-macros.outcome == 'failure' }}"
+          } > test-diagnostics/failed-steps.txt
+
+      - name: Upload test diagnostics on failure
+        if: failure() && steps.macros-changed.outputs.macros == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: xcresult-macros-${{ github.run_attempt }}
           if-no-files-found: ignore
           retention-days: 7
           path: test-diagnostics/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,12 @@ swift test --filter BaseChatTestSupportTests --disable-default-traits
 swift test --filter BaseChatAppIntentsTests --disable-default-traits
 swift test --filter BaseChatServerTests --disable-default-traits --traits Server
 
+# @ToolSchema macro (trait-gated; off by default — keeps swift-syntax out
+# of default builds, ~647 source files saved). The macro plugin and the
+# `@ToolSchema` declaration in BaseChatInference are wrapped in `#if Macros`,
+# so the bare invocation runs zero macro tests.
+swift test --filter ToolSchemaMacro --disable-default-traits --traits Macros
+
 # Apple Silicon only — MLX mock tests + llama.cpp
 swift test --filter BaseChatBackendsTests --traits MLX,Llama
 

--- a/Package.swift
+++ b/Package.swift
@@ -40,6 +40,7 @@ let package = Package(
         .trait(name: "MCPBuiltinCatalog", description: "Enable BaseChatMCP's built-in catalog descriptors."),
         .trait(name: "Voice", description: "Enable the BaseChatVoice speech I/O spike and voice composer UI."),
         .trait(name: "Server", description: "Enable BaseChatServer (OpenAI-compatible HTTP server) and its Hummingbird dependency."),
+        .trait(name: "Macros", description: "Enable the @ToolSchema macro plugin and its swift-syntax dependency. Off by default — pulls ~647 source files into the build graph."),
         // Fuzz is intentionally NOT a default trait. Enabling it adds BaseChatBackends
         // (and transitively LlamaSwift) to fuzz-chat, which conflicts with the MLX
         // integration test targets in the auto-generated Xcode scheme. Run the fuzzer via
@@ -77,25 +78,34 @@ let package = Package(
     targets: [
         // Macro compiler plugin: implements @ToolSchema. Runs at build time in
         // the compiler's plugin host, not in app binaries. Only target that
-        // pulls swift-syntax into the graph.
+        // pulls swift-syntax into the graph — gated behind the `Macros` trait
+        // (off by default) so the ~647-file swift-syntax tree stays out of
+        // default builds. Consumers using `@ToolSchema` must add `--traits Macros`.
         .macro(
             name: "BaseChatMacrosPlugin",
             dependencies: [
-                .product(name: "SwiftSyntax", package: "swift-syntax"),
-                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
-                .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
-                .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
-                .product(name: "SwiftDiagnostics", package: "swift-syntax"),
+                .product(name: "SwiftSyntax", package: "swift-syntax", condition: .when(traits: ["Macros"])),
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax", condition: .when(traits: ["Macros"])),
+                .product(name: "SwiftSyntaxBuilder", package: "swift-syntax", condition: .when(traits: ["Macros"])),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax", condition: .when(traits: ["Macros"])),
+                .product(name: "SwiftDiagnostics", package: "swift-syntax", condition: .when(traits: ["Macros"])),
             ],
-            path: "Sources/BaseChatMacrosPlugin"
+            path: "Sources/BaseChatMacrosPlugin",
+            swiftSettings: [
+                .define("Macros", .when(traits: ["Macros"])),
+            ]
         ),
         // Inference: models, protocols, services — no SwiftData, no heavy ML deps.
         // Hosts the @ToolSchema attribute declaration so callers get the macro
-        // for free wherever JSONSchemaValue is in scope.
+        // for free wherever JSONSchemaValue is in scope. The macro plugin and
+        // its swift-syntax dependency are trait-gated (`Macros`, off by
+        // default); the `Sources/BaseChatInference/Macros/ToolSchema.swift`
+        // declaration is wrapped in `#if Macros` so the public API is only
+        // visible when the trait is enabled.
         .target(
             name: "BaseChatInference",
             dependencies: [
-                "BaseChatMacrosPlugin",
+                .target(name: "BaseChatMacrosPlugin", condition: .when(traits: ["Macros"])),
             ],
             path: "Sources/BaseChatInference",
             swiftSettings: [
@@ -104,6 +114,7 @@ let package = Package(
                 .define("Ollama", .when(traits: ["Ollama"])),
                 .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
                 .define("HuggingFace", .when(traits: ["HuggingFace"])),
+                .define("Macros", .when(traits: ["Macros"])),
             ]
         ),
         // MCP: Model Context Protocol client surface and tool bridge.
@@ -294,8 +305,8 @@ let package = Package(
             dependencies: [
                 "BaseChatInference",
                 "BaseChatTestSupport",
-                "BaseChatMacrosPlugin",
-                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+                .target(name: "BaseChatMacrosPlugin", condition: .when(traits: ["Macros"])),
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax", condition: .when(traits: ["Macros"])),
             ],
             // SilentCatchAuditTest reads `silent_catch_allowlist.txt` directly
             // from its on-disk source location via `#filePath`, so we don't
@@ -304,6 +315,7 @@ let package = Package(
             exclude: ["silent_catch_allowlist.txt"],
             swiftSettings: [
                 .define("HuggingFace", .when(traits: ["HuggingFace"])),
+                .define("Macros", .when(traits: ["Macros"])),
             ]
         ),
         // Swift Testing suites split from BaseChatInferenceTests to prevent a

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ BaseChatUI  ──────>  BaseChatPersistenceSwiftData  ─────�
 - **BaseChatAnyLanguageModelBridge** *(trait: `AnyLanguageModel`, default-off)* — Thin `InferenceBackend` adapter over HuggingFace's `AnyLanguageModel`.
 - **BaseChatVoice** — Optional speech-recognition / synthesis adapters and voice composer UI. Depends on `BaseChatUI` so hosts can opt in without adding a back-edge into the base chat surface.
 - **BaseChatServer** *(trait: `Server`, default-off)* — OpenAI-compatible HTTP server executable for exposing a selected `BaseChatInference` backend over `/v1/chat/completions`. Server targets are trait-gated; add `--traits Server` to `swift run`/`swift build`/`swift test` commands when working with `BaseChatServer`.
+- **`@ToolSchema` macro** *(trait: `Macros`, default-off)* — Synthesises `static var jsonSchema` on `Decodable` tool-argument structs. The macro plugin and its `swift-syntax` dependency (~647 source files) are gated behind the `Macros` trait so default builds skip the swift-syntax compile cost. Add `--traits Macros` to `swift build`/`swift test` invocations that use `@ToolSchema`.
 
 ## Quick Start
 

--- a/Sources/BaseChatInference/Macros/ToolSchema.swift
+++ b/Sources/BaseChatInference/Macros/ToolSchema.swift
@@ -1,3 +1,4 @@
+#if Macros
 import Foundation
 
 // MARK: - @ToolSchema
@@ -109,3 +110,4 @@ import Foundation
 /// `jsonSchema` property) without modifying any existing declarations.
 @attached(member, names: named(jsonSchema))
 public macro ToolSchema() = #externalMacro(module: "BaseChatMacrosPlugin", type: "ToolSchemaMacro")
+#endif

--- a/Sources/BaseChatMacrosPlugin/Plugin.swift
+++ b/Sources/BaseChatMacrosPlugin/Plugin.swift
@@ -1,3 +1,4 @@
+#if Macros
 import SwiftCompilerPlugin
 import SwiftSyntaxMacros
 
@@ -7,3 +8,15 @@ struct BaseChatMacrosPlugin: CompilerPlugin {
         ToolSchemaMacro.self,
     ]
 }
+#else
+// When the `Macros` trait is off, swift-syntax is excluded from the build
+// graph entirely (~647 files saved). The `.macro` SwiftPM target still
+// needs an `@main` entrypoint to link, so this stub provides a no-op
+// executable that is never invoked — the macro is unavailable behind
+// `#if Macros` guards in `Sources/BaseChatInference/Macros/ToolSchema.swift`,
+// so the compiler never asks the plugin to expand anything.
+@main
+struct BaseChatMacrosPluginNoOp {
+    static func main() {}
+}
+#endif

--- a/Sources/BaseChatMacrosPlugin/ToolSchemaMacro.swift
+++ b/Sources/BaseChatMacrosPlugin/ToolSchemaMacro.swift
@@ -1,3 +1,4 @@
+#if Macros
 import Foundation
 import SwiftSyntax
 import SwiftSyntaxMacros
@@ -454,3 +455,4 @@ enum ToolSchemaDiagnostic: DiagnosticMessage {
 
     var severity: DiagnosticSeverity { .error }
 }
+#endif

--- a/Tests/BaseChatInferenceTests/ToolSchemaMacroIntegrationTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolSchemaMacroIntegrationTests.swift
@@ -1,3 +1,4 @@
+#if Macros
 import XCTest
 import Foundation
 @testable import BaseChatInference
@@ -131,3 +132,4 @@ final class ToolSchemaMacroIntegrationTests: XCTestCase {
         XCTAssertFalse(result.isError)
     }
 }
+#endif

--- a/Tests/BaseChatInferenceTests/ToolSchemaMacroTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolSchemaMacroTests.swift
@@ -1,3 +1,4 @@
+#if Macros
 import XCTest
 import SwiftSyntax
 import SwiftSyntaxMacros
@@ -417,3 +418,4 @@ final class ToolSchemaMacroTests: XCTestCase {
         )
     }
 }
+#endif


### PR DESCRIPTION
## Summary

The `@ToolSchema` macro plugin imports `swift-syntax`, which adds **~647 source files** to every default build. Zero in-tree production code uses the macro — only its own tests do — so the swift-syntax compile cost buys nothing for the common build path. This PR mirrors the Server-trait pattern from #946 and peels the cost out of the default graph behind a new `Macros` trait (off by default).

Closes #952.

## What changed

- **`Package.swift`** — New `Macros` trait declaration (default-off). Every `.product(name: "SwiftSyntax*", package: "swift-syntax", ...)` reference now carries `condition: .when(traits: ["Macros"])`. `BaseChatInference`'s dep on `BaseChatMacrosPlugin` is conditional on the trait. `BaseChatInferenceTests` deps on `BaseChatMacrosPlugin` and `SwiftSyntaxMacrosTestSupport` are conditional. `Macros` `.define()` added to `BaseChatMacrosPlugin`, `BaseChatInference`, and `BaseChatInferenceTests` `swiftSettings`.
- **`Sources/BaseChatMacrosPlugin/Plugin.swift`** — Real `CompilerPlugin @main` wrapped in `#if Macros`; an `#else` no-op `@main` stub keeps the `.macro` target linkable when the trait is off (the macro is unavailable behind `#if Macros` guards in `BaseChatInference`, so the compiler never asks the plugin to expand anything).
- **`Sources/BaseChatMacrosPlugin/ToolSchemaMacro.swift`** — Whole file body wrapped in `#if Macros`.
- **`Sources/BaseChatInference/Macros/ToolSchema.swift`** — `@ToolSchema` declaration (and its `Foundation` import) wrapped in `#if Macros`.
- **`Tests/BaseChatInferenceTests/ToolSchemaMacroTests.swift`** + **`ToolSchemaMacroIntegrationTests.swift`** — Both wrapped in `#if Macros`. Bare invocation runs zero macro tests (verified).
- **`.github/workflows/ci.yml`** — New `macros-tests` job mirroring `server-tests`: path-filtered on `Sources/BaseChatMacrosPlugin/**`, `Sources/BaseChatInference/Macros/**`, `Tests/BaseChatInferenceTests/ToolSchemaMacro*.swift`, `Package.swift`, `Package.resolved`. Runs `scripts/test.sh --filter ToolSchemaMacro --disable-default-traits --traits Macros --skip-update`.
- **`CLAUDE.md`** + **`README.md`** — One-line opt-in note for the new trait.

## Verification

```
$ swift build --disable-default-traits 2>&1 | grep -c "Compiling SwiftSyntax"
0
$ swift build --disable-default-traits --traits Macros 2>&1 | grep -c "Compiling SwiftSyntax"
66
$ swift test --filter ToolSchemaMacro --disable-default-traits          # bare: 0 tests
$ swift test --filter ToolSchemaMacro --disable-default-traits --traits Macros  # 18/18 pass
```

Pre-push two-invocation gate (mirrors CI shape):
- XCTest mega-batch: **2512 passed, 0 failed, 11 skipped**
- Swift Testing isolated: **83 passed, 0 failed**

`Package.resolved` is unchanged (no new pins added to the default graph), so the `dep-budget` job stays at `0 new pins`.

## Test plan

- [ ] CI's `test` job continues to skip swift-syntax (build time should drop slightly vs. previous `main`).
- [ ] CI's new `macros-tests` job runs and passes.
- [ ] `dep-budget` reports `0 new pins`.

BREAKING CHANGE: `@ToolSchema` is no longer in the default build. Consumers using the macro must add `--traits Macros` to `swift build`/`swift test` invocations.