### PR TITLE
chore(tests): trim MLX from llama isolation script + clarify trait flag docs

### DIFF
--- a/Tests/README.md
+++ b/Tests/README.md
@@ -41,7 +41,11 @@ BCK's test targets are conditionally linked on Swift package traits:
 | `Server` | no | ManifoldServer |
 | `Operational` | (planned, T4) | Nightly soak/migration/throughput |
 
-The default-traits build is what CI's per-PR matrix runs against. Use `--disable-default-traits` locally to drop MLX/Llama (faster, sim-friendly).
+The default-traits build is what CI's per-PR matrix runs against. Use `--disable-default-traits` locally to drop MLX/Llama/HuggingFace (faster, sim-friendly).
+
+**When to disable default traits locally:** any iteration that doesn't exercise a hardware backend — `ManifoldRuntimeTests`, `ManifoldPersistenceSwiftDataTests`, `ManifoldUITests`, `ManifoldInferenceTests`, `ManifoldMCPTests`, `ManifoldServerTests`. Skipping MLX avoids an mlx-swift source checkout and a Metal shader compilation pass on every rebuild — the dominant cost in a default-traits cold build.
+
+**When to keep defaults on:** changes under `Sources/ManifoldMLX/` or `Sources/ManifoldLlama/`, the matching `ManifoldBackendsTests` MLX/Llama suites, and `ManifoldE2ETests`. Those tests `XCTSkip` without the trait — the run looks green but exercises nothing.
 
 ## Running a single suite
 

--- a/scripts/test-llama-isolated.sh
+++ b/scripts/test-llama-isolated.sh
@@ -102,8 +102,13 @@ done
 # ── Build once, reuse the bundle across invocations ───────────────────────────
 # `swift test --skip-build` reads the existing test bundle from .build, so
 # pre-building here saves the per-invocation compile-time check.
-echo "[test-llama-isolated] Pre-building tests with traits MLX,Llama..."
-swift build --build-tests --traits MLX,Llama
+#
+# Trait set is `Llama` only (not `MLX,Llama`) — every class in
+# LLAMA_TEST_CLASSES is `#if Llama`-gated and references zero ManifoldMLX
+# symbols, so dropping MLX skips an mlx-swift source checkout and a full
+# Metal shader compilation pass for no loss of coverage.
+echo "[test-llama-isolated] Pre-building tests with traits Llama..."
+swift build --build-tests --traits Llama
 echo ""
 
 # ── Run each class in its own invocation ──────────────────────────────────────
@@ -121,7 +126,7 @@ for class in "${LLAMA_TEST_CLASSES[@]}"; do
     set +e
     swift test \
         --filter "ManifoldBackendsTests\.${class}/" \
-        --traits MLX,Llama \
+        --traits Llama \
         --skip-build \
         "${EXTRA_ARGS[@]}" \
         2>&1 | tee "$LOG"


### PR DESCRIPTION
## Summary

Two small test-ergonomics wins surfaced from a Metal/test duplication audit:

- `scripts/test-llama-isolated.sh` was building with `--traits MLX,Llama`. Every class in `LLAMA_TEST_CLASSES` is `#if Llama`-gated and references zero `ManifoldMLX` symbols, so `MLX` in the trait set forced an mlx-swift source checkout and a full Metal shader compile pass for nothing. Now `--traits Llama` only, with an inline comment explaining *why* so it doesn't get "fixed" back.
- `Tests/README.md` mentioned `--disable-default-traits` in one line. Expanded with concrete when-to-use guidance — non-backend local iteration (`Runtime`, `Persistence`, `UI`, `MCP`, `Server`) skips the MLX shader-compile by default; backend work keeps defaults so MLX/Llama tests don't silently `XCTSkip` into a green-but-empty run.

## Why this is safe

- `ManifoldLlama` source files are all `#if Llama`-guarded and have no `import ManifoldMLX` references.
- The 11 isolated test classes (`LlamaArchitecturePreflightTests` … `LlamaToolCapabilityTests`) contain zero MLX symbols (audited).
- `Package.swift` makes `ManifoldLlama → LlamaSwift` (binary xcframework) the only build edge added by the `Llama` trait. No transitive MLX dep.

## Test plan

- [ ] `bash -n scripts/test-llama-isolated.sh` passes (script syntax)
- [ ] `swift build --build-tests --traits Llama` succeeds locally on Apple Silicon
- [ ] `RUN_LLAMA_TESTS=1 MANIFOLD_DISCOVER_LOCAL_MODELS=1 LLAMA_TEST_MODEL=… scripts/test-llama-isolated.sh` runs end-to-end (full validation requires a local GGUF + Apple Silicon hardware)
- [ ] CI's existing default lanes are unaffected (script isn't wired into CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)