### PR TITLE
test: add cold-start conformance gate for downstream consumers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,3 +526,37 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
           path: test-diagnostics/
+
+  # Cold-start conformance — scaffolds a fresh SwiftPM consumer in a tmpdir,
+  # links BCK by local path, and runs one chat turn through a tiny inline fake
+  # backend. Catches breaks in the public consumer surface that BCK's own
+  # in-tree tests miss (Package.swift link shape, public registration / load /
+  # generate APIs, GenerationStream consumption pattern, swift-tools-version
+  # floor). See scripts/cold-start-conformance.sh for the full rationale.
+  cold-start:
+    runs-on: macos-15  # match the `test` job runner so cache keys collide
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.3"
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v5
+        with:
+          path: |
+            .build/artifacts
+            .build/checkouts
+            .build/repositories
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
+            ${{ runner.os }}-${{ runner.arch }}-spm-
+
+      - name: Run cold-start conformance
+        timeout-minutes: 6
+        run: scripts/cold-start-conformance.sh

--- a/scripts/cold-start-conformance.sh
+++ b/scripts/cold-start-conformance.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Cold-start conformance test.
+#
+# Scaffolds a fresh SwiftPM consumer in a tmpdir, links BaseChatKit by local
+# path, builds against the public consumer surface (BaseChatInference only —
+# no internal test-support targets), runs one chat turn through a tiny inline
+# fake backend, and asserts the round trip works.
+#
+# This is the missing test that would have caught most of the friction
+# documented in agent cold-start runs (BCK-test-01, BCK-test-02): it exercises
+# Package.swift wiring, BCK linking, the public registration / load / generate
+# API, and the GenerationStream consumption pattern from the *outside in*.
+#
+# Runs in CI on every PR. ~30s on a warm cache.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORK="$(mktemp -d -t bck-cold-start.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "==> Cold-start conformance"
+echo "    BCK:  $REPO_ROOT"
+echo "    work: $WORK"
+
+cd "$WORK"
+
+# 1. Scaffold consumer Package.swift.
+#
+# tools-version 6.2 is required for `.macOS(.v26)`; we pin to v15 (BCK's floor)
+# so the test runs on every macOS BCK supports, not just the latest.
+cat > Package.swift <<EOF
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "ColdStartConsumer",
+    platforms: [.macOS(.v15)],
+    products: [
+        .executable(name: "ColdStart", targets: ["ColdStart"]),
+    ],
+    dependencies: [
+        .package(path: "$REPO_ROOT"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "ColdStart",
+            dependencies: [
+                .product(name: "BaseChatInference", package: "BaseChatKit"),
+            ],
+            path: "Sources/ColdStart"
+        ),
+    ]
+)
+EOF
+
+# 2. Scaffold consumer source.
+mkdir -p Sources/ColdStart
+cat > Sources/ColdStart/main.swift <<'SWIFT'
+import BaseChatInference
+import Foundation
+
+// MARK: - Inline fake backend
+//
+// A real downstream consumer would register MLX / Llama / Foundation. For the
+// conformance test we want zero external dependencies (no model files, no OS
+// availability) so we roll a minimal fake here. This is deliberately the
+// *consumer-facing* shape — anything required to conform from outside the BCK
+// monorepo must be public on `InferenceBackend`.
+
+final class FakeBackend: InferenceBackend, @unchecked Sendable {
+    nonisolated(unsafe) var isModelLoaded = false
+    nonisolated(unsafe) var isGenerating = false
+
+    let capabilities = BackendCapabilities(
+        supportedParameters: [.temperature],
+        maxContextTokens: 2048,
+        supportsSystemPrompt: true,
+        memoryStrategy: .external,   // skip the resident-memory plan math
+        maxOutputTokens: 64,
+        supportsStreaming: true
+    )
+
+    func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
+        isModelLoaded = true
+    }
+
+    func generate(
+        prompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig
+    ) throws -> GenerationStream {
+        isGenerating = true
+        let stream = AsyncThrowingStream<GenerationEvent, Error> { continuation in
+            for chunk in ["pong-", "from-", "fake"] {
+                continuation.yield(.token(chunk))
+            }
+            continuation.finish()
+        }
+        isGenerating = false
+        return GenerationStream(stream)
+    }
+
+    func stopGeneration() { isGenerating = false }
+    func unloadModel() { isModelLoaded = false }
+}
+
+// MARK: - Cold-start round trip
+
+@MainActor
+func run() async throws -> Int32 {
+    let service = InferenceService()
+    service.declareSupport(for: .foundation)
+    service.registerBackendFactory { type in
+        type == .foundation ? FakeBackend() : nil
+    }
+
+    // ModelInfo.builtInFoundation is the canonical public entry for Foundation
+    // models; we reuse it here to exercise the same code path real consumers
+    // would hit, with our fake backend stepping in for Apple's.
+    try await service.loadModel(
+        from: .builtInFoundation,
+        plan: .systemManaged(requestedContextSize: 512)
+    )
+
+    let stream = try service.generate(
+        messages: [(role: "user", content: "ping")]
+    )
+
+    var collected = ""
+    for try await event in stream.events {
+        if case .token(let chunk) = event {
+            collected += chunk
+        }
+    }
+
+    if collected.isEmpty {
+        FileHandle.standardError.write(Data("FAIL: empty reply\n".utf8))
+        return 2
+    }
+
+    print("OK reply=\(collected.count)chars text=\(collected)")
+    return 0
+}
+
+let exitCode = try await run()
+exit(exitCode)
+SWIFT
+
+# 3. Build.
+echo "==> swift build"
+swift build --package-path . 2>&1 | tail -40
+
+# 4. Run.
+echo "==> swift run"
+swift run --package-path . ColdStart
+EXIT=$?
+
+if [[ $EXIT -ne 0 ]]; then
+    echo "FAIL: cold-start consumer exited with $EXIT"
+    exit $EXIT
+fi
+
+echo "==> Cold-start conformance: OK"


### PR DESCRIPTION
## Summary

Scaffolds a fresh SwiftPM consumer in a tmpdir on every PR, links BaseChatKit by local path, and runs one chat turn through a tiny inline fake backend — using only the public consumer surface (`BaseChatInference`). Asserts the round trip works.

## Why

Two recent agent-driven cold-start runs (BCK-test-01, BCK-test-02) shipped working apps but surfaced eight P0 friction points in the public consumer surface — deprecated APIs that autocomplete picks first, undocumented constants only visible in source, `swift-tools-version` floors not stated in docs, link-shape gotchas. None of these are caught by BCK's in-tree test suites, because those tests import internal targets directly and never exercise the link path or registration ergonomics a real downstream consumer faces.

This PR adds the missing floor: a single bash script that builds and runs a minimal external consumer, plus a CI job that gates every PR on it. ~30s on a warm cache.

## What this catches

Anything that breaks the public consumer surface for `BaseChatInference`:

- `InferenceService()` no-arg init
- `service.declareSupport(for:)` / `registerBackendFactory(_:)`
- `service.loadModel(from:plan:)` (non-deprecated path)
- `service.generate(messages:)`
- `GenerationStream(_:)` public init
- `GenerationEvent.token(_:)` case
- `BackendCapabilities.init(...)` with all-defaulted args
- `ModelLoadPlan.systemManaged(requestedContextSize:)`
- `ModelInfo.builtInFoundation`
- `ModelType.foundation`
- The `InferenceBackend` protocol's externally-conformable shape

## What this does *not* catch (yet)

This is a deliberate floor, not a ceiling. Future expansions, in priority order:

- A second test that exercises `BaseChatBootstrap` + `ChatViewModel` (would catch the `default.store` SwiftData collision and the Foundation 4-step selection ritual)
- A third that exercises `BaseChatUI` + `ChatView` (would catch view-builder defaults and the `@Observable` vs `ObservableObject` deadlock)

## Test plan
- [x] Local run on `main` passes (`pong-from-fake` round trip, exit 0)
- [ ] CI green on this PR
- [ ] Sanity-check failure mode: introduce a temporary breaking change to a public API (e.g. rename `registerBackendFactory`) and confirm the gate fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)