### PR TITLE
fix: fail closed for unsupported cloud grammars

### DIFF
--- a/Sources/BaseChatBackends/SSECloudBackend.swift
+++ b/Sources/BaseChatBackends/SSECloudBackend.swift
@@ -353,6 +353,10 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
             throw CloudBackendError.invalidURL("Backend not configured. Call loadModel first.")
         }
 
+        if config.grammar != nil, !capabilities.supportsGrammarConstrainedSampling {
+            throw InferenceError.unsupportedGrammar(reason: "\(backendName) does not support grammar-constrained sampling")
+        }
+
         let request = try buildRequest(
             prompt: prompt,
             systemPrompt: systemPrompt,
@@ -656,4 +660,3 @@ private final class WeakBox<T: AnyObject>: @unchecked Sendable {
     init(_ value: T?) { self.value = value }
 }
 #endif
-

--- a/Sources/BaseChatTestSupport/ConversationRuntimeScenario.swift
+++ b/Sources/BaseChatTestSupport/ConversationRuntimeScenario.swift
@@ -1,3 +1,4 @@
+#if DEBUG
 import Foundation
 import BaseChatRuntime
 import BaseChatInference
@@ -352,3 +353,4 @@ public enum ConversationRuntimeScenarioRunner {
         return (true, nil)
     }
 }
+#endif

--- a/Tests/BaseChatBackendsTests/BackendContractTests.swift
+++ b/Tests/BaseChatBackendsTests/BackendContractTests.swift
@@ -210,6 +210,7 @@ enum BackendContractChecks {
     /// the flag's value. When the flag is `true` this method is a no-op
     /// (the true side will be claimed by a separate "grammar produces valid
     /// output" family in a future patch).
+    @MainActor
     static func assertGrammarFailClosedContract<B: InferenceBackend>(
         backendName: String,
         makingBackend makeBackend: () -> B,
@@ -230,7 +231,7 @@ enum BackendContractChecks {
         }
 
         try await backend.loadModel(
-            from: URL(fileURLWithPath: "/tmp/contract-grammar"),
+            from: URL(string: "unused:")!,
             plan: .testStub(effectiveContextSize: 512)
         )
 

--- a/Tests/BaseChatBackendsTests/Conformance/ClaudeBackendConformanceTests.swift
+++ b/Tests/BaseChatBackendsTests/Conformance/ClaudeBackendConformanceTests.swift
@@ -6,12 +6,8 @@ import BaseChatTestSupport
 
 /// ClaudeBackend conformance against the universal BCK backend contract.
 ///
-/// Grammar fail-closed is skipped: `supportsGrammarConstrainedSampling` is
-/// `false` for ClaudeBackend but the backend does not validate grammar before
-/// forwarding the request to Anthropic — a real behavioral gap, not guarded via
-/// `withKnownIssue`. Capability claims are bootstrapped via
-/// `claimWithoutBehaviouralAssertion`; Phase C work will replace each with a
-/// real assertion family.
+/// Grammar fail-closed is asserted because ClaudeBackend currently reports
+/// `supportsGrammarConstrainedSampling = false`.
 ///
 /// Default model name is `claude-sonnet-4-20250514`, which contains
 /// `claude-sonnet-4` and therefore sets `supportsVision = true` via
@@ -21,7 +17,7 @@ final class ClaudeBackendConformanceTests: XCTestCase {
 
     private let backendName = "ClaudeBackend"
 
-    override func setUp() {
+    override class func setUp() {
         super.setUp()
         BackendContractChecks.resetCapabilityClaims()
     }
@@ -34,9 +30,21 @@ final class ClaudeBackendConformanceTests: XCTestCase {
     }
 
     // MARK: - Grammar fail-closed
-    // Skipped: ClaudeBackend.supportsGrammarConstrainedSampling = false but the
-    // backend does not validate grammar before forwarding the request to Anthropic.
-    // This is a cloud-backend gap — no fail-closed throw is implemented.
+
+    func test_contract_grammarFailClosed() async throws {
+        try await BackendContractChecks.assertGrammarFailClosedContract(
+            backendName: backendName,
+            makingBackend: {
+                let backend = ClaudeBackend()
+                backend.configure(
+                    baseURL: URL(string: "https://api.anthropic.com")!,
+                    apiKey: "sk-ant-test",
+                    modelName: "claude-sonnet-4-20250514"
+                )
+                return backend
+            }
+        )
+    }
 
     // MARK: - Per-capability claims (bootstrap)
 

--- a/Tests/BaseChatBackendsTests/Conformance/OllamaBackendConformanceTests.swift
+++ b/Tests/BaseChatBackendsTests/Conformance/OllamaBackendConformanceTests.swift
@@ -6,18 +6,14 @@ import BaseChatTestSupport
 
 /// OllamaBackend conformance against the universal BCK backend contract.
 ///
-/// Grammar fail-closed is skipped: `supportsGrammarConstrainedSampling` is
-/// `false` for OllamaBackend but the backend does not check grammar before
-/// forwarding to Ollama — a real behavioral gap, not guarded via
-/// `withKnownIssue`. Capability claims are bootstrapped via
-/// `claimWithoutBehaviouralAssertion`; Phase C work will replace each with a
-/// real assertion family.
+/// Grammar fail-closed is asserted because OllamaBackend currently reports
+/// `supportsGrammarConstrainedSampling = false`.
 @MainActor
 final class OllamaBackendConformanceTests: XCTestCase {
 
     private let backendName = "OllamaBackend"
 
-    override func setUp() {
+    override class func setUp() {
         super.setUp()
         BackendContractChecks.resetCapabilityClaims()
     }
@@ -30,9 +26,30 @@ final class OllamaBackendConformanceTests: XCTestCase {
     }
 
     // MARK: - Grammar fail-closed
-    // Skipped: OllamaBackend.supportsGrammarConstrainedSampling = false but the
-    // backend does not validate grammar before forwarding the request to Ollama.
-    // This is a cloud-backend gap — no fail-closed throw is implemented.
+
+    func test_contract_grammarFailClosed() async throws {
+        let sessionConfig = URLSessionConfiguration.ephemeral
+        sessionConfig.protocolClasses = [MockURLProtocol.self]
+        let baseURL = URL(string: "http://localhost/ollama-\(UUID().uuidString)")!
+        let showURL = baseURL.appendingPathComponent("api/show")
+        MockURLProtocol.stub(
+            url: showURL,
+            response: .immediate(
+                data: Data(#"{"capabilities":[]}"#.utf8),
+                statusCode: 200
+            )
+        )
+        defer { MockURLProtocol.unstub(url: showURL) }
+
+        try await BackendContractChecks.assertGrammarFailClosedContract(
+            backendName: backendName,
+            makingBackend: {
+                let backend = OllamaBackend(urlSession: URLSession(configuration: sessionConfig))
+                backend.configure(baseURL: baseURL, modelName: "llama3.2")
+                return backend
+            }
+        )
+    }
 
     // MARK: - Per-capability claims (bootstrap)
 

--- a/Tests/BaseChatBackendsTests/Conformance/OpenAIBackendConformanceTests.swift
+++ b/Tests/BaseChatBackendsTests/Conformance/OpenAIBackendConformanceTests.swift
@@ -6,12 +6,8 @@ import BaseChatTestSupport
 
 /// OpenAIBackend conformance against the universal BCK backend contract.
 ///
-/// Grammar fail-closed is skipped: `supportsGrammarConstrainedSampling` is
-/// `false` for OpenAIBackend but the backend does not validate grammar before
-/// forwarding the request to OpenAI — a real behavioral gap, not guarded via
-/// `withKnownIssue`. Capability claims are bootstrapped via
-/// `claimWithoutBehaviouralAssertion`; Phase C work will replace each with a
-/// real assertion family.
+/// Grammar fail-closed is asserted because OpenAIBackend currently reports
+/// `supportsGrammarConstrainedSampling = false`.
 ///
 /// Default model name is `gpt-4o-mini`, which matches the `gpt-4o`
 /// substring token and therefore sets `supportsVision = true`.
@@ -20,7 +16,7 @@ final class OpenAIBackendConformanceTests: XCTestCase {
 
     private let backendName = "OpenAIBackend"
 
-    override func setUp() {
+    override class func setUp() {
         super.setUp()
         BackendContractChecks.resetCapabilityClaims()
     }
@@ -33,9 +29,21 @@ final class OpenAIBackendConformanceTests: XCTestCase {
     }
 
     // MARK: - Grammar fail-closed
-    // Skipped: OpenAIBackend.supportsGrammarConstrainedSampling = false but the
-    // backend does not validate grammar before forwarding the request to OpenAI.
-    // This is a cloud-backend gap — no fail-closed throw is implemented.
+
+    func test_contract_grammarFailClosed() async throws {
+        try await BackendContractChecks.assertGrammarFailClosedContract(
+            backendName: backendName,
+            makingBackend: {
+                let backend = OpenAIBackend()
+                backend.configure(
+                    baseURL: URL(string: "https://api.openai.com")!,
+                    apiKey: "sk-test",
+                    modelName: "gpt-4o-mini"
+                )
+                return backend
+            }
+        )
+    }
 
     // MARK: - Per-capability claims (bootstrap)
 

--- a/Tests/BaseChatBackendsTests/Conformance/OpenAIResponsesBackendConformanceTests.swift
+++ b/Tests/BaseChatBackendsTests/Conformance/OpenAIResponsesBackendConformanceTests.swift
@@ -6,12 +6,8 @@ import BaseChatTestSupport
 
 /// OpenAIResponsesBackend conformance against the universal BCK backend contract.
 ///
-/// Grammar fail-closed is skipped: `supportsGrammarConstrainedSampling` is
-/// `false` for OpenAIResponsesBackend but the backend does not validate grammar
-/// before forwarding the request to OpenAI — a real behavioral gap, not guarded
-/// via `withKnownIssue`. Capability claims are bootstrapped via
-/// `claimWithoutBehaviouralAssertion`; Phase C work will replace each with a
-/// real assertion family.
+/// Grammar fail-closed is asserted because OpenAIResponsesBackend currently
+/// reports `supportsGrammarConstrainedSampling = false`.
 ///
 /// Default model name is `gpt-5`.
 /// `supportsVision` evaluates to `false` for this backend regardless of model
@@ -22,7 +18,7 @@ final class OpenAIResponsesBackendConformanceTests: XCTestCase {
 
     private let backendName = "OpenAIResponsesBackend"
 
-    override func setUp() {
+    override class func setUp() {
         super.setUp()
         BackendContractChecks.resetCapabilityClaims()
     }
@@ -35,9 +31,21 @@ final class OpenAIResponsesBackendConformanceTests: XCTestCase {
     }
 
     // MARK: - Grammar fail-closed
-    // Skipped: OpenAIResponsesBackend.supportsGrammarConstrainedSampling = false but the
-    // backend does not validate grammar before forwarding the request to OpenAI.
-    // This is a cloud-backend gap — no fail-closed throw is implemented.
+
+    func test_contract_grammarFailClosed() async throws {
+        try await BackendContractChecks.assertGrammarFailClosedContract(
+            backendName: backendName,
+            makingBackend: {
+                let backend = OpenAIResponsesBackend()
+                backend.configure(
+                    baseURL: URL(string: "https://api.openai.com")!,
+                    apiKey: "sk-test",
+                    modelName: "gpt-5"
+                )
+                return backend
+            }
+        )
+    }
 
     // MARK: - Per-capability claims (bootstrap)
 


### PR DESCRIPTION
## Summary
- Fixes #1089 and the #1086 grammar fail-closed blocker for SSE cloud backends.
- Throws `InferenceError.unsupportedGrammar(reason:)` synchronously when `GenerationConfig.grammar` is set on a backend that does not support grammar-constrained sampling.
- Enables the grammar fail-closed contract for Ollama, OpenAI, Claude, and OpenAI Responses conformance tests.

## Tests
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all scripts/test.sh --filter BaseChatBackendsTests.OllamaBackendConformanceTests/test_contract_grammarFailClosed --filter BaseChatBackendsTests.OpenAIBackendConformanceTests/test_contract_grammarFailClosed --filter BaseChatBackendsTests.ClaudeBackendConformanceTests/test_contract_grammarFailClosed --filter BaseChatBackendsTests.OpenAIResponsesBackendConformanceTests/test_contract_grammarFailClosed --traits Ollama,CloudSaaS --disable-default-traits --skip-update` — passed (4 tests).
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all scripts/test.sh --filter BaseChatBackendsTests --disable-default-traits --skip-update` — passed (153 passed, 1 skipped).
