### PR TITLE
perf(ci): spike .build/debug caching with mtime fix (Lever C of #953)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,23 +59,59 @@ jobs:
           xcode-version: "26.3"
 
       - name: Cache SwiftPM build
+        id: cache-spm
         uses: actions/cache@v5
         with:
-          # .build/debug is intentionally excluded: SwiftPM module fingerprints
-          # embed absolute paths + compiler timestamps, so restored object files
-          # are invalidated on every fresh ephemeral runner. Caching .build/debug
-          # produced 0 incremental-build savings in practice and wasted the 10 GB
-          # per-repo cache quota. .build/artifacts holds the prebuilt llama.cpp
-          # xcframework (~100 MB, the real win); .build/checkouts + repositories
-          # save the per-dep clone phase.
+          # TODO(#953 Lever C): spike — re-including .build/debug to measure
+          # incremental-build savings. The previous "0 savings" comment was
+          # written before the dep-set shrunk from 38 → 21 pins (#946) and
+          # before the InferenceService decomp (#306) + runtime-ports refactor
+          # reshaped the build graph. The runner path is stable
+          # (/Users/runner/work/BaseChatKit/BaseChatKit) and Xcode is pinned to
+          # 26.3, so the SwiftPM module fingerprint inputs are now stable
+          # enough that incremental compilation should land. The likely prior
+          # failure mode — mtime invalidation after tarball restore — is
+          # addressed by the post-restore touch step below.
+          #
+          # Measurement plan: merge this, observe ci.test wall time vs. the
+          # ~253s baseline from PR #946 across 3-5 PRs. Ship if wins ≥20%;
+          # revert and update this comment with the new evidence if not.
+          #
+          # The key includes a hash of Sources/**/*.swift so any source change
+          # invalidates the .build/debug snapshot cleanly. Package.resolved is
+          # still the primary key (dependency graph dominates), with sources
+          # appended so we never restore a stale debug build over fresh code.
           path: |
             .build/artifacts
             .build/checkouts
             .build/repositories
-          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
+            .build/debug
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-debug-${{ hashFiles('Package.resolved') }}-${{ hashFiles('Sources/**/*.swift') }}
           restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-debug-${{ hashFiles('Package.resolved') }}-
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-debug-
             ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
             ${{ runner.os }}-${{ runner.arch }}-spm-
+
+      - name: Refresh mtimes on cached build artifacts
+        # actions/cache restores files with their tarball-extraction mtime,
+        # which is uniformly "now". SwiftPM's incremental driver compares
+        # source mtime to .swiftmodule/.o mtime to decide whether to rebuild —
+        # and on a cold runner the source files (just checked out) have a
+        # newer mtime than the just-restored cache. Touching every cached
+        # build product after restore makes them appear newer than the
+        # sources, so the driver trusts them as up-to-date. This is the
+        # standard mtime-fix incantation for SwiftPM CI caches.
+        if: steps.cache-spm.outputs.cache-hit == 'true'
+        run: |
+          set -euo pipefail
+          if [[ -d .build/debug ]]; then
+            find .build/debug \( -name '*.swiftmodule' -o -name '*.swiftdoc' -o -name '*.swiftsourceinfo' -o -name '*.o' -o -name '*.d' \) -print0 \
+              | xargs -0 -r touch
+            echo "Refreshed mtimes on cached .build/debug artifacts."
+          else
+            echo ".build/debug not present after cache restore (partial hit); skipping mtime refresh."
+          fi
 
       - name: Verify Swift toolchain matches Package.swift tools-version
         # The runner's Xcode (pinned above) ships a specific Swift version. If


### PR DESCRIPTION
## Summary

Lever C of #953 — re-include `.build/debug` in the SwiftPM cache for the `ci.test` job, with a post-restore mtime fix to dodge the most likely prior failure mode.

The other three levers in #953 already shipped:
- **A** (`build-modes.full` to nightly) — #955
- **B** (security-audits batch) — #954
- **D** (lint consolidation) — #956

This is the highest-leverage but biggest-unknown lever. The pre-existing `Cache SwiftPM build` step deliberately excluded `.build/debug` based on a "produced 0 incremental-build savings in practice" comment that's now stale:

- The default-trait dep set shrunk from 38 → 21 pins (#946)
- The InferenceService decomp (#306) and runtime-ports refactor reshaped the build graph
- Runner path is stable on GHA (`/Users/runner/work/BaseChatKit/BaseChatKit`); Xcode is pinned to 26.3

The likely failure mode of past attempts was mtime invalidation after tarball restore — addressed here.

## Changes

`.github/workflows/ci.yml` — `test` job only:

- Add `.build/debug` to the cache `path:` list.
- Give the cache step `id: cache-spm` so a follow-up step can read its `cache-hit` output.
- New cache key: `${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-debug-${{ hashFiles('Package.resolved') }}-${{ hashFiles('Sources/**/*.swift') }}` so any source change invalidates the debug snapshot cleanly.
- Restore-keys cascade lets dep-only changes reuse a near-fresh debug build (Sources hash changes → fall through to Package.resolved-only key).
- New step `Refresh mtimes on cached build artifacts` runs after restore (gated on `cache-hit == 'true'`). It touches every `.swiftmodule`, `.swiftdoc`, `.swiftsourceinfo`, `.o`, and `.d` under `.build/debug` so SwiftPM's incremental driver sees the cached products as newer than the freshly-checked-out sources.
- The `server-tests` and `macros-tests` jobs are intentionally untouched — they're path-filtered and rarely hit, so the spike's measurement target is the always-running `test` job.

## Measurement plan

After merge, observe the `ci.test` step wall time across the next 3–5 PRs and compare to the ~253s baseline from PR #946.

- **Ship** if wins ≥ 20% (~50s+ off `ci.test`).
- **Revert** if not, and update the cache comment with the new evidence so the next person to consider this knows the post-#946 / post-#306 graph still doesn't yield incremental wins.

#953 stays open. Closing decision waits for the measurement.

## Risks

- **Cache miss on every PR** — if the `Sources/**/*.swift` hash invalidates too aggressively, every Sources-touching PR pays the full cold-build cost _plus_ the ~10–30s save-cache step at the end. Restore-keys mitigate by letting Package.resolved-keyed entries serve as a partial restore base for the SwiftPM module/object files that didn't change.
- **mtime fix not enough** — SwiftPM may re-invalidate based on driver-version embedding, ABI hashes, or other inputs the touch can't fix. Measurement will tell us.
- **10 GB cache quota pressure** — the cache size grows substantially with `.build/debug` included. GHA evicts least-recently-used entries automatically, so this self-limits, but other cache entries (server-tests, macros-tests) might churn faster.

## Test plan

- [x] YAML parses (validated locally with `python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] `actionlint` passes on the modified file
- [ ] Post-merge: confirm first PR run still passes (cache miss; verify nothing regressed)
- [ ] Measure 3–5 subsequent PRs' `ci.test` wall time vs. 253s baseline
- [ ] Decide ship vs. revert; either way update the comment

Refs #953.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>