### PR TITLE
feat(backends): add llama DRY sampler option

### DIFF
--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -50,6 +50,7 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
             supportedParameters: [
                 .temperature, .topP, .topK, .repeatPenalty,
                 .minP, .repetitionPenalty, .presencePenalty, .frequencyPenalty,
+                .llamaDRY,
             ],
             maxContextTokens: ctxSize,
             requiresPromptTemplate: true,

--- a/Sources/BaseChatBackends/LlamaGenerationDriver.swift
+++ b/Sources/BaseChatBackends/LlamaGenerationDriver.swift
@@ -31,6 +31,17 @@ struct LlamaGenerationDriver {
     /// Capacity of the phrase-detection token buffer (maxPhraseLen × minPhraseRepeats + 1).
     private static let phraseWindowCap = maxPhraseLen * minPhraseRepeats + 1
 
+    struct DRYSamplerDescriptor: Equatable {
+        let nCtxTrain: Int32
+        let options: LlamaDRYSamplerOptions
+
+        init?(config: GenerationConfig, nCtxTrain: Int32) {
+            guard let options = config.llamaDRY else { return nil }
+            self.nCtxTrain = nCtxTrain
+            self.options = options
+        }
+    }
+
     // MARK: - Run
 
     /// Executes the generation loop: clears the KV cache, builds the sampler
@@ -118,7 +129,7 @@ struct LlamaGenerationDriver {
         // `std::runtime_error: Unexpected empty grammar stack` across the C ABI
         // and aborts the process with libc++abi (see prior crash logs from
         // test_grammar_cancelCleansTeardown). Final order:
-        //   penalties → grammar → top_k → top_p → min_p → temp → dist
+        //   penalties → grammar → dry → top_k → top_p → min_p → temp → dist
         let sparams = llama_sampler_chain_default_params()
         guard let sampler = llama_sampler_chain_init(sparams) else {
             await MainActor.run { generationStream.setPhase(.failed("Failed to create sampler")) }
@@ -173,6 +184,26 @@ struct LlamaGenerationDriver {
                 // so the cache is still coherent and the caller can keep `sessionKVState`.
                 return true
             }
+        }
+
+        if let model = llama_get_model(context),
+           let dry = DRYSamplerDescriptor(config: config, nCtxTrain: llama_model_n_ctx_train(model)) {
+            let drySampler = withCStringArray(dry.options.sequenceBreakers) { breakers in
+                var mutableBreakers = breakers
+                return mutableBreakers.withUnsafeMutableBufferPointer { breakerBuffer in
+                    llama_sampler_init_dry(
+                        vocab,
+                        dry.nCtxTrain,
+                        dry.options.multiplier,
+                        dry.options.base,
+                        dry.options.allowedLength,
+                        dry.options.penaltyLastN,
+                        breakerBuffer.baseAddress,
+                        breakerBuffer.count
+                    )
+                }
+            }
+            llama_sampler_chain_add(sampler, drySampler)
         }
 
         // Surface `config.topK` to the sampler chain. Historical default of 40 is
@@ -469,6 +500,27 @@ struct LlamaGenerationDriver {
             if window[start..<end].elementsEqual(phrase) == false { return false }
         }
         return true
+    }
+
+    private func withCStringArray<Result>(
+        _ strings: [String],
+        _ body: ([UnsafePointer<CChar>?]) -> Result
+    ) -> Result {
+        var pointers: [UnsafePointer<CChar>?] = []
+
+        func append(_ index: Int) -> Result {
+            guard index < strings.count else {
+                return body(pointers)
+            }
+
+            return strings[index].withCString { pointer in
+                pointers.append(pointer)
+                defer { pointers.removeLast() }
+                return append(index + 1)
+            }
+        }
+
+        return append(0)
     }
 }
 #endif

--- a/Sources/BaseChatInference/Protocols/BackendCapabilities.swift
+++ b/Sources/BaseChatInference/Protocols/BackendCapabilities.swift
@@ -11,6 +11,7 @@ public enum GenerationParameter: String, CaseIterable, Sendable, Codable {
     case repetitionPenalty
     case presencePenalty
     case frequencyPenalty
+    case llamaDRY
 }
 
 /// How the backend loads model weights into memory.

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -1,5 +1,38 @@
 import Foundation
 
+/// llama.cpp DRY sampler configuration.
+///
+/// DRY ("Don't Repeat Yourself") penalizes tokens that would extend repeated
+/// token sequences. This is llama.cpp-specific: other backends ignore it. The
+/// defaults mirror llama.cpp's `common_params_sampling` defaults; keep
+/// ``GenerationConfig/llamaDRY`` `nil` to preserve each backend's sampler chain.
+public struct LlamaDRYSamplerOptions: Sendable, Codable, Equatable {
+    /// Penalty multiplier. `0.0` disables DRY in llama.cpp.
+    public var multiplier: Float
+    /// Exponential penalty base. llama.cpp treats values below `1.0` as disabled.
+    public var base: Float
+    /// Repetition length allowed before DRY applies a penalty.
+    public var allowedLength: Int32
+    /// Number of recent tokens to scan (`-1` = training context, `0` = disabled).
+    public var penaltyLastN: Int32
+    /// Sequence breakers that reset repetition scanning.
+    public var sequenceBreakers: [String]
+
+    public init(
+        multiplier: Float = 0.0,
+        base: Float = 1.75,
+        allowedLength: Int32 = 2,
+        penaltyLastN: Int32 = -1,
+        sequenceBreakers: [String] = ["\n", ":", "\"", "*"]
+    ) {
+        self.multiplier = multiplier
+        self.base = base
+        self.allowedLength = allowedLength
+        self.penaltyLastN = penaltyLastN
+        self.sequenceBreakers = sequenceBreakers
+    }
+}
+
 /// Sampling and generation parameters shared across all inference backends.
 public struct GenerationConfig: Sendable, Codable {
     public var temperature: Float
@@ -70,6 +103,13 @@ public struct GenerationConfig: Sendable, Codable {
     /// `nil` lets each backend use its own default. MLX-only — see
     /// ``presenceContextSize`` for why llama.cpp ignores it.
     public var frequencyContextSize: Int?
+
+    /// llama.cpp DRY repetition sampler options.
+    ///
+    /// `nil` (the default) preserves the backend's existing sampler chain. When
+    /// set, ``LlamaBackend`` inserts `llama_sampler_init_dry` after penalties
+    /// and grammar, before probability filters. Other backends ignore it.
+    public var llamaDRY: LlamaDRYSamplerOptions?
 
     /// Deterministic sampling seed.
     ///
@@ -225,7 +265,8 @@ public struct GenerationConfig: Sendable, Codable {
         thinkingMarkers: ThinkingMarkers? = nil,
         maxToolIterations: Int = 10,
         grammar: String? = nil,
-        yieldEveryNTokens: Int = 8
+        yieldEveryNTokens: Int = 8,
+        llamaDRY: LlamaDRYSamplerOptions? = nil
     ) {
         self.temperature = temperature
         self.topP = topP
@@ -246,6 +287,7 @@ public struct GenerationConfig: Sendable, Codable {
         self.maxToolIterations = max(1, maxToolIterations)
         self.grammar = grammar
         self.yieldEveryNTokens = yieldEveryNTokens
+        self.llamaDRY = llamaDRY
     }
 
     public init(
@@ -261,6 +303,7 @@ public struct GenerationConfig: Sendable, Codable {
         presenceContextSize: Int? = nil,
         frequencyPenalty: Float? = nil,
         frequencyContextSize: Int? = nil,
+        llamaDRY: LlamaDRYSamplerOptions? = nil,
         seed: UInt64? = nil,
         maxOutputTokens: Int? = 2048,
         tools: [ToolDefinition] = [],
@@ -286,6 +329,7 @@ public struct GenerationConfig: Sendable, Codable {
         self.presenceContextSize = presenceContextSize
         self.frequencyPenalty = frequencyPenalty
         self.frequencyContextSize = frequencyContextSize
+        self.llamaDRY = llamaDRY
         self.seed = seed
         self.maxOutputTokens = maxOutputTokens
         self.tools = tools
@@ -311,6 +355,7 @@ public struct GenerationConfig: Sendable, Codable {
         case repetitionContextSize
         case presencePenalty, presenceContextSize
         case frequencyPenalty, frequencyContextSize
+        case llamaDRY
         case requiredCapabilities
     }
 
@@ -355,6 +400,7 @@ public struct GenerationConfig: Sendable, Codable {
         presenceContextSize = try c.decodeIfPresent(Int.self, forKey: .presenceContextSize)
         frequencyPenalty = try c.decodeIfPresent(Float.self, forKey: .frequencyPenalty)
         frequencyContextSize = try c.decodeIfPresent(Int.self, forKey: .frequencyContextSize)
+        llamaDRY = try c.decodeIfPresent(LlamaDRYSamplerOptions.self, forKey: .llamaDRY)
         // requiredCapabilities is a per-request runtime contract; landed after
         // the original shape, so older payloads decode to an empty set.
         requiredCapabilities = (try c.decodeIfPresent(
@@ -388,6 +434,7 @@ public struct GenerationConfig: Sendable, Codable {
         try c.encodeIfPresent(presenceContextSize, forKey: .presenceContextSize)
         try c.encodeIfPresent(frequencyPenalty, forKey: .frequencyPenalty)
         try c.encodeIfPresent(frequencyContextSize, forKey: .frequencyContextSize)
+        try c.encodeIfPresent(llamaDRY, forKey: .llamaDRY)
         if !requiredCapabilities.isEmpty {
             try c.encode(requiredCapabilities, forKey: .requiredCapabilities)
         }

--- a/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
@@ -71,6 +71,7 @@ final class LlamaBackendTests: XCTestCase {
         XCTAssertTrue(caps.supportedParameters.contains(.repetitionPenalty))
         XCTAssertTrue(caps.supportedParameters.contains(.presencePenalty))
         XCTAssertTrue(caps.supportedParameters.contains(.frequencyPenalty))
+        XCTAssertTrue(caps.supportedParameters.contains(.llamaDRY))
     }
 
     func test_capabilities_requiresPromptTemplate() {

--- a/Tests/BaseChatBackendsTests/LlamaDRYSamplerPlumbingTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaDRYSamplerPlumbingTests.swift
@@ -1,0 +1,41 @@
+#if Llama
+import XCTest
+@testable import BaseChatInference
+@testable import BaseChatBackends
+
+final class LlamaDRYSamplerPlumbingTests: XCTestCase {
+
+    func test_descriptorIsNilWhenDRYUnset() {
+        let descriptor = LlamaGenerationDriver.DRYSamplerDescriptor(
+            config: GenerationConfig(),
+            nCtxTrain: 4096
+        )
+
+        XCTAssertNil(descriptor)
+    }
+
+    func test_descriptorPreservesDRYOptionsAndTrainingContext() throws {
+        let options = LlamaDRYSamplerOptions(
+            multiplier: 0.8,
+            base: 1.9,
+            allowedLength: 4,
+            penaltyLastN: 512,
+            sequenceBreakers: ["\n", "</s>"]
+        )
+        let descriptor = try XCTUnwrap(LlamaGenerationDriver.DRYSamplerDescriptor(
+            config: GenerationConfig(llamaDRY: options),
+            nCtxTrain: 8192
+        ))
+
+        XCTAssertEqual(descriptor.nCtxTrain, 8192)
+        XCTAssertEqual(descriptor.options, options)
+    }
+
+    func test_capabilitiesAdvertiseDRYSampler() {
+        let backend = LlamaBackend()
+
+        XCTAssertTrue(backend.capabilities.supportedParameters.contains(.llamaDRY))
+    }
+}
+#endif
+

--- a/Tests/BaseChatInferenceTests/BackendCapabilitiesTests.swift
+++ b/Tests/BaseChatInferenceTests/BackendCapabilitiesTests.swift
@@ -428,10 +428,11 @@ final class BackendCapabilitiesTests: XCTestCase {
         XCTAssertTrue(allCases.contains(.repetitionPenalty))
         XCTAssertTrue(allCases.contains(.presencePenalty))
         XCTAssertTrue(allCases.contains(.frequencyPenalty))
+        XCTAssertTrue(allCases.contains(.llamaDRY))
     }
 
     func test_generationParameter_codableRoundTrip_additivePenalties() throws {
-        let cases: [GenerationParameter] = [.minP, .repetitionPenalty, .presencePenalty, .frequencyPenalty]
+        let cases: [GenerationParameter] = [.minP, .repetitionPenalty, .presencePenalty, .frequencyPenalty, .llamaDRY]
         let data = try JSONEncoder().encode(cases)
         let decoded = try JSONDecoder().decode([GenerationParameter].self, from: data)
         XCTAssertEqual(decoded, cases)

--- a/Tests/BaseChatInferenceTests/GenerationConfigTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationConfigTests.swift
@@ -243,13 +243,18 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertNil(GenerationConfig().frequencyContextSize)
     }
 
+    func test_defaultInit_llamaDRY_isNil() {
+        XCTAssertNil(GenerationConfig().llamaDRY)
+    }
+
     func test_customInit_propagatesAdditivePenaltyKnobs() {
         let config = GenerationConfig(
             repetitionContextSize: 128,
             presencePenalty: 0.4,
             presenceContextSize: 32,
             frequencyPenalty: 0.6,
-            frequencyContextSize: 16
+            frequencyContextSize: 16,
+            llamaDRY: LlamaDRYSamplerOptions(multiplier: 0.8)
         )
 
         XCTAssertEqual(config.repetitionContextSize, 128)
@@ -257,6 +262,17 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertEqual(config.presenceContextSize, 32)
         XCTAssertEqual(config.frequencyPenalty, 0.6)
         XCTAssertEqual(config.frequencyContextSize, 16)
+        XCTAssertEqual(config.llamaDRY, LlamaDRYSamplerOptions(multiplier: 0.8))
+    }
+
+    func test_llamaDRY_defaultsMatchLlamaCppCommonParams() {
+        let options = LlamaDRYSamplerOptions()
+
+        XCTAssertEqual(options.multiplier, 0.0)
+        XCTAssertEqual(options.base, 1.75)
+        XCTAssertEqual(options.allowedLength, 2)
+        XCTAssertEqual(options.penaltyLastN, -1)
+        XCTAssertEqual(options.sequenceBreakers, ["\n", ":", "\"", "*"])
     }
 
     func test_codableRoundtrip_preservesAdditivePenaltyKnobs() throws {
@@ -266,6 +282,13 @@ final class GenerationConfigTests: XCTestCase {
         original.repetitionContextSize = 96
         original.presenceContextSize = 48
         original.frequencyContextSize = 24
+        original.llamaDRY = LlamaDRYSamplerOptions(
+            multiplier: 0.7,
+            base: 1.9,
+            allowedLength: 3,
+            penaltyLastN: 256,
+            sequenceBreakers: ["\n", "</s>"]
+        )
 
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(GenerationConfig.self, from: data)
@@ -275,6 +298,7 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertEqual(decoded.repetitionContextSize, 96)
         XCTAssertEqual(decoded.presenceContextSize, 48)
         XCTAssertEqual(decoded.frequencyContextSize, 24)
+        XCTAssertEqual(decoded.llamaDRY, original.llamaDRY)
     }
 
     func test_codableDecode_legacyPayload_omittingAdditivePenaltyKnobs() throws {
@@ -298,6 +322,7 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertNil(decoded.repetitionContextSize)
         XCTAssertNil(decoded.presenceContextSize)
         XCTAssertNil(decoded.frequencyContextSize)
+        XCTAssertNil(decoded.llamaDRY)
     }
 
     func test_codable_omitsAdditivePenaltyKnobsWhenNil() throws {
@@ -311,6 +336,7 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertNil(json["repetitionContextSize"])
         XCTAssertNil(json["presenceContextSize"])
         XCTAssertNil(json["frequencyContextSize"])
+        XCTAssertNil(json["llamaDRY"])
     }
 
     // MARK: - Mock backend captures additive-penalty fields
@@ -324,7 +350,8 @@ final class GenerationConfigTests: XCTestCase {
             presencePenalty: 0.3,
             presenceContextSize: 40,
             frequencyPenalty: 0.7,
-            frequencyContextSize: 20
+            frequencyContextSize: 20,
+            llamaDRY: LlamaDRYSamplerOptions(multiplier: 0.6)
         )
         let stream = try backend.generate(prompt: "test", systemPrompt: nil, config: config)
         for try await _ in stream.events {}
@@ -334,5 +361,6 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertEqual(backend.lastConfig?.presenceContextSize, 40)
         XCTAssertEqual(backend.lastConfig?.frequencyPenalty, 0.7)
         XCTAssertEqual(backend.lastConfig?.frequencyContextSize, 20)
+        XCTAssertEqual(backend.lastConfig?.llamaDRY, LlamaDRYSamplerOptions(multiplier: 0.6))
     }
 }


### PR DESCRIPTION
## Summary\n- add Codable llama DRY sampler options to GenerationConfig\n- advertise the llamaDRY generation parameter on LlamaBackend\n- insert llama_sampler_init_dry before top_k in the llama sampler chain\n- add inference Codable/default tests and Llama plumbing tests\n\n## Validation\n- scripts/test.sh --filter GenerationConfigTests --filter BackendCapabilitiesTests --disable-default-traits --skip-update\n- swift build --build-tests --disable-default-traits\n- swift build --build-tests --traits Llama\n- scripts/test.sh --filter LlamaDRYSamplerPlumbingTests --traits Llama --skip-update\n- scripts/test.sh --filter LlamaTopKConsumptionTests --traits Llama --skip-update (skipped: no GGUF on disk)