### PR TITLE
fix: derive default SwiftData store path from bundle identifier

### DIFF
--- a/Sources/BaseChatInference/BaseChatConfiguration.swift
+++ b/Sources/BaseChatInference/BaseChatConfiguration.swift
@@ -107,9 +107,15 @@ public struct BaseChatConfiguration: Sendable {
     /// fail-closed regardless of this setting.
     public var customHostTrustPolicy: CustomHostTrustPolicy
 
+    /// The framework's fallback ``bundleIdentifier``. Host apps that surface
+    /// this value back to the user (e.g. as part of a default-path
+    /// derivation) can compare against it to detect when the host forgot to
+    /// install a real configuration.
+    public static let frameworkDefaultBundleIdentifier = "com.basechatkit"
+
     public init(
         appName: String = "BaseChatKit",
-        bundleIdentifier: String = "com.basechatkit",
+        bundleIdentifier: String = BaseChatConfiguration.frameworkDefaultBundleIdentifier,
         modelsDirectoryName: String = "Models",
         features: Features = Features(),
         fileProtectionClass: FileProtectionType? = .completeUntilFirstUserAuthentication,

--- a/Sources/BaseChatPersistenceSwiftData/BaseChatBootstrap.swift
+++ b/Sources/BaseChatPersistenceSwiftData/BaseChatBootstrap.swift
@@ -70,6 +70,16 @@ public final class BaseChatBootstrap {
 
     public var modelContext: ModelContext { modelContainer.mainContext }
 
+    /// Builds the full BaseChatKit stack synchronously.
+    ///
+    /// - Parameter makeModelContainer: Closure producing the SwiftData
+    ///   `ModelContainer`. The default derives a per-app on-disk store at
+    ///   `<Application Support>/<bundleIdentifier>/store.sqlite` from the
+    ///   `configuration` parameter (see
+    ///   ``ModelContainerFactory/defaultModelConfiguration()``). Pass an
+    ///   explicit closure to use an in-memory store, a custom directory, or to
+    ///   migrate an existing app away from the legacy
+    ///   `<Application Support>/default.store` path.
     public init(
         configuration: BaseChatConfiguration,
         inferenceService: InferenceService? = nil,

--- a/Sources/BaseChatPersistenceSwiftData/ModelContainerFactory.swift
+++ b/Sources/BaseChatPersistenceSwiftData/ModelContainerFactory.swift
@@ -30,12 +30,30 @@ public enum ModelContainerFactory {
 
     /// Returns an on-disk `ModelContainer` configured with the current schema.
     ///
+    /// When `configurations` is omitted, the factory derives a per-app default
+    /// store URL from ``BaseChatConfiguration/bundleIdentifier``:
+    /// `<Application Support>/<bundleIdentifier>/store.sqlite`. This prevents
+    /// two BaseChatKit-based apps installed on the same machine from clobbering
+    /// each other's SwiftData store at
+    /// `<Application Support>/default.store` — a collision that previously
+    /// crashed the second app to launch with a schema-mismatch trap because
+    /// `BaseChatBootstrap`'s default container is built via `try!`.
+    ///
+    /// If the host has not customised ``BaseChatConfiguration/bundleIdentifier``
+    /// (still the framework default, `com.basechatkit`), the factory logs a
+    /// loud warning and falls back to SwiftData's default URL — the legacy
+    /// `default.store` path. Failures stay loud, never silent.
+    ///
+    /// To override entirely, pass an explicit `ModelConfiguration` with the
+    /// store URL of your choice (or call ``makeInMemoryContainer()`` for tests).
+    ///
     /// - Parameter configurations: Additional `ModelConfiguration` values to
-    ///   pass to `ModelContainer`. Defaults to a single default (on-disk) config.
+    ///   pass to `ModelContainer`. When omitted, defaults to a single
+    ///   per-app on-disk configuration as described above.
     /// - Returns: A `ModelContainer` using the current schema.
     /// - Throws: If `ModelContainer` initialisation fails.
     public static func makeContainer(
-        configurations: [ModelConfiguration] = [ModelConfiguration()]
+        configurations: [ModelConfiguration] = [defaultModelConfiguration()]
     ) throws -> ModelContainer {
         let container = try ModelContainer(
             for: Schema(versionedSchema: currentSchema),
@@ -44,6 +62,70 @@ public enum ModelContainerFactory {
         )
         applyFileProtection(to: configurations)
         return container
+    }
+
+    /// Returns the default on-disk `ModelConfiguration` used by
+    /// ``makeContainer(configurations:)`` when no explicit configurations are
+    /// supplied.
+    ///
+    /// The returned configuration points at
+    /// `<Application Support>/<bundleIdentifier>/store.sqlite`. The
+    /// per-bundle directory is created if missing. If
+    /// ``BaseChatConfiguration/bundleIdentifier`` is still the framework
+    /// default `com.basechatkit`, or Application Support cannot be located, the
+    /// fallback is the SwiftData default URL (the legacy `default.store`
+    /// path) — the failure mode is loud (logged warning), not silent.
+    public static func defaultModelConfiguration() -> ModelConfiguration {
+        guard let storeURL = defaultStoreURL() else {
+            return ModelConfiguration()
+        }
+        return ModelConfiguration(url: storeURL)
+    }
+
+    /// The default per-app store URL, or `nil` when the host has not configured
+    /// a non-default ``BaseChatConfiguration/bundleIdentifier`` or Application
+    /// Support cannot be resolved. Callers fall back to SwiftData's
+    /// `ModelConfiguration()` default in either case.
+    static func defaultStoreURL() -> URL? {
+        let bundleIdentifier = BaseChatConfiguration.shared.bundleIdentifier
+        if bundleIdentifier == BaseChatConfiguration.frameworkDefaultBundleIdentifier {
+            // We won't silently invent a path for hosts that forgot to set
+            // their own bundle identifier — two such apps would still collide.
+            // Fall back to SwiftData's default and shout about it: this is a
+            // host-configuration bug, not a recoverable runtime condition,
+            // but per BaseChatKit's error-handling policy it must not trap.
+            Log.persistence.warning(
+                "BaseChatConfiguration.shared.bundleIdentifier is still the framework default (\(bundleIdentifier, privacy: .public)). Two apps using this default will collide on a shared SwiftData store. Set BaseChatConfiguration.shared = BaseChatConfiguration(bundleIdentifier: \"com.your-app\") at app launch."
+            )
+            return nil
+        }
+
+        let fileManager = FileManager.default
+        let appSupport: URL
+        do {
+            appSupport = try fileManager.url(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            )
+        } catch {
+            Log.persistence.warning(
+                "Failed to resolve Application Support directory: \(error.localizedDescription). Falling back to SwiftData default store URL."
+            )
+            return nil
+        }
+
+        let storeDirectory = appSupport.appendingPathComponent(bundleIdentifier, isDirectory: true)
+        do {
+            try fileManager.createDirectory(at: storeDirectory, withIntermediateDirectories: true)
+        } catch {
+            Log.persistence.warning(
+                "Failed to create per-app SwiftData store directory at \(storeDirectory.path, privacy: .private): \(error.localizedDescription). Falling back to SwiftData default store URL."
+            )
+            return nil
+        }
+        return storeDirectory.appendingPathComponent("store.sqlite")
     }
 
     /// Returns an ephemeral in-memory `ModelContainer` configured with the

--- a/Tests/BaseChatPersistenceSwiftDataTests/ModelContainerDefaultStorePathTests.swift
+++ b/Tests/BaseChatPersistenceSwiftDataTests/ModelContainerDefaultStorePathTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+@testable import BaseChatPersistenceSwiftData
+@testable import BaseChatInference
+
+/// Defends the per-app default SwiftData store path derivation in
+/// ``ModelContainerFactory/defaultStoreURL()``.
+///
+/// The bug this guards against: prior to this change, every BaseChatKit
+/// consumer that called `BaseChatBootstrap` without overriding
+/// `makeModelContainer:` shared a single
+/// `<Application Support>/default.store` path. Two BCK-based apps installed
+/// on the same machine would clobber each other's SwiftData store and crash
+/// the second app to launch via `try!` in `BaseChatBootstrap`'s default
+/// container build.
+///
+/// These tests verify the URL derivation is stable per `bundleIdentifier`
+/// and that the legacy fallback path triggers (silently — there's no public
+/// hook on the os.Logger output) when the host has not configured one.
+@MainActor
+final class ModelContainerDefaultStorePathTests: XCTestCase {
+
+    private var originalConfiguration: BaseChatConfiguration!
+
+    override func setUp() {
+        super.setUp()
+        originalConfiguration = BaseChatConfiguration.shared
+    }
+
+    override func tearDown() {
+        BaseChatConfiguration.shared = originalConfiguration
+        super.tearDown()
+    }
+
+    func test_defaultStoreURL_isUnderApplicationSupport_perBundleDirectory() throws {
+        let bundleIdentifier = "com.basechatkit.tests.\(UUID().uuidString)"
+        BaseChatConfiguration.shared = BaseChatConfiguration(
+            appName: "Default Store Path",
+            bundleIdentifier: bundleIdentifier
+        )
+        defer {
+            // Clean up the directory the derivation creates so the test
+            // doesn't leave artefacts behind.
+            if let url = ModelContainerFactory.defaultStoreURL() {
+                try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+            }
+        }
+
+        let url = try XCTUnwrap(ModelContainerFactory.defaultStoreURL())
+
+        let appSupport = try FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: false
+        )
+        XCTAssertTrue(
+            url.path.hasPrefix(appSupport.path),
+            "Derived store URL must live under Application Support — got: \(url.path)"
+        )
+        XCTAssertEqual(url.deletingLastPathComponent().lastPathComponent, bundleIdentifier,
+                       "Default store must live in a per-bundle directory")
+        XCTAssertEqual(url.lastPathComponent, "store.sqlite",
+                       "Default store filename should be store.sqlite (not the legacy default.store)")
+    }
+
+    func test_defaultStoreURL_differsBetweenBundleIdentifiers() throws {
+        // The whole point of this fix: two BCK consumers with different bundle
+        // identifiers must derive different default store URLs.
+        let bundleA = "com.example.appA.\(UUID().uuidString)"
+        let bundleB = "com.example.appB.\(UUID().uuidString)"
+
+        BaseChatConfiguration.shared = BaseChatConfiguration(bundleIdentifier: bundleA)
+        let urlA = try XCTUnwrap(ModelContainerFactory.defaultStoreURL())
+
+        BaseChatConfiguration.shared = BaseChatConfiguration(bundleIdentifier: bundleB)
+        let urlB = try XCTUnwrap(ModelContainerFactory.defaultStoreURL())
+
+        defer {
+            try? FileManager.default.removeItem(at: urlA.deletingLastPathComponent())
+            try? FileManager.default.removeItem(at: urlB.deletingLastPathComponent())
+        }
+
+        XCTAssertNotEqual(urlA, urlB,
+                          "Distinct bundle identifiers must derive distinct default store URLs")
+        XCTAssertEqual(urlA.lastPathComponent, "store.sqlite")
+        XCTAssertEqual(urlB.lastPathComponent, "store.sqlite")
+    }
+
+    func test_defaultStoreURL_returnsNil_whenBundleIdentifierIsFrameworkDefault() {
+        // Hosts that forget to set their own bundle identifier inherit
+        // `com.basechatkit`. Per the new derivation, the factory must NOT
+        // invent a per-app path in that case (because two such hosts would
+        // still collide). Instead it returns nil so the caller falls back to
+        // SwiftData's `ModelConfiguration()` default — the legacy
+        // `default.store` path. The behaviour is loud (logged warning) but
+        // not a trap.
+        BaseChatConfiguration.shared = BaseChatConfiguration()
+        XCTAssertEqual(BaseChatConfiguration.shared.bundleIdentifier,
+                       BaseChatConfiguration.frameworkDefaultBundleIdentifier)
+        XCTAssertNil(ModelContainerFactory.defaultStoreURL(),
+                     "Framework-default bundle identifier must fall back to SwiftData's default")
+    }
+
+    func test_defaultStoreURL_createsPerBundleDirectoryOnDisk() throws {
+        let bundleIdentifier = "com.basechatkit.tests.directory.\(UUID().uuidString)"
+        BaseChatConfiguration.shared = BaseChatConfiguration(bundleIdentifier: bundleIdentifier)
+
+        let url = try XCTUnwrap(ModelContainerFactory.defaultStoreURL())
+        let directory = url.deletingLastPathComponent()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        var isDirectory: ObjCBool = false
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: directory.path, isDirectory: &isDirectory),
+            "Per-bundle directory should be created on first derivation"
+        )
+        XCTAssertTrue(isDirectory.boolValue, "Per-bundle path should be a directory")
+    }
+}


### PR DESCRIPTION
## Summary

`BaseChatBootstrap`'s default `makeModelContainer` closure calls
`ModelContainerFactory.makeContainer()` with no arguments. SwiftData's
default `ModelConfiguration()` resolves to `<Application Support>/default.store`,
so two BaseChatKit consumers installed on the same machine share that single
path. The second app to launch crashes via `try!` when its schema mismatches
the resident store.

This was the #1 P0 from the recent agent cold-start audit (PR #1097's
analysis): hits 100% of dev boxes that have run two BCK consumers (e.g.
`BaseChatDemo` + a downstream app like localclaw or a fresh consumer
project).

## Fix

Derive the default store URL from `BaseChatConfiguration.shared.bundleIdentifier`:

- New default: `<Application Support>/<bundleIdentifier>/store.sqlite`
- Two consumers with distinct bundle identifiers can never collide
- The override seam (`makeModelContainer:` parameter on `BaseChatBootstrap`)
  is unchanged — explicit callers keep working
- Exposes `BaseChatConfiguration.frameworkDefaultBundleIdentifier` so callers
  (and the factory itself) can detect the framework-default sentinel

## Fallback shape

When `bundleIdentifier` is still the framework default `com.basechatkit`,
the factory logs a warning via `Log.persistence` and falls back to
SwiftData's default URL (the legacy `default.store` path). Same for
Application Support resolution failures.

Per `CLAUDE.md` error-handling policy: loud (logged) but never a trap;
`assertionFailure`/`fatalError` would crash `swift test`. Hosts get a
clear console warning telling them to set their own `bundleIdentifier`.

## Migration story for existing apps

- Apps that pass an explicit `makeModelContainer:` closure are unaffected.
- Apps that rely on the default and have a real `bundleIdentifier` set
  will start writing to the new per-app path on first launch after upgrade.
  Their old `<Application Support>/default.store` is left behind untouched
  — host apps that need to migrate user data should do so explicitly
  (via a one-time copy from `default.store` to the new path) before
  constructing `BaseChatBootstrap`.
- Apps that never set `bundleIdentifier` (still the framework default)
  see a logged warning and continue to use `default.store` — no behaviour
  change, just visibility into the latent collision.
- The `BaseChatBootstrap.init(makeModelContainer:)` parameter is the
  documented escape hatch for any host that wants to pin their store at
  the legacy path: pass `{ try ModelContainerFactory.makeContainer(configurations: [ModelConfiguration()]) }`.

## Test plan

- [x] `ModelContainerDefaultStorePathTests` (new, 4 tests):
  - Default URL is under Application Support, in a per-bundle directory,
    named `store.sqlite`
  - Two distinct `bundleIdentifier` values derive distinct URLs
  - Framework-default `bundleIdentifier` returns `nil` (legacy fallback)
  - Per-bundle directory is created on disk during derivation
- [x] Full pre-push gate green:
  - 2764 XCTest tests passed (XCTest CI suites)
  - 83 Swift Testing tests passed (Swift Testing CI suite)
- [x] No existing test broken — tests that pass explicit `configurations:`
  arrays exercise unchanged code paths
- [x] `SilentCatchAuditTest` clean: error paths use `do/catch` with
  `Log.persistence.warning`, no `try?`

🤖 Generated with [Claude Code](https://claude.com/claude-code)