### PR TITLE
fix: scope default model storage per app

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,15 @@ endpoint and diagnostics wiring.
 | Ollama | `OpenAIBackend` | Local API | localhost:11434 | Vision-capable OpenAI-compatible models |
 | LM Studio | `OpenAIBackend` | Local API | localhost:1234 | Vision-capable OpenAI-compatible models |
 
+### Model storage scoping
+
+`ModelStorageService()` stores and discovers local models under
+`<Application Support>/<BaseChatConfiguration.shared.bundleIdentifier>/<modelsDirectoryName>`
+by default. This keeps multiple BaseChatKit-based apps on the same machine from
+seeing each other's downloaded models. Hosts that intentionally share a model
+pool can opt in by passing an explicit directory, for example
+`ModelStorageService(baseDirectory: sharedModelsDirectory)`.
+
 ## Key Types
 
 ### View Models

--- a/Tests/BaseChatInferenceTests/ModelStorageServiceTests.swift
+++ b/Tests/BaseChatInferenceTests/ModelStorageServiceTests.swift
@@ -472,15 +472,40 @@ final class ModelStorageServiceTests: XCTestCase {
 
     // MARK: - Per-app scoping
 
-    func test_modelsDirectory_differsByBundleIdentifier() {
-        let serviceA = ModelStorageService(bundleIdentifier: "com.test.app-a")
-        let serviceB = ModelStorageService(bundleIdentifier: "com.test.app-b")
+    func test_discoverModels_scopesDefaultDirectoriesByBundleIdentifier() throws {
+        let suffix = UUID().uuidString
+        let bundleA = "com.basechatkit.tests.model-storage-a.\(suffix)"
+        let bundleB = "com.basechatkit.tests.model-storage-b.\(suffix)"
+        let serviceA = ModelStorageService(bundleIdentifier: bundleA)
+        let serviceB = ModelStorageService(bundleIdentifier: bundleB)
 
         XCTAssertNotEqual(
             serviceA.modelsDirectory.path,
             serviceB.modelsDirectory.path,
             "Different bundle identifiers must produce different models directories"
         )
+
+        defer {
+            try? FileManager.default.removeItem(at: serviceA.modelsDirectory.deletingLastPathComponent())
+            try? FileManager.default.removeItem(at: serviceB.modelsDirectory.deletingLastPathComponent())
+        }
+
+        try serviceA.ensureModelsDirectory()
+        try serviceB.ensureModelsDirectory()
+
+        let modelAName = "only-app-a-\(suffix).gguf"
+        let modelBName = "only-app-b-\(suffix).gguf"
+        let ggufData = Data([0x47, 0x47, 0x55, 0x46])
+        try ggufData.write(to: serviceA.modelsDirectory.appendingPathComponent(modelAName))
+        try ggufData.write(to: serviceB.modelsDirectory.appendingPathComponent(modelBName))
+
+        let modelsA = serviceA.discoverModels().map(\.fileName)
+        let modelsB = serviceB.discoverModels().map(\.fileName)
+
+        XCTAssertTrue(modelsA.contains(modelAName), "App A should discover its own model")
+        XCTAssertFalse(modelsA.contains(modelBName), "App A must not discover App B's model")
+        XCTAssertTrue(modelsB.contains(modelBName), "App B should discover its own model")
+        XCTAssertFalse(modelsB.contains(modelAName), "App B must not discover App A's model")
     }
 
     func test_modelsDirectory_containsBundleIdentifier() {


### PR DESCRIPTION
## Summary
- Strengthen ModelStorageService coverage so two bundle-scoped default services discover only their own local GGUF files
- Document the default per-app model storage path and explicit baseDirectory opt-in for shared model pools

## Validation
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all scripts/test.sh --filter BaseChatInferenceTests --filter BaseChatUIModelManagementTests --disable-default-traits --skip-update
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all swift test --filter 'ModelStorageServiceTests.test_discoverModels_scopesDefaultDirectoriesByBundleIdentifier' --disable-default-traits

Closes #1108
