### PR TITLE
feat: add image loading placeholders

### DIFF
--- a/Sources/BaseChatBackends/ClaudeBackend.swift
+++ b/Sources/BaseChatBackends/ClaudeBackend.swift
@@ -343,7 +343,7 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             // Image blocks (rare on assistant turns; supported for
             // round-trip parity with persisted rows).
             for part in message.parts {
-                if case .image(let data, let mimeType) = part {
+                if case .image(let data, let mimeType, _) = part {
                     blocks.append(encodeImageBlock(data: data, mimeType: mimeType))
                 }
             }
@@ -379,7 +379,7 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         if message.role == "user", hasImage {
             var blocks: [[String: Any]] = []
             for part in message.parts {
-                if case .image(let data, let mimeType) = part {
+                if case .image(let data, let mimeType, _) = part {
                     blocks.append(encodeImageBlock(data: data, mimeType: mimeType))
                 }
             }

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -516,7 +516,7 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
 
     private static func imageInputs(from parts: [MessagePart]) throws -> [UserInput.Image] {
         try parts.compactMap { part in
-            guard case let .image(data, mimeType) = part else { return nil }
+            guard case let .image(data, mimeType, _) = part else { return nil }
             return try userInputImage(from: data, mimeType: mimeType)
         }
     }

--- a/Sources/BaseChatBackends/OpenAIBackend.swift
+++ b/Sources/BaseChatBackends/OpenAIBackend.swift
@@ -609,7 +609,7 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             contentParts.append(["type": "text", "text": text])
         }
         for part in message.parts {
-            if case .image(let data, let mimeType) = part {
+            if case .image(let data, let mimeType, _) = part {
                 contentParts.append([
                     "type": "image_url",
                     "image_url": [

--- a/Sources/BaseChatInference/Models/ImagePlaceholderHash.swift
+++ b/Sources/BaseChatInference/Models/ImagePlaceholderHash.swift
@@ -1,0 +1,134 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+
+/// Compact color-field placeholder for image attachments.
+///
+/// The value is intentionally small and dependency-free: a tiny RGB grid plus
+/// the source image aspect ratio. It gives SwiftUI enough information to draw a
+/// blurred color field while the full attachment bytes decode.
+public struct ImagePlaceholderHash: Codable, Hashable, Sendable {
+    public static let algorithm = "bck-color-grid-v1"
+
+    public let value: String
+
+    public init(value: String) {
+        self.value = value
+    }
+
+    public static func generate(from imageData: Data, gridWidth: Int = 4, gridHeight: Int = 3) -> ImagePlaceholderHash? {
+        guard gridWidth > 0, gridHeight > 0 else { return nil }
+        guard let source = CGImageSourceCreateWithData(imageData as CFData, nil) else { return nil }
+        let options = [kCGImageSourceShouldCache: false] as CFDictionary
+        guard let image = CGImageSourceCreateImageAtIndex(source, 0, options) else { return nil }
+
+        let bytesPerPixel = 4
+        let bytesPerRow = gridWidth * bytesPerPixel
+        var pixels = [UInt8](repeating: 0, count: gridHeight * bytesPerRow)
+        guard let context = CGContext(
+            data: &pixels,
+            width: gridWidth,
+            height: gridHeight,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+
+        context.interpolationQuality = .medium
+        context.draw(image, in: CGRect(x: 0, y: 0, width: gridWidth, height: gridHeight))
+
+        var rgb = Data(capacity: gridWidth * gridHeight * 3)
+        for row in 0..<gridHeight {
+            for column in 0..<gridWidth {
+                let offset = row * bytesPerRow + column * bytesPerPixel
+                let alpha = pixels[offset + 3]
+                if alpha == 0 {
+                    rgb.append(contentsOf: [255, 255, 255])
+                } else if alpha == 255 {
+                    rgb.append(contentsOf: [pixels[offset], pixels[offset + 1], pixels[offset + 2]])
+                } else {
+                    let inverse = UInt16(255 - alpha)
+                    let red = UInt8(min(255, UInt16(pixels[offset]) + inverse))
+                    let green = UInt8(min(255, UInt16(pixels[offset + 1]) + inverse))
+                    let blue = UInt8(min(255, UInt16(pixels[offset + 2]) + inverse))
+                    rgb.append(contentsOf: [red, green, blue])
+                }
+            }
+        }
+
+        let encoded = rgb.base64URLEncodedString()
+        return ImagePlaceholderHash(
+            value: "bckg1:\(image.width)x\(image.height):\(gridWidth)x\(gridHeight):\(encoded)"
+        )
+    }
+
+    public var colorGrid: ColorGrid? {
+        let pieces = value.split(separator: ":", omittingEmptySubsequences: false)
+        guard pieces.count == 4, pieces[0] == "bckg1" else { return nil }
+        guard let imageSize = Self.parseSize(pieces[1]), let gridSize = Self.parseSize(pieces[2]) else { return nil }
+        guard imageSize.width > 0, imageSize.height > 0, gridSize.width > 0, gridSize.height > 0 else { return nil }
+        guard let data = Data(base64URLEncoded: String(pieces[3])) else { return nil }
+        guard data.count == gridSize.width * gridSize.height * 3 else { return nil }
+
+        var colors: [RGBColor] = []
+        colors.reserveCapacity(gridSize.width * gridSize.height)
+        var index = 0
+        while index < data.count {
+            colors.append(RGBColor(red: data[index], green: data[index + 1], blue: data[index + 2]))
+            index += 3
+        }
+        return ColorGrid(
+            imageWidth: imageSize.width,
+            imageHeight: imageSize.height,
+            width: gridSize.width,
+            height: gridSize.height,
+            colors: colors
+        )
+    }
+
+    private static func parseSize(_ raw: Substring) -> (width: Int, height: Int)? {
+        let parts = raw.split(separator: "x")
+        guard parts.count == 2, let width = Int(parts[0]), let height = Int(parts[1]) else { return nil }
+        return (width, height)
+    }
+
+    public struct ColorGrid: Hashable, Sendable {
+        public let imageWidth: Int
+        public let imageHeight: Int
+        public let width: Int
+        public let height: Int
+        public let colors: [RGBColor]
+
+        public var aspectRatio: Double {
+            guard imageHeight > 0 else { return 1 }
+            return Double(imageWidth) / Double(imageHeight)
+        }
+    }
+
+    public struct RGBColor: Hashable, Sendable {
+        public let red: UInt8
+        public let green: UInt8
+        public let blue: UInt8
+    }
+}
+
+private extension Data {
+    func base64URLEncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    init?(base64URLEncoded string: String) {
+        var base64 = string
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = base64.count % 4
+        if remainder != 0 {
+            base64.append(String(repeating: "=", count: 4 - remainder))
+        }
+        self.init(base64Encoded: base64)
+    }
+}

--- a/Sources/BaseChatInference/Models/MessagePart.swift
+++ b/Sources/BaseChatInference/Models/MessagePart.swift
@@ -24,8 +24,10 @@ public enum MessagePart: Hashable, Sendable {
     ///
     /// Distinct from ``generatedImage(_:)`` — this case carries inline
     /// bytes the model is asked to look at; that case carries a file URL
-    /// pointing at an image the model produced.
-    case image(data: Data, mimeType: String)
+    /// pointing at an image the model produced. ``placeholderHash`` is optional
+    /// so legacy persisted images and callers that do not need placeholder
+    /// rendering can continue to omit it.
+    case image(data: Data, mimeType: String, placeholderHash: ImagePlaceholderHash? = nil)
     /// Accumulated model reasoning. Excluded from context window (textContent returns nil).
     ///
     /// ``signature`` carries the provider-supplied opaque token that some
@@ -47,11 +49,11 @@ public enum MessagePart: Hashable, Sendable {
     /// An image produced by an ``ImageGenerationBackend`` and attached to
     /// a saved message.
     ///
-    /// Distinct from ``image(data:mimeType:)`` — that case carries raw
-    /// bytes the user submitted as multimodal *input*; this case references
-    /// a file URL whose binary is the model's *output*. Excluded from
-    /// ``textContent`` (the payload's prompt is metadata, not visible
-    /// chat text).
+    /// Distinct from ``image(data:mimeType:placeholderHash:)`` — that case
+    /// carries raw bytes the user submitted as multimodal *input*; this case
+    /// references a file URL whose binary is the model's *output*. Excluded
+    /// from ``textContent`` (the payload's prompt is metadata, not visible chat
+    /// text).
     case generatedImage(ImageMessagePayload)
 }
 
@@ -68,7 +70,7 @@ extension MessagePart: Codable {
     }
 
     private enum ImageKeys: String, CodingKey {
-        case data, mimeType
+        case data, mimeType, placeholderHash
     }
 
     /// Nested payload used for the `.thinking` discriminator.
@@ -109,7 +111,8 @@ extension MessagePart: Codable {
             let nested = try container.nestedContainer(keyedBy: ImageKeys.self, forKey: .image)
             let data = try nested.decode(Data.self, forKey: .data)
             let mimeType = try nested.decode(String.self, forKey: .mimeType)
-            self = .image(data: data, mimeType: mimeType)
+            let placeholderHash = try nested.decodeIfPresent(ImagePlaceholderHash.self, forKey: .placeholderHash)
+            self = .image(data: data, mimeType: mimeType, placeholderHash: placeholderHash)
         case .thinking:
             // Accept both shapes:
             //   legacy:  {"thinking": "text"}
@@ -139,10 +142,11 @@ extension MessagePart: Codable {
         switch self {
         case .text(let text):
             try container.encode(text, forKey: .text)
-        case .image(let data, let mimeType):
+        case .image(let data, let mimeType, let placeholderHash):
             var nested = container.nestedContainer(keyedBy: ImageKeys.self, forKey: .image)
             try nested.encode(data, forKey: .data)
             try nested.encode(mimeType, forKey: .mimeType)
+            try nested.encodeIfPresent(placeholderHash, forKey: .placeholderHash)
         case .thinking(let text, let signature):
             // Always emit the structured object form; legacy readers in
             // BaseChatSchemaV3 decode through the branch above. A nil
@@ -197,5 +201,25 @@ extension MessagePart {
     public var generatedImageContent: ImageMessagePayload? {
         if case .generatedImage(let p) = self { return p }
         return nil
+    }
+
+    /// The compact placeholder hash for an uploaded image part, or `nil` for
+    /// non-image parts and legacy image parts that pre-date placeholders.
+    public var imagePlaceholderHash: ImagePlaceholderHash? {
+        if case .image(_, _, let placeholderHash) = self { return placeholderHash }
+        return nil
+    }
+
+    /// Returns the same image part with a generated placeholder hash when one
+    /// is missing. Non-image parts and images that already carry a hash are
+    /// returned unchanged.
+    public func generatingImagePlaceholderIfNeeded() -> MessagePart {
+        guard case .image(let data, let mimeType, let placeholderHash) = self else { return self }
+        guard placeholderHash == nil else { return self }
+        return .image(
+            data: data,
+            mimeType: mimeType,
+            placeholderHash: ImagePlaceholderHash.generate(from: data)
+        )
     }
 }

--- a/Sources/BaseChatRuntime/Services/ConversationRuntime.swift
+++ b/Sources/BaseChatRuntime/Services/ConversationRuntime.swift
@@ -26,7 +26,8 @@ public struct SendInput: Sendable {
     /// non-empty the runtime builds the user record's `contentParts` as
     /// `[.text(userText), <attachments>...]` so vision-capable backends see
     /// the images and the persisted record preserves them. The runtime does
-    /// not transform the attachments — backends own the on-wire shape.
+    /// only fills in missing image placeholder hashes; backends own the
+    /// remaining on-wire shape.
     public let attachments: [MessagePart]
     public let systemPrompt: String?
     public let temperature: Float
@@ -457,13 +458,14 @@ public final class ConversationRuntime: Sendable {
         // both carry `[.text, <attachments>...]`. Empty text + attachments
         // yields an attachment-only record (e.g. a "describe this image"
         // turn with no caption).
+        let attachments = input.attachments.map { $0.generatingImagePlaceholderIfNeeded() }
         let userContentParts: [MessagePart]
-        if input.attachments.isEmpty {
+        if attachments.isEmpty {
             userContentParts = [.text(input.userText)]
         } else if input.userText.isEmpty {
-            userContentParts = input.attachments
+            userContentParts = attachments
         } else {
-            userContentParts = [.text(input.userText)] + input.attachments
+            userContentParts = [.text(input.userText)] + attachments
         }
         let userMessage = ChatMessageRecord(
             role: .user,

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+IngestPendingPayload.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+IngestPendingPayload.swift
@@ -29,7 +29,11 @@ public enum PendingPayload: Sendable {
     /// `mimeType` defaults to `"image/png"` since most extension
     /// pasteboards expose PNG; pass an explicit value for JPEG, HEIC,
     /// etc.
-    case image(Data, mimeType: String = "image/png")
+    case image(
+        Data,
+        mimeType: String = "image/png",
+        placeholderHash: ImagePlaceholderHash? = nil
+    )
 
     /// A file URL pointing at content the host has already staged
     /// inside the app group. Today the file's path is rendered into
@@ -314,8 +318,17 @@ private extension PendingPayload {
             return (string, [])
         case .url(let url):
             return (url.absoluteString, [])
-        case .image(let data, let mimeType):
-            return ("", [.image(data: data, mimeType: mimeType)])
+        case .image(let data, let mimeType, let placeholderHash):
+            return (
+                "",
+                [
+                    .image(
+                        data: data,
+                        mimeType: mimeType,
+                        placeholderHash: placeholderHash ?? ImagePlaceholderHash.generate(from: data)
+                    ),
+                ]
+            )
         case .file(let url):
             // No file part exists in MessagePart yet (issue #441 will
             // add one), so render the path as the message body. This

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Messages.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Messages.swift
@@ -319,7 +319,7 @@ extension ChatViewModel {
     }
 
     func stageDraftAttachment(_ part: MessagePart) {
-        draftAttachments.append(part)
+        draftAttachments.append(part.generatingImagePlaceholderIfNeeded())
     }
 
     func removeDraftAttachment(id index: Int) {

--- a/Sources/BaseChatUI/Views/Chat/ChatInputBar.swift
+++ b/Sources/BaseChatUI/Views/Chat/ChatInputBar.swift
@@ -203,9 +203,9 @@ public struct ChatInputBar: View {
 
     @ViewBuilder
     private func draftAttachmentPreview(for part: MessagePart, at index: Int) -> some View {
-        if case let .image(data, _) = part {
+        if case let .image(data, _, placeholderHash) = part {
             ZStack(alignment: .topTrailing) {
-                draftThumbnail(data: data)
+                draftThumbnail(data: data, placeholderHash: placeholderHash)
                     .frame(width: 72, height: 72)
                     .clipShape(RoundedRectangle(cornerRadius: 10))
 
@@ -225,18 +225,22 @@ public struct ChatInputBar: View {
     }
 
     @ViewBuilder
-    private func draftThumbnail(data: Data) -> some View {
+    private func draftThumbnail(data: Data, placeholderHash: ImagePlaceholderHash?) -> some View {
         #if os(iOS)
         if let uiImage = UIImage(data: data) {
             Image(uiImage: uiImage)
                 .resizable()
                 .scaledToFill()
+        } else {
+            ImagePlaceholderView(placeholderHash: placeholderHash)
         }
         #elseif os(macOS)
         if let nsImage = NSImage(data: data) {
             Image(nsImage: nsImage)
                 .resizable()
                 .scaledToFill()
+        } else {
+            ImagePlaceholderView(placeholderHash: placeholderHash)
         }
         #endif
     }

--- a/Sources/BaseChatUI/Views/Chat/ImagePlaceholderView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ImagePlaceholderView.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+import BaseChatInference
+
+struct ImageAttachmentView: View {
+    let data: Data
+    let placeholderHash: ImagePlaceholderHash?
+
+    @State private var decodedImage: PlatformImage?
+    @State private var decodeAttempted = false
+
+    var body: some View {
+        ZStack {
+            ImagePlaceholderView(placeholderHash: placeholderHash)
+                .opacity(decodedImage == nil ? 1 : 0)
+
+            if let decodedImage {
+                platformImage(decodedImage)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxHeight: 200)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .opacity(1)
+                    .transition(.opacity)
+            } else if decodeAttempted {
+                missingImagePlaceholder
+            }
+        }
+        .task(id: data) {
+            decodedImage = nil
+            decodeAttempted = false
+            await Task.yield()
+            let image = Self.decodeImage(from: data)
+            withAnimation(.easeInOut(duration: 0.18)) {
+                decodedImage = image
+                decodeAttempted = true
+            }
+        }
+    }
+
+    private var missingImagePlaceholder: some View {
+        RoundedRectangle(cornerRadius: 8)
+            .fill(Color.gray.opacity(0.15))
+            .overlay {
+                Image(systemName: "photo.badge.exclamationmark")
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 160)
+    }
+
+    #if os(iOS)
+    typealias PlatformImage = UIImage
+
+    private static func decodeImage(from data: Data) -> UIImage? {
+        UIImage(data: data)
+    }
+
+    private func platformImage(_ image: UIImage) -> Image {
+        Image(uiImage: image)
+    }
+    #elseif os(macOS)
+    typealias PlatformImage = NSImage
+
+    private static func decodeImage(from data: Data) -> NSImage? {
+        NSImage(data: data)
+    }
+
+    private func platformImage(_ image: NSImage) -> Image {
+        Image(nsImage: image)
+    }
+    #endif
+}
+
+struct ImagePlaceholderView: View {
+    let placeholderHash: ImagePlaceholderHash?
+
+    var body: some View {
+        if let grid = placeholderHash?.colorGrid {
+            GeometryReader { proxy in
+                colorGrid(grid)
+                    .blur(radius: max(8, min(proxy.size.width, proxy.size.height) * 0.08))
+                    .scaleEffect(1.08)
+                    .clipped()
+            }
+            .aspectRatio(grid.aspectRatio, contentMode: .fit)
+            .frame(maxWidth: 320, maxHeight: 200)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .accessibilityHidden(true)
+        } else {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.gray.opacity(0.15))
+                .frame(maxWidth: 320)
+                .frame(height: 160)
+                .accessibilityHidden(true)
+        }
+    }
+
+    private func colorGrid(_ grid: ImagePlaceholderHash.ColorGrid) -> some View {
+        VStack(spacing: 0) {
+            ForEach(0..<grid.height, id: \.self) { row in
+                HStack(spacing: 0) {
+                    ForEach(0..<grid.width, id: \.self) { column in
+                        Rectangle()
+                            .fill(color(for: grid.colors[row * grid.width + column]))
+                    }
+                }
+            }
+        }
+    }
+
+    private func color(for rgb: ImagePlaceholderHash.RGBColor) -> Color {
+        Color(
+            red: Double(rgb.red) / 255.0,
+            green: Double(rgb.green) / 255.0,
+            blue: Double(rgb.blue) / 255.0
+        )
+    }
+}

--- a/Sources/BaseChatUI/Views/Chat/MessagePartsView.swift
+++ b/Sources/BaseChatUI/Views/Chat/MessagePartsView.swift
@@ -60,8 +60,8 @@ struct MessagePartsView: View {
         case .text(let text):
             textView(text)
 
-        case .image(let data, _):
-            imageView(data)
+        case .image(let data, _, let placeholderHash):
+            ImageAttachmentView(data: data, placeholderHash: placeholderHash)
 
         case .thinking(let text, _):
             // While reasoning is in progress (`isThinkingStreaming`), the part's
@@ -195,27 +195,6 @@ struct MessagePartsView: View {
                 .foregroundStyle(role == .user ? .white : .primary)
                 .textSelection(.enabled)
         }
-    }
-
-    @ViewBuilder
-    private func imageView(_ data: Data) -> some View {
-        #if os(iOS)
-        if let uiImage = UIImage(data: data) {
-            Image(uiImage: uiImage)
-                .resizable()
-                .scaledToFit()
-                .frame(maxHeight: 200)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
-        }
-        #elseif os(macOS)
-        if let nsImage = NSImage(data: data) {
-            Image(nsImage: nsImage)
-                .resizable()
-                .scaledToFit()
-                .frame(maxHeight: 200)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
-        }
-        #endif
     }
 
 }

--- a/Tests/BaseChatCoreTests/MessagePartGeneratedImageTests.swift
+++ b/Tests/BaseChatCoreTests/MessagePartGeneratedImageTests.swift
@@ -242,7 +242,7 @@ final class MessagePartGeneratedImageTests: XCTestCase {
         XCTAssertEqual(think, "reasoning")
         XCTAssertEqual(sig, "sig-1")
 
-        guard case .image(let data, let mime) = parts[2] else { return XCTFail("2: expected .image") }
+        guard case .image(let data, let mime, _) = parts[2] else { return XCTFail("2: expected .image") }
         XCTAssertEqual(data, Data([0x01, 0x02]))
         XCTAssertEqual(mime, "image/png")
 

--- a/Tests/BaseChatPersistenceSwiftDataTests/MessagePartTests.swift
+++ b/Tests/BaseChatPersistenceSwiftDataTests/MessagePartTests.swift
@@ -23,6 +23,36 @@ final class MessagePartTests: XCTestCase {
         XCTAssertEqual(decoded, [part])
     }
 
+    func test_imagePartWithPlaceholder_codableRoundTrip() throws {
+        let imageData = ImageFixtures.oneByOnePNGData
+        let placeholder = try XCTUnwrap(ImagePlaceholderHash.generate(from: imageData))
+        let part = MessagePart.image(data: imageData, mimeType: "image/png", placeholderHash: placeholder)
+
+        let data = try JSONEncoder().encode([part])
+        let decoded = try JSONDecoder().decode([MessagePart].self, from: data)
+
+        XCTAssertEqual(decoded, [part])
+        XCTAssertNotNil(decoded.first?.imagePlaceholderHash?.colorGrid)
+    }
+
+    func test_imagePart_withoutPlaceholder_decodesLegacyJSON() throws {
+        let imageData = Data([0xFF, 0xD8, 0xFF, 0xE0])
+        let legacyJSON = #"[{"image":{"data":"\#(imageData.base64EncodedString())","mimeType":"image/jpeg"}}]"#
+
+        let decoded = try JSONDecoder().decode([MessagePart].self, from: Data(legacyJSON.utf8))
+
+        XCTAssertEqual(decoded, [.image(data: imageData, mimeType: "image/jpeg")])
+        XCTAssertNil(decoded.first?.imagePlaceholderHash)
+    }
+
+    func test_generatingImagePlaceholderIfNeeded_preservesExistingPlaceholder() throws {
+        let imageData = ImageFixtures.oneByOnePNGData
+        let placeholder = try XCTUnwrap(ImagePlaceholderHash.generate(from: imageData))
+        let part = MessagePart.image(data: imageData, mimeType: "image/png", placeholderHash: placeholder)
+
+        XCTAssertEqual(part.generatingImagePlaceholderIfNeeded(), part)
+    }
+
     func test_mixedParts_codableRoundTrip() throws {
         let parts: [MessagePart] = [
             .text("Here is the weather:"),

--- a/Tests/BaseChatUITests/ChatInputBarLogicTests.swift
+++ b/Tests/BaseChatUITests/ChatInputBarLogicTests.swift
@@ -223,14 +223,15 @@ final class ChatInputBarLogicTests: XCTestCase {
         mock.tokensToYield = ["Done"]
         let (vm, backend) = makeViewModelWithMock(mock: mock)
         let image = MessagePart.image(data: ImageFixtures.oneByOnePNGData, mimeType: "image/png")
+        let expectedImage = image.generatingImagePlaceholderIfNeeded()
         vm.stageDraftAttachment(image)
 
         await vm.sendMessage()
 
         XCTAssertTrue(vm.draftAttachments.isEmpty, "Draft attachments should be cleared after sending")
         let userMessage = vm.messages.first(where: { $0.role == .user })
-        XCTAssertEqual(userMessage?.contentParts, [image])
-        XCTAssertEqual(backend.lastReceivedStructuredHistory?.first?.parts, [image])
+        XCTAssertEqual(userMessage?.contentParts, [expectedImage])
+        XCTAssertEqual(backend.lastReceivedStructuredHistory?.first?.parts, [expectedImage])
     }
 
     func test_sendMessage_textAndAttachmentPreservesPartOrder() async {
@@ -238,12 +239,13 @@ final class ChatInputBarLogicTests: XCTestCase {
         mock.tokensToYield = ["Done"]
         let (vm, backend) = makeViewModelWithMock(mock: mock)
         let image = MessagePart.image(data: ImageFixtures.oneByOnePNGData, mimeType: "image/png")
+        let expectedImage = image.generatingImagePlaceholderIfNeeded()
         vm.inputText = "Describe this image"
         vm.stageDraftAttachment(image)
 
         await vm.sendMessage()
 
-        let expectedParts: [MessagePart] = [.text("Describe this image"), image]
+        let expectedParts: [MessagePart] = [.text("Describe this image"), expectedImage]
         let userMessage = vm.messages.first(where: { $0.role == .user })
         XCTAssertEqual(userMessage?.contentParts, expectedParts)
         XCTAssertEqual(backend.lastReceivedStructuredHistory?.first?.parts, expectedParts)

--- a/Tests/BaseChatUITests/ChatViewModelIngestPendingPayloadTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelIngestPendingPayloadTests.swift
@@ -180,10 +180,13 @@ final class ChatViewModelIngestPendingPayloadTests: XCTestCase {
         // Image payloads don't carry a text body, so the draft text is cleared
         // while the image itself is staged in the compose bar.
         XCTAssertEqual(vm.inputText, "")
-        XCTAssertEqual(
-            vm.draftAttachments,
-            [.image(data: imageData, mimeType: "image/png")]
-        )
+        XCTAssertEqual(vm.draftAttachments.count, 1)
+        guard case .image(let data, let mimeType, let placeholderHash) = vm.draftAttachments[0] else {
+            return XCTFail("Expected image draft attachment")
+        }
+        XCTAssertEqual(data, imageData)
+        XCTAssertEqual(mimeType, "image/png")
+        XCTAssertNotNil(placeholderHash?.colorGrid)
 
         // No new messages should have been persisted.
         let messages = fetchMessages(for: session.id)
@@ -203,7 +206,13 @@ final class ChatViewModelIngestPendingPayloadTests: XCTestCase {
         )
 
         XCTAssertEqual(vm.inputText, "Please inspect this")
-        XCTAssertEqual(vm.draftAttachments, [.image(data: imageData, mimeType: "image/png")])
+        XCTAssertEqual(vm.draftAttachments.count, 1)
+        guard case .image(let data, let mimeType, let placeholderHash) = vm.draftAttachments[0] else {
+            return XCTFail("Expected image draft attachment")
+        }
+        XCTAssertEqual(data, imageData)
+        XCTAssertEqual(mimeType, "image/png")
+        XCTAssertNotNil(placeholderHash?.colorGrid)
 
         let messages = fetchMessages(for: session.id)
         XCTAssertTrue(messages.isEmpty, "Appending an image payload should stay in draft state until the user sends")

--- a/Tests/BaseChatUITests/ChatViewModelIngestTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelIngestTests.swift
@@ -92,17 +92,18 @@ final class ChatViewModelIngestTests: XCTestCase {
             source: .shareExtension
         )
         await vm.ingest(payload)
+        let expectedImage = image.generatingImagePlaceholderIfNeeded()
 
         // The user message is the first one in the active session.
         let userMessage = vm.messages.first(where: { $0.role == .user })
         XCTAssertNotNil(userMessage, "Ingest should seed a user message")
         XCTAssertEqual(
             userMessage?.contentParts,
-            [.text("here is the prompt"), image],
+            [.text("here is the prompt"), expectedImage],
             "User message should carry the prompt plus the image attachment"
         )
         XCTAssertEqual(vm.draftAttachments, [], "Ingested attachments should be consumed by sendMessage()")
-        XCTAssertEqual(mock.lastReceivedStructuredHistory?.first?.parts, [.text("here is the prompt"), image])
+        XCTAssertEqual(mock.lastReceivedStructuredHistory?.first?.parts, [.text("here is the prompt"), expectedImage])
     }
 
     func test_switchToSession_clearsDraftAttachments() async throws {


### PR DESCRIPTION
Closes #1012.

## Summary
- add a compact image placeholder hash model with legacy-compatible `MessagePart.image` persistence
- generate placeholders during draft staging, pending payload ingest, and runtime send paths
- render placeholder content with crossfade while full images load, plus cover the new behavior with tests

## Validation
- `scripts/test.sh --filter BaseChatInferenceTests --filter BaseChatUITests --filter BaseChatPersistenceSwiftDataTests --disable-default-traits --skip-update`