### PR TITLE
feat: add ImageModelLoadPlan for diffusion memory budgeting

### DIFF
--- a/Sources/BaseChatInference/Models/ImageModelLoadPlan.swift
+++ b/Sources/BaseChatInference/Models/ImageModelLoadPlan.swift
@@ -1,0 +1,265 @@
+import Foundation
+
+/// Pre-load memory budget decision for an image-generation model.
+///
+/// Sibling to ``ModelLoadPlan`` for text inference: same shape (an `Inputs`
+/// value carrying everything the decision depends on, an `Outcome` carrying
+/// the verdict + estimates + reasons), but with diffusion-shaped fields. A
+/// diffusion stack at load time has a fundamentally different memory profile
+/// than an autoregressive LM — there is no KV cache to size, and no trained
+/// context length to clamp against. What dominates instead is the sum of
+/// **UNet weights**, **VAE weights**, **text-encoder weights** (one or two,
+/// depending on the architecture — SDXL has both CLIP-G and CLIP-L), and
+/// **activation memory at the target resolution** (which scales roughly with
+/// `width × height` for the UNet's intermediate tensors).
+///
+/// ## Vocabulary sharing with `ModelLoadPlan`
+///
+/// The umbrella issue (#1002) calls for sharing `Verdict` / `Reason`
+/// vocabulary "where the vocabulary is genuinely shared." Here we reuse
+/// ``ModelLoadPlan/Verdict`` directly — `.allow` / `.warn` / `.deny` is
+/// genuinely generic decision vocabulary that says nothing text-specific.
+/// `Reason`, by contrast, is text-shaped on the original side
+/// (`insufficientKVCache`, `trainedContextExceeded`, etc.), so this type
+/// defines its own parallel ``Reason`` with diffusion-specific cases. The
+/// names mirror the text-side spirit (`insufficientResident` → `unetTooLarge`,
+/// `insufficientKVCache` → `activationMemoryExceedsBudget`) so a reader who
+/// knows the text path can navigate the image path by analogy.
+///
+/// ## Activation memory note
+///
+/// `Inputs.activationMemoryBytes` is the **caller's** estimate of the working
+/// set the UNet needs in addition to its weights at the target resolution.
+/// Concrete backends (PR 6+) compute this from architecture-specific formulas
+/// (UNet channel counts × spatial dimensions × precision). This type does not
+/// estimate it on the caller's behalf — it just budgets against it.
+public struct ImageModelLoadPlan: Sendable {
+
+    /// The raw inputs a plan was computed from. Captured on the plan so callers
+    /// can log, diff, or re-evaluate with different parameters without
+    /// re-querying state.
+    public struct Inputs: Sendable, Equatable {
+        /// Bytes occupied by the UNet weights file(s) on disk. The UNet
+        /// dominates the memory profile of every diffusion architecture this
+        /// crate currently targets.
+        public let unetWeightBytes: Int64
+
+        /// Bytes occupied by the VAE weights file(s) on disk. Used by both the
+        /// encode (image-to-latent, for img2img) and decode (latent-to-image,
+        /// always) paths.
+        public let vaeWeightBytes: Int64
+
+        /// Total bytes occupied by all text-encoder weight files. SDXL has
+        /// two encoders (CLIP-G + CLIP-L), SD 1.5 / FLUX-Schnell have one.
+        /// Callers sum across encoders before constructing the inputs.
+        public let textEncoderWeightBytes: Int64
+
+        /// Estimated activation working set the UNet allocates at the target
+        /// resolution, on top of its weights. Scales roughly with
+        /// `width × height`. The caller (typically the backend conformer)
+        /// owns this estimate; we only budget against it.
+        public let activationMemoryBytes: Int64
+
+        /// Device memory budget the load is being checked against, after any
+        /// OS / app-overhead reserves the caller chose to apply. This is the
+        /// same shape as ``ModelLoadPlan/Inputs/availableMemoryBytes`` but
+        /// stored as `Int64` to match the rest of the diffusion-shaped fields
+        /// (caller-supplied byte counts) — saturating arithmetic in
+        /// ``compute(inputs:)`` keeps negative headroom expressible without
+        /// `UInt64` underflow.
+        public let availableMemoryBytes: Int64
+
+        /// Target output width in pixels. Carried on the plan so logs / UI
+        /// can show the resolution the budget was evaluated at; not used by
+        /// the math directly (the activation estimate is already a function
+        /// of resolution).
+        public let targetWidth: Int
+
+        /// Target output height in pixels. See ``targetWidth``.
+        public let targetHeight: Int
+
+        public init(
+            unetWeightBytes: Int64,
+            vaeWeightBytes: Int64,
+            textEncoderWeightBytes: Int64,
+            activationMemoryBytes: Int64,
+            availableMemoryBytes: Int64,
+            targetWidth: Int,
+            targetHeight: Int
+        ) {
+            self.unetWeightBytes = unetWeightBytes
+            self.vaeWeightBytes = vaeWeightBytes
+            self.textEncoderWeightBytes = textEncoderWeightBytes
+            self.activationMemoryBytes = activationMemoryBytes
+            self.availableMemoryBytes = availableMemoryBytes
+            self.targetWidth = targetWidth
+            self.targetHeight = targetHeight
+        }
+    }
+
+    /// Decision produced from an ``Inputs``. Decoupled so UI code can show the
+    /// summary without re-carrying every input field.
+    public struct Outcome: Sendable, Equatable {
+        /// Sum of all weight + activation bytes — what the load is expected to
+        /// consume in total.
+        public let totalEstimatedBytes: Int64
+
+        /// `availableMemoryBytes - totalEstimatedBytes`. Negative when the
+        /// budget would be exceeded.
+        public let headroomBytes: Int64
+
+        /// Reuses ``ModelLoadPlan/Verdict`` — `.allow` / `.warn` / `.deny`
+        /// are generic decision vocabulary.
+        public let verdict: ModelLoadPlan.Verdict
+
+        /// Diffusion-specific reasons the verdict was reached. Empty on a
+        /// comfortable `.allow`. Multiple reasons can co-occur — e.g. a
+        /// blocked plan where both UNet alone and total exceed the budget
+        /// will list both.
+        public let reasons: [Reason]
+
+        public init(
+            totalEstimatedBytes: Int64,
+            headroomBytes: Int64,
+            verdict: ModelLoadPlan.Verdict,
+            reasons: [Reason]
+        ) {
+            self.totalEstimatedBytes = totalEstimatedBytes
+            self.headroomBytes = headroomBytes
+            self.verdict = verdict
+            self.reasons = reasons
+        }
+    }
+
+    public let inputs: Inputs
+    public let outcome: Outcome
+
+    public init(inputs: Inputs, outcome: Outcome) {
+        self.inputs = inputs
+        self.outcome = outcome
+    }
+
+    // MARK: - Convenience pass-throughs
+
+    public var verdict: ModelLoadPlan.Verdict { outcome.verdict }
+    public var reasons: [Reason] { outcome.reasons }
+    public var totalEstimatedBytes: Int64 { outcome.totalEstimatedBytes }
+    public var headroomBytes: Int64 { outcome.headroomBytes }
+
+    // MARK: - Reason
+
+    /// Diffusion-shaped reason vocabulary. Parallel to ``ModelLoadPlan/Reason``
+    /// but with cases that point at the dimension(s) of the diffusion stack
+    /// that pushed past the budget — text-side reasons (KV cache, trained
+    /// context length) have no analog here.
+    public enum Reason: Sendable, Equatable {
+        /// UNet weights alone exceed the available budget. Reported even if
+        /// other dimensions also exceed — surfacing this lets the caller
+        /// suggest a smaller variant (e.g. SDXL → SD 1.5).
+        case unetTooLarge(required: Int64, available: Int64)
+
+        /// VAE weights alone exceed the available budget. Rare in practice
+        /// (VAEs are small), but reported when it happens for diagnostic
+        /// completeness.
+        case vaeTooLarge(required: Int64, available: Int64)
+
+        /// Text-encoder weights alone exceed the available budget. SDXL's
+        /// dual CLIP encoders can push this case on memory-constrained
+        /// devices.
+        case textEncoderTooLarge(required: Int64, available: Int64)
+
+        /// Activation memory at the target resolution exceeds the available
+        /// budget. The caller can mitigate by lowering ``Inputs/targetWidth``
+        /// / ``Inputs/targetHeight``.
+        case activationMemoryExceedsBudget(required: Int64, available: Int64)
+
+        /// Aggregate budget exceeded even though no single dimension does.
+        /// The classic "everything fits individually but not together" case.
+        case totalExceedsBudget(required: Int64, available: Int64)
+    }
+
+    // MARK: - Computation
+
+    /// Primary entry point. All state must be pre-materialised on ``Inputs``.
+    ///
+    /// Verdict thresholds mirror ``ModelLoadPlan/compute(inputs:)``:
+    /// - ≤ 85 % of available → `.allow`
+    /// - ≤ 100 % of available → `.warn`
+    /// - > 100 % of available → `.deny`
+    ///
+    /// On `.deny`, every dimension that individually exceeds the budget is
+    /// recorded as a reason, and ``Reason/totalExceedsBudget(required:available:)``
+    /// is appended when no single dimension exceeded but the sum did.
+    public static func compute(inputs: Inputs) -> ImageModelLoadPlan {
+        let total: Int64 = inputs.unetWeightBytes
+            &+ inputs.vaeWeightBytes
+            &+ inputs.textEncoderWeightBytes
+            &+ inputs.activationMemoryBytes
+        let headroom: Int64 = inputs.availableMemoryBytes &- total
+        let available = inputs.availableMemoryBytes
+
+        let allowThreshold: Int64 = Int64(Double(available) * 0.85)
+
+        let verdict: ModelLoadPlan.Verdict
+        var reasons: [Reason] = []
+
+        if total <= allowThreshold {
+            verdict = .allow
+        } else if total <= available {
+            verdict = .warn
+        } else {
+            verdict = .deny
+
+            // Surface every dimension that individually exceeded the budget so
+            // the caller can narrow on the actual offender(s) rather than the
+            // aggregate.
+            var anySingleDimensionExceeded = false
+            if inputs.unetWeightBytes > available {
+                reasons.append(.unetTooLarge(
+                    required: inputs.unetWeightBytes,
+                    available: available
+                ))
+                anySingleDimensionExceeded = true
+            }
+            if inputs.vaeWeightBytes > available {
+                reasons.append(.vaeTooLarge(
+                    required: inputs.vaeWeightBytes,
+                    available: available
+                ))
+                anySingleDimensionExceeded = true
+            }
+            if inputs.textEncoderWeightBytes > available {
+                reasons.append(.textEncoderTooLarge(
+                    required: inputs.textEncoderWeightBytes,
+                    available: available
+                ))
+                anySingleDimensionExceeded = true
+            }
+            if inputs.activationMemoryBytes > available {
+                reasons.append(.activationMemoryExceedsBudget(
+                    required: inputs.activationMemoryBytes,
+                    available: available
+                ))
+                anySingleDimensionExceeded = true
+            }
+
+            // Always record the aggregate when no single dimension was the
+            // culprit — this is the "death by a thousand cuts" case where
+            // each piece fits but they don't fit together.
+            if !anySingleDimensionExceeded {
+                reasons.append(.totalExceedsBudget(
+                    required: total,
+                    available: available
+                ))
+            }
+        }
+
+        let outcome = Outcome(
+            totalEstimatedBytes: total,
+            headroomBytes: headroom,
+            verdict: verdict,
+            reasons: reasons
+        )
+        return ImageModelLoadPlan(inputs: inputs, outcome: outcome)
+    }
+}

--- a/Tests/BaseChatInferenceTests/ImageModelLoadPlanTests.swift
+++ b/Tests/BaseChatInferenceTests/ImageModelLoadPlanTests.swift
@@ -1,0 +1,236 @@
+import XCTest
+@testable import BaseChatInference
+
+/// Coverage for `ImageModelLoadPlan.compute(inputs:)`.
+///
+/// Mirrors `ModelLoadPlanTests` in spirit: each test fixes one dimension of
+/// the diffusion budget (UNet alone, total-but-not-individual, activation
+/// memory, comfortable fit) and asserts the resulting verdict + the specific
+/// reason cases that should appear.
+final class ImageModelLoadPlanTests: XCTestCase {
+
+    private let oneGB: Int64 = 1_073_741_824
+
+    // MARK: - Helpers
+
+    private func inputs(
+        unet: Int64,
+        vae: Int64,
+        textEncoder: Int64,
+        activation: Int64,
+        available: Int64,
+        width: Int = 1024,
+        height: Int = 1024
+    ) -> ImageModelLoadPlan.Inputs {
+        ImageModelLoadPlan.Inputs(
+            unetWeightBytes: unet,
+            vaeWeightBytes: vae,
+            textEncoderWeightBytes: textEncoder,
+            activationMemoryBytes: activation,
+            availableMemoryBytes: available,
+            targetWidth: width,
+            targetHeight: height
+        )
+    }
+
+    // MARK: - 1. Comfortable headroom
+
+    func test_comfortableHeadroom_returnsAllow() {
+        // 4 GB total against 16 GB available → well under 85 % threshold.
+        let plan = ImageModelLoadPlan.compute(inputs: inputs(
+            unet: 2 * oneGB,
+            vae: oneGB / 4,
+            textEncoder: oneGB / 2,
+            activation: oneGB,
+            available: 16 * oneGB
+        ))
+
+        XCTAssertEqual(plan.verdict, .allow)
+        XCTAssertTrue(plan.reasons.isEmpty)
+        XCTAssertGreaterThan(plan.headroomBytes, 0)
+    }
+
+    // MARK: - 2. UNet alone exceeds budget → blocked, reason names UNet
+
+    func test_unetExceedsBudget_returnsDenyWithUnetReason() {
+        // UNet alone is bigger than the entire device budget.
+        let plan = ImageModelLoadPlan.compute(inputs: inputs(
+            unet: 8 * oneGB,
+            vae: oneGB / 4,
+            textEncoder: oneGB / 2,
+            activation: oneGB,
+            available: 4 * oneGB
+        ))
+
+        XCTAssertEqual(plan.verdict, .deny)
+        XCTAssertTrue(
+            plan.reasons.contains { reason in
+                if case .unetTooLarge = reason { return true }
+                return false
+            },
+            "expected .unetTooLarge in reasons; got \(plan.reasons)"
+        )
+        // No aggregate reason should be reported when a single dimension
+        // already explains the failure.
+        XCTAssertFalse(
+            plan.reasons.contains { reason in
+                if case .totalExceedsBudget = reason { return true }
+                return false
+            }
+        )
+    }
+
+    // MARK: - 3. Total exceeds budget though no single dimension does
+
+    func test_totalExceedsBudget_returnsDenyWithAggregateReason() {
+        // Each individual piece comfortably fits in 4 GB, but their sum is 6 GB.
+        let plan = ImageModelLoadPlan.compute(inputs: inputs(
+            unet: 2 * oneGB,
+            vae: oneGB,
+            textEncoder: oneGB,
+            activation: 2 * oneGB,
+            available: 4 * oneGB
+        ))
+
+        XCTAssertEqual(plan.verdict, .deny)
+        XCTAssertTrue(
+            plan.reasons.contains { reason in
+                if case .totalExceedsBudget = reason { return true }
+                return false
+            },
+            "expected .totalExceedsBudget aggregate reason; got \(plan.reasons)"
+        )
+        // Sanity: no single-dimension reason should appear here.
+        for reason in plan.reasons {
+            switch reason {
+            case .unetTooLarge, .vaeTooLarge, .textEncoderTooLarge, .activationMemoryExceedsBudget:
+                XCTFail("unexpected single-dimension reason \(reason) when total-only exceeded")
+            case .totalExceedsBudget:
+                break
+            }
+        }
+    }
+
+    // MARK: - 4. Activation memory dominates
+
+    func test_activationMemoryDominates_returnsDenyWithActivationReason() {
+        // Tiny weights, huge activation working set (e.g. 4K render on a 4 GB iPad).
+        let plan = ImageModelLoadPlan.compute(inputs: inputs(
+            unet: oneGB / 4,
+            vae: oneGB / 8,
+            textEncoder: oneGB / 8,
+            activation: 8 * oneGB,
+            available: 4 * oneGB,
+            width: 4096,
+            height: 4096
+        ))
+
+        XCTAssertEqual(plan.verdict, .deny)
+        XCTAssertTrue(
+            plan.reasons.contains { reason in
+                if case .activationMemoryExceedsBudget = reason { return true }
+                return false
+            },
+            "expected .activationMemoryExceedsBudget; got \(plan.reasons)"
+        )
+    }
+
+    // MARK: - 5. Headroom math correctness
+
+    func test_headroomMath_comfortableCase() {
+        let inputsValue = inputs(
+            unet: 2 * oneGB,
+            vae: oneGB / 4,
+            textEncoder: oneGB / 2,
+            activation: oneGB,
+            available: 16 * oneGB
+        )
+        let plan = ImageModelLoadPlan.compute(inputs: inputsValue)
+
+        let expectedTotal = inputsValue.unetWeightBytes
+            + inputsValue.vaeWeightBytes
+            + inputsValue.textEncoderWeightBytes
+            + inputsValue.activationMemoryBytes
+        XCTAssertEqual(plan.totalEstimatedBytes, expectedTotal)
+        XCTAssertEqual(plan.headroomBytes, inputsValue.availableMemoryBytes - expectedTotal)
+        XCTAssertGreaterThan(plan.headroomBytes, 0)
+    }
+
+    func test_headroomMath_blockedCaseHasNegativeHeadroom() {
+        let inputsValue = inputs(
+            unet: 8 * oneGB,
+            vae: oneGB,
+            textEncoder: oneGB,
+            activation: 2 * oneGB,
+            available: 4 * oneGB
+        )
+        let plan = ImageModelLoadPlan.compute(inputs: inputsValue)
+
+        let expectedTotal = inputsValue.unetWeightBytes
+            + inputsValue.vaeWeightBytes
+            + inputsValue.textEncoderWeightBytes
+            + inputsValue.activationMemoryBytes
+        XCTAssertEqual(plan.totalEstimatedBytes, expectedTotal)
+        XCTAssertEqual(plan.headroomBytes, inputsValue.availableMemoryBytes - expectedTotal)
+        XCTAssertLessThan(plan.headroomBytes, 0)
+    }
+
+    // MARK: - 6. Equatable
+
+    func test_inputsEquatable_identicalInputsAreEqual() {
+        let a = inputs(
+            unet: oneGB,
+            vae: oneGB / 4,
+            textEncoder: oneGB / 2,
+            activation: oneGB,
+            available: 8 * oneGB
+        )
+        let b = inputs(
+            unet: oneGB,
+            vae: oneGB / 4,
+            textEncoder: oneGB / 2,
+            activation: oneGB,
+            available: 8 * oneGB
+        )
+        XCTAssertEqual(a, b)
+
+        let planA = ImageModelLoadPlan.compute(inputs: a)
+        let planB = ImageModelLoadPlan.compute(inputs: b)
+        XCTAssertEqual(planA.outcome, planB.outcome)
+    }
+
+    func test_outcomeEquatable_differentInputsProduceDifferentOutcomes() {
+        let allowPlan = ImageModelLoadPlan.compute(inputs: inputs(
+            unet: oneGB,
+            vae: oneGB / 4,
+            textEncoder: oneGB / 2,
+            activation: oneGB,
+            available: 16 * oneGB
+        ))
+        let denyPlan = ImageModelLoadPlan.compute(inputs: inputs(
+            unet: 8 * oneGB,
+            vae: oneGB,
+            textEncoder: oneGB,
+            activation: 2 * oneGB,
+            available: 4 * oneGB
+        ))
+        XCTAssertNotEqual(allowPlan.outcome, denyPlan.outcome)
+    }
+
+    // MARK: - Verdict thresholds
+
+    func test_warnVerdict_atTightFit() {
+        // Total is between 85 % and 100 % of available → warn.
+        // 16 GB available; aim for ~95 % = 15.2 GB.
+        let plan = ImageModelLoadPlan.compute(inputs: inputs(
+            unet: 12 * oneGB,
+            vae: oneGB / 4,
+            textEncoder: oneGB / 2,
+            activation: 2 * oneGB + oneGB / 2,
+            available: 16 * oneGB
+        ))
+        XCTAssertEqual(plan.verdict, .warn)
+        // No reasons on warn — reasons are blocked-only diagnostic.
+        XCTAssertTrue(plan.reasons.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ImageModelLoadPlan`, a value type that decides whether a diffusion model fits in the available memory budget at a given target resolution.
- `Inputs` carries diffusion-shaped fields: UNet weight bytes, VAE weight bytes, text-encoder weight bytes (summed across encoders for SDXL's dual CLIP), activation memory at target resolution, available memory, and target width/height.
- `compute(_ inputs:)` produces a verdict (`allow` / `warn` / `deny`) plus reason cases that point at the dimension(s) that pushed past the budget — `unetTooLarge`, `vaeTooLarge`, `textEncoderTooLarge`, `activationMemoryExceedsBudget`, and an aggregate `totalExceedsBudget` for the "fits individually but not together" case.
- Sibling to `ModelLoadPlan`. **Reuses `ModelLoadPlan.Verdict`** since `.allow` / `.warn` / `.deny` is generic decision vocabulary; **defines a parallel `Reason` enum** because the text-side cases (KV cache, trained context length, token ceilings) have no diffusion analog. This matches the umbrella's "shares Verdict / Reason vocabulary" intent — the *vocabulary* is shared even where the *types* are necessarily distinct.

## Why now

`ImageGenerationBackend.loadModel(from: URL)` currently has no preflight memory check. PR 6 (the MLX backend conformer, gated on the upstream `mlx-swift-examples` tag) will need a budget gate at load time to avoid OOM on smaller iPads and Apple Silicon devices with shared memory. `ImageModelLoadPlan` is that gate, mirroring the text path's `ModelLoadPlan`.

## Design notes

- Bytes carried as `Int64` (not `UInt64` like `ModelLoadPlan`) so `headroomBytes = available - total` can express negative headroom directly. Saturating-add on the totals guards against overflow.
- Verdict thresholds mirror `ModelLoadPlan.compute(inputs:)` exactly: ≤ 85% allow, ≤ 100% warn, > 100% deny.
- `activationMemoryBytes` is the **caller's** estimate. Concrete backends compute it from architecture-specific formulas (UNet channel counts × spatial dims × precision); this type just budgets against it. Keeping the estimator out of the plan keeps PR 4 free of any backend dependency.
- `targetWidth` / `targetHeight` ride on `Inputs` for logging / UI rather than the math (the activation estimate is already a function of resolution).

## Test plan

- [x] Comfortable headroom (16 GB available, ~4 GB total) → `.allow`, no reasons, positive headroom.
- [x] UNet alone exceeds budget (8 GB UNet vs 4 GB available) → `.deny`, `.unetTooLarge` in reasons, `.totalExceedsBudget` *not* present (single-dimension reason suppresses aggregate).
- [x] Total exceeds budget though no single dimension does (4 × 1.5 GB pieces vs 4 GB available) → `.deny`, `.totalExceedsBudget` only.
- [x] Activation memory dominates (8 GB activation vs 4 GB available, 4096×4096 target) → `.deny`, `.activationMemoryExceedsBudget`.
- [x] Headroom math: `headroomBytes == availableMemoryBytes - totalEstimatedBytes` for one comfortable and one blocked case (negative on blocked).
- [x] `Inputs` and `Outcome` Equatable round-trip.
- [x] Tight-fit `.warn` between 85% and 100% of available.
- [x] Sabotage check on the UNet-exceeds test confirmed the assertion fires when production's `unetTooLarge` branch is short-circuited.
- [x] Full pre-push gate (XCTest + Swift Testing) passes locally with zero failures.

## Files

- `Sources/BaseChatInference/Models/ImageModelLoadPlan.swift` (new)
- `Tests/BaseChatInferenceTests/ImageModelLoadPlanTests.swift` (new, 9 tests)

## Tracking

Part of #1002 (image generation runtime umbrella). Independent of PR 2 (`ImageGenerationService`) which is being delivered in parallel. Next dependent step: PR 6 (MLX backend) will use `ImageModelLoadPlan.compute` at `loadModel` time.