### PR TITLE
feat: add structured output strategy routing

### DIFF
--- a/Sources/BaseChatBackends/FoundationBackend.swift
+++ b/Sources/BaseChatBackends/FoundationBackend.swift
@@ -138,7 +138,8 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
         // Whole-call emission only — Apple's GuidedGeneration streams the
         // partially-decoded structure but we do not surface name/argument
         // deltas as separate events (parity with MLXBackend's inline parser).
-        streamsToolCallArguments: false
+        streamsToolCallArguments: false,
+        supportsGuidedStructuredOutput: true
     )
 
     // MARK: - Private

--- a/Sources/BaseChatInference/Models/StructuredOutputStrategy.swift
+++ b/Sources/BaseChatInference/Models/StructuredOutputStrategy.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+/// Backend-specific mechanism used to request structured model output.
+public enum StructuredOutputStrategy: Sendable, Equatable {
+    /// GBNF grammar string for sampler-level constrained decoding.
+    case gbnf(String)
+    /// Foundation guided-generation target type.
+    case guided(any Decodable.Type)
+    /// JSON Schema document serialized as a string.
+    case jsonSchema(String)
+    /// Prompt-level JSON instruction fallback.
+    case jsonPrompting
+
+    public static func == (lhs: StructuredOutputStrategy, rhs: StructuredOutputStrategy) -> Bool {
+        switch (lhs, rhs) {
+        case (.gbnf(let lhsGrammar), .gbnf(let rhsGrammar)):
+            lhsGrammar == rhsGrammar
+        case (.guided(let lhsType), .guided(let rhsType)):
+            ObjectIdentifier(lhsType) == ObjectIdentifier(rhsType)
+        case (.jsonSchema(let lhsSchema), .jsonSchema(let rhsSchema)):
+            lhsSchema == rhsSchema
+        case (.jsonPrompting, .jsonPrompting):
+            true
+        default:
+            false
+        }
+    }
+}
+
+/// Payload a caller wants a backend to produce in structured form.
+public struct StructuredOutputTarget: Sendable, Equatable {
+    public var gbnfGrammar: String?
+    public var guidedType: (any Decodable.Type)?
+    public var jsonSchema: String?
+
+    public init(
+        gbnfGrammar: String? = nil,
+        guidedType: (any Decodable.Type)? = nil,
+        jsonSchema: String? = nil
+    ) {
+        self.gbnfGrammar = gbnfGrammar
+        self.guidedType = guidedType
+        self.jsonSchema = jsonSchema
+    }
+
+    public init(
+        gbnfGrammar: String? = nil,
+        guidedType: (any Decodable.Type)? = nil,
+        jsonSchema: JSONSchemaValue,
+        encoder: JSONEncoder = JSONEncoder()
+    ) throws {
+        self.gbnfGrammar = gbnfGrammar
+        self.guidedType = guidedType
+        self.jsonSchema = try Self.encodeSchema(jsonSchema, encoder: encoder)
+    }
+
+    public static func guided<T: Decodable>(
+        _ type: T.Type,
+        jsonSchema: String? = nil,
+        gbnfGrammar: String? = nil
+    ) -> StructuredOutputTarget {
+        StructuredOutputTarget(gbnfGrammar: gbnfGrammar, guidedType: type, jsonSchema: jsonSchema)
+    }
+
+    public static func jsonSchema(
+        _ schema: JSONSchemaValue,
+        gbnfGrammar: String? = nil,
+        encoder: JSONEncoder = JSONEncoder()
+    ) throws -> StructuredOutputTarget {
+        try StructuredOutputTarget(gbnfGrammar: gbnfGrammar, jsonSchema: schema, encoder: encoder)
+    }
+
+    private static func encodeSchema(_ schema: JSONSchemaValue, encoder: JSONEncoder) throws -> String {
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(schema)
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    public static func == (lhs: StructuredOutputTarget, rhs: StructuredOutputTarget) -> Bool {
+        lhs.gbnfGrammar == rhs.gbnfGrammar
+        && lhs.jsonSchema == rhs.jsonSchema
+        && lhs.guidedType.map(ObjectIdentifier.init) == rhs.guidedType.map(ObjectIdentifier.init)
+    }
+}
+
+/// Best structured-output mechanism a backend capability profile can advertise.
+public enum StructuredOutputSupport: String, CaseIterable, Sendable, Codable, Equatable {
+    case grammarConstrainedSampling
+    case guidedGeneration
+    case jsonSchema
+    case jsonPrompting
+}
+
+/// Chooses the strongest structured-output strategy supported by a backend.
+public enum StructuredOutputRouter {
+    public static func selectStrategy(
+        capabilities: BackendCapabilities,
+        target: StructuredOutputTarget
+    ) -> StructuredOutputStrategy {
+        if capabilities.supportsGrammarConstrainedSampling,
+           let grammar = target.gbnfGrammar,
+           !grammar.isEmpty {
+            return .gbnf(grammar)
+        }
+
+        if capabilities.supportsGuidedStructuredOutput,
+           let type = target.guidedType {
+            return .guided(type)
+        }
+
+        if capabilities.supportsStructuredOutput,
+           let schema = target.jsonSchema,
+           !schema.isEmpty {
+            return .jsonSchema(schema)
+        }
+
+        return .jsonPrompting
+    }
+
+    public static func selectStrategy(
+        capabilities: BackendCapabilities,
+        gbnfGrammar: String? = nil,
+        guidedType: (any Decodable.Type)? = nil,
+        jsonSchema: String? = nil
+    ) -> StructuredOutputStrategy {
+        selectStrategy(
+            capabilities: capabilities,
+            target: StructuredOutputTarget(
+                gbnfGrammar: gbnfGrammar,
+                guidedType: guidedType,
+                jsonSchema: jsonSchema
+            )
+        )
+    }
+}

--- a/Sources/BaseChatInference/Protocols/BackendCapabilities.swift
+++ b/Sources/BaseChatInference/Protocols/BackendCapabilities.swift
@@ -135,6 +135,23 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
     /// `false`.
     public let supportsParallelToolCalls: Bool
 
+    /// Whether the backend supports Foundation-style guided structured output.
+    public let supportsGuidedStructuredOutput: Bool
+
+    /// Preferred structured-output mechanism implied by this capability set.
+    public var preferredStructuredOutputSupport: StructuredOutputSupport {
+        if supportsGrammarConstrainedSampling {
+            return .grammarConstrainedSampling
+        }
+        if supportsGuidedStructuredOutput {
+            return .guidedGeneration
+        }
+        if supportsStructuredOutput {
+            return .jsonSchema
+        }
+        return .jsonPrompting
+    }
+
     /// Parameters the UI should present controls for.
     public var visibleParameters: [GenerationParameter] {
         GenerationParameter.allCases.filter { supportedParameters.contains($0) }
@@ -159,7 +176,8 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         supportsThinking: Bool = false,
         supportsVision: Bool = false,
         streamsToolCallArguments: Bool = false,
-        supportsParallelToolCalls: Bool = false
+        supportsParallelToolCalls: Bool = false,
+        supportsGuidedStructuredOutput: Bool = false
     ) {
         self.supportedParameters = supportedParameters
         self.maxContextTokens = maxContextTokens
@@ -180,6 +198,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         self.supportsVision = supportsVision
         self.streamsToolCallArguments = streamsToolCallArguments
         self.supportsParallelToolCalls = supportsParallelToolCalls
+        self.supportsGuidedStructuredOutput = supportsGuidedStructuredOutput
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -202,6 +221,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         case supportsVision
         case streamsToolCallArguments
         case supportsParallelToolCalls
+        case supportsGuidedStructuredOutput
     }
 
     public init(from decoder: Decoder) throws {
@@ -225,6 +245,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         supportsVision = (try c.decodeIfPresent(Bool.self, forKey: .supportsVision)) ?? false
         streamsToolCallArguments = (try c.decodeIfPresent(Bool.self, forKey: .streamsToolCallArguments)) ?? false
         supportsParallelToolCalls = (try c.decodeIfPresent(Bool.self, forKey: .supportsParallelToolCalls)) ?? false
+        supportsGuidedStructuredOutput = (try c.decodeIfPresent(Bool.self, forKey: .supportsGuidedStructuredOutput)) ?? false
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -248,5 +269,6 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         try c.encode(supportsVision, forKey: .supportsVision)
         try c.encode(streamsToolCallArguments, forKey: .streamsToolCallArguments)
         try c.encode(supportsParallelToolCalls, forKey: .supportsParallelToolCalls)
+        try c.encode(supportsGuidedStructuredOutput, forKey: .supportsGuidedStructuredOutput)
     }
 }

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -258,6 +258,13 @@ public struct GenerationConfig: Sendable, Codable {
     /// Defaults to `nil` (no grammar constraint).
     public var grammar: String?
 
+    /// Routed structured-output strategy for this generation request.
+    ///
+    /// Runtime-only hint: callers can use ``StructuredOutputRouter`` to choose a
+    /// strategy from backend capabilities, then pass it through config without
+    /// forcing every backend to understand every representation.
+    public var structuredOutput: StructuredOutputStrategy?
+
     /// Per-request override for the thinking-marker pair the backend should use
     /// to split reasoning tokens from visible output.
     ///
@@ -332,6 +339,7 @@ public struct GenerationConfig: Sendable, Codable {
         thinkingMarkers: ThinkingMarkers? = nil,
         maxToolIterations: Int = 10,
         grammar: String? = nil,
+        structuredOutput: StructuredOutputStrategy? = nil,
         yieldEveryNTokens: Int = 8,
         llamaDRY: LlamaDRYSamplerOptions? = nil,
         llamaXTC: LlamaXTCSamplerOptions? = nil,
@@ -355,6 +363,7 @@ public struct GenerationConfig: Sendable, Codable {
         self.thinkingMarkers = thinkingMarkers
         self.maxToolIterations = max(1, maxToolIterations)
         self.grammar = grammar
+        self.structuredOutput = structuredOutput
         self.yieldEveryNTokens = yieldEveryNTokens
         self.llamaDRY = llamaDRY
         self.llamaXTC = llamaXTC
@@ -387,6 +396,7 @@ public struct GenerationConfig: Sendable, Codable {
         thinkingMarkers: ThinkingMarkers? = nil,
         maxToolIterations: Int = 10,
         grammar: String? = nil,
+        structuredOutput: StructuredOutputStrategy? = nil,
         yieldEveryNTokens: Int = 8,
         requiredCapabilities: Set<GenerationCapabilityRequirement> = []
     ) {
@@ -415,6 +425,7 @@ public struct GenerationConfig: Sendable, Codable {
         self.thinkingMarkers = thinkingMarkers
         self.maxToolIterations = max(1, maxToolIterations)
         self.grammar = grammar
+        self.structuredOutput = structuredOutput
         self.yieldEveryNTokens = yieldEveryNTokens
         self.requiredCapabilities = requiredCapabilities
     }
@@ -462,6 +473,8 @@ public struct GenerationConfig: Sendable, Codable {
         // thinkingMarkers is a per-request runtime hint; it is not persisted.
         thinkingMarkers = nil
         grammar = try c.decodeIfPresent(String.self, forKey: .grammar)
+        // structuredOutput is a per-request runtime hint; it is not persisted.
+        structuredOutput = nil
         // yieldEveryNTokens landed after the original shape; default to 8 when absent.
         yieldEveryNTokens = (try c.decodeIfPresent(Int.self, forKey: .yieldEveryNTokens)) ?? 8
         // minP / repetitionPenalty / seed landed after the original shape; absent

--- a/Sources/BaseChatInference/Services/RouterBackend.swift
+++ b/Sources/BaseChatInference/Services/RouterBackend.swift
@@ -78,6 +78,7 @@ public final class RouterBackend: InferenceBackend, @unchecked Sendable {
         var supportsVision = first.supportsVision
         var streamsToolCallArguments = first.streamsToolCallArguments
         var supportsParallelToolCalls = first.supportsParallelToolCalls
+        var supportsGuidedStructuredOutput = first.supportsGuidedStructuredOutput
 
         for child in children.dropFirst() {
             let c = child.capabilities
@@ -108,6 +109,7 @@ public final class RouterBackend: InferenceBackend, @unchecked Sendable {
             supportsVision = supportsVision || c.supportsVision
             streamsToolCallArguments = streamsToolCallArguments || c.streamsToolCallArguments
             supportsParallelToolCalls = supportsParallelToolCalls || c.supportsParallelToolCalls
+            supportsGuidedStructuredOutput = supportsGuidedStructuredOutput || c.supportsGuidedStructuredOutput
         }
         return BackendCapabilities(
             supportedParameters: supportedParameters,
@@ -128,7 +130,8 @@ public final class RouterBackend: InferenceBackend, @unchecked Sendable {
             supportsThinking: supportsThinking,
             supportsVision: supportsVision,
             streamsToolCallArguments: streamsToolCallArguments,
-            supportsParallelToolCalls: supportsParallelToolCalls
+            supportsParallelToolCalls: supportsParallelToolCalls,
+            supportsGuidedStructuredOutput: supportsGuidedStructuredOutput
         )
     }
 

--- a/Tests/BaseChatBackendsTests/BackendCapabilitiesContractTests.swift
+++ b/Tests/BaseChatBackendsTests/BackendCapabilitiesContractTests.swift
@@ -167,6 +167,15 @@ final class BackendCapabilitiesContractTests: XCTestCase {
     }
 
     @available(iOS 26, macOS 26, *)
+    func test_foundationBackend_supportsGuidedStructuredOutput() {
+        let caps = FoundationBackend().capabilities
+
+        XCTAssertTrue(caps.supportsGuidedStructuredOutput,
+                      "FoundationBackend routes structured generation through FoundationModels GuidedGeneration.")
+        XCTAssertEqual(caps.preferredStructuredOutputSupport, .guidedGeneration)
+    }
+
+    @available(iOS 26, macOS 26, *)
     func test_foundationBackend_doesNotSupportNativeJSONMode() {
         XCTAssertFalse(FoundationBackend().capabilities.supportsNativeJSONMode,
                        "FoundationBackend does not expose a native JSON mode in this version")

--- a/Tests/BaseChatInferenceTests/RouterBackendTests.swift
+++ b/Tests/BaseChatInferenceTests/RouterBackendTests.swift
@@ -286,6 +286,15 @@ final class RouterBackendTests: XCTestCase {
         XCTAssertTrue(router.capabilities.supportsThinking)
     }
 
+    func test_capabilities_unionsGuidedStructuredOutputFlags() {
+        let guidedOnly = loaded(BackendCapabilities(supportsGuidedStructuredOutput: true))
+        let plain = loaded(minimalCaps())
+        let router = RouterBackend(children: [plain, guidedOnly])
+
+        XCTAssertTrue(router.capabilities.supportsGuidedStructuredOutput)
+        XCTAssertEqual(router.capabilities.preferredStructuredOutputSupport, .guidedGeneration)
+    }
+
     func test_capabilities_takesMaxContext() {
         let small = loaded(minimalCaps(maxContext: 2048))
         let large = loaded(capableCaps(maxContext: 32_000))

--- a/Tests/BaseChatInferenceTests/StructuredOutputRouterTests.swift
+++ b/Tests/BaseChatInferenceTests/StructuredOutputRouterTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import BaseChatInference
+
+final class StructuredOutputRouterTests: XCTestCase {
+    private struct GuidedFixture: Decodable {}
+
+    func test_selectStrategy_prefersGrammarWhenSupported() {
+        let caps = BackendCapabilities(supportsGrammarConstrainedSampling: true)
+        let target = StructuredOutputTarget(
+            gbnfGrammar: #"root ::= "ok""#,
+            guidedType: GuidedFixture.self,
+            jsonSchema: #"{"type":"object"}"#
+        )
+
+        let strategy = StructuredOutputRouter.selectStrategy(capabilities: caps, target: target)
+
+        XCTAssertEqual(strategy, .gbnf(#"root ::= "ok""#))
+    }
+
+    func test_selectStrategy_usesGuidedWhenGrammarUnavailable() {
+        let caps = BackendCapabilities(supportsGuidedStructuredOutput: true)
+        let target = StructuredOutputTarget(
+            guidedType: GuidedFixture.self,
+            jsonSchema: #"{"type":"object"}"#
+        )
+
+        let strategy = StructuredOutputRouter.selectStrategy(capabilities: caps, target: target)
+
+        XCTAssertEqual(strategy, .guided(GuidedFixture.self))
+    }
+
+    func test_selectStrategy_usesJsonSchemaWhenSupported() {
+        let caps = BackendCapabilities(supportsStructuredOutput: true)
+        let strategy = StructuredOutputRouter.selectStrategy(
+            capabilities: caps,
+            jsonSchema: #"{"type":"object","properties":{}}"#
+        )
+
+        XCTAssertEqual(strategy, .jsonSchema(#"{"type":"object","properties":{}}"#))
+    }
+
+    func test_selectStrategy_fallsBackToJsonPrompting() {
+        let caps = BackendCapabilities()
+        let strategy = StructuredOutputRouter.selectStrategy(
+            capabilities: caps,
+            guidedType: GuidedFixture.self,
+            jsonSchema: #"{"type":"object"}"#
+        )
+
+        XCTAssertEqual(strategy, .jsonPrompting)
+    }
+
+    func test_targetEncodesExistingJSONSchemaValue() throws {
+        let target = try StructuredOutputTarget.jsonSchema(.object([
+            "type": .string("object"),
+            "properties": .object([
+                "answer": .object(["type": .string("string")])
+            ])
+        ]))
+
+        XCTAssertEqual(
+            target.jsonSchema,
+            #"{"properties":{"answer":{"type":"string"}},"type":"object"}"#
+        )
+    }
+
+    func test_generationConfigStructuredOutput_isRuntimeOnly() throws {
+        let original = GenerationConfig(structuredOutput: .jsonSchema(#"{"type":"object"}"#))
+
+        let data = try JSONEncoder().encode(original)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: data)
+
+        XCTAssertNil(json["structuredOutput"])
+        XCTAssertNil(decoded.structuredOutput)
+    }
+
+    func test_capabilitiesPreferredStructuredOutputSupport() {
+        XCTAssertEqual(
+            BackendCapabilities(supportsGrammarConstrainedSampling: true).preferredStructuredOutputSupport,
+            .grammarConstrainedSampling
+        )
+        XCTAssertEqual(
+            BackendCapabilities(supportsGuidedStructuredOutput: true).preferredStructuredOutputSupport,
+            .guidedGeneration
+        )
+        XCTAssertEqual(
+            BackendCapabilities(supportsStructuredOutput: true).preferredStructuredOutputSupport,
+            .jsonSchema
+        )
+        XCTAssertEqual(
+            BackendCapabilities().preferredStructuredOutputSupport,
+            .jsonPrompting
+        )
+    }
+}


### PR DESCRIPTION
Closes #108

## Summary
- add StructuredOutputStrategy, StructuredOutputTarget, and StructuredOutputRouter in BaseChatInference
- add runtime-only GenerationConfig.structuredOutput integration
- add guided structured-output capability plus preferredStructuredOutputSupport
- cover routing priority and jsonPrompting fallback with XCTest

## Tests
- scripts/test.sh --filter StructuredOutputRouterTests --disable-default-traits --skip-update

## Notes
- Worktree creation outside the active checkout was blocked in this environment, so the branch was built from origin/main and pushed directly while restoring the shared worktree afterward.
- guided(any Decodable.Type) is runtime-only and not persisted by GenerationConfig because metatypes are not Codable-friendly.