### PR TITLE
feat: enrich server models response

### DIFF
--- a/Sources/ManifoldServer/ServerApp.swift
+++ b/Sources/ManifoldServer/ServerApp.swift
@@ -60,9 +60,9 @@ internal struct ServerApp: Sendable {
             }
             metrics.recordRequestStarted()
             do {
-                let models = try await backendProvider.listModels()
+                let models = try await backendProvider.listModelRecords()
                 metrics.recordRequestCompleted()
-                return jsonResponse(ModelsListResponse(models: models))
+                return jsonResponse(ModelsListResponse(modelRecords: models))
             } catch {
                 metrics.recordFailure()
                 metrics.recordRequestCompleted()

--- a/Sources/ManifoldServer/ServerBackendProvider.swift
+++ b/Sources/ManifoldServer/ServerBackendProvider.swift
@@ -12,7 +12,14 @@ internal struct ServerBackendRequest: Equatable, Sendable {
 
 internal protocol ServerBackendProvider: Sendable {
     func listModels() async throws -> [String]
+    func listModelRecords() async throws -> [ModelsListResponse.Model]
     func backend(for request: ServerBackendRequest) async throws -> any InferenceBackend
+}
+
+extension ServerBackendProvider {
+    internal func listModelRecords() async throws -> [ModelsListResponse.Model] {
+        try await listModels().map { ModelsListResponse.Model(id: $0, status: "available") }
+    }
 }
 
 internal struct UnavailableServerBackendProvider: ServerBackendProvider {

--- a/Sources/ManifoldServer/ServerHTTPResponses.swift
+++ b/Sources/ManifoldServer/ServerHTTPResponses.swift
@@ -6,10 +6,33 @@ internal struct ModelsListResponse: Codable, Equatable, Sendable {
     internal struct Model: Codable, Equatable, Sendable {
         internal var id: String
         internal var object: String
+        internal var created: Int
+        internal var ownedBy: String
+        internal var status: String?
+        internal var backend: String?
+        internal var source: String?
 
-        internal init(id: String, object: String = "model") {
+        internal init(
+            id: String,
+            object: String = "model",
+            created: Int = 0,
+            ownedBy: String = "manifold",
+            status: String? = nil,
+            backend: String? = nil,
+            source: String? = nil
+        ) {
             self.id = id
             self.object = object
+            self.created = created
+            self.ownedBy = ownedBy
+            self.status = status
+            self.backend = backend
+            self.source = source
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case id, object, created, status, backend, source
+            case ownedBy = "owned_by"
         }
     }
 
@@ -17,8 +40,12 @@ internal struct ModelsListResponse: Codable, Equatable, Sendable {
     internal var data: [Model]
 
     internal init(models: [String]) {
+        self.init(modelRecords: models.map { Model(id: $0) })
+    }
+
+    internal init(modelRecords: [Model]) {
         self.object = "list"
-        self.data = models.map { Model(id: $0) }
+        self.data = modelRecords
     }
 }
 

--- a/Sources/ManifoldServer/TraitAwareServerBackendProvider.swift
+++ b/Sources/ManifoldServer/TraitAwareServerBackendProvider.swift
@@ -73,21 +73,42 @@ internal actor TraitAwareServerBackendProvider: ServerBackendProvider {
     internal let selection: ServerBackendSelection
     internal let compiledBackends: CompiledBackends
     private var cachedBackend: (any InferenceBackend)?
+    private var loadedModelID: String?
 
     internal init(
         selection: ServerBackendSelection,
-        compiledBackends: CompiledBackends = DefaultBackends.compiledBackends
+        compiledBackends: CompiledBackends = DefaultBackends.compiledBackends,
+        loadedModelID: String? = nil
     ) {
         self.selection = selection
         self.compiledBackends = compiledBackends
+        self.loadedModelID = loadedModelID
     }
 
     internal func listModels() async throws -> [String] {
-        switch selection.backend {
+        let configuredModels: [String] = switch selection.backend {
         case .foundation:
-            return [ModelInfo.builtInFoundation.name]
-        case .ollama, .cloud, .mlx, .llama:
-            return [selection.model, selection.modelPath].compactMap { $0 }
+            [ModelInfo.builtInFoundation.name]
+        case .ollama:
+            [selection.model ?? APIProvider.ollama.defaultModelName]
+        case .cloud, .mlx, .llama:
+            [selection.model, selection.modelPath].compactMap { $0 }
+        }
+
+        guard let loadedModelID, !configuredModels.contains(loadedModelID) else {
+            return configuredModels
+        }
+        return [loadedModelID] + configuredModels
+    }
+
+    internal func listModelRecords() async throws -> [ModelsListResponse.Model] {
+        try await listModels().map { id in
+            ModelsListResponse.Model(
+                id: id,
+                status: loadedModelID == id ? "loaded" : "available",
+                backend: selection.backend.rawValue,
+                source: modelSource
+            )
         }
     }
 
@@ -112,7 +133,34 @@ internal actor TraitAwareServerBackendProvider: ServerBackendProvider {
             throw ServerError.notImplemented("Cloud SaaS backend loading is not implemented for ManifoldServer v1; configure a local or self-hosted backend instead.")
         }
         cachedBackend = backend
+        loadedModelID = modelID(for: request)
         return backend
+    }
+
+    private var modelSource: String {
+        switch selection.backend {
+        case .foundation:
+            return "built_in"
+        case .mlx, .llama:
+            return selection.modelPath == nil ? "remote_identifier" : "local_path"
+        case .ollama, .cloud:
+            return "remote_endpoint"
+        }
+    }
+
+    internal func modelID(for request: ServerBackendRequest) -> String? {
+        switch selection.backend {
+        case .foundation:
+            return ModelInfo.builtInFoundation.name
+        case .mlx:
+            return selection.modelPath ?? request.model ?? selection.model
+        case .ollama:
+            return request.model ?? selection.model ?? APIProvider.ollama.defaultModelName
+        case .llama:
+            return selection.modelPath
+        case .cloud:
+            return selection.model
+        }
     }
 
     private func loadMLXBackend(modelOverride: String?) async throws -> any InferenceBackend {

--- a/Tests/ManifoldServerTests/ManifoldServerSmokeTests.swift
+++ b/Tests/ManifoldServerTests/ManifoldServerSmokeTests.swift
@@ -36,6 +36,9 @@ final class ManifoldServerSmokeTests: XCTestCase {
                 XCTAssertEqual(response.status, .ok)
                 let models = try JSONDecoder().decode(ModelsListResponse.self, from: Data(buffer: response.body))
                 XCTAssertEqual(models.data.map(\.id), ["tiny"])
+                XCTAssertEqual(models.data.first?.object, "model")
+                XCTAssertEqual(models.data.first?.ownedBy, "manifold")
+                XCTAssertEqual(models.data.first?.status, "available")
             }
 
             let body = try requestBody(ChatCompletionRequest(model: "tiny", messages: [.init(role: "user", content: "hi")]))

--- a/Tests/ManifoldServerTests/OpenAIJSONGoldenTests.swift
+++ b/Tests/ManifoldServerTests/OpenAIJSONGoldenTests.swift
@@ -173,6 +173,31 @@ final class OpenAIJSONGoldenTests: XCTestCase {
         XCTAssertEqual(chunk.usage?.completionTokens, 5)
         XCTAssertEqual(chunk.usage?.totalTokens, 12)
     }
+
+    func testModelsListResponseIncludesOpenAIAndManifoldMetadata() throws {
+        let response = ModelsListResponse(modelRecords: [
+            ModelsListResponse.Model(
+                id: "demo-model",
+                created: 0,
+                ownedBy: "manifold",
+                status: "loaded",
+                backend: "foundation",
+                source: "built_in"
+            )
+        ])
+
+        let encoded = try OpenAIJSONGolden.encode(response)
+        let decoded = try JSONDecoder().decode(ModelsListResponse.self, from: Data(encoded.utf8))
+
+        XCTAssertEqual(decoded.object, "list")
+        XCTAssertEqual(decoded.data.first?.id, "demo-model")
+        XCTAssertEqual(decoded.data.first?.object, "model")
+        XCTAssertEqual(decoded.data.first?.created, 0)
+        XCTAssertEqual(decoded.data.first?.ownedBy, "manifold")
+        XCTAssertEqual(decoded.data.first?.status, "loaded")
+        XCTAssertEqual(decoded.data.first?.backend, "foundation")
+        XCTAssertTrue(encoded.contains("\"owned_by\":\"manifold\""))
+    }
 }
 
 #endif

--- a/Tests/ManifoldServerTests/ServerBackendProviderTests.swift
+++ b/Tests/ManifoldServerTests/ServerBackendProviderTests.swift
@@ -31,12 +31,81 @@ final class ServerBackendProviderTests: XCTestCase {
         let provider = FakeServerBackendProvider(models: ["alpha", "beta"], backend: backend)
 
         let models = try await provider.listModels()
+        let modelRecords = try await provider.listModelRecords()
         let resolved = try await provider.backend(for: ServerBackendRequest(model: "beta"))
 
         XCTAssertEqual(models, ["alpha", "beta"])
+        XCTAssertEqual(modelRecords.map(\.id), ["alpha", "beta"])
+        XCTAssertEqual(modelRecords.map(\.status), ["available", "available"])
         XCTAssertTrue(resolved is MockInferenceBackend)
-        XCTAssertEqual(provider.listModelsCallCount, 1)
+        XCTAssertEqual(provider.listModelsCallCount, 2)
         XCTAssertEqual(provider.backendRequests, [ServerBackendRequest(model: "beta")])
+    }
+
+    func testTraitAwareProviderAnnotatesModelRecords() async throws {
+        let provider = TraitAwareServerBackendProvider(selection: ServerBackendSelection(
+            backend: .ollama,
+            model: "llama3",
+            ollamaBaseURL: "http://localhost:11434"
+        ))
+
+        let records = try await provider.listModelRecords()
+
+        XCTAssertEqual(records, [
+            ModelsListResponse.Model(
+                id: "llama3",
+                status: "available",
+                backend: "ollama",
+                source: "remote_endpoint"
+            )
+        ])
+    }
+
+    func testTraitAwareProviderListsOllamaDefaultModel() async throws {
+        let provider = TraitAwareServerBackendProvider(selection: ServerBackendSelection(
+            backend: .ollama,
+            ollamaBaseURL: "http://localhost:11434"
+        ))
+
+        let records = try await provider.listModelRecords()
+
+        XCTAssertEqual(records, [
+            ModelsListResponse.Model(
+                id: "llama3.2",
+                status: "available",
+                backend: "ollama",
+                source: "remote_endpoint"
+            )
+        ])
+    }
+
+    func testTraitAwareProviderMarksMLXModelPathLoadedBeforeModelIdentifier() async throws {
+        let provider = TraitAwareServerBackendProvider(
+            selection: ServerBackendSelection(
+                backend: .mlx,
+                model: "mlx-community/example",
+                modelPath: "Models/example"
+            )
+        )
+
+        let modelID = await provider.modelID(for: ServerBackendRequest(model: "request-override"))
+
+        XCTAssertEqual(modelID, "Models/example")
+    }
+
+    func testTraitAwareProviderListsLoadedOverrideBeforeConfiguredModels() async throws {
+        let provider = TraitAwareServerBackendProvider(
+            selection: ServerBackendSelection(
+                backend: .ollama,
+                ollamaBaseURL: "http://localhost:11434"
+            ),
+            loadedModelID: "llama3"
+        )
+
+        let records = try await provider.listModelRecords()
+
+        XCTAssertEqual(records.map(\.id), ["llama3", "llama3.2"])
+        XCTAssertEqual(records.map(\.status), ["loaded", "available"])
     }
 }
 


### PR DESCRIPTION
## Summary\n- add richer /v1/models records with OpenAI-compatible created/owned_by metadata\n- include Manifold-specific status/backend/source fields for configured and loaded models\n- make trait-aware providers include Ollama defaults and loaded request overrides in the model list\n\n## Validation\n- scripts/test.sh --filter ManifoldServerTests --disable-default-traits --traits Server --skip-update --min-passed 1\n- swift build --build-tests --disable-default-traits --traits Server