### PR TITLE
feat: flip default backend load options

### DIFF
--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -627,8 +627,8 @@ extension LlamaBackend: LoadProgressReporting {
 
     /// Installs backend tuning knobs (KV cache quantization, Flash Attention,
     /// prefill batch size) that take effect on the **next** ``loadModel(from:plan:)``
-    /// call. Defaults preserve historical behaviour bit-for-bit; opt in
-    /// per ``BackendLoadOptions`` to trade memory for context size or perf.
+    /// call. Defaults use Q8 KV cache and platform-gated Flash Attention; pass
+    /// explicit ``BackendLoadOptions`` to choose different memory/perf tradeoffs.
     ///
     /// Calling this after a model is already loaded does not retune the live
     /// context — applying KV-quantization changes requires rebuilding the

--- a/Sources/BaseChatBackends/LlamaModelLoader.swift
+++ b/Sources/BaseChatBackends/LlamaModelLoader.swift
@@ -173,9 +173,9 @@ final class LlamaModelLoader: @unchecked Sendable {
         ctxParams.n_threads = Int32(max(1, min(8, ProcessInfo.processInfo.processorCount - 2)))
         ctxParams.n_threads_batch = ctxParams.n_threads
 
-        // Apply BackendLoadOptions. Each branch is no-op when the option matches
-        // the library default, preserving bit-exact behaviour for callers that
-        // don't set load options explicitly.
+        // Apply BackendLoadOptions. Defaults prefer Q8 KV cache and Flash
+        // Attention on physical devices; callers can still choose llama.cpp's
+        // F16/no-FA library defaults explicitly.
         switch loadOptions.kvCacheQuantization {
         case .f16:
             // Library default; leave ctxParams.type_k / type_v as-is (GGML_TYPE_F16).

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -1303,11 +1303,11 @@ extension MLXBackend: LoadProgressReporting {
     /// field is silently ignored — MLX's SDPA path is always
     /// flash-attention-shaped.
     ///
-    /// Defaults preserve historical behaviour bit-for-bit. Per the BCK API
-    /// shape, `BackendLoadOptions` is named "load" because llama.cpp wires
-    /// these into `ctxParams` at context-creation time. MLX could in
-    /// principle change them per-generation; the API stays load-time-shaped
-    /// to keep both backends symmetric.
+    /// Defaults use Q8 KV cache and backend-default prefill batching. Per the
+    /// BCK API shape, `BackendLoadOptions` is named "load" because llama.cpp
+    /// wires these into `ctxParams` at context-creation time. MLX could in
+    /// principle change them per-generation; the API stays load-time-shaped to
+    /// keep both backends symmetric.
     public func setLoadOptions(_ options: BackendLoadOptions) {
         withStateLock { _loadOptions = options }
     }

--- a/Sources/BaseChatInference/Models/BackendLoadOptions.swift
+++ b/Sources/BaseChatInference/Models/BackendLoadOptions.swift
@@ -15,9 +15,8 @@ import Foundation
 /// `flashAttention` knob — it is always on in mlx-swift's SDPA) silently
 /// ignore that field.
 ///
-/// Defaults preserve historical behaviour bit-for-bit. See issue #1017 for
-/// the planned default flips after the opt-in surface has soaked through one
-/// release.
+/// Defaults favor memory/performance for local models: Q8 KV cache, Flash
+/// Attention on physical devices, and backend-default prefill batching.
 public struct BackendLoadOptions: Sendable, Codable, Equatable {
 
     /// KV cache element type.
@@ -27,11 +26,11 @@ public struct BackendLoadOptions: Sendable, Codable, Equatable {
     /// model's weight quantization (Q4 weights + ``q8`` KV is the standard
     /// recipe in mlx-lm Python and llama.cpp).
     public enum KVCacheQuantization: String, Sendable, Codable, CaseIterable {
-        /// Full-precision FP16. Library default. Highest quality, highest memory.
+        /// Full-precision FP16. Highest quality, highest memory.
         case f16
         /// 8-bit quantized. ~50% memory reduction at effectively zero quality
         /// loss. Maps to llama.cpp's `GGML_TYPE_Q8_0` and mlx-swift-lm's
-        /// `kvBits = 8`. Recommended once the opt-in surface soaks (#1017).
+        /// `kvBits = 8`. Default.
         case q8
         /// 4-bit quantized. ~75% memory reduction with measurable quality
         /// loss, especially on GQA/MQA models. Use only when memory pressure
@@ -56,9 +55,22 @@ public struct BackendLoadOptions: Sendable, Codable, Equatable {
     /// on long prompts at the cost of a memory spike during prefill.
     public var prefillBatchSize: Int?
 
+    /// Platform default for ``flashAttention``.
+    ///
+    /// Simulator Metal does not reliably support Flash Attention kernels, so
+    /// the default remains disabled there and ``LlamaModelLoader`` also guards
+    /// against explicit simulator requests.
+    public static var platformDefaultFlashAttention: Bool {
+        #if targetEnvironment(simulator)
+        false
+        #else
+        true
+        #endif
+    }
+
     public init(
-        kvCacheQuantization: KVCacheQuantization = .f16,
-        flashAttention: Bool = false,
+        kvCacheQuantization: KVCacheQuantization = .q8,
+        flashAttention: Bool = BackendLoadOptions.platformDefaultFlashAttention,
         prefillBatchSize: Int? = nil
     ) {
         self.kvCacheQuantization = kvCacheQuantization
@@ -66,8 +78,8 @@ public struct BackendLoadOptions: Sendable, Codable, Equatable {
         self.prefillBatchSize = prefillBatchSize
     }
 
-    /// Library-default options. Behaviour matches BCK pre-PR (no quantized KV,
-    /// no Flash Attention, library-default prefill batch).
+    /// Default options: Q8 KV cache, platform-default Flash Attention, and
+    /// backend-default prefill batch.
     public static let `default` = BackendLoadOptions()
 
     // MARK: Codable
@@ -80,11 +92,12 @@ public struct BackendLoadOptions: Sendable, Codable, Equatable {
 
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        // Forward-compat: every field decodes to its library-default when absent
+        // Forward-compat: every field decodes to its current default when absent
         // so older payloads written before this type existed decode cleanly.
         kvCacheQuantization =
-            (try c.decodeIfPresent(KVCacheQuantization.self, forKey: .kvCacheQuantization)) ?? .f16
-        flashAttention = (try c.decodeIfPresent(Bool.self, forKey: .flashAttention)) ?? false
+            (try c.decodeIfPresent(KVCacheQuantization.self, forKey: .kvCacheQuantization)) ?? .q8
+        flashAttention =
+            (try c.decodeIfPresent(Bool.self, forKey: .flashAttention)) ?? BackendLoadOptions.platformDefaultFlashAttention
         prefillBatchSize = try c.decodeIfPresent(Int.self, forKey: .prefillBatchSize)
     }
 

--- a/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
@@ -30,11 +30,11 @@ final class LlamaBackendTests: XCTestCase {
 
     // MARK: - Load Options Plumbing
 
-    func test_loadOptions_defaultIsHistoricalBehavior() {
+    func test_loadOptions_defaultUsesBackendTunedDefaults() {
         let backend = LlamaBackend()
         let opts = backend.loadOptionsForTesting
-        XCTAssertEqual(opts.kvCacheQuantization, .f16)
-        XCTAssertFalse(opts.flashAttention)
+        XCTAssertEqual(opts.kvCacheQuantization, .q8)
+        XCTAssertEqual(opts.flashAttention, BackendLoadOptions.platformDefaultFlashAttention)
         XCTAssertNil(opts.prefillBatchSize)
     }
 

--- a/Tests/BaseChatBackendsTests/MLXBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXBackendTests.swift
@@ -49,10 +49,10 @@ final class MLXBackendTests: XCTestCase {
 
     // MARK: - Load Options Plumbing (no hardware gate)
 
-    func test_loadOptions_defaultIsHistoricalBehavior() {
+    func test_loadOptions_defaultUsesBackendTunedDefaults() {
         let opts = MLXBackend().loadOptionsForTesting
-        XCTAssertEqual(opts.kvCacheQuantization, .f16)
-        XCTAssertFalse(opts.flashAttention)
+        XCTAssertEqual(opts.kvCacheQuantization, .q8)
+        XCTAssertEqual(opts.flashAttention, BackendLoadOptions.platformDefaultFlashAttention)
         XCTAssertNil(opts.prefillBatchSize)
     }
 

--- a/Tests/BaseChatInferenceTests/BackendLoadOptionsTests.swift
+++ b/Tests/BaseChatInferenceTests/BackendLoadOptionsTests.swift
@@ -8,14 +8,14 @@ final class BackendLoadOptionsTests: XCTestCase {
 
     // MARK: - Defaults
 
-    func test_default_isHistoricalBehavior() {
+    func test_default_usesBackendTunedDefaults() {
         let opts = BackendLoadOptions.default
-        XCTAssertEqual(opts.kvCacheQuantization, .f16,
-                       "Default must preserve full-precision KV cache so opt-in PR doesn't shift behaviour")
-        XCTAssertFalse(opts.flashAttention,
-                       "Default must keep Flash Attention disabled so existing token streams don't change")
+        XCTAssertEqual(opts.kvCacheQuantization, .q8,
+                       "Default uses Q8 KV cache to reduce local backend memory pressure")
+        XCTAssertEqual(opts.flashAttention, BackendLoadOptions.platformDefaultFlashAttention,
+                       "Flash Attention defaults on for physical devices and off for simulator")
         XCTAssertNil(opts.prefillBatchSize,
-                     "Default leaves prefill batch at the library default (nil sentinel)")
+                      "Default leaves prefill batch at the library default (nil sentinel)")
     }
 
     func test_init_propagatesAllFields() {
@@ -102,15 +102,15 @@ final class BackendLoadOptionsTests: XCTestCase {
 
     func test_codableDecode_partialPayload_fillsMissingFieldsWithDefaults() throws {
         // Only `kvCacheQuantization` set — flashAttention and prefillBatchSize must
-        // decode to their library defaults so callers get a coherent value type.
+        // decode to current defaults so callers get a coherent value type.
         let partialJSON = """
-        { "kvCacheQuantization": "q8" }
+        { "kvCacheQuantization": "q4" }
         """
         let data = try XCTUnwrap(partialJSON.data(using: .utf8))
         let decoded = try JSONDecoder().decode(BackendLoadOptions.self, from: data)
 
-        XCTAssertEqual(decoded.kvCacheQuantization, .q8)
-        XCTAssertFalse(decoded.flashAttention)
+        XCTAssertEqual(decoded.kvCacheQuantization, .q4)
+        XCTAssertEqual(decoded.flashAttention, BackendLoadOptions.platformDefaultFlashAttention)
         XCTAssertNil(decoded.prefillBatchSize)
     }
 }


### PR DESCRIPTION
Closes #1017.

## Summary
- change backend load defaults to `kvCacheQuantization = .q8`
- default `flashAttention` to enabled off-simulator while preserving the llama simulator guard
- update decoding/tests/comments so omitted fields follow current platform defaults

## Validation
- `scripts/test.sh --filter BaseChatInferenceTests --filter BaseChatBackendsTests --disable-default-traits --skip-update`
- `scripts/test.sh --filter BaseChatInferenceTests --filter BaseChatBackendsTests --disable-default-traits --skip-update --traits MLX,Llama`