### PR TITLE
feat: add image generation entry on ChatViewModel

### DIFF
--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+ImageGeneration.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+ImageGeneration.swift
@@ -1,0 +1,242 @@
+import Foundation
+import BaseChatRuntime
+import BaseChatInference
+
+// MARK: - ChatViewModel + ImageGeneration
+//
+// Host-facing entry surface for `ImageGenerationRuntime`. Mirrors the role
+// `ChatViewModel+RuntimeAdapter` plays for `ConversationRuntime`: forwards
+// commands to the runtime and maps `ImageRuntimeEvent` back to `@Observable`
+// state on `@MainActor`.
+//
+// The runtime is **optional** — chat-only hosts never call
+// `configure(imageRuntime:)` and the image methods throw `.notConfigured`.
+// The text path on `ChatViewModel` is unchanged.
+
+/// Per-message progress snapshot for in-flight or completed image generations.
+///
+/// Populated by ``ChatViewModel/imageGenerationProgress`` from
+/// ``ImageRuntimeEvent`` values. Hosts subscribe via `@Observable` to render
+/// progress UIs keyed off the placeholder message ID returned by
+/// ``ChatViewModel/generateImage(prompt:config:)``.
+public struct ImageGenerationProgress: Sendable, Equatable {
+
+    /// The placeholder ``ChatMessageRecord/ID`` the generation is writing to.
+    public let messageID: UUID
+
+    /// User-supplied prompt the generation was started with.
+    public let prompt: String
+
+    /// 1-indexed denoising step. `0` while waiting for the first
+    /// ``ImageRuntimeEvent/progress(messageID:step:totalSteps:)`` event.
+    public let step: Int
+
+    /// Total denoising steps the runtime is targeting (after backend clamp).
+    /// `0` until the first progress event arrives.
+    public let totalSteps: Int
+
+    /// `true` once a terminal event (completed / failed / cancelled) has been
+    /// observed. UI can stop animating progress affordances at this point.
+    public let isComplete: Bool
+
+    /// Localized error description if the generation failed; `nil` otherwise.
+    /// Set independently of ``isComplete`` so cancellation surfaces as
+    /// `isComplete = true, error = nil`.
+    public let error: String?
+
+    public init(
+        messageID: UUID,
+        prompt: String,
+        step: Int,
+        totalSteps: Int,
+        isComplete: Bool,
+        error: String?
+    ) {
+        self.messageID = messageID
+        self.prompt = prompt
+        self.step = step
+        self.totalSteps = totalSteps
+        self.isComplete = isComplete
+        self.error = error
+    }
+}
+
+/// Errors thrown by ``ChatViewModel`` image-generation entry methods.
+public enum ChatViewModelImageError: Error, LocalizedError, Equatable {
+
+    /// ``ChatViewModel/configure(imageRuntime:)`` was never called.
+    case notConfigured
+
+    /// ``ChatViewModel/activeSession`` is `nil` — there is no conversation
+    /// to insert the placeholder image message into.
+    case noActiveConversation
+
+    public var errorDescription: String? {
+        switch self {
+        case .notConfigured:
+            return "Image generation is not configured. Install an ImageGenerationRuntime via configure(imageRuntime:)."
+        case .noActiveConversation:
+            return "No active conversation. Create or select a session before generating an image."
+        }
+    }
+}
+
+@MainActor
+extension ChatViewModel {
+
+    // MARK: - Runtime install
+
+    /// The image-generation runtime, if the host wired one up. `nil` for
+    /// chat-only hosts; image methods throw ``ChatViewModelImageError/notConfigured``
+    /// in that case.
+    public var imageRuntime: ImageGenerationRuntime? {
+        _imageRuntime
+    }
+
+    /// Install an ``ImageGenerationRuntime``. Typically called by
+    /// ``BaseChatBootstrap`` when the host opts in to image generation;
+    /// app code can also call it directly.
+    ///
+    /// Latest-wins: a prior runtime's event-drain task is cancelled before
+    /// the new one starts, so reconfiguring at runtime is safe. The view
+    /// model holds the runtime strongly for the rest of its lifetime — same
+    /// ownership model as ``conversationRuntime``.
+    public func configure(imageRuntime: ImageGenerationRuntime) {
+        _imageRuntime = imageRuntime
+        startImageRuntimeEventDrain(runtime: imageRuntime)
+    }
+
+    /// Cancels the existing image-runtime drain task (if any) and starts a
+    /// fresh one for `runtime`.
+    ///
+    /// Strong `self` capture: the drain task is the long-lived owner of the
+    /// progress dictionary's update path and must not silently drop events
+    /// if the host releases its last `ChatViewModel` reference mid-flight.
+    /// The `@MainActor` ownership model means the view model lives for the
+    /// host's lifetime in practice; per the CLAUDE.md memory note on
+    /// `Task.detached`, weak capture would risk dropping the work.
+    private func startImageRuntimeEventDrain(runtime: ImageGenerationRuntime) {
+        imageRuntimeEventDrainTask?.cancel()
+        imageRuntimeEventDrainTask = Task { [self] in
+            for await event in runtime.events {
+                if Task.isCancelled { return }
+                self.handle(imageRuntimeEvent: event)
+            }
+        }
+    }
+
+    // MARK: - Commands
+
+    /// Begin an image generation in the active conversation.
+    ///
+    /// Inserts a placeholder ``ChatMessageRecord`` immediately (via the
+    /// runtime's `MessageStore` port) and dispatches a consumer task that
+    /// updates ``imageGenerationProgress`` from runtime events. Returns the
+    /// placeholder message ID synchronously so the caller can pair UI state
+    /// with the in-flight generation.
+    ///
+    /// - Parameters:
+    ///   - prompt: User-supplied prompt.
+    ///   - config: Sampling and diffusion parameters.
+    /// - Returns: The placeholder ``ChatMessageRecord/ID``.
+    /// - Throws: ``ChatViewModelImageError/notConfigured`` if no runtime is
+    ///   installed, ``ChatViewModelImageError/noActiveConversation`` if
+    ///   there is no active session, or any persistence error from the
+    ///   placeholder insert.
+    @discardableResult
+    public func generateImage(
+        prompt: String,
+        config: ImageGenerationConfig
+    ) async throws -> UUID {
+        guard let runtime = _imageRuntime else {
+            throw ChatViewModelImageError.notConfigured
+        }
+        guard let sessionID = activeSessionID else {
+            throw ChatViewModelImageError.noActiveConversation
+        }
+        return try await runtime.generate(
+            prompt: prompt,
+            config: config,
+            in: sessionID
+        )
+    }
+
+    /// Cancel an in-flight image generation by its placeholder message ID.
+    ///
+    /// Idempotent — cancelling an unknown or already-finished generation is
+    /// a no-op. The terminal ``ImageRuntimeEvent/cancelled(messageID:)``
+    /// event flips ``ImageGenerationProgress/isComplete`` to `true` once the
+    /// underlying stream observes the cancellation.
+    public func cancelImageGeneration(messageID: UUID) async {
+        guard let runtime = _imageRuntime else { return }
+        await runtime.cancel(messageID: messageID)
+    }
+
+    // MARK: - Event drain
+
+    /// Maps an incoming ``ImageRuntimeEvent`` to mutations on
+    /// ``imageGenerationProgress``. Sibling to
+    /// ``handle(runtimeEvent:)`` for ``ConversationEvent``.
+    func handle(imageRuntimeEvent event: ImageRuntimeEvent) {
+        switch event {
+        case .started(let messageID, let prompt):
+            imageGenerationProgress[messageID] = ImageGenerationProgress(
+                messageID: messageID,
+                prompt: prompt,
+                step: 0,
+                totalSteps: 0,
+                isComplete: false,
+                error: nil
+            )
+
+        case .progress(let messageID, let step, let totalSteps):
+            // A `progress` for an unknown ID would mean we missed `started`;
+            // create the entry with what we know rather than dropping the
+            // event silently. The prompt is unrecoverable here, so leave it
+            // empty — hosts observing this case can treat it as a recovery
+            // path.
+            let prompt = imageGenerationProgress[messageID]?.prompt ?? ""
+            imageGenerationProgress[messageID] = ImageGenerationProgress(
+                messageID: messageID,
+                prompt: prompt,
+                step: step,
+                totalSteps: totalSteps,
+                isComplete: false,
+                error: nil
+            )
+
+        case .completed(let messageID, let payload):
+            let existing = imageGenerationProgress[messageID]
+            imageGenerationProgress[messageID] = ImageGenerationProgress(
+                messageID: messageID,
+                prompt: existing?.prompt ?? payload.prompt,
+                step: existing?.totalSteps ?? 0,
+                totalSteps: existing?.totalSteps ?? 0,
+                isComplete: true,
+                error: nil
+            )
+
+        case .failed(let messageID, let error):
+            let existing = imageGenerationProgress[messageID]
+            imageGenerationProgress[messageID] = ImageGenerationProgress(
+                messageID: messageID,
+                prompt: existing?.prompt ?? "",
+                step: existing?.step ?? 0,
+                totalSteps: existing?.totalSteps ?? 0,
+                isComplete: true,
+                error: error.localizedDescription
+            )
+
+        case .cancelled(let messageID):
+            let existing = imageGenerationProgress[messageID]
+            imageGenerationProgress[messageID] = ImageGenerationProgress(
+                messageID: messageID,
+                prompt: existing?.prompt ?? "",
+                step: existing?.step ?? 0,
+                totalSteps: existing?.totalSteps ?? 0,
+                isComplete: true,
+                error: nil
+            )
+        }
+    }
+}

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -562,6 +562,29 @@ public final class ChatViewModel {
     /// Handle to the in-flight ConversationRuntime stream, used to cancel it.
     var activeConversationStreamHandle: ConversationStreamHandle?
 
+    // MARK: - ImageGenerationRuntime
+    //
+    // Optional sibling to `conversationRuntime` for the image-generation
+    // path. Hosts that opt in to image generation install one via
+    // `configure(imageRuntime:)` (typically through `BaseChatBootstrap`);
+    // chat-only hosts leave this nil and the public image-generation methods
+    // throw `.notConfigured`. Storage lives on the main type because
+    // extensions cannot add stored properties — all behavior lives in
+    // `ChatViewModel+ImageGeneration.swift`.
+
+    /// Backing storage for ``imageRuntime``. Internal so the
+    /// `ChatViewModel+ImageGeneration` extension can mutate it.
+    var _imageRuntime: ImageGenerationRuntime?
+
+    /// Drain task for the image runtime event stream. Cancelled when the
+    /// runtime is replaced (latest-wins) or the view model is torn down.
+    @ObservationIgnored
+    var imageRuntimeEventDrainTask: Task<Void, Never>?
+
+    /// Per-message-ID progress dictionary for in-flight or completed image
+    /// generations. Driven by the `ImageGenerationRuntime` event drain.
+    public internal(set) var imageGenerationProgress: [UUID: ImageGenerationProgress] = [:]
+
     /// The assistant `messageID` carried by the most-recent `streamStarted`
     /// event. Used by ``ChatViewModel/handle(runtimeEvent:)`` to gate
     /// terminal events against the active turn — late events from a

--- a/Tests/BaseChatUITests/ChatViewModelImageGenerationTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelImageGenerationTests.swift
@@ -1,0 +1,316 @@
+@preconcurrency import XCTest
+import Foundation
+import os
+@testable import BaseChatUI
+@testable import BaseChatRuntime
+@testable import BaseChatInference
+
+/// Coverage for ``ChatViewModel`` image-generation entry surface — runtime
+/// install, command forwarding, and event-to-progress mapping.
+@MainActor
+final class ChatViewModelImageGenerationTests: XCTestCase {
+
+    // MARK: - In-memory MessageStore
+
+    @MainActor
+    final class TestMessageStore: MessageStore {
+        private(set) var messages: [UUID: ChatMessageRecord] = [:]
+
+        func insertMessage(_ message: ChatMessageRecord) async throws {
+            messages[message.id] = message
+        }
+        func updateMessage(_ message: ChatMessageRecord) async throws {
+            guard messages[message.id] != nil else {
+                throw ChatPersistenceError.messageNotFound(message.id)
+            }
+            messages[message.id] = message
+        }
+        func deleteMessage(_ messageID: UUID) async throws {
+            messages.removeValue(forKey: messageID)
+        }
+        func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
+            messages.values.filter { $0.sessionID == sessionID }.sorted { $0.timestamp < $1.timestamp }
+        }
+        func deleteMessages(for sessionID: UUID) async throws {
+            messages = messages.filter { $0.value.sessionID != sessionID }
+        }
+        func addPostWriteHook(_ hook: any MessageStorePostWriteHook) {}
+    }
+
+    // MARK: - Mock backend (driven by a configurable plan)
+
+    final class MockImageBackend: ImageGenerationBackend, @unchecked Sendable {
+        struct Plan: Sendable {
+            var events: [ImageGenerationEvent] = []
+            var trailingError: (any Error)?
+            var delayPerEventNs: UInt64 = 1_000_000
+        }
+
+        private struct State: Sendable {
+            var isLoaded = true
+            var isGenerating = false
+            var plan = Plan()
+        }
+
+        private let state = OSAllocatedUnfairLock(initialState: State())
+
+        var isLoaded: Bool { state.withLock { $0.isLoaded } }
+        var isGenerating: Bool { state.withLock { $0.isGenerating } }
+
+        func setPlan(_ plan: Plan) { state.withLock { $0.plan = plan } }
+
+        func loadModel(from url: URL) async throws { state.withLock { $0.isLoaded = true } }
+
+        func generate(
+            prompt: String,
+            config: ImageGenerationConfig
+        ) throws -> AsyncThrowingStream<ImageGenerationEvent, Error> {
+            let plan: Plan = state.withLock { snap in
+                snap.isGenerating = true
+                return snap.plan
+            }
+            return AsyncThrowingStream { continuation in
+                let task = Task<Void, Never> { [self] in
+                    for event in plan.events {
+                        if Task.isCancelled { break }
+                        try? await Task.sleep(nanoseconds: plan.delayPerEventNs)
+                        if Task.isCancelled { break }
+                        continuation.yield(event)
+                    }
+                    if let trailingError = plan.trailingError, !Task.isCancelled {
+                        continuation.finish(throwing: trailingError)
+                    } else {
+                        continuation.finish()
+                    }
+                    self.state.withLock { $0.isGenerating = false }
+                }
+                continuation.onTermination = { _ in task.cancel() }
+            }
+        }
+
+        func stopGeneration() { state.withLock { $0.isGenerating = false } }
+        func unloadModel() { state.withLock { $0.isLoaded = false } }
+    }
+
+    // MARK: - Builders
+
+    private func makeRuntime(backend: MockImageBackend) async throws -> (ImageGenerationRuntime, TestMessageStore) {
+        let service = ImageGenerationService()
+        let captured = backend
+        service.registerBackendFactory(for: .mlxDiffusion) { _ in captured }
+        let info = ImageModelInfo(
+            id: "test-model",
+            name: "Test Model",
+            directoryURL: URL(fileURLWithPath: NSTemporaryDirectory()),
+            format: .mlxDiffusion,
+            fileSize: 1
+        )
+        try await service.loadModel(info)
+        let store = TestMessageStore()
+        let runtime = ImageGenerationRuntime(service: service, messageStore: store)
+        return (runtime, store)
+    }
+
+    private func makeViewModel() -> ChatViewModel {
+        ChatViewModel(
+            inferenceService: InferenceService(),
+            userDefaults: UserDefaults(suiteName: "ChatViewModelImageGenerationTests-\(UUID().uuidString)")!
+        )
+    }
+
+    /// Spin until `predicate(vm.imageGenerationProgress[messageID])` becomes
+    /// `true`, or fail after `timeout`. The progress dict is updated from a
+    /// detached `@MainActor` task so we yield in a tight loop rather than
+    /// using a one-shot expectation — events arrive in batches.
+    private func awaitProgress(
+        _ vm: ChatViewModel,
+        for messageID: UUID,
+        until predicate: (ImageGenerationProgress) -> Bool,
+        timeout: TimeInterval = 5.0,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        let deadline = ContinuousClock.now + .seconds(timeout)
+        while ContinuousClock.now < deadline {
+            if let progress = vm.imageGenerationProgress[messageID], predicate(progress) {
+                return
+            }
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        XCTFail("Timed out waiting for progress predicate on \(messageID)", file: file, line: line)
+    }
+
+    // MARK: - Test 1: not configured
+
+    func test_generateImage_withoutConfiguredRuntime_throwsNotConfigured() async {
+        let vm = makeViewModel()
+        vm.activeSession = ChatSessionRecord(title: "Test")
+        do {
+            _ = try await vm.generateImage(prompt: "x", config: ImageGenerationConfig())
+            XCTFail("Expected throw")
+        } catch let error as ChatViewModelImageError {
+            XCTAssertEqual(error, .notConfigured)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    // MARK: - Test 2: no active conversation
+
+    func test_generateImage_withoutActiveSession_throwsNoActiveConversation() async throws {
+        let backend = MockImageBackend()
+        let (runtime, _) = try await makeRuntime(backend: backend)
+        let vm = makeViewModel()
+        vm.configure(imageRuntime: runtime)
+        // No session set — activeSessionID is nil.
+        XCTAssertNil(vm.activeSessionID)
+        do {
+            _ = try await vm.generateImage(prompt: "x", config: ImageGenerationConfig())
+            XCTFail("Expected throw")
+        } catch let error as ChatViewModelImageError {
+            XCTAssertEqual(error, .noActiveConversation)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    // MARK: - Test 3: happy path
+
+    func test_generateImage_happyPath_populatesProgress() async throws {
+        let outDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ivm-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: outDir) }
+
+        let imageURL = outDir.appendingPathComponent("out.png")
+        try Data([0x89, 0x50, 0x4E, 0x47]).write(to: imageURL)
+
+        let backend = MockImageBackend()
+        backend.setPlan(.init(events: [
+            .progress(step: 1, total: 4),
+            .progress(step: 2, total: 4),
+            .progress(step: 3, total: 4),
+            .progress(step: 4, total: 4),
+            .completed(imageURL)
+        ]))
+
+        let (runtime, _) = try await makeRuntime(backend: backend)
+        let vm = makeViewModel()
+        vm.configure(imageRuntime: runtime)
+        vm.activeSession = ChatSessionRecord(title: "Image Test")
+
+        let messageID = try await vm.generateImage(
+            prompt: "a cat",
+            config: ImageGenerationConfig(steps: 4, width: 64, height: 64, outputDirectory: outDir)
+        )
+
+        // First, started should arrive (step 0).
+        await awaitProgress(vm, for: messageID) { p in
+            p.prompt == "a cat" && !p.isComplete
+        }
+
+        // Wait for terminal completion.
+        await awaitProgress(vm, for: messageID) { $0.isComplete && $0.error == nil }
+
+        let final = vm.imageGenerationProgress[messageID]
+        XCTAssertNotNil(final)
+        XCTAssertEqual(final?.prompt, "a cat")
+        XCTAssertTrue(final?.isComplete ?? false)
+        XCTAssertNil(final?.error)
+    }
+
+    // MARK: - Test 4: failed generation
+
+    func test_generateImage_failure_surfacesErrorInProgress() async throws {
+        struct BoomError: LocalizedError { var errorDescription: String? { "boom" } }
+
+        let backend = MockImageBackend()
+        backend.setPlan(.init(events: [.progress(step: 1, total: 4)], trailingError: BoomError()))
+
+        let (runtime, _) = try await makeRuntime(backend: backend)
+        let vm = makeViewModel()
+        vm.configure(imageRuntime: runtime)
+        vm.activeSession = ChatSessionRecord(title: "Fail Test")
+
+        let messageID = try await vm.generateImage(
+            prompt: "broken",
+            config: ImageGenerationConfig(steps: 4, width: 64, height: 64)
+        )
+
+        await awaitProgress(vm, for: messageID) { $0.isComplete && $0.error != nil }
+        XCTAssertEqual(vm.imageGenerationProgress[messageID]?.error, "boom")
+    }
+
+    // MARK: - Test 5: cancel
+
+    func test_cancelImageGeneration_marksProgressComplete() async throws {
+        let backend = MockImageBackend()
+        // Long-running plan so we can cancel mid-flight.
+        backend.setPlan(.init(
+            events: (1...20).map { .progress(step: $0, total: 20) },
+            delayPerEventNs: 20_000_000  // 20ms each
+        ))
+
+        let (runtime, _) = try await makeRuntime(backend: backend)
+        let vm = makeViewModel()
+        vm.configure(imageRuntime: runtime)
+        vm.activeSession = ChatSessionRecord(title: "Cancel Test")
+
+        let messageID = try await vm.generateImage(
+            prompt: "slow",
+            config: ImageGenerationConfig(steps: 20, width: 64, height: 64)
+        )
+
+        // Wait for at least one progress event.
+        await awaitProgress(vm, for: messageID) { !$0.isComplete }
+
+        await vm.cancelImageGeneration(messageID: messageID)
+        await awaitProgress(vm, for: messageID) { $0.isComplete && $0.error == nil }
+    }
+
+    // MARK: - Test 6: reconfigure cancels prior subscription
+
+    func test_configure_reconfigureCancelsPriorSubscription() async throws {
+        let backend1 = MockImageBackend()
+        backend1.setPlan(.init(events: [.progress(step: 1, total: 4)]))
+        let (runtime1, _) = try await makeRuntime(backend: backend1)
+
+        let backend2 = MockImageBackend()
+        let outDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ivm-reconf-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: outDir) }
+        let imageURL = outDir.appendingPathComponent("out.png")
+        try Data([0x89]).write(to: imageURL)
+        backend2.setPlan(.init(events: [
+            .progress(step: 1, total: 1),
+            .completed(imageURL)
+        ]))
+        let (runtime2, _) = try await makeRuntime(backend: backend2)
+
+        let vm = makeViewModel()
+        vm.configure(imageRuntime: runtime1)
+        // Capture the first drain task to assert it's been cancelled after
+        // reconfigure.
+        let firstDrain = vm.imageRuntimeEventDrainTask
+        XCTAssertNotNil(firstDrain)
+
+        vm.configure(imageRuntime: runtime2)
+        XCTAssertTrue(firstDrain?.isCancelled ?? false, "Prior drain task should be cancelled")
+        XCTAssertNotNil(vm.imageRuntimeEventDrainTask)
+        XCTAssertNotIdentical(
+            vm.imageRuntime as AnyObject,
+            runtime1 as AnyObject
+        )
+
+        vm.activeSession = ChatSessionRecord(title: "Reconf Test")
+        let messageID = try await vm.generateImage(
+            prompt: "second",
+            config: ImageGenerationConfig(steps: 1, width: 64, height: 64, outputDirectory: outDir)
+        )
+
+        // The new runtime's events feed the dict.
+        await awaitProgress(vm, for: messageID) { $0.isComplete && $0.error == nil }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ChatViewModel.generateImage(prompt:config:)`, `cancelImageGeneration(messageID:)`, and `configure(imageRuntime:)` — the host-facing entry to image generation.
- Adds `ChatViewModel.imageGenerationProgress: [UUID: ImageGenerationProgress]` observable dict — hosts subscribe via `@Observable` to render progress UIs.
- The `imageRuntime` is **optional** — chat-only hosts leave it nil and image methods throw `.notConfigured`. No regression in the text path.

## Why

PR 3 (#1016) shipped `ImageGenerationRuntime`. Until this PR, hosts had no way to drive it from the same view model that drives chat. This is the integration layer that lets a host call `chatVM.generateImage(...)` and get image messages in the same `ChatMessageRecord` stream as text messages.

## Subscription model

`configure(imageRuntime:)` starts a long-lived event drain task on the runtime's `events` stream. Strong `self` capture (the task is owned by the view model and must complete to clean up the progress dict). Reconfiguring cancels the prior subscription latest-wins.

## Test plan

- [x] `generateImage` without configured runtime throws `.notConfigured`.
- [x] `generateImage` without active conversation throws `.noActiveConversation`.
- [x] Happy path: progress dict populated from runtime events.
- [x] Failed generation: error surfaced in progress dict.
- [x] Cancel: progress entry resolved.
- [x] Reconfigure: prior subscription cancelled.
- [x] Full pre-push gate passes locally (2431 XCTest + 83 Swift Testing).

## Files

- `Sources/BaseChatUI/ViewModels/ChatViewModel+ImageGeneration.swift` (new)
- `Sources/BaseChatUI/ViewModels/ChatViewModel.swift` (storage prop only — additive, no behavior change to text path)
- `Tests/BaseChatUITests/ChatViewModelImageGenerationTests.swift` (new)

## Tracking

Part of #1002 (image generation runtime umbrella). PR 8 (`BaseChatUIModelManagement` install UI) is being delivered in parallel. Next: PR 9 (`BaseChatBootstrap` wiring) ties this together; PR 6 (MLX backend conformer) revision-pin path is being unblocked separately.

## Note on delivery

The original delivery worker was killed mid-pre-push-gate (orphaned `swift-test` process); implementation was complete but uncommitted. Salvage path: orphan reaped, files staged from worker's worktree, full pre-push gate re-run cleanly, branch pushed.