### PR TITLE
docs: link Swift 6 concurrency gotchas

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,11 @@ four blessed configurations and what each one guarantees.
 
 For repo-developer build-mode workflow (Xcode trait limitations, common mistakes,
 the `#warning` stub mechanism), see [CLAUDE.md](CLAUDE.md).
+Swift 6 concurrency pitfalls that can compile while racing or deadlocking are
+covered in
+[CLAUDE.md § Swift 6 concurrency gotchas](CLAUDE.md#swift-6-concurrency-gotchas);
+review that section before adding actor-isolated state, async helper closures,
+mutable `Sendable` wrappers, streams, detached tasks, or async cleanup.
 
 ## Architecture invariants
 


### PR DESCRIPTION
## Summary
- Add a contributor-facing pointer from CONTRIBUTING.md to the canonical Swift 6 concurrency gotchas section in CLAUDE.md.
- Confirm the canonical section covers the six issue patterns, including actor annotations, mutable Sendable captures, @preconcurrency limits, AsyncStream sendability, Task.detached risks, and deinit cleanup deadlocks.

## Validation
- Documentation review only; no build required for markdown-only link update.
- Verified CLAUDE.md contains all six Swift 6 concurrency gotchas and CONTRIBUTING.md links to the section.

Closes #1056