### PR TITLE
feat(openai): image_url content parts for vision models

### DIFF
--- a/Sources/BaseChatBackends/Internal/CloudImageEncoding.swift
+++ b/Sources/BaseChatBackends/Internal/CloudImageEncoding.swift
@@ -33,6 +33,20 @@ enum CloudImageEncoding {
         data.base64EncodedString()
     }
 
+    /// Returns a `data:` URI (RFC 2397) suitable for OpenAI's
+    /// `image_url.url` field — `data:<mime>;base64,<payload>`. OpenAI also
+    /// accepts public `https://` URLs there, but we always have the bytes
+    /// in-process at this layer, so the data URI is the simplest path.
+    ///
+    /// The MIME type is passed through untouched. OpenAI's vision endpoint
+    /// accepts at least `image/png`, `image/jpeg`, `image/gif`, and
+    /// `image/webp`; an exotic value will surface as an upstream 400, which
+    /// matches the same failure mode persisted images would already have on
+    /// other backends.
+    static func dataURI(data: Data, mimeType: String) -> String {
+        "data:\(mimeType);base64,\(base64String(from: data))"
+    }
+
     /// Counts every `.image` part across `messages`. Used by callers that
     /// enforce a per-request image cap (Anthropic = 5 per *turn*, but the
     /// caller decides whether the cap applies turn-by-turn or

--- a/Sources/BaseChatBackends/OpenAIBackend.swift
+++ b/Sources/BaseChatBackends/OpenAIBackend.swift
@@ -20,7 +20,7 @@ import BaseChatInference
 /// let stream = try backend.generate(prompt: "Hello", systemPrompt: nil, config: .init())
 /// for try await event in stream.events { if case .token(let t) = event { print(t, terminator: "") } }
 /// ```
-public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBackendURLModelConfigurable, CloudBackendKeychainConfigurable, ToolCallingHistoryReceiver, @unchecked Sendable {
+public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBackendURLModelConfigurable, CloudBackendKeychainConfigurable, StructuredHistoryReceiver, ToolCallingHistoryReceiver, @unchecked Sendable {
 
     // MARK: - Init
 
@@ -78,9 +78,90 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             maxOutputTokens: 16_384,
             supportsStreaming: true,
             isRemote: true,
+            // Vision support is gated on the configured model name. OpenAI's
+            // vision-capable families (gpt-4o*, gpt-4-turbo, gpt-4.1, o1, o3)
+            // accept `image_url` content parts; older completions-only models
+            // do not. ``GenerationCoordinator``'s pre-flight reads this flag
+            // and rejects image attachments before we ever build a request,
+            // so a non-vision model surfaces a clear local error rather than
+            // a 400 from upstream.
+            supportsVision: Self.isVisionCapableModel(modelName),
             streamsToolCallArguments: true,
             supportsParallelToolCalls: true
         )
+    }
+
+    /// Returns `true` when `modelName` belongs to an OpenAI family that
+    /// accepts `image_url` content parts on the Chat Completions API.
+    ///
+    /// Two matcher styles are used together:
+    ///
+    /// - **Substring tokens** (`gpt-4o`, `gpt-4-turbo`, `gpt-4.1`) — long
+    ///   enough to be unambiguous on their own, so a `contains` check
+    ///   picks up dated-suffix variants (`gpt-4o-2024-08-06`) and vendor
+    ///   aliases (`openai/gpt-4o`) automatically.
+    /// - **Anchored prefixes** (`o1`, `o3`) — too short to be safe as a
+    ///   substring (a name like `gpt-foo1bar` would accidentally match),
+    ///   so we require the token at the start of the name or
+    ///   immediately after a `/` or `:` separator (vendor namespaces like
+    ///   `openai/o1-mini`), and the token must either end the string or
+    ///   be followed by a `-`.
+    ///
+    /// Allowlist source: OpenAI's "Models with vision" docs as of 2026.
+    /// Update ``OpenAIVisionModels`` when OpenAI ships a new family.
+    static func isVisionCapableModel(_ modelName: String) -> Bool {
+        let lowered = modelName.lowercased()
+        if OpenAIVisionModels.substringTokens.contains(where: lowered.contains) {
+            return true
+        }
+        for prefix in OpenAIVisionModels.anchoredPrefixes {
+            if matchesAnchoredPrefix(lowered, prefix: prefix) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Returns `true` when `prefix` appears at the start of `name` or
+    /// immediately after a `/` or `:` separator, and is followed either by
+    /// the end of the string or by a `-`. Used by ``isVisionCapableModel``
+    /// for short tokens (`o1`, `o3`) where a bare substring match would
+    /// produce false positives.
+    static func matchesAnchoredPrefix(_ name: String, prefix: String) -> Bool {
+        let chars = Array(name)
+        let prefixChars = Array(prefix)
+        guard prefixChars.count <= chars.count else { return false }
+        // Walk every plausible start position: index 0 or right after a `/`/`:`.
+        var startIndices: [Int] = [0]
+        for (i, c) in chars.enumerated() where c == "/" || c == ":" {
+            startIndices.append(i + 1)
+        }
+        for start in startIndices {
+            guard start + prefixChars.count <= chars.count else { continue }
+            if Array(chars[start..<start + prefixChars.count]) == prefixChars {
+                let after = start + prefixChars.count
+                if after == chars.count || chars[after] == "-" {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    // MARK: - Structured History
+
+    /// Structured replay history. Set by ``GenerationCoordinator`` when the
+    /// caller uses ``InferenceService/enqueue(structuredMessages:...)``;
+    /// carries ``MessagePart/image(data:mimeType:)`` parts so vision turns
+    /// can be serialised as `image_url` content parts on the request body.
+    ///
+    /// Also consumed by text-only multi-turn replay: when no image parts are
+    /// present the encoder still uses the structured history so a user that
+    /// later attaches an image gets the structured array shape consistently.
+    private var _structuredHistory: [StructuredMessage]?
+
+    public func setStructuredHistory(_ messages: [StructuredMessage]) {
+        withStateLock { self._structuredHistory = messages }
     }
 
     // MARK: - Tool-Aware Conversation History
@@ -131,12 +212,41 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             return snapshot
         }
 
+        let structuredSnapshot: [StructuredMessage]? = withStateLock { self._structuredHistory }
+
         var messages: [[String: Any]] = []
         if let systemPrompt, !systemPrompt.isEmpty {
             messages.append(["role": "system", "content": systemPrompt])
         }
+
+        // Precedence:
+        //   1. tool-aware history — only set during a tool-call loop, must
+        //      win over the structured/plain replay so the model sees the
+        //      `tool_calls` ↔ `tool` pairing it requires.
+        //   2. structured history (only when it carries images) — emits
+        //      `image_url` content parts for vision turns, and collapses
+        //      text-only turns to plain string content for the common case.
+        //   3. plain (role, content) history — legacy fallback. Keeps the
+        //      common text-only wire shape minimal and matches every
+        //      pre-vision OpenAIBackend test that asserts on it.
+        //   4. prompt-only single user turn.
         if let toolHistory = snapshotToolHistory {
             messages.append(contentsOf: toolHistory.map(OpenAIToolEncoding.encodeChatCompletionsEntry))
+        } else if let structured = structuredSnapshot,
+                  !structured.isEmpty,
+                  CloudImageEncoding.imageCount(in: structured) > 0 {
+            // Vision pre-flight: refuse to forward images to a model that
+            // doesn't advertise vision support. ``GenerationCoordinator``
+            // already gates this path on `capabilities.supportsVision`, but
+            // the backend may be driven directly (e.g. the OpenAI-compat
+            // server, or callers wiring their own pipeline), so keep the
+            // belt-and-suspenders check here.
+            if !Self.isVisionCapableModel(modelName) {
+                throw InferenceError.inferenceFailure(
+                    "Model \"\(modelName)\" does not support image input. Switch to a vision-capable OpenAI model (gpt-4o, gpt-4o-mini, gpt-4-turbo, gpt-4.1, o1, o3) and retry."
+                )
+            }
+            messages.append(contentsOf: structured.map(Self.encodeChatCompletionsContent(for:)))
         } else if let history = conversationHistory {
             // Reasoning-model asymmetry: OpenAI-compatible providers (DeepSeek,
             // o-series, hosted Qwen reasoning) deliver chain-of-thought via
@@ -376,6 +486,52 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         }
     }
 
+    // MARK: - Structured Content Encoding
+
+    /// Encodes one ``StructuredMessage`` as a Chat Completions
+    /// `messages[]` entry.
+    ///
+    /// - Text-only turns collapse to a plain string `content` to keep the
+    ///   wire shape minimal — every existing OpenAI-compatible compat
+    ///   server (Ollama, LM Studio, etc.) accepts both shapes and the
+    ///   string form is the lower-friction default.
+    /// - Image-bearing turns emit a structured `content[]` array with one
+    ///   `text` part (when present) followed by `image_url` parts for each
+    ///   image. The text-first ordering matches OpenAI's vision examples in
+    ///   the docs and keeps the prompt visible at the top of the array.
+    /// - Non-`user` roles (assistant, system, tool) collapse to plain
+    ///   string content. The model never emits `image_url` parts on
+    ///   assistant turns, and the persisted-row case where an assistant row
+    ///   somehow carries an image is rare enough that dropping the image
+    ///   silently — rather than emitting an `image_url` part the API will
+    ///   reject — is the safer choice.
+    static func encodeChatCompletionsContent(for message: StructuredMessage) -> [String: Any] {
+        let hasImage = message.parts.contains { part in
+            if case .image = part { return true }
+            return false
+        }
+        guard message.role == "user", hasImage else {
+            return ["role": message.role, "content": message.textContent]
+        }
+
+        var contentParts: [[String: Any]] = []
+        let text = message.textContent
+        if !text.isEmpty {
+            contentParts.append(["type": "text", "text": text])
+        }
+        for part in message.parts {
+            if case .image(let data, let mimeType) = part {
+                contentParts.append([
+                    "type": "image_url",
+                    "image_url": [
+                        "url": CloudImageEncoding.dataURI(data: data, mimeType: mimeType),
+                    ] as [String: Any],
+                ])
+            }
+        }
+        return ["role": "user", "content": contentParts]
+    }
+
     // MARK: - SSE Payload Handler
 
     /// OpenAI-specific SSE payload interpreter for use with `SSEStreamParser.streamTokens`.
@@ -587,5 +743,40 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         )
     }
 
+}
+
+/// Allowlist of OpenAI model-name family tokens that accept `image_url`
+/// content parts on the Chat Completions API.
+///
+/// Lives next to ``OpenAIBackend`` so the matcher stays a one-line
+/// substring check. Adding a new token here is the single edit required
+/// when OpenAI ships a new vision-capable family — the dated-suffix
+/// variants (e.g. `gpt-4o-2024-08-06`) and vendor aliases (e.g.
+/// `openai/gpt-4o`) match automatically because the classifier uses
+/// substring containment.
+///
+/// Kept here (rather than as a public type) because it is an
+/// implementation detail of one backend's capability gating; promoting it
+/// would invite host apps to take a dependency on a list that needs to
+/// move whenever OpenAI updates their model lineup.
+enum OpenAIVisionModels {
+    /// Tokens long enough to be safe as substring matches. A name like
+    /// `gpt-4o-2024-08-06` or `openai/gpt-4o-mini` lights these up.
+    /// Tokens are lowercase; the classifier lowercases its input first.
+    static let substringTokens: [String] = [
+        "gpt-4o",       // gpt-4o, gpt-4o-mini, gpt-4o-2024-* — full vision family
+        "gpt-4-turbo",  // gpt-4-turbo, gpt-4-turbo-2024-* — original vision turbo
+        "gpt-4.1",      // gpt-4.1 family — vision-capable per the 2025 refresh
+    ]
+
+    /// Tokens that are too short for a bare `contains` check (a name like
+    /// `gpt-foo1bar` would otherwise accidentally match `o1`). Matched via
+    /// ``OpenAIBackend/matchesAnchoredPrefix(_:prefix:)`` which requires
+    /// the token at a name boundary (start or after `/` / `:`) and either
+    /// ending the string or followed by a `-`.
+    static let anchoredPrefixes: [String] = [
+        "o1",           // o1, o1-preview, o1-mini-* — reasoning family with vision
+        "o3",           // o3, o3-mini-* — newer reasoning family with vision
+    ]
 }
 #endif

--- a/Tests/BaseChatBackendsTests/OpenAIBackendImageInputTests.swift
+++ b/Tests/BaseChatBackendsTests/OpenAIBackendImageInputTests.swift
@@ -1,0 +1,419 @@
+#if CloudSaaS
+import XCTest
+import BaseChatInference
+import BaseChatTestSupport
+@testable import BaseChatBackends
+
+/// Tests for #943 (part of #20): `image_url` content parts on the OpenAI
+/// Chat Completions API.
+///
+/// `OpenAIBackend` must:
+///
+/// 1. Encode each ``MessagePart/image(data:mimeType:)`` part as an
+///    `{"type":"image_url","image_url":{"url":"data:..."}}` content
+///    part on the request body.
+/// 2. Keep text-only turns collapsed to plain `content: "..."` so the
+///    common-case wire shape stays minimal — the existing replay tests
+///    assert on this exact form.
+/// 3. Reject image attachments when the configured model isn't
+///    vision-capable, with a clear local error.
+/// 4. Advertise `supportsVision` based on the configured model name so
+///    ``GenerationCoordinator``'s pre-flight matches the wire-level
+///    behaviour.
+/// 5. Conform to ``StructuredHistoryReceiver`` so the coordinator routes
+///    `MessagePart.image` parts to it.
+final class OpenAIBackendImageInputTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Builds a backend wired to a unique mock URL host. Each test gets its
+    /// own UUID-stamped host so concurrent runs don't see each other's
+    /// captured requests — `MockURLProtocol.reset()` is deliberately not
+    /// called (it would race with parallel suites).
+    private func makeBackend(
+        modelName: String = "gpt-4o-mini"
+    ) async throws -> (OpenAIBackend, URL) {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let backend = OpenAIBackend(urlSession: session)
+        let url = URL(string: "https://openai-image-\(UUID().uuidString).test")!
+        backend.configure(baseURL: url, apiKey: "sk-test", modelName: modelName)
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+        return (backend, url)
+    }
+
+    private func sseStub(url: URL) {
+        let chunk = Data(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\ndata: [DONE]\n\n".utf8
+        )
+        MockURLProtocol.stub(url: url, response: .sse(chunks: [chunk], statusCode: 200))
+    }
+
+    private func extractRequestJSON(host: String?) throws -> [String: Any] {
+        let captured = MockURLProtocol.capturedRequests.last(where: { $0.url?.host == host })
+        // URLSession may convert httpBody → httpBodyStream during transmission.
+        let body: Data
+        if let direct = captured?.httpBody {
+            body = direct
+        } else if let stream = captured?.httpBodyStream {
+            var data = Data()
+            stream.open()
+            let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 4096)
+            defer { buffer.deallocate() }
+            while stream.hasBytesAvailable {
+                let read = stream.read(buffer, maxLength: 4096)
+                if read > 0 { data.append(buffer, count: read) }
+            }
+            stream.close()
+            body = data
+        } else {
+            throw NSError(domain: "test", code: 0, userInfo: [NSLocalizedDescriptionKey: "no body"])
+        }
+        return try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+    }
+
+    /// 4-byte payload — the bytes are not a valid PNG, but the encoder
+    /// doesn't decode the data, it only base64-encodes it. Using a tiny
+    /// fixture keeps the test fast and the assertion exact.
+    private func fixtureImage(_ marker: UInt8) -> Data {
+        Data([0x89, 0x50, 0x4E, marker])
+    }
+
+    // MARK: - 1. Single image — promoted to content[] with image_url part
+
+    func test_singleImage_emitsImageURLPartAfterText() async throws {
+        let (backend, url) = try await makeBackend()
+        sseStub(url: url)
+        defer { MockURLProtocol.unstub(url: url) }
+
+        let imageData = fixtureImage(0xAA)
+        backend.setStructuredHistory([
+            StructuredMessage(role: "user", parts: [
+                .text("Describe this image."),
+                .image(data: imageData, mimeType: "image/png"),
+            ]),
+        ])
+
+        let stream = try backend.generate(prompt: "Describe this image.", systemPrompt: nil, config: GenerationConfig())
+        for try await _ in stream.events { }
+
+        let json = try extractRequestJSON(host: url.host)
+        let messages = try XCTUnwrap(json["messages"] as? [[String: Any]])
+        XCTAssertEqual(messages.count, 1)
+        let userContent = try XCTUnwrap(messages[0]["content"] as? [[String: Any]],
+            "Image-bearing user turn must serialize as a content[] array, not a string")
+        XCTAssertEqual(userContent.count, 2, "Expect one text part and one image_url part")
+
+        XCTAssertEqual(userContent[0]["type"] as? String, "text",
+            "Text part comes first — matches OpenAI's vision examples")
+        XCTAssertEqual(userContent[0]["text"] as? String, "Describe this image.")
+
+        XCTAssertEqual(userContent[1]["type"] as? String, "image_url")
+        let imageURL = try XCTUnwrap(userContent[1]["image_url"] as? [String: Any])
+        let dataURI = try XCTUnwrap(imageURL["url"] as? String)
+        XCTAssertEqual(dataURI, "data:image/png;base64,\(imageData.base64EncodedString())",
+            "Data URI must round-trip MIME and base64 verbatim")
+    }
+
+    // MARK: - 2. Multiple images on one turn
+
+    func test_multipleImages_allEncoded_inOrder() async throws {
+        let (backend, url) = try await makeBackend()
+        sseStub(url: url)
+        defer { MockURLProtocol.unstub(url: url) }
+
+        let img1 = fixtureImage(0x01)
+        let img2 = fixtureImage(0x02)
+        let img3 = fixtureImage(0x03)
+        backend.setStructuredHistory([
+            StructuredMessage(role: "user", parts: [
+                .text("Compare these."),
+                .image(data: img1, mimeType: "image/png"),
+                .image(data: img2, mimeType: "image/jpeg"),
+                .image(data: img3, mimeType: "image/webp"),
+            ]),
+        ])
+
+        let stream = try backend.generate(prompt: "Compare these.", systemPrompt: nil, config: GenerationConfig())
+        for try await _ in stream.events { }
+
+        let json = try extractRequestJSON(host: url.host)
+        let messages = try XCTUnwrap(json["messages"] as? [[String: Any]])
+        let userContent = try XCTUnwrap(messages[0]["content"] as? [[String: Any]])
+        XCTAssertEqual(userContent.count, 4, "One text part plus three image_url parts")
+
+        XCTAssertEqual(userContent[0]["type"] as? String, "text")
+        for i in 1...3 {
+            XCTAssertEqual(userContent[i]["type"] as? String, "image_url",
+                "Position \(i) must be an image_url part")
+        }
+
+        // Image data ordering must match the parts ordering — sabotage check:
+        // if the encoder reordered images, these byte-level matches would fail.
+        let url1 = try XCTUnwrap((userContent[1]["image_url"] as? [String: Any])?["url"] as? String)
+        let url2 = try XCTUnwrap((userContent[2]["image_url"] as? [String: Any])?["url"] as? String)
+        let url3 = try XCTUnwrap((userContent[3]["image_url"] as? [String: Any])?["url"] as? String)
+        XCTAssertEqual(url1, "data:image/png;base64,\(img1.base64EncodedString())")
+        XCTAssertEqual(url2, "data:image/jpeg;base64,\(img2.base64EncodedString())")
+        XCTAssertEqual(url3, "data:image/webp;base64,\(img3.base64EncodedString())")
+    }
+
+    // MARK: - 3. Text/image/text ordering is preserved as a single text part
+
+    func test_textImageTextOrdering_collapsedTextFirst() async throws {
+        let (backend, url) = try await makeBackend()
+        sseStub(url: url)
+        defer { MockURLProtocol.unstub(url: url) }
+
+        let imageData = fixtureImage(0xBB)
+        // Two text parts + image — `textContent` joins all `.text` parts in
+        // order, so the resulting content[] gets one combined text part
+        // followed by the image part.
+        backend.setStructuredHistory([
+            StructuredMessage(role: "user", parts: [
+                .text("Before. "),
+                .image(data: imageData, mimeType: "image/png"),
+                .text("After."),
+            ]),
+        ])
+
+        let stream = try backend.generate(prompt: "ignored", systemPrompt: nil, config: GenerationConfig())
+        for try await _ in stream.events { }
+
+        let json = try extractRequestJSON(host: url.host)
+        let messages = try XCTUnwrap(json["messages"] as? [[String: Any]])
+        let userContent = try XCTUnwrap(messages[0]["content"] as? [[String: Any]])
+        XCTAssertEqual(userContent.count, 2, "Two text parts collapse into one combined text + one image")
+        XCTAssertEqual(userContent[0]["type"] as? String, "text")
+        XCTAssertEqual(userContent[0]["text"] as? String, "Before. After.",
+            "Text fragments around the image join via StructuredMessage.textContent")
+        XCTAssertEqual(userContent[1]["type"] as? String, "image_url")
+    }
+
+    // MARK: - 4. Multi-turn: text-only collapse + multimodal array
+
+    func test_multiTurn_textOnlyTurnsCollapse_multimodalTurnArrays() async throws {
+        let (backend, url) = try await makeBackend()
+        sseStub(url: url)
+        defer { MockURLProtocol.unstub(url: url) }
+
+        let imageData = fixtureImage(0xCC)
+        backend.setStructuredHistory([
+            StructuredMessage(role: "user", parts: [
+                .text("What is this?"),
+                .image(data: imageData, mimeType: "image/png"),
+            ]),
+            StructuredMessage(role: "assistant", content: "It looks like a logo."),
+            StructuredMessage(role: "user", content: "Thanks."),
+        ])
+
+        let stream = try backend.generate(prompt: "Thanks.", systemPrompt: nil, config: GenerationConfig())
+        for try await _ in stream.events { }
+
+        let json = try extractRequestJSON(host: url.host)
+        let messages = try XCTUnwrap(json["messages"] as? [[String: Any]])
+        XCTAssertEqual(messages.count, 3)
+
+        // First turn: image-bearing → structured array.
+        XCTAssertNotNil(messages[0]["content"] as? [[String: Any]],
+            "Image-bearing user turn must serialise as a content[] array")
+
+        // Second turn: assistant text-only → plain string content. Keeping
+        // the simple form on assistant turns matches every existing
+        // OpenAI-compatible compat server's expectations.
+        XCTAssertEqual(messages[1]["content"] as? String, "It looks like a logo.",
+            "Assistant text-only turns must collapse to plain string content")
+
+        // Third turn: user text-only → plain string content. The wire shape
+        // must not promote text-only turns to structured arrays just
+        // because *some other turn* in the request carried an image.
+        XCTAssertEqual(messages[2]["content"] as? String, "Thanks.",
+            "Image-less user turns must keep the simple string content shape")
+    }
+
+    // MARK: - 5. Non-vision model rejects image input
+
+    func test_nonVisionModel_rejectsImageInput() async throws {
+        // `gpt-3.5-turbo` predates vision support — image attachments must
+        // never be forwarded to it.
+        let (backend, url) = try await makeBackend(modelName: "gpt-3.5-turbo")
+        defer { MockURLProtocol.unstub(url: url) }
+
+        backend.setStructuredHistory([
+            StructuredMessage(role: "user", parts: [
+                .text("hi"),
+                .image(data: fixtureImage(0xDD), mimeType: "image/png"),
+            ]),
+        ])
+
+        do {
+            let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: GenerationConfig())
+            for try await _ in stream.events { }
+            XCTFail("Should have thrown for non-vision model")
+        } catch let error as InferenceError {
+            guard case .inferenceFailure(let message) = error else {
+                XCTFail("Expected inferenceFailure, got \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("gpt-3.5-turbo"), "Error should name the model: \(message)")
+            XCTAssertTrue(message.lowercased().contains("image"), "Error should mention images: \(message)")
+        }
+    }
+
+    // MARK: - 6. Capabilities flip with model name
+
+    func test_capabilities_supportsVision_reflectsModelName() {
+        let backend = OpenAIBackend()
+
+        backend.configure(
+            baseURL: URL(string: "https://api.openai.com")!,
+            apiKey: "x",
+            modelName: "gpt-4o-mini"
+        )
+        XCTAssertTrue(backend.capabilities.supportsVision,
+            "gpt-4o-mini must advertise vision support")
+
+        backend.configure(
+            baseURL: URL(string: "https://api.openai.com")!,
+            apiKey: "x",
+            modelName: "gpt-4o-2024-08-06"
+        )
+        XCTAssertTrue(backend.capabilities.supportsVision,
+            "Dated gpt-4o variants must advertise vision support")
+
+        backend.configure(
+            baseURL: URL(string: "https://api.openai.com")!,
+            apiKey: "x",
+            modelName: "gpt-3.5-turbo"
+        )
+        XCTAssertFalse(backend.capabilities.supportsVision,
+            "gpt-3.5-turbo predates vision support — must not advertise it")
+
+        backend.configure(
+            baseURL: URL(string: "https://api.openai.com")!,
+            apiKey: "x",
+            modelName: "o1-mini"
+        )
+        XCTAssertTrue(backend.capabilities.supportsVision,
+            "o1 reasoning family must advertise vision support")
+    }
+
+    // MARK: - 7. isVisionCapableModel — direct unit coverage
+
+    func test_isVisionCapableModel_classifierAcceptsKnownFamilies() {
+        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("gpt-4o"))
+        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("gpt-4o-mini"))
+        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("gpt-4o-2024-08-06"))
+        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("gpt-4-turbo"))
+        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("gpt-4-turbo-2024-04-09"))
+        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("gpt-4.1"))
+        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("gpt-4.1-mini"))
+        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("o1"))
+        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("o1-preview"))
+        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("o1-mini"))
+        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("o3"))
+        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("o3-mini"))
+        // Vendor-prefixed aliases (proxy/router-style) should still match.
+        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("openai/gpt-4o"))
+        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("openai/o3-mini"))
+    }
+
+    func test_isVisionCapableModel_classifierRejectsLegacyAndUnrelated() {
+        XCTAssertFalse(OpenAIBackend.isVisionCapableModel("gpt-3.5-turbo"))
+        XCTAssertFalse(OpenAIBackend.isVisionCapableModel("gpt-4"),
+            "Bare gpt-4 (no -turbo, no -o, no -.1 suffix) is not vision-capable")
+        XCTAssertFalse(OpenAIBackend.isVisionCapableModel("text-davinci-003"))
+        XCTAssertFalse(OpenAIBackend.isVisionCapableModel("some-other-model"))
+        // The anchored-prefix matcher must NOT light up on substring
+        // collisions: `o1` appears mid-name here and must not match.
+        XCTAssertFalse(OpenAIBackend.isVisionCapableModel("foo1bar"),
+            "Bare o1 substring inside another name must not match")
+        XCTAssertFalse(OpenAIBackend.isVisionCapableModel("legacy-o1-thing-noprefix"),
+            "o1 surrounded by hyphens but not at a name boundary must not match")
+    }
+
+    // MARK: - 8. Structured-text-only doesn't promote to array
+
+    func test_structuredTextOnly_keepsSimpleStringContent() async throws {
+        let (backend, url) = try await makeBackend()
+        sseStub(url: url)
+        defer { MockURLProtocol.unstub(url: url) }
+
+        // Coordinator typically sets BOTH structured + flattened histories.
+        // When the structured form has zero images, the encoder must stay on
+        // the flattened (legacy) path so existing OpenAI-compat servers see
+        // the same wire shape they did before this change.
+        backend.setStructuredHistory([
+            StructuredMessage(role: "user", content: "hello"),
+            StructuredMessage(role: "assistant", content: "hi"),
+        ])
+        backend.setConversationHistory([
+            (role: "user", content: "hello"),
+            (role: "assistant", content: "hi"),
+        ])
+
+        let stream = try backend.generate(prompt: "next", systemPrompt: nil, config: GenerationConfig())
+        for try await _ in stream.events { }
+
+        let json = try extractRequestJSON(host: url.host)
+        let messages = try XCTUnwrap(json["messages"] as? [[String: Any]])
+        XCTAssertEqual(messages.count, 2)
+        XCTAssertEqual(messages[0]["content"] as? String, "hello",
+            "Text-only structured turns must NOT promote to a content[] array")
+        XCTAssertEqual(messages[1]["content"] as? String, "hi")
+    }
+
+    // MARK: - 9. StructuredHistoryReceiver conformance
+
+    func test_conformsToStructuredHistoryReceiver() {
+        // A protocol-typed binding fails to compile if the conformance is
+        // ever removed — the runtime cast is downcast through `Any` so the
+        // compiler doesn't warn that the test is tautological while still
+        // failing the build if the conformance regresses.
+        let backend: Any = OpenAIBackend()
+        XCTAssertNotNil(backend as? StructuredHistoryReceiver,
+            "OpenAIBackend must conform to StructuredHistoryReceiver so GenerationCoordinator routes MessagePart.image parts to it")
+    }
+
+    // MARK: - 10. Data URI shape — exact MIME + base64 round-trip
+
+    func test_dataURI_exactShape() {
+        let bytes = Data([0xDE, 0xAD, 0xBE, 0xEF])
+        let uri = CloudImageEncoding.dataURI(data: bytes, mimeType: "image/jpeg")
+        XCTAssertEqual(uri, "data:image/jpeg;base64,3q2+7w==",
+            "dataURI must produce the exact RFC 2397 form OpenAI expects")
+    }
+
+    // MARK: - 11. MIME passthrough — exotic types still surface verbatim
+
+    func test_mimeType_passthroughVerbatim() async throws {
+        let (backend, url) = try await makeBackend()
+        sseStub(url: url)
+        defer { MockURLProtocol.unstub(url: url) }
+
+        // Pass an unusual MIME — the backend should not silently rewrite
+        // it. If OpenAI rejects the request the upstream 400 surfaces; we
+        // don't mask that by guessing a default.
+        let bytes = fixtureImage(0xEE)
+        backend.setStructuredHistory([
+            StructuredMessage(role: "user", parts: [
+                .text("look"),
+                .image(data: bytes, mimeType: "image/heic"),
+            ]),
+        ])
+
+        let stream = try backend.generate(prompt: "look", systemPrompt: nil, config: GenerationConfig())
+        for try await _ in stream.events { }
+
+        let json = try extractRequestJSON(host: url.host)
+        let messages = try XCTUnwrap(json["messages"] as? [[String: Any]])
+        let userContent = try XCTUnwrap(messages[0]["content"] as? [[String: Any]])
+        let imagePart = try XCTUnwrap(userContent.first(where: { $0["type"] as? String == "image_url" }))
+        let imageURL = try XCTUnwrap(imagePart["image_url"] as? [String: Any])
+        let dataURI = try XCTUnwrap(imageURL["url"] as? String)
+        XCTAssertTrue(dataURI.hasPrefix("data:image/heic;base64,"),
+            "MIME must pass through verbatim — got \(dataURI.prefix(40))")
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Wires `MessagePart.image(data:mimeType:)` through `OpenAIBackend` to OpenAI's `image_url` content-part wire format. OpenAI vision models (gpt-4o, gpt-4o-mini, gpt-4-turbo, gpt-4.1, o1, o3) now receive images alongside text in multimodal turns; non-vision models surface a clear error before the request leaves the client.

Closes part of #943 / #20.

## Changes

- **`OpenAIBackend`** adopts `StructuredHistoryReceiver` so `GenerationCoordinator` routes `MessagePart.image` parts to it. `buildRequest` consults the structured history when it carries image parts and serialises each multimodal turn as `content: [{type:"text"}, {type:"image_url", image_url:{url:"data:image/...;base64,..."}}]`. Text-only turns still collapse to plain `content: "..."` to keep the wire shape minimal for the common case — every existing OpenAI-compatible compat server (Ollama, LM Studio, etc.) accepts both shapes and the simple form is what the existing replay tests assert on.
- **`capabilities.supportsVision`** is now derived per-configured-model via `OpenAIVisionModels`. Two matcher styles are used together: substring tokens (`gpt-4o`, `gpt-4-turbo`, `gpt-4.1`) for names long enough to be safe as a bare `contains` check, and anchored prefixes (`o1`, `o3`) for short tokens that would otherwise produce false positives mid-name. A non-vision model name reports `false` so `GenerationCoordinator.containsImages` rejects image messages with the existing clear error rather than letting the request 400 upstream.
- **`CloudImageEncoding`** (introduced by Lane A in #944) is reused. Added one new helper `dataURI(data:mimeType:)` that returns the `data:<mime>;base64,<payload>` RFC 2397 form OpenAI expects in `image_url.url`. No new file — the helper file from #944 is the single source of truth.

## Backend checklist (vision input)

- [x] OpenAI Chat Completions (this PR)
- [x] Claude content blocks — Lane A, #944, already merged
- [x] MLX — already shipped in #904
- [ ] Llama (out of scope — local llava/qwen-vl wiring)
- [ ] Ollama (out of scope — separate wire format)

## Test plan

- [x] `swift test --filter OpenAIBackendImageInputTests --traits CloudSaaS` — 12 new tests covering: single image, multiple images, text/image/text ordering, multi-turn (text-only collapse + multimodal array), non-vision model capability gate, capabilities flip with model name, classifier accept/reject sets (including anchored-prefix false-positive rejection), structured-text-only doesn't promote to array, `StructuredHistoryReceiver` conformance, data-URI exact shape, MIME passthrough verbatim. All green.
- [x] **Sabotage-verified** the `image_url` type assertion: changed the encoder's `"image_url"` to `"img_url"` and watched `test_singleImage_emitsImageURLPartAfterText` fail with a clear "img_url is not equal to image_url" error, then restored.
- [x] Existing OpenAI suites unchanged — `OpenAIBackendTests` (12), `OpenAIBackendToolCallingTests` (22), `OpenAICompatEndpointTests` (10) all pass alongside the 12 new tests.
- [x] Pre-push gate (CLAUDE.md two-invocation form): XCTest batch 2526 passed / 0 failed / 11 XCTSkip; Swift Testing batch 83 passed / 0 failed.

## Constraints honoured

- Stays inside the cloud OpenAI path. No changes to Claude, MLX, Llama, Foundation, Ollama, UI, `SSECloudBackend`, or anything else.
- No hooks skipped.

## Release Note

`OpenAIBackend` now forwards `MessagePart.image` parts as native `image_url` content parts on the Chat Completions API, so vision-capable OpenAI models (gpt-4o, gpt-4o-mini, gpt-4-turbo, gpt-4.1, o1, o3 families) can answer about attached images. Non-vision models surface a clear local error before the request leaves the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)