### PR TITLE
fix(test): disable thinking in LlamaE2ETests basic real-inference suite

### DIFF
--- a/Tests/BaseChatE2ETests/LlamaE2ETests.swift
+++ b/Tests/BaseChatE2ETests/LlamaE2ETests.swift
@@ -92,9 +92,15 @@ final class LlamaE2ETests: XCTestCase {
         systemPrompt: String? = nil,
         maxTokens: Int = 64
     ) async throws -> String {
+        // `maxThinkingTokens: 0` so thinking-capable GGUFs (Qwen3 etc.) emit
+        // visible content immediately instead of consuming the budget on a
+        // `<think>` block. This suite asserts visible content is non-empty;
+        // the dedicated `LlamaThinkingE2ETests` suite covers the thinking
+        // pathway. See #1135.
         let config = GenerationConfig(
             temperature: 0.3,
-            maxOutputTokens: maxTokens
+            maxOutputTokens: maxTokens,
+            maxThinkingTokens: 0
         )
         // LlamaBackend does not apply chat templates — callers must format
         // prompts in the template the model was trained on. PromptTemplate
@@ -145,9 +151,11 @@ final class LlamaE2ETests: XCTestCase {
         // Shared backend is loaded at contextSize: 2048; maxOutputTokens must
         // leave room for the formatted prompt (≈47 tokens) or the new
         // context-exhaustion preflight will reject the request.
+        // See `generate(...)` for the `maxThinkingTokens: 0` rationale (#1135).
         let config = GenerationConfig(
             temperature: 0.7,
-            maxOutputTokens: 1024
+            maxOutputTokens: 1024,
+            maxThinkingTokens: 0
         )
 
         let formattedPrompt = PromptTemplate.chatML.format(
@@ -216,7 +224,8 @@ final class LlamaE2ETests: XCTestCase {
             messages: [(role: "user", content: longInput)],
             systemPrompt: nil
         )
-        let config = GenerationConfig(temperature: 0.3, maxOutputTokens: 32)
+        // See `generate(...)` for the `maxThinkingTokens: 0` rationale (#1135).
+        let config = GenerationConfig(temperature: 0.3, maxOutputTokens: 32, maxThinkingTokens: 0)
         let stream = try dedicatedBackend.generate(
             prompt: formattedPrompt,
             systemPrompt: nil,


### PR DESCRIPTION
## Summary

`LlamaE2ETests.test_realInference_*` asserts the visible response is non-empty. When the suite is pinned to a thinking-capable GGUF (Qwen3-* etc.) via `LLAMA_TEST_MODEL`, the model spends the test-stub's token budget on a `<think>` block and emits no visible content — 5 tests fail on `XCTAssertFalse(visibleContent.isEmpty)` even though the backend is behaving correctly.

Set `maxThinkingTokens: 0` on the three `GenerationConfig`s the suite consumes to completion, so thinking is suppressed and visible output lands within the budget. The dedicated `LlamaThinkingE2ETests` suite continues to exercise the thinking pathway separately.

## Validation

With `BASECHAT_DISCOVER_LOCAL_MODELS=1` + `LLAMA_TEST_MODEL=Qwen3-1.7B`:

| Test | Before | After |
|------|--------|-------|
| `LlamaE2ETests.test_realInference_generatesNonEmptyResponse` | fail | pass |
| `LlamaE2ETests.test_realInference_longPrompt_exceedsNBatch_doesNotCrash` | fail | pass |
| `LlamaE2ETests.test_realInference_multiTurn` | fail (both turns) | pass |
| `LlamaE2ETests.test_realInference_respectsMaxOutputTokens` | fail | pass |
| `LlamaE2ETests.test_realInference_withSystemPrompt` | fail | pass |
| `LlamaThinkingE2ETests.testLlamaBackend_thinkingGGUF_emitsThinkingEventsBeforeVisibleOutput` | pass (33s) | pass (41.8s) |

No effect on non-thinking models (smollm2 etc.) — `maxThinkingTokens: 0` is a no-op when the model doesn't emit thinking tokens.

The `test_realInference_preflight_throwsContextExhausted` site is left alone — it asserts on the preflight throw, never reads tokens.

Closes #1135. Unblocks the `MID_THINKING` fixture item in #1115.