### PR TITLE
fix(backends): OllamaBackend.processToolCalls honors mid-line cancellation

### DIFF
--- a/Sources/BaseChatBackends/OllamaBackend.swift
+++ b/Sources/BaseChatBackends/OllamaBackend.swift
@@ -514,8 +514,21 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
         // `StreamingToolCallAccumulator` from `OpenAIToolEncoding.swift`
         // and key by tool-call index here. `streamsToolCallArguments`
         // would flip to `true` at the same time.
-        func processToolCalls(_ parsed: ParsedLine) throws {
-            guard let toolCalls = parsed.toolCalls, !toolCalls.isEmpty else { return }
+        // Returns `false` when `Task.isCancelled` is observed at any point
+        // during this helper so `handleLine` can skip the remaining
+        // sub-handlers (`processThinking` / `processContent`) for the same
+        // NDJSON line. Pre-#970 the equivalent in-loop `if Task.isCancelled
+        // { return }` exited `handleLine` directly; after the decomposition
+        // a bare `return` exits only this helper, which would let
+        // post-cancel thinking and content events surface — the regression
+        // #972 fixes by mirroring `processContent`'s `Bool` convention.
+        func processToolCalls(_ parsed: ParsedLine) throws -> Bool {
+            guard let toolCalls = parsed.toolCalls, !toolCalls.isEmpty else {
+                // Even with no tool_calls on this line, a cancel that
+                // arrived between sub-handlers must short-circuit
+                // downstream emission for the same line.
+                return !Task.isCancelled
+            }
             for call in toolCalls {
                 // Cancellation contract: a consumer that drops the stream
                 // mid-flight must NOT observe `.toolCall` events for
@@ -523,7 +536,7 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
                 // `Task.isCancelled` at the emit boundary so a single-line
                 // tool_calls payload arriving alongside the cancel doesn't
                 // fire a phantom dispatch.
-                if Task.isCancelled { return }
+                if Task.isCancelled { return false }
                 try noteEventYielded()
                 continuation.yield(.toolCallStart(callId: call.id, name: call.toolName))
                 if !call.arguments.isEmpty {
@@ -536,6 +549,10 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
                 try noteEventYielded()
                 continuation.yield(.toolCall(call))
             }
+            // Post-loop cancellation: if the cancel arrived after the last
+            // tool_call was emitted but before this helper returned, still
+            // bail so thinking/content on the same line don't surface.
+            return !Task.isCancelled
         }
 
         // Route thinking field (if any) first so downstream consumers see
@@ -659,7 +676,7 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
 
         func handleLine(_ line: String) throws {
             guard let parsed = Self.parseLine(line) else { return }
-            try processToolCalls(parsed)
+            guard try processToolCalls(parsed) else { return }
             try processThinking(parsed)
             guard try processContent(parsed) else { return }
             if parsed.done {

--- a/Tests/BaseChatBackendsTests/OllamaBackendToolCallingTests.swift
+++ b/Tests/BaseChatBackendsTests/OllamaBackendToolCallingTests.swift
@@ -311,5 +311,86 @@ final class OllamaBackendToolCallingTests: XCTestCase {
             "no .toolCall event must fire after the consumer cancels the stream"
         )
     }
+
+    /// Mid-line cancellation contract (regression for #972).
+    ///
+    /// PR #970 decomposed `handleLine` into `processToolCalls` →
+    /// `processThinking` → `processContent`. The original single-method form
+    /// caught `Task.isCancelled` mid-loop with `return`, which exited
+    /// `handleLine` entirely. After the split, that bare `return` exited
+    /// only the helper, so any thinking/content fields on the SAME NDJSON
+    /// line still fired post-cancel.
+    ///
+    /// This test drives a single line carrying many tool_calls plus
+    /// thinking and content fields, cancels the producer task while it is
+    /// iterating tool_calls, and asserts that no `.thinkingToken` /
+    /// `.token` events surface after the cancellation point.
+    func test_cancellation_midLine_doesNotEmitThinkingOrContentAfterStop() async throws {
+        // Build a single NDJSON line carrying many tool_calls plus thinking
+        // and content fields. The high call count widens the in-loop
+        // cancellation window so the producer reliably observes
+        // `Task.isCancelled` partway through `processToolCalls`.
+        let callCount = 64
+        let toolCallsJSON = (0..<callCount).map { i in
+            #"{"id":"call-\#(i)","type":"function","function":{"name":"f_\#(i)","arguments":"{}"}}"#
+        }.joined(separator: ",")
+        let bigLine = #"""
+        {"model":"llama3.2","message":{"role":"assistant","thinking":"LEAKED_THINKING","content":"LEAKED_CONTENT","tool_calls":[\#(toolCallsJSON)]},"done":false}
+        """#
+
+        let (backend, chatURL) = makeBackend()
+        try await loadBackend(backend)
+
+        let chunks: [Data] = [
+            ndjsonLine(bigLine),
+            ndjsonLine(#"{"model":"llama3.2","message":{"role":"assistant","content":""},"done":true}"#),
+        ]
+        MockURLProtocol.stub(
+            url: chatURL,
+            response: .asyncSSE(chunks: chunks, chunkDelay: 0.030, statusCode: 200)
+        )
+        defer { MockURLProtocol.unstub(url: chatURL) }
+
+        let stream = try backend.generate(prompt: "go", systemPrompt: nil, config: GenerationConfig())
+
+        var observed: [GenerationEvent] = []
+        let task = Task<Void, Error> {
+            for try await event in stream.events {
+                observed.append(event)
+                // Cancel the producer the moment the first tool_call event
+                // surfaces. The producer is mid-`processToolCalls` for the
+                // big line; with #972's fix it bails out of `handleLine`,
+                // so subsequent thinking/content fields on the same line
+                // never reach the consumer.
+                if case .toolCallStart = event {
+                    backend.stopGeneration()
+                }
+            }
+        }
+        do {
+            try await task.value
+        } catch is CancellationError {
+            // Expected on cancellation
+        } catch {
+            // Cancellation may also surface as a clean stream end
+        }
+
+        let leakedThinking = observed.contains { event in
+            if case .thinkingToken(let text) = event { return text.contains("LEAKED_THINKING") }
+            return false
+        }
+        let leakedContent = observed.contains { event in
+            if case .token(let text) = event { return text.contains("LEAKED_CONTENT") }
+            return false
+        }
+        XCTAssertFalse(
+            leakedThinking,
+            "no .thinkingToken event must fire from the same line after cancellation interrupts processToolCalls"
+        )
+        XCTAssertFalse(
+            leakedContent,
+            "no .token event must fire from the same line after cancellation interrupts processToolCalls"
+        )
+    }
 }
 #endif


### PR DESCRIPTION
## Summary

PR #970 decomposed `OllamaBackend.handleLine` into per-field helpers (`processToolCalls` / `processThinking` / `processContent` / `processDoneFlush`). The original `if Task.isCancelled { return }` exited the entire line handler, but post-#970 the bare `return` only exited the `processToolCalls` helper — so `processThinking` and `processContent` still fired on the same NDJSON line after cancellation, leaking events the consumer had already abandoned.

This fix mirrors `processContent`'s `Bool` return convention: `processToolCalls` returns `false` when `Task.isCancelled` is observed (mid-loop or post-loop), and `handleLine` `guard`s on it before invoking further sub-handlers.

## Why CI didn't catch the original regression

The existing cancellation test (`test_cancellation_midStream_doesNotEmitToolCallAfterStop`) only covers the **between-line** path: cancellation observed at the top of the next `handleLine` invocation. There was no test driving cancellation across sub-handlers within a single NDJSON line.

## Regression test

`test_cancellation_midLine_doesNotEmitThinkingOrContentAfterStop` constructs a single NDJSON line carrying 64 tool_calls plus `thinking` and `content` fields, cancels the producer the moment the first `.toolCallStart` surfaces, and asserts no `.thinkingToken` / `.token` events from the same line reach the consumer.

Sabotage check (per CLAUDE.md test conventions): replaced `guard try processToolCalls(parsed) else { return }` with `_ = try processToolCalls(parsed)` — the new test reported both `LEAKED_THINKING` and `LEAKED_CONTENT` (2 failures) as expected. Restored before commit; test passes.

Closes #972.

## Test plan

- [x] `swift test --filter OllamaBackendToolCallingTests --traits Ollama --skip-update` — 7 pass (was 6 before this PR)
- [x] Sabotage check on the new regression test confirms it fails on the buggy code path
- [x] Pre-push gate batch 1 — `scripts/test.sh` with all XCTest filters, `--disable-default-traits --skip-update` — 2553 pass / 12 skipped / 0 fail
- [x] Pre-push gate batch 2 — `BaseChatInferenceSwiftTestingTests` in a separate process — 83 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)