### PR TITLE
feat: wire image generation stack into BaseChatBootstrap

### DIFF
--- a/Sources/BaseChatPersistenceSwiftData/BaseChatBootstrap.swift
+++ b/Sources/BaseChatPersistenceSwiftData/BaseChatBootstrap.swift
@@ -57,11 +57,23 @@ public final class BaseChatBootstrap {
     /// path.
     public let conversationRuntime: ConversationRuntime
 
+    /// The image-generation service, when the host opted in to image generation.
+    /// `nil` when ``BaseChatBootstrap`` was constructed without an
+    /// `imageGenerationService` parameter.
+    public let imageGenerationService: ImageGenerationService?
+
+    /// The image-generation runtime, pre-wired against ``imageGenerationService``
+    /// and ``persistence``. Pass to ``ChatViewModel/configure(imageRuntime:)``
+    /// to enable image generation in the chat view model.
+    /// `nil` when ``imageGenerationService`` is `nil`.
+    public let imageRuntime: ImageGenerationRuntime?
+
     public var modelContext: ModelContext { modelContainer.mainContext }
 
     public init(
         configuration: BaseChatConfiguration,
         inferenceService: InferenceService? = nil,
+        imageGenerationService: ImageGenerationService? = nil,
         diagnostics: DiagnosticsService = DiagnosticsService(),
         makeModelContainer: @MainActor () throws -> ModelContainer = { try ModelContainerFactory.makeContainer() }
     ) throws {
@@ -91,6 +103,15 @@ public final class BaseChatBootstrap {
                 sessionStore: resolvedPersistence,
                 inferenceService: resolvedInferenceService
             )
+            self.imageGenerationService = imageGenerationService
+            if let imageGenerationService {
+                self.imageRuntime = ImageGenerationRuntime(
+                    service: imageGenerationService,
+                    messageStore: resolvedPersistence
+                )
+            } else {
+                self.imageRuntime = nil
+            }
         } catch {
             BaseChatConfiguration.shared = previousConfiguration
             throw error
@@ -104,7 +125,8 @@ public final class BaseChatBootstrap {
         persistence: SwiftDataPersistenceProvider,
         samplerPresetStore: SwiftDataSamplerPresetStore,
         benchmarkCache: SwiftDataBenchmarkCache,
-        endpointStore: SwiftDataEndpointStore
+        endpointStore: SwiftDataEndpointStore,
+        imageGenerationService: ImageGenerationService? = nil
     ) {
         self.inferenceService = inferenceService
         self.diagnostics = diagnostics
@@ -118,11 +140,21 @@ public final class BaseChatBootstrap {
             sessionStore: persistence,
             inferenceService: inferenceService
         )
+        self.imageGenerationService = imageGenerationService
+        if let imageGenerationService {
+            self.imageRuntime = ImageGenerationRuntime(
+                service: imageGenerationService,
+                messageStore: persistence
+            )
+        } else {
+            self.imageRuntime = nil
+        }
     }
 
     public static func build(
         configuration: BaseChatConfiguration,
         inferenceService: InferenceService? = nil,
+        imageGenerationService: ImageGenerationService? = nil,
         diagnostics: DiagnosticsService = DiagnosticsService(),
         makeModelContainer: @MainActor @escaping () throws -> ModelContainer = { try ModelContainerFactory.makeContainer() }
     ) -> (progress: AsyncStream<RuntimeBootstrapMilestone>, task: Task<BaseChatBootstrap, any Error>) {
@@ -165,7 +197,8 @@ public final class BaseChatBootstrap {
                     persistence: persistence,
                     samplerPresetStore: samplerPresetStore,
                     benchmarkCache: benchmarkCache,
-                    endpointStore: endpointStore
+                    endpointStore: endpointStore,
+                    imageGenerationService: imageGenerationService
                 )
             } catch {
                 BaseChatConfiguration.shared = previousConfiguration

--- a/Sources/BaseChatUI/ViewModels/RuntimeConfiguration.swift
+++ b/Sources/BaseChatUI/ViewModels/RuntimeConfiguration.swift
@@ -14,6 +14,24 @@ extension ChatViewModel {
     public func configure(runtime: BaseChatBootstrap) {
         configure(persistence: runtime.persistence)
     }
+
+    /// Wires the bootstrap's runtimes into this ``ChatViewModel``.
+    ///
+    /// Equivalent to calling `configure(persistence:)` with the bootstrap's
+    /// persistence layer and (if image generation is enabled)
+    /// `configure(imageRuntime:)` with the bootstrap's
+    /// ``BaseChatBootstrap/imageRuntime``.
+    ///
+    /// - Parameter bootstrap: The fully-constructed ``BaseChatBootstrap``
+    ///   instance produced by ``BaseChatBootstrap/init(configuration:inferenceService:imageGenerationService:diagnostics:makeModelContainer:)``
+    ///   or ``BaseChatBootstrap/build(configuration:inferenceService:imageGenerationService:diagnostics:makeModelContainer:)``.
+    @MainActor
+    public func configure(_ bootstrap: BaseChatBootstrap) {
+        configure(persistence: bootstrap.persistence)
+        if let imageRuntime = bootstrap.imageRuntime {
+            configure(imageRuntime: imageRuntime)
+        }
+    }
 }
 
 extension SessionManagerViewModel {

--- a/Tests/BaseChatPersistenceSwiftDataTests/BootstrapImageWiringTests.swift
+++ b/Tests/BaseChatPersistenceSwiftDataTests/BootstrapImageWiringTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+import BaseChatRuntime
+@testable import BaseChatPersistenceSwiftData
+@testable import BaseChatInference
+
+/// Defends the image-generation opt-in wiring on ``BaseChatBootstrap`` (PR 9 / umbrella #1002).
+///
+/// Hosts that do not pass `imageGenerationService:` get identical behaviour to
+/// pre-PR-9 bootstrap — both image properties remain `nil`. Hosts that opt in
+/// get a wired ``ImageGenerationRuntime`` backed by the supplied service and
+/// the bootstrap's persistence layer.
+@MainActor
+final class BootstrapImageWiringTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeBootstrap(
+        imageGenerationService: ImageGenerationService? = nil
+    ) throws -> BaseChatBootstrap {
+        let originalConfiguration = BaseChatConfiguration.shared
+        addTeardownBlock { BaseChatConfiguration.shared = originalConfiguration }
+
+        return try BaseChatBootstrap(
+            configuration: BaseChatConfiguration(
+                appName: "Bootstrap Image Wiring Tests",
+                bundleIdentifier: "com.basechatkit.tests.bootstrap-image-wiring.\(UUID().uuidString)"
+            ),
+            imageGenerationService: imageGenerationService,
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+    }
+
+    // MARK: - Test 1: Default init — image stack is nil
+
+    func test_defaultInit_imagePropertiesAreNil() throws {
+        // Hosts that don't pass `imageGenerationService:` must not observe any
+        // image-generation surface on the bootstrap — neither the service nor
+        // the runtime. Sabotage the nil-assignment of `imageGenerationService`
+        // or `imageRuntime` in BaseChatBootstrap.init and this test fails.
+        let bootstrap = try makeBootstrap()
+
+        XCTAssertNil(
+            bootstrap.imageGenerationService,
+            "imageGenerationService must be nil when not provided at init time"
+        )
+        XCTAssertNil(
+            bootstrap.imageRuntime,
+            "imageRuntime must be nil when imageGenerationService is nil"
+        )
+    }
+
+    // MARK: - Test 2: Opt-in init — image stack is wired
+
+    func test_optInInit_imagePropertiesAreNonNil() throws {
+        // When the host passes an `ImageGenerationService`, both the service
+        // and the runtime must be present and the runtime must hold the
+        // exact service instance that was supplied.
+        //
+        // Sabotage: comment out `self.imageRuntime = ImageGenerationRuntime(...)`
+        // in BaseChatBootstrap.init and this test fails on `imageRuntime` nil check.
+        let service = ImageGenerationService()
+        let bootstrap = try makeBootstrap(imageGenerationService: service)
+
+        XCTAssertNotNil(
+            bootstrap.imageGenerationService,
+            "imageGenerationService must be non-nil when provided at init time"
+        )
+        XCTAssertNotNil(
+            bootstrap.imageRuntime,
+            "imageRuntime must be non-nil when imageGenerationService is provided"
+        )
+        XCTAssertTrue(
+            bootstrap.imageGenerationService === service,
+            "imageGenerationService must be the exact instance passed to init"
+        )
+    }
+}

--- a/Tests/BaseChatUITests/BootstrapConfigureImageWiringTests.swift
+++ b/Tests/BaseChatUITests/BootstrapConfigureImageWiringTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+import BaseChatRuntime
+@testable import BaseChatUI
+@testable import BaseChatPersistenceSwiftData
+@testable import BaseChatInference
+
+/// Defends the `ChatViewModel.configure(_:)` convenience method that wires both
+/// runtimes into a view model in a single call (PR 9 / umbrella #1002).
+///
+/// Tests 3 and 4 from the BootstrapImageWiring spec live here because
+/// `BaseChatPersistenceSwiftDataTests` cannot import `BaseChatUI` (no `ChatViewModel`).
+@MainActor
+final class BootstrapConfigureImageWiringTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeBootstrap(
+        imageGenerationService: ImageGenerationService? = nil
+    ) throws -> BaseChatBootstrap {
+        let originalConfiguration = BaseChatConfiguration.shared
+        addTeardownBlock { BaseChatConfiguration.shared = originalConfiguration }
+
+        return try BaseChatBootstrap(
+            configuration: BaseChatConfiguration(
+                appName: "Bootstrap Configure Image Wiring Tests",
+                bundleIdentifier: "com.basechatkit.tests.bootstrap-configure-image-wiring.\(UUID().uuidString)"
+            ),
+            imageGenerationService: imageGenerationService,
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+    }
+
+    // MARK: - Test 3: configure(_:) wires imageRuntime into ChatViewModel when opted in
+
+    func test_configure_wiresImageRuntimeIntoViewModel_whenOptedIn() throws {
+        let service = ImageGenerationService()
+        let bootstrap = try makeBootstrap(imageGenerationService: service)
+
+        let chatViewModel = ChatViewModel(
+            inferenceService: bootstrap.inferenceService,
+            conversationRuntime: bootstrap.conversationRuntime
+        )
+
+        // Before configure — imageRuntime should be nil (no runtime installed yet).
+        XCTAssertNil(
+            chatViewModel.imageRuntime,
+            "chatViewModel.imageRuntime must be nil before configure(_:) is called"
+        )
+
+        chatViewModel.configure(bootstrap)
+
+        // After configure — imageRuntime must be the bootstrap's runtime instance.
+        // Sabotage: remove `if let imageRuntime = bootstrap.imageRuntime { configure(imageRuntime: imageRuntime) }`
+        // from RuntimeConfiguration.configure(_:) and this assertion fails.
+        XCTAssertNotNil(
+            chatViewModel.imageRuntime,
+            "chatViewModel.imageRuntime must be non-nil after configure(_:) when bootstrap has an imageRuntime"
+        )
+        XCTAssertTrue(
+            chatViewModel.imageRuntime === bootstrap.imageRuntime,
+            "chatViewModel.imageRuntime must be the exact ImageGenerationRuntime the bootstrap created"
+        )
+    }
+
+    // MARK: - Test 4: configure(_:) without image service leaves chatViewModel.imageRuntime nil
+
+    func test_configure_doesNotWireImageRuntime_whenNotOptedIn() throws {
+        // A bootstrap constructed without imageGenerationService must not
+        // alter the view model's imageRuntime when configure(_:) is called.
+        let bootstrap = try makeBootstrap()
+
+        let chatViewModel = ChatViewModel(
+            inferenceService: bootstrap.inferenceService,
+            conversationRuntime: bootstrap.conversationRuntime
+        )
+
+        chatViewModel.configure(bootstrap)
+
+        XCTAssertNil(
+            chatViewModel.imageRuntime,
+            "chatViewModel.imageRuntime must remain nil when the bootstrap was not configured with an imageGenerationService"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `imageGenerationService` and `imageRuntime` as optional public stored properties on `BaseChatBootstrap`. Both are `nil` by default — hosts that don't use image generation get identical behaviour.
- Adds an `imageGenerationService:` parameter to the public `init` and `build(...)` factory. When non-nil, wires `ImageGenerationRuntime` against the service and the persistence layer.
- Adds `ChatViewModel.configure(_:)` convenience method (in `BaseChatUI/RuntimeConfiguration.swift`) that wires both the persistence layer and, when opted in, the image runtime into a `ChatViewModel` in one call.

This is PR 9 / 9 in umbrella #1002. The full image-generation stack (PRs 1–8) is already on `main`; this PR ties it together at the host entry point.

## Opt-in host pattern

```swift
// Opt in to image generation at bootstrap:
let imageService = ImageGenerationService()
let bootstrap = try BaseChatBootstrap(
    configuration: config,
    imageGenerationService: imageService
)
// Register the MLX backend (Apple Silicon only):
#if MLX
imageService.registerMLXDiffusionBackend()
#endif
// Wire both runtimes into the view model:
chatViewModel.configure(bootstrap)
```

Hosts that don't pass `imageGenerationService` continue to work without any changes.

## Test plan

- [x] Default init: `imageGenerationService` and `imageRuntime` are nil (`BootstrapImageWiringTests`).
- [x] Opt-in init: both are non-nil and runtime is wired to service + persistence (`BootstrapImageWiringTests`).
- [x] `configure(_:)` wires `imageRuntime` into `ChatViewModel` when present (`BootstrapConfigureImageWiringTests`).
- [x] `configure(_:)` leaves `chatViewModel.imageRuntime == nil` when not opted in (`BootstrapConfigureImageWiringTests`).
- [x] Sabotage check: commenting out the `imageRuntime` assignment in `init` causes test 2 to fail.
- [x] Full pre-push gate passes locally (2437 tests passing, 0 failures).

## Files

- `Sources/BaseChatPersistenceSwiftData/BaseChatBootstrap.swift` — new `imageGenerationService:` param, `imageGenerationService` + `imageRuntime` properties in public init, internal init, and `build(...)`
- `Sources/BaseChatUI/ViewModels/RuntimeConfiguration.swift` — new `ChatViewModel.configure(_:)` taking a `BaseChatBootstrap`
- `Tests/BaseChatPersistenceSwiftDataTests/BootstrapImageWiringTests.swift` — new (tests 1 & 2)
- `Tests/BaseChatUITests/BootstrapConfigureImageWiringTests.swift` — new (tests 3 & 4)

## Note on placement of `configure(_:)`

`BaseChatPersistenceSwiftData` does not import `BaseChatUI` (it's the other direction), so `configure(_ chatViewModel:)` cannot live on `BaseChatBootstrap` directly. It follows the existing pattern in `RuntimeConfiguration.swift` — an extension on `ChatViewModel` in `BaseChatUI` that accepts a `BaseChatBootstrap` parameter.

## Tracking

Closes #1002 (image generation runtime umbrella — all 9 PRs now shipped).