### PR TITLE
feat: add ImageGenerationRuntime in BaseChatRuntime

### DIFF
--- a/Sources/BaseChatRuntime/Services/ImageGenerationRuntime.swift
+++ b/Sources/BaseChatRuntime/Services/ImageGenerationRuntime.swift
@@ -1,0 +1,297 @@
+import Foundation
+import BaseChatInference
+
+// MARK: - ImageGenerationRuntime
+//
+// Sibling to `ConversationRuntime` for the image-generation path. Owns an
+// `ImageGenerationService`, drives `generate(prompt:config:)`, and persists
+// the resulting `.generatedImage` part via the `MessageStore` port.
+//
+// Per umbrella #1002:
+//   - Image-side runtime is a sibling type, not a new method on
+//     `ConversationRuntime`. Image lifecycle has different shape (no
+//     turn-loop, no streaming tokens, no thinking blocks) and squeezing
+//     it into the text runtime would distort both surfaces.
+//   - Events ride `ImageRuntimeEvent` — distinct from `ConversationEvent`
+//     so text-side exhaustive switches stay closed.
+//   - Persistence uses the existing `MessageStore` port. The runtime
+//     inserts an empty placeholder on `generate` and updates it in place
+//     with the `.generatedImage` part when the backend completes.
+//
+// Concurrency: `@MainActor` because both `MessageStore` and
+// `ImageGenerationService` are `@MainActor`-isolated. The backend's stream
+// is consumed on a `Task` per generation so `cancel(messageID:)` can locate
+// and tear it down by ID without blocking the actor.
+
+/// Drives image-generation lifecycle through ``ImageGenerationService`` and
+/// persists results via ``MessageStore``.
+///
+/// Sibling to ``ConversationRuntime``. Hosts call ``generate(prompt:config:in:)``
+/// to start a generation, observe progress on ``events`` (an
+/// ``AsyncStream`` of ``ImageRuntimeEvent``), and call ``cancel(messageID:)``
+/// to tear down an in-flight job.
+///
+/// ## Persistence
+///
+/// On ``generate(prompt:config:in:)`` the runtime inserts a placeholder
+/// ``ChatMessageRecord`` (role `.assistant`, empty `contentParts`) into the
+/// message store. Backend progress events are forwarded as
+/// ``ImageRuntimeEvent/progress(messageID:step:totalSteps:)`` *without*
+/// touching the store — UI subscribes to events for the in-flight indicator;
+/// persistence stays minimal until the terminal step.
+///
+/// On backend completion the runtime builds an ``ImageMessagePayload`` and
+/// updates the placeholder message via
+/// ``MessageStore/updateMessage(_:)`` so its `contentParts` becomes a single
+/// ``MessagePart/generatedImage(_:)`` carrying the payload, then emits
+/// ``ImageRuntimeEvent/completed(messageID:payload:)``.
+///
+/// On error or cancellation the placeholder remains in the store with its
+/// original empty `contentParts`. Hosts that prefer to drop the slot can
+/// observe the terminal event and call ``MessageStore/deleteMessage(_:)``
+/// from the adapter — the runtime intentionally does not pick a UX policy.
+///
+/// ## Concurrency
+///
+/// `@MainActor`-isolated for parity with both ports. Each in-flight
+/// generation runs on a tracked `Task` keyed to its placeholder message ID;
+/// ``cancel(messageID:)`` cancels the task and unloads the backend's
+/// in-flight stream via ``ImageGenerationService``'s
+/// `AsyncThrowingStream` cancellation hook (which calls
+/// `backend.stopGeneration()` per the service contract).
+@MainActor
+public final class ImageGenerationRuntime {
+
+    // MARK: Ports
+
+    private let service: ImageGenerationService
+    private let messageStore: any MessageStore
+    private let modelIdentifierProvider: @MainActor () -> String?
+
+    // MARK: Event stream
+
+    /// Lifecycle event stream. Single-consumer by design — adapters either
+    /// iterate it directly or install an observable wrapper.
+    public let events: AsyncStream<ImageRuntimeEvent>
+    private let continuation: AsyncStream<ImageRuntimeEvent>.Continuation
+
+    // MARK: In-flight state
+    //
+    // Tracks the consumer task for each in-flight generation by the
+    // placeholder message ID. The dict is `@MainActor`-protected — every
+    // mutation happens from main-actor methods and the runtime itself is
+    // `@MainActor`.
+
+    private var inFlight: [ChatMessageRecord.ID: Task<Void, Never>] = [:]
+
+    // MARK: Init
+
+    /// Creates a runtime that composes the supplied service and message store.
+    ///
+    /// - Parameters:
+    ///   - service: The ``ImageGenerationService`` whose lifecycle the runtime
+    ///     drives. The service must already have a backend factory registered
+    ///     for the format of any model the host intends to load.
+    ///   - messageStore: Required. Persists the placeholder and final
+    ///     `.generatedImage` part across the generation.
+    ///   - modelIdentifier: Optional override for the identifier embedded in
+    ///     ``ImageMessagePayload/modelIdentifier``. When `nil` (the default),
+    ///     the runtime reads ``ImageGenerationService/loadedModel`` at the
+    ///     moment of completion and uses its `id`. Tests inject this when
+    ///     they want a deterministic identifier without driving the service
+    ///     through a real `loadModel` call.
+    public init(
+        service: ImageGenerationService,
+        messageStore: any MessageStore,
+        modelIdentifier: (@MainActor () -> String?)? = nil
+    ) {
+        self.service = service
+        self.messageStore = messageStore
+        // The default closure returns `nil` so `modelIdentifier()` falls
+        // through to reading `service.loadedModel?.id` at completion time.
+        // Tests inject a non-nil override when they want a deterministic
+        // identifier without driving the service through a real load.
+        self.modelIdentifierProvider = modelIdentifier ?? { nil }
+        var cap: AsyncStream<ImageRuntimeEvent>.Continuation!
+        self.events = AsyncStream(bufferingPolicy: .unbounded) { cap = $0 }
+        self.continuation = cap
+    }
+
+    deinit {
+        continuation.finish()
+    }
+
+    // MARK: Commands
+
+    /// Begins an image generation in the supplied session.
+    ///
+    /// Persists a placeholder ``ChatMessageRecord`` (role `.assistant`,
+    /// empty `contentParts`) before returning, then starts a detached task
+    /// that forwards backend events through ``events``. The returned
+    /// message ID is stable for the lifetime of the generation — pass it
+    /// to ``cancel(messageID:)`` to tear down the job, and observe the
+    /// terminal event (`completed` / `failed` / `cancelled`) on
+    /// ``events`` to know when the placeholder has been finalised.
+    ///
+    /// Generation runs asynchronously on a tracked `Task`; this method
+    /// returns once the placeholder has been inserted and the consumer
+    /// task is dispatched.
+    ///
+    /// - Parameters:
+    ///   - prompt: User-supplied prompt.
+    ///   - config: Sampling and diffusion parameters.
+    ///   - sessionID: The session the placeholder message belongs to.
+    /// - Returns: The placeholder ``ChatMessageRecord/ID`` so the host can
+    ///   pair UI state with the in-flight generation.
+    /// - Throws: Persistence errors from the placeholder insert.
+    @discardableResult
+    public func generate(
+        prompt: String,
+        config: ImageGenerationConfig,
+        in sessionID: UUID
+    ) async throws -> ChatMessageRecord.ID {
+        // Insert placeholder synchronously so the caller observes the
+        // message ID before any event fires. Empty `contentParts` because
+        // we don't have a `.generatedImage` payload yet — the placeholder
+        // is finalised via `updateMessage` when the backend completes.
+        let placeholder = ChatMessageRecord(
+            role: .assistant,
+            contentParts: [],
+            sessionID: sessionID
+        )
+        try await messageStore.insertMessage(placeholder)
+
+        let messageID = placeholder.id
+        emit(.started(messageID: messageID, prompt: prompt))
+
+        // Snapshot config for the persisted payload. Take it now so the
+        // payload reflects the call-site value even if a future runtime
+        // mutates the live `config` mid-flight.
+        let snapshot = ImageGenerationConfigSnapshot(from: config)
+
+        let stream = service.generate(prompt: prompt, config: config)
+
+        // Strong capture: the consumer task owns this generation's logical
+        // unit of work and must complete (emit terminal event, clean up
+        // `inFlight`) even if the host releases its last reference to the
+        // runtime mid-flight. Per the `[weak self]`-in-detached-tasks
+        // memory note: weak capture would silently drop the work. The
+        // task removes itself from `inFlight` on completion so the runtime
+        // can still deinit normally.
+        let task = Task { @MainActor [self] in
+            await self.consume(
+                stream: stream,
+                messageID: messageID,
+                prompt: prompt,
+                placeholder: placeholder,
+                snapshot: snapshot,
+                totalSteps: config.steps
+            )
+        }
+        inFlight[messageID] = task
+        return messageID
+    }
+
+    /// Cancels an in-flight generation by its placeholder message ID.
+    ///
+    /// Idempotent — cancelling an unknown or already-finished message is a
+    /// no-op. The terminal ``ImageRuntimeEvent/cancelled(messageID:)`` event
+    /// fires once the underlying stream observes the cancellation.
+    public func cancel(messageID: ChatMessageRecord.ID) async {
+        guard let task = inFlight[messageID] else { return }
+        task.cancel()
+        // Don't await `task.value` — the consumer task itself emits the
+        // terminal event and removes itself from `inFlight`. Awaiting here
+        // would serialise callers behind a denoising loop's cancellation
+        // latency.
+    }
+
+    // MARK: - Stream consumer
+
+    private func consume(
+        stream: AsyncThrowingStream<ImageGenerationEvent, Error>,
+        messageID: ChatMessageRecord.ID,
+        prompt: String,
+        placeholder: ChatMessageRecord,
+        snapshot: ImageGenerationConfigSnapshot,
+        totalSteps: Int
+    ) async {
+        defer {
+            inFlight.removeValue(forKey: messageID)
+        }
+
+        do {
+            for try await event in stream {
+                if Task.isCancelled {
+                    emit(.cancelled(messageID: messageID))
+                    return
+                }
+                switch event {
+                case .progress(let step, let total):
+                    // Use the backend-reported `total` when present; fall
+                    // back to the config value if a backend yields zero.
+                    let resolvedTotal = total > 0 ? total : totalSteps
+                    emit(.progress(messageID: messageID, step: step, totalSteps: resolvedTotal))
+
+                case .completed(let url):
+                    let identifier = modelIdentifier()
+                    let payload = ImageMessagePayload(
+                        prompt: prompt,
+                        imageURL: url,
+                        modelIdentifier: identifier,
+                        generationConfig: snapshot
+                    )
+                    var finalised = placeholder
+                    finalised.contentParts = [.generatedImage(payload)]
+                    do {
+                        try await messageStore.updateMessage(finalised)
+                    } catch {
+                        emit(.failed(messageID: messageID, error: error))
+                        return
+                    }
+                    emit(.completed(messageID: messageID, payload: payload))
+                    return
+                }
+            }
+            // Stream ended without `.completed` — treat as cancellation
+            // when the task is cancelled, otherwise report empty completion
+            // as a failure so adapters surface something rather than
+            // silently abandoning the placeholder.
+            if Task.isCancelled {
+                emit(.cancelled(messageID: messageID))
+            } else {
+                emit(.failed(
+                    messageID: messageID,
+                    error: ImageGenerationServiceError.notLoaded
+                ))
+            }
+        } catch is CancellationError {
+            emit(.cancelled(messageID: messageID))
+        } catch {
+            if Task.isCancelled {
+                emit(.cancelled(messageID: messageID))
+            } else {
+                emit(.failed(messageID: messageID, error: error))
+            }
+        }
+    }
+
+    // MARK: Helpers
+
+    private func emit(_ event: ImageRuntimeEvent) {
+        continuation.yield(event)
+    }
+
+    /// Resolves the model identifier for the persisted payload. Reads the
+    /// service's `loadedModel` at completion time so a model swap mid-flight
+    /// is reflected. Falls back to `"unknown"` when the service has no
+    /// loaded model — the alternative (an optional field on the payload)
+    /// would force every UI consumer to handle nil for a value that's
+    /// always known at this point in practice.
+    private func modelIdentifier() -> String {
+        if let override = modelIdentifierProvider() {
+            return override
+        }
+        return service.loadedModel?.id ?? "unknown"
+    }
+}

--- a/Sources/BaseChatRuntime/Services/ImageRuntimeEvent.swift
+++ b/Sources/BaseChatRuntime/Services/ImageRuntimeEvent.swift
@@ -1,0 +1,83 @@
+import Foundation
+import BaseChatInference
+
+// MARK: - ImageRuntimeEvent
+//
+// Sibling to `ConversationEvent` for the image-generation runtime. Per the
+// umbrella-#1002 architectural call, image-side runtime events ride a
+// parallel enum rather than landing as new cases on `ConversationEvent`:
+// text-side consumers exhaustively switch over `ConversationEvent`, and
+// adding image cases would gain unreachable switch arms in every text
+// consumer with no upside.
+//
+// `ImageRuntimeEvent` is also distinct from the backend-level
+// `ImageGenerationEvent` (`progress(step:total:)` / `completed(URL)`):
+// the runtime translates between layers, keying every event to a
+// `ChatMessageRecord.ID` so adapters can pair UI state to the right
+// placeholder slot.
+
+/// Events emitted by ``ImageGenerationRuntime``.
+///
+/// Sibling to ``ConversationEvent`` — image-side events are deliberately a
+/// parallel enum rather than additional cases on the text-side surface so
+/// exhaustive switches in text consumers stay closed. The runtime translates
+/// the backend-level ``ImageGenerationEvent`` (raw step + URL) into these
+/// runtime-level events keyed to a placeholder ``ChatMessageRecord/ID``.
+public enum ImageRuntimeEvent: Sendable, Equatable {
+
+    /// Generation started for the placeholder message at `messageID`. The
+    /// placeholder has been persisted via ``MessageStore`` with empty
+    /// `contentParts` — adapters render a "generating" affordance until the
+    /// terminal ``completed(messageID:payload:)`` event updates the message
+    /// in place.
+    case started(messageID: ChatMessageRecord.ID, prompt: String)
+
+    /// Denoising progress. `step` is 1-indexed; `totalSteps` is the value
+    /// the caller passed in ``ImageGenerationConfig/steps`` (after any
+    /// backend-side clamping). Intermediate state is **not** persisted —
+    /// adapters subscribe to events for progressive UI; persistence stays
+    /// minimal until completion.
+    case progress(messageID: ChatMessageRecord.ID, step: Int, totalSteps: Int)
+
+    /// Generation completed; the persisted message at `messageID` now
+    /// carries a single ``MessagePart/generatedImage(_:)`` part with
+    /// `payload`. Adapters refresh their view-state for `messageID` from
+    /// the store (the runtime has already written through ``MessageStore``).
+    case completed(messageID: ChatMessageRecord.ID, payload: ImageMessagePayload)
+
+    /// Generation failed. Carries the underlying error so adapters can
+    /// surface user-facing error UI; the placeholder message at `messageID`
+    /// remains in the store with its original (empty) `contentParts` so
+    /// adapters can either render an inline failure indicator or call
+    /// ``MessageStore/deleteMessage(_:)`` to drop the slot — the runtime
+    /// emits the event, the host decides UX.
+    case failed(messageID: ChatMessageRecord.ID, error: any Error)
+
+    /// User cancelled before completion. The placeholder message at
+    /// `messageID` remains in the store with empty `contentParts`; same
+    /// host-decides-UX policy as ``failed(messageID:error:)``.
+    case cancelled(messageID: ChatMessageRecord.ID)
+
+    // MARK: - Equatable
+
+    // Custom because `any Error` is not `Equatable`. Two `.failed` events
+    // are considered equal when their message IDs match and the localized
+    // descriptions of their errors match — sufficient for tests asserting
+    // event sequences without forcing every error type through `Equatable`.
+    public static func == (lhs: ImageRuntimeEvent, rhs: ImageRuntimeEvent) -> Bool {
+        switch (lhs, rhs) {
+        case let (.started(lid, lp), .started(rid, rp)):
+            return lid == rid && lp == rp
+        case let (.progress(lid, ls, lt), .progress(rid, rs, rt)):
+            return lid == rid && ls == rs && lt == rt
+        case let (.completed(lid, lp), .completed(rid, rp)):
+            return lid == rid && lp == rp
+        case let (.failed(lid, le), .failed(rid, re)):
+            return lid == rid && le.localizedDescription == re.localizedDescription
+        case let (.cancelled(lid), .cancelled(rid)):
+            return lid == rid
+        default:
+            return false
+        }
+    }
+}

--- a/Tests/BaseChatRuntimeTests/ImageGenerationRuntimeTests.swift
+++ b/Tests/BaseChatRuntimeTests/ImageGenerationRuntimeTests.swift
@@ -1,0 +1,526 @@
+@preconcurrency import XCTest
+import Foundation
+import os
+@testable import BaseChatRuntime
+@testable import BaseChatInference
+
+/// Coverage for ``ImageGenerationRuntime`` — the image-side sibling to
+/// ``ConversationRuntime``. Drives a mock ``ImageGenerationBackend`` through
+/// the runtime, asserts events and persistence.
+@MainActor
+final class ImageGenerationRuntimeTests: XCTestCase {
+
+    // MARK: - In-memory MessageStore
+
+    @MainActor
+    final class RuntimeMessageStore: MessageStore {
+        private(set) var messages: [UUID: ChatMessageRecord] = [:]
+        var updateError: (any Error)?
+
+        func insertMessage(_ message: ChatMessageRecord) async throws {
+            messages[message.id] = message
+        }
+
+        func updateMessage(_ message: ChatMessageRecord) async throws {
+            if let error = updateError {
+                updateError = nil
+                throw error
+            }
+            guard messages[message.id] != nil else {
+                throw ChatPersistenceError.messageNotFound(message.id)
+            }
+            messages[message.id] = message
+        }
+
+        func deleteMessage(_ messageID: UUID) async throws {
+            guard messages.removeValue(forKey: messageID) != nil else {
+                throw ChatPersistenceError.messageNotFound(messageID)
+            }
+        }
+
+        func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
+            messages.values
+                .filter { $0.sessionID == sessionID }
+                .sorted { $0.timestamp < $1.timestamp }
+        }
+
+        func deleteMessages(for sessionID: UUID) async throws {
+            messages = messages.filter { $0.value.sessionID != sessionID }
+        }
+
+        func addPostWriteHook(_ hook: any MessageStorePostWriteHook) {}
+    }
+
+    // MARK: - Mock image-gen backend
+    //
+    // Drives `ImageGenerationService.generate(...)` through a controllable
+    // stream. Each test configures the events the backend yields and the
+    // delay between them; the service wraps this stream and the runtime
+    // consumes from there.
+
+    final class MockImageBackend: ImageGenerationBackend, @unchecked Sendable {
+        struct Plan: Sendable {
+            var events: [ImageGenerationEvent] = []
+            /// When non-nil the stream throws this error after yielding all
+            /// configured events.
+            var trailingError: (any Error)?
+            /// Per-event delay in nanoseconds. Tests can use a small value
+            /// to give cancellation a chance to interleave.
+            var delayPerEventNs: UInt64 = 1_000_000  // 1ms
+        }
+
+        private struct State: Sendable {
+            var isLoaded = true
+            var isGenerating = false
+            var plan = Plan()
+            var stopRequested = false
+        }
+
+        private let state = OSAllocatedUnfairLock(initialState: State())
+
+        var isLoaded: Bool { state.withLock { $0.isLoaded } }
+        var isGenerating: Bool { state.withLock { $0.isGenerating } }
+        var stopRequested: Bool { state.withLock { $0.stopRequested } }
+
+        func setPlan(_ plan: Plan) {
+            state.withLock { $0.plan = plan }
+        }
+
+        func loadModel(from url: URL) async throws {
+            state.withLock { $0.isLoaded = true }
+        }
+
+        func generate(
+            prompt: String,
+            config: ImageGenerationConfig
+        ) throws -> AsyncThrowingStream<ImageGenerationEvent, Error> {
+            let plan: Plan = state.withLock { snapshot in
+                snapshot.isGenerating = true
+                snapshot.stopRequested = false
+                return snapshot.plan
+            }
+
+            return AsyncThrowingStream { continuation in
+                let task = Task<Void, Never> { [self] in
+                    for event in plan.events {
+                        if Task.isCancelled { break }
+                        try? await Task.sleep(nanoseconds: plan.delayPerEventNs)
+                        if Task.isCancelled { break }
+                        continuation.yield(event)
+                    }
+                    if let trailingError = plan.trailingError, !Task.isCancelled {
+                        continuation.finish(throwing: trailingError)
+                    } else {
+                        continuation.finish()
+                    }
+                    self.state.withLock { $0.isGenerating = false }
+                }
+                continuation.onTermination = { _ in
+                    task.cancel()
+                }
+            }
+        }
+
+        func stopGeneration() {
+            state.withLock { snapshot in
+                snapshot.stopRequested = true
+                snapshot.isGenerating = false
+            }
+        }
+
+        func unloadModel() {
+            state.withLock { $0.isLoaded = false }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeRuntime(
+        backend: MockImageBackend = MockImageBackend(),
+        modelIdentifier: String? = "test-model"
+    ) async throws -> (
+        runtime: ImageGenerationRuntime,
+        store: RuntimeMessageStore,
+        backend: MockImageBackend,
+        service: ImageGenerationService
+    ) {
+        let service = ImageGenerationService()
+        // Register a factory that yields our mock so the service has a
+        // backend to call. The factory is invoked synchronously during
+        // `loadModel` — which we don't drive here; instead we hand the
+        // service a pre-loaded backend by overriding the identifier
+        // resolver and calling `loadModel` ourselves through the factory.
+        let captured = backend
+        service.registerBackendFactory(for: .mlxDiffusion) { _ in
+            captured
+        }
+        let info = ImageModelInfo(
+            id: modelIdentifier ?? "test-model",
+            name: "Test Model",
+            directoryURL: URL(fileURLWithPath: NSTemporaryDirectory()),
+            format: .mlxDiffusion,
+            fileSize: 1
+        )
+        try await service.loadModel(info)
+
+        let store = RuntimeMessageStore()
+        let runtime = ImageGenerationRuntime(
+            service: service,
+            messageStore: store
+        )
+        return (runtime, store, backend, service)
+    }
+
+    /// Drains events until `predicate` is true or `deadline` elapses.
+    private func collectEvents(
+        from runtime: ImageGenerationRuntime,
+        until predicate: @escaping @Sendable (ImageRuntimeEvent) -> Bool,
+        deadline: Duration = .seconds(5)
+    ) async throws -> [ImageRuntimeEvent] {
+        var collected: [ImageRuntimeEvent] = []
+        let task = Task {
+            for await event in runtime.events {
+                collected.append(event)
+                if predicate(event) { break }
+            }
+            return collected
+        }
+        let result = try await withThrowingTaskGroup(of: [ImageRuntimeEvent].self) { group in
+            group.addTask { await task.value }
+            group.addTask {
+                try await Task.sleep(for: deadline)
+                task.cancel()
+                throw TestError.deadlineElapsed
+            }
+            let first = try await group.next()
+            group.cancelAll()
+            return first ?? []
+        }
+        return result
+    }
+
+    enum TestError: Error { case deadlineElapsed }
+
+    // MARK: - Test 1: Generate happy path
+
+    func test_generate_happyPath_persistsAndEmitsEvents() async throws {
+        let outDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("image-runtime-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: outDir) }
+
+        let imageURL = outDir.appendingPathComponent("out.png")
+        // Write a real placeholder file so the URL points at on-disk bytes —
+        // the runtime doesn't read the file, but tests that assert on
+        // payload validity should reflect realistic state.
+        try Data([0x89, 0x50, 0x4E, 0x47]).write(to: imageURL)
+
+        let backend = MockImageBackend()
+        backend.setPlan(.init(events: [
+            .progress(step: 1, total: 4),
+            .progress(step: 2, total: 4),
+            .progress(step: 3, total: 4),
+            .progress(step: 4, total: 4),
+            .completed(imageURL)
+        ]))
+
+        let (runtime, store, _, _) = try await makeRuntime(backend: backend)
+        let sessionID = UUID()
+        let config = ImageGenerationConfig(steps: 4, width: 64, height: 64, outputDirectory: outDir)
+
+        let messageID = try await runtime.generate(
+            prompt: "a cat",
+            config: config,
+            in: sessionID
+        )
+
+        let events = try await collectEvents(from: runtime) { event in
+            if case .completed = event { return true }
+            if case .failed = event { return true }
+            return false
+        }
+
+        // Check event sequence: started → 4× progress → completed.
+        XCTAssertEqual(events.count, 6)
+        guard case .started(let startID, let prompt) = events.first else {
+            return XCTFail("Expected first event to be .started, got \(events.first as Any)")
+        }
+        XCTAssertEqual(startID, messageID)
+        XCTAssertEqual(prompt, "a cat")
+
+        for (i, event) in events[1...4].enumerated() {
+            guard case .progress(let pid, let step, let total) = event else {
+                return XCTFail("Expected progress at index \(i+1), got \(event)")
+            }
+            XCTAssertEqual(pid, messageID)
+            XCTAssertEqual(step, i + 1)
+            XCTAssertEqual(total, 4)
+        }
+
+        guard case .completed(let cid, let payload) = events.last else {
+            return XCTFail("Expected last event to be .completed, got \(events.last as Any)")
+        }
+        XCTAssertEqual(cid, messageID)
+        XCTAssertEqual(payload.prompt, "a cat")
+        XCTAssertEqual(payload.imageURL, imageURL)
+        XCTAssertEqual(payload.modelIdentifier, "test-model")
+        XCTAssertEqual(payload.generationConfig.steps, 4)
+
+        // Persistence: placeholder updated to carry the .generatedImage part.
+        let stored = try await store.fetchMessages(for: sessionID)
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertEqual(stored.first?.id, messageID)
+        XCTAssertEqual(stored.first?.contentParts.count, 1)
+        guard case .generatedImage(let storedPayload) = stored.first?.contentParts.first else {
+            return XCTFail("Expected stored part to be .generatedImage")
+        }
+        XCTAssertEqual(storedPayload.imageURL, imageURL)
+    }
+
+    // MARK: - Test 2: Generate without loaded model
+
+    func test_generate_withoutLoadedModel_emitsFailed() async throws {
+        // Build a service with a registered factory but no loaded model — the
+        // service's `generate` will finish the stream with `.notLoaded`.
+        let service = ImageGenerationService()
+        let backend = MockImageBackend()
+        let captured = backend
+        service.registerBackendFactory(for: .mlxDiffusion) { _ in captured }
+        // Do NOT call loadModel.
+
+        let store = RuntimeMessageStore()
+        let runtime = ImageGenerationRuntime(service: service, messageStore: store)
+        let sessionID = UUID()
+
+        let messageID = try await runtime.generate(
+            prompt: "a dog",
+            config: ImageGenerationConfig(steps: 1, width: 64, height: 64),
+            in: sessionID
+        )
+
+        let events = try await collectEvents(from: runtime) { event in
+            if case .failed = event { return true }
+            if case .completed = event { return true }
+            return false
+        }
+
+        guard case .failed(let fid, let error) = events.last else {
+            return XCTFail("Expected .failed, got \(events.last as Any)")
+        }
+        XCTAssertEqual(fid, messageID)
+        // The service surfaces `notLoaded` when no model has been loaded.
+        XCTAssertTrue(
+            error is ImageGenerationServiceError,
+            "Expected ImageGenerationServiceError, got \(type(of: error))"
+        )
+    }
+
+    // MARK: - Test 3: Cancel
+
+    func test_cancel_emitsCancelledAndIgnoresLaterBackendEvents() async throws {
+        let backend = MockImageBackend()
+        backend.setPlan(.init(events: [
+            .progress(step: 1, total: 100),
+            .progress(step: 2, total: 100),
+            .progress(step: 3, total: 100),
+            // Many more steps to give cancellation time to interleave
+            .progress(step: 4, total: 100),
+            .progress(step: 5, total: 100),
+            .completed(URL(fileURLWithPath: "/tmp/never-emitted.png"))
+        ], delayPerEventNs: 50_000_000))  // 50ms per event
+
+        let (runtime, store, _, _) = try await makeRuntime(backend: backend)
+        let sessionID = UUID()
+
+        let messageID = try await runtime.generate(
+            prompt: "x",
+            config: ImageGenerationConfig(steps: 100, width: 64, height: 64),
+            in: sessionID
+        )
+
+        // Wait for at least the started event and one progress event before
+        // cancelling — otherwise cancel races the consumer task setup.
+        let task = Task { [runtime] in
+            var seen: [ImageRuntimeEvent] = []
+            for await event in runtime.events {
+                seen.append(event)
+                if case .progress = event { break }
+            }
+            return seen
+        }
+        _ = await task.value
+
+        await runtime.cancel(messageID: messageID)
+
+        let terminalEvents = try await collectEvents(from: runtime) { event in
+            if case .cancelled = event { return true }
+            if case .completed = event { return true }
+            if case .failed = event { return true }
+            return false
+        }
+
+        guard case .cancelled(let cid) = terminalEvents.last else {
+            return XCTFail("Expected .cancelled terminal, got \(terminalEvents.last as Any)")
+        }
+        XCTAssertEqual(cid, messageID)
+
+        // Placeholder is NOT updated to a .generatedImage part on cancel.
+        let stored = try await store.fetchMessages(for: sessionID)
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertTrue(
+            stored.first?.contentParts.isEmpty ?? false,
+            "Expected placeholder contentParts empty on cancel; got \(stored.first?.contentParts as Any)"
+        )
+    }
+
+    // MARK: - Test 4: Multiple concurrent generations
+
+    func test_concurrentGenerations_emitDistinctMessageIDs() async throws {
+        // Two backends so each generation has its own stream. We can't run
+        // two concurrent generations through one `ImageGenerationService` —
+        // the service is `.loaded → .generating → .loaded` single-threaded
+        // and by design two services share no state. Use two runtimes
+        // backed by two services to exercise the routing invariant.
+        //
+        // The runtime invariant under test is event routing keyed to the
+        // distinct message IDs — the runtime never writes events for one
+        // ID into another's slot.
+        let outDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("image-runtime-concurrent-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: outDir) }
+
+        let urlA = outDir.appendingPathComponent("a.png")
+        let urlB = outDir.appendingPathComponent("b.png")
+        try Data([0x89]).write(to: urlA)
+        try Data([0x89]).write(to: urlB)
+
+        let backendA = MockImageBackend()
+        backendA.setPlan(.init(events: [
+            .progress(step: 1, total: 2),
+            .progress(step: 2, total: 2),
+            .completed(urlA)
+        ]))
+        let backendB = MockImageBackend()
+        backendB.setPlan(.init(events: [
+            .progress(step: 1, total: 2),
+            .progress(step: 2, total: 2),
+            .completed(urlB)
+        ]))
+
+        let (runtimeA, _, _, _) = try await makeRuntime(backend: backendA, modelIdentifier: "model-a")
+        let (runtimeB, _, _, _) = try await makeRuntime(backend: backendB, modelIdentifier: "model-b")
+
+        let sessionA = UUID()
+        let sessionB = UUID()
+
+        let idA = try await runtimeA.generate(
+            prompt: "a", config: ImageGenerationConfig(steps: 2, width: 64, height: 64), in: sessionA
+        )
+        let idB = try await runtimeB.generate(
+            prompt: "b", config: ImageGenerationConfig(steps: 2, width: 64, height: 64), in: sessionB
+        )
+
+        XCTAssertNotEqual(idA, idB, "Distinct generations must yield distinct message IDs")
+
+        // Drain runtime A first, then runtime B. Both have already started
+        // their detached consumer tasks (via `generate(...)` above), so the
+        // backend streams run concurrently even though we collect events
+        // serially. Avoiding `async let` keeps the test off the
+        // main-actor-self sending diagnostic — what we care about is that
+        // each runtime's events route to the right messageID, not that the
+        // collection itself is concurrent.
+        let collectedA = try await collectEvents(from: runtimeA) { e in
+            if case .completed = e { return true }
+            if case .failed = e { return true }
+            return false
+        }
+        let collectedB = try await collectEvents(from: runtimeB) { e in
+            if case .completed = e { return true }
+            if case .failed = e { return true }
+            return false
+        }
+
+        // All events from runtime A reference idA; all events from runtime
+        // B reference idB. Routing invariant: events do not bleed across
+        // runtimes (or, more importantly, across message IDs within one).
+        for event in collectedA {
+            switch event {
+            case .started(let id, _), .progress(let id, _, _), .completed(let id, _),
+                 .failed(let id, _), .cancelled(let id):
+                XCTAssertEqual(id, idA, "runtimeA emitted event for non-matching messageID")
+            }
+        }
+        for event in collectedB {
+            switch event {
+            case .started(let id, _), .progress(let id, _, _), .completed(let id, _),
+                 .failed(let id, _), .cancelled(let id):
+                XCTAssertEqual(id, idB, "runtimeB emitted event for non-matching messageID")
+            }
+        }
+
+        // The completed payloads carry the right model identifiers.
+        guard case .completed(_, let payloadA) = collectedA.last else {
+            return XCTFail("runtime A did not complete")
+        }
+        guard case .completed(_, let payloadB) = collectedB.last else {
+            return XCTFail("runtime B did not complete")
+        }
+        XCTAssertEqual(payloadA.modelIdentifier, "model-a")
+        XCTAssertEqual(payloadB.modelIdentifier, "model-b")
+    }
+
+    // MARK: - Test 5: ConversationEvent case discipline
+    //
+    // Sentry: confirms ImageRuntimeEvent did not land as new cases on
+    // ConversationEvent. ConversationEvent's case set is the load-bearing
+    // contract for text-side adapters; an image-side leak would silently
+    // gain unreachable switch arms in every consumer.
+    //
+    // Counts cases by exhaustively switching. If a future PR adds a
+    // ConversationEvent case, this test must be updated deliberately —
+    // which is the point.
+
+    func test_conversationEvent_caseCount_unchangedByImageRuntime() {
+        // Build one of each ConversationEvent case via a sample. We only
+        // need the type-system commitment that the cases below are the
+        // full set — exhaustive switch is the gate.
+        let samples: [ConversationEvent] = [
+            .messageInserted(ChatMessageRecord(role: .user, content: "", sessionID: UUID())),
+            .messageRemoved(messageID: UUID()),
+            .messageUpdated(ChatMessageRecord(role: .user, content: "", sessionID: UUID())),
+            .sessionBranched(newSessionID: UUID(), copiedCount: 0),
+            .streamStarted(messageID: UUID()),
+            .tokenEmitted(messageID: UUID(), delta: ""),
+            .thinkingStarted(messageID: UUID()),
+            .thinkingUpdated(messageID: UUID(), partialText: ""),
+            .thinkingFinalized(messageID: UUID(), text: "", signature: nil),
+            .loopDetected(messageID: UUID()),
+            .streamFinished(messageID: UUID(), reason: .stop),
+            .errorRaised(.cancelled),
+            .beforeContextAssembly(prompt: nil, request: PromptContextRequest(sessionID: UUID(), messageCount: 0, userInput: nil)),
+            .contextAssembled(slots: []),
+            .afterGeneration(messageID: UUID(), finalText: ""),
+            .compressionTriggered(removed: [], reason: .manual),
+            .toolCallRequested(ToolCall(id: "", toolName: "", arguments: "")),
+            .toolCallApproved(""),
+            .toolCallCompleted("", ToolResult(callId: "", content: ""))
+        ]
+        // The exhaustive switch below is the actual test — if any new
+        // case landed (e.g. an image-side leak), this fails to compile.
+        for event in samples {
+            switch event {
+            case .messageInserted, .messageRemoved, .messageUpdated, .sessionBranched,
+                 .streamStarted, .tokenEmitted, .thinkingStarted, .thinkingUpdated,
+                 .thinkingFinalized, .loopDetected, .streamFinished, .errorRaised,
+                 .beforeContextAssembly, .contextAssembled, .afterGeneration,
+                 .compressionTriggered, .toolCallRequested, .toolCallApproved,
+                 .toolCallCompleted:
+                continue
+            }
+        }
+        // Pin the exact case count as a runtime assertion too — the
+        // sample list is the source of truth.
+        XCTAssertEqual(samples.count, 19, "ConversationEvent case count drifted — image-side cases may have leaked in")
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ImageGenerationRuntime` in `BaseChatRuntime` — sibling to `ConversationRuntime`. Holds an `ImageGenerationService`, drives generation, and persists `.generatedImage` parts via the existing `MessageStore` port.
- Adds `ImageRuntimeEvent`: a runtime-level event enum (`started` / `progress` / `completed` / `failed` / `cancelled`), distinct from the backend-level `ImageGenerationEvent`. The runtime translates between layers.
- No changes to `ConversationEvent`, `ConversationRuntime`, or any text-side type. Per the umbrella's parallel-types rule, image-side runtime events are a sibling, not a new case on the closed text-side enum.

## Why parallel events instead of new cases on `ConversationEvent`

Same reason `ImageModelInfo` is parallel to `ModelInfo`: text-side consumers exhaustively switch over `ConversationEvent`. Adding image cases would gain unreachable switch arms in every text consumer. Sibling event types preserve the closed-switch invariant. A test in this PR pins the `ConversationEvent` case count (19) so any future image-side leak fails the suite.

## Persistence

The existing `MessageStore` protocol already exposes `insertMessage(_:)` / `updateMessage(_:)` / `deleteMessage(_:)`. The runtime:

1. Inserts a placeholder `ChatMessageRecord` (role `.assistant`, empty `contentParts`) on `generate(...)`.
2. Forwards backend `ImageGenerationEvent.progress(...)` as `ImageRuntimeEvent.progress(...)` without touching the store — UI subscribes to events for the in-flight indicator.
3. On backend completion, builds an `ImageMessagePayload` and calls `messageStore.updateMessage(_:)` so the placeholder's `contentParts` becomes `[.generatedImage(payload)]`, then emits `ImageRuntimeEvent.completed`.
4. On error / cancel, emits the corresponding terminal event and leaves the placeholder in place with empty `contentParts` — host adapters decide whether to render an inline failure indicator or call `deleteMessage(_:)` to drop the slot.

No port extension needed.

## Concurrency

`@MainActor`-isolated for parity with both `MessageStore` and `ImageGenerationService`. Each in-flight generation runs on a tracked `Task` keyed to its placeholder message ID; `cancel(messageID:)` cancels that task, and the service's `AsyncThrowingStream` cancellation hook calls `backend.stopGeneration()` so the denoising loop tears down promptly.

## Test plan

- [x] Generate happy path: placeholder inserted, started + 4× progress + completed events emitted, store has the updated message with `.generatedImage(payload)`.
- [x] Generate without a loaded model: runtime surfaces the service's `ImageGenerationServiceError.notLoaded` as `ImageRuntimeEvent.failed`.
- [x] Cancel: `cancel(messageID:)` produces a terminal `.cancelled` event and the placeholder retains empty `contentParts` (no `.generatedImage` part attached).
- [x] Concurrent generations: two runtimes drive two services; events route to the correct message IDs and the persisted payloads carry the right model identifiers.
- [x] `ConversationEvent` case discipline: exhaustive-switch sentry asserts the text-side case set is unchanged (19 cases).
- [x] Sabotage check on the happy path: temporarily skipped `messageStore.updateMessage(_:)`; the test failed with the expected assertion. Restored before commit.
- [x] Full pre-push gate (XCTest 2419/2419 + Swift Testing 83/83) passes locally.

## Files

- `Sources/BaseChatRuntime/Services/ImageGenerationRuntime.swift` (new)
- `Sources/BaseChatRuntime/Services/ImageRuntimeEvent.swift` (new)
- `Tests/BaseChatRuntimeTests/ImageGenerationRuntimeTests.swift` (new)

## Tracking

Part of #1002 (image generation runtime umbrella). With PR 1 (#1003), PR 2 (#1008), PR 4 (#1009) already merged, this lands the foundations layer at 4-of-4. PR 5 (HuggingFace diffusion download topology) is being delivered in parallel. Next: PR 6 (MLX backend conformer), still gated on the upstream `mlx-swift-examples` tag — see umbrella's Spikes section.