### PR TITLE
fix(test): resolve cross-test state leakage in FoundationBackend and LlamaBackend test suites

### DIFF
--- a/Tests/ManifoldBackendsTests/FoundationBackendUnitTests.swift
+++ b/Tests/ManifoldBackendsTests/FoundationBackendUnitTests.swift
@@ -50,7 +50,32 @@ final class FoundationBackendUnitTests: XCTestCase {
         guard ready else {
             throw XCTSkip("Apple Intelligence not ready — ensure it is enabled and downloaded in System Settings > Apple Intelligence & Siri")
         }
-        backend = FoundationBackend()
+        let freshBackend = FoundationBackend()
+        backend = freshBackend
+        // Register an async teardown block that stops and awaits any in-flight
+        // generation Task before ARC releases the backend.
+        //
+        // Without this, tests that call generate() without draining the resulting
+        // stream (e.g. test_loadModel_doesNotRetainProbeSessionHistory) leave a
+        // Task alive that holds a strong local reference to the FoundationBackend
+        // and its LanguageModelSession.  When the NEXT test's setUp calls
+        // probeIsReady() the system still sees an active session from the prior
+        // test, which can cause the probe to return false and the test to throw
+        // XCTSkip even on hardware that has Apple Intelligence available.
+        //
+        // FoundationBackend is @unchecked Sendable, so the direct capture is safe.
+        addTeardownBlock {
+            // Cancel any in-flight generation task and release the
+            // LanguageModelSession.  unloadModel() calls stopGeneration() which:
+            //   1. Synchronously sets _isGenerating = false and session = nil
+            //   2. Cancels the generation Task so its async body exits soon
+            // The async body holds a local strong reference to activeSession; it
+            // will release it once it observes Task.isCancelled. Yielding once
+            // gives the task a chance to run its cancellation path before the
+            // next test's setUp allocates another session. #1115.
+            freshBackend.unloadModel()
+            await Task.yield()
+        }
     }
 
     override func tearDown() {

--- a/Tests/ManifoldBackendsTests/LlamaBackendTests.swift
+++ b/Tests/ManifoldBackendsTests/LlamaBackendTests.swift
@@ -683,6 +683,16 @@ final class LlamaBackendTests: XCTestCase {
 
         let backend = LlamaBackend()
         addTeardownBlock { await backend.unloadAndWait() }
+
+        // Flush any pending detached cleanup task left by alphabetically-preceding
+        // GGUF-loading tests (e.g. test_countTokens_*). unloadAndWait() is a
+        // no-op here (nothing is loaded yet) but it awaits the prior test's
+        // cleanup chain before we touch llama.cpp, preventing the Metal pipeline
+        // from being in a partially-freed state when our first decode begins.
+        // See scripts/test-llama-isolated.sh for the single-process isolation
+        // alternative when accumulated Metal state causes persistent failures.
+        await backend.unloadAndWait()
+
         try await backend.loadModel(from: modelURL, plan: .testStub(effectiveContextSize: 512))
 
         let maxBudget = 256


### PR DESCRIPTION
## Summary

- **FoundationBackend leakage**: Tests that call `generate()` without draining the stream leave a `Task` alive that holds a strong local reference to `FoundationBackend` and its `LanguageModelSession` past the synchronous `tearDown`. The system caps concurrent `LanguageModelSession` objects, so accumulated sessions cause the next test's `probeIsReady()` to return false, producing spurious `XCTSkip` on `test_stopGeneration_resetsSession_preservesIsModelLoaded` and others that run later in the process.
- **LlamaBackend leakage**: Alphabetically-preceding GGUF-loading tests (`test_countTokens_*`) spawn a `Task.detached` cleanup that frees Metal/llama.cpp resources; when that cleanup task hasn't fully settled, the next test's first decode sees partially-freed pipeline state, causing `test_fixture_eogTokenTerminatesStreamBeforeBudget_regression519` to fail or produce 0 tokens.

## What changed

**`FoundationBackendUnitTests`** (`Tests/ManifoldBackendsTests/FoundationBackendUnitTests.swift`):
- Added an async `addTeardownBlock` from `setUp` that calls `backend.unloadModel()` + `Task.yield()` after every test. `unloadModel()` synchronously cancels the in-flight generation task and nils the `LanguageModelSession`; `Task.yield()` gives the cancelled task one scheduling opportunity to exit its body and release `activeSession` before the next test's `setUp` allocates another session.

**`LlamaBackendTests`** (`Tests/ManifoldBackendsTests/LlamaBackendTests.swift`):
- Added `await backend.unloadAndWait()` before `loadModel()` in `test_fixture_eogTokenTerminatesStreamBeforeBudget_regression519`. This is a no-op on the fresh backend, but it awaits the prior test's detached cleanup chain (via `waitForPendingCleanup()`) before touching llama.cpp, ensuring the Metal pipeline is fully quiesced. This mirrors the identical fence already in `test_stopGeneration_thenGenerate_succeeds_regression390`.

## Hardware requirements

Both failing tests require hardware traits:
- `test_stopGeneration_resetsSession_preservesIsModelLoaded` — `canImport(FoundationModels)` + Apple Intelligence available (`FoundationBackend.isAvailable == true`)
- `test_fixture_eogTokenTerminatesStreamBeforeBudget_regression519` — `--traits Llama` + a GGUF model on disk (`LLAMA_TEST_MODEL` or `~/Documents/Models/`)

CI runs `--disable-default-traits` so these tests are skipped there. To reproduce the leakage locally:
```bash
# Foundation leakage
swift test --filter FoundationBackendUnitTests

# Llama leakage — requires GGUF on disk
swift test --traits Llama --filter LlamaBackendTests
# or use the isolated script when Metal state accumulates:
scripts/test-llama-isolated.sh
```

## Test plan

- [x] `swift build --build-tests --disable-default-traits` — build clean
- [x] `scripts/test.sh --filter ManifoldBackendsTests --disable-default-traits --skip-update` — 520 passed, 0 failed (pre-existing `TrafficBoundaryAuditTest` crash unrelated to this PR)
- [ ] On hardware with Apple Intelligence: run full `FoundationBackendUnitTests` suite and confirm `test_stopGeneration_resetsSession_preservesIsModelLoaded` no longer fails mid-suite
- [ ] On Apple Silicon with GGUF on disk: `swift test --traits Llama --filter LlamaBackendTests` — confirm `test_fixture_eogTokenTerminatesStreamBeforeBudget_regression519` passes consistently

Part of #1115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)