### PR TITLE
fix(mcp): replace Continuation! pattern with AsyncStream.makeStream()

### DIFF
--- a/Sources/ManifoldMCP/InternalMCPTransport.swift
+++ b/Sources/ManifoldMCP/InternalMCPTransport.swift
@@ -63,11 +63,9 @@ internal actor MCPStreamableHTTPTransport: MCPTransport {
 
     init(configuration: MCPTransportConfiguration) {
         self.configuration = configuration
-        var streamContinuation: AsyncThrowingStream<Data, Error>.Continuation!
-        self.incomingMessages = AsyncThrowingStream { continuation in
-            streamContinuation = continuation
-        }
-        self.continuation = streamContinuation
+        let (incomingMessages, continuation) = AsyncThrowingStream.makeStream(of: Data.self, throwing: Error.self)
+        self.incomingMessages = incomingMessages
+        self.continuation = continuation
     }
 
     func start() async throws {
@@ -224,11 +222,9 @@ internal actor MCPStdioTransport: MCPTransport {
         self.command = command
         self.maxMessageBytes = maxMessageBytes
         self.inheritedEnvironment = inheritedEnvironment
-        var streamContinuation: AsyncThrowingStream<Data, Error>.Continuation!
-        self.incomingMessages = AsyncThrowingStream { continuation in
-            streamContinuation = continuation
-        }
-        self.continuation = streamContinuation
+        let (incomingMessages, continuation) = AsyncThrowingStream.makeStream(of: Data.self, throwing: Error.self)
+        self.incomingMessages = incomingMessages
+        self.continuation = continuation
     }
 
     func start() async throws {

--- a/Sources/ManifoldMCP/MCPClient.swift
+++ b/Sources/ManifoldMCP/MCPClient.swift
@@ -46,14 +46,10 @@ public actor MCPClient {
 
     public init(configuration: MCPClientConfiguration = .init()) {
         self.configuration = configuration
-        var eventContinuation: AsyncStream<MCPConnectionEvent>.Continuation!
-        var stateContinuation: AsyncStream<MCPConnectionState>.Continuation!
-        connectionEvents = AsyncStream { continuation in
-            eventContinuation = continuation
-        }
-        connectionState = AsyncStream { continuation in
-            stateContinuation = continuation
-        }
+        let (connectionEvents, eventContinuation) = AsyncStream.makeStream(of: MCPConnectionEvent.self)
+        let (connectionState, stateContinuation) = AsyncStream.makeStream(of: MCPConnectionState.self)
+        self.connectionEvents = connectionEvents
+        self.connectionState = connectionState
         connectionEventContinuation = eventContinuation
         connectionStateContinuation = stateContinuation
         connectionStateContinuation.yield(.idle)

--- a/Sources/ManifoldMCP/MCPNotificationLifecycleEventObserver.swift
+++ b/Sources/ManifoldMCP/MCPNotificationLifecycleEventObserver.swift
@@ -17,11 +17,9 @@ public final class MCPNotificationLifecycleEventObserver: MCPLifecycleEventObser
     ) {
         self.notificationCenter = notificationCenter
 
-        var eventContinuation: AsyncStream<MCPLifecycleEvent>.Continuation!
-        self.events = AsyncStream { streamContinuation in
-            eventContinuation = streamContinuation
-        }
-        self.continuation = eventContinuation
+        let (events, continuation) = AsyncStream.makeStream(of: MCPLifecycleEvent.self)
+        self.events = events
+        self.continuation = continuation
 
         self.tokens = mapping.map { name, event in
             notificationCenter.addObserver(
@@ -29,7 +27,7 @@ public final class MCPNotificationLifecycleEventObserver: MCPLifecycleEventObser
                 object: nil,
                 queue: nil
             ) { _ in
-                eventContinuation.yield(event)
+                continuation.yield(event)
             }
         }
     }


### PR DESCRIPTION
## Summary

Replaces the `var continuation: T!` + closure initialization pattern with Swift 5.9's `AsyncStream.makeStream()` and `AsyncThrowingStream.makeStream()` APIs across ManifoldMCP.

The old pattern:
```swift
var streamContinuation: AsyncThrowingStream<Data, Error>.Continuation!
self.stream = AsyncThrowingStream { continuation in streamContinuation = continuation }
self.continuation = streamContinuation
```

...relies on the `AsyncThrowingStream` closure being called synchronously (which is guaranteed by the stdlib, but not enforced by the type system). The `!` creates a window where accessing the property before assignment would crash.

`makeStream()` is the idiomatic Swift 5.9 replacement that returns both values together, eliminating the intermediate optional entirely.

## Files changed
- `Sources/ManifoldMCP/InternalMCPTransport.swift`
- `Sources/ManifoldMCP/MCPClient.swift`
- `Sources/ManifoldMCP/MCPNotificationLifecycleEventObserver.swift`

## Test plan
- [x] `swift build --build-tests` passes
- [x] ManifoldMCPTests pass (47 tests, 0 failures, `--traits MCP`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)