### PR TITLE
ci: add code coverage thresholds for critical modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
       - "Package.resolved"
       - ".github/workflows/ci.yml"
       - "scripts/test.sh"
+      - "scripts/check-coverage.sh"
       - "scripts/example-ui-tests.sh"
       - "scripts/ci-normalize-swiftpm-debug-cache.sh"
       - "scripts/cold-start*.sh"
@@ -25,6 +26,7 @@ on:
       - "Package.resolved"
       - ".github/workflows/ci.yml"
       - "scripts/test.sh"
+      - "scripts/check-coverage.sh"
       - "scripts/example-ui-tests.sh"
       - "scripts/ci-normalize-swiftpm-debug-cache.sh"
       - "scripts/cold-start*.sh"
@@ -284,6 +286,29 @@ jobs:
         env:
           MANIFOLD_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-inference-swift-testing.log
         run: scripts/test.sh --filter ManifoldInferenceSwiftTestingTests --disable-default-traits --skip-update
+
+      # Coverage thresholds — runs a fresh swift test with --enable-code-coverage
+      # over the four critical modules and verifies each module's line coverage
+      # meets its threshold (set 10pp below the 2026-05-15 baseline).  Runs only
+      # on main-branch pushes so per-PR CI is not slowed by the extra build pass.
+      # The check is informational on first-push; raise thresholds as coverage
+      # improves.  See scripts/check-coverage.sh for threshold values and rationale.
+      - name: Coverage thresholds
+        if: github.ref == 'refs/heads/main'
+        timeout-minutes: 15
+        run: |
+          set -euo pipefail
+          swift test \
+            --filter ManifoldCoreTests \
+            --filter ManifoldRuntimeTests \
+            --filter ManifoldPersistenceSwiftDataTests \
+            --filter ManifoldInferenceTests \
+            --filter ManifoldMCPTests \
+            --disable-default-traits \
+            --traits MCP \
+            --enable-code-coverage \
+            --skip-update
+          scripts/check-coverage.sh
 
       - name: Report SwiftPM debug cache state
         if: always()

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# scripts/check-coverage.sh — Verify per-module line coverage against thresholds.
+#
+# Usage:
+#   scripts/check-coverage.sh [--profdata <path>] [--binary <path>]
+#
+# When called with no arguments the script discovers the most recent profdata
+# and xctest binary under .build/arm64-apple-macosx/debug (or .build/debug as
+# a fallback).  Pass explicit paths when you want to check a specific run.
+#
+# Exit codes:
+#   0   All modules meet their thresholds (or llvm-cov is unavailable).
+#   1   One or more modules are below threshold.
+#
+# Thresholds are set 10 percentage points below the measured baseline at the
+# time issue #1224 was implemented (2026-05-15).  Raise them as coverage
+# improves.
+#
+# Baseline measurements (ManifoldCoreTests + ManifoldRuntimeTests +
+# ManifoldPersistenceSwiftDataTests + ManifoldInferenceTests +
+# ManifoldMCPTests, --disable-default-traits --enable-code-coverage):
+#
+#   ManifoldInference            84.0%  -> threshold 74%
+#   ManifoldRuntime              84.2%  -> threshold 74%
+#   ManifoldPersistenceSwiftData 84.7%  -> threshold 74%
+#   ManifoldMCP                  85.5%  -> threshold 75%
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PACKAGE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PACKAGE_DIR"
+
+# ── Thresholds (integer percent) ─────────────────────────────────────────────
+declare -A THRESHOLDS=(
+  [ManifoldInference]=74
+  [ManifoldRuntime]=74
+  [ManifoldPersistenceSwiftData]=74
+  [ManifoldMCP]=75
+)
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+PROFDATA_ARG=""
+BINARY_ARG=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profdata)
+      PROFDATA_ARG="${2:?'--profdata requires a path'}"
+      shift 2
+      ;;
+    --binary)
+      BINARY_ARG="${2:?'--binary requires a path'}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ── Tool availability check ──────────────────────────────────────────────────
+if ! command -v xcrun &>/dev/null || ! xcrun --find llvm-cov &>/dev/null 2>&1; then
+  echo "WARNING: llvm-cov not available — skipping coverage check."
+  exit 0
+fi
+
+# ── Discover profdata and binary ─────────────────────────────────────────────
+ARCH_DEBUG=""
+for candidate in \
+  .build/arm64-apple-macosx/debug \
+  .build/x86_64-apple-macosx/debug \
+  .build/debug; do
+  if [[ -d "$candidate" ]]; then
+    ARCH_DEBUG="$candidate"
+    break
+  fi
+done
+
+if [[ -z "$PROFDATA_ARG" ]]; then
+  if [[ -n "$ARCH_DEBUG" ]]; then
+    PROFDATA_ARG="$ARCH_DEBUG/codecov/default.profdata"
+  fi
+fi
+
+if [[ -z "$BINARY_ARG" ]]; then
+  if [[ -n "$ARCH_DEBUG" ]]; then
+    XCTEST=$(find "$ARCH_DEBUG" -maxdepth 1 -name "*.xctest" 2>/dev/null | head -1)
+    if [[ -n "$XCTEST" ]]; then
+      BUNDLE_NAME=$(basename "$XCTEST" .xctest)
+      BINARY_ARG="$XCTEST/Contents/MacOS/$BUNDLE_NAME"
+    fi
+  fi
+fi
+
+if [[ ! -f "$PROFDATA_ARG" ]]; then
+  echo "WARNING: profdata not found at '${PROFDATA_ARG}' — run 'swift test --enable-code-coverage' first, or pass --profdata."
+  echo "         Skipping coverage check."
+  exit 0
+fi
+
+if [[ ! -f "$BINARY_ARG" ]]; then
+  echo "WARNING: xctest binary not found at '${BINARY_ARG}' — skipping coverage check."
+  exit 0
+fi
+
+# ── Generate coverage report ──────────────────────────────────────────────────
+REPORT=$(xcrun llvm-cov report \
+  "$BINARY_ARG" \
+  --instr-profile="$PROFDATA_ARG" \
+  --ignore-filename-regex="Tests|\.build" \
+  2>/dev/null) || {
+  echo "WARNING: llvm-cov report failed — skipping coverage check."
+  exit 0
+}
+
+# ── Compute per-module line coverage ─────────────────────────────────────────
+# llvm-cov report columns (space-separated):
+#   Filename  Regions  MissedRegions  Cover%  Functions  MissedFunctions
+#   Executed  Lines  MissedLines  Cover%  Branches  MissedBranches  Cover%
+# We sum Lines ($8) and MissedLines ($9) per source directory prefix.
+
+declare -A COV_PERCENT
+
+for module in "${!THRESHOLDS[@]}"; do
+  result=$(printf '%s\n' "$REPORT" | awk -v mod="${module}/" '
+    $1 ~ "^" mod {
+      total  += $8
+      missed += $9
+    }
+    END {
+      if (total > 0) {
+        covered = total - missed
+        printf "%.1f %d %d", (covered / total) * 100, covered, total
+      } else {
+        print "NO_DATA 0 0"
+      }
+    }
+  ')
+  COV_PERCENT[$module]="$result"
+done
+
+# ── Print summary table ───────────────────────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  CODE COVERAGE THRESHOLDS"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+printf "  %-36s %10s %10s %8s\n" "Module" "Coverage" "Threshold" "Status"
+echo "  ─────────────────────────────────────────────────────────────────"
+
+FAILED=0
+FAILED_MODULES=()
+
+for module in $(printf '%s\n' "${!THRESHOLDS[@]}" | sort); do
+  threshold=${THRESHOLDS[$module]}
+  data=${COV_PERCENT[$module]}
+  pct=$(echo "$data" | awk '{print $1}')
+  covered=$(echo "$data" | awk '{print $2}')
+  total=$(echo "$data" | awk '{print $3}')
+
+  if [[ "$pct" == "NO_DATA" ]]; then
+    status="NO DATA"
+    printf "  %-36s %10s %9d%% %8s\n" "$module" "--" "$threshold" "$status"
+    # No data means the module wasn't in the profdata — treat as warning not failure
+    # (e.g. MCP tests require --traits MCP, which the coverage run may not include)
+    continue
+  fi
+
+  pct_int=$(echo "$pct" | awk '{printf "%d", $1}')
+  if [[ $pct_int -ge $threshold ]]; then
+    status="PASS"
+  else
+    status="FAIL"
+    FAILED=1
+    FAILED_MODULES+=("$module (${pct}% < ${threshold}% threshold)")
+  fi
+  printf "  %-36s %9s%% %9d%% %8s\n" "$module" "$pct" "$threshold" "$status"
+done
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [[ $FAILED -eq 1 ]]; then
+  echo ""
+  echo "  COVERAGE BELOW THRESHOLD in ${#FAILED_MODULES[@]} module(s):"
+  for m in "${FAILED_MODULES[@]}"; do
+    echo "    - $m"
+  done
+  echo ""
+  echo "  To investigate: xcrun llvm-cov report <binary> --instr-profile=<profdata>"
+  echo "                  --ignore-filename-regex='Tests|\.build'"
+  echo ""
+  exit 1
+else
+  echo "  RESULT: All modules meet coverage thresholds."
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+fi


### PR DESCRIPTION
## Summary

- Adds `scripts/check-coverage.sh` that reads llvm-cov profdata after a `--enable-code-coverage` run and fails if any critical module drops below its threshold
- Wires a "Coverage thresholds" step into `ci.yml` that runs only on `main`-branch pushes (not per-PR, to avoid the extra build cost)
- Adds `scripts/check-coverage.sh` to the workflow `paths:` filter so threshold changes trigger CI

## Baseline measurements (2026-05-15)

Run: `swift test --filter ManifoldCoreTests --filter ManifoldRuntimeTests --filter ManifoldPersistenceSwiftDataTests --filter ManifoldInferenceTests --filter ManifoldMCPTests --disable-default-traits --traits MCP --enable-code-coverage`

| Module | Measured | Threshold (−10pp) |
|---|---|---|
| ManifoldInference | 84.0% | 74% |
| ManifoldRuntime | 84.2% | 74% |
| ManifoldPersistenceSwiftData | 84.7% | 74% |
| ManifoldMCP | 85.5% | 75% |

## How it works

`scripts/check-coverage.sh` discovers the profdata and xctest binary from `.build/arm64-apple-macosx/debug` (or passes explicit `--profdata`/`--binary` args). It runs `xcrun llvm-cov report`, sums `Lines` and `MissedLines` per source directory prefix, computes a line-coverage percentage per module, and prints a summary table. If `llvm-cov` is unavailable or no profdata exists the script exits 0 with a warning so tooling gaps don't hard-fail CI.

## Test plan

- [x] `bash scripts/check-coverage.sh` after the full coverage build prints all-PASS table and exits 0
- [x] Script exits 1 with human-readable failure message when a module is below threshold (verified by running MCP-only profdata against multi-module thresholds)
- [x] `llvm-cov` unavailable path exits 0 (warning only)
- [x] ci.yml "Coverage thresholds" step is gated to `github.ref == 'refs/heads/main'`
- [x] Two-invocation XCTest + Swift Testing shape preserved unchanged

Closes #1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)