### PR TITLE
fix: fail closed for unsupported grammar

### DIFF
--- a/Sources/BaseChatBackends/SSECloudBackend.swift
+++ b/Sources/BaseChatBackends/SSECloudBackend.swift
@@ -353,9 +353,7 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
             throw CloudBackendError.invalidURL("Backend not configured. Call loadModel first.")
         }
 
-        if config.grammar != nil, !capabilities.supportsGrammarConstrainedSampling {
-            throw InferenceError.unsupportedGrammar(reason: "\(backendName) does not support grammar-constrained sampling")
-        }
+        try validateGenerationConfig(config)
 
         let request = try buildRequest(
             prompt: prompt,
@@ -470,6 +468,14 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
         let generationStream = GenerationStream(stream, idleTimeout: capturedTimeout)
         streamBox.value = generationStream
         return generationStream
+    }
+
+    private func validateGenerationConfig(_ config: GenerationConfig) throws {
+        if config.grammar != nil, !capabilities.supportsGrammarConstrainedSampling {
+            throw InferenceError.unsupportedGrammar(
+                reason: "\(backendName) does not support grammar-constrained sampling"
+            )
+        }
     }
 
     // MARK: - Stream Parsing

--- a/Tests/BaseChatBackendsTests/BackendContractTests.swift
+++ b/Tests/BaseChatBackendsTests/BackendContractTests.swift
@@ -214,6 +214,7 @@ enum BackendContractChecks {
     static func assertGrammarFailClosedContract<B: InferenceBackend>(
         backendName: String,
         makingBackend makeBackend: () -> B,
+        forbiddenRequestURL: URL? = nil,
         file: StaticString = #filePath,
         line: UInt = #line
     ) async throws {
@@ -237,6 +238,7 @@ enum BackendContractChecks {
 
         var cfg = GenerationConfig()
         cfg.grammar = "root ::= \"hello\""
+        let capturedRequestsBefore = capturedRequestCount(for: forbiddenRequestURL)
 
         XCTAssertThrowsError(
             try backend.generate(prompt: "x", systemPrompt: nil, config: cfg),
@@ -251,6 +253,19 @@ enum BackendContractChecks {
                 return
             }
         }
+
+        XCTAssertEqual(
+            capturedRequestCount(for: forbiddenRequestURL),
+            capturedRequestsBefore,
+            "Backend must reject unsupported grammar before opening a network request",
+            file: file,
+            line: line
+        )
+    }
+
+    private static func capturedRequestCount(for url: URL?) -> Int {
+        guard let url else { return 0 }
+        return MockURLProtocol.capturedRequests.filter { $0.url == url }.count
     }
 
     // MARK: - True-claim convenience: claim-and-skip helper

--- a/Tests/BaseChatBackendsTests/Conformance/ClaudeBackendConformanceTests.swift
+++ b/Tests/BaseChatBackendsTests/Conformance/ClaudeBackendConformanceTests.swift
@@ -32,17 +32,25 @@ final class ClaudeBackendConformanceTests: XCTestCase {
     // MARK: - Grammar fail-closed
 
     func test_contract_grammarFailClosed() async throws {
+        let sessionConfig = URLSessionConfiguration.ephemeral
+        sessionConfig.protocolClasses = [MockURLProtocol.self]
+        let baseURL = URL(string: "http://claude-\(UUID().uuidString).test")!
+        let messagesURL = baseURL.appendingPathComponent("v1/messages")
+        MockURLProtocol.stub(url: messagesURL, response: .error(URLError(.cannotConnectToHost)))
+        defer { MockURLProtocol.unstub(url: messagesURL) }
+
         try await BackendContractChecks.assertGrammarFailClosedContract(
             backendName: backendName,
             makingBackend: {
-                let backend = ClaudeBackend()
+                let backend = ClaudeBackend(urlSession: URLSession(configuration: sessionConfig))
                 backend.configure(
-                    baseURL: URL(string: "https://api.anthropic.com")!,
+                    baseURL: baseURL,
                     apiKey: "sk-ant-test",
                     modelName: "claude-sonnet-4-20250514"
                 )
                 return backend
-            }
+            },
+            forbiddenRequestURL: messagesURL
         )
     }
 

--- a/Tests/BaseChatBackendsTests/Conformance/OllamaBackendConformanceTests.swift
+++ b/Tests/BaseChatBackendsTests/Conformance/OllamaBackendConformanceTests.swift
@@ -32,6 +32,7 @@ final class OllamaBackendConformanceTests: XCTestCase {
         sessionConfig.protocolClasses = [MockURLProtocol.self]
         let baseURL = URL(string: "http://localhost/ollama-\(UUID().uuidString)")!
         let showURL = baseURL.appendingPathComponent("api/show")
+        let chatURL = baseURL.appendingPathComponent("api/chat")
         MockURLProtocol.stub(
             url: showURL,
             response: .immediate(
@@ -39,7 +40,9 @@ final class OllamaBackendConformanceTests: XCTestCase {
                 statusCode: 200
             )
         )
+        MockURLProtocol.stub(url: chatURL, response: .error(URLError(.cannotConnectToHost)))
         defer { MockURLProtocol.unstub(url: showURL) }
+        defer { MockURLProtocol.unstub(url: chatURL) }
 
         try await BackendContractChecks.assertGrammarFailClosedContract(
             backendName: backendName,
@@ -47,7 +50,8 @@ final class OllamaBackendConformanceTests: XCTestCase {
                 let backend = OllamaBackend(urlSession: URLSession(configuration: sessionConfig))
                 backend.configure(baseURL: baseURL, modelName: "llama3.2")
                 return backend
-            }
+            },
+            forbiddenRequestURL: chatURL
         )
     }
 

--- a/Tests/BaseChatBackendsTests/Conformance/OpenAIBackendConformanceTests.swift
+++ b/Tests/BaseChatBackendsTests/Conformance/OpenAIBackendConformanceTests.swift
@@ -31,17 +31,25 @@ final class OpenAIBackendConformanceTests: XCTestCase {
     // MARK: - Grammar fail-closed
 
     func test_contract_grammarFailClosed() async throws {
+        let sessionConfig = URLSessionConfiguration.ephemeral
+        sessionConfig.protocolClasses = [MockURLProtocol.self]
+        let baseURL = URL(string: "http://openai-\(UUID().uuidString).test")!
+        let completionsURL = baseURL.appendingPathComponent("v1/chat/completions")
+        MockURLProtocol.stub(url: completionsURL, response: .error(URLError(.cannotConnectToHost)))
+        defer { MockURLProtocol.unstub(url: completionsURL) }
+
         try await BackendContractChecks.assertGrammarFailClosedContract(
             backendName: backendName,
             makingBackend: {
-                let backend = OpenAIBackend()
+                let backend = OpenAIBackend(urlSession: URLSession(configuration: sessionConfig))
                 backend.configure(
-                    baseURL: URL(string: "https://api.openai.com")!,
+                    baseURL: baseURL,
                     apiKey: "sk-test",
                     modelName: "gpt-4o-mini"
                 )
                 return backend
-            }
+            },
+            forbiddenRequestURL: completionsURL
         )
     }
 

--- a/Tests/BaseChatBackendsTests/Conformance/OpenAIResponsesBackendConformanceTests.swift
+++ b/Tests/BaseChatBackendsTests/Conformance/OpenAIResponsesBackendConformanceTests.swift
@@ -33,17 +33,25 @@ final class OpenAIResponsesBackendConformanceTests: XCTestCase {
     // MARK: - Grammar fail-closed
 
     func test_contract_grammarFailClosed() async throws {
+        let sessionConfig = URLSessionConfiguration.ephemeral
+        sessionConfig.protocolClasses = [MockURLProtocol.self]
+        let baseURL = URL(string: "http://openai-responses-\(UUID().uuidString).test")!
+        let responsesURL = baseURL.appendingPathComponent("v1/responses")
+        MockURLProtocol.stub(url: responsesURL, response: .error(URLError(.cannotConnectToHost)))
+        defer { MockURLProtocol.unstub(url: responsesURL) }
+
         try await BackendContractChecks.assertGrammarFailClosedContract(
             backendName: backendName,
             makingBackend: {
-                let backend = OpenAIResponsesBackend()
+                let backend = OpenAIResponsesBackend(urlSession: URLSession(configuration: sessionConfig))
                 backend.configure(
-                    baseURL: URL(string: "https://api.openai.com")!,
+                    baseURL: baseURL,
                     apiKey: "sk-test",
                     modelName: "gpt-5"
                 )
                 return backend
-            }
+            },
+            forbiddenRequestURL: responsesURL
         )
     }
 


### PR DESCRIPTION
## Summary
- Keeps the SSE cloud backend grammar preflight ahead of request construction/network startup.
- Strengthens the grammar fail-closed contract to assert no backend request is opened.
- Wires no-network grammar contract coverage for Ollama, OpenAI, Claude, and OpenAI Responses conformance tests.

## Validation
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all scripts/test.sh --filter BaseChatBackendsTests --disable-default-traits --skip-update
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all scripts/test.sh --filter OllamaBackendConformanceTests --filter OpenAIBackendConformanceTests --filter ClaudeBackendConformanceTests --filter OpenAIResponsesBackendConformanceTests --traits Ollama,CloudSaaS --skip-update

Closes #1086