### PR TITLE
feat(security): SHA-256 verification for downloaded weights (Phase 1 of #367)

### DIFF
--- a/Example/BaseChatDemo/BaseChatDemoApp.swift
+++ b/Example/BaseChatDemo/BaseChatDemoApp.swift
@@ -155,7 +155,11 @@ struct BaseChatDemoApp: App {
             recommendedFor: [.small, .medium, .large, .xlarge],
             contextSize: 2048,
             promptTemplate: .chatML,
-            description: "Tiny but capable chat model, great for testing"
+            description: "Tiny but capable chat model, great for testing",
+            // SHA-256 from HuggingFace LFS pointer (x-linked-etag) on 2026-05-02.
+            // If the upstream file is republished, this hash will need to be
+            // refreshed (the download will fail-closed against the old digest).
+            expectedSHA256: "48ab3034d0dd401fbc721eb1df3217902fee7dab9078992d66431f09b7750201"
         ),
         CuratedModel(
             id: "phi-4-mini-mlx",
@@ -180,7 +184,9 @@ struct BaseChatDemoApp: App {
             recommendedFor: [.medium, .large, .xlarge],
             contextSize: 4096,
             promptTemplate: .mistral,
-            description: "Excellent general-purpose chat model"
+            description: "Excellent general-purpose chat model",
+            // SHA-256 from HuggingFace LFS pointer (x-linked-etag) on 2026-05-02.
+            expectedSHA256: "1270d22c0fbb3d092fb725d4d96c457b7b687a5f5a715abe1e818da303e562b6"
         ),
         CuratedModel(
             id: "llama-3.2-3b-mlx",

--- a/Sources/BaseChatHuggingFace/BackgroundDownloadManager.swift
+++ b/Sources/BaseChatHuggingFace/BackgroundDownloadManager.swift
@@ -262,7 +262,14 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
     /// - Throws: `HuggingFaceError.insufficientDiskSpace` if there isn't enough room.
     @MainActor @discardableResult
     public func startDownload(_ model: DownloadableModel, downloadURL: URL) async throws -> DownloadState {
-        try await startDownload(model, plan: .singleFile(url: downloadURL, expectedChecksum: nil))
+        // Promote `DownloadableModel.expectedSHA256` into the plan so the
+        // post-download validator can enforce the digest. Callers that have
+        // already resolved a richer `ModelDownloadPlan` (e.g. snapshot files
+        // with per-file checksums) should use the plan-based overload instead.
+        let checksum = model.expectedSHA256.map {
+            ModelFileChecksum(algorithm: .sha256, hexDigest: $0)
+        }
+        return try await startDownload(model, plan: .singleFile(url: downloadURL, expectedChecksum: checksum))
     }
 
     /// Starts a background download using a resolved download plan.

--- a/Sources/BaseChatHuggingFace/HuggingFaceService.swift
+++ b/Sources/BaseChatHuggingFace/HuggingFaceService.swift
@@ -95,7 +95,13 @@ public final class HuggingFaceService: HuggingFaceServiceProtocol {
     public func downloadPlan(for model: DownloadableModel) async throws -> ModelDownloadPlan {
         switch model.modelType {
         case .gguf:
-            return .singleFile(url: downloadURL(for: model))
+            // Forward `expectedSHA256` (when set) so the validator can enforce
+            // the digest after download. For MLX snapshots, per-file checksums
+            // are out of scope for Phase 1 — those entries stay unverified.
+            let checksum = model.expectedSHA256.map {
+                ModelFileChecksum(algorithm: .sha256, hexDigest: $0)
+            }
+            return .singleFile(url: downloadURL(for: model), expectedChecksum: checksum)
         case .mlx:
             guard let repoIdentifier = Repo.ID(rawValue: model.repoID) else {
                 throw HuggingFaceError.invalidRepoID(model.repoID)

--- a/Sources/BaseChatInference/Models/CuratedModel.swift
+++ b/Sources/BaseChatInference/Models/CuratedModel.swift
@@ -29,6 +29,14 @@ public struct CuratedModel: Identifiable, Sendable {
     /// via ``MultimodalProjectorConfigurable``.
     public let mmprojFileName: String?
 
+    /// Expected SHA-256 digest (lowercase hex, 64 chars) for ``fileName``.
+    ///
+    /// Forwarded to ``DownloadableModel/expectedSHA256`` when the curated entry
+    /// is materialised for the download UI. Populate from the file's HuggingFace
+    /// LFS pointer (`oid sha256:<hex>`); leave `nil` to mark the entry as
+    /// unverified.
+    public let expectedSHA256: String?
+
     public init(
         id: String,
         displayName: String,
@@ -40,7 +48,8 @@ public struct CuratedModel: Identifiable, Sendable {
         contextSize: Int32,
         promptTemplate: PromptTemplate,
         description: String,
-        mmprojFileName: String? = nil
+        mmprojFileName: String? = nil,
+        expectedSHA256: String? = nil
     ) {
         self.id = id
         self.displayName = displayName
@@ -53,6 +62,7 @@ public struct CuratedModel: Identifiable, Sendable {
         self.promptTemplate = promptTemplate
         self.description = description
         self.mmprojFileName = mmprojFileName
+        self.expectedSHA256 = expectedSHA256
     }
 
     /// The curated model list to display in model discovery UI.

--- a/Sources/BaseChatInference/Models/DownloadableModel.swift
+++ b/Sources/BaseChatInference/Models/DownloadableModel.swift
@@ -33,6 +33,20 @@ public struct DownloadableModel: Identifiable, Sendable, Hashable {
     /// alongside ``fileName``. Mirrors ``CuratedModel/mmprojFileName`` for curated entries.
     public let mmprojFileName: String?
 
+    /// Expected SHA-256 digest (lowercase hex, 64 chars) for the downloaded file.
+    ///
+    /// When set, ``DownloadFileValidator`` computes the SHA-256 of the
+    /// downloaded artifact and rejects the download if the digest does not
+    /// match — the partial file is deleted and the download is marked failed.
+    /// When `nil`, the SHA check is skipped; the validator's other checks
+    /// (GGUF magic bytes, minimum file size, MLX directory layout) still run.
+    ///
+    /// Curated catalogue entries should populate this from the
+    /// HuggingFace LFS pointer's `oid sha256:<hex>` value. User-supplied URLs
+    /// (e.g. paste-a-URL flows) typically pass `nil` and are surfaced in the
+    /// UI as unverified.
+    public let expectedSHA256: String?
+
     /// Human-readable size (e.g., "4.1 GB").
     public var sizeFormatted: String {
         ByteCountFormatter.string(fromByteCount: Int64(sizeBytes), countStyle: .file)
@@ -69,6 +83,7 @@ public struct DownloadableModel: Identifiable, Sendable, Hashable {
         self.promptTemplate = curated.promptTemplate
         self.description = curated.description
         self.mmprojFileName = curated.mmprojFileName
+        self.expectedSHA256 = curated.expectedSHA256
     }
 
     // MARK: - Memberwise
@@ -83,7 +98,8 @@ public struct DownloadableModel: Identifiable, Sendable, Hashable {
         isCurated: Bool = false,
         promptTemplate: PromptTemplate? = nil,
         description: String? = nil,
-        mmprojFileName: String? = nil
+        mmprojFileName: String? = nil,
+        expectedSHA256: String? = nil
     ) {
         self.id = "\(repoID)/\(fileName)"
         self.repoID = repoID
@@ -96,6 +112,7 @@ public struct DownloadableModel: Identifiable, Sendable, Hashable {
         self.promptTemplate = promptTemplate
         self.description = description
         self.mmprojFileName = mmprojFileName
+        self.expectedSHA256 = expectedSHA256
     }
 }
 

--- a/Sources/BaseChatUIModelManagement/Views/Models/DownloadableModelRow.swift
+++ b/Sources/BaseChatUIModelManagement/Views/Models/DownloadableModelRow.swift
@@ -86,6 +86,18 @@ public struct DownloadableModelRow: View {
                         .padding(.top, 1)
                         .accessibilityLabel("Backend unavailable: \(reason)")
                 }
+
+                // Phase 1 of #367: surface verified vs. unverified downloads.
+                // When the curated entry ships an `expectedSHA256`, the validator
+                // enforces it after download; when it is `nil` (search results,
+                // user-pasted URLs, MLX snapshots without per-file digests), the
+                // download proceeds without integrity verification.
+                if model.expectedSHA256 == nil {
+                    Text("Unverified source")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .accessibilityLabel("Unverified source — no SHA-256 hash available")
+                }
             }
 
             Spacer()

--- a/Tests/BaseChatHuggingFaceTests/DownloadFileValidatorTests.swift
+++ b/Tests/BaseChatHuggingFaceTests/DownloadFileValidatorTests.swift
@@ -101,5 +101,90 @@ final class DownloadFileValidatorTests: XCTestCase {
 
         XCTAssertThrowsError(try DownloadFileValidator().validate(at: url, modelType: .mlx))
     }
+
+    // MARK: - DownloadableModel.expectedSHA256 Plumbing
+    //
+    // Phase 1 of #367: the public `DownloadableModel.expectedSHA256` field must
+    // flow through `HuggingFaceService.downloadPlan(for:)` into the validator
+    // path. These tests pin the wiring so a future refactor cannot silently
+    // drop the digest on the floor.
+
+    func testDownloadPlan_GGUF_propagatesExpectedSHA256() async throws {
+        let model = DownloadableModel(
+            repoID: "TestOrg/Test-GGUF",
+            fileName: "model.Q4_K_M.gguf",
+            displayName: "Test",
+            modelType: .gguf,
+            sizeBytes: 1_000_000,
+            expectedSHA256: "1270d22c0fbb3d092fb725d4d96c457b7b687a5f5a715abe1e818da303e562b6"
+        )
+
+        let plan = try await HuggingFaceService().downloadPlan(for: model)
+        guard case .singleFile(_, let checksum) = plan else {
+            return XCTFail("Expected .singleFile plan for GGUF model, got: \(plan)")
+        }
+        XCTAssertEqual(checksum?.algorithm, .sha256)
+        XCTAssertEqual(
+            checksum?.hexDigest,
+            "1270d22c0fbb3d092fb725d4d96c457b7b687a5f5a715abe1e818da303e562b6"
+        )
+    }
+
+    func testDownloadPlan_GGUF_nilExpectedSHA256_yieldsUnverifiedPlan() async throws {
+        let model = DownloadableModel(
+            repoID: "TestOrg/Test-GGUF",
+            fileName: "model.Q4_K_M.gguf",
+            displayName: "Test",
+            modelType: .gguf,
+            sizeBytes: 1_000_000,
+            expectedSHA256: nil
+        )
+
+        let plan = try await HuggingFaceService().downloadPlan(for: model)
+        guard case .singleFile(_, let checksum) = plan else {
+            return XCTFail("Expected .singleFile plan for GGUF model, got: \(plan)")
+        }
+        XCTAssertNil(checksum, "Unverified models must not synthesise a checksum")
+    }
+
+    func testDownloadableModel_fromCurated_inheritsExpectedSHA256() {
+        let curated = CuratedModel(
+            id: "test-curated",
+            displayName: "Test Curated",
+            fileName: "test.gguf",
+            repoID: "TestOrg/Test-GGUF",
+            modelType: .gguf,
+            approximateSizeBytes: 1_000_000,
+            recommendedFor: [.small],
+            contextSize: 2048,
+            promptTemplate: .chatML,
+            description: "Fixture",
+            expectedSHA256: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+        )
+
+        let downloadable = DownloadableModel(from: curated)
+        XCTAssertEqual(
+            downloadable.expectedSHA256,
+            "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+        )
+    }
+
+    func testDownloadableModel_fromCurated_nilSHA_passesThrough() {
+        let curated = CuratedModel(
+            id: "test-unverified",
+            displayName: "Test Unverified",
+            fileName: "test.gguf",
+            repoID: "TestOrg/Test-GGUF",
+            modelType: .gguf,
+            approximateSizeBytes: 1_000_000,
+            recommendedFor: [.small],
+            contextSize: 2048,
+            promptTemplate: .chatML,
+            description: "Fixture"
+        )
+
+        let downloadable = DownloadableModel(from: curated)
+        XCTAssertNil(downloadable.expectedSHA256)
+    }
 }
 #endif


### PR DESCRIPTION
## Summary

Closes Phase 1 of #367. Phases 2 (signed manifests) and 3 (strict mode) remain open on the same issue.

This PR makes downloaded model weights verifiable end-to-end against an opt-in SHA-256 digest. The plumbing for `ModelFileChecksum` already existed inside the `BaseChatHuggingFace` module — what was missing was the public surface on `DownloadableModel` (and its `CuratedModel` factory) and the wiring from there into `HuggingFaceService.downloadPlan(for:)` and `BackgroundDownloadManager.startDownload(_:downloadURL:)`. With those connected, the existing `DownloadFileValidator.validateChecksum(...)` path enforces the digest after the file finishes downloading; on mismatch the temp file is deleted and the download is marked failed.

The change is **additive and non-breaking**: `expectedSHA256` defaults to `nil` on every initialiser, every existing call site continues to compile unchanged, and a `nil` digest preserves today's validator behaviour (GGUF magic bytes + minimum size, MLX directory layout). It also addresses a downstream consumer's resume-gate requirement for download integrity.

```swift
// Curated entry — verified against the file's HF LFS pointer hash.
CuratedModel(
    id: "smollm2-360m",
    fileName: "smollm2-360m-instruct-q8_0.gguf",
    repoID: "HuggingFaceTB/SmolLM2-360M-Instruct-GGUF",
    // ...other fields...
    expectedSHA256: "48ab3034d0dd401fbc721eb1df3217902fee7dab9078992d66431f09b7750201"
)

// Search results / paste-a-URL flow — pass nil; UI labels the row "Unverified source".
DownloadableModel(
    repoID: "user/repo", fileName: "weights.gguf", displayName: "Weights",
    modelType: .gguf, sizeBytes: 4_000_000_000
    // expectedSHA256 omitted → nil
)
```

### Curated entries populated

Both populated entries use **real** SHA-256 digests fetched from each file's HuggingFace LFS pointer (`x-linked-etag` on `resolve/main`) on 2026-05-02:

| Entry | File | SHA-256 status |
|-------|------|----------------|
| `smollm2-360m` | `smollm2-360m-instruct-q8_0.gguf` | real, fetched from HF LFS pointer |
| `mistral-7b-gguf` | `Mistral-7B-Instruct-v0.3-Q4_K_M.gguf` | real, fetched from HF LFS pointer |
| `phi-4-mini-mlx` | snapshot directory | `nil` — MLX snapshots out of scope for Phase 1 |
| `llama-3.2-3b-mlx` | snapshot directory | `nil` — MLX snapshots out of scope for Phase 1 |
| `qwen-2.5-7b-mlx` | snapshot directory | `nil` — MLX snapshots out of scope for Phase 1 |

No placeholder hashes are checked in. If either upstream GGUF is republished, the validator will fail-closed against the old digest until the catalogue is refreshed — that is the intended behaviour.

### Streaming-hash note

The issue body asks for SHA-256 to be computed "as the file streams to disk". The existing `DownloadFileValidator.sha256HexDigest(of:)` already hashes the file in 64 KB chunks via incremental `SHA256.update(data:)`, but it does so **after** `URLSession`'s download task delivers the temp file (which is the only point at which the file is observable from `urlSession(_:downloadTask:didFinishDownloadingTo:)`). True in-flight hashing would require switching from `URLSessionDownloadTask` to a streaming data task — a deeper refactor outside Phase 1's scope. The post-download chunked hash gives the same security property (we still refuse to commit the file to the models directory if the digest doesn't match) without that refactor.

### UI

`DownloadableModelRow` now shows an "Unverified source" caption when `expectedSHA256 == nil`. No icons, no settings toggle, no row redesign — just a single conditional `Text` line so the user can see at a glance which curated entries are checksum-verified vs. which are taken on trust (search results, pasted URLs, MLX snapshots).

### Testing

The validator's three core cases (matching SHA passes, mismatching SHA throws, `nil` digest skips) were already covered in `DownloadManagerTests.test_validateChecksum_*`. This PR adds:

- `testDownloadPlan_GGUF_propagatesExpectedSHA256` — the field on `DownloadableModel` actually arrives in `ModelDownloadPlan.singleFile`'s `expectedChecksum` slot.
- `testDownloadPlan_GGUF_nilExpectedSHA256_yieldsUnverifiedPlan` — `nil` doesn't synthesise a bogus checksum.
- `testDownloadableModel_fromCurated_inheritsExpectedSHA256` / `testDownloadableModel_fromCurated_nilSHA_passesThrough` — the `CuratedModel` factory propagates the digest.

Sabotage-verified: temporarily forcing the `HuggingFaceService` to drop the checksum makes the propagation test fail; restoring the line passes 1434 tests + 5 environment-skipped on the spike gate.

## Test plan

- [x] `swift build --build-tests --disable-default-traits`
- [x] `scripts/test.sh --filter BaseChatHuggingFaceTests --filter BaseChatInferenceTests --filter BaseChatUIModelManagementTests --disable-default-traits --traits HuggingFace --skip-update` — 1434 passed, 5 skipped
- [x] Sabotage check on `testDownloadPlan_GGUF_propagatesExpectedSHA256`
- [x] `xcodebuild` build of the demo app succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)