### PR TITLE
feat(server): RequestAuthMiddleware bearer-token abstraction

### DIFF
--- a/Sources/BaseChatServer/RequestAuthMiddleware.swift
+++ b/Sources/BaseChatServer/RequestAuthMiddleware.swift
@@ -1,0 +1,147 @@
+#if Server
+import Foundation
+import HTTPTypes
+import Hummingbird
+
+/// A request inspected by `RequestAuthMiddleware`.
+///
+/// Captures the data needed to authenticate without coupling the middleware
+/// to Hummingbird's request type — host apps can write tests against
+/// `AuthRequest` directly.
+internal struct AuthRequest: Sendable {
+    internal let headers: [String: String]
+    internal let path: String
+    internal let method: String
+    internal let remoteAddress: String?
+
+    internal init(
+        headers: [String: String],
+        path: String,
+        method: String,
+        remoteAddress: String? = nil
+    ) {
+        self.headers = headers
+        self.path = path
+        self.method = method
+        self.remoteAddress = remoteAddress
+    }
+}
+
+/// Opaque authenticated identity returned by `RequestAuthMiddleware`.
+///
+/// `id` is host-defined (token fingerprint, user-id, etc.). `scopes` is a
+/// host-defined capability set — kept as free-form strings for flexibility.
+/// Endpoints that need scope checks compare against this set.
+internal struct AuthPrincipal: Sendable, Hashable {
+    internal let id: String
+    internal let scopes: Set<String>
+
+    internal init(id: String, scopes: Set<String> = []) {
+        self.id = id
+        self.scopes = scopes
+    }
+
+    /// The principal returned for explicitly anonymous (unauthenticated)
+    /// access. Hosts that opt in via `AnonymousAuthMiddleware` see this.
+    internal static let anonymous = AuthPrincipal(id: "anonymous", scopes: [])
+}
+
+/// Reasons a `RequestAuthMiddleware` can reject a request.
+///
+/// Conforms to `Error` so middleware can `throw` directly. The HTTP layer
+/// translates these to `401 Unauthorized` envelopes.
+internal enum AuthError: Error, Equatable, Sendable {
+    /// No credential was supplied (e.g. missing `Authorization` header).
+    case missingCredential
+    /// A credential was supplied but did not match expected format
+    /// (e.g. wrong scheme, empty token).
+    case malformedCredential
+    /// A well-formed credential was supplied but is not valid (wrong token,
+    /// revoked, expired).
+    case invalidCredential
+}
+
+/// Authenticates an inbound HTTP request, returning an `AuthPrincipal` or
+/// throwing `AuthError`.
+///
+/// Implementations should fail closed: when no credential / invalid credential
+/// is presented, throw. Only return a principal (anonymous or otherwise) when
+/// the host has explicitly opted in to that behavior.
+internal protocol RequestAuthMiddleware: Sendable {
+    func authenticate(_ request: AuthRequest) async throws -> AuthPrincipal
+}
+
+/// Default no-op middleware: every request authenticates as `.anonymous`.
+///
+/// This is the default for `ServerConfiguration`, so the existing behavior
+/// (no auth) is preserved for hosts that don't opt in.
+internal struct AnonymousAuthMiddleware: RequestAuthMiddleware {
+    internal init() {}
+
+    internal func authenticate(_ request: AuthRequest) async throws -> AuthPrincipal {
+        AuthPrincipal.anonymous
+    }
+}
+
+/// Validates `Authorization: Bearer <token>` against a fixed token.
+///
+/// Compares in constant time to avoid leaking match-prefix information through
+/// timing. The principal returned uses a stable id (`"bearer"`) so hosts can
+/// use it as a sentinel; richer identity belongs in a host-specific impl.
+internal struct BearerTokenMiddleware: RequestAuthMiddleware {
+    internal let token: String
+    internal let scopes: Set<String>
+
+    internal init(token: String, scopes: Set<String> = []) {
+        self.token = token
+        self.scopes = scopes
+    }
+
+    internal func authenticate(_ request: AuthRequest) async throws -> AuthPrincipal {
+        // Headers are case-insensitive per RFC 9110 §5.1; lookup must match either casing.
+        let header = request.headers["Authorization"]
+            ?? request.headers["authorization"]
+        guard let header, !header.isEmpty else {
+            throw AuthError.missingCredential
+        }
+        let prefix = "Bearer "
+        guard header.hasPrefix(prefix) else {
+            throw AuthError.malformedCredential
+        }
+        let supplied = String(header.dropFirst(prefix.count))
+        guard !supplied.isEmpty else {
+            throw AuthError.malformedCredential
+        }
+        guard Self.constantTimeEqual(supplied, token) else {
+            throw AuthError.invalidCredential
+        }
+        return AuthPrincipal(id: "bearer", scopes: scopes)
+    }
+
+    private static func constantTimeEqual(_ a: String, _ b: String) -> Bool {
+        let aBytes = Array(a.utf8)
+        let bBytes = Array(b.utf8)
+        guard aBytes.count == bBytes.count else { return false }
+        return zip(aBytes, bBytes).reduce(0 as UInt8) { $0 | ($1.0 ^ $1.1) } == 0
+    }
+}
+
+extension AuthRequest {
+    /// Builds an `AuthRequest` from the Hummingbird request types used by
+    /// `ServerApp`. Lives here so the protocol stays Hummingbird-free for
+    /// host tests.
+    internal static func from(_ request: Request) -> AuthRequest {
+        var headers: [String: String] = [:]
+        for field in request.headers {
+            headers[field.name.canonicalName] = field.value
+        }
+        return AuthRequest(
+            headers: headers,
+            path: request.uri.path,
+            method: request.method.rawValue,
+            remoteAddress: nil
+        )
+    }
+}
+
+#endif

--- a/Sources/BaseChatServer/ServerApp.swift
+++ b/Sources/BaseChatServer/ServerApp.swift
@@ -18,18 +18,30 @@ internal struct ServerApp: Sendable {
     internal let adapter: any ChatCompletionsAdapter
     internal let metrics: ServerMetrics
     internal let generationGate: AsyncSemaphore
+    internal let authMiddleware: any RequestAuthMiddleware
 
     internal init(
         configuration: ServerConfiguration = ServerConfiguration(),
         backendProvider: any ServerBackendProvider = UnavailableServerBackendProvider(),
         adapter: any ChatCompletionsAdapter = DefaultChatCompletionsAdapter(),
-        metrics: ServerMetrics = ServerMetrics()
+        metrics: ServerMetrics = ServerMetrics(),
+        authMiddleware: (any RequestAuthMiddleware)? = nil
     ) {
         self.configuration = configuration
         self.backendProvider = backendProvider
         self.adapter = adapter
         self.metrics = metrics
         self.generationGate = AsyncSemaphore(value: configuration.parallelSlots)
+        // Back-compat: when no explicit middleware is supplied, the legacy
+        // `apiKey` field still works — it's wrapped in a BearerTokenMiddleware.
+        // An empty/nil apiKey means anonymous access (today's default).
+        if let authMiddleware {
+            self.authMiddleware = authMiddleware
+        } else if let apiKey = configuration.apiKey, !apiKey.isEmpty {
+            self.authMiddleware = BearerTokenMiddleware(token: apiKey)
+        } else {
+            self.authMiddleware = AnonymousAuthMiddleware()
+        }
     }
 
     internal func health() -> ServerHealth { ServerHealth() }
@@ -43,7 +55,7 @@ internal struct ServerApp: Sendable {
         }
 
         router.get("/v1/models") { request, _ in
-            if let unauthorized = authorizationFailure(for: request) {
+            if let unauthorized = await authorizationFailure(for: request) {
                 return unauthorized
             }
             metrics.recordRequestStarted()
@@ -60,7 +72,7 @@ internal struct ServerApp: Sendable {
         }
 
         router.post("/v1/chat/completions") { request, context in
-            if let unauthorized = authorizationFailure(for: request) {
+            if let unauthorized = await authorizationFailure(for: request) {
                 return unauthorized
             }
             metrics.recordRequestStarted()
@@ -79,7 +91,7 @@ internal struct ServerApp: Sendable {
 
         if configuration.metricsEnabled {
             router.get("/metrics") { request, _ in
-                if let unauthorized = authorizationFailure(for: request) {
+                if let unauthorized = await authorizationFailure(for: request) {
                     return unauthorized
                 }
                 return metricsResponse()
@@ -113,11 +125,13 @@ internal struct ServerApp: Sendable {
         )
     }
 
-    private func authorizationFailure(for request: Request) -> Response? {
-        guard let apiKey = configuration.apiKey, !apiKey.isEmpty else { return nil }
-        let expected = "Bearer \(apiKey)"
-        let provided = request.headers[.authorization] ?? ""
-        guard constantTimeEqual(provided, expected) else {
+    private func authorizationFailure(for request: Request) async -> Response? {
+        // AnonymousAuthMiddleware always succeeds, so the cost here is one
+        // protocol dispatch per request — same shape as the original guard.
+        do {
+            _ = try await authMiddleware.authenticate(AuthRequest.from(request))
+            return nil
+        } catch {
             return errorResponse(
                 "Missing or invalid bearer token.",
                 status: .unauthorized,
@@ -125,14 +139,6 @@ internal struct ServerApp: Sendable {
                 code: "invalid_api_key"
             )
         }
-        return nil
-    }
-
-    private func constantTimeEqual(_ a: String, _ b: String) -> Bool {
-        let aBytes = Array(a.utf8)
-        let bBytes = Array(b.utf8)
-        guard aBytes.count == bBytes.count else { return false }
-        return zip(aBytes, bBytes).reduce(0 as UInt8) { $0 | ($1.0 ^ $1.1) } == 0
     }
 
     private func chatCompletionResponse(for request: ChatCompletionRequest) async throws -> Response {

--- a/Tests/BaseChatServerTests/BaseChatServerSmokeTests.swift
+++ b/Tests/BaseChatServerTests/BaseChatServerSmokeTests.swift
@@ -104,6 +104,50 @@ final class BaseChatServerSmokeTests: XCTestCase {
         }
     }
 
+    func testAuthMiddlewareInjectionRejectsMissingAndAcceptsValid() async throws {
+        // Wires BearerTokenMiddleware via the explicit `authMiddleware:`
+        // injection (issue #976) rather than the legacy `apiKey` field.
+        let server = ServerApp(
+            backendProvider: FakeBackendProvider(models: ["tiny"]),
+            adapter: FixedChatAdapter(),
+            authMiddleware: BearerTokenMiddleware(token: "via-middleware")
+        )
+        let app = server.makeApplication()
+
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/v1/models", method: .get) { response in
+                XCTAssertEqual(response.status, .unauthorized)
+            }
+
+            var malformed = HTTPFields()
+            malformed[.authorization] = "Basic dXNlcjpwYXNz"
+            try await client.execute(uri: "/v1/models", method: .get, headers: malformed) { response in
+                XCTAssertEqual(response.status, .unauthorized)
+            }
+
+            var headers = HTTPFields()
+            headers[.authorization] = "Bearer via-middleware"
+            try await client.execute(uri: "/v1/models", method: .get, headers: headers) { response in
+                XCTAssertEqual(response.status, .ok)
+            }
+        }
+    }
+
+    func testAnonymousMiddlewareDefaultPreservesUnauthenticatedAccess() async throws {
+        // No apiKey, no middleware → AnonymousAuthMiddleware default → today's behavior.
+        let server = ServerApp(
+            backendProvider: FakeBackendProvider(models: ["tiny"]),
+            adapter: FixedChatAdapter()
+        )
+        let app = server.makeApplication()
+
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/v1/models", method: .get) { response in
+                XCTAssertEqual(response.status, .ok)
+            }
+        }
+    }
+
     func testCORSDefaultsConfiguredOriginUnsafeWildcardAndPreflight() async throws {
         try await ServerApp(
             configuration: ServerConfiguration(corsOrigin: "https://example.com")

--- a/Tests/BaseChatServerTests/RequestAuthMiddlewareTests.swift
+++ b/Tests/BaseChatServerTests/RequestAuthMiddlewareTests.swift
@@ -1,0 +1,182 @@
+#if Server
+@testable import BaseChatServer
+import XCTest
+
+final class RequestAuthMiddlewareTests: XCTestCase {
+    // MARK: - AnonymousAuthMiddleware
+
+    func testAnonymousMiddlewarePassesThroughEvenWhenNoCredentialPresent() async throws {
+        let middleware = AnonymousAuthMiddleware()
+
+        let principal = try await middleware.authenticate(
+            AuthRequest(headers: [:], path: "/v1/models", method: "GET")
+        )
+
+        XCTAssertEqual(principal, AuthPrincipal.anonymous)
+        XCTAssertEqual(principal.id, "anonymous")
+        XCTAssertTrue(principal.scopes.isEmpty)
+        // SABOTAGE: change AnonymousAuthMiddleware.authenticate to throw — confirms this asserts the no-op contract
+    }
+
+    func testAnonymousMiddlewareIgnoresAuthorizationHeader() async throws {
+        let middleware = AnonymousAuthMiddleware()
+
+        let principal = try await middleware.authenticate(
+            AuthRequest(
+                headers: ["Authorization": "Bearer anything"],
+                path: "/v1/models",
+                method: "GET"
+            )
+        )
+
+        XCTAssertEqual(principal, AuthPrincipal.anonymous)
+    }
+
+    // MARK: - BearerTokenMiddleware happy path
+
+    func testBearerTokenMiddlewareAcceptsValidBearer() async throws {
+        let middleware = BearerTokenMiddleware(token: "secret-123", scopes: ["chat", "models"])
+
+        let principal = try await middleware.authenticate(
+            AuthRequest(
+                headers: ["Authorization": "Bearer secret-123"],
+                path: "/v1/chat/completions",
+                method: "POST"
+            )
+        )
+
+        XCTAssertEqual(principal.id, "bearer")
+        XCTAssertEqual(principal.scopes, ["chat", "models"])
+    }
+
+    func testBearerTokenMiddlewareAcceptsLowercasedHeaderName() async throws {
+        // RFC 9110 §5.1: header field names are case-insensitive.
+        let middleware = BearerTokenMiddleware(token: "abc")
+
+        let principal = try await middleware.authenticate(
+            AuthRequest(
+                headers: ["authorization": "Bearer abc"],
+                path: "/v1/models",
+                method: "GET"
+            )
+        )
+
+        XCTAssertEqual(principal.id, "bearer")
+    }
+
+    // MARK: - BearerTokenMiddleware rejection
+
+    func testBearerTokenMiddlewareRejectsMissingHeader() async {
+        let middleware = BearerTokenMiddleware(token: "secret")
+
+        await assertThrows(
+            try await middleware.authenticate(
+                AuthRequest(headers: [:], path: "/v1/models", method: "GET")
+            ),
+            expecting: AuthError.missingCredential
+        )
+        // SABOTAGE: change `throw AuthError.missingCredential` in middleware to `return .anonymous` — confirms missing-cred path is enforced
+    }
+
+    func testBearerTokenMiddlewareRejectsEmptyHeader() async {
+        let middleware = BearerTokenMiddleware(token: "secret")
+
+        await assertThrows(
+            try await middleware.authenticate(
+                AuthRequest(headers: ["Authorization": ""], path: "/v1/models", method: "GET")
+            ),
+            expecting: AuthError.missingCredential
+        )
+    }
+
+    func testBearerTokenMiddlewareRejectsWrongScheme() async {
+        let middleware = BearerTokenMiddleware(token: "secret")
+
+        await assertThrows(
+            try await middleware.authenticate(
+                AuthRequest(
+                    headers: ["Authorization": "Basic dXNlcjpwYXNz"],
+                    path: "/v1/models",
+                    method: "GET"
+                )
+            ),
+            expecting: AuthError.malformedCredential
+        )
+    }
+
+    func testBearerTokenMiddlewareRejectsBearerWithoutToken() async {
+        let middleware = BearerTokenMiddleware(token: "secret")
+
+        await assertThrows(
+            try await middleware.authenticate(
+                AuthRequest(
+                    headers: ["Authorization": "Bearer "],
+                    path: "/v1/models",
+                    method: "GET"
+                )
+            ),
+            expecting: AuthError.malformedCredential
+        )
+    }
+
+    func testBearerTokenMiddlewareRejectsWrongToken() async {
+        let middleware = BearerTokenMiddleware(token: "secret")
+
+        await assertThrows(
+            try await middleware.authenticate(
+                AuthRequest(
+                    headers: ["Authorization": "Bearer not-the-secret"],
+                    path: "/v1/models",
+                    method: "GET"
+                )
+            ),
+            expecting: AuthError.invalidCredential
+        )
+    }
+
+    func testBearerTokenMiddlewareIsConstantTimeAtBytesLevel() async {
+        // We can't measure timing reliably in CI, but we can at least confirm
+        // the comparison rejects same-length non-equal tokens (i.e. doesn't
+        // short-circuit on the first mismatch via prefix equality).
+        let middleware = BearerTokenMiddleware(token: "abcdef")
+
+        await assertThrows(
+            try await middleware.authenticate(
+                AuthRequest(
+                    headers: ["Authorization": "Bearer abcdeg"],
+                    path: "/", method: "GET"
+                )
+            ),
+            expecting: AuthError.invalidCredential
+        )
+        await assertThrows(
+            try await middleware.authenticate(
+                AuthRequest(
+                    headers: ["Authorization": "Bearer xbcdef"],
+                    path: "/", method: "GET"
+                )
+            ),
+            expecting: AuthError.invalidCredential
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func assertThrows<T>(
+        _ expression: @autoclosure () async throws -> T,
+        expecting expected: AuthError,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            _ = try await expression()
+            XCTFail("Expected throw of \(expected) but call succeeded", file: file, line: line)
+        } catch let error as AuthError {
+            XCTAssertEqual(error, expected, file: file, line: line)
+        } catch {
+            XCTFail("Expected AuthError.\(expected) but got \(error)", file: file, line: line)
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary

- Introduces `RequestAuthMiddleware` as the shared request-pipeline auth abstraction (issue #976) with two implementations: `AnonymousAuthMiddleware` (default — no-op pass-through) and `BearerTokenMiddleware` (constant-time `Bearer <token>` validator).
- `ServerApp` now consumes a middleware via a new `authMiddleware:` init parameter; the legacy `ServerConfiguration.apiKey` path still works and is automatically wrapped as a `BearerTokenMiddleware` for back-compat.
- Adds 12 new tests covering anonymous pass-through, valid bearer accepted, missing/empty/wrong-scheme/empty-token/wrong-token rejections (each with a distinct `AuthError` case), and `ServerApp`-level wiring through the new injection point.

Closes #976

## Notes on the protocol shape

- The protocol is `internal` to match the rest of `BaseChatServer` (the target is an executable; everything in it is internal). The shape matches the issue spec: `authenticate(_ request: AuthRequest) async throws -> AuthPrincipal` with free-form scope strings.
- `AuthRequest` is Hummingbird-free so host tests can construct one directly; the `from(_ request: Request)` extension lives alongside.
- Header lookup tolerates either casing (RFC 9110 §5.1).
- Token storage / persistence intentionally out of scope per the issue's open-questions section — the host owns it.

## Test plan

- [x] `swift test --filter BaseChatServerTests --disable-default-traits --traits Server` — 60 tests pass (48 prior + 12 new).
- [x] Pre-push gate batch 1 (`scripts/test.sh` umbrella, all CI filters, `--disable-default-traits --skip-update`) — 2553 tests, 0 failures.
- [x] Pre-push gate batch 2 (`BaseChatInferenceSwiftTestingTests`, `--disable-default-traits --skip-update`) — 83 tests, 0 failures.
- [x] Sabotage-verified: breaking `constantTimeEqual` flips `testBearerTokenMiddlewareRejectsWrongToken` red as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)