### PR TITLE
fix: extract needsFoundationSession predicate for CI testability

### DIFF
--- a/Sources/ManifoldFoundation/FoundationBackend.swift
+++ b/Sources/ManifoldFoundation/FoundationBackend.swift
@@ -388,9 +388,12 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
             // consumed.  In the last case the session is "dirty" — LanguageModelSession
             // asserts (SIGTRAP) if streamResponse() is called on a session whose
             // previous ResponseStream iterator was dropped before returning nil.
-            let needsNewSession = session == nil
-                || effectiveInstructions != currentSystemPrompt
-                || !_sessionIsClean
+            let needsNewSession = needsNewFoundationSession(
+                sessionExists: session != nil,
+                currentInstructions: currentSystemPrompt,
+                newInstructions: effectiveInstructions,
+                isClean: _sessionIsClean
+            )
             if needsNewSession {
                 if let effectiveInstructions, !effectiveInstructions.isEmpty {
                     session = LanguageModelSession(instructions: effectiveInstructions)
@@ -697,4 +700,29 @@ struct FoundationTokenizer: TokenizerProvider {
         max(1, text.count / 3)
     }
 }
+
+// MARK: - Session predicate
+
+/// Returns `true` when `generate()` must allocate a fresh `LanguageModelSession`.
+///
+/// Extracted as a file-private pure function so tests can cover all four branches
+/// without requiring a real Apple Intelligence entitlement.
+///
+/// - Parameters:
+///   - sessionExists: Whether a session has already been created.
+///   - currentInstructions: The instructions that were used to create the current session.
+///   - newInstructions: The instructions required for the upcoming generation turn.
+///   - isClean: `true` when the current session's `ResponseStream` was fully consumed
+///     (iterator returned `nil`). `false` means the stream was abandoned mid-flight;
+///     reusing it would cause `LanguageModelSession` to SIGTRAP on the next
+///     `streamResponse()` call.
+func needsNewFoundationSession(
+    sessionExists: Bool,
+    currentInstructions: String?,
+    newInstructions: String?,
+    isClean: Bool
+) -> Bool {
+    !sessionExists || currentInstructions != newInstructions || !isClean
+}
+
 #endif

--- a/Tests/ManifoldBackendsTests/FoundationBackendUnitTests.swift
+++ b/Tests/ManifoldBackendsTests/FoundationBackendUnitTests.swift
@@ -700,4 +700,140 @@ final class FoundationBackendUnitTests: XCTestCase {
     }
 }
 
+// MARK: - needsNewFoundationSession predicate tests
+
+/// Tests for the `needsNewFoundationSession` pure function.
+///
+/// These tests do NOT gate on `FoundationBackend.isAvailable` and run on every
+/// CI machine — including simulators — because they exercise only the extracted
+/// predicate, not the `LanguageModelSession` API.
+@available(iOS 26, macOS 26, *)
+final class NeedsNewFoundationSessionTests: XCTestCase {
+
+    override func setUp() async throws {
+        try await super.setUp()
+        guard ProcessInfo.processInfo.isOperatingSystemAtLeast(
+            OperatingSystemVersion(majorVersion: 26, minorVersion: 0, patchVersion: 0)
+        ) else {
+            throw XCTSkip("FoundationModels requires iOS 26 / macOS 26")
+        }
+    }
+
+    // MARK: - 1. No session exists → always create new
+
+    func test_noSession_alwaysCreatesNew() {
+        XCTAssertTrue(
+            needsNewFoundationSession(
+                sessionExists: false,
+                currentInstructions: nil,
+                newInstructions: nil,
+                isClean: true
+            ),
+            "When no session exists a new one must always be created"
+        )
+    }
+
+    func test_noSession_withInstructions_createsNew() {
+        XCTAssertTrue(
+            needsNewFoundationSession(
+                sessionExists: false,
+                currentInstructions: nil,
+                newInstructions: "You are helpful.",
+                isClean: true
+            ),
+            "When no session exists a new one must be created regardless of instructions"
+        )
+    }
+
+    // MARK: - 2. Session exists, clean, same instructions → reuse
+
+    func test_existingCleanSession_sameInstructions_reuses() {
+        XCTAssertFalse(
+            needsNewFoundationSession(
+                sessionExists: true,
+                currentInstructions: "You are helpful.",
+                newInstructions: "You are helpful.",
+                isClean: true
+            ),
+            "A clean session with matching instructions must be reused to preserve conversation history"
+        )
+    }
+
+    func test_existingCleanSession_bothNilInstructions_reuses() {
+        XCTAssertFalse(
+            needsNewFoundationSession(
+                sessionExists: true,
+                currentInstructions: nil,
+                newInstructions: nil,
+                isClean: true
+            ),
+            "A clean session with no instructions on either side must be reused"
+        )
+    }
+
+    // MARK: - 3. Session exists, dirty → create new
+
+    func test_dirtySession_sameInstructions_createsNew() {
+        XCTAssertTrue(
+            needsNewFoundationSession(
+                sessionExists: true,
+                currentInstructions: "You are helpful.",
+                newInstructions: "You are helpful.",
+                isClean: false
+            ),
+            "A dirty session must never be reused — calling streamResponse() on it would SIGTRAP"
+        )
+    }
+
+    func test_dirtySession_nilInstructions_createsNew() {
+        XCTAssertTrue(
+            needsNewFoundationSession(
+                sessionExists: true,
+                currentInstructions: nil,
+                newInstructions: nil,
+                isClean: false
+            ),
+            "A dirty session with nil instructions must still be replaced"
+        )
+    }
+
+    // MARK: - 4. Session exists, clean, instructions changed → create new
+
+    func test_existingCleanSession_instructionsChanged_createsNew() {
+        XCTAssertTrue(
+            needsNewFoundationSession(
+                sessionExists: true,
+                currentInstructions: "You are a pirate.",
+                newInstructions: "You are helpful.",
+                isClean: true
+            ),
+            "Instructions are baked into LanguageModelSession at creation — a change forces a new session"
+        )
+    }
+
+    func test_existingCleanSession_instructionsNilToNonNil_createsNew() {
+        XCTAssertTrue(
+            needsNewFoundationSession(
+                sessionExists: true,
+                currentInstructions: nil,
+                newInstructions: "You are helpful.",
+                isClean: true
+            ),
+            "Transitioning from no instructions to having instructions forces a new session"
+        )
+    }
+
+    func test_existingCleanSession_instructionsNonNilToNil_createsNew() {
+        XCTAssertTrue(
+            needsNewFoundationSession(
+                sessionExists: true,
+                currentInstructions: "You are helpful.",
+                newInstructions: nil,
+                isClean: true
+            ),
+            "Removing instructions forces a new session"
+        )
+    }
+}
+
 #endif


### PR DESCRIPTION
## Summary

`FoundationBackend` contains critical session-reuse logic that prevents a SIGTRAP: Apple's `LanguageModelSession` asserts if `streamResponse()` is called while the previous iterator was dropped early (mid-stream cancellation). The backend tracks this via `_sessionIsClean`, and the three-part session-selection condition (`session == nil || instructions changed || !_sessionIsClean`) guards against it.

The problem: all tests that exercise this condition are gated on `FoundationBackend.isAvailable` (real Apple Intelligence required), so **the SIGTRAP-prevention logic was completely invisible to CI**. Accidentally removing the `|| !_sessionIsClean` clause would pass all CI checks and only surface as a SIGTRAP on-device.

## What changed

- **`Sources/ManifoldFoundation/FoundationBackend.swift`**: Extracts the inline three-part condition into a file-private pure function `needsNewFoundationSession(sessionExists:currentInstructions:newInstructions:isClean:)`. The `generate()` call site is replaced with a call to this function. Logic is identical — this is a pure refactor of the predicate.

- **`Tests/ManifoldBackendsTests/FoundationBackendUnitTests.swift`**: Adds `NeedsNewFoundationSessionTests` (9 `XCTestCase` tests) that cover all four meaningful branches of the predicate without gating on `FoundationBackend.isAvailable`. These run in CI on every push.

## Coverage

| Case | Test |
|------|------|
| No session → always create new | `test_noSession_alwaysCreatesNew`, `test_noSession_withInstructions_createsNew` |
| Exists, clean, same instructions → reuse | `test_existingCleanSession_sameInstructions_reuses`, `test_existingCleanSession_bothNilInstructions_reuses` |
| Exists, dirty → create new | `test_dirtySession_sameInstructions_createsNew`, `test_dirtySession_nilInstructions_createsNew` |
| Exists, clean, instructions changed → create new | `test_existingCleanSession_instructionsChanged_createsNew`, `test_existingCleanSession_instructionsNilToNonNil_createsNew`, `test_existingCleanSession_instructionsNonNilToNil_createsNew` |

## Test plan

- [ ] `scripts/test.sh --filter ManifoldBackendsTests --disable-default-traits --skip-update` passes (9 new `NeedsNewFoundationSessionTests` cases all green, full suite PASSED)
- [ ] No existing tests modified or skipped
- [ ] No `@available` guards altered on existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)