### PR TITLE
fix(backends): MLXResourceArbiter for per-instance cache accounting; ToolArgumentCoercer recurses into nested schemas

### DIFF
--- a/Sources/BaseChatBackends/MLX/MLXResourceArbiter.swift
+++ b/Sources/BaseChatBackends/MLX/MLXResourceArbiter.swift
@@ -1,0 +1,161 @@
+#if MLX
+import Foundation
+import MLX
+import os
+import BaseChatInference
+
+/// Coordinates MLX's process-global GPU buffer cache across multiple
+/// `MLXBackend` instances in the same host.
+///
+/// `MLX.Memory.cacheLimit` and `MLX.Memory.clearCache()` operate on a single
+/// process-wide pool. A naive multi-MLX setup — for example, a chat backend
+/// plus an embeddings backend, or two `MLXBackend`s loaded for A/B comparison
+/// — has the second `loadModel` overwrite the first's `cacheLimit`, and any
+/// `clearCache()` from one backend evicts pooled buffers that other backends
+/// depend on for KV-cache reuse. Both behaviours corrupt KV reuse silently.
+///
+/// The arbiter solves this by accumulating per-backend cache claims and
+/// programming `MLX.Memory.cacheLimit` to the **sum** of all active claims.
+/// `clearCache()` is only invoked on the **last** release — until every MLX
+/// backend has unloaded, the cache stays populated so other live backends
+/// keep their residue.
+///
+/// ## Metallib guard
+///
+/// Every call into `MLX.Memory` is conditioned on the caller having completed
+/// at least one successful `loadModelContainer` (the proxy is the caller — it
+/// only invokes `claim`/`release` after that gate). The arbiter itself trusts
+/// that contract and does not attempt to detect uninitialised runtime state.
+/// Calling `MLX.Memory.cacheLimit` before any model has loaded would trip a
+/// "Failed to load default metallib" abort in plain `swift test` environments.
+///
+/// ## Usage
+///
+/// ```swift
+/// // After loadModelContainer succeeds:
+/// await MLXResourceArbiter.shared.claim(
+///     backendID: backendID,
+///     requestedCacheBytes: cachePolicy.resolvedBytes()
+/// )
+///
+/// // In unloadModel / cleanup:
+/// await MLXResourceArbiter.shared.release(backendID: backendID)
+/// ```
+///
+/// All `MLXBackend` instances must coordinate through `shared`; mixing
+/// arbitrated and direct `MLX.Memory.*` calls in the same process defeats the
+/// accounting.
+public actor MLXResourceArbiter {
+
+    /// Stable per-backend identity used as the claim key.
+    public typealias BackendID = UUID
+
+    public static let shared = MLXResourceArbiter()
+
+    private static let logger = Logger(
+        subsystem: BaseChatConfiguration.shared.logSubsystem,
+        category: "mlx-arbiter"
+    )
+
+    /// Active claims, keyed by backend identity. Value is the requested
+    /// cache-bytes contribution from that backend.
+    private var claims: [BackendID: Int] = [:]
+
+    // MARK: - Test seams
+
+    /// Closure invoked to set MLX's process-global `cacheLimit`. Production
+    /// hits `MLX.Memory.cacheLimit = bytes`. Tests inject a stub so the
+    /// arbiter's accounting logic can run in `swift test` (where the
+    /// metallib isn't compiled and a real `MLX.Memory` access aborts the
+    /// process).
+    private var setCacheLimit: @Sendable (Int) -> Void = { Memory.cacheLimit = $0 }
+
+    /// Closure invoked to clear MLX's process-global pool. Mirrors
+    /// `setCacheLimit` for the same reason.
+    private var clearCache: @Sendable () -> Void = { Memory.clearCache() }
+
+    public init() {}
+
+    /// Test-only initialiser that lets the suite inject its own
+    /// `setCacheLimit` / `clearCache` recorders. Not exposed on `shared` —
+    /// tests that need an isolated arbiter construct a fresh instance.
+    init(
+        setCacheLimit: @escaping @Sendable (Int) -> Void,
+        clearCache: @escaping @Sendable () -> Void
+    ) {
+        self.setCacheLimit = setCacheLimit
+        self.clearCache = clearCache
+    }
+
+    /// Records a cache-bytes claim for `backendID` and reprograms
+    /// `MLX.Memory.cacheLimit` to the sum of all current claims.
+    ///
+    /// If `backendID` already has a claim, the existing value is replaced —
+    /// callers can re-issue with a different policy without an explicit
+    /// release first. Negative values are clamped to zero.
+    ///
+    /// - Important: Caller must have completed a successful
+    ///   `loadModelContainer` before invoking this. See the metallib guard
+    ///   note in the type-level documentation.
+    public func claim(backendID: BackendID, requestedCacheBytes: Int) {
+        let bytes = max(0, requestedCacheBytes)
+        claims[backendID] = bytes
+        let total = claims.values.reduce(0, +)
+        setCacheLimit(total)
+        Self.logger.info(
+            "MLX arbiter claim: backend=\(backendID, privacy: .public) bytes=\(bytes) total=\(total) activeClaims=\(self.claims.count)"
+        )
+    }
+
+    /// Releases the claim for `backendID`. If any other backends still hold
+    /// claims, `MLX.Memory.cacheLimit` is reduced to the new sum and pooled
+    /// buffers are left in place (they belong to the surviving backends).
+    /// On the last release, `MLX.Memory.clearCache()` is invoked so freed
+    /// buffers return to the OS.
+    ///
+    /// Idempotent: releasing a backend that holds no claim is a no-op.
+    public func release(backendID: BackendID) {
+        guard claims.removeValue(forKey: backendID) != nil else {
+            return
+        }
+        if claims.isEmpty {
+            clearCache()
+            Self.logger.info("MLX arbiter release: last backend, clearCache invoked")
+        } else {
+            let total = claims.values.reduce(0, +)
+            setCacheLimit(total)
+            Self.logger.info(
+                "MLX arbiter release: backend=\(backendID, privacy: .public) remaining=\(self.claims.count) total=\(total)"
+            )
+        }
+    }
+
+    /// Emergency hatch: drops every claim and calls `MLX.Memory.clearCache()`.
+    ///
+    /// Reserved for memory-pressure handlers that need to force a global
+    /// eviction across all MLX backends. After this returns, every backend
+    /// must re-claim before its next generate call would be safe.
+    public func clearAll() {
+        let count = claims.count
+        claims.removeAll(keepingCapacity: false)
+        clearCache()
+        Self.logger.info("MLX arbiter clearAll: dropped \(count) claims")
+    }
+
+    // MARK: - Test seams
+
+    /// Test-only read of the active claim count. Used by
+    /// `MLXResourceArbiterTests` to verify accounting without exposing the
+    /// claims map.
+    func _activeClaimCountForTesting() -> Int {
+        claims.count
+    }
+
+    /// Test-only read of the summed claim bytes. Callers that exercise the
+    /// arbiter without a live MLX runtime must use this rather than reading
+    /// `MLX.Memory.cacheLimit` (which requires the metallib).
+    func _totalClaimedBytesForTesting() -> Int {
+        claims.values.reduce(0, +)
+    }
+}
+#endif

--- a/Sources/BaseChatBackends/MLXBackend.swift
+++ b/Sources/BaseChatBackends/MLXBackend.swift
@@ -1,6 +1,10 @@
 #if MLX
 import CoreImage
 import Foundation
+// Direct `MLX.Memory.cacheLimit` / `MLX.Memory.clearCache()` calls from this
+// file are forbidden — the cache is process-global and must be coordinated
+// across multiple MLX backends via `MLXResourceArbiter.shared`. See
+// `MLX/MLXResourceArbiter.swift` for the rationale.
 import MLX
 import MLXLLM
 import MLXLMCommon
@@ -94,7 +98,8 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 isRemote: false,
                 supportsKVCachePersistence: enableKVCacheReuse,
                 supportsThinking: true,
-                supportsVision: _supportsVision
+                supportsVision: _supportsVision,
+                sharesMLXProcessResources: true
             )
         }
     }
@@ -140,6 +145,10 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
     /// Tracks whether a real MLX model load initialized the runtime in this process.
     /// Access only under `stateLock`.
     private var _hasInitializedRuntime = false
+    /// Stable per-instance identity used by `MLXResourceArbiter` to track
+    /// which backend holds which slice of the process-global cache budget.
+    /// Generated once at init; never changes.
+    private let backendID: MLXResourceArbiter.BackendID = UUID()
     /// Whether the currently loaded MLX model accepts image inputs.
     /// Access only under `stateLock`.
     private var _supportsVision = false
@@ -949,9 +958,17 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             // (e.g. `swift test`). The cost is that the load itself runs
             // under whatever cacheLimit was previously in effect — usually
             // mlx-swift's own default on a fresh process, which is fine.
+            //
+            // The cache is process-global; route through `MLXResourceArbiter`
+            // so multi-backend hosts (chat + embeddings, A/B comparisons)
+            // accumulate per-instance claims rather than overwriting each
+            // other's `cacheLimit`.
             let cacheBytes = cachePolicy.resolvedBytes()
-            Memory.cacheLimit = cacheBytes
-            Self.logger.info("MLX cache limit set to \(cacheBytes / (1024 * 1024)) MB (policy: \(String(describing: self.cachePolicy)))")
+            await MLXResourceArbiter.shared.claim(
+                backendID: backendID,
+                requestedCacheBytes: cacheBytes
+            )
+            Self.logger.info("MLX cache claim registered: \(cacheBytes / (1024 * 1024)) MB (policy: \(String(describing: self.cachePolicy)))")
             isModelLoaded = true
             // Signal load complete before returning so InferenceService sees 1.0
             // before it clears the handler and flips isModelLoaded.
@@ -1237,8 +1254,9 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         stopGeneration()
         // Only touch MLX's Memory namespace after a real model load has
         // initialized the runtime in this process. Injected test doubles do not
-        // compile the metallib, so clearing the cache after `_inject(...)`
-        // would trip the same failure this guard exists to avoid.
+        // compile the metallib, so releasing the arbiter claim after
+        // `_inject(...)` would trip the same failure this guard exists to
+        // avoid (the arbiter calls `Memory.clearCache()` on the last release).
         let hadInitializedRuntime: Bool = withStateLock {
             let had = _hasInitializedRuntime
             _modelContainer = nil
@@ -1257,7 +1275,14 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             return had
         }
         if hadInitializedRuntime {
-            Memory.clearCache()
+            // Fire-and-forget: the protocol contract for `unloadModel()` is
+            // synchronous, but cache eviction does not need to block teardown.
+            // The arbiter clears `MLX.Memory` only on the last release; while
+            // sibling MLX backends are still loaded, this preserves their
+            // pooled buffers — that's the whole point of routing through the
+            // arbiter rather than calling `Memory.clearCache()` directly.
+            let id = backendID
+            Task { await MLXResourceArbiter.shared.release(backendID: id) }
         }
         Self.logger.info("MLX backend unloaded")
     }
@@ -1291,10 +1316,10 @@ extension MLXBackend {
     ///
     /// MLX does not expose an API to explicitly zero Metal `MTLBuffer` contents
     /// after the fact; the best available measure is to evict all pooled buffers
-    /// via `Memory.clearCache()` so they are returned to the OS rather than
-    /// reused by the next request. This is the same call made by
-    /// ``unloadModel()``. The prompt-cache state is also invalidated so the next
-    /// ``generate(_:config:)`` call starts fresh.
+    /// (`MLX.Memory.clearCache()` under the hood, routed through
+    /// ``MLXResourceArbiter/clearAll()``) so they are returned to the OS rather
+    /// than reused by the next request. The prompt-cache state is also
+    /// invalidated so the next ``generate(_:config:)`` call starts fresh.
     ///
     /// **Note**: this provides an eviction guarantee, NOT a zero guarantee. Any
     /// residue in currently-active Metal allocations (e.g. mid-stream) is
@@ -1306,7 +1331,13 @@ extension MLXBackend {
         }
         #if MLX
         if hasRuntime {
-            Memory.clearCache()
+            // `secureWipe` is an explicit eviction request — the docstring
+            // promises the pooled buffers are returned to the OS. Because the
+            // pool is process-global, partial scrubbing isn't possible: route
+            // through `clearAll` so the arbiter drops accounting state too,
+            // and surviving sibling backends will re-claim on their next
+            // load.
+            Task { await MLXResourceArbiter.shared.clearAll() }
         }
         #endif
     }

--- a/Sources/BaseChatInference/Protocols/BackendCapabilities.swift
+++ b/Sources/BaseChatInference/Protocols/BackendCapabilities.swift
@@ -138,6 +138,22 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
     /// Whether the backend supports Foundation-style guided structured output.
     public let supportsGuidedStructuredOutput: Bool
 
+    /// `true` when the backend uses MLX's process-global resources — the GPU
+    /// buffer cache (`MLX.Memory.cacheLimit`), the Metal device, and the MLX
+    /// runtime singleton — and must coordinate with `MLXResourceArbiter` for
+    /// safe multi-backend hosting in the same process.
+    ///
+    /// Hosts loading multiple MLX-family backends concurrently (e.g. a chat
+    /// LLM plus an MLX embedding model) read this flag to decide whether to
+    /// serialize lifecycle hooks or assume the backends are independent.
+    /// For single-MLX setups the flag is informational; for multi-MLX it
+    /// signals that direct `MLX.Memory.*` calls from sibling code would
+    /// trample the arbiter's per-instance accounting.
+    ///
+    /// Defaults to `false` — only the MLX backend (and any future backends
+    /// sharing the MLX runtime) sets this to `true`.
+    public let sharesMLXProcessResources: Bool
+
     /// Preferred structured-output mechanism implied by this capability set.
     public var preferredStructuredOutputSupport: StructuredOutputSupport {
         if supportsGrammarConstrainedSampling {
@@ -177,7 +193,8 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         supportsVision: Bool = false,
         streamsToolCallArguments: Bool = false,
         supportsParallelToolCalls: Bool = false,
-        supportsGuidedStructuredOutput: Bool = false
+        supportsGuidedStructuredOutput: Bool = false,
+        sharesMLXProcessResources: Bool = false
     ) {
         self.supportedParameters = supportedParameters
         self.maxContextTokens = maxContextTokens
@@ -199,6 +216,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         self.streamsToolCallArguments = streamsToolCallArguments
         self.supportsParallelToolCalls = supportsParallelToolCalls
         self.supportsGuidedStructuredOutput = supportsGuidedStructuredOutput
+        self.sharesMLXProcessResources = sharesMLXProcessResources
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -222,6 +240,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         case streamsToolCallArguments
         case supportsParallelToolCalls
         case supportsGuidedStructuredOutput
+        case sharesMLXProcessResources
     }
 
     public init(from decoder: Decoder) throws {
@@ -246,6 +265,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         streamsToolCallArguments = (try c.decodeIfPresent(Bool.self, forKey: .streamsToolCallArguments)) ?? false
         supportsParallelToolCalls = (try c.decodeIfPresent(Bool.self, forKey: .supportsParallelToolCalls)) ?? false
         supportsGuidedStructuredOutput = (try c.decodeIfPresent(Bool.self, forKey: .supportsGuidedStructuredOutput)) ?? false
+        sharesMLXProcessResources = (try c.decodeIfPresent(Bool.self, forKey: .sharesMLXProcessResources)) ?? false
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -270,5 +290,6 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         try c.encode(streamsToolCallArguments, forKey: .streamsToolCallArguments)
         try c.encode(supportsParallelToolCalls, forKey: .supportsParallelToolCalls)
         try c.encode(supportsGuidedStructuredOutput, forKey: .supportsGuidedStructuredOutput)
+        try c.encode(sharesMLXProcessResources, forKey: .sharesMLXProcessResources)
     }
 }

--- a/Sources/BaseChatInference/Services/ToolArgumentCoercer.swift
+++ b/Sources/BaseChatInference/Services/ToolArgumentCoercer.swift
@@ -1,9 +1,21 @@
 import Foundation
 
+// MARK: - ToolArgumentError
+
+/// Errors surfaced by ``ToolArgumentCoercer`` when the schema or argument tree
+/// violates a structural invariant the coercer cannot recover from.
+enum ToolArgumentError: Error, Equatable {
+    /// The input schema or arguments exceed ``ToolArgumentCoercer/maxDepth``.
+    /// Pathologically nested or self-referential schemas would otherwise blow
+    /// the coercer's stack; failing fast forces the caller to surface a real
+    /// diagnostic rather than crashing inside the dispatch hot path.
+    case schemaTooDeep
+}
+
 // MARK: - ToolArgumentCoercer
 
-/// Coerces top-level string-typed arguments to the primitive type declared in
-/// a JSON Schema's `properties` map.
+/// Coerces string-typed arguments to the primitive type declared in a JSON
+/// Schema's `properties` map.
 ///
 /// Models — especially smaller open-weight ones — frequently emit
 /// JSON-encoded tool arguments where every value is a string, even when the
@@ -12,28 +24,87 @@ import Foundation
 /// the user sees a hard failure for what is effectively a serialisation
 /// quirk.
 ///
-/// Behaviour mirrors Goose AI's `coerce_tool_arguments` helper
-/// (`crates/goose/src/agents/reply_parts.rs`):
+/// ## Recursion
 ///
-/// - Coercion only runs at the top level of `properties`. Nested objects
-///   and arrays pass through unchanged — matching Goose's scope, and
-///   keeping the cost bounded so the coercer is safe to run on every
-///   dispatch.
+/// As of I3, coercion descends into nested objects and arrays of objects up
+/// to ``maxDepth``. Schemas that declare
+///
+/// ```json
+/// { "properties": { "filter": { "type": "object",
+///   "properties": { "limit": { "type": "integer" } } } } }
+/// ```
+///
+/// now coerce `{"filter":{"limit":"10"}}` to `{"filter":{"limit":10}}`. Small
+/// open-weight models — the explicit motivating case for this coercer —
+/// mistype nested fields more often than top-level ones, so the original
+/// "top-level only" scope shipped with a known false-rejection rate that
+/// was not justified by any safety property.
+///
+/// ## Bounded depth
+///
+/// The recursion is hard-capped at ``maxDepth`` (8) levels. A schema deeper
+/// than that throws ``ToolArgumentError/schemaTooDeep`` so callers surface a
+/// precise failure rather than a stack overflow. Real tool schemas in
+/// practice rarely exceed three or four levels — the cap exists to bound
+/// adversarial inputs, not to limit legitimate use.
+///
+/// ## Behaviour
+///
 /// - Strings that fail to parse fall through unchanged so the validator
 ///   still produces its real error message.
 /// - Already-correct types (an actual JSON number against a `number`
 ///   schema, etc.) pass through untouched.
+/// - Schemas without a `properties` map (or non-object inputs) pass
+///   through unchanged.
 ///
 /// The coercer is intentionally a free namespace rather than a stored
 /// dependency on ``ToolRegistry``: it has no state and no allocation cost
 /// on the no-op path.
 enum ToolArgumentCoercer {
 
-    /// Returns `value` with top-level string entries coerced to match the
-    /// primitive types declared in `schema.properties`. Inputs that aren't
-    /// objects, or schemas without a `properties` map, pass through
-    /// unchanged.
-    static func coerce(_ value: JSONSchemaValue, against schema: JSONSchemaValue) -> JSONSchemaValue {
+    /// Maximum recursion depth before the coercer throws
+    /// ``ToolArgumentError/schemaTooDeep``. Eight levels covers every
+    /// real-world tool schema observed in practice; the cap exists to
+    /// bound stack usage on adversarial / pathological inputs.
+    static let maxDepth: Int = 8
+
+    /// Returns `value` with string entries coerced to match the primitive
+    /// types declared in `schema.properties`, recursing into nested objects
+    /// and arrays of objects up to ``maxDepth``.
+    ///
+    /// Inputs that aren't objects, or schemas without a `properties` map,
+    /// pass through unchanged. Throws ``ToolArgumentError/schemaTooDeep`` if
+    /// the schema or argument tree exceeds the depth cap.
+    static func coerce(
+        _ value: JSONSchemaValue,
+        against schema: JSONSchemaValue
+    ) throws -> JSONSchemaValue {
+        try coerceObject(value, against: schema, depth: 0)
+    }
+
+    /// Convenience wrapper that swallows ``ToolArgumentError/schemaTooDeep``
+    /// and returns the original `value`. Use when the call site wants the
+    /// coercion to be fully best-effort — the validator will then surface
+    /// whatever real error the un-coerced arguments produce.
+    static func coerceBestEffort(
+        _ value: JSONSchemaValue,
+        against schema: JSONSchemaValue
+    ) -> JSONSchemaValue {
+        do {
+            return try coerce(value, against: schema)
+        } catch {
+            return value
+        }
+    }
+
+    // MARK: - Recursion core
+
+    private static func coerceObject(
+        _ value: JSONSchemaValue,
+        against schema: JSONSchemaValue,
+        depth: Int
+    ) throws -> JSONSchemaValue {
+        guard depth <= maxDepth else { throw ToolArgumentError.schemaTooDeep }
         guard case .object(let args) = value else { return value }
         guard case .object(let schemaObject) = schema,
               case .object(let properties) = schemaObject["properties"] ?? .null
@@ -44,14 +115,100 @@ enum ToolArgumentCoercer {
         var coerced: [String: JSONSchemaValue] = [:]
         coerced.reserveCapacity(args.count)
         for (key, argValue) in args {
-            if case .string(let s) = argValue, let propertySchema = properties[key] {
-                coerced[key] = coerceScalar(s, against: propertySchema)
-            } else {
+            guard let propertySchema = properties[key] else {
                 coerced[key] = argValue
+                continue
             }
+            coerced[key] = try coerceValue(argValue, against: propertySchema, depth: depth + 1)
         }
         return .object(coerced)
     }
+
+    private static func coerceValue(
+        _ value: JSONSchemaValue,
+        against schema: JSONSchemaValue,
+        depth: Int
+    ) throws -> JSONSchemaValue {
+        guard depth <= maxDepth else { throw ToolArgumentError.schemaTooDeep }
+        switch value {
+        case .string(let s):
+            return coerceScalar(s, against: schema)
+        case .object:
+            // Recurse into a nested object only when the schema also declares
+            // an object shape. Otherwise the original value passes through —
+            // the validator will surface the type mismatch with its native
+            // message.
+            if isObjectSchema(schema) {
+                return try coerceObject(value, against: schema, depth: depth)
+            }
+            return value
+        case .array(let elements):
+            // Recurse into each element when the schema's `items` shape is an
+            // object. JSON Schema allows `items` to be either a sub-schema
+            // object (homogeneous list) or an array of sub-schemas (tuple
+            // form, draft-04 / 2019-09); we handle both.
+            return try coerceArray(elements, against: schema, depth: depth)
+        case .number, .bool, .null:
+            return value
+        }
+    }
+
+    private static func coerceArray(
+        _ elements: [JSONSchemaValue],
+        against schema: JSONSchemaValue,
+        depth: Int
+    ) throws -> JSONSchemaValue {
+        guard case .object(let schemaObject) = schema,
+              let itemsValue = schemaObject["items"]
+        else {
+            return .array(elements)
+        }
+        switch itemsValue {
+        case .object:
+            // Single sub-schema — apply to every element.
+            var coerced: [JSONSchemaValue] = []
+            coerced.reserveCapacity(elements.count)
+            for element in elements {
+                coerced.append(try coerceValue(element, against: itemsValue, depth: depth + 1))
+            }
+            return .array(coerced)
+        case .array(let perIndexSchemas):
+            // Tuple form: pair each element with the schema at its index.
+            // Elements past the schema array fall through unchanged — that's
+            // what JSON Schema's `additionalItems: true` (the default) means.
+            var coerced: [JSONSchemaValue] = []
+            coerced.reserveCapacity(elements.count)
+            for (index, element) in elements.enumerated() {
+                if index < perIndexSchemas.count {
+                    coerced.append(try coerceValue(element, against: perIndexSchemas[index], depth: depth + 1))
+                } else {
+                    coerced.append(element)
+                }
+            }
+            return .array(coerced)
+        default:
+            return .array(elements)
+        }
+    }
+
+    /// Returns `true` when `schema` declares `type: object` — gates whether
+    /// nested-object recursion fires. Without this check we'd happily descend
+    /// into a property whose schema is just `{ "type": "string" }` and an
+    /// argument that surprised us with an object value, which would silently
+    /// rewrite the keys and mask a real validator failure.
+    private static func isObjectSchema(_ schema: JSONSchemaValue) -> Bool {
+        guard case .object(let dict) = schema else { return false }
+        guard case .string(let typeName) = dict["type"] ?? .null else {
+            // No declared `type` — be permissive: if the schema has a
+            // `properties` map, treat it as an object. This matches the
+            // behaviour many JSON-schema validators take for under-specified
+            // sub-schemas.
+            return dict["properties"] != nil
+        }
+        return typeName == "object"
+    }
+
+    // MARK: - Scalar coercion
 
     /// Coerces a single string against a property's declared `type`.
     ///

--- a/Sources/BaseChatInference/Services/ToolRegistry.swift
+++ b/Sources/BaseChatInference/Services/ToolRegistry.swift
@@ -367,9 +367,15 @@ public protocol JSONSchemaValidating: Sendable {
         // that small models emit `"42"` and the tool wants `42`, so the
         // executor must see the coerced form. Tools that need the raw
         // string can opt out by clearing ``coercesArguments``.
+        //
+        // `coerceBestEffort` swallows ``ToolArgumentError/schemaTooDeep``:
+        // a pathologically deep schema falls through to the validator with
+        // un-coerced args, which then surfaces whatever real error the
+        // schema produces. We don't want a depth cap to short-circuit
+        // dispatch on a schema the validator might still accept.
         let dispatchArguments: JSONSchemaValue
         if coercesArguments {
-            dispatchArguments = ToolArgumentCoercer.coerce(parsedArguments, against: executor.definition.parameters)
+            dispatchArguments = ToolArgumentCoercer.coerceBestEffort(parsedArguments, against: executor.definition.parameters)
         } else {
             dispatchArguments = parsedArguments
         }

--- a/Tests/APIFreezeTests/Fixtures/PublicSurfaceConsumer.swift
+++ b/Tests/APIFreezeTests/Fixtures/PublicSurfaceConsumer.swift
@@ -92,7 +92,8 @@ enum PublicSurfaceConsumer {
             supportsVision: false,
             streamsToolCallArguments: false,
             supportsParallelToolCalls: false,
-            supportsGuidedStructuredOutput: false
+            supportsGuidedStructuredOutput: false,
+            sharesMLXProcessResources: false
         )
 
         // Computed property accessors — host code reads these.

--- a/Tests/BaseChatBackendsTests/BackendCapabilitiesContractTests.swift
+++ b/Tests/BaseChatBackendsTests/BackendCapabilitiesContractTests.swift
@@ -147,6 +147,16 @@ final class BackendCapabilitiesContractTests: XCTestCase {
         XCTAssertTrue(MLXBackend().capabilities.supportsThinking,
                       "MLXBackend emits thinking events via ThinkingParser — supportsThinking must be true")
     }
+
+    /// MLXBackend uses MLX's process-global GPU buffer cache and Metal
+    /// device — it must coordinate with `MLXResourceArbiter` for safe
+    /// multi-backend hosting. See `MLXResourceArbiter.swift` for details.
+    func test_mlxBackend_sharesMLXProcessResources() throws {
+        try XCTSkipUnless(HardwareRequirements.isAppleSilicon,
+                          "MLXBackend requires Apple Silicon")
+        XCTAssertTrue(MLXBackend().capabilities.sharesMLXProcessResources,
+                      "MLXBackend uses MLX.Memory.cacheLimit — sharesMLXProcessResources must be true")
+    }
 #endif
 
 #if canImport(FoundationModels)

--- a/Tests/BaseChatBackendsTests/MLXResourceArbiterTests.swift
+++ b/Tests/BaseChatBackendsTests/MLXResourceArbiterTests.swift
@@ -1,0 +1,226 @@
+#if MLX
+import XCTest
+@testable import BaseChatBackends
+
+/// Unit tests for ``MLXResourceArbiter`` — the per-instance cache-claim
+/// accounting that prevents multi-MLX hosts from trampling each other's
+/// `MLX.Memory.cacheLimit` and prematurely evicting KV-cache residue.
+///
+/// The arbiter exposes a test-only init that injects recorder closures in
+/// place of the real `MLX.Memory.cacheLimit` setter and `clearCache()`
+/// invocation. This is required because plain `swift test` doesn't compile
+/// the metallib — calling into `MLX.Memory` outside a real model load aborts
+/// the process with "Failed to load default metallib" (per CLAUDE.md
+/// hardware constraints).
+///
+/// Real-MLX integration coverage of the arbiter→runtime path lives with
+/// `BaseChatMLXIntegrationTests` (Xcode-only).
+final class MLXResourceArbiterTests: XCTestCase {
+
+    /// Thread-safe recorder for the closures the arbiter invokes — actor
+    /// isolation in the arbiter means writes happen serialized, but the
+    /// reads from the test body need cross-actor safety too.
+    final class Recorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _setCalls: [Int] = []
+        private var _clearCount: Int = 0
+
+        var setCalls: [Int] {
+            lock.lock(); defer { lock.unlock() }
+            return _setCalls
+        }
+
+        var clearCount: Int {
+            lock.lock(); defer { lock.unlock() }
+            return _clearCount
+        }
+
+        func recordSet(_ bytes: Int) {
+            lock.lock(); defer { lock.unlock() }
+            _setCalls.append(bytes)
+        }
+
+        func recordClear() {
+            lock.lock(); defer { lock.unlock() }
+            _clearCount += 1
+        }
+    }
+
+    /// Builds a fresh arbiter wired to a recorder. Returning the recorder
+    /// strongly so the test can inspect it after the arbiter awaits.
+    private func makeArbiter() -> (MLXResourceArbiter, Recorder) {
+        let recorder = Recorder()
+        let arbiter = MLXResourceArbiter(
+            setCacheLimit: { [recorder] bytes in recorder.recordSet(bytes) },
+            clearCache: { [recorder] in recorder.recordClear() }
+        )
+        return (arbiter, recorder)
+    }
+
+    // MARK: - Single-backend lifecycle
+
+    func test_singleBackend_claimSetsCacheLimit_releaseClearsCache() async {
+        let (arbiter, recorder) = makeArbiter()
+        let id = UUID()
+
+        await arbiter.claim(backendID: id, requestedCacheBytes: 256 * 1024 * 1024)
+        XCTAssertEqual(recorder.setCalls, [256 * 1024 * 1024])
+        XCTAssertEqual(recorder.clearCount, 0)
+        let activeAfterClaim = await arbiter._activeClaimCountForTesting()
+        XCTAssertEqual(activeAfterClaim, 1)
+
+        await arbiter.release(backendID: id)
+        XCTAssertEqual(recorder.clearCount, 1, "last release must invoke clearCache")
+        // cacheLimit setter must NOT fire on the last release — clearCache
+        // is the terminal call.
+        XCTAssertEqual(recorder.setCalls.count, 1)
+        let activeAfterRelease = await arbiter._activeClaimCountForTesting()
+        XCTAssertEqual(activeAfterRelease, 0)
+    }
+
+    // MARK: - Two-backend overlap (the I3 motivating bug)
+
+    /// The bug: backend A claims 200 MB, backend B claims 300 MB; the naive
+    /// implementation overwrites A's limit with B's value. The arbiter
+    /// instead programs the sum (500 MB).
+    func test_twoBackends_claimSetsLimitToSum() async {
+        let (arbiter, recorder) = makeArbiter()
+        let a = UUID()
+        let b = UUID()
+
+        await arbiter.claim(backendID: a, requestedCacheBytes: 200)
+        await arbiter.claim(backendID: b, requestedCacheBytes: 300)
+
+        XCTAssertEqual(recorder.setCalls, [200, 500],
+                       "second claim must reflect sum of A+B, not just B")
+        let totalBytes = await arbiter._totalClaimedBytesForTesting()
+        XCTAssertEqual(totalBytes, 500)
+    }
+
+    /// Releasing one backend out of two: cacheLimit drops to the survivor's
+    /// claim; clearCache must NOT fire (the surviving backend's pooled
+    /// buffers are still in use).
+    func test_twoBackends_releaseOneKeepsOtherBacked() async {
+        let (arbiter, recorder) = makeArbiter()
+        let a = UUID()
+        let b = UUID()
+        await arbiter.claim(backendID: a, requestedCacheBytes: 200)
+        await arbiter.claim(backendID: b, requestedCacheBytes: 300)
+
+        await arbiter.release(backendID: a)
+
+        XCTAssertEqual(recorder.setCalls, [200, 500, 300],
+                       "release of A must reduce limit to B's claim, not clear")
+        XCTAssertEqual(recorder.clearCount, 0,
+                       "clearCache must not fire while B still holds a claim")
+    }
+
+    /// Two-backend full lifecycle: A and B claim, A releases (cache stays),
+    /// B releases (cache clears).
+    func test_twoBackends_fullLifecycleClearsOnLastRelease() async {
+        let (arbiter, recorder) = makeArbiter()
+        let a = UUID()
+        let b = UUID()
+
+        await arbiter.claim(backendID: a, requestedCacheBytes: 200)
+        await arbiter.claim(backendID: b, requestedCacheBytes: 300)
+        await arbiter.release(backendID: a)
+        await arbiter.release(backendID: b)
+
+        XCTAssertEqual(recorder.clearCount, 1, "clearCache fires exactly once on last release")
+        XCTAssertEqual(recorder.setCalls, [200, 500, 300])
+    }
+
+    // MARK: - Three-backend stress
+
+    /// Three backends claim, then release in arbitrary order. The cacheLimit
+    /// must always reflect the sum of survivors; clearCache must fire only
+    /// once and only on the last release.
+    func test_threeBackends_releaseInArbitraryOrder() async {
+        let (arbiter, recorder) = makeArbiter()
+        let a = UUID()
+        let b = UUID()
+        let c = UUID()
+
+        await arbiter.claim(backendID: a, requestedCacheBytes: 100)
+        await arbiter.claim(backendID: b, requestedCacheBytes: 200)
+        await arbiter.claim(backendID: c, requestedCacheBytes: 400)
+        // Cumulative claim totals: 100, 300, 700
+        XCTAssertEqual(recorder.setCalls, [100, 300, 700])
+
+        // Release B first: 100 + 400 = 500
+        await arbiter.release(backendID: b)
+        // Release A next: 0 + 400 = 400
+        await arbiter.release(backendID: a)
+        // Release C last: clearCache.
+        await arbiter.release(backendID: c)
+
+        XCTAssertEqual(recorder.setCalls, [100, 300, 700, 500, 400],
+                       "every non-final release reprograms limit to surviving sum")
+        XCTAssertEqual(recorder.clearCount, 1, "clearCache fires exactly once")
+    }
+
+    // MARK: - Idempotence + replacement
+
+    /// Re-claiming with the same backend ID replaces the previous value
+    /// rather than double-counting.
+    func test_reclaim_replacesPreviousValue() async {
+        let (arbiter, recorder) = makeArbiter()
+        let id = UUID()
+
+        await arbiter.claim(backendID: id, requestedCacheBytes: 100)
+        await arbiter.claim(backendID: id, requestedCacheBytes: 250)
+
+        XCTAssertEqual(recorder.setCalls, [100, 250],
+                       "second claim from same backend replaces, not adds")
+        let total = await arbiter._totalClaimedBytesForTesting()
+        XCTAssertEqual(total, 250)
+    }
+
+    /// Releasing a backend that holds no claim is a no-op — neither setter
+    /// nor clear fires, and any active claims survive.
+    func test_releaseUnknownID_isNoOp() async {
+        let (arbiter, recorder) = makeArbiter()
+        let real = UUID()
+        await arbiter.claim(backendID: real, requestedCacheBytes: 100)
+
+        await arbiter.release(backendID: UUID())
+
+        XCTAssertEqual(recorder.setCalls, [100], "no extra setCacheLimit on unknown release")
+        XCTAssertEqual(recorder.clearCount, 0, "clearCache must not fire if real claim still active")
+        let total = await arbiter._totalClaimedBytesForTesting()
+        XCTAssertEqual(total, 100)
+    }
+
+    /// Negative requested bytes clamp to zero (defence-in-depth — the real
+    /// `MLX.Memory.cacheLimit` setter accepts an `Int` but a negative value
+    /// is meaningless).
+    func test_negativeBytes_clampToZero() async {
+        let (arbiter, recorder) = makeArbiter()
+        let id = UUID()
+
+        await arbiter.claim(backendID: id, requestedCacheBytes: -100)
+
+        XCTAssertEqual(recorder.setCalls, [0])
+    }
+
+    // MARK: - clearAll
+
+    func test_clearAll_dropsAllClaimsAndInvokesClear() async {
+        let (arbiter, recorder) = makeArbiter()
+        let a = UUID()
+        let b = UUID()
+        await arbiter.claim(backendID: a, requestedCacheBytes: 100)
+        await arbiter.claim(backendID: b, requestedCacheBytes: 200)
+
+        await arbiter.clearAll()
+
+        XCTAssertEqual(recorder.clearCount, 1)
+        let active = await arbiter._activeClaimCountForTesting()
+        XCTAssertEqual(active, 0)
+        // Subsequent release of a or b must be a no-op.
+        await arbiter.release(backendID: a)
+        XCTAssertEqual(recorder.clearCount, 1, "release after clearAll must not double-clear")
+    }
+}
+#endif

--- a/Tests/BaseChatInferenceTests/ToolArgumentCoercerNestedTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolArgumentCoercerNestedTests.swift
@@ -1,0 +1,360 @@
+import XCTest
+@testable import BaseChatInference
+
+/// Tests for ``ToolArgumentCoercer``'s nested-recursion contract introduced
+/// in I3. Coverage:
+/// - single-level nesting (`{filter: {limit: "10"}}`)
+/// - two-level nesting (`{user: {prefs: {age: "42"}}}`)
+/// - arrays of objects (`{items: [{n: "1"}]}`)
+/// - tuple-form arrays
+/// - depth cap throws ``ToolArgumentError/schemaTooDeep``
+/// - non-object schemas at recursion sites pass through
+/// - already-correct nested types untouched
+///
+/// Top-level-only behaviour is exercised by ``ToolArgumentCoercerTests``;
+/// this file is purely about the recursive descent and its bounds.
+final class ToolArgumentCoercerNestedTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func intProp() -> JSONSchemaValue { .object(["type": .string("integer")]) }
+    private func numProp() -> JSONSchemaValue { .object(["type": .string("number")]) }
+    private func boolProp() -> JSONSchemaValue { .object(["type": .string("boolean")]) }
+    private func stringProp() -> JSONSchemaValue { .object(["type": .string("string")]) }
+
+    /// Builds a schema of shape `{ "type": "object", "properties": { ... } }`.
+    private func objectSchema(_ properties: [String: JSONSchemaValue]) -> JSONSchemaValue {
+        .object([
+            "type": .string("object"),
+            "properties": .object(properties)
+        ])
+    }
+
+    private func topSchema(_ properties: [String: JSONSchemaValue]) -> JSONSchemaValue {
+        objectSchema(properties)
+    }
+
+    // MARK: - single-level nesting
+
+    /// The motivating case: an LLM emits `{"filter":{"limit":"10"}}` against
+    /// a schema that declares `filter.limit: integer`. Without nested
+    /// coercion, this hits the validator as a string and fails despite being
+    /// trivially type-coercible.
+    func test_singleLevelNesting_coercesNestedInteger() throws {
+        let filterSchema = objectSchema(["limit": intProp()])
+        let schema = topSchema(["filter": filterSchema])
+        let args: JSONSchemaValue = .object([
+            "filter": .object(["limit": .string("10")])
+        ])
+
+        let result = try ToolArgumentCoercer.coerce(args, against: schema)
+
+        XCTAssertEqual(result, .object([
+            "filter": .object(["limit": .number(10)])
+        ]))
+    }
+
+    /// All three primitive coercions fire inside a nested object.
+    func test_singleLevelNesting_coercesAllPrimitives() throws {
+        let inner = objectSchema([
+            "age": intProp(),
+            "score": numProp(),
+            "active": boolProp()
+        ])
+        let schema = topSchema(["data": inner])
+        let args: JSONSchemaValue = .object([
+            "data": .object([
+                "age": .string("42"),
+                "score": .string("3.14"),
+                "active": .string("true")
+            ])
+        ])
+
+        let result = try ToolArgumentCoercer.coerce(args, against: schema)
+
+        XCTAssertEqual(result, .object([
+            "data": .object([
+                "age": .number(42),
+                "score": .number(3.14),
+                "active": .bool(true)
+            ])
+        ]))
+    }
+
+    // MARK: - two-level nesting
+
+    func test_twoLevelNesting_coercesDeeplyNestedField() throws {
+        let prefsSchema = objectSchema(["age": intProp()])
+        let userSchema = objectSchema(["prefs": prefsSchema])
+        let schema = topSchema(["user": userSchema])
+        let args: JSONSchemaValue = .object([
+            "user": .object([
+                "prefs": .object(["age": .string("42")])
+            ])
+        ])
+
+        let result = try ToolArgumentCoercer.coerce(args, against: schema)
+
+        XCTAssertEqual(result, .object([
+            "user": .object([
+                "prefs": .object(["age": .number(42)])
+            ])
+        ]))
+    }
+
+    // MARK: - arrays of objects
+
+    func test_arrayOfObjects_coercesEachElement() throws {
+        let itemSchema = objectSchema(["n": intProp()])
+        let schema: JSONSchemaValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "items": .object([
+                    "type": .string("array"),
+                    "items": itemSchema
+                ])
+            ])
+        ])
+        let args: JSONSchemaValue = .object([
+            "items": .array([
+                .object(["n": .string("1")]),
+                .object(["n": .string("2")])
+            ])
+        ])
+
+        let result = try ToolArgumentCoercer.coerce(args, against: schema)
+
+        XCTAssertEqual(result, .object([
+            "items": .array([
+                .object(["n": .number(1)]),
+                .object(["n": .number(2)])
+            ])
+        ]))
+    }
+
+    /// Tuple-form `items` (an array of per-index sub-schemas) — a draft-04 /
+    /// 2019-09 shape some tool authors still use. Each element must coerce
+    /// against its positional schema; elements past the schema array pass
+    /// through unchanged.
+    func test_arrayOfObjects_tupleForm_coercesByIndex() throws {
+        let firstSchema = objectSchema(["a": intProp()])
+        let secondSchema = objectSchema(["b": boolProp()])
+        let schema: JSONSchemaValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "items": .object([
+                    "type": .string("array"),
+                    "items": .array([firstSchema, secondSchema])
+                ])
+            ])
+        ])
+        let args: JSONSchemaValue = .object([
+            "items": .array([
+                .object(["a": .string("7")]),
+                .object(["b": .string("true")]),
+                .object(["c": .string("untouched")])
+            ])
+        ])
+
+        let result = try ToolArgumentCoercer.coerce(args, against: schema)
+
+        XCTAssertEqual(result, .object([
+            "items": .array([
+                .object(["a": .number(7)]),
+                .object(["b": .bool(true)]),
+                .object(["c": .string("untouched")])
+            ])
+        ]))
+    }
+
+    /// Array of scalars (not objects): each scalar coerces against the
+    /// element schema. Without this branch, an LLM emitting
+    /// `{"counts": ["1", "2"]}` against `items: { type: integer }` would
+    /// still fail.
+    func test_arrayOfScalars_coercesEachElement() throws {
+        let schema: JSONSchemaValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "counts": .object([
+                    "type": .string("array"),
+                    "items": intProp()
+                ])
+            ])
+        ])
+        let args: JSONSchemaValue = .object([
+            "counts": .array([.string("1"), .string("2"), .string("3")])
+        ])
+
+        let result = try ToolArgumentCoercer.coerce(args, against: schema)
+
+        XCTAssertEqual(result, .object([
+            "counts": .array([.number(1), .number(2), .number(3)])
+        ]))
+    }
+
+    // MARK: - depth cap
+
+    /// A schema deeper than `maxDepth` (8) must throw `schemaTooDeep`.
+    /// Nine levels of nested objects, each with a single `next` property,
+    /// terminating in an integer field that an LLM mistyped — the recursion
+    /// bottoms out in the error before reaching the leaf.
+    func test_depthLimit_throwsSchemaTooDeep() {
+        var schema: JSONSchemaValue = objectSchema(["leaf": intProp()])
+        var args: JSONSchemaValue = .object(["leaf": .string("42")])
+        // Wrap nine times — total depth becomes 10, exceeding the cap of 8.
+        for _ in 0..<9 {
+            schema = objectSchema(["next": schema])
+            args = .object(["next": args])
+        }
+
+        XCTAssertThrowsError(try ToolArgumentCoercer.coerce(args, against: schema)) { error in
+            XCTAssertEqual(error as? ToolArgumentError, .schemaTooDeep)
+        }
+    }
+
+    /// A schema exactly at `maxDepth` succeeds (boundary case).
+    func test_depthAtBoundary_succeeds() throws {
+        // Build down to depth 7 (still <= 8).
+        var schema: JSONSchemaValue = objectSchema(["leaf": intProp()])
+        var args: JSONSchemaValue = .object(["leaf": .string("42")])
+        for _ in 0..<6 {
+            schema = objectSchema(["next": schema])
+            args = .object(["next": args])
+        }
+
+        // Should not throw.
+        let result = try ToolArgumentCoercer.coerce(args, against: schema)
+
+        // Walk back down to confirm the leaf coerced.
+        var cursor = result
+        for _ in 0..<6 {
+            guard case .object(let dict) = cursor, let next = dict["next"] else {
+                XCTFail("missing 'next' at expected depth")
+                return
+            }
+            cursor = next
+        }
+        guard case .object(let leafDict) = cursor else {
+            XCTFail("expected object at leaf")
+            return
+        }
+        XCTAssertEqual(leafDict["leaf"], .number(42))
+    }
+
+    // MARK: - pass-through paths
+
+    /// A property whose schema is `{ "type": "string" }` should not have a
+    /// nested object value mutated, even if the args surprise us with one.
+    /// The original value passes through so the validator can reject it
+    /// with a precise message.
+    func test_nonObjectSchema_atRecursionSite_passesThrough() throws {
+        let schema = topSchema(["maybe": stringProp()])
+        let args: JSONSchemaValue = .object([
+            "maybe": .object(["unexpected": .string("42")])
+        ])
+
+        let result = try ToolArgumentCoercer.coerce(args, against: schema)
+
+        XCTAssertEqual(result, args, "non-object property schema must not rewrite a surprise object")
+    }
+
+    /// Already-correct nested values must round-trip untouched.
+    func test_alreadyCorrectNestedTypes_passThrough() throws {
+        let inner = objectSchema(["age": intProp(), "active": boolProp()])
+        let schema = topSchema(["data": inner])
+        let args: JSONSchemaValue = .object([
+            "data": .object([
+                "age": .number(42),
+                "active": .bool(true)
+            ])
+        ])
+
+        let result = try ToolArgumentCoercer.coerce(args, against: schema)
+
+        XCTAssertEqual(result, args)
+    }
+
+    // MARK: - backwards compatibility
+
+    /// Top-level-only inputs (the original v1 contract) must produce the
+    /// exact same output. The recursion is a strict superset.
+    func test_topLevelOnly_remainsBackwardsCompatible() throws {
+        let schema = topSchema([
+            "age": intProp(),
+            "active": boolProp(),
+            "score": numProp()
+        ])
+        let args: JSONSchemaValue = .object([
+            "age": .string("42"),
+            "active": .string("true"),
+            "score": .string("3.14")
+        ])
+
+        let result = try ToolArgumentCoercer.coerce(args, against: schema)
+
+        XCTAssertEqual(result, .object([
+            "age": .number(42),
+            "active": .bool(true),
+            "score": .number(3.14)
+        ]))
+    }
+
+    // MARK: - registry integration
+
+    /// The registry uses ``ToolArgumentCoercer/coerceBestEffort(_:against:)``
+    /// so a `schemaTooDeep` from a pathological schema falls back to the
+    /// un-coerced args; the validator then surfaces whatever real error the
+    /// schema produces.
+    @MainActor
+    func test_registryDispatch_coercesNestedArguments() async {
+        let registry = ToolRegistry()
+        registry.validator = JSONSchemaValidator()
+
+        final class Box: @unchecked Sendable {
+            var captured: JSONSchemaValue?
+        }
+        let box = Box()
+
+        final class Recorder: ToolExecutor, @unchecked Sendable {
+            let definition: ToolDefinition
+            let box: Box
+            init(box: Box) {
+                self.box = box
+                self.definition = ToolDefinition(
+                    name: "search",
+                    description: "",
+                    parameters: .object([
+                        "type": .string("object"),
+                        "properties": .object([
+                            "filter": .object([
+                                "type": .string("object"),
+                                "properties": .object([
+                                    "limit": .object(["type": .string("integer")])
+                                ])
+                            ])
+                        ]),
+                        "required": .array([.string("filter")])
+                    ])
+                )
+            }
+            func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+                box.captured = arguments
+                return ToolResult(callId: "", content: "ok", errorKind: nil)
+            }
+        }
+
+        registry.register(Recorder(box: box))
+
+        let call = ToolCall(
+            id: "c1",
+            toolName: "search",
+            arguments: #"{"filter":{"limit":"10"}}"#
+        )
+        let result = await registry.dispatch(call)
+
+        XCTAssertNil(result.errorKind, "validator should pass after nested coercion")
+        XCTAssertEqual(box.captured, .object([
+            "filter": .object(["limit": .number(10)])
+        ]))
+    }
+}

--- a/Tests/BaseChatInferenceTests/ToolArgumentCoercerTests.swift
+++ b/Tests/BaseChatInferenceTests/ToolArgumentCoercerTests.swift
@@ -34,7 +34,7 @@ final class ToolArgumentCoercerTests: XCTestCase {
         let s = schema(["age": intProp()])
         let args: JSONSchemaValue = .object(["age": .string("42")])
 
-        let result = ToolArgumentCoercer.coerce(args, against: s)
+        let result = try! ToolArgumentCoercer.coerce(args, against: s)
 
         XCTAssertEqual(result, .object(["age": .number(42)]))
     }
@@ -43,7 +43,7 @@ final class ToolArgumentCoercerTests: XCTestCase {
         let s = schema(["pi": numProp()])
         let args: JSONSchemaValue = .object(["pi": .string("3.14")])
 
-        let result = ToolArgumentCoercer.coerce(args, against: s)
+        let result = try! ToolArgumentCoercer.coerce(args, against: s)
 
         XCTAssertEqual(result, .object(["pi": .number(3.14)]))
     }
@@ -55,7 +55,7 @@ final class ToolArgumentCoercerTests: XCTestCase {
             "y": .string("-7")
         ])
 
-        let result = ToolArgumentCoercer.coerce(args, against: s)
+        let result = try! ToolArgumentCoercer.coerce(args, against: s)
 
         XCTAssertEqual(result, .object([
             "x": .number(-2500),
@@ -67,7 +67,7 @@ final class ToolArgumentCoercerTests: XCTestCase {
         let s = schema(["age": intProp()])
         let args: JSONSchemaValue = .object(["age": .string("not-a-number")])
 
-        let result = ToolArgumentCoercer.coerce(args, against: s)
+        let result = try! ToolArgumentCoercer.coerce(args, against: s)
 
         XCTAssertEqual(result, .object(["age": .string("not-a-number")]))
     }
@@ -81,7 +81,7 @@ final class ToolArgumentCoercerTests: XCTestCase {
         let s = schema(["age": intProp()])
         let args: JSONSchemaValue = .object(["age": .string("3.14")])
 
-        let result = ToolArgumentCoercer.coerce(args, against: s)
+        let result = try! ToolArgumentCoercer.coerce(args, against: s)
 
         XCTAssertEqual(result, .object(["age": .string("3.14")]))
     }
@@ -92,7 +92,7 @@ final class ToolArgumentCoercerTests: XCTestCase {
         let s = schema(["pi": numProp()])
         let args: JSONSchemaValue = .object(["pi": .string("3.14")])
 
-        let result = ToolArgumentCoercer.coerce(args, against: s)
+        let result = try! ToolArgumentCoercer.coerce(args, against: s)
 
         XCTAssertEqual(result, .object(["pi": .number(3.14)]))
     }
@@ -106,7 +106,7 @@ final class ToolArgumentCoercerTests: XCTestCase {
             "b": .string("false")
         ])
 
-        let result = ToolArgumentCoercer.coerce(args, against: s)
+        let result = try! ToolArgumentCoercer.coerce(args, against: s)
 
         XCTAssertEqual(result, .object([
             "a": .bool(true),
@@ -122,7 +122,7 @@ final class ToolArgumentCoercerTests: XCTestCase {
             "c": .string("False")
         ])
 
-        let result = ToolArgumentCoercer.coerce(args, against: s)
+        let result = try! ToolArgumentCoercer.coerce(args, against: s)
 
         XCTAssertEqual(result, .object([
             "a": .bool(true),
@@ -138,7 +138,7 @@ final class ToolArgumentCoercerTests: XCTestCase {
             "other": .string("abc")
         ])
 
-        let result = ToolArgumentCoercer.coerce(args, against: s)
+        let result = try! ToolArgumentCoercer.coerce(args, against: s)
 
         XCTAssertEqual(result, .object([
             "flag": .string("yes"),
@@ -156,7 +156,7 @@ final class ToolArgumentCoercerTests: XCTestCase {
             "pi": .number(3.14)
         ])
 
-        let result = ToolArgumentCoercer.coerce(args, against: s)
+        let result = try! ToolArgumentCoercer.coerce(args, against: s)
 
         XCTAssertEqual(result, args)
     }
@@ -165,7 +165,7 @@ final class ToolArgumentCoercerTests: XCTestCase {
         let s = schema(["name": stringProp()])
         let args: JSONSchemaValue = .object(["name": .string("42")])
 
-        let result = ToolArgumentCoercer.coerce(args, against: s)
+        let result = try! ToolArgumentCoercer.coerce(args, against: s)
 
         XCTAssertEqual(result, .object(["name": .string("42")]))
     }
@@ -174,7 +174,7 @@ final class ToolArgumentCoercerTests: XCTestCase {
         let s: JSONSchemaValue = .object(["type": .string("object")])
         let args: JSONSchemaValue = .object(["age": .string("42")])
 
-        let result = ToolArgumentCoercer.coerce(args, against: s)
+        let result = try! ToolArgumentCoercer.coerce(args, against: s)
 
         XCTAssertEqual(result, args)
     }
@@ -183,7 +183,7 @@ final class ToolArgumentCoercerTests: XCTestCase {
         let s: JSONSchemaValue = .object([:])
         let args: JSONSchemaValue = .object(["age": .string("42")])
 
-        let result = ToolArgumentCoercer.coerce(args, against: s)
+        let result = try! ToolArgumentCoercer.coerce(args, against: s)
 
         XCTAssertEqual(result, args)
     }
@@ -195,7 +195,7 @@ final class ToolArgumentCoercerTests: XCTestCase {
             "extra": .string("hello")
         ])
 
-        let result = ToolArgumentCoercer.coerce(args, against: s)
+        let result = try! ToolArgumentCoercer.coerce(args, against: s)
 
         XCTAssertEqual(result, .object([
             "age": .number(42),
@@ -207,17 +207,17 @@ final class ToolArgumentCoercerTests: XCTestCase {
         let s = schema(["age": intProp()])
         let args: JSONSchemaValue = .array([.string("42")])
 
-        let result = ToolArgumentCoercer.coerce(args, against: s)
+        let result = try! ToolArgumentCoercer.coerce(args, against: s)
 
         XCTAssertEqual(result, args)
     }
 
-    // MARK: - top-level only
+    // MARK: - nested recursion (I3)
 
-    func test_doesNotRecurseIntoNestedObjects() {
-        // `nested.age` is a string and the nested object's schema says
-        // integer, but coercion is top-level only — nested values pass
-        // through unchanged. This matches Goose's scope.
+    /// As of I3, the coercer recurses into nested object properties so
+    /// small open-weight models that mistype nested fields (more common
+    /// than mistyping top-level fields) don't fail the validator.
+    func test_recursesIntoNestedObjects() throws {
         let nestedSchema: JSONSchemaValue = .object([
             "type": .string("object"),
             "properties": .object(["age": intProp()])
@@ -227,10 +227,10 @@ final class ToolArgumentCoercerTests: XCTestCase {
             "nested": .object(["age": .string("42")])
         ])
 
-        let result = ToolArgumentCoercer.coerce(args, against: s)
+        let result = try ToolArgumentCoercer.coerce(args, against: s)
 
         XCTAssertEqual(result, .object([
-            "nested": .object(["age": .string("42")])
+            "nested": .object(["age": .number(42)])
         ]))
     }
 


### PR DESCRIPTION
## Summary

Two related correctness fixes for multi-MLX hosts and small-model tool calls.

### MLXResourceArbiter (per-instance cache accounting)

`MLX.Memory.cacheLimit` and `MLX.Memory.clearCache()` operate on a process-global pool. Multi-MLX hosts (chat + embeddings, A/B comparisons) had the second backend's `loadModel` overwrite the first's `cacheLimit`, and any `clearCache()` from one backend evicted pooled buffers other backends depended on for KV-cache reuse — silently corrupting KV reuse.

`MLXResourceArbiter` (new actor at `Sources/BaseChatBackends/MLX/MLXResourceArbiter.swift`) accumulates per-backend claims and programs `MLX.Memory.cacheLimit` to the **sum** of all active claims. `clearCache()` fires only on the **last** release; surviving backends keep their pooled buffers.

```swift
// After loadModelContainer succeeds:
await MLXResourceArbiter.shared.claim(
    backendID: backendID,
    requestedCacheBytes: cachePolicy.resolvedBytes()
)

// In unloadModel / cleanup:
await MLXResourceArbiter.shared.release(backendID: backendID)
```

`MLXBackend` no longer touches `MLX.Memory.*` directly — all calls go through the arbiter. New `BackendCapabilities.sharesMLXProcessResources` flag (default `false`, MLXBackend reports `true`) signals the coordination requirement to host code.

### ToolArgumentCoercer nested-schema recursion

`ToolArgumentCoercer` previously walked only top-level `properties`. Tools whose schemas declare nested objects (e.g. `parameters: { type: object, properties: { filter: { type: object, properties: { limit: integer } } } }`) rejected LLM-emitted `{"filter":{"limit":"10"}}` despite being trivially type-coercible. Small open-weight models — the explicit motivating case in the original docstring — mistype nested fields more often than top-level ones.

Coercion now recurses into nested objects and arrays of objects (homogeneous + tuple-form `items`) up to a hardcap `maxDepth` of 8. Pathological / self-referential schemas throw `ToolArgumentError.schemaTooDeep`; the registry uses `coerceBestEffort` so the validator still surfaces real errors when the cap is hit. Top-level-only behaviour is a strict subset — the existing test suite passes unchanged.

## Test plan

- [x] `swift test --filter MLXResourceArbiterTests` (9 cases) — single-backend lifecycle, two-backend overlap, three-backend stress with arbitrary release order, idempotence, negative-byte clamp, `clearAll`. Sabotage-verified by replacing `sum` with `set` and confirming the multi-backend tests fail with the expected diff.
- [x] `swift test --filter ToolArgumentCoercerNestedTests` (12 cases) — single/two-level nesting, arrays of objects (homogeneous + tuple), arrays of scalars, depth cap throws, boundary succeeds, non-object schema pass-through, registry integration. Sabotage-verified by skipping nested-object recursion and confirming 9 tests fail.
- [x] `BackendCapabilitiesContractTests.test_mlxBackend_sharesMLXProcessResources` added.
- [x] `ToolArgumentCoercerTests.test_doesNotRecurseIntoNestedObjects` flipped to `_recursesIntoNestedObjects` — contract change.
- [x] `APIFreezeTests/PublicSurfaceConsumer` fixture updated for the new init parameter.
- [x] Pre-push two-invocation gate green: 2827 XCTest passed, 82 Swift Testing passed, 0 failures, 11 skips.
- [x] Trait-combo build green: `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz`.
- [x] `FoundationOnly` build green: `swift build --traits FoundationOnly`.
- [x] `swift test --filter BaseChatBackendsTests --traits MLX,Llama,HuggingFace`: 411 tests, 41 skipped (hardware-gated), 0 failures.

## Files

- `Sources/BaseChatBackends/MLX/MLXResourceArbiter.swift` — new actor.
- `Sources/BaseChatBackends/MLXBackend.swift` — claim/release wiring + `sharesMLXProcessResources: true` + import-banner comment.
- `Sources/BaseChatInference/Protocols/BackendCapabilities.swift` — new `sharesMLXProcessResources` field with Codable round-trip.
- `Sources/BaseChatInference/Services/ToolArgumentCoercer.swift` — recursion + depth cap + `coerceBestEffort` helper.
- `Sources/BaseChatInference/Services/ToolRegistry.swift` — call site updated to `coerceBestEffort`.
- Tests: `MLXResourceArbiterTests.swift`, `ToolArgumentCoercerNestedTests.swift`, `BackendCapabilitiesContractTests.swift`, `ToolArgumentCoercerTests.swift`, `APIFreezeTests/Fixtures/PublicSurfaceConsumer.swift`.