### PR TITLE
feat(ui): message context menu (copy/regenerate/branch/delete)

### DIFF
--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Messages.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Messages.swift
@@ -167,6 +167,52 @@ extension ChatViewModel {
         Log.ui.debug("Generation stopped by user")
     }
 
+    /// Removes a single message from the active session.
+    ///
+    /// Deletes the message from persistence and the in-memory transcript.
+    /// No-op when the message is not present in the active session, or when
+    /// no session is active. Errors propagate via ``surfaceError(_:kind:)``.
+    public func deleteMessage(id messageID: UUID) async {
+        guard let index = messages.firstIndex(where: { $0.id == messageID }) else { return }
+        let message = messages[index]
+        // Remove from in-memory transcript first so the UI reflects the
+        // deletion immediately. If persistence fails we surface the error
+        // and reload to reconcile — matches `clearChat`'s pattern.
+        messages.remove(at: index)
+        tokenCountCache.removeValue(forKey: messageID)
+        pinnedMessageIDs.remove(messageID)
+        do {
+            try await deleteMessage(message)
+            updateContextEstimate()
+        } catch {
+            Log.persistence.error("Failed to delete message: \(error)")
+            await loadMessages()
+            updateContextEstimate()
+            surfaceError(error, kind: .persistence)
+        }
+    }
+
+    /// Forks the current session at `messageID`, creating a new session that
+    /// contains the messages up to and including the branch point.
+    ///
+    /// The runtime persists the new session and copied messages; the
+    /// ``onSessionBranched`` callback (when set) is invoked with the new
+    /// session ID so the host can refresh its sidebar and select the new
+    /// session. No-op when no session is active.
+    public func branch(from messageID: UUID) async {
+        guard let activeSessionID else { return }
+        let input = BranchInput(
+            sourceSessionID: activeSessionID,
+            branchMessageID: messageID
+        )
+        do {
+            _ = try await conversationRuntime.branch(input)
+        } catch {
+            Log.ui.error("ConversationRuntime.branch failed: \(error)")
+            surfaceError(error, kind: .persistence)
+        }
+    }
+
     /// Clears all messages in the current session.
     ///
     /// Cancels any in-flight generation before clearing to avoid inconsistent UI state.

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+RuntimeAdapter.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+RuntimeAdapter.swift
@@ -207,11 +207,22 @@ extension ChatViewModel {
             errorMessage = "Generation stopped: the model appears to be repeating itself."
             transitionPhase(to: .idle)
 
+        // MARK: Session branching
+
+        case .sessionBranched(let newSessionID, _):
+            // Forward to the host so its session-manager can refresh the
+            // sidebar and select the new session. The runtime has already
+            // persisted the new session and copied messages; the callback is
+            // pure notification.
+            if let onSessionBranched {
+                await onSessionBranched(newSessionID)
+            }
+
         // MARK: Observational / future cases
 
         case .beforeContextAssembly, .contextAssembled, .afterGeneration,
              .compressionTriggered, .toolCallRequested, .toolCallApproved,
-             .toolCallCompleted, .sessionBranched:
+             .toolCallCompleted:
             // These are observational or reserved for future sub-flows.
             // No ChatViewModel state mutation is needed here yet.
             break

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -92,6 +92,13 @@ public final class ChatViewModel {
     /// Set by the view layer to connect to SessionManagerViewModel.
     public var onFirstMessage: (@MainActor (ChatSessionRecord, String) async -> Void)?
 
+    /// Called after ``branch(from:)`` forks a conversation, with the new
+    /// session's ID. Hosts wire this to their session-manager flow so the
+    /// sidebar refreshes and the new session is selected. The runtime
+    /// persists the new session and its copied messages itself; this callback
+    /// only signals "a new session exists, show it".
+    public var onSessionBranched: (@MainActor (UUID) async -> Void)?
+
     // MARK: - First Run / Onboarding
 
     /// Called on the first launch instead of the default first-run behaviour.

--- a/Sources/BaseChatUI/Views/Chat/ChatView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ChatView.swift
@@ -53,6 +53,13 @@ public struct ChatView<APIConfig: View>: View {
     /// renders no link previews unless a host supplies this closure.
     private let linkPreviewProvider: LinkPreviewProvider?
 
+    /// Builder for extra per-message context-menu items rendered after the
+    /// built-in actions (pin, copy, edit, regenerate, branch, delete).
+    /// Defaults to `nil`, in which case only the built-in items appear.
+    /// The closure is invoked per message so hosts can vary items by role
+    /// or content.
+    private let contextMenuItemsBuilder: ((ChatMessageRecord) -> AnyView)?
+
     public init(
         showModelManagement: Binding<Bool>,
         linkPreviewProvider: LinkPreviewProvider? = nil,
@@ -63,6 +70,7 @@ public struct ChatView<APIConfig: View>: View {
         self.apiConfigurationBuilder = apiConfiguration
         self.composerAccessoryBuilder = nil
         self.linkPreviewProvider = linkPreviewProvider
+        self.contextMenuItemsBuilder = nil
     }
 
     public init<ComposerAccessory: View>(
@@ -76,6 +84,7 @@ public struct ChatView<APIConfig: View>: View {
         self.apiConfigurationBuilder = apiConfiguration
         self.composerAccessoryBuilder = { AnyView(composerAccessory()) }
         self.linkPreviewProvider = linkPreviewProvider
+        self.contextMenuItemsBuilder = nil
     }
 
     /// Creates a ``ChatView`` with a host-supplied empty-state view rendered
@@ -94,6 +103,7 @@ public struct ChatView<APIConfig: View>: View {
         self.apiConfigurationBuilder = apiConfiguration
         self.composerAccessoryBuilder = nil
         self.linkPreviewProvider = linkPreviewProvider
+        self.contextMenuItemsBuilder = nil
     }
 
     public init<EmptyContent: View, ComposerAccessory: View>(
@@ -108,6 +118,75 @@ public struct ChatView<APIConfig: View>: View {
         self.apiConfigurationBuilder = apiConfiguration
         self.composerAccessoryBuilder = { AnyView(composerAccessory()) }
         self.linkPreviewProvider = linkPreviewProvider
+        self.contextMenuItemsBuilder = nil
+    }
+
+    /// Creates a ``ChatView`` with host-supplied extra items appended to each
+    /// message's context menu.
+    ///
+    /// The `contextMenuItems` closure is invoked per ``ChatMessageRecord``;
+    /// items it returns render after the built-in pin/copy/edit/regenerate/
+    /// branch/delete actions. Use this overload to add app-specific actions
+    /// such as "Reply", "Translate", or "Send to…" without forking the
+    /// stock message bubble.
+    public init<ExtraItems: View>(
+        showModelManagement: Binding<Bool>,
+        linkPreviewProvider: LinkPreviewProvider? = nil,
+        @ViewBuilder contextMenuItems: @escaping (ChatMessageRecord) -> ExtraItems,
+        @ViewBuilder apiConfiguration: @escaping () -> APIConfig
+    ) {
+        self._showModelManagement = showModelManagement
+        self.customEmptyPlaceholder = nil
+        self.apiConfigurationBuilder = apiConfiguration
+        self.composerAccessoryBuilder = nil
+        self.linkPreviewProvider = linkPreviewProvider
+        self.contextMenuItemsBuilder = { message in AnyView(contextMenuItems(message)) }
+    }
+
+    public init<ExtraItems: View, ComposerAccessory: View>(
+        showModelManagement: Binding<Bool>,
+        linkPreviewProvider: LinkPreviewProvider? = nil,
+        @ViewBuilder contextMenuItems: @escaping (ChatMessageRecord) -> ExtraItems,
+        @ViewBuilder composerAccessory: @escaping () -> ComposerAccessory,
+        @ViewBuilder apiConfiguration: @escaping () -> APIConfig
+    ) {
+        self._showModelManagement = showModelManagement
+        self.customEmptyPlaceholder = nil
+        self.apiConfigurationBuilder = apiConfiguration
+        self.composerAccessoryBuilder = { AnyView(composerAccessory()) }
+        self.linkPreviewProvider = linkPreviewProvider
+        self.contextMenuItemsBuilder = { message in AnyView(contextMenuItems(message)) }
+    }
+
+    public init<EmptyContent: View, ExtraItems: View>(
+        showModelManagement: Binding<Bool>,
+        linkPreviewProvider: LinkPreviewProvider? = nil,
+        @ViewBuilder emptyState: () -> EmptyContent,
+        @ViewBuilder contextMenuItems: @escaping (ChatMessageRecord) -> ExtraItems,
+        @ViewBuilder apiConfiguration: @escaping () -> APIConfig
+    ) {
+        self._showModelManagement = showModelManagement
+        self.customEmptyPlaceholder = AnyView(emptyState())
+        self.apiConfigurationBuilder = apiConfiguration
+        self.composerAccessoryBuilder = nil
+        self.linkPreviewProvider = linkPreviewProvider
+        self.contextMenuItemsBuilder = { message in AnyView(contextMenuItems(message)) }
+    }
+
+    public init<EmptyContent: View, ExtraItems: View, ComposerAccessory: View>(
+        showModelManagement: Binding<Bool>,
+        linkPreviewProvider: LinkPreviewProvider? = nil,
+        @ViewBuilder emptyState: () -> EmptyContent,
+        @ViewBuilder contextMenuItems: @escaping (ChatMessageRecord) -> ExtraItems,
+        @ViewBuilder composerAccessory: @escaping () -> ComposerAccessory,
+        @ViewBuilder apiConfiguration: @escaping () -> APIConfig
+    ) {
+        self._showModelManagement = showModelManagement
+        self.customEmptyPlaceholder = AnyView(emptyState())
+        self.apiConfigurationBuilder = apiConfiguration
+        self.composerAccessoryBuilder = { AnyView(composerAccessory()) }
+        self.linkPreviewProvider = linkPreviewProvider
+        self.contextMenuItemsBuilder = { message in AnyView(contextMenuItems(message)) }
     }
 
     // MARK: - Body
@@ -427,14 +506,23 @@ public struct ChatView<APIConfig: View>: View {
                     }
 
                     ForEach(viewModel.messages) { message in
-                        MessageBubbleView(
+                        let bubble = MessageBubbleView(
                             message: message,
                             isStreaming: isMessageStreaming(message),
                             isPinned: viewModel.isMessagePinned(id: message.id),
                             linkPreviewProvider: linkPreviewProvider
                         )
-                        .messageActionMenu(message: message, viewModel: viewModel)
-                        .id(message.id)
+                        if let contextMenuItemsBuilder {
+                            bubble
+                                .messageActionMenu(message: message, viewModel: viewModel) { msg in
+                                    contextMenuItemsBuilder(msg)
+                                }
+                                .id(message.id)
+                        } else {
+                            bubble
+                                .messageActionMenu(message: message, viewModel: viewModel)
+                                .id(message.id)
+                        }
                     }
 
                     // Invisible anchor for auto-scrolling.

--- a/Sources/BaseChatUI/Views/Chat/MessageActionMenu.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessageActionMenu.swift
@@ -4,19 +4,31 @@ import BaseChatInference
 
 /// A view modifier that attaches a context menu to a message bubble.
 ///
-/// Provides copy, edit (user messages only), and regenerate (assistant messages
-/// only) actions. Uses platform-appropriate clipboard APIs.
-public struct MessageActionMenuModifier: ViewModifier {
+/// Surfaces per-message actions on macOS via secondary-tap (right-click) and
+/// on iOS / iPadOS via long-press. Default actions cover pin, copy, edit
+/// (user messages only), regenerate (assistant messages only), branch from
+/// here, and delete.
+///
+/// Hosts extend the menu by passing a `@ViewBuilder` closure to
+/// ``SwiftUICore/View/messageActionMenu(message:viewModel:contextMenuItems:)``;
+/// the extra items render after the default set.
+public struct MessageActionMenuModifier<ExtraItems: View>: ViewModifier {
 
     public let message: ChatMessageRecord
     public let viewModel: ChatViewModel
+    private let extraItems: (ChatMessageRecord) -> ExtraItems
 
     @State private var isEditing: Bool = false
     @State private var editText: String = ""
 
-    public init(message: ChatMessageRecord, viewModel: ChatViewModel) {
+    public init(
+        message: ChatMessageRecord,
+        viewModel: ChatViewModel,
+        @ViewBuilder extraItems: @escaping (ChatMessageRecord) -> ExtraItems
+    ) {
         self.message = message
         self.viewModel = viewModel
+        self.extraItems = extraItems
     }
 
     public func body(content: Content) -> some View {
@@ -37,6 +49,14 @@ public struct MessageActionMenuModifier: ViewModifier {
                 if message.role == .assistant {
                     regenerateButton
                 }
+
+                branchButton
+
+                Divider()
+
+                deleteButton
+
+                extraItems(message)
             }
             .sheet(isPresented: $isEditing) {
                 editSheet
@@ -88,6 +108,22 @@ public struct MessageActionMenuModifier: ViewModifier {
         }
     }
 
+    private var branchButton: some View {
+        Button {
+            Task { await viewModel.branch(from: message.id) }
+        } label: {
+            Label("Branch from here", systemImage: "arrow.triangle.branch")
+        }
+    }
+
+    private var deleteButton: some View {
+        Button(role: .destructive) {
+            Task { await viewModel.deleteMessage(id: message.id) }
+        } label: {
+            Label("Delete", systemImage: "trash")
+        }
+    }
+
     // MARK: - Edit Sheet
 
     private var editSheet: some View {
@@ -124,9 +160,29 @@ public struct MessageActionMenuModifier: ViewModifier {
 // MARK: - View Extension
 
 extension View {
-    /// Attaches a context menu with message actions (copy, edit, regenerate).
-    public func messageActionMenu(message: ChatMessageRecord, viewModel: ChatViewModel) -> some View {
-        modifier(MessageActionMenuModifier(message: message, viewModel: viewModel))
+    /// Attaches a context menu with the default message actions (pin, copy,
+    /// edit, regenerate, branch, delete).
+    public func messageActionMenu(
+        message: ChatMessageRecord,
+        viewModel: ChatViewModel
+    ) -> some View {
+        modifier(MessageActionMenuModifier(message: message, viewModel: viewModel) { _ in
+            EmptyView()
+        })
+    }
+
+    /// Attaches a context menu with the default message actions plus the
+    /// host-supplied items rendered after the defaults.
+    public func messageActionMenu<ExtraItems: View>(
+        message: ChatMessageRecord,
+        viewModel: ChatViewModel,
+        @ViewBuilder contextMenuItems: @escaping (ChatMessageRecord) -> ExtraItems
+    ) -> some View {
+        modifier(MessageActionMenuModifier(
+            message: message,
+            viewModel: viewModel,
+            extraItems: contextMenuItems
+        ))
     }
 }
 

--- a/Tests/BaseChatUITests/MessageContextMenuTests.swift
+++ b/Tests/BaseChatUITests/MessageContextMenuTests.swift
@@ -1,0 +1,228 @@
+@preconcurrency import XCTest
+import SwiftData
+@testable import BaseChatUI
+import BaseChatRuntime
+import BaseChatPersistenceSwiftData
+@testable import BaseChatPersistenceSwiftData
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Tests for the per-message context menu introduced in #1011.
+///
+/// Verifies the wire-up of the context menu's default actions against the
+/// underlying ``ConversationRuntime`` — `deleteMessage`, `branch(from:)`,
+/// `regenerateLastResponse`, and the `onSessionBranched` callback.
+@MainActor
+final class MessageContextMenuTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+    private var vm: ChatViewModel!
+    private var mock: MockInferenceBackend!
+    private var sessionManager: SessionManagerViewModel!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        container = try makeInMemoryContainer()
+        context = container.mainContext
+
+        mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.tokensToYield = ["Hello", " world"]
+
+        let service = InferenceService(backend: mock, name: "MockMenu")
+        vm = ChatViewModel(inferenceService: service)
+        vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
+
+        sessionManager = SessionManagerViewModel()
+        sessionManager.configure(
+            persistence: SwiftDataPersistenceProvider(modelContext: context),
+            autoLoad: false
+        )
+    }
+
+    override func tearDown() async throws {
+        vm = nil
+        sessionManager = nil
+        mock = nil
+        context = nil
+        container = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    @discardableResult
+    private func createAndActivateSession(title: String = "Menu Test") async throws -> ChatSessionRecord {
+        let session = try await sessionManager.createSession(title: title)
+        sessionManager.activeSession = session
+        await vm.switchToSession(session)
+        return session
+    }
+
+    private func fetchMessages(for sessionID: UUID) -> [ChatMessage] {
+        let descriptor = FetchDescriptor<ChatMessage>(
+            predicate: #Predicate { $0.sessionID == sessionID },
+            sortBy: [SortDescriptor(\.timestamp)]
+        )
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
+    private func fetchSessions() -> [ChatSession] {
+        let descriptor = FetchDescriptor<ChatSession>()
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
+    // MARK: - deleteMessage
+
+    func test_deleteMessage_removesFromInMemoryTranscript() async throws {
+        try await createAndActivateSession()
+        mock.tokensToYield = ["Reply"]
+        vm.inputText = "First"
+        await vm.sendMessage()
+        XCTAssertEqual(vm.messages.count, 2)
+
+        let assistant = vm.messages[1]
+        await vm.deleteMessage(id: assistant.id)
+
+        XCTAssertEqual(vm.messages.count, 1, "Assistant message should be removed from transcript")
+        XCTAssertEqual(vm.messages.first?.role, .user, "User message should remain")
+    }
+
+    func test_deleteMessage_persistsRemoval() async throws {
+        let session = try await createAndActivateSession()
+        mock.tokensToYield = ["Reply"]
+        vm.inputText = "Persisted"
+        await vm.sendMessage()
+        XCTAssertEqual(fetchMessages(for: session.id).count, 2)
+
+        let assistantID = vm.messages[1].id
+        await vm.deleteMessage(id: assistantID)
+
+        let remaining = fetchMessages(for: session.id)
+        XCTAssertEqual(remaining.count, 1, "Persisted assistant record should be deleted")
+        XCTAssertFalse(remaining.contains(where: { $0.id == assistantID }))
+    }
+
+    func test_deleteMessage_unknownID_isNoOp() async throws {
+        try await createAndActivateSession()
+        mock.tokensToYield = ["Reply"]
+        vm.inputText = "Question"
+        await vm.sendMessage()
+        let beforeCount = vm.messages.count
+
+        await vm.deleteMessage(id: UUID())
+
+        XCTAssertEqual(vm.messages.count, beforeCount, "Unknown ID should not mutate the transcript")
+    }
+
+    func test_deleteMessage_alsoUnpins() async throws {
+        try await createAndActivateSession()
+        mock.tokensToYield = ["Reply"]
+        vm.inputText = "Pin me"
+        await vm.sendMessage()
+        let userID = vm.messages[0].id
+
+        await vm.pinMessage(id: userID)
+        XCTAssertTrue(vm.isMessagePinned(id: userID))
+
+        await vm.deleteMessage(id: userID)
+
+        XCTAssertFalse(vm.pinnedMessageIDs.contains(userID),
+                       "Deleted message must drop from pinned set so the pin badge does not linger")
+    }
+
+    // MARK: - branch(from:)
+
+    func test_branch_createsNewSessionWithCopiedMessages() async throws {
+        let source = try await createAndActivateSession(title: "Source")
+        mock.tokensToYield = ["Reply"]
+        vm.inputText = "Original"
+        await vm.sendMessage()
+        XCTAssertEqual(vm.messages.count, 2)
+
+        let branchPoint = vm.messages[1].id  // assistant reply
+        let beforeSessionCount = fetchSessions().count
+
+        await vm.branch(from: branchPoint)
+        // Drain the runtime event so the .sessionBranched callback (and any
+        // host-installed observer) lands before we read state.
+        await Task.yield()
+        await Task.yield()
+
+        let sessions = fetchSessions()
+        XCTAssertEqual(sessions.count, beforeSessionCount + 1,
+                       "branch should produce exactly one new session")
+
+        let newSession = sessions.first(where: { $0.id != source.id })
+        XCTAssertNotNil(newSession, "New session should exist alongside the source")
+        let newID = try XCTUnwrap(newSession?.id)
+        XCTAssertEqual(fetchMessages(for: newID).count, 2,
+                       "Both source messages should be copied to the new session")
+    }
+
+    func test_branch_firesOnSessionBranchedCallback() async throws {
+        try await createAndActivateSession()
+        mock.tokensToYield = ["Reply"]
+        vm.inputText = "Source question"
+        await vm.sendMessage()
+
+        let captured = NewSessionIDBox()
+        vm.onSessionBranched = { id in
+            await captured.set(id)
+        }
+
+        let branchPoint = vm.messages[0].id
+        await vm.branch(from: branchPoint)
+
+        // Spin until the runtime emits .sessionBranched (typically 1–2 yields).
+        for _ in 0..<10 {
+            if await captured.get() != nil { break }
+            await Task.yield()
+        }
+
+        let observed = await captured.get()
+        XCTAssertNotNil(observed, "onSessionBranched should fire with the new session ID")
+    }
+
+    func test_branch_withoutActiveSession_isNoOp() async {
+        // No session activated.
+        let beforeCount = fetchSessions().count
+
+        await vm.branch(from: UUID())
+
+        XCTAssertEqual(fetchSessions().count, beforeCount,
+                       "branch with no active session must not create a session")
+    }
+
+    // MARK: - regenerate wire-up (sanity)
+
+    func test_regenerate_replacesAssistantMessage() async throws {
+        try await createAndActivateSession()
+        mock.tokensToYield = ["First"]
+        vm.inputText = "Hello"
+        await vm.sendMessage()
+        let firstAssistantID = vm.messages[1].id
+        XCTAssertEqual(vm.messages[1].content, "First")
+
+        mock.tokensToYield = ["Second"]
+        await vm.regenerateLastResponse()
+
+        XCTAssertEqual(vm.messages.count, 2,
+                       "Regenerate should replace, not append, the assistant message")
+        XCTAssertNotEqual(vm.messages[1].id, firstAssistantID,
+                          "Regenerated response should have a fresh ID")
+        XCTAssertEqual(vm.messages[1].content, "Second")
+    }
+}
+
+/// Actor box used to capture the new-session ID emitted by
+/// `onSessionBranched` from the long-lived runtime drain task. The callback
+/// is `@MainActor`, but the test reads via `Task.yield()` interleaving so we
+/// shield the storage with an actor to satisfy strict-concurrency checks.
+private actor NewSessionIDBox {
+    private var value: UUID?
+    func set(_ newValue: UUID) { value = newValue }
+    func get() -> UUID? { value }
+}


### PR DESCRIPTION
Closes #1011.

## Summary

- Adds a per-message context menu to every bubble in `ChatView`. macOS surfaces it on secondary-tap (right-click); iOS / iPadOS get it for free via long-press because both platforms read from SwiftUI's `.contextMenu { }`.
- Default items: **Pin/Unpin**, **Copy**, **Edit** (user only), **Regenerate** (assistant only), **Branch from here**, **Delete**. Pin/Copy/Edit were already wired; this PR adds Branch and Delete and reorganises the menu so destructive actions sit below a divider.
- Extensibility seam: a new `contextMenuItems:` `@ViewBuilder` parameter on `ChatView` lets hosts append app-specific items per message. The closure receives the `ChatMessageRecord` so items can vary by role or content. This follows the existing `apiConfiguration:` injection shape so the API surface stays consistent.
- Adds public `ChatViewModel.deleteMessage(id:)` and `branch(from:)`. Both forward to existing infrastructure — `deleteMessage` calls the existing internal persistence wrapper plus a token-cache + pinned-set cleanup; `branch` builds a `BranchInput` and calls `ConversationRuntime.branch(_:)`. **No `ConversationRuntime` changes, no new public types in `BaseChatRuntime` or below.**
- Adds an `onSessionBranched: (UUID) async -> Void` callback property on `ChatViewModel`. The runtime's adapter previously ignored `.sessionBranched`; the new branch-from-here path needs hosts to react (refresh the sidebar, select the new session). Existing call sites that don't set the callback see no behaviour change.

## Tests

`Tests/BaseChatUITests/MessageContextMenuTests.swift` — 8 XCTest cases against the in-memory `MockInferenceBackend`:

- `test_deleteMessage_removesFromInMemoryTranscript`
- `test_deleteMessage_persistsRemoval`
- `test_deleteMessage_unknownID_isNoOp`
- `test_deleteMessage_alsoUnpins`
- `test_branch_createsNewSessionWithCopiedMessages`
- `test_branch_firesOnSessionBranchedCallback`
- `test_branch_withoutActiveSession_isNoOp`
- `test_regenerate_replacesAssistantMessage`

## Test plan

- [x] `scripts/test.sh --filter MessageContextMenuTests --disable-default-traits --skip-update` — 8/8 pass
- [x] Two-invocation pre-push gate (XCTest mega-batch + Swift Testing) — XCTest 2475 passed / Swift Testing 83 passed; one unrelated `LargeSessionListPerformanceTests` SIGSEGV that re-ran clean in isolation (50K-message in-memory SwiftData perf baseline, no contact with the changed surface).
- [ ] Manual right-click verification on macOS (out of scope for the PR; the same `.contextMenu { }` modifier already drives Pin/Copy/Edit so the wire-up is identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)