### PR TITLE
fix: add FoundationBackend availability provider seam (#524)

### DIFF
--- a/Sources/ManifoldFoundation/FoundationBackend.swift
+++ b/Sources/ManifoldFoundation/FoundationBackend.swift
@@ -165,6 +165,11 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
     /// the same as a `nil` session and creates a fresh `LanguageModelSession`.
     private var _sessionIsClean = true
 
+    /// Determines `SystemLanguageModel` availability. Injected at init so unit
+    /// tests can drive the unavailable branch without a real Apple Intelligence
+    /// entitlement. Production code always uses `SystemAvailabilityProvider.shared`.
+    private let availabilityProvider: any FoundationModelAvailabilityProvider
+
     private func withStateLock<T>(_ body: () throws -> T) rethrows -> T {
         stateLock.lock()
         defer { stateLock.unlock() }
@@ -173,7 +178,16 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
 
     // MARK: - Init
 
-    public init() {}
+    public init() {
+        self.availabilityProvider = SystemAvailabilityProvider.shared
+    }
+
+    /// Designated init for testing — allows injecting a stub availability provider
+    /// so the unavailable branch in `loadModel` can be exercised without a real
+    /// Apple Intelligence entitlement.
+    init(availabilityProvider: any FoundationModelAvailabilityProvider) {
+        self.availabilityProvider = availabilityProvider
+    }
 
     // MARK: - Test-only accessors
 
@@ -229,6 +243,13 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
         SystemLanguageModel.default.availability == .available
     }
 
+    /// Whether the system language model is available according to this backend's
+    /// injected availability provider. Equals `FoundationBackend.isAvailable` in
+    /// production; can differ in tests that inject a stub provider.
+    var isAvailableViaProvider: Bool {
+        availabilityProvider.availability == .available
+    }
+
     /// Probes the model with a minimal request to confirm it can serve inference.
     ///
     /// `isAvailable` can return `true` while the model isn't fully downloaded or
@@ -254,7 +275,7 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
         // Plan is informational for Foundation — the system owns all memory.
         unloadModel()
 
-        guard SystemLanguageModel.default.availability == .available else {
+        guard availabilityProvider.availability == .available else {
             throw InferenceError.inferenceFailure(
                 "Apple Intelligence model is not available on this device"
             )

--- a/Sources/ManifoldFoundation/Internal/FoundationModelAvailabilityProvider.swift
+++ b/Sources/ManifoldFoundation/Internal/FoundationModelAvailabilityProvider.swift
@@ -1,0 +1,24 @@
+#if canImport(FoundationModels)
+import FoundationModels
+
+/// Abstracts `SystemLanguageModel.default.availability` so unit tests can inject
+/// a stubbed answer without requiring a real Apple Intelligence entitlement.
+///
+/// The production implementation (`SystemAvailabilityProvider`) forwards directly
+/// to `SystemLanguageModel.default.availability`. Tests inject
+/// `StubAvailabilityProvider` to drive the unavailable branch in `loadModel`.
+@available(iOS 26, macOS 26, *)
+protocol FoundationModelAvailabilityProvider: Sendable {
+    var availability: SystemLanguageModel.Availability { get }
+}
+
+/// Production implementation — forwards to the real system model.
+@available(iOS 26, macOS 26, *)
+struct SystemAvailabilityProvider: FoundationModelAvailabilityProvider {
+    static let shared = SystemAvailabilityProvider()
+    var availability: SystemLanguageModel.Availability {
+        SystemLanguageModel.default.availability
+    }
+}
+
+#endif

--- a/Tests/ManifoldBackendsTests/FoundationBackendUnitTests.swift
+++ b/Tests/ManifoldBackendsTests/FoundationBackendUnitTests.swift
@@ -1,11 +1,23 @@
 #if canImport(FoundationModels)
 import XCTest
+import FoundationModels
 import ManifoldRuntime
 import ManifoldPersistenceSwiftData
 import ManifoldInference
 @testable import ManifoldTestSupport
 @testable import ManifoldBackends
 @testable import ManifoldFoundation
+
+// MARK: - Test doubles
+
+/// Stub availability provider that always reports the configured availability.
+/// Injected into `FoundationBackend` to drive unavailable / available branches
+/// in unit tests without requiring a real Apple Intelligence entitlement.
+@available(iOS 26, macOS 26, *)
+private struct StubAvailabilityProvider: FoundationModelAvailabilityProvider {
+    let stubbedAvailability: SystemLanguageModel.Availability
+    var availability: SystemLanguageModel.Availability { stubbedAvailability }
+}
 
 /// Isolated unit tests for `FoundationBackend` state management and guard paths.
 ///
@@ -552,36 +564,35 @@ final class FoundationBackendUnitTests: XCTestCase {
 
     // MARK: - Availability variants (#524)
 
-    /// Documents the current gap: `FoundationBackend.loadModel` collapses every
-    /// non-`.available` `SystemLanguageModel.Availability` case into a single
-    /// error message. There is no dependency-injection hook to stub availability,
-    /// so per-reason assertions (`.deviceNotEligible`, `.appleIntelligenceNotEnabled`,
-    /// `.modelNotReady`, …) can't be driven from a unit test today.
+    /// Verifies that `loadModel` throws `InferenceError.inferenceFailure` when
+    /// the injected availability provider reports anything other than `.available`.
     ///
-    /// The weak contract we CAN pin: on a device where Apple Intelligence is not
-    /// available (simulator / CI), `loadModel` throws, and the error is an
-    /// `InferenceError.inferenceFailure` whose message mentions Apple Intelligence.
-    /// Any future refactor that swallows the error, changes the type, or returns
-    /// success on a non-available device trips this test.
+    /// Uses `StubAvailabilityProvider` to force the unavailable branch, so this
+    /// test runs on every machine — including those where Apple Intelligence IS
+    /// available — without relying on the real system state.
     ///
-    /// Follow-up: #524 tracks adding an `AvailabilityProvider` injection hook so
-    /// the per-reason messages can be asserted.
+    /// Sabotage check: remove (or negate) the `guard availabilityProvider.availability == .available`
+    /// check in `FoundationBackend.loadModel`. The `XCTFail("loadModel must throw…")` line
+    /// will fire because `loadModel` will proceed to the probe and (on a machine with
+    /// real Apple Intelligence) succeed, returning without throwing. Remove the sabotage
+    /// before committing.
     func test_loadModel_whenUnavailable_throwsInferenceFailure() async throws {
-        // Only meaningful when the real system says "unavailable" — otherwise
-        // we'd need the injection hook that #524 exists to track.
-        try XCTSkipIf(
-            FoundationBackend.isAvailable,
-            "Apple Intelligence IS available on this device — cannot exercise the unavailable branch without the availability-provider hook tracked in #524"
+        // Build a backend that is wired to report "unavailable" regardless of the
+        // real system state. The stub covers every non-.available reason without
+        // needing to enumerate them individually.
+        let stub = StubAvailabilityProvider(
+            stubbedAvailability: .unavailable(.appleIntelligenceNotEnabled)
         )
+        let unavailableBackend = FoundationBackend(availabilityProvider: stub)
 
         let url = URL(fileURLWithPath: "/dev/null")
         do {
-            try await backend.loadModel(from: url, plan: .testStub(effectiveContextSize: 4096))
+            try await unavailableBackend.loadModel(from: url, plan: .testStub(effectiveContextSize: 4096))
             XCTFail("loadModel must throw when SystemLanguageModel availability is not .available")
         } catch let InferenceError.inferenceFailure(msg) {
-            // Current behaviour: the probe path and the pre-probe availability
-            // check both throw inferenceFailure. Either message is acceptable
-            // for this contract — both reference Apple Intelligence.
+            // The availability guard fires before the probe, so the message should
+            // always reference Apple Intelligence regardless of which unavailable
+            // reason the stub returns.
             XCTAssertTrue(
                 msg.localizedCaseInsensitiveContains("Apple Intelligence"),
                 "Error message should mention Apple Intelligence, got: \(msg)"


### PR DESCRIPTION
## Summary

- Adds `FoundationModelAvailabilityProvider` protocol (internal to `ManifoldFoundation`) so unit tests can stub `SystemLanguageModel.default.availability` without a real Apple Intelligence entitlement.
- `FoundationBackend` gains a package-internal `init(availabilityProvider:)` alongside the existing `public init()`. The public init passes `SystemAvailabilityProvider.shared`; no call sites change.
- `FoundationBackend.loadModel` now reads from the injected provider instead of calling `SystemLanguageModel.default.availability` directly.
- `test_loadModel_whenUnavailable_throwsInferenceFailure` removes its `XCTSkipIf(FoundationBackend.isAvailable, …)` guard and instead creates a backend wired to `.unavailable(.appleIntelligenceNotEnabled)` via `StubAvailabilityProvider`. The test now runs and passes on every machine, including machines where Apple Intelligence IS available.

## Test plan

- [x] `scripts/test.sh --filter ManifoldBackendsTests --disable-default-traits --skip-update` — 177 passed, 0 skipped, 0 failed. `test_loadModel_whenUnavailable_throwsInferenceFailure` passed in 0.273 s.
- [x] `scripts/test.sh --filter ManifoldInferenceTests --disable-default-traits --skip-update` — 1421 passed, 5 skipped (pre-existing hardware-gated skips), 0 failed.
- [x] `swift build --build-tests --disable-default-traits` — Build complete.

Closes #524.

🤖 Generated with [Claude Code](https://claude.com/claude-code)