### PR TITLE
feat: improve architecture boundaries and capability contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,25 +165,13 @@ jobs:
         # BaseChatUI must not reach the SwiftData adapter layer directly.
         # All persistence access goes through the port protocols in BaseChatRuntime.
         #
-        # Known exceptions (tracked for cleanup):
-        #   - RuntimeConfiguration.swift: bootstrap wiring that references BaseChatBootstrap
-        #     (which owns ModelContainer — can't be in BaseChatRuntime).
-        #   - ChatViewModel*.swift + ModelLoadCoordinator.swift: use APIEndpoint which is
-        #     currently a typealias for BaseChatSchemaV3.APIEndpoint (@Model). These files
-        #     must be updated to use APIEndpointRecord instead — tracked as Phase 2 follow-up.
         run: |
           set -euo pipefail
-          # `+` and `.` are escaped because grep -vE treats them as regex
-          # metacharacters; without escaping, `ChatViewModel+ModelLoading.swift`
-          # parses as `ChatViewModel` + one-or-more `l` + `ModelLoading.swift`,
-          # which never matches the literal filename containing a `+`.
-          KNOWN_EXCEPTIONS='RuntimeConfiguration\.swift|ChatViewModel\.swift|ChatViewModel\+ModelLoading\.swift|ChatViewModel\+SessionManagement\.swift|ModelLoadCoordinator\.swift|ExportButton\.swift'
-          if grep -rn --include='*.swift' 'import BaseChatPersistenceSwiftData' Sources/BaseChatUI/ \
-             | grep -vE "$KNOWN_EXCEPTIONS"; then
+          if grep -rn --include='*.swift' 'import BaseChatPersistenceSwiftData' Sources/BaseChatUI/; then
             echo "::error::BaseChatUI must not import BaseChatPersistenceSwiftData directly."
             exit 1
           fi
-          echo "BaseChatUI -> BaseChatPersistenceSwiftData edge is clean (known exceptions excluded)."
+          echo "BaseChatUI -> BaseChatPersistenceSwiftData edge is clean."
 
       - name: Lint — Macro plugin builds inside the SwiftPM sandbox
         # SwiftPM compiles macro plugins (`BaseChatMacrosPlugin`) inside a

--- a/FUZZING.md
+++ b/FUZZING.md
@@ -18,6 +18,7 @@ On its first real-model smoke run against `qwen3.5:4b` via Ollama, the harness l
 - [Adding a New Detector](#adding-a-new-detector)
 - [Real-Bug Rediscovery Recipes](#real-bug-rediscovery-recipes)
 - [Calibration Corpus](#calibration-corpus)
+- [Regression Positioning](#regression-positioning)
 - [Known Gaps](#known-gaps)
 - [CI tiers](#ci-tiers)
 
@@ -324,6 +325,24 @@ All ten single-turn detectors pass both gates as of [#488](https://github.com/ro
 3. A new detector added to `DetectorRegistry.all` will fail `test_badCorpusCoverage_allDetectorsCovered` until at least one bad record is added for it.
 
 See `Sources/BaseChatTestSupport/FuzzCalibrationCorpus/README.md` for the full schema reference and corpus-group descriptions.
+
+---
+
+## Regression Positioning
+
+The fuzz harness should record the new architecture regressions as fixtures or documented gaps, but it should not become a broader CI gate by default. Keep the PR tier bounded to the existing mock/chaos smoke campaigns; promote any expensive real-backend campaign only after the detector or scenario has a deterministic fixture and an allowlist policy.
+
+Use this map when turning a runtime/backend bug into fuzz coverage:
+
+| Regression class | Fuzz representation | Gate position |
+|---|---|---|
+| Runtime empty/cancel/error finish-state | Prefer session-level fixtures, because these are turn-loop outcomes rather than single `RunRecord` text anomalies. Extend `Resources/session_scripts/rapid-send-cancel.json` or add a sibling script when the bug is reproducible through `SessionScriptRunner`; keep unit tests as the source of truth for exact terminal-event order. | Local/session-script smoke only until a session fixture corpus exists; do not add a required CI gate for it. |
+| Context trimming edge cases | Represent prompt-shape pressure with deterministic mock or scenario fixtures: overlong system prompts, assistant-only histories, latest-user preservation, `maxOutputTokens == nil`, reserve greater than context, and token-counter failure. Random prompt mutators are not a substitute for these boundary fixtures. | Unit/scenario tests first; optional `--backend mock --corpus-subset smoke` fuzz once fixture-backed. |
+| Tool-call streaming order | Use `--tools` plus `tool-call-validity` for structural tool-call findings, and add focused tool-stream records for the ordered event contract `toolCallStart -> toolCallArgumentsDelta -> toolCall`. Whole-call local backends and incremental cloud backends should have separate labeled records so ordering normalization is explicit. | Keep in tool contract tests or calibration fixtures; do not require real cloud fuzz in CI. |
+| Backend capability rejection / unsupported inputs | Treat negative requests as capability fixtures, not stochastic model prompts: unsupported images/tools/JSON/thinking should fail early with a clear error or be explicitly marked unsupported. Add bad records only when a detector can distinguish honest rejection from silent ignore. | Mock/fixture gate only; hardware traits remain opt-in. |
+| Server invalid-request handling | `fuzz-chat` drives `InferenceBackend`, not HTTP routes. Preserve invalid request bodies as server request-validation fixtures or a future server-specific fuzz corpus; link any generated backend finding back to the request validation test that owns the 4xx contract. | No new CI fuzz gate; server validation tests remain the gate. |
+
+When adding a new detector for any row above, add at least one labeled bad record and enough good records to keep the existing calibration thresholds meaningful. When the regression is multi-turn or request-level and cannot fit `RunRecord`, document the fixture gap here rather than forcing it into the single-turn corpus.
 
 ---
 

--- a/Package.swift
+++ b/Package.swift
@@ -189,12 +189,10 @@ let package = Package(
                 .define("HuggingFace", .when(traits: ["HuggingFace"])),
             ]
         ),
-        // UI: SwiftUI views and view models — needs inference, runtime, and persistence.
-        // TODO: decouple APIEndpoint (@Model) out of BaseChatUI into BaseChatRuntime
-        // so the CI lint rule (BaseChatUI must not import BaseChatPersistenceSwiftData) can be enforced.
+        // UI: SwiftUI views and view models — depends on runtime ports, not persistence adapters.
         .target(
             name: "BaseChatUI",
-            dependencies: ["BaseChatRuntime", "BaseChatPersistenceSwiftData", "BaseChatInference"],
+            dependencies: ["BaseChatRuntime", "BaseChatInference"],
             path: "Sources/BaseChatUI",
             swiftSettings: [
                 .define("Ollama", .when(traits: ["Ollama"])),

--- a/README.md
+++ b/README.md
@@ -52,33 +52,38 @@ BCK and AnyLanguageModel occupy adjacent niches. AnyLanguageModel optimizes for 
 
 ## Architecture
 
-BaseChatKit is split into six primary targets plus optional bridge modules:
+BaseChatKit is split into primary targets plus optional bridge modules:
 
 ```
-BaseChatUI  ──────>  BaseChatPersistenceSwiftData  ──────>  BaseChatRuntime  ──────>  BaseChatInference
-(Views,              (SwiftData schema, @Model            (Ports, use cases,         (Protocols, Models,
- ViewModels)          types, container, adapters,          session-list               Services, Inference
-                      BaseChatBootstrap)                   orchestration)             orchestration)
-                                                                                              ↑
-                                              BaseChatMCP ─────────────────────────────────────┤
-                                              (MCP descriptors, client,                        │
-                                               tool bridge)                                    │
-                                                                                               │
-                                              BaseChatBackends ────────────────────────────────┘
-                                              (MLX, llama.cpp,
-                                               Foundation, Cloud)
+BaseChatUI ───────────────────────┐
+(Views, ViewModels)               │
+                                  ├──> BaseChatRuntime ──────> BaseChatInference
+BaseChatUIModelManagement ────────┘    (Ports, use cases,       (Protocols, Models,
+(model + endpoint UI; also             session-list,            Services, Inference
+ depends on BaseChatUI)                 runtime events)          orchestration)
+                                            ▲                          ▲
+                                            │                          │
+BaseChatPersistenceSwiftData ───────────────┘                          │
+(SwiftData schema, @Model types,                                        │
+ container, adapters, BaseChatBootstrap)                                │
+                                                                       │
+BaseChatMCP ───────────────────────────────────────────────────────────┤
+(MCP descriptors, client, tool bridge)                                  │
+                                                                       │
+BaseChatBackends ──────────────────────────────────────────────────────┘
+(MLX, llama.cpp, Foundation, Cloud)
 ```
 
 - **BaseChatInference** — Inference orchestration. Protocols, models, and services for model loading, generation, context windows, prompt assembly, compression, tokenizers, and capability detection. No SwiftData. No ML dependencies. This is the integration point for custom backends and the minimum target for apps that bring their own persistence and UI.
 - **BaseChatMCP** — Model Context Protocol client surface: descriptors, auth/transport types, connection lifecycle (`MCPClient`), and tool bridge (`MCPToolSource`) for registering MCP tools with `ToolRegistry`.
-- **BaseChatRuntime** — Persistence-agnostic ports (`EndpointStore`, `SamplerPresetStore`, `BenchmarkCache`), use cases (`PromptContextPipeline`, `ChatExportService`, `SessionListService`), and session-list orchestration. No SwiftData, no SwiftUI, no Observation — apps that bring their own persistence stop here and supply their own adapters.
+- **BaseChatRuntime** — Persistence-agnostic ports (`EndpointStore`, `SamplerPresetStore`, `BenchmarkCache`), use cases (`PromptContextPipeline`, `ChatExportService`, `SessionListService`), session-list orchestration, and `ConversationEvent` observability for turn state, token usage, and best-effort session-touch failures. No SwiftData, no SwiftUI, no Observation — apps that bring their own persistence stop here and supply their own adapters.
 - **BaseChatPersistenceSwiftData** — SwiftData schema, `@Model` types (`ChatMessage`, `ChatSession`, `SamplerPreset`, `APIEndpoint`, `ModelBenchmarkCache`), `ModelContainerFactory`, adapter implementations of the runtime ports, and the full-stack `BaseChatBootstrap` entry point.
 - **BaseChatBackends** — Concrete inference backend implementations. Depends on `BaseChatInference` (not `BaseChatRuntime` or `BaseChatPersistenceSwiftData`), so backends stay free of SwiftData. Pulls MLX, llama.cpp, and cloud APIs.
-- **BaseChatUI** — SwiftUI views and view models. Depends on `BaseChatRuntime`, `BaseChatPersistenceSwiftData`, and `BaseChatInference`.
+- **BaseChatUI** — SwiftUI views and view models. Depends on `BaseChatRuntime` and `BaseChatInference`; cloud endpoint state crosses the UI boundary as SwiftData-free `APIEndpointRecord` values supplied by an `EndpointStore`.
 - **BaseChatHuggingFace** *(trait: `HuggingFace`, default-on)* — HuggingFace Hub search plus background download / validation services.
 - **BaseChatAnyLanguageModelBridge** *(trait: `AnyLanguageModel`, default-off)* — Thin `InferenceBackend` adapter over HuggingFace's `AnyLanguageModel`.
 - **BaseChatVoice** — Optional speech-recognition / synthesis adapters and voice composer UI. Depends on `BaseChatUI` so hosts can opt in without adding a back-edge into the base chat surface.
-- **BaseChatServer** *(trait: `Server`, default-off)* — OpenAI-compatible HTTP server executable for exposing a selected `BaseChatInference` backend over `/v1/chat/completions`. Server targets are trait-gated; add `--traits Server` to `swift run`/`swift build`/`swift test` commands when working with `BaseChatServer`.
+- **BaseChatServer** *(trait: `Server`, default-off)* — OpenAI-compatible HTTP server executable for exposing a selected `BaseChatInference` backend over `/v1/chat/completions`. It validates unsupported request capabilities before dispatch and returns clear `invalid_request_error` responses with `unsupported_capability` codes. Server targets are trait-gated; add `--traits Server` to `swift run`/`swift build`/`swift test` commands when working with `BaseChatServer`.
 - **`@ToolSchema` macro** *(trait: `Macros`, default-off)* — Synthesises `static var jsonSchema` on `Decodable` tool-argument structs. The macro plugin and its `swift-syntax` dependency (~647 source files) are gated behind the `Macros` trait so default builds skip the swift-syntax compile cost. Add `--traits Macros` to `swift build`/`swift test` invocations that use `@ToolSchema`.
 
 ## Quick Start
@@ -260,7 +265,8 @@ inject a custom transcriber or audio-session coordinator.
 
 ```swift
 import SwiftData
-import BaseChatCore
+import BaseChatRuntime
+import BaseChatPersistenceSwiftData
 import BaseChatInference
 import BaseChatBackends
 import BaseChatUI
@@ -268,13 +274,13 @@ import BaseChatUIModelManagement
 
 @main
 struct MyApp: App {
-    private let runtime: BaseChatRuntime
+    private let runtime: BaseChatBootstrap
     @State private var chatViewModel: ChatViewModel
     @State private var sessionManager: SessionManagerViewModel
     @State private var modelManagement: ModelManagementViewModel
 
     init() {
-        let runtime = try! BaseChatRuntime(
+        let runtime = try! BaseChatBootstrap(
             configuration: BaseChatConfiguration(
                 appName: "My Chat App",
                 bundleIdentifier: "com.example.mychatapp"
@@ -349,40 +355,32 @@ struct ContentView: View {
 
 ### Migrating from `configure(persistence:)`
 
-Pre-runtime BaseChatKit apps wired persistence by reading
-`@Environment(\.modelContext)` from a root view's `.task` or `.onAppear` and
-calling `chatViewModel.configure(persistence: SwiftDataPersistenceProvider(...))`
-once the SwiftData container was attached. The runtime collapses that into a
-single bootstrap call.
+Pre-runtime BaseChatKit apps often wired persistence from a root view's `.task`
+or `.onAppear` and called `chatViewModel.configure(persistence:)` once stores
+were available. A runtime bootstrap collapses that into one value created in
+`App.init()` while keeping BaseChatUI behind runtime ports.
 
 **Before** — late-binding from a view lifecycle:
 
 ```swift
 import SwiftUI
-import SwiftData
-import BaseChatCore
 import BaseChatInference
+import BaseChatRuntime
 import BaseChatUI
 
 @main
 struct LegacyApp: App {
     @State private var chatViewModel = ChatViewModel()
-    let modelContainer: ModelContainer
-
-    init() {
-        modelContainer = try! ModelContainer(for: ChatSessionRecord.self, ChatMessageRecord.self)
-    }
+    private let stores = AppStores.open()
 
     var body: some Scene {
         WindowGroup {
             RootView()
                 .environment(chatViewModel)
                 .task {
-                    let provider = SwiftDataPersistenceProvider(modelContext: modelContainer.mainContext)
-                    chatViewModel.configure(persistence: provider)
+                    chatViewModel.configure(persistence: stores)
                 }
         }
-        .modelContainer(modelContainer)
     }
 }
 ```
@@ -392,18 +390,19 @@ struct LegacyApp: App {
 ```swift
 import SwiftUI
 import SwiftData
-import BaseChatCore
+import BaseChatRuntime
+import BaseChatPersistenceSwiftData
 import BaseChatInference
 import BaseChatUI
 
 @main
 struct ModernApp: App {
-    private let runtime: BaseChatRuntime
+    private let runtime: BaseChatBootstrap
     @State private var chatViewModel: ChatViewModel
     @State private var sessionManager: SessionManagerViewModel
 
     init() {
-        let runtime = try! BaseChatRuntime(
+        let runtime = try! BaseChatBootstrap(
             configuration: BaseChatConfiguration(
                 appName: "My App",
                 bundleIdentifier: "com.example.myapp"
@@ -431,7 +430,7 @@ struct ModernApp: App {
 }
 ```
 
-Both view models must be configured from the runtime. `ChatViewModel.configure(runtime:)` wires the persistence provider used by chat sessions; `SessionManagerViewModel.configure(runtime:)` wires both persistence and diagnostics for the session list. Skipping the session-manager configuration leaves it on a nil-persistence path that fails on first save. See the MinimalExample app for the canonical wiring.
+Both view models must be configured from the runtime. `ChatViewModel.configure(runtime:)` wires chat persistence, endpoint loading, and the shared `ConversationRuntime`; `SessionManagerViewModel.configure(runtime:)` wires persistence and diagnostics for the session list. Skipping the session-manager configuration leaves it on a nil-persistence path that fails on first save. See the MinimalExample app for the canonical wiring.
 
 #### What still works unchanged
 
@@ -472,11 +471,12 @@ The runtime owns only the chat schema; non-chat schemas stay yours.
 
 #### When to keep `configure(persistence:)`
 
-Keep `configure(persistence:)` for adopters that provide a custom
-``ChatPersistenceProvider`` (e.g. an in-memory test fixture, or a non-SwiftData
-backing store). Construct ``ChatViewModel`` and ``SessionManagerViewModel``
-directly and call `configure(persistence:)` — `BaseChatRuntime` is the
-SwiftData-backed bootstrap and does not yet support custom providers.
+Keep `configure(persistence:)` for adopters that provide custom
+`SessionStore` / `MessageStore` implementations (e.g. an in-memory test fixture
+or a non-SwiftData backing store). Construct `ChatViewModel` and
+`SessionManagerViewModel` directly and call `configure(persistence:)`, or wrap
+the stores in your own `ChatRuntimeBootstrap` when you also want runtime
+endpoint and diagnostics wiring.
 
 ## Supported Model Types
 
@@ -505,7 +505,8 @@ SwiftData-backed bootstrap and does not yet support custom providers.
 | Type | Purpose |
 |------|---------|
 | `InferenceService` | Backend orchestrator — selects and delegates to the right backend |
-| `BaseChatRuntime` | Preferred bootstrap surface — installs configuration, builds SwiftData persistence, and holds shared services |
+| `BaseChatBootstrap` | SwiftData-backed bootstrap — installs configuration, builds persistence adapters, and holds shared services |
+| `ConversationRuntime` | Single turn loop for send/regenerate/edit/cancel/branch, with `ConversationEvent` hooks for token usage and recoverable session-touch failures |
 | `BackgroundDownloadManager` | Background model downloads with progress and validation (`BaseChatHuggingFace`) |
 | `ModelStorageService` | Local model file discovery and storage paths |
 | `DeviceCapabilityService` | RAM/chipset queries for model size recommendations |
@@ -531,6 +532,7 @@ SwiftData-backed bootstrap and does not yet support custom providers.
 | `SSEPayloadHandler` | Interprets SSE JSON payloads for cloud API streaming |
 | `ConversationHistoryReceiver` | Passes multi-turn history to cloud backends |
 | `TokenUsageProvider` | Reports token usage from cloud API responses |
+| `EndpointStore` | Storage-neutral CRUD for cloud endpoint `APIEndpointRecord` values |
 | `HuggingFaceServiceProtocol` | Abstraction for HuggingFace Hub operations |
 
 ## Tool Calling
@@ -614,17 +616,21 @@ Recommendations are filtered by `DeviceCapabilityService.recommendedModelSize()`
 
 ## Cloud API Configuration
 
-Cloud endpoints are persisted via SwiftData. Users configure them through `APIConfigurationView`, or you can create them programmatically:
+Cloud endpoints flow through storage-neutral `APIEndpointRecord` values.
+`APIConfigurationView` persists records through the runtime's `EndpointStore`;
+the shipped SwiftData bootstrap converts those records to `APIEndpoint` rows in
+its adapter. You can create records programmatically through the same port:
 
 ```swift
-let endpoint = APIEndpoint(
+let endpoint = APIEndpointRecord(
     name: "My OpenAI",
     provider: .openAI,
     baseURL: "https://api.openai.com",
     modelName: "gpt-4o-mini"
 )
 do {
-    try endpoint.setAPIKey("sk-...")  // Stored in Keychain
+    try KeychainService.store(key: "sk-...", account: endpoint.keychainAccount)
+    try await runtime.endpointStore.insertEndpoint(endpoint)
 } catch {
     // Surface `error.localizedDescription` in your settings UI — it already
     // maps known Keychain statuses (locked device, missing entitlement, etc.)
@@ -634,9 +640,10 @@ do {
 
 ### Migrating from `Bool`-returning Keychain APIs
 
-`KeychainService.store` / `.delete` and `APIEndpoint.setAPIKey` / `.deleteAPIKey`
-used to return `Bool` and virtually no caller checked the result. They now
-throw a typed `KeychainError` so failures can't be silently discarded.
+`KeychainService.store` / `.delete` and the SwiftData `APIEndpoint.setAPIKey` /
+`.deleteAPIKey` helpers used to return `Bool` and virtually no caller checked
+the result. They now throw a typed `KeychainError` so failures can't be silently
+discarded.
 
 ```swift
 // Before

--- a/Sources/BaseChatBackends/BackendVisionCapability.swift
+++ b/Sources/BaseChatBackends/BackendVisionCapability.swift
@@ -1,0 +1,78 @@
+import BaseChatInference
+
+/// Centralized, testable capability gates for image-input support.
+///
+/// The helpers live outside trait-gated backend files so CI can exercise the
+/// declarations with default traits disabled. Returning `true` means the
+/// backend has both a model family known to accept images and an implemented
+/// request/generation path that preserves ``MessagePart/image`` payloads.
+enum BackendVisionCapability {
+    static var llamaSupportsImageInput: Bool { false }
+
+    static func mlxSupportsImageInput(probedCapabilities: ModelCapabilities?) -> Bool {
+        probedCapabilities?.supportsVision ?? false
+    }
+
+    static func openAIChatCompletionsSupportsImageInput(modelName: String) -> Bool {
+        let lowered = modelName.lowercased()
+        if OpenAIChatCompletionsVisionModels.substringTokens.contains(where: lowered.contains) {
+            return true
+        }
+        for prefix in OpenAIChatCompletionsVisionModels.anchoredPrefixes {
+            if matchesAnchoredPrefix(lowered, prefix: prefix) {
+                return true
+            }
+        }
+        return false
+    }
+
+    static func openAIResponsesSupportsImageInput(modelName _: String) -> Bool {
+        false
+    }
+
+    static func claudeMessagesSupportsImageInput(modelName: String) -> Bool {
+        let lowered = modelName.lowercased()
+        if lowered.contains("claude-2") || lowered.contains("claude-instant") {
+            return false
+        }
+        let visionFamilies = [
+            "claude-3", "claude-sonnet-4", "claude-opus-4", "claude-haiku-4",
+            "claude-4", "claude-sonnet-3", "claude-opus-3", "claude-haiku-3",
+        ]
+        return visionFamilies.contains(where: lowered.contains)
+    }
+
+    private static func matchesAnchoredPrefix(_ name: String, prefix: String) -> Bool {
+        let chars = Array(name)
+        let prefixChars = Array(prefix)
+        guard prefixChars.count <= chars.count else { return false }
+
+        var startIndices: [Int] = [0]
+        for (i, c) in chars.enumerated() where c == "/" || c == ":" {
+            startIndices.append(i + 1)
+        }
+        for start in startIndices {
+            guard start + prefixChars.count <= chars.count else { continue }
+            if Array(chars[start..<start + prefixChars.count]) == prefixChars {
+                let after = start + prefixChars.count
+                if after == chars.count || chars[after] == "-" {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+}
+
+private enum OpenAIChatCompletionsVisionModels {
+    static let substringTokens: [String] = [
+        "gpt-4o",
+        "gpt-4-turbo",
+        "gpt-4.1",
+    ]
+
+    static let anchoredPrefixes: [String] = [
+        "o1",
+        "o3",
+    ]
+}

--- a/Sources/BaseChatBackends/ClaudeBackend.swift
+++ b/Sources/BaseChatBackends/ClaudeBackend.swift
@@ -97,7 +97,7 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             // image attachments before we ever build a request body, so an
             // outdated model name surfaces a clear "not vision-capable"
             // error rather than a 400 from Anthropic.
-            supportsVision: Self.isVisionCapableModel(modelName),
+            supportsVision: BackendVisionCapability.claudeMessagesSupportsImageInput(modelName: modelName),
             streamsToolCallArguments: true,
             supportsParallelToolCalls: true
         )
@@ -108,29 +108,6 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
     /// instead so callers can prompt the user to drop attachments without
     /// burning a round-trip.
     static let maxImagesPerTurn: Int = 5
-
-    /// Returns `true` when `modelName` belongs to a Claude family that
-    /// accepts image content blocks. The matcher is intentionally
-    /// permissive — any name containing a vision-capable family token
-    /// counts, so dated-suffix variants (`claude-3-5-sonnet-20241022`) and
-    /// vendor aliases (`anthropic.claude-sonnet-4`) both light up.
-    static func isVisionCapableModel(_ modelName: String) -> Bool {
-        let lowered = modelName.lowercased()
-        // Explicit denylist: every Claude name that pre-dates vision support.
-        // These have to be rejected even when the broader `claude-*` match
-        // below would otherwise pass.
-        if lowered.contains("claude-2") || lowered.contains("claude-instant") {
-            return false
-        }
-        // Allowlist of vision-capable family tokens. Update when Anthropic
-        // ships a new family; the deny rules above fence off the legacy
-        // text-only models so a wildcard `claude-` match would be unsafe.
-        let visionFamilies = [
-            "claude-3", "claude-sonnet-4", "claude-opus-4", "claude-haiku-4",
-            "claude-4", "claude-sonnet-3", "claude-opus-3", "claude-haiku-3",
-        ]
-        return visionFamilies.contains(where: lowered.contains)
-    }
 
     // MARK: - Tool-Aware Conversation History
 
@@ -220,7 +197,7 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             // driven directly — e.g. the OpenAI-compat server — so keep the
             // belt-and-suspenders check here.)
             let totalImages = CloudImageEncoding.imageCount(in: structured)
-            if totalImages > 0, !Self.isVisionCapableModel(modelName) {
+            if totalImages > 0, !BackendVisionCapability.claudeMessagesSupportsImageInput(modelName: modelName) {
                 throw InferenceError.inferenceFailure(
                     "Model \"\(modelName)\" does not support image input. Switch to a Claude 3, 3.5, 3.7, or 4 family model and retry."
                 )

--- a/Sources/BaseChatBackends/FoundationBackend.swift
+++ b/Sources/BaseChatBackends/FoundationBackend.swift
@@ -149,6 +149,7 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
     private var _isGenerating = false
     private var session: LanguageModelSession?
     private var generationTask: Task<Void, Never>?
+    private var generationSequence: UInt64 = 0
     /// Tracks the system prompt used to create the current session, so we only
     /// recreate when the prompt actually changes.
     private var currentSystemPrompt: String?
@@ -332,13 +333,15 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
             }
         }()
 
-        let activeSession: LanguageModelSession = try withStateLock {
+        let (activeSession, generationID): (LanguageModelSession, UInt64) = try withStateLock {
             guard _isModelLoaded else {
                 throw InferenceError.inferenceFailure("No model loaded")
             }
             guard !_isGenerating else {
                 throw InferenceError.alreadyGenerating
             }
+            generationSequence &+= 1
+            let generationID = generationSequence
             _isGenerating = true
 
             // Reuse the existing session to preserve conversation history.
@@ -360,7 +363,7 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
                 _sessionIsClean = true  // fresh session always starts clean
             }
 
-            return session!
+            return (session!, generationID)
         }
 
         Self.logger.debug("Foundation generate started (tools=\(toolsForRound.count, privacy: .public))")
@@ -376,8 +379,10 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
 
             defer {
                 backend.withStateLock {
-                    backend._isGenerating = false
-                    backend.generationTask = nil
+                    if backend.generationSequence == generationID {
+                        backend._isGenerating = false
+                        backend.generationTask = nil
+                    }
                 }
                 Self.logger.debug("Foundation generate finished")
             }
@@ -620,18 +625,18 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
 
     public func stopGeneration() {
         let task = withStateLock { () -> Task<Void, Never>? in
-            defer { generationTask = nil }
-            return generationTask
-        }
-        task?.cancel()
-
-        // Discard the session after cancellation so the partial response
-        // doesn't corrupt the conversation history for subsequent turns.
-        withStateLock {
+            generationSequence &+= 1
+            let task = generationTask
+            generationTask = nil
+            _isGenerating = false
+            // Discard the session after cancellation so the partial response
+            // doesn't corrupt the conversation history for subsequent turns.
             session = nil
             currentSystemPrompt = nil
             _sessionIsClean = true
+            return task
         }
+        task?.cancel()
     }
 
 }

--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -66,7 +66,7 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
             supportsKVCachePersistence: true,
             supportsGrammarConstrainedSampling: true,
             supportsThinking: true,
-            supportsVision: false
+            supportsVision: BackendVisionCapability.llamaSupportsImageInput
         )
     }
 

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -795,7 +795,7 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 )
                 probedCapabilities = nil
             }
-            let supportsVision = probedCapabilities?.supportsVision ?? false
+            let supportsVision = BackendVisionCapability.mlxSupportsImageInput(probedCapabilities: probedCapabilities)
             let routeThroughVLMFactory = Self.requiresVLMFactory(at: url, precomputedCapabilities: probedCapabilities)
             // Load from a local directory containing config.json + .safetensors.
             // We dispatch directly to either `LLMModelFactory.shared` or

--- a/Sources/BaseChatBackends/OpenAIBackend.swift
+++ b/Sources/BaseChatBackends/OpenAIBackend.swift
@@ -85,67 +85,10 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             // and rejects image attachments before we ever build a request,
             // so a non-vision model surfaces a clear local error rather than
             // a 400 from upstream.
-            supportsVision: Self.isVisionCapableModel(modelName),
+            supportsVision: BackendVisionCapability.openAIChatCompletionsSupportsImageInput(modelName: modelName),
             streamsToolCallArguments: true,
             supportsParallelToolCalls: true
         )
-    }
-
-    /// Returns `true` when `modelName` belongs to an OpenAI family that
-    /// accepts `image_url` content parts on the Chat Completions API.
-    ///
-    /// Two matcher styles are used together:
-    ///
-    /// - **Substring tokens** (`gpt-4o`, `gpt-4-turbo`, `gpt-4.1`) — long
-    ///   enough to be unambiguous on their own, so a `contains` check
-    ///   picks up dated-suffix variants (`gpt-4o-2024-08-06`) and vendor
-    ///   aliases (`openai/gpt-4o`) automatically.
-    /// - **Anchored prefixes** (`o1`, `o3`) — too short to be safe as a
-    ///   substring (a name like `gpt-foo1bar` would accidentally match),
-    ///   so we require the token at the start of the name or
-    ///   immediately after a `/` or `:` separator (vendor namespaces like
-    ///   `openai/o1-mini`), and the token must either end the string or
-    ///   be followed by a `-`.
-    ///
-    /// Allowlist source: OpenAI's "Models with vision" docs as of 2026.
-    /// Update ``OpenAIVisionModels`` when OpenAI ships a new family.
-    static func isVisionCapableModel(_ modelName: String) -> Bool {
-        let lowered = modelName.lowercased()
-        if OpenAIVisionModels.substringTokens.contains(where: lowered.contains) {
-            return true
-        }
-        for prefix in OpenAIVisionModels.anchoredPrefixes {
-            if matchesAnchoredPrefix(lowered, prefix: prefix) {
-                return true
-            }
-        }
-        return false
-    }
-
-    /// Returns `true` when `prefix` appears at the start of `name` or
-    /// immediately after a `/` or `:` separator, and is followed either by
-    /// the end of the string or by a `-`. Used by ``isVisionCapableModel``
-    /// for short tokens (`o1`, `o3`) where a bare substring match would
-    /// produce false positives.
-    static func matchesAnchoredPrefix(_ name: String, prefix: String) -> Bool {
-        let chars = Array(name)
-        let prefixChars = Array(prefix)
-        guard prefixChars.count <= chars.count else { return false }
-        // Walk every plausible start position: index 0 or right after a `/`/`:`.
-        var startIndices: [Int] = [0]
-        for (i, c) in chars.enumerated() where c == "/" || c == ":" {
-            startIndices.append(i + 1)
-        }
-        for start in startIndices {
-            guard start + prefixChars.count <= chars.count else { continue }
-            if Array(chars[start..<start + prefixChars.count]) == prefixChars {
-                let after = start + prefixChars.count
-                if after == chars.count || chars[after] == "-" {
-                    return true
-                }
-            }
-        }
-        return false
     }
 
     // MARK: - Structured History
@@ -241,7 +184,7 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             // the backend may be driven directly (e.g. the OpenAI-compat
             // server, or callers wiring their own pipeline), so keep the
             // belt-and-suspenders check here.
-            if !Self.isVisionCapableModel(modelName) {
+            if !BackendVisionCapability.openAIChatCompletionsSupportsImageInput(modelName: modelName) {
                 throw InferenceError.inferenceFailure(
                     "Model \"\(modelName)\" does not support image input. Switch to a vision-capable OpenAI model (gpt-4o, gpt-4o-mini, gpt-4-turbo, gpt-4.1, o1, o3) and retry."
                 )
@@ -834,38 +777,4 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
 
 }
 
-/// Allowlist of OpenAI model-name family tokens that accept `image_url`
-/// content parts on the Chat Completions API.
-///
-/// Lives next to ``OpenAIBackend`` so the matcher stays a one-line
-/// substring check. Adding a new token here is the single edit required
-/// when OpenAI ships a new vision-capable family — the dated-suffix
-/// variants (e.g. `gpt-4o-2024-08-06`) and vendor aliases (e.g.
-/// `openai/gpt-4o`) match automatically because the classifier uses
-/// substring containment.
-///
-/// Kept here (rather than as a public type) because it is an
-/// implementation detail of one backend's capability gating; promoting it
-/// would invite host apps to take a dependency on a list that needs to
-/// move whenever OpenAI updates their model lineup.
-enum OpenAIVisionModels {
-    /// Tokens long enough to be safe as substring matches. A name like
-    /// `gpt-4o-2024-08-06` or `openai/gpt-4o-mini` lights these up.
-    /// Tokens are lowercase; the classifier lowercases its input first.
-    static let substringTokens: [String] = [
-        "gpt-4o",       // gpt-4o, gpt-4o-mini, gpt-4o-2024-* — full vision family
-        "gpt-4-turbo",  // gpt-4-turbo, gpt-4-turbo-2024-* — original vision turbo
-        "gpt-4.1",      // gpt-4.1 family — vision-capable per the 2025 refresh
-    ]
-
-    /// Tokens that are too short for a bare `contains` check (a name like
-    /// `gpt-foo1bar` would otherwise accidentally match `o1`). Matched via
-    /// ``OpenAIBackend/matchesAnchoredPrefix(_:prefix:)`` which requires
-    /// the token at a name boundary (start or after `/` / `:`) and either
-    /// ending the string or followed by a `-`.
-    static let anchoredPrefixes: [String] = [
-        "o1",           // o1, o1-preview, o1-mini-* — reasoning family with vision
-        "o3",           // o3, o3-mini-* — newer reasoning family with vision
-    ]
-}
 #endif

--- a/Sources/BaseChatBackends/OpenAIResponsesBackend.swift
+++ b/Sources/BaseChatBackends/OpenAIResponsesBackend.swift
@@ -111,6 +111,9 @@ public final class OpenAIResponsesBackend: SSECloudBackend, TokenUsageProvider, 
             supportsStreaming: true,
             isRemote: true,
             supportsThinking: true,
+            // Responses API image input stays disabled until this backend encodes
+            // MessagePart.image as input_image content items.
+            supportsVision: BackendVisionCapability.openAIResponsesSupportsImageInput(modelName: modelName),
             streamsToolCallArguments: true,
             supportsParallelToolCalls: true
         )

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -219,7 +219,8 @@ public struct GenerationConfig: Sendable, Codable {
     /// - `0` — **disable thinking entirely.** On supporting backends (Ollama
     ///   with thinking-capable models, MLX/Llama with reasoning GGUFs), this
     ///   instructs the model to skip the reasoning phase and emit visible
-    ///   output directly. On non-thinking models this is a no-op.
+    ///   output directly. On non-thinking models this is a no-op after
+    ///   `GenerationQueue` emits an explicit unsupported-thinking warning.
     /// - `N > 0` — cap thinking tokens at `N`; additional reasoning tokens are
     ///   dropped. Visible output is still produced.
     ///
@@ -277,10 +278,10 @@ public struct GenerationConfig: Sendable, Codable {
     ///   when the caller knows better (e.g. a fine-tune that ships an empty
     ///   chat template but still emits `<think>` blocks at runtime).
     ///
-    /// Backends without thinking support (`BackendCapabilities.supportsThinking == false`)
-    /// silently ignore this field. There is no longer a hardcoded fallback to
-    /// `.qwen3` — if neither auto-detection nor the caller surfaces markers,
-    /// the parser stays off.
+    /// `GenerationQueue` emits an explicit warning when callers pass markers
+    /// to a backend with `BackendCapabilities.supportsThinking == false`.
+    /// There is no longer a hardcoded fallback to `.qwen3` — if neither
+    /// auto-detection nor the caller surfaces markers, the parser stays off.
     public var thinkingMarkers: ThinkingMarkers?
 
     /// Maximum number of tool-call iterations permitted inside a single

--- a/Sources/BaseChatInference/Services/GenerationQueue.swift
+++ b/Sources/BaseChatInference/Services/GenerationQueue.swift
@@ -85,6 +85,15 @@ final class GenerationQueue {
     /// its registry is never invoked. Tests must reset this in `tearDown`.
     nonisolated(unsafe) static var toolsUnsupportedWarningHook: (@Sendable (String, String) -> Void)?
 
+    /// Test-only hook invoked alongside `Log.inference.warning` when a request
+    /// passes thinking-only hints to a backend whose capabilities report
+    /// `supportsThinking == false`. Receives `(backendTypeName, message)`.
+    ///
+    /// Unsupported thinking hints are not fatal because older callers may set
+    /// a default budget globally, but they must never be silently ignored.
+    /// Tests must reset this in `tearDown` to avoid cross-test leakage.
+    nonisolated(unsafe) static var thinkingUnsupportedWarningHook: (@Sendable (String, String) -> Void)?
+
     /// Test-only hook invoked alongside `Log.inference.info` for each tool
     /// dispatch lifecycle log line (`tool_dispatch_started` /
     /// `tool_dispatch_completed`). Receives `(eventName, fields)` where
@@ -221,6 +230,8 @@ final class GenerationQueue {
         )
         config.maxThinkingTokens = maxThinkingTokens
 
+        Self.warnIfThinkingUnsupported(backend: backend, config: config)
+
         return try dispatchToBackend(
             backend: backend,
             messages: messages,
@@ -268,6 +279,8 @@ final class GenerationQueue {
             Self.jsonModeUnsupportedWarningHook?(backendType, message)
         }
 
+        Self.warnIfThinkingUnsupported(backend: backend, config: config)
+
         return try dispatchToBackend(
             backend: backend,
             messages: messages,
@@ -277,6 +290,28 @@ final class GenerationQueue {
     }
 
     // MARK: - Backend dispatch (Private)
+
+    private static func warnIfThinkingUnsupported(
+        backend: InferenceBackend,
+        config: GenerationConfig
+    ) {
+        guard !backend.capabilities.supportsThinking else { return }
+
+        var requestedHints: [String] = []
+        if config.maxThinkingTokens != nil {
+            requestedHints.append("maxThinkingTokens")
+        }
+        if config.thinkingMarkers != nil {
+            requestedHints.append("thinkingMarkers")
+        }
+        guard !requestedHints.isEmpty else { return }
+
+        let backendType = String(describing: type(of: backend))
+        let hintList = requestedHints.joined(separator: ", ")
+        let message = "GenerationQueue: thinking hint(s) \(hintList) requested but \(backendType) reports capabilities.supportsThinking == false; the backend may ignore these hints. Check `backend.capabilities.supportsThinking` before setting thinking budgets or markers."
+        Log.inference.warning("\(message, privacy: .public)")
+        Self.thinkingUnsupportedWarningHook?(backendType, message)
+    }
 
     /// Common dispatch path shared by ``generate(structuredMessages:...)``
     /// and ``generateWithConfig(structuredMessages:...)``.
@@ -586,6 +621,8 @@ final class GenerationQueue {
         )
         config.maxThinkingTokens = maxThinkingTokens
         config.grammar = grammar
+
+        Self.warnIfThinkingUnsupported(backend: backend, config: config)
 
         let request = QueuedRequest(
             token: token,

--- a/Sources/BaseChatPersistenceSwiftData/BaseChatBootstrap.swift
+++ b/Sources/BaseChatPersistenceSwiftData/BaseChatBootstrap.swift
@@ -246,3 +246,10 @@ public final class BaseChatBootstrap {
         return KeychainService.sweep(validAccounts: validAccounts)
     }
 }
+
+extension BaseChatBootstrap: ChatRuntimeBootstrap {
+    public var persistenceStores: any SessionStore & MessageStore { persistence }
+    public var apiEndpointStore: any EndpointStore { endpointStore }
+    public var diagnosticsService: DiagnosticsService { diagnostics }
+    public var imageGenerationRuntime: ImageGenerationRuntime? { imageRuntime }
+}

--- a/Sources/BaseChatPersistenceSwiftData/Services/ConversationExporter.swift
+++ b/Sources/BaseChatPersistenceSwiftData/Services/ConversationExporter.swift
@@ -1,90 +1,14 @@
 import Foundation
-import UniformTypeIdentifiers
 import BaseChatInference
 import BaseChatRuntime
 
-/// A reference to a file written to disk that is suitable for sharing via
-/// SwiftUI's `ShareLink`.
-///
-/// `ShareLink` accepts `URL`, but a bare URL hides the suggested filename and
-/// content type from the share sheet's preview. Bundling them keeps the
-/// preview helpful and lets callers clean up the temp file when sharing
-/// completes.
-public struct ShareableFile: Sendable, Equatable {
-
-    /// On-disk location of the file. Typically inside `FileManager.default.temporaryDirectory`.
-    public let url: URL
-
-    /// Display name shown in the share sheet preview, including extension.
-    public let suggestedFilename: String
-
-    /// UTI used by the share sheet to pick handlers and icons.
-    public let contentType: UTType
-
-    public init(url: URL, suggestedFilename: String, contentType: UTType) {
-        self.url = url
-        self.suggestedFilename = suggestedFilename
-        self.contentType = contentType
-    }
-}
-
-/// Errors surfaced by ``ConversationExporter`` when the export pipeline
-/// trips at a system boundary (filesystem, persistence).
-public enum ConversationExportError: Error, Equatable {
-    case writeFailed(URL, String)
-}
-
-/// Exports a chat session through any ``ConversationExportFormat`` and
-/// returns a ``ShareableFile`` suitable for `ShareLink`.
-///
-/// Two ways to drive it:
-/// - ``export(session:messages:format:directory:)`` — caller already has the
-///   message list. Pure: no persistence dependency.
-/// - ``export(session:format:provider:directory:)`` — the exporter fetches
-///   the linear active path from a ``SwiftDataPersistenceProvider``. Use this
-///   when you have a SwiftData ``ChatSession`` in hand.
-///
-/// Files are written to a unique subdirectory of the system temporary
-/// directory by default; pass `directory:` to override (e.g. for tests or
-/// when targeting a sandboxed app group). The caller owns cleanup.
-public enum ConversationExporter {
-
-    // MARK: - Pure path (no persistence dependency)
-
-    /// Serialises `messages` via `format` and writes the result to disk.
-    public static func export(
-        session: ChatSessionRecord,
-        messages: [ChatMessageRecord],
-        format: ConversationExportFormat,
-        directory: URL? = nil
-    ) throws -> ShareableFile {
-        let data = try format.export(session: session, messages: messages)
-        let filename = sanitisedFilename(for: session, fileExtension: format.fileExtension)
-
-        let dir = try resolveDirectory(directory)
-        let fileURL = dir.appendingPathComponent(filename, isDirectory: false)
-
-        do {
-            try data.write(to: fileURL, options: .atomic)
-        } catch {
-            throw ConversationExportError.writeFailed(fileURL, error.localizedDescription)
-        }
-
-        return ShareableFile(
-            url: fileURL,
-            suggestedFilename: filename,
-            contentType: format.contentType
-        )
-    }
-
-    // MARK: - SwiftData convenience
-
+extension ConversationExporter {
     /// Loads the session's messages via `provider`, then writes the export.
     ///
     /// Uses the SwiftData ``ChatSession`` directly — `provider.fetchMessages`
     /// returns the linear chronological history. Apps modelling branches
-    /// should call ``export(session:messages:format:directory:)`` with the
-    /// active path they have already materialised.
+    /// should call ``BaseChatRuntime/ConversationExporter/export(session:messages:format:directory:)``
+    /// with the active path they have already materialised.
     ///
     /// `@MainActor` because ``MessageStore`` is `@MainActor`-isolated.
     @MainActor
@@ -101,103 +25,5 @@ public enum ConversationExporter {
             format: format,
             directory: directory
         )
-    }
-
-    // MARK: - Helpers
-
-    /// Strips characters that don't survive `FileManager` round-trips on any
-    /// supported platform. Falls back to "chat" when the title is entirely
-    /// whitespace or filtered out. The `fileExtension` is sanitised
-    /// independently — custom ``ConversationExportFormat`` adopters can return
-    /// arbitrary strings, so we never trust the value verbatim in a path
-    /// component.
-    static func sanitisedFilename(for session: ChatSessionRecord, fileExtension: String) -> String {
-        let stem = sanitiseStem(session.title)
-        let ext = sanitiseFileExtension(fileExtension)
-        return "\(stem).\(ext)"
-    }
-
-    /// Maximum stem length, measured in UTF-8 bytes. APFS allows 255 bytes per
-    /// path component; we leave headroom for the dot + extension and to keep
-    /// share-sheet previews readable. A scalar-by-scalar prefix below ensures
-    /// emoji and CJK characters never split mid-sequence.
-    private static let stemUTF8ByteLimit = 200
-
-    static func sanitiseStem(_ raw: String) -> String {
-        // Trim first so whitespace-only input (including \n/\t which would
-        // otherwise be replaced with _) falls back to "chat" cleanly.
-        let trimmedRaw = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmedRaw.isEmpty {
-            return "chat"
-        }
-
-        // Slashes break path components; control characters break some
-        // share-sheet previews; colons break HFS+. Replace everything in
-        // one pass rather than chaining `replacingOccurrences`.
-        let banned: Set<Character> = ["/", "\\", ":", "*", "?", "\"", "<", ">", "|", "\n", "\r", "\t"]
-        let cleaned = trimmedRaw.unicodeScalars
-            .map { scalar -> Character in
-                let ch = Character(scalar)
-                if banned.contains(ch) { return "_" }
-                if scalar.value < 0x20 { return "_" }
-                return ch
-            }
-        var stem = String(cleaned).trimmingCharacters(in: .whitespacesAndNewlines)
-
-        if stem.isEmpty {
-            stem = "chat"
-        }
-
-        // Cap by UTF-8 byte length, not grapheme count — an 80-emoji title is
-        // 320+ bytes and would blow past APFS's 255-byte path-component limit.
-        // Truncate Character-wise so we never split a multi-byte scalar.
-        stem = truncateToUTF8Bytes(stem, limit: stemUTF8ByteLimit)
-        return stem
-    }
-
-    /// Restricts the extension to a conservative ASCII alphanumeric set so a
-    /// custom ``ConversationExportFormat`` can't slip `..`, a leading `.`, or
-    /// a path separator into the filename. Falls back to `"txt"` when the
-    /// caller's extension is empty or entirely outside the allowed set.
-    static func sanitiseFileExtension(_ raw: String) -> String {
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        let allowed = trimmed.unicodeScalars.filter { scalar in
-            (scalar.value >= 0x30 && scalar.value <= 0x39) || // 0-9
-                (scalar.value >= 0x41 && scalar.value <= 0x5A) || // A-Z
-                (scalar.value >= 0x61 && scalar.value <= 0x7A) // a-z
-        }
-        if allowed.isEmpty { return "txt" }
-        // Cap at 10 chars — `jsonl` is the longest built-in; leaving generous
-        // headroom for hypothetical custom formats without inviting abuse.
-        let capped = String(String.UnicodeScalarView(allowed.prefix(10)))
-        return capped
-    }
-
-    private static func truncateToUTF8Bytes(_ input: String, limit: Int) -> String {
-        if input.utf8.count <= limit { return input }
-        var out = ""
-        out.reserveCapacity(limit)
-        var bytes = 0
-        for character in input {
-            let charBytes = character.utf8.count
-            if bytes + charBytes > limit { break }
-            out.append(character)
-            bytes += charBytes
-        }
-        // Trim trailing whitespace introduced by truncation.
-        return out.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private static func resolveDirectory(_ override: URL?) throws -> URL {
-        if let override {
-            try FileManager.default.createDirectory(at: override, withIntermediateDirectories: true)
-            return override
-        }
-        // Each export gets its own temp subdir so two exports of the same
-        // session don't clobber each other before the share sheet finishes.
-        let dir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("BaseChatKit-export-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return dir
     }
 }

--- a/Sources/BaseChatRuntime/Services/ChatRuntimeBootstrap.swift
+++ b/Sources/BaseChatRuntime/Services/ChatRuntimeBootstrap.swift
@@ -1,0 +1,13 @@
+import BaseChatInference
+
+/// Runtime-facing bootstrap contract consumed by UI view models.
+///
+/// Concrete bootstraps can live in persistence-specific targets while the UI
+/// depends only on the runtime ports exposed here.
+@MainActor
+public protocol ChatRuntimeBootstrap: AnyObject {
+    var persistenceStores: any SessionStore & MessageStore { get }
+    var apiEndpointStore: any EndpointStore { get }
+    var diagnosticsService: DiagnosticsService { get }
+    var imageGenerationRuntime: ImageGenerationRuntime? { get }
+}

--- a/Sources/BaseChatRuntime/Services/ConversationEvent.swift
+++ b/Sources/BaseChatRuntime/Services/ConversationEvent.swift
@@ -8,7 +8,7 @@ import BaseChatInference
 // themselves and key off the underlying ``GenerationStream`` directly —
 // they do not consume this event surface.
 //
-// Phase 1.2.5 PR-A ships the full 12-case enum but only emits a subset
+// Phase 1.2.5 PR-A ships the initial event enum but only emits a subset
 // from the send sub-flow:
 //   - `.beforeContextAssembly`, `.contextAssembled` — fire each turn (with
 //     empty slots when no providers are registered)
@@ -21,11 +21,11 @@ import BaseChatInference
 // later PRs as the corresponding behaviour migrates from
 // ``GenerationQueue`` and ``ChatViewModel``.
 //
-// Phase 1.2.5 PR-B adds `.messageRemoved` (the 13th case) and emits it
+// Phase 1.2.5 PR-B adds `.messageRemoved` and emits it
 // from the regenerate sub-flow when the runtime deletes the last assistant
 // message before replacing it.
 //
-// Phase 1.2.5 PR-C adds `.messageUpdated` (the 14th case) and emits it
+// Phase 1.2.5 PR-C adds `.messageUpdated` and emits it
 // from the edit sub-flow when the runtime updates an existing message's
 // content in place.
 
@@ -79,6 +79,12 @@ public enum ConversationEvent: Sendable {
     /// display.
     case tokenEmitted(messageID: ChatMessageRecord.ID, delta: String)
 
+    /// The backend reported token usage for the turn. Fires before the
+    /// terminal stream event when usage is available, including partial-output
+    /// error and cancellation paths. The runtime also copies these counts onto
+    /// the persisted assistant message when one is saved.
+    case tokenUsageRecorded(messageID: ChatMessageRecord.ID, promptTokens: Int, completionTokens: Int)
+
     /// The model began emitting a thinking block. Fires when the first thinking
     /// token arrives. Adapters use this to show a "Thinking…" indicator.
     case thinkingStarted(messageID: ChatMessageRecord.ID)
@@ -107,6 +113,11 @@ public enum ConversationEvent: Sendable {
     /// error UI; the runtime has already cleaned up partial state by the
     /// time this event fires.
     case errorRaised(ConversationError)
+
+    /// Updating the session timestamp failed. This is intentionally distinct
+    /// from ``errorRaised(_:)`` because sidebar recency is best-effort and
+    /// must not fail the user's turn.
+    case sessionTouchFailed(sessionID: UUID)
 
     // MARK: Context pipeline (runtime hook points)
 

--- a/Sources/BaseChatRuntime/Services/ConversationExporter.swift
+++ b/Sources/BaseChatRuntime/Services/ConversationExporter.swift
@@ -1,0 +1,165 @@
+import Foundation
+import UniformTypeIdentifiers
+import BaseChatInference
+
+/// A reference to a file written to disk that is suitable for sharing via
+/// SwiftUI's `ShareLink`.
+///
+/// `ShareLink` accepts `URL`, but a bare URL hides the suggested filename and
+/// content type from the share sheet's preview. Bundling them keeps the
+/// preview helpful and lets callers clean up the temp file when sharing
+/// completes.
+public struct ShareableFile: Sendable, Equatable {
+
+    /// On-disk location of the file. Typically inside `FileManager.default.temporaryDirectory`.
+    public let url: URL
+
+    /// Display name shown in the share sheet preview, including extension.
+    public let suggestedFilename: String
+
+    /// UTI used by the share sheet to pick handlers and icons.
+    public let contentType: UTType
+
+    public init(url: URL, suggestedFilename: String, contentType: UTType) {
+        self.url = url
+        self.suggestedFilename = suggestedFilename
+        self.contentType = contentType
+    }
+}
+
+/// Errors surfaced by ``ConversationExporter`` when the export pipeline
+/// trips at a system boundary (filesystem, persistence).
+public enum ConversationExportError: Error, Equatable {
+    case writeFailed(URL, String)
+}
+
+/// Exports a chat session through any ``ConversationExportFormat`` and
+/// returns a ``ShareableFile`` suitable for `ShareLink`.
+///
+/// Files are written to a unique subdirectory of the system temporary
+/// directory by default; pass `directory:` to override (e.g. for tests or
+/// when targeting a sandboxed app group). The caller owns cleanup.
+public enum ConversationExporter {
+
+    /// Serialises `messages` via `format` and writes the result to disk.
+    public static func export(
+        session: ChatSessionRecord,
+        messages: [ChatMessageRecord],
+        format: ConversationExportFormat,
+        directory: URL? = nil
+    ) throws -> ShareableFile {
+        let data = try format.export(session: session, messages: messages)
+        let filename = sanitisedFilename(for: session, fileExtension: format.fileExtension)
+
+        let dir = try resolveDirectory(directory)
+        let fileURL = dir.appendingPathComponent(filename, isDirectory: false)
+
+        do {
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            throw ConversationExportError.writeFailed(fileURL, error.localizedDescription)
+        }
+
+        return ShareableFile(
+            url: fileURL,
+            suggestedFilename: filename,
+            contentType: format.contentType
+        )
+    }
+
+    /// Strips characters that don't survive `FileManager` round-trips on any
+    /// supported platform. Falls back to "chat" when the title is entirely
+    /// whitespace or filtered out. The `fileExtension` is sanitised
+    /// independently — custom ``ConversationExportFormat`` adopters can return
+    /// arbitrary strings, so we never trust the value verbatim in a path
+    /// component.
+    static func sanitisedFilename(for session: ChatSessionRecord, fileExtension: String) -> String {
+        let stem = sanitiseStem(session.title)
+        let ext = sanitiseFileExtension(fileExtension)
+        return "\(stem).\(ext)"
+    }
+
+    /// Maximum stem length, measured in UTF-8 bytes. APFS allows 255 bytes per
+    /// path component; we leave headroom for the dot + extension and to keep
+    /// share-sheet previews readable. A scalar-by-scalar prefix below ensures
+    /// emoji and CJK characters never split mid-sequence.
+    private static let stemUTF8ByteLimit = 200
+
+    static func sanitiseStem(_ raw: String) -> String {
+        // Trim first so whitespace-only input (including \n/\t which would
+        // otherwise be replaced with _) falls back to "chat" cleanly.
+        let trimmedRaw = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedRaw.isEmpty {
+            return "chat"
+        }
+
+        // Slashes break path components; control characters break some
+        // share-sheet previews; colons break HFS+. Replace everything in
+        // one pass rather than chaining `replacingOccurrences`.
+        let banned: Set<Character> = ["/", "\\", ":", "*", "?", "\"", "<", ">", "|", "\n", "\r", "\t"]
+        let cleaned = trimmedRaw.unicodeScalars
+            .map { scalar -> Character in
+                let ch = Character(scalar)
+                if banned.contains(ch) { return "_" }
+                if scalar.value < 0x20 { return "_" }
+                return ch
+            }
+        var stem = String(cleaned).trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if stem.isEmpty {
+            stem = "chat"
+        }
+
+        // Cap by UTF-8 byte length, not grapheme count — an 80-emoji title is
+        // 320+ bytes and would blow past APFS's 255-byte path-component limit.
+        // Truncate Character-wise so we never split a multi-byte scalar.
+        stem = truncateToUTF8Bytes(stem, limit: stemUTF8ByteLimit)
+        return stem
+    }
+
+    /// Restricts the extension to a conservative ASCII alphanumeric set so a
+    /// custom ``ConversationExportFormat`` can't slip `..`, a leading `.`, or
+    /// a path separator into the filename. Falls back to `"txt"` when the
+    /// caller's extension is empty or entirely outside the allowed set.
+    static func sanitiseFileExtension(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        let allowed = trimmed.unicodeScalars.filter { scalar in
+            (scalar.value >= 0x30 && scalar.value <= 0x39) || // 0-9
+                (scalar.value >= 0x41 && scalar.value <= 0x5A) || // A-Z
+                (scalar.value >= 0x61 && scalar.value <= 0x7A) // a-z
+        }
+        if allowed.isEmpty { return "txt" }
+        // Cap at 10 chars — `jsonl` is the longest built-in; leaving generous
+        // headroom for hypothetical custom formats without inviting abuse.
+        let capped = String(String.UnicodeScalarView(allowed.prefix(10)))
+        return capped
+    }
+
+    private static func truncateToUTF8Bytes(_ input: String, limit: Int) -> String {
+        if input.utf8.count <= limit { return input }
+        var out = ""
+        out.reserveCapacity(limit)
+        var bytes = 0
+        for character in input {
+            let charBytes = character.utf8.count
+            if bytes + charBytes > limit { break }
+            out.append(character)
+            bytes += charBytes
+        }
+        // Trim trailing whitespace introduced by truncation.
+        return out.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func resolveDirectory(_ override: URL?) throws -> URL {
+        if let override {
+            try FileManager.default.createDirectory(at: override, withIntermediateDirectories: true)
+            return override
+        }
+        // Each export gets its own temp subdir so two exports of the same
+        // session don't clobber each other before the share sheet finishes.
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BaseChatKit-export-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+}

--- a/Sources/BaseChatRuntime/Services/ConversationRuntime.swift
+++ b/Sources/BaseChatRuntime/Services/ConversationRuntime.swift
@@ -972,6 +972,7 @@ public final class ConversationRuntime: Sendable {
         var accumulated = ""
         var emptyResponse = true
         var streamFailed: ConversationError?
+        var tokenUsage: (promptTokens: Int, completionTokens: Int)?
 
         var consumer = GenerationStreamConsumer(loopDetectionEnabled: loopDetectionEnabled)
         var batcher = StreamingTokenBatcher(
@@ -1046,10 +1047,8 @@ public final class ConversationRuntime: Sendable {
                         InferenceError.inferenceFailure("Tool-call loop stopped after \(iterations) iterations.")
                     )))
 
-                case .recordUsage:
-                    // Usage events are advisory; adapters that need token counts
-                    // observe InferenceService.lastTokenUsage directly.
-                    break
+                case .recordUsage(let prompt, let completion):
+                    tokenUsage = (prompt, completion)
 
                 case .ignore:
                     break
@@ -1106,10 +1105,20 @@ public final class ConversationRuntime: Sendable {
         // sends do not cross-contaminate prompt/completion counts. Read on
         // the main actor — `InferenceService.lastTokenUsage` is MainActor-
         // isolated.
-        let usage = await readLastTokenUsage()
+        let usage: (promptTokens: Int, completionTokens: Int)?
+        if let tokenUsage {
+            usage = tokenUsage
+        } else {
+            usage = await readLastTokenUsage()
+        }
         if let usage {
             assistantMessage.promptTokens = usage.promptTokens
             assistantMessage.completionTokens = usage.completionTokens
+            emit(.tokenUsageRecorded(
+                messageID: assistantID,
+                promptTokens: usage.promptTokens,
+                completionTokens: usage.completionTokens
+            ))
         }
 
         let reason: FinishReason
@@ -1287,6 +1296,7 @@ public final class ConversationRuntime: Sendable {
             Log.persistence.warning(
                 "ConversationRuntime: touchSession failed: \(error.localizedDescription)"
             )
+            emit(.sessionTouchFailed(sessionID: sessionID))
         }
     }
 

--- a/Sources/BaseChatServer/ChatCompletionsAdapter.swift
+++ b/Sources/BaseChatServer/ChatCompletionsAdapter.swift
@@ -440,6 +440,14 @@ internal struct ChatCompletionErrorEnvelope: Codable, Equatable, Sendable {
 
     internal static func from(_ error: Error) -> ChatCompletionErrorEnvelope {
         if let serverError = error as? ServerError {
+            if case .invalidRequest(let message, let param, let code) = serverError {
+                return ChatCompletionErrorEnvelope(
+                    message: message,
+                    type: "invalid_request_error",
+                    param: param,
+                    code: code
+                )
+            }
             return ChatCompletionErrorEnvelope(message: serverError.description, type: "server_error")
         }
         return ChatCompletionErrorEnvelope(message: String(describing: error), type: "server_error")

--- a/Sources/BaseChatServer/ServerApp.swift
+++ b/Sources/BaseChatServer/ServerApp.swift
@@ -67,7 +67,7 @@ internal struct ServerApp: Sendable {
                 metrics.recordFailure()
                 metrics.recordRequestCompleted()
                 let envelope = ChatCompletionErrorEnvelope.from(error)
-                return errorResponse(envelope.error.message, status: .internalServerError)
+                return jsonResponse(envelope, status: httpStatus(for: error))
             }
         }
 
@@ -85,7 +85,7 @@ internal struct ServerApp: Sendable {
                 metrics.recordFailure()
                 metrics.recordRequestCompleted()
                 let envelope = ChatCompletionErrorEnvelope.from(error)
-                return errorResponse(envelope.error.message, status: .internalServerError)
+                return jsonResponse(envelope, status: httpStatus(for: error))
             }
         }
 
@@ -153,7 +153,7 @@ internal struct ServerApp: Sendable {
         }
         metrics.recordGenerationStarted()
         do {
-            let backend = try await backendProvider.backend(for: ServerBackendRequest(model: request.model))
+            let backend = try await validatedBackend(for: request)
             let response = try await adapter.response(for: request, using: backend)
             await generationGate.signal()
             metrics.recordGenerationCompleted(tokenCount: tokenCount(in: response.contentText))
@@ -166,6 +166,22 @@ internal struct ServerApp: Sendable {
     }
 
     private func streamingChatCompletionResponse(for request: ChatCompletionRequest) async throws -> Response {
+        do {
+            try await generationGate.wait()
+        } catch is CancellationError {
+            return errorResponse("Request was cancelled.", status: .serviceUnavailable)
+        }
+        metrics.recordGenerationStarted()
+
+        let backend: any InferenceBackend
+        do {
+            backend = try await validatedBackend(for: request)
+        } catch {
+            await generationGate.signal()
+            metrics.recordGenerationFailed()
+            throw error
+        }
+
         var headers = HTTPFields()
         headers[.contentType] = "text/event-stream"
         headers[.cacheControl] = "no-cache"
@@ -173,18 +189,8 @@ internal struct ServerApp: Sendable {
         headers[HTTPField.Name("X-Accel-Buffering")!] = "no"
 
         let body = ResponseBody { writer in
-            do {
-                try await generationGate.wait()
-            } catch is CancellationError {
-                return
-            } catch {
-                // AsyncSemaphore.wait() only throws CancellationError; any other error is unexpected — abort the stream.
-                return
-            }
-            metrics.recordGenerationStarted()
             var streamedTokenCount = 0
             do {
-                let backend = try await backendProvider.backend(for: ServerBackendRequest(model: request.model))
                 let chunks = try adapter.chunks(for: request, using: backend)
                 let encoder = JSONEncoder()
                 for try await chunk in chunks {
@@ -204,6 +210,72 @@ internal struct ServerApp: Sendable {
         }
 
         return Response(status: .ok, headers: headers, body: body)
+    }
+
+    private func validatedBackend(for request: ChatCompletionRequest) async throws -> any InferenceBackend {
+        let backend = try await backendProvider.backend(for: ServerBackendRequest(model: request.model))
+        try validateRequestCapabilities(for: request, backend: backend)
+        return backend
+    }
+
+    private func validateRequestCapabilities(for request: ChatCompletionRequest, backend: any InferenceBackend) throws {
+        let capabilities = backend.capabilities
+        let unsupportedCode = "unsupported_capability"
+
+        if request.messages.contains(where: { $0.role == .system || $0.role == .developer }),
+           !capabilities.supportsSystemPrompt {
+            throw ServerError.invalidRequest(
+                message: "This backend does not support system or developer messages; remove those messages or choose a backend with system-prompt support.",
+                param: "messages",
+                code: unsupportedCode
+            )
+        }
+
+        if request.tools?.isEmpty == false, !capabilities.supportsToolCalling {
+            throw ServerError.invalidRequest(
+                message: "This backend does not support tool calling; remove tools or choose a tool-capable backend.",
+                param: "tools",
+                code: unsupportedCode
+            )
+        }
+
+        if let toolChoice = request.toolChoice,
+           toolChoice.requiresToolCalling,
+           !capabilities.supportsToolCalling {
+            throw ServerError.invalidRequest(
+                message: "This backend does not support tool_choice values that require tool calling; remove tool_choice or choose a tool-capable backend.",
+                param: "tool_choice",
+                code: unsupportedCode
+            )
+        }
+
+        switch request.responseFormat?.type {
+        case .jsonObject:
+            if !capabilities.supportsNativeJSONMode {
+                throw ServerError.invalidRequest(
+                    message: "response_format json_object requires a backend that supports native JSON mode.",
+                    param: "response_format",
+                    code: unsupportedCode
+                )
+            }
+        case .jsonSchema:
+            if !capabilities.supportsStructuredOutput {
+                throw ServerError.invalidRequest(
+                    message: "response_format json_schema requires a backend that supports structured output.",
+                    param: "response_format",
+                    code: unsupportedCode
+                )
+            }
+        case .text, .none:
+            break
+        }
+    }
+
+    private func httpStatus(for error: Error) -> HTTPResponse.Status {
+        if case .invalidRequest = error as? ServerError {
+            return .badRequest
+        }
+        return .internalServerError
     }
 
     private func metricsResponse() -> Response {
@@ -233,6 +305,17 @@ internal struct ServerApp: Sendable {
     private func tokenCount(in chunk: ChatCompletionChunk) -> Int {
         chunk.choices.reduce(0) { count, choice in
             count + tokenCount(in: choice.delta.content ?? "")
+        }
+    }
+}
+
+private extension ChatCompletionToolChoice {
+    var requiresToolCalling: Bool {
+        switch self {
+        case .function, .required:
+            return true
+        case .auto, .none:
+            return false
         }
     }
 }

--- a/Sources/BaseChatServer/ServerApp.swift
+++ b/Sources/BaseChatServer/ServerApp.swift
@@ -272,7 +272,7 @@ internal struct ServerApp: Sendable {
     }
 
     private func httpStatus(for error: Error) -> HTTPResponse.Status {
-        if case .invalidRequest = error as? ServerError {
+        if let serverError = error as? ServerError, case .invalidRequest = serverError {
             return .badRequest
         }
         return .internalServerError

--- a/Sources/BaseChatServer/ServerError.swift
+++ b/Sources/BaseChatServer/ServerError.swift
@@ -4,6 +4,7 @@ import Foundation
 internal enum ServerError: Error, Equatable, Sendable, CustomStringConvertible {
     case backendUnavailable(String)
     case invalidConfiguration(String)
+    case invalidRequest(message: String, param: String? = nil, code: String? = nil)
     case notImplemented(String)
 
     internal var description: String {
@@ -11,6 +12,8 @@ internal enum ServerError: Error, Equatable, Sendable, CustomStringConvertible {
         case .backendUnavailable(let message),
              .invalidConfiguration(let message),
              .notImplemented(let message):
+            message
+        case .invalidRequest(let message, _, _):
             message
         }
     }

--- a/Sources/BaseChatUI/BaseChatUI.docc/Articles/BuildingAChatUI.md
+++ b/Sources/BaseChatUI/BaseChatUI.docc/Articles/BuildingAChatUI.md
@@ -12,31 +12,29 @@ Create both view models at the app level and share the same `InferenceService` b
 
 ```swift
 import BaseChatRuntime
-import BaseChatPersistenceSwiftData
 import BaseChatInference
 import BaseChatBackends
 import BaseChatUI
-import SwiftData
 import SwiftUI
 
 @main
 struct MyApp: App {
-    let runtime: BaseChatBootstrap
+    let runtime: any ChatRuntimeBootstrap
+    let inferenceService: InferenceService
     let chatVM: ChatViewModel
     let sessionVM: SessionManagerViewModel
 
     init() {
-        let runtime = try! BaseChatBootstrap(
-            configuration: BaseChatConfiguration(
-                appName: "MyApp",
-                bundleIdentifier: Bundle.main.bundleIdentifier ?? "com.example.myapp"
-            )
-        )
+        let inferenceService = InferenceService()
+        DefaultBackends.register(with: inferenceService)
+
+        // AppRuntime lives in your app composition root. It may wrap the
+        // shipped SwiftData bootstrap or your own SessionStore/MessageStore.
+        let runtime = AppRuntime.make(inferenceService: inferenceService)
         self.runtime = runtime
+        self.inferenceService = inferenceService
 
-        DefaultBackends.register(with: runtime.inferenceService)
-
-        let chatVM = ChatViewModel(inferenceService: runtime.inferenceService)
+        let chatVM = ChatViewModel(inferenceService: inferenceService)
         chatVM.configure(runtime: runtime)
         chatVM.refreshModels()
         self.chatVM = chatVM
@@ -57,7 +55,7 @@ struct MyApp: App {
                 await sessionVM.autoRenameSession(
                     session,
                     firstMessage: firstMessage,
-                    inferenceService: runtime.inferenceService
+                    inferenceService: inferenceService
                 )
             }
         }
@@ -69,7 +67,6 @@ struct MyApp: App {
                 .environment(chatVM)
                 .environment(sessionVM)
         }
-        .modelContainer(runtime.modelContainer)
     }
 }
 ```
@@ -99,7 +96,7 @@ struct RootView: View {
 }
 ```
 
-Both view models share the same runtime-backed ``SwiftDataPersistenceProvider`` instance, so session records created by `SessionManagerViewModel` are immediately visible to `ChatViewModel`. The root view no longer has to late-bind persistence from `modelContext` on first appearance.
+Both view models share the same runtime-backed ``SessionStore`` / ``MessageStore`` ports, so session records created by `SessionManagerViewModel` are immediately visible to `ChatViewModel`. The root view no longer has to late-bind persistence from `modelContext` on first appearance.
 
 ### Switching sessions
 
@@ -160,36 +157,29 @@ Tasks run sequentially off `@MainActor`. Errors surface in ``ChatViewModel/backg
 
 ### Migrating from `configure(persistence:)`
 
-Pre-runtime BaseChatKit apps wired persistence by reading `@Environment(\.modelContext)` from a root view's `.task` and calling `chatViewModel.configure(persistence:)` once the SwiftData container was attached. ``BaseChatBootstrap`` collapses that into a single bootstrap call in `App.init()`.
+Pre-runtime BaseChatKit apps often wired persistence from a root view's `.task` and called `chatViewModel.configure(persistence:)` once stores were available. A ``ChatRuntimeBootstrap`` collapses that into a single bootstrap value in `App.init()` while keeping BaseChatUI behind runtime ports.
 
 **Before** — view-lifecycle late-binding:
 
 ```swift
-import SwiftData
 import SwiftUI
-import BaseChatPersistenceSwiftData
 import BaseChatInference
+import BaseChatRuntime
 import BaseChatUI
 
 @main
 struct LegacyApp: App {
     @State private var chatViewModel = ChatViewModel()
-    let modelContainer: ModelContainer
-
-    init() {
-        modelContainer = try! ModelContainer(for: ChatSessionRecord.self, ChatMessageRecord.self)
-    }
+    private let stores = AppStores.open()
 
     var body: some Scene {
         WindowGroup {
             RootView()
                 .environment(chatViewModel)
                 .task {
-                    let provider = SwiftDataPersistenceProvider(modelContext: modelContainer.mainContext)
-                    chatViewModel.configure(persistence: provider)
+                    chatViewModel.configure(persistence: stores)
                 }
         }
-        .modelContainer(modelContainer)
     }
 }
 ```
@@ -197,29 +187,23 @@ struct LegacyApp: App {
 **After** — runtime-driven bootstrap:
 
 ```swift
-import SwiftData
 import SwiftUI
 import BaseChatRuntime
-import BaseChatPersistenceSwiftData
 import BaseChatInference
 import BaseChatUI
 
 @main
 struct ModernApp: App {
-    private let runtime: BaseChatBootstrap
+    private let runtime: any ChatRuntimeBootstrap
     @State private var chatViewModel: ChatViewModel
     @State private var sessionManager: SessionManagerViewModel
 
     init() {
-        let runtime = try! BaseChatBootstrap(
-            configuration: BaseChatConfiguration(
-                appName: "My App",
-                bundleIdentifier: "com.example.myapp"
-            )
-        )
+        let inferenceService = InferenceService()
+        let runtime = AppRuntime.make(inferenceService: inferenceService)
         self.runtime = runtime
 
-        let chatVM = ChatViewModel(inferenceService: runtime.inferenceService)
+        let chatVM = ChatViewModel(inferenceService: inferenceService)
         chatVM.configure(runtime: runtime)
         _chatViewModel = State(initialValue: chatVM)
 
@@ -234,29 +218,15 @@ struct ModernApp: App {
                 .environment(chatViewModel)
                 .environment(sessionManager)
         }
-        .modelContainer(runtime.modelContainer)
     }
 }
 ```
 
-Both view models must be configured from the runtime: `ChatViewModel.configure(runtime:)` wires persistence for chat sessions, and `SessionManagerViewModel.configure(runtime:)` wires persistence and diagnostics for the session list. Skipping the session-manager configuration leaves it on a nil-persistence path that fails on first save. The MinimalExample app shows the canonical pattern. `@Query` and `@Environment(\.modelContext)` views still work because `runtime.modelContainer` is attached to the scene via the standard `.modelContainer(_:)` modifier. Apps that buffered inbound payloads in `App.init()` for processing once persistence was wired should keep that pattern — the runtime makes persistence available before view rendering, so the buffer can drain immediately on first appearance.
+Both view models must be configured from the runtime: `ChatViewModel.configure(runtime:)` wires persistence for chat sessions, and `SessionManagerViewModel.configure(runtime:)` wires persistence and diagnostics for the session list. Skipping the session-manager configuration leaves it on a nil-persistence path that fails on first save. Apps that buffered inbound payloads in `App.init()` for processing once persistence was wired should keep that pattern — the runtime makes persistence available before view rendering, so the buffer can drain immediately on first appearance.
 
-Apps using a second ``ModelContainer`` for non-chat data should construct it independently and attach it via a separate `.modelContainer(_:)` modifier alongside `runtime.modelContainer`. The runtime only owns the chat schema:
+Attach any persistence-specific scene modifiers from the app or persistence target. BaseChatUI only requires the runtime-port values exposed by ``ChatRuntimeBootstrap``.
 
-```swift
-import SwiftData
-
-var body: some Scene {
-    WindowGroup {
-        RootView()
-            .environment(chatViewModel)
-    }
-    .modelContainer(runtime.modelContainer)
-    .modelContainer(analyticsContainer)
-}
-```
-
-Keep `configure(persistence:)` for adopters that provide custom ``SessionStore`` / ``MessageStore`` impls (e.g. an in-memory test fixture, or a non-SwiftData backing store) — construct ``ChatViewModel`` and ``SessionManagerViewModel`` directly and call `configure(persistence:)`. ``BaseChatBootstrap`` is the SwiftData-backed bootstrap; runtime support for custom stores is tracked separately.
+Keep `configure(persistence:)` for adopters that provide custom ``SessionStore`` / ``MessageStore`` impls (e.g. an in-memory test fixture, or a non-SwiftData backing store) — construct ``ChatViewModel`` and ``SessionManagerViewModel`` directly and call `configure(persistence:)`. The shipped SwiftData bootstrap and custom stores both satisfy the same runtime-port boundary.
 
 ## Next Steps
 

--- a/Sources/BaseChatUI/BaseChatUI.docc/BaseChatUI.md
+++ b/Sources/BaseChatUI/BaseChatUI.docc/BaseChatUI.md
@@ -4,7 +4,7 @@ SwiftUI views and view models for building on-device and cloud-connected chat in
 
 ## Overview
 
-BaseChatUI provides the view layer for BaseChatKit. It depends on ``BaseChatRuntime`` (the persistence-free orchestration target) and, as an interim measure, on ``BaseChatPersistenceSwiftData`` for the `APIEndpoint` `@Model` type — that coupling is scheduled to be removed once the endpoint surface is decoupled from SwiftData. It has no knowledge of specific inference backends. Drop ``ChatView`` into your app and supply a ``ChatViewModel`` to get a fully-featured chat interface: streaming generation, model selection, and session management.
+BaseChatUI provides the view layer for BaseChatKit. It depends on ``BaseChatRuntime`` (the persistence-free orchestration target) and exposes cloud endpoint selection through SwiftData-free `APIEndpointRecord` values. SwiftData `APIEndpoint` rows are converted by the persistence adapters before reaching UI state. It has no knowledge of specific inference backends. Drop ``ChatView`` into your app and supply a ``ChatViewModel`` to get a fully-featured chat interface: streaming generation, model selection, and session management.
 
 `ChatInputBar` automatically exposes image attachments only when the active backend's ``BackendCapabilities/supportsVision`` flag is `true`. If a host routes image-bearing history to a text-only backend anyway, the runtime fails fast rather than silently flattening the images away.
 
@@ -14,30 +14,28 @@ Turn-loop orchestration — send, regenerate, edit, cancel, and branch — lives
 
 ```swift
 import BaseChatRuntime
-import BaseChatPersistenceSwiftData
 import BaseChatInference
 import BaseChatBackends
 import BaseChatUI
-import SwiftData
 import SwiftUI
 
 @main
 struct MyApp: App {
-    let runtime: BaseChatBootstrap
+    let runtime: any ChatRuntimeBootstrap
+    let inferenceService: InferenceService
     let chatVM: ChatViewModel
 
     init() {
-        let runtime = try! BaseChatBootstrap(
-            configuration: BaseChatConfiguration(
-                appName: "MyApp",
-                bundleIdentifier: Bundle.main.bundleIdentifier ?? "com.example.myapp"
-            )
-        )
+        let inferenceService = InferenceService()
+        DefaultBackends.register(with: inferenceService)
+
+        // AppRuntime lives in your app composition root. It may wrap the
+        // shipped SwiftData bootstrap or your own SessionStore/MessageStore.
+        let runtime = AppRuntime.make(inferenceService: inferenceService)
         self.runtime = runtime
+        self.inferenceService = inferenceService
 
-        DefaultBackends.register(with: runtime.inferenceService)
-
-        let chatVM = ChatViewModel(inferenceService: runtime.inferenceService)
+        let chatVM = ChatViewModel(inferenceService: inferenceService)
         chatVM.configure(runtime: runtime)
         chatVM.refreshModels()
 
@@ -56,7 +54,6 @@ struct MyApp: App {
             ContentView()
                 .environment(chatVM)
         }
-        .modelContainer(runtime.modelContainer)
     }
 }
 ```

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+ImageGeneration.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+ImageGeneration.swift
@@ -109,17 +109,15 @@ extension ChatViewModel {
     /// Cancels the existing image-runtime drain task (if any) and starts a
     /// fresh one for `runtime`.
     ///
-    /// Strong `self` capture: the drain task is the long-lived owner of the
-    /// progress dictionary's update path and must not silently drop events
-    /// if the host releases its last `ChatViewModel` reference mid-flight.
-    /// The `@MainActor` ownership model means the view model lives for the
-    /// host's lifetime in practice; per the CLAUDE.md memory note on
-    /// `Task.detached`, weak capture would risk dropping the work.
+    /// Weak capture mirrors the chat-runtime drain: the host owns the view
+    /// model, and the drain task must not keep old test or preview instances
+    /// alive after their bootstrap and SwiftData container tear down.
     private func startImageRuntimeEventDrain(runtime: ImageGenerationRuntime) {
         imageRuntimeEventDrainTask?.cancel()
-        imageRuntimeEventDrainTask = Task { [self] in
+        imageRuntimeEventDrainTask = Task { [weak self] in
             for await event in runtime.events {
                 if Task.isCancelled { return }
+                guard let self else { return }
                 self.handle(imageRuntimeEvent: event)
             }
         }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+ModelLoading.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+ModelLoading.swift
@@ -1,6 +1,5 @@
 import Foundation
 import BaseChatRuntime
-import BaseChatPersistenceSwiftData
 import BaseChatInference
 
 // MARK: - ChatViewModel + Model Loading (facade)
@@ -57,7 +56,7 @@ extension ChatViewModel {
     ///
     /// - Note: Prefer `dispatchSelectedLoad()` for UI-driven loads — it coordinates
     ///   intent and cancels superseded requests.
-    public func loadCloudEndpoint(_ endpoint: APIEndpoint) async {
+    public func loadCloudEndpoint(_ endpoint: APIEndpointRecord) async {
         await loadCoordinator.loadCloudEndpointInternal(endpoint, generation: nil)
     }
 

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+RuntimeAdapter.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+RuntimeAdapter.swift
@@ -88,6 +88,12 @@ extension ChatViewModel {
             // when none exists).
             mutateMessage(id: messageID) { Self.appendVisibleText(delta, into: &$0) }
 
+        case .tokenUsageRecorded(let messageID, let promptTokens, let completionTokens):
+            mutateMessage(id: messageID) {
+                $0.promptTokens = promptTokens
+                $0.completionTokens = completionTokens
+            }
+
         case .streamFinished(let messageID, let reason):
             // Drop terminal events that belong to a previous turn —
             // `switchToSession` cancels the current turn but a NEW turn may
@@ -221,6 +227,7 @@ extension ChatViewModel {
         // MARK: Observational / future cases
 
         case .beforeContextAssembly, .contextAssembled, .afterGeneration,
+             .sessionTouchFailed,
              .compressionTriggered, .toolCallRequested, .toolCallApproved,
              .toolCallCompleted:
             // These are observational or reserved for future sub-flows.

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+SessionManagement.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+SessionManagement.swift
@@ -1,6 +1,5 @@
 import Foundation
 import BaseChatRuntime
-import BaseChatPersistenceSwiftData
 import BaseChatInference
 
 // MARK: - ChatViewModel + Session Management
@@ -57,6 +56,8 @@ extension ChatViewModel {
         backgroundTask = nil
         backgroundTaskError = nil
 
+        await refreshAvailableEndpointsFromStore()
+
         let resolvedEndpoint = selectionState.selectedEndpointID.flatMap { endpointID in
             availableEndpoints.first(where: { $0.id == endpointID })
         }
@@ -110,11 +111,20 @@ extension ChatViewModel {
     /// Replaces the in-memory list of selectable cloud endpoints.
     ///
     /// Clears `selectedEndpoint` when that endpoint is no longer available.
-    public func setAvailableEndpoints(_ endpoints: [APIEndpoint]) {
-        availableEndpoints = endpoints
+    public func setAvailableEndpoints(_ endpoints: [APIEndpointRecord]) {
+        availableEndpoints = endpoints.filter(\.isEnabled)
         if let selected = selectedEndpoint,
            !availableEndpoints.contains(where: { $0.id == selected.id }) {
             selectedEndpoint = nil
+        }
+    }
+
+    func refreshAvailableEndpointsFromStore() async {
+        guard let endpointStore else { return }
+        do {
+            setAvailableEndpoints(try await endpointStore.fetchEndpoints())
+        } catch {
+            Log.persistence.error("Failed to fetch endpoints: \(error)")
         }
     }
 

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Observation
 import BaseChatRuntime
-import BaseChatPersistenceSwiftData
 import BaseChatInference
 
 /// Central view model for the chat interface.
@@ -77,6 +76,8 @@ public final class ChatViewModel {
         set { sessionController.persistence = newValue }
     }
 
+    var endpointStore: (any EndpointStore)?
+
     // MARK: - Session
 
     /// The currently active chat session. Set via `switchToSession(_:)`.
@@ -143,7 +144,7 @@ public final class ChatViewModel {
     }
 
     /// Enabled cloud endpoints available for selection.
-    public internal(set) var availableEndpoints: [APIEndpoint] = []
+    public internal(set) var availableEndpoints: [APIEndpointRecord] = []
 
     /// The model the user has selected in the sidebar.
     ///
@@ -161,7 +162,7 @@ public final class ChatViewModel {
 
     /// The cloud API endpoint the user has selected, or `nil` for local models.
     /// Setting this clears `selectedModel` and vice versa.
-    public var selectedEndpoint: APIEndpoint? {
+    public var selectedEndpoint: APIEndpointRecord? {
         didSet {
             guard !isSynchronizingSelection else { return }
             guard selectedEndpoint != nil, selectedModel != nil else { return }
@@ -572,6 +573,9 @@ public final class ChatViewModel {
     /// Handle to the in-flight ConversationRuntime stream, used to cancel it.
     var activeConversationStreamHandle: ConversationStreamHandle?
 
+    @ObservationIgnored
+    var endpointRefreshTask: Task<Void, Never>?
+
     // MARK: - ImageGenerationRuntime
     //
     // Optional sibling to `conversationRuntime` for the image-generation
@@ -779,6 +783,12 @@ public final class ChatViewModel {
         installRegistryObservation()
     }
 
+    deinit {
+        runtimeEventDrainTask?.cancel()
+        imageRuntimeEventDrainTask?.cancel()
+        endpointRefreshTask?.cancel()
+    }
+
     /// Re-installs an Observation tracker on ``modelRegistry/selectedModel``
     /// so direct writes to the registry (e.g. from the new explicit-init
     /// `ModelSelectionTabView` path) still run the endpoint-clear sync that
@@ -843,6 +853,14 @@ public final class ChatViewModel {
                 inferenceService: inferenceService
             )
             startRuntimeEventDrain()
+        }
+    }
+
+    public func configure(endpointStore: any EndpointStore) {
+        self.endpointStore = endpointStore
+        endpointRefreshTask?.cancel()
+        endpointRefreshTask = Task { [weak self] in
+            await self?.refreshAvailableEndpointsFromStore()
         }
     }
 

--- a/Sources/BaseChatUI/ViewModels/ModelLoadCoordinator.swift
+++ b/Sources/BaseChatUI/ViewModels/ModelLoadCoordinator.swift
@@ -1,6 +1,5 @@
 import Foundation
 import BaseChatRuntime
-import BaseChatPersistenceSwiftData
 import BaseChatInference
 
 // MARK: - LoadIntent
@@ -8,7 +7,7 @@ import BaseChatInference
 /// The two kinds of load request that can be dispatched to the coordinator.
 enum LoadIntent {
     case localModel(ModelInfo)
-    case cloudEndpoint(APIEndpoint)
+    case cloudEndpoint(APIEndpointRecord)
 }
 
 // MARK: - ModelLoadCoordinator
@@ -192,7 +191,7 @@ final class ModelLoadCoordinator {
         }
     }
 
-    func loadCloudEndpointInternal(_ endpoint: APIEndpoint, generation: UInt64?) async {
+    func loadCloudEndpointInternal(_ endpoint: APIEndpointRecord, generation: UInt64?) async {
         guard beginLoadUIState(generation: generation) else { return }
         let bridge = Task { @MainActor [weak self] in
             await self?.observeModelLoadProgress(generation: generation)

--- a/Sources/BaseChatUI/ViewModels/RuntimeConfiguration.swift
+++ b/Sources/BaseChatUI/ViewModels/RuntimeConfiguration.swift
@@ -1,18 +1,18 @@
 import BaseChatRuntime
-import BaseChatPersistenceSwiftData
 
 extension ChatViewModel {
     /// Preferred bootstrap path for apps that assemble shared services through
-    /// ``BaseChatBootstrap``. Wires the persistence stores onto the view
-    /// model.
+    /// a ``ChatRuntimeBootstrap``. Wires the persistence and endpoint stores
+    /// onto the view model.
     ///
     /// The shared ``ConversationRuntime`` is constructor-injected, not wired
     /// here — pass `runtime.conversationRuntime` to ``ChatViewModel/init`` so
     /// the runtime is available before the first observation occurs. Calling
     /// this method late (after construction) cannot retroactively replace the
     /// non-optional runtime stored on the view model.
-    public func configure(runtime: BaseChatBootstrap) {
-        configure(persistence: runtime.persistence)
+    public func configure(runtime: any ChatRuntimeBootstrap) {
+        configure(persistence: runtime.persistenceStores)
+        configure(endpointStore: runtime.apiEndpointStore)
     }
 
     /// Wires the bootstrap's runtimes into this ``ChatViewModel``.
@@ -20,15 +20,14 @@ extension ChatViewModel {
     /// Equivalent to calling `configure(persistence:)` with the bootstrap's
     /// persistence layer and (if image generation is enabled)
     /// `configure(imageRuntime:)` with the bootstrap's
-    /// ``BaseChatBootstrap/imageRuntime``.
+    /// ``ChatRuntimeBootstrap/imageGenerationRuntime``.
     ///
-    /// - Parameter bootstrap: The fully-constructed ``BaseChatBootstrap``
-    ///   instance produced by ``BaseChatBootstrap/init(configuration:inferenceService:imageGenerationService:diagnostics:makeModelContainer:)``
-    ///   or ``BaseChatBootstrap/build(configuration:inferenceService:imageGenerationService:diagnostics:makeModelContainer:)``.
+    /// - Parameter bootstrap: The fully-constructed runtime bootstrap.
     @MainActor
-    public func configure(_ bootstrap: BaseChatBootstrap) {
-        configure(persistence: bootstrap.persistence)
-        if let imageRuntime = bootstrap.imageRuntime {
+    public func configure(_ bootstrap: any ChatRuntimeBootstrap) {
+        configure(persistence: bootstrap.persistenceStores)
+        configure(endpointStore: bootstrap.apiEndpointStore)
+        if let imageRuntime = bootstrap.imageGenerationRuntime {
             configure(imageRuntime: imageRuntime)
         }
     }
@@ -36,14 +35,14 @@ extension ChatViewModel {
 
 extension SessionManagerViewModel {
     /// Preferred bootstrap path for apps that assemble shared services through
-    /// ``BaseChatBootstrap``. Schedules the initial session load so the UI
+    /// a ``ChatRuntimeBootstrap``. Schedules the initial session load so the UI
     /// matches pre-Phase-1.0 behavior. Direct callers of
     /// ``configure(persistence:autoLoad:diagnostics:)`` must opt in explicitly.
-    public func configure(runtime: BaseChatBootstrap) {
+    public func configure(runtime: any ChatRuntimeBootstrap) {
         configure(
-            persistence: runtime.persistence,
+            persistence: runtime.persistenceStores,
             autoLoad: true,
-            diagnostics: runtime.diagnostics
+            diagnostics: runtime.diagnosticsService
         )
     }
 }

--- a/Sources/BaseChatUI/Views/Chat/ExportButton.swift
+++ b/Sources/BaseChatUI/Views/Chat/ExportButton.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import BaseChatRuntime
-import BaseChatPersistenceSwiftData
 import BaseChatInference
 
 /// Drop-in toolbar button that exports the active chat session via a

--- a/TESTING.md
+++ b/TESTING.md
@@ -295,7 +295,7 @@ This matrix maps every major feature area to its current test coverage and ident
 | Sampler presets | SamplerPresetTests | - | - | - | No integration test |
 | System prompt templating | - | ChatViewModelSystemPromptContextTests | - | - | - |
 | Generation settings | GenerationConfigTests | GenerationViewModelTests | - | SettingsUITests | - |
-| Backend capabilities | BackendCapabilitiesTests | - | - | - | - |
+| Backend capabilities | BackendCapabilitiesTests, BackendCapabilityMatrixTests | BackendVisionCapabilityTests | - | - | Claims must match supported tool/vision/JSON behavior |
 | Backend contract | BackendContractTests | - | - | - | - |
 
 ### System & Lifecycle

--- a/Tests/BaseChatBackendsTests/BackendVisionCapabilityTests.swift
+++ b/Tests/BaseChatBackendsTests/BackendVisionCapabilityTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+import BaseChatInference
+@testable import BaseChatBackends
+
+final class BackendVisionCapabilityTests: XCTestCase {
+    func test_llamaVisionGate_staysFalseUntilImageEmbeddingIsImplemented() {
+        XCTAssertFalse(
+            BackendVisionCapability.llamaSupportsImageInput,
+            "LlamaBackend must not advertise vision while the vendored llama.cpp binding lacks an image-embedding path."
+        )
+    }
+
+    func test_mlxVisionGate_followsConfigProbeOnly() {
+        XCTAssertFalse(BackendVisionCapability.mlxSupportsImageInput(probedCapabilities: nil))
+        XCTAssertFalse(
+            BackendVisionCapability.mlxSupportsImageInput(
+                probedCapabilities: ModelCapabilities(supportsVision: false, supportsAudio: false, contextLength: 4096)
+            )
+        )
+        XCTAssertTrue(
+            BackendVisionCapability.mlxSupportsImageInput(
+                probedCapabilities: ModelCapabilities(supportsVision: true, supportsAudio: false, contextLength: 8192)
+            )
+        )
+    }
+
+    func test_openAIChatCompletionsVisionGate_allowsOnlyImplementedVisionFamilies() {
+        let supported = [
+            "gpt-4o-mini",
+            "openai/gpt-4o-2024-08-06",
+            "gpt-4-turbo",
+            "gpt-4.1-2025-04-14",
+            "o1-mini",
+            "openai:o3-mini",
+        ]
+        for model in supported {
+            XCTAssertTrue(
+                BackendVisionCapability.openAIChatCompletionsSupportsImageInput(modelName: model),
+                "expected \(model) to use the implemented Chat Completions image_url path"
+            )
+        }
+
+        let unsupported = [
+            "gpt-3.5-turbo",
+            "gpt-4",
+            "gpt-foo1bar",
+            "foo-o1",
+            "custom/text-only",
+        ]
+        for model in unsupported {
+            XCTAssertFalse(
+                BackendVisionCapability.openAIChatCompletionsSupportsImageInput(modelName: model),
+                "must not advertise vision for ambiguous or text-only OpenAI-compatible model \(model)"
+            )
+        }
+    }
+
+    func test_openAIResponsesVisionGate_staysFalseUntilInputImageEncodingExists() {
+        for model in ["gpt-5", "gpt-4o", "openai/gpt-4.1"] {
+            XCTAssertFalse(
+                BackendVisionCapability.openAIResponsesSupportsImageInput(modelName: model),
+                "Responses backend must stay text-only until it maps MessagePart.image to input_image items."
+            )
+        }
+    }
+
+    func test_claudeVisionGate_rejectsLegacyTextOnlyFamilies() {
+        let supported = [
+            "claude-3-opus-20240229",
+            "claude-3-5-sonnet-20241022",
+            "anthropic.claude-sonnet-4",
+            "claude-opus-4-1",
+        ]
+        for model in supported {
+            XCTAssertTrue(
+                BackendVisionCapability.claudeMessagesSupportsImageInput(modelName: model),
+                "expected \(model) to use the implemented Anthropic image content block path"
+            )
+        }
+
+        let unsupported = [
+            "claude-2.1",
+            "claude-instant-1.2",
+            "claude-v1",
+            "custom/text-only",
+        ]
+        for model in unsupported {
+            XCTAssertFalse(
+                BackendVisionCapability.claudeMessagesSupportsImageInput(modelName: model),
+                "must not advertise vision for legacy/text-only Claude model \(model)"
+            )
+        }
+    }
+}

--- a/Tests/BaseChatBackendsTests/ClaudeImageInputTests.swift
+++ b/Tests/BaseChatBackendsTests/ClaudeImageInputTests.swift
@@ -287,27 +287,8 @@ final class ClaudeImageInputTests: XCTestCase {
             "Claude Instant predates vision support — must not advertise it")
     }
 
-    // MARK: - 7. isVisionCapableModel — direct unit coverage
-
-    func test_isVisionCapableModel_classifierAcceptsKnownFamilies() {
-        XCTAssertTrue(ClaudeBackend.isVisionCapableModel("claude-3-haiku-20240307"))
-        XCTAssertTrue(ClaudeBackend.isVisionCapableModel("claude-3-5-sonnet-20241022"))
-        XCTAssertTrue(ClaudeBackend.isVisionCapableModel("claude-3-7-sonnet-20250219"))
-        XCTAssertTrue(ClaudeBackend.isVisionCapableModel("claude-sonnet-4-20250514"))
-        XCTAssertTrue(ClaudeBackend.isVisionCapableModel("claude-opus-4-1-20250805"))
-        // Vendor-prefixed aliases (Bedrock-style) should still match.
-        XCTAssertTrue(ClaudeBackend.isVisionCapableModel("anthropic.claude-sonnet-4"))
-    }
-
-    func test_isVisionCapableModel_classifierRejectsLegacyFamilies() {
-        XCTAssertFalse(ClaudeBackend.isVisionCapableModel("claude-2"))
-        XCTAssertFalse(ClaudeBackend.isVisionCapableModel("claude-2.1"))
-        XCTAssertFalse(ClaudeBackend.isVisionCapableModel("claude-instant-1"))
-        XCTAssertFalse(ClaudeBackend.isVisionCapableModel("claude-instant-1.2"))
-        // Unknown / future family that doesn't match any allowlisted token
-        // defaults to false — better to surface a clear error than to assume
-        // vision support and 400.
-        XCTAssertFalse(ClaudeBackend.isVisionCapableModel("some-other-model"))
-    }
+    // Direct classifier coverage moved to BackendVisionCapabilityTests
+    // (test_claudeVisionGate_rejectsLegacyTextOnlyFamilies) when the helper
+    // was lifted out of ClaudeBackend into BackendVisionCapability.
 }
 #endif

--- a/Tests/BaseChatBackendsTests/CloudEndpointSelectionIntegrationTests.swift
+++ b/Tests/BaseChatBackendsTests/CloudEndpointSelectionIntegrationTests.swift
@@ -93,7 +93,16 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
         return session
     }
 
-    private func persistEndpoint(_ endpoint: APIEndpoint) throws {
+    private func persistEndpoint(_ record: APIEndpointRecord) throws {
+        let endpoint = APIEndpoint(
+            name: record.name,
+            provider: record.provider,
+            baseURL: record.baseURL,
+            modelName: record.modelName
+        )
+        endpoint.id = record.id
+        endpoint.createdAt = record.createdAt
+        endpoint.isEnabled = record.isEnabled
         context.insert(endpoint)
         try context.save()
     }
@@ -120,7 +129,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
     // MARK: - Select → Load → isModelLoaded
 
     func test_selectedEndpointAndLoad_setsIsModelLoaded() async throws {
-        let endpoint = APIEndpoint(
+        let endpoint = APIEndpointRecord(
             name: "Local Ollama",
             provider: .ollama,
             baseURL: "http://localhost:11434",
@@ -151,7 +160,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
         let uniqueHost = UUID().uuidString + ".invalid"
 
         try await makeSession(title: "Cloud Chat")
-        let endpoint = APIEndpoint(
+        let endpoint = APIEndpointRecord(
             name: "Local LM Studio",
             provider: .lmStudio,
             baseURL: "https://\(uniqueHost):1234",
@@ -212,7 +221,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
 
     func test_modelAndEndpointSelection_areMutuallyExclusive() {
         let localModel = makeLocalModel()
-        let endpoint = APIEndpoint(
+        let endpoint = APIEndpointRecord(
             name: "Cloud Endpoint",
             provider: .ollama,
             baseURL: "http://localhost:11434",
@@ -238,13 +247,13 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
     // MARK: - Session Persistence
 
     func test_sessionRestoresSelectedEndpoint() async throws {
-        let endpointA = APIEndpoint(
+        let endpointA = APIEndpointRecord(
             name: "Endpoint A",
             provider: .ollama,
             baseURL: "http://localhost:11434",
             modelName: "llama3.2"
         )
-        let endpointB = APIEndpoint(
+        let endpointB = APIEndpointRecord(
             name: "Endpoint B",
             provider: .lmStudio,
             baseURL: "http://localhost:1234",
@@ -287,7 +296,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
 
     func test_switchingLocalToCloudAndBack_preservesSessionState() async throws {
         let localModel = makeLocalModel()
-        let endpoint = APIEndpoint(
+        let endpoint = APIEndpointRecord(
             name: "Cloud Endpoint",
             provider: .ollama,
             baseURL: "http://localhost:11434",
@@ -335,7 +344,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
     // MARK: - Error Paths
 
     func test_loadCloudEndpoint_invalidURL_surfacesError() async throws {
-        let invalidEndpoint = APIEndpoint(
+        let invalidEndpoint = APIEndpointRecord(
             name: "Bad URL",
             provider: .custom,
             baseURL: "http://foo\0bar",
@@ -354,7 +363,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
         XCTAssertFalse(vm.isModelLoaded)
 
         // Sabotage: a valid URL should not produce an invalid-URL error.
-        let validEndpoint = APIEndpoint(
+        let validEndpoint = APIEndpointRecord(
             name: "Valid URL",
             provider: .ollama,
             baseURL: "http://localhost:11434",
@@ -371,7 +380,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
         let claudeVM = makeViewModel { _ in
             ConfiguringClaudeCloudBackend(urlSession: Self.makeMockURLSession())
         }
-        let claudeEndpoint = APIEndpoint(
+        let claudeEndpoint = APIEndpointRecord(
             name: "Claude Endpoint",
             provider: .claude,
             baseURL: "https://api.anthropic.com",
@@ -395,7 +404,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
         let ollamaVM = makeViewModel { [cloudSession] _ in
             ConfiguringOpenAICloudBackend(urlSession: cloudSession!)
         }
-        let ollamaEndpoint = APIEndpoint(
+        let ollamaEndpoint = APIEndpointRecord(
             name: "Ollama (no key)",
             provider: .ollama,
             baseURL: "http://localhost:11434",
@@ -415,7 +424,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
             )
         }
         // https:// is required for non-localhost endpoints per endpoint validation.
-        let networkEndpoint = APIEndpoint(
+        let networkEndpoint = APIEndpointRecord(
             name: "Flaky Endpoint",
             provider: .ollama,
             baseURL: "https://\(uniqueHost):11434",
@@ -464,7 +473,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
             let privateVM = makeViewModel { [cloudSession] _ in
                 ConfiguringOpenAICloudBackend(urlSession: cloudSession!)
             }
-            let endpoint = APIEndpoint(
+            let endpoint = APIEndpointRecord(
                 name: "Private",
                 provider: .custom,
                 baseURL: baseURL,
@@ -483,7 +492,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
         let validVM = makeViewModel { [cloudSession] _ in
             ConfiguringOpenAICloudBackend(urlSession: cloudSession!)
         }
-        let validEndpoint = APIEndpoint(
+        let validEndpoint = APIEndpointRecord(
             name: "Valid",
             provider: .ollama,
             baseURL: "http://localhost:11434",
@@ -497,7 +506,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
         let imdsVM = makeViewModel { [cloudSession] _ in
             ConfiguringOpenAICloudBackend(urlSession: cloudSession!)
         }
-        let imdsEndpoint = APIEndpoint(
+        let imdsEndpoint = APIEndpointRecord(
             name: "IMDS",
             provider: .custom,
             baseURL: "https://169.254.169.254/latest/meta-data",
@@ -514,7 +523,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
         let insecureVM = makeViewModel { [cloudSession] _ in
             ConfiguringOpenAICloudBackend(urlSession: cloudSession!)
         }
-        let insecureEndpoint = APIEndpoint(
+        let insecureEndpoint = APIEndpointRecord(
             name: "Insecure",
             provider: .custom,
             baseURL: "http://api.example.com",
@@ -530,7 +539,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
         let httpsVM = makeViewModel { [cloudSession] _ in
             ConfiguringOpenAICloudBackend(urlSession: cloudSession!)
         }
-        let httpsEndpoint = APIEndpoint(
+        let httpsEndpoint = APIEndpointRecord(
             name: "Secure",
             provider: .custom,
             baseURL: "https://api.example.com",

--- a/Tests/BaseChatBackendsTests/FoundationBackendUnitTests.swift
+++ b/Tests/BaseChatBackendsTests/FoundationBackendUnitTests.swift
@@ -246,8 +246,12 @@ final class FoundationBackendUnitTests: XCTestCase {
         )
         backend.stopGeneration()
 
-        // Drain the cancelled stream so the generation task's defer block runs
-        // and clears isGenerating before we attempt a second generate().
+        XCTAssertFalse(
+            backend.isGenerating,
+            "stopGeneration() must synchronously clear isGenerating"
+        )
+
+        // Drain the cancelled stream before we attempt a second generate().
         for try await _ in stream.events {}
 
         XCTAssertTrue(

--- a/Tests/BaseChatBackendsTests/OpenAIBackendImageInputTests.swift
+++ b/Tests/BaseChatBackendsTests/OpenAIBackendImageInputTests.swift
@@ -299,39 +299,9 @@ final class OpenAIBackendImageInputTests: XCTestCase {
             "o1 reasoning family must advertise vision support")
     }
 
-    // MARK: - 7. isVisionCapableModel — direct unit coverage
-
-    func test_isVisionCapableModel_classifierAcceptsKnownFamilies() {
-        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("gpt-4o"))
-        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("gpt-4o-mini"))
-        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("gpt-4o-2024-08-06"))
-        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("gpt-4-turbo"))
-        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("gpt-4-turbo-2024-04-09"))
-        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("gpt-4.1"))
-        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("gpt-4.1-mini"))
-        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("o1"))
-        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("o1-preview"))
-        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("o1-mini"))
-        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("o3"))
-        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("o3-mini"))
-        // Vendor-prefixed aliases (proxy/router-style) should still match.
-        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("openai/gpt-4o"))
-        XCTAssertTrue(OpenAIBackend.isVisionCapableModel("openai/o3-mini"))
-    }
-
-    func test_isVisionCapableModel_classifierRejectsLegacyAndUnrelated() {
-        XCTAssertFalse(OpenAIBackend.isVisionCapableModel("gpt-3.5-turbo"))
-        XCTAssertFalse(OpenAIBackend.isVisionCapableModel("gpt-4"),
-            "Bare gpt-4 (no -turbo, no -o, no -.1 suffix) is not vision-capable")
-        XCTAssertFalse(OpenAIBackend.isVisionCapableModel("text-davinci-003"))
-        XCTAssertFalse(OpenAIBackend.isVisionCapableModel("some-other-model"))
-        // The anchored-prefix matcher must NOT light up on substring
-        // collisions: `o1` appears mid-name here and must not match.
-        XCTAssertFalse(OpenAIBackend.isVisionCapableModel("foo1bar"),
-            "Bare o1 substring inside another name must not match")
-        XCTAssertFalse(OpenAIBackend.isVisionCapableModel("legacy-o1-thing-noprefix"),
-            "o1 surrounded by hyphens but not at a name boundary must not match")
-    }
+    // Direct classifier coverage moved to BackendVisionCapabilityTests
+    // (test_openAIChatCompletionsVisionGate_allowsOnlyImplementedVisionFamilies)
+    // when the helper was lifted out of OpenAIBackend into BackendVisionCapability.
 
     // MARK: - 8. Structured-text-only doesn't promote to array
 

--- a/Tests/BaseChatInferenceTests/BackendCapabilityMatrixTests.swift
+++ b/Tests/BaseChatInferenceTests/BackendCapabilityMatrixTests.swift
@@ -1,0 +1,253 @@
+import XCTest
+import Foundation
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Matrix tests for capability-gated requests at the inference boundary.
+///
+/// These use `MockInferenceBackend` so they stay CI-safe with default traits
+/// disabled while still pinning the shared behavior every backend relies on:
+/// advertised capabilities must either allow the request through or produce an
+/// explicit local signal before an unsupported hint can be silently dropped.
+@MainActor
+final class BackendCapabilityMatrixTests: XCTestCase {
+    private var provider: FakeGenerationContextProvider!
+    private var coordinator: GenerationQueue!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        provider = FakeGenerationContextProvider()
+        coordinator = GenerationQueue()
+        coordinator.provider = provider
+    }
+
+    override func tearDown() async throws {
+        await coordinator?.stopGenerationAndWait()
+        GenerationQueue.jsonModeUnsupportedWarningHook = nil
+        GenerationQueue.toolsUnsupportedWarningHook = nil
+        GenerationQueue.thinkingUnsupportedWarningHook = nil
+        coordinator = nil
+        provider = nil
+        try await super.tearDown()
+    }
+
+    func test_visionCapabilityMatrix_rejectsImagesWhenUnsupportedBeforeBackendGenerate() throws {
+        provider.backend.capabilities = capabilities(supportsVision: false)
+
+        XCTAssertThrowsError(
+            try coordinator.generate(structuredMessages: [imageMessage()])
+        ) { error in
+            guard case InferenceError.inferenceFailure(let message) = error else {
+                XCTFail("expected InferenceError.inferenceFailure, got \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("supportsVision"), message)
+        }
+
+        XCTAssertEqual(provider.backend.generateCallCount, 0,
+                       "unsupported images must fail before backend.generate can flatten or drop them")
+        XCTAssertNil(provider.backend.lastReceivedStructuredHistory,
+                     "unsupported images must not be installed on a text-only backend")
+    }
+
+    func test_visionCapabilityMatrix_forwardsImagesWhenAdvertised() async throws {
+        provider.backend.capabilities = capabilities(supportsVision: true)
+
+        let stream = try coordinator.generate(structuredMessages: [imageMessage()])
+        for try await _ in stream.events {}
+
+        XCTAssertEqual(provider.backend.generateCallCount, 1)
+        let history = try XCTUnwrap(provider.backend.lastReceivedStructuredHistory)
+        XCTAssertTrue(history.contains { message in
+            message.parts.contains { part in
+                if case .image = part { return true }
+                return false
+            }
+        }, "vision-capable backends must receive image parts intact")
+    }
+
+    func test_toolCapabilityMatrix_rejectsToolsWhenUnsupportedBeforeBackendGenerate() throws {
+        provider.backend.capabilities = capabilities(supportsToolCalling: false)
+        let warnings = CapabilityWarningCapture()
+        GenerationQueue.toolsUnsupportedWarningHook = { backendType, message in
+            warnings.record(backendType: backendType, message: message)
+        }
+
+        XCTAssertThrowsError(
+            try coordinator.enqueue(messages: [("user", "use a tool")], tools: [weatherTool()])
+        ) { error in
+            guard case InferenceError.inferenceFailure(let message) = error else {
+                XCTFail("expected InferenceError.inferenceFailure, got \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("does not support tool calling"), message)
+        }
+
+        XCTAssertEqual(provider.backend.generateCallCount, 0,
+                       "unsupported tools must fail before the request reaches the backend")
+        let entry = try XCTUnwrap(warnings.snapshot().first)
+        XCTAssertEqual(entry.backendType, "MockInferenceBackend")
+        XCTAssertTrue(entry.message.contains("supportsToolCalling"), entry.message)
+    }
+
+    func test_toolCapabilityMatrix_forwardsToolsWhenAdvertised() async throws {
+        provider.backend.capabilities = capabilities(supportsToolCalling: true)
+        let warnings = CapabilityWarningCapture()
+        GenerationQueue.toolsUnsupportedWarningHook = { backendType, message in
+            warnings.record(backendType: backendType, message: message)
+        }
+
+        let (_, stream) = try coordinator.enqueue(
+            messages: [("user", "use a tool")],
+            tools: [weatherTool()]
+        )
+        for try await _ in stream.events {}
+
+        XCTAssertTrue(warnings.snapshot().isEmpty)
+        XCTAssertEqual(provider.backend.generateCallCount, 1)
+        XCTAssertEqual(provider.backend.lastConfig?.tools.map(\.name), ["get_weather"])
+    }
+
+    func test_jsonCapabilityMatrix_warnsButForwardsWhenNativeJSONModeUnsupported() async throws {
+        provider.backend.capabilities = capabilities(supportsNativeJSONMode: false)
+        let warnings = CapabilityWarningCapture()
+        GenerationQueue.jsonModeUnsupportedWarningHook = { backendType, message in
+            warnings.record(backendType: backendType, message: message)
+        }
+
+        let stream = try coordinator.generate(messages: [("user", "return json")], jsonMode: true)
+        for try await _ in stream.events {}
+
+        XCTAssertEqual(provider.backend.generateCallCount, 1)
+        XCTAssertTrue(provider.backend.lastConfig?.jsonMode == true)
+        let entry = try XCTUnwrap(warnings.snapshot().first)
+        XCTAssertEqual(entry.backendType, "MockInferenceBackend")
+        XCTAssertTrue(entry.message.contains("supportsNativeJSONMode"), entry.message)
+    }
+
+    func test_jsonCapabilityMatrix_forwardsWithoutWarningWhenNativeJSONModeAdvertised() async throws {
+        provider.backend.capabilities = capabilities(supportsNativeJSONMode: true)
+        let warnings = CapabilityWarningCapture()
+        GenerationQueue.jsonModeUnsupportedWarningHook = { backendType, message in
+            warnings.record(backendType: backendType, message: message)
+        }
+
+        let stream = try coordinator.generate(messages: [("user", "return json")], jsonMode: true)
+        for try await _ in stream.events {}
+
+        XCTAssertTrue(warnings.snapshot().isEmpty)
+        XCTAssertEqual(provider.backend.generateCallCount, 1)
+        XCTAssertTrue(provider.backend.lastConfig?.jsonMode == true)
+    }
+
+    func test_thinkingCapabilityMatrix_warnsButForwardsHintsWhenThinkingUnsupported() async throws {
+        provider.backend.capabilities = capabilities(supportsThinking: false)
+        let warnings = CapabilityWarningCapture()
+        GenerationQueue.thinkingUnsupportedWarningHook = { backendType, message in
+            warnings.record(backendType: backendType, message: message)
+        }
+
+        var config = GenerationConfig(maxOutputTokens: 16)
+        config.maxThinkingTokens = 4
+        config.thinkingMarkers = .qwen3
+        let stream = try coordinator.generateWithConfig(
+            messages: [("user", "think briefly")],
+            systemPrompt: nil,
+            config: config
+        )
+        for try await _ in stream.events {}
+
+        XCTAssertEqual(provider.backend.generateCallCount, 1)
+        XCTAssertEqual(provider.backend.lastConfig?.maxThinkingTokens, 4)
+        XCTAssertEqual(provider.backend.lastConfig?.thinkingMarkers, .qwen3)
+        let entry = try XCTUnwrap(warnings.snapshot().first)
+        XCTAssertEqual(entry.backendType, "MockInferenceBackend")
+        XCTAssertTrue(entry.message.contains("supportsThinking"), entry.message)
+        XCTAssertTrue(entry.message.contains("maxThinkingTokens"), entry.message)
+        XCTAssertTrue(entry.message.contains("thinkingMarkers"), entry.message)
+    }
+
+    func test_thinkingCapabilityMatrix_emitsThinkingEventsOnlyWhenAdvertisedAndProduced() async throws {
+        provider.backend.capabilities = capabilities(supportsThinking: true)
+        provider.backend.thinkingTokensToYield = ["reasoning"]
+        let warnings = CapabilityWarningCapture()
+        GenerationQueue.thinkingUnsupportedWarningHook = { backendType, message in
+            warnings.record(backendType: backendType, message: message)
+        }
+
+        let stream = try coordinator.generate(messages: [("user", "think")], maxThinkingTokens: 8)
+        var sawThinkingToken = false
+        var sawThinkingComplete = false
+        for try await event in stream.events {
+            switch event {
+            case .thinkingToken:
+                sawThinkingToken = true
+            case .thinkingComplete:
+                sawThinkingComplete = true
+            default:
+                break
+            }
+        }
+
+        XCTAssertTrue(warnings.snapshot().isEmpty)
+        XCTAssertTrue(sawThinkingToken, "a backend advertising thinking must surface reasoning tokens when produced")
+        XCTAssertTrue(sawThinkingComplete, "thinking tokens must be closed by thinkingComplete")
+    }
+
+    private func capabilities(
+        supportsToolCalling: Bool = false,
+        supportsNativeJSONMode: Bool = false,
+        supportsThinking: Bool = false,
+        supportsVision: Bool = false
+    ) -> BackendCapabilities {
+        BackendCapabilities(
+            supportedParameters: [.temperature],
+            maxContextTokens: 4096,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsToolCalling: supportsToolCalling,
+            supportsStructuredOutput: supportsNativeJSONMode,
+            supportsNativeJSONMode: supportsNativeJSONMode,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: false,
+            supportsThinking: supportsThinking,
+            supportsVision: supportsVision
+        )
+    }
+
+    private func imageMessage() -> StructuredMessage {
+        StructuredMessage(
+            role: "user",
+            parts: [
+                .text("describe this"),
+                .image(data: Data([0x89, 0x50, 0x4E, 0x47]), mimeType: "image/png")
+            ]
+        )
+    }
+
+    private func weatherTool() -> ToolDefinition {
+        ToolDefinition(name: "get_weather", description: "Lookup weather")
+    }
+}
+
+private final class CapabilityWarningCapture: @unchecked Sendable {
+    struct Entry {
+        let backendType: String
+        let message: String
+    }
+
+    private let lock = NSLock()
+    private var entries: [Entry] = []
+
+    func record(backendType: String, message: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        entries.append(Entry(backendType: backendType, message: message))
+    }
+
+    func snapshot() -> [Entry] {
+        lock.lock()
+        defer { lock.unlock() }
+        return entries
+    }
+}

--- a/Tests/BaseChatInferenceTests/GenerationQueueTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationQueueTests.swift
@@ -1078,6 +1078,210 @@ final class GenerationQueueTests: XCTestCase {
                        "generate must succeed without trimming when thinking reserve is zero.")
     }
 
+    /// Passing `maxOutputTokens: nil` must still reserve the documented
+    /// default visible-output budget (2048 tokens) during exact preflight.
+    ///
+    /// Scenario:
+    ///   contextSize = 3000, maxOutput = nil -> visible reserve = 2048.
+    ///   First countTokens returns 1000 -> over budget (3048 > 3000) -> trim.
+    ///   Second countTokens returns 900 -> fits (2948 <= 3000) -> generate.
+    ///
+    /// Sabotage check: if nil were treated as a zero-token reservation, the
+    /// first count would fit and `countTokensCalled` would be 1.
+    func test_exactPreflightAndTrim_maxOutputNilUsesDefaultVisibleReserve() async throws {
+        let tcBackend = TokenCountingMockBackend(contextSize: 3000)
+        tcBackend.countTokensResponses = [1000, 900]
+        tcBackend.tokensToYield = ["ok"]
+        let tcProvider = TokenCountingFakeProvider(backend: tcBackend)
+
+        let coord = GenerationQueue()
+        coord.provider = tcProvider
+
+        let stream = try coord.generate(
+            messages: [
+                (role: "user", content: "oldest — trimmed because nil maxOutput reserves 2048"),
+                (role: "user", content: "latest — kept")
+            ],
+            maxOutputTokens: nil
+        )
+        for try await _ in stream.events {}
+
+        XCTAssertEqual(tcBackend.countTokensCalled, 2,
+                       "nil maxOutputTokens must reserve 2048, forcing one trim in this fixture")
+        XCTAssertEqual(tcBackend.generateCallCount, 1)
+    }
+
+    /// If the reserved output budget itself exceeds the context window, exact
+    /// preflight must surface `contextExhausted` before the backend generate
+    /// call, preserving the associated values callers use for remediation UI.
+    func test_exactPreflightAndTrim_reserveGreaterThanContextThrowsContextExhausted() throws {
+        let tcBackend = TokenCountingMockBackend(contextSize: 1000)
+        tcBackend.countTokensResponses = [1]
+        let tcProvider = TokenCountingFakeProvider(backend: tcBackend)
+
+        let coord = GenerationQueue()
+        coord.provider = tcProvider
+
+        XCTAssertThrowsError(
+            try coord.generate(
+                messages: [(role: "user", content: "tiny prompt")],
+                maxOutputTokens: 1500
+            )
+        ) { error in
+            guard case InferenceError.contextExhausted(let promptTokens, let maxOutputTokens, let contextSize) = error else {
+                XCTFail("Expected contextExhausted, got \(error)")
+                return
+            }
+            XCTAssertEqual(promptTokens, 1)
+            XCTAssertEqual(maxOutputTokens, 1500)
+            XCTAssertEqual(contextSize, 1000)
+        }
+
+        XCTAssertEqual(tcBackend.generateCallCount, 0,
+                       "over-reserved prompts must not reach backend.generate")
+    }
+
+    /// The exact trim loop is intentionally bounded. When every count remains
+    /// over budget and enough user turns exist that the last-user guard is not
+    /// reached first, it must stop after the default 20 trim attempts.
+    func test_exactPreflightAndTrim_maxTrimAttemptsExhaustedThrows() throws {
+        let tcBackend = TokenCountingMockBackend(contextSize: 500)
+        tcBackend.countTokensResponses = Array(repeating: 1000, count: 25)
+        let tcProvider = TokenCountingFakeProvider(backend: tcBackend)
+
+        let coord = GenerationQueue()
+        coord.provider = tcProvider
+
+        let messages = (0..<25).map { idx in
+            (role: "user", content: "message \(idx)")
+        }
+
+        XCTAssertThrowsError(
+            try coord.generate(messages: messages, maxOutputTokens: 100)
+        ) { error in
+            guard case InferenceError.contextExhausted(let promptTokens, let maxOutputTokens, let contextSize) = error else {
+                XCTFail("Expected contextExhausted, got \(error)")
+                return
+            }
+            XCTAssertEqual(promptTokens, 1000)
+            XCTAssertEqual(maxOutputTokens, 100)
+            XCTAssertEqual(contextSize, 500)
+        }
+
+        XCTAssertEqual(tcBackend.countTokensCalled, 21,
+                       "default maxTrimAttempts is 20: initial count plus 20 retry counts")
+        XCTAssertEqual(tcBackend.generateCallCount, 0)
+    }
+
+    /// A history containing only system-role tuples has no non-system message
+    /// available to trim, so exact preflight must fail closed with
+    /// `contextExhausted` rather than forwarding an over-budget prompt.
+    func test_exactPreflightAndTrim_systemOnlyHistoryThrowsContextExhausted() throws {
+        let tcBackend = TokenCountingMockBackend(contextSize: 100)
+        tcBackend.countTokensResponses = [80]
+        let tcProvider = TokenCountingFakeProvider(backend: tcBackend)
+
+        let coord = GenerationQueue()
+        coord.provider = tcProvider
+
+        XCTAssertThrowsError(
+            try coord.generate(
+                messages: [(role: "system", content: "system-only injected history")],
+                maxOutputTokens: 50
+            )
+        ) { error in
+            guard case InferenceError.contextExhausted = error else {
+                XCTFail("Expected contextExhausted, got \(error)")
+                return
+            }
+        }
+
+        XCTAssertEqual(tcBackend.countTokensCalled, 1)
+        XCTAssertEqual(tcBackend.generateCallCount, 0)
+    }
+
+    /// Assistant-only histories are trimmable because no user turn would be
+    /// lost. If trimming all assistant content brings the prompt under budget,
+    /// generation may proceed with the reduced prompt.
+    func test_exactPreflightAndTrim_assistantOnlyHistoryCanTrimToFit() async throws {
+        let tcBackend = TokenCountingMockBackend(contextSize: 100)
+        tcBackend.countTokensResponses = [80, 10]
+        tcBackend.tokensToYield = ["ok"]
+        let tcProvider = TokenCountingFakeProvider(backend: tcBackend)
+
+        let coord = GenerationQueue()
+        coord.provider = tcProvider
+
+        let stream = try coord.generate(
+            messages: [(role: "assistant", content: "assistant-only stale response")],
+            maxOutputTokens: 50
+        )
+        for try await _ in stream.events {}
+
+        XCTAssertEqual(tcBackend.countTokensCalled, 2)
+        XCTAssertEqual(tcBackend.generateCallCount, 1)
+        XCTAssertFalse(tcBackend.lastPrompt?.contains("assistant-only stale response") ?? true,
+                       "assistant-only content should be removed before generation")
+    }
+
+    /// Once trimming would remove the only remaining user turn, exact preflight
+    /// must throw instead of preserving context fit by deleting the latest user
+    /// message.
+    func test_exactPreflightAndTrim_preservesLatestUserMessageWhenStillOverBudget() throws {
+        let tcBackend = TokenCountingMockBackend(contextSize: 100)
+        tcBackend.countTokensResponses = [80, 80, 10]
+        let tcProvider = TokenCountingFakeProvider(backend: tcBackend)
+
+        let coord = GenerationQueue()
+        coord.provider = tcProvider
+
+        XCTAssertThrowsError(
+            try coord.generate(
+                messages: [
+                    (role: "assistant", content: "old assistant response that can be trimmed"),
+                    (role: "user", content: "latest user question must remain")
+                ],
+                maxOutputTokens: 50
+            )
+        ) { error in
+            guard case InferenceError.contextExhausted = error else {
+                XCTFail("Expected contextExhausted, got \(error)")
+                return
+            }
+        }
+
+        XCTAssertEqual(tcBackend.countTokensCalled, 2,
+                       "the loop should stop before counting an empty prompt created by deleting the latest user turn")
+        XCTAssertEqual(tcBackend.generateCallCount, 0)
+    }
+
+    /// Tokenizer failures are authoritative exact-preflight failures. They
+    /// must propagate without falling back to heuristic counting or calling
+    /// the backend generate path.
+    func test_exactPreflightAndTrim_tokenCounterErrorPropagates() throws {
+        let tcBackend = TokenCountingMockBackend(contextSize: 256)
+        tcBackend.countTokensError = TokenCountingTestError.tokenizerUnavailable
+        let tcProvider = TokenCountingFakeProvider(backend: tcBackend)
+
+        let coord = GenerationQueue()
+        coord.provider = tcProvider
+
+        XCTAssertThrowsError(
+            try coord.generate(
+                messages: [(role: "user", content: "hello")],
+                maxOutputTokens: 50
+            )
+        ) { error in
+            guard case TokenCountingTestError.tokenizerUnavailable = error else {
+                XCTFail("Expected tokenizerUnavailable, got \(error)")
+                return
+            }
+        }
+
+        XCTAssertEqual(tcBackend.generateCallCount, 0,
+                       "generate must not run when exact token counting throws")
+    }
+
     // MARK: - Provider teardown safety
 
     /// Deallocating the provider mid-stream must not crash the coordinator.
@@ -1230,6 +1434,10 @@ private final class NilBackendProvider: GenerationContextProvider {
     var currentBackend: (any InferenceBackend)? { nil }
     var isBackendLoaded: Bool { false }
     var selectedPromptTemplate: PromptTemplate { .chatML }
+}
+
+private enum TokenCountingTestError: Error {
+    case tokenizerUnavailable
 }
 
 // MARK: - TokenCounting fakes

--- a/Tests/BaseChatInferenceTests/ToolCallStreamingContractTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolCallStreamingContractTests.swift
@@ -67,6 +67,81 @@ final class ToolCallStreamingContractTests: XCTestCase {
         return backend
     }
 
+    private struct ToolCallLifecycleState {
+        var started = false
+        var deltaFragments: [String] = []
+        var completed = false
+    }
+
+    /// Validate the public lifecycle contract for tool-call stream events:
+    /// `.toolCallStart` must open a call, argument deltas (when present) must
+    /// follow that start, and the authoritative `.toolCall` must close it.
+    private func toolCallLifecycleViolations(
+        in events: [GenerationEvent],
+        requireArgumentDelta: Bool = false
+    ) -> [String] {
+        var states: [String: ToolCallLifecycleState] = [:]
+        var violations: [String] = []
+
+        for (index, event) in events.enumerated() {
+            switch event {
+            case .toolCallStart(let callId, let name):
+                if callId.isEmpty {
+                    violations.append("event \(index): toolCallStart has empty callId")
+                }
+                if name.isEmpty {
+                    violations.append("event \(index): toolCallStart(\(callId)) has empty name")
+                }
+                var state = states[callId, default: ToolCallLifecycleState()]
+                if state.started {
+                    violations.append("event \(index): duplicate toolCallStart for \(callId)")
+                }
+                if state.completed {
+                    violations.append("event \(index): toolCallStart after toolCall for \(callId)")
+                }
+                state.started = true
+                states[callId] = state
+
+            case .toolCallArgumentsDelta(let callId, let textDelta):
+                var state = states[callId, default: ToolCallLifecycleState()]
+                if !state.started {
+                    violations.append("event \(index): arguments delta before toolCallStart for \(callId)")
+                }
+                if state.completed {
+                    violations.append("event \(index): arguments delta after toolCall for \(callId)")
+                }
+                state.deltaFragments.append(textDelta)
+                states[callId] = state
+
+            case .toolCall(let call):
+                var state = states[call.id, default: ToolCallLifecycleState()]
+                if !state.started {
+                    violations.append("event \(index): toolCall before toolCallStart for \(call.id)")
+                }
+                if requireArgumentDelta && state.deltaFragments.isEmpty {
+                    violations.append("event \(index): toolCall without arguments delta for \(call.id)")
+                }
+                if state.completed {
+                    violations.append("event \(index): duplicate toolCall for \(call.id)")
+                }
+                let streamedArguments = state.deltaFragments.joined()
+                if !streamedArguments.isEmpty && streamedArguments != call.arguments {
+                    violations.append("event \(index): streamed arguments differ from toolCall.arguments for \(call.id)")
+                }
+                state.completed = true
+                states[call.id] = state
+
+            default:
+                break
+            }
+        }
+
+        for (callId, state) in states where state.started && !state.completed {
+            violations.append("stream ended before toolCall for \(callId)")
+        }
+        return violations
+    }
+
     // MARK: - 1. Streaming backend: start → deltas → call
 
     /// Contract: a streaming backend emits `.toolCallStart` first, then one or
@@ -99,6 +174,11 @@ final class ToolCallStreamingContractTests: XCTestCase {
             XCTFail("Expected 4 tool events (start + 2 deltas + call), got \(toolEvents.count)")
             return
         }
+        XCTAssertEqual(
+            toolCallLifecycleViolations(in: toolEvents, requireArgumentDelta: true),
+            [],
+            "streaming backend must emit start → delta(s) → toolCall for each call"
+        )
         if case .toolCallStart(let id, let name) = toolEvents[0] {
             XCTAssertEqual(id, "c1")
             XCTAssertEqual(name, "get_weather")
@@ -157,6 +237,61 @@ final class ToolCallStreamingContractTests: XCTestCase {
         XCTAssertTrue(deltas.isEmpty, "non-streaming backend must not emit .toolCallArgumentsDelta")
         XCTAssertEqual(calls.count, 1)
         XCTAssertEqual(calls.first?.id, "c2")
+    }
+
+    // MARK: - 2b. Whole-call local backend: canonical start → delta → call triple
+
+    /// Contract: local whole-call backends that normalise a completed tool call
+    /// into progressive events still advertise `streamsToolCallArguments == false`,
+    /// but emit a canonical `.toolCallStart` → single full-arguments
+    /// `.toolCallArgumentsDelta` → `.toolCall` triple for UI consumers.
+    func test_wholeCallLocalBackend_emitsCanonicalStartDeltaToolCallTriple() async throws {
+        let backend = try makeNonStreamingBackend()
+        XCTAssertFalse(
+            backend.capabilities.streamsToolCallArguments,
+            "whole-call local backend must not advertise incremental argument streaming"
+        )
+
+        let call = ToolCall(id: "local-1", toolName: "lookup", arguments: #"{"q":"swift"}"#)
+        backend.tokensToYield = []
+        backend.scriptedToolCallDeltasPerTurn = [[
+            .start(callId: call.id, name: call.toolName),
+            .delta(callId: call.id, textDelta: call.arguments),
+            .call(call),
+        ]]
+
+        let stream = try backend.generate(prompt: "lookup swift", systemPrompt: nil, config: .init())
+        let events = try await collectEvents(stream)
+        let toolEvents = events.filter {
+            switch $0 {
+            case .toolCallStart, .toolCallArgumentsDelta, .toolCall: return true
+            default: return false
+            }
+        }
+
+        XCTAssertEqual(
+            toolCallLifecycleViolations(in: toolEvents, requireArgumentDelta: true),
+            [],
+            "whole-call local normalization must preserve start → delta → toolCall ordering"
+        )
+        XCTAssertEqual(toolEvents.count, 3)
+        if case .toolCallStart(let id, let name) = toolEvents[0] {
+            XCTAssertEqual(id, "local-1")
+            XCTAssertEqual(name, "lookup")
+        } else {
+            XCTFail("First tool event must be .toolCallStart, got \(toolEvents[0])")
+        }
+        if case .toolCallArgumentsDelta(let id, let textDelta) = toolEvents[1] {
+            XCTAssertEqual(id, "local-1")
+            XCTAssertEqual(textDelta, #"{"q":"swift"}"#)
+        } else {
+            XCTFail("Second tool event must be .toolCallArgumentsDelta, got \(toolEvents[1])")
+        }
+        if case .toolCall(let received) = toolEvents[2] {
+            XCTAssertEqual(received, call)
+        } else {
+            XCTFail("Third tool event must be .toolCall, got \(toolEvents[2])")
+        }
     }
 
     // MARK: - 3. Exactly one .toolCall per callId
@@ -319,6 +454,11 @@ final class ToolCallStreamingContractTests: XCTestCase {
 
         XCTAssertNotNil(receivedA, "toolCall for a1 must be present")
         XCTAssertNotNil(receivedB, "toolCall for b1 must be present")
+        XCTAssertEqual(
+            toolCallLifecycleViolations(in: events, requireArgumentDelta: true),
+            [],
+            "interleaved calls must each preserve start → delta(s) → toolCall ordering"
+        )
 
         // Sabotage: mixing all deltas into a single accumulator (ignoring callId)
         // would make concatenation equal one giant string rather than per-id slices.
@@ -430,6 +570,32 @@ final class ToolCallStreamingContractTests: XCTestCase {
         // to the .call event — toolCalls would be non-empty.
         XCTAssertTrue(toolCalls.isEmpty,
             "no .toolCall must reach the consumer after stream cancellation pre-call; got \(toolCalls)")
+    }
+
+    // MARK: - 7b. Lifecycle validator catches out-of-order streams
+
+    func test_lifecycleValidator_reportsOutOfOrderToolCallEvents() {
+        let call = ToolCall(id: "bad-1", toolName: "broken", arguments: #"{"x":1}"#)
+        let events: [GenerationEvent] = [
+            .toolCallArgumentsDelta(callId: "bad-1", textDelta: #"{"x":"#),
+            .toolCall(call),
+            .toolCallStart(callId: "bad-1", name: "broken"),
+        ]
+
+        let violations = toolCallLifecycleViolations(in: events, requireArgumentDelta: true)
+
+        XCTAssertTrue(
+            violations.contains { $0.contains("arguments delta before toolCallStart") },
+            "validator must flag deltas that arrive before toolCallStart; got \(violations)"
+        )
+        XCTAssertTrue(
+            violations.contains { $0.contains("toolCall before toolCallStart") },
+            "validator must flag toolCall before toolCallStart; got \(violations)"
+        )
+        XCTAssertTrue(
+            violations.contains { $0.contains("toolCallStart after toolCall") },
+            "validator must flag starts that arrive after the authoritative call; got \(violations)"
+        )
     }
 
     // MARK: - 8. Orphan start (no matching call): silently dropped, no error

--- a/Tests/BaseChatInferenceTests/TrafficBoundaryAuditTest.swift
+++ b/Tests/BaseChatInferenceTests/TrafficBoundaryAuditTest.swift
@@ -41,8 +41,10 @@ import XCTest
 ///    code at build time).
 ///
 /// 6. **Import-graph boundary** — locks in the layered architecture from
-///    `CLAUDE.md`. UI must not depend on Backends; Inference must not
-///    depend on Core or Backends.
+///    `CLAUDE.md`. UI must not depend on Backends or SwiftData persistence;
+///    Inference must not depend on Core or Backends. The rule checks both
+///    source imports and the SwiftPM manifest so a target dependency cannot
+///    reintroduce a forbidden module before an import lands.
 ///
 /// 7. **Trait gate sanity** — every `#if`/`#elseif` identifier in
 ///    `Sources/` that looks trait-named (TitleCase or UPPERCASE, not a
@@ -368,8 +370,8 @@ final class TrafficBoundaryAuditTest: XCTestCase {
         // (file-path-prefix, forbidden-imports, why)
         let rules: [(prefix: String, forbidden: [String], why: String)] = [
             ("BaseChatUI/",
-             ["BaseChatBackends"],
-             "BaseChatUI must not depend on BaseChatBackends. UI is consumer-facing; backend code carries cloud-SDK weight that local-only builds want to exclude."),
+             ["BaseChatBackends", "BaseChatPersistenceSwiftData"],
+             "BaseChatUI must not depend on BaseChatBackends or BaseChatPersistenceSwiftData. UI is consumer-facing; backend code carries cloud-SDK weight and persistence adapters belong behind BaseChatRuntime ports."),
             ("BaseChatCore/",
              ["BaseChatBackends"],
              "BaseChatCore is the persistence layer; backend code belongs above it."),
@@ -399,6 +401,42 @@ final class TrafficBoundaryAuditTest: XCTestCase {
                         ))
                     }
                 }
+            }
+        }
+
+        Self.assertNoOffenders(offenders)
+    }
+
+    func test_rule6_packageManifestTargetBoundaries() throws {
+        let packageURL = try Self.locatePackageManifest()
+        let manifest = try String(contentsOf: packageURL, encoding: .utf8)
+        var offenders: [Offender] = []
+
+        let rules: [(target: String, forbidden: [String], why: String)] = [
+            ("BaseChatUI",
+             ["BaseChatBackends", "BaseChatPersistenceSwiftData", "BaseChatUIModelManagement"],
+             "BaseChatUI must stay a chat-only consumer surface. Backends, SwiftData adapters, and model-management UI belong behind lower-layer ports or sibling modules."),
+            ("BaseChatUIModelManagement",
+             ["BaseChatPersistenceSwiftData"],
+             "BaseChatUIModelManagement must use BaseChatRuntime endpoint-store ports instead of depending on concrete SwiftData adapters.")
+        ]
+
+        for rule in rules {
+            guard let block = Self.manifestTargetBlock(in: manifest, targetName: rule.target) else {
+                XCTFail("Could not locate Package.swift target '\(rule.target)' for Rule 6 manifest boundary audit.")
+                continue
+            }
+
+            for forbidden in rule.forbidden where Self.manifestTarget(block.text, declaresDependencyOn: forbidden) {
+                offenders.append(.init(
+                    rule: 6,
+                    ruleName: "Package manifest target boundary",
+                    file: "Package.swift",
+                    line: block.startLine,
+                    text: ".target(name: \"\(rule.target)\", dependencies: ... \(forbidden) ...)",
+                    why: rule.why,
+                    fix: "Remove the \(forbidden) dependency from \(rule.target). Depend on BaseChatRuntime/BaseChatInference ports or closure-inject the sibling surface instead."
+                ))
             }
         }
 
@@ -639,6 +677,52 @@ final class TrafficBoundaryAuditTest: XCTestCase {
         if line.hasPrefix("///") { return false }
         if line.hasPrefix("*") { return false }
         return true
+    }
+
+    // MARK: - Rule 6 helpers (Package.swift target boundaries)
+
+    private static func manifestTargetBlock(
+        in manifest: String,
+        targetName: String
+    ) -> (text: String, startLine: Int)? {
+        let marker = ".target("
+        var searchStart = manifest.startIndex
+
+        while let targetStart = manifest.range(of: marker, range: searchStart..<manifest.endIndex)?.lowerBound {
+            var depth = 0
+            var end = targetStart
+            var index = targetStart
+            while index < manifest.endIndex {
+                let character = manifest[index]
+                if character == "(" {
+                    depth += 1
+                } else if character == ")" {
+                    depth -= 1
+                    if depth == 0 {
+                        end = manifest.index(after: index)
+                        break
+                    }
+                }
+                index = manifest.index(after: index)
+            }
+
+            guard end > targetStart else { return nil }
+            let block = String(manifest[targetStart..<end])
+            if block.contains("name: \"\(targetName)\"") {
+                let startLine = manifest[..<targetStart].reduce(1) { count, character in
+                    character == "\n" ? count + 1 : count
+                }
+                return (block, startLine)
+            }
+
+            searchStart = end
+        }
+
+        return nil
+    }
+
+    private static func manifestTarget(_ block: String, declaresDependencyOn dependency: String) -> Bool {
+        block.contains("\"\(dependency)\"") || block.contains("name: \"\(dependency)\"")
     }
 
     // MARK: - Reporting
@@ -921,7 +1005,7 @@ final class TrafficBoundaryAuditTest: XCTestCase {
         XCTAssertEqual(parsed, ["MLX", "Llama", "Ollama", "CloudSaaS", "Fuzz"])
     }
 
-    func test_sabotage_rule6_detectsForbiddenImports() {
+    func test_sabotage_rule6_detectsForbiddenImportsAndManifestDependencies() {
         // Rule 6 is implemented inline in test_rule6_importGraphBoundary
         // (it's a per-line `import X` check rather than a single regex), so
         // the sabotage check verifies the prefix-matching logic works.
@@ -936,5 +1020,21 @@ final class TrafficBoundaryAuditTest: XCTestCase {
         // BaseChatBackends — the trailing space distinguishes them.
         XCTAssertFalse(unrelated == "import BaseChatBackends" || unrelated.hasPrefix("import BaseChatBackends "),
                        "Rule 6 must not flag unrelated module names that share a prefix")
+
+        let manifest = """
+            .target(
+                name: "BaseChatUI",
+                dependencies: [
+                    "BaseChatRuntime",
+                    "BaseChatPersistenceSwiftData",
+                ],
+                path: "Sources/BaseChatUI"
+            ),
+            """
+        let block = Self.manifestTargetBlock(in: manifest, targetName: "BaseChatUI")
+        XCTAssertNotNil(block)
+        XCTAssertTrue(Self.manifestTarget(block?.text ?? "", declaresDependencyOn: "BaseChatPersistenceSwiftData"))
+        XCTAssertFalse(Self.manifestTarget(block?.text ?? "", declaresDependencyOn: "BaseChatPersistenceSwiftDataExtras"),
+                       "Rule 6 manifest check must not flag dependency names that only share a prefix")
     }
 }

--- a/Tests/BaseChatPersistenceSwiftDataTests/BaseChatBootstrapTests.swift
+++ b/Tests/BaseChatPersistenceSwiftDataTests/BaseChatBootstrapTests.swift
@@ -116,6 +116,34 @@ final class BaseChatBootstrapTests: XCTestCase {
             "Session inserted via runtime.persistence must be visible through runtime.modelContainer.mainContext")
     }
 
+    func test_init_endpointStoreSharesContainerWithPersistence() async throws {
+        let originalConfiguration = BaseChatConfiguration.shared
+        defer { BaseChatConfiguration.shared = originalConfiguration }
+
+        let runtime = try BaseChatBootstrap(
+            configuration: BaseChatConfiguration(
+                appName: "Endpoint Store Wiring",
+                bundleIdentifier: "com.basechatkit.runtime-tests.endpoint-store.\(UUID().uuidString)"
+            ),
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+
+        let endpoint = APIEndpointRecord(name: "Shared Endpoint", provider: .openAI)
+        var session = ChatSessionRecord(title: "Shared Session")
+        session.selectedEndpointID = endpoint.id
+
+        try await runtime.endpointStore.insertEndpoint(endpoint)
+        try await runtime.persistence.insertSession(session)
+
+        let endpointsViaContainer = try runtime.modelContainer.mainContext.fetch(FetchDescriptor<APIEndpoint>())
+        let sessionsViaPersistence = try await runtime.persistence.fetchSessions()
+
+        XCTAssertTrue(endpointsViaContainer.contains(where: { $0.id == endpoint.id }),
+            "Endpoint inserted through runtime.endpointStore must be visible through runtime.modelContainer.mainContext")
+        XCTAssertEqual(sessionsViaPersistence.first(where: { $0.id == session.id })?.selectedEndpointID, endpoint.id,
+            "Session settings persisted through runtime.persistence must reference the same endpoint id")
+    }
+
     func test_persistence_roundTripsSessionsThroughRuntimeProvider() async throws {
         let originalConfiguration = BaseChatConfiguration.shared
         defer { BaseChatConfiguration.shared = originalConfiguration }

--- a/Tests/BaseChatPersistenceSwiftDataTests/SwiftDataEndpointStoreRegressionTests.swift
+++ b/Tests/BaseChatPersistenceSwiftDataTests/SwiftDataEndpointStoreRegressionTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+import SwiftData
+import BaseChatRuntime
+@testable import BaseChatPersistenceSwiftData
+import BaseChatInference
+
+@MainActor
+final class SwiftDataEndpointStoreRegressionTests: XCTestCase {
+
+    func test_inMemoryStore_createEditDeleteLoadAndRestoreBySameID() async throws {
+        let container = try ModelContainerFactory.makeInMemoryContainer()
+        let firstStore = SwiftDataEndpointStore(modelContext: ModelContext(container))
+
+        let endpointID = UUID()
+        let original = APIEndpointRecord(
+            id: endpointID,
+            name: "Original",
+            provider: .openAI,
+            baseURL: "https://api.openai.com/v1",
+            modelName: "gpt-4o-mini",
+            createdAt: Date(timeIntervalSinceReferenceDate: 10)
+        )
+
+        try await firstStore.insertEndpoint(original)
+
+        var edited = original
+        edited.name = "Edited"
+        edited.provider = .custom
+        edited.baseURL = "https://example.com/v1"
+        edited.modelName = "custom-model"
+        edited.isEnabled = false
+        try await firstStore.updateEndpoint(edited)
+
+        let reloadedStore = SwiftDataEndpointStore(modelContext: ModelContext(container))
+        let reloadedEndpoints = try await reloadedStore.fetchEndpoints()
+        let reloaded = try XCTUnwrap(reloadedEndpoints.first)
+        XCTAssertEqual(reloaded.id, endpointID)
+        XCTAssertEqual(reloaded.name, "Edited")
+        XCTAssertEqual(reloaded.provider, .custom)
+        XCTAssertEqual(reloaded.baseURL, "https://example.com/v1")
+        XCTAssertEqual(reloaded.modelName, "custom-model")
+        XCTAssertFalse(reloaded.isEnabled)
+
+        try await reloadedStore.deleteEndpoint(endpointID)
+        let endpointsAfterDelete = try await reloadedStore.fetchEndpoints()
+        XCTAssertTrue(endpointsAfterDelete.isEmpty)
+
+        var restored = original
+        restored.name = "Restored"
+        restored.modelName = "restored-model"
+        try await reloadedStore.insertEndpoint(restored)
+
+        let restoredRows = try await SwiftDataEndpointStore(modelContext: ModelContext(container)).fetchEndpoints()
+        XCTAssertEqual(restoredRows.map(\.id), [endpointID])
+        XCTAssertEqual(restoredRows.first?.name, "Restored")
+        XCTAssertEqual(restoredRows.first?.keychainAccount, endpointID.uuidString)
+    }
+
+    func test_fetchEndpoints_preservesDisabledStateForCallerFiltering() async throws {
+        let store = SwiftDataEndpointStore(modelContext: ModelContext(try ModelContainerFactory.makeInMemoryContainer()))
+        let enabled = APIEndpointRecord(name: "Enabled", provider: .openAI, isEnabled: true)
+        let disabled = APIEndpointRecord(name: "Disabled", provider: .claude, isEnabled: false)
+
+        try await store.insertEndpoint(enabled)
+        try await store.insertEndpoint(disabled)
+
+        let fetched = try await store.fetchEndpoints()
+        XCTAssertEqual(Set(fetched.map(\.id)), Set([enabled.id, disabled.id]))
+        XCTAssertEqual(fetched.first(where: { $0.id == disabled.id })?.isEnabled, false)
+        XCTAssertEqual(fetched.filter(\.isEnabled).map(\.id), [enabled.id])
+    }
+}

--- a/Tests/BaseChatRuntimeTests/ConversationRuntimeTests.swift
+++ b/Tests/BaseChatRuntimeTests/ConversationRuntimeTests.swift
@@ -4,6 +4,88 @@ import Foundation
 @testable import BaseChatInference
 import BaseChatTestSupport
 
+private final class RuntimeUsageBackend: InferenceBackend, TokenUsageProvider, @unchecked Sendable {
+    struct Turn: Sendable {
+        let tokens: [String]
+        let usage: (promptTokens: Int, completionTokens: Int)?
+        let streamErrorMessage: String?
+
+        init(
+            tokens: [String],
+            usage: (promptTokens: Int, completionTokens: Int)?,
+            streamErrorMessage: String? = nil
+        ) {
+            self.tokens = tokens
+            self.usage = usage
+            self.streamErrorMessage = streamErrorMessage
+        }
+    }
+
+    var isModelLoaded = true
+    var isGenerating = false
+    var capabilities = BackendCapabilities(
+        supportedParameters: [.temperature, .topP, .repeatPenalty],
+        maxContextTokens: 4096,
+        requiresPromptTemplate: false,
+        supportsSystemPrompt: true
+    )
+    var lastUsage: (promptTokens: Int, completionTokens: Int)?
+
+    private let lock = NSLock()
+    private var turns: [Turn]
+
+    init(turns: [Turn]) {
+        self.turns = turns
+    }
+
+    func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
+        isModelLoaded = true
+    }
+
+    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> GenerationStream {
+        guard isModelLoaded else { throw InferenceError.inferenceFailure("No model loaded") }
+        let turn = nextTurn()
+        isGenerating = true
+
+        return GenerationStream(AsyncThrowingStream<GenerationEvent, Error> { [self] continuation in
+            Task {
+                for token in turn.tokens {
+                    if Task.isCancelled { break }
+                    continuation.yield(.token(token))
+                }
+                if let usage = turn.usage, !Task.isCancelled {
+                    continuation.yield(.usage(prompt: usage.promptTokens, completion: usage.completionTokens))
+                    self.lastUsage = usage
+                }
+                self.isGenerating = false
+                if let message = turn.streamErrorMessage, !Task.isCancelled {
+                    continuation.finish(throwing: InferenceError.inferenceFailure(message))
+                } else {
+                    continuation.finish()
+                }
+            }
+        })
+    }
+
+    func stopGeneration() {
+        isGenerating = false
+    }
+
+    func unloadModel() {
+        isModelLoaded = false
+        isGenerating = false
+    }
+
+    private func nextTurn() -> Turn {
+        lock.lock()
+        defer { lock.unlock() }
+        if turns.isEmpty {
+            return Turn(tokens: [], usage: nil)
+        }
+        return turns.removeFirst()
+    }
+}
+
 /// Phase 1.2.5 PR-A — coverage for the new `ConversationRuntime` send sub-flow.
 ///
 /// Send is the only sub-flow PR-A ships. Regenerate / edit / branch are
@@ -28,8 +110,16 @@ final class ConversationRuntimeTests: XCTestCase {
         /// of performing the update. Cleared after the throw so subsequent
         /// updates succeed normally.
         var updateError: (any Error)?
+        /// When set, the next `insertMessage` call throws this error instead
+        /// of performing the insert. Cleared after the throw so subsequent
+        /// inserts succeed normally.
+        var insertError: (any Error)?
 
         func insertMessage(_ message: ChatMessageRecord) async throws {
+            if let error = insertError {
+                insertError = nil
+                throw error
+            }
             messages[message.id] = message
             for hook in hooks {
                 await hook.messageDidWrite(message, in: message.sessionID)
@@ -84,6 +174,12 @@ final class ConversationRuntimeTests: XCTestCase {
         /// When set, the next `insertSession` call throws this error instead
         /// of performing the insert. Cleared after the throw.
         var insertError: (any Error)?
+        /// When set, the next `updateSession` call throws this error instead
+        /// of performing the update. Cleared after the throw.
+        var updateError: (any Error)?
+        /// When set, the next `fetchSessions` call throws this error instead
+        /// of returning sessions. Cleared after the throw.
+        var fetchError: (any Error)?
 
         func insertSession(_ session: ChatSessionRecord) async throws {
             if let error = insertError {
@@ -94,6 +190,10 @@ final class ConversationRuntimeTests: XCTestCase {
         }
 
         func updateSession(_ session: ChatSessionRecord) async throws {
+            if let error = updateError {
+                updateError = nil
+                throw error
+            }
             guard sessions[session.id] != nil else {
                 throw ChatPersistenceError.sessionNotFound(session.id)
             }
@@ -108,7 +208,11 @@ final class ConversationRuntimeTests: XCTestCase {
         }
 
         func fetchSessions() async throws -> [ChatSessionRecord] {
-            sessions.values.sorted { $0.updatedAt > $1.updatedAt }
+            if let error = fetchError {
+                fetchError = nil
+                throw error
+            }
+            return sessions.values.sorted { $0.updatedAt > $1.updatedAt }
         }
     }
 
@@ -181,6 +285,51 @@ final class ConversationRuntimeTests: XCTestCase {
             return first ?? []
         }
         return result
+    }
+
+    private func waitForEvents(
+        from task: Task<[ConversationEvent], Never>,
+        deadline: Duration = .seconds(5)
+    ) async throws -> [ConversationEvent] {
+        try await withThrowingTaskGroup(of: [ConversationEvent].self) { group in
+            group.addTask { await task.value }
+            group.addTask {
+                try await Task.sleep(for: deadline)
+                task.cancel()
+                throw TestError.deadlineElapsed
+            }
+            let first = try await group.next()
+            group.cancelAll()
+            return first ?? []
+        }
+    }
+
+    private func collectUntilStreamFinished(
+        from runtime: ConversationRuntime,
+        deadline: Duration = .seconds(5)
+    ) async throws -> [ConversationEvent] {
+        try await collectEvents(from: runtime, until: { event in
+            if case .streamFinished = event { return true }
+            return false
+        }, deadline: deadline)
+    }
+
+    private func drainUntilStreamFinished(from runtime: ConversationRuntime) -> Task<[ConversationEvent], Never> {
+        Task { @MainActor [runtime] in
+            var events: [ConversationEvent] = []
+            for await event in runtime.events {
+                events.append(event)
+                if case .streamFinished = event { return events }
+            }
+            return events
+        }
+    }
+
+    private func streamFinishedReasons(in events: [ConversationEvent]) -> [FinishReason] {
+        events.compactMap { event in
+            if case let .streamFinished(_, reason) = event { return reason }
+            return nil
+        }
     }
 
     enum TestError: Error { case deadlineElapsed }
@@ -286,6 +435,292 @@ final class ConversationRuntimeTests: XCTestCase {
         }), "Stream finishes with .empty when no tokens were emitted")
     }
 
+    // MARK: - Finish-state regressions
+
+    func test_finishState_success_emitsSingleStopTerminalAfterAssistantInsert() async throws {
+        let mock = MockInferenceBackend()
+        mock.tokensToYield = ["done"]
+        let (runtime, store, _, _) = makeRuntime(mock: mock)
+
+        _ = try await runtime.send(SendInput(sessionID: UUID(), userText: "go"))
+        let events = try await collectEvents(from: runtime) { event in
+            if case .afterGeneration = event { return true }
+            return false
+        }
+
+        XCTAssertEqual(streamFinishedReasons(in: events), [.stop],
+                       "Successful generation emits exactly one .stop terminal")
+        let assistantInsertIndex = events.firstIndex {
+            if case let .messageInserted(record) = $0, record.role == .assistant { return true }
+            return false
+        }
+        let finishIndex = events.firstIndex {
+            if case .streamFinished = $0 { return true }
+            return false
+        }
+        XCTAssertNotNil(assistantInsertIndex)
+        XCTAssertNotNil(finishIndex)
+        if let assistantInsertIndex, let finishIndex {
+            XCTAssertLessThan(assistantInsertIndex, finishIndex,
+                              "Assistant insert precedes the terminal event on success")
+        }
+        XCTAssertEqual(store.messages.values.filter { $0.role == .assistant }.map(\.content), ["done"])
+    }
+
+    func test_finishState_emptyResponse_emitsSingleEmptyTerminalAndDropsAssistant() async throws {
+        let mock = MockInferenceBackend()
+        mock.tokensToYield = []
+        let (runtime, store, _, _) = makeRuntime(mock: mock)
+
+        _ = try await runtime.send(SendInput(sessionID: UUID(), userText: "empty"))
+        let events = try await collectEvents(from: runtime) { event in
+            if case .afterGeneration = event { return true }
+            return false
+        }
+
+        XCTAssertEqual(streamFinishedReasons(in: events), [.empty],
+                       "Empty generation emits exactly one .empty terminal")
+        XCTAssertEqual(store.messages.values.filter { $0.role == .assistant }.count, 0,
+                       "Empty assistant response is not persisted")
+        guard case let .afterGeneration(_, finalText) = events.last else {
+            XCTFail("Expected afterGeneration after empty terminal")
+            return
+        }
+        XCTAssertEqual(finalText, "")
+    }
+
+    func test_finishState_cancelBeforeFirstToken_emitsSingleCancelledTerminalAndNoAssistant() async throws {
+        let mock = MockInferenceBackend()
+        mock.tokensToYield = ["late"]
+        let gate = TokenEmissionGate()
+        mock.tokenEmissionGate = gate
+        let (runtime, store, _, _) = makeRuntime(mock: mock)
+        let drain = drainUntilStreamFinished(from: runtime)
+
+        let handle = try await runtime.send(SendInput(
+            sessionID: UUID(),
+            userText: "cancel",
+            streamingBatchCharacterLimit: 1
+        ))
+        await runtime.cancel(handle)
+
+        let events = try await waitForEvents(from: drain)
+        await gate.release()
+
+        XCTAssertEqual(streamFinishedReasons(in: events), [.cancelled],
+                       "Cancel before the first visible token emits exactly one cancelled terminal")
+        XCTAssertFalse(events.contains {
+            if case .tokenEmitted = $0 { return true }
+            return false
+        }, "No token event should escape after pre-token cancel")
+        XCTAssertEqual(store.messages.values.filter { $0.role == .assistant }.count, 0,
+                       "Pre-token cancel drops the empty assistant")
+    }
+
+    func test_finishState_cancelAfterPartialOutput_persistsPartialAndEmitsSingleCancelledTerminal() async throws {
+        let mock = MockInferenceBackend()
+        mock.tokensToYield = ["one", " two"]
+        let gate = TokenEmissionGate()
+        mock.tokenEmissionGate = gate
+        let (runtime, store, _, _) = makeRuntime(mock: mock)
+
+        let handle = try await runtime.send(SendInput(
+            sessionID: UUID(),
+            userText: "cancel partial",
+            streamingBatchCharacterLimit: 1
+        ))
+        let drain = Task { @MainActor [runtime] in
+            var events: [ConversationEvent] = []
+            var didCancel = false
+            for await event in runtime.events {
+                events.append(event)
+                switch event {
+                case .tokenEmitted:
+                    if !didCancel {
+                        didCancel = true
+                        await runtime.cancel(handle)
+                        await gate.release()
+                    }
+                case .streamFinished:
+                    return events
+                default:
+                    break
+                }
+            }
+            return events
+        }
+
+        await gate.advance()
+        let events = try await waitForEvents(from: drain)
+
+        XCTAssertEqual(streamFinishedReasons(in: events), [.cancelled],
+                       "Cancel after partial output emits exactly one cancelled terminal")
+        XCTAssertEqual(store.messages.values.filter { $0.role == .assistant }.map(\.content), ["one"],
+                       "Cancel after partial output persists only the streamed prefix")
+    }
+
+    func test_finishState_streamErrorWithoutPartial_emitsErrorBeforeSingleStopTerminalAndNoAssistant() async throws {
+        let mock = MockInferenceBackend()
+        mock.tokensToYield = []
+        mock.shouldThrowInsideStream = InferenceError.inferenceFailure("no partial")
+        let (runtime, store, _, _) = makeRuntime(mock: mock)
+
+        _ = try await runtime.send(SendInput(sessionID: UUID(), userText: "fail"))
+        let events = try await collectUntilStreamFinished(from: runtime)
+
+        XCTAssertEqual(streamFinishedReasons(in: events), [.stop],
+                       "Stream error emits exactly one terminal event")
+        XCTAssertEqual(store.messages.values.filter { $0.role == .assistant }.count, 0,
+                       "No assistant is persisted when the stream errors before visible output")
+        let errorIndex = events.firstIndex {
+            if case let .errorRaised(error) = $0, case .inference = error { return true }
+            return false
+        }
+        let finishIndex = events.firstIndex {
+            if case .streamFinished = $0 { return true }
+            return false
+        }
+        XCTAssertNotNil(errorIndex)
+        XCTAssertNotNil(finishIndex)
+        if let errorIndex, let finishIndex {
+            XCTAssertLessThan(errorIndex, finishIndex,
+                              "Inference error is surfaced before the terminal event")
+        }
+    }
+
+    func test_finishState_streamErrorWithPartial_persistsPartialThenErrorsBeforeSingleStopTerminal() async throws {
+        let mock = MockInferenceBackend()
+        mock.tokensToYield = ["partial"]
+        mock.shouldThrowInsideStream = InferenceError.inferenceFailure("partial")
+        let (runtime, store, _, _) = makeRuntime(mock: mock)
+
+        _ = try await runtime.send(SendInput(sessionID: UUID(), userText: "fail partial"))
+        let events = try await collectUntilStreamFinished(from: runtime)
+
+        XCTAssertEqual(streamFinishedReasons(in: events), [.stop],
+                       "Partial stream error emits exactly one terminal event")
+        XCTAssertEqual(store.messages.values.filter { $0.role == .assistant }.map(\.content), ["partial"])
+        let assistantInsertIndex = events.firstIndex {
+            if case let .messageInserted(record) = $0, record.role == .assistant { return true }
+            return false
+        }
+        let errorIndex = events.firstIndex {
+            if case let .errorRaised(error) = $0, case .inference = error { return true }
+            return false
+        }
+        let finishIndex = events.firstIndex {
+            if case .streamFinished = $0 { return true }
+            return false
+        }
+        XCTAssertNotNil(assistantInsertIndex)
+        XCTAssertNotNil(errorIndex)
+        XCTAssertNotNil(finishIndex)
+        if let assistantInsertIndex, let errorIndex, let finishIndex {
+            XCTAssertLessThan(assistantInsertIndex, errorIndex,
+                              "Partial assistant insert precedes the inference error event")
+            XCTAssertLessThan(errorIndex, finishIndex,
+                              "Inference error precedes the terminal event")
+        }
+    }
+
+    func test_finishState_thinkingOnlySuccess_finalizesThinkingThenDropsEmptyAssistant() async throws {
+        let mock = MockInferenceBackend()
+        mock.thinkingBlocksToYield = [["plan"]]
+        mock.signaturesPerThinkingBlock = ["sig-thinking"]
+        mock.tokensToYield = []
+        let (runtime, store, _, _) = makeRuntime(mock: mock)
+
+        _ = try await runtime.send(SendInput(sessionID: UUID(), userText: "think only"))
+        let events = try await collectEvents(from: runtime) { event in
+            if case .afterGeneration = event { return true }
+            return false
+        }
+
+        XCTAssertEqual(streamFinishedReasons(in: events), [.empty],
+                       "Thinking-only success currently has no visible assistant text and finishes as empty")
+        XCTAssertEqual(store.messages.values.filter { $0.role == .assistant }.count, 0,
+                       "Thinking-only output must not leave an empty assistant in the transcript")
+        let finalized = events.compactMap { event -> (String, String?)? in
+            if case let .thinkingFinalized(_, text, signature) = event { return (text, signature) }
+            return nil
+        }
+        XCTAssertEqual(finalized.count, 1)
+        XCTAssertEqual(finalized.first?.0, "plan")
+        XCTAssertEqual(finalized.first?.1, "sig-thinking")
+    }
+
+    func test_finishState_thinkingOnlyError_finalizesThinkingThenErrorsWithoutAssistantInsert() async throws {
+        let mock = MockInferenceBackend()
+        mock.thinkingBlocksToYield = [["reason"]]
+        mock.tokensToYield = []
+        mock.shouldThrowInsideStream = InferenceError.inferenceFailure("thinking failed")
+        let (runtime, store, _, _) = makeRuntime(mock: mock)
+
+        _ = try await runtime.send(SendInput(sessionID: UUID(), userText: "think fail"))
+        let events = try await collectUntilStreamFinished(from: runtime)
+
+        XCTAssertEqual(streamFinishedReasons(in: events), [.stop],
+                       "Thinking-only stream error emits exactly one terminal event")
+        XCTAssertEqual(store.messages.values.filter { $0.role == .assistant }.count, 0,
+                       "Thinking-only error without visible text does not persist an assistant")
+        let finalizedIndex = events.firstIndex {
+            if case .thinkingFinalized = $0 { return true }
+            return false
+        }
+        let errorIndex = events.firstIndex {
+            if case let .errorRaised(error) = $0, case .inference = error { return true }
+            return false
+        }
+        XCTAssertNotNil(finalizedIndex)
+        XCTAssertNotNil(errorIndex)
+        if let finalizedIndex, let errorIndex {
+            XCTAssertLessThan(finalizedIndex, errorIndex,
+                              "Thinking block is finalized before the inference error is surfaced")
+        }
+    }
+
+    func test_finishState_assistantInsertFailure_emitsPersistenceErrorBeforeSingleStopTerminal() async throws {
+        let mock = MockInferenceBackend()
+        mock.tokensToYield = ["will not persist"]
+        let gate = TokenEmissionGate()
+        mock.tokenEmissionGate = gate
+        let (runtime, store, _, _) = makeRuntime(mock: mock)
+
+        let drain = drainUntilStreamFinished(from: runtime)
+        _ = try await runtime.send(SendInput(
+            sessionID: UUID(),
+            userText: "persist fail",
+            streamingBatchCharacterLimit: 1
+        ))
+        store.insertError = ChatPersistenceError.providerNotConfigured
+        await gate.advance()
+
+        let events = try await waitForEvents(from: drain)
+
+        XCTAssertEqual(streamFinishedReasons(in: events), [.stop],
+                       "Assistant insert failure still emits exactly one terminal event")
+        XCTAssertEqual(store.messages.values.filter { $0.role == .assistant }.count, 0,
+                       "Failed assistant insert must not leave transcript state behind")
+        let persistenceErrorIndex = events.firstIndex {
+            if case let .errorRaised(error) = $0, case .persistence = error { return true }
+            return false
+        }
+        let finishIndex = events.firstIndex {
+            if case .streamFinished = $0 { return true }
+            return false
+        }
+        XCTAssertNotNil(persistenceErrorIndex)
+        XCTAssertNotNil(finishIndex)
+        if let persistenceErrorIndex, let finishIndex {
+            XCTAssertLessThan(persistenceErrorIndex, finishIndex,
+                              "Persistence error is surfaced before the terminal event")
+        }
+        XCTAssertFalse(events.contains {
+            if case .afterGeneration = $0 { return true }
+            return false
+        }, "afterGeneration is skipped when final assistant persistence fails")
+    }
+
     // MARK: - Inference error
 
     func test_send_inferenceErrorAtStream_emitsErrorRaised() async throws {
@@ -357,6 +792,85 @@ final class ConversationRuntimeTests: XCTestCase {
             return false
         }
         XCTAssertTrue(hasError, "errorRaised(.inference) fires on mid-stream failure")
+    }
+
+    // MARK: - Token usage
+
+    func test_send_tokenUsageEventPinsPerStreamUsageAcrossBackToBackSends() async throws {
+        let backend = RuntimeUsageBackend(turns: [
+            .init(tokens: ["one"], usage: (promptTokens: 11, completionTokens: 1)),
+            .init(tokens: ["two"], usage: (promptTokens: 22, completionTokens: 2))
+        ])
+        let inference = InferenceService(backend: backend, name: "Usage")
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(messageStore: store, inferenceService: inference)
+        let drain = Task { @MainActor [runtime] in
+            var events: [ConversationEvent] = []
+            var completedTurns = 0
+            for await event in runtime.events {
+                events.append(event)
+                if case .afterGeneration = event {
+                    completedTurns += 1
+                    if completedTurns == 2 { return events }
+                }
+            }
+            return events
+        }
+
+        let sessionID = UUID()
+        _ = try await runtime.send(SendInput(sessionID: sessionID, userText: "first"))
+        _ = try await runtime.send(SendInput(sessionID: sessionID, userText: "second"))
+
+        let events = try await waitForEvents(from: drain)
+        let usageEvents = events.compactMap { event -> (prompt: Int, completion: Int)? in
+            if case let .tokenUsageRecorded(_, promptTokens, completionTokens) = event {
+                return (promptTokens, completionTokens)
+            }
+            return nil
+        }
+
+        XCTAssertEqual(usageEvents.map { $0.prompt }, [11, 22],
+                       "Each turn emits its own prompt-token usage")
+        XCTAssertEqual(usageEvents.map { $0.completion }, [1, 2],
+                       "Each turn emits its own completion-token usage")
+
+        let assistants = store.messages.values
+            .filter { $0.role == .assistant }
+            .sorted { $0.timestamp < $1.timestamp }
+        XCTAssertEqual(assistants.map(\.content), ["one", "two"])
+        XCTAssertEqual(assistants.compactMap(\.promptTokens), [11, 22],
+                       "Persisted assistant usage is pinned per turn, not overwritten by the next send")
+        XCTAssertEqual(assistants.compactMap(\.completionTokens), [1, 2])
+    }
+
+    func test_send_tokenUsageSurvivesPartialStreamError() async throws {
+        let backend = RuntimeUsageBackend(turns: [
+            .init(
+                tokens: ["partial"],
+                usage: (promptTokens: 31, completionTokens: 4),
+                streamErrorMessage: "usage after partial"
+            )
+        ])
+        let inference = InferenceService(backend: backend, name: "Usage")
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(messageStore: store, inferenceService: inference)
+
+        _ = try await runtime.send(SendInput(sessionID: UUID(), userText: "fail with usage"))
+        let events = try await collectUntilStreamFinished(from: runtime)
+
+        XCTAssertTrue(events.contains {
+            if case .tokenUsageRecorded(_, 31, 4) = $0 { return true }
+            return false
+        }, "Usage is observable even when the stream later errors")
+        XCTAssertTrue(events.contains {
+            if case let .errorRaised(error) = $0, case .inference = error { return true }
+            return false
+        }, "The inference error is still surfaced")
+
+        let assistant = store.messages.values.first { $0.role == .assistant }
+        XCTAssertEqual(assistant?.content, "partial")
+        XCTAssertEqual(assistant?.promptTokens, 31)
+        XCTAssertEqual(assistant?.completionTokens, 4)
     }
 
     // MARK: - Cancellation
@@ -505,6 +1019,33 @@ final class ConversationRuntimeTests: XCTestCase {
                                     "Session updatedAt is touched at least once per send")
     }
 
+    func test_send_touchSessionFailureEmitsEventButDoesNotFailTurn() async throws {
+        let mock = MockInferenceBackend()
+        mock.tokensToYield = ["ok"]
+        let sessions = RuntimeSessionStore()
+        let original = ChatSessionRecord(title: "Test")
+        try await sessions.insertSession(original)
+        sessions.updateError = ChatPersistenceError.sessionNotFound(original.id)
+
+        let (runtime, store, _, _) = makeRuntime(mock: mock, sessionStore: sessions)
+
+        _ = try await runtime.send(SendInput(sessionID: original.id, userText: "hi"))
+        let events = try await collectEvents(from: runtime) { event in
+            if case .afterGeneration = event { return true }
+            return false
+        }
+
+        XCTAssertTrue(events.contains {
+            if case let .sessionTouchFailed(id) = $0 { return id == original.id }
+            return false
+        }, "touchSession failure is observable without becoming a user-turn error")
+        XCTAssertFalse(events.contains {
+            if case let .errorRaised(error) = $0, case .persistence = error { return true }
+            return false
+        }, "Sidebar timestamp failures must not surface as turn-failing persistence errors")
+        XCTAssertEqual(store.messages.values.filter { $0.role == .assistant }.map(\.content), ["ok"])
+    }
+
     // MARK: - Helpers
 
     private func eventKind(_ event: ConversationEvent) -> String {
@@ -517,6 +1058,8 @@ final class ConversationRuntimeTests: XCTestCase {
             return "messageUpdated-\(record.role.rawValue)"
         case .streamStarted: return "streamStarted"
         case let .tokenEmitted(_, delta): return "tokenEmitted(\(delta))"
+        case let .tokenUsageRecorded(_, promptTokens, completionTokens):
+            return "tokenUsageRecorded(\(promptTokens),\(completionTokens))"
         case let .streamFinished(_, reason):
             switch reason {
             case .stop: return "streamFinished-stop"
@@ -525,6 +1068,7 @@ final class ConversationRuntimeTests: XCTestCase {
             case .length: return "streamFinished-length"
             }
         case .errorRaised: return "errorRaised"
+        case .sessionTouchFailed: return "sessionTouchFailed"
         case .beforeContextAssembly: return "beforeContextAssembly"
         case .contextAssembled: return "contextAssembled"
         case .afterGeneration: return "afterGeneration"

--- a/Tests/BaseChatRuntimeTests/EmptyResponseDiagnosticTests.swift
+++ b/Tests/BaseChatRuntimeTests/EmptyResponseDiagnosticTests.swift
@@ -129,4 +129,55 @@ final class EmptyResponseDiagnosticTests: XCTestCase {
         XCTAssertTrue(persistedAsst, "Happy path: assistant should persist")
         XCTAssertTrue(box.snapshot.isEmpty, "Observer must not fire when the assistant streamed content")
     }
+
+    func test_emptyStreamError_doesNotFireObserver() async throws {
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = []
+        backend.shouldThrowInsideStream = InferenceError.inferenceFailure("empty failure")
+
+        let inference = InferenceService(backend: backend, name: "FailingBackend")
+        let store = FakeMessageStore()
+        let box = DiagnosticBox()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            sessionStore: nil,
+            inferenceService: inference,
+            pipeline: nil,
+            emptyResponseObserver: { d in box.append(d) }
+        )
+
+        let drain = Task.detached { [runtime] in
+            for await event in runtime.events {
+                if case .streamFinished = event { return }
+            }
+        }
+
+        let sessionID = UUID()
+        _ = try await runtime.send(SendInput(sessionID: sessionID, userText: "fail empty"))
+        try await wait(for: drain)
+
+        XCTAssertTrue(box.snapshot.isEmpty,
+                      "Observer must not fire when an empty turn failed instead of being dropped")
+        let persisted = try await store.fetchMessages(for: sessionID)
+        XCTAssertEqual(persisted.filter { $0.role == .assistant }.count, 0,
+                       "Failed empty assistant must remain unpersisted")
+    }
+
+    private func wait(for task: Task<Void, Never>) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { await task.value }
+            group.addTask {
+                try await Task.sleep(for: .seconds(3))
+                task.cancel()
+                throw TestError.deadlineElapsed
+            }
+            try await group.next()
+            group.cancelAll()
+        }
+    }
+
+    private enum TestError: Error {
+        case deadlineElapsed
+    }
 }

--- a/Tests/BaseChatRuntimeTests/ImageGenerationRuntimeTests.swift
+++ b/Tests/BaseChatRuntimeTests/ImageGenerationRuntimeTests.swift
@@ -492,12 +492,14 @@ final class ImageGenerationRuntimeTests: XCTestCase {
             .sessionBranched(newSessionID: UUID(), copiedCount: 0),
             .streamStarted(messageID: UUID()),
             .tokenEmitted(messageID: UUID(), delta: ""),
+            .tokenUsageRecorded(messageID: UUID(), promptTokens: 0, completionTokens: 0),
             .thinkingStarted(messageID: UUID()),
             .thinkingUpdated(messageID: UUID(), partialText: ""),
             .thinkingFinalized(messageID: UUID(), text: "", signature: nil),
             .loopDetected(messageID: UUID()),
             .streamFinished(messageID: UUID(), reason: .stop),
             .errorRaised(.cancelled),
+            .sessionTouchFailed(sessionID: UUID()),
             .beforeContextAssembly(prompt: nil, request: PromptContextRequest(sessionID: UUID(), messageCount: 0, userInput: nil)),
             .contextAssembled(slots: []),
             .afterGeneration(messageID: UUID(), finalText: ""),
@@ -511,8 +513,9 @@ final class ImageGenerationRuntimeTests: XCTestCase {
         for event in samples {
             switch event {
             case .messageInserted, .messageRemoved, .messageUpdated, .sessionBranched,
-                 .streamStarted, .tokenEmitted, .thinkingStarted, .thinkingUpdated,
-                 .thinkingFinalized, .loopDetected, .streamFinished, .errorRaised,
+                 .streamStarted, .tokenEmitted, .tokenUsageRecorded,
+                 .thinkingStarted, .thinkingUpdated, .thinkingFinalized,
+                 .loopDetected, .streamFinished, .errorRaised, .sessionTouchFailed,
                  .beforeContextAssembly, .contextAssembled, .afterGeneration,
                  .compressionTriggered, .toolCallRequested, .toolCallApproved,
                  .toolCallCompleted:
@@ -521,6 +524,6 @@ final class ImageGenerationRuntimeTests: XCTestCase {
         }
         // Pin the exact case count as a runtime assertion too — the
         // sample list is the source of truth.
-        XCTAssertEqual(samples.count, 19, "ConversationEvent case count drifted — image-side cases may have leaked in")
+        XCTAssertEqual(samples.count, 21, "ConversationEvent case count drifted — image-side cases may have leaked in")
     }
 }

--- a/Tests/BaseChatServerTests/BaseChatServerSmokeTests.swift
+++ b/Tests/BaseChatServerTests/BaseChatServerSmokeTests.swift
@@ -315,6 +315,98 @@ final class BaseChatServerSmokeTests: XCTestCase {
         }
     }
 
+    func testUnsupportedToolRequestReturnsClearInvalidRequestError() async throws {
+        let server = ServerApp(
+            backendProvider: FakeBackendProvider(models: ["tiny"]),
+            adapter: FixedChatAdapter()
+        )
+        let app = server.makeApplication()
+
+        try await app.test(.router) { client in
+            let request = ChatCompletionRequest(
+                model: "tiny",
+                messages: [.init(role: "user", content: "hi")],
+                tools: [ChatCompletionTool(function: ChatCompletionFunctionDefinition(name: "lookup"))]
+            )
+            let body = try requestBody(request)
+
+            try await client.execute(uri: "/v1/chat/completions", method: .post, body: body) { response in
+                XCTAssertEqual(response.status, .badRequest)
+                XCTAssertTrue(
+                    response.headers[.contentType]?.contains("application/json") == true,
+                    "Capability errors must be JSON"
+                )
+                let envelope = try JSONDecoder().decode(
+                    ChatCompletionErrorEnvelope.self,
+                    from: Data(buffer: response.body)
+                )
+                XCTAssertEqual(envelope.error.type, "invalid_request_error")
+                XCTAssertEqual(envelope.error.param, "tools")
+                XCTAssertEqual(envelope.error.code, "unsupported_capability")
+                XCTAssertTrue(envelope.error.message.contains("tool calling"))
+            }
+        }
+    }
+
+    func testUnsupportedStreamingResponseFormatReturnsJSONErrorBeforeSSE() async throws {
+        let server = ServerApp(
+            backendProvider: FakeBackendProvider(models: ["tiny"]),
+            adapter: FixedStreamingChatAdapter()
+        )
+        let app = server.makeApplication()
+
+        try await app.test(.router) { client in
+            let request = ChatCompletionRequest(
+                model: "tiny",
+                messages: [.init(role: "user", content: "hi")],
+                stream: true,
+                responseFormat: ChatCompletionResponseFormat(type: .jsonObject)
+            )
+            let body = try requestBody(request)
+
+            try await client.execute(uri: "/v1/chat/completions", method: .post, body: body) { response in
+                XCTAssertEqual(response.status, .badRequest)
+                XCTAssertTrue(
+                    response.headers[.contentType]?.contains("application/json") == true,
+                    "Pre-stream capability errors must be JSON"
+                )
+                XCTAssertNotEqual(response.headers[.contentType], "text/event-stream")
+                let envelope = try JSONDecoder().decode(
+                    ChatCompletionErrorEnvelope.self,
+                    from: Data(buffer: response.body)
+                )
+                XCTAssertEqual(envelope.error.type, "invalid_request_error")
+                XCTAssertEqual(envelope.error.param, "response_format")
+                XCTAssertTrue(envelope.error.message.contains("native JSON mode"))
+            }
+        }
+    }
+
+    func testToolRequestSucceedsWhenBackendAdvertisesToolCalling() async throws {
+        let backend = MockInferenceBackend(capabilities: BackendCapabilities(supportsToolCalling: true))
+        let server = ServerApp(
+            backendProvider: FakeBackendProvider(models: ["tiny"], backend: backend),
+            adapter: FixedChatAdapter(content: "tool ready")
+        )
+        let app = server.makeApplication()
+
+        try await app.test(.router) { client in
+            let request = ChatCompletionRequest(
+                model: "tiny",
+                messages: [.init(role: "user", content: "hi")],
+                tools: [ChatCompletionTool(function: ChatCompletionFunctionDefinition(name: "lookup"))],
+                toolChoice: .function(name: "lookup")
+            )
+            let body = try requestBody(request)
+
+            try await client.execute(uri: "/v1/chat/completions", method: .post, body: body) { response in
+                XCTAssertEqual(response.status, .ok)
+                let completion = try JSONDecoder().decode(ChatCompletionResponse.self, from: Data(buffer: response.body))
+                XCTAssertEqual(completion.content, "tool ready")
+            }
+        }
+    }
+
     func testMalformedRequestBodyReturnsError() async throws {
         let server = ServerApp(
             backendProvider: FakeBackendProvider(models: ["tiny"]),
@@ -355,7 +447,12 @@ private func requestBody(_ request: ChatCompletionRequest) throws -> ByteBuffer 
 
 private struct FakeBackendProvider: ServerBackendProvider {
     let models: [String]
-    let backend = MockInferenceBackend()
+    let backend: any InferenceBackend
+
+    init(models: [String], backend: any InferenceBackend = MockInferenceBackend()) {
+        self.models = models
+        self.backend = backend
+    }
 
     func listModels() async throws -> [String] {
         models

--- a/Tests/BaseChatUITests/ChatViewModelRegistryForwardingTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelRegistryForwardingTests.swift
@@ -149,7 +149,7 @@ final class ChatViewModelRegistryForwardingTests: XCTestCase {
         let vm = try makeViewModel()
 
         // Pre-condition: an endpoint is selected.
-        let endpoint = APIEndpoint(name: "Test", provider: .openAI)
+        let endpoint = APIEndpointRecord(name: "Test", provider: .openAI)
         vm.availableEndpoints = [endpoint]
         vm.selectedEndpoint = endpoint
         XCTAssertNotNil(vm.selectedEndpoint)

--- a/Tests/BaseChatUITests/LoadDispatchCoordinationTests.swift
+++ b/Tests/BaseChatUITests/LoadDispatchCoordinationTests.swift
@@ -39,8 +39,8 @@ final class LoadDispatchCoordinationTests: XCTestCase {
         )
     }
 
-    private func makeEndpoint(name: String, provider: APIProvider, modelName: String) -> APIEndpoint {
-        APIEndpoint(
+    private func makeEndpoint(name: String, provider: APIProvider, modelName: String) -> APIEndpointRecord {
+        APIEndpointRecord(
             name: name,
             provider: provider,
             baseURL: provider.defaultBaseURL,

--- a/Tests/BaseChatUITests/RuntimeConfigurationTests.swift
+++ b/Tests/BaseChatUITests/RuntimeConfigurationTests.swift
@@ -125,4 +125,50 @@ final class RuntimeConfigurationTests: XCTestCase {
         let persistedIDs = try await runtime.persistence.fetchSessions().map(\.id)
         XCTAssertEqual(persistedIDs, [initialSession.id])
     }
+
+    func test_configureRuntime_loadsEndpointsAndSwitchUsesFreshEndpointRecords() async throws {
+        let originalConfiguration = BaseChatConfiguration.shared
+        defer { BaseChatConfiguration.shared = originalConfiguration }
+
+        let runtime = try BaseChatBootstrap(
+            configuration: BaseChatConfiguration(
+                appName: "Endpoint Bootstrap Tests",
+                bundleIdentifier: "com.basechatkit.runtime-ui-tests.endpoints"
+            ),
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+
+        let endpointID = UUID()
+        let originalEndpoint = APIEndpointRecord(
+            id: endpointID,
+            name: "Original Endpoint",
+            provider: .openAI,
+            baseURL: "https://api.openai.com/v1",
+            modelName: "old-model"
+        )
+        try await runtime.endpointStore.insertEndpoint(originalEndpoint)
+
+        var session = ChatSessionRecord(title: "Endpoint Session")
+        session.selectedEndpointID = endpointID
+        try await runtime.persistence.insertSession(session)
+
+        let chatViewModel = ChatViewModel(inferenceService: runtime.inferenceService)
+        chatViewModel.configure(runtime: runtime)
+        await chatViewModel.endpointRefreshTask?.value
+
+        XCTAssertEqual(chatViewModel.availableEndpoints.map(\.id), [endpointID],
+            "configure(runtime:) should load selectable endpoints through the runtime endpoint store")
+
+        var freshEndpoint = originalEndpoint
+        freshEndpoint.name = "Fresh Endpoint"
+        freshEndpoint.modelName = "fresh-model"
+        try await runtime.endpointStore.updateEndpoint(freshEndpoint)
+
+        await chatViewModel.switchToSession(session)
+
+        XCTAssertEqual(chatViewModel.selectedEndpoint?.id, endpointID)
+        XCTAssertEqual(chatViewModel.selectedEndpoint?.name, "Fresh Endpoint",
+            "switchToSession should resolve selectedEndpointID from freshly fetched endpoint records")
+        XCTAssertEqual(chatViewModel.selectedEndpoint?.modelName, "fresh-model")
+    }
 }

--- a/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
+++ b/Tests/BaseChatUITests/ViewModelEdgeCaseTests.swift
@@ -271,7 +271,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         let vm = await makeViewModel()
         vm.selectedModel = ModelInfo.builtInFoundation
 
-        let endpoint = APIEndpoint(name: "OpenAI", provider: .openAI)
+        let endpoint = APIEndpointRecord(name: "OpenAI", provider: .openAI)
         vm.selectedEndpoint = endpoint
 
         XCTAssertNil(vm.selectedModel, "Selecting an endpoint should clear selectedModel")
@@ -280,7 +280,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
 
     func test_selectionMutualExclusion_selectingModel_clearsEndpoint() async {
         let vm = await makeViewModel()
-        let endpoint = APIEndpoint(name: "OpenAI", provider: .openAI)
+        let endpoint = APIEndpointRecord(name: "OpenAI", provider: .openAI)
         vm.selectedEndpoint = endpoint
 
         vm.selectedModel = ModelInfo.builtInFoundation
@@ -291,7 +291,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
 
     func test_switchToSession_restoresSelectedEndpoint_whenEndpointExists() async throws {
         let (vm, _, _) = try makeViewModelWithPersistence()
-        let endpoint = APIEndpoint(name: "OpenAI", provider: .openAI)
+        let endpoint = APIEndpointRecord(name: "OpenAI", provider: .openAI)
         vm.setAvailableEndpoints([endpoint])
         vm.selectedModel = ModelInfo.builtInFoundation
 
@@ -307,7 +307,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
 
     func test_switchToSession_clearsSelectedEndpoint_whenEndpointMissing() async throws {
         let (vm, _, _) = try makeViewModelWithPersistence()
-        let oldEndpoint = APIEndpoint(name: "Old", provider: .openAI)
+        let oldEndpoint = APIEndpointRecord(name: "Old", provider: .openAI)
         vm.setAvailableEndpoints([oldEndpoint])
         vm.selectedEndpoint = oldEndpoint
 
@@ -319,10 +319,33 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         XCTAssertNil(vm.selectedEndpoint, "Missing endpoint should clear selectedEndpoint")
     }
 
+    func test_switchToSession_clearsSelectedEndpoint_whenSessionHasNoEndpointID() async throws {
+        let (vm, _, _) = try makeViewModelWithPersistence()
+        let oldEndpoint = APIEndpointRecord(name: "Old", provider: .openAI)
+        vm.setAvailableEndpoints([oldEndpoint])
+        vm.selectedEndpoint = oldEndpoint
+
+        let session = ChatSessionRecord(title: "Local Model Session")
+
+        await vm.switchToSession(session)
+
+        XCTAssertNil(vm.selectedEndpoint, "A session without selectedEndpointID should not keep the prior endpoint")
+    }
+
+    func test_setAvailableEndpoints_filtersDisabledEndpoints() async {
+        let vm = await makeViewModel()
+        let enabled = APIEndpointRecord(name: "Enabled", provider: .openAI, isEnabled: true)
+        let disabled = APIEndpointRecord(name: "Disabled", provider: .claude, isEnabled: false)
+
+        vm.setAvailableEndpoints([enabled, disabled])
+
+        XCTAssertEqual(vm.availableEndpoints.map(\.id), [enabled.id])
+    }
+
     func test_switchToSession_doesNotPersistNilSelectionWhenEndpointUnavailable() async throws {
         let (vm, _, persistence) = try makeViewModelWithPersistence()
 
-        let endpoint = APIEndpoint(name: "Delayed Endpoint", provider: .openAI)
+        let endpoint = APIEndpointRecord(name: "Delayed Endpoint", provider: .openAI)
         var session = ChatSessionRecord(title: "Deferred Endpoint Session")
         session.selectedEndpointID = endpoint.id
         try await persistence.insertSession(session)
@@ -340,7 +363,7 @@ final class ViewModelEdgeCaseTests: XCTestCase {
 
     func test_saveSettingsToSession_persistsSelectedEndpointID() async throws {
         let (vm, _, persistence) = try makeViewModelWithPersistence()
-        let endpoint = APIEndpoint(name: "Claude", provider: .claude)
+        let endpoint = APIEndpointRecord(name: "Claude", provider: .claude)
         vm.setAvailableEndpoints([endpoint])
 
         let session = ChatSessionRecord(title: "Persist Endpoint Session")


### PR DESCRIPTION
## Summary

This PR bundles the overnight architecture-improvement waves into one reviewable batch. It focuses on higher-leverage correctness and boundary work rather than broad feature expansion:

1. Runtime turn-loop correctness and observability
2. UI/persistence dependency boundary cleanup
3. Backend capability honesty and server request validation
4. Shift-left docs, fuzz positioning, and architectural tripwires

## Wave 1: Runtime correctness and observability

Strengthens the `ConversationRuntime` and inference queue contracts so terminal behavior is explicit and regression-tested.

- Adds finish-state coverage for success, empty output, cancellation before/after partial output, stream errors, thinking-only output, and persistence insert failures.
- Adds runtime events for token usage and session-touch failures so telemetry is observable without relying only on transient service state.
- Keeps sidebar/session timestamp failures best-effort: user turns do not fail because a session touch failed, but the failure is now visible.
- Expands `GenerationQueue` preflight/trim coverage for nil output reserve, reserve larger than context, trim-attempt exhaustion, system-only/assistant-only histories, preserving latest user input, and token-counter failures.

Key files:
- `Sources/BaseChatRuntime/Services/ConversationRuntime.swift`
- `Sources/BaseChatRuntime/Services/ConversationEvent.swift`
- `Sources/BaseChatInference/Services/GenerationQueue.swift`
- `Tests/BaseChatRuntimeTests/ConversationRuntimeTests.swift`
- `Tests/BaseChatInferenceTests/GenerationQueueTests.swift`

## Wave 2: UI/persistence boundary cleanup

Removes the direct `BaseChatUI -> BaseChatPersistenceSwiftData` dependency and moves UI-facing endpoint state to persistence-agnostic records/runtime ports.

- Introduces `ChatRuntimeBootstrap` as the runtime-facing bootstrap protocol consumed by UI view models.
- Moves pure `ConversationExporter`/`ShareableFile` support into `BaseChatRuntime`, leaving persistence convenience wrapping in the SwiftData target.
- Updates chat endpoint state/loading to use `APIEndpointRecord` and `EndpointStore` instead of SwiftData `@Model` endpoint types.
- Wires `BaseChatBootstrap.endpointStore` through the runtime bootstrap seam so chat endpoint restoration uses the same container-backed store as settings.
- Refreshes endpoint records during session switching before restoring `selectedEndpointID`, including missing/deleted/disabled endpoint behavior.
- Cancels runtime/image/endpoint drain tasks in `ChatViewModel.deinit` and weakens image-drain captures to avoid leaked view model/task crashes in tests.

Key files:
- `Package.swift`
- `Sources/BaseChatRuntime/Services/ChatRuntimeBootstrap.swift`
- `Sources/BaseChatRuntime/Services/ConversationExporter.swift`
- `Sources/BaseChatPersistenceSwiftData/BaseChatBootstrap.swift`
- `Sources/BaseChatUI/ViewModels/RuntimeConfiguration.swift`
- `Sources/BaseChatUI/ViewModels/ChatViewModel.swift`
- `Sources/BaseChatUI/ViewModels/ChatViewModel+SessionManagement.swift`
- `Tests/BaseChatPersistenceSwiftDataTests/SwiftDataEndpointStoreRegressionTests.swift`
- `Tests/BaseChatUITests/RuntimeConfigurationTests.swift`

## Wave 3: Backend capability honesty and server validation

Makes advertised backend capabilities more honest and adds request-level validation so unsupported features fail early and clearly.

- Adds a backend capability matrix covering tool, vision, JSON, and thinking-hint behavior with CI-safe mocks.
- Adds `BackendVisionCapability` gates so Llama/MLX/OpenAI/Claude/OpenAI Responses vision claims reflect usable support.
- Keeps OpenAI Responses vision disabled until `input_image` encoding exists.
- Adds tool-call streaming lifecycle validation for `toolCallStart -> toolCallArgumentsDelta -> toolCall`, including out-of-order and interleaved delta cases.
- Normalizes/checks local whole-call tool output behavior against streaming cloud behavior.
- Adds `ServerError.invalidRequest` and OpenAI-style `invalid_request_error` envelopes for unsupported request capabilities.
- Validates unsupported tools/required tool choice, JSON object/schema response formats, and unsupported system/developer messages before SSE streaming begins.
- Fixes the Server-trait route path so typed invalid-request errors do not collapse into `500/server_error`.
- Fixes a Foundation backend cancellation race by clearing `isGenerating` synchronously and guarding old-generation cleanup from clobbering new generation state.

Key files:
- `Sources/BaseChatBackends/BackendVisionCapability.swift`
- `Sources/BaseChatBackends/FoundationBackend.swift`
- `Sources/BaseChatBackends/OpenAIBackend.swift`
- `Sources/BaseChatBackends/ClaudeBackend.swift`
- `Sources/BaseChatBackends/OpenAIResponsesBackend.swift`
- `Sources/BaseChatServer/ServerApp.swift`
- `Sources/BaseChatServer/ServerError.swift`
- `Sources/BaseChatServer/ChatCompletionsAdapter.swift`
- `Tests/BaseChatInferenceTests/BackendCapabilityMatrixTests.swift`
- `Tests/BaseChatInferenceTests/ToolCallStreamingContractTests.swift`
- `Tests/BaseChatBackendsTests/BackendVisionCapabilityTests.swift`
- `Tests/BaseChatServerTests/BaseChatServerSmokeTests.swift`

## Wave 4: Shift-left docs, fuzz positioning, and tripwires

Updates reviewer/developer-facing material and adds guards so the architectural boundaries are harder to regress.

- Updates README/DocC/TESTING docs for the new UI endpoint/runtime-bootstrap boundary and runtime observability.
- Adds fuzz-regression positioning for runtime finish states, context trimming, tool streaming order, capability rejection, and server invalid-request handling without enabling new expensive CI fuzz gates.
- Strengthens `TrafficBoundaryAuditTest` so it blocks both source imports and manifest dependency regressions, including `BaseChatUI -> BaseChatPersistenceSwiftData/BaseChatBackends/BaseChatUIModelManagement`.
- Updates CI import lint so `BaseChatUI` has no persistence exceptions.
- Restores `Package.resolved` resolution churn; there is no intentional resolved-file change in this PR.

Key files:
- `README.md`
- `TESTING.md`
- `FUZZING.md`
- `Sources/BaseChatUI/BaseChatUI.docc/BaseChatUI.md`
- `Sources/BaseChatUI/BaseChatUI.docc/Articles/BuildingAChatUI.md`
- `.github/workflows/ci.yml`
- `Tests/BaseChatInferenceTests/TrafficBoundaryAuditTest.swift`

## Review notes

- This is intentionally one PR because the approved operating model was one branch/one PR-sized batch for the architecture waves.
- Hardware-gated MLX/Llama/Ollama paths remain opt-in; new coverage is CI-safe unless a trait is explicitly enabled.
- `Package.swift` changes are limited to the intended target-boundary cleanup. `Package.resolved` was restored after disabled-trait SwiftPM runs pruned trait-gated pins.
- Original dirty checkout was left untouched; work was done in `/Users/roryford/Repos/BaseChatKit-autopilot` on `autopilot/bck-architecture-waves`.

## Validation

Passed locally:

```bash
scripts/test.sh --filter BaseChatCoreTests --filter BaseChatRuntimeTests \
  --filter BaseChatPersistenceSwiftDataTests --filter BaseChatUITests \
  --filter BaseChatUIModelManagementTests --filter BaseChatMCPTests \
  --filter BaseChatBackendsTests --filter BaseChatInferenceTests \
  --filter BaseChatTestSupportTests --filter BaseChatAppIntentsTests \
  --filter BaseChatServerTests \
  --disable-default-traits --skip-update

scripts/test.sh --filter BaseChatInferenceSwiftTestingTests \
  --disable-default-traits --skip-update

git diff --check
```

Additional targeted gates were run during the waves, including runtime/inference, UI/persistence/model-management, Server-trait validation, backend/inference capability tests, and the boundary audit.

Logs are available locally at:

```text
/Users/roryford/Repos/BaseChatKit/tmp/autopilot-logs/20260505-231951/
```
