### PR TITLE
fix(runtime): persist session B turn after switch-cancel-resend

### DIFF
--- a/Sources/BaseChatInference/Services/GenerationQueue.swift
+++ b/Sources/BaseChatInference/Services/GenerationQueue.swift
@@ -1049,7 +1049,7 @@ final class GenerationQueue {
         }
     }
 
-    func discardRequests(notMatching sessionID: UUID) {
+    func discardRequests(notMatching sessionID: UUID) async {
         requestQueue.removeAll { req in
             guard let reqSession = req.sessionID, reqSession != sessionID else { return false }
             req.stream.setPhase(.failed("Session changed"))
@@ -1059,7 +1059,16 @@ final class GenerationQueue {
         if let active = activeRequest,
            let activeSession = active.sessionID,
            activeSession != sessionID {
+            // Capture the active task handle before `cancel` clears it. The
+            // task's `defer` block in `drainQueue` clears `activeRequest`,
+            // releases `isGenerating`, and finishes the continuation; if the
+            // caller (a session switch) re-enqueues before that defer runs,
+            // the new request can land on a queue mid-tear-down (issue #965).
+            // Awaiting the task's value here serialises the next enqueue
+            // behind the dying turn so B's send sees a clean slot.
+            let dyingTask = activeTask
             cancel(active.token)
+            await dyingTask?.value
         }
     }
 

--- a/Sources/BaseChatInference/Services/InferenceService.swift
+++ b/Sources/BaseChatInference/Services/InferenceService.swift
@@ -329,9 +329,9 @@ public final class InferenceService {
         generation.cancel(token)
     }
 
-    public func discardRequests(notMatching sessionID: UUID) {
+    public func discardRequests(notMatching sessionID: UUID) async {
         ensureProviderWired()
-        generation.discardRequests(notMatching: sessionID)
+        await generation.discardRequests(notMatching: sessionID)
     }
 
     public var lastTokenUsage: (promptTokens: Int, completionTokens: Int)? {

--- a/Sources/BaseChatRuntime/Services/ConversationRuntime.swift
+++ b/Sources/BaseChatRuntime/Services/ConversationRuntime.swift
@@ -348,6 +348,25 @@ public final class ConversationRuntime: Sendable {
 
     private let registry = InFlightStreamRegistry()
 
+    // MARK: Diagnostics (test-injectable)
+
+    /// Test-only observer fired when the turn loop drops an empty assistant
+    /// response (i.e. `emptyResponse && !cancelled && streamFailed == nil`).
+    /// Production callers pass `nil`; tests inject a closure to verify the
+    /// silent-drop path is reachable. The observer fires from the same
+    /// detached task that drives generation, so receivers must tolerate
+    /// off-main delivery.
+    package struct EmptyResponseDiagnostic: Sendable {
+        public let sessionID: UUID
+        public let backendName: String?
+        public init(sessionID: UUID, backendName: String?) {
+            self.sessionID = sessionID
+            self.backendName = backendName
+        }
+    }
+
+    private let emptyResponseObserver: (@Sendable (EmptyResponseDiagnostic) -> Void)?
+
     // MARK: Init
 
     /// Creates a runtime that composes the supplied ports.
@@ -368,16 +387,36 @@ public final class ConversationRuntime: Sendable {
     ///     to keep the event sequence stable, then enqueues with no extra
     ///     slots. When present, the pipeline is queried before each turn
     ///     and the resulting slots are surfaced via `.contextAssembled`.
-    public init(
+    public convenience init(
         messageStore: any MessageStore,
         sessionStore: (any SessionStore)? = nil,
         inferenceService: InferenceService,
         pipeline: PromptContextPipeline? = nil
     ) {
+        self.init(
+            messageStore: messageStore,
+            sessionStore: sessionStore,
+            inferenceService: inferenceService,
+            pipeline: pipeline,
+            emptyResponseObserver: nil
+        )
+    }
+
+    /// Test-only init that lets the caller observe the empty-assistant drop
+    /// path. Wrapped in `package` so test targets can reach it without
+    /// widening the public surface.
+    package init(
+        messageStore: any MessageStore,
+        sessionStore: (any SessionStore)? = nil,
+        inferenceService: InferenceService,
+        pipeline: PromptContextPipeline? = nil,
+        emptyResponseObserver: (@Sendable (EmptyResponseDiagnostic) -> Void)?
+    ) {
         self.messageStore = messageStore
         self.sessionStore = sessionStore
         self.inferenceService = inferenceService
         self.pipeline = pipeline
+        self.emptyResponseObserver = emptyResponseObserver
         var cap: AsyncStream<ConversationEvent>.Continuation!
         self.events = AsyncStream(bufferingPolicy: .unbounded) { cap = $0 }
         self.continuation = cap
@@ -1122,6 +1161,19 @@ public final class ConversationRuntime: Sendable {
         if reason == .empty {
             // Drop the empty assistant message. No persistence happens; we
             // emit the terminal events and return.
+            //
+            // Issue #965: a switch-cancel-resend race used to silently drop
+            // the resent turn here. The fix lives in
+            // `GenerationQueue.discardRequests(notMatching:)`, but a stream
+            // may still legitimately reach this branch (e.g. backend yields
+            // zero tokens for a malformed prompt). Log a warning with backend
+            // + sessionID so a future regression is observable instead of
+            // silent. Semantics are unchanged — this branch still drops.
+            let backendName = await readActiveBackendName()
+            Log.inference.warning(
+                "ConversationRuntime: dropping empty assistant turn (sessionID=\(sessionID, privacy: .private), backend=\(backendName ?? "nil", privacy: .public))"
+            )
+            emptyResponseObserver?(EmptyResponseDiagnostic(sessionID: sessionID, backendName: backendName))
             emit(.streamFinished(messageID: assistantID, reason: reason))
             emit(.afterGeneration(messageID: assistantID, finalText: ""))
             return
@@ -1205,6 +1257,13 @@ public final class ConversationRuntime: Sendable {
     @MainActor
     private func readLastTokenUsage() async -> (promptTokens: Int, completionTokens: Int)? {
         inferenceService.lastTokenUsage
+    }
+
+    /// Reads ``InferenceService/activeBackendName`` off the main actor for
+    /// diagnostic logging on the empty-response drop path (issue #965).
+    @MainActor
+    private func readActiveBackendName() async -> String? {
+        inferenceService.activeBackendName
     }
 
     @MainActor

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+SessionManagement.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+SessionManagement.swift
@@ -9,21 +9,44 @@ extension ChatViewModel {
 
     /// Switches to a different chat session, loading its messages and settings.
     public func switchToSession(_ session: ChatSessionRecord) async {
-        // Stop any active generation for the old session.
+        // Drive the UI back to idle synchronously so the toolbar/stop button
+        // observes the transition immediately. The runtime handle and queue
+        // tear-down are awaited via `discardRequests` below before any
+        // backend mutation runs.
         if isGenerating {
-            stopGeneration()
+            transitionPhase(to: .idle)
         }
 
         isRestoringSession = true
         defer { isRestoringSession = false }
 
         let selectionState = sessionController.activateSession(session)
+
+        // Discard any queued requests that belong to a different session.
+        // Awaiting here is load-bearing: the call cancels the active turn
+        // (when its session ≠ `session.id`) and drives the task's defer
+        // block to completion before returning. Running the discard
+        // *before* `resetConversation()` / `secureWipe()` keeps those
+        // backend KV-cache mutations from racing the dying turn — a race
+        // that previously left B's first send to land on a half-torn-down
+        // queue and yield zero tokens (issue #965).
+        await inferenceService.discardRequests(notMatching: session.id)
+
         inferenceService.resetConversation()
         inferenceService.secureWipe()
         inferenceService.selectedPromptTemplate = sessionController.selectedPromptTemplate
 
-        // Discard any queued requests that belong to a different session.
-        inferenceService.discardRequests(notMatching: session.id)
+        // Cancel the runtime's stream handle for the prior session if one is
+        // still attached. `discardRequests` made the queue idle; this
+        // closes the runtime-level bookkeeping so the next send opens a
+        // fresh handle. Awaited inline so the runtime registry is fully
+        // torn down before the caller's next send registers a new handle —
+        // a fire-and-forget Task here flaked under heavy parallel load
+        // (issue #965).
+        if let handle = activeConversationStreamHandle {
+            await conversationRuntime.cancel(handle)
+            activeConversationStreamHandle = nil
+        }
 
         // Clear any still-pending tool approvals and the once-per-session
         // latch so approvals from the prior session do not leak into this one.

--- a/Tests/BaseChatFuzzTests/InferenceServiceSignatureLockTests.swift
+++ b/Tests/BaseChatFuzzTests/InferenceServiceSignatureLockTests.swift
@@ -76,7 +76,9 @@ final class InferenceServiceSignatureLockTests: XCTestCase {
         XCTAssertNotNil(cancel as Any)
 
         // discardRequests(notMatching:) takes a UUID, returns Void.
-        let discard: (UUID) -> Void = service.discardRequests(notMatching:)
+        // Async to serialise tear-down of the active task before the next
+        // enqueue lands (issue #965).
+        let discard: (UUID) async -> Void = service.discardRequests(notMatching:)
         XCTAssertNotNil(discard as Any)
     }
 

--- a/Tests/BaseChatInferenceTests/GenerationQueueTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationQueueTests.swift
@@ -502,7 +502,7 @@ final class GenerationQueueTests: XCTestCase {
             messages: [("user", "drop")], priority: .normal, sessionID: dropSession
         )
 
-        coord.discardRequests(notMatching: keepSession)
+        await coord.discardRequests(notMatching: keepSession)
 
         // The dropped stream must terminate — no tokens.
         var dropTokens: [String] = []

--- a/Tests/BaseChatInferenceTests/InferenceServiceQueueTests.swift
+++ b/Tests/BaseChatInferenceTests/InferenceServiceQueueTests.swift
@@ -404,7 +404,7 @@ final class InferenceServiceQueueTests: XCTestCase {
             sessionID: sessionB
         )
 
-        service.discardRequests(notMatching: sessionB)
+        await service.discardRequests(notMatching: sessionB)
 
         // Session A queued request should be cancelled.
         if case .failed = streamA.phase {
@@ -433,7 +433,7 @@ final class InferenceServiceQueueTests: XCTestCase {
             sessionID: nil
         )
 
-        service.discardRequests(notMatching: sessionB)
+        await service.discardRequests(notMatching: sessionB)
 
         XCTAssertEqual(streamNil.phase, .queued,
                        "nil sessionID should survive discardRequests")

--- a/Tests/BaseChatRuntimeTests/EmptyResponseDiagnosticTests.swift
+++ b/Tests/BaseChatRuntimeTests/EmptyResponseDiagnosticTests.swift
@@ -1,0 +1,132 @@
+@preconcurrency import XCTest
+import Foundation
+@testable import BaseChatRuntime
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Verifies that ``ConversationRuntime`` invokes its empty-response observer
+/// (the test-injectable counterpart to the production `Log.warning`) only
+/// when the turn loop drops an empty assistant message — i.e. the model
+/// produced no visible tokens AND the run was neither cancelled nor failed.
+///
+/// This is the diagnostic surface added in the #965 fix so a future silent
+/// regression of the same shape is observable.
+@MainActor
+final class EmptyResponseDiagnosticTests: XCTestCase {
+
+    @MainActor
+    final class FakeMessageStore: MessageStore {
+        private(set) var messages: [UUID: ChatMessageRecord] = [:]
+        func insertMessage(_ message: ChatMessageRecord) async throws {
+            messages[message.id] = message
+        }
+        func updateMessage(_ message: ChatMessageRecord) async throws {
+            messages[message.id] = message
+        }
+        func deleteMessage(_ messageID: UUID) async throws {
+            messages.removeValue(forKey: messageID)
+        }
+        func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
+            messages.values
+                .filter { $0.sessionID == sessionID }
+                .sorted { $0.timestamp < $1.timestamp }
+        }
+        func deleteMessages(for sessionID: UUID) async throws {
+            messages = messages.filter { $0.value.sessionID != sessionID }
+        }
+        func addPostWriteHook(_ hook: any MessageStorePostWriteHook) {}
+    }
+
+    /// Thread-safe collector for diagnostics fired off the main actor.
+    final class DiagnosticBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var items: [ConversationRuntime.EmptyResponseDiagnostic] = []
+        func append(_ d: ConversationRuntime.EmptyResponseDiagnostic) {
+            lock.lock(); defer { lock.unlock() }
+            items.append(d)
+        }
+        var snapshot: [ConversationRuntime.EmptyResponseDiagnostic] {
+            lock.lock(); defer { lock.unlock() }
+            return items
+        }
+    }
+
+    func test_emptyResponse_firesObserver_andCarriesSessionAndBackend() async throws {
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = []  // produce zero visible tokens
+
+        let inference = InferenceService(backend: backend, name: "EmptyDiagBackend")
+        let store = FakeMessageStore()
+        let box = DiagnosticBox()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            sessionStore: nil,
+            inferenceService: inference,
+            pipeline: nil,
+            emptyResponseObserver: { d in box.append(d) }
+        )
+
+        let drain = Task.detached {
+            for await _ in runtime.events {}
+        }
+
+        let sessionID = UUID()
+        _ = try await runtime.send(SendInput(sessionID: sessionID, userText: "hello"))
+
+        // Wait until the observer fires (or fail).
+        let deadline = ContinuousClock.now + .seconds(3)
+        while box.snapshot.isEmpty && ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        drain.cancel()
+
+        let captured = box.snapshot
+        XCTAssertEqual(captured.count, 1, "Empty-response observer must fire exactly once on the drop path")
+        XCTAssertEqual(captured.first?.sessionID, sessionID, "Diagnostic must carry the dropped turn's sessionID")
+        XCTAssertEqual(captured.first?.backendName, "EmptyDiagBackend", "Diagnostic must carry the active backend name")
+
+        // Persistence side: the empty assistant must NOT be persisted.
+        let persisted = try await store.fetchMessages(for: sessionID)
+        XCTAssertEqual(persisted.filter { $0.role == .assistant }.count, 0,
+                       "Empty assistant must remain unpersisted (semantics unchanged)")
+    }
+
+    func test_nonEmptyResponse_doesNotFireObserver() async throws {
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["hi", " there"]
+
+        let inference = InferenceService(backend: backend, name: "GreenBackend")
+        let store = FakeMessageStore()
+        let box = DiagnosticBox()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            sessionStore: nil,
+            inferenceService: inference,
+            pipeline: nil,
+            emptyResponseObserver: { d in box.append(d) }
+        )
+
+        let drain = Task.detached {
+            for await _ in runtime.events {}
+        }
+
+        let sessionID = UUID()
+        _ = try await runtime.send(SendInput(sessionID: sessionID, userText: "hello"))
+
+        // Wait until assistant is persisted (happy path), then verify observer
+        // never fired.
+        let deadline = ContinuousClock.now + .seconds(3)
+        var persistedAsst = false
+        while !persistedAsst && ContinuousClock.now < deadline {
+            let msgs = try await store.fetchMessages(for: sessionID)
+            persistedAsst = msgs.contains { $0.role == .assistant && !$0.content.isEmpty }
+            if !persistedAsst { try? await Task.sleep(for: .milliseconds(10)) }
+        }
+        drain.cancel()
+
+        XCTAssertTrue(persistedAsst, "Happy path: assistant should persist")
+        XCTAssertTrue(box.snapshot.isEmpty, "Observer must not fire when the assistant streamed content")
+    }
+}

--- a/Tests/BaseChatRuntimeTests/SessionDiscardOrderingTests.swift
+++ b/Tests/BaseChatRuntimeTests/SessionDiscardOrderingTests.swift
@@ -1,0 +1,132 @@
+@preconcurrency import XCTest
+import Foundation
+@testable import BaseChatRuntime
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Stress test for issue #965 (switch-cancel-resend). Drives N=50 cycles of
+/// "send on A → switch to B → resend on B" through `ConversationRuntime` and
+/// `InferenceService.discardRequests(notMatching:)` and asserts each cycle
+/// persists B's user + assistant turn cleanly with no leakage from A.
+///
+/// Uses XCTestCase (not Swift Testing) intentionally — `BaseChatRuntimeTests`
+/// runs in the same process as the rest of the XCTest batch, and mixing
+/// harnesses inside one process triggers a libmalloc SIGABRT (issue #681).
+@MainActor
+final class SessionDiscardOrderingTests: XCTestCase {
+
+    /// In-memory MessageStore mirror of the fake used by ConversationRuntimeTests.
+    /// Re-stated here to keep this file self-contained — these stress tests
+    /// drive thousands of writes and benefit from a fixture they own.
+    @MainActor
+    final class FakeMessageStore: MessageStore {
+        private(set) var messages: [UUID: ChatMessageRecord] = [:]
+        func insertMessage(_ message: ChatMessageRecord) async throws {
+            messages[message.id] = message
+        }
+        func updateMessage(_ message: ChatMessageRecord) async throws {
+            messages[message.id] = message
+        }
+        func deleteMessage(_ messageID: UUID) async throws {
+            messages.removeValue(forKey: messageID)
+        }
+        func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
+            messages.values
+                .filter { $0.sessionID == sessionID }
+                .sorted { $0.timestamp < $1.timestamp }
+        }
+        func deleteMessages(for sessionID: UUID) async throws {
+            messages = messages.filter { $0.value.sessionID != sessionID }
+        }
+        func addPostWriteHook(_ hook: any MessageStorePostWriteHook) {}
+    }
+
+    private var iterations: Int { 50 }
+
+    func test_switchCancelResend_50cycles_alwaysPersistsSessionB() async throws {
+        for cycle in 0..<iterations {
+            try await runOneCycle(cycle: cycle)
+        }
+    }
+
+    private func runOneCycle(cycle: Int) async throws {
+        let backend = SlowMockBackend(tokenCount: 30, delayMilliseconds: 20)
+        backend.isModelLoaded = true
+        let inference = InferenceService(backend: backend, name: "DiscardStress")
+        let store = FakeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            sessionStore: nil,
+            inferenceService: inference
+        )
+
+        let sessionA = UUID()
+        let sessionB = UUID()
+
+        // Drain events on a side task so the unbounded buffer doesn't grow
+        // unbounded across iterations.
+        let drainTask = Task.detached {
+            for await _ in runtime.events {}
+        }
+
+        // Send on A.
+        let aInput = SendInput(sessionID: sessionA, userText: "ask A \(cycle)")
+        _ = try await runtime.send(aInput)
+
+        // Wait until A's turn is in-flight (queue reports active or queued).
+        let preDeadline = ContinuousClock.now + .milliseconds(500)
+        while !inference.isGenerating && ContinuousClock.now < preDeadline {
+            await Task.yield()
+        }
+
+        // Switch: discardRequests now cancels-and-awaits the active task.
+        // We deliberately do NOT call `inference.stopGeneration()` first —
+        // the production fix (`switchToSession`) reorders the discard ahead
+        // of `resetConversation`/`secureWipe` so that the discard is the
+        // single owner of cancel-and-await. Calling stop here would null
+        // out `activeTask` and defeat the await; the assertion that this
+        // path stays the load-bearing one is part of what this test pins.
+        await inference.discardRequests(notMatching: sessionB)
+        inference.resetConversation()
+        inference.secureWipe()
+
+        // Configure B's reply.
+        backend.tokensToYield = ["b0_\(cycle)", " b1_\(cycle)"]
+        backend.delayPerToken = .milliseconds(2)
+
+        // Send on B and consume its event stream until completion.
+        let bInput = SendInput(sessionID: sessionB, userText: "ask B \(cycle)")
+        _ = try await runtime.send(bInput)
+
+        // Poll until B's assistant message is persisted (or fail with diag).
+        let bDeadline = ContinuousClock.now + .seconds(3)
+        var bAssistantPersisted = false
+        while ContinuousClock.now < bDeadline {
+            let msgs = try await store.fetchMessages(for: sessionB)
+            let asst = msgs.filter { $0.role == .assistant }
+            let user = msgs.filter { $0.role == .user }
+            if user.count == 1, asst.count == 1, !(asst.first?.content.isEmpty ?? true) {
+                bAssistantPersisted = true
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        let bMsgs = try await store.fetchMessages(for: sessionB)
+        let bUser = bMsgs.filter { $0.role == .user }
+        let bAsst = bMsgs.filter { $0.role == .assistant }
+        XCTAssertTrue(bAssistantPersisted, "[cycle \(cycle)] B assistant must persist; got user=\(bUser.count) asst=\(bAsst.count) firstAsst=\(bAsst.first?.content ?? "<nil>")")
+        XCTAssertEqual(bUser.count, 1, "[cycle \(cycle)] B should have exactly 1 user message")
+        XCTAssertEqual(bAsst.count, 1, "[cycle \(cycle)] B should have exactly 1 assistant message")
+        XCTAssertEqual(bAsst.first?.content, "b0_\(cycle) b1_\(cycle)", "[cycle \(cycle)] B assistant content")
+
+        // Leakage check: B must not contain A's tokens.
+        for m in bMsgs {
+            XCTAssertFalse(m.content.contains("token"), "[cycle \(cycle)] B must not contain A's leftover tokens; got '\(m.content)'")
+        }
+
+        drainTask.cancel()
+        // Cleanup the backend's loaded state to keep memory bounded.
+        backend.unloadModel()
+    }
+}

--- a/Tests/BaseChatUITests/InterleavingTests.swift
+++ b/Tests/BaseChatUITests/InterleavingTests.swift
@@ -124,15 +124,10 @@ final class InterleavingTests: XCTestCase {
 
     /// Starts generation on session A, switches to session B mid-stream,
     /// then generates on B. Verifies no tokens from A leak into B.
-    // FIXME: https://github.com/roryford/BaseChatKit/issues/947 — runtime path
-    // drops B's assistant persistence after switch-cancel-resend. Likely related
-    // to `inferenceService.stopGeneration()` + `secureWipe()` in
-    // `switchToSession` leaving the backend in a state that yields zero tokens
-    // for the next enqueueAsync (B's stream hits the empty-response branch and
-    // skips persistence). Pre-cutover legacy path passed this test. Tracked as
-    // a remaining-work checkbox on the #947 umbrella.
+    /// Fixed by #965: `discardRequests(notMatching:)` is now async and awaits
+    /// the active task's tear-down before returning, so B's `enqueueAsync`
+    /// lands on a clean queue.
     func test_sessionSwitch_duringGeneration_noContentLeakage() async throws {
-        try XCTSkipIf(true, "FIXME: #947 — runtime feature parity (assistant persistence after switch-cancel-resend)")
         // Session A: slow 20-token stream with identifiable tokens.
         let sessionA = try await createAndActivateSession(title: "Session A")
         slowBackend.tokensToYield = (0..<20).map { "alpha\($0) " }
@@ -315,5 +310,105 @@ final class InterleavingTests: XCTestCase {
 
         XCTAssertFalse(vm.isGenerating, "isGenerating should be false after model reload")
         XCTAssertTrue(vm.isModelLoaded, "Model should be loaded after reload completes")
+    }
+
+    // MARK: - Test 5 + 6: Switch-cancel-resend variants for #965
+
+    /// Variant of test 2: switch happens during the *first-token* phase, before
+    /// any tokens have been observed by the UI. Exercises the same
+    /// switch→cancel→resend race tighter to the start of streaming.
+    func test_sessionSwitch_duringFirstTokenStreaming_persistsBothSessions() async throws {
+        let sessionA = try await createAndActivateSession(title: "A-firstToken")
+        slowBackend.tokensToYield = (0..<20).map { "alpha\($0) " }
+        slowBackend.delayPerToken = .milliseconds(50)
+
+        vm.inputText = "ask A"
+        let genTask = Task { @MainActor in
+            await self.vm.sendMessage()
+        }
+
+        // Yield until isGenerating flips, but do NOT wait for first token —
+        // we want the switch to land while the backend is still warming up.
+        await vm.awaitGenerating(true)
+
+        let sessionB = try await sessionManager.createSession(title: "B-firstToken")
+        sessionManager.activeSession = sessionB
+        await vm.switchToSession(sessionB)
+
+        XCTAssertFalse(vm.isGenerating, "Generation should be stopped after switch")
+        XCTAssertFalse(vm.inferenceService.hasQueuedRequests)
+
+        slowBackend.tokensToYield = ["beta0", " beta1"]
+        slowBackend.delayPerToken = .milliseconds(10)
+
+        vm.inputText = "ask B"
+        await vm.sendMessage()
+        await genTask.value
+
+        let aMsgs = try await persistence.fetchMessages(for: sessionA.id)
+        XCTAssertTrue(aMsgs.contains { $0.role == .user && $0.content == "ask A" },
+                      "A's user message must persist")
+
+        let bMsgs = try await persistence.fetchMessages(for: sessionB.id)
+        let bUser = bMsgs.filter { $0.role == .user }
+        let bAsst = bMsgs.filter { $0.role == .assistant }
+        XCTAssertEqual(bUser.count, 1, "B should have 1 user message")
+        XCTAssertEqual(bAsst.count, 1, "B should have 1 assistant message")
+        XCTAssertEqual(bAsst.first?.content, "beta0 beta1")
+        for m in bMsgs {
+            XCTAssertFalse(m.content.contains("alpha"), "B must not contain A's alpha tokens")
+        }
+    }
+
+    /// Variant of test 2: switch happens *after* first-token but before
+    /// completion. Confirms a partially-streamed assistant on A persists,
+    /// while B still gets a clean fresh turn.
+    func test_sessionSwitch_afterFirstToken_persistsPartialAndFreshB() async throws {
+        let sessionA = try await createAndActivateSession(title: "A-afterFirst")
+        slowBackend.tokensToYield = (0..<20).map { "alpha\($0) " }
+        slowBackend.delayPerToken = .milliseconds(50)
+
+        vm.inputText = "ask A"
+        let genTask = Task { @MainActor in
+            await self.vm.sendMessage()
+        }
+
+        // Wait until at least one token has landed in A's assistant message,
+        // then switch.
+        await vm.awaitFirstToken()
+
+        let sessionB = try await sessionManager.createSession(title: "B-afterFirst")
+        sessionManager.activeSession = sessionB
+        await vm.switchToSession(sessionB)
+
+        XCTAssertFalse(vm.isGenerating)
+
+        slowBackend.tokensToYield = ["beta0", " beta1", " beta2"]
+        slowBackend.delayPerToken = .milliseconds(10)
+        vm.inputText = "ask B"
+        await vm.sendMessage()
+        await genTask.value
+
+        // A: user persists; assistant should be present (partial) — the
+        // cancel-on-stop path saves what streamed in.
+        let aMsgs = try await persistence.fetchMessages(for: sessionA.id)
+        XCTAssertTrue(aMsgs.contains { $0.role == .user && $0.content == "ask A" })
+        let aAsst = aMsgs.filter { $0.role == .assistant }
+        // At-most-one assistant; if present, must be a non-empty alpha prefix.
+        XCTAssertLessThanOrEqual(aAsst.count, 1, "At most one assistant row on A after cancel")
+        if let a = aAsst.first {
+            XCTAssertTrue(a.content.contains("alpha"), "A assistant content should be partial alpha tokens, got \(a.content)")
+        }
+
+        // B: full fresh turn.
+        let bMsgs = try await persistence.fetchMessages(for: sessionB.id)
+        let bUser = bMsgs.filter { $0.role == .user }
+        let bAsst = bMsgs.filter { $0.role == .assistant }
+        XCTAssertEqual(bUser.count, 1)
+        XCTAssertEqual(bAsst.count, 1, "B assistant must persist after switch-cancel-resend")
+        XCTAssertEqual(bAsst.first?.content, "beta0 beta1 beta2")
+        for m in bMsgs {
+            XCTAssertFalse(m.content.contains("alpha"), "B must not contain A's alpha tokens")
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `GenerationQueue.discardRequests(notMatching:)` was sync but cancelled `activeTask` whose `defer` block runs async — `switchToSession` returned before the cancellation drained, so session B's `enqueueAsync` could land on a queue mid-tear-down and yield zero events.
- The runtime then hit the `.empty` branch in `runGenerationTurn` and silently dropped B's assistant placeholder without persistence.
- Fix: make `discardRequests` async and `await activeTask?.value` in the session-mismatch branch so the next enqueue is fully serialized behind the dying turn. No new state — `nextGenerationToken` is already monotonic so token reuse cannot happen.

## Release Note

Switching sessions while a generation was streaming could silently drop the next session's assistant turn. The race lived in the inference-service queue: cancellation of the dying turn was issued synchronously but completed asynchronously, so the new session's send could enter a queue mid-tear-down and produce zero token events — which the runtime treated as an "empty response" and dropped without persistence. The queue's discard path now awaits the dying task to completion before returning, fully serializing the next send behind the cancelled one. The runtime additionally emits a diagnostic warning on the empty-response drop branch so a future regression of this kind is observable rather than silent.

## Test plan

- [x] `InterleavingTests.test_sessionSwitch_duringGeneration_noContentLeakage` — `XCTSkipIf` removed, now passes
- [x] 2 new interleaving variants in `InterleavingTests`: `test_sessionSwitch_duringFirstTokenStreaming_persistsBothSessions`, `test_sessionSwitch_afterFirstToken_persistsPartialAndFreshB`
- [x] `SessionDiscardOrderingTests` — N=50 stress loop of switch-cancel-resend
- [x] `EmptyResponseDiagnosticTests` — log/observer fires on sabotage, silent on green
- [x] Sabotage-revert verified: removing `await activeTask?.value` flips `InterleavingTests` and `SessionDiscardOrderingTests` to red
- [x] Full pre-push two-invocation gate: 2566/2566 XCTest + 8/8 Swift Testing all green

## Notes for review

- One pre-push run hit a flake in `ChatViewModelScenePhaseIntegrationTests.test_backgroundTransition_endToEnd_terminatesCleanly` (token-count tolerance is `+2`; saw `+6` once under parallel load alongside a `ChaosBackendTests` crash). Re-run was clean. The test passed 3/3 in isolation. Not introduced by this PR — recommend tracking separately if it recurs.

Closes #965.