### PR TITLE
fix(test): deflake ConversationRuntime back-to-back token-usage assertion

### DIFF
--- a/Tests/BaseChatRuntimeTests/ConversationRuntimeTests.swift
+++ b/Tests/BaseChatRuntimeTests/ConversationRuntimeTests.swift
@@ -822,9 +822,9 @@ final class ConversationRuntimeTests: XCTestCase {
         _ = try await runtime.send(SendInput(sessionID: sessionID, userText: "second"))
 
         let events = try await waitForEvents(from: drain)
-        let usageEvents = events.compactMap { event -> (prompt: Int, completion: Int)? in
-            if case let .tokenUsageRecorded(_, promptTokens, completionTokens) = event {
-                return (promptTokens, completionTokens)
+        let usageEvents = events.compactMap { event -> (messageID: UUID, prompt: Int, completion: Int)? in
+            if case let .tokenUsageRecorded(messageID, promptTokens, completionTokens) = event {
+                return (messageID, promptTokens, completionTokens)
             }
             return nil
         }
@@ -834,9 +834,14 @@ final class ConversationRuntimeTests: XCTestCase {
         XCTAssertEqual(usageEvents.map { $0.completion }, [1, 2],
                        "Each turn emits its own completion-token usage")
 
-        let assistants = store.messages.values
-            .filter { $0.role == .assistant }
-            .sorted { $0.timestamp < $1.timestamp }
+        // Look assistants up by the per-turn `tokenUsageRecorded` message id
+        // rather than sorting by `timestamp`. Two back-to-back sends on a fast
+        // runner can produce assistant records with identical `Date()` values,
+        // making a timestamp sort non-deterministic. Event order, by contrast,
+        // is the order the runtime emits — that's the contract under test.
+        let assistants = usageEvents.compactMap { store.messages[$0.messageID] }
+        XCTAssertEqual(assistants.count, 2, "Both assistant turns are persisted")
+        XCTAssertTrue(assistants.allSatisfy { $0.role == .assistant })
         XCTAssertEqual(assistants.map(\.content), ["one", "two"])
         XCTAssertEqual(assistants.compactMap(\.promptTokens), [11, 22],
                        "Persisted assistant usage is pinned per turn, not overwritten by the next send")


### PR DESCRIPTION
## Summary
- `test_send_tokenUsageEventPinsPerStreamUsageAcrossBackToBackSends` was sorting persisted assistants by `timestamp`, but two back-to-back `runtime.send` calls land within the same microsecond on a fast runner. The fallback iteration order through `RuntimeMessageStore.messages` (a `[UUID: ChatMessageRecord]`) is non-deterministic, failing ~40% of local runs and surfacing on PR #1121's CI.
- Surfaced the per-turn order via the `tokenUsageRecorded` events instead — they carry `messageID` and arrive in deterministic emit order. The contract under test (per-turn usage isn't overwritten by the next send) is unchanged.
- This is a pure test fix; no production code changed. Pre-existing flake on `origin/main`, not caused by #1121.

## Test plan
- [x] Targeted run 15× locally on the rebased fix branch — 15 passed, 0 failed
- [x] Same test 5× on `origin/main` (no fix) — 2 failures reproduced
- [x] Pre-push CI shape (two `scripts/test.sh` invocations, `--disable-default-traits --skip-update`) — 2767 + 83 passed, 0 failed
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)