### PR TITLE
ci: add iOS simulator lane for file protection tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
       - "scripts/ci-normalize-swiftpm-debug-cache.sh"
       - "scripts/cold-start*.sh"
       - "scripts/check-foundation-only-bundle.sh"
+      - "scripts/test-ios-simulator.sh"
   pull_request:
     branches: [main]
     paths:
@@ -27,6 +28,7 @@ on:
       - "scripts/ci-normalize-swiftpm-debug-cache.sh"
       - "scripts/cold-start*.sh"
       - "scripts/check-foundation-only-bundle.sh"
+      - "scripts/test-ios-simulator.sh"
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
@@ -644,3 +646,80 @@ jobs:
       - name: Run FoundationOnly bundle audit
         timeout-minutes: 6
         run: scripts/check-foundation-only-bundle.sh
+
+  # iOS Simulator lane — runs ModelContainerFileProtectionTests on a real iOS
+  # Simulator destination so the four tests guarded by `#if os(iOS)` actually
+  # execute.  NSFileProtectionComplete / NSFileProtectionCompleteUntilFirst-
+  # UserAuthentication are iOS kernel features; the standard macOS `swift test`
+  # lane skips those tests entirely.  Scoped to only the
+  # ManifoldPersistenceSwiftDataTests/ModelContainerFileProtectionTests suite to
+  # keep runtime short.  See scripts/test-ios-simulator.sh for the full rationale.
+  ci-ios-file-protection:
+    runs-on: macos-15  # match the `test` job runner
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Detect persistence-relevant changes
+        id: persistence-changed
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            persistence:
+              - 'Sources/ManifoldPersistenceSwiftData/**'
+              - 'Tests/ManifoldPersistenceSwiftDataTests/ModelContainerFileProtectionTests.swift'
+              - '.swiftpm/xcode/xcshareddata/xcschemes/ManifoldPersistenceSwiftDataTests.xcscheme'
+              - 'Package.swift'
+              - 'Package.resolved'
+              - '.github/workflows/ci.yml'
+              - 'scripts/test-ios-simulator.sh'
+
+      - name: Select Xcode
+        if: steps.persistence-changed.outputs.persistence == 'true'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.3"
+
+      - name: Cache SwiftPM build
+        if: steps.persistence-changed.outputs.persistence == 'true'
+        uses: actions/cache@v5
+        with:
+          path: |
+            .build/artifacts
+            .build/checkouts
+            .build/repositories
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
+            ${{ runner.os }}-${{ runner.arch }}-spm-
+
+      - name: Test — ModelContainerFileProtectionTests (iOS Simulator)
+        id: test-ios-file-protection
+        if: steps.persistence-changed.outputs.persistence == 'true'
+        timeout-minutes: 15
+        run: scripts/test-ios-simulator.sh --ci
+
+      - name: Stage test diagnostics
+        if: failure() && steps.persistence-changed.outputs.persistence == 'true'
+        run: |
+          mkdir -p test-diagnostics
+          {
+            echo "run-id=${{ github.run_id }}"
+            echo "run-attempt=${{ github.run_attempt }}"
+            echo "job=ci-ios-file-protection"
+            echo "test-ios-file-protection-failed=${{ steps.test-ios-file-protection.outcome == 'failure' }}"
+          } > test-diagnostics/failed-steps.txt
+          find "${HOME}/Library/Developer/Xcode/DerivedData" -type d -name "*.xcresult" -maxdepth 6 2>/dev/null \
+            | while read -r r; do cp -R "$r" test-diagnostics/ || true; done
+
+      - name: Upload test diagnostics on failure
+        if: failure() && steps.persistence-changed.outputs.persistence == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: xcresult-ios-file-protection-${{ github.run_attempt }}
+          if-no-files-found: ignore
+          retention-days: 7
+          path: test-diagnostics/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,19 @@
 .build/
 .swiftpm/
+# Un-ignore only the shared xcschemes directory so platform-specific
+# test lanes (e.g. iOS Simulator file-protection tests) can be tracked.
+# Each intermediate component must be explicitly un-ignored for git to
+# descend into the otherwise-ignored .swiftpm/ tree.  Files Xcode may
+# auto-generate inside .swiftpm/xcode/ (pbxproj, xcuserstate, etc.) stay
+# ignored via the wildcard rules below.
+!.swiftpm/
+!.swiftpm/xcode/
+!.swiftpm/xcode/xcshareddata/
+!.swiftpm/xcode/xcshareddata/xcschemes/
+!.swiftpm/xcode/xcshareddata/xcschemes/*.xcscheme
+.swiftpm/xcode/*.pbxproj
+.swiftpm/xcode/*.pbxproj.bak
+.swiftpm/xcode/xcuserdata/
 DerivedData/
 *.xcodeproj/project.xcworkspace/
 *.xcodeproj/xcuserdata/

--- a/.swiftpm/xcode/xcshareddata/xcschemes/ManifoldPersistenceSwiftDataTests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ManifoldPersistenceSwiftDataTests.xcscheme
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Minimal scheme for running ManifoldPersistenceSwiftDataTests (and nothing
+     else) against an iOS Simulator destination.  The full ManifoldKit-Package
+     scheme is not suitable because ManifoldFuzz uses Process, which doesn't
+     exist on iOS.  This scheme deliberately scopes the build to only the
+     persistence library and its test target so the iOS SDK compilation
+     succeeds. -->
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldPersistenceSwiftData"
+               BuildableName = "ManifoldPersistenceSwiftData"
+               BlueprintName = "ManifoldPersistenceSwiftData"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldPersistenceSwiftDataTests"
+               BuildableName = "ManifoldPersistenceSwiftDataTests"
+               BlueprintName = "ManifoldPersistenceSwiftDataTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldPersistenceSwiftDataTests"
+               BuildableName = "ManifoldPersistenceSwiftDataTests"
+               BlueprintName = "ManifoldPersistenceSwiftDataTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ When Apple ships a new major OS each September, bump both minimums and remove `#
 | `scripts/clean-build.sh` | Full `.build` wipe + `swift package resolve`. Use when builds fail with "XCFramework Info.plist not found" or other `workspace-state.json` desync errors after changing the trait set. |
 | `scripts/fuzz.sh` | Runs the ManifoldFuzz harness (default: 5 min against Ollama). |
 | `scripts/test-mlx-integration.sh` | Runs `ManifoldMLXIntegrationTests` with discovery env vars patched into `.xctestrun`. Use instead of bare `xcodebuild test`. See #986. |
+| `scripts/test-ios-simulator.sh` | Runs `ModelContainerFileProtectionTests` on an iOS Simulator via xcodebuild. Required because `NSFileProtection*` is an iOS-only kernel feature skipped by the macOS `swift test` lane. |
 
 **SwiftPM local-package consumers need explicit `name:`.** When adding `.package(path: ...)` references (worktrees, cold-start gates, scratch consumers), pass `name: "ManifoldKit"` explicitly — `.package(path:)` derives identity from the last path component, which breaks under non-default checkout paths.
 

--- a/Tests/ManifoldPersistenceSwiftDataTests/ModelContainerFileProtectionTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/ModelContainerFileProtectionTests.swift
@@ -40,13 +40,47 @@ final class ModelContainerFileProtectionTests: XCTestCase {
         return directory.appendingPathComponent("Manifold.sqlite")
     }
 
-    /// Reads the Data Protection class from `url` via `FileManager` attributes.
-    /// Returns `nil` if the key is unset (expected on macOS) or the file is
-    /// missing. We read via `attributesOfItem(atPath:)` rather than
-    /// `URLResourceValues` because the latter has known Swift type-checker
-    /// issues around `fileProtection` in some SDK/compiler combinations.
+    /// Reads the Data Protection class from `url`.
+    ///
+    /// Returns `nil` if no protection class is set (expected on macOS) or the
+    /// file is missing.
+    ///
+    /// ## Simulator / real-device differences
+    ///
+    /// `FileManager.attributesOfItem` does not populate `.protectionKey` on the
+    /// iOS Simulator — `setAttributes` accepts the call without error but the
+    /// stat metadata the simulator exposes never reflects it.
+    ///
+    /// `URLResourceValues.fileProtection` works on both the simulator and real
+    /// hardware and is therefore used as the primary read path.  However, its
+    /// raw-value namespace uses the `NSURLFileProtection*` prefix while
+    /// `FileProtectionType` uses `NSFileProtection*`, so a conversion is
+    /// required.  The two namespaces map 1-to-1 by replacing the `NSURL` prefix
+    /// with `NSFile`.
+    ///
+    /// On the simulator all four protection classes are reported identically as
+    /// `.completeUntilFirstUserAuthentication` because the simulator sandbox
+    /// does not enforce individual tiers.  Tests that rely on reading back a
+    /// specific non-default class must be skipped on the simulator — see
+    /// `test_makeContainer_honoursCustomProtectionClass`.
     private func readFileProtection(at url: URL) -> FileProtectionType? {
         guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+
+        // Primary: URLResourceValues works on both real devices and simulators.
+        // The returned type uses the `NSURLFileProtection*` raw-value prefix;
+        // convert to `FileProtectionType` by swapping in the `NSFileProtection*`
+        // prefix.
+        if let rv = try? url.resourceValues(forKeys: [.fileProtectionKey]),
+           let fp = rv.fileProtection {
+            let rawValue = fp.rawValue.replacingOccurrences(
+                of: "NSURLFileProtection",
+                with: "NSFileProtection"
+            )
+            return FileProtectionType(rawValue: rawValue)
+        }
+
+        // Fallback: attributesOfItem works on real iOS devices but the
+        // simulator never populates .protectionKey here.
         guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path) else {
             return nil
         }
@@ -81,6 +115,15 @@ final class ModelContainerFileProtectionTests: XCTestCase {
         #if !(os(iOS) || os(tvOS) || os(watchOS)) || targetEnvironment(macCatalyst)
         try XCTSkipIf(true, "File protection only applies on iOS/tvOS/watchOS")
         #else
+        // The iOS Simulator sandbox does not distinguish individual protection
+        // classes — setAttributes succeeds but every class reads back as the
+        // simulator default (.completeUntilFirstUserAuthentication).  This
+        // assertion requires the real Secure Enclave to be meaningful.
+        try XCTSkipIf(
+            ProcessInfo.processInfo.environment["SIMULATOR_DEVICE_NAME"] != nil,
+            "Simulator reports all protection classes as the default — run on physical hardware"
+        )
+
         ManifoldConfiguration.shared.fileProtectionClass = .complete
 
         let storeURL = try makeTempStoreURL()

--- a/scripts/test-ios-simulator.sh
+++ b/scripts/test-ios-simulator.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# scripts/test-ios-simulator.sh — Run ModelContainerFileProtectionTests on an
+# iOS simulator via xcodebuild.
+#
+# Why this exists
+# ---------------
+# NSFileProtectionComplete / NSFileProtectionCompleteUntilFirstUserAuthentication
+# are iOS kernel features.  The four tests in ModelContainerFileProtectionTests
+# are guarded by a compile-time `#if os(iOS)` (and skip on macOS/Catalyst), so
+# the normal `swift test` CI lane — which targets macOS — never exercises them.
+# xcodebuild against an iOS Simulator destination compiles the bundle as iOS,
+# making the guard false and the tests actually run.
+#
+# Simulator selection
+# -------------------
+# CI uses `name=iPhone 16` (available on every Xcode 26.x macOS-15 runner).
+# Locally the script picks the first booted iPhone simulator, falling back to
+# any available iPhone simulator.  Pass --destination to override both.
+#
+# Usage
+# -----
+#   scripts/test-ios-simulator.sh                    # auto-pick simulator
+#   scripts/test-ios-simulator.sh --destination 'platform=iOS Simulator,name=iPhone 16'
+#   scripts/test-ios-simulator.sh --ci               # force CI name= form
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+SCHEME="ManifoldPersistenceSwiftDataTests"
+TEST_TARGET="ManifoldPersistenceSwiftDataTests"
+TEST_SUITE="ModelContainerFileProtectionTests"
+DERIVED_DATA="$REPO_ROOT/.build/ios-simulator-file-protection-derived"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  scripts/test-ios-simulator.sh [options]
+
+Options:
+  --destination '<xcodebuild destination string>'
+      Override the simulator destination. Default: auto-pick from simctl.
+  --ci
+      Use a name= destination suitable for GitHub Actions runners
+      (platform=iOS Simulator,name=iPhone 16).
+  -h, --help
+      Show this help.
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+DESTINATION=""
+CI_MODE=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --destination)
+            [[ $# -ge 2 ]] || { echo "--destination requires a value" >&2; exit 1; }
+            DESTINATION="$2"
+            shift 2
+            ;;
+        --ci)
+            CI_MODE=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Resolve destination
+# ---------------------------------------------------------------------------
+
+# Helpers — intentionally mirror example-ui-tests.sh's approach.
+extract_simulator_id() {
+    printf '%s\n' "$1" \
+        | sed -E 's/.*\(([0-9A-F-]{36})\) \((Booted|Shutdown|Creating|Booting)\)[[:space:]]*$/\1/'
+}
+
+extract_simulator_name() {
+    printf '%s\n' "$1" \
+        | sed -E 's/^[[:space:]]+(.+) \([0-9A-F-]{36}\) \((Booted|Shutdown|Creating|Booting)\)[[:space:]]*$/\1/'
+}
+
+pick_simulator_line() {
+    xcrun simctl list devices available | grep -E "$1" | head -n 1 || true
+}
+
+resolve_local_destination() {
+    local line=""
+
+    # 1. Prefer a currently-booted iPhone (saves the boot wait).
+    line="$(pick_simulator_line '^[[:space:]]+iPhone .*\([0-9A-F-]{36}\) \(Booted\)[[:space:]]*$')"
+
+    # 2. Any available iPhone simulator.
+    if [[ -z "$line" ]]; then
+        line="$(pick_simulator_line '^[[:space:]]+iPhone .*\([0-9A-F-]{36}\) \((Shutdown|Creating|Booting)\)[[:space:]]*$')"
+    fi
+
+    if [[ -z "$line" ]]; then
+        echo "No available iPhone simulator found." >&2
+        echo "Run 'xcrun simctl list devices available' and pass --destination manually." >&2
+        exit 1
+    fi
+
+    local sim_id sim_name
+    sim_id="$(extract_simulator_id "$line")"
+    sim_name="$(extract_simulator_name "$line")"
+    DESTINATION="platform=iOS Simulator,id=$sim_id"
+    echo "Using simulator: $sim_name ($sim_id)" >&2
+}
+
+if [[ -n "$DESTINATION" ]]; then
+    echo "Using destination: $DESTINATION" >&2
+elif [[ "$CI_MODE" -eq 1 ]]; then
+    # GitHub Actions macos-15 runners with Xcode 26.x ship iPhone 16 simulators.
+    DESTINATION="platform=iOS Simulator,name=iPhone 16"
+    echo "CI mode — destination: $DESTINATION" >&2
+else
+    resolve_local_destination
+fi
+
+# ---------------------------------------------------------------------------
+# Build and test
+# ---------------------------------------------------------------------------
+
+mkdir -p "$DERIVED_DATA"
+
+echo ""
+echo "Scheme:       $SCHEME"
+echo "Test suite:   $TEST_TARGET/$TEST_SUITE"
+echo "Destination:  $DESTINATION"
+echo "Derived data: $DERIVED_DATA"
+echo ""
+
+xcodebuild test \
+    -scheme "$SCHEME" \
+    -destination "$DESTINATION" \
+    -derivedDataPath "$DERIVED_DATA" \
+    -only-testing:"$TEST_TARGET/$TEST_SUITE" \
+    -disableAutomaticPackageResolution


### PR DESCRIPTION
## Summary

- Adds `scripts/test-ios-simulator.sh` that runs only `ModelContainerFileProtectionTests` on an iPhone Simulator via xcodebuild
- Adds `.swiftpm/xcode/xcshareddata/xcschemes/ManifoldPersistenceSwiftDataTests.xcscheme` — a narrow scheme scoped to just the persistence library + test target (needed because `ManifoldFuzz` uses `Process`, which doesn't compile on iOS)
- Fixes `readFileProtection` in the test file to use `URLResourceValues.fileProtection` as primary (iOS Simulator never populates `FileManager.attributesOfItem(.protectionKey)`)
- Skips `test_makeContainer_honoursCustomProtectionClass` on the simulator — the sandbox reports all protection classes identically; distinguishing `.complete` requires the Secure Enclave on physical hardware
- Adds `ci-ios-file-protection` job to `ci.yml` (separate job, path-filtered, macos-15 runner, iPhone 16 simulator, 15 min timeout)
- Updates `.gitignore` to track `xcschemes/` only
- Documents the new script in CLAUDE.md tooling table

## Test plan

- [x] `bash scripts/test-ios-simulator.sh` passes locally (iPhone 17 Pro, iOS 26.4): 3 pass, 1 skipped, 0 failures
- [x] `swift build --build-tests --disable-default-traits` green on macOS
- [x] Previously-skipped tests now execute on iOS Simulator
- [ ] CI `ci-ios-file-protection` job passes on macos-15 / Xcode 26.3 / iPhone 16 simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)