### PR TITLE
feat(inference): unified error category surface across InferenceError + CloudBackendError

### DIFF
--- a/Sources/ManifoldCloud/ClaudeBackend.swift
+++ b/Sources/ManifoldCloud/ClaudeBackend.swift
@@ -492,6 +492,14 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             let retryAfter = response.value(forHTTPHeaderField: "Retry-After")
                 .flatMap { TimeInterval($0) }
             throw CloudBackendError.rateLimited(retryAfter: retryAfter)
+        case 529:
+            // Claude-specific "overloaded" status — provider is temporarily at
+            // capacity. Distinct from 503 Service Unavailable; signals a known
+            // operational state rather than a generic server fault, so callers
+            // can apply purpose-built backoff rather than the generic 5xx path.
+            let retryAfter = response.value(forHTTPHeaderField: "Retry-After")
+                .flatMap { TimeInterval($0) }
+            throw CloudBackendError.providerOverloaded(provider: "Claude", retryAfter: retryAfter)
         default:
             let errorBody = await Self.readErrorBody(from: bytes)
             Log.network.debug("Claude upstream error body: \(errorBody, privacy: .private)")

--- a/Sources/ManifoldInference/Services/CloudBackendError.swift
+++ b/Sources/ManifoldInference/Services/CloudBackendError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Errors from cloud API backends (OpenAI-compatible and Claude).
-public enum CloudBackendError: LocalizedError {
+public enum CloudBackendError: LocalizedError, CategorizedError {
     case invalidURL(String)
     case authenticationFailed(provider: String)
     case rateLimited(retryAfter: TimeInterval?)
@@ -25,6 +25,42 @@ public enum CloudBackendError: LocalizedError {
     /// suspenders mitigation for regulated runtimes that need to lock the
     /// network even in a `full`-trait build. Not retryable.
     case networkDisabled
+    /// HTTP 429 where the provider signals a billing cap or quota exhaustion
+    /// (distinct from throttle-based rate limiting). Not retryable within the
+    /// same billing period — the user must take action (increase quota, add
+    /// credits, or switch endpoint).
+    case quotaExceeded(provider: String)
+    /// HTTP 529 or provider-specific "overloaded" response (e.g. Claude 529).
+    /// The provider is temporarily at capacity. A short exponential backoff
+    /// helps; it is not a permanent error.
+    case providerOverloaded(provider: String, retryAfter: TimeInterval?)
+    /// The request was rejected by the provider's content filter.
+    /// Not retryable — the content must change.
+    case contentFiltered(provider: String, reason: String?)
+
+    // MARK: - CategorizedError
+
+    public var category: InferenceErrorCategory {
+        switch self {
+        case .rateLimited(let retryAfter):
+            return .rateLimited(retryAfter: retryAfter)
+        case .quotaExceeded:
+            return .quotaExceeded
+        case .providerOverloaded(_, let retryAfter):
+            return .providerOverloaded(retryAfter: retryAfter)
+        case .authenticationFailed, .missingAPIKey:
+            return .authenticationFailed
+        case .contentFiltered:
+            return .contentFiltered
+        case .networkError, .streamInterrupted, .timeout:
+            return .retryableTransient
+        case .serverError(let code, _) where code >= 500:
+            return .retryableTransient
+        case .invalidURL, .parseError, .backendDeallocated,
+             .blockedAddress, .networkDisabled, .serverError:
+            return .nonRetryable
+        }
+    }
 
     public var errorDescription: String? {
         switch self {
@@ -59,17 +95,30 @@ public enum CloudBackendError: LocalizedError {
             return "Connection blocked: the endpoint resolved to a private or reserved address. \(detail)"
         case .networkDisabled:
             return "Network access is disabled by the runtime kill-switch (URLSessionProvider.networkDisabled)."
+        case .quotaExceeded(let provider):
+            return "\(provider) quota exceeded. Check your billing plan or add credits to continue."
+        case .providerOverloaded(let provider, let retryAfter):
+            if let seconds = retryAfter {
+                return "\(provider) is temporarily at capacity. Try again in \(Int(seconds)) seconds."
+            }
+            return "\(provider) is temporarily at capacity. Try again shortly."
+        case .contentFiltered(let provider, let reason):
+            if let reason {
+                return "\(provider) rejected the request due to content policy: \(reason)"
+            }
+            return "\(provider) rejected the request due to content policy."
         }
     }
 
     public var isRetryable: Bool {
         switch self {
-        case .rateLimited, .networkError, .streamInterrupted, .timeout:
+        case .rateLimited, .networkError, .streamInterrupted, .timeout, .providerOverloaded:
             return true
         case .serverError(let statusCode, _):
             return statusCode >= 500
         case .invalidURL, .authenticationFailed, .parseError, .missingAPIKey,
-             .backendDeallocated, .blockedAddress, .networkDisabled:
+             .backendDeallocated, .blockedAddress, .networkDisabled,
+             .quotaExceeded, .contentFiltered:
             return false
         }
     }

--- a/Sources/ManifoldInference/Services/InferenceError.swift
+++ b/Sources/ManifoldInference/Services/InferenceError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Errors that can occur during model loading and inference.
-public enum InferenceError: LocalizedError {
+public enum InferenceError: LocalizedError, CategorizedError {
     case modelNotFound(path: String)
     case modelLoadFailed(underlying: Error)
     case inferenceFailure(String)
@@ -58,6 +58,24 @@ public enum InferenceError: LocalizedError {
             }
             let names = unmet.map { String(describing: $0) }.joined(separator: ", ")
             return "No wired backend satisfies the request's required capabilities: \(names)."
+        }
+    }
+
+    // MARK: - CategorizedError
+
+    public var category: InferenceErrorCategory {
+        switch self {
+        case .contextExhausted:
+            return .contextExceeded
+        case .unsupportedModelArchitecture, .unsupportedGrammar:
+            return .unsupportedRequest
+        case .noBackendSatisfiesRequirements:
+            return .unsupportedRequest
+        case .alreadyGenerating:
+            return .retryableTransient
+        case .modelNotFound, .modelLoadFailed, .inferenceFailure,
+             .memoryInsufficient, .generationError:
+            return .nonRetryable
         }
     }
 

--- a/Sources/ManifoldInference/Services/InferenceErrorCategory.swift
+++ b/Sources/ManifoldInference/Services/InferenceErrorCategory.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// A coarse-grained, type-erased view of an inference or cloud backend error.
+/// Use this when you need to make a routing decision (retry vs fail-fast vs
+/// user-action-required) without switching on the concrete error type.
+public enum InferenceErrorCategory: Sendable, Equatable {
+    /// Network blip, 5xx, stream interrupted — a retry may succeed.
+    case retryableTransient
+    /// Provider throttled the request. The associated value is the
+    /// recommended retry delay, if the provider supplied one.
+    case rateLimited(retryAfter: TimeInterval?)
+    /// Billing cap or quota exhausted. The user must take action.
+    case quotaExceeded
+    /// Provider is temporarily at capacity (Claude 529, etc.).
+    /// Short exponential backoff is appropriate.
+    case providerOverloaded(retryAfter: TimeInterval?)
+    /// API key missing or invalid.
+    case authenticationFailed
+    /// Prompt + requested output exceeds the model's context window.
+    case contextExceeded
+    /// Provider's content policy rejected the request.
+    case contentFiltered
+    /// Capability mismatch — grammar, vision, tools not supported by this backend.
+    case unsupportedRequest
+    /// Permanent error — no retry will help.
+    case nonRetryable
+}
+
+/// Implemented by ``InferenceError`` and ``CloudBackendError`` to expose a
+/// uniform category view without changing the concrete enum type.
+public protocol CategorizedError: Error {
+    var category: InferenceErrorCategory { get }
+}

--- a/Tests/ManifoldBackendsTests/ClaudeBackendTests.swift
+++ b/Tests/ManifoldBackendsTests/ClaudeBackendTests.swift
@@ -421,4 +421,82 @@ extension ClaudeBackendTests {
     }
 }
 
+// MARK: - HTTP 529 providerOverloaded
+
+extension ClaudeBackendTests {
+
+    /// Claude returns HTTP 529 when it is temporarily at capacity.
+    /// The backend must route this to `.providerOverloaded` — not the
+    /// generic `serverError` bucket — so callers can apply purpose-built
+    /// backoff rather than treating it as an opaque 5xx.
+    func test_529_throwsProviderOverloaded() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let backend = ClaudeBackend(urlSession: session)
+        // Disable retries so the error surfaces immediately.
+        backend.retryStrategy = ExponentialBackoffStrategy(maxRetries: 0)
+        let url = URL(string: "https://claude-529-\(UUID().uuidString).test")!
+        backend.configure(baseURL: url, apiKey: "sk-ant-test", modelName: "claude-sonnet-4-20250514")
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+
+        MockURLProtocol.stub(url: url, response: .immediate(data: Data(), statusCode: 529))
+        defer { MockURLProtocol.unstub(url: url) }
+
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: GenerationConfig())
+        do {
+            for try await _ in stream.events {}
+            XCTFail("Expected providerOverloaded error for HTTP 529")
+        } catch {
+            guard let cloudError = extractCloudError(error) else {
+                XCTFail("Expected CloudBackendError, got \(error)")
+                return
+            }
+            if case .providerOverloaded(let provider, _) = cloudError {
+                XCTAssertEqual(provider, "Claude",
+                               "529 must surface as providerOverloaded with provider='Claude'")
+            } else {
+                XCTFail("Expected .providerOverloaded for HTTP 529, got \(cloudError)")
+            }
+        }
+    }
+
+    /// Sabotage check: a 503 must NOT become providerOverloaded — it must remain
+    /// the generic serverError so 529 routing stays narrow.
+    func test_503_doesNotThrowProviderOverloaded() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let backend = ClaudeBackend(urlSession: session)
+        backend.retryStrategy = ExponentialBackoffStrategy(maxRetries: 0)
+        let url = URL(string: "https://claude-503-\(UUID().uuidString).test")!
+        backend.configure(baseURL: url, apiKey: "sk-ant-test", modelName: "claude-sonnet-4-20250514")
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+
+        MockURLProtocol.stub(url: url, response: .immediate(
+            data: Data(#"{"error":{"message":"service unavailable"}}"#.utf8),
+            statusCode: 503
+        ))
+        defer { MockURLProtocol.unstub(url: url) }
+
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: GenerationConfig())
+        do {
+            for try await _ in stream.events {}
+            XCTFail("Expected serverError for HTTP 503")
+        } catch {
+            guard let cloudError = extractCloudError(error) else {
+                XCTFail("Expected CloudBackendError, got \(error)")
+                return
+            }
+            if case .providerOverloaded = cloudError {
+                XCTFail("503 must not surface as providerOverloaded — that path is reserved for 529")
+            } else if case .serverError(let code, _) = cloudError {
+                XCTAssertEqual(code, 503)
+            }
+            // Any non-providerOverloaded error is acceptable — the important
+            // thing is that 503 is not mis-classified as providerOverloaded.
+        }
+    }
+}
+
 #endif

--- a/Tests/ManifoldInferenceTests/CloudBackendErrorTests.swift
+++ b/Tests/ManifoldInferenceTests/CloudBackendErrorTests.swift
@@ -141,4 +141,116 @@ final class CloudBackendErrorTests: XCTestCase {
         XCTAssertNotNil(error.errorDescription)
         XCTAssertFalse(error.errorDescription?.isEmpty ?? true)
     }
+
+    // MARK: - New cases: quotaExceeded / providerOverloaded / contentFiltered
+
+    func test_quotaExceeded_description_includesProvider() {
+        let error = CloudBackendError.quotaExceeded(provider: "Claude")
+        let description = error.errorDescription ?? ""
+        XCTAssertTrue(description.contains("Claude"),
+                      "quotaExceeded should mention the provider: \(description)")
+        XCTAssertTrue(description.lowercased().contains("quota") || description.lowercased().contains("billing"),
+                      "quotaExceeded should mention quota or billing: \(description)")
+    }
+
+    func test_quotaExceeded_isNotRetryable() {
+        // Billing cap: the user must act; retrying within the same period won't help.
+        // Sabotage check: moving quotaExceeded into the retryable arm would flip this.
+        XCTAssertFalse(CloudBackendError.quotaExceeded(provider: "Claude").isRetryable,
+                       "quotaExceeded must not be retryable — user action required")
+    }
+
+    func test_providerOverloaded_description_withRetryAfter() {
+        let error = CloudBackendError.providerOverloaded(provider: "Claude", retryAfter: 15)
+        let description = error.errorDescription ?? ""
+        XCTAssertTrue(description.contains("Claude"),
+                      "providerOverloaded should mention the provider: \(description)")
+        XCTAssertTrue(description.contains("15"),
+                      "providerOverloaded should include the retry delay: \(description)")
+    }
+
+    func test_providerOverloaded_description_withoutRetryAfter() {
+        let error = CloudBackendError.providerOverloaded(provider: "Claude", retryAfter: nil)
+        let description = error.errorDescription ?? ""
+        XCTAssertFalse(description.isEmpty,
+                       "providerOverloaded should have a description even without retryAfter")
+    }
+
+    func test_providerOverloaded_isRetryable() {
+        // Provider at capacity is transient — exponential backoff should help.
+        // Sabotage check: removing providerOverloaded from the retryable arm flips this.
+        XCTAssertTrue(CloudBackendError.providerOverloaded(provider: "Claude", retryAfter: nil).isRetryable,
+                      "providerOverloaded must be retryable — capacity issues are transient")
+    }
+
+    func test_contentFiltered_description_withReason() {
+        let error = CloudBackendError.contentFiltered(provider: "Claude", reason: "violence")
+        let description = error.errorDescription ?? ""
+        XCTAssertTrue(description.contains("Claude"),
+                      "contentFiltered should mention the provider: \(description)")
+        XCTAssertTrue(description.contains("violence"),
+                      "contentFiltered should include the reason: \(description)")
+    }
+
+    func test_contentFiltered_description_withoutReason() {
+        let error = CloudBackendError.contentFiltered(provider: "OpenAI", reason: nil)
+        let description = error.errorDescription ?? ""
+        XCTAssertTrue(description.contains("OpenAI"),
+                      "contentFiltered should mention the provider when no reason: \(description)")
+    }
+
+    func test_contentFiltered_isNotRetryable() {
+        // Content must change for the request to succeed — retrying the same prompt won't help.
+        // Sabotage check: adding contentFiltered to the retryable arm flips this.
+        XCTAssertFalse(CloudBackendError.contentFiltered(provider: "Claude", reason: nil).isRetryable,
+                       "contentFiltered must not be retryable — content must change")
+    }
+
+    // MARK: - CategorizedError conformance
+
+    func test_category_rateLimited_passesRetryAfter() {
+        let error = CloudBackendError.rateLimited(retryAfter: 30)
+        XCTAssertEqual(error.category, .rateLimited(retryAfter: 30),
+                       "rateLimited category must preserve the retryAfter value")
+    }
+
+    func test_category_rateLimited_nilRetryAfter() {
+        let error = CloudBackendError.rateLimited(retryAfter: nil)
+        XCTAssertEqual(error.category, .rateLimited(retryAfter: nil))
+    }
+
+    func test_category_quotaExceeded() {
+        let error = CloudBackendError.quotaExceeded(provider: "Claude")
+        XCTAssertEqual(error.category, .quotaExceeded)
+    }
+
+    func test_category_providerOverloaded_passesRetryAfter() {
+        let error = CloudBackendError.providerOverloaded(provider: "Claude", retryAfter: nil)
+        XCTAssertEqual(error.category, .providerOverloaded(retryAfter: nil),
+                       "providerOverloaded category must preserve the retryAfter value")
+    }
+
+    func test_category_authenticationFailed() {
+        XCTAssertEqual(CloudBackendError.authenticationFailed(provider: "Claude").category, .authenticationFailed)
+        XCTAssertEqual(CloudBackendError.missingAPIKey.category, .authenticationFailed)
+    }
+
+    func test_category_contentFiltered() {
+        let error = CloudBackendError.contentFiltered(provider: "Claude", reason: nil)
+        XCTAssertEqual(error.category, .contentFiltered)
+    }
+
+    func test_category_networkErrors_areRetryableTransient() {
+        XCTAssertEqual(CloudBackendError.networkError(underlying: URLError(.notConnectedToInternet)).category, .retryableTransient)
+        XCTAssertEqual(CloudBackendError.streamInterrupted.category, .retryableTransient)
+        XCTAssertEqual(CloudBackendError.timeout(.seconds(30)).category, .retryableTransient)
+    }
+
+    func test_category_5xxServerError_isRetryableTransient() {
+        XCTAssertEqual(CloudBackendError.serverError(statusCode: 503, message: "unavailable").category, .retryableTransient)
+    }
+
+    func test_category_4xxServerError_isNonRetryable() {
+        XCTAssertEqual(CloudBackendError.serverError(statusCode: 400, message: "bad request").category, .nonRetryable)
+    }
 }

--- a/Tests/ManifoldInferenceTests/ErrorDescriptionTests.swift
+++ b/Tests/ManifoldInferenceTests/ErrorDescriptionTests.swift
@@ -120,4 +120,59 @@ final class ErrorDescriptionTests: XCTestCase {
         // The cast succeeds if CloudBackendError conforms to BackendError.
         XCTAssertTrue(error is CloudBackendError)
     }
+
+    // MARK: - InferenceErrorCategory (InferenceError)
+
+    func test_inferenceError_contextExhausted_category_isContextExceeded() {
+        let error = InferenceError.contextExhausted(promptTokens: 1000, maxOutputTokens: 100, contextSize: 512)
+        XCTAssertEqual(error.category, .contextExceeded,
+                       "contextExhausted must map to .contextExceeded — callers branch on this to offer compression")
+    }
+
+    func test_inferenceError_unsupportedModelArchitecture_category_isUnsupportedRequest() {
+        let error = InferenceError.unsupportedModelArchitecture("clip")
+        XCTAssertEqual(error.category, .unsupportedRequest)
+    }
+
+    func test_inferenceError_unsupportedGrammar_category_isUnsupportedRequest() {
+        let error = InferenceError.unsupportedGrammar(reason: "backend lacks GBNF support")
+        XCTAssertEqual(error.category, .unsupportedRequest)
+    }
+
+    func test_inferenceError_noBackendSatisfiesRequirements_category_isUnsupportedRequest() {
+        let error = InferenceError.noBackendSatisfiesRequirements([.toolCalling])
+        XCTAssertEqual(error.category, .unsupportedRequest)
+    }
+
+    func test_inferenceError_alreadyGenerating_category_isRetryableTransient() {
+        // The caller can wait for the active generation to finish and retry.
+        // Sabotage check: moving alreadyGenerating to .nonRetryable flips this.
+        XCTAssertEqual(InferenceError.alreadyGenerating.category, .retryableTransient,
+                       "alreadyGenerating must be retryableTransient — the caller should wait and retry")
+    }
+
+    func test_inferenceError_permanentErrors_category_isNonRetryable() {
+        let permanentErrors: [InferenceError] = [
+            .modelNotFound(path: "/missing.gguf"),
+            .modelLoadFailed(underlying: NSError(domain: "test", code: 1)),
+            .inferenceFailure("crash"),
+            .memoryInsufficient(required: 8_589_934_592, available: 0),
+            .generationError("decode error"),
+        ]
+        for error in permanentErrors {
+            XCTAssertEqual(error.category, .nonRetryable,
+                           "\(error) must map to .nonRetryable")
+        }
+    }
+
+    func test_inferenceError_conformsToCategorizedError() {
+        // Protocol conformance is verified via protocol existential.
+        let error: any CategorizedError = InferenceError.alreadyGenerating
+        XCTAssertNotNil(error.category as InferenceErrorCategory?)
+    }
+
+    func test_cloudBackendError_conformsToCategorizedError() {
+        let error: any CategorizedError = CloudBackendError.missingAPIKey
+        XCTAssertNotNil(error.category as InferenceErrorCategory?)
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `InferenceErrorCategory` enum and `CategorizedError` protocol to ManifoldInference
- Conforms both `InferenceError` and `CloudBackendError` to `CategorizedError`
- Adds `quotaExceeded`, `providerOverloaded`, and `contentFiltered` cases to `CloudBackendError`
- Routes Claude HTTP 529 to `.providerOverloaded` instead of the generic `serverError` bucket

Closes #1206

## Test plan

- [ ] `InferenceError.contextExhausted` → `.contextExceeded` category
- [ ] `CloudBackendError.rateLimited` → `.rateLimited` category with retryAfter passthrough
- [ ] `CloudBackendError.providerOverloaded` → `.providerOverloaded` category
- [ ] `ClaudeBackend` throws `.providerOverloaded` on HTTP 529
- [ ] `quotaExceeded.isRetryable == false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)