### PR TITLE
feat: smooth BYO UI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,8 +315,7 @@ import BaseChatVoice
 
 ChatView(
     showModelManagement: $isModelManagementPresented,
-    composerAccessory: { VoiceComposerAccessory(controller: voice) },
-    apiConfiguration: { APIConfigurationView() }
+    composerAccessory: { VoiceComposerAccessory(controller: voice) }
 )
 ```
 
@@ -357,6 +356,115 @@ The full list of SwiftPM traits, derived from `Package.swift`. Defaults
 
 `Package.swift` is the authoritative source — add `--list-traits` to a
 `swift package` invocation if you suspect this table has drifted.
+
+### 2.5 Bring your own UI
+
+If you want host-owned SwiftUI views instead of `ChatView`, depend only on
+`BaseChatInference` plus the backends you want. This keeps SwiftData,
+`BaseChatRuntime`, `BaseChatUI`, and model-management UI out of your app graph.
+
+```swift
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "MyChatApp",
+    platforms: [.iOS(.v18), .macOS(.v15)],
+    dependencies: [
+        .package(
+            url: "https://github.com/roryford/BaseChatKit.git",
+            from: "1.0.0",
+            traits: [
+                .trait(name: "MLX"),
+                .trait(name: "Llama"),
+                // Add CloudSaaS or Ollama only if your UI exposes those providers.
+            ]
+        )
+    ],
+    targets: [
+        .target(
+            name: "MyChatApp",
+            dependencies: [
+                .product(name: "BaseChatInference", package: "BaseChatKit"),
+                .product(name: "BaseChatBackends", package: "BaseChatKit"),
+            ]
+        )
+    ]
+)
+```
+
+Own the observable state in your app, register the compiled backends once, load a
+`ModelInfo`, and stream `GenerationEvent.token` values into your transcript:
+
+```swift
+import Observation
+import SwiftUI
+import BaseChatInference
+import BaseChatBackends
+
+@MainActor
+@Observable
+final class HostChatStore {
+    var transcript: [(role: String, content: String)] = []
+    var draft = ""
+    var errorMessage: String?
+
+    private let inference = InferenceService()
+
+    init() {
+        DefaultBackends.register(with: inference)
+    }
+
+    func loadFoundationIfAvailable() async {
+        guard #available(iOS 26, macOS 26, *), FoundationBackend.isAvailable else { return }
+
+        do {
+            try await inference.loadModel(from: .builtInFoundation, plan: .cloud())
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func send() async {
+        let prompt = draft
+        draft = ""
+        transcript.append(("user", prompt))
+        transcript.append(("assistant", ""))
+
+        do {
+            let stream = try inference.generate(messages: transcript)
+            for try await event in stream {
+                if case .token(let text) = event {
+                    transcript[transcript.count - 1].content += text
+                }
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+struct HostChatView: View {
+    @State private var store = HostChatStore()
+
+    var body: some View {
+        VStack {
+            List(store.transcript, id: \.content) { message in
+                Text("\(message.role): \(message.content)")
+            }
+            TextField("Message", text: $store.draft)
+                .onSubmit { Task { await store.send() } }
+        }
+        .task { await store.loadFoundationIfAvailable() }
+    }
+}
+```
+
+BaseChatKit's view models and services use Swift Observation (`@Observable`),
+not Combine `ObservableObject`. In SwiftUI, store them in `@State` and inject
+them with `.environment(value)`, then read them with `@Environment(Type.self)`.
+Use `ObservableObject` only in a host-owned adapter when you must bridge to
+legacy Combine-based views.
 
 ### 3. Create the runtime at app startup
 
@@ -581,7 +689,7 @@ endpoint and diagnostics wiring.
 |------|---------|--------|--------|-------------|
 | GGUF | `LlamaBackend` (llama.cpp) | Single `.gguf` file | HuggingFace, local | Not yet; tracked in [#416](https://github.com/roryford/BaseChatKit/issues/416) |
 | MLX | `MLXBackend` (mlx-swift) | Directory with `config.json` + `.safetensors` | HuggingFace, local | Vision models only |
-| Foundation | `FoundationBackend` | Built-in (no download) | Apple Intelligence | No public FoundationModels image-input API yet |
+| Foundation | `FoundationBackend` | `ModelInfo.builtInFoundation` (built-in, no download) | Apple Intelligence | No public FoundationModels image-input API yet |
 | OpenAI | `OpenAIBackend` | Cloud API | api.openai.com | Vision-capable models |
 | Claude | `ClaudeBackend` | Cloud API | api.anthropic.com | Vision-capable models |
 | Ollama | `OpenAIBackend` | Local API | localhost:11434 | Vision-capable OpenAI-compatible models |

--- a/Sources/BaseChatUI/BaseChatUI.docc/Articles/BuildingAChatUI.md
+++ b/Sources/BaseChatUI/BaseChatUI.docc/Articles/BuildingAChatUI.md
@@ -82,10 +82,7 @@ struct RootView: View {
         NavigationSplitView {
             SessionListView()
         } detail: {
-            ChatView(
-                showModelManagement: .constant(false),
-                apiConfiguration: { EmptyView() }
-            )
+            ChatView(showModelManagement: .constant(false))
         }
         .onChange(of: sessionVM.activeSession) { _, newSession in
             guard let newSession, chatVM.activeSession?.id != newSession.id else { return }
@@ -248,7 +245,7 @@ struct RootView: View {
 }
 ```
 
-Hosts that don't use `BaseChatUIModelManagement` (e.g. cloud-only builds or apps with their own settings UI) pass `apiConfiguration: { EmptyView() }` to satisfy the parameter.
+Hosts that don't use `BaseChatUIModelManagement` (e.g. cloud-only builds or apps with their own settings UI) can use `ChatView(showModelManagement:)`; the `APIConfig == EmptyView` convenience initializer supplies the empty API sheet for them.
 
 The closure is invoked at sheet/popover presentation time, not at `ChatView` init, so any `@Environment` or `@Bindable` lookups inside `APIConfigurationView` resolve against the live view tree rather than the value captured at construction.
 

--- a/Sources/BaseChatUI/BaseChatUI.docc/BaseChatUI.md
+++ b/Sources/BaseChatUI/BaseChatUI.docc/BaseChatUI.md
@@ -65,10 +65,7 @@ struct ContentView: View {
     @Environment(ChatViewModel.self) var chatVM
 
     var body: some View {
-        ChatView(
-            showModelManagement: .constant(false),
-            apiConfiguration: { EmptyView() }
-        )
+        ChatView(showModelManagement: .constant(false))
     }
 }
 ```

--- a/Sources/BaseChatUI/Views/Chat/ChatView.swift
+++ b/Sources/BaseChatUI/Views/Chat/ChatView.swift
@@ -189,6 +189,126 @@ public struct ChatView<APIConfig: View>: View {
         self.contextMenuItemsBuilder = { message in AnyView(contextMenuItems(message)) }
     }
 
+    /// Creates a ``ChatView`` without an API-configuration surface.
+    ///
+    /// Use this overload when the host app does not ship
+    /// `BaseChatUIModelManagement` or provides API settings elsewhere.
+    public init(
+        showModelManagement: Binding<Bool>,
+        linkPreviewProvider: LinkPreviewProvider? = nil
+    ) where APIConfig == EmptyView {
+        self.init(
+            showModelManagement: showModelManagement,
+            linkPreviewProvider: linkPreviewProvider,
+            apiConfiguration: { EmptyView() }
+        )
+    }
+
+    public init<ComposerAccessory: View>(
+        showModelManagement: Binding<Bool>,
+        linkPreviewProvider: LinkPreviewProvider? = nil,
+        @ViewBuilder composerAccessory: @escaping () -> ComposerAccessory
+    ) where APIConfig == EmptyView {
+        self.init(
+            showModelManagement: showModelManagement,
+            linkPreviewProvider: linkPreviewProvider,
+            composerAccessory: composerAccessory,
+            apiConfiguration: { EmptyView() }
+        )
+    }
+
+    /// Creates a ``ChatView`` with a custom empty state and no
+    /// API-configuration surface.
+    public init<EmptyContent: View>(
+        showModelManagement: Binding<Bool>,
+        linkPreviewProvider: LinkPreviewProvider? = nil,
+        @ViewBuilder emptyState: () -> EmptyContent
+    ) where APIConfig == EmptyView {
+        self.init(
+            showModelManagement: showModelManagement,
+            linkPreviewProvider: linkPreviewProvider,
+            emptyState: emptyState,
+            apiConfiguration: { EmptyView() }
+        )
+    }
+
+    public init<EmptyContent: View, ComposerAccessory: View>(
+        showModelManagement: Binding<Bool>,
+        linkPreviewProvider: LinkPreviewProvider? = nil,
+        @ViewBuilder emptyState: () -> EmptyContent,
+        @ViewBuilder composerAccessory: @escaping () -> ComposerAccessory
+    ) where APIConfig == EmptyView {
+        self.init(
+            showModelManagement: showModelManagement,
+            linkPreviewProvider: linkPreviewProvider,
+            emptyState: emptyState,
+            composerAccessory: composerAccessory,
+            apiConfiguration: { EmptyView() }
+        )
+    }
+
+    /// Creates a ``ChatView`` with host-supplied context-menu items and no
+    /// API-configuration surface.
+    public init<ExtraItems: View>(
+        showModelManagement: Binding<Bool>,
+        linkPreviewProvider: LinkPreviewProvider? = nil,
+        @ViewBuilder contextMenuItems: @escaping (ChatMessageRecord) -> ExtraItems
+    ) where APIConfig == EmptyView {
+        self.init(
+            showModelManagement: showModelManagement,
+            linkPreviewProvider: linkPreviewProvider,
+            contextMenuItems: contextMenuItems,
+            apiConfiguration: { EmptyView() }
+        )
+    }
+
+    public init<ExtraItems: View, ComposerAccessory: View>(
+        showModelManagement: Binding<Bool>,
+        linkPreviewProvider: LinkPreviewProvider? = nil,
+        @ViewBuilder contextMenuItems: @escaping (ChatMessageRecord) -> ExtraItems,
+        @ViewBuilder composerAccessory: @escaping () -> ComposerAccessory
+    ) where APIConfig == EmptyView {
+        self.init(
+            showModelManagement: showModelManagement,
+            linkPreviewProvider: linkPreviewProvider,
+            contextMenuItems: contextMenuItems,
+            composerAccessory: composerAccessory,
+            apiConfiguration: { EmptyView() }
+        )
+    }
+
+    public init<EmptyContent: View, ExtraItems: View>(
+        showModelManagement: Binding<Bool>,
+        linkPreviewProvider: LinkPreviewProvider? = nil,
+        @ViewBuilder emptyState: () -> EmptyContent,
+        @ViewBuilder contextMenuItems: @escaping (ChatMessageRecord) -> ExtraItems
+    ) where APIConfig == EmptyView {
+        self.init(
+            showModelManagement: showModelManagement,
+            linkPreviewProvider: linkPreviewProvider,
+            emptyState: emptyState,
+            contextMenuItems: contextMenuItems,
+            apiConfiguration: { EmptyView() }
+        )
+    }
+
+    public init<EmptyContent: View, ExtraItems: View, ComposerAccessory: View>(
+        showModelManagement: Binding<Bool>,
+        linkPreviewProvider: LinkPreviewProvider? = nil,
+        @ViewBuilder emptyState: () -> EmptyContent,
+        @ViewBuilder contextMenuItems: @escaping (ChatMessageRecord) -> ExtraItems,
+        @ViewBuilder composerAccessory: @escaping () -> ComposerAccessory
+    ) where APIConfig == EmptyView {
+        self.init(
+            showModelManagement: showModelManagement,
+            linkPreviewProvider: linkPreviewProvider,
+            emptyState: emptyState,
+            contextMenuItems: contextMenuItems,
+            composerAccessory: composerAccessory,
+            apiConfiguration: { EmptyView() }
+        )
+    }
+
     // MARK: - Body
 
     public var body: some View {

--- a/Tests/BaseChatUITests/ChatComposerAccessoryMigrationGuardTests.swift
+++ b/Tests/BaseChatUITests/ChatComposerAccessoryMigrationGuardTests.swift
@@ -12,12 +12,20 @@ import SwiftUI
 final class ChatComposerAccessoryMigrationGuardTests: XCTestCase {
 
     @MainActor
+    func test_chatView_isInstantiableWithoutAPIConfigurationView() {
+        let view: AnyView = AnyView(
+            ChatView(showModelManagement: .constant(false))
+        )
+
+        XCTAssertNotNil(view)
+    }
+
+    @MainActor
     func test_chatView_isInstantiableWithComposerAccessoryUnderDisabledTraits() {
         let view: AnyView = AnyView(
             ChatView(
                 showModelManagement: .constant(false),
-                composerAccessory: { Text("Voice spike") },
-                apiConfiguration: { EmptyView() }
+                composerAccessory: { Text("Voice spike") }
             )
         )
 


### PR DESCRIPTION
## Summary
- Add `ChatView` convenience initializers for `APIConfig == EmptyView` so apps that do not ship model-management UI can omit `apiConfiguration`.
- Document the BYO-UI path using `BaseChatInference` + `BaseChatBackends`, including a copy-paste `Package.swift`, minimal host-owned SwiftUI wiring, and `@Observable` guidance.
- Document `ModelInfo.builtInFoundation` in the Supported Model Types table.

## Validation
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all scripts/test.sh --filter BaseChatUITests --filter BaseChatInferenceTests --disable-default-traits --skip-update`

Closes #1105