### PR TITLE
feat: add persistence search maturation slice

### DIFF
--- a/Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift
@@ -116,22 +116,26 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore {
         guard !trimmed.isEmpty, limit > 0 else { return [] }
 
         // SwiftData #Predicate localizedStandardContains is case- and
-        // diacritic-insensitive and runs in-store, so we don't pull every
-        // message into memory just to filter. A small over-fetch (limit*2)
-        // covers the case where the plain-text `content` cache is stale and
-        // a snippet pass rejects the match.
-        let needle = trimmed
+        // diacritic-insensitive and runs in-store. For multi-term queries we
+        // use the first term as the store predicate, then require every term
+        // in memory so words can match across non-adjacent parts of a message.
+        let terms = Self.messageSearchTerms(from: trimmed)
+        let needle = terms[0]
         var descriptor = FetchDescriptor<ChatMessage>(
             predicate: #Predicate { $0.content.localizedStandardContains(needle) },
             sortBy: [SortDescriptor(\.timestamp, order: .reverse)]
         )
-        descriptor.fetchLimit = limit
+        if terms.count == 1 {
+            descriptor.fetchLimit = limit
+        }
 
         let results = try modelContext.fetch(descriptor)
         var hits: [MessageSearchHit] = []
-        hits.reserveCapacity(results.count)
+        hits.reserveCapacity(min(results.count, limit))
         for message in results {
-            guard let (snippet, range) = makeMessageSearchSnippet(content: message.content, query: trimmed) else {
+            guard terms.allSatisfy({ message.content.localizedStandardContains($0) }),
+                  let snippetTerm = terms.first(where: { message.content.localizedStandardContains($0) }),
+                  let (snippet, range) = makeMessageSearchSnippet(content: message.content, query: snippetTerm) else {
                 continue
             }
             hits.append(MessageSearchHit(
@@ -141,8 +145,13 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore {
                 matchRange: range,
                 timestamp: message.timestamp
             ))
+            if hits.count == limit { break }
         }
         return hits
+    }
+
+    private static func messageSearchTerms(from query: String) -> [String] {
+        query.split(whereSeparator: \.isWhitespace).map(String.init)
     }
 
     // MARK: - Messages

--- a/Sources/ManifoldRuntime/Protocols/MessageStore.swift
+++ b/Sources/ManifoldRuntime/Protocols/MessageStore.swift
@@ -68,7 +68,9 @@ public protocol MessageStore: AnyObject, Sendable {
 
     /// Searches messages whose plain-text content contains `query`.
     ///
-    /// Matching is case-insensitive. Results are sorted by message timestamp
+    /// Matching is case- and diacritic-insensitive. Multi-word queries match
+    /// messages containing every whitespace-delimited term, even when the
+    /// terms are not adjacent. Results are sorted by message timestamp
     /// in descending order (most recent first) and capped at `limit`. Each hit
     /// carries a short snippet centred on the first match to support inline
     /// previews in search UI.
@@ -145,7 +147,7 @@ public protocol MessageStorePostWriteHook: Sendable {
 
 // MARK: - Snippet helpers
 
-/// Builds a short snippet around the first case-insensitive occurrence of
+/// Builds a short snippet around the first case- and diacritic-insensitive occurrence of
 /// `query` in `content`. Used by ``MessageStore`` implementations to
 /// populate ``MessageSearchHit/snippet``.
 ///
@@ -157,8 +159,9 @@ public func makeMessageSearchSnippet(
     query: String,
     contextRadius: Int = 50
 ) -> (snippet: String, matchRange: Range<String.Index>)? {
+    let options: String.CompareOptions = [.caseInsensitive, .diacriticInsensitive]
     guard !query.isEmpty,
-          let matchInContent = content.range(of: query, options: .caseInsensitive) else {
+          let matchInContent = content.range(of: query, options: options) else {
         return nil
     }
 
@@ -177,9 +180,9 @@ public func makeMessageSearchSnippet(
     snippet = prefixEllipsis + snippet + suffixEllipsis
 
     // Re-locate the query inside the snippet — the ellipsis prefix shifts
-    // indices, and re-running the case-insensitive search is cheaper and
-    // simpler than offset arithmetic.
-    guard let matchInSnippet = snippet.range(of: query, options: .caseInsensitive) else {
+    // indices, and re-running the case- and diacritic-insensitive search is
+    // cheaper and simpler than offset arithmetic.
+    guard let matchInSnippet = snippet.range(of: query, options: options) else {
         return (snippet, snippet.startIndex..<snippet.startIndex)
     }
     return (snippet, matchInSnippet)

--- a/Tests/ManifoldPersistenceSwiftDataTests/SwiftDataPersistenceProviderSearchTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/SwiftDataPersistenceProviderSearchTests.swift
@@ -42,6 +42,46 @@ final class SwiftDataPersistenceProviderSearchTests: XCTestCase {
         XCTAssertTrue(hits.allSatisfy { $0.snippet.localizedStandardContains("dragon") })
     }
 
+    func test_searchMessages_multiTermQueryMatchesNonAdjacentTerms() async throws {
+        let session = ChatSessionRecord(title: "Multi Term")
+        try await provider.insertSession(session)
+        try await provider.insertMessage(ChatMessageRecord(
+            role: .user,
+            content: "dragon lore with maps and treasure",
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            sessionID: session.id
+        ))
+        try await provider.insertMessage(ChatMessageRecord(
+            role: .assistant,
+            content: "dragon migration routes",
+            timestamp: Date(timeIntervalSince1970: 2_000),
+            sessionID: session.id
+        ))
+        try await provider.insertMessage(ChatMessageRecord(
+            role: .user,
+            content: "treasure vault inventory",
+            timestamp: Date(timeIntervalSince1970: 3_000),
+            sessionID: session.id
+        ))
+
+        let hits = try await provider.searchMessages(query: "dragon treasure", limit: 100)
+
+        XCTAssertEqual(hits.map(\.snippet).map { $0.replacingOccurrences(of: "…", with: "") },
+                       ["dragon lore with maps and treasure"])
+    }
+
+    func test_searchMessages_diacriticInsensitiveQueryBuildsSnippet() async throws {
+        let session = ChatSessionRecord(title: "Diacritics")
+        try await provider.insertSession(session)
+        try await provider.insertMessage(ChatMessageRecord(role: .user, content: "Meet at the café after lunch", sessionID: session.id))
+
+        let hits = try await provider.searchMessages(query: "cafe", limit: 100)
+
+        XCTAssertEqual(hits.count, 1)
+        let hit = try XCTUnwrap(hits.first)
+        XCTAssertEqual(String(hit.snippet[hit.matchRange]), "café")
+    }
+
     func test_searchMessages_emptyQueryReturnsNoHits() async throws {
         let session = ChatSessionRecord(title: "Empty Query")
         try await provider.insertSession(session)


### PR DESCRIPTION
## Summary\n- Extend SwiftData message search to support whitespace-delimited multi-term queries across non-adjacent text\n- Make search snippets diacritic-insensitive to match localizedStandardContains behavior\n- Add in-memory SwiftData coverage for multi-term and diacritic-insensitive search\n\n## Validation\n- MANIFOLD_TEST_OUTPUT_FILE=.build/test-output-wave5-targeted.txt scripts/test.sh --filter SwiftDataPersistenceProviderSearchTests --disable-default-traits --skip-update --min-passed 1\n- MANIFOLD_TEST_OUTPUT_FILE=.build/test-output-wave5-required.txt scripts/test.sh --filter ManifoldRuntimeTests --filter ManifoldPersistenceSwiftDataTests --disable-default-traits --skip-update --min-passed 1