### PR TITLE
refactor(ui): Phase 1 — extract ChatSessionManager from ChatViewModel

### DIFF
--- a/Sources/ManifoldUI/ViewModels/ChatSessionManager.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatSessionManager.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Observation
+import ManifoldRuntime
+import ManifoldInference
+
+/// Coordinates session-switching transitions in the chat UI.
+///
+/// `ChatSessionManager` owns the teardown-and-setup choreography that runs
+/// whenever the user picks a different session: cancelling in-flight
+/// inference, tearing down the runtime stream handle, resetting per-session
+/// tool-approval state, and resolving the persisted model/endpoint selection
+/// from the new session's stored IDs.
+///
+/// It is intentionally decoupled from every collaborator via closure
+/// injection, making it testable without constructing a full
+/// `ChatViewModel`. `ChatViewModel` owns one instance and delegates the
+/// orchestration methods; the `+SessionManagement` extension remains the
+/// public surface that callers see.
+///
+/// `SessionController` owns the complementary lower layer: session-record
+/// activation, settings I/O, and message loading. `ChatSessionManager`
+/// sits one level above, coordinating the inference-side teardown before
+/// `SessionController.activateSession(_:)` runs.
+@Observable
+@MainActor
+final class ChatSessionManager {
+
+    // MARK: - State
+
+    /// `true` while a session switch is in progress.
+    ///
+    /// `ModelLoadCoordinator` reads this flag to suppress stale model-load
+    /// transitions that arrive mid-switch — a new session select must not be
+    /// shadowed by the dying session's load progress.
+    var isRestoringSession: Bool = false
+
+    // MARK: - Teardown collaborators (closure-injected)
+    //
+    // Each closure captures a specific piece of `ChatViewModel` state or an
+    // external service without coupling this type to any concrete class.
+    // Closures are set once during `ChatViewModel.init` and never replaced.
+
+    /// Cancels in-flight inference requests that do not belong to `sessionID`.
+    var discardRequests: (@MainActor (UUID) async -> Void)?
+
+    /// Resets the active backend conversation history and zeroes the KV cache.
+    var resetConversation: (@MainActor () -> Void)?
+
+    /// Zeroes the model's KV cache via a secure wipe pass.
+    var secureWipe: (@MainActor () -> Void)?
+
+    /// Applies the prompt template to the active backend so the next
+    /// generation uses the new session's format.
+    var applyPromptTemplate: (@MainActor (PromptTemplate) -> Void)?
+
+    /// Cancels and clears the runtime stream handle for the prior session.
+    var cancelActiveStreamHandle: (@MainActor () async -> Void)?
+
+    /// Resets per-session tool-approval state so approvals from the prior
+    /// session do not leak into the new one.
+    var resetToolApprovals: (@MainActor () -> Void)?
+
+    /// Cancels any in-flight post-generation background task and clears the
+    /// error surface.
+    var cancelBackgroundTask: (@MainActor () -> Void)?
+
+    /// Refreshes the available endpoint list from the configured endpoint store.
+    var refreshAvailableEndpoints: (@MainActor () async -> Void)?
+
+    // MARK: - Resolution helpers (closure-injected)
+
+    /// Resolves a model ID to a `ModelInfo` in the current registry.
+    var resolveModel: (@MainActor (UUID) -> ModelInfo?)?
+
+    /// Resolves an endpoint ID to an `APIEndpointRecord` in the available list.
+    var resolveEndpoint: (@MainActor (UUID) -> APIEndpointRecord?)?
+
+    /// Applies a resolved model selection to `ChatViewModel`.
+    var applyModelSelection: (@MainActor (ModelInfo?) -> Void)?
+
+    /// Applies a resolved endpoint selection to `ChatViewModel`.
+    var applyEndpointSelection: (@MainActor (APIEndpointRecord?) -> Void)?
+
+    // MARK: - Session switching
+
+    /// Teardown result describing what model and endpoint the new session
+    /// stored, after all prior-session state has been cleared.
+    struct TeardownResult {
+        let resolvedModel: ModelInfo?
+        let resolvedEndpoint: APIEndpointRecord?
+    }
+
+    /// Performs the teardown phase of a session switch, then returns the
+    /// resolved model and endpoint from `selectionState`.
+    ///
+    /// Call order matters:
+    /// 1. Discard inference requests for the prior session.
+    /// 2. Reset conversation + KV cache on the active backend.
+    /// 3. Cancel the runtime stream handle.
+    /// 4. Reset tool-approval gate for the new session.
+    /// 5. Cancel lingering background tasks.
+    /// 6. Refresh the endpoint list (required before resolution in step 7).
+    /// 7. Resolve stored model/endpoint IDs → live registry objects.
+    ///
+    /// `ChatViewModel+SessionManagement.switchToSession(_:)` wraps this in
+    /// `isRestoringSession = true` / `false` and performs the remaining UI
+    /// resets (input text, draft attachments, scroll state) that need
+    /// `@MainActor` `ChatViewModel` state.
+    func teardown(
+        sessionID: UUID,
+        promptTemplate: PromptTemplate,
+        selectionState: SessionController.SessionSelectionState
+    ) async -> TeardownResult {
+        await discardRequests?(sessionID)
+        resetConversation?()
+        secureWipe?()
+        applyPromptTemplate?(promptTemplate)
+        await cancelActiveStreamHandle?()
+        resetToolApprovals?()
+        cancelBackgroundTask?()
+        await refreshAvailableEndpoints?()
+
+        let resolvedEndpoint = selectionState.selectedEndpointID.flatMap { resolveEndpoint?($0) }
+        let resolvedModel = selectionState.selectedModelID.flatMap { resolveModel?($0) }
+
+        return TeardownResult(resolvedModel: resolvedModel, resolvedEndpoint: resolvedEndpoint)
+    }
+
+    /// Applies the resolved model/endpoint selections after the teardown phase.
+    ///
+    /// Exactly one of `model` or `endpoint` will be set from the persisted
+    /// session state; when neither was stored, both are cleared.
+    func applySelection(_ result: TeardownResult) {
+        if let endpoint = result.resolvedEndpoint {
+            applyEndpointSelection?(endpoint)
+        } else if let model = result.resolvedModel {
+            applyModelSelection?(model)
+        } else {
+            applyModelSelection?(nil)
+            applyEndpointSelection?(nil)
+        }
+    }
+}

--- a/Sources/ManifoldUI/ViewModels/ChatViewModel+SessionManagement.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel+SessionManagement.swift
@@ -10,69 +10,37 @@ extension ChatViewModel {
     public func switchToSession(_ session: ChatSessionRecord) async {
         // Drive the UI back to idle synchronously so the toolbar/stop button
         // observes the transition immediately. The runtime handle and queue
-        // tear-down are awaited via `discardRequests` below before any
+        // tear-down are awaited by `sessionManager.teardown` before any
         // backend mutation runs.
         if isGenerating {
             transitionPhase(to: .idle)
         }
 
-        isRestoringSession = true
-        defer { isRestoringSession = false }
+        sessionManager.isRestoringSession = true
+        defer { sessionManager.isRestoringSession = false }
 
+        // Activate the session record in the controller (sets settings, prompt template,
+        // pinned IDs) and capture what model/endpoint was persisted for this session.
         let selectionState = sessionController.activateSession(session)
 
-        // Discard any queued requests that belong to a different session.
-        // Awaiting here is load-bearing: the call cancels the active turn
-        // (when its session ≠ `session.id`) and drives the task's defer
-        // block to completion before returning. Running the discard
-        // *before* `resetConversation()` / `secureWipe()` keeps those
-        // backend KV-cache mutations from racing the dying turn — a race
-        // that previously left B's first send to land on a half-torn-down
-        // queue and yield zero tokens (issue #965).
-        await inferenceService.discardRequests(notMatching: session.id)
+        // Delegate the teardown sequence to ChatSessionManager:
+        // - Discard inference requests for the prior session (load-bearing await:
+        //   cancels the dying turn before any KV-cache mutation runs — see #965).
+        // - Reset conversation history + KV cache on the active backend.
+        // - Cancel the runtime stream handle (closes bookkeeping before the next
+        //   send registers a new handle).
+        // - Reset tool-approval gate (prevent prior-session approvals from leaking).
+        // - Cancel lingering background tasks.
+        // - Refresh the available endpoint list (required before resolution).
+        // - Resolve the persisted model/endpoint IDs to live registry objects.
+        let teardownResult = await sessionManager.teardown(
+            sessionID: session.id,
+            promptTemplate: sessionController.selectedPromptTemplate,
+            selectionState: selectionState
+        )
 
-        inferenceService.resetConversation()
-        inferenceService.secureWipe()
-        inferenceService.selectedPromptTemplate = sessionController.selectedPromptTemplate
-
-        // Cancel the runtime's stream handle for the prior session if one is
-        // still attached. `discardRequests` made the queue idle; this
-        // closes the runtime-level bookkeeping so the next send opens a
-        // fresh handle. Awaited inline so the runtime registry is fully
-        // torn down before the caller's next send registers a new handle —
-        // a fire-and-forget Task here flaked under heavy parallel load
-        // (issue #965).
-        if let handle = activeConversationStreamHandle {
-            await conversationRuntime.cancel(handle)
-            activeConversationStreamHandle = nil
-        }
-
-        // Clear any still-pending tool approvals and the once-per-session
-        // latch so approvals from the prior session do not leak into this one.
-        toolApprovalGate?.resetForNewSession()
-
-        // Cancel any in-flight post-generation background tasks from the prior session.
-        backgroundTask?.cancel()
-        backgroundTask = nil
-        backgroundTaskError = nil
-
-        await refreshAvailableEndpointsFromStore()
-
-        let resolvedEndpoint = selectionState.selectedEndpointID.flatMap { endpointID in
-            availableEndpoints.first(where: { $0.id == endpointID })
-        }
-        let resolvedModel = selectionState.selectedModelID.flatMap { modelID in
-            availableModels.first(where: { $0.id == modelID })
-        }
-
-        if let resolvedEndpoint {
-            selectedEndpoint = resolvedEndpoint
-        } else if let resolvedModel {
-            selectedModel = resolvedModel
-        } else {
-            selectedModel = nil
-            selectedEndpoint = nil
-        }
+        // Apply the resolved model/endpoint selection (exactly one or neither).
+        sessionManager.applySelection(teardownResult)
 
         showUpgradeHint = false
         inputText = ""

--- a/Sources/ManifoldUI/ViewModels/ChatViewModel+SessionManager.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel+SessionManager.swift
@@ -1,0 +1,78 @@
+import Foundation
+import ManifoldRuntime
+import ManifoldInference
+
+// MARK: - ChatViewModel + SessionManager wiring
+
+extension ChatViewModel {
+
+    /// Wires ``ChatSessionManager`` closures to this view model's collaborators.
+    ///
+    /// Called once at the end of `init` after all stored properties are
+    /// initialized. The closures capture `self` weakly so the session manager
+    /// does not extend the view model's lifetime. Every closure re-checks
+    /// `guard let self` before touching state.
+    ///
+    /// This is the only place where `ChatSessionManager` learns about
+    /// `InferenceService`, `ConversationRuntime`, and other concrete types —
+    /// the manager itself stays decoupled and testable in isolation.
+    func installSessionManagerClosures() {
+        let mgr = sessionManager
+
+        mgr.discardRequests = { [weak self] sessionID in
+            guard let self else { return }
+            await self.inferenceService.discardRequests(notMatching: sessionID)
+        }
+
+        mgr.resetConversation = { [weak self] in
+            self?.inferenceService.resetConversation()
+        }
+
+        mgr.secureWipe = { [weak self] in
+            self?.inferenceService.secureWipe()
+        }
+
+        mgr.applyPromptTemplate = { [weak self] template in
+            self?.inferenceService.selectedPromptTemplate = template
+        }
+
+        mgr.cancelActiveStreamHandle = { [weak self] in
+            guard let self else { return }
+            if let handle = self.activeConversationStreamHandle {
+                await self.conversationRuntime.cancel(handle)
+                self.activeConversationStreamHandle = nil
+            }
+        }
+
+        mgr.resetToolApprovals = { [weak self] in
+            self?.toolApprovalGate?.resetForNewSession()
+        }
+
+        mgr.cancelBackgroundTask = { [weak self] in
+            guard let self else { return }
+            self.backgroundTask?.cancel()
+            self.backgroundTask = nil
+            self.backgroundTaskError = nil
+        }
+
+        mgr.refreshAvailableEndpoints = { [weak self] in
+            await self?.refreshAvailableEndpointsFromStore()
+        }
+
+        mgr.resolveModel = { [weak self] modelID in
+            self?.availableModels.first(where: { $0.id == modelID })
+        }
+
+        mgr.resolveEndpoint = { [weak self] endpointID in
+            self?.availableEndpoints.first(where: { $0.id == endpointID })
+        }
+
+        mgr.applyModelSelection = { [weak self] model in
+            self?.selectedModel = model
+        }
+
+        mgr.applyEndpointSelection = { [weak self] endpoint in
+            self?.selectedEndpoint = endpoint
+        }
+    }
+}

--- a/Sources/ManifoldUI/ViewModels/ChatViewModel.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel.swift
@@ -81,6 +81,13 @@ public final class ChatViewModel {
 
     let sessionController: SessionController
 
+    // MARK: - Session Manager
+
+    /// Coordinates session-switching teardown (inference cancellation,
+    /// runtime handle release, tool-approval reset, model/endpoint resolution).
+    /// Extracted from `ChatViewModel+SessionManagement.swift` in #1221 phase 1.
+    let sessionManager: ChatSessionManager
+
     var persistence: (any SessionStore & MessageStore)? {
         get { sessionController.persistence }
         set { sessionController.persistence = newValue }
@@ -645,7 +652,15 @@ public final class ChatViewModel {
     var backgroundTask: Task<Void, Never>?
     var lastPressureLevel: MemoryPressureLevel = .nominal
     private var isSynchronizingSelection = false
-    var isRestoringSession = false
+
+    /// Forwarded to ``ChatSessionManager/isRestoringSession`` so that
+    /// `ModelLoadCoordinator` can read and write it through the same path
+    /// as before extraction. All writes route through `sessionManager` to
+    /// keep the observable state in one place.
+    var isRestoringSession: Bool {
+        get { sessionManager.isRestoringSession }
+        set { sessionManager.isRestoringSession = newValue }
+    }
 
     /// Cached per-message token counts keyed by message ID, to avoid recalculating all messages.
     @ObservationIgnored
@@ -760,6 +775,7 @@ public final class ChatViewModel {
         self.toolApprovalGate = toolApprovalGate
         self.userDefaults = userDefaults
         self.sessionController = SessionController(selectedPromptTemplate: inferenceService.selectedPromptTemplate)
+        self.sessionManager = ChatSessionManager()
         self.modelRegistry = ModelRegistry(
             inferenceService: inferenceService,
             modelStorage: modelStorage
@@ -812,6 +828,7 @@ public final class ChatViewModel {
 
         startRuntimeEventDrain()
         installRegistryObservation()
+        installSessionManagerClosures()
     }
 
     deinit {

--- a/Tests/ManifoldUITests/ChatSessionManagerTests.swift
+++ b/Tests/ManifoldUITests/ChatSessionManagerTests.swift
@@ -1,0 +1,246 @@
+import XCTest
+import ManifoldInference
+import ManifoldRuntime
+@testable import ManifoldUI
+
+/// Unit tests for ``ChatSessionManager`` — verifies that the teardown
+/// choreography delegates to each injected closure and that selection
+/// resolution follows the persisted model/endpoint priority rules.
+///
+/// Tests drive `ChatSessionManager` in isolation without constructing a
+/// full `ChatViewModel`, confirming the extraction keeps the type
+/// decoupled from its collaborators.
+@MainActor
+final class ChatSessionManagerTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeEndpoint(name: String = "Test") -> APIEndpointRecord {
+        APIEndpointRecord(name: name, provider: .openAI)
+    }
+
+    private func makeModel(name: String = "Local") -> ModelInfo {
+        ModelInfo(
+            name: name,
+            fileName: "\(name).bin",
+            url: URL(fileURLWithPath: "/\(name).bin"),
+            fileSize: 0,
+            modelType: .gguf
+        )
+    }
+
+    private func silentMgr() -> ChatSessionManager {
+        let mgr = ChatSessionManager()
+        mgr.discardRequests = { _ in }
+        mgr.resetConversation = {}
+        mgr.secureWipe = {}
+        mgr.applyPromptTemplate = { _ in }
+        mgr.cancelActiveStreamHandle = {}
+        mgr.resetToolApprovals = {}
+        mgr.cancelBackgroundTask = {}
+        mgr.refreshAvailableEndpoints = {}
+        mgr.resolveModel = { _ in nil }
+        mgr.resolveEndpoint = { _ in nil }
+        return mgr
+    }
+
+    // MARK: - isRestoringSession
+
+    func test_isRestoringSession_defaultsFalse() {
+        let mgr = ChatSessionManager()
+        XCTAssertFalse(mgr.isRestoringSession)
+    }
+
+    func test_isRestoringSession_canBeToggled() {
+        let mgr = ChatSessionManager()
+        mgr.isRestoringSession = true
+        XCTAssertTrue(mgr.isRestoringSession)
+        mgr.isRestoringSession = false
+        XCTAssertFalse(mgr.isRestoringSession)
+    }
+
+    // MARK: - teardown closure ordering
+
+    func test_teardown_invokesAllClosures() async {
+        let mgr = ChatSessionManager()
+        var log: [String] = []
+
+        mgr.discardRequests = { _ in log.append("discard") }
+        mgr.resetConversation = { log.append("reset") }
+        mgr.secureWipe = { log.append("wipe") }
+        mgr.applyPromptTemplate = { _ in log.append("template") }
+        mgr.cancelActiveStreamHandle = { log.append("handle") }
+        mgr.resetToolApprovals = { log.append("approvals") }
+        mgr.cancelBackgroundTask = { log.append("bg") }
+        mgr.refreshAvailableEndpoints = { log.append("endpoints") }
+        mgr.resolveModel = { _ in nil }
+        mgr.resolveEndpoint = { _ in nil }
+
+        _ = await mgr.teardown(
+            sessionID: UUID(),
+            promptTemplate: .chatML,
+            selectionState: SessionController.SessionSelectionState(
+                selectedModelID: nil, selectedEndpointID: nil
+            )
+        )
+
+        // discardRequests must run before resetConversation/secureWipe (issue #965).
+        XCTAssertEqual(log.first, "discard",
+            "discardRequests must run first to avoid KV-cache mutation races")
+        XCTAssertTrue(log.contains("reset"))
+        XCTAssertTrue(log.contains("wipe"))
+        XCTAssertTrue(log.contains("template"))
+        XCTAssertTrue(log.contains("handle"))
+        XCTAssertTrue(log.contains("approvals"))
+        XCTAssertTrue(log.contains("bg"))
+        XCTAssertTrue(log.contains("endpoints"))
+        XCTAssertEqual(log.count, 8)
+    }
+
+    // Sabotage: wiring closures in a different order must not change execution order.
+    func test_teardown_discardFirstRegardlessOfClosureAssignmentOrder() async {
+        let mgr = ChatSessionManager()
+        var log: [String] = []
+
+        // Intentionally assign resetConversation before discardRequests.
+        mgr.resetConversation = { log.append("reset") }
+        mgr.discardRequests = { _ in log.append("discard") }
+        mgr.secureWipe = {}
+        mgr.applyPromptTemplate = { _ in }
+        mgr.cancelActiveStreamHandle = {}
+        mgr.resetToolApprovals = {}
+        mgr.cancelBackgroundTask = {}
+        mgr.refreshAvailableEndpoints = {}
+        mgr.resolveModel = { _ in nil }
+        mgr.resolveEndpoint = { _ in nil }
+
+        _ = await mgr.teardown(
+            sessionID: UUID(),
+            promptTemplate: .chatML,
+            selectionState: SessionController.SessionSelectionState(
+                selectedModelID: nil, selectedEndpointID: nil
+            )
+        )
+
+        XCTAssertEqual(log.first, "discard",
+            "discardRequests must always execute before resetConversation")
+    }
+
+    // MARK: - selection resolution
+
+    func test_teardown_returnsNilsWhenNothingPersisted() async {
+        let mgr = silentMgr()
+
+        let result = await mgr.teardown(
+            sessionID: UUID(),
+            promptTemplate: .chatML,
+            selectionState: SessionController.SessionSelectionState(
+                selectedModelID: nil, selectedEndpointID: nil
+            )
+        )
+
+        XCTAssertNil(result.resolvedModel)
+        XCTAssertNil(result.resolvedEndpoint)
+    }
+
+    func test_teardown_resolvesEndpointWhenIDPresent() async {
+        let mgr = silentMgr()
+        let endpoint = makeEndpoint()
+        mgr.resolveEndpoint = { id in id == endpoint.id ? endpoint : nil }
+
+        let result = await mgr.teardown(
+            sessionID: UUID(),
+            promptTemplate: .chatML,
+            selectionState: SessionController.SessionSelectionState(
+                selectedModelID: nil, selectedEndpointID: endpoint.id
+            )
+        )
+
+        XCTAssertEqual(result.resolvedEndpoint?.id, endpoint.id)
+        XCTAssertNil(result.resolvedModel)
+    }
+
+    func test_teardown_resolvesModelWhenIDPresent() async {
+        let mgr = silentMgr()
+        let model = makeModel()
+        mgr.resolveModel = { id in id == model.id ? model : nil }
+
+        let result = await mgr.teardown(
+            sessionID: UUID(),
+            promptTemplate: .chatML,
+            selectionState: SessionController.SessionSelectionState(
+                selectedModelID: model.id, selectedEndpointID: nil
+            )
+        )
+
+        XCTAssertEqual(result.resolvedModel?.id, model.id)
+        XCTAssertNil(result.resolvedEndpoint)
+    }
+
+    // MARK: - applySelection
+
+    func test_applySelection_prefersEndpointOverModel() {
+        let mgr = ChatSessionManager()
+
+        var modelCallCount = 0
+        var appliedEndpoint: APIEndpointRecord?
+
+        mgr.applyModelSelection = { _ in modelCallCount += 1 }
+        mgr.applyEndpointSelection = { appliedEndpoint = $0 }
+
+        let endpoint = makeEndpoint(name: "E")
+        let model = makeModel(name: "M")
+        mgr.applySelection(ChatSessionManager.TeardownResult(
+            resolvedModel: model,
+            resolvedEndpoint: endpoint
+        ))
+
+        // When an endpoint is resolved it wins; applyModelSelection must not be called.
+        XCTAssertEqual(appliedEndpoint?.id, endpoint.id)
+        XCTAssertEqual(modelCallCount, 0,
+            "applyModelSelection must not be called when endpoint is resolved")
+    }
+
+    func test_applySelection_usesModelWhenNoEndpoint() {
+        let mgr = ChatSessionManager()
+
+        var appliedModel: ModelInfo?
+        var endpointCallCount = 0
+
+        mgr.applyModelSelection = { appliedModel = $0 }
+        mgr.applyEndpointSelection = { _ in endpointCallCount += 1 }
+
+        let model = makeModel()
+        mgr.applySelection(ChatSessionManager.TeardownResult(
+            resolvedModel: model,
+            resolvedEndpoint: nil
+        ))
+
+        XCTAssertEqual(appliedModel?.id, model.id)
+        XCTAssertEqual(endpointCallCount, 0,
+            "applyEndpointSelection must not be called when only model is resolved")
+    }
+
+    func test_applySelection_clearsWhenBothNil() {
+        let mgr = ChatSessionManager()
+
+        var appliedModelArg: ModelInfo?? = .none    // .none = closure not called
+        var appliedEndpointArg: APIEndpointRecord?? = .none
+
+        // Wrap optionals in another optional to distinguish "not called" from "called with nil".
+        mgr.applyModelSelection = { appliedModelArg = .some($0) }
+        mgr.applyEndpointSelection = { appliedEndpointArg = .some($0) }
+
+        mgr.applySelection(ChatSessionManager.TeardownResult(resolvedModel: nil, resolvedEndpoint: nil))
+
+        // Both closures must be called with nil to clear any prior selection.
+        guard case .some(let m) = appliedModelArg else {
+            XCTFail("applyModelSelection was not called"); return
+        }
+        guard case .some(let e) = appliedEndpointArg else {
+            XCTFail("applyEndpointSelection was not called"); return
+        }
+        XCTAssertNil(m)
+        XCTAssertNil(e)
+    }
+}


### PR DESCRIPTION
## Assessment: what Phase 1 found already extracted

Before writing any code, I read `SessionController.swift`, `ChatViewModel.swift` (904 lines), and all 14 extension files. Here is the state of session-related extraction prior to this PR:

- **`SessionController`** — session-record activation (`activateSession`), settings I/O, message loading, pagination, and all message CRUD. Already delegated to from `ChatViewModel`.
- **`SessionManagerViewModel`** — session-list management (CRUD, search, pagination) already lives in its own `@Observable @MainActor` type.
- **Session branching** — a single `onSessionBranched` callback forwarded from `ChatViewModel+RuntimeAdapter.swift`; no new type needed.

What was **not** yet extracted: the teardown choreography inside `switchToSession` — cancelling inference, resetting the backend KV cache, tearing down the runtime stream handle, resetting the tool-approval gate, cancelling background tasks, refreshing the endpoint list, and resolving stored model/endpoint IDs to live registry objects. This lived inline in `ChatViewModel+SessionManagement.switchToSession`, tangled with eight separate collaborators.

## What this PR extracts

**`ChatSessionManager`** (`Sources/ManifoldUI/ViewModels/ChatSessionManager.swift`) — a focused `@Observable @MainActor` type that owns:

- `isRestoringSession: Bool` — previously a bare stored property on `ChatViewModel`; now observable from `sessionManager` and forwarded via a computed property so all existing readers compile unchanged.
- `teardown(sessionID:promptTemplate:selectionState:) async -> TeardownResult` — the ordered teardown sequence with its critical ordering invariant (discard-requests-before-KV-reset, see #965).
- `applySelection(_ result: TeardownResult)` — applies the resolved model/endpoint after teardown.

All collaborators (`inferenceService`, `conversationRuntime`, `toolApprovalGate`, background task handle, endpoint store) are closure-injected via `installSessionManagerClosures()`, called once at the end of `init`. `ChatSessionManager` holds no references to concrete types; every collaborator is a `(@MainActor ...) async -> Void` closure, making the type testable in isolation.

**`ChatViewModel+SessionManager.swift`** — wiring extension that assigns the closures once during `init`.

**`ChatViewModel+SessionManagement.swift`** — `switchToSession` now delegates teardown to `sessionManager.teardown(...)` and selection application to `sessionManager.applySelection(...)`. The `+SessionManagement` extension file itself remains (per #329 constraints).

## Tests

**`Tests/ManifoldUITests/ChatSessionManagerTests.swift`** (11 new tests):

- `isRestoringSession` defaults + toggle.
- `teardown` invokes all 8 closures and verifies `discardRequests` fires first (the ordering invariant that prevents KV-cache races from #965).
- Sabotage test: closure assignment order does not change execution order.
- Selection resolution: nil/nil, endpoint-only, model-only cases.
- `applySelection`: endpoint wins over model; model-only path; both-nil clears both selections.

All 385 `ManifoldUITests` pass. All existing `switchToSession`-exercising tests (`ViewModelEdgeCaseTests`) continue to pass unchanged.

## Constraints satisfied

- `ChatViewModel` public `init` signature unchanged.
- `+Messages` and `+SessionManagement` extension files kept.
- No `ObservableObject`/`@Published`, no Combine, no `try?`, no `assertionFailure`, no `Task.detached`.
- No backend family target imported from UI.
- `inferenceService` remains `internal`.

Part of #1221.