### PR TITLE
docs: README install pins, AGENTS.md, .cursorrules, README-snippet CI gate

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,20 @@
+This project uses BaseChatKit (BCK), a Swift framework for building chat
+interfaces backed by local and cloud LLMs on Apple platforms.
+
+Read AGENTS.md at the repo root for the canonical API surface, common LLM
+hallucinations to avoid, and recipe code that compiles against the current
+release. CLAUDE.md is for contributors; AGENTS.md is for consumers.
+
+Key facts when generating code that uses BCK:
+
+- The send method is `vm.sendMessage(_:)`, not `.send(_:)`.
+- Backend identity is the typed `BackendName.foundation`, not a raw string.
+- The `@ToolSchema` macro requires `--traits Macros` (default-off). Without
+  the trait, declare `JSONSchemaValue` by hand.
+- There is no `BaseChatKit` umbrella module yet — import the product you
+  need (e.g. `BaseChatUI`, `BaseChatPersistenceSwiftData`, `BaseChatBackends`).
+- The current release is 0.18.0. BCK is pre-1.0; minor versions can break.
+- View models are Swift `@Observable` + `@MainActor`. Never `ObservableObject`,
+  never `Task.detached` from a `@MainActor` class.
+
+See AGENTS.md for the canonical bootstrap recipe and working code examples.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -220,6 +220,19 @@ jobs:
 
           echo "✓ All ${#hits[@]} withKnownIssue usage(s) have a tracking // FIXME link."
 
+      # ── readme-lint ───────────────────────────────────────────────────────
+      # Tripwire for stale README API references. Ensures the install pin
+      # matches version.txt and that no deleted public API names re-appear in
+      # the README. See scripts/check-readme.sh for the full rationale.
+      #
+      # The script's path is in this workflow's trigger so an edit to the
+      # script revalidates against the current README. README edits also
+      # re-run this job because the workflow has no `paths:` filter; running
+      # on every PR keeps the cost negligible (a single grep pass).
+      - name: readme-lint — verify README install pin and API references
+        if: always()
+        run: scripts/check-readme.sh
+
       # ── secret-scan (trufflehog) ──────────────────────────────────────────
       - name: secret-scan — scan changed commits for leaked secrets
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,388 @@
+# AGENTS.md — BaseChatKit guide for AI coding assistants
+
+This file is for AI coding assistants (Claude, Cursor, Copilot, …) helping a
+human use **BaseChatKit (BCK)** in their app. Contributors who need the
+project's internal conventions read [`CLAUDE.md`](CLAUDE.md); this is the
+shorter, recipe-shaped surface for *consumers*.
+
+BCK is a Swift package. Install via SwiftPM:
+
+```swift
+.package(url: "https://github.com/roryford/BaseChatKit.git", from: "0.18.0")
+```
+
+> **Pre-1.0.** Minor versions can introduce breaking changes. For production,
+> pin to a specific tag (`exact: "0.18.0"`) and read [CHANGELOG.md](CHANGELOG.md)
+> before bumping. The `0.x` line stabilises pieces incrementally; `1.0.0` will
+> be the freeze point.
+
+## Imports
+
+There is **no `BaseChatKit` umbrella module** — every dependency is imported by
+its product name. (An umbrella product is planned for 0.19.) The eight products
+a typical consumer wires up:
+
+| Product | Import when you need… |
+|---------|------------------------|
+| `BaseChatInference` | Backend protocols, `InferenceService`, `ModelInfo`, `GenerationEvent`, tool types. |
+| `BaseChatRuntime` | Storage-neutral ports (`EndpointStore`, `SamplerPresetStore`), use cases, `ConversationRuntime`. |
+| `BaseChatPersistenceSwiftData` | The shipped SwiftData stack: `BaseChatBootstrap`, `@Model` types, container factory. |
+| `BaseChatBackends` | Concrete backends (MLX, llama.cpp, Foundation, OpenAI, Claude, Ollama). `DefaultBackends.register(with:)`. |
+| `BaseChatUI` | `ChatView`, `SessionListView`, `ChatViewModel`, `SessionManagerViewModel`. |
+| `BaseChatUIModelManagement` | `ModelManagementSheet`, `APIConfigurationView`, model browser/download UI. |
+| `BaseChatHuggingFace` *(optional, `HuggingFace` trait, default-on)* | Hub search, browse, background downloads. |
+| `BaseChatVoice` *(optional, `Voice` trait)* | Speech I/O composer accessory. |
+| `BaseChatMCP` *(optional, `MCP` trait)* | Model Context Protocol client + tool bridge. |
+
+The dependency graph is one-way: UI depends on Runtime depends on Inference;
+backends depend on Inference directly. Never import `BaseChatBackends` from a
+view target — CI lint rejects that edge.
+
+## Bootstrap recipe (canonical hello-world)
+
+The shipped `BaseChatBootstrap` wires inference, persistence, the conversation
+runtime, and the model container in the right order. Drop this in
+`@main App.init()`:
+
+```swift
+import SwiftUI
+import SwiftData
+import BaseChatPersistenceSwiftData
+import BaseChatInference
+import BaseChatUI
+import BaseChatUIModelManagement
+import BaseChatBackends
+
+@main
+struct MyChatApp: App {
+    private let runtime: BaseChatBootstrap
+    @State private var chatViewModel: ChatViewModel
+    @State private var sessionManager: SessionManagerViewModel
+    @State private var modelManagement: ModelManagementViewModel
+
+    init() {
+        let runtime = try! BaseChatBootstrap(
+            configuration: BaseChatConfiguration(
+                appName: "My Chat",
+                bundleIdentifier: "com.example.mychat"
+            )
+        )
+        self.runtime = runtime
+
+        DefaultBackends.register(with: runtime.inferenceService)
+
+        let vm = ChatViewModel(
+            inferenceService: runtime.inferenceService,
+            conversationRuntime: runtime.conversationRuntime
+        )
+        vm.foundationModelProvider = {
+            if #available(iOS 26, macOS 26, *) {
+                return FoundationBackend.isAvailable
+            }
+            return false
+        }
+        vm.configure(runtime: runtime)
+        _chatViewModel = State(initialValue: vm)
+
+        let sessions = SessionManagerViewModel()
+        sessions.configure(runtime: runtime)
+        _sessionManager = State(initialValue: sessions)
+
+        _modelManagement = State(initialValue: ModelManagementViewModel.live())
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environment(chatViewModel)
+                .environment(sessionManager)
+                .environment(modelManagement)
+                .environment(\.endpointStore, runtime.endpointStore)
+        }
+        .modelContainer(runtime.modelContainer)
+    }
+}
+```
+
+The corresponding `ContentView` is small:
+
+```swift
+import SwiftUI
+import BaseChatUI
+import BaseChatUIModelManagement
+
+struct ContentView: View {
+    @Environment(ChatViewModel.self) private var vm
+    @Environment(ModelManagementViewModel.self) private var mm
+    @State private var showModelManagement = false
+
+    var body: some View {
+        NavigationStack {
+            ChatView(
+                showModelManagement: $showModelManagement,
+                apiConfiguration: { APIConfigurationView() }
+            )
+            .sheet(isPresented: $showModelManagement) {
+                ModelManagementSheet(modelRegistry: vm.modelRegistry)
+                    .environment(mm)
+            }
+        }
+    }
+}
+```
+
+`Example/Examples/MinimalExample/` is the runnable version of this — keep it
+open while you wire the real app.
+
+## Sending a message
+
+The user-facing API is **`vm.sendMessage(_:)`** (NOT `vm.send(_:)` — that name
+does not exist on `ChatViewModel`):
+
+```swift
+let reply = try await vm.sendMessage("hi")
+print(reply.content)
+```
+
+For scripted drivers / integration tests, `sendMessage(_:)` returns the
+completed `ChatMessageRecord`. Polling `vm.lastTurnState` after the awaited call
+inspects the same outcome:
+
+```swift
+await vm.sendMessage()                  // uses vm.inputText + draftAttachments
+switch vm.lastTurnState {
+case .completed(let record): /* use record */
+case .failed(let err):       /* surface error */
+case .idle, .generating:     /* unexpected */
+}
+```
+
+`sendMessage(_:)` throws `NoResponseError` when a turn ends without producing a
+message. Make sure a session is selected and a model is loaded first; the
+method enforces both preconditions.
+
+## Backend identity
+
+Use the typed constants in `BackendName`. Do not compare against raw strings:
+
+```swift
+import BaseChatInference
+
+if vm.activeBackendName == BackendName.foundation {
+    // Foundation-specific copy
+}
+```
+
+Available constants today (raw values shown for reference, but **don't compare
+against them directly** — write `BackendName.foundation`, not `"Apple"`):
+
+| Constant | Raw value |
+|----------|-----------|
+| `.foundation` | `"Apple"` |
+| `.ollama` | `"Ollama"` |
+| `.claude` | `"Claude"` |
+| `.openAI` | `"OpenAI"` |
+| `.mlx` | `"MLX"` |
+| `.llama` | `"llama.cpp"` |
+
+The 0.19 release converts `BackendName` to a true Swift `enum` (raw values
+become lowercase: `.foundation == "foundation"`). The typed accessor pattern
+above is forward-compatible — code that hardcodes `"Apple"` will break.
+
+## Message types
+
+There are three message-shaped types. Pick the right one:
+
+| Type | Module | When to use |
+|------|--------|-------------|
+| `ChatMessageRecord` | `BaseChatInference` | Transport / app code. The shape `sendMessage(_:)` returns. |
+| `ChatMessage` (`@Model`) | `BaseChatPersistenceSwiftData` | SwiftData row — owned by the persistence layer. |
+| `StructuredMessage` | `BaseChatInference` | Cloud-wire payload assembled by `InferenceService`. Internal — backends consume it. |
+
+App code reads and writes `ChatMessageRecord`. The persistence and wire types
+are managed by BCK.
+
+## Tool calling
+
+Register an executor with `ToolRegistry`, then thread the registry's
+`definitions` into `GenerationConfig.tools`:
+
+```swift
+let registry = ToolRegistry()
+registry.register(MyWeatherTool())
+
+let (_, stream) = try inferenceService.enqueue(
+    messages: history,
+    tools: registry.definitions
+)
+```
+
+### `@ToolSchema` macro requires `--traits Macros`
+
+The `@ToolSchema` macro synthesises `static var jsonSchema` on a `Decodable`
+struct. **It is gated behind the `Macros` SwiftPM trait, default-off**, because
+the macro plugin pulls swift-syntax (~647 source files) into the build. Opt in
+on every consumer:
+
+```swift
+.package(
+    url: "https://github.com/roryford/BaseChatKit.git",
+    from: "0.18.0",
+    traits: [.trait(name: "Macros")]
+)
+```
+
+```swift
+@ToolSchema
+struct WeatherArguments: Decodable, Sendable {
+    /// City name
+    let city: String
+}
+
+let tool = ToolDefinition(
+    name: "get_weather",
+    description: "Returns weather for a city.",
+    parameters: WeatherArguments.jsonSchema
+)
+```
+
+### Manual `JSONSchemaValue` (no Macros trait)
+
+Without `--traits Macros`, declare the parameter schema by hand. `JSONSchemaValue`
+is a recursive enum (`.string`, `.number`, `.bool`, `.null`, `.array`, `.object`):
+
+```swift
+let tool = ToolDefinition(
+    name: "get_weather",
+    description: "Returns weather for a city.",
+    parameters: .object([
+        "type": .string("object"),
+        "properties": .object([
+            "city": .object([
+                "type": .string("string"),
+                "description": .string("City name")
+            ])
+        ]),
+        "required": .array([.string("city")])
+    ])
+)
+```
+
+**Local backend ceiling:** local instruct models (3B–8B) degrade past ~5 tools
+per request. Curate per call. Cloud backends handle 20+ tools fine.
+
+## Cloud backend setup
+
+Cloud endpoints (OpenAI, Claude, Ollama, LM Studio, custom) flow through
+`APIEndpointRecord` values. The 5-step canonical flow:
+
+```swift
+import BaseChatInference
+
+// 1. Build the record.
+let endpoint = APIEndpointRecord(
+    name: "My OpenAI",
+    provider: .openAI,
+    baseURL: "https://api.openai.com",
+    modelName: "gpt-4o-mini"
+)
+
+// 2. Store the API key in the Keychain (throws on failure).
+try KeychainService.store(key: "sk-...", account: endpoint.keychainAccount)
+
+// 3. Persist the endpoint via the runtime's EndpointStore.
+try await runtime.endpointStore.insertEndpoint(endpoint)
+
+// 4. Route the chat view model to the new backend.
+await vm.loadCloudEndpoint(endpoint)
+
+// 5. Send.
+let reply = try await vm.sendMessage("hello")
+```
+
+Cloud backends require **`--traits CloudSaaS`** (default-off):
+
+```swift
+.package(
+    url: "https://github.com/roryford/BaseChatKit.git",
+    from: "0.18.0",
+    traits: [
+        .trait(name: "MLX"),
+        .trait(name: "Llama"),
+        .trait(name: "CloudSaaS"),
+    ]
+)
+```
+
+`KeychainService.store` / `.delete` and the `APIEndpoint.setAPIKey` /
+`.deleteAPIKey` helpers throw `KeychainError` on failure — never use the legacy
+`Bool`-returning shape.
+
+## Common LLM hallucinations to avoid
+
+These are the four mistakes most assistants make against BCK. Don't write any
+of them:
+
+1. **There is NO `BaseChatKit` umbrella module.** `import BaseChatKit` does not
+   compile. Import the specific products you need
+   (`BaseChatPersistenceSwiftData`, `BaseChatUI`, `BaseChatBackends`, …). An
+   umbrella product is on the 0.19 roadmap.
+2. **The send method is `vm.sendMessage(_:)`, NOT `vm.send(_:)`.**
+   `ChatViewModel.send` does not exist. Use `try await vm.sendMessage("hi")`
+   for scripted use, or set `vm.inputText` and call `await vm.sendMessage()`.
+3. **Backend identity is `BackendName.foundation` (typed), NOT a raw string
+   `"foundation"` or `"Apple"`.** The raw values are an implementation detail
+   that 0.19 will change.
+4. **Local model loading goes through
+   `ModelManagementViewModel.dispatchSelectedLoad()`** — there is no shortcut
+   like `vm.loadModel(url:)` or `vm.loadModel(from:)`. Foundation Models are
+   the exception: call `vm.loadFoundationModelIfAvailable()` directly.
+
+## Trait gotchas
+
+BCK uses SwiftPM traits aggressively to keep dependency graphs small. The ones
+that bite consumers:
+
+- **`Macros` (default-off)** — required for `@ToolSchema`. See above.
+- **`MLX` (default-on)** — pulls mlx-swift; large checkout. Drop on cloud-only
+  builds. Apple Silicon only at runtime.
+- **`Llama` (default-on)** — pulls llama.cpp xcframework (~200 MB). Drop on
+  Foundation-Models-only or cloud-only builds.
+- **`HuggingFace` (default-on)** — Hub browser/downloader. Drop if you don't
+  ship a model picker.
+- **`CloudSaaS` (default-off)** — required for OpenAI / Claude. Off in regulated
+  builds.
+- **`Ollama` (default-off)** — required for `OllamaBackend`. Self-hosted only.
+- **`MCPBuiltinCatalog` (default-off)** — required for the built-in MCP catalog
+  (`notion`, `linear`, `github` descriptors).
+- **`Voice` (default-off)** — required for `BaseChatVoice` speech I/O.
+
+When you `--disable-default-traits`, you must explicitly add the ones you want
+back. The "default consumer app" build is `swift build` with no flags —
+`MLX,Llama,HuggingFace`.
+
+## Concurrency
+
+BCK is Swift-concurrency-native. The rules:
+
+- **`@Observable` + `@MainActor` everywhere.** The view models are `@Observable`
+  (Swift Observation), not Combine `ObservableObject`. Store them in `@State`
+  and pass via `.environment(_)`; read with `@Environment(Type.self)`.
+- **No Combine, no `@Published`, no callback pyramids.** Async/await throughout.
+- **Never use `Task.detached` from a `@MainActor` class.** It captures mutable
+  state without inheriting actor isolation. Use `Task { … }` and let the callee
+  hop off-actor itself. (Swift 6 doesn't always warn on this — see
+  [`CLAUDE.md` → Swift 6 concurrency gotchas item 5](CLAUDE.md#swift-6-concurrency-gotchas).)
+- **Don't block in `deinit` under `@MainActor` ownership.** Async cleanup hops
+  to a `Task.detached` after capturing the resource strongly.
+- **Streams are `AsyncThrowingStream<GenerationEvent, Error>`.** Consume with
+  `for try await event in stream { … }`. The wrapper alias is `GenerationStream`.
+
+## When in doubt
+
+- Read the relevant source under `Sources/`. The public surface is small.
+- The `Example/Examples/MinimalExample/` app is the canonical runnable wiring.
+- DocC catalogs live alongside the modules
+  (`Sources/BaseChatUI/BaseChatUI.docc/`).
+- For contributor-facing conventions (testing, traits, release process),
+  see [CLAUDE.md](CLAUDE.md). For consumer-facing API, this file is enough.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ for the full list of dependency rules the lint enforces.
 ### 1. Add the package
 
 ```swift
-.package(url: "https://github.com/roryford/BaseChatKit.git", from: "1.0.0")
+.package(url: "https://github.com/roryford/BaseChatKit.git", from: "0.18.0")
 ```
 
 Add the targets you need:
@@ -168,7 +168,7 @@ Pass the matching set as `traits:` on your `.package(...)` entry to lock the con
 ```swift
 .package(
     url: "https://github.com/roryford/BaseChatKit.git",
-    from: "0.11.0",
+    from: "0.18.0",
     traits: [
         .trait(name: "MLX"),
         .trait(name: "Llama"),
@@ -189,7 +189,7 @@ If your app targets Apple's built-in Foundation model exclusively, you can drop 
 ```swift
 .package(
     url: "https://github.com/roryford/BaseChatKit.git",
-    from: "1.0.0",
+    from: "0.18.0",
     traits: []   // disables MLX, Llama, HuggingFace defaults
 )
 ```
@@ -210,7 +210,7 @@ For example, a cloud-only consumer can keep the chat UI and local-model loaders 
 ```swift
 .package(
     url: "https://github.com/roryford/BaseChatKit.git",
-    from: "1.0.0",
+    from: "0.18.0",
     traits: [
         .trait(name: "MLX"),
         .trait(name: "Llama"),
@@ -258,7 +258,7 @@ If you already depend on `BaseChatBackends`, the same data is also available via
 ```swift
 .package(
     url: "https://github.com/roryford/BaseChatKit.git",
-    from: "1.0.0",
+    from: "0.18.0",
     traits: [
         .trait(name: "MCP"),
         .trait(name: "MCPBuiltinCatalog"), // optional: only if you use MCPCatalog
@@ -298,7 +298,7 @@ stock `ChatInputBar`.
 ```swift
  .package(
      url: "https://github.com/roryford/BaseChatKit.git",
-     from: "1.0.0",
+     from: "0.18.0",
      traits: [
          .trait(name: "Voice"),
      ]
@@ -373,7 +373,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/roryford/BaseChatKit.git",
-            from: "1.0.0",
+            from: "0.18.0",
             traits: [
                 .trait(name: "MLX"),
                 .trait(name: "Llama"),
@@ -751,6 +751,14 @@ pool can opt in by passing an explicit directory, for example
 
 ## Tool Calling
 
+> [!WARNING]
+> The `@ToolSchema` macro is gated behind the `Macros` SwiftPM trait (default-off,
+> see `Package.swift`). Default builds skip swift-syntax (~647 source files) and
+> `@ToolSchema` is invisible. To use the macro, opt in with `--traits Macros` (or
+> add `.trait(name: "Macros")` to the `traits:` array on your `.package(...)`
+> entry). Without the trait, declare `JSONSchemaValue` by hand on
+> `ToolDefinition.parameters`.
+
 Register tools with `ToolRegistry` and pass `toolRegistry.definitions` as `GenerationConfig.tools` when enqueueing a request:
 
 ```swift
@@ -781,7 +789,9 @@ For a complete walkthrough (descriptor setup, lifecycle, and built-in catalog), 
 
 ## Custom Backends
 
-Implement `InferenceBackend` and register it:
+Implement `InferenceBackend` and register it. The protocol takes a precomputed
+`ModelLoadPlan` so the caller's memory-admission verdict and effective context
+size flow through to the backend instead of being recomputed:
 
 ```swift
 class MyBackend: InferenceBackend, @unchecked Sendable {
@@ -789,9 +799,9 @@ class MyBackend: InferenceBackend, @unchecked Sendable {
     var isGenerating = false
     var capabilities: BackendCapabilities { /* ... */ }
 
-    func loadModel(from url: URL, contextSize: Int32) async throws { /* ... */ }
+    func loadModel(from url: URL, plan: ModelLoadPlan) async throws { /* ... */ }
     func generate(prompt: String, systemPrompt: String?, config: GenerationConfig)
-        throws -> AsyncThrowingStream<GenerationEvent, Error> { /* ... */ }
+        throws -> GenerationStream { /* ... */ }
     func stopGeneration() { /* ... */ }
     func unloadModel() { /* ... */ }
 }
@@ -804,6 +814,10 @@ inferenceService.registerBackendFactory { modelType in
     }
 }
 ```
+
+`plan.effectiveContextSize` carries the resolved context window and `plan.verdict`
+is one of `.allow` / `.warn` / `.deny`. Callers must check the verdict before
+invoking `loadModel`; conformers may rely on that precondition.
 
 ## Curated Model Recommendations
 

--- a/Tests/BaseChatInferenceTests/AgentsMdAuditTest.swift
+++ b/Tests/BaseChatInferenceTests/AgentsMdAuditTest.swift
@@ -1,0 +1,210 @@
+import XCTest
+
+/// Tripwire for `AGENTS.md` (the consumer-facing AI-coding-assistant guide
+/// shipped at the repo root, alongside `CLAUDE.md` for contributors).
+///
+/// AGENTS.md exists so AI assistants helping someone *use* BaseChatKit have
+/// a short, recipe-shaped surface that points at the right APIs. If the
+/// file falls out of sync — references a method we deleted, drops a section,
+/// goes missing entirely — assistants regenerate hallucinations the doc was
+/// chartered to prevent. This test fails when that happens.
+///
+/// The checks are deliberately textual rather than structural: AGENTS.md is
+/// markdown that sometimes wraps API names in inline code, sometimes in a
+/// table cell, sometimes in prose. Greppy substring tests survive layout
+/// edits; an HTML/markdown parser would couple us to formatting.
+final class AgentsMdAuditTest: XCTestCase {
+
+    /// Resolve `<repo-root>/AGENTS.md` from the test source location. Mirrors
+    /// the pattern in `SilentCatchAuditTest` so this test works under both
+    /// `swift test` and `xcodebuild test` without bundling the resource into
+    /// the test target.
+    private static func locateAgentsMd() throws -> URL {
+        let here = URL(fileURLWithPath: #filePath)
+        // Tests/BaseChatInferenceTests/AgentsMdAuditTest.swift → repo root is 3 up.
+        let repoRoot = here
+            .deletingLastPathComponent()  // Tests/BaseChatInferenceTests/
+            .deletingLastPathComponent()  // Tests/
+            .deletingLastPathComponent()  // <repo>
+        let path = repoRoot.appendingPathComponent("AGENTS.md")
+        guard FileManager.default.fileExists(atPath: path.path) else {
+            throw XCTSkip("AGENTS.md not found at \(path.path)")
+        }
+        return path
+    }
+
+    private static func loadAgentsMd() throws -> String {
+        let url = try locateAgentsMd()
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    // MARK: - File presence
+
+    func testAgentsMdExists() throws {
+        _ = try Self.loadAgentsMd()
+    }
+
+    // MARK: - Required current-API references
+
+    /// AGENTS.md must mention the canonical send method by its exact name,
+    /// because `vm.send(_:)` (the deleted alternate) is the most common LLM
+    /// hallucination this file exists to prevent.
+    func testReferencesCurrentSendMessageAPI() throws {
+        let body = try Self.loadAgentsMd()
+        XCTAssertTrue(
+            body.contains("sendMessage(_:)") || body.contains("vm.sendMessage("),
+            "AGENTS.md must reference `sendMessage(_:)` so consumers don't fall back to the deleted `vm.send(_:)`."
+        )
+    }
+
+    /// Backend identity is a typed accessor (`BackendName.foundation`), not a
+    /// raw string. Assistants that hardcode `"Apple"` or `"foundation"` will
+    /// break across the 0.19 BackendName conversion.
+    func testReferencesTypedBackendName() throws {
+        let body = try Self.loadAgentsMd()
+        XCTAssertTrue(
+            body.contains("BackendName.foundation"),
+            "AGENTS.md must reference `BackendName.foundation` (typed) over raw strings like `\"Apple\"`."
+        )
+    }
+
+    /// The bootstrap recipe is the most-copied snippet in the file. It must
+    /// name `BaseChatBootstrap` so assistants don't reach for the legacy
+    /// `configure(persistence:)` shape.
+    func testReferencesBaseChatBootstrap() throws {
+        let body = try Self.loadAgentsMd()
+        XCTAssertTrue(
+            body.contains("BaseChatBootstrap"),
+            "AGENTS.md must reference `BaseChatBootstrap` as the canonical bootstrap entry point."
+        )
+    }
+
+    /// The Tool Calling section must call out the `--traits Macros` requirement
+    /// because `@ToolSchema` is the most likely source of "this snippet doesn't
+    /// compile" reports from consumers.
+    func testCallsOutMacrosTraitForToolSchema() throws {
+        let body = try Self.loadAgentsMd()
+        XCTAssertTrue(
+            body.contains("--traits Macros") || body.contains("trait(name: \"Macros\")"),
+            "AGENTS.md must call out the `Macros` trait gating for `@ToolSchema`."
+        )
+    }
+
+    // MARK: - Forbidden references (deleted APIs)
+
+    /// AGENTS.md must NOT reference the `loadModel(from:contextSize:)` shape;
+    /// that was replaced by `loadModel(from:plan:)` in 0.18.
+    func testDoesNotReferenceDeletedLoadModelSignature() throws {
+        let body = try Self.loadAgentsMd()
+        XCTAssertFalse(
+            body.contains("loadModel(from:contextSize:)"),
+            "AGENTS.md references deleted API `loadModel(from:contextSize:)`. Use `loadModel(from:plan:)`."
+        )
+    }
+
+    /// AGENTS.md must NOT use `vm.send(` (open-paren) as a method call —
+    /// that's the deleted shape the doc exists to steer consumers away from.
+    /// Prose mentions like "the old `vm.send` was removed" are fine; what we
+    /// reject is a code-shaped invocation. The whole-word boundary keeps
+    /// `vm.sendMessage(` from matching.
+    func testDoesNotInstructConsumersToCallDeletedSendMethod() throws {
+        let body = try Self.loadAgentsMd()
+        // Match `vm.send(`, `viewModel.send(`, or `chatViewModel.send(` —
+        // any "<identifier>.send(" that is not "<identifier>.sendMessage(".
+        let lines = body.split(separator: "\n", omittingEmptySubsequences: false)
+        for (idx, line) in lines.enumerated() {
+            // Allow lines that explicitly mention the deletion (those contain
+            // both "send(" and one of the obvious negation cues).
+            let lower = String(line).lowercased()
+            let isNegation = lower.contains("removed") || lower.contains("deleted")
+                || lower.contains("not ") || lower.contains("no longer")
+            if isNegation { continue }
+
+            // Match `\b<identifier>\.send\(` but explicitly not `.sendMessage(`.
+            let regex = try NSRegularExpression(pattern: #"\b\w+\.send\("#)
+            let nsLine = String(line) as NSString
+            let range = NSRange(location: 0, length: nsLine.length)
+            let matches = regex.matches(in: String(line), options: [], range: range)
+            for match in matches {
+                let matchedText = nsLine.substring(with: match.range)
+                if matchedText.contains(".sendMessage(") { continue }
+                XCTFail("AGENTS.md line \(idx + 1) instructs consumers to call deleted method `\(matchedText)`: \(line)")
+            }
+        }
+    }
+
+    // MARK: - Hallucination-list completeness
+
+    /// The "Common LLM hallucinations to avoid" section is the load-bearing
+    /// part of the file. Verify all four listed items are present so a future
+    /// edit doesn't silently delete one.
+    func testCommonHallucinationsSectionListsAllFourItems() throws {
+        let body = try Self.loadAgentsMd()
+        XCTAssertTrue(body.contains("Common LLM hallucinations to avoid"),
+                      "AGENTS.md must contain the `Common LLM hallucinations to avoid` section.")
+        // The four hallucination cues — each must appear somewhere in the file.
+        let cues = [
+            "umbrella module",            // #1
+            "sendMessage",                // #2
+            "BackendName.foundation",     // #3
+            "dispatchSelectedLoad",       // #4
+        ]
+        for cue in cues {
+            XCTAssertTrue(
+                body.contains(cue),
+                "AGENTS.md must reference `\(cue)` in the Common LLM hallucinations section."
+            )
+        }
+    }
+
+    // MARK: - check-readme.sh smoke test
+
+    /// Smoke-verify that `scripts/check-readme.sh` exits 0 against the
+    /// current README. This is intentionally a smoke test — the script's
+    /// detailed failure modes are exercised by the script's own logic in
+    /// CI. We just assert the happy path so a stale pin or deleted-API
+    /// reference can't slip in.
+    ///
+    /// Skips on non-macOS hosts (the script uses POSIX bash only, but the
+    /// per-platform runner config ships shell on macOS unconditionally —
+    /// guarding keeps Linux CI tiers happy if BCK ever extends them).
+    func testCheckReadmeScriptPassesAgainstCurrentTree() throws {
+        #if !os(macOS)
+        throw XCTSkip("Process-launch smoke tests run on macOS only.")
+        #else
+        let here = URL(fileURLWithPath: #filePath)
+        let repoRoot = here
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let scriptURL = repoRoot.appendingPathComponent("scripts/check-readme.sh")
+        guard FileManager.default.isExecutableFile(atPath: scriptURL.path) else {
+            throw XCTSkip("scripts/check-readme.sh missing or not executable at \(scriptURL.path)")
+        }
+
+        let process = Process()
+        process.executableURL = scriptURL
+        process.currentDirectoryURL = repoRoot
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        try process.run()
+        process.waitUntilExit()
+
+        let outData = stdout.fileHandleForReading.readDataToEndOfFile()
+        let errData = stderr.fileHandleForReading.readDataToEndOfFile()
+        let combined = (String(data: outData, encoding: .utf8) ?? "")
+            + "\n--- stderr ---\n"
+            + (String(data: errData, encoding: .utf8) ?? "")
+
+        XCTAssertEqual(
+            process.terminationStatus,
+            0,
+            "scripts/check-readme.sh failed against the current tree:\n\(combined)"
+        )
+        #endif
+    }
+}

--- a/scripts/check-readme.sh
+++ b/scripts/check-readme.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# check-readme.sh — Lint the README's API references against the current package.
+#
+# This is the load-bearing tripwire for initiative I8 (Docs from source). The
+# goal is that future PRs cannot reintroduce stale snippets without flipping
+# this check red.
+#
+# Two checks today:
+#
+#   1. Every `from: "X.Y.Z"` install pin in README.md must match the current
+#      release recorded in version.txt. Stale pins point readers at versions
+#      that may no longer exist.
+#   2. README must not reference deleted public API names. The current
+#      blacklist:
+#        - `loadModel(from:contextSize:)`     (replaced by `loadModel(from:plan:)`)
+#        - `vm.send(_:)` / `viewModel.send(_:)` (replaced by `sendMessage(_:)`)
+#        - `import BaseChatKit`               (no umbrella module exists)
+#
+# Why not full Swift snippet typecheck:
+#   The README's Package.swift fragments and `.target(dependencies:)` snippets
+#   are not standalone Swift programs. A full `swift -typecheck` pass against
+#   the package would need a synthetic per-snippet harness with imports,
+#   surrounding types, and trait gating. That work belongs to a follow-up
+#   if README drift continues to slip past lint. For now this catches the
+#   high-frequency mistakes (version pin, deleted method names) that I8 was
+#   chartered to prevent.
+#
+# Exit 0 on success, non-zero on any check failure.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+README_PATH="${REPO_ROOT}/README.md"
+VERSION_PATH="${REPO_ROOT}/version.txt"
+
+if [[ ! -f "${README_PATH}" ]]; then
+    echo "::error::README.md not found at ${README_PATH}"
+    exit 1
+fi
+
+if [[ ! -f "${VERSION_PATH}" ]]; then
+    echo "::error::version.txt not found at ${VERSION_PATH}"
+    exit 1
+fi
+
+CURRENT_VERSION="$(tr -d '[:space:]' < "${VERSION_PATH}")"
+if [[ -z "${CURRENT_VERSION}" ]]; then
+    echo "::error::version.txt is empty"
+    exit 1
+fi
+
+echo "Current package version: ${CURRENT_VERSION}"
+
+failures=0
+
+# ── Check 1: install-pin freshness ────────────────────────────────────────
+#
+# Every `from: "X.Y.Z"` line in README.md must reference the current release.
+# We do NOT match `exact: "..."`, `branch: "..."`, or `revision: "..."` —
+# those are intentional pins for specific scenarios. Only the open-ended
+# `from:` declarations are required to match `version.txt`.
+echo
+echo "── Check: README install pins match version.txt ─────────────────────"
+
+# Grep with -n for line numbers; awk to extract the version literal.
+mapfile -t pin_lines < <(grep -nE '^\s*from:\s*"[0-9]+\.[0-9]+\.[0-9]+' "${README_PATH}" || true)
+
+if [[ ${#pin_lines[@]} -eq 0 ]]; then
+    echo "::warning::README contains no \`from: \"X.Y.Z\"\` install pins. Did the install snippet move?"
+fi
+
+bad_pins=0
+for entry in "${pin_lines[@]}"; do
+    line_no="${entry%%:*}"
+    line_text="${entry#*:}"
+    pinned_version=$(printf '%s' "${line_text}" | sed -nE 's/.*from:\s*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p')
+    if [[ -z "${pinned_version}" ]]; then
+        continue
+    fi
+    if [[ "${pinned_version}" != "${CURRENT_VERSION}" ]]; then
+        echo "::error file=README.md,line=${line_no}::Install pin \`from: \"${pinned_version}\"\` does not match version.txt (${CURRENT_VERSION})."
+        bad_pins=$((bad_pins + 1))
+    fi
+done
+
+if [[ ${bad_pins} -gt 0 ]]; then
+    failures=$((failures + 1))
+    echo "Found ${bad_pins} stale install pin(s). Bump them to ${CURRENT_VERSION}."
+else
+    echo "✓ All \`from:\` install pins match version.txt (${CURRENT_VERSION})."
+fi
+
+# ── Check 2: deleted API references ───────────────────────────────────────
+#
+# README must not reference public API that no longer exists. The blacklist
+# below is keyed on the exact textual shape the deleted name took in past
+# READMEs — keep entries narrow so we don't false-positive on prose.
+echo
+echo "── Check: README does not reference deleted public API ──────────────"
+
+declare -a forbidden=(
+    'loadModel(from:contextSize:)|deleted in 0.18; use \`loadModel(from:plan:)\` taking a \`ModelLoadPlan\`'
+    'import BaseChatKit$|no umbrella module — import the specific product (e.g. \`BaseChatUI\`)'
+)
+
+# Looking up `vm.send(` is too noisy because `vm.send` could legitimately
+# appear in prose like "vm.sendMessage". Match the exact two-arg call shape
+# that was the deleted method, anchored by parens that do NOT start with
+# "Message".
+declare -a method_renames=(
+    '\bvm\.send\(|use \`vm.sendMessage(_:)\` (the old \`vm.send\` was removed)'
+    '\bviewModel\.send\(|use \`viewModel.sendMessage(_:)\`'
+    '\bChatViewModel\.send\(|use \`ChatViewModel.sendMessage(_:)\`'
+)
+
+bad_apis=0
+
+for entry in "${forbidden[@]}"; do
+    pattern="${entry%%|*}"
+    reason="${entry#*|}"
+    # -F makes the pattern fixed-string for the literal API names; -E for
+    # regex. Use -F if the pattern doesn't contain regex meta. The first two
+    # entries are simple literals.
+    if grep -nF -- "${pattern}" "${README_PATH}" > /tmp/check-readme-hits 2>/dev/null && [[ -s /tmp/check-readme-hits ]]; then
+        while IFS= read -r hit; do
+            line_no="${hit%%:*}"
+            echo "::error file=README.md,line=${line_no}::References deleted API \`${pattern}\` — ${reason}."
+            bad_apis=$((bad_apis + 1))
+        done < /tmp/check-readme-hits
+    fi
+done
+
+for entry in "${method_renames[@]}"; do
+    pattern="${entry%%|*}"
+    reason="${entry#*|}"
+    if grep -nE -- "${pattern}" "${README_PATH}" > /tmp/check-readme-hits 2>/dev/null && [[ -s /tmp/check-readme-hits ]]; then
+        while IFS= read -r hit; do
+            line_no="${hit%%:*}"
+            echo "::error file=README.md,line=${line_no}::References deleted API matching \`${pattern}\` — ${reason}."
+            bad_apis=$((bad_apis + 1))
+        done < /tmp/check-readme-hits
+    fi
+done
+
+rm -f /tmp/check-readme-hits
+
+if [[ ${bad_apis} -gt 0 ]]; then
+    failures=$((failures + 1))
+    echo "Found ${bad_apis} reference(s) to deleted public API."
+else
+    echo "✓ README contains no references to known-deleted public API."
+fi
+
+echo
+
+if [[ ${failures} -gt 0 ]]; then
+    echo "::error::check-readme.sh found ${failures} failing check(s)."
+    exit 1
+fi
+
+echo "✓ check-readme.sh passed."

--- a/scripts/check-readme.sh
+++ b/scripts/check-readme.sh
@@ -63,7 +63,11 @@ echo
 echo "── Check: README install pins match version.txt ─────────────────────"
 
 # Grep with -n for line numbers; awk to extract the version literal.
-mapfile -t pin_lines < <(grep -nE '^\s*from:\s*"[0-9]+\.[0-9]+\.[0-9]+' "${README_PATH}" || true)
+# `mapfile` is bash 4+; macOS ships bash 3.2, so use a portable read loop.
+pin_lines=()
+while IFS= read -r line; do
+    pin_lines+=("$line")
+done < <(grep -nE '^\s*from:\s*"[0-9]+\.[0-9]+\.[0-9]+' "${README_PATH}" || true)
 
 if [[ ${#pin_lines[@]} -eq 0 ]]; then
     echo "::warning::README contains no \`from: \"X.Y.Z\"\` install pins. Did the install snippet move?"


### PR DESCRIPTION
Initiative **I8 (Docs from source + AGENTS.md)** from `put-together-an-improvement-glistening-rossum`. Aligns consumer-facing docs with the actual public API surface and adds a CI tripwire so future PRs can't reintroduce stale snippets.

## Summary

- **README sweep.** Replaced 7 stale install-pin lines (`from: "1.0.0"`, `from: "0.11.0"`) with the current release `from: "0.18.0"`. Updated the Custom Backends example to use `loadModel(from:plan:)` with `ModelLoadPlan` — the `loadModel(from:contextSize:)` signature was removed in 0.18. Added a `[!WARNING]` callout to the Tool Calling section calling out the `@ToolSchema` macro's `--traits Macros` (default-off) requirement.
- **AGENTS.md (new).** ~310-line consumer-facing AI-coding-assistant guide covering imports, the canonical `BaseChatBootstrap` recipe pulled from `MinimalExampleApp.swift`, `sendMessage(_:)` usage, `BackendName.foundation` over raw strings, the three message types, tool calling (both macro and manual `JSONSchemaValue` paths), cloud-backend setup, four common LLM hallucinations to steer away from, trait gotchas, and concurrency rules. Voice is terse and code-snippet-heavy as briefed.
- **.cursorrules (new).** Thin pointer at AGENTS.md plus the high-frequency hallucination cues.
- **scripts/check-readme.sh (new, executable).** Tripwire enforcing two invariants: every `from: "X.Y.Z"` install pin matches `version.txt`, and the README contains no references to deleted public API (`loadModel(from:contextSize:)`, `<identifier>.send(`, `import BaseChatKit`). Wired into the consolidated `lint` workflow as a new step. Per the brief's escape hatch (\"reduce to version-pin check if README has many illustrative-only snippets\"), I limited the script to version-pin + naming checks rather than attempting a full Swift typecheck of every fenced block — most README Swift fences are `Package.swift` fragments or partial bodies that aren't standalone-compilable.
- **AgentsMdAuditTest.swift (new).** 9 XCTest cases asserting AGENTS.md exists, references the current API names (`sendMessage(_:)`, `BackendName.foundation`, `BaseChatBootstrap`, `--traits Macros`), lists all four \"Common LLM hallucinations\" cues, and does NOT reference `loadModel(from:contextSize:)` or instruct callers to use a deleted `<id>.send(` invocation. Includes a Process-based smoke test for `scripts/check-readme.sh`.

## Hero block deliberately untouched

Per the brief, the README Quick Start hero is gated behind I5 (Week 4). This PR only touches version pins and the Custom Backend example.

## Test plan

- [x] `scripts/check-readme.sh` passes locally (versions match, no deleted-API references).
- [x] `swift test --filter AgentsMdAuditTest --disable-default-traits` — 9/9 pass (~0.18s).
- [x] Pre-push gate (CLAUDE.md two-invocation shape):
  - XCTest batch (Core + Runtime + PersistenceSwiftData + UI + UIModelManagement + MCP + Backends + Inference + TestSupport + AppIntents + Server) — **2755 passed, 32 skipped, 0 failed**.
  - Swift Testing isolated (BaseChatInferenceSwiftTestingTests) — **83 passed, 0 failed**.
- [x] `actionlint` clean against the modified `lint.yml`.
- [x] `BaseChatInferenceTests` — 1356 passed, 5 skipped, 0 failed.

## Notes for review

- The release category is `docs:` so Release Please should not cut a version bump.
- The script lives in `scripts/check-readme.sh` and is wired to the existing consolidated `lint.yml` (Ubuntu runner, no Swift toolchain needed). The lint workflow has no `paths:` filter so this runs on every PR — cost is one grep pass.
- The `BackendName` doc example points at `vm.activeBackendName == BackendName.foundation`, matching the existing `BackendName.swift` doc comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)