### PR TITLE
docs: document Swift 6 concurrency gotchas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,17 @@ For trait conventions, suite layout, classification (Unit / Integration / E2E), 
 
 - **Concurrency**: async/await throughout. No Combine, no callback pyramids.
 - **Observable state**: `@Observable` + `@MainActor`. Not `ObservableObject`/`@Published`.
+
+### Swift 6 concurrency gotchas
+
+These patterns either produce `#SendingRisksDataRace` in strict Swift 6 builds or compile while hiding a real race. Fix the isolation boundary instead of silencing the compiler.
+
+1. **Non-isolated `async` helpers that receive `@MainActor`-capturing closures.** A `with*` helper whose body is `() async throws -> R` sends the closure away from the caller's actor. When the body closes over `@MainActor` state, annotate the closure explicitly, for example `try await withErrorHandler({ ... }) { @MainActor in try await container.generate(...) }`. Watch `withTaskGroup`, `withCheckedContinuation`, and pre-Swift-6 library helpers.
+2. **`@unchecked Sendable` is not a race fix.** A mutable capture box such as `final class Capture: @unchecked Sendable { var message: String? }` is only safe for synchronous same-thread callbacks read back immediately on the same actor. For escaping callbacks or C/library callbacks that can fire on another thread, use an `actor` or a real lock (`OSAllocatedUnfairLock`/`Mutex` where available).
+3. **`@preconcurrency import` is narrow.** It can suppress missing `Sendable` annotations from older libraries, but it does not suppress region-based isolation errors such as the non-isolated closure-sending pattern above. Do not use it as a blanket Swift 6 escape hatch.
+4. **`AsyncStream<T>` inherits `T`'s sendability.** `AsyncStream<Generation>` is `Sendable` only while `Generation` is. If an upstream library adds a non-`Sendable` field, errors often appear at call sites; keep explicit stream annotations like `let stream: AsyncStream<Generation> = ...` so failures point at the declaration.
+5. **Never use `Task.detached` inside `@MainActor` classes.** `Task { }` inherits the current actor; `Task.detached { }` does not, and the compiler may not warn when it captures mutable `@MainActor` properties. Use `Task { }` and let the callee hop off-actor for expensive non-UI work.
+
 - **Persistence**: SwiftData only. No CoreData.
 - **Error handling**: validate at system boundaries only. Don't guard internal invariants the type system already enforces.
 - **Comments**: explain *why*, not *what*.


### PR DESCRIPTION
## Scope
- Fixes/addresses #1056
- Exact slice implemented: added a `Swift 6 concurrency gotchas` section to `CLAUDE.md` covering all five issue patterns: non-isolated async helpers with `@MainActor` captures, unsafe `@unchecked Sendable` capture boxes, `@preconcurrency import` limits, `AsyncStream<T>` sendability inheritance, and `Task.detached` in `@MainActor` classes.
- Explicitly not included: source-code changes, test changes, broader documentation rewrites, or new follow-up issues.

## Product value
This gives contributors a concise checklist for Swift 6 strict-concurrency traps that otherwise surface late as confusing compiler diagnostics or latent races.

## Technical notes
- Modules touched: none; contributor documentation only (`CLAUDE.md`).
- Dependency-boundary statement: no package targets or dependency boundaries changed.
- Public API changes: none.
- Migration/schema changes: none

## Risk and rollback
- Risk level: low; docs-only change.
- Rollback: revert the single documentation commit.

## Validation
- Commands run: `gh issue view 1056 --json number,title,body,url,state`; `git diff --check`.
- Result: issue scope confirmed; diff check passed.
- Tests skipped, if any: build/tests skipped because this is docs-only.

## Autonomous worker notes
- Blockers or assumptions: assumed `CLAUDE.md` is the preferred contributor-facing home because it already contains the repository concurrency conventions.
- Follow-up recommended in PR body only, not a new issue: none.