### PR TITLE
feat(ui): add link preview provider seam

### DIFF
--- a/Sources/BaseChatUI/Views/Chat/ChatView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ChatView.swift
@@ -47,18 +47,27 @@ public struct ChatView<APIConfig: View>: View {
     /// forcing `BaseChatUI` to depend on optional sibling modules.
     private let composerAccessoryBuilder: (() -> AnyView)?
 
+    /// Optional opt-in metadata provider for URL preview cards in messages.
+    ///
+    /// The default is `nil`: `BaseChatUI` performs no network fetching and
+    /// renders no link previews unless a host supplies this closure.
+    private let linkPreviewProvider: LinkPreviewProvider?
+
     public init(
         showModelManagement: Binding<Bool>,
+        linkPreviewProvider: LinkPreviewProvider? = nil,
         @ViewBuilder apiConfiguration: @escaping () -> APIConfig
     ) {
         self._showModelManagement = showModelManagement
         self.customEmptyPlaceholder = nil
         self.apiConfigurationBuilder = apiConfiguration
         self.composerAccessoryBuilder = nil
+        self.linkPreviewProvider = linkPreviewProvider
     }
 
     public init<ComposerAccessory: View>(
         showModelManagement: Binding<Bool>,
+        linkPreviewProvider: LinkPreviewProvider? = nil,
         @ViewBuilder composerAccessory: @escaping () -> ComposerAccessory,
         @ViewBuilder apiConfiguration: @escaping () -> APIConfig
     ) {
@@ -66,6 +75,7 @@ public struct ChatView<APIConfig: View>: View {
         self.customEmptyPlaceholder = nil
         self.apiConfigurationBuilder = apiConfiguration
         self.composerAccessoryBuilder = { AnyView(composerAccessory()) }
+        self.linkPreviewProvider = linkPreviewProvider
     }
 
     /// Creates a ``ChatView`` with a host-supplied empty-state view rendered
@@ -75,6 +85,7 @@ public struct ChatView<APIConfig: View>: View {
     /// tour, or any other call-to-action in place of the default placeholder.
     public init<EmptyContent: View>(
         showModelManagement: Binding<Bool>,
+        linkPreviewProvider: LinkPreviewProvider? = nil,
         @ViewBuilder emptyState: () -> EmptyContent,
         @ViewBuilder apiConfiguration: @escaping () -> APIConfig
     ) {
@@ -82,10 +93,12 @@ public struct ChatView<APIConfig: View>: View {
         self.customEmptyPlaceholder = AnyView(emptyState())
         self.apiConfigurationBuilder = apiConfiguration
         self.composerAccessoryBuilder = nil
+        self.linkPreviewProvider = linkPreviewProvider
     }
 
     public init<EmptyContent: View, ComposerAccessory: View>(
         showModelManagement: Binding<Bool>,
+        linkPreviewProvider: LinkPreviewProvider? = nil,
         @ViewBuilder emptyState: () -> EmptyContent,
         @ViewBuilder composerAccessory: @escaping () -> ComposerAccessory,
         @ViewBuilder apiConfiguration: @escaping () -> APIConfig
@@ -94,6 +107,7 @@ public struct ChatView<APIConfig: View>: View {
         self.customEmptyPlaceholder = AnyView(emptyState())
         self.apiConfigurationBuilder = apiConfiguration
         self.composerAccessoryBuilder = { AnyView(composerAccessory()) }
+        self.linkPreviewProvider = linkPreviewProvider
     }
 
     // MARK: - Body
@@ -416,7 +430,8 @@ public struct ChatView<APIConfig: View>: View {
                         MessageBubbleView(
                             message: message,
                             isStreaming: isMessageStreaming(message),
-                            isPinned: viewModel.isMessagePinned(id: message.id)
+                            isPinned: viewModel.isMessagePinned(id: message.id),
+                            linkPreviewProvider: linkPreviewProvider
                         )
                         .messageActionMenu(message: message, viewModel: viewModel)
                         .id(message.id)

--- a/Sources/BaseChatUI/Views/Chat/LinkPreview.swift
+++ b/Sources/BaseChatUI/Views/Chat/LinkPreview.swift
@@ -1,0 +1,165 @@
+import Foundation
+import SwiftUI
+
+/// Host-supplied metadata for rendering a compact preview of a URL in a chat message.
+///
+/// `BaseChatUI` never fetches preview metadata by default. Hosts that want link
+/// previews must provide a ``LinkPreviewProvider`` so they can make their own
+/// privacy and networking choices.
+public struct LinkPreviewMetadata: Equatable, Sendable {
+    public let url: URL
+    public let title: String
+    public let summary: String?
+    public let siteName: String?
+    public let imageURL: URL?
+
+    public init(
+        url: URL,
+        title: String,
+        summary: String? = nil,
+        siteName: String? = nil,
+        imageURL: URL? = nil
+    ) {
+        self.url = url
+        self.title = title
+        self.summary = summary
+        self.siteName = siteName
+        self.imageURL = imageURL
+    }
+}
+
+/// Async opt-in seam for resolving link-preview metadata.
+public typealias LinkPreviewProvider = @Sendable (URL) async throws -> LinkPreviewMetadata?
+
+/// Detects previewable URLs in message text.
+public enum LinkPreviewDetector {
+    public static func firstURL(in text: String) -> URL? {
+        guard !text.isEmpty,
+              let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+        else {
+            return nil
+        }
+
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        let match = detector.firstMatch(in: text, options: [], range: range)
+        guard let url = match?.url,
+              let scheme = url.scheme?.lowercased(),
+              ["http", "https"].contains(scheme)
+        else {
+            return nil
+        }
+        return url
+    }
+}
+
+public enum LinkPreviewRenderPhase: Equatable, Sendable {
+    case idle
+    case loading(URL)
+    case loaded(LinkPreviewMetadata)
+    case unavailable(URL)
+}
+
+enum LinkPreviewResolver {
+    static func resolve(text: String, provider: LinkPreviewProvider?) async -> LinkPreviewRenderPhase {
+        guard let provider else { return .idle }
+        guard let url = LinkPreviewDetector.firstURL(in: text) else { return .idle }
+
+        do {
+            guard let metadata = try await provider(url) else {
+                return .unavailable(url)
+            }
+            return .loaded(metadata)
+        } catch {
+            return .unavailable(url)
+        }
+    }
+}
+
+struct LinkPreviewAttachmentView: View {
+    let text: String
+    let provider: LinkPreviewProvider?
+
+    @State private var phase: LinkPreviewRenderPhase = .idle
+
+    var body: some View {
+        Group {
+            if case .loaded(let metadata) = phase {
+                LinkPreviewCard(metadata: metadata)
+            }
+        }
+        .task(id: taskID) {
+            guard provider != nil, let url = LinkPreviewDetector.firstURL(in: text) else {
+                phase = .idle
+                return
+            }
+            phase = .loading(url)
+            let resolved = await LinkPreviewResolver.resolve(text: text, provider: provider)
+            guard !Task.isCancelled else { return }
+            phase = resolved
+        }
+    }
+
+    private var taskID: String {
+        guard provider != nil, let url = LinkPreviewDetector.firstURL(in: text) else {
+            return "disabled"
+        }
+        return url.absoluteString
+    }
+}
+
+struct LinkPreviewCard: View {
+    let metadata: LinkPreviewMetadata
+
+    var body: some View {
+        Link(destination: metadata.url) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: "link")
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 28, height: 28)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    if let siteName = metadata.siteName, !siteName.isEmpty {
+                        Text(siteName)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .accessibilityIdentifier("link-preview-site")
+                    }
+
+                    Text(metadata.title)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.primary)
+                        .lineLimit(2)
+                        .accessibilityIdentifier("link-preview-title")
+
+                    if let summary = metadata.summary, !summary.isEmpty {
+                        Text(summary)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                            .accessibilityIdentifier("link-preview-summary")
+                    }
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(10)
+            .background(.fill.quaternary, in: RoundedRectangle(cornerRadius: 12))
+            .overlay {
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(.separator.opacity(0.35), lineWidth: 1)
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("link-preview-card")
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var accessibilityLabel: String {
+        if let siteName = metadata.siteName, !siteName.isEmpty {
+            return "\(siteName): \(metadata.title)"
+        }
+        return metadata.title
+    }
+}

--- a/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessageBubbleView.swift
@@ -15,13 +15,20 @@ public struct MessageBubbleView: View {
     public let message: ChatMessageRecord
     public let isStreaming: Bool
     public let isPinned: Bool
+    public let linkPreviewProvider: LinkPreviewProvider?
 
     @Environment(\.horizontalSizeClass) private var sizeClass
 
-    public init(message: ChatMessageRecord, isStreaming: Bool, isPinned: Bool = false) {
+    public init(
+        message: ChatMessageRecord,
+        isStreaming: Bool,
+        isPinned: Bool = false,
+        linkPreviewProvider: LinkPreviewProvider? = nil
+    ) {
         self.message = message
         self.isStreaming = isStreaming
         self.isPinned = isPinned
+        self.linkPreviewProvider = linkPreviewProvider
     }
 
     // MARK: - Body
@@ -30,10 +37,18 @@ public struct MessageBubbleView: View {
         HStack {
             if message.role == .user { Spacer(minLength: spacerMinLength) }
 
-            bubbleContent
+            VStack(alignment: stackAlignment, spacing: 6) {
+                bubbleContent
+                    .frame(maxWidth: 700, alignment: alignment)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(Self.accessibilityLabel(for: message))
+
+                LinkPreviewAttachmentView(
+                    text: message.content,
+                    provider: linkPreviewProvider
+                )
                 .frame(maxWidth: 700, alignment: alignment)
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel(Self.accessibilityLabel(for: message))
+            }
 
             if message.role == .assistant { Spacer(minLength: spacerMinLength) }
         }
@@ -162,6 +177,14 @@ public struct MessageBubbleView: View {
     // MARK: - Layout Helpers
 
     private var alignment: Alignment {
+        switch message.role {
+        case .user: .trailing
+        case .assistant: .leading
+        case .system: .center
+        }
+    }
+
+    private var stackAlignment: HorizontalAlignment {
         switch message.role {
         case .user: .trailing
         case .assistant: .leading

--- a/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
+++ b/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
@@ -305,6 +305,12 @@ BaseChatTools/ReferenceTools/SampleRepoSearchTool.swift:guard let contents = try
 # the work that would otherwise execute on a stale query.
 BaseChatUI/Views/Sidebar/SessionListView.swift:try? await Task.sleep(nanoseconds: 200_000_000)
 
+# LinkPreviewDetector.firstURL: NSDataDetector init throws only for invalid
+# CheckingType bitmasks; `.link.rawValue` is a compile-time constant so this
+# cannot fail in practice. nil return means "no URL found", which is the
+# correct no-preview fallback.
+BaseChatUI/Views/Chat/LinkPreview.swift:let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+
 # ---------------------------------------------------------------------------
 # BaseChatMCP
 # ---------------------------------------------------------------------------

--- a/Tests/BaseChatUITests/LinkPreviewTests.swift
+++ b/Tests/BaseChatUITests/LinkPreviewTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+import SwiftUI
+import ViewInspector
+import BaseChatInference
+import BaseChatRuntime
+@testable import BaseChatUI
+
+@MainActor
+final class LinkPreviewTests: XCTestCase {
+
+    func test_detector_returnsFirstHTTPURL() throws {
+        let url = try XCTUnwrap(LinkPreviewDetector.firstURL(in: "Read https://example.com/a then https://swift.org"))
+
+        XCTAssertEqual(url.absoluteString, "https://example.com/a")
+    }
+
+    func test_detector_ignoresNonHTTPURL() {
+        XCTAssertNil(LinkPreviewDetector.firstURL(in: "Email mailto:hello@example.com"))
+    }
+
+    func test_resolver_invokesProviderWithFirstURL() async throws {
+        let recorder = LinkPreviewProviderRecorder(metadata: LinkPreviewMetadata(
+            url: URL(string: "https://example.com/article")!,
+            title: "Example article",
+            summary: "Short summary",
+            siteName: "Example"
+        ))
+
+        let phase = await LinkPreviewResolver.resolve(
+            text: "See https://example.com/article for details",
+            provider: { url in await recorder.resolve(url) }
+        )
+
+        let invokedURLs = await recorder.invokedURLs()
+        XCTAssertEqual(invokedURLs, [URL(string: "https://example.com/article")!])
+        XCTAssertEqual(phase, .loaded(LinkPreviewMetadata(
+            url: URL(string: "https://example.com/article")!,
+            title: "Example article",
+            summary: "Short summary",
+            siteName: "Example"
+        )))
+    }
+
+    func test_resolverWithNilProviderOptsOutWithoutFetching() async {
+        let phase = await LinkPreviewResolver.resolve(
+            text: "No fetch for https://example.com/private",
+            provider: nil
+        )
+
+        XCTAssertEqual(phase, .idle)
+    }
+
+    func test_resolverMapsNilMetadataToUnavailable() async {
+        let phase = await LinkPreviewResolver.resolve(
+            text: "No preview for https://example.com/no-preview",
+            provider: { url in
+                XCTAssertEqual(url.absoluteString, "https://example.com/no-preview")
+                return nil
+            }
+        )
+
+        XCTAssertEqual(phase, .unavailable(URL(string: "https://example.com/no-preview")!))
+    }
+
+    func test_cardRendersMetadataState() throws {
+        let metadata = LinkPreviewMetadata(
+            url: URL(string: "https://example.com/article")!,
+            title: "Example article",
+            summary: "A compact preview summary",
+            siteName: "Example"
+        )
+
+        let view = LinkPreviewCard(metadata: metadata)
+
+        _ = try view.inspect().find(viewWithAccessibilityIdentifier: "link-preview-card")
+        XCTAssertNoThrow(try view.inspect().find(text: "Example"))
+        XCTAssertNoThrow(try view.inspect().find(text: "Example article"))
+        XCTAssertNoThrow(try view.inspect().find(text: "A compact preview summary"))
+    }
+
+    func test_messageBubbleAcceptsLinkPreviewProviderSeam() {
+        let message = ChatMessageRecord(
+            role: .assistant,
+            content: "See https://example.com",
+            sessionID: UUID()
+        )
+
+        let view = MessageBubbleView(
+            message: message,
+            isStreaming: false,
+            linkPreviewProvider: { url in
+                LinkPreviewMetadata(url: url, title: "Example")
+            }
+        )
+
+        XCTAssertNotNil(AnyView(view))
+    }
+}
+
+private actor LinkPreviewProviderRecorder {
+    private let metadata: LinkPreviewMetadata?
+    private(set) var urls: [URL] = []
+
+    init(metadata: LinkPreviewMetadata?) {
+        self.metadata = metadata
+    }
+
+    func resolve(_ url: URL) -> LinkPreviewMetadata? {
+        urls.append(url)
+        return metadata
+    }
+
+    func invokedURLs() -> [URL] {
+        urls
+    }
+}


### PR DESCRIPTION
## Summary
- add an opt-in LinkPreviewProvider seam on ChatView/MessageBubbleView with nil default
- detect the first http(s) URL in message text and render compact tappable metadata cards when hosts provide metadata
- cover URL detection, provider invocation/opt-out, and metadata rendering state

Closes #1014

## Tests
- scripts/test.sh --filter BaseChatUITests --disable-default-traits --skip-update