### PR TITLE
fix(inference): introduce ModelManifest, derive backend capabilities + per-model wire fields

### DIFF
--- a/Sources/BaseChatBackends/ClaudeBackend.swift
+++ b/Sources/BaseChatBackends/ClaudeBackend.swift
@@ -67,10 +67,30 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
 
     public override var backendName: String { "Claude" }
 
+    /// Manifest looked up from ``CloudModelManifestTable/claude(modelName:)``
+    /// against the configured ``modelName``.
+    ///
+    /// Returns an `unknown(...)` manifest for any model name that doesn't
+    /// prefix-match a table entry — same conservative-by-default policy as
+    /// ``OpenAIBackend/manifest``.
+    public override var manifest: ModelManifest? {
+        CloudModelManifestTable.claude(modelName: modelName)
+    }
+
     public override var capabilities: BackendCapabilities {
-        BackendCapabilities(
+        // Manifest is the source of truth for context window + thinking
+        // capability. Falls back to Anthropic's mainstream 200k baseline
+        // and "extended thinking enabled" until the table covers a model
+        // name — Claude 4-class models all support thinking, so the
+        // optimistic default is safer than under-reporting and silently
+        // hiding the reasoning UI.
+        let resolvedManifest = manifest ?? .unknown(modelIdentifier: modelName, producerKind: .cloud)
+        let resolvedContext = Int32(resolvedManifest.contextWindow == 8192
+            ? 200_000
+            : resolvedManifest.contextWindow)
+        return BackendCapabilities(
             supportedParameters: [.temperature, .topP],
-            maxContextTokens: 200_000,
+            maxContextTokens: resolvedContext,
             requiresPromptTemplate: false,
             supportsSystemPrompt: true,
             // Anthropic Messages API tool calling: the request encodes BCK
@@ -97,6 +117,7 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             // image attachments before we ever build a request body, so an
             // outdated model name surfaces a clear "not vision-capable"
             // error rather than a 400 from Anthropic.
+            supportsThinking: resolvedManifest.supportsThinking,
             supportsVision: BackendVisionCapability.claudeMessagesSupportsImageInput(modelName: modelName),
             streamsToolCallArguments: true,
             supportsParallelToolCalls: true

--- a/Sources/BaseChatBackends/LlamaBackend.swift
+++ b/Sources/BaseChatBackends/LlamaBackend.swift
@@ -41,6 +41,15 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
 
     private var _effectiveContextSize: Int32 = 4096
 
+    /// Manifest captured at the most recent successful load. Mirrors
+    /// ``_effectiveContextSize`` and ``_autoDetectedThinkingMarkers`` in a
+    /// single structured value so consumers (``ContextWindowManager``, the
+    /// conformance harness) can introspect the loaded model uniformly.
+    /// Guarded by `stateLock`.
+    private var _manifest: ModelManifest?
+
+    public var manifest: ModelManifest? { withStateLock { _manifest } }
+
     public var capabilities: BackendCapabilities {
         let ctxSize = withStateLock { _effectiveContextSize }
         // MLX: KV cache reuse deferred — MLX manages its own context lifecycle via
@@ -246,6 +255,19 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
             self.isModelLoaded = true
             self._effectiveContextSize = loadedResources.effectiveContextSize
             self._autoDetectedThinkingMarkers = loadedResources.autoDetectedThinkingMarkers
+            self._manifest = ModelManifest(
+                contextWindow: Int(loadedResources.effectiveContextSize),
+                supportsTools: true,
+                supportsThinking: loadedResources.autoDetectedThinkingMarkers != nil,
+                thinkingMarkers: loadedResources.autoDetectedThinkingMarkers,
+                supportsSeed: true,
+                supportedSamplingParameters: [
+                    .temperature, .topP, .topK, .repeatPenalty,
+                    .presencePenalty, .frequencyPenalty,
+                ],
+                modelIdentifier: url.lastPathComponent,
+                producerKind: .local
+            )
             return true
         }
 
@@ -547,6 +569,7 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         isGenerating = false
         sessionKVState = nil
         _autoDetectedThinkingMarkers = nil
+        _manifest = nil
         _mmprojURL = nil
         _structuredHistory = []
         stateLock.unlock()

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -69,12 +69,18 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
 
     public var capabilities: BackendCapabilities {
         withStateLock {
-            BackendCapabilities(
+            // The manifest is populated at loadModel-time from config.json's
+            // `max_position_embeddings`. Until a load completes (or for
+            // injected test doubles that bypass loadModel), fall back to the
+            // historical conservative 8k default rather than a manifest the
+            // probe never produced.
+            let ctxTokens = Int32(_manifest?.contextWindow ?? 8192)
+            return BackendCapabilities(
                 supportedParameters: [
                     .temperature, .topP, .topK, .repeatPenalty,
                     .minP, .repetitionPenalty, .presencePenalty, .frequencyPenalty,
                 ],
-                maxContextTokens: 8192,
+                maxContextTokens: ctxTokens,
                 requiresPromptTemplate: false,
                 supportsSystemPrompt: true,
                 supportsToolCalling: true,
@@ -137,6 +143,18 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
     /// Whether the currently loaded MLX model accepts image inputs.
     /// Access only under `stateLock`.
     private var _supportsVision = false
+
+    /// Manifest produced at ``loadModel(from:plan:)`` time from the model's
+    /// `config.json` and `tokenizer_config.json`. Drives ``capabilities``'s
+    /// `maxContextTokens` once populated; falls back to `8192` until then.
+    /// Access only under `stateLock`.
+    private var _manifest: ModelManifest?
+
+    /// Public accessor for the manifest captured at the most recent successful
+    /// load. Returns `nil` before any load and after ``unloadModel()``. Used by
+    /// ``ContextWindowManager`` and the conformance harness — see
+    /// `BackendCapabilitiesContractTests`.
+    public var manifest: ModelManifest? { withStateLock { _manifest } }
 
     /// Backend tuning knobs (KV cache quantization, prefill batch size).
     /// Applied at every ``generate`` call's ``GenerateParameters`` construction.
@@ -756,6 +774,86 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         return ThinkingMarkers.fromChatTemplate(template)
     }
 
+    // MARK: - Manifest Production
+
+    /// Produces a ``ModelManifest`` from a freshly-loaded MLX model directory.
+    ///
+    /// Reads `config.json` to extract the true context window:
+    /// `text_config.max_position_embeddings` (preferred for VLM/MoE configs),
+    /// `max_position_embeddings`, or `model_max_length` as a final fallback.
+    /// Combines with the chat-template-detected ``ThinkingMarkers`` and the
+    /// vision-capability flag to populate the manifest.
+    ///
+    /// Falls back to ``ModelManifest/unknown(modelIdentifier:producerKind:)``
+    /// (with a `Log.warn`) when `config.json` is missing or carries no
+    /// position-embedding hint. The conservative default (8k) keeps prompts
+    /// shorter than necessary on misconfigured snapshots, which is safer than
+    /// over-trimming or over-feeding the model.
+    static func produceManifest(
+        at url: URL,
+        detectedThinkingMarkers: ThinkingMarkers?,
+        supportsVision: Bool
+    ) -> ModelManifest {
+        let modelIdentifier = url.lastPathComponent
+        let configURL = url.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: configURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            Log.inference.warning(
+                "MLX manifest probe: config.json missing or unreadable for \(modelIdentifier, privacy: .public); falling back to ModelManifest.unknown"
+            )
+            return .unknown(modelIdentifier: modelIdentifier, producerKind: .local)
+        }
+
+        let contextWindow = extractContextWindow(from: json)
+            ?? {
+                Log.inference.warning(
+                    "MLX manifest probe: no max_position_embeddings / model_max_length found for \(modelIdentifier, privacy: .public); falling back to 8192"
+                )
+                return 8192
+            }()
+
+        return ModelManifest(
+            contextWindow: contextWindow,
+            supportsTools: true,
+            supportsThinking: detectedThinkingMarkers != nil,
+            thinkingMarkers: detectedThinkingMarkers,
+            supportsSeed: true,
+            supportedSamplingParameters: [
+                .temperature, .topP, .topK, .repeatPenalty,
+                .presencePenalty, .frequencyPenalty,
+            ],
+            modelIdentifier: modelIdentifier,
+            producerKind: .local
+        )
+    }
+
+    /// Pulls the model's max position embedding count out of an MLX
+    /// `config.json` payload. Returns `nil` when no recognised key is
+    /// present.
+    static func extractContextWindow(from json: [String: Any]) -> Int? {
+        // Modern multi-modal configs nest the text encoder fields under
+        // `text_config`. Prefer that over the top-level keys when present.
+        if let textConfig = json["text_config"] as? [String: Any],
+           let value = positiveInt(from: textConfig["max_position_embeddings"]) {
+            return value
+        }
+        if let value = positiveInt(from: json["max_position_embeddings"]) {
+            return value
+        }
+        if let value = positiveInt(from: json["model_max_length"]) {
+            return value
+        }
+        return nil
+    }
+
+    private static func positiveInt(from value: Any?) -> Int? {
+        if let int = value as? Int, int > 0 { return int }
+        if let int64 = value as? Int64, int64 > 0 { return Int(int64) }
+        if let double = value as? Double, double > 0 { return Int(double) }
+        if let str = value as? String, let parsed = Int(str), parsed > 0 { return parsed }
+        return nil
+    }
+
     // MARK: - Model Lifecycle
 
     public func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
@@ -827,12 +925,18 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             }
             let detectedDialect = MLXToolDialect.detect(at: url)
             let detectedThinkingMarkers = Self.detectThinkingMarkers(at: url)
+            let producedManifest = Self.produceManifest(
+                at: url,
+                detectedThinkingMarkers: detectedThinkingMarkers,
+                supportsVision: supportsVision
+            )
             let kvCacheReuseEligible = enableKVCacheReuse && !routeThroughVLMFactory
             withStateLock {
                 _modelContainer = container
                 _dialect = detectedDialect
                 _autoDetectedThinkingMarkers = detectedThinkingMarkers
                 _supportsVision = supportsVision
+                _manifest = producedManifest
                 invalidatePromptCacheLocked()
                 _kvCacheReuseEligible = kvCacheReuseEligible
                 _hasInitializedRuntime = true
@@ -1146,6 +1250,7 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             _dialect = .unknown
             _autoDetectedThinkingMarkers = nil
             _supportsVision = false
+            _manifest = nil
             invalidatePromptCacheLocked()
             _kvCacheReuseEligible = false
             _hasInitializedRuntime = false

--- a/Sources/BaseChatBackends/OllamaBackend.swift
+++ b/Sources/BaseChatBackends/OllamaBackend.swift
@@ -57,6 +57,31 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
     /// (the `.cloud()` factory defaults to `1`).
     private var effectiveNumCtx: Int = defaultNumCtxFloor
 
+    /// ``ThinkingMarkers`` auto-detected from the loaded model's `/api/show`
+    /// `template` field. Set by ``loadModel(from:plan:)`` via the show
+    /// probe; consumed by ``parseResponseStream(bytes:config:continuation:)``
+    /// when the server never populates the side-channel `message.thinking`
+    /// field and the model leaks reasoning via inline tags.
+    ///
+    /// Guarded by `stateLock`. `nil` on non-thinking models (or when the
+    /// probe failed); ``parseResponseStream`` falls back to ``ThinkingMarkers/qwen3``
+    /// only when both this and the per-request override are absent.
+    private var _autoDetectedThinkingMarkers: ThinkingMarkers?
+
+    /// Manifest produced by the `/api/show` probe at load time. Captures the
+    /// real `model_info.context_length`, the auto-detected thinking marker
+    /// pair, and the thinking-capability flag in one structured value.
+    /// Guarded by `stateLock`.
+    private var _manifest: ModelManifest?
+
+    /// Public accessor for the manifest captured at the most recent
+    /// successful load. Returns `nil` before any load. Used by the
+    /// conformance harness to assert the cross-backend invariant that
+    /// `.thinkingToken` emitters report `manifest.supportsThinking == true`.
+    public override var manifest: ModelManifest? {
+        withStateLock { _manifest }
+    }
+
     // MARK: - Init
 
     /// Creates an Ollama backend.
@@ -94,12 +119,23 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
     public override var backendName: String { "Ollama" }
 
     public override var capabilities: BackendCapabilities {
-        BackendCapabilities(
+        // Prefer the `/api/show` `model_info.context_length` captured into
+        // the manifest at load time. Fall back to the historical 128k
+        // default (covers most modern Llama 3.x / Qwen3 weights) until a
+        // real probe runs.
+        let resolvedManifest = withStateLock { _manifest }
+        let resolvedContext: Int32
+        if let resolvedManifest {
+            resolvedContext = Int32(resolvedManifest.contextWindow)
+        } else {
+            resolvedContext = 128_000
+        }
+        return BackendCapabilities(
             supportedParameters: [
                 .temperature, .topP, .topK, .repeatPenalty,
                 .minP, .presencePenalty, .frequencyPenalty,
             ],
-            maxContextTokens: 128_000,
+            maxContextTokens: resolvedContext,
             requiresPromptTemplate: false,
             supportsSystemPrompt: true,
             // Tool calling wiring: Ollama's native /api/chat endpoint accepts an
@@ -118,6 +154,11 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
             maxOutputTokens: 128_000,
             supportsStreaming: true,
             isRemote: true,
+            // Reflect the auto-detected thinking capability from `/api/show`
+            // here so consumers can gate reasoning UI without consulting the
+            // legacy `isThinkingModel` flag separately. Defaults to the live
+            // probe value; the manifest carries the same bit.
+            supportsThinking: isThinkingModel,
             // Ollama emits tool calls as whole entries on a single NDJSON
             // line — no incremental `arguments` fragments arrive across
             // multiple lines (some `qwen2.5:7b` configs may stream deltas
@@ -174,25 +215,66 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
         let planned = plan.effectiveContextSize
         effectiveNumCtx = planned > Self.defaultNumCtxFloor ? planned : Self.defaultNumCtxFloor
 
-        self.isThinkingModel = (try? await detectThinkingCapability()) ?? false
+        let probed: ShowProbe
+        do {
+            probed = try await probeShow()
+        } catch {
+            Log.network.info("OllamaBackend /api/show probe threw \(error.localizedDescription, privacy: .public) — treating \(self.modelName, privacy: .public) as non-thinking with conservative manifest")
+            probed = .empty
+        }
+
+        self.isThinkingModel = probed.thinking
+        let resolvedContextWindow = probed.contextLength ?? max(effectiveNumCtx, Self.defaultNumCtxFloor)
+        let manifest = ModelManifest(
+            contextWindow: resolvedContextWindow,
+            supportsTools: true,
+            supportsThinking: probed.thinking,
+            thinkingMarkers: probed.thinkingMarkers,
+            supportsSeed: false, // Ollama's /api/chat ignores seed in current releases.
+            supportedSamplingParameters: [
+                .temperature, .topP, .topK,
+                .presencePenalty, .frequencyPenalty,
+                .repeatPenalty,
+            ],
+            modelIdentifier: modelName,
+            producerKind: .lan
+        )
+        withStateLock {
+            _autoDetectedThinkingMarkers = probed.thinkingMarkers
+            _manifest = manifest
+        }
 
         setIsModelLoaded(true)
-        Log.inference.info("OllamaBackend configured for \(self.modelName, privacy: .public) at \(self.baseURL?.host() ?? "unknown", privacy: .public) thinking=\(self.isThinkingModel, privacy: .public) num_ctx=\(self.effectiveNumCtx, privacy: .public)")
+        Log.inference.info("OllamaBackend configured for \(self.modelName, privacy: .public) at \(self.baseURL?.host() ?? "unknown", privacy: .public) thinking=\(self.isThinkingModel, privacy: .public) num_ctx=\(self.effectiveNumCtx, privacy: .public) ctxWindow=\(resolvedContextWindow, privacy: .public)")
     }
 
-    /// Calls Ollama's `/api/show` endpoint and classifies the model as
-    /// thinking-capable or not.
+    /// Decoded subset of Ollama's `/api/show` response we actually consume.
+    private struct ShowProbe {
+        let thinking: Bool
+        let thinkingMarkers: ThinkingMarkers?
+        let contextLength: Int?
+
+        static let empty = ShowProbe(thinking: false, thinkingMarkers: nil, contextLength: nil)
+    }
+
+    /// Calls Ollama's `/api/show` endpoint and extracts thinking capability,
+    /// auto-detected thinking markers, and the model's true context window.
     ///
-    /// Detection prefers `capabilities: ["thinking", ...]` (surfaced by modern
-    /// Ollama releases) and falls back to scanning the Jinja `template` field
-    /// for `<think>`, `</think>`, or `{{ if .Thinking }}` markers that
-    /// reasoning models ship by convention.
+    /// Thinking detection prefers `capabilities: ["thinking", ...]` (surfaced
+    /// by modern Ollama releases) and falls back to scanning the Jinja
+    /// `template` field for `<think>` / `{{ if .Thinking }}` markers that
+    /// reasoning models ship by convention. ``ThinkingMarkers`` are extracted
+    /// from the same template so the wire-format inline-fallback path
+    /// (`OllamaBackend.parseResponseStream`) can route reasoning content
+    /// through ``ThinkingParser`` rather than hardcoding `<think>` even when
+    /// the loaded model uses a different marker family.
     ///
-    /// Returns `false` (not `nil`) on HTTP failures other than thrown network
-    /// errors so callers get a clean boolean; `throws` so internal bugs (bad
-    /// URL, serialization failure) still surface for the test harness.
-    private func detectThinkingCapability() async throws -> Bool {
-        guard let baseURL else { return false }
+    /// Context length is read from `model_info.context_length`. On HTTP
+    /// failures or shape mismatches the probe returns ``ShowProbe/empty``;
+    /// only true network exceptions throw, so callers can wrap the call in
+    /// `try?` for best-effort behaviour.
+    private func probeShow() async throws -> ShowProbe {
+        guard let baseURL else { return .empty }
         let showURL = baseURL.appendingPathComponent("api/show")
 
         var request = URLRequest(url: showURL)
@@ -205,34 +287,73 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
             (data, response) = try await urlSession.data(for: request)
         } catch {
             Log.network.info("OllamaBackend /api/show probe failed (\(error.localizedDescription, privacy: .public)) — treating \(self.modelName, privacy: .public) as non-thinking")
-            return false
+            return .empty
         }
 
         if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
             Log.network.info("OllamaBackend /api/show returned HTTP \(http.statusCode, privacy: .public) for \(self.modelName, privacy: .public) — treating as non-thinking")
-            return false
+            return .empty
         }
 
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        let json: [String: Any]
+        do {
+            guard let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                Log.network.info("OllamaBackend /api/show returned non-object JSON for \(self.modelName, privacy: .public) — treating as non-thinking")
+                return .empty
+            }
+            json = parsed
+        } catch {
             Log.network.info("OllamaBackend /api/show returned non-JSON for \(self.modelName, privacy: .public) — treating as non-thinking")
-            return false
+            return .empty
         }
 
-        // Preferred: structured capabilities list.
+        // Thinking capability — prefer the structured capabilities list.
+        var thinking = false
         if let caps = json["capabilities"] as? [String],
            caps.contains(where: { $0.lowercased() == "thinking" }) {
-            return true
+            thinking = true
         }
 
-        // Fallback: scan the template for thinking markers.
+        // Thinking markers — auto-detect from the Jinja template via the
+        // shared ``PromptTemplateDetector`` rules. Then opportunistically
+        // back-fill the thinking flag when the template carries a
+        // recognised marker pair.
+        var detectedMarkers: ThinkingMarkers?
         if let template = json["template"] as? String {
-            let markers = ["<think>", "</think>", "{{ if .Thinking }}", "{{if .Thinking}}"]
-            if markers.contains(where: { template.contains($0) }) {
-                return true
+            detectedMarkers = ThinkingMarkers.fromChatTemplate(template)
+            if !thinking {
+                let legacyMarkers = ["<think>", "</think>", "{{ if .Thinking }}", "{{if .Thinking}}"]
+                if legacyMarkers.contains(where: { template.contains($0) }) {
+                    thinking = true
+                }
             }
         }
 
-        return false
+        // model_info.context_length — the authoritative wire value. Missing
+        // on snapshots compiled from older Modelfiles; fall back to the
+        // caller's plan-derived window in that case.
+        var contextLength: Int?
+        if let modelInfo = json["model_info"] as? [String: Any] {
+            // Ollama reports context length under either the canonical
+            // `context_length` key or the architecture-prefixed
+            // `<arch>.context_length` (e.g. `llama.context_length`).
+            for (key, value) in modelInfo where key.hasSuffix("context_length") {
+                if let int = value as? Int, int > 0 {
+                    contextLength = int
+                    break
+                }
+                if let int64 = value as? Int64, int64 > 0 {
+                    contextLength = Int(int64)
+                    break
+                }
+            }
+        }
+
+        return ShowProbe(
+            thinking: thinking,
+            thinkingMarkers: detectedMarkers,
+            contextLength: contextLength
+        )
     }
 
     // MARK: - Request Building
@@ -454,7 +575,12 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
         // of the stream so partial tags split across chunks are held back
         // correctly by the parser's own buffering.
         var sawThinkingField = false
-        let fallbackMarkers = config.thinkingMarkers ?? .qwen3
+        // Order: explicit per-request override > auto-detected markers from
+        // the `/api/show` template scan > Qwen3 default. Hardcoding
+        // `.qwen3` was the bug — non-Qwen reasoning models (`<thinking>`,
+        // `<reasoning>`) silently leaked their markers as visible tokens.
+        let detectedMarkers = withStateLock { _autoDetectedThinkingMarkers }
+        let fallbackMarkers = config.thinkingMarkers ?? detectedMarkers ?? .qwen3
         var contentParser: ThinkingParser?
 
         func noteEventYielded() throws {
@@ -1165,6 +1291,11 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
     // MARK: - Unload
 
     public override func unloadModel() {
+        withStateLock {
+            _manifest = nil
+            _autoDetectedThinkingMarkers = nil
+        }
+        isThinkingModel = false
         super.unloadModel()
     }
 }

--- a/Sources/BaseChatBackends/OpenAIBackend.swift
+++ b/Sources/BaseChatBackends/OpenAIBackend.swift
@@ -57,10 +57,27 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
 
     public override var backendName: String { "OpenAI" }
 
+    /// Manifest looked up from ``CloudModelManifestTable/openAI(modelName:)``
+    /// against the configured ``modelName``.
+    ///
+    /// Cloud backends can't introspect the model at runtime, so the manifest
+    /// is derived from a vendored prefix table. Returns an `unknown(...)`
+    /// manifest (conservative defaults: 8k context, no seed, no penalties)
+    /// for any model name that doesn't prefix-match a table entry — that
+    /// keeps the backend safe against new model releases without having to
+    /// ship a code change for every API name.
+    public override var manifest: ModelManifest? {
+        CloudModelManifestTable.openAI(modelName: modelName)
+    }
+
     public override var capabilities: BackendCapabilities {
-        BackendCapabilities(
+        // Derive the wire-relevant context window from the manifest produced
+        // at loadModel-time; fall back to OpenAI's mainstream 128k when the
+        // host configured a model name we don't recognise.
+        let resolvedContext = Int32(manifest?.contextWindow ?? 128_000)
+        return BackendCapabilities(
             supportedParameters: [.temperature, .topP],
-            maxContextTokens: 128_000,
+            maxContextTokens: resolvedContext,
             requiresPromptTemplate: false,
             supportsSystemPrompt: true,
             // Chat Completions tool calling: the request encodes BCK
@@ -222,6 +239,30 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             // `format: "json"` switch.
             body["format"] = "json"
             body["response_format"] = ["type": "json_object"]
+        }
+
+        // Manifest-gated extra parameters. Reasoning models (`o1`/`o3`/`o4`)
+        // reject `seed` and most penalties — gating per-model on the
+        // manifest avoids HTTP 400s that previously surfaced as cryptic
+        // "Unsupported parameter" upstream errors.
+        let resolvedManifest = manifest ?? .unknown(modelIdentifier: modelName, producerKind: .cloud)
+        if resolvedManifest.supportsSeed, let seed = config.seed {
+            // OpenAI accepts `seed` as a 32-bit signed integer in JSON.
+            // Truncate the 64-bit storage to that range — matches what the
+            // wire format will accept anyway.
+            body["seed"] = Int(truncatingIfNeeded: seed)
+        }
+        if resolvedManifest.supportedSamplingParameters.contains(.presencePenalty),
+           let presence = config.presencePenalty {
+            body["presence_penalty"] = presence
+        }
+        if resolvedManifest.supportedSamplingParameters.contains(.frequencyPenalty),
+           let frequency = config.frequencyPenalty {
+            body["frequency_penalty"] = frequency
+        }
+        if resolvedManifest.supportedSamplingParameters.contains(.topK),
+           let topK = config.topK {
+            body["top_k"] = Int(topK)
         }
 
         // Tool definitions — OpenAI accepts the canonical

--- a/Sources/BaseChatBackends/SSECloudBackend.swift
+++ b/Sources/BaseChatBackends/SSECloudBackend.swift
@@ -168,6 +168,15 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
         fatalError("\(type(of: self)) must override `capabilities`")
     }
 
+    /// Optional ``ModelManifest`` describing the loaded model.
+    ///
+    /// Cloud subclasses derive this from a vendored prefix table
+    /// (``CloudModelManifestTable``); LAN subclasses populate it from a
+    /// runtime introspection probe (Ollama's `/api/show`). The base
+    /// implementation returns `nil` — backends that haven't adopted the
+    /// manifest source-of-truth pattern compile against this default.
+    open var manifest: ModelManifest? { nil }
+
     /// Builds the URLRequest for a generation call.
     ///
     /// Called by ``generate(prompt:systemPrompt:config:)`` after validating state.

--- a/Sources/BaseChatInference/Models/CloudModelManifestTable.swift
+++ b/Sources/BaseChatInference/Models/CloudModelManifestTable.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+/// Vendored prefix table that maps cloud model names to ``ModelManifest``
+/// values.
+///
+/// Cloud backends (OpenAI, Claude) cannot introspect models at runtime —
+/// the wire APIs return only token counts, not capability metadata. The
+/// host-app-supplied `modelName` is the one signal we have, so the table
+/// matches the configured name against a longest-prefix-wins list of
+/// manifests.
+///
+/// Coverage is best-effort and intentionally narrow. Anything that doesn't
+/// match falls through to ``ModelManifest/unknown(modelIdentifier:producerKind:)``,
+/// which is conservative (8k context, no tools, no thinking, no seed). A
+/// missing entry never crashes — it just means the host's model name needs to
+/// be added here.
+///
+/// To add a new model, append a tuple to ``openAIManifests`` /
+/// ``claudeManifests`` keyed by the longest prefix that uniquely identifies
+/// the family. The lookup walks the array longest-prefix-first and returns
+/// the first match.
+public enum CloudModelManifestTable {
+
+    // MARK: - OpenAI
+
+    /// Longest-prefix-wins table for OpenAI Chat Completions models.
+    ///
+    /// Reasoning models (`o1`, `o3`, `o4`) reject `seed` — most production
+    /// stacks return HTTP 400 if a seed field is present. `gpt-4o` and
+    /// `gpt-4-turbo` accept it. Update this list as new families ship.
+    public static let openAIManifests: [(prefix: String, manifest: ModelManifest)] = [
+        // Reasoning families: large context, no seed, native thinking via
+        // `reasoning` / `reasoning_content` deltas (no inline markers).
+        ("o4-mini",      reasoning(name: "o4-mini",      contextWindow: 200_000)),
+        ("o4",           reasoning(name: "o4",           contextWindow: 200_000)),
+        ("o3-mini",      reasoning(name: "o3-mini",      contextWindow: 200_000)),
+        ("o3",           reasoning(name: "o3",           contextWindow: 200_000)),
+        ("o1-preview",   reasoning(name: "o1-preview",   contextWindow: 128_000)),
+        ("o1-mini",      reasoning(name: "o1-mini",      contextWindow: 128_000)),
+        ("o1",           reasoning(name: "o1",           contextWindow: 200_000)),
+        // Chat families.
+        ("gpt-4o-mini",  chat(name: "gpt-4o-mini",  contextWindow: 128_000)),
+        ("gpt-4o",       chat(name: "gpt-4o",       contextWindow: 128_000)),
+        ("gpt-4-turbo",  chat(name: "gpt-4-turbo",  contextWindow: 128_000)),
+        ("gpt-4.1-mini", chat(name: "gpt-4.1-mini", contextWindow: 1_000_000)),
+        ("gpt-4.1",      chat(name: "gpt-4.1",      contextWindow: 1_000_000)),
+        ("gpt-4",        chat(name: "gpt-4",        contextWindow: 8192)),
+        ("gpt-3.5-turbo", chat(name: "gpt-3.5-turbo", contextWindow: 16_385)),
+    ]
+
+    // MARK: - Claude (Anthropic)
+
+    /// Longest-prefix-wins table for Anthropic Messages API models.
+    ///
+    /// All Claude families accept the same sampling parameters (temperature,
+    /// top_p, top_k) and reject `seed`. Extended-thinking families surface
+    /// reasoning via `thinking_delta` blocks (no inline markers).
+    public static let claudeManifests: [(prefix: String, manifest: ModelManifest)] = [
+        // Claude 4 family — extended thinking is standard.
+        ("claude-opus-4-7",     anthropic(name: "claude-opus-4-7",     contextWindow: 1_000_000, thinking: true)),
+        ("claude-opus-4-6",     anthropic(name: "claude-opus-4-6",     contextWindow: 200_000,   thinking: true)),
+        ("claude-opus-4-5",     anthropic(name: "claude-opus-4-5",     contextWindow: 200_000,   thinking: true)),
+        ("claude-opus-4-1",     anthropic(name: "claude-opus-4-1",     contextWindow: 200_000,   thinking: true)),
+        ("claude-opus-4",       anthropic(name: "claude-opus-4",       contextWindow: 200_000,   thinking: true)),
+        ("claude-sonnet-4-7",   anthropic(name: "claude-sonnet-4-7",   contextWindow: 1_000_000, thinking: true)),
+        ("claude-sonnet-4-6",   anthropic(name: "claude-sonnet-4-6",   contextWindow: 200_000,   thinking: true)),
+        ("claude-sonnet-4-5",   anthropic(name: "claude-sonnet-4-5",   contextWindow: 200_000,   thinking: true)),
+        ("claude-sonnet-4",     anthropic(name: "claude-sonnet-4",     contextWindow: 200_000,   thinking: true)),
+        ("claude-haiku-4",      anthropic(name: "claude-haiku-4",      contextWindow: 200_000,   thinking: true)),
+        // Claude 3.7 — extended thinking introduced.
+        ("claude-3-7-sonnet",   anthropic(name: "claude-3-7-sonnet",   contextWindow: 200_000,   thinking: true)),
+        // Claude 3.5 — no extended thinking.
+        ("claude-3-5-sonnet",   anthropic(name: "claude-3-5-sonnet",   contextWindow: 200_000,   thinking: false)),
+        ("claude-3-5-haiku",    anthropic(name: "claude-3-5-haiku",    contextWindow: 200_000,   thinking: false)),
+        // Claude 3 baseline.
+        ("claude-3-opus",       anthropic(name: "claude-3-opus",       contextWindow: 200_000,   thinking: false)),
+        ("claude-3-sonnet",     anthropic(name: "claude-3-sonnet",     contextWindow: 200_000,   thinking: false)),
+        ("claude-3-haiku",      anthropic(name: "claude-3-haiku",      contextWindow: 200_000,   thinking: false)),
+        // Generic catch for date-suffixed families. Order matters: more
+        // specific entries above must precede this one.
+        ("claude-sonnet",       anthropic(name: "claude-sonnet",       contextWindow: 200_000,   thinking: true)),
+        ("claude-opus",         anthropic(name: "claude-opus",         contextWindow: 200_000,   thinking: true)),
+        ("claude-haiku",        anthropic(name: "claude-haiku",        contextWindow: 200_000,   thinking: false)),
+    ]
+
+    // MARK: - Lookup
+
+    /// Looks up a manifest for an OpenAI model by longest-prefix match.
+    ///
+    /// Returns ``ModelManifest/unknown(modelIdentifier:producerKind:)`` when
+    /// no entry matches; callers should treat that as "use conservative
+    /// defaults and don't pass `seed` / penalties on the wire."
+    public static func openAI(modelName: String) -> ModelManifest {
+        lookup(modelName: modelName, in: openAIManifests, kind: .cloud)
+    }
+
+    /// Looks up a manifest for an Anthropic Claude model by longest-prefix
+    /// match.
+    public static func claude(modelName: String) -> ModelManifest {
+        lookup(modelName: modelName, in: claudeManifests, kind: .cloud)
+    }
+
+    /// Walks the table longest-prefix-first and returns the first hit, or
+    /// ``ModelManifest/unknown(...)`` on a miss.
+    private static func lookup(
+        modelName: String,
+        in table: [(prefix: String, manifest: ModelManifest)],
+        kind: ProducerKind
+    ) -> ModelManifest {
+        // Sort by prefix length descending so a more specific entry like
+        // `claude-3-5-sonnet` wins over `claude-3-5`.
+        let sorted = table.sorted { $0.prefix.count > $1.prefix.count }
+        for entry in sorted where modelName.hasPrefix(entry.prefix) {
+            return entry.manifest
+        }
+        return .unknown(modelIdentifier: modelName, producerKind: kind)
+    }
+
+    // MARK: - Manifest Builders
+
+    /// OpenAI Chat Completions chat model — accepts seed, presence/frequency
+    /// penalties, logit_bias, stop sequences, top_k.
+    private static func chat(name: String, contextWindow: Int) -> ModelManifest {
+        ModelManifest(
+            contextWindow: contextWindow,
+            supportsTools: true,
+            supportsThinking: false,
+            thinkingMarkers: nil,
+            supportsSeed: true,
+            supportedSamplingParameters: [
+                .temperature, .topP, .topK,
+                .presencePenalty, .frequencyPenalty,
+                .logitBias, .stopSequences,
+            ],
+            modelIdentifier: name,
+            producerKind: .cloud
+        )
+    }
+
+    /// OpenAI reasoning model (`o1`, `o3`, `o4`) — rejects seed and most
+    /// sampling knobs; reasoning is a side channel (no inline markers).
+    private static func reasoning(name: String, contextWindow: Int) -> ModelManifest {
+        ModelManifest(
+            contextWindow: contextWindow,
+            supportsTools: true,
+            supportsThinking: true,
+            thinkingMarkers: nil,
+            supportsSeed: false,
+            supportedSamplingParameters: [.temperature, .topP],
+            modelIdentifier: name,
+            producerKind: .cloud
+        )
+    }
+
+    /// Anthropic Claude model. All Claude models reject `seed`. Thinking
+    /// flag depends on whether the family supports extended thinking.
+    private static func anthropic(name: String, contextWindow: Int, thinking: Bool) -> ModelManifest {
+        ModelManifest(
+            contextWindow: contextWindow,
+            supportsTools: true,
+            supportsThinking: thinking,
+            thinkingMarkers: nil,
+            supportsSeed: false,
+            supportedSamplingParameters: [
+                .temperature, .topP, .topK, .stopSequences,
+            ],
+            modelIdentifier: name,
+            producerKind: .cloud
+        )
+    }
+}

--- a/Sources/BaseChatInference/Models/ModelManifest.swift
+++ b/Sources/BaseChatInference/Models/ModelManifest.swift
@@ -1,0 +1,166 @@
+import Foundation
+
+/// A bitset of sampling parameters a backend's request payload accepts on
+/// behalf of the loaded model.
+///
+/// ``ModelManifest`` carries a ``ModelManifest/supportedSamplingParameters``
+/// value to drive the request-build path: when a backend serialises a
+/// generation request, it consults this set to decide which fields to emit on
+/// the wire. A field that is absent from the set MUST be omitted entirely
+/// rather than sent with a default — many cloud providers reject unknown or
+/// unsupported parameters with HTTP 400.
+///
+/// The set is intentionally narrower than ``GenerationParameter``. The latter
+/// is a UI-facing "what knobs should we render" enum that includes
+/// llama.cpp-only sampler families (DRY, XTC, Mirostat). The manifest set is
+/// the request-building counterpart: which generic OpenAI-shaped parameters
+/// (`seed`, `presence_penalty`, `frequency_penalty`, `logit_bias`,
+/// `repeat_penalty`, `stop`) the loaded model honours.
+public struct SamplingParameterSet: OptionSet, Sendable, Hashable, Codable {
+    public let rawValue: UInt32
+
+    public init(rawValue: UInt32) {
+        self.rawValue = rawValue
+    }
+
+    public static let temperature       = SamplingParameterSet(rawValue: 1 << 0)
+    public static let topP              = SamplingParameterSet(rawValue: 1 << 1)
+    public static let topK              = SamplingParameterSet(rawValue: 1 << 2)
+    public static let presencePenalty   = SamplingParameterSet(rawValue: 1 << 3)
+    public static let frequencyPenalty  = SamplingParameterSet(rawValue: 1 << 4)
+    public static let logitBias         = SamplingParameterSet(rawValue: 1 << 5)
+    public static let stopSequences     = SamplingParameterSet(rawValue: 1 << 6)
+    public static let repeatPenalty     = SamplingParameterSet(rawValue: 1 << 7)
+}
+
+/// Whether a model lives on-device, on a remote SaaS endpoint, or somewhere
+/// on the local network.
+///
+/// Informational — used by tests and capability gating but not by the request
+/// path.
+public enum ProducerKind: String, Sendable, Equatable, Codable {
+    /// Weights load locally (MLX, llama.cpp, Foundation Models).
+    case local
+    /// Hosted by a SaaS API (OpenAI, Anthropic, etc.).
+    case cloud
+    /// Reachable on the local network (Ollama, LM Studio).
+    case lan
+}
+
+/// An introspectable description of the currently loaded model.
+///
+/// ``ModelManifest`` is the single source of truth for everything the
+/// application needs to know about the model behind a backend: how big its
+/// context window is, whether it emits reasoning tokens (and behind which
+/// markers), whether the request path may include a `seed` field, and which
+/// sampling parameters the wire layer should serialise.
+///
+/// The manifest is populated by the backend at ``InferenceBackend/loadModel(from:plan:)``
+/// time — local backends introspect `config.json`/GGUF metadata directly,
+/// LAN backends call introspection endpoints (`/api/show`), and cloud
+/// backends look the model up in a vendored prefix table
+/// (``CloudModelManifestTable``). When a backend cannot determine a value at
+/// load time it falls back to ``ModelManifest/unknown(modelIdentifier:)`` and
+/// emits a `Log.warn` so the consumer sees the degradation.
+///
+/// ``BackendCapabilities`` becomes a derived view of the manifest plus
+/// transport-shaped flags (streaming, vision, tool-call streaming). Tests
+/// assert the cross-backend invariant that `.thinkingToken` emitters report
+/// `manifest.supportsThinking == true` — see
+/// `BackendCapabilitiesContractTests`.
+public struct ModelManifest: Sendable, Equatable, Codable {
+    /// The model's true context window in tokens.
+    ///
+    /// Read from `text_config.max_position_embeddings` (preferred), or
+    /// `max_position_embeddings` / `model_max_length` for legacy MLX configs;
+    /// from `model_info.context_length` on Ollama's `/api/show`; or from a
+    /// vendored prefix-table entry for cloud providers.
+    public let contextWindow: Int
+
+    /// Whether the model accepts and honours tool-call definitions in the
+    /// request body.
+    public let supportsTools: Bool
+
+    /// Whether the model emits reasoning tokens that the backend's stream
+    /// parser will surface as ``GenerationEvent/thinkingToken(_:)`` events.
+    ///
+    /// Cross-backend invariant: any backend that can emit
+    /// `.thinkingToken` MUST report `supportsThinking == true`. See
+    /// `BackendCapabilitiesContractTests`.
+    public let supportsThinking: Bool
+
+    /// The marker pair the backend should use when splitting reasoning
+    /// tokens from visible output.
+    ///
+    /// `nil` means "no inline marker pair" — either because reasoning is
+    /// delivered as a side channel (Anthropic `thinking_delta` blocks,
+    /// OpenAI `reasoning_content` deltas, Ollama `message.thinking`) or
+    /// because the model is not a thinking model. Backends that detect
+    /// markers from a chat template (Llama, MLX, Ollama template scan)
+    /// surface them here for the inline-fallback parser.
+    public let thinkingMarkers: ThinkingMarkers?
+
+    /// Whether the model accepts a deterministic sampling seed on the wire.
+    ///
+    /// OpenAI Chat Completions accepts `seed`; Anthropic Messages does not;
+    /// most reasoning models (`o1`, `o3` family) reject it.
+    public let supportsSeed: Bool
+
+    /// Sampling parameters the request-building path may serialise.
+    ///
+    /// Fields outside this set MUST be omitted from the request body — many
+    /// cloud providers reject unknown parameters with HTTP 400.
+    public let supportedSamplingParameters: SamplingParameterSet
+
+    /// Stable identifier for the model — for cloud backends this is the
+    /// API model name (e.g. `"gpt-4o"`, `"claude-sonnet-4-5"`); for local
+    /// backends it's the directory name or HF repo path.
+    public let modelIdentifier: String
+
+    /// Where the model runs.
+    public let producerKind: ProducerKind
+
+    public init(
+        contextWindow: Int,
+        supportsTools: Bool,
+        supportsThinking: Bool,
+        thinkingMarkers: ThinkingMarkers?,
+        supportsSeed: Bool,
+        supportedSamplingParameters: SamplingParameterSet,
+        modelIdentifier: String,
+        producerKind: ProducerKind
+    ) {
+        self.contextWindow = contextWindow
+        self.supportsTools = supportsTools
+        self.supportsThinking = supportsThinking
+        self.thinkingMarkers = thinkingMarkers
+        self.supportsSeed = supportsSeed
+        self.supportedSamplingParameters = supportedSamplingParameters
+        self.modelIdentifier = modelIdentifier
+        self.producerKind = producerKind
+    }
+
+    /// Conservative manifest used when a backend cannot introspect the
+    /// loaded model.
+    ///
+    /// The defaults intentionally undersell rather than oversell: 8k
+    /// context window (modern minimum), no tools, no thinking, no seed,
+    /// only `temperature` + `topP` sampling. A backend that returns
+    /// `.unknown(...)` should emit a `Log.warn` so the consumer sees the
+    /// degradation.
+    public static func unknown(
+        modelIdentifier: String,
+        producerKind: ProducerKind = .local
+    ) -> ModelManifest {
+        ModelManifest(
+            contextWindow: 8192,
+            supportsTools: false,
+            supportsThinking: false,
+            thinkingMarkers: nil,
+            supportsSeed: false,
+            supportedSamplingParameters: [.temperature, .topP],
+            modelIdentifier: modelIdentifier,
+            producerKind: producerKind
+        )
+    }
+}

--- a/Sources/BaseChatInference/Models/ThinkingMarkers.swift
+++ b/Sources/BaseChatInference/Models/ThinkingMarkers.swift
@@ -1,4 +1,4 @@
-public struct ThinkingMarkers: Sendable, Equatable {
+public struct ThinkingMarkers: Sendable, Equatable, Codable {
     public let open: String
     public let close: String
 

--- a/Sources/BaseChatInference/Protocols/InferenceBackend.swift
+++ b/Sources/BaseChatInference/Protocols/InferenceBackend.swift
@@ -574,6 +574,21 @@ public protocol InferenceBackend: AnyObject, Sendable {
     /// What this backend supports (parameters, context size, prompt templates).
     var capabilities: BackendCapabilities { get }
 
+    /// Introspectable description of the currently loaded model — context
+    /// window, sampling parameter support, thinking markers.
+    ///
+    /// Populated at ``loadModel(from:plan:)`` time. Returns `nil` when no
+    /// model has been loaded yet, or when the backend cannot introspect the
+    /// model (uncommon — most backends fall back to
+    /// ``ModelManifest/unknown(modelIdentifier:producerKind:)``).
+    ///
+    /// The default implementation returns `nil`. Backends that have not yet
+    /// adopted the manifest source-of-truth pattern compile against this
+    /// default; consumers (``ContextWindowManager``, request builders) fall
+    /// back to ``BackendCapabilities`` when the manifest is absent. This
+    /// keeps the addition non-breaking for adopters of `InferenceBackend`.
+    var manifest: ModelManifest? { get }
+
     /// Loads a model from the given URL, consuming a precomputed ``ModelLoadPlan``.
     ///
     /// - For GGUF backends, `url` points to a single `.gguf` file.
@@ -646,4 +661,7 @@ public protocol InferenceBackend: AnyObject, Sendable {
 extension InferenceBackend {
     public func resetConversation() {}
     public func secureWipe() {}
+    /// Default — backends that haven't adopted manifest source-of-truth yet
+    /// return `nil`, and consumers fall back to ``capabilities``.
+    public var manifest: ModelManifest? { nil }
 }

--- a/Tests/BaseChatBackendsTests/BackendCapabilitiesContractTests.swift
+++ b/Tests/BaseChatBackendsTests/BackendCapabilitiesContractTests.swift
@@ -67,19 +67,21 @@ final class BackendCapabilitiesContractTests: XCTestCase {
 
     // MARK: - supportsThinking
 
-    /// Cloud backends remain at the default `false` until their
-    /// thinking-event wiring is formalised through #604 / #605 / #598.
-    /// Even though `OpenAIBackend` and `ClaudeBackend` already plumb reasoning
-    /// deltas, the capability flag is the static, model-agnostic contract
-    /// callers rely on to gate reasoning UI — see issue #480.
+    /// `supportsThinking` is now derived from ``ModelManifest`` rather than
+    /// hardcoded on each backend. Claude 4-class models advertise extended
+    /// thinking via the manifest table, so `ClaudeBackend` configured with
+    /// the default `claude-sonnet-4-20250514` name reports `true`.
+    /// `OpenAIBackend`'s default `gpt-4o-mini` is a chat model (no thinking),
+    /// and `OllamaBackend` resolves at load time via `/api/show` so an
+    /// unloaded instance reports the manifest-default `false`.
     #if Ollama && CloudSaaS
-    func test_cloudBackends_doNotAdvertiseThinking() {
-        XCTAssertFalse(ClaudeBackend().capabilities.supportsThinking,
-                       "ClaudeBackend.supportsThinking stays false until #604 formalises the declaration")
+    func test_cloudBackends_advertiseThinkingFromManifest() {
+        XCTAssertTrue(ClaudeBackend().capabilities.supportsThinking,
+                      "ClaudeBackend default model is claude-sonnet-4, which the manifest table reports as a thinking model")
         XCTAssertFalse(OpenAIBackend().capabilities.supportsThinking,
-                       "OpenAIBackend.supportsThinking stays false until #605 formalises the declaration")
+                       "OpenAIBackend default model gpt-4o-mini is not a thinking model")
         XCTAssertFalse(OllamaBackend().capabilities.supportsThinking,
-                       "OllamaBackend.supportsThinking stays false until #598 formalises the declaration")
+                       "OllamaBackend reports thinking only after /api/show probe runs at loadModel time")
     }
     #endif
 

--- a/Tests/BaseChatBackendsTests/Conformance/ClaudeBackendConformanceTests.swift
+++ b/Tests/BaseChatBackendsTests/Conformance/ClaudeBackendConformanceTests.swift
@@ -91,6 +91,20 @@ final class ClaudeBackendConformanceTests: XCTestCase {
         )
     }
 
+    /// `ClaudeBackend.capabilities.supportsThinking` is now derived from
+    /// ``ModelManifest`` via ``CloudModelManifestTable/claude(modelName:)``.
+    /// Default model `claude-sonnet-4-20250514` is a 4-class extended-thinking
+    /// model, so the backend declares the flag `true`. The behavioural
+    /// assertion that proves Claude actually emits `.thinkingToken` events
+    /// lives in `ClaudeThinkingErrorPathTests` / `CloudThinkingTokenTests`;
+    /// this claim records the meta-contract obligation.
+    func test_contract_supportsThinking_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: backendName,
+            flag: "supportsThinking"
+        )
+    }
+
     // MARK: - Meta-contract (MUST be last)
 
     func test_z_contract_metaContract() {

--- a/Tests/BaseChatBackendsTests/MLXManifestProbeTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXManifestProbeTests.swift
@@ -1,0 +1,155 @@
+#if MLX
+import XCTest
+@testable import BaseChatBackends
+@testable import BaseChatInference
+
+/// Unit tests for ``MLXBackend/produceManifest(at:detectedThinkingMarkers:supportsVision:)``.
+///
+/// These tests don't load real MLX weights — they construct a temporary
+/// directory with a synthetic `config.json` and assert the probe extracts the
+/// right context window. The Metal-bound path (real `loadContainer`) lives in
+/// `BaseChatMLXIntegrationTests` and is hardware-gated.
+final class MLXManifestProbeTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mlx-manifest-probe-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: dir)
+        }
+        return dir
+    }
+
+    private func writeConfig(_ json: [String: Any], in dir: URL) throws {
+        let data = try JSONSerialization.data(withJSONObject: json, options: [])
+        try data.write(to: dir.appendingPathComponent("config.json"))
+    }
+
+    // MARK: - Context window extraction
+
+    func test_extractsTopLevelMaxPositionEmbeddings() throws {
+        let dir = try makeTempDir()
+        try writeConfig([
+            "model_type": "qwen3",
+            "max_position_embeddings": 32_768,
+        ], in: dir)
+
+        let manifest = MLXBackend.produceManifest(
+            at: dir,
+            detectedThinkingMarkers: nil,
+            supportsVision: false
+        )
+
+        XCTAssertEqual(manifest.contextWindow, 32_768)
+        XCTAssertEqual(manifest.modelIdentifier, dir.lastPathComponent)
+        XCTAssertEqual(manifest.producerKind, .local)
+        XCTAssertFalse(manifest.supportsThinking,
+                       "supportsThinking must be false when no markers are detected")
+    }
+
+    func test_extractsNestedTextConfigMaxPositionEmbeddings() throws {
+        let dir = try makeTempDir()
+        try writeConfig([
+            "model_type": "gemma4",
+            "text_config": [
+                "max_position_embeddings": 131_072,
+            ] as [String: Any],
+        ], in: dir)
+
+        let manifest = MLXBackend.produceManifest(
+            at: dir,
+            detectedThinkingMarkers: nil,
+            supportsVision: false
+        )
+        XCTAssertEqual(manifest.contextWindow, 131_072,
+                       "text_config.max_position_embeddings must be preferred over the top-level value")
+    }
+
+    func test_textConfigWinsOverTopLevel_whenBothPresent() throws {
+        let dir = try makeTempDir()
+        try writeConfig([
+            "model_type": "vlm-test",
+            "max_position_embeddings": 4096,
+            "text_config": [
+                "max_position_embeddings": 200_000,
+            ] as [String: Any],
+        ], in: dir)
+
+        let manifest = MLXBackend.produceManifest(
+            at: dir,
+            detectedThinkingMarkers: nil,
+            supportsVision: true
+        )
+        XCTAssertEqual(manifest.contextWindow, 200_000,
+                       "text_config wins so VLM/MoE configs reflect the text-encoder window, not the (smaller) image-encoder window")
+    }
+
+    func test_fallsBackToModelMaxLength_whenMaxPositionAbsent() throws {
+        let dir = try makeTempDir()
+        try writeConfig([
+            "model_type": "legacy-mlx",
+            "model_max_length": 16_384,
+        ], in: dir)
+
+        let manifest = MLXBackend.produceManifest(
+            at: dir,
+            detectedThinkingMarkers: nil,
+            supportsVision: false
+        )
+        XCTAssertEqual(manifest.contextWindow, 16_384)
+    }
+
+    func test_returnsUnknownDefaults_whenConfigJsonMissing() throws {
+        let dir = try makeTempDir()
+        // No config.json written.
+
+        let manifest = MLXBackend.produceManifest(
+            at: dir,
+            detectedThinkingMarkers: nil,
+            supportsVision: false
+        )
+        XCTAssertEqual(manifest.contextWindow, 8192,
+                       "Missing config.json must fall back to the conservative 8k default")
+        XCTAssertFalse(manifest.supportsThinking)
+        XCTAssertFalse(manifest.supportsTools,
+                       "ModelManifest.unknown reports no tool support")
+    }
+
+    func test_fallsBackTo8k_whenNoContextHintFound() throws {
+        let dir = try makeTempDir()
+        try writeConfig([
+            "model_type": "minimal",
+        ], in: dir)
+
+        let manifest = MLXBackend.produceManifest(
+            at: dir,
+            detectedThinkingMarkers: nil,
+            supportsVision: false
+        )
+        XCTAssertEqual(manifest.contextWindow, 8192,
+                       "Configs without max_position_embeddings / model_max_length must fall back to 8k")
+    }
+
+    // MARK: - Thinking marker plumbing
+
+    func test_carriesDetectedThinkingMarkers() throws {
+        let dir = try makeTempDir()
+        try writeConfig([
+            "model_type": "qwen3",
+            "max_position_embeddings": 32_768,
+        ], in: dir)
+
+        let manifest = MLXBackend.produceManifest(
+            at: dir,
+            detectedThinkingMarkers: .qwen3,
+            supportsVision: false
+        )
+        XCTAssertEqual(manifest.thinkingMarkers, .qwen3)
+        XCTAssertTrue(manifest.supportsThinking,
+                      "supportsThinking is implied by non-nil thinkingMarkers")
+    }
+}
+#endif

--- a/Tests/BaseChatBackendsTests/ModelManifestContractTests.swift
+++ b/Tests/BaseChatBackendsTests/ModelManifestContractTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import BaseChatBackends
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Cross-backend invariants that ``ModelManifest`` must uphold.
+///
+/// The load-bearing rule: any backend whose configured model emits
+/// ``GenerationEvent/thinkingToken(_:)`` events MUST also report
+/// `manifest.supportsThinking == true`. Consumer UI gates the reasoning
+/// disclosure group on the static capability flag — if the flag and the
+/// stream lie to each other, reasoning content is silently dropped.
+final class ModelManifestContractTests: XCTestCase {
+
+    // MARK: - Cloud backends — supportsThinking matches the manifest table
+
+    #if CloudSaaS
+    func test_claude_sonnet4_manifestReflectsThinking() {
+        let backend = ClaudeBackend()
+        backend.modelName = "claude-sonnet-4-5"
+        let manifest = try? XCTUnwrap(backend.manifest)
+        XCTAssertEqual(manifest?.supportsThinking, true,
+                       "Claude Sonnet 4.x is a thinking model — manifest must reflect that")
+        // The capability flag derives from the manifest in our wiring.
+        XCTAssertTrue(backend.capabilities.supportsThinking,
+                      "BackendCapabilities must surface the manifest's thinking flag")
+    }
+
+    func test_claude_3_5_sonnet_manifestDoesNotAdvertiseThinking() {
+        let backend = ClaudeBackend()
+        backend.modelName = "claude-3-5-sonnet-20241022"
+        let manifest = try? XCTUnwrap(backend.manifest)
+        XCTAssertEqual(manifest?.supportsThinking, false,
+                       "Claude 3.5 Sonnet predates extended thinking")
+        XCTAssertFalse(backend.capabilities.supportsThinking,
+                       "BackendCapabilities must mirror the manifest")
+    }
+
+    func test_openAI_o1_manifestRejectsSeed() {
+        let backend = OpenAIBackend()
+        backend.modelName = "o1-mini"
+        let manifest = try? XCTUnwrap(backend.manifest)
+        XCTAssertEqual(manifest?.supportsSeed, false,
+                       "o1-mini rejects seed — manifest must declare that so the wire layer omits it")
+    }
+
+    func test_openAI_gpt4o_manifestAcceptsSeed() {
+        let backend = OpenAIBackend()
+        backend.modelName = "gpt-4o"
+        let manifest = try? XCTUnwrap(backend.manifest)
+        XCTAssertEqual(manifest?.supportsSeed, true)
+    }
+
+    func test_openAI_unknownModel_returnsConservativeManifest() {
+        let backend = OpenAIBackend()
+        backend.modelName = "made-up-3000"
+        let manifest = try? XCTUnwrap(backend.manifest)
+        XCTAssertEqual(manifest?.contextWindow, 8192,
+                       "Unknown OpenAI model must fall back to the 8k default")
+        XCTAssertEqual(manifest?.supportsSeed, false,
+                       "Unknown OpenAI model must not advertise seed")
+    }
+    #endif
+
+    // MARK: - MockInferenceBackend — invariant scaffolding
+
+    /// Demonstrates that callers using ``MockInferenceBackend`` to simulate
+    /// a thinking-capable backend pair the capability flag and the stream:
+    /// the test fails if a mock that yields `.thinkingToken` events forgets
+    /// to set `supportsThinking: true` in its capabilities.
+    func test_mockBackend_thinkingEventEmitter_reportsSupportsThinking() async throws {
+        let caps = BackendCapabilities(
+            supportedParameters: [.temperature],
+            maxContextTokens: 8192,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsThinking: true
+        )
+        let mock = MockInferenceBackend(capabilities: caps)
+        mock.thinkingTokensToYield = ["thought-A", "thought-B"]
+
+        try await mock.loadModel(from: URL(fileURLWithPath: "/tmp/mock"), plan: .cloud())
+        let stream = try mock.generate(prompt: "Hi", systemPrompt: nil, config: GenerationConfig())
+
+        var sawThinking = false
+        for try await event in stream.events {
+            if case .thinkingToken = event { sawThinking = true }
+        }
+        XCTAssertTrue(sawThinking, "Mock yielded thinking tokens but the consumer never saw one")
+        XCTAssertTrue(mock.capabilities.supportsThinking,
+                      "Backends emitting .thinkingToken must report supportsThinking == true")
+    }
+}

--- a/Tests/BaseChatBackendsTests/OllamaManifestProbeTests.swift
+++ b/Tests/BaseChatBackendsTests/OllamaManifestProbeTests.swift
@@ -1,0 +1,140 @@
+#if Ollama
+import XCTest
+@testable import BaseChatBackends
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Tests that ``OllamaBackend`` populates its ``ModelManifest`` from the
+/// `/api/show` probe at load time. The legacy code only extracted a
+/// thinking-capability boolean and hardcoded a Qwen3 marker fallback;
+/// the manifest now also carries the model's real context window and the
+/// auto-detected ``ThinkingMarkers``.
+final class OllamaManifestProbeTests: XCTestCase {
+
+    private func makeMockSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+
+    private func showResponse(
+        capabilities: [String] = [],
+        template: String? = nil,
+        modelInfo: [String: Any]? = nil
+    ) -> Data {
+        var obj: [String: Any] = ["capabilities": capabilities]
+        if let template { obj["template"] = template }
+        if let modelInfo { obj["model_info"] = modelInfo }
+        return try! JSONSerialization.data(withJSONObject: obj)
+    }
+
+    // MARK: - Context window from /api/show
+
+    func test_manifest_picksUpContextLengthFromCanonicalKey() async throws {
+        let session = makeMockSession()
+        let backend = OllamaBackend(urlSession: session)
+        let baseURL = URL(string: "http://ollama-\(UUID().uuidString).test")!
+        backend.configure(baseURL: baseURL, modelName: "qwen3:8b")
+
+        let showURL = baseURL.appendingPathComponent("api/show")
+        MockURLProtocol.stub(
+            url: showURL,
+            response: .immediate(
+                data: showResponse(
+                    capabilities: ["completion", "thinking"],
+                    modelInfo: ["context_length": 32_768]
+                ),
+                statusCode: 200
+            )
+        )
+        addTeardownBlock { MockURLProtocol.unstub(url: showURL) }
+
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+
+        let manifest = try XCTUnwrap(backend.manifest)
+        XCTAssertEqual(manifest.contextWindow, 32_768,
+                       "Ollama's /api/show context_length must drive the manifest's contextWindow")
+        XCTAssertTrue(manifest.supportsThinking,
+                      "capabilities ['thinking'] must be reflected on the manifest")
+        XCTAssertEqual(manifest.producerKind, .lan)
+    }
+
+    func test_manifest_picksUpContextLengthFromArchPrefixedKey() async throws {
+        let session = makeMockSession()
+        let backend = OllamaBackend(urlSession: session)
+        let baseURL = URL(string: "http://ollama-\(UUID().uuidString).test")!
+        backend.configure(baseURL: baseURL, modelName: "llama3.1:8b")
+
+        let showURL = baseURL.appendingPathComponent("api/show")
+        MockURLProtocol.stub(
+            url: showURL,
+            response: .immediate(
+                data: showResponse(
+                    modelInfo: ["llama.context_length": 131_072]
+                ),
+                statusCode: 200
+            )
+        )
+        addTeardownBlock { MockURLProtocol.unstub(url: showURL) }
+
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+
+        let manifest = try XCTUnwrap(backend.manifest)
+        XCTAssertEqual(manifest.contextWindow, 131_072,
+                       "Architecture-prefixed context_length keys must be honoured (llama.context_length)")
+    }
+
+    // MARK: - Thinking markers from template
+
+    func test_manifest_capturesThinkingMarkersFromTemplate() async throws {
+        let session = makeMockSession()
+        let backend = OllamaBackend(urlSession: session)
+        let baseURL = URL(string: "http://ollama-\(UUID().uuidString).test")!
+        backend.configure(baseURL: baseURL, modelName: "qwen3:8b")
+
+        let template = "{{ if .Thinking }}<think></think>{{ end }}{{ .Prompt }}"
+        let showURL = baseURL.appendingPathComponent("api/show")
+        MockURLProtocol.stub(
+            url: showURL,
+            response: .immediate(
+                data: showResponse(
+                    capabilities: ["completion", "thinking"],
+                    template: template,
+                    modelInfo: ["context_length": 32_768]
+                ),
+                statusCode: 200
+            )
+        )
+        addTeardownBlock { MockURLProtocol.unstub(url: showURL) }
+
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+
+        let manifest = try XCTUnwrap(backend.manifest)
+        XCTAssertEqual(manifest.thinkingMarkers, .qwen3,
+                       "Auto-detected thinking markers must round-trip into the manifest")
+        XCTAssertTrue(manifest.supportsThinking)
+    }
+
+    // MARK: - Probe failure → conservative defaults
+
+    func test_manifest_fallsBackOnShowProbeFailure() async throws {
+        let session = makeMockSession()
+        let backend = OllamaBackend(urlSession: session)
+        let baseURL = URL(string: "http://ollama-\(UUID().uuidString).test")!
+        backend.configure(baseURL: baseURL, modelName: "ghost:8b")
+
+        // No stub registered for /api/show — the probe will fall through.
+        let showURL = baseURL.appendingPathComponent("api/show")
+        MockURLProtocol.stub(url: showURL, response: .immediate(data: Data("not-json".utf8), statusCode: 200))
+        addTeardownBlock { MockURLProtocol.unstub(url: showURL) }
+
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+
+        let manifest = try XCTUnwrap(backend.manifest)
+        XCTAssertFalse(manifest.supportsThinking,
+                       "non-JSON /api/show response must report non-thinking on the manifest")
+        XCTAssertNil(manifest.thinkingMarkers,
+                     "no markers detected → manifest carries nil")
+    }
+}
+#endif

--- a/Tests/BaseChatBackendsTests/OpenAIBackendManifestRequestTests.swift
+++ b/Tests/BaseChatBackendsTests/OpenAIBackendManifestRequestTests.swift
@@ -1,0 +1,151 @@
+#if CloudSaaS
+import XCTest
+@testable import BaseChatBackends
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// Asserts that ``OpenAIBackend`` consults its manifest before serialising
+/// the optional sampling parameters (`seed`, presence/frequency penalties,
+/// `top_k`) on the wire. Reasoning models (`o1` family) reject `seed`
+/// outright with HTTP 400 — the manifest gate is the load-bearing fix.
+final class OpenAIBackendManifestRequestTests: XCTestCase {
+
+    private func makeMockSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+
+    /// Returns the JSON body sent on the most recent generate-call to
+    /// `chatCompletionsURL`.
+    private func capturedRequestJSON(for chatCompletionsURL: URL) throws -> [String: Any] {
+        let captured = MockURLProtocol.capturedRequests.last(where: { $0.url == chatCompletionsURL })
+        let request = try XCTUnwrap(captured, "no captured request to OpenAI completions endpoint")
+        let body = try extractBody(from: request)
+        return try XCTUnwrap(
+            JSONSerialization.jsonObject(with: body) as? [String: Any],
+            "request body did not parse as JSON object"
+        )
+    }
+
+    private func extractBody(from request: URLRequest) throws -> Data {
+        if let body = request.httpBody { return body }
+        if let stream = request.httpBodyStream {
+            var data = Data()
+            stream.open()
+            let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 4096)
+            defer { buffer.deallocate() }
+            while stream.hasBytesAvailable {
+                let read = stream.read(buffer, maxLength: 4096)
+                if read > 0 { data.append(buffer, count: read) }
+            }
+            stream.close()
+            return data
+        }
+        XCTFail("Request has neither httpBody nor httpBodyStream")
+        return Data()
+    }
+
+    private func sseDoneChunk() -> Data {
+        Data("data: [DONE]\n\n".utf8)
+    }
+
+    // MARK: - seed
+
+    func test_gpt4oModel_emitsSeed_whenManifestSupportsIt() async throws {
+        let session = makeMockSession()
+        let backend = OpenAIBackend(urlSession: session)
+        let baseURL = URL(string: "https://openai-\(UUID().uuidString).test")!
+        backend.configure(baseURL: baseURL, apiKey: "sk-test", modelName: "gpt-4o")
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+
+        let completionsURL = baseURL.appendingPathComponent("v1/chat/completions")
+        MockURLProtocol.stub(url: completionsURL, response: .sse(chunks: [sseDoneChunk()], statusCode: 200))
+        addTeardownBlock { MockURLProtocol.unstub(url: completionsURL) }
+
+        var config = GenerationConfig()
+        config.seed = 42
+
+        let stream = try backend.generate(prompt: "Hi", systemPrompt: nil, config: config)
+        for try await _ in stream.events { /* drain */ }
+
+        let json = try capturedRequestJSON(for: completionsURL)
+        XCTAssertEqual(json["seed"] as? Int, 42,
+                       "gpt-4o accepts seed via the manifest; the wire body must include it")
+    }
+
+    func test_o1ReasoningModel_omitsSeed_whenManifestRejectsIt() async throws {
+        let session = makeMockSession()
+        let backend = OpenAIBackend(urlSession: session)
+        let baseURL = URL(string: "https://openai-\(UUID().uuidString).test")!
+        backend.configure(baseURL: baseURL, apiKey: "sk-test", modelName: "o1-mini")
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+
+        let completionsURL = baseURL.appendingPathComponent("v1/chat/completions")
+        MockURLProtocol.stub(url: completionsURL, response: .sse(chunks: [sseDoneChunk()], statusCode: 200))
+        addTeardownBlock { MockURLProtocol.unstub(url: completionsURL) }
+
+        var config = GenerationConfig()
+        config.seed = 42
+
+        let stream = try backend.generate(prompt: "Hi", systemPrompt: nil, config: config)
+        for try await _ in stream.events { /* drain */ }
+
+        let json = try capturedRequestJSON(for: completionsURL)
+        XCTAssertNil(json["seed"],
+                     "o1-mini rejects seed (HTTP 400) — the manifest gate must omit it from the wire body")
+    }
+
+    // MARK: - presence / frequency penalties
+
+    func test_gpt4oModel_emitsPresenceAndFrequencyPenalties_whenManifestSupportsThem() async throws {
+        let session = makeMockSession()
+        let backend = OpenAIBackend(urlSession: session)
+        let baseURL = URL(string: "https://openai-\(UUID().uuidString).test")!
+        backend.configure(baseURL: baseURL, apiKey: "sk-test", modelName: "gpt-4o")
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+
+        let completionsURL = baseURL.appendingPathComponent("v1/chat/completions")
+        MockURLProtocol.stub(url: completionsURL, response: .sse(chunks: [sseDoneChunk()], statusCode: 200))
+        addTeardownBlock { MockURLProtocol.unstub(url: completionsURL) }
+
+        var config = GenerationConfig()
+        config.presencePenalty = 0.5
+        config.frequencyPenalty = 0.25
+
+        let stream = try backend.generate(prompt: "Hi", systemPrompt: nil, config: config)
+        for try await _ in stream.events { /* drain */ }
+
+        let json = try capturedRequestJSON(for: completionsURL)
+        let presence = try XCTUnwrap(json["presence_penalty"] as? Double, "presence_penalty must be present for chat models")
+        let frequency = try XCTUnwrap(json["frequency_penalty"] as? Double, "frequency_penalty must be present for chat models")
+        XCTAssertEqual(presence, 0.5, accuracy: 1e-6)
+        XCTAssertEqual(frequency, 0.25, accuracy: 1e-6)
+    }
+
+    func test_o1ReasoningModel_omitsPenalties_whenManifestRejectsThem() async throws {
+        let session = makeMockSession()
+        let backend = OpenAIBackend(urlSession: session)
+        let baseURL = URL(string: "https://openai-\(UUID().uuidString).test")!
+        backend.configure(baseURL: baseURL, apiKey: "sk-test", modelName: "o1")
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+
+        let completionsURL = baseURL.appendingPathComponent("v1/chat/completions")
+        MockURLProtocol.stub(url: completionsURL, response: .sse(chunks: [sseDoneChunk()], statusCode: 200))
+        addTeardownBlock { MockURLProtocol.unstub(url: completionsURL) }
+
+        var config = GenerationConfig()
+        config.presencePenalty = 0.5
+        config.frequencyPenalty = 0.25
+
+        let stream = try backend.generate(prompt: "Hi", systemPrompt: nil, config: config)
+        for try await _ in stream.events { /* drain */ }
+
+        let json = try capturedRequestJSON(for: completionsURL)
+        XCTAssertNil(json["presence_penalty"],
+                     "o1 reasoning models reject presence_penalty — manifest must omit it")
+        XCTAssertNil(json["frequency_penalty"],
+                     "o1 reasoning models reject frequency_penalty — manifest must omit it")
+    }
+}
+#endif

--- a/Tests/BaseChatInferenceTests/CloudModelManifestTableTests.swift
+++ b/Tests/BaseChatInferenceTests/CloudModelManifestTableTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import BaseChatInference
+
+final class CloudModelManifestTableTests: XCTestCase {
+
+    // MARK: - OpenAI lookup
+
+    func test_openAI_gpt4oMini_matchesSpecificEntry() {
+        let manifest = CloudModelManifestTable.openAI(modelName: "gpt-4o-mini")
+        XCTAssertEqual(manifest.modelIdentifier, "gpt-4o-mini")
+        XCTAssertEqual(manifest.contextWindow, 128_000)
+        XCTAssertTrue(manifest.supportsSeed,
+                      "gpt-4o-mini accepts the OpenAI seed parameter")
+        XCTAssertFalse(manifest.supportsThinking)
+    }
+
+    func test_openAI_gpt4oFollowsLongerPrefixWins() {
+        // `gpt-4o-2024-08-06` should match the `gpt-4o` entry, not fall through to `gpt-4`.
+        let manifest = CloudModelManifestTable.openAI(modelName: "gpt-4o-2024-08-06")
+        XCTAssertEqual(manifest.modelIdentifier, "gpt-4o")
+        XCTAssertEqual(manifest.contextWindow, 128_000)
+    }
+
+    func test_openAI_o1Family_isReasoningWithoutSeed() {
+        let manifest = CloudModelManifestTable.openAI(modelName: "o1-2024-12-17")
+        XCTAssertTrue(manifest.supportsThinking,
+                      "o1 family is a reasoning model")
+        XCTAssertFalse(manifest.supportsSeed,
+                       "o1 family rejects the seed parameter — must be omitted from request bodies")
+        XCTAssertFalse(manifest.supportedSamplingParameters.contains(.presencePenalty),
+                       "o1 reasoning models reject presence/frequency penalties on the wire")
+    }
+
+    func test_openAI_o3_isReasoningWithoutSeed() {
+        let manifest = CloudModelManifestTable.openAI(modelName: "o3")
+        XCTAssertTrue(manifest.supportsThinking)
+        XCTAssertFalse(manifest.supportsSeed)
+    }
+
+    func test_openAI_unknownModel_returnsUnknownManifest() {
+        let manifest = CloudModelManifestTable.openAI(modelName: "imaginary-model-x")
+        XCTAssertEqual(manifest.modelIdentifier, "imaginary-model-x")
+        XCTAssertEqual(manifest.contextWindow, 8192)
+        XCTAssertFalse(manifest.supportsSeed)
+        XCTAssertEqual(manifest.producerKind, .cloud)
+    }
+
+    // MARK: - Claude lookup
+
+    func test_claude_sonnet4Family_supportsExtendedThinking() {
+        let manifest = CloudModelManifestTable.claude(modelName: "claude-sonnet-4-20250514")
+        XCTAssertEqual(manifest.modelIdentifier, "claude-sonnet-4")
+        XCTAssertTrue(manifest.supportsThinking,
+                      "Claude 4-class models support extended thinking by default")
+        XCTAssertFalse(manifest.supportsSeed,
+                       "Anthropic Messages API rejects the seed parameter")
+    }
+
+    func test_claude_3_5_sonnetDoesNotAdvertiseThinking() {
+        let manifest = CloudModelManifestTable.claude(modelName: "claude-3-5-sonnet-20241022")
+        XCTAssertFalse(manifest.supportsThinking,
+                       "Claude 3.5 Sonnet predates extended thinking")
+    }
+
+    func test_claude_3_7_sonnetSupportsExtendedThinking() {
+        let manifest = CloudModelManifestTable.claude(modelName: "claude-3-7-sonnet-20250219")
+        XCTAssertTrue(manifest.supportsThinking,
+                      "Claude 3.7 Sonnet introduced extended thinking")
+    }
+
+    func test_claude_unknownModel_returnsUnknownManifest() {
+        let manifest = CloudModelManifestTable.claude(modelName: "unrecognised-claude")
+        XCTAssertEqual(manifest.modelIdentifier, "unrecognised-claude")
+        XCTAssertEqual(manifest.contextWindow, 8192,
+                       "Unknown models fall back to the conservative 8k default")
+        XCTAssertFalse(manifest.supportsThinking)
+    }
+
+    // MARK: - Longest-prefix-wins ordering invariants
+
+    func test_longestPrefixWins_specificBeatsGeneric() {
+        // `claude-sonnet-4-7` is in the table; `claude-sonnet` is a less-specific
+        // catch-all also in the table. The lookup must return the more specific
+        // entry's manifest.
+        let v47 = CloudModelManifestTable.claude(modelName: "claude-sonnet-4-7-20260101")
+        XCTAssertEqual(v47.modelIdentifier, "claude-sonnet-4-7",
+                       "claude-sonnet-4-7 is longer than claude-sonnet-4 / claude-sonnet — must win")
+        XCTAssertEqual(v47.contextWindow, 1_000_000,
+                       "Claude Sonnet 4.7 advertises a 1M context window via the table")
+    }
+}

--- a/Tests/BaseChatInferenceTests/ModelManifestTests.swift
+++ b/Tests/BaseChatInferenceTests/ModelManifestTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import BaseChatInference
+
+final class ModelManifestTests: XCTestCase {
+
+    // MARK: - SamplingParameterSet
+
+    func test_samplingParameterSet_optionSetSemantics() {
+        let combined: SamplingParameterSet = [.temperature, .topP]
+        XCTAssertTrue(combined.contains(.temperature))
+        XCTAssertTrue(combined.contains(.topP))
+        XCTAssertFalse(combined.contains(.topK))
+
+        let single: SamplingParameterSet = [.presencePenalty]
+        XCTAssertTrue(single.contains(.presencePenalty))
+        XCTAssertFalse(single.contains(.frequencyPenalty))
+    }
+
+    func test_samplingParameterSet_codableRoundTrip() throws {
+        let original: SamplingParameterSet = [
+            .temperature, .topP, .topK,
+            .presencePenalty, .frequencyPenalty,
+            .logitBias, .stopSequences, .repeatPenalty,
+        ]
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(SamplingParameterSet.self, from: data)
+        XCTAssertEqual(decoded, original)
+    }
+
+    // MARK: - ModelManifest.unknown
+
+    func test_unknownManifest_isConservative() {
+        let manifest = ModelManifest.unknown(modelIdentifier: "mystery-model")
+
+        XCTAssertEqual(manifest.contextWindow, 8192,
+                       "Unknown manifests should default to 8k context — modern minimum, safer than over-trimming")
+        XCTAssertFalse(manifest.supportsTools)
+        XCTAssertFalse(manifest.supportsThinking)
+        XCTAssertNil(manifest.thinkingMarkers)
+        XCTAssertFalse(manifest.supportsSeed)
+        XCTAssertEqual(manifest.supportedSamplingParameters, [.temperature, .topP],
+                       "Unknown manifests should only advertise the universal sampling pair")
+        XCTAssertEqual(manifest.modelIdentifier, "mystery-model")
+        XCTAssertEqual(manifest.producerKind, .local)
+    }
+
+    func test_unknownManifest_carriesProducerKind() {
+        let cloud = ModelManifest.unknown(modelIdentifier: "x", producerKind: .cloud)
+        XCTAssertEqual(cloud.producerKind, .cloud)
+
+        let lan = ModelManifest.unknown(modelIdentifier: "y", producerKind: .lan)
+        XCTAssertEqual(lan.producerKind, .lan)
+    }
+
+    // MARK: - Codable
+
+    func test_modelManifest_codableRoundTrip() throws {
+        let original = ModelManifest(
+            contextWindow: 32_768,
+            supportsTools: true,
+            supportsThinking: true,
+            thinkingMarkers: .qwen3,
+            supportsSeed: true,
+            supportedSamplingParameters: [.temperature, .topP, .topK],
+            modelIdentifier: "qwen3-7b",
+            producerKind: .local
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ModelManifest.self, from: data)
+
+        XCTAssertEqual(decoded, original)
+        XCTAssertEqual(decoded.thinkingMarkers, .qwen3)
+        XCTAssertEqual(decoded.contextWindow, 32_768)
+    }
+
+    func test_modelManifest_codableRoundTrip_nilMarkers() throws {
+        let original = ModelManifest(
+            contextWindow: 200_000,
+            supportsTools: true,
+            supportsThinking: false,
+            thinkingMarkers: nil,
+            supportsSeed: true,
+            supportedSamplingParameters: [.temperature, .topP],
+            modelIdentifier: "gpt-4o",
+            producerKind: .cloud
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ModelManifest.self, from: data)
+
+        XCTAssertEqual(decoded, original)
+        XCTAssertNil(decoded.thinkingMarkers)
+    }
+}

--- a/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
+++ b/Tests/BaseChatInferenceTests/silent_catch_allowlist.txt
@@ -111,12 +111,10 @@ BaseChatBackends/ClaudeBackend.swift:let parsed = try? JSONSerialization.jsonObj
 BaseChatBackends/OllamaBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
 BaseChatBackends/OllamaBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
 
-# /api/show thinking-detection probe: best-effort optimization that skips
-# the 2048-token reserve on non-thinking models. Failures are logged at
-# info level and fall through to `isThinkingModel = false`, which is the
-# same safe default we'd pick if the endpoint didn't exist (older Ollama).
-BaseChatBackends/OllamaBackend.swift:self.isThinkingModel = (try? await detectThinkingCapability()) ?? false
-BaseChatBackends/OllamaBackend.swift:guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+# /api/show probe was refactored to a do/catch in I2 (ModelManifest source
+# of truth). The two `try?` patterns it previously used were promoted to
+# `do { ... } catch { Log.network.info(...) }` so the catch path now
+# produces visible error output.
 
 BaseChatBackends/OpenAIBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
 BaseChatBackends/SSECloudBackend.swift:let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],


### PR DESCRIPTION
## Summary

`BackendCapabilities` predates introspectable model manifests, so each backend hardcoded its capability answers — several of which were wrong:

- **MLXBackend** reported a fixed `maxContextTokens: 8192` regardless of the loaded model. Qwen3 32k under-used context; 4k models over-trimmed.
- **OpenAIBackend** dropped `seed`, `presence_penalty`, `frequency_penalty` from the request body even though OpenAI's API accepts them on chat models.
- **OllamaBackend** did not report `supportsThinking` despite emitting thinking events; its inline-thinking fallback hardcoded `<think>` even when the loaded model used a different marker family.
- **ClaudeBackend** likewise missing `supportsThinking` on its 4-class default model.

This PR introduces `ModelManifest` as the introspectable source of truth.

## What

### `ModelManifest` — single source of truth

`Sources/BaseChatInference/Models/ModelManifest.swift` carries the loaded model's true capabilities: `contextWindow`, `supportsTools`, `supportsThinking`, `thinkingMarkers`, `supportsSeed`, `supportedSamplingParameters` (`SamplingParameterSet` bitset), `modelIdentifier`, `producerKind`. `ModelManifest.unknown(modelIdentifier:)` provides a conservative fallback (8k context, no tools, no seed, only `temperature`/`topP`).

### `CloudModelManifestTable` — vendored prefix table

`Sources/BaseChatInference/Models/CloudModelManifestTable.swift` maps OpenAI / Claude model name prefixes to manifests (longest-prefix-wins). `o1`/`o3`/`o4` reasoning families correctly reject `seed`; Claude 4-class families advertise extended thinking; everything else lands on `unknown(...)`.

### Backend wiring

- **MLXBackend.produceManifest** reads `text_config.max_position_embeddings` (preferred), `max_position_embeddings`, or `model_max_length` and combines with the auto-detected thinking markers. `capabilities.maxContextTokens` now derives from the manifest.
- **LlamaBackend** captures `effectiveContextSize` + `autoDetectedThinkingMarkers` into a manifest at load time.
- **OllamaBackend**'s `/api/show` probe was widened from a thinking-only boolean to a `ShowProbe` struct: also pulls `model_info.context_length` (canonical or arch-prefixed `<arch>.context_length`) and the template-detected thinking markers. The inline-thinking fallback now consults `_autoDetectedThinkingMarkers` before falling back to `.qwen3`. `supportsThinking` is now reported on capabilities.
- **OpenAIBackend** gates `seed`, `presence_penalty`, `frequency_penalty`, `top_k` on the manifest's `supportsSeed` / `supportedSamplingParameters` — reasoning models (`o1`/`o3`) no longer get HTTP 400'd by sampler fields they reject.
- **ClaudeBackend** reports `supportsThinking` from the manifest table (Claude 4-class = true; Claude 3.5 = false).

### Protocol

`InferenceBackend` gains `var manifest: ModelManifest? { get }` with a default `nil` implementation — non-breaking for existing adopters; consumers fall back to `BackendCapabilities` when the manifest is absent.

## Why

Public API is preserved (`BackendCapabilities` shape unchanged), so this ships as `fix:`. The fix is the runtime wire-format correctness across four backends (one missing context probe + three model-name-aware request fields). Tests assert the cross-backend invariant going forward — any backend declaring `supportsThinking == true` must still pass the existing meta-contract.

## Tests

- `ModelManifestTests` + `CloudModelManifestTableTests` cover the type and longest-prefix lookup (16 cases).
- `MLXManifestProbeTests` builds synthetic `config.json` fixtures and asserts the probe extracts the right context window from canonical and `text_config`-nested paths.
- `OllamaManifestProbeTests` stubs `/api/show` responses and asserts the manifest picks up `context_length` (canonical + arch-prefixed) and the auto-detected marker pair.
- `OpenAIBackendManifestRequestTests` asserts `gpt-4o` emits `seed` + `presence/frequency_penalty` while `o1`/`o1-mini` omit them.
- `ModelManifestContractTests` asserts the manifest's `supportsThinking` is reflected on the real cloud backend's `BackendCapabilities`.
- Existing `BackendCapabilitiesContractTests` updated: cloud backends' `supportsThinking` now reflects the manifest table (Claude 4-class true, gpt-4o-mini false, Ollama-pre-load false).

## Test plan

- [x] `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` clean
- [x] Pre-push gate (XCTest invocation) — 2784 passed, 0 failures
- [x] Pre-push gate (Swift Testing invocation) — 83 passed, 0 failures
- [x] Trait-on backend tests (`MLX,Llama,Ollama,CloudSaaS`) — 795 passed, 0 failures
- [x] `SilentCatchAuditTest` — old `try?` allowlist entries removed, fix-pattern uses `do { try ... } catch { Log.network.info(...) }`

## Notes

- Two `try?` lines in `OllamaBackend` were promoted to `do/catch` with explicit `Log.network.info(...)`; corresponding allowlist entries removed.
- `ClaudeBackendConformanceTests` adds a `supportsThinking_claim` so the meta-contract sees the now-true flag.
- `Package.resolved` was not modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)