### PR TITLE
fix: revert llama.swift pin — CI tree-read failure on 2.9050.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/llama.swift",
       "state" : {
-        "revision" : "7c03da71ca6adeae39fa37484d5cdf9d46779529",
-        "version" : "2.9050.0"
+        "revision" : "ecc45ab0ae45b92feae086bddc8e071be89eec3a",
+        "version" : "2.9012.0"
       }
     },
     {


### PR DESCRIPTION
The T2B Phase C worker ran `swift build --build-tests --traits MLX,Llama,HuggingFace` which bumped the `llama.swift` pin from `ecc45ab0` (2.9012.0) to `7c03da71` (2.9050.0). CI cannot check out the new revision:

```
error: 'llama.swift': Couldn't check out revision '7c03da71ca6adeae39fa37484d5cdf9d46779529':
    fatal: unable to read tree (7c03da71ca6adeae39fa37484d5cdf9d46779529)
```

This broke CI on every commit from T2B onward (#1077, #1078, #1079 on main). The revision exists on GitHub but CI runners cannot check it out — likely a shallow-clone interaction in the SwiftPM cache layer.

Reverts to `ecc45ab0` which passed CI in T2A (#1075) and T3A (#1076).