### PR TITLE
test: add GGUF manifest verification seam

### DIFF
--- a/Sources/ManifoldInference/Models/GGUFSignedManifest.swift
+++ b/Sources/ManifoldInference/Models/GGUFSignedManifest.swift
@@ -1,0 +1,165 @@
+import CryptoKit
+import Foundation
+
+/// Detached, signed manifest describing GGUF weight digests.
+///
+/// The verifier below deliberately makes signature enforcement an injected seam:
+/// ManifoldKit can fail closed for unsigned/rejected manifests now, while a future
+/// trust-chain implementation owns key discovery and cryptographic policy.
+public struct GGUFSignedManifest: Codable, Hashable, Sendable {
+    public struct Payload: Codable, Hashable, Sendable {
+        public let files: [File]
+
+        public init(files: [File]) {
+            self.files = files
+        }
+    }
+
+    public struct File: Codable, Hashable, Sendable {
+        public let path: String
+        public let sha256: String
+
+        public init(path: String, sha256: String) {
+            self.path = path
+            self.sha256 = sha256
+        }
+    }
+
+    public struct Signature: Codable, Hashable, Sendable {
+        public let algorithm: String
+        public let keyID: String
+        public let value: String
+
+        public init(algorithm: String, keyID: String, value: String) {
+            self.algorithm = algorithm
+            self.keyID = keyID
+            self.value = value
+        }
+    }
+
+    public let payload: Payload
+    public let signature: Signature?
+
+    public init(payload: Payload, signature: Signature?) {
+        self.payload = payload
+        self.signature = signature
+    }
+}
+
+/// Signature policy injected into ``GGUFSignedManifestVerifier``.
+public protocol GGUFSignedManifestSignatureVerifying: Sendable {
+    /// Return `true` only when `canonicalPayload` is authenticated by `signature`.
+    func verify(signature: GGUFSignedManifest.Signature, canonicalPayload: Data) throws -> Bool
+}
+
+/// Explicit fail-closed placeholder used until product trust-chain policy exists.
+public struct RejectingGGUFSignedManifestSignatureVerifier: GGUFSignedManifestSignatureVerifying {
+    public init() {}
+
+    public func verify(signature _: GGUFSignedManifest.Signature, canonicalPayload _: Data) throws -> Bool {
+        false
+    }
+}
+
+public enum GGUFSignedManifestVerificationError: LocalizedError, Equatable {
+    case unsignedManifest
+    case signatureRejected(keyID: String)
+    case malformedSHA256(path: String)
+    case missingManifestEntry(path: String)
+    case fileMissing(path: String)
+    case digestMismatch(path: String, expected: String, actual: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsignedManifest:
+            return "GGUF manifest is unsigned."
+        case .signatureRejected(let keyID):
+            return "GGUF manifest signature was rejected for key '\(keyID)'."
+        case .malformedSHA256(let path):
+            return "GGUF manifest entry for '\(path)' has a malformed SHA-256 digest."
+        case .missingManifestEntry(let path):
+            return "GGUF manifest does not contain an entry for '\(path)'."
+        case .fileMissing(let path):
+            return "GGUF file for manifest verification is missing at '\(path)'."
+        case .digestMismatch(let path, let expected, let actual):
+            return "GGUF SHA-256 mismatch for '\(path)': expected \(expected), got \(actual)."
+        }
+    }
+}
+
+/// Opt-in verifier for GGUF files described by a signed SHA-256 manifest.
+public struct GGUFSignedManifestVerifier: Sendable {
+    private let signatureVerifier: any GGUFSignedManifestSignatureVerifying
+
+    public init(signatureVerifier: any GGUFSignedManifestSignatureVerifying = RejectingGGUFSignedManifestSignatureVerifier()) {
+        self.signatureVerifier = signatureVerifier
+    }
+
+    /// Decodes and verifies `fileURL` against `manifestData`.
+    ///
+    /// - Parameters:
+    ///   - expectedPath: Relative manifest path to match. Defaults to the file's last path component.
+    /// - Throws: ``GGUFSignedManifestVerificationError`` when the manifest is unsigned,
+    ///   the signature verifier rejects it, the manifest entry is malformed/missing,
+    ///   or the file digest does not match.
+    public func verify(fileURL: URL, manifestData: Data, expectedPath: String? = nil) throws {
+        let manifest = try JSONDecoder().decode(GGUFSignedManifest.self, from: manifestData)
+        try verify(fileURL: fileURL, manifest: manifest, expectedPath: expectedPath)
+    }
+
+    public func verify(fileURL: URL, manifest: GGUFSignedManifest, expectedPath: String? = nil) throws {
+        try requireAcceptedSignature(for: manifest)
+
+        let path = expectedPath ?? fileURL.lastPathComponent
+        guard let entry = manifest.payload.files.first(where: { $0.path == path }) else {
+            throw GGUFSignedManifestVerificationError.missingManifestEntry(path: path)
+        }
+
+        let expected = entry.sha256.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard expected.count == 64, expected.allSatisfy({ $0.isHexDigit }) else {
+            throw GGUFSignedManifestVerificationError.malformedSHA256(path: entry.path)
+        }
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            throw GGUFSignedManifestVerificationError.fileMissing(path: fileURL.path)
+        }
+
+        let actual = try sha256HexDigest(of: fileURL)
+        guard actual == expected else {
+            throw GGUFSignedManifestVerificationError.digestMismatch(
+                path: entry.path,
+                expected: expected,
+                actual: actual
+            )
+        }
+    }
+
+    private func requireAcceptedSignature(for manifest: GGUFSignedManifest) throws -> GGUFSignedManifest.Signature {
+        guard let signature = manifest.signature else {
+            throw GGUFSignedManifestVerificationError.unsignedManifest
+        }
+        let canonicalPayload = try Self.canonicalPayloadData(for: manifest.payload)
+        guard try signatureVerifier.verify(signature: signature, canonicalPayload: canonicalPayload) else {
+            throw GGUFSignedManifestVerificationError.signatureRejected(keyID: signature.keyID)
+        }
+        return signature
+    }
+
+    public static func canonicalPayloadData(for payload: GGUFSignedManifest.Payload) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(payload)
+    }
+
+    private func sha256HexDigest(of fileURL: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: fileURL)
+        defer { try? handle.close() }
+
+        var hasher = SHA256()
+        while true {
+            let chunk = try handle.read(upToCount: 65_536) ?? Data()
+            if chunk.isEmpty { break }
+            hasher.update(data: chunk)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Tests/ManifoldInferenceTests/GGUFSignedManifestVerifierTests.swift
+++ b/Tests/ManifoldInferenceTests/GGUFSignedManifestVerifierTests.swift
@@ -1,0 +1,148 @@
+import CryptoKit
+import XCTest
+@testable import ManifoldInference
+
+final class GGUFSignedManifestVerifierTests: XCTestCase {
+    private struct AcceptingSignatureVerifier: GGUFSignedManifestSignatureVerifying {
+        func verify(signature _: GGUFSignedManifest.Signature, canonicalPayload _: Data) throws -> Bool {
+            true
+        }
+    }
+
+    private struct RejectingSignatureVerifier: GGUFSignedManifestSignatureVerifying {
+        func verify(signature _: GGUFSignedManifest.Signature, canonicalPayload _: Data) throws -> Bool {
+            false
+        }
+    }
+
+    private var scratchURLs: [URL] = []
+
+    override func tearDownWithError() throws {
+        for url in scratchURLs.reversed() {
+            try? FileManager.default.removeItem(at: url)
+        }
+        scratchURLs.removeAll()
+        try super.tearDownWithError()
+    }
+
+    func testVerify_acceptsSignedManifestWhenSHA256Matches() throws {
+        let fileURL = try makeScratchFile(name: "model.gguf", contents: Data("GGUF signed payload".utf8))
+        let manifest = makeManifest(path: "model.gguf", sha256: sha256Hex(Data("GGUF signed payload".utf8)))
+
+        XCTAssertNoThrow(
+            try GGUFSignedManifestVerifier(signatureVerifier: AcceptingSignatureVerifier())
+                .verify(fileURL: fileURL, manifest: manifest)
+        )
+    }
+
+    func testVerify_decodesManifestDataAndMatchesExpectedPath() throws {
+        let fileURL = try makeScratchFile(name: "renamed.gguf", contents: Data("GGUF signed payload".utf8))
+        let manifest = makeManifest(path: "weights/model.gguf", sha256: sha256Hex(Data("GGUF signed payload".utf8)))
+        let manifestData = try JSONEncoder().encode(manifest)
+
+        XCTAssertNoThrow(
+            try GGUFSignedManifestVerifier(signatureVerifier: AcceptingSignatureVerifier())
+                .verify(fileURL: fileURL, manifestData: manifestData, expectedPath: "weights/model.gguf")
+        )
+    }
+
+    func testVerify_failsClosedWhenManifestIsUnsigned() throws {
+        let fileURL = try makeScratchFile(name: "model.gguf", contents: Data("GGUF signed payload".utf8))
+        let manifest = GGUFSignedManifest(
+            payload: .init(files: [.init(path: "model.gguf", sha256: sha256Hex(Data("GGUF signed payload".utf8)))]),
+            signature: nil
+        )
+
+        XCTAssertThrowsError(
+            try GGUFSignedManifestVerifier(signatureVerifier: AcceptingSignatureVerifier())
+                .verify(fileURL: fileURL, manifest: manifest)
+        ) { error in
+            XCTAssertEqual(error as? GGUFSignedManifestVerificationError, .unsignedManifest)
+        }
+    }
+
+    func testVerify_failsClosedWhenSignatureVerifierRejects() throws {
+        let fileURL = try makeScratchFile(name: "model.gguf", contents: Data("GGUF signed payload".utf8))
+        let manifest = makeManifest(path: "model.gguf", sha256: sha256Hex(Data("GGUF signed payload".utf8)))
+
+        XCTAssertThrowsError(
+            try GGUFSignedManifestVerifier(signatureVerifier: RejectingSignatureVerifier())
+                .verify(fileURL: fileURL, manifest: manifest)
+        ) { error in
+            XCTAssertEqual(error as? GGUFSignedManifestVerificationError, .signatureRejected(keyID: "test-key"))
+        }
+    }
+
+    func testVerify_rejectsDigestMismatch() throws {
+        let fileURL = try makeScratchFile(name: "model.gguf", contents: Data("tampered".utf8))
+        let expected = sha256Hex(Data("original".utf8))
+        let actual = sha256Hex(Data("tampered".utf8))
+        let manifest = makeManifest(path: "model.gguf", sha256: expected)
+
+        XCTAssertThrowsError(
+            try GGUFSignedManifestVerifier(signatureVerifier: AcceptingSignatureVerifier())
+                .verify(fileURL: fileURL, manifest: manifest)
+        ) { error in
+            XCTAssertEqual(
+                error as? GGUFSignedManifestVerificationError,
+                .digestMismatch(path: "model.gguf", expected: expected, actual: actual)
+            )
+        }
+    }
+
+    func testVerify_rejectsMalformedManifestSHA256() throws {
+        let fileURL = try makeScratchFile(name: "model.gguf", contents: Data("GGUF signed payload".utf8))
+        let manifest = makeManifest(path: "model.gguf", sha256: "not-a-sha")
+
+        XCTAssertThrowsError(
+            try GGUFSignedManifestVerifier(signatureVerifier: AcceptingSignatureVerifier())
+                .verify(fileURL: fileURL, manifest: manifest)
+        ) { error in
+            XCTAssertEqual(error as? GGUFSignedManifestVerificationError, .malformedSHA256(path: "model.gguf"))
+        }
+    }
+
+    func testVerify_rejectsMissingManifestEntry() throws {
+        let fileURL = try makeScratchFile(name: "model.gguf", contents: Data("GGUF signed payload".utf8))
+        let manifest = makeManifest(path: "other.gguf", sha256: sha256Hex(Data("GGUF signed payload".utf8)))
+
+        XCTAssertThrowsError(
+            try GGUFSignedManifestVerifier(signatureVerifier: AcceptingSignatureVerifier())
+                .verify(fileURL: fileURL, manifest: manifest)
+        ) { error in
+            XCTAssertEqual(error as? GGUFSignedManifestVerificationError, .missingManifestEntry(path: "model.gguf"))
+        }
+    }
+
+    func testDefaultSignatureVerifierRejectsUntilTrustPolicyIsInjected() throws {
+        let fileURL = try makeScratchFile(name: "model.gguf", contents: Data("GGUF signed payload".utf8))
+        let manifest = makeManifest(path: "model.gguf", sha256: sha256Hex(Data("GGUF signed payload".utf8)))
+
+        XCTAssertThrowsError(try GGUFSignedManifestVerifier().verify(fileURL: fileURL, manifest: manifest)) { error in
+            XCTAssertEqual(error as? GGUFSignedManifestVerificationError, .signatureRejected(keyID: "test-key"))
+        }
+    }
+
+    private func makeManifest(path: String, sha256: String) -> GGUFSignedManifest {
+        GGUFSignedManifest(
+            payload: .init(files: [.init(path: path, sha256: sha256)]),
+            signature: .init(algorithm: "placeholder-ed25519", keyID: "test-key", value: "signature")
+        )
+    }
+
+    private func makeScratchFile(name: String, contents: Data) throws -> URL {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent("tmp", isDirectory: true)
+            .appendingPathComponent("GGUFSignedManifestVerifierTests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        scratchURLs.append(root)
+        let url = root.appendingPathComponent(name)
+        try contents.write(to: url)
+        return url
+    }
+
+    private func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+}


### PR DESCRIPTION
## Summary
- add an opt-in signed GGUF manifest model and verifier seam
- fail closed for unsigned manifests, rejected signatures, malformed SHA-256 entries, missing entries, and digest mismatches
- add focused ManifoldInference tests for the verifier and signature-policy seam

## Validation
- TMPDIR="/Users/roryford/Repos/ManifoldKit/tmp/test-tmp" scripts/test.sh --filter ManifoldInferenceTests.GGUFSignedManifestVerifierTests --disable-default-traits --skip-update --min-passed 8