### PR TITLE
fix: close Foundation multimodal support gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,15 +480,15 @@ SwiftData-backed bootstrap and does not yet support custom providers.
 
 ## Supported Model Types
 
-| Type | Backend | Format | Source |
-|------|---------|--------|--------|
-| GGUF | `LlamaBackend` (llama.cpp) | Single `.gguf` file | HuggingFace, local |
-| MLX | `MLXBackend` (mlx-swift) | Directory with `config.json` + `.safetensors` | HuggingFace, local |
-| Foundation | `FoundationBackend` | Built-in (no download) | Apple Intelligence |
-| OpenAI | `OpenAIBackend` | Cloud API | api.openai.com |
-| Claude | `ClaudeBackend` | Cloud API | api.anthropic.com |
-| Ollama | `OpenAIBackend` | Local API | localhost:11434 |
-| LM Studio | `OpenAIBackend` | Local API | localhost:1234 |
+| Type | Backend | Format | Source | Image input |
+|------|---------|--------|--------|-------------|
+| GGUF | `LlamaBackend` (llama.cpp) | Single `.gguf` file | HuggingFace, local | Not yet; tracked in [#416](https://github.com/roryford/BaseChatKit/issues/416) |
+| MLX | `MLXBackend` (mlx-swift) | Directory with `config.json` + `.safetensors` | HuggingFace, local | Vision models only |
+| Foundation | `FoundationBackend` | Built-in (no download) | Apple Intelligence | No public FoundationModels image-input API yet |
+| OpenAI | `OpenAIBackend` | Cloud API | api.openai.com | Vision-capable models |
+| Claude | `ClaudeBackend` | Cloud API | api.anthropic.com | Vision-capable models |
+| Ollama | `OpenAIBackend` | Local API | localhost:11434 | Vision-capable OpenAI-compatible models |
+| LM Studio | `OpenAIBackend` | Local API | localhost:1234 | Vision-capable OpenAI-compatible models |
 
 ## Key Types
 

--- a/README.md
+++ b/README.md
@@ -482,13 +482,13 @@ SwiftData-backed bootstrap and does not yet support custom providers.
 
 | Type | Backend | Format | Source | Image input |
 |------|---------|--------|--------|-------------|
-| GGUF | `LlamaBackend` (llama.cpp) | Single `.gguf` file | HuggingFace, local | Not yet; tracked in [#416](https://github.com/roryford/BaseChatKit/issues/416) |
+| GGUF | `LlamaBackend` (llama.cpp) | Single `.gguf` file | HuggingFace, local | No; blocked on LlamaSwift multimodal bindings |
 | MLX | `MLXBackend` (mlx-swift) | Directory with `config.json` + `.safetensors` | HuggingFace, local | Vision models only |
-| Foundation | `FoundationBackend` | Built-in (no download) | Apple Intelligence | No public FoundationModels image-input API yet |
-| OpenAI | `OpenAIBackend` | Cloud API | api.openai.com | Vision-capable models |
-| Claude | `ClaudeBackend` | Cloud API | api.anthropic.com | Vision-capable models |
-| Ollama | `OpenAIBackend` | Local API | localhost:11434 | Vision-capable OpenAI-compatible models |
-| LM Studio | `OpenAIBackend` | Local API | localhost:1234 | Vision-capable OpenAI-compatible models |
+| Foundation | `FoundationBackend` | Built-in (no download) | Apple Intelligence | No; no public FoundationModels image-input API yet |
+| OpenAI | `OpenAIBackend` | Cloud API | api.openai.com | OpenAI vision models only |
+| Claude | `ClaudeBackend` | Cloud API | api.anthropic.com | Claude vision models only |
+| Ollama | `OllamaBackend` | Local API | localhost:11434 | No; native Ollama image parts are not wired yet |
+| LM Studio | `OpenAIBackend` | Local API | localhost:1234 | OpenAI-compatible vision models recognized by `OpenAIBackend` |
 
 ## Key Types
 

--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -43,7 +43,6 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
 
     public var capabilities: BackendCapabilities {
         let ctxSize = withStateLock { _effectiveContextSize }
-        let hasMMProj = withStateLock { _mmprojURL != nil }
         // MLX: KV cache reuse deferred — MLX manages its own context lifecycle via
         // MLXModelContainer and does not expose a KV-trim API.
         return BackendCapabilities(
@@ -67,7 +66,7 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
             supportsKVCachePersistence: true,
             supportsGrammarConstrainedSampling: true,
             supportsThinking: true,
-            supportsVision: hasMMProj
+            supportsVision: false
         )
     }
 
@@ -109,12 +108,9 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
     /// URL of the mmproj companion file, set by ``MultimodalProjectorConfigurable`` before each load.
     ///
     /// Guarded by `stateLock`. Non-nil when a vision-capable model's projector is staged for load.
-    /// Cleared by ``unloadModel()``. When non-nil, ``capabilities`` advertises `supportsVision = true`.
-    ///
-    /// - Note: The bundled mattt/llama.swift 2.8772.0 (llama.cpp build b8772) does not expose
-    ///   the CLIP / mmproj C APIs (`clip.h`, `mtmd.h`). The URL is stored so `supportsVision`
-    ///   accurately reflects the projector's presence for model-selection UI; actual image token
-    ///   embedding will be wired when the xcframework is upgraded to a build that includes those headers.
+    /// Cleared by ``unloadModel()``. The current vendored LlamaSwift xcframework does not expose
+    /// the CLIP / mtmd C APIs needed to turn images into embeddings, so ``capabilities`` continues
+    /// to advertise `supportsVision = false` until that binding exists.
     private var _mmprojURL: URL?
 
     /// Structured history set by ``StructuredHistoryReceiver``. Guarded by `stateLock`.
@@ -701,9 +697,8 @@ extension LlamaBackend: MultimodalProjectorConfigurable {
     /// Stages the mmproj companion URL before the next ``loadModel(from:plan:)`` call.
     ///
     /// Called by ``ModelLifecycleCoordinator`` with ``ModelInfo/mmprojURL`` before loading.
-    /// When non-nil, ``capabilities`` advertises `supportsVision = true` so the coordinator
-    /// routes image-bearing turns to this backend. Actual image embedding requires a future
-    /// xcframework upgrade — see the comment on ``_mmprojURL``.
+    /// The URL is retained for future multimodal loading, but it does not flip
+    /// ``BackendCapabilities/supportsVision`` until this backend can embed images.
     public func setMmprojURL(_ url: URL?) {
         withStateLock { _mmprojURL = url }
     }

--- a/Sources/BaseChatInference/Protocols/BackendOptInProtocols.swift
+++ b/Sources/BaseChatInference/Protocols/BackendOptInProtocols.swift
@@ -189,8 +189,9 @@ public protocol TokenCountingBackend: AnyObject {
 ///
 /// ``ModelLifecycleCoordinator`` calls ``setMmprojURL(_:)`` with the URL from
 /// ``ModelInfo/mmprojURL`` before each ``InferenceBackend/loadModel(from:plan:)`` call.
-/// Conformers that receive a non-nil URL should set ``BackendCapabilities/supportsVision``
-/// to `true` in their `capabilities` implementation.
+/// Conformers should set ``BackendCapabilities/supportsVision`` to `true` only
+/// once they can translate ``MessagePart/image(data:mimeType:)`` into backend
+/// image embeddings, not merely because a projector URL is present.
 ///
 /// - Note: Passing `nil` clears the projector, returning the backend to text-only mode.
 ///   ``ModelLifecycleCoordinator`` always calls this before load so the projector state

--- a/Sources/BaseChatInference/Services/GenerationQueue.swift
+++ b/Sources/BaseChatInference/Services/GenerationQueue.swift
@@ -293,7 +293,7 @@ final class GenerationQueue {
     ) throws -> GenerationStream {
         if Self.containsImages(messages), !backend.capabilities.supportsVision {
             throw InferenceError.inferenceFailure(
-                "Image attachments require a vision-capable backend. Load an MLX vision model before sending image parts."
+                "Image attachments require a backend whose capabilities.supportsVision is true. Select a vision-capable backend before sending image parts."
             )
         }
         // Exact-count pre-flight: backends that conform to TokenCountingBackend

--- a/Tests/BaseChatBackendsTests/BackendCapabilitiesContractTests.swift
+++ b/Tests/BaseChatBackendsTests/BackendCapabilitiesContractTests.swift
@@ -179,5 +179,15 @@ final class BackendCapabilitiesContractTests: XCTestCase {
         XCTAssertFalse(FoundationBackend().capabilities.supportsThinking,
                        "FoundationBackend does not emit thinking events — supportsThinking must be false")
     }
+
+    /// Apple's public FoundationModels SDK currently exposes text and
+    /// structured prompt segments, but no image-bearing prompt/input type.
+    /// Keep the capability explicit so the runtime rejects image-bearing
+    /// turns locally instead of flattening them away for FoundationBackend.
+    @available(iOS 26, macOS 26, *)
+    func test_foundationBackend_doesNotAdvertiseVision() {
+        XCTAssertFalse(FoundationBackend().capabilities.supportsVision,
+                       "FoundationBackend must not advertise image input until FoundationModels exposes an image-bearing Prompt/Transcript surface")
+    }
 #endif
 }

--- a/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
@@ -1021,12 +1021,12 @@ final class LlamaBackendTests: XCTestCase {
                        "supportsVision must be false when no mmproj URL has been set")
     }
 
-    func test_capabilities_supportsVision_afterSetMmprojURL_isTrue() {
+    func test_capabilities_supportsVision_afterSetMmprojURL_remainsFalseUntilImageEmbeddingIsWired() {
         let backend = LlamaBackend()
         let fakeMMProj = URL(fileURLWithPath: "/nonexistent/mmproj-model.gguf")
         backend.setMmprojURL(fakeMMProj)
-        XCTAssertTrue(backend.capabilities.supportsVision,
-                      "supportsVision must be true once a mmproj URL is staged")
+        XCTAssertFalse(backend.capabilities.supportsVision,
+                       "supportsVision must remain false until LlamaBackend can pass image embeddings to llama.cpp")
     }
 
     func test_capabilities_supportsVision_afterClearingMmprojURL_isFalse() {
@@ -1034,7 +1034,7 @@ final class LlamaBackendTests: XCTestCase {
         backend.setMmprojURL(URL(fileURLWithPath: "/nonexistent/mmproj-model.gguf"))
         backend.setMmprojURL(nil)
         XCTAssertFalse(backend.capabilities.supportsVision,
-                       "supportsVision must revert to false after setMmprojURL(nil)")
+                       "supportsVision must remain false after setMmprojURL(nil)")
     }
 
     func test_capabilities_supportsVision_afterUnload_isFalse() {


### PR DESCRIPTION
## Summary
- documents per-backend image-input support in the model type matrix, including Foundation's public SDK gap and Llama's current upstream binding block
- keeps FoundationBackend vision support explicitly pinned off with a backend capability contract test
- keeps LlamaBackend from advertising supportsVision until it can actually embed image parts
- generalizes the image-attachment fail-fast error so it does not imply only MLX can handle images

Closes #20

## Tests
- swift test --disable-default-traits --filter 'GenerationQueueStructuredHistoryTests|BackendCapabilitiesContractTests' (implementation worker: passed, 17 tests)
- scripts/test.sh --filter GenerationQueueStructuredHistoryTests --filter BackendCapabilitiesContractTests --disable-default-traits --skip-update (implementation worker: selected tests passed; script returned a stale summary failure)
- GitHub Actions on 1c37443 kicked off after rebase/push
