### PR TITLE
fix(llama): synchronize Metal command buffers between consecutive generate() calls

### DIFF
--- a/Sources/ManifoldLlama/LlamaGenerationDriver.swift
+++ b/Sources/ManifoldLlama/LlamaGenerationDriver.swift
@@ -334,6 +334,11 @@ struct LlamaGenerationDriver {
 
         if promptDecodeFailed {
             Self.logger.error("Llama prompt decode failed")
+            // Synchronize before returning so any partially-committed Metal
+            // command buffers from the prompt chunks that did succeed are
+            // flushed.  The next generate() call will clear the KV cache;
+            // without this fence that clear can race with in-flight GPU work.
+            llama_synchronize(context)
             await MainActor.run { generationStream.setPhase(.failed("Failed to decode prompt")) }
             continuation.finish(throwing: InferenceError.inferenceFailure("Failed to decode prompt"))
             return false
@@ -342,6 +347,8 @@ struct LlamaGenerationDriver {
         // Honour cancellation that fired mid-prompt before entering the
         // generation loop.
         if isCancelled() {
+            // Flush any Metal ops from prompt chunks already decoded.
+            llama_synchronize(context)
             await MainActor.run { generationStream.setPhase(.done) }
             continuation.finish()
             return true
@@ -547,6 +554,10 @@ struct LlamaGenerationDriver {
             if isCancelled() { break }
 
             if llama_decode(context, genBatch) != 0 {
+                // Synchronize before surfacing the error so the GPU drains any
+                // work that *did* commit before the failure.  Without this, a
+                // subsequent KV-cache clear from a retry can race Metal ops.
+                llama_synchronize(context)
                 await MainActor.run { generationStream.setPhase(.failed("Decode failed during generation")) }
                 continuation.finish(throwing: InferenceError.inferenceFailure("Decode failed during generation"))
                 return false
@@ -566,6 +577,28 @@ struct LlamaGenerationDriver {
                 continuation.yield(event)
             }
         }
+
+        // Flush all pending Metal command buffers before returning.
+        //
+        // `llama_decode` enqueues Metal compute passes asynchronously — by the
+        // time the generation loop exits (EOG, cancellation, or token budget),
+        // the GPU may still be executing the last batch.  If the caller
+        // immediately starts a new `generate()` call, the KV-cache clear
+        // (`llama_memory_clear` / `llama_memory_seq_rm`) at the top of the next
+        // run enqueues *new* Metal operations before the previous command buffers
+        // have committed.  That ordering violation trips llama.cpp's internal
+        // render-set assertion:
+        //
+        //   GGML_ASSERT([rsets->data count] == 0)   (ggml-metal-device.m:618)
+        //
+        // which leads to corrupted KV state and, on the very next `llama_decode`,
+        // a Swift array bounds crash (ContiguousArrayBuffer.swift:692).
+        // `llama_synchronize` blocks the calling thread until the GPU is idle,
+        // making the context safe for the next caller.  The call is cheap when
+        // the GPU is already done (typically sub-millisecond) and is the
+        // authoritative fix recommended by the llama.cpp contract (see
+        // `docs/LLAMA_CONTRACT.md` and `llama.h` line 972).
+        llama_synchronize(context)
 
         await MainActor.run { generationStream.setPhase(.done) }
         Self.logger.debug("LlamaGenerationDriver run finished")

--- a/Tests/ManifoldE2ETests/LlamaE2ETests.swift
+++ b/Tests/ManifoldE2ETests/LlamaE2ETests.swift
@@ -264,6 +264,34 @@ final class LlamaE2ETests: XCTestCase {
         }
     }
 
+    /// Regression test for the Metal render-set assertion that fires when a second
+    /// `generate()` call starts before the GPU has drained the previous run's command
+    /// buffers.
+    ///
+    /// Root cause: `llama_decode` enqueues Metal compute passes asynchronously.  Without
+    /// `llama_synchronize` at the end of the generation driver, the KV-cache clear at the
+    /// top of the next `run()` call (`llama_memory_clear` / `llama_memory_seq_rm`) can
+    /// race in-flight GPU work, tripping:
+    ///
+    ///   GGML_ASSERT([rsets->data count] == 0)   (ggml-metal-device.m:618)
+    ///
+    /// which corrupts context state and causes a Swift array bounds crash on the next
+    /// `llama_decode` call.  The fix adds `llama_synchronize(context)` at every exit
+    /// path of `LlamaGenerationDriver.run()`.
+    ///
+    /// Model: any GGUF — the race is architecture-independent; it is gated by the
+    /// `LLAMA_TEST_MODEL` env check so it only runs when a model is present.
+    func test_consecutiveGenerateCalls_doesNotCrash() async throws {
+        let firstResponse = try await generate(prompt: "Say hello in one word.")
+        XCTAssertFalse(firstResponse.isEmpty, "First generate() call should return non-empty output")
+
+        // The second call was the crash site before the fix: Metal command buffers from
+        // the first run were still in flight when the KV-cache clear for the second run
+        // enqueued new GPU operations, tripping the render-set assertion.
+        let secondResponse = try await generate(prompt: "Say goodbye in one word.")
+        XCTAssertFalse(secondResponse.isEmpty, "Second consecutive generate() call should return non-empty output without crashing")
+    }
+
     func test_backendCapabilities() {
         XCTAssertTrue(backend.capabilities.supportsStreaming)
         XCTAssertFalse(backend.capabilities.isRemote)

--- a/docs/LLAMA_CONTRACT.md
+++ b/docs/LLAMA_CONTRACT.md
@@ -465,6 +465,39 @@ systems where it does not recognise `NSLock` as a synchronisation primitive.
 between the `stopGeneration()` caller thread and the generation task background
 thread.
 
+### 5. Unsynchronized Metal command buffers between consecutive `generate()` calls — fixed in this PR
+
+**Violation:** `llama_decode` enqueues Metal compute passes asynchronously.
+When `LlamaGenerationDriver.run()` returned without calling `llama_synchronize`,
+the GPU could still be executing the final batch's command buffers at the time
+the *next* `generate()` call began.  The KV-cache clear at the top of the new
+run (`llama_memory_clear` / `llama_memory_seq_rm`) enqueues fresh Metal
+operations before the previous command buffers had committed.  That ordering
+violation trips llama.cpp's internal render-set assertion:
+
+```
+GGML_ASSERT([rsets->data count] == 0)   (ggml-metal-device.m:618)
+Signal 5 (SIGTRAP)
+Swift/ContiguousArrayBuffer.swift:692: Fatal error: Index out of range
+```
+
+The crash was model-specific (observed on llama3.1:8b, not Qwen3-4B) because
+larger models produce longer Metal command buffers that are more likely to still
+be in flight when the second call begins.
+
+**Fix:** `llama_synchronize(context)` is called at every exit path of
+`LlamaGenerationDriver.run()`: the normal completion path, the mid-prompt
+cancellation path, the prompt-decode-failure path, and the in-loop
+decode-failure path.  `llama_synchronize` blocks the calling thread until the
+GPU is idle — sub-millisecond when the GPU is already done — and is the
+authoritative synchronization primitive for this purpose (see `llama.h` line 972).
+
+**Detection signal:** `GGML_ASSERT([rsets->data count] == 0)` in
+`ggml-metal-device.m` on the second consecutive `generate()` call; followed by
+a Swift `Fatal error: Index out of range` in `ContiguousArrayBuffer.swift`.
+Regression test: `test_consecutiveGenerateCalls_doesNotCrash` in
+`Tests/ManifoldE2ETests/LlamaE2ETests.swift`.
+
 ---
 
 ## Security


### PR DESCRIPTION
## Root cause

`llama_decode` enqueues Metal compute passes asynchronously. `LlamaGenerationDriver.run()` was returning without calling `llama_synchronize`, leaving the GPU potentially still executing the previous run's command buffers. When the next `generate()` call began immediately after, the KV-cache clear at the top of the new run (`llama_memory_clear` / `llama_memory_seq_rm`) enqueued fresh Metal operations before the prior command buffers had committed. That ordering violation trips llama.cpp's internal render-set assertion:

```
GGML_ASSERT([rsets->data count] == 0)   (ggml-metal-device.m:618)
Signal 5 (SIGTRAP)
Swift/ContiguousArrayBuffer.swift:692: Fatal error: Index out of range
```

The crash manifested only on the *second* consecutive `generate()` call (first call succeeds, Metal assert fires asynchronously, state corrupts, second call crashes). It was model-specific to llama3.1:8b and not Qwen3-4B because larger models produce longer Metal command buffers that are more likely to still be in flight when the second call starts.

## Fix

Add `llama_synchronize(context)` at every exit path of `LlamaGenerationDriver.run()`:

- **Normal completion** (EOG / token budget / repetition guard) — the primary crash path
- **Mid-prompt cancellation** — partial prompt decode may have run
- **Prompt-decode failure** — chunks that did succeed left Metal work in flight
- **In-loop decode failure** — same reasoning

`llama_synchronize` blocks the calling thread until the GPU is idle. It is sub-millisecond when the GPU has already finished and is the authoritative synchronization primitive for this purpose (`llama.h` line 972).

This is the in-process, between-calls variant of the same class of bug fixed for teardown in `unloadAndWait()` (issue #391).

## Changes

- `Sources/ManifoldLlama/LlamaGenerationDriver.swift` — four `llama_synchronize` call sites, one per exit path
- `Tests/ManifoldE2ETests/LlamaE2ETests.swift` — `test_consecutiveGenerateCalls_doesNotCrash`: calls `generate()` twice in sequence and asserts both return non-empty output
- `docs/LLAMA_CONTRACT.md` — documents this as known violation #5 with root cause, fix, and detection signal

## Test results

```
LLAMA_TEST_MODEL="$HOME/Documents/Models/llama3.1-8b-instruct-Q4_K_M.gguf" \
  swift test --traits Llama --filter LlamaE2ETests --skip-update
```

Executed 11 tests, with 1 test skipped and 0 failures.