### PR TITLE
fix(llama): re-decode last 2 tokens batched in KV-reuse turn to match Metal kernel path

### DIFF
--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -321,9 +321,21 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         // is no race between this read and those two paths under stateLock.
         let previousTokens = withStateLock { sessionKVState?.tokens ?? [] }
         let commonPrefixLen = zip(tokens, previousTokens).prefix(while: { $0.0 == $0.1 }).count
-        // Must leave at least one token for the sampler (the last prompt token),
-        // so cap reuse at tokens.count - 1.
-        let reuseLen = min(commonPrefixLen, tokens.count - 1)
+        // Cap reuse at tokens.count - 2 so the driver always re-decodes the last
+        // *two* prompt tokens as a 2-token batch. Why two and not one: Metal's
+        // attention kernels select different parallel-reduction strategies for
+        // 1-token vs N-token decode batches. A 1-token re-decode of position
+        // N-1 would take a different reduction path than Turn 1 (which decoded
+        // the prompt as one batched call) and the resulting FP-accumulation
+        // drift can flip the argmax on near-tied tokens (e.g. Qwen3-0.6B
+        // splitting between "," and "." after " Paris"). Re-decoding the last
+        // two tokens batched matches Turn 1's kernel path for position N-1,
+        // restoring greedy determinism. KV reuse for positions 0..N-3 is
+        // preserved, so the perf cost is exactly one extra token decode per
+        // reuse turn. See #966. The `max(0, …)` floor handles short prompts
+        // (tokens.count < 2) where the cap would go negative — in that case
+        // reuse is not viable anyway and the driver decodes the whole prompt.
+        let reuseLen = max(0, min(commonPrefixLen, tokens.count - 2))
 
         // Trim the KV cache tail beyond the reuse prefix before flipping
         // isGenerating. The context pointer is safe to snapshot here: the outer


### PR DESCRIPTION
## Summary

Closes #966.

`LlamaKVPersistenceTests.test_kvReuse_determinism` was failing on Apple Silicon (Apple M5, macOS 26) with Qwen3-0.6B-Q4_K_M because Turn 2 of a KV-reuse generation produced different greedy output than Turn 1 despite an identical prompt:

```
Turn1: [" Paris", ",", " and", " the", " capital", " of", " Germany", " is"]
Turn2: [" Paris", ".", " The", " capital", " of", " the", " United", " States"]
```

## Root cause

When KV-cache reuse is active:
- **Turn 1** decodes the full prompt in a single batched call (N tokens together).
- **Turn 2** re-decoded only the last prompt token in a 1-token batch (positions 0..N-2 from cache, position N-1 fresh).

Metal's attention kernels select different parallel-reduction strategies for 1-token vs N-token decode batches. The K/V values stored in the cache are mathematically identical in both cases, but position N-1's logits drifted by small amounts of FP accumulation. For Qwen3-0.6B, the tokens `,` and `.` are nearly tied after ` Paris`, so the tiny FP difference flipped the argmax under greedy decoding.

This is a real GPU kernel divergence, not a logic bug — but the fix is straightforward.

## Fix — Option A from the issue

Cap KV reuse at `tokens.count - 2` (was `tokens.count - 1`) so Turn 2 always re-decodes the last **two** prompt tokens as a 2-token batch. This matches Turn 1's kernel path for position N-1 and restores greedy determinism. KV reuse for positions 0..N-3 is preserved.

The `max(0, …)` floor handles short prompts (tokens.count < 2) where the cap would go negative — in that case reuse is not viable anyway and the driver decodes the whole prompt.

```diff
-let reuseLen = min(commonPrefixLen, tokens.count - 1)
+let reuseLen = max(0, min(commonPrefixLen, tokens.count - 2))
```

## Why Option A and not B (tolerance)

The brief considered four options:
- **A** — re-decode 2 tokens batched (chosen)
- **B** — relax the test to a tolerance assertion
- **C** — `XCTSkipIf` Metal
- **D** — disable KV reuse on Metal

Option A is surgical (3-line diff), preserves the exact-equality determinism guarantee, and costs exactly one extra token decode per reuse turn — negligible compared to the savings from skipping N-2 prompt tokens. The rewind logic in `LlamaBackend.processKVReuse` already supports arbitrary cap values; no deeper refactor was needed.

Option B would have weakened a real correctness guarantee for a Metal-specific edge case.

## Validation

- **`scripts/test-llama-isolated.sh`** with `LLAMA_TEST_MODEL=$HOME/Documents/Models/Qwen3-0.6B-Q4_K_M.gguf` on Apple M5: **75 / 75** pass (was 73 / 75 with `test_kvReuse_determinism` and `test_fixture_eogTokenTerminatesStreamBeforeBudget_regression519` failing — the latter is unrelated and tracked as #968).
- **Sabotage check**: reverted the fix to `tokens.count - 1`, ran `swift test --filter LlamaKVPersistenceTests/test_kvReuse_determinism` with the test env vars, confirmed it fails in 0.691s with the documented divergence pattern, restored, confirmed pass.

## Perf trade-off

One extra token decode per KV-reuse turn. For a typical 200-token prompt, this is a 0.5% overhead on the prompt-decode phase of Turn 2+, with the original ~99.5% reuse benefit preserved.

## Notes

This PR was implemented in the worker worktree from PR #966's investigation. The worker stalled mid-validation; the partial fix was already on disk and well-commented, so I finished the validation (sabotage + test run) and shipped it directly rather than re-dispatching.