### PR TITLE
fix: enforce input size bounds on user messages, RAG queries, MCP tool metadata, and server request bodies

### DIFF
--- a/Sources/ManifoldInference/ManifoldConfiguration.swift
+++ b/Sources/ManifoldInference/ManifoldConfiguration.swift
@@ -93,6 +93,23 @@ public struct ManifoldConfiguration: Sendable {
     /// Defaults to `false` for conservative rollout.
     public var useSecureEnclave: Bool
 
+    /// Maximum UTF-8 byte length of a user message. Messages exceeding this are rejected
+    /// before SwiftData insertion to prevent OOM on constrained iOS devices.
+    public var maxUserMessageBytes: Int = 500_000        // 500 KB
+
+    /// Maximum UTF-8 byte length of the RAG query string passed to the embedding backend.
+    /// Truncated (not rejected) to avoid embedding runaway on long messages.
+    public var maxRAGQueryBytes: Int = 8_000             // 8 KB
+
+    /// Maximum UTF-8 byte length of an MCP tool name received from a server.
+    public var maxMCPToolNameBytes: Int = 256
+
+    /// Maximum UTF-8 byte length of an MCP tool description received from a server.
+    public var maxMCPToolDescriptionBytes: Int = 4_096   // 4 KB
+
+    /// Maximum HTTP request body size accepted by ManifoldServer.
+    public var maxServerRequestBodyBytes: Int = 4_194_304 // 4 MB
+
     /// Controls how ``PinnedSessionDelegate`` treats custom hosts that have no
     /// pins configured in ``PinnedSessionDelegate/pinnedHosts``.
     ///

--- a/Sources/ManifoldMCP/MCPToolExecutor.swift
+++ b/Sources/ManifoldMCP/MCPToolExecutor.swift
@@ -158,10 +158,13 @@ public final class MCPToolExecutor: ToolExecutor, @unchecked Sendable {
             return true
         }
         let string = String(String.UnicodeScalarView(filtered))
-        if string.count <= limit {
+        // Compare and truncate by UTF-8 byte count, not grapheme clusters, so
+        // multi-byte characters (CJK, emoji) can't be used to smuggle oversized
+        // payloads past a grapheme-cluster limit check.
+        if string.utf8.count <= limit {
             return string
         }
-        return String(string.prefix(limit))
+        return String(bytes: Array(string.utf8.prefix(limit)), encoding: .utf8) ?? String(string.prefix(limit / 4))
     }
 
     private static func jsonString(from value: JSONSchemaValue) -> String {

--- a/Sources/ManifoldMCP/MCPToolSource.swift
+++ b/Sources/ManifoldMCP/MCPToolSource.swift
@@ -229,16 +229,39 @@ public final class MCPToolSource: @unchecked Sendable {
         guard case .array(let toolValues)? = root["tools"] else {
             throw MCPError.malformedMetadata("tools/list response missing tools array")
         }
+        let config = ManifoldConfiguration.shared
         return try toolValues.map { value in
             guard case .object(let object) = value else {
                 throw MCPError.malformedMetadata("tools/list item must be an object")
             }
-            guard case .string(let name)? = object["name"], !name.isEmpty else {
+            guard case .string(let rawName)? = object["name"], !rawName.isEmpty else {
                 throw MCPError.malformedMetadata("tools/list item missing name")
+            }
+            // Cap name and description by UTF-8 byte count before construction
+            // so an adversarial MCP server can't inject unbounded metadata into
+            // the tool registry. Log a warning so operators can detect it.
+            let name: String
+            if rawName.utf8.count > config.maxMCPToolNameBytes {
+                name = String(
+                    bytes: Array(rawName.utf8.prefix(config.maxMCPToolNameBytes)),
+                    encoding: .utf8
+                ) ?? rawName
+                Log.inference.warning("MCPToolSource: tool name truncated from \(rawName.utf8.count) to \(config.maxMCPToolNameBytes) bytes")
+            } else {
+                name = rawName
             }
             let description: String
             if case .string(let rawDescription)? = object["description"] {
-                description = rawDescription
+                if rawDescription.utf8.count > config.maxMCPToolDescriptionBytes {
+                    let truncated = String(
+                        bytes: Array(rawDescription.utf8.prefix(config.maxMCPToolDescriptionBytes)),
+                        encoding: .utf8
+                    ) ?? rawDescription
+                    Log.inference.warning("MCPToolSource: tool description truncated from \(rawDescription.utf8.count) to \(config.maxMCPToolDescriptionBytes) bytes for tool '\(name)'")
+                    description = truncated
+                } else {
+                    description = rawDescription
+                }
             } else {
                 description = "MCP tool '\(name)'"
             }

--- a/Sources/ManifoldRuntime/Services/ConversationRuntimeTypes.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationRuntimeTypes.swift
@@ -108,6 +108,11 @@ public enum ConversationError: Error, Sendable {
     /// callers that surface persistence-style errors uniformly.
     case providerNotConfigured
 
+    /// The user message exceeded the configured byte limit. The message is
+    /// rejected before SwiftData insertion to prevent OOM on constrained
+    /// iOS devices. The associated value is the limit in bytes.
+    case messageTooLarge(limit: Int)
+
     /// `regenerate` was called when no assistant message exists in the
     /// session. There is nothing to replace — callers should gate the
     /// regenerate action on the presence of at least one assistant message.
@@ -140,6 +145,8 @@ extension ConversationError: LocalizedError {
         switch self {
         case .providerNotConfigured:
             return "ConversationRuntime persistence is not configured."
+        case let .messageTooLarge(limit):
+            return "User message exceeds the \(limit)-byte limit and was rejected."
         case .noAssistantMessageToRegenerate:
             return "No assistant message to regenerate — the conversation has no assistant turn yet."
         case let .messageNotFound(id):

--- a/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
@@ -57,6 +57,16 @@ struct ConversationTurnExecutor: Sendable {
     ) async throws -> ConversationStreamHandle {
         let handle = ConversationStreamHandle()
 
+        // Reject messages that exceed the configured byte limit before any
+        // SwiftData work happens. A very large payload can OOM constrained
+        // iOS devices during UTF-8 encoding and SwiftData serialisation;
+        // rejecting here is cheaper and surfaces a typed error the caller
+        // can present to the user.
+        let sizeLimit = ManifoldConfiguration.shared.maxUserMessageBytes
+        guard text.utf8.count <= sizeLimit else {
+            throw ConversationError.messageTooLarge(limit: sizeLimit)
+        }
+
         // Persist the user message synchronously so the caller observes
         // ordering (`messageInserted(user)` before `processTurn` returns) —
         // the stream task fires off after this point. Persistence failures

--- a/Sources/ManifoldRuntime/Services/RAGService.swift
+++ b/Sources/ManifoldRuntime/Services/RAGService.swift
@@ -123,17 +123,31 @@ public actor RAGService {
             return .empty
         }
 
+        // Embedding models can hang or OOM on very long inputs. Truncate to
+        // the configured byte cap before handing off — a shorter query loses
+        // some precision but still produces useful nearest-neighbour results.
+        let cappedQuery: String
+        let maxRAGQueryBytes = ManifoldConfiguration.shared.maxRAGQueryBytes
+        if query.utf8.count > maxRAGQueryBytes {
+            cappedQuery = String(
+                bytes: Array(query.utf8.prefix(maxRAGQueryBytes)),
+                encoding: .utf8
+            ) ?? String(query.prefix(maxRAGQueryBytes / 4))
+        } else {
+            cappedQuery = query
+        }
+
         let hits: [VectorSearchHit]
         if let backend = embeddingBackend, backend.isModelLoaded {
             do {
-                let queryEmbedding = try await backend.embed([query])[0]
+                let queryEmbedding = try await backend.embed([cappedQuery])[0]
                 hits = try await vectorStore.search(embedding: queryEmbedding, limit: limit)
             } catch {
                 Log.inference.warning("RAGService: embedding query failed, falling back to keyword search: \(error.localizedDescription)")
-                hits = try await vectorStore.keywordSearch(query: query, limit: limit)
+                hits = try await vectorStore.keywordSearch(query: cappedQuery, limit: limit)
             }
         } else {
-            hits = try await vectorStore.keywordSearch(query: query, limit: limit)
+            hits = try await vectorStore.keywordSearch(query: cappedQuery, limit: limit)
         }
 
         guard !hits.isEmpty else { return .empty }

--- a/Sources/ManifoldServer/ServerApp.swift
+++ b/Sources/ManifoldServer/ServerApp.swift
@@ -4,6 +4,24 @@ import Foundation
 import Hummingbird
 import HTTPTypes
 
+// MARK: - Custom request context with configurable body-size limit
+
+/// A Hummingbird `RequestContext` that enforces the server's configured
+/// maximum upload size. Hummingbird rejects bodies larger than
+/// `maxUploadSize` with HTTP 413 before any handler logic runs.
+internal struct ManifoldServerRequestContext: RequestContext {
+    internal var coreContext: CoreRequestContextStorage
+    internal let maxUploadSize: Int
+
+    internal init(source: Source) {
+        self.coreContext = .init(source: source)
+        // Read the limit once per request from the global configuration. This
+        // avoids threading the value through every handler while still letting
+        // host apps reconfigure it before the first request arrives.
+        self.maxUploadSize = ManifoldConfiguration.shared.maxServerRequestBodyBytes
+    }
+}
+
 internal struct ServerHealth: Codable, Equatable, Sendable {
     internal var status: String
 
@@ -47,7 +65,7 @@ internal struct ServerApp: Sendable {
     internal func health() -> ServerHealth { ServerHealth() }
 
     internal func makeApplication() -> some ApplicationProtocol {
-        let router = Router()
+        let router = Router(context: ManifoldServerRequestContext.self)
         router.add(middleware: corsMiddleware())
 
         router.get("/health") { _, _ in
@@ -109,8 +127,8 @@ internal struct ServerApp: Sendable {
         try await makeApplication().runService()
     }
 
-    private func corsMiddleware() -> CORSMiddleware<BasicRequestContext> {
-        let allowOrigin: CORSMiddleware<BasicRequestContext>.AllowOrigin
+    private func corsMiddleware() -> CORSMiddleware<ManifoldServerRequestContext> {
+        let allowOrigin: CORSMiddleware<ManifoldServerRequestContext>.AllowOrigin
         if configuration.unsafeCORS {
             allowOrigin = .all
         } else if let corsOrigin = configuration.corsOrigin {

--- a/Sources/ManifoldServer/ServerCommandOptions.swift
+++ b/Sources/ManifoldServer/ServerCommandOptions.swift
@@ -74,6 +74,9 @@ internal struct ServerCommandOptions: ParsableArguments, Sendable {
     }
 
     internal func serverConfiguration() -> ServerConfiguration {
+        // maxServerRequestBodyBytes is not CLI-configurable; it flows from
+        // ManifoldConfiguration.shared so host apps can set it at startup.
+        // The ServerConfiguration default already reads it from there.
         ServerConfiguration(
             host: host,
             port: port,

--- a/Sources/ManifoldServer/ServerConfiguration.swift
+++ b/Sources/ManifoldServer/ServerConfiguration.swift
@@ -1,5 +1,6 @@
 #if Server
 import Foundation
+import ManifoldInference
 
 internal struct ServerConfiguration: Equatable, Sendable {
     internal var host: String
@@ -9,6 +10,10 @@ internal struct ServerConfiguration: Equatable, Sendable {
     internal var unsafeCORS: Bool
     internal var corsOrigin: String?
     internal var metricsEnabled: Bool
+    /// Maximum HTTP request body size accepted by the server in bytes.
+    /// Requests whose body exceeds this limit are rejected with 413 before any
+    /// handler logic runs. Defaults to the value in ``ManifoldConfiguration``.
+    internal var maxServerRequestBodyBytes: Int
 
     internal init(
         host: String = "127.0.0.1",
@@ -17,7 +22,8 @@ internal struct ServerConfiguration: Equatable, Sendable {
         parallelSlots: Int = 1,
         unsafeCORS: Bool = false,
         corsOrigin: String? = nil,
-        metricsEnabled: Bool = false
+        metricsEnabled: Bool = false,
+        maxServerRequestBodyBytes: Int = ManifoldConfiguration.shared.maxServerRequestBodyBytes
     ) {
         self.host = host
         self.port = port
@@ -26,6 +32,7 @@ internal struct ServerConfiguration: Equatable, Sendable {
         self.unsafeCORS = unsafeCORS
         self.corsOrigin = corsOrigin
         self.metricsEnabled = metricsEnabled
+        self.maxServerRequestBodyBytes = maxServerRequestBodyBytes
     }
 }
 

--- a/Sources/ManifoldUI/ViewModels/ChatViewModel+RuntimeAdapter.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel+RuntimeAdapter.swift
@@ -174,7 +174,7 @@ extension ChatViewModel {
                 break
             case .contextAssembly(let underlying):
                 surfaceError(underlying, kind: .generation)
-            case .messageNotFound, .noAssistantMessageToRegenerate, .providerNotConfigured:
+            case .messageNotFound, .noAssistantMessageToRegenerate, .providerNotConfigured, .messageTooLarge:
                 errorMessage = error.localizedDescription
             }
             if case .cancelled = error {

--- a/Tests/ManifoldMCPTests/MCPToolBridgeTests.swift
+++ b/Tests/ManifoldMCPTests/MCPToolBridgeTests.swift
@@ -643,6 +643,140 @@ final class MCPToolBridgeTests: XCTestCase {
         let names = await MainActor.run { registry.definitions.map(\.name) }
         XCTAssertEqual(names, ["search"])
     }
+
+    // MARK: - SEC-07: MCP tool name / description caps
+
+    /// A tool whose name exceeds `maxMCPToolNameBytes` must be truncated to
+    /// the configured byte limit before the tool is registered.
+    func test_oversizeToolName_isTruncatedAtByteLimit() async throws {
+        let limit = 32 // small limit for the test
+        var config = ManifoldConfiguration.shared
+        config.maxMCPToolNameBytes = limit
+        ManifoldConfiguration.shared = config
+        defer {
+            var restore = ManifoldConfiguration.shared
+            restore.maxMCPToolNameBytes = 256
+            ManifoldConfiguration.shared = restore
+        }
+
+        let longName = String(repeating: "a", count: limit + 50)
+        XCTAssertGreaterThan(longName.utf8.count, limit)
+
+        let source = MCPToolSource(
+            serverID: UUID(),
+            displayName: "Test",
+            capabilities: .init(),
+            toolNamespace: nil,
+            toolFilter: .allowAll,
+            approvalPolicy: .perCall,
+            listTools: {
+                .object([
+                    "tools": .array([
+                        .object([
+                            "name": .string(longName),
+                            "description": .string("a tool"),
+                            "inputSchema": .object(["type": .string("object")]),
+                        ]),
+                    ]),
+                ])
+            },
+            callTool: { _, _ in nil }
+        )
+        let registry = ToolRegistry()
+        await source.register(in: registry)
+
+        let registeredNames = await MainActor.run { registry.definitions.map(\.name) }
+        XCTAssertEqual(registeredNames.count, 1,
+                       "tool must still be registered after name truncation")
+        let registeredNameBytes = registeredNames[0].utf8.count
+        XCTAssertLessThanOrEqual(registeredNameBytes, limit,
+                                 "registered name must be at most \(limit) bytes, got \(registeredNameBytes)")
+
+        // Sabotage: confirm the registered name is shorter than the original.
+        XCTAssertLessThan(registeredNameBytes, longName.utf8.count,
+                          "registered name must be shorter than the oversize input")
+    }
+
+    /// A tool whose description exceeds `maxMCPToolDescriptionBytes` must be
+    /// truncated to the configured byte limit.
+    func test_oversizeToolDescription_isTruncatedAtByteLimit() async throws {
+        let limit = 64
+        var config = ManifoldConfiguration.shared
+        config.maxMCPToolDescriptionBytes = limit
+        ManifoldConfiguration.shared = config
+        defer {
+            var restore = ManifoldConfiguration.shared
+            restore.maxMCPToolDescriptionBytes = 4_096
+            ManifoldConfiguration.shared = restore
+        }
+
+        let longDescription = String(repeating: "b", count: limit + 200)
+        XCTAssertGreaterThan(longDescription.utf8.count, limit)
+
+        let source = MCPToolSource(
+            serverID: UUID(),
+            displayName: "Test",
+            capabilities: .init(),
+            toolNamespace: nil,
+            toolFilter: .allowAll,
+            approvalPolicy: .perCall,
+            listTools: {
+                .object([
+                    "tools": .array([
+                        .object([
+                            "name": .string("tool_a"),
+                            "description": .string(longDescription),
+                            "inputSchema": .object(["type": .string("object")]),
+                        ]),
+                    ]),
+                ])
+            },
+            callTool: { _, _ in nil }
+        )
+        let registry = ToolRegistry()
+        await source.register(in: registry)
+
+        let definitions = await MainActor.run { registry.definitions }
+        XCTAssertEqual(definitions.count, 1)
+        let descriptionBytes = definitions[0].description.utf8.count
+        XCTAssertLessThanOrEqual(descriptionBytes, limit,
+                                 "registered description must be at most \(limit) bytes, got \(descriptionBytes)")
+    }
+
+    /// A tool whose name is exactly at the byte limit must NOT be truncated.
+    func test_toolNameAtByteLimit_isNotTruncated() async throws {
+        let limit = 256
+        let exactName = String(repeating: "z", count: limit)
+        XCTAssertEqual(exactName.utf8.count, limit)
+
+        let source = MCPToolSource(
+            serverID: UUID(),
+            displayName: "Test",
+            capabilities: .init(),
+            toolNamespace: nil,
+            toolFilter: .allowAll,
+            approvalPolicy: .perCall,
+            listTools: {
+                .object([
+                    "tools": .array([
+                        .object([
+                            "name": .string(exactName),
+                            "description": .string("ok"),
+                            "inputSchema": .object(["type": .string("object")]),
+                        ]),
+                    ]),
+                ])
+            },
+            callTool: { _, _ in nil }
+        )
+        let registry = ToolRegistry()
+        await source.register(in: registry)
+
+        let registeredNames = await MainActor.run { registry.definitions.map(\.name) }
+        XCTAssertEqual(registeredNames.count, 1)
+        XCTAssertEqual(registeredNames[0].utf8.count, limit,
+                       "tool name at exact byte limit must not be truncated")
+    }
 }
 
 private func makeSource(

--- a/Tests/ManifoldRuntimeTests/ConversationRuntimeTests.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationRuntimeTests.swift
@@ -2335,4 +2335,75 @@ final class ConversationRuntimeTests: XCTestCase {
             "If the stream were unbounded the consumer could receive all 501+ events"
         )
     }
+
+    // MARK: - SEC-01: User message size guard
+
+    /// A message that exceeds `maxUserMessageBytes` must be rejected before
+    /// any persistence attempt. The error surfaces as `messageTooLarge`.
+    func test_send_oversizeMessage_throwsMessageTooLarge() async throws {
+        let limit = 512 // use a small limit so the test allocates minimally
+        var config = ManifoldConfiguration.shared
+        config.maxUserMessageBytes = limit
+        ManifoldConfiguration.shared = config
+        defer {
+            var restore = ManifoldConfiguration.shared
+            restore.maxUserMessageBytes = 500_000
+            ManifoldConfiguration.shared = restore
+        }
+
+        // Construct a message that is one byte over the limit.
+        let oversizeText = String(repeating: "a", count: limit + 1)
+        XCTAssertGreaterThan(oversizeText.utf8.count, limit)
+
+        let (runtime, store, _, _) = makeRuntime()
+        let sessionID = UUID()
+
+        do {
+            _ = try await runtime.processTurn(
+                TurnInput(sessionID: sessionID, kind: .send(text: oversizeText))
+            )
+            XCTFail("Expected messageTooLarge to be thrown")
+        } catch ConversationError.messageTooLarge(let reported) {
+            XCTAssertEqual(reported, limit,
+                           "reported limit must match ManifoldConfiguration.maxUserMessageBytes")
+        }
+
+        // No user message must have been persisted — the guard fires before insertion.
+        let persisted = store.messages.values.filter { $0.sessionID == sessionID }
+        XCTAssertTrue(persisted.isEmpty,
+                      "oversize message must not reach SwiftData insertion")
+    }
+
+    /// A message at exactly the byte limit must succeed (not be rejected).
+    func test_send_atLimitMessage_isAccepted() async throws {
+        let limit = 512
+        var config = ManifoldConfiguration.shared
+        config.maxUserMessageBytes = limit
+        ManifoldConfiguration.shared = config
+        defer {
+            var restore = ManifoldConfiguration.shared
+            restore.maxUserMessageBytes = 500_000
+            ManifoldConfiguration.shared = restore
+        }
+
+        let exactText = String(repeating: "a", count: limit)
+        XCTAssertEqual(exactText.utf8.count, limit)
+
+        let mock = MockInferenceBackend()
+        mock.tokensToYield = ["ok"]
+        let (runtime, store, _, _) = makeRuntime(mock: mock)
+        let sessionID = UUID()
+
+        let handle = try await runtime.processTurn(
+            TurnInput(sessionID: sessionID, kind: .send(text: exactText))
+        )
+        XCTAssertNotNil(handle, "message at the byte limit must be accepted and return a handle")
+
+        // Allow the stream to settle so the user message persistence is flushed.
+        _ = try await collectUntilStreamFinished(from: runtime)
+
+        let persisted = store.messages.values.filter { $0.sessionID == sessionID && $0.role == .user }
+        XCTAssertEqual(persisted.count, 1,
+                       "user message at the exact limit must be persisted once")
+    }
 }

--- a/Tests/ManifoldRuntimeTests/RAGServiceTests.swift
+++ b/Tests/ManifoldRuntimeTests/RAGServiceTests.swift
@@ -53,6 +53,21 @@ private final class FakeEmbeddingBackend: EmbeddingBackend, @unchecked Sendable 
     func unloadModel() { isModelLoaded = false }
 }
 
+/// Records every text passed to `embed(_:)` so tests can inspect whether
+/// the RAG service truncated the query before calling the backend.
+private final class CapturingEmbeddingBackend: EmbeddingBackend, @unchecked Sendable {
+    var isModelLoaded: Bool = true
+    var dimensions: Int = 4
+    var capturedTexts: [String] = []
+
+    func loadModel(from url: URL) async throws { isModelLoaded = true }
+    func embed(_ texts: [String]) async throws -> [[Float]] {
+        capturedTexts.append(contentsOf: texts)
+        return texts.map { _ in [1.0, 0.0, 0.0, 0.0] }
+    }
+    func unloadModel() { isModelLoaded = false }
+}
+
 // MARK: - Tests
 
 @MainActor
@@ -231,6 +246,74 @@ final class RAGServiceTests: XCTestCase {
             score: 1.0
         )
         XCTAssertEqual(citation.snippet, "Short.")
+    }
+
+    // MARK: - SEC-02: RAG query size cap
+
+    /// A query longer than maxRAGQueryBytes must be truncated to at most
+    /// maxRAGQueryBytes UTF-8 bytes before hitting the embedding backend.
+    func test_retrieve_oversizeQuery_isTruncatedBeforeEmbedding() async throws {
+        let maxBytes = 8_000
+        var config = ManifoldConfiguration.shared
+        config.maxRAGQueryBytes = maxBytes
+        ManifoldConfiguration.shared = config
+        defer {
+            var restore = ManifoldConfiguration.shared
+            restore.maxRAGQueryBytes = 8_000
+            ManifoldConfiguration.shared = restore
+        }
+
+        // Build a query that is clearly over the limit: 10_000 ASCII bytes.
+        let oversizeQuery = String(repeating: "a", count: 10_000)
+        XCTAssertGreaterThan(oversizeQuery.utf8.count, maxBytes)
+
+        // FakeEmbeddingBackend stores the text it received so we can inspect it.
+        let capturingBackend = CapturingEmbeddingBackend()
+        let vectorStore = FakeVectorStore()
+        let sut = RAGService(
+            documentStore: FakeDocumentStore(),
+            vectorStore: vectorStore,
+            embeddingBackend: capturingBackend
+        )
+
+        _ = try await sut.retrieve(query: oversizeQuery)
+
+        let capturedTexts = capturingBackend.capturedTexts
+        XCTAssertEqual(capturedTexts.count, 1,
+                       "embedding backend must receive exactly one query text")
+        let receivedBytes = capturedTexts[0].utf8.count
+        XCTAssertLessThanOrEqual(receivedBytes, maxBytes,
+                                 "embedded query must be capped at \(maxBytes) bytes, got \(receivedBytes)")
+
+        // Sabotage: confirm the test would fail if truncation weren't applied.
+        XCTAssertLessThan(receivedBytes, oversizeQuery.utf8.count,
+                          "captured query must be shorter than the original oversize input")
+    }
+
+    /// A query at exactly the limit must pass through unchanged.
+    func test_retrieve_atLimitQuery_isNotTruncated() async throws {
+        let maxBytes = 8_000
+        // Construct a query whose UTF-8 length is exactly maxBytes.
+        let exactQuery = String(repeating: "x", count: maxBytes)
+        XCTAssertEqual(exactQuery.utf8.count, maxBytes)
+
+        let capturingBackend = CapturingEmbeddingBackend()
+        let vectorStore = FakeVectorStore()
+        let sut = RAGService(
+            documentStore: FakeDocumentStore(),
+            vectorStore: vectorStore,
+            embeddingBackend: capturingBackend
+        )
+
+        _ = try await sut.retrieve(query: exactQuery)
+
+        let capturedTexts = capturingBackend.capturedTexts
+        guard capturedTexts.count == 1 else {
+            XCTFail("Expected 1 captured text, got \(capturedTexts.count)")
+            return
+        }
+        XCTAssertEqual(capturedTexts[0].utf8.count, maxBytes,
+                       "query at exactly the limit must not be truncated")
     }
 
     func testDeleteDocumentRemovesFromBothStores() async throws {


### PR DESCRIPTION
## Summary

- **SEC-01** — `ConversationTurnExecutor.runSendFlow` rejects user messages exceeding `ManifoldConfiguration.shared.maxUserMessageBytes` (500 KB default) before any SwiftData insertion, throwing `ConversationError.messageTooLarge(limit:)`.
- **SEC-02** — `RAGService.retrieve` truncates the query to `maxRAGQueryBytes` (8 KB default) in UTF-8 bytes before calling the embedding backend, preventing runaway on large messages.
- **SEC-07** — `MCPToolSource.parseToolsListResponse` caps tool name at `maxMCPToolNameBytes` (256 B) and description at `maxMCPToolDescriptionBytes` (4 KB) with a `Log.inference.warning` when truncation occurs.
- **SEC-13** — `ManifoldServer` now uses a custom `ManifoldServerRequestContext` that sets Hummingbird's `maxUploadSize` from `maxServerRequestBodyBytes` (4 MB default), causing HTTP 413 for oversized bodies before any handler runs. `ServerConfiguration` gains a `maxServerRequestBodyBytes` property.
- **SEC-20** — `MCPToolExecutor.sanitize` now compares and truncates using UTF-8 byte count instead of grapheme clusters, closing a multi-byte character bypass.

All five limits are exposed as `public var` on `ManifoldConfiguration` and can be overridden by host apps at startup.

## Test plan

- [ ] `ConversationRuntimeTests.test_send_oversizeMessage_throwsMessageTooLarge` — message > 512 B throws `.messageTooLarge`, no persistence
- [ ] `ConversationRuntimeTests.test_send_atLimitMessage_isAccepted` — message at exact limit succeeds
- [ ] `RAGServiceTests.test_retrieve_oversizeQuery_isTruncatedBeforeEmbedding` — 10 KB query capped to 8 KB at embedding boundary
- [ ] `RAGServiceTests.test_retrieve_atLimitQuery_isNotTruncated` — exact-limit query passes through unchanged
- [ ] `MCPToolBridgeTests.test_oversizeToolName_isTruncatedAtByteLimit` — tool with 32+50 B name truncated to ≤ 32 B
- [ ] `MCPToolBridgeTests.test_oversizeToolDescription_isTruncatedAtByteLimit` — description truncated to ≤ 64 B
- [ ] `MCPToolBridgeTests.test_toolNameAtByteLimit_isNotTruncated` — 256 B name not truncated
- [ ] All 1901 XCTest suites pass (`ManifoldInferenceTests`, `ManifoldRuntimeTests`, `ManifoldMCPTests`, `ManifoldServerTests`)
- [ ] 83 Swift Testing tests pass (`ManifoldInferenceSwiftTestingTests`)
- [ ] All-traits build clean (`MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz`)

> **Note for reviewers:** WP-E depends on `maxMCPToolNameBytes` and `maxMCPToolDescriptionBytes` defined here. Merge this PR before WP-E.

Closes SEC-01, SEC-02, SEC-07, SEC-13, SEC-20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)