### PR TITLE
test: add MCP filesystem demo scenario coverage

### DIFF
--- a/Tests/ManifoldMCPE2ETests/EverythingServerSmokeTests.swift
+++ b/Tests/ManifoldMCPE2ETests/EverythingServerSmokeTests.swift
@@ -4,6 +4,7 @@ import Foundation
 import XCTest
 @testable import ManifoldMCP
 import ManifoldInference
+import ManifoldTestSupport
 
 final class EverythingServerSmokeTests: XCTestCase {
     override func setUpWithError() throws {
@@ -12,26 +13,14 @@ final class EverythingServerSmokeTests: XCTestCase {
             ProcessInfo.processInfo.environment["RUN_MCP_E2E"] == "1",
             "Set RUN_MCP_E2E=1 to run MCP E2E tests"
         )
-        try XCTSkipIf(!hasNpx(), "npx not installed")
+        try XCTSkipUnless(hasExecutableOnPATH("npx"), "npx not installed or not on PATH")
     }
 
     func test_everythingServer_connectsAndListsTools() async throws {
         // Sabotage: returning early before connect() would fail the tool-count assertion
 
-        let command = MCPStdioCommand.npx(package: "@modelcontextprotocol/server-everything")
-        let descriptor = MCPServerDescriptor(
-            displayName: "Everything Server",
-            transport: .stdio(command),
-            initializationTimeout: .seconds(60),
-            dataDisclosure: "E2E test server"
-        )
-
-        let client = MCPClient()
-        let source = try await client.connect(descriptor)
-
-        defer {
-            Task { await client.disconnect(serverID: descriptor.id) }
-        }
+        let (server, source) = try await connectEverythingServer()
+        defer { Task { await server.close() } }
 
         // Verify we get tools back after connecting
         try await source.refreshTools()
@@ -42,20 +31,8 @@ final class EverythingServerSmokeTests: XCTestCase {
     func test_everythingServer_refreshToolsReturnsPositiveCount() async throws {
         // Sabotage: returning early before connect() would fail the tool-count assertion
 
-        let command = MCPStdioCommand.npx(package: "@modelcontextprotocol/server-everything")
-        let descriptor = MCPServerDescriptor(
-            displayName: "Everything Server",
-            transport: .stdio(command),
-            initializationTimeout: .seconds(60),
-            dataDisclosure: "E2E test server"
-        )
-
-        let client = MCPClient()
-        let source = try await client.connect(descriptor)
-
-        defer {
-            Task { await client.disconnect(serverID: descriptor.id) }
-        }
+        let (server, source) = try await connectEverythingServer()
+        defer { Task { await server.close() } }
 
         try await source.refreshTools()
         let toolNames = await source.currentToolNames()
@@ -63,20 +40,8 @@ final class EverythingServerSmokeTests: XCTestCase {
     }
 
     func test_everythingServer_taskCancellationPropagates() async throws {
-        let command = MCPStdioCommand.npx(package: "@modelcontextprotocol/server-everything")
-        let descriptor = MCPServerDescriptor(
-            displayName: "Everything Server",
-            transport: .stdio(command),
-            initializationTimeout: .seconds(60),
-            dataDisclosure: "E2E test server"
-        )
-
-        let client = MCPClient()
-        let source = try await client.connect(descriptor)
-
-        defer {
-            Task { await client.disconnect(serverID: descriptor.id) }
-        }
+        let (server, source) = try await connectEverythingServer()
+        defer { Task { await server.close() } }
 
         // Start a task that does work on the source and immediately cancel it.
         // The task should surface CancellationError (or MCPError.cancelled).
@@ -103,11 +68,32 @@ final class EverythingServerSmokeTests: XCTestCase {
         }
     }
 
-    // MARK: - Helpers
-
-    private func hasNpx() -> Bool {
-        FileManager.default.fileExists(atPath: "/usr/local/bin/npx")
-            || FileManager.default.fileExists(atPath: "/opt/homebrew/bin/npx")
+    private func connectEverythingServer() async throws -> (MCPJSONLineProcessServer, MCPToolSource) {
+        let server = MCPJSONLineProcessServer(package: "@modelcontextprotocol/server-everything")
+        let capabilities = try await withTimeout(.seconds(30)) {
+            try await server.start()
+        }
+        let source = MCPToolSource(
+            serverID: UUID(),
+            displayName: "Everything Server",
+            capabilities: capabilities,
+            toolNamespace: nil,
+            toolFilter: .allowAll,
+            approvalPolicy: .perCall,
+            listTools: {
+                try await server.sendRequest(method: "tools/list", params: nil)
+            },
+            callTool: { toolName, arguments in
+                try await server.sendRequest(
+                    method: "tools/call",
+                    params: .object([
+                        "name": .string(toolName),
+                        "arguments": arguments,
+                    ])
+                )
+            }
+        )
+        return (server, source)
     }
 }
 #endif

--- a/Tests/ManifoldMCPE2ETests/FilesystemServerSmokeTests.swift
+++ b/Tests/ManifoldMCPE2ETests/FilesystemServerSmokeTests.swift
@@ -1,0 +1,137 @@
+#if MCP
+#if os(macOS) && !targetEnvironment(macCatalyst)
+import Foundation
+import XCTest
+@testable import ManifoldMCP
+import ManifoldInference
+import ManifoldTestSupport
+
+final class FilesystemServerSmokeTests: XCTestCase {
+    private var sandboxRoot: URL?
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["RUN_MCP_E2E"] == "1",
+            "Set RUN_MCP_E2E=1 to run MCP filesystem E2E tests."
+        )
+        try XCTSkipUnless(hasExecutableOnPATH("npx"), "npx not installed or not on PATH")
+    }
+
+    override func tearDownWithError() throws {
+        if let sandboxRoot {
+            try? FileManager.default.removeItem(at: sandboxRoot)
+        }
+        try super.tearDownWithError()
+    }
+
+    func test_filesystemServer_listsReadsWritesAndRejectsTraversal() async throws {
+        let sandbox = try makeProjectSandbox(named: "mcp-filesystem-e2e")
+        sandboxRoot = sandbox
+        let allowedRoot = sandbox.appendingPathComponent("allowed", isDirectory: true)
+        let outside = sandbox.appendingPathComponent("outside.txt")
+        try FileManager.default.createDirectory(at: allowedRoot, withIntermediateDirectories: true)
+        try "outside".write(to: outside, atomically: true, encoding: .utf8)
+
+        let server = MCPJSONLineProcessServer(
+            package: "@modelcontextprotocol/server-filesystem",
+            args: [allowedRoot.path]
+        )
+        let capabilities = try await withTimeout(.seconds(30)) {
+            try await server.start()
+        }
+        XCTAssertEqual(capabilities.serverName, "secure-filesystem-server")
+        defer { Task { await server.close() } }
+
+        let source = MCPToolSource(
+            serverID: UUID(),
+            displayName: "Filesystem Server",
+            capabilities: capabilities,
+            toolNamespace: nil,
+            toolFilter: .allowAll,
+            approvalPolicy: .perCall,
+            listTools: {
+                try await server.sendRequest(method: "tools/list", params: nil)
+            },
+            callTool: { toolName, arguments in
+                try await server.sendRequest(
+                    method: "tools/call",
+                    params: .object([
+                        "name": .string(toolName),
+                        "arguments": arguments,
+                    ])
+                )
+            }
+        )
+
+        try await withTimeout(.seconds(30)) {
+            try await source.refreshTools()
+        }
+        let toolNames = await source.currentToolNames()
+        XCTAssertTrue(toolNames.contains("list_directory"), "server-filesystem should advertise list_directory")
+        XCTAssertTrue(toolNames.contains("read_file"), "server-filesystem should advertise read_file")
+        XCTAssertTrue(toolNames.contains("write_file"), "server-filesystem should advertise write_file")
+
+        let registry = await MainActor.run { ToolRegistry() }
+        await source.register(in: registry)
+        let registeredNames = await MainActor.run { registry.definitions.map(\.name) }
+        XCTAssertTrue(registeredNames.contains("write_file"))
+
+        let fileURL = allowedRoot.appendingPathComponent("notes/e2e.txt")
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let writeResult = try await withTimeout(.seconds(30)) {
+            await registry.dispatch(ToolCall(
+                id: "write-e2e",
+                toolName: "write_file",
+                arguments: #"{"path":"\#(fileURL.path)","content":"hello from e2e"}"#
+            ))
+        }
+        XCTAssertNil(writeResult.errorKind, writeResult.content)
+        XCTAssertEqual(try String(contentsOf: fileURL, encoding: .utf8), "hello from e2e")
+
+        let readResult = try await withTimeout(.seconds(30)) {
+            await registry.dispatch(ToolCall(
+                id: "read-e2e",
+                toolName: "read_file",
+                arguments: #"{"path":"\#(fileURL.path)"}"#
+            ))
+        }
+        XCTAssertNil(readResult.errorKind, readResult.content)
+        XCTAssertTrue(readResult.content.contains("hello from e2e"))
+
+        let listResult = try await withTimeout(.seconds(30)) {
+            await registry.dispatch(ToolCall(
+                id: "list-e2e",
+                toolName: "list_directory",
+                arguments: #"{"path":"\#(allowedRoot.appendingPathComponent("notes").path)"}"#
+            ))
+        }
+        XCTAssertNil(listResult.errorKind, listResult.content)
+        XCTAssertTrue(listResult.content.contains("e2e.txt"))
+
+        let traversalPath = "\(allowedRoot.path)/../outside.txt"
+        let traversalResult = try await withTimeout(.seconds(30)) {
+            await registry.dispatch(ToolCall(
+                id: "traversal-e2e",
+                toolName: "read_file",
+                arguments: #"{"path":"\#(traversalPath)"}"#
+            ))
+        }
+        XCTAssertNotNil(traversalResult.errorKind, "server-filesystem must reject traversal outside allowed roots")
+        XCTAssertEqual(try String(contentsOf: outside, encoding: .utf8), "outside")
+    }
+
+    private func makeProjectSandbox(named prefix: String) throws -> URL {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent("tmp", isDirectory: true)
+            .appendingPathComponent(prefix, isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+}
+#endif
+#endif

--- a/Tests/ManifoldMCPE2ETests/MCPJSONLineProcessServer.swift
+++ b/Tests/ManifoldMCPE2ETests/MCPJSONLineProcessServer.swift
@@ -1,0 +1,168 @@
+#if MCP
+#if os(macOS) && !targetEnvironment(macCatalyst)
+import Foundation
+@testable import ManifoldMCP
+import ManifoldInference
+
+actor MCPJSONLineProcessServer {
+    private let package: String
+    private let args: [String]
+    private let codec = MCPJSONRPCCodec(maxMessageBytes: 4 * 1024 * 1024, maxJSONNestingDepth: 32)
+    private var process: Process?
+    private var stdinHandle: FileHandle?
+    private var stdoutHandle: FileHandle?
+    private var nextRequestID = 1
+
+    init(package: String, args: [String] = []) {
+        self.package = package
+        self.args = args
+    }
+
+    func start() async throws -> MCPCapabilities {
+        guard process == nil else {
+            throw MCPError.transportFailure("JSON-line MCP process already started")
+        }
+
+        let process = Process()
+        let stdinPipe = Pipe()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["npx", "-y", package] + args
+        process.standardInput = stdinPipe
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        try process.run()
+        self.process = process
+        self.stdinHandle = stdinPipe.fileHandleForWriting
+        self.stdoutHandle = stdoutPipe.fileHandleForReading
+
+        let response = try await sendRequest(method: "initialize", params: .object([
+            "protocolVersion": .string("2025-03-26"),
+            "capabilities": .object([:]),
+            "clientInfo": .object([
+                "name": .string("ManifoldKitE2E"),
+                "version": .string("1.0.0"),
+            ]),
+        ]))
+        try await sendNotification(method: "notifications/initialized", params: nil)
+        return try parseInitializeResponse(response)
+    }
+
+    func sendRequest(method: String, params: JSONSchemaValue?) async throws -> JSONSchemaValue? {
+        let id = MCPRequestID.int(nextRequestID)
+        nextRequestID += 1
+        let request = MCPJSONRPCMessage.request(id: id, method: method, params: params)
+        try write(request)
+
+        while true {
+            let message = try readMessage()
+            switch message {
+            case .result(let responseID, let result) where responseID == id:
+                return result
+            case .error(let responseID, let error) where responseID == id:
+                throw MCPError.protocolError(
+                    code: error.code,
+                    message: error.message,
+                    data: error.data.flatMap(stringify)
+                )
+            case .request, .notification, .result, .error:
+                continue
+            }
+        }
+    }
+
+    func sendNotification(method: String, params: JSONSchemaValue?) async throws {
+        try write(.notification(method: method, params: params))
+    }
+
+    func close() {
+        stdinHandle?.closeFile()
+        stdoutHandle?.closeFile()
+        if let process, process.isRunning {
+            process.terminate()
+        }
+        process = nil
+        stdinHandle = nil
+        stdoutHandle = nil
+    }
+
+    private func write(_ message: MCPJSONRPCMessage) throws {
+        guard let stdinHandle else { throw MCPError.transportClosed }
+        var payload = try codec.encode(message)
+        payload.append(0x0A)
+        try stdinHandle.write(contentsOf: payload)
+    }
+
+    private func readMessage() throws -> MCPJSONRPCMessage {
+        guard let stdoutHandle else { throw MCPError.transportClosed }
+        var line = Data()
+        while true {
+            let byte = try stdoutHandle.read(upToCount: 1) ?? Data()
+            if byte.isEmpty { throw MCPError.transportClosed }
+            if byte[byte.startIndex] == 0x0A { break }
+            line.append(byte)
+        }
+        if line.last == 0x0D {
+            line.removeLast()
+        }
+        return try codec.decode(line)
+    }
+
+    private func parseInitializeResponse(_ response: JSONSchemaValue?) throws -> MCPCapabilities {
+        guard case .object(let object) = response else {
+            throw MCPError.malformedMetadata("Initialize response must be an object")
+        }
+        let capabilities = objectValue(object["capabilities"])
+        let toolCapabilities = objectValue(capabilities?["tools"])
+        return MCPCapabilities(
+            protocolVersion: stringValue(object["protocolVersion"]) ?? "",
+            serverName: objectValue(object["serverInfo"])?["name"].flatMap(stringValue) ?? package,
+            serverVersion: objectValue(object["serverInfo"])?["version"].flatMap(stringValue) ?? "",
+            supportsToolListChanged: toolCapabilities?["listChanged"].flatMap(boolValue) ?? true,
+            supportsResources: capabilities?["resources"] != nil,
+            supportsPrompts: capabilities?["prompts"] != nil,
+            supportsLogging: capabilities?["logging"] != nil
+        )
+    }
+}
+
+func hasExecutableOnPATH(_ name: String) -> Bool {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = ["which", name]
+    process.standardOutput = Pipe()
+    process.standardError = Pipe()
+    do {
+        try process.run()
+        process.waitUntilExit()
+        return process.terminationStatus == 0
+    } catch {
+        return false
+    }
+}
+
+private func objectValue(_ value: JSONSchemaValue?) -> [String: JSONSchemaValue]? {
+    guard case .object(let object) = value else { return nil }
+    return object
+}
+
+private func stringValue(_ value: JSONSchemaValue?) -> String? {
+    guard case .string(let string) = value else { return nil }
+    return string
+}
+
+private func boolValue(_ value: JSONSchemaValue?) -> Bool? {
+    guard case .bool(let bool) = value else { return nil }
+    return bool
+}
+
+private func stringify(_ value: JSONSchemaValue) -> String {
+    switch value {
+    case .string(let string): return string
+    default: return String(describing: value)
+    }
+}
+#endif
+#endif

--- a/Tests/ManifoldMCPTests/MCPToolBridgeTests.swift
+++ b/Tests/ManifoldMCPTests/MCPToolBridgeTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import XCTest
 @testable import ManifoldMCP
 import ManifoldInference
+import ManifoldTestSupport
 
 @MainActor
 final class MCPToolBridgeTests: XCTestCase {
@@ -643,6 +644,85 @@ final class MCPToolBridgeTests: XCTestCase {
         let names = await MainActor.run { registry.definitions.map(\.name) }
         XCTAssertEqual(names, ["search"])
     }
+
+    func test_filesystemSourceRegistersToolsAndDispatchesScriptedBackendTurn() async throws {
+        let sandbox = try makeProjectSandbox(named: "mcp-filesystem-unit")
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let filesystem = ScriptedFilesystemSandbox(root: sandbox)
+        let source = MCPToolSource(
+            serverID: UUID(),
+            displayName: "Filesystem",
+            capabilities: .init(),
+            toolNamespace: nil,
+            toolFilter: .allowAll,
+            approvalPolicy: .perCall,
+            listTools: {
+                .object([
+                    "tools": .array([
+                        filesystemTool(name: "list_directory", description: "List sandbox contents"),
+                        filesystemTool(name: "read_file", description: "Read a sandbox file"),
+                        filesystemTool(name: "write_file", description: "Write a sandbox file"),
+                    ]),
+                ])
+            },
+            callTool: { toolName, arguments in
+                try await filesystem.call(toolName: toolName, arguments: arguments)
+            }
+        )
+
+        let registry = ToolRegistry()
+        await source.register(in: registry)
+        let registeredToolNames = registry.definitions.map(\.name)
+        XCTAssertEqual(registeredToolNames, ["list_directory", "read_file", "write_file"])
+
+        let backend = MockInferenceBackend(capabilities: BackendCapabilities(
+            supportedParameters: [.temperature, .topP, .repeatPenalty],
+            maxContextTokens: 4096,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsToolCalling: true,
+            supportsStructuredOutput: false,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: false
+        ))
+        backend.isModelLoaded = true
+        backend.scriptedToolCallsPerTurn = [
+            [ToolCall(id: "write-1", toolName: "write_file", arguments: #"{"path":"notes/hello.txt","content":"hello filesystem"}"#)],
+            [ToolCall(id: "read-1", toolName: "read_file", arguments: #"{"path":"notes/hello.txt"}"#)],
+            [ToolCall(id: "list-1", toolName: "list_directory", arguments: #"{"path":"notes"}"#)],
+            [],
+        ]
+        backend.tokensToYieldPerTurn = [[], [], [], ["done"]]
+
+        let service = InferenceService(backend: backend, toolRegistry: registry)
+        let (_, stream) = try service.enqueue(
+            messages: [.user("write, read, then list a sandbox file")],
+            tools: registry.definitions,
+            maxToolIterations: 5
+        )
+
+        let events = try await collectEvents(stream)
+        let toolResults = events.compactMap { event -> ToolResult? in
+            if case .toolResult(let result) = event { return result }
+            return nil
+        }
+
+        XCTAssertEqual(toolResults.map(\.callId), ["write-1", "read-1", "list-1"])
+        XCTAssertTrue(toolResults.allSatisfy { $0.errorKind == nil }, "Expected all filesystem tool calls to succeed")
+        let fileExists = try await filesystem.fileExists(relativePath: "notes/hello.txt")
+        let fileContents = try await filesystem.read(relativePath: "notes/hello.txt")
+        XCTAssertTrue(fileExists)
+        XCTAssertEqual(fileContents, "hello filesystem")
+        XCTAssertTrue(toolResults[1].content.contains("hello filesystem"))
+        XCTAssertTrue(toolResults[2].content.contains("hello.txt"))
+
+        let traversal = await registry.dispatch(
+            ToolCall(id: "escape-1", toolName: "read_file", arguments: #"{"path":"../outside.txt"}"#)
+        )
+        XCTAssertEqual(traversal.callId, "escape-1")
+        XCTAssertNotNil(traversal.errorKind, "Path traversal must be rejected by the filesystem tool")
+    }
 }
 
 private func makeSource(
@@ -664,6 +744,101 @@ private func makeSource(
         },
         callTool: { _, _ in nil }
     )
+}
+
+private func filesystemTool(name: String, description: String) -> JSONSchemaValue {
+    .object([
+        "name": .string(name),
+        "description": .string(description),
+        "inputSchema": .object([
+            "type": .string("object"),
+            "properties": .object([
+                "path": .object(["type": .string("string")]),
+                "content": .object(["type": .string("string")]),
+            ]),
+            "required": .array([.string("path")]),
+        ]),
+    ])
+}
+
+private func collectEvents(_ stream: GenerationStream) async throws -> [GenerationEvent] {
+    var events: [GenerationEvent] = []
+    for try await event in stream.events {
+        events.append(event)
+    }
+    return events
+}
+
+private func makeProjectSandbox(named prefix: String) throws -> URL {
+    let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        .appendingPathComponent("tmp", isDirectory: true)
+        .appendingPathComponent(prefix, isDirectory: true)
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    return root
+}
+
+private actor ScriptedFilesystemSandbox {
+    private let root: URL
+    private let fileManager = FileManager.default
+
+    init(root: URL) {
+        self.root = root.standardizedFileURL
+    }
+
+    func call(toolName: String, arguments: JSONSchemaValue) throws -> JSONSchemaValue {
+        guard case .object(let object) = arguments,
+              case .string(let path)? = object["path"] else {
+            throw MCPError.malformedMetadata("filesystem tool requires a string path")
+        }
+
+        switch toolName {
+        case "list_directory":
+            let url = try resolve(path)
+            let names = try fileManager.contentsOfDirectory(atPath: url.path).sorted()
+            return textResult(names.joined(separator: "\n"))
+        case "read_file":
+            return try textResult(read(relativePath: path))
+        case "write_file":
+            guard case .string(let content)? = object["content"] else {
+                throw MCPError.malformedMetadata("write_file requires string content")
+            }
+            let url = try resolve(path)
+            try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try content.write(to: url, atomically: true, encoding: .utf8)
+            return textResult("wrote \(path)")
+        default:
+            throw MCPError.toolNotFound(toolName)
+        }
+    }
+
+    func fileExists(relativePath: String) throws -> Bool {
+        fileManager.fileExists(atPath: try resolve(relativePath).path)
+    }
+
+    func read(relativePath: String) throws -> String {
+        try String(contentsOf: resolve(relativePath), encoding: .utf8)
+    }
+
+    private func resolve(_ relativePath: String) throws -> URL {
+        let candidate = root.appendingPathComponent(relativePath).standardizedFileURL
+        let rootPath = root.path.hasSuffix("/") ? root.path : root.path + "/"
+        guard candidate.path == root.path || candidate.path.hasPrefix(rootPath) else {
+            throw MCPError.authorizationFailed("path traversal rejected: \(relativePath)")
+        }
+        return candidate
+    }
+
+    private func textResult(_ text: String) -> JSONSchemaValue {
+        .object([
+            "content": .array([
+                .object([
+                    "type": .string("text"),
+                    "text": .string(text),
+                ]),
+            ]),
+        ])
+    }
 }
 
 private actor ToolListProvider {


### PR DESCRIPTION
## Summary
- Add MCPToolSource filesystem unit coverage that dynamically registers list/read/write tools into ToolRegistry and drives a scripted backend turn through InferenceService.
- Add RUN_MCP_E2E-gated filesystem server coverage using @modelcontextprotocol/server-filesystem via npx in a per-test project sandbox.
- Reuse a JSON-line npx E2E helper for existing server-everything smoke tests so real MCP npm servers complete reliably without making normal CI require external servers.

## Scenario coverage
| Scenario | Coverage | Assertions |
| --- | --- | --- |
| MCPToolSource filesystem bridge | ManifoldMCPTests.MCPToolBridgeTests.test_filesystemSourceRegistersToolsAndDispatchesScriptedBackendTurn | dynamic ToolRegistry registration, scripted backend dispatches write/read/list, sandbox side effect, traversal rejected |
| server-filesystem E2E | ManifoldMCPE2ETests.FilesystemServerSmokeTests.test_filesystemServer_listsReadsWritesAndRejectsTraversal | npx startup, tools/list advertises list/read/write, ToolRegistry dispatch writes/reads/lists inside sandbox, traversal rejected |
| server-everything E2E stability | Existing EverythingServerSmokeTests via JSON-line npx helper | tools listed and refresh/cancellation smoke coverage remains RUN_MCP_E2E-gated |

## Demo UI mock gap
No narrow existing demo settings/test-injection seam for an MCP filesystem mock was present, so this PR does not make broad app architecture changes for UI coverage.

## Validation
- PASS: `scripts/test.sh --filter ManifoldMCPTests --traits MCP --disable-default-traits --skip-update --min-passed 1` (158 passed)
- PASS: `RUN_MCP_E2E=1 scripts/test.sh --filter ManifoldMCPE2ETests --traits MCP --disable-default-traits --skip-update --min-passed 1` (5 passed)