### PR TITLE
fix(build): trait-gate BaseChatServer's BaseChatBackends dep to fix xcodebuild scheme conflict

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -418,11 +418,21 @@ let package = Package(
         // which also conditionally pulls in Hummingbird. Without the trait the
         // target compiles to a no-op stub that prints a "trait not enabled"
         // message (see `BaseChatServerCommand.swift`).
+        //
+        // BaseChatBackends and BaseChatInference are also `Server`-conditional
+        // for the same reason `fuzz-chat`'s BaseChatBackends dep is `Fuzz`-
+        // conditional (see comment on the `Fuzz` trait above): an unconditional
+        // BaseChatBackends dep on a second executable in the auto-generated
+        // `BaseChatKit-Package` Xcode scheme produces two `Copy llama.framework`
+        // tasks that collide on the same output path — breaking
+        // `xcodebuild test -only-testing BaseChatMLXIntegrationTests`. Gating
+        // the deps keeps `bck-tools` as the sole executable that pulls
+        // llama.framework into the auto-scheme. See issue #982.
         .executableTarget(
             name: "BaseChatServer",
             dependencies: [
-                "BaseChatInference",
-                "BaseChatBackends",
+                .target(name: "BaseChatInference", condition: .when(traits: ["Server"])),
+                .target(name: "BaseChatBackends", condition: .when(traits: ["Server"])),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "Hummingbird", package: "hummingbird", condition: .when(traits: ["Server"])),
             ],


### PR DESCRIPTION
## Summary

Closes #982.

PR #974 (server collapse) made `BaseChatServer` (executable) depend directly on `BaseChatBackends`. The auto-generated `BaseChatKit-Package` Xcode scheme builds every executable, and both `bck-tools` and `BaseChatServer` now had unconditional `BaseChatBackends` deps — producing two `Copy llama.framework` tasks pointing at the same path:

```
Multiple commands produce '.../Build/Products/Debug/Frameworks/llama.framework'
```

This broke `xcodebuild test -scheme BaseChatKit-Package -only-testing BaseChatMLXIntegrationTests` at the build phase.

## Fix

Mirror the established `Fuzz`-trait pattern documented at `Package.swift:43–47`: gate `BaseChatBackends` and `BaseChatInference` behind the `Server` trait on the `BaseChatServer` executable target so they only join the build graph when the trait is explicitly enabled. The `#else` no-op stub in `BaseChatServerCommand.swift` (added in #946) keeps the executable linkable when `Server` is off, so this is purely a build-graph adjustment — **no runtime behavior change**.

`bck-tools` remains the sole executable in the auto-scheme with an unconditional `BaseChatBackends` dep, so there is no longer a collision.

## Validation

- [x] `swift build --disable-default-traits` — passes
- [x] `swift build --traits Server` — passes
- [x] `swift test --filter BaseChatServerTests --traits Server --skip-update` — 48 tests, 0 failures
- [x] `rm -rf ~/Library/Developer/Xcode/DerivedData/BaseChatKit-* && xcodebuild test -scheme BaseChatKit-Package -only-testing BaseChatMLXIntegrationTests -destination 'platform=macOS'` — `** TEST SUCCEEDED **` (13 executed; 12 skipped because no fixture model matched on this checkout, 1 skipped pending #802 — none related to the build conflict)

## Behavior note

When the `Server` trait is **on**, all deps are present and the server runs as before. When **off**, the executable compiles to the no-op stub from #946 that prints `BaseChatServer was built without the 'Server' trait.` This matches the pre-#974 default-traits behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)