### PR TITLE
refactor(backends): extract MLXGenerationDriver, drop generate CC from 62 to 18 (#964)

### DIFF
--- a/Sources/BaseChatBackends/MLX/MLXGenerationDriver.swift
+++ b/Sources/BaseChatBackends/MLX/MLXGenerationDriver.swift
@@ -1,0 +1,158 @@
+#if MLX
+import Foundation
+import MLXLMCommon
+import os
+import BaseChatInference
+
+/// Owns the token-streaming loop for a single `MLXBackend.generate()` call.
+///
+/// `MLXGenerationDriver` is stateless — every dependency it needs is passed
+/// as an explicit parameter to `run()`. It mirrors `LlamaGenerationDriver`'s
+/// shape but runs `@MainActor` because every MLX call (`prepare`, `makeCache`,
+/// `generate`, KV-cache snapshot capture) shares the single-threaded GPU
+/// scheduler with the rest of the MLX runtime.
+@MainActor
+struct MLXGenerationDriver {
+
+    private static let logger = Logger(
+        subsystem: BaseChatConfiguration.shared.logSubsystem,
+        category: "inference"
+    )
+
+    /// Outcome of a `run(...)` call.
+    struct RunResult {
+        /// `true` when the loop completed without throwing and was not cancelled —
+        /// callers may snapshot the prompt cache for next-turn reuse.
+        let completedNormally: Bool
+    }
+
+    /// Drives the MLX stream:
+    ///   1. Calls `container.generate(...)` to materialise the underlying token stream.
+    ///   2. Routes each chunk through the optional tool-call parser, then the optional
+    ///      thinking parser.
+    ///   3. Enforces `config.maxOutputTokens` and `config.maxThinkingTokens`.
+    ///   4. Issues a cooperative `Task.sleep(50µs)` (or the test hook) every
+    ///      `config.yieldEveryNTokens` chunks to keep the WindowServer GPU queue moving.
+    ///   5. Flushes both parsers' tail buffers on exit.
+    ///
+    /// On any thrown error the caller wraps the call in a do/catch and is
+    /// responsible for setting the `generationStream`'s failure phase. This
+    /// helper only yields events into `continuation`; it does not call
+    /// `continuation.finish()` — the caller owns lifecycle.
+    func run(
+        container: any MLXModelContainerProtocol,
+        generationInput: MLXPreparedInput,
+        cache: MLXPromptCache,
+        generateConfig: GenerateParameters,
+        config: GenerationConfig,
+        dialect: MLXToolDialect,
+        markers: ThinkingMarkers?,
+        generationStream: GenerationStream,
+        continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation,
+        yieldHook: (@Sendable () async -> Void)?
+    ) async throws -> RunResult {
+        Self.logger.debug("MLXGenerationDriver run started")
+
+        let outputLimit = config.maxOutputTokens
+        var outputTokenCount = 0
+        var isFirstToken = true
+
+        let useThinkingParser = markers != nil
+        // ThinkingParser must always be initialized (its initializer can't take nil).
+        // When useThinkingParser is false the parser is never invoked, so the
+        // placeholder marker pair is never observed.
+        var thinkingParser = ThinkingParser(markers: markers ?? .qwen3)
+
+        // Tool-call parser activates only when tools are configured AND the model
+        // speaks a known dialect. It's a no-op pass-through otherwise.
+        let useToolParser = !config.tools.isEmpty && dialect != .unknown
+        var toolParser = MLXToolCallParser()
+
+        // A thinking model that runs away on a 16 GB Mac can OOM mid-generation;
+        // the budget gate breaks out of the stream once the limit is reached.
+        var thinkingTokenCount = 0
+        var thinkingLimitReached = false
+
+        let mlxStream = try await container.generate(
+            input: generationInput,
+            cache: cache,
+            parameters: generateConfig
+        )
+
+        let yieldEvery = config.yieldEveryNTokens
+        var completionTokenCount = 0
+        outer: for await generation in mlxStream {
+            if Task.isCancelled { break }
+            guard let text = generation.chunk else { continue }
+
+            let stageOneEvents: [GenerationEvent] = useToolParser
+                ? toolParser.process(text)
+                : [.token(text)]
+
+            for event in stageOneEvents {
+                let finalEvents: [GenerationEvent]
+                if case .token(let tokenText) = event, useThinkingParser {
+                    finalEvents = thinkingParser.process(tokenText)
+                } else {
+                    finalEvents = [event]
+                }
+
+                for finalEvent in finalEvents {
+                    if isFirstToken {
+                        switch finalEvent {
+                        case .token, .thinkingToken, .toolCall:
+                            generationStream.setPhase(.streaming)
+                            isFirstToken = false
+                        default: break
+                        }
+                    }
+                    if case .token = finalEvent { outputTokenCount += 1 }
+                    continuation.yield(finalEvent)
+                    if case .thinkingToken = finalEvent {
+                        thinkingTokenCount += 1
+                        if let limit = config.maxThinkingTokens, thinkingTokenCount >= limit {
+                            thinkingLimitReached = true
+                            break
+                        }
+                    }
+                }
+            }
+            if thinkingLimitReached { break outer }
+            if let limit = outputLimit, outputTokenCount >= limit { break }
+
+            // Per-chunk yield: counted on every MLX-emitted chunk regardless
+            // of whether it surfaced as visible text, was swallowed by the
+            // tool-call parser, or wrapped in thinking tags — so the cadence
+            // tracks real generation work.
+            completionTokenCount += 1
+            if yieldEvery > 0 && completionTokenCount % yieldEvery == 0 {
+                if let yieldHook {
+                    await yieldHook()
+                } else {
+                    try? await Task.sleep(for: .microseconds(50))
+                }
+            }
+        }
+
+        // Flush both parsers' tail buffers. Tool-parser output flows through
+        // the thinking parser to preserve the streaming-loop's two-stage pipeline.
+        if useToolParser {
+            for event in toolParser.finalize() {
+                if case .token(let tokenText) = event, useThinkingParser {
+                    for finalEvent in thinkingParser.process(tokenText) {
+                        continuation.yield(finalEvent)
+                    }
+                } else {
+                    continuation.yield(event)
+                }
+            }
+        }
+        for event in thinkingParser.finalize() {
+            continuation.yield(event)
+        }
+
+        Self.logger.debug("MLXGenerationDriver run finished")
+        return RunResult(completedNormally: !Task.isCancelled)
+    }
+}
+#endif

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -309,6 +309,18 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         zip(lhs, rhs).prefix(while: { $0 == $1 }).count
     }
 
+    /// Resolves the active thinking-marker pair from the per-request override
+    /// (`config.thinkingMarkers`), then the load-time auto-detected markers.
+    /// Returns `nil` when `config.maxThinkingTokens == 0` (issue #597) or when
+    /// neither source supplied markers — both cases keep `ThinkingParser` off.
+    static func resolveThinkingMarkers(
+        config: GenerationConfig,
+        autoDetected: ThinkingMarkers?
+    ) -> ThinkingMarkers? {
+        if config.maxThinkingTokens == 0 { return nil }
+        return config.thinkingMarkers ?? autoDetected
+    }
+
     /// Assembles the prepared chat-message inputs for the MLX container's two
     /// `prepare(...)` overloads. Returns both shapes because the caller picks
     /// `prepare(chat:)` for vision history (non-nil first element) and
@@ -853,20 +865,11 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 var outputTokenCount = 0
                 var isFirstToken = true
 
-                // Markers are resolved from two sources, manual-override first:
-                //   1. `config.thinkingMarkers` — caller's per-request override.
-                //   2. `autoDetectedMarkers` — sniffed from `tokenizer_config.json`'s
-                //      Jinja chat template at load time.
-                // If both are nil, the model does not advertise reasoning blocks and
-                // the parser stays off — raw `<think>` substrings (if the model emits
-                // them anyway) surface as visible `.token` text instead of being split
-                // into `.thinkingToken` events.
-                //
-                // `config.maxThinkingTokens == 0` disables thinking entirely (issue #597),
-                // overriding both sources above.
-                let thinkingDisabled = config.maxThinkingTokens == 0
-                let resolvedMarkers = config.thinkingMarkers ?? autoDetectedMarkers
-                let useThinkingParser = !thinkingDisabled && resolvedMarkers != nil
+                let resolvedMarkers = Self.resolveThinkingMarkers(
+                    config: config,
+                    autoDetected: autoDetectedMarkers
+                )
+                let useThinkingParser = resolvedMarkers != nil
                 // ThinkingParser must always be initialized (its initializer can't take nil).
                 // When useThinkingParser is false the parser is never invoked, so the
                 // placeholder marker pair is never observed.

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -20,14 +20,14 @@ import BaseChatInference
 /// Requires real Apple Silicon hardware — does not work in iOS Simulator.
 public final class MLXBackend: InferenceBackend, @unchecked Sendable {
 
-    private struct CachedLayerState {
+    struct CachedLayerState {
         let cacheTypeName: String
         let offset: Int
         let state: [MLXArray]
         let metaState: [String]
     }
 
-    private struct PromptCacheSnapshot {
+    struct PromptCacheSnapshot {
         let promptTokens: [Int]
         let layers: [CachedLayerState]
     }
@@ -307,6 +307,75 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
 
     private static func longestCommonPrefixLength(_ lhs: [Int], _ rhs: [Int]) -> Int {
         zip(lhs, rhs).prefix(while: { $0 == $1 }).count
+    }
+
+    /// Result of `prepareInputAndCache(...)`.
+    struct PreparedGenerationInputs {
+        let generationInput: MLXPreparedInput
+        let cache: MLXPromptCache
+        /// Captured prompt token IDs when KV-cache reuse is eligible — used to
+        /// snapshot the cache after generation finishes. `nil` otherwise.
+        let promptTokenIds: [Int]?
+        /// Number of leading prompt tokens whose KV state was restored from
+        /// the previous turn. `0` when no reuse occurred.
+        let reuseLen: Int
+    }
+
+    /// Prepares the model input, allocates a KV cache, and applies the
+    /// longest-common-prefix reuse heuristic when an eligible snapshot exists.
+    ///
+    /// **CRITICAL:** the reuse path here is byte-identical to the inline
+    /// version it replaced — `longestCommonPrefixLength` clamped to
+    /// `promptTokenIds.count - 1`, gated by `isSupportedPromptCache` and
+    /// `promptTokenIds.count > 1`. Behaviour drift here corrupts the KV cache
+    /// across turns (see v0.5.3 incident).
+    @MainActor
+    static func prepareInputAndCache(
+        container: any MLXModelContainerProtocol,
+        chatMessages: [Chat.Message]?,
+        messages: [[String: String]],
+        generateConfig: GenerateParameters,
+        kvCacheReuseEligible: Bool,
+        snapshot: PromptCacheSnapshot?
+    ) async throws -> PreparedGenerationInputs {
+        let preparedInput =
+            if let chatMessages {
+                try await container.prepare(chat: SendableChatMessages(chatMessages))
+            } else {
+                try await container.prepare(messages: messages)
+            }
+        let cache = try await container.makeCache(parameters: generateConfig)
+        let promptTokenIds: [Int]? = if kvCacheReuseEligible {
+            preparedInput.promptTokenIds
+        } else {
+            nil
+        }
+
+        var generationInput = preparedInput
+        var reuseLen = 0
+        if kvCacheReuseEligible,
+           let snapshot,
+           let promptTokenIds,
+           isSupportedPromptCache(cache.value),
+           promptTokenIds.count > 1 {
+            let commonPrefixLen = longestCommonPrefixLength(
+                promptTokenIds,
+                snapshot.promptTokens
+            )
+            let candidate = min(commonPrefixLen, promptTokenIds.count - 1)
+            if candidate > 0,
+               restorePromptCache(snapshot, into: cache, reusedPromptTokenCount: candidate) {
+                generationInput = preparedInput.suffix(from: candidate)
+                reuseLen = candidate
+            }
+        }
+
+        return PreparedGenerationInputs(
+            generationInput: generationInput,
+            cache: cache,
+            promptTokenIds: promptTokenIds,
+            reuseLen: reuseLen
+        )
     }
 
     /// Resolves the active thinking-marker pair from the per-request override
@@ -890,19 +959,6 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 var thinkingTokenCount = 0
                 var thinkingLimitReached = false
 
-                let preparedInput =
-                    if let chatMessages {
-                        try await modelContainer.prepare(chat: SendableChatMessages(chatMessages))
-                    } else {
-                        try await modelContainer.prepare(messages: messages)
-                    }
-                let cache = try await modelContainer.makeCache(parameters: generateConfig)
-                var generationInput = preparedInput
-                let promptTokenIds: [Int]? = if kvCacheReuseEligible {
-                    preparedInput.promptTokenIds
-                } else {
-                    nil
-                }
                 if kvCacheReuseEligible, let pendingSnapshotTask {
                     await pendingSnapshotTask.value
                 }
@@ -912,26 +968,19 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                     } else {
                         nil
                     }
-
-                if kvCacheReuseEligible,
-                   let snapshot = resolvedSnapshot,
-                   let promptTokenIds,
-                   Self.isSupportedPromptCache(cache.value),
-                   promptTokenIds.count > 1 {
-                    let commonPrefixLen = Self.longestCommonPrefixLength(
-                        promptTokenIds,
-                        snapshot.promptTokens
-                    )
-                    let reuseLen = min(commonPrefixLen, promptTokenIds.count - 1)
-                    if reuseLen > 0,
-                       Self.restorePromptCache(
-                        snapshot,
-                        into: cache,
-                        reusedPromptTokenCount: reuseLen
-                       ) {
-                        generationInput = preparedInput.suffix(from: reuseLen)
-                        continuation.yield(.kvCacheReuse(promptTokensReused: reuseLen))
-                    }
+                let prepared = try await Self.prepareInputAndCache(
+                    container: modelContainer,
+                    chatMessages: chatMessages,
+                    messages: messages,
+                    generateConfig: generateConfig,
+                    kvCacheReuseEligible: kvCacheReuseEligible,
+                    snapshot: resolvedSnapshot
+                )
+                let generationInput = prepared.generationInput
+                let cache = prepared.cache
+                let promptTokenIds = prepared.promptTokenIds
+                if prepared.reuseLen > 0 {
+                    continuation.yield(.kvCacheReuse(promptTokensReused: prepared.reuseLen))
                 }
 
                 let mlxStream = try await modelContainer.generate(

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -309,6 +309,37 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         zip(lhs, rhs).prefix(while: { $0 == $1 }).count
     }
 
+    /// Returns the Qwen 2.5 `<tools>…</tools>` block to append to the system
+    /// prompt, or `nil` when the dialect doesn't use this mechanism or the
+    /// caller supplied no tools.
+    static func buildQwenToolBlock(
+        config: GenerationConfig,
+        dialect: MLXToolDialect
+    ) -> String? {
+        guard !config.tools.isEmpty, dialect == .qwen25 else { return nil }
+        let toolObjects: [[String: Any]] = config.tools.map { tool -> [String: Any] in
+            var function_: [String: Any] = [
+                "name": tool.name,
+                "description": tool.description,
+            ]
+            if let paramsData = try? JSONEncoder().encode(tool.parameters),
+               let paramsObj = try? JSONSerialization.jsonObject(with: paramsData) {
+                function_["parameters"] = paramsObj
+            } else {
+                function_["parameters"] = ["type": "object", "properties": [String: Any]()]
+            }
+            return ["type": "function", "function": function_]
+        }
+        let toolsJSON: String
+        if let data = try? JSONSerialization.data(withJSONObject: toolObjects, options: [.prettyPrinted]),
+           let str = String(data: data, encoding: .utf8) {
+            toolsJSON = str
+        } else {
+            toolsJSON = "[]"
+        }
+        return "\n\n# Tools\n\nYou may call one or more functions to assist with the user query. Don't make assumptions about what values to plug into functions. Here are the available tools:\n\n<tools>\n\(toolsJSON)\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags as follows:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>"
+    }
+
     private func invalidatePromptCacheLocked() {
         _pendingPromptCacheSnapshotTask?.cancel()
         _pendingPromptCacheSnapshotTask = nil
@@ -744,36 +775,11 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             (_conversationHistory, _toolAwareHistory, _structuredHistory, _dialect, _autoDetectedThinkingMarkers)
         }
 
-        // For Qwen 2.5: serialize tool definitions into a <tools>…</tools> block
-        // appended to the system message content. This is the standard Qwen chat
-        // template mechanism for exposing tools to the model.
         let effectiveSystemPrompt: String? = {
-            guard !config.tools.isEmpty, dialect == .qwen25 else {
-                return systemPrompt
+            if let toolBlock = Self.buildQwenToolBlock(config: config, dialect: dialect) {
+                return (systemPrompt ?? "") + toolBlock
             }
-            let toolObjects: [[String: Any]] = config.tools.map { tool -> [String: Any] in
-                var function_: [String: Any] = [
-                    "name": tool.name,
-                    "description": tool.description,
-                ]
-                if let paramsData = try? JSONEncoder().encode(tool.parameters),
-                   let paramsObj = try? JSONSerialization.jsonObject(with: paramsData) {
-                    function_["parameters"] = paramsObj
-                } else {
-                    function_["parameters"] = ["type": "object", "properties": [String: Any]()]
-                }
-                return ["type": "function", "function": function_]
-            }
-            let toolsJSON: String
-            if let data = try? JSONSerialization.data(withJSONObject: toolObjects, options: [.prettyPrinted]),
-               let str = String(data: data, encoding: .utf8) {
-                toolsJSON = str
-            } else {
-                toolsJSON = "[]"
-            }
-            let toolBlock = "\n\n# Tools\n\nYou may call one or more functions to assist with the user query. Don't make assumptions about what values to plug into functions. Here are the available tools:\n\n<tools>\n\(toolsJSON)\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags as follows:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>"
-            let base = systemPrompt ?? ""
-            return base + toolBlock
+            return systemPrompt
         }()
 
         let chatMessages: [Chat.Message]? =

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -930,34 +930,10 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             }
 
             do {
-                let outputLimit = config.maxOutputTokens
-                var outputTokenCount = 0
-                var isFirstToken = true
-
                 let resolvedMarkers = Self.resolveThinkingMarkers(
                     config: config,
                     autoDetected: autoDetectedMarkers
                 )
-                let useThinkingParser = resolvedMarkers != nil
-                // ThinkingParser must always be initialized (its initializer can't take nil).
-                // When useThinkingParser is false the parser is never invoked, so the
-                // placeholder marker pair is never observed.
-                var thinkingParser = ThinkingParser(markers: resolvedMarkers ?? .qwen3)
-
-                // Instantiate the tool-call parser when tools are configured and the
-                // loaded model speaks a known tool-call dialect. The parser is a no-op
-                // pass-through when tools are empty or the dialect is unknown.
-                let useToolParser = !config.tools.isEmpty && dialect != .unknown
-                var toolParser = MLXToolCallParser()
-
-                // Enforces `config.maxThinkingTokens` with the same semantics as
-                // LlamaGenerationDriver: a thinking model that runs away on a 16 GB
-                // Mac can OOM mid-generation, so when the configured budget is hit
-                // we stop emitting further thinking tokens and break out of the
-                // MLX stream. Visible `.token` events are never counted toward
-                // this budget. See issue #550.
-                var thinkingTokenCount = 0
-                var thinkingLimitReached = false
 
                 if kvCacheReuseEligible, let pendingSnapshotTask {
                     await pendingSnapshotTask.value
@@ -976,100 +952,27 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                     kvCacheReuseEligible: kvCacheReuseEligible,
                     snapshot: resolvedSnapshot
                 )
-                let generationInput = prepared.generationInput
-                let cache = prepared.cache
-                let promptTokenIds = prepared.promptTokenIds
                 if prepared.reuseLen > 0 {
                     continuation.yield(.kvCacheReuse(promptTokensReused: prepared.reuseLen))
                 }
 
-                let mlxStream = try await modelContainer.generate(
-                    input: generationInput,
-                    cache: cache,
-                    parameters: generateConfig
+                let driver = MLXGenerationDriver()
+                let result = try await driver.run(
+                    container: modelContainer,
+                    generationInput: prepared.generationInput,
+                    cache: prepared.cache,
+                    generateConfig: generateConfig,
+                    config: config,
+                    dialect: dialect,
+                    markers: resolvedMarkers,
+                    generationStream: generationStream,
+                    continuation: continuation,
+                    yieldHook: MLXBackend._yieldHookForTesting
                 )
-                // Inserts a brief cooperative yield every N tokens so sustained MLX
-                // generation doesn't starve WindowServer's GPU command queue and
-                // cause UI hitches in other apps. Mirrors the pattern in SwiftLM's
-                // `Server.swift` (50µs sleep every 8 tokens). Configurable via
-                // `GenerationConfig.yieldEveryNTokens`; `0` disables the yield.
-                let yieldEvery = config.yieldEveryNTokens
-                var completionTokenCount = 0
-                outer: for await generation in mlxStream {
-                    if Task.isCancelled { break }
-                    if let text = generation.chunk {
-                        // Stage 1: tool-call parsing (suppresses tokens inside <tool_call>…</tool_call>).
-                        // Stage 2: thinking parsing on remaining .token events.
-                        let stageOneEvents: [GenerationEvent] = useToolParser
-                            ? toolParser.process(text)
-                            : [.token(text)]
 
-                        for event in stageOneEvents {
-                            // Apply thinking parser only to visible token events.
-                            let finalEvents: [GenerationEvent]
-                            if case .token(let tokenText) = event, useThinkingParser {
-                                finalEvents = thinkingParser.process(tokenText)
-                            } else {
-                                finalEvents = [event]
-                            }
-
-                            for finalEvent in finalEvents {
-                                if isFirstToken {
-                                    switch finalEvent {
-                                    case .token, .thinkingToken, .toolCall:
-                                        await MainActor.run { generationStream.setPhase(.streaming) }
-                                        isFirstToken = false
-                                    default: break
-                                    }
-                                }
-                                // Only count visible output tokens toward maxOutputTokens limit.
-                                // Tool call events do not count as output tokens.
-                                if case .token = finalEvent { outputTokenCount += 1 }
-                                continuation.yield(finalEvent)
-                                if case .thinkingToken = finalEvent {
-                                    thinkingTokenCount += 1
-                                    if let limit = config.maxThinkingTokens, thinkingTokenCount >= limit {
-                                        thinkingLimitReached = true
-                                        break
-                                    }
-                                }
-                            }
-                        }
-                        if thinkingLimitReached { break outer }
-                        if let limit = outputLimit, outputTokenCount >= limit { break }
-
-                        // Per-chunk yield: count every MLX-emitted chunk (regardless
-                        // of whether it became a visible token, thinking token, or
-                        // got swallowed by the tool-call parser) so the cadence
-                        // tracks real generation work.
-                        completionTokenCount += 1
-                        if yieldEvery > 0 && completionTokenCount % yieldEvery == 0 {
-                            if let hook = MLXBackend._yieldHookForTesting {
-                                await hook()
-                            } else {
-                                try? await Task.sleep(for: .microseconds(50))
-                            }
-                        }
-                    }
-                }
-                // Flush any bytes held back at tag-boundary buffers.
-                if useToolParser {
-                    for event in toolParser.finalize() {
-                        if case .token(let tokenText) = event, useThinkingParser {
-                            for finalEvent in thinkingParser.process(tokenText) {
-                                continuation.yield(finalEvent)
-                            }
-                        } else {
-                            continuation.yield(event)
-                        }
-                    }
-                }
-                for event in thinkingParser.finalize() {
-                    continuation.yield(event)
-                }
                 let snapshotInputs: (MLXPromptCache, [Int])? =
-                    if kvCacheReuseEligible, !Task.isCancelled, let promptTokenIds {
-                        (cache, promptTokenIds)
+                    if kvCacheReuseEligible, result.completedNormally, let ids = prepared.promptTokenIds {
+                        (prepared.cache, ids)
                     } else {
                         nil
                     }
@@ -1077,30 +980,9 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 if let self {
                     self.withStateLock { self._isGenerating = false }
                 }
-                await MainActor.run { generationStream.setPhase(.done) }
+                generationStream.setPhase(.done)
                 if let self, let (cache, promptTokenIds) = snapshotInputs {
-                    self.withStateLock {
-                        self._promptCacheWriteToken &+= 1
-                        let snapshotWriteToken = self._promptCacheWriteToken
-                        // The snapshot must capture on `@MainActor`: every MLX
-                        // call inside `capturePromptCacheSnapshot` (copy/eval/
-                        // slicing/trim) shares the single-threaded GPU scheduler
-                        // with `ModelContainer.generate`. Running it on a free
-                        // executor would race the next generation's compute.
-                        let snapshotTask = Task<Void, Never> { @MainActor [weak self] in
-                            let snapshot = Self.capturePromptCacheSnapshot(
-                                from: cache,
-                                promptTokens: promptTokenIds
-                            )
-                            guard let self else { return }
-                            self.withStateLock {
-                                guard self._promptCacheWriteToken == snapshotWriteToken else { return }
-                                self._promptCacheSnapshot = snapshot
-                                self._pendingPromptCacheSnapshotTask = nil
-                            }
-                        }
-                        self._pendingPromptCacheSnapshotTask = snapshotTask
-                    }
+                    self.scheduleSnapshotCaptureLocked(cache: cache, promptTokenIds: promptTokenIds)
                 }
                 continuation.finish()
             } catch {
@@ -1109,11 +991,11 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 }
                 if !Task.isCancelled {
                     Self.logger.error("MLX generation error: \(error)")
-                    await MainActor.run { generationStream.setPhase(.failed(error.localizedDescription)) }
+                    generationStream.setPhase(.failed(error.localizedDescription))
                     continuation.finish(throwing: error)
                     return
                 }
-                await MainActor.run { generationStream.setPhase(.done) }
+                generationStream.setPhase(.done)
                 continuation.finish()
             }
         }
@@ -1127,6 +1009,38 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         }
 
         return generationStream
+    }
+
+    /// Schedules an off-main capture of the prompt KV cache for next-turn reuse.
+    ///
+    /// The capture itself runs `@MainActor` because every MLX call inside
+    /// `capturePromptCacheSnapshot` (`copy()`, `eval`, `state` slicing, `trim`)
+    /// shares the single-threaded GPU scheduler with `ModelContainer.generate`.
+    /// A monotonic write token guards against stale snapshots overwriting a
+    /// newer turn's cache state if the next `generate()` call has already
+    /// invalidated this lineage.
+    @MainActor
+    private func scheduleSnapshotCaptureLocked(
+        cache: MLXPromptCache,
+        promptTokenIds: [Int]
+    ) {
+        withStateLock {
+            _promptCacheWriteToken &+= 1
+            let snapshotWriteToken = _promptCacheWriteToken
+            let snapshotTask = Task<Void, Never> { @MainActor [weak self] in
+                let snapshot = Self.capturePromptCacheSnapshot(
+                    from: cache,
+                    promptTokens: promptTokenIds
+                )
+                guard let self else { return }
+                self.withStateLock {
+                    guard self._promptCacheWriteToken == snapshotWriteToken else { return }
+                    self._promptCacheSnapshot = snapshot
+                    self._pendingPromptCacheSnapshotTask = nil
+                }
+            }
+            _pendingPromptCacheSnapshotTask = snapshotTask
+        }
     }
 
     // MARK: - Testing

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -309,6 +309,55 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         zip(lhs, rhs).prefix(while: { $0 == $1 }).count
     }
 
+    /// Assembles the prepared chat-message inputs for the MLX container's two
+    /// `prepare(...)` overloads. Returns both shapes because the caller picks
+    /// `prepare(chat:)` for vision history (non-nil first element) and
+    /// `prepare(messages:)` otherwise.
+    static func buildChatMessages(
+        prompt: String,
+        effectiveSystemPrompt: String?,
+        conversationHistory: [(role: String, content: String)],
+        toolAwareHistory: [ToolAwareHistoryEntry]?,
+        structuredHistory: [StructuredMessage]?,
+        dialect: MLXToolDialect
+    ) throws -> (chatMessages: [Chat.Message]?, messages: [[String: String]]) {
+        let chatMessages: [Chat.Message]? =
+            if let structuredHistory, !structuredHistory.isEmpty {
+                if let toolAwareHistory, !toolAwareHistory.isEmpty {
+                    try toolAwareChatMessages(
+                        structuredHistory: structuredHistory,
+                        toolAwareHistory: toolAwareHistory,
+                        systemPrompt: effectiveSystemPrompt,
+                        dialect: dialect
+                    )
+                } else {
+                    try plainChatMessages(
+                        history: structuredHistory,
+                        systemPrompt: effectiveSystemPrompt
+                    )
+                }
+            } else {
+                nil
+            }
+
+        var msgs: [[String: String]] = []
+        if let sp = effectiveSystemPrompt, !sp.isEmpty {
+            msgs.append(["role": "system", "content": sp])
+        }
+        if let toolHistory = toolAwareHistory, !toolHistory.isEmpty {
+            for entry in toolHistory {
+                msgs.append(encodeToolAwareEntryAsText(entry, dialect: dialect))
+            }
+        } else if !conversationHistory.isEmpty {
+            for msg in conversationHistory {
+                msgs.append(["role": msg.role, "content": msg.content])
+            }
+        } else {
+            msgs.append(["role": "user", "content": prompt])
+        }
+        return (chatMessages, msgs)
+    }
+
     /// Returns the Qwen 2.5 `<tools>…</tools>` block to append to the system
     /// prompt, or `nil` when the dialect doesn't use this mechanism or the
     /// caller supplied no tools.
@@ -782,49 +831,14 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             return systemPrompt
         }()
 
-        let chatMessages: [Chat.Message]? =
-            if let structuredHistory, !structuredHistory.isEmpty {
-                if let toolAwareHistory, !toolAwareHistory.isEmpty {
-                    try Self.toolAwareChatMessages(
-                        structuredHistory: structuredHistory,
-                        toolAwareHistory: toolAwareHistory,
-                        systemPrompt: effectiveSystemPrompt,
-                        dialect: dialect
-                    )
-                } else {
-                    try Self.plainChatMessages(
-                        history: structuredHistory,
-                        systemPrompt: effectiveSystemPrompt
-                    )
-                }
-            } else {
-                nil
-            }
-
-        // All non-vision messages are encoded as plain [String: String]
-        // dictionaries before the container applies the tokenizer's chat
-        // template. For Qwen 2.5 tool history, tool calls are text-encoded into
-        // content fields using the same <tool_call>…</tool_call> format the
-        // model emits.
-        let messages: [[String: String]] = {
-            var msgs: [[String: String]] = []
-            if let sp = effectiveSystemPrompt, !sp.isEmpty {
-                msgs.append(["role": "system", "content": sp])
-            }
-            if let toolHistory = toolAwareHistory, !toolHistory.isEmpty {
-                // Encode tool-aware history entries into the Qwen text format.
-                for entry in toolHistory {
-                    msgs.append(Self.encodeToolAwareEntryAsText(entry, dialect: dialect))
-                }
-            } else if !conversationHistory.isEmpty {
-                for msg in conversationHistory {
-                    msgs.append(["role": msg.role, "content": msg.content])
-                }
-            } else {
-                msgs.append(["role": "user", "content": prompt])
-            }
-            return msgs
-        }()
+        let (chatMessages, messages) = try Self.buildChatMessages(
+            prompt: prompt,
+            effectiveSystemPrompt: effectiveSystemPrompt,
+            conversationHistory: conversationHistory,
+            toolAwareHistory: toolAwareHistory,
+            structuredHistory: structuredHistory,
+            dialect: dialect
+        )
 
         let (stream, continuation) = AsyncThrowingStream.makeStream(of: GenerationEvent.self)
         let generationStream = GenerationStream(stream)

--- a/Tests/BaseChatBackendsTests/MLXBackendHelpersTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXBackendHelpersTests.swift
@@ -1,0 +1,214 @@
+#if MLX
+import XCTest
+import BaseChatInference
+@testable import BaseChatBackends
+
+/// Unit tests for the pure helpers extracted from `MLXBackend.generate` (#964).
+///
+/// These run in CI without Apple Silicon — every helper is value-in / value-out
+/// and never touches the MLX runtime or Metal stack.
+final class MLXBackendHelpersTests: XCTestCase {
+
+    // MARK: - buildQwenToolBlock
+
+    func test_buildQwenToolBlock_returnsNilWhenNoTools() {
+        let block = MLXBackend.buildQwenToolBlock(
+            config: GenerationConfig(),
+            dialect: .qwen25
+        )
+        XCTAssertNil(block)
+    }
+
+    func test_buildQwenToolBlock_returnsNilForUnknownDialect() {
+        var config = GenerationConfig()
+        config.tools = [
+            ToolDefinition(name: "echo", description: "Echo input", parameters: .object([:]))
+        ]
+        let block = MLXBackend.buildQwenToolBlock(config: config, dialect: .unknown)
+        XCTAssertNil(block)
+    }
+
+    func test_buildQwenToolBlock_serialisesToolsForQwenDialect() {
+        var config = GenerationConfig()
+        config.tools = [
+            ToolDefinition(
+                name: "get_weather",
+                description: "Look up current weather",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "city": .object(["type": .string("string")])
+                    ]),
+                    "required": .array([.string("city")])
+                ])
+            )
+        ]
+        let block = MLXBackend.buildQwenToolBlock(config: config, dialect: .qwen25)
+        XCTAssertNotNil(block)
+        XCTAssertTrue(block!.contains("<tools>"))
+        XCTAssertTrue(block!.contains("</tools>"))
+        XCTAssertTrue(block!.contains("get_weather"))
+        XCTAssertTrue(block!.contains("Look up current weather"))
+        // The Qwen contract expects the model to emit <tool_call>…</tool_call>.
+        XCTAssertTrue(block!.contains("<tool_call>"))
+        XCTAssertTrue(block!.contains("</tool_call>"))
+    }
+
+    // MARK: - resolveThinkingMarkers
+
+    func test_resolveThinkingMarkers_returnsNilWhenMaxThinkingTokensIsZero() {
+        var config = GenerationConfig()
+        config.maxThinkingTokens = 0
+        // Even with both override and auto-detected available, zero budget wins (#597).
+        let resolved = MLXBackend.resolveThinkingMarkers(
+            config: config,
+            autoDetected: .qwen3
+        )
+        XCTAssertNil(resolved)
+    }
+
+    func test_resolveThinkingMarkers_prefersConfigOverrideWhenSet() {
+        var config = GenerationConfig()
+        let override = ThinkingMarkers(open: "<a>", close: "</a>")
+        config.thinkingMarkers = override
+        let resolved = MLXBackend.resolveThinkingMarkers(
+            config: config,
+            autoDetected: .qwen3
+        )
+        XCTAssertEqual(resolved, override)
+    }
+
+    func test_resolveThinkingMarkers_fallsBackToAutoDetectedWhenConfigUnset() {
+        let resolved = MLXBackend.resolveThinkingMarkers(
+            config: GenerationConfig(),
+            autoDetected: .qwen3
+        )
+        XCTAssertEqual(resolved, .qwen3)
+    }
+
+    func test_resolveThinkingMarkers_returnsNilWhenNeitherSourceProvided() {
+        let resolved = MLXBackend.resolveThinkingMarkers(
+            config: GenerationConfig(),
+            autoDetected: nil
+        )
+        XCTAssertNil(resolved)
+    }
+
+    // MARK: - buildChatMessages
+
+    func test_buildChatMessages_fallsBackToBarePromptWhenNoHistory() throws {
+        let (chatMessages, messages) = try MLXBackend.buildChatMessages(
+            prompt: "hi there",
+            effectiveSystemPrompt: nil,
+            conversationHistory: [],
+            toolAwareHistory: nil,
+            structuredHistory: nil,
+            dialect: .unknown
+        )
+        XCTAssertNil(chatMessages, "no images → no Chat.Message path")
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0]["role"], "user")
+        XCTAssertEqual(messages[0]["content"], "hi there")
+    }
+
+    func test_buildChatMessages_prependsSystemPromptWhenSet() throws {
+        let (_, messages) = try MLXBackend.buildChatMessages(
+            prompt: "hi",
+            effectiveSystemPrompt: "You are helpful.",
+            conversationHistory: [],
+            toolAwareHistory: nil,
+            structuredHistory: nil,
+            dialect: .unknown
+        )
+        XCTAssertEqual(messages.count, 2)
+        XCTAssertEqual(messages[0]["role"], "system")
+        XCTAssertEqual(messages[0]["content"], "You are helpful.")
+        XCTAssertEqual(messages[1]["role"], "user")
+        XCTAssertEqual(messages[1]["content"], "hi")
+    }
+
+    func test_buildChatMessages_replaysConversationHistoryWhenSet() throws {
+        let (_, messages) = try MLXBackend.buildChatMessages(
+            prompt: "ignored when history present",
+            effectiveSystemPrompt: nil,
+            conversationHistory: [
+                (role: "user", content: "first"),
+                (role: "assistant", content: "ack"),
+                (role: "user", content: "second")
+            ],
+            toolAwareHistory: nil,
+            structuredHistory: nil,
+            dialect: .unknown
+        )
+        XCTAssertEqual(messages.count, 3)
+        XCTAssertEqual(messages.map { $0["content"] }, ["first", "ack", "second"])
+        XCTAssertEqual(messages.map { $0["role"] }, ["user", "assistant", "user"])
+    }
+
+    func test_buildChatMessages_toolAwareHistorySupersedesPlain() throws {
+        let toolEntry = ToolAwareHistoryEntry(
+            role: "user",
+            content: "what's the weather?"
+        )
+        let (_, messages) = try MLXBackend.buildChatMessages(
+            prompt: "ignored",
+            effectiveSystemPrompt: nil,
+            conversationHistory: [(role: "user", content: "plain history that should NOT appear")],
+            toolAwareHistory: [toolEntry],
+            structuredHistory: nil,
+            dialect: .qwen25
+        )
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0]["role"], "user")
+        XCTAssertEqual(messages[0]["content"], "what's the weather?")
+    }
+
+    func test_buildChatMessages_returnsNilChatMessagesWhenStructuredHistoryHasNoImages() throws {
+        let history = [
+            StructuredMessage(role: "user", content: "text only"),
+            StructuredMessage(role: "assistant", content: "still text")
+        ]
+        let (chatMessages, _) = try MLXBackend.buildChatMessages(
+            prompt: "ignored",
+            effectiveSystemPrompt: nil,
+            conversationHistory: [],
+            toolAwareHistory: nil,
+            structuredHistory: history,
+            dialect: .unknown
+        )
+        XCTAssertNil(chatMessages, "vision path stays off when no .image parts present")
+    }
+
+    func test_buildChatMessages_returnsChatMessagesWhenStructuredHistoryHasImages() throws {
+        // 1×1 PNG (smallest valid) so CIImage(data:) succeeds.
+        let pngBytes: [UInt8] = [
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+            0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+            0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+            0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41,
+            0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+            0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+            0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+            0x42, 0x60, 0x82
+        ]
+        let pngData = Data(pngBytes)
+        let history = [
+            StructuredMessage(role: "user", parts: [
+                .text("describe this"),
+                .image(data: pngData, mimeType: "image/png")
+            ])
+        ]
+        let (chatMessages, _) = try MLXBackend.buildChatMessages(
+            prompt: "ignored",
+            effectiveSystemPrompt: "system!",
+            conversationHistory: [],
+            toolAwareHistory: nil,
+            structuredHistory: history,
+            dialect: .unknown
+        )
+        XCTAssertNotNil(chatMessages)
+        XCTAssertEqual(chatMessages?.count, 2, "system + user")
+    }
+}
+#endif

--- a/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
+++ b/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
@@ -157,7 +157,7 @@ BaseChatBackends/MLXBackend.swift:if let data = try? JSONSerialization.data(with
 # best-effort: if the generation Task is cancelled mid-yield we
 # intentionally fall through to the next loop iteration where
 # `Task.isCancelled` is checked, rather than observing CancellationError.
-BaseChatBackends/MLXBackend.swift:try? await Task.sleep(for: .microseconds(50))
+BaseChatBackends/MLX/MLXGenerationDriver.swift:try? await Task.sleep(for: .microseconds(50))
 
 # MLXToolCallParser.parseToolCall: defensive JSON parse of the buffered
 # payload between <tool_call>…</tool_call>. Models routinely emit


### PR DESCRIPTION
Closes a slice of #964 (cyclomatic-complexity reduction).

## Summary

`MLXBackend.generate(prompt:systemPrompt:config:)` was 363 LOC at CC 62. It now collapses to a ~80-line orchestrator at **CC 18** (target ≤20) by lifting four pure helpers and moving the streaming loop into a new `MLXGenerationDriver` struct that mirrors `LlamaGenerationDriver`.

| Function | NLOC before | CC before | NLOC after | CC after |
|---|---|---|---|---|
| `MLXBackend.generate` | 279 | **62** | 131 | **18** |
| `MLXGenerationDriver.run` | — | — | 90 | **29** (target ≤30) |
| `MLXBackend.buildQwenToolBlock` | — | — | 27 | 4 |
| `MLXBackend.buildChatMessages` | — | — | 43 | 12 |
| `MLXBackend.resolveThinkingMarkers` | — | — | 7 | 2 |
| `MLXBackend.prepareInputAndCache` | — | — | 45 | 7 |

## Approach (one commit per extraction)

1. `buildQwenToolBlock(config:dialect:) -> String?` — Qwen 2.5 `<tools>…</tools>` block builder.
2. `buildChatMessages(...)` — assembles both shapes the MLX container's `prepare(...)` overloads need (`[Chat.Message]?` for vision, `[[String:String]]` for text).
3. `resolveThinkingMarkers(config:autoDetected:) -> ThinkingMarkers?` — config override → auto-detected, with the `maxThinkingTokens == 0` short-circuit (#597).
4. `prepareInputAndCache(...)` — prepare → makeCache → KV-reuse heuristic. **The reuse path is byte-identical** (`longestCommonPrefixLength` clamped to `promptTokenIds.count - 1`, gated by `isSupportedPromptCache` and `count > 1`) — the v0.5.3 KV-cache incident is the reason this matters.
5. `MLXGenerationDriver` — stateless `@MainActor` struct mirroring `LlamaGenerationDriver`'s shape. Owns the streaming loop, both parsers' two-stage routing, `maxOutputTokens`/`maxThinkingTokens` budgets, and the cooperative `microseconds(50)` yield. Lifecycle (snapshot scheduling, `setPhase(.done/.failed)`, `continuation.finish()`) stays in `MLXBackend.generate`.

The driver is `@MainActor` (unlike Llama's, which is not) because every MLX call shares the single-threaded GPU scheduler. The redundant `await MainActor.run { generationStream.setPhase(...) }` wrappers became direct calls — the Task already runs on `@MainActor`.

## Code motion only — zero behavior change

Every gate, parser routing path, budget enforcement, yield cadence, and snapshot-scheduling decision is preserved. The two nested `PromptCacheSnapshot`/`CachedLayerState` types were widened from `private` to default-internal so the lifted `prepareInputAndCache` static can take them in its signature.

## Tests

- 13 new XCTest unit tests in `MLXBackendHelpersTests.swift` cover the three pure helpers (`buildQwenToolBlock`, `resolveThinkingMarkers`, `buildChatMessages`). Hardware-free — they run in CI.
- The 4th helper (`prepareInputAndCache`) and `MLXGenerationDriver.run` stay covered by existing `MLXBackendGenerationTests` (mock container, no Metal) and `BaseChatMLXIntegrationTests` (Xcode-only, real models).
- **Sabotage check passed locally**: removing the `maxThinkingTokens == 0` short-circuit from `resolveThinkingMarkers` makes `test_resolveThinkingMarkers_returnsNilWhenMaxThinkingTokensIsZero` fail. Reverted before commit.
- Updated `Tests/BaseChatInferenceTests/silent_catch_allowlist.txt` so `SilentCatchAuditTest` finds the moved `try? await Task.sleep(for: .microseconds(50))` line at its new path under `MLX/MLXGenerationDriver.swift`.

## Test plan

- [x] `swift build --traits MLX --skip-update` green
- [x] `scripts/test.sh ... --disable-default-traits --skip-update` (XCTest invocation): 2488 passed / 0 failed
- [x] `scripts/test.sh --filter BaseChatInferenceSwiftTestingTests --disable-default-traits --skip-update`: 83 passed / 0 failed
- [x] `swift test --filter BaseChatBackendsTests --traits MLX --skip-update`: 214 passed (3 skipped) — including the 13 new helper tests and all existing MLX coverage
- [ ] CI green