### PR TITLE
fix: resolve Swift 6 @Sendable closure and mlx-swift-examples iOS platform conflict

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "81aa349ca25bae866c85052e64f3a728cdcccb77ed3ead24f9909b0ea8f2a0b6",
+  "originHash" : "fa47eda4744cc72b09d4f93af339d8c6c5325c46bc91547fdea8c3efa93c440c",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -11,38 +11,12 @@
       }
     },
     {
-      "identity" : "gzipswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/1024jp/GzipSwift",
-      "state" : {
-        "revision" : "731037f6cc2be2ec01562f6597c1d0aa3fe6fd05",
-        "version" : "6.0.1"
-      }
-    },
-    {
-      "identity" : "llama.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattt/llama.swift",
-      "state" : {
-        "revision" : "ecc45ab0ae45b92feae086bddc8e071be89eec3a",
-        "version" : "2.9012.0"
-      }
-    },
-    {
       "identity" : "mlx-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift.git",
       "state" : {
         "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
         "version" : "0.31.3"
-      }
-    },
-    {
-      "identity" : "mlx-swift-examples",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift-examples.git",
-      "state" : {
-        "revision" : "357c97fbd39abe600704b889dd114c208b0ed915"
       }
     },
     {
@@ -138,7 +112,7 @@
     {
       "identity" : "swift-numerics",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics.git",
+      "location" : "https://github.com/apple/swift-numerics",
       "state" : {
         "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
         "version" : "1.1.1"
@@ -165,7 +139,7 @@
     {
       "identity" : "swift-system",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system",
+      "location" : "https://github.com/apple/swift-system.git",
       "state" : {
         "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
         "version" : "1.6.4"

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fa47eda4744cc72b09d4f93af339d8c6c5325c46bc91547fdea8c3efa93c440c",
+  "originHash" : "81aa349ca25bae866c85052e64f3a728cdcccb77ed3ead24f9909b0ea8f2a0b6",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "llama.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/llama.swift",
+      "state" : {
+        "revision" : "ecc45ab0ae45b92feae086bddc8e071be89eec3a",
+        "version" : "2.9012.0"
       }
     },
     {
@@ -112,7 +121,7 @@
     {
       "identity" : "swift-numerics",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics",
+      "location" : "https://github.com/apple/swift-numerics.git",
       "state" : {
         "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
         "version" : "1.1.1"
@@ -139,7 +148,7 @@
     {
       "identity" : "swift-system",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system.git",
+      "location" : "https://github.com/apple/swift-system",
       "state" : {
         "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
         "version" : "1.6.4"

--- a/Package.swift
+++ b/Package.swift
@@ -54,15 +54,12 @@ let package = Package(
         // manual revision pin) and adds the `gemma4` model_type to LLMTypeRegistry so
         // mlx-community/gemma-4-* can load.
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", from: "3.31.3"),
-        // mlx-swift-examples ships the `StableDiffusion` library used by
-        // `MLXDiffusionBackend`. Pinned to the post-swift-transformers-1.3.0-bump
-        // commit on `main` (Apr 17 2026) — the latest tag (2.29.1) pins
-        // swift-transformers to 1.0.x which conflicts with BCK's 1.3.0+. Revision
-        // pin until upstream cuts a new tag. See umbrella issue #1002.
-        .package(
-            url: "https://github.com/ml-explore/mlx-swift-examples.git",
-            revision: "357c97fbd39abe600704b889dd114c208b0ed915"
-        ),
+        // mlx-swift-examples was previously a direct dependency for StableDiffusion.
+        // Its package manifest declared platforms: iOS 16 while depending on mlx-swift
+        // which requires iOS 17, causing a SPM platform-validation error for consumers.
+        // The StableDiffusion source (9 files, MIT) is now vendored in Sources/StableDiffusion.
+        // If upstream resolves the platform conflict and cuts a new tag, revert to the
+        // package dependency. Tracked in umbrella issue #1002.
         .package(url: "https://github.com/huggingface/swift-huggingface.git", from: "0.9.0"),
         .package(url: "https://github.com/huggingface/AnyLanguageModel", from: "0.8.0"),
         // Explicit dep required: mlx-swift-lm no longer pulls swift-transformers transitively.
@@ -156,6 +153,20 @@ let package = Package(
             ],
             path: "Sources/BaseChatPersistenceSwiftData"
         ),
+        // Vendored StableDiffusion (from mlx-swift-examples, MIT License).
+        // All sources are inside #if MLX guards so non-MLX builds compile to empty files.
+        // Dependencies: MLX + MLXNN from mlx-swift, Hub from swift-transformers (both already direct deps).
+        .target(
+            name: "StableDiffusion",
+            dependencies: [
+                .product(name: "MLX", package: "mlx-swift", condition: .when(traits: ["MLX"])),
+                .product(name: "MLXNN", package: "mlx-swift", condition: .when(traits: ["MLX"])),
+                .product(name: "Hub", package: "swift-transformers", condition: .when(traits: ["MLX"])),
+            ],
+            path: "Sources/StableDiffusion",
+            exclude: ["LICENSE"],
+            swiftSettings: [.define("MLX", .when(traits: ["MLX"]))]
+        ),
         // Backends: MLX, llama.cpp, Foundation, cloud
         .target(
             name: "BaseChatBackends",
@@ -173,11 +184,9 @@ let package = Package(
                 .product(name: "MLXVLM", package: "mlx-swift-lm", condition: .when(traits: ["MLX"])),
                 .product(name: "MLXHuggingFace", package: "mlx-swift-lm", condition: .when(traits: ["MLX"])),
                 .product(name: "Tokenizers", package: "swift-transformers", condition: .when(traits: ["MLX"])),
-                // StableDiffusion library from mlx-swift-examples, used by
-                // MLXDiffusionBackend (ImageGenerationBackend conformer).
-                // MLX-trait-gated so chat-only / default-trait builds don't pull
-                // the diffusion code into the link graph.
-                .product(name: "StableDiffusion", package: "mlx-swift-examples", condition: .when(traits: ["MLX"])),
+                // Vendored StableDiffusion (Sources/StableDiffusion), used by MLXDiffusionBackend.
+                // Replaces the mlx-swift-examples package dep which had a platform conflict (iOS 16 vs iOS 17).
+                .target(name: "StableDiffusion", condition: .when(traits: ["MLX"])),
                 .product(name: "LlamaSwift", package: "llama.swift", condition: .when(traits: ["Llama"])),
             ],
             path: "Sources/BaseChatBackends",

--- a/Sources/BaseChatBackends/MLX/MLXGenerationDriver.swift
+++ b/Sources/BaseChatBackends/MLX/MLXGenerationDriver.swift
@@ -79,15 +79,18 @@ struct MLXGenerationDriver {
         // converted from uncatchable `fatalError` calls into thrown Swift errors
         // that the caller can surface as InferenceError rather than crashing the app.
         //
-        // MLXError.ErrorCapture is @unchecked Sendable so the @Sendable handler
-        // can write into it; we read back on the same actor after generate() returns.
+        // The handler is @Sendable because MLX may invoke it from a C++ thread.
+        // MLXErrorCapture is @unchecked Sendable so it can safely cross the
+        // boundary. The body is @Sendable because all captured params (container,
+        // generationInput, cache, generateConfig) conform to Sendable; generate()
+        // handles its own actor isolation internally via ModelContainer.perform.
         final class MLXErrorCapture: @unchecked Sendable {
             var message: String?
         }
         let capture = MLXErrorCapture()
         let mlxStream = try await withErrorHandler(
-            { capture.message = capture.message ?? $0 }
-        ) { @MainActor in
+            { @Sendable in capture.message = capture.message ?? $0 }
+        ) { @Sendable in
             try await container.generate(
                 input: generationInput,
                 cache: cache,

--- a/Sources/StableDiffusion/Clip.swift
+++ b/Sources/StableDiffusion/Clip.swift
@@ -1,0 +1,141 @@
+// Vendored from github.com/ml-explore/mlx-swift-examples (MIT License, Copyright 2024 ml-explore)
+// See Sources/StableDiffusion/LICENSE for full terms.
+#if MLX
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+import MLX
+import MLXNN
+
+// port of https://github.com/ml-explore/mlx-examples/blob/main/stable_diffusion/stable_diffusion/clip.py
+
+struct CLIPOutput {
+    /// The lastHiddenState indexed at the EOS token and possibly projected if
+    /// the model has a projection layer
+    public var pooledOutput: MLXArray
+
+    /// The full sequence output of the transformer after the final layernorm
+    public var lastHiddenState: MLXArray
+
+    /// A list of hidden states corresponding to the outputs of the transformer layers
+    public var hiddenStates: [MLXArray]
+}
+
+/// The transformer encoder layer from CLIP
+class CLIPEncoderLayer: Module {
+
+    @ModuleInfo(key: "layer_norm1") var layerNorm1: LayerNorm
+    @ModuleInfo(key: "layer_norm2") var layerNorm2: LayerNorm
+
+    let attention: MultiHeadAttention
+
+    @ModuleInfo var linear1: Linear
+    @ModuleInfo var linear2: Linear
+
+    let activation: (MLXArray) -> MLXArray
+
+    init(modelDimensions: Int, numHeads: Int, activation: @escaping (MLXArray) -> MLXArray) {
+        self._layerNorm1.wrappedValue = LayerNorm(dimensions: modelDimensions)
+        self._layerNorm2.wrappedValue = LayerNorm(dimensions: modelDimensions)
+
+        self.attention = MultiHeadAttention(
+            dimensions: modelDimensions, numHeads: numHeads, bias: true)
+
+        self.linear1 = Linear(modelDimensions, 4 * modelDimensions)
+        self.linear2 = Linear(4 * modelDimensions, modelDimensions)
+
+        self.activation = activation
+    }
+
+    func callAsFunction(_ x: MLXArray, attentionMask: MLXArray? = nil) -> MLXArray {
+        var y = layerNorm1(x)
+        y = attention(y, keys: y, values: y, mask: attentionMask)
+        var x = y + x
+
+        y = layerNorm2(x)
+        y = linear1(y)
+        y = activation(y)
+        y = linear2(y)
+        x = y + x
+
+        return x
+    }
+}
+
+/// Implements the text encoder transformer from CLIP
+class CLIPTextModel: Module {
+
+    @ModuleInfo(key: "token_embedding") var tokenEmbedding: Embedding
+    @ModuleInfo(key: "position_embedding") var positionEmbedding: Embedding
+
+    let layers: [CLIPEncoderLayer]
+
+    @ModuleInfo(key: "final_layer_norm") var finalLayerNorm: LayerNorm
+
+    @ModuleInfo(key: "text_projection") var textProjection: Linear?
+
+    init(configuration: CLIPTextModelConfiguration) {
+        self._tokenEmbedding.wrappedValue = Embedding(
+            embeddingCount: configuration.vocabularySize, dimensions: configuration.modelDimensions)
+        self._positionEmbedding.wrappedValue = Embedding(
+            embeddingCount: configuration.maxLength, dimensions: configuration.modelDimensions)
+
+        self.layers = (0 ..< configuration.numLayers)
+            .map { _ in
+                CLIPEncoderLayer(
+                    modelDimensions: configuration.modelDimensions,
+                    numHeads: configuration.numHeads,
+                    activation: configuration.hiddenActivation.activation)
+            }
+
+        self._finalLayerNorm.wrappedValue = LayerNorm(dimensions: configuration.modelDimensions)
+
+        if let projectionDimensions = configuration.projectionDimensions {
+            self._textProjection.wrappedValue = Linear(
+                configuration.modelDimensions, projectionDimensions, bias: false)
+        } else {
+            self._textProjection.wrappedValue = nil
+        }
+    }
+
+    func mask(_ N: Int, _ dType: DType) -> MLXArray {
+        let indices = MLXArray(0 ..< Int32(N))
+        var mask = indices[0..., .newAxis] .< indices[.newAxis]
+        mask = mask.asType(dType) * (dType == .float16 ? -6e4 : -1e9)
+        return mask
+    }
+
+    func callAsFunction(_ x: MLXArray) -> CLIPOutput {
+        var x = x
+        let (_, N) = x.shape2
+        let eosTokens = x.argMax(axis: -1)
+
+        // compute the embeddings
+        x = tokenEmbedding(x)
+        x = x + positionEmbedding.weight[..<N]
+
+        // compute the features from the transformer
+        let mask = mask(N, x.dtype)
+        var hiddenStates = [MLXArray]()
+        for l in layers {
+            x = l(x, attentionMask: mask)
+            hiddenStates.append(x)
+        }
+
+        // apply the final layernorm
+        x = finalLayerNorm(x)
+        let lastHiddenState = x
+
+        // select the EOS token
+        var pooledOutput = x[MLXArray(0 ..< x.count), eosTokens]
+        if let textProjection {
+            pooledOutput = textProjection(pooledOutput)
+        }
+
+        return CLIPOutput(
+            pooledOutput: pooledOutput, lastHiddenState: lastHiddenState, hiddenStates: hiddenStates
+        )
+    }
+}
+
+#endif

--- a/Sources/StableDiffusion/Configuration.swift
+++ b/Sources/StableDiffusion/Configuration.swift
@@ -1,0 +1,276 @@
+// Vendored from github.com/ml-explore/mlx-swift-examples (MIT License, Copyright 2024 ml-explore)
+// See Sources/StableDiffusion/LICENSE for full terms.
+#if MLX
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+import MLX
+import MLXNN
+
+// port of https://github.com/ml-explore/mlx-examples/blob/main/stable_diffusion/stable_diffusion/config.py
+
+/// Configuration for ``Autoencoder``
+struct AutoencoderConfiguration: Codable {
+
+    public var inputChannels = 3
+    public var outputChannels = 3
+    public var latentChannelsOut: Int { latentChannelsIn * 2 }
+    public var latentChannelsIn = 4
+    public var blockOutChannels = [128, 256, 512, 512]
+    public var layersPerBlock = 2
+    public var normNumGroups = 32
+    public var scalingFactor: Float = 0.18215
+
+    enum CodingKeys: String, CodingKey {
+        case inputChannels = "in_channels"
+        case outputChannels = "out_channels"
+        case latentChannelsIn = "latent_channels"
+        case blockOutChannels = "block_out_channels"
+        case layersPerBlock = "layers_per_block"
+        case normNumGroups = "norm_num_groups"
+        case scalingFactor = "scaling_factor"
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container: KeyedDecodingContainer<AutoencoderConfiguration.CodingKeys> =
+            try decoder.container(keyedBy: AutoencoderConfiguration.CodingKeys.self)
+
+        // load_autoencoder()
+
+        self.scalingFactor =
+            try container.decodeIfPresent(Float.self, forKey: .scalingFactor) ?? 0.18215
+
+        self.inputChannels = try container.decode(Int.self, forKey: .inputChannels)
+        self.outputChannels = try container.decode(Int.self, forKey: .outputChannels)
+        self.latentChannelsIn = try container.decode(Int.self, forKey: .latentChannelsIn)
+        self.blockOutChannels = try container.decode([Int].self, forKey: .blockOutChannels)
+        self.layersPerBlock = try container.decode(Int.self, forKey: .layersPerBlock)
+        self.normNumGroups = try container.decode(Int.self, forKey: .normNumGroups)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container: KeyedEncodingContainer<AutoencoderConfiguration.CodingKeys> =
+            encoder.container(keyedBy: AutoencoderConfiguration.CodingKeys.self)
+
+        try container.encode(self.inputChannels, forKey: .inputChannels)
+        try container.encode(self.outputChannels, forKey: .outputChannels)
+        try container.encode(self.latentChannelsIn, forKey: .latentChannelsIn)
+        try container.encode(self.blockOutChannels, forKey: .blockOutChannels)
+        try container.encode(self.layersPerBlock, forKey: .layersPerBlock)
+        try container.encode(self.normNumGroups, forKey: .normNumGroups)
+        try container.encode(self.scalingFactor, forKey: .scalingFactor)
+    }
+}
+
+/// Configuration for ``CLIPTextModel``
+struct CLIPTextModelConfiguration: Codable {
+
+    public enum ClipActivation: String, Codable {
+        case fast = "quick_gelu"
+        case gelu = "gelu"
+
+        var activation: (MLXArray) -> MLXArray {
+            switch self {
+            case .fast: MLXNN.geluFastApproximate
+            case .gelu: MLXNN.gelu
+            }
+        }
+    }
+
+    public var numLayers = 23
+    public var modelDimensions = 1024
+    public var numHeads = 16
+    public var maxLength = 77
+    public var vocabularySize = 49408
+    public var projectionDimensions: Int? = nil
+    public var hiddenActivation: ClipActivation = .fast
+
+    enum CodingKeys: String, CodingKey {
+        case numLayers = "num_hidden_layers"
+        case modelDimensions = "hidden_size"
+        case numHeads = "num_attention_heads"
+        case maxLength = "max_position_embeddings"
+        case vocabularySize = "vocab_size"
+        case projectionDimensions = "projection_dim"
+        case hiddenActivation = "hidden_act"
+        case architectures = "architectures"
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container: KeyedDecodingContainer<CLIPTextModelConfiguration.CodingKeys> =
+            try decoder.container(keyedBy: CLIPTextModelConfiguration.CodingKeys.self)
+
+        // see load_text_encoder
+
+        let architectures = try container.decode([String].self, forKey: .architectures)
+        let withProjection = architectures[0].contains("WithProjection")
+
+        self.projectionDimensions =
+            withProjection
+            ? try container.decodeIfPresent(Int.self, forKey: .projectionDimensions) : nil
+        self.hiddenActivation =
+            try container.decodeIfPresent(
+                CLIPTextModelConfiguration.ClipActivation.self, forKey: .hiddenActivation) ?? .fast
+
+        self.numLayers = try container.decode(Int.self, forKey: .numLayers)
+        self.modelDimensions = try container.decode(Int.self, forKey: .modelDimensions)
+        self.numHeads = try container.decode(Int.self, forKey: .numHeads)
+        self.maxLength = try container.decode(Int.self, forKey: .maxLength)
+        self.vocabularySize = try container.decode(Int.self, forKey: .vocabularySize)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container: KeyedEncodingContainer<CLIPTextModelConfiguration.CodingKeys> =
+            encoder.container(keyedBy: CLIPTextModelConfiguration.CodingKeys.self)
+
+        if projectionDimensions != nil {
+            try container.encode(["WithProjection"], forKey: .architectures)
+        } else {
+            try container.encode(["Other"], forKey: .architectures)
+        }
+
+        try container.encode(self.numLayers, forKey: .numLayers)
+        try container.encode(self.modelDimensions, forKey: .modelDimensions)
+        try container.encode(self.numHeads, forKey: .numHeads)
+        try container.encode(self.maxLength, forKey: .maxLength)
+        try container.encode(self.vocabularySize, forKey: .vocabularySize)
+        try container.encodeIfPresent(self.projectionDimensions, forKey: .projectionDimensions)
+        try container.encode(self.hiddenActivation, forKey: .hiddenActivation)
+    }
+}
+
+/// Configuration for ``UNetModel``
+struct UNetConfiguration: Codable {
+
+    public var inputChannels = 4
+    public var outputChannels = 4
+    public var convolutionInKernel = 3
+    public var convolutionOutKernel = 3
+    public var blockOutChannels = [320, 640, 1280, 1280]
+    public var layersPerBlock = [2, 2, 2, 2]
+    public var midBlockLayers = 2
+    public var transformerLayersPerBlock = [2, 2, 2, 2]
+    public var numHeads = [5, 10, 20, 20]
+    public var crossAttentionDimension = [1024, 1024, 1024, 1024]
+    public var normNumGroups = 32
+    public var downBlockTypes: [String] = []
+    public var upBlockTypes: [String] = []
+    public var additionEmbedType: String? = nil
+    public var additionTimeEmbedDimension: Int? = nil
+    public var projectionClassEmbeddingsInputDimension: Int? = nil
+
+    enum CodingKeys: String, CodingKey {
+        case inputChannels = "in_channels"
+        case outputChannels = "out_channels"
+        case convolutionInKernel = "conv_in_kernel"
+        case convolutionOutKernel = "conv_out_kernel"
+        case blockOutChannels = "block_out_channels"
+        case layersPerBlock = "layers_per_block"
+        case midBlockLayers = "mid_block_layers"
+        case transformerLayersPerBlock = "transformer_layers_per_block"
+        case numHeads = "attention_head_dim"
+        case crossAttentionDimension = "cross_attention_dim"
+        case normNumGroups = "norm_num_groups"
+        case downBlockTypes = "down_block_types"
+        case upBlockTypes = "up_block_types"
+        case additionEmbedType = "addition_embed_type"
+        case additionTimeEmbedDimension = "addition_time_embed_dim"
+        case projectionClassEmbeddingsInputDimension = "projection_class_embeddings_input_dim"
+    }
+
+    public init() {
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container: KeyedDecodingContainer<UNetConfiguration.CodingKeys> = try decoder.container(
+            keyedBy: UNetConfiguration.CodingKeys.self)
+
+        // customizations based on def load_unet(key: str = _DEFAULT_MODEL, float16: bool = False):
+        //
+        // Note: the encode() writes out the internal format (and this can load it back in)
+
+        self.blockOutChannels = try container.decode([Int].self, forKey: .blockOutChannels)
+        let nBlocks = blockOutChannels.count
+
+        self.layersPerBlock =
+            try (try? container.decode([Int].self, forKey: .layersPerBlock))
+            ?? Array(repeating: container.decode(Int.self, forKey: .layersPerBlock), count: nBlocks)
+        self.transformerLayersPerBlock =
+            (try? container.decode([Int].self, forKey: .transformerLayersPerBlock)) ?? [1, 1, 1, 1]
+        self.numHeads =
+            try (try? container.decodeIfPresent([Int].self, forKey: .numHeads))
+            ?? Array(repeating: container.decode(Int.self, forKey: .numHeads), count: nBlocks)
+        self.crossAttentionDimension =
+            try (try? container.decode([Int].self, forKey: .crossAttentionDimension))
+            ?? Array(
+                repeating: container.decode(Int.self, forKey: .crossAttentionDimension),
+                count: nBlocks)
+        self.upBlockTypes = try container.decode([String].self, forKey: .upBlockTypes).reversed()
+
+        self.convolutionInKernel =
+            try container.decodeIfPresent(Int.self, forKey: .convolutionInKernel) ?? 3
+        self.convolutionOutKernel =
+            try container.decodeIfPresent(Int.self, forKey: .convolutionOutKernel) ?? 3
+        self.midBlockLayers = try container.decodeIfPresent(Int.self, forKey: .midBlockLayers) ?? 2
+
+        self.inputChannels = try container.decode(Int.self, forKey: .inputChannels)
+        self.outputChannels = try container.decode(Int.self, forKey: .outputChannels)
+        self.normNumGroups = try container.decode(Int.self, forKey: .normNumGroups)
+        self.downBlockTypes = try container.decode([String].self, forKey: .downBlockTypes)
+        self.additionEmbedType = try container.decodeIfPresent(
+            String.self, forKey: .additionEmbedType)
+        self.additionTimeEmbedDimension = try container.decodeIfPresent(
+            Int.self, forKey: .additionTimeEmbedDimension)
+        self.projectionClassEmbeddingsInputDimension = try container.decodeIfPresent(
+            Int.self, forKey: .projectionClassEmbeddingsInputDimension)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container: KeyedEncodingContainer<UNetConfiguration.CodingKeys> = encoder.container(
+            keyedBy: UNetConfiguration.CodingKeys.self)
+
+        try container.encode(self.upBlockTypes.reversed(), forKey: .upBlockTypes)
+
+        try container.encode(self.inputChannels, forKey: .inputChannels)
+        try container.encode(self.outputChannels, forKey: .outputChannels)
+        try container.encode(self.convolutionInKernel, forKey: .convolutionInKernel)
+        try container.encode(self.convolutionOutKernel, forKey: .convolutionOutKernel)
+        try container.encode(self.blockOutChannels, forKey: .blockOutChannels)
+        try container.encode(self.layersPerBlock, forKey: .layersPerBlock)
+        try container.encode(self.midBlockLayers, forKey: .midBlockLayers)
+        try container.encode(self.transformerLayersPerBlock, forKey: .transformerLayersPerBlock)
+        try container.encode(self.numHeads, forKey: .numHeads)
+        try container.encode(self.crossAttentionDimension, forKey: .crossAttentionDimension)
+        try container.encode(self.normNumGroups, forKey: .normNumGroups)
+        try container.encode(self.downBlockTypes, forKey: .downBlockTypes)
+        try container.encodeIfPresent(self.additionEmbedType, forKey: .additionEmbedType)
+        try container.encodeIfPresent(
+            self.additionTimeEmbedDimension, forKey: .additionTimeEmbedDimension)
+        try container.encodeIfPresent(
+            self.projectionClassEmbeddingsInputDimension,
+            forKey: .projectionClassEmbeddingsInputDimension)
+    }
+}
+
+/// Configuration for ``StableDiffusion``
+public struct DiffusionConfiguration: Codable {
+
+    public enum BetaSchedule: String, Codable {
+        case linear = "linear"
+        case scaledLinear = "scaled_linear"
+    }
+
+    public var betaSchedule = BetaSchedule.scaledLinear
+    public var betaStart: Float = 0.00085
+    public var betaEnd: Float = 0.012
+    public var trainSteps = 3
+
+    enum CodingKeys: String, CodingKey {
+        case betaSchedule = "beta_schedule"
+        case betaStart = "beta_start"
+        case betaEnd = "beta_end"
+        case trainSteps = "num_train_timesteps"
+    }
+}
+
+#endif

--- a/Sources/StableDiffusion/Image.swift
+++ b/Sources/StableDiffusion/Image.swift
@@ -1,0 +1,159 @@
+// Vendored from github.com/ml-explore/mlx-swift-examples (MIT License, Copyright 2024 ml-explore)
+// See Sources/StableDiffusion/LICENSE for full terms.
+#if MLX
+// Copyright © 2024 Apple Inc.
+
+import CoreGraphics
+import CoreImage
+import Foundation
+import ImageIO
+import MLX
+import UniformTypeIdentifiers
+
+enum ImageError: LocalizedError {
+    case failedToSave
+    case unableToOpen
+
+    var errorDescription: String? {
+        switch self {
+        case .failedToSave:
+            return String(localized: "Failed to save the image to the specified location.")
+        case .unableToOpen:
+            return String(localized: "Unable to open the image file.")
+        }
+    }
+}
+
+/// Conversion utilities for moving between `MLXArray`, `CGImage` and files.
+public struct Image {
+
+    public let data: MLXArray
+
+    /// Create an Image from a MLXArray with ndim == 3
+    public init(_ data: MLXArray) {
+        precondition(data.ndim == 3)
+        self.data = data
+    }
+
+    /// Create an Image by loading from a file
+    public init(url: URL, maximumEdge: Int? = nil) throws {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+            let image = CGImageSourceCreateImageAtIndex(source, 0, nil)
+        else {
+            throw ImageError.unableToOpen
+        }
+
+        self.init(image: image)
+    }
+
+    /// Create an image from a CGImage
+    public init(image: CGImage, maximumEdge: Int? = nil) {
+        // ensure the sizes ar multiples of 64 -- this doesn't worry about
+        // the aspect ratio
+
+        var width = image.width
+        var height = image.height
+
+        if let maximumEdge {
+            func scale(_ edge: Int, _ maxEdge: Int) -> Int {
+                Int(round(Float(maximumEdge) / Float(maxEdge) * Float(edge)))
+            }
+
+            // aspect fit inside the given maximum
+            if width >= height {
+                width = scale(width, image.width)
+                height = scale(height, image.width)
+            } else {
+                width = scale(width, image.height)
+                height = scale(height, image.height)
+            }
+        }
+
+        // size must be multiples of 64 -- coerce without regard to aspect ratio
+        width = width - width % 64
+        height = height - height % 64
+
+        var raster = Data(count: width * 4 * height)
+        raster.withUnsafeMutableBytes { ptr in
+            let cs = CGColorSpace(name: CGColorSpace.sRGB)!
+            let context = CGContext(
+                data: ptr.baseAddress, width: width, height: height, bitsPerComponent: 8,
+                bytesPerRow: width * 4, space: cs,
+                bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue
+                    | CGBitmapInfo.byteOrder32Big.rawValue)!
+
+            context.draw(
+                image, in: CGRect(origin: .zero, size: .init(width: width, height: height)))
+        }
+
+        self.data = MLXArray(raster, [height, width, 4], type: UInt8.self)[0..., 0..., ..<3]
+    }
+
+    /// Convert the image data to a CGImage
+    public func asCGImage() -> CGImage {
+        var raster = data
+
+        // we need 4 bytes per pixel
+        if data.dim(-1) == 3 {
+            raster = padded(raster, widths: [0, 0, [0, 1]])
+        }
+
+        class DataHolder {
+            var data: Data
+            init(_ data: Data) {
+                self.data = data
+            }
+        }
+
+        let holder = DataHolder(raster.asData(access: .copy).data)
+
+        let payload = Unmanaged.passRetained(holder).toOpaque()
+        func release(payload: UnsafeMutableRawPointer?, data: UnsafeMutableRawPointer?) {
+            Unmanaged<DataHolder>.fromOpaque(payload!).release()
+        }
+
+        return holder.data.withUnsafeMutableBytes { ptr in
+            let (H, W, C) = raster.shape3
+            let cs = CGColorSpace(name: CGColorSpace.sRGB)!
+
+            let context = CGContext(
+                data: ptr.baseAddress, width: W, height: H, bitsPerComponent: 8, bytesPerRow: W * C,
+                space: cs,
+                bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue
+                    | CGBitmapInfo.byteOrder32Big.rawValue, releaseCallback: release,
+                releaseInfo: payload)!
+            return context.makeImage()!
+        }
+    }
+
+    /// Convert the image data to a CIImage
+    public func asCIImage() -> CIImage {
+        // we need 4 bytes per pixel
+        var raster = data
+        if data.dim(-1) == 3 {
+            raster = padded(raster, widths: [0, 0, [0, 1]], value: MLXArray(255))
+        }
+
+        let arrayData = raster.asData()
+        let (H, W, C) = raster.shape3
+        let cs = CGColorSpace(name: CGColorSpace.sRGB)!
+
+        return CIImage(
+            bitmapData: arrayData.data, bytesPerRow: W * 4, size: .init(width: W, height: H),
+            format: .RGBA8, colorSpace: cs)
+    }
+
+    /// Save the image
+    public func save(url: URL) throws {
+        let uti = UTType(filenameExtension: url.pathExtension) ?? UTType.png
+
+        let destination = CGImageDestinationCreateWithURL(
+            url as CFURL, uti.identifier as CFString, 1, nil)!
+        CGImageDestinationAddImage(destination, asCGImage(), nil)
+        if !CGImageDestinationFinalize(destination) {
+            throw ImageError.failedToSave
+        }
+    }
+}
+
+#endif

--- a/Sources/StableDiffusion/LICENSE
+++ b/Sources/StableDiffusion/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 ml-explore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Sources/StableDiffusion/Load.swift
+++ b/Sources/StableDiffusion/Load.swift
@@ -1,0 +1,464 @@
+// Vendored from github.com/ml-explore/mlx-swift-examples (MIT License, Copyright 2024 ml-explore)
+// See Sources/StableDiffusion/LICENSE for full terms.
+#if MLX
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+import Hub
+import MLX
+import MLXNN
+
+// port of https://github.com/ml-explore/mlx-examples/blob/main/stable_diffusion/stable_diffusion/model_io.py
+
+/// Configuration for loading stable diffusion weights.
+///
+/// These options can be tuned to conserve memory.
+public struct LoadConfiguration: Sendable {
+
+    /// convert weights to float16
+    public var float16 = true
+
+    /// quantize weights
+    public var quantize = false
+
+    public var dType: DType {
+        float16 ? .float16 : .float32
+    }
+
+    public init(float16: Bool = true, quantize: Bool = false) {
+        self.float16 = float16
+        self.quantize = quantize
+    }
+}
+
+/// Parameters for evaluating a stable diffusion prompt and generating latents
+public struct EvaluateParameters: Sendable {
+
+    /// `cfg` value from the preset
+    public var cfgWeight: Float
+
+    /// number of steps -- default is from the preset
+    public var steps: Int
+
+    /// number of images to generate at a time
+    public var imageCount = 1
+    public var decodingBatchSize = 1
+
+    /// size of the latent tensor -- the result image is a factor of 8 larger than this
+    public var latentSize = [64, 64]
+
+    public var seed: UInt64
+    public var prompt = ""
+    public var negativePrompt = ""
+
+    public init(
+        cfgWeight: Float, steps: Int, imageCount: Int = 1, decodingBatchSize: Int = 1,
+        latentSize: [Int] = [64, 64], seed: UInt64? = nil, prompt: String = "",
+        negativePrompt: String = ""
+    ) {
+        self.cfgWeight = cfgWeight
+        self.steps = steps
+        self.imageCount = imageCount
+        self.decodingBatchSize = decodingBatchSize
+        self.latentSize = latentSize
+        self.seed = seed ?? UInt64(Date.timeIntervalSinceReferenceDate * 1000)
+        self.prompt = prompt
+        self.negativePrompt = negativePrompt
+    }
+}
+
+/// File types for ``StableDiffusionConfiguration/files``. Used by the presets to provide
+/// relative file paths for different types of files.
+enum FileKey {
+    case unetConfig
+    case unetWeights
+    case textEncoderConfig
+    case textEncoderWeights
+    case textEncoderConfig2
+    case textEncoderWeights2
+    case vaeConfig
+    case vaeWeights
+    case diffusionConfig
+    case tokenizerVocabulary
+    case tokenizerMerges
+    case tokenizerVocabulary2
+    case tokenizerMerges2
+}
+
+/// Stable diffusion configuration -- this selects the model to load.
+///
+/// Use the preset values:
+/// - ``presetSDXLTurbo``
+/// - ``presetStableDiffusion21Base``
+///
+/// or use the enum (convenient for command line tools):
+///
+/// - ``Preset/sdxlTurbo``
+/// - ``Preset/sdxlTurbo``
+///
+/// Call ``download(hub:progressHandler:)`` to download the weights, then
+/// ``textToImageGenerator(hub:configuration:)`` or
+/// ``imageToImageGenerator(hub:configuration:)`` to produce the ``ImageGenerator``.
+///
+/// The ``ImageGenerator`` has a method to generate the latents:
+/// - ``TextToImageGenerator/generateLatents(parameters:)``
+/// - ``ImageToImageGenerator/generateLatents(image:parameters:strength:)``
+///
+/// Evaluate each of the latents from that iterator and use the decoder to turn the last latent
+/// into an image:
+///
+/// - ``ImageGenerator/decode(xt:)``
+///
+/// Finally use ``Image`` to save it to a file or convert to a CGImage for display.
+public struct StableDiffusionConfiguration: Sendable {
+    public let id: String
+    let files: [FileKey: String]
+    public let defaultParameters: @Sendable () -> EvaluateParameters
+    let factory:
+        @Sendable (HubApi, StableDiffusionConfiguration, LoadConfiguration) throws ->
+            StableDiffusion
+
+    public func download(
+        hub: HubApi = HubApi(), progressHandler: @escaping (Progress) -> Void = { _ in }
+    ) async throws {
+        let repo = Hub.Repo(id: self.id)
+        try await hub.snapshot(
+            from: repo, matching: Array(files.values), progressHandler: progressHandler)
+    }
+
+    public func textToImageGenerator(hub: HubApi = HubApi(), configuration: LoadConfiguration)
+        throws -> TextToImageGenerator?
+    {
+        try factory(hub, self, configuration) as? TextToImageGenerator
+    }
+
+    public func imageToImageGenerator(hub: HubApi = HubApi(), configuration: LoadConfiguration)
+        throws -> ImageToImageGenerator?
+    {
+        try factory(hub, self, configuration) as? ImageToImageGenerator
+    }
+
+    public enum Preset: String, Codable, CaseIterable, Sendable {
+        case base
+        case sdxlTurbo = "sdxl-turbo"
+
+        public var configuration: StableDiffusionConfiguration {
+            switch self {
+            case .base: presetStableDiffusion21Base
+            case .sdxlTurbo: presetSDXLTurbo
+            }
+        }
+    }
+
+    /// See https://huggingface.co/stabilityai/sdxl-turbo for the model details and license
+    public static let presetSDXLTurbo = StableDiffusionConfiguration(
+        id: "stabilityai/sdxl-turbo",
+        files: [
+            .unetConfig: "unet/config.json",
+            .unetWeights: "unet/diffusion_pytorch_model.safetensors",
+            .textEncoderConfig: "text_encoder/config.json",
+            .textEncoderWeights: "text_encoder/model.safetensors",
+            .textEncoderConfig2: "text_encoder_2/config.json",
+            .textEncoderWeights2: "text_encoder_2/model.safetensors",
+            .vaeConfig: "vae/config.json",
+            .vaeWeights: "vae/diffusion_pytorch_model.safetensors",
+            .diffusionConfig: "scheduler/scheduler_config.json",
+            .tokenizerVocabulary: "tokenizer/vocab.json",
+            .tokenizerMerges: "tokenizer/merges.txt",
+            .tokenizerVocabulary2: "tokenizer_2/vocab.json",
+            .tokenizerMerges2: "tokenizer_2/merges.txt",
+        ],
+        defaultParameters: { EvaluateParameters(cfgWeight: 0, steps: 2) },
+        factory: { hub, sdConfiguration, loadConfiguration in
+            let sd = try StableDiffusionXL(
+                hub: hub, configuration: sdConfiguration, dType: loadConfiguration.dType)
+            if loadConfiguration.quantize {
+                quantize(model: sd.textEncoder, filter: { k, m in m is Linear })
+                quantize(model: sd.textEncoder2, filter: { k, m in m is Linear })
+                quantize(model: sd.unet, groupSize: 32, bits: 8)
+            }
+            return sd
+        }
+    )
+
+    /// See https://huggingface.co/stabilityai/stable-diffusion-2-1-base for the model details and license
+    public static let presetStableDiffusion21Base = StableDiffusionConfiguration(
+        id: "stabilityai/stable-diffusion-2-1-base",
+        files: [
+            .unetConfig: "unet/config.json",
+            .unetWeights: "unet/diffusion_pytorch_model.safetensors",
+            .textEncoderConfig: "text_encoder/config.json",
+            .textEncoderWeights: "text_encoder/model.safetensors",
+            .vaeConfig: "vae/config.json",
+            .vaeWeights: "vae/diffusion_pytorch_model.safetensors",
+            .diffusionConfig: "scheduler/scheduler_config.json",
+            .tokenizerVocabulary: "tokenizer/vocab.json",
+            .tokenizerMerges: "tokenizer/merges.txt",
+        ],
+        defaultParameters: { EvaluateParameters(cfgWeight: 7.5, steps: 50) },
+        factory: { hub, sdConfiguration, loadConfiguration in
+            let sd = try StableDiffusionBase(
+                hub: hub, configuration: sdConfiguration, dType: loadConfiguration.dType)
+            if loadConfiguration.quantize {
+                quantize(model: sd.textEncoder, filter: { k, m in m is Linear })
+                quantize(model: sd.unet, groupSize: 32, bits: 8)
+            }
+            return sd
+        }
+    )
+
+}
+
+// MARK: - Key Mapping
+
+func keyReplace(_ replace: String, _ with: String) -> @Sendable (String) -> String? {
+    return { [replace, with] key in
+        if key.contains(replace) {
+            return key.replacingOccurrences(of: replace, with: with)
+        }
+        return nil
+    }
+}
+
+func dropPrefix(_ prefix: String) -> @Sendable (String) -> String? {
+    return { [prefix] key in
+        if key.hasPrefix(prefix) {
+            return String(key.dropFirst(prefix.count))
+        }
+        return nil
+    }
+}
+
+// see map_unet_weights()
+
+let unetRules: [@Sendable (String) -> String?] = [
+    // Map up/downsampling
+    keyReplace("downsamplers.0.conv", "downsample"),
+    keyReplace("upsamplers.0.conv", "upsample"),
+
+    // Map the mid block
+    keyReplace("mid_block.resnets.0", "mid_blocks.0"),
+    keyReplace("mid_block.attentions.0", "mid_blocks.1"),
+    keyReplace("mid_block.resnets.1", "mid_blocks.2"),
+
+    // Map attention layers
+    keyReplace("to_k", "key_proj"),
+    keyReplace("to_out.0", "out_proj"),
+    keyReplace("to_q", "query_proj"),
+    keyReplace("to_v", "value_proj"),
+
+    // Map transformer ffn
+    keyReplace("ff.net.2", "linear3"),
+]
+
+func unetRemap(key: String, value: MLXArray) -> [(String, MLXArray)] {
+    var key = key
+    var value = value
+
+    for rule in unetRules {
+        key = rule(key) ?? key
+    }
+
+    // Map transformer ffn
+    if key.contains("ff.net.0") {
+        let k1 = key.replacingOccurrences(of: "ff.net.0.proj", with: "linear1")
+        let k2 = key.replacingOccurrences(of: "ff.net.0.proj", with: "linear2")
+        let (v1, v2) = value.split()
+        return [(k1, v1), (k2, v2)]
+    }
+
+    if key.contains("conv_shortcut.weight") {
+        value = value.squeezed()
+    }
+
+    // Transform the weights from 1x1 convs to linear
+    if value.ndim == 4 && (key.contains("proj_in") || key.contains("proj_out")) {
+        value = value.squeezed()
+    }
+
+    if value.ndim == 4 {
+        value = value.transposed(0, 2, 3, 1)
+        value = value.reshaped(-1).reshaped(value.shape)
+    }
+
+    return [(key, value)]
+}
+
+let clipRules: [@Sendable (String) -> String?] = [
+    dropPrefix("text_model."),
+    dropPrefix("embeddings."),
+    dropPrefix("encoder."),
+
+    // Map attention layers
+    keyReplace("self_attn.", "attention."),
+    keyReplace("q_proj.", "query_proj."),
+    keyReplace("k_proj.", "key_proj."),
+    keyReplace("v_proj.", "value_proj."),
+
+    // Map ffn layers
+    keyReplace("mlp.fc1", "linear1"),
+    keyReplace("mlp.fc2", "linear2"),
+]
+
+func clipRemap(key: String, value: MLXArray) -> [(String, MLXArray)] {
+    var key = key
+
+    for rule in clipRules {
+        key = rule(key) ?? key
+    }
+
+    // not used
+    if key == "position_ids" {
+        return []
+    }
+
+    return [(key, value)]
+}
+
+let vaeRules: [@Sendable (String) -> String?] = [
+    // Map up/downsampling
+    keyReplace("downsamplers.0.conv", "downsample"),
+    keyReplace("upsamplers.0.conv", "upsample"),
+
+    // Map attention layers
+    keyReplace("to_k", "key_proj"),
+    keyReplace("to_out.0", "out_proj"),
+    keyReplace("to_q", "query_proj"),
+    keyReplace("to_v", "value_proj"),
+
+    // Map the mid block
+    keyReplace("mid_block.resnets.0", "mid_blocks.0"),
+    keyReplace("mid_block.attentions.0", "mid_blocks.1"),
+    keyReplace("mid_block.resnets.1", "mid_blocks.2"),
+
+    keyReplace("mid_blocks.1.key.", "mid_blocks.1.key_proj."),
+    keyReplace("mid_blocks.1.query.", "mid_blocks.1.query_proj."),
+    keyReplace("mid_blocks.1.value.", "mid_blocks.1.value_proj."),
+    keyReplace("mid_blocks.1.proj_attn.", "mid_blocks.1.out_proj."),
+
+]
+
+func vaeRemap(key: String, value: MLXArray) -> [(String, MLXArray)] {
+    var key = key
+    var value = value
+
+    for rule in vaeRules {
+        key = rule(key) ?? key
+    }
+
+    // Map the quant/post_quant layers
+    if key.contains("quant_conv") {
+        key = key.replacingOccurrences(of: "quant_conv", with: "quant_proj")
+        value = value.squeezed()
+    }
+
+    // Map the conv_shortcut to linear
+    if key.contains("conv_shortcut.weight") {
+        value = value.squeezed()
+    }
+
+    if value.ndim == 4 {
+        value = value.transposed(0, 2, 3, 1)
+        value = value.reshaped(-1).reshaped(value.shape)
+    }
+
+    return [(key, value)]
+}
+
+func loadWeights(
+    url: URL, model: Module, mapper: (String, MLXArray) -> [(String, MLXArray)], dType: DType
+) throws {
+    let weights = try loadArrays(url: url).flatMap { mapper($0.key, $0.value.asType(dType)) }
+
+    // Note: not using verifier because some shapes change upon load
+    try model.update(parameters: ModuleParameters.unflattened(weights), verify: .none)
+}
+
+// MARK: - Loading
+
+func resolve(hub: HubApi, configuration: StableDiffusionConfiguration, key: FileKey) -> URL {
+    precondition(
+        configuration.files[key] != nil, "configuration \(configuration.id) missing key: \(key)")
+    let repo = Hub.Repo(id: configuration.id)
+    let directory = hub.localRepoLocation(repo)
+    return directory.appending(component: configuration.files[key]!)
+}
+
+func loadConfiguration<T: Decodable>(
+    hub: HubApi, configuration: StableDiffusionConfiguration, key: FileKey, type: T.Type
+) throws -> T {
+    let url = resolve(hub: hub, configuration: configuration, key: key)
+    return try JSONDecoder().decode(T.self, from: Data(contentsOf: url))
+}
+
+func loadUnet(hub: HubApi, configuration: StableDiffusionConfiguration, dType: DType) throws
+    -> UNetModel
+{
+    let unetConfiguration = try loadConfiguration(
+        hub: hub, configuration: configuration, key: .unetConfig, type: UNetConfiguration.self)
+    let model = UNetModel(configuration: unetConfiguration)
+
+    let weightsURL = resolve(hub: hub, configuration: configuration, key: .unetWeights)
+    try loadWeights(url: weightsURL, model: model, mapper: unetRemap, dType: dType)
+
+    return model
+}
+
+func loadTextEncoder(
+    hub: HubApi, configuration: StableDiffusionConfiguration,
+    configKey: FileKey = .textEncoderConfig, weightsKey: FileKey = .textEncoderWeights, dType: DType
+) throws -> CLIPTextModel {
+    let clipConfiguration = try loadConfiguration(
+        hub: hub, configuration: configuration, key: configKey,
+        type: CLIPTextModelConfiguration.self)
+    let model = CLIPTextModel(configuration: clipConfiguration)
+
+    let weightsURL = resolve(hub: hub, configuration: configuration, key: weightsKey)
+    try loadWeights(url: weightsURL, model: model, mapper: clipRemap, dType: dType)
+
+    return model
+}
+
+func loadAutoEncoder(hub: HubApi, configuration: StableDiffusionConfiguration, dType: DType) throws
+    -> Autoencoder
+{
+    let autoEncoderConfiguration = try loadConfiguration(
+        hub: hub, configuration: configuration, key: .vaeConfig, type: AutoencoderConfiguration.self
+    )
+    let model = Autoencoder(configuration: autoEncoderConfiguration)
+
+    let weightsURL = resolve(hub: hub, configuration: configuration, key: .vaeWeights)
+    try loadWeights(url: weightsURL, model: model, mapper: vaeRemap, dType: dType)
+
+    return model
+}
+
+func loadDiffusionConfiguration(hub: HubApi, configuration: StableDiffusionConfiguration) throws
+    -> DiffusionConfiguration
+{
+    try loadConfiguration(
+        hub: hub, configuration: configuration, key: .diffusionConfig,
+        type: DiffusionConfiguration.self)
+}
+
+// MARK: - Tokenizer
+
+func loadTokenizer(
+    hub: HubApi, configuration: StableDiffusionConfiguration,
+    vocabulary: FileKey = .tokenizerVocabulary, merges: FileKey = .tokenizerMerges
+) throws -> CLIPTokenizer {
+    let vocabularyURL = resolve(hub: hub, configuration: configuration, key: vocabulary)
+    let mergesURL = resolve(hub: hub, configuration: configuration, key: merges)
+
+    let vocabulary = try JSONDecoder().decode(
+        [String: Int].self, from: Data(contentsOf: vocabularyURL))
+    let merges = try String(contentsOf: mergesURL)
+        .components(separatedBy: .newlines)
+        // first line is a comment
+        .dropFirst()
+        .filter { !$0.isEmpty }
+
+    return CLIPTokenizer(merges: merges, vocabulary: vocabulary)
+}
+
+#endif

--- a/Sources/StableDiffusion/Sampler.swift
+++ b/Sources/StableDiffusion/Sampler.swift
@@ -1,0 +1,122 @@
+// Vendored from github.com/ml-explore/mlx-swift-examples (MIT License, Copyright 2024 ml-explore)
+// See Sources/StableDiffusion/LICENSE for full terms.
+#if MLX
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+import MLX
+
+// port of https://github.com/ml-explore/mlx-examples/blob/main/stable_diffusion/stable_diffusion/sampler.py
+
+/// Interpolate the function defined by `(0 ..< y.count) y)` at positions `xNew`.
+func interpolate(y: MLXArray, xNew: MLXArray) -> MLXArray {
+    let xLow = xNew.asType(.int32)
+    let xHigh = minimum(xLow + 1, y.count - 1)
+
+    let yLow = y[xLow]
+    let yHigh = y[xHigh]
+    let deltaX = xNew - xLow
+    let yNew = yLow * (1 - deltaX) + deltaX * yHigh
+
+    return yNew
+}
+
+/// A simple Euler integrator that can be used to sample from our diffusion models.
+///
+/// The method ``step()`` performs one Euler step from `x_t` to `x_t_prev`.
+class SimpleEulerSampler {
+
+    let sigmas: MLXArray
+
+    public init(configuration: DiffusionConfiguration) {
+        let betas: MLXArray
+
+        // compute the noise schedule
+        switch configuration.betaSchedule {
+        case .linear:
+            betas = MLXArray.linspace(
+                configuration.betaStart, configuration.betaEnd, count: configuration.trainSteps)
+        case .scaledLinear:
+            betas = MLXArray.linspace(
+                sqrt(configuration.betaStart), sqrt(configuration.betaEnd),
+                count: configuration.trainSteps
+            ).square()
+        }
+
+        let alphas = 1 - betas
+        let alphasCumprod = cumprod(alphas)
+
+        self.sigmas = concatenated([
+            MLXArray.zeros([1]), ((1 - alphasCumprod) / alphasCumprod).sqrt(),
+        ])
+    }
+
+    public var maxTime: Int {
+        sigmas.count - 1
+    }
+
+    public func samplePrior(shape: [Int], dType: DType = .float32, key: MLXArray? = nil) -> MLXArray
+    {
+        let noise = MLXRandom.normal(shape, key: key)
+        return (noise * sigmas[-1] * (sigmas[-1].square() + 1).rsqrt()).asType(dType)
+    }
+
+    public func addNoise(x: MLXArray, t: MLXArray, key: MLXArray? = nil) -> MLXArray {
+        let noise = MLXRandom.normal(x.shape, key: key)
+        let s = sigmas(t)
+        return (x + noise * s) * (s.square() + 1).rsqrt()
+    }
+
+    public func sigmas(_ t: MLXArray) -> MLXArray {
+        interpolate(y: sigmas, xNew: t)
+    }
+
+    public func timeSteps(steps: Int, start: Int? = nil, dType: DType = .float32) -> [(
+        MLXArray, MLXArray
+    )] {
+        let start = start ?? (sigmas.count - 1)
+        precondition(0 < start)
+        precondition(start <= sigmas.count - 1)
+        let steps = MLX.linspace(start, 0, count: steps + 1).asType(dType)
+
+        return Array(zip(steps, steps[1...]))
+    }
+
+    open func step(epsPred: MLXArray, xt: MLXArray, t: MLXArray, tPrev: MLXArray) -> MLXArray {
+        let dtype = epsPred.dtype
+        let sigma = sigmas(t).asType(dtype)
+        let sigmaPrev = sigmas(tPrev).asType(dtype)
+
+        let dt = sigmaPrev - sigma
+        var xtPrev = (sigma.square() + 1).sqrt() * xt + epsPred * dt
+        xtPrev = xtPrev * (sigmaPrev.square() + 1).rsqrt()
+
+        return xtPrev
+    }
+}
+
+class SimpleEulerAncestralSampler: SimpleEulerSampler {
+
+    open override func step(epsPred: MLXArray, xt: MLXArray, t: MLXArray, tPrev: MLXArray)
+        -> MLXArray
+    {
+        let dtype = epsPred.dtype
+        let sigma = sigmas(t).asType(dtype)
+        let sigmaPrev = sigmas(tPrev).asType(dtype)
+
+        let sigma2 = sigma.square()
+        let sigmaPrev2 = sigmaPrev.square()
+        let sigmaUp = (sigmaPrev2 * (sigma2 - sigmaPrev2) / sigma2).sqrt()
+        let sigmaDown = (sigmaPrev2 - sigmaUp ** 2).sqrt()
+
+        let dt = sigmaDown - sigma
+        var xtPrev = (sigma2 + 1).sqrt() * xt + epsPred * dt
+        let noise = MLXRandom.normal(xtPrev.shape).asType(xtPrev.dtype)
+        xtPrev = xtPrev + noise * sigmaUp
+        xtPrev = xtPrev * (sigmaPrev2 + 1).rsqrt()
+
+        return xtPrev
+    }
+}
+
+#endif

--- a/Sources/StableDiffusion/StableDiffusion.swift
+++ b/Sources/StableDiffusion/StableDiffusion.swift
@@ -1,0 +1,457 @@
+// Vendored from github.com/ml-explore/mlx-swift-examples (MIT License, Copyright 2024 ml-explore)
+// See Sources/StableDiffusion/LICENSE for full terms.
+#if MLX
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+import Hub
+import MLX
+import MLXNN
+
+// port of https://github.com/ml-explore/mlx-examples/blob/main/stable_diffusion/stable_diffusion/__init__.py
+
+/// Iterator that produces latent images.
+///
+/// Created by:
+///
+/// - ``TextToImageGenerator/generateLatents(parameters:)``
+/// - ``ImageToImageGenerator/generateLatents(image:parameters:strength:)``
+public struct DenoiseIterator: Sequence, IteratorProtocol {
+
+    let sd: StableDiffusion
+
+    var xt: MLXArray
+
+    let conditioning: MLXArray
+    let cfgWeight: Float
+    let textTime: (MLXArray, MLXArray)?
+
+    var i: Int
+    let steps: [(MLXArray, MLXArray)]
+
+    init(
+        sd: StableDiffusion, xt: MLXArray, t: Int, conditioning: MLXArray, steps: Int,
+        cfgWeight: Float, textTime: (MLXArray, MLXArray)? = nil
+    ) {
+        self.sd = sd
+        self.steps = sd.sampler.timeSteps(steps: steps, start: t, dType: sd.dType)
+        self.i = 0
+        self.xt = xt
+        self.conditioning = conditioning
+        self.cfgWeight = cfgWeight
+        self.textTime = textTime
+    }
+
+    public var underestimatedCount: Int {
+        steps.count
+    }
+
+    mutating public func next() -> MLXArray? {
+        guard i < steps.count else {
+            return nil
+        }
+
+        let (t, tPrev) = steps[i]
+        i += 1
+
+        xt = sd.step(
+            xt: xt, t: t, tPrev: tPrev, conditioning: conditioning, cfgWeight: cfgWeight,
+            textTime: textTime)
+        return xt
+    }
+}
+
+/// Type for the _decoder_ step.
+public typealias ImageDecoder = (MLXArray) -> MLXArray
+
+public protocol ImageGenerator {
+    func ensureLoaded()
+
+    /// Return a detached decoder -- this is useful if trying to conserve memory.
+    ///
+    /// The decoder can be used independently of the ImageGenerator to transform
+    /// latents into raster images.
+    func detachedDecoder() -> ImageDecoder
+
+    /// the equivalent to the ``detachedDecoder()`` but without the detatching
+    func decode(xt: MLXArray) -> MLXArray
+}
+
+/// Public interface for transforming a text prompt into an image.
+///
+/// Steps:
+///
+/// - ``generateLatents(parameters:)``
+/// - evaluate each of the latents from the iterator
+/// - ``ImageGenerator/decode(xt:)`` or ``ImageGenerator/detachedDecoder()`` to convert the final latent into an image
+/// - use ``Image`` to save the image
+public protocol TextToImageGenerator: ImageGenerator {
+    func generateLatents(parameters: EvaluateParameters) -> DenoiseIterator
+}
+
+/// Public interface for transforming a text prompt into an image.
+///
+/// Steps:
+///
+/// - ``generateLatents(image:parameters:strength:)``
+/// - evaluate each of the latents from the iterator
+/// - ``ImageGenerator/decode(xt:)`` or ``ImageGenerator/detachedDecoder()`` to convert the final latent into an image
+/// - use ``Image`` to save the image
+public protocol ImageToImageGenerator: ImageGenerator {
+    func generateLatents(image: MLXArray, parameters: EvaluateParameters, strength: Float)
+        -> DenoiseIterator
+}
+
+enum ModelContainerError: LocalizedError {
+    /// Unable to create the particular type of model, e.g. it doesn't support image to image
+    case unableToCreate(String, String)
+    /// When operating in conserveMemory mode, it tried to use a model that had been discarded
+    case modelDiscarded
+
+    var errorDescription: String? {
+        switch self {
+        case .unableToCreate(let modelId, let generatorType):
+            return String(
+                localized:
+                    "Unable to create a \(generatorType) with model ID '\(modelId)'. The model may not support this operation type."
+            )
+        case .modelDiscarded:
+            return String(
+                localized:
+                    "The model has been discarded to conserve memory and is no longer available. Please recreate the model container."
+            )
+        }
+    }
+}
+
+/// Container for models that guarantees single threaded access.
+public actor ModelContainer<M> {
+
+    enum State {
+        case discarded
+        case loaded(M)
+    }
+
+    var state: State
+
+    /// if true this will discard the model in ``performTwoStage(first:second:)``
+    var conserveMemory = false
+
+    private init(model: M) {
+        self.state = .loaded(model)
+    }
+
+    /// create a ``ModelContainer`` that supports ``TextToImageGenerator``
+    static public func createTextToImageGenerator(
+        configuration: StableDiffusionConfiguration, loadConfiguration: LoadConfiguration = .init()
+    ) throws -> ModelContainer<TextToImageGenerator> {
+        if let model = try configuration.textToImageGenerator(configuration: loadConfiguration) {
+            return .init(model: model)
+        } else {
+            throw ModelContainerError.unableToCreate(configuration.id, "TextToImageGenerator")
+        }
+    }
+
+    /// create a ``ModelContainer`` that supports ``ImageToImageGenerator``
+    static public func createImageToImageGenerator(
+        configuration: StableDiffusionConfiguration, loadConfiguration: LoadConfiguration = .init()
+    ) throws -> ModelContainer<ImageToImageGenerator> {
+        if let model = try configuration.imageToImageGenerator(configuration: loadConfiguration) {
+            return .init(model: model)
+        } else {
+            throw ModelContainerError.unableToCreate(configuration.id, "ImageToImageGenerator")
+        }
+    }
+
+    public func setConserveMemory(_ conserveMemory: Bool) {
+        self.conserveMemory = conserveMemory
+    }
+
+    /// Perform an action on the model and/or tokenizer. Callers _must_ eval any `MLXArray` before returning as
+    /// `MLXArray` is not `Sendable`.
+    public func perform<R>(_ action: @Sendable (M) throws -> R) throws -> R {
+        switch state {
+        case .discarded:
+            throw ModelContainerError.modelDiscarded
+        case .loaded(let m):
+            try action(m)
+        }
+    }
+
+    /// Perform a two stage action where the first stage returns values passed to the second stage.
+    ///
+    /// If ``setConservativeMemory(_:)`` is `true` this will discard the model in between
+    /// the `first` and `second` blocks. The container will have to be recreated if a caller
+    /// wants to use it again.
+    ///
+    /// If `false` this will just run them in sequence and the container can be reused.
+    ///
+    /// Callers _must_ eval any `MLXArray` before returning as `MLXArray` is not `Sendable`.
+    public func performTwoStage<R1, R2>(
+        first: @Sendable (M) throws -> R1, second: @Sendable (R1) throws -> R2
+    ) throws -> R2 {
+        let r1 =
+            switch state {
+            case .discarded:
+                throw ModelContainerError.modelDiscarded
+            case .loaded(let m):
+                try first(m)
+            }
+        if conserveMemory {
+            self.state = .discarded
+        }
+        return try second(r1)
+    }
+
+}
+
+/// Base class for Stable Diffusion.
+open class StableDiffusion {
+
+    let dType: DType
+    let diffusionConfiguration: DiffusionConfiguration
+    let unet: UNetModel
+    let textEncoder: CLIPTextModel
+    let autoencoder: Autoencoder
+    let sampler: SimpleEulerSampler
+    let tokenizer: CLIPTokenizer
+
+    internal init(
+        hub: HubApi, configuration: StableDiffusionConfiguration, dType: DType,
+        diffusionConfiguration: DiffusionConfiguration? = nil, unet: UNetModel? = nil,
+        textEncoder: CLIPTextModel? = nil, autoencoder: Autoencoder? = nil,
+        sampler: SimpleEulerSampler? = nil, tokenizer: CLIPTokenizer? = nil
+    ) throws {
+        self.dType = dType
+        self.diffusionConfiguration =
+            try diffusionConfiguration
+            ?? loadDiffusionConfiguration(hub: hub, configuration: configuration)
+        self.unet = try unet ?? loadUnet(hub: hub, configuration: configuration, dType: dType)
+        self.textEncoder =
+            try textEncoder ?? loadTextEncoder(hub: hub, configuration: configuration, dType: dType)
+
+        // note: autoencoder uses float32 weights
+        self.autoencoder =
+            try autoencoder
+            ?? loadAutoEncoder(hub: hub, configuration: configuration, dType: .float32)
+
+        if let sampler {
+            self.sampler = sampler
+        } else {
+            self.sampler = SimpleEulerSampler(configuration: self.diffusionConfiguration)
+        }
+        self.tokenizer = try tokenizer ?? loadTokenizer(hub: hub, configuration: configuration)
+    }
+
+    open func ensureLoaded() {
+        eval(unet, textEncoder, autoencoder)
+    }
+
+    func tokenize(tokenizer: CLIPTokenizer, text: String, negativeText: String?) -> MLXArray {
+        var tokens = [tokenizer.tokenize(text: text)]
+        if let negativeText {
+            tokens.append(tokenizer.tokenize(text: negativeText))
+        }
+
+        let c = tokens.count
+        let max = tokens.map { $0.count }.max() ?? 0
+        let mlxTokens = MLXArray(
+            tokens
+                .map {
+                    ($0 + Array(repeating: 0, count: max - $0.count))
+                }
+                .flatMap { $0 }
+        )
+        .reshaped(c, max)
+
+        return mlxTokens
+    }
+
+    open func step(
+        xt: MLXArray, t: MLXArray, tPrev: MLXArray, conditioning: MLXArray, cfgWeight: Float,
+        textTime: (MLXArray, MLXArray)?
+    ) -> MLXArray {
+        let xtUnet = cfgWeight > 1 ? concatenated([xt, xt], axis: 0) : xt
+        let tUnet = broadcast(t, to: [xtUnet.count])
+
+        var epsPred = unet(xtUnet, timestep: tUnet, encoderX: conditioning, textTime: textTime)
+
+        if cfgWeight > 1 {
+            let (epsText, epsNeg) = epsPred.split()
+            epsPred = epsNeg + cfgWeight * (epsText - epsNeg)
+        }
+
+        return sampler.step(epsPred: epsPred, xt: xt, t: t, tPrev: tPrev)
+    }
+
+    public func detachedDecoder() -> ImageDecoder {
+        let autoencoder = self.autoencoder
+        func decode(xt: MLXArray) -> MLXArray {
+            var x = autoencoder.decode(xt)
+            x = clip(x / 2 + 0.5, min: 0, max: 1)
+            return x
+        }
+        return decode(xt:)
+    }
+
+    public func decode(xt: MLXArray) -> MLXArray {
+        detachedDecoder()(xt)
+    }
+}
+
+/// Implementation of ``StableDiffusion`` for the `stabilityai/stable-diffusion-2-1-base` model.
+open class StableDiffusionBase: StableDiffusion, TextToImageGenerator {
+
+    public init(hub: HubApi, configuration: StableDiffusionConfiguration, dType: DType) throws {
+        try super.init(hub: hub, configuration: configuration, dType: dType)
+    }
+
+    func conditionText(text: String, imageCount: Int, cfgWeight: Float, negativeText: String?)
+        -> MLXArray
+    {
+        // tokenize the text
+        let tokens = tokenize(
+            tokenizer: tokenizer, text: text, negativeText: cfgWeight > 1 ? negativeText : nil)
+
+        // compute the features
+        var conditioning = textEncoder(tokens).lastHiddenState
+
+        // repeat the conditioning for each of the generated images
+        if imageCount > 1 {
+            conditioning = repeated(conditioning, count: imageCount, axis: 0)
+        }
+
+        return conditioning
+    }
+
+    public func generateLatents(parameters: EvaluateParameters) -> DenoiseIterator {
+        MLXRandom.seed(parameters.seed)
+
+        let conditioning = conditionText(
+            text: parameters.prompt, imageCount: parameters.imageCount,
+            cfgWeight: parameters.cfgWeight, negativeText: parameters.negativePrompt)
+
+        let xt = sampler.samplePrior(
+            shape: [parameters.imageCount] + parameters.latentSize + [autoencoder.latentChannels],
+            dType: dType)
+
+        return DenoiseIterator(
+            sd: self, xt: xt, t: sampler.maxTime, conditioning: conditioning,
+            steps: parameters.steps, cfgWeight: parameters.cfgWeight)
+    }
+
+}
+
+/// Implementation of ``StableDiffusion`` for the `stabilityai/sdxl-turbo` model.
+open class StableDiffusionXL: StableDiffusion, TextToImageGenerator, ImageToImageGenerator {
+
+    let textEncoder2: CLIPTextModel
+    let tokenizer2: CLIPTokenizer
+
+    public init(hub: HubApi, configuration: StableDiffusionConfiguration, dType: DType) throws {
+        let diffusionConfiguration = try loadConfiguration(
+            hub: hub, configuration: configuration, key: .diffusionConfig,
+            type: DiffusionConfiguration.self)
+        let sampler = SimpleEulerAncestralSampler(configuration: diffusionConfiguration)
+
+        self.textEncoder2 = try loadTextEncoder(
+            hub: hub, configuration: configuration, configKey: .textEncoderConfig2,
+            weightsKey: .textEncoderWeights2, dType: dType)
+
+        self.tokenizer2 = try loadTokenizer(
+            hub: hub, configuration: configuration, vocabulary: .tokenizerVocabulary2,
+            merges: .tokenizerMerges2)
+
+        try super.init(
+            hub: hub, configuration: configuration, dType: dType,
+            diffusionConfiguration: diffusionConfiguration, sampler: sampler)
+    }
+
+    open override func ensureLoaded() {
+        super.ensureLoaded()
+        eval(textEncoder2)
+    }
+
+    func conditionText(text: String, imageCount: Int, cfgWeight: Float, negativeText: String?) -> (
+        MLXArray, MLXArray
+    ) {
+        let tokens1 = tokenize(
+            tokenizer: tokenizer, text: text, negativeText: cfgWeight > 1 ? negativeText : nil)
+        let tokens2 = tokenize(
+            tokenizer: tokenizer2, text: text, negativeText: cfgWeight > 1 ? negativeText : nil)
+
+        let conditioning1 = textEncoder(tokens1)
+        let conditioning2 = textEncoder2(tokens2)
+        var conditioning = concatenated(
+            [
+                conditioning1.hiddenStates.dropLast().last!,
+                conditioning2.hiddenStates.dropLast().last!,
+            ],
+            axis: -1)
+        var pooledConditionng = conditioning2.pooledOutput
+
+        if imageCount > 1 {
+            conditioning = repeated(conditioning, count: imageCount, axis: 0)
+            pooledConditionng = repeated(pooledConditionng, count: imageCount, axis: 0)
+        }
+
+        return (conditioning, pooledConditionng)
+    }
+
+    public func generateLatents(parameters: EvaluateParameters) -> DenoiseIterator {
+        MLXRandom.seed(parameters.seed)
+
+        let (conditioning, pooledConditioning) = conditionText(
+            text: parameters.prompt, imageCount: parameters.imageCount,
+            cfgWeight: parameters.cfgWeight, negativeText: parameters.negativePrompt)
+
+        let textTime = (
+            pooledConditioning,
+            repeated(
+                MLXArray(converting: [512.0, 512, 0, 0, 512, 512]).reshaped(1, -1),
+                count: pooledConditioning.count, axis: 0)
+        )
+
+        let xt = sampler.samplePrior(
+            shape: [parameters.imageCount] + parameters.latentSize + [autoencoder.latentChannels],
+            dType: dType)
+
+        return DenoiseIterator(
+            sd: self, xt: xt, t: sampler.maxTime, conditioning: conditioning,
+            steps: parameters.steps, cfgWeight: parameters.cfgWeight, textTime: textTime)
+    }
+
+    public func generateLatents(image: MLXArray, parameters: EvaluateParameters, strength: Float)
+        -> DenoiseIterator
+    {
+        MLXRandom.seed(parameters.seed)
+
+        // Define the num steps and start step
+        let startStep = Float(sampler.maxTime) * strength
+        let numSteps = Int(Float(parameters.steps) * strength)
+
+        let (conditioning, pooledConditioning) = conditionText(
+            text: parameters.prompt, imageCount: parameters.imageCount,
+            cfgWeight: parameters.cfgWeight, negativeText: parameters.negativePrompt)
+
+        let textTime = (
+            pooledConditioning,
+            repeated(
+                MLXArray(converting: [512.0, 512, 0, 0, 512, 512]).reshaped(1, -1),
+                count: pooledConditioning.count, axis: 0)
+        )
+
+        // Get the latents from the input image and add noise according to the
+        // start time.
+
+        var (x0, _) = autoencoder.encode(image[.newAxis])
+        x0 = broadcast(x0, to: [parameters.imageCount] + x0.shape.dropFirst())
+        let xt = sampler.addNoise(x: x0, t: MLXArray(startStep))
+
+        return DenoiseIterator(
+            sd: self, xt: xt, t: sampler.maxTime, conditioning: conditioning, steps: numSteps,
+            cfgWeight: parameters.cfgWeight, textTime: textTime)
+    }
+}
+
+#endif

--- a/Sources/StableDiffusion/Tokenizer.swift
+++ b/Sources/StableDiffusion/Tokenizer.swift
@@ -1,0 +1,140 @@
+// Vendored from github.com/ml-explore/mlx-swift-examples (MIT License, Copyright 2024 ml-explore)
+// See Sources/StableDiffusion/LICENSE for full terms.
+#if MLX
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+
+struct Bigram: Hashable {
+    let a: String
+    let b: String
+
+    init(_ s: String) {
+        let pieces = s.split(separator: " ")
+        precondition(pieces.count == 2, "BPEPair expected two pieces for '\(s)'")
+        self.a = String(pieces[0])
+        self.b = String(pieces[1])
+    }
+
+    init(_ a: String, _ b: String) {
+        self.a = a
+        self.b = b
+    }
+
+    init(_ v: (String, String)) {
+        self.a = v.0
+        self.b = v.1
+    }
+}
+
+/// A CLIP tokenizer.
+///
+/// Ported from:
+///
+/// - https://github.com/ml-explore/mlx-examples/blob/main/stable_diffusion/stable_diffusion/tokenizer.py
+/// - https://github.com/huggingface/transformers/blob/main/src/transformers/models/clip/tokenization_clip.py
+///
+/// Ideally this would be a tokenizer from `swift-transformers` but this is too special purpose to be representable in
+/// what exists there (at time of writing).
+class CLIPTokenizer {
+
+    let pattern =
+        #/<\|startoftext\|>|<\|endoftext\|>|'s|'t|'re|'ve|'m|'ll|'d|[\p{L}]+|[\p{N}]|[^\s\p{L}\p{N}]+/#
+    let bpeRanks: [Bigram: Int]
+    let vocabulary: [String: Int]
+
+    let bos = "<|startoftext|>"
+    let eos = "<|endoftext|>"
+
+    let bosToken: Int
+    let eosToken: Int
+
+    var cache = [String: [String]]()
+
+    init(merges: [String], vocabulary: [String: Int]) {
+        self.bpeRanks = Dictionary(
+            uniqueKeysWithValues:
+                merges
+                .map { Bigram($0) }
+                .enumerated()
+                .map { ($0.element, $0.offset) })
+
+        self.vocabulary = vocabulary
+        self.cache[bos] = [bos]
+        self.cache[eos] = [eos]
+        self.bosToken = vocabulary[bos]!
+        self.eosToken = vocabulary[eos]!
+    }
+
+    func bpe(text: String) -> [String] {
+        if let result = cache[text] {
+            return result
+        }
+
+        precondition(!text.isEmpty)
+
+        var unigrams = text.dropLast().map { String($0) } + ["\(text.last!)</w>"]
+        var uniqueBigrams = Set(zip(unigrams, unigrams.dropFirst()).map { Bigram($0) })
+
+        // In every iteration try to merge the two most likely bigrams. If none
+        // was merged we are done
+
+        while !uniqueBigrams.isEmpty {
+            let (bigram, _) =
+                uniqueBigrams
+                .map { ($0, bpeRanks[$0] ?? Int.max) }
+                .min { $0.1 < $1.1 }!
+
+            if bpeRanks[bigram] == nil {
+                break
+            }
+
+            var newUnigrams = [String]()
+            var skip = false
+
+            for (a, b) in zip(unigrams, unigrams.dropFirst()) {
+                if skip {
+                    skip = false
+                    continue
+                }
+
+                if Bigram(a, b) == bigram {
+                    newUnigrams.append(a + b)
+                    skip = true
+                } else {
+                    newUnigrams.append(a)
+                }
+            }
+
+            if !skip, let last = unigrams.last {
+                newUnigrams.append(last)
+            }
+
+            unigrams = newUnigrams
+            uniqueBigrams = Set(zip(unigrams, unigrams.dropFirst()).map { Bigram($0) })
+        }
+
+        cache[text] = unigrams
+
+        return unigrams
+    }
+
+    public func tokenize(text: String) -> [Int32] {
+        // Lower case cleanup and split according to self.pat. Hugging Face does
+        // a much more thorough job here but this should suffice for 95% of
+        // cases.
+
+        let clean = text.lowercased().replacing(#/\s+/#, with: " ")
+        let tokens = clean.matches(of: pattern).map { $0.description }
+
+        // Split the tokens according to the byte-pair merge file
+        let bpeTokens = tokens.flatMap { bpe(text: String($0)) }
+
+        // Map to token ids and return
+        let result = [bosToken] + bpeTokens.compactMap { vocabulary[$0] } + [eosToken]
+
+        return result.map { Int32($0) }
+    }
+}
+
+#endif

--- a/Sources/StableDiffusion/UNet.swift
+++ b/Sources/StableDiffusion/UNet.swift
@@ -1,0 +1,515 @@
+// Vendored from github.com/ml-explore/mlx-swift-examples (MIT License, Copyright 2024 ml-explore)
+// See Sources/StableDiffusion/LICENSE for full terms.
+#if MLX
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+import MLX
+import MLXNN
+
+// port of https://github.com/ml-explore/mlx-examples/blob/main/stable_diffusion/stable_diffusion/unet.py
+
+func upsampleNearest(_ x: MLXArray, scale: Int = 2) -> MLXArray {
+    precondition(x.ndim == 4)
+    let (B, H, W, C) = x.shape4
+    var x = broadcast(
+        x[0..., 0..., .newAxis, 0..., .newAxis, 0...], to: [B, H, scale, W, scale, C])
+    x = x.reshaped(B, H * scale, W * scale, C)
+    return x
+}
+
+class TimestepEmbedding: Module, UnaryLayer {
+
+    @ModuleInfo(key: "linear_1") var linear1: Linear
+    @ModuleInfo(key: "linear_2") var linear2: Linear
+
+    init(inputChannels: Int, timeEmbedDimensions: Int) {
+        self._linear1.wrappedValue = Linear(inputChannels, timeEmbedDimensions)
+        self._linear2.wrappedValue = Linear(timeEmbedDimensions, timeEmbedDimensions)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var x = linear1(x)
+        x = silu(x)
+        x = linear2(x)
+
+        return x
+    }
+}
+
+class TransformerBlock: Module {
+
+    let norm1: LayerNorm
+    let attn1: MultiHeadAttention
+
+    let norm2: LayerNorm
+    let attn2: MultiHeadAttention
+
+    let norm3: LayerNorm
+    @ModuleInfo var linear1: Linear
+    @ModuleInfo var linear2: Linear
+    @ModuleInfo var linear3: Linear
+
+    init(
+        modelDimensions: Int, numHeads: Int, hiddenDimensions: Int? = nil,
+        memoryDimensions: Int? = nil
+    ) {
+        norm1 = LayerNorm(dimensions: modelDimensions)
+        attn1 = MultiHeadAttention(dimensions: modelDimensions, numHeads: numHeads)
+
+        // we want to self.attn1.out_proj.bias = mx.zeros(model_dims) turn enable the
+        // bias in one of the four Linears attached to attn1. Since bias is nil we can't
+        // update it so just replace the layer.
+        attn1.update(
+            modules: ModuleChildren(
+                values: ["out_proj": .value(Linear(modelDimensions, modelDimensions, bias: true))]))
+
+        let memoryDimensions = memoryDimensions ?? modelDimensions
+        self.norm2 = LayerNorm(dimensions: modelDimensions)
+        self.attn2 = MultiHeadAttention(
+            dimensions: modelDimensions, numHeads: numHeads, keyInputDimensions: memoryDimensions)
+        attn2.update(
+            modules: ModuleChildren(
+                values: ["out_proj": .value(Linear(modelDimensions, modelDimensions, bias: true))]))
+
+        let hiddenDimensions = hiddenDimensions ?? (4 * modelDimensions)
+        self.norm3 = LayerNorm(dimensions: modelDimensions)
+        self.linear1 = Linear(modelDimensions, hiddenDimensions)
+        self.linear2 = Linear(modelDimensions, hiddenDimensions)
+        self.linear3 = Linear(hiddenDimensions, modelDimensions)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, memory: MLXArray, attentionMask: MLXArray?, memoryMask: MLXArray?
+    ) -> MLXArray {
+        var x = x
+
+        // self attention
+        var y = norm1(x)
+        y = attn1(y, keys: y, values: y, mask: attentionMask)
+        x = x + y
+
+        // cross attention
+        y = norm2(x)
+        y = attn2(y, keys: memory, values: memory, mask: memoryMask)
+        x = x + y
+
+        // FFN
+        y = norm3(x)
+        let ya = linear1(y)
+        let yb = linear2(y)
+        y = ya * gelu(yb)
+        y = linear3(y)
+        x = x + y
+
+        return x
+    }
+}
+
+/// A transformer model for inputs with 2 spatial dimensions
+class Transformer2D: Module {
+
+    let norm: GroupNorm
+    @ModuleInfo(key: "proj_in") var projectIn: Linear
+    @ModuleInfo(key: "transformer_blocks") var transformerBlocks: [TransformerBlock]
+    @ModuleInfo(key: "proj_out") var projectOut: Linear
+
+    init(
+        inputChannels: Int, modelDimensions: Int, encoderDimensions: Int, numHeads: Int,
+        numLayers: Int, groupCount: Int = 32
+    ) {
+        self.norm = GroupNorm(
+            groupCount: groupCount, dimensions: inputChannels, pytorchCompatible: true)
+        self._projectIn.wrappedValue = Linear(inputChannels, modelDimensions)
+        self._transformerBlocks.wrappedValue = (0 ..< numLayers)
+            .map { _ in
+                TransformerBlock(
+                    modelDimensions: modelDimensions, numHeads: numHeads,
+                    memoryDimensions: encoderDimensions)
+            }
+        self._projectOut.wrappedValue = Linear(modelDimensions, inputChannels)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, encoderX: MLXArray, attentionMask: MLXArray?, encoderAttentionMask: MLXArray?
+    ) -> MLXArray {
+        let inputX = x
+        let dtype = x.dtype
+        var x = x
+
+        // Perform the input norm and projection
+        let (B, H, W, C) = x.shape4
+        x = norm(x).reshaped(B, -1, C)
+        x = projectIn(x)
+
+        // apply the transformer
+        for block in transformerBlocks {
+            x = block(
+                x, memory: encoderX, attentionMask: attentionMask, memoryMask: encoderAttentionMask)
+        }
+
+        // apply the output projection and reshape
+        x = projectOut(x)
+        x = x.reshaped(B, H, W, C)
+
+        return x + inputX
+    }
+}
+
+class ResnetBlock2D: Module {
+
+    let norm1: GroupNorm
+    let conv1: Conv2d
+
+    @ModuleInfo(key: "time_emb_proj") var timeEmbedProjection: Linear?
+
+    let norm2: GroupNorm
+    let conv2: Conv2d
+
+    @ModuleInfo(key: "conv_shortcut") var convolutionShortcut: Linear?
+
+    init(
+        inputChannels: Int, outputChannels: Int? = nil, groupCount: Int = 32,
+        timeEmbedChannels: Int? = nil
+    ) {
+        let outputChannels = outputChannels ?? inputChannels
+
+        self.norm1 = GroupNorm(
+            groupCount: groupCount, dimensions: inputChannels, pytorchCompatible: true)
+        self.conv1 = Conv2d(
+            inputChannels: inputChannels, outputChannels: outputChannels,
+            kernelSize: 3, stride: 1, padding: 1)
+
+        if let timeEmbedChannels {
+            self._timeEmbedProjection.wrappedValue = Linear(timeEmbedChannels, outputChannels)
+        }
+
+        self.norm2 = GroupNorm(
+            groupCount: groupCount, dimensions: outputChannels, pytorchCompatible: true)
+        self.conv2 = Conv2d(
+            inputChannels: outputChannels, outputChannels: outputChannels,
+            kernelSize: 3, stride: 1, padding: 1)
+
+        if inputChannels != outputChannels {
+            self._convolutionShortcut.wrappedValue = Linear(inputChannels, outputChannels)
+        }
+    }
+
+    func callAsFunction(_ x: MLXArray, timeEmbedding: MLXArray? = nil) -> MLXArray {
+        let dtype = x.dtype
+
+        var y = norm1(x)
+        y = silu(y)
+        y = conv1(y)
+
+        if var timeEmbedding, let timeEmbedProjection {
+            timeEmbedding = timeEmbedProjection(silu(timeEmbedding))
+            y = y + timeEmbedding[0..., .newAxis, .newAxis, 0...]
+        }
+
+        y = norm2(y)
+        y = silu(y)
+        y = conv2(y)
+
+        if let convolutionShortcut {
+            return y + convolutionShortcut(x)
+        } else {
+            return y + x
+        }
+    }
+}
+
+class UNetBlock2D: Module {
+
+    let resnets: [ResnetBlock2D]
+    let attentions: [Transformer2D]?
+    let downsample: Conv2d?
+    let upsample: Conv2d?
+
+    init(
+        inputChannels: Int, outputChannels: Int, timeEmbedChannels: Int,
+        previousOutChannels: Int? = nil, numLayers: Int = 1, transformerLayersPerBlock: Int = 1,
+        numHeads: Int = 8, crossAttentionDimension: Int = 1280, resnetGroups: Int = 32,
+        addDownSample: Bool = true, addUpSample: Bool = true, addCrossAttention: Bool = true
+    ) {
+
+        // Prepare the inputChannelsArray for the resnets
+        let inputChannelsArray: [Int]
+        if let previousOutChannels {
+            let inputChannelsBuild =
+                [previousOutChannels] + Array(repeating: outputChannels, count: numLayers - 1)
+            let resChannelsArray =
+                Array(repeating: outputChannels, count: numLayers - 1) + [inputChannels]
+            inputChannelsArray = zip(inputChannelsBuild, resChannelsArray).map { $0.0 + $0.1 }
+        } else {
+            inputChannelsArray =
+                [inputChannels] + Array(repeating: outputChannels, count: numLayers - 1)
+        }
+
+        // Add resnet blocks that also process the time embedding
+        self.resnets =
+            inputChannelsArray
+            .map { ic in
+                ResnetBlock2D(
+                    inputChannels: ic, outputChannels: outputChannels, groupCount: resnetGroups,
+                    timeEmbedChannels: timeEmbedChannels)
+            }
+
+        // Add optional cross attention layers
+        if addCrossAttention {
+            self.attentions = (0 ..< numLayers)
+                .map { _ in
+                    Transformer2D(
+                        inputChannels: outputChannels, modelDimensions: outputChannels,
+                        encoderDimensions: crossAttentionDimension, numHeads: numHeads,
+                        numLayers: transformerLayersPerBlock)
+                }
+        } else {
+            self.attentions = nil
+        }
+
+        // Add an optional downsampling layer
+        if addDownSample {
+            self.downsample = Conv2d(
+                inputChannels: outputChannels, outputChannels: outputChannels, kernelSize: 3,
+                stride: 2, padding: 1)
+        } else {
+            self.downsample = nil
+        }
+
+        // or upsampling layer
+        if addUpSample {
+            self.upsample = Conv2d(
+                inputChannels: outputChannels, outputChannels: outputChannels, kernelSize: 3,
+                stride: 1, padding: 1)
+        } else {
+            self.upsample = nil
+        }
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, encoderX: MLXArray, timeEmbedding: MLXArray? = nil,
+        attentionMask: MLXArray? = nil, encoderAttentionMask: MLXArray? = nil,
+        residualHiddenStates: [MLXArray]? = nil
+    ) -> (MLXArray, [MLXArray], [MLXArray]) {
+        var x = x
+        var outputStates = [MLXArray]()
+        var residualHiddenStates = residualHiddenStates
+
+        for i in 0 ..< resnets.count {
+            if residualHiddenStates != nil {
+                x = concatenated([x, residualHiddenStates!.removeLast()], axis: -1)
+            }
+
+            x = resnets[i](x, timeEmbedding: timeEmbedding)
+
+            if let attentions {
+                x = attentions[i](
+                    x, encoderX: encoderX, attentionMask: attentionMask,
+                    encoderAttentionMask: encoderAttentionMask)
+            }
+
+            outputStates.append(x)
+        }
+
+        if let downsample {
+            x = downsample(x)
+            outputStates.append(x)
+        }
+
+        if let upsample {
+            x = upsample(upsampleNearest(x))
+            outputStates.append(x)
+        }
+
+        if let residualHiddenStates {
+            return (x, outputStates, residualHiddenStates)
+        } else {
+            return (x, outputStates, [])
+        }
+    }
+}
+
+class UNetModel: Module {
+
+    @ModuleInfo(key: "conv_in") var convIn: Conv2d
+    let timesteps: SinusoidalPositionalEncoding
+    @ModuleInfo(key: "time_embedding") var timeEmbedding: TimestepEmbedding
+
+    @ModuleInfo(key: "addition_embed_type") var addTimeProj: SinusoidalPositionalEncoding?
+    @ModuleInfo(key: "add_embedding") var addEmbedding: TimestepEmbedding?
+
+    @ModuleInfo(key: "down_blocks") var downBlocks: [UNetBlock2D]
+    @ModuleInfo(key: "mid_blocks") var midBlocks: (ResnetBlock2D, Transformer2D, ResnetBlock2D)
+    @ModuleInfo(key: "up_blocks") var upBlocks: [UNetBlock2D]
+
+    @ModuleInfo(key: "conv_norm_out") var convNormOut: GroupNorm
+    @ModuleInfo(key: "conv_out") var convOut: Conv2d
+
+    init(configuration: UNetConfiguration) {
+        let channels0 = configuration.blockOutChannels[0]
+
+        self._convIn.wrappedValue = Conv2d(
+            inputChannels: configuration.inputChannels, outputChannels: channels0,
+            kernelSize: .init(configuration.convolutionInKernel),
+            padding: .init((configuration.convolutionInKernel - 1) / 2))
+
+        self.timesteps = SinusoidalPositionalEncoding(
+            dimensions: channels0,
+            minFrequency: exp(-log(10_000) + 2 * log(10_000) / Float(channels0)),
+            maxFrequency: 1, scale: 1, cosineFirst: true, fullTurns: false)
+
+        self._timeEmbedding.wrappedValue = TimestepEmbedding(
+            inputChannels: channels0, timeEmbedDimensions: channels0 * 4)
+
+        if configuration.additionEmbedType == "text_time",
+            let additionTimeEmbedDimension = configuration.additionTimeEmbedDimension,
+            let projectionClassEmbeddingsInputDimension = configuration
+                .projectionClassEmbeddingsInputDimension
+        {
+            self._addTimeProj.wrappedValue = SinusoidalPositionalEncoding(
+                dimensions: additionTimeEmbedDimension,
+                minFrequency: exp(
+                    -log(10_000) + 2 * log(10_000) / Float(additionTimeEmbedDimension)),
+                maxFrequency: 1,
+                scale: 1, cosineFirst: true, fullTurns: false)
+
+            self._addEmbedding.wrappedValue = TimestepEmbedding(
+                inputChannels: projectionClassEmbeddingsInputDimension,
+                timeEmbedDimensions: channels0 * 4)
+        }
+
+        // make the downsampling blocks
+        let downblockChannels = [channels0] + configuration.blockOutChannels
+        self._downBlocks.wrappedValue = zip(downblockChannels, downblockChannels.dropFirst())
+            .enumerated()
+            .map { (i, pair) in
+                let (inChannels, outChannels) = pair
+                return UNetBlock2D(
+                    inputChannels: inChannels,
+                    outputChannels: outChannels,
+                    timeEmbedChannels: channels0 * 4,
+                    numLayers: configuration.layersPerBlock[i],
+                    transformerLayersPerBlock: configuration.transformerLayersPerBlock[i],
+                    numHeads: configuration.numHeads[i],
+                    crossAttentionDimension: configuration.crossAttentionDimension[i],
+                    resnetGroups: configuration.normNumGroups,
+                    addDownSample: i < configuration.blockOutChannels.count - 1,
+                    addUpSample: false,
+                    addCrossAttention: configuration.downBlockTypes[i].contains("CrossAttn")
+                )
+            }
+
+        // make the middle block
+        let channelsLast = configuration.blockOutChannels.last!
+        self._midBlocks.wrappedValue = (
+            ResnetBlock2D(
+                inputChannels: channelsLast,
+                outputChannels: channelsLast,
+                groupCount: configuration.normNumGroups,
+                timeEmbedChannels: channels0 * 4
+            ),
+            Transformer2D(
+                inputChannels: channelsLast,
+                modelDimensions: channelsLast,
+                encoderDimensions: configuration.crossAttentionDimension.last!,
+                numHeads: configuration.numHeads.last!,
+                numLayers: configuration.transformerLayersPerBlock.last!
+            ),
+            ResnetBlock2D(
+                inputChannels: channelsLast,
+                outputChannels: channelsLast,
+                groupCount: configuration.normNumGroups,
+                timeEmbedChannels: channels0 * 4
+            )
+        )
+
+        // make the upsampling blocks
+        let upblockChannels =
+            [channels0] + configuration.blockOutChannels + [configuration.blockOutChannels.last!]
+        self._upBlocks.wrappedValue =
+            zip(upblockChannels, zip(upblockChannels.dropFirst(), upblockChannels.dropFirst(2)))
+            .enumerated()
+            .reversed()
+            .map { (i, triple) in
+                let (inChannels, (outChannels, prevOutChannels)) = triple
+                return UNetBlock2D(
+                    inputChannels: inChannels,
+                    outputChannels: outChannels,
+                    timeEmbedChannels: channels0 * 4,
+                    previousOutChannels: prevOutChannels,
+                    numLayers: configuration.layersPerBlock[i] + 1,
+                    transformerLayersPerBlock: configuration.transformerLayersPerBlock[i],
+                    numHeads: configuration.numHeads[i],
+                    crossAttentionDimension: configuration.crossAttentionDimension[i],
+                    resnetGroups: configuration.normNumGroups,
+                    addDownSample: false,
+                    addUpSample: i > 0,
+                    addCrossAttention: configuration.upBlockTypes[i].contains("CrossAttn")
+                )
+            }
+
+        self._convNormOut.wrappedValue = GroupNorm(
+            groupCount: configuration.normNumGroups, dimensions: channels0, pytorchCompatible: true)
+        self._convOut.wrappedValue = Conv2d(
+            inputChannels: channels0, outputChannels: configuration.outputChannels,
+            kernelSize: .init(configuration.convolutionOutKernel),
+            padding: .init((configuration.convolutionOutKernel - 1) / 2))
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, timestep: MLXArray, encoderX: MLXArray, attentionMask: MLXArray? = nil,
+        encoderAttentionMask: MLXArray? = nil, textTime: (MLXArray, MLXArray)? = nil
+    ) -> MLXArray {
+        // compute the time embeddings
+        var temb = timesteps(timestep).asType(x.dtype)
+        temb = timeEmbedding(temb)
+
+        // add the extra textTime conditioning
+        if let (textEmbedding, timeIds) = textTime,
+            let addTimeProj, let addEmbedding
+        {
+            var emb = addTimeProj(timeIds).flattened(start: 1).asType(x.dtype)
+            emb = concatenated([textEmbedding, emb], axis: -1)
+            emb = addEmbedding(emb)
+            temb = temb + emb
+        }
+
+        // preprocess the input
+        var x = convIn(x)
+
+        // run the downsampling part of the unet
+        var residuals = [x]
+        for block in self.downBlocks {
+            let res: [MLXArray]
+            (x, res, _) = block(
+                x, encoderX: encoderX, timeEmbedding: temb, attentionMask: attentionMask,
+                encoderAttentionMask: encoderAttentionMask)
+            residuals.append(contentsOf: res)
+        }
+
+        // run the middle part of the unet
+        x = midBlocks.0(x, timeEmbedding: temb)
+        x = midBlocks.1(
+            x, encoderX: encoderX, attentionMask: attentionMask,
+            encoderAttentionMask: encoderAttentionMask)
+        x = midBlocks.2(x, timeEmbedding: temb)
+
+        // run the upsampling part of the unet
+        for block in self.upBlocks {
+            (x, _, residuals) = block(
+                x, encoderX: encoderX, timeEmbedding: temb, attentionMask: attentionMask,
+                encoderAttentionMask: encoderAttentionMask, residualHiddenStates: residuals)
+        }
+
+        // postprocess the output
+        let dtype = x.dtype
+        x = convNormOut(x)
+        x = silu(x)
+        x = convOut(x)
+
+        return x
+    }
+}
+
+#endif

--- a/Sources/StableDiffusion/VAE.swift
+++ b/Sources/StableDiffusion/VAE.swift
@@ -1,0 +1,323 @@
+// Vendored from github.com/ml-explore/mlx-swift-examples (MIT License, Copyright 2024 ml-explore)
+// See Sources/StableDiffusion/LICENSE for full terms.
+#if MLX
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+import MLX
+import MLXNN
+
+// port of https://github.com/ml-explore/mlx-examples/blob/main/stable_diffusion/stable_diffusion/vae.py
+
+class Attention: Module, UnaryLayer {
+
+    @ModuleInfo(key: "group_norm") public var groupNorm: GroupNorm
+
+    @ModuleInfo(key: "query_proj") public var queryProjection: Linear
+    @ModuleInfo(key: "key_proj") public var keyProjection: Linear
+    @ModuleInfo(key: "value_proj") public var valueProjection: Linear
+    @ModuleInfo(key: "out_proj") public var outProjection: Linear
+
+    init(dimensions: Int, groupCount: Int = 32) {
+        self._groupNorm.wrappedValue = GroupNorm(
+            groupCount: groupCount, dimensions: dimensions, pytorchCompatible: true)
+
+        self._queryProjection.wrappedValue = Linear(dimensions, dimensions)
+        self._keyProjection.wrappedValue = Linear(dimensions, dimensions)
+        self._valueProjection.wrappedValue = Linear(dimensions, dimensions)
+        self._outProjection.wrappedValue = Linear(dimensions, dimensions)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let (B, H, W, C) = x.shape4
+
+        var y = groupNorm(x)
+
+        let queries = queryProjection(y).reshaped(B, H * W, C)
+        let keys = keyProjection(y).reshaped(B, H * W, C)
+        let values = valueProjection(y).reshaped(B, H * W, C)
+
+        let scale = 1 / sqrt(Float(queries.dim(-1)))
+        let scores = (queries * scale).matmul(keys.transposed(0, 2, 1))
+        let attention = softmax(scores, axis: -1)
+
+        y = matmul(attention, values).reshaped(B, H, W, C)
+        y = outProjection(y)
+
+        return x + y
+    }
+}
+
+class EncoderDecoderBlock2D: Module, UnaryLayer {
+
+    let resnets: [ResnetBlock2D]
+    let downsample: Conv2d?
+    let upsample: Conv2d?
+
+    init(
+        inputChannels: Int, outputChannels: Int, numLayers: Int = 1, resnetGroups: Int = 32,
+        addDownSample: Bool = true, addUpSample: Bool = true
+    ) {
+        // Add the resnet blocks
+        self.resnets = (0 ..< numLayers)
+            .map { i in
+                ResnetBlock2D(
+                    inputChannels: i == 0 ? inputChannels : outputChannels,
+                    outputChannels: outputChannels,
+                    groupCount: resnetGroups)
+            }
+
+        // Add an optional downsampling layer
+        if addDownSample {
+            self.downsample = Conv2d(
+                inputChannels: outputChannels, outputChannels: outputChannels, kernelSize: 3,
+                stride: 2, padding: 0)
+        } else {
+            self.downsample = nil
+        }
+
+        // or upsampling layer
+        if addUpSample {
+            self.upsample = Conv2d(
+                inputChannels: outputChannels, outputChannels: outputChannels, kernelSize: 3,
+                stride: 1, padding: 1)
+        } else {
+            self.upsample = nil
+        }
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var x = x
+
+        for resnet in resnets {
+            x = resnet(x)
+        }
+
+        if let downsample {
+            x = padded(x, widths: [[0, 0], [0, 1], [0, 1], [0, 0]])
+            x = downsample(x)
+        }
+
+        if let upsample {
+            x = upsample(upsampleNearest(x))
+        }
+
+        return x
+    }
+}
+
+/// Implements the encoder side of the Autoencoder
+class VAEncoder: Module, UnaryLayer {
+
+    @ModuleInfo(key: "conv_in") var convIn: Conv2d
+    @ModuleInfo(key: "down_blocks") var downBlocks: [EncoderDecoderBlock2D]
+    @ModuleInfo(key: "mid_blocks") var midBlocks: (ResnetBlock2D, Attention, ResnetBlock2D)
+    @ModuleInfo(key: "conv_norm_out") var convNormOut: GroupNorm
+    @ModuleInfo(key: "conv_out") var convOut: Conv2d
+
+    init(
+        inputChannels: Int, outputChannels: Int, blockOutChannels: [Int] = [64],
+        layersPerBlock: Int = 2, resnetGroups: Int = 32
+    ) {
+        let channels0 = blockOutChannels[0]
+
+        self._convIn.wrappedValue = Conv2d(
+            inputChannels: inputChannels, outputChannels: channels0, kernelSize: 3, stride: 1,
+            padding: 1)
+
+        let downblockChannels = [channels0] + blockOutChannels
+        self._downBlocks.wrappedValue = zip(downblockChannels, downblockChannels.dropFirst())
+            .enumerated()
+            .map { (i, pair) in
+                let (inChannels, outChannels) = pair
+                return EncoderDecoderBlock2D(
+                    inputChannels: inChannels, outputChannels: outChannels,
+                    numLayers: layersPerBlock, resnetGroups: resnetGroups,
+                    addDownSample: i < blockOutChannels.count - 1,
+                    addUpSample: false
+                )
+            }
+
+        let channelsLast = blockOutChannels.last!
+        self._midBlocks.wrappedValue = (
+            ResnetBlock2D(
+                inputChannels: channelsLast,
+                outputChannels: channelsLast,
+                groupCount: resnetGroups
+            ),
+            Attention(dimensions: channelsLast, groupCount: resnetGroups),
+            ResnetBlock2D(
+                inputChannels: channelsLast,
+                outputChannels: channelsLast,
+                groupCount: resnetGroups
+            )
+        )
+
+        self._convNormOut.wrappedValue = GroupNorm(
+            groupCount: resnetGroups, dimensions: channelsLast, pytorchCompatible: true)
+        self._convOut.wrappedValue = Conv2d(
+            inputChannels: channelsLast, outputChannels: outputChannels,
+            kernelSize: 3,
+            padding: 1)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var x = convIn(x)
+
+        for l in downBlocks {
+            x = l(x)
+        }
+
+        x = midBlocks.0(x)
+        x = midBlocks.1(x)
+        x = midBlocks.2(x)
+
+        x = convNormOut(x)
+        x = silu(x)
+        x = convOut(x)
+
+        return x
+    }
+}
+
+/// Implements the decoder side of the Autoencoder
+class VADecoder: Module, UnaryLayer {
+
+    @ModuleInfo(key: "conv_in") var convIn: Conv2d
+    @ModuleInfo(key: "mid_blocks") var midBlocks: (ResnetBlock2D, Attention, ResnetBlock2D)
+    @ModuleInfo(key: "up_blocks") var upBlocks: [EncoderDecoderBlock2D]
+    @ModuleInfo(key: "conv_norm_out") var convNormOut: GroupNorm
+    @ModuleInfo(key: "conv_out") var convOut: Conv2d
+
+    init(
+        inputChannels: Int, outputChannels: Int, blockOutChannels: [Int] = [64],
+        layersPerBlock: Int = 2, resnetGroups: Int = 32
+    ) {
+        let channels0 = blockOutChannels[0]
+        let channelsLast = blockOutChannels.last!
+
+        self._convIn.wrappedValue = Conv2d(
+            inputChannels: inputChannels, outputChannels: channelsLast, kernelSize: 3, stride: 1,
+            padding: 1)
+
+        self._midBlocks.wrappedValue = (
+            ResnetBlock2D(
+                inputChannels: channelsLast,
+                outputChannels: channelsLast,
+                groupCount: resnetGroups
+            ),
+            Attention(dimensions: channelsLast, groupCount: resnetGroups),
+            ResnetBlock2D(
+                inputChannels: channelsLast,
+                outputChannels: channelsLast,
+                groupCount: resnetGroups
+            )
+        )
+
+        let channels = [channelsLast] + blockOutChannels.reversed()
+        self._upBlocks.wrappedValue = zip(channels, channels.dropFirst())
+            .enumerated()
+            .map { (i, pair) in
+                let (inChannels, outChannels) = pair
+                return EncoderDecoderBlock2D(
+                    inputChannels: inChannels,
+                    outputChannels: outChannels,
+                    numLayers: layersPerBlock,
+                    resnetGroups: resnetGroups,
+                    addDownSample: false,
+                    addUpSample: i < blockOutChannels.count - 1
+                )
+            }
+
+        self._convNormOut.wrappedValue = GroupNorm(
+            groupCount: resnetGroups, dimensions: channels0, pytorchCompatible: true)
+        self._convOut.wrappedValue = Conv2d(
+            inputChannels: channels0, outputChannels: outputChannels,
+            kernelSize: 3,
+            padding: 1)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var x = convIn(x)
+
+        x = midBlocks.0(x)
+        x = midBlocks.1(x)
+        x = midBlocks.2(x)
+
+        for l in upBlocks {
+            x = l(x)
+        }
+
+        x = convNormOut(x)
+        x = silu(x)
+        x = convOut(x)
+
+        return x
+    }
+}
+
+/// The autoencoder that allows us to perform diffusion in the latent space
+class Autoencoder: Module {
+
+    let latentChannels: Int
+    let scalingFactor: Float
+    let encoder: VAEncoder
+    let decoder: VADecoder
+
+    @ModuleInfo(key: "quant_proj") public var quantProjection: Linear
+    @ModuleInfo(key: "post_quant_proj") public var postQuantProjection: Linear
+
+    init(configuration: AutoencoderConfiguration) {
+        self.latentChannels = configuration.latentChannelsIn
+        self.scalingFactor = configuration.scalingFactor
+        self.encoder = VAEncoder(
+            inputChannels: configuration.inputChannels,
+            outputChannels: configuration.latentChannelsOut,
+            blockOutChannels: configuration.blockOutChannels,
+            layersPerBlock: configuration.layersPerBlock,
+            resnetGroups: configuration.normNumGroups)
+        self.decoder = VADecoder(
+            inputChannels: configuration.latentChannelsIn,
+            outputChannels: configuration.outputChannels,
+            blockOutChannels: configuration.blockOutChannels,
+            layersPerBlock: configuration.layersPerBlock + 1,
+            resnetGroups: configuration.normNumGroups)
+
+        self._quantProjection.wrappedValue = Linear(
+            configuration.latentChannelsIn, configuration.latentChannelsOut)
+        self._postQuantProjection.wrappedValue = Linear(
+            configuration.latentChannelsIn, configuration.latentChannelsIn)
+    }
+
+    func decode(_ z: MLXArray) -> MLXArray {
+        let z = z / scalingFactor
+        return decoder(postQuantProjection(z))
+    }
+
+    func encode(_ x: MLXArray) -> (MLXArray, MLXArray) {
+        var x = encoder(x)
+        x = quantProjection(x)
+        var (mean, logvar) = x.split(axis: -1)
+        mean = mean * scalingFactor
+        logvar = logvar + 2 * log(scalingFactor)
+
+        return (mean, logvar)
+    }
+
+    struct Result {
+        let xHat: MLXArray
+        let z: MLXArray
+        let mean: MLXArray
+        let logvar: MLXArray
+    }
+
+    func callAsFunction(_ x: MLXArray, key: MLXArray? = nil) -> Result {
+        let (mean, logvar) = encode(x)
+        let z = MLXRandom.normal(mean.shape, key: key) * exp(0.5 * logvar) + mean
+        let xHat = decode(z)
+
+        return Result(xHat: xHat, z: z, mean: mean, logvar: logvar)
+    }
+}
+
+#endif

--- a/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
+++ b/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
@@ -440,3 +440,15 @@ BaseChatBackends/MLXDiffusionBackend.swift:return (try? FileManager.default.attr
 # BCK's slug-based download path to Hub's expected directory convention;
 # removal is pure cleanup and its result is never actionable.
 BaseChatBackends/MLXDiffusionBackend.swift:return (tmpBase, { try? FileManager.default.removeItem(at: tmpBase) })
+
+# ---------------------------------------------------------------------------
+# StableDiffusion — vendored from mlx-swift-examples (MIT, PR #1068)
+# ---------------------------------------------------------------------------
+
+# Optional JSON field decoding in UNet/VAE configuration. These keys are
+# absent from older stable-diffusion checkpoints; nil is the correct fallback,
+# not an error to surface. Uses the "try-each-key-or-nil" pattern.
+StableDiffusion/Configuration.swift:try (try? container.decode([Int].self, forKey: .layersPerBlock))
+StableDiffusion/Configuration.swift:(try? container.decode([Int].self, forKey: .transformerLayersPerBlock)) ?? [1, 1, 1, 1]
+StableDiffusion/Configuration.swift:try (try? container.decodeIfPresent([Int].self, forKey: .numHeads))
+StableDiffusion/Configuration.swift:try (try? container.decode([Int].self, forKey: .crossAttentionDimension))


### PR DESCRIPTION
## Summary

Two consumer-facing bugs reported against 0.17.3, both in the MLX path.

**Bug 1 — Swift 6 `#SendingRisksDataRace` in `MLXGenerationDriver.swift:88`**

The `withErrorHandler` body closure was formed inside `@MainActor run()`, so Swift 6 treated it as a non-Sendable `@MainActor`-isolated value being sent to the nonisolated global function `withErrorHandler`. The compiler error:

```
sending main actor-isolated value of non-Sendable type '() async throws -> AsyncStream<Generation>'
to nonisolated global function 'withErrorHandler' risks causing races
```

Fix: mark both the handler and body closures `@Sendable`. All captured parameters (`container`, `generationInput`, `cache`, `generateConfig`) already conform to `Sendable`; `ModelContainer.generate` manages its own actor isolation internally via `perform`/`context.read`, so removing the implicit `@MainActor` is safe.

**Bug 2 — mlx-swift-examples iOS 16 vs iOS 17 SPM platform conflict**

`mlx-swift-examples` at the pinned revision declares `platforms: [.iOS(.v16)]` but its dependency `mlx-swift` requires iOS 17. This causes a SPM platform-validation error for consumers on Xcode 15+. No upstream commit or tag resolves both that platform mismatch and the `swift-transformers >=1.2.0` requirement simultaneously.

Fix: vendor the 9-file `StableDiffusion` library (MIT License, Copyright 2024 ml-explore) into `Sources/StableDiffusion/`. Each file is wrapped in `#if MLX … #endif` guards so non-MLX builds compile to empty modules. The `mlx-swift-examples` package dependency is removed from `Package.swift`. If upstream cuts a clean tag, revert; tracked in #1002.

## Test plan

- [ ] `swift build --target BaseChatBackends --traits MLX` — clean (no `#SendingRisksDataRace`)
- [ ] `swift build --build-tests --disable-default-traits` — clean
- [ ] `swift build --target StableDiffusion --traits MLX` — StableDiffusion vendored target compiles
- [ ] `swift build --target StableDiffusion --disable-default-traits` — compiles to empty module
- [ ] CI green on all suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)