### PR TITLE
refactor: decompose ClaudeBackend

### DIFF
--- a/Sources/ManifoldCloud/ClaudeBackend.swift
+++ b/Sources/ManifoldCloud/ClaudeBackend.swift
@@ -198,7 +198,7 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         //   4. prompt-only single user turn.
         let chatMessages: [[String: Any]]
         if let toolHistory = snapshotToolHistory, !toolHistory.isEmpty {
-            chatMessages = toolHistory.map(Self.encodeToolAwareEntry)
+            chatMessages = toolHistory.map(ClaudeMessageEncoder.encodeToolAwareEntry)
         } else if let structured = structuredHistory, !structured.isEmpty {
             // Per-turn image cap: Anthropic rejects more than 5 inline
             // base64 images on a single turn. Validate before serialising
@@ -224,7 +224,7 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
                     "Model \"\(modelName)\" does not support image input. Switch to a Claude 3, 3.5, 3.7, or 4 family model and retry."
                 )
             }
-            chatMessages = structured.map(Self.encodeMessageContent(for:))
+            chatMessages = structured.map(ClaudeMessageEncoder.encodeMessageContent(for:))
         } else if let history = conversationHistory {
             chatMessages = history.map { ["role": $0.role, "content": $0.content] }
         } else {
@@ -264,7 +264,7 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         // Anthropic's side; the framework-level `.none` suppresses the
         // tools field entirely so the model has nothing to call.
         if !config.tools.isEmpty, config.toolChoice != .none {
-            body["tools"] = config.tools.map(Self.encodeToolDefinition)
+            body["tools"] = config.tools.map(ClaudeMessageEncoder.encodeToolDefinition)
             switch config.toolChoice {
             case .auto:
                 // Anthropic defaults to auto when tool_choice is omitted.
@@ -293,233 +293,6 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
         return request
-    }
-
-    // MARK: - Structured Content Encoding
-
-    /// Encodes one ``StructuredMessage`` as an Anthropic Messages API
-    /// `messages[]` entry.
-    ///
-    /// - User turns collapse to a plain string `content` when they only
-    ///   carry text. When the turn carries one or more
-    ///   ``MessagePart/image(data:mimeType:)`` parts, the encoder emits a
-    ///   structured `content[]` with `image` blocks before any `text` block
-    ///   — the ordering Anthropic recommends so the model attends to the
-    ///   visual context first.
-    /// - Assistant turns serialize to a structured `content` array. Thinking
-    ///   blocks are emitted **before** any text block, with their
-    ///   ``MessagePart/thinkingSignature`` carried verbatim. Anthropic's
-    ///   multi-turn extended-thinking contract requires the signature to
-    ///   match what the model emitted on the previous turn, so any
-    ///   thinking block missing a signature is dropped rather than sent
-    ///   with a blank one (which would 400). Image parts on an assistant
-    ///   turn are unusual but supported — the model never emits them, but
-    ///   round-tripping a persisted assistant row with an image attached
-    ///   should not crash the encoder.
-    /// - System / tool turns fall back to plain string content.
-    static func encodeMessageContent(for message: StructuredMessage) -> [String: Any] {
-        if message.role == "assistant" {
-            var blocks: [[String: Any]] = []
-
-            // Thinking blocks first — Anthropic requires thinking content to
-            // precede any text/tool_use within the same assistant turn.
-            for part in message.parts {
-                if case .thinking(let text, let signature) = part {
-                    // Signature-less thinking blocks (legacy persisted rows
-                    // that pre-date #604, or local backends like MLX/Llama
-                    // where Anthropic never issued one) are dropped from the
-                    // replay payload. Sending them blank would fail the
-                    // server-side signature check and 400 the request.
-                    guard let signature else { continue }
-                    blocks.append([
-                        "type": "thinking",
-                        "thinking": text,
-                        "signature": signature
-                    ])
-                }
-            }
-
-            // Image blocks (rare on assistant turns; supported for
-            // round-trip parity with persisted rows).
-            for part in message.parts {
-                if case .image(let data, let mimeType, _) = part {
-                    blocks.append(encodeImageBlock(data: data, mimeType: mimeType))
-                }
-            }
-
-            // Then text. Concatenated into a single block to match how the
-            // model originally emitted its visible content.
-            let visible = message.textContent
-            if !visible.isEmpty {
-                blocks.append([
-                    "type": "text",
-                    "text": visible
-                ])
-            }
-
-            // An assistant turn with neither thinking nor text would 400.
-            // Emit a single empty text block in that pathological case so
-            // the wire shape is still valid and the server returns a normal
-            // error rather than a stream-level parse failure.
-            if blocks.isEmpty {
-                return ["role": "assistant", "content": ""]
-            }
-            return ["role": "assistant", "content": blocks]
-        }
-
-        // User and other roles. If any image parts are present, emit a
-        // structured content array with image blocks before the text block.
-        // Anthropic's vision examples lead with `image` then `text`; the
-        // model attends to images first when they precede the prompt.
-        let hasImage = message.parts.contains { part in
-            if case .image = part { return true }
-            return false
-        }
-        if message.role == "user", hasImage {
-            var blocks: [[String: Any]] = []
-            for part in message.parts {
-                if case .image(let data, let mimeType, _) = part {
-                    blocks.append(encodeImageBlock(data: data, mimeType: mimeType))
-                }
-            }
-            let text = message.textContent
-            if !text.isEmpty {
-                blocks.append(["type": "text", "text": text])
-            }
-            return ["role": "user", "content": blocks]
-        }
-
-        // System / tool / image-less user turns: collapse to plain text.
-        return ["role": message.role, "content": message.textContent]
-    }
-
-    /// Encodes a single image part as an Anthropic content block:
-    /// `{type:"image", source:{type:"base64", media_type:..., data:...}}`.
-    ///
-    /// Falls back to `image/png` for unrecognised MIME types — Anthropic
-    /// rejects exotic media types with a 400, but in practice every
-    /// persisted image is one of the four supported formats. The lenient
-    /// fallback keeps a corrupt mime field from blocking the entire turn.
-    static func encodeImageBlock(data: Data, mimeType: String) -> [String: Any] {
-        let normalised = mimeType.lowercased()
-        let mediaType = CloudImageEncoding.anthropicSupportedMimeTypes.contains(normalised)
-            ? normalised
-            : "image/png"
-        return [
-            "type": "image",
-            "source": [
-                "type": "base64",
-                "media_type": mediaType,
-                "data": CloudImageEncoding.base64String(from: data),
-            ] as [String: Any],
-        ]
-    }
-
-    // MARK: - Tool Encoding
-
-    /// Encodes a ``ToolDefinition`` into Anthropic's `tools[]` envelope:
-    /// `{name, description, input_schema}`. `input_schema` is the same
-    /// JSON Schema graph the rest of BCK uses; we round-trip it through
-    /// `JSONSerialization` via the shared
-    /// ``OpenAIToolEncoding/foundationJSON(from:)`` helper so the
-    /// resulting body is JSONSerialization-compatible.
-    static func encodeToolDefinition(_ tool: ToolDefinition) -> [String: Any] {
-        var entry: [String: Any] = [
-            "name": tool.name,
-            "description": tool.description,
-        ]
-        if let schema = encodeJSONSchemaToFoundation(tool.parameters) {
-            entry["input_schema"] = schema
-        } else {
-            entry["input_schema"] = ["type": "object", "properties": [String: Any]()]
-        }
-        return entry
-    }
-
-    /// Encodes one ``ToolAwareHistoryEntry`` for the Anthropic Messages
-    /// API `messages[]` array.
-    ///
-    /// Anthropic represents both tool calls and tool results as content
-    /// blocks rather than message roles:
-    ///
-    /// - Assistant turns that requested tools serialise as
-    ///   `{role:"assistant", content:[{type:"text",...}, {type:"tool_use",
-    ///   id, name, input}, ...]}`. Visible text (if any) precedes the
-    ///   tool_use blocks; an empty assistant turn collapses to a single
-    ///   tool_use block with no preamble.
-    /// - Tool-role turns (the orchestrator's tool-result feedback) collapse
-    ///   to a `user` role message carrying a `tool_result` content block:
-    ///   `{role:"user", content:[{type:"tool_result", tool_use_id, content}]}`.
-    /// - Plain text turns fall back to the simple `{role, content}` shape.
-    static func encodeToolAwareEntry(_ entry: ToolAwareHistoryEntry) -> [String: Any] {
-        // Tool-result feedback → user-role tool_result block.
-        if entry.role == "tool", let callId = entry.toolCallId {
-            return [
-                "role": "user",
-                "content": [
-                    [
-                        "type": "tool_result",
-                        "tool_use_id": callId,
-                        "content": entry.content,
-                    ] as [String: Any]
-                ],
-            ]
-        }
-
-        // Assistant turn carrying tool_use blocks.
-        if entry.role == "assistant", let calls = entry.toolCalls, !calls.isEmpty {
-            var blocks: [[String: Any]] = []
-            if !entry.content.isEmpty {
-                blocks.append([
-                    "type": "text",
-                    "text": entry.content,
-                ])
-            }
-            for call in calls {
-                let inputObj = decodeArgumentsForReplay(call.arguments)
-                blocks.append([
-                    "type": "tool_use",
-                    "id": call.id,
-                    "name": call.toolName,
-                    "input": inputObj,
-                ])
-            }
-            return ["role": "assistant", "content": blocks]
-        }
-
-        // Plain message turn (user / system / assistant-text-only).
-        return ["role": entry.role, "content": entry.content]
-    }
-
-    /// Decodes a stored arguments-JSON string for replay inside a
-    /// `tool_use` content block. The Anthropic wire contract requires
-    /// `input` to be a JSON object (not a stringified blob), unlike
-    /// OpenAI Chat Completions where `arguments` is a string.
-    ///
-    /// On parse failure — or if the parsed value is not a JSON object
-    /// (e.g. an array, string, or number snuck into the stored
-    /// arguments) — we fall back to an empty object so we never send a
-    /// `tool_use.input` shape Anthropic will 400 on. Mirrors the MLX
-    /// replay fallback for corrupted tool-call history.
-    private static func decodeArgumentsForReplay(_ arguments: String) -> [String: Any] {
-        guard let data = arguments.data(using: .utf8) else {
-            return [:]
-        }
-        do {
-            let decoded = try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
-            if let object = decoded as? [String: Any] {
-                return object
-            }
-            Log.inference.warning(
-                "ClaudeBackend: tool_use input parsed but is not a JSON object — substituting empty object to satisfy Anthropic schema."
-            )
-            return [:]
-        } catch {
-            Log.inference.warning(
-                "ClaudeBackend: tool_use input could not be re-parsed for replay — substituting empty object. error=\(error.localizedDescription, privacy: .public)"
-            )
-            return [:]
-        }
     }
 
     /// Claude reports usage split across `message_start` (prompt) and
@@ -576,70 +349,16 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         // Signature events bypass open/close entirely.
         var thinking = ThinkingBlockManager()
 
-        // Tool-use content blocks are keyed by `index` (the integer
-        // content-block index Anthropic assigns within an assistant turn).
-        // The accumulator stores entries keyed by the stringified index;
-        // the public call id lives in `entry.id` so downstream events
-        // expose the call id, not the index.
-        let toolAccumulator = StreamingToolCallAccumulator()
-        // Tracks indexes whose `content_block_start` declared `type:"tool_use"`
-        // so we can route subsequent `content_block_delta` / `content_block_stop`
-        // events to the accumulator — Anthropic interleaves tool_use blocks
-        // with text/thinking blocks in the same numbering space.
-        var toolUseIndexes: Set<Int> = []
-        // Tracks indexes for which we've emitted at least one
-        // `.toolCallArgumentsDelta`. `content_block_stop` falls back to a
-        // synthetic `"{}"` delta when the index never received any
-        // `input_json_delta`.
-        var toolUseEmittedDelta: Set<Int> = []
-        // Tracks indexes already finalized via `content_block_stop` so we
-        // don't double-emit `.toolCall` from the message_stop fallback.
-        var toolUseFinalized: Set<Int> = []
-        // Whether to skip finalising any pending tool blocks at stream end
-        // (cancellation contract: dropped consumers must not see phantom
-        // `.toolCall` events for incomplete blocks).
-        var cancelled = false
-
-        // Finalize one tool_use block. Emits a synthetic empty-input delta
-        // when no `input_json_delta` was ever observed so the event surface
-        // (start → ≥1 delta → toolCall) stays uniform with OpenAI's shape.
-        func finalizeToolUse(at index: Int) {
-            guard toolUseIndexes.contains(index), !toolUseFinalized.contains(index) else { return }
-            let key = "\(index)"
-            guard let entry = toolAccumulator.entriesByKey[key], !entry.name.isEmpty else { return }
-            let resolvedId = !entry.id.isEmpty ? entry.id : "claude-call-\(key)"
-            if !toolUseEmittedDelta.contains(index) {
-                continuation.yield(.toolCallArgumentsDelta(callId: resolvedId, textDelta: "{}"))
-                toolUseEmittedDelta.insert(index)
-            }
-            let args = entry.arguments.isEmpty ? "{}" : entry.arguments
-            continuation.yield(.toolCall(ToolCall(
-                id: resolvedId,
-                toolName: entry.name,
-                arguments: args
-            )))
-            toolUseFinalized.insert(index)
-        }
-
-        // Finalize all pending tool_use blocks in `index` order. Used by
-        // both `message_stop` and end-of-stream fallback so callers always
-        // see `.toolCall` events emitted in the order the model produced
-        // the underlying content blocks.
-        func finalizePendingToolUses() {
-            guard !cancelled else { return }
-            for idx in toolUseIndexes.sorted() {
-                finalizeToolUse(at: idx)
-            }
-        }
+        let toolAccumulator = ClaudeToolCallAccumulator()
 
         do {
             for try await payload in tokenStream {
                 if Task.isCancelled {
-                    cancelled = true
+                    toolAccumulator.markCancelled()
                     break
                 }
 
-                let eventType = Self.parseEventType(from: payload)
+                let eventType = ClaudePayloadParser.parseEventType(from: payload)
 
                 // Thinking-block start: opportunistically capture the signature
                 // if Anthropic shipped one inline on the start event. Real
@@ -647,7 +366,7 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
                 // `signature_delta`, but a couple of beta endpoints attach it
                 // here, and the redundant emission is harmless — UI consumers
                 // overwrite stored signatures rather than appending.
-                if eventType == "content_block_start", let signature = Self.parseThinkingBlockStartSignature(from: payload) {
+                if eventType == "content_block_start", let signature = ClaudePayloadParser.parseThinkingBlockStartSignature(from: payload) {
                     continuation.yield(.thinkingSignature(signature))
                     continue
                 }
@@ -656,54 +375,31 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
                 // `.toolCallStart`. Anthropic always carries id and name on
                 // the start event itself, so we don't need the accumulator's
                 // lazy-emit pattern.
-                if eventType == "content_block_start", let toolStart = Self.parseToolUseBlockStart(from: payload) {
+                if eventType == "content_block_start", let toolStart = ClaudePayloadParser.parseToolUseBlockStart(from: payload) {
                     thinking.flushIfOpen(into: continuation)
-                    let key = "\(toolStart.index)"
-                    toolAccumulator.upsert(
-                        key: key,
-                        id: toolStart.id,
-                        name: toolStart.name,
-                        argumentsDelta: nil
-                    )
-                    toolUseIndexes.insert(toolStart.index)
-                    continuation.yield(.toolCallStart(callId: toolStart.id, name: toolStart.name))
-                    toolAccumulator.markStarted(key: key)
+                    toolAccumulator.handleToolUseBlockStart(toolStart, continuation: continuation)
                     continue
                 }
 
                 // input_json_delta — append to the accumulator and emit a
                 // streaming `.toolCallArgumentsDelta` under the resolved call id.
-                if eventType == "content_block_delta", let inputDelta = Self.parseInputJSONDelta(from: payload) {
-                    let key = "\(inputDelta.index)"
-                    toolAccumulator.upsert(
-                        key: key,
-                        id: nil,
-                        name: nil,
-                        argumentsDelta: inputDelta.partialJSON
-                    )
-                    let resolvedId = toolAccumulator.resolvedId(forKey: key)
-                    if !inputDelta.partialJSON.isEmpty {
-                        continuation.yield(.toolCallArgumentsDelta(
-                            callId: resolvedId,
-                            textDelta: inputDelta.partialJSON
-                        ))
-                        toolUseEmittedDelta.insert(inputDelta.index)
-                    }
+                if eventType == "content_block_delta", let inputDelta = ClaudePayloadParser.parseInputJSONDelta(from: payload) {
+                    toolAccumulator.handleInputJSONDelta(inputDelta, continuation: continuation)
                     continue
                 }
 
                 // content_block_stop on a tool_use index — finalize that one
                 // call now so per-block latency is preserved. (Sibling text /
                 // thinking blocks pass through this branch as a no-op.)
-                if eventType == "content_block_stop", let stopIndex = Self.parseContentBlockIndex(from: payload),
-                   toolUseIndexes.contains(stopIndex) {
-                    finalizeToolUse(at: stopIndex)
+                if eventType == "content_block_stop", let stopIndex = ClaudePayloadParser.parseContentBlockIndex(from: payload),
+                   toolAccumulator.isToolUseIndex(stopIndex) {
+                    toolAccumulator.finalizeToolUse(at: stopIndex, continuation: continuation)
                     continue
                 }
 
                 // Signature delta inside the thinking block. Primary path
                 // Anthropic uses today for extended-thinking signatures.
-                if eventType == "content_block_delta", let signature = Self.parseSignatureDelta(from: payload) {
+                if eventType == "content_block_delta", let signature = ClaudePayloadParser.parseSignatureDelta(from: payload) {
                     continuation.yield(.thinkingSignature(signature))
                     continue
                 }
@@ -734,29 +430,9 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
                 // payload. Treat each tool_use block as a uniform start +
                 // single delta + toolCall triple so consumers don't have to
                 // special-case the path.
-                if let wholeCalls = Self.parseWholeMessageToolUseBlocks(from: payload), !wholeCalls.isEmpty {
+                if let wholeCalls = ClaudePayloadParser.parseWholeMessageToolUseBlocks(from: payload), !wholeCalls.isEmpty {
                     thinking.flushIfOpen(into: continuation)
-                    for call in wholeCalls {
-                        let key = "whole-\(call.id.isEmpty ? UUID().uuidString : call.id)"
-                        toolAccumulator.upsert(
-                            key: key,
-                            id: call.id,
-                            name: call.name,
-                            argumentsDelta: call.serializedInput
-                        )
-                        let resolvedId = toolAccumulator.resolvedId(forKey: key)
-                        continuation.yield(.toolCallStart(callId: resolvedId, name: call.name))
-                        toolAccumulator.markStarted(key: key)
-                        continuation.yield(.toolCallArgumentsDelta(
-                            callId: resolvedId,
-                            textDelta: call.serializedInput
-                        ))
-                        continuation.yield(.toolCall(ToolCall(
-                            id: resolvedId,
-                            toolName: call.name,
-                            arguments: call.serializedInput
-                        )))
-                    }
+                    toolAccumulator.handleWholeMessageToolUseBlocks(wholeCalls, continuation: continuation)
                     continue
                 }
 
@@ -785,7 +461,7 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         }
 
         if Task.isCancelled {
-            cancelled = true
+            toolAccumulator.markCancelled()
         }
 
         // Safety net: stream ended without a text block or message_stop while
@@ -795,8 +471,8 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         // Stream end fallback: if the upstream closed without `message_stop`
         // (truncated, server hangup), emit any buffered tool calls now so
         // the orchestrator can still dispatch them. Cancellation suppresses
-        // this branch — see `cancelled`.
-        finalizePendingToolUses()
+        // this branch via ClaudeToolCallAccumulator.
+        toolAccumulator.finalizePendingToolUses(continuation: continuation)
     }
 
     // MARK: - HTTP Status Validation
@@ -845,337 +521,6 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         return body
     }
 
-    // MARK: - SSE Payload Handler
-
-    /// Claude-specific SSE payload interpreter for use with `SSEStreamParser.streamTokens`.
-    static let payloadHandler = ClaudePayloadHandler()
-
-    struct ClaudePayloadHandler: SSEPayloadHandler {
-        func extractToken(from payload: String) -> String? {
-            ClaudeBackend.parseToken(from: payload)
-        }
-
-        /// Maps a single Anthropic SSE payload to the visible-text /
-        /// reasoning-text events it carries.
-        ///
-        /// - `content_block_delta` with `delta.type == "thinking_delta"`
-        ///   produces a single `.thinkingToken`.
-        /// - `content_block_delta` with a `delta.text` (i.e. the regular
-        ///   text-delta path) produces a single `.token`.
-        /// - All other event shapes (tool_use, signature, message_*) are
-        ///   handled inline in
-        ///   ``ClaudeBackend/parseResponseStream(bytes:config:continuation:)``
-        ///   because they require cross-payload state (tool-call accumulator,
-        ///   index→id routing) that a stateless handler cannot model.
-        ///
-        /// Returning an empty array for those shapes is safe: the inline
-        /// parser still inspects them via the same `payload` string before
-        /// consulting the handler.
-        func extractEvents(from payload: String) -> [GenerationEvent] {
-            if let thinking = ClaudeBackend.parseThinkingDelta(from: payload) {
-                return [.thinkingToken(thinking)]
-            }
-            if let token = ClaudeBackend.parseToken(from: payload) {
-                return [.token(token)]
-            }
-            return []
-        }
-
-        func extractUsage(from payload: String) -> (promptTokens: Int?, completionTokens: Int?)? {
-            ClaudeBackend.parseUsage(from: payload)
-        }
-        func isStreamEnd(_ payload: String) -> Bool {
-            ClaudeBackend.parseIsStreamEnd(payload)
-        }
-        func extractStreamError(from payload: String) -> Error? {
-            ClaudeBackend.parseStreamError(from: payload)
-        }
-    }
-
-    // MARK: - JSON Parsing
-
-    /// Returns the `type` field of an Anthropic SSE event payload, if any.
-    static func parseEventType(from json: String) -> String? {
-        guard let data = json.data(using: .utf8),
-              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return nil
-        }
-        return parsed["type"] as? String
-    }
-
-    // MARK: - Tool-call parsing
-
-    /// Decoded shape of a `content_block_start` event whose
-    /// `content_block.type == "tool_use"`.
-    struct ToolUseBlockStart {
-        let index: Int
-        let id: String
-        let name: String
-    }
-
-    /// Decoded shape of a `content_block_delta` event whose
-    /// `delta.type == "input_json_delta"`.
-    struct InputJSONDelta {
-        let index: Int
-        let partialJSON: String
-    }
-
-    /// Decoded shape of one whole `tool_use` block delivered inside a
-    /// non-streaming-style `message.content[]` payload.
-    struct WholeToolUseBlock {
-        let id: String
-        let name: String
-        /// The block's `input` object re-serialised back into a stable
-        /// JSON string. Stored as the canonical arguments value so the
-        /// streaming and non-streaming paths produce a uniform
-        /// `.toolCallArgumentsDelta` / `.toolCall` shape.
-        let serializedInput: String
-    }
-
-    /// Extracts a tool_use block-start payload, if the event carries one.
-    ///
-    /// Shape: `{type:"content_block_start", index:N, content_block:{type:"tool_use", id, name, input}}`.
-    /// `input` is conventionally an empty object `{}` on the start event;
-    /// the actual arguments stream in via `input_json_delta` events.
-    static func parseToolUseBlockStart(from json: String) -> ToolUseBlockStart? {
-        guard let data = json.data(using: .utf8) else { return nil }
-        let parsed: [String: Any]?
-        do {
-            parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        } catch {
-            // Malformed JSON on a probe is a non-event — skip the payload
-            // and let the next valid one drive state. Same shape as the
-            // Chat Completions handlers; covered by silent-catch allowlist.
-            return nil
-        }
-        guard let parsed,
-              parsed["type"] as? String == "content_block_start",
-              let index = parsed["index"] as? Int,
-              let block = parsed["content_block"] as? [String: Any],
-              block["type"] as? String == "tool_use",
-              let id = block["id"] as? String, !id.isEmpty,
-              let name = block["name"] as? String, !name.isEmpty else {
-            return nil
-        }
-        return ToolUseBlockStart(index: index, id: id, name: name)
-    }
-
-    /// Extracts an `input_json_delta` payload, if the event carries one.
-    ///
-    /// Shape: `{type:"content_block_delta", index:N, delta:{type:"input_json_delta", partial_json:"..."}}`.
-    static func parseInputJSONDelta(from json: String) -> InputJSONDelta? {
-        guard let data = json.data(using: .utf8) else { return nil }
-        let parsed: [String: Any]?
-        do {
-            parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        } catch {
-            return nil
-        }
-        guard let parsed,
-              parsed["type"] as? String == "content_block_delta",
-              let index = parsed["index"] as? Int,
-              let delta = parsed["delta"] as? [String: Any],
-              delta["type"] as? String == "input_json_delta",
-              let partial = delta["partial_json"] as? String else {
-            return nil
-        }
-        return InputJSONDelta(index: index, partialJSON: partial)
-    }
-
-    /// Extracts the `index` field from a `content_block_*` payload (used
-    /// to route `content_block_stop` events to the right tool_use index).
-    static func parseContentBlockIndex(from json: String) -> Int? {
-        guard let data = json.data(using: .utf8) else { return nil }
-        let parsed: [String: Any]?
-        do {
-            parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        } catch {
-            return nil
-        }
-        return parsed?["index"] as? Int
-    }
-
-    /// Extracts a non-streaming-style `content:[{type:"tool_use",...}, ...]`
-    /// array from a single-shot payload, when present. Returns `nil` if
-    /// the payload is not a whole-message envelope, or an empty array if
-    /// the envelope contains no tool_use blocks.
-    ///
-    /// Shape:
-    /// ```json
-    /// {"type":"message", "content":[
-    ///   {"type":"tool_use", "id":"...", "name":"...", "input":{...}},
-    ///   ...
-    /// ]}
-    /// ```
-    static func parseWholeMessageToolUseBlocks(from json: String) -> [WholeToolUseBlock]? {
-        guard let data = json.data(using: .utf8) else { return nil }
-        let parsed: [String: Any]?
-        do {
-            parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        } catch {
-            return nil
-        }
-        guard let parsed else { return nil }
-        // Only treat top-level `{type:"message", content:[...]}` envelopes
-        // as whole-message payloads. The streaming events
-        // `content_block_*`, `message_delta`, `message_stop`, `error`
-        // never carry a top-level `content` array, so this guard prevents
-        // accidental double-emission against streaming chunks.
-        guard parsed["type"] as? String == "message",
-              let content = parsed["content"] as? [[String: Any]] else {
-            return nil
-        }
-        var result: [WholeToolUseBlock] = []
-        for block in content {
-            guard block["type"] as? String == "tool_use",
-                  let id = block["id"] as? String, !id.isEmpty,
-                  let name = block["name"] as? String, !name.isEmpty else {
-                continue
-            }
-            let input = block["input"] ?? [String: Any]()
-            let serialized = serializeInputObject(input)
-            result.append(WholeToolUseBlock(id: id, name: name, serializedInput: serialized))
-        }
-        return result
-    }
-
-    /// Re-serialises a `tool_use.input` value back to a JSON string for
-    /// the canonical `ToolCall.arguments` storage. Falls back to `"{}"`
-    /// for anything that fails to re-encode — same conservative empty
-    /// default the OpenAI helpers use.
-    private static func serializeInputObject(_ value: Any) -> String {
-        guard JSONSerialization.isValidJSONObject(value) else {
-            return "{}"
-        }
-        do {
-            let data = try JSONSerialization.data(withJSONObject: value, options: [])
-            return String(data: data, encoding: .utf8) ?? "{}"
-        } catch {
-            Log.inference.warning(
-                "ClaudeBackend: tool_use.input could not be re-serialised — falling back to empty object. error=\(error.localizedDescription, privacy: .public)"
-            )
-            return "{}"
-        }
-    }
-
-    /// Extracts the `.signature` field from a thinking-block
-    /// `content_block_start` payload, when present.
-    ///
-    /// Shape: `{type:"content_block_start", content_block:{type:"thinking", signature:"..."}}`.
-    /// Returns `nil` for non-thinking blocks or starts that don't carry a
-    /// signature.
-    static func parseThinkingBlockStartSignature(from json: String) -> String? {
-        guard let data = json.data(using: .utf8),
-              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              parsed["type"] as? String == "content_block_start",
-              let block = parsed["content_block"] as? [String: Any],
-              block["type"] as? String == "thinking",
-              let signature = block["signature"] as? String,
-              !signature.isEmpty else {
-            return nil
-        }
-        return signature
-    }
-
-    /// Extracts the `.signature` from a `signature_delta` event nested
-    /// inside a `content_block_delta`. Anthropic emits the extended-thinking
-    /// signature via this path on most production responses.
-    ///
-    /// Shape: `{type:"content_block_delta", delta:{type:"signature_delta", signature:"..."}}`.
-    static func parseSignatureDelta(from json: String) -> String? {
-        guard let data = json.data(using: .utf8),
-              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              parsed["type"] as? String == "content_block_delta",
-              let delta = parsed["delta"] as? [String: Any],
-              delta["type"] as? String == "signature_delta",
-              let signature = delta["signature"] as? String,
-              !signature.isEmpty else {
-            return nil
-        }
-        return signature
-    }
-
-    /// Extracts the `.thinking` text from a `thinking_delta` content-block delta.
-    ///
-    /// Anthropic extended-thinking responses carry reasoning as a separate
-    /// content-block type. The delta shape is
-    /// `{type:"content_block_delta", delta:{type:"thinking_delta", thinking:"..."}}`.
-    static func parseThinkingDelta(from json: String) -> String? {
-        guard let data = json.data(using: .utf8),
-              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              parsed["type"] as? String == "content_block_delta",
-              let delta = parsed["delta"] as? [String: Any],
-              delta["type"] as? String == "thinking_delta",
-              let thinking = delta["thinking"] as? String else {
-            return nil
-        }
-        return thinking
-    }
-
-    /// Extracts a text token from a `content_block_delta` event payload.
-    static func parseToken(from json: String) -> String? {
-        guard let data = json.data(using: .utf8),
-              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              parsed["type"] as? String == "content_block_delta",
-              let delta = parsed["delta"] as? [String: Any],
-              let text = delta["text"] as? String else {
-            return nil
-        }
-        return text
-    }
-
-    /// Returns `true` if the SSE payload signals end of stream.
-    private static func parseIsStreamEnd(_ json: String) -> Bool {
-        guard let data = json.data(using: .utf8),
-              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let type = parsed["type"] as? String else {
-            return false
-        }
-        return type == "message_stop"
-    }
-
-    /// Extracts token usage from Claude SSE event payloads.
-    ///
-    /// `message_start` contains `input_tokens`, `message_delta` contains `output_tokens`.
-    private static func parseUsage(from json: String) -> (promptTokens: Int?, completionTokens: Int?)? {
-        guard let data = json.data(using: .utf8),
-              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let type = parsed["type"] as? String else {
-            return nil
-        }
-
-        switch type {
-        case "message_start":
-            guard let message = parsed["message"] as? [String: Any],
-                  let usage = message["usage"] as? [String: Any],
-                  let inputTokens = usage["input_tokens"] as? Int else {
-                return nil
-            }
-            return (promptTokens: inputTokens, completionTokens: nil)
-
-        case "message_delta":
-            guard let usage = parsed["usage"] as? [String: Any],
-                  let outputTokens = usage["output_tokens"] as? Int else {
-                return nil
-            }
-            return (promptTokens: nil, completionTokens: outputTokens)
-
-        default:
-            return nil
-        }
-    }
-
-    /// Extracts an error from an SSE `error` event payload.
-    private static func parseStreamError(from json: String) -> CloudBackendError? {
-        guard let data = json.data(using: .utf8),
-              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              parsed["type"] as? String == "error",
-              let error = parsed["error"] as? [String: Any],
-              let message = error["message"] as? String else {
-            return nil
-        }
-        return .parseError(message)
-    }
 }
 #endif
 

--- a/Sources/ManifoldCloud/ClaudeMessageEncoder.swift
+++ b/Sources/ManifoldCloud/ClaudeMessageEncoder.swift
@@ -1,0 +1,155 @@
+#if CloudSaaS
+import Foundation
+import os
+import ManifoldInference
+
+/// Encodes Manifold structured and tool-aware history into Anthropic Messages API payloads.
+enum ClaudeMessageEncoder {
+    /// Encodes one ``StructuredMessage`` as an Anthropic Messages API `messages[]` entry.
+    static func encodeMessageContent(for message: StructuredMessage) -> [String: Any] {
+        if message.role == "assistant" {
+            var blocks: [[String: Any]] = []
+
+            for part in message.parts {
+                if case .thinking(let text, let signature) = part {
+                    guard let signature else { continue }
+                    blocks.append([
+                        "type": "thinking",
+                        "thinking": text,
+                        "signature": signature
+                    ])
+                }
+            }
+
+            for part in message.parts {
+                if case .image(let data, let mimeType, _) = part {
+                    blocks.append(encodeImageBlock(data: data, mimeType: mimeType))
+                }
+            }
+
+            let visible = message.textContent
+            if !visible.isEmpty {
+                blocks.append([
+                    "type": "text",
+                    "text": visible
+                ])
+            }
+
+            if blocks.isEmpty {
+                return ["role": "assistant", "content": ""]
+            }
+            return ["role": "assistant", "content": blocks]
+        }
+
+        let hasImage = message.parts.contains { part in
+            if case .image = part { return true }
+            return false
+        }
+        if message.role == "user", hasImage {
+            var blocks: [[String: Any]] = []
+            for part in message.parts {
+                if case .image(let data, let mimeType, _) = part {
+                    blocks.append(encodeImageBlock(data: data, mimeType: mimeType))
+                }
+            }
+            let text = message.textContent
+            if !text.isEmpty {
+                blocks.append(["type": "text", "text": text])
+            }
+            return ["role": "user", "content": blocks]
+        }
+
+        return ["role": message.role, "content": message.textContent]
+    }
+
+    /// Encodes a single image part as an Anthropic image content block.
+    static func encodeImageBlock(data: Data, mimeType: String) -> [String: Any] {
+        let normalised = mimeType.lowercased()
+        let mediaType = CloudImageEncoding.anthropicSupportedMimeTypes.contains(normalised)
+            ? normalised
+            : "image/png"
+        return [
+            "type": "image",
+            "source": [
+                "type": "base64",
+                "media_type": mediaType,
+                "data": CloudImageEncoding.base64String(from: data),
+            ] as [String: Any],
+        ]
+    }
+
+    /// Encodes a ``ToolDefinition`` into Anthropic's `tools[]` envelope.
+    static func encodeToolDefinition(_ tool: ToolDefinition) -> [String: Any] {
+        var entry: [String: Any] = [
+            "name": tool.name,
+            "description": tool.description,
+        ]
+        if let schema = encodeJSONSchemaToFoundation(tool.parameters) {
+            entry["input_schema"] = schema
+        } else {
+            entry["input_schema"] = ["type": "object", "properties": [String: Any]()]
+        }
+        return entry
+    }
+
+    /// Encodes one ``ToolAwareHistoryEntry`` for the Anthropic Messages API `messages[]` array.
+    static func encodeToolAwareEntry(_ entry: ToolAwareHistoryEntry) -> [String: Any] {
+        if entry.role == "tool", let callId = entry.toolCallId {
+            return [
+                "role": "user",
+                "content": [
+                    [
+                        "type": "tool_result",
+                        "tool_use_id": callId,
+                        "content": entry.content,
+                    ] as [String: Any]
+                ],
+            ]
+        }
+
+        if entry.role == "assistant", let calls = entry.toolCalls, !calls.isEmpty {
+            var blocks: [[String: Any]] = []
+            if !entry.content.isEmpty {
+                blocks.append([
+                    "type": "text",
+                    "text": entry.content,
+                ])
+            }
+            for call in calls {
+                let inputObj = decodeArgumentsForReplay(call.arguments)
+                blocks.append([
+                    "type": "tool_use",
+                    "id": call.id,
+                    "name": call.toolName,
+                    "input": inputObj,
+                ])
+            }
+            return ["role": "assistant", "content": blocks]
+        }
+
+        return ["role": entry.role, "content": entry.content]
+    }
+
+    /// Decodes stored arguments JSON for replay inside an Anthropic `tool_use.input` object.
+    static func decodeArgumentsForReplay(_ arguments: String) -> [String: Any] {
+        guard let data = arguments.data(using: .utf8) else {
+            return [:]
+        }
+        do {
+            let decoded = try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+            if let object = decoded as? [String: Any] {
+                return object
+            }
+            Log.inference.warning(
+                "ClaudeMessageEncoder: tool_use input parsed but is not a JSON object — substituting empty object to satisfy Anthropic schema."
+            )
+            return [:]
+        } catch {
+            Log.inference.warning(
+                "ClaudeMessageEncoder: tool_use input could not be re-parsed for replay — substituting empty object. error=\(error.localizedDescription, privacy: .public)"
+            )
+            return [:]
+        }
+    }
+}
+#endif

--- a/Sources/ManifoldCloud/ClaudePayloadParser.swift
+++ b/Sources/ManifoldCloud/ClaudePayloadParser.swift
@@ -1,0 +1,216 @@
+#if CloudSaaS
+import Foundation
+import os
+import ManifoldInference
+import ManifoldCloudCore
+
+/// Stateless parser for Anthropic Messages API SSE payloads.
+enum ClaudePayloadParser {
+    struct ToolUseBlockStart {
+        let index: Int
+        let id: String
+        let name: String
+    }
+
+    struct InputJSONDelta {
+        let index: Int
+        let partialJSON: String
+    }
+
+    struct WholeToolUseBlock {
+        let id: String
+        let name: String
+        let serializedInput: String
+    }
+
+    static func parseEventType(from json: String) -> String? {
+        guard let parsed = parseObject(json) else { return nil }
+        return parsed["type"] as? String
+    }
+
+    static func parseToolUseBlockStart(from json: String) -> ToolUseBlockStart? {
+        guard let parsed = parseObject(json),
+              parsed["type"] as? String == "content_block_start",
+              let index = parsed["index"] as? Int,
+              let block = parsed["content_block"] as? [String: Any],
+              block["type"] as? String == "tool_use",
+              let id = block["id"] as? String, !id.isEmpty,
+              let name = block["name"] as? String, !name.isEmpty else {
+            return nil
+        }
+        return ToolUseBlockStart(index: index, id: id, name: name)
+    }
+
+    static func parseInputJSONDelta(from json: String) -> InputJSONDelta? {
+        guard let parsed = parseObject(json),
+              parsed["type"] as? String == "content_block_delta",
+              let index = parsed["index"] as? Int,
+              let delta = parsed["delta"] as? [String: Any],
+              delta["type"] as? String == "input_json_delta",
+              let partial = delta["partial_json"] as? String else {
+            return nil
+        }
+        return InputJSONDelta(index: index, partialJSON: partial)
+    }
+
+    static func parseContentBlockIndex(from json: String) -> Int? {
+        parseObject(json)?["index"] as? Int
+    }
+
+    static func parseWholeMessageToolUseBlocks(from json: String) -> [WholeToolUseBlock]? {
+        guard let parsed = parseObject(json) else { return nil }
+        guard parsed["type"] as? String == "message",
+              let content = parsed["content"] as? [[String: Any]] else {
+            return nil
+        }
+        var result: [WholeToolUseBlock] = []
+        for block in content {
+            guard block["type"] as? String == "tool_use",
+                  let id = block["id"] as? String, !id.isEmpty,
+                  let name = block["name"] as? String, !name.isEmpty else {
+                continue
+            }
+            let input = block["input"] ?? [String: Any]()
+            result.append(WholeToolUseBlock(id: id, name: name, serializedInput: serializeInputObject(input)))
+        }
+        return result
+    }
+
+    static func parseThinkingBlockStartSignature(from json: String) -> String? {
+        guard let parsed = parseObject(json),
+              parsed["type"] as? String == "content_block_start",
+              let block = parsed["content_block"] as? [String: Any],
+              block["type"] as? String == "thinking",
+              let signature = block["signature"] as? String,
+              !signature.isEmpty else {
+            return nil
+        }
+        return signature
+    }
+
+    static func parseSignatureDelta(from json: String) -> String? {
+        guard let parsed = parseObject(json),
+              parsed["type"] as? String == "content_block_delta",
+              let delta = parsed["delta"] as? [String: Any],
+              delta["type"] as? String == "signature_delta",
+              let signature = delta["signature"] as? String,
+              !signature.isEmpty else {
+            return nil
+        }
+        return signature
+    }
+
+    static func parseThinkingDelta(from json: String) -> String? {
+        guard let parsed = parseObject(json),
+              parsed["type"] as? String == "content_block_delta",
+              let delta = parsed["delta"] as? [String: Any],
+              delta["type"] as? String == "thinking_delta",
+              let thinking = delta["thinking"] as? String else {
+            return nil
+        }
+        return thinking
+    }
+
+    static func parseToken(from json: String) -> String? {
+        guard let parsed = parseObject(json),
+              parsed["type"] as? String == "content_block_delta",
+              let delta = parsed["delta"] as? [String: Any],
+              let text = delta["text"] as? String else {
+            return nil
+        }
+        return text
+    }
+
+    static func parseIsStreamEnd(_ json: String) -> Bool {
+        guard let type = parseObject(json)?["type"] as? String else { return false }
+        return type == "message_stop"
+    }
+
+    static func parseUsage(from json: String) -> (promptTokens: Int?, completionTokens: Int?)? {
+        guard let parsed = parseObject(json),
+              let type = parsed["type"] as? String else {
+            return nil
+        }
+
+        switch type {
+        case "message_start":
+            guard let message = parsed["message"] as? [String: Any],
+                  let usage = message["usage"] as? [String: Any],
+                  let inputTokens = usage["input_tokens"] as? Int else {
+                return nil
+            }
+            return (promptTokens: inputTokens, completionTokens: nil)
+        case "message_delta":
+            guard let usage = parsed["usage"] as? [String: Any],
+                  let outputTokens = usage["output_tokens"] as? Int else {
+                return nil
+            }
+            return (promptTokens: nil, completionTokens: outputTokens)
+        default:
+            return nil
+        }
+    }
+
+    static func parseStreamError(from json: String) -> CloudBackendError? {
+        guard let parsed = parseObject(json),
+              parsed["type"] as? String == "error",
+              let error = parsed["error"] as? [String: Any],
+              let message = error["message"] as? String else {
+            return nil
+        }
+        return .parseError(message)
+    }
+
+    private static func parseObject(_ json: String) -> [String: Any]? {
+        guard let data = json.data(using: .utf8) else { return nil }
+        do {
+            return try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        } catch {
+            return nil
+        }
+    }
+
+    private static func serializeInputObject(_ value: Any) -> String {
+        guard JSONSerialization.isValidJSONObject(value) else {
+            return "{}"
+        }
+        do {
+            let data = try JSONSerialization.data(withJSONObject: value, options: [])
+            return String(data: data, encoding: .utf8) ?? "{}"
+        } catch {
+            Log.inference.warning(
+                "ClaudePayloadParser: tool_use.input could not be re-serialised — falling back to empty object. error=\(error.localizedDescription, privacy: .public)"
+            )
+            return "{}"
+        }
+    }
+}
+
+struct ClaudePayloadHandler: SSEPayloadHandler {
+    func extractToken(from payload: String) -> String? {
+        ClaudePayloadParser.parseToken(from: payload)
+    }
+
+    func extractEvents(from payload: String) -> [GenerationEvent] {
+        if let thinking = ClaudePayloadParser.parseThinkingDelta(from: payload) {
+            return [.thinkingToken(thinking)]
+        }
+        if let token = ClaudePayloadParser.parseToken(from: payload) {
+            return [.token(token)]
+        }
+        return []
+    }
+
+    func extractUsage(from payload: String) -> (promptTokens: Int?, completionTokens: Int?)? {
+        ClaudePayloadParser.parseUsage(from: payload)
+    }
+
+    func isStreamEnd(_ payload: String) -> Bool {
+        ClaudePayloadParser.parseIsStreamEnd(payload)
+    }
+
+    func extractStreamError(from payload: String) -> Error? {
+        ClaudePayloadParser.parseStreamError(from: payload)
+    }
+}
+#endif

--- a/Sources/ManifoldCloud/ClaudeToolCallAccumulator.swift
+++ b/Sources/ManifoldCloud/ClaudeToolCallAccumulator.swift
@@ -1,0 +1,84 @@
+#if CloudSaaS
+import Foundation
+import ManifoldInference
+
+/// Stateful accumulator for Claude streaming and whole-message `tool_use` blocks.
+final class ClaudeToolCallAccumulator {
+    private let accumulator = StreamingToolCallAccumulator()
+    private var toolUseIndexes: Set<Int> = []
+    private var toolUseEmittedDelta: Set<Int> = []
+    private var toolUseFinalized: Set<Int> = []
+    private var cancelled = false
+
+    func markCancelled() {
+        cancelled = true
+    }
+
+    func handleToolUseBlockStart(
+        _ start: ClaudePayloadParser.ToolUseBlockStart,
+        continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
+    ) {
+        let key = "\(start.index)"
+        accumulator.upsert(key: key, id: start.id, name: start.name, argumentsDelta: nil)
+        toolUseIndexes.insert(start.index)
+        continuation.yield(.toolCallStart(callId: start.id, name: start.name))
+        accumulator.markStarted(key: key)
+    }
+
+    func handleInputJSONDelta(
+        _ delta: ClaudePayloadParser.InputJSONDelta,
+        continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
+    ) {
+        let key = "\(delta.index)"
+        accumulator.upsert(key: key, id: nil, name: nil, argumentsDelta: delta.partialJSON)
+        let resolvedId = accumulator.resolvedId(forKey: key)
+        if !delta.partialJSON.isEmpty {
+            continuation.yield(.toolCallArgumentsDelta(callId: resolvedId, textDelta: delta.partialJSON))
+            toolUseEmittedDelta.insert(delta.index)
+        }
+    }
+
+    func finalizeToolUse(
+        at index: Int,
+        continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
+    ) {
+        guard toolUseIndexes.contains(index), !toolUseFinalized.contains(index) else { return }
+        let key = "\(index)"
+        guard let entry = accumulator.entriesByKey[key], !entry.name.isEmpty else { return }
+        let resolvedId = !entry.id.isEmpty ? entry.id : "claude-call-\(key)"
+        if !toolUseEmittedDelta.contains(index) {
+            continuation.yield(.toolCallArgumentsDelta(callId: resolvedId, textDelta: "{}"))
+            toolUseEmittedDelta.insert(index)
+        }
+        let args = entry.arguments.isEmpty ? "{}" : entry.arguments
+        continuation.yield(.toolCall(ToolCall(id: resolvedId, toolName: entry.name, arguments: args)))
+        toolUseFinalized.insert(index)
+    }
+
+    func finalizePendingToolUses(continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation) {
+        guard !cancelled else { return }
+        for idx in toolUseIndexes.sorted() {
+            finalizeToolUse(at: idx, continuation: continuation)
+        }
+    }
+
+    func isToolUseIndex(_ index: Int) -> Bool {
+        toolUseIndexes.contains(index)
+    }
+
+    func handleWholeMessageToolUseBlocks(
+        _ calls: [ClaudePayloadParser.WholeToolUseBlock],
+        continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
+    ) {
+        for call in calls {
+            let key = "whole-\(call.id.isEmpty ? UUID().uuidString : call.id)"
+            accumulator.upsert(key: key, id: call.id, name: call.name, argumentsDelta: call.serializedInput)
+            let resolvedId = accumulator.resolvedId(forKey: key)
+            continuation.yield(.toolCallStart(callId: resolvedId, name: call.name))
+            accumulator.markStarted(key: key)
+            continuation.yield(.toolCallArgumentsDelta(callId: resolvedId, textDelta: call.serializedInput))
+            continuation.yield(.toolCall(ToolCall(id: resolvedId, toolName: call.name, arguments: call.serializedInput)))
+        }
+    }
+}
+#endif

--- a/Tests/ManifoldBackendsTests/ClaudePayloadHandlerTests.swift
+++ b/Tests/ManifoldBackendsTests/ClaudePayloadHandlerTests.swift
@@ -5,7 +5,7 @@ import ManifoldTestSupport
 @testable import ManifoldCloud
 @testable import ManifoldInference
 
-/// Asserts that ``ClaudeBackend/ClaudePayloadHandler/extractEvents(from:)``
+/// Asserts that ``ClaudePayloadHandler/extractEvents(from:)``
 /// preserves the `thinking_delta` and `text_delta` event surface that the
 /// migration from individual `parseToken` / `parseThinkingDelta` calls is
 /// supposed to keep intact.
@@ -13,7 +13,7 @@ import ManifoldTestSupport
 /// Closes the per-handler half of #604 (Claude reasoning event preservation).
 final class ClaudePayloadHandlerTests: XCTestCase {
 
-    private let handler = ClaudeBackend.payloadHandler
+    private let handler = ClaudePayloadHandler()
 
     // MARK: - thinking_delta classification
 

--- a/Tests/ManifoldBackendsTests/ClaudeStructuredReplayTests.swift
+++ b/Tests/ManifoldBackendsTests/ClaudeStructuredReplayTests.swift
@@ -191,21 +191,21 @@ final class ClaudeStructuredReplayTests: XCTestCase {
 
     func test_parseSignatureDelta_extractsSignatureFromDelta() {
         let payload = #"{"type":"content_block_delta","delta":{"type":"signature_delta","signature":"sig_xyz"}}"#
-        XCTAssertEqual(ClaudeBackend.parseSignatureDelta(from: payload), "sig_xyz")
+        XCTAssertEqual(ClaudePayloadParser.parseSignatureDelta(from: payload), "sig_xyz")
 
         // Sabotage check: removing the type==signature_delta guard would
         // make this return non-nil for thinking_delta payloads.
         let thinkingPayload = #"{"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"...","signature":"oops"}}"#
-        XCTAssertNil(ClaudeBackend.parseSignatureDelta(from: thinkingPayload),
+        XCTAssertNil(ClaudePayloadParser.parseSignatureDelta(from: thinkingPayload),
             "thinking_delta is not a signature_delta — must not match")
     }
 
     func test_parseThinkingBlockStartSignature_extractsFromStart() {
         let payload = #"{"type":"content_block_start","content_block":{"type":"thinking","signature":"sig_start"}}"#
-        XCTAssertEqual(ClaudeBackend.parseThinkingBlockStartSignature(from: payload), "sig_start")
+        XCTAssertEqual(ClaudePayloadParser.parseThinkingBlockStartSignature(from: payload), "sig_start")
 
         let textStart = #"{"type":"content_block_start","content_block":{"type":"text"}}"#
-        XCTAssertNil(ClaudeBackend.parseThinkingBlockStartSignature(from: textStart))
+        XCTAssertNil(ClaudePayloadParser.parseThinkingBlockStartSignature(from: textStart))
     }
 
     // MARK: - 6. End-to-end: signature flows from SSE → emit ordering

--- a/Tests/ManifoldBackendsTests/CloudEncoderGeneratedImageSkipTests.swift
+++ b/Tests/ManifoldBackendsTests/CloudEncoderGeneratedImageSkipTests.swift
@@ -64,7 +64,7 @@ final class CloudEncoderGeneratedImageSkipTests: XCTestCase {
             generatedImagePart(),
         ])
 
-        let encoded = ClaudeBackend.encodeMessageContent(for: message)
+        let encoded = ClaudeMessageEncoder.encodeMessageContent(for: message)
 
         // The user turn carries an input image, so content must be a
         // structured array — that's the path that loops over parts.
@@ -97,7 +97,7 @@ final class CloudEncoderGeneratedImageSkipTests: XCTestCase {
             generatedImagePart(),
         ])
 
-        let encoded = ClaudeBackend.encodeMessageContent(for: message)
+        let encoded = ClaudeMessageEncoder.encodeMessageContent(for: message)
 
         XCTAssertEqual(encoded["content"] as? String, "hello",
             "Image-less user turn (input-image-wise) must collapse to plain string content")

--- a/Tests/ManifoldBackendsTests/CrossBackendReplayParityTests.swift
+++ b/Tests/ManifoldBackendsTests/CrossBackendReplayParityTests.swift
@@ -82,7 +82,7 @@ final class CrossBackendReplayParityTests: XCTestCase {
     func test_anthropic_fixtureReplay_producesExpectedToolCall() throws {
         let json = try loadFixture(named: "anthropic_tool_use.json")
 
-        let blocks = try XCTUnwrap(ClaudeBackend.parseWholeMessageToolUseBlocks(from: json))
+        let blocks = try XCTUnwrap(ClaudePayloadParser.parseWholeMessageToolUseBlocks(from: json))
 
         XCTAssertEqual(blocks.count, 1, "expected exactly one tool_use block in Anthropic fixture")
         let block = try XCTUnwrap(blocks.first)
@@ -136,7 +136,7 @@ final class CrossBackendReplayParityTests: XCTestCase {
 
         // Anthropic
         let anthropicJson = try loadFixture(named: "anthropic_tool_use.json")
-        let anthropicBlocks = try XCTUnwrap(ClaudeBackend.parseWholeMessageToolUseBlocks(from: anthropicJson))
+        let anthropicBlocks = try XCTUnwrap(ClaudePayloadParser.parseWholeMessageToolUseBlocks(from: anthropicJson))
         let anthropicArgs = try parseArgs(try XCTUnwrap(anthropicBlocks.first).serializedInput)
 
         // Ollama

--- a/Tests/ManifoldBackendsTests/SSEPayloadReplayTests.swift
+++ b/Tests/ManifoldBackendsTests/SSEPayloadReplayTests.swift
@@ -66,7 +66,7 @@ final class SSEPayloadReplayTests: XCTestCase {
         let payloads = try await collectPayloads(from: sseText)
 
         // Extract tokens using the Claude payload handler
-        let handler = ClaudeBackend.payloadHandler
+        let handler = ClaudePayloadHandler()
         let tokens = payloads.compactMap { handler.extractToken(from: $0) }
         XCTAssertEqual(tokens, ["Hello", " world"])
 
@@ -110,7 +110,7 @@ final class SSEPayloadReplayTests: XCTestCase {
         let payloads = try await collectPayloads(from: sseText)
         XCTAssertEqual(payloads.count, 1)
 
-        let handler = ClaudeBackend.payloadHandler
+        let handler = ClaudePayloadHandler()
         let error = handler.extractStreamError(from: payloads[0])
         XCTAssertNotNil(error)
 
@@ -138,7 +138,7 @@ final class SSEPayloadReplayTests: XCTestCase {
         """
 
         let payloads = try await collectPayloads(from: sseText)
-        let handler = ClaudeBackend.payloadHandler
+        let handler = ClaudePayloadHandler()
 
         // Accumulate usage across events the way the backend does
         var promptTokens: Int?
@@ -258,7 +258,7 @@ final class SSEPayloadReplayTests: XCTestCase {
 
         // Claude's extractToken should return nil for malformed/irrelevant JSON and
         // a valid token for the content_block_delta
-        let handler = ClaudeBackend.payloadHandler
+        let handler = ClaudePayloadHandler()
         let tokens = payloads.compactMap { handler.extractToken(from: $0) }
         XCTAssertEqual(tokens, ["ok"])
 
@@ -286,7 +286,7 @@ final class SSEPayloadReplayTests: XCTestCase {
         """
 
         let payloads = try await collectPayloads(from: sseText)
-        let handler = ClaudeBackend.payloadHandler
+        let handler = ClaudePayloadHandler()
         let tokens = payloads.compactMap { handler.extractToken(from: $0) }
         XCTAssertEqual(tokens, ["A", "B", "C"])
     }
@@ -316,7 +316,7 @@ final class SSEPayloadReplayTests: XCTestCase {
         """
 
         let payloads = try await collectPayloads(from: sseText)
-        let handler = ClaudeBackend.payloadHandler
+        let handler = ClaudePayloadHandler()
         let tokens = payloads.compactMap { handler.extractToken(from: $0) }
 
         // Contract-pinning: today only the text_delta survives; the thinking_delta
@@ -358,7 +358,7 @@ final class SSEPayloadReplayTests: XCTestCase {
         """
 
         let payloads = try await collectPayloads(from: sseText)
-        let handler = ClaudeBackend.payloadHandler
+        let handler = ClaudePayloadHandler()
 
         // Every payload should return nil from extractToken — no token leakage.
         for payload in payloads {
@@ -396,7 +396,7 @@ final class SSEPayloadReplayTests: XCTestCase {
         """
 
         let payloads = try await collectPayloads(from: sseText)
-        let handler = ClaudeBackend.payloadHandler
+        let handler = ClaudePayloadHandler()
         let tokens = payloads.compactMap { handler.extractToken(from: $0) }
 
         // Today: citation delta drops cleanly, text_deltas flow through in order.
@@ -429,7 +429,7 @@ final class SSEPayloadReplayTests: XCTestCase {
         """
 
         let payloads = try await collectPayloads(from: sseText)
-        let handler = ClaudeBackend.payloadHandler
+        let handler = ClaudePayloadHandler()
 
         // No tokens produced from any of the three message_delta events.
         let tokens = payloads.compactMap { handler.extractToken(from: $0) }
@@ -481,7 +481,7 @@ final class SSEPayloadReplayTests: XCTestCase {
         """
 
         let payloads = try await collectPayloads(from: sseText)
-        let handler = ClaudeBackend.payloadHandler
+        let handler = ClaudePayloadHandler()
         let tokens = payloads.compactMap { handler.extractToken(from: $0) }
 
         // Two text_deltas survive, the tool_use input_json_delta is dropped.
@@ -502,7 +502,7 @@ final class SSEPayloadReplayTests: XCTestCase {
         """
 
         let payloads = try await collectPayloads(from: sseText)
-        let handler = ClaudeBackend.payloadHandler
+        let handler = ClaudePayloadHandler()
         let tokens = payloads.compactMap { handler.extractToken(from: $0) }
 
         XCTAssertEqual(tokens.count, 3)


### PR DESCRIPTION
Part of #1113.

Summary:
- Extracts ClaudeMessageEncoder, ClaudePayloadParser, and ClaudeToolCallAccumulator.
- Preserves Claude wire payloads, SSE parsing, structured replay, image handling, and tool-use accumulation.
- Updates Claude/cloud replay tests for the extracted collaborators.

LOC:
- ClaudeBackend.swift: 1,181 -> 526.

Validation:
- swift build --build-tests --traits CloudSaaS --disable-default-traits
- scripts/test.sh --filter ManifoldBackendsTests --traits CloudSaaS --disable-default-traits --skip-update
- Code review pass: no SSE, trait-gating, tool-use, or API regressions found.
