### PR TITLE
feat: add ModelLoadPlan.compute(for:requestedContextSize:) overload that picks strategy from ModelInfo

### DIFF
--- a/Sources/BaseChatInference/Services/ModelLoadPlan.swift
+++ b/Sources/BaseChatInference/Services/ModelLoadPlan.swift
@@ -319,6 +319,58 @@ public struct ModelLoadPlan: Sendable {
         return compute(inputs: inputs)
     }
 
+    /// Ergonomic factory that infers the right `MemoryStrategy` from `model.modelType`.
+    ///
+    /// Callers that have a `ModelInfo` but no live backend instance can build a plan
+    /// without first looking up which `MemoryStrategy` each model format requires. The
+    /// mapping mirrors the default backend roster registered by `DefaultBackends`:
+    ///
+    /// | `ModelType`   | Strategy     | Why                                              |
+    /// |---------------|--------------|--------------------------------------------------|
+    /// | `.foundation` | `.external`  | OS owns memory; delegates to `systemManaged`.    |
+    /// | `.mlx`        | `.resident`  | Weights must be fully resident (unified memory). |
+    /// | `.gguf`       | `.mappable`  | llama.cpp mmap; only active pages need RAM.      |
+    ///
+    /// Prefer this overload over `compute(for:requestedContextSize:strategy:)` when
+    /// you do *not* need to override the strategy — pre-load UI badges, recommendation
+    /// paths, and the standard load flow all want the canonical strategy for the
+    /// model's format. The strategy-explicit overload is still available for advanced
+    /// callers that register a non-default backend (e.g. an MLX backend with a
+    /// hypothetical mmap mode) and want to model that explicitly.
+    ///
+    /// For `.foundation`, the result is identical to ``systemManaged(requestedContextSize:)``
+    /// — the OS owns memory and there is nothing to estimate.
+    public static func compute(
+        for model: ModelInfo,
+        requestedContextSize: Int,
+        environment: Environment = .current,
+        absoluteContextCeiling: Int = 128_000,
+        headroomFraction: Double = 0.40
+    ) -> ModelLoadPlan {
+        switch model.modelType {
+        case .foundation:
+            return systemManaged(requestedContextSize: requestedContextSize)
+        case .mlx:
+            return compute(
+                for: model,
+                requestedContextSize: requestedContextSize,
+                strategy: .resident,
+                environment: environment,
+                absoluteContextCeiling: absoluteContextCeiling,
+                headroomFraction: headroomFraction
+            )
+        case .gguf:
+            return compute(
+                for: model,
+                requestedContextSize: requestedContextSize,
+                strategy: .mappable,
+                environment: environment,
+                absoluteContextCeiling: absoluteContextCeiling,
+                headroomFraction: headroomFraction
+            )
+        }
+    }
+
     /// For system-managed backends (Apple Foundation Models) where memory is owned
     /// by the OS and there's nothing to estimate. Always allows with stub fields.
     public static func systemManaged(requestedContextSize: Int) -> ModelLoadPlan {

--- a/Tests/BaseChatInferenceTests/ModelLoadPlanTests.swift
+++ b/Tests/BaseChatInferenceTests/ModelLoadPlanTests.swift
@@ -917,6 +917,98 @@ final class ModelLoadPlanTests: XCTestCase {
         // here, because a 140 GB file cannot fit with only 4 GB resident.
         XCTAssertEqual(plan.verdict, .deny)
     }
+
+    // MARK: - ModelType-driven overload
+
+    /// `.foundation` ModelInfo must produce a plan identical to `systemManaged(...)`.
+    /// The OS owns memory; the plan is a stub-allow regardless of `environment`.
+    func test_computeForModelInfo_foundation_matchesSystemManaged() {
+        let model = ModelInfo(
+            name: "AppleFoundation",
+            fileName: "",
+            url: URL(fileURLWithPath: "/dev/null"),
+            fileSize: 0,
+            modelType: .foundation,
+            detectedContextLength: nil,
+            estimatedKVBytesPerToken: nil
+        )
+        let inferred = ModelLoadPlan.compute(for: model, requestedContextSize: 4096)
+        let expected = ModelLoadPlan.systemManaged(requestedContextSize: 4096)
+
+        XCTAssertEqual(inferred.verdict, expected.verdict)
+        XCTAssertEqual(inferred.effectiveContextSize, expected.effectiveContextSize)
+        XCTAssertEqual(inferred.outcome, expected.outcome)
+        XCTAssertEqual(inferred.inputs, expected.inputs)
+    }
+
+    /// `.gguf` ModelInfo must produce a plan equivalent to the explicit overload
+    /// with `.mappable` — the strategy llama.cpp actually declares in production.
+    /// (LlamaBackend.capabilities.memoryStrategy == .mappable).
+    func test_computeForModelInfo_gguf_matchesMappableExplicit() {
+        let model = ModelInfo(
+            name: "test",
+            fileName: "test.gguf",
+            url: URL(fileURLWithPath: "/tmp/test.gguf"),
+            fileSize: 4 * oneGB,
+            modelType: .gguf,
+            detectedContextLength: 8192,
+            estimatedKVBytesPerToken: 65_536
+        )
+        let twoGBLocal = 2 * oneGB
+        let env = ModelLoadPlan.Environment(
+            availableMemoryBytes: { twoGBLocal },
+            physicalMemoryBytes: 16 * oneGB
+        )
+        let inferred = ModelLoadPlan.compute(
+            for: model,
+            requestedContextSize: 4096,
+            environment: env
+        )
+        let explicit = ModelLoadPlan.compute(
+            for: model,
+            requestedContextSize: 4096,
+            strategy: .mappable,
+            environment: env
+        )
+
+        XCTAssertEqual(inferred.outcome, explicit.outcome)
+        XCTAssertEqual(inferred.inputs, explicit.inputs)
+        XCTAssertEqual(inferred.inputs.memoryStrategy, .mappable)
+    }
+
+    /// `.mlx` ModelInfo must produce a plan equivalent to the explicit overload
+    /// with `.resident` — MLXBackend.capabilities.memoryStrategy == .resident.
+    func test_computeForModelInfo_mlx_matchesResidentExplicit() {
+        let model = ModelInfo(
+            name: "test-mlx",
+            fileName: "model.safetensors",
+            url: URL(fileURLWithPath: "/tmp/mlx-model"),
+            fileSize: 4 * oneGB,
+            modelType: .mlx,
+            detectedContextLength: 8192,
+            estimatedKVBytesPerToken: 65_536
+        )
+        let eightGBLocal = 8 * oneGB
+        let env = ModelLoadPlan.Environment(
+            availableMemoryBytes: { eightGBLocal },
+            physicalMemoryBytes: 16 * oneGB
+        )
+        let inferred = ModelLoadPlan.compute(
+            for: model,
+            requestedContextSize: 4096,
+            environment: env
+        )
+        let explicit = ModelLoadPlan.compute(
+            for: model,
+            requestedContextSize: 4096,
+            strategy: .resident,
+            environment: env
+        )
+
+        XCTAssertEqual(inferred.outcome, explicit.outcome)
+        XCTAssertEqual(inferred.inputs, explicit.inputs)
+        XCTAssertEqual(inferred.inputs.memoryStrategy, .resident)
+    }
 }
 
 // MARK: - Convenience accessor (test-scoped, avoids repeating `plan.outcome.totalEstimatedBytes`)


### PR DESCRIPTION
## Summary

Adds an additive overload `ModelLoadPlan.compute(for: ModelInfo, requestedContextSize: Int, ...)` that infers the right `MemoryStrategy` from `model.modelType`. Callers no longer need a live backend instance — or to grep `FoundationBackend.swift:127` — to discover which strategy each model format requires.

**Mapping (matches the `DefaultBackends` roster):**

| `ModelType`   | Strategy     | Backend            | Why                                              |
|---------------|--------------|--------------------|--------------------------------------------------|
| `.foundation` | `.external`  | `FoundationBackend`| OS owns memory; delegates to `systemManaged`.    |
| `.mlx`        | `.resident`  | `MLXBackend`       | Weights must be fully resident (unified memory). |
| `.gguf`       | `.mappable`  | `LlamaBackend`     | llama.cpp mmap; only active pages need RAM.      |

Note: the dispatch brief suggested `.gguf` -> `.resident`, but `LlamaBackend.capabilities.memoryStrategy` is actually `.mappable`, and `ModelLifecycleCoordinator.loadModel(from:contextSize:)` reads strategy directly from the backend instance. The new overload mirrors what production already produces today, so swapping a call site over keeps the verdict identical.

## Motivation — agent-DX P0 (cold-start audit BCK-test-02)

Before: a caller with a `ModelInfo` who wanted a plan had to either (a) instantiate a backend just to read `capabilities.memoryStrategy`, or (b) hard-code the strategy by reading each backend file end to end. That's a real cold-start cost — and exactly what the `BCK-test-02` audit flagged.

After: `ModelLoadPlan.compute(for: model, requestedContextSize: ctx)` Just Works.

## Compatibility

Purely additive. The existing `compute(for:requestedContextSize:strategy:)` overload is unchanged — advanced callers that register a non-default backend (e.g. a hypothetical MLX backend with mmap) keep the explicit override. No deprecation, no behaviour change to existing call sites.

## Test plan

- [x] New `compute(for:requestedContextSize:)` covered in `ModelLoadPlanTests`:
  - `.foundation` ModelInfo -> `Outcome` and `Inputs` equal `systemManaged(requestedContextSize:)`.
  - `.gguf` ModelInfo -> `Outcome` and `Inputs` equal `compute(for:..., strategy: .mappable)`.
  - `.mlx` ModelInfo -> `Outcome` and `Inputs` equal `compute(for:..., strategy: .resident)`.
- [x] CI two-invocation pre-push gate run locally with `--disable-default-traits --skip-update`. XCTest invocation: 2755/2755 tests passing (one suite, `ModelManagementExplicitInitTests`, was spuriously flagged crashed by `scripts/test.sh`'s post-run summary; the underlying suite reports `Test Suite 'ModelManagementExplicitInitTests' passed... 0 failures` and re-running it alone passes cleanly — environmental teardown flake unrelated to this change). Swift Testing invocation: 83/83 passing.