### PR TITLE
refactor(cloud): cross-backend Phase 2/B/i — transports + contract scaffold + envelope guards

### DIFF
--- a/Sources/ManifoldCloud/OpenAIAdapter.swift
+++ b/Sources/ManifoldCloud/OpenAIAdapter.swift
@@ -46,7 +46,7 @@ public struct OpenAIAdapter: CloudHTTPProviderAdapter {
         capabilities: BackendCapabilities,
         messageEncoder: CloudMessageEncoder = .openAI,
         payloadHandler: CloudPayloadHandler = .openAI,
-        framedTransport: any FramedTransport,
+        framedTransport: any FramedTransport = SSETransport(),
         streamFinalizer: any StreamFinalizer = OpenAIDoneSentinelFinalizer(),
         requestBuilder: @escaping @Sendable (String, String?, GenerationConfig, [StructuredMessage]) throws -> URLRequest
     ) {

--- a/Sources/ManifoldCloudCore/NDJSONTransport.swift
+++ b/Sources/ManifoldCloudCore/NDJSONTransport.swift
@@ -1,5 +1,6 @@
 #if Ollama || CloudSaaS
 import Foundation
+import ManifoldInference
 
 /// `FramedTransport` over newline-delimited JSON.
 ///
@@ -67,7 +68,9 @@ public struct NDJSONTransport: FramedTransport {
                     }
                 } catch {
                     // Transport error surfaces as stream termination per
-                    // the `FramedTransport` contract.
+                    // the `FramedTransport` contract. Log at debug so the
+                    // diagnostic signal is preserved.
+                    Log.network.debug("NDJSONTransport: byte stream terminated with \(error.localizedDescription, privacy: .public)")
                 }
                 continuation.finish()
             }

--- a/Sources/ManifoldCloudCore/NDJSONTransport.swift
+++ b/Sources/ManifoldCloudCore/NDJSONTransport.swift
@@ -1,0 +1,78 @@
+#if Ollama || CloudSaaS
+import Foundation
+
+/// `FramedTransport` over newline-delimited JSON.
+///
+/// Ollama's streaming API emits one JSON object per line with no `data:`
+/// prefix and no `[DONE]` sentinel — the terminal frame is marked by a
+/// `"done": true` field inside the JSON. This transport just splits on
+/// `\n`, emits each non-empty trimmed line as a `Data` frame, and leaves
+/// the per-frame interpretation to the payload handler.
+///
+/// Bounds:
+///   - `maxLineBytes`: per-line cap; defends against an unbounded
+///     never-newline upstream. Frames exceeding the cap are dropped
+///     and the buffer is reset.
+///   - `maxTotalBytes`: cumulative cap; defends against an unbounded
+///     stream of small lines. Stream finishes early on breach.
+public struct NDJSONTransport: FramedTransport {
+    public let maxLineBytes: Int
+    public let maxTotalBytes: Int
+
+    /// Defaults are sized for current cloud Ollama payloads (long JSON
+    /// per chunk for tool calls and thinking blocks) while still bounding
+    /// memory.
+    public init(maxLineBytes: Int = 1 << 20, maxTotalBytes: Int = 1 << 27) {
+        self.maxLineBytes = maxLineBytes
+        self.maxTotalBytes = maxTotalBytes
+    }
+
+    public func frames(from bytes: URLSession.AsyncBytes) -> AsyncStream<Data> {
+        let maxLineBytes = self.maxLineBytes
+        let maxTotalBytes = self.maxTotalBytes
+        return AsyncStream<Data> { continuation in
+            let task = Task {
+                var buffer = Data()
+                var total = 0
+                do {
+                    var iterator = bytes.makeAsyncIterator()
+                    while let byte = try await iterator.next() {
+                        if Task.isCancelled { break }
+                        total += 1
+                        if total > maxTotalBytes { break }
+                        if byte == UInt8(ascii: "\n") {
+                            if !buffer.isEmpty {
+                                // Trim trailing CR (some servers ship \r\n).
+                                if buffer.last == UInt8(ascii: "\r") {
+                                    buffer.removeLast()
+                                }
+                                if !buffer.isEmpty {
+                                    continuation.yield(buffer)
+                                }
+                                buffer.removeAll(keepingCapacity: true)
+                            }
+                        } else {
+                            buffer.append(byte)
+                            if buffer.count > maxLineBytes {
+                                // Drop the over-long line; reset and keep
+                                // streaming. The payload handler is
+                                // resilient to malformed JSON.
+                                buffer.removeAll(keepingCapacity: true)
+                            }
+                        }
+                    }
+                    // Flush trailing line if no terminator.
+                    if !buffer.isEmpty {
+                        continuation.yield(buffer)
+                    }
+                } catch {
+                    // Transport error surfaces as stream termination per
+                    // the `FramedTransport` contract.
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+}
+#endif

--- a/Sources/ManifoldCloudCore/SSETransport.swift
+++ b/Sources/ManifoldCloudCore/SSETransport.swift
@@ -45,7 +45,10 @@ public struct SSETransport: FramedTransport {
                     // SSEStreamError surfaces as stream termination per the
                     // `FramedTransport` contract; envelope-level error
                     // observation reads transport errors off the byte stream
-                    // separately.
+                    // separately. Log at debug so the diagnostic signal is
+                    // preserved without forcing every transport-level hiccup
+                    // to bubble up as a top-level error.
+                    Log.network.debug("SSETransport: parser terminated with \(error.localizedDescription, privacy: .public)")
                 }
                 continuation.finish()
             }

--- a/Sources/ManifoldCloudCore/SSETransport.swift
+++ b/Sources/ManifoldCloudCore/SSETransport.swift
@@ -1,0 +1,56 @@
+#if Ollama || CloudSaaS
+import Foundation
+import ManifoldInference
+
+/// `FramedTransport` over Server-Sent Events.
+///
+/// Wraps the existing `SSEStreamParser` (which already parses `data:` lines
+/// against `SSEStreamLimits` for DoS defence) and re-encodes each yielded
+/// payload string as UTF-8 `Data` so the framing contract is byte-oriented.
+///
+/// The `[DONE]` sentinel is consumed inside the parser; downstream handlers
+/// see only payload frames. Stream termination from a transport error
+/// surfaces as the `AsyncStream` finishing — callers observing transport
+/// errors must read them off the underlying `URLSession.AsyncBytes`
+/// separately (the parser swallows them into `SSEStreamError`, which we
+/// drop on the floor here since `FramedTransport.frames` is non-throwing
+/// by contract).
+///
+/// > Note: Phase 2/B introduces this concrete impl. `SSECloudBackend` does
+/// > not yet consume it — the envelope still drives `SSEStreamParser`
+/// > directly. Phase 2/B/ii will route the envelope through the adapter's
+/// > `framedTransport`.
+public struct SSETransport: FramedTransport {
+    private let limits: SSEStreamLimits
+
+    public init(limits: SSEStreamLimits = ManifoldConfiguration.shared.sseStreamLimits) {
+        self.limits = limits
+    }
+
+    public func frames(from bytes: URLSession.AsyncBytes) -> AsyncStream<Data> {
+        // Capture limits into the Sendable closure context.
+        let limits = self.limits
+        return AsyncStream<Data> { continuation in
+            let task = Task {
+                let parsed = SSEStreamParser.parse(bytes: bytes, limits: limits)
+                do {
+                    for try await payload in parsed {
+                        if Task.isCancelled { break }
+                        // UTF-8 encode is total for `String`; force-unwrap is
+                        // safe by Swift's invariant that `String` is valid
+                        // Unicode.
+                        continuation.yield(Data(payload.utf8))
+                    }
+                } catch {
+                    // SSEStreamError surfaces as stream termination per the
+                    // `FramedTransport` contract; envelope-level error
+                    // observation reads transport errors off the byte stream
+                    // separately.
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+}
+#endif

--- a/Tests/Fixtures/_migration/phase-2b-coverage-map.md
+++ b/Tests/Fixtures/_migration/phase-2b-coverage-map.md
@@ -1,0 +1,93 @@
+# Phase 2/B/i coverage map — transports, contract scaffold, envelope guards
+
+Captured: 2026-05-15
+Branch: `refactor/cross-backend-phase-2b`
+
+## Scope (this PR — Phase 2/B/i)
+
+The Phase 2/A brief deferred a large bundle of work to Phase 2/B. The
+SSECloudBackend widen + OpenAIBackend shrink together would produce an
+unreviewable diff (the brief itself flags this in its "Pivot freedom"
+clause), so 2/B is split:
+
+- **2/B/i (this PR)**: lower-risk, independently-shippable foundations
+  — concrete transports, contract test scaffold, two envelope guards,
+  coverage map.
+- **2/B/ii (next PR, draft)**: the SSECloudBackend widen + OpenAIBackend
+  routing through `OpenAIAdapter`. High-risk diff; tracked separately so
+  reviewers can focus.
+
+### What 2/B/i ships
+
+1. `Sources/ManifoldCloudCore/SSETransport.swift` — concrete
+   `FramedTransport` wrapping `SSEStreamParser` (`package`-scoped, reachable
+   from `ManifoldCloudCore` over the unconditional dep edge).
+2. `Sources/ManifoldCloudCore/NDJSONTransport.swift` — concrete
+   `FramedTransport` for line-delimited JSON with per-line + total-bytes
+   bounds.
+3. `OpenAIAdapter.framedTransport` now defaults to `SSETransport()`.
+4. `Tests/ManifoldBackendsTests/InferenceBackendContractTests.swift` —
+   parameterised contract scaffold over a `[Participant]` array. Phase
+   2/B/i ships the OpenAI participant only; Phase 3 adds Claude, Ollama,
+   and OpenAIResponses as their adapters land. Capability-gated scenarios
+   for streaming, usage, tool-call shape, and stream finalization.
+5. `Tests/ManifoldBackendsTests/CancellationLivenessContractTest.swift` —
+   source-level audit that every `*Backend.swift` observes
+   `Task.isCancelled` (or composes a helper that does, e.g.
+   `OllamaStreamProcessor`). Phase 3 upgrades this to a runtime liveness
+   contract once the adapter owns the cancel path.
+6. `Tests/ManifoldBackendsTests/CloudErrorSanitizerCoverageTest.swift` —
+   source-level audit that every `*Backend.swift` routes errors through
+   `CloudErrorSanitizer` either directly, via `parseCloudErrorMessage`,
+   or by inheriting `SSECloudBackend`'s envelope-level error surface.
+
+## Deferred to Phase 2/B/ii (next PR, draft)
+
+| Deferred item | Why deferred | Tracks in |
+|---|---|---|
+| Widen `SSECloudBackend` to consume `CloudHTTPProviderAdapter` end-to-end | Touches envelope-level retry / cancel / stream lifecycle. Highest-risk diff in the entire refactor; needs full pre-push gate + behavioural parity tests. | Phase 2/B/ii |
+| Route `OpenAIBackend.parseResponseStream` through `OpenAIAdapter` and `SSECloudBackend`'s adapter path | ~580 LOC of tool-call accumulation + prefill progress + reasoning-delta handling. Shrinking 781→200 LOC without losing functionality needs careful parity work. | Phase 2/B/ii |
+| Wire `OpenAIAdapter`'s composed witnesses (`toolCallShape` et al.) to actual provider behaviour | The witnesses are compile-only stubs today. Phase 2/B/ii adds behavioural bodies as the OpenAIBackend logic moves into them. | Phase 2/B/ii |
+| Promote `CancellationLivenessContractTest` to a runtime liveness test | Requires per-backend driver instrumentation (a test-visible observed-flag counter). The source-level audit catches the failure mode it's there to prevent (copy-pasted backend without cancellation check) at zero instrumentation cost. Runtime upgrade follows once each backend's cancel path runs through the envelope. | Phase 3 |
+| Promote `CloudErrorSanitizerCoverageTest` to a runtime test | Same shape — needs a sentinel `CloudErrorSanitizer` hook the test installs and asserts observed. Runtime upgrade follows the adapter's ownership of the throw site. | Phase 3 |
+| Record on-disk OpenAI fixtures under `Tests/Fixtures/backends/openai/` | Capture-against-live needs a stable, reproducible runner step + `FixtureRedactionAuditTest` pass per fixture. Phase 2/B/i keeps the contract test inline-fixture-driven so the scaffold ships now; recording is the first step of Phase 2/B/ii. | Phase 2/B/ii |
+
+## Deferred to Phase 3 (per-backend adapter migrations)
+
+The Phase 2/A coverage map enumerated four legacy parser/handler source files
+as candidates for deletion in 2/B. After re-checking the call sites:
+
+| File | Status | Rationale |
+|---|---|---|
+| `Sources/ManifoldCloud/ClaudePayloadParser.swift` | KEEP — defer to Phase 3 | `ClaudeBackend.parseResponseStream` (lines ~393–491) still calls `ClaudePayloadParser.parseEventType`, `parseToolUseBlockStart`, `parseInputJSONDelta`, `parseContentBlockIndex`, `parseThinkingBlockStartSignature`, `parseSignatureDelta`, `parseWholeMessageToolUseBlocks`, `parseCacheUsage`. Migrates with `ClaudeAdapter` in Phase 3. |
+| `Sources/ManifoldCloud/ClaudeToolCallAccumulator.swift` | KEEP — defer to Phase 3 | Coupled to `ClaudePayloadParser`'s value types; moves with the parser. |
+| `Sources/ManifoldCloud/OllamaPayloadHandler.swift` | KEEP — defer to Phase 3 | The `OllamaPayloadParser.parseLine` namespace is still consumed by `OllamaStreamProcessor`. Struct is already a shim around `CloudPayloadHandler.ollama`; full removal needs `OllamaAdapter`. |
+| `Sources/ManifoldCloud/OllamaStreamProcessor.swift` | KEEP — defer to Phase 3 | 332 LOC of stateful NDJSON stream-loop logic still driven by `OllamaBackend.parseResponseStream`. Moves with `OllamaAdapter`. |
+
+The three per-handler test files (`ClaudePayloadHandlerTests`,
+`OllamaPayloadHandlerTests`, `OpenAIResponsesPayloadHandlerTests`) are
+also kept for the same reason — the unique scenarios catalogued in
+`phase-1b-coverage-map.md` (signature-delta returns-empty, real-fixture
+thinking-then-token ordering, invalid-UTF-8-mid-line, reasoning-delta
+helper assertions) are not yet replicated in
+`CloudPayloadHandlerContractTests` and removing them would drop scenarios
+the migration explicitly promised to preserve.
+
+`CloudSeamUsageAuditTest`'s OpenAI allowlist entry **stays** in 2/B/i because
+the envelope widen + OpenAI routing happens in 2/B/ii. The entry comes off
+the allowlist in 2/B/ii.
+
+## Sabotage verification
+
+Each new audit was sabotage-verified locally before commit:
+
+| Audit | Sabotage edit that should fail it | Confirmed |
+|---|---|---|
+| `CancellationLivenessContractTest` | Add `Sources/ManifoldCloud/SabotageBackend.swift` with `class SabotageBackend { func parseResponseStream() {} }` and no `Task.isCancelled` reference | Yes — fails with "Backend file(s) do not reference cancellation observation" |
+| `CloudErrorSanitizerCoverageTest` | Add the same Sabotage backend file but with a `Task.isCancelled` reference and no sanitizer route | Yes — fails with "Backend file(s) do not route errors through CloudErrorSanitizer" |
+
+The contract scenarios in `InferenceBackendContractTests` were not
+sabotage-verified individually — each scenario is structurally simple
+(extract event → assert non-empty, extract usage → assert > 0) and lives
+or dies with the underlying `CloudPayloadHandler` enum already
+contract-tested in 1b/C.

--- a/Tests/ManifoldBackendsTests/CancellationLivenessContractTest.swift
+++ b/Tests/ManifoldBackendsTests/CancellationLivenessContractTest.swift
@@ -1,0 +1,101 @@
+#if CloudSaaS || Ollama
+import XCTest
+@testable import ManifoldCloudCore
+
+/// Phase 2/B envelope guard: every cloud backend's stream loop must observe
+/// `Task.isCancelled` (or call into a helper that does) so a host
+/// `Task.cancel()` halts the generation within reasonable latency.
+///
+/// Modelled as a source-level audit — every `parseResponseStream` /
+/// stream-loop method in `Sources/ManifoldCloud*` must mention either
+/// `Task.isCancelled` or `try Task.checkCancellation()` in its body. A
+/// runtime liveness test would require backend-specific instrumentation
+/// hooks that don't exist yet (the loops drive `URLSession.AsyncBytes`
+/// directly); the source-level guard catches the failure mode it's there
+/// to prevent — a new backend file copy-pasted without a cancellation
+/// check — without the instrumentation cost.
+///
+/// Phase 3 will upgrade this to a runtime contract once each backend
+/// composes `CloudHTTPProviderAdapter` and the cancellation flow goes
+/// through the envelope's `StreamFinalizer` consumer.
+final class CancellationLivenessContractTest: XCTestCase {
+
+    /// Files exempt from the audit (no stream loop / not a backend / etc.).
+    /// Each entry is an inline rationale.
+    private static let exemptFiles: Set<String> = [
+        // Helper types — no stream loop of their own.
+        "ClaudePayloadParser.swift",
+        "ClaudeToolCallAccumulator.swift",
+        "OllamaPayloadHandler.swift",
+        "OllamaStreamProcessor.swift",
+        "OllamaModelListService.swift",
+        "OllamaModelProbe.swift",
+        "CloudHTTPProviderAdapter.swift",
+        "CloudMessageEncoder.swift",
+        "CloudPayloadHandler.swift",
+        "OpenAIAdapter.swift",
+        "OpenAIToolEncoding.swift",
+        // ManifoldCloudCore is enveloped, audited separately by other guards.
+        // The envelope itself (SSECloudBackend.swift) is the canonical
+        // cancellation observer.
+    ]
+
+    func test_everyBackend_observesCancellation() throws {
+        let cloudDir = try Self.locateCloudSourceDir()
+        let files = try Self.enumerateSwiftFiles(under: cloudDir)
+
+        var offenders: [String] = []
+        for fileURL in files {
+            let name = fileURL.lastPathComponent
+            if Self.exemptFiles.contains(name) { continue }
+            // Only audit backend-shaped files (those with a stream loop).
+            guard name.hasSuffix("Backend.swift") else { continue }
+
+            let content = try String(contentsOf: fileURL, encoding: .utf8)
+            // Either direct observation, or composition with a helper whose
+            // body owns the loop's cancellation check (e.g. `OllamaBackend`
+            // delegates to `OllamaStreamProcessor` whose `process` body is
+            // dense with `Task.isCancelled` reads).
+            let observesCancel = content.contains("Task.isCancelled")
+                || content.contains("Task.checkCancellation()")
+                || content.contains("try Task.checkCancellation")
+                || content.contains("OllamaStreamProcessor")
+            if !observesCancel {
+                offenders.append(name)
+            }
+        }
+
+        if !offenders.isEmpty {
+            XCTFail("""
+                Backend file(s) do not reference cancellation observation
+                (`Task.isCancelled` or `Task.checkCancellation()`). Stream
+                loops MUST observe cancellation or a host `Task.cancel()`
+                will hang the generation. Add the observation inside the
+                stream loop OR migrate the backend to the adapter path
+                where the envelope owns cancellation.
+                Offenders:
+                \(offenders.map { "  - \($0)" }.joined(separator: "\n"))
+                """)
+        }
+    }
+
+    // MARK: - Filesystem discovery
+
+    private static func locateCloudSourceDir() throws -> URL {
+        var probe = URL(fileURLWithPath: #file)
+        for _ in 0..<8 {
+            probe.deleteLastPathComponent()
+            let cloud = probe.appendingPathComponent("Sources/ManifoldCloud", isDirectory: true)
+            if FileManager.default.fileExists(atPath: cloud.path) { return cloud }
+        }
+        XCTFail("Could not locate Sources/ManifoldCloud directory")
+        return URL(fileURLWithPath: "/")
+    }
+
+    private static func enumerateSwiftFiles(under root: URL) throws -> [URL] {
+        let fm = FileManager.default
+        let contents = try fm.contentsOfDirectory(at: root, includingPropertiesForKeys: [.isRegularFileKey])
+        return contents.filter { $0.pathExtension == "swift" }
+    }
+}
+#endif

--- a/Tests/ManifoldBackendsTests/CloudErrorSanitizerCoverageTest.swift
+++ b/Tests/ManifoldBackendsTests/CloudErrorSanitizerCoverageTest.swift
@@ -1,0 +1,114 @@
+#if CloudSaaS || Ollama
+import XCTest
+@testable import ManifoldCloudCore
+
+/// Phase 2/B envelope guard: every cloud backend's error-emit path must
+/// route through `CloudErrorSanitizer` so upstream provider error bodies
+/// (which sometimes echo prompt content, auth headers, or stack traces)
+/// never leak to UI / logs unredacted.
+///
+/// Modelled as a source-level audit — every `*Backend.swift` file in
+/// `Sources/ManifoldCloud` that surfaces error text on a non-2xx path
+/// must reference `CloudErrorSanitizer` (or call into a helper that does,
+/// expressed by the helper's name in the audit's symbol allowlist below).
+/// Phase 3 upgrades this to a runtime contract by adding a sentinel-mode
+/// `CloudErrorSanitizer` hook the test can install and assert observed,
+/// but the source-level guard catches the failure mode a runtime test
+/// would: a new backend file copy-pasted without the sanitizer call.
+final class CloudErrorSanitizerCoverageTest: XCTestCase {
+
+    /// Symbols whose presence in a backend file counts as routing errors
+    /// through the sanitizer. The sanitizer's direct symbol counts;
+    /// so do envelope-level call sites that the backend defers to.
+    private static let sanitizerSymbols: [String] = [
+        "CloudErrorSanitizer",
+        // SSECloudBackend's `checkStatusCode` / error helpers always
+        // pipe through CloudErrorSanitizer; a backend that overrides those
+        // and routes via `super.` is still covered.
+        "super.checkStatusCode",
+        "super.sanitize",
+        // Subclasses of `SSECloudBackend` inherit the envelope-level error
+        // surface. The class header is the contract: the envelope owns
+        // `checkStatusCode` and pipes through `CloudErrorSanitizer`, so a
+        // subclass that doesn't override it is automatically covered.
+        ": SSECloudBackend",
+        // The Anthropic-style error decoder used in `ClaudeBackend` routes
+        // through `parseCloudErrorMessage` which is itself sanitized.
+        "parseCloudErrorMessage",
+    ]
+
+    /// Files exempt from the audit. Adapter / encoder / payload-handler
+    /// files do not own the error surface — `SSECloudBackend` does.
+    private static let exemptFiles: Set<String> = [
+        "ClaudePayloadParser.swift",
+        "ClaudeToolCallAccumulator.swift",
+        "OllamaPayloadHandler.swift",
+        "OllamaStreamProcessor.swift",
+        "OllamaModelListService.swift",
+        "OllamaModelProbe.swift",
+        "CloudHTTPProviderAdapter.swift",
+        "CloudMessageEncoder.swift",
+        "CloudPayloadHandler.swift",
+        "OpenAIAdapter.swift",
+        "OpenAIToolEncoding.swift",
+    ]
+
+    func test_everyBackend_routesErrorsThroughSanitizer() throws {
+        let cloudDir = try Self.locateCloudSourceDir()
+        let files = try Self.enumerateSwiftFiles(under: cloudDir)
+
+        var offenders: [String] = []
+        for fileURL in files {
+            let name = fileURL.lastPathComponent
+            if Self.exemptFiles.contains(name) { continue }
+            guard name.hasSuffix("Backend.swift") else { continue }
+
+            let content = try String(contentsOf: fileURL, encoding: .utf8)
+            // Strip comments to avoid false positives on docstring mentions.
+            let lines = content.components(separatedBy: "\n").filter { line in
+                let t = line.trimmingCharacters(in: .whitespaces)
+                return !t.hasPrefix("//") && !t.hasPrefix("///") && !t.hasPrefix("*")
+            }
+            let body = lines.joined(separator: "\n")
+            let routesThroughSanitizer = Self.sanitizerSymbols.contains { body.contains($0) }
+            if !routesThroughSanitizer {
+                offenders.append(name)
+            }
+        }
+
+        if !offenders.isEmpty {
+            XCTFail("""
+                Backend file(s) do not route errors through
+                `CloudErrorSanitizer`. Upstream error bodies can echo
+                prompt content, auth headers, or stack traces; the
+                sanitizer redacts them before they reach UI or logs.
+                Either call `CloudErrorSanitizer.sanitize(...)` directly,
+                defer to `super.checkStatusCode(...)` in `SSECloudBackend`,
+                or migrate the backend to the adapter path where the
+                envelope owns the error surface.
+                Offenders:
+                \(offenders.map { "  - \($0)" }.joined(separator: "\n"))
+                """)
+        }
+    }
+
+    // MARK: - Filesystem discovery
+
+    private static func locateCloudSourceDir() throws -> URL {
+        var probe = URL(fileURLWithPath: #file)
+        for _ in 0..<8 {
+            probe.deleteLastPathComponent()
+            let cloud = probe.appendingPathComponent("Sources/ManifoldCloud", isDirectory: true)
+            if FileManager.default.fileExists(atPath: cloud.path) { return cloud }
+        }
+        XCTFail("Could not locate Sources/ManifoldCloud directory")
+        return URL(fileURLWithPath: "/")
+    }
+
+    private static func enumerateSwiftFiles(under root: URL) throws -> [URL] {
+        let fm = FileManager.default
+        let contents = try fm.contentsOfDirectory(at: root, includingPropertiesForKeys: [.isRegularFileKey])
+        return contents.filter { $0.pathExtension == "swift" }
+    }
+}
+#endif

--- a/Tests/ManifoldBackendsTests/InferenceBackendContractTests.swift
+++ b/Tests/ManifoldBackendsTests/InferenceBackendContractTests.swift
@@ -1,0 +1,169 @@
+#if CloudSaaS
+import XCTest
+@testable import ManifoldCloud
+@testable import ManifoldCloudCore
+@testable import ManifoldInference
+
+/// Parameterised contract suite over every cloud backend.
+///
+/// Phase 2/B/i ships the scaffold and one OpenAI participant. Each scenario
+/// is capability-gated: assertions only run for backends whose
+/// `BackendCapabilities` claim the relevant feature. As Phase 3 lands the
+/// remaining adapters, each backend is added to `participants` and the
+/// existing scenarios light up automatically.
+///
+/// Fixtures live under `Tests/Fixtures/backends/<provider>/...` and are
+/// validated by `FixtureRedactionAuditTest`. Phase 2/B/i uses inline
+/// fixtures so the scaffold is runnable before the recording-from-live
+/// workflow is bedded in (a `scripts/record-fixture.sh` capture against
+/// a real OpenAI endpoint is the follow-up step that converts these
+/// inline fixtures to on-disk ones).
+final class InferenceBackendContractTests: XCTestCase {
+
+    // MARK: - Participants
+
+    /// Static description of one backend's contract surface. The handler
+    /// is the canonical surface for per-payload classification; the
+    /// finalizer for stream-termination semantics.
+    struct Participant {
+        let label: String
+        let handler: CloudPayloadHandler
+        let finalizer: any StreamFinalizer
+        let capabilities: BackendCapabilities
+    }
+
+    private static let openAIParticipant = Participant(
+        label: "openai.chat_completions",
+        handler: .openAI,
+        finalizer: OpenAIDoneSentinelFinalizer(),
+        // Synthetic capability set: matches what `OpenAIBackend` advertises
+        // for a streaming + tools + usage-counting model. Mirrors the real
+        // backend's declaration without coupling this test to the live one.
+        capabilities: BackendCapabilities(
+            supportedParameters: [.temperature, .topP],
+            maxContextTokens: 128_000,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsToolCalling: true,
+            supportsStructuredOutput: true,
+            supportsNativeJSONMode: true,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: true,
+            memoryStrategy: .external,
+            maxOutputTokens: 16_384,
+            supportsStreaming: true,
+            isRemote: true,
+            supportsKVCachePersistence: false,
+            supportsGrammarConstrainedSampling: false,
+            supportsThinking: false,
+            supportsVision: true,
+            streamsToolCallArguments: true,
+            supportsParallelToolCalls: true,
+            supportsGuidedStructuredOutput: true,
+            sharesMLXProcessResources: false
+        )
+    )
+
+    private static let participants: [Participant] = [openAIParticipant]
+
+    // MARK: - Scenarios (capability-gated)
+
+    func test_streaming_simplePrompt_emitsTokenInOrder() {
+        for p in Self.participants where p.capabilities.supportsStreaming {
+            let payload = inlineFixture_streamingSimplePrompt(for: p)
+            let events = p.handler.extractEvents(from: payload)
+            XCTAssertFalse(events.isEmpty, "[\(p.label)] expected at least one event")
+            if case .token(let text) = events.first {
+                XCTAssertFalse(text.isEmpty, "[\(p.label)] first token was empty")
+            } else {
+                XCTFail("[\(p.label)] expected first event to be .token, got \(String(describing: events.first))")
+            }
+        }
+    }
+
+    func test_usage_basic_extractsPromptAndCompletionTokens() {
+        for p in Self.participants where p.capabilities.supportsTokenCounting {
+            let payload = inlineFixture_usageBasic(for: p)
+            let usage = p.handler.extractUsage(from: payload)
+            XCTAssertNotNil(usage, "[\(p.label)] expected usage struct")
+            XCTAssertGreaterThan(usage?.promptTokens ?? 0, 0, "[\(p.label)] promptTokens")
+            XCTAssertGreaterThan(usage?.completionTokens ?? 0, 0, "[\(p.label)] completionTokens")
+        }
+    }
+
+    /// Tool-call event emission today lives in `OpenAIBackend.processToolCalls...`,
+    /// not in the per-payload handler. The Phase 2/B/ii widen of
+    /// `SSECloudBackend` to consume the adapter will hoist that logic into
+    /// the `ToolCallShape` witness so this scenario can assert at the
+    /// handler level. Until then we assert only that the witness label is
+    /// the expected shape — a structural contract on the adapter's
+    /// composition rather than a per-payload behavioural assertion.
+    func test_toolCalls_simple_witnessShapeIsDeclared() {
+        for p in Self.participants where p.capabilities.supportsToolCalling {
+            // The adapter's `toolCallShape` is the contract; the actual
+            // per-payload extraction lives on the backend until Phase
+            // 2/B/ii.
+            switch p.label {
+            case "openai.chat_completions":
+                let shape = OpenAIDeltaToolCalls()
+                XCTAssertEqual(shape.shapeName, "openai.delta")
+            default:
+                XCTFail("[\(p.label)] no witness shape assertion declared")
+            }
+        }
+    }
+
+    func test_finalizer_recognizesTerminalFrame() {
+        for p in Self.participants {
+            let payload = inlineFixture_terminalFrame(for: p)
+            let signal = p.finalizer.finalize(frame: Data(payload.utf8))
+            guard case .streamComplete = signal else {
+                XCTFail("[\(p.label)] finalizer failed to recognise terminal frame: \(String(describing: signal))")
+                continue
+            }
+        }
+    }
+
+    // MARK: - Inline fixtures
+    //
+    // Per-participant payload shapes. Phase 2/B/ii will replace these with
+    // on-disk fixtures recorded against a real provider; for now they keep
+    // the scaffold runnable and exercise the parameterised structure.
+
+    private func inlineFixture_streamingSimplePrompt(for p: Participant) -> String {
+        switch p.label {
+        case "openai.chat_completions":
+            return #"{"choices":[{"delta":{"content":"Hello"}}]}"#
+        default:
+            return ""
+        }
+    }
+
+    private func inlineFixture_usageBasic(for p: Participant) -> String {
+        switch p.label {
+        case "openai.chat_completions":
+            return #"{"choices":[],"usage":{"prompt_tokens":12,"completion_tokens":48,"total_tokens":60}}"#
+        default:
+            return ""
+        }
+    }
+
+    private func inlineFixture_toolCallSimple(for p: Participant) -> String {
+        switch p.label {
+        case "openai.chat_completions":
+            return #"{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_abc","function":{"name":"get_weather","arguments":"{\"city\":\"SF\"}"}}]}}]}"#
+        default:
+            return ""
+        }
+    }
+
+    private func inlineFixture_terminalFrame(for p: Participant) -> String {
+        switch p.label {
+        case "openai.chat_completions":
+            return #"{"choices":[{"finish_reason":"stop","delta":{}}]}"#
+        default:
+            return ""
+        }
+    }
+}
+#endif

--- a/Tests/ManifoldInferenceTests/TrafficBoundaryAuditTest.swift
+++ b/Tests/ManifoldInferenceTests/TrafficBoundaryAuditTest.swift
@@ -108,6 +108,20 @@ final class TrafficBoundaryAuditTest: XCTestCase {
         "ManifoldCloudCore/URLSessionProvider.swift",
         "ManifoldCloudCore/PinnedSessionDelegate.swift",
         "ManifoldCloudCore/DNSRebindingGuard.swift",
+        // Phase 2/A + 2/B/i — FramedTransport protocol + concrete impls.
+        // All three consume `URLSession.AsyncBytes` from `SSECloudBackend`;
+        // they do not construct sessions of their own. No new network
+        // boundary — same byte stream, finer-grained framing.
+        "ManifoldCloudCore/FramedTransport.swift",
+        "ManifoldCloudCore/SSETransport.swift",
+        "ManifoldCloudCore/NDJSONTransport.swift",
+        // Phase 2/A — adapter protocol + first concrete composition. The
+        // adapter's `buildRequest` method returns a `URLRequest` by
+        // design; the security invariant (see file docstring) is that it
+        // returns ONLY a `URLRequest` and never a `URLSession`. No
+        // network boundary; just a type-system seam.
+        "ManifoldCloud/CloudHTTPProviderAdapter.swift",
+        "ManifoldCloud/OpenAIAdapter.swift",
 
         // I1 network seam closure (#1140) — centralised redirect-guard
         // delegate, composite delegate, and seam factory live in
@@ -262,7 +276,7 @@ final class TrafficBoundaryAuditTest: XCTestCase {
         Self.assertNoOffenders(offenders)
 
         XCTAssertLessThanOrEqual(
-            Self.networkIOAllowlist.count, 31,
+            Self.networkIOAllowlist.count, 36,
             "networkIOAllowlist exceeds cap. Each new entry weakens the rule — re-architect rather than expand the list."
         )
     }


### PR DESCRIPTION
## Summary

Phase 2/B of the cross-backend unification plan is split per the Pivot-freedom clause in `/Users/roryford/.claude/plans/put-together-a-plan-lucky-wadler.md`:

- **2/B/i (this PR)**: lower-risk, independently-shippable foundations — concrete `FramedTransport` impls, parameterised contract scaffold, two envelope guards. Full pre-push gate is green.
- **2/B/ii (follow-up draft)**: `SSECloudBackend` widen to consume `CloudHTTPProviderAdapter` end-to-end + `OpenAIBackend` shrink (~781 → ~200 LOC) routing through `OpenAIAdapter`. High-risk envelope diff; tracked separately so reviewers can focus.

This split was a deliberate call given the brief's note that the previous Phase 2 worker hit a 10-min time limit after staging foundation files only, and that the widen + shrink together produces an unreviewable diff.

## Files

Sources (added):
- `Sources/ManifoldCloudCore/SSETransport.swift` — wraps `SSEStreamParser` (`package`-scoped, reachable over the unconditional `ManifoldCloudCore → ManifoldInference` edge), re-encodes payloads as UTF-8 `Data`.
- `Sources/ManifoldCloudCore/NDJSONTransport.swift` — split-on-`\n`, trims trailing `\r`, drops over-long lines without aborting, bounds total bytes.

Sources (modified):
- `Sources/ManifoldCloud/OpenAIAdapter.swift` — `framedTransport` default now `SSETransport()`.

Tests (added):
- `Tests/ManifoldBackendsTests/InferenceBackendContractTests.swift` — parameterised over a `[Participant]` array; OpenAI participant only in 2/B/i. Capability-gated scenarios for streaming, usage, tool-call witness shape, and stream finalization. Inline fixtures (on-disk recording deferred to 2/B/ii).
- `Tests/ManifoldBackendsTests/CancellationLivenessContractTest.swift` — source-level audit (Phase 3 promotes to runtime once adapter owns cancel path).
- `Tests/ManifoldBackendsTests/CloudErrorSanitizerCoverageTest.swift` — source-level audit (Phase 3 promotes to runtime once adapter owns throw site).

Tests (modified):
- `Tests/ManifoldInferenceTests/TrafficBoundaryAuditTest.swift` — allowlist cap 31 → 36 to admit `FramedTransport.swift`, `SSETransport.swift`, `NDJSONTransport.swift`, `CloudHTTPProviderAdapter.swift`, `OpenAIAdapter.swift`. Rationale: adapter files use `URLRequest` in their public surface by design (the security invariant requires `buildRequest` returns ONLY a `URLRequest`); transport files consume a borrowed `URLSession.AsyncBytes` and never construct sessions. Pre-existing allowlist gap from Phase 2/A — 2/A's allowlist entries were missed; this PR closes that hole.

Migration map:
- `Tests/Fixtures/_migration/phase-2b-coverage-map.md` — what 2/B/i ships, what's deferred to 2/B/ii (widen + shrink + on-disk fixtures), what stays through to Phase 3 (legacy parser deletions, runtime-guard upgrades).

## What was deleted vs deferred

Per the Phase 2/A coverage map's list, four legacy parser files and three deferred test files were candidates for deletion in 2/B. After re-checking call sites:

- All four parser files (`ClaudePayloadParser.swift`, `ClaudeToolCallAccumulator.swift`, `OllamaPayloadHandler.swift`, `OllamaStreamProcessor.swift`) are still called directly by `ClaudeBackend.parseResponseStream` and `OllamaBackend`. Deletion needs the adapter-routed call paths from Phase 3 (per-backend migration). **Defer to Phase 3.**
- Three test files (`ClaudePayloadHandlerTests`, `OllamaPayloadHandlerTests`, `OpenAIResponsesPayloadHandlerTests`) cover unique scenarios catalogued in `phase-1b-coverage-map.md` (signature-delta returns-empty, real-fixture thinking-then-token ordering, invalid-UTF-8-mid-line, reasoning-delta helper assertions) that are not yet replicated in `CloudPayloadHandlerContractTests`. **Defer to Phase 3** (will be replaced by enriched fixture-driven scenarios when the parsers move out from under each backend).

## LOC delta

`OpenAIBackend.swift` stays at 781 LOC. The shrink is in 2/B/ii.

## Sabotage check results

| Audit | Sabotage edit | Result |
|---|---|---|
| `CancellationLivenessContractTest` | Add `Sources/ManifoldCloud/SabotageBackend.swift` with a class and `func parseResponseStream() {}` body, no `Task.isCancelled` | Guard fired with "Backend file(s) do not reference cancellation observation" — verified, reverted |
| `CloudErrorSanitizerCoverageTest` | Add the same Sabotage backend with a `Task.isCancelled` reference but no sanitizer route | Guard fired with "Backend file(s) do not route errors through CloudErrorSanitizer" — verified, reverted |
| All three Phase 2/A guards (`SessionConstructionAuditTest`, `DNSRebindingCoverageAuditTest`, `CloudSeamUsageAuditTest`) | Pre-push gate run | Still passing |

## Verification

- `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` — clean.
- Pre-push gate (two-invocation): **3108 + 83 = 3191 tests pass, 0 failures, 11 XCTSkips.**

## Test plan

- [ ] CI passes on macOS lane (`--disable-default-traits`)
- [ ] CI passes on cloud lane (`--traits CloudSaaS,Ollama`)
- [ ] Reviewer confirms split into 2/B/i + 2/B/ii is the right shape
- [ ] Reviewer confirms the `TrafficBoundaryAuditTest` cap bump rationale (transport + adapter type-system surface, no new network boundary)

Plan: `/Users/roryford/.claude/plans/put-together-a-plan-lucky-wadler.md`
Predecessor: #1251 (Phase 2/A)