### PR TITLE
fix: remove duplicate ManifoldConfiguration properties that broke ManifoldInferenceTests compile

### DIFF
--- a/Sources/ManifoldInference/ManifoldConfiguration.swift
+++ b/Sources/ManifoldInference/ManifoldConfiguration.swift
@@ -130,17 +130,6 @@ public struct ManifoldConfiguration: Sendable {
     /// install a real configuration.
     public static let frameworkDefaultBundleIdentifier = "com.manifoldkit"
 
-    /// Maximum byte length (UTF-8) for an MCP tool name parsed from a server's
-    /// `tools/list` response. Names exceeding this limit are truncated at a UTF-8
-    /// code-unit boundary and a warning is logged. Defends against servers that
-    /// send pathologically long names. (SEC-10)
-    public var maxMCPToolNameBytes: Int = 256
-
-    /// Maximum byte length (UTF-8) for an MCP tool description parsed from a
-    /// server's `tools/list` response. Descriptions exceeding this limit are
-    /// truncated at a UTF-8 code-unit boundary and a warning is logged. (SEC-10)
-    public var maxMCPToolDescriptionBytes: Int = 4_096
-
     public init(
         appName: String = "ManifoldKit",
         bundleIdentifier: String = ManifoldConfiguration.frameworkDefaultBundleIdentifier,


### PR DESCRIPTION
## Summary

- PRs #1254 and #1256 both added `maxMCPToolNameBytes` and `maxMCPToolDescriptionBytes` to `ManifoldConfiguration`, producing a Swift `invalid redeclaration` compile error.
- The compile failure prevented the entire `ManifoldInferenceTests` suite — including `TrafficBoundaryAuditTest` — from running.
- Fix: remove the duplicate declarations introduced by #1254. The copies from #1256 (which also added `maxServerRequestBodyBytes`) are the canonical forms and already include the fuller doc comment with the `(SEC-10)` reference.

## Root cause

The `TrafficBoundaryAuditTest` CI failure reported for the cross-backend Phase 2 PRs (#1251, #1259, #1260) was not an allowlist gap — all five Phase 2 transport files (`FramedTransport`, `SSETransport`, `NDJSONTransport`, `CloudHTTPProviderAdapter`, `OpenAIAdapter`) were already in the allowlist with the cap raised to 36. The real failure was a compile error upstream in `ManifoldConfiguration.swift` caused by a merge collision between two security-hardening PRs.

## Test plan

- [x] `RUN_SLOW_TESTS=1 scripts/test.sh --filter ManifoldInferenceTests --disable-default-traits --skip-update` — 1499 passed, 0 failed (`TrafficBoundaryAuditTest` included)
- [x] `scripts/test.sh --filter ManifoldInferenceSwiftTestingTests --disable-default-traits --skip-update` — 83 passed, 0 failed
- [x] `swift build --build-tests --disable-default-traits` — Build complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)