### PR TITLE
feat: add chat message status slice

### DIFF
--- a/Sources/ManifoldInference/Models/ConversationRecords.swift
+++ b/Sources/ManifoldInference/Models/ConversationRecords.swift
@@ -52,6 +52,13 @@ public struct ChatSessionRecord: Identifiable, Hashable, Sendable {
     }
 }
 
+/// Delivery state used by chat UI affordances for user-authored messages.
+public enum MessageStatus: String, Codable, Hashable, Sendable {
+    case sending
+    case sent
+    case failed
+}
+
 /// Plain-data snapshot of a chat message for use across persistence boundaries.
 public struct ChatMessageRecord: Identifiable, Hashable, Sendable {
     public var id: UUID
@@ -61,6 +68,9 @@ public struct ChatMessageRecord: Identifiable, Hashable, Sendable {
     public var sessionID: UUID
     public var promptTokens: Int?
     public var completionTokens: Int?
+    /// Transient UI delivery state. Persistence intentionally omits this value
+    /// so adding message status does not require a SwiftData schema migration.
+    public var status: MessageStatus?
     /// Provenance of any RAG passages injected into the prompt for this turn.
     ///
     /// Populated by ``ConversationRuntime`` from
@@ -98,6 +108,7 @@ public struct ChatMessageRecord: Identifiable, Hashable, Sendable {
         sessionID: UUID,
         promptTokens: Int? = nil,
         completionTokens: Int? = nil,
+        status: MessageStatus? = nil,
         citations: [Citation]? = nil
     ) {
         self.id = id
@@ -107,6 +118,7 @@ public struct ChatMessageRecord: Identifiable, Hashable, Sendable {
         self.sessionID = sessionID
         self.promptTokens = promptTokens
         self.completionTokens = completionTokens
+        self.status = status
         self.citations = citations
     }
 
@@ -119,6 +131,7 @@ public struct ChatMessageRecord: Identifiable, Hashable, Sendable {
         sessionID: UUID,
         promptTokens: Int? = nil,
         completionTokens: Int? = nil,
+        status: MessageStatus? = nil,
         citations: [Citation]? = nil
     ) {
         self.id = id
@@ -128,7 +141,7 @@ public struct ChatMessageRecord: Identifiable, Hashable, Sendable {
         self.sessionID = sessionID
         self.promptTokens = promptTokens
         self.completionTokens = completionTokens
+        self.status = status
         self.citations = citations
     }
 }
-

--- a/Sources/ManifoldUI/ViewModels/ChatViewModel+RuntimeAdapter.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel+RuntimeAdapter.swift
@@ -31,6 +31,7 @@ extension ChatViewModel {
         // MARK: Message lifecycle
 
         case .messageInserted(let record):
+            var record = record
             // The runtime persists user and assistant messages and re-emits
             // them via `.messageInserted`. Two cases:
             //
@@ -51,10 +52,14 @@ extension ChatViewModel {
             // gate, would leak the cancelled session's content into the
             // newly-active transcript.
             guard record.sessionID == activeSessionID else { break }
+            if record.role == .user {
+                record.status = .sent
+            }
             if let idx = messages.firstIndex(where: { $0.id == record.id }) {
                 messages[idx].timestamp = record.timestamp
                 messages[idx].promptTokens = record.promptTokens
                 messages[idx].completionTokens = record.completionTokens
+                messages[idx].status = record.status
             } else {
                 messages.append(record)
             }
@@ -175,6 +180,7 @@ extension ChatViewModel {
             if case .cancelled = error {
                 lastTurnState = .idle
             } else {
+                markMostRecentUserMessageFailed()
                 lastTurnState = .failed(error)
             }
             activeConversationStreamHandle = nil
@@ -312,5 +318,14 @@ extension ChatViewModel {
         // update the text. Signatures arrive separately.
         let signature = msg.contentParts[idx].thinkingSignature
         msg.contentParts[idx] = .thinking(partial, signature: signature)
+    }
+}
+
+private extension ChatViewModel {
+    func markMostRecentUserMessageFailed() {
+        guard let idx = messages.lastIndex(where: { $0.role == .user && $0.sessionID == activeSessionID }) else {
+            return
+        }
+        messages[idx].status = .failed
     }
 }

--- a/Sources/ManifoldUI/Views/Chat/MessageBubbleView.swift
+++ b/Sources/ManifoldUI/Views/Chat/MessageBubbleView.swift
@@ -75,8 +75,17 @@ public struct MessageBubbleView: View {
         VStack(alignment: .trailing, spacing: 4) {
             MessagePartsView(parts: message.contentParts, role: .user)
 
-            timestampLabel
-                .foregroundStyle(.white.opacity(0.7))
+            HStack(spacing: 6) {
+                if let statusText = Self.statusText(for: message) {
+                    Text(statusText)
+                        .font(.caption2)
+                        .foregroundStyle(.white.opacity(0.75))
+                        .accessibilityLabel(Self.statusAccessibilityLabel(for: message) ?? statusText)
+                }
+
+                timestampLabel
+                    .foregroundStyle(.white.opacity(0.7))
+            }
         }
         .padding(12)
         .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 16))
@@ -229,6 +238,24 @@ public struct MessageBubbleView: View {
         if hasThinking { suffixes.append("Includes reasoning.") }
         if hasAudio { suffixes.append("Includes audio.") }
         return suffixes.isEmpty ? base : "\(base). \(suffixes.joined(separator: " "))"
+    }
+
+    public static func statusText(for message: ChatMessageRecord) -> String? {
+        guard message.role == .user, let status = message.status else { return nil }
+        return switch status {
+        case .sending: "Sending…"
+        case .sent: "Sent"
+        case .failed: "Failed"
+        }
+    }
+
+    public static func statusAccessibilityLabel(for message: ChatMessageRecord) -> String? {
+        guard message.role == .user, let status = message.status else { return nil }
+        return switch status {
+        case .sending: "Message sending"
+        case .sent: "Message sent"
+        case .failed: "Message failed to send"
+        }
     }
 }
 

--- a/Tests/ManifoldPersistenceSwiftDataTests/SwiftDataPersistenceProviderTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/SwiftDataPersistenceProviderTests.swift
@@ -154,6 +154,23 @@ final class SwiftDataPersistenceProviderTests: XCTestCase {
         XCTAssertEqual(fetched[0].completionTokens, 7)
     }
 
+    func test_insertMessage_doesNotPersistTransientStatus() async throws {
+        let session = ChatSessionRecord(title: "Status Test")
+        try await provider.insertSession(session)
+        let record = ChatMessageRecord(
+            role: .user,
+            content: "hello",
+            sessionID: session.id,
+            status: .sent
+        )
+
+        try await provider.insertMessage(record)
+
+        let fetched = try await provider.fetchMessages(for: session.id)
+        XCTAssertEqual(fetched.count, 1)
+        XCTAssertNil(fetched[0].status, "Message status is UI-only and must not force a SwiftData schema migration")
+    }
+
     func test_fetchMessages_ordersByTimestampAscending() async throws {
         let session = ChatSessionRecord(title: "Order Test")
         try await provider.insertSession(session)

--- a/Tests/ManifoldUITests/ChatViewModelRuntimeAdapterTests.swift
+++ b/Tests/ManifoldUITests/ChatViewModelRuntimeAdapterTests.swift
@@ -23,6 +23,10 @@ import ManifoldTestSupport
 @MainActor
 final class ChatViewModelRuntimeAdapterTests: XCTestCase {
 
+    private struct MessageStatusTestError: LocalizedError {
+        var errorDescription: String? { "status test failure" }
+    }
+
     // MARK: - In-memory stores (copied shape from ConversationRuntimeTests)
 
     /// Minimal in-memory MessageStore used by the runtime in these tests.
@@ -156,7 +160,36 @@ final class ChatViewModelRuntimeAdapterTests: XCTestCase {
         let stored = try await store.fetchMessages(for: sessionID)
         XCTAssertEqual(stored.count, 2, "Runtime store should hold user + assistant messages")
         XCTAssertTrue(stored.contains(where: { $0.role == .assistant && $0.content == "Hello from runtime" }),
-                      "Persisted assistant message should contain streamed tokens")
+                       "Persisted assistant message should contain streamed tokens")
+    }
+
+    func test_runtimeAdapter_marksInsertedUserMessageSent() async throws {
+        let mock = MockInferenceBackend()
+        let (vm, _) = try makeVMWithRuntime(mock: mock)
+        guard let sessionID = vm.activeSessionID else {
+            XCTFail("activeSession must be set")
+            return
+        }
+        let record = ChatMessageRecord(role: .user, content: "Hello", sessionID: sessionID)
+
+        await vm.handle(runtimeEvent: .messageInserted(record))
+
+        XCTAssertEqual(vm.messages.first?.status, .sent)
+    }
+
+    func test_runtimeAdapter_marksMostRecentUserMessageFailedOnTurnError() async throws {
+        let mock = MockInferenceBackend()
+        let (vm, _) = try makeVMWithRuntime(mock: mock)
+        guard let sessionID = vm.activeSessionID else {
+            XCTFail("activeSession must be set")
+            return
+        }
+        let record = ChatMessageRecord(role: .user, content: "Hello", sessionID: sessionID)
+        await vm.handle(runtimeEvent: .messageInserted(record))
+
+        await vm.handle(runtimeEvent: .errorRaised(.inference(MessageStatusTestError())))
+
+        XCTAssertEqual(vm.messages.first?.status, .failed)
     }
 
     // MARK: - Test 2: stopGeneration cancels the in-flight handle
@@ -260,4 +293,3 @@ final class ChatViewModelRuntimeAdapterTests: XCTestCase {
         XCTAssertNil(weakVM, "VM must be deallocated once external strong refs drop — drain task must not retain self across the for-await suspension")
     }
 }
-

--- a/Tests/ManifoldUITests/MessageBubbleViewLogicTests.swift
+++ b/Tests/ManifoldUITests/MessageBubbleViewLogicTests.swift
@@ -173,6 +173,34 @@ final class MessageBubbleViewLogicTests: XCTestCase {
         XCTAssertNil(msg.promptTokens, "Prompt tokens should be nil by default")
     }
 
+    // MARK: - Message status
+
+    func test_messageRecord_statusDefaultsToNil() {
+        let msg = ChatMessageRecord(role: .user, content: "Hello", sessionID: sessionID)
+
+        XCTAssertNil(msg.status, "Status is opt-in so existing records keep their current rendering")
+    }
+
+    func test_messageBubbleStatusText_rendersUserDeliveryStates() {
+        let sent = ChatMessageRecord(role: .user, content: "Hello", sessionID: sessionID, status: .sent)
+        let failed = ChatMessageRecord(role: .user, content: "Hello", sessionID: sessionID, status: .failed)
+        let sending = ChatMessageRecord(role: .user, content: "Hello", sessionID: sessionID, status: .sending)
+
+        XCTAssertEqual(MessageBubbleView.statusText(for: sent), "Sent")
+        XCTAssertEqual(MessageBubbleView.statusAccessibilityLabel(for: sent), "Message sent")
+        XCTAssertEqual(MessageBubbleView.statusText(for: failed), "Failed")
+        XCTAssertEqual(MessageBubbleView.statusAccessibilityLabel(for: failed), "Message failed to send")
+        XCTAssertEqual(MessageBubbleView.statusText(for: sending), "Sending…")
+        XCTAssertEqual(MessageBubbleView.statusAccessibilityLabel(for: sending), "Message sending")
+    }
+
+    func test_messageBubbleStatusText_ignoresAssistantStatus() {
+        let assistant = ChatMessageRecord(role: .assistant, content: "Reply", sessionID: sessionID, status: .sent)
+
+        XCTAssertNil(MessageBubbleView.statusText(for: assistant))
+        XCTAssertNil(MessageBubbleView.statusAccessibilityLabel(for: assistant))
+    }
+
     // MARK: - Role enumeration coverage
 
     func test_allRoles_areDistinct() {


### PR DESCRIPTION
## Summary
- Add transient MessageStatus to ChatMessageRecord for user-message delivery/error UI.
- Render sent/failed/sending status text on user bubbles and mark runtime-inserted user messages sent.
- Mark the latest user message failed when a turn errors without adding reply/reaction schema changes.

Fixes #1015

## Validation
- scripts/test.sh --filter MessageBubbleViewLogicTests --filter ChatViewModelRuntimeAdapterTests --filter SwiftDataPersistenceProviderTests --disable-default-traits --skip-update --min-passed 1
- scripts/test.sh --filter ManifoldUITests --filter ManifoldPersistenceSwiftDataTests --disable-default-traits --skip-update --min-passed 1