### PR TITLE
test: add tier-2 cold-start conformance for Bootstrap + ChatViewModel path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,3 +560,37 @@ jobs:
       - name: Run cold-start conformance
         timeout-minutes: 6
         run: scripts/cold-start-conformance.sh
+
+  # Cold-start conformance (tier 2) — extends the tier-1 pattern to the
+  # high-level orchestration surface real chat apps use: BaseChatBootstrap →
+  # ChatViewModel → vm.sendMessage(). Catches breaks in BaseChatBootstrap link
+  # shape (Inference + Runtime + PersistenceSwiftData + UI products), the
+  # configure(runtime:) ergonomics, and the ambient inputText / sendMessage
+  # pattern. See scripts/cold-start-tier2-bootstrap.sh for the full rationale.
+  cold-start-tier2:
+    runs-on: macos-15  # match the `test` job runner so cache keys collide
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.3"
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v5
+        with:
+          path: |
+            .build/artifacts
+            .build/checkouts
+            .build/repositories
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
+            ${{ runner.os }}-${{ runner.arch }}-spm-
+
+      - name: Run cold-start tier-2 conformance
+        timeout-minutes: 6
+        run: scripts/cold-start-tier2-bootstrap.sh

--- a/scripts/cold-start-tier2-bootstrap.sh
+++ b/scripts/cold-start-tier2-bootstrap.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# Cold-start conformance — tier 2: Bootstrap + ChatViewModel orchestration path.
+#
+# Tier 1 (`scripts/cold-start-conformance.sh`) covers the lowest-level surface:
+# `BaseChatInference` only, a fake backend, and raw
+# `service.generate(messages:)`. It catches breaks in `Package.swift` link
+# shape, public registration, the load API, and `GenerationStream`
+# consumption.
+#
+# Tier 2 covers the *high-level orchestration* surface that real chat apps
+# use: `BaseChatBootstrap` builds the SwiftData container, persistence
+# provider, conversation runtime, endpoint store, and inference service in
+# one shot; `ChatViewModel` is then constructed against that bootstrap and
+# driven through one user → assistant turn via `vm.inputText` and
+# `await vm.sendMessage()`. This is the path that recent agent cold-start
+# audits found buggiest:
+#
+#   - `BaseChatBootstrap` → `ChatViewModel` link shape (BaseChatInference,
+#     BaseChatRuntime, BaseChatPersistenceSwiftData, BaseChatUI products
+#     must all be reachable from a single downstream consumer).
+#   - `ChatViewModel.configure(runtime:)` ergonomics — wires persistence
+#     and endpoint stores from the bootstrap in one call.
+#   - The ambient `vm.inputText = "..."; await vm.sendMessage()` pattern
+#     that all production hosts use, including the fact that `sendMessage`
+#     consumes `inputText` rather than taking it as an argument.
+#   - The `BaseChatBootstrap` default `makeModelContainer:` path resolves
+#     to `ModelContainerFactory.makeContainer()`, which in turn writes a
+#     `default.store` SQLite file under `Application Support`. Two
+#     bootstraps in the same process collide on that path — every
+#     non-trivial test must pass an explicit `makeModelContainer:` closure
+#     pointing at a tmp URL, even though "tier 2 + isolation" sounds
+#     redundant. We do that here both to keep the cold-start runner
+#     hermetic and to surface this footgun in the conformance script
+#     itself: a downstream consumer that copies this scaffold will see
+#     the explicit override and learn the convention before they trip
+#     over the collision.
+#
+# Like tier 1, this rolls a minimal fake `InferenceBackend` inline because
+# `BaseChatTestSupport` is intentionally not a public product (the kit's
+# `MockInferenceBackend` lives inside that target). The fake registers
+# under `.foundation` so the existing `ModelInfo.builtInFoundation` entry
+# point exercises the same code path real consumers hit.
+#
+# Runs in CI on every PR. ~30s on a warm cache.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORK="$(mktemp -d -t bck-cold-start-tier2.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "==> Cold-start conformance (tier 2 — Bootstrap + ChatViewModel)"
+echo "    BCK:  $REPO_ROOT"
+echo "    work: $WORK"
+
+cd "$WORK"
+
+# 1. Scaffold consumer Package.swift.
+#
+# tools-version 6.2 matches tier 1 (the platforms floor pin to v15 keeps the
+# consumer buildable on every macOS BCK supports). Tier 2 needs four
+# products linked in concert:
+#
+#   - BaseChatInference            — InferenceService, InferenceBackend, BackendCapabilities, ModelLoadPlan, ModelInfo
+#   - BaseChatRuntime              — SendInput, ConversationRuntime (transitively via BaseChatPersistenceSwiftData)
+#   - BaseChatPersistenceSwiftData — BaseChatBootstrap, ModelContainerFactory, SwiftDataPersistenceProvider
+#   - BaseChatUI                   — ChatViewModel, ChatViewModel.configure(runtime:)
+cat > Package.swift <<EOF
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "ColdStartTier2Consumer",
+    platforms: [.macOS(.v15)],
+    products: [
+        .executable(name: "ColdStartTier2", targets: ["ColdStartTier2"]),
+    ],
+    dependencies: [
+        // Pin the dependency identity to "BaseChatKit" instead of letting
+        // SwiftPM derive it from the last path component. CI checks out to
+        // a directory named BaseChatKit so the inferred identity matches,
+        // but local runs from a git worktree (\`.claude/worktrees/agent-*\`)
+        // would otherwise resolve the identity to the worktree dir name
+        // and fail \`.product(package: "BaseChatKit")\`.
+        .package(name: "BaseChatKit", path: "$REPO_ROOT"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "ColdStartTier2",
+            dependencies: [
+                .product(name: "BaseChatInference", package: "BaseChatKit"),
+                .product(name: "BaseChatRuntime", package: "BaseChatKit"),
+                .product(name: "BaseChatPersistenceSwiftData", package: "BaseChatKit"),
+                .product(name: "BaseChatUI", package: "BaseChatKit"),
+            ],
+            path: "Sources/ColdStartTier2"
+        ),
+    ]
+)
+EOF
+
+# 2. Scaffold consumer source.
+mkdir -p Sources/ColdStartTier2
+STORE_DIR="$WORK/swiftdata"
+mkdir -p "$STORE_DIR"
+
+cat > Sources/ColdStartTier2/main.swift <<SWIFT
+import BaseChatInference
+import BaseChatRuntime
+import BaseChatPersistenceSwiftData
+import BaseChatUI
+import Foundation
+import SwiftData
+
+// MARK: - Inline fake backend
+//
+// Same shape as tier 1: a downstream consumer would normally register MLX /
+// Llama / Foundation backends, but we want zero external dependencies in a
+// conformance run. The fake registers under \`.foundation\` and stops in for
+// Apple's built-in model so we exercise the same load → generate path real
+// chat apps walk.
+
+final class FakeBackend: InferenceBackend, @unchecked Sendable {
+    nonisolated(unsafe) var isModelLoaded = false
+    nonisolated(unsafe) var isGenerating = false
+
+    let capabilities = BackendCapabilities(
+        supportedParameters: [.temperature],
+        maxContextTokens: 2048,
+        supportsSystemPrompt: true,
+        memoryStrategy: .external,
+        maxOutputTokens: 64,
+        supportsStreaming: true
+    )
+
+    func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
+        isModelLoaded = true
+    }
+
+    func generate(
+        prompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig
+    ) throws -> GenerationStream {
+        isGenerating = true
+        let stream = AsyncThrowingStream<GenerationEvent, Error> { continuation in
+            for chunk in ["pong-", "from-", "tier2"] {
+                continuation.yield(.token(chunk))
+            }
+            continuation.finish()
+        }
+        isGenerating = false
+        return GenerationStream(stream)
+    }
+
+    func stopGeneration() { isGenerating = false }
+    func unloadModel() { isModelLoaded = false }
+}
+
+// MARK: - Cold-start round trip (tier 2)
+
+@MainActor
+func run() async throws -> Int32 {
+    // Per-test SwiftData store. \`BaseChatBootstrap\`'s default
+    // \`makeModelContainer:\` calls \`ModelContainerFactory.makeContainer()\`,
+    // which writes \`default.store\` under Application Support. Two
+    // bootstraps in the same process collide there, so every non-trivial
+    // test (and this conformance runner) must override.
+    let storeURL = URL(fileURLWithPath: "$STORE_DIR/cold-start-tier2.store")
+    let storeConfig = ModelConfiguration(url: storeURL)
+
+    let configuration = BaseChatConfiguration(
+        appName: "ColdStartTier2",
+        bundleIdentifier: "com.basechatkit.coldstart.tier2"
+    )
+
+    let bootstrap = try BaseChatBootstrap(
+        configuration: configuration,
+        makeModelContainer: {
+            try ModelContainerFactory.makeContainer(configurations: [storeConfig])
+        }
+    )
+
+    // Register the fake under .foundation so ModelInfo.builtInFoundation
+    // routes to it. declareSupport must come before the load — the
+    // lifecycle coordinator gates registration on declared model types.
+    bootstrap.inferenceService.declareSupport(for: .foundation)
+    bootstrap.inferenceService.registerBackendFactory { type in
+        type == .foundation ? FakeBackend() : nil
+    }
+
+    try await bootstrap.inferenceService.loadModel(
+        from: .builtInFoundation,
+        plan: .systemManaged(requestedContextSize: 512)
+    )
+
+    // Seed a session in SwiftData so the runtime's user-message insert has
+    // a parent row. \`ChatViewModel.sendMessage()\` requires
+    // \`activeSession\` to be set — we bypass the SessionManagerViewModel
+    // path here because tier 2 is about ChatViewModel, not session list
+    // orchestration (that's what makes tier 2 distinct from a real app
+    // boot, which would go through SessionManagerViewModel.createSession).
+    let sessionRecord = ChatSessionRecord(title: "Tier 2 cold-start")
+    try await bootstrap.persistence.insertSession(sessionRecord)
+
+    // Construct ChatViewModel against the bootstrap's services. Passing
+    // \`bootstrap.conversationRuntime\` is load-bearing: without it the view
+    // model creates a default \`InMemoryMessageStore\`-backed runtime, which
+    // would persist the user/assistant messages to a different store than
+    // \`bootstrap.persistence\`. \`ownsDefaultRuntime\` is then \`false\`, so
+    // \`configure(persistence:)\` will not silently replace the runtime —
+    // exactly what we want.
+    let vm = ChatViewModel(
+        inferenceService: bootstrap.inferenceService,
+        conversationRuntime: bootstrap.conversationRuntime
+    )
+    vm.configure(runtime: bootstrap)
+
+    vm.activeSession = sessionRecord
+
+    // Drive one turn through the ambient \`inputText\` + \`sendMessage()\`
+    // pattern. This is the exact shape ChatInputBar.swift uses, so a
+    // regression here would surface in every host app's compose bar.
+    vm.inputText = "ping"
+    await vm.sendMessage()
+
+    guard let last = vm.messages.last else {
+        FileHandle.standardError.write(Data("FAIL: no messages after sendMessage()\n".utf8))
+        return 2
+    }
+
+    guard last.role == .assistant else {
+        let roleString = String(describing: last.role)
+        FileHandle.standardError.write(Data("FAIL: last message role=\(roleString), expected assistant\n".utf8))
+        return 3
+    }
+
+    let text = last.content
+    if text.isEmpty {
+        FileHandle.standardError.write(Data("FAIL: empty assistant content\n".utf8))
+        return 4
+    }
+
+    print("OK messages=\(vm.messages.count) reply=\(text.count)chars text=\(text)")
+    return 0
+}
+
+let exitCode = try await run()
+exit(exitCode)
+SWIFT
+
+# 3. Build.
+echo "==> swift build"
+swift build --package-path . 2>&1 | tail -40
+
+# 4. Run.
+echo "==> swift run"
+swift run --package-path . ColdStartTier2
+EXIT=$?
+
+if [[ $EXIT -ne 0 ]]; then
+    echo "FAIL: cold-start tier-2 consumer exited with $EXIT"
+    exit $EXIT
+fi
+
+echo "==> Cold-start conformance (tier 2): OK"


### PR DESCRIPTION
## Summary

Extends [PR #1097](https://github.com/roryford/BaseChatKit/pull/1097)'s
cold-start pattern to the **high-level orchestration surface** real chat
apps use. Tier 1 covers `BaseChatInference` only — fake backend, raw
`service.generate(messages:)`. Tier 2 covers `BaseChatBootstrap` →
`ChatViewModel` → `await vm.sendMessage()` driven through the same
ambient `inputText` pattern every host's compose bar uses.

This is the path recent agent cold-start audits found buggiest (silent
regressions, ambient `inputText`, default-store collision, Foundation
4-step ritual).

## What tier-2 catches that tier-1 misses

- **Four-product link shape.** A downstream consumer building anything
  more than a generation harness must link `BaseChatInference`,
  `BaseChatRuntime`, `BaseChatPersistenceSwiftData`, and `BaseChatUI`
  in one consumer target. Any of those products dropping a public type
  or breaking `@MainActor` contract surfaces here, not in tier 1.
- **`BaseChatBootstrap` construction.** The default
  `makeModelContainer:` path collides on `default.store`, so non-trivial
  consumers must always pass an explicit `makeModelContainer:` override
  pointing at a per-test URL. The script does so, both to keep the
  runner hermetic and to demonstrate the convention in script form so
  copy-paste consumers learn it the easy way.
- **`ChatViewModel.configure(runtime:)` ergonomics.** Wires persistence
  + endpoint stores from the bootstrap in one call. Catches regressions
  in the `ChatRuntimeBootstrap` adapter contract.
- **Ambient `inputText` + `sendMessage()` pattern.** The script sets
  `vm.inputText = "..."` then `await vm.sendMessage()` — the exact shape
  `ChatInputBar.swift` uses. A regression that, e.g., breaks
  `sendMessage` consuming `inputText` would surface in every host app's
  compose bar.

## Verification

- `bash scripts/cold-start-tier2-bootstrap.sh` exits 0 with
  `OK messages=2 reply=15chars text=pong-from-tier2`.
- Sabotage check — emptied the fake's token list. Script exits non-zero
  with `FAIL: last message role=user, expected assistant` (the empty
  assistant placeholder is removed on `streamFinished(reason: .empty)`).
- Same overall shape as `scripts/cold-start-conformance.sh`. New CI job
  `cold-start-tier2` mirrors `cold-start` (same runner, cache key,
  Xcode pin; required-status — no `continue-on-error`).

## Discoveries / silent-failure observations (deferred)

These were not present in tier 1 and are recorded here as future work
rather than fixed in this PR:

- `BaseChatBootstrap`'s default `makeModelContainer:` resolves to a
  shared `default.store` path. Two bootstraps in the same process
  silently collide on it (no error, just inconsistent state). Every
  non-trivial test must pass an explicit override. Worth considering a
  guard or a "for tests" factory variant that requires an explicit
  store URL.
- `ChatViewModel.sendMessage()` requires `activeSession` to be set
  *and* `isModelLoaded` to be true; the failure for missing session is
  surfaced as `errorMessage = "..."` rather than thrown. A consumer
  who forgets to call `vm.activeSession = ...` sees nothing happen
  and no exception.
- `SwiftPM` resolves `.package(path:)` identity from the last path
  component, not the manifest's `name`. Tier 1 happens to work in CI
  only because the checkout dir is named `BaseChatKit`; the same
  scaffold run from a worktree (`.claude/worktrees/agent-*`) fails to
  resolve `.product(package: "BaseChatKit")`. Tier 2 pins the
  identity via `.package(name: "BaseChatKit", path: ...)` to be
  worktree-portable.

## Test plan

- [x] Local: `bash scripts/cold-start-tier2-bootstrap.sh` → exit 0
- [x] Local sabotage: empty token list → non-zero exit, role-assert fails
- [ ] CI: `cold-start-tier2` job passes on macos-15 with Xcode 26.3