### PR TITLE
feat(runtime): relocate MessageStore, SessionStore, persistence-port types to BaseChatRuntime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@
 
 | Target | Role | ML deps |
 |--------|------|---------|
-| `BaseChatInference` | Inference orchestration — protocols, models, services (no persistence) | None |
+| `BaseChatInference` | Inference orchestration — backend protocols, generation events, prompt assembly, conversation records (no persistence ports) | None |
 | `BaseChatMCP` | Model Context Protocol client surface, descriptors, tool bridge (`MCPClient`, `MCPToolSource`) | None |
-| `BaseChatRuntime` | Persistence-agnostic ports (`EndpointStore`, `SamplerPresetStore`, `BenchmarkCache`), use cases (`PromptContextPipeline`, `ChatExportService`, `SessionListService`), and session-list orchestration | None |
+| `BaseChatRuntime` | Persistence ports (`MessageStore`, `SessionStore`, `EndpointStore`, `SamplerPresetStore`, `BenchmarkCache`), use cases (`PromptContextPipeline`, `ChatExportService`, `SessionListService`, `ConversationRuntime`), and session-list orchestration | None |
 | `BaseChatPersistenceSwiftData` | SwiftData schema, `@Model` types, container factory, adapter implementations, and the full-stack `BaseChatBootstrap` | None |
 | `BaseChatBackends` | MLX, llama.cpp, Foundation, cloud backends (depends on `BaseChatInference`) | MLX, LlamaSwift |
 | `BaseChatUI` | SwiftUI chat-runtime views and view models (chat-only consumer stops here) | None |

--- a/Package.swift
+++ b/Package.swift
@@ -102,7 +102,15 @@ let package = Package(
                 .define("Macros", .when(traits: ["Macros"])),
             ]
         ),
-        // Inference: models, protocols, services — no SwiftData, no heavy ML deps.
+        // Inference: models, protocols, services — no SwiftData, no heavy ML
+        // deps, no persistence ports. The persistence-port protocols
+        // (MessageStore, SessionStore, ChatPersistenceError, MessageSearchHit,
+        // and the post-write hooks) live in BaseChatRuntime alongside the
+        // ConversationRuntime use case that consumes them. The records they
+        // traffic in (ChatMessageRecord, ChatSessionRecord, MessagePart,
+        // MessageRole) stay here because inference services (PromptAssembler,
+        // ContextWindowManager, TranscriptHealer) also consume them and the
+        // dep DAG points BaseChatRuntime → BaseChatInference, not the other way.
         // Hosts the @ToolSchema attribute declaration so callers get the macro
         // for free wherever JSONSchemaValue is in scope. The macro plugin and
         // its swift-syntax dependency are trait-gated (`Macros`, off by
@@ -133,9 +141,13 @@ let package = Package(
                 .define("MCPBuiltinCatalog", .when(traits: ["MCPBuiltinCatalog"])),
             ]
         ),
-        // Runtime: ports (EndpointStore, SamplerPresetStore, BenchmarkCache),
-        // use cases (PromptContextPipeline, ChatExportService, SessionListService),
-        // and session-list orchestration. No SwiftData, no SwiftUI, no Observation.
+        // Runtime: ports (MessageStore, SessionStore, EndpointStore,
+        // SamplerPresetStore, BenchmarkCache), use cases (PromptContextPipeline,
+        // ChatExportService, SessionListService, ConversationRuntime), and
+        // session-list orchestration. No SwiftData, no SwiftUI, no Observation.
+        // MessageStore and SessionStore moved here from BaseChatInference in
+        // initiative I4 so persistence ports live alongside the use cases that
+        // consume them.
         .target(
             name: "BaseChatRuntime",
             dependencies: [

--- a/Sources/BaseChatInference/Models/ConversationRecords.swift
+++ b/Sources/BaseChatInference/Models/ConversationRecords.swift
@@ -115,31 +115,3 @@ public struct ChatMessageRecord: Identifiable, Hashable, Sendable {
     }
 }
 
-/// A single match returned from full-text message search.
-///
-/// `snippet` is a short excerpt of the matched message centred around the
-/// first occurrence of the query, suitable for display under the parent
-/// session row. `matchRange` locates the query within `snippet` so callers
-/// can highlight it without re-searching.
-public struct MessageSearchHit: Identifiable, Hashable, Sendable {
-    public var id: UUID { messageID }
-    public var messageID: UUID
-    public var sessionID: UUID
-    public var snippet: String
-    public var matchRange: Range<String.Index>
-    public var timestamp: Date
-
-    public init(
-        messageID: UUID,
-        sessionID: UUID,
-        snippet: String,
-        matchRange: Range<String.Index>,
-        timestamp: Date
-    ) {
-        self.messageID = messageID
-        self.sessionID = sessionID
-        self.snippet = snippet
-        self.matchRange = matchRange
-        self.timestamp = timestamp
-    }
-}

--- a/Sources/BaseChatPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift
+++ b/Sources/BaseChatPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift
@@ -1,5 +1,6 @@
 import Foundation
 import BaseChatInference
+import BaseChatRuntime
 import SwiftData
 
 /// Default ``SessionStore`` + ``MessageStore`` adapter backed by SwiftData.

--- a/Sources/BaseChatRuntime/Models/MessageSearchHit.swift
+++ b/Sources/BaseChatRuntime/Models/MessageSearchHit.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// A single match returned from full-text message search.
+///
+/// `snippet` is a short excerpt of the matched message centred around the
+/// first occurrence of the query, suitable for display under the parent
+/// session row. `matchRange` locates the query within `snippet` so callers
+/// can highlight it without re-searching.
+///
+/// Lives alongside ``MessageStore`` (the producer) in `BaseChatRuntime`. The
+/// record types it summarises (``ChatMessageRecord``, ``ChatSessionRecord``)
+/// remain in `BaseChatInference` because inference-layer services (prompt
+/// assembly, context-window management, transcript healing) traffic in them
+/// independently of any persistence port.
+public struct MessageSearchHit: Identifiable, Hashable, Sendable {
+    public var id: UUID { messageID }
+    public var messageID: UUID
+    public var sessionID: UUID
+    public var snippet: String
+    public var matchRange: Range<String.Index>
+    public var timestamp: Date
+
+    public init(
+        messageID: UUID,
+        sessionID: UUID,
+        snippet: String,
+        matchRange: Range<String.Index>,
+        timestamp: Date
+    ) {
+        self.messageID = messageID
+        self.sessionID = sessionID
+        self.snippet = snippet
+        self.matchRange = matchRange
+        self.timestamp = timestamp
+    }
+}

--- a/Sources/BaseChatRuntime/Protocols/MessageStore.swift
+++ b/Sources/BaseChatRuntime/Protocols/MessageStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import BaseChatInference
 
 /// Storage port for chat messages and message-scope search.
 ///

--- a/Sources/BaseChatRuntime/Protocols/SessionStore.swift
+++ b/Sources/BaseChatRuntime/Protocols/SessionStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import BaseChatInference
 
 /// Errors produced by ``SessionStore`` and ``MessageStore`` implementations.
 ///

--- a/Sources/BaseChatTestSupport/ErrorInjectingPersistenceProvider.swift
+++ b/Sources/BaseChatTestSupport/ErrorInjectingPersistenceProvider.swift
@@ -1,5 +1,6 @@
 import Foundation
 import BaseChatInference
+import BaseChatRuntime
 
 /// Test double that wraps any combined ``SessionStore`` + ``MessageStore``
 /// adapter and adds two facilities the real adapter cannot offer: per-method

--- a/Sources/BaseChatUI/ViewModels/InMemoryMessageStore.swift
+++ b/Sources/BaseChatUI/ViewModels/InMemoryMessageStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import BaseChatInference
+import BaseChatRuntime
 
 /// Process-local message store used as the default backing for
 /// ``ChatViewModel/conversationRuntime`` when the host did not pass a runtime

--- a/Tests/BaseChatPersistenceSwiftDataTests/SwiftDataPersistenceProviderHookTests.swift
+++ b/Tests/BaseChatPersistenceSwiftDataTests/SwiftDataPersistenceProviderHookTests.swift
@@ -2,11 +2,12 @@ import XCTest
 import SwiftData
 @testable import BaseChatPersistenceSwiftData
 import BaseChatInference
+import BaseChatRuntime
 import BaseChatTestSupport
 
 /// Phase 1.2.1 — `MessageStorePostWriteHook` integration coverage for the
 /// SwiftData adapter. Same contract as the protocol-level tests in
-/// `BaseChatInferenceTests/MessageStorePostWriteHookTests.swift`, but
+/// `BaseChatRuntimeTests/MessageStorePostWriteHookTests.swift`, but
 /// exercising the real `SwiftDataPersistenceProvider` against an in-memory
 /// SwiftData container so the post-commit ordering and the
 /// `addPostWriteHook` registration path are covered against the production

--- a/Tests/BaseChatPersistenceSwiftDataTests/SwiftDataPersistenceProviderTests.swift
+++ b/Tests/BaseChatPersistenceSwiftDataTests/SwiftDataPersistenceProviderTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftData
 @testable import BaseChatPersistenceSwiftData
 import BaseChatInference
+import BaseChatRuntime
 import BaseChatTestSupport
 
 /// Integration tests for ``SwiftDataPersistenceProvider`` against a fresh

--- a/Tests/BaseChatRuntimeTests/MessageStorePostWriteHookTests.swift
+++ b/Tests/BaseChatRuntimeTests/MessageStorePostWriteHookTests.swift
@@ -1,6 +1,7 @@
 @preconcurrency import XCTest
 import Foundation
 @testable import BaseChatInference
+@testable import BaseChatRuntime
 
 /// Phase 1.2.1 — protocol-level coverage for ``MessageStorePostWriteHook``
 /// against an in-memory ``MessageStore`` fake.

--- a/Tests/BaseChatRuntimeTests/ProtocolLocationAuditTest.swift
+++ b/Tests/BaseChatRuntimeTests/ProtocolLocationAuditTest.swift
@@ -1,0 +1,72 @@
+import XCTest
+import Foundation
+import BaseChatInference
+import BaseChatRuntime
+
+/// Tripwire that pins the persistence-port protocols and their port-only
+/// types in ``BaseChatRuntime``.
+///
+/// Initiative I4 (May 2026) relocated ``MessageStore`` and ``SessionStore``
+/// from ``BaseChatInference`` to ``BaseChatRuntime`` to align with the layering
+/// rule documented in `CLAUDE.md`: BaseChatInference owns inference
+/// orchestration (no persistence); BaseChatRuntime owns persistence-agnostic
+/// ports plus the use cases that consume them. The records the ports traffic
+/// in (``ChatMessageRecord``, ``ChatSessionRecord``, ``MessagePart``,
+/// ``MessageRole``) deliberately stayed in BaseChatInference because the
+/// inference services (PromptAssembler, ContextWindowManager, TranscriptHealer)
+/// also traffic in them — the dep DAG points BaseChatRuntime → BaseChatInference.
+///
+/// Future PRs that move these symbols back to BaseChatInference (or sideways
+/// to a third module without updating this test) will fail here at runtime.
+final class ProtocolLocationAuditTest: XCTestCase {
+
+    func test_persistencePortProtocols_liveInBaseChatRuntime() {
+        XCTAssertTrue(
+            String(reflecting: MessageStore.self).hasPrefix("BaseChatRuntime."),
+            "MessageStore must live in BaseChatRuntime — got \(String(reflecting: MessageStore.self))"
+        )
+        XCTAssertTrue(
+            String(reflecting: SessionStore.self).hasPrefix("BaseChatRuntime."),
+            "SessionStore must live in BaseChatRuntime — got \(String(reflecting: SessionStore.self))"
+        )
+        XCTAssertTrue(
+            String(reflecting: MessageStorePostWriteHook.self).hasPrefix("BaseChatRuntime."),
+            "MessageStorePostWriteHook must live in BaseChatRuntime — got \(String(reflecting: MessageStorePostWriteHook.self))"
+        )
+        XCTAssertTrue(
+            String(reflecting: SessionStorePostWriteHook.self).hasPrefix("BaseChatRuntime."),
+            "SessionStorePostWriteHook must live in BaseChatRuntime — got \(String(reflecting: SessionStorePostWriteHook.self))"
+        )
+        XCTAssertTrue(
+            String(reflecting: ChatPersistenceError.self).hasPrefix("BaseChatRuntime."),
+            "ChatPersistenceError must live in BaseChatRuntime — got \(String(reflecting: ChatPersistenceError.self))"
+        )
+        XCTAssertTrue(
+            String(reflecting: MessageSearchHit.self).hasPrefix("BaseChatRuntime."),
+            "MessageSearchHit must live in BaseChatRuntime — got \(String(reflecting: MessageSearchHit.self))"
+        )
+    }
+
+    /// The records remain in `BaseChatInference` because inference-layer
+    /// services consume them and the dep DAG forbids `BaseChatInference →
+    /// BaseChatRuntime`. Pinned here so a future move that breaks that
+    /// invariant fails loudly rather than silently inverting the layering.
+    func test_conversationRecords_liveInBaseChatInference() {
+        XCTAssertTrue(
+            String(reflecting: ChatMessageRecord.self).hasPrefix("BaseChatInference."),
+            "ChatMessageRecord must remain in BaseChatInference — got \(String(reflecting: ChatMessageRecord.self))"
+        )
+        XCTAssertTrue(
+            String(reflecting: ChatSessionRecord.self).hasPrefix("BaseChatInference."),
+            "ChatSessionRecord must remain in BaseChatInference — got \(String(reflecting: ChatSessionRecord.self))"
+        )
+        XCTAssertTrue(
+            String(reflecting: MessagePart.self).hasPrefix("BaseChatInference."),
+            "MessagePart must remain in BaseChatInference — got \(String(reflecting: MessagePart.self))"
+        )
+        XCTAssertTrue(
+            String(reflecting: MessageRole.self).hasPrefix("BaseChatInference."),
+            "MessageRole must remain in BaseChatInference — got \(String(reflecting: MessageRole.self))"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Initiative **I4** (persistence ports relocation). Moves the persistence-port protocols from `BaseChatInference` to `BaseChatRuntime` so the ports live alongside `ConversationRuntime`, the use case that consumes them.

`CLAUDE.md` and `Package.swift` previously declared `BaseChatInference` as **"no persistence"** while it owned the two foundational persistence ports for the turn loop. This PR aligns the layout with the documented role.

## What moves

To `BaseChatRuntime`:
- `MessageStore` → `Sources/BaseChatRuntime/Protocols/MessageStore.swift`
- `SessionStore` → `Sources/BaseChatRuntime/Protocols/SessionStore.swift`
- `MessageStorePostWriteHook`, `SessionStorePostWriteHook`
- `ChatPersistenceError`
- `MessageSearchHit` → `Sources/BaseChatRuntime/Models/MessageSearchHit.swift`
- `makeMessageSearchSnippet` helper

## What stays in `BaseChatInference`

- `ChatMessageRecord`, `ChatSessionRecord` — used pervasively by inference-layer services (`PromptAssembler`, `ContextWindowManager`, `TranscriptHealer`, `SettingsService`, `PostGenerationTask`)
- `MessagePart`, `MessageRole` — foundational types referenced by `GenerationEvent`, `InboundPayload`, `BackendOptInProtocols`, `MarkdownRendering`, etc.

The records **cannot** move: the dep DAG is `BaseChatRuntime → BaseChatInference`, and `BaseChatInference`'s own services traffic in these record types. Pinning them in place is the only DAG-safe option without inverting the layering. The new audit test makes that intent explicit.

## Source-breaking note

Why `feat:` (not `refactor:`): external consumers that implement `MessageStore` / `SessionStore` will need to add `import BaseChatRuntime` to their conformance. In-repo consumers are updated in this PR; their target deps already include `BaseChatRuntime`, so no `Package.swift` dep changes were needed.

In-repo files that picked up `import BaseChatRuntime`:
- `Sources/BaseChatTestSupport/ErrorInjectingPersistenceProvider.swift`
- `Sources/BaseChatUI/ViewModels/InMemoryMessageStore.swift`
- `Sources/BaseChatPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift`
- `Tests/BaseChatPersistenceSwiftDataTests/SwiftDataPersistenceProvider{Hook,}Tests.swift`

`Tests/BaseChatInferenceTests/MessageStorePostWriteHookTests.swift` moved to `Tests/BaseChatRuntimeTests/` since the `BaseChatInferenceTests` target does not depend on `BaseChatRuntime`.

## Tripwire

`Tests/BaseChatRuntimeTests/ProtocolLocationAuditTest.swift` pins both halves of the layering:
- Persistence-port symbols must live in `BaseChatRuntime`
- Conversation-record types must remain in `BaseChatInference`

A future PR that moves these symbols back (or sideways without updating the audit) fails at runtime via `String(reflecting:)` checks.

## Test plan

- [x] `swift build --build-tests --disable-default-traits` — clean
- [x] Trait-combo sweep: `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` — clean (PR #1139 still OPEN, so no `FoundationOnly` sweep)
- [x] Pre-push gate, two-invocation shape:
  - `BaseChat{Core,Runtime,PersistenceSwiftData,UI,UIModelManagement,MCP,Backends,Inference,TestSupport,AppIntents,Server}Tests` — 2778 passed, 0 failed, 11 skipped
  - `BaseChatInferenceSwiftTestingTests` — 83 passed, 0 failed
- [x] `scripts/cold-start-conformance.sh` (tier 1) — green
- [x] `scripts/cold-start-tier2-bootstrap.sh` (tier 2) — green
- [x] `ProtocolLocationAuditTest` — both methods pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)