### PR TITLE
feat: GenerationHook + CompressionPolicy for post-generation extensibility

### DIFF
--- a/Sources/ManifoldInference/Services/PromptAssembler.swift
+++ b/Sources/ManifoldInference/Services/PromptAssembler.swift
@@ -126,11 +126,17 @@ public enum PromptAssembler {
         // 6. Build the final message list, inserting history-positioned slots
         let finalMessages = insertSlotsIntoHistory(slots: sortedSlots, messages: trimmedMessages)
 
+        let totalTokens = totalSlotTokens + messageTokens
+        let contextUtilization = contextSize > 0
+            ? min(1.0, Double(totalTokens) / Double(contextSize))
+            : 0.0
+
         return AssembledPrompt(
             orderedSlots: sortedSlots,
             messages: finalMessages,
-            totalTokens: totalSlotTokens + messageTokens,
-            budgetBreakdown: budgetBreakdown
+            totalTokens: totalTokens,
+            budgetBreakdown: budgetBreakdown,
+            contextUtilization: contextUtilization
         )
     }
 

--- a/Sources/ManifoldInference/Services/PromptSlot.swift
+++ b/Sources/ManifoldInference/Services/PromptSlot.swift
@@ -360,15 +360,22 @@ public struct AssembledPrompt: Sendable {
     /// Per-slot token usage keyed by slot id.
     public let budgetBreakdown: [String: Int]
 
+    /// Fraction of the context window consumed: `totalTokens / contextSize`.
+    /// 0.0 when context size is unknown (computed by ``PromptAssembler``
+    /// overloads that receive a `contextSize` or `BackendCapabilities` argument).
+    public let contextUtilization: Double
+
     public init(
         orderedSlots: [ResolvedSlot],
         messages: [(role: String, content: String)],
         totalTokens: Int,
-        budgetBreakdown: [String: Int]
+        budgetBreakdown: [String: Int],
+        contextUtilization: Double = 0.0
     ) {
         self.orderedSlots = orderedSlots
         self.messages = messages
         self.totalTokens = totalTokens
         self.budgetBreakdown = budgetBreakdown
+        self.contextUtilization = contextUtilization
     }
 }

--- a/Sources/ManifoldRuntime/Protocols/CompressionPolicy.swift
+++ b/Sources/ManifoldRuntime/Protocols/CompressionPolicy.swift
@@ -1,0 +1,59 @@
+import Foundation
+import ManifoldInference
+
+/// Decides when and how to compress conversation history.
+///
+/// The runtime calls ``shouldCompress(promptTokens:contextSize:)`` after each
+/// successful generation turn (after hooks). When it returns `true`, the runtime
+/// calls ``compress(history:sessionID:generate:)``, replaces the stored
+/// messages with the result, and emits ``ConversationEvent/historyCompressed(sessionID:)``.
+///
+/// Compression failures are logged and do not abort the turn — the existing
+/// history is preserved.
+///
+/// ## Example
+///
+/// ```swift
+/// struct ThresholdCompressionPolicy: CompressionPolicy {
+///     let threshold: Double
+///
+///     func shouldCompress(promptTokens: Int, contextSize: Int) -> Bool {
+///         guard contextSize > 0 else { return false }
+///         return Double(promptTokens) / Double(contextSize) >= threshold
+///     }
+///
+///     func compress(history: [ChatMessageRecord], sessionID: UUID,
+///                   generate: @Sendable ([ChatMessageRecord]) async throws -> String) async throws -> [ChatMessageRecord] {
+///         // Build a summarisation prompt from old messages, call generate(),
+///         // return summary + recent messages
+///         let summary = try await generate(history)
+///         let summaryMessage = ChatMessageRecord(role: .assistant, content: summary, sessionID: sessionID)
+///         return [summaryMessage]
+///     }
+/// }
+/// ```
+public protocol CompressionPolicy: Sendable {
+    /// Returns `true` if the runtime should compress history before the next turn.
+    ///
+    /// - Parameters:
+    ///   - promptTokens: Tokens consumed by the last prompt (history + slots).
+    ///   - contextSize: Backend context window size. 0 when unknown; treat as "skip compression".
+    func shouldCompress(promptTokens: Int, contextSize: Int) -> Bool
+
+    /// Compresses message history and returns the replacement record set.
+    ///
+    /// The runtime replaces the session's stored messages with the returned
+    /// array in a bulk delete + re-insert. Return the full desired history
+    /// state, not just a diff.
+    ///
+    /// - Parameters:
+    ///   - history: Current full message history, oldest-first.
+    ///   - sessionID: The session being compressed.
+    ///   - generate: Calls the inference backend; receives messages as a
+    ///     mini-conversation and returns the model's accumulated text output.
+    func compress(
+        history: [ChatMessageRecord],
+        sessionID: UUID,
+        generate: @Sendable ([ChatMessageRecord]) async throws -> String
+    ) async throws -> [ChatMessageRecord]
+}

--- a/Sources/ManifoldRuntime/Protocols/GenerationHook.swift
+++ b/Sources/ManifoldRuntime/Protocols/GenerationHook.swift
@@ -1,0 +1,38 @@
+import Foundation
+import ManifoldInference
+
+/// A completed generation turn, passed to ``GenerationHook`` implementations.
+public struct CompletedTurn: Sendable {
+    public let sessionID: UUID
+    public let assistantMessage: ChatMessageRecord
+    public let promptTokens: Int?
+    public let completionTokens: Int?
+
+    public init(
+        sessionID: UUID,
+        assistantMessage: ChatMessageRecord,
+        promptTokens: Int?,
+        completionTokens: Int?
+    ) {
+        self.sessionID = sessionID
+        self.assistantMessage = assistantMessage
+        self.promptTokens = promptTokens
+        self.completionTokens = completionTokens
+    }
+}
+
+/// A callback invoked after each successful generation turn.
+///
+/// `postGeneration(_:)` is awaited with a configurable timeout (default 30 s).
+/// A hung hook logs a warning and is skipped; it never blocks the next turn.
+///
+/// Hooks are **not** called when:
+/// - the turn was cancelled
+/// - the stream produced an error
+/// - the assistant response was empty (no-op turn)
+///
+/// Register via
+/// ``ConversationRuntime/init(messageStore:sessionStore:inferenceService:pipeline:ragService:auxiliaryInferenceService:usageStore:generationHooks:compressionPolicy:)``.
+public protocol GenerationHook: Sendable {
+    func postGeneration(_ turn: CompletedTurn) async
+}

--- a/Sources/ManifoldRuntime/Services/ConversationPersistencePort.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationPersistencePort.swift
@@ -36,6 +36,11 @@ struct ConversationPersistencePort: Sendable {
     }
 
     @MainActor
+    func deleteMessages(for sessionID: UUID) async throws {
+        try await messageStore.deleteMessages(for: sessionID)
+    }
+
+    @MainActor
     func insertSession(_ session: ChatSessionRecord) async throws {
         guard let sessionStore else { return }
         try await sessionStore.insertSession(session)

--- a/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
@@ -847,16 +847,27 @@ struct ConversationTurnExecutor: Sendable {
                 // so compression doesn't compete with the user's next turn.
                 let generate: @Sendable ([ChatMessageRecord]) async throws -> String = { [inferenceService] messages in
                     let structured = messages.map { StructuredMessage(role: $0.role.rawValue, parts: $0.contentParts) }
-                    let (_, compressStream) = try await inferenceService.enqueueAsync(
+                    let (token, compressStream) = try await inferenceService.enqueueAsync(
                         structuredMessages: structured,
                         priority: .background
                     )
                     var result = ""
                     var consumer = GenerationStreamConsumer(loopDetectionEnabled: false)
-                    for try await event in compressStream.events {
-                        if case .appendText(let chunk) = consumer.handle(event) {
-                            result += chunk
+                    do {
+                        for try await event in compressStream.events {
+                            // Propagate parent-task cancellation into the
+                            // backend stream so we don't keep draining after
+                            // the runtime has moved on.
+                            try Task.checkCancellation()
+                            if case .appendText(let chunk) = consumer.handle(event) {
+                                result += chunk
+                            }
                         }
+                    } catch {
+                        // Cancel the backend token on any exit (cancellation or
+                        // inference error) so the backend doesn't keep running.
+                        await inferenceService.cancelAsync(token)
+                        throw error
                     }
                     return result
                 }
@@ -867,6 +878,16 @@ struct ConversationTurnExecutor: Sendable {
                         sessionID: sessionID,
                         generate: generate
                     )
+                    // Guard against an empty result — deleting all messages
+                    // without re-inserting anything would silently wipe the
+                    // conversation. Treat this as a policy error; preserve the
+                    // existing history rather than destroying it.
+                    guard !compressed.isEmpty else {
+                        Log.inference.warning(
+                            "CompressionPolicy.compress returned empty history (sessionID=\(sessionID, privacy: .private)); skipping replacement to preserve existing messages"
+                        )
+                        return
+                    }
                     try await persistence.deleteMessages(for: sessionID)
                     for message in compressed {
                         try await persistence.insertMessage(message)

--- a/Tests/ManifoldInferenceTests/PromptAssemblerUtilizationTests.swift
+++ b/Tests/ManifoldInferenceTests/PromptAssemblerUtilizationTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import ManifoldInference
+
+/// Coverage for ``AssembledPrompt/contextUtilization`` — the fraction of the
+/// context window consumed by a prompt assembly pass.
+final class PromptAssemblerUtilizationTests: XCTestCase {
+
+    private static let sessionID = UUID()
+
+    private func makeMessages(_ texts: [String], roles: [MessageRole]? = nil) -> [ChatMessageRecord] {
+        texts.enumerated().map { i, text in
+            let role = roles?[i] ?? (i % 2 == 0 ? .user : .assistant)
+            return ChatMessageRecord(role: role, content: text, sessionID: Self.sessionID)
+        }
+    }
+
+    // MARK: - Test 1: utilization computed correctly
+
+    func test_contextUtilization_isRatioOfTotalTokensToContextSize() {
+        // Use HeuristicTokenizer (the default): ~1 token per 4 chars.
+        // "hello" ≈ 1 token. Build a small message set.
+        let messages = makeMessages(["hello world", "how are you"])
+        let contextSize = 100
+
+        let assembled = PromptAssembler.assemble(
+            slots: [],
+            messages: messages,
+            systemPrompt: nil,
+            contextSize: contextSize
+        )
+
+        // Utilization must equal totalTokens / contextSize, capped at 1.0.
+        let expected = min(1.0, Double(assembled.totalTokens) / Double(contextSize))
+        XCTAssertEqual(assembled.contextUtilization, expected, accuracy: 1e-9)
+        // Should be positive (there are messages), and at most 1.0.
+        XCTAssertGreaterThan(assembled.contextUtilization, 0.0)
+        XCTAssertLessThanOrEqual(assembled.contextUtilization, 1.0)
+    }
+
+    // MARK: - Test 2: utilization capped at 1.0
+
+    func test_contextUtilization_cappedAtOneWhenTokensExceedContextSize() {
+        // A tiny context window forces utilization to 1.0 even with few tokens.
+        let messages = makeMessages(["This is a somewhat longer message that should exceed a tiny context."])
+        let contextSize = 1  // impossibly small
+
+        let assembled = PromptAssembler.assemble(
+            slots: [],
+            messages: messages,
+            systemPrompt: nil,
+            contextSize: contextSize
+        )
+
+        // Regardless of how many tokens the message has, utilization ≤ 1.0.
+        XCTAssertLessThanOrEqual(
+            assembled.contextUtilization,
+            1.0,
+            "contextUtilization must never exceed 1.0 even when totalTokens > contextSize"
+        )
+        XCTAssertEqual(
+            assembled.contextUtilization,
+            1.0,
+            accuracy: 1e-9,
+            "contextUtilization should be 1.0 when the prompt is at or over capacity"
+        )
+    }
+
+    // MARK: - Test 3: utilization is 0.0 when contextSize is 0
+
+    func test_contextUtilization_isZeroWhenContextSizeIsZero() {
+        let messages = makeMessages(["hello"])
+        let assembled = PromptAssembler.assemble(
+            slots: [],
+            messages: messages,
+            systemPrompt: nil,
+            contextSize: 0
+        )
+
+        XCTAssertEqual(
+            assembled.contextUtilization,
+            0.0,
+            accuracy: 1e-9,
+            "contextUtilization should be 0.0 when contextSize is unknown (0)"
+        )
+    }
+
+    // MARK: - Test 4: capabilities overload populates utilization
+
+    func test_contextUtilization_populatedByCapabilitiesOverload() {
+        let messages = makeMessages(["hi there"])
+        let caps = BackendCapabilities(
+            supportedParameters: [],
+            maxContextTokens: 200,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true
+        )
+
+        let assembled = PromptAssembler.assemble(
+            slots: [],
+            messages: messages,
+            systemPrompt: nil,
+            capabilities: caps
+        )
+
+        // contextWindowSize = Int(maxContextTokens) = 200.
+        let expected = min(1.0, Double(assembled.totalTokens) / Double(caps.contextWindowSize))
+        XCTAssertEqual(assembled.contextUtilization, expected, accuracy: 1e-9)
+    }
+}

--- a/Tests/ManifoldRuntimeTests/CompressionPolicyTests.swift
+++ b/Tests/ManifoldRuntimeTests/CompressionPolicyTests.swift
@@ -1,0 +1,413 @@
+@preconcurrency import XCTest
+import Foundation
+@testable import ManifoldRuntime
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+/// Coverage for ``CompressionPolicy`` — history compression triggered by
+/// ``ConversationRuntime`` after successful generation turns.
+@MainActor
+final class CompressionPolicyTests: XCTestCase {
+
+    // MARK: - In-memory MessageStore
+
+    @MainActor
+    final class RuntimeMessageStore: MessageStore {
+        private(set) var messages: [UUID: ChatMessageRecord] = [:]
+        private var hooks: [any MessageStorePostWriteHook] = []
+
+        func insertMessage(_ message: ChatMessageRecord) async throws {
+            messages[message.id] = message
+            for hook in hooks {
+                await hook.messageDidWrite(message, in: message.sessionID)
+            }
+        }
+
+        func updateMessage(_ message: ChatMessageRecord) async throws {
+            guard messages[message.id] != nil else {
+                throw ChatPersistenceError.messageNotFound(message.id)
+            }
+            messages[message.id] = message
+        }
+
+        func deleteMessage(_ messageID: UUID) async throws {
+            guard messages.removeValue(forKey: messageID) != nil else {
+                throw ChatPersistenceError.messageNotFound(messageID)
+            }
+        }
+
+        func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
+            messages.values
+                .filter { $0.sessionID == sessionID }
+                .sorted { $0.timestamp < $1.timestamp }
+        }
+
+        func deleteMessages(for sessionID: UUID) async throws {
+            messages = messages.filter { $0.value.sessionID != sessionID }
+        }
+
+        func addPostWriteHook(_ hook: any MessageStorePostWriteHook) {
+            hooks.append(hook)
+        }
+    }
+
+    // MARK: - Backend that reports token usage
+
+    /// Wraps MockInferenceBackend and adds a per-turn token-usage emission.
+    /// Compression requires non-nil `usage?.promptTokens`, which the standard
+    /// MockInferenceBackend doesn't provide; this shim injects usage events.
+    final class UsageReportingBackend: InferenceBackend, TokenUsageProvider, @unchecked Sendable {
+        let inner: MockInferenceBackend
+        var lastUsage: (promptTokens: Int, completionTokens: Int)?
+
+        init(inner: MockInferenceBackend) {
+            self.inner = inner
+        }
+
+        var isModelLoaded: Bool {
+            get { inner.isModelLoaded }
+            set { inner.isModelLoaded = newValue }
+        }
+
+        var isGenerating: Bool { inner.isGenerating }
+
+        var capabilities: BackendCapabilities { inner.capabilities }
+
+        func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
+            try await inner.loadModel(from: url, plan: plan)
+        }
+
+        func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> GenerationStream {
+            let innerStream = try inner.generate(prompt: prompt, systemPrompt: systemPrompt, config: config)
+            // Wrap the inner stream to inject a usage event before finishing.
+            return GenerationStream(AsyncThrowingStream<GenerationEvent, Error> { [self] continuation in
+                Task {
+                    do {
+                        for try await event in innerStream.events {
+                            continuation.yield(event)
+                        }
+                        // Inject usage after all content tokens.
+                        let promptTokens = 50
+                        let completionTokens = 10
+                        continuation.yield(.usage(prompt: promptTokens, completion: completionTokens))
+                        self.lastUsage = (promptTokens, completionTokens)
+                        continuation.finish()
+                    } catch {
+                        continuation.finish(throwing: error)
+                    }
+                }
+            })
+        }
+
+        func stopGeneration() { inner.stopGeneration() }
+
+        func unloadModel() { inner.unloadModel() }
+    }
+
+    // MARK: - Call counter (actor for Sendable safety)
+
+    actor CallCounter {
+        private(set) var count = 0
+        func increment() { count += 1 }
+    }
+
+    // MARK: - Policy implementations for tests
+
+    /// Policy that always returns `true` from `shouldCompress`.
+    struct AlwaysCompressPolicy: CompressionPolicy {
+        let summaryContent: String
+        let counter: CallCounter
+
+        init(summaryContent: String = "Summary") {
+            self.summaryContent = summaryContent
+            self.counter = CallCounter()
+        }
+
+        func shouldCompress(promptTokens: Int, contextSize: Int) -> Bool {
+            guard contextSize > 0 else { return false }
+            return true
+        }
+
+        func compress(
+            history: [ChatMessageRecord],
+            sessionID: UUID,
+            generate: @Sendable ([ChatMessageRecord]) async throws -> String
+        ) async throws -> [ChatMessageRecord] {
+            await counter.increment()
+            return [ChatMessageRecord(role: .assistant, content: summaryContent, sessionID: sessionID)]
+        }
+    }
+
+    /// Policy that always returns `false` from `shouldCompress`.
+    struct NeverCompressPolicy: CompressionPolicy {
+        let counter: CallCounter
+
+        init() {
+            self.counter = CallCounter()
+        }
+
+        func shouldCompress(promptTokens: Int, contextSize: Int) -> Bool {
+            false
+        }
+
+        func compress(
+            history: [ChatMessageRecord],
+            sessionID: UUID,
+            generate: @Sendable ([ChatMessageRecord]) async throws -> String
+        ) async throws -> [ChatMessageRecord] {
+            await counter.increment()
+            return history
+        }
+    }
+
+    /// Policy that throws from `compress`.
+    struct FailingCompressPolicy: CompressionPolicy {
+        struct CompressionError: Error {}
+
+        func shouldCompress(promptTokens: Int, contextSize: Int) -> Bool {
+            contextSize > 0
+        }
+
+        func compress(
+            history: [ChatMessageRecord],
+            sessionID: UUID,
+            generate: @Sendable ([ChatMessageRecord]) async throws -> String
+        ) async throws -> [ChatMessageRecord] {
+            throw CompressionError()
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeMockWithUsage(
+        tokensToYield: [String] = ["ok"],
+        contextTokens: Int32 = 1024
+    ) -> UsageReportingBackend {
+        let inner = MockInferenceBackend(capabilities: BackendCapabilities(
+            supportedParameters: [],
+            maxContextTokens: contextTokens,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true
+        ))
+        inner.tokensToYield = tokensToYield
+        inner.isModelLoaded = true
+        return UsageReportingBackend(inner: inner)
+    }
+
+    private func drainUntilStreamFinished(
+        from runtime: ConversationRuntime,
+        deadline: Duration = .seconds(5)
+    ) async throws -> [ConversationEvent] {
+        var collected: [ConversationEvent] = []
+        let task = Task {
+            for await event in runtime.events {
+                collected.append(event)
+                if case .streamFinished = event { break }
+            }
+            return collected
+        }
+        let result = try await withThrowingTaskGroup(of: [ConversationEvent].self) { group in
+            group.addTask { await task.value }
+            group.addTask {
+                try await Task.sleep(for: deadline)
+                task.cancel()
+                throw TestError.deadlineElapsed
+            }
+            let first = try await group.next()
+            group.cancelAll()
+            return first ?? []
+        }
+        return result
+    }
+
+    private func drainUntilHistoryCompressed(
+        from runtime: ConversationRuntime,
+        deadline: Duration = .seconds(5)
+    ) async throws -> [ConversationEvent] {
+        var collected: [ConversationEvent] = []
+        let task = Task {
+            for await event in runtime.events {
+                collected.append(event)
+                if case .historyCompressed = event { break }
+            }
+            return collected
+        }
+        let result = try await withThrowingTaskGroup(of: [ConversationEvent].self) { group in
+            group.addTask { await task.value }
+            group.addTask {
+                try await Task.sleep(for: deadline)
+                task.cancel()
+                throw TestError.deadlineElapsed
+            }
+            let first = try await group.next()
+            group.cancelAll()
+            return first ?? []
+        }
+        return result
+    }
+
+    enum TestError: Error { case deadlineElapsed }
+
+    // MARK: - Test 1: policy called when threshold met
+
+    func test_policy_compressCalledWhenShouldCompressReturnsTrue() async throws {
+        // UsageReportingBackend always emits 50 prompt tokens; contextSize=1024.
+        // AlwaysCompressPolicy.shouldCompress returns true for any contextSize > 0.
+        let backend = makeMockWithUsage(tokensToYield: ["ok"])
+        // The compression generate() call also hits the backend — seed a second response.
+        backend.inner.tokensToYieldPerTurn = [["ok"], ["summary text"]]
+
+        let policy = AlwaysCompressPolicy(summaryContent: "summary text")
+        let inference = InferenceService(backend: backend, name: "Mock")
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference,
+            compressionPolicy: policy
+        )
+
+        let sessionID = UUID()
+        _ = try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hi", attachments: []),
+            config: TurnConfig()
+        ))
+
+        // Wait for historyCompressed to confirm compression ran.
+        let events = try await drainUntilHistoryCompressed(from: runtime)
+        let compressed = events.contains { if case .historyCompressed = $0 { return true }; return false }
+
+        let callCount = await policy.counter.count
+        XCTAssertEqual(callCount, 1, "compress() should be called when shouldCompress returns true")
+        XCTAssertTrue(compressed, "historyCompressed event should be emitted")
+    }
+
+    // MARK: - Test 2: policy not called when threshold not met
+
+    func test_policy_compressNotCalledWhenShouldCompressReturnsFalse() async throws {
+        let backend = makeMockWithUsage()
+        let policy = NeverCompressPolicy()
+        let inference = InferenceService(backend: backend, name: "Mock")
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference,
+            compressionPolicy: policy
+        )
+
+        let sessionID = UUID()
+        _ = try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hi", attachments: []),
+            config: TurnConfig()
+        ))
+        _ = try await drainUntilStreamFinished(from: runtime)
+        // Brief wait to confirm compress() never fires.
+        try await Task.sleep(for: .milliseconds(200))
+
+        let callCount = await policy.counter.count
+        XCTAssertEqual(callCount, 0, "compress() must not be called when shouldCompress returns false")
+    }
+
+    // MARK: - Test 3: compressed messages replace store
+
+    func test_policy_compressedMessagesReplaceStore() async throws {
+        let summaryContent = "The summary"
+        let backend = makeMockWithUsage(tokensToYield: ["ok"])
+        // Second generate() call (from policy's generate closure) returns the summary.
+        backend.inner.tokensToYieldPerTurn = [["ok"], [summaryContent]]
+
+        let policy = AlwaysCompressPolicy(summaryContent: summaryContent)
+        let inference = InferenceService(backend: backend, name: "Mock")
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference,
+            compressionPolicy: policy
+        )
+
+        let sessionID = UUID()
+        _ = try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hi", attachments: []),
+            config: TurnConfig()
+        ))
+        _ = try await drainUntilHistoryCompressed(from: runtime)
+        // Allow time for post-compression persistence.
+        try await Task.sleep(for: .milliseconds(300))
+
+        let remaining = try await store.fetchMessages(for: sessionID)
+        // After compression: only the summary message should remain.
+        XCTAssertEqual(remaining.count, 1, "Store should contain only the compressed summary message")
+        XCTAssertEqual(remaining[0].content, summaryContent)
+    }
+
+    // MARK: - Test 4: compression failure does not abort turn
+
+    func test_policy_compressionFailureDoesNotAbortTurn() async throws {
+        let backend = makeMockWithUsage()
+        let policy = FailingCompressPolicy()
+        let inference = InferenceService(backend: backend, name: "Mock")
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference,
+            compressionPolicy: policy
+        )
+
+        let sessionID = UUID()
+        _ = try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hi", attachments: []),
+            config: TurnConfig()
+        ))
+
+        // streamFinished must still arrive despite compression throwing.
+        let events = try await drainUntilStreamFinished(from: runtime)
+        let streamFinished = events.contains {
+            if case .streamFinished(_, let reason) = $0, reason == .stop { return true }
+            return false
+        }
+        XCTAssertTrue(streamFinished, "streamFinished(reason: .stop) must still emit when compression fails")
+
+        // No historyCompressed event — compression threw before completion.
+        let compressed = events.contains { if case .historyCompressed = $0 { return true }; return false }
+        XCTAssertFalse(compressed, "historyCompressed must not emit when compression throws")
+    }
+
+    // MARK: - Test 5: policy skipped when contextSize is 0
+
+    func test_policy_skippedWhenContextSizeIsZero() async throws {
+        // Backend with contextWindowSize = 0.
+        let inner = MockInferenceBackend(capabilities: BackendCapabilities(
+            supportedParameters: [],
+            maxContextTokens: Int32(0),
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true
+        ))
+        inner.tokensToYield = ["ok"]
+        inner.isModelLoaded = true
+        let backend = UsageReportingBackend(inner: inner)
+
+        let policy = AlwaysCompressPolicy(summaryContent: "never")
+        let inference = InferenceService(backend: backend, name: "Mock")
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference,
+            compressionPolicy: policy
+        )
+
+        let sessionID = UUID()
+        _ = try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hi", attachments: []),
+            config: TurnConfig()
+        ))
+        _ = try await drainUntilStreamFinished(from: runtime)
+        try await Task.sleep(for: .milliseconds(200))
+
+        let callCount = await policy.counter.count
+        XCTAssertEqual(callCount, 0, "compress() must not be called when contextSize is 0")
+    }
+}

--- a/Tests/ManifoldRuntimeTests/CompressionPolicyTests.swift
+++ b/Tests/ManifoldRuntimeTests/CompressionPolicyTests.swift
@@ -55,13 +55,25 @@ final class CompressionPolicyTests: XCTestCase {
 
     /// Wraps MockInferenceBackend and adds a per-turn token-usage emission.
     /// Compression requires non-nil `usage?.promptTokens`, which the standard
-    /// MockInferenceBackend doesn't provide; this shim injects usage events.
+    /// MockInferenceBackend doesn't provide; this shim injects `.usage` events
+    /// into the stream so the runtime's token-usage tracking activates.
+    ///
+    /// `lastUsage` is a computed constant — no state is mutated after init, so
+    /// the `@unchecked Sendable` marker is sound (inner is itself @unchecked Sendable
+    /// and there is no additional mutable state on this type).
     final class UsageReportingBackend: InferenceBackend, TokenUsageProvider, @unchecked Sendable {
         let inner: MockInferenceBackend
-        var lastUsage: (promptTokens: Int, completionTokens: Int)?
 
         init(inner: MockInferenceBackend) {
             self.inner = inner
+        }
+
+        // TokenUsageProvider — the runtime reads this as a fallback when no
+        // in-stream usage event arrived. The injected .usage events below take
+        // precedence via `tokenUsage` in the stream consumer, so this value
+        // is only a safety net.
+        var lastUsage: (promptTokens: Int, completionTokens: Int)? {
+            (50, 10)
         }
 
         var isModelLoaded: Bool {
@@ -79,18 +91,15 @@ final class CompressionPolicyTests: XCTestCase {
 
         func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> GenerationStream {
             let innerStream = try inner.generate(prompt: prompt, systemPrompt: systemPrompt, config: config)
-            // Wrap the inner stream to inject a usage event before finishing.
-            return GenerationStream(AsyncThrowingStream<GenerationEvent, Error> { [self] continuation in
+            // Inject a usage event after all content tokens so the runtime's
+            // in-stream usage tracking fires (which the compression gate relies on).
+            return GenerationStream(AsyncThrowingStream<GenerationEvent, Error> { continuation in
                 Task {
                     do {
                         for try await event in innerStream.events {
                             continuation.yield(event)
                         }
-                        // Inject usage after all content tokens.
-                        let promptTokens = 50
-                        let completionTokens = 10
-                        continuation.yield(.usage(prompt: promptTokens, completion: completionTokens))
-                        self.lastUsage = (promptTokens, completionTokens)
+                        continuation.yield(.usage(prompt: 50, completion: 10))
                         continuation.finish()
                     } catch {
                         continuation.finish(throwing: error)
@@ -174,6 +183,22 @@ final class CompressionPolicyTests: XCTestCase {
             generate: @Sendable ([ChatMessageRecord]) async throws -> String
         ) async throws -> [ChatMessageRecord] {
             throw CompressionError()
+        }
+    }
+
+    /// Policy that returns an empty array from `compress` — simulates a policy
+    /// that mistakenly returns nothing. The runtime must not delete all messages.
+    struct EmptyReturnCompressPolicy: CompressionPolicy {
+        func shouldCompress(promptTokens: Int, contextSize: Int) -> Bool {
+            contextSize > 0
+        }
+
+        func compress(
+            history: [ChatMessageRecord],
+            sessionID: UUID,
+            generate: @Sendable ([ChatMessageRecord]) async throws -> String
+        ) async throws -> [ChatMessageRecord] {
+            return []  // Intentionally returns nothing — should be treated as an error.
         }
     }
 
@@ -375,7 +400,42 @@ final class CompressionPolicyTests: XCTestCase {
         XCTAssertFalse(compressed, "historyCompressed must not emit when compression throws")
     }
 
-    // MARK: - Test 5: policy skipped when contextSize is 0
+    // MARK: - Test 5 (new): empty compress() result does not delete all messages
+
+    func test_policy_emptyCompressResultPreservesExistingHistory() async throws {
+        // If a policy returns an empty array from compress(), the runtime must
+        // NOT delete all messages. The conversation history must be preserved
+        // and historyCompressed must not fire.
+        let backend = makeMockWithUsage(tokensToYield: ["ok"])
+        let policy = EmptyReturnCompressPolicy()
+        let inference = InferenceService(backend: backend, name: "Mock")
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference,
+            compressionPolicy: policy
+        )
+
+        let sessionID = UUID()
+        _ = try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hi", attachments: []),
+            config: TurnConfig()
+        ))
+        _ = try await drainUntilStreamFinished(from: runtime)
+        // Give the compression path time to run (or not run).
+        try await Task.sleep(for: .milliseconds(300))
+
+        let remaining = try await store.fetchMessages(for: sessionID)
+        // The original user + assistant messages must still be in the store.
+        XCTAssertGreaterThan(
+            remaining.count,
+            0,
+            "Empty compress() result must not wipe the store; existing history must be preserved"
+        )
+    }
+
+    // MARK: - Test 7: policy skipped when contextSize is 0
 
     func test_policy_skippedWhenContextSizeIsZero() async throws {
         // Backend with contextWindowSize = 0.
@@ -409,5 +469,160 @@ final class CompressionPolicyTests: XCTestCase {
 
         let callCount = await policy.counter.count
         XCTAssertEqual(callCount, 0, "compress() must not be called when contextSize is 0")
+    }
+
+    // MARK: - Test 8: no-op compression (same history returned) does not clear the store
+
+    func test_policy_noOpCompressionPreservesHistory() async throws {
+        // A policy that returns the full history unchanged is a valid no-op.
+        // The store must be replaced with the same content — same count, same
+        // contents (different record IDs because the runtime re-inserts).
+        struct IdentityCompressPolicy: CompressionPolicy {
+            func shouldCompress(promptTokens: Int, contextSize: Int) -> Bool {
+                contextSize > 0
+            }
+
+            func compress(
+                history: [ChatMessageRecord],
+                sessionID: UUID,
+                generate: @Sendable ([ChatMessageRecord]) async throws -> String
+            ) async throws -> [ChatMessageRecord] {
+                // Return history with fresh IDs + same sessionID so they can
+                // be re-inserted (store rejects duplicates for existing IDs).
+                return history.map {
+                    ChatMessageRecord(role: $0.role, content: $0.content, sessionID: $0.sessionID)
+                }
+            }
+        }
+
+        let backend = makeMockWithUsage(tokensToYield: ["response"])
+        let inference = InferenceService(backend: backend, name: "Mock")
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference,
+            compressionPolicy: IdentityCompressPolicy()
+        )
+
+        let sessionID = UUID()
+        _ = try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hi", attachments: []),
+            config: TurnConfig()
+        ))
+        _ = try await drainUntilHistoryCompressed(from: runtime)
+        try await Task.sleep(for: .milliseconds(200))
+
+        // The store should still have the compressed history (same count as pre-
+        // compression: user + assistant = 2).
+        let remaining = try await store.fetchMessages(for: sessionID)
+        XCTAssertEqual(remaining.count, 2, "No-op compression must preserve message count")
+        XCTAssertTrue(remaining.contains { $0.role == .user }, "User message must be preserved")
+        XCTAssertTrue(remaining.contains { $0.role == .assistant }, "Assistant message must be preserved")
+    }
+
+    // MARK: - Test 9: generate closure receives post-turn history
+
+    func test_policy_generateClosureReceivesPostTurnHistory() async throws {
+        // After the turn completes (user + assistant persisted), the runtime
+        // fetches fresh history before calling compress(). The history passed
+        // to compress() must include the just-inserted assistant message.
+        actor HistoryCapture {
+            private(set) var capturedHistory: [ChatMessageRecord]?
+            func capture(_ history: [ChatMessageRecord]) { capturedHistory = history }
+        }
+
+        let capture = HistoryCapture()
+
+        struct CapturingPolicy: CompressionPolicy {
+            let capture: HistoryCapture
+
+            func shouldCompress(promptTokens: Int, contextSize: Int) -> Bool {
+                contextSize > 0
+            }
+
+            func compress(
+                history: [ChatMessageRecord],
+                sessionID: UUID,
+                generate: @Sendable ([ChatMessageRecord]) async throws -> String
+            ) async throws -> [ChatMessageRecord] {
+                await capture.capture(history)
+                // Return the same history (re-wrapped with fresh IDs).
+                return history.map {
+                    ChatMessageRecord(role: $0.role, content: $0.content, sessionID: $0.sessionID)
+                }
+            }
+        }
+
+        let backend = makeMockWithUsage(tokensToYield: ["assistant reply"])
+        let inference = InferenceService(backend: backend, name: "Mock")
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference,
+            compressionPolicy: CapturingPolicy(capture: capture)
+        )
+
+        let sessionID = UUID()
+        _ = try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hello there", attachments: []),
+            config: TurnConfig()
+        ))
+        _ = try await drainUntilHistoryCompressed(from: runtime)
+        try await Task.sleep(for: .milliseconds(200))
+
+        let history = await capture.capturedHistory
+        XCTAssertNotNil(history, "compress() must receive history")
+        // The history passed to compress() must include the assistant message
+        // that was just generated — it is the post-turn snapshot.
+        let assistantMessages = history?.filter { $0.role == .assistant } ?? []
+        XCTAssertFalse(
+            assistantMessages.isEmpty,
+            "History passed to compress() must include the assistant message from the completed turn"
+        )
+        let userMessages = history?.filter { $0.role == .user } ?? []
+        XCTAssertFalse(
+            userMessages.isEmpty,
+            "History passed to compress() must include the user message that triggered the turn"
+        )
+    }
+
+    // MARK: - Test 10: old messages are removed after compression
+
+    func test_policy_oldMessagesRemovedAfterCompression() async throws {
+        // After compression, the original user and assistant messages must no
+        // longer exist in the store — only the compressed replacement remains.
+        let summaryContent = "Compressed summary"
+        let backend = makeMockWithUsage(tokensToYield: ["original response"])
+        backend.inner.tokensToYieldPerTurn = [["original response"], [summaryContent]]
+
+        let policy = AlwaysCompressPolicy(summaryContent: summaryContent)
+        let inference = InferenceService(backend: backend, name: "Mock")
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference,
+            compressionPolicy: policy
+        )
+
+        let sessionID = UUID()
+        _ = try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Original user message", attachments: []),
+            config: TurnConfig()
+        ))
+        _ = try await drainUntilHistoryCompressed(from: runtime)
+        try await Task.sleep(for: .milliseconds(300))
+
+        let remaining = try await store.fetchMessages(for: sessionID)
+        // Old user message must be gone.
+        XCTAssertFalse(
+            remaining.contains { $0.role == .user },
+            "Original user messages must be removed after bulk-replace compression"
+        )
+        // Only the summary (assistant role) must remain.
+        XCTAssertEqual(remaining.count, 1)
+        XCTAssertEqual(remaining[0].content, summaryContent)
     }
 }

--- a/Tests/ManifoldRuntimeTests/GenerationHookTests.swift
+++ b/Tests/ManifoldRuntimeTests/GenerationHookTests.swift
@@ -1,0 +1,318 @@
+@preconcurrency import XCTest
+import Foundation
+@testable import ManifoldRuntime
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+/// Coverage for ``GenerationHook`` — post-generation turn callbacks registered
+/// on ``ConversationRuntime``.
+///
+/// Uses the same in-memory store and mock backend shapes as
+/// `ConversationRuntimeTests` so both fixtures stay independent.
+@MainActor
+final class GenerationHookTests: XCTestCase {
+
+    // MARK: - In-memory MessageStore
+
+    @MainActor
+    final class RuntimeMessageStore: MessageStore {
+        private(set) var messages: [UUID: ChatMessageRecord] = [:]
+        private var hooks: [any MessageStorePostWriteHook] = []
+
+        func insertMessage(_ message: ChatMessageRecord) async throws {
+            messages[message.id] = message
+            for hook in hooks {
+                await hook.messageDidWrite(message, in: message.sessionID)
+            }
+        }
+
+        func updateMessage(_ message: ChatMessageRecord) async throws {
+            guard messages[message.id] != nil else {
+                throw ChatPersistenceError.messageNotFound(message.id)
+            }
+            messages[message.id] = message
+        }
+
+        func deleteMessage(_ messageID: UUID) async throws {
+            guard messages.removeValue(forKey: messageID) != nil else {
+                throw ChatPersistenceError.messageNotFound(messageID)
+            }
+        }
+
+        func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
+            messages.values
+                .filter { $0.sessionID == sessionID }
+                .sorted { $0.timestamp < $1.timestamp }
+        }
+
+        func deleteMessages(for sessionID: UUID) async throws {
+            messages = messages.filter { $0.value.sessionID != sessionID }
+        }
+
+        func addPostWriteHook(_ hook: any MessageStorePostWriteHook) {
+            hooks.append(hook)
+        }
+    }
+
+    // MARK: - Hook implementations for tests
+
+    /// Hook that records every completed turn it receives.
+    actor RecordingHook: GenerationHook {
+        private(set) var receivedTurns: [CompletedTurn] = []
+
+        func postGeneration(_ turn: CompletedTurn) async {
+            receivedTurns.append(turn)
+        }
+    }
+
+    /// Hook that blocks indefinitely — used to verify timeout behaviour.
+    struct HangingHook: GenerationHook {
+        func postGeneration(_ turn: CompletedTurn) async {
+            // Sleep for a very long time; the runtime's timeout will cancel this task.
+            try? await Task.sleep(for: .seconds(3600))
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeRuntime(
+        mock: MockInferenceBackend? = nil,
+        generationHooks: [any GenerationHook] = [],
+        hookTimeout: Duration = .seconds(30)
+    ) -> (runtime: ConversationRuntime, store: RuntimeMessageStore, mock: MockInferenceBackend) {
+        let backend = mock ?? MockInferenceBackend()
+        backend.isModelLoaded = true
+        let inference = InferenceService(backend: backend, name: "Mock")
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference,
+            generationHooks: generationHooks
+        )
+        return (runtime, store, backend)
+    }
+
+    private func collectUntilAfterGeneration(
+        from runtime: ConversationRuntime,
+        deadline: Duration = .seconds(5)
+    ) async throws -> [ConversationEvent] {
+        var collected: [ConversationEvent] = []
+        let task = Task {
+            for await event in runtime.events {
+                collected.append(event)
+                if case .afterGeneration = event { break }
+            }
+            return collected
+        }
+        let result = try await withThrowingTaskGroup(of: [ConversationEvent].self) { group in
+            group.addTask { await task.value }
+            group.addTask {
+                try await Task.sleep(for: deadline)
+                task.cancel()
+                throw TestError.deadlineElapsed
+            }
+            let first = try await group.next()
+            group.cancelAll()
+            return first ?? []
+        }
+        return result
+    }
+
+    private func collectUntilStreamFinished(
+        from runtime: ConversationRuntime,
+        deadline: Duration = .seconds(5)
+    ) async throws -> [ConversationEvent] {
+        var collected: [ConversationEvent] = []
+        let task = Task {
+            for await event in runtime.events {
+                collected.append(event)
+                if case .streamFinished = event { break }
+            }
+            return collected
+        }
+        let result = try await withThrowingTaskGroup(of: [ConversationEvent].self) { group in
+            group.addTask { await task.value }
+            group.addTask {
+                try await Task.sleep(for: deadline)
+                task.cancel()
+                throw TestError.deadlineElapsed
+            }
+            let first = try await group.next()
+            group.cancelAll()
+            return first ?? []
+        }
+        return result
+    }
+
+    enum TestError: Error { case deadlineElapsed }
+
+    // MARK: - Test 1: hook fires on success
+
+    func test_hook_firesAfterSuccessfulTurn() async throws {
+        let hook = RecordingHook()
+        let mock = MockInferenceBackend()
+        mock.tokensToYield = ["Hello", " world"]
+
+        let (runtime, _, _) = makeRuntime(mock: mock, generationHooks: [hook])
+        let sessionID = UUID()
+
+        _ = try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hi", attachments: []),
+            config: TurnConfig()
+        ))
+        _ = try await collectUntilAfterGeneration(from: runtime)
+
+        // Give the hook time to run (it fires after afterGeneration is emitted).
+        try await Task.sleep(for: .milliseconds(200))
+
+        let turns = await hook.receivedTurns
+        XCTAssertEqual(turns.count, 1, "Hook should fire exactly once per successful turn")
+        XCTAssertEqual(turns[0].sessionID, sessionID)
+        XCTAssertEqual(turns[0].assistantMessage.role, .assistant)
+        XCTAssertEqual(turns[0].assistantMessage.content, "Hello world")
+    }
+
+    // MARK: - Test 2: hook not called on cancel
+
+    func test_hook_notCalledWhenTurnIsCancelled() async throws {
+        let hook = RecordingHook()
+        let mock = MockInferenceBackend()
+        // Slow stream so we have time to cancel mid-turn.
+        mock.tokensToYield = ["slow"]
+
+        let (runtime, _, _) = makeRuntime(mock: mock, generationHooks: [hook])
+        let sessionID = UUID()
+
+        let handle = try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hi", attachments: []),
+            config: TurnConfig()
+        ))!
+
+        // Cancel immediately.
+        await runtime.cancel(handle)
+
+        _ = try await collectUntilStreamFinished(from: runtime)
+
+        // Brief wait to confirm hook doesn't fire.
+        try await Task.sleep(for: .milliseconds(200))
+
+        let turns = await hook.receivedTurns
+        XCTAssertEqual(turns.count, 0, "Hook must not fire when turn is cancelled")
+    }
+
+    // MARK: - Test 3: hook not called on empty response
+
+    func test_hook_notCalledOnEmptyResponse() async throws {
+        let hook = RecordingHook()
+        let mock = MockInferenceBackend()
+        // Zero tokens yields an empty response — runtime drops the turn.
+        mock.tokensToYield = []
+        mock.isModelLoaded = true
+
+        let inference = InferenceService(backend: mock, name: "Mock")
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference,
+            generationHooks: [hook]
+        )
+        let sessionID = UUID()
+
+        _ = try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hi", attachments: []),
+            config: TurnConfig()
+        ))
+        _ = try await collectUntilStreamFinished(from: runtime)
+        // Brief wait to confirm hook never fires.
+        try await Task.sleep(for: .milliseconds(200))
+
+        let turns = await hook.receivedTurns
+        XCTAssertEqual(turns.count, 0, "Hook must not fire when response is empty")
+    }
+
+    // MARK: - Test 4: timeout does not hang turn
+
+    func test_hook_timeoutDoesNotHangTurn() async throws {
+        let hangingHook = HangingHook()
+        let mock = MockInferenceBackend()
+        mock.tokensToYield = ["ok"]
+        mock.isModelLoaded = true
+
+        let inference = InferenceService(backend: mock, name: "Mock")
+        let store = RuntimeMessageStore()
+        // Short 1s timeout — turn should complete even though the hook never returns.
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference,
+            emptyResponseObserver: nil,
+            generationHooks: [hangingHook],
+            compressionPolicy: nil,
+            hookTimeout: .seconds(1)
+        )
+
+        let sessionID = UUID()
+        let startTime = ContinuousClock.now
+
+        _ = try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hi", attachments: []),
+            config: TurnConfig()
+        ))
+
+        // Drain until afterGeneration; the hook fires in the detached task after that.
+        // With a 1-second hookTimeout, the turn-completing sequence should finish
+        // well under 5 seconds total.
+        _ = try await collectUntilAfterGeneration(from: runtime, deadline: .seconds(10))
+
+        let elapsed = ContinuousClock.now - startTime
+        // The turn should complete; total time < 5 seconds even with a 1s hook timeout.
+        XCTAssertLessThan(
+            Double(elapsed.components.seconds),
+            5.0,
+            "Turn must complete in under 5 seconds even with a hanging hook"
+        )
+    }
+
+    // MARK: - Test 5: multiple hooks fire in order
+
+    func test_multipleHooks_fireInRegistrationOrder() async throws {
+        // Use an actor to collect labels safely across concurrent contexts.
+        actor OrderRecorder {
+            private(set) var labels: [String] = []
+            func record(_ label: String) { labels.append(label) }
+        }
+
+        let recorder = OrderRecorder()
+
+        struct LabeledHook: GenerationHook {
+            let label: String
+            let recorder: OrderRecorder
+
+            func postGeneration(_ turn: CompletedTurn) async {
+                await recorder.record(label)
+            }
+        }
+
+        let hookA = LabeledHook(label: "A", recorder: recorder)
+        let hookB = LabeledHook(label: "B", recorder: recorder)
+
+        let mock = MockInferenceBackend()
+        mock.tokensToYield = ["ok"]
+        let (runtime, _, _) = makeRuntime(mock: mock, generationHooks: [hookA, hookB])
+        let sessionID = UUID()
+
+        _ = try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hi", attachments: []),
+            config: TurnConfig()
+        ))
+        _ = try await collectUntilAfterGeneration(from: runtime)
+        try await Task.sleep(for: .milliseconds(300))
+
+        let labels = await recorder.labels
+        XCTAssertEqual(labels, ["A", "B"], "Hooks must fire in registration order")
+    }
+}

--- a/Tests/ManifoldRuntimeTests/GenerationHookTests.swift
+++ b/Tests/ManifoldRuntimeTests/GenerationHookTests.swift
@@ -56,12 +56,26 @@ final class GenerationHookTests: XCTestCase {
 
     // MARK: - Hook implementations for tests
 
-    /// Hook that records every completed turn it receives.
+    /// Hook that records every completed turn it receives and signals each
+    /// completion so tests can await it deterministically instead of sleeping.
     actor RecordingHook: GenerationHook {
         private(set) var receivedTurns: [CompletedTurn] = []
+        private var continuations: [CheckedContinuation<CompletedTurn, Never>] = []
 
         func postGeneration(_ turn: CompletedTurn) async {
             receivedTurns.append(turn)
+            for continuation in continuations {
+                continuation.resume(returning: turn)
+            }
+            continuations.removeAll()
+        }
+
+        /// Suspends until the next `postGeneration(_:)` call completes and
+        /// returns the `CompletedTurn` that was delivered.
+        func awaitNextTurn() async -> CompletedTurn {
+            await withCheckedContinuation { continuation in
+                continuations.append(continuation)
+            }
         }
     }
 
@@ -161,16 +175,25 @@ final class GenerationHookTests: XCTestCase {
             kind: .send(text: "Hi", attachments: []),
             config: TurnConfig()
         ))
-        _ = try await collectUntilAfterGeneration(from: runtime)
 
-        // Give the hook time to run (it fires after afterGeneration is emitted).
-        try await Task.sleep(for: .milliseconds(200))
+        // Await the hook's own completion signal — deterministic, no sleep needed.
+        // withThrowingTaskGroup bounds the wait so a broken hook doesn't hang CI.
+        let deliveredTurn = try await withThrowingTaskGroup(of: CompletedTurn.self) { group in
+            group.addTask { await hook.awaitNextTurn() }
+            group.addTask {
+                try await Task.sleep(for: .seconds(5))
+                throw TestError.deadlineElapsed
+            }
+            let turn = try await group.next()!
+            group.cancelAll()
+            return turn
+        }
 
         let turns = await hook.receivedTurns
         XCTAssertEqual(turns.count, 1, "Hook should fire exactly once per successful turn")
-        XCTAssertEqual(turns[0].sessionID, sessionID)
-        XCTAssertEqual(turns[0].assistantMessage.role, .assistant)
-        XCTAssertEqual(turns[0].assistantMessage.content, "Hello world")
+        XCTAssertEqual(deliveredTurn.sessionID, sessionID)
+        XCTAssertEqual(deliveredTurn.assistantMessage.role, .assistant)
+        XCTAssertEqual(deliveredTurn.assistantMessage.content, "Hello world")
     }
 
     // MARK: - Test 2: hook not called on cancel
@@ -279,13 +302,30 @@ final class GenerationHookTests: XCTestCase {
     // MARK: - Test 5: multiple hooks fire in order
 
     func test_multipleHooks_fireInRegistrationOrder() async throws {
-        // Use an actor to collect labels safely across concurrent contexts.
+        // Actor collects labels and signals when the expected count is reached.
         actor OrderRecorder {
             private(set) var labels: [String] = []
-            func record(_ label: String) { labels.append(label) }
+            private var continuations: [CheckedContinuation<[String], Never>] = []
+            private let expectedCount: Int
+
+            init(expectedCount: Int) { self.expectedCount = expectedCount }
+
+            func record(_ label: String) {
+                labels.append(label)
+                if labels.count >= expectedCount {
+                    for c in continuations { c.resume(returning: labels) }
+                    continuations.removeAll()
+                }
+            }
+
+            /// Suspends until `expectedCount` labels have been recorded.
+            func awaitAllLabels() async -> [String] {
+                if labels.count >= expectedCount { return labels }
+                return await withCheckedContinuation { continuations.append($0) }
+            }
         }
 
-        let recorder = OrderRecorder()
+        let recorder = OrderRecorder(expectedCount: 2)
 
         struct LabeledHook: GenerationHook {
             let label: String
@@ -309,10 +349,70 @@ final class GenerationHookTests: XCTestCase {
             kind: .send(text: "Hi", attachments: []),
             config: TurnConfig()
         ))
-        _ = try await collectUntilAfterGeneration(from: runtime)
-        try await Task.sleep(for: .milliseconds(300))
 
-        let labels = await recorder.labels
+        // Await the recorder's deterministic completion signal.
+        let labels = try await withThrowingTaskGroup(of: [String].self) { group in
+            group.addTask { await recorder.awaitAllLabels() }
+            group.addTask {
+                try await Task.sleep(for: .seconds(5))
+                throw TestError.deadlineElapsed
+            }
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
+
         XCTAssertEqual(labels, ["A", "B"], "Hooks must fire in registration order")
+    }
+
+    // MARK: - Test 6: first hook passes, second times out — turn still completes
+
+    func test_hooks_secondTimeoutDoesNotPreventTurnCompletion() async throws {
+        // hookA completes immediately; hookB hangs forever. With a short timeout
+        // the runtime must cancel hookB and still complete the turn — hookA's
+        // delivery and the persisted assistant message must be unaffected.
+        let hookA = RecordingHook()
+
+        let mock = MockInferenceBackend()
+        mock.tokensToYield = ["ok"]
+        mock.isModelLoaded = true
+
+        let inference = InferenceService(backend: mock, name: "Mock")
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference,
+            emptyResponseObserver: nil,
+            generationHooks: [hookA, HangingHook()],
+            compressionPolicy: nil,
+            hookTimeout: .seconds(1)
+        )
+
+        let sessionID = UUID()
+        _ = try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hi", attachments: []),
+            config: TurnConfig()
+        ))
+
+        // hookA must fire; bound the wait with a deadline.
+        _ = try await withThrowingTaskGroup(of: CompletedTurn.self) { group in
+            group.addTask { await hookA.awaitNextTurn() }
+            group.addTask {
+                try await Task.sleep(for: .seconds(5))
+                throw TestError.deadlineElapsed
+            }
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
+
+        let turns = await hookA.receivedTurns
+        XCTAssertEqual(turns.count, 1, "hookA must still receive the turn even when hookB times out")
+
+        // The assistant message must have been persisted before hooks ran.
+        let messages = try await store.fetchMessages(for: sessionID)
+        let assistantMessages = messages.filter { $0.role == .assistant }
+        XCTAssertEqual(assistantMessages.count, 1, "Assistant message must be persisted regardless of hook timeout")
     }
 }


### PR DESCRIPTION
## Problem

Apps that need to run extraction or indexing work after each generation turn (e.g. pulling entity facts into a knowledge graph, or compressing history when the context window fills up) have no hook point in `ConversationRuntime` today. They build a parallel turn loop alongside the runtime, which means their work can run on every turn without needing full turn-loop ownership.

## What changed

**Change 3 — `GenerationHook` protocol** (`Sources/ManifoldRuntime/Protocols/GenerationHook.swift`)

A `GenerationHook` is called after every successful generation turn (not on cancel, error, or empty-response turns). The runtime awaits each hook in registration order with a configurable timeout (default 30 s). A hung hook is cancelled and logged — it never blocks the next turn.

```swift
struct EntityExtractionHook: GenerationHook {
    func postGeneration(_ turn: CompletedTurn) async {
        let entities = await extract(from: turn.assistantMessage.content)
        await knowledgeGraph.persist(entities, sessionID: turn.sessionID)
    }
}

let runtime = ConversationRuntime(
    messageStore: store,
    inferenceService: inference,
    generationHooks: [EntityExtractionHook()]
)
```

**Change 4 — `CompressionPolicy` protocol** (`Sources/ManifoldRuntime/Protocols/CompressionPolicy.swift`)

A `CompressionPolicy` is consulted after each successful generation turn (after hooks). When `shouldCompress(promptTokens:contextSize:)` returns `true`, the runtime calls `compress(history:sessionID:generate:)`, replaces the session's stored messages with the result, and emits `ConversationEvent.historyCompressed(sessionID:)`. Compression failures are logged and never abort the turn.

```swift
struct ThresholdPolicy: CompressionPolicy {
    func shouldCompress(promptTokens: Int, contextSize: Int) -> Bool {
        guard contextSize > 0 else { return false }
        return Double(promptTokens) / Double(contextSize) >= 0.8
    }

    func compress(history: [ChatMessageRecord], sessionID: UUID,
                  generate: @Sendable ([ChatMessageRecord]) async throws -> String) async throws -> [ChatMessageRecord] {
        let summary = try await generate(history)
        return [ChatMessageRecord(role: .assistant, content: summary, sessionID: sessionID)]
    }
}

let runtime = ConversationRuntime(
    messageStore: store,
    inferenceService: inference,
    compressionPolicy: ThresholdPolicy()
)
```

**`AssembledPrompt.contextUtilization`** — added to `PromptSlot.swift` and computed in `PromptAssembler.swift`. Gives policies a ready-made utilization fraction (`totalTokens / contextSize`, capped at 1.0) without re-counting tokens.

## Tests

- `GenerationHookTests` — 5 tests: fires on success, not on cancel, not on empty response, timeout doesn't hang turn, multiple hooks fire in order.
- `CompressionPolicyTests` — 5 tests: called when threshold met, not called when not met, compressed messages replace store, failure doesn't abort turn, skipped when `contextSize == 0`.
- `PromptAssemblerUtilizationTests` — 4 tests: correct ratio, capped at 1.0, zero when `contextSize == 0`, populated by capabilities overload.

## Notes

- This is **part 2** of a 4-change context-injection pass. Part 1 (TurnContext + ContextBudgetPlanner) is in the preceding commit on `main` (`94f2ec5`). This PR is built on top and will need a rebase on `ConversationRuntime.swift` init when part 1 merges (expected: the `budgetPlanner` parameter position).
- The `hookTimeout` parameter is exposed on the `package` init so tests can set a short timeout without widening the public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)