### PR TITLE
fix: restore maxMCPToolNameBytes/maxMCPToolDescriptionBytes after duplicate-PR overcorrection

### DIFF
--- a/Sources/ManifoldInference/ManifoldConfiguration.swift
+++ b/Sources/ManifoldInference/ManifoldConfiguration.swift
@@ -104,6 +104,17 @@ public struct ManifoldConfiguration: Sendable {
     /// Maximum HTTP request body size accepted by ManifoldServer.
     public var maxServerRequestBodyBytes: Int = 4_194_304 // 4 MB
 
+    /// Maximum byte length (UTF-8) for an MCP tool name parsed from a server's
+    /// `tools/list` response. Names exceeding this limit are truncated at a UTF-8
+    /// code-unit boundary and a warning is logged. Defends against servers that
+    /// send pathologically long names. (SEC-10)
+    public var maxMCPToolNameBytes: Int = 256
+
+    /// Maximum byte length (UTF-8) for an MCP tool description parsed from a
+    /// server's `tools/list` response. Descriptions exceeding this limit are
+    /// truncated at a UTF-8 code-unit boundary and a warning is logged. (SEC-10)
+    public var maxMCPToolDescriptionBytes: Int = 4_096
+
     /// Controls how ``PinnedSessionDelegate`` treats custom hosts that have no
     /// pins configured in ``PinnedSessionDelegate/pinnedHosts``.
     ///


### PR DESCRIPTION
PRs #1264 and #1267 both targeted the same \"duplicate declaration\" issue in \`ManifoldConfiguration.swift\`, but each PR's diff independently removed *one* set of the duplicates. When both PRs landed cumulatively, **both** sets disappeared, leaving \`MCPToolSource.swift\` with 6 references to fields that no longer existed:

\`\`\`
Sources/ManifoldMCP/MCPToolSource.swift:244: config.maxMCPToolNameBytes
Sources/ManifoldMCP/MCPToolSource.swift:246: config.maxMCPToolNameBytes
Sources/ManifoldMCP/MCPToolSource.swift:249: config.maxMCPToolNameBytes
Sources/ManifoldMCP/MCPToolSource.swift:255: config.maxMCPToolDescriptionBytes
Sources/ManifoldMCP/MCPToolSource.swift:257: config.maxMCPToolDescriptionBytes
Sources/ManifoldMCP/MCPToolSource.swift:260: config.maxMCPToolDescriptionBytes
\`\`\`

Build error: \`value of type 'ManifoldConfiguration' has no member 'maxMCPToolNameBytes'\`.

## Fix

Restored a single set of declarations with the SEC-10 doc comments preserved. \`swift build --build-tests --disable-default-traits\` clean after the fix.

## Lesson

Two parallel agents fixed the same bug ~1 minute apart without coordination. Both \`--admin\` merged. Their diffs were redundant in intent but additive in effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)