### PR TITLE
chore: re-enable release-please after ManifoldKit rename

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,12 +11,6 @@ permissions:
 
 jobs:
   release-please:
-    # Skip release-please during the BaseChatKit → ManifoldKit GitHub-repo rename window.
-    # Without this guard, merging the rename PR fires release-please against the
-    # not-yet-renamed repo and `feat!:` would otherwise bump us to 1.0.0. The lead
-    # reverts this guard in a small follow-up PR after the GitHub repo is renamed,
-    # so release-please then opens the v0.20.0 PR against the renamed repo.
-    if: ${{ !contains(github.event.head_commit.message, 'rename BaseChatKit') }}
     runs-on: ubuntu-latest
     # Cancelling in-progress runs is safe here — only the latest matters.
     concurrency:


### PR DESCRIPTION
## Summary
Reverts the temporary `if:` guard on the release-please job that was added by Worker C in #1150 to prevent release-please firing during the BaseChatKit → ManifoldKit GitHub repo rename window.

The rename has merged (#1150 squash-merged as `8a785ee`); the GitHub repo is now `roryford/ManifoldKit`. With this guard removed, the next merge to main fires release-please normally and it opens the v0.20.0 release PR against the renamed repo.

## Test plan
- [x] Verify the rename PR's merge fired release-please with `conclusion: skipped` (it did — run 25594462902)
- [ ] After this PR merges, release-please opens a release PR against `roryford/ManifoldKit/main` for v0.20.0
- [ ] Apply the Prisma snippet from `docs/release-notes/v0.20.0-prisma.md` to that release PR's CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)