### PR TITLE
docs: promote 9 agentic-engineering gotchas from session memory to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ Use `scripts/test.sh` — it runs configured suites and prints an honest summary
 - MCP E2E: `RUN_MCP_E2E=1 swift test --traits MCP --filter BaseChatMCPE2ESmokeTests` — `MCP` isn't in the default trait set (defaults are MLX/Llama/HuggingFace), so the trait flag is required or the filter matches zero compiled tests and the build emits `error: fatalError`. Filter to the streamable suite; `EverythingServerSmokeTests` has hung 28+ min in past runs.
 - Ollama E2E requires Ollama at localhost:11434 and `--traits Ollama` (dropped from defaults in v2.0)
 - Llama: use `scripts/test-llama-isolated.sh` when in-process runs accumulate Metal global state
+- `BaseChatE2ETests`: bare form `swift test --filter BaseChatE2ETests --disable-default-traits` runs the full suite; for narrower targeting anchor the regex (`--filter 'BaseChatE2ETests\.'` then test name). Bare-vs-anchored behavior shifted in swift-test post-v2.
 
 ## Test conventions
 
@@ -41,6 +42,7 @@ For trait conventions, suite layout, classification (Unit / Integration / E2E), 
 - Async tests: use real `async/await`. Use `XCTestExpectation`/`XCTWaiter` with tight deadlines for callback-based code only.
 - After asserting an expected outcome, add a sabotage check to confirm the test fails when the code path breaks. Remove before committing.
 - `withKnownIssue` is test debt. Every use requires `// FIXME: <issue URL>` above it. Never in critical E2E paths.
+- Never call `MockURLProtocol.reset()` across suites — `canInit(with:)` returns true whenever any stubs are registered (global state). Use UUID-based hostnames per suite (`http://ollama-\(UUID()).test`) to isolate stubs instead.
 
 ## Service sharing
 
@@ -64,10 +66,13 @@ These patterns either produce `#SendingRisksDataRace` in strict Swift 6 builds o
 3. **`@preconcurrency import` is narrow.** It can suppress missing `Sendable` annotations from older libraries, but it does not suppress region-based isolation errors such as the non-isolated closure-sending pattern above. Do not use it as a blanket Swift 6 escape hatch.
 4. **`AsyncStream<T>` inherits `T`'s sendability.** `AsyncStream<Generation>` is `Sendable` only while `Generation` is. If an upstream library adds a non-`Sendable` field, errors often appear at call sites; keep explicit stream annotations like `let stream: AsyncStream<Generation> = ...` so failures point at the declaration.
 5. **Never use `Task.detached` inside `@MainActor` classes.** `Task { }` inherits the current actor; `Task.detached { }` does not, and the compiler may not warn when it captures mutable `@MainActor` properties. Use `Task { }` and let the callee hop off-actor for expensive non-UI work.
+6. **Never block in `deinit` under `@MainActor` ownership.** `DispatchSemaphore.wait()` in `deinit` either freezes the UI or deadlocks the actor. For async C cleanup, mirror `LlamaBackend`'s retain/detach/release pattern: capture the resource strongly into a `Task.detached`, hop off-actor, then release.
 
 - **Persistence**: SwiftData only. No CoreData.
 - **Error handling**: validate at system boundaries only. Don't guard internal invariants the type system already enforces.
 - **Comments**: explain *why*, not *what*.
+- **Inject `UserDefaults`.** Production code must accept `userDefaults: UserDefaults = .standard` rather than touching `UserDefaults.standard` directly. `swift test --parallel` (default in CI as of v0.16.1) makes shared-instance access flaky. Bitten twice: #734, #761.
+- **Trait gating: gate consumer→library edges, not library→library.** Wrap `M-Tests → M` and `cli-using-M → M` package edges in `.when(traits: ["M"])`. Do NOT gate `M → L` while `M`'s sources still import `L` unconditionally. `PackageTraitGateAuditTest` is a tripwire but doesn't catch every shape — sweep with the trait-combo build below when adding a trait.
 
 ## Platform policy
 
@@ -80,12 +85,15 @@ BaseChatKit targets **n-1**: the current Apple OS release and the one immediatel
 
 When Apple ships a new major OS each September, bump both minimums and remove `#available` guards added for the previous floor. Do not use `Atomic`, `OSAllocatedUnfairLock`, or other APIs that post-date the minimum without checking their availability.
 
+**`swift-tools-version` ceiling = installed Xcode toolchain.** Xcode 26.x ships Swift 6.2.x, not 6.3 — bumping the tools version above what CI runners have breaks `resolve-check` and `fuzz`.
+
 ## Hardware constraints (simulator / CI)
 
 - `LlamaBackend` uses a global `llama_backend_init` — only one instance per process. Tests must share a single instance or use `MockInferenceBackend`.
 - Metal is unavailable in the simulator. Gate any `MLXBackend`/`LlamaBackend` test with `XCTSkipIf`.
 - `FoundationBackend` requires iOS 26 / macOS 26. Gate accordingly.
 - Context window capped at 512 tokens in the simulator to avoid OOM.
+- `MLX.Memory.cacheLimit` / `clearCache()` require the metallib. Calling them without a successful `loadModelContainer` triggers "Failed to load default metallib" and aborts the test process. Guard on container presence as the proxy.
 
 ## Tooling
 
@@ -97,6 +105,8 @@ When Apple ships a new major OS each September, bump both minimums and remove `#
 | `scripts/clean-build.sh` | Full `.build` wipe + `swift package resolve`. Use when builds fail with "XCFramework Info.plist not found" or other `workspace-state.json` desync errors after changing the trait set. |
 | `scripts/fuzz.sh` | Runs the BaseChatFuzz harness (default: 5 min against Ollama). |
 | `scripts/test-mlx-integration.sh` | Runs `BaseChatMLXIntegrationTests` with discovery env vars patched into `.xctestrun`. Use instead of bare `xcodebuild test`. See #986. |
+
+**SwiftPM local-package consumers need explicit `name:`.** When adding `.package(path: ...)` references (worktrees, cold-start gates, scratch consumers), pass `name: "BaseChatKit"` explicitly — `.package(path:)` derives identity from the last path component, which breaks under non-default checkout paths.
 
 ## Pre-push checklist
 
@@ -119,10 +129,11 @@ scripts/test.sh --filter BaseChatInferenceSwiftTestingTests \
 
 **Spike gate** (bounded changes only): `swift build --build-tests --disable-default-traits` then run only the affected suite. Valid only when the diff touches one module and you've run the full suite once already on this branch. Full two-invocation gate is mandatory before the final push and after any rebase.
 
-**Trait-combo sweep** (only when a PR adds/modifies a switched enum in a trait-gated file):
+**Trait-combo sweep** (whenever modifying a switched enum, a `GenerationEvent` / `GenerationConfig` / `BackendCapabilities`-shaped type, or any trait-gated source file):
 ```bash
-swift build --build-tests --traits MLX,Llama,MCPBuiltinCatalog,Ollama,CloudSaaS,HuggingFace
+swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz
 ```
+Default-trait builds won't catch CloudSaaS- or Ollama-gated switch exhaustiveness. The all-traits-on `--build-tests` is the cheapest single check.
 
 CI runs on macOS (10× billing). Each failed push wastes ~25 billed minutes. Test locally first.
 
@@ -131,6 +142,8 @@ When changing behavior of any function or type, grep for ALL test references acr
 ## Error handling
 
 Never use `assertionFailure`/`fatalError` for conditions that have fallback logic — they trap in `swift test`. Use `Log.*` warnings. Reserve `assertionFailure` for true programmer errors with no recovery path.
+
+`try?` is banned in production code. `SilentCatchAuditTest` (in `BaseChatInferenceTests`) fails CI if `try?` appears in error-propagation paths. Use `do/catch` with `Log.*` so the error is visible. Optional decoding at trust boundaries is the only legitimate exception.
 
 ## Commit style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ When Apple ships a new major OS each September, bump both minimums and remove `#
 | `scripts/test.sh` | Runs configured Swift test suites and prints an honest summary. |
 | `scripts/example-ui-tests.sh` | `build-for-testing` / `test-without-building` for Example app XCUITests. |
 | `scripts/clean-leaked-test-artifacts.sh` | Removes test fixtures that leaked into `~/Documents/Models/`. |
+| `scripts/clean-build.sh` | Full `.build` wipe + `swift package resolve`. Use when builds fail with "XCFramework Info.plist not found" or other `workspace-state.json` desync errors after changing the trait set. |
 | `scripts/fuzz.sh` | Runs the BaseChatFuzz harness (default: 5 min against Ollama). |
 | `scripts/test-mlx-integration.sh` | Runs `BaseChatMLXIntegrationTests` with discovery env vars patched into `.xctestrun`. Use instead of bare `xcodebuild test`. See #986. |
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See [docs/SCOPE_DECISION.md](docs/SCOPE_DECISION.md) for the scoping rationale b
 
 ## Requirements
 
-- Swift 5.9+
+- **Swift 6.2** (`swift-tools-version: 6.2` in your `Package.swift`) — required for `.macOS(.v26)` / `.iOS(.v26)` platform entries. Using an older tools version produces `'v26' is unavailable` errors from `PackageDescription`.
 - iOS 18+ / macOS 15+
 - Apple Foundation Models require iOS 26+ / macOS 26+
 
@@ -179,6 +179,31 @@ Pass the matching set as `traits:` on your `.package(...)` entry to lock the con
 ```
 
 `CloudSaaS` and `Ollama` are opt-in. `HuggingFace` is default-on for backwards compatibility; drop it from `traits:` (or start from `--disable-default-traits`) to remove the stock Hub browser/downloader from the build graph. `AnyLanguageModel` is also opt-in and only needed when you want the bridge target.
+
+> **Note on `--disable-default-traits`:** this flag applies to the package where it is passed. If your consumer package declares no traits of its own, SwiftPM will error with `"Disabled default traits by command-line trait configuration on package 'X' that declares no traits"`. Use the flag when building BCK directly or when your package declares its own traits; otherwise control the BCK trait set via the `traits:` array in your `Package.swift` dependency declaration.
+
+**Apple Foundation Models only (no llama.cpp / MLX download)**
+
+If your app targets Apple's built-in Foundation model exclusively, you can drop the 200 MB+ llama.cpp xcframework and 16+ transitive packages by disabling the default traits:
+
+```swift
+.package(
+    url: "https://github.com/roryford/BaseChatKit.git",
+    from: "1.0.0",
+    traits: []   // disables MLX, Llama, HuggingFace defaults
+)
+```
+
+Then at app launch:
+
+```swift
+if #available(macOS 26, iOS 26, *) {
+    vm.foundationModelProvider = { FoundationBackend.isAvailable }
+    vm.loadFoundationModelIfAvailable()
+}
+```
+
+No `--disable-default-traits` flag is needed in your `swift build` command — the empty `traits:` array already communicates your intent to SPM.
 
 For example, a cloud-only consumer can keep the chat UI and local-model loaders out of the download path:
 
@@ -776,6 +801,28 @@ primitives BCK invokes and where the validation boundary actually sits.
 - **mlx-swift** — Apple's MLX framework ships as a pre-built xcframework from [ml-explore/mlx-swift](https://github.com/ml-explore/mlx-swift). Source builds are supported via that upstream repo.
 
 Both dependencies are pinned to specific tagged releases in `Package.swift`. Review `Package.resolved` to verify the exact versions in use.
+
+## Troubleshooting
+
+### "XCFramework Info.plist not found" or "workspace-state.json desync"
+
+This typically happens after changing the active trait set (e.g. switching from the default MLX/Llama traits to traits-disabled, or vice versa). SwiftPM caches binary-target paths in `.build/workspace-state.json` and does not automatically re-resolve stale paths on subsequent builds. A partial cleanup like `rm -rf .build/artifacts/` is insufficient.
+
+Run the recovery script:
+
+```bash
+scripts/clean-build.sh
+```
+
+This removes the entire `.build` directory and runs `swift package resolve` before your next build.
+
+### Stale "No such module 'BaseChatPersistenceSwiftData'" in the editor
+
+SourceKit can retain stale module-not-found diagnostics from a previous trait-set build even while `swift build` succeeds cleanly. The editor's index does not flush automatically when the trait set changes.
+
+**Workaround:** restart the SourceKit language server. In Xcode: *Product → Clean Build Folder*, then reopen the file. In VS Code with Swift extension: run "Swift: Restart SourceKit-LSP" from the command palette (⇧⌘P). The false diagnostic disappears after the language server re-indexes with the current trait set.
+
+If restarting the language server is insufficient, run `scripts/clean-build.sh` and reopen the project.
 
 ## Example App
 

--- a/Sources/BaseChatInference/Services/BackendName.swift
+++ b/Sources/BaseChatInference/Services/BackendName.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Typed constants for the backend-name strings returned by
+/// ``InferenceService/activeBackendName``.
+///
+/// Use these instead of raw string literals when branching on the active backend:
+///
+/// ```swift
+/// if vm.activeBackendName == BackendName.foundation {
+///     // Foundation-specific behaviour
+/// }
+/// ```
+public enum BackendName {
+    /// The Apple Foundation Models backend (`"Apple"`).
+    public static let foundation = "Apple"
+    /// The Ollama backend (`"Ollama"`).
+    public static let ollama = "Ollama"
+    /// The Claude (Anthropic) backend (`"Claude"`).
+    public static let claude = "Claude"
+    /// The OpenAI-compatible backend (`"OpenAI"`).
+    public static let openAI = "OpenAI"
+    /// The MLX backend (`"MLX"`).
+    public static let mlx = "MLX"
+    /// The llama.cpp backend (`"Llama"`).
+    public static let llama = "Llama"
+}

--- a/Sources/BaseChatInference/Services/InferenceService.swift
+++ b/Sources/BaseChatInference/Services/InferenceService.swift
@@ -151,29 +151,11 @@ public final class InferenceService {
 
     // MARK: - Model Lifecycle
 
-    /// Loads a model using the appropriate backend for its format.
-    ///
-    /// If another load request starts before this call completes, this request is
-    /// treated as stale and its completion is suppressed.
-    @available(*, deprecated, message: "Use loadModel(from:plan:); build the plan with ModelLoadPlan.compute(for:requestedContextSize:strategy:)")
-    public func loadModel(
-        from modelInfo: ModelInfo,
-        contextSize: Int32 = 2048
-    ) async throws {
-        ensureProviderWired()
-        generation.stopGeneration()
-        // Delegation without a plan: the coordinator picks the backend first and
-        // then builds a plan using the backend's declared memory strategy. This
-        // preserves the legacy behaviour where `MemoryStrategy` was sourced from
-        // `backend.capabilities.memoryStrategy`.
-        try await lifecycle.loadModel(from: modelInfo, contextSize: contextSize)
-    }
-
     /// Loads a model using a precomputed ``ModelLoadPlan``.
     ///
-    /// Prefer this over ``loadModel(from:contextSize:)`` when the caller has already
-    /// produced a plan (for example via the UI load flow). The plan carries the
-    /// authoritative effective context size and memory verdict.
+    /// Build the plan with ``ModelLoadPlan/compute(for:requestedContextSize:strategy:)``
+    /// or the ``ModelLoadPlan/compute(for:requestedContextSize:)`` overload that accepts
+    /// a ``ModelInfo`` value and picks the strategy automatically.
     public func loadModel(
         from modelInfo: ModelInfo,
         plan: ModelLoadPlan

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+RuntimeAdapter.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+RuntimeAdapter.swift
@@ -150,7 +150,7 @@ extension ChatViewModel {
                !showUpgradeHint,
                let completed = messages.first(where: { $0.id == messageID }),
                completed.hasVisibleContent,
-               activeBackendName == "Apple",
+               activeBackendName == BackendName.foundation,
                messages.filter({ $0.role == .assistant }).count == 1 {
                 showUpgradeHint = true
                 onUpgradeHintTriggered?()

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+SessionManagement.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+SessionManagement.swift
@@ -92,6 +92,30 @@ extension ChatViewModel {
 
     // MARK: - Model Discovery
 
+    /// Refreshes the model registry and, if a Foundation model is discovered,
+    /// selects and begins loading it immediately.
+    ///
+    /// Call this after setting `foundationModelProvider` — typically once at
+    /// app launch on OS versions where Foundation is available:
+    ///
+    /// ```swift
+    /// if #available(macOS 26, iOS 26, *) {
+    ///     vm.foundationModelProvider = { FoundationBackend.isAvailable }
+    ///     vm.loadFoundationModelIfAvailable()
+    /// }
+    /// ```
+    ///
+    /// If no Foundation model is discovered (either because `foundationModelProvider`
+    /// is not set, returns `false`, or the OS is unsupported) this method is a no-op.
+    /// Unlike ``autoSelectFirstRunModel()``, this method is not gated on a first-launch
+    /// flag — call it whenever you want to (re-)enable Foundation as the active backend.
+    public func loadFoundationModelIfAvailable() {
+        refreshModels()
+        guard let foundation = availableModels.first(where: { $0.modelType == .foundation }) else { return }
+        selectedModel = foundation
+        dispatchSelectedLoad()
+    }
+
     /// Re-scans the models directory and rebuilds `availableModels`.
     ///
     /// Includes the built-in Foundation model when `foundationModelProvider` returns `true`.

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel.swift
@@ -121,12 +121,21 @@ public final class ChatViewModel {
     /// double-load race condition.
     public var onFirstLaunch: (@MainActor () -> Void)?
 
-    /// Returns `true` if the Foundation model backend is available on this device.
-    /// Apps should set this to enable Foundation model auto-discovery.
-    /// Example: `chatViewModel.foundationModelProvider = { FoundationBackend.isAvailable }`
+    /// Returns `true` when the Foundation model backend is available on this device.
     ///
-    /// Forwarded to ``modelRegistry`` so both the registry-driven refresh
-    /// path and the legacy ``refreshModels()`` see the same provider.
+    /// Set this closure and call ``loadFoundationModelIfAvailable()`` to enable
+    /// Foundation discovery without the first-launch gate that
+    /// ``autoSelectFirstRunModel()`` imposes:
+    ///
+    /// ```swift
+    /// if #available(macOS 26, iOS 26, *) {
+    ///     vm.foundationModelProvider = { FoundationBackend.isAvailable }
+    ///     vm.loadFoundationModelIfAvailable()
+    /// }
+    /// ```
+    ///
+    /// Forwarded to ``modelRegistry`` so both the registry-driven refresh path
+    /// and ``refreshModels()`` see the same provider.
     public var foundationModelProvider: (@MainActor () -> Bool)? {
         get { modelRegistry.foundationModelProvider }
         set { modelRegistry.foundationModelProvider = newValue }

--- a/Tests/BaseChatInferenceTests/InferenceServiceFacadeTests.swift
+++ b/Tests/BaseChatInferenceTests/InferenceServiceFacadeTests.swift
@@ -16,7 +16,7 @@ final class InferenceServiceFacadeTests: XCTestCase {
         let service = InferenceService()
         service.registerBackendFactory { type in type == .gguf ? mock : nil }
 
-        try await service.loadModel(from: makeModelInfo())
+        try await service.loadModel(from: makeModelInfo(), plan: .testStub())
         XCTAssertTrue(service.isModelLoaded)
 
         let (_, stream) = try service.enqueue(messages: [("user", "hi")])
@@ -64,7 +64,7 @@ final class InferenceServiceFacadeTests: XCTestCase {
             loadObserved.fulfill()
         }
 
-        try await service.loadModel(from: makeModelInfo())
+        try await service.loadModel(from: makeModelInfo(), plan: .testStub())
         await fulfillment(of: [loadObserved], timeout: 2)
         XCTAssertTrue(service.isModelLoaded)
 

--- a/Tests/BaseChatInferenceTests/InferenceServiceNonisolatedTests.swift
+++ b/Tests/BaseChatInferenceTests/InferenceServiceNonisolatedTests.swift
@@ -186,7 +186,7 @@ final class InferenceServiceNonisolatedTests: XCTestCase {
             url: URL(fileURLWithPath: "/Test.bin"),
             fileSize: 0,
             modelType: .gguf
-        ))
+        ), plan: .testStub())
         return service
     }
 }

--- a/Tests/BaseChatInferenceTests/InferenceServiceObservationTests.swift
+++ b/Tests/BaseChatInferenceTests/InferenceServiceObservationTests.swift
@@ -26,7 +26,7 @@ final class InferenceServiceObservationTests: XCTestCase {
             changed.fulfill()
         }
 
-        try await service.loadModel(from: makeModelInfo())
+        try await service.loadModel(from: makeModelInfo(), plan: .testStub())
         await fulfillment(of: [changed], timeout: 2)
         XCTAssertTrue(service.isModelLoaded)
     }
@@ -80,7 +80,7 @@ final class InferenceServiceObservationTests: XCTestCase {
             changed.fulfill()
         }
 
-        try await service.loadModel(from: makeModelInfo())
+        try await service.loadModel(from: makeModelInfo(), plan: .testStub())
         await fulfillment(of: [changed], timeout: 2)
         XCTAssertNotNil(service.activeBackendName)
     }
@@ -99,7 +99,7 @@ final class InferenceServiceObservationTests: XCTestCase {
             changed.fulfill()
         }
 
-        try await service.loadModel(from: makeModelInfo())
+        try await service.loadModel(from: makeModelInfo(), plan: .testStub())
         await fulfillment(of: [changed], timeout: 2)
         XCTAssertEqual(service.activeModelName, "Test")
     }
@@ -118,7 +118,7 @@ final class InferenceServiceObservationTests: XCTestCase {
             changed.fulfill()
         }
 
-        let loadTask = Task { try await service.loadModel(from: makeModelInfo()) }
+        let loadTask = Task { try await service.loadModel(from: makeModelInfo(), plan: .testStub()) }
         await backend.waitUntilLoadStarted()
 
         await fulfillment(of: [changed], timeout: 2)
@@ -133,7 +133,7 @@ final class InferenceServiceObservationTests: XCTestCase {
         let backend = GatedLoadBackend()
         service.registerBackendFactory { type in type == .gguf ? backend : nil }
 
-        let loadTask = Task { try await service.loadModel(from: makeModelInfo()) }
+        let loadTask = Task { try await service.loadModel(from: makeModelInfo(), plan: .testStub()) }
         await backend.waitUntilLoadStarted()
 
         // Now modelLoadProgress is 0.0 — observe the transition to nil on completion.
@@ -174,7 +174,7 @@ final class InferenceServiceObservationTests: XCTestCase {
         let initialState = await iterator.next()
         XCTAssertEqual(initialState, .idle)
 
-        let loadTask = Task { try await service.loadModel(from: makeModelInfo()) }
+        let loadTask = Task { try await service.loadModel(from: makeModelInfo(), plan: .testStub()) }
         await backend.waitUntilLoadStarted()
 
         let loadingState = await iterator.next()
@@ -200,7 +200,7 @@ final class InferenceServiceObservationTests: XCTestCase {
         let backend = GatedLoadBackend()
         service.registerBackendFactory { type in type == .gguf ? backend : nil }
 
-        let loadTask = Task { try await service.loadModel(from: makeModelInfo()) }
+        let loadTask = Task { try await service.loadModel(from: makeModelInfo(), plan: .testStub()) }
         await backend.waitUntilLoadStarted()
 
         let waitTask = Task { await service.waitUntilModelReady(maxPollCount: 50, pollIntervalNanoseconds: 50_000_000) }
@@ -217,7 +217,7 @@ final class InferenceServiceObservationTests: XCTestCase {
         let backend = GatedLoadBackend()
         service.registerBackendFactory { type in type == .gguf ? backend : nil }
 
-        let loadTask = Task { try await service.loadModel(from: makeModelInfo()) }
+        let loadTask = Task { try await service.loadModel(from: makeModelInfo(), plan: .testStub()) }
         await backend.waitUntilLoadStarted()
 
         let ready = await service.waitUntilModelReady(maxPollCount: 1, pollIntervalNanoseconds: 1_000_000)

--- a/Tests/BaseChatInferenceTests/InferenceServiceProgressTests.swift
+++ b/Tests/BaseChatInferenceTests/InferenceServiceProgressTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import BaseChatInference
+import BaseChatTestSupport
 
 /// Tests for `InferenceService.modelLoadProgress` and the `LoadProgressReporting`
 /// opt-in protocol.
@@ -24,7 +25,7 @@ final class InferenceServiceProgressTests: XCTestCase {
         let backend = ProgressReportingBackend()
         service.registerBackendFactory { type in type == .gguf ? backend : nil }
 
-        let task = Task { try await service.loadModel(from: makeModelInfo()) }
+        let task = Task { try await service.loadModel(from: makeModelInfo(), plan: .testStub()) }
         await backend.waitUntilLoadStarted()
 
         XCTAssertEqual(service.modelLoadProgress, 0.0,
@@ -39,7 +40,7 @@ final class InferenceServiceProgressTests: XCTestCase {
         let backend = ProgressReportingBackend()
         service.registerBackendFactory { type in type == .gguf ? backend : nil }
 
-        let task = Task { try await service.loadModel(from: makeModelInfo()) }
+        let task = Task { try await service.loadModel(from: makeModelInfo(), plan: .testStub()) }
         await backend.waitUntilLoadStarted()
 
         await backend.fireProgress(0.25)
@@ -57,7 +58,7 @@ final class InferenceServiceProgressTests: XCTestCase {
         let backend = ProgressReportingBackend()
         service.registerBackendFactory { type in type == .gguf ? backend : nil }
 
-        let task = Task { try await service.loadModel(from: makeModelInfo()) }
+        let task = Task { try await service.loadModel(from: makeModelInfo(), plan: .testStub()) }
         await backend.waitUntilLoadStarted()
         await backend.fireProgress(0.5)
         try await waitForProgress(0.5, on: service)
@@ -75,7 +76,7 @@ final class InferenceServiceProgressTests: XCTestCase {
         let backend = ProgressReportingBackend()
         service.registerBackendFactory { type in type == .gguf ? backend : nil }
 
-        let task = Task { try await service.loadModel(from: makeModelInfo()) }
+        let task = Task { try await service.loadModel(from: makeModelInfo(), plan: .testStub()) }
         await backend.waitUntilLoadStarted()
         await backend.fireProgress(0.4)
         try await waitForProgress(0.4, on: service)
@@ -110,7 +111,7 @@ final class InferenceServiceProgressTests: XCTestCase {
 
         // Start first load and let it report some progress.
         let firstTask = Task {
-            try await service.loadModel(from: makeModelInfo(name: "First", modelType: .gguf))
+            try await service.loadModel(from: makeModelInfo(name: "First", modelType: .gguf), plan: .testStub())
         }
         await firstBackend.waitUntilLoadStarted()
         await firstBackend.fireProgress(0.3)
@@ -118,7 +119,7 @@ final class InferenceServiceProgressTests: XCTestCase {
 
         // Start a second load that supersedes the first.
         let secondTask = Task {
-            try await service.loadModel(from: makeModelInfo(name: "Second", modelType: .foundation))
+            try await service.loadModel(from: makeModelInfo(name: "Second", modelType: .foundation), plan: .testStub())
         }
         await secondBackend.waitUntilLoadStarted()
 
@@ -157,7 +158,7 @@ final class InferenceServiceProgressTests: XCTestCase {
         let backend = ProgressReportingBackend()
         service.registerBackendFactory { type in type == .gguf ? backend : nil }
 
-        let task = Task { try await service.loadModel(from: makeModelInfo()) }
+        let task = Task { try await service.loadModel(from: makeModelInfo(), plan: .testStub()) }
         await backend.waitUntilLoadStarted()
 
         await backend.fireProgress(-0.5)
@@ -180,7 +181,7 @@ final class InferenceServiceProgressTests: XCTestCase {
         let backend = ProgressReportingBackend()
         service.registerBackendFactory { type in type == .gguf ? backend : nil }
 
-        let task = Task { try await service.loadModel(from: makeModelInfo()) }
+        let task = Task { try await service.loadModel(from: makeModelInfo(), plan: .testStub()) }
         await backend.waitUntilLoadStarted()
         XCTAssertEqual(backend.handlerInstallCount, 1, "Service should install a handler at load start")
         XCTAssertFalse(backend.hasNilHandler, "Handler should be non-nil during load")
@@ -197,7 +198,7 @@ final class InferenceServiceProgressTests: XCTestCase {
         let backend = ProgressReportingBackend()
         service.registerBackendFactory { type in type == .gguf ? backend : nil }
 
-        let task = Task { try await service.loadModel(from: makeModelInfo()) }
+        let task = Task { try await service.loadModel(from: makeModelInfo(), plan: .testStub()) }
         await backend.waitUntilLoadStarted()
         await backend.releaseLoadFailure(ProgressTestError.plannedFailure)
         _ = try? await task.value

--- a/Tests/BaseChatInferenceTests/InferenceServiceTests.swift
+++ b/Tests/BaseChatInferenceTests/InferenceServiceTests.swift
@@ -361,12 +361,12 @@ final class InferenceServiceTests: XCTestCase {
         }
 
         let firstTask = Task {
-            try await service.loadModel(from: makeModelInfo(name: "First", modelType: .gguf))
+            try await service.loadModel(from: makeModelInfo(name: "First", modelType: .gguf), plan: .testStub())
         }
         await firstBackend.waitUntilLoadStarted()
 
         let secondTask = Task {
-            try await service.loadModel(from: makeModelInfo(name: "Second", modelType: .foundation))
+            try await service.loadModel(from: makeModelInfo(name: "Second", modelType: .foundation), plan: .testStub())
         }
         await secondBackend.waitUntilLoadStarted()
 
@@ -444,12 +444,12 @@ final class InferenceServiceTests: XCTestCase {
         }
 
         let firstTask = Task {
-            try await service.loadModel(from: makeModelInfo(name: "First", modelType: .gguf))
+            try await service.loadModel(from: makeModelInfo(name: "First", modelType: .gguf), plan: .testStub())
         }
         await firstBackend.waitUntilLoadStarted()
 
         let secondTask = Task {
-            try await service.loadModel(from: makeModelInfo(name: "Second", modelType: .foundation))
+            try await service.loadModel(from: makeModelInfo(name: "Second", modelType: .foundation), plan: .testStub())
         }
         await secondBackend.waitUntilLoadStarted()
 
@@ -476,7 +476,7 @@ final class InferenceServiceTests: XCTestCase {
         }
 
         let loadTask = Task {
-            try await service.loadModel(from: makeModelInfo(name: "InFlight", modelType: .gguf))
+            try await service.loadModel(from: makeModelInfo(name: "InFlight", modelType: .gguf), plan: .testStub())
         }
         await backend.waitUntilLoadStarted()
 
@@ -618,7 +618,7 @@ final class InferenceServiceTests: XCTestCase {
             fileSize: 0,
             modelType: .foundation
         )
-        try await service.loadModel(from: modelInfo)
+        try await service.loadModel(from: modelInfo, plan: .testStub())
 
         XCTAssertEqual(firstCallCount, 1, "First factory should be called once")
         XCTAssertEqual(secondCallCount, 0, "Second factory should never be called when first wins")
@@ -650,7 +650,7 @@ final class InferenceServiceTests: XCTestCase {
             fileSize: 0,
             modelType: .gguf
         )
-        try await service.loadModel(from: modelInfo)
+        try await service.loadModel(from: modelInfo, plan: .testStub())
 
         XCTAssertEqual(firstCallCount, 1, "First factory should be called once")
         XCTAssertEqual(secondCallCount, 1, "Second factory should be called after first rejects")
@@ -673,7 +673,7 @@ final class InferenceServiceTests: XCTestCase {
         )
 
         do {
-            try await service.loadModel(from: modelInfo)
+            try await service.loadModel(from: modelInfo, plan: .testStub())
             XCTFail("Expected InferenceError.inferenceFailure to be thrown")
         } catch InferenceError.inferenceFailure {
             // expected
@@ -763,7 +763,7 @@ final class InferenceServiceTests: XCTestCase {
             fileSize: 0,
             modelType: .gguf
         )
-        try await service.loadModel(from: modelInfo)
+        try await service.loadModel(from: modelInfo, plan: .testStub())
 
         XCTAssertEqual(firstMock.unloadCallCount, 1, "First backend's unloadModel() should be called exactly once")
         XCTAssertEqual(secondMock.loadModelCallCount, 1, "Second backend should be loaded")
@@ -778,7 +778,7 @@ final class InferenceServiceTests: XCTestCase {
         service.registerBackendFactory { _ in mock }
 
         let modelInfo = makeModelInfo(name: "TestModel", modelType: .gguf)
-        try await service.loadModel(from: modelInfo)
+        try await service.loadModel(from: modelInfo, plan: .testStub())
 
         XCTAssertEqual(mock.loadModelCallCount, 1)
         XCTAssertEqual(mock.loadModelCalledOnMainThread, false,
@@ -831,7 +831,8 @@ final class InferenceServiceTests: XCTestCase {
             let modelType: ModelType = (i % 2 == 0) ? .gguf : .gguf
             let task = Task {
                 try await service.loadModel(
-                    from: self.makeModelInfo(name: "Model\(i)", modelType: modelType)
+                    from: self.makeModelInfo(name: "Model\(i)", modelType: modelType),
+                    plan: .testStub()
                 )
             }
             loadTasks.append(task)

--- a/scripts/clean-build.sh
+++ b/scripts/clean-build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# clean-build.sh — full .build directory wipe + resolve
+#
+# Use this when `swift build` fails with "XCFramework Info.plist not found" or
+# other workspace-state.json desync errors. A partial cleanup (e.g. removing
+# only .build/artifacts/) is insufficient: SwiftPM caches binary-target paths
+# in .build/workspace-state.json and does not re-resolve stale entries without
+# a full clean.
+#
+# Common trigger: changing the active trait set (--disable-default-traits,
+# adding/removing Llama or MLX) after a prior build has cached the xcframework
+# paths from the previous configuration.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo "Removing .build directory…"
+rm -rf "$REPO_ROOT/.build"
+
+echo "Resolving packages…"
+swift package resolve --package-path "$REPO_ROOT"
+
+echo "Done. Run your build command now."


### PR DESCRIPTION
## Summary

Promotes 9 load-bearing technical gotchas from local session memory into CLAUDE.md so they're discoverable to fresh contributors and LLM agents in new sessions. Each is a fact you can't derive from reading the repo — they exist because something burned us once and we wrote down "don't do that again."

## Why

A meta-rating session against four agentic-engineering drivers (externalize knowledge / compiler-as-truth / feedback-loop length / ground-truth integrity) flagged "externalize knowledge across sessions" as the weakest driver among CLAUDE.md and adjacent docs. A memory audit then surfaced ~10 facts living only in private session notes that the codebase implicitly depends on.

This PR plus #1116 / #1117 / #1118 / #1115 / #1113 close the gap.

## What landed

| Section | Addition |
|---------|----------|
| Running tests > Special cases | `BaseChatE2ETests` regex-anchor guidance (post-v2 swift-test behavior shift) |
| Test conventions | `MockURLProtocol.reset()` ban — use UUID hostnames per suite |
| Coding conventions > Swift 6 gotchas | Item 6: never block in `deinit` under `@MainActor` ownership |
| Coding conventions | Inject `UserDefaults` (parallel-test flake source — #734, #761) |
| Coding conventions | Trait gating: gate consumer→library edges, not library→library |
| Platform policy | `swift-tools-version` ceiling = installed Xcode toolchain |
| Hardware constraints | `MLX.Memory.cacheLimit` / `clearCache()` require the metallib |
| Tooling | SwiftPM `.package(path:)` needs explicit `name:` for non-default paths |
| Pre-push checklist | Strengthened trait-combo sweep — all traits on, includes Fuzz/MCP |
| Error handling | `try?` is banned (SilentCatchAuditTest); use `do/catch` + `Log.*` |

## Test plan

- [ ] Read each new entry in context — does the new bullet sit naturally with its neighbors?
- [ ] No CI changes; this is docs-only so the standard checks should be near-instant
- [ ] If anything feels stale or duplicates existing content, comment and I'll tighten

🤖 Generated with [Claude Code](https://claude.com/claude-code)