### PR TITLE
test: isolate UserDefaults.standard reads in download tests + add tripwire

### DIFF
--- a/Tests/BaseChatCoreTests/UserDefaultsStandardAuditTest.swift
+++ b/Tests/BaseChatCoreTests/UserDefaultsStandardAuditTest.swift
@@ -1,0 +1,152 @@
+import XCTest
+
+/// Guards against regressions on issue #910: tests that read or write
+/// `UserDefaults.standard` directly cannot run safely under
+/// `swift test --parallel` because XCTest workers run in separate processes
+/// and `UserDefaults.standard` is keyed by bundle ID, persisting to the same
+/// on-disk plist across worker processes.
+///
+/// ## Why this matters
+///
+/// `swift test --parallel` cuts CI test wall time roughly in half by running
+/// each XCTest target in its own worker process. The original block on this
+/// (issue #756) was a small set of tests that read/wrote
+/// `UserDefaults.standard`. Once those flake sources were eliminated, every
+/// remaining `UserDefaults.standard` reference in `Tests/` is a latent
+/// race waiting to break a future parallel run.
+///
+/// Production code already does the right thing: a quick
+/// `grep -r "UserDefaults.standard" Sources/` returns nothing — every read or
+/// write goes through an injected `UserDefaults` instance. Tests should
+/// mirror that by allocating a per-suite `UserDefaults(suiteName:)` and
+/// asserting against it.
+///
+/// ## What this test enforces
+///
+/// Every `.swift` file under `Tests/` must contain zero non-comment
+/// occurrences of the string `UserDefaults.standard`. Comment lines and doc
+/// comments are skipped so explanatory text (like the comment you're reading)
+/// can still mention the API.
+///
+/// ## Fixing a violation
+///
+/// Replace the bare `.standard` access with the per-suite pattern already
+/// used elsewhere in the codebase, e.g. in
+/// `Tests/BaseChatHuggingFaceTests/BackgroundDownloadIntegrationTests.swift`:
+///
+///     suiteName = "com.basechatkit.test.<area>.\(UUID().uuidString)"
+///     testDefaults = UserDefaults(suiteName: suiteName)!
+///     // …
+///     // inject testDefaults into the SUT, assert against testDefaults
+///     // tearDown: testDefaults?.removePersistentDomain(forName: suiteName)
+///
+/// DO NOT add an allowlist to silence this test. The whole point of the
+/// audit is that one bare reference is enough to reintroduce the
+/// cross-process race.
+final class UserDefaultsStandardAuditTest: XCTestCase {
+
+    func test_noDirectUserDefaultsStandardAccessInTests() throws {
+        let testsURL = try Self.locateTestsDirectory()
+        let swiftFiles = try Self.enumerateSwiftFiles(under: testsURL)
+
+        // The audit file itself mentions the string in code paths (the
+        // search needle below) and in error messages. Scope the audit to
+        // every other file.
+        let auditFileName = (#filePath as NSString).lastPathComponent
+
+        var violations: [String] = []
+
+        for fileURL in swiftFiles {
+            if fileURL.lastPathComponent == auditFileName { continue }
+
+            let content = (try? String(contentsOf: fileURL, encoding: .utf8)) ?? ""
+            let hits = Self.findNonCommentHits(of: "UserDefaults.standard", in: content)
+            if !hits.isEmpty {
+                let relativePath = Self.relativePath(of: fileURL, under: testsURL)
+                for lineNumber in hits {
+                    violations.append("\(relativePath):\(lineNumber)")
+                }
+            }
+        }
+
+        if !violations.isEmpty {
+            let formatted = violations
+                .map { "  \($0)" }
+                .joined(separator: "\n")
+            XCTFail("""
+                Direct `UserDefaults.standard` access detected in test files.
+
+                `UserDefaults.standard` is keyed by bundle ID and persists across
+                XCTest worker processes, so any test that touches it races under
+                `swift test --parallel` (see issue #910 and #756 for prior incidents).
+
+                Replace each violation with a per-suite `UserDefaults(suiteName:)`
+                instance and inject it into the SUT — see the doc comment in
+                Tests/BaseChatCoreTests/UserDefaultsStandardAuditTest.swift for the
+                approved pattern.
+
+                Violations (file:line):
+                \(formatted)
+                """)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Returns the 1-based line numbers in `content` where `needle` appears
+    /// outside of `//`, `///`, and `*`-prefixed comment lines.
+    private static func findNonCommentHits(of needle: String, in content: String) -> [Int] {
+        var hits: [Int] = []
+        let lines = content.components(separatedBy: "\n")
+        for (index, rawLine) in lines.enumerated() {
+            let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
+            // Skip comment lines.
+            if trimmed.hasPrefix("//") || trimmed.hasPrefix("///") || trimmed.hasPrefix("*") {
+                continue
+            }
+            if rawLine.contains(needle) {
+                hits.append(index + 1)
+            }
+        }
+        return hits
+    }
+
+    /// Walks upward from this test file to find the `Tests/` directory at
+    /// the repo root. Mirrors `SwiftTestingAuditTest.locateTestsDirectory`.
+    private static func locateTestsDirectory(filePath: StaticString = #filePath) throws -> URL {
+        var dir = URL(fileURLWithPath: "\(filePath)").deletingLastPathComponent()
+        while dir.path != "/" {
+            let candidate = dir.appendingPathComponent("Tests")
+            var isDir: ObjCBool = false
+            if FileManager.default.fileExists(atPath: candidate.path, isDirectory: &isDir), isDir.boolValue {
+                return candidate
+            }
+            dir.deleteLastPathComponent()
+        }
+        throw NSError(domain: "UserDefaultsStandardAuditTest", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "Could not locate Tests/ from #filePath",
+        ])
+    }
+
+    private static func enumerateSwiftFiles(under root: URL) throws -> [URL] {
+        var result: [URL] = []
+        guard let enumerator = FileManager.default.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            result.append(url)
+        }
+        return result
+    }
+
+    private static func relativePath(of fileURL: URL, under root: URL) -> String {
+        let filePath = fileURL.path
+        let rootPath = root.path
+        if filePath.hasPrefix(rootPath + "/") {
+            return String(filePath.dropFirst(rootPath.count + 1))
+        }
+        return fileURL.lastPathComponent
+    }
+}

--- a/Tests/BaseChatHuggingFaceTests/BackgroundDownloadIntegrationTests.swift
+++ b/Tests/BaseChatHuggingFaceTests/BackgroundDownloadIntegrationTests.swift
@@ -547,6 +547,11 @@ final class BackgroundDownloadIntegrationTests: XCTestCase {
     // MARK: - No UserDefaults contamination
 
     /// startDownload must not write anything to UserDefaults under the pending downloads key.
+    ///
+    /// Asserts against the per-suite `testDefaults` (the instance injected into the SUT)
+    /// rather than `UserDefaults.standard` — bare `.standard` reads race across parallel
+    /// XCTest worker processes (issue #910). The SUT writes through the injected defaults,
+    /// so this is the honest contract surface for the assertion.
     func test_startDownload_doesNotWriteToUserDefaults() async throws {
         let model = makeModel(
             repoID: "test/no-defaults",
@@ -554,11 +559,11 @@ final class BackgroundDownloadIntegrationTests: XCTestCase {
             displayName: "No Defaults Test"
         )
         let legacyKey = BaseChatConfiguration.shared.pendingDownloadsKey
-        let beforeValue = UserDefaults.standard.dictionary(forKey: legacyKey)
+        let beforeValue = testDefaults.dictionary(forKey: legacyKey)
 
         _ = try await manager.startDownload(model, downloadURL: URL(string: "http://localhost/x.gguf")!)
 
-        let afterValue = UserDefaults.standard.dictionary(forKey: legacyKey)
+        let afterValue = testDefaults.dictionary(forKey: legacyKey)
         XCTAssertEqual(
             NSDictionary(dictionary: beforeValue ?? [:]),
             NSDictionary(dictionary: afterValue ?? [:]),

--- a/Tests/BaseChatHuggingFaceTests/ResumableDownloadTests.swift
+++ b/Tests/BaseChatHuggingFaceTests/ResumableDownloadTests.swift
@@ -336,6 +336,11 @@ final class ResumableDownloadTests: XCTestCase {
 
     /// Resume data must NOT appear in UserDefaults — verifies the new file-based path
     /// does not accidentally write to the old keys.
+    ///
+    /// Asserts against the per-suite `testDefaults` (the instance injected into the SUT)
+    /// rather than `UserDefaults.standard` — bare `.standard` reads race across parallel
+    /// XCTest worker processes (issue #910). The SUT writes through the injected defaults,
+    /// so this is the honest contract surface for the assertion.
     func test_persistResumeData_doesNotWriteToUserDefaults() {
         let model = makeModel()
         let data = Data("no-defaults".utf8)
@@ -344,7 +349,7 @@ final class ResumableDownloadTests: XCTestCase {
 
         let legacyKey = "resumeData.\(model.id)"
         XCTAssertNil(
-            UserDefaults.standard.data(forKey: legacyKey),
+            testDefaults.data(forKey: legacyKey),
             "Resume data must not be written to UserDefaults (legacy path)"
         )
 


### PR DESCRIPTION
Closes part of #910 — the test-isolation half. The CI \`--parallel\` flip is held back pending follow-up work on two unrelated flakes (see *Out of scope* below).

## Summary

- **Two named test sites migrated off \`UserDefaults.standard\`** — \`BackgroundDownloadIntegrationTests.test_startDownload_doesNotWriteToUserDefaults\` and \`ResumableDownloadTests.test_persistResumeData_doesNotWriteToUserDefaults\` now assert against the per-suite \`testDefaults\` instance that's already injected into the SUT. Production code only ever writes through the injected \`UserDefaults\` (\`grep UserDefaults.standard Sources/\` returns nothing), so the assertion's contract is preserved while removing the cross-process race that \`.standard\` introduces under \`swift test --parallel\`.
- **\`UserDefaultsStandardAuditTest\` tripwire** added in \`BaseChatCoreTests\` — walks \`Tests/\` and fails if any non-comment line references \`UserDefaults.standard\`. Mirrors the existing \`SwiftTestingAuditTest\` pattern. Sabotage-verified: temporarily planting a \`UserDefaults.standard.string(forKey:)\` call in a sibling file produced the expected \`Violations (file:line)\` failure with the right path and line number.

## Out of scope (held back)

The original plan in #910 also called for flipping \`scripts/test.sh\` and the CI \"XCTest suites\" step to \`--parallel\` by default. Local validation surfaced two flakes under the parallel batch that are **unrelated** to \`UserDefaults.standard\`:

1. \`BaseChatInferenceTests.SSEStreamParserTests.test_limits_eventRateExceeded_rejectsFlood\` — CPU-saturation flake. The test relies on a 6000-event burst landing inside a 1-second wall-clock window to trip the rate limiter; under parallel CPU contention the burst legitimately spans >1s and the limiter never fires.
2. \`BaseChatInferenceTests.KeychainServiceTests.test_store_updatesExisting\` — intermittent under load. Observed once across two full \`--parallel\` runs of the merged batch; passed on a follow-up re-run of just the inference suite.

Per the workplan I stopped at the named scope rather than expanding into those — they need their own diagnosis. \`scripts/test.sh\` and \`.github/workflows/ci.yml\` are intentionally unchanged in this PR. With the tripwire and these two test fixes landed, the CI flip is a one-line follow-up once the two flakes above are addressed.

## Measured wall-clock

Pre-push gate (CLAUDE.md two-invocation form, serial — current state):

| invocation | tests | wall-clock |
|---|---|---|
| XCTest batch (11 filters) | 2513 passed / 11 skipped | 2m 39s |
| Swift Testing | 83 passed | 3s |

For comparison, a one-off run of the same XCTest batch with \`--parallel\` (modulo the two flakes above) clocked at 8m 28s with full CPU saturation on the same machine — counter-intuitive, but the merged batch hit memory pressure and CPU contention that more than offset the per-target parallelism win. A clean parallel speedup likely needs the batch to be sharded into smaller groups, which is also a follow-up.

## Test plan

- [x] \`swift test --filter UserDefaultsStandardAuditTest\` passes
- [x] Sabotage-verify: tripwire fails when a stub \`UserDefaults.standard\` ref is added
- [x] Two changed tests pass under both serial and \`--parallel\` runs
- [x] Full CLAUDE.md two-invocation pre-push gate green (2596 tests, 0 failures)
- [x] Tripwire flagged zero existing violations after the two test fixes — every remaining \`UserDefaults.standard\` reference in \`Tests/\` is in a comment line

🤖 Generated with [Claude Code](https://claude.com/claude-code)