### PR TITLE
ci: add MCP test gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,8 @@ jobs:
       # - Run `swift test --filter ManifoldBackendsTests --traits MLX,Llama` on
       #   Apple Silicon for MLX/llama.cpp paths.
       # - Run `swift test --filter ManifoldE2ETests` on physical hardware.
+      # - --traits MCP compiles the offline ManifoldMCPTests target; RUN_MCP_E2E
+      #   stays unset here, so per-PR CI never requires external MCP servers.
       # - MCP E2E stays out of per-PR CI; nightly-slow-tests runs the
       #   RUN_MCP_E2E-gated streamable-HTTP smoke with a narrow filter so
       #   npx/network-backed subprocess tests remain local-only.
@@ -263,7 +265,7 @@ jobs:
         timeout-minutes: 12
         env:
           MANIFOLD_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-xctest-suites.log
-        run: scripts/test.sh --filter ManifoldCoreTests --filter ManifoldRuntimeTests --filter ManifoldPersistenceSwiftDataTests --filter ManifoldUITests --filter ManifoldUIModelManagementTests --filter ManifoldMCPTests --filter ManifoldBackendsTests --filter ManifoldTestSupportTests --filter ManifoldAppIntentsTests --filter ManifoldInferenceTests --disable-default-traits --skip-update --parallel
+        run: scripts/test.sh --filter ManifoldCoreTests --filter ManifoldRuntimeTests --filter ManifoldPersistenceSwiftDataTests --filter ManifoldUITests --filter ManifoldUIModelManagementTests --filter ManifoldMCPTests --filter ManifoldBackendsTests --filter ManifoldTestSupportTests --filter ManifoldAppIntentsTests --filter ManifoldInferenceTests --disable-default-traits --traits MCP --skip-update --parallel
 
       # `if: always()` so a failing XCTest step still surfaces Swift Testing
       # failures in the same run — otherwise breakage in both harnesses costs

--- a/.github/workflows/security-gates.yml
+++ b/.github/workflows/security-gates.yml
@@ -69,7 +69,7 @@ jobs:
         env:
           RUN_SLOW_TESTS: "1"
           MANIFOLD_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-traffic-boundary-and-mcp-hardening.log
-        run: scripts/test.sh --filter "ManifoldInferenceTests.TrafficBoundaryAuditTest" --filter "ManifoldMCPTests.MCPHardeningTests" --disable-default-traits --skip-update --min-passed 2
+        run: scripts/test.sh --filter "ManifoldInferenceTests.TrafficBoundaryAuditTest" --filter "ManifoldMCPTests.MCPHardeningTests" --disable-default-traits --traits MCP --skip-update --min-passed 2
 
       - name: Test — PinnedSessionDelegateTests (CloudSaaS)
         env:

--- a/README.md
+++ b/README.md
@@ -296,8 +296,8 @@ If you already depend on `ManifoldBackends`, the same data is also available via
 Quick checks:
 
 ```bash
-scripts/test.sh --filter ManifoldMCPTests --disable-default-traits --skip-update
-scripts/test.sh --filter ManifoldMCPTests --disable-default-traits --traits MCPBuiltinCatalog --skip-update
+scripts/test.sh --filter ManifoldMCPTests --disable-default-traits --traits MCP --skip-update
+scripts/test.sh --filter ManifoldMCPTests --disable-default-traits --traits MCP,MCPBuiltinCatalog --skip-update
 ```
 
 ### 2.2 ManifoldServer
@@ -988,6 +988,12 @@ SourceKit can retain stale module-not-found diagnostics from a previous trait-se
 **Workaround:** restart the SourceKit language server. In Xcode: *Product → Clean Build Folder*, then reopen the file. In VS Code with Swift extension: run "Swift: Restart SourceKit-LSP" from the command palette (⇧⌘P). The false diagnostic disappears after the language server re-indexes with the current trait set.
 
 If restarting the language server is insufficient, run `scripts/clean-build.sh` and reopen the project.
+
+For non-destructive investigation, see `docs/SOURCEKIT_DIAGNOSTICS.md` and run:
+
+```bash
+scripts/sourcekit-stale-module-diagnostics.sh
+```
 
 ## Example App
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -106,13 +106,13 @@ swift test --filter ManifoldBackendsTests --traits MLX,Llama
 swift test --filter ManifoldE2ETests --disable-default-traits
 
 # MCP built-in catalog descriptors (trait-gated metadata tests)
-scripts/test.sh --filter ManifoldMCPTests --disable-default-traits --traits MCPBuiltinCatalog --skip-update
+scripts/test.sh --filter ManifoldMCPTests --disable-default-traits --traits MCP,MCPBuiltinCatalog --skip-update
 
 # MCP end-to-end smoke tests are explicit opt-in only.
 # Nightly runs the streamable-HTTP smoke; keep the filter narrow so the
 # npx/network-backed EverythingServerSmokeTests suite does not run by default.
 RUN_MCP_E2E=1 scripts/test.sh --filter ManifoldMCPE2ESmokeTests \
-  --disable-default-traits --skip-update --min-passed 1
+  --disable-default-traits --traits MCP --skip-update --min-passed 1
 
 # Full subprocess E2E, local only: requires npx on PATH and network access to
 # download @modelcontextprotocol/server-everything.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -239,6 +239,11 @@ if [[ $PARALLEL_MODE -eq 1 ]]; then
     fi
 fi
 
+mcp_test_events=0
+if [[ $MCP_FILTER_REQUESTED -eq 1 ]]; then
+    mcp_test_events=$(grep -cE "(Test Case '-\[ManifoldMCP(E2E)?Tests\.|^\[[0-9]+/[0-9]+\] Testing ManifoldMCP(E2E)?Tests\.)" "$OUTPUT_FILE" || true)
+fi
+
 # Suites that started but never emitted a 'passed' or 'failed' line are crash victims.
 # Exclude the two top-level container lines ("All tests" and the .xctest bundle).
 xctest_suites_started=$(grep "^Test Suite '" "$OUTPUT_FILE" \
@@ -354,6 +359,9 @@ elif [[ $total_crashed_count -gt 0 ]]; then
 elif [[ $SWIFT_EXIT -ne 0 ]]; then
     echo "  RESULT: FAILED (swift test exit code $SWIFT_EXIT)"
     FINAL_EXIT=$SWIFT_EXIT
+elif [[ $MCP_FILTER_REQUESTED -eq 1 && $mcp_test_events -eq 0 ]]; then
+    echo "  RESULT: TRIPWIRE — MCP filter matched 0 MCP test cases; ensure --traits MCP compiled the target"
+    FINAL_EXIT=3
 elif [[ $total_passed -eq 0 && $total_skipped -gt 0 && $total_failed -eq 0 && $total_crashed_count -eq 0 ]]; then
     echo "  RESULT: TRIPWIRE — 0 tests passed, $total_skipped skipped (entire suite silently skipped)"
     FINAL_EXIT=3


### PR DESCRIPTION
## Summary
- Run ManifoldMCPTests in per-PR CI with the MCP trait enabled while leaving RUN_MCP_E2E unset so normal CI stays offline and does not require external MCP servers.
- Add an MCP zero-test tripwire in scripts/test.sh so MCP filters fail if no MCP test case is observed.
- Keep the RUN_MCP_E2E=1 streamable-HTTP smoke in the existing nightly/manual slow-test workflow, with docs updated to pass --traits MCP explicitly.

## Validation
- bash -n scripts/test.sh
- python3 YAML parse: .github/workflows/ci.yml, .github/workflows/security-gates.yml, .github/workflows/nightly-slow-tests.yml
- MANIFOLD_TEST_OUTPUT_FILE="/Users/roryford/Repos/ManifoldKit/tmp/wave-4-mcp-gates-validate/test-diagnostics/wave-4-mcp-gates.log" scripts/test.sh --filter ManifoldMCPTests --traits MCP --disable-default-traits --skip-update --min-passed 1 (clean detached worktree; 157 tests, 0 failures)