### PR TITLE
feat(persistence): persist sampler preset penalty knobs

### DIFF
--- a/Sources/BaseChatInference/Models/ImageMessagePayload.swift
+++ b/Sources/BaseChatInference/Models/ImageMessagePayload.swift
@@ -12,7 +12,7 @@ import Foundation
 /// ## Why URL instead of inline bytes?
 ///
 /// Generated images are typically 1–4 MB PNGs. Storing the bytes in
-/// ``BaseChatSchemaV3/ChatMessage/contentPartsJSON`` would balloon the
+/// ``BaseChatSchemaV4/ChatMessage/contentPartsJSON`` would balloon the
 /// JSON payload size for every saved row and make pagination expensive.
 /// The image binary is owned by the host app's storage strategy; this
 /// payload only references it.

--- a/Sources/BaseChatInference/Models/MessagePart.swift
+++ b/Sources/BaseChatInference/Models/MessagePart.swift
@@ -11,11 +11,11 @@ import Foundation
 ///
 /// ## Persistence compatibility
 ///
-/// ``BaseChatSchemaV3/ChatMessage/decode(_:)`` falls back to a `.text` part
+/// ``BaseChatSchemaV4/ChatMessage/decode(_:)`` falls back to a `.text` part
 /// when JSON decoding fails. Historically this meant pre-removal rows that
 /// contained ``toolCall`` / ``toolResult`` discriminators degraded gracefully
 /// to text bubbles.  Those discriminators are now first-class cases again
-/// (see ``BaseChatSchemaV3``), so such rows decode correctly as their actual
+/// (see ``BaseChatSchemaV4``), so such rows decode correctly as their actual
 /// cases. The `.text` fallback remains as a safety net for genuinely
 /// malformed JSON until V5.
 public enum MessagePart: Hashable, Sendable {

--- a/Sources/BaseChatInference/Models/SamplerPresetRecord.swift
+++ b/Sources/BaseChatInference/Models/SamplerPresetRecord.swift
@@ -12,6 +12,11 @@ public struct SamplerPresetRecord: Sendable, Hashable, Identifiable {
     public var temperature: Float
     public var topP: Float
     public var repeatPenalty: Float
+    public var presencePenalty: Float?
+    public var frequencyPenalty: Float?
+    public var repetitionContextSize: Int?
+    public var presenceContextSize: Int?
+    public var frequencyContextSize: Int?
     public var createdAt: Date
 
     public init(
@@ -20,6 +25,11 @@ public struct SamplerPresetRecord: Sendable, Hashable, Identifiable {
         temperature: Float = 0.7,
         topP: Float = 0.9,
         repeatPenalty: Float = 1.1,
+        presencePenalty: Float? = nil,
+        frequencyPenalty: Float? = nil,
+        repetitionContextSize: Int? = nil,
+        presenceContextSize: Int? = nil,
+        frequencyContextSize: Int? = nil,
         createdAt: Date = Date()
     ) {
         self.id = id
@@ -27,6 +37,11 @@ public struct SamplerPresetRecord: Sendable, Hashable, Identifiable {
         self.temperature = temperature
         self.topP = topP
         self.repeatPenalty = repeatPenalty
+        self.presencePenalty = presencePenalty
+        self.frequencyPenalty = frequencyPenalty
+        self.repetitionContextSize = repetitionContextSize
+        self.presenceContextSize = presenceContextSize
+        self.frequencyContextSize = frequencyContextSize
         self.createdAt = createdAt
     }
 }

--- a/Sources/BaseChatPersistenceSwiftData/Adapters/SwiftDataEndpointStore.swift
+++ b/Sources/BaseChatPersistenceSwiftData/Adapters/SwiftDataEndpointStore.swift
@@ -6,7 +6,7 @@ import SwiftData
 /// Default ``EndpointStore`` backed by SwiftData.
 ///
 /// Operates on the ``ModelContext`` injected at init time, converting between
-/// ``BaseChatSchemaV3/APIEndpoint`` `@Model` rows and
+/// ``BaseChatSchemaV4/APIEndpoint`` `@Model` rows and
 /// ``APIEndpointRecord`` value types at the boundary.
 @MainActor
 public final class SwiftDataEndpointStore: EndpointStore {

--- a/Sources/BaseChatPersistenceSwiftData/Adapters/SwiftDataSamplerPresetStore.swift
+++ b/Sources/BaseChatPersistenceSwiftData/Adapters/SwiftDataSamplerPresetStore.swift
@@ -6,7 +6,7 @@ import SwiftData
 /// Default ``SamplerPresetStore`` backed by SwiftData.
 ///
 /// Operates on the ``ModelContext`` injected at init time, converting between
-/// ``BaseChatSchemaV3/SamplerPreset`` `@Model` rows and ``SamplerPresetRecord``
+/// ``BaseChatSchemaV4/SamplerPreset`` `@Model` rows and ``SamplerPresetRecord``
 /// value types at the boundary.
 @MainActor
 public final class SwiftDataSamplerPresetStore: SamplerPresetStore {
@@ -29,7 +29,12 @@ public final class SwiftDataSamplerPresetStore: SamplerPresetStore {
             name: record.name,
             temperature: record.temperature,
             topP: record.topP,
-            repeatPenalty: record.repeatPenalty
+            repeatPenalty: record.repeatPenalty,
+            presencePenalty: record.presencePenalty,
+            frequencyPenalty: record.frequencyPenalty,
+            repetitionContextSize: record.repetitionContextSize,
+            presenceContextSize: record.presenceContextSize,
+            frequencyContextSize: record.frequencyContextSize
         )
         preset.id = record.id
         preset.createdAt = record.createdAt
@@ -58,6 +63,11 @@ extension SamplerPreset {
             temperature: temperature,
             topP: topP,
             repeatPenalty: repeatPenalty,
+            presencePenalty: presencePenalty,
+            frequencyPenalty: frequencyPenalty,
+            repetitionContextSize: repetitionContextSize,
+            presenceContextSize: presenceContextSize,
+            frequencyContextSize: frequencyContextSize,
             createdAt: createdAt
         )
     }

--- a/Sources/BaseChatPersistenceSwiftData/BaseChatBootstrap.swift
+++ b/Sources/BaseChatPersistenceSwiftData/BaseChatBootstrap.swift
@@ -211,7 +211,7 @@ public final class BaseChatBootstrap {
 
     // MARK: - Boot hooks
 
-    /// Removes Keychain items whose owning ``BaseChatSchemaV3/APIEndpoint`` row
+    /// Removes Keychain items whose owning ``BaseChatSchemaV4/APIEndpoint`` row
     /// no longer exists.
     ///
     /// Orphans accumulate when an endpoint row is deleted while the matching
@@ -235,7 +235,7 @@ public final class BaseChatBootstrap {
 
         let validAccounts: Set<String>
         do {
-            let descriptor = FetchDescriptor<BaseChatSchemaV3.APIEndpoint>()
+            let descriptor = FetchDescriptor<APIEndpoint>()
             let endpoints = try modelContext.fetch(descriptor)
             validAccounts = Set(endpoints.map(\.keychainAccount))
         } catch {

--- a/Sources/BaseChatPersistenceSwiftData/ModelContainerFactory.swift
+++ b/Sources/BaseChatPersistenceSwiftData/ModelContainerFactory.swift
@@ -25,7 +25,7 @@ import BaseChatInference
 public enum ModelContainerFactory {
     /// The current schema version.
     public static var currentSchema: any VersionedSchema.Type {
-        BaseChatSchemaV3.self
+        BaseChatSchemaV4.self
     }
 
     /// Returns an on-disk `ModelContainer` configured with the current schema.
@@ -39,6 +39,7 @@ public enum ModelContainerFactory {
     ) throws -> ModelContainer {
         let container = try ModelContainer(
             for: Schema(versionedSchema: currentSchema),
+            migrationPlan: BaseChatMigrationPlan.self,
             configurations: configurations
         )
         applyFileProtection(to: configurations)

--- a/Sources/BaseChatPersistenceSwiftData/Schema/APIEndpoint.swift
+++ b/Sources/BaseChatPersistenceSwiftData/Schema/APIEndpoint.swift
@@ -1,2 +1,2 @@
 /// Public alias for the current SwiftData API endpoint model.
-public typealias APIEndpoint = BaseChatSchemaV3.APIEndpoint
+public typealias APIEndpoint = BaseChatSchemaV4.APIEndpoint

--- a/Sources/BaseChatPersistenceSwiftData/Schema/BaseChatMigrationPlan.swift
+++ b/Sources/BaseChatPersistenceSwiftData/Schema/BaseChatMigrationPlan.swift
@@ -1,0 +1,16 @@
+import SwiftData
+
+public enum BaseChatMigrationPlan: SchemaMigrationPlan {
+    public static var schemas: [any VersionedSchema.Type] {
+        [
+            BaseChatSchemaV3.self,
+            BaseChatSchemaV4.self,
+        ]
+    }
+
+    public static var stages: [MigrationStage] {
+        [
+            .lightweight(fromVersion: BaseChatSchemaV3.self, toVersion: BaseChatSchemaV4.self),
+        ]
+    }
+}

--- a/Sources/BaseChatPersistenceSwiftData/Schema/BaseChatSchemaV4.swift
+++ b/Sources/BaseChatPersistenceSwiftData/Schema/BaseChatSchemaV4.swift
@@ -3,13 +3,13 @@ import BaseChatInference
 import BaseChatRuntime
 @preconcurrency import SwiftData
 
-/// BaseChatKit SwiftData schema version 3.
+/// BaseChatKit SwiftData schema version 4.
 ///
 /// All model definitions live here. Previous schema versions (V1, V2) were
 /// removed while the repo was still private — no users carry legacy data that
-/// needs migration.
-public enum BaseChatSchemaV3: VersionedSchema {
-    public static let versionIdentifier = Schema.Version(3, 0, 0)
+/// needs migration before V3. V4 adds optional sampler penalty columns.
+public enum BaseChatSchemaV4: VersionedSchema {
+    public static let versionIdentifier = Schema.Version(4, 0, 0)
 
     public static var models: [any PersistentModel.Type] {
         [
@@ -195,14 +195,34 @@ public enum BaseChatSchemaV3: VersionedSchema {
         public var temperature: Float
         public var topP: Float
         public var repeatPenalty: Float
+        public var presencePenalty: Float?
+        public var frequencyPenalty: Float?
+        public var repetitionContextSize: Int?
+        public var presenceContextSize: Int?
+        public var frequencyContextSize: Int?
         public var createdAt: Date
 
-        public init(name: String, temperature: Float = 0.7, topP: Float = 0.9, repeatPenalty: Float = 1.1) {
+        public init(
+            name: String,
+            temperature: Float = 0.7,
+            topP: Float = 0.9,
+            repeatPenalty: Float = 1.1,
+            presencePenalty: Float? = nil,
+            frequencyPenalty: Float? = nil,
+            repetitionContextSize: Int? = nil,
+            presenceContextSize: Int? = nil,
+            frequencyContextSize: Int? = nil
+        ) {
             self.id = UUID()
             self.name = name
             self.temperature = temperature
             self.topP = topP
             self.repeatPenalty = repeatPenalty
+            self.presencePenalty = presencePenalty
+            self.frequencyPenalty = frequencyPenalty
+            self.repetitionContextSize = repetitionContextSize
+            self.presenceContextSize = presenceContextSize
+            self.frequencyContextSize = frequencyContextSize
             self.createdAt = Date()
         }
     }

--- a/Sources/BaseChatPersistenceSwiftData/Schema/ChatMessage.swift
+++ b/Sources/BaseChatPersistenceSwiftData/Schema/ChatMessage.swift
@@ -1,2 +1,2 @@
 /// Public alias for the current SwiftData chat message model.
-public typealias ChatMessage = BaseChatSchemaV3.ChatMessage
+public typealias ChatMessage = BaseChatSchemaV4.ChatMessage

--- a/Sources/BaseChatPersistenceSwiftData/Schema/ChatSession.swift
+++ b/Sources/BaseChatPersistenceSwiftData/Schema/ChatSession.swift
@@ -1,2 +1,2 @@
 /// Public alias for the current SwiftData chat session model.
-public typealias ChatSession = BaseChatSchemaV3.ChatSession
+public typealias ChatSession = BaseChatSchemaV4.ChatSession

--- a/Sources/BaseChatPersistenceSwiftData/Schema/ModelBenchmarkCache.swift
+++ b/Sources/BaseChatPersistenceSwiftData/Schema/ModelBenchmarkCache.swift
@@ -1,2 +1,2 @@
 /// Public alias so host code uses `ModelBenchmarkCache` without schema qualification.
-public typealias ModelBenchmarkCache = BaseChatSchemaV3.ModelBenchmarkCache
+public typealias ModelBenchmarkCache = BaseChatSchemaV4.ModelBenchmarkCache

--- a/Sources/BaseChatPersistenceSwiftData/Schema/SamplerPreset.swift
+++ b/Sources/BaseChatPersistenceSwiftData/Schema/SamplerPreset.swift
@@ -1,2 +1,2 @@
 /// Public alias for the current SwiftData sampler preset model.
-public typealias SamplerPreset = BaseChatSchemaV3.SamplerPreset
+public typealias SamplerPreset = BaseChatSchemaV4.SamplerPreset

--- a/Sources/BaseChatRuntime/Models/APIEndpointValidationReason.swift
+++ b/Sources/BaseChatRuntime/Models/APIEndpointValidationReason.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Reasons an ``BaseChatSchemaV3/APIEndpoint`` URL can fail structural validation.
+/// Reasons an ``BaseChatSchemaV4/APIEndpoint`` URL can fail structural validation.
 ///
 /// Produced by `APIEndpoint.validate()`. Conforms to `LocalizedError` so settings
 /// UI can render `localizedDescription` directly as the reason the endpoint is
@@ -8,7 +8,7 @@ import Foundation
 ///
 /// The SSRF-related cases (``privateHost``, ``linkLocalHost``, ``ipv6UniqueLocal``,
 /// ``ipv4MappedLoopback``, ``multicastReserved``) correspond to the address-class
-/// blocks enforced by ``BaseChatSchemaV3/APIEndpoint`` — see `validate()` for the
+/// blocks enforced by ``BaseChatSchemaV4/APIEndpoint`` — see `validate()` for the
 /// full classification.
 public enum APIEndpointValidationReason: Error, Equatable, Sendable {
     /// The base URL string is empty or only whitespace.

--- a/Tests/BaseChatCoreTests/MessagePartThinkingSignatureTests.swift
+++ b/Tests/BaseChatCoreTests/MessagePartThinkingSignatureTests.swift
@@ -94,7 +94,7 @@ final class MessagePartThinkingSignatureTests: XCTestCase {
         ]
         let record = ChatMessageRecord(role: .assistant, contentParts: parts, sessionID: UUID())
 
-        // Round-trip via JSON to mirror what BaseChatSchemaV3.ChatMessage does.
+        // Round-trip via JSON to mirror what BaseChatSchemaV4.ChatMessage does.
         let data = try JSONEncoder().encode(record.contentParts)
         let decoded = try JSONDecoder().decode([MessagePart].self, from: data)
 

--- a/Tests/BaseChatCoreTests/SwiftDataSamplerPresetStoreTests.swift
+++ b/Tests/BaseChatCoreTests/SwiftDataSamplerPresetStoreTests.swift
@@ -36,7 +36,12 @@ final class SwiftDataSamplerPresetStoreTests: XCTestCase {
             name: "Precise",
             temperature: 0.2,
             topP: 0.85,
-            repeatPenalty: 1.05
+            repeatPenalty: 1.05,
+            presencePenalty: 0.25,
+            frequencyPenalty: 0.5,
+            repetitionContextSize: 96,
+            presenceContextSize: 48,
+            frequencyContextSize: 24
         )
 
         try await store.insertPreset(record)
@@ -49,6 +54,11 @@ final class SwiftDataSamplerPresetStoreTests: XCTestCase {
         XCTAssertEqual(fetched.temperature, 0.2, accuracy: 0.001)
         XCTAssertEqual(fetched.topP, 0.85, accuracy: 0.001)
         XCTAssertEqual(fetched.repeatPenalty, 1.05, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(fetched.presencePenalty), 0.25, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(fetched.frequencyPenalty), 0.5, accuracy: 0.001)
+        XCTAssertEqual(fetched.repetitionContextSize, 96)
+        XCTAssertEqual(fetched.presenceContextSize, 48)
+        XCTAssertEqual(fetched.frequencyContextSize, 24)
     }
 
     func test_fetchPresets_returnsMostRecentFirst() async throws {

--- a/Tests/BaseChatPersistenceSwiftDataTests/MessagePartTests.swift
+++ b/Tests/BaseChatPersistenceSwiftDataTests/MessagePartTests.swift
@@ -92,7 +92,7 @@ final class MessagePartTests: XCTestCase {
     }
 
     func test_chatMessage_decode_emptyString_returnsEmptyArray() {
-        let parts = BaseChatSchemaV3.ChatMessage.decode("")
+        let parts = BaseChatSchemaV4.ChatMessage.decode("")
         XCTAssertEqual(parts, [])
     }
 
@@ -105,7 +105,7 @@ final class MessagePartTests: XCTestCase {
         [{"text":{"_0":"Hello"}},{"toolCall":{"_0":{"id":"tc1","name":"get_weather","arguments":"{\"city\":\"London\"}"}}}]
         """#
 
-        let parts = BaseChatSchemaV3.ChatMessage.decode(legacyJSON)
+        let parts = BaseChatSchemaV4.ChatMessage.decode(legacyJSON)
 
         XCTAssertEqual(parts, [.text(legacyJSON)])
     }

--- a/Tests/BaseChatPersistenceSwiftDataTests/SamplerPresetRoundTripTests.swift
+++ b/Tests/BaseChatPersistenceSwiftDataTests/SamplerPresetRoundTripTests.swift
@@ -25,7 +25,12 @@ final class SamplerPresetRoundTripTests: XCTestCase {
             name: "Precise",
             temperature: 0.2,
             topP: 0.85,
-            repeatPenalty: 1.05
+            repeatPenalty: 1.05,
+            presencePenalty: 0.25,
+            frequencyPenalty: 0.5,
+            repetitionContextSize: 96,
+            presenceContextSize: 48,
+            frequencyContextSize: 24
         )
         let savedID = preset.id
 
@@ -45,6 +50,11 @@ final class SamplerPresetRoundTripTests: XCTestCase {
         XCTAssertEqual(fetched.temperature, 0.2, accuracy: 0.001)
         XCTAssertEqual(fetched.topP, 0.85, accuracy: 0.001)
         XCTAssertEqual(fetched.repeatPenalty, 1.05, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(fetched.presencePenalty), 0.25, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(fetched.frequencyPenalty), 0.5, accuracy: 0.001)
+        XCTAssertEqual(fetched.repetitionContextSize, 96)
+        XCTAssertEqual(fetched.presenceContextSize, 48)
+        XCTAssertEqual(fetched.frequencyContextSize, 24)
         XCTAssertLessThanOrEqual(fetched.createdAt, Date())
     }
 
@@ -64,6 +74,8 @@ final class SamplerPresetRoundTripTests: XCTestCase {
 
         // Mutate and re-save
         preset.temperature = 1.4
+        preset.presencePenalty = 0.3
+        preset.repetitionContextSize = 80
         preset.name = "Creative"
         try context.save()
 
@@ -79,6 +91,11 @@ final class SamplerPresetRoundTripTests: XCTestCase {
         // Unchanged fields stay intact
         XCTAssertEqual(fetched.topP, 0.95, accuracy: 0.001)
         XCTAssertEqual(fetched.repeatPenalty, 1.2, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(fetched.presencePenalty), 0.3, accuracy: 0.001)
+        XCTAssertEqual(fetched.repetitionContextSize, 80)
+        XCTAssertNil(fetched.frequencyPenalty)
+        XCTAssertNil(fetched.presenceContextSize)
+        XCTAssertNil(fetched.frequencyContextSize)
     }
 
     // MARK: - Multiple presets coexist

--- a/Tests/BaseChatPersistenceSwiftDataTests/SamplerPresetTests.swift
+++ b/Tests/BaseChatPersistenceSwiftDataTests/SamplerPresetTests.swift
@@ -10,22 +10,37 @@ final class SamplerPresetTests: XCTestCase {
         XCTAssertEqual(preset.temperature, 0.7, accuracy: 0.01)
         XCTAssertEqual(preset.topP, 0.9, accuracy: 0.01)
         XCTAssertEqual(preset.repeatPenalty, 1.1, accuracy: 0.01)
+        XCTAssertNil(preset.presencePenalty)
+        XCTAssertNil(preset.frequencyPenalty)
+        XCTAssertNil(preset.repetitionContextSize)
+        XCTAssertNil(preset.presenceContextSize)
+        XCTAssertNil(preset.frequencyContextSize)
         XCTAssertNotNil(preset.id)
         XCTAssertNotNil(preset.createdAt)
     }
 
-    func test_init_customValues() {
+    func test_init_customValues() throws {
         let preset = SamplerPreset(
             name: "Creative",
             temperature: 1.5,
             topP: 0.95,
-            repeatPenalty: 1.3
+            repeatPenalty: 1.3,
+            presencePenalty: 0.4,
+            frequencyPenalty: 0.2,
+            repetitionContextSize: 128,
+            presenceContextSize: 64,
+            frequencyContextSize: 32
         )
 
         XCTAssertEqual(preset.name, "Creative")
         XCTAssertEqual(preset.temperature, 1.5, accuracy: 0.01)
         XCTAssertEqual(preset.topP, 0.95, accuracy: 0.01)
         XCTAssertEqual(preset.repeatPenalty, 1.3, accuracy: 0.01)
+        XCTAssertEqual(try XCTUnwrap(preset.presencePenalty), 0.4, accuracy: 0.01)
+        XCTAssertEqual(try XCTUnwrap(preset.frequencyPenalty), 0.2, accuracy: 0.01)
+        XCTAssertEqual(preset.repetitionContextSize, 128)
+        XCTAssertEqual(preset.presenceContextSize, 64)
+        XCTAssertEqual(preset.frequencyContextSize, 32)
     }
 
     func test_uniqueIDs() {

--- a/Tests/BaseChatPersistenceSwiftDataTests/SchemaMigrationTests.swift
+++ b/Tests/BaseChatPersistenceSwiftDataTests/SchemaMigrationTests.swift
@@ -16,29 +16,38 @@ final class SchemaMigrationTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    // MARK: - BaseChatSchemaV3
-
-    func test_schemaV3_versionIdentifier() {
-        XCTAssertEqual(BaseChatSchemaV3.versionIdentifier, Schema.Version(3, 0, 0))
+    private func makeStoreDirectory(named prefix: String) throws -> URL {
+        let storeDirectory = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent(".build", isDirectory: true)
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: storeDirectory, withIntermediateDirectories: true)
+        tempStoreDirectory = storeDirectory
+        return storeDirectory
     }
 
-    func test_schemaV3_modelsContainsAllExpectedTypes() {
-        let models = BaseChatSchemaV3.models
+    // MARK: - BaseChatSchemaV4
+
+    func test_schemaV4_versionIdentifier() {
+        XCTAssertEqual(BaseChatSchemaV4.versionIdentifier, Schema.Version(4, 0, 0))
+    }
+
+    func test_schemaV4_modelsContainsAllExpectedTypes() {
+        let models = BaseChatSchemaV4.models
         XCTAssertEqual(models.count, 5)
         let ids = models.map { ObjectIdentifier($0) }
-        XCTAssertTrue(ids.contains(ObjectIdentifier(BaseChatSchemaV3.ChatMessage.self)))
-        XCTAssertTrue(ids.contains(ObjectIdentifier(BaseChatSchemaV3.ChatSession.self)))
-        XCTAssertTrue(ids.contains(ObjectIdentifier(BaseChatSchemaV3.SamplerPreset.self)))
-        XCTAssertTrue(ids.contains(ObjectIdentifier(BaseChatSchemaV3.APIEndpoint.self)))
-        XCTAssertTrue(ids.contains(ObjectIdentifier(BaseChatSchemaV3.ModelBenchmarkCache.self)))
+        XCTAssertTrue(ids.contains(ObjectIdentifier(BaseChatSchemaV4.ChatMessage.self)))
+        XCTAssertTrue(ids.contains(ObjectIdentifier(BaseChatSchemaV4.ChatSession.self)))
+        XCTAssertTrue(ids.contains(ObjectIdentifier(BaseChatSchemaV4.SamplerPreset.self)))
+        XCTAssertTrue(ids.contains(ObjectIdentifier(BaseChatSchemaV4.APIEndpoint.self)))
+        XCTAssertTrue(ids.contains(ObjectIdentifier(BaseChatSchemaV4.ModelBenchmarkCache.self)))
     }
 
-    func test_publicTypealiases_matchV3ModelTypes() {
-        XCTAssertEqual(ObjectIdentifier(ChatMessage.self), ObjectIdentifier(BaseChatSchemaV3.ChatMessage.self))
-        XCTAssertEqual(ObjectIdentifier(ChatSession.self), ObjectIdentifier(BaseChatSchemaV3.ChatSession.self))
-        XCTAssertEqual(ObjectIdentifier(SamplerPreset.self), ObjectIdentifier(BaseChatSchemaV3.SamplerPreset.self))
-        XCTAssertEqual(ObjectIdentifier(APIEndpoint.self), ObjectIdentifier(BaseChatSchemaV3.APIEndpoint.self))
-        XCTAssertEqual(ObjectIdentifier(ModelBenchmarkCache.self), ObjectIdentifier(BaseChatSchemaV3.ModelBenchmarkCache.self))
+    func test_publicTypealiases_matchV4ModelTypes() {
+        XCTAssertEqual(ObjectIdentifier(ChatMessage.self), ObjectIdentifier(BaseChatSchemaV4.ChatMessage.self))
+        XCTAssertEqual(ObjectIdentifier(ChatSession.self), ObjectIdentifier(BaseChatSchemaV4.ChatSession.self))
+        XCTAssertEqual(ObjectIdentifier(SamplerPreset.self), ObjectIdentifier(BaseChatSchemaV4.SamplerPreset.self))
+        XCTAssertEqual(ObjectIdentifier(APIEndpoint.self), ObjectIdentifier(BaseChatSchemaV4.APIEndpoint.self))
+        XCTAssertEqual(ObjectIdentifier(ModelBenchmarkCache.self), ObjectIdentifier(BaseChatSchemaV4.ModelBenchmarkCache.self))
     }
 
     // MARK: - ModelContainerFactory
@@ -64,15 +73,12 @@ final class SchemaMigrationTests: XCTestCase {
         XCTAssertNotNil(container)
     }
 
-    func test_containerFactory_currentSchema_isV3() {
-        XCTAssertEqual(ObjectIdentifier(ModelContainerFactory.currentSchema), ObjectIdentifier(BaseChatSchemaV3.self))
+    func test_containerFactory_currentSchema_isV4() {
+        XCTAssertEqual(ObjectIdentifier(ModelContainerFactory.currentSchema), ObjectIdentifier(BaseChatSchemaV4.self))
     }
 
     func test_containerFactory_reopensPersistedStore() throws {
-        let storeDirectory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("BaseChatSchemaV3-\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: storeDirectory, withIntermediateDirectories: true)
-        tempStoreDirectory = storeDirectory
+        let storeDirectory = try makeStoreDirectory(named: "BaseChatSchemaV4")
         let storeURL = storeDirectory.appendingPathComponent("BaseChat.sqlite")
         let originalSessionID: UUID
 
@@ -98,11 +104,55 @@ final class SchemaMigrationTests: XCTestCase {
         XCTAssertEqual(fetchedSessions.first?.title, "Persisted session")
     }
 
+    func test_migrationPlan_migratesV3SamplerPresetToV4WithNilPenaltyKnobs() throws {
+        let storeDirectory = try makeStoreDirectory(named: "BaseChatSchemaV3ToV4")
+        let storeURL = storeDirectory.appendingPathComponent("BaseChat.sqlite")
+        let presetID: UUID
+
+        do {
+            let config = ModelConfiguration(url: storeURL)
+            let container = try ModelContainer(
+                for: Schema(versionedSchema: BaseChatSchemaV3.self),
+                configurations: [config]
+            )
+            let context = ModelContext(container)
+            let preset = BaseChatSchemaV3.SamplerPreset(
+                name: "Legacy",
+                temperature: 0.4,
+                topP: 0.8,
+                repeatPenalty: 1.2
+            )
+            context.insert(preset)
+            try context.save()
+            presetID = preset.id
+        }
+
+        let migratedContainer = try ModelContainerFactory.makeContainer(
+            configurations: [ModelConfiguration(url: storeURL)]
+        )
+        let migratedContext = ModelContext(migratedContainer)
+        let fetched = try migratedContext.fetch(FetchDescriptor<SamplerPreset>(
+            predicate: #Predicate { $0.id == presetID }
+        ))
+
+        XCTAssertEqual(fetched.count, 1)
+        let migratedPreset = try XCTUnwrap(fetched.first)
+        XCTAssertEqual(migratedPreset.name, "Legacy")
+        XCTAssertEqual(migratedPreset.temperature, 0.4, accuracy: 0.001)
+        XCTAssertEqual(migratedPreset.topP, 0.8, accuracy: 0.001)
+        XCTAssertEqual(migratedPreset.repeatPenalty, 1.2, accuracy: 0.001)
+        XCTAssertNil(migratedPreset.presencePenalty)
+        XCTAssertNil(migratedPreset.frequencyPenalty)
+        XCTAssertNil(migratedPreset.repetitionContextSize)
+        XCTAssertNil(migratedPreset.presenceContextSize)
+        XCTAssertNil(migratedPreset.frequencyContextSize)
+    }
+
     func test_schemaOwnedModelAndPublicAlias_areInterchangeable() throws {
         let container = try ModelContainerFactory.makeInMemoryContainer()
         let context = ModelContext(container)
 
-        let nestedMessage = BaseChatSchemaV3.ChatMessage(role: .user, content: "alias check", sessionID: UUID())
+        let nestedMessage = BaseChatSchemaV4.ChatMessage(role: .user, content: "alias check", sessionID: UUID())
         context.insert(nestedMessage)
         try context.save()
         let nestedMessageID = nestedMessage.id
@@ -172,7 +222,17 @@ final class SchemaMigrationTests: XCTestCase {
         let container = try ModelContainerFactory.makeInMemoryContainer()
         let context = ModelContext(container)
 
-        let preset = SamplerPreset(name: "Creative", temperature: 1.2, topP: 0.95, repeatPenalty: 1.05)
+        let preset = SamplerPreset(
+            name: "Creative",
+            temperature: 1.2,
+            topP: 0.95,
+            repeatPenalty: 1.05,
+            presencePenalty: 0.2,
+            frequencyPenalty: 0.3,
+            repetitionContextSize: 96,
+            presenceContextSize: 48,
+            frequencyContextSize: 24
+        )
         context.insert(preset)
         try context.save()
 
@@ -187,6 +247,11 @@ final class SchemaMigrationTests: XCTestCase {
         XCTAssertEqual(fetched0.temperature, 1.2, accuracy: 0.001)
         XCTAssertEqual(fetched0.topP, 0.95, accuracy: 0.001)
         XCTAssertEqual(fetched0.repeatPenalty, 1.05, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(fetched0.presencePenalty), 0.2, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(fetched0.frequencyPenalty), 0.3, accuracy: 0.001)
+        XCTAssertEqual(fetched0.repetitionContextSize, 96)
+        XCTAssertEqual(fetched0.presenceContextSize, 48)
+        XCTAssertEqual(fetched0.frequencyContextSize, 24)
     }
 
     // MARK: - Codable round-trip (APIEndpoint)


### PR DESCRIPTION
## Summary
- add SamplerPresetRecord fields for presence/frequency penalties and context windows
- introduce BaseChatSchemaV4 with a lightweight V3→V4 migration for sampler presets
- round-trip new fields through SwiftDataSamplerPresetStore and migration tests
- leave sampler preset UI limited to currently exposed ChatViewModel knobs (temperature/topP/repeat penalty)

Closes #1019

## Tests
- scripts/test.sh --filter BaseChatPersistenceSwiftDataTests --filter BaseChatCoreTests --disable-default-traits --skip-update
- scripts/test.sh --filter BaseChatRuntimeTests --filter BaseChatInferenceTests --disable-default-traits --skip-update
- scripts/test.sh --filter BaseChatCoreTests --filter BaseChatRuntimeTests --filter BaseChatPersistenceSwiftDataTests --filter BaseChatUITests --filter BaseChatUIModelManagementTests --filter BaseChatMCPTests --filter BaseChatBackendsTests --filter BaseChatInferenceTests --filter BaseChatTestSupportTests --filter BaseChatAppIntentsTests --filter BaseChatServerTests --disable-default-traits --skip-update
- scripts/test.sh --filter BaseChatInferenceSwiftTestingTests --disable-default-traits --skip-update