### PR TITLE
test: expand demo scenario Ollama e2e coverage

### DIFF
--- a/Tests/ManifoldE2ETests/DemoScenarioE2EHarness.swift
+++ b/Tests/ManifoldE2ETests/DemoScenarioE2EHarness.swift
@@ -10,19 +10,22 @@ struct DemoScenarioE2ESpec: Sendable {
     let userPrompt: String
     let expectedToolNames: [String]
     let maxIterations: Int
+    let allowsAdditionalToolCalls: Bool
 
     init(
         id: String,
         systemPrompt: String,
         userPrompt: String,
         expectedToolNames: [String],
-        maxIterations: Int = 4
+        maxIterations: Int = 4,
+        allowsAdditionalToolCalls: Bool = false
     ) {
         self.id = id
         self.systemPrompt = systemPrompt
         self.userPrompt = userPrompt
         self.expectedToolNames = expectedToolNames
         self.maxIterations = maxIterations
+        self.allowsAdditionalToolCalls = allowsAdditionalToolCalls
     }
 }
 
@@ -98,13 +101,29 @@ struct DemoScenarioE2EHarness {
             line: line
         )
         if !spec.expectedToolNames.isEmpty {
-            XCTAssertEqual(
-                Set(result.dispatchedCalls.map(\.toolName)),
-                Set(spec.expectedToolNames),
-                "Scenario should dispatch the expected tool set.\n\(result.diagnostics)",
-                file: file,
-                line: line
-            )
+            if spec.allowsAdditionalToolCalls {
+                let actualNames = result.dispatchedCalls.map(\.toolName)
+                XCTAssertTrue(
+                    actualNames.starts(with: spec.expectedToolNames),
+                    "Scenario should start with the expected tool calls.\n\(result.diagnostics)",
+                    file: file,
+                    line: line
+                )
+                XCTAssertTrue(
+                    actualNames.allSatisfy { spec.expectedToolNames.contains($0) },
+                    "Scenario should not dispatch unexpected tool names.\n\(result.diagnostics)",
+                    file: file,
+                    line: line
+                )
+            } else {
+                XCTAssertEqual(
+                    result.dispatchedCalls.map(\.toolName),
+                    spec.expectedToolNames,
+                    "Scenario should dispatch exactly the expected tool calls in order.\n\(result.diagnostics)",
+                    file: file,
+                    line: line
+                )
+            }
         }
 
         return result

--- a/Tests/ManifoldE2ETests/DemoScenarioOllamaE2ETests.swift
+++ b/Tests/ManifoldE2ETests/DemoScenarioOllamaE2ETests.swift
@@ -5,18 +5,16 @@ import ManifoldTools
 @testable import ManifoldTestSupport
 @testable import ManifoldBackends
 
-/// True end-to-end coverage of the four P1 demo scenarios against a real
+/// True end-to-end coverage of the #754 demo scenario matrix against a real
 /// local Ollama server.
 ///
 /// Local-only: `XCTSkipUnless(HardwareRequirements.hasOllamaServer)` and the
 /// preferred-model gate match the pattern in `OllamaToolCallingE2ETests`.
 /// Not run in CI.
 ///
-/// Assertion strategy is deliberately loose — the model is free to phrase
-/// the final visible answer however it likes; we only assert that at least
-/// one tool call was dispatched and that a non-empty visible answer arrived.
-/// Tighter assertions on tool name / argument shape are covered at Layer 1
-/// (mock-backed) and Layer 2 (XCUITest with scripted backend).
+/// Assertion strategy is intentionally semantic rather than prose-exact: each
+/// scenario verifies the exact tool sequence, argument shape or side effect,
+/// and that the final answer reflects the tool output.
 ///
 /// `OLLAMA_TEST_MODEL` env var can pin a specific model; when set but the
 /// model is not installed the test fails loudly rather than silently
@@ -100,15 +98,20 @@ final class DemoScenarioOllamaE2ETests: XCTestCase {
         let registry = ToolRegistry()
         registry.register(CalcTool.makeExecutor())
 
-        _ = try await harness.runAndAssert(
+        let result = try await harness.runAndAssert(
             DemoScenarioE2ESpec(
                 id: "tip-calc",
-                systemPrompt: "Use the `calc` tool to evaluate any arithmetic in the user's question. Then answer in one sentence.",
-                userPrompt: "What's an 18% tip on $73.40?",
+                systemPrompt: "Use the `calc` tool for arithmetic. For an 18% tip on 73.40, call calc with a=73.40, op=*, b=0.18. Then answer in one sentence.",
+                userPrompt: "What's an 18% tip on $73.40? Use multiplication, not addition.",
                 expectedToolNames: ["calc"]
             ),
             registry: registry,
         )
+        DemoScenarioOllamaAssertions.assertArgumentContains(result.dispatchedCalls[0], "73.4", result: result)
+        DemoScenarioOllamaAssertions.assertArgumentContains(result.dispatchedCalls[0], "*", result: result)
+        DemoScenarioOllamaAssertions.assertArgumentContains(result.dispatchedCalls[0], "0.18", result: result)
+        DemoScenarioOllamaAssertions.assertToolResultContains("13.212", trace: result.toolTraces[0], result: result)
+        DemoScenarioOllamaAssertions.assertFinalTextContainsAny(["13", "13.21"], result: result)
     }
 
     func test_worldClock_invokesToolAndReturnsAnswer() async throws {
@@ -130,6 +133,7 @@ final class DemoScenarioOllamaE2ETests: XCTestCase {
             },
             "World-clock scenario should call now with Asia/Tokyo.\n\(result.diagnostics)"
         )
+        DemoScenarioOllamaAssertions.assertFinalTextContainsAny(["Tokyo", "JST", "Asia"], result: result)
     }
 
     func test_workspaceSearch_invokesToolAndReturnsAnswer() async throws {
@@ -158,6 +162,8 @@ final class DemoScenarioOllamaE2ETests: XCTestCase {
             result.finalText.localizedCaseInsensitiveContains("MCP"),
             "Workspace-search answer should mention MCP.\n\(result.diagnostics)"
         )
+        DemoScenarioOllamaAssertions.assertArgumentContains(result.dispatchedCalls[0], "MCP", result: result)
+        DemoScenarioOllamaAssertions.assertToolResultContains("ideas.md", trace: result.toolTraces[0], result: result)
     }
 
     func test_journalWrite_invokesToolAndReturnsAnswer() async throws {
@@ -178,6 +184,254 @@ final class DemoScenarioOllamaE2ETests: XCTestCase {
             FileManager.default.fileExists(atPath: journalPath.path),
             "Journal-write scenario should create journal/today.md.\n\(result.diagnostics)"
         )
+        let journal = try String(contentsOf: journalPath, encoding: .utf8)
+        XCTAssertTrue(
+            journal.localizedCaseInsensitiveContains("productive"),
+            "Journal-write scenario should persist the requested content.\n\(result.diagnostics)"
+        )
+        DemoScenarioOllamaAssertions.assertArgumentContains(result.dispatchedCalls[0], "journal/today.md", result: result)
+        DemoScenarioOllamaAssertions.assertFinalTextContainsAny(["journal", "today.md", "saved", "wrote"], result: result)
+    }
+
+    func test_invalidArgsRecover_retriesAfterCalcError() async throws {
+        let registry = ToolRegistry()
+        registry.register(CalcTool.makeExecutor())
+
+        let result = try await harness.runAndAssert(
+            DemoScenarioE2ESpec(
+                id: "invalid-args-recover",
+                systemPrompt: "Use the `calc` tool. First call calc with a=100, op=/, b=0. If that returns invalidArguments, call calc again with a=100, op=/, b=4. Then answer with the successful result.",
+                userPrompt: "Demonstrate recovery from an invalid divide-by-zero calculator call.",
+                expectedToolNames: ["calc", "calc"],
+                maxIterations: 5
+            ),
+            registry: registry
+        )
+        DemoScenarioOllamaAssertions.assertArgumentContains(result.dispatchedCalls[0], "\"b\":0", result: result)
+        XCTAssertEqual(
+            result.toolTraces[0].result.errorKind,
+            .invalidArguments,
+            "First calculator call should fail as invalidArguments.\n\(result.diagnostics)"
+        )
+        DemoScenarioOllamaAssertions.assertArgumentContains(result.dispatchedCalls[1], "4", result: result)
+        DemoScenarioOllamaAssertions.assertToolResultContains("25", trace: result.toolTraces[1], result: result)
+        DemoScenarioOllamaAssertions.assertFinalTextContainsAny(["25", "zero", "divide"], result: result)
+    }
+
+    func test_rateLimitedRetry_retriesSameArguments() async throws {
+        let registry = ToolRegistry()
+        registry.register(DemoScenarioOllamaTestTools.makeRateLimitedExecutor())
+
+        let result = try await harness.runAndAssert(
+            DemoScenarioE2ESpec(
+                id: "rate-limited-retry",
+                systemPrompt: "Use `fakeRateLimited` with query `ManifoldKit`. If the first call is rate-limited, retry the same call once and then report the successful result.",
+                userPrompt: "Use fakeRateLimited to look up ManifoldKit.",
+                expectedToolNames: ["fakeRateLimited", "fakeRateLimited"],
+                maxIterations: 5
+            ),
+            registry: registry
+        )
+        DemoScenarioOllamaAssertions.assertArgumentContains(result.dispatchedCalls[0], "ManifoldKit", result: result)
+        XCTAssertEqual(
+            DemoScenarioOllamaAssertions.normalized(result.dispatchedCalls[0].arguments),
+            DemoScenarioOllamaAssertions.normalized(result.dispatchedCalls[1].arguments),
+            "Retry should use the same arguments.\n\(result.diagnostics)"
+        )
+        XCTAssertEqual(result.toolTraces[0].result.errorKind, .rateLimited, "First call should be rate-limited.\n\(result.diagnostics)")
+        XCTAssertNil(result.toolTraces[1].result.errorKind, "Retry should succeed.\n\(result.diagnostics)")
+        DemoScenarioOllamaAssertions.assertToolResultContains("ManifoldKit", trace: result.toolTraces[1], result: result)
+        DemoScenarioOllamaAssertions.assertFinalTextContainsAny(["ManifoldKit", "succeeded", "retry"], result: result)
+    }
+
+    func test_mcpToolFailure_surfacesTransientFailure() async throws {
+        let registry = ToolRegistry()
+        registry.register(DemoScenarioOllamaTestTools.makeMCPLookupExecutor())
+
+        let result = try await harness.runAndAssert(
+            DemoScenarioE2ESpec(
+                id: "mcp-tool-failure",
+                systemPrompt: "Use `fakeMCPLookup` once with path `/projects/scout`. The tool is expected to fail; do not retry. Explain the failure clearly.",
+                userPrompt: "Call fakeMCPLookup for /projects/scout and tell me what happened.",
+                expectedToolNames: ["fakeMCPLookup"]
+            ),
+            registry: registry
+        )
+        DemoScenarioOllamaAssertions.assertArgumentContains(result.dispatchedCalls[0], "/projects/scout", result: result)
+        XCTAssertEqual(result.toolTraces[0].result.errorKind, .transient, "MCP lookup should surface a transient failure.\n\(result.diagnostics)")
+        DemoScenarioOllamaAssertions.assertToolResultContains("connection refused", trace: result.toolTraces[0], result: result)
+        DemoScenarioOllamaAssertions.assertFinalTextContainsAny(["connection", "refused", "MCP", "failed"], result: result)
+    }
+
+    func test_mcpEcho_invokesNamespacedEchoTool() async throws {
+        let registry = ToolRegistry()
+        registry.register(DemoScenarioOllamaTestTools.makeMCPEchoExecutor())
+
+        let result = try await harness.runAndAssert(
+            DemoScenarioE2ESpec(
+                id: "mcp-echo",
+                systemPrompt: "Use `everything__echo` to repeat the exact message `Hello from ManifoldKit`, then confirm exactly what it returned.",
+                userPrompt: "Echo Hello from ManifoldKit through the connected demo MCP server.",
+                expectedToolNames: ["everything__echo"]
+            ),
+            registry: registry
+        )
+        DemoScenarioOllamaAssertions.assertArgumentContains(result.dispatchedCalls[0], "Hello from ManifoldKit", result: result)
+        DemoScenarioOllamaAssertions.assertToolResultContains("Hello from ManifoldKit", trace: result.toolTraces[0], result: result)
+        DemoScenarioOllamaAssertions.assertFinalTextContainsAny(["Hello from ManifoldKit", "echo"], result: result)
+    }
+
+    func test_meetingNotesSummary_listsAndReadsSeededNotes() async throws {
+        try writeFixture("meetings/standup.md", "BetaLaunch owner: Riley. Status: ready for rollout.")
+        try writeFixture("meetings/retro.md", "Retrospective notes without the launch marker.")
+
+        let registry = ToolRegistry()
+        registry.register(ListDirTool.makeExecutor(root: sandboxRoot))
+        registry.register(ReadFileTool.makeExecutor(root: sandboxRoot))
+
+        let result = try await harness.runAndAssert(
+            DemoScenarioE2ESpec(
+                id: "meeting-notes-summary",
+                systemPrompt: "First use `list_dir` with dir `meetings`. Then use `read_file` on `meetings/standup.md`. Answer with the BetaLaunch owner from the file.",
+                userPrompt: "Summarize the relevant meeting note for BetaLaunch.",
+                expectedToolNames: ["list_dir", "read_file"],
+                maxIterations: 5
+            ),
+            registry: registry
+        )
+        DemoScenarioOllamaAssertions.assertArgumentContains(result.dispatchedCalls[0], "meetings", result: result)
+        DemoScenarioOllamaAssertions.assertArgumentContains(result.dispatchedCalls[1], "meetings/standup.md", result: result)
+        DemoScenarioOllamaAssertions.assertToolResultContains("Riley", trace: result.toolTraces[1], result: result)
+        DemoScenarioOllamaAssertions.assertFinalTextContainsAny(["Riley", "BetaLaunch"], result: result)
+    }
+
+    func test_shoppingListBudget_readsListAndCalculatesTotal() async throws {
+        try writeFixture("shopping/list.md", "oranges: $4.20\nrice: $6.30\nignore candles: $9.99")
+
+        let registry = ToolRegistry()
+        registry.register(ReadFileTool.makeExecutor(root: sandboxRoot))
+        registry.register(CalcTool.makeExecutor())
+
+        let result = try await harness.runAndAssert(
+            DemoScenarioE2ESpec(
+                id: "shopping-list-budget",
+                systemPrompt: "Use `read_file` on `shopping/list.md`, then use `calc` to add only oranges 4.20 and rice 6.30. Answer with the total 10.50.",
+                userPrompt: "What is the food total for oranges and rice in my shopping list?",
+                expectedToolNames: ["read_file", "calc"],
+                maxIterations: 5
+            ),
+            registry: registry
+        )
+        DemoScenarioOllamaAssertions.assertArgumentContains(result.dispatchedCalls[0], "shopping/list.md", result: result)
+        DemoScenarioOllamaAssertions.assertArgumentContains(result.dispatchedCalls[1], "+", result: result)
+        DemoScenarioOllamaAssertions.assertToolResultContains("10.5", trace: result.toolTraces[1], result: result)
+        DemoScenarioOllamaAssertions.assertFinalTextContainsAny(["10.5", "10.50", "$10"], result: result)
+    }
+
+    func test_parallelReadmeComparison_readsBothFiles() async throws {
+        try writeFixture("repoA/README.md", "Repo A uses AlphaDB for persistence.")
+        try writeFixture("repoB/README.md", "Repo B uses BetaCache for persistence.")
+
+        let registry = ToolRegistry()
+        registry.register(ReadFileTool.makeExecutor(root: sandboxRoot))
+
+        let result = try await harness.runAndAssert(
+            DemoScenarioE2ESpec(
+                id: "parallel-readme-comparison",
+                systemPrompt: "Use `read_file` for both `repoA/README.md` and `repoB/README.md`, then compare the persistence technologies.",
+                userPrompt: "Compare the persistence notes in repoA and repoB READMEs.",
+                expectedToolNames: ["read_file", "read_file"],
+                maxIterations: 5,
+                allowsAdditionalToolCalls: true
+            ),
+            registry: registry
+        )
+        let combinedArguments = result.dispatchedCalls.map(\.arguments).joined(separator: "\n")
+        let combinedResults = result.toolTraces.map(\.result.content).joined(separator: "\n")
+        XCTAssertTrue(
+            DemoScenarioOllamaAssertions.normalized(combinedArguments).localizedCaseInsensitiveContains("repoA/README.md"),
+            "Parallel README scenario should read repoA/README.md.\n\(result.diagnostics)"
+        )
+        XCTAssertTrue(
+            DemoScenarioOllamaAssertions.normalized(combinedArguments).localizedCaseInsensitiveContains("repoB/README.md"),
+            "Parallel README scenario should read repoB/README.md.\n\(result.diagnostics)"
+        )
+        XCTAssertTrue(
+            combinedResults.localizedCaseInsensitiveContains("AlphaDB"),
+            "Parallel README tool results should include AlphaDB.\n\(result.diagnostics)"
+        )
+        XCTAssertTrue(
+            combinedResults.localizedCaseInsensitiveContains("BetaCache"),
+            "Parallel README tool results should include BetaCache.\n\(result.diagnostics)"
+        )
+        DemoScenarioOllamaAssertions.assertFinalTextContainsAny(["AlphaDB", "BetaCache"], result: result)
+    }
+
+    func test_oversizeToolOutput_reportsMarkerFromLargeFile() async throws {
+        let largeBody = Array(repeating: "padding line for context budget\n", count: 600).joined()
+        try writeFixture("docs/large.md", "OVERSIZE-SENTINEL-ZEBRA\n" + largeBody)
+
+        let registry = ToolRegistry()
+        registry.register(ReadFileTool.makeExecutor(root: sandboxRoot))
+
+        let result = try await harness.runAndAssert(
+            DemoScenarioE2ESpec(
+                id: "oversize-tool-output",
+                systemPrompt: "Use `read_file` on `docs/large.md`. The first line contains the marker; answer only with that marker.",
+                userPrompt: "Read the large document and report its marker.",
+                expectedToolNames: ["read_file"]
+            ),
+            registry: registry
+        )
+        DemoScenarioOllamaAssertions.assertArgumentContains(result.dispatchedCalls[0], "docs/large.md", result: result)
+        DemoScenarioOllamaAssertions.assertToolResultContains("OVERSIZE-SENTINEL-ZEBRA", trace: result.toolTraces[0], result: result)
+        DemoScenarioOllamaAssertions.assertFinalTextContainsAny(["OVERSIZE-SENTINEL-ZEBRA", "ZEBRA"], result: result)
+    }
+
+    func test_progressiveArgumentStreaming_composesEmailDraft() async throws {
+        let registry = ToolRegistry()
+        registry.register(DemoScenarioOllamaTestTools.makeComposeEmailExecutor())
+
+        let result = try await harness.runAndAssert(
+            DemoScenarioE2ESpec(
+                id: "progressive-argument-streaming",
+                systemPrompt: "Use `compose_email` with to `mina@example.com`, subject `Project Falcon`, and a body that says `Project Falcon is ready for review`. Then answer with the draft id.",
+                userPrompt: "Draft the Project Falcon status email to Mina.",
+                expectedToolNames: ["compose_email"]
+            ),
+            registry: registry
+        )
+        DemoScenarioOllamaAssertions.assertArgumentContains(result.dispatchedCalls[0], "mina@example.com", result: result)
+        DemoScenarioOllamaAssertions.assertArgumentContains(result.dispatchedCalls[0], "Project Falcon", result: result)
+        DemoScenarioOllamaAssertions.assertToolResultContains("draft-701", trace: result.toolTraces[0], result: result)
+        DemoScenarioOllamaAssertions.assertFinalTextContainsAny(["draft-701", "Project Falcon", "draft"], result: result)
+    }
+
+    func test_mcpFilesystemServer_readsFixtureThroughMCPTool() async throws {
+        let registry = ToolRegistry()
+        registry.register(DemoScenarioOllamaTestTools.makeMCPFilesystemReadExecutor())
+
+        let result = try await harness.runAndAssert(
+            DemoScenarioE2ESpec(
+                id: "mcp-filesystem-server",
+                systemPrompt: "Use `mcp_fs_read` with path `/workspace/plan.md`, then answer with the migration status from the tool result.",
+                userPrompt: "Read the MCP filesystem plan and tell me the status.",
+                expectedToolNames: ["mcp_fs_read"]
+            ),
+            registry: registry
+        )
+        DemoScenarioOllamaAssertions.assertArgumentContains(result.dispatchedCalls[0], "/workspace/plan.md", result: result)
+        DemoScenarioOllamaAssertions.assertToolResultContains("Neptune migration complete", trace: result.toolTraces[0], result: result)
+        DemoScenarioOllamaAssertions.assertFinalTextContainsAny(["Neptune", "complete", "migration"], result: result)
+    }
+
+    private func writeFixture(_ relativePath: String, _ content: String) throws {
+        let destination = sandboxRoot.appendingPathComponent(relativePath)
+        try FileManager.default.createDirectory(
+            at: destination.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try content.write(to: destination, atomically: true, encoding: .utf8)
     }
 }
 #endif

--- a/Tests/ManifoldE2ETests/DemoScenarioOllamaHelpers.swift
+++ b/Tests/ManifoldE2ETests/DemoScenarioOllamaHelpers.swift
@@ -1,0 +1,239 @@
+#if Ollama && Tools
+import Foundation
+import XCTest
+import ManifoldInference
+
+enum DemoScenarioOllamaTestTools {
+    static func makeRateLimitedExecutor() -> any ToolExecutor {
+        FakeRateLimitedTool.makeExecutor()
+    }
+
+    static func makeMCPLookupExecutor() -> any ToolExecutor {
+        FakeMCPLookupTool.makeExecutor()
+    }
+
+    static func makeMCPEchoExecutor() -> any ToolExecutor {
+        struct Args: Decodable, Sendable {
+            let message: String
+        }
+        struct Result: Encodable, Sendable {
+            let echoed: String
+            let server: String
+        }
+
+        return TypedToolExecutor<Args, Result>(
+            definition: ToolDefinition(
+                name: "everything__echo",
+                description: "Echoes the supplied message through the connected demo MCP server.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "message": .object(["type": .string("string")])
+                    ]),
+                    "required": .array([.string("message")])
+                ])
+            )
+        ) { args in
+            Result(echoed: args.message, server: "demo-everything")
+        }
+    }
+
+    static func makeComposeEmailExecutor() -> any ToolExecutor {
+        struct Args: Decodable, Sendable {
+            let to: String
+            let subject: String
+            let body: String
+        }
+        struct Result: Encodable, Sendable {
+            let draftId: String
+            let summary: String
+        }
+
+        return TypedToolExecutor<Args, Result>(
+            definition: ToolDefinition(
+                name: "compose_email",
+                description: "Creates an email draft. Include recipient, subject, and full body.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "to": .object(["type": .string("string")]),
+                        "subject": .object(["type": .string("string")]),
+                        "body": .object(["type": .string("string")]),
+                    ]),
+                    "required": .array([.string("to"), .string("subject"), .string("body")])
+                ])
+            ),
+            requiresApproval: false
+        ) { args in
+            Result(
+                draftId: "draft-701",
+                summary: "Draft for \(args.to) about \(args.subject): \(args.body)"
+            )
+        }
+    }
+
+    static func makeMCPFilesystemReadExecutor() -> any ToolExecutor {
+        struct Args: Decodable, Sendable {
+            let path: String
+        }
+        struct Result: Encodable, Sendable {
+            let path: String
+            let content: String
+        }
+
+        return TypedToolExecutor<Args, Result>(
+            definition: ToolDefinition(
+                name: "mcp_fs_read",
+                description: "Reads a file through the connected filesystem MCP server.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "path": .object(["type": .string("string")])
+                    ]),
+                    "required": .array([.string("path")])
+                ])
+            )
+        ) { args in
+            Result(
+                path: args.path,
+                content: "filesystem MCP fixture: Neptune migration complete"
+            )
+        }
+    }
+}
+
+enum DemoScenarioOllamaAssertions {
+    static func normalized(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: #"\/"#, with: "/")
+            .replacingOccurrences(of: " ", with: "")
+            .replacingOccurrences(of: "\n", with: "")
+    }
+
+    static func assertArgumentContains(
+        _ call: ToolCall,
+        _ needle: String,
+        result: DemoScenarioE2EResult,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(
+            normalized(call.arguments).localizedCaseInsensitiveContains(normalized(needle)),
+            "Expected \(call.toolName) args to contain \(needle).\n\(result.diagnostics)",
+            file: file,
+            line: line
+        )
+    }
+
+    static func assertFinalTextContainsAny(
+        _ needles: [String],
+        result: DemoScenarioE2EResult,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(
+            needles.contains { result.finalText.localizedCaseInsensitiveContains($0) },
+            "Expected final answer to contain one of \(needles).\n\(result.diagnostics)",
+            file: file,
+            line: line
+        )
+    }
+
+    static func assertToolResultContains(
+        _ needle: String,
+        trace: DemoScenarioE2EResult.ToolTrace,
+        result: DemoScenarioE2EResult,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(
+            trace.result.content.localizedCaseInsensitiveContains(needle),
+            "Expected \(trace.call.toolName) result to contain \(needle).\n\(result.diagnostics)",
+            file: file,
+            line: line
+        )
+    }
+}
+
+private enum FakeRateLimitedTool {
+    struct Args: Decodable, Sendable {
+        let query: String
+    }
+    struct Result: Encodable, Sendable {
+        let result: String
+        let attempt: Int
+    }
+
+    static func makeExecutor() -> any ToolExecutor {
+        RateLimitedExecutor(
+            definition: ToolDefinition(
+                name: "fakeRateLimited",
+                description: "Fetches a fact about the supplied query. The first call returns rateLimited; retry the exact same arguments once.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "query": .object(["type": .string("string")])
+                    ]),
+                    "required": .array([.string("query")])
+                ])
+            ),
+            state: CallState()
+        )
+    }
+
+    actor CallState {
+        private var calls = 0
+
+        func next() -> Int {
+            calls += 1
+            return calls
+        }
+    }
+
+    private struct RateLimitedExecutor: ToolExecutor {
+        let definition: ToolDefinition
+        let state: CallState
+
+        func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+            let data = try JSONEncoder().encode(arguments)
+            let args = try JSONDecoder().decode(Args.self, from: data)
+            let attempt = await state.next()
+            if attempt == 1 {
+                return ToolResult(callId: "", content: "rate limit exceeded — retry shortly", errorKind: .rateLimited)
+            }
+            let encoded = try JSONEncoder().encode(Result(result: "Lookup for '\(args.query)' succeeded.", attempt: attempt))
+            return ToolResult(callId: "", content: String(data: encoded, encoding: .utf8) ?? "", errorKind: nil)
+        }
+    }
+}
+
+private enum FakeMCPLookupTool {
+    static func makeExecutor() -> any ToolExecutor {
+        MCPLookupExecutor(
+            definition: ToolDefinition(
+                name: "fakeMCPLookup",
+                description: "Looks up a remote MCP path. The demo server is unreachable; call once and report the transient failure.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "path": .object(["type": .string("string")])
+                    ]),
+                    "required": .array([.string("path")])
+                ])
+            )
+        )
+    }
+
+    private struct MCPLookupExecutor: ToolExecutor {
+        let definition: ToolDefinition
+
+        func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+            ToolResult(
+                callId: "",
+                content: "MCP transport failure: connection refused",
+                errorKind: .transient
+            )
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Expands DemoScenarioOllamaE2ETests from 4 to 14 real Ollama tool-calling scenarios using the Wave 0 shared harness.
- Tightens harness assertions so scenarios reject unexpected tool names/order by default, with an explicit opt-in for extra same-tool read calls in the README comparison case.
- Adds test-local helper executors for failure-path/MCP-shaped demo tools without touching UI tests or ManifoldTools JSON.

## Scenario coverage
| Scenario | Tools asserted | Coverage |
|---|---|---|
| tip-calc | calc | args, calc result, final answer |
| world-clock | now | Asia/Tokyo args, final answer |
| workspace-search | sample_repo_search | query args, seeded result, final answer |
| journal-write | write_file | path args, file side effect, final answer |
| invalid-args-recover | calc, calc | invalidArguments then recovery result |
| rate-limited-retry | fakeRateLimited, fakeRateLimited | same-args retry, rateLimited then success |
| mcp-tool-failure | fakeMCPLookup | path args, transient failure, final answer |
| mcp-echo | everything__echo | message args/result/final answer |
| meeting-notes-summary | list_dir, read_file | seeded notes, read result, final answer |
| shopping-list-budget | read_file, calc | seeded list, calculation, final answer |
| parallel-readme-comparison | read_file/read_file | both README reads; allows extra read_file calls only |
| oversize-tool-output | read_file | large fixture marker, result, final answer |
| progressive-argument-streaming | compose_email | rich args, draft result, final answer |
| mcp-filesystem-server | mcp_fs_read | path args, MCP-shaped result, final answer |

## Validation
```
OLLAMA_TEST_MODEL=llama3.1:8b scripts/test.sh --filter DemoScenarioOllamaE2ETests --traits Ollama,Tools --skip-update --min-passed 14

Test Suite DemoScenarioOllamaE2ETests passed.
Executed 14 tests, with 0 failures (0 unexpected) in 81.130 seconds.
TEST SUMMARY: Passed 14, Failed 0, Skipped 0. RESULT: PASSED.
```