### PR TITLE
feat(inference): ModelInfo factory for HuggingFace-sourced models

### DIFF
--- a/Sources/BaseChatInference/Models/ModelInfo.swift
+++ b/Sources/BaseChatInference/Models/ModelInfo.swift
@@ -11,6 +11,12 @@ public enum ModelType: Hashable, Sendable {
 }
 
 /// Represents a model available on disk (either a GGUF file or an MLX model directory).
+///
+/// Construct via one of the factory initializers:
+/// - ``init(ggufURL:)`` for local `.gguf` files (reads size from disk).
+/// - ``init(mlxDirectory:namespace:)`` for MLX model directories.
+/// - ``init(huggingFaceRepoID:fileName:sizeBytes:localURL:modelType:)`` for completed
+///   HuggingFace downloads (trusts caller-supplied size, skips disk attribute lookup).
 public struct ModelInfo: Identifiable, Hashable, Sendable {
     public let id: UUID
     public let name: String
@@ -51,6 +57,15 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
 
     /// The most recent benchmark result for this model, if one has been run.
     public var benchmarkResult: ModelBenchmarkResult?
+
+    // MARK: - Provenance
+
+    /// The HuggingFace repository this model was downloaded from, when known
+    /// (e.g. `"bartowski/Llama-3.2-3B-Instruct-GGUF"`).
+    ///
+    /// Populated by ``init(huggingFaceRepoID:fileName:sizeBytes:localURL:modelType:)``.
+    /// `nil` for locally-discovered files and built-in models.
+    public var huggingFaceRepoID: String?
 
     /// Returns the benchmark-confirmed tier when one is available, otherwise falls back
     /// to the stored ``capabilityTier``, and finally to a static file-size estimate.
@@ -221,7 +236,8 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
         chatTemplateRaw: String? = nil,
         estimatedKVBytesPerToken: UInt64? = nil,
         capabilityTier: ModelCapabilityTier? = nil,
-        benchmarkResult: ModelBenchmarkResult? = nil
+        benchmarkResult: ModelBenchmarkResult? = nil,
+        huggingFaceRepoID: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -237,6 +253,7 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
         self.estimatedKVBytesPerToken = estimatedKVBytesPerToken
         self.capabilityTier = capabilityTier
         self.benchmarkResult = benchmarkResult
+        self.huggingFaceRepoID = huggingFaceRepoID
     }
 
     // MARK: - Private
@@ -265,5 +282,60 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
         name = name.replacingOccurrences(of: "-", with: " ")
         name = name.replacingOccurrences(of: "_", with: " ")
         return name
+    }
+}
+
+// MARK: - HuggingFace Factory
+
+extension ModelInfo {
+    /// Creates a ModelInfo from a completed HuggingFace download.
+    ///
+    /// Unlike ``init(ggufURL:)``, this factory trusts caller-supplied size metadata
+    /// (typically derived from the HuggingFace manifest) and skips the on-disk
+    /// `attributesOfItem` lookup. The GGUF header is still read for prompt-template
+    /// detection, context length, and KV-cache estimation.
+    ///
+    /// Returns `nil` if `localURL` does not have a `.gguf` extension or fails the
+    /// GGUF magic-byte check.
+    ///
+    /// - Parameters:
+    ///   - huggingFaceRepoID: The source repo (e.g. `"bartowski/Llama-3.2-3B-Instruct-GGUF"`).
+    ///   - fileName: The file name as known to the download flow. Used directly,
+    ///     not derived from `localURL`, because HuggingFace flows pre-compute it.
+    ///   - sizeBytes: Trusted size from the HuggingFace manifest.
+    ///   - localURL: On-disk location of the downloaded `.gguf` file.
+    ///   - modelType: Defaults to `.gguf` — currently the only supported HuggingFace
+    ///     download path through this factory.
+    public init?(
+        huggingFaceRepoID: String,
+        fileName: String,
+        sizeBytes: UInt64,
+        localURL: URL,
+        modelType: ModelType = .gguf
+    ) {
+        guard localURL.pathExtension.lowercased() == "gguf" else { return nil }
+        guard GGUFMetadataReader.isValidGGUF(at: localURL) else { return nil }
+
+        self.id = Self.stableID(for: localURL)
+        self.fileName = fileName
+        self.name = Self.displayName(from: fileName, strippingExtension: ".gguf")
+        self.url = localURL
+        self.fileSize = sizeBytes
+        self.modelType = modelType
+        self.huggingFaceRepoID = huggingFaceRepoID
+        self.benchmarkResult = nil
+
+        // Read GGUF header metadata for template detection. mmproj companion scan
+        // is skipped — HuggingFace downloads flow file-by-file, not directory-wide.
+        if let metadata = try? GGUFMetadataReader.readMetadata(from: localURL) {
+            self.detectedPromptTemplate = PromptTemplateDetector.detect(from: metadata)
+            self.detectedContextLength = metadata.contextLength
+            self.modelArchitecture = metadata.generalArchitecture
+            self.chatTemplateRaw = metadata.chatTemplate
+            self.estimatedKVBytesPerToken = GGUFKVCacheEstimator.estimateBytesPerToken(from: metadata)
+        }
+
+        // Static tier estimate; may be upgraded by a benchmark result later.
+        self.capabilityTier = ModelCapabilityTier.estimate(from: self)
     }
 }

--- a/Tests/BaseChatInferenceTests/ModelInfoHuggingFaceFactoryTests.swift
+++ b/Tests/BaseChatInferenceTests/ModelInfoHuggingFaceFactoryTests.swift
@@ -1,0 +1,172 @@
+import XCTest
+@testable import BaseChatInference
+
+final class ModelInfoHuggingFaceFactoryTests: XCTestCase {
+
+    private var tempDirectory: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ModelInfoHuggingFaceFactoryTests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDirectory)
+        tempDirectory = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Writes a minimal fixture with a real GGUF magic-bytes header padded to the requested size.
+    /// The first 4 bytes are `[0x47, 0x47, 0x55, 0x46]` so the file passes
+    /// `GGUFMetadataReader.isValidGGUF(at:)` without needing a full GGUF structure.
+    @discardableResult
+    private func writeGGUFFixture(at url: URL, totalSize: Int = 1024) throws -> URL {
+        precondition(totalSize >= 4, "GGUF fixture must be at least 4 bytes for the magic header")
+        var data = Data([0x47, 0x47, 0x55, 0x46])
+        data.append(Data(repeating: 0, count: totalSize - 4))
+        try data.write(to: url)
+        return url
+    }
+
+    // MARK: - Happy Path
+
+    func test_huggingFaceInit_validGGUF_populatesAllFields() throws {
+        let localURL = tempDirectory.appendingPathComponent("Llama-3.2-3B-Instruct-Q4_K_M.gguf")
+        try writeGGUFFixture(at: localURL, totalSize: 2048)
+
+        let model = try XCTUnwrap(ModelInfo(
+            huggingFaceRepoID: "bartowski/Llama-3.2-3B-Instruct-GGUF",
+            fileName: "Llama-3.2-3B-Instruct-Q4_K_M.gguf",
+            sizeBytes: 1_234_567_890,
+            localURL: localURL
+        ))
+
+        XCTAssertEqual(model.fileName, "Llama-3.2-3B-Instruct-Q4_K_M.gguf")
+        XCTAssertEqual(model.modelType, .gguf)
+        XCTAssertEqual(model.url, localURL)
+        XCTAssertEqual(model.huggingFaceRepoID, "bartowski/Llama-3.2-3B-Instruct-GGUF")
+        XCTAssertNotNil(model.capabilityTier, "capabilityTier should be set after init")
+        // Display name should strip .gguf and replace separators with spaces.
+        XCTAssertEqual(model.name, "Llama 3.2 3B Instruct Q4 K M")
+    }
+
+    // MARK: - Validation
+
+    func test_huggingFaceInit_wrongExtension_returnsNil() throws {
+        let localURL = tempDirectory.appendingPathComponent("config.txt")
+        try Data(repeating: 0, count: 512).write(to: localURL)
+
+        let model = ModelInfo(
+            huggingFaceRepoID: "user/repo",
+            fileName: "config.txt",
+            sizeBytes: 512,
+            localURL: localURL
+        )
+
+        XCTAssertNil(model, "Non-.gguf extension must return nil")
+    }
+
+    func test_huggingFaceInit_missingMagicBytes_returnsNil() throws {
+        // 100-byte file of zeros — passes the extension check but fails the magic-byte check.
+        let localURL = tempDirectory.appendingPathComponent("fake.gguf")
+        try Data(repeating: 0, count: 100).write(to: localURL)
+
+        let model = ModelInfo(
+            huggingFaceRepoID: "user/repo",
+            fileName: "fake.gguf",
+            sizeBytes: 100,
+            localURL: localURL
+        )
+
+        XCTAssertNil(model, "GGUF without magic bytes must return nil")
+    }
+
+    func test_huggingFaceInit_missingFile_returnsNil() {
+        let localURL = tempDirectory.appendingPathComponent("nonexistent.gguf")
+
+        let model = ModelInfo(
+            huggingFaceRepoID: "user/repo",
+            fileName: "nonexistent.gguf",
+            sizeBytes: 1024,
+            localURL: localURL
+        )
+
+        XCTAssertNil(model)
+    }
+
+    // MARK: - Field Round-trips
+
+    func test_huggingFaceInit_repoID_roundTrips() throws {
+        let localURL = tempDirectory.appendingPathComponent("model.gguf")
+        try writeGGUFFixture(at: localURL, totalSize: 64)
+
+        let model = try XCTUnwrap(ModelInfo(
+            huggingFaceRepoID: "TheBloke/Mistral-7B-Instruct-v0.2-GGUF",
+            fileName: "model.gguf",
+            sizeBytes: 7_000_000_000,
+            localURL: localURL
+        ))
+
+        XCTAssertEqual(model.huggingFaceRepoID, "TheBloke/Mistral-7B-Instruct-v0.2-GGUF")
+    }
+
+    func test_huggingFaceInit_trustsCallerSizeBytes_skipsDiskAttributes() throws {
+        // Write a 64-byte fixture but tell the factory the size is 4 GB. If the
+        // factory honoured the caller-supplied value, fileSize must be 4 GB.
+        // If it secretly fell through to attributesOfItem, fileSize would be 64.
+        let localURL = tempDirectory.appendingPathComponent("trust-test.gguf")
+        try writeGGUFFixture(at: localURL, totalSize: 64)
+
+        let claimedSize: UInt64 = 4_000_000_000
+        let model = try XCTUnwrap(ModelInfo(
+            huggingFaceRepoID: "user/repo",
+            fileName: "trust-test.gguf",
+            sizeBytes: claimedSize,
+            localURL: localURL
+        ))
+
+        XCTAssertEqual(model.fileSize, claimedSize, "fileSize must match caller-supplied sizeBytes, not the on-disk size")
+    }
+
+    func test_huggingFaceInit_useCallerFileName_notDerivedFromURL() throws {
+        // localURL has a different basename than the supplied fileName — the
+        // factory must use the caller-supplied value verbatim.
+        let localURL = tempDirectory.appendingPathComponent("cached-blob-abc123.gguf")
+        try writeGGUFFixture(at: localURL, totalSize: 64)
+
+        let model = try XCTUnwrap(ModelInfo(
+            huggingFaceRepoID: "user/repo",
+            fileName: "Llama-3.2-3B-Q4_K_M.gguf",
+            sizeBytes: 1024,
+            localURL: localURL
+        ))
+
+        XCTAssertEqual(model.fileName, "Llama-3.2-3B-Q4_K_M.gguf")
+    }
+
+    // MARK: - Stable ID
+
+    func test_huggingFaceInit_sameLocalURL_producesStableID() throws {
+        let localURL = tempDirectory.appendingPathComponent("stable.gguf")
+        try writeGGUFFixture(at: localURL, totalSize: 64)
+
+        let first = try XCTUnwrap(ModelInfo(
+            huggingFaceRepoID: "user/repo",
+            fileName: "stable.gguf",
+            sizeBytes: 64,
+            localURL: localURL
+        ))
+        let second = try XCTUnwrap(ModelInfo(
+            huggingFaceRepoID: "user/repo",
+            fileName: "stable.gguf",
+            sizeBytes: 64,
+            localURL: localURL
+        ))
+
+        XCTAssertEqual(first.id, second.id)
+    }
+}

--- a/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
+++ b/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
@@ -40,6 +40,7 @@ BaseChatInference/Models/ToolTypes.swift:} else if let arr = try? container.deco
 
 BaseChatInference/Models/ModelInfo.swift:guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),
 BaseChatInference/Models/ModelInfo.swift:if let metadata = try? GGUFMetadataReader.readMetadata(from: url) {
+BaseChatInference/Models/ModelInfo.swift:if let metadata = try? GGUFMetadataReader.readMetadata(from: localURL) {
 BaseChatInference/Models/ModelInfo.swift:guard let contents = try? fileManager.contentsOfDirectory(
 BaseChatInference/Models/ModelInfo.swift:let values = try? fileURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
 


### PR DESCRIPTION
## Summary

Adds an additive `ModelInfo` factory for completed HuggingFace downloads:

```swift
extension ModelInfo {
    public init?(
        huggingFaceRepoID: String,
        fileName: String,
        sizeBytes: UInt64,
        localURL: URL,
        modelType: ModelType = .gguf
    )
}
```

The factory **trusts caller-supplied `sizeBytes`** (typically derived from the HuggingFace manifest) and skips the on-disk `attributesOfItem` lookup that `init?(ggufURL:)` performs. It still reads the GGUF header so the value-add stays — `detectedPromptTemplate`, `detectedContextLength`, `modelArchitecture`, `chatTemplateRaw`, and `estimatedKVBytesPerToken` are all populated. The mmproj companion-file scan is intentionally skipped (HF flows are single-file).

`fileName` is used verbatim from the caller, not derived from `localURL` — HF download flows pre-compute the canonical name and the on-disk path may be a cached blob.

## Non-breaking

This is **purely additive**:

- New optional stored property `huggingFaceRepoID: String?` on `ModelInfo` (defaults to `nil`).
- New factory init.
- Memberwise init gains a `huggingFaceRepoID: String? = nil` parameter at the end of the parameter list — existing call sites compile unchanged.
- No behavior change to `init?(ggufURL:)`, `init?(mlxDirectory:namespace:)`, or `ModelInfo.builtInFoundation`.

## New public surface

- `ModelInfo.init?(huggingFaceRepoID:fileName:sizeBytes:localURL:modelType:)`
- `ModelInfo.huggingFaceRepoID: String?`

## Tests

`Tests/BaseChatInferenceTests/ModelInfoHuggingFaceFactoryTests.swift` covers:

- Happy path: valid GGUF + HF metadata returns a fully-populated `ModelInfo`.
- Wrong extension (`.txt`) returns `nil`.
- Missing magic bytes (100-byte zero file with `.gguf` extension) returns `nil`.
- Missing file returns `nil`.
- `huggingFaceRepoID` round-trips onto the resulting model.
- `fileSize` matches caller-supplied `sizeBytes` (verifies no disk lookup).
- `fileName` is taken verbatim from the caller, not from `localURL`.
- Stable ID across repeated construction.

Sabotage check verified: removing the `isValidGGUF` guard makes the missing-magic-bytes test fail; restored before commit.

## Test plan

- [x] `swift build --build-tests --disable-default-traits`
- [x] `scripts/test.sh --filter BaseChatInferenceTests --disable-default-traits --skip-update` — 1233 passed, 0 failed, 5 skipped (XCTSkip)

Closes #975