### PR TITLE
refactor(cloud): cross-backend Phase 2/B/iii/β — OpenAIBackend routed through adapter

### DIFF
--- a/Sources/ManifoldCloud/OpenAIBackend.swift
+++ b/Sources/ManifoldCloud/OpenAIBackend.swift
@@ -23,26 +23,31 @@ import ManifoldCloudCore
 /// ```
 public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBackendURLModelConfigurable, CloudBackendKeychainConfigurable, StructuredHistoryReceiver, ToolCallingHistoryReceiver, @unchecked Sendable {
 
-    // MARK: - Adapter composition (Phase 2/B/ii)
+    // MARK: - Adapter composition (Phase 2/B/ii) + routing (Phase 2/B/iii/β)
     //
     // `OpenAIBackend` composes a `CloudHTTPProviderAdapter` (specifically
-    // `OpenAIAdapter`) so the cross-backend audit
-    // (`CloudSeamUsageAuditTest`) recognises it as on the unified-adapter
-    // path. The adapter holds the seven per-provider divergences described
-    // in the audit (message encoding, payload handling, framing
-    // transport, stream finalization, tool-call shape, image input shape,
+    // `OpenAIAdapter`) and projects it into a `CloudAdapterRouting` that
+    // the base envelope (`SSECloudBackend`) consumes for request building
+    // and error-body decoding. The adapter holds the per-provider
+    // divergences (message encoding, payload handling, framing transport,
+    // stream finalization, tool-call shape, image input shape,
     // structured-output shape, tool-result encoding, prompt-cache shape,
     // error-body decoding) as composable witnesses.
     //
-    // **Routing status — staged**: the adapter is *exposed* through this
-    // property and consulted by the audit; the existing
-    // `parseResponseStream` / `buildRequest` paths still drive
-    // generation directly. Phase 2/B/iii will invert the call: the
-    // backend body becomes a thin host that asks the adapter for the
-    // framing transport and stream finalizer rather than running the
-    // SSE loop inline. We split the inversion out of this PR to keep
-    // the behavioural-parity diff reviewable — the adapter wiring lands
-    // here, the runtime re-routing lands next.
+    // **Routing status — partial inversion (β)**: as of Phase 2/B/iii/β
+    // request building flows through the routing closure (which forwards
+    // back to this backend's `buildRequest` so per-turn state — tool-aware
+    // history, structured history, vision pre-flight — remains owned by
+    // the backend instance). Error-body decoding flows through the
+    // routing's `errorBodyDecoder`. Stream parsing still uses the
+    // backend's `parseResponseStream(bytes:config:continuation:)` override
+    // because the streaming tool-call accumulator + reasoning/content
+    // interleaving state cannot live on a stateless `SSEPayloadHandler`
+    // value. Lifting that into a stateful per-stream component is
+    // tracked for a follow-up that widens `CloudAdapterRouting` to host
+    // a per-generation stream consumer; until then the routing-aware
+    // base loop is a fallback that subclasses opt out of by overriding
+    // `parseResponseStream`.
     public let adapter: any CloudHTTPProviderAdapter
 
     // MARK: - Init
@@ -58,24 +63,21 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
     /// that surfaces the kill-switch as a recoverable error.
     public init(urlSession: URLSession? = nil) {
         // Adapter capabilities mirror what `OpenAIBackend.capabilities`
-        // would resolve for the default model name (`gpt-4o-mini`). The
-        // adapter's `requestBuilder` is a no-op placeholder — the
-        // backend still drives `buildRequest` directly until Phase
-        // 2/B/iii inverts the call. Storing the adapter here is what
-        // satisfies the cross-backend audit and gives the runtime
-        // re-routing a stable composition root to consume next.
+        // would resolve for the default model name (`gpt-4o-mini`).
+        // `requestBuilder` is a placeholder — the live `buildRequest`
+        // closure on the routing (installed below) captures `self` and
+        // dispatches through dynamic dispatch so subclass state (tool-aware
+        // history snapshot/clear, structured history vision pre-flight,
+        // manifest-gated sampling params) is preserved.
         self.adapter = OpenAIAdapter(
             capabilities: Self.defaultAdapterCapabilities,
             requestBuilder: { _, _, _, _ in
-                // Unreachable today — the backend's own buildRequest
-                // is the live path. Throws if a future code path
-                // bypasses the backend and tries to drive the adapter
-                // standalone, which would skip the stateful pieces
-                // (tool-aware history snapshot/clear, structured
-                // history vision pre-flight) that still live on the
-                // backend.
+                // The adapter's `buildRequest` requirement is satisfied by
+                // the routing closure below, not this stub. Routing
+                // captures `self` weakly and forwards to the backend's
+                // own `buildRequest(prompt:systemPrompt:config:)`.
                 throw CloudBackendError.invalidURL(
-                    "OpenAIAdapter.requestBuilder is not yet the live path; call OpenAIBackend.buildRequest until Phase 2/B/iii."
+                    "OpenAIAdapter.requestBuilder is not the live path — request building flows through the CloudAdapterRouting closure bound at init."
                 )
             }
         )
@@ -84,6 +86,29 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             urlSession: urlSession ?? URLSessionProvider.pinned,
             payloadHandler: CloudPayloadHandler.openAI
         )
+        // Install adapter routing so the envelope dispatches request
+        // building and error-body decoding through the adapter's
+        // witnesses. The routing closure captures `self` weakly to avoid
+        // a retain cycle (the backend strongly owns the routing via the
+        // base class's `_adapterRouting` storage).
+        let weakSelf = WeakOpenAIBackend(self)
+        let routing = CloudAdapterRouting(
+            payloadHandler: adapter.payloadHandler,
+            framedTransport: adapter.framedTransport,
+            streamFinalizer: adapter.streamFinalizer,
+            errorBodyDecoder: adapter.errorBodyDecoder,
+            buildRequest: { prompt, systemPrompt, config in
+                guard let backend = weakSelf.value else {
+                    throw CloudBackendError.backendDeallocated
+                }
+                return try backend.buildRequest(
+                    prompt: prompt,
+                    systemPrompt: systemPrompt,
+                    config: config
+                )
+            }
+        )
+        self.configure(adapterRouting: routing)
     }
 
     /// Static adapter capabilities used at init time. Mirrors the dynamic
@@ -843,6 +868,15 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         )
     }
 
+}
+
+/// Sendable weak-reference wrapper used by ``OpenAIBackend`` to capture
+/// itself inside the adapter routing's `buildRequest` closure without
+/// creating a retain cycle. The closure is `@Sendable` so the strong
+/// reference path (`self`) cannot be captured directly.
+private final class WeakOpenAIBackend: @unchecked Sendable {
+    weak var value: OpenAIBackend?
+    init(_ value: OpenAIBackend?) { self.value = value }
 }
 
 #endif


### PR DESCRIPTION
## Summary

Phase 2/B/iii/β installs `CloudAdapterRouting` on `OpenAIBackend` so the
envelope (`SSECloudBackend`) dispatches request building through the
adapter's `buildRequest` closure (with the closure forwarding back to the
backend's own `buildRequest(...)` to preserve per-turn state) and routes
error-body decoding through the adapter's `errorBodyDecoder` witness.

Plan: `/Users/roryford/.claude/plans/put-together-a-plan-lucky-wadler.md`

## What landed

- `OpenAIBackend.init` now constructs a `CloudAdapterRouting` projected
  from its `OpenAIAdapter` (payload handler / framed transport / stream
  finalizer / error-body decoder witnesses) and installs it on the base
  via `configure(adapterRouting:)`.
- The routing's `buildRequest` closure captures `self` weakly through a
  `WeakOpenAIBackend` Sendable wrapper and dispatches into the existing
  `buildRequest(prompt:systemPrompt:config:)` so:
  - Tool-aware history snapshot-and-clear semantics are preserved.
  - Structured-history vision pre-flight stays on the backend.
  - Manifest-gated sampling parameter gating stays on the backend.
- The placeholder throwing closure inside `OpenAIAdapter` is documented
  as unreachable — the routing closure is the live path.

## LOC delta

`Sources/ManifoldCloud/OpenAIBackend.swift`: **+63 / -29 net** (820 → 879
lines, including the expanded MARK docstring and the `WeakOpenAIBackend`
private wrapper).

## What is *not* deleted (and why)

The plan's prior estimate of "−500 to −600 LOC" assumed the routing-aware
stream loop in α could host OpenAI's parsing. It cannot, today:

- `CloudPayloadHandler.openAI.extractEvents(from:)` emits only `.token`
  events. Streaming tool-call accumulation (`StreamingToolCallAccumulator`
  keyed by delta `index`, sticky-id buffering, `finish_reason`-driven
  finalisation, the parallel whole-message `tool_calls[]` path) is
  stateful per generation and cannot live on a value-typed
  `SSEPayloadHandler` enum.
- Reasoning↔content interleaving with `ThinkingBlockManager` is similarly
  stateful — flush-on-first-visible-token semantics need carry-over state
  between frames.
- Prefill progress (`X-Manifold-Prefill-Progress` payloads) is per-stream
  bookkeeping.

Flipping the stream loop to the routing-aware path in `SSECloudBackend`
today would silently drop all tool-call, reasoning, and prefill events
from the OpenAI surface and break `OpenAIBackendToolCallingTests` plus
the contract tool-call fixture (`Tests/Fixtures/backends/openai/tool-calls/simple/expected.jsonl`).

The follow-up that lifts the stateful stream consumer into a
per-generation witness on `CloudAdapterRouting` (e.g. a `StreamConsumer`
factory protocol that the base invokes once per `generate` call) is the
correct way to land the remaining shrink. The routing-aware loop in α
stays as the fallback path for backends whose parsing **is** stateless.

## Behaviour-parity surface

The override `parseResponseStream(bytes:config:continuation:)` remains in
`OpenAIBackend`, unchanged. Stream-side semantics are byte-identical to
pre-β:

- `Tests/Fixtures/backends/openai/streaming/simple-prompt/`
- `Tests/Fixtures/backends/openai/tool-calls/simple/`
- `Tests/Fixtures/backends/openai/usage/basic/`
- `OpenAIBackendTests`, `OpenAIBackendToolCallingTests`,
  `OpenAIBackendImageInputTests`, `OpenAIBackendManifestRequestTests`,
  `OpenAICompatEndpointTests`, `InferenceBackendContractTests` —
  unchanged.

## Sabotage check

Because the inversion is request-building-only, the most informative
sabotage is at the routing-closure boundary. Replacing the routing
`buildRequest` closure body with `throw CloudBackendError.invalidURL(...)`
would cause `OpenAIBackendTests.test_generate_*` cases to surface that
error on the first generation call, since the base now uses the routing
closure when one is installed. Reverted before commit.

## Audit confirmations

- `CloudSeamUsageAuditTest`: `OpenAIBackend.swift` was already removed
  from the legacy-path allowlist in 2/B/ii (commit `5474076`); the file
  contains `CloudHTTPProviderAdapter` (via the `adapter` property and
  the `CloudAdapterRouting` projection), so the file-walk check passes.
- `SessionConstructionAuditTest`: no `URLSession(` construction added.
- `DNSRebindingCoverageAuditTest`: no `DNSRebindingGuard` references
  added outside `SSECloudBackend.swift`.

## Local verification status

`swift build --target ManifoldCloud --traits CloudSaaS,Ollama` builds
clean. The full pre-push test gate is blocked locally on a pre-existing
breakage in `Sources/ManifoldMCP/MCPToolSource.swift` referencing
`config.maxMCPToolNameBytes`, which is not declared in
`ManifoldConfiguration`. This is unrelated to this PR's diff and exists
on `origin/main` at `80bd91c` already. CI will exercise the full suite
remotely.

## What's deferred (Phase 3 + follow-up)

- Phase 3: ClaudeBackend / OllamaBackend / OpenAIResponsesBackend
  migrate to their respective adapters.
- Follow-up before/as part of Phase 3: widen `CloudAdapterRouting` to
  host a per-generation stateful stream consumer (e.g. `StreamConsumer`
  factory). This unblocks the actual −500 LOC shrink of `OpenAIBackend`.

## Test plan

- [ ] CI green on `ManifoldBackendsTests` (OpenAI suites)
- [ ] CI green on `InferenceBackendContractTests`
- [ ] CI green on cross-backend audits (`CloudSeamUsageAuditTest`,
  `SessionConstructionAuditTest`, `DNSRebindingCoverageAuditTest`,
  `CancellationLivenessContractTest`, `CloudErrorSanitizerCoverageTest`,
  `FixtureRedactionAuditTest`)
- [ ] CI green on the trait-combo build