### PR TITLE
fix(build): wrapper script for MLX integration tests with env passthrough

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,9 +56,14 @@ swift test --filter BaseChatMCPTests --disable-default-traits --traits MCPBuilti
 # in past runs — filter to the streamable suite to avoid that path.
 RUN_MCP_E2E=1 swift test --filter BaseChatMCPE2ESmokeTests --disable-default-traits
 
-# Xcode-only — real MLX model inference (metallib required)
+# Xcode-only — real MLX model inference (metallib required).
 # Cannot run via swift test; MLX Metal shaders are only compiled by Xcode.
-xcodebuild test -scheme BaseChatKit-Package -only-testing BaseChatMLXIntegrationTests -destination 'platform=macOS'
+# Use the wrapper — bare `xcodebuild test` builds and runs but every test
+# silently `XCTSkip`s because xcodebuild does not propagate the
+# `BASECHAT_DISCOVER_LOCAL_MODELS=1` env to the xctest runner. The wrapper
+# patches the .xctestrun file's EnvironmentVariables before running. See #986.
+scripts/test-mlx-integration.sh                              # discover any valid MLX dir
+scripts/test-mlx-integration.sh Meta-Llama-3.1-8B-Instruct  # prefer dir whose name contains the hint
 
 # Example app UI tests — prefer build-for-testing once, then targeted reruns
 scripts/example-ui-tests.sh build-for-testing
@@ -147,6 +152,7 @@ When Apple ships a new major OS each September, bump both minimums by one and re
 | `scripts/example-ui-tests.sh` | `build-for-testing` / `test-without-building` for Example app XCUITests. |
 | `scripts/clean-leaked-test-artifacts.sh` | Removes test fixtures that leaked into `~/Documents/Models/`. |
 | `scripts/fuzz.sh` | Runs the BaseChatFuzz harness (default: 5 min against Ollama). Passes `--traits Fuzz,MLX,Llama` automatically. See [FUZZING.md](FUZZING.md). |
+| `scripts/test-mlx-integration.sh` | Runs `BaseChatMLXIntegrationTests` with discovery env vars patched into the `.xctestrun` so real-model tests don't silently skip. Use instead of bare `xcodebuild test`. See #986. |
 
 ## Pre-push checklist
 

--- a/scripts/test-mlx-integration.sh
+++ b/scripts/test-mlx-integration.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# scripts/test-mlx-integration.sh — Run BaseChatMLXIntegrationTests with the
+# discovery env vars properly forwarded to the xctest runner.
+#
+# Why this exists
+# ---------------
+# `BaseChatMLXIntegrationTests` requires real MLX model files on disk (Apple
+# Silicon + Metal + a HuggingFace-style snapshot dir with config.json,
+# tokenizer.json, and *.safetensors weights). The discovery helper
+# `HardwareRequirements.findMLXModelDirectory()` is opt-out — it returns nil
+# unless `BASECHAT_DISCOVER_LOCAL_MODELS=1` (or `MLX_TEST_MODEL=<name>`) is
+# set in the test runner's environment. Without it, every test silently
+# `XCTSkip`s and the suite reports green with zero real-model coverage.
+#
+# `xcodebuild test ...` does NOT propagate shell env vars to the spawned
+# xctest runner. Neither `export VAR=1; xcodebuild ...` nor the
+# `TEST_RUNNER_*` prefix convention reaches the test process for a SwiftPM
+# auto-generated scheme. The only working path is:
+#
+#   1. `xcodebuild build-for-testing` to produce the test bundle and an
+#      `.xctestrun` plist.
+#   2. PlistBuddy-edit the `.xctestrun` to add `EnvironmentVariables` to the
+#      `BaseChatMLXIntegrationTests` target's dict.
+#   3. `xcodebuild test-without-building -xctestrun <patched>` to execute
+#      with the injected env.
+#
+# This script automates that. See #986.
+#
+# Usage
+# -----
+#   scripts/test-mlx-integration.sh                # discover any valid MLX dir
+#   scripts/test-mlx-integration.sh <name>         # prefer dir whose name contains <name>
+#   scripts/test-mlx-integration.sh <name> --rebuild  # force rebuild
+#
+# Models are searched in $HOME/Documents/Models/ (and one nested level) per
+# `HardwareRequirements.modelSearchDirectories()`. A dir is valid if it has:
+#   - config.json with non-empty model_type
+#   - tokenizer.json or tokenizer.model
+#   - at least one .safetensors weights file
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+MODEL_HINT="${1:-}"
+REBUILD=0
+for arg in "$@"; do
+    [[ "$arg" == "--rebuild" ]] && REBUILD=1
+done
+
+DERIVED="$REPO_ROOT/.build/mlx-integration-test-derived"
+
+if [[ "$REBUILD" -eq 1 || ! -d "$DERIVED" ]]; then
+    echo "==> Building test bundle (xcodebuild build-for-testing)…"
+    rm -rf "$DERIVED"
+    xcodebuild build-for-testing \
+        -scheme BaseChatKit-Package \
+        -only-testing BaseChatMLXIntegrationTests \
+        -destination 'platform=macOS' \
+        -derivedDataPath "$DERIVED" \
+        -quiet
+fi
+
+RUNFILE=$(find "$DERIVED" -name "*.xctestrun" 2>/dev/null | head -1)
+if [[ -z "$RUNFILE" ]]; then
+    echo "ERROR: No .xctestrun found under $DERIVED — try --rebuild" >&2
+    exit 1
+fi
+
+# Find the BaseChatMLXIntegrationTests target index in the TestTargets array.
+TARGET_INDEX=""
+TOTAL=$(/usr/libexec/PlistBuddy -c "Print :TestConfigurations:0:TestTargets" "$RUNFILE" 2>/dev/null | grep -c "BlueprintName")
+for ((i = 0; i < TOTAL; i++)); do
+    name=$(/usr/libexec/PlistBuddy -c "Print :TestConfigurations:0:TestTargets:$i:BlueprintName" "$RUNFILE" 2>/dev/null || true)
+    if [[ "$name" == "BaseChatMLXIntegrationTests" ]]; then
+        TARGET_INDEX=$i
+        break
+    fi
+done
+
+if [[ -z "$TARGET_INDEX" ]]; then
+    echo "ERROR: BaseChatMLXIntegrationTests target not found in $RUNFILE" >&2
+    exit 1
+fi
+
+# Inject env vars. Use Set (which works whether the key existed before or was
+# added by a prior run of this script).
+ENV_PATH=":TestConfigurations:0:TestTargets:$TARGET_INDEX:EnvironmentVariables"
+/usr/libexec/PlistBuddy -c "Add $ENV_PATH:BASECHAT_DISCOVER_LOCAL_MODELS string 1" "$RUNFILE" 2>/dev/null \
+    || /usr/libexec/PlistBuddy -c "Set $ENV_PATH:BASECHAT_DISCOVER_LOCAL_MODELS 1" "$RUNFILE"
+
+if [[ -n "$MODEL_HINT" ]]; then
+    /usr/libexec/PlistBuddy -c "Add $ENV_PATH:MLX_TEST_MODEL string $MODEL_HINT" "$RUNFILE" 2>/dev/null \
+        || /usr/libexec/PlistBuddy -c "Set $ENV_PATH:MLX_TEST_MODEL $MODEL_HINT" "$RUNFILE"
+    echo "==> Selecting MLX model whose name contains: $MODEL_HINT"
+else
+    echo "==> Discovering MLX models from \$HOME/Documents/Models/ (first valid wins)"
+fi
+
+echo "==> Running tests (xcodebuild test-without-building)…"
+xcodebuild test-without-building \
+    -xctestrun "$RUNFILE" \
+    -only-testing BaseChatMLXIntegrationTests \
+    -destination 'platform=macOS'


### PR DESCRIPTION
## Summary

Closes #986.

\`xcodebuild test -scheme BaseChatKit-Package -only-testing BaseChatMLXIntegrationTests\` builds and runs cleanly post-#983, but every test silently \`XCTSkip\`s because **xcodebuild does not propagate \`BASECHAT_DISCOVER_LOCAL_MODELS=1\` to the spawned xctest runner.** Neither shell \`export\` nor the \`TEST_RUNNER_*\` prefix reaches the test process for the SwiftPM auto-generated scheme.

## Fix

Add \`scripts/test-mlx-integration.sh\` that:

1. Runs \`xcodebuild build-for-testing\` to produce the test bundle and \`.xctestrun\` plist.
2. PlistBuddy-edits the \`.xctestrun\` to add \`EnvironmentVariables\` (\`BASECHAT_DISCOVER_LOCAL_MODELS=1\` + optional \`MLX_TEST_MODEL=<hint>\`) to the \`BaseChatMLXIntegrationTests\` target's dict.
3. Runs \`xcodebuild test-without-building -xctestrun <patched>\` to execute with the injected env.

Mirrors the existing wrapper-script convention (\`test-llama-isolated.sh\`, \`test-sandboxed.sh\`, \`example-ui-tests.sh\`).

## Usage

\`\`\`bash
scripts/test-mlx-integration.sh                                # discover any valid MLX dir
scripts/test-mlx-integration.sh Meta-Llama-3.1-8B-Instruct     # prefer name containing hint
scripts/test-mlx-integration.sh Meta-Llama-3.1-8B-Instruct --rebuild  # force rebuild
\`\`\`

## CLAUDE.md updated

The \"Xcode-only — real MLX model inference\" section now directs to the script with an explanation of why the bare xcodebuild command silently skips. Added a \`scripts/test-mlx-integration.sh\` row to the Tooling table.

## Verified end-to-end

Apple M5 / macOS 26 / Meta-Llama-3.1-8B-Instruct-4bit MLX snapshot:

| Result | Count |
|---|---|
| Passed | 12 |
| Skipped | 1 (Gemma4MoE pending #802) |
| Failed | 0 |

Real inference latencies:
- \`test_realInference_generatesNonEmptyResponse\` — 1.5s
- \`test_realInference_multiTurn\` — 2.4s
- \`test_kvCacheReuse_warmSecondTurnImprovesTTFTByAtLeast2x\` — 33s (confirms 2x TTFT improvement on warm second turn)

Wall clock from-scratch: ~4 min (mostly the \`build-for-testing\` step). Subsequent runs reuse the cached build at \`.build/mlx-integration-test-derived/\` unless \`--rebuild\` is passed.

## Why a script and not a checked-in scheme / test plan

- **No persistent scheme**: SwiftPM auto-generates \`BaseChatKit-Package\` on the fly; checking in an \`.xcscheme\` would either be ignored or fight the generator.
- **\`.xctestplan\` files** require container/identifier references that don't map cleanly to SwiftPM target shapes.
- The wrapper-script pattern is already established and survives Xcode regenerating things.

## Out of scope

CI integration — there's no MLX integration test CI job today (verified \`grep -l "MLXIntegration" .github/workflows/\` returns empty), and adding one requires Apple Silicon runners + curated MLX models. Worth a separate issue if the maintainer wants nightly real-model coverage.