### PR TITLE
fix(tests): make DemoScenarioOllamaE2ETests compile so all 4 tests register

### DIFF
--- a/Tests/ManifoldE2ETests/DemoScenarioOllamaE2ETests.swift
+++ b/Tests/ManifoldE2ETests/DemoScenarioOllamaE2ETests.swift
@@ -155,8 +155,8 @@ final class DemoScenarioOllamaE2ETests: XCTestCase {
             systemPrompt: "Use the `write_file` tool to save the user's content. Path must be relative. Then confirm in one sentence.",
             userPrompt: "Write a one-sentence journal entry to journal/today.md saying I had a productive day.",
             expectedToolNames: ["write_file"]
-        ) { _, _ in
-            let journalPath = sandboxRoot.appendingPathComponent("journal/today.md")
+        ) { [self] _, _ in
+            let journalPath = sandboxRoot!.appendingPathComponent("journal/today.md")
             XCTAssertTrue(
                 FileManager.default.fileExists(atPath: journalPath.path),
                 "Journal-write scenario should create journal/today.md"


### PR DESCRIPTION
## Summary

`Tests/ManifoldE2ETests/DemoScenarioOllamaE2ETests.swift` had a closure that referenced `sandboxRoot` (a stored property) without an explicit `self.` or `[self]` capture, which fails to compile under Swift 6 strict concurrency. The compile error wrote a `.dia` diagnostics file but produced no `.swift.o`, so the four test methods silently dropped out of the linked `ManifoldKitPackageTests` xctest binary.

Symptoms:

- `swift test --traits Ollama,Tools --skip-update --skip-build --list-tests | grep DemoScenario` → zero hits
- `swift test --traits Ollama,Tools --filter 'ManifoldE2ETests\.DemoScenarioOllamaE2ETests'` → `error: fatalError` (swift-test post-v2 emits this when a `--filter` regex matches zero compiled tests)
- Sibling `OllamaToolCallingE2ETests` registered fine (no closure-self issue)

The misleading part: `swift build --build-tests --traits Ollama,Tools` reports `Build complete!` because `swift-test` only fails the build when stitching the xctest target — at the per-source-file level the failure is silently absorbed once the dependency graph is satisfied. Running with `touch` to force recompile surfaces:

```
DemoScenarioOllamaE2ETests.swift:159:31: error: reference to property 'sandboxRoot' in closure requires explicit use of 'self' to make capture semantics explicit
```

## Fix

Capture `self` explicitly in the closure so the file compiles. The `[self]` form keeps the existing semantics (the closure is non-escaping anyway).

## Test plan

- [x] `swift test --traits Ollama,Tools --skip-update --skip-build --list-tests` shows all 4 demo tests
- [x] `swift test --traits Ollama,Tools --filter 'ManifoldE2ETests\.DemoScenarioOllamaE2ETests'` runs all 4 tests against local Ollama (`llama3.1:8b`); 3 pass, 1 fails on a model-quality assertion (`worldClock` didn't pass `Asia/Tokyo` — flaky model behaviour, out of scope for this PR)
- [x] No effect on suites built without `Tools` trait — the file is `#if Ollama && Tools` gated

🤖 Generated with [Claude Code](https://claude.com/claude-code)