### PR TITLE
fix: remove fuzz dependency on test support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -552,7 +552,6 @@ let package = Package(
             dependencies: [
                 "BaseChatFuzz",
                 "BaseChatInference",
-                "BaseChatTestSupport",
                 "BaseChatBackends",
             ],
             path: "Sources/BaseChatFuzzBackends",

--- a/Sources/BaseChatFuzzBackends/FuzzModelDiscovery.swift
+++ b/Sources/BaseChatFuzzBackends/FuzzModelDiscovery.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if Ollama
+import BaseChatBackends
+#endif
 
 /// Fuzz-local model discovery utilities.
 ///
@@ -8,22 +11,19 @@ enum FuzzModelDiscovery {
 
     // MARK: - Ollama
 
+#if Ollama
     static func listOllamaModels(baseURL: URL) -> [String]? {
         guard let models = fetchOllamaModels(baseURL: baseURL) else { return nil }
-        return models.compactMap { $0["name"] as? String }
+        return models.map(\.name)
     }
 
-    private static func fetchOllamaModels(baseURL: URL) -> [[String: Any]]? {
-        let url = baseURL.appendingPathComponent("api/tags")
-        var request = URLRequest(url: url)
-        request.timeoutInterval = 3
-
+    private static func fetchOllamaModels(baseURL: URL) -> [RemoteModelInfo]? {
         let semaphore = DispatchSemaphore(value: 0)
         final class Box: @unchecked Sendable {
             private let lock = NSLock()
-            private var storedValue: [[String: Any]]?
+            private var storedValue: [RemoteModelInfo]?
 
-            var value: [[String: Any]]? {
+            var value: [RemoteModelInfo]? {
                 get {
                     lock.lock()
                     defer { lock.unlock() }
@@ -38,22 +38,18 @@ enum FuzzModelDiscovery {
         }
         let box = Box()
 
-        URLSession.shared.dataTask(with: request) { data, response, _ in
+        Task {
             defer { semaphore.signal() }
-            guard let data,
-                  let http = response as? HTTPURLResponse,
-                  http.statusCode == 200 else { return }
             do {
-                guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-                      let models = json["models"] as? [[String: Any]] else { return }
-                box.value = models
+                box.value = try await OllamaModelListService().fetchModels(from: baseURL)
             } catch {
                 return
             }
-        }.resume()
+        }
         let result = semaphore.wait(timeout: .now() + 5)
         return result == .success ? box.value : nil
     }
+#endif
 
     // MARK: - MLX Models
 

--- a/Sources/BaseChatFuzzBackends/FuzzModelDiscovery.swift
+++ b/Sources/BaseChatFuzzBackends/FuzzModelDiscovery.swift
@@ -1,169 +1,55 @@
 import Foundation
-#if canImport(Metal)
-import Metal
-#endif
 
-/// Static flags for hardware-gated test skipping.
+/// Fuzz-local model discovery utilities.
 ///
-/// Use these with `XCTSkipUnless` / `XCTSkipIf` at the top of tests that
-/// require specific hardware or OS capabilities.
-enum HardwareRequirements {
-
-    /// `true` when running on Apple Silicon (arm64). MLX and llama.cpp
-    /// backends require this architecture.
-    static var isAppleSilicon: Bool {
-        #if arch(arm64)
-        return true
-        #else
-        return false
-        #endif
-    }
-
-    /// `true` when running on a physical device rather than the iOS Simulator.
-    /// Metal compute is unavailable in the simulator, so backends that use
-    /// GPU acceleration (MLX, llama.cpp) will fail there.
-    static var isPhysicalDevice: Bool {
-        #if targetEnvironment(simulator)
-        return false
-        #else
-        return true
-        #endif
-    }
-
-    /// `true` when a real Metal GPU device is accessible in the current process context.
-    ///
-    /// Apple Silicon may still fail to access Metal when running `swift test` via SSH
-    /// or in a headless CI environment without a GPU context. Tests that create
-    /// `MLXArray` values must gate on this flag, not just `isAppleSilicon`.
-    static var hasMetalDevice: Bool {
-        #if canImport(Metal)
-        return MTLCreateSystemDefaultDevice() != nil
-        #else
-        return false
-        #endif
-    }
-
-    /// `true` when the OS version supports Foundation Models (macOS 26+ / iOS 26+).
-    /// This does NOT check whether Apple Intelligence is enabled — use
-    /// `FoundationBackend.isAvailable` for that.
-    static var hasFoundationModels: Bool {
-        if #available(macOS 26, iOS 26, *) {
-            return true
-        }
-        return false
-    }
+/// These mirror the test harness selection rules without making the importable
+/// fuzz backend library depend on `BaseChatTestSupport`.
+enum FuzzModelDiscovery {
 
     // MARK: - Ollama
 
-    /// `true` when a local Ollama server is reachable at `localhost:11434`.
-    ///
-    /// Performs a synchronous HTTP GET to `/api/tags` with a short timeout.
-    /// Use with `XCTSkipUnless` to skip Ollama E2E tests when the server is down.
-    static var hasOllamaServer: Bool {
-        fetchOllamaModels() != nil
-    }
-
-    /// Returns an Ollama model name, preferring one in the given parameter size range.
-    ///
-    /// Queries `/api/tags` synchronously. If the `OLLAMA_TEST_MODEL` environment
-    /// variable is set AND names a model that is installed locally, that name
-    /// wins — CI / local runs can pin to a specific fast model without having to
-    /// edit test code. Otherwise prefers models whose `parameter_size` falls in
-    /// `preferredSizeRange` (e.g. "7.2B" → 7.2). Falls back to the first
-    /// available model if none match the range. Returns `nil` only if the
-    /// server is unreachable or has no models.
-    static func findOllamaModel(
-        preferredSizeRange: ClosedRange<Double> = 6.5...9.0,
-        environment: [String: String] = ProcessInfo.processInfo.environment
-    ) -> String? {
-        guard let models = fetchOllamaModels() else { return nil }
-        return selectOllamaModel(
-            from: models,
-            preferredSizeRange: preferredSizeRange,
-            environment: environment
-        )
-    }
-
-    /// Returns the first installed Ollama model whose name contains `substring`,
-    /// or `nil` if none match. Returns `nil` if the server is unreachable.
-    ///
-    /// Unlike `findOllamaModel(preferredSizeRange:environment:)`, this matches by
-    /// name only and does not consult `parameter_size`. Use for callers that let
-    /// the user nominate a specific model by substring.
-    static func findOllamaModel(
-        nameContains substring: String,
-        environment: [String: String] = ProcessInfo.processInfo.environment
-    ) -> String? {
-        guard let models = fetchOllamaModels() else { return nil }
-        guard let query = normalizedModelSelector(substring) else {
-            return selectOllamaModel(from: models, environment: environment)
-        }
-        for model in models {
-            if let name = model["name"] as? String,
-               name.localizedCaseInsensitiveContains(query) {
-                return name
-            }
-        }
-        return nil
-    }
-
-    /// Returns the list of installed Ollama model names, or `nil` if the server
-    /// is unreachable.
-    static func listOllamaModels() -> [String]? {
-        guard let models = fetchOllamaModels() else { return nil }
+    static func listOllamaModels(baseURL: URL) -> [String]? {
+        guard let models = fetchOllamaModels(baseURL: baseURL) else { return nil }
         return models.compactMap { $0["name"] as? String }
     }
 
-    /// Selects the best model from a pre-fetched Ollama model list.
-    /// Extracted from `findOllamaModel` for testability.
-    ///
-    /// When `environment` carries `OLLAMA_TEST_MODEL` and the named model is in
-    /// `models`, that name is returned. Otherwise falls through to the existing
-    /// size-based selection logic. Pass an explicit `environment` dictionary
-    /// (e.g. `["OLLAMA_TEST_MODEL": "llama3.1:8b"]`) from tests to avoid
-    /// depending on the real process environment.
-    static func selectOllamaModel(
-        from models: [[String: Any]],
-        preferredSizeRange: ClosedRange<Double> = 6.5...9.0,
-        environment: [String: String] = [:]
-    ) -> String? {
-        if let override = environment["OLLAMA_TEST_MODEL"], !override.isEmpty {
-            for model in models {
-                if let name = model["name"] as? String, name == override {
-                    return name
-                }
-            }
-        }
-        for model in models {
-            guard let name = model["name"] as? String,
-                  let details = model["details"] as? [String: Any],
-                  let paramSize = details["parameter_size"] as? String else { continue }
-            let numeric = paramSize.replacingOccurrences(of: "B", with: "")
-            if let value = Double(numeric), preferredSizeRange.contains(value) {
-                return name
-            }
-        }
-        return models.first?["name"] as? String
-    }
-
-    /// Fetches the model list from Ollama's `/api/tags` endpoint synchronously.
-    /// Returns `nil` if the server is unreachable or the response is malformed.
-    private static func fetchOllamaModels() -> [[String: Any]]? {
-        guard let url = URL(string: "http://localhost:11434/api/tags") else { return nil }
+    private static func fetchOllamaModels(baseURL: URL) -> [[String: Any]]? {
+        let url = baseURL.appendingPathComponent("api/tags")
         var request = URLRequest(url: url)
         request.timeoutInterval = 3
 
         let semaphore = DispatchSemaphore(value: 0)
-        final class Box: @unchecked Sendable { var value: [[String: Any]]? }
+        final class Box: @unchecked Sendable {
+            private let lock = NSLock()
+            private var storedValue: [[String: Any]]?
+
+            var value: [[String: Any]]? {
+                get {
+                    lock.lock()
+                    defer { lock.unlock() }
+                    return storedValue
+                }
+                set {
+                    lock.lock()
+                    defer { lock.unlock() }
+                    storedValue = newValue
+                }
+            }
+        }
         let box = Box()
 
         URLSession.shared.dataTask(with: request) { data, response, _ in
             defer { semaphore.signal() }
             guard let data,
-                  let http = response as? HTTPURLResponse, http.statusCode == 200,
-                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  let models = json["models"] as? [[String: Any]] else { return }
-            box.value = models
+                  let http = response as? HTTPURLResponse,
+                  http.statusCode == 200 else { return }
+            do {
+                guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let models = json["models"] as? [[String: Any]] else { return }
+                box.value = models
+            } catch {
+                return
+            }
         }.resume()
         let result = semaphore.wait(timeout: .now() + 5)
         return result == .success ? box.value : nil
@@ -171,16 +57,6 @@ enum HardwareRequirements {
 
     // MARK: - MLX Models
 
-    /// Scans common model directories for a loadable local MLX model directory.
-    ///
-    /// To avoid unbounded walks through user model folders during routine test
-    /// runs, common-directory discovery is opt-in. Set `MLX_TEST_MODEL` or pass
-    /// `nameContains` to select a specific fixture, or set
-    /// `BASECHAT_DISCOVER_LOCAL_MODELS=1` to allow fallback discovery.
-    ///
-    /// When `MLX_TEST_MODEL` is set, the first directory whose path contains that
-    /// value wins. Otherwise falls back to `nameContains`, then to the first
-    /// discovered candidate in deterministic path order.
     static func findMLXModelDirectory(
         nameContains substring: String? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment
@@ -221,17 +97,22 @@ enum HardwareRequirements {
         )
     }
 
-    static func discoverMLXModelDirectories(
+    private static func discoverMLXModelDirectories(
         in searchDirs: [URL],
         fileManager: FileManager = .default
     ) -> [URL] {
         var results: [URL] = []
         for dir in searchDirs {
-            guard let contents = try? fileManager.contentsOfDirectory(
-                at: dir,
-                includingPropertiesForKeys: [.isDirectoryKey],
-                options: [.skipsHiddenFiles]
-            ) else { continue }
+            let contents: [URL]
+            do {
+                contents = try fileManager.contentsOfDirectory(
+                    at: dir,
+                    includingPropertiesForKeys: [.isDirectoryKey],
+                    options: [.skipsHiddenFiles]
+                )
+            } catch {
+                continue
+            }
 
             for candidate in contents {
                 if isValidMLXDirectory(candidate, fileManager: fileManager) {
@@ -241,12 +122,17 @@ enum HardwareRequirements {
 
                 var isDirectory: ObjCBool = false
                 guard fileManager.fileExists(atPath: candidate.path, isDirectory: &isDirectory),
-                      isDirectory.boolValue,
-                      let nestedContents = try? fileManager.contentsOfDirectory(
+                      isDirectory.boolValue else { continue }
+                let nestedContents: [URL]
+                do {
+                    nestedContents = try fileManager.contentsOfDirectory(
                         at: candidate,
                         includingPropertiesForKeys: [.isDirectoryKey],
                         options: [.skipsHiddenFiles]
-                      ) else { continue }
+                    )
+                } catch {
+                    continue
+                }
 
                 for nestedCandidate in nestedContents
                 where isValidMLXDirectory(nestedCandidate, fileManager: fileManager) {
@@ -259,16 +145,6 @@ enum HardwareRequirements {
 
     // MARK: - GGUF Models
 
-    /// Scans common model directories for a loadable `.gguf` file.
-    ///
-    /// To avoid unbounded walks through user model folders during routine test
-    /// runs, common-directory discovery is opt-in. Set `LLAMA_TEST_MODEL` or pass
-    /// `nameContains` to select a specific fixture, or set
-    /// `BASECHAT_DISCOVER_LOCAL_MODELS=1` to allow fallback discovery.
-    ///
-    /// When `LLAMA_TEST_MODEL` is set, the first GGUF whose path contains that
-    /// value wins. Otherwise falls back to `nameContains`, then to the smallest
-    /// discovered candidate that satisfies the size bounds.
     static func findGGUFModel(
         nameContains substring: String? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment,
@@ -318,20 +194,6 @@ enum HardwareRequirements {
         )
     }
 
-    static func discoverGGUFModels(
-        in searchDirs: [URL],
-        fileManager: FileManager = .default,
-        minimumModelSize: Int64 = 50 * 1024 * 1024,
-        maximumModelSize: Int64? = nil
-    ) -> [URL] {
-        discoverGGUFModelCandidates(
-            in: searchDirs,
-            fileManager: fileManager,
-            minimumModelSize: minimumModelSize,
-            maximumModelSize: maximumModelSize
-        ).map(\.url)
-    }
-
     private static func discoverGGUFModelCandidates(
         in searchDirs: [URL],
         fileManager: FileManager = .default,
@@ -340,11 +202,16 @@ enum HardwareRequirements {
     ) -> [GGUFModelCandidate] {
         var results: [GGUFModelCandidate] = []
         for dir in searchDirs {
-            guard let contents = try? fileManager.contentsOfDirectory(
-                at: dir,
-                includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey, .fileSizeKey],
-                options: [.skipsHiddenFiles]
-            ) else { continue }
+            let contents: [URL]
+            do {
+                contents = try fileManager.contentsOfDirectory(
+                    at: dir,
+                    includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey, .fileSizeKey],
+                    options: [.skipsHiddenFiles]
+                )
+            } catch {
+                continue
+            }
 
             for candidate in contents {
                 appendGGUFModel(
@@ -356,12 +223,17 @@ enum HardwareRequirements {
 
                 var isDirectory: ObjCBool = false
                 guard fileManager.fileExists(atPath: candidate.path, isDirectory: &isDirectory),
-                      isDirectory.boolValue,
-                      let nestedContents = try? fileManager.contentsOfDirectory(
+                      isDirectory.boolValue else { continue }
+                let nestedContents: [URL]
+                do {
+                    nestedContents = try fileManager.contentsOfDirectory(
                         at: candidate,
                         includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
                         options: [.skipsHiddenFiles]
-                      ) else { continue }
+                    )
+                } catch {
+                    continue
+                }
 
                 for nestedCandidate in nestedContents {
                     appendGGUFModel(
@@ -376,32 +248,35 @@ enum HardwareRequirements {
         return sortedUniqueGGUFCandidates(results)
     }
 
-    /// Checks whether a directory looks like a loadable local MLX snapshot.
-    ///
-    /// A directory must contain:
-    /// - `config.json` with a non-empty `model_type`
-    /// - at least one `.safetensors` weight file
-    /// - a Hugging Face tokenizer artifact (`tokenizer.json` or `tokenizer.model`)
-    static func isValidMLXDirectory(_ url: URL, fileManager: FileManager = .default) -> Bool {
+    private static func isValidMLXDirectory(_ url: URL, fileManager: FileManager = .default) -> Bool {
         var isDir: ObjCBool = false
         guard fileManager.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue else {
             return false
         }
 
         let configURL = url.appendingPathComponent("config.json")
-        guard fileManager.fileExists(atPath: configURL.path),
-              let configData = try? Data(contentsOf: configURL),
-              let json = try? JSONSerialization.jsonObject(with: configData) as? [String: Any],
-              let modelType = json["model_type"] as? String,
-              !modelType.isEmpty else {
+        guard fileManager.fileExists(atPath: configURL.path) else { return false }
+        do {
+            let configData = try Data(contentsOf: configURL)
+            guard let json = try JSONSerialization.jsonObject(with: configData) as? [String: Any],
+                  let modelType = json["model_type"] as? String,
+                  !modelType.isEmpty else {
+                return false
+            }
+        } catch {
             return false
         }
 
-        guard let files = try? fileManager.contentsOfDirectory(
-            at: url,
-            includingPropertiesForKeys: nil,
-            options: [.skipsHiddenFiles]
-        ) else { return false }
+        let files: [URL]
+        do {
+            files = try fileManager.contentsOfDirectory(
+                at: url,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )
+        } catch {
+            return false
+        }
 
         let fileNames = Set(files.map { $0.lastPathComponent.lowercased() })
         let hasWeights = files.contains { $0.pathExtension.lowercased() == "safetensors" }
@@ -410,7 +285,7 @@ enum HardwareRequirements {
         return hasWeights && hasTokenizer
     }
 
-    static func isValidGGUFModel(
+    private static func isValidGGUFModel(
         _ url: URL,
         minimumModelSize: Int64 = 50 * 1024 * 1024,
         maximumModelSize: Int64? = nil
@@ -422,7 +297,7 @@ enum HardwareRequirements {
         ) != nil
     }
 
-    static func selectFilesystemModel(
+    private static func selectFilesystemModel(
         from candidates: [URL],
         environmentKey: String,
         nameContains substring: String?,
@@ -444,7 +319,7 @@ enum HardwareRequirements {
         return ordered.first
     }
 
-    static func matchingFilesystemModel(_ query: String, in candidates: [URL]) -> URL? {
+    private static func matchingFilesystemModel(_ query: String, in candidates: [URL]) -> URL? {
         if let exact = candidates.first(where: {
             $0.lastPathComponent.caseInsensitiveCompare(query) == .orderedSame
                 || $0.deletingPathExtension().lastPathComponent.caseInsensitiveCompare(query) == .orderedSame
@@ -532,9 +407,14 @@ enum HardwareRequirements {
         maximumModelSize: Int64?
     ) -> GGUFModelCandidate? {
         guard url.pathExtension.lowercased() == "gguf" else { return nil }
-        let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-        guard values?.isRegularFile == true,
-              let size = values?.fileSize else {
+        let values: URLResourceValues
+        do {
+            values = try url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+        } catch {
+            return nil
+        }
+        guard values.isRegularFile == true,
+              let size = values.fileSize else {
             return nil
         }
         let modelSize = Int64(size)
@@ -578,16 +458,20 @@ enum HardwareRequirements {
 
         if let library = fileManager.urls(for: .libraryDirectory, in: .userDomainMask).first {
             let containersDir = library.appendingPathComponent("Containers", isDirectory: true)
-            if let containers = try? fileManager.contentsOfDirectory(
-                at: containersDir,
-                includingPropertiesForKeys: [.isDirectoryKey],
-                options: [.skipsHiddenFiles]
-            ) {
-                for container in containers {
-                    searchDirs.append(
-                        container.appendingPathComponent("Data/Documents/Models", isDirectory: true)
-                    )
-                }
+            let containers: [URL]
+            do {
+                containers = try fileManager.contentsOfDirectory(
+                    at: containersDir,
+                    includingPropertiesForKeys: [.isDirectoryKey],
+                    options: [.skipsHiddenFiles]
+                )
+            } catch {
+                return searchDirs
+            }
+            for container in containers {
+                searchDirs.append(
+                    container.appendingPathComponent("Data/Documents/Models", isDirectory: true)
+                )
             }
         }
 

--- a/Sources/BaseChatFuzzBackends/FuzzModelLoadPlan.swift
+++ b/Sources/BaseChatFuzzBackends/FuzzModelLoadPlan.swift
@@ -1,0 +1,26 @@
+import BaseChatInference
+
+extension ModelLoadPlan {
+    static func fuzzStub(effectiveContextSize: Int) -> ModelLoadPlan {
+        let inputs = Inputs(
+            modelFileSize: 0,
+            memoryStrategy: .external,
+            requestedContextSize: effectiveContextSize,
+            trainedContextLength: nil,
+            kvBytesPerToken: 0,
+            availableMemoryBytes: UInt64.max,
+            physicalMemoryBytes: UInt64.max,
+            absoluteContextCeiling: 128_000,
+            headroomFraction: 0.40
+        )
+        let outcome = Outcome(
+            effectiveContextSize: max(1, effectiveContextSize),
+            estimatedResidentBytes: 0,
+            estimatedKVBytes: 0,
+            totalEstimatedBytes: 0,
+            verdict: .allow,
+            reasons: []
+        )
+        return ModelLoadPlan(inputs: inputs, outcome: outcome)
+    }
+}

--- a/Sources/BaseChatFuzzBackends/LlamaFuzzFactory.swift
+++ b/Sources/BaseChatFuzzBackends/LlamaFuzzFactory.swift
@@ -3,7 +3,6 @@ import Foundation
 import BaseChatBackends
 import BaseChatFuzz
 import BaseChatInference
-import BaseChatTestSupport
 
 /// `FuzzBackendFactory` conformance that instantiates `LlamaBackend` against a
 /// single GGUF model selected from the local model directories.
@@ -28,7 +27,7 @@ public final class LlamaFuzzFactory: FuzzBackendFactory, @unchecked Sendable {
     public var supportsDeterministicReplay: Bool { true }
 
     public func makeHandle() async throws -> FuzzRunner.BackendHandle {
-        guard let modelURL = HardwareRequirements.findGGUFModel(
+        guard let modelURL = FuzzModelDiscovery.findGGUFModel(
             nameContains: modelHint,
             environment: environment
         ) else {
@@ -40,7 +39,7 @@ public final class LlamaFuzzFactory: FuzzBackendFactory, @unchecked Sendable {
         let backend = LlamaBackend()
         try await backend.loadModel(
             from: modelURL,
-            plan: .testStub(effectiveContextSize: 4096)
+            plan: .fuzzStub(effectiveContextSize: 4096)
         )
         self.backend = backend
         return FuzzRunner.BackendHandle(

--- a/Sources/BaseChatFuzzBackends/MLXFuzzFactory.swift
+++ b/Sources/BaseChatFuzzBackends/MLXFuzzFactory.swift
@@ -3,7 +3,6 @@ import Foundation
 import BaseChatBackends
 import BaseChatFuzz
 import BaseChatInference
-import BaseChatTestSupport
 
 /// `FuzzBackendFactory` conformance that instantiates `MLXBackend` from a local
 /// safetensors directory.
@@ -27,7 +26,7 @@ public struct MLXFuzzFactory: FuzzBackendFactory {
 
     @MainActor
     public func makeHandle() async throws -> FuzzRunner.BackendHandle {
-        guard let modelURL = HardwareRequirements.findMLXModelDirectory(
+        guard let modelURL = FuzzModelDiscovery.findMLXModelDirectory(
             nameContains: modelHint,
             environment: environment
         ) else {
@@ -39,7 +38,7 @@ public struct MLXFuzzFactory: FuzzBackendFactory {
         let backend = MLXBackend()
         try await backend.loadModel(
             from: modelURL,
-            plan: .testStub(effectiveContextSize: 4096)
+            plan: .fuzzStub(effectiveContextSize: 4096)
         )
         return FuzzRunner.BackendHandle(
             backend: backend,

--- a/Sources/BaseChatFuzzBackends/OllamaFuzzFactory.swift
+++ b/Sources/BaseChatFuzzBackends/OllamaFuzzFactory.swift
@@ -3,13 +3,12 @@ import Foundation
 import BaseChatBackends
 import BaseChatFuzz
 import BaseChatInference
-import BaseChatTestSupport
 
 /// `FuzzBackendFactory` conformance that instantiates a fresh `OllamaBackend`
 /// configured against a local Ollama server.
 ///
 /// When used directly, the factory honours the existing
-/// `HardwareRequirements.findOllamaModel` selection rules, including the
+/// `FuzzModelDiscovery.selectModel` selection rules, including the
 /// `OLLAMA_TEST_MODEL` environment override. `makeCampaignFactory(modelHint:)`
 /// preserves the CLI's rotate-all default when no explicit model hint is given.
 public struct OllamaFuzzFactory: FuzzBackendFactory {
@@ -30,9 +29,9 @@ public struct OllamaFuzzFactory: FuzzBackendFactory {
     public func makeHandle() async throws -> FuzzRunner.BackendHandle {
         // Single `/api/tags` round-trip per iteration: select from the
         // already-fetched list rather than re-querying via
-        // `HardwareRequirements.findOllamaModel`, which would hit the endpoint
+        // `FuzzModelDiscovery.selectModel`, which would hit the endpoint
         // again. In rotation mode this halves the per-iteration request count.
-        guard let models = HardwareRequirements.listOllamaModels() else {
+        guard let models = FuzzModelDiscovery.listOllamaModels(baseURL: baseURL) else {
             throw FuzzBackendFactoryError(
                 "No Ollama server reachable at \(baseURL.absoluteString). Start with: ollama serve"
             )
@@ -73,7 +72,7 @@ public struct OllamaFuzzFactory: FuzzBackendFactory {
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) throws -> any FuzzBackendFactory {
         guard let normalizedHint = normalizedModelHint(modelHint) else {
-            guard let models = HardwareRequirements.listOllamaModels() else {
+            guard let models = FuzzModelDiscovery.listOllamaModels(baseURL: baseURL) else {
                 throw FuzzBackendFactoryError(
                     "No Ollama server reachable at \(baseURL.absoluteString). Start with: ollama serve"
                 )
@@ -101,7 +100,7 @@ public struct OllamaFuzzFactory: FuzzBackendFactory {
     }
 
     /// Selects an Ollama model from a pre-fetched name list, applying the same
-    /// precedence as the per-call helpers in `HardwareRequirements`:
+    /// precedence as the per-call helpers in `FuzzModelDiscovery`:
     /// 1. explicit `modelHint` (substring match, case-insensitive)
     /// 2. `OLLAMA_TEST_MODEL` env override (substring match)
     /// 3. first model in the list (rotation deterministically pins one model

--- a/Sources/BaseChatTestSupport/CharTokenizer.swift
+++ b/Sources/BaseChatTestSupport/CharTokenizer.swift
@@ -4,10 +4,10 @@ import BaseChatInference
 ///
 /// Useful for tests that need exact, predictable token counts
 /// without depending on a real tokenizer model.
-public struct CharTokenizer: TokenizerProvider {
-    public init() {}
+struct CharTokenizer: TokenizerProvider {
+    init() {}
 
-    public func tokenCount(_ text: String) -> Int {
+    func tokenCount(_ text: String) -> Int {
         max(1, text.count)
     }
 }

--- a/Sources/BaseChatTestSupport/ConversationRuntimeScenario.swift
+++ b/Sources/BaseChatTestSupport/ConversationRuntimeScenario.swift
@@ -35,12 +35,12 @@ import BaseChatInference
 ///     backend: MockInferenceBackend()
 /// )
 /// ```
-public struct ConversationRuntimeScenario: Sendable, Codable {
+struct ConversationRuntimeScenario: Sendable, Codable {
 
-    public struct Step: Sendable, Codable {
+    struct Step: Sendable, Codable {
 
         /// User-facing action driven against the runtime turn-loop.
-        public enum Action: Sendable, Codable, Equatable {
+        enum Action: Sendable, Codable, Equatable {
             case send(text: String)
             case regenerate
             /// Send a message but cancel the stream after observing
@@ -49,31 +49,31 @@ public struct ConversationRuntimeScenario: Sendable, Codable {
             case cancelMidStream(text: String, cancelAfterTokens: Int)
         }
 
-        public let action: Action
+        let action: Action
 
         /// Tokens the backend should yield for this step's stream. Nil leaves
         /// the backend's existing `tokensToYield` in place.
-        public let scriptedTokens: [String]?
+        let scriptedTokens: [String]?
 
-        public init(action: Action, scriptedTokens: [String]? = nil) {
+        init(action: Action, scriptedTokens: [String]? = nil) {
             self.action = action
             self.scriptedTokens = scriptedTokens
         }
     }
 
-    public let steps: [Step]
+    let steps: [Step]
 
     /// If non-nil, the final assistant message's text content must contain
     /// this substring. OOD nonces are encouraged so a passing scenario
     /// can't be reproduced by a mock that silently swallows the script.
-    public let expectedFinalAssistantContains: String?
+    let expectedFinalAssistantContains: String?
 
     /// If non-nil, the number of assistant messages persisted after all
     /// steps complete must equal this value. Discriminates send (appends)
     /// from regenerate (replaces).
-    public let expectedAssistantMessageCount: Int?
+    let expectedAssistantMessageCount: Int?
 
-    public init(
+    init(
         steps: [Step],
         expectedFinalAssistantContains: String? = nil,
         expectedAssistantMessageCount: Int? = nil
@@ -86,31 +86,31 @@ public struct ConversationRuntimeScenario: Sendable, Codable {
 
 /// Result of running a ``ConversationRuntimeScenario`` through the
 /// composition harness. Per-step outcomes plus a final aggregate.
-public struct ConversationRuntimeScenarioResult: Sendable {
+struct ConversationRuntimeScenarioResult: Sendable {
 
-    public struct StepResult: Sendable {
-        public let action: ConversationRuntimeScenario.Step.Action
-        public let tokensObserved: [String]
+    struct StepResult: Sendable {
+        let action: ConversationRuntimeScenario.Step.Action
+        let tokensObserved: [String]
         /// `true` when the step completed normally; `false` when it ended
         /// in error (e.g. cancelled streams) — note that `cancelMidStream`
         /// is *expected* to end in error, so `success=false` is fine there.
-        public let endedNormally: Bool
-        public let error: Error?
+        let endedNormally: Bool
+        let error: Error?
     }
 
-    public let stepResults: [StepResult]
+    let stepResults: [StepResult]
 
     /// Concatenation of all `tokensObserved` across all steps, in order.
-    public let allTokensObserved: [String]
+    let allTokensObserved: [String]
 
     /// All assistant message contents persisted at the end, in order.
-    public let finalAssistantContents: [String]
+    let finalAssistantContents: [String]
 
     /// `true` when both expected predicates (if non-nil) hold.
-    public let assertionsPassed: Bool
+    let assertionsPassed: Bool
 
     /// Human-readable diagnostic when ``assertionsPassed`` is `false`.
-    public let assertionFailureReason: String?
+    let assertionFailureReason: String?
 }
 
 /// Drives a ``ConversationRuntimeScenario`` against a fresh in-memory
@@ -120,13 +120,13 @@ public struct ConversationRuntimeScenarioResult: Sendable {
 /// runs every step, and returns the result. Tests should NOT cache a runner
 /// instance across scenarios; each `run(...)` call gets its own state.
 @MainActor
-public enum ConversationRuntimeScenarioRunner {
+enum ConversationRuntimeScenarioRunner {
 
     /// Runs the scenario and returns the aggregated result. Throws only on
     /// infrastructure failures (e.g. failure to construct the SwiftData
     /// container). Step-level errors are recorded in `stepResults` and do
     /// not throw.
-    public static func run(
+    static func run(
         scenario: ConversationRuntimeScenario,
         backend: MockInferenceBackend
     ) async throws -> ConversationRuntimeScenarioResult {

--- a/Sources/BaseChatTestSupport/ImageFixtures.swift
+++ b/Sources/BaseChatTestSupport/ImageFixtures.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 /// Shared tiny image fixtures for multimodal and attachment tests.
-public enum ImageFixtures {
+enum ImageFixtures {
     /// A valid 1×1 transparent PNG.
-    public static let oneByOnePNGData = Data(
+    static let oneByOnePNGData = Data(
         base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z0ioAAAAASUVORK5CYII="
     )!
 
@@ -17,7 +17,7 @@ public enum ImageFixtures {
     /// Used by perf-audit tests that need realistic-size attachments without
     /// the cost of actually encoding image data. `approxBytes < 4` is clamped
     /// to a minimal SOI+EOI pair.
-    public static func largeJPEG(approxBytes: Int) -> Data {
+    static func largeJPEG(approxBytes: Int) -> Data {
         let minimum = 4 // SOI (2) + EOI (2)
         let total = max(approxBytes, minimum)
         var data = Data(count: total)

--- a/Sources/BaseChatTestSupport/TestHelpers.swift
+++ b/Sources/BaseChatTestSupport/TestHelpers.swift
@@ -122,10 +122,10 @@ public func currentResidentBytes() -> UInt64 {
 
 /// Error thrown by ``withTimeout(_:file:line:_:)`` when the wrapped operation
 /// exceeds its deadline.
-public enum TimeoutError: Error, CustomStringConvertible, Equatable {
+enum TimeoutError: Error, CustomStringConvertible, Equatable {
     case timedOut(Duration)
 
-    public var description: String {
+    var description: String {
         switch self {
         case .timedOut(let duration):
             return "Operation timed out after \(duration)"

--- a/Tests/BaseChatBackendsTests/BackendCapabilitiesContractTests.swift
+++ b/Tests/BaseChatBackendsTests/BackendCapabilitiesContractTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import BaseChatRuntime
 import BaseChatPersistenceSwiftData
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Contract tests that lock down capability fields on every concrete backend.

--- a/Tests/BaseChatBackendsTests/DefaultBackendsTests.swift
+++ b/Tests/BaseChatBackendsTests/DefaultBackendsTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import BaseChatRuntime
 import BaseChatPersistenceSwiftData
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 // MARK: - Pure Routing Tests (no hardware required)

--- a/Tests/BaseChatBackendsTests/FoundationBackendUnitTests.swift
+++ b/Tests/BaseChatBackendsTests/FoundationBackendUnitTests.swift
@@ -3,7 +3,7 @@ import XCTest
 import BaseChatRuntime
 import BaseChatPersistenceSwiftData
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Isolated unit tests for `FoundationBackend` state management and guard paths.

--- a/Tests/BaseChatBackendsTests/FoundationModelE2ETests.swift
+++ b/Tests/BaseChatBackendsTests/FoundationModelE2ETests.swift
@@ -5,7 +5,7 @@ import BaseChatRuntime
 import BaseChatPersistenceSwiftData
 @testable import BaseChatPersistenceSwiftData
 @testable import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 @testable import BaseChatUI
 

--- a/Tests/BaseChatBackendsTests/LlamaArchitecturePreflightTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaArchitecturePreflightTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 @testable import BaseChatInference
 @testable import BaseChatBackends
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 
 /// Preflight-check tests for `LlamaModelLoader` — unsupported GGUF architectures
 /// (vision encoders, embedding-only models, speech/diffusion) must throw

--- a/Tests/BaseChatBackendsTests/LlamaBackendMemoryPressureTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaBackendMemoryPressureTests.swift
@@ -168,7 +168,7 @@ final class MemoryPressureCallbackAPITests: XCTestCase {
 
 #if Llama
 @testable import BaseChatBackends
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 
 // MARK: - Hardware-gated tests
 

--- a/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaBackendTests.swift
@@ -3,7 +3,7 @@ import XCTest
 import BaseChatRuntime
 import BaseChatPersistenceSwiftData
 @testable import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Tests for LlamaBackend state, capabilities, and error handling.

--- a/Tests/BaseChatBackendsTests/LlamaEmbeddingBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaEmbeddingBackendTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 @testable import BaseChatInference
 @testable import BaseChatBackends
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 
 /// Locates a GGUF embedding model on disk for `LlamaEmbeddingBackend` tests.
 ///

--- a/Tests/BaseChatBackendsTests/LlamaGrammarSamplerTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaGrammarSamplerTests.swift
@@ -1,7 +1,7 @@
 #if Llama
 import XCTest
 @testable import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Tests for GBNF grammar-constrained sampling in LlamaBackend/LlamaGenerationDriver.

--- a/Tests/BaseChatBackendsTests/LlamaKVPersistenceTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaKVPersistenceTests.swift
@@ -1,7 +1,7 @@
 #if Llama
 import XCTest
 @testable import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Tests for KV-cache prefix reuse across consecutive turns in `LlamaBackend`.

--- a/Tests/BaseChatBackendsTests/LlamaKVReuseTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaKVReuseTests.swift
@@ -1,7 +1,7 @@
 #if Llama
 import XCTest
 @testable import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Perf-audit α-1 ground-truth: real-Llama KV-cache-reuse coverage.

--- a/Tests/BaseChatBackendsTests/LlamaModernSamplerIntegrationTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaModernSamplerIntegrationTests.swift
@@ -1,7 +1,7 @@
 #if Llama
 import XCTest
 @testable import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Integration determinism coverage for the XTC and Mirostat v2 sampler additions.

--- a/Tests/BaseChatBackendsTests/LlamaSeedDeterminismTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaSeedDeterminismTests.swift
@@ -1,7 +1,7 @@
 #if Llama
 import XCTest
 @testable import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Verifies that ``GenerationConfig/seed`` makes ``LlamaBackend`` token streams

--- a/Tests/BaseChatBackendsTests/LlamaThinkingMarkerAutoDiscoveryTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaThinkingMarkerAutoDiscoveryTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 @testable import BaseChatInference
 @testable import BaseChatBackends
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 
 /// Auto-discovery tests for `LlamaBackend`'s thinking-marker plumbing.
 ///

--- a/Tests/BaseChatBackendsTests/LlamaTokenizationTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaTokenizationTests.swift
@@ -1,7 +1,7 @@
 #if Llama
 import XCTest
 @testable import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Regression tests for the `parse_special: true` fix in `LlamaTokenization.tokenize`

--- a/Tests/BaseChatBackendsTests/LlamaTopKConsumptionTests.swift
+++ b/Tests/BaseChatBackendsTests/LlamaTopKConsumptionTests.swift
@@ -1,7 +1,7 @@
 #if Llama
 import XCTest
 @testable import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Regression coverage for the `top_k` consumption fix.

--- a/Tests/BaseChatBackendsTests/MLXBackendGenerationTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXBackendGenerationTests.swift
@@ -4,7 +4,7 @@ import MLXLMCommon
 import BaseChatRuntime
 import BaseChatPersistenceSwiftData
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 // Conform MockMLXModelContainer to the internal protocol in this test target,

--- a/Tests/BaseChatBackendsTests/MLXBackendTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXBackendTests.swift
@@ -3,7 +3,7 @@ import XCTest
 import BaseChatRuntime
 import BaseChatPersistenceSwiftData
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Tests for MLXBackend state, capabilities, and lifecycle.

--- a/Tests/BaseChatE2ETests/Conformance/LlamaBackendE2EConformanceTests.swift
+++ b/Tests/BaseChatE2ETests/Conformance/LlamaBackendE2EConformanceTests.swift
@@ -1,7 +1,7 @@
 #if Llama
 import XCTest
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Real-hardware conformance suite for ``LlamaBackend``.

--- a/Tests/BaseChatE2ETests/Conformance/LlamaEmbeddingBackendE2EConformanceTests.swift
+++ b/Tests/BaseChatE2ETests/Conformance/LlamaEmbeddingBackendE2EConformanceTests.swift
@@ -1,7 +1,7 @@
 #if Llama
 import XCTest
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Real-hardware conformance suite for ``LlamaEmbeddingBackend`` against

--- a/Tests/BaseChatE2ETests/Conformance/MLXBackendE2EConformanceTests.swift
+++ b/Tests/BaseChatE2ETests/Conformance/MLXBackendE2EConformanceTests.swift
@@ -1,7 +1,7 @@
 #if MLX
 import XCTest
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Real-hardware conformance suite for ``MLXBackend``.

--- a/Tests/BaseChatE2ETests/DemoScenarioOllamaE2ETests.swift
+++ b/Tests/BaseChatE2ETests/DemoScenarioOllamaE2ETests.swift
@@ -2,7 +2,7 @@
 import XCTest
 import BaseChatInference
 import BaseChatTools
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// True end-to-end coverage of the four P1 demo scenarios against a real

--- a/Tests/BaseChatE2ETests/LlamaBackendLoadSerializationCharacterizationE2ETests.swift
+++ b/Tests/BaseChatE2ETests/LlamaBackendLoadSerializationCharacterizationE2ETests.swift
@@ -2,7 +2,7 @@
 import XCTest
 @testable import BaseChatBackends
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 
 /// Characterization (not specification) tests for `LlamaBackend`'s load-serialization
 /// machinery. Pins the current observable behavior of:

--- a/Tests/BaseChatE2ETests/LlamaE2ETests.swift
+++ b/Tests/BaseChatE2ETests/LlamaE2ETests.swift
@@ -3,7 +3,7 @@ import XCTest
 import BaseChatRuntime
 import BaseChatPersistenceSwiftData
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 import BaseChatBackends
 
 /// True end-to-end tests hitting a real local GGUF model through `LlamaBackend`.

--- a/Tests/BaseChatE2ETests/LlamaThinkingE2ETests.swift
+++ b/Tests/BaseChatE2ETests/LlamaThinkingE2ETests.swift
@@ -3,7 +3,7 @@ import XCTest
 import BaseChatRuntime
 import BaseChatPersistenceSwiftData
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Hardware-gated end-to-end test for `LlamaBackend` driving a real thinking-capable

--- a/Tests/BaseChatE2ETests/OllamaE2ETests.swift
+++ b/Tests/BaseChatE2ETests/OllamaE2ETests.swift
@@ -3,7 +3,7 @@ import XCTest
 import BaseChatRuntime
 import BaseChatPersistenceSwiftData
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// True end-to-end tests hitting a real local Ollama server.

--- a/Tests/BaseChatE2ETests/OllamaThinkingE2ETests.swift
+++ b/Tests/BaseChatE2ETests/OllamaThinkingE2ETests.swift
@@ -3,7 +3,7 @@ import XCTest
 import BaseChatRuntime
 import BaseChatPersistenceSwiftData
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// End-to-end tests for thinking/reasoning model behaviour on a real Ollama server.

--- a/Tests/BaseChatE2ETests/OllamaToolCallingE2ETests.swift
+++ b/Tests/BaseChatE2ETests/OllamaToolCallingE2ETests.swift
@@ -1,7 +1,7 @@
 #if Ollama
 import XCTest
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// End-to-end tool-calling test against a real local Ollama server.

--- a/Tests/BaseChatE2ETests/QualityBaselineTests.swift
+++ b/Tests/BaseChatE2ETests/QualityBaselineTests.swift
@@ -1,7 +1,7 @@
 #if Llama
 import XCTest
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Quality baseline: compares deterministic token-id output against stored fixtures.

--- a/Tests/BaseChatE2ETests/ThroughputBaselineTests.swift
+++ b/Tests/BaseChatE2ETests/ThroughputBaselineTests.swift
@@ -1,7 +1,7 @@
 #if Llama
 import XCTest
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Throughput baseline: measures real-model token generation rate.

--- a/Tests/BaseChatFuzzTests/LlamaFuzzFactoryTests.swift
+++ b/Tests/BaseChatFuzzTests/LlamaFuzzFactoryTests.swift
@@ -3,7 +3,7 @@
 import XCTest
 import BaseChatFuzz
 import BaseChatFuzzBackends
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 
 final class LlamaFuzzFactoryTests: XCTestCase {
 

--- a/Tests/BaseChatFuzzTests/MLXFuzzTests.swift
+++ b/Tests/BaseChatFuzzTests/MLXFuzzTests.swift
@@ -3,7 +3,7 @@
 import XCTest
 import BaseChatFuzz
 import BaseChatFuzzBackends
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 
 final class MLXFuzzTests: XCTestCase {
 

--- a/Tests/BaseChatInferenceTests/GenerationQueueStructuredHistoryTests.swift
+++ b/Tests/BaseChatInferenceTests/GenerationQueueStructuredHistoryTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 
 /// Tests for #482: ``GenerationQueue`` must thread
 /// ``StructuredMessage`` (carrying ``MessagePart`` content including

--- a/Tests/BaseChatInferenceTests/RetryPolicyTests.swift
+++ b/Tests/BaseChatInferenceTests/RetryPolicyTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatInference
 
 final class RetryPolicyTests: XCTestCase {

--- a/Tests/BaseChatMLXIntegrationTests/Gemma4MoESmokeTests.swift
+++ b/Tests/BaseChatMLXIntegrationTests/Gemma4MoESmokeTests.swift
@@ -1,7 +1,7 @@
 #if MLX
 import XCTest
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Real-inference smoke test for `mlx-community/gemma-4-26b-a4b-it-4bit`,

--- a/Tests/BaseChatMLXIntegrationTests/MLXKVPersistenceIntegrationTests.swift
+++ b/Tests/BaseChatMLXIntegrationTests/MLXKVPersistenceIntegrationTests.swift
@@ -3,7 +3,7 @@ import XCTest
 import BaseChatRuntime
 import BaseChatPersistenceSwiftData
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Real-model validation for MLX KV-cache prefix reuse.

--- a/Tests/BaseChatMLXIntegrationTests/MLXKVReuseIntegrationTests.swift
+++ b/Tests/BaseChatMLXIntegrationTests/MLXKVReuseIntegrationTests.swift
@@ -1,7 +1,7 @@
 #if MLX
 import XCTest
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Real-MLX measurement of KV-cache prefix reuse across two consecutive turns.

--- a/Tests/BaseChatMLXIntegrationTests/MLXModelE2ETests.swift
+++ b/Tests/BaseChatMLXIntegrationTests/MLXModelE2ETests.swift
@@ -3,7 +3,7 @@ import XCTest
 import BaseChatRuntime
 import BaseChatPersistenceSwiftData
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// True end-to-end tests using a real MLX model on Apple Silicon.

--- a/Tests/BaseChatMLXIntegrationTests/MLXVLMGateExperimentTests.swift
+++ b/Tests/BaseChatMLXIntegrationTests/MLXVLMGateExperimentTests.swift
@@ -1,7 +1,7 @@
 #if MLX
 import XCTest
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatBackends
 
 /// Confirms the VLM-side KV-reuse gate is currently on.

--- a/Tests/BaseChatPersistenceSwiftDataTests/ImageAttachmentInflationTests.swift
+++ b/Tests/BaseChatPersistenceSwiftDataTests/ImageAttachmentInflationTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import SwiftData
 @testable import BaseChatPersistenceSwiftData
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 
 /// Perf-audit ground-truth: confirms that persisting `MessagePart.image(data:)`
 /// through the SwiftData JSON column inflates on-disk bytes by ~1.33×, the

--- a/Tests/BaseChatPersistenceSwiftDataTests/MessagePartTests.swift
+++ b/Tests/BaseChatPersistenceSwiftDataTests/MessagePartTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import SwiftData
 @testable import BaseChatPersistenceSwiftData
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 
 final class MessagePartTests: XCTestCase {
 

--- a/Tests/BaseChatPersistenceSwiftDataTests/VisionSessionResidentMemoryTests.swift
+++ b/Tests/BaseChatPersistenceSwiftDataTests/VisionSessionResidentMemoryTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import SwiftData
 @testable import BaseChatPersistenceSwiftData
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 
 /// Perf-audit ground-truth: measures the resident-memory delta between a
 /// vision session (50 messages, every other one carrying an image attachment)

--- a/Tests/BaseChatRuntimeTests/BranchAttachmentCopyCostTests.swift
+++ b/Tests/BaseChatRuntimeTests/BranchAttachmentCopyCostTests.swift
@@ -2,7 +2,7 @@
 import Foundation
 @testable import BaseChatRuntime
 @testable import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 
 /// Perf-audit ground-truth: cost of `ConversationRuntime.branch(...)` when the
 /// source session carries image attachments. The audit estimated branch on a

--- a/Tests/BaseChatRuntimeTests/ConversationRuntimeScenarioTests.swift
+++ b/Tests/BaseChatRuntimeTests/ConversationRuntimeScenarioTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import BaseChatRuntime
 import BaseChatPersistenceSwiftData
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 
 /// Demonstrates the ``ConversationRuntimeScenario`` harness against
 /// `MockInferenceBackend`. Exists primarily to lock the harness contract:

--- a/Tests/BaseChatTestSupportTests/WithTimeoutTests.swift
+++ b/Tests/BaseChatTestSupportTests/WithTimeoutTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 
 /// Tests for the ``withTimeout`` helper in `BaseChatTestSupport`.
 ///

--- a/Tests/BaseChatUITests/ChatInputBarLogicTests.swift
+++ b/Tests/BaseChatUITests/ChatInputBarLogicTests.swift
@@ -3,7 +3,7 @@
 import BaseChatRuntime
 import BaseChatPersistenceSwiftData
 @testable import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 
 /// Tests for the logic that drives ChatInputBar's enabled/disabled states.
 ///

--- a/Tests/BaseChatUITests/ChatViewModelIngestPendingPayloadTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelIngestPendingPayloadTests.swift
@@ -4,7 +4,7 @@ import SwiftData
 import BaseChatRuntime
 import BaseChatPersistenceSwiftData
 @testable import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 
 /// Integration tests for ``ChatViewModel/ingestPendingPayload(_:intent:)``.
 ///

--- a/Tests/BaseChatUITests/ChatViewModelIngestTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelIngestTests.swift
@@ -4,7 +4,7 @@ import SwiftData
 import BaseChatRuntime
 import BaseChatPersistenceSwiftData
 @testable import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 
 /// Integration tests for ``ChatViewModel/ingest(_:)``.
 ///

--- a/Tests/BaseChatUITests/ContextEstimateCostTests.swift
+++ b/Tests/BaseChatUITests/ContextEstimateCostTests.swift
@@ -4,7 +4,7 @@ import SwiftData
 import BaseChatRuntime
 import BaseChatPersistenceSwiftData
 @testable import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 
 /// Perf-audit β-1: ChatViewModel hot-path measurements for `updateContextEstimate`.
 ///

--- a/Tests/BaseChatUITests/TokenCountCacheInvalidationTests.swift
+++ b/Tests/BaseChatUITests/TokenCountCacheInvalidationTests.swift
@@ -4,7 +4,7 @@ import SwiftData
 import BaseChatRuntime
 import BaseChatPersistenceSwiftData
 @testable import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 
 /// Perf-audit β-1: contract tests for the `tokenCountCache` invalidation path.
 ///

--- a/Tests/BaseChatUITests/UIToolApprovalGateTests.swift
+++ b/Tests/BaseChatUITests/UIToolApprovalGateTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import BaseChatInference
-import BaseChatTestSupport
+@testable import BaseChatTestSupport
 @testable import BaseChatUI
 
 /// Behavioural tests for ``UIToolApprovalGate``. These exercise the policy


### PR DESCRIPTION
## Summary
- Remove `BaseChatTestSupport` from the importable `BaseChatFuzzBackends` target and replace its model discovery/load-plan uses with fuzz-local helpers.
- Tighten test-only helper surface in `BaseChatTestSupport` by making the candidate fixtures/hardware/scenario/timeout types internal.
- Switch in-repo tests that consume those internal test helpers to `@testable import BaseChatTestSupport`.

## Validation
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all scripts/test.sh --filter BaseChatFuzzTests --filter BaseChatTestSupportTests --disable-default-traits`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all swift build --target BaseChatFuzzBackends --traits Fuzz,MLX,Llama,Ollama --disable-default-traits`
- `rg -n "^import BaseChatTestSupport" Sources/BaseChatFuzzBackends -g "*.swift"` → no matches

Closes #1116
Closes #1117