### PR TITLE
feat(inference): BackendLoadOptions for KV quant, Flash Attention, prefill batch

### DIFF
--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -93,6 +93,16 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
     /// Guarded by `stateLock`. Set by `setLoadProgressHandler(_:)` before each load.
     private var _loadProgressHandler: (@Sendable (Double) async -> Void)?
 
+    /// Backend tuning knobs applied at the next ``loadModel(from:plan:)`` call.
+    /// Guarded by `stateLock`. Set via ``setLoadOptions(_:)``; defaults preserve
+    /// historical behaviour bit-for-bit.
+    private var _loadOptions: BackendLoadOptions = .default
+
+    /// Test-only read-side accessor that snapshots `_loadOptions` under the
+    /// state lock. Lets plumbing tests assert the setter persisted the value
+    /// without needing a real model load.
+    var loadOptionsForTesting: BackendLoadOptions { withStateLock { _loadOptions } }
+
     // MARK: - Multimodal Projector
 
     /// URL of the mmproj companion file, set by ``MultimodalProjectorConfigurable`` before each load.
@@ -216,10 +226,16 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         // InferenceService.applyLoadProgress(_:for:) drops values whose request
         // token no longer matches the active loading phase.
         let capturedHandler = withStateLock { _loadProgressHandler }
+        let capturedLoadOptions = withStateLock { _loadOptions }
         let effectiveContextSize = Int32(plan.effectiveContextSize)
 
         let loadedResources = try await Task.detached(priority: .userInitiated) { [modelLoader] in
-            return try modelLoader.serializedModelLoad(at: url, effectiveContextSize: effectiveContextSize, progressHandler: capturedHandler)
+            return try modelLoader.serializedModelLoad(
+                at: url,
+                effectiveContextSize: effectiveContextSize,
+                loadOptions: capturedLoadOptions,
+                progressHandler: capturedHandler
+            )
         }.value
 
         let didCommit = withStateLock {
@@ -606,6 +622,18 @@ extension LlamaBackend: LoadProgressReporting {
     /// The handler fires from the loader thread via an unstructured Task.
     public func setLoadProgressHandler(_ handler: (@Sendable (Double) async -> Void)?) {
         withStateLock { _loadProgressHandler = handler }
+    }
+
+    /// Installs backend tuning knobs (KV cache quantization, Flash Attention,
+    /// prefill batch size) that take effect on the **next** ``loadModel(from:plan:)``
+    /// call. Defaults preserve historical behaviour bit-for-bit; opt in
+    /// per ``BackendLoadOptions`` to trade memory for context size or perf.
+    ///
+    /// Calling this after a model is already loaded does not retune the live
+    /// context — applying KV-quantization changes requires rebuilding the
+    /// llama context, which only happens at load time.
+    public func setLoadOptions(_ options: BackendLoadOptions) {
+        withStateLock { _loadOptions = options }
     }
 }
 

--- a/Sources/BaseChatBackends/LlamaModelLoader.swift
+++ b/Sources/BaseChatBackends/LlamaModelLoader.swift
@@ -86,16 +86,23 @@ final class LlamaModelLoader: @unchecked Sendable {
     func serializedModelLoad(
         at url: URL,
         effectiveContextSize: Int32,
+        loadOptions: BackendLoadOptions,
         progressHandler: (@Sendable (Double) async -> Void)?
     ) throws -> LoadedResources {
         loadSerializationLock.lock()
         defer { loadSerializationLock.unlock() }
-        return try Self.initializeModel(at: url, effectiveContextSize: effectiveContextSize, progressHandler: progressHandler)
+        return try Self.initializeModel(
+            at: url,
+            effectiveContextSize: effectiveContextSize,
+            loadOptions: loadOptions,
+            progressHandler: progressHandler
+        )
     }
 
     static func initializeModel(
         at url: URL,
         effectiveContextSize: Int32,
+        loadOptions: BackendLoadOptions = .default,
         progressHandler: (@Sendable (Double) async -> Void)? = nil
     ) throws -> LoadedResources {
         var modelParams = llama_model_default_params()
@@ -166,9 +173,41 @@ final class LlamaModelLoader: @unchecked Sendable {
         ctxParams.n_threads = Int32(max(1, min(8, ProcessInfo.processInfo.processorCount - 2)))
         ctxParams.n_threads_batch = ctxParams.n_threads
 
-        Self.logger.info(
-            "LlamaBackend: initializing context at \(effectiveContextSize) tokens (plan-authoritative)"
-        )
+        // Apply BackendLoadOptions. Each branch is no-op when the option matches
+        // the library default, preserving bit-exact behaviour for callers that
+        // don't set load options explicitly.
+        switch loadOptions.kvCacheQuantization {
+        case .f16:
+            // Library default; leave ctxParams.type_k / type_v as-is (GGML_TYPE_F16).
+            break
+        case .q8:
+            ctxParams.type_k = GGML_TYPE_Q8_0
+            ctxParams.type_v = GGML_TYPE_Q8_0
+        case .q4:
+            ctxParams.type_k = GGML_TYPE_Q4_0
+            ctxParams.type_v = GGML_TYPE_Q4_0
+        }
+
+        // Flash attention. Simulator path stays disabled regardless of the
+        // requested value: simulator Metal does not reliably support FA kernels.
+        #if !targetEnvironment(simulator)
+        if loadOptions.flashAttention {
+            ctxParams.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_ENABLED
+        }
+        #endif
+
+        if let prefillBatch = loadOptions.prefillBatchSize {
+            ctxParams.n_batch = UInt32(max(1, prefillBatch))
+        }
+
+        let prefillBatchDescription = loadOptions.prefillBatchSize.map(String.init) ?? "default"
+        let kvDescription = loadOptions.kvCacheQuantization.rawValue
+        let faDescription = loadOptions.flashAttention ? "on" : "off"
+        Self.logger.info("""
+            LlamaBackend: initializing context at \(effectiveContextSize, privacy: .public) tokens (plan-authoritative); \
+            kv=\(kvDescription, privacy: .public), fa=\(faDescription, privacy: .public), \
+            prefillBatch=\(prefillBatchDescription, privacy: .public)
+            """)
 
         // Single attempt. The plan is authoritative — it has already clamped the
         // context to a memory-safe value. If llama_init_from_model still returns

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -138,6 +138,18 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
     /// Access only under `stateLock`.
     private var _supportsVision = false
 
+    /// Backend tuning knobs (KV cache quantization, prefill batch size).
+    /// Applied at every ``generate`` call's ``GenerateParameters`` construction.
+    /// Access only under `stateLock`. MLX honours `kvCacheQuantization` and
+    /// `prefillBatchSize`; `flashAttention` is silently ignored (MLX's SDPA
+    /// path is always flash-attention-shaped).
+    private var _loadOptions: BackendLoadOptions = .default
+
+    /// Test-only read-side accessor that snapshots `_loadOptions` under the
+    /// state lock. Lets plumbing tests assert the setter persisted the value
+    /// without needing a real model load.
+    var loadOptionsForTesting: BackendLoadOptions { withStateLock { _loadOptions } }
+
     // MARK: - Load Progress
 
     /// Guarded by `stateLock`. Set by `setLoadProgressHandler(_:)` before each load.
@@ -890,11 +902,27 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             MLXRandom.seed(seed)
         }
 
+        // Snapshot load options under the lock — same pattern as the prompt-cache
+        // snapshot. Per-generation reads stay coherent even if `setLoadOptions(_:)`
+        // is called mid-flight from another actor.
+        let loadOptions = withStateLock { _loadOptions }
+        // KV cache quantization: nil = library default (FP16). 8 / 4 map to mlx's
+        // explicit kvBits levels. Group size 64 and quantizedKVStart 0 match mlx-lm
+        // Python conventions and have no exposure on the BCK API yet.
+        let kvBits: Int? = {
+            switch loadOptions.kvCacheQuantization {
+            case .f16: return nil
+            case .q8:  return 8
+            case .q4:  return 4
+            }
+        }()
+
         // Honour `config.minP` and `config.repetitionPenalty` when set; fall back to the
         // upstream defaults / `repeatPenalty` for callers that haven't migrated to the
         // explicit knobs yet. `nil` on a context-size knob falls through to upstream's
         // own default (20 in mlx-swift-lm) by passing the upstream default explicitly.
         let generateConfig = GenerateParameters(
+            kvBits: kvBits,
             temperature: config.temperature,
             topP: config.topP,
             topK: Int(config.topK ?? 0),
@@ -904,7 +932,8 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             presencePenalty: config.presencePenalty,
             presenceContextSize: config.presenceContextSize ?? 20,
             frequencyPenalty: config.frequencyPenalty,
-            frequencyContextSize: config.frequencyContextSize ?? 20
+            frequencyContextSize: config.frequencyContextSize ?? 20,
+            prefillStepSize: loadOptions.prefillBatchSize ?? 512
         )
 
         // Build messages in chat format, using full conversation history when available
@@ -1263,6 +1292,24 @@ extension MLXBackend: LoadProgressReporting {
     /// a non-zero progress indicator rather than a flat 0% spinner.
     public func setLoadProgressHandler(_ handler: (@Sendable (Double) async -> Void)?) {
         withStateLock { _loadProgressHandler = handler }
+    }
+
+    /// Installs backend tuning knobs (KV cache quantization, prefill batch size)
+    /// applied at every ``generate(prompt:systemPrompt:config:)``
+    /// ``GenerateParameters`` construction.
+    ///
+    /// MLX honours `kvCacheQuantization` (mapped to `kvBits = nil/8/4`) and
+    /// `prefillBatchSize` (mapped to `prefillStepSize`). The `flashAttention`
+    /// field is silently ignored — MLX's SDPA path is always
+    /// flash-attention-shaped.
+    ///
+    /// Defaults preserve historical behaviour bit-for-bit. Per the BCK API
+    /// shape, `BackendLoadOptions` is named "load" because llama.cpp wires
+    /// these into `ctxParams` at context-creation time. MLX could in
+    /// principle change them per-generation; the API stays load-time-shaped
+    /// to keep both backends symmetric.
+    public func setLoadOptions(_ options: BackendLoadOptions) {
+        withStateLock { _loadOptions = options }
     }
 }
 #endif

--- a/Sources/BaseChatInference/Models/BackendLoadOptions.swift
+++ b/Sources/BaseChatInference/Models/BackendLoadOptions.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// Tuning knobs that affect how a local backend allocates KV cache, attention
+/// kernels, and prefill batches at load time.
+///
+/// Distinct from ``GenerationConfig`` (per-message) because llama.cpp wires
+/// these into `ctxParams` at context-creation time — they cannot be changed
+/// per-generation without rebuilding the context. MLX exposes some of the
+/// same knobs per-generation; BCK normalises them to load-time so the API
+/// shape matches across backends.
+///
+/// Apply via the backend's `setLoadOptions(_:)` method **before** calling
+/// `loadModel(from:plan:)`. Changing options after load takes effect on the
+/// next load. Backends that do not honour a particular field (e.g. MLX has no
+/// `flashAttention` knob — it is always on in mlx-swift's SDPA) silently
+/// ignore that field.
+///
+/// Defaults preserve historical behaviour bit-for-bit. See issue #1017 for
+/// the planned default flips after the opt-in surface has soaked through one
+/// release.
+public struct BackendLoadOptions: Sendable, Codable, Equatable {
+
+    /// KV cache element type.
+    ///
+    /// The KV cache stores per-token attention key/value tensors. Quantizing
+    /// it cuts memory roughly proportionally and is independent of the
+    /// model's weight quantization (Q4 weights + ``q8`` KV is the standard
+    /// recipe in mlx-lm Python and llama.cpp).
+    public enum KVCacheQuantization: String, Sendable, Codable, CaseIterable {
+        /// Full-precision FP16. Library default. Highest quality, highest memory.
+        case f16
+        /// 8-bit quantized. ~50% memory reduction at effectively zero quality
+        /// loss. Maps to llama.cpp's `GGML_TYPE_Q8_0` and mlx-swift-lm's
+        /// `kvBits = 8`. Recommended once the opt-in surface soaks (#1017).
+        case q8
+        /// 4-bit quantized. ~75% memory reduction with measurable quality
+        /// loss, especially on GQA/MQA models. Use only when memory pressure
+        /// forces it. Maps to `GGML_TYPE_Q4_0` and `kvBits = 4`.
+        case q4
+    }
+
+    /// KV cache element type. See ``KVCacheQuantization``.
+    public var kvCacheQuantization: KVCacheQuantization
+
+    /// Enable Flash Attention. Llama-only — MLX's SDPA path is always
+    /// flash-attention-shaped. Free perf on Metal at long context.
+    ///
+    /// Always disabled under `targetEnvironment(simulator)` regardless of
+    /// this value: simulator Metal does not reliably support FA kernels.
+    public var flashAttention: Bool
+
+    /// Number of tokens fed to the model per prefill step.
+    ///
+    /// `nil` lets each backend use its library default (llama.cpp `n_batch`
+    /// 2048; mlx-swift-lm `prefillStepSize` 512). Larger values reduce TTFT
+    /// on long prompts at the cost of a memory spike during prefill.
+    public var prefillBatchSize: Int?
+
+    public init(
+        kvCacheQuantization: KVCacheQuantization = .f16,
+        flashAttention: Bool = false,
+        prefillBatchSize: Int? = nil
+    ) {
+        self.kvCacheQuantization = kvCacheQuantization
+        self.flashAttention = flashAttention
+        self.prefillBatchSize = prefillBatchSize
+    }
+
+    /// Library-default options. Behaviour matches BCK pre-PR (no quantized KV,
+    /// no Flash Attention, library-default prefill batch).
+    public static let `default` = BackendLoadOptions()
+
+    // MARK: Codable
+
+    private enum CodingKeys: String, CodingKey {
+        case kvCacheQuantization
+        case flashAttention
+        case prefillBatchSize
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        // Forward-compat: every field decodes to its library-default when absent
+        // so older payloads written before this type existed decode cleanly.
+        kvCacheQuantization =
+            (try c.decodeIfPresent(KVCacheQuantization.self, forKey: .kvCacheQuantization)) ?? .f16
+        flashAttention = (try c.decodeIfPresent(Bool.self, forKey: .flashAttention)) ?? false
+        prefillBatchSize = try c.decodeIfPresent(Int.self, forKey: .prefillBatchSize)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(kvCacheQuantization, forKey: .kvCacheQuantization)
+        try c.encode(flashAttention, forKey: .flashAttention)
+        try c.encodeIfPresent(prefillBatchSize, forKey: .prefillBatchSize)
+    }
+}

--- a/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
@@ -28,6 +28,36 @@ final class LlamaBackendTests: XCTestCase {
         XCTAssertFalse(backend.isGenerating)
     }
 
+    // MARK: - Load Options Plumbing
+
+    func test_loadOptions_defaultIsHistoricalBehavior() {
+        let backend = LlamaBackend()
+        let opts = backend.loadOptionsForTesting
+        XCTAssertEqual(opts.kvCacheQuantization, .f16)
+        XCTAssertFalse(opts.flashAttention)
+        XCTAssertNil(opts.prefillBatchSize)
+    }
+
+    func test_setLoadOptions_persistsForNextLoad() {
+        let backend = LlamaBackend()
+        backend.setLoadOptions(BackendLoadOptions(
+            kvCacheQuantization: .q8,
+            flashAttention: true,
+            prefillBatchSize: 1024
+        ))
+        let opts = backend.loadOptionsForTesting
+        XCTAssertEqual(opts.kvCacheQuantization, .q8)
+        XCTAssertTrue(opts.flashAttention)
+        XCTAssertEqual(opts.prefillBatchSize, 1024)
+    }
+
+    func test_setLoadOptions_overridesPreviousValue() {
+        let backend = LlamaBackend()
+        backend.setLoadOptions(BackendLoadOptions(kvCacheQuantization: .q4))
+        backend.setLoadOptions(BackendLoadOptions(kvCacheQuantization: .q8))
+        XCTAssertEqual(backend.loadOptionsForTesting.kvCacheQuantization, .q8)
+    }
+
     // MARK: - Capabilities
 
     func test_capabilities_supportsAllSamplingParameters() {

--- a/Tests/BaseChatBackendsTests/MLXBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXBackendTests.swift
@@ -47,6 +47,29 @@ final class MLXBackendTests: XCTestCase {
         XCTAssertTrue(caps.supportedParameters.contains(.frequencyPenalty))
     }
 
+    // MARK: - Load Options Plumbing (no hardware gate)
+
+    func test_loadOptions_defaultIsHistoricalBehavior() {
+        let opts = MLXBackend().loadOptionsForTesting
+        XCTAssertEqual(opts.kvCacheQuantization, .f16)
+        XCTAssertFalse(opts.flashAttention)
+        XCTAssertNil(opts.prefillBatchSize)
+    }
+
+    func test_setLoadOptions_persistsForNextLoad() {
+        let backend = MLXBackend()
+        backend.setLoadOptions(BackendLoadOptions(
+            kvCacheQuantization: .q4,
+            flashAttention: true,
+            prefillBatchSize: 2048
+        ))
+        let opts = backend.loadOptionsForTesting
+        XCTAssertEqual(opts.kvCacheQuantization, .q4)
+        XCTAssertTrue(opts.flashAttention,
+                      "flashAttention must round-trip through state even though MLX silently ignores it on the generate path")
+        XCTAssertEqual(opts.prefillBatchSize, 2048)
+    }
+
     func test_capabilities_contextSize() {
         XCTAssertEqual(MLXBackend().capabilities.maxContextTokens, 8192)
     }

--- a/Tests/BaseChatInferenceTests/BackendLoadOptionsTests.swift
+++ b/Tests/BaseChatInferenceTests/BackendLoadOptionsTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+@testable import BaseChatInference
+
+/// Coverage for ``BackendLoadOptions`` — the value type that carries KV cache
+/// quantization, Flash Attention, and prefill batch size into the local
+/// backends' load path.
+final class BackendLoadOptionsTests: XCTestCase {
+
+    // MARK: - Defaults
+
+    func test_default_isHistoricalBehavior() {
+        let opts = BackendLoadOptions.default
+        XCTAssertEqual(opts.kvCacheQuantization, .f16,
+                       "Default must preserve full-precision KV cache so opt-in PR doesn't shift behaviour")
+        XCTAssertFalse(opts.flashAttention,
+                       "Default must keep Flash Attention disabled so existing token streams don't change")
+        XCTAssertNil(opts.prefillBatchSize,
+                     "Default leaves prefill batch at the library default (nil sentinel)")
+    }
+
+    func test_init_propagatesAllFields() {
+        let opts = BackendLoadOptions(
+            kvCacheQuantization: .q8,
+            flashAttention: true,
+            prefillBatchSize: 1024
+        )
+        XCTAssertEqual(opts.kvCacheQuantization, .q8)
+        XCTAssertTrue(opts.flashAttention)
+        XCTAssertEqual(opts.prefillBatchSize, 1024)
+    }
+
+    // MARK: - Equality
+
+    func test_equality_holdsAcrossIdenticalValues() {
+        XCTAssertEqual(
+            BackendLoadOptions(kvCacheQuantization: .q4, flashAttention: true, prefillBatchSize: 2048),
+            BackendLoadOptions(kvCacheQuantization: .q4, flashAttention: true, prefillBatchSize: 2048)
+        )
+    }
+
+    func test_equality_distinguishesEachField() {
+        let base = BackendLoadOptions(kvCacheQuantization: .f16, flashAttention: false, prefillBatchSize: nil)
+        XCTAssertNotEqual(base, BackendLoadOptions(kvCacheQuantization: .q8, flashAttention: false, prefillBatchSize: nil))
+        XCTAssertNotEqual(base, BackendLoadOptions(kvCacheQuantization: .f16, flashAttention: true, prefillBatchSize: nil))
+        XCTAssertNotEqual(base, BackendLoadOptions(kvCacheQuantization: .f16, flashAttention: false, prefillBatchSize: 512))
+    }
+
+    // MARK: - KVCacheQuantization enum
+
+    func test_kvCacheQuantization_allCasesAreDistinct() {
+        XCTAssertEqual(BackendLoadOptions.KVCacheQuantization.allCases.count, 3)
+        XCTAssertEqual(Set(BackendLoadOptions.KVCacheQuantization.allCases),
+                       [.f16, .q8, .q4])
+    }
+
+    func test_kvCacheQuantization_codableUsesRawString() throws {
+        // Pinning the wire format — if these change, persisted preset payloads break.
+        let cases: [BackendLoadOptions.KVCacheQuantization] = [.f16, .q8, .q4]
+        let data = try JSONEncoder().encode(cases)
+        let json = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertTrue(json.contains("\"f16\""))
+        XCTAssertTrue(json.contains("\"q8\""))
+        XCTAssertTrue(json.contains("\"q4\""))
+
+        let decoded = try JSONDecoder().decode([BackendLoadOptions.KVCacheQuantization].self, from: data)
+        XCTAssertEqual(decoded, cases)
+    }
+
+    // MARK: - Codable round-trip
+
+    func test_codable_roundtripPreservesAllFields() throws {
+        let original = BackendLoadOptions(
+            kvCacheQuantization: .q8,
+            flashAttention: true,
+            prefillBatchSize: 1024
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(BackendLoadOptions.self, from: data)
+
+        XCTAssertEqual(decoded, original)
+    }
+
+    func test_codable_omitsPrefillBatchSizeWhenNil() throws {
+        let opts = BackendLoadOptions.default  // prefillBatchSize nil
+        let data = try JSONEncoder().encode(opts)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertNil(json["prefillBatchSize"],
+                     "nil prefillBatchSize must stay out of the wire payload to keep persisted shapes compact")
+    }
+
+    func test_codableDecode_legacyEmptyPayload_decodesToDefault() throws {
+        // Forward-compat: a payload written before this type existed (or by a
+        // future caller that omits all fields) must decode to the documented
+        // default rather than throw.
+        let legacyJSON = "{}"
+        let data = try XCTUnwrap(legacyJSON.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(BackendLoadOptions.self, from: data)
+
+        XCTAssertEqual(decoded, .default)
+    }
+
+    func test_codableDecode_partialPayload_fillsMissingFieldsWithDefaults() throws {
+        // Only `kvCacheQuantization` set — flashAttention and prefillBatchSize must
+        // decode to their library defaults so callers get a coherent value type.
+        let partialJSON = """
+        { "kvCacheQuantization": "q8" }
+        """
+        let data = try XCTUnwrap(partialJSON.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(BackendLoadOptions.self, from: data)
+
+        XCTAssertEqual(decoded.kvCacheQuantization, .q8)
+        XCTAssertFalse(decoded.flashAttention)
+        XCTAssertNil(decoded.prefillBatchSize)
+    }
+}


### PR DESCRIPTION
## Summary

Adds opt-in load-time tuning knobs to `LlamaBackend` and `MLXBackend`, exposed via a single backend-agnostic value type. Defaults preserve historical behaviour bit-for-bit.

This is **PR 2 of 2** — depends on **#1022** (per-generation sampler knobs). Base branch is set to `feat/per-generation-sampler-knobs` so the diff is just the load-time work; once #1022 merges, GitHub will auto-retarget this to `main`.

## What's new

### `BackendLoadOptions` value type

`Sources/BaseChatInference/Models/BackendLoadOptions.swift`:

```swift
public struct BackendLoadOptions: Sendable, Codable, Equatable {
    public enum KVCacheQuantization: String { case f16, q8, q4 }
    public var kvCacheQuantization: KVCacheQuantization     // .f16 default
    public var flashAttention: Bool                          // false default; llama-only
    public var prefillBatchSize: Int?                        // nil = library default
    public static let `default` = BackendLoadOptions()
}
```

Codable forward-compat: every field decodes to its library default when absent so older preset payloads decode cleanly.

### Why a separate type, not `GenerationConfig` fields

llama.cpp wires KV cache quantization and Flash Attention into `ctxParams` at context-creation time — they cannot be changed per-generation without rebuilding the context. MLX could in principle change them per-generation, but BCK normalises to load-time so the API shape stays symmetric across backends.

### `setLoadOptions(_:)` setter on both backends

```swift
let backend = LlamaBackend()
backend.setLoadOptions(BackendLoadOptions(
    kvCacheQuantization: .q8,        // ~50% KV memory cut
    flashAttention: true,            // free perf on Metal at long context
    prefillBatchSize: 2048           // faster TTFT on long prompts
))
try await backend.loadModel(from: url, plan: plan)
```

Calling after a model is already loaded does not retune the live context — applying KV-quantization changes requires rebuilding the llama context, which only happens at load time.

### Wiring details

**`LlamaBackend` / `LlamaModelLoader`:**
- `_loadOptions` state, NSLock-protected
- `loadModel` snapshots options under the lock (same pattern as `_loadProgressHandler`) and passes through `serializedModelLoad` → `initializeModel`
- `initializeModel` applies to `ctxParams.type_k`/`type_v` (GGML_TYPE_Q8_0/Q4_0), `ctxParams.flash_attn_type` (`LLAMA_FLASH_ATTN_TYPE_ENABLED`), `ctxParams.n_batch`
- **Simulator guard**: `flash_attn_type` only applied under `#if !targetEnvironment(simulator)` — Metal in simulator doesn't reliably support FA kernels
- Logger emits the active KV/FA/prefill values at load time for diagnosis

**`MLXBackend`:**
- Same `_loadOptions` / setter / state-lock pattern
- Generate path snapshots options and maps to `GenerateParameters.kvBits` (nil/8/4) + `prefillStepSize`
- `flashAttention` field is silently ignored — MLX's SDPA path is always flash-attention-shaped

### Out of scope (deferred)

- **Default flips** — flip `kvCacheQuantization = .q8` and `flashAttention = true` (non-simulator) defaults after the opt-in surface soaks: issue **#1017**
- **Hardware-gated integration tests** (KV memory shrink, FA token-stream determinism, prefill batch equivalence) — the unit + plumbing tests in this PR cover state propagation and library mapping; real-world quality regressions would surface through the opt-in surface and can get dedicated tests if/when reported

## Test plan

- [x] `BackendLoadOptionsTests` — 10 tests: defaults, equality per-field, enum cases + raw-string Codable contract, Codable roundtrip, partial-payload decode (forward-compat)
- [x] `LlamaBackendTests` — 3 plumbing tests: default state, setter persists, setter overrides previous value
- [x] `MLXBackendTests` — 2 plumbing tests: default state, setter round-trips through state (incl. `flashAttention` even though MLX silently ignores it on the generate path)
- [x] Pre-push gate — XCTest 2456 passing, Swift Testing 83 passing locally (two unrelated UI test flakes seen across runs: `ConsumerRuntimeHarnessTests` temp-dir cleanup race + `ChatViewModelScenePhaseIntegrationTests` token-growth slack — both pre-existing, alternate between runs, no relation to this PR)
- [ ] CI green
- [ ] Apple Silicon `--traits MLX,Llama` smoke before merge — load a real GGUF with `kvCacheQuantization = .q8` to confirm the `ctxParams.type_k`/`type_v` wiring doesn't regress llama init

🤖 Generated with [Claude Code](https://claude.com/claude-code)