### PR TITLE
feat: add tier-3 cold-start CI gate for ManifoldUI ChatView composition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -569,15 +569,13 @@ jobs:
         timeout-minutes: 6
         run: scripts/cold-start-conformance.sh
 
-  # Cold-start conformance (tiers 2 + 3) — extends the tier-1 pattern to the
+  # Cold-start conformance (tier 2) — extends the tier-1 pattern to the
   # high-level orchestration surface real chat apps use: ManifoldBootstrap →
   # ChatViewModel → vm.sendMessage(). Catches breaks in ManifoldBootstrap link
   # shape (Inference + Runtime + PersistenceSwiftData + UI products), the
   # configure(runtime:) ergonomics, and the ambient inputText / sendMessage
-  # pattern. Tier 3 then composes a downstream SwiftUI RootView around ChatView,
-  # proving @Observable view models are passed via `.environment(_)` and the
-  # `apiConfiguration:` builder shape still compiles. See the scripts for the
-  # full rationale.
+  # pattern. See scripts/cold-start-tier2-bootstrap.sh for the full rationale.
+  # Tier-3 (ChatView composition) runs in its own job below.
   cold-start-tier2:
     runs-on: macos-15  # match the `test` job runner so cache keys collide
 
@@ -606,9 +604,42 @@ jobs:
         timeout-minutes: 6
         run: scripts/cold-start-tier2-bootstrap.sh
 
+  # Cold-start conformance (tier 3) — scaffolds a fresh SwiftPM consumer that
+  # composes a downstream SwiftUI RootView around ChatView, proving @Observable
+  # view models are passed via `.environment(_:)` (not ObservableObject/
+  # @EnvironmentObject) and that the `@ViewBuilder apiConfiguration:` closure
+  # shape still compiles. Runs against ManifoldUI + ManifoldKit (FoundationOnly
+  # trait — no MLX/Llama). Catches the two UI cold-start mistakes the lower
+  # tiers miss: treating view models as Combine ObservableObjects and forgetting
+  # the ChatView API-configuration builder. See scripts/cold-start-tier3-chatview.sh
+  # for the full rationale.
+  cold-start-tier3:
+    runs-on: macos-15  # match the `test` job runner so cache keys collide
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.3"
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v5
+        with:
+          path: |
+            .build/artifacts
+            .build/checkouts
+            .build/repositories
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
+            ${{ runner.os }}-${{ runner.arch }}-spm-
+
       - name: Run cold-start tier-3 ChatView conformance
         timeout-minutes: 6
-        run: scripts/cold-start-tier3-chatview.sh
+        run: bash scripts/cold-start-tier3-chatview.sh
 
   # FoundationOnly bundle audit — proves the App Store-lean trait set keeps
   # ManifoldKit overhead under 5 MB and never leaks MLX/Llama framework symbols. One

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ for the full list of dependency rules the lint enforces.
 ### 1. Add the package
 
 ```swift
-.package(url: "https://github.com/roryford/ManifoldKit.git", from: "0.23.0")
+.package(url: "https://github.com/roryford/ManifoldKit.git", from: "0.24.0")
 ```
 
 Most apps add a single product — the `ManifoldKit` umbrella, which re-exports
@@ -173,7 +173,7 @@ Pass the matching set as `traits:` on your `.package(...)` entry to lock the con
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.23.0",
+    from: "0.24.0",
     traits: [
         .trait(name: "MLX"),
         .trait(name: "Llama"),
@@ -199,7 +199,7 @@ Apple Foundation Models.
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.23.0",
+    from: "0.24.0",
     traits: ["FoundationOnly"]   // overrides the MLX/Llama/HuggingFace defaults
 )
 ```
@@ -216,7 +216,7 @@ Equivalent legacy form (still supported, before the named trait existed):
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.23.0",
+    from: "0.24.0",
     traits: []   // disables MLX, Llama, HuggingFace defaults
 )
 ```
@@ -237,7 +237,7 @@ For example, a cloud-only consumer can keep the chat UI and local-model loaders 
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.23.0",
+    from: "0.24.0",
     traits: [
         .trait(name: "MLX"),
         .trait(name: "Llama"),
@@ -285,7 +285,7 @@ If you already depend on `ManifoldBackends`, the same data is also available via
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.23.0",
+    from: "0.24.0",
     traits: [
         .trait(name: "MCP"),
         .trait(name: "MCPBuiltinCatalog"), // optional: only if you use MCPCatalog
@@ -325,7 +325,7 @@ stock `ChatInputBar`.
 ```swift
  .package(
      url: "https://github.com/roryford/ManifoldKit.git",
-     from: "0.23.0",
+     from: "0.24.0",
      traits: [
          .trait(name: "Voice"),
      ]
@@ -401,7 +401,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/roryford/ManifoldKit.git",
-            from: "0.23.0",
+            from: "0.24.0",
             traits: [
                 .trait(name: "MLX"),
                 .trait(name: "Llama"),
@@ -1008,7 +1008,7 @@ open ManifoldDemo.xcodeproj
 
 This package was renamed from `BaseChatKit` to `ManifoldKit` in v0.20. The old GitHub URL `github.com/roryford/BaseChatKit` redirects to `roryford/ManifoldKit`, but for clarity:
 
-- Update SPM dependencies: `.package(url: "https://github.com/roryford/ManifoldKit.git", from: "0.23.0")`
+- Update SPM dependencies: `.package(url: "https://github.com/roryford/ManifoldKit.git", from: "0.24.0")`
 - Update imports: `import BaseChatKit` → `import ManifoldKit` (and similarly for sub-modules — `BaseChatInference` → `ManifoldInference`, etc.)
 - Renamed public types: `BaseChatBootstrap` → `ManifoldBootstrap`, `BaseChatConfiguration` → `ManifoldConfiguration`, `BaseChatSchemaV3/4/5` → `ManifoldSchemaV3/4/5`, `BaseChatMigrationPlan` → `ManifoldMigrationPlan`, `BaseChatBackgroundTaskIdentifiers` → `ManifoldBackgroundTaskIdentifiers`
 - **BREAKING — local SwiftData stores reset.** SwiftData persists fully-qualified `@Model` type names; renaming the schema namespace orphans existing on-disk stores. Apps upgrading from 0.19.x will create fresh databases on first launch. We chose this clean break over preserving data with `@Model.originalName` because v0.20 is pre-1.0.


### PR DESCRIPTION
## Summary

- Adds a dedicated `cold-start-tier3` CI job that runs `scripts/cold-start-tier3-chatview.sh` on every push and PR touching `Sources/**`, `Package.swift`, `Package.resolved`, or any `scripts/cold-start*.sh` file — so edits to the script self-validate.
- Extracts the tier-3 step out of the `cold-start-tier2` job (where it was piggy-backed) into its own first-class job, matching the tier-1 (`cold-start`) and tier-2 (`cold-start-tier2`) pattern already in CI.
- Closes the tier-3 item in #1115.

## What the gate catches

The tier-3 script scaffolds a fresh SwiftPM consumer that builds a `RootView` wrapping `ChatView` and exercises two composition shapes that the lower tiers cannot reach:

1. **`@Observable` vs `ObservableObject` deadlock** — if a `ChatViewModel` or `SessionManagerViewModel` is accidentally wired up as a Combine `ObservableObject` the consumer fails to compile, because `@State` + `.environment(_:)` only work with `@Observable` types under Swift Observation.
2. **`@ViewBuilder apiConfiguration:` closure shape** — the closure-injected `APIConfigurationView` seam that dissolved the `ManifoldUI → ManifoldUIModelManagement` dependency cycle must remain a `@ViewBuilder` parameter; any signature drift breaks the consumer at the call site.

The script uses the `FoundationOnly` trait so it runs without MLX or Llama and keeps the job fast.

## Relation to existing gates

| Job | Script | What it covers |
|-----|--------|----------------|
| `cold-start` | `cold-start-conformance.sh` | Tier 1 — public `InferenceService` API surface |
| `cold-start-tier2` | `cold-start-tier2-bootstrap.sh` | Tier 2 — `ManifoldBootstrap` + `ChatViewModel` orchestration |
| `cold-start-tier3` _(this PR)_ | `cold-start-tier3-chatview.sh` | Tier 3 — `ManifoldUI` `ChatView` composition |

🤖 Generated with [Claude Code](https://claude.com/claude-code)