### PR TITLE
perf(ci): revert .build/debug cache spike — no measurable wins (#953)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,59 +59,24 @@ jobs:
           xcode-version: "26.3"
 
       - name: Cache SwiftPM build
-        id: cache-spm
         uses: actions/cache@v5
         with:
-          # TODO(#953 Lever C): spike — re-including .build/debug to measure
-          # incremental-build savings. The previous "0 savings" comment was
-          # written before the dep-set shrunk from 38 → 21 pins (#946) and
-          # before the InferenceService decomp (#306) + runtime-ports refactor
-          # reshaped the build graph. The runner path is stable
-          # (/Users/runner/work/BaseChatKit/BaseChatKit) and Xcode is pinned to
-          # 26.3, so the SwiftPM module fingerprint inputs are now stable
-          # enough that incremental compilation should land. The likely prior
-          # failure mode — mtime invalidation after tarball restore — is
-          # addressed by the post-restore touch step below.
-          #
-          # Measurement plan: merge this, observe ci.test wall time vs. the
-          # ~253s baseline from PR #946 across 3-5 PRs. Ship if wins ≥20%;
-          # revert and update this comment with the new evidence if not.
-          #
-          # The key includes a hash of Sources/**/*.swift so any source change
-          # invalidates the .build/debug snapshot cleanly. Package.resolved is
-          # still the primary key (dependency graph dominates), with sources
-          # appended so we never restore a stale debug build over fresh code.
+          # .build/debug deliberately excluded from cache — re-tested 2026-05-05
+          # against the 253s baseline from #946 and saw post-spike median 263s,
+          # mean 286s across 8 main runs (PR #961 spike, mtime-touch fix
+          # included). High cache-hit/miss variance dominated any savings, with
+          # two runs landing 35-50% over baseline. .build/artifacts holds the
+          # prebuilt llama.cpp xcframework (~100 MB, the real win);
+          # .build/checkouts + .build/repositories save the per-dep clone phase.
+          # See #953 (Lever C) for the measurement table.
           path: |
             .build/artifacts
             .build/checkouts
             .build/repositories
-            .build/debug
-          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-debug-${{ hashFiles('Package.resolved') }}-${{ hashFiles('Sources/**/*.swift') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-debug-${{ hashFiles('Package.resolved') }}-
-            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-debug-
             ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
             ${{ runner.os }}-${{ runner.arch }}-spm-
-
-      - name: Refresh mtimes on cached build artifacts
-        # actions/cache restores files with their tarball-extraction mtime,
-        # which is uniformly "now". SwiftPM's incremental driver compares
-        # source mtime to .swiftmodule/.o mtime to decide whether to rebuild —
-        # and on a cold runner the source files (just checked out) have a
-        # newer mtime than the just-restored cache. Touching every cached
-        # build product after restore makes them appear newer than the
-        # sources, so the driver trusts them as up-to-date. This is the
-        # standard mtime-fix incantation for SwiftPM CI caches.
-        if: steps.cache-spm.outputs.cache-hit == 'true'
-        run: |
-          set -euo pipefail
-          if [[ -d .build/debug ]]; then
-            find .build/debug \( -name '*.swiftmodule' -o -name '*.swiftdoc' -o -name '*.swiftsourceinfo' -o -name '*.o' -o -name '*.d' \) -print0 \
-              | xargs -0 -r touch
-            echo "Refreshed mtimes on cached .build/debug artifacts."
-          else
-            echo ".build/debug not present after cache restore (partial hit); skipping mtime refresh."
-          fi
 
       - name: Verify Swift toolchain matches Package.swift tools-version
         # The runner's Xcode (pinned above) ships a specific Swift version. If


### PR DESCRIPTION
## Summary

Reverts the `.build/debug` SwiftPM cache spike merged in #961 (Lever C of #953). The spike landed with an explicit ship-or-revert gate — measure incremental-build savings vs. the 253s baseline from #946 across 3-5 PRs, ship if wins ≥20%. After 8 post-merge runs the data is in and the spike doesn't pay for itself.

## Measurements

8 runs on `main` after #961 merged, with the mtime-touch fix in place:

| Date | SHA | `test` duration |
|------|-----|----|
| 2026-05-05 | 600fad2 | 377s |
| 2026-05-05 | 3c823af | 337s |
| 2026-05-05 | c7ff806 | 262s |
| 2026-05-05 | fe34220 | 228s |
| 2026-05-05 | 58947e9 | 264s |
| 2026-05-04 | 9bf8034 | 229s |
| 2026-05-04 | 89bcefc | 342s |
| 2026-05-04 | 75c93a0 | 247s |

- Baseline (pre-spike, from #946 final passing run): **253s**
- Post-spike median: **263s**
- Post-spike mean: **286s**
- Two runs ran 35–50% over baseline.

Cache-hit/miss variance dominated any incremental savings. There is no measurable win, and the worst-case tail is materially worse than the no-cache baseline.

## Changes

Restores the `Cache SwiftPM build` step to its pre-#961 shape:

- Drops `.build/debug` from the cache `path:` list.
- Drops the `id: cache-spm` field (only present to gate the now-removed mtime step).
- Drops the `Sources/**/*.swift` hash from the cache key — back to keying on `Package.resolved` only.
- Drops the `Refresh mtimes on cached build artifacts` step entirely.
- Replaces the spike-measurement comment block with a tight outcome note so the next reader doesn't re-attempt this without new evidence.

`.build/artifacts` (prebuilt llama.cpp xcframework, ~100 MB — the real win), `.build/checkouts`, and `.build/repositories` continue to be cached as before.

Workflow-only change. No source edits.

## Refs

- Reverts the CI change from #961 (the spike PR).
- Parent issue: #953 (Lever C of the CI cost-reduction umbrella). Issue stays open; #953 has other open work.

## Test plan

- [x] `actionlint .github/workflows/ci.yml` clean
- [ ] Per-PR CI green on this branch (the empirical proof — and the next data point on whether dropping the cache step regresses or matches the 253s baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)