### PR TITLE
refactor(inference): narrow KeychainService.sweep to package

### DIFF
--- a/Sources/BaseChatInference/Services/KeychainService.swift
+++ b/Sources/BaseChatInference/Services/KeychainService.swift
@@ -237,7 +237,7 @@ public enum KeychainService {
     /// the sweep — a single bad row should not prevent the rest from being
     /// reclaimed. Intended to be driven once at boot from ``BaseChatBootstrap``.
     @discardableResult
-    public static func sweep(validAccounts: Set<String>) -> Int {
+    package static func sweep(validAccounts: Set<String>) -> Int {
         let stored = allAccounts()
         guard !stored.isEmpty else {
             Log.security.info("KeychainService.sweep: namespace empty, nothing to reap")


### PR DESCRIPTION
## Summary

- Narrows `KeychainService.sweep(validAccounts:)` from `public` to `package`
- The method is only called from `BaseChatBootstrap` (inside `BaseChatPersistenceSwiftData`), which is in the same package — no callers outside the package boundary exist
- Reduces the public API surface of `BaseChatInference` per the security hardening audit (#932)

## Test plan

- [ ] CI green (no call sites outside the package, so no compile breakage expected)
- [ ] Confirm `BaseChatBootstrap` still compiles — it's the only caller and lives in the same package