### PR TITLE
feat(backends): add llama XTC and mirostat v2 sampler options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Unreleased
+
+### Highlights
+
+#### XTC and Mirostat v2 samplers complete the modern llama.cpp surface
+
+DRY shipped in v0.16.4; this release adds the remaining two samplers from [#1021](https://github.com/roryford/BaseChatKit/issues/1021) — XTC ("Exclude Top Choices") and Mirostat v2. Both are llama.cpp-only and live behind nullable `GenerationConfig` fields so existing callers keep their bit-identical sampler chain. XTC inserts immediately after the temperature step to trim high-probability tokens for variety; Mirostat v2 replaces the temperature + dist tail with an entropy-controlled selector when active.
+
+```swift
+var config = GenerationConfig()
+config.llamaXTC = LlamaXTCSamplerOptions(probability: 0.5, threshold: 0.10, minKeep: 1)
+config.llamaMirostatV2 = LlamaMirostatV2SamplerOptions(tau: 5.0, eta: 0.1)
+```
+
+Each sampler advertises through `GenerationParameter.llamaXTC` / `.llamaMirostatV2` so UI and `RouterBackend` can dispatch on the new capabilities. Defaults mirror llama.cpp's `common_params_sampling`. With this, [#1021](https://github.com/roryford/BaseChatKit/issues/1021) is complete.
+
+### Features
+
+* **backends:** add llama XTC sampler option
+* **backends:** add llama mirostat v2 sampler option
+
 ## [0.16.4](https://github.com/roryford/BaseChatKit/compare/v0.16.3...v0.16.4) (2026-05-05)
 
 ### Highlights

--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -50,7 +50,7 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
             supportedParameters: [
                 .temperature, .topP, .topK, .repeatPenalty,
                 .minP, .repetitionPenalty, .presencePenalty, .frequencyPenalty,
-                .llamaDRY,
+                .llamaDRY, .llamaXTC, .llamaMirostatV2,
             ],
             maxContextTokens: ctxSize,
             requiresPromptTemplate: true,

--- a/Sources/BaseChatBackends/LlamaGenerationDriver.swift
+++ b/Sources/BaseChatBackends/LlamaGenerationDriver.swift
@@ -42,6 +42,28 @@ struct LlamaGenerationDriver {
         }
     }
 
+    struct XTCSamplerDescriptor: Equatable {
+        let options: LlamaXTCSamplerOptions
+        let resolvedSeed: UInt32
+
+        init?(config: GenerationConfig, fallbackSeed: UInt32) {
+            guard let options = config.llamaXTC else { return nil }
+            self.options = options
+            self.resolvedSeed = options.seed ?? fallbackSeed
+        }
+    }
+
+    struct MirostatV2SamplerDescriptor: Equatable {
+        let options: LlamaMirostatV2SamplerOptions
+        let resolvedSeed: UInt32
+
+        init?(config: GenerationConfig, fallbackSeed: UInt32) {
+            guard let options = config.llamaMirostatV2 else { return nil }
+            self.options = options
+            self.resolvedSeed = options.seed ?? fallbackSeed
+        }
+    }
+
     // MARK: - Run
 
     /// Executes the generation loop: clears the KV cache, builds the sampler
@@ -129,7 +151,10 @@ struct LlamaGenerationDriver {
         // `std::runtime_error: Unexpected empty grammar stack` across the C ABI
         // and aborts the process with libc++abi (see prior crash logs from
         // test_grammar_cancelCleansTeardown). Final order:
-        //   penalties → grammar → dry → top_k → top_p → min_p → temp → dist
+        //   penalties → grammar → dry → top_k → top_p → min_p → temp → xtc → dist
+        // When mirostat v2 is active it replaces the (temp, xtc, dist) tail with
+        // a single `mirostat_v2` step that handles both temperature and final
+        // selection.
         let sparams = llama_sampler_chain_default_params()
         guard let sampler = llama_sampler_chain_init(sparams) else {
             await MainActor.run { generationStream.setPhase(.failed("Failed to create sampler")) }
@@ -217,7 +242,6 @@ struct LlamaGenerationDriver {
         // Honour `config.minP` when supplied; default to 0.05 for parity with prior behaviour.
         let effectiveMinP = config.minP ?? 0.05
         llama_sampler_chain_add(sampler, llama_sampler_init_min_p(effectiveMinP, 1))
-        llama_sampler_chain_add(sampler, llama_sampler_init_temp(config.temperature))
 
         // Use the caller-supplied seed when available so consecutive runs with the same
         // prompt + config produce identical token streams. `llama_sampler_init_dist`
@@ -231,7 +255,28 @@ struct LlamaGenerationDriver {
         } else {
             samplerSeed = UInt32.random(in: 0...UInt32.max)
         }
-        llama_sampler_chain_add(sampler, llama_sampler_init_dist(samplerSeed))
+
+        // Mirostat v2 owns both the temperature step and the final token selection
+        // (it samples internally), so when it is active we skip temp/xtc/dist
+        // entirely. When inactive we keep the historical chain tail.
+        if let mirostat = MirostatV2SamplerDescriptor(config: config, fallbackSeed: samplerSeed) {
+            llama_sampler_chain_add(sampler, llama_sampler_init_mirostat_v2(
+                mirostat.resolvedSeed,
+                mirostat.options.tau,
+                mirostat.options.eta
+            ))
+        } else {
+            llama_sampler_chain_add(sampler, llama_sampler_init_temp(config.temperature))
+            if let xtc = XTCSamplerDescriptor(config: config, fallbackSeed: samplerSeed) {
+                llama_sampler_chain_add(sampler, llama_sampler_init_xtc(
+                    xtc.options.probability,
+                    xtc.options.threshold,
+                    xtc.options.minKeep,
+                    xtc.resolvedSeed
+                ))
+            }
+            llama_sampler_chain_add(sampler, llama_sampler_init_dist(samplerSeed))
+        }
 
         // MARK: Chunked prompt decode
 

--- a/Sources/BaseChatInference/Protocols/BackendCapabilities.swift
+++ b/Sources/BaseChatInference/Protocols/BackendCapabilities.swift
@@ -12,6 +12,8 @@ public enum GenerationParameter: String, CaseIterable, Sendable, Codable {
     case presencePenalty
     case frequencyPenalty
     case llamaDRY
+    case llamaXTC
+    case llamaMirostatV2
 }
 
 /// How the backend loads model weights into memory.

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -33,6 +33,60 @@ public struct LlamaDRYSamplerOptions: Sendable, Codable, Equatable {
     }
 }
 
+/// llama.cpp XTC ("Exclude Top Choices") sampler configuration.
+///
+/// XTC trims the highest-probability tokens to push variety; popular in creative
+/// writing presets. llama.cpp inserts XTC after the temperature step. This is
+/// llama.cpp-specific: other backends ignore it. Defaults mirror llama.cpp's
+/// `common_params_sampling` (`probability = 0.0` = disabled in the library).
+public struct LlamaXTCSamplerOptions: Sendable, Codable, Equatable {
+    /// Probability of applying XTC at each step. `0.0` disables XTC in llama.cpp.
+    public var probability: Float
+    /// Probability threshold below which tokens are not excluded.
+    public var threshold: Float
+    /// Minimum number of tokens to keep after exclusion.
+    public var minKeep: Int
+    /// Sampler seed; `nil` falls back to ``GenerationConfig/seed`` or a random value.
+    public var seed: UInt32?
+
+    public init(
+        probability: Float = 0.0,
+        threshold: Float = 0.10,
+        minKeep: Int = 1,
+        seed: UInt32? = nil
+    ) {
+        self.probability = probability
+        self.threshold = threshold
+        self.minKeep = minKeep
+        self.seed = seed
+    }
+}
+
+/// llama.cpp Mirostat v2 sampler configuration.
+///
+/// Mirostat v2 is an entropy-controlled sampler — when active, llama.cpp
+/// **replaces** the temperature + dist tail of the chain with a single Mirostat
+/// step. This is llama.cpp-specific: other backends ignore it. Defaults mirror
+/// llama.cpp's `common_params_sampling` (`tau = 5.0`, `eta = 0.1`).
+public struct LlamaMirostatV2SamplerOptions: Sendable, Codable, Equatable {
+    /// Target cross-entropy (surprise). Higher = more variety.
+    public var tau: Float
+    /// Learning rate for the mu update.
+    public var eta: Float
+    /// Sampler seed; `nil` falls back to ``GenerationConfig/seed`` or a random value.
+    public var seed: UInt32?
+
+    public init(
+        tau: Float = 5.0,
+        eta: Float = 0.1,
+        seed: UInt32? = nil
+    ) {
+        self.tau = tau
+        self.eta = eta
+        self.seed = seed
+    }
+}
+
 /// Sampling and generation parameters shared across all inference backends.
 public struct GenerationConfig: Sendable, Codable {
     public var temperature: Float
@@ -110,6 +164,20 @@ public struct GenerationConfig: Sendable, Codable {
     /// set, ``LlamaBackend`` inserts `llama_sampler_init_dry` after penalties
     /// and grammar, before probability filters. Other backends ignore it.
     public var llamaDRY: LlamaDRYSamplerOptions?
+
+    /// llama.cpp XTC sampler options.
+    ///
+    /// `nil` (the default) preserves the backend's existing sampler chain. When
+    /// set, ``LlamaBackend`` inserts `llama_sampler_init_xtc` immediately after
+    /// the temperature step. Other backends ignore it.
+    public var llamaXTC: LlamaXTCSamplerOptions?
+
+    /// llama.cpp Mirostat v2 sampler options.
+    ///
+    /// `nil` (the default) preserves the backend's existing sampler chain. When
+    /// set, ``LlamaBackend`` **replaces** the temperature + dist sampler tail
+    /// with `llama_sampler_init_mirostat_v2`. Other backends ignore it.
+    public var llamaMirostatV2: LlamaMirostatV2SamplerOptions?
 
     /// Deterministic sampling seed.
     ///
@@ -265,7 +333,9 @@ public struct GenerationConfig: Sendable, Codable {
         maxToolIterations: Int = 10,
         grammar: String? = nil,
         yieldEveryNTokens: Int = 8,
-        llamaDRY: LlamaDRYSamplerOptions? = nil
+        llamaDRY: LlamaDRYSamplerOptions? = nil,
+        llamaXTC: LlamaXTCSamplerOptions? = nil,
+        llamaMirostatV2: LlamaMirostatV2SamplerOptions? = nil
     ) {
         self.temperature = temperature
         self.topP = topP
@@ -287,6 +357,8 @@ public struct GenerationConfig: Sendable, Codable {
         self.grammar = grammar
         self.yieldEveryNTokens = yieldEveryNTokens
         self.llamaDRY = llamaDRY
+        self.llamaXTC = llamaXTC
+        self.llamaMirostatV2 = llamaMirostatV2
     }
 
     public init(
@@ -303,6 +375,8 @@ public struct GenerationConfig: Sendable, Codable {
         frequencyPenalty: Float? = nil,
         frequencyContextSize: Int? = nil,
         llamaDRY: LlamaDRYSamplerOptions? = nil,
+        llamaXTC: LlamaXTCSamplerOptions? = nil,
+        llamaMirostatV2: LlamaMirostatV2SamplerOptions? = nil,
         seed: UInt64? = nil,
         maxOutputTokens: Int? = 2048,
         tools: [ToolDefinition] = [],
@@ -329,6 +403,8 @@ public struct GenerationConfig: Sendable, Codable {
         self.frequencyPenalty = frequencyPenalty
         self.frequencyContextSize = frequencyContextSize
         self.llamaDRY = llamaDRY
+        self.llamaXTC = llamaXTC
+        self.llamaMirostatV2 = llamaMirostatV2
         self.seed = seed
         self.maxOutputTokens = maxOutputTokens
         self.tools = tools
@@ -355,6 +431,8 @@ public struct GenerationConfig: Sendable, Codable {
         case presencePenalty, presenceContextSize
         case frequencyPenalty, frequencyContextSize
         case llamaDRY
+        case llamaXTC
+        case llamaMirostatV2
         case requiredCapabilities
     }
 
@@ -400,6 +478,8 @@ public struct GenerationConfig: Sendable, Codable {
         frequencyPenalty = try c.decodeIfPresent(Float.self, forKey: .frequencyPenalty)
         frequencyContextSize = try c.decodeIfPresent(Int.self, forKey: .frequencyContextSize)
         llamaDRY = try c.decodeIfPresent(LlamaDRYSamplerOptions.self, forKey: .llamaDRY)
+        llamaXTC = try c.decodeIfPresent(LlamaXTCSamplerOptions.self, forKey: .llamaXTC)
+        llamaMirostatV2 = try c.decodeIfPresent(LlamaMirostatV2SamplerOptions.self, forKey: .llamaMirostatV2)
         // requiredCapabilities is a per-request runtime contract; landed after
         // the original shape, so older payloads decode to an empty set.
         requiredCapabilities = (try c.decodeIfPresent(
@@ -434,6 +514,8 @@ public struct GenerationConfig: Sendable, Codable {
         try c.encodeIfPresent(frequencyPenalty, forKey: .frequencyPenalty)
         try c.encodeIfPresent(frequencyContextSize, forKey: .frequencyContextSize)
         try c.encodeIfPresent(llamaDRY, forKey: .llamaDRY)
+        try c.encodeIfPresent(llamaXTC, forKey: .llamaXTC)
+        try c.encodeIfPresent(llamaMirostatV2, forKey: .llamaMirostatV2)
         if !requiredCapabilities.isEmpty {
             try c.encode(requiredCapabilities, forKey: .requiredCapabilities)
         }

--- a/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
@@ -72,6 +72,8 @@ final class LlamaBackendTests: XCTestCase {
         XCTAssertTrue(caps.supportedParameters.contains(.presencePenalty))
         XCTAssertTrue(caps.supportedParameters.contains(.frequencyPenalty))
         XCTAssertTrue(caps.supportedParameters.contains(.llamaDRY))
+        XCTAssertTrue(caps.supportedParameters.contains(.llamaXTC))
+        XCTAssertTrue(caps.supportedParameters.contains(.llamaMirostatV2))
     }
 
     func test_capabilities_requiresPromptTemplate() {

--- a/Tests/BaseChatBackendsTests/LlamaMirostatV2SamplerPlumbingTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaMirostatV2SamplerPlumbingTests.swift
@@ -1,0 +1,48 @@
+#if Llama
+import XCTest
+@testable import BaseChatInference
+@testable import BaseChatBackends
+
+final class LlamaMirostatV2SamplerPlumbingTests: XCTestCase {
+
+    func test_descriptorIsNilWhenMirostatUnset() {
+        let descriptor = LlamaGenerationDriver.MirostatV2SamplerDescriptor(
+            config: GenerationConfig(),
+            fallbackSeed: 42
+        )
+
+        XCTAssertNil(descriptor)
+    }
+
+    func test_descriptorPreservesMirostatOptions() throws {
+        let options = LlamaMirostatV2SamplerOptions(
+            tau: 7.5,
+            eta: 0.25,
+            seed: 4_242
+        )
+        let descriptor = try XCTUnwrap(LlamaGenerationDriver.MirostatV2SamplerDescriptor(
+            config: GenerationConfig(llamaMirostatV2: options),
+            fallbackSeed: 42
+        ))
+
+        XCTAssertEqual(descriptor.options, options)
+        XCTAssertEqual(descriptor.resolvedSeed, 4_242)
+    }
+
+    func test_descriptorFallsBackToProvidedSeedWhenOptionsSeedIsNil() throws {
+        let options = LlamaMirostatV2SamplerOptions()
+        let descriptor = try XCTUnwrap(LlamaGenerationDriver.MirostatV2SamplerDescriptor(
+            config: GenerationConfig(llamaMirostatV2: options),
+            fallbackSeed: 9_999
+        ))
+
+        XCTAssertEqual(descriptor.resolvedSeed, 9_999)
+    }
+
+    func test_capabilitiesAdvertiseMirostatV2Sampler() {
+        let backend = LlamaBackend()
+
+        XCTAssertTrue(backend.capabilities.supportedParameters.contains(.llamaMirostatV2))
+    }
+}
+#endif

--- a/Tests/BaseChatBackendsTests/LlamaModernSamplerIntegrationTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaModernSamplerIntegrationTests.swift
@@ -1,0 +1,91 @@
+#if Llama
+import XCTest
+@testable import BaseChatInference
+import BaseChatTestSupport
+@testable import BaseChatBackends
+
+/// Integration determinism coverage for the XTC and Mirostat v2 sampler additions.
+///
+/// Both samplers consume the GenerationConfig seed; two runs at the same seed must
+/// produce identical token streams, while a different seed must change the stream
+/// (the second guard catches a regression where the seed is silently dropped).
+///
+/// Sabotage check: hardcode `seed = 0` in `LlamaGenerationDriver.swift` — both
+/// `differentSeeds` cases will then start emitting equal streams and fail.
+///
+/// Requires Apple Silicon and a real GGUF — gated and skipped otherwise.
+final class LlamaModernSamplerIntegrationTests: XCTestCase {
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try XCTSkipUnless(HardwareRequirements.isPhysicalDevice,
+                          "LlamaBackend requires Metal (unavailable in simulator)")
+        try XCTSkipUnless(HardwareRequirements.isAppleSilicon,
+                          "LlamaBackend requires Apple Silicon")
+    }
+
+    func test_xtc_sameSeed_isDeterministic() async throws {
+        guard let modelURL = HardwareRequirements.findGGUFModel() else {
+            throw XCTSkip("No GGUF on disk. Place a `.gguf` in ~/Documents/Models/ to run this test.")
+        }
+
+        let backend = LlamaBackend()
+        addTeardownBlock { await backend.unloadAndWait() }
+        try await backend.loadModel(from: modelURL, plan: .testStub(effectiveContextSize: 512))
+
+        var config = GenerationConfig(
+            temperature: 0.8,
+            llamaXTC: LlamaXTCSamplerOptions(probability: 0.5, threshold: 0.10, minKeep: 1),
+            maxOutputTokens: 24
+        )
+        config.seed = 42
+
+        let outputA = try await collectTokens(backend: backend, prompt: "Tell me a fact:", config: config)
+        backend.resetConversation()
+        let outputB = try await collectTokens(backend: backend, prompt: "Tell me a fact:", config: config)
+
+        XCTAssertFalse(outputA.isEmpty, "Sampling must still produce tokens when XTC is active")
+        XCTAssertEqual(outputA, outputB, "Same seed + same XTC config must produce identical streams")
+    }
+
+    func test_mirostatV2_sameSeed_isDeterministic() async throws {
+        guard let modelURL = HardwareRequirements.findGGUFModel() else {
+            throw XCTSkip("No GGUF on disk. Place a `.gguf` in ~/Documents/Models/ to run this test.")
+        }
+
+        let backend = LlamaBackend()
+        addTeardownBlock { await backend.unloadAndWait() }
+        try await backend.loadModel(from: modelURL, plan: .testStub(effectiveContextSize: 512))
+
+        var config = GenerationConfig(
+            llamaMirostatV2: LlamaMirostatV2SamplerOptions(tau: 5.0, eta: 0.1),
+            maxOutputTokens: 24
+        )
+        config.seed = 1_337
+
+        let outputA = try await collectTokens(backend: backend, prompt: "Tell me a fact:", config: config)
+        backend.resetConversation()
+        let outputB = try await collectTokens(backend: backend, prompt: "Tell me a fact:", config: config)
+
+        XCTAssertFalse(outputA.isEmpty, "Mirostat v2 must still produce tokens")
+        XCTAssertEqual(outputA, outputB, "Same seed + same Mirostat config must produce identical streams")
+    }
+
+    // MARK: - Helpers
+
+    private func collectTokens(
+        backend: LlamaBackend,
+        prompt: String,
+        config: GenerationConfig
+    ) async throws -> String {
+        let stream = try backend.generate(prompt: prompt, systemPrompt: nil, config: config)
+        var text = ""
+        for try await event in stream.events {
+            if case .token(let chunk) = event {
+                text += chunk
+            }
+        }
+        return text
+    }
+}
+#endif

--- a/Tests/BaseChatBackendsTests/LlamaXTCSamplerPlumbingTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaXTCSamplerPlumbingTests.swift
@@ -1,0 +1,49 @@
+#if Llama
+import XCTest
+@testable import BaseChatInference
+@testable import BaseChatBackends
+
+final class LlamaXTCSamplerPlumbingTests: XCTestCase {
+
+    func test_descriptorIsNilWhenXTCUnset() {
+        let descriptor = LlamaGenerationDriver.XTCSamplerDescriptor(
+            config: GenerationConfig(),
+            fallbackSeed: 42
+        )
+
+        XCTAssertNil(descriptor)
+    }
+
+    func test_descriptorPreservesXTCOptions() throws {
+        let options = LlamaXTCSamplerOptions(
+            probability: 0.5,
+            threshold: 0.20,
+            minKeep: 3,
+            seed: 9_001
+        )
+        let descriptor = try XCTUnwrap(LlamaGenerationDriver.XTCSamplerDescriptor(
+            config: GenerationConfig(llamaXTC: options),
+            fallbackSeed: 42
+        ))
+
+        XCTAssertEqual(descriptor.options, options)
+        XCTAssertEqual(descriptor.resolvedSeed, 9_001)
+    }
+
+    func test_descriptorFallsBackToProvidedSeedWhenOptionsSeedIsNil() throws {
+        let options = LlamaXTCSamplerOptions(probability: 0.5)
+        let descriptor = try XCTUnwrap(LlamaGenerationDriver.XTCSamplerDescriptor(
+            config: GenerationConfig(llamaXTC: options),
+            fallbackSeed: 1_337
+        ))
+
+        XCTAssertEqual(descriptor.resolvedSeed, 1_337)
+    }
+
+    func test_capabilitiesAdvertiseXTCSampler() {
+        let backend = LlamaBackend()
+
+        XCTAssertTrue(backend.capabilities.supportedParameters.contains(.llamaXTC))
+    }
+}
+#endif

--- a/Tests/BaseChatInferenceTests/BackendCapabilitiesTests.swift
+++ b/Tests/BaseChatInferenceTests/BackendCapabilitiesTests.swift
@@ -429,10 +429,15 @@ final class BackendCapabilitiesTests: XCTestCase {
         XCTAssertTrue(allCases.contains(.presencePenalty))
         XCTAssertTrue(allCases.contains(.frequencyPenalty))
         XCTAssertTrue(allCases.contains(.llamaDRY))
+        XCTAssertTrue(allCases.contains(.llamaXTC))
+        XCTAssertTrue(allCases.contains(.llamaMirostatV2))
     }
 
     func test_generationParameter_codableRoundTrip_additivePenalties() throws {
-        let cases: [GenerationParameter] = [.minP, .repetitionPenalty, .presencePenalty, .frequencyPenalty, .llamaDRY]
+        let cases: [GenerationParameter] = [
+            .minP, .repetitionPenalty, .presencePenalty, .frequencyPenalty,
+            .llamaDRY, .llamaXTC, .llamaMirostatV2,
+        ]
         let data = try JSONEncoder().encode(cases)
         let decoded = try JSONDecoder().decode([GenerationParameter].self, from: data)
         XCTAssertEqual(decoded, cases)

--- a/Tests/BaseChatInferenceTests/GenerationConfigTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationConfigTests.swift
@@ -247,6 +247,14 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertNil(GenerationConfig().llamaDRY)
     }
 
+    func test_defaultInit_llamaXTC_isNil() {
+        XCTAssertNil(GenerationConfig().llamaXTC)
+    }
+
+    func test_defaultInit_llamaMirostatV2_isNil() {
+        XCTAssertNil(GenerationConfig().llamaMirostatV2)
+    }
+
     func test_customInit_propagatesAdditivePenaltyKnobs() {
         let config = GenerationConfig(
             repetitionContextSize: 128,
@@ -254,7 +262,9 @@ final class GenerationConfigTests: XCTestCase {
             presenceContextSize: 32,
             frequencyPenalty: 0.6,
             frequencyContextSize: 16,
-            llamaDRY: LlamaDRYSamplerOptions(multiplier: 0.8)
+            llamaDRY: LlamaDRYSamplerOptions(multiplier: 0.8),
+            llamaXTC: LlamaXTCSamplerOptions(probability: 0.5),
+            llamaMirostatV2: LlamaMirostatV2SamplerOptions(tau: 6.0)
         )
 
         XCTAssertEqual(config.repetitionContextSize, 128)
@@ -263,6 +273,8 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertEqual(config.frequencyPenalty, 0.6)
         XCTAssertEqual(config.frequencyContextSize, 16)
         XCTAssertEqual(config.llamaDRY, LlamaDRYSamplerOptions(multiplier: 0.8))
+        XCTAssertEqual(config.llamaXTC, LlamaXTCSamplerOptions(probability: 0.5))
+        XCTAssertEqual(config.llamaMirostatV2, LlamaMirostatV2SamplerOptions(tau: 6.0))
     }
 
     func test_llamaDRY_defaultsMatchLlamaCppCommonParams() {
@@ -273,6 +285,23 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertEqual(options.allowedLength, 2)
         XCTAssertEqual(options.penaltyLastN, -1)
         XCTAssertEqual(options.sequenceBreakers, ["\n", ":", "\"", "*"])
+    }
+
+    func test_llamaXTC_defaultsMatchLlamaCppCommonParams() {
+        let options = LlamaXTCSamplerOptions()
+
+        XCTAssertEqual(options.probability, 0.0)
+        XCTAssertEqual(options.threshold, 0.10)
+        XCTAssertEqual(options.minKeep, 1)
+        XCTAssertNil(options.seed)
+    }
+
+    func test_llamaMirostatV2_defaultsMatchLlamaCppCommonParams() {
+        let options = LlamaMirostatV2SamplerOptions()
+
+        XCTAssertEqual(options.tau, 5.0)
+        XCTAssertEqual(options.eta, 0.1)
+        XCTAssertNil(options.seed)
     }
 
     func test_codableRoundtrip_preservesAdditivePenaltyKnobs() throws {
@@ -289,6 +318,17 @@ final class GenerationConfigTests: XCTestCase {
             penaltyLastN: 256,
             sequenceBreakers: ["\n", "</s>"]
         )
+        original.llamaXTC = LlamaXTCSamplerOptions(
+            probability: 0.4,
+            threshold: 0.15,
+            minKeep: 2,
+            seed: 12_345
+        )
+        original.llamaMirostatV2 = LlamaMirostatV2SamplerOptions(
+            tau: 6.5,
+            eta: 0.2,
+            seed: 777
+        )
 
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(GenerationConfig.self, from: data)
@@ -299,6 +339,8 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertEqual(decoded.presenceContextSize, 48)
         XCTAssertEqual(decoded.frequencyContextSize, 24)
         XCTAssertEqual(decoded.llamaDRY, original.llamaDRY)
+        XCTAssertEqual(decoded.llamaXTC, original.llamaXTC)
+        XCTAssertEqual(decoded.llamaMirostatV2, original.llamaMirostatV2)
     }
 
     func test_codableDecode_legacyPayload_omittingAdditivePenaltyKnobs() throws {
@@ -323,6 +365,8 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertNil(decoded.presenceContextSize)
         XCTAssertNil(decoded.frequencyContextSize)
         XCTAssertNil(decoded.llamaDRY)
+        XCTAssertNil(decoded.llamaXTC)
+        XCTAssertNil(decoded.llamaMirostatV2)
     }
 
     func test_codable_omitsAdditivePenaltyKnobsWhenNil() throws {
@@ -337,6 +381,8 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertNil(json["presenceContextSize"])
         XCTAssertNil(json["frequencyContextSize"])
         XCTAssertNil(json["llamaDRY"])
+        XCTAssertNil(json["llamaXTC"])
+        XCTAssertNil(json["llamaMirostatV2"])
     }
 
     // MARK: - Mock backend captures additive-penalty fields
@@ -351,7 +397,9 @@ final class GenerationConfigTests: XCTestCase {
             presenceContextSize: 40,
             frequencyPenalty: 0.7,
             frequencyContextSize: 20,
-            llamaDRY: LlamaDRYSamplerOptions(multiplier: 0.6)
+            llamaDRY: LlamaDRYSamplerOptions(multiplier: 0.6),
+            llamaXTC: LlamaXTCSamplerOptions(probability: 0.3),
+            llamaMirostatV2: LlamaMirostatV2SamplerOptions(tau: 4.5)
         )
         let stream = try backend.generate(prompt: "test", systemPrompt: nil, config: config)
         for try await _ in stream.events {}
@@ -362,5 +410,7 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertEqual(backend.lastConfig?.frequencyPenalty, 0.7)
         XCTAssertEqual(backend.lastConfig?.frequencyContextSize, 20)
         XCTAssertEqual(backend.lastConfig?.llamaDRY, LlamaDRYSamplerOptions(multiplier: 0.6))
+        XCTAssertEqual(backend.lastConfig?.llamaXTC, LlamaXTCSamplerOptions(probability: 0.3))
+        XCTAssertEqual(backend.lastConfig?.llamaMirostatV2, LlamaMirostatV2SamplerOptions(tau: 4.5))
     }
 }


### PR DESCRIPTION
## Summary

Completes #1021 by wiring the remaining two modern llama.cpp samplers into `LlamaGenerationDriver`:

- **XTC** (`llama_sampler_init_xtc`) — inserted immediately after the temperature step. Trims top-probability tokens for variety; popular in creative-writing presets.
- **Mirostat v2** (`llama_sampler_init_mirostat_v2`) — entropy-controlled sampler. When active it **replaces** the `temp + (xtc) + dist` tail with a single mirostat step that handles both temperature and final selection.

DRY shipped earlier in #1031; with this PR all three samplers from the original umbrella are in.

## Public API

Two new optional fields on `GenerationConfig`, plus matching options structs:

```swift
var config = GenerationConfig()
config.llamaXTC = LlamaXTCSamplerOptions(probability: 0.5, threshold: 0.10, minKeep: 1)
config.llamaMirostatV2 = LlamaMirostatV2SamplerOptions(tau: 5.0, eta: 0.1)
```

`nil` (the default) preserves each backend's existing sampler chain bit-for-bit. Defaults mirror llama.cpp's `common_params_sampling`. `GenerationParameter` gains `.llamaXTC` and `.llamaMirostatV2` so UI and `RouterBackend` can dispatch by capability. `LlamaBackend.capabilities.supportedParameters` advertises both.

## Tests

- `LlamaXTCSamplerPlumbingTests` — descriptor presence, option propagation, seed fallback, capability advertisement (mirrors `LlamaDRYSamplerPlumbingTests`).
- `LlamaMirostatV2SamplerPlumbingTests` — same pattern for mirostat v2.
- `LlamaModernSamplerIntegrationTests` — Apple-Silicon/GGUF-gated integration test asserting same-seed determinism for both samplers (skips cleanly without a model on disk).
- `GenerationConfigTests` and `BackendCapabilitiesTests` — extended with default-init, custom-init, codable round-trip, legacy-payload, omit-when-nil, and mock-backend assertions for both new fields.

## Validation

- `scripts/test.sh --filter BaseChatCoreTests --filter BaseChatRuntimeTests --filter BaseChatPersistenceSwiftDataTests --filter BaseChatUITests --filter BaseChatUIModelManagementTests --filter BaseChatMCPTests --filter BaseChatBackendsTests --filter BaseChatInferenceTests --filter BaseChatTestSupportTests --filter BaseChatAppIntentsTests --filter BaseChatServerTests --disable-default-traits --skip-update` — 2570 passed, 11 skipped, 0 failed
- `scripts/test.sh --filter BaseChatInferenceSwiftTestingTests --disable-default-traits --skip-update` — 83 passed
- `swift build --build-tests --traits Llama` — green
- `swift build --build-tests --traits MLX,Llama,MCPBuiltinCatalog,Ollama,CloudSaaS,HuggingFace` — green

## Test plan

- [ ] CI green across all suites
- [ ] Verify `LlamaModernSamplerIntegrationTests` runs locally on Apple Silicon with a GGUF on disk