### PR TITLE
perf(mlx): yield during long token generation

### DIFF
--- a/Sources/BaseChatBackends/MLX/MLXGenerationDriver.swift
+++ b/Sources/BaseChatBackends/MLX/MLXGenerationDriver.swift
@@ -31,7 +31,7 @@ struct MLXGenerationDriver {
     ///   2. Routes each chunk through the optional tool-call parser, then the optional
     ///      thinking parser.
     ///   3. Enforces `config.maxOutputTokens` and `config.maxThinkingTokens`.
-    ///   4. Issues a cooperative `Task.sleep(50µs)` (or the test hook) every
+    ///   4. Issues a cooperative `Task.yield()` (or the test hook) every
     ///      `config.yieldEveryNTokens` chunks to keep the WindowServer GPU queue moving.
     ///   5. Flushes both parsers' tail buffers on exit.
     ///
@@ -129,7 +129,7 @@ struct MLXGenerationDriver {
                 if let yieldHook {
                     await yieldHook()
                 } else {
-                    try? await Task.sleep(for: .microseconds(50))
+                    await Task.yield()
                 }
             }
         }

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -170,11 +170,11 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
 
     // MARK: - Test seams
 
-    /// Invoked in place of `Task.sleep(for: .microseconds(50))` at every
+    /// Invoked in place of `Task.yield()` at every
     /// `yieldEveryNTokens`-th token during generation. Tests use this to count
     /// yield occurrences deterministically without timing assertions.
     ///
-    /// `nil` in production — the real microsecond sleep runs instead.
+    /// `nil` in production — the real cooperative yield runs instead.
     nonisolated(unsafe) static var _yieldHookForTesting: (@Sendable () async -> Void)?
 
     // MARK: - Init

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -187,8 +187,7 @@ public struct GenerationConfig: Sendable, Codable {
     ///
     /// Sustained MLX inference on Mac can starve WindowServer's GPU command
     /// queue and cause hitches in other apps. To mitigate this, ``MLXBackend``
-    /// inserts a 50µs `Task.sleep` every `yieldEveryNTokens` tokens. The same
-    /// pattern is used in `SwiftLM/Server.swift`.
+    /// inserts a cooperative `Task.yield()` every `yieldEveryNTokens` tokens.
     ///
     /// - Defaults to `8` (one yield per ~8 tokens).
     /// - `0` disables the yield entirely.

--- a/Tests/BaseChatBackendsTests/MLXBackendGenerationTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXBackendGenerationTests.swift
@@ -852,7 +852,7 @@ final class MLXBackendGenerationTests: XCTestCase {
 
     /// Asserts the cooperative yield inserted to prevent WindowServer GPU-queue
     /// starvation fires every `yieldEveryNTokens` MLX-emitted chunks. We replace
-    /// the production `Task.sleep(for: .microseconds(50))` with a counting hook
+    /// the production `Task.yield()` with a counting hook
     /// so the test is deterministic and free of timing assumptions. Setting
     /// `yieldEveryNTokens = 0` must disable the yield entirely.
     ///
@@ -935,10 +935,10 @@ final class MLXBackendGenerationTests: XCTestCase {
     /// and the next loop iteration's `Task.isCancelled` check must terminate
     /// the stream cleanly.
     ///
-    /// The hook substitutes for `Task.sleep`, so to model "cancellation while
-    /// the task is sleeping" we cancel the surrounding generation Task from
-    /// inside the hook itself — this exercises the same control-flow shape as
-    /// a real cancel arriving during the 50µs sleep.
+    /// The hook substitutes for `Task.yield()`, so to model "cancellation while
+    /// yielding" we cancel the surrounding generation Task from inside the hook
+    /// itself — this exercises the same control-flow shape as a real cancel
+    /// arriving at a cooperative yield point.
     func test_yieldEveryNTokens_cancellationDuringYield_terminatesCleanly() async throws {
         let mock = MockMLXModelContainer()
         mock.tokensToYield = Array(repeating: "x", count: 32)
@@ -966,10 +966,9 @@ final class MLXBackendGenerationTests: XCTestCase {
         )
 
         // Drain the stream — must complete without throwing, even though the
-        // surrounding task was cancelled mid-yield. The `try?` on the sleep
-        // (allowlisted in SilentCatchAuditTest) intentionally swallows any
-        // CancellationError so the for-await observes cancellation at the top
-        // of the next iteration.
+        // surrounding task was cancelled mid-yield. The yield hook does not throw,
+        // matching production `Task.yield()`, so the for-await observes
+        // cancellation at the top of the next iteration.
         let tokens = try await collectTokens(from: stream)
 
         // Expect at most ~yieldEvery tokens to have been emitted before the

--- a/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
+++ b/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
@@ -172,13 +172,6 @@ BaseChatBackends/MLXBackend.swift:let parsed = try? JSONSerialization.jsonObject
 # ensures only successfully-encoded calls are appended.
 BaseChatBackends/MLXBackend.swift:if let data = try? JSONSerialization.data(withJSONObject: callObj),
 
-# 50µs cooperative yield inserted every N tokens to prevent
-# WindowServer GPU-queue starvation during sustained MLX generation
-# (see issue #747; mirrors SwiftLM/Server.swift). The sleep is
-# best-effort: if the generation Task is cancelled mid-yield we
-# intentionally fall through to the next loop iteration where
-# `Task.isCancelled` is checked, rather than observing CancellationError.
-BaseChatBackends/MLX/MLXGenerationDriver.swift:try? await Task.sleep(for: .microseconds(50))
 
 # MLXToolCallParser.parseToolCall: defensive JSON parse of the buffered
 # payload between <tool_call>…</tool_call>. Models routinely emit


### PR DESCRIPTION
## Summary
- Replace the MLX generation cadence pause with cooperative Task.yield() every configured yieldEveryNTokens chunks.
- Update MLX yield docs and the existing deterministic yield/cancellation regression tests to reflect Task.yield().

## Validation
- scripts/test.sh --filter MLXBackendGenerationTests --skip-update

## Notes
- Direct scheduling behavior is covered via the existing yield hook so the test remains non-flaky and hardware-independent.
- #748 still looks like a good follow-up if more MLX responsiveness tuning is needed.

Fixes #747
Refs #758