### PR TITLE
feat(rag): Phase 2 — document library UI, source citations, demo wiring

### DIFF
--- a/Example/ManifoldDemo/DemoContentView.swift
+++ b/Example/ManifoldDemo/DemoContentView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import SwiftData
 import ManifoldPersistenceSwiftData
 import ManifoldInference
+import ManifoldRuntime
 import ManifoldUI
 import ManifoldUIModelManagement
 import ManifoldVoice
@@ -20,6 +21,7 @@ struct DemoContentView: View {
     @State private var isModelManagementPresented = false
     @State private var isToolPolicyPresented = false
     @State private var isConnectedServicesPresented = false
+    @State private var isDocumentLibraryPresented = false
     // ManifoldVoice's AppleSpeechTranscriber drives AVAudioEngine, which raises
     // on iOS Simulator launch (no audio input device). Mount the controller
     // and the composer accessory only on real hardware.
@@ -37,6 +39,11 @@ struct DemoContentView: View {
     /// here (rather than re-resolved per-scenario) so `--uitesting` runs use
     /// a stable temp directory the test harness can inspect.
     let sandboxRoot: URL
+
+    /// The RAG knowledge-base service. Forwarded into ``DocumentLibrarySheet``
+    /// when the user opens the sidebar's "Knowledge Base" entry. `nil` when
+    /// the demo bootstraps without ``RAGConfiguration``.
+    let ragService: RAGService?
 
     /// Buffer holding any ``InboundPayload`` that arrived during the
     /// cold-launch window, before the runtime finished bootstrapping.
@@ -105,6 +112,16 @@ struct DemoContentView: View {
             ConnectedServicesView(
                 toolRegistry: toolRegistry,
                 isFoundationModelsActive: { viewModel.activeBackendName == "Apple" }
+            )
+        }
+        .sheet(isPresented: $isDocumentLibraryPresented) {
+            // The demo wires `RAGConfiguration()` (no embedding backend) so
+            // retrieval falls back to keyword search — `hasEmbeddingBackend`
+            // is `false` and the sheet renders the "Using keyword fallback"
+            // banner.
+            DocumentLibrarySheet(
+                ragService: ragService,
+                hasEmbeddingBackend: false
             )
         }
         .sheet(isPresented: approvalSheetIsPresented) {
@@ -314,6 +331,21 @@ struct DemoContentView: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityIdentifier("sidebar-connected-services-button")
+
+                Button {
+                    isDocumentLibraryPresented = true
+                } label: {
+                    HStack {
+                        Label("Knowledge Base", systemImage: "books.vertical")
+                            .font(.caption)
+                        Spacer()
+                        Text("Manage")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("sidebar-knowledge-base-button")
             }
             .padding()
         }

--- a/Example/ManifoldDemo/ManifoldDemoApp.swift
+++ b/Example/ManifoldDemo/ManifoldDemoApp.swift
@@ -214,6 +214,7 @@ struct ManifoldDemoApp: App {
                     DemoContentView(
                         toolRegistry: toolRegistry,
                         sandboxRoot: sandboxRoot,
+                        ragService: runtime.ragService,
                         pendingPayloadBuffer: pendingPayloadBuffer,
                         pendingDemoScenarioID: pendingDemoScenarioID
                     )
@@ -350,8 +351,14 @@ struct ManifoldDemoApp: App {
 
     @MainActor
     private func installRuntime(using container: ModelContainer) {
+        // Pass an unconfigured `RAGConfiguration()` so the demo exercises the
+        // keyword-fallback retrieval path even without a configured embedding
+        // model. Hosts that want semantic search supply an `EmbeddingBackend`
+        // here; without one, retrieval still runs on case-insensitive keyword
+        // search via `FlatFileVectorStore.keywordSearch(query:limit:)`.
         let runtime = try! ManifoldBootstrap(
             configuration: runtimeConfiguration,
+            ragConfiguration: RAGConfiguration(),
             inferenceService: inferenceService,
             makeModelContainer: { container }
         )

--- a/Sources/ManifoldInference/Models/Citation.swift
+++ b/Sources/ManifoldInference/Models/Citation.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Provenance for a single retrieved chunk surfaced as part of a RAG-augmented
+/// assistant turn.
+///
+/// One ``Citation`` is produced per ``VectorSearchHit`` returned by
+/// ``VectorStore/search(embedding:limit:)`` /
+/// ``VectorStore/keywordSearch(query:limit:)``. ``ConversationRuntime`` attaches
+/// the citation list to the assistant ``ChatMessageRecord`` it produces so the
+/// UI can render a "Sources" disclosure beneath the bubble.
+///
+/// The struct is intentionally minimal: ``documentTitle`` + ``chunkIndex``
+/// uniquely identify the source passage, ``snippet`` is a truncated preview for
+/// the UI, and ``score`` is the relevance score (cosine similarity for semantic
+/// hits, 1.0 for keyword hits) so adopters can filter or sort if they want.
+public struct Citation: Sendable, Hashable, Codable {
+    /// UUID of the parent ``DocumentRecord``.
+    public let documentID: UUID
+    /// Human-readable source label (typically the document file name).
+    public let documentTitle: String
+    /// Zero-based chunk index within the parent document.
+    public let chunkIndex: Int
+    /// Truncated preview of the chunk text. Capped at ``snippetCharacterLimit``
+    /// to keep persisted/wire payloads bounded.
+    public let snippet: String
+    /// Relevance score in `[0, 1]`. Cosine similarity for semantic search,
+    /// `1.0` for keyword hits.
+    public let score: Float
+
+    /// Maximum characters retained in ``snippet``. Anything longer is
+    /// truncated with an ellipsis when constructed via
+    /// ``init(documentID:documentTitle:chunkIndex:fullText:score:)``.
+    public static let snippetCharacterLimit = 240
+
+    public init(
+        documentID: UUID,
+        documentTitle: String,
+        chunkIndex: Int,
+        snippet: String,
+        score: Float
+    ) {
+        self.documentID = documentID
+        self.documentTitle = documentTitle
+        self.chunkIndex = chunkIndex
+        self.snippet = snippet
+        self.score = score
+    }
+
+    /// Convenience initialiser that truncates `fullText` to
+    /// ``snippetCharacterLimit`` characters with an ellipsis when needed.
+    public init(
+        documentID: UUID,
+        documentTitle: String,
+        chunkIndex: Int,
+        fullText: String,
+        score: Float
+    ) {
+        let trimmed = fullText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let snippet: String
+        if trimmed.count <= Self.snippetCharacterLimit {
+            snippet = trimmed
+        } else {
+            let endIndex = trimmed.index(trimmed.startIndex, offsetBy: Self.snippetCharacterLimit)
+            snippet = String(trimmed[..<endIndex]) + "…"
+        }
+        self.init(
+            documentID: documentID,
+            documentTitle: documentTitle,
+            chunkIndex: chunkIndex,
+            snippet: snippet,
+            score: score
+        )
+    }
+}

--- a/Sources/ManifoldInference/Models/ConversationRecords.swift
+++ b/Sources/ManifoldInference/Models/ConversationRecords.swift
@@ -61,6 +61,19 @@ public struct ChatMessageRecord: Identifiable, Hashable, Sendable {
     public var sessionID: UUID
     public var promptTokens: Int?
     public var completionTokens: Int?
+    /// Provenance of any RAG passages injected into the prompt for this turn.
+    ///
+    /// Populated by ``ConversationRuntime`` from
+    /// ``RAGService/retrieve(query:limit:)`` before generation; consumed by
+    /// ``MessageBubbleView`` to render a collapsed "Sources" disclosure beneath
+    /// the assistant bubble. `nil` when the turn was not RAG-augmented; an
+    /// empty array signals "RAG ran but no passages scored above zero".
+    ///
+    /// > Note: Phase 2 keeps citations transient — they live on the in-memory
+    /// > record but are NOT persisted across app launches. Cross-session
+    /// > persistence is a deliberate Phase-3 follow-up so we don't have to
+    /// > bump the SwiftData schema.
+    public var citations: [Citation]?
 
     /// Concatenated text parts for backward compatibility.
     ///
@@ -84,7 +97,8 @@ public struct ChatMessageRecord: Identifiable, Hashable, Sendable {
         timestamp: Date = Date(),
         sessionID: UUID,
         promptTokens: Int? = nil,
-        completionTokens: Int? = nil
+        completionTokens: Int? = nil,
+        citations: [Citation]? = nil
     ) {
         self.id = id
         self.role = role
@@ -93,6 +107,7 @@ public struct ChatMessageRecord: Identifiable, Hashable, Sendable {
         self.sessionID = sessionID
         self.promptTokens = promptTokens
         self.completionTokens = completionTokens
+        self.citations = citations
     }
 
     /// Creates a record from structured content parts.
@@ -103,7 +118,8 @@ public struct ChatMessageRecord: Identifiable, Hashable, Sendable {
         timestamp: Date = Date(),
         sessionID: UUID,
         promptTokens: Int? = nil,
-        completionTokens: Int? = nil
+        completionTokens: Int? = nil,
+        citations: [Citation]? = nil
     ) {
         self.id = id
         self.role = role
@@ -112,6 +128,7 @@ public struct ChatMessageRecord: Identifiable, Hashable, Sendable {
         self.sessionID = sessionID
         self.promptTokens = promptTokens
         self.completionTokens = completionTokens
+        self.citations = citations
     }
 }
 

--- a/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
@@ -384,10 +384,12 @@ struct ConversationTurnExecutor: Sendable {
             slots = []
         }
 
+        var ragCitations: [Citation] = []
         if let ragService, let userPrompt {
             do {
-                let ragSlots = try await ragService.retrieveSlots(query: userPrompt)
-                slots.append(contentsOf: ragSlots)
+                let result = try await ragService.retrieve(query: userPrompt)
+                slots.append(contentsOf: result.slots)
+                ragCitations = result.citations
             } catch {
                 Log.inference.warning("ConversationRuntime: RAG retrieval failed, continuing without retrieved context: \(error.localizedDescription)")
             }
@@ -397,10 +399,16 @@ struct ConversationTurnExecutor: Sendable {
 
         // Build the assistant message slot up front so token deltas can
         // reference its id from the first emitted token.
+        //
+        // Citations carry the provenance of any retrieved passages so the UI
+        // can render a "Sources" disclosure beneath the assistant bubble.
+        // `nil` when RAG didn't run for this turn (no service, no user
+        // prompt, or retrieval threw).
         var assistantMessage = ChatMessageRecord(
             role: .assistant,
             content: "",
-            sessionID: sessionID
+            sessionID: sessionID,
+            citations: ragCitations.isEmpty ? nil : ragCitations
         )
         let assistantID = assistantMessage.id
 

--- a/Sources/ManifoldRuntime/Services/RAGService.swift
+++ b/Sources/ManifoldRuntime/Services/RAGService.swift
@@ -93,13 +93,34 @@ public actor RAGService {
 
     // MARK: - Retrieval
 
-    /// Returns a ``PromptSlot`` containing the top relevant passages for `query`,
-    /// or an empty array when no passages score above zero.
+    /// The combined output of a single retrieval call: the prompt slot to inject
+    /// into context, plus the per-hit ``Citation`` provenance to surface in the
+    /// UI.
     ///
-    /// Called by ``ConversationRuntime`` before each generation turn.
-    public func retrieveSlots(query: String, limit: Int = 5) async throws -> [PromptSlot] {
+    /// ``slots`` and ``citations`` are produced from the same underlying
+    /// ``VectorSearchHit`` array, so a non-empty `slots` always implies a
+    /// non-empty `citations` (one citation per hit, in the same order).
+    public struct RetrievalResult: Sendable {
+        public let slots: [PromptSlot]
+        public let citations: [Citation]
+
+        public init(slots: [PromptSlot], citations: [Citation]) {
+            self.slots = slots
+            self.citations = citations
+        }
+
+        public static let empty = RetrievalResult(slots: [], citations: [])
+    }
+
+    /// Returns the prompt slot AND citation list for the top `limit` passages
+    /// matching `query`.
+    ///
+    /// Called by ``ConversationRuntime`` before each generation turn. Empty
+    /// results (whitespace-only query, no above-zero scores) round-trip as
+    /// ``RetrievalResult/empty``.
+    public func retrieve(query: String, limit: Int = 5) async throws -> RetrievalResult {
         guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return []
+            return .empty
         }
 
         let hits: [VectorSearchHit]
@@ -115,19 +136,40 @@ public actor RAGService {
             hits = try await vectorStore.keywordSearch(query: query, limit: limit)
         }
 
-        guard !hits.isEmpty else { return [] }
+        guard !hits.isEmpty else { return .empty }
 
         let content = hits.map { hit in
             "[\(hit.documentTitle)]\n\(hit.chunk.text)"
         }.joined(separator: "\n\n---\n\n")
 
-        return [PromptSlot(
+        let slot = PromptSlot(
             id: "rag-retrieval",
             content: content,
             position: .contextSetup,
             role: .retrieval,
             label: "Retrieved Documents"
-        )]
+        )
+
+        let citations = hits.map { hit in
+            Citation(
+                documentID: hit.chunk.documentID,
+                documentTitle: hit.documentTitle,
+                chunkIndex: hit.chunk.chunkIndex,
+                fullText: hit.chunk.text,
+                score: hit.score
+            )
+        }
+
+        return RetrievalResult(slots: [slot], citations: citations)
+    }
+
+    /// Returns a ``PromptSlot`` containing the top relevant passages for `query`,
+    /// or an empty array when no passages score above zero.
+    ///
+    /// Compatibility shim retained for callers that don't need the citation
+    /// metadata — internally just calls ``retrieve(query:limit:)``.
+    public func retrieveSlots(query: String, limit: Int = 5) async throws -> [PromptSlot] {
+        try await retrieve(query: query, limit: limit).slots
     }
 }
 

--- a/Sources/ManifoldUI/Views/Chat/CitationsView.swift
+++ b/Sources/ManifoldUI/Views/Chat/CitationsView.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+import ManifoldInference
+
+/// Renders the "Sources" disclosure shown beneath a RAG-augmented assistant
+/// message bubble.
+///
+/// Collapsed by default — the disclosure label shows the source count and
+/// expands into a vertical stack of per-citation rows. Each row prints the
+/// document title, chunk index, score, and a truncated snippet of the
+/// retrieved passage. Designed to mirror the existing
+/// ``ThinkingBlockView`` idiom (collapsed-by-default `DisclosureGroup` with
+/// caption typography) so adopters get a familiar feel without learning a
+/// new control.
+public struct CitationsView: View {
+
+    public let citations: [Citation]
+    @State private var isExpanded: Bool = false
+
+    public init(citations: [Citation]) {
+        self.citations = citations
+    }
+
+    public var body: some View {
+        if citations.isEmpty {
+            EmptyView()
+        } else {
+            DisclosureGroup(isExpanded: $isExpanded) {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(Array(citations.enumerated()), id: \.offset) { index, citation in
+                        CitationRow(index: index + 1, citation: citation)
+                    }
+                }
+                .padding(.top, 6)
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "doc.text.magnifyingglass")
+                        .font(.caption)
+                    Text("\(citations.count) source\(citations.count == 1 ? "" : "s")")
+                        .font(.caption.weight(.medium))
+                }
+                .foregroundStyle(.secondary)
+            }
+            .accessibilityIdentifier("assistant-citations-disclosure")
+        }
+    }
+}
+
+// MARK: - CitationRow
+
+private struct CitationRow: View {
+    let index: Int
+    let citation: Citation
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Text("[\(index)]")
+                    .font(.caption2.weight(.semibold).monospaced())
+                    .foregroundStyle(.tint)
+                Text(citation.documentTitle)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+                Text("· chunk \(citation.chunkIndex)")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 0)
+                if citation.score > 0 {
+                    Text(scoreLabel)
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(.tertiary)
+                        .accessibilityLabel("Relevance score \(scoreLabel)")
+                }
+            }
+            Text(citation.snippet)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(4)
+                .textSelection(.enabled)
+        }
+        .padding(8)
+        .background(.fill.quinary, in: RoundedRectangle(cornerRadius: 6))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Source \(index): \(citation.documentTitle), chunk \(citation.chunkIndex). \(citation.snippet)")
+    }
+
+    private var scoreLabel: String {
+        String(format: "%.2f", citation.score)
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Three sources") {
+    CitationsView(citations: [
+        Citation(
+            documentID: UUID(),
+            documentTitle: "Whitepaper.pdf",
+            chunkIndex: 2,
+            snippet: "The retrieval-augmented generation pattern combines a vector search index with an autoregressive language model so that answers can cite specific sources rather than relying solely on parameterized memory.",
+            score: 0.91
+        ),
+        Citation(
+            documentID: UUID(),
+            documentTitle: "design-notes.txt",
+            chunkIndex: 0,
+            snippet: "FlatFileVectorStore is correct up to ~50k chunks; sqlite-vec ANN comes in Phase 3.",
+            score: 0.78
+        ),
+        Citation(
+            documentID: UUID(),
+            documentTitle: "release-notes.md",
+            chunkIndex: 4,
+            snippet: "Phase 2 adds the document library UI, source citations, and demo wiring.",
+            score: 0.66
+        ),
+    ])
+    .padding()
+}
+
+#Preview("Empty (renders nothing)") {
+    CitationsView(citations: [])
+        .padding()
+}

--- a/Sources/ManifoldUI/Views/Chat/MessageBubbleView.swift
+++ b/Sources/ManifoldUI/Views/Chat/MessageBubbleView.swift
@@ -107,6 +107,14 @@ public struct MessageBubbleView: View {
                 streamingIndicator
             }
 
+            // Show citations only after streaming finishes so the disclosure
+            // doesn't pop in/out while the bubble is still filling. Empty
+            // citation arrays render an EmptyView via CitationsView.
+            if !isStreaming, let citations = message.citations, !citations.isEmpty {
+                CitationsView(citations: citations)
+                    .padding(.top, 2)
+            }
+
             if !isStreaming || message.hasVisibleContent {
                 HStack(spacing: 6) {
                     timestampLabel

--- a/Sources/ManifoldUIModelManagement/ViewModels/DocumentLibraryViewModel.swift
+++ b/Sources/ManifoldUIModelManagement/ViewModels/DocumentLibraryViewModel.swift
@@ -66,8 +66,8 @@ public final class DocumentLibraryViewModel {
         await withTaskGroup(of: Void.self) { group in
             for url in urls {
                 ingestingURLs.insert(url)
-                group.addTask { [weak self] in
-                    await self?.ingestOne(url: url, service: ragService)
+                group.addTask {
+                    await self.ingestOne(url: url, service: ragService)
                 }
             }
             await group.waitForAll()

--- a/Sources/ManifoldUIModelManagement/ViewModels/DocumentLibraryViewModel.swift
+++ b/Sources/ManifoldUIModelManagement/ViewModels/DocumentLibraryViewModel.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Observation
+import ManifoldRuntime
+import ManifoldInference
+
+/// View model for ``DocumentLibraryView``.
+///
+/// Owns the on-screen ``DocumentRecord`` list, drives ingestion through the
+/// shared ``RAGService`` actor, and tracks per-URL ingest progress so the UI
+/// can surface a per-file spinner. Stateless when ``ragService`` is `nil` —
+/// the view shows an "RAG disabled" placeholder in that case.
+@Observable
+@MainActor
+public final class DocumentLibraryViewModel {
+
+    /// Hands-off ingestion + retrieval surface. `nil` when the host
+    /// bootstrapped without ``RAGConfiguration``.
+    public let ragService: RAGService?
+
+    /// `true` when the active retrieval path uses an embedding backend.
+    /// Drives the "Using keyword fallback" banner in the view — keyword
+    /// fallback works but isn't obvious to users without this signal.
+    public let hasEmbeddingBackend: Bool
+
+    /// Current list of ingested documents, sorted newest-first.
+    public private(set) var documents: [DocumentRecord] = []
+
+    /// `true` while ``refresh()`` is fetching the document list.
+    public private(set) var isLoading: Bool = false
+
+    /// File URLs currently being ingested. Drives per-row spinners.
+    public private(set) var ingestingURLs: Set<URL> = []
+
+    /// Last user-facing error from ingest or delete. Cleared when set to `nil`.
+    public var errorMessage: String?
+
+    public init(ragService: RAGService?, hasEmbeddingBackend: Bool = false) {
+        self.ragService = ragService
+        self.hasEmbeddingBackend = hasEmbeddingBackend
+    }
+
+    // MARK: - Refresh
+
+    /// Reloads ``documents`` from the service. Called on view appear.
+    public func refresh() async {
+        guard let ragService else { return }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            let records = try await ragService.fetchDocuments()
+            // Newest-first: matches the model-management list idiom.
+            documents = records.sorted(by: { $0.indexedAt > $1.indexedAt })
+        } catch {
+            Log.persistence.warning("DocumentLibraryViewModel: refresh failed: \(error.localizedDescription)")
+            errorMessage = "Failed to load documents: \(error.localizedDescription)"
+        }
+    }
+
+    // MARK: - Ingest
+
+    /// Ingests a list of file URLs concurrently. Each URL drives its own
+    /// progress entry in ``ingestingURLs`` and refreshes the list once it
+    /// completes — successful adds appear in real time as parsing finishes.
+    public func ingest(urls: [URL]) async {
+        guard let ragService else { return }
+        await withTaskGroup(of: Void.self) { group in
+            for url in urls {
+                ingestingURLs.insert(url)
+                group.addTask { [weak self] in
+                    await self?.ingestOne(url: url, service: ragService)
+                }
+            }
+            await group.waitForAll()
+        }
+        await refresh()
+    }
+
+    private func ingestOne(url: URL, service: RAGService) async {
+        defer { ingestingURLs.remove(url) }
+        // Some macOS file pickers and drag drops hand back security-scoped
+        // URLs. Start/stop accessing brackets the read so sandboxed builds
+        // don't read-deny on the parser hop. No-op on iOS-bundled URLs.
+        let scopeOK = url.startAccessingSecurityScopedResource()
+        defer { if scopeOK { url.stopAccessingSecurityScopedResource() } }
+
+        do {
+            _ = try await service.ingest(url: url)
+        } catch {
+            Log.inference.warning("DocumentLibraryViewModel: ingest failed for \(url.lastPathComponent): \(error.localizedDescription)")
+            errorMessage = "Failed to ingest \(url.lastPathComponent): \(error.localizedDescription)"
+        }
+    }
+
+    // MARK: - Delete
+
+    public func delete(_ document: DocumentRecord) async {
+        guard let ragService else { return }
+        do {
+            try await ragService.deleteDocument(id: document.id)
+            documents.removeAll { $0.id == document.id }
+        } catch {
+            Log.persistence.warning("DocumentLibraryViewModel: delete failed for \(document.title): \(error.localizedDescription)")
+            errorMessage = "Failed to delete \(document.title): \(error.localizedDescription)"
+        }
+    }
+}

--- a/Sources/ManifoldUIModelManagement/Views/Documents/DocumentLibrarySheet.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Documents/DocumentLibrarySheet.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+import ManifoldRuntime
+import ManifoldInference
+
+/// Modal sheet wrapper for ``DocumentLibraryView``.
+///
+/// Provides the chrome the bare ``DocumentLibraryView`` doesn't carry —
+/// `NavigationStack`, "Done" toolbar item, and platform-appropriate sizing —
+/// so a host app can present it with a one-line `.sheet { }` modifier.
+public struct DocumentLibrarySheet: View {
+
+    @Environment(\.dismiss) private var dismiss
+
+    private let viewModel: DocumentLibraryViewModel
+
+    public init(viewModel: DocumentLibraryViewModel) {
+        self.viewModel = viewModel
+    }
+
+    /// Convenience overload that builds the view model from a ``RAGService``
+    /// reference. `hasEmbeddingBackend` defaults to `false` because the
+    /// service exposes no public read for its embedding backend — the host
+    /// supplies this signal so the keyword-fallback banner stays accurate.
+    public init(ragService: RAGService?, hasEmbeddingBackend: Bool = false) {
+        self.viewModel = DocumentLibraryViewModel(
+            ragService: ragService,
+            hasEmbeddingBackend: hasEmbeddingBackend
+        )
+    }
+
+    public var body: some View {
+        NavigationStack {
+            DocumentLibraryView(viewModel: viewModel)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Done") { dismiss() }
+                    }
+                }
+        }
+        #if os(macOS)
+        .frame(minWidth: 560, idealWidth: 720, minHeight: 480, idealHeight: 640)
+        #endif
+    }
+}

--- a/Sources/ManifoldUIModelManagement/Views/Documents/DocumentLibraryView.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Documents/DocumentLibraryView.swift
@@ -1,0 +1,329 @@
+import SwiftUI
+import UniformTypeIdentifiers
+import ManifoldRuntime
+import ManifoldInference
+
+/// Lists ingested RAG documents and lets the user add or remove them.
+///
+/// Reuses the host's ``RAGService`` actor (typically obtained from
+/// ``ManifoldBootstrap/ragService``). Designed to live alongside the model
+/// management UI — host apps can present it as a sheet from a sidebar
+/// "Knowledge Base" button, or embed it in a settings tab.
+///
+/// Add flow: file picker (``allowedContentTypes`` is ``txt`` + ``pdf`` to
+/// match the shipped ``DocumentParser`` set) and, on macOS, drag-and-drop
+/// from Finder. Each ingest runs concurrently and surfaces a per-row spinner
+/// while the parser + chunker run.
+public struct DocumentLibraryView: View {
+
+    @State private var viewModel: DocumentLibraryViewModel
+    @State private var showImporter: Bool = false
+    @State private var pendingDelete: DocumentRecord?
+    @State private var isDropTargeted: Bool = false
+
+    /// Document file types accepted by the importer. Mirrors the `parsers:`
+    /// list passed to ``RAGService`` in ``ManifoldBootstrap`` — keep in sync
+    /// when adding a new ``DocumentParser``.
+    private static let allowedContentTypes: [UTType] = [.plainText, .pdf]
+
+    public init(viewModel: DocumentLibraryViewModel) {
+        _viewModel = State(initialValue: viewModel)
+    }
+
+    public var body: some View {
+        Group {
+            if viewModel.ragService == nil {
+                disabledStateView
+            } else {
+                contentList
+            }
+        }
+        .navigationTitle("Knowledge Base")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    showImporter = true
+                } label: {
+                    Label("Add Document", systemImage: "plus")
+                }
+                .disabled(viewModel.ragService == nil)
+                .accessibilityIdentifier("document-library-add-button")
+            }
+        }
+        .fileImporter(
+            isPresented: $showImporter,
+            allowedContentTypes: Self.allowedContentTypes,
+            allowsMultipleSelection: true
+        ) { result in
+            handleImport(result)
+        }
+        .alert(
+            "Delete Document",
+            isPresented: Binding(
+                get: { pendingDelete != nil },
+                set: { if !$0 { pendingDelete = nil } }
+            ),
+            presenting: pendingDelete
+        ) { document in
+            Button("Delete", role: .destructive) {
+                Task { await viewModel.delete(document) }
+                pendingDelete = nil
+            }
+            Button("Cancel", role: .cancel) {
+                pendingDelete = nil
+            }
+        } message: { document in
+            Text("Remove \"\(document.title)\" from the knowledge base? Its chunks will be deleted from the vector index.")
+        }
+        .alert(
+            "Document Library",
+            isPresented: Binding(
+                get: { viewModel.errorMessage != nil },
+                set: { if !$0 { viewModel.errorMessage = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) {
+                viewModel.errorMessage = nil
+            }
+        } message: {
+            Text(viewModel.errorMessage ?? "")
+        }
+        .task {
+            await viewModel.refresh()
+        }
+        #if os(macOS)
+        .onDrop(of: [.fileURL], isTargeted: $isDropTargeted) { providers in
+            handleDrop(providers: providers)
+        }
+        #endif
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var contentList: some View {
+        List {
+            if !viewModel.hasEmbeddingBackend {
+                Section {
+                    Label {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Using keyword fallback")
+                                .font(.subheadline.weight(.semibold))
+                            Text("RAG retrieval is running on case-insensitive keyword search. Configure an embedding model for semantic search.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    } icon: {
+                        Image(systemName: "info.circle")
+                            .foregroundStyle(.orange)
+                    }
+                    .accessibilityIdentifier("document-library-keyword-banner")
+                }
+            }
+
+            Section {
+                if viewModel.documents.isEmpty && viewModel.ingestingURLs.isEmpty {
+                    emptyStateRow
+                } else {
+                    ForEach(viewModel.documents) { document in
+                        DocumentRow(
+                            document: document,
+                            onDelete: { pendingDelete = document }
+                        )
+                    }
+
+                    ForEach(Array(viewModel.ingestingURLs), id: \.self) { url in
+                        IngestProgressRow(url: url)
+                    }
+                }
+            } header: {
+                if !viewModel.documents.isEmpty || !viewModel.ingestingURLs.isEmpty {
+                    Text("Documents")
+                }
+            } footer: {
+                Text("Add .txt or .pdf files. RAG runs automatically on each turn — retrieved passages appear as a \"Sources\" disclosure beneath the assistant's reply.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        #if os(iOS)
+        .listStyle(.insetGrouped)
+        #endif
+        .overlay {
+            if viewModel.isLoading && viewModel.documents.isEmpty {
+                ProgressView()
+            }
+        }
+        #if os(macOS)
+        .overlay {
+            if isDropTargeted {
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(Color.accentColor, lineWidth: 3)
+                    .padding(8)
+                    .allowsHitTesting(false)
+            }
+        }
+        #endif
+    }
+
+    private var emptyStateRow: some View {
+        VStack(alignment: .center, spacing: 12) {
+            Image(systemName: "doc.text.magnifyingglass")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+            Text("No documents yet")
+                .font(.headline)
+            Text("Add .txt or .pdf files to power retrieval-augmented chat.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 24)
+        .accessibilityIdentifier("document-library-empty-state")
+    }
+
+    private var disabledStateView: some View {
+        VStack(alignment: .center, spacing: 12) {
+            Image(systemName: "books.vertical")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+            Text("Knowledge Base Disabled")
+                .font(.headline)
+            Text("This app was bootstrapped without RAGConfiguration. Pass `ragConfiguration:` to ManifoldBootstrap to enable on-device retrieval.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 360)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+
+    // MARK: - Import handlers
+
+    private func handleImport(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            guard !urls.isEmpty else { return }
+            Task { await viewModel.ingest(urls: urls) }
+        case .failure(let error):
+            viewModel.errorMessage = error.localizedDescription
+        }
+    }
+
+    #if os(macOS)
+    private func handleDrop(providers: [NSItemProvider]) -> Bool {
+        var collected: [URL] = []
+        let group = DispatchGroup()
+        for provider in providers {
+            group.enter()
+            _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                if let url, Self.allowedContentTypes.contains(where: { url.pathExtension.lowercased() == $0.preferredFilenameExtension }) {
+                    collected.append(url)
+                }
+                group.leave()
+            }
+        }
+        group.notify(queue: .main) {
+            guard !collected.isEmpty else { return }
+            Task { await viewModel.ingest(urls: collected) }
+        }
+        return true
+    }
+    #endif
+}
+
+// MARK: - DocumentRow
+
+private struct DocumentRow: View {
+    let document: DocumentRecord
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 10) {
+            Image(systemName: iconName)
+                .font(.title3)
+                .foregroundStyle(.tint)
+                .frame(width: 28)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(document.title)
+                    .font(.body)
+                    .lineLimit(2)
+                HStack(spacing: 6) {
+                    Text(document.fileType.uppercased())
+                        .font(.caption2.weight(.semibold))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.fill.tertiary, in: Capsule())
+                    Text("\(document.chunkCount) chunk\(document.chunkCount == 1 ? "" : "s")")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(document.indexedAt, style: .date)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+
+            Button(role: .destructive, action: onDelete) {
+                Image(systemName: "trash")
+                    .foregroundStyle(.red)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Delete \(document.title)")
+        }
+        .padding(.vertical, 2)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(document.title), \(document.fileType.uppercased()), \(document.chunkCount) chunks")
+    }
+
+    private var iconName: String {
+        switch document.fileType.lowercased() {
+        case "pdf": return "doc.richtext"
+        case "txt": return "doc.text"
+        default: return "doc"
+        }
+    }
+}
+
+// MARK: - IngestProgressRow
+
+private struct IngestProgressRow: View {
+    let url: URL
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 10) {
+            ProgressView()
+                .controlSize(.small)
+                .frame(width: 28)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(url.lastPathComponent)
+                    .font(.body)
+                    .lineLimit(1)
+                Text("Parsing & indexing…")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(.vertical, 2)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Ingesting \(url.lastPathComponent)")
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Empty") {
+    NavigationStack {
+        DocumentLibraryView(
+            viewModel: DocumentLibraryViewModel(ragService: nil)
+        )
+    }
+}

--- a/Sources/ManifoldUIModelManagement/Views/Documents/DocumentLibraryView.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Documents/DocumentLibraryView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UniformTypeIdentifiers
+import os
 import ManifoldRuntime
 import ManifoldInference
 
@@ -24,7 +25,7 @@ public struct DocumentLibraryView: View {
     /// Document file types accepted by the importer. Mirrors the `parsers:`
     /// list passed to ``RAGService`` in ``ManifoldBootstrap`` — keep in sync
     /// when adding a new ``DocumentParser``.
-    private static let allowedContentTypes: [UTType] = [.plainText, .pdf]
+    nonisolated private static let allowedContentTypes: [UTType] = [.plainText, .pdf]
 
     public init(viewModel: DocumentLibraryViewModel) {
         _viewModel = State(initialValue: viewModel)
@@ -217,20 +218,21 @@ public struct DocumentLibraryView: View {
 
     #if os(macOS)
     private func handleDrop(providers: [NSItemProvider]) -> Bool {
-        var collected: [URL] = []
+        let collectedLock = OSAllocatedUnfairLock(initialState: [URL]())
         let group = DispatchGroup()
         for provider in providers {
             group.enter()
             _ = provider.loadObject(ofClass: URL.self) { url, _ in
                 if let url, Self.allowedContentTypes.contains(where: { url.pathExtension.lowercased() == $0.preferredFilenameExtension }) {
-                    collected.append(url)
+                    collectedLock.withLock { $0.append(url) }
                 }
                 group.leave()
             }
         }
         group.notify(queue: .main) {
-            guard !collected.isEmpty else { return }
-            Task { await viewModel.ingest(urls: collected) }
+            let urls = collectedLock.withLock { $0 }
+            guard !urls.isEmpty else { return }
+            Task { await viewModel.ingest(urls: urls) }
         }
         return true
     }

--- a/Tests/ManifoldRuntimeTests/ConversationRuntimeTests.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationRuntimeTests.swift
@@ -334,6 +334,105 @@ final class ConversationRuntimeTests: XCTestCase {
 
     enum TestError: Error { case deadlineElapsed }
 
+    // MARK: - RAG citations
+
+    /// In-memory RAG-adjacent fakes mirroring the shapes from `RAGServiceTests`,
+    /// re-stated here so this file stays independent of that fixture set.
+    @MainActor
+    final class CitationDocumentStore: DocumentStore {
+        var inserted: [DocumentRecord] = []
+        func insertDocument(_ record: DocumentRecord) async throws { inserted.append(record) }
+        func fetchDocuments() async throws -> [DocumentRecord] { inserted }
+        func fetchDocument(id: UUID) async throws -> DocumentRecord? { inserted.first { $0.id == id } }
+        func deleteDocument(id: UUID) async throws { inserted.removeAll { $0.id == id } }
+    }
+
+    actor CitationVectorStore: VectorStore {
+        var keywordHits: [VectorSearchHit] = []
+        func setKeywordHits(_ hits: [VectorSearchHit]) { keywordHits = hits }
+        func insert(chunks: [DocumentChunk], documentTitle: String, embeddings: [[Float]]) throws {}
+        func search(embedding: [Float], limit: Int) throws -> [VectorSearchHit] { [] }
+        func keywordSearch(query: String, limit: Int) throws -> [VectorSearchHit] { keywordHits }
+        func delete(documentID: UUID) throws {}
+        func deleteAll() throws {}
+    }
+
+    func test_send_withRagService_attachesCitationsToAssistantMessage() async throws {
+        // Pre-seed the vector store with a keyword hit so RAGService.retrieve()
+        // returns one slot + one citation for any non-empty query.
+        let vectorStore = CitationVectorStore()
+        let docID = UUID()
+        let hit = VectorSearchHit(
+            chunk: DocumentChunk(documentID: docID, text: "ManifoldKit is a SwiftUI chat framework.", chunkIndex: 0),
+            documentTitle: "Overview.txt",
+            score: 1.0
+        )
+        await vectorStore.setKeywordHits([hit])
+        let ragService = RAGService(documentStore: CitationDocumentStore(), vectorStore: vectorStore)
+
+        let mock = MockInferenceBackend()
+        mock.tokensToYield = ["ok"]
+        let backend = mock
+        backend.isModelLoaded = true
+        let inference = InferenceService(backend: backend, name: "Mock")
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            sessionStore: nil,
+            inferenceService: inference,
+            ragService: ragService
+        )
+
+        let sessionID = UUID()
+        _ = try await runtime.send(SendInput(sessionID: sessionID, userText: "What is ManifoldKit?"))
+        _ = try await collectEvents(from: runtime) { event in
+            if case .afterGeneration = event { return true }
+            return false
+        }
+
+        let stored = Array(store.messages.values).sorted { $0.timestamp < $1.timestamp }
+        let assistant = stored.first(where: { $0.role == .assistant })
+        XCTAssertNotNil(assistant, "Assistant message persisted")
+        let citations = assistant?.citations ?? []
+        XCTAssertEqual(citations.count, 1, "One citation per retrieval hit")
+        XCTAssertEqual(citations.first?.documentID, docID)
+        XCTAssertEqual(citations.first?.documentTitle, "Overview.txt")
+        XCTAssertEqual(citations.first?.chunkIndex, 0)
+    }
+
+    func test_send_withRagService_noHits_assistantMessageHasNilCitations() async throws {
+        // Empty keyword hits → no citations attached. Assistant.citations stays nil
+        // so the bubble doesn't render an empty "Sources" disclosure.
+        let vectorStore = CitationVectorStore()
+        await vectorStore.setKeywordHits([])
+        let ragService = RAGService(documentStore: CitationDocumentStore(), vectorStore: vectorStore)
+
+        let mock = MockInferenceBackend()
+        mock.tokensToYield = ["fine"]
+        let backend = mock
+        backend.isModelLoaded = true
+        let inference = InferenceService(backend: backend, name: "Mock")
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            sessionStore: nil,
+            inferenceService: inference,
+            ragService: ragService
+        )
+
+        let sessionID = UUID()
+        _ = try await runtime.send(SendInput(sessionID: sessionID, userText: "anything"))
+        _ = try await collectEvents(from: runtime) { event in
+            if case .afterGeneration = event { return true }
+            return false
+        }
+
+        let stored = Array(store.messages.values).sorted { $0.timestamp < $1.timestamp }
+        let assistant = stored.first(where: { $0.role == .assistant })
+        XCTAssertNotNil(assistant)
+        XCTAssertNil(assistant?.citations, "No retrieval hits → citations stays nil")
+    }
+
     // MARK: - Send happy path
 
     func test_send_happyPath_persistsBothMessagesAndStreamsTokens() async throws {

--- a/Tests/ManifoldRuntimeTests/RAGServiceTests.swift
+++ b/Tests/ManifoldRuntimeTests/RAGServiceTests.swift
@@ -163,6 +163,76 @@ final class RAGServiceTests: XCTestCase {
         XCTAssertTrue(slots.isEmpty)
     }
 
+    // MARK: - retrieve(query:) — citations
+
+    func testRetrieveReturnsCitationsForEachHit() async throws {
+        let vectorStore = FakeVectorStore()
+        let docID = UUID()
+        let hits = [
+            VectorSearchHit(
+                chunk: DocumentChunk(documentID: docID, text: "First passage about widgets.", chunkIndex: 0),
+                documentTitle: "Widgets.pdf",
+                score: 0.91
+            ),
+            VectorSearchHit(
+                chunk: DocumentChunk(documentID: docID, text: "Second passage about widgets and gadgets.", chunkIndex: 3),
+                documentTitle: "Widgets.pdf",
+                score: 0.78
+            ),
+        ]
+        await vectorStore.setKeywordResults(hits)
+
+        let sut = RAGService(documentStore: FakeDocumentStore(), vectorStore: vectorStore)
+        let result = try await sut.retrieve(query: "widgets")
+
+        XCTAssertEqual(result.slots.count, 1)
+        XCTAssertEqual(result.citations.count, 2)
+        XCTAssertEqual(result.citations[0].documentID, docID)
+        XCTAssertEqual(result.citations[0].documentTitle, "Widgets.pdf")
+        XCTAssertEqual(result.citations[0].chunkIndex, 0)
+        XCTAssertEqual(result.citations[0].score, 0.91, accuracy: 0.001)
+        XCTAssertEqual(result.citations[1].chunkIndex, 3)
+        XCTAssertTrue(result.citations[0].snippet.contains("First passage"))
+    }
+
+    func testRetrieveEmptyQueryReturnsEmptyResult() async throws {
+        let sut = RAGService(documentStore: FakeDocumentStore(), vectorStore: FakeVectorStore())
+        let result = try await sut.retrieve(query: "  ")
+        XCTAssertTrue(result.slots.isEmpty)
+        XCTAssertTrue(result.citations.isEmpty)
+    }
+
+    func testRetrieveNoHitsReturnsEmptyResult() async throws {
+        let sut = RAGService(documentStore: FakeDocumentStore(), vectorStore: FakeVectorStore())
+        let result = try await sut.retrieve(query: "anything")
+        XCTAssertTrue(result.slots.isEmpty)
+        XCTAssertTrue(result.citations.isEmpty)
+    }
+
+    func testCitationSnippetTruncatesLongText() {
+        let longText = String(repeating: "a", count: Citation.snippetCharacterLimit + 50)
+        let citation = Citation(
+            documentID: UUID(),
+            documentTitle: "Doc",
+            chunkIndex: 0,
+            fullText: longText,
+            score: 1.0
+        )
+        XCTAssertTrue(citation.snippet.hasSuffix("…"))
+        XCTAssertEqual(citation.snippet.count, Citation.snippetCharacterLimit + 1)
+    }
+
+    func testCitationSnippetPreservesShortText() {
+        let citation = Citation(
+            documentID: UUID(),
+            documentTitle: "Doc",
+            chunkIndex: 0,
+            fullText: "Short.",
+            score: 1.0
+        )
+        XCTAssertEqual(citation.snippet, "Short.")
+    }
+
     func testDeleteDocumentRemovesFromBothStores() async throws {
         let vectorStore = FakeVectorStore()
         let docStore = FakeDocumentStore()


### PR DESCRIPTION
Closes the user-facing gap left by Phase 1 (#1148). Phase 1 shipped the engine (FlatFileVectorStore, RAGService, ConversationRuntime wiring); Phase 2 makes RAG reachable in the demo and surfaces retrieved sources in the chat UI.

Linked issue: #1149

## Summary

- **Demo wiring**: `ManifoldBootstrap` now receives `RAGConfiguration()` in the demo, so retrieval runs on every turn (keyword-fallback path until an embedding backend is wired). New sidebar "Knowledge Base" button opens `DocumentLibrarySheet`.
- **Document library** (`ManifoldUIModelManagement/Views/Documents/`): lists ingested `DocumentRecord`s (title, file type, chunk count, indexed date) with file-picker + macOS drag-and-drop add, per-row ingest spinner, delete-with-confirmation. Renders a "Using keyword fallback" banner when no embedding backend is configured.
- **Source citations**: new `Citation` value type carries `documentID + documentTitle + chunkIndex + snippet + score`. `RAGService` gains `retrieve(query:limit:)` returning a `RetrievalResult { slots, citations }`; the existing `retrieveSlots` is now a thin shim. `ConversationRuntime` plumbs citations onto the assistant `ChatMessageRecord`. New `CitationsView` renders a collapsed-by-default `DisclosureGroup` beneath the assistant bubble (mirrors the `ThinkingBlockView` idiom).

## What shipped vs deferred

| Area | Shipped | Deferred |
|---|---|---|
| Demo wiring | RAGConfiguration() opt-in | — |
| Document library | List, add (.txt/.pdf), delete, progress, drag-and-drop | — |
| Citations | In-memory plumbing + UI disclosure | **Cross-session persistence** — flagged below |
| Embedding model picker | Not in this PR | Tracked separately for Phase 3 |

### Architectural decisions warranting follow-up issues

1. **Citation persistence is transient.** Storing citations across app launches needs either a new column on `ManifoldSchemaV4.ChatMessage` or a `SchemaV6` bump. The brief explicitly said \"flag and stop rather than ship a half-baked migration\", so citations live only on the in-memory `ChatMessageRecord` for now. A clean Phase-3 issue: \"Persist `ChatMessageRecord.citations` via SchemaV6 (or an additive column on V5)\".
2. **`RAGService.retrieveSlots` is now a shim** for `retrieve(query:limit:)`. Internal callers should migrate over time; the slot-only signature is preserved for back-compat with any external adopters.
3. **`hasEmbeddingBackend` flag is host-supplied** — `RAGService` does not expose its embedding backend publicly, so the document library UI takes this as a constructor arg. If/when we ship the embedding-model picker, that signal can flip automatically.

## Test plan

- [x] `swift test --skip-update --filter \"ConversationRuntimeTests|RAGServiceTests\"` — 56/56 green (added 5 RAGService tests for `retrieve(query:)` + Citation truncation, 2 ConversationRuntime tests for citation attachment / nil-on-empty-hits).
- [x] `swift test --skip-update` — full default-trait suite passes; 138/138 in the umbrella `ManifoldKitPackageTests.xctest` plus all sub-suites zero-failures.
- [x] `xcodebuild -scheme ManifoldDemo -destination platform=macOS,arch=arm64 build` — demo app builds clean.
- [ ] Manual smoke (out of scope for the worker — left for reviewer): open Knowledge Base sheet, drop a .txt file, send a query that mentions its content, confirm citation disclosure renders beneath the assistant reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)