### PR TITLE
refactor(runtime): phase 1.2.5 PR-D — wire ChatViewModel adapter + branch sub-flow [rescue]

### DIFF
--- a/Sources/BaseChatBackends/OpenAIBackend.swift
+++ b/Sources/BaseChatBackends/OpenAIBackend.swift
@@ -164,10 +164,6 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             "max_tokens": config.maxOutputTokens ?? 2048
         ]
         if config.jsonMode {
-            // OpenAI-native providers accept `response_format`; Ollama's
-            // OpenAI-compatible adapter looks for the legacy top-level
-            // `format: "json"` switch.
-            body["format"] = "json"
             body["response_format"] = ["type": "json_object"]
         }
 
@@ -224,12 +220,19 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
     ) async throws {
         let tokenStream = SSEStreamParser.parse(bytes: bytes, limits: effectiveSSEStreamLimits)
 
-        var thinking = ThinkingBlockManager()
+        var thinkingOpen = false
         let toolAccumulator = StreamingToolCallAccumulator()
         // Tracks whether we've finalised tool calls already (for non-streaming
         // whole responses delivered as a single chunk, where `finish_reason`
         // and the final `tool_calls[]` arrive in the same payload).
         var finalisedToolCalls = false
+
+        func flushThinkingCompleteIfNeeded() {
+            if thinkingOpen {
+                continuation.yield(.thinkingComplete)
+                thinkingOpen = false
+            }
+        }
 
         func finaliseToolCalls() {
             guard !finalisedToolCalls else { return }
@@ -243,132 +246,133 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             }
         }
 
-        do {
-            for try await payload in tokenStream {
-                if Task.isCancelled { break }
+        for try await payload in tokenStream {
+            if Task.isCancelled { break }
 
-                if let progress = Self.parsePrefillProgress(from: payload) {
-                    continuation.yield(.prefillProgress(
-                        nPast: progress.nPast,
-                        nTotal: progress.nTotal,
-                        tokensPerSecond: progress.tokensPerSecond
-                    ))
-                    continue
+            if let progress = Self.parsePrefillProgress(from: payload) {
+                continuation.yield(.prefillProgress(
+                    nPast: progress.nPast,
+                    nTotal: progress.nTotal,
+                    tokensPerSecond: progress.tokensPerSecond
+                ))
+                continue
+            }
+
+            // Reasoning delta: emit as thinkingToken, keep the block open.
+            if let thinking = Self.parseReasoningDelta(from: payload) {
+                continuation.yield(.thinkingToken(thinking))
+                thinkingOpen = true
+                // Fall through — a single chunk may legally carry both
+                // reasoning and content (edge case on some providers), and
+                // usage may still need emitting.
+            }
+
+            // Tool-call deltas (streaming) — keyed by `index`. The first delta
+            // for each `index` carries `id` + `function.name`; subsequent
+            // deltas carry `function.arguments` fragments. Some compat servers
+            // do not re-emit `id` on later deltas, so we sticky-buffer it.
+            let toolDeltas = Self.parseToolCallDeltas(from: payload)
+            for delta in toolDeltas {
+                let key = "\(delta.index)"
+                let isNew = toolAccumulator.upsert(
+                    key: key,
+                    id: delta.id,
+                    name: delta.name,
+                    argumentsDelta: delta.argumentsDelta
+                )
+                if isNew {
+                    flushThinkingCompleteIfNeeded()
                 }
-
-                // Reasoning delta: emit as thinkingToken, keep the block open.
-                if let reasoning = Self.parseReasoningDelta(from: payload) {
-                    continuation.yield(.thinkingToken(reasoning))
-                    thinking.open()
-                    // Fall through — a single chunk may legally carry both
-                    // reasoning and content (edge case on some providers), and
-                    // usage may still need emitting.
+                // Emit `.toolCallStart` once we have both an id and a name
+                // for this entry. Some providers send the name in a later
+                // delta than the id, hence the lazy emit.
+                if let entry = toolAccumulator.entriesByKey[key],
+                   !entry.started, !entry.name.isEmpty {
+                    let resolvedId = toolAccumulator.resolvedId(forKey: key)
+                    continuation.yield(.toolCallStart(callId: resolvedId, name: entry.name))
+                    toolAccumulator.markStarted(key: key)
                 }
-
-                // Visible content delta: close thinking first so consumers see a
-                // clean handoff before the first visible token.
-                if let token = extractToken(from: payload) {
-                    thinking.flushIfOpen(into: continuation)
-                    continuation.yield(.token(token))
+                // Stream argument fragments under the resolved (sticky) id.
+                if let fragment = delta.argumentsDelta, !fragment.isEmpty {
+                    let resolvedId = toolAccumulator.resolvedId(forKey: key)
+                    continuation.yield(.toolCallArgumentsDelta(callId: resolvedId, textDelta: fragment))
                 }
+            }
 
-                // Tool-call deltas (streaming) — keyed by `index`. The first delta
-                // for each `index` carries `id` + `function.name`; subsequent
-                // deltas carry `function.arguments` fragments. Some compat servers
-                // do not re-emit `id` on later deltas, so we sticky-buffer it.
-                let toolDeltas = Self.parseToolCallDeltas(from: payload)
-                for delta in toolDeltas {
-                    let key = "\(delta.index)"
-                    let isNew = toolAccumulator.upsert(
-                        key: key,
-                        id: delta.id,
-                        name: delta.name,
-                        argumentsDelta: delta.argumentsDelta
-                    )
-                    if isNew {
-                        thinking.flushIfOpen(into: continuation)
-                    }
-                    // Emit `.toolCallStart` once we have both an id and a name.
-                    if let entry = toolAccumulator.entriesByKey[key],
-                       !entry.started, !entry.name.isEmpty {
+            // Non-streaming whole-message tool_calls (`message.tool_calls[]`).
+            // Some compat servers — and OpenAI itself when `stream:false` —
+            // deliver tool calls on `choices[0].message.tool_calls`. Treat
+            // each call as a single start+delta+toolCall triple to keep the
+            // event surface uniform across streaming/non-streaming.
+            if !finalisedToolCalls {
+                let wholeCalls = Self.parseWholeToolCalls(from: payload)
+                if !wholeCalls.isEmpty {
+                    flushThinkingCompleteIfNeeded()
+                    for call in wholeCalls {
+                        let key = call.id.isEmpty ? UUID().uuidString : call.id
+                        toolAccumulator.upsert(
+                            key: key,
+                            id: call.id,
+                            name: call.name,
+                            argumentsDelta: call.arguments
+                        )
                         let resolvedId = toolAccumulator.resolvedId(forKey: key)
-                        continuation.yield(.toolCallStart(callId: resolvedId, name: entry.name))
+                        continuation.yield(.toolCallStart(callId: resolvedId, name: call.name))
                         toolAccumulator.markStarted(key: key)
-                    }
-                    // Stream argument fragments under the resolved (sticky) id.
-                    if let fragment = delta.argumentsDelta, !fragment.isEmpty {
-                        let resolvedId = toolAccumulator.resolvedId(forKey: key)
-                        continuation.yield(.toolCallArgumentsDelta(callId: resolvedId, textDelta: fragment))
-                    }
-                }
-
-                // Non-streaming whole-message tool_calls (`message.tool_calls[]`).
-                if !finalisedToolCalls {
-                    let wholeCalls = Self.parseWholeToolCalls(from: payload)
-                    if !wholeCalls.isEmpty {
-                        thinking.flushIfOpen(into: continuation)
-                        for call in wholeCalls {
-                            let key = call.id.isEmpty ? UUID().uuidString : call.id
-                            toolAccumulator.upsert(
-                                key: key,
-                                id: call.id,
-                                name: call.name,
-                                argumentsDelta: call.arguments
-                            )
-                            let resolvedId = toolAccumulator.resolvedId(forKey: key)
-                            continuation.yield(.toolCallStart(callId: resolvedId, name: call.name))
-                            toolAccumulator.markStarted(key: key)
-                            if !call.arguments.isEmpty {
-                                continuation.yield(.toolCallArgumentsDelta(
-                                    callId: resolvedId,
-                                    textDelta: call.arguments
-                                ))
-                            }
+                        if !call.arguments.isEmpty {
+                            continuation.yield(.toolCallArgumentsDelta(
+                                callId: resolvedId,
+                                textDelta: call.arguments
+                            ))
                         }
                     }
                 }
+            }
 
-                if let usage = extractUsage(from: payload) {
-                    handleUsage(usage)
-                    if let prompt = usage.promptTokens,
-                       let completion = usage.completionTokens {
-                        continuation.yield(.usage(prompt: prompt, completion: completion))
-                    }
-                }
+            // Visible content delta: close thinking first so consumers see a
+            // clean handoff before the first visible token.
+            if let token = extractToken(from: payload) {
+                flushThinkingCompleteIfNeeded()
+                continuation.yield(.token(token))
+            }
 
-                // `finish_reason: "tool_calls"` finalises any buffered streaming
-                // tool calls. When the assistant turn ends with `stop` we still
-                // flush any accumulated tool calls so callers in the non-stream
-                // path see a uniform shape.
-                if let reason = Self.parseFinishReason(from: payload) {
-                    if reason == "tool_calls" || !toolAccumulator.entriesByKey.isEmpty {
-                        finaliseToolCalls()
-                    }
-                }
-
-                if isStreamEnd(payload) {
-                    thinking.flushIfOpen(into: continuation)
-                    break
-                }
-
-                if let error = extractStreamError(from: payload) {
-                    throw error
+            if let usage = extractUsage(from: payload) {
+                handleUsage(usage)
+                if let prompt = usage.promptTokens,
+                   let completion = usage.completionTokens {
+                    continuation.yield(.usage(prompt: prompt, completion: completion))
                 }
             }
-        } catch {
-            // Close any open thinking block before rethrowing so consumers
-            // see a clean handoff and don't hang in a thinking-only state.
-            thinking.flushIfOpen(into: continuation)
-            throw error
+
+            // `finish_reason: "tool_calls"` finalises any buffered streaming
+            // tool calls. When the assistant turn ends with `stop` we still
+            // flush any accumulated tool calls so callers in the non-stream
+            // path see a uniform shape.
+            if let reason = Self.parseFinishReason(from: payload) {
+                if reason == "tool_calls" || !toolAccumulator.entriesByKey.isEmpty {
+                    finaliseToolCalls()
+                }
+            }
+
+            if isStreamEnd(payload) {
+                flushThinkingCompleteIfNeeded()
+                break
+            }
+
+            if let error = extractStreamError(from: payload) {
+                throw error
+            }
         }
 
-        thinking.flushIfOpen(into: continuation)
-        // Stream end fallback: if the upstream closed without a `finish_reason`
-        // (some compat servers omit it), emit any buffered tool calls now so
-        // the orchestrator can dispatch them. On cancellation we deliberately
-        // skip this — dropping the consumer mid-stream must not produce
-        // phantom `.toolCall` events.
-        if !Task.isCancelled {
+        flushThinkingCompleteIfNeeded()
+        // Stream end fallback: if the upstream closed without a
+        // `finish_reason` (some compat servers omit it), emit any buffered
+        // tool calls now so the orchestrator can dispatch them.
+        if Task.isCancelled {
+            // Cancellation: do NOT emit `.toolCall` for incomplete entries.
+            // The contract is that consumers who drop the stream must not
+            // observe partial tool dispatch.
+        } else {
             finaliseToolCalls()
         }
     }

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -90,9 +90,7 @@ public struct GenerationConfig: Sendable, Codable {
 
     /// Requests backend-specific JSON-object-only generation for this call.
     ///
-    /// Runtime-only flag: defaults to `false` and is intentionally excluded
-    /// from Codable persistence, matching other per-request hints like
-    /// ``thinkingMarkers``. Backends that do not support structured output, or
+    /// Defaults to `false`. Backends that do not support structured output, or
     /// have not implemented JSON-mode wiring yet, silently ignore this flag.
     public var jsonMode: Bool
 
@@ -158,17 +156,7 @@ public struct GenerationConfig: Sendable, Codable {
     /// - Only honoured by `MLXBackend`; other backends ignore this field.
     public var yieldEveryNTokens: Int = 8
 
-    /// Capabilities the backend serving this request must provide.
-    ///
-    /// Empty (the default) means any wired backend may serve the request —
-    /// preserves the existing zero-config behaviour. When non-empty, ``RouterBackend``
-    /// dispatches to the first child whose ``BackendCapabilities`` satisfy every
-    /// requirement; backends used directly may use this for fail-fast validation.
-    /// Independent of ``tools`` / ``grammar`` / ``jsonMode`` — those are
-    /// per-request payloads; this is a per-request *contract*.
-    public var requiredCapabilities: Set<GenerationCapabilityRequirement> = []
-
-    @available(*, deprecated, message: "Use init(temperature:topP:repeatPenalty:topK:typicalP:minP:repetitionPenalty:seed:maxOutputTokens:tools:toolChoice:maxThinkingTokens:jsonMode:streamPrefillProgress:thinkingMarkers:maxToolIterations:grammar:yieldEveryNTokens:requiredCapabilities:) instead.")
+    @available(*, deprecated, message: "Use init(temperature:topP:repeatPenalty:topK:typicalP:minP:repetitionPenalty:seed:maxOutputTokens:tools:toolChoice:maxThinkingTokens:jsonMode:streamPrefillProgress:thinkingMarkers:maxToolIterations:grammar:yieldEveryNTokens:) instead.")
     public init(
         temperature: Float = 0.7,
         topP: Float = 0.9,
@@ -229,8 +217,7 @@ public struct GenerationConfig: Sendable, Codable {
         thinkingMarkers: ThinkingMarkers? = nil,
         maxToolIterations: Int = 10,
         grammar: String? = nil,
-        yieldEveryNTokens: Int = 8,
-        requiredCapabilities: Set<GenerationCapabilityRequirement> = []
+        yieldEveryNTokens: Int = 8
     ) {
         self.temperature = temperature
         self.topP = topP
@@ -250,18 +237,16 @@ public struct GenerationConfig: Sendable, Codable {
         self.maxToolIterations = max(1, maxToolIterations)
         self.grammar = grammar
         self.yieldEveryNTokens = yieldEveryNTokens
-        self.requiredCapabilities = requiredCapabilities
     }
 
     // MARK: Codable
 
     private enum CodingKeys: String, CodingKey {
         case temperature, topP, repeatPenalty, maxTokens, topK, typicalP, maxOutputTokens
-        case tools, toolChoice, maxThinkingTokens, maxToolIterations, grammar
+        case tools, toolChoice, maxThinkingTokens, jsonMode, maxToolIterations, grammar
         case yieldEveryNTokens
         case streamPrefillProgress
         case minP, repetitionPenalty, seed
-        case requiredCapabilities
     }
 
     public init(from decoder: Decoder) throws {
@@ -279,9 +264,7 @@ public struct GenerationConfig: Sendable, Codable {
         tools = (try c.decodeIfPresent([ToolDefinition].self, forKey: .tools)) ?? []
         toolChoice = (try c.decodeIfPresent(ToolChoice.self, forKey: .toolChoice)) ?? .auto
         maxThinkingTokens = try c.decodeIfPresent(Int.self, forKey: .maxThinkingTokens)
-        // jsonMode is a per-request runtime hint; persisted payloads always decode
-        // with the canonical default regardless of any legacy on-disk key.
-        jsonMode = false
+        jsonMode = (try c.decodeIfPresent(Bool.self, forKey: .jsonMode)) ?? false
         streamPrefillProgress = (try c.decodeIfPresent(Bool.self, forKey: .streamPrefillProgress)) ?? false
         // maxToolIterations landed after the original shape; default to 10 when absent and
         // clamp any persisted zero/negative value to the minimum of 1.
@@ -297,12 +280,6 @@ public struct GenerationConfig: Sendable, Codable {
         minP = try c.decodeIfPresent(Float.self, forKey: .minP)
         repetitionPenalty = try c.decodeIfPresent(Float.self, forKey: .repetitionPenalty)
         seed = try c.decodeIfPresent(UInt64.self, forKey: .seed)
-        // requiredCapabilities is a per-request runtime contract; landed after
-        // the original shape, so older payloads decode to an empty set.
-        requiredCapabilities = (try c.decodeIfPresent(
-            Set<GenerationCapabilityRequirement>.self,
-            forKey: .requiredCapabilities
-        )) ?? []
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -318,6 +295,7 @@ public struct GenerationConfig: Sendable, Codable {
         try c.encode(tools, forKey: .tools)
         try c.encode(toolChoice, forKey: .toolChoice)
         try c.encodeIfPresent(maxThinkingTokens, forKey: .maxThinkingTokens)
+        try c.encode(jsonMode, forKey: .jsonMode)
         try c.encode(streamPrefillProgress, forKey: .streamPrefillProgress)
         try c.encode(maxToolIterations, forKey: .maxToolIterations)
         try c.encodeIfPresent(grammar, forKey: .grammar)
@@ -325,9 +303,6 @@ public struct GenerationConfig: Sendable, Codable {
         try c.encodeIfPresent(minP, forKey: .minP)
         try c.encodeIfPresent(repetitionPenalty, forKey: .repetitionPenalty)
         try c.encodeIfPresent(seed, forKey: .seed)
-        if !requiredCapabilities.isEmpty {
-            try c.encode(requiredCapabilities, forKey: .requiredCapabilities)
-        }
     }
 }
 

--- a/Sources/BaseChatInference/Services/ToolRegistry.swift
+++ b/Sources/BaseChatInference/Services/ToolRegistry.swift
@@ -50,58 +50,12 @@ public protocol JSONSchemaValidating: Sendable {
 /// an actor would force a hop on every dispatch for no benefit. The executor's
 /// async `execute` call may still suspend off the main actor inside its own
 /// implementation.
-///
-/// ## Reentrancy
-///
-/// MainActor isolation serialises *entry* into ``register(_:)``,
-/// ``unregister(name:)``, and ``dispatch(_:)``, but `await
-/// executor.execute(arguments:)` inside ``dispatch(_:)`` suspends the
-/// current task. While that suspension is in flight, another MainActor
-/// caller can enter the registry and mutate the tool table — register
-/// a replacement, unregister the in-flight tool, swap the validator, or
-/// adjust the ``outputPolicy``.
-///
-/// The dispatch contract is:
-///
-/// > ``ToolRegistry`` captures the executor at dispatch entry. Registry
-/// > mutations during a suspended dispatch do not affect that dispatch's
-/// > outcome — the originally-resolved executor runs to completion.
-/// > Subsequent dispatches see the mutated state.
-///
-/// Concretely:
-///
-/// - The executor is looked up exactly once, at the top of ``dispatch(_:)``.
-///   The local `executor` reference holds the value; later table mutations
-///   on the same name do not retarget it.
-/// - The ``outputPolicy`` and ``validator`` references are also captured
-///   into local constants at dispatch entry, so a mid-flight policy swap
-///   only affects subsequent dispatches.
-/// - Snapshots taken from ``definitions`` reflect whatever state the
-///   table is in when the snapshot is read. Mid-dispatch mutations are
-///   visible immediately — the registry doesn't hide the change, it
-///   merely refuses to retarget the in-flight call.
-///
-/// As an observability hook, ``unregister(name:)`` emits a warning when
-/// it drops a tool that has at least one dispatch in flight. The
-/// in-flight dispatch still completes against the originally-resolved
-/// executor; the warning exists so ad-hoc registry juggling is visible
-/// in the inference log.
 @MainActor public final class ToolRegistry {
-    private static let reservedToolPrefixes = ["mcp__", "intent__"]
 
     // MARK: Storage
 
     /// Keyed on the lowercased tool name for case-insensitive lookup.
     private var tools: [String: any ToolExecutor] = [:]
-
-    /// In-flight dispatch counter, keyed on the lowercased tool name.
-    ///
-    /// Incremented at the top of ``dispatch(_:)`` once the executor has
-    /// been resolved, decremented in `defer`. ``unregister(name:)``
-    /// reads this to decide whether to log the
-    /// "unregistering while dispatch is in flight" warning. The counter
-    /// is single-threaded — every mutator hops the MainActor first.
-    private var dispatchesInFlight: [String: Int] = [:]
 
     // MARK: Configuration
 
@@ -112,34 +66,6 @@ public protocol JSONSchemaValidating: Sendable {
     /// concrete ``JSONSchemaValidator`` (or any other ``JSONSchemaValidating``
     /// conformer) so failures come back as ``ToolResult/ErrorKind/invalidArguments``.
     public var validator: (any JSONSchemaValidating)? = nil
-
-    /// When `true`, top-level string arguments are coerced to the primitive
-    /// type declared in the tool's `properties` schema before validation —
-    /// **and the coerced value is what the executor receives**.
-    ///
-    /// Smaller open-weight models routinely emit `"42"` for an `integer`
-    /// property or `"true"` for a `boolean`. Without coercion, the schema
-    /// validator rejects these calls and the user sees a hard failure for a
-    /// pure serialisation quirk. See ``ToolArgumentCoercer`` for the exact
-    /// rules — coercion only runs at the top level and unparseable strings
-    /// fall through unchanged so genuine type errors still surface.
-    ///
-    /// Tools that want to inspect the raw model output themselves can opt
-    /// out by setting this to `false`.
-    public var coercesArguments: Bool = true
-
-    /// Size policy applied to tool results before they are returned from
-    /// ``dispatch(_:)``.
-    ///
-    /// Defaults to ``ToolOutputPolicy``'s default — 32 KB
-    /// (``OversizeAction/rejectWithError``). See ``ToolOutputPolicy`` for
-    /// guidance on when to raise the ceiling (long file reads on
-    /// large-context backends) versus keep the default.
-    ///
-    /// The policy is captured into a local constant at dispatch entry, so
-    /// changing it mid-dispatch only affects subsequent dispatches —
-    /// matching the reentrancy contract on the registry itself.
-    public var outputPolicy: ToolOutputPolicy = ToolOutputPolicy()
 
     // MARK: - Init
 
@@ -169,12 +95,6 @@ public protocol JSONSchemaValidating: Sendable {
     /// inference log.
     public func register(_ tool: any ToolExecutor) {
         let key = tool.definition.name.lowercased()
-        if Self.reservedToolPrefixes.contains(where: { key.hasPrefix($0) }) {
-            Log.inference.warning(
-                "ToolRegistry: refusing to register reserved tool prefix for '\(tool.definition.name, privacy: .public)'"
-            )
-            return
-        }
         if tools[key] != nil {
             Log.inference.warning(
                 "ToolRegistry: overriding existing tool '\(tool.definition.name, privacy: .public)'"
@@ -184,20 +104,8 @@ public protocol JSONSchemaValidating: Sendable {
     }
 
     /// Removes a tool by name. No-op when the name is not registered.
-    ///
-    /// When the named tool has at least one in-flight dispatch, this method
-    /// logs an observability warning before removing the entry. The
-    /// in-flight dispatch still completes against the executor that was
-    /// resolved at its entry point — see the type-level "Reentrancy"
-    /// section.
     public func unregister(name: String) {
-        let key = name.lowercased()
-        if let inFlight = dispatchesInFlight[key], inFlight > 0 {
-            Log.inference.warning(
-                "ToolRegistry: unregistering '\(name, privacy: .public)' while a dispatch for that tool is in flight; the in-flight dispatch will complete with the originally-resolved executor"
-            )
-        }
-        tools.removeValue(forKey: key)
+        tools.removeValue(forKey: name.lowercased())
     }
 
     /// Returns `true` when a tool is registered under `name` (case-insensitive).
@@ -206,32 +114,10 @@ public protocol JSONSchemaValidating: Sendable {
     }
 
     /// All registered tool definitions, sorted by name for stable diffs / tests.
-    ///
-    /// Pass the result as `GenerationConfig.tools` when enqueueing a request.
-    /// For local backends (3B–8B instruct models), keep this list at or below
-    /// 5 entries — see README "Tool Calling" section.
     public var definitions: [ToolDefinition] {
-        let result = tools.values
+        tools.values
             .map(\.definition)
             .sorted { $0.name < $1.name }
-        #if DEBUG
-        if result.count > 5 {
-            print("[BaseChatKit] ⚠️ \(result.count) tools in this request. Local backends (3B–8B) degrade beyond ~5 — see README Tool Calling section.")
-        }
-        #endif
-        return result
-    }
-
-    /// Returns the registered executor for `toolName` (case-insensitive),
-    /// or `nil` when no tool is registered under that name.
-    ///
-    /// Used by ``ToolCallLoopOrchestrator`` to read
-    /// ``ToolExecutor/supportsConcurrentDispatch`` on every executor in a
-    /// batch before deciding whether to dispatch the batch in parallel.
-    /// The lookup does not mutate the registry and does not increment the
-    /// in-flight counter.
-    public func executor(for toolName: String) -> (any ToolExecutor)? {
-        tools[toolName.lowercased()]
     }
 
     /// Returns the registered executor's ``ToolExecutor/requiresApproval``
@@ -256,15 +142,8 @@ public protocol JSONSchemaValidating: Sendable {
     /// - Malformed argument JSON → ``ToolResult/ErrorKind/invalidArguments``
     /// - Schema validation failure (when ``validator`` is set) →
     ///   ``ToolResult/ErrorKind/invalidArguments``
-    /// - Executor throws `CancellationError`, or the surrounding task is
-    ///   cancelled mid-execute →
-    ///   ``ToolResult/ErrorKind/cancelled`` with a fixed
-    ///   `"cancelled by user"` content. This is the cooperative-cancellation
-    ///   path the orchestrator relies on when the user hits stop while a
-    ///   tool is in flight; see ``ToolExecutor`` for the executor-author
-    ///   contract.
-    /// - Executor throws any other error → ``ToolResult/ErrorKind/permanent``
-    ///   with `String(describing: error)` as the content.
+    /// - Executor throws → ``ToolResult/ErrorKind/permanent`` with
+    ///   `String(describing: error)` as the content
     ///
     /// The returned ``ToolResult/callId`` always matches the incoming
     /// ``ToolCall/id``, regardless of what the executor returned.
@@ -282,24 +161,6 @@ public protocol JSONSchemaValidating: Sendable {
             Log.inference.warning(
                 "ToolRegistry: case-insensitive match for '\(call.toolName, privacy: .public)' (registered as '\(executor.definition.name, privacy: .public)')"
             )
-        }
-
-        // Capture mutable configuration into local constants so a mid-flight
-        // mutation of `outputPolicy`/`validator` does not retarget this
-        // dispatch. See the type-level "Reentrancy" section.
-        let policy = outputPolicy
-        let activeValidator = validator
-
-        // Track this dispatch as in-flight so unregister(name:) can emit an
-        // observability warning if the registry is mutated mid-dispatch.
-        dispatchesInFlight[key, default: 0] += 1
-        defer {
-            let remaining = (dispatchesInFlight[key] ?? 1) - 1
-            if remaining <= 0 {
-                dispatchesInFlight.removeValue(forKey: key)
-            } else {
-                dispatchesInFlight[key] = remaining
-            }
         }
 
         // 2. Parse the raw argument JSON.
@@ -328,23 +189,9 @@ public protocol JSONSchemaValidating: Sendable {
             }
         }
 
-        // 3. Optional argument coercion — runs before validation so a
-        // string "42" for an integer property reaches the validator as
-        // .number(42), not .string("42"). The coerced value is then passed
-        // through to the executor as well: the whole point of coercion is
-        // that small models emit `"42"` and the tool wants `42`, so the
-        // executor must see the coerced form. Tools that need the raw
-        // string can opt out by clearing ``coercesArguments``.
-        let dispatchArguments: JSONSchemaValue
-        if coercesArguments {
-            dispatchArguments = ToolArgumentCoercer.coerce(parsedArguments, against: executor.definition.parameters)
-        } else {
-            dispatchArguments = parsedArguments
-        }
-
-        // 4. Optional schema validation (wave 2 wiring).
-        if let activeValidator,
-           let message = activeValidator.validateAgainst(executor.definition.parameters, value: dispatchArguments) {
+        // 3. Optional schema validation (wave 2 wiring).
+        if let validator,
+           let message = validator.validateAgainst(executor.definition.parameters, value: parsedArguments) {
             return ToolResult(
                 callId: call.id,
                 content: "arguments failed schema validation: \(message)",
@@ -352,207 +199,20 @@ public protocol JSONSchemaValidating: Sendable {
             )
         }
 
-        // 5. Execute, stamp callId, and apply the size policy.
-        let outcome: ToolResult
+        // 4. Execute and stamp callId.
         do {
-            let raw = try await executor.execute(arguments: dispatchArguments)
-            // If the surrounding task was cancelled but the executor returned
-            // a value anyway (didn't observe cancellation), still treat the
-            // outcome as cancelled so the orchestrator's transcript records
-            // the contract-defined ``ToolResult`` instead of a stale value.
-            if Task.isCancelled {
-                return ToolResult(
-                    callId: call.id,
-                    content: "cancelled by user",
-                    errorKind: .cancelled
-                )
-            }
-            outcome = ToolResult(
+            let raw = try await executor.execute(arguments: parsedArguments)
+            return ToolResult(
                 callId: call.id,
                 content: raw.content,
                 errorKind: raw.errorKind
             )
-        } catch is CancellationError {
-            return ToolResult(
-                callId: call.id,
-                content: "cancelled by user",
-                errorKind: .cancelled
-            )
         } catch {
-            // Foundation APIs that observe cancellation often throw
-            // `URLError(.cancelled)` rather than `CancellationError`. When
-            // the surrounding task has been cancelled, classify any thrown
-            // error as a cooperative cancellation so the dispatcher can
-            // distinguish "user hit stop" from a true permanent failure.
-            if Task.isCancelled {
-                return ToolResult(
-                    callId: call.id,
-                    content: "cancelled by user",
-                    errorKind: .cancelled
-                )
-            }
             return ToolResult(
                 callId: call.id,
                 content: String(describing: error),
                 errorKind: .permanent
             )
         }
-
-        return Self.applyOutputPolicy(policy, to: outcome)
-    }
-
-    // MARK: - Output policy
-
-    /// Applies ``outputPolicy`` to a finalized ``ToolResult``.
-    ///
-    /// Behaviour:
-    ///
-    /// - Successful results that fit within ``ToolOutputPolicy/maxBytes``
-    ///   pass through unchanged.
-    /// - Successful results that exceed the ceiling are rejected,
-    ///   truncated, or allowed according to ``ToolOutputPolicy/onOversize``.
-    /// - Already-errored results bypass the ``OversizeAction`` switch:
-    ///   re-classifying a `.permanent` error as `.invalidArguments` would
-    ///   confuse the model's retry logic, so oversize error content is
-    ///   simply truncated to ``ToolOutputPolicy/maxBytes`` while
-    ///   preserving the original ``ToolResult/errorKind``. Error messages
-    ///   that overflow the budget are pathological enough that the
-    ///   trimmed payload is always more useful than a hard reject.
-    /// - ``OversizeAction/allow`` skips the ceiling only for non-errored
-    ///   oversize results; already-errored results are still trimmed as
-    ///   described above (debug only).
-    static func applyOutputPolicy(
-        _ policy: ToolOutputPolicy,
-        to result: ToolResult
-    ) -> ToolResult {
-        let byteLength = result.content.utf8.count
-        if byteLength <= policy.maxBytes {
-            return result
-        }
-
-        // Already-errored results: keep the original errorKind, just trim.
-        if result.errorKind != nil {
-            return ToolResult(
-                callId: result.callId,
-                content: truncateUTF8(result.content, toByteLimit: policy.maxBytes),
-                errorKind: result.errorKind
-            )
-        }
-
-        switch policy.onOversize {
-        case .allow:
-            return result
-
-        case .rejectWithError:
-            return ToolResult(
-                callId: result.callId,
-                content: "output exceeds maxBytes (\(byteLength) > \(policy.maxBytes))",
-                errorKind: .invalidArguments
-            )
-
-        case .truncate(let suffix):
-            return truncateOversize(result: result, byteLength: byteLength, maxBytes: policy.maxBytes, suffix: suffix)
-
-        case .spillToFile(let threshold, let message):
-            // Below threshold: still oversize per maxBytes, but small
-            // enough that a file round-trip is unwarranted. Fall back to
-            // a generic truncation rather than silently passing through.
-            if byteLength < threshold {
-                return truncateOversize(result: result, byteLength: byteLength, maxBytes: policy.maxBytes, suffix: "... [truncated]")
-            }
-            do {
-                let url = try ToolSpillReaper.spill(content: result.content)
-                return ToolResult(
-                    callId: result.callId,
-                    content: message(byteLength, url),
-                    errorKind: nil
-                )
-            } catch {
-                // IO failure during spill must not crash the chat loop.
-                // Degrade gracefully to truncation so the model still gets
-                // a partial answer it can act on.
-                Log.inference.warning(
-                    "tool-spill write failed (\(String(describing: error), privacy: .public)); falling back to truncation"
-                )
-                return truncateOversize(result: result, byteLength: byteLength, maxBytes: policy.maxBytes, suffix: "... [truncated; spill failed]")
-            }
-        }
-    }
-
-    /// Shared truncation helper used by both ``OversizeAction/truncate`` and
-    /// the ``OversizeAction/spillToFile`` fallback paths. Guarantees the
-    /// returned content's UTF-8 byte length is `<= maxBytes`.
-    private static func truncateOversize(
-        result: ToolResult,
-        byteLength: Int,
-        maxBytes: Int,
-        suffix: String
-    ) -> ToolResult {
-        let suffixBytes = suffix.utf8.count
-        if suffixBytes >= maxBytes {
-            return ToolResult(
-                callId: result.callId,
-                content: truncateUTF8(suffix, toByteLimit: maxBytes),
-                errorKind: nil
-            )
-        }
-        let bodyBudget = maxBytes - suffixBytes
-        let trimmed = truncateUTF8(result.content, toByteLimit: bodyBudget)
-        return ToolResult(
-            callId: result.callId,
-            content: trimmed + suffix,
-            errorKind: nil
-        )
-    }
-
-    /// Trims `string` so its UTF-8 byte length is `<= byteLimit` without
-    /// splitting a multi-byte codepoint.
-    ///
-    /// Walks back from the limit until we find a byte that begins a UTF-8
-    /// scalar (i.e. is not a continuation byte `0b10xxxxxx`). Cheap and
-    /// boundary-safe for any Swift `String`.
-    static func truncateUTF8(_ string: String, toByteLimit byteLimit: Int) -> String {
-        if byteLimit <= 0 { return "" }
-        let utf8 = string.utf8
-        if utf8.count <= byteLimit { return string }
-
-        var endIndex = utf8.index(utf8.startIndex, offsetBy: byteLimit)
-        // Walk back past continuation bytes (10xxxxxx) so we don't slice
-        // mid-codepoint. The leading byte of any valid UTF-8 scalar has
-        // top bits 0xxxxxxx, 110xxxxx, 1110xxxx, or 11110xxx — never
-        // 10xxxxxx.
-        while endIndex > utf8.startIndex {
-            let byte = utf8[utf8.index(before: endIndex)]
-            if (byte & 0b1100_0000) == 0b1000_0000 {
-                endIndex = utf8.index(before: endIndex)
-            } else {
-                // The byte before endIndex is a leading byte. We need to
-                // confirm the scalar starting there fits entirely within
-                // the limit; if not, drop it.
-                let leadingIndex = utf8.index(before: endIndex)
-                let leading = utf8[leadingIndex]
-                let scalarLength: Int
-                if leading & 0b1000_0000 == 0 {
-                    scalarLength = 1
-                } else if leading & 0b1110_0000 == 0b1100_0000 {
-                    scalarLength = 2
-                } else if leading & 0b1111_0000 == 0b1110_0000 {
-                    scalarLength = 3
-                } else if leading & 0b1111_1000 == 0b1111_0000 {
-                    scalarLength = 4
-                } else {
-                    // Malformed leading byte — treat as 1 to make progress.
-                    scalarLength = 1
-                }
-                let scalarEnd = utf8.index(leadingIndex, offsetBy: scalarLength)
-                if scalarEnd <= endIndex {
-                    endIndex = scalarEnd
-                } else {
-                    endIndex = leadingIndex
-                }
-                break
-            }
-        }
-        return String(decoding: utf8[utf8.startIndex..<endIndex], as: UTF8.self)
     }
 }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Messages.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Messages.swift
@@ -25,6 +25,30 @@ extension ChatViewModel {
         inputText = ""
         Log.ui.debug("User sent message")
 
+        // Runtime path — delegate to ConversationRuntime when configured.
+        if let runtime = conversationRuntime {
+            let input = SendInput(
+                sessionID: activeSessionID,
+                userText: text,
+                systemPrompt: systemPrompt.isEmpty ? nil : systemPrompt,
+                temperature: temperature,
+                topP: topP,
+                repeatPenalty: repeatPenalty,
+                maxOutputTokens: maxOutputTokens,
+                maxThinkingTokens: maxThinkingTokens
+            )
+            do {
+                let handle = try await runtime.send(input)
+                activeConversationStreamHandle = handle
+            } catch {
+                Log.persistence.error("ConversationRuntime.send failed: \(error)")
+                surfaceError(error, kind: .persistence)
+            }
+            return
+        }
+
+        // GenerationCoordinator path (existing).
+
         // Create and persist the user message.
         let userMessage = ChatMessageRecord(role: .user, content: text, sessionID: activeSessionID)
         messages.append(userMessage)
@@ -64,6 +88,29 @@ extension ChatViewModel {
 
         guard let activeSessionID else { return }
 
+        // Runtime path — delegate to ConversationRuntime when configured.
+        if let runtime = conversationRuntime {
+            let input = RegenerateInput(
+                sessionID: activeSessionID,
+                systemPrompt: systemPrompt.isEmpty ? nil : systemPrompt,
+                temperature: temperature,
+                topP: topP,
+                repeatPenalty: repeatPenalty,
+                maxOutputTokens: maxOutputTokens,
+                maxThinkingTokens: maxThinkingTokens
+            )
+            do {
+                let handle = try await runtime.regenerate(input)
+                activeConversationStreamHandle = handle
+            } catch {
+                Log.ui.error("ConversationRuntime.regenerate failed: \(error)")
+                surfaceError(error, kind: .generation)
+            }
+            return
+        }
+
+        // GenerationCoordinator path (existing).
+
         // Find and remove the last assistant message.
         guard let lastAssistantIndex = messages.lastIndex(where: { $0.role == .assistant }) else {
             return
@@ -89,10 +136,38 @@ extension ChatViewModel {
 
     /// Edits a message and regenerates everything after it.
     public func editMessage(_ messageID: UUID, newContent: String) async {
-        guard let index = messages.firstIndex(where: { $0.id == messageID }) else { return }
+        guard messages.firstIndex(where: { $0.id == messageID }) != nil else { return }
         guard !isGenerating else { return }
 
         guard let activeSessionID else { return }
+
+        // Runtime path — delegate to ConversationRuntime when configured.
+        if let runtime = conversationRuntime {
+            let input = EditInput(
+                sessionID: activeSessionID,
+                messageID: messageID,
+                newContent: newContent,
+                systemPrompt: systemPrompt.isEmpty ? nil : systemPrompt,
+                temperature: temperature,
+                topP: topP,
+                repeatPenalty: repeatPenalty,
+                maxOutputTokens: maxOutputTokens,
+                maxThinkingTokens: maxThinkingTokens
+            )
+            // Invalidate the token cache for the edited message — content changed.
+            tokenCountCache.removeValue(forKey: messageID)
+            do {
+                let handle = try await runtime.edit(input)
+                activeConversationStreamHandle = handle
+            } catch {
+                Log.ui.error("ConversationRuntime.edit failed: \(error)")
+                surfaceError(error, kind: .generation)
+            }
+            return
+        }
+
+        // GenerationCoordinator path (existing).
+        guard let index = messages.firstIndex(where: { $0.id == messageID }) else { return }
 
         // Update the edited message.
         let originalMessage = messages[index]
@@ -146,6 +221,21 @@ extension ChatViewModel {
     /// changing observable semantics. Keep sync; do not "fix" the
     /// inconsistency in a future refactor.
     public func stopGeneration() {
+        // Runtime path — cancel the in-flight ConversationRuntime stream.
+        if let runtime = conversationRuntime, let handle = activeConversationStreamHandle {
+            activeConversationStreamHandle = nil
+            Task { [weak self] in
+                await runtime.cancel(handle)
+                // The runtime emits .streamFinished(reason: .cancelled) which
+                // drives transitionPhase(.idle) via handle(runtimeEvent:).
+                // No additional phase transition needed here.
+                _ = self  // suppress capture warning
+            }
+            Log.ui.debug("Generation stopped by user (runtime path)")
+            return
+        }
+
+        // GenerationCoordinator path (existing).
         generationTask?.cancel()
         generationTask = nil
         activeGenerationToken = nil

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+RuntimeAdapter.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+RuntimeAdapter.swift
@@ -1,0 +1,88 @@
+import Foundation
+import BaseChatCore
+import BaseChatInference
+
+// MARK: - ChatViewModel + RuntimeAdapter
+//
+// Maps ConversationEvent values from the optional ConversationRuntime drain
+// task back to @Observable state mutations. This file owns the event-to-state
+// bridge; ChatViewModel+Messages.swift owns the send/regenerate/edit/stop
+// delegation through the runtime.
+
+extension ChatViewModel {
+
+    /// Maps an incoming ``ConversationEvent`` to `@Observable` state mutations.
+    ///
+    /// Called exclusively from the long-lived drain task started in
+    /// ``configure(conversationRuntime:)``. All mutations land on `@MainActor`
+    /// so SwiftUI observation picks them up synchronously.
+    @MainActor
+    func handle(runtimeEvent event: ConversationEvent) async {
+        switch event {
+
+        // MARK: Message lifecycle
+
+        case .messageInserted(let record):
+            // Guard against duplicates — the runtime may insert the user
+            // message before `sendMessage` appends it locally, or vice versa.
+            if !messages.contains(where: { $0.id == record.id }) {
+                messages.append(record)
+            } else {
+                // Update in place in case the runtime persisted a richer version
+                // (e.g. timestamped) of a message we pre-inserted as a placeholder.
+                mutateMessage(id: record.id) { $0 = record }
+            }
+
+        case .messageRemoved(let id):
+            messages.removeAll(where: { $0.id == id })
+
+        case .messageUpdated(let record):
+            if let idx = messages.firstIndex(where: { $0.id == record.id }) {
+                messages[idx] = record
+            }
+
+        // MARK: Stream lifecycle
+
+        case .streamStarted:
+            // The runtime pre-inserts the assistant record; here we just
+            // transition phase. The actual message slot arrives via
+            // .messageInserted when the runtime finalises the assistant record.
+            transitionPhase(to: .waitingForFirstToken)
+
+        case .tokenEmitted(let messageID, let delta):
+            transitionPhase(to: .streaming)
+            mutateMessage(id: messageID) { $0.content += delta }
+
+        case .streamFinished:
+            transitionPhase(to: .idle)
+            updateContextEstimate()
+
+        // MARK: Errors
+
+        case .errorRaised(let error):
+            switch error {
+            case .persistence(let underlying):
+                surfaceError(underlying, kind: .persistence)
+            case .inference(let underlying):
+                surfaceError(underlying, kind: .generation)
+            case .cancelled:
+                // User-initiated cancel — suppress error UI.
+                break
+            case .contextAssembly(let underlying):
+                surfaceError(underlying, kind: .generation)
+            case .messageNotFound, .noAssistantMessageToRegenerate, .providerNotConfigured:
+                errorMessage = error.localizedDescription
+            }
+            transitionPhase(to: .idle)
+
+        // MARK: Observational / future cases
+
+        case .beforeContextAssembly, .contextAssembled, .afterGeneration,
+             .compressionTriggered, .toolCallRequested, .toolCallApproved,
+             .toolCallCompleted, .sessionBranched:
+            // These are observational or reserved for future sub-flows.
+            // No ChatViewModel state mutation is needed here yet.
+            break
+        }
+    }
+}

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -481,6 +481,26 @@ public final class ChatViewModel {
         set { loadCoordinator.progressBridgeMinTransitionInterval = newValue }
     }
 
+    // MARK: - ConversationRuntime Adapter
+
+    /// Optional reference runtime. When non-nil, send/regenerate/edit/cancel
+    /// delegate to it and the event drain task maps ConversationEvent back to
+    /// @Observable state. When nil, the existing GenerationCoordinator path
+    /// runs unchanged.
+    ///
+    /// Internal (not private) so that extensions in sibling files within this
+    /// module can read it. The setter stays internal — external callers use
+    /// ``configure(conversationRuntime:)``.
+    var conversationRuntime: ConversationRuntime?
+
+    /// Drain task for the runtime event stream. Cancelled when the runtime
+    /// is replaced or the view model is torn down.
+    @ObservationIgnored
+    private var runtimeEventDrainTask: Task<Void, Never>?
+
+    /// Handle to the in-flight ConversationRuntime stream, used to cancel it.
+    var activeConversationStreamHandle: ConversationStreamHandle?
+
     // MARK: - Private State
 
     /// Token for the currently active generation request, if any.
@@ -717,6 +737,29 @@ public final class ChatViewModel {
     /// genuinely separate stores can pass a small composed adapter.
     public func configure(persistence: any SessionStore & MessageStore) {
         sessionController.configure(persistence: persistence)
+    }
+
+    /// Wires an optional ``ConversationRuntime`` as the send/regenerate/edit/cancel
+    /// delegate for this view model.
+    ///
+    /// When a runtime is configured, ``sendMessage()``, ``regenerateLastResponse()``,
+    /// ``editMessage(_:newContent:)``, and ``stopGeneration()`` route through it
+    /// instead of ``GenerationCoordinator``. A long-lived event-drain task maps
+    /// ``ConversationEvent`` values back to `@Observable` state on `@MainActor`.
+    ///
+    /// Calling this method a second time cancels the prior drain task and replaces
+    /// the runtime. Pass `nil` explicitly (via the private path) to revert to the
+    /// ``GenerationCoordinator`` path — the public API only supports setting a runtime,
+    /// not clearing one, to avoid accidental reversion after bootstrap.
+    public func configure(conversationRuntime runtime: ConversationRuntime) {
+        runtimeEventDrainTask?.cancel()
+        conversationRuntime = runtime
+        runtimeEventDrainTask = Task { [weak self] in
+            guard let self else { return }
+            for await event in runtime.events {
+                await self.handle(runtimeEvent: event)
+            }
+        }
     }
 
     // MARK: - Structured Error Surfacing

--- a/Tests/BaseChatBackendsTests/OpenAICompatEndpointTests.swift
+++ b/Tests/BaseChatBackendsTests/OpenAICompatEndpointTests.swift
@@ -207,20 +207,6 @@ struct OpenAICompatEndpointTests {
         #expect(events[1] == .prefillProgress(nPast: 3072, nTotal: 4096, tokensPerSecond: 300.5))
         #expect(events[2] == .prefillProgress(nPast: 4096, nTotal: 4096, tokensPerSecond: 295.0))
         #expect(events[3] == .token("Hello"))
-
-        // Contract (issue #746): the prefill_progress event immediately preceding
-        // the first content token must satisfy nPast == nTotal. UI observers
-        // rely on this equality to flip from "evaluating prompt" to "generating".
-        let firstTokenIndex = events.firstIndex(where: { if case .token = $0 { true } else { false } })
-        let lastPrefillBeforeToken = events
-            .prefix(firstTokenIndex ?? events.count)
-            .last(where: { if case .prefillProgress = $0 { true } else { false } })
-        guard case let .prefillProgress(nPast: boundaryNPast, nTotal: boundaryNTotal, tokensPerSecond: _) = lastPrefillBeforeToken else {
-            Issue.record("Expected at least one prefill_progress event before the first content token")
-            return
-        }
-        #expect(boundaryNPast == boundaryNTotal,
-                "Final prefill_progress before generation must report nPast == nTotal")
     }
 
     /// Ollama versions before 0.4.0 do not support `stream_options` and silently

--- a/Tests/BaseChatInferenceTests/GenerationConfigTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationConfigTests.swift
@@ -85,31 +85,6 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertTrue(config.jsonMode)
     }
 
-    func test_codable_omitsJsonMode_evenWhenTrue() throws {
-        let config = GenerationConfig(jsonMode: true)
-
-        let data = try JSONEncoder().encode(config)
-        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
-
-        XCTAssertNil(json["jsonMode"])
-    }
-
-    func test_codable_decode_resetsRuntimeOnlyJsonModeToFalse() throws {
-        let payload = """
-        {
-            "temperature": 0.7,
-            "topP": 0.9,
-            "repeatPenalty": 1.1,
-            "maxTokens": 512,
-            "jsonMode": true
-        }
-        """
-        let data = try XCTUnwrap(payload.data(using: .utf8))
-        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: data)
-
-        XCTAssertFalse(decoded.jsonMode)
-    }
-
     func test_streamPrefillProgress_isMutable() {
         var config = GenerationConfig()
         config.streamPrefillProgress = true
@@ -209,6 +184,7 @@ final class GenerationConfigTests: XCTestCase {
             "repeatPenalty": 1.1,
             "tools": [],
             "toolChoice": {"type": "auto"},
+            "jsonMode": false,
             "maxToolIterations": 10
         }
         """

--- a/Tests/BaseChatUITests/ChatViewModelRuntimeAdapterTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelRuntimeAdapterTests.swift
@@ -1,0 +1,246 @@
+@preconcurrency import XCTest
+import Foundation
+@testable import BaseChatUI
+@testable import BaseChatCore
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+// MARK: - Phase 1.2.5 PR-D: ChatViewModel ↔ ConversationRuntime adapter tests
+//
+// These tests verify the three new behaviours introduced by the adapter layer:
+//
+//  1. `test_sendMessage_withRuntime_delegatesToRuntime` — when a runtime is
+//     configured, `sendMessage()` routes through it and the event drain maps
+//     ConversationEvent back to `messages`.
+//
+//  2. `test_stopGeneration_withRuntime_cancelsHandle` — `stopGeneration()` on
+//     the runtime path calls `runtime.cancel(handle)` which drives the stream
+//     to a `cancelled` finish reason via the drain task.
+//
+//  3. `test_sendMessage_withoutRuntime_usesExistingPath` — no runtime
+//     configured; the existing GenerationCoordinator path runs unchanged.
+
+@MainActor
+final class ChatViewModelRuntimeAdapterTests: XCTestCase {
+
+    // MARK: - In-memory stores (copied shape from ConversationRuntimeTests)
+
+    /// Minimal in-memory MessageStore used by the runtime in these tests.
+    final class RuntimeMessageStore: MessageStore, @unchecked Sendable {
+        private(set) var messages: [UUID: ChatMessageRecord] = [:]
+        private var hooks: [any MessageStorePostWriteHook] = []
+
+        func insertMessage(_ message: ChatMessageRecord) async throws {
+            messages[message.id] = message
+            for hook in hooks { await hook.messageDidWrite(message, in: message.sessionID) }
+        }
+        func updateMessage(_ message: ChatMessageRecord) async throws {
+            guard messages[message.id] != nil else {
+                throw ChatPersistenceError.messageNotFound(message.id)
+            }
+            messages[message.id] = message
+            for hook in hooks { await hook.messageDidWrite(message, in: message.sessionID) }
+        }
+        func deleteMessage(_ messageID: UUID) async throws {
+            guard messages.removeValue(forKey: messageID) != nil else {
+                throw ChatPersistenceError.messageNotFound(messageID)
+            }
+        }
+        func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
+            messages.values
+                .filter { $0.sessionID == sessionID }
+                .sorted { $0.timestamp < $1.timestamp }
+        }
+        func deleteMessages(for sessionID: UUID) async throws {
+            messages = messages.filter { $0.value.sessionID != sessionID }
+        }
+        func addPostWriteHook(_ hook: any MessageStorePostWriteHook) {
+            hooks.append(hook)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var harnesses: [TestChatViewModelHarness] = []
+
+    override func tearDown() async throws {
+        for h in harnesses { h.cleanup() }
+        harnesses.removeAll()
+        try await super.tearDown()
+    }
+
+    /// Builds a `ChatViewModel` backed by a `MockInferenceBackend` (model pre-loaded).
+    private func makeVM(mock: MockInferenceBackend) throws -> ChatViewModel {
+        let h = try makeTestChatViewModel(
+            mock: mock,
+            activateSession: true
+        )
+        harnesses.append(h)
+        return h.vm
+    }
+
+    /// Builds a `ConversationRuntime` wired to `mock` and a fresh in-memory store.
+    private func makeRuntime(
+        mock: MockInferenceBackend,
+        store: RuntimeMessageStore = RuntimeMessageStore()
+    ) -> ConversationRuntime {
+        let inference = InferenceService(backend: mock, name: "Mock")
+        mock.isModelLoaded = true
+        return ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference
+        )
+    }
+
+    // MARK: - Test 1: sendMessage with runtime delegates and drains events to messages
+
+    func test_sendMessage_withRuntime_delegatesToRuntime() async throws {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.tokensToYield = ["Hello", " from", " runtime"]
+
+        let vm = try makeVM(mock: mock)
+        let store = RuntimeMessageStore()
+        let runtime = makeRuntime(mock: mock, store: store)
+
+        // Wire the runtime to the view model.
+        vm.configure(conversationRuntime: runtime)
+
+        guard let sessionID = vm.activeSessionID else {
+            XCTFail("activeSession must be set")
+            return
+        }
+
+        // Launch sendMessage on a Task so we can interleave await points.
+        // The runtime path returns immediately after kicking off the detached
+        // generation task, so we cannot simply `await sendMessage()` and then
+        // check results — we must wait for the drain to finish.
+        vm.inputText = "Hello runtime"
+        let sendTask = Task { @MainActor in
+            await vm.sendMessage()
+        }
+
+        // Wait for the stream to start (streamStarted event drives .waitingForFirstToken).
+        await vm.awaitGenerating(true)
+        // Wait for the stream to finish (streamFinished event drives .idle).
+        await vm.awaitGenerating(false)
+        await sendTask.value
+
+        // The runtime's event drain should have inserted both the user message
+        // and the assistant message into vm.messages.
+        let userMessages = vm.messages.filter { $0.role == .user }
+        let assistantMessages = vm.messages.filter { $0.role == .assistant }
+
+        XCTAssertEqual(userMessages.count, 1, "Should have one user message from runtime send")
+        XCTAssertEqual(userMessages.first?.content, "Hello runtime", "User message content must match input")
+
+        // The runtime persists the assistant message and emits .messageInserted.
+        XCTAssertEqual(assistantMessages.count, 1, "Should have one assistant message from runtime drain")
+        XCTAssertEqual(
+            assistantMessages.first?.content, "Hello from runtime",
+            "Assistant content should be the concatenated token stream"
+        )
+
+        // The runtime should have persisted both messages to the store.
+        let stored = try await store.fetchMessages(for: sessionID)
+        XCTAssertEqual(stored.count, 2, "Runtime store should hold user + assistant messages")
+        XCTAssertTrue(stored.contains(where: { $0.role == .assistant && $0.content == "Hello from runtime" }),
+                      "Persisted assistant message should contain streamed tokens")
+    }
+
+    // Sabotage check: if configure(conversationRuntime:) were never called, the runtime
+    // path would not run. This is validated by test 3 below.
+
+    // MARK: - Test 2: stopGeneration with runtime cancels the in-flight handle
+
+    func test_stopGeneration_withRuntime_cancelsHandle() async throws {
+        let slowBackend = SlowMockBackend()
+        slowBackend.tokensToYield = (0..<20).map { "tok\($0) " }
+        slowBackend.delayPerToken = .milliseconds(30)
+
+        let suiteName = "BaseChatKitTests-RuntimeAdapter-Cancel-\(UUID().uuidString)"
+        guard let testDefaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to allocate UserDefaults suite")
+            return
+        }
+        defer { testDefaults.removePersistentDomain(forName: suiteName) }
+
+        let modelsDir = makeIsolatedModelsDirectory()
+        defer { try? FileManager.default.removeItem(at: modelsDir) }
+
+        let inference = InferenceService(backend: slowBackend, name: "SlowMock")
+        let vm = ChatViewModel(
+            inferenceService: inference,
+            modelStorage: ModelStorageService(baseDirectory: modelsDir),
+            memoryPressure: MemoryPressureHandler(),
+            userDefaults: testDefaults
+        )
+        vm.activeSession = ChatSessionRecord(title: "Cancel Test")
+
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference
+        )
+
+        vm.configure(conversationRuntime: runtime)
+
+        vm.inputText = "Tell me something slow"
+        let sendTask = Task { @MainActor in
+            await vm.sendMessage()
+        }
+
+        // Wait until the stream is flowing (streamStarted drives .waitingForFirstToken).
+        await vm.awaitGenerating(true)
+        // Give at least one token time to land so partial content exists.
+        try? await Task.sleep(for: .milliseconds(80))
+
+        // Cancel via stopGeneration — runtime path must be chosen.
+        vm.stopGeneration()
+
+        await sendTask.value
+
+        // Wait for the drain task to process the cancelled stream's terminal events.
+        await vm.awaitGenerating(false)
+
+        XCTAssertFalse(vm.isGenerating, "isGenerating should be false after stopGeneration")
+
+        // The runtime path does not produce error UI for user-initiated cancellation.
+        XCTAssertNil(vm.errorMessage, "No error message should be surfaced for user-initiated cancel")
+
+        // At most user + partial assistant (the user message is inserted by the runtime
+        // before the stream task fires; the partial assistant arrives on cancel if
+        // any tokens landed).
+        XCTAssertLessThanOrEqual(vm.messages.count, 2, "Should have at most user + partial assistant")
+    }
+
+    // MARK: - Test 3: sendMessage without runtime uses GenerationCoordinator (existing path)
+
+    func test_sendMessage_withoutRuntime_usesExistingPath() async throws {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.tokensToYield = ["GenerationCoordinator", " path"]
+
+        let vm = try makeVM(mock: mock)
+
+        // No configure(conversationRuntime:) call — runtime stays nil.
+        XCTAssertNil(vm.conversationRuntime, "Precondition: no runtime configured")
+
+        vm.inputText = "Hello from coordinator path"
+        await vm.sendMessage()
+
+        // GenerationCoordinator path: messages are built locally and streamed in.
+        let userMessages = vm.messages.filter { $0.role == .user }
+        let assistantMessages = vm.messages.filter { $0.role == .assistant }
+
+        XCTAssertEqual(userMessages.count, 1, "Should have one user message")
+        XCTAssertEqual(userMessages.first?.content, "Hello from coordinator path")
+        XCTAssertEqual(assistantMessages.count, 1, "Should have one assistant message")
+        XCTAssertEqual(
+            assistantMessages.first?.content, "GenerationCoordinator path",
+            "Assistant content should match mock tokens (coordinator path)"
+        )
+        XCTAssertFalse(vm.isGenerating, "isGenerating should be false after completion")
+    }
+}
+


### PR DESCRIPTION
## Summary

Two commits rescued from BCK-3 worktrees before that clone is deleted. Both are phase 1.2.5 (ConversationRuntime) PR-D work — needs review to determine if this is already covered by merged PRs (#899/#902/#903/#905) or if it contains net-new changes.

**Commits:**
- `8936388` — add branch sub-flow to ConversationRuntime (`BranchInput`, `ConversationEvent.sessionBranched`, `branch(_:)`, 5 tests)
- `17421b5` — wire ChatViewModel adapter to ConversationRuntime (`ChatViewModel+RuntimeAdapter.swift`, 246-line test file)

⚠️ This branch will need a rebase onto main before it can merge — cherry-pick conflicted due to main moving past the base. Review first to confirm these aren't already covered.

See also companion branch: `worktree-agent-a9fb21b6d27748279`