### PR TITLE
feat: enrich ManifoldServer models response

### DIFF
--- a/Sources/ManifoldServer/ServerHTTPResponses.swift
+++ b/Sources/ManifoldServer/ServerHTTPResponses.swift
@@ -11,6 +11,7 @@ internal struct ModelsListResponse: Codable, Equatable, Sendable {
         internal var status: String?
         internal var backend: String?
         internal var source: String?
+        internal var current: Bool?
 
         internal init(
             id: String,
@@ -19,7 +20,8 @@ internal struct ModelsListResponse: Codable, Equatable, Sendable {
             ownedBy: String = "manifold",
             status: String? = nil,
             backend: String? = nil,
-            source: String? = nil
+            source: String? = nil,
+            current: Bool? = nil
         ) {
             self.id = id
             self.object = object
@@ -28,10 +30,11 @@ internal struct ModelsListResponse: Codable, Equatable, Sendable {
             self.status = status
             self.backend = backend
             self.source = source
+            self.current = current
         }
 
         private enum CodingKeys: String, CodingKey {
-            case id, object, created, status, backend, source
+            case id, object, created, status, backend, source, current
             case ownedBy = "owned_by"
         }
     }

--- a/Sources/ManifoldServer/TraitAwareServerBackendProvider.swift
+++ b/Sources/ManifoldServer/TraitAwareServerBackendProvider.swift
@@ -102,12 +102,15 @@ internal actor TraitAwareServerBackendProvider: ServerBackendProvider {
     }
 
     internal func listModelRecords() async throws -> [ModelsListResponse.Model] {
-        try await listModels().map { id in
-            ModelsListResponse.Model(
+        let currentModelID = loadedModelID ?? modelID(for: ServerBackendRequest())
+        return try await listModels().map { id in
+            let isCurrent = currentModelID == id
+            return ModelsListResponse.Model(
                 id: id,
                 status: loadedModelID == id ? "loaded" : "available",
                 backend: selection.backend.rawValue,
-                source: modelSource
+                source: modelSource,
+                current: isCurrent
             )
         }
     }

--- a/Tests/ManifoldServerTests/ManifoldServerCLITests.swift
+++ b/Tests/ManifoldServerTests/ManifoldServerCLITests.swift
@@ -131,6 +131,21 @@ final class TraitAwareServerBackendProviderTests: XCTestCase {
         let models = try await provider.listModels()
         XCTAssertEqual(models, ["mlx-community/example", "Models/example"])
     }
+
+    func testListModelRecordsMarksConfiguredModelCurrent() async throws {
+        let provider = TraitAwareServerBackendProvider(
+            selection: ServerBackendSelection(backend: .mlx, model: "mlx-community/example", modelPath: "Models/example"),
+            compiledBackends: emptyBuild
+        )
+
+        let records = try await provider.listModelRecords()
+
+        XCTAssertEqual(records.map(\.id), ["mlx-community/example", "Models/example"])
+        XCTAssertEqual(records.map(\.backend), ["mlx", "mlx"])
+        XCTAssertEqual(records.map(\.source), ["local_path", "local_path"])
+        XCTAssertEqual(records.map(\.current), [false, true])
+        XCTAssertEqual(records.map(\.status), ["available", "available"])
+    }
 }
 
 #endif

--- a/Tests/ManifoldServerTests/ManifoldServerSmokeTests.swift
+++ b/Tests/ManifoldServerTests/ManifoldServerSmokeTests.swift
@@ -39,6 +39,7 @@ final class ManifoldServerSmokeTests: XCTestCase {
                 XCTAssertEqual(models.data.first?.object, "model")
                 XCTAssertEqual(models.data.first?.ownedBy, "manifold")
                 XCTAssertEqual(models.data.first?.status, "available")
+                XCTAssertNil(models.data.first?.current)
             }
 
             let body = try requestBody(ChatCompletionRequest(model: "tiny", messages: [.init(role: "user", content: "hi")]))
@@ -46,6 +47,26 @@ final class ManifoldServerSmokeTests: XCTestCase {
                 XCTAssertEqual(response.status, .ok)
                 let completion = try JSONDecoder().decode(ChatCompletionResponse.self, from: Data(buffer: response.body))
                 XCTAssertEqual(completion.content, "hello world")
+            }
+        }
+    }
+
+    func testModelsRouteIncludesCurrentBackendMetadataForTraitAwareProvider() async throws {
+        let provider = TraitAwareServerBackendProvider(
+            selection: ServerBackendSelection(backend: .mlx, model: "mlx-community/example", modelPath: "Models/example"),
+            compiledBackends: CompiledBackends(buildProfile: .offline, traits: [], localModelTypes: [], cloudProviders: [])
+        )
+        let app = ServerApp(backendProvider: provider).makeApplication()
+
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/v1/models", method: .get) { response in
+                XCTAssertEqual(response.status, .ok)
+                let models = try JSONDecoder().decode(ModelsListResponse.self, from: Data(buffer: response.body))
+                XCTAssertEqual(models.data.map(\.id), ["mlx-community/example", "Models/example"])
+                XCTAssertEqual(models.data.map(\.backend), ["mlx", "mlx"])
+                XCTAssertEqual(models.data.map(\.source), ["local_path", "local_path"])
+                XCTAssertEqual(models.data.map(\.current), [false, true])
+                XCTAssertEqual(models.data.map(\.status), ["available", "available"])
             }
         }
     }

--- a/Tests/ManifoldServerTests/OpenAIJSONGoldenTests.swift
+++ b/Tests/ManifoldServerTests/OpenAIJSONGoldenTests.swift
@@ -182,7 +182,8 @@ final class OpenAIJSONGoldenTests: XCTestCase {
                 ownedBy: "manifold",
                 status: "loaded",
                 backend: "foundation",
-                source: "built_in"
+                source: "built_in",
+                current: true
             )
         ])
 
@@ -196,7 +197,9 @@ final class OpenAIJSONGoldenTests: XCTestCase {
         XCTAssertEqual(decoded.data.first?.ownedBy, "manifold")
         XCTAssertEqual(decoded.data.first?.status, "loaded")
         XCTAssertEqual(decoded.data.first?.backend, "foundation")
+        XCTAssertEqual(decoded.data.first?.current, true)
         XCTAssertTrue(encoded.contains("\"owned_by\":\"manifold\""))
+        XCTAssertTrue(encoded.contains("\"current\":true"))
     }
 }
 

--- a/Tests/ManifoldServerTests/ServerBackendProviderTests.swift
+++ b/Tests/ManifoldServerTests/ServerBackendProviderTests.swift
@@ -56,7 +56,8 @@ final class ServerBackendProviderTests: XCTestCase {
                 id: "llama3",
                 status: "available",
                 backend: "ollama",
-                source: "remote_endpoint"
+                source: "remote_endpoint",
+                current: true
             )
         ])
     }
@@ -74,7 +75,8 @@ final class ServerBackendProviderTests: XCTestCase {
                 id: "llama3.2",
                 status: "available",
                 backend: "ollama",
-                source: "remote_endpoint"
+                source: "remote_endpoint",
+                current: true
             )
         ])
     }


### PR DESCRIPTION
## Summary
- add a `current` metadata field to ManifoldServer `/v1/models` records
- mark the configured or loaded TraitAware provider model as current while preserving OpenAI-compatible fields
- cover provider records, route JSON, and golden encoding

## Validation
- scripts/test.sh --filter ManifoldServerTests --traits Server --disable-default-traits --skip-update --min-passed 1 (82 passed)