### PR TITLE
fix: pin .package(name:) on tier-1 cold-start script for worktree portability

### DIFF
--- a/scripts/cold-start-conformance.sh
+++ b/scripts/cold-start-conformance.sh
@@ -40,7 +40,12 @@ let package = Package(
         .executable(name: "ColdStart", targets: ["ColdStart"]),
     ],
     dependencies: [
-        .package(path: "$REPO_ROOT"),
+        // Pin package identity explicitly. SwiftPM derives \`.package(path:)\`
+        // identity from the last path component, not the manifest \`name:\`. On
+        // a normal checkout the dir is \`BaseChatKit\` so \`.product(... package:
+        // "BaseChatKit")\` resolves; in a worktree (e.g. \`agent-<id>\`) it would
+        // not. Pinning \`name:\` keeps this script worktree-portable.
+        .package(name: "BaseChatKit", path: "$REPO_ROOT"),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
## Summary

Backport from PR #1098: SwiftPM derives `.package(path:)` identity from the last path component, not the manifest `name:`. Tier-1's `cold-start-conformance.sh` worked in CI only because the runner checks BCK out into a directory called `BaseChatKit` — running from any worktree path (e.g. `.claude/worktrees/agent-<id>`) would fail at resolve because `.product(... package: "BaseChatKit")` would not match the auto-derived identity.

The tier-2 worker discovered this while writing #1098 and pinned `.package(name: "BaseChatKit", path: ...)` explicitly. This PR backports the same pin to tier-1.

## Test plan
- [x] Local tier-1 run still green (`pong-from-fake`, exit 0)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)