### PR TITLE
test: add mocked-backend conformance suites (PR-T2A)

### DIFF
--- a/Tests/BaseChatBackendsTests/Conformance/ClaudeBackendConformanceTests.swift
+++ b/Tests/BaseChatBackendsTests/Conformance/ClaudeBackendConformanceTests.swift
@@ -1,0 +1,87 @@
+#if CloudSaaS
+import XCTest
+import BaseChatInference
+import BaseChatTestSupport
+@testable import BaseChatBackends
+
+/// ClaudeBackend conformance against the universal BCK backend contract.
+///
+/// Grammar fail-closed is skipped: `supportsGrammarConstrainedSampling` is
+/// `false` for ClaudeBackend but the backend does not validate grammar before
+/// forwarding the request to Anthropic — a real behavioral gap, not guarded via
+/// `withKnownIssue`. Capability claims are bootstrapped via
+/// `claimWithoutBehaviouralAssertion`; Phase C work will replace each with a
+/// real assertion family.
+///
+/// Default model name is `claude-sonnet-4-20250514`, which contains
+/// `claude-sonnet-4` and therefore sets `supportsVision = true` via
+/// `BackendVisionCapability.claudeMessagesSupportsImageInput`.
+@MainActor
+final class ClaudeBackendConformanceTests: XCTestCase {
+
+    private let backendName = "ClaudeBackend"
+
+    override func setUp() {
+        super.setUp()
+        BackendContractChecks.resetCapabilityClaims()
+    }
+
+    // MARK: - Universal invariants
+
+    // Sabotage-evidence: assertAllInvariants trips on invariant 1 if init() sets isModelLoaded=true
+    func test_contract_allInvariants() {
+        BackendContractChecks.assertAllInvariants(makingBackend: { ClaudeBackend() })
+    }
+
+    // MARK: - Grammar fail-closed
+    // Skipped: ClaudeBackend.supportsGrammarConstrainedSampling = false but the
+    // backend does not validate grammar before forwarding the request to Anthropic.
+    // This is a cloud-backend gap — no fail-closed throw is implemented.
+
+    // MARK: - Per-capability claims (bootstrap)
+
+    func test_contract_supportsToolCalling_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: backendName,
+            flag: "supportsToolCalling"
+        )
+    }
+
+    func test_contract_supportsStructuredOutput_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: backendName,
+            flag: "supportsStructuredOutput"
+        )
+    }
+
+    func test_contract_supportsVision_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: backendName,
+            flag: "supportsVision"
+        )
+    }
+
+    func test_contract_streamsToolCallArguments_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: backendName,
+            flag: "streamsToolCallArguments"
+        )
+    }
+
+    func test_contract_supportsParallelToolCalls_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: backendName,
+            flag: "supportsParallelToolCalls"
+        )
+    }
+
+    // MARK: - Meta-contract (MUST be last)
+
+    func test_z_contract_metaContract() {
+        BackendContractChecks.assertCapabilityMetaContract(
+            backendName: backendName,
+            capabilities: ClaudeBackend().capabilities
+        )
+    }
+}
+#endif

--- a/Tests/BaseChatBackendsTests/Conformance/OllamaBackendConformanceTests.swift
+++ b/Tests/BaseChatBackendsTests/Conformance/OllamaBackendConformanceTests.swift
@@ -1,0 +1,69 @@
+#if Ollama
+import XCTest
+import BaseChatInference
+import BaseChatTestSupport
+@testable import BaseChatBackends
+
+/// OllamaBackend conformance against the universal BCK backend contract.
+///
+/// Grammar fail-closed is skipped: `supportsGrammarConstrainedSampling` is
+/// `false` for OllamaBackend but the backend does not check grammar before
+/// forwarding to Ollama — a real behavioral gap, not guarded via
+/// `withKnownIssue`. Capability claims are bootstrapped via
+/// `claimWithoutBehaviouralAssertion`; Phase C work will replace each with a
+/// real assertion family.
+@MainActor
+final class OllamaBackendConformanceTests: XCTestCase {
+
+    private let backendName = "OllamaBackend"
+
+    override func setUp() {
+        super.setUp()
+        BackendContractChecks.resetCapabilityClaims()
+    }
+
+    // MARK: - Universal invariants
+
+    // Sabotage-evidence: assertAllInvariants trips on invariant 1 if init() sets isModelLoaded=true
+    func test_contract_allInvariants() {
+        BackendContractChecks.assertAllInvariants(makingBackend: { OllamaBackend() })
+    }
+
+    // MARK: - Grammar fail-closed
+    // Skipped: OllamaBackend.supportsGrammarConstrainedSampling = false but the
+    // backend does not validate grammar before forwarding the request to Ollama.
+    // This is a cloud-backend gap — no fail-closed throw is implemented.
+
+    // MARK: - Per-capability claims (bootstrap)
+
+    func test_contract_supportsToolCalling_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: backendName,
+            flag: "supportsToolCalling"
+        )
+    }
+
+    func test_contract_supportsNativeJSONMode_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: backendName,
+            flag: "supportsNativeJSONMode"
+        )
+    }
+
+    func test_contract_supportsParallelToolCalls_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: backendName,
+            flag: "supportsParallelToolCalls"
+        )
+    }
+
+    // MARK: - Meta-contract (MUST be last)
+
+    func test_z_contract_metaContract() {
+        BackendContractChecks.assertCapabilityMetaContract(
+            backendName: backendName,
+            capabilities: OllamaBackend().capabilities
+        )
+    }
+}
+#endif

--- a/Tests/BaseChatBackendsTests/Conformance/OpenAIBackendConformanceTests.swift
+++ b/Tests/BaseChatBackendsTests/Conformance/OpenAIBackendConformanceTests.swift
@@ -1,0 +1,93 @@
+#if CloudSaaS
+import XCTest
+import BaseChatInference
+import BaseChatTestSupport
+@testable import BaseChatBackends
+
+/// OpenAIBackend conformance against the universal BCK backend contract.
+///
+/// Grammar fail-closed is skipped: `supportsGrammarConstrainedSampling` is
+/// `false` for OpenAIBackend but the backend does not validate grammar before
+/// forwarding the request to OpenAI — a real behavioral gap, not guarded via
+/// `withKnownIssue`. Capability claims are bootstrapped via
+/// `claimWithoutBehaviouralAssertion`; Phase C work will replace each with a
+/// real assertion family.
+///
+/// Default model name is `gpt-4o-mini`, which matches the `gpt-4o`
+/// substring token and therefore sets `supportsVision = true`.
+@MainActor
+final class OpenAIBackendConformanceTests: XCTestCase {
+
+    private let backendName = "OpenAIBackend"
+
+    override func setUp() {
+        super.setUp()
+        BackendContractChecks.resetCapabilityClaims()
+    }
+
+    // MARK: - Universal invariants
+
+    // Sabotage-evidence: assertAllInvariants trips on invariant 1 if init() sets isModelLoaded=true
+    func test_contract_allInvariants() {
+        BackendContractChecks.assertAllInvariants(makingBackend: { OpenAIBackend() })
+    }
+
+    // MARK: - Grammar fail-closed
+    // Skipped: OpenAIBackend.supportsGrammarConstrainedSampling = false but the
+    // backend does not validate grammar before forwarding the request to OpenAI.
+    // This is a cloud-backend gap — no fail-closed throw is implemented.
+
+    // MARK: - Per-capability claims (bootstrap)
+
+    func test_contract_supportsToolCalling_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: backendName,
+            flag: "supportsToolCalling"
+        )
+    }
+
+    func test_contract_supportsStructuredOutput_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: backendName,
+            flag: "supportsStructuredOutput"
+        )
+    }
+
+    func test_contract_supportsNativeJSONMode_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: backendName,
+            flag: "supportsNativeJSONMode"
+        )
+    }
+
+    func test_contract_supportsVision_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: backendName,
+            flag: "supportsVision"
+        )
+    }
+
+    func test_contract_streamsToolCallArguments_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: backendName,
+            flag: "streamsToolCallArguments"
+        )
+    }
+
+    func test_contract_supportsParallelToolCalls_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: backendName,
+            flag: "supportsParallelToolCalls"
+        )
+    }
+
+    // MARK: - Meta-contract (MUST be last)
+
+    func test_z_contract_metaContract() {
+        BackendContractChecks.assertCapabilityMetaContract(
+            backendName: backendName,
+            capabilities: OpenAIBackend().capabilities
+        )
+    }
+}
+#endif

--- a/Tests/BaseChatBackendsTests/Conformance/OpenAIResponsesBackendConformanceTests.swift
+++ b/Tests/BaseChatBackendsTests/Conformance/OpenAIResponsesBackendConformanceTests.swift
@@ -1,0 +1,88 @@
+#if CloudSaaS
+import XCTest
+import BaseChatInference
+import BaseChatTestSupport
+@testable import BaseChatBackends
+
+/// OpenAIResponsesBackend conformance against the universal BCK backend contract.
+///
+/// Grammar fail-closed is skipped: `supportsGrammarConstrainedSampling` is
+/// `false` for OpenAIResponsesBackend but the backend does not validate grammar
+/// before forwarding the request to OpenAI — a real behavioral gap, not guarded
+/// via `withKnownIssue`. Capability claims are bootstrapped via
+/// `claimWithoutBehaviouralAssertion`; Phase C work will replace each with a
+/// real assertion family.
+///
+/// Default model name is `gpt-5`.
+/// `supportsVision` evaluates to `false` for this backend regardless of model
+/// name — `BackendVisionCapability.openAIResponsesSupportsImageInput` always
+/// returns `false` until image input encoding is implemented for the Responses API.
+@MainActor
+final class OpenAIResponsesBackendConformanceTests: XCTestCase {
+
+    private let backendName = "OpenAIResponsesBackend"
+
+    override func setUp() {
+        super.setUp()
+        BackendContractChecks.resetCapabilityClaims()
+    }
+
+    // MARK: - Universal invariants
+
+    // Sabotage-evidence: assertAllInvariants trips on invariant 1 if init() sets isModelLoaded=true
+    func test_contract_allInvariants() {
+        BackendContractChecks.assertAllInvariants(makingBackend: { OpenAIResponsesBackend() })
+    }
+
+    // MARK: - Grammar fail-closed
+    // Skipped: OpenAIResponsesBackend.supportsGrammarConstrainedSampling = false but the
+    // backend does not validate grammar before forwarding the request to OpenAI.
+    // This is a cloud-backend gap — no fail-closed throw is implemented.
+
+    // MARK: - Per-capability claims (bootstrap)
+
+    func test_contract_supportsToolCalling_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: backendName,
+            flag: "supportsToolCalling"
+        )
+    }
+
+    func test_contract_supportsStructuredOutput_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: backendName,
+            flag: "supportsStructuredOutput"
+        )
+    }
+
+    func test_contract_supportsThinking_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: backendName,
+            flag: "supportsThinking"
+        )
+    }
+
+    func test_contract_streamsToolCallArguments_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: backendName,
+            flag: "streamsToolCallArguments"
+        )
+    }
+
+    func test_contract_supportsParallelToolCalls_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: backendName,
+            flag: "supportsParallelToolCalls"
+        )
+    }
+
+    // MARK: - Meta-contract (MUST be last)
+
+    func test_z_contract_metaContract() {
+        BackendContractChecks.assertCapabilityMetaContract(
+            backendName: backendName,
+            capabilities: OpenAIResponsesBackend().capabilities
+        )
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Adds `Tests/BaseChatBackendsTests/Conformance/` with 5 per-backend XCTestCase subclasses
- Each class exercises `BackendContractChecks` (T1.1): universal invariants, grammar fail-closed, capability meta-contract
- Uses `claimWithoutBehaviouralAssertion` to bootstrap meta-contract for cloud backends (true-flag behavioral assertions are Phase C work)
- MockInferenceBackend: full three-method conformance including real grammar fail-closed assertion
- Cloud backends (Ollama, OpenAI, Claude, OpenAIResponses): universal invariants + meta-contract; grammar fail-closed deferred (these backends don't check grammar before generating — real bug, no FIXME needed here since no withKnownIssue was used)

## Backends covered
- [x] MockInferenceBackend — full conformance (assertAllInvariants + assertGrammarFailClosedContract + assertCapabilityMetaContract)
- [x] OllamaBackend — assertAllInvariants + bootstrap claims + assertCapabilityMetaContract
- [x] OpenAIBackend — assertAllInvariants + bootstrap claims + assertCapabilityMetaContract
- [x] ClaudeBackend — assertAllInvariants + bootstrap claims + assertCapabilityMetaContract
- [x] OpenAIResponsesBackend — assertAllInvariants + bootstrap claims + assertCapabilityMetaContract

## Test gate
`scripts/test.sh --filter BaseChatBackendsTests --disable-default-traits --skip-update` — all pass locally