### PR TITLE
feat(huggingface): support multi-component packages

### DIFF
--- a/Sources/BaseChatHuggingFace/BackgroundDownloadManager.swift
+++ b/Sources/BaseChatHuggingFace/BackgroundDownloadManager.swift
@@ -278,7 +278,11 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
         // Layered defence: the URL-standardized prefix check below already blocks
         // path-traversal writes, but validating the filename at the boundary
         // catches malformed input before any disk operation runs.
-        try DownloadableModel.validate(fileName: model.fileName)
+        if model.packageKind == .diffusion {
+            try validatePackageName(model.fileName)
+        } else {
+            try DownloadableModel.validate(fileName: model.fileName)
+        }
         try await checkDiskSpace(requiredBytes: model.sizeBytes)
         try storageService.ensureModelsDirectory()
 
@@ -333,8 +337,13 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
         // Reject retries with a corrupted persisted filename — the metadata file lives
         // in Caches and a malicious or damaged entry must not be allowed to escape the
         // models directory on resume.
+        let packageKind = info["packageKind"].flatMap(ModelPackageKind.init(rawValue:))
         do {
-            try DownloadableModel.validate(fileName: fileName)
+            if packageKind == .diffusion {
+                try validatePackageName(fileName)
+            } else {
+                try DownloadableModel.validate(fileName: fileName)
+            }
         } catch {
             Log.download.error("Refusing to retry \(id): persisted fileName failed validation: \(error.localizedDescription)")
             activeDownloads[id]?.markFailed(error: "Download metadata is invalid; please re-add the model.")
@@ -349,7 +358,8 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
             fileName: fileName,
             displayName: displayName,
             modelType: modelType,
-            sizeBytes: sizeBytes
+            sizeBytes: sizeBytes,
+            packageKind: packageKind
         )
 
         // Reset to queued so the UI reflects that a new attempt is underway.
@@ -753,10 +763,14 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
             try FileManager.default.removeItem(at: resolvedDestination)
         }
         try FileManager.default.moveItem(at: tempURL, to: resolvedDestination)
-        try DownloadFileValidator().validateChecksum(
-            at: resolvedDestination,
-            expectedChecksum: snapshot.files[relativePath]?.expectedChecksum
-        )
+        if activeDownloads[modelID]?.model.packageKind == .diffusion {
+            try validateDiffusionComponent(at: resolvedDestination, relativePath: relativePath)
+        } else {
+            try DownloadFileValidator().validateChecksum(
+                at: resolvedDestination,
+                expectedChecksum: snapshot.files[relativePath]?.expectedChecksum
+            )
+        }
 
         let fileSize = (try FileManager.default.attributesOfItem(atPath: resolvedDestination.path)[.size] as? NSNumber)?.int64Value ?? snapshot.progressByFile[relativePath]?.expectedBytes ?? 0
         snapshot.completedFiles.insert(relativePath)
@@ -777,8 +791,13 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
 
         guard snapshot.completedFiles.count == snapshot.files.count else { return }
 
-        try validateDownloadedFile(at: snapshot.stagingDirectory, modelType: .mlx)
-        let finalFileName = activeDownloads[modelID]?.model.fileName ?? snapshot.stagingDirectory.lastPathComponent
+        let packageModel = activeDownloads[modelID]?.model
+        if packageModel?.packageKind == .diffusion {
+            try validateDiffusionPackage(at: snapshot.stagingDirectory, files: Array(snapshot.files.keys))
+        } else {
+            try validateDownloadedFile(at: snapshot.stagingDirectory, modelType: .mlx)
+        }
+        let finalFileName = packageModel?.fileName ?? snapshot.stagingDirectory.lastPathComponent
         let finalURL = storageService.modelsDirectory.appendingPathComponent(finalFileName)
         let resolvedFinalURL = finalURL.standardized
         let resolvedModelsDir = storageService.modelsDirectory.standardized
@@ -792,10 +811,95 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
         if FileManager.default.fileExists(atPath: finalURL.path) {
             try FileManager.default.removeItem(at: finalURL)
         }
+        if packageModel?.packageKind == .diffusion, let packageModel {
+            try writePackageManifest(for: packageModel, files: Array(snapshot.files.keys), in: snapshot.stagingDirectory)
+        }
         try FileManager.default.moveItem(at: snapshot.stagingDirectory, to: finalURL)
         activeDownloads[modelID]?.markCompleted(localURL: finalURL)
         removePendingDownload(id: modelID)
         snapshotDownloads.removeValue(forKey: modelID)
+    }
+
+    private func validatePackageName(_ packageName: String) throws {
+        guard !packageName.isEmpty,
+              packageName.count < 255,
+              !packageName.contains("/"),
+              !packageName.contains("\\"),
+              packageName != ".",
+              packageName != "..",
+              !packageName.hasPrefix(".") else {
+            throw HuggingFaceError.invalidDownloadedFile(reason: "Invalid package directory name: \(packageName)")
+        }
+        guard packageName.unicodeScalars.allSatisfy({ scalar in
+            let v = scalar.value
+            return v >= 0x20 && v != 0x7F && !(0x80...0x9F).contains(v)
+        }) else {
+            throw HuggingFaceError.invalidDownloadedFile(reason: "Package directory name contains control characters")
+        }
+    }
+
+    private func validateDiffusionComponent(at url: URL, relativePath: String) throws {
+        guard let role = diffusionRole(for: relativePath) else {
+            throw HuggingFaceError.invalidDownloadedFile(reason: "Unsupported diffusion package component: \(relativePath)")
+        }
+        try DownloadFileValidator.validate(url, diffusionRole: role)
+    }
+
+    private func validateDiffusionPackage(at directory: URL, files: [String]) throws {
+        let fileSet = Set(files)
+        for required in [
+            "model_index.json",
+            "vae/config.json",
+            "vae/diffusion_pytorch_model.safetensors",
+        ] where !fileSet.contains(required) {
+            throw HuggingFaceError.invalidDownloadedFile(reason: "Diffusion package is missing required component: \(required)")
+        }
+        let hasDenoiser = fileSet.contains("unet/diffusion_pytorch_model.safetensors")
+            || fileSet.contains("transformer/diffusion_pytorch_model.safetensors")
+            || fileSet.contains("transformer/model.safetensors")
+        guard hasDenoiser else {
+            throw HuggingFaceError.invalidDownloadedFile(reason: "Diffusion package is missing transformer/UNet weights")
+        }
+        for relativePath in files {
+            try validateDiffusionComponent(at: directory.appendingPathComponent(relativePath), relativePath: relativePath)
+        }
+    }
+
+    private func diffusionRole(for relativePath: String) -> DownloadFileValidator.DiffusionFileRole? {
+        switch relativePath {
+        case "model_index.json":
+            return .manifest
+        case let path where path.hasSuffix("/config.json") || path.hasSuffix("/scheduler_config.json"):
+            return .submoduleConfig
+        case let path where path.hasSuffix(".safetensors"):
+            return .weights
+        case let path where path.hasSuffix("/vocab.json"):
+            return .tokenizerVocab
+        case let path where path.hasSuffix("/merges.txt"):
+            return .tokenizerMerges
+        default:
+            return nil
+        }
+    }
+
+    private func writePackageManifest(
+        for model: DownloadableModel,
+        files: [String],
+        in directory: URL
+    ) throws {
+        let manifest = DownloadedModelPackageManifest(
+            packageKind: .diffusion,
+            id: model.repoID,
+            displayName: model.displayName,
+            format: .mlxDiffusion,
+            huggingFaceRepoID: model.repoID,
+            files: files.sorted()
+        )
+        let data = try JSONEncoder().encode(manifest)
+        try data.write(
+            to: directory.appendingPathComponent(DownloadedModelPackageManifest.fileName),
+            options: .atomic
+        )
     }
 
     // internal: required by BackgroundDownloadManager+URLSessionDelegate.swift
@@ -908,6 +1012,9 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
             "modelType": model.modelType == .gguf ? "gguf" : "mlx",
             "sizeBytes": String(model.sizeBytes),
         ]
+        if let packageKind = model.packageKind {
+            entry["packageKind"] = packageKind.rawValue
+        }
         if !snapshotFiles.isEmpty {
             let data = try JSONEncoder().encode(snapshotFiles)
             guard let json = String(data: data, encoding: .utf8) else {
@@ -958,7 +1065,11 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
             // URL-standardized prefix check would reject it — skip early so the
             // stale entry is also pruned from the pending-downloads JSON.
             do {
-                try DownloadableModel.validate(fileName: fileName)
+                if info["packageKind"] == ModelPackageKind.diffusion.rawValue {
+                    try validatePackageName(fileName)
+                } else {
+                    try DownloadableModel.validate(fileName: fileName)
+                }
             } catch {
                 Log.download.warning("Dropping pending download \(id) with invalid fileName: \(error.localizedDescription)")
                 removePendingDownload(id: id)
@@ -971,7 +1082,8 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
                 fileName: fileName,
                 displayName: displayName,
                 modelType: modelType,
-                sizeBytes: UInt64(info["sizeBytes"] ?? "") ?? 0
+                sizeBytes: UInt64(info["sizeBytes"] ?? "") ?? 0,
+                packageKind: info["packageKind"].flatMap(ModelPackageKind.init(rawValue:))
             )
             let state = DownloadState(model: model)
             activeDownloads[id] = state

--- a/Sources/BaseChatHuggingFace/BackgroundDownloadManager.swift
+++ b/Sources/BaseChatHuggingFace/BackgroundDownloadManager.swift
@@ -366,6 +366,21 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
         let state = DownloadState(model: model)
         activeDownloads[model.id] = state
 
+        let snapshotFiles = decodePendingSnapshotFiles(info["snapshotFiles"], repoID: repoID)
+
+        // Snapshot downloads are retried file-by-file from the persisted package
+        // plan. URLSession resume blobs are only valid for single-file tasks.
+        if let snapshotFiles, !snapshotFiles.isEmpty {
+            _ = consumeResumeData(for: id)
+            do {
+                try startSnapshotDownload(model: model, files: snapshotFiles)
+            } catch {
+                Log.download.error("Failed to restart snapshot download for \(id): \(error.localizedDescription)")
+                activeDownloads[model.id]?.markFailed(error: error.localizedDescription)
+            }
+            return
+        }
+
         // Consume any persisted resume data. Clean it up regardless of outcome so
         // we never retry with stale data on a subsequent failure.
         let resumeData = consumeResumeData(for: id)
@@ -393,17 +408,35 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
         }
     }
 
+    private func decodePendingSnapshotFiles(_ json: String?, repoID: String) -> [ModelDownloadFile]? {
+        guard let json, let data = json.data(using: .utf8) else { return nil }
+        do {
+            let metadata = try JSONDecoder().decode([SnapshotFileMetadata].self, from: data)
+            return metadata.map { file in
+                ModelDownloadFile(
+                    relativePath: file.relativePath,
+                    url: huggingFaceDownloadURL(repoID: repoID, filePath: file.relativePath),
+                    sizeBytes: file.sizeBytes,
+                    expectedChecksum: file.expectedChecksum
+                )
+            }
+        } catch {
+            Log.download.error("Failed to decode pending snapshot metadata for \(repoID): \(error.localizedDescription)")
+            return nil
+        }
+    }
+
     /// Starts a fresh single-file download for a model from its HuggingFace URL.
     ///
     /// Used as the fallback when resume data is absent or rejected by the server.
     @MainActor private func retryWithFreshDownload(model: DownloadableModel) async {
-        var components = URLComponents()
-        components.scheme = "https"
-        components.host = "huggingface.co"
-        let segments = ([model.repoID, "resolve", "main"] + model.fileName.components(separatedBy: "/"))
-            .map { $0.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? $0 }
-        components.percentEncodedPath = "/" + segments.joined(separator: "/")
-        guard let url = components.url else {
+        guard model.modelType != .mlx || model.packageKind == nil else {
+            Log.download.error("Cannot retry snapshot download \(model.id) without persisted package metadata")
+            activeDownloads[model.id]?.markFailed(error: "Download metadata is incomplete; please re-add the model.")
+            return
+        }
+        let url = huggingFaceDownloadURL(repoID: model.repoID, filePath: model.fileName)
+        guard url.host == "huggingface.co" else {
             Log.download.error("Failed to build retry URL for \(model.id)")
             activeDownloads[model.id]?.markFailed(error: "Could not construct download URL for retry")
             return
@@ -414,6 +447,20 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
             Log.download.error("Failed to start fresh retry download for \(model.id): \(error.localizedDescription)")
             activeDownloads[model.id]?.markFailed(error: error.localizedDescription)
         }
+    }
+
+    private func huggingFaceDownloadURL(repoID: String, filePath: String) -> URL {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "huggingface.co"
+        let segments = ([repoID, "resolve", "main"] + filePath.components(separatedBy: "/"))
+            .map { $0.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? $0 }
+        components.percentEncodedPath = "/" + segments.joined(separator: "/")
+        guard let url = components.url else {
+            Log.download.error("Failed to build download URL for \(repoID)/\(filePath)")
+            return URL(string: "https://huggingface.co")!
+        }
+        return url
     }
 
     /// Cancels an in-progress download.
@@ -910,7 +957,6 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
                 return
             }
             activeDownloads[modelID]?.markFailed(error: error)
-            removePendingDownload(id: modelID)
             return
         }
 
@@ -928,7 +974,6 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
         }
 
         activeDownloads[modelID]?.markFailed(error: error)
-        removePendingDownload(id: modelID)
         snapshotDownloads.removeValue(forKey: modelID)
         do {
             try FileManager.default.removeItem(at: snapshot.stagingDirectory)

--- a/Sources/BaseChatHuggingFace/DiffusionDownload.swift
+++ b/Sources/BaseChatHuggingFace/DiffusionDownload.swift
@@ -93,11 +93,45 @@ public extension HuggingFaceService {
         let session = urlSession ?? URLSession(configuration: .ephemeral)
         let resolvedDisplayName = displayName ?? repoID.split(separator: "/").last.map(String.init) ?? repoID
 
-        try FileManager.default.createDirectory(at: destinationDirectory, withIntermediateDirectories: true)
+        let parentDirectory = destinationDirectory.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parentDirectory, withIntermediateDirectories: true)
+        let stagingDirectory = parentDirectory.appendingPathComponent(
+            ".staging-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: stagingDirectory, withIntermediateDirectories: true)
+
+        do {
+            return try await downloadDiffusionModelAtomically(
+                from: repoID,
+                to: destinationDirectory,
+                stagingDirectory: stagingDirectory,
+                displayName: resolvedDisplayName,
+                using: session,
+                progress: progress
+            )
+        } catch {
+            do {
+                try FileManager.default.removeItem(at: stagingDirectory)
+            } catch {
+                Log.download.warning("Failed to remove diffusion staging directory: \(error.localizedDescription)")
+            }
+            throw error
+        }
+    }
+
+    private func downloadDiffusionModelAtomically(
+        from repoID: String,
+        to destinationDirectory: URL,
+        stagingDirectory: URL,
+        displayName resolvedDisplayName: String,
+        using session: URLSession,
+        progress: @escaping @Sendable (DiffusionDownloadProgress) -> Void
+    ) async throws -> ImageModelInfo {
 
         // 1. Fetch manifest.
         let manifestRemoteURL = downloadURL(repoID: repoID, filePath: "model_index.json")
-        let manifestLocalURL = destinationDirectory.appendingPathComponent("model_index.json")
+        let manifestLocalURL = stagingDirectory.appendingPathComponent("model_index.json")
         try await downloadFile(
             from: manifestRemoteURL,
             to: manifestLocalURL,
@@ -111,7 +145,7 @@ public extension HuggingFaceService {
         // 3. Plan the file list.
         let plan = try buildDiffusionDownloadPlan(
             manifest: manifest,
-            destinationDirectory: destinationDirectory
+            destinationDirectory: stagingDirectory
         )
 
         // 4. Download each file sequentially with summed progress.
@@ -172,13 +206,44 @@ public extension HuggingFaceService {
             "Diffusion download complete: \(repoID, privacy: .private) (\(plan.items.count) files, \(totalBytes) bytes)"
         )
 
-        return ImageModelInfo(
+        let info = ImageModelInfo(
             id: repoID,
             name: resolvedDisplayName,
             directoryURL: destinationDirectory,
             format: .mlxDiffusion,
             fileSize: totalBytes,
             huggingFaceRepoID: repoID
+        )
+
+        try writePackageManifest(
+            for: info,
+            files: ["model_index.json"] + plan.items.map(\.relativePath),
+            in: stagingDirectory
+        )
+        if FileManager.default.fileExists(atPath: destinationDirectory.path) {
+            try FileManager.default.removeItem(at: destinationDirectory)
+        }
+        try FileManager.default.moveItem(at: stagingDirectory, to: destinationDirectory)
+        return info
+    }
+
+    private func writePackageManifest(
+        for info: ImageModelInfo,
+        files: [String],
+        in directory: URL
+    ) throws {
+        let manifest = DownloadedModelPackageManifest(
+            packageKind: .diffusion,
+            id: info.id,
+            displayName: info.name,
+            format: info.format,
+            huggingFaceRepoID: info.huggingFaceRepoID,
+            files: files.sorted()
+        )
+        let data = try JSONEncoder().encode(manifest)
+        try data.write(
+            to: directory.appendingPathComponent(DownloadedModelPackageManifest.fileName),
+            options: .atomic
         )
     }
 

--- a/Sources/BaseChatHuggingFace/HuggingFaceService.swift
+++ b/Sources/BaseChatHuggingFace/HuggingFaceService.swift
@@ -117,9 +117,11 @@ public final class HuggingFaceService: HuggingFaceServiceProtocol {
                 Log.network.error("Failed to fetch MLX snapshot for \(model.repoID): \(error.localizedDescription)")
                 throw HuggingFaceError.modelNotFound(repoID: model.repoID)
             }
-            let files = snapshotFiles(from: detailed)
+            let files = model.packageKind == .diffusion
+                ? diffusionPackageFiles(from: detailed)
+                : snapshotFiles(from: detailed)
             guard !files.isEmpty else {
-                throw HuggingFaceError.invalidDownloadedFile(reason: "MLX repo has no snapshot files to download")
+                throw HuggingFaceError.invalidDownloadedFile(reason: "Repo has no package files to download")
             }
             return .snapshot(files: files)
         case .foundation:
@@ -169,6 +171,23 @@ public final class HuggingFaceService: HuggingFaceServiceProtocol {
             ))
         }
 
+        let diffusionFiles = diffusionPackageFiles(from: model)
+        if !diffusionFiles.isEmpty {
+            let repoName = model.id.name
+            results.append(DownloadableModel(
+                repoID: repoID,
+                fileName: packageDirectoryName(for: repoID),
+                displayName: Self.cleanDisplayName(from: repoName),
+                modelType: .mlx,
+                sizeBytes: diffusionFiles.reduce(0) { $0 + $1.sizeBytes },
+                downloads: model.downloads,
+                isCurated: false,
+                promptTemplate: nil,
+                description: nil,
+                packageKind: .diffusion
+            ))
+        }
+
         let snapshotFiles = snapshotFiles(from: model)
         if !snapshotFiles.isEmpty {
             let repoName = model.id.name
@@ -181,7 +200,8 @@ public final class HuggingFaceService: HuggingFaceServiceProtocol {
                 downloads: model.downloads,
                 isCurated: false,
                 promptTemplate: nil,
-                description: nil
+                description: nil,
+                packageKind: .mlxSnapshot
             ))
         }
 
@@ -190,7 +210,7 @@ public final class HuggingFaceService: HuggingFaceServiceProtocol {
 
     private func isDownloadableRepo(_ model: Model) -> Bool {
         guard let siblings = model.siblings else { return false }
-        return hasGGUFFiles(in: siblings) || isMLXSnapshot(model)
+        return hasGGUFFiles(in: siblings) || isMLXSnapshot(model) || isDiffusionPackage(model)
     }
 
     private func hasGGUFFiles(in siblings: [Model.SiblingInfo]) -> Bool {
@@ -221,6 +241,46 @@ public final class HuggingFaceService: HuggingFaceServiceProtocol {
                 sizeBytes: UInt64(file.size ?? 0)
             )
         }
+    }
+
+    private func isDiffusionPackage(_ model: Model) -> Bool {
+        guard let siblings = model.siblings else { return false }
+        let names = Set(siblings.map { $0.relativeFilename.lowercased() })
+        let hasManifest = names.contains("model_index.json")
+        let hasVAE = names.contains("vae/config.json")
+            && names.contains("vae/diffusion_pytorch_model.safetensors")
+        let hasDenoiser = names.contains("unet/diffusion_pytorch_model.safetensors")
+            || names.contains("transformer/diffusion_pytorch_model.safetensors")
+            || names.contains("transformer/model.safetensors")
+        let hasTextEncoder = names.contains("text_encoder/model.safetensors")
+            || names.contains("text_encoder_2/model.safetensors")
+        let hasScheduler = names.contains("scheduler/scheduler_config.json")
+        return hasManifest && hasVAE && hasDenoiser && hasTextEncoder && hasScheduler
+    }
+
+    private func diffusionPackageFiles(from model: Model) -> [ModelDownloadFile] {
+        guard let siblings = model.siblings, isDiffusionPackage(model) else { return [] }
+        let allowed: (String) -> Bool = { name in
+            name == "model_index.json"
+                || name.hasSuffix("/config.json")
+                || name.hasSuffix("/scheduler_config.json")
+                || name.hasSuffix(".safetensors")
+                || name.hasSuffix("/vocab.json")
+                || name.hasSuffix("/merges.txt")
+        }
+        return siblings
+            .filter { allowed($0.relativeFilename.lowercased()) }
+            .map { file in
+                ModelDownloadFile(
+                    relativePath: file.relativeFilename,
+                    url: downloadURL(repoID: model.id.rawValue, filePath: file.relativeFilename),
+                    sizeBytes: UInt64(file.size ?? 0)
+                )
+            }
+    }
+
+    private func packageDirectoryName(for repoID: String) -> String {
+        repoID.replacingOccurrences(of: "/", with: "__")
     }
 
     private static func cleanDisplayName(from name: String) -> String {

--- a/Sources/BaseChatInference/Models/DownloadableModel.swift
+++ b/Sources/BaseChatInference/Models/DownloadableModel.swift
@@ -33,6 +33,13 @@ public struct DownloadableModel: Identifiable, Sendable, Hashable {
     /// alongside ``fileName``. Mirrors ``CuratedModel/mmprojFileName`` for curated entries.
     public let mmprojFileName: String?
 
+    /// Logical package kind when this downloadable resolves to multiple files.
+    ///
+    /// `nil` preserves the historical single-file GGUF behavior. `.mlxSnapshot`
+    /// represents existing MLX directory downloads, while `.diffusion` lets the
+    /// same background transfer machinery surface diffusers packages as one model.
+    public let packageKind: ModelPackageKind?
+
     /// Expected SHA-256 digest (lowercase hex, 64 chars) for the downloaded file.
     ///
     /// When set, ``DownloadFileValidator`` computes the SHA-256 of the
@@ -83,6 +90,7 @@ public struct DownloadableModel: Identifiable, Sendable, Hashable {
         self.promptTemplate = curated.promptTemplate
         self.description = curated.description
         self.mmprojFileName = curated.mmprojFileName
+        self.packageKind = nil
         self.expectedSHA256 = curated.expectedSHA256
     }
 
@@ -99,6 +107,7 @@ public struct DownloadableModel: Identifiable, Sendable, Hashable {
         promptTemplate: PromptTemplate? = nil,
         description: String? = nil,
         mmprojFileName: String? = nil,
+        packageKind: ModelPackageKind? = nil,
         expectedSHA256: String? = nil
     ) {
         self.id = "\(repoID)/\(fileName)"
@@ -112,6 +121,7 @@ public struct DownloadableModel: Identifiable, Sendable, Hashable {
         self.promptTemplate = promptTemplate
         self.description = description
         self.mmprojFileName = mmprojFileName
+        self.packageKind = packageKind
         self.expectedSHA256 = expectedSHA256
     }
 }

--- a/Sources/BaseChatInference/Models/DownloadedModelPackageManifest.swift
+++ b/Sources/BaseChatInference/Models/DownloadedModelPackageManifest.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Narrow on-disk readiness marker for multi-file model packages.
+///
+/// This is deliberately local storage metadata, not the catalog/sidecar manifest
+/// layer tracked by #977. Downloaders write it only after every component file has
+/// been validated and moved into its final package directory, so discovery can
+/// treat the package atomically.
+public struct DownloadedModelPackageManifest: Codable, Hashable, Sendable {
+    public static let fileName = ".basechatkit-package.json"
+
+    public let packageKind: ModelPackageKind
+    public let id: String
+    public let displayName: String
+    public let format: ImageModelFormat?
+    public let huggingFaceRepoID: String?
+    public let files: [String]
+
+    public init(
+        packageKind: ModelPackageKind,
+        id: String,
+        displayName: String,
+        format: ImageModelFormat? = nil,
+        huggingFaceRepoID: String? = nil,
+        files: [String]
+    ) {
+        self.packageKind = packageKind
+        self.id = id
+        self.displayName = displayName
+        self.format = format
+        self.huggingFaceRepoID = huggingFaceRepoID
+        self.files = files
+    }
+}
+
+/// Logical package kinds that share the multi-component download machinery.
+public enum ModelPackageKind: String, Codable, Hashable, Sendable {
+    /// Existing text MLX snapshot layout (`config.json` + safetensors).
+    case mlxSnapshot
+    /// Diffusers-style image package (`model_index.json`, transformer/UNet, VAE,
+    /// text encoder, tokenizer, and scheduler components).
+    case diffusion
+}
+

--- a/Sources/BaseChatInference/Services/ModelStorageService.swift
+++ b/Sources/BaseChatInference/Services/ModelStorageService.swift
@@ -89,6 +89,10 @@ public final class ModelStorageService {
             guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory),
                   isDirectory.boolValue else { continue }
 
+            if isImagePackageDirectory(url) {
+                continue
+            }
+
             if let model = ModelInfo(mlxDirectory: url) {
                 models.append(model)
                 continue
@@ -107,12 +111,39 @@ public final class ModelStorageService {
             for nestedURL in nestedContents {
                 var nestedIsDir: ObjCBool = false
                 guard fileManager.fileExists(atPath: nestedURL.path, isDirectory: &nestedIsDir),
+                      !isImagePackageDirectory(nestedURL),
                       nestedIsDir.boolValue,
                       let model = ModelInfo(mlxDirectory: nestedURL, namespace: namespace) else {
                     continue
                 }
                 models.append(model)
             }
+        }
+
+        return models.sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+    }
+
+    /// Scans for atomically completed image model packages under `rootDirectory`.
+    ///
+    /// A package is surfaced only when its local readiness manifest exists and
+    /// every component listed in that manifest is present. Staging directories or
+    /// partially downloaded packages without the manifest are intentionally hidden.
+    public func discoverImageModels(in rootDirectory: URL? = nil) -> [ImageModelInfo] {
+        let root = rootDirectory ?? modelsDirectory
+
+        guard let contents = try? fileManager.contentsOfDirectory(
+            at: root,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+
+        let models = contents.compactMap { url -> ImageModelInfo? in
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory),
+                  isDirectory.boolValue else { return nil }
+            return imageModelInfoIfReady(at: url)
         }
 
         return models.sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
@@ -178,5 +209,72 @@ public final class ModelStorageService {
         resourceValues.isExcludedFromBackup = true
         try resourceURL.setResourceValues(resourceValues)
         #endif
+    }
+
+    private func imageModelInfoIfReady(at directory: URL) -> ImageModelInfo? {
+        let manifestURL = directory.appendingPathComponent(DownloadedModelPackageManifest.fileName)
+        let manifest: DownloadedModelPackageManifest
+        do {
+            let data = try Data(contentsOf: manifestURL)
+            manifest = try JSONDecoder().decode(DownloadedModelPackageManifest.self, from: data)
+        } catch {
+            return nil
+        }
+        guard manifest.packageKind == .diffusion,
+              manifest.format == .mlxDiffusion else {
+            return nil
+        }
+
+        for relativePath in manifest.files {
+            guard isSafeRelativePackagePath(relativePath) else { return nil }
+            let fileURL = directory.appendingPathComponent(relativePath)
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: fileURL.path, isDirectory: &isDirectory),
+                  !isDirectory.boolValue else {
+                return nil
+            }
+        }
+
+        return ImageModelInfo(
+            id: manifest.id,
+            name: manifest.displayName,
+            directoryURL: directory,
+            format: .mlxDiffusion,
+            fileSize: packageSize(at: directory, files: manifest.files),
+            huggingFaceRepoID: manifest.huggingFaceRepoID
+        )
+    }
+
+    private func packageSize(at directory: URL, files: [String]) -> Int64 {
+        files.reduce(Int64(0)) { total, relativePath in
+            let url = directory.appendingPathComponent(relativePath)
+            let size: Int64
+            do {
+                size = Int64(try url.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0)
+            } catch {
+                size = 0
+            }
+            return total + size
+        }
+    }
+
+    private func isImagePackageDirectory(_ directory: URL) -> Bool {
+        let manifestURL = directory.appendingPathComponent(DownloadedModelPackageManifest.fileName)
+        do {
+            let data = try Data(contentsOf: manifestURL)
+            let manifest = try JSONDecoder().decode(DownloadedModelPackageManifest.self, from: data)
+            return manifest.packageKind == .diffusion
+        } catch {
+            return false
+        }
+    }
+
+    private func isSafeRelativePackagePath(_ path: String) -> Bool {
+        guard !path.isEmpty, !path.hasPrefix("/"), !path.contains("\\") else { return false }
+        let components = path.split(separator: "/", omittingEmptySubsequences: false)
+        guard !components.isEmpty else { return false }
+        return components.allSatisfy { component in
+            !component.isEmpty && component != "." && component != ".." && !component.hasPrefix(".")
+        }
     }
 }

--- a/Sources/BaseChatUIModelManagement/Views/Image/ImageModelInstallView.swift
+++ b/Sources/BaseChatUIModelManagement/Views/Image/ImageModelInstallView.swift
@@ -73,6 +73,9 @@ public struct ImageModelInstallView: View {
             }
         }
         .accessibilityIdentifier("image-model-install-list")
+        .onAppear {
+            refreshInstalledModels()
+        }
     }
 
     @ViewBuilder
@@ -168,6 +171,12 @@ public struct ImageModelInstallView: View {
     /// don't collide on disk.
     private func slug(for repoID: String) -> String {
         repoID.replacingOccurrences(of: "/", with: "__")
+    }
+
+    private func refreshInstalledModels() {
+        let discovered = ModelStorageService(baseDirectory: storageRoot)
+            .discoverImageModels()
+        installedModels = Dictionary(uniqueKeysWithValues: discovered.map { ($0.id, $0) })
     }
 }
 #endif

--- a/Tests/BaseChatHuggingFaceTests/DownloadManagerTests.swift
+++ b/Tests/BaseChatHuggingFaceTests/DownloadManagerTests.swift
@@ -58,6 +58,49 @@ final class DownloadManagerTests: XCTestCase {
         ]
     }
 
+    private func makeDiffusionPackageFiles() -> [ModelDownloadFile] {
+        [
+            "model_index.json",
+            "unet/config.json",
+            "unet/diffusion_pytorch_model.safetensors",
+            "vae/config.json",
+            "vae/diffusion_pytorch_model.safetensors",
+            "text_encoder/config.json",
+            "text_encoder/model.safetensors",
+            "scheduler/scheduler_config.json",
+        ].enumerated().map { index, path in
+            ModelDownloadFile(
+                relativePath: path,
+                url: URL(string: "https://example.com/component-\(index)")!,
+                sizeBytes: 100
+            )
+        }
+    }
+
+    private func makeSafetensorsBlob(payloadByteCount: Int = 4) -> Data {
+        let headerJSON = #"{"x":{"dtype":"F16","shape":[2],"data_offsets":[0,4]}}"#
+        let headerBytes = Data(headerJSON.utf8)
+        var prefix = Data(count: 8)
+        let headerLen = UInt64(headerBytes.count).littleEndian
+        prefix.withUnsafeMutableBytes { raw in
+            raw.storeBytes(of: headerLen, as: UInt64.self)
+        }
+        var blob = prefix
+        blob.append(headerBytes)
+        blob.append(Data(repeating: 0, count: payloadByteCount))
+        return blob
+    }
+
+    private func fixtureData(forDiffusionRelativePath relativePath: String) -> Data {
+        if relativePath.hasSuffix(".safetensors") {
+            return makeSafetensorsBlob()
+        }
+        if relativePath.hasSuffix("merges.txt") {
+            return Data("#version: 0.2\na b\n".utf8)
+        }
+        return Data(#"{"ok": true}"#.utf8)
+    }
+
     // MARK: - Disk Space
 
     func test_diskSpaceCheck_sufficientSpace() async {
@@ -393,6 +436,43 @@ final class DownloadManagerTests: XCTestCase {
         XCTAssertEqual(progress, 0.55, accuracy: 0.001)
     }
 
+    func test_updateSnapshotProgress_aggregatesDiffusionPackageAsSingleDownload() {
+        let model = DownloadableModel(
+            repoID: "stabilityai/sdxl-test",
+            fileName: "stabilityai__sdxl-test",
+            displayName: "SDXL Test",
+            modelType: .mlx,
+            sizeBytes: 800,
+            packageKind: .diffusion
+        )
+        let state = DownloadState(model: model)
+        manager.activeDownloads[model.id] = state
+
+        let stagingDirectory = tempDirectory.appendingPathComponent(".staging-diffusion-progress", isDirectory: true)
+        try? FileManager.default.createDirectory(at: stagingDirectory, withIntermediateDirectories: true)
+        manager.prepareSnapshotDownload(model: model, files: makeDiffusionPackageFiles(), stagingDirectory: stagingDirectory)
+
+        manager.updateSnapshotProgress(
+            modelID: model.id,
+            relativePath: "unet/diffusion_pytorch_model.safetensors",
+            bytesDownloaded: 250,
+            totalBytesExpected: 400
+        )
+        manager.updateSnapshotProgress(
+            modelID: model.id,
+            relativePath: "vae/diffusion_pytorch_model.safetensors",
+            bytesDownloaded: 150,
+            totalBytesExpected: 400
+        )
+
+        guard case .downloading(let progress, let bytesDownloaded, let totalBytes) = state.status else {
+            return XCTFail("Expected diffusion package progress to be aggregated in one DownloadState")
+        }
+        XCTAssertEqual(bytesDownloaded, 400)
+        XCTAssertEqual(totalBytes, 800)
+        XCTAssertEqual(progress, 0.5, accuracy: 0.001)
+    }
+
     func test_completeSnapshotFile_finalizesDirectoryAfterLastFile() throws {
         let model = DownloadableModel(
             repoID: "mlx-community/Test-4bit",
@@ -438,6 +518,42 @@ final class DownloadManagerTests: XCTestCase {
             FileManager.default.fileExists(
                 atPath: finalURL.appendingPathComponent("weights/model.safetensors").path
             )
+        )
+    }
+
+    func test_completeSnapshotFile_writesReadinessManifestForDiffusionPackage() throws {
+        let model = DownloadableModel(
+            repoID: "stabilityai/sdxl-test",
+            fileName: "stabilityai__sdxl-test",
+            displayName: "SDXL Test",
+            modelType: .mlx,
+            sizeBytes: 800,
+            packageKind: .diffusion
+        )
+        let state = DownloadState(model: model)
+        manager.activeDownloads[model.id] = state
+
+        let stagingDirectory = tempDirectory.appendingPathComponent(".staging-diffusion-finalize", isDirectory: true)
+        try FileManager.default.createDirectory(at: stagingDirectory, withIntermediateDirectories: true)
+        let files = makeDiffusionPackageFiles()
+        manager.prepareSnapshotDownload(model: model, files: files, stagingDirectory: stagingDirectory)
+
+        for file in files {
+            let tempURL = tempDirectory.appendingPathComponent(UUID().uuidString)
+            try fixtureData(forDiffusionRelativePath: file.relativePath).write(to: tempURL)
+            try manager.completeSnapshotFile(modelID: model.id, relativePath: file.relativePath, tempURL: tempURL)
+        }
+
+        let finalURL = tempDirectory.appendingPathComponent("stabilityai__sdxl-test", isDirectory: true)
+        guard case .completed(let localURL) = state.status else {
+            return XCTFail("Diffusion package should complete after every component is validated")
+        }
+        XCTAssertEqual(localURL.standardizedFileURL.path, finalURL.standardizedFileURL.path)
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: finalURL.appendingPathComponent(DownloadedModelPackageManifest.fileName).path
+            ),
+            "Completed diffusion packages need a local readiness manifest for atomic discovery"
         )
     }
 

--- a/Tests/BaseChatInferenceTests/ModelStorageServiceTests.swift
+++ b/Tests/BaseChatInferenceTests/ModelStorageServiceTests.swift
@@ -85,6 +85,45 @@ final class ModelStorageServiceTests: XCTestCase {
         return url
     }
 
+    @discardableResult
+    private func createDiffusionPackage(
+        named name: String = "diffusion-\(UUID().uuidString)",
+        writeManifest: Bool = true,
+        omitFile omitted: String? = nil
+    ) throws -> URL {
+        let dir = service.modelsDirectory.appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let files = [
+            "model_index.json",
+            "unet/config.json",
+            "unet/diffusion_pytorch_model.safetensors",
+            "vae/config.json",
+            "vae/diffusion_pytorch_model.safetensors",
+            "text_encoder/config.json",
+            "text_encoder/model.safetensors",
+            "scheduler/scheduler_config.json",
+        ]
+        for file in files where file != omitted {
+            let url = dir.appendingPathComponent(file)
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try Data("x".utf8).write(to: url)
+        }
+        if writeManifest {
+            let manifest = DownloadedModelPackageManifest(
+                packageKind: .diffusion,
+                id: "test-org/\(name)",
+                displayName: "Diffusion \(name)",
+                format: .mlxDiffusion,
+                huggingFaceRepoID: "test-org/\(name)",
+                files: files
+            )
+            let data = try JSONEncoder().encode(manifest)
+            try data.write(to: dir.appendingPathComponent(DownloadedModelPackageManifest.fileName))
+        }
+        createdURLs.append(dir)
+        return dir
+    }
+
     // MARK: - ensureModelsDirectory
 
     func test_ensureModelsDirectory_createsDirectory() throws {
@@ -115,6 +154,19 @@ final class ModelStorageServiceTests: XCTestCase {
         XCTAssertNotNil(match, "Should discover the GGUF file")
         XCTAssertEqual(match?.modelType, .gguf)
         XCTAssertEqual(match?.fileSize, 1024)
+    }
+
+    func test_discoverModels_singleFileCompatibilityIgnoresPackageManifest() throws {
+        let ggufURL = try createGgufFile()
+        try createDiffusionPackage()
+
+        let models = service.discoverModels()
+
+        XCTAssertNotNil(models.first { $0.fileName == ggufURL.lastPathComponent })
+        XCTAssertNil(
+            models.first { $0.modelType == .mlx && $0.fileName.contains("diffusion") },
+            "Image packages must not alter the existing text-model discovery list"
+        )
     }
 
     func test_discoverModels_findsMlxDirectories() throws {
@@ -230,6 +282,52 @@ final class ModelStorageServiceTests: XCTestCase {
         XCTAssertNotNil(
             models.first { $0.fileName == "\(nsB.lastPathComponent)/model-b" },
             "Namespaced MLX directory under \(nsB.lastPathComponent) should be discovered"
+        )
+    }
+
+    func test_discoverImageModels_ignoresPartialPackageWithoutManifest() throws {
+        let packageURL = try createDiffusionPackage(writeManifest: false)
+
+        let imageModels = service.discoverImageModels()
+
+        XCTAssertNil(
+            imageModels.first {
+                $0.directoryURL.standardizedFileURL.path == packageURL.standardizedFileURL.path
+            },
+            "Partially downloaded packages without readiness manifests must stay hidden"
+        )
+    }
+
+    func test_discoverImageModels_ignoresManifestWhenComponentMissing() throws {
+        let packageURL = try createDiffusionPackage(omitFile: "vae/diffusion_pytorch_model.safetensors")
+
+        let imageModels = service.discoverImageModels()
+
+        XCTAssertNil(
+            imageModels.first {
+                $0.directoryURL.standardizedFileURL.path == packageURL.standardizedFileURL.path
+            },
+            "Readiness manifests are atomic: every listed component must exist"
+        )
+    }
+
+    func test_discoverImageModels_surfacesCompletePackageAsSingleEntry() throws {
+        let packageURL = try createDiffusionPackage(named: "ready-diffusion-\(UUID().uuidString)")
+
+        let imageModels = service.discoverImageModels()
+        let match = imageModels.first {
+            $0.directoryURL.standardizedFileURL.path == packageURL.standardizedFileURL.path
+        }
+
+        XCTAssertNotNil(match)
+        XCTAssertEqual(match?.format, .mlxDiffusion)
+        XCTAssertEqual(match?.huggingFaceRepoID, match?.id)
+        XCTAssertEqual(
+            imageModels.filter {
+                $0.directoryURL.standardizedFileURL.path == packageURL.standardizedFileURL.path
+            }.count,
+            1,
+            "A multi-component package should appear as one logical model"
         )
     }
 


### PR DESCRIPTION
Closes #988

## Summary
- adds a narrow local package readiness manifest for completed diffusion packages
- treats diffusers component sets as one downloadable package with aggregate progress and atomic finalization
- discovers complete image packages as single entries while keeping GGUF single-file behavior unchanged

## Tests
- scripts/test.sh --filter BaseChatInferenceTests --filter BaseChatUIModelManagementTests --disable-default-traits --skip-update
- scripts/test.sh --filter BaseChatHuggingFaceTests --traits HuggingFace --disable-default-traits --skip-update
