### PR TITLE
refactor: decompose MLXBackend

### DIFF
--- a/Sources/ManifoldMLX/MLXBackend.swift
+++ b/Sources/ManifoldMLX/MLXBackend.swift
@@ -24,18 +24,6 @@ import ManifoldInference
 /// Requires real Apple Silicon hardware — does not work in iOS Simulator.
 public final class MLXBackend: InferenceBackend, @unchecked Sendable {
 
-    struct CachedLayerState {
-        let cacheTypeName: String
-        let offset: Int
-        let state: [MLXArray]
-        let metaState: [String]
-    }
-
-    struct PromptCacheSnapshot {
-        let promptTokens: [Int]
-        let layers: [CachedLayerState]
-    }
-
     // MARK: - Logging
 
     private static let logger = Logger(
@@ -130,15 +118,8 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
     /// overrides this — see the generate path below.
     /// Access only under `stateLock`.
     private var _autoDetectedThinkingMarkers: ThinkingMarkers?
-    /// Cached prompt KV state for longest-common-prefix reuse on the next turn.
-    /// Access only under `stateLock`.
-    private var _promptCacheSnapshot: PromptCacheSnapshot?
-    /// Snapshot capture still materializing after the previous turn finished.
-    /// Access only under `stateLock`.
-    private var _pendingPromptCacheSnapshotTask: Task<Void, Never>?
-    /// Monotonic token used to invalidate stale post-finish snapshot writes.
-    /// Access only under `stateLock`.
-    private var _promptCacheWriteToken: UInt64 = 0
+    /// Prompt KV-cache reuse state. Access only under `stateLock`.
+    private var _promptCacheState = MLXPromptCacheCoordinator.State()
     /// Whether the currently loaded model/config is eligible for prompt-cache reuse.
     /// Access only under `stateLock`.
     private var _kvCacheReuseEligible = false
@@ -214,212 +195,6 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         self.enableKVCacheReuse = enableKVCacheReuse
     }
 
-    // MARK: - Architecture Allowlist
-
-    /// Canonical `model_type` values that `mlx-swift-lm`'s `LLMTypeRegistry.shared`
-    /// can serve as chat/instruct LMs. Anything outside this set (or the
-    /// VLM-specific set below) — CLIP, SigLIP, Whisper, BERT embeddings, etc. —
-    /// is refused at
-    /// load time via `InferenceError.unsupportedModelArchitecture`.
-    ///
-    /// Sourced from `LLMTypeRegistry.shared` in mlx-swift-lm
-    /// (`Libraries/MLXLLM/LLMModelFactory.swift`). When mlx-swift-lm adds a new
-    /// LM architecture, update this list to match so the preflight doesn't reject
-    /// a freshly supported model.
-    static let supportedLMArchitectures: Set<String> = [
-        "mistral", "llama", "phi", "phi3", "phimoe",
-        "gemma", "gemma2", "gemma3", "gemma3_text", "gemma3n", "gemma4",
-        "qwen2", "qwen3", "qwen3_moe", "qwen3_next",
-        "qwen3_5", "qwen3_5_moe", "qwen3_5_text",
-        "minicpm", "starcoder2", "cohere", "openelm", "internlm2",
-        "deepseek_v3", "granite", "granitemoehybrid",
-        "mimo", "mimo_v2_flash", "minimax",
-        "glm4", "glm4_moe", "glm4_moe_lite",
-        "acereason", "falcon_h1", "bitnet", "smollm3",
-        "ernie4_5", "lfm2", "lfm2_moe",
-        "baichuan_m1", "exaone4", "gpt_oss",
-        "lille-130m", "olmoe", "olmo2", "olmo3",
-        "bailing_moe", "nanochat", "nemotron_h",
-        "afmoe", "jamba_3b", "mistral3", "apertus",
-    ]
-
-    static let supportedVLMArchitectures: Set<String> = [
-        "paligemma", "qwen2_vl", "qwen2_5_vl", "qwen3_vl",
-        "qwen3_5", "qwen3_5_moe", "idefics3", "gemma3", "gemma4",
-        "smolvlm", "fastvlm", "llava_qwen2", "pixtral", "mistral3",
-        "lfm2_vl", "lfm2-vl", "glm_ocr",
-    ]
-
-    private static let normalizedSupportedArchitectures: Set<String> =
-        Set((supportedLMArchitectures.union(supportedVLMArchitectures)).map(normalizeArchitectureKey))
-
-    private static func normalizeArchitectureKey(_ value: String) -> String {
-        value.lowercased().unicodeScalars
-            .filter { CharacterSet.alphanumerics.contains($0) }
-            .map(String.init)
-            .joined()
-    }
-
-    /// Reads `config.json` at `url` and throws
-    /// `InferenceError.unsupportedModelArchitecture` if the declared `model_type`
-    /// is not a chat/instruct LM. If `config.json` is missing or unreadable the
-    /// check is a no-op — mlx-swift-lm's own load path will then surface the
-    /// real error (missing weights, malformed directory, etc.).
-    static func validateArchitecture(at url: URL) throws {
-        let configURL = url.appendingPathComponent("config.json")
-        guard let data = try? Data(contentsOf: configURL),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            // Missing / malformed config.json: let the MLX load path produce the
-            // real diagnostic rather than masking it with a false architecture error.
-            return
-        }
-
-        let modelType = (json["model_type"] as? String)?
-            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let normalizedModelType = normalizeArchitectureKey(modelType)
-        if !normalizedModelType.isEmpty,
-           normalizedSupportedArchitectures.contains(normalizedModelType) {
-            return
-        }
-
-        // Some HF repos omit model_type but include an `architectures` array
-        // (e.g. ["LlamaForCausalLM"]). Accept the load if any entry's snake_case
-        // prefix matches the allowlist — this keeps older snapshots working.
-        if let archs = json["architectures"] as? [String] {
-            for arch in archs {
-                let normalized = normalizeArchitectureKey(arch)
-                if Self.normalizedSupportedArchitectures.contains(where: { normalized.hasPrefix($0) }) {
-                    return
-                }
-            }
-        }
-
-        let reported = modelType.isEmpty ? (json["architectures"] as? [String])?.joined(separator: ",") ?? "unknown" : modelType
-        throw InferenceError.unsupportedModelArchitecture(reported)
-    }
-
-    // MARK: - Factory Routing
-
-    /// Returns `true` when the model at `url` must load through the VLM factory.
-    ///
-    /// This covers both explicit multimodal models (`vision_config`) and the
-    /// Gemma 4 MoE path that only exists behind `VLMModelFactory` today.
-    ///
-    /// Falls back to `false` (LLM factory) when config.json is missing/unreadable —
-    /// matches the same conservative default used by `validateArchitecture`. Dense
-    /// Gemma 4 models intentionally stay on the LLM factory so we don't pay the
-    /// memory cost of resident vision-tower weights.
-    static func requiresVLMFactory(at url: URL) -> Bool {
-        requiresVLMFactory(at: url, precomputedCapabilities: nil)
-    }
-
-    /// Variant that accepts pre-computed capabilities to avoid re-reading
-    /// `config.json` when the caller already ran ``ModelCapabilityProbe``.
-    static func requiresVLMFactory(
-        at url: URL,
-        precomputedCapabilities capabilities: ModelCapabilities?
-    ) -> Bool {
-        // Fast path: vision was already detected by the caller's probe run.
-        if let capabilities {
-            if capabilities.supportsVision { return true }
-        } else {
-            do {
-                if try ModelCapabilityProbe.probe(modelDirectory: url).supportsVision {
-                    return true
-                }
-            } catch {
-                Log.inference.info(
-                    "MLX capability probe failed for \(url.lastPathComponent, privacy: .public); falling back to config.json routing (\(error.localizedDescription, privacy: .public))"
-                )
-            }
-        }
-        // MoE fallback: Gemma 4 26B ships `text_config.enable_moe_block = true`
-        // and its MoE decoder only exists in the VLM factory today.
-        let configURL = url.appendingPathComponent("config.json")
-        guard let data = try? Data(contentsOf: configURL),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return false
-        }
-        if let textConfig = json["text_config"] as? [String: Any],
-           textConfig["enable_moe_block"] as? Bool == true {
-            return true
-        }
-        return false
-    }
-
-    private static func longestCommonPrefixLength(_ lhs: [Int], _ rhs: [Int]) -> Int {
-        zip(lhs, rhs).prefix(while: { $0 == $1 }).count
-    }
-
-    /// Result of `prepareInputAndCache(...)`.
-    struct PreparedGenerationInputs {
-        let generationInput: MLXPreparedInput
-        let cache: MLXPromptCache
-        /// Captured prompt token IDs when KV-cache reuse is eligible — used to
-        /// snapshot the cache after generation finishes. `nil` otherwise.
-        let promptTokenIds: [Int]?
-        /// Number of leading prompt tokens whose KV state was restored from
-        /// the previous turn. `0` when no reuse occurred.
-        let reuseLen: Int
-    }
-
-    /// Prepares the model input, allocates a KV cache, and applies the
-    /// longest-common-prefix reuse heuristic when an eligible snapshot exists.
-    ///
-    /// **CRITICAL:** the reuse path here is byte-identical to the inline
-    /// version it replaced — `longestCommonPrefixLength` clamped to
-    /// `promptTokenIds.count - 1`, gated by `isSupportedPromptCache` and
-    /// `promptTokenIds.count > 1`. Behaviour drift here corrupts the KV cache
-    /// across turns (see v0.5.3 incident).
-    @MainActor
-    static func prepareInputAndCache(
-        container: any MLXModelContainerProtocol,
-        chatMessages: [Chat.Message]?,
-        messages: [[String: String]],
-        generateConfig: GenerateParameters,
-        kvCacheReuseEligible: Bool,
-        snapshot: PromptCacheSnapshot?
-    ) async throws -> PreparedGenerationInputs {
-        let preparedInput =
-            if let chatMessages {
-                try await container.prepare(chat: SendableChatMessages(chatMessages))
-            } else {
-                try await container.prepare(messages: messages)
-            }
-        let cache = try await container.makeCache(parameters: generateConfig)
-        let promptTokenIds: [Int]? = if kvCacheReuseEligible {
-            preparedInput.promptTokenIds
-        } else {
-            nil
-        }
-
-        var generationInput = preparedInput
-        var reuseLen = 0
-        if kvCacheReuseEligible,
-           let snapshot,
-           let promptTokenIds,
-           isSupportedPromptCache(cache.value),
-           promptTokenIds.count > 1 {
-            let commonPrefixLen = longestCommonPrefixLength(
-                promptTokenIds,
-                snapshot.promptTokens
-            )
-            let candidate = min(commonPrefixLen, promptTokenIds.count - 1)
-            if candidate > 0,
-               restorePromptCache(snapshot, into: cache, reusedPromptTokenCount: candidate) {
-                generationInput = preparedInput.suffix(from: candidate)
-                reuseLen = candidate
-            }
-        }
-
-        return PreparedGenerationInputs(
-            generationInput: generationInput,
-            cache: cache,
-            promptTokenIds: promptTokenIds,
-            reuseLen: reuseLen
-        )
-    }
-
     /// Resolves the active thinking-marker pair from the per-request override
     /// (`config.thinkingMarkers`), then the load-time auto-detected markers.
     /// Returns `nil` when `config.maxThinkingTokens == 0` (issue #597) or when
@@ -430,437 +205,6 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
     ) -> ThinkingMarkers? {
         if config.maxThinkingTokens == 0 { return nil }
         return config.thinkingMarkers ?? autoDetected
-    }
-
-    /// Assembles the prepared chat-message inputs for the MLX container's two
-    /// `prepare(...)` overloads. Returns both shapes because the caller picks
-    /// `prepare(chat:)` for vision history (non-nil first element) and
-    /// `prepare(messages:)` otherwise.
-    static func buildChatMessages(
-        prompt: String,
-        effectiveSystemPrompt: String?,
-        conversationHistory: [(role: String, content: String)],
-        toolAwareHistory: [ToolAwareHistoryEntry]?,
-        structuredHistory: [StructuredMessage]?,
-        dialect: MLXToolDialect
-    ) throws -> (chatMessages: [Chat.Message]?, messages: [[String: String]]) {
-        let chatMessages: [Chat.Message]? =
-            if let structuredHistory, !structuredHistory.isEmpty {
-                if let toolAwareHistory, !toolAwareHistory.isEmpty {
-                    try toolAwareChatMessages(
-                        structuredHistory: structuredHistory,
-                        toolAwareHistory: toolAwareHistory,
-                        systemPrompt: effectiveSystemPrompt,
-                        dialect: dialect
-                    )
-                } else {
-                    try plainChatMessages(
-                        history: structuredHistory,
-                        systemPrompt: effectiveSystemPrompt
-                    )
-                }
-            } else {
-                nil
-            }
-
-        var msgs: [[String: String]] = []
-        if let sp = effectiveSystemPrompt, !sp.isEmpty {
-            msgs.append(["role": "system", "content": sp])
-        }
-        if let toolHistory = toolAwareHistory, !toolHistory.isEmpty {
-            for entry in toolHistory {
-                msgs.append(encodeToolAwareEntryAsText(entry, dialect: dialect))
-            }
-        } else if !conversationHistory.isEmpty {
-            for msg in conversationHistory {
-                msgs.append(["role": msg.role, "content": msg.content])
-            }
-        } else {
-            msgs.append(["role": "user", "content": prompt])
-        }
-        return (chatMessages, msgs)
-    }
-
-    /// Returns the Qwen 2.5 `<tools>…</tools>` block to append to the system
-    /// prompt, or `nil` when the dialect doesn't use this mechanism or the
-    /// caller supplied no tools.
-    static func buildQwenToolBlock(
-        config: GenerationConfig,
-        dialect: MLXToolDialect
-    ) -> String? {
-        guard !config.tools.isEmpty, dialect == .qwen25 else { return nil }
-        let toolObjects: [[String: Any]] = config.tools.map { tool -> [String: Any] in
-            var function_: [String: Any] = [
-                "name": tool.name,
-                "description": tool.description,
-            ]
-            if let paramsData = try? JSONEncoder().encode(tool.parameters),
-               let paramsObj = try? JSONSerialization.jsonObject(with: paramsData) {
-                function_["parameters"] = paramsObj
-            } else {
-                function_["parameters"] = ["type": "object", "properties": [String: Any]()]
-            }
-            return ["type": "function", "function": function_]
-        }
-        let toolsJSON: String
-        if let data = try? JSONSerialization.data(withJSONObject: toolObjects, options: [.prettyPrinted]),
-           let str = String(data: data, encoding: .utf8) {
-            toolsJSON = str
-        } else {
-            toolsJSON = "[]"
-        }
-        return "\n\n# Tools\n\nYou may call one or more functions to assist with the user query. Don't make assumptions about what values to plug into functions. Here are the available tools:\n\n<tools>\n\(toolsJSON)\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags as follows:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>"
-    }
-
-    private func invalidatePromptCacheLocked() {
-        _pendingPromptCacheSnapshotTask?.cancel()
-        _pendingPromptCacheSnapshotTask = nil
-        _promptCacheSnapshot = nil
-        _promptCacheWriteToken &+= 1
-    }
-
-    private static func isSupportedPromptCache(_ caches: [any KVCache]) -> Bool {
-        !caches.isEmpty && caches.allSatisfy { $0 is KVCacheSimple }
-    }
-
-    private static func chatRole(for role: String) -> Chat.Message.Role {
-        switch role {
-        case "assistant": .assistant
-        case "system": .system
-        case "tool": .tool
-        default: .user
-        }
-    }
-
-    private static func userInputImage(from data: Data, mimeType: String) throws -> UserInput.Image {
-        guard let image = CIImage(data: data) else {
-            throw InferenceError.inferenceFailure(
-                "Unsupported image attachment format (\(mimeType))."
-            )
-        }
-        return .ciImage(image)
-    }
-
-    private static func imageInputs(from parts: [MessagePart]) throws -> [UserInput.Image] {
-        try parts.compactMap { part in
-            guard case let .image(data, mimeType, _) = part else { return nil }
-            return try userInputImage(from: data, mimeType: mimeType)
-        }
-    }
-
-    private static func plainChatMessages(
-        history: [StructuredMessage],
-        systemPrompt: String?
-    ) throws -> [Chat.Message]? {
-        let containsImages = history.contains { message in
-            message.parts.contains { part in
-                if case .image = part { return true }
-                return false
-            }
-        }
-        guard containsImages else { return nil }
-
-        var messages: [Chat.Message] = []
-        if let systemPrompt, !systemPrompt.isEmpty {
-            messages.append(.system(systemPrompt))
-        }
-        for message in history {
-            messages.append(
-                Chat.Message(
-                    role: chatRole(for: message.role),
-                    content: message.textContent,
-                    images: try imageInputs(from: message.parts)
-                )
-            )
-        }
-        return messages
-    }
-
-    private static func toolAwareChatMessages(
-        structuredHistory: [StructuredMessage],
-        toolAwareHistory: [ToolAwareHistoryEntry],
-        systemPrompt: String?,
-        dialect: MLXToolDialect
-    ) throws -> [Chat.Message]? {
-        guard structuredHistory.contains(where: { message in
-            message.parts.contains { part in
-                if case .image = part { return true }
-                return false
-            }
-        }) else {
-            return nil
-        }
-
-        var messages: [Chat.Message] = []
-        if let systemPrompt, !systemPrompt.isEmpty {
-            messages.append(.system(systemPrompt))
-        }
-
-        let structuredImageParts = try structuredHistory.map { try imageInputs(from: $0.parts) }
-        for (index, entry) in toolAwareHistory.enumerated() {
-            let encoded = encodeToolAwareEntryAsText(entry, dialect: dialect)
-            let role = encoded["role"] ?? entry.role
-            let content = encoded["content"] ?? entry.content
-            let images = index < structuredImageParts.count ? structuredImageParts[index] : []
-            messages.append(
-                Chat.Message(
-                    role: chatRole(for: role),
-                    content: content,
-                    images: images
-                )
-            )
-        }
-
-        if toolAwareHistory.count < structuredHistory.count {
-            for (offset, structuredMessage) in structuredHistory.dropFirst(toolAwareHistory.count).enumerated() {
-                let images = structuredImageParts[toolAwareHistory.count + offset]
-                messages.append(
-                    Chat.Message(
-                        role: chatRole(for: structuredMessage.role),
-                        content: structuredMessage.textContent,
-                        images: images
-                    )
-                )
-            }
-        }
-
-        return messages
-    }
-
-    /// Captures prompt-only KV state for the next turn.
-    ///
-    /// Contract assumptions taken from the currently pinned `mlx-swift-lm`:
-    /// 1. `LanguageModel.prepare(_:cache:windowSize:)` consumes any cached prefix
-    ///    from the front of the prepared prompt and only evaluates the remaining
-    ///    suffix, so restored caches must be paired with the uncached prompt tail.
-    /// 2. `KVCacheSimple.copy()/state/metaState/trim(_:)` are sufficient to clone
-    ///    and shrink prompt-only state safely for text-only models.
-    /// 3. Future `mlx-swift-lm` bumps must rerun the MLX KV-cache integration and
-    ///    performance suite before this contract is trusted unchanged.
-    ///
-    /// Marked `@MainActor` because every MLX call here (`copy()`, `eval`,
-    /// `state` slicing, `trim`) shares the same single-threaded GPU scheduler
-    /// as `ModelContainer.generate()`; running off-main risks racy crashes /
-    /// cache corruption.
-    @MainActor
-    private static func capturePromptCacheSnapshot(
-        from cache: MLXPromptCache,
-        promptTokens: [Int]
-    ) -> PromptCacheSnapshot? {
-        guard !promptTokens.isEmpty, isSupportedPromptCache(cache.value) else {
-            return nil
-        }
-        // Early-exit if the surrounding generation task was cancelled — `copy()`
-        // and `eval` materialise full prompt-prefix tensors per layer, which is
-        // expensive enough to be worth skipping when a reset/unload already
-        // invalidated the snapshot we'd be writing.
-        if Task.isCancelled { return nil }
-
-        var layers: [CachedLayerState] = []
-        layers.reserveCapacity(cache.value.count)
-        for original in cache.value {
-            if Task.isCancelled { return nil }
-            guard original.offset >= promptTokens.count else {
-                return nil
-            }
-
-            if original.state.isEmpty {
-                layers.append(
-                    CachedLayerState(
-                        cacheTypeName: String(describing: type(of: original)),
-                        offset: promptTokens.count,
-                        state: [],
-                        metaState: original.metaState
-                    )
-                )
-                continue
-            }
-
-            let copy = original.copy()
-            eval([copy])
-
-            let excess = copy.offset - promptTokens.count
-            if excess > 0 {
-                guard copy.isTrimmable, copy.trim(excess) == excess else {
-                    return nil
-                }
-            }
-
-            let state = copy.state.map { $0[.ellipsis] }
-            eval(state)
-            layers.append(
-                CachedLayerState(
-                    cacheTypeName: String(describing: type(of: copy)),
-                    offset: copy.offset,
-                    state: state,
-                    metaState: copy.metaState
-                )
-            )
-        }
-        return PromptCacheSnapshot(promptTokens: promptTokens, layers: layers)
-    }
-
-    private static func restorePromptCache(
-        _ snapshot: PromptCacheSnapshot,
-        into cache: MLXPromptCache,
-        reusedPromptTokenCount: Int
-    ) -> Bool {
-        guard reusedPromptTokenCount > 0,
-              cache.value.count == snapshot.layers.count,
-              isSupportedPromptCache(cache.value) else {
-            return false
-        }
-
-        for (index, layer) in snapshot.layers.enumerated() {
-            var target = cache.value[index]
-            guard String(describing: type(of: target)) == layer.cacheTypeName else {
-                return false
-            }
-            if layer.state.isEmpty {
-                guard let target = target as? KVCacheSimple else { return false }
-                target.offset = layer.offset
-                target.metaState = layer.metaState
-            } else {
-                target.state = layer.state.map { $0[.ellipsis] }
-                target.metaState = layer.metaState
-            }
-
-            guard target.offset >= reusedPromptTokenCount else { return false }
-            let excess = target.offset - reusedPromptTokenCount
-            if excess > 0 {
-                guard target.isTrimmable, target.trim(excess) == excess else {
-                    return false
-                }
-            }
-        }
-
-        eval(cache.value)
-        return true
-    }
-
-    // MARK: - Thinking-Marker Auto-Discovery
-
-    /// Reads `tokenizer_config.json` inside `url` and returns the best-matching
-    /// thinking-marker preset for the chat template it declares.
-    ///
-    /// Best-effort: a missing or unreadable `tokenizer_config.json`, or one
-    /// without a `chat_template` field, returns `nil`. The MLX tokenizer object
-    /// in `mlx-swift-lm` exposes the chat template through Hugging Face's
-    /// swift-transformers, but reaching it requires opening a `ModelContainer`
-    /// session — reading the on-disk JSON directly is faster and avoids
-    /// tying up the GPU during the load.
-    ///
-    /// - Parameter url: The model directory URL (same one passed to
-    ///   `MLXBackend.loadModel(from:plan:)`).
-    /// - Returns: The auto-detected ``ThinkingMarkers`` or `nil` if no known
-    ///   marker pair is present in the template.
-    static func detectThinkingMarkers(at url: URL) -> ThinkingMarkers? {
-        let configURL = url.appendingPathComponent("tokenizer_config.json")
-        guard let data = try? Data(contentsOf: configURL),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            // Missing / unreadable tokenizer_config.json is expected for some
-            // model layouts (older snapshots, partial downloads). Don't warn —
-            // callers explicitly opt out of thinking parsing when this is nil.
-            return nil
-        }
-
-        // `chat_template` is a single string for most HF tokenizers, but a
-        // small number of repos ship an array of `{name, template}` entries
-        // (multi-template configs). When that happens, sniff the first entry
-        // whose name is `default` (or the first entry overall).
-        let templateString: String? = {
-            if let s = json["chat_template"] as? String { return s }
-            if let arr = json["chat_template"] as? [[String: Any]] {
-                if let def = arr.first(where: { ($0["name"] as? String)?.lowercased() == "default" }),
-                   let s = def["template"] as? String {
-                    return s
-                }
-                if let s = arr.first?["template"] as? String { return s }
-            }
-            return nil
-        }()
-        guard let template = templateString else { return nil }
-        return ThinkingMarkers.fromChatTemplate(template)
-    }
-
-    // MARK: - Manifest Production
-
-    /// Produces a ``ModelManifest`` from a freshly-loaded MLX model directory.
-    ///
-    /// Reads `config.json` to extract the true context window:
-    /// `text_config.max_position_embeddings` (preferred for VLM/MoE configs),
-    /// `max_position_embeddings`, or `model_max_length` as a final fallback.
-    /// Combines with the chat-template-detected ``ThinkingMarkers`` and the
-    /// vision-capability flag to populate the manifest.
-    ///
-    /// Falls back to ``ModelManifest/unknown(modelIdentifier:producerKind:)``
-    /// (with a `Log.warn`) when `config.json` is missing or carries no
-    /// position-embedding hint. The conservative default (8k) keeps prompts
-    /// shorter than necessary on misconfigured snapshots, which is safer than
-    /// over-trimming or over-feeding the model.
-    static func produceManifest(
-        at url: URL,
-        detectedThinkingMarkers: ThinkingMarkers?,
-        supportsVision: Bool
-    ) -> ModelManifest {
-        let modelIdentifier = url.lastPathComponent
-        let configURL = url.appendingPathComponent("config.json")
-        guard let data = try? Data(contentsOf: configURL),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            Log.inference.warning(
-                "MLX manifest probe: config.json missing or unreadable for \(modelIdentifier, privacy: .public); falling back to ModelManifest.unknown"
-            )
-            return .unknown(modelIdentifier: modelIdentifier, producerKind: .local)
-        }
-
-        let contextWindow = extractContextWindow(from: json)
-            ?? {
-                Log.inference.warning(
-                    "MLX manifest probe: no max_position_embeddings / model_max_length found for \(modelIdentifier, privacy: .public); falling back to 8192"
-                )
-                return 8192
-            }()
-
-        return ModelManifest(
-            contextWindow: contextWindow,
-            supportsTools: true,
-            supportsThinking: detectedThinkingMarkers != nil,
-            thinkingMarkers: detectedThinkingMarkers,
-            supportsSeed: true,
-            supportedSamplingParameters: [
-                .temperature, .topP, .topK, .repeatPenalty,
-                .presencePenalty, .frequencyPenalty,
-            ],
-            modelIdentifier: modelIdentifier,
-            producerKind: .local
-        )
-    }
-
-    /// Pulls the model's max position embedding count out of an MLX
-    /// `config.json` payload. Returns `nil` when no recognised key is
-    /// present.
-    static func extractContextWindow(from json: [String: Any]) -> Int? {
-        // Modern multi-modal configs nest the text encoder fields under
-        // `text_config`. Prefer that over the top-level keys when present.
-        if let textConfig = json["text_config"] as? [String: Any],
-           let value = positiveInt(from: textConfig["max_position_embeddings"]) {
-            return value
-        }
-        if let value = positiveInt(from: json["max_position_embeddings"]) {
-            return value
-        }
-        if let value = positiveInt(from: json["model_max_length"]) {
-            return value
-        }
-        return nil
-    }
-
-    private static func positiveInt(from value: Any?) -> Int? {
-        if let int = value as? Int, int > 0 { return int }
-        if let int64 = value as? Int64, int64 > 0 { return Int(int64) }
-        if let double = value as? Double, double > 0 { return Int(double) }
-        if let str = value as? String, let parsed = Int(str), parsed > 0 { return parsed }
-        return nil
     }
 
     // MARK: - Model Lifecycle
@@ -880,7 +224,7 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         // surfaces through `modelLoadFailed(underlying:)` and hides the root cause
         // from the UI. Throwing `.unsupportedModelArchitecture` here makes the reason
         // explicit and lets `ChatError` map it to `.selectModel`.
-        try Self.validateArchitecture(at: url)
+        try MLXModelProbe.validateArchitecture(at: url)
 
         let progressHandler = withStateLock { _loadProgressHandler }
 
@@ -903,7 +247,7 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 probedCapabilities = nil
             }
             let supportsVision = BackendVisionCapability.mlxSupportsImageInput(probedCapabilities: probedCapabilities)
-            let routeThroughVLMFactory = Self.requiresVLMFactory(at: url, precomputedCapabilities: probedCapabilities)
+            let routeThroughVLMFactory = MLXModelProbe.requiresVLMFactory(at: url, precomputedCapabilities: probedCapabilities)
             // Load from a local directory containing config.json + .safetensors.
             // We dispatch directly to either `LLMModelFactory.shared` or
             // `VLMModelFactory.shared` rather than calling the registry-iterating
@@ -933,8 +277,8 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 )
             }
             let detectedDialect = MLXToolDialect.detect(at: url)
-            let detectedThinkingMarkers = Self.detectThinkingMarkers(at: url)
-            let producedManifest = Self.produceManifest(
+            let detectedThinkingMarkers = MLXModelProbe.detectThinkingMarkers(at: url)
+            let producedManifest = MLXModelProbe.produceManifest(
                 at: url,
                 detectedThinkingMarkers: detectedThinkingMarkers,
                 supportsVision: supportsVision
@@ -946,7 +290,7 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 _autoDetectedThinkingMarkers = detectedThinkingMarkers
                 _supportsVision = supportsVision
                 _manifest = producedManifest
-                invalidatePromptCacheLocked()
+                _promptCacheState.invalidate()
                 _kvCacheReuseEligible = kvCacheReuseEligible
                 _hasInitializedRuntime = true
             }
@@ -1011,7 +355,7 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 throw InferenceError.alreadyGenerating
             }
             _isGenerating = true
-            return (container, _pendingPromptCacheSnapshotTask, _kvCacheReuseEligible)
+            return (container, _promptCacheState.pendingSnapshotTask, _kvCacheReuseEligible)
         }
         Self.logger.debug("MLX generate started")
 
@@ -1065,13 +409,13 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         }
 
         let effectiveSystemPrompt: String? = {
-            if let toolBlock = Self.buildQwenToolBlock(config: config, dialect: dialect) {
+            if let toolBlock = MLXChatMessageEncoder.buildQwenToolBlock(config: config, dialect: dialect) {
                 return (systemPrompt ?? "") + toolBlock
             }
             return systemPrompt
         }()
 
-        let (chatMessages, messages) = try Self.buildChatMessages(
+        let (chatMessages, messages) = try MLXChatMessageEncoder.buildChatMessages(
             prompt: prompt,
             effectiveSystemPrompt: effectiveSystemPrompt,
             conversationHistory: conversationHistory,
@@ -1097,13 +441,13 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 if kvCacheReuseEligible, let pendingSnapshotTask {
                     await pendingSnapshotTask.value
                 }
-                let resolvedSnapshot: PromptCacheSnapshot? =
+                let resolvedSnapshot: MLXPromptCacheCoordinator.Snapshot? =
                     if kvCacheReuseEligible, let self {
-                        self.withStateLock { self._promptCacheSnapshot }
+                        self.withStateLock { self._promptCacheState.snapshot }
                     } else {
                         nil
                     }
-                let prepared = try await Self.prepareInputAndCache(
+                let prepared = try await MLXPromptCacheCoordinator.prepareInputAndCache(
                     container: modelContainer,
                     chatMessages: chatMessages,
                     messages: messages,
@@ -1129,9 +473,12 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                     yieldHook: MLXBackend._yieldHookForTesting
                 )
 
-                let snapshotInputs: (MLXPromptCache, [Int])? =
+                let snapshotInputs: MLXPromptCacheCoordinator.SnapshotCaptureInputs? =
                     if kvCacheReuseEligible, result.completedNormally, let ids = prepared.promptTokenIds {
-                        (prepared.cache, ids)
+                        MLXPromptCacheCoordinator.SnapshotCaptureInputs(
+                            cache: prepared.cache,
+                            promptTokenIds: ids
+                        )
                     } else {
                         nil
                     }
@@ -1140,8 +487,11 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                     self.withStateLock { self._isGenerating = false }
                 }
                 generationStream.setPhase(.done)
-                if let self, let (cache, promptTokenIds) = snapshotInputs {
-                    self.scheduleSnapshotCaptureLocked(cache: cache, promptTokenIds: promptTokenIds)
+                if let self, let snapshotInputs {
+                    self.scheduleSnapshotCaptureLocked(
+                        cache: snapshotInputs.cache,
+                        promptTokenIds: snapshotInputs.promptTokenIds
+                    )
                 }
                 continuation.finish()
             } catch {
@@ -1173,32 +523,32 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
     /// Schedules an off-main capture of the prompt KV cache for next-turn reuse.
     ///
     /// The capture itself runs `@MainActor` because every MLX call inside
-    /// `capturePromptCacheSnapshot` (`copy()`, `eval`, `state` slicing, `trim`)
-    /// shares the single-threaded GPU scheduler with `ModelContainer.generate`.
-    /// A monotonic write token guards against stale snapshots overwriting a
-    /// newer turn's cache state if the next `generate()` call has already
-    /// invalidated this lineage.
+    /// `MLXPromptCacheCoordinator.capturePromptCacheSnapshot` shares the
+    /// single-threaded GPU scheduler with `ModelContainer.generate`. A monotonic
+    /// write token guards against stale snapshots overwriting a newer turn's
+    /// cache state if the next `generate()` call has already invalidated this
+    /// lineage.
     @MainActor
     private func scheduleSnapshotCaptureLocked(
         cache: MLXPromptCache,
         promptTokenIds: [Int]
     ) {
         withStateLock {
-            _promptCacheWriteToken &+= 1
-            let snapshotWriteToken = _promptCacheWriteToken
-            let snapshotTask = Task<Void, Never> { @MainActor [weak self] in
-                let snapshot = Self.capturePromptCacheSnapshot(
-                    from: cache,
-                    promptTokens: promptTokenIds
-                )
+            _promptCacheState.writeToken &+= 1
+            let snapshotWriteToken = _promptCacheState.writeToken
+            let snapshotTask = MLXPromptCacheCoordinator.makeSnapshotCaptureTask(
+                cache: cache,
+                promptTokenIds: promptTokenIds,
+                writeToken: snapshotWriteToken
+            ) { [weak self] token, snapshot in
                 guard let self else { return }
                 self.withStateLock {
-                    guard self._promptCacheWriteToken == snapshotWriteToken else { return }
-                    self._promptCacheSnapshot = snapshot
-                    self._pendingPromptCacheSnapshotTask = nil
+                    guard self._promptCacheState.writeToken == token else { return }
+                    self._promptCacheState.snapshot = snapshot
+                    self._promptCacheState.pendingSnapshotTask = nil
                 }
             }
-            _pendingPromptCacheSnapshotTask = snapshotTask
+            _promptCacheState.pendingSnapshotTask = snapshotTask
         }
     }
 
@@ -1218,18 +568,18 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             _isModelLoaded = true
             _supportsVision = supportsVision
             _dialect = dialect
-            invalidatePromptCacheLocked()
+            _promptCacheState.invalidate()
             _kvCacheReuseEligible = enableKVCacheReuse
             _hasInitializedRuntime = false
         }
     }
 
     func _hasPromptCacheSnapshotForTesting() -> Bool {
-        withStateLock { _promptCacheSnapshot != nil || _pendingPromptCacheSnapshotTask != nil }
+        withStateLock { _promptCacheState.hasSnapshotOrPending }
     }
 
     func _isPromptCacheSnapshotReadyForTesting() -> Bool {
-        withStateLock { _promptCacheSnapshot != nil && _pendingPromptCacheSnapshotTask == nil }
+        withStateLock { _promptCacheState.isSnapshotReady }
     }
 
     /// Test-only seam: forces the auto-detected thinking markers to a specific
@@ -1269,7 +619,7 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             _autoDetectedThinkingMarkers = nil
             _supportsVision = false
             _manifest = nil
-            invalidatePromptCacheLocked()
+            _promptCacheState.invalidate()
             _kvCacheReuseEligible = false
             _hasInitializedRuntime = false
             return had
@@ -1307,7 +657,7 @@ extension MLXBackend {
             _conversationHistory = []
             _toolAwareHistory = nil
             _structuredHistory = nil
-            invalidatePromptCacheLocked()
+            _promptCacheState.invalidate()
         }
     }
 
@@ -1326,7 +676,7 @@ extension MLXBackend {
     /// not affected.
     public func secureWipe() {
         let hasRuntime = withStateLock { () -> Bool in
-            invalidatePromptCacheLocked()
+            _promptCacheState.invalidate()
             return _hasInitializedRuntime
         }
         #if MLX
@@ -1362,60 +712,6 @@ extension MLXBackend: ToolCallingHistoryReceiver {
     /// being passed to the MLX generate path.
     public func setToolAwareHistory(_ messages: [ToolAwareHistoryEntry]) {
         withStateLock { _toolAwareHistory = messages }
-    }
-}
-
-// MARK: - Tool-Aware Entry Encoding
-
-extension MLXBackend {
-    /// Encodes a ``ToolAwareHistoryEntry`` into a plain `[String: String]` message
-    /// compatible with MLX chat-template preparation.
-    ///
-    /// For the Qwen 2.5 dialect:
-    /// - Assistant entries with `toolCalls` have the calls serialised as
-    ///   `<tool_call>{"name":…,"arguments":…}</tool_call>` appended to (or
-    ///   replacing) the textual content.
-    /// - Tool-role entries (carrying a ``ToolResult``) are represented as
-    ///   `role: "tool"` with the result content. The MLX chat template for
-    ///   Qwen maps the `tool` role to an `<tool_response>` block internally.
-    ///
-    /// For the `.unknown` dialect (and plain text turns) the entry collapses to
-    /// a simple `{role, content}` pair.
-    static func encodeToolAwareEntryAsText(
-        _ entry: ToolAwareHistoryEntry,
-        dialect: MLXToolDialect
-    ) -> [String: String] {
-        // For non-Qwen dialects or plain turns, fall back to the bare shape.
-        guard dialect == .qwen25 else {
-            return ["role": entry.role, "content": entry.content]
-        }
-
-        if let calls = entry.toolCalls, !calls.isEmpty {
-            // Assistant turn that triggered tool calls: encode calls as text.
-            var parts: [String] = []
-            if !entry.content.isEmpty {
-                parts.append(entry.content)
-            }
-            for call in calls {
-                let argsValue: Any
-                if let data = call.arguments.data(using: .utf8),
-                   let parsed = try? JSONSerialization.jsonObject(with: data) {
-                    argsValue = parsed
-                } else {
-                    argsValue = [String: Any]()
-                }
-                let callObj: [String: Any] = ["name": call.toolName, "arguments": argsValue]
-                if let data = try? JSONSerialization.data(withJSONObject: callObj),
-                   let jsonStr = String(data: data, encoding: .utf8) {
-                    parts.append("<tool_call>\n\(jsonStr)\n</tool_call>")
-                }
-            }
-            return ["role": "assistant", "content": parts.joined(separator: "\n")]
-        }
-
-        // Tool result turn: pass role and content as-is.
-        // The Qwen tokenizer template handles `role: "tool"` natively.
-        return ["role": entry.role, "content": entry.content]
     }
 }
 

--- a/Sources/ManifoldMLX/MLXChatMessageEncoder.swift
+++ b/Sources/ManifoldMLX/MLXChatMessageEncoder.swift
@@ -1,0 +1,243 @@
+#if MLX
+import CoreImage
+import Foundation
+import MLXLMCommon
+import ManifoldInference
+
+/// Encodes Manifold chat history into the message shapes accepted by MLX.
+enum MLXChatMessageEncoder {
+    /// Assembles the prepared chat-message inputs for the MLX container's two
+    /// `prepare(...)` overloads. Returns both shapes because the caller picks
+    /// `prepare(chat:)` for vision history (non-nil first element) and
+    /// `prepare(messages:)` otherwise.
+    static func buildChatMessages(
+        prompt: String,
+        effectiveSystemPrompt: String?,
+        conversationHistory: [(role: String, content: String)],
+        toolAwareHistory: [ToolAwareHistoryEntry]?,
+        structuredHistory: [StructuredMessage]?,
+        dialect: MLXToolDialect
+    ) throws -> (chatMessages: [Chat.Message]?, messages: [[String: String]]) {
+        let chatMessages: [Chat.Message]? =
+            if let structuredHistory, !structuredHistory.isEmpty {
+                if let toolAwareHistory, !toolAwareHistory.isEmpty {
+                    try toolAwareChatMessages(
+                        structuredHistory: structuredHistory,
+                        toolAwareHistory: toolAwareHistory,
+                        systemPrompt: effectiveSystemPrompt,
+                        dialect: dialect
+                    )
+                } else {
+                    try plainChatMessages(
+                        history: structuredHistory,
+                        systemPrompt: effectiveSystemPrompt
+                    )
+                }
+            } else {
+                nil
+            }
+
+        var msgs: [[String: String]] = []
+        if let sp = effectiveSystemPrompt, !sp.isEmpty {
+            msgs.append(["role": "system", "content": sp])
+        }
+        if let toolHistory = toolAwareHistory, !toolHistory.isEmpty {
+            for entry in toolHistory {
+                msgs.append(encodeToolAwareEntryAsText(entry, dialect: dialect))
+            }
+        } else if !conversationHistory.isEmpty {
+            for msg in conversationHistory {
+                msgs.append(["role": msg.role, "content": msg.content])
+            }
+        } else {
+            msgs.append(["role": "user", "content": prompt])
+        }
+        return (chatMessages, msgs)
+    }
+
+    /// Returns the Qwen 2.5 `<tools>…</tools>` block to append to the system
+    /// prompt, or `nil` when the dialect doesn't use this mechanism or the
+    /// caller supplied no tools.
+    static func buildQwenToolBlock(
+        config: GenerationConfig,
+        dialect: MLXToolDialect
+    ) -> String? {
+        guard !config.tools.isEmpty, dialect == .qwen25 else { return nil }
+        let toolObjects: [[String: Any]] = config.tools.map { tool -> [String: Any] in
+            var function_: [String: Any] = [
+                "name": tool.name,
+                "description": tool.description,
+            ]
+            if let paramsData = try? JSONEncoder().encode(tool.parameters),
+               let paramsObj = try? JSONSerialization.jsonObject(with: paramsData) {
+                function_["parameters"] = paramsObj
+            } else {
+                function_["parameters"] = ["type": "object", "properties": [String: Any]()] 
+            }
+            return ["type": "function", "function": function_]
+        }
+        let toolsJSON: String
+        if let data = try? JSONSerialization.data(withJSONObject: toolObjects, options: [.prettyPrinted]),
+           let str = String(data: data, encoding: .utf8) {
+            toolsJSON = str
+        } else {
+            toolsJSON = "[]"
+        }
+        return "\n\n# Tools\n\nYou may call one or more functions to assist with the user query. Don't make assumptions about what values to plug into functions. Here are the available tools:\n\n<tools>\n\(toolsJSON)\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags as follows:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>"
+    }
+
+    /// Encodes a ``ToolAwareHistoryEntry`` into a plain `[String: String]` message
+    /// compatible with MLX chat-template preparation.
+    ///
+    /// For the Qwen 2.5 dialect:
+    /// - Assistant entries with `toolCalls` have the calls serialised as
+    ///   `<tool_call>{"name":…, "arguments":…}</tool_call>` appended to (or
+    ///   replacing) the textual content.
+    /// - Tool-role entries (carrying a ``ToolResult``) are represented as
+    ///   `role: "tool"` with the result content. The MLX chat template for
+    ///   Qwen maps the `tool` role to an `<tool_response>` block internally.
+    ///
+    /// For the `.unknown` dialect (and plain text turns) the entry collapses to
+    /// a simple `{role, content}` pair.
+    static func encodeToolAwareEntryAsText(
+        _ entry: ToolAwareHistoryEntry,
+        dialect: MLXToolDialect
+    ) -> [String: String] {
+        // For non-Qwen dialects or plain turns, fall back to the bare shape.
+        guard dialect == .qwen25 else {
+            return ["role": entry.role, "content": entry.content]
+        }
+
+        if let calls = entry.toolCalls, !calls.isEmpty {
+            // Assistant turn that triggered tool calls: encode calls as text.
+            var parts: [String] = []
+            if !entry.content.isEmpty {
+                parts.append(entry.content)
+            }
+            for call in calls {
+                let argsValue: Any
+                if let data = call.arguments.data(using: .utf8),
+                   let parsed = try? JSONSerialization.jsonObject(with: data) {
+                    argsValue = parsed
+                } else {
+                    argsValue = [String: Any]()
+                }
+                let callObj: [String: Any] = ["name": call.toolName, "arguments": argsValue]
+                if let data = try? JSONSerialization.data(withJSONObject: callObj),
+                   let jsonStr = String(data: data, encoding: .utf8) {
+                    parts.append("<tool_call>\n\(jsonStr)\n</tool_call>")
+                }
+            }
+            return ["role": "assistant", "content": parts.joined(separator: "\n")]
+        }
+
+        // Tool result turn: pass role and content as-is.
+        // The Qwen tokenizer template handles `role: "tool"` natively.
+        return ["role": entry.role, "content": entry.content]
+    }
+
+    private static func chatRole(for role: String) -> Chat.Message.Role {
+        switch role {
+        case "assistant": .assistant
+        case "system": .system
+        case "tool": .tool
+        default: .user
+        }
+    }
+
+    private static func userInputImage(from data: Data, mimeType: String) throws -> UserInput.Image {
+        guard let image = CIImage(data: data) else {
+            throw InferenceError.inferenceFailure(
+                "Unsupported image attachment format (\(mimeType))."
+            )
+        }
+        return .ciImage(image)
+    }
+
+    private static func imageInputs(from parts: [MessagePart]) throws -> [UserInput.Image] {
+        try parts.compactMap { part in
+            guard case let .image(data, mimeType, _) = part else { return nil }
+            return try userInputImage(from: data, mimeType: mimeType)
+        }
+    }
+
+    private static func plainChatMessages(
+        history: [StructuredMessage],
+        systemPrompt: String?
+    ) throws -> [Chat.Message]? {
+        let containsImages = history.contains { message in
+            message.parts.contains { part in
+                if case .image = part { return true }
+                return false
+            }
+        }
+        guard containsImages else { return nil }
+
+        var messages: [Chat.Message] = []
+        if let systemPrompt, !systemPrompt.isEmpty {
+            messages.append(.system(systemPrompt))
+        }
+        for message in history {
+            messages.append(
+                Chat.Message(
+                    role: chatRole(for: message.role),
+                    content: message.textContent,
+                    images: try imageInputs(from: message.parts)
+                )
+            )
+        }
+        return messages
+    }
+
+    private static func toolAwareChatMessages(
+        structuredHistory: [StructuredMessage],
+        toolAwareHistory: [ToolAwareHistoryEntry],
+        systemPrompt: String?,
+        dialect: MLXToolDialect
+    ) throws -> [Chat.Message]? {
+        guard structuredHistory.contains(where: { message in
+            message.parts.contains { part in
+                if case .image = part { return true }
+                return false
+            }
+        }) else {
+            return nil
+        }
+
+        var messages: [Chat.Message] = []
+        if let systemPrompt, !systemPrompt.isEmpty {
+            messages.append(.system(systemPrompt))
+        }
+
+        let structuredImageParts = try structuredHistory.map { try imageInputs(from: $0.parts) }
+        for (index, entry) in toolAwareHistory.enumerated() {
+            let encoded = encodeToolAwareEntryAsText(entry, dialect: dialect)
+            let role = encoded["role"] ?? entry.role
+            let content = encoded["content"] ?? entry.content
+            let images = index < structuredImageParts.count ? structuredImageParts[index] : []
+            messages.append(
+                Chat.Message(
+                    role: chatRole(for: role),
+                    content: content,
+                    images: images
+                )
+            )
+        }
+
+        if toolAwareHistory.count < structuredHistory.count {
+            for (offset, structuredMessage) in structuredHistory.dropFirst(toolAwareHistory.count).enumerated() {
+                let images = structuredImageParts[toolAwareHistory.count + offset]
+                messages.append(
+                    Chat.Message(
+                        role: chatRole(for: structuredMessage.role),
+                        content: structuredMessage.textContent,
+                        images: images
+                    )
+                )
+            }
+        }
+
+        return messages
+    }
+}
+#endif

--- a/Sources/ManifoldMLX/MLXModelProbe.swift
+++ b/Sources/ManifoldMLX/MLXModelProbe.swift
@@ -1,0 +1,255 @@
+#if MLX
+import Foundation
+import ManifoldInference
+
+/// Probes MLX model directories for architecture, factory routing, and manifest metadata.
+enum MLXModelProbe {
+    /// Canonical `model_type` values that `mlx-swift-lm`'s `LLMTypeRegistry.shared`
+    /// can serve as chat/instruct LMs. Anything outside this set (or the
+    /// VLM-specific set below) — CLIP, SigLIP, Whisper, BERT embeddings, etc. —
+    /// is refused at load time via `InferenceError.unsupportedModelArchitecture`.
+    ///
+    /// Sourced from `LLMTypeRegistry.shared` in mlx-swift-lm
+    /// (`Libraries/MLXLLM/LLMModelFactory.swift`). When mlx-swift-lm adds a new
+    /// LM architecture, update this list to match so the preflight doesn't reject
+    /// a freshly supported model.
+    static let supportedLMArchitectures: Set<String> = [
+        "mistral", "llama", "phi", "phi3", "phimoe",
+        "gemma", "gemma2", "gemma3", "gemma3_text", "gemma3n", "gemma4",
+        "qwen2", "qwen3", "qwen3_moe", "qwen3_next",
+        "qwen3_5", "qwen3_5_moe", "qwen3_5_text",
+        "minicpm", "starcoder2", "cohere", "openelm", "internlm2",
+        "deepseek_v3", "granite", "granitemoehybrid",
+        "mimo", "mimo_v2_flash", "minimax",
+        "glm4", "glm4_moe", "glm4_moe_lite",
+        "acereason", "falcon_h1", "bitnet", "smollm3",
+        "ernie4_5", "lfm2", "lfm2_moe",
+        "baichuan_m1", "exaone4", "gpt_oss",
+        "lille-130m", "olmoe", "olmo2", "olmo3",
+        "bailing_moe", "nanochat", "nemotron_h",
+        "afmoe", "jamba_3b", "mistral3", "apertus",
+    ]
+
+    static let supportedVLMArchitectures: Set<String> = [
+        "paligemma", "qwen2_vl", "qwen2_5_vl", "qwen3_vl",
+        "qwen3_5", "qwen3_5_moe", "idefics3", "gemma3", "gemma4",
+        "smolvlm", "fastvlm", "llava_qwen2", "pixtral", "mistral3",
+        "lfm2_vl", "lfm2-vl", "glm_ocr",
+    ]
+
+    private static let normalizedSupportedArchitectures: Set<String> =
+        Set((supportedLMArchitectures.union(supportedVLMArchitectures)).map(normalizeArchitectureKey))
+
+    static func normalizeArchitectureKey(_ value: String) -> String {
+        value.lowercased().unicodeScalars
+            .filter { CharacterSet.alphanumerics.contains($0) }
+            .map(String.init)
+            .joined()
+    }
+
+    /// Reads `config.json` at `url` and throws
+    /// `InferenceError.unsupportedModelArchitecture` if the declared `model_type`
+    /// is not a chat/instruct LM. If `config.json` is missing or unreadable the
+    /// check is a no-op — mlx-swift-lm's own load path will then surface the
+    /// real error (missing weights, malformed directory, etc.).
+    static func validateArchitecture(at url: URL) throws {
+        let configURL = url.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: configURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            // Missing / malformed config.json: let the MLX load path produce the
+            // real diagnostic rather than masking it with a false architecture error.
+            return
+        }
+
+        let modelType = (json["model_type"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let normalizedModelType = normalizeArchitectureKey(modelType)
+        if !normalizedModelType.isEmpty,
+           normalizedSupportedArchitectures.contains(normalizedModelType) {
+            return
+        }
+
+        // Some HF repos omit model_type but include an `architectures` array
+        // (e.g. ["LlamaForCausalLM"]). Accept the load if any entry's snake_case
+        // prefix matches the allowlist — this keeps older snapshots working.
+        if let archs = json["architectures"] as? [String] {
+            for arch in archs {
+                let normalized = normalizeArchitectureKey(arch)
+                if Self.normalizedSupportedArchitectures.contains(where: { normalized.hasPrefix($0) }) {
+                    return
+                }
+            }
+        }
+
+        let reported = modelType.isEmpty ? (json["architectures"] as? [String])?.joined(separator: ",") ?? "unknown" : modelType
+        throw InferenceError.unsupportedModelArchitecture(reported)
+    }
+
+    /// Returns `true` when the model at `url` must load through the VLM factory.
+    ///
+    /// This covers both explicit multimodal models (`vision_config`) and the
+    /// Gemma 4 MoE path that only exists behind `VLMModelFactory` today.
+    ///
+    /// Falls back to `false` (LLM factory) when config.json is missing/unreadable —
+    /// matches the same conservative default used by `validateArchitecture`. Dense
+    /// Gemma 4 models intentionally stay on the LLM factory so we don't pay the
+    /// memory cost of resident vision-tower weights.
+    static func requiresVLMFactory(at url: URL) -> Bool {
+        requiresVLMFactory(at: url, precomputedCapabilities: nil)
+    }
+
+    /// Variant that accepts pre-computed capabilities to avoid re-reading
+    /// `config.json` when the caller already ran ``ModelCapabilityProbe``.
+    static func requiresVLMFactory(
+        at url: URL,
+        precomputedCapabilities capabilities: ModelCapabilities?
+    ) -> Bool {
+        // Fast path: vision was already detected by the caller's probe run.
+        if let capabilities {
+            if capabilities.supportsVision { return true }
+        } else {
+            do {
+                if try ModelCapabilityProbe.probe(modelDirectory: url).supportsVision {
+                    return true
+                }
+            } catch {
+                Log.inference.info(
+                    "MLX capability probe failed for \(url.lastPathComponent, privacy: .public); falling back to config.json routing (\(error.localizedDescription, privacy: .public))"
+                )
+            }
+        }
+        // MoE fallback: Gemma 4 26B ships `text_config.enable_moe_block = true`
+        // and its MoE decoder only exists in the VLM factory today.
+        let configURL = url.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: configURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return false
+        }
+        if let textConfig = json["text_config"] as? [String: Any],
+           textConfig["enable_moe_block"] as? Bool == true {
+            return true
+        }
+        return false
+    }
+
+    /// Reads `tokenizer_config.json` inside `url` and returns the best-matching
+    /// thinking-marker preset for the chat template it declares.
+    ///
+    /// Best-effort: a missing or unreadable `tokenizer_config.json`, or one
+    /// without a `chat_template` field, returns `nil`. The MLX tokenizer object
+    /// in `mlx-swift-lm` exposes the chat template through Hugging Face's
+    /// swift-transformers, but reaching it requires opening a `ModelContainer`
+    /// session — reading the on-disk JSON directly is faster and avoids
+    /// tying up the GPU during the load.
+    ///
+    /// - Parameter url: The model directory URL (same one passed to
+    ///   `MLXBackend.loadModel(from:plan:)`).
+    /// - Returns: The auto-detected ``ThinkingMarkers`` or `nil` if no known
+    ///   marker pair is present in the template.
+    static func detectThinkingMarkers(at url: URL) -> ThinkingMarkers? {
+        let configURL = url.appendingPathComponent("tokenizer_config.json")
+        guard let data = try? Data(contentsOf: configURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            // Missing / unreadable tokenizer_config.json is expected for some
+            // model layouts (older snapshots, partial downloads). Don't warn —
+            // callers explicitly opt out of thinking parsing when this is nil.
+            return nil
+        }
+
+        // `chat_template` is a single string for most HF tokenizers, but a
+        // small number of repos ship an array of `{name, template}` entries
+        // (multi-template configs). When that happens, sniff the first entry
+        // whose name is `default` (or the first entry overall).
+        let templateString: String? = {
+            if let s = json["chat_template"] as? String { return s }
+            if let arr = json["chat_template"] as? [[String: Any]] {
+                if let def = arr.first(where: { ($0["name"] as? String)?.lowercased() == "default" }),
+                   let s = def["template"] as? String {
+                    return s
+                }
+                if let s = arr.first?["template"] as? String { return s }
+            }
+            return nil
+        }()
+        guard let template = templateString else { return nil }
+        return ThinkingMarkers.fromChatTemplate(template)
+    }
+
+    /// Produces a ``ModelManifest`` from a freshly-loaded MLX model directory.
+    ///
+    /// Reads `config.json` to extract the true context window:
+    /// `text_config.max_position_embeddings` (preferred for VLM/MoE configs),
+    /// `max_position_embeddings`, or `model_max_length` as a final fallback.
+    /// Combines with the chat-template-detected ``ThinkingMarkers`` and the
+    /// vision-capability flag to populate the manifest.
+    ///
+    /// Falls back to ``ModelManifest/unknown(modelIdentifier:producerKind:)``
+    /// (with a `Log.warn`) when `config.json` is missing or carries no
+    /// position-embedding hint. The conservative default (8k) keeps prompts
+    /// shorter than necessary on misconfigured snapshots, which is safer than
+    /// over-trimming or over-feeding the model.
+    static func produceManifest(
+        at url: URL,
+        detectedThinkingMarkers: ThinkingMarkers?,
+        supportsVision: Bool
+    ) -> ModelManifest {
+        let modelIdentifier = url.lastPathComponent
+        let configURL = url.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: configURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            Log.inference.warning(
+                "MLX manifest probe: config.json missing or unreadable for \(modelIdentifier, privacy: .public); falling back to ModelManifest.unknown"
+            )
+            return .unknown(modelIdentifier: modelIdentifier, producerKind: .local)
+        }
+
+        let contextWindow = extractContextWindow(from: json)
+            ?? {
+                Log.inference.warning(
+                    "MLX manifest probe: no max_position_embeddings / model_max_length found for \(modelIdentifier, privacy: .public); falling back to 8192"
+                )
+                return 8192
+            }()
+
+        return ModelManifest(
+            contextWindow: contextWindow,
+            supportsTools: true,
+            supportsThinking: detectedThinkingMarkers != nil,
+            thinkingMarkers: detectedThinkingMarkers,
+            supportsSeed: true,
+            supportedSamplingParameters: [
+                .temperature, .topP, .topK, .repeatPenalty,
+                .presencePenalty, .frequencyPenalty,
+            ],
+            modelIdentifier: modelIdentifier,
+            producerKind: .local
+        )
+    }
+
+    /// Pulls the model's max position embedding count out of an MLX
+    /// `config.json` payload. Returns `nil` when no recognised key is present.
+    static func extractContextWindow(from json: [String: Any]) -> Int? {
+        // Modern multi-modal configs nest the text encoder fields under
+        // `text_config`. Prefer that over the top-level keys when present.
+        if let textConfig = json["text_config"] as? [String: Any],
+           let value = positiveInt(from: textConfig["max_position_embeddings"]) {
+            return value
+        }
+        if let value = positiveInt(from: json["max_position_embeddings"]) {
+            return value
+        }
+        if let value = positiveInt(from: json["model_max_length"]) {
+            return value
+        }
+        return nil
+    }
+
+    static func positiveInt(from value: Any?) -> Int? {
+        if let int = value as? Int, int > 0 { return int }
+        if let int64 = value as? Int64, int64 > 0 { return Int(int64) }
+        if let double = value as? Double, double > 0 { return Int(double) }
+        if let str = value as? String, let parsed = Int(str), parsed > 0 { return parsed }
+        return nil
+    }
+}
+#endif

--- a/Sources/ManifoldMLX/MLXPromptCacheCoordinator.swift
+++ b/Sources/ManifoldMLX/MLXPromptCacheCoordinator.swift
@@ -1,0 +1,250 @@
+#if MLX
+import Foundation
+@preconcurrency import MLX
+import MLXLMCommon
+import ManifoldInference
+
+/// Coordinates prompt KV-cache reuse for `MLXBackend`.
+enum MLXPromptCacheCoordinator {
+    struct CachedLayerState {
+        let cacheTypeName: String
+        let offset: Int
+        let state: [MLXArray]
+        let metaState: [String]
+    }
+
+    struct Snapshot {
+        let promptTokens: [Int]
+        let layers: [CachedLayerState]
+    }
+
+    struct State {
+        var snapshot: Snapshot?
+        var pendingSnapshotTask: Task<Void, Never>?
+        var writeToken: UInt64 = 0
+
+        mutating func invalidate() {
+            pendingSnapshotTask?.cancel()
+            pendingSnapshotTask = nil
+            snapshot = nil
+            writeToken &+= 1
+        }
+
+        var hasSnapshotOrPending: Bool {
+            snapshot != nil || pendingSnapshotTask != nil
+        }
+
+        var isSnapshotReady: Bool {
+            snapshot != nil && pendingSnapshotTask == nil
+        }
+    }
+
+    struct SnapshotCaptureInputs {
+        let cache: MLXPromptCache
+        let promptTokenIds: [Int]
+    }
+
+    /// Result of `prepareInputAndCache(...)`.
+    struct PreparedGenerationInputs {
+        let generationInput: MLXPreparedInput
+        let cache: MLXPromptCache
+        /// Captured prompt token IDs when KV-cache reuse is eligible — used to
+        /// snapshot the cache after generation finishes. `nil` otherwise.
+        let promptTokenIds: [Int]?
+        /// Number of leading prompt tokens whose KV state was restored from
+        /// the previous turn. `0` when no reuse occurred.
+        let reuseLen: Int
+    }
+
+    static func longestCommonPrefixLength(_ lhs: [Int], _ rhs: [Int]) -> Int {
+        zip(lhs, rhs).prefix(while: { $0 == $1 }).count
+    }
+
+    /// Prepares the model input, allocates a KV cache, and applies the
+    /// longest-common-prefix reuse heuristic when an eligible snapshot exists.
+    ///
+    /// **CRITICAL:** the reuse path here is byte-identical to the inline
+    /// version it replaced — `longestCommonPrefixLength` clamped to
+    /// `promptTokenIds.count - 1`, gated by `isSupportedPromptCache` and
+    /// `promptTokenIds.count > 1`. Behaviour drift here corrupts the KV cache
+    /// across turns (see v0.5.3 incident).
+    @MainActor
+    static func prepareInputAndCache(
+        container: any MLXModelContainerProtocol,
+        chatMessages: [Chat.Message]?,
+        messages: [[String: String]],
+        generateConfig: GenerateParameters,
+        kvCacheReuseEligible: Bool,
+        snapshot: Snapshot?
+    ) async throws -> PreparedGenerationInputs {
+        let preparedInput =
+            if let chatMessages {
+                try await container.prepare(chat: SendableChatMessages(chatMessages))
+            } else {
+                try await container.prepare(messages: messages)
+            }
+        let cache = try await container.makeCache(parameters: generateConfig)
+        let promptTokenIds: [Int]? = if kvCacheReuseEligible {
+            preparedInput.promptTokenIds
+        } else {
+            nil
+        }
+
+        var generationInput = preparedInput
+        var reuseLen = 0
+        if kvCacheReuseEligible,
+           let snapshot,
+           let promptTokenIds,
+           isSupportedPromptCache(cache.value),
+           promptTokenIds.count > 1 {
+            let commonPrefixLen = longestCommonPrefixLength(
+                promptTokenIds,
+                snapshot.promptTokens
+            )
+            let candidate = min(commonPrefixLen, promptTokenIds.count - 1)
+            if candidate > 0,
+               restorePromptCache(snapshot, into: cache, reusedPromptTokenCount: candidate) {
+                generationInput = preparedInput.suffix(from: candidate)
+                reuseLen = candidate
+            }
+        }
+
+        return PreparedGenerationInputs(
+            generationInput: generationInput,
+            cache: cache,
+            promptTokenIds: promptTokenIds,
+            reuseLen: reuseLen
+        )
+    }
+
+    static func isSupportedPromptCache(_ caches: [any KVCache]) -> Bool {
+        !caches.isEmpty && caches.allSatisfy { $0 is KVCacheSimple }
+    }
+
+    static func makeSnapshotCaptureTask(
+        cache: MLXPromptCache,
+        promptTokenIds: [Int],
+        writeToken: UInt64,
+        store: @escaping @MainActor @Sendable (UInt64, Snapshot?) -> Void
+    ) -> Task<Void, Never> {
+        Task<Void, Never> { @MainActor in
+            let snapshot = capturePromptCacheSnapshot(
+                from: cache,
+                promptTokens: promptTokenIds
+            )
+            store(writeToken, snapshot)
+        }
+    }
+
+    /// Captures prompt-only KV state for the next turn.
+    ///
+    /// Contract assumptions taken from the currently pinned `mlx-swift-lm`:
+    /// 1. `LanguageModel.prepare(_:cache:windowSize:)` consumes any cached prefix
+    ///    from the front of the prepared prompt and only evaluates the remaining
+    ///    suffix, so restored caches must be paired with the uncached prompt tail.
+    /// 2. `KVCacheSimple.copy()/state/metaState/trim(_:)` are sufficient to clone
+    ///    and shrink prompt-only state safely for text-only models.
+    /// 3. Future `mlx-swift-lm` bumps must rerun the MLX KV-cache integration and
+    ///    performance suite before this contract is trusted unchanged.
+    ///
+    /// Marked `@MainActor` because every MLX call here (`copy()`, `eval`,
+    /// `state` slicing, `trim`) shares the same single-threaded GPU scheduler
+    /// as `ModelContainer.generate()`; running off-main risks racy crashes /
+    /// cache corruption.
+    @MainActor
+    static func capturePromptCacheSnapshot(
+        from cache: MLXPromptCache,
+        promptTokens: [Int]
+    ) -> Snapshot? {
+        guard !promptTokens.isEmpty, isSupportedPromptCache(cache.value) else {
+            return nil
+        }
+        // Early-exit if the surrounding generation task was cancelled — `copy()`
+        // and `eval` materialise full prompt-prefix tensors per layer, which is
+        // expensive enough to be worth skipping when a reset/unload already
+        // invalidated the snapshot we'd be writing.
+        if Task.isCancelled { return nil }
+
+        var layers: [CachedLayerState] = []
+        layers.reserveCapacity(cache.value.count)
+        for original in cache.value {
+            if Task.isCancelled { return nil }
+            guard original.offset >= promptTokens.count else {
+                return nil
+            }
+
+            if original.state.isEmpty {
+                layers.append(
+                    CachedLayerState(
+                        cacheTypeName: String(describing: type(of: original)),
+                        offset: promptTokens.count,
+                        state: [],
+                        metaState: original.metaState
+                    )
+                )
+                continue
+            }
+
+            let copy = original.copy()
+            eval([copy])
+
+            let excess = copy.offset - promptTokens.count
+            if excess > 0 {
+                guard copy.isTrimmable, copy.trim(excess) == excess else {
+                    return nil
+                }
+            }
+
+            let state = copy.state.map { $0[.ellipsis] }
+            eval(state)
+            layers.append(
+                CachedLayerState(
+                    cacheTypeName: String(describing: type(of: copy)),
+                    offset: copy.offset,
+                    state: state,
+                    metaState: copy.metaState
+                )
+            )
+        }
+        return Snapshot(promptTokens: promptTokens, layers: layers)
+    }
+
+    private static func restorePromptCache(
+        _ snapshot: Snapshot,
+        into cache: MLXPromptCache,
+        reusedPromptTokenCount: Int
+    ) -> Bool {
+        guard reusedPromptTokenCount > 0,
+              cache.value.count == snapshot.layers.count,
+              isSupportedPromptCache(cache.value) else {
+            return false
+        }
+
+        for (index, layer) in snapshot.layers.enumerated() {
+            var target = cache.value[index]
+            guard String(describing: type(of: target)) == layer.cacheTypeName else {
+                return false
+            }
+            if layer.state.isEmpty {
+                guard let target = target as? KVCacheSimple else { return false }
+                target.offset = layer.offset
+                target.metaState = layer.metaState
+            } else {
+                target.state = layer.state.map { $0[.ellipsis] }
+                target.metaState = layer.metaState
+            }
+
+            guard target.offset >= reusedPromptTokenCount else { return false }
+            let excess = target.offset - reusedPromptTokenCount
+            if excess > 0 {
+                guard target.isTrimmable, target.trim(excess) == excess else {
+                    return false
+                }
+            }
+        }
+
+        eval(cache.value)
+        return true
+    }
+}
+#endif

--- a/Tests/ManifoldBackendsTests/MLXBackendHelpersTests.swift
+++ b/Tests/ManifoldBackendsTests/MLXBackendHelpersTests.swift
@@ -4,16 +4,16 @@ import ManifoldInference
 @testable import ManifoldBackends
 @testable import ManifoldMLX
 
-/// Unit tests for the pure helpers extracted from `MLXBackend.generate` (#964).
+/// Unit tests for the chat-message encoding helpers extracted from `MLXBackend.generate` (#1113).
 ///
 /// These run in CI without Apple Silicon — every helper is value-in / value-out
 /// and never touches the MLX runtime or Metal stack.
-final class MLXBackendHelpersTests: XCTestCase {
+final class MLXChatMessageEncoderTests: XCTestCase {
 
     // MARK: - buildQwenToolBlock
 
     func test_buildQwenToolBlock_returnsNilWhenNoTools() {
-        let block = MLXBackend.buildQwenToolBlock(
+        let block = MLXChatMessageEncoder.buildQwenToolBlock(
             config: GenerationConfig(),
             dialect: .qwen25
         )
@@ -25,7 +25,7 @@ final class MLXBackendHelpersTests: XCTestCase {
         config.tools = [
             ToolDefinition(name: "echo", description: "Echo input", parameters: .object([:]))
         ]
-        let block = MLXBackend.buildQwenToolBlock(config: config, dialect: .unknown)
+        let block = MLXChatMessageEncoder.buildQwenToolBlock(config: config, dialect: .unknown)
         XCTAssertNil(block)
     }
 
@@ -44,7 +44,7 @@ final class MLXBackendHelpersTests: XCTestCase {
                 ])
             )
         ]
-        let block = MLXBackend.buildQwenToolBlock(config: config, dialect: .qwen25)
+        let block = MLXChatMessageEncoder.buildQwenToolBlock(config: config, dialect: .qwen25)
         XCTAssertNotNil(block)
         XCTAssertTrue(block!.contains("<tools>"))
         XCTAssertTrue(block!.contains("</tools>"))
@@ -55,8 +55,126 @@ final class MLXBackendHelpersTests: XCTestCase {
         XCTAssertTrue(block!.contains("</tool_call>"))
     }
 
-    // MARK: - resolveThinkingMarkers
+    // MARK: - buildChatMessages
 
+    func test_buildChatMessages_fallsBackToBarePromptWhenNoHistory() throws {
+        let (chatMessages, messages) = try MLXChatMessageEncoder.buildChatMessages(
+            prompt: "hi there",
+            effectiveSystemPrompt: nil,
+            conversationHistory: [],
+            toolAwareHistory: nil,
+            structuredHistory: nil,
+            dialect: .unknown
+        )
+        XCTAssertNil(chatMessages, "no images → no Chat.Message path")
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0]["role"], "user")
+        XCTAssertEqual(messages[0]["content"], "hi there")
+    }
+
+    func test_buildChatMessages_prependsSystemPromptWhenSet() throws {
+        let (_, messages) = try MLXChatMessageEncoder.buildChatMessages(
+            prompt: "hi",
+            effectiveSystemPrompt: "You are helpful.",
+            conversationHistory: [],
+            toolAwareHistory: nil,
+            structuredHistory: nil,
+            dialect: .unknown
+        )
+        XCTAssertEqual(messages.count, 2)
+        XCTAssertEqual(messages[0]["role"], "system")
+        XCTAssertEqual(messages[0]["content"], "You are helpful.")
+        XCTAssertEqual(messages[1]["role"], "user")
+        XCTAssertEqual(messages[1]["content"], "hi")
+    }
+
+    func test_buildChatMessages_replaysConversationHistoryWhenSet() throws {
+        let (_, messages) = try MLXChatMessageEncoder.buildChatMessages(
+            prompt: "ignored when history present",
+            effectiveSystemPrompt: nil,
+            conversationHistory: [
+                (role: "user", content: "first"),
+                (role: "assistant", content: "ack"),
+                (role: "user", content: "second")
+            ],
+            toolAwareHistory: nil,
+            structuredHistory: nil,
+            dialect: .unknown
+        )
+        XCTAssertEqual(messages.count, 3)
+        XCTAssertEqual(messages.map { $0["content"] }, ["first", "ack", "second"])
+        XCTAssertEqual(messages.map { $0["role"] }, ["user", "assistant", "user"])
+    }
+
+    func test_buildChatMessages_toolAwareHistorySupersedesPlain() throws {
+        let toolEntry = ToolAwareHistoryEntry(
+            role: "user",
+            content: "what's the weather?"
+        )
+        let (_, messages) = try MLXChatMessageEncoder.buildChatMessages(
+            prompt: "ignored",
+            effectiveSystemPrompt: nil,
+            conversationHistory: [(role: "user", content: "plain history that should NOT appear")],
+            toolAwareHistory: [toolEntry],
+            structuredHistory: nil,
+            dialect: .qwen25
+        )
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0]["role"], "user")
+        XCTAssertEqual(messages[0]["content"], "what's the weather?")
+    }
+
+    func test_buildChatMessages_returnsNilChatMessagesWhenStructuredHistoryHasNoImages() throws {
+        let history = [
+            StructuredMessage(role: "user", content: "text only"),
+            StructuredMessage(role: "assistant", content: "still text")
+        ]
+        let (chatMessages, _) = try MLXChatMessageEncoder.buildChatMessages(
+            prompt: "ignored",
+            effectiveSystemPrompt: nil,
+            conversationHistory: [],
+            toolAwareHistory: nil,
+            structuredHistory: history,
+            dialect: .unknown
+        )
+        XCTAssertNil(chatMessages, "vision path stays off when no .image parts present")
+    }
+
+    func test_buildChatMessages_returnsChatMessagesWhenStructuredHistoryHasImages() throws {
+        // 1×1 PNG (smallest valid) so CIImage(data:) succeeds.
+        let pngBytes: [UInt8] = [
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+            0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+            0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+            0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41,
+            0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+            0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+            0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+            0x42, 0x60, 0x82
+        ]
+        let pngData = Data(pngBytes)
+        let history = [
+            StructuredMessage(role: "user", parts: [
+                .text("describe this"),
+                .image(data: pngData, mimeType: "image/png")
+            ])
+        ]
+        let (chatMessages, _) = try MLXChatMessageEncoder.buildChatMessages(
+            prompt: "ignored",
+            effectiveSystemPrompt: "system!",
+            conversationHistory: [],
+            toolAwareHistory: nil,
+            structuredHistory: history,
+            dialect: .unknown
+        )
+        XCTAssertNotNil(chatMessages)
+        XCTAssertEqual(chatMessages?.count, 2, "system + user")
+    }
+}
+
+/// Unit tests for the small thinking-marker resolution helper retained on `MLXBackend`.
+final class MLXBackendThinkingMarkerResolutionTests: XCTestCase {
     func test_resolveThinkingMarkers_returnsNilWhenMaxThinkingTokensIsZero() {
         var config = GenerationConfig()
         config.maxThinkingTokens = 0
@@ -95,121 +213,5 @@ final class MLXBackendHelpersTests: XCTestCase {
         XCTAssertNil(resolved)
     }
 
-    // MARK: - buildChatMessages
-
-    func test_buildChatMessages_fallsBackToBarePromptWhenNoHistory() throws {
-        let (chatMessages, messages) = try MLXBackend.buildChatMessages(
-            prompt: "hi there",
-            effectiveSystemPrompt: nil,
-            conversationHistory: [],
-            toolAwareHistory: nil,
-            structuredHistory: nil,
-            dialect: .unknown
-        )
-        XCTAssertNil(chatMessages, "no images → no Chat.Message path")
-        XCTAssertEqual(messages.count, 1)
-        XCTAssertEqual(messages[0]["role"], "user")
-        XCTAssertEqual(messages[0]["content"], "hi there")
-    }
-
-    func test_buildChatMessages_prependsSystemPromptWhenSet() throws {
-        let (_, messages) = try MLXBackend.buildChatMessages(
-            prompt: "hi",
-            effectiveSystemPrompt: "You are helpful.",
-            conversationHistory: [],
-            toolAwareHistory: nil,
-            structuredHistory: nil,
-            dialect: .unknown
-        )
-        XCTAssertEqual(messages.count, 2)
-        XCTAssertEqual(messages[0]["role"], "system")
-        XCTAssertEqual(messages[0]["content"], "You are helpful.")
-        XCTAssertEqual(messages[1]["role"], "user")
-        XCTAssertEqual(messages[1]["content"], "hi")
-    }
-
-    func test_buildChatMessages_replaysConversationHistoryWhenSet() throws {
-        let (_, messages) = try MLXBackend.buildChatMessages(
-            prompt: "ignored when history present",
-            effectiveSystemPrompt: nil,
-            conversationHistory: [
-                (role: "user", content: "first"),
-                (role: "assistant", content: "ack"),
-                (role: "user", content: "second")
-            ],
-            toolAwareHistory: nil,
-            structuredHistory: nil,
-            dialect: .unknown
-        )
-        XCTAssertEqual(messages.count, 3)
-        XCTAssertEqual(messages.map { $0["content"] }, ["first", "ack", "second"])
-        XCTAssertEqual(messages.map { $0["role"] }, ["user", "assistant", "user"])
-    }
-
-    func test_buildChatMessages_toolAwareHistorySupersedesPlain() throws {
-        let toolEntry = ToolAwareHistoryEntry(
-            role: "user",
-            content: "what's the weather?"
-        )
-        let (_, messages) = try MLXBackend.buildChatMessages(
-            prompt: "ignored",
-            effectiveSystemPrompt: nil,
-            conversationHistory: [(role: "user", content: "plain history that should NOT appear")],
-            toolAwareHistory: [toolEntry],
-            structuredHistory: nil,
-            dialect: .qwen25
-        )
-        XCTAssertEqual(messages.count, 1)
-        XCTAssertEqual(messages[0]["role"], "user")
-        XCTAssertEqual(messages[0]["content"], "what's the weather?")
-    }
-
-    func test_buildChatMessages_returnsNilChatMessagesWhenStructuredHistoryHasNoImages() throws {
-        let history = [
-            StructuredMessage(role: "user", content: "text only"),
-            StructuredMessage(role: "assistant", content: "still text")
-        ]
-        let (chatMessages, _) = try MLXBackend.buildChatMessages(
-            prompt: "ignored",
-            effectiveSystemPrompt: nil,
-            conversationHistory: [],
-            toolAwareHistory: nil,
-            structuredHistory: history,
-            dialect: .unknown
-        )
-        XCTAssertNil(chatMessages, "vision path stays off when no .image parts present")
-    }
-
-    func test_buildChatMessages_returnsChatMessagesWhenStructuredHistoryHasImages() throws {
-        // 1×1 PNG (smallest valid) so CIImage(data:) succeeds.
-        let pngBytes: [UInt8] = [
-            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
-            0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
-            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
-            0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
-            0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41,
-            0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
-            0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
-            0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
-            0x42, 0x60, 0x82
-        ]
-        let pngData = Data(pngBytes)
-        let history = [
-            StructuredMessage(role: "user", parts: [
-                .text("describe this"),
-                .image(data: pngData, mimeType: "image/png")
-            ])
-        ]
-        let (chatMessages, _) = try MLXBackend.buildChatMessages(
-            prompt: "ignored",
-            effectiveSystemPrompt: "system!",
-            conversationHistory: [],
-            toolAwareHistory: nil,
-            structuredHistory: history,
-            dialect: .unknown
-        )
-        XCTAssertNotNil(chatMessages)
-        XCTAssertEqual(chatMessages?.count, 2, "system + user")
-    }
 }
 #endif

--- a/Tests/ManifoldBackendsTests/MLXBackendTests.swift
+++ b/Tests/ManifoldBackendsTests/MLXBackendTests.swift
@@ -130,7 +130,7 @@ final class MLXBackendTests: XCTestCase {
     // MARK: - Architecture preflight (no hardware gate)
 
     /// Writes a throwaway `config.json` into a temp directory so we can exercise
-    /// `MLXBackend.validateArchitecture` without invoking the real MLX load path
+    /// `MLXModelProbe.validateArchitecture` without invoking the real MLX load path
     /// (which would trip the metallib guard in `swift test`).
     private func writeTempConfig(_ json: [String: Any]) throws -> URL {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory())
@@ -144,7 +144,7 @@ final class MLXBackendTests: XCTestCase {
 
     func test_validateArchitecture_acceptsQwen3() throws {
         let url = try writeTempConfig(["model_type": "qwen3"])
-        XCTAssertNoThrow(try MLXBackend.validateArchitecture(at: url))
+        XCTAssertNoThrow(try MLXModelProbe.validateArchitecture(at: url))
     }
 
     func test_validateArchitecture_acceptsGemma4() throws {
@@ -152,7 +152,7 @@ final class MLXBackendTests: XCTestCase {
         // mlx-swift-lm's LLMTypeRegistry in 3.31.3). Sabotage check: removing
         // "gemma4" from `supportedLMArchitectures` makes this throw.
         let url = try writeTempConfig(["model_type": "gemma4"])
-        XCTAssertNoThrow(try MLXBackend.validateArchitecture(at: url))
+        XCTAssertNoThrow(try MLXModelProbe.validateArchitecture(at: url))
     }
 
     func test_validateArchitecture_acceptsQwen25VL() throws {
@@ -160,19 +160,19 @@ final class MLXBackendTests: XCTestCase {
             "model_type": "qwen2_5_vl",
             "vision_config": ["hidden_size": 1]
         ])
-        XCTAssertNoThrow(try MLXBackend.validateArchitecture(at: url))
+        XCTAssertNoThrow(try MLXModelProbe.validateArchitecture(at: url))
     }
 
     func test_validateArchitecture_acceptsLlamaViaArchitectures() throws {
         // HF repos that omit `model_type` but ship `architectures: ["LlamaForCausalLM"]`
         // must still pass — snake_case prefix match keeps older snapshots working.
         let url = try writeTempConfig(["architectures": ["LlamaForCausalLM"]])
-        XCTAssertNoThrow(try MLXBackend.validateArchitecture(at: url))
+        XCTAssertNoThrow(try MLXModelProbe.validateArchitecture(at: url))
     }
 
     func test_validateArchitecture_rejectsVisionEncoder() throws {
         let url = try writeTempConfig(["model_type": "clip"])
-        XCTAssertThrowsError(try MLXBackend.validateArchitecture(at: url)) { error in
+        XCTAssertThrowsError(try MLXModelProbe.validateArchitecture(at: url)) { error in
             guard case InferenceError.unsupportedModelArchitecture(let arch) = error else {
                 return XCTFail("Expected .unsupportedModelArchitecture, got \(error)")
             }
@@ -184,7 +184,7 @@ final class MLXBackendTests: XCTestCase {
 
     func test_validateArchitecture_rejectsEmbeddings() throws {
         let url = try writeTempConfig(["model_type": "bert"])
-        XCTAssertThrowsError(try MLXBackend.validateArchitecture(at: url)) { error in
+        XCTAssertThrowsError(try MLXModelProbe.validateArchitecture(at: url)) { error in
             guard case InferenceError.unsupportedModelArchitecture = error else {
                 return XCTFail("Expected .unsupportedModelArchitecture, got \(error)")
             }
@@ -194,7 +194,7 @@ final class MLXBackendTests: XCTestCase {
     func test_validateArchitecture_rejectsVisionViaArchitectures() throws {
         // `model_type` missing, `architectures` says CLIPModel — must still be refused.
         let url = try writeTempConfig(["architectures": ["CLIPModel"]])
-        XCTAssertThrowsError(try MLXBackend.validateArchitecture(at: url)) { error in
+        XCTAssertThrowsError(try MLXModelProbe.validateArchitecture(at: url)) { error in
             guard case InferenceError.unsupportedModelArchitecture = error else {
                 return XCTFail("Expected .unsupportedModelArchitecture, got \(error)")
             }
@@ -208,7 +208,7 @@ final class MLXBackendTests: XCTestCase {
             .appendingPathComponent("mlx-arch-empty-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
-        XCTAssertNoThrow(try MLXBackend.validateArchitecture(at: dir))
+        XCTAssertNoThrow(try MLXModelProbe.validateArchitecture(at: dir))
     }
 
     // MARK: - VLM Factory Routing (issue #752, no hardware gate)
@@ -222,7 +222,7 @@ final class MLXBackendTests: XCTestCase {
         let url = try writeTempConfig([
             "text_config": ["enable_moe_block": true]
         ])
-        XCTAssertTrue(MLXBackend.requiresVLMFactory(at: url))
+        XCTAssertTrue(MLXModelProbe.requiresVLMFactory(at: url))
     }
 
     func test_requiresVLMFactory_whenVisionConfigPresent_returnsTrue() throws {
@@ -230,7 +230,7 @@ final class MLXBackendTests: XCTestCase {
             "model_type": "qwen2_5_vl",
             "vision_config": ["hidden_size": 1]
         ])
-        XCTAssertTrue(MLXBackend.requiresVLMFactory(at: url))
+        XCTAssertTrue(MLXModelProbe.requiresVLMFactory(at: url))
     }
 
     func test_requiresVLMFactory_whenTextConfigOmitsMoE_returnsFalse() throws {
@@ -241,14 +241,14 @@ final class MLXBackendTests: XCTestCase {
         let url = try writeTempConfig([
             "text_config": ["enable_moe_block": false]
         ])
-        XCTAssertFalse(MLXBackend.requiresVLMFactory(at: url))
+        XCTAssertFalse(MLXModelProbe.requiresVLMFactory(at: url))
     }
 
     func test_requiresVLMFactory_whenConfigHasNoTextConfig_returnsFalse() throws {
         // Regular LLMs (qwen3, llama, mistral, …) have a flat config.json with
         // no `text_config` block. They route through LLMModelFactory.
         let url = try writeTempConfig(["model_type": "qwen3"])
-        XCTAssertFalse(MLXBackend.requiresVLMFactory(at: url))
+        XCTAssertFalse(MLXModelProbe.requiresVLMFactory(at: url))
     }
 
     func test_requiresVLMFactory_whenConfigMissing_returnsFalse() throws {
@@ -258,7 +258,7 @@ final class MLXBackendTests: XCTestCase {
             .appendingPathComponent("mlx-vlm-empty-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
-        XCTAssertFalse(MLXBackend.requiresVLMFactory(at: dir))
+        XCTAssertFalse(MLXModelProbe.requiresVLMFactory(at: dir))
     }
 }
 

--- a/Tests/ManifoldBackendsTests/MLXManifestProbeTests.swift
+++ b/Tests/ManifoldBackendsTests/MLXManifestProbeTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import ManifoldMLX
 @testable import ManifoldInference
 
-/// Unit tests for ``MLXBackend/produceManifest(at:detectedThinkingMarkers:supportsVision:)``.
+/// Unit tests for ``MLXModelProbe/produceManifest(at:detectedThinkingMarkers:supportsVision:)``.
 ///
 /// These tests don't load real MLX weights — they construct a temporary
 /// directory with a synthetic `config.json` and assert the probe extracts the
@@ -38,7 +38,7 @@ final class MLXManifestProbeTests: XCTestCase {
             "max_position_embeddings": 32_768,
         ], in: dir)
 
-        let manifest = MLXBackend.produceManifest(
+        let manifest = MLXModelProbe.produceManifest(
             at: dir,
             detectedThinkingMarkers: nil,
             supportsVision: false
@@ -60,7 +60,7 @@ final class MLXManifestProbeTests: XCTestCase {
             ] as [String: Any],
         ], in: dir)
 
-        let manifest = MLXBackend.produceManifest(
+        let manifest = MLXModelProbe.produceManifest(
             at: dir,
             detectedThinkingMarkers: nil,
             supportsVision: false
@@ -79,7 +79,7 @@ final class MLXManifestProbeTests: XCTestCase {
             ] as [String: Any],
         ], in: dir)
 
-        let manifest = MLXBackend.produceManifest(
+        let manifest = MLXModelProbe.produceManifest(
             at: dir,
             detectedThinkingMarkers: nil,
             supportsVision: true
@@ -95,7 +95,7 @@ final class MLXManifestProbeTests: XCTestCase {
             "model_max_length": 16_384,
         ], in: dir)
 
-        let manifest = MLXBackend.produceManifest(
+        let manifest = MLXModelProbe.produceManifest(
             at: dir,
             detectedThinkingMarkers: nil,
             supportsVision: false
@@ -107,7 +107,7 @@ final class MLXManifestProbeTests: XCTestCase {
         let dir = try makeTempDir()
         // No config.json written.
 
-        let manifest = MLXBackend.produceManifest(
+        let manifest = MLXModelProbe.produceManifest(
             at: dir,
             detectedThinkingMarkers: nil,
             supportsVision: false
@@ -125,7 +125,7 @@ final class MLXManifestProbeTests: XCTestCase {
             "model_type": "minimal",
         ], in: dir)
 
-        let manifest = MLXBackend.produceManifest(
+        let manifest = MLXModelProbe.produceManifest(
             at: dir,
             detectedThinkingMarkers: nil,
             supportsVision: false
@@ -143,7 +143,7 @@ final class MLXManifestProbeTests: XCTestCase {
             "max_position_embeddings": 32_768,
         ], in: dir)
 
-        let manifest = MLXBackend.produceManifest(
+        let manifest = MLXModelProbe.produceManifest(
             at: dir,
             detectedThinkingMarkers: .qwen3,
             supportsVision: false

--- a/Tests/ManifoldBackendsTests/MLXPromptCacheCoordinatorTests.swift
+++ b/Tests/ManifoldBackendsTests/MLXPromptCacheCoordinatorTests.swift
@@ -1,0 +1,38 @@
+#if MLX
+import XCTest
+@testable import ManifoldMLX
+
+/// Unit tests for prompt-cache coordination helpers that do not touch MLX/Metal runtime state.
+final class MLXPromptCacheCoordinatorTests: XCTestCase {
+    func test_longestCommonPrefixLength_countsSharedHeadOnly() {
+        XCTAssertEqual(
+            MLXPromptCacheCoordinator.longestCommonPrefixLength([1, 2, 3, 4], [1, 2, 9, 4]),
+            2
+        )
+        XCTAssertEqual(
+            MLXPromptCacheCoordinator.longestCommonPrefixLength([7, 8], [7, 8, 9]),
+            2
+        )
+        XCTAssertEqual(
+            MLXPromptCacheCoordinator.longestCommonPrefixLength([1], [2]),
+            0
+        )
+    }
+
+    func test_stateInvalidateClearsSnapshotAndPendingTask() {
+        var state = MLXPromptCacheCoordinator.State()
+        let task = Task<Void, Never> { }
+        state.pendingSnapshotTask = task
+        state.snapshot = MLXPromptCacheCoordinator.Snapshot(promptTokens: [1, 2], layers: [])
+        let originalToken = state.writeToken
+
+        state.invalidate()
+
+        XCTAssertNil(state.snapshot)
+        XCTAssertNil(state.pendingSnapshotTask)
+        XCTAssertEqual(state.writeToken, originalToken + 1)
+        XCTAssertFalse(state.hasSnapshotOrPending)
+        XCTAssertFalse(state.isSnapshotReady)
+    }
+}
+#endif

--- a/Tests/ManifoldMLXIntegrationTests/Gemma4MoESmokeTests.swift
+++ b/Tests/ManifoldMLXIntegrationTests/Gemma4MoESmokeTests.swift
@@ -8,7 +8,7 @@ import ManifoldInference
 /// Real-inference smoke test for `mlx-community/gemma-4-26b-a4b-it-4bit`,
 /// the 26B Mixture-of-Experts Gemma 4 variant. Validates the VLM-factory
 /// routing added in PR #769 (closes #752): the model has
-/// `text_config.enable_moe_block: true`, so `MLXBackend.requiresVLMFactory`
+/// `text_config.enable_moe_block: true`, so `MLXModelProbe.requiresVLMFactory`
 /// should send it to `VLMModelFactory.shared.loadContainer` rather than the
 /// LLM factory's no-MoE `Gemma4Model`.
 ///
@@ -40,7 +40,7 @@ final class Gemma4MoESmokeTests: XCTestCase {
 
         // Sanity: the routing helper must agree with the on-disk config.
         XCTAssertTrue(
-            MLXBackend.requiresVLMFactory(at: modelURL),
+            MLXModelProbe.requiresVLMFactory(at: modelURL),
             "requiresVLMFactory should return true for the 26B MoE config"
         )
 

--- a/Tests/ManifoldMLXIntegrationTests/MLXKVPersistenceIntegrationTests.swift
+++ b/Tests/ManifoldMLXIntegrationTests/MLXKVPersistenceIntegrationTests.swift
@@ -31,7 +31,7 @@ final class MLXKVPersistenceIntegrationTests: XCTestCase {
             )
         }
         try XCTSkipIf(
-            MLXBackend.requiresVLMFactory(at: mlxDir),
+            MLXModelProbe.requiresVLMFactory(at: mlxDir),
             "KV-cache reuse v1 is intentionally limited to text-only MLX models; VLM/MoE fixtures are out of scope."
         )
         modelURL = mlxDir

--- a/Tests/ManifoldMLXIntegrationTests/MLXKVReuseIntegrationTests.swift
+++ b/Tests/ManifoldMLXIntegrationTests/MLXKVReuseIntegrationTests.swift
@@ -36,7 +36,7 @@ final class MLXKVReuseIntegrationTests: XCTestCase {
             )
         }
         try XCTSkipIf(
-            MLXBackend.requiresVLMFactory(at: mlxDir),
+            MLXModelProbe.requiresVLMFactory(at: mlxDir),
             "KV-cache reuse is gated off for VLMs — see MLXVLMGateExperimentTests for that path."
         )
         modelURL = mlxDir

--- a/Tests/ManifoldMLXIntegrationTests/MLXVLMGateExperimentTests.swift
+++ b/Tests/ManifoldMLXIntegrationTests/MLXVLMGateExperimentTests.swift
@@ -44,7 +44,7 @@ final class MLXVLMGateExperimentTests: XCTestCase {
 
         let resolved = try resolveVLMModelURL(selector: selector)
         try XCTSkipUnless(
-            MLXBackend.requiresVLMFactory(at: resolved),
+            MLXModelProbe.requiresVLMFactory(at: resolved),
             "MLX_VLM_TEST_MODEL=\(selector) does not resolve to a VLM (requiresVLMFactory returned false). Pick a model with vision_config or text_config.enable_moe_block."
         )
         modelURL = resolved


### PR DESCRIPTION
Part of #1113.

Summary:
- Extracts MLXPromptCacheCoordinator, MLXChatMessageEncoder, and MLXModelProbe.
- Keeps existing MLXGenerationDriver as the generation-loop owner.
- Updates MLX helper/probe/integration tests for the extracted collaborators.

LOC:
- MLXBackend.swift: 1,451 -> 747.

Validation:
- scripts/test.sh --filter ManifoldBackendsTests --disable-default-traits --skip-update
- swift build --build-tests --traits MLX --disable-default-traits
- Focused MLX helper/probe tests: 22 passed
- Code review pass: no KV-cache, trait-gating, actor-isolation, or API regressions found.

Risk:
- Real hardware-gated MLX integration suites were not run locally.
