### PR TITLE
fix: stop backend generation on SSE disconnect

### DIFF
--- a/Sources/BaseChatServer/ChatCompletionsAdapter.swift
+++ b/Sources/BaseChatServer/ChatCompletionsAdapter.swift
@@ -546,7 +546,11 @@ internal struct DefaultChatCompletionsAdapter: ChatCompletionsAdapter {
         let (prompt, systemPrompt) = promptParts(for: request)
         let stream = try backend.generate(prompt: prompt, systemPrompt: systemPrompt, config: generationConfig(for: request))
         let mapper = ChatCompletionEventMapper(id: completionID(), created: currentTimestamp(), model: request.model)
-        return mapper.chunks(from: stream.events, includeUsage: request.includesStreamUsage)
+        return mapper.chunks(
+            from: stream.events,
+            includeUsage: request.includesStreamUsage,
+            onCancel: { backend.stopGeneration() }
+        )
     }
 
     private func promptParts(for request: ChatCompletionRequest) -> (prompt: String, systemPrompt: String?) {
@@ -604,7 +608,8 @@ internal struct ChatCompletionEventMapper: Sendable {
 
     internal func chunks<S: AsyncSequence & Sendable>(
         from events: S,
-        includeUsage: Bool
+        includeUsage: Bool,
+        onCancel: @escaping @Sendable () -> Void = {}
     ) -> AsyncThrowingStream<ChatCompletionChunk, Error> where S.Element == GenerationEvent {
         AsyncThrowingStream { continuation in
             let id = self.id
@@ -677,7 +682,12 @@ internal struct ChatCompletionEventMapper: Sendable {
                     continuation.finish(throwing: error)
                 }
             }
-            continuation.onTermination = { @Sendable _ in task.cancel() }
+            continuation.onTermination = { @Sendable termination in
+                task.cancel()
+                if case .cancelled = termination {
+                    onCancel()
+                }
+            }
         }
     }
 

--- a/Tests/BaseChatServerTests/ChatCompletionsAdapterTests.swift
+++ b/Tests/BaseChatServerTests/ChatCompletionsAdapterTests.swift
@@ -126,6 +126,40 @@ final class ChatCompletionsAdapterTests: XCTestCase {
         XCTAssertEqual(chunks.last?.usage, ChatCompletionUsage(promptTokens: 3, completionTokens: 2))
     }
 
+    func testCancellingStreamingChunksStopsBackendGeneration() async throws {
+        let gate = TokenEmissionGate()
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["one", "two"]
+        backend.tokenEmissionGate = gate
+        let request = ChatCompletionRequest(
+            model: "m",
+            messages: [ChatCompletionMessage(role: .user, content: "hi")],
+            stream: true
+        )
+
+        let stream = try DefaultChatCompletionsAdapter().chunks(for: request, using: backend)
+        let firstToken = expectation(description: "first token streamed")
+        let consumer = Task {
+            for try await chunk in stream {
+                if chunk.choices.first?.delta.content == "one" {
+                    firstToken.fulfill()
+                }
+            }
+        }
+
+        await gate.advance()
+        await fulfillment(of: [firstToken], timeout: 1)
+        consumer.cancel()
+        await waitUntil {
+            backend.stopCallCount == 1 && backend.isGenerating == false
+        }
+        await gate.release()
+        _ = await consumer.result
+
+        XCTAssertEqual(backend.generateCallCount, 1)
+    }
+
     func testNonStreamResponseAssemblesContentReasoningToolCallsAndUsage() async throws {
         let backend = EventSequenceBackend(events: [
             .thinkingToken("think "),
@@ -219,6 +253,23 @@ final class ChatCompletionsAdapterTests: XCTestCase {
             chunks.append(chunk)
         }
         return chunks
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ condition: @escaping () -> Bool
+    ) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if condition() {
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertTrue(condition(), file: file, line: line)
     }
 }
 

--- a/Tests/BaseChatServerTests/SSECancellationTests.swift
+++ b/Tests/BaseChatServerTests/SSECancellationTests.swift
@@ -11,27 +11,15 @@ import XCTest
 /// SSE streaming response structure and cancellation-path tests for
 /// ``BaseChatServer``'s `/v1/chat/completions` endpoint.
 ///
-/// ## Cancellation gap note
+/// ## Cancellation coverage note
 ///
-/// The server's `ChatCompletionsAdapter` wires `continuation.onTermination`
-/// to cancel the inner `Task`, propagating structured cancellation into the
-/// generation loop. However, neither ``DefaultChatCompletionsAdapter`` nor the
-/// production `ServerApp` calls `backend.stopGeneration()` explicitly when
-/// the client disconnects. In the Hummingbird in-process test client the
-/// connection is fully consumed before `execute` returns, so there is no
-/// mid-stream disconnect to observe in the test harness.
+/// ``ChatCompletionsAdapterTests/testCancellingStreamingChunksStopsBackendGeneration()``
+/// asserts that terminating the adapter stream calls
+/// ``InferenceBackend/stopGeneration()``. In the Hummingbird in-process test
+/// client the connection is fully consumed before `execute` returns, so these
+/// endpoint-level tests continue to assert the SSE framing delivered to clients.
 ///
-/// A stronger assertion (``isGenerating`` becomes `false` within 500 ms of
-/// client disconnect) requires either:
-///   - A real TCP socket test where the client drops the connection while
-///     chunks are still in-flight, or
-///   - The server routing backend-disconnect notification through
-///     ``InferenceBackend/stopGeneration()`` and the adapter honouring it.
-///
-/// Until that gap is closed (see issue tracker) the tests in this file assert
-/// on the SSE *structure* delivered to the client — headers, chunk decodability,
-/// multi-token delivery, and the final `[DONE]` sentinel. These assertions are
-/// load-bearing: they fail if the SSE framing regresses.
+/// These assertions are load-bearing: they fail if the SSE framing regresses.
 ///
 /// Sabotage-evidence:
 ///   M1: Remove `text/event-stream` header assertion → test passes even when
@@ -196,17 +184,9 @@ final class SSECancellationTests: XCTestCase {
         }
     }
 
-    // MARK: - Cancellation gap documentation
+    // MARK: - Completion sanity
 
-    /// Documents the current cancellation behaviour: the generation task is
-    /// cancelled via structured concurrency when the response continuation
-    /// terminates, but ``InferenceBackend/stopGeneration()`` is not called by
-    /// the server. `isGenerating` may therefore remain true briefly after the
-    /// stream ends.
-    ///
-    /// This test verifies the stream completes (is fully consumed) without
-    /// hanging — the stronger assertion about `isGenerating` is deferred until
-    /// the server calls `stopGeneration()` on disconnect.
+    /// Verifies a fully consumed stream completes without hanging.
     func testStreamingCompletesWithoutHanging() async throws {
         // Use many tokens to ensure the stream is non-trivial.
         let tokenCount = 20


### PR DESCRIPTION
## Summary
- stop the backend generation stream when an SSE chat completion stream is cancelled
- add a BaseChatServer cancellation regression test using MockInferenceBackend + TokenEmissionGate
- update SSE cancellation notes now that adapter termination calls stopGeneration

Fixes the SSE cancellation blocker from #1087 for issue #1089.

## Tests
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all scripts/test.sh --filter BaseChatServerTests.ChatCompletionsAdapterTests/testCancellingStreamingChunksStopsBackendGeneration --disable-default-traits --traits Server --skip-update (1 passed)
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all scripts/test.sh --filter BaseChatServerTests --disable-default-traits --traits Server --skip-update (70 passed)

Note: the Server trait is required for BaseChatServerTests; without it the #if Server tests compile out and 0 tests run.