### PR TITLE
feat: add ImageModelInfo value type for image generation

### DIFF
--- a/Sources/BaseChatInference/Models/ImageModelFormat.swift
+++ b/Sources/BaseChatInference/Models/ImageModelFormat.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// The on-disk format / runtime an image-generation model uses.
+///
+/// Sibling to ``ModelType`` for text inference. Image models live in their own type
+/// space — ``ModelType``'s switches stay closed over text formats, and image-side code
+/// keys off this enum instead.
+///
+/// Additional cases (e.g. a `gguf` variant for `stable-diffusion.cpp`, or a `coreAI`
+/// case once Apple's Core AI image-gen surface ships) land alongside their conformers
+/// rather than as forward-declared placeholders.
+public enum ImageModelFormat: String, Codable, Hashable, Sendable {
+    /// A directory containing UNet, VAE, and text-encoder weights in MLX-compatible
+    /// safetensors form, plus the configs that describe their topology. Loaded by
+    /// the MLX diffusion backend (e.g. via `mlx-swift-examples`'s `StableDiffusion`).
+    case mlxDiffusion
+}

--- a/Sources/BaseChatInference/Models/ImageModelInfo.swift
+++ b/Sources/BaseChatInference/Models/ImageModelInfo.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Identity for an image-generation model on disk.
+///
+/// Sibling to ``ModelInfo`` for text inference: same shape (identity + path + format
+/// + size + optional HuggingFace provenance), narrowed to what every image format
+/// needs. Format-specific topology — which file holds the UNet, where the VAE
+/// weights live, how many text encoders are present — is the loader's concern,
+/// resolved relative to ``directoryURL`` at load time.
+///
+/// The diffusion-shaped fields were validated against `mlx-swift-examples`'s
+/// `StableDiffusion.Configuration.FileKey` enum (UNet config + weights, VAE
+/// config + weights, one or two text encoders, scheduler config, tokenizer
+/// vocab/merges). Putting individual file URLs on the value type would bloat
+/// it and make adding non-MLX formats (e.g. `stable-diffusion.cpp`, future
+/// Core AI surfaces) painful — `directoryURL + format` is enough for a loader
+/// that knows the topology of its own format. If a later PR's runtime needs
+/// richer identity (e.g. cached UNet bytes, target resolution range), those
+/// fields are additive at that point.
+public struct ImageModelInfo: Codable, Hashable, Identifiable, Sendable {
+    /// Stable identifier — typically the HuggingFace repo ID
+    /// (e.g. `"stabilityai/sdxl-turbo"`) for downloaded models, or a path-derived
+    /// identifier for locally-discovered ones.
+    public let id: String
+
+    /// Human-readable display name (e.g. `"SDXL Turbo"`).
+    public let name: String
+
+    /// Root directory on disk. Format-specific loaders resolve their files
+    /// (UNet, VAE, text encoder(s), tokenizer, scheduler config) within this
+    /// directory using the conventions of ``format``.
+    public let directoryURL: URL
+
+    /// The format/runtime this model uses.
+    public let format: ImageModelFormat
+
+    /// Total size of the model's files on disk, in bytes.
+    public let fileSize: Int64
+
+    /// Source HuggingFace repository, when known
+    /// (e.g. `"stabilityai/sdxl-turbo"`). `nil` for locally-discovered models
+    /// or those distributed outside HuggingFace. Used by the redownload /
+    /// update flow.
+    public let huggingFaceRepoID: String?
+
+    public init(
+        id: String,
+        name: String,
+        directoryURL: URL,
+        format: ImageModelFormat,
+        fileSize: Int64,
+        huggingFaceRepoID: String? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.directoryURL = directoryURL
+        self.format = format
+        self.fileSize = fileSize
+        self.huggingFaceRepoID = huggingFaceRepoID
+    }
+
+    /// Human-readable file size (e.g. `"4.2 GB"`).
+    public var fileSizeFormatted: String {
+        ByteCountFormatter.string(fromByteCount: fileSize, countStyle: .file)
+    }
+}

--- a/Tests/BaseChatInferenceTests/ImageModelInfoTests.swift
+++ b/Tests/BaseChatInferenceTests/ImageModelInfoTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import BaseChatInference
+
+final class ImageModelInfoTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeInfo(
+        id: String = "stabilityai/sdxl-turbo",
+        name: String = "SDXL Turbo",
+        directoryURL: URL = URL(fileURLWithPath: "/tmp/models/sdxl-turbo"),
+        format: ImageModelFormat = .mlxDiffusion,
+        fileSize: Int64 = 4_200_000_000,
+        huggingFaceRepoID: String? = "stabilityai/sdxl-turbo"
+    ) -> ImageModelInfo {
+        ImageModelInfo(
+            id: id,
+            name: name,
+            directoryURL: directoryURL,
+            format: format,
+            fileSize: fileSize,
+            huggingFaceRepoID: huggingFaceRepoID
+        )
+    }
+
+    // MARK: - Codable
+
+    func test_codable_roundTrip_withHuggingFaceRepoID() throws {
+        let original = makeInfo(huggingFaceRepoID: "stabilityai/sdxl-turbo")
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ImageModelInfo.self, from: data)
+
+        XCTAssertEqual(decoded, original)
+        XCTAssertEqual(decoded.huggingFaceRepoID, "stabilityai/sdxl-turbo")
+    }
+
+    func test_codable_roundTrip_withNilHuggingFaceRepoID() throws {
+        let original = makeInfo(huggingFaceRepoID: nil)
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ImageModelInfo.self, from: data)
+
+        XCTAssertEqual(decoded, original)
+        XCTAssertNil(decoded.huggingFaceRepoID)
+    }
+
+    // MARK: - Equatable / Hashable
+
+    func test_equatable_sameFields_areEqual() {
+        let a = makeInfo()
+        let b = makeInfo()
+
+        XCTAssertEqual(a, b)
+    }
+
+    func test_hashable_sameFields_haveSameHash() {
+        let a = makeInfo()
+        let b = makeInfo()
+
+        XCTAssertEqual(a.hashValue, b.hashValue)
+    }
+
+    func test_equatable_differentID_notEqual() {
+        let a = makeInfo(id: "first")
+        let b = makeInfo(id: "second")
+
+        XCTAssertNotEqual(a, b)
+    }
+
+    // MARK: - Identifiable
+
+    func test_identifiable_idMatchesIDField() {
+        let info = makeInfo(id: "my-id")
+
+        // `id` requirement of Identifiable resolves to the stored `id` property.
+        XCTAssertEqual(info.id, "my-id")
+    }
+
+    // MARK: - Format
+
+    func test_format_mlxDiffusion_persistsAcrossCodableRoundTrip() throws {
+        let original = makeInfo(format: .mlxDiffusion)
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ImageModelInfo.self, from: data)
+
+        XCTAssertEqual(decoded.format, .mlxDiffusion)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ImageModelInfo`, a value type that represents an on-disk image-generation model. Mirrors the role `ModelInfo` plays for text inference.
- Adds `ImageModelFormat` enum (`mlxDiffusion` only for now — additional cases land alongside their conformers).
- Purely additive: no changes to `ModelType`, `ModelInfo`, or any existing text-side switch. Text inference path is byte-identical before/after.

## Why now

`ImageGenerationBackend.loadModel(from: URL)` is currently the only way a caller identifies a model — a bare URL with no metadata. Once a real backend lands (PR 6 in the umbrella) the runtime needs richer identity: which weights, which format, where they live, optionally the source HuggingFace repo. `ImageModelInfo` is that identity, and every later PR in the umbrella references it.

Kept narrow on purpose: this PR introduces a value type and its tests. No service, no runtime, no UI. Reviewers can evaluate the shape independently of the integration layer.

## Why a parallel type instead of widening `ModelType` / `ModelInfo`

Adding `.diffusion` to `ModelType` source-breaks 15 switch sites across `BaseChatInference`, `BaseChatBackends`, `BaseChatHuggingFace`, `BaseChatUI`, and `BaseChatUIModelManagement` — every one of which would become `case .diffusion: fatalError("not text")`. The existing switches are correctly closed over text formats; image models don't belong in their type space. A parallel `ImageModelInfo` keeps text invariants intact and lets image code grow independently.

## Why not enumerate UNet / VAE / text-encoder URLs as fields

Format-specific loaders (e.g. `mlx-swift-examples`'s `StableDiffusion.Configuration.FileKey` resolver, verified during the umbrella's pre-PR-6 spike) know how to find their files relative to a root directory. Putting individual file URLs on the value type would bloat it and make adding future formats (sd.cpp, Core AI post-WWDC) painful. `directoryURL + format` is enough; the loader handles topology.

## Test plan

- [x] Codable round-trip for `ImageModelInfo` (with and without `huggingFaceRepoID`).
- [x] Hashable / Equatable / Identifiable conformance.
- [x] No regressions in existing text-side suites (full pre-push gate locally).

## Files

- `Sources/BaseChatInference/Models/ImageModelInfo.swift` (new)
- `Sources/BaseChatInference/Models/ImageModelFormat.swift` (new)
- `Tests/BaseChatInferenceTests/ImageModelInfoTests.swift` (new)

## Tracking

Part of #1002. Foundations for the image-generation runtime — see the umbrella for the full PR sequence and the pre-PR-6 spike outcome.
