### PR TITLE
ci: wire MCP tests into scripted runs

### DIFF
--- a/.github/workflows/nightly-slow-tests.yml
+++ b/.github/workflows/nightly-slow-tests.yml
@@ -79,7 +79,7 @@ jobs:
         env:
           RUN_MCP_E2E: "1"
           BASECHAT_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-mcp-e2e-smoke.log
-        run: scripts/test.sh --filter "BaseChatMCPE2ESmokeTests" --disable-default-traits --skip-update --min-passed 1
+        run: scripts/test.sh --filter "BaseChatMCPE2ESmokeTests" --disable-default-traits --traits MCP --skip-update --min-passed 1
 
       - name: Test — Operational tier (soak + migration)
         id: test-operational

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -38,6 +38,9 @@ PACKAGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 MIN_PASSED=0
 PARALLEL_MODE=0
 SWIFT_ARGS=()
+MCP_FILTER_REQUESTED=0
+MCP_TRAIT_REQUESTED=0
+TRAITS_ARG_INDEX=-1
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --min-passed)
@@ -53,12 +56,56 @@ while [[ $# -gt 0 ]]; do
             SWIFT_ARGS+=("$1")
             shift
             ;;
+        --filter)
+            filter="${2:?'--filter requires a test filter argument'}"
+            if [[ "$filter" == *BaseChatMCPTests* || "$filter" == *BaseChatMCPE2ETests* || "$filter" == *BaseChatMCPE2ESmokeTests* ]]; then
+                MCP_FILTER_REQUESTED=1
+            fi
+            SWIFT_ARGS+=("$1" "$filter")
+            shift 2
+            ;;
+        --filter=*)
+            filter="${1#--filter=}"
+            if [[ "$filter" == *BaseChatMCPTests* || "$filter" == *BaseChatMCPE2ETests* || "$filter" == *BaseChatMCPE2ESmokeTests* ]]; then
+                MCP_FILTER_REQUESTED=1
+            fi
+            SWIFT_ARGS+=("$1")
+            shift
+            ;;
+        --traits)
+            traits="${2:?'--traits requires a comma-separated trait list'}"
+            if [[ ",$traits," == *",MCP,"* ]]; then
+                MCP_TRAIT_REQUESTED=1
+            fi
+            TRAITS_ARG_INDEX=$((${#SWIFT_ARGS[@]} + 1))
+            SWIFT_ARGS+=("$1" "$traits")
+            shift 2
+            ;;
+        --traits=*)
+            traits="${1#--traits=}"
+            if [[ ",$traits," == *",MCP,"* ]]; then
+                MCP_TRAIT_REQUESTED=1
+            fi
+            TRAITS_ARG_INDEX=${#SWIFT_ARGS[@]}
+            SWIFT_ARGS+=("$1")
+            shift
+            ;;
         *)
             SWIFT_ARGS+=("$1")
             shift
             ;;
     esac
 done
+
+if [[ $MCP_FILTER_REQUESTED -eq 1 && $MCP_TRAIT_REQUESTED -eq 0 ]]; then
+    # BaseChatMCP test sources are #if MCP-gated; without the trait SwiftPM
+    # builds an empty target and reports a false-green 0-test run.
+    if [[ $TRAITS_ARG_INDEX -ge 0 ]]; then
+        SWIFT_ARGS[$TRAITS_ARG_INDEX]="${SWIFT_ARGS[$TRAITS_ARG_INDEX]},MCP"
+    else
+        SWIFT_ARGS+=("--traits" "MCP")
+    fi
+fi
 
 # ── Run ──────────────────────────────────────────────────────────────────────
 echo "Running swift test in: $PACKAGE_DIR"


### PR DESCRIPTION
## Scope
- Fixes/addresses #792
- Exact slice implemented: MCP-filtered `scripts/test.sh` runs now enable the required `MCP` trait, and the nightly MCP streamable HTTP E2E smoke job passes `--traits MCP` explicitly.
- Explicitly not included: MCP product behavior, approval settings UI, custom server sheet, OAuth/Universal Links, consent UX, localized errors, or tool-cap work.

## Product value
MCP regressions are now exercised by the existing script and nightly smoke path instead of silently compiling zero MCP tests when default traits are disabled.

## Technical notes
- Modules touched: test script and GitHub Actions workflow only.
- Dependency-boundary statement: no product module imports or target dependency changes; default CI only gains fixture/mock-backed MCP unit coverage through the `MCP` trait, not hardware, credentials, or external services.
- Public API changes: none
- Migration/schema changes: none
- Workflow cost note: per-PR CI does not add a new job or external-service requirement; it only makes the existing `BaseChatMCPTests` filter compile the intended MCP target. The E2E smoke remains opt-in/nightly behind `RUN_MCP_E2E=1`, a narrow streamable smoke filter, and avoids the known hanging everything-server suite.

## Risk and rollback
- Risk level: low
- Rollback: revert this commit to restore prior script argument passthrough and nightly command.

## Validation
- Commands run:
  - `bash -n scripts/test.sh`
  - `scripts/test.sh --filter BaseChatMCPTests --disable-default-traits --skip-update`
  - `scripts/test.sh --filter BaseChatMCPTests --disable-default-traits --skip-update --parallel`
  - `RUN_MCP_E2E=1 scripts/test.sh --filter "BaseChatMCPE2ESmokeTests" --disable-default-traits --traits MCP --skip-update --min-passed 1`
- Result: all passed; `BaseChatMCPTests` executed 152 XCTest tests, and the streamable E2E smoke executed 1 XCTest test.
- Tests skipped, if any: none in the validation commands above.

## Autonomous worker notes
- Blockers or assumptions: existing main working directory was dirty, so work was done in isolated worktree `../BaseChatKit-worker-792-mcp-ci` from `origin/main`.
- Follow-up recommended in PR body only, not a new issue: consider documenting the script's automatic MCP trait injection in `Tests/README.md` if maintainers want local docs beyond the script comment.
