### PR TITLE
chore: clarify deprecation guidance for #1118

### DIFF
--- a/Sources/BaseChatBackends/OllamaBackend.swift
+++ b/Sources/BaseChatBackends/OllamaBackend.swift
@@ -67,7 +67,7 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
     /// ``URLSessionProvider/networkDisabled`` is set, the underlying property
     /// access traps. Use ``makeChecked(urlSession:)`` for a throwing variant
     /// that surfaces the kill-switch as a recoverable error.
-    @available(*, deprecated, message: "Ollama remains in default traits this minor; in the next major it moves to opt-in. Add the `Ollama` trait to your .package(...) entry, or register via DefaultBackends.register(_:). See README 'Build modes' and #714.")
+    @available(*, deprecated, message: "OllamaBackend remains available; this is a build-mode migration notice. Before the next major, add the `Ollama` trait to package dependencies or register via DefaultBackends.register(_:); see README 'Build modes' and #714.")
     public init(urlSession: URLSession? = nil) {
         super.init(
             defaultModelName: "llama3.2",
@@ -78,7 +78,7 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
 
     /// Throwing factory that propagates ``URLSessionProvider/networkDisabled``
     /// as ``CloudBackendError/networkDisabled`` instead of trapping.
-    @available(*, deprecated, message: "Ollama remains in default traits this minor; in the next major it moves to opt-in. Add the `Ollama` trait to your .package(...) entry, or register via DefaultBackends.register(_:). See README 'Build modes' and #714.")
+    @available(*, deprecated, message: "OllamaBackend remains available; this is a build-mode migration notice. Before the next major, add the `Ollama` trait to package dependencies or register via DefaultBackends.register(_:); see README 'Build modes' and #714.")
     public static func makeChecked(urlSession: URLSession? = nil) throws -> OllamaBackend {
         let session: URLSession
         if let urlSession {

--- a/Sources/BaseChatInference/Models/ToolTypes.swift
+++ b/Sources/BaseChatInference/Models/ToolTypes.swift
@@ -306,7 +306,7 @@ public struct ToolResult: Sendable, Codable, Equatable, Hashable {
     /// Maps `isError == true` to ``ErrorKind/permanent`` and `isError == false`
     /// to `nil`. New code should pass an explicit ``ErrorKind`` via the primary
     /// initializer so the failure class is preserved on the wire.
-    @available(*, deprecated, renamed: "init(callId:content:errorKind:)")
+    @available(*, deprecated, renamed: "init(callId:content:errorKind:)", message: "Use init(callId:content:errorKind:) and pass .permanent for legacy isError == true, or nil for success.")
     public init(callId: String, content: String, isError: Bool) {
         self.callId = callId
         self.content = content

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -92,7 +92,7 @@ public struct GenerationConfig: Sendable, Codable {
     public var temperature: Float
     public var topP: Float
     public var repeatPenalty: Float
-    @available(*, deprecated, renamed: "maxOutputTokens", message: "Use maxOutputTokens instead.")
+    @available(*, deprecated, renamed: "maxOutputTokens", message: "Use maxOutputTokens (Int?) for the generation cap; maxTokens is legacy Int32 Codable compatibility only.")
     public var maxTokens: Int32 {
         get { _legacyMaxTokens }
         set { _legacyMaxTokens = newValue }
@@ -320,7 +320,7 @@ public struct GenerationConfig: Sendable, Codable {
     /// per-request payloads; this is a per-request *contract*.
     public var requiredCapabilities: Set<GenerationCapabilityRequirement> = []
 
-    @available(*, deprecated, message: "Use init(temperature:topP:repeatPenalty:topK:typicalP:minP:repetitionPenalty:seed:maxOutputTokens:tools:toolChoice:maxThinkingTokens:jsonMode:streamPrefillProgress:thinkingMarkers:maxToolIterations:grammar:yieldEveryNTokens:requiredCapabilities:) instead.")
+    @available(*, deprecated, message: "Drop the maxTokens argument and use the primary GenerationConfig init with maxOutputTokens; this overload only preserves legacy maxTokens storage.")
     public init(
         temperature: Float = 0.7,
         topP: Float = 0.9,

--- a/Sources/BaseChatInference/Services/InferenceService.swift
+++ b/Sources/BaseChatInference/Services/InferenceService.swift
@@ -419,7 +419,7 @@ public final class InferenceService {
         return generation.hasQueuedRequests
     }
 
-    @available(*, deprecated, message: "The queue auto-drains when the stream terminates. This method is a no-op and will be removed in a future release.")
+    @available(*, deprecated, message: "Remove calls to generationDidFinish(); the queue auto-drains when the returned stream terminates, and this method is a no-op.")
     public func generationDidFinish() {}
 
     public func resetConversation() {

--- a/Sources/BaseChatInference/ThinkingBlockFilter.swift
+++ b/Sources/BaseChatInference/ThinkingBlockFilter.swift
@@ -80,5 +80,5 @@ public struct ThinkingParser {
 }
 
 @available(*, deprecated, renamed: "ThinkingParser",
-    message: "Return type changed from String to [GenerationEvent]. Use ThinkingParser directly.")
+    message: "Use ThinkingParser; process(_:) returns [GenerationEvent] instead of a filtered String.")
 public typealias ThinkingBlockFilter = ThinkingParser

--- a/Sources/BaseChatMCP/MCPOAuth.swift
+++ b/Sources/BaseChatMCP/MCPOAuth.swift
@@ -19,7 +19,7 @@ public struct MCPOAuthTokens: Sendable, Codable, Equatable {
 
     /// String form of the access token. Kept for Codable compatibility and callers
     /// that need the raw string (e.g. logging with redaction).
-    @available(*, deprecated, message: "Use accessTokenData")
+    @available(*, deprecated, message: "Use accessTokenData (Data) instead of accessToken (String); convert with String(data:encoding:) only at UI or protocol boundaries.")
     public var accessToken: String {
         String(data: accessTokenData, encoding: .utf8) ?? ""
     }

--- a/Sources/BaseChatUIModelManagement/Views/Models/ModelManagementSheet.swift
+++ b/Sources/BaseChatUIModelManagement/Views/Models/ModelManagementSheet.swift
@@ -63,8 +63,8 @@ public struct ModelManagementSheet: View {
 
     /// Deprecated environment-based init. Reads ``ChatViewModel`` from the
     /// SwiftUI environment and forwards to the registry-driven path.
-    /// Will be removed in a future minor — pass `modelRegistry` explicitly.
-    @available(*, deprecated, message: "Pass modelRegistry explicitly. The Environment-based init reads from ChatViewModel and will be removed in a future minor.")
+    /// Pass `modelRegistry` explicitly instead.
+    @available(*, deprecated, message: "Use ModelManagementSheet(modelRegistry:initialTab:recommendedModelIDs:recommendationTitle:recommendationMessage:) and pass chatViewModel.modelRegistry explicitly.")
     public init(
         initialTab: Tab = .select,
         recommendedModelIDs: Set<String>? = nil,

--- a/Sources/BaseChatUIModelManagement/Views/Models/StorageManagementView.swift
+++ b/Sources/BaseChatUIModelManagement/Views/Models/StorageManagementView.swift
@@ -27,8 +27,8 @@ public struct StorageManagementView: View {
 
     /// Deprecated environment-based init. Reads ``ChatViewModel`` from the
     /// SwiftUI environment and forwards to the registry-driven path.
-    /// Will be removed in a future minor — pass `modelRegistry` explicitly.
-    @available(*, deprecated, message: "Pass modelRegistry explicitly. The Environment-based init reads from ChatViewModel and will be removed in a future minor.")
+    /// Pass `modelRegistry` explicitly instead.
+    @available(*, deprecated, message: "Use StorageManagementView(modelRegistry:) and pass chatViewModel.modelRegistry explicitly.")
     public init() {
         self.registrySource = .environment
     }


### PR DESCRIPTION
## Summary
- Clarify all deprecated `@available` messages under `Sources/` so migration guidance names replacement APIs and key type/behavior changes.
- Remove vague removal-timeline wording where no concrete version is documented.
- Keep changes limited to API annotations/doc comments; no behavior changes.

## Validation
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all scripts/test.sh --filter BaseChatInferenceTests --filter BaseChatMCPTests --filter BaseChatUIModelManagementTests --filter BaseChatBackendsTests --disable-default-traits --skip-update`
  - Result: PASSED (51 total, 51 passed, 0 failed)

Closes #1118