### PR TITLE
fix: replace silent try? with do/catch logging in MCP, Inference, Persistence

### DIFF
--- a/Sources/ManifoldInference/Models/ModelInfo.swift
+++ b/Sources/ManifoldInference/Models/ModelInfo.swift
@@ -117,8 +117,14 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
         guard GGUFMetadataReader.isValidGGUF(at: url) else { return nil }
 
         let fileManager = FileManager.default
-        guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),
-              let size = attributes[.size] as? UInt64 else {
+        let attributes: [FileAttributeKey: Any]
+        do {
+            attributes = try fileManager.attributesOfItem(atPath: url.path)
+        } catch {
+            Log.inference.warning("ModelInfo: failed to read file attributes for \(url.lastPathComponent, privacy: .public): \(error, privacy: .private)")
+            return nil
+        }
+        guard let size = attributes[.size] as? UInt64 else {
             return nil
         }
 
@@ -131,12 +137,15 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
         self.benchmarkResult = nil
 
         // Attempt to read GGUF header metadata for template detection.
-        if let metadata = try? GGUFMetadataReader.readMetadata(from: url) {
+        do {
+            let metadata = try GGUFMetadataReader.readMetadata(from: url)
             self.detectedPromptTemplate = PromptTemplateDetector.detect(from: metadata)
             self.detectedContextLength = metadata.contextLength
             self.modelArchitecture = metadata.generalArchitecture
             self.chatTemplateRaw = metadata.chatTemplate
             self.estimatedKVBytesPerToken = GGUFKVCacheEstimator.estimateBytesPerToken(from: metadata)
+        } catch {
+            Log.inference.warning("ModelInfo: failed to read GGUF metadata from \(url.lastPathComponent, privacy: .public): \(error, privacy: .private)")
         }
 
         // Static tier estimate; may be upgraded by a benchmark result later.
@@ -147,14 +156,18 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
         // projector files don't try to find their own companion.
         if !url.lastPathComponent.lowercased().hasPrefix("mmproj") {
             let parentDir = url.deletingLastPathComponent()
-            let candidates = (try? FileManager.default.contentsOfDirectory(
-                at: parentDir,
-                includingPropertiesForKeys: nil,
-                options: [.skipsHiddenFiles]
-            )) ?? []
-            self.mmprojURL = candidates.first {
-                $0.lastPathComponent.lowercased().hasPrefix("mmproj") &&
-                $0.pathExtension.lowercased() == "gguf"
+            do {
+                let candidates = try FileManager.default.contentsOfDirectory(
+                    at: parentDir,
+                    includingPropertiesForKeys: nil,
+                    options: [.skipsHiddenFiles]
+                )
+                self.mmprojURL = candidates.first {
+                    $0.lastPathComponent.lowercased().hasPrefix("mmproj") &&
+                    $0.pathExtension.lowercased() == "gguf"
+                }
+            } catch {
+                Log.inference.warning("ModelInfo: failed to scan for mmproj companion in \(parentDir.lastPathComponent, privacy: .public): \(error, privacy: .private)")
             }
         }
     }
@@ -176,11 +189,15 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
         let configURL = url.appendingPathComponent("config.json")
         guard fileManager.fileExists(atPath: configURL.path) else { return nil }
 
-        guard let contents = try? fileManager.contentsOfDirectory(
-            at: url,
-            includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey],
-            options: [.skipsHiddenFiles]
-        ) else {
+        let contents: [URL]
+        do {
+            contents = try fileManager.contentsOfDirectory(
+                at: url,
+                includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey],
+                options: [.skipsHiddenFiles]
+            )
+        } catch {
+            Log.inference.warning("ModelInfo: failed to read MLX model directory \(url.lastPathComponent, privacy: .public): \(error, privacy: .private)")
             return nil
         }
 
@@ -200,9 +217,14 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
         }
 
         let totalSize = allFiles.reduce(UInt64(0)) { sum, fileURL in
-            let values = try? fileURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
-            guard values?.isRegularFile == true else { return sum }
-            return sum + UInt64(values?.fileSize ?? 0)
+            do {
+                let values = try fileURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+                guard values.isRegularFile == true else { return sum }
+                return sum + UInt64(values.fileSize ?? 0)
+            } catch {
+                Log.inference.warning("ModelInfo: failed to read resource values for \(fileURL.lastPathComponent, privacy: .public): \(error, privacy: .private)")
+                return sum
+            }
         }
         let hasSafetensors = allFiles.contains { $0.pathExtension.lowercased() == "safetensors" }
         guard hasSafetensors else { return nil }
@@ -327,12 +349,15 @@ extension ModelInfo {
 
         // Read GGUF header metadata for template detection. mmproj companion scan
         // is skipped — HuggingFace downloads flow file-by-file, not directory-wide.
-        if let metadata = try? GGUFMetadataReader.readMetadata(from: localURL) {
+        do {
+            let metadata = try GGUFMetadataReader.readMetadata(from: localURL)
             self.detectedPromptTemplate = PromptTemplateDetector.detect(from: metadata)
             self.detectedContextLength = metadata.contextLength
             self.modelArchitecture = metadata.generalArchitecture
             self.chatTemplateRaw = metadata.chatTemplate
             self.estimatedKVBytesPerToken = GGUFKVCacheEstimator.estimateBytesPerToken(from: metadata)
+        } catch {
+            Log.inference.warning("ModelInfo: failed to read GGUF metadata from \(localURL.lastPathComponent, privacy: .public): \(error, privacy: .private)")
         }
 
         // Static tier estimate; may be upgraded by a benchmark result later.

--- a/Sources/ManifoldInference/Services/ModelStorageService.swift
+++ b/Sources/ManifoldInference/Services/ModelStorageService.swift
@@ -90,11 +90,15 @@ public final class ModelStorageService: @unchecked Sendable {
     public func discoverModels() -> [ModelInfo] {
         let directory = modelsDirectory
 
-        guard let contents = try? fileManager.contentsOfDirectory(
-            at: directory,
-            includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey, .isDirectoryKey],
-            options: [.skipsHiddenFiles]
-        ) else {
+        let contents: [URL]
+        do {
+            contents = try fileManager.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey, .isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+        } catch {
+            Log.inference.warning("ModelStorageService: failed to read models directory: \(error, privacy: .private)")
             return []
         }
 
@@ -130,11 +134,17 @@ public final class ModelStorageService: @unchecked Sendable {
             // and look one level deeper. We only recurse one level — anything beyond
             // that is out of scope for this layout convention.
             let namespace = url.lastPathComponent
-            guard let nestedContents = try? fileManager.contentsOfDirectory(
-                at: url,
-                includingPropertiesForKeys: [.isDirectoryKey],
-                options: [.skipsHiddenFiles]
-            ) else { continue }
+            let nestedContents: [URL]
+            do {
+                nestedContents = try fileManager.contentsOfDirectory(
+                    at: url,
+                    includingPropertiesForKeys: [.isDirectoryKey],
+                    options: [.skipsHiddenFiles]
+                )
+            } catch {
+                Log.inference.warning("ModelStorageService: failed to read namespace directory '\(namespace, privacy: .public)': \(error, privacy: .private)")
+                continue
+            }
 
             for nestedURL in nestedContents {
                 var nestedIsDir: ObjCBool = false
@@ -159,11 +169,15 @@ public final class ModelStorageService: @unchecked Sendable {
     public func discoverImageModels(in rootDirectory: URL? = nil) -> [ImageModelInfo] {
         let root = rootDirectory ?? modelsDirectory
 
-        guard let contents = try? fileManager.contentsOfDirectory(
-            at: root,
-            includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsHiddenFiles]
-        ) else {
+        let contents: [URL]
+        do {
+            contents = try fileManager.contentsOfDirectory(
+                at: root,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+        } catch {
+            Log.inference.warning("ModelStorageService: failed to read image models directory: \(error, privacy: .private)")
             return []
         }
 

--- a/Sources/ManifoldInference/Services/PromptTemplate.swift
+++ b/Sources/ManifoldInference/Services/PromptTemplate.swift
@@ -339,21 +339,31 @@ public enum PromptTemplate: String, CaseIterable, Sendable, Identifiable {
     }
 
     /// Serialises a `ToolDefinition` to the JSON string placed after `<|tool>`.
-    /// Returns `nil` when serialisation fails (the tool is silently skipped).
+    /// Returns `nil` when serialisation fails; the caller is responsible for logging the skip.
     private func toolDeclarationBlock(for tool: ToolDefinition) -> String? {
-        guard let paramsData   = try? JSONEncoder().encode(tool.parameters),
-              let paramsObject = try? JSONSerialization.jsonObject(with: paramsData)
-        else { return nil }
+        let paramsData: Data
+        let paramsObject: Any
+        do {
+            paramsData = try JSONEncoder().encode(tool.parameters)
+            paramsObject = try JSONSerialization.jsonObject(with: paramsData)
+        } catch {
+            Log.prompt.warning("PromptTemplate: failed to encode parameters for tool '\(tool.name, privacy: .public)': \(error, privacy: .private)")
+            return nil
+        }
 
         let dict: [String: Any] = [
             "name":        tool.name,
             "description": tool.description,
             "parameters":  paramsObject
         ]
-        guard let data = try? JSONSerialization.data(withJSONObject: dict, options: .sortedKeys),
-              let str  = String(data: data, encoding: .utf8)
-        else { return nil }
-        return str
+        do {
+            let data = try JSONSerialization.data(withJSONObject: dict, options: .sortedKeys)
+            guard let str = String(data: data, encoding: .utf8) else { return nil }
+            return str
+        } catch {
+            Log.prompt.warning("PromptTemplate: failed to serialize tool declaration for '\(tool.name, privacy: .public)': \(error, privacy: .private)")
+            return nil
+        }
     }
 
     // MARK: - Phi

--- a/Sources/ManifoldMCP/InternalMCPSession.swift
+++ b/Sources/ManifoldMCP/InternalMCPSession.swift
@@ -128,12 +128,22 @@ internal actor MCPSession {
         await stateHook.sessionDidSend(message)
     }
 
-    /// Fire-and-forget notification — errors are swallowed so callers can use this from a
-    /// cancellation handler without preventing `CancellationError` from propagating.
+    /// Fire-and-forget notification — errors are logged but do not propagate, so callers can
+    /// use this from a cancellation handler without preventing `CancellationError` from propagating.
     func sendNotificationIgnoringErrors(method: String, params: JSONSchemaValue?) async {
         let message = MCPJSONRPCMessage.notification(method: method, params: params)
-        guard let payload = try? codec.encode(message) else { return }
-        try? await transport.send(payload)
+        let payload: Data
+        do {
+            payload = try codec.encode(message)
+        } catch {
+            Log.inference.error("MCPSession: failed to encode notification '\(method, privacy: .public)': \(error, privacy: .private)")
+            return
+        }
+        do {
+            try await transport.send(payload)
+        } catch {
+            Log.inference.error("MCPSession: failed to send notification '\(method, privacy: .public)': \(error, privacy: .private)")
+        }
     }
 
     func close(reason: MCPDisconnectReason = .requested) async {

--- a/Sources/ManifoldPersistenceSwiftData/ModelContainerFactory.swift
+++ b/Sources/ManifoldPersistenceSwiftData/ModelContainerFactory.swift
@@ -176,7 +176,11 @@ public enum ModelContainerFactory {
         // Sidecars live in the same directory and share the store basename.
         let directory = storeURL.deletingLastPathComponent()
         let baseName = storeURL.lastPathComponent
-        guard let entries = try? fm.contentsOfDirectory(atPath: directory.path) else {
+        let entries: [String]
+        do {
+            entries = try fm.contentsOfDirectory(atPath: directory.path)
+        } catch {
+            Log.persistence.warning("ModelContainerFactory: failed to list sidecar files for store protection: \(error, privacy: .private)")
             return
         }
         for entry in entries where entry != baseName && entry.hasPrefix(baseName) {

--- a/Tests/ManifoldInferenceTests/silent_catch_allowlist.txt
+++ b/Tests/ManifoldInferenceTests/silent_catch_allowlist.txt
@@ -40,12 +40,6 @@ ManifoldUI/Views/Chat/AssistantMarkdownView.swift:if let parsed = try? Attribute
 # would terminate the iteration without adding signal.
 ManifoldTools/ReferenceTools/SampleRepoSearchTool.swift:guard let contents = try? String(contentsOf: url, encoding: .utf8) else { continue }
 
-# MCP transport encode/send — fire-and-forget pattern. Encoding failure is
-# swallowed because the next call will retry with a fresh codec, and the
-# caller is the framing layer that has no recovery path.
-ManifoldMCP/InternalMCPSession.swift:guard let payload = try? codec.encode(message) else { return }
-ManifoldMCP/InternalMCPSession.swift:try? await transport.send(payload)
-
 # AVAudioSession deactivation in tear-down. iOS routinely returns
 # `kAudioSessionInactiveError` for sessions that other apps still hold
 # active; that is expected and not actionable.


### PR DESCRIPTION
## Summary

- **ManifoldMCP/InternalMCPSession.swift**: `sendNotificationIgnoringErrors` now logs encode and send failures via `Log.inference.error` with `privacy: .private` instead of silently swallowing them.
- **ManifoldInference/Models/ModelInfo.swift**: Six `try?` sites replaced with `do/catch` + `Log.inference.warning`: GGUF file attributes read, GGUF metadata reads (in both `init(ggufURL:)` and `init(huggingFaceRepoID:...)`), mmproj companion directory scan, MLX directory read, and per-file resource values in the size accumulator.
- **ManifoldInference/Services/ModelStorageService.swift**: Three `contentsOfDirectory` calls in `discoverModels()`, namespace directory scan, and `discoverImageModels()` replaced with `do/catch` + `Log.inference.warning`.
- **ManifoldPersistenceSwiftData/ModelContainerFactory.swift**: Sidecar file enumeration for store protection replaced with `do/catch` + `Log.persistence.warning`.
- **ManifoldInference/Services/PromptTemplate.swift**: `toolDeclarationBlock` JSON encoding replaced with `do/catch` + `Log.prompt.warning` so serialization failures are visible (caller already logs the skip).
- **Tests/ManifoldInferenceTests/silent_catch_allowlist.txt**: Removed two stale MCP allowlist entries that no longer exist in source.

`SilentCatchAuditTest` passes. Build clean with `--disable-default-traits`.

Closes #1222

## Test plan

- [x] `swift build --build-tests --disable-default-traits` — build complete, no errors
- [x] `SilentCatchAuditTest` passes (0 unapproved swallows, 0 stale allowlist entries)
- [x] `scripts/test.sh --filter ManifoldMCPTests --filter ManifoldInferenceTests --filter ManifoldPersistenceSwiftDataTests --disable-default-traits --skip-update` — 1786 tests, 1 pre-existing failure unrelated to this change (TrafficBoundaryAuditTest network gate), 9 skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)