### PR TITLE
fix(ci): trigger CI on changes to scripts/cold-start*.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
       - "scripts/test.sh"
       - "scripts/example-ui-tests.sh"
       - "scripts/ci-normalize-swiftpm-debug-cache.sh"
+      - "scripts/cold-start*.sh"
   pull_request:
     branches: [main]
     paths:
@@ -23,6 +24,7 @@ on:
       - "scripts/test.sh"
       - "scripts/example-ui-tests.sh"
       - "scripts/ci-normalize-swiftpm-debug-cache.sh"
+      - "scripts/cold-start*.sh"
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}


### PR DESCRIPTION
## Summary

The CI workflow's path filter (`.github/workflows/ci.yml` lines 6–25) only triggers on `Sources/**`, `Tests/**`, `Package.swift`, and a few explicit scripts. The two cold-start conformance scripts (`cold-start-conformance.sh`, `cold-start-tier2-bootstrap.sh`) were not listed — so changes to *either script* did not run the gate that exercises them.

Confirmed on PR #1102, which edited only `cold-start-conformance.sh`: only the separate Lint workflow ran. The CI workflow (and its `cold-start` / `cold-start-tier2` jobs) was skipped entirely.

This makes the gates self-defeating: the most likely change vector for those scripts is editing the scripts themselves, and that's exactly what bypasses CI today.

Glob `scripts/cold-start*.sh` covers both current scripts and any future tier-3.

## Test plan
- [x] PR title matches conventional-commits lint
- [ ] CI runs on this PR (the diff itself touches `.github/workflows/ci.yml`, which IS in the existing filter, so this PR will trigger)
- [ ] Sanity-check post-merge: edit a cold-start script in a follow-up branch and confirm the cold-start job fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)