### PR TITLE
feat(runtime): collapse TurnInput, typed SendMessageError, configure(bootstrap:), enqueue([Message])

### DIFF
--- a/Sources/BaseChatInference/Models/Message.swift
+++ b/Sources/BaseChatInference/Models/Message.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// A typed conversation message used by ``InferenceService/enqueue(messages:...)``
+/// (the typed overload) and ``InferenceService/generate(messages:...)``.
+///
+/// **Not the same as `ChatMessage` / `ChatMessageRecord`.** Those types live
+/// further down the stack:
+///
+/// - `ChatMessage` (a SwiftData `@Model` in `BaseChatPersistenceSwiftData`)
+///   is the persisted record with a UUID, timestamp, attachments, token-
+///   usage counters, and SwiftData identity. It exists to back the on-disk
+///   session/transcript model.
+/// - `ChatMessageRecord` (in `BaseChatInference`) is the persistence-agnostic
+///   value type adapters convert ChatMessage to. It carries `contentParts`,
+///   role enums, and structured attachment metadata.
+/// - ``Message`` (this type) is the **wire-shaped** input the inference
+///   queue takes when a caller wants to drive a one-shot generation without
+///   constructing the richer persistence records. Each case carries only
+///   role-discriminator + content text — no IDs, no timestamps, no
+///   attachments.
+///
+/// Replaces the typo-prone `[(role: String, content: String)]` tuple
+/// variant. The tuple variant remains as a deprecation shim for one minor
+/// (`enqueue(messages: [(role:content:)])` / `generate(messages:...)`).
+public enum Message: Sendable, Equatable {
+    /// A system message, typically setting role/persona/policy.
+    case system(String)
+    /// A user message — the human turn.
+    case user(String)
+    /// An assistant message — the model's prior turn.
+    case assistant(String)
+}
+
+extension Message {
+    /// The role string the underlying queue/backend layer expects on the
+    /// `(role, content)` tuple shape. Stable across cases — bridge code
+    /// maps this 1:1 onto the legacy tuple wire format.
+    public var role: String {
+        switch self {
+        case .system: return "system"
+        case .user: return "user"
+        case .assistant: return "assistant"
+        }
+    }
+
+    /// The associated string payload of this message.
+    public var content: String {
+        switch self {
+        case let .system(text), let .user(text), let .assistant(text):
+            return text
+        }
+    }
+
+    /// Materialises the legacy tuple wire shape so the typed overload can
+    /// forward into existing tuple-shaped queue and backend code without a
+    /// duplicated implementation.
+    public var asRoleContentTuple: (role: String, content: String) {
+        (role: role, content: content)
+    }
+}
+
+extension Array where Element == Message {
+    /// Convenience — converts a `[Message]` slice into the legacy tuple
+    /// shape for the one-shot adaptors that still take `[(role:content:)]`.
+    public var asRoleContentTuples: [(role: String, content: String)] {
+        map(\.asRoleContentTuple)
+    }
+}

--- a/Sources/BaseChatInference/Services/InferenceService.swift
+++ b/Sources/BaseChatInference/Services/InferenceService.swift
@@ -310,10 +310,54 @@ public final class InferenceService {
 
     // MARK: - Generation Queue
 
-    /// Enqueues a generation request and returns a token + stream pair.
+    /// Enqueues a generation request from a typed ``Message`` slice and
+    /// returns a token + stream pair.
     ///
     /// The stream starts in `.queued` phase and transitions to `.connecting`
     /// when the request reaches the front of the queue.
+    ///
+    /// Prefer this overload over the tuple-shaped `enqueue(messages: [(role:content:)])`
+    /// — `Message.system(_:)` / `.user(_:)` / `.assistant(_:)` cannot be
+    /// misspelled, while raw `"systme"` typos in the tuple variant pass
+    /// the type checker and surface as silent backend errors.
+    public func enqueue(
+        messages: [Message],
+        systemPrompt: String? = nil,
+        temperature: Float = 0.7,
+        topP: Float = 0.9,
+        repeatPenalty: Float = 1.1,
+        maxOutputTokens: Int? = 2048,
+        maxThinkingTokens: Int? = nil,
+        jsonMode: Bool = false,
+        grammar: String? = nil,
+        tools: [ToolDefinition] = [],
+        toolChoice: ToolChoice = .auto,
+        maxToolIterations: Int = 10,
+        priority: GenerationPriority = .normal,
+        sessionID: UUID? = nil
+    ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
+        ensureProviderWired()
+        return try generation.enqueue(
+            messages: messages.asRoleContentTuples,
+            systemPrompt: systemPrompt,
+            temperature: temperature,
+            topP: topP,
+            repeatPenalty: repeatPenalty,
+            maxOutputTokens: maxOutputTokens,
+            maxThinkingTokens: maxThinkingTokens,
+            jsonMode: jsonMode,
+            grammar: grammar,
+            tools: tools,
+            toolChoice: toolChoice,
+            maxToolIterations: maxToolIterations,
+            priority: priority,
+            sessionID: sessionID
+        )
+    }
+
+    /// Tuple-shaped enqueue retained for one minor while consumers migrate
+    /// to the typed ``enqueue(messages:[Message],...)`` overload.
+    @available(*, deprecated, message: "Use [Message] with .system/.user/.assistant — raw role strings are typo-prone.")
     public func enqueue(
         messages: [(role: String, content: String)],
         systemPrompt: String? = nil,

--- a/Sources/BaseChatRuntime/Services/ConversationRuntime+TurnInput.swift
+++ b/Sources/BaseChatRuntime/Services/ConversationRuntime+TurnInput.swift
@@ -1,0 +1,129 @@
+import Foundation
+import BaseChatInference
+
+// MARK: - TurnConfig
+//
+// I6 collapses the four near-identical input structs (SendInput / RegenerateInput
+// / EditInput / BranchInput) into a single normalised pair: TurnConfig (the
+// shared sampling/streaming/loop-detection knobs) and TurnKind (the per-flow
+// payload). Adding a new knob is now a single-touch change rather than a
+// 4× edit across paralleled init signatures. Old structs are kept as
+// deprecation shims for one minor — see ConversationRuntime.swift.
+
+/// The sampling, streaming, and loop-detection knobs shared by every
+/// ``ConversationRuntime`` turn flow.
+///
+/// Identical for `send`, `regenerate`, `edit`, and `branch`. The runtime reads
+/// these once per turn and forwards them to ``InferenceService/enqueueAsync(...)``.
+public struct TurnConfig: Sendable, Equatable {
+    public let systemPrompt: String?
+    public let temperature: Float
+    public let topP: Float
+    public let repeatPenalty: Float
+    public let maxOutputTokens: Int?
+    public let maxThinkingTokens: Int?
+    public let streamingUpdateInterval: Duration
+    public let streamingBatchCharacterLimit: Int
+    public let thinkingStreamingUpdateInterval: Duration
+    public let thinkingStreamingBatchCharacterLimit: Int
+    public let loopDetectionEnabled: Bool
+
+    public init(
+        systemPrompt: String? = nil,
+        temperature: Float = 0.7,
+        topP: Float = 0.9,
+        repeatPenalty: Float = 1.1,
+        maxOutputTokens: Int? = 2048,
+        maxThinkingTokens: Int? = nil,
+        streamingUpdateInterval: Duration = .milliseconds(33),
+        streamingBatchCharacterLimit: Int = 128,
+        thinkingStreamingUpdateInterval: Duration = .milliseconds(33),
+        thinkingStreamingBatchCharacterLimit: Int = 128,
+        loopDetectionEnabled: Bool = true
+    ) {
+        self.systemPrompt = systemPrompt
+        self.temperature = temperature
+        self.topP = topP
+        self.repeatPenalty = repeatPenalty
+        self.maxOutputTokens = maxOutputTokens
+        self.maxThinkingTokens = maxThinkingTokens
+        self.streamingUpdateInterval = streamingUpdateInterval
+        self.streamingBatchCharacterLimit = streamingBatchCharacterLimit
+        self.thinkingStreamingUpdateInterval = thinkingStreamingUpdateInterval
+        self.thinkingStreamingBatchCharacterLimit = thinkingStreamingBatchCharacterLimit
+        self.loopDetectionEnabled = loopDetectionEnabled
+    }
+}
+
+// MARK: - TurnKind
+
+/// The per-flow payload distinguishing one turn from another.
+///
+/// Each case carries only the fields that flow truly needs — `send` adds new
+/// user text plus optional attachments; `regenerate` re-runs the last user
+/// turn; `edit` rewrites a message and re-runs trailing generation;
+/// `branch` forks a session at a chosen message and optionally generates on
+/// the new fork.
+public enum TurnKind: Sendable {
+    /// New user message — persists `text` (and any image/file attachments) as
+    /// a `.user` record before generation begins.
+    ///
+    /// `attachments` is `[MessagePart]` — the existing structured-content
+    /// type. `MessagePart.image` is the only attachment shape the runtime
+    /// owns today; future shapes (file, audio) are added by extending
+    /// `MessagePart` rather than this enum.
+    case send(text: String, attachments: [MessagePart] = [])
+
+    /// Re-runs the last user turn. The runtime deletes the trailing assistant
+    /// message synchronously, then drives a fresh generation from the
+    /// preserved history.
+    case regenerate
+
+    /// Replaces `messageID`'s content with `text`, deletes all trailing
+    /// messages, and (when the edited message was `.user`) drives a fresh
+    /// generation. Editing a `.assistant` message persists the edit but
+    /// does not re-generate.
+    case edit(messageID: UUID, text: String)
+
+    /// Forks the session at `messageID` (inclusive) into a new session
+    /// identified by `newSessionID`. When `generateAfter` is `true` and the
+    /// last copied message is `.user`, the runtime drives a generation turn
+    /// on the new session.
+    ///
+    /// `newSessionTitle == nil` preserves the source session's title.
+    case branch(
+        messageID: UUID,
+        newSessionID: UUID = UUID(),
+        newSessionTitle: String? = nil,
+        generateAfter: Bool = false
+    )
+}
+
+// MARK: - TurnInput
+
+/// The unified input for every ``ConversationRuntime`` turn flow.
+///
+/// Compose with ``TurnConfig`` (defaults are sensible across all four flows)
+/// and a ``TurnKind`` payload. The runtime exposes
+/// ``ConversationRuntime/processTurn(_:)`` as the canonical entry point;
+/// the per-flow methods (``ConversationRuntime/send(_:)``,
+/// ``ConversationRuntime/regenerate(_:)`` etc.) are kept as thin wrappers
+/// that build a `TurnInput` for callers still passing the legacy `*Input`
+/// structs.
+public struct TurnInput: Sendable {
+    /// The session this turn targets. For `.branch`, this is the **source**
+    /// session — the new session ID lives on the kind payload.
+    public let sessionID: UUID
+    public let kind: TurnKind
+    public let config: TurnConfig
+
+    public init(
+        sessionID: UUID,
+        kind: TurnKind,
+        config: TurnConfig = TurnConfig()
+    ) {
+        self.sessionID = sessionID
+        self.kind = kind
+        self.config = config
+    }
+}

--- a/Sources/BaseChatRuntime/Services/ConversationRuntime.swift
+++ b/Sources/BaseChatRuntime/Services/ConversationRuntime.swift
@@ -1,14 +1,14 @@
 import Foundation
 import BaseChatInference
 
-// MARK: - Send input
+// MARK: - Legacy Send input
 //
-// PR-A ships the ``send`` sub-flow. Regenerate lands in PR-B; edit lands in
-// PR-C; branch lands in PR-D. PR-E absorbs token batching, thinking-block
-// disclosure, loop detection, and tool dispatch into ``runGenerationTurn``.
-// Each sub-flow has its own input type and command method; all four share
-// the ``runGenerationTurn`` private helper for the generation inner loop
-// (context assembly → enqueue → drain → finalise).
+// I6 collapsed the four near-identical input structs into a single ``TurnInput``
+// + ``TurnConfig`` + ``TurnKind`` triple (see ConversationRuntime+TurnInput.swift).
+// `SendInput` / `RegenerateInput` / `EditInput` / `BranchInput` remain as
+// deprecation shims for one minor so adopters can migrate without a hard break.
+// New callers should construct ``TurnInput`` and call
+// ``ConversationRuntime/processTurn(_:)``.
 
 /// Input for ``ConversationRuntime/send(_:)``.
 ///
@@ -18,6 +18,7 @@ import BaseChatInference
 /// public stance), and turning a no-session call into a "generic" turn
 /// would require a parallel error path consumers shouldn't have to
 /// pattern-match.
+@available(*, deprecated, renamed: "TurnInput", message: "Build a TurnInput with .send(text:attachments:) and call processTurn(_:). SendInput will be removed in a future release.")
 public struct SendInput: Sendable {
     public let sessionID: UUID
     public let userText: String
@@ -74,6 +75,33 @@ public struct SendInput: Sendable {
     }
 }
 
+@available(*, deprecated)
+extension SendInput {
+    /// Translates the legacy struct into the canonical ``TurnInput`` used by
+    /// ``ConversationRuntime/processTurn(_:)``. Used by the deprecated
+    /// ``ConversationRuntime/send(_:)`` overload to forward without
+    /// duplicating the per-field plumbing.
+    var asTurnInput: TurnInput {
+        TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: userText, attachments: attachments),
+            config: TurnConfig(
+                systemPrompt: systemPrompt,
+                temperature: temperature,
+                topP: topP,
+                repeatPenalty: repeatPenalty,
+                maxOutputTokens: maxOutputTokens,
+                maxThinkingTokens: maxThinkingTokens,
+                streamingUpdateInterval: streamingUpdateInterval,
+                streamingBatchCharacterLimit: streamingBatchCharacterLimit,
+                thinkingStreamingUpdateInterval: thinkingStreamingUpdateInterval,
+                thinkingStreamingBatchCharacterLimit: thinkingStreamingBatchCharacterLimit,
+                loopDetectionEnabled: loopDetectionEnabled
+            )
+        )
+    }
+}
+
 // MARK: - Regenerate input
 
 /// Input for ``ConversationRuntime/regenerate(_:)``.
@@ -81,6 +109,7 @@ public struct SendInput: Sendable {
 /// No `userText` — regenerate re-runs the last user turn with no new input.
 /// The runtime finds the last assistant message, deletes it, and streams a
 /// fresh response into a new assistant record.
+@available(*, deprecated, renamed: "TurnInput", message: "Build a TurnInput with .regenerate and call processTurn(_:). RegenerateInput will be removed in a future release.")
 public struct RegenerateInput: Sendable {
     public let sessionID: UUID
     public let systemPrompt: String?
@@ -124,6 +153,29 @@ public struct RegenerateInput: Sendable {
     }
 }
 
+@available(*, deprecated)
+extension RegenerateInput {
+    var asTurnInput: TurnInput {
+        TurnInput(
+            sessionID: sessionID,
+            kind: .regenerate,
+            config: TurnConfig(
+                systemPrompt: systemPrompt,
+                temperature: temperature,
+                topP: topP,
+                repeatPenalty: repeatPenalty,
+                maxOutputTokens: maxOutputTokens,
+                maxThinkingTokens: maxThinkingTokens,
+                streamingUpdateInterval: streamingUpdateInterval,
+                streamingBatchCharacterLimit: streamingBatchCharacterLimit,
+                thinkingStreamingUpdateInterval: thinkingStreamingUpdateInterval,
+                thinkingStreamingBatchCharacterLimit: thinkingStreamingBatchCharacterLimit,
+                loopDetectionEnabled: loopDetectionEnabled
+            )
+        )
+    }
+}
+
 // MARK: - Edit input
 
 /// Input for ``ConversationRuntime/edit(_:)``.
@@ -131,6 +183,7 @@ public struct RegenerateInput: Sendable {
 /// Identifies the message to edit by ID, carries the replacement content,
 /// and includes the same generation knobs as ``SendInput`` and
 /// ``RegenerateInput`` for the subsequent generation turn (if any).
+@available(*, deprecated, renamed: "TurnInput", message: "Build a TurnInput with .edit(messageID:text:) and call processTurn(_:). EditInput will be removed in a future release.")
 public struct EditInput: Sendable {
     public let sessionID: UUID
     /// The ID of the message whose content will be replaced.
@@ -182,6 +235,29 @@ public struct EditInput: Sendable {
     }
 }
 
+@available(*, deprecated)
+extension EditInput {
+    var asTurnInput: TurnInput {
+        TurnInput(
+            sessionID: sessionID,
+            kind: .edit(messageID: messageID, text: newContent),
+            config: TurnConfig(
+                systemPrompt: systemPrompt,
+                temperature: temperature,
+                topP: topP,
+                repeatPenalty: repeatPenalty,
+                maxOutputTokens: maxOutputTokens,
+                maxThinkingTokens: maxThinkingTokens,
+                streamingUpdateInterval: streamingUpdateInterval,
+                streamingBatchCharacterLimit: streamingBatchCharacterLimit,
+                thinkingStreamingUpdateInterval: thinkingStreamingUpdateInterval,
+                thinkingStreamingBatchCharacterLimit: thinkingStreamingBatchCharacterLimit,
+                loopDetectionEnabled: loopDetectionEnabled
+            )
+        )
+    }
+}
+
 // MARK: - Branch input
 
 /// Input for ``ConversationRuntime/branch(_:)``.
@@ -190,6 +266,7 @@ public struct EditInput: Sendable {
 /// `sourceSessionID` up to and including `branchMessageID` into a new session
 /// identified by `newSessionID`, then optionally triggers a generation turn on
 /// the new session if the last copied message is a user message.
+@available(*, deprecated, renamed: "TurnInput", message: "Build a TurnInput with .branch(messageID:newSessionID:newSessionTitle:generateAfter:) and call processTurn(_:). BranchInput will be removed in a future release.")
 public struct BranchInput: Sendable {
     /// The session to fork from.
     public let sourceSessionID: UUID
@@ -238,11 +315,34 @@ public struct BranchInput: Sendable {
     }
 }
 
+@available(*, deprecated)
+extension BranchInput {
+    var asTurnInput: TurnInput {
+        TurnInput(
+            sessionID: sourceSessionID,
+            kind: .branch(
+                messageID: branchMessageID,
+                newSessionID: newSessionID,
+                newSessionTitle: newSessionTitle,
+                generateAfter: generateAfterBranch
+            ),
+            config: TurnConfig(
+                systemPrompt: systemPrompt,
+                temperature: temperature,
+                topP: topP,
+                repeatPenalty: repeatPenalty,
+                maxOutputTokens: maxOutputTokens,
+                maxThinkingTokens: maxThinkingTokens
+            )
+        )
+    }
+}
+
 // MARK: - Stream handle
 
 /// Identifier for an in-flight runtime stream.
 ///
-/// Returned from ``ConversationRuntime/send(_:)`` and passed back to
+/// Returned from ``ConversationRuntime/processTurn(_:)`` and passed back to
 /// ``ConversationRuntime/cancel(_:)`` to cancel a specific in-flight turn.
 /// Per-runtime unique; not stable across runtime instances.
 public struct ConversationStreamHandle: Sendable, Hashable {
@@ -320,15 +420,14 @@ actor InFlightStreamRegistry {
 /// (`ChatViewModel`-shaped consumers). The stream is unbounded — adapters
 /// must drain it on a long-lived task or the buffer grows.
 ///
-/// ## Scope (PR-E)
+/// ## Turn entry points
 ///
-/// PR-A ships the scaffolding plus the ``send(_:)`` sub-flow. PR-B adds
-/// ``regenerate(_:)``. PR-C adds ``edit(_:)`` and extracts a shared
-/// ``runGenerationTurn`` helper. PR-D adds ``branch(_:)``. PR-E absorbs
-/// the streaming-token batcher, thinking-block disclosure, loop detection,
-/// and tool-dispatch loop from `GenerationQueue` into
-/// ``runGenerationTurn`` so all four sub-flows share the same rich
-/// streaming behaviour.
+/// ``processTurn(_:)`` is the canonical entry point for every turn flow.
+/// Build a ``TurnInput`` with the appropriate ``TurnKind`` (`.send`,
+/// `.regenerate`, `.edit`, or `.branch`) and a shared ``TurnConfig``.
+/// The legacy per-flow methods (``send(_:)``, ``regenerate(_:)``,
+/// ``edit(_:)``, ``branch(_:)``) and their `*Input` types are kept as
+/// deprecation shims for one minor.
 public final class ConversationRuntime: Sendable {
 
     // MARK: Ports
@@ -427,7 +526,72 @@ public final class ConversationRuntime: Sendable {
         continuation.finish()
     }
 
-    // MARK: Commands
+    // MARK: Canonical entry point
+
+    /// Processes one turn. Routes by ``TurnKind`` to the appropriate
+    /// per-flow setup (synchronous persistence) and dispatches the
+    /// generation portion (when applicable) onto a detached task.
+    ///
+    /// Returns:
+    /// - A ``ConversationStreamHandle`` for any flow that drives generation.
+    /// - `nil` for `.edit` of a non-user message (no regeneration) and for
+    ///   `.branch` when the last copied message is not `.user` or
+    ///   `generateAfter` is `false`.
+    ///
+    /// Cancellation: pass the returned handle to ``cancel(_:)``. The
+    /// in-flight stream terminates with
+    /// ``ConversationEvent/streamFinished(messageID:reason:)`` carrying
+    /// ``FinishReason/cancelled``.
+    @discardableResult
+    public func processTurn(_ input: TurnInput) async throws -> ConversationStreamHandle? {
+        switch input.kind {
+        case let .send(text, attachments):
+            return try await runSendFlow(
+                sessionID: input.sessionID,
+                text: text,
+                attachments: attachments,
+                config: input.config
+            )
+        case .regenerate:
+            return try await runRegenerateFlow(
+                sessionID: input.sessionID,
+                config: input.config
+            )
+        case let .edit(messageID, text):
+            return try await runEditFlow(
+                sessionID: input.sessionID,
+                messageID: messageID,
+                text: text,
+                config: input.config
+            )
+        case let .branch(messageID, newSessionID, newSessionTitle, generateAfter):
+            return try await runBranchFlow(
+                sourceSessionID: input.sessionID,
+                branchMessageID: messageID,
+                newSessionID: newSessionID,
+                newSessionTitle: newSessionTitle,
+                generateAfter: generateAfter,
+                config: input.config
+            )
+        }
+    }
+
+    // MARK: Cancel
+
+    /// Cancels an in-flight stream identified by `handle`.
+    ///
+    /// Idempotent — cancelling an already-cancelled or already-finished
+    /// handle is a no-op. The stream fires its terminal
+    /// ``ConversationEvent/streamFinished(messageID:reason:)`` with
+    /// ``FinishReason/cancelled`` once the cancel propagates through the
+    /// underlying inference layer.
+    public func cancel(_ handle: ConversationStreamHandle) async {
+        let token = await registry.markCancelled(handle)
+        guard let token else { return }
+        await inferenceService.cancelAsync(token)
+    }
+
+    // MARK: Legacy command surface (deprecated)
 
     /// Sends a user message and drives one generation turn.
     ///
@@ -443,71 +607,19 @@ public final class ConversationRuntime: Sendable {
     /// ``ConversationEvent/streamFinished(messageID:reason:)`` carrying
     /// ``FinishReason/cancelled``.
     @discardableResult
+    @available(*, deprecated, renamed: "processTurn(_:)", message: "Build a TurnInput with .send(text:attachments:) and call processTurn(_:).")
     public func send(_ input: SendInput) async throws -> ConversationStreamHandle {
-        let handle = ConversationStreamHandle()
-
-        // Persist the user message synchronously so the caller observes
-        // ordering (`messageInserted(user)` before `send` returns) — the
-        // stream task fires off after this point. Persistence failures
-        // throw out so the caller can surface them; matching ChatViewModel's
-        // current shape where a user-message persistence failure aborts the
-        // turn before any assistant work runs.
-        // Build user contentParts: when attachments are present, splice the
-        // text part (if any) before the attachments so the persisted record
-        // and the structured-history snapshot the runtime hands the backend
-        // both carry `[.text, <attachments>...]`. Empty text + attachments
-        // yields an attachment-only record (e.g. a "describe this image"
-        // turn with no caption).
-        let attachments = input.attachments.map { $0.generatingImagePlaceholderIfNeeded() }
-        let userContentParts: [MessagePart]
-        if attachments.isEmpty {
-            userContentParts = [.text(input.userText)]
-        } else if input.userText.isEmpty {
-            userContentParts = attachments
-        } else {
-            userContentParts = [.text(input.userText)] + attachments
+        // The deprecated overloads forward through processTurn. `.send` always
+        // produces a stream handle, so force-unwrap the optional return — the
+        // underlying flow guarantees non-nil for `.send`.
+        guard let handle = try await processTurn(input.asTurnInput) else {
+            // Unreachable: runSendFlow always returns a non-nil handle.
+            // Prefer Log + a synthetic handle over a trap so a stale flow
+            // change can't take down the app.
+            Log.inference.warning("ConversationRuntime.send: processTurn returned nil for .send — synthesising handle")
+            return ConversationStreamHandle()
         }
-        let userMessage = ChatMessageRecord(
-            role: .user,
-            contentParts: userContentParts,
-            sessionID: input.sessionID
-        )
-        do {
-            try await insertMessage(userMessage)
-        } catch {
-            throw ConversationError.persistence(error)
-        }
-        emit(.messageInserted(userMessage))
-
-        // Touch session updatedAt — best-effort. Persistence errors here
-        // are logged and continue; the runtime should not lose a turn over
-        // a sidebar-ordering failure.
-        if let sessionStore {
-            await touchSession(sessionStore: sessionStore, sessionID: input.sessionID)
-        }
-
-        // Detach the streaming work onto an unstructured task so `send`
-        // returns the handle promptly. The task captures `self` strongly
-        // for the duration of the turn — releases via the registry when
-        // the turn ends.
-        Task.detached { [self] in
-            await runSendTurn(input: input, handle: handle)
-        }
-
         return handle
-    }
-
-    /// Cancels an in-flight stream identified by `handle`.
-    ///
-    /// Idempotent — cancelling an already-cancelled or already-finished
-    /// handle is a no-op. The stream fires its terminal
-    /// ``ConversationEvent/streamFinished(messageID:reason:)`` with
-    /// ``FinishReason/cancelled`` once the cancel propagates through the
-    /// underlying inference layer.
-    public func cancel(_ handle: ConversationStreamHandle) async {
-        let token = await registry.markCancelled(handle)
-        guard let token else { return }
-        await inferenceService.cancelAsync(token)
     }
 
     /// Deletes the last assistant message for `input.sessionID` and drives
@@ -522,17 +634,139 @@ public final class ConversationRuntime: Sendable {
     ///
     /// Cancellation: pass the returned handle to ``cancel(_:)``.
     @discardableResult
+    @available(*, deprecated, renamed: "processTurn(_:)", message: "Build a TurnInput with .regenerate and call processTurn(_:).")
     public func regenerate(_ input: RegenerateInput) async throws -> ConversationStreamHandle {
+        guard let handle = try await processTurn(input.asTurnInput) else {
+            Log.inference.warning("ConversationRuntime.regenerate: processTurn returned nil for .regenerate — synthesising handle")
+            return ConversationStreamHandle()
+        }
+        return handle
+    }
+
+    /// Edits a message's content, deletes all messages after it, then
+    /// regenerates if the edited message was a user message.
+    ///
+    /// Returns a ``ConversationStreamHandle`` if generation was triggered
+    /// (edited message was `.user`); returns `nil` if the edited message was
+    /// `.assistant` and no generation is needed. The call is `async throws`
+    /// for synchronous setup failures (message not found, persistence errors
+    /// before the detached task fires); once the task is running, failures
+    /// route to ``ConversationEvent/errorRaised(_:)``.
+    ///
+    /// Cancellation: pass the returned handle to ``cancel(_:)``.
+    @discardableResult
+    @available(*, deprecated, renamed: "processTurn(_:)", message: "Build a TurnInput with .edit(messageID:text:) and call processTurn(_:).")
+    public func edit(_ input: EditInput) async throws -> ConversationStreamHandle? {
+        try await processTurn(input.asTurnInput)
+    }
+
+    /// Forks a conversation at a chosen message, creating a new session with
+    /// the messages up to and including the branch point copied in.
+    ///
+    /// Returns a ``ConversationStreamHandle`` when `generateAfterBranch` is
+    /// `true` and the last copied message is `.user`; returns `nil` otherwise.
+    /// Setup failures (branch point not found, persistence errors) throw
+    /// synchronously before any task is launched; generation failures after
+    /// the task is launched route to ``ConversationEvent/errorRaised(_:)``.
+    @discardableResult
+    @available(*, deprecated, renamed: "processTurn(_:)", message: "Build a TurnInput with .branch(messageID:...) and call processTurn(_:).")
+    public func branch(_ input: BranchInput) async throws -> ConversationStreamHandle? {
+        try await processTurn(input.asTurnInput)
+    }
+
+    // MARK: Send flow
+
+    private func runSendFlow(
+        sessionID: UUID,
+        text: String,
+        attachments rawAttachments: [MessagePart],
+        config: TurnConfig
+    ) async throws -> ConversationStreamHandle {
+        let handle = ConversationStreamHandle()
+
+        // Persist the user message synchronously so the caller observes
+        // ordering (`messageInserted(user)` before `processTurn` returns) —
+        // the stream task fires off after this point. Persistence failures
+        // throw out so the caller can surface them; matching ChatViewModel's
+        // current shape where a user-message persistence failure aborts the
+        // turn before any assistant work runs.
+        // Build user contentParts: when attachments are present, splice the
+        // text part (if any) before the attachments so the persisted record
+        // and the structured-history snapshot the runtime hands the backend
+        // both carry `[.text, <attachments>...]`. Empty text + attachments
+        // yields an attachment-only record (e.g. a "describe this image"
+        // turn with no caption).
+        let attachments = rawAttachments.map { $0.generatingImagePlaceholderIfNeeded() }
+        let userContentParts: [MessagePart]
+        if attachments.isEmpty {
+            userContentParts = [.text(text)]
+        } else if text.isEmpty {
+            userContentParts = attachments
+        } else {
+            userContentParts = [.text(text)] + attachments
+        }
+        let userMessage = ChatMessageRecord(
+            role: .user,
+            contentParts: userContentParts,
+            sessionID: sessionID
+        )
+        do {
+            try await insertMessage(userMessage)
+        } catch {
+            throw ConversationError.persistence(error)
+        }
+        emit(.messageInserted(userMessage))
+
+        // Touch session updatedAt — best-effort. Persistence errors here
+        // are logged and continue; the runtime should not lose a turn over
+        // a sidebar-ordering failure.
+        if let sessionStore {
+            await touchSession(sessionStore: sessionStore, sessionID: sessionID)
+        }
+
+        // Detach the streaming work onto an unstructured task so the
+        // command returns the handle promptly. The task captures `self`
+        // strongly for the duration of the turn — releases via the
+        // registry when the turn ends.
+        Task.detached { [self] in
+            // Fetch history first — one store fetch covers both the
+            // message count for context assembly and the structured
+            // messages for enqueueAsync. By the time we get here, the
+            // user message we just inserted is in the store
+            // (insertMessage awaited above).
+            let history: [ChatMessageRecord]
+            do {
+                history = try await fetchMessages(sessionID: sessionID)
+            } catch {
+                emit(.errorRaised(.persistence(error)))
+                return
+            }
+            await runGenerationTurn(
+                sessionID: sessionID,
+                userPrompt: text,
+                history: history,
+                config: config,
+                handle: handle
+            )
+        }
+
+        return handle
+    }
+
+    // MARK: Regenerate flow
+
+    private func runRegenerateFlow(
+        sessionID: UUID,
+        config: TurnConfig
+    ) async throws -> ConversationStreamHandle {
         let handle = ConversationStreamHandle()
 
         // Fetch history synchronously so we can locate and delete the last
         // assistant message before returning the handle. Callers observe
-        // ordering: `.messageRemoved` fires before `regenerate` returns, so
-        // adapters that unsubscribe from the old message slot can do so
-        // before the new stream starts.
+        // ordering: `.messageRemoved` fires before `processTurn` returns.
         let history: [ChatMessageRecord]
         do {
-            history = try await fetchMessages(sessionID: input.sessionID)
+            history = try await fetchMessages(sessionID: sessionID)
         } catch {
             throw ConversationError.persistence(error)
         }
@@ -549,44 +783,54 @@ public final class ConversationRuntime: Sendable {
         emit(.messageRemoved(messageID: lastAssistant.id))
 
         Task.detached { [self] in
-            await runRegenerateTurn(input: input, handle: handle)
+            // Fetch history after deletion — the removed assistant message
+            // is gone, so context assembly starts from the last user turn.
+            let postHistory: [ChatMessageRecord]
+            do {
+                postHistory = try await fetchMessages(sessionID: sessionID)
+            } catch {
+                emit(.errorRaised(.persistence(error)))
+                return
+            }
+            await runGenerationTurn(
+                sessionID: sessionID,
+                userPrompt: nil,
+                history: postHistory,
+                config: config,
+                handle: handle
+            )
         }
 
         return handle
     }
 
-    /// Edits a message's content, deletes all messages after it, then
-    /// regenerates if the edited message was a user message.
-    ///
-    /// Returns a ``ConversationStreamHandle`` if generation was triggered
-    /// (edited message was `.user`); returns `nil` if the edited message was
-    /// `.assistant` and no generation is needed. The call is `async throws`
-    /// for synchronous setup failures (message not found, persistence errors
-    /// before the detached task fires); once the task is running, failures
-    /// route to ``ConversationEvent/errorRaised(_:)``.
-    ///
-    /// Cancellation: pass the returned handle to ``cancel(_:)``.
-    @discardableResult
-    public func edit(_ input: EditInput) async throws -> ConversationStreamHandle? {
-        // Fetch history synchronously so we can locate the target message and
-        // delete trailing messages before returning. Callers observe ordering:
-        // `.messageUpdated` and `.messageRemoved` events fire before `edit`
-        // returns so adapters can update their view-state before the stream
-        // starts.
+    // MARK: Edit flow
+
+    private func runEditFlow(
+        sessionID: UUID,
+        messageID: UUID,
+        text: String,
+        config: TurnConfig
+    ) async throws -> ConversationStreamHandle? {
+        // Fetch history synchronously so we can locate the target message
+        // and delete trailing messages before returning. Callers observe
+        // ordering: `.messageUpdated` and `.messageRemoved` events fire
+        // before `processTurn` returns so adapters can update their view-
+        // state before the stream starts.
         let history: [ChatMessageRecord]
         do {
-            history = try await fetchMessages(sessionID: input.sessionID)
+            history = try await fetchMessages(sessionID: sessionID)
         } catch {
             throw ConversationError.persistence(error)
         }
 
-        guard let index = history.firstIndex(where: { $0.id == input.messageID }) else {
-            throw ConversationError.messageNotFound(input.messageID)
+        guard let index = history.firstIndex(where: { $0.id == messageID }) else {
+            throw ConversationError.messageNotFound(messageID)
         }
 
         // Update the edited message's content in the store.
         var updatedMessage = history[index]
-        updatedMessage.content = input.newContent
+        updatedMessage.content = text
         do {
             try await updateMessage(updatedMessage)
         } catch {
@@ -595,8 +839,9 @@ public final class ConversationRuntime: Sendable {
         emit(.messageUpdated(updatedMessage))
 
         // Delete all messages after the edited one. On first failure stop
-        // deleting and throw — callers reload from the store on failure; the
-        // partial deletion is acknowledged, matching ChatViewModel's behaviour.
+        // deleting and throw — callers reload from the store on failure;
+        // the partial deletion is acknowledged, matching ChatViewModel's
+        // behaviour.
         let trailing = Array(history[(index + 1)...])
         for msg in trailing {
             do {
@@ -607,51 +852,68 @@ public final class ConversationRuntime: Sendable {
             emit(.messageRemoved(messageID: msg.id))
         }
 
-        // If the edited message was from the user, regenerate.
+        // If the edited message was from the user, regenerate. Assistant
+        // edits persist the change but do not re-run generation.
         guard updatedMessage.role == .user else {
-            // Assistant edit: no generation needed.
             return nil
         }
 
         let handle = ConversationStreamHandle()
         Task.detached { [self] in
-            await runEditGenerationTurn(input: input, handle: handle)
+            // Fetch history fresh after the synchronous edit + deletion —
+            // the updated message and removed trailing messages are
+            // already committed to the store before the detached task
+            // runs.
+            let postHistory: [ChatMessageRecord]
+            do {
+                postHistory = try await fetchMessages(sessionID: sessionID)
+            } catch {
+                emit(.errorRaised(.persistence(error)))
+                return
+            }
+            await runGenerationTurn(
+                sessionID: sessionID,
+                userPrompt: nil,
+                history: postHistory,
+                config: config,
+                handle: handle
+            )
         }
         return handle
     }
 
-    /// Forks a conversation at a chosen message, creating a new session with
-    /// the messages up to and including the branch point copied in.
-    ///
-    /// Returns a ``ConversationStreamHandle`` when `generateAfterBranch` is
-    /// `true` and the last copied message is `.user`; returns `nil` otherwise.
-    /// Setup failures (branch point not found, persistence errors) throw
-    /// synchronously before any task is launched; generation failures after
-    /// the task is launched route to ``ConversationEvent/errorRaised(_:)``.
-    @discardableResult
-    public func branch(_ input: BranchInput) async throws -> ConversationStreamHandle? {
+    // MARK: Branch flow
+
+    private func runBranchFlow(
+        sourceSessionID: UUID,
+        branchMessageID: UUID,
+        newSessionID: UUID,
+        newSessionTitle: String?,
+        generateAfter: Bool,
+        config: TurnConfig
+    ) async throws -> ConversationStreamHandle? {
         // Fetch source history synchronously so callers observe ordering:
-        // `.sessionBranched` fires before `branch` returns.
+        // `.sessionBranched` fires before `processTurn` returns.
         let sourceHistory: [ChatMessageRecord]
         do {
-            sourceHistory = try await fetchMessages(sessionID: input.sourceSessionID)
+            sourceHistory = try await fetchMessages(sessionID: sourceSessionID)
         } catch {
             throw ConversationError.persistence(error)
         }
 
         // Find the branch point and slice history up to and including it.
-        guard let branchIndex = sourceHistory.firstIndex(where: { $0.id == input.branchMessageID }) else {
-            throw ConversationError.messageNotFound(input.branchMessageID)
+        guard let branchIndex = sourceHistory.firstIndex(where: { $0.id == branchMessageID }) else {
+            throw ConversationError.messageNotFound(branchMessageID)
         }
         let slice = Array(sourceHistory[...branchIndex])
 
         // Derive the new session's title from the source session when the
-        // caller didn't supply one. A title-fetch failure must not abort the
-        // branch — the session insert below still runs with the fallback —
-        // but the failure is logged so it isn't silently lost.
-        let newSessionTitle: String
-        if let supplied = input.newSessionTitle {
-            newSessionTitle = supplied
+        // caller didn't supply one. A title-fetch failure must not abort
+        // the branch — the session insert below still runs with the
+        // fallback — but the failure is logged so it isn't silently lost.
+        let resolvedTitle: String
+        if let supplied = newSessionTitle {
+            resolvedTitle = supplied
         } else if let sessionStore {
             let sessions: [ChatSessionRecord]
             do {
@@ -662,12 +924,12 @@ public final class ConversationRuntime: Sendable {
                 )
                 sessions = []
             }
-            newSessionTitle = sessions.first(where: { $0.id == input.sourceSessionID })?.title ?? "New Chat"
+            resolvedTitle = sessions.first(where: { $0.id == sourceSessionID })?.title ?? "New Chat"
         } else {
-            newSessionTitle = "New Chat"
+            resolvedTitle = "New Chat"
         }
 
-        let newSession = ChatSessionRecord(id: input.newSessionID, title: newSessionTitle)
+        let newSession = ChatSessionRecord(id: newSessionID, title: resolvedTitle)
         if let sessionStore {
             do {
                 try await insertSession(sessionStore: sessionStore, session: newSession)
@@ -676,13 +938,14 @@ public final class ConversationRuntime: Sendable {
             }
         }
 
-        // Copy messages into the new session with fresh IDs and updated sessionID.
+        // Copy messages into the new session with fresh IDs and updated
+        // sessionID.
         for original in slice {
             let copy = ChatMessageRecord(
                 role: original.role,
                 contentParts: original.contentParts,
                 timestamp: original.timestamp,
-                sessionID: input.newSessionID
+                sessionID: newSessionID
             )
             do {
                 try await insertMessage(copy)
@@ -691,172 +954,58 @@ public final class ConversationRuntime: Sendable {
             }
         }
 
-        emit(.sessionBranched(newSessionID: input.newSessionID, copiedCount: slice.count))
+        emit(.sessionBranched(newSessionID: newSessionID, copiedCount: slice.count))
 
         // Optionally trigger generation on the new session.
-        guard input.generateAfterBranch, slice.last?.role == .user else {
+        guard generateAfter, slice.last?.role == .user else {
             return nil
         }
 
         let handle = ConversationStreamHandle()
-        Task.detached { [self] in
-            await runBranchGenerationTurn(input: input, branchedHistory: slice, handle: handle)
-        }
-        return handle
-    }
-
-    // MARK: Send turn
-
-    private func runSendTurn(
-        input: SendInput,
-        handle: ConversationStreamHandle
-    ) async {
-        // 1. Build history first — one store fetch covers both the message
-        //    count for context assembly and the structured messages for
-        //    enqueueAsync. By the time we get here, the user message we
-        //    just inserted is in the store (insertMessage awaited above).
-        //    We do not include the empty assistant slot — it is not yet
-        //    inserted.
-        let history: [ChatMessageRecord]
-        do {
-            history = try await fetchMessages(sessionID: input.sessionID)
-        } catch {
-            emit(.errorRaised(.persistence(error)))
-            return
-        }
-
-        await runGenerationTurn(
-            sessionID: input.sessionID,
-            userPrompt: input.userText,
-            history: history,
-            systemPrompt: input.systemPrompt,
-            temperature: input.temperature,
-            topP: input.topP,
-            repeatPenalty: input.repeatPenalty,
-            maxOutputTokens: input.maxOutputTokens,
-            maxThinkingTokens: input.maxThinkingTokens,
-            streamingUpdateInterval: input.streamingUpdateInterval,
-            streamingBatchCharacterLimit: input.streamingBatchCharacterLimit,
-            thinkingStreamingUpdateInterval: input.thinkingStreamingUpdateInterval,
-            thinkingStreamingBatchCharacterLimit: input.thinkingStreamingBatchCharacterLimit,
-            loopDetectionEnabled: input.loopDetectionEnabled,
-            handle: handle
-        )
-    }
-
-    // MARK: Regenerate turn
-
-    private func runRegenerateTurn(
-        input: RegenerateInput,
-        handle: ConversationStreamHandle
-    ) async {
-        // Fetch history after deletion — the removed assistant message is
-        // gone, so context assembly starts from the last user turn.
-        let history: [ChatMessageRecord]
-        do {
-            history = try await fetchMessages(sessionID: input.sessionID)
-        } catch {
-            emit(.errorRaised(.persistence(error)))
-            return
-        }
-
-        await runGenerationTurn(
-            sessionID: input.sessionID,
-            userPrompt: nil,
-            history: history,
-            systemPrompt: input.systemPrompt,
-            temperature: input.temperature,
-            topP: input.topP,
-            repeatPenalty: input.repeatPenalty,
-            maxOutputTokens: input.maxOutputTokens,
-            maxThinkingTokens: input.maxThinkingTokens,
-            streamingUpdateInterval: input.streamingUpdateInterval,
-            streamingBatchCharacterLimit: input.streamingBatchCharacterLimit,
-            thinkingStreamingUpdateInterval: input.thinkingStreamingUpdateInterval,
-            thinkingStreamingBatchCharacterLimit: input.thinkingStreamingBatchCharacterLimit,
-            loopDetectionEnabled: input.loopDetectionEnabled,
-            handle: handle
-        )
-    }
-
-    // MARK: Edit generation turn
-
-    private func runEditGenerationTurn(
-        input: EditInput,
-        handle: ConversationStreamHandle
-    ) async {
-        // Fetch history fresh after the synchronous edit + deletion — the
-        // updated message and removed trailing messages are already
-        // committed to the store before the detached task runs.
-        let history: [ChatMessageRecord]
-        do {
-            history = try await fetchMessages(sessionID: input.sessionID)
-        } catch {
-            emit(.errorRaised(.persistence(error)))
-            return
-        }
-
-        // `prompt: nil` — same as regenerate; no new user-supplied text.
-        await runGenerationTurn(
-            sessionID: input.sessionID,
-            userPrompt: nil,
-            history: history,
-            systemPrompt: input.systemPrompt,
-            temperature: input.temperature,
-            topP: input.topP,
-            repeatPenalty: input.repeatPenalty,
-            maxOutputTokens: input.maxOutputTokens,
-            maxThinkingTokens: input.maxThinkingTokens,
-            streamingUpdateInterval: input.streamingUpdateInterval,
-            streamingBatchCharacterLimit: input.streamingBatchCharacterLimit,
-            thinkingStreamingUpdateInterval: input.thinkingStreamingUpdateInterval,
-            thinkingStreamingBatchCharacterLimit: input.thinkingStreamingBatchCharacterLimit,
-            loopDetectionEnabled: input.loopDetectionEnabled,
-            handle: handle
-        )
-    }
-
-    // MARK: Branch generation turn
-
-    private func runBranchGenerationTurn(
-        input: BranchInput,
-        branchedHistory: [ChatMessageRecord],
-        handle: ConversationStreamHandle
-    ) async {
-        // Re-fetch from the new session so the history reflects the persisted
-        // copies with their new IDs and sessionID.
-        let history: [ChatMessageRecord]
-        do {
-            history = try await fetchMessages(sessionID: input.newSessionID)
-        } catch {
-            emit(.errorRaised(.persistence(error)))
-            return
-        }
-
-        // BranchInput does not carry streaming/loop knobs; use defaults
-        // matching GenerationQueue's current behaviour.
-        await runGenerationTurn(
-            sessionID: input.newSessionID,
-            userPrompt: nil,
-            history: history,
-            systemPrompt: input.systemPrompt,
-            temperature: input.temperature,
-            topP: input.topP,
-            repeatPenalty: input.repeatPenalty,
-            maxOutputTokens: input.maxOutputTokens,
-            maxThinkingTokens: input.maxThinkingTokens,
+        // BranchInput historically pinned the streaming/loop knobs to
+        // hard-coded defaults regardless of caller config (see legacy
+        // BranchInput, which only carried sampling knobs). Preserve that
+        // by overriding those four fields when running the branch flow,
+        // even though TurnConfig now carries them. If callers want
+        // configurable streaming for branched generation, that's a
+        // follow-up tuning knob.
+        let branchConfig = TurnConfig(
+            systemPrompt: config.systemPrompt,
+            temperature: config.temperature,
+            topP: config.topP,
+            repeatPenalty: config.repeatPenalty,
+            maxOutputTokens: config.maxOutputTokens,
+            maxThinkingTokens: config.maxThinkingTokens,
             streamingUpdateInterval: .milliseconds(33),
             streamingBatchCharacterLimit: 128,
             thinkingStreamingUpdateInterval: .milliseconds(33),
             thinkingStreamingBatchCharacterLimit: 128,
-            loopDetectionEnabled: true,
-            handle: handle
+            loopDetectionEnabled: true
         )
+        Task.detached { [self] in
+            // Re-fetch from the new session so the history reflects the
+            // persisted copies with their new IDs and sessionID.
+            let history: [ChatMessageRecord]
+            do {
+                history = try await fetchMessages(sessionID: newSessionID)
+            } catch {
+                emit(.errorRaised(.persistence(error)))
+                return
+            }
+            await runGenerationTurn(
+                sessionID: newSessionID,
+                userPrompt: nil,
+                history: history,
+                config: branchConfig,
+                handle: handle
+            )
+        }
+        return handle
     }
 
     // MARK: Shared generation inner loop
     //
-    // All four turn methods (send, regenerate, edit, branch) converge here
+    // All four turn flows (send, regenerate, edit, branch) converge here
     // after their respective setup steps. The caller is responsible for
     // fetching a clean `history` slice; this method owns context assembly →
     // enqueue → drain → finalise.
@@ -865,17 +1014,7 @@ public final class ConversationRuntime: Sendable {
         sessionID: UUID,
         userPrompt: String?,
         history: [ChatMessageRecord],
-        systemPrompt: String?,
-        temperature: Float,
-        topP: Float,
-        repeatPenalty: Float,
-        maxOutputTokens: Int?,
-        maxThinkingTokens: Int?,
-        streamingUpdateInterval: Duration,
-        streamingBatchCharacterLimit: Int,
-        thinkingStreamingUpdateInterval: Duration,
-        thinkingStreamingBatchCharacterLimit: Int,
-        loopDetectionEnabled: Bool,
+        config: TurnConfig,
         handle: ConversationStreamHandle
     ) async {
         let messageCount = history.count
@@ -914,7 +1053,7 @@ public final class ConversationRuntime: Sendable {
         )
         let assistantID = assistantMessage.id
 
-        let composedSystemPrompt = composeSystemPrompt(systemPrompt, slots: slots)
+        let composedSystemPrompt = composeSystemPrompt(config.systemPrompt, slots: slots)
 
         let structuredHistory: [StructuredMessage] = history.map { record in
             StructuredMessage(role: record.role.rawValue, parts: record.contentParts)
@@ -935,11 +1074,11 @@ public final class ConversationRuntime: Sendable {
             (token, stream) = try await inferenceService.enqueueAsync(
                 structuredMessages: structuredHistory,
                 systemPrompt: composedSystemPrompt,
-                temperature: temperature,
-                topP: topP,
-                repeatPenalty: repeatPenalty,
-                maxOutputTokens: maxOutputTokens,
-                maxThinkingTokens: maxThinkingTokens,
+                temperature: config.temperature,
+                topP: config.topP,
+                repeatPenalty: config.repeatPenalty,
+                maxOutputTokens: config.maxOutputTokens,
+                maxThinkingTokens: config.maxThinkingTokens,
                 tools: advertisedTools,
                 priority: .userInitiated,
                 sessionID: sessionID
@@ -974,14 +1113,14 @@ public final class ConversationRuntime: Sendable {
         var streamFailed: ConversationError?
         var tokenUsage: (promptTokens: Int, completionTokens: Int)?
 
-        var consumer = GenerationStreamConsumer(loopDetectionEnabled: loopDetectionEnabled)
+        var consumer = GenerationStreamConsumer(loopDetectionEnabled: config.loopDetectionEnabled)
         var batcher = StreamingTokenBatcher(
-            interval: streamingUpdateInterval,
-            maxBufferedCharacters: streamingBatchCharacterLimit
+            interval: config.streamingUpdateInterval,
+            maxBufferedCharacters: config.streamingBatchCharacterLimit
         )
         var thinkingBatcher = StreamingTokenBatcher(
-            interval: thinkingStreamingUpdateInterval,
-            maxBufferedCharacters: thinkingStreamingBatchCharacterLimit
+            interval: config.thinkingStreamingUpdateInterval,
+            maxBufferedCharacters: config.thinkingStreamingBatchCharacterLimit
         )
         var thinkingAccumulator = ""
         var thinkingDisplayed = ""

--- a/Sources/BaseChatRuntime/Services/SessionListService.swift
+++ b/Sources/BaseChatRuntime/Services/SessionListService.swift
@@ -317,9 +317,7 @@ package final class SessionListService: Sendable {
         using inferenceService: InferenceService
     ) async throws -> String? {
         let systemPrompt = "Generate a concise 3-5 word title for a conversation that starts with the following message. Reply with ONLY the title, no punctuation, no quotes."
-        let messages: [(role: String, content: String)] = [
-            (role: "user", content: firstMessage)
-        ]
+        let messages: [Message] = [.user(firstMessage)]
         let (_, stream) = try inferenceService.enqueue(
             messages: messages,
             systemPrompt: systemPrompt,

--- a/Sources/BaseChatTestSupport/ConversationRuntimeScenario.swift
+++ b/Sources/BaseChatTestSupport/ConversationRuntimeScenario.swift
@@ -193,19 +193,35 @@ enum ConversationRuntimeScenarioRunner {
             return await driveAndAwait(
                 step: step,
                 runtime: runtime,
-                drivingAction: { try await runtime.send(SendInput(sessionID: sessionID, userText: text)) }
+                drivingAction: {
+                    let handle = try await runtime.processTurn(
+                        TurnInput(sessionID: sessionID, kind: .send(text: text))
+                    )
+                    // `.send` always produces a stream handle.
+                    return handle ?? ConversationStreamHandle()
+                }
             )
         case .regenerate:
             return await driveAndAwait(
                 step: step,
                 runtime: runtime,
-                drivingAction: { try await runtime.regenerate(RegenerateInput(sessionID: sessionID)) }
+                drivingAction: {
+                    let handle = try await runtime.processTurn(
+                        TurnInput(sessionID: sessionID, kind: .regenerate)
+                    )
+                    return handle ?? ConversationStreamHandle()
+                }
             )
         case .cancelMidStream(let text, _):
             return await driveAndAwait(
                 step: step,
                 runtime: runtime,
-                drivingAction: { try await runtime.send(SendInput(sessionID: sessionID, userText: text)) }
+                drivingAction: {
+                    let handle = try await runtime.processTurn(
+                        TurnInput(sessionID: sessionID, kind: .send(text: text))
+                    )
+                    return handle ?? ConversationStreamHandle()
+                }
             )
         }
     }

--- a/Sources/BaseChatUI/ViewModels/ChatViewModel+Messages.swift
+++ b/Sources/BaseChatUI/ViewModels/ChatViewModel+Messages.swift
@@ -2,14 +2,70 @@ import Foundation
 import BaseChatRuntime
 import BaseChatInference
 
-// MARK: - NoResponseError
+// MARK: - SendMessageError
 
-/// Thrown by `sendMessage(_:)` when a turn completes without producing a
-/// visible assistant message (e.g. empty output or a precondition failure).
-public struct NoResponseError: LocalizedError {
-    public var errorDescription: String? { "Turn ended without producing a response" }
-    public init() {}
+/// Typed failure modes for ``ChatViewModel/sendMessage(_:)``.
+///
+/// Replaces the old `NoResponseError` opaque struct so callers can
+/// pattern-match the actual upstream failure rather than guess from the
+/// localizedDescription. Each case maps to one observable precondition or
+/// outcome of a single-turn drive:
+///
+/// - ``noActiveSession`` — `activeSessionID` was `nil` at call time.
+/// - ``noModelLoaded`` — `isModelLoaded` was `false` at call time.
+/// - ``empty`` — the turn ended (`lastTurnState == .idle`) with no assistant
+///   record produced and no error surfaced.
+/// - ``runtime(_:)`` — the underlying `ConversationRuntime` produced an
+///   error (persistence / inference / context assembly / cancellation).
+public enum SendMessageError: Error, Sendable {
+    /// `activeSessionID` was `nil`. Create or select a session first.
+    case noActiveSession
+    /// No model is loaded. Select a model from the sidebar first.
+    case noModelLoaded
+    /// The turn ended without producing tokens and without an error.
+    /// Maps to a runtime ``FinishReason/empty`` or a precondition that
+    /// was satisfied at call time but produced no output downstream.
+    case empty
+    /// The runtime surfaced an error. The wrapped value is whatever the
+    /// runtime reported (typically `ConversationError` or `ChatError`).
+    case runtime(any Error)
 }
+
+extension SendMessageError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .noActiveSession:
+            return "No active session. Create or select a session first."
+        case .noModelLoaded:
+            return "No model loaded. Select a model from the sidebar first."
+        case .empty:
+            return "Turn ended without producing a response."
+        case let .runtime(error):
+            return error.localizedDescription
+        }
+    }
+}
+
+// MARK: - ChatErrorBridge
+
+/// Adapts a ``ChatError`` value type into something that conforms to
+/// `Error`. ``ChatError`` deliberately does not conform to `Error` (it's a
+/// presentation-layer struct with `kind`/`recovery`/`message`); when
+/// ``ChatViewModel/sendMessage(_:)`` needs to surface a precondition error
+/// that lives only on `activeError`, this bridge lifts it into the typed
+/// `Error` channel without forcing `ChatError` itself to conform.
+struct ChatErrorBridge: LocalizedError, Sendable {
+    let chatError: ChatError
+    var errorDescription: String? { chatError.message }
+}
+
+// MARK: - NoResponseError (deprecated alias)
+
+/// Deprecated alias retained for one minor while consumers migrate to
+/// ``SendMessageError``. New code should pattern-match on
+/// ``SendMessageError`` directly.
+@available(*, deprecated, renamed: "SendMessageError", message: "Switch on SendMessageError to distinguish noActiveSession / noModelLoaded / empty / runtime(Error). NoResponseError will be removed in a future release.")
+public typealias NoResponseError = SendMessageError
 
 // MARK: - ChatViewModel + Messages
 
@@ -20,21 +76,50 @@ extension ChatViewModel {
     /// Convenience for scripted drivers and integration tests that want to drive
     /// one turn without setting `inputText` and polling observation surfaces.
     ///
-    /// - Throws: The underlying `ConversationError` on inference/persistence
-    ///   failure, or a `ChatError` when the preconditions aren't met (no session,
-    ///   no model loaded). Throws if the turn ends without producing a response
-    ///   (e.g. empty output or an unhandled stop reason).
+    /// - Throws: ``SendMessageError`` — `.noActiveSession` / `.noModelLoaded` for
+    ///   precondition failures, `.empty` when the turn produces no assistant
+    ///   record, or `.runtime(error)` when the underlying runtime surfaces an
+    ///   error.
     @discardableResult
     public func sendMessage(_ text: String) async throws -> ChatMessageRecord {
+        // Check preconditions BEFORE invoking the runtime so callers that
+        // pattern-match on SendMessageError see the precondition case rather
+        // than an opaque runtime error. The inner sendMessage() also performs
+        // these checks (and surfaces them via activeError / errorMessage),
+        // but routing them here gives the typed-error caller a clean shape.
+        guard activeSessionID != nil else {
+            throw SendMessageError.noActiveSession
+        }
+        guard isModelLoaded else {
+            throw SendMessageError.noModelLoaded
+        }
+
         inputText = text
         await sendMessage()
         switch lastTurnState {
         case .completed(let record):
             return record
         case .failed(let error):
-            throw error
+            throw SendMessageError.runtime(error)
         case .idle, .generating:
-            throw NoResponseError()
+            // The inner sendMessage() may have surfaced the failure on
+            // `activeError` (e.g. precondition that flipped between our
+            // check above and the inner check, or a runtime fault that
+            // couldn't be reported through `lastTurnState`). Propagate as
+            // `.runtime(activeError)` so the caller still sees the typed
+            // shape; fall back to `.empty` when no error was recorded.
+            if let active = activeError {
+                // ChatError is a value type without `Error` conformance —
+                // the API freeze pins its shape so we can't retroactively
+                // conform it. Use the wrapped underlying error if it's
+                // available; otherwise wrap the message in an ad-hoc
+                // bridge so the typed shape is preserved.
+                if let underlying = active.underlyingError {
+                    throw SendMessageError.runtime(underlying)
+                }
+                throw SendMessageError.runtime(ChatErrorBridge(chatError: active))
+            }
+            throw SendMessageError.empty
         }
     }
 
@@ -68,29 +153,17 @@ extension ChatViewModel {
             await onFirstMessage?(session, text)
         }
 
-        let resolvedSystemPrompt = effectiveSystemPrompt()
-        let input = SendInput(
+        let input = TurnInput(
             sessionID: activeSessionID,
-            userText: text,
-            attachments: attachments,
-            systemPrompt: resolvedSystemPrompt,
-            temperature: temperature,
-            topP: topP,
-            repeatPenalty: repeatPenalty,
-            maxOutputTokens: maxOutputTokens,
-            maxThinkingTokens: maxThinkingTokens,
-            streamingUpdateInterval: streamingUpdateInterval,
-            streamingBatchCharacterLimit: streamingBatchCharacterLimit,
-            thinkingStreamingUpdateInterval: thinkingStreamingUpdateInterval,
-            thinkingStreamingBatchCharacterLimit: thinkingStreamingBatchCharacterLimit,
-            loopDetectionEnabled: loopDetectionEnabled
+            kind: .send(text: text, attachments: attachments),
+            config: makeTurnConfig(systemPrompt: effectiveSystemPrompt())
         )
         do {
-            let handle = try await conversationRuntime.send(input)
+            let handle = try await conversationRuntime.processTurn(input)
             activeConversationStreamHandle = handle
             await awaitStreamCompletion()
         } catch {
-            Log.persistence.error("ConversationRuntime.send failed: \(error)")
+            Log.persistence.error("ConversationRuntime.processTurn(.send) failed: \(error)")
             surfaceError(error, kind: .persistence)
         }
     }
@@ -101,26 +174,17 @@ extension ChatViewModel {
 
         guard let activeSessionID else { return }
 
-        let input = RegenerateInput(
+        let input = TurnInput(
             sessionID: activeSessionID,
-            systemPrompt: effectiveSystemPrompt(),
-            temperature: temperature,
-            topP: topP,
-            repeatPenalty: repeatPenalty,
-            maxOutputTokens: maxOutputTokens,
-            maxThinkingTokens: maxThinkingTokens,
-            streamingUpdateInterval: streamingUpdateInterval,
-            streamingBatchCharacterLimit: streamingBatchCharacterLimit,
-            thinkingStreamingUpdateInterval: thinkingStreamingUpdateInterval,
-            thinkingStreamingBatchCharacterLimit: thinkingStreamingBatchCharacterLimit,
-            loopDetectionEnabled: loopDetectionEnabled
+            kind: .regenerate,
+            config: makeTurnConfig(systemPrompt: effectiveSystemPrompt())
         )
         do {
-            let handle = try await conversationRuntime.regenerate(input)
+            let handle = try await conversationRuntime.processTurn(input)
             activeConversationStreamHandle = handle
             await awaitStreamCompletion()
         } catch {
-            Log.ui.error("ConversationRuntime.regenerate failed: \(error)")
+            Log.ui.error("ConversationRuntime.processTurn(.regenerate) failed: \(error)")
             surfaceError(error, kind: .generation)
         }
     }
@@ -132,30 +196,19 @@ extension ChatViewModel {
 
         guard let activeSessionID else { return }
 
-        let input = EditInput(
+        let input = TurnInput(
             sessionID: activeSessionID,
-            messageID: messageID,
-            newContent: newContent,
-            systemPrompt: effectiveSystemPrompt(),
-            temperature: temperature,
-            topP: topP,
-            repeatPenalty: repeatPenalty,
-            maxOutputTokens: maxOutputTokens,
-            maxThinkingTokens: maxThinkingTokens,
-            streamingUpdateInterval: streamingUpdateInterval,
-            streamingBatchCharacterLimit: streamingBatchCharacterLimit,
-            thinkingStreamingUpdateInterval: thinkingStreamingUpdateInterval,
-            thinkingStreamingBatchCharacterLimit: thinkingStreamingBatchCharacterLimit,
-            loopDetectionEnabled: loopDetectionEnabled
+            kind: .edit(messageID: messageID, text: newContent),
+            config: makeTurnConfig(systemPrompt: effectiveSystemPrompt())
         )
         // Invalidate the token cache for the edited message — content changed.
         tokenCountCache.removeValue(forKey: messageID)
         do {
-            let handle = try await conversationRuntime.edit(input)
+            let handle = try await conversationRuntime.processTurn(input)
             activeConversationStreamHandle = handle
             await awaitStreamCompletion()
         } catch {
-            Log.ui.error("ConversationRuntime.edit failed: \(error)")
+            Log.ui.error("ConversationRuntime.processTurn(.edit) failed: \(error)")
             surfaceError(error, kind: .generation)
         }
     }
@@ -233,14 +286,14 @@ extension ChatViewModel {
     /// session. No-op when no session is active.
     public func branch(from messageID: UUID) async {
         guard let activeSessionID else { return }
-        let input = BranchInput(
-            sourceSessionID: activeSessionID,
-            branchMessageID: messageID
+        let input = TurnInput(
+            sessionID: activeSessionID,
+            kind: .branch(messageID: messageID)
         )
         do {
-            _ = try await conversationRuntime.branch(input)
+            _ = try await conversationRuntime.processTurn(input)
         } catch {
-            Log.ui.error("ConversationRuntime.branch failed: \(error)")
+            Log.ui.error("ConversationRuntime.processTurn(.branch) failed: \(error)")
             surfaceError(error, kind: .persistence)
         }
     }
@@ -348,6 +401,27 @@ extension ChatViewModel {
     public func consumeScrollToMessageRequest(_ request: ChatScrollToMessageRequest) {
         guard scrollToMessageRequest?.requestID == request.requestID else { return }
         scrollToMessageRequest = nil
+    }
+
+    /// Builds a ``TurnConfig`` from the view model's current sampling/streaming
+    /// state. Centralised so each turn-flow call site reads the same pinned
+    /// snapshot — adding a knob is a one-touch change here, not five edits
+    /// across the call sites that used to construct one of `SendInput`,
+    /// `RegenerateInput`, `EditInput`, or `BranchInput`.
+    func makeTurnConfig(systemPrompt: String?) -> TurnConfig {
+        TurnConfig(
+            systemPrompt: systemPrompt,
+            temperature: temperature,
+            topP: topP,
+            repeatPenalty: repeatPenalty,
+            maxOutputTokens: maxOutputTokens,
+            maxThinkingTokens: maxThinkingTokens,
+            streamingUpdateInterval: streamingUpdateInterval,
+            streamingBatchCharacterLimit: streamingBatchCharacterLimit,
+            thinkingStreamingUpdateInterval: thinkingStreamingUpdateInterval,
+            thinkingStreamingBatchCharacterLimit: thinkingStreamingBatchCharacterLimit,
+            loopDetectionEnabled: loopDetectionEnabled
+        )
     }
 
     func stageDraftAttachment(_ part: MessagePart) {

--- a/Sources/BaseChatUI/ViewModels/RuntimeConfiguration.swift
+++ b/Sources/BaseChatUI/ViewModels/RuntimeConfiguration.swift
@@ -1,15 +1,35 @@
 import BaseChatRuntime
 
 extension ChatViewModel {
+    /// Canonical bootstrap-wiring entry point.
+    ///
+    /// Wires the bootstrap's persistence stores, endpoint store, and (if
+    /// image generation is enabled) the image runtime onto this view model.
+    /// The shared ``ConversationRuntime`` is constructor-injected, not wired
+    /// here — pass `bootstrap.conversationRuntime` to ``ChatViewModel/init``
+    /// so the runtime is available before the first observation occurs.
+    /// Calling this method late (after construction) cannot retroactively
+    /// replace the non-optional runtime stored on the view model.
+    ///
+    /// - Parameter bootstrap: The fully-constructed runtime bootstrap.
+    @MainActor
+    public func configure(bootstrap: any ChatRuntimeBootstrap) {
+        configure(persistence: bootstrap.persistenceStores)
+        configure(endpointStore: bootstrap.apiEndpointStore)
+        if let imageRuntime = bootstrap.imageGenerationRuntime {
+            configure(imageRuntime: imageRuntime)
+        }
+    }
+
     /// Preferred bootstrap path for apps that assemble shared services through
     /// a ``ChatRuntimeBootstrap``. Wires the persistence and endpoint stores
     /// onto the view model.
     ///
-    /// The shared ``ConversationRuntime`` is constructor-injected, not wired
-    /// here — pass `runtime.conversationRuntime` to ``ChatViewModel/init`` so
-    /// the runtime is available before the first observation occurs. Calling
-    /// this method late (after construction) cannot retroactively replace the
-    /// non-optional runtime stored on the view model.
+    /// Behaviour preserved as a deprecation shim — pre-I6 this overload did
+    /// not wire `imageGenerationRuntime`. New callers should use
+    /// ``configure(bootstrap:)``, which wires the image runtime when present.
+    @available(*, deprecated, renamed: "configure(bootstrap:)", message: "Use configure(bootstrap:) — it also wires imageGenerationRuntime when the bootstrap exposes one.")
+    @MainActor
     public func configure(runtime: any ChatRuntimeBootstrap) {
         configure(persistence: runtime.persistenceStores)
         configure(endpointStore: runtime.apiEndpointStore)
@@ -17,19 +37,12 @@ extension ChatViewModel {
 
     /// Wires the bootstrap's runtimes into this ``ChatViewModel``.
     ///
-    /// Equivalent to calling `configure(persistence:)` with the bootstrap's
-    /// persistence layer and (if image generation is enabled)
-    /// `configure(imageRuntime:)` with the bootstrap's
-    /// ``ChatRuntimeBootstrap/imageGenerationRuntime``.
-    ///
-    /// - Parameter bootstrap: The fully-constructed runtime bootstrap.
+    /// Equivalent to ``configure(bootstrap:)``. Retained as a deprecation
+    /// shim for one minor while adopters migrate.
+    @available(*, deprecated, renamed: "configure(bootstrap:)", message: "Use configure(bootstrap:) — same behaviour, more explicit argument label.")
     @MainActor
     public func configure(_ bootstrap: any ChatRuntimeBootstrap) {
-        configure(persistence: bootstrap.persistenceStores)
-        configure(endpointStore: bootstrap.apiEndpointStore)
-        if let imageRuntime = bootstrap.imageGenerationRuntime {
-            configure(imageRuntime: imageRuntime)
-        }
+        configure(bootstrap: bootstrap)
     }
 }
 
@@ -38,11 +51,17 @@ extension SessionManagerViewModel {
     /// a ``ChatRuntimeBootstrap``. Schedules the initial session load so the UI
     /// matches pre-Phase-1.0 behavior. Direct callers of
     /// ``configure(persistence:autoLoad:diagnostics:)`` must opt in explicitly.
-    public func configure(runtime: any ChatRuntimeBootstrap) {
+    public func configure(bootstrap: any ChatRuntimeBootstrap) {
         configure(
-            persistence: runtime.persistenceStores,
+            persistence: bootstrap.persistenceStores,
             autoLoad: true,
-            diagnostics: runtime.diagnosticsService
+            diagnostics: bootstrap.diagnosticsService
         )
+    }
+
+    /// Deprecated shim kept for one minor.
+    @available(*, deprecated, renamed: "configure(bootstrap:)", message: "Use configure(bootstrap:) — same behaviour.")
+    public func configure(runtime: any ChatRuntimeBootstrap) {
+        configure(bootstrap: runtime)
     }
 }

--- a/Tests/BaseChatInferenceTests/MessageEnqueueTests.swift
+++ b/Tests/BaseChatInferenceTests/MessageEnqueueTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// I6 introduces a typed ``Message`` enum (`.system` / `.user` / `.assistant`)
+/// for the ``InferenceService/enqueue(messages:...)`` overload. The legacy
+/// `[(role: String, content: String)]` tuple variant is retained as a
+/// deprecation shim. These tests pin the typed variant's wire mapping.
+@MainActor
+final class MessageEnqueueTests: XCTestCase {
+
+    /// Captures the prompt the backend ultimately receives so we can verify
+    /// the typed messages flow through to the wire shape.
+    private final class CapturingBackend: InferenceBackend, @unchecked Sendable {
+        var isModelLoaded: Bool = true
+        var isGenerating: Bool = false
+        let capabilities = BackendCapabilities(
+            supportedParameters: [.temperature],
+            maxContextTokens: 4096,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true
+        )
+        var lastPrompt: String?
+        var lastSystemPrompt: String?
+
+        func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
+            isModelLoaded = true
+        }
+
+        func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> GenerationStream {
+            lastPrompt = prompt
+            lastSystemPrompt = systemPrompt
+            return GenerationStream(AsyncThrowingStream<GenerationEvent, Error> { continuation in
+                continuation.yield(.token("ok"))
+                continuation.finish()
+            })
+        }
+
+        func stopGeneration() {}
+        func unloadModel() { isModelLoaded = false }
+    }
+
+    // MARK: - .user mapping
+
+    func test_enqueue_userMessage_mapsToUserRole() async throws {
+        let backend = CapturingBackend()
+        let service = InferenceService(backend: backend, name: "Capture")
+
+        let (_, stream) = try service.enqueue(messages: [.user("hello world")])
+        for try await _ in stream.events {}
+
+        // The default backend prompt-format places "User: hello world" in the
+        // composed prompt. We assert on the substring (not exact format) so
+        // the test isn't coupled to prompt-template trivia.
+        let prompt = try XCTUnwrap(backend.lastPrompt)
+        XCTAssertTrue(prompt.contains("hello world"),
+                      "User content should reach the backend prompt; got: \(prompt)")
+    }
+
+    // MARK: - systemPrompt parameter is honoured alongside .user
+
+    func test_enqueue_systemPromptParameter_routesToBackend() async throws {
+        // The Message variant doesn't reroute `.system` cases into the
+        // top-level systemPrompt parameter — that's an explicit caller
+        // choice via the `systemPrompt:` argument. Pin that the typed
+        // overload still threads systemPrompt through correctly.
+        let backend = CapturingBackend()
+        let service = InferenceService(backend: backend, name: "Capture")
+
+        let (_, stream) = try service.enqueue(
+            messages: [.user("hi")],
+            systemPrompt: "you are concise"
+        )
+        for try await _ in stream.events {}
+
+        XCTAssertEqual(backend.lastSystemPrompt, "you are concise",
+                       "systemPrompt argument must reach the backend.")
+    }
+
+    // MARK: - Round-trip with the legacy tuple variant
+
+    /// Constructs the same logical conversation via both overloads and
+    /// asserts the backend sees the same final prompt. Pins that the typed
+    /// variant doesn't accidentally re-encode the messages differently.
+    func test_typedAndTupleVariants_produceSameWireShape() async throws {
+        let typedBackend = CapturingBackend()
+        let typedService = InferenceService(backend: typedBackend, name: "Typed")
+        let (_, typedStream) = try typedService.enqueue(messages: [
+            .user("hi"),
+            .assistant("hello"),
+            .user("how are you?")
+        ])
+        for try await _ in typedStream.events {}
+
+        let tupleBackend = CapturingBackend()
+        let tupleService = InferenceService(backend: tupleBackend, name: "Tuple")
+        // Suppress the deprecation warning on the legacy overload — that's
+        // exactly the surface this round-trip is checking.
+        let (_, tupleStream) = try enqueueTuples(service: tupleService)
+        for try await _ in tupleStream.events {}
+
+        XCTAssertEqual(typedBackend.lastPrompt, tupleBackend.lastPrompt,
+                       "Typed and tuple variants must produce the same composed prompt.")
+    }
+
+    @available(*, deprecated)
+    private func enqueueTuples(
+        service: InferenceService
+    ) throws -> (token: InferenceService.GenerationRequestToken, stream: GenerationStream) {
+        try service.enqueue(messages: [
+            ("user", "hi"),
+            ("assistant", "hello"),
+            ("user", "how are you?")
+        ])
+    }
+
+    // MARK: - Message conformance / role mapping
+
+    /// Smoke-test for the Message → tuple bridge. If a future change adds a
+    /// new case (e.g. `.tool(...)`) the bridge must be updated; this test
+    /// pins the existing role discriminators.
+    func test_message_roleAndContent_areCorrectForEachCase() {
+        XCTAssertEqual(Message.system("s").role, "system")
+        XCTAssertEqual(Message.system("s").content, "s")
+        XCTAssertEqual(Message.user("u").role, "user")
+        XCTAssertEqual(Message.user("u").content, "u")
+        XCTAssertEqual(Message.assistant("a").role, "assistant")
+        XCTAssertEqual(Message.assistant("a").content, "a")
+
+        let tuples: [(role: String, content: String)] = [
+            Message.system("s"),
+            Message.user("u"),
+            Message.assistant("a")
+        ].asRoleContentTuples
+        XCTAssertEqual(tuples.map(\.role), ["system", "user", "assistant"])
+        XCTAssertEqual(tuples.map(\.content), ["s", "u", "a"])
+    }
+}

--- a/Tests/BaseChatInferenceTests/TrafficBoundaryAuditTest.swift
+++ b/Tests/BaseChatInferenceTests/TrafficBoundaryAuditTest.swift
@@ -545,8 +545,13 @@ final class TrafficBoundaryAuditTest: XCTestCase {
     private static let networkIOPattern =
         #"(?<![A-Za-z0-9_])(URLSession|URLRequest|URLSessionConfiguration)(?![A-Za-z0-9_])"#
 
+    /// `system(` is matched only when used as a free function call —
+    /// excluding both member-access (`.system(...)` is a SwiftUI/AppKit
+    /// idiom) and Swift enum case constructors (`case system(...)`).
+    /// The doubled negative lookbehind keeps the C-interop tripwire while
+    /// allowing legitimate Swift idioms.
     private static let cInteropPattern =
-        #"(?<![A-Za-z0-9_])(@_silgen_name|@_cdecl|dlopen\(|dlsym\(|NSClassFromString|objc_getClass|class_createInstance|NSTask|posix_spawn|popen\()|(?<![A-Za-z0-9_.])system\("#
+        #"(?<![A-Za-z0-9_])(@_silgen_name|@_cdecl|dlopen\(|dlsym\(|NSClassFromString|objc_getClass|class_createInstance|NSTask|posix_spawn|popen\()|(?<![A-Za-z0-9_.])(?<!case )system\("#
 
     /// `Process(` as a constructor call — distinguishes from Swift's
     /// `Process` type used as a parameter type. The open-paren is the
@@ -874,6 +879,13 @@ final class TrafficBoundaryAuditTest: XCTestCase {
         let swiftUIFontCall = "Text(\"Hi\").font(.system(.body))"
         XCTAssertFalse(Self.matches(Self.cInteropPattern, in: swiftUIFontCall),
                        "Rule 2 must not match SwiftUI's .system(...) member call")
+
+        // Negative: Swift enum case constructor `case system(...)` must
+        // not match — the C-interop tripwire targets free `system()` calls,
+        // not enum cases. (See `BaseChatInference.Message.system(_:)`.)
+        let enumCase = "    case system(String)"
+        XCTAssertFalse(Self.matches(Self.cInteropPattern, in: enumCase),
+                       "Rule 2 must not match Swift enum case `case system(...)` constructors")
     }
 
     func test_sabotage_rule3_catchesHostnameLiterals() {

--- a/Tests/BaseChatRuntimeTests/TurnInputCollapseTests.swift
+++ b/Tests/BaseChatRuntimeTests/TurnInputCollapseTests.swift
@@ -1,0 +1,370 @@
+import XCTest
+import Foundation
+@testable import BaseChatRuntime
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// I6 collapsed `SendInput` / `RegenerateInput` / `EditInput` / `BranchInput`
+/// into a single ``TurnInput`` + ``TurnConfig`` + ``TurnKind`` triple.
+///
+/// These tests pin two contracts:
+///
+/// 1. **Round-trip parity**: each legacy `*Input` struct produces the same
+///    observable event sequence whether the caller invokes the deprecated
+///    `runtime.send(_:)` / `regenerate(_:)` / `edit(_:)` / `branch(_:)`
+///    overloads or the canonical `runtime.processTurn(_:)` with the
+///    matching ``TurnKind``.
+/// 2. **Knob propagation**: the per-flow knobs encoded on ``TurnConfig``
+///    reach the inner generation loop intact (proxied via the assistant
+///    record produced by a finished turn).
+@MainActor
+final class TurnInputCollapseTests: XCTestCase {
+
+    // MARK: - In-memory MessageStore (minimal — sibling to ConversationRuntimeTests')
+
+    @MainActor
+    final class MemoryStore: MessageStore {
+        private(set) var messages: [UUID: ChatMessageRecord] = [:]
+
+        func insertMessage(_ message: ChatMessageRecord) async throws {
+            messages[message.id] = message
+        }
+
+        func updateMessage(_ message: ChatMessageRecord) async throws {
+            guard messages[message.id] != nil else {
+                throw ChatPersistenceError.messageNotFound(message.id)
+            }
+            messages[message.id] = message
+        }
+
+        func deleteMessage(_ messageID: UUID) async throws {
+            guard messages.removeValue(forKey: messageID) != nil else {
+                throw ChatPersistenceError.messageNotFound(messageID)
+            }
+        }
+
+        func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
+            messages.values
+                .filter { $0.sessionID == sessionID }
+                .sorted { $0.timestamp < $1.timestamp }
+        }
+
+        func deleteMessages(for sessionID: UUID) async throws {
+            messages = messages.filter { $0.value.sessionID != sessionID }
+        }
+
+        func addPostWriteHook(_ hook: any MessageStorePostWriteHook) {}
+    }
+
+    @MainActor
+    final class MemorySessionStore: SessionStore {
+        private(set) var sessions: [UUID: ChatSessionRecord] = [:]
+
+        func insertSession(_ session: ChatSessionRecord) async throws {
+            sessions[session.id] = session
+        }
+
+        func updateSession(_ session: ChatSessionRecord) async throws {
+            guard sessions[session.id] != nil else {
+                throw ChatPersistenceError.sessionNotFound(session.id)
+            }
+            sessions[session.id] = session
+        }
+
+        func deleteSession(_ sessionID: UUID) async throws {
+            sessions.removeValue(forKey: sessionID)
+        }
+
+        func fetchSessions() async throws -> [ChatSessionRecord] {
+            sessions.values.sorted { $0.updatedAt > $1.updatedAt }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeRuntime(
+        tokens: [String] = ["a", "b"],
+        sessionStore: MemorySessionStore? = nil
+    ) -> (ConversationRuntime, MemoryStore, MemorySessionStore?) {
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = tokens
+        let inference = InferenceService(backend: backend, name: "Mock")
+        let store = MemoryStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            sessionStore: sessionStore,
+            inferenceService: inference,
+            pipeline: nil
+        )
+        return (runtime, store, sessionStore)
+    }
+
+    enum DrainError: Error { case deadlineElapsed }
+
+    private func drainUntilAfterGeneration(
+        _ runtime: ConversationRuntime,
+        deadline: Duration = .seconds(5)
+    ) async throws -> [ConversationEvent] {
+        var collected: [ConversationEvent] = []
+        let collectTask = Task {
+            for await event in runtime.events {
+                collected.append(event)
+                if case .afterGeneration = event { break }
+                if case .streamFinished(_, let reason) = event, reason == .empty { break }
+            }
+            return collected
+        }
+        return try await withThrowingTaskGroup(of: [ConversationEvent].self) { group in
+            group.addTask { await collectTask.value }
+            group.addTask {
+                try await Task.sleep(for: deadline)
+                collectTask.cancel()
+                throw DrainError.deadlineElapsed
+            }
+            let result = try await group.next()
+            group.cancelAll()
+            return result ?? []
+        }
+    }
+
+    /// Reduces a transcript to a stable shape we can assert across two
+    /// runs. We strip identifiers (UUIDs vary between runs) and message
+    /// timestamps, leaving only the case discriminator and load-bearing
+    /// payloads.
+    private func eventShapes(_ events: [ConversationEvent]) -> [String] {
+        events.map { event -> String in
+            switch event {
+            case let .messageInserted(record):
+                return "messageInserted-\(record.role.rawValue)-\(record.content)"
+            case .beforeContextAssembly:
+                return "beforeContextAssembly"
+            case .contextAssembled:
+                return "contextAssembled"
+            case .streamStarted:
+                return "streamStarted"
+            case let .tokenEmitted(_, delta):
+                return "tokenEmitted-\(delta)"
+            case let .streamFinished(_, reason):
+                return "streamFinished-\(reason)"
+            case let .afterGeneration(_, finalText):
+                return "afterGeneration-\(finalText)"
+            case .messageRemoved:
+                return "messageRemoved"
+            case .messageUpdated:
+                return "messageUpdated"
+            case .sessionBranched:
+                return "sessionBranched"
+            case .errorRaised:
+                return "errorRaised"
+            case .thinkingStarted:
+                return "thinkingStarted"
+            case .thinkingUpdated:
+                return "thinkingUpdated"
+            case .thinkingFinalized:
+                return "thinkingFinalized"
+            case .toolCallRequested:
+                return "toolCallRequested"
+            case .toolCallApproved:
+                return "toolCallApproved"
+            case .toolCallCompleted:
+                return "toolCallCompleted"
+            case .tokenUsageRecorded:
+                return "tokenUsageRecorded"
+            case .loopDetected:
+                return "loopDetected"
+            case .compressionTriggered:
+                return "compressionTriggered"
+            case .sessionTouchFailed:
+                return "sessionTouchFailed"
+            }
+        }
+    }
+
+    // MARK: - Send round-trip
+
+    func test_send_processTurn_matchesLegacySendInput() async throws {
+        // Drive the canonical TurnInput path.
+        let (runtimeNew, _, _) = makeRuntime()
+        let sessionID = UUID()
+        _ = try await runtimeNew.processTurn(
+            TurnInput(sessionID: sessionID, kind: .send(text: "hi"))
+        )
+        let newEvents = try await drainUntilAfterGeneration(runtimeNew)
+
+        // Drive the deprecated SendInput path and confirm the event-sequence
+        // shape matches. Suppress deprecation warnings for the legacy struct
+        // — that's the whole point of this test.
+        let (runtimeLegacy, _, _) = makeRuntime()
+        let legacyInput = legacySendInput(sessionID: sessionID, text: "hi")
+        _ = try await runtimeLegacy.send(legacyInput)
+        let legacyEvents = try await drainUntilAfterGeneration(runtimeLegacy)
+
+        XCTAssertEqual(eventShapes(newEvents), eventShapes(legacyEvents),
+                       "Canonical TurnInput.processTurn and legacy send(SendInput) must produce identical event sequences")
+    }
+
+    // MARK: - Regenerate round-trip
+
+    func test_regenerate_processTurn_matchesLegacyRegenerateInput() async throws {
+        // Seed each runtime with one user + assistant turn so regenerate has
+        // something to replace. Run sequentially so the test class's MainActor
+        // isolation isn't sent across an `async let` boundary.
+        let canonical = try await drivePathA()
+        let legacy = try await drivePathB()
+        XCTAssertEqual(eventShapes(canonical), eventShapes(legacy),
+                       "Canonical regenerate via processTurn(.regenerate) must mirror legacy regenerate(RegenerateInput)")
+    }
+
+    private func drivePathA() async throws -> [ConversationEvent] {
+        let (runtime, _, _) = makeRuntime(tokens: ["second"])
+        let sessionID = UUID()
+        _ = try await runtime.processTurn(TurnInput(sessionID: sessionID, kind: .send(text: "hi")))
+        _ = try await drainUntilAfterGeneration(runtime)
+        _ = try await runtime.processTurn(TurnInput(sessionID: sessionID, kind: .regenerate))
+        return try await drainUntilAfterGeneration(runtime)
+    }
+
+    private func drivePathB() async throws -> [ConversationEvent] {
+        let (runtime, _, _) = makeRuntime(tokens: ["second"])
+        let sessionID = UUID()
+        _ = try await runtime.send(legacySendInput(sessionID: sessionID, text: "hi"))
+        _ = try await drainUntilAfterGeneration(runtime)
+        _ = try await runtime.regenerate(legacyRegenerateInput(sessionID: sessionID))
+        return try await drainUntilAfterGeneration(runtime)
+    }
+
+    // MARK: - Edit round-trip
+
+    func test_edit_processTurn_matchesLegacyEditInput() async throws {
+        // Path A: canonical TurnInput.
+        let (runtimeA, storeA, _) = makeRuntime()
+        let sessionA = UUID()
+        _ = try await runtimeA.processTurn(TurnInput(sessionID: sessionA, kind: .send(text: "first")))
+        _ = try await drainUntilAfterGeneration(runtimeA)
+        let userMsgA = try XCTUnwrap(storeA.messages.values.first { $0.role == .user })
+        _ = try await runtimeA.processTurn(
+            TurnInput(sessionID: sessionA, kind: .edit(messageID: userMsgA.id, text: "edited"))
+        )
+        let canonical = try await drainUntilAfterGeneration(runtimeA)
+
+        // Path B: legacy EditInput.
+        let (runtimeB, storeB, _) = makeRuntime()
+        let sessionB = UUID()
+        _ = try await runtimeB.send(legacySendInput(sessionID: sessionB, text: "first"))
+        _ = try await drainUntilAfterGeneration(runtimeB)
+        let userMsgB = try XCTUnwrap(storeB.messages.values.first { $0.role == .user })
+        _ = try await runtimeB.edit(legacyEditInput(sessionID: sessionB, messageID: userMsgB.id, text: "edited"))
+        let legacy = try await drainUntilAfterGeneration(runtimeB)
+
+        XCTAssertEqual(eventShapes(canonical), eventShapes(legacy),
+                       "Canonical edit via processTurn(.edit) must mirror legacy edit(EditInput)")
+    }
+
+    // MARK: - Branch round-trip
+
+    func test_branch_processTurn_matchesLegacyBranchInput() async throws {
+        // Both paths: send one user+assistant turn, then branch at the user
+        // message with `generateAfter: true` so the new session also runs a
+        // generation pass.
+
+        // Path A: canonical TurnInput.
+        let sessionsA = MemorySessionStore()
+        let (runtimeA, storeA, _) = makeRuntime(sessionStore: sessionsA)
+        let sourceA = UUID()
+        try await sessionsA.insertSession(ChatSessionRecord(id: sourceA, title: "A"))
+        _ = try await runtimeA.processTurn(TurnInput(sessionID: sourceA, kind: .send(text: "hello")))
+        _ = try await drainUntilAfterGeneration(runtimeA)
+        let userA = try XCTUnwrap(storeA.messages.values.first { $0.role == .user })
+        let newSessionA = UUID()
+        _ = try await runtimeA.processTurn(
+            TurnInput(
+                sessionID: sourceA,
+                kind: .branch(messageID: userA.id, newSessionID: newSessionA, generateAfter: true)
+            )
+        )
+        let canonical = try await drainUntilAfterGeneration(runtimeA)
+
+        // Path B: legacy BranchInput.
+        let sessionsB = MemorySessionStore()
+        let (runtimeB, storeB, _) = makeRuntime(sessionStore: sessionsB)
+        let sourceB = UUID()
+        try await sessionsB.insertSession(ChatSessionRecord(id: sourceB, title: "B"))
+        _ = try await runtimeB.send(legacySendInput(sessionID: sourceB, text: "hello"))
+        _ = try await drainUntilAfterGeneration(runtimeB)
+        let userB = try XCTUnwrap(storeB.messages.values.first { $0.role == .user })
+        let newSessionB = UUID()
+        _ = try await runtimeB.branch(
+            legacyBranchInput(sourceSessionID: sourceB, branchMessageID: userB.id, newSessionID: newSessionB, generateAfterBranch: true)
+        )
+        let legacy = try await drainUntilAfterGeneration(runtimeB)
+
+        XCTAssertEqual(eventShapes(canonical), eventShapes(legacy),
+                       "Canonical branch via processTurn(.branch) must mirror legacy branch(BranchInput)")
+    }
+
+    // MARK: - TurnConfig knob propagation
+
+    /// Sanity-check that custom TurnConfig values reach the runtime — the
+    /// streaming-batcher knobs influence how tokens are coalesced. We pin
+    /// the system prompt because that's the easiest knob to observe via the
+    /// composeSystemPrompt path: the runtime forwards a non-nil systemPrompt
+    /// onto the enqueue call, and a custom prompt threading through means
+    /// the config was honoured.
+    func test_turnConfig_systemPrompt_threadsToBackend() async throws {
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["hi"]
+        let inference = InferenceService(backend: backend, name: "Mock")
+        let store = MemoryStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference,
+            pipeline: nil
+        )
+        let sessionID = UUID()
+        let pinned = "you are a unicorn"
+        _ = try await runtime.processTurn(
+            TurnInput(
+                sessionID: sessionID,
+                kind: .send(text: "hi"),
+                config: TurnConfig(systemPrompt: pinned)
+            )
+        )
+        _ = try await drainUntilAfterGeneration(runtime)
+        XCTAssertEqual(backend.lastSystemPrompt, pinned,
+                       "TurnConfig.systemPrompt must reach the backend's generate(prompt:systemPrompt:config:) call.")
+    }
+
+    // MARK: - Legacy struct construction (deprecation-suppressed)
+
+    @available(*, deprecated)
+    private func legacySendInput(sessionID: UUID, text: String) -> SendInput {
+        SendInput(sessionID: sessionID, userText: text)
+    }
+
+    @available(*, deprecated)
+    private func legacyRegenerateInput(sessionID: UUID) -> RegenerateInput {
+        RegenerateInput(sessionID: sessionID)
+    }
+
+    @available(*, deprecated)
+    private func legacyEditInput(sessionID: UUID, messageID: UUID, text: String) -> EditInput {
+        EditInput(sessionID: sessionID, messageID: messageID, newContent: text)
+    }
+
+    @available(*, deprecated)
+    private func legacyBranchInput(
+        sourceSessionID: UUID,
+        branchMessageID: UUID,
+        newSessionID: UUID,
+        generateAfterBranch: Bool
+    ) -> BranchInput {
+        BranchInput(
+            sourceSessionID: sourceSessionID,
+            branchMessageID: branchMessageID,
+            newSessionID: newSessionID,
+            generateAfterBranch: generateAfterBranch
+        )
+    }
+}

--- a/Tests/BaseChatUITests/ChatViewModelSendMessageErrorTests.swift
+++ b/Tests/BaseChatUITests/ChatViewModelSendMessageErrorTests.swift
@@ -1,0 +1,168 @@
+@preconcurrency import XCTest
+import SwiftData
+@testable import BaseChatUI
+import BaseChatRuntime
+import BaseChatPersistenceSwiftData
+@testable import BaseChatInference
+import BaseChatTestSupport
+
+/// I6 replaces ``NoResponseError`` with the typed ``SendMessageError`` enum so
+/// callers can pattern-match each upstream failure mode of the async
+/// ``ChatViewModel/sendMessage(_:)`` overload. These tests pin one
+/// representative case per arm of the enum.
+@MainActor
+final class ChatViewModelSendMessageErrorTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+    private var sessionManager: SessionManagerViewModel!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        container = try makeInMemoryContainer()
+        context = container.mainContext
+        sessionManager = SessionManagerViewModel()
+        sessionManager.configure(
+            persistence: SwiftDataPersistenceProvider(modelContext: context),
+            autoLoad: false
+        )
+    }
+
+    override func tearDown() async throws {
+        sessionManager = nil
+        context = nil
+        container = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeViewModel(backend: any InferenceBackend, name: String = "MockTest") -> ChatViewModel {
+        let service = InferenceService(backend: backend, name: name)
+        let vm = ChatViewModel(inferenceService: service)
+        vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
+        return vm
+    }
+
+    @discardableResult
+    private func createAndActivateSession(vm: ChatViewModel, title: String = "Test Chat") async throws -> ChatSessionRecord {
+        let session = try await sessionManager.createSession(title: title)
+        sessionManager.activeSession = session
+        await vm.switchToSession(session)
+        return session
+    }
+
+    // MARK: - .noActiveSession
+
+    func test_sendMessage_noActiveSession_throwsNoActiveSession() async throws {
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        let vm = makeViewModel(backend: backend)
+        // Skip session creation so activeSessionID stays nil.
+
+        do {
+            _ = try await vm.sendMessage("hello")
+            XCTFail("Expected SendMessageError.noActiveSession to be thrown")
+        } catch SendMessageError.noActiveSession {
+            // Pass.
+        } catch {
+            XCTFail("Expected .noActiveSession, got \(error)")
+        }
+    }
+
+    // MARK: - .noModelLoaded
+
+    func test_sendMessage_noModelLoaded_throwsNoModelLoaded() async throws {
+        // The lifecycle's `InferenceService(backend:name:)` constructor
+        // force-flips `isModelLoaded` to true (it's a debug shortcut for
+        // test fixtures). Construct InferenceService bare so the lifecycle
+        // stays in the unloaded state — that's the path that triggers the
+        // .noModelLoaded precondition.
+        let service = InferenceService()
+        let vm = ChatViewModel(inferenceService: service)
+        vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
+        try await createAndActivateSession(vm: vm)
+        XCTAssertFalse(vm.isModelLoaded, "Precondition: model is not loaded")
+
+        do {
+            _ = try await vm.sendMessage("hello")
+            XCTFail("Expected SendMessageError.noModelLoaded to be thrown")
+        } catch SendMessageError.noModelLoaded {
+            // Pass.
+        } catch {
+            XCTFail("Expected .noModelLoaded, got \(error)")
+        }
+    }
+
+    // MARK: - .empty
+
+    func test_sendMessage_emptyResponse_throwsEmpty() async throws {
+        // The inner sendMessage() drops empty assistant turns silently —
+        // lastTurnState stays in `.idle` after the runtime emits
+        // FinishReason.empty. The outer sendMessage(_:) overload must
+        // surface this as `SendMessageError.empty` so callers can
+        // distinguish the no-output case from a real error.
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = []  // empty stream
+        let vm = makeViewModel(backend: backend)
+        try await createAndActivateSession(vm: vm)
+
+        do {
+            _ = try await vm.sendMessage("hello")
+            XCTFail("Expected SendMessageError.empty to be thrown")
+        } catch SendMessageError.empty {
+            // Pass.
+        } catch SendMessageError.runtime(let underlying) {
+            XCTFail("Expected .empty, got .runtime(\(underlying))")
+        } catch {
+            XCTFail("Expected .empty, got \(error)")
+        }
+    }
+
+    // MARK: - .runtime
+
+    func test_sendMessage_streamFailure_throwsRuntime() async throws {
+        // The MidStreamErrorBackend yields some tokens then throws — the
+        // turn ends in lastTurnState == .failed(error), which the typed
+        // overload must lift into SendMessageError.runtime.
+        let backend = MidStreamErrorBackend(
+            tokensBeforeError: ["partial"],
+            errorToThrow: InferenceError.inferenceFailure("simulated stream failure")
+        )
+        let vm = makeViewModel(backend: backend)
+        try await createAndActivateSession(vm: vm)
+
+        do {
+            _ = try await vm.sendMessage("hello")
+            XCTFail("Expected SendMessageError.runtime to be thrown")
+        } catch SendMessageError.runtime(let underlying) {
+            // The underlying error type is implementation-detail (it can
+            // be either the ConversationError wrapping or the raw
+            // InferenceError depending on which surfacing path the runtime
+            // used). What matters is that .runtime fired, not .empty or
+            // a precondition case.
+            let description = underlying.localizedDescription
+            XCTAssertTrue(
+                description.contains("simulated stream failure") || description.contains("Inference"),
+                "Underlying error should reference the stream failure, got: \(description)"
+            )
+        } catch {
+            XCTFail("Expected .runtime, got \(error)")
+        }
+    }
+
+    // MARK: - Happy path returns the assistant record (no throw)
+
+    func test_sendMessage_happyPath_returnsAssistantRecord() async throws {
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["Hi", " there"]
+        let vm = makeViewModel(backend: backend)
+        try await createAndActivateSession(vm: vm)
+
+        let record = try await vm.sendMessage("hello")
+        XCTAssertEqual(record.role, .assistant, "sendMessage(_:) must return the assistant record on success")
+        XCTAssertEqual(record.content, "Hi there", "Assistant content should be the streamed tokens")
+    }
+}

--- a/Tests/BaseChatUITests/ConsumerRuntimeHarness.swift
+++ b/Tests/BaseChatUITests/ConsumerRuntimeHarness.swift
@@ -82,10 +82,10 @@ final class ConsumerRuntimeHarness {
                 conversationRuntime: runtime.conversationRuntime
             )
             chatViewModel.foundationModelProvider = foundationModelProvider
-            chatViewModel.configure(runtime: runtime)
+            chatViewModel.configure(bootstrap: runtime)
 
             let sessionManager = SessionManagerViewModel()
-            sessionManager.configure(runtime: runtime)
+            sessionManager.configure(bootstrap: runtime)
 
             self.originalConfiguration = originalConfiguration
             self.userDefaults = defaults

--- a/Tests/BaseChatUITests/SessionQueueIsolationTests.swift
+++ b/Tests/BaseChatUITests/SessionQueueIsolationTests.swift
@@ -70,7 +70,7 @@ final class SessionQueueIsolationTests: XCTestCase {
 
         // Enqueue a request scoped to session A.
         let (_, stream) = try vm.inferenceService.enqueue(
-            messages: [("user", "hello")],
+            messages: [.user("hello")],
             sessionID: sessionA.id
         )
 
@@ -125,10 +125,10 @@ final class SessionQueueIsolationTests: XCTestCase {
 
         // Enqueue additional requests directly on the service.
         let (_, stream2) = try vm.inferenceService.enqueue(
-            messages: [("user", "second")]
+            messages: [.user("second")]
         )
         let (_, stream3) = try vm.inferenceService.enqueue(
-            messages: [("user", "third")]
+            messages: [.user("third")]
         )
 
         XCTAssertTrue(vm.inferenceService.hasQueuedRequests, "Should have queued requests")


### PR DESCRIPTION
## Summary

I6 from the architectural-improvement plan: normalize the runtime input boundary across the four turn flows and lift opaque error types into typed enums. Each rough edge ships in this PR with a deprecation shim so consumers compile across the transition.

## What changed

### 1. `TurnInput` / `TurnConfig` / `TurnKind`
One normalised input replaces `SendInput` / `RegenerateInput` / `EditInput` / `BranchInput`. Adding a sampling knob is now a one-touch change in `TurnConfig`, not five edits across paralleled init signatures.

```swift
let input = TurnInput(
    sessionID: sessionID,
    kind: .send(text: \"hi\", attachments: []),
    config: TurnConfig(systemPrompt: \"you are concise\")
)
let handle = try await runtime.processTurn(input)
```

Legacy `*Input` structs remain as `@available(*, deprecated, renamed: \"TurnInput\")` shims; their `asTurnInput` extensions forward to `processTurn(_:)`.

### 2. `ConversationRuntime.processTurn(_:)`
Canonical entry point. The four `runXxxTurn` setups collapse into per-flow private functions routed by `TurnKind`. The old `send` / `regenerate` / `edit` / `branch` methods stay as deprecated wrappers.

### 3. `SendMessageError`
Replaces `NoResponseError`. The async `sendMessage(_:)` on `ChatViewModel` now throws one of:

- `.noActiveSession` — `activeSessionID` was `nil` at call time
- `.noModelLoaded` — `isModelLoaded` was `false` at call time
- `.empty` — turn ended without producing tokens
- `.runtime(any Error)` — runtime surfaced an underlying error

`NoResponseError` is a deprecated typealias for one minor.

### 4. `configure(bootstrap:)`
Single canonical wiring on `ChatViewModel` and `SessionManagerViewModel`. Folded the prior split between `configure(runtime:)` (didn't wire imageRuntime) and `configure(_:)` (did) into one method that always wires `imageGenerationRuntime` when the bootstrap exposes it. Both old methods are deprecated shims.

### 5. `enqueue(messages: [Message])`
New `.system` / `.user` / `.assistant` typed variant replaces the typo-prone `[(role: String, content: String)]` tuple shape. The legacy tuple overload is deprecated.

```swift
public enum Message: Sendable, Equatable {
    case system(String)
    case user(String)
    case assistant(String)
}
```

`Message` is distinct from `ChatMessage` (SwiftData `@Model`) and `ChatMessageRecord` (persistence-agnostic value type) — see the docstring on `Sources/BaseChatInference/Models/Message.swift`.

## Tests

- `TurnInputCollapseTests` — round-trip tests pin event-sequence parity between `processTurn(.send/.regenerate/.edit/.branch)` and the legacy `runtime.send(SendInput)` / `regenerate(RegenerateInput)` / `edit(EditInput)` / `branch(BranchInput)` paths. Plus a `TurnConfig.systemPrompt` propagation test.
- `ChatViewModelSendMessageErrorTests` — one test per `SendMessageError` case (noActiveSession / noModelLoaded / empty / runtime) plus the happy path.
- `MessageEnqueueTests` — typed `[Message]` overload, role/content mapping, and round-trip parity with the deprecated tuple variant.
- `TrafficBoundaryAuditTest` rule-2 regex tightened to exclude Swift enum case constructors (`case system(_:)`); its sabotage suite gains a fixture for the new exclusion.

All sabotage-verified per CLAUDE.md (sabotage temporarily reverted before commit).

## Pre-push gates

- ✅ Two-invocation pre-push (XCTest + Swift Testing): 2829 + 83 passing
- ✅ Trait-combo build: `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` clean
- ✅ `SilentCatchAuditTest` clean
- ✅ `TrafficBoundaryAuditTest` clean (15 tests, including new exclusion fixture)

## Plan context

Part of the I5/I6/I7 architectural-improvement bundle slated for 0.19.0. Each PR ships independently with deprecation shims so adopters compile across the transition.

## Test plan

- [ ] CI passes on all suites
- [ ] No regressions in `RuntimeConfigurationTests` / `BootstrapConfigureImageWiringTests` / `ConversationRuntimeTests`
- [ ] Cold-start gates remain green (the deprecation shims preserve the prior public surface)