### PR TITLE
test: add cross-backend demo scenario coverage

### DIFF
--- a/Tests/ManifoldE2ETests/DemoScenarioCrossBackendE2ETests.swift
+++ b/Tests/ManifoldE2ETests/DemoScenarioCrossBackendE2ETests.swift
@@ -1,0 +1,201 @@
+#if Tools && (Ollama || CloudSaaS || canImport(FoundationModels))
+import Foundation
+import XCTest
+import ManifoldInference
+@testable import ManifoldTestSupport
+@testable import ManifoldBackends
+
+@MainActor
+final class DemoScenarioCrossBackendContractTests: XCTestCase {
+
+    func test_meetingNotes_wholeCallMock_matchesSharedContract() async throws {
+        let backend = MockInferenceBackend(capabilities: BackendCapabilities(
+            supportsToolCalling: true,
+            streamsToolCallArguments: false,
+            supportsParallelToolCalls: false
+        ))
+        backend.isModelLoaded = true
+        backend.tokensToYield = []
+        backend.scriptedToolCallsPerTurn = [[DemoScenarioMeetingNotes.makeScriptedCall()], []]
+        backend.tokensToYieldPerTurn = [
+            [],
+            ["Riley owns BetaLaunch. Decision: Ship candidate Friday. Blocker: Security review."]
+        ]
+
+        let result = try await DemoScenarioE2EHarness(
+            backend: backend,
+            backendName: "whole-call-mock",
+            modelName: "scripted"
+        ).runAndAssert(DemoScenarioMeetingNotes.spec, registry: DemoScenarioMeetingNotes.makeRegistry())
+
+        DemoScenarioMeetingNotes.assertContract(result)
+    }
+
+    func test_meetingNotes_streamingArgsMock_matchesSharedContract() async throws {
+        let backend = MockInferenceBackend(capabilities: BackendCapabilities(
+            supportsToolCalling: true,
+            streamsToolCallArguments: true,
+            supportsParallelToolCalls: true
+        ))
+        backend.isModelLoaded = true
+        let call = DemoScenarioMeetingNotes.makeScriptedCall(id: "stream-meeting-notes")
+        backend.tokensToYield = []
+        backend.scriptedToolCallDeltasPerTurn = [[
+            .start(callId: call.id, name: call.toolName),
+            .delta(callId: call.id, textDelta: call.arguments),
+            .call(call),
+        ], []]
+        backend.tokensToYieldPerTurn = [
+            [],
+            ["Riley owns BetaLaunch. Decision: Ship candidate Friday. Blocker: Security review."]
+        ]
+
+        let result = try await DemoScenarioE2EHarness(
+            backend: backend,
+            backendName: "streaming-args-mock",
+            modelName: "scripted"
+        ).runAndAssert(DemoScenarioMeetingNotes.spec, registry: DemoScenarioMeetingNotes.makeRegistry())
+
+        DemoScenarioMeetingNotes.assertContract(result)
+    }
+}
+
+/// Cross-backend #707 meeting-notes scenario coverage.
+///
+/// All three real legs use the same prompt, `meeting_notes_lookup` toolset,
+/// and `DemoScenarioMeetingNotes.assertContract` transcript assertions. Live
+/// dependencies are explicitly gated so normal CI gets deterministic mock
+/// coverage without requiring Ollama, Anthropic credentials, or Apple
+/// Intelligence availability.
+@MainActor
+final class DemoScenarioCrossBackendE2ETests: XCTestCase {
+
+    func test_deterministicMeetingNotesContract_coversOptionalBackendSkips() async throws {
+        let backend = MockInferenceBackend(capabilities: BackendCapabilities(
+            supportsToolCalling: true,
+            streamsToolCallArguments: false,
+            supportsParallelToolCalls: false
+        ))
+        backend.isModelLoaded = true
+        backend.tokensToYield = []
+        backend.scriptedToolCallsPerTurn = [[DemoScenarioMeetingNotes.makeScriptedCall()], []]
+        backend.tokensToYieldPerTurn = [
+            [],
+            ["Riley owns BetaLaunch. Decision: Ship candidate Friday. Blocker: Security review."]
+        ]
+
+        let result = try await DemoScenarioE2EHarness(
+            backend: backend,
+            backendName: "cross-backend-deterministic-mock",
+            modelName: "scripted"
+        ).runAndAssert(DemoScenarioMeetingNotes.spec, registry: DemoScenarioMeetingNotes.makeRegistry())
+
+        DemoScenarioMeetingNotes.assertContract(result)
+    }
+
+#if Ollama
+    func test_ollama_meetingNotes_sharedScenario() async throws {
+        try XCTSkipUnless(
+            HardwareRequirements.hasOllamaServer,
+            "Ollama server not running at localhost:11434"
+        )
+        let available = HardwareRequirements.listOllamaModels() ?? []
+        let preferredModels = ["llama3.1:8b", "qwen2.5:7b-instruct", "qwen2.5:7b"]
+        let modelName: String
+        if let pinned = ProcessInfo.processInfo.environment["OLLAMA_TEST_MODEL"] {
+            guard available.contains(pinned) else {
+                XCTFail("OLLAMA_TEST_MODEL=\(pinned) is set but not installed locally. Installed: \(available)")
+                throw XCTSkip("OLLAMA_TEST_MODEL not installed")
+            }
+            modelName = pinned
+        } else {
+            guard let match = preferredModels.first(where: { available.contains($0) }) else {
+                throw XCTSkip("No tool-calling-capable Ollama model installed; need one of \(preferredModels). Installed: \(available)")
+            }
+            modelName = match
+        }
+
+        let backend = OllamaBackend()
+        backend.configure(baseURL: URL(string: "http://localhost:11434")!, modelName: modelName)
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+        defer { backend.unloadModel() }
+
+        let result = try await DemoScenarioE2EHarness(
+            backend: backend,
+            backendName: "Ollama",
+            modelName: modelName
+        ).runAndAssert(DemoScenarioMeetingNotes.spec, registry: DemoScenarioMeetingNotes.makeRegistry())
+
+        DemoScenarioMeetingNotes.assertContract(result)
+    }
+#endif
+
+#if CloudSaaS
+    func test_claude_meetingNotes_sharedScenario() async throws {
+        guard let apiKey = ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"], !apiKey.isEmpty else {
+            throw XCTSkip("ANTHROPIC_API_KEY not set; skipping live Claude meeting-notes scenario")
+        }
+        let modelName = try claudeModelName()
+        let backend = ClaudeBackend()
+        backend.configure(
+            baseURL: URL(string: "https://api.anthropic.com")!,
+            apiKey: apiKey,
+            modelName: modelName
+        )
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+        defer { backend.unloadModel() }
+
+        let result = try await DemoScenarioE2EHarness(
+            backend: backend,
+            backendName: "Claude",
+            modelName: modelName
+        ).runAndAssert(DemoScenarioMeetingNotes.spec, registry: DemoScenarioMeetingNotes.makeRegistry())
+
+        DemoScenarioMeetingNotes.assertContract(result)
+    }
+
+    private func claudeModelName() throws -> String {
+        if let pinned = ProcessInfo.processInfo.environment["CLAUDE_TEST_MODEL"] {
+            guard !pinned.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                XCTFail("CLAUDE_TEST_MODEL is set but empty")
+                throw XCTSkip("CLAUDE_TEST_MODEL is empty")
+            }
+            return pinned
+        }
+        return "claude-3-5-haiku-20241022"
+    }
+#endif
+
+#if canImport(FoundationModels)
+    @available(iOS 26, macOS 26, *)
+    func test_foundation_meetingNotes_sharedScenario() async throws {
+        guard ProcessInfo.processInfo.environment["RUN_FOUNDATION_CROSS_BACKEND"] == "1" else {
+            throw XCTSkip("RUN_FOUNDATION_CROSS_BACKEND=1 not set; skipping nondeterministic live Foundation meeting-notes scenario")
+        }
+        guard ProcessInfo.processInfo.isOperatingSystemAtLeast(
+            OperatingSystemVersion(majorVersion: 26, minorVersion: 0, patchVersion: 0)
+        ) else {
+            throw XCTSkip("FoundationModels requires iOS 26 / macOS 26")
+        }
+        try XCTSkipUnless(
+            FoundationBackend.isAvailable,
+            "Apple Intelligence is not available on this device"
+        )
+        let foundationReady = await FoundationBackend.probeIsReady()
+        try XCTSkipUnless(foundationReady, "Apple Intelligence model is not ready")
+
+        let backend = FoundationBackend()
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+        defer { backend.unloadModel() }
+
+        let result = try await DemoScenarioE2EHarness(
+            backend: backend,
+            backendName: "Foundation",
+            modelName: "SystemLanguageModel.default"
+        ).runAndAssert(DemoScenarioMeetingNotes.spec, registry: DemoScenarioMeetingNotes.makeRegistry())
+
+        DemoScenarioMeetingNotes.assertContract(result)
+    }
+#endif
+}
+#endif

--- a/Tests/ManifoldE2ETests/DemoScenarioE2EHarness.swift
+++ b/Tests/ManifoldE2ETests/DemoScenarioE2EHarness.swift
@@ -1,4 +1,4 @@
-#if Ollama && Tools
+#if Tools && (Ollama || CloudSaaS || canImport(FoundationModels))
 import Foundation
 import XCTest
 import ManifoldInference
@@ -76,7 +76,7 @@ struct DemoScenarioE2EResult: Sendable {
 
 @MainActor
 struct DemoScenarioE2EHarness {
-    let backend: any InferenceBackend & ToolCallingHistoryReceiver
+    let backend: any InferenceBackend
     let backendName: String
     let modelName: String
 
@@ -152,8 +152,17 @@ struct DemoScenarioE2EHarness {
         var finalText = ""
 
         for _ in 0..<config.maxToolIterations {
-            backend.setToolAwareHistory(history)
-            let stream = try backend.generate(prompt: "", systemPrompt: nil, config: config)
+            let stream: GenerationStream
+            if let receiver = backend as? ToolCallingHistoryReceiver {
+                receiver.setToolAwareHistory(history)
+                stream = try backend.generate(prompt: "", systemPrompt: nil, config: config)
+            } else {
+                stream = try backend.generate(
+                    prompt: transcriptPrompt(from: history),
+                    systemPrompt: spec.systemPrompt,
+                    config: config
+                )
+            }
 
             var turnCalls: [ToolCall] = []
             var turnText = ""
@@ -189,6 +198,26 @@ struct DemoScenarioE2EHarness {
             toolTraces: toolTraces,
             finalText: finalText
         )
+    }
+
+    private func transcriptPrompt(from history: [ToolAwareHistoryEntry]) -> String {
+        let body = history.map { entry -> String in
+            if let toolCallId = entry.toolCallId {
+                return "tool_result id=\(toolCallId): \(entry.content)"
+            }
+            if let toolCalls = entry.toolCalls, !toolCalls.isEmpty {
+                let calls = toolCalls
+                    .map { "\($0.toolName)(id:\($0.id), arguments:\($0.arguments))" }
+                    .joined(separator: "\n")
+                return "assistant tool_calls:\n\(calls)"
+            }
+            return "\(entry.role): \(entry.content)"
+        }.joined(separator: "\n\n")
+        return """
+        Continue this tool-calling transcript. If a tool result is present, answer the original user using the tool-derived facts. Otherwise call the required tool.
+
+        \(body)
+        """
     }
 }
 
@@ -285,6 +314,111 @@ enum DemoScenarioE2EFixtures {
             let payload = Data(args.content.utf8)
             try payload.write(to: resolved, options: .atomic)
             return Result(path: args.path, bytesWritten: payload.count)
+        }
+    }
+}
+
+enum DemoScenarioMeetingNotes {
+    static let requiredFinalFacts = ["Riley", "Friday", "Security review"]
+
+    static var spec: DemoScenarioE2ESpec {
+        DemoScenarioE2ESpec(
+            id: "meeting-notes-cross-backend",
+            systemPrompt: """
+            You are validating ManifoldKit demo tool calling. Use exactly the `meeting_notes_lookup` tool with meeting_id `beta-launch-sync` and include_decisions true. After the tool returns, answer in one concise sentence that includes the owner, ship decision, and blocker exactly from the tool result.
+            """,
+            userPrompt: "Summarize the BetaLaunch meeting note.",
+            expectedToolNames: ["meeting_notes_lookup"],
+            maxIterations: 4
+        )
+    }
+
+    @MainActor
+    static func makeRegistry() -> ToolRegistry {
+        struct Args: Decodable, Sendable {
+            let meeting_id: String
+            let include_decisions: Bool
+        }
+        struct Result: Encodable, Sendable {
+            let meeting_id: String
+            let project: String
+            let owner: String
+            let decision: String
+            let blocker: String
+        }
+
+        let registry = ToolRegistry()
+        registry.register(TypedToolExecutor<Args, Result>(
+            definition: ToolDefinition(
+                name: "meeting_notes_lookup",
+                description: "Looks up deterministic meeting notes by meeting_id. Pass include_decisions true when decisions are needed.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "meeting_id": .object([
+                            "type": .string("string"),
+                            "description": .string("Canonical meeting id, for example beta-launch-sync.")
+                        ]),
+                        "include_decisions": .object([
+                            "type": .string("boolean"),
+                            "description": .string("Whether to include decision and blocker facts.")
+                        ]),
+                    ]),
+                    "required": .array([.string("meeting_id"), .string("include_decisions")])
+                ])
+            )
+        ) { args in
+            guard args.meeting_id == "beta-launch-sync", args.include_decisions else {
+                throw NSError(
+                    domain: "MeetingNotesTool",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "expected beta-launch-sync with include_decisions=true"]
+                )
+            }
+            return Result(
+                meeting_id: args.meeting_id,
+                project: "BetaLaunch",
+                owner: "Riley",
+                decision: "Ship candidate Friday",
+                blocker: "Security review"
+            )
+        })
+        return registry
+    }
+
+    static func makeScriptedCall(id: String = "call-meeting-notes") -> ToolCall {
+        ToolCall(
+            id: id,
+            toolName: "meeting_notes_lookup",
+            arguments: #"{"meeting_id":"beta-launch-sync","include_decisions":true}"#
+        )
+    }
+
+    static func assertContract(
+        _ result: DemoScenarioE2EResult,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(
+            result.dispatchedCalls.map(\.toolName),
+            ["meeting_notes_lookup"],
+            "Meeting-notes scenario should dispatch the shared tool path.\n\(result.diagnostics)",
+            file: file,
+            line: line
+        )
+        guard let call = result.dispatchedCalls.first, let trace = result.toolTraces.first else {
+            XCTFail("Meeting-notes scenario did not dispatch a tool.\n\(result.diagnostics)", file: file, line: line)
+            return
+        }
+        let normalizedArgs = call.arguments
+            .replacingOccurrences(of: #"\/"#, with: "/")
+            .replacingOccurrences(of: " ", with: "")
+            .replacingOccurrences(of: "\n", with: "")
+        XCTAssertTrue(normalizedArgs.contains(#""meeting_id":"beta-launch-sync""#), "Arguments must include meeting_id.\n\(result.diagnostics)", file: file, line: line)
+        XCTAssertTrue(normalizedArgs.contains(#""include_decisions":true"#), "Arguments must include include_decisions=true.\n\(result.diagnostics)", file: file, line: line)
+        for fact in requiredFinalFacts {
+            XCTAssertTrue(trace.result.content.localizedCaseInsensitiveContains(fact), "Tool result must contain \(fact).\n\(result.diagnostics)", file: file, line: line)
+            XCTAssertTrue(result.finalText.localizedCaseInsensitiveContains(fact), "Final answer must contain \(fact).\n\(result.diagnostics)", file: file, line: line)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds shared #707 meeting-notes scenario coverage across deterministic mocks plus gated Ollama, Claude, and Foundation legs.
- Reuses one prompt/toolset/contract via `DemoScenarioMeetingNotes` and extends the E2E harness to support backends without `ToolCallingHistoryReceiver`.
- Keeps live cloud/Foundation execution gated so normal CI does not require credentials or Apple Intelligence.

## Scenario coverage
| Backend / shape | Gate | Expected coverage | Local result |
| --- | --- | --- | --- |
| Whole-call mock | none | `meeting_notes_lookup`, `meeting_id`, `include_decisions`, Riley/Friday/Security review facts | Passed |
| Streaming-args mock | none | Same contract via start/delta/call shape | Passed |
| Ollama | local server + installed/pinned `OLLAMA_TEST_MODEL` | Same contract against real local backend | Passed (`test_ollama_meetingNotes_sharedScenario`) |
| Claude | `CloudSaaS` + `ANTHROPIC_API_KEY`, optional `CLAUDE_TEST_MODEL` | Same contract against live Claude | Skipped locally: no `ANTHROPIC_API_KEY` |
| Foundation | `canImport(FoundationModels)` + `RUN_FOUNDATION_CROSS_BACKEND=1` + OS/model availability | Same contract against live Foundation when explicitly enabled | Skipped locally: `RUN_FOUNDATION_CROSS_BACKEND` unset |

## Validation
```text
scripts/test.sh --filter CrossBackend --traits Ollama,CloudSaaS,Tools --skip-update --min-passed 1
TOTAL RUN: 171
Passed: 169
Skipped: 2
RESULT: PASSED

scripts/test.sh --filter DemoScenarioCrossBackendE2ETests --traits Ollama,CloudSaaS,Tools --skip-update --min-passed 1
TOTAL RUN: 4
Passed: 2
Skipped: 2
RESULT: PASSED
```
