### PR TITLE
docs: refresh architecture coverage and fix stale references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,8 @@ you're making and follow the gates listed there. Cross-references point at
 ## Table of contents
 
 - [Getting started](#getting-started)
+- [Architecture invariants](#architecture-invariants) — read **before** moving
+  imports between modules
 - [Pre-push checklist](#pre-push-checklist) — run **every** time, regardless of
   change type
 - [Adding a new backend](#adding-a-new-backend)
@@ -43,6 +45,44 @@ four blessed configurations and what each one guarantees.
 
 For repo-developer build-mode workflow (Xcode trait limitations, common mistakes,
 the `#warning` stub mechanism), see [CLAUDE.md](CLAUDE.md).
+
+## Architecture invariants
+
+BaseChatKit's module graph is enforced by lint, not just convention. Four hard
+rules must hold for every PR; the
+[`TrafficBoundaryAuditTest`](Tests/BaseChatInferenceTests/TrafficBoundaryAuditTest.swift)
+suite fails CI if any of them is violated.
+
+1. **`BaseChatUI` never imports `BaseChatBackends`.** UI is a consumer-facing
+   chat surface. Backend code carries cloud-SDK weight, MLX/llama.cpp binary
+   xcframeworks, and SwiftData adapters (transitively) that have no business
+   in the view layer. Inference reaches UI through `BaseChatInference`'s
+   service protocols and `BaseChatRuntime`'s ports.
+
+2. **`BaseChatUI` never imports `BaseChatUIModelManagement`.** The dependency
+   is one-way: model-management views depend on chat views, not the other way
+   around. The cycle is dissolved by closure-injecting `APIConfigurationView`
+   via a `@ViewBuilder apiConfiguration:` parameter on `ChatView` — see
+   [Building a Chat UI](Sources/BaseChatUI/BaseChatUI.docc/Articles/BuildingAChatUI.md)
+   for the canonical wiring.
+
+3. **`BaseChatBackends` and `BaseChatMCP` depend on `BaseChatInference`
+   directly, not on `BaseChatRuntime`.** That keeps both modules free of
+   SwiftData and free of runtime-port adapters, so host apps can wire backends
+   or MCP into a non-SwiftData runtime without dragging the persistence layer
+   in transitively.
+
+4. **`ConversationRuntime` is the single turn loop.** Every user-facing chat
+   action — `send`, `regenerate`, `edit`, `cancel`, `branch` — routes through
+   `ConversationRuntime`. There is no alternative path. New features that
+   touch turn flow extend `ConversationRuntime`; they must not call
+   `InferenceService` directly from the UI layer.
+
+If a PR genuinely needs to cross one of these boundaries, the fix is almost
+always to promote a protocol downward (into `BaseChatInference`) or extract a
+new port (into `BaseChatRuntime`) — never to add the reverse import. Reviewers
+will push back on `// swiftlint:disable` style escape hatches in the audit
+allowlists; the cap on each allowlist is intentionally low.
 
 ## Pre-push checklist
 

--- a/README.md
+++ b/README.md
@@ -52,39 +52,82 @@ BCK and AnyLanguageModel occupy adjacent niches. AnyLanguageModel optimizes for 
 
 ## Architecture
 
-BaseChatKit is split into primary targets plus optional bridge modules:
+BaseChatKit ships **14 libraries**, **2 executables**, and **1 macro plugin**. The
+core runtime stack is six libraries; the rest are optional sibling modules and
+test-only targets gated behind SwiftPM traits.
+
+The diagram below shows the dependency graph for the targets a typical adopter
+cares about. Arrows point from a consumer toward its dependency:
 
 ```
-BaseChatUI ───────────────────────┐
-(Views, ViewModels)               │
-                                  ├──> BaseChatRuntime ──────> BaseChatInference
-BaseChatUIModelManagement ────────┘    (Ports, use cases,       (Protocols, Models,
-(model + endpoint UI; also             session-list,            Services, Inference
- depends on BaseChatUI)                 runtime events)          orchestration)
-                                            ▲                          ▲
-                                            │                          │
-BaseChatPersistenceSwiftData ───────────────┘                          │
-(SwiftData schema, @Model types,                                        │
- container, adapters, BaseChatBootstrap)                                │
-                                                                       │
-BaseChatMCP ───────────────────────────────────────────────────────────┤
-(MCP descriptors, client, tool bridge)                                  │
-                                                                       │
-BaseChatBackends ──────────────────────────────────────────────────────┘
-(MLX, llama.cpp, Foundation, Cloud)
+BaseChatVoice              BaseChatUIModelManagement
+(Voice trait)              (model browser + endpoint UI)
+        │                          │
+        └────────► BaseChatUI ◄────┘
+                       │
+                       ▼
+            BaseChatPersistenceSwiftData
+            (SwiftData schema, BaseChatBootstrap)
+                       │
+                       ▼
+                 BaseChatRuntime
+                 (Ports, use cases, ConversationRuntime)
+                       │
+                       ▼
+                BaseChatInference  ◄─── BaseChatBackends
+                (Protocols, services)   (MLX, llama.cpp,
+                       ▲                 Foundation, Cloud)
+                       │
+                BaseChatMCP
+                (MCP descriptors, client, tool bridge)
 ```
+
+`BaseChatBackends` and `BaseChatMCP` depend on `BaseChatInference` **directly**,
+not via `BaseChatRuntime` — that keeps both modules free of SwiftData so
+host apps can wire backends or MCP into a non-SwiftData runtime.
+
+### Core runtime targets
 
 - **BaseChatInference** — Inference orchestration. Protocols, models, and services for model loading, generation, context windows, prompt assembly, compression, tokenizers, and capability detection. No SwiftData. No ML dependencies. This is the integration point for custom backends and the minimum target for apps that bring their own persistence and UI.
-- **BaseChatMCP** — Model Context Protocol client surface: descriptors, auth/transport types, connection lifecycle (`MCPClient`), and tool bridge (`MCPToolSource`) for registering MCP tools with `ToolRegistry`.
-- **BaseChatRuntime** — Persistence-agnostic ports (`EndpointStore`, `SamplerPresetStore`, `BenchmarkCache`), use cases (`PromptContextPipeline`, `ChatExportService`, `SessionListService`), session-list orchestration, and `ConversationEvent` observability for turn state, token usage, and best-effort session-touch failures. No SwiftData, no SwiftUI, no Observation — apps that bring their own persistence stop here and supply their own adapters.
+- **BaseChatMCP** — Model Context Protocol client surface: descriptors, auth/transport types, connection lifecycle (`MCPClient`), and tool bridge (`MCPToolSource`) for registering MCP tools with `ToolRegistry`. Depends on `BaseChatInference` directly.
+- **BaseChatRuntime** — Persistence-agnostic ports (`EndpointStore`, `SamplerPresetStore`, `BenchmarkCache`), use cases (`PromptContextPipeline`, `ChatExportService`, `SessionListService`), session-list orchestration, `ConversationEvent` observability, and the shared turn loop `ConversationRuntime`. No SwiftData, no SwiftUI, no Observation — apps that bring their own persistence stop here and supply their own adapters.
 - **BaseChatPersistenceSwiftData** — SwiftData schema, `@Model` types (`ChatMessage`, `ChatSession`, `SamplerPreset`, `APIEndpoint`, `ModelBenchmarkCache`), `ModelContainerFactory`, adapter implementations of the runtime ports, and the full-stack `BaseChatBootstrap` entry point.
 - **BaseChatBackends** — Concrete inference backend implementations. Depends on `BaseChatInference` (not `BaseChatRuntime` or `BaseChatPersistenceSwiftData`), so backends stay free of SwiftData. Pulls MLX, llama.cpp, and cloud APIs.
-- **BaseChatUI** — SwiftUI views and view models. Depends on `BaseChatRuntime` and `BaseChatInference`; cloud endpoint state crosses the UI boundary as SwiftData-free `APIEndpointRecord` values supplied by an `EndpointStore`.
+- **BaseChatUI** — SwiftUI chat views and view models. Depends on `BaseChatRuntime` and `BaseChatInference`. Stays a chat-only consumer surface — never imports `BaseChatBackends` or `BaseChatUIModelManagement`. Cloud endpoint state crosses the UI boundary as SwiftData-free `APIEndpointRecord` values supplied by an `EndpointStore`.
+
+### Optional sibling modules
+
+- **BaseChatUIModelManagement** — Model browser, download UI, storage management, and cloud-endpoint editors (`APIConfigurationView`). Depends on `BaseChatUI`. The reverse edge is broken by closure-injecting `APIConfigurationView` via a `@ViewBuilder apiConfiguration:` parameter on `ChatView` — see [Building a Chat UI](Sources/BaseChatUI/BaseChatUI.docc/Articles/BuildingAChatUI.md) for the canonical wiring.
 - **BaseChatHuggingFace** *(trait: `HuggingFace`, default-on)* — HuggingFace Hub search plus background download / validation services.
 - **BaseChatAnyLanguageModelBridge** *(trait: `AnyLanguageModel`, default-off)* — Thin `InferenceBackend` adapter over HuggingFace's `AnyLanguageModel`.
-- **BaseChatVoice** — Optional speech-recognition / synthesis adapters and voice composer UI. Depends on `BaseChatUI` so hosts can opt in without adding a back-edge into the base chat surface.
-- **BaseChatServer** *(trait: `Server`, default-off)* — OpenAI-compatible HTTP server executable for exposing a selected `BaseChatInference` backend over `/v1/chat/completions`. It validates unsupported request capabilities before dispatch and returns clear `invalid_request_error` responses with `unsupported_capability` codes. Server targets are trait-gated; add `--traits Server` to `swift run`/`swift build`/`swift test` commands when working with `BaseChatServer`.
-- **`@ToolSchema` macro** *(trait: `Macros`, default-off)* — Synthesises `static var jsonSchema` on `Decodable` tool-argument structs. The macro plugin and its `swift-syntax` dependency (~647 source files) are gated behind the `Macros` trait so default builds skip the swift-syntax compile cost. Add `--traits Macros` to `swift build`/`swift test` invocations that use `@ToolSchema`.
+- **BaseChatVoice** *(trait: `Voice`, default-off)* — Optional speech-recognition / synthesis adapters and voice composer UI. Depends on `BaseChatUI` so hosts can opt in without adding a back-edge into the base chat surface.
+- **BaseChatServer** *(trait: `Server`, default-off, executable)* — OpenAI-compatible HTTP server executable for exposing a selected `BaseChatInference` backend over `/v1/chat/completions`. Validates unsupported request capabilities before dispatch and returns clear `invalid_request_error` responses with `unsupported_capability` codes. Trait-gated; add `--traits Server` to `swift run`/`swift build`/`swift test` commands.
+- **BaseChatTools** *(trait: `Tools`, default-off)* + **`bck-tools`** executable — End-to-end tool-calling validation harness and CLI for exercising `ToolRegistry` against real backends.
+- **BaseChatAppIntents** *(trait: `AppIntents`, default-off)* — Bridge between Apple `AppIntent` types and BaseChatKit's `ToolDefinition`, so iOS/macOS app intents can be exposed as tools to the inference layer.
+- **BaseChatFuzz** *(trait: `Fuzz`, default-off)* + **`fuzz-chat`** executable — Fuzzing harness that drives real backends with adversarial inputs. Run via `scripts/fuzz.sh`.
+- **`@ToolSchema` macro** *(trait: `Macros`, default-off)* — `BaseChatMacrosPlugin` synthesises `static var jsonSchema` on `Decodable` tool-argument structs. The plugin and its `swift-syntax` dependency (~647 source files) are gated behind the `Macros` trait so default builds skip the swift-syntax compile cost. Add `--traits Macros` to `swift build`/`swift test` invocations that use `@ToolSchema`.
+
+### Test-only targets
+
+`BaseChatTestSupport` ships shared mocks and fakes (`MockInferenceBackend`,
+`CharTokenizer`, `makeInMemoryContainer`, etc.) for app-level testing.
+`BaseChatMLXIntegrationTests` runs real MLX model E2E tests under Xcode (Metal
+shaders unavailable to `swift test`); see `scripts/test-mlx-integration.sh`.
+
+### Turn-loop orchestration
+
+`ConversationRuntime` (`Sources/BaseChatRuntime/Services/ConversationRuntime.swift`)
+is the **single turn loop** for chat. It owns `send`, `regenerate`, `edit`,
+`cancel`, and `branch` — there is no alternative path. Host apps get a
+configured `ConversationRuntime` from `BaseChatBootstrap` (exposed as
+`bootstrap.conversationRuntime`) and forward user actions to it via
+`ChatViewModel.configure(runtime:)` or `ChatViewModel.configure(conversationRuntime:)`.
+Custom adopters wiring their own runtime stack should still route every user
+turn through `ConversationRuntime` rather than calling `InferenceService`
+directly — anything else regresses cancellation, regenerate semantics, and
+session-touch observability. See
+[CONTRIBUTING.md → Architecture invariants](CONTRIBUTING.md#architecture-invariants)
+for the full list of dependency rules the lint enforces.
 
 ## Quick Start
 
@@ -260,6 +303,32 @@ audio-session coordinator activates `.playAndRecord` / `.spokenAudio` with
 `.defaultToSpeaker` and `.duckOthers` while capture is active, then deactivates
 the session when recording stops. Apps with their own audio-session policy can
 inject a custom transcriber or audio-session coordinator.
+
+### 2.4 Trait reference
+
+The full list of SwiftPM traits, derived from `Package.swift`. Defaults
+(`MLX`, `Llama`, `HuggingFace`) are enabled when callers don't pass
+`--disable-default-traits` or a custom `traits:` array.
+
+| Trait | Default? | Gates / pulls in |
+|-------|----------|-------------------|
+| `MLX` | Yes | `MLXBackend` (Apple Silicon, mlx-swift xcframework). |
+| `Llama` | Yes | `LlamaBackend` (GGUF via mattt/llama.swift xcframework). |
+| `HuggingFace` | Yes | `BaseChatHuggingFace` Hub search, browse, and background download/validation. |
+| `Ollama` | No | `OllamaBackend` (self-hosted HTTP at `localhost:11434` or custom host). |
+| `CloudSaaS` | No | `OpenAIBackend`, `ClaudeBackend`, and any third-party SaaS code paths. |
+| `MCP` | No | `BaseChatMCP` opt-in marker for consumer manifests. |
+| `MCPBuiltinCatalog` | No | Built-in `MCPCatalog` descriptors (`notion`, `linear`, `github`). |
+| `AnyLanguageModel` | No | `BaseChatAnyLanguageModelBridge` adapter over HuggingFace's `AnyLanguageModel`. |
+| `Voice` | No | `BaseChatVoice` speech I/O adapters and voice composer accessory. |
+| `Tools` | No | `BaseChatTools` tool-calling validation harness and `bck-tools` CLI. |
+| `AppIntents` | No | `BaseChatAppIntents` AppIntent ↔ ToolDefinition bridge. |
+| `Server` | No | `BaseChatServer` executable + Hummingbird HTTP dependency. |
+| `Macros` | No | `BaseChatMacrosPlugin` (`@ToolSchema`) + swift-syntax (~647 source files). |
+| `Fuzz` | No | Real backends in `fuzz-chat` for `scripts/fuzz.sh`. Not needed for `swift test`. |
+
+`Package.swift` is the authoritative source — add `--list-traits` to a
+`swift package` invocation if you suspect this table has drifted.
 
 ### 3. Create the runtime at app startup
 
@@ -681,7 +750,7 @@ Templates auto-detect from GGUF metadata when available. User content is sanitis
 
 ## Security
 
-See the [Security Model](Sources/BaseChatCore/BaseChatCore.docc/Articles/SecurityModel.md) DocC article for the full threat model, what BCK protects against, what remains your responsibility, and how to tune for stricter environments. A quick summary:
+See [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md) for the full threat model, what BCK protects against, what remains your responsibility, and how to tune for stricter environments. A quick summary:
 
 - API keys stored in Keychain with `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`
 - Keys read just-in-time from Keychain rather than cached as long-lived properties; during an in-flight `URLSession` request the key bytes do exist in process memory as a Swift `String` and are not zeroized after use (see [docs/FIPS.md](docs/FIPS.md) §non-mitigations)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,7 @@ interfaces on Apple platforms. This document describes:
 - [Pending mitigations](#pending-mitigations) — known gaps with linked tracking issues.
 
 For the full threat model (assets, trust boundaries, mitigations, and known
-non-mitigations), see [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md). The DocC article
-[Security Model](Sources/BaseChatCore/BaseChatCore.docc/Articles/SecurityModel.md)
+non-mitigations), see [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md). It also
 covers the in-source mitigations (transport pinning, SSRF gating, error sanitisation,
 SSE bounds, download path validation) at API granularity.
 
@@ -126,9 +125,9 @@ Same `offline` guarantees, plus:
 ```
 
 `saas` adds Claude and OpenAI backends. Pinning is **on by default** for both
-hosts — the framework fails closed if no pin matches. See the
-[Security Model](Sources/BaseChatCore/BaseChatCore.docc/Articles/SecurityModel.md#transport-security)
-DocC article for the SPKI pin set.
+hosts — the framework fails closed if no pin matches. See
+[docs/THREAT_MODEL.md](docs/THREAT_MODEL.md) for the SPKI pin set and the full
+transport-security boundary.
 
 #### `full` — every backend
 
@@ -264,10 +263,9 @@ checklist — see [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md).
 
 ## Cross-references
 
-- [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md) — full threat model.
-- [Security Model](Sources/BaseChatCore/BaseChatCore.docc/Articles/SecurityModel.md) —
-  in-source DocC article on transport, SSRF, Keychain, error sanitisation, SSE bounds,
-  download validation.
+- [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md) — full threat model, including the
+  in-source mitigations (transport pinning, SSRF gating, Keychain, error sanitisation,
+  SSE bounds, download path validation) at API granularity.
 - [CONTRIBUTING.md](CONTRIBUTING.md) — contributor guide indexed by change type.
   Each change-type section lists the security-relevant gates.
 - [README.md](README.md) — quick-start, build-mode decision table, and feature

--- a/Sources/BaseChatInference/BaseChatInference.docc/BaseChatInference.md
+++ b/Sources/BaseChatInference/BaseChatInference.docc/BaseChatInference.md
@@ -11,13 +11,20 @@ events and streams, context window management, prompt templates and assembly,
 macro expansion, repetition detection, tokenizers, and the
 capability/compatibility API.
 
-It does **not** depend on SwiftData. Apps that need inference orchestration but
-implement their own persistence and chat UI can depend on this target alone and
-leave `BaseChatCore` (which contains the SwiftData schema and persistence
-provider) out of their build graph.
+`BaseChatInference` is the lowest production layer in BaseChatKit (apart from
+`BaseChatTestSupport`). It carries no SwiftData schema, no SwiftUI views, no
+ML dependencies, and no concrete inference backends — those live in higher
+layers:
 
-For apps that want the full chat experience, `BaseChatCore` re-exports
-`BaseChatInference` so a single `import BaseChatCore` brings in everything.
+- `BaseChatRuntime` adds persistence-agnostic ports and use cases.
+- `BaseChatPersistenceSwiftData` adds the shipped SwiftData schema and
+  ``BaseChatBootstrap`` entry point.
+- `BaseChatBackends` adds the concrete MLX, llama.cpp, Foundation, and cloud
+  backends, depending on `BaseChatInference` directly so it stays free of
+  SwiftData.
+
+Apps that bring their own persistence and UI can depend on this target alone
+to integrate a custom backend or drive a custom chat surface.
 
 For the source-backed operational contract around loading, streaming, memory handling, cancellation, and pinning, see [`docs/RELIABILITY.md`](../../../docs/RELIABILITY.md).
 

--- a/Sources/BaseChatUI/BaseChatUI.docc/Articles/BuildingAChatUI.md
+++ b/Sources/BaseChatUI/BaseChatUI.docc/Articles/BuildingAChatUI.md
@@ -228,6 +228,30 @@ Attach any persistence-specific scene modifiers from the app or persistence targ
 
 Keep `configure(persistence:)` for adopters that provide custom ``SessionStore`` / ``MessageStore`` impls (e.g. an in-memory test fixture, or a non-SwiftData backing store) — construct ``ChatViewModel`` and ``SessionManagerViewModel`` directly and call `configure(persistence:)`. The shipped SwiftData bootstrap and custom stores both satisfy the same runtime-port boundary.
 
+### Wiring `APIConfigurationView` from `BaseChatUIModelManagement`
+
+`ChatView` accepts a `@ViewBuilder apiConfiguration:` closure that returns the host's API-key recovery sheet. The closure-injection pattern is **the canonical way** to mount `BaseChatUIModelManagement.APIConfigurationView` from a host that depends on both chat surfaces — and it is structural, not stylistic. Without it, `BaseChatUI` would have to import `BaseChatUIModelManagement` to reference the view directly, which would close a forbidden import cycle (the dependency edge runs UIModelManagement → UI, never the reverse). Closure injection lets the host module sit above both and pass the value down by name.
+
+```swift
+import BaseChatUI
+import BaseChatUIModelManagement
+
+struct RootView: View {
+    @State private var showModelManagement = false
+
+    var body: some View {
+        ChatView(
+            showModelManagement: $showModelManagement,
+            apiConfiguration: { APIConfigurationView() }
+        )
+    }
+}
+```
+
+Hosts that don't use `BaseChatUIModelManagement` (e.g. cloud-only builds or apps with their own settings UI) pass `apiConfiguration: { EmptyView() }` to satisfy the parameter.
+
+The closure is invoked at sheet/popover presentation time, not at `ChatView` init, so any `@Environment` or `@Bindable` lookups inside `APIConfigurationView` resolve against the live view tree rather than the value captured at construction.
+
 ## Next Steps
 
 - See ``GenerationSettingsView`` to give users control over temperature and prompt templates

--- a/TESTING.md
+++ b/TESTING.md
@@ -619,7 +619,7 @@ Ask these questions in order:
 import XCTest
 import SwiftData
 @testable import BaseChatUI
-import BaseChatCore
+import BaseChatInference
 import BaseChatTestSupport
 
 @MainActor

--- a/Tests/BaseChatInferenceTests/TrafficBoundaryAuditTest.swift
+++ b/Tests/BaseChatInferenceTests/TrafficBoundaryAuditTest.swift
@@ -372,11 +372,14 @@ final class TrafficBoundaryAuditTest: XCTestCase {
             ("BaseChatUI/",
              ["BaseChatBackends", "BaseChatPersistenceSwiftData"],
              "BaseChatUI must not depend on BaseChatBackends or BaseChatPersistenceSwiftData. UI is consumer-facing; backend code carries cloud-SDK weight and persistence adapters belong behind BaseChatRuntime ports."),
-            ("BaseChatCore/",
+            ("BaseChatRuntime/",
+             ["BaseChatBackends", "BaseChatPersistenceSwiftData"],
+             "BaseChatRuntime carries persistence-agnostic ports and use cases. Concrete backends and SwiftData adapters live above it."),
+            ("BaseChatPersistenceSwiftData/",
              ["BaseChatBackends"],
-             "BaseChatCore is the persistence layer; backend code belongs above it."),
+             "BaseChatPersistenceSwiftData is the SwiftData persistence layer; backend code belongs above it."),
             ("BaseChatInference/",
-             ["BaseChatBackends", "BaseChatCore"],
+             ["BaseChatBackends", "BaseChatRuntime", "BaseChatPersistenceSwiftData"],
              "BaseChatInference is the lowest production layer (apart from BaseChatTestSupport) and must not depend upward."),
         ]
 


### PR DESCRIPTION
## Why this PR exists

Public-facing docs had drifted from the post-`BaseChatCore`-deletion module graph: README example imports the deleted module, several `Sources/BaseChatCore/.../SecurityModel.md` links 404, and architectural facts adopters need (single turn loop, four hard dependency rules, the `@ViewBuilder` cycle break) lived only in CLAUDE.md.

## Punch list

### P0 — compile-breaking lies in public examples

- [x] Drop `import BaseChatCore` from `TESTING.md` test scaffold (replaced with `import BaseChatInference`). README's previous `BaseChatRuntime(configuration:)` constructor and `import BaseChatCore` example lines were already updated on `main` — verified during the audit pass.
- [x] Rewrite `Sources/BaseChatInference/BaseChatInference.docc/BaseChatInference.md` overview: drop the dead "BaseChatCore re-exports BaseChatInference" claim; describe the actual layering against `BaseChatRuntime` / `BaseChatPersistenceSwiftData` / `BaseChatBackends`.
- [x] Repoint 4 broken `Sources/BaseChatCore/.../SecurityModel.md` links (README L684, SECURITY L16/L130/L268) at `docs/THREAT_MODEL.md`.

### P1 — architectural truth missing from public docs

- [x] Add a "Turn-loop orchestration" subsection to README naming `ConversationRuntime` as the single `send`/`regenerate`/`edit`/`cancel`/`branch` path, with the source location and the wiring contract (`bootstrap.conversationRuntime` -> `ChatViewModel.configure(runtime:)`).
- [x] Add an "Architecture invariants" section to `CONTRIBUTING.md` listing the four hard rules verbatim with a pointer to `TrafficBoundaryAuditTest` as the lint.
- [x] Document the canonical `@ViewBuilder apiConfiguration:` closure-injection pattern in `Sources/BaseChatUI/BaseChatUI.docc/Articles/BuildingAChatUI.md`, including a code snippet.

### P2 — completeness

- [x] Redraw README architecture: replace "six primary targets" with an honest accounting of 14 libraries + 2 executables + 1 macro plugin. The dependency diagram now shows `BaseChatBackends` and `BaseChatMCP` as siblings depending on `BaseChatInference` directly (not through `BaseChatRuntime`). Added all previously-missing targets to the prose list (`BaseChatUIModelManagement`, `BaseChatTestSupport`, `BaseChatTools`, `BaseChatAppIntents`, `BaseChatFuzz`, `BaseChatMacrosPlugin`, `BaseChatMLXIntegrationTests`).
- [x] Add a consolidated "Trait reference" table to README sourced from `Package.swift`'s `traits:` array. All 14 traits covered.
- [x] Fix `Tests/BaseChatInferenceTests/TrafficBoundaryAuditTest.swift` rule-6 import-graph table: drop the dead `"BaseChatCore/"` prefix (can never match anything in `Sources/`), replace with the live layering — `BaseChatRuntime/` and `BaseChatPersistenceSwiftData/` carry the rule's invariants, plus the `BaseChatInference/` rule now also bans `BaseChatRuntime`/`BaseChatPersistenceSwiftData` upward edges.

## Verification

- `swift build --build-tests --disable-default-traits --skip-update` passes (`Build complete! (47.56s)`).
- `swift test --filter "BaseChatInferenceTests.TrafficBoundaryAuditTest" --disable-default-traits --skip-update` passes — 15/15 tests including all sabotage checks.
- All markdown link targets in changed files exist on disk (`docs/THREAT_MODEL.md`, `Sources/BaseChatUI/BaseChatUI.docc/Articles/BuildingAChatUI.md`, etc.).
- Spot-checked README example code against the actual public initializer of `BaseChatBootstrap` in `Sources/BaseChatPersistenceSwiftData/BaseChatBootstrap.swift`.

## Future work not in scope

- DocC catalogs for `BaseChatRuntime`, `BaseChatPersistenceSwiftData`, and `BaseChatBackends` — currently undocumented at the module level. Worth a follow-up but out of scope for a doc-fix PR.
- Refreshed `Example/Screenshots/demo.png` reflecting the current chat UI.

## Test plan

- [ ] CI passes on macOS runner
- [ ] Markdown renders correctly on GitHub (architecture diagram in the README is ASCII; verify alignment in the PR's Files view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)