### PR TITLE
fix: close three P0 security holes in SSRF guard, GGUF parser, and OAuth DCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ for the full list of dependency rules the lint enforces.
 ### 1. Add the package
 
 ```swift
-.package(url: "https://github.com/roryford/ManifoldKit.git", from: "0.23.0")
+.package(url: "https://github.com/roryford/ManifoldKit.git", from: "0.24.0")
 ```
 
 Most apps add a single product — the `ManifoldKit` umbrella, which re-exports
@@ -173,7 +173,7 @@ Pass the matching set as `traits:` on your `.package(...)` entry to lock the con
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.23.0",
+    from: "0.24.0",
     traits: [
         .trait(name: "MLX"),
         .trait(name: "Llama"),
@@ -199,7 +199,7 @@ Apple Foundation Models.
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.23.0",
+    from: "0.24.0",
     traits: ["FoundationOnly"]   // overrides the MLX/Llama/HuggingFace defaults
 )
 ```
@@ -216,7 +216,7 @@ Equivalent legacy form (still supported, before the named trait existed):
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.23.0",
+    from: "0.24.0",
     traits: []   // disables MLX, Llama, HuggingFace defaults
 )
 ```
@@ -237,7 +237,7 @@ For example, a cloud-only consumer can keep the chat UI and local-model loaders 
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.23.0",
+    from: "0.24.0",
     traits: [
         .trait(name: "MLX"),
         .trait(name: "Llama"),
@@ -285,7 +285,7 @@ If you already depend on `ManifoldBackends`, the same data is also available via
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.23.0",
+    from: "0.24.0",
     traits: [
         .trait(name: "MCP"),
         .trait(name: "MCPBuiltinCatalog"), // optional: only if you use MCPCatalog
@@ -325,7 +325,7 @@ stock `ChatInputBar`.
 ```swift
  .package(
      url: "https://github.com/roryford/ManifoldKit.git",
-     from: "0.23.0",
+     from: "0.24.0",
      traits: [
          .trait(name: "Voice"),
      ]
@@ -401,7 +401,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/roryford/ManifoldKit.git",
-            from: "0.23.0",
+            from: "0.24.0",
             traits: [
                 .trait(name: "MLX"),
                 .trait(name: "Llama"),
@@ -1008,7 +1008,7 @@ open ManifoldDemo.xcodeproj
 
 This package was renamed from `BaseChatKit` to `ManifoldKit` in v0.20. The old GitHub URL `github.com/roryford/BaseChatKit` redirects to `roryford/ManifoldKit`, but for clarity:
 
-- Update SPM dependencies: `.package(url: "https://github.com/roryford/ManifoldKit.git", from: "0.23.0")`
+- Update SPM dependencies: `.package(url: "https://github.com/roryford/ManifoldKit.git", from: "0.24.0")`
 - Update imports: `import BaseChatKit` → `import ManifoldKit` (and similarly for sub-modules — `BaseChatInference` → `ManifoldInference`, etc.)
 - Renamed public types: `BaseChatBootstrap` → `ManifoldBootstrap`, `BaseChatConfiguration` → `ManifoldConfiguration`, `BaseChatSchemaV3/4/5` → `ManifoldSchemaV3/4/5`, `BaseChatMigrationPlan` → `ManifoldMigrationPlan`, `BaseChatBackgroundTaskIdentifiers` → `ManifoldBackgroundTaskIdentifiers`
 - **BREAKING — local SwiftData stores reset.** SwiftData persists fully-qualified `@Model` type names; renaming the schema namespace orphans existing on-disk stores. Apps upgrading from 0.19.x will create fresh databases on first launch. We chose this clean break over preserving data with `@Model.originalName` because v0.20 is pre-1.0.

--- a/Sources/ManifoldInference/Services/GGUFMetadataReader.swift
+++ b/Sources/ManifoldInference/Services/GGUFMetadataReader.swift
@@ -371,11 +371,19 @@ struct GGUFMetadataReader {
 
     // MARK: - Value Skipping
 
+    /// Maximum nesting depth for GGUF array values. Bounds `skipValue` recursion to
+    /// prevent stack overflow from crafted files with deeply nested arrays.
+    private static let maxArrayDepth = 32
+
+    /// Maximum element count for a single GGUF array. Bounds the inner loop to
+    /// prevent spin-loops from crafted files with huge declared array counts.
+    private static let maxArrayElementCount: UInt64 = 65_536
+
     /// Skips a value of the given type without parsing it.
     ///
-    /// For arrays, recursively skips each element. For strings, reads the length prefix
-    /// and skips that many bytes.
-    private static func skipValue(type: UInt32, from handle: FileHandle) throws {
+    /// For arrays, recursively skips each element up to ``maxArrayDepth`` nesting
+    /// levels and ``maxArrayElementCount`` elements per array.
+    private static func skipValue(type: UInt32, from handle: FileHandle, depth: Int = 0) throws {
         guard let valueType = ValueType(rawValue: type) else {
             throw GGUFReaderError.readError("Unknown value type: \(type)")
         }
@@ -397,10 +405,16 @@ struct GGUFMetadataReader {
             _ = try readString(from: handle)
 
         case .array:
+            guard depth < maxArrayDepth else {
+                throw GGUFReaderError.readError("Array nesting depth exceeds safety limit (\(maxArrayDepth))")
+            }
             let elementType = try readUInt32(from: handle)
             let count = try readUInt64(from: handle)
+            guard count <= maxArrayElementCount else {
+                throw GGUFReaderError.readError("Array element count \(count) exceeds safety limit (\(maxArrayElementCount))")
+            }
             for _ in 0..<count {
-                try skipValue(type: elementType, from: handle)
+                try skipValue(type: elementType, from: handle, depth: depth + 1)
             }
         }
     }

--- a/Sources/ManifoldMCP/MCPOAuth.swift
+++ b/Sources/ManifoldMCP/MCPOAuth.swift
@@ -119,10 +119,12 @@ public actor MCPOAuthAuthorization: MCPAuthorization {
             request.httpMethod = "DELETE"
             request.setValue("Bearer \(managementToken)", forHTTPHeaderField: "Authorization")
             request.timeoutInterval = 5
+            // Management URI is a fixed endpoint — redirects are not expected and would be
+            // a sign of misconfiguration or a hostile network. Allow zero.
             _ = try await sessionProvider().data(
                 for: request,
                 delegate: MCPRedirectCapDelegate(
-                    maxRedirects: nil,
+                    maxRedirects: 0,
                     validator: MCPSSRFPolicy.validateOAuthRedirectURL
                 )
             )
@@ -459,12 +461,25 @@ public actor MCPOAuthAuthorization: MCPAuthorization {
             cachedRegisteredClientID = parsed.clientID
 
             // RFC 7592 — persist management credentials if provided (D12).
+            // Validate both the URI (SSRF) and token (bearer-safe chars) at storage time so
+            // disconnect() never operates on untrusted values even if its own check is bypassed.
             if let token = parsed.registrationAccessToken,
                let uriString = parsed.registrationClientURI,
                let uri = URL(string: uriString) {
-                registrationManagementToken = token
-                registrationManagementURI = uri
-                Log.inference.info("MCPOAuthAuthorization: RFC 7592 management token stored for \(self.serverID)")
+                do {
+                    try await MCPSSRFPolicy.validateOAuthRequestURL(uri, label: "registration management URI")
+                    let invalidScalars = CharacterSet.controlCharacters
+                        .union(.newlines)
+                        .union(.whitespacesAndNewlines)
+                    guard !token.unicodeScalars.contains(where: { invalidScalars.contains($0) }) else {
+                        throw MCPError.dcrFailed("registration_access_token contains invalid bearer characters")
+                    }
+                    registrationManagementToken = token
+                    registrationManagementURI = uri
+                    Log.inference.info("MCPOAuthAuthorization: RFC 7592 management token stored for \(self.serverID)")
+                } catch {
+                    Log.inference.warning("MCPOAuthAuthorization: RFC 7592 management credentials rejected (\(error.localizedDescription)); client deregistration will be skipped")
+                }
             }
 
             return parsed.clientID

--- a/Sources/ManifoldMCP/MCPSSRFPolicy.swift
+++ b/Sources/ManifoldMCP/MCPSSRFPolicy.swift
@@ -5,7 +5,8 @@ import ManifoldInference
 // MARK: - MCPSSRFPolicy
 
 internal enum MCPSSRFPolicy {
-    nonisolated(unsafe) static var _resolverForTesting: ((String) async -> [String])? = nil
+    nonisolated(unsafe) static var _resolverForTesting: ((String) async -> [String]?)? = nil
+    nonisolated(unsafe) static var _synchronousResolverForTesting: ((String) -> [String]?)? = nil
 
     static func validateTransportURL(_ url: URL) throws {
         guard let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" else {
@@ -76,7 +77,12 @@ internal enum MCPSSRFPolicy {
         if PrivateIPClassifier.classifyIPLiteral(host) != nil {
             throw MCPError.ssrfBlocked(url)
         }
-        let addresses = await resolveHostname(host)
+        // Nil means resolution failed. Block rather than fall through — an attacker can
+        // arrange SERVFAIL for the guard's query, then serve a private IP to URLSession's
+        // separate resolver query (TTL-0 / SERVFAIL pattern).
+        guard let addresses = await resolveHostname(host) else {
+            throw MCPError.ssrfBlocked(url)
+        }
         for address in addresses where PrivateIPClassifier.classifyIPLiteral(address) != nil {
             throw MCPError.ssrfBlocked(url)
         }
@@ -90,7 +96,9 @@ internal enum MCPSSRFPolicy {
         if PrivateIPClassifier.classifyIPLiteral(host) != nil {
             throw MCPError.ssrfBlocked(url)
         }
-        let addresses = resolveHostnameSynchronously(host)
+        guard let addresses = resolveHostnameSynchronously(host) else {
+            throw MCPError.ssrfBlocked(url)
+        }
         for address in addresses where PrivateIPClassifier.classifyIPLiteral(address) != nil {
             throw MCPError.ssrfBlocked(url)
         }
@@ -101,7 +109,7 @@ internal enum MCPSSRFPolicy {
         return host.hasSuffix(".") ? String(host.dropLast()) : host
     }
 
-    private static func resolveHostname(_ hostname: String) async -> [String] {
+    private static func resolveHostname(_ hostname: String) async -> [String]? {
         if let override = _resolverForTesting {
             return await override(hostname)
         }
@@ -110,7 +118,11 @@ internal enum MCPSSRFPolicy {
         }.value
     }
 
-    private static func resolveHostnameSynchronously(_ hostname: String) -> [String] {
+    /// Returns `nil` on resolution failure so callers can fail closed.
+    private static func resolveHostnameSynchronously(_ hostname: String) -> [String]? {
+        if let override = _synchronousResolverForTesting {
+            return override(hostname)
+        }
         var hints = addrinfo()
         hints.ai_family = AF_UNSPEC
         hints.ai_socktype = SOCK_STREAM
@@ -120,7 +132,7 @@ internal enum MCPSSRFPolicy {
         defer { freeaddrinfo(result) }
 
         guard getaddrinfo(hostname, nil, &hints, &result) == 0, result != nil else {
-            return []
+            return nil
         }
 
         var addresses: [String] = []

--- a/Tests/ManifoldInferenceTests/GGUFMetadataReaderTests.swift
+++ b/Tests/ManifoldInferenceTests/GGUFMetadataReaderTests.swift
@@ -199,6 +199,40 @@ final class GGUFMetadataReaderTests: XCTestCase {
         XCTAssertTrue(GGUFMetadataReader.isValidGGUF(at: url))
     }
 
+    // MARK: - Security: malformed input bounds
+
+    func test_readMetadata_deeplyNestedArray_throwsBeforeStackOverflow() throws {
+        // A crafted GGUF with 64 levels of nested single-element arrays must be rejected
+        // by the depth limit, not crash the process via stack overflow.
+        let data = makeGGUFV3Header(metadata: [makeNestedArrayKV(key: "k", depth: 64)])
+        let url = try writeTempFile(named: "nested.gguf", data: data)
+
+        XCTAssertThrowsError(try GGUFMetadataReader.readMetadata(from: url)) { error in
+            guard case .readError(let msg) = error as? GGUFReaderError else {
+                XCTFail("Expected readError for deep nesting, got \(error)")
+                return
+            }
+            XCTAssertTrue(msg.contains("depth"), "Error message must mention depth limit, got: \(msg)")
+        }
+        // Sabotage: remove the depth guard from skipValue — readMetadata succeeds instead of
+        // throwing, so the XCTAssertThrowsError assertion fails.
+    }
+
+    func test_readMetadata_arrayExceedingElementLimit_throws() throws {
+        // A crafted GGUF with a single key whose array claims 100 000 elements (all uint8)
+        // must be rejected by the element-count limit.
+        let data = makeGGUFV3Header(metadata: [makeHugeArrayKV(key: "k", count: 100_000)])
+        let url = try writeTempFile(named: "huge-array.gguf", data: data)
+
+        XCTAssertThrowsError(try GGUFMetadataReader.readMetadata(from: url)) { error in
+            guard case .readError(let msg) = error as? GGUFReaderError else {
+                XCTFail("Expected readError for oversized array, got \(error)")
+                return
+            }
+            XCTAssertTrue(msg.contains("element count"), "Error message must mention element count, got: \(msg)")
+        }
+    }
+
     func test_isValidGGUF_invalidFile_returnsFalse() throws {
         let data = Data(repeating: 0, count: 64)
         let url = try writeTempFile(named: "invalid.gguf", data: data)
@@ -278,6 +312,44 @@ final class GGUFMetadataReaderTests: XCTestCase {
         // Value
         appendUInt32(&data, value)
         return data
+    }
+
+    /// Builds a KV pair whose value is `depth` levels of nested single-element arrays
+    /// terminating in a uint8. Used to exercise the recursion depth limit in `skipValue`.
+    private func makeNestedArrayKV(key: String, depth: Int) -> Data {
+        var data = Data()
+        let keyBytes = Array(key.utf8)
+        appendUInt64(&data, UInt64(keyBytes.count))
+        data.append(contentsOf: keyBytes)
+        // Value type: ARRAY = 9
+        appendUInt32(&data, 9)
+        // Build nested arrays: each level wraps one element of type ARRAY (9), except
+        // the innermost which contains one uint8 (type 0).
+        for level in 0..<depth {
+            let innerType: UInt32 = level == depth - 1 ? 0 : 9  // innermost = uint8
+            appendUInt32(&data, innerType)   // element type
+            appendUInt64(&data, 1)           // count = 1
+        }
+        appendUInt8(&data, 0)               // the single innermost uint8 value
+        return data
+    }
+
+    /// Builds a KV pair whose value is a uint8 array declaring `count` elements but
+    /// providing no actual data. Used to exercise the element-count safety limit.
+    private func makeHugeArrayKV(key: String, count: UInt64) -> Data {
+        var data = Data()
+        let keyBytes = Array(key.utf8)
+        appendUInt64(&data, UInt64(keyBytes.count))
+        data.append(contentsOf: keyBytes)
+        // Value type: ARRAY = 9
+        appendUInt32(&data, 9)
+        appendUInt32(&data, 0)              // element type: uint8
+        appendUInt64(&data, count)          // declared count (no actual bytes follow)
+        return data
+    }
+
+    private func appendUInt8(_ data: inout Data, _ value: UInt8) {
+        data.append(value)
     }
 
     private func appendUInt32(_ data: inout Data, _ value: UInt32) {

--- a/Tests/ManifoldMCPTests/MCPHardeningTests.swift
+++ b/Tests/ManifoldMCPTests/MCPHardeningTests.swift
@@ -8,6 +8,7 @@ final class MCPHardeningTests: XCTestCase {
     override func tearDown() {
         MockURLProtocol.reset()
         MCPSSRFPolicy._resolverForTesting = nil
+        MCPSSRFPolicy._synchronousResolverForTesting = nil
         super.tearDown()
     }
 
@@ -143,6 +144,55 @@ final class MCPHardeningTests: XCTestCase {
                 return
             }
             XCTAssertEqual(blockedURL.host, "token.example.com")
+        }
+    }
+
+    // MARK: - DNS resolution failure — fail-closed
+
+    func test_ssrf_transportRequest_blocksOnDNSResolutionFailure() async {
+        // Resolution failure must block, not pass. An attacker can arrange SERVFAIL for
+        // the guard's query and then serve a private IP to URLSession's separate query.
+        MCPSSRFPolicy._resolverForTesting = { _ in nil }
+
+        await XCTAssertThrowsErrorAsync(
+            try await MCPSSRFPolicy.validateTransportRequestURL(URL(string: "https://example.com/mcp")!)
+        ) { error in
+            guard case .ssrfBlocked = error as? MCPError else {
+                XCTFail("DNS resolution failure must produce ssrfBlocked, got \(error)")
+                return
+            }
+        }
+        // Sabotage: swap nil return to [] (empty array) — the test would pass the SSRF check,
+        // failing the assertion above and confirming the fail-open bug is still present.
+    }
+
+    func test_ssrf_oauthRequest_blocksOnDNSResolutionFailure() async {
+        MCPSSRFPolicy._resolverForTesting = { _ in nil }
+
+        await XCTAssertThrowsErrorAsync(
+            try await MCPSSRFPolicy.validateOAuthRequestURL(
+                URL(string: "https://auth.example.com/token")!,
+                label: "token endpoint"
+            )
+        ) { error in
+            guard case .ssrfBlocked = error as? MCPError else {
+                XCTFail("DNS resolution failure must produce ssrfBlocked, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_ssrf_transportRedirect_blocksOnDNSResolutionFailure() {
+        // The synchronous redirect path uses _synchronousResolverForTesting.
+        MCPSSRFPolicy._synchronousResolverForTesting = { _ in nil }
+
+        XCTAssertThrowsError(
+            try MCPSSRFPolicy.validateTransportRedirectURL(URL(string: "https://example.com/mcp")!)
+        ) { error in
+            guard case .ssrfBlocked = error as? MCPError else {
+                XCTFail("DNS resolution failure must produce ssrfBlocked, got \(error)")
+                return
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- **MCPSSRFPolicy DNS fail-open**: `resolveHostnameSynchronously` returned `[]` on `getaddrinfo` failure, making an empty result indistinguishable from "no blocked addresses." Both `validateResolvedHostNotBlocked` paths silently passed. Changed return type to `[String]?`, guard on nil, and throw `ssrfBlocked` — matching `DNSRebindingGuard`'s existing fail-closed pattern. Added `_synchronousResolverForTesting` seam for the redirect path (mirrors `RedirectGuardDelegate`).
- **GGUFMetadataReader unbounded recursion**: `skipValue` had no recursion depth limit. A ~12 KB crafted GGUF with 1 000 nested single-element arrays overflows the default iOS thread stack. Added a depth cap of 32 and an element-count cap of 65 536 per array.
- **RFC 7592 management credentials (header injection + SSRF)**: `registrationAccessToken` from the DCR response was stored without the bearer-character validation already applied to access tokens, enabling HTTP header injection via `disconnect()`'s `Authorization` header. Also: management URI is now SSRF-validated at storage time (defence-in-depth against the fail-open DNS guard), and `disconnect()` caps redirects at 0 — a DELETE to a fixed management endpoint has no legitimate redirect.

## Test plan

- [ ] `MCPHardeningTests`: three new DNS-failure tests (async transport, async OAuth, synchronous redirect) — each injects nil from the resolver seam and asserts `ssrfBlocked`
- [ ] `GGUFMetadataReaderTests`: two new tests build synthetic adversarial GGUF payloads (64-deep nested arrays; 100 000-element array) and assert `readError` with the correct limit message
- [ ] Existing `MCPHardeningTests` DNS-rebinding tests continue to pass (existing closures returning `[String]` coerce to `[String]?` implicitly)
- [ ] `scripts/test.sh --filter ManifoldMCPTests --filter ManifoldInferenceTests --disable-default-traits --skip-update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)