### PR TITLE
refactor: expose model readiness on InferenceService

### DIFF
--- a/Sources/BaseChatInference/Services/InferenceService.swift
+++ b/Sources/BaseChatInference/Services/InferenceService.swift
@@ -9,6 +9,21 @@ public typealias BackendFactory = @MainActor (ModelType) -> (any InferenceBacken
 /// Return `nil` if this factory does not handle the given provider.
 public typealias CloudBackendFactory = @MainActor (APIProvider) -> (any InferenceBackend)?
 
+/// Readiness state for the primary model managed by ``InferenceService``.
+public enum ModelLoadReadinessState: Equatable, Sendable {
+    /// No model is loaded and no load operation is currently in flight.
+    case idle
+    /// A model load is currently in flight.
+    case loading(progress: Double?)
+    /// The primary model is loaded and ready for generation.
+    case ready
+
+    /// Whether generation can be attempted against the primary backend.
+    public var isReady: Bool {
+        self == .ready
+    }
+}
+
 /// Orchestrates inference across multiple backends.
 ///
 /// Selects the appropriate backend based on model format and delegates all
@@ -71,6 +86,11 @@ public final class InferenceService {
     public var activeBackendName: String? { lifecycle.activeBackendName }
     public var activeModelName: String? { lifecycle.activeModelName }
     public var modelLoadProgress: Double? { lifecycle.modelLoadProgress }
+    public var modelLoadReadinessState: ModelLoadReadinessState {
+        if lifecycle.isModelLoaded { return .ready }
+        if let progress = lifecycle.modelLoadProgress { return .loading(progress: progress) }
+        return .idle
+    }
 
     /// The prompt template to apply for backends that require one (GGUF).
     public var selectedPromptTemplate: PromptTemplate {
@@ -179,6 +199,73 @@ public final class InferenceService {
         ensureProviderWired()
         generation.stopGeneration()
         lifecycle.unloadModel()
+    }
+
+    /// Streams primary-model readiness transitions.
+    ///
+    /// The stream yields the current state immediately, then yields subsequent
+    /// changes observed through Swift Observation. Values are buffered newest-only
+    /// so callers interested in readiness never build an event backlog.
+    public func modelLoadReadinessUpdates() -> AsyncStream<ModelLoadReadinessState> {
+        AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in
+            let observer = ModelLoadReadinessObserver(service: self, continuation: continuation)
+            continuation.onTermination = { _ in
+                Task { @MainActor in observer.cancel() }
+            }
+            observer.start()
+        }
+    }
+
+    /// Waits for an in-flight model load to finish before generation begins.
+    ///
+    /// - Returns: `true` when the model is already ready, or becomes ready within
+    ///   the compatibility timeout window. Returns `false` when no load is in
+    ///   progress, the load finishes without a ready model, timeout elapses, or
+    ///   the waiting task is cancelled.
+    public func waitUntilModelReady(
+        maxPollCount: Int = 300,
+        pollIntervalNanoseconds: UInt64 = 50_000_000
+    ) async -> Bool {
+        switch modelLoadReadinessState {
+        case .ready:
+            return true
+        case .idle:
+            return false
+        case .loading:
+            break
+        }
+
+        let timeoutNanoseconds = Self.modelReadyTimeoutNanoseconds(
+            maxPollCount: maxPollCount,
+            pollIntervalNanoseconds: pollIntervalNanoseconds
+        )
+
+        return await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                let updates = await self.modelLoadReadinessUpdates()
+                for await state in updates {
+                    if Task.isCancelled { return false }
+                    switch state {
+                    case .ready:
+                        return true
+                    case .idle:
+                        return false
+                    case .loading:
+                        continue
+                    }
+                }
+                return false
+            }
+            group.addTask {
+                guard timeoutNanoseconds > 0 else { return false }
+                try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+                return false
+            }
+
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
+        }
     }
 
     // MARK: - Generation
@@ -472,6 +559,15 @@ public final class InferenceService {
         }
     }
 
+    private nonisolated static func modelReadyTimeoutNanoseconds(
+        maxPollCount: Int,
+        pollIntervalNanoseconds: UInt64
+    ) -> UInt64 {
+        guard maxPollCount > 0, pollIntervalNanoseconds > 0 else { return 0 }
+        let (timeout, overflow) = UInt64(maxPollCount).multipliedReportingOverflow(by: pollIntervalNanoseconds)
+        return overflow ? UInt64.max : timeout
+    }
+
     // MARK: - Fast-Backend Dispatch
 
     /// Dispatches a backend-level generation request through the optional
@@ -546,6 +642,50 @@ public final class InferenceService {
     private func ensureProviderWired() {
         if generation.provider == nil {
             generation.provider = self
+        }
+    }
+}
+
+@MainActor
+private final class ModelLoadReadinessObserver {
+    private weak var service: InferenceService?
+    private let continuation: AsyncStream<ModelLoadReadinessState>.Continuation
+    private var isCancelled = false
+    private var lastState: ModelLoadReadinessState?
+
+    init(
+        service: InferenceService,
+        continuation: AsyncStream<ModelLoadReadinessState>.Continuation
+    ) {
+        self.service = service
+        self.continuation = continuation
+    }
+
+    func start() {
+        emitAndTrack()
+    }
+
+    func cancel() {
+        isCancelled = true
+    }
+
+    private func emitAndTrack() {
+        guard !isCancelled else { return }
+        guard let service else {
+            continuation.finish()
+            return
+        }
+
+        withObservationTracking {
+            let state = service.modelLoadReadinessState
+            if state != lastState {
+                lastState = state
+                continuation.yield(state)
+            }
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                self?.emitAndTrack()
+            }
         }
     }
 }

--- a/Tests/BaseChatInferenceTests/InferenceServiceObservationTests.swift
+++ b/Tests/BaseChatInferenceTests/InferenceServiceObservationTests.swift
@@ -170,17 +170,21 @@ final class InferenceServiceObservationTests: XCTestCase {
         service.registerBackendFactory { type in type == .gguf ? backend : nil }
 
         var iterator = service.modelLoadReadinessUpdates().makeAsyncIterator()
-        XCTAssertEqual(await iterator.next(), .idle)
+        // XCTAssertEqual takes non-async autoclosures; extract awaited values first.
+        let initialState = await iterator.next()
+        XCTAssertEqual(initialState, .idle)
 
         let loadTask = Task { try await service.loadModel(from: makeModelInfo()) }
         await backend.waitUntilLoadStarted()
 
-        XCTAssertEqual(await iterator.next(), .loading(progress: 0.0))
+        let loadingState = await iterator.next()
+        XCTAssertEqual(loadingState, .loading(progress: 0.0))
 
         await backend.releaseLoad()
         try await loadTask.value
 
-        XCTAssertEqual(await iterator.next(), .ready)
+        let readyState = await iterator.next()
+        XCTAssertEqual(readyState, .ready)
     }
 
     func test_waitUntilModelReady_returnsFalseWhenIdle() async {

--- a/Tests/BaseChatInferenceTests/InferenceServiceObservationTests.swift
+++ b/Tests/BaseChatInferenceTests/InferenceServiceObservationTests.swift
@@ -153,6 +153,77 @@ final class InferenceServiceObservationTests: XCTestCase {
         XCTAssertNil(service.modelLoadProgress)
     }
 
+    // MARK: - Model Load Readiness
+
+    func test_modelLoadReadinessUpdates_yieldsCurrentReadyState() async {
+        let service = InferenceService(backend: MockInferenceBackend(), name: "Mock")
+
+        var iterator = service.modelLoadReadinessUpdates().makeAsyncIterator()
+        let state = await iterator.next()
+
+        XCTAssertEqual(state, .ready)
+    }
+
+    func test_modelLoadReadinessUpdates_emitsLoadingAndReadyTransitions() async throws {
+        let service = InferenceService()
+        let backend = GatedLoadBackend()
+        service.registerBackendFactory { type in type == .gguf ? backend : nil }
+
+        var iterator = service.modelLoadReadinessUpdates().makeAsyncIterator()
+        XCTAssertEqual(await iterator.next(), .idle)
+
+        let loadTask = Task { try await service.loadModel(from: makeModelInfo()) }
+        await backend.waitUntilLoadStarted()
+
+        XCTAssertEqual(await iterator.next(), .loading(progress: 0.0))
+
+        await backend.releaseLoad()
+        try await loadTask.value
+
+        XCTAssertEqual(await iterator.next(), .ready)
+    }
+
+    func test_waitUntilModelReady_returnsFalseWhenIdle() async {
+        let service = InferenceService()
+
+        let ready = await service.waitUntilModelReady(maxPollCount: 5, pollIntervalNanoseconds: 0)
+
+        XCTAssertFalse(ready)
+    }
+
+    func test_waitUntilModelReady_awaitsInFlightLoad() async throws {
+        let service = InferenceService()
+        let backend = GatedLoadBackend()
+        service.registerBackendFactory { type in type == .gguf ? backend : nil }
+
+        let loadTask = Task { try await service.loadModel(from: makeModelInfo()) }
+        await backend.waitUntilLoadStarted()
+
+        let waitTask = Task { await service.waitUntilModelReady(maxPollCount: 50, pollIntervalNanoseconds: 50_000_000) }
+        await backend.releaseLoad()
+
+        let ready = await waitTask.value
+        try await loadTask.value
+
+        XCTAssertTrue(ready)
+    }
+
+    func test_waitUntilModelReady_timesOutWhenLoadNeverCompletes() async {
+        let service = InferenceService()
+        let backend = GatedLoadBackend()
+        service.registerBackendFactory { type in type == .gguf ? backend : nil }
+
+        let loadTask = Task { try await service.loadModel(from: makeModelInfo()) }
+        await backend.waitUntilLoadStarted()
+
+        let ready = await service.waitUntilModelReady(maxPollCount: 1, pollIntervalNanoseconds: 1_000_000)
+
+        XCTAssertFalse(ready)
+        loadTask.cancel()
+        await backend.releaseLoad()
+        _ = try? await loadTask.value
+    }
+
     // MARK: - Helpers
 
     private func makeModelInfo() -> ModelInfo {

--- a/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
+++ b/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
@@ -409,6 +409,15 @@ BaseChatUIModelManagement/Views/Models/ModelManagementSheet.swift:try? modelRegi
 BaseChatInference/Models/ModelInfo.swift:let candidates = (try? FileManager.default.contentsOfDirectory(
 
 # ---------------------------------------------------------------------------
+# BaseChatInference — waitUntilModelReady timeout sleep
+# ---------------------------------------------------------------------------
+
+# Timeout arm of the withTaskGroup race in waitUntilModelReady: group.cancelAll()
+# cancels this Task.sleep when the readiness stream wins first; swallowing
+# the CancellationError here is the intended "timer task exits cleanly" path.
+BaseChatInference/Services/InferenceService.swift:try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+
+# ---------------------------------------------------------------------------
 # BaseChatServer
 # ---------------------------------------------------------------------------
 

--- a/Tests/BaseChatUITests/ConsumerRuntimeHarness.swift
+++ b/Tests/BaseChatUITests/ConsumerRuntimeHarness.swift
@@ -36,10 +36,17 @@ final class ConsumerRuntimeHarness {
     /// Test-only initializer that lets a caller inject a throwing
     /// `makeModelContainer` closure, which exercises the rollback/cleanup
     /// path when bootstrap fails partway through.
+    ///
+    /// `temporaryDirectory` defaults to `FileManager.default.temporaryDirectory`.
+    /// Tests that inspect the cleanup path should pass a private directory so
+    /// their assertions are not polluted by sibling tests running in parallel
+    /// under `--parallel` execution — each harness dir is a child of this root,
+    /// so an isolated root keeps assertions narrow.
     init(
         inferenceService: InferenceService,
         toolApprovalGate: UIToolApprovalGate? = nil,
         foundationModelProvider: (@MainActor () -> Bool)? = nil,
+        temporaryDirectory: URL = FileManager.default.temporaryDirectory,
         makeModelContainer: @MainActor () throws -> ModelContainer
     ) throws {
         // Capture the live configuration before any mutation so the catch path
@@ -51,7 +58,7 @@ final class ConsumerRuntimeHarness {
             throw Error.userDefaultsSuiteAllocationFailed(suiteName)
         }
 
-        let directory = FileManager.default.temporaryDirectory
+        let directory = temporaryDirectory
             .appendingPathComponent("consumer-runtime-harness-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
 

--- a/Tests/BaseChatUITests/ConsumerRuntimeHarnessTests.swift
+++ b/Tests/BaseChatUITests/ConsumerRuntimeHarnessTests.swift
@@ -103,13 +103,14 @@ final class ConsumerRuntimeHarnessTests: XCTestCase {
 
     func test_init_throwingRuntime_restoresConfigurationAndCleansUp() throws {
         let originalConfiguration = BaseChatConfiguration.shared
-        let tmp = FileManager.default.temporaryDirectory
 
-        // Snapshot any existing harness tmp dirs so we can prove this run
-        // didn't leak one.
-        let prefix = "consumer-runtime-harness-"
-        let before = (try? FileManager.default.contentsOfDirectory(atPath: tmp.path)) ?? []
-        let beforeHarnessDirs = Set(before.filter { $0.hasPrefix(prefix) })
+        // Use a private temp root so the assertion is scoped to exactly this
+        // test run and cannot be polluted by sibling ConsumerRuntimeHarness
+        // instances created concurrently under --parallel execution.
+        let isolatedRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ConsumerRuntimeHarnessTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: isolatedRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: isolatedRoot) }
 
         let backend = MockInferenceBackend()
         var makeModelContainerInvoked = false
@@ -117,6 +118,7 @@ final class ConsumerRuntimeHarnessTests: XCTestCase {
         XCTAssertThrowsError(
             try ConsumerRuntimeHarness(
                 inferenceService: InferenceService(backend: backend, name: "RuntimeMock"),
+                temporaryDirectory: isolatedRoot,
                 makeModelContainer: {
                     makeModelContainerInvoked = true
                     throw URLError(.cannotOpenFile)
@@ -135,10 +137,11 @@ final class ConsumerRuntimeHarnessTests: XCTestCase {
             "Failed harness construction must roll BaseChatConfiguration.shared back to the value held before init"
         )
 
-        let after = (try? FileManager.default.contentsOfDirectory(atPath: tmp.path)) ?? []
-        let afterHarnessDirs = Set(after.filter { $0.hasPrefix(prefix) })
+        // All harness dirs inside our isolated root must have been removed on
+        // failure — nothing else writes here, so any survivor is a leak.
+        let remaining = (try? FileManager.default.contentsOfDirectory(atPath: isolatedRoot.path)) ?? []
         XCTAssertEqual(
-            afterHarnessDirs.subtracting(beforeHarnessDirs),
+            remaining,
             [],
             "Failed harness construction must remove the temp models directory it created"
         )


### PR DESCRIPTION
## Summary
- Add public ModelLoadReadinessState on BaseChatInference.InferenceService.
- Add modelLoadReadinessUpdates() as a newest-buffered AsyncStream driven by Swift Observation.
- Add waitUntilModelReady(maxPollCount:pollIntervalNanoseconds:) compatibility helper backed by readiness updates instead of host-app polling.
- Cover readiness state, stream transitions, wait success, idle, and timeout cases in InferenceServiceObservationTests.

## Validation
- swift build --disable-default-traits --target BaseChatInference ✅
- swift test --filter InferenceServiceObservationTests ❌ SwiftPM aborted with bare fatalError while building package test bundle/executables.
- swift test --disable-default-traits --filter BaseChatInferenceTests.InferenceServiceObservationTests ❌ same bare SwiftPM fatalError after compiling test targets.

## Fireside #517 handoff
This is the upstream additive API needed before Fireside can safely delete its local SharedModelGate awaitModelReady / InferenceService extension. Once merged, update Fireside to call the BCK API and remove the duplicate helper/tests.