### PR TITLE
fix: gate streaming usage chunks

### DIFF
--- a/Sources/BaseChatServer/ChatCompletionsAdapter.swift
+++ b/Sources/BaseChatServer/ChatCompletionsAdapter.swift
@@ -500,9 +500,18 @@ extension ChatCompletionsAdapter {
                         created: response.created,
                         model: response.model,
                         choices: [ChatCompletionChunkChoice(index: 0, delta: ChatCompletionDelta(content: response.contentText), finishReason: .stop)],
-                        usage: response.usage
+                        usage: nil
                     )
                     continuation.yield(chunk)
+                    if request.includesStreamUsage, let usage = response.usage {
+                        continuation.yield(ChatCompletionChunk(
+                            id: response.id,
+                            created: response.created,
+                            model: response.model,
+                            choices: [],
+                            usage: usage
+                        ))
+                    }
                     continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)

--- a/Tests/BaseChatServerTests/BaseChatServerSmokeTests.swift
+++ b/Tests/BaseChatServerTests/BaseChatServerSmokeTests.swift
@@ -290,6 +290,67 @@ final class BaseChatServerSmokeTests: XCTestCase {
         }
     }
 
+    func testSSEUsageChunkIsOnlyIncludedWhenRequested() async throws {
+        let server = ServerApp(
+            backendProvider: FakeBackendProvider(models: ["tiny"]),
+            adapter: ResponseOnlyUsageChatAdapter()
+        )
+        let app = server.makeApplication()
+
+        try await app.test(.router) { client in
+            let body = try requestBody(ChatCompletionRequest(
+                model: "tiny",
+                messages: [],
+                stream: true,
+                streamOptions: ChatCompletionStreamOptions(includeUsage: true)
+            ))
+            try await client.execute(uri: "/v1/chat/completions", method: .post, body: body) { response in
+                XCTAssertEqual(response.status, .ok)
+                let text = String(buffer: response.body)
+                let events = try decodeSSEChunks(from: text)
+
+                XCTAssertTrue(text.hasSuffix("data: [DONE]\n\n"))
+                XCTAssertGreaterThanOrEqual(events.count, 2)
+                XCTAssertEqual(events[events.count - 2].choices.first?.finishReason, .stop)
+                XCTAssertNil(events[events.count - 2].usage)
+                XCTAssertEqual(events.last?.choices, [])
+                XCTAssertEqual(events.last?.usage, ChatCompletionUsage(promptTokens: 8, completionTokens: 5))
+            }
+        }
+    }
+
+    func testSSEUsageChunkIsOmittedByDefaultAndWhenFalse() async throws {
+        let server = ServerApp(
+            backendProvider: FakeBackendProvider(models: ["tiny"]),
+            adapter: ResponseOnlyUsageChatAdapter()
+        )
+        let app = server.makeApplication()
+
+        try await app.test(.router) { client in
+            let requests = [
+                ChatCompletionRequest(model: "tiny", messages: [], stream: true),
+                ChatCompletionRequest(
+                    model: "tiny",
+                    messages: [],
+                    stream: true,
+                    streamOptions: ChatCompletionStreamOptions(includeUsage: false)
+                )
+            ]
+
+            for request in requests {
+                let body = try requestBody(request)
+                try await client.execute(uri: "/v1/chat/completions", method: .post, body: body) { response in
+                    XCTAssertEqual(response.status, .ok)
+                    let events = try decodeSSEChunks(from: String(buffer: response.body))
+
+                    XCTAssertEqual(events.count, 1)
+                    XCTAssertEqual(events.last?.choices.first?.finishReason, .stop)
+                    XCTAssertNil(events.last?.usage)
+                }
+            }
+        }
+    }
+
     func testBackendFailureReturns500WithErrorEnvelope() async throws {
         let server = ServerApp(
             backendProvider: FakeBackendProvider(models: ["tiny"]),
@@ -445,6 +506,17 @@ private func requestBody(_ request: ChatCompletionRequest) throws -> ByteBuffer 
     ByteBuffer(bytes: try JSONEncoder().encode(request))
 }
 
+private func decodeSSEChunks(from text: String) throws -> [ChatCompletionChunk] {
+    let decoder = JSONDecoder()
+    return try text.components(separatedBy: "\n\n")
+        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { $0.hasPrefix("data: ") && $0 != "data: [DONE]" }
+        .map { line in
+            let payload = line.dropFirst("data: ".count)
+            return try decoder.decode(ChatCompletionChunk.self, from: Data(payload.utf8))
+        }
+}
+
 private struct FakeBackendProvider: ServerBackendProvider {
     let models: [String]
     let backend: any InferenceBackend
@@ -526,6 +598,29 @@ private struct FixedStreamingChatAdapter: ChatCompletionsAdapter {
             ))
             continuation.finish()
         }
+    }
+}
+
+private struct ResponseOnlyUsageChatAdapter: ChatCompletionsAdapter {
+    func generationConfig(for request: ChatCompletionRequest) throws -> GenerationConfig {
+        GenerationConfig()
+    }
+
+    func response(
+        for request: ChatCompletionRequest,
+        using backend: any InferenceBackend
+    ) async throws -> ChatCompletionResponse {
+        ChatCompletionResponse(
+            id: "chatcmpl-usage",
+            created: 0,
+            model: request.model,
+            choices: [ChatCompletionChoice(
+                index: 0,
+                message: ChatCompletionMessage(role: .assistant, content: "done"),
+                finishReason: .stop
+            )],
+            usage: ChatCompletionUsage(promptTokens: 8, completionTokens: 5)
+        )
     }
 }
 

--- a/Tests/BaseChatServerTests/ChatCompletionsAdapterTests.swift
+++ b/Tests/BaseChatServerTests/ChatCompletionsAdapterTests.swift
@@ -160,6 +160,61 @@ final class ChatCompletionsAdapterTests: XCTestCase {
         XCTAssertEqual(backend.generateCallCount, 1)
     }
 
+    func testUsageEventDoesNotMapToStreamingChunkByDefaultOrWhenFalse() async throws {
+        let requests = [
+            ChatCompletionRequest(
+                model: "m",
+                messages: [ChatCompletionMessage(role: .user, content: "hi")],
+                stream: true
+            ),
+            ChatCompletionRequest(
+                model: "m",
+                messages: [ChatCompletionMessage(role: .user, content: "hi")],
+                stream: true,
+                streamOptions: ChatCompletionStreamOptions(includeUsage: false)
+            )
+        ]
+
+        for request in requests {
+            let backend = EventSequenceBackend(events: [.token("ok"), .usage(prompt: 3, completion: 2)])
+            let chunks = try await collect(try DefaultChatCompletionsAdapter().chunks(for: request, using: backend))
+
+            XCTAssertTrue(chunks.allSatisfy { $0.usage == nil })
+            XCTAssertEqual(chunks.last?.choices.first?.finishReason, .stop)
+        }
+    }
+
+    func testDefaultStreamingAdapterEmitsUsageOnlyWhenRequested() async throws {
+        let response = ChatCompletionResponse(
+            id: "chatcmpl-response-only",
+            created: 42,
+            model: "m",
+            choices: [ChatCompletionChoice(index: 0, message: ChatCompletionMessage(role: .assistant, content: "ok"), finishReason: .stop)],
+            usage: ChatCompletionUsage(promptTokens: 4, completionTokens: 2)
+        )
+        let adapter = ResponseOnlyUsageAdapter(response: response)
+        let backend = EventSequenceBackend(events: [])
+        let defaultRequest = ChatCompletionRequest(
+            model: "m",
+            messages: [ChatCompletionMessage(role: .user, content: "hi")],
+            stream: true
+        )
+        let usageRequest = ChatCompletionRequest(
+            model: "m",
+            messages: [ChatCompletionMessage(role: .user, content: "hi")],
+            stream: true,
+            streamOptions: ChatCompletionStreamOptions(includeUsage: true)
+        )
+
+        let defaultChunks = try await collect(try adapter.chunks(for: defaultRequest, using: backend))
+        let usageChunks = try await collect(try adapter.chunks(for: usageRequest, using: backend))
+
+        XCTAssertEqual(defaultChunks.count, 1)
+        XCTAssertNil(defaultChunks.last?.usage)
+        XCTAssertEqual(usageChunks.last?.choices, [])
+        XCTAssertEqual(usageChunks.last?.usage, ChatCompletionUsage(promptTokens: 4, completionTokens: 2))
+    }
+
     func testNonStreamResponseAssemblesContentReasoningToolCallsAndUsage() async throws {
         let backend = EventSequenceBackend(events: [
             .thinkingToken("think "),
@@ -306,6 +361,21 @@ private final class EventSequenceBackend: InferenceBackend, @unchecked Sendable 
 
     func stopGeneration() {}
     func unloadModel() { isModelLoaded = false }
+}
+
+private struct ResponseOnlyUsageAdapter: ChatCompletionsAdapter {
+    let response: ChatCompletionResponse
+
+    func generationConfig(for request: ChatCompletionRequest) throws -> GenerationConfig {
+        GenerationConfig()
+    }
+
+    func response(
+        for request: ChatCompletionRequest,
+        using backend: any InferenceBackend
+    ) async throws -> ChatCompletionResponse {
+        response
+    }
 }
 
 private final class CapturingBackend: InferenceBackend, @unchecked Sendable {


### PR DESCRIPTION
## Scope
- Fixes/addresses #807
- Exact slice implemented: OpenAI-compatible `stream_options.include_usage` final streaming usage chunks for BaseChatServer response-based streaming fallback, plus server wire and adapter coverage for requested/default/false behavior.
- Explicitly not included: /v1/models richer response, metrics, pass-through, quota, multi-model, distribution, completions, embeddings, logprobs, logit_bias, JSON response-format routing.

## Product value
Clients that request OpenAI streaming usage accounting now receive the expected final usage chunk without changing default stream output for existing clients.

## Technical notes
- Modules touched: BaseChatServer, BaseChatServerTests
- Dependency-boundary statement: BaseChatServer continues to depend only on inference/server surfaces; no UI, persistence, backend, or model-management boundaries changed.
- Public API changes: none
- Migration/schema changes: none

## Risk and rollback
- Risk level: low
- Rollback: revert this PR to restore the previous streaming fallback chunk shape.

## Validation
- Commands run: `scripts/test.sh --filter BaseChatServerTests --disable-default-traits --skip-update`
- Result: passed
- Tests skipped, if any: none beyond default trait disabling per requested command

## Autonomous worker notes
- Blockers or assumptions: Issue #807 is an umbrella; this PR is scoped only to `stream_options.include_usage` streaming usage chunks.
- Follow-up recommended in PR body only, not a new issue: verify against a real OpenAI SDK soak test under the existing #807 test coverage uplift item.