### PR TITLE
feat(ui): add scroll-to-message request API

### DIFF
--- a/Sources/BaseChatUI/ViewModels/ChatScrollToMessageRequest.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatScrollToMessageRequest.swift
@@ -1,0 +1,31 @@
+import Foundation
+import BaseChatInference
+
+/// Preferred vertical alignment when scrolling a message into view.
+public enum ChatMessageScrollAnchor: Sendable, Hashable {
+    case top
+    case center
+    case bottom
+}
+
+/// A one-shot request for ``ChatView`` to scroll a message into view.
+///
+/// Each request carries a fresh ``requestID`` so callers can request the same
+/// ``messageID`` repeatedly and still trigger SwiftUI observation.
+public struct ChatScrollToMessageRequest: Sendable, Identifiable, Hashable {
+    public var id: UUID { requestID }
+
+    public let requestID: UUID
+    public let messageID: ChatMessageRecord.ID
+    public let anchor: ChatMessageScrollAnchor?
+
+    public init(
+        requestID: UUID = UUID(),
+        messageID: ChatMessageRecord.ID,
+        anchor: ChatMessageScrollAnchor? = nil
+    ) {
+        self.requestID = requestID
+        self.messageID = messageID
+        self.anchor = anchor
+    }
+}

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Messages.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Messages.swift
@@ -250,6 +250,28 @@ extension ChatViewModel {
         pinnedMessageIDs.contains(messageID)
     }
 
+    // MARK: - Scroll Requests
+
+    /// Requests that the bound ``ChatView`` scroll the message into view.
+    ///
+    /// Calling this repeatedly for the same message creates distinct requests
+    /// so observers can deterministically consume each command.
+    public func requestScrollToMessage(
+        id messageID: ChatMessageRecord.ID,
+        anchor: ChatMessageScrollAnchor? = nil
+    ) {
+        scrollToMessageRequest = ChatScrollToMessageRequest(messageID: messageID, anchor: anchor)
+    }
+
+    /// Clears a pending scroll request once the view has attempted it.
+    ///
+    /// The request identity check prevents a stale consumer from clearing a
+    /// newer request issued for the same or a different message.
+    public func consumeScrollToMessageRequest(_ request: ChatScrollToMessageRequest) {
+        guard scrollToMessageRequest?.requestID == request.requestID else { return }
+        scrollToMessageRequest = nil
+    }
+
     func stageDraftAttachment(_ part: MessagePart) {
         draftAttachments.append(part)
     }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -182,6 +182,9 @@ public final class ChatViewModel {
         set { sessionController.messages = newValue }
     }
 
+    /// One-shot command consumed by ``ChatView`` to bring a message into view.
+    public internal(set) var scrollToMessageRequest: ChatScrollToMessageRequest?
+
     /// The user's current input text.
     public var inputText: String = ""
 

--- a/Sources/BaseChatUI/Views/Chat/ChatView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ChatView.swift
@@ -430,7 +430,14 @@ public struct ChatView<APIConfig: View>: View {
                 .padding(.vertical, 8)
             }
             .defaultScrollAnchor(.bottom)
+            .onAppear {
+                _ = consumeScrollToMessageRequest(proxy: proxy)
+            }
+            .onChange(of: viewModel.scrollToMessageRequest?.requestID) {
+                _ = consumeScrollToMessageRequest(proxy: proxy)
+            }
             .onChange(of: viewModel.messages.count) {
+                if consumeScrollToMessageRequest(proxy: proxy) { return }
                 // Only auto-scroll to bottom for new messages appended at the end,
                 // not when older messages are prepended at the top.
                 if !viewModel.isLoadingOlderMessages {
@@ -438,6 +445,7 @@ public struct ChatView<APIConfig: View>: View {
                 }
             }
             .onChange(of: viewModel.messages.last?.content) {
+                if consumeScrollToMessageRequest(proxy: proxy) { return }
                 scrollToBottom(proxy: proxy)
             }
         }
@@ -581,9 +589,42 @@ public struct ChatView<APIConfig: View>: View {
         }
     }
 
+    @discardableResult
+    private func consumeScrollToMessageRequest(proxy: ScrollViewProxy) -> Bool {
+        guard let request = viewModel.scrollToMessageRequest else { return false }
+        guard Self.canConsumeScrollToMessageRequest(request, in: viewModel.messages) else { return false }
+        withAnimation(.easeOut(duration: 0.15)) {
+            proxy.scrollTo(request.messageID, anchor: request.anchor.unitPoint)
+        }
+        viewModel.consumeScrollToMessageRequest(request)
+        return true
+    }
+
+    static func canConsumeScrollToMessageRequest(
+        _ request: ChatScrollToMessageRequest,
+        in messages: [ChatMessageRecord]
+    ) -> Bool {
+        messages.contains(where: { $0.id == request.messageID })
+    }
+
     private func scrollToBottom(proxy: ScrollViewProxy) {
         withAnimation(.easeOut(duration: 0.15)) {
             proxy.scrollTo("chatBottom", anchor: .bottom)
+        }
+    }
+}
+
+private extension Optional where Wrapped == ChatMessageScrollAnchor {
+    var unitPoint: UnitPoint? {
+        switch self {
+        case .some(.top):
+            .top
+        case .some(.center):
+            .center
+        case .some(.bottom):
+            .bottom
+        case nil:
+            nil
         }
     }
 }

--- a/Tests/BaseChatUITests/ChatViewModelScrollToMessageTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelScrollToMessageTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+import SwiftUI
+import BaseChatInference
+import BaseChatTestSupport
+@testable import BaseChatUI
+
+@MainActor
+final class ChatViewModelScrollToMessageTests: XCTestCase {
+
+    func test_requestScrollToMessage_recordsMessageIDAndAnchor() {
+        let vm = makeViewModel()
+        let messageID = UUID()
+
+        vm.requestScrollToMessage(id: messageID, anchor: .center)
+
+        XCTAssertEqual(vm.scrollToMessageRequest?.messageID, messageID)
+        XCTAssertEqual(vm.scrollToMessageRequest?.anchor, .center)
+    }
+
+    func test_requestScrollToMessage_reissuesDistinctRequestsForSameMessage() {
+        let vm = makeViewModel()
+        let messageID = UUID()
+
+        vm.requestScrollToMessage(id: messageID, anchor: .top)
+        let first = vm.scrollToMessageRequest
+        vm.requestScrollToMessage(id: messageID, anchor: .top)
+        let second = vm.scrollToMessageRequest
+
+        XCTAssertEqual(first?.messageID, second?.messageID)
+        XCTAssertNotEqual(first?.requestID, second?.requestID)
+    }
+
+    func test_consumeScrollToMessageRequest_clearsMatchingRequest() throws {
+        let vm = makeViewModel()
+        vm.requestScrollToMessage(id: UUID(), anchor: .bottom)
+        let request = try XCTUnwrap(vm.scrollToMessageRequest)
+
+        vm.consumeScrollToMessageRequest(request)
+
+        XCTAssertNil(vm.scrollToMessageRequest)
+    }
+
+    func test_consumeScrollToMessageRequest_doesNotClearNewerRequest() throws {
+        let vm = makeViewModel()
+        vm.requestScrollToMessage(id: UUID(), anchor: .top)
+        let stale = try XCTUnwrap(vm.scrollToMessageRequest)
+        let newerMessageID = UUID()
+        vm.requestScrollToMessage(id: newerMessageID, anchor: .bottom)
+
+        vm.consumeScrollToMessageRequest(stale)
+
+        XCTAssertEqual(vm.scrollToMessageRequest?.messageID, newerMessageID)
+        XCTAssertEqual(vm.scrollToMessageRequest?.anchor, .bottom)
+    }
+
+    func test_chatViewConsumesOnlyWhenRequestedMessageIsLoaded() {
+        let sessionID = UUID()
+        let requested = ChatMessageRecord(role: .user, content: "target", sessionID: sessionID)
+        let other = ChatMessageRecord(role: .assistant, content: "other", sessionID: sessionID)
+        let request = ChatScrollToMessageRequest(messageID: requested.id, anchor: .top)
+
+        XCTAssertTrue(
+            ChatView<EmptyView>.canConsumeScrollToMessageRequest(request, in: [other, requested]),
+            "ChatView should consume a request once its target row exists."
+        )
+        XCTAssertFalse(
+            ChatView<EmptyView>.canConsumeScrollToMessageRequest(request, in: [other]),
+            "ChatView should leave missing-message requests pending so later pagination/load can satisfy them."
+        )
+    }
+
+    private func makeViewModel() -> ChatViewModel {
+        let mock = MockInferenceBackend()
+        let service = InferenceService(backend: mock, name: "MockScrollToMessage")
+        return ChatViewModel(inferenceService: service)
+    }
+}


### PR DESCRIPTION
## Summary
- add public ChatViewModel scroll-to-message request state and command API
- consume requests in ChatView through the existing ScrollViewReader while preserving bottom auto-scroll
- cover request identity, stale consumption, and loaded-message consumption behavior in BaseChatUITests

## Tests
- scripts/test.sh --filter ChatViewModelScrollToMessageTests --disable-default-traits --skip-update
- scripts/test.sh --filter BaseChatUITests --disable-default-traits --skip-update