### PR TITLE
feat: harden MCP platform callbacks

### DIFF
--- a/Sources/ManifoldMCP/MCPCatalog.swift
+++ b/Sources/ManifoldMCP/MCPCatalog.swift
@@ -7,6 +7,14 @@ public enum MCPCatalog {
         [notion, linear, github]
     }
 
+    public static func all(oauthRedirectBaseURL: URL) throws -> [MCPServerDescriptor] {
+        [
+            try notion(oauthRedirectBaseURL: Optional(oauthRedirectBaseURL)),
+            try linear(oauthRedirectBaseURL: Optional(oauthRedirectBaseURL)),
+            try github(oauthRedirectBaseURL: Optional(oauthRedirectBaseURL)),
+        ]
+    }
+
     public static var notion: MCPServerDescriptor {
         descriptor(
             id: UUID(uuidString: "5E4A6401-C86D-43DE-847E-AE02A34E89D8")!,
@@ -16,7 +24,29 @@ public enum MCPCatalog {
             toolNamespace: "notion",
             oauthScopes: ["read:content", "write:content"],
             oauthIssuerHost: "notion.com",
-            dataDisclosure: "Tool calls may send prompt content and selected arguments to Notion."
+            dataDisclosure: "Tool calls may send prompt content and selected arguments to Notion.",
+            redirectURI: defaultRedirectURI(toolNamespace: "notion")
+        )
+    }
+
+    public static func notion(oauthRedirectBaseURL: URL) throws -> MCPServerDescriptor {
+        try notion(oauthRedirectBaseURL: Optional(oauthRedirectBaseURL))
+    }
+
+    private static func notion(oauthRedirectBaseURL: URL?) throws -> MCPServerDescriptor {
+        descriptor(
+            id: UUID(uuidString: "5E4A6401-C86D-43DE-847E-AE02A34E89D8")!,
+            displayName: "Notion",
+            endpointHost: "mcp.notion.com",
+            endpointPath: "/mcp",
+            toolNamespace: "notion",
+            oauthScopes: ["read:content", "write:content"],
+            oauthIssuerHost: "notion.com",
+            dataDisclosure: "Tool calls may send prompt content and selected arguments to Notion.",
+            redirectURI: try universalLinkRedirectURI(
+                toolNamespace: "notion",
+                oauthRedirectBaseURL: oauthRedirectBaseURL
+            )
         )
     }
 
@@ -29,7 +59,29 @@ public enum MCPCatalog {
             toolNamespace: "linear",
             oauthScopes: ["read", "write"],
             oauthIssuerHost: "linear.app",
-            dataDisclosure: "Tool calls may send prompt content and selected arguments to Linear."
+            dataDisclosure: "Tool calls may send prompt content and selected arguments to Linear.",
+            redirectURI: defaultRedirectURI(toolNamespace: "linear")
+        )
+    }
+
+    public static func linear(oauthRedirectBaseURL: URL) throws -> MCPServerDescriptor {
+        try linear(oauthRedirectBaseURL: Optional(oauthRedirectBaseURL))
+    }
+
+    private static func linear(oauthRedirectBaseURL: URL?) throws -> MCPServerDescriptor {
+        descriptor(
+            id: UUID(uuidString: "B146A315-DFA4-4F75-9AF8-7B98CDE569FB")!,
+            displayName: "Linear",
+            endpointHost: "mcp.linear.app",
+            endpointPath: "/mcp",
+            toolNamespace: "linear",
+            oauthScopes: ["read", "write"],
+            oauthIssuerHost: "linear.app",
+            dataDisclosure: "Tool calls may send prompt content and selected arguments to Linear.",
+            redirectURI: try universalLinkRedirectURI(
+                toolNamespace: "linear",
+                oauthRedirectBaseURL: oauthRedirectBaseURL
+            )
         )
     }
 
@@ -42,7 +94,29 @@ public enum MCPCatalog {
             toolNamespace: "github",
             oauthScopes: ["read:user", "repo"],
             oauthIssuerHost: "github.com",
-            dataDisclosure: "Tool calls may send prompt content and selected arguments to GitHub."
+            dataDisclosure: "Tool calls may send prompt content and selected arguments to GitHub.",
+            redirectURI: defaultRedirectURI(toolNamespace: "github")
+        )
+    }
+
+    public static func github(oauthRedirectBaseURL: URL) throws -> MCPServerDescriptor {
+        try github(oauthRedirectBaseURL: Optional(oauthRedirectBaseURL))
+    }
+
+    private static func github(oauthRedirectBaseURL: URL?) throws -> MCPServerDescriptor {
+        descriptor(
+            id: UUID(uuidString: "7B573A8A-C3CB-450D-9EBE-2E7D4C973682")!,
+            displayName: "GitHub",
+            endpointHost: "api.githubcopilot.com",
+            endpointPath: "/mcp/",
+            toolNamespace: "github",
+            oauthScopes: ["read:user", "repo"],
+            oauthIssuerHost: "github.com",
+            dataDisclosure: "Tool calls may send prompt content and selected arguments to GitHub.",
+            redirectURI: try universalLinkRedirectURI(
+                toolNamespace: "github",
+                oauthRedirectBaseURL: oauthRedirectBaseURL
+            )
         )
     }
 
@@ -54,7 +128,8 @@ public enum MCPCatalog {
         toolNamespace: String,
         oauthScopes: [String],
         oauthIssuerHost: String,
-        dataDisclosure: String
+        dataDisclosure: String,
+        redirectURI: URL
     ) -> MCPServerDescriptor {
         var endpoint = URLComponents()
         endpoint.scheme = "https"
@@ -65,11 +140,6 @@ public enum MCPCatalog {
         issuer.scheme = "https"
         issuer.host = oauthIssuerHost
 
-        var redirect = URLComponents()
-        redirect.scheme = "basechat"
-        redirect.host = "oauth"
-        redirect.path = "/mcp/\(toolNamespace)/callback"
-
         return MCPServerDescriptor(
             id: id,
             displayName: displayName,
@@ -77,13 +147,50 @@ public enum MCPCatalog {
             authorization: .oauth(.init(
                 clientName: "ManifoldKit",
                 scopes: oauthScopes,
-                redirectURI: redirect.url!,
+                redirectURI: redirectURI,
                 authorizationServerIssuer: issuer.url!
             )),
             toolNamespace: toolNamespace,
             resourceURL: endpoint.url!,
             dataDisclosure: dataDisclosure
         )
+    }
+
+    private static func defaultRedirectURI(toolNamespace: String) -> URL {
+        var redirect = URLComponents()
+        redirect.scheme = "basechat"
+        redirect.host = "oauth"
+        redirect.path = "/mcp/\(toolNamespace)/callback"
+        return redirect.url!
+    }
+
+    private static func universalLinkRedirectURI(
+        toolNamespace: String,
+        oauthRedirectBaseURL: URL?
+    ) throws -> URL {
+        guard let oauthRedirectBaseURL else {
+            return defaultRedirectURI(toolNamespace: toolNamespace)
+        }
+
+        guard oauthRedirectBaseURL.scheme == "https",
+              oauthRedirectBaseURL.host?.isEmpty == false,
+              var redirect = URLComponents(
+                url: oauthRedirectBaseURL,
+                resolvingAgainstBaseURL: false
+              ) else {
+            throw MCPError.malformedMetadata("OAuth Universal Link redirect base URL must be absolute HTTPS")
+        }
+
+        let basePath = redirect.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let pathComponents = ([basePath, "mcp", toolNamespace, "callback"])
+            .filter { $0.isEmpty == false }
+        redirect.path = "/" + pathComponents.joined(separator: "/")
+        redirect.query = nil
+        redirect.fragment = nil
+        guard let url = redirect.url else {
+            throw MCPError.malformedMetadata("OAuth Universal Link redirect base URL could not be normalized")
+        }
+        return url
     }
 }
 #endif

--- a/Sources/ManifoldMCP/MCPNotificationLifecycleEventObserver.swift
+++ b/Sources/ManifoldMCP/MCPNotificationLifecycleEventObserver.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+public final class MCPNotificationLifecycleEventObserver: MCPLifecycleEventObserver, @unchecked Sendable {
+    public let events: AsyncStream<MCPLifecycleEvent>
+
+    private let notificationCenter: NotificationCenter
+    private let continuation: AsyncStream<MCPLifecycleEvent>.Continuation
+    private var tokens: [NSObjectProtocol] = []
+
+    public init(
+        notificationCenter: NotificationCenter = .default,
+        mapping: [Notification.Name: MCPLifecycleEvent]
+    ) {
+        self.notificationCenter = notificationCenter
+
+        var eventContinuation: AsyncStream<MCPLifecycleEvent>.Continuation!
+        self.events = AsyncStream { streamContinuation in
+            eventContinuation = streamContinuation
+        }
+        self.continuation = eventContinuation
+
+        self.tokens = mapping.map { name, event in
+            notificationCenter.addObserver(
+                forName: name,
+                object: nil,
+                queue: nil
+            ) { _ in
+                eventContinuation.yield(event)
+            }
+        }
+    }
+
+    deinit {
+        for token in tokens {
+            notificationCenter.removeObserver(token)
+        }
+        continuation.finish()
+    }
+
+    public static func platformMemoryWarnings(
+        notificationCenter: NotificationCenter = .default
+    ) -> MCPNotificationLifecycleEventObserver? {
+        #if canImport(UIKit)
+        return MCPNotificationLifecycleEventObserver(
+            notificationCenter: notificationCenter,
+            mapping: [UIApplication.didReceiveMemoryWarningNotification: .memoryWarning]
+        )
+        #else
+        _ = notificationCenter
+        return nil
+        #endif
+    }
+}

--- a/Sources/ManifoldMCP/MCPTypes.swift
+++ b/Sources/ManifoldMCP/MCPTypes.swift
@@ -161,7 +161,7 @@ public struct MCPClientConfiguration: Sendable {
         keychain: MCPKeychainConfiguration = .init(),
         lifecyclePolicy: MCPSessionLifecyclePolicy = .cancelOnBackground,
         networkPathObserver: (any MCPNetworkPathObserver)? = nil,
-        lifecycleObserver: (any MCPLifecycleEventObserver)? = nil
+        lifecycleObserver: (any MCPLifecycleEventObserver)? = MCPNotificationLifecycleEventObserver.platformMemoryWarnings()
     ) {
         self.sseStreamLimits = sseStreamLimits
         self.requestTimeout = requestTimeout

--- a/Tests/ManifoldMCPTests/MCPCatalogTests.swift
+++ b/Tests/ManifoldMCPTests/MCPCatalogTests.swift
@@ -39,6 +39,32 @@ final class MCPCatalogTests: XCTestCase {
         let ids = MCPCatalog.all.map(\.id)
         XCTAssertEqual(ids.count, Set(ids).count, "Duplicate catalog entry IDs found")
     }
+
+    func test_universalLinkOAuthRedirectBaseURLOverridesCatalogCallbacks() throws {
+        let descriptors = try MCPCatalog.all(oauthRedirectBaseURL: URL(string: "https://demo.manifoldkit.dev/oauth")!)
+        XCTAssertEqual(descriptors.count, MCPCatalog.all.count)
+
+        for descriptor in descriptors {
+            guard case .oauth(let oauth) = descriptor.authorization else {
+                XCTFail("\(descriptor.displayName) missing OAuth descriptor")
+                continue
+            }
+
+            XCTAssertEqual(oauth.redirectURI.scheme, "https")
+            XCTAssertEqual(oauth.redirectURI.host, "demo.manifoldkit.dev")
+            XCTAssertTrue(oauth.redirectURI.path.hasPrefix("/oauth/mcp/"))
+            XCTAssertTrue(oauth.redirectURI.path.hasSuffix("/callback"))
+        }
+    }
+
+    func test_universalLinkOAuthRedirectBaseURLRejectsNonHTTPS() {
+        XCTAssertThrowsError(try MCPCatalog.all(oauthRedirectBaseURL: URL(string: "basechat://oauth")!)) { error in
+            guard case MCPError.malformedMetadata = error else {
+                XCTFail("Expected malformedMetadata, got \(error)")
+                return
+            }
+        }
+    }
     #endif
 }
 #endif

--- a/Tests/ManifoldMCPTests/MCPHardeningTests.swift
+++ b/Tests/ManifoldMCPTests/MCPHardeningTests.swift
@@ -458,6 +458,36 @@ final class MCPHardeningTests: XCTestCase {
         XCTAssertEqual(afterForeground, .idle)
     }
 
+    func test_notificationLifecycleObserverMapsFoundationNotifications() async {
+        let center = NotificationCenter()
+        let notificationName = Notification.Name("test.mcp.memory-warning")
+        let observer = MCPNotificationLifecycleEventObserver(
+            notificationCenter: center,
+            mapping: [notificationName: .memoryWarning]
+        )
+
+        var iterator = observer.events.makeAsyncIterator()
+        center.post(name: notificationName, object: nil)
+        let event = await iterator.next()
+
+        XCTAssertEqual(event, .memoryWarning)
+    }
+
+    func test_notificationLifecycleObserverFinishesStreamOnDeinit() async {
+        let center = NotificationCenter()
+        let notificationName = Notification.Name("test.mcp.memory-warning")
+        var observer: MCPNotificationLifecycleEventObserver? = MCPNotificationLifecycleEventObserver(
+            notificationCenter: center,
+            mapping: [notificationName: .memoryWarning]
+        )
+        var iterator = observer!.events.makeAsyncIterator()
+
+        observer = nil
+        let event = await iterator.next()
+
+        XCTAssertNil(event)
+    }
+
     private func makeSession() -> URLSession {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [MockURLProtocol.self]


### PR DESCRIPTION
## Summary\n- add a notification-backed MCP lifecycle observer and make MCPClientConfiguration listen for UIKit memory warnings by default\n- add validated throwing built-in catalog overloads for HTTPS Universal Link OAuth redirect callback bases\n- cover notification mapping/deinit completion and Universal Link redirect validation in MCP tests\n\n## Validation\n- scripts/test.sh --filter ManifoldMCPTests.MCPHardeningTests --filter ManifoldMCPTests.MCPCatalogTests --disable-default-traits --traits MCP,MCPBuiltinCatalog --skip-update --min-passed 1\n- scripts/test.sh --filter ManifoldMCPTests --disable-default-traits --traits MCP,MCPBuiltinCatalog --skip-update --min-passed 1\n- swift build --build-tests --disable-default-traits