### PR TITLE
feat(cloud): set Anthropic prompt-cache breakpoints in ClaudeBackend

### DIFF
--- a/Sources/ManifoldCloud/ClaudeBackend.swift
+++ b/Sources/ManifoldCloud/ClaudeBackend.swift
@@ -30,6 +30,21 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         )
     }
 
+    // MARK: - Prompt Cache Policy
+
+    private var _cachePolicy: PromptCachePolicy = .automatic
+
+    /// Controls whether Anthropic prompt-cache breakpoints are inserted into
+    /// outbound requests. Defaults to `.automatic`, which tags the system
+    /// prompt block and the last tool definition with
+    /// `cache_control: {type: "ephemeral"}` — reducing repeat-turn input costs
+    /// by 4–10× for large system prompts or tool catalogs. Set to `.disabled`
+    /// to restore pre-0.25.0 behaviour.
+    public var cachePolicy: PromptCachePolicy {
+        get { withStateLock { _cachePolicy } }
+        set { withStateLock { _cachePolicy = newValue } }
+    }
+
     // MARK: - Structured History
 
     /// Structured replay history. Set by the coordinator when the caller
@@ -240,8 +255,25 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             "top_p": config.topP
         ]
 
+        // Snapshot cache policy under the lock once so the rest of the build
+        // is consistent even if another thread toggles it concurrently.
+        let resolvedCachePolicy = withStateLock { _cachePolicy }
+
         if let systemPrompt, !systemPrompt.isEmpty {
-            body["system"] = systemPrompt
+            if resolvedCachePolicy == .automatic {
+                // Emit as a single-element content-block array so Anthropic can
+                // cache the entire prefix up to and including this block. The
+                // plain-string form has no slot for cache_control.
+                body["system"] = [
+                    [
+                        "type": "text",
+                        "text": systemPrompt,
+                        "cache_control": ["type": "ephemeral"],
+                    ] as [String: Any]
+                ]
+            } else {
+                body["system"] = systemPrompt
+            }
         }
 
         // Enable extended thinking when the caller asked for a thinking budget.
@@ -264,7 +296,16 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         // Anthropic's side; the framework-level `.none` suppresses the
         // tools field entirely so the model has nothing to call.
         if !config.tools.isEmpty, config.toolChoice != .none {
-            body["tools"] = config.tools.map(ClaudeMessageEncoder.encodeToolDefinition)
+            var toolEntries = config.tools.map(ClaudeMessageEncoder.encodeToolDefinition)
+            // Tag the last tool entry with cache_control when automatic so
+            // Anthropic caches the entire system+tools prefix. The breakpoint
+            // applies to the last block in the tagged sequence — tagging every
+            // entry would create redundant breakpoints and potentially conflict
+            // with the system-prompt breakpoint already set above.
+            if resolvedCachePolicy == .automatic, !toolEntries.isEmpty {
+                toolEntries[toolEntries.count - 1]["cache_control"] = ["type": "ephemeral"]
+            }
+            body["tools"] = toolEntries
             switch config.toolChoice {
             case .auto:
                 // Anthropic defaults to auto when tool_choice is omitted.
@@ -442,6 +483,15 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
                        let completion = usage.completionTokens {
                         continuation.yield(.usage(prompt: prompt, completion: completion))
                     }
+                }
+
+                // Log prompt-cache activity from the message_start event so
+                // operators can verify that breakpoints are being hit without
+                // needing a structured extension to TokenUsage.
+                if let cacheUsage = ClaudePayloadParser.parseCacheUsage(from: payload) {
+                    Log.inference.debug(
+                        "Claude prompt cache: creation=\(cacheUsage.cacheCreationInputTokens) read=\(cacheUsage.cacheReadInputTokens)"
+                    )
                 }
 
                 if isStreamEnd(payload) {

--- a/Sources/ManifoldCloud/ClaudePayloadParser.swift
+++ b/Sources/ManifoldCloud/ClaudePayloadParser.swift
@@ -126,6 +126,11 @@ enum ClaudePayloadParser {
         return type == "message_stop"
     }
 
+    struct CacheUsage {
+        let cacheCreationInputTokens: Int
+        let cacheReadInputTokens: Int
+    }
+
     static func parseUsage(from json: String) -> (promptTokens: Int?, completionTokens: Int?)? {
         guard let parsed = parseObject(json),
               let type = parsed["type"] as? String else {
@@ -149,6 +154,26 @@ enum ClaudePayloadParser {
         default:
             return nil
         }
+    }
+
+    /// Parses Anthropic prompt-cache token counts from a `message_start` payload.
+    ///
+    /// Both fields default to 0 when absent — an absent field means no cache
+    /// activity occurred, not a parse failure, so we treat them as optional
+    /// with a zero fallback rather than nil-gating the whole result.
+    static func parseCacheUsage(from json: String) -> CacheUsage? {
+        guard let parsed = parseObject(json),
+              parsed["type"] as? String == "message_start",
+              let message = parsed["message"] as? [String: Any],
+              let usage = message["usage"] as? [String: Any] else {
+            return nil
+        }
+        let creation = usage["cache_creation_input_tokens"] as? Int ?? 0
+        let read = usage["cache_read_input_tokens"] as? Int ?? 0
+        // Only materialise a CacheUsage when there is actual cache activity to
+        // report — avoids a debug log on every non-cached turn.
+        guard creation > 0 || read > 0 else { return nil }
+        return CacheUsage(cacheCreationInputTokens: creation, cacheReadInputTokens: read)
     }
 
     static func parseStreamError(from json: String) -> CloudBackendError? {

--- a/Sources/ManifoldCloudCore/PromptCachePolicy.swift
+++ b/Sources/ManifoldCloudCore/PromptCachePolicy.swift
@@ -1,0 +1,15 @@
+/// Controls whether Anthropic prompt-cache breakpoints are emitted in outbound requests.
+///
+/// Anthropic charges full input-token rates on every turn unless blocks are
+/// tagged with `cache_control: {type: "ephemeral"}`. Enabling caching here
+/// inserts those markers at the system-prompt block and the last tool definition
+/// so the prefix is priced at cache-read rates on subsequent turns — typically
+/// a 4–10× cost reduction for conversations with large system prompts or tool
+/// catalogs. See https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching.
+public enum PromptCachePolicy: Sendable {
+    /// No `cache_control` markers emitted. Matches pre-0.25.0 behaviour.
+    case disabled
+    /// Tag the system prompt block and the last tool definition with
+    /// `cache_control: {type: "ephemeral"}`. Default for ``ClaudeBackend``.
+    case automatic
+}

--- a/Tests/ManifoldBackendsTests/ClaudePromptCacheTests.swift
+++ b/Tests/ManifoldBackendsTests/ClaudePromptCacheTests.swift
@@ -1,0 +1,291 @@
+#if CloudSaaS
+import XCTest
+import Foundation
+@testable import ManifoldBackends
+@testable import ManifoldCloud
+@testable import ManifoldCloudCore
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+/// Tests for ``ClaudeBackend`` prompt-cache breakpoint emission.
+///
+/// Covers #1205: system prompt serialised as an array content block with
+/// `cache_control` when `cachePolicy == .automatic`, plain string when
+/// `.disabled`, and the last tool definition tagged when tools are present.
+@MainActor
+final class ClaudePromptCacheTests: XCTestCase {
+
+    private var mockURL: URL!
+    private var messagesURL: URL!
+    private var session: URLSession!
+
+    override func setUp() {
+        super.setUp()
+        mockURL = URL(string: "https://claude-cache-\(UUID().uuidString).test")!
+        messagesURL = mockURL.appendingPathComponent("v1/messages")
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        session = URLSession(configuration: config)
+    }
+
+    override func tearDown() {
+        if let url = messagesURL {
+            MockURLProtocol.unstub(url: url)
+        }
+        session = nil
+        mockURL = nil
+        messagesURL = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeBackend(cachePolicy: PromptCachePolicy = .automatic) -> ClaudeBackend {
+        let backend = ClaudeBackend(urlSession: session)
+        backend.configure(baseURL: mockURL, apiKey: "sk-ant-test", modelName: "claude-sonnet-4-20250514")
+        backend.cachePolicy = cachePolicy
+        return backend
+    }
+
+    private func stubMessageStop() {
+        let chunk = Data("data: {\"type\":\"message_stop\"}\n\n".utf8)
+        MockURLProtocol.stub(url: messagesURL, response: .sse(chunks: [chunk], statusCode: 200))
+    }
+
+    /// Fires a minimal generate() and returns the captured request body as JSON.
+    private func captureRequestBody(
+        backend: ClaudeBackend,
+        systemPrompt: String?,
+        config: GenerationConfig = GenerationConfig()
+    ) async throws -> [String: Any] {
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+        stubMessageStop()
+
+        let stream = try backend.generate(prompt: "hi", systemPrompt: systemPrompt, config: config)
+        for try await _ in stream.events { }
+
+        let captured = MockURLProtocol.capturedRequests.last(where: { $0.url?.host == mockURL.host })
+        let data: Data
+        if let direct = captured?.httpBody {
+            data = direct
+        } else if let bodyStream = captured?.httpBodyStream {
+            var buf = Data()
+            bodyStream.open()
+            let ptr = UnsafeMutablePointer<UInt8>.allocate(capacity: 4096)
+            defer { ptr.deallocate() }
+            while bodyStream.hasBytesAvailable {
+                let n = bodyStream.read(ptr, maxLength: 4096)
+                if n > 0 { buf.append(ptr, count: n) }
+            }
+            bodyStream.close()
+            data = buf
+        } else {
+            XCTFail("No request body captured")
+            return [:]
+        }
+        return try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    // MARK: - System prompt as array block (automatic)
+
+    /// With `.automatic`, `system` must be an array containing a single text
+    /// block with `cache_control: {type: "ephemeral"}`.
+    ///
+    /// Sabotage check: change `resolvedCachePolicy == .automatic` to `false`
+    /// in `ClaudeBackend.buildRequest`; the system field will be a plain String
+    /// and this test fails on the `XCTAssertNotNil(blocks)` assertion.
+    func test_systemPrompt_automatic_emitsArrayBlockWithCacheControl() async throws {
+        let backend = makeBackend(cachePolicy: .automatic)
+        let json = try await captureRequestBody(backend: backend, systemPrompt: "You are helpful.")
+
+        let blocks = json["system"] as? [[String: Any]]
+        XCTAssertNotNil(blocks, "system must be an array of content blocks when cachePolicy is .automatic")
+        XCTAssertEqual(blocks?.count, 1)
+
+        let block = try XCTUnwrap(blocks?.first)
+        XCTAssertEqual(block["type"] as? String, "text")
+        XCTAssertEqual(block["text"] as? String, "You are helpful.")
+
+        let cacheControl = try XCTUnwrap(block["cache_control"] as? [String: Any])
+        XCTAssertEqual(cacheControl["type"] as? String, "ephemeral")
+    }
+
+    // MARK: - System prompt as plain string (disabled)
+
+    /// With `.disabled`, `system` must remain a plain String — no content
+    /// blocks, no `cache_control` — preserving pre-0.25.0 wire behaviour.
+    ///
+    /// Sabotage check: set `cachePolicy = .automatic` in the test; the
+    /// assertion on `json["system"] as? String` will return nil and fail.
+    func test_systemPrompt_disabled_emitsPlainString() async throws {
+        let backend = makeBackend(cachePolicy: .disabled)
+        let json = try await captureRequestBody(backend: backend, systemPrompt: "You are helpful.")
+
+        let systemString = json["system"] as? String
+        XCTAssertEqual(systemString, "You are helpful.",
+                       "system must be a plain String when cachePolicy is .disabled")
+        XCTAssertNil(json["system"] as? [[String: Any]],
+                     "system must NOT be a block array when cachePolicy is .disabled")
+    }
+
+    // MARK: - Empty system prompt omitted
+
+    /// A nil or empty system prompt must not emit a `system` field regardless
+    /// of cache policy — the Anthropic API treats an absent system as "no
+    /// system prompt" and both nil and empty are equivalent to the caller.
+    func test_systemPrompt_nil_omitsSystemField() async throws {
+        let backend = makeBackend(cachePolicy: .automatic)
+        let json = try await captureRequestBody(backend: backend, systemPrompt: nil)
+        XCTAssertNil(json["system"], "system field must be absent when systemPrompt is nil")
+    }
+
+    func test_systemPrompt_empty_omitsSystemField() async throws {
+        let backend = makeBackend(cachePolicy: .automatic)
+        let json = try await captureRequestBody(backend: backend, systemPrompt: "")
+        XCTAssertNil(json["system"], "system field must be absent when systemPrompt is empty")
+    }
+
+    // MARK: - Tool catalog last-entry tagging (automatic)
+
+    /// With `.automatic` and a non-empty tool list, the last entry in the
+    /// `tools[]` array must carry `cache_control: {type: "ephemeral"}`.
+    /// Earlier entries must not be tagged — Anthropic caches everything up to
+    /// and including the last tagged block, so tagging every entry would create
+    /// redundant breakpoints.
+    ///
+    /// Sabotage check: remove the `toolEntries[toolEntries.count - 1]["cache_control"]`
+    /// assignment in `ClaudeBackend.buildRequest`; the last tool will lack
+    /// `cache_control` and the assertion fails.
+    func test_tools_automatic_tagsLastToolWithCacheControl() async throws {
+        let backend = makeBackend(cachePolicy: .automatic)
+
+        var cfg = GenerationConfig()
+        cfg.tools = [
+            ToolDefinition(name: "search", description: "Web search", parameters: .init(properties: [:], required: [])),
+            ToolDefinition(name: "calculator", description: "Do math", parameters: .init(properties: [:], required: [])),
+        ]
+        cfg.toolChoice = .auto
+
+        let json = try await captureRequestBody(backend: backend, systemPrompt: nil, config: cfg)
+        let tools = try XCTUnwrap(json["tools"] as? [[String: Any]])
+        XCTAssertEqual(tools.count, 2)
+
+        // First tool must NOT have cache_control.
+        XCTAssertNil(tools[0]["cache_control"],
+                     "Only the last tool should be tagged; first tool must have no cache_control")
+
+        // Last tool must have cache_control: {type: "ephemeral"}.
+        let lastCC = try XCTUnwrap(tools[1]["cache_control"] as? [String: Any])
+        XCTAssertEqual(lastCC["type"] as? String, "ephemeral")
+    }
+
+    // MARK: - Tool catalog with disabled policy
+
+    /// With `.disabled`, no tool entry should carry `cache_control`.
+    func test_tools_disabled_noToolTagged() async throws {
+        let backend = makeBackend(cachePolicy: .disabled)
+
+        var cfg = GenerationConfig()
+        cfg.tools = [
+            ToolDefinition(name: "search", description: "Web search", parameters: .init(properties: [:], required: [])),
+        ]
+        cfg.toolChoice = .auto
+
+        let json = try await captureRequestBody(backend: backend, systemPrompt: nil, config: cfg)
+        let tools = try XCTUnwrap(json["tools"] as? [[String: Any]])
+        for (i, tool) in tools.enumerated() {
+            XCTAssertNil(tool["cache_control"],
+                         "Tool at index \(i) must not have cache_control when cachePolicy is .disabled")
+        }
+    }
+
+    // MARK: - Single-tool list tagging
+
+    /// Edge case: a single tool must be tagged when policy is automatic.
+    func test_tools_automatic_singleTool_isTagged() async throws {
+        let backend = makeBackend(cachePolicy: .automatic)
+
+        var cfg = GenerationConfig()
+        cfg.tools = [
+            ToolDefinition(name: "ping", description: "Ping", parameters: .init(properties: [:], required: [])),
+        ]
+        cfg.toolChoice = .auto
+
+        let json = try await captureRequestBody(backend: backend, systemPrompt: nil, config: cfg)
+        let tools = try XCTUnwrap(json["tools"] as? [[String: Any]])
+        XCTAssertEqual(tools.count, 1)
+        let cc = try XCTUnwrap(tools[0]["cache_control"] as? [String: Any])
+        XCTAssertEqual(cc["type"] as? String, "ephemeral")
+    }
+
+    // MARK: - Default policy is .automatic
+
+    /// Verify ClaudeBackend ships with .automatic as the default so all users
+    /// get the cost reduction without opting in.
+    func test_defaultCachePolicy_isAutomatic() {
+        let backend = ClaudeBackend(urlSession: session)
+        if case .automatic = backend.cachePolicy {
+            // Expected
+        } else {
+            XCTFail("Default cachePolicy must be .automatic, got \(backend.cachePolicy)")
+        }
+    }
+}
+
+// MARK: - ClaudePayloadParser cache usage parsing tests
+
+final class ClaudePayloadParserCacheUsageTests: XCTestCase {
+
+    func test_parseCacheUsage_messageStart_withBothFields_returnsCacheUsage() {
+        let payload = """
+        {"type":"message_start","message":{"usage":{"input_tokens":25,"cache_creation_input_tokens":2200,"cache_read_input_tokens":0}}}
+        """
+        // cache_read = 0 with creation > 0 → should still return a CacheUsage
+        // (creation is the signal that caching is active)
+        let usage = ClaudePayloadParser.parseCacheUsage(from: payload)
+        XCTAssertNotNil(usage)
+        XCTAssertEqual(usage?.cacheCreationInputTokens, 2200)
+        XCTAssertEqual(usage?.cacheReadInputTokens, 0)
+    }
+
+    func test_parseCacheUsage_messageStart_readHit_returnsCacheUsage() {
+        let payload = """
+        {"type":"message_start","message":{"usage":{"input_tokens":25,"cache_creation_input_tokens":0,"cache_read_input_tokens":2200}}}
+        """
+        let usage = ClaudePayloadParser.parseCacheUsage(from: payload)
+        XCTAssertNotNil(usage)
+        XCTAssertEqual(usage?.cacheCreationInputTokens, 0)
+        XCTAssertEqual(usage?.cacheReadInputTokens, 2200)
+    }
+
+    func test_parseCacheUsage_messageStart_noCacheFields_returnsNil() {
+        // No cache activity → parser must return nil (avoids logging on uncached turns)
+        let payload = """
+        {"type":"message_start","message":{"usage":{"input_tokens":25,"output_tokens":0}}}
+        """
+        XCTAssertNil(ClaudePayloadParser.parseCacheUsage(from: payload))
+    }
+
+    func test_parseCacheUsage_messageDelta_returnsNil() {
+        // Cache counts only live on message_start, not message_delta.
+        let payload = """
+        {"type":"message_delta","usage":{"output_tokens":42}}
+        """
+        XCTAssertNil(ClaudePayloadParser.parseCacheUsage(from: payload))
+    }
+
+    func test_parseCacheUsage_malformed_returnsNil() {
+        XCTAssertNil(ClaudePayloadParser.parseCacheUsage(from: "not json"))
+        XCTAssertNil(ClaudePayloadParser.parseCacheUsage(from: "{}"))
+    }
+
+    func test_parseCacheUsage_bothFieldsZero_returnsNil() {
+        // Zero creation + zero read = no caching occurred — return nil so
+        // we don't emit a pointless log line on every uncached turn.
+        let payload = """
+        {"type":"message_start","message":{"usage":{"input_tokens":25,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+        """
+        XCTAssertNil(ClaudePayloadParser.parseCacheUsage(from: payload))
+    }
+}
+#endif

--- a/Tests/ManifoldBackendsTests/ClaudePromptCacheTests.swift
+++ b/Tests/ManifoldBackendsTests/ClaudePromptCacheTests.swift
@@ -161,8 +161,8 @@ final class ClaudePromptCacheTests: XCTestCase {
 
         var cfg = GenerationConfig()
         cfg.tools = [
-            ToolDefinition(name: "search", description: "Web search", parameters: .init(properties: [:], required: [])),
-            ToolDefinition(name: "calculator", description: "Do math", parameters: .init(properties: [:], required: [])),
+            ToolDefinition(name: "search", description: "Web search", parameters: .object([:])),
+            ToolDefinition(name: "calculator", description: "Do math", parameters: .object([:])),
         ]
         cfg.toolChoice = .auto
 
@@ -187,7 +187,7 @@ final class ClaudePromptCacheTests: XCTestCase {
 
         var cfg = GenerationConfig()
         cfg.tools = [
-            ToolDefinition(name: "search", description: "Web search", parameters: .init(properties: [:], required: [])),
+            ToolDefinition(name: "search", description: "Web search", parameters: .object([:])),
         ]
         cfg.toolChoice = .auto
 
@@ -207,7 +207,7 @@ final class ClaudePromptCacheTests: XCTestCase {
 
         var cfg = GenerationConfig()
         cfg.tools = [
-            ToolDefinition(name: "ping", description: "Ping", parameters: .init(properties: [:], required: [])),
+            ToolDefinition(name: "ping", description: "Ping", parameters: .object([:])),
         ]
         cfg.toolChoice = .auto
 


### PR DESCRIPTION
## Summary

- Emits `system` as an Anthropic content block array with `cache_control: {type: "ephemeral"}` when `cachePolicy == .automatic`
- Tags the last tool definition with `cache_control` when tools are present
- Parses `cache_creation_input_tokens` + `cache_read_input_tokens` from `message_start` usage and logs at debug level
- Adds `PromptCachePolicy` enum in `ManifoldCloudCore` (`.automatic` default / `.disabled` for pre-0.25.0 behaviour)

Closes #1205

## Test plan

- [x] System prompt emitted as array block with cache_control when `.automatic`
- [x] System prompt emitted as plain string when `.disabled` or empty
- [x] Last tool definition tagged with cache_control when tools present and policy is `.automatic`
- [x] No tool tagged when policy is `.disabled`
- [x] Cache token counts parsed from `message_start` payload (nil returned when both fields are zero, avoiding log noise on uncached turns)
- [x] Full XCTest CI suite: 1,711 passed, 0 failed
- [x] Trait-combo build (`MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace`): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)