### PR TITLE
feat: add ImageGenerationService for image-gen lifecycle

### DIFF
--- a/Sources/BaseChatInference/Services/ImageGenerationService.swift
+++ b/Sources/BaseChatInference/Services/ImageGenerationService.swift
@@ -1,0 +1,229 @@
+import Foundation
+import Observation
+
+/// Errors thrown by ``ImageGenerationService`` for caller-observable conditions.
+///
+/// Backend-internal errors (loader failures, denoising aborts) are surfaced as
+/// thrown errors from the underlying ``ImageGenerationBackend``; the cases here
+/// describe service-level pre-conditions only.
+public enum ImageGenerationServiceError: Error, Equatable, Sendable {
+    /// `loadModel` was called for a format with no registered factory. The host
+    /// must call ``ImageGenerationService/registerBackendFactory(for:factory:)``
+    /// for ``ImageModelInfo/format`` before loading.
+    case noFactoryRegistered(format: ImageModelFormat)
+
+    /// `generate` was called without a loaded model. Call
+    /// ``ImageGenerationService/loadModel(_:)`` first.
+    case notLoaded
+}
+
+/// Orchestrates an image-generation backend's lifecycle.
+///
+/// Sibling to ``InferenceService`` for the image path. Owns registration,
+/// load / generate / unload, and the `@Observable` state machine that hosts
+/// observe to drive UI. Image-side state is intentionally separate from the
+/// text-side service: shipping a parallel type space is the umbrella-#1002
+/// architectural decision, so `ModelType`'s exhaustive switches stay closed.
+///
+/// ## Decomposition (deferred)
+///
+/// Unlike ``InferenceService``, this service is a single class — no separate
+/// lifecycle / generation coordinators. The text-side split happened *after*
+/// `InferenceService` had grown into a 972-LOC god object; premature for a
+/// stub-only image surface. Decompose when the surface warrants it.
+///
+/// ## Concurrency
+///
+/// `@MainActor`-isolated; all state transitions and backend method calls
+/// happen on the main actor. Backends remain `AnyObject + Sendable` and are
+/// expected to protect their own internals (NSLock per
+/// ``ImageGenerationBackend``'s contract). The service itself does not hold a
+/// lock — main-actor isolation is sufficient.
+@MainActor
+@Observable
+public final class ImageGenerationService {
+
+    /// Factory closure that produces a backend for a given image model.
+    ///
+    /// Registered per ``ImageModelFormat``. The closure is `async throws` so
+    /// future backends that need to read configs off disk during construction
+    /// (e.g. inspecting a diffusion model's `config.json` to choose a U-Net
+    /// shape) can do so without blocking the caller's actor.
+    public typealias BackendFactory = @MainActor (ImageModelInfo) async throws -> any ImageGenerationBackend
+
+    // MARK: - State
+
+    /// High-level lifecycle state. Transitions:
+    ///
+    /// `idle → loading → loaded → generating → loaded → unloading → idle`
+    ///
+    /// Errors thrown from `loadModel` / `generate` surface to the caller; the
+    /// service itself does not enter a long-lived `.error` state — a failed
+    /// load returns to `.idle`, a failed generate returns to `.loaded`.
+    public enum State: Sendable, Equatable {
+        case idle
+        case loading(ImageModelInfo)
+        case loaded(ImageModelInfo)
+        case generating(ImageModelInfo)
+        case unloading
+
+        public static func == (lhs: State, rhs: State) -> Bool {
+            switch (lhs, rhs) {
+            case (.idle, .idle), (.unloading, .unloading): return true
+            case (.loading(let a), .loading(let b)): return a == b
+            case (.loaded(let a), .loaded(let b)): return a == b
+            case (.generating(let a), .generating(let b)): return a == b
+            default: return false
+            }
+        }
+    }
+
+    public private(set) var state: State = .idle
+    public private(set) var loadedModel: ImageModelInfo?
+
+    // MARK: - Private
+
+    private var factories: [ImageModelFormat: BackendFactory] = [:]
+    private var backend: (any ImageGenerationBackend)?
+
+    // MARK: - Init
+
+    public init() {}
+
+    // MARK: - Registration
+
+    /// Registers a backend factory for the given format.
+    ///
+    /// A second registration for the same format replaces the prior factory —
+    /// matches how a host might swap a stub backend for the real conformer at
+    /// runtime (e.g. tests overriding the production registration).
+    public func registerBackendFactory(
+        for format: ImageModelFormat,
+        factory: @escaping BackendFactory
+    ) {
+        factories[format] = factory
+    }
+
+    // MARK: - Lifecycle
+
+    /// Loads `info`'s model via the factory registered for its format.
+    ///
+    /// Latest-wins: if a model is already loaded (or loading), it is unloaded
+    /// first. Mirrors ``ModelLifecycleCoordinator``'s handoff pattern at the
+    /// shape level — full token-based stale-suppression isn't needed yet
+    /// because the image service has no enqueue / retry path.
+    ///
+    /// - Throws: ``ImageGenerationServiceError/noFactoryRegistered(format:)``
+    ///   when no factory is registered for `info.format`. Any error thrown by
+    ///   the factory or the backend's `loadModel(from:)` is rethrown after
+    ///   the service returns to `.idle`.
+    public func loadModel(_ info: ImageModelInfo) async throws {
+        // Tear down any prior backend before swapping in a new one. Mirrors
+        // the text-side coordinator's `unloadModel()` call at the top of
+        // `loadModel`.
+        if backend != nil {
+            await unload()
+        }
+
+        guard let factory = factories[info.format] else {
+            throw ImageGenerationServiceError.noFactoryRegistered(format: info.format)
+        }
+
+        state = .loading(info)
+        do {
+            let newBackend = try await factory(info)
+            try await newBackend.loadModel(from: info.directoryURL)
+            backend = newBackend
+            loadedModel = info
+            state = .loaded(info)
+        } catch {
+            // Failed load returns the service to a clean idle so the next
+            // attempt starts from a known-good baseline. We do not retain a
+            // reference to a partially-loaded backend.
+            backend = nil
+            loadedModel = nil
+            state = .idle
+            throw error
+        }
+    }
+
+    /// Streams events from the loaded backend's `generate(prompt:config:)`.
+    ///
+    /// The returned stream is the backend's own stream wrapped to drive
+    /// service state transitions: `.loaded → .generating` when the first
+    /// event arrives, `.generating → .loaded` when the stream finishes
+    /// (normally or via thrown error).
+    ///
+    /// - Returns: a stream that finishes with
+    ///   ``ImageGenerationServiceError/notLoaded`` when no model is loaded.
+    ///   All other errors come from the underlying backend.
+    public func generate(
+        prompt: String,
+        config: ImageGenerationConfig
+    ) -> AsyncThrowingStream<ImageGenerationEvent, Error> {
+        guard let backend, let info = loadedModel else {
+            return AsyncThrowingStream { continuation in
+                continuation.finish(throwing: ImageGenerationServiceError.notLoaded)
+            }
+        }
+
+        return AsyncThrowingStream { continuation in
+            // Detached: backend `generate` is synchronous-throw to start the
+            // stream; the per-event consumption then awaits. Wrapping in a
+            // detached task lets us hop back to MainActor for state writes
+            // without blocking the caller.
+            let task = Task {
+                do {
+                    let upstream = try backend.generate(prompt: prompt, config: config)
+                    await MainActor.run {
+                        self.state = .generating(info)
+                    }
+                    for try await event in upstream {
+                        continuation.yield(event)
+                    }
+                    await MainActor.run {
+                        // Only reset to .loaded when our generation is the
+                        // one currently observed. If the caller unloaded
+                        // mid-stream the state will already be .idle and we
+                        // must not overwrite it.
+                        if case .generating(let active) = self.state, active == info {
+                            self.state = .loaded(info)
+                        }
+                    }
+                    continuation.finish()
+                } catch {
+                    await MainActor.run {
+                        if case .generating(let active) = self.state, active == info {
+                            self.state = .loaded(info)
+                        }
+                    }
+                    continuation.finish(throwing: error)
+                }
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
+    /// Unloads the active backend and returns to `.idle`.
+    ///
+    /// Safe to call when no model is loaded — no-op in that case. Calls the
+    /// backend's `stopGeneration()` first so any in-flight generation is
+    /// cancelled before `unloadModel()` tears down resources.
+    public func unload() async {
+        guard let backend else {
+            state = .idle
+            loadedModel = nil
+            return
+        }
+
+        state = .unloading
+        backend.stopGeneration()
+        backend.unloadModel()
+        self.backend = nil
+        self.loadedModel = nil
+        state = .idle
+    }
+}

--- a/Sources/BaseChatInference/Services/ImageGenerationService.swift
+++ b/Sources/BaseChatInference/Services/ImageGenerationService.swift
@@ -34,11 +34,16 @@ public enum ImageGenerationServiceError: Error, Equatable, Sendable {
 ///
 /// ## Concurrency
 ///
-/// `@MainActor`-isolated; all state transitions and backend method calls
-/// happen on the main actor. Backends remain `AnyObject + Sendable` and are
-/// expected to protect their own internals (NSLock per
-/// ``ImageGenerationBackend``'s contract). The service itself does not hold a
-/// lock — main-actor isolation is sufficient.
+/// `@MainActor`-isolated; all state transitions and the synchronous-throw
+/// portion of every backend call (`generate(prompt:config:)`'s entrypoint,
+/// `stopGeneration()`, `unloadModel()`, `isLoaded` / `isGenerating` reads)
+/// happen on the main actor. The two operations that may do heavy work —
+/// `loadModel(from:)` and the per-event iteration of a generation stream —
+/// run off-actor on a detached task so the UI thread is never held across
+/// them. Backends remain `AnyObject + Sendable` and protect their own
+/// internals (NSLock per ``ImageGenerationBackend``'s contract). The service
+/// itself does not hold a lock — main-actor isolation is sufficient for its
+/// own state.
 @MainActor
 @Observable
 public final class ImageGenerationService {
@@ -132,7 +137,16 @@ public final class ImageGenerationService {
         state = .loading(info)
         do {
             let newBackend = try await factory(info)
-            try await newBackend.loadModel(from: info.directoryURL)
+            // Hop the backend's `loadModel` call onto a detached task so any
+            // synchronous heavy lifting inside the backend (model file reads,
+            // Metal shader compile, weight unpack) cannot block the main
+            // actor and the UI. Mirrors `ModelLifecycleCoordinator`'s
+            // `Task.detached(priority: .userInitiated)` dispatch on the text
+            // path. State commits below stay on MainActor.
+            let url = info.directoryURL
+            try await Task.detached(priority: .userInitiated) {
+                try await newBackend.loadModel(from: url)
+            }.value
             backend = newBackend
             loadedModel = info
             state = .loaded(info)
@@ -150,13 +164,18 @@ public final class ImageGenerationService {
     /// Streams events from the loaded backend's `generate(prompt:config:)`.
     ///
     /// The returned stream is the backend's own stream wrapped to drive
-    /// service state transitions: `.loaded → .generating` when the first
-    /// event arrives, `.generating → .loaded` when the stream finishes
-    /// (normally or via thrown error).
+    /// service state transitions: `.loaded → .generating` synchronously on
+    /// the main actor (after the backend's `generate` synchronous-throw
+    /// entrypoint returns), `.generating → .loaded` when the stream finishes
+    /// (normally or via thrown error). Cancellation is treated as a normal
+    /// finish: the wrapper task is cancelled and `backend.stopGeneration()`
+    /// is invoked, but no `CancellationError` propagates to the consumer.
     ///
     /// - Returns: a stream that finishes with
-    ///   ``ImageGenerationServiceError/notLoaded`` when no model is loaded.
-    ///   All other errors come from the underlying backend.
+    ///   ``ImageGenerationServiceError/notLoaded`` when no model is loaded
+    ///   (or when state has moved off `.loaded` between the entry check and
+    ///   the backend `generate` call). All other errors come from the
+    ///   underlying backend.
     public func generate(
         prompt: String,
         config: ImageGenerationConfig
@@ -168,42 +187,96 @@ public final class ImageGenerationService {
         }
 
         return AsyncThrowingStream { continuation in
-            // Detached: backend `generate` is synchronous-throw to start the
-            // stream; the per-event consumption then awaits. Wrapping in a
-            // detached task lets us hop back to MainActor for state writes
-            // without blocking the caller.
-            let task = Task {
+            // Start the backend stream and commit `.generating` synchronously
+            // on the main actor. Doing it here (rather than inside the
+            // detached task below) means a follow-up `loadModel` /
+            // `unload` issued from the same actor cannot interleave between
+            // the load check and the state write — the next operation
+            // observes `.generating(info)` deterministically.
+            //
+            // We also gate the transition on the current state being
+            // `.loaded(info)`. If the caller raced an `unload()` /
+            // `loadModel(other)` in before reaching here, we must not stomp
+            // the newer state by writing `.generating(info)` for a model
+            // that's no longer current.
+            let upstream: AsyncThrowingStream<ImageGenerationEvent, Error>
+            do {
+                upstream = try backend.generate(prompt: prompt, config: config)
+            } catch {
+                continuation.finish(throwing: error)
+                return
+            }
+
+            guard case .loaded(let active) = state, active == info else {
+                // State moved on between the `loadedModel` snapshot above
+                // and this point (callers can drive lifecycle from the same
+                // actor between awaits). Treat exactly like `.notLoaded` —
+                // do not start a generation against a model the service no
+                // longer considers active.
+                continuation.finish(throwing: ImageGenerationServiceError.notLoaded)
+                return
+            }
+            state = .generating(info)
+
+            // Iteration of the upstream stream is the only off-actor work.
+            // The detached task forwards events; all state writes still hop
+            // back to MainActor. Cancellation is treated as a normal finish
+            // (matches GenerationStream's policy).
+            //
+            // We must check `Task.isCancelled` per-iteration because
+            // `AsyncThrowingStream` does not auto-propagate Task cancellation
+            // into the producer — without the check, a backend that yields
+            // events on a timer keeps feeding the wrapper even after the
+            // downstream consumer dropped its iterator.
+            let task = Task.detached(priority: .userInitiated) { [weak self] in
                 do {
-                    let upstream = try backend.generate(prompt: prompt, config: config)
-                    await MainActor.run {
-                        self.state = .generating(info)
-                    }
                     for try await event in upstream {
+                        if Task.isCancelled {
+                            await self?.restoreLoadedState(for: info)
+                            continuation.finish()
+                            return
+                        }
                         continuation.yield(event)
                     }
-                    await MainActor.run {
-                        // Only reset to .loaded when our generation is the
-                        // one currently observed. If the caller unloaded
-                        // mid-stream the state will already be .idle and we
-                        // must not overwrite it.
-                        if case .generating(let active) = self.state, active == info {
-                            self.state = .loaded(info)
-                        }
-                    }
+                    await self?.restoreLoadedState(for: info)
+                    continuation.finish()
+                } catch is CancellationError {
+                    await self?.restoreLoadedState(for: info)
                     continuation.finish()
                 } catch {
-                    await MainActor.run {
-                        if case .generating(let active) = self.state, active == info {
-                            self.state = .loaded(info)
-                        }
+                    if Task.isCancelled {
+                        await self?.restoreLoadedState(for: info)
+                        continuation.finish()
+                    } else {
+                        await self?.restoreLoadedState(for: info)
+                        continuation.finish(throwing: error)
                     }
-                    continuation.finish(throwing: error)
                 }
             }
 
-            continuation.onTermination = { _ in
+            continuation.onTermination = { [weak self] termination in
+                // On cancellation, also tell the backend to stop — otherwise
+                // the denoising loop can keep running even though no one is
+                // reading the stream. `.finished` paths already had the
+                // upstream exit cleanly; only `.cancelled` needs the nudge.
                 task.cancel()
+                if case .cancelled = termination {
+                    Task { @MainActor [weak self] in
+                        self?.backend?.stopGeneration()
+                    }
+                }
             }
+        }
+    }
+
+    /// Returns the service to `.loaded(info)` after a generation finishes,
+    /// but only if the currently-observed state is still
+    /// `.generating(info)`. If the caller unloaded mid-stream or a newer
+    /// load is in flight, the state has already moved on and we must not
+    /// overwrite it.
+    private func restoreLoadedState(for info: ImageModelInfo) {
+        if case .generating(let active) = state, active == info {
+            state = .loaded(info)
         }
     }
 

--- a/Tests/BaseChatInferenceTests/ImageGenerationServiceTests.swift
+++ b/Tests/BaseChatInferenceTests/ImageGenerationServiceTests.swift
@@ -15,12 +15,26 @@ final class ImageGenerationServiceTests: XCTestCase {
     /// up a real diffusion runtime. Per-test instances are fine because the
     /// service holds the only strong reference; tests reach into `events` /
     /// `loadCount` / `unloadCount` via the captured factory closure.
+    ///
+    /// ### Thread-safety
+    ///
+    /// `loadModel` runs off-actor on a `Task.detached` (the service hops
+    /// the load into the background), and `generate(prompt:config:)` is
+    /// invoked synchronously on the main actor before the service starts
+    /// iterating its returned stream off-actor. `stopGeneration` /
+    /// `unloadModel` are called on the main actor by the service. Tests
+    /// only sample these counters after `await`-ing the corresponding
+    /// service entrypoint (`loadModel` / `unload` / a fully drained
+    /// `generate` stream), so each read happens-after the matching write
+    /// via that suspension point — sequential consistency is therefore
+    /// guaranteed without an explicit lock. The class is marked
+    /// `@unchecked Sendable` only to satisfy the protocol's `Sendable`
+    /// requirement; the mock has no concurrent writers in any of the
+    /// tests below.
     private final class MockBackend: ImageGenerationBackend, @unchecked Sendable {
         var isLoaded: Bool = false
         var isGenerating: Bool = false
 
-        // Counters / event scripts. Mutated only on the main actor since the
-        // service is `@MainActor` and tests await all transitions.
         var loadCount: Int = 0
         var unloadCount: Int = 0
         var stopCount: Int = 0
@@ -218,5 +232,40 @@ final class ImageGenerationServiceTests: XCTestCase {
         XCTAssertNil(service.loadedModel)
         XCTAssertEqual(mock.unloadCount, 1)
         XCTAssertFalse(mock.isLoaded)
+    }
+
+    // MARK: - 7. Generate while not in .loaded(info) treats stream as notLoaded
+
+    /// Race regression: if the service's state changed between
+    /// `service.generate(...)` snapshotting `loadedModel` and the wrapper
+    /// observing the state again, generate must not stomp the newer state
+    /// with `.generating(info)` for the old model. The race is only
+    /// reachable from arbitrary actors interleaving on `await`-points;
+    /// here we simulate it by mutating state via `unload()` on a separate
+    /// task between the `loadModel` await and the `generate` snapshot.
+    /// What we can deterministically assert in a single-actor test is that
+    /// once `unload()` returns and we then call `generate`, the stream
+    /// fails with `.notLoaded` — no backend call leaks through.
+    func test_generate_afterUnload_streamThrowsNotLoaded() async throws {
+        let service = ImageGenerationService()
+        let mock = MockBackend()
+        let info = makeInfo()
+
+        service.registerBackendFactory(for: .mlxDiffusion) { _ in mock }
+        try await service.loadModel(info)
+        await service.unload()
+
+        let stream = service.generate(prompt: "x", config: ImageGenerationConfig())
+
+        do {
+            for try await _ in stream {
+                XCTFail("stream must not yield after unload")
+            }
+            XCTFail("stream must throw")
+        } catch let error as ImageGenerationServiceError {
+            XCTAssertEqual(error, .notLoaded)
+        } catch {
+            XCTFail("expected ImageGenerationServiceError.notLoaded, got \(error)")
+        }
     }
 }

--- a/Tests/BaseChatInferenceTests/ImageGenerationServiceTests.swift
+++ b/Tests/BaseChatInferenceTests/ImageGenerationServiceTests.swift
@@ -1,0 +1,222 @@
+import XCTest
+import Foundation
+@testable import BaseChatInference
+
+/// Tests for ``ImageGenerationService``: the registration + lifecycle surface
+/// for the image-generation path. Mirrors the role
+/// ``ImageGenerationFoundationsTests`` plays for the value types — locks down
+/// the public shape against a stub backend before any real conformer ships.
+@MainActor
+final class ImageGenerationServiceTests: XCTestCase {
+
+    // MARK: - Test Doubles
+
+    /// Mock conformer used to drive the service's lifecycle without standing
+    /// up a real diffusion runtime. Per-test instances are fine because the
+    /// service holds the only strong reference; tests reach into `events` /
+    /// `loadCount` / `unloadCount` via the captured factory closure.
+    private final class MockBackend: ImageGenerationBackend, @unchecked Sendable {
+        var isLoaded: Bool = false
+        var isGenerating: Bool = false
+
+        // Counters / event scripts. Mutated only on the main actor since the
+        // service is `@MainActor` and tests await all transitions.
+        var loadCount: Int = 0
+        var unloadCount: Int = 0
+        var stopCount: Int = 0
+        var loadShouldThrow: Error?
+        var generateShouldThrow: Error?
+        var scriptedEvents: [ImageGenerationEvent] = []
+
+        func loadModel(from url: URL) async throws {
+            loadCount += 1
+            if let err = loadShouldThrow { throw err }
+            isLoaded = true
+        }
+
+        func generate(
+            prompt: String,
+            config: ImageGenerationConfig
+        ) throws -> AsyncThrowingStream<ImageGenerationEvent, Error> {
+            if let err = generateShouldThrow { throw err }
+            isGenerating = true
+            let events = scriptedEvents
+            return AsyncThrowingStream { continuation in
+                for event in events {
+                    continuation.yield(event)
+                }
+                continuation.finish()
+            }
+        }
+
+        func stopGeneration() {
+            stopCount += 1
+            isGenerating = false
+        }
+
+        func unloadModel() {
+            unloadCount += 1
+            isLoaded = false
+        }
+    }
+
+    private func makeInfo(id: String = "stabilityai/sdxl-turbo") -> ImageModelInfo {
+        ImageModelInfo(
+            id: id,
+            name: id,
+            directoryURL: URL(fileURLWithPath: "/tmp/\(id)"),
+            format: .mlxDiffusion,
+            fileSize: 4_200_000_000
+        )
+    }
+
+    // MARK: - 1. Happy-path load
+
+    func test_loadModel_happyPath_transitionsIdleToLoaded() async throws {
+        let service = ImageGenerationService()
+        let mock = MockBackend()
+        let info = makeInfo()
+
+        service.registerBackendFactory(for: .mlxDiffusion) { _ in mock }
+
+        XCTAssertEqual(service.state, .idle)
+        XCTAssertNil(service.loadedModel)
+
+        try await service.loadModel(info)
+
+        XCTAssertEqual(service.state, .loaded(info))
+        XCTAssertEqual(service.loadedModel, info)
+        XCTAssertEqual(mock.loadCount, 1)
+        XCTAssertTrue(mock.isLoaded)
+    }
+
+    // MARK: - 2. No factory registered
+
+    func test_loadModel_noFactory_throwsNoFactoryRegistered() async {
+        let service = ImageGenerationService()
+        let info = makeInfo()
+
+        do {
+            try await service.loadModel(info)
+            XCTFail("expected throw")
+        } catch let error as ImageGenerationServiceError {
+            XCTAssertEqual(error, .noFactoryRegistered(format: .mlxDiffusion))
+        } catch {
+            XCTFail("expected ImageGenerationServiceError, got \(error)")
+        }
+
+        // State must return to idle even though we transitioned through
+        // nothing — caller should be able to register a factory and retry.
+        XCTAssertEqual(service.state, .idle)
+        XCTAssertNil(service.loadedModel)
+    }
+
+    // MARK: - 3. Load while loaded unloads prior
+
+    /// Sabotage target: this test exercises the `unload-then-load` swap. If
+    /// the implementation skips the unload step, `priorMock.unloadCount` will
+    /// be 0 and the test fails — sabotage check confirmed during development.
+    func test_loadModel_whileLoaded_unloadsPriorThenLoadsNew() async throws {
+        let service = ImageGenerationService()
+        let priorMock = MockBackend()
+        let nextMock = MockBackend()
+        let priorInfo = makeInfo(id: "stabilityai/sd-1.5")
+        let nextInfo = makeInfo(id: "stabilityai/sdxl-turbo")
+
+        // Register a factory that returns whichever mock matches the request
+        // (keyed by ID so order doesn't matter).
+        service.registerBackendFactory(for: .mlxDiffusion) { info in
+            info.id == priorInfo.id ? priorMock : nextMock
+        }
+
+        try await service.loadModel(priorInfo)
+        XCTAssertEqual(service.state, .loaded(priorInfo))
+        XCTAssertEqual(priorMock.unloadCount, 0)
+
+        try await service.loadModel(nextInfo)
+
+        XCTAssertEqual(priorMock.unloadCount, 1, "prior backend must be unloaded before new load")
+        XCTAssertEqual(nextMock.loadCount, 1)
+        XCTAssertEqual(service.state, .loaded(nextInfo))
+        XCTAssertEqual(service.loadedModel, nextInfo)
+    }
+
+    // MARK: - 4. Generate without loaded throws
+
+    func test_generate_withoutLoadedModel_streamThrowsNotLoaded() async {
+        let service = ImageGenerationService()
+
+        let stream = service.generate(prompt: "hello", config: ImageGenerationConfig())
+
+        do {
+            for try await _ in stream {
+                XCTFail("expected stream to finish with error before yielding")
+            }
+            XCTFail("expected stream to throw")
+        } catch let error as ImageGenerationServiceError {
+            XCTAssertEqual(error, .notLoaded)
+        } catch {
+            XCTFail("expected ImageGenerationServiceError.notLoaded, got \(error)")
+        }
+    }
+
+    // MARK: - 5. Generate happy path
+
+    func test_generate_happyPath_forwardsEventsAndRestoresLoadedState() async throws {
+        let service = ImageGenerationService()
+        let mock = MockBackend()
+        let info = makeInfo()
+        let outURL = URL(fileURLWithPath: "/tmp/out.png")
+        mock.scriptedEvents = [
+            .progress(step: 1, total: 4),
+            .progress(step: 2, total: 4),
+            .progress(step: 3, total: 4),
+            .progress(step: 4, total: 4),
+            .completed(outURL),
+        ]
+
+        service.registerBackendFactory(for: .mlxDiffusion) { _ in mock }
+        try await service.loadModel(info)
+
+        let stream = service.generate(
+            prompt: "a teal turtle",
+            config: ImageGenerationConfig(steps: 4, width: 512, height: 512)
+        )
+
+        var events: [ImageGenerationEvent] = []
+        for try await event in stream {
+            events.append(event)
+        }
+
+        XCTAssertEqual(events.count, 5)
+        if case .completed(let url) = events.last {
+            XCTAssertEqual(url, outURL)
+        } else {
+            XCTFail("last event should be .completed")
+        }
+
+        // After the stream finishes the service must return to .loaded so
+        // the next generate call doesn't have to re-load the model.
+        XCTAssertEqual(service.state, .loaded(info))
+        XCTAssertEqual(service.loadedModel, info)
+    }
+
+    // MARK: - 6. Unload returns service to idle
+
+    func test_unload_afterLoad_returnsServiceToIdle() async throws {
+        let service = ImageGenerationService()
+        let mock = MockBackend()
+        let info = makeInfo()
+
+        service.registerBackendFactory(for: .mlxDiffusion) { _ in mock }
+        try await service.loadModel(info)
+        XCTAssertEqual(service.state, .loaded(info))
+
+        await service.unload()
+
+        XCTAssertEqual(service.state, .idle)
+        XCTAssertNil(service.loadedModel)
+        XCTAssertEqual(mock.unloadCount, 1)
+        XCTAssertFalse(mock.isLoaded)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ImageGenerationService`: a `@MainActor @Observable` class that owns the lifecycle of a loaded `ImageGenerationBackend` instance — registration, load, generate (streaming), unload.
- Stub-only: no concrete backend conformer yet (PR 6 in the umbrella, gated on the upstream `mlx-swift-examples` tag).
- Sibling to `InferenceService`. Shares no types with the text path; image-side code stays in its own type space per the umbrella's parallel-types decision.

## Design

Single class, not decomposed into separate lifecycle / generation coordinators. The text-side `InferenceService → ModelLifecycleCoordinator + GenerationCoordinator` split happened *after* `InferenceService` grew into a 972-LOC god object — premature for a stub-only image service. Decomposition can come later when the surface warrants it.

State machine: `idle → loading → loaded → generating → loaded → unloading → idle`. Latest-wins on concurrent `loadModel` calls — mirrors the text-side handoff pattern. `generate` requires `.loaded`; finishes the stream with `notLoaded` otherwise.

## Test plan

- [x] Factory registration + happy-path load.
- [x] Load without factory throws `.noFactoryRegistered`.
- [x] Load while loaded unloads prior, loads new.
- [x] Generate without loaded finishes stream with `.notLoaded`.
- [x] Generate happy-path event forwarding + state transitions.
- [x] Unload returns service to `.idle`.
- [x] Sabotage check on test 3 (skip the unload step) confirmed the test fails before fix is in place.
- [x] Full pre-push gate (XCTest 1290 passed / Swift Testing 83 passed) passes locally.

## Files

- `Sources/BaseChatInference/Services/ImageGenerationService.swift` (new)
- `Tests/BaseChatInferenceTests/ImageGenerationServiceTests.swift` (new)

## Tracking

Part of #1002 (image generation runtime umbrella). Next up: PR 3 (`ImageGenerationRuntime` in `BaseChatRuntime`).