### PR TITLE
fix(mlx): convert Gemma4 MoE fatalError to thrown InferenceError

### DIFF
--- a/Sources/BaseChatBackends/MLX/MLXGenerationDriver.swift
+++ b/Sources/BaseChatBackends/MLX/MLXGenerationDriver.swift
@@ -1,5 +1,6 @@
 #if MLX
 import Foundation
+@preconcurrency import MLX
 import MLXLMCommon
 import os
 import BaseChatInference
@@ -73,11 +74,29 @@ struct MLXGenerationDriver {
         var thinkingTokenCount = 0
         var thinkingLimitReached = false
 
-        let mlxStream = try await container.generate(
-            input: generationInput,
-            cache: cache,
-            parameters: generateConfig
-        )
+        // Wrap `container.generate` in MLX's error handler so that fatal model
+        // errors (e.g. Gemma4 MoE broadcast shape mismatch — issue #802) are
+        // converted from uncatchable `fatalError` calls into thrown Swift errors
+        // that the caller can surface as InferenceError rather than crashing the app.
+        //
+        // MLXError.ErrorCapture is @unchecked Sendable so the @Sendable handler
+        // can write into it; we read back on the same actor after generate() returns.
+        final class MLXErrorCapture: @unchecked Sendable {
+            var message: String?
+        }
+        let capture = MLXErrorCapture()
+        let mlxStream = try await withErrorHandler(
+            { capture.message = capture.message ?? $0 }
+        ) { @MainActor in
+            try await container.generate(
+                input: generationInput,
+                cache: cache,
+                parameters: generateConfig
+            )
+        }
+        if let message = capture.message {
+            throw InferenceError.inferenceFailure(message)
+        }
 
         let yieldEvery = config.yieldEveryNTokens
         var completionTokenCount = 0


### PR DESCRIPTION
## Summary

- Wraps `container.generate()` in MLX's `withErrorHandler` in `MLXGenerationDriver`, converting uncatchable `fatalError` calls from the C++ runtime into thrown `InferenceError.inferenceFailure` errors that the caller can surface gracefully.
- The body closure is annotated `@MainActor` to satisfy Swift 6 region-based isolation — `@MainActor` closures are `Sendable`, so the compiler can safely pass the closure to the non-isolated `withErrorHandler` free function.
- Uses a local `@unchecked Sendable` capture class (`MLXErrorCapture`) so the `@Sendable` error handler closure can write back the message and we read it on the same actor after `generate()` returns.

## Root cause

Gemma4 27B MoE crashes with:
```
[broadcast_shapes] Shapes (20) and (69) cannot be broadcast.
Fatal error: [broadcast_shapes] ... — MLX/ErrorHandler.swift:343
```
`numKvSharedLayers` defaults to `20` in `Gemma4TextConfiguration` when the config key is absent. The value is used in a tensor broadcast that expects it to match the sequence length, causing a shape mismatch for any prompt longer than ~20 tokens.

## Test plan

- [ ] Default CI must pass (`scripts/test.sh --disable-default-traits --skip-update` both invocations)
- [ ] Manually test: load Gemma4 27B MoE in a host app with a tool-calling config, send a multi-token prompt — should surface an error message instead of crashing
- [ ] `swift build --build-tests --traits MLX` to confirm MLX-gated compilation still passes

Closes #802

🤖 Generated with [Claude Code](https://claude.com/claude-code)