### PR TITLE
feat: add image-model install UI in BaseChatUIModelManagement

### DIFF
--- a/Sources/BaseChatUIModelManagement/Catalogs/DiffusionModelCatalog.swift
+++ b/Sources/BaseChatUIModelManagement/Catalogs/DiffusionModelCatalog.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// One curated entry in the diffusion-model install catalog.
+///
+/// Sibling to the curated text-model list — kept narrow on purpose so the
+/// first-run image install flow has obvious good defaults without inviting a
+/// general-purpose browser. Hosts that want a different list can ignore the
+/// catalog and call ``HuggingFaceService/downloadDiffusionModel(from:to:displayName:urlSession:progress:)``
+/// directly.
+public struct DiffusionModelCatalogEntry: Sendable, Identifiable, Hashable {
+    /// Stable identifier — the HuggingFace repo ID
+    /// (e.g. `"stabilityai/sdxl-turbo"`). Matches `id` on the resulting
+    /// ``ImageModelInfo``.
+    public let id: String
+
+    /// Human-readable display name (e.g. `"SDXL Turbo"`).
+    public let displayName: String
+
+    /// One- or two-sentence description of what the model is good at and any
+    /// memory-class caveats. Rendered next to the install button.
+    public let description: String
+
+    /// Estimated total bytes the model will occupy on disk after download.
+    /// Used for the install button label and a soft disk-space heads-up; the
+    /// real size is whatever the manifest resolves to.
+    public let approximateBytes: Int64
+
+    public init(
+        id: String,
+        displayName: String,
+        description: String,
+        approximateBytes: Int64
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.description = description
+        self.approximateBytes = approximateBytes
+    }
+
+    /// Human-readable size (e.g. `"4.2 GB"`).
+    public var approximateSizeFormatted: String {
+        ByteCountFormatter.string(fromByteCount: approximateBytes, countStyle: .file)
+    }
+}
+
+/// Curated list of known-good diffusion models for the first-run install flow.
+///
+/// Intentionally narrow. Adding more entries is mechanical — a follow-up PR
+/// can broaden this without re-architecting. Pure data, deliberately not
+/// `@MainActor` so it's usable from any context.
+public enum DiffusionModelCatalog {
+    public static let curated: [DiffusionModelCatalogEntry] = [
+        DiffusionModelCatalogEntry(
+            id: "stabilityai/stable-diffusion-2-1-base",
+            displayName: "Stable Diffusion 2.1 Base",
+            description: "512×512 image generation. Fast and memory-efficient; runs on most M-series Macs.",
+            approximateBytes: 4_500_000_000
+        ),
+        DiffusionModelCatalogEntry(
+            id: "stabilityai/sdxl-turbo",
+            displayName: "SDXL Turbo",
+            description: "1024×1024 single-step generation. Higher fidelity but needs more memory.",
+            approximateBytes: 6_700_000_000
+        ),
+    ]
+}

--- a/Sources/BaseChatUIModelManagement/Views/Image/ImageModelInstallView.swift
+++ b/Sources/BaseChatUIModelManagement/Views/Image/ImageModelInstallView.swift
@@ -1,0 +1,173 @@
+#if HuggingFace
+import SwiftUI
+import BaseChatInference
+import BaseChatHuggingFace
+
+/// First-run install UI for image-generation models.
+///
+/// Renders the curated ``DiffusionModelCatalog`` and drives
+/// ``HuggingFaceService/downloadDiffusionModel(from:to:displayName:urlSession:progress:)``
+/// per-row. On success, the resulting ``ImageModelInfo`` is handed back to
+/// the host via ``onInstalled`` — typically the host feeds it to
+/// `ImageGenerationService.loadModel(_:)`. Sibling to the existing text-model
+/// browser; deliberately separate so the closed `ModelType` switches stay
+/// untouched.
+@MainActor
+public struct ImageModelInstallView: View {
+
+    private let huggingFaceService: HuggingFaceService
+    private let onInstalled: (ImageModelInfo) -> Void
+    private let catalog: [DiffusionModelCatalogEntry]
+    private let storageRoot: URL
+
+    @State private var installingID: String? = nil
+    @State private var progress: Double = 0
+    @State private var rowError: [String: String] = [:]
+    @State private var installedModels: [String: ImageModelInfo] = [:]
+
+    /// Creates the install view.
+    ///
+    /// - Parameters:
+    ///   - huggingFaceService: The service that performs the diffusion download.
+    ///   - storageRoot: Directory under which each model gets its own
+    ///     subdirectory. Defaults to
+    ///     `<ModelStorageService.modelsDirectory>/ImageModels`.
+    ///   - catalog: The list of installable models. Defaults to
+    ///     ``DiffusionModelCatalog/curated``.
+    ///   - onInstalled: Called on the main actor with the resulting
+    ///     ``ImageModelInfo`` once a download finishes successfully.
+    public init(
+        huggingFaceService: HuggingFaceService,
+        storageRoot: URL? = nil,
+        catalog: [DiffusionModelCatalogEntry] = DiffusionModelCatalog.curated,
+        onInstalled: @escaping (ImageModelInfo) -> Void
+    ) {
+        self.huggingFaceService = huggingFaceService
+        self.catalog = catalog
+        self.onInstalled = onInstalled
+        // Sit alongside the text-model `Models/` directory under a sibling
+        // `ImageModels/` namespace, so storage accounting and cleanup are
+        // straightforward.
+        if let storageRoot {
+            self.storageRoot = storageRoot
+        } else {
+            self.storageRoot = ModelStorageService()
+                .modelsDirectory
+                .deletingLastPathComponent()
+                .appendingPathComponent("ImageModels", isDirectory: true)
+        }
+    }
+
+    public var body: some View {
+        List {
+            Section {
+                ForEach(catalog) { entry in
+                    row(for: entry)
+                }
+            } header: {
+                Text("Available image models")
+            } footer: {
+                Text("Models download from HuggingFace and are stored in your app's data directory.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityIdentifier("image-model-install-list")
+    }
+
+    @ViewBuilder
+    private func row(for entry: DiffusionModelCatalogEntry) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(entry.displayName)
+                        .font(.headline)
+                    Text(entry.description)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Text(entry.approximateSizeFormatted)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+                Spacer()
+                installButton(for: entry)
+            }
+
+            if installingID == entry.id {
+                ProgressView(value: progress, total: 1.0)
+                    .progressViewStyle(.linear)
+                    .accessibilityIdentifier("image-model-install-progress-\(entry.id)")
+            }
+            if let message = rowError[entry.id] {
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .accessibilityIdentifier("image-model-install-error-\(entry.id)")
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private func installButton(for entry: DiffusionModelCatalogEntry) -> some View {
+        if installedModels[entry.id] != nil {
+            Label("Installed", systemImage: "checkmark.circle.fill")
+                .labelStyle(.titleAndIcon)
+                .foregroundStyle(.green)
+                .accessibilityIdentifier("image-model-installed-\(entry.id)")
+        } else if installingID == entry.id {
+            ProgressView()
+                .controlSize(.small)
+        } else {
+            Button {
+                Task { await install(entry) }
+            } label: {
+                Text("Install")
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(installingID != nil)
+            .accessibilityIdentifier("image-model-install-button-\(entry.id)")
+        }
+    }
+
+    private func install(_ entry: DiffusionModelCatalogEntry) async {
+        installingID = entry.id
+        progress = 0
+        rowError[entry.id] = nil
+
+        let destination = storageRoot.appendingPathComponent(
+            slug(for: entry.id),
+            isDirectory: true
+        )
+
+        do {
+            let info = try await huggingFaceService.downloadDiffusionModel(
+                from: entry.id,
+                to: destination,
+                displayName: entry.displayName,
+                progress: { snapshot in
+                    Task { @MainActor in
+                        progress = snapshot.fractionCompleted
+                    }
+                }
+            )
+            installedModels[entry.id] = info
+            installingID = nil
+            progress = 0
+            onInstalled(info)
+        } catch {
+            rowError[entry.id] = error.localizedDescription
+            installingID = nil
+            progress = 0
+        }
+    }
+
+    /// Slugifies a HuggingFace repo ID (`"stabilityai/sdxl-turbo"`) into a
+    /// single safe directory name (`"stabilityai__sdxl-turbo"`). Keeps the
+    /// `org/name` distinction so two repos that happen to share a basename
+    /// don't collide on disk.
+    private func slug(for repoID: String) -> String {
+        repoID.replacingOccurrences(of: "/", with: "__")
+    }
+}
+#endif

--- a/Sources/BaseChatUIModelManagement/Views/Image/ImageModelManagementSheet.swift
+++ b/Sources/BaseChatUIModelManagement/Views/Image/ImageModelManagementSheet.swift
@@ -1,0 +1,60 @@
+#if HuggingFace
+import SwiftUI
+import BaseChatInference
+import BaseChatHuggingFace
+
+/// Sheet wrapper around ``ImageModelInstallView`` for hosts that want to
+/// present the install flow as a modal (settings menu, first-run prompt,
+/// "Install your first image model" empty state, etc.).
+///
+/// Sibling to ``ModelManagementSheet`` for text models. Deliberately separate
+/// — the text and image stacks have different identifier types
+/// (`ModelInfo` vs ``ImageModelInfo``) and different lifecycles, and the
+/// catalog here is a curated short-list rather than a Hub browser.
+public struct ImageModelManagementSheet: View {
+
+    @Environment(\.dismiss) private var dismiss
+
+    private let huggingFaceService: HuggingFaceService
+    private let storageRoot: URL?
+    private let catalog: [DiffusionModelCatalogEntry]
+    private let onInstalled: (ImageModelInfo) -> Void
+
+    public init(
+        huggingFaceService: HuggingFaceService,
+        storageRoot: URL? = nil,
+        catalog: [DiffusionModelCatalogEntry] = DiffusionModelCatalog.curated,
+        onInstalled: @escaping (ImageModelInfo) -> Void
+    ) {
+        self.huggingFaceService = huggingFaceService
+        self.storageRoot = storageRoot
+        self.catalog = catalog
+        self.onInstalled = onInstalled
+    }
+
+    public var body: some View {
+        NavigationStack {
+            ImageModelInstallView(
+                huggingFaceService: huggingFaceService,
+                storageRoot: storageRoot,
+                catalog: catalog,
+                onInstalled: onInstalled
+            )
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .navigationTitle("Image Models")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+        #if os(macOS)
+        // Match `ModelManagementSheet` — without an explicit frame the inner
+        // List collapses to zero height on macOS sheets.
+        .frame(minWidth: 560, idealWidth: 720, minHeight: 480, idealHeight: 640)
+        #endif
+    }
+}
+#endif

--- a/Tests/BaseChatUIModelManagementTests/ImageModelInstallViewTests.swift
+++ b/Tests/BaseChatUIModelManagementTests/ImageModelInstallViewTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import BaseChatUIModelManagement
+
+/// Sanity tests for the curated diffusion-model catalog that drives the
+/// first-run image install flow. The view itself wraps a HuggingFace
+/// download path that needs network and disk to exercise meaningfully —
+/// covered end-to-end at the host level. These tests guard the catalog
+/// shape that hosts depend on and make sure the entries stay valid.
+final class ImageModelInstallViewTests: XCTestCase {
+
+    func testCatalogHasAtLeastTwoEntries() {
+        XCTAssertGreaterThanOrEqual(
+            DiffusionModelCatalog.curated.count, 2,
+            "Curated catalog should expose at least two installable models so the first-run UI has obvious good defaults."
+        )
+    }
+
+    func testCatalogEntriesHaveValidIdentity() {
+        for entry in DiffusionModelCatalog.curated {
+            XCTAssertFalse(entry.id.isEmpty, "Catalog entry has an empty id")
+            XCTAssertTrue(entry.id.contains("/"), "Catalog entry id \"\(entry.id)\" is not a HuggingFace repo ID (expected org/name).")
+            XCTAssertFalse(entry.displayName.isEmpty, "Catalog entry \(entry.id) has an empty displayName")
+            XCTAssertFalse(entry.description.isEmpty, "Catalog entry \(entry.id) has an empty description")
+            XCTAssertGreaterThan(entry.approximateBytes, 0, "Catalog entry \(entry.id) has a non-positive approximateBytes")
+        }
+    }
+
+    func testCatalogEntryIDsAreUnique() {
+        let ids = DiffusionModelCatalog.curated.map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count, "Curated catalog has duplicate ids: \(ids)")
+    }
+
+    func testApproximateSizeFormattedIsHumanReadable() {
+        let entry = DiffusionModelCatalogEntry(
+            id: "x/y",
+            displayName: "Y",
+            description: "z",
+            approximateBytes: 4_500_000_000
+        )
+        // ByteCountFormatter is locale-aware; just verify it produced a
+        // non-empty string with a "GB" suffix on the en_US-ish defaults
+        // every CI runner uses.
+        let formatted = entry.approximateSizeFormatted
+        XCTAssertFalse(formatted.isEmpty)
+        XCTAssertTrue(
+            formatted.contains("GB") || formatted.contains("MB") || formatted.contains("KB"),
+            "Expected a byte-suffix unit, got \(formatted)"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ImageModelInstallView` and `ImageModelManagementSheet` in `BaseChatUIModelManagement` — a first-run install flow for diffusion models, parallel to the existing text-model browser.
- Adds `DiffusionModelCatalog` with two curated entries (SD 2.1 Base, SDXL Turbo) so hosts have something to install out of the box.
- Drives `HuggingFaceService.downloadDiffusionModel(...)` (landed in #1018) and produces an `ImageModelInfo` for the host to feed to `ImageGenerationService.loadModel`.
- Purely additive: no changes to the existing text-model browser, no changes to `ModelType`, no widening of the closed switch sites.

## Curation policy

The catalog is intentionally narrow (2 entries) for this PR. Adding more entries is mechanical — a follow-up PR can broaden it without re-architecting. Hosts that want a different list can ignore the catalog and present their own UI calling `huggingFaceService.downloadDiffusionModel(from:)` directly.

## Storage path

Models land under `<ModelStorageService.modelsDirectory>/../ImageModels/<org>__<name>/` — sibling to the text `Models/` directory so storage accounting and cleanup are easy. Hosts can override via the `storageRoot:` parameter on either view.

## Trait gating

`ImageModelInstallView` and `ImageModelManagementSheet` are wrapped in `#if HuggingFace` because `HuggingFaceService` is itself trait-gated. `DiffusionModelCatalog` is unconditional — pure data.

## Test plan

- [x] Catalog is non-empty with valid identities (4 unit tests).
- [x] Sabotage check: emptied catalog id → `testCatalogEntriesHaveValidIdentity` failed as expected; restored.
- [x] Full pre-push gate passes locally (XCTest batch: 2427 passed; Swift Testing: 83 passed).

## Files

- `Sources/BaseChatUIModelManagement/Catalogs/DiffusionModelCatalog.swift` (new)
- `Sources/BaseChatUIModelManagement/Views/Image/ImageModelInstallView.swift` (new)
- `Sources/BaseChatUIModelManagement/Views/Image/ImageModelManagementSheet.swift` (new)
- `Tests/BaseChatUIModelManagementTests/ImageModelInstallViewTests.swift` (new)

## Tracking

Part of #1002 (image generation runtime umbrella). PR 7 (`ChatViewModel` image entry) is being delivered in parallel. Next: PR 9 (`BaseChatBootstrap` wiring) ties everything together; PR 6 (MLX backend conformer) is still gated on the upstream `mlx-swift-examples` tag.