### PR TITLE
fix: close DNS rebinding guard fail-open and hostless URL bypass

### DIFF
--- a/Sources/ManifoldCloudCore/DNSRebindingGuard.swift
+++ b/Sources/ManifoldCloudCore/DNSRebindingGuard.swift
@@ -37,7 +37,7 @@ public enum DNSRebindingGuard {
     /// tests to inject deterministic address lists without touching the network.
     ///
     /// - Warning: For testing only. Write this before any concurrent access.
-    nonisolated(unsafe) static var _resolverForTesting: ((String) async -> [String])? = nil
+    nonisolated(unsafe) static var _resolverForTesting: ((String) async -> [String]?)? = nil
 
     // MARK: - Public API
 
@@ -55,7 +55,9 @@ public enum DNSRebindingGuard {
         // Localhost is always allowed — it is an explicitly configured local server.
         if PrivateIPClassifier.isLocalhostURL(url) { return }
 
-        guard let host = url.host() else { return }
+        guard let host = url.host() else {
+            throw CloudBackendError.blockedAddress("URL has no host component")
+        }
 
         // IP literals are checked immediately without DNS resolution.
         if let category = PrivateIPClassifier.classifyIPLiteral(host) {
@@ -65,7 +67,14 @@ public enum DNSRebindingGuard {
         }
 
         // DNS hostname — resolve and check every returned address.
-        let addresses = await resolveHostname(host)
+        // Nil return means resolution failed; block rather than fall through —
+        // an attacker can arrange SERVFAIL for this call, then serve a private
+        // IP to URLSession's separate resolver query (TTL-0 / SERVFAIL pattern).
+        guard let addresses = await resolveHostname(host) else {
+            throw CloudBackendError.blockedAddress(
+                "Could not resolve hostname '\(host)' — connection blocked"
+            )
+        }
         for address in addresses {
             if let category = PrivateIPClassifier.classifyIPLiteral(address) {
                 Log.network.error(
@@ -84,10 +93,11 @@ public enum DNSRebindingGuard {
     ///
     /// Runs `getaddrinfo` on a utility-priority background task to avoid blocking
     /// the cooperative thread pool during the resolver round-trip.
-    /// Returns an empty array on resolution failure (network error, NXDOMAIN, etc.)
-    /// so the guard fails open for unresolvable names — the subsequent URLSession
-    /// connection will produce the appropriate network error itself.
-    private static func resolveHostname(_ hostname: String) async -> [String] {
+    /// Returns `nil` on resolution failure (network error, NXDOMAIN, etc.) —
+    /// callers treat `nil` as a block. Failing open would let an attacker arrange
+    /// SERVFAIL for the guard's query, then serve a private IP to URLSession's
+    /// subsequent query (TTL-0 pattern), bypassing the entire DNS rebinding defence.
+    private static func resolveHostname(_ hostname: String) async -> [String]? {
         if let override = _resolverForTesting {
             return await override(hostname)
         }
@@ -103,7 +113,7 @@ public enum DNSRebindingGuard {
 
             guard getaddrinfo(hostname, nil, &hints, &result) == 0,
                   result != nil else {
-                return []
+                return nil
             }
 
             var addresses: [String] = []

--- a/Sources/ManifoldInference/Networking/RedirectGuardDelegate.swift
+++ b/Sources/ManifoldInference/Networking/RedirectGuardDelegate.swift
@@ -62,6 +62,17 @@ public final class RedirectGuardDelegate: NSObject, URLSessionTaskDelegate, @unc
     /// Per-task hop counters keyed by `URLSessionTask.taskIdentifier`.
     private var hopCounts: [Int: Int] = [:]
 
+    // MARK: - Testing seam
+
+    /// Overrides the synchronous hostname resolver used by ``blockedHostReason(for:)``.
+    ///
+    /// `nil` (the default) uses the real `getaddrinfo` resolver. Set this in
+    /// tests to inject deterministic address lists. Return `nil` to simulate
+    /// resolution failure (the redirect will be blocked).
+    ///
+    /// - Warning: For testing only. Reset to `nil` in `tearDown`.
+    nonisolated(unsafe) static var _synchronousResolverForTesting: ((String) -> [String]?)? = nil
+
     // MARK: - Init
 
     /// Creates a redirect guard with the given hop cap.
@@ -224,7 +235,12 @@ public final class RedirectGuardDelegate: NSObject, URLSessionTaskDelegate, @unc
         }
 
         // DNS hostname — resolve synchronously and reject on any blocked address.
-        for address in resolveSynchronously(host) {
+        // Nil return means resolution failed; block the redirect rather than
+        // falling through (same TTL-0 bypass risk as in DNSRebindingGuard).
+        guard let addresses = resolveSynchronously(host) else {
+            return "could not resolve hostname '\(host)'"
+        }
+        for address in addresses {
             if let category = PrivateIPClassifier.classifyIPLiteral(address) {
                 return "host \(host) resolved to \(address) (\(category))"
             }
@@ -232,10 +248,12 @@ public final class RedirectGuardDelegate: NSObject, URLSessionTaskDelegate, @unc
         return nil
     }
 
-    /// Synchronous `getaddrinfo` wrapper. Returns an empty array on
-    /// resolution failure — the subsequent connection attempt will produce
-    /// the appropriate network error itself.
-    static func resolveSynchronously(_ hostname: String) -> [String] {
+    /// Synchronous `getaddrinfo` wrapper. Returns `nil` on resolution failure;
+    /// callers treat `nil` as a block rather than failing open.
+    static func resolveSynchronously(_ hostname: String) -> [String]? {
+        if let override = _synchronousResolverForTesting {
+            return override(hostname)
+        }
         var hints = addrinfo()
         hints.ai_family = AF_UNSPEC
         hints.ai_socktype = SOCK_STREAM
@@ -246,7 +264,7 @@ public final class RedirectGuardDelegate: NSObject, URLSessionTaskDelegate, @unc
 
         guard getaddrinfo(hostname, nil, &hints, &result) == 0,
               result != nil else {
-            return []
+            return nil
         }
 
         var addresses: [String] = []

--- a/Tests/ManifoldBackendsTests/DNSRebindingGuardTests.swift
+++ b/Tests/ManifoldBackendsTests/DNSRebindingGuardTests.swift
@@ -173,13 +173,31 @@ final class DNSRebindingGuardTests: XCTestCase {
         }
     }
 
-    // MARK: - Resolution Failure (fail-open)
+    // MARK: - Resolution Failure (fail-closed)
 
-    func test_unresolvedHostname_failsOpen() async throws {
-        // If DNS resolution fails (NXDOMAIN, network error), the guard fails open
-        // so the subsequent URLSession connection produces the right error.
+    func test_unresolvedHostname_isBlocked() async {
+        // Resolution failure must block — an attacker can arrange SERVFAIL for
+        // the guard's query, then serve a private IP to URLSession's next
+        // resolver query (TTL-0 / SERVFAIL pattern), bypassing the guard if it
+        // fails open. Sabotage: returning [] (not nil) here causes this to pass,
+        // exposing the bypass.
+        DNSRebindingGuard._resolverForTesting = { _ in nil }
+        await assertBlocked(url: "https://does-not-exist.invalid/api")
+    }
+
+    func test_nodataResolution_passes() async throws {
+        // A seam returning [] means "resolved successfully but no addresses" —
+        // no blocked address was found, so the guard passes.
+        // (In production getaddrinfo never returns success with zero addresses,
+        // but the seam distinguishes NODATA from failure explicitly.)
         DNSRebindingGuard._resolverForTesting = { _ in [] }
-        try await DNSRebindingGuard.validate(url: URL(string: "https://does-not-exist.invalid/api")!)
+        try await DNSRebindingGuard.validate(url: URL(string: "https://api.example.com/v1")!)
+    }
+
+    func test_hostlessURL_isBlocked() async {
+        // A URL with no host (e.g. file://, data:) must not silently pass.
+        // Sabotage: changing `throw` to `return` in the guard lets these through.
+        await assertBlocked(url: "file:///etc/passwd")
     }
 
     // MARK: - Helpers

--- a/Tests/ManifoldBackendsTests/RedirectGuardDelegateTests.swift
+++ b/Tests/ManifoldBackendsTests/RedirectGuardDelegateTests.swift
@@ -19,6 +19,19 @@ import XCTest
 /// UUID-namespaced hostname so stubs don't bleed between tests.
 final class RedirectGuardDelegateTests: XCTestCase {
 
+    override func setUp() {
+        super.setUp()
+        // UUID-based fake hostnames used in E2E tests can't resolve via real DNS.
+        // Default the seam to a public IP so those hosts pass the rebinding guard.
+        // Tests that specifically exercise resolution failure override this to nil.
+        RedirectGuardDelegate._synchronousResolverForTesting = { _ in ["93.184.216.34"] }
+    }
+
+    override func tearDown() {
+        RedirectGuardDelegate._synchronousResolverForTesting = nil
+        super.tearDown()
+    }
+
     // MARK: - Static helper: same-origin check
 
     func test_isSameOrigin_truePerSchemeHostPort() {
@@ -144,6 +157,28 @@ final class RedirectGuardDelegateTests: XCTestCase {
     func test_blockedHostReason_publicIP_passes() {
         XCTAssertNil(RedirectGuardDelegate.blockedHostReason(
             for: URL(string: "https://1.1.1.1/")!
+        ))
+    }
+
+    func test_blockedHostReason_unresolvableHostname_isBlocked() {
+        // Resolution failure must block — same TTL-0 bypass risk as DNSRebindingGuard.
+        // Sabotage: returning [] (not nil) from the seam causes this to pass,
+        // exposing the redirect-chain SSRF bypass.
+        RedirectGuardDelegate._synchronousResolverForTesting = { _ in nil }
+        let reason = RedirectGuardDelegate.blockedHostReason(
+            for: URL(string: "https://does-not-exist.invalid/api")!
+        )
+        XCTAssertNotNil(reason, "Unresolvable hostname must be blocked as a redirect target")
+        XCTAssertTrue(
+            reason?.contains("could not resolve") == true,
+            "Expected resolution-failure reason, got: \(reason ?? "nil")"
+        )
+    }
+
+    func test_blockedHostReason_hostnameResolvingToPublicIP_passes() {
+        RedirectGuardDelegate._synchronousResolverForTesting = { _ in ["93.184.216.34"] }
+        XCTAssertNil(RedirectGuardDelegate.blockedHostReason(
+            for: URL(string: "https://api.example.com/v1")!
         ))
     }
 


### PR DESCRIPTION
## Summary

- `DNSRebindingGuard.resolveHostname` and `RedirectGuardDelegate.resolveSynchronously` both returned `[]` when `getaddrinfo` failed, letting the connection proceed. An attacker who controls a DNS record can arrange SERVFAIL for the guard's query, then serve a private IP to URLSession's separate resolver call milliseconds later (TTL-0 / SERVFAIL pattern) — the guard was bypassed entirely.
- `DNSRebindingGuard.validate` silently returned (allowed) when a URL had no host component (`file://`, `data:`, malformed URLs), while `RedirectGuardDelegate.blockedHostReason` already correctly blocked this case.

## Changes

- `resolveHostname` / `resolveSynchronously` now return `[String]?` — `nil` means resolution failed, callers throw/block on `nil`
- `DNSRebindingGuard.validate` throws `.blockedAddress` on a missing URL host component
- Added `_synchronousResolverForTesting` seam to `RedirectGuardDelegate` (mirrors the existing seam on `DNSRebindingGuard`) so tests can inject deterministic DNS without network
- Flipped `test_unresolvedHostname_failsOpen` → `test_unresolvedHostname_isBlocked`; added `test_nodataResolution_passes`, `test_hostlessURL_isBlocked`, and two new `RedirectGuardDelegate` unit tests covering the nil path

## Test plan

- [ ] `scripts/test.sh --filter ManifoldBackendsTests --filter ManifoldInferenceTests --disable-default-traits --skip-update` — 69 tests, 0 failures
- [ ] `test_unresolvedHostname_isBlocked` fails if `return nil` is reverted to `return []` in `resolveHostname` (sabotage verified during development)
- [ ] `test_hostlessURL_isBlocked` fails if `throw` is reverted to `return` in the hostless-URL guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)