### PR TITLE
feat(rag): add RAG knowledge base — document ingestion, vector store, retrieval-augmented context

### DIFF
--- a/Sources/BaseChatInference/Models/DocumentChunk.swift
+++ b/Sources/BaseChatInference/Models/DocumentChunk.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// A contiguous passage of text extracted from a ``DocumentRecord``.
+///
+/// The `text` is the retrieval unit — what gets embedded and what gets injected
+/// into the context window when retrieved. `chunkIndex` is zero-based within the
+/// parent document and is used to reconstruct reading order.
+public struct DocumentChunk: Identifiable, Sendable, Hashable {
+    public let id: UUID
+    public let documentID: UUID
+    public let text: String
+    public let chunkIndex: Int
+
+    public init(
+        id: UUID = UUID(),
+        documentID: UUID,
+        text: String,
+        chunkIndex: Int
+    ) {
+        self.id = id
+        self.documentID = documentID
+        self.text = text
+        self.chunkIndex = chunkIndex
+    }
+}

--- a/Sources/BaseChatInference/Models/DocumentRecord.swift
+++ b/Sources/BaseChatInference/Models/DocumentRecord.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Metadata for a document that has been ingested into the RAG knowledge base.
+///
+/// The raw text and embeddings live in the `VectorStore`; this record tracks
+/// identity, provenance, and chunk count so callers can list and delete documents
+/// without touching the vector index directly.
+public struct DocumentRecord: Identifiable, Sendable, Codable, Hashable {
+    public let id: UUID
+    public var title: String
+    public var sourceURL: URL
+    /// Lowercase file extension without the dot (e.g. "pdf", "txt").
+    public var fileType: String
+    public var chunkCount: Int
+    public var indexedAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        title: String,
+        sourceURL: URL,
+        fileType: String,
+        chunkCount: Int,
+        indexedAt: Date = Date()
+    ) {
+        self.id = id
+        self.title = title
+        self.sourceURL = sourceURL
+        self.fileType = fileType
+        self.chunkCount = chunkCount
+        self.indexedAt = indexedAt
+    }
+}

--- a/Sources/BaseChatInference/Models/VectorSearchHit.swift
+++ b/Sources/BaseChatInference/Models/VectorSearchHit.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// A retrieved chunk with its relevance score and source document title.
+///
+/// Returned by ``VectorStore/search(embedding:limit:)`` and
+/// ``VectorStore/keywordSearch(query:limit:)``. The `documentTitle` is stored
+/// alongside the chunk record so context formatters can attribute retrieved
+/// passages without an extra round-trip to ``DocumentStore``.
+public struct VectorSearchHit: Sendable {
+    public let chunk: DocumentChunk
+    /// Human-readable source label (typically the document file name).
+    public let documentTitle: String
+    /// Cosine similarity in [0, 1] for semantic hits; 1.0 for keyword hits.
+    public let score: Float
+
+    public init(chunk: DocumentChunk, documentTitle: String, score: Float) {
+        self.chunk = chunk
+        self.documentTitle = documentTitle
+        self.score = score
+    }
+}

--- a/Sources/BaseChatPersistenceSwiftData/Adapters/FlatFileVectorStore.swift
+++ b/Sources/BaseChatPersistenceSwiftData/Adapters/FlatFileVectorStore.swift
@@ -1,0 +1,367 @@
+import Foundation
+import BaseChatInference
+import BaseChatRuntime
+
+// MARK: - FlatFileVectorStore
+
+/// ``VectorStore`` backed by a compact binary file loaded fully into memory.
+///
+/// Correct for libraries up to ~50 000 chunks. Search is O(n) cosine
+/// similarity over L2-normalized embeddings (dot-product after normalization).
+/// The entire index is rewritten on each mutation — acceptable for the write
+/// patterns of a local document library (ingest once, query many times).
+///
+/// File format: 20-byte header followed by variable-length records. See the
+/// private `encode`/`decode` helpers for the exact byte layout.
+public actor FlatFileVectorStore: VectorStore {
+
+    // MARK: - In-memory model
+
+    private struct Record: Sendable {
+        var chunkID: UUID
+        var documentID: UUID
+        var chunkIndex: Int32
+        /// L2-normalized; empty when ingested without an embedding model.
+        var embedding: [Float]
+        var documentTitle: String
+        var text: String
+    }
+
+    // MARK: - State
+
+    private let storageURL: URL
+    /// Nil until the first access; loaded lazily.
+    private var records: [Record]?
+
+    public init(storageURL: URL) {
+        self.storageURL = storageURL
+    }
+
+    // MARK: - VectorStore
+
+    public func insert(
+        chunks: [DocumentChunk],
+        documentTitle: String,
+        embeddings: [[Float]]
+    ) throws {
+        var loaded = try ensureLoaded()
+
+        for (i, chunk) in chunks.enumerated() {
+            let rawEmbedding = i < embeddings.count ? embeddings[i] : []
+            let normalized = rawEmbedding.isEmpty ? [] : l2normalize(rawEmbedding)
+            loaded.append(Record(
+                chunkID: chunk.id,
+                documentID: chunk.documentID,
+                chunkIndex: Int32(chunk.chunkIndex),
+                embedding: normalized,
+                documentTitle: documentTitle,
+                text: chunk.text
+            ))
+        }
+
+        records = loaded
+        try persist(loaded)
+    }
+
+    public func search(embedding: [Float], limit: Int) throws -> [VectorSearchHit] {
+        let loaded = try ensureLoaded()
+        let query = l2normalize(embedding)
+        guard !query.isEmpty else { return [] }
+
+        let scored: [(record: Record, score: Float)] = loaded.compactMap { record in
+            guard record.embedding.count == query.count else { return nil }
+            let score = dotProduct(query, record.embedding)
+            return (record, score)
+        }
+
+        return scored
+            .sorted { $0.score > $1.score }
+            .prefix(limit)
+            .map { pair in
+                VectorSearchHit(
+                    chunk: DocumentChunk(
+                        id: pair.record.chunkID,
+                        documentID: pair.record.documentID,
+                        text: pair.record.text,
+                        chunkIndex: Int(pair.record.chunkIndex)
+                    ),
+                    documentTitle: pair.record.documentTitle,
+                    score: pair.score
+                )
+            }
+    }
+
+    public func keywordSearch(query: String, limit: Int) throws -> [VectorSearchHit] {
+        let loaded = try ensureLoaded()
+        guard !query.isEmpty else { return [] }
+        let lower = query.lowercased()
+
+        return loaded
+            .filter { $0.text.lowercased().contains(lower) }
+            .prefix(limit)
+            .map { record in
+                VectorSearchHit(
+                    chunk: DocumentChunk(
+                        id: record.chunkID,
+                        documentID: record.documentID,
+                        text: record.text,
+                        chunkIndex: Int(record.chunkIndex)
+                    ),
+                    documentTitle: record.documentTitle,
+                    score: 1.0
+                )
+            }
+    }
+
+    public func delete(documentID: UUID) throws {
+        var loaded = try ensureLoaded()
+        loaded.removeAll { $0.documentID == documentID }
+        records = loaded
+        try persist(loaded)
+    }
+
+    public func deleteAll() throws {
+        records = []
+        try persist([])
+    }
+
+    // MARK: - Persistence
+
+    private func ensureLoaded() throws -> [Record] {
+        if let cached = records { return cached }
+        let loaded = try load()
+        records = loaded
+        return loaded
+    }
+
+    private func load() throws -> [Record] {
+        guard FileManager.default.fileExists(atPath: storageURL.path) else { return [] }
+        let data: Data
+        do {
+            data = try Data(contentsOf: storageURL)
+        } catch {
+            let name = self.storageURL.lastPathComponent
+            Log.persistence.warning("FlatFileVectorStore: failed to read \(name, privacy: .public): \(error.localizedDescription)")
+            return []
+        }
+        do {
+            return try decode(data)
+        } catch {
+            Log.persistence.warning("FlatFileVectorStore: corrupt index, starting fresh: \(error.localizedDescription)")
+            return []
+        }
+    }
+
+    private func persist(_ records: [Record]) throws {
+        let data = encode(records)
+        do {
+            try data.write(to: storageURL, options: .atomic)
+        } catch {
+            throw VectorStoreError.writeFailed(underlying: error)
+        }
+    }
+
+    // MARK: - Binary encoding
+
+    private static let magic: [UInt8] = [0x42, 0x43, 0x4B, 0x56]  // "BCKV"
+    private static let version: UInt8 = 1
+
+    private func encode(_ records: [Record]) -> Data {
+        var data = Data()
+        data.append(contentsOf: Self.magic)
+        data.append(Self.version)
+        data.append(contentsOf: [0x00, 0x00, 0x00])  // pad
+        data.appendUInt32(UInt32(records.count))
+        data.appendUInt32(0)  // dims field reserved
+
+        for record in records {
+            data.appendUUID(record.chunkID)
+            data.appendUUID(record.documentID)
+            data.appendInt32(record.chunkIndex)
+            data.appendUInt32(UInt32(record.embedding.count))
+            record.embedding.forEach { data.appendFloat($0) }
+            data.appendLengthPrefixedUTF8(record.documentTitle)
+            data.appendLengthPrefixedUTF8(record.text)
+        }
+
+        return data
+    }
+
+    private func decode(_ data: Data) throws -> [Record] {
+        var cursor = DataCursor(data: data)
+
+        let magic = try cursor.readBytes(4)
+        guard magic == Self.magic else { throw VectorStoreError.invalidFormat }
+        let version = try cursor.readByte()
+        guard version == Self.version else { throw VectorStoreError.unsupportedVersion(version) }
+        try cursor.skip(3)
+        let count = try cursor.readUInt32()
+        try cursor.skip(4)  // dims (reserved)
+
+        var records: [Record] = []
+        records.reserveCapacity(Int(count))
+
+        for _ in 0..<count {
+            let chunkID = try cursor.readUUID()
+            let documentID = try cursor.readUUID()
+            let chunkIndex = try cursor.readInt32()
+            let embedLen = Int(try cursor.readUInt32())
+            let embedding = try cursor.readFloats(count: embedLen)
+            let title = try cursor.readLengthPrefixedUTF8()
+            let text = try cursor.readLengthPrefixedUTF8()
+
+            records.append(Record(
+                chunkID: chunkID,
+                documentID: documentID,
+                chunkIndex: chunkIndex,
+                embedding: embedding,
+                documentTitle: title,
+                text: text
+            ))
+        }
+
+        return records
+    }
+
+    // MARK: - Math
+
+    private func l2normalize(_ v: [Float]) -> [Float] {
+        let norm = sqrt(v.reduce(0.0) { $0 + $1 * $1 })
+        guard norm > 0 else { return v }
+        return v.map { $0 / norm }
+    }
+
+    private func dotProduct(_ a: [Float], _ b: [Float]) -> Float {
+        zip(a, b).reduce(0.0) { $0 + $1.0 * $1.1 }
+    }
+}
+
+// MARK: - VectorStoreError
+
+public enum VectorStoreError: LocalizedError {
+    case invalidFormat
+    case unsupportedVersion(UInt8)
+    case writeFailed(underlying: Error)
+    case truncatedData
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidFormat:
+            return "Vector store file has an unrecognized format."
+        case .unsupportedVersion(let v):
+            return "Vector store file version \(v) is not supported."
+        case .writeFailed(let error):
+            return "Failed to write vector store: \(error.localizedDescription)"
+        case .truncatedData:
+            return "Vector store file is truncated or corrupt."
+        }
+    }
+}
+
+// MARK: - Data write helpers
+
+private extension Data {
+    mutating func appendUInt32(_ value: UInt32) {
+        let v = value.littleEndian
+        append(UInt8((v >> 0) & 0xFF))
+        append(UInt8((v >> 8) & 0xFF))
+        append(UInt8((v >> 16) & 0xFF))
+        append(UInt8((v >> 24) & 0xFF))
+    }
+
+    mutating func appendInt32(_ value: Int32) {
+        appendUInt32(UInt32(bitPattern: value))
+    }
+
+    mutating func appendFloat(_ value: Float) {
+        appendUInt32(value.bitPattern)
+    }
+
+    mutating func appendUUID(_ value: UUID) {
+        let t = value.uuid
+        append(contentsOf: [
+            t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7,
+            t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15
+        ])
+    }
+
+    mutating func appendLengthPrefixedUTF8(_ string: String) {
+        let utf8 = Data(string.utf8)
+        appendUInt32(UInt32(utf8.count))
+        append(utf8)
+    }
+}
+
+// MARK: - DataCursor
+
+private struct DataCursor {
+    let data: Data
+    var offset: Int = 0
+
+    mutating func readByte() throws -> UInt8 {
+        guard offset < data.count else { throw VectorStoreError.truncatedData }
+        defer { offset += 1 }
+        return data[offset]
+    }
+
+    mutating func readBytes(_ count: Int) throws -> [UInt8] {
+        guard offset + count <= data.count else { throw VectorStoreError.truncatedData }
+        defer { offset += count }
+        return Array(data[offset..<(offset + count)])
+    }
+
+    mutating func skip(_ count: Int) throws {
+        guard offset + count <= data.count else { throw VectorStoreError.truncatedData }
+        offset += count
+    }
+
+    mutating func readUInt32() throws -> UInt32 {
+        guard offset + 4 <= data.count else { throw VectorStoreError.truncatedData }
+        defer { offset += 4 }
+        return data.withUnsafeBytes { ptr in
+            UInt32(littleEndian: ptr.loadUnaligned(fromByteOffset: offset, as: UInt32.self))
+        }
+    }
+
+    mutating func readInt32() throws -> Int32 {
+        guard offset + 4 <= data.count else { throw VectorStoreError.truncatedData }
+        defer { offset += 4 }
+        return data.withUnsafeBytes { ptr in
+            Int32(littleEndian: ptr.loadUnaligned(fromByteOffset: offset, as: Int32.self))
+        }
+    }
+
+    mutating func readUUID() throws -> UUID {
+        let bytes = try readBytes(16)
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
+    }
+
+    mutating func readFloats(count: Int) throws -> [Float] {
+        guard count >= 0 else { throw VectorStoreError.invalidFormat }
+        guard offset + count * 4 <= data.count else { throw VectorStoreError.truncatedData }
+        var result = [Float](repeating: 0, count: count)
+        for i in 0..<count {
+            let bits = data.withUnsafeBytes { ptr in
+                UInt32(littleEndian: ptr.loadUnaligned(fromByteOffset: offset + i * 4, as: UInt32.self))
+            }
+            result[i] = Float(bitPattern: bits)
+        }
+        offset += count * 4
+        return result
+    }
+
+    mutating func readLengthPrefixedUTF8() throws -> String {
+        let length = Int(try readUInt32())
+        guard offset + length <= data.count else { throw VectorStoreError.truncatedData }
+        defer { offset += length }
+        guard let string = String(data: data[offset..<(offset + length)], encoding: .utf8) else {
+            throw VectorStoreError.invalidFormat
+        }
+        return string
+    }
+}

--- a/Sources/BaseChatPersistenceSwiftData/Adapters/SwiftDataDocumentStore.swift
+++ b/Sources/BaseChatPersistenceSwiftData/Adapters/SwiftDataDocumentStore.swift
@@ -1,0 +1,57 @@
+import Foundation
+import SwiftData
+import BaseChatInference
+import BaseChatRuntime
+
+/// ``DocumentStore`` backed by SwiftData's ``RagDocument`` model.
+///
+/// Operates on the ``ModelContext`` injected at init time, consistent with
+/// other SwiftData adapters in this target.
+@MainActor
+public final class SwiftDataDocumentStore: DocumentStore {
+
+    private let modelContext: ModelContext
+
+    public init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    public func insertDocument(_ record: DocumentRecord) throws {
+        let model = RagDocument(
+            id: record.id,
+            title: record.title,
+            sourceURLString: record.sourceURL.absoluteString,
+            fileType: record.fileType,
+            chunkCount: record.chunkCount,
+            indexedAt: record.indexedAt
+        )
+        modelContext.insert(model)
+        try modelContext.save()
+    }
+
+    public func fetchDocuments() throws -> [DocumentRecord] {
+        let descriptor = FetchDescriptor<RagDocument>(
+            sortBy: [SortDescriptor(\.indexedAt, order: .reverse)]
+        )
+        let models = try modelContext.fetch(descriptor)
+        return models.map { $0.toRecord() }
+    }
+
+    public func fetchDocument(id: UUID) throws -> DocumentRecord? {
+        let needle = id
+        let descriptor = FetchDescriptor<RagDocument>(
+            predicate: #Predicate { $0.id == needle }
+        )
+        return try modelContext.fetch(descriptor).first?.toRecord()
+    }
+
+    public func deleteDocument(id: UUID) throws {
+        let needle = id
+        let descriptor = FetchDescriptor<RagDocument>(
+            predicate: #Predicate { $0.id == needle }
+        )
+        let matches = try modelContext.fetch(descriptor)
+        matches.forEach { modelContext.delete($0) }
+        try modelContext.save()
+    }
+}

--- a/Sources/BaseChatPersistenceSwiftData/BaseChatBootstrap.swift
+++ b/Sources/BaseChatPersistenceSwiftData/BaseChatBootstrap.swift
@@ -3,6 +3,47 @@ import SwiftData
 import BaseChatRuntime
 import BaseChatInference
 
+// MARK: - RAGConfiguration
+
+/// Configuration for the RAG knowledge base.
+///
+/// Pass to ``BaseChatBootstrap/init(configuration:ragConfiguration:inferenceService:imageGenerationService:diagnostics:makeModelContainer:)``
+/// to enable on-device RAG. When `nil`, the runtime runs without retrieval.
+///
+/// ```swift
+/// let rag = RAGConfiguration(embeddingBackend: myLlamaEmbeddingBackend)
+/// let bootstrap = try BaseChatBootstrap(configuration: config, ragConfiguration: rag)
+/// bootstrap.ragService?.ingest(url: myDocumentURL)
+/// ```
+public struct RAGConfiguration: Sendable {
+    /// Optional embedding backend for semantic search. When `nil`, retrieval
+    /// falls back to case-insensitive keyword search.
+    public var embeddingBackend: (any EmbeddingBackend)?
+    /// Character count per chunk. Default: 1800.
+    public var chunkSize: Int
+    /// Character overlap between consecutive chunks. Default: 200.
+    public var chunkOverlap: Int
+    /// Number of chunks to retrieve per turn. Default: 5.
+    public var topK: Int
+    /// URL for the flat-file vector index. Defaults to
+    /// `<Application Support>/<bundleIdentifier>/ragvectors.bin`.
+    public var vectorStoreURL: URL?
+
+    public init(
+        embeddingBackend: (any EmbeddingBackend)? = nil,
+        chunkSize: Int = 1800,
+        chunkOverlap: Int = 200,
+        topK: Int = 5,
+        vectorStoreURL: URL? = nil
+    ) {
+        self.embeddingBackend = embeddingBackend
+        self.chunkSize = chunkSize
+        self.chunkOverlap = chunkOverlap
+        self.topK = topK
+        self.vectorStoreURL = vectorStoreURL
+    }
+}
+
 /// Preferred bootstrap surface for host apps that use BaseChatKit's shipped
 /// SwiftData persistence.
 ///
@@ -68,6 +109,15 @@ public final class BaseChatBootstrap {
     /// `nil` when ``imageGenerationService`` is `nil`.
     public let imageRuntime: ImageGenerationRuntime?
 
+    /// The RAG knowledge-base service, when the host opted in via
+    /// ``RAGConfiguration``. `nil` when bootstrapped without RAG.
+    ///
+    /// Call ``RAGService/ingest(url:)`` to add documents and
+    /// ``RAGService/deleteDocument(id:)`` to remove them. The service is
+    /// automatically queried before each generation turn via
+    /// ``ConversationRuntime``.
+    public let ragService: RAGService?
+
     public var modelContext: ModelContext { modelContainer.mainContext }
 
     /// Builds the full BaseChatKit stack synchronously.
@@ -82,6 +132,7 @@ public final class BaseChatBootstrap {
     ///   `<Application Support>/default.store` path.
     public init(
         configuration: BaseChatConfiguration,
+        ragConfiguration: RAGConfiguration? = nil,
         inferenceService: InferenceService? = nil,
         imageGenerationService: ImageGenerationService? = nil,
         diagnostics: DiagnosticsService = DiagnosticsService(),
@@ -108,10 +159,37 @@ public final class BaseChatBootstrap {
             self.samplerPresetStore = SwiftDataSamplerPresetStore(modelContext: mainContext)
             self.benchmarkCache = SwiftDataBenchmarkCache(modelContext: mainContext)
             self.endpointStore = SwiftDataEndpointStore(modelContext: mainContext)
+
+            let resolvedRAGService: RAGService?
+            if let ragConfig = ragConfiguration {
+                let vectorURL = ragConfig.vectorStoreURL
+                    ?? ModelContainerFactory.defaultStoreURL()?
+                        .deletingLastPathComponent()
+                        .appendingPathComponent("ragvectors.bin")
+                    ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+                        .first!.appendingPathComponent("ragvectors.bin")
+                let vectorStore = FlatFileVectorStore(storageURL: vectorURL)
+                let documentStore = SwiftDataDocumentStore(modelContext: mainContext)
+                let chunker = DocumentChunker(
+                    chunkSize: ragConfig.chunkSize,
+                    overlap: ragConfig.chunkOverlap
+                )
+                resolvedRAGService = RAGService(
+                    documentStore: documentStore,
+                    vectorStore: vectorStore,
+                    embeddingBackend: ragConfig.embeddingBackend,
+                    chunker: chunker
+                )
+            } else {
+                resolvedRAGService = nil
+            }
+            self.ragService = resolvedRAGService
+
             self.conversationRuntime = ConversationRuntime(
                 messageStore: resolvedPersistence,
                 sessionStore: resolvedPersistence,
-                inferenceService: resolvedInferenceService
+                inferenceService: resolvedInferenceService,
+                ragService: resolvedRAGService
             )
             self.imageGenerationService = imageGenerationService
             if let imageGenerationService {
@@ -136,7 +214,8 @@ public final class BaseChatBootstrap {
         samplerPresetStore: SwiftDataSamplerPresetStore,
         benchmarkCache: SwiftDataBenchmarkCache,
         endpointStore: SwiftDataEndpointStore,
-        imageGenerationService: ImageGenerationService? = nil
+        imageGenerationService: ImageGenerationService? = nil,
+        ragService: RAGService? = nil
     ) {
         self.inferenceService = inferenceService
         self.diagnostics = diagnostics
@@ -145,10 +224,12 @@ public final class BaseChatBootstrap {
         self.samplerPresetStore = samplerPresetStore
         self.benchmarkCache = benchmarkCache
         self.endpointStore = endpointStore
+        self.ragService = ragService
         self.conversationRuntime = ConversationRuntime(
             messageStore: persistence,
             sessionStore: persistence,
-            inferenceService: inferenceService
+            inferenceService: inferenceService,
+            ragService: ragService
         )
         self.imageGenerationService = imageGenerationService
         if let imageGenerationService {

--- a/Sources/BaseChatPersistenceSwiftData/ModelContainerFactory.swift
+++ b/Sources/BaseChatPersistenceSwiftData/ModelContainerFactory.swift
@@ -25,7 +25,7 @@ import BaseChatInference
 public enum ModelContainerFactory {
     /// The current schema version.
     public static var currentSchema: any VersionedSchema.Type {
-        BaseChatSchemaV4.self
+        BaseChatSchemaV5.self
     }
 
     /// Returns an on-disk `ModelContainer` configured with the current schema.

--- a/Sources/BaseChatPersistenceSwiftData/Schema/BaseChatMigrationPlan.swift
+++ b/Sources/BaseChatPersistenceSwiftData/Schema/BaseChatMigrationPlan.swift
@@ -5,12 +5,14 @@ public enum BaseChatMigrationPlan: SchemaMigrationPlan {
         [
             BaseChatSchemaV3.self,
             BaseChatSchemaV4.self,
+            BaseChatSchemaV5.self,
         ]
     }
 
     public static var stages: [MigrationStage] {
         [
             .lightweight(fromVersion: BaseChatSchemaV3.self, toVersion: BaseChatSchemaV4.self),
+            .lightweight(fromVersion: BaseChatSchemaV4.self, toVersion: BaseChatSchemaV5.self),
         ]
     }
 }

--- a/Sources/BaseChatPersistenceSwiftData/Schema/BaseChatSchemaV5.swift
+++ b/Sources/BaseChatPersistenceSwiftData/Schema/BaseChatSchemaV5.swift
@@ -1,0 +1,72 @@
+import Foundation
+import BaseChatInference
+import BaseChatRuntime
+@preconcurrency import SwiftData
+
+/// BaseChatKit SwiftData schema version 5.
+///
+/// Adds ``RagDocument`` for the RAG knowledge base. All V4 model types are
+/// carried forward unchanged via a lightweight migration stage.
+public enum BaseChatSchemaV5: VersionedSchema {
+    public static let versionIdentifier = Schema.Version(5, 0, 0)
+
+    public static var models: [any PersistentModel.Type] {
+        [
+            BaseChatSchemaV4.ChatMessage.self,
+            BaseChatSchemaV4.ChatSession.self,
+            BaseChatSchemaV4.SamplerPreset.self,
+            BaseChatSchemaV4.APIEndpoint.self,
+            BaseChatSchemaV4.ModelBenchmarkCache.self,
+            RagDocument.self,
+        ]
+    }
+
+    // MARK: - RagDocument
+
+    /// Persisted metadata for a document in the RAG knowledge base.
+    ///
+    /// The actual chunk text and embedding vectors are stored separately in
+    /// `FlatFileVectorStore`. This record tracks identity and provenance so
+    /// callers can list and delete documents without touching the vector index.
+    @Model
+    public final class RagDocument {
+        public var id: UUID
+        public var title: String
+        /// Absolute URL of the original source file, stored as a string.
+        public var sourceURLString: String
+        /// Lowercase file extension without the dot (e.g. "pdf", "txt").
+        public var fileType: String
+        public var chunkCount: Int
+        public var indexedAt: Date
+
+        public init(
+            id: UUID,
+            title: String,
+            sourceURLString: String,
+            fileType: String,
+            chunkCount: Int,
+            indexedAt: Date
+        ) {
+            self.id = id
+            self.title = title
+            self.sourceURLString = sourceURLString
+            self.fileType = fileType
+            self.chunkCount = chunkCount
+            self.indexedAt = indexedAt
+        }
+
+        func toRecord() -> DocumentRecord {
+            DocumentRecord(
+                id: id,
+                title: title,
+                sourceURL: URL(string: sourceURLString) ?? URL(filePath: "/"),
+                fileType: fileType,
+                chunkCount: chunkCount,
+                indexedAt: indexedAt
+            )
+        }
+    }
+}
+
+/// Public alias for the current SwiftData RAG document model.
+public typealias RagDocument = BaseChatSchemaV5.RagDocument

--- a/Sources/BaseChatRuntime/Protocols/DocumentParser.swift
+++ b/Sources/BaseChatRuntime/Protocols/DocumentParser.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Extracts plain text from a document at a given URL.
+///
+/// ``RAGService`` selects the appropriate parser by matching the URL's
+/// `pathExtension` against each parser's ``supportedExtensions``. Built-in
+/// parsers handle plain text and PDF; custom parsers can be injected into
+/// ``RAGService/init(documentStore:vectorStore:embeddingBackend:chunker:parsers:)``.
+public protocol DocumentParser: Sendable {
+    /// Lowercase file extensions this parser handles (without leading dot).
+    var supportedExtensions: Set<String> { get }
+    func parse(url: URL) async throws -> String
+}
+
+/// Errors thrown by document parsers.
+public enum DocumentParserError: LocalizedError {
+    case unsupportedFileType(String)
+    case readFailed(underlying: Error)
+    case parseFailed(underlying: Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedFileType(let ext):
+            return "No parser available for file type: .\(ext)"
+        case .readFailed(let error):
+            return "Failed to read document: \(error.localizedDescription)"
+        case .parseFailed(let error):
+            return "Failed to parse document: \(error.localizedDescription)"
+        }
+    }
+}

--- a/Sources/BaseChatRuntime/Protocols/DocumentStore.swift
+++ b/Sources/BaseChatRuntime/Protocols/DocumentStore.swift
@@ -1,0 +1,15 @@
+import Foundation
+import BaseChatInference
+
+/// Persistence port for ``DocumentRecord`` metadata.
+///
+/// Stores identity and provenance for ingested documents. Vector data lives
+/// separately in ``VectorStore``. The default concrete implementation is
+/// `SwiftDataDocumentStore` in `BaseChatPersistenceSwiftData`.
+@MainActor
+public protocol DocumentStore: AnyObject, Sendable {
+    func insertDocument(_ record: DocumentRecord) async throws
+    func fetchDocuments() async throws -> [DocumentRecord]
+    func fetchDocument(id: UUID) async throws -> DocumentRecord?
+    func deleteDocument(id: UUID) async throws
+}

--- a/Sources/BaseChatRuntime/Protocols/VectorStore.swift
+++ b/Sources/BaseChatRuntime/Protocols/VectorStore.swift
@@ -1,0 +1,37 @@
+import Foundation
+import BaseChatInference
+
+/// Persistence port for chunk embeddings and text.
+///
+/// Implementations are responsible for storing ``DocumentChunk`` text alongside
+/// its embedding vector and performing similarity search at query time. The
+/// default concrete implementation is `FlatFileVectorStore` in
+/// `BaseChatPersistenceSwiftData`.
+public protocol VectorStore: Sendable {
+    /// Persists `chunks` with their parallel `embeddings` and `documentTitle`.
+    ///
+    /// - Parameter chunks: Ordered chunks produced by ``DocumentChunker``.
+    /// - Parameter documentTitle: Display name stored with every chunk for
+    ///   context formatting; typically the source file name.
+    /// - Parameter embeddings: Parallel Float32 vectors. When empty (no embedding
+    ///   model loaded), chunks are stored for keyword search only.
+    func insert(
+        chunks: [DocumentChunk],
+        documentTitle: String,
+        embeddings: [[Float]]
+    ) async throws
+
+    /// Returns the `limit` most similar chunks to `embedding`, sorted by
+    /// descending cosine similarity. Skips records with empty embeddings.
+    func search(embedding: [Float], limit: Int) async throws -> [VectorSearchHit]
+
+    /// Returns up to `limit` chunks whose text contains `query` (case-insensitive).
+    /// Used as the fallback when no embedding model is loaded.
+    func keywordSearch(query: String, limit: Int) async throws -> [VectorSearchHit]
+
+    /// Removes all chunks belonging to `documentID`.
+    func delete(documentID: UUID) async throws
+
+    /// Removes all stored chunks and embeddings.
+    func deleteAll() async throws
+}

--- a/Sources/BaseChatRuntime/Services/ConversationRuntime.swift
+++ b/Sources/BaseChatRuntime/Services/ConversationRuntime.swift
@@ -436,6 +436,7 @@ public final class ConversationRuntime: Sendable {
     private let sessionStore: (any SessionStore)?
     private let inferenceService: InferenceService
     private let pipeline: PromptContextPipeline?
+    private let ragService: RAGService?
 
     // MARK: Event stream
 
@@ -491,13 +492,15 @@ public final class ConversationRuntime: Sendable {
         messageStore: any MessageStore,
         sessionStore: (any SessionStore)? = nil,
         inferenceService: InferenceService,
-        pipeline: PromptContextPipeline? = nil
+        pipeline: PromptContextPipeline? = nil,
+        ragService: RAGService? = nil
     ) {
         self.init(
             messageStore: messageStore,
             sessionStore: sessionStore,
             inferenceService: inferenceService,
             pipeline: pipeline,
+            ragService: ragService,
             emptyResponseObserver: nil
         )
     }
@@ -510,12 +513,14 @@ public final class ConversationRuntime: Sendable {
         sessionStore: (any SessionStore)? = nil,
         inferenceService: InferenceService,
         pipeline: PromptContextPipeline? = nil,
+        ragService: RAGService? = nil,
         emptyResponseObserver: (@Sendable (EmptyResponseDiagnostic) -> Void)?
     ) {
         self.messageStore = messageStore
         self.sessionStore = sessionStore
         self.inferenceService = inferenceService
         self.pipeline = pipeline
+        self.ragService = ragService
         self.emptyResponseObserver = emptyResponseObserver
         var cap: AsyncStream<ConversationEvent>.Continuation!
         self.events = AsyncStream(bufferingPolicy: .unbounded) { cap = $0 }
@@ -1031,7 +1036,7 @@ public final class ConversationRuntime: Sendable {
         )
         emit(.beforeContextAssembly(prompt: userPrompt, request: request))
 
-        let slots: [PromptSlot]
+        var slots: [PromptSlot]
         if let pipeline {
             do {
                 slots = try await pipeline.assemble(messageCount: messageCount)
@@ -1042,6 +1047,16 @@ public final class ConversationRuntime: Sendable {
         } else {
             slots = []
         }
+
+        if let ragService, let userPrompt {
+            do {
+                let ragSlots = try await ragService.retrieveSlots(query: userPrompt)
+                slots.append(contentsOf: ragSlots)
+            } catch {
+                Log.inference.warning("ConversationRuntime: RAG retrieval failed, continuing without retrieved context: \(error.localizedDescription)")
+            }
+        }
+
         emit(.contextAssembled(slots: slots))
 
         // Build the assistant message slot up front so token deltas can

--- a/Sources/BaseChatRuntime/Services/DocumentChunker.swift
+++ b/Sources/BaseChatRuntime/Services/DocumentChunker.swift
@@ -1,0 +1,52 @@
+import Foundation
+import BaseChatInference
+
+/// Splits a document's text into overlapping ``DocumentChunk`` passages.
+///
+/// Uses character-count boundaries rather than token counts so chunking works
+/// without a loaded tokenizer. The overlap keeps enough shared context between
+/// consecutive chunks that relevant passages aren't split at a boundary.
+///
+/// Default chunk size of 1800 chars with 200-char overlap maps to roughly
+/// 400–450 tokens for typical prose, leaving comfortable headroom in a
+/// 512-token embedding model's context window.
+public struct DocumentChunker: Sendable {
+    public var chunkSize: Int
+    public var overlap: Int
+
+    public init(chunkSize: Int = 1800, overlap: Int = 200) {
+        precondition(chunkSize > 0, "chunkSize must be positive")
+        precondition(overlap >= 0 && overlap < chunkSize, "overlap must be in [0, chunkSize)")
+        self.chunkSize = chunkSize
+        self.overlap = overlap
+    }
+
+    /// Returns an ordered array of chunks for `text`, each tagged with `documentID`.
+    public func chunk(text: String, documentID: UUID) -> [DocumentChunk] {
+        guard !text.isEmpty else { return [] }
+
+        let scalars = Array(text.unicodeScalars)
+        let total = scalars.count
+        var chunks: [DocumentChunk] = []
+        var start = 0
+        var index = 0
+
+        while start < total {
+            let end = min(start + chunkSize, total)
+            let slice = String(String.UnicodeScalarView(scalars[start..<end]))
+            let trimmed = slice.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                chunks.append(DocumentChunk(
+                    documentID: documentID,
+                    text: trimmed,
+                    chunkIndex: index
+                ))
+                index += 1
+            }
+            if end == total { break }
+            start = end - overlap
+        }
+
+        return chunks
+    }
+}

--- a/Sources/BaseChatRuntime/Services/PDFDocumentParser.swift
+++ b/Sources/BaseChatRuntime/Services/PDFDocumentParser.swift
@@ -1,0 +1,29 @@
+import Foundation
+import PDFKit
+
+/// Extracts plain text from PDF documents using PDFKit.
+///
+/// Text is extracted page by page and joined with newlines. Scanned PDFs
+/// without embedded text return an empty string — OCR is out of scope for v1.
+public struct PDFDocumentParser: DocumentParser {
+    public let supportedExtensions: Set<String> = ["pdf"]
+
+    public init() {}
+
+    public func parse(url: URL) async throws -> String {
+        guard let pdf = PDFDocument(url: url) else {
+            throw DocumentParserError.parseFailed(
+                underlying: CocoaError(.fileReadCorruptFile, userInfo: [NSURLErrorKey: url])
+            )
+        }
+
+        var pages: [String] = []
+        for i in 0..<pdf.pageCount {
+            if let page = pdf.page(at: i), let text = page.string {
+                pages.append(text)
+            }
+        }
+
+        return pages.joined(separator: "\n")
+    }
+}

--- a/Sources/BaseChatRuntime/Services/RAGService.swift
+++ b/Sources/BaseChatRuntime/Services/RAGService.swift
@@ -1,0 +1,145 @@
+import Foundation
+import BaseChatInference
+
+/// Orchestrates document ingestion and retrieval for RAG-augmented turns.
+///
+/// Call ``ingest(url:)`` to parse, chunk, embed, and persist a document.
+/// ``ConversationRuntime`` calls ``retrieveSlots(query:limit:)`` before each
+/// generation turn to inject the most relevant passages as a ``PromptSlot``
+/// with ``PromptSlotRole/retrieval``.
+///
+/// When no embedding model is loaded, retrieval falls back to case-insensitive
+/// keyword search so the knowledge base remains useful without configuring a
+/// separate embedding model.
+public actor RAGService {
+
+    private let documentStore: any DocumentStore
+    private let vectorStore: any VectorStore
+    private let embeddingBackend: (any EmbeddingBackend)?
+    private let chunker: DocumentChunker
+    private let parsers: [any DocumentParser]
+
+    public init(
+        documentStore: any DocumentStore,
+        vectorStore: any VectorStore,
+        embeddingBackend: (any EmbeddingBackend)? = nil,
+        chunker: DocumentChunker = DocumentChunker(),
+        parsers: [any DocumentParser] = [TextDocumentParser(), PDFDocumentParser()]
+    ) {
+        self.documentStore = documentStore
+        self.vectorStore = vectorStore
+        self.embeddingBackend = embeddingBackend
+        self.chunker = chunker
+        self.parsers = parsers
+    }
+
+    // MARK: - Ingestion
+
+    /// Parses, chunks, embeds, and persists the document at `url`.
+    ///
+    /// - Returns: The ``DocumentRecord`` stored for the new document.
+    /// - Throws: ``DocumentParserError`` if the file type is unsupported or
+    ///   reading fails; ``RAGError/embeddingFailed`` if the embedding call fails.
+    @discardableResult
+    public func ingest(url: URL) async throws -> DocumentRecord {
+        let ext = url.pathExtension.lowercased()
+        guard let parser = parsers.first(where: { $0.supportedExtensions.contains(ext) }) else {
+            throw DocumentParserError.unsupportedFileType(ext)
+        }
+
+        let text = try await parser.parse(url: url)
+        let title = url.deletingPathExtension().lastPathComponent
+        let documentID = UUID()
+        let chunks = chunker.chunk(text: text, documentID: documentID)
+
+        let embeddings: [[Float]]
+        if let backend = embeddingBackend, backend.isModelLoaded, !chunks.isEmpty {
+            do {
+                embeddings = try await backend.embed(chunks.map(\.text))
+            } catch {
+                throw RAGError.embeddingFailed(underlying: error)
+            }
+        } else {
+            embeddings = []
+        }
+
+        try await vectorStore.insert(
+            chunks: chunks,
+            documentTitle: title,
+            embeddings: embeddings
+        )
+
+        let record = DocumentRecord(
+            id: documentID,
+            title: title,
+            sourceURL: url,
+            fileType: ext,
+            chunkCount: chunks.count,
+            indexedAt: Date()
+        )
+        try await documentStore.insertDocument(record)
+        return record
+    }
+
+    /// Removes a document's metadata and all its chunks from the vector store.
+    public func deleteDocument(id: UUID) async throws {
+        try await vectorStore.delete(documentID: id)
+        try await documentStore.deleteDocument(id: id)
+    }
+
+    public func fetchDocuments() async throws -> [DocumentRecord] {
+        try await documentStore.fetchDocuments()
+    }
+
+    // MARK: - Retrieval
+
+    /// Returns a ``PromptSlot`` containing the top relevant passages for `query`,
+    /// or an empty array when no passages score above zero.
+    ///
+    /// Called by ``ConversationRuntime`` before each generation turn.
+    public func retrieveSlots(query: String, limit: Int = 5) async throws -> [PromptSlot] {
+        guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return []
+        }
+
+        let hits: [VectorSearchHit]
+        if let backend = embeddingBackend, backend.isModelLoaded {
+            do {
+                let queryEmbedding = try await backend.embed([query])[0]
+                hits = try await vectorStore.search(embedding: queryEmbedding, limit: limit)
+            } catch {
+                Log.inference.warning("RAGService: embedding query failed, falling back to keyword search: \(error.localizedDescription)")
+                hits = try await vectorStore.keywordSearch(query: query, limit: limit)
+            }
+        } else {
+            hits = try await vectorStore.keywordSearch(query: query, limit: limit)
+        }
+
+        guard !hits.isEmpty else { return [] }
+
+        let content = hits.map { hit in
+            "[\(hit.documentTitle)]\n\(hit.chunk.text)"
+        }.joined(separator: "\n\n---\n\n")
+
+        return [PromptSlot(
+            id: "rag-retrieval",
+            content: content,
+            position: .contextSetup,
+            role: .retrieval,
+            label: "Retrieved Documents"
+        )]
+    }
+}
+
+// MARK: - RAGError
+
+public enum RAGError: LocalizedError {
+    case embeddingFailed(underlying: Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .embeddingFailed(let error):
+            return "Embedding failed: \(error.localizedDescription)"
+        }
+    }
+}

--- a/Sources/BaseChatRuntime/Services/TextDocumentParser.swift
+++ b/Sources/BaseChatRuntime/Services/TextDocumentParser.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Reads plain-text and Markdown files as UTF-8 strings.
+public struct TextDocumentParser: DocumentParser {
+    public let supportedExtensions: Set<String> = ["txt", "md", "markdown"]
+
+    public init() {}
+
+    public func parse(url: URL) async throws -> String {
+        do {
+            return try String(contentsOf: url, encoding: .utf8)
+        } catch {
+            throw DocumentParserError.readFailed(underlying: error)
+        }
+    }
+}

--- a/Tests/BaseChatInferenceTests/DocumentChunkTests.swift
+++ b/Tests/BaseChatInferenceTests/DocumentChunkTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import BaseChatInference
+
+final class DocumentChunkTests: XCTestCase {
+
+    func testDocumentRecordIdentity() {
+        let id = UUID()
+        let url = URL(filePath: "/tmp/test.pdf")
+        let record = DocumentRecord(
+            id: id,
+            title: "Test",
+            sourceURL: url,
+            fileType: "pdf",
+            chunkCount: 3
+        )
+        XCTAssertEqual(record.id, id)
+        XCTAssertEqual(record.title, "Test")
+        XCTAssertEqual(record.fileType, "pdf")
+        XCTAssertEqual(record.chunkCount, 3)
+        XCTAssertEqual(record.sourceURL, url)
+    }
+
+    func testDocumentRecordCodable() throws {
+        let record = DocumentRecord(
+            title: "Doc",
+            sourceURL: URL(filePath: "/tmp/doc.txt"),
+            fileType: "txt",
+            chunkCount: 7
+        )
+        let encoded = try JSONEncoder().encode(record)
+        let decoded = try JSONDecoder().decode(DocumentRecord.self, from: encoded)
+        XCTAssertEqual(record, decoded)
+    }
+
+    func testDocumentChunkIdentity() {
+        let docID = UUID()
+        let chunk = DocumentChunk(documentID: docID, text: "Hello", chunkIndex: 2)
+        XCTAssertEqual(chunk.documentID, docID)
+        XCTAssertEqual(chunk.text, "Hello")
+        XCTAssertEqual(chunk.chunkIndex, 2)
+    }
+
+    func testVectorSearchHitScore() {
+        let chunk = DocumentChunk(documentID: UUID(), text: "passage", chunkIndex: 0)
+        let hit = VectorSearchHit(chunk: chunk, documentTitle: "Doc", score: 0.92)
+        XCTAssertEqual(hit.score, 0.92, accuracy: 1e-6)
+        XCTAssertEqual(hit.documentTitle, "Doc")
+    }
+
+    // Sabotage: changing score should not equal original
+    func testVectorSearchHitSabotage() {
+        let chunk = DocumentChunk(documentID: UUID(), text: "x", chunkIndex: 0)
+        let hit = VectorSearchHit(chunk: chunk, documentTitle: "D", score: 0.5)
+        XCTAssertNotEqual(hit.score, 0.9)
+    }
+}

--- a/Tests/BaseChatPersistenceSwiftDataTests/FlatFileVectorStoreTests.swift
+++ b/Tests/BaseChatPersistenceSwiftDataTests/FlatFileVectorStoreTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+@testable import BaseChatPersistenceSwiftData
+import BaseChatInference
+import BaseChatRuntime
+
+final class FlatFileVectorStoreTests: XCTestCase {
+
+    private var storeURL: URL!
+
+    override func setUp() {
+        super.setUp()
+        storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + ".bin")
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: storeURL)
+        super.tearDown()
+    }
+
+    func testEmptyStoreSearchReturnsNothing() async throws {
+        let store = FlatFileVectorStore(storageURL: storeURL)
+        let results = try await store.search(embedding: [1, 0, 0], limit: 5)
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func testInsertAndSearchReturnsHits() async throws {
+        let store = FlatFileVectorStore(storageURL: storeURL)
+        let docID = UUID()
+        let chunk = DocumentChunk(documentID: docID, text: "The quick brown fox", chunkIndex: 0)
+        // Unit vector along first axis
+        try await store.insert(chunks: [chunk], documentTitle: "Doc", embeddings: [[1, 0, 0]])
+
+        let results = try await store.search(embedding: [1, 0, 0], limit: 5)
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].chunk.text, "The quick brown fox")
+        XCTAssertEqual(results[0].documentTitle, "Doc")
+        XCTAssertGreaterThan(results[0].score, 0.99)
+    }
+
+    func testSearchResultsAreSortedByDescendingScore() async throws {
+        let store = FlatFileVectorStore(storageURL: storeURL)
+        let docID = UUID()
+        let chunkA = DocumentChunk(id: UUID(), documentID: docID, text: "A", chunkIndex: 0)
+        let chunkB = DocumentChunk(id: UUID(), documentID: docID, text: "B", chunkIndex: 1)
+        // chunkA is aligned with query; chunkB is perpendicular
+        try await store.insert(
+            chunks: [chunkA, chunkB],
+            documentTitle: "Doc",
+            embeddings: [[1, 0, 0], [0, 1, 0]]
+        )
+
+        let results = try await store.search(embedding: [1, 0, 0], limit: 5)
+        XCTAssertEqual(results.count, 2)
+        XCTAssertGreaterThanOrEqual(results[0].score, results[1].score)
+        XCTAssertEqual(results[0].chunk.text, "A")
+    }
+
+    func testSearchRespectsLimit() async throws {
+        let store = FlatFileVectorStore(storageURL: storeURL)
+        let docID = UUID()
+        let chunks = (0..<10).map { i in
+            DocumentChunk(documentID: docID, text: "chunk \(i)", chunkIndex: i)
+        }
+        let embeddings = chunks.map { _ in [Float(1), 0, 0] }
+        try await store.insert(chunks: chunks, documentTitle: "Doc", embeddings: embeddings)
+
+        let results = try await store.search(embedding: [1, 0, 0], limit: 3)
+        XCTAssertEqual(results.count, 3)
+    }
+
+    func testKeywordSearchFindsMatches() async throws {
+        let store = FlatFileVectorStore(storageURL: storeURL)
+        let docID = UUID()
+        let chunkA = DocumentChunk(documentID: docID, text: "Swift is great", chunkIndex: 0)
+        let chunkB = DocumentChunk(documentID: docID, text: "Python is also good", chunkIndex: 1)
+        try await store.insert(chunks: [chunkA, chunkB], documentTitle: "Doc", embeddings: [])
+
+        let results = try await store.keywordSearch(query: "swift", limit: 5)
+        XCTAssertEqual(results.count, 1)
+        XCTAssertTrue(results[0].chunk.text.lowercased().contains("swift"))
+    }
+
+    func testDeleteRemovesChunksForDocument() async throws {
+        let store = FlatFileVectorStore(storageURL: storeURL)
+        let docID = UUID()
+        let chunk = DocumentChunk(documentID: docID, text: "To be deleted", chunkIndex: 0)
+        try await store.insert(chunks: [chunk], documentTitle: "Doc", embeddings: [[1, 0, 0]])
+
+        try await store.delete(documentID: docID)
+
+        let results = try await store.search(embedding: [1, 0, 0], limit: 5)
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func testDeleteAllClearsStore() async throws {
+        let store = FlatFileVectorStore(storageURL: storeURL)
+        let docID = UUID()
+        let chunks = [DocumentChunk(documentID: docID, text: "text", chunkIndex: 0)]
+        try await store.insert(chunks: chunks, documentTitle: "Doc", embeddings: [[1, 0, 0]])
+
+        try await store.deleteAll()
+        let results = try await store.search(embedding: [1, 0, 0], limit: 5)
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func testPersistenceRoundTrip() async throws {
+        // Insert into one store instance, reload from file in a second instance
+        let store1 = FlatFileVectorStore(storageURL: storeURL)
+        let docID = UUID()
+        let chunk = DocumentChunk(documentID: docID, text: "Persisted chunk", chunkIndex: 0)
+        try await store1.insert(chunks: [chunk], documentTitle: "Source", embeddings: [[0, 1, 0]])
+
+        let store2 = FlatFileVectorStore(storageURL: storeURL)
+        let results = try await store2.keywordSearch(query: "persisted", limit: 5)
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].chunk.text, "Persisted chunk")
+        XCTAssertEqual(results[0].documentTitle, "Source")
+    }
+
+    func testChunksWithNoEmbeddingAreExcludedFromVectorSearch() async throws {
+        let store = FlatFileVectorStore(storageURL: storeURL)
+        let docID = UUID()
+        let chunk = DocumentChunk(documentID: docID, text: "keyword only chunk", chunkIndex: 0)
+        // Insert with empty embeddings (keyword-only indexing)
+        try await store.insert(chunks: [chunk], documentTitle: "Doc", embeddings: [])
+
+        let vectorResults = try await store.search(embedding: [1, 0, 0], limit: 5)
+        XCTAssertTrue(vectorResults.isEmpty, "Chunks without embeddings must not appear in vector search")
+
+        let keywordResults = try await store.keywordSearch(query: "keyword", limit: 5)
+        XCTAssertEqual(keywordResults.count, 1)
+    }
+
+    // Sabotage: deleted chunks must not appear
+    func testSabotageDeletedChunksDoNotAppear() async throws {
+        let store = FlatFileVectorStore(storageURL: storeURL)
+        let docID = UUID()
+        let chunk = DocumentChunk(documentID: docID, text: "delete me", chunkIndex: 0)
+        try await store.insert(chunks: [chunk], documentTitle: "Doc", embeddings: [[1, 0, 0]])
+        try await store.delete(documentID: docID)
+
+        let keyword = try await store.keywordSearch(query: "delete", limit: 5)
+        XCTAssertTrue(keyword.isEmpty, "Deleted chunks must not appear in keyword search")
+    }
+}

--- a/Tests/BaseChatPersistenceSwiftDataTests/SchemaMigrationTests.swift
+++ b/Tests/BaseChatPersistenceSwiftDataTests/SchemaMigrationTests.swift
@@ -73,8 +73,8 @@ final class SchemaMigrationTests: XCTestCase {
         XCTAssertNotNil(container)
     }
 
-    func test_containerFactory_currentSchema_isV4() {
-        XCTAssertEqual(ObjectIdentifier(ModelContainerFactory.currentSchema), ObjectIdentifier(BaseChatSchemaV4.self))
+    func test_containerFactory_currentSchema_isV5() {
+        XCTAssertEqual(ObjectIdentifier(ModelContainerFactory.currentSchema), ObjectIdentifier(BaseChatSchemaV5.self))
     }
 
     func test_containerFactory_reopensPersistedStore() throws {

--- a/Tests/BaseChatPersistenceSwiftDataTests/SwiftDataDocumentStoreTests.swift
+++ b/Tests/BaseChatPersistenceSwiftDataTests/SwiftDataDocumentStoreTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+import SwiftData
+@testable import BaseChatPersistenceSwiftData
+import BaseChatInference
+import BaseChatRuntime
+
+@MainActor
+final class SwiftDataDocumentStoreTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var sut: SwiftDataDocumentStore!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        container = try ModelContainerFactory.makeInMemoryContainer()
+        sut = SwiftDataDocumentStore(modelContext: container.mainContext)
+    }
+
+    override func tearDown() {
+        container = nil
+        sut = nil
+        super.tearDown()
+    }
+
+    func testInsertAndFetch() throws {
+        let record = makeRecord(title: "Test Doc")
+        try sut.insertDocument(record)
+
+        let fetched = try sut.fetchDocuments()
+        XCTAssertEqual(fetched.count, 1)
+        XCTAssertEqual(fetched[0].title, "Test Doc")
+        XCTAssertEqual(fetched[0].id, record.id)
+    }
+
+    func testFetchDocumentById() throws {
+        let record = makeRecord(title: "Find Me")
+        try sut.insertDocument(record)
+
+        let found = try sut.fetchDocument(id: record.id)
+        XCTAssertNotNil(found)
+        XCTAssertEqual(found?.title, "Find Me")
+    }
+
+    func testFetchDocumentByIdMissing() throws {
+        let result = try sut.fetchDocument(id: UUID())
+        XCTAssertNil(result)
+    }
+
+    func testDeleteDocument() throws {
+        let record = makeRecord(title: "Delete Me")
+        try sut.insertDocument(record)
+        try sut.deleteDocument(id: record.id)
+
+        let fetched = try sut.fetchDocuments()
+        XCTAssertTrue(fetched.isEmpty)
+    }
+
+    func testMultipleDocuments() throws {
+        try sut.insertDocument(makeRecord(title: "A"))
+        try sut.insertDocument(makeRecord(title: "B"))
+        try sut.insertDocument(makeRecord(title: "C"))
+
+        let fetched = try sut.fetchDocuments()
+        XCTAssertEqual(fetched.count, 3)
+    }
+
+    func testDeleteOnlyTargetedDocument() throws {
+        let recordA = makeRecord(title: "Keep")
+        let recordB = makeRecord(title: "Remove")
+        try sut.insertDocument(recordA)
+        try sut.insertDocument(recordB)
+
+        try sut.deleteDocument(id: recordB.id)
+
+        let fetched = try sut.fetchDocuments()
+        XCTAssertEqual(fetched.count, 1)
+        XCTAssertEqual(fetched[0].title, "Keep")
+    }
+
+    // Sabotage: deleted document must not be fetchable by ID
+    func testSabotageDeletedDocumentNotFetchable() throws {
+        let record = makeRecord(title: "Gone")
+        try sut.insertDocument(record)
+        try sut.deleteDocument(id: record.id)
+
+        let found = try sut.fetchDocument(id: record.id)
+        XCTAssertNil(found, "Deleted document must not be retrievable")
+    }
+
+    // MARK: - Helper
+
+    private func makeRecord(title: String) -> DocumentRecord {
+        DocumentRecord(
+            title: title,
+            sourceURL: URL(filePath: "/tmp/\(title).txt"),
+            fileType: "txt",
+            chunkCount: 1
+        )
+    }
+}

--- a/Tests/BaseChatRuntimeTests/DocumentChunkerTests.swift
+++ b/Tests/BaseChatRuntimeTests/DocumentChunkerTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import BaseChatRuntime
+import BaseChatInference
+
+final class DocumentChunkerTests: XCTestCase {
+
+    func testEmptyTextReturnsNoChunks() {
+        let chunker = DocumentChunker()
+        XCTAssertTrue(chunker.chunk(text: "", documentID: UUID()).isEmpty)
+    }
+
+    func testSingleChunkWhenTextFitsInWindow() {
+        let chunker = DocumentChunker(chunkSize: 1800, overlap: 200)
+        let docID = UUID()
+        let chunks = chunker.chunk(text: "Short text.", documentID: docID)
+        XCTAssertEqual(chunks.count, 1)
+        XCTAssertEqual(chunks[0].text, "Short text.")
+        XCTAssertEqual(chunks[0].documentID, docID)
+        XCTAssertEqual(chunks[0].chunkIndex, 0)
+    }
+
+    func testMultipleChunksForLongText() {
+        let chunker = DocumentChunker(chunkSize: 100, overlap: 10)
+        let text = String(repeating: "a", count: 350)
+        let chunks = chunker.chunk(text: text, documentID: UUID())
+        // Expect 4 chunks: [0-100], [90-190], [180-280], [270-350]
+        XCTAssertEqual(chunks.count, 4)
+    }
+
+    func testChunkIndicesAreZeroBased() {
+        let chunker = DocumentChunker(chunkSize: 50, overlap: 5)
+        let text = String(repeating: "b", count: 200)
+        let chunks = chunker.chunk(text: text, documentID: UUID())
+        XCTAssertEqual(chunks[0].chunkIndex, 0)
+        XCTAssertEqual(chunks[1].chunkIndex, 1)
+        for (i, chunk) in chunks.enumerated() {
+            XCTAssertEqual(chunk.chunkIndex, i)
+        }
+    }
+
+    func testWhitespaceOnlyChunkIsDropped() {
+        let chunker = DocumentChunker(chunkSize: 100, overlap: 10)
+        let text = "Real content" + String(repeating: " ", count: 100)
+        let chunks = chunker.chunk(text: text, documentID: UUID())
+        // Last window is all spaces — should be dropped
+        for chunk in chunks {
+            XCTAssertFalse(chunk.text.trimmingCharacters(in: .whitespaces).isEmpty)
+        }
+    }
+
+    func testChunkSizeOf1ReturnsSingleChunks() {
+        let chunker = DocumentChunker(chunkSize: 1, overlap: 0)
+        let chunks = chunker.chunk(text: "abc", documentID: UUID())
+        XCTAssertEqual(chunks.count, 3)
+    }
+
+    // Sabotage check: without chunking, no chunks exist
+    func testSabotageEmptyTextHasNoChunks() {
+        let chunker = DocumentChunker()
+        XCTAssertEqual(chunker.chunk(text: "", documentID: UUID()).count, 0)
+        // If chunk() wrongly returned chunks for empty input, this would fail
+        XCTAssertFalse(chunker.chunk(text: "", documentID: UUID()).count > 0)
+    }
+}

--- a/Tests/BaseChatRuntimeTests/RAGServiceTests.swift
+++ b/Tests/BaseChatRuntimeTests/RAGServiceTests.swift
@@ -1,0 +1,201 @@
+import XCTest
+@testable import BaseChatRuntime
+import BaseChatInference
+
+// MARK: - Fakes
+
+private actor FakeVectorStore: VectorStore {
+    var insertedChunks: [DocumentChunk] = []
+    var insertedEmbeddings: [[Float]] = []
+    var insertedTitles: [String] = []
+    var deletedDocumentIDs: [UUID] = []
+    var searchResults: [VectorSearchHit] = []
+    var keywordResults: [VectorSearchHit] = []
+
+    func insert(chunks: [DocumentChunk], documentTitle: String, embeddings: [[Float]]) throws {
+        insertedChunks.append(contentsOf: chunks)
+        insertedEmbeddings.append(contentsOf: embeddings)
+        insertedTitles.append(contentsOf: [String](repeating: documentTitle, count: chunks.count))
+    }
+
+    func search(embedding: [Float], limit: Int) throws -> [VectorSearchHit] { searchResults }
+    func keywordSearch(query: String, limit: Int) throws -> [VectorSearchHit] { keywordResults }
+    func delete(documentID: UUID) throws { deletedDocumentIDs.append(documentID) }
+    func deleteAll() throws { insertedChunks.removeAll() }
+}
+
+@MainActor
+private final class FakeDocumentStore: DocumentStore {
+    var insertedRecords: [DocumentRecord] = []
+    var deletedIDs: [UUID] = []
+
+    func insertDocument(_ record: DocumentRecord) throws { insertedRecords.append(record) }
+    func fetchDocuments() throws -> [DocumentRecord] { insertedRecords }
+    func fetchDocument(id: UUID) throws -> DocumentRecord? { insertedRecords.first { $0.id == id } }
+    func deleteDocument(id: UUID) throws {
+        insertedRecords.removeAll { $0.id == id }
+        deletedIDs.append(id)
+    }
+}
+
+private final class FakeEmbeddingBackend: EmbeddingBackend, @unchecked Sendable {
+    var isModelLoaded: Bool
+    var dimensions: Int = 4
+    var embedCallCount = 0
+
+    init(isModelLoaded: Bool = true) { self.isModelLoaded = isModelLoaded }
+
+    func loadModel(from url: URL) async throws { isModelLoaded = true }
+    func embed(_ texts: [String]) async throws -> [[Float]] {
+        embedCallCount += 1
+        return texts.map { _ in [1.0, 0.0, 0.0, 0.0] }
+    }
+    func unloadModel() { isModelLoaded = false }
+}
+
+// MARK: - Tests
+
+@MainActor
+final class RAGServiceTests: XCTestCase {
+
+    func testIngestStoresChunksAndDocument() async throws {
+        let vectorStore = FakeVectorStore()
+        let docStore = FakeDocumentStore()
+        let sut = RAGService(documentStore: docStore, vectorStore: vectorStore)
+
+        let url = try writeTempFile(content: "Hello world. This is a test document.")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let record = try await sut.ingest(url: url)
+
+        let inserted = await vectorStore.insertedChunks
+        XCTAssertFalse(inserted.isEmpty)
+        XCTAssertEqual(docStore.insertedRecords.count, 1)
+        XCTAssertEqual(docStore.insertedRecords[0].id, record.id)
+    }
+
+    func testIngestWithEmbeddingBackendCallsEmbed() async throws {
+        let vectorStore = FakeVectorStore()
+        let docStore = FakeDocumentStore()
+        let backend = FakeEmbeddingBackend(isModelLoaded: true)
+        let sut = RAGService(
+            documentStore: docStore,
+            vectorStore: vectorStore,
+            embeddingBackend: backend
+        )
+
+        let url = try writeTempFile(content: String(repeating: "word ", count: 20))
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try await sut.ingest(url: url)
+
+        XCTAssertGreaterThan(backend.embedCallCount, 0)
+        let embeddings = await vectorStore.insertedEmbeddings
+        XCTAssertFalse(embeddings.isEmpty)
+    }
+
+    func testIngestWithoutEmbeddingBackendStoresEmptyEmbeddings() async throws {
+        let vectorStore = FakeVectorStore()
+        let docStore = FakeDocumentStore()
+        let sut = RAGService(documentStore: docStore, vectorStore: vectorStore)
+
+        let url = try writeTempFile(content: "Some text")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try await sut.ingest(url: url)
+
+        let embeddings = await vectorStore.insertedEmbeddings
+        XCTAssertTrue(embeddings.isEmpty)
+    }
+
+    func testIngestUnsupportedFileTypeThrows() async throws {
+        let sut = RAGService(documentStore: FakeDocumentStore(), vectorStore: FakeVectorStore())
+        let url = URL(filePath: "/tmp/file.docx")
+        do {
+            try await sut.ingest(url: url)
+            XCTFail("Expected unsupportedFileType error")
+        } catch DocumentParserError.unsupportedFileType {
+            // expected
+        }
+    }
+
+    func testRetrieveSlotsWithEmbeddingBackend() async throws {
+        let vectorStore = FakeVectorStore()
+        let chunk = DocumentChunk(documentID: UUID(), text: "Relevant passage", chunkIndex: 0)
+        let hit = VectorSearchHit(chunk: chunk, documentTitle: "Doc", score: 0.9)
+        await vectorStore.setSearchResults([hit])
+
+        let backend = FakeEmbeddingBackend(isModelLoaded: true)
+        let sut = RAGService(
+            documentStore: FakeDocumentStore(),
+            vectorStore: vectorStore,
+            embeddingBackend: backend
+        )
+
+        let slots = try await sut.retrieveSlots(query: "What is relevant?")
+        XCTAssertEqual(slots.count, 1)
+        XCTAssertEqual(slots[0].role, .retrieval)
+        XCTAssertTrue(slots[0].content.contains("Relevant passage"))
+    }
+
+    func testRetrieveSlotsWithoutEmbeddingFallsBackToKeyword() async throws {
+        let vectorStore = FakeVectorStore()
+        let chunk = DocumentChunk(documentID: UUID(), text: "keyword result", chunkIndex: 0)
+        let hit = VectorSearchHit(chunk: chunk, documentTitle: "Doc", score: 1.0)
+        await vectorStore.setKeywordResults([hit])
+
+        let sut = RAGService(documentStore: FakeDocumentStore(), vectorStore: vectorStore)
+
+        let slots = try await sut.retrieveSlots(query: "keyword")
+        XCTAssertEqual(slots.count, 1)
+        XCTAssertTrue(slots[0].content.contains("keyword result"))
+    }
+
+    func testRetrieveSlotsWithNoHitsReturnsEmpty() async throws {
+        let sut = RAGService(documentStore: FakeDocumentStore(), vectorStore: FakeVectorStore())
+        let slots = try await sut.retrieveSlots(query: "anything")
+        XCTAssertTrue(slots.isEmpty)
+    }
+
+    func testRetrieveSlotsEmptyQueryReturnsEmpty() async throws {
+        let sut = RAGService(documentStore: FakeDocumentStore(), vectorStore: FakeVectorStore())
+        let slots = try await sut.retrieveSlots(query: "   ")
+        XCTAssertTrue(slots.isEmpty)
+    }
+
+    func testDeleteDocumentRemovesFromBothStores() async throws {
+        let vectorStore = FakeVectorStore()
+        let docStore = FakeDocumentStore()
+        let sut = RAGService(documentStore: docStore, vectorStore: vectorStore)
+
+        let url = try writeTempFile(content: "Delete me")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let record = try await sut.ingest(url: url)
+        try await sut.deleteDocument(id: record.id)
+
+        let deleted = await vectorStore.deletedDocumentIDs
+        XCTAssertTrue(deleted.contains(record.id))
+        XCTAssertTrue(docStore.deletedIDs.contains(record.id))
+    }
+
+    // MARK: - Helpers
+
+    private func writeTempFile(content: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + ".txt")
+        try content.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+}
+
+// MARK: - FakeVectorStore helper
+
+private extension FakeVectorStore {
+    func setSearchResults(_ results: [VectorSearchHit]) {
+        searchResults = results
+    }
+    func setKeywordResults(_ results: [VectorSearchHit]) {
+        keywordResults = results
+    }
+}


### PR DESCRIPTION
## Summary

- Adds on-device RAG to BCK with zero new binary dependencies — a pure-Swift flat-file vector index (`FlatFileVectorStore`) stores L2-normalized embeddings and does O(n) cosine similarity search (correct for ~50k chunks)
- `RAGService` orchestrates the full pipeline: parse → chunk → embed → store at ingest time; embed query → retrieve top-k → inject as `PromptSlot(.retrieval)` at turn time
- `ConversationRuntime` gains an optional `ragService` parameter; retrieval runs after `PromptContextPipeline.assemble()` so RAG slots appear in the `contextAssembled` event
- Graceful keyword fallback when no `EmbeddingBackend` is loaded (uses `VectorStore.keywordSearch` — case-insensitive substring match)
- Schema V5 adds `RagDocument @Model` via a lightweight migration from V4 — no existing data touched
- `BaseChatBootstrap` gains `RAGConfiguration` and exposes `ragService?: RAGService` for host apps

## New public surface

```swift
// Configure at bootstrap
let rag = RAGConfiguration(embeddingBackend: myLlamaEmbeddingBackend)
let bootstrap = try BaseChatBootstrap(configuration: config, ragConfiguration: rag)

// Ingest documents
try await bootstrap.ragService?.ingest(url: pdfURL)
try await bootstrap.ragService?.ingest(url: txtURL)

// Retrieval is automatic — ConversationRuntime calls it before each turn
// Supported file types: .txt, .md, .markdown, .pdf
```

## What this does not include (Phase 2 PR)

- Source citations in the message UI
- `DocumentLibraryView` / drag-and-drop
- Cloud embedding API support (OpenAI text-embedding-3-small)
- sqlite-vec ANN index for libraries >50k chunks

## Test plan

- [ ] `scripts/test.sh --filter BaseChatInferenceTests --filter BaseChatRuntimeTests --filter BaseChatPersistenceSwiftDataTests --disable-default-traits --skip-update` → 2879 pass
- [ ] `scripts/test.sh --filter BaseChatInferenceSwiftTestingTests --disable-default-traits --skip-update` → 83 pass
- [ ] `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` → clean
- [ ] Manual: wire `LlamaEmbeddingBackend` + a `.txt` fixture in the Example app, ingest, send a query, confirm retrieved chunk appears in `.contextAssembled` event

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)