### PR TITLE
docs(foundation): document multimodal gap and gate capability flag

### DIFF
--- a/Sources/BaseChatBackends/FoundationBackend.swift
+++ b/Sources/BaseChatBackends/FoundationBackend.swift
@@ -50,6 +50,43 @@ import BaseChatInference
 /// `.thinkingToken` while reasoning is in flight and `.thinkingComplete`
 /// exactly once at the transition to visible content, matching the pattern
 /// already used by ``OllamaBackend``.
+///
+/// ## Multimodal / vision support
+///
+/// BaseChatKit surfaces image attachments via ``MessagePart/image(data:mimeType:)``
+/// and gates UI affordances on ``BackendCapabilities/supportsVision``. The
+/// MLX, Claude, and OpenAI backends accept image input today; **FoundationBackend
+/// does not**, because Apple's public FoundationModels SDK (Xcode 26.4,
+/// module version 1.4.34) exposes no image-input surface:
+///
+/// - `Transcript.Segment` is `text(TextSegment) | structure(StructuredSegment)`.
+///   There is no `image` / `attachment` / `media` case, and `TextSegment` /
+///   `StructuredSegment` carry only `String` and `GeneratedContent` payloads.
+/// - `Transcript.Entry` (instructions, prompt, toolCalls, toolOutput, response)
+///   has no image-bearing case.
+/// - `Transcript.Prompt` carries only `[Transcript.Segment]`.
+/// - `LanguageModelSession.respond(to:)` and `streamResponse(to:)` accept only
+///   `String`, `Prompt`, or `@PromptBuilder` closures whose components conform
+///   to `PromptRepresentable` — a protocol whose sole requirement is a
+///   `Prompt`-typed `promptRepresentation` (text-only, transitively).
+/// - A case-insensitive search of the entire `FoundationModels.swiftinterface`
+///   for `image|vision|multimodal|cgimage|uiimage|nsimage|cvpixelbuffer|jpeg|png`
+///   returns zero hits outside `LanguageModelFeedback.logFeedbackAttachment`,
+///   which is a telemetry helper unrelated to model input.
+///
+/// In other words: the SDK has no Data/CGImage/PixelBuffer ingress for the
+/// model. The on-device model itself may be multimodal-capable internally, but
+/// host apps cannot pass images through the public API. The backend therefore
+/// advertises ``BackendCapabilities/supportsVision`` as `false`; the runtime's
+/// pre-flight in ``GenerationQueue`` rejects image-bearing turns with a clear
+/// local error before any request is built. Tracked by issue #20.
+///
+/// When Apple ships an image-input surface (e.g. an `image` case on
+/// `Transcript.Segment`, a `Data`-accepting `Prompt` initialiser, or a
+/// `PromptRepresentable` extension on `CGImage` / `UIImage`), this backend
+/// should be updated to flip the capability flag and translate
+/// ``MessagePart/image(data:mimeType:)`` parts into the new SDK type, matching
+/// the pattern already used by ``ClaudeBackend`` and ``OpenAIBackend``.
 @available(iOS 26, macOS 26, *)
 public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
 
@@ -91,6 +128,13 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
         maxOutputTokens: 4096,
         supportsStreaming: true,
         isRemote: false,
+        // Apple's FoundationModels SDK (Xcode 26.4) exposes no image-input
+        // surface — `Transcript.Segment` is text/structure only, `Prompt`
+        // carries only segments, and there is no `Data`/`CGImage` ingress
+        // anywhere in the public API. See the type-level doc comment above
+        // for the full audit. Flip to `true` and wire MessagePart.image
+        // through the SDK when Apple ships an image-bearing segment.
+        supportsVision: false,
         // Whole-call emission only — Apple's GuidedGeneration streams the
         // partially-decoded structure but we do not surface name/argument
         // deltas as separate events (parity with MLXBackend's inline parser).

--- a/Tests/BaseChatBackendsTests/FoundationBackendUnitTests.swift
+++ b/Tests/BaseChatBackendsTests/FoundationBackendUnitTests.swift
@@ -152,6 +152,23 @@ final class FoundationBackendUnitTests: XCTestCase {
         )
     }
 
+    /// Pins the multimodal capability to `false` until Apple ships an
+    /// image-input surface in the FoundationModels SDK.
+    ///
+    /// This is a regression guard: if `supportsVision` ever flips to `true`
+    /// without simultaneously translating `MessagePart.image` into a real
+    /// SDK type, the runtime would advertise vision support, the UI would
+    /// expose the image picker, and image-bearing turns would either be
+    /// silently dropped or fail at the SDK boundary with an opaque error.
+    /// See the doc comment on ``FoundationBackend`` for the SDK audit and
+    /// issue #20 for the multimodal umbrella.
+    func test_capabilities_supportsVision_isFalse_whileSDKHasNoImageInput() {
+        XCTAssertFalse(
+            backend.capabilities.supportsVision,
+            "FoundationBackend must advertise supportsVision == false until Apple's FoundationModels SDK exposes an image-input surface (Transcript.Segment.image, Data-accepting Prompt init, or CGImage/UIImage PromptRepresentable). Flip with care — wire MessagePart.image through the new SDK type in the same change."
+        )
+    }
+
     // MARK: - 7. generate() while already generating throws alreadyGenerating
 
     func test_generate_whileAlreadyGenerating_throwsAlreadyGenerating() throws {


### PR DESCRIPTION
## Summary

Closes the FoundationBackend item on the multimodal umbrella (#20). MLX shipped via #904, Cloud (Claude + OpenAI) via #943, and Llama is upstream-blocked on #416. FoundationBackend was the last open box on #20's checklist.

## What I confirmed about Apple's FoundationModels SDK

Audited the SDK shipped in Xcode 26.4 (`MacOSX26.4.sdk/System/Library/Frameworks/FoundationModels.framework`, module version 1.4.34):

- `Transcript.Segment` is `text(TextSegment) | structure(StructuredSegment)` — no `image` / `attachment` / `media` case, and `TextSegment` / `StructuredSegment` carry only `String` and `GeneratedContent` payloads.
- `Transcript.Entry` enumerates `instructions | prompt | toolCalls | toolOutput | response` — no image-bearing case.
- `Transcript.Prompt` carries only `[Transcript.Segment]`.
- `LanguageModelSession.respond(to:)` and `streamResponse(to:)` take only `String`, `Prompt`, or `@PromptBuilder` closures whose components conform to `PromptRepresentable` — a protocol whose sole requirement is a `Prompt`-typed `promptRepresentation` (text-only, transitively).
- A case-insensitive grep of `FoundationModels.swiftinterface` for `image|vision|multimodal|cgimage|uiimage|nsimage|cvpixelbuffer|jpeg|png` returns zero hits outside `LanguageModelFeedback.logFeedbackAttachment` — a telemetry helper unrelated to model input.

The Apple developer-docs page for the framework (https://developer.apple.com/documentation/foundationmodels) confirms the same surface: `Prompt`, `Transcript`, `LanguageModelSession`, `GenerationOptions`, `Tool`, `ToolOutput` — no image-input type. Nothing in the 26.4 release notes (https://developer.apple.com/documentation/foundationmodels/foundationmodels-release-notes) mentions image input either.

So the public SDK has no `Data` / `CGImage` / `CVPixelBuffer` ingress for the model. The on-device model may itself be multimodal-capable internally, but host apps cannot pass images through. Wiring is impossible today; documenting the gap is the deliverable.

## Changes

- Make `BackendCapabilities.supportsVision = false` **explicit** in `FoundationBackend`'s capabilities (it was previously relying on the protocol default), with an inline comment pointing at the doc-comment audit.
- Expand the type-level doc comment with a `## Multimodal / vision support` section that mirrors the existing thinking-tokens audit: cites the missing SDK surfaces and lists the trigger conditions for flipping the flag (`Transcript.Segment.image`, `Data`-accepting `Prompt` init, or `CGImage`/`UIImage` `PromptRepresentable`).
- Add a pinning regression test `test_capabilities_supportsVision_isFalse_whileSDKHasNoImageInput` so a future flip without wiring `MessagePart.image` through the SDK fails CI rather than silently dropping image-bearing turns.

The runtime's `GenerationQueue` pre-flight already rejects image-bearing turns on backends with `supportsVision == false`, so user-visible behaviour does not change.

## Issue #20 status after this PR

- [x] MLX (#904)
- [x] Claude + OpenAI (#943)
- [ ] LlamaBackend (#416 — upstream xcframework gap)
- [x] FoundationBackend (this PR — gap documented, capability gated)

## Test plan

- [x] `swift build --build-tests --disable-default-traits` — clean
- [x] `BaseChatBackendsTests` (131 tests) and `BaseChatInferenceTests` — all green via `scripts/test.sh --filter BaseChatBackendsTests --filter BaseChatInferenceTests --disable-default-traits --skip-update` (1582 passed across all matched suites; the two crashed runner-level suites — `ToolArgumentCoercerTests`, `LargeSessionListPerformanceTests` — are unrelated to this change)
- [x] New pinning test passes; sabotage-verified by flipping the assertion locally (failed with the expected message), then restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)