### PR TITLE
feat(benchmark): add repeatable backend throughput benchmark suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ for the full list of dependency rules the lint enforces.
 ### 1. Add the package
 
 ```swift
-.package(url: "https://github.com/roryford/ManifoldKit.git", from: "0.21.0")
+.package(url: "https://github.com/roryford/ManifoldKit.git", from: "0.22.0")
 ```
 
 Most apps add a single product — the `ManifoldKit` umbrella, which re-exports
@@ -173,7 +173,7 @@ Pass the matching set as `traits:` on your `.package(...)` entry to lock the con
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.21.0",
+    from: "0.22.0",
     traits: [
         .trait(name: "MLX"),
         .trait(name: "Llama"),
@@ -199,7 +199,7 @@ Apple Foundation Models.
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.21.0",
+    from: "0.22.0",
     traits: ["FoundationOnly"]   // overrides the MLX/Llama/HuggingFace defaults
 )
 ```
@@ -216,7 +216,7 @@ Equivalent legacy form (still supported, before the named trait existed):
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.21.0",
+    from: "0.22.0",
     traits: []   // disables MLX, Llama, HuggingFace defaults
 )
 ```
@@ -237,7 +237,7 @@ For example, a cloud-only consumer can keep the chat UI and local-model loaders 
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.21.0",
+    from: "0.22.0",
     traits: [
         .trait(name: "MLX"),
         .trait(name: "Llama"),
@@ -285,7 +285,7 @@ If you already depend on `ManifoldBackends`, the same data is also available via
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.21.0",
+    from: "0.22.0",
     traits: [
         .trait(name: "MCP"),
         .trait(name: "MCPBuiltinCatalog"), // optional: only if you use MCPCatalog
@@ -325,7 +325,7 @@ stock `ChatInputBar`.
 ```swift
  .package(
      url: "https://github.com/roryford/ManifoldKit.git",
-     from: "0.21.0",
+     from: "0.22.0",
      traits: [
          .trait(name: "Voice"),
      ]
@@ -401,7 +401,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/roryford/ManifoldKit.git",
-            from: "0.21.0",
+            from: "0.22.0",
             traits: [
                 .trait(name: "MLX"),
                 .trait(name: "Llama"),
@@ -1002,7 +1002,7 @@ open ManifoldDemo.xcodeproj
 
 This package was renamed from `BaseChatKit` to `ManifoldKit` in v0.20. The old GitHub URL `github.com/roryford/BaseChatKit` redirects to `roryford/ManifoldKit`, but for clarity:
 
-- Update SPM dependencies: `.package(url: "https://github.com/roryford/ManifoldKit.git", from: "0.21.0")`
+- Update SPM dependencies: `.package(url: "https://github.com/roryford/ManifoldKit.git", from: "0.22.0")`
 - Update imports: `import BaseChatKit` → `import ManifoldKit` (and similarly for sub-modules — `BaseChatInference` → `ManifoldInference`, etc.)
 - Renamed public types: `BaseChatBootstrap` → `ManifoldBootstrap`, `BaseChatConfiguration` → `ManifoldConfiguration`, `BaseChatSchemaV3/4/5` → `ManifoldSchemaV3/4/5`, `BaseChatMigrationPlan` → `ManifoldMigrationPlan`, `BaseChatBackgroundTaskIdentifiers` → `ManifoldBackgroundTaskIdentifiers`
 - **BREAKING — local SwiftData stores reset.** SwiftData persists fully-qualified `@Model` type names; renaming the schema namespace orphans existing on-disk stores. Apps upgrading from 0.19.x will create fresh databases on first launch. We chose this clean break over preserving data with `@Model.originalName` because v0.20 is pre-1.0.

--- a/Tests/ManifoldE2ETests/BackendBenchmarkE2ETests.swift
+++ b/Tests/ManifoldE2ETests/BackendBenchmarkE2ETests.swift
@@ -67,10 +67,15 @@ private func printResults(
     }
     let sortedTTFT = results.map(\.ttftMs).sorted()
     let sortedTPS  = results.map { Double($0.tokens) / ($0.totalMs / 1000) }.sorted()
-    let mid = results.count / 2
+    // Compute true median: average the two middle values for even counts,
+    // matching Python's statistics.median() behaviour.
+    func median(_ xs: [Double]) -> Double {
+        let n = xs.count
+        return n.isMultiple(of: 2) ? (xs[n / 2 - 1] + xs[n / 2]) / 2 : xs[n / 2]
+    }
     // BENCH_RESULT sentinel — grep'd by benchmark.sh to assemble the table.
     print(String(format: "BENCH_RESULT label=%@ model=%@ median_ttft_ms=%.0f median_tps=%.1f",
-                 label, model, sortedTTFT[mid], sortedTPS[mid]))
+                 label, model, median(sortedTTFT), median(sortedTPS)))
 }
 
 // MARK: - Ollama backend

--- a/Tests/ManifoldE2ETests/BackendBenchmarkE2ETests.swift
+++ b/Tests/ManifoldE2ETests/BackendBenchmarkE2ETests.swift
@@ -1,0 +1,193 @@
+/// Backend throughput benchmarks — local developer use only, never run in CI.
+///
+/// Measures TTFT and tokens/sec for each compiled-in backend through the
+/// ManifoldKit SDK. Results are printed via a `BENCH_RESULT` sentinel line
+/// that `scripts/benchmark.sh` greps to assemble a Markdown table.
+///
+/// ## Running individually
+///
+/// ```bash
+/// # Ollama backend (requires Ollama at localhost:11434):
+/// MANIFOLD_BENCH_OLLAMA_MODEL=llama3.1:8b \
+///   xcrun swift test --traits Ollama \
+///   --filter OllamaBackendBenchmark --skip-update
+///
+/// # LlamaBackend (set MANIFOLD_BENCH_LLAMA_MODEL to an absolute .gguf path):
+/// MANIFOLD_BENCH_LLAMA_MODEL=~/Documents/Models/llama3.1-8b-instruct-Q4_K_M.gguf \
+///   xcrun swift test --traits Llama \
+///   --filter LlamaBackendBenchmark --skip-update
+/// ```
+///
+/// MLX requires Xcode — use `scripts/benchmark.sh --mlx` for that path.
+import XCTest
+import ManifoldInference
+@testable import ManifoldTestSupport
+@testable import ManifoldBackends
+
+// MARK: - Shared helpers
+
+private let benchPrompt = "Write a short story about a robot learning to paint. Be concise."
+private let benchRuns   = 4
+private let benchTokens = 300
+
+@MainActor
+private func timedGenerate(
+    backend: any InferenceBackend,
+    maxOutputTokens: Int = benchTokens
+) async throws -> (ttftMs: Double, totalMs: Double, tokens: Int) {
+    let config = GenerationConfig(temperature: 0.3, maxOutputTokens: maxOutputTokens)
+    let t0 = ContinuousClock.now
+    var t1: ContinuousClock.Instant?
+    var count = 0
+
+    let stream = try backend.generate(prompt: benchPrompt, systemPrompt: nil, config: config)
+    for try await event in stream.events {
+        if case .token = event {
+            if t1 == nil { t1 = ContinuousClock.now }
+            count += 1
+        }
+    }
+    let t2 = ContinuousClock.now
+
+    func ms(_ d: Duration) -> Double {
+        Double(d.components.seconds) * 1000 + Double(d.components.attoseconds) / 1e15
+    }
+    guard let first = t1 else { return (0, ms(t2 - t0), 0) }
+    return (ms(first - t0), ms(t2 - t0), count)
+}
+
+private func printResults(
+    label: String, model: String,
+    results: [(ttftMs: Double, totalMs: Double, tokens: Int)]
+) {
+    for (i, r) in results.enumerated() {
+        let tps = Double(r.tokens) / (r.totalMs / 1000)
+        print(String(format: "  [%@ run %d] TTFT=%.0fms  total=%.0fms  tokens=%d  TPS=%.1f",
+                     label, i + 1, r.ttftMs, r.totalMs, r.tokens, tps))
+    }
+    let sortedTTFT = results.map(\.ttftMs).sorted()
+    let sortedTPS  = results.map { Double($0.tokens) / ($0.totalMs / 1000) }.sorted()
+    let mid = results.count / 2
+    // BENCH_RESULT sentinel — grep'd by benchmark.sh to assemble the table.
+    print(String(format: "BENCH_RESULT label=%@ model=%@ median_ttft_ms=%.0f median_tps=%.1f",
+                 label, model, sortedTTFT[mid], sortedTPS[mid]))
+}
+
+// MARK: - Ollama backend
+
+#if Ollama
+@MainActor
+final class OllamaBackendBenchmark: XCTestCase {
+
+    private var backend: OllamaBackend!
+    private var modelName: String = "unknown"
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try XCTSkipUnless(HardwareRequirements.hasOllamaServer,
+                          "Ollama server not running at localhost:11434")
+        // Prefer explicit model from MANIFOLD_BENCH_OLLAMA_MODEL (set by benchmark.sh),
+        // otherwise auto-discover the first available model.
+        let envModel = ProcessInfo.processInfo.environment["MANIFOLD_BENCH_OLLAMA_MODEL"] ?? ""
+        if !envModel.isEmpty {
+            modelName = envModel
+        } else if let found = HardwareRequirements.findOllamaModel() {
+            modelName = found
+        } else {
+            throw XCTSkip("No Ollama model — set MANIFOLD_BENCH_OLLAMA_MODEL=<name>")
+        }
+        backend = OllamaBackend()
+        backend.configure(baseURL: URL(string: "http://localhost:11434")!, modelName: modelName)
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+    }
+
+    override func tearDown() async throws {
+        backend?.unloadModel(); backend = nil
+        try await super.tearDown()
+    }
+
+    func test_throughput() async throws {
+        let config = GenerationConfig(temperature: 0.3, maxOutputTokens: benchTokens)
+        // Warmup
+        let warmup = try backend.generate(prompt: benchPrompt, systemPrompt: nil, config: config)
+        for try await _ in warmup.events {}
+
+        var results: [(ttftMs: Double, totalMs: Double, tokens: Int)] = []
+        for _ in 1...benchRuns {
+            results.append(try await timedGenerate(backend: backend))
+        }
+        printResults(label: "ManifoldKit→Ollama", model: modelName, results: results)
+        XCTAssertGreaterThan(results.map { Double($0.tokens) / ($0.totalMs / 1000) }.max() ?? 0, 5)
+    }
+}
+#endif
+
+// MARK: - Llama backend
+
+#if Llama
+@MainActor
+final class LlamaBackendBenchmark: XCTestCase {
+
+    // Shared across test methods — llama_backend_init is once-per-process.
+    private nonisolated(unsafe) static var sharedBackend: LlamaBackend?
+    private nonisolated(unsafe) static var sharedModelURL: URL?
+
+    private var backend: LlamaBackend!
+    private var modelURL: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try XCTSkipUnless(HardwareRequirements.isAppleSilicon, "Requires Apple Silicon")
+        try XCTSkipUnless(HardwareRequirements.isPhysicalDevice, "Requires Metal")
+
+        // MANIFOLD_BENCH_LLAMA_MODEL (absolute path) is set by benchmark.sh.
+        // Fall back to MANIFOLD_DISCOVER_LOCAL_MODELS + LLAMA_TEST_MODEL hint.
+        let url: URL
+        let envPath = ProcessInfo.processInfo.environment["MANIFOLD_BENCH_LLAMA_MODEL"] ?? ""
+        if !envPath.isEmpty, FileManager.default.fileExists(atPath: envPath) {
+            url = URL(fileURLWithPath: envPath)
+        } else if let found = HardwareRequirements.findGGUFModel() {
+            url = found
+        } else {
+            throw XCTSkip(
+                "No GGUF found. Set MANIFOLD_BENCH_LLAMA_MODEL=<path> or " +
+                "MANIFOLD_DISCOVER_LOCAL_MODELS=1 + LLAMA_TEST_MODEL=<name hint>"
+            )
+        }
+
+        if Self.sharedBackend == nil {
+            let fresh = LlamaBackend()
+            try await fresh.loadModel(from: url, plan: .testStub(effectiveContextSize: 4096))
+            Self.sharedBackend = fresh
+            Self.sharedModelURL = url
+        }
+        backend  = Self.sharedBackend
+        modelURL = Self.sharedModelURL
+    }
+
+    override func tearDown() async throws {
+        backend = nil; modelURL = nil
+        try await super.tearDown()
+    }
+
+    func test_throughput() async throws {
+        let config = GenerationConfig(temperature: 0.3, maxOutputTokens: benchTokens)
+        // Warmup
+        let warmup = try backend.generate(prompt: benchPrompt, systemPrompt: nil, config: config)
+        for try await _ in warmup.events {}
+
+        var results: [(ttftMs: Double, totalMs: Double, tokens: Int)] = []
+        for _ in 1...benchRuns {
+            results.append(try await timedGenerate(backend: backend))
+        }
+        printResults(label: "ManifoldKit→Llama", model: modelURL.lastPathComponent, results: results)
+        XCTAssertGreaterThan(results.map { Double($0.tokens) / ($0.totalMs / 1000) }.max() ?? 0, 5)
+    }
+
+    func test_zzz_cleanup() async throws {
+        guard let b = Self.sharedBackend else { return }
+        await b.unloadAndWait()
+        Self.sharedBackend = nil
+    }
+}
+#endif

--- a/scripts/bench/http-bench.py
+++ b/scripts/bench/http-bench.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+ManifoldKit HTTP backend benchmark client.
+
+Measures TTFT and throughput for any OpenAI-compatible or Ollama-native
+streaming endpoint. Token count is derived by counting SSE content chunks
+(each chunk == 1 token for llama.cpp/Ollama-backed servers).
+
+Usage:
+    # OpenAI-compat endpoint (ManifoldKit server, Ollama /v1/):
+    python3 http-bench.py --url http://localhost:8080/v1/chat/completions \
+        --model llama3.1:8b --runs 4
+
+    # Ollama native endpoint:
+    python3 http-bench.py --url http://localhost:11434/api/generate \
+        --model llama3.1:8b --mode ollama --runs 4
+
+    # Print as Markdown row (for benchmark.sh table assembly):
+    python3 http-bench.py ... --label "Raw Ollama" --markdown
+"""
+
+import argparse
+import json
+import statistics
+import sys
+import time
+import urllib.request
+
+PROMPT = "Write a short story about a robot learning to paint. Be concise."
+MAX_TOKENS = 300
+
+
+def bench_openai(url: str, model: str, runs: int) -> list[dict]:
+    results = []
+
+    def run_once() -> tuple[float, float, int]:
+        payload = json.dumps({
+            "model": model,
+            "messages": [{"role": "user", "content": PROMPT}],
+            "stream": True,
+            "max_tokens": MAX_TOKENS,
+        }).encode()
+        req = urllib.request.Request(
+            url, data=payload, headers={"Content-Type": "application/json"}
+        )
+        t_start = time.perf_counter()
+        t_first = None
+        token_count = 0
+        t_end = t_start
+        with urllib.request.urlopen(req, timeout=180) as resp:
+            for raw in resp:
+                line = raw.strip()
+                if not line or line == b"data: [DONE]":
+                    continue
+                if line.startswith(b"data: "):
+                    try:
+                        chunk = json.loads(line[6:])
+                        content = (
+                            chunk.get("choices", [{}])[0]
+                            .get("delta", {})
+                            .get("content", "")
+                        )
+                        if content:
+                            if t_first is None:
+                                t_first = time.perf_counter()
+                            token_count += 1  # 1 SSE chunk == 1 token
+                    except (json.JSONDecodeError, IndexError, KeyError):
+                        pass
+        t_end = time.perf_counter()
+        return (t_first - t_start) if t_first else 0.0, t_end - t_start, token_count
+
+    # Warmup
+    run_once()
+
+    for _ in range(runs):
+        ttft, total, tokens = run_once()
+        results.append({"ttft_ms": ttft * 1000, "total_ms": total * 1000, "tokens": tokens})
+
+    return results
+
+
+def bench_ollama(url: str, model: str, runs: int) -> list[dict]:
+    results = []
+
+    def run_once() -> tuple[float, float, int]:
+        payload = json.dumps({"model": model, "prompt": PROMPT, "stream": True}).encode()
+        req = urllib.request.Request(
+            url, data=payload, headers={"Content-Type": "application/json"}
+        )
+        t_start = time.perf_counter()
+        t_first = None
+        t_end = t_start
+        eval_count = 0
+        eval_duration_ns = 0
+        with urllib.request.urlopen(req, timeout=180) as resp:
+            for raw in resp:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    data = json.loads(raw)
+                    if data.get("response"):
+                        if t_first is None:
+                            t_first = time.perf_counter()
+                    if data.get("done"):
+                        t_end = time.perf_counter()
+                        eval_count = data.get("eval_count", 0)
+                        eval_duration_ns = data.get("eval_duration", 0)
+                except json.JSONDecodeError:
+                    pass
+        tps = eval_count / (eval_duration_ns / 1e9) if eval_duration_ns else 0
+        return (t_first - t_start) if t_first else 0.0, t_end - t_start, eval_count
+
+    # Warmup
+    run_once()
+
+    for _ in range(runs):
+        ttft, total, tokens = run_once()
+        results.append({"ttft_ms": ttft * 1000, "total_ms": total * 1000, "tokens": tokens})
+
+    return results
+
+
+def summarize(results: list[dict]) -> dict:
+    ttfts = [r["ttft_ms"] for r in results]
+    tpss = [r["tokens"] / (r["total_ms"] / 1000) for r in results]
+    return {
+        "median_ttft_ms": statistics.median(ttfts),
+        "median_tps": statistics.median(tpss),
+        "runs": len(results),
+    }
+
+
+def main():
+    p = argparse.ArgumentParser(description="ManifoldKit HTTP benchmark client")
+    p.add_argument("--url", required=True, help="Endpoint URL")
+    p.add_argument("--model", required=True, help="Model name/id")
+    p.add_argument("--mode", choices=["openai", "ollama"], default="openai",
+                   help="API format (default: openai)")
+    p.add_argument("--runs", type=int, default=4, help="Timed runs after warmup")
+    p.add_argument("--label", default="", help="Row label for --markdown output")
+    p.add_argument("--markdown", action="store_true",
+                   help="Print a single Markdown table row instead of verbose output")
+    args = p.parse_args()
+
+    bench_fn = bench_ollama if args.mode == "ollama" else bench_openai
+    results = bench_fn(args.url, args.model, args.runs)
+    s = summarize(results)
+
+    if args.markdown:
+        label = args.label or args.url
+        print(f"| {label} | {s['median_ttft_ms']:.0f} ms | {s['median_tps']:.1f} tok/s |")
+    else:
+        print(f"median TTFT : {s['median_ttft_ms']:.0f} ms")
+        print(f"median TPS  : {s['median_tps']:.1f} tok/s")
+        print(f"runs        : {s['runs']}")
+        for i, r in enumerate(results, 1):
+            tps = r["tokens"] / (r["total_ms"] / 1000)
+            print(f"  run {i}: TTFT={r['ttft_ms']:.0f}ms  "
+                  f"total={r['total_ms']:.0f}ms  tokens={r['tokens']}  TPS={tps:.1f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench/http-bench.py
+++ b/scripts/bench/http-bench.py
@@ -149,7 +149,7 @@ def main():
 
     if args.markdown:
         label = args.label or args.url
-        print(f"| {label} | {s['median_ttft_ms']:.0f} ms | {s['median_tps']:.1f} tok/s |")
+        print(f"| {label} | {s['median_ttft_ms']:.0f} ms | {s['median_tps']:.1f} tok/s | {args.model} |")
     else:
         print(f"median TTFT : {s['median_ttft_ms']:.0f} ms")
         print(f"median TPS  : {s['median_tps']:.1f} tok/s")

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# scripts/benchmark.sh — ManifoldKit backend throughput benchmark suite
+#
+# Measures TTFT (time-to-first-token) and tokens/sec across all available
+# backends and surfaces the results as a Markdown table.
+#
+# Local developer use only — never run in CI.
+#
+# ## Quick start
+#
+#   scripts/benchmark.sh
+#
+# Auto-detects available backends and skips paths that aren't configured.
+#
+# ## Configuration (environment variables)
+#
+#   OLLAMA_URL            Ollama base URL (default: http://localhost:11434)
+#   OLLAMA_MODEL          Model for Ollama paths (default: auto-select)
+#   LLAMA_MODEL_PATH      Absolute path to a GGUF file for LlamaBackend paths
+#                         (default: auto-discover from ~/Documents/Models/)
+#   LLAMA_MODEL_HINT      Name substring for GGUF discovery when LLAMA_MODEL_PATH
+#                         is not set (default: "")
+#   BENCH_RUNS            Warm runs per path (default: 4)
+#   BENCH_SERVER_PORT     Port for the temporary ManifoldKit server (default: 18080)
+#
+# ## Flags
+#
+#   --mlx         Also benchmark ManifoldKit → MLXBackend (requires Xcode)
+#   --no-raw      Skip the raw Ollama HTTP baseline
+#   --only PATH   Run only one path:
+#                   ollama-raw | sdk-ollama | sdk-llama | server-ollama | server-llama | mlx
+#
+# ## Examples
+#
+#   # Full suite with a specific llama3.1:8b GGUF:
+#   LLAMA_MODEL_PATH=~/Documents/Models/llama3.1-8b-instruct-Q4_K_M.gguf \
+#     scripts/benchmark.sh
+#
+#   # Llama paths only:
+#   LLAMA_MODEL_HINT=llama3.1 scripts/benchmark.sh --only sdk-llama
+#
+#   # Include MLX:
+#   scripts/benchmark.sh --mlx
+#
+# ## First-run note
+#
+# On a clean checkout, run `xcrun swift build --traits Ollama,Llama,MLX` once
+# before invoking this script. The warm-up step below does this automatically.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+OLLAMA_URL="${OLLAMA_URL:-http://localhost:11434}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-}"
+LLAMA_MODEL_PATH="${LLAMA_MODEL_PATH:-}"
+LLAMA_MODEL_HINT="${LLAMA_MODEL_HINT:-}"
+BENCH_RUNS="${BENCH_RUNS:-4}"
+BENCH_SERVER_PORT="${BENCH_SERVER_PORT:-18080}"
+RUN_MLX=0
+SKIP_RAW=0
+ONLY_PATH=""
+
+for arg in "$@"; do
+    case "$arg" in
+        --mlx)     RUN_MLX=1 ;;
+        --no-raw)  SKIP_RAW=1 ;;
+        --only=*)  ONLY_PATH="${arg#*=}" ;;
+        --only)    shift; ONLY_PATH="$1" ;;
+        -h|--help)
+            grep "^#" "$0" | sed 's/^# \?//' | sed 's/^#//'
+            exit 0
+            ;;
+    esac
+done
+
+# ── Colours ───────────────────────────────────────────────────────────────────
+BOLD=""; DIM=""; RESET=""
+if [[ -t 1 ]]; then BOLD="\033[1m"; DIM="\033[2m"; RESET="\033[0m"; fi
+
+log()  { echo -e "${DIM}[bench]${RESET} $*"; }
+head_() { echo -e "\n${BOLD}$*${RESET}"; }
+
+# ── Dependency checks ─────────────────────────────────────────────────────────
+if ! command -v python3 &>/dev/null; then
+    echo "error: python3 required" >&2; exit 1
+fi
+BENCH_PY="$(dirname "$0")/bench/http-bench.py"
+if [[ ! -f "$BENCH_PY" ]]; then
+    echo "error: scripts/bench/http-bench.py not found" >&2; exit 1
+fi
+
+# ── First-run warm-up ─────────────────────────────────────────────────────────
+# Ensures _NumericsShims and all module interfaces are cached before the
+# parallel xcrun swift test compilations start. No-op on subsequent runs.
+log "Warming up build artifacts (xcrun swift build)…"
+xcrun swift build --traits Ollama,Llama,MLX 2>&1 | { grep -E "Build complete|^error:" || true; } | head -3 || true
+
+# ── Backend detection ─────────────────────────────────────────────────────────
+OLLAMA_AVAILABLE=0
+LLAMA_AVAILABLE=0
+LLAMA_RESOLVED=""
+
+if curl -sf "${OLLAMA_URL}/api/tags" > /dev/null 2>&1; then
+    OLLAMA_AVAILABLE=1
+    if [[ -z "$OLLAMA_MODEL" ]]; then
+        OLLAMA_MODEL=$(curl -sf "${OLLAMA_URL}/api/tags" | \
+            python3 -c "import json,sys; ms=json.load(sys.stdin)['models']; \
+            print(ms[0]['name'] if ms else '')" 2>/dev/null || true)
+    fi
+    [[ -n "$OLLAMA_MODEL" ]] || OLLAMA_AVAILABLE=0
+fi
+
+if [[ -n "$LLAMA_MODEL_PATH" ]]; then
+    expanded="${LLAMA_MODEL_PATH/#\~/$HOME}"
+    if [[ -f "$expanded" && "$expanded" == *.gguf ]]; then
+        LLAMA_AVAILABLE=1
+        LLAMA_RESOLVED="$expanded"
+    else
+        log "LLAMA_MODEL_PATH=$LLAMA_MODEL_PATH not found or not a .gguf — skipping Llama paths"
+    fi
+else
+    SEARCH_DIR="$HOME/Documents/Models"
+    if [[ -d "$SEARCH_DIR" ]]; then
+        HINT="${LLAMA_MODEL_HINT:-}"
+        FOUND=$(find "$SEARCH_DIR" -maxdepth 1 -name "*${HINT}*.gguf" -size +50M \
+            ! -name "nomic-*" ! -name "all-MiniLM-*" \
+            -exec ls -1S {} + 2>/dev/null | head -1 || true)
+        if [[ -n "$FOUND" ]]; then
+            LLAMA_AVAILABLE=1
+            LLAMA_RESOLVED="$FOUND"
+        fi
+    fi
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+head_ "ManifoldKit benchmark suite"
+[[ $OLLAMA_AVAILABLE -eq 1 ]] && log "Ollama : $OLLAMA_URL  model=$OLLAMA_MODEL" \
+                               || log "Ollama : not available (skipping Ollama paths)"
+[[ $LLAMA_AVAILABLE  -eq 1 ]] && log "Llama  : $LLAMA_RESOLVED" \
+                               || log "Llama  : no GGUF found (skipping Llama paths)"
+[[ $RUN_MLX          -eq 1 ]] && log "MLX    : enabled (requires Xcode build)" \
+                               || log "MLX    : disabled (pass --mlx to enable)"
+log "Runs   : $BENCH_RUNS warm runs per path"
+
+TABLE_ROWS=()
+add_row() { TABLE_ROWS+=("$1"); }
+
+# Extract a BENCH_RESULT sentinel line from swift test output and format it as
+# a Markdown table row.
+extract_sdk_result() {
+    local output="$1" label="$2"
+    local line
+    line=$(echo "$output" | grep "^BENCH_RESULT label=${label}" | tail -1)
+    if [[ -z "$line" ]]; then
+        echo "| ${label} | — | — | (skipped or failed) |"
+        return
+    fi
+    local ttft tps model
+    ttft=$(echo "$line"  | grep -o 'median_ttft_ms=[0-9.]*' | cut -d= -f2)
+    tps=$(echo  "$line"  | grep -o 'median_tps=[0-9.]*'     | cut -d= -f2)
+    model=$(echo "$line" | grep -o 'model=[^ ]*'            | cut -d= -f2)
+    printf "| %s | %s ms | %s tok/s | %s |\n" "$label" "${ttft%.}" "${tps%.}" "$model"
+}
+
+# ── Path 1: Raw Ollama HTTP ───────────────────────────────────────────────────
+if [[ $OLLAMA_AVAILABLE -eq 1 && $SKIP_RAW -eq 0 ]] && \
+   [[ -z "$ONLY_PATH" || "$ONLY_PATH" == "ollama-raw" ]]; then
+    head_ "Raw Ollama HTTP (baseline)"
+    ROW=$(python3 "$BENCH_PY" \
+        --url "${OLLAMA_URL}/api/generate" \
+        --model "$OLLAMA_MODEL" \
+        --mode ollama \
+        --runs "$BENCH_RUNS" \
+        --label "Raw Ollama HTTP" \
+        --markdown)
+    echo "$ROW"
+    add_row "$ROW"
+fi
+
+# ── Path 2: ManifoldKit SDK → OllamaBackend ───────────────────────────────────
+if [[ $OLLAMA_AVAILABLE -eq 1 ]] && \
+   [[ -z "$ONLY_PATH" || "$ONLY_PATH" == "sdk-ollama" ]]; then
+    head_ "ManifoldKit SDK → OllamaBackend"
+    SDK_OUT=$(MANIFOLD_BENCH_OLLAMA_MODEL="$OLLAMA_MODEL" \
+        xcrun swift test --traits Ollama \
+            --filter OllamaBackendBenchmark \
+            --skip-update 2>&1)
+    echo "$SDK_OUT" | grep -E "ManifoldKit→Ollama run|BENCH_RESULT" || true
+    add_row "$(extract_sdk_result "$SDK_OUT" "ManifoldKit→Ollama")"
+fi
+
+# ── Path 3: ManifoldKit SDK → LlamaBackend ────────────────────────────────────
+if [[ $LLAMA_AVAILABLE -eq 1 ]] && \
+   [[ -z "$ONLY_PATH" || "$ONLY_PATH" == "sdk-llama" ]]; then
+    head_ "ManifoldKit SDK → LlamaBackend"
+    SDK_OUT=$(MANIFOLD_BENCH_LLAMA_MODEL="$LLAMA_RESOLVED" \
+        xcrun swift test --traits Llama \
+            --filter LlamaBackendBenchmark \
+            --skip-update 2>&1)
+    echo "$SDK_OUT" | grep -E "ManifoldKit→Llama run|BENCH_RESULT" || true
+    add_row "$(extract_sdk_result "$SDK_OUT" "ManifoldKit→Llama")"
+fi
+
+# ── Paths 4 & 5: ManifoldKit server ──────────────────────────────────────────
+run_server_bench() {
+    local traits="$1" backend_flag="$2" model_arg="$3" label="$4"
+    local server_bin=".build/arm64-apple-macosx/debug/ManifoldServer"
+
+    log "Building ManifoldServer (traits: $traits)…"
+    xcrun swift build --traits "$traits" --product ManifoldServer 2>&1 | tail -1 || true
+
+    log "Starting ManifoldServer on port $BENCH_SERVER_PORT (backend=$backend_flag)…"
+    local log_file="/tmp/manifold-bench-server-$$.log"
+    # shellcheck disable=SC2086
+    "$server_bin" --backend "$backend_flag" $model_arg \
+        --port "$BENCH_SERVER_PORT" --unsafe-cors > "$log_file" 2>&1 &
+    local server_pid=$!
+
+    local ready=0
+    for i in $(seq 1 60); do
+        if curl -sf "http://localhost:${BENCH_SERVER_PORT}/v1/models" > /dev/null 2>&1; then
+            ready=1; log "Server ready after ${i}s"; break
+        fi
+        sleep 1
+    done
+
+    if [[ $ready -eq 0 ]]; then
+        log "Server failed to start — see $log_file"
+        kill "$server_pid" 2>/dev/null || true
+        return
+    fi
+
+    # Use the model path as the model id for the OpenAI request
+    local model_id
+    model_id=$(curl -sf "http://localhost:${BENCH_SERVER_PORT}/v1/models" | \
+        python3 -c "import json,sys; print(json.load(sys.stdin)['data'][0]['id'])" 2>/dev/null || echo "unknown")
+
+    ROW=$(python3 "$BENCH_PY" \
+        --url "http://localhost:${BENCH_SERVER_PORT}/v1/chat/completions" \
+        --model "$model_id" \
+        --mode openai \
+        --runs "$BENCH_RUNS" \
+        --label "$label" \
+        --markdown)
+    echo "$ROW"
+    add_row "$ROW"
+
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+    rm -f "$log_file"
+}
+
+if [[ $OLLAMA_AVAILABLE -eq 1 ]] && \
+   [[ -z "$ONLY_PATH" || "$ONLY_PATH" == "server-ollama" ]]; then
+    head_ "ManifoldKit server → OllamaBackend"
+    run_server_bench "Server,Ollama" "ollama" \
+        "--model $OLLAMA_MODEL --ollama-base-url $OLLAMA_URL" \
+        "ManifoldKit server→Ollama"
+fi
+
+if [[ $LLAMA_AVAILABLE -eq 1 ]] && \
+   [[ -z "$ONLY_PATH" || "$ONLY_PATH" == "server-llama" ]]; then
+    head_ "ManifoldKit server → LlamaBackend"
+    run_server_bench "Server,Llama" "llama" \
+        "--model-path $LLAMA_RESOLVED" \
+        "ManifoldKit server→Llama"
+fi
+
+# ── Path 6: ManifoldKit SDK → MLXBackend ─────────────────────────────────────
+if [[ $RUN_MLX -eq 1 ]] && \
+   [[ -z "$ONLY_PATH" || "$ONLY_PATH" == "mlx" ]]; then
+    head_ "ManifoldKit SDK → MLXBackend (via xcodebuild)"
+    MLX_HINT="${MLX_MODEL_HINT:-}"
+    MLX_OUT=$(scripts/test-mlx-integration.sh "$MLX_HINT" 2>&1 | \
+        grep -E "(MLX run|MLX summary)" || true)
+    echo "$MLX_OUT"
+    TTFT=$(echo "$MLX_OUT"  | grep "MLX summary" | grep -o 'median TTFT=[0-9.]*ms' | grep -o '[0-9.]*')
+    TPS=$(echo  "$MLX_OUT"  | grep "MLX summary" | grep -o 'median TPS=[0-9.]*'    | grep -o '[0-9.]*')
+    MODEL=$(echo "$MLX_OUT" | grep "MLX summary" | grep -o 'model=[^ ]*'           | cut -d= -f2)
+    if [[ -n "$TTFT" ]]; then
+        add_row "| ManifoldKit→MLX | ${TTFT} ms | ${TPS} tok/s | $MODEL |"
+    else
+        add_row "| ManifoldKit→MLX | — | — | (no results) |"
+    fi
+fi
+
+# ── Results table ─────────────────────────────────────────────────────────────
+if [[ ${#TABLE_ROWS[@]} -gt 0 ]]; then
+    head_ "Results"
+    echo ""
+    echo "| Path | TTFT | Throughput | Model |"
+    echo "|------|-----:|------------|-------|"
+    for row in "${TABLE_ROWS[@]}"; do
+        echo "$row"
+    done
+    echo ""
+    echo "> Prompt: \"Write a short story about a robot learning to paint. Be concise.\""
+    echo "> Runs: $BENCH_RUNS warm runs per path. Medians reported."
+    echo "> Token count: Ollama \`eval_count\` (exact); SDK paths from stream event count (exact);"
+    echo "> server paths from SSE chunk count (1 chunk ≈ 1 token for llama.cpp/Ollama)."
+fi

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -60,17 +60,18 @@ RUN_MLX=0
 SKIP_RAW=0
 ONLY_PATH=""
 
-for arg in "$@"; do
-    case "$arg" in
+while [[ $# -gt 0 ]]; do
+    case "$1" in
         --mlx)     RUN_MLX=1 ;;
         --no-raw)  SKIP_RAW=1 ;;
-        --only=*)  ONLY_PATH="${arg#*=}" ;;
+        --only=*)  ONLY_PATH="${1#*=}" ;;
         --only)    shift; ONLY_PATH="$1" ;;
         -h|--help)
             grep "^#" "$0" | sed 's/^# \?//' | sed 's/^#//'
             exit 0
             ;;
     esac
+    shift
 done
 
 # ── Colours ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a repeatable benchmark suite so developers can measure and compare TTFT + tokens/sec across ManifoldKit backends.

**New benchmark files:**
- `scripts/benchmark.sh` — orchestrator; auto-detects available backends and assembles a Markdown table
- `scripts/bench/http-bench.py` — reusable Python client for raw Ollama and server paths
- `Tests/ManifoldE2ETests/BackendBenchmarkE2ETests.swift` — in-process Swift benchmarks for OllamaBackend and LlamaBackend

**CI maintenance:**
- Bumps README install pins from `0.21.0` to `0.22.0` so `scripts/check-readme.sh` passes on this branch.

## Paths measured

| Path | How |
|------|-----|
| Raw Ollama HTTP | `http-bench.py --mode ollama` |
| ManifoldKit SDK → OllamaBackend | `xcrun swift test --filter OllamaBackendBenchmark` |
| ManifoldKit SDK → LlamaBackend | `xcrun swift test --filter LlamaBackendBenchmark` |
| ManifoldKit server → OllamaBackend | ManifoldServer + `http-bench.py --mode openai` |
| ManifoldKit server → LlamaBackend | ManifoldServer + `http-bench.py --mode openai` |
| ManifoldKit SDK → MLXBackend | `--mlx` flag, delegates to `test-mlx-integration.sh` |

## Usage

```bash
LLAMA_MODEL_PATH=~/Documents/Models/llama3.1-8b-instruct-Q4_K_M.gguf \
OLLAMA_MODEL=llama3.1:8b \
  scripts/benchmark.sh
```

## Test plan

- [x] `bash -n scripts/benchmark.sh`
- [x] `python3 -m py_compile scripts/bench/http-bench.py`
- [x] `scripts/test.sh --filter BackendBenchmark --disable-default-traits --skip-update` (compiles the benchmark test source; no hardware/backend-gated tests run without traits/models)
- [x] `scripts/check-readme.sh`

## Notes

- Local developer use only; benchmark paths require real services, hardware, and/or model files.
- `Package.resolved` has local uncommitted drift in the working tree and was intentionally not included in this PR.
