### PR TITLE
refactor(inference): rename GenerationCoordinator to GenerationQueue

### DIFF
--- a/Sources/BaseChatBackends/ClaudeBackend.swift
+++ b/Sources/BaseChatBackends/ClaudeBackend.swift
@@ -93,7 +93,7 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             // Vision is gated on the configured model name — Claude 3, 3.5,
             // 3.7, and 4 families all accept images as content blocks; the
             // Claude 2 family and `claude-instant-*` do not. The
-            // GenerationCoordinator's pre-flight reads this flag and rejects
+            // GenerationQueue's pre-flight reads this flag and rejects
             // image attachments before we ever build a request body, so an
             // outdated model name surfaces a clear "not vision-capable"
             // error rather than a 400 from Anthropic.
@@ -215,7 +215,7 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             }
             // Vision pre-flight: if the configured model isn't vision-capable
             // and the structured history carries any image, fail with a
-            // clear local error. (GenerationCoordinator already gates this
+            // clear local error. (GenerationQueue already gates this
             // path on `capabilities.supportsVision`, but the backend may be
             // driven directly — e.g. the OpenAI-compat server — so keep the
             // belt-and-suspenders check here.)

--- a/Sources/BaseChatBackends/OpenAIBackend.swift
+++ b/Sources/BaseChatBackends/OpenAIBackend.swift
@@ -81,7 +81,7 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             // Vision support is gated on the configured model name. OpenAI's
             // vision-capable families (gpt-4o*, gpt-4-turbo, gpt-4.1, o1, o3)
             // accept `image_url` content parts; older completions-only models
-            // do not. ``GenerationCoordinator``'s pre-flight reads this flag
+            // do not. ``GenerationQueue``'s pre-flight reads this flag
             // and rejects image attachments before we ever build a request,
             // so a non-vision model surfaces a clear local error rather than
             // a 400 from upstream.
@@ -150,7 +150,7 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
 
     // MARK: - Structured History
 
-    /// Structured replay history. Set by ``GenerationCoordinator`` when the
+    /// Structured replay history. Set by ``GenerationQueue`` when the
     /// caller uses ``InferenceService/enqueue(structuredMessages:...)``;
     /// carries ``MessagePart/image(data:mimeType:)`` parts so vision turns
     /// can be serialised as `image_url` content parts on the request body.
@@ -236,7 +236,7 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
                   !structured.isEmpty,
                   CloudImageEncoding.imageCount(in: structured) > 0 {
             // Vision pre-flight: refuse to forward images to a model that
-            // doesn't advertise vision support. ``GenerationCoordinator``
+            // doesn't advertise vision support. ``GenerationQueue``
             // already gates this path on `capabilities.supportsVision`, but
             // the backend may be driven directly (e.g. the OpenAI-compat
             // server, or callers wiring their own pipeline), so keep the
@@ -252,7 +252,7 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             // o-series, hosted Qwen reasoning) deliver chain-of-thought via
             // `reasoning_content` / `reasoning` deltas but **don't** require
             // it on multi-turn replay — and most providers reject blocks they
-            // didn't emit. ``GenerationCoordinator`` already collapsed
+            // didn't emit. ``GenerationQueue`` already collapsed
             // structured history to `(role, content)` text via
             // ``StructuredMessage/textContent``, which drops `.thinking`
             // parts. So thinking is informational only on this backend's

--- a/Sources/BaseChatInference/Models/GenerationEvent.swift
+++ b/Sources/BaseChatInference/Models/GenerationEvent.swift
@@ -9,16 +9,16 @@
 /// The tool-call event vocabulary is locked as of the 1.0 release. Key design
 /// decisions recorded here for Wave 3 consumers:
 ///
-/// ### Coordinator-emitted lifecycle events
+/// ### Queue-emitted lifecycle events
 ///
 /// ``toolDispatchStarted(callId:name:attempt:)`` and
 /// ``toolDispatchCompleted(callId:durationMs:errorKind:)`` are emitted by the
-/// **coordinator** (`GenerationCoordinator`), not by individual backends.
+/// **queue** (`GenerationQueue`), not by individual backends.
 /// Backends emit only ``toolCall(_:)`` (and, when
 /// streaming, ``toolCallStart(callId:name:)`` and
 /// ``toolCallArgumentsDelta(callId:textDelta:)``). Consumers driving generation
-/// through `InferenceService` / `GenerationCoordinator` that reconstruct
-/// timelines or present per-call spinners should key on these coordinator events,
+/// through `InferenceService` / `GenerationQueue` that reconstruct
+/// timelines or present per-call spinners should key on these queue events,
 /// not on the backend streaming events.
 ///
 /// ### `.toolCallNameDelta` is intentionally absent

--- a/Sources/BaseChatInference/Protocols/BackendOptInProtocols.swift
+++ b/Sources/BaseChatInference/Protocols/BackendOptInProtocols.swift
@@ -30,7 +30,7 @@ public protocol ConversationHistoryReceiver: AnyObject {
 ///
 /// Text-only backends collapse a ``StructuredMessage`` back to
 /// `(role, content)` at their boundary — see
-/// ``GenerationCoordinator`` for the flattening rule (text parts joined,
+/// ``GenerationQueue`` for the flattening rule (text parts joined,
 /// thinking parts dropped from the prompt).
 public struct StructuredMessage: Sendable, Hashable {
 
@@ -69,7 +69,7 @@ public struct StructuredMessage: Sendable, Hashable {
 /// history — including thinking blocks with their provider signatures and
 /// tool call / result parts.
 ///
-/// ``GenerationCoordinator`` calls this in addition to (not instead of)
+/// ``GenerationQueue`` calls this in addition to (not instead of)
 /// ``ConversationHistoryReceiver`` so backends can pick whichever shape
 /// matches their wire format. The Anthropic backend reads the structured
 /// form so it can serialize prior `thinking` content blocks with their
@@ -170,7 +170,7 @@ public protocol LoadProgressReporting: AnyObject {
 /// Adopted by local backends that can count tokens exactly using their loaded vocabulary.
 ///
 /// Non-local backends (cloud, Ollama) should not conform — they have no
-/// local tokenizer. `GenerationCoordinator` gates the exact pre-flight
+/// local tokenizer. `GenerationQueue` gates the exact pre-flight
 /// check on this protocol so the trim-and-retry path only activates for
 /// backends where KV cache overflow is a real concern.
 ///

--- a/Sources/BaseChatInference/Protocols/GenerationContextProvider.swift
+++ b/Sources/BaseChatInference/Protocols/GenerationContextProvider.swift
@@ -1,7 +1,7 @@
 /// Provides the generation coordinator with read access to the currently loaded
 /// backend, model-loaded state, and prompt template.
 ///
-/// `InferenceService` conforms to this protocol so the `GenerationCoordinator`
+/// `InferenceService` conforms to this protocol so the `GenerationQueue`
 /// can operate without a direct dependency on `ModelLifecycleCoordinator`.
 @MainActor
 protocol GenerationContextProvider: AnyObject {

--- a/Sources/BaseChatInference/Protocols/PromptContextProvider.swift
+++ b/Sources/BaseChatInference/Protocols/PromptContextProvider.swift
@@ -12,7 +12,7 @@ import Foundation
 ///
 /// > Note: This protocol is distinct from the internal `GenerationContextProvider`,
 /// > which is a `@MainActor`-bound, `AnyObject`-constrained model-state provider
-/// > used by `GenerationCoordinator` to read backend / template state. The two
+/// > used by `GenerationQueue` to read backend / template state. The two
 /// > do not overlap and should not be merged.
 public protocol PromptContextProvider: Sendable {
     /// Slots to inject into the next prompt.

--- a/Sources/BaseChatInference/Services/ContextWindowManager.swift
+++ b/Sources/BaseChatInference/Services/ContextWindowManager.swift
@@ -15,14 +15,14 @@ import Foundation
 ///
 /// ### Per-caller reservation (post issue #587)
 ///
-/// - `BaseChatUI.GenerationCoordinator` derives `responseBuffer` from
+/// - `BaseChatUI.GenerationQueue` derives `responseBuffer` from
 ///   `maxOutputTokens() ?? 2048` + `maxThinkingTokens() ?? 0`, wired up from
 ///   `ChatViewModel.maxOutputTokens` / `maxThinkingTokens` host-facing settings.
 /// - `BaseChatInference.PromptAssembler` still uses a hardcoded default of `512`
 ///   when no `responseBuffer` is supplied — that default only governs callers
 ///   that don't pass their own value (tests, diagnostic tooling). Production
 ///   callers all supply an explicit buffer.
-/// - `BaseChatInference.GenerationCoordinator.exactPreflightAndTrim` reserves
+/// - `BaseChatInference.GenerationQueue.exactPreflightAndTrim` reserves
 ///   `(config.maxOutputTokens ?? 2048) + (config.maxThinkingTokens ?? 0)`.
 ///   `nil` on `maxThinkingTokens` reserves **zero** rather than a default slice
 ///   — see "Default policy" below.

--- a/Sources/BaseChatInference/Services/GenerationQueue.swift
+++ b/Sources/BaseChatInference/Services/GenerationQueue.swift
@@ -1,19 +1,21 @@
 import Foundation
 import Observation
 
-/// Owns the generation queue, in-flight request tracking, prompt formatting,
-/// and generation lifecycle management.
+/// FIFO + priority queue and tool-dispatch transport for generation requests.
 ///
-/// This is an internal implementation detail of `BaseChatInference`.
-/// `InferenceService` delegates all generation operations to this coordinator
-/// and preserves the unchanged public API.
+/// `GenerationQueue` owns the generation queue, in-flight request tracking,
+/// prompt formatting, the per-token thermal-pause loop, and the tool-call
+/// dispatch transport that ``ConversationRuntime`` runs on top of. It is an
+/// internal implementation detail of `BaseChatInference`; `InferenceService`
+/// delegates all generation operations here and preserves the unchanged
+/// public API.
 @Observable
 @MainActor
-final class GenerationCoordinator {
+final class GenerationQueue {
 
     // MARK: - Published State
 
-    /// Whether the coordinator has an active generation in progress.
+    /// Whether the queue has an active generation in progress.
     ///
     /// `internal` storage, exposed as `public` via `InferenceService.isGenerating`.
     private(set) var isGenerating = false
@@ -46,7 +48,7 @@ final class GenerationCoordinator {
 
     /// Optional registry used to dispatch model-emitted ``ToolCall`` events.
     ///
-    /// Stored here in wave 1 so the coordinator's init surface is stable for
+    /// Stored here in wave 1 so the queue's init surface is stable for
     /// downstream wiring; the actual dispatch site lands in wave 2 Agent D.
     let toolRegistry: ToolRegistry?
 
@@ -55,9 +57,9 @@ final class GenerationCoordinator {
     /// not opted into per-call approval see unchanged behaviour.
     ///
     /// The gate is invoked on the *finalized* ``ToolCall`` — streaming
-    /// argument deltas are merged by the backend before the coordinator
+    /// argument deltas are merged by the backend before the queue
     /// observes the call event. On ``ToolApprovalDecision/denied(reason:)``
-    /// the coordinator synthesises a ``ToolResult`` with
+    /// the queue synthesises a ``ToolResult`` with
     /// ``ToolResult/ErrorKind/permissionDenied`` and continues the stream
     /// rather than cancelling generation.
     let toolApprovalGate: any ToolApprovalGate
@@ -205,7 +207,7 @@ final class GenerationCoordinator {
         // suppress the warning by not setting the flag in the first place.
         if jsonMode && !backend.capabilities.supportsNativeJSONMode {
             let backendType = String(describing: type(of: backend))
-            let message = "GenerationCoordinator: jsonMode=true requested but \(backendType) does not support native JSON mode (capabilities.supportsNativeJSONMode == false); the flag will be ignored and the response will be plain text. Check `backend.capabilities.supportsNativeJSONMode` before setting `config.jsonMode`."
+            let message = "GenerationQueue: jsonMode=true requested but \(backendType) does not support native JSON mode (capabilities.supportsNativeJSONMode == false); the flag will be ignored and the response will be plain text. Check `backend.capabilities.supportsNativeJSONMode` before setting `config.jsonMode`."
             Log.inference.warning("\(message, privacy: .public)")
             Self.jsonModeUnsupportedWarningHook?(backendType, message)
         }
@@ -261,7 +263,7 @@ final class GenerationCoordinator {
 
         if config.jsonMode && !backend.capabilities.supportsNativeJSONMode {
             let backendType = String(describing: type(of: backend))
-            let message = "GenerationCoordinator: jsonMode=true requested but \(backendType) does not support native JSON mode (capabilities.supportsNativeJSONMode == false); the flag will be ignored and the response will be plain text. Check `backend.capabilities.supportsNativeJSONMode` before setting `config.jsonMode`."
+            let message = "GenerationQueue: jsonMode=true requested but \(backendType) does not support native JSON mode (capabilities.supportsNativeJSONMode == false); the flag will be ignored and the response will be plain text. Check `backend.capabilities.supportsNativeJSONMode` before setting `config.jsonMode`."
             Log.inference.warning("\(message, privacy: .public)")
             Self.jsonModeUnsupportedWarningHook?(backendType, message)
         }
@@ -476,7 +478,7 @@ final class GenerationCoordinator {
             }
 
             Log.inference.warning(
-                "GenerationCoordinator: prompt over budget — trimming oldest non-system message (attempt \(attempt + 1)/\(maxTrimAttempts))"
+                "GenerationQueue: prompt over budget — trimming oldest non-system message (attempt \(attempt + 1)/\(maxTrimAttempts))"
             )
             workingMessages.remove(at: dropIndex)
             attempt += 1
@@ -557,7 +559,7 @@ final class GenerationCoordinator {
         if !tools.isEmpty && !backend.capabilities.supportsToolCalling {
             let backendType = String(describing: type(of: backend))
             let toolWord = tools.count == 1 ? "tool" : "tools"
-            let message = "GenerationCoordinator: \(tools.count) \(toolWord) passed to enqueue() but \(backendType) reports capabilities.supportsToolCalling == false; tools will be ignored on the wire and tool calls will never be dispatched. Check `backend.capabilities.supportsToolCalling` before passing tools, or load a tool-capable backend."
+            let message = "GenerationQueue: \(tools.count) \(toolWord) passed to enqueue() but \(backendType) reports capabilities.supportsToolCalling == false; tools will be ignored on the wire and tool calls will never be dispatched. Check `backend.capabilities.supportsToolCalling` before passing tools, or load a tool-capable backend."
             Log.inference.warning("\(message, privacy: .public)")
             Self.toolsUnsupportedWarningHook?(backendType, message)
             throw InferenceError.inferenceFailure("Tools passed to a backend that does not support tool calling (\(backendType)); set capabilities.supportsToolCalling = true or remove tools from the request.")
@@ -703,7 +705,7 @@ final class GenerationCoordinator {
             .diagnosticThrottle(reason: "thermalState=.critical")
         )
         Log.inference.warning(
-            "GenerationCoordinator: pausing generation — ProcessInfo.thermalState == .critical"
+            "GenerationQueue: pausing generation — ProcessInfo.thermalState == .critical"
         )
 
         while !Task.isCancelled {
@@ -717,7 +719,7 @@ final class GenerationCoordinator {
             }
             if thermalStateProvider() != .critical {
                 Log.inference.info(
-                    "GenerationCoordinator: thermal state dropped below .critical — resuming generation"
+                    "GenerationQueue: thermal state dropped below .critical — resuming generation"
                 )
                 return
             }
@@ -797,7 +799,7 @@ final class GenerationCoordinator {
                 // Cap reached — loop terminated before invoking the backend
                 // with the next turn's request.
                 Log.inference.warning(
-                    "GenerationCoordinator: tool-dispatch loop hit maxToolIterations=\(limit, privacy: .public); terminating."
+                    "GenerationQueue: tool-dispatch loop hit maxToolIterations=\(limit, privacy: .public); terminating."
                 )
                 self.continuations[request.token]?.yield(
                     .toolLoopLimitReached(iterations: limit)
@@ -872,7 +874,7 @@ final class GenerationCoordinator {
                        prev.arguments == call.arguments {
                         // Identical repeat — don't re-invoke the executor.
                         Log.inference.warning(
-                            "GenerationCoordinator: tool '\(call.toolName, privacy: .public)' called twice in a row with identical arguments; short-circuiting to previous result."
+                            "GenerationQueue: tool '\(call.toolName, privacy: .public)' called twice in a row with identical arguments; short-circuiting to previous result."
                         )
                         let prevContent = dispatchedInThisTurn.last?.1.content ?? ""
                         result = ToolResult(
@@ -882,7 +884,7 @@ final class GenerationCoordinator {
                         )
                     } else if toolResultByteTotal >= Self.toolResultByteBudget {
                         Log.inference.warning(
-                            "GenerationCoordinator: tool-result byte budget (\(Self.toolResultByteBudget, privacy: .public)) exhausted before dispatching '\(call.toolName, privacy: .public)'; terminating loop."
+                            "GenerationQueue: tool-result byte budget (\(Self.toolResultByteBudget, privacy: .public)) exhausted before dispatching '\(call.toolName, privacy: .public)'; terminating loop."
                         )
                         result = ToolResult(
                             callId: call.id,
@@ -919,7 +921,7 @@ final class GenerationCoordinator {
                             result = await toolRegistry!.dispatch(call)
                         case .denied(let reason):
                             Log.inference.info(
-                                "GenerationCoordinator: tool '\(call.toolName, privacy: .public)' denied by ToolApprovalGate"
+                                "GenerationQueue: tool '\(call.toolName, privacy: .public)' denied by ToolApprovalGate"
                             )
                             result = ToolResult(
                                 callId: call.id,

--- a/Sources/BaseChatInference/Services/InferenceService.swift
+++ b/Sources/BaseChatInference/Services/InferenceService.swift
@@ -57,7 +57,7 @@ public final class InferenceService {
     // MARK: - Internal Coordinators
 
     private let lifecycle: ModelLifecycleCoordinator
-    private let generation: GenerationCoordinator
+    private let generation: GenerationQueue
 
     // MARK: - Public Type Aliases (preserve InferenceService.GenerationRequestToken syntax)
 
@@ -383,7 +383,7 @@ public final class InferenceService {
 
     public nonisolated init() {
         self.lifecycle = ModelLifecycleCoordinator()
-        self.generation = GenerationCoordinator()
+        self.generation = GenerationQueue()
         // Provider wiring happens lazily via ensureProviderWired() on first use,
         // since `self` is not available inside a nonisolated init.
         Self.scheduleToolSpillReap()
@@ -404,7 +404,7 @@ public final class InferenceService {
     /// (e.g. a UI-driven approval sheet).
     public nonisolated init(toolRegistry: ToolRegistry) {
         self.lifecycle = ModelLifecycleCoordinator()
-        self.generation = GenerationCoordinator(toolRegistry: toolRegistry)
+        self.generation = GenerationQueue(toolRegistry: toolRegistry)
         Self.scheduleToolSpillReap()
     }
 
@@ -418,7 +418,7 @@ public final class InferenceService {
     /// — generation is not cancelled.
     public nonisolated init(toolRegistry: ToolRegistry, toolApprovalGate: any ToolApprovalGate) {
         self.lifecycle = ModelLifecycleCoordinator()
-        self.generation = GenerationCoordinator(
+        self.generation = GenerationQueue(
             toolRegistry: toolRegistry,
             toolApprovalGate: toolApprovalGate
         )
@@ -453,7 +453,7 @@ public final class InferenceService {
         toolApprovalGate: any ToolApprovalGate = AutoApproveGate()
     ) {
         self.lifecycle = ModelLifecycleCoordinator(backend: backend, name: name, modelName: modelName)
-        self.generation = GenerationCoordinator(
+        self.generation = GenerationQueue(
             toolRegistry: toolRegistry,
             toolApprovalGate: toolApprovalGate
         )

--- a/Sources/BaseChatInference/Services/StreamingTokenBatcher.swift
+++ b/Sources/BaseChatInference/Services/StreamingTokenBatcher.swift
@@ -5,8 +5,8 @@ import Foundation
 /// Buffers streamed tokens and emits coalesced batches to reduce high-frequency
 /// mutations that would otherwise trigger excessive UI re-renders.
 ///
-/// Moved from `BaseChatUI/GenerationCoordinator` to `BaseChatInference` so both
-/// `ConversationRuntime` (in `BaseChatRuntime`) and `GenerationCoordinator` (in
+/// Moved from `BaseChatUI/GenerationQueue` to `BaseChatInference` so both
+/// `ConversationRuntime` (in `BaseChatRuntime`) and `GenerationQueue` (in
 /// `BaseChatUI`) can share the same implementation without a cross-module copy.
 public struct StreamingTokenBatcher: Sendable {
     private let interval: Duration

--- a/Sources/BaseChatInference/Services/ToolExecutor.swift
+++ b/Sources/BaseChatInference/Services/ToolExecutor.swift
@@ -75,7 +75,7 @@ import Foundation
 ///
 /// `execute(arguments:)` runs inside a `Task` owned by the orchestrator
 /// (``ToolRegistry/dispatch(_:)`` is invoked from a child task in
-/// `GenerationCoordinator`). When the user hits stop mid-generation, the
+/// `GenerationQueue`). When the user hits stop mid-generation, the
 /// orchestrator calls `Task.cancel()` on its active generation task and the
 /// cancellation propagates into this executor through structured concurrency.
 ///

--- a/Sources/BaseChatRuntime/Services/ConversationEvent.swift
+++ b/Sources/BaseChatRuntime/Services/ConversationEvent.swift
@@ -19,7 +19,7 @@ import BaseChatInference
 // `.toolCallCompleted`) and `.compressionTriggered` are present on the
 // surface so adapters can bind to them today; the runtime emits them in
 // later PRs as the corresponding behaviour migrates from
-// ``GenerationCoordinator`` and ``ChatViewModel``.
+// ``GenerationQueue`` and ``ChatViewModel``.
 //
 // Phase 1.2.5 PR-B adds `.messageRemoved` (the 13th case) and emits it
 // from the regenerate sub-flow when the runtime deletes the last assistant
@@ -137,7 +137,7 @@ public enum ConversationEvent: Sendable {
     /// History was compressed (older messages dropped to fit the context
     /// window, or via a host-driven compression command). Load-bearing,
     /// although PR-A does not emit it from the send sub-flow — context
-    /// management still lives in `GenerationCoordinator` for the pre-PR-A
+    /// management still lives in `GenerationQueue` for the pre-PR-A
     /// surface. Reserved for later sub-flows that route compression
     /// through the runtime.
     case compressionTriggered(removed: [ChatMessageRecord.ID], reason: CompressionReason)
@@ -147,7 +147,7 @@ public enum ConversationEvent: Sendable {
     /// The model requested a tool invocation. Adapters that gate tools
     /// behind user approval pause for explicit `.toolCallApproved` before
     /// dispatching. PR-A does not emit this — the existing tool-loop
-    /// orchestration stays in `ChatViewModel`/`GenerationCoordinator`
+    /// orchestration stays in `ChatViewModel`/`GenerationQueue`
     /// until a follow-up PR routes it through the runtime.
     case toolCallRequested(ToolCall)
 

--- a/Sources/BaseChatRuntime/Services/ConversationRuntime.swift
+++ b/Sources/BaseChatRuntime/Services/ConversationRuntime.swift
@@ -325,7 +325,7 @@ actor InFlightStreamRegistry {
 /// ``regenerate(_:)``. PR-C adds ``edit(_:)`` and extracts a shared
 /// ``runGenerationTurn`` helper. PR-D adds ``branch(_:)``. PR-E absorbs
 /// the streaming-token batcher, thinking-block disclosure, loop detection,
-/// and tool-dispatch loop from `GenerationCoordinator` into
+/// and tool-dispatch loop from `GenerationQueue` into
 /// ``runGenerationTurn`` so all four sub-flows share the same rich
 /// streaming behaviour.
 public final class ConversationRuntime: Sendable {
@@ -793,7 +793,7 @@ public final class ConversationRuntime: Sendable {
         }
 
         // BranchInput does not carry streaming/loop knobs; use defaults
-        // matching GenerationCoordinator's current behaviour.
+        // matching GenerationQueue's current behaviour.
         await runGenerationTurn(
             sessionID: input.newSessionID,
             userPrompt: nil,
@@ -881,7 +881,7 @@ public final class ConversationRuntime: Sendable {
 
         // Forward the registered tool surface so the backend's GenerationConfig
         // gets `tools = registry.advertisedDefinitions` (legacy parity with
-        // GenerationCoordinator.enqueueGeneration). `advertisedDefinitions`
+        // GenerationQueue.enqueueGeneration). `advertisedDefinitions`
         // already honours `advertisedToolNames` filtering — registering a
         // tool but limiting which names go on the wire works without
         // unregistering the executor. Fetched on the main actor because the
@@ -921,7 +921,7 @@ public final class ConversationRuntime: Sendable {
 
         emit(.streamStarted(messageID: assistantID))
 
-        // Drain the stream, mirroring GenerationCoordinator's four features:
+        // Drain the stream, mirroring GenerationQueue's four features:
         //   (a) token batcher — coalesce per-token events into UI-cadenced batches
         //   (b) thinking-block disclosure — track/batch reasoning tokens and emit
         //       thinkingStarted / thinkingUpdated / thinkingFinalized events
@@ -1048,7 +1048,7 @@ public final class ConversationRuntime: Sendable {
 
         // Finalise the assistant message. If the stream produced no visible
         // content and was not cancelled, drop it — matches the
-        // `ChatViewModel`/`GenerationCoordinator` rule that keeps the
+        // `ChatViewModel`/`GenerationQueue` rule that keeps the
         // transcript clean of empty turns.
         //
         // Unregister before emitting terminal events so that any cancel(_:)
@@ -1059,7 +1059,7 @@ public final class ConversationRuntime: Sendable {
         await registry.unregister(handle: handle)
 
         // Capture token usage off the active backend before any subsequent
-        // turn can overwrite it. The legacy `GenerationCoordinator` set this
+        // turn can overwrite it. The legacy `GenerationQueue` set this
         // on the assistant `ChatMessage` immediately after the stream ended;
         // the runtime path needs the same per-turn pinning so back-to-back
         // sends do not cross-contaminate prompt/completion counts. Read on

--- a/Sources/BaseChatRuntime/Services/ConversationRuntimeTypes.swift
+++ b/Sources/BaseChatRuntime/Services/ConversationRuntimeTypes.swift
@@ -73,7 +73,7 @@ public enum FinishReason: Sendable, Hashable {
 ///
 /// Carried by ``ConversationEvent/compressionTriggered(removed:reason:)``.
 /// PR-A does not emit this case from its send flow — context-window
-/// management remains in `ChatViewModel`'s `GenerationCoordinator` for the
+/// management remains in `ChatViewModel`'s `GenerationQueue` for the
 /// pre-PR-A surface. The case is wired into the event enum for future sub-
 /// flows (PR-B/PR-C) and Phase 1.2.5 follow-ups so adopters can subscribe
 /// today and receive events when later PRs route compression through the

--- a/Sources/BaseChatTools/ScenarioRunner.swift
+++ b/Sources/BaseChatTools/ScenarioRunner.swift
@@ -16,7 +16,7 @@ import BaseChatInference
 ///    accumulated text is the final answer and assertions run against it.
 ///
 /// Conversation history is plumbed into backends that conform to
-/// ``ConversationHistoryReceiver`` (same pattern as ``GenerationCoordinator``);
+/// ``ConversationHistoryReceiver`` (same pattern as ``GenerationQueue``);
 /// backends that do not conform get a plain-text prompt with appended tool
 /// results.
 @MainActor
@@ -88,7 +88,7 @@ public final class ScenarioRunner {
                     continue
                 case .toolResult, .toolLoopLimitReached:
                     // ScenarioRunner calls backend.generate() directly and owns
-                    // dispatch below, so it never receives GenerationCoordinator's
+                    // dispatch below, so it never receives GenerationQueue's
                     // orchestrator events on this path. Stay exhaustive for growth.
                     continue
                 case .kvCacheReuse:

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+RuntimeAdapter.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+RuntimeAdapter.swift
@@ -112,7 +112,7 @@ extension ChatViewModel {
             }
 
             // Fire post-generation tasks for successful turns. Cancelled and
-            // empty turns are skipped — the legacy `GenerationCoordinator`
+            // empty turns are skipped — the legacy `GenerationQueue`
             // gated on `hasVisibleContent`, so partial-cancel persistence
             // does not retroactively run summarisation hooks.
             if reason == .stop,
@@ -124,7 +124,7 @@ extension ChatViewModel {
 
             // After the first assistant response on Foundation, nudge the
             // user to consider downloading a local model for longer
-            // context. Mirrors the legacy `GenerationCoordinator` rule:
+            // context. Mirrors the legacy `GenerationQueue` rule:
             // gated on the feature flag, only on the Apple backend, only
             // once per session.
             if reason == .stop,
@@ -174,7 +174,7 @@ extension ChatViewModel {
 
         case .thinkingUpdated(let messageID, let partialText):
             // Write `partialText` into the last in-flight `.thinking` part
-            // for live preview. Mirrors GenerationCoordinator.writeThinkingPartialText.
+            // for live preview. Mirrors GenerationQueue.writeThinkingPartialText.
             mutateMessage(id: messageID) { msg in
                 guard let idx = msg.contentParts.lastIndex(where: { $0.thinkingContent != nil }) else {
                     return
@@ -200,7 +200,7 @@ extension ChatViewModel {
         // MARK: Loop detection
 
         case .loopDetected(_):
-            // Wording mirrors the legacy `GenerationCoordinator` ("appears
+            // Wording mirrors the legacy `GenerationQueue` ("appears
             // to be repeating itself") so existing UI tests that probe for
             // the substring "repeating" continue to pin the user-visible
             // message.
@@ -263,7 +263,7 @@ extension ChatViewModel {
 
     /// Writes `partial` into the message's last `.thinking` part for live preview.
     ///
-    /// Mirrors the legacy `GenerationCoordinator.writeThinkingPartialText` —
+    /// Mirrors the legacy `GenerationQueue.writeThinkingPartialText` —
     /// retained because tests assert the preserve-placeholder behaviour
     /// directly.
     static func writeThinkingPartialText(_ partial: String, into msg: inout ChatMessageRecord) {

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -290,7 +290,7 @@ public final class ChatViewModel {
     /// Cap on visible response tokens for each generation.
     ///
     /// Feeds two places:
-    /// - The trim math in ``GenerationCoordinator`` reserves this many tokens
+    /// - The trim math in ``GenerationQueue`` reserves this many tokens
     ///   of the context window so the prompt is trimmed enough to leave room
     ///   for the response (see issue #587).
     /// - Forwarded to ``InferenceService/enqueue(...)`` as `maxOutputTokens`,

--- a/Sources/BaseChatUI/ViewModels/UIToolApprovalGate.swift
+++ b/Sources/BaseChatUI/ViewModels/UIToolApprovalGate.swift
@@ -6,7 +6,7 @@ import BaseChatInference
 /// that UI surfaces can observe and resolve.
 ///
 /// The gate cooperates with ``ChatViewModel`` and the backing
-/// ``GenerationCoordinator``: when the model emits a ``ToolCall``, the
+/// ``GenerationQueue``: when the model emits a ``ToolCall``, the
 /// coordinator awaits ``approve(_:)``. Depending on ``policy`` this either:
 /// - returns immediately (``Policy/autoApprove`` or the cached "already
 ///   approved once" flag for ``Policy/askOncePerSession``), or

--- a/Sources/BaseChatUI/Views/Chat/ThinkingBlockView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ThinkingBlockView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 /// While `isThinkingStreaming` is true the view renders a collapsed disclosure
 /// group whose label is `"Thinking… <inline preview>"` — the latest few lines
 /// of partial reasoning text streamed in via the thinking batcher in
-/// ``GenerationCoordinator``. Expanding the group reveals the full
+/// ``GenerationQueue``. Expanding the group reveals the full
 /// accumulated text. Once `isThinkingStreaming` flips to false the disclosure
 /// group switches to its finalized "Reasoning" label, still collapsed by
 /// default. This is intentionally decoupled from the overall message

--- a/Tests/BaseChatBackendsTests/ClaudeImageInputTests.swift
+++ b/Tests/BaseChatBackendsTests/ClaudeImageInputTests.swift
@@ -18,7 +18,7 @@ import BaseChatTestSupport
 ///    trip, with a message that names the offending count.
 /// 4. Reject image attachments when the configured model isn't vision-capable.
 /// 5. Advertise `supportsVision` based on the configured model name so
-///    GenerationCoordinator's pre-flight matches the wire-level behaviour.
+///    GenerationQueue's pre-flight matches the wire-level behaviour.
 final class ClaudeImageInputTests: XCTestCase {
 
     // MARK: - Helpers

--- a/Tests/BaseChatBackendsTests/OpenAIBackendImageInputTests.swift
+++ b/Tests/BaseChatBackendsTests/OpenAIBackendImageInputTests.swift
@@ -18,7 +18,7 @@ import BaseChatTestSupport
 /// 3. Reject image attachments when the configured model isn't
 ///    vision-capable, with a clear local error.
 /// 4. Advertise `supportsVision` based on the configured model name so
-///    ``GenerationCoordinator``'s pre-flight matches the wire-level
+///    ``GenerationQueue``'s pre-flight matches the wire-level
 ///    behaviour.
 /// 5. Conform to ``StructuredHistoryReceiver`` so the coordinator routes
 ///    `MessagePart.image` parts to it.
@@ -373,7 +373,7 @@ final class OpenAIBackendImageInputTests: XCTestCase {
         // failing the build if the conformance regresses.
         let backend: Any = OpenAIBackend()
         XCTAssertNotNil(backend as? StructuredHistoryReceiver,
-            "OpenAIBackend must conform to StructuredHistoryReceiver so GenerationCoordinator routes MessagePart.image parts to it")
+            "OpenAIBackend must conform to StructuredHistoryReceiver so GenerationQueue routes MessagePart.image parts to it")
     }
 
     // MARK: - 10. Data URI shape — exact MIME + base64 round-trip

--- a/Tests/BaseChatFuzzTests/InferenceServiceSignatureLockTests.swift
+++ b/Tests/BaseChatFuzzTests/InferenceServiceSignatureLockTests.swift
@@ -4,7 +4,7 @@ import BaseChatTestSupport
 
 /// Canary: pins the exact signatures of ``InferenceService/enqueue`` and
 /// ``InferenceService/stopGeneration(sessionID:)`` so that a refactor of
-/// ``GenerationCoordinator`` cannot silently break the multi-turn fuzzer.
+/// ``GenerationQueue`` cannot silently break the multi-turn fuzzer.
 ///
 /// The fuzzer's ``SessionScriptRunner`` drives through the real
 /// ``InferenceService``; a drift in these signatures would compile cleanly

--- a/Tests/BaseChatInferenceTests/CapabilityFlagEnforcementTests.swift
+++ b/Tests/BaseChatInferenceTests/CapabilityFlagEnforcementTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import BaseChatInference
 import BaseChatTestSupport
 
-/// Tests that `GenerationCoordinator.enqueue()` enforces capability flags.
+/// Tests that `GenerationQueue.enqueue()` enforces capability flags.
 ///
 /// Coverage:
 /// - tools rejected (throw + warning) when backend reports `supportsToolCalling == false`
@@ -44,15 +44,15 @@ final class CapabilityFlagEnforcementTests: XCTestCase {
 
     override func tearDown() async throws {
         // Always clear the warning hook to avoid cross-test leakage.
-        GenerationCoordinator.toolsUnsupportedWarningHook = nil
+        GenerationQueue.toolsUnsupportedWarningHook = nil
         provider = nil
         try await super.tearDown()
     }
 
     // MARK: - Helpers
 
-    private func makeCoordinator() -> GenerationCoordinator {
-        let coordinator = GenerationCoordinator()
+    private func makeCoordinator() -> GenerationQueue {
+        let coordinator = GenerationQueue()
         coordinator.provider = provider
         return coordinator
     }
@@ -83,7 +83,7 @@ final class CapabilityFlagEnforcementTests: XCTestCase {
     ///    stream is returned — tools must never silently no-op.
     ///
     /// Sabotage: if you comment out the `throw` at the end of the capability
-    /// guard in `GenerationCoordinator.enqueue(structuredMessages:...)`, this
+    /// guard in `GenerationQueue.enqueue(structuredMessages:...)`, this
     /// test fails because `enqueue` returns a stream instead of throwing.
     func test_tools_rejectedOnNonToolCallingBackend() throws {
         let backend = makeNonToolCapableBackend()
@@ -91,7 +91,7 @@ final class CapabilityFlagEnforcementTests: XCTestCase {
         let coordinator = makeCoordinator()
 
         let collector = WarningCollector()
-        GenerationCoordinator.toolsUnsupportedWarningHook = { backendType, message in
+        GenerationQueue.toolsUnsupportedWarningHook = { backendType, message in
             collector.record(backendType: backendType, message: message)
         }
 

--- a/Tests/BaseChatInferenceTests/GenerationQueueApprovalTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationQueueApprovalTests.swift
@@ -3,7 +3,7 @@ import os
 @testable import BaseChatInference
 import BaseChatTestSupport
 
-/// Integration tests for the ``ToolApprovalGate`` + ``GenerationCoordinator``
+/// Integration tests for the ``ToolApprovalGate`` + ``GenerationQueue``
 /// interaction at the full-stream level.
 ///
 /// Distinct from ``ToolApprovalGateTests`` in that these exercise stream
@@ -11,7 +11,7 @@ import BaseChatTestSupport
 /// active request, the coordinator proceeds to the model's next turn, and
 /// the synthesised ``ToolResult`` flows through as a normal event.
 @MainActor
-final class GenerationCoordinatorApprovalTests: XCTestCase {
+final class GenerationQueueApprovalTests: XCTestCase {
 
     // MARK: - Fixtures
 
@@ -80,7 +80,7 @@ final class GenerationCoordinatorApprovalTests: XCTestCase {
             ["I", " cannot", " check", " the", " weather."],
         ]
 
-        let coordinator = GenerationCoordinator(
+        let coordinator = GenerationQueue(
             toolRegistry: registry,
             toolApprovalGate: FixedGate(.denied(reason: "user blocked this tool"))
         )
@@ -107,7 +107,7 @@ final class GenerationCoordinatorApprovalTests: XCTestCase {
         // Model continued past the denial: turn 2's visible tokens must have
         // flowed through the stream, proving it wasn't cancelled.
         // Sabotage-verify: deleting the `self.continuations[...].yield(.toolResult(result))`
-        // emission in GenerationCoordinator.runToolDispatchLoop empties the
+        // emission in GenerationQueue.runToolDispatchLoop empties the
         // `results` array above and this test fails. Verified, reverted.
         let tokens = events.compactMap { event -> String? in
             if case .token(let t) = event { return t } else { return nil }
@@ -131,7 +131,7 @@ final class GenerationCoordinatorApprovalTests: XCTestCase {
         ]
         provider.backend.tokensToYieldPerTurn = [[], ["done"]]
 
-        let coordinator = GenerationCoordinator(
+        let coordinator = GenerationQueue(
             toolRegistry: registry,
             toolApprovalGate: FixedGate(.denied(reason: nil))
         )
@@ -176,7 +176,7 @@ final class GenerationCoordinatorApprovalTests: XCTestCase {
         }
         let gate = CountingGate()
 
-        let coordinator = GenerationCoordinator(
+        let coordinator = GenerationQueue(
             toolRegistry: registry,
             toolApprovalGate: gate
         )

--- a/Tests/BaseChatInferenceTests/GenerationQueueStructuredHistoryTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationQueueStructuredHistoryTests.swift
@@ -2,20 +2,20 @@ import XCTest
 @testable import BaseChatInference
 import BaseChatTestSupport
 
-/// Tests for #482: ``GenerationCoordinator`` must thread
+/// Tests for #482: ``GenerationQueue`` must thread
 /// ``StructuredMessage`` (carrying ``MessagePart`` content including
 /// thinking signatures) through to the backend boundary instead of
 /// flattening to `(role, content)` strings.
 @MainActor
-final class GenerationCoordinatorStructuredHistoryTests: XCTestCase {
+final class GenerationQueueStructuredHistoryTests: XCTestCase {
 
     private var provider: FakeGenerationContextProvider!
-    private var coordinator: GenerationCoordinator!
+    private var coordinator: GenerationQueue!
 
     override func setUp() async throws {
         try await super.setUp()
         provider = FakeGenerationContextProvider()
-        coordinator = GenerationCoordinator()
+        coordinator = GenerationQueue()
         coordinator.provider = provider
     }
 

--- a/Tests/BaseChatInferenceTests/GenerationQueueTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationQueueTests.swift
@@ -3,7 +3,7 @@ import Foundation
 @testable import BaseChatInference
 import BaseChatTestSupport
 
-/// Direct unit tests for the `GenerationCoordinator`.
+/// Direct unit tests for the `GenerationQueue`.
 ///
 /// The coordinator is `internal`, so this file uses `@testable import
 /// BaseChatInference` to construct it directly. A file-local
@@ -17,17 +17,17 @@ import BaseChatTestSupport
 /// reflecting into `@Observable`-rewritten storage breaks silently when the
 /// macro changes its naming scheme.
 @MainActor
-final class GenerationCoordinatorTests: XCTestCase {
+final class GenerationQueueTests: XCTestCase {
 
     // MARK: - Fixture
 
     private var provider: FakeGenerationContextProvider!
-    private var coordinator: GenerationCoordinator!
+    private var coordinator: GenerationQueue!
 
     override func setUp() async throws {
         try await super.setUp()
         provider = FakeGenerationContextProvider()
-        coordinator = GenerationCoordinator()
+        coordinator = GenerationQueue()
         coordinator.provider = provider
     }
 
@@ -45,8 +45,8 @@ final class GenerationCoordinatorTests: XCTestCase {
     /// Makes a coordinator with the given thermal closure.
     private func makeCoordinator(
         thermal: @escaping @Sendable () -> ProcessInfo.ThermalState
-    ) -> GenerationCoordinator {
-        let coord = GenerationCoordinator(thermalStateProvider: thermal)
+    ) -> GenerationQueue {
+        let coord = GenerationQueue(thermalStateProvider: thermal)
         coord.provider = provider
         return coord
     }
@@ -74,15 +74,15 @@ final class GenerationCoordinatorTests: XCTestCase {
     /// traffic also goes to `Log.inference.warning`, which OSLog renders to
     /// Console.app.
     ///
-    /// Sabotage check: deleting the warning branch in `GenerationCoordinator.generate`
+    /// Sabotage check: deleting the warning branch in `GenerationQueue.generate`
     /// leaves `captured` empty and this assertion fails.
     func test_generate_jsonMode_unsupportedBackend_emitsWarning() async throws {
         // MockInferenceBackend defaults to supportsNativeJSONMode == false.
         let captured = WarningCapture()
-        GenerationCoordinator.jsonModeUnsupportedWarningHook = { backendType, message in
+        GenerationQueue.jsonModeUnsupportedWarningHook = { backendType, message in
             captured.record(backendType: backendType, message: message)
         }
-        defer { GenerationCoordinator.jsonModeUnsupportedWarningHook = nil }
+        defer { GenerationQueue.jsonModeUnsupportedWarningHook = nil }
 
         let stream = try coordinator.generate(
             messages: [("user", "Return JSON")],
@@ -111,10 +111,10 @@ final class GenerationCoordinatorTests: XCTestCase {
     /// accidentally flips the condition.
     func test_generate_jsonModeFalse_neverWarns() async throws {
         let captured = WarningCapture()
-        GenerationCoordinator.jsonModeUnsupportedWarningHook = { backendType, message in
+        GenerationQueue.jsonModeUnsupportedWarningHook = { backendType, message in
             captured.record(backendType: backendType, message: message)
         }
-        defer { GenerationCoordinator.jsonModeUnsupportedWarningHook = nil }
+        defer { GenerationQueue.jsonModeUnsupportedWarningHook = nil }
 
         let stream = try coordinator.generate(
             messages: [("user", "Return plain")],
@@ -131,10 +131,10 @@ final class GenerationCoordinatorTests: XCTestCase {
     /// `supportsNativeJSONMode = true`.
     func test_generate_jsonMode_supportedBackend_noWarning() async throws {
         let captured = WarningCapture()
-        GenerationCoordinator.jsonModeUnsupportedWarningHook = { backendType, message in
+        GenerationQueue.jsonModeUnsupportedWarningHook = { backendType, message in
             captured.record(backendType: backendType, message: message)
         }
-        defer { GenerationCoordinator.jsonModeUnsupportedWarningHook = nil }
+        defer { GenerationQueue.jsonModeUnsupportedWarningHook = nil }
 
         provider.backend.capabilities = BackendCapabilities(
             supportedParameters: [.temperature],
@@ -167,15 +167,15 @@ final class GenerationCoordinatorTests: XCTestCase {
     /// then throw `InferenceError.inferenceFailure` so callers have a clear
     /// signal that the registry will never see a dispatch.
     ///
-    /// Sabotage check: deleting the warning branch in `GenerationCoordinator.enqueue`
+    /// Sabotage check: deleting the warning branch in `GenerationQueue.enqueue`
     /// leaves `captured` empty and the warning assertion fails.
     func test_enqueue_toolsOnUnsupportedBackend_emitsWarningAndThrows() async throws {
         // MockInferenceBackend defaults to supportsToolCalling == false.
         let captured = WarningCapture()
-        GenerationCoordinator.toolsUnsupportedWarningHook = { backendType, message in
+        GenerationQueue.toolsUnsupportedWarningHook = { backendType, message in
             captured.record(backendType: backendType, message: message)
         }
-        defer { GenerationCoordinator.toolsUnsupportedWarningHook = nil }
+        defer { GenerationQueue.toolsUnsupportedWarningHook = nil }
 
         let tool = ToolDefinition(
             name: "get_weather",
@@ -214,10 +214,10 @@ final class GenerationCoordinatorTests: XCTestCase {
     /// flips the condition to `tools.isEmpty`.
     func test_enqueue_noTools_neverWarns() async throws {
         let captured = WarningCapture()
-        GenerationCoordinator.toolsUnsupportedWarningHook = { backendType, message in
+        GenerationQueue.toolsUnsupportedWarningHook = { backendType, message in
             captured.record(backendType: backendType, message: message)
         }
-        defer { GenerationCoordinator.toolsUnsupportedWarningHook = nil }
+        defer { GenerationQueue.toolsUnsupportedWarningHook = nil }
 
         let (_, stream) = try coordinator.enqueue(messages: [("user", "hi")])
         for try await _ in stream.events {}
@@ -230,10 +230,10 @@ final class GenerationCoordinatorTests: XCTestCase {
     /// even if the request includes tools.
     func test_enqueue_toolsOnSupportedBackend_noWarning() async throws {
         let captured = WarningCapture()
-        GenerationCoordinator.toolsUnsupportedWarningHook = { backendType, message in
+        GenerationQueue.toolsUnsupportedWarningHook = { backendType, message in
             captured.record(backendType: backendType, message: message)
         }
-        defer { GenerationCoordinator.toolsUnsupportedWarningHook = nil }
+        defer { GenerationQueue.toolsUnsupportedWarningHook = nil }
 
         provider.backend.capabilities = BackendCapabilities(
             supportedParameters: [.temperature],
@@ -290,7 +290,7 @@ final class GenerationCoordinatorTests: XCTestCase {
     /// stream must advance to `.connecting` before either background stream.
     func test_enqueue_userInitiatedBehindBackground_drainsFirst() async throws {
         let slowProvider = SlowFakeProvider()
-        let coord = GenerationCoordinator()
+        let coord = GenerationQueue()
         coord.provider = slowProvider
 
         // Active slot holds one request; queue builds behind it.
@@ -323,7 +323,7 @@ final class GenerationCoordinatorTests: XCTestCase {
 
     func test_cancel_queuedRequest_removesFromQueueAndLeavesActiveRunning() async throws {
         let slowProvider = SlowFakeProvider()
-        let coord = GenerationCoordinator()
+        let coord = GenerationQueue()
         coord.provider = slowProvider
 
         let (_, activeStream) = try coord.enqueue(messages: [("user", "active")], priority: .normal)
@@ -359,7 +359,7 @@ final class GenerationCoordinatorTests: XCTestCase {
     /// the continuation such that further yields are dropped.
     func test_cancel_activeRequest_noTokenAfterCancel() async throws {
         let slowProvider = SlowFakeProvider(tokenCount: 50, delayMilliseconds: 20)
-        let coord = GenerationCoordinator()
+        let coord = GenerationQueue()
         coord.provider = slowProvider
 
         let (token, stream) = try coord.enqueue(messages: [("user", "active")], priority: .normal)
@@ -404,7 +404,7 @@ final class GenerationCoordinatorTests: XCTestCase {
     /// stream to completion, must return without hanging.
     func test_stopGeneration_emptiesQueueAndTerminatesAllStreams() async throws {
         let slowProvider = SlowFakeProvider(tokenCount: 50, delayMilliseconds: 20)
-        let coord = GenerationCoordinator()
+        let coord = GenerationQueue()
         coord.provider = slowProvider
 
         let (_, activeStream) = try coord.enqueue(messages: [("user", "active")], priority: .normal)
@@ -456,7 +456,7 @@ final class GenerationCoordinatorTests: XCTestCase {
     func test_stopGenerationAndWait_returnsPromptly_evenWithLongTokenDelay() async throws {
         let backend = SlowMockBackend(tokenCount: 1, delayMilliseconds: 60_000)
         let slowProvider = SlowFakeProvider(backend: backend)
-        let coord = GenerationCoordinator()
+        let coord = GenerationQueue()
         coord.provider = slowProvider
 
         _ = try coord.enqueue(messages: [("user", "long")], priority: .normal)
@@ -484,7 +484,7 @@ final class GenerationCoordinatorTests: XCTestCase {
 
     func test_discardRequests_keepsMatchingSessionCancelsOthers() async throws {
         let slowProvider = SlowFakeProvider(tokenCount: 50, delayMilliseconds: 20)
-        let coord = GenerationCoordinator()
+        let coord = GenerationQueue()
         coord.provider = slowProvider
 
         let keepSession = UUID()
@@ -566,7 +566,7 @@ final class GenerationCoordinatorTests: XCTestCase {
 
     func test_isGenerating_transitions_onCancel() async throws {
         let slowProvider = SlowFakeProvider(tokenCount: 50, delayMilliseconds: 20)
-        let coord = GenerationCoordinator()
+        let coord = GenerationQueue()
         coord.provider = slowProvider
 
         let (token, stream) = try coord.enqueue(messages: [("user", "hi")], priority: .normal)
@@ -588,7 +588,7 @@ final class GenerationCoordinatorTests: XCTestCase {
     /// generating, no queued requests, and a fresh enqueue succeeds.
     func test_drainQueue_reentryRace_noCrash_stateConsistent() async throws {
         let slowProvider = SlowFakeProvider(tokenCount: 2, delayMilliseconds: 5)
-        let coord = GenerationCoordinator()
+        let coord = GenerationQueue()
         coord.provider = slowProvider
 
         let (token1, s1) = try coord.enqueue(messages: [("user", "a")], priority: .normal)
@@ -623,7 +623,7 @@ final class GenerationCoordinatorTests: XCTestCase {
     /// can't silently change the observable error.
     func test_enqueue_noBackend_throwsNoModelLoaded() {
         let nilProvider = NilBackendProvider()
-        let coord = GenerationCoordinator()
+        let coord = GenerationQueue()
         coord.provider = nilProvider
 
         XCTAssertThrowsError(
@@ -726,7 +726,7 @@ final class GenerationCoordinatorTests: XCTestCase {
 
         let sleepCalls = SleepCallCounter()
 
-        let coord = GenerationCoordinator(
+        let coord = GenerationQueue(
             thermalStateProvider: { @Sendable in
                 let idx = thermalReads.next()
                 return idx < states.count ? states[idx] : .nominal
@@ -810,7 +810,7 @@ final class GenerationCoordinatorTests: XCTestCase {
     func test_perTokenLoop_thermalPause_cancellationUnwindsCleanly() async throws {
         // Provider always reports `.critical` so the pause loop would
         // otherwise spin forever. Cancellation is the only exit.
-        let coord = GenerationCoordinator(
+        let coord = GenerationQueue(
             thermalStateProvider: { @Sendable in .critical },
             thermalSleep: { @Sendable duration in
                 // Forward to the real sleep so the cooperative cancellation
@@ -881,7 +881,7 @@ final class GenerationCoordinatorTests: XCTestCase {
         tcBackend.tokensToYield = ["ok"]
         let tcProvider = TokenCountingFakeProvider(backend: tcBackend)
 
-        let coord = GenerationCoordinator()
+        let coord = GenerationQueue()
         coord.provider = tcProvider
 
         let (_, stream) = try coord.enqueue(
@@ -913,7 +913,7 @@ final class GenerationCoordinatorTests: XCTestCase {
         tcBackend.tokensToYield = ["trimmed"]
         let tcProvider = TokenCountingFakeProvider(backend: tcBackend)
 
-        let coord = GenerationCoordinator()
+        let coord = GenerationQueue()
         coord.provider = tcProvider
 
         // Two messages so we have something to trim.
@@ -947,7 +947,7 @@ final class GenerationCoordinatorTests: XCTestCase {
         tcBackend.countTokensResponses = [80, 80, 80, 80, 80]
         let tcProvider = TokenCountingFakeProvider(backend: tcBackend)
 
-        let coord = GenerationCoordinator()
+        let coord = GenerationQueue()
         coord.provider = tcProvider
 
         // Single user message — cannot trim (would remove the only user turn).
@@ -982,7 +982,7 @@ final class GenerationCoordinatorTests: XCTestCase {
         tcBackend.tokensToYield = ["done"]
         let tcProvider = TokenCountingFakeProvider(backend: tcBackend)
 
-        let coord = GenerationCoordinator()
+        let coord = GenerationQueue()
         coord.provider = tcProvider
 
         let (_, stream) = try coord.enqueue(
@@ -1023,7 +1023,7 @@ final class GenerationCoordinatorTests: XCTestCase {
         tcBackend.tokensToYield = ["ok"]
         let tcProvider = TokenCountingFakeProvider(backend: tcBackend)
 
-        let coord = GenerationCoordinator()
+        let coord = GenerationQueue()
         coord.provider = tcProvider
 
         let stream = try coord.generate(
@@ -1062,7 +1062,7 @@ final class GenerationCoordinatorTests: XCTestCase {
         tcBackend.tokensToYield = ["ok"]
         let tcProvider = TokenCountingFakeProvider(backend: tcBackend)
 
-        let coord = GenerationCoordinator()
+        let coord = GenerationQueue()
         coord.provider = tcProvider
 
         let stream = try coord.generate(
@@ -1085,7 +1085,7 @@ final class GenerationCoordinatorTests: XCTestCase {
     func test_providerTeardown_midStream_noCrash_cleanEnd() async throws {
         let slow = SlowMockBackend(tokenCount: 20, delayMilliseconds: 20)
         var slowProvider: SlowFakeProvider? = SlowFakeProvider(backend: slow)
-        let coord = GenerationCoordinator()
+        let coord = GenerationQueue()
         coord.provider = slowProvider
 
         let (_, stream) = try coord.enqueue(messages: [("user", "x")], priority: .normal)
@@ -1112,7 +1112,7 @@ final class GenerationCoordinatorTests: XCTestCase {
 // MARK: - Warning capture (PR #615 review fix)
 
 /// Thread-safe collector for the `jsonModeUnsupportedWarningHook` on
-/// `GenerationCoordinator`. The hook is `@Sendable` and may fire from any
+/// `GenerationQueue`. The hook is `@Sendable` and may fire from any
 /// isolation; an `NSLock` keeps recorded entries race-free without
 /// introducing actor hops into the test.
 private final class WarningCapture: @unchecked Sendable {
@@ -1235,7 +1235,7 @@ private final class NilBackendProvider: GenerationContextProvider {
 // MARK: - TokenCounting fakes
 
 /// An inference backend that also conforms to `TokenCountingBackend` for testing
-/// the exact pre-flight trim loop in `GenerationCoordinator`.
+/// the exact pre-flight trim loop in `GenerationQueue`.
 ///
 /// `countTokensResponses` controls what `countTokens` returns on each successive
 /// call (FIFO). Once exhausted the last value is repeated.

--- a/Tests/BaseChatInferenceTests/GenerationQueueToolLoopTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationQueueToolLoopTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import BaseChatInference
 import BaseChatTestSupport
 
-/// Unit tests for the tool-dispatch loop inside `GenerationCoordinator`.
+/// Unit tests for the tool-dispatch loop inside `GenerationQueue`.
 ///
 /// Coverage:
 /// - end-to-end dispatch: model emits a tool call, registry dispatches,
@@ -15,7 +15,7 @@ import BaseChatTestSupport
 /// - byte-budget guard: a tool that returns huge content terminates the loop
 ///   with a synthesised `.permanent` result
 @MainActor
-final class GenerationCoordinatorToolLoopTests: XCTestCase {
+final class GenerationQueueToolLoopTests: XCTestCase {
 
     // MARK: - Fixtures
 
@@ -65,8 +65,8 @@ final class GenerationCoordinatorToolLoopTests: XCTestCase {
     // MARK: - Helpers
 
     /// Build a coordinator with the supplied registry already wired.
-    private func makeCoordinator(registry: ToolRegistry) -> GenerationCoordinator {
-        let coordinator = GenerationCoordinator(toolRegistry: registry)
+    private func makeCoordinator(registry: ToolRegistry) -> GenerationQueue {
+        let coordinator = GenerationQueue(toolRegistry: registry)
         coordinator.provider = provider
         return coordinator
     }
@@ -211,7 +211,7 @@ final class GenerationCoordinatorToolLoopTests: XCTestCase {
         let registry = ToolRegistry()
         registry.register(executor)
 
-        let coordinator = GenerationCoordinator(toolRegistry: registry)
+        let coordinator = GenerationQueue(toolRegistry: registry)
         coordinator.provider = toolAwareProvider
 
         let (_, stream) = try coordinator.enqueue(
@@ -355,7 +355,7 @@ final class GenerationCoordinatorToolLoopTests: XCTestCase {
 /// Extension that exposes a raw-config enqueue path for tests that need to
 /// set every field on `GenerationConfig` (notably `maxToolIterations`).
 @MainActor
-extension GenerationCoordinator {
+extension GenerationQueue {
     func enqueueCustomConfig(
         messages: [(role: String, content: String)],
         config: GenerationConfig,

--- a/Tests/BaseChatInferenceTests/InferenceServiceNonisolatedTests.swift
+++ b/Tests/BaseChatInferenceTests/InferenceServiceNonisolatedTests.swift
@@ -169,7 +169,7 @@ final class InferenceServiceNonisolatedTests: XCTestCase {
     ///
     /// The `#if DEBUG` `init(backend:)` debug helper does not survive
     /// the off-main reference round-trip cleanly here — `weak var provider`
-    /// inside `GenerationCoordinator` ends up nil by the time enqueue runs
+    /// inside `GenerationQueue` ends up nil by the time enqueue runs
     /// from a non-MainActor context. The supported off-main composition
     /// path is to construct via the nonisolated `init()` and load through
     /// the registered factory, which is exactly what runtime use cases

--- a/Tests/BaseChatInferenceTests/ParallelToolCallOrderingTests.swift
+++ b/Tests/BaseChatInferenceTests/ParallelToolCallOrderingTests.swift
@@ -14,7 +14,7 @@ import BaseChatTestSupport
 /// directly (`MockInferenceBackend.generate(...)`) so any future
 /// reordering or buffering introduced *inside the backend* is caught
 /// without coordinator-side noise. Test 4 routes through
-/// `GenerationCoordinator` to lock in the higher-level callId↔result
+/// `GenerationQueue` to lock in the higher-level callId↔result
 /// association contract. The two layers exercise different invariants
 /// and intentionally use different harnesses.
 ///
@@ -185,10 +185,10 @@ final class ParallelToolCallOrderingTests: XCTestCase {
         registry.register(weatherExecutor)
         registry.register(timeExecutor)
 
-        // FakeGenerationContextProvider (defined in GenerationCoordinatorTests.swift)
+        // FakeGenerationContextProvider (defined in GenerationQueueTests.swift)
         // is package-internal — wire the coordinator directly instead.
         let provider = DirectProvider(backend: backend)
-        let coordinator = GenerationCoordinator(toolRegistry: registry)
+        let coordinator = GenerationQueue(toolRegistry: registry)
         coordinator.provider = provider
 
         let (_, stream) = try coordinator.enqueue(
@@ -235,7 +235,7 @@ private struct SimpleExecutor: ToolExecutor {
 
 /// Minimal `GenerationContextProvider` that wraps an already-loaded
 /// `MockInferenceBackend`. Avoids the package-internal
-/// `FakeGenerationContextProvider` defined in `GenerationCoordinatorTests`.
+/// `FakeGenerationContextProvider` defined in `GenerationQueueTests`.
 @MainActor
 private final class DirectProvider: GenerationContextProvider {
     private let _backend: MockInferenceBackend

--- a/Tests/BaseChatInferenceTests/ToolApprovalGateTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolApprovalGateTests.swift
@@ -4,12 +4,12 @@ import os
 import BaseChatTestSupport
 
 /// Unit tests for ``ToolApprovalGate`` and its interaction with
-/// ``GenerationCoordinator`` at the single-call level.
+/// ``GenerationQueue`` at the single-call level.
 ///
 /// These tests exercise just the gate-to-dispatch chokepoint: one tool call
 /// per test, so approve/deny paths can be isolated from the broader
 /// tool-dispatch loop assertions (iteration caps, repeat short-circuit,
-/// byte budgets) covered in ``GenerationCoordinatorToolLoopTests``.
+/// byte budgets) covered in ``GenerationQueueToolLoopTests``.
 @MainActor
 final class ToolApprovalGateTests: XCTestCase {
 
@@ -90,7 +90,7 @@ final class ToolApprovalGateTests: XCTestCase {
     /// The executor emits `c-1` on turn 1, nothing on turn 2 (loop exits).
     private func makeSingleCallSetup(
         gate: any ToolApprovalGate
-    ) -> (coordinator: GenerationCoordinator, executor: CountingExecutor) {
+    ) -> (coordinator: GenerationQueue, executor: CountingExecutor) {
         let executor = CountingExecutor(name: "get_weather")
         let registry = ToolRegistry()
         registry.register(executor)
@@ -101,7 +101,7 @@ final class ToolApprovalGateTests: XCTestCase {
         ]
         provider.backend.tokensToYieldPerTurn = [[], ["ok"]]
 
-        let coordinator = GenerationCoordinator(
+        let coordinator = GenerationQueue(
             toolRegistry: registry,
             toolApprovalGate: gate
         )
@@ -138,7 +138,7 @@ final class ToolApprovalGateTests: XCTestCase {
         _ = try await collectEvents(stream)
 
         // Sabotage-verify: flipping the `.denied` branch in
-        // GenerationCoordinator to fall through to
+        // GenerationQueue to fall through to
         // `result = await toolRegistry!.dispatch(call)` makes callCount == 1
         // and this assertion fails. Verified locally, reverted before commit.
         XCTAssertEqual(executor.callCount, 0, "denied path must NOT reach the registry")
@@ -219,7 +219,7 @@ final class ToolApprovalGateTests: XCTestCase {
         ]
         provider.backend.tokensToYieldPerTurn = [[], ["done"]]
 
-        let coordinator = GenerationCoordinator(toolRegistry: registry)
+        let coordinator = GenerationQueue(toolRegistry: registry)
         coordinator.provider = provider
 
         let (_, stream) = try coordinator.enqueue(

--- a/Tests/BaseChatInferenceTests/ToolCallStreamingContractTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolCallStreamingContractTests.swift
@@ -7,7 +7,7 @@ import BaseChatTestSupport
 /// These tests drive a ``MockInferenceBackend`` with scripted event sequences
 /// and assert ordering, content, and edge-case behaviour — all without hitting
 /// real network or hardware. They complement the existing ``ToolCallContractTests``
-/// (Codable round-trips, non-streaming emission) and ``GenerationCoordinatorToolLoopTests``
+/// (Codable round-trips, non-streaming emission) and ``GenerationQueueToolLoopTests``
 /// (orchestrator dispatch loop). Coverage here focuses exclusively on the
 /// streaming-event contract: ordering of start/delta/call, non-streaming
 /// back-compat, cancellation, and interleaved multi-call sequencing.
@@ -368,7 +368,7 @@ final class ToolCallStreamingContractTests: XCTestCase {
         backend.toolDeltaEmissionGate = gate
 
         let provider = FakeGenerationContextProvider(backend: backend)
-        let coordinator = GenerationCoordinator()
+        let coordinator = GenerationQueue()
         coordinator.provider = provider
 
         let (_, stream) = try coordinator.enqueue(
@@ -426,7 +426,7 @@ final class ToolCallStreamingContractTests: XCTestCase {
         }
 
         // Sabotage: removing the `guard !Task.isCancelled` check in
-        // GenerationCoordinator's dispatch loop would let the stream continue
+        // GenerationQueue's dispatch loop would let the stream continue
         // to the .call event — toolCalls would be non-empty.
         XCTAssertTrue(toolCalls.isEmpty,
             "no .toolCall must reach the consumer after stream cancellation pre-call; got \(toolCalls)")

--- a/Tests/BaseChatInferenceTests/ToolCancellationContractTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolCancellationContractTests.swift
@@ -7,7 +7,7 @@ import BaseChatTestSupport
 ///
 /// Coverage:
 /// - Orchestrator-driven cancellation: scripted backend emits a tool call,
-///   executor awaits forever, ``GenerationCoordinator.stopGeneration()``
+///   executor awaits forever, ``GenerationQueue.stopGeneration()``
 ///   propagates cancellation into the executor, the transcript records a
 ///   ``ToolResult/ErrorKind/cancelled`` result, and no further backend turn
 ///   runs.
@@ -109,7 +109,7 @@ final class ToolCancellationContractTests: XCTestCase {
             ["second", "-turn", "-must-not-run"]
         ]
 
-        let coordinator = GenerationCoordinator(toolRegistry: registry)
+        let coordinator = GenerationQueue(toolRegistry: registry)
         coordinator.provider = provider
 
         let (_, stream) = try coordinator.enqueue(

--- a/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
+++ b/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
@@ -25,8 +25,8 @@
 # False positive: `ToolRegistry?` as an optional type annotation contains
 # the substring `try?` inside `Regis-try?`. No `try?` call site is present
 # on either line; the audit's substring scan is not AST-aware.
-BaseChatInference/Services/GenerationCoordinator.swift:let toolRegistry: ToolRegistry?
-BaseChatInference/Services/GenerationCoordinator.swift:toolRegistry: ToolRegistry? = nil,
+BaseChatInference/Services/GenerationQueue.swift:let toolRegistry: ToolRegistry?
+BaseChatInference/Services/GenerationQueue.swift:toolRegistry: ToolRegistry? = nil,
 BaseChatInference/Services/InferenceService.swift:public var toolRegistry: ToolRegistry? {
 BaseChatInference/Services/InferenceService.swift:toolRegistry: ToolRegistry? = nil,
 


### PR DESCRIPTION
Closes #967.

## Summary

Mechanical rename only — no behavior changes, no API reshaping. File rename + 138-reference grep sweep across `Sources/` and `Tests/`.

The class was `internal` (not `public` or `package`), so this is **not** a breaking change for SDK consumers.

## Why `GenerationQueue` (over `InferencePipeline`)

`GenerationQueue` is the issue's preferred name and emphasises the type's headline behavior: it owns the FIFO + priority queue of generation requests, in-flight request tracking, the per-token thermal-pause loop, and the tool-call dispatch transport that `ConversationRuntime` runs on top of. It is not a parallel turn loop — `ConversationRuntime` is the canonical orchestrator (per CLAUDE.md "Turn-loop orchestration"). The new doc comment frames it that way.

## What changed

- `Sources/BaseChatInference/Services/GenerationCoordinator.swift` → `GenerationQueue.swift` (`git mv`).
- `final class GenerationCoordinator` → `final class GenerationQueue`; doc comment rewritten to describe it as the queue + tool-dispatch transport that `ConversationRuntime` runs on top of (not a turn loop).
- 4 test files renamed alongside their classes:
  - `GenerationCoordinatorTests.swift` → `GenerationQueueTests.swift`
  - `GenerationCoordinatorApprovalTests.swift` → `GenerationQueueApprovalTests.swift`
  - `GenerationCoordinatorStructuredHistoryTests.swift` → `GenerationQueueStructuredHistoryTests.swift`
  - `GenerationCoordinatorToolLoopTests.swift` → `GenerationQueueToolLoopTests.swift`
- Type references, doc-comment DocC links (` ``GenerationCoordinator`` ` → ` ``GenerationQueue`` `), `// MARK:` headers, and log-message string literals (`"GenerationCoordinator: …"` → `"GenerationQueue: …"`) all updated.
- Doc comments inside `GenerationQueue.swift` that conceptually said "the coordinator" updated to "the queue" so the renamed file reads consistently. The DocC headline in `GenerationEvent.swift` ("Coordinator-emitted lifecycle events") also became "Queue-emitted lifecycle events" because it directly cross-references the type.

## What I deliberately left

Doc comments in *other* files that say "the generation coordinator" or "the orchestrator" in conceptual prose (e.g. `InferenceService.swift`, `ToolApprovalGate.swift`, `ToolRegistry.swift`, backend files) were left as-is. Those passages describe the runtime *role* the type plays during tool dispatch and approval gating — calling that "the queue" alone would be misleading because in those moments the type is acting as a dispatcher. The type-name references and DocC links in those files were updated; only the surrounding prose nouns stayed.

CLAUDE.md was checked (`grep GenerationCoordinator CLAUDE.md` → 0 matches) — no doc updates needed there.

## Verification

- `grep -rn "GenerationCoordinator" Sources/ Tests/ CLAUDE.md` → 0 matches.
- `swift build --build-tests --disable-default-traits` → builds clean.
- `scripts/test.sh --filter BaseChatInferenceTests --filter BaseChatRuntimeTests --filter BaseChatBackendsTests --disable-default-traits --skip-update` → 1468 passed, 0 failed, 6 skipped.

Spike gate (per CLAUDE.md) — full pre-push gate skipped because the diff is a pure mechanical rename scoped to one type.