### PR TITLE
test: add backend protocol contract mixins

### DIFF
--- a/Tests/ManifoldBackendsTests/Conformance/BackendContractMixins.swift
+++ b/Tests/ManifoldBackendsTests/Conformance/BackendContractMixins.swift
@@ -1,0 +1,122 @@
+import XCTest
+import ManifoldInference
+
+/// XCTest-visible mixins for opt-in backend protocol contracts.
+///
+/// Extension methods are intentionally assertion helpers rather than `test_…`
+/// methods: XCTest does not discover protocol-extension tests. Adopting suites
+/// call these helpers from concrete test methods so each backend explicitly opts
+/// into the protocol contracts it supports.
+/// All contract mixin protocols are `@MainActor`-isolated so that conforming
+/// test classes (which are `@MainActor`) satisfy Swift 6's isolation boundary
+/// checks without wrapping factory calls in extra closures.
+@MainActor
+protocol BackendContractMixin: AnyObject {
+    associatedtype BackendUnderContract: InferenceBackend
+
+    var contractBackendName: String { get }
+    func makeContractBackend() -> BackendUnderContract
+}
+
+extension BackendContractMixin where Self: XCTestCase {
+    @MainActor
+    func assertUniversalBackendContract(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        BackendContractChecks.assertAllInvariants(
+            makingBackend: makeContractBackend,
+            file: file,
+            line: line
+        )
+    }
+}
+
+protocol GrammarFailClosedContractMixin: BackendContractMixin {}
+
+extension GrammarFailClosedContractMixin where Self: XCTestCase {
+    @MainActor
+    func assertGrammarFailClosedContract(
+        forbiddenRequestURL: URL? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        try await BackendContractChecks.assertGrammarFailClosedContract(
+            backendName: contractBackendName,
+            makingBackend: makeContractBackend,
+            forbiddenRequestURL: forbiddenRequestURL,
+            file: file,
+            line: line
+        )
+    }
+}
+
+@MainActor
+protocol ConversationHistoryReceiverContractMixin: BackendContractMixin where BackendUnderContract: ConversationHistoryReceiver {}
+
+extension ConversationHistoryReceiverContractMixin where Self: XCTestCase {
+    @MainActor
+    func assertConversationHistoryReceiverContract(
+        readHistory: (BackendUnderContract) -> [(role: String, content: String)]?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let backend = makeContractBackend()
+        let firstHistory: [(role: String, content: String)] = [
+            (role: "system", content: "You are concise."),
+            (role: "user", content: "Hello"),
+            (role: "assistant", content: "Hi")
+        ]
+        backend.setConversationHistory(firstHistory)
+        assertHistory(readHistory(backend), equals: firstHistory, file: file, line: line)
+
+        let replacementHistory: [(role: String, content: String)] = [
+            (role: "user", content: "Replacement history")
+        ]
+        backend.setConversationHistory(replacementHistory)
+        assertHistory(readHistory(backend), equals: replacementHistory, file: file, line: line)
+    }
+
+    private func assertHistory(
+        _ actual: [(role: String, content: String)]?,
+        equals expected: [(role: String, content: String)],
+        file: StaticString,
+        line: UInt
+    ) {
+        guard let actual else {
+            XCTFail("Expected backend to retain conversation history", file: file, line: line)
+            return
+        }
+        XCTAssertEqual(actual.count, expected.count, file: file, line: line)
+        for (index, expectedEntry) in expected.enumerated() where index < actual.count {
+            XCTAssertEqual(actual[index].role, expectedEntry.role, file: file, line: line)
+            XCTAssertEqual(actual[index].content, expectedEntry.content, file: file, line: line)
+        }
+    }
+}
+
+@MainActor
+protocol StructuredHistoryReceiverContractMixin: BackendContractMixin where BackendUnderContract: StructuredHistoryReceiver {}
+
+extension StructuredHistoryReceiverContractMixin where Self: XCTestCase {
+    @MainActor
+    func assertStructuredHistoryReceiverContract(
+        readHistory: (BackendUnderContract) -> [StructuredMessage]?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let backend = makeContractBackend()
+        let firstHistory = [
+            StructuredMessage(role: "user", parts: [.text("Question")]),
+            StructuredMessage(role: "assistant", parts: [.thinking("Reasoning", signature: "sig-1"), .text("Answer")])
+        ]
+        backend.setStructuredHistory(firstHistory)
+        XCTAssertEqual(readHistory(backend), firstHistory, file: file, line: line)
+
+        let replacementHistory = [
+            StructuredMessage(role: "tool", parts: [.text("{\"ok\":true}")])
+        ]
+        backend.setStructuredHistory(replacementHistory)
+        XCTAssertEqual(readHistory(backend), replacementHistory, file: file, line: line)
+    }
+}

--- a/Tests/ManifoldBackendsTests/Conformance/MockInferenceBackendConformanceTests.swift
+++ b/Tests/ManifoldBackendsTests/Conformance/MockInferenceBackendConformanceTests.swift
@@ -19,9 +19,18 @@ import ManifoldTestSupport
 ///    `claimWithoutBehaviouralAssertion(...)` records do clear the unproven
 ///    bit. Acts as a self-test of the meta-contract bookkeeping itself.
 @MainActor
-final class MockInferenceBackendConformanceTests: XCTestCase {
+final class MockInferenceBackendConformanceTests: XCTestCase,
+                                                 BackendContractMixin,
+                                                 GrammarFailClosedContractMixin,
+                                                 ConversationHistoryReceiverContractMixin,
+                                                 StructuredHistoryReceiverContractMixin {
 
     private let backendName = "MockInferenceBackend"
+    let contractBackendName = "MockInferenceBackend"
+
+    func makeContractBackend() -> MockInferenceBackend {
+        MockInferenceBackend()
+    }
 
     override func setUp() {
         super.setUp()
@@ -34,7 +43,7 @@ final class MockInferenceBackendConformanceTests: XCTestCase {
     // MARK: - Universal invariants
 
     func test_universalInvariants_allPass() {
-        BackendContractChecks.assertAllInvariants(makingBackend: { MockInferenceBackend() })
+        assertUniversalBackendContract()
     }
 
     // MARK: - False-claim family: grammar fail-closed
@@ -52,16 +61,24 @@ final class MockInferenceBackendConformanceTests: XCTestCase {
     ///       capabilities; the early-return inside the assertion family fires
     ///       and the test correctly skips the throw assertion (claim is
     ///       still recorded, so meta-contract still satisfied).
+    @MainActor
     func test_grammarFailClosed_throwsUnsupportedGrammar() async throws {
-        try await BackendContractChecks.assertGrammarFailClosedContract(
-            backendName: backendName,
-            makingBackend: { MockInferenceBackend() }
-        )
+        try await assertGrammarFailClosedContract()
         // Claim recorded.
         XCTAssertTrue(
             BackendContractChecks.capturedClaims().contains("\(backendName)::supportsGrammarConstrainedSampling"),
             "assertGrammarFailClosedContract must record the capability claim"
         )
+    }
+
+    // MARK: - Opt-in protocol contracts
+
+    func test_conversationHistoryReceiverContract_replacesHistory() {
+        assertConversationHistoryReceiverContract(readHistory: \.lastReceivedHistory)
+    }
+
+    func test_structuredHistoryReceiverContract_replacesHistory() {
+        assertStructuredHistoryReceiverContract(readHistory: \.lastReceivedStructuredHistory)
     }
 
     // MARK: - Meta-contract self-tests

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -81,38 +81,47 @@ If your test hits SwiftData, it's an integration test — name and place it acco
 ## Adding a new backend
 
 1. Implement `InferenceBackend` (and any opt-in protocols) in `Sources/ManifoldBackends/<YourBackend>.swift`.
-2. Add a conformance test class under `Tests/ManifoldBackendsTests/Conformance/<YourBackend>ConformanceTests.swift`. Subclass `XCTestCase` and use the strengthened harness:
+2. Add a conformance test class under `Tests/ManifoldBackendsTests/Conformance/<YourBackend>ConformanceTests.swift`. Subclass `XCTestCase` and opt into the relevant contract mixins:
 
    ```swift
-   override func setUp() {
-       super.setUp()
-       BackendContractChecks.resetCapabilityClaims()
-   }
+   final class YourBackendConformanceTests: XCTestCase,
+                                            BackendContractMixin,
+                                            GrammarFailClosedContractMixin {
+       let contractBackendName = "YourBackend"
 
-   func test_universalInvariants_allPass() {
-       BackendContractChecks.assertAllInvariants(makingBackend: { YourBackend() })
-   }
+       func makeContractBackend() -> YourBackend {
+           YourBackend()
+       }
 
-   func test_grammarFailClosed_throwsUnsupportedGrammar() async throws {
-       try await BackendContractChecks.assertGrammarFailClosedContract(
-           backendName: "YourBackend",
-           makingBackend: { YourBackend() }
-       )
-   }
+       override func setUp() {
+           super.setUp()
+           BackendContractChecks.resetCapabilityClaims()
+       }
 
-   // …other per-capability assertions…
+       func test_universalInvariants_allPass() {
+           assertUniversalBackendContract()
+       }
 
-   func test_metaContract() {
-       BackendContractChecks.assertCapabilityMetaContract(
-           backendName: "YourBackend",
-           capabilities: YourBackend().capabilities
-       )
+       @MainActor
+       func test_grammarFailClosed_throwsUnsupportedGrammar() async throws {
+           try await assertGrammarFailClosedContract()
+       }
+
+       // …other per-capability assertions…
+
+       func test_metaContract() {
+           BackendContractChecks.assertCapabilityMetaContract(
+               backendName: "YourBackend",
+               capabilities: YourBackend().capabilities
+           )
+       }
    }
    ```
 
-3. Every `true` capability flag your backend declares must have at least one assertion family that records a claim against it (or call `claimWithoutBehaviouralAssertion(...)` as a temporary bootstrap — file the follow-up issue).
-4. Every `false` flag with a fail-closed contract (today: `supportsGrammarConstrainedSampling`) must run its fail-closed family.
-5. Run `scripts/test.sh --filter ManifoldBackendsTests` and verify the meta-contract test passes.
+3. If the backend adopts an opt-in protocol, add the matching mixin (`ConversationHistoryReceiverContractMixin`, `StructuredHistoryReceiverContractMixin`, etc.) and a concrete `test_…` method that calls its assertion helper. Protocol-extension methods are not XCTest-discoverable on their own.
+4. Every `true` capability flag your backend declares must have at least one assertion family that records a claim against it (or call `claimWithoutBehaviouralAssertion(...)` as a temporary bootstrap — file the follow-up issue).
+5. Every `false` flag with a fail-closed contract (today: `supportsGrammarConstrainedSampling`) must run its fail-closed family.
+6. Run `scripts/test.sh --filter ManifoldBackendsTests` and verify the meta-contract test passes.
 
 The full assertion shape is documented in `Tests/ManifoldBackendsTests/BackendContractTests.swift`.
 


### PR DESCRIPTION
## Summary
- Add reusable XCTest contract mixins for backend conformance suites.
- Apply the mixin pattern to the mock-backed conformance suite.
- Document the mixin adoption pattern in Tests/README.md.

## Contract list
- InferenceBackend universal invariants via BackendContractMixin.
- Grammar fail-closed behavior via GrammarFailClosedContractMixin.
- ConversationHistoryReceiver replacement semantics.
- StructuredHistoryReceiver replacement semantics, including thinking signatures.

## Adopters
- MockInferenceBackendConformanceTests adopts BackendContractMixin, GrammarFailClosedContractMixin, ConversationHistoryReceiverContractMixin, and StructuredHistoryReceiverContractMixin.

## Validation
- scripts/test.sh --filter ManifoldBackendsTests --disable-default-traits --skip-update --min-passed 1
  - Result: passed (176 passed, 1 skipped).

## Known limitations
- Initial opt-in coverage is mock-backed only to avoid hardware/cloud requirements in normal CI.
- Tool-aware history, token usage, token counting, load progress, and multimodal projector protocol mixins remain future candidates.
- True capability claims that still use claimWithoutBehaviouralAssertion remain bootstrap coverage, not behavioral proof.