### PR TITLE
chore: bump-minor-pre-major for feat: in pre-1.0 releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": false,
   "packages": {
     ".": {}
   }


### PR DESCRIPTION
## Summary

Flip `bump-patch-for-minor-pre-major` from `true` to `false` in `release-please-config.json`. Pre-1.0, `feat:` commits will now bump **MINOR** (e.g. 0.18.x → 0.19.0) instead of patch — matching how recent release PRs have been hand-corrected.

Config-only; no code change.

## Notes

Re-do of #1131, which got created with the wrong head branch (the parent shell's cwd was on a stale feature branch when `gh pr create` ran), producing a no-op squash merge.