### PR TITLE
perf: spike SwiftPM debug cache reuse in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - ".github/workflows/ci.yml"
       - "scripts/test.sh"
       - "scripts/example-ui-tests.sh"
+      - "scripts/ci-normalize-swiftpm-debug-cache.sh"
   pull_request:
     branches: [main]
     paths:
@@ -21,6 +22,7 @@ on:
       - ".github/workflows/ci.yml"
       - "scripts/test.sh"
       - "scripts/example-ui-tests.sh"
+      - "scripts/ci-normalize-swiftpm-debug-cache.sh"
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
@@ -58,17 +60,14 @@ jobs:
           # version-discovery API call that `latest-stable` requires.
           xcode-version: "26.3"
 
-      - name: Cache SwiftPM build
+      - name: Cache SwiftPM dependencies
         uses: actions/cache@v5
         with:
-          # .build/debug deliberately excluded from cache — re-tested 2026-05-05
-          # against the 253s baseline from #946 and saw post-spike median 263s,
-          # mean 286s across 8 main runs (PR #961 spike, mtime-touch fix
-          # included). High cache-hit/miss variance dominated any savings, with
-          # two runs landing 35-50% over baseline. .build/artifacts holds the
-          # prebuilt llama.cpp xcframework (~100 MB, the real win);
+          # Keep dependency material in the broad Package.resolved cache: .build/artifacts
+          # holds the prebuilt llama.cpp xcframework (~100 MB, the real win), and
           # .build/checkouts + .build/repositories save the per-dep clone phase.
-          # See #953 (Lever C) for the measurement table.
+          # .build/debug is measured separately below for #953 Lever C so a stale
+          # incremental-build cache cannot evict or destabilize this dependency cache.
           path: |
             .build/artifacts
             .build/checkouts
@@ -77,6 +76,26 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
             ${{ runner.os }}-${{ runner.arch }}-spm-
+
+      - name: Cache SwiftPM debug build (Lever C spike)
+        id: swiftpm-debug-cache
+        uses: actions/cache@v5
+        with:
+          # Lever C (#953) spike: re-test .build/debug with a narrow content key and
+          # post-restore mtime normalization instead of folding it into the broad
+          # dependency cache above. The key includes package pins, Package.swift,
+          # Sources, and Tests so restored object/module files match the checked-out
+          # content exactly; no restore-keys are used because touching stale objects
+          # newer than changed sources could hide rebuild work. Real evidence still
+          # requires PR/main runs: compare this step's hit state plus the test-step
+          # durations and the final debug-cache size report before deciding whether
+          # to keep or remove the spike.
+          path: .build/debug
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-debug-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**/*.swift', 'Tests/**/*.swift') }}
+
+      - name: Normalize SwiftPM debug cache mtimes
+        if: steps.swiftpm-debug-cache.outputs.cache-hit == 'true'
+        run: scripts/ci-normalize-swiftpm-debug-cache.sh .build/debug
 
       - name: Verify Swift toolchain matches Package.swift tools-version
         # The runner's Xcode (pinned above) ships a specific Swift version. If
@@ -264,6 +283,19 @@ jobs:
         env:
           BASECHAT_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-inference-swift-testing.log
         run: scripts/test.sh --filter BaseChatInferenceSwiftTestingTests --disable-default-traits --skip-update
+
+      - name: Report SwiftPM debug cache state
+        if: always()
+        run: |
+          set -euo pipefail
+          echo "debug-cache-hit=${{ steps.swiftpm-debug-cache.outputs.cache-hit }}"
+          if [ -d .build/debug ]; then
+            du -sh .build/debug || true
+            primary_files=$(find .build/debug -type f \( -name '*.o' -o -name '*.swiftmodule' -o -name '*.swiftdeps' \) -print | wc -l | tr -d ' ')
+            echo "debug-cache-primary-files=${primary_files}"
+          else
+            echo ".build/debug not present"
+          fi
 
       - name: Stage test diagnostics
         # Each test step writes to a unique workspace log path via

--- a/scripts/ci-normalize-swiftpm-debug-cache.sh
+++ b/scripts/ci-normalize-swiftpm-debug-cache.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Normalize restored SwiftPM debug-cache mtimes after actions/cache extraction.
+# GitHub checkout gives source files fresh mtimes; cached .o/.swiftmodule files
+# can look older than identical sources and force a full rebuild. This script is
+# intentionally limited to SwiftPM debug outputs and only runs on exact cache hits.
+
+set -euo pipefail
+
+BUILD_DIR="${1:-.build/debug}"
+
+if [[ ! -d "$BUILD_DIR" ]]; then
+    echo "SwiftPM debug cache directory not found: $BUILD_DIR"
+    exit 0
+fi
+
+# Keep the list focused on files SwiftPM/Swift's incremental build consults or
+# emits for debug builds. Do not touch source checkouts or repositories.
+count=$(find "$BUILD_DIR" -type f \( \
+    -name '*.o' -o \
+    -name '*.swiftmodule' -o \
+    -name '*.swiftdoc' -o \
+    -name '*.swiftsourceinfo' -o \
+    -name '*.swiftinterface' -o \
+    -name '*.swiftdeps' -o \
+    -name '*.swiftdeps~' -o \
+    -name '*.abi.json' -o \
+    -name '*.d' -o \
+    -name '*.buildrecord' \
+\) -print | wc -l | tr -d ' ')
+
+if [[ "$count" == "0" ]]; then
+    echo "No SwiftPM debug-cache outputs needed mtime normalization."
+    exit 0
+fi
+
+find "$BUILD_DIR" -type f \( \
+    -name '*.o' -o \
+    -name '*.swiftmodule' -o \
+    -name '*.swiftdoc' -o \
+    -name '*.swiftsourceinfo' -o \
+    -name '*.swiftinterface' -o \
+    -name '*.swiftdeps' -o \
+    -name '*.swiftdeps~' -o \
+    -name '*.abi.json' -o \
+    -name '*.d' -o \
+    -name '*.buildrecord' \
+\) -print0 | xargs -0 touch -c
+
+echo "Normalized mtimes for $count SwiftPM debug-cache output files under $BUILD_DIR."


### PR DESCRIPTION
Closes #953.

## Summary
- add experimental `.build/debug` caching to CI with a source-aware cache key
- normalize SwiftPM debug artifact mtimes on exact cache hits to improve incremental reuse odds
- document that real effectiveness must be measured from PR/main CI runs rather than assumed locally

## Validation
- `actionlint .github/workflows/ci.yml`
- `bash -n scripts/ci-normalize-swiftpm-debug-cache.sh`
- synthetic mtime normalization check
- `git diff --check`