### PR TITLE
fix: network security hardening — TLS floor, SSRF lock, CGNAT range, scheme guard, log annotations

### DIFF
--- a/Sources/ManifoldCloudCore/PinnedSessionDelegate.swift
+++ b/Sources/ManifoldCloudCore/PinnedSessionDelegate.swift
@@ -196,7 +196,7 @@ public final class PinnedSessionDelegate: NSObject, URLSessionDelegate {
             }
         }
 
-        Log.network.error("Certificate pin mismatch for \(host). No certificate in chain matched any of \(expectedPins.count) pins. Seen hashes: \(seenHashes.joined(separator: ", "))")
+        Log.network.error("Certificate pin mismatch for \(host, privacy: .public). No certificate in chain matched any of \(expectedPins.count) pins. Seen hashes: \(seenHashes.joined(separator: ", "), privacy: .public)")
         completionHandler(.cancelAuthenticationChallenge, nil)
     }
 

--- a/Sources/ManifoldCloudCore/URLSessionProvider.swift
+++ b/Sources/ManifoldCloudCore/URLSessionProvider.swift
@@ -89,6 +89,7 @@ public enum URLSessionProvider {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 300
         config.timeoutIntervalForResource = 600
+        config.tlsMinimumSupportedProtocolVersion = .TLSv12
         return URLSession(configuration: config, delegate: composite, delegateQueue: nil)
     }()
 
@@ -134,6 +135,7 @@ public enum URLSessionProvider {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 300
         config.timeoutIntervalForResource = 600
+        config.tlsMinimumSupportedProtocolVersion = .TLSv12
         return URLSession(configuration: config, delegate: composite, delegateQueue: nil)
     }()
 

--- a/Sources/ManifoldInference/Networking/URLSessionFactory.swift
+++ b/Sources/ManifoldInference/Networking/URLSessionFactory.swift
@@ -52,6 +52,7 @@ public enum URLSessionFactory {
         let config = URLSessionConfiguration.ephemeral
         config.timeoutIntervalForRequest = defaultRequestTimeout
         config.timeoutIntervalForResource = resourceTimeout
+        config.tlsMinimumSupportedProtocolVersion = .TLSv12
         let composite = CompositeURLSessionDelegate(
             redirectGuard: RedirectGuardDelegate(hopCap: hopCap),
             serverTrustHandler: nil,
@@ -83,6 +84,7 @@ public enum URLSessionFactory {
         config.isDiscretionary = false
         config.sessionSendsLaunchEvents = true
         config.allowsCellularAccess = true
+        config.tlsMinimumSupportedProtocolVersion = .TLSv12
         let composite = CompositeURLSessionDelegate(
             redirectGuard: RedirectGuardDelegate(hopCap: hopCap),
             serverTrustHandler: nil,

--- a/Sources/ManifoldInference/Utilities/PrivateIPClassifier.swift
+++ b/Sources/ManifoldInference/Utilities/PrivateIPClassifier.swift
@@ -113,6 +113,8 @@ package enum PrivateIPClassifier {
         if a == 10 { return .privateHost }                           // 10.0.0.0/8 — RFC1918
         if a == 172 && (16...31).contains(b) { return .privateHost } // 172.16.0.0/12 — RFC1918
         if a == 192 && b == 168 { return .privateHost }              // 192.168.0.0/16 — RFC1918
+        // 100.64.0.0/10 — Shared Address Space (RFC 6598); carrier NAT / cloud-internal
+        if a == 100 && (64...127).contains(b) { return .privateHost }
         if a == 169 && b == 254 { return .linkLocalHost }            // 169.254.0.0/16 — link-local (cloud IMDS)
         if a == 0 { return .multicastReserved }                      // 0.0.0.0/8 — "this host"
         // 127.0.0.0/8 — loopback (full /8, including 127.0.0.1).

--- a/Sources/ManifoldMCP/MCPSSRFPolicy.swift
+++ b/Sources/ManifoldMCP/MCPSSRFPolicy.swift
@@ -5,8 +5,17 @@ import ManifoldInference
 // MARK: - MCPSSRFPolicy
 
 internal enum MCPSSRFPolicy {
-    nonisolated(unsafe) static var _resolverForTesting: ((String) async -> [String]?)? = nil
-    nonisolated(unsafe) static var _synchronousResolverForTesting: ((String) -> [String]?)? = nil
+    private static let overrideLock = NSLock()
+    nonisolated(unsafe) private static var _resolverForTesting_storage: ((String) async -> [String]?)? = nil
+    static var _resolverForTesting: ((String) async -> [String]?)? {
+        get { overrideLock.withLock { _resolverForTesting_storage } }
+        set { overrideLock.withLock { _resolverForTesting_storage = newValue } }
+    }
+    nonisolated(unsafe) private static var _synchronousResolverForTesting_storage: ((String) -> [String]?)? = nil
+    static var _synchronousResolverForTesting: ((String) -> [String]?)? {
+        get { overrideLock.withLock { _synchronousResolverForTesting_storage } }
+        set { overrideLock.withLock { _synchronousResolverForTesting_storage = newValue } }
+    }
 
     static func validateTransportURL(_ url: URL) throws {
         guard let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" else {

--- a/Sources/ManifoldMCP/MCPURLSessionFactory.swift
+++ b/Sources/ManifoldMCP/MCPURLSessionFactory.swift
@@ -7,6 +7,7 @@ internal enum MCPURLSessionFactory {
         let configuration = URLSessionConfiguration.default
         configuration.timeoutIntervalForRequest = 300
         configuration.timeoutIntervalForResource = 600
+        configuration.tlsMinimumSupportedProtocolVersion = .TLSv12
         return URLSession(configuration: configuration)
     }()
 

--- a/Sources/ManifoldServer/ServerCommandOptions.swift
+++ b/Sources/ManifoldServer/ServerCommandOptions.swift
@@ -9,7 +9,7 @@ internal struct ServerCommandOptions: ParsableArguments, Sendable {
     @Option(help: "Port to bind.")
     internal var port = 8080
 
-    @Option(help: "API key required by the server for incoming requests.")
+    @Option(help: "API key required by the server for incoming requests. Omitting this option allows unauthenticated access from any process on the bound interface.")
     internal var apiKey: String?
 
     @Option(help: "Maximum number of concurrent generation requests.")
@@ -58,6 +58,9 @@ internal struct ServerCommandOptions: ParsableArguments, Sendable {
         }
         guard parallel > 0 else {
             throw ValidationError("--parallel must be greater than zero")
+        }
+        if apiKey == nil || apiKey?.isEmpty == true {
+            fputs("warning: ManifoldServer started without --api-key; any process on \(host) can invoke inference without credentials\n", stderr)
         }
         if unsafeCORS, corsOrigin != nil {
             throw ValidationError("--unsafe-cors cannot be combined with --cors-origin")

--- a/Sources/ManifoldTools/ReferenceTools/HttpGetFixtureTool.swift
+++ b/Sources/ManifoldTools/ReferenceTools/HttpGetFixtureTool.swift
@@ -75,8 +75,16 @@ public enum HttpGetFixtureTool {
                 )
             }
 
+            guard url.scheme?.lowercased() == "https" else {
+                return ToolResult(
+                    callId: "",
+                    content: "Only HTTPS URLs are permitted when real network is enabled.",
+                    errorKind: .permissionDenied
+                )
+            }
+
             do {
-                let (data, response) = try await URLSession.shared.data(from: url)
+                let (data, response) = try await URLSessionFactory.ephemeral().data(from: url)
                 let status = (response as? HTTPURLResponse)?.statusCode ?? 0
                 let body = String(data: data, encoding: .utf8) ?? ""
                 return encode(Result(url: args.url, status: status, body: body))

--- a/Tests/ManifoldBackendsTests/DirectURLSessionConstructionAuditTest.swift
+++ b/Tests/ManifoldBackendsTests/DirectURLSessionConstructionAuditTest.swift
@@ -61,6 +61,51 @@ final class DirectURLSessionConstructionAuditTest: XCTestCase {
         "ManifoldTestSupport/",
     ]
 
+    /// Relative paths (under `Sources/`) permitted to reference `URLSession.shared`.
+    /// Keep this empty — production network calls must go through `URLSessionFactory`
+    /// or `URLSessionProvider` so the redirect guard and TLS floor are enforced.
+    private static let sharedSessionAllowlistedPrefixes: [String] = [
+        "ManifoldTestSupport/",
+    ]
+
+    func test_sourcesContainNoURLSessionSharedCalls() throws {
+        let sourcesURL = try Self.locateSourcesDirectory()
+        let swiftFiles = try Self.enumerateSwiftFiles(under: sourcesURL)
+        XCTAssertFalse(swiftFiles.isEmpty, "Sources directory yielded no .swift files — path probably wrong")
+
+        var offenders: [(file: String, line: Int, text: String)] = []
+        for fileURL in swiftFiles {
+            let relativePath = fileURL.path.replacingOccurrences(of: sourcesURL.path + "/", with: "")
+            // Check against shared-session allowlist (prefix-only — no file-level exceptions).
+            let isAllowlisted = Self.sharedSessionAllowlistedPrefixes.contains { relativePath.hasPrefix($0) }
+            if isAllowlisted { continue }
+
+            let content = try String(contentsOf: fileURL, encoding: .utf8)
+            let lines = content.components(separatedBy: "\n")
+            for (index, rawLine) in lines.enumerated() {
+                let line = rawLine.trimmingCharacters(in: .whitespaces)
+                if line.hasPrefix("//") || line.hasPrefix("///") || line.hasPrefix("*") || line.hasPrefix("*/") {
+                    continue
+                }
+                guard line.contains("URLSession.shared") else { continue }
+                offenders.append((file: relativePath, line: index + 1, text: line))
+            }
+        }
+
+        if !offenders.isEmpty {
+            let formatted = offenders
+                .map { "  \($0.file):\($0.line)  \($0.text)" }
+                .joined(separator: "\n")
+            XCTFail("""
+                URLSession.shared usage found in production sources.
+                Route network calls through URLSessionFactory.ephemeral() or URLSessionProvider
+                so the redirect guard, TLS floor (TLS 1.2+), and SSRF mitigations are enforced.
+
+                \(formatted)
+                """)
+        }
+    }
+
     func test_sourcesContainNoUnauthorisedURLSessionConstruction() throws {
         let sourcesURL = try Self.locateSourcesDirectory()
         let swiftFiles = try Self.enumerateSwiftFiles(under: sourcesURL)

--- a/Tests/ManifoldInferenceTests/PrivateIPClassifierTests.swift
+++ b/Tests/ManifoldInferenceTests/PrivateIPClassifierTests.swift
@@ -91,6 +91,31 @@ final class PrivateIPClassifierTests: XCTestCase {
         XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("192.168.255.255"), .privateHost)
     }
 
+    // MARK: - classifyIPLiteral: CGNAT / Shared Address Space (RFC 6598)
+
+    func test_cgnat_100_64_0_1_isPrivate() {
+        // 100.64.0.1 is inside the RFC 6598 Shared Address Space (100.64.0.0/10).
+        // Carrier-grade NAT and cloud-internal infrastructure use this range;
+        // it must not be reachable from production network calls.
+        // Sabotage: removing the 100.64/10 check from classifyIPv4 would return nil here.
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("100.64.0.1"), .privateHost)
+    }
+
+    func test_cgnat_100_127_255_255_isPrivate() {
+        // Last address in the 100.64.0.0/10 block.
+        XCTAssertEqual(PrivateIPClassifier.classifyIPLiteral("100.127.255.255"), .privateHost)
+    }
+
+    func test_cgnat_boundary_100_63_255_255_isNil() {
+        // 100.63.x.x is just outside the block and must be allowed.
+        XCTAssertNil(PrivateIPClassifier.classifyIPLiteral("100.63.255.255"))
+    }
+
+    func test_cgnat_boundary_100_128_0_0_isNil() {
+        // 100.128.x.x is just outside the block and must be allowed.
+        XCTAssertNil(PrivateIPClassifier.classifyIPLiteral("100.128.0.0"))
+    }
+
     // MARK: - classifyIPLiteral: Link-Local
 
     func test_linkLocal_169_254_0_0_isLinkLocal() {


### PR DESCRIPTION
## Summary

Seven network security fixes across ManifoldMCP, ManifoldServer, ManifoldCloudCore, ManifoldInference, and ManifoldTools.

- **SEC-11** — `MCPSSRFPolicy` test overrides were bare `nonisolated(unsafe) static var`, which is unsafe under `swift test --parallel`. Replaced with NSLock-guarded computed properties backed by private `_storage` vars.
- **SEC-12** — `ManifoldServer` silently started without authentication. `validate()` now emits a `stderr` warning when `--api-key` is absent; the `--api-key` help text now mentions the unauthenticated-access consequence.
- **SEC-15** — `config.tlsMinimumSupportedProtocolVersion = .TLSv12` added to every `URLSessionConfiguration` setup block: `URLSessionProvider._pinned`, `URLSessionProvider._unpinned`, `URLSessionFactory.ephemeral()`, `URLSessionFactory.background()`, and `MCPURLSessionFactory.sharedSession`.
- **SEC-18** — The `PinnedSessionDelegate` pin-mismatch log line was missing `privacy: .public` on the `seenHashes` interpolation, causing the hashes to be redacted in unified-log subscribers used for incident investigation. Added `privacy: .public` to both `host` and `seenHashes`.
- **SEC-21** — `HttpGetFixtureTool` used `URLSession.shared.data(from:)` in the real-network path, bypassing the redirect guard, TLS floor, and SSRF mitigations installed by `URLSessionFactory`. Replaced with `URLSessionFactory.ephemeral().data(from:)`. Added an HTTPS-only scheme guard before the network call. Added a `test_sourcesContainNoURLSessionSharedCalls` audit test to `DirectURLSessionConstructionAuditTest` to lock this seam for future code.
- **SEC-25** — `PrivateIPClassifier` did not block `100.64.0.0/10` (RFC 6598 Shared Address Space, used by carrier-grade NAT and cloud-internal infrastructure). Added the range as `.privateHost`. Added four boundary tests (first address, last address, and both adjacent-but-outside addresses).

## Pre-existing failures on main

The `TrafficBoundaryAuditTest.test_rule1_networkIOOnlyInAllowlistedFiles` failure and the `DownloadableModelTests` crash are both from upstream commit e6e3cdf (PR #1251 — cross-backend Phase 2/A). Neither `TrafficBoundaryAuditTest.swift` nor `DownloadableModelTests` files were touched by this PR. The failures were present before this branch was created and are unrelated to these security fixes.

## Test plan

- [ ] `scripts/test.sh --filter ManifoldInferenceTests --filter ManifoldMCPTests --filter ManifoldBackendsTests --filter ManifoldServerTests --disable-default-traits --skip-update`
- [ ] `scripts/test.sh --filter ManifoldInferenceSwiftTestingTests --disable-default-traits --skip-update`
- [ ] Verify new `test_cgnat_100_64_0_1_isPrivate` and boundary tests pass
- [ ] Verify new `test_sourcesContainNoURLSessionSharedCalls` audit test passes
- [ ] All-traits build sweep: `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz`

Closes SEC-11, SEC-12, SEC-15, SEC-18, SEC-21, SEC-25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)