### PR TITLE
refactor(local): cross-backend Phase 2.5/β — MLXBackend delegates generation to MLXGenerationDriver

### DIFF
--- a/Sources/ManifoldMLX/MLX/MLXGenerationDriver.swift
+++ b/Sources/ManifoldMLX/MLX/MLXGenerationDriver.swift
@@ -2,6 +2,7 @@
 import Foundation
 @preconcurrency import MLX
 import MLXLMCommon
+import MLXRandom
 import os
 import ManifoldInference
 
@@ -59,6 +60,185 @@ struct MLXGenerationDriver: LocalInferenceAdapter {
         /// `true` when the loop completed without throwing and was not cancelled —
         /// callers may snapshot the prompt cache for next-turn reuse.
         let completedNormally: Bool
+    }
+
+    /// Outcome of a `generate(...)` call.
+    ///
+    /// Wraps `RunResult` and surfaces the inputs the backend needs to schedule
+    /// a post-generation prompt-cache snapshot capture. The backend owns the
+    /// snapshot lineage (write-token bookkeeping, install under the state
+    /// lock), so the driver returns the *materials* for the capture rather
+    /// than performing it.
+    struct GenerateResult {
+        let run: RunResult
+        /// Non-nil only when KV-cache reuse was eligible, the run completed
+        /// normally, and a prompt-token array was captured during input
+        /// preparation. The backend reads this to decide whether to fire a
+        /// `MLXPromptCacheCoordinator.makeSnapshotCaptureTask`.
+        let snapshotInputs: MLXPromptCacheCoordinator.SnapshotCaptureInputs?
+    }
+
+    /// High-level orchestrator: encodes chat messages, prepares the model
+    /// input and KV cache (honouring reuse eligibility), seeds the RNG,
+    /// constructs `GenerateParameters`, and drives the token stream via
+    /// ``run(...)``.
+    ///
+    /// This is the entry point the backend calls — `run(...)` stays public
+    /// to the file so the inner token-streaming loop remains independently
+    /// testable, but the backend never has to reach past `generate(...)`.
+    ///
+    /// On the happy path the function yields `.kvCacheReuse` (when a prompt
+    /// prefix was restored) and the full event stream from the inner loop
+    /// into `continuation`. The caller is responsible for `continuation.finish()`
+    /// and `generationStream.setPhase(...)` once the function returns or
+    /// throws. The driver only yields events and updates the "streaming" phase
+    /// on first content (mirrors the previous in-backend behaviour).
+    func generate(
+        prompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig,
+        loadOptions: BackendLoadOptions,
+        container: any MLXModelContainerProtocol,
+        conversationHistory: [(role: String, content: String)],
+        toolAwareHistory: [ToolAwareHistoryEntry]?,
+        structuredHistory: [StructuredMessage]?,
+        dialect: MLXToolDialect,
+        autoDetectedMarkers: ThinkingMarkers?,
+        kvCacheReuseEligible: Bool,
+        pendingSnapshotTask: Task<Void, Never>?,
+        existingSnapshot: MLXPromptCacheCoordinator.Snapshot?,
+        generationStream: GenerationStream,
+        continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation,
+        yieldHook: (@Sendable () async -> Void)?
+    ) async throws -> GenerateResult {
+        // Seed the MLX global RandomState before constructing GenerateParameters
+        // so the sampler's per-instance `RandomState()` (initialised from the
+        // default state) produces a deterministic token stream. `nil` skips
+        // seeding entirely — the process keeps whatever entropy MLX last picked up.
+        if let seed = config.seed {
+            MLXRandom.seed(seed)
+        }
+
+        // KV cache quantization: nil = library default (FP16). 8 / 4 map to mlx's
+        // explicit kvBits levels. Group size 64 and quantizedKVStart 0 match
+        // mlx-lm Python conventions and have no exposure on the BCK API yet.
+        let kvBits: Int? = {
+            switch loadOptions.kvCacheQuantization {
+            case .f16: return nil
+            case .q8:  return 8
+            case .q4:  return 4
+            }
+        }()
+
+        let generateConfig = GenerateParameters(
+            kvBits: kvBits,
+            temperature: config.temperature,
+            topP: config.topP,
+            topK: Int(config.topK ?? 0),
+            minP: config.minP ?? 0.0,
+            repetitionPenalty: config.repetitionPenalty ?? config.repeatPenalty,
+            repetitionContextSize: config.repetitionContextSize ?? 20,
+            presencePenalty: config.presencePenalty,
+            presenceContextSize: config.presenceContextSize ?? 20,
+            frequencyPenalty: config.frequencyPenalty,
+            frequencyContextSize: config.frequencyContextSize ?? 20,
+            prefillStepSize: loadOptions.prefillBatchSize ?? 512
+        )
+
+        let effectiveSystemPrompt: String? = {
+            if let toolBlock = MLXChatMessageEncoder.buildQwenToolBlock(config: config, dialect: dialect) {
+                return (systemPrompt ?? "") + toolBlock
+            }
+            return systemPrompt
+        }()
+
+        let (chatMessages, messages) = try MLXChatMessageEncoder.buildChatMessages(
+            prompt: prompt,
+            effectiveSystemPrompt: effectiveSystemPrompt,
+            conversationHistory: conversationHistory,
+            toolAwareHistory: toolAwareHistory,
+            structuredHistory: structuredHistory,
+            dialect: dialect
+        )
+
+        let resolvedMarkers = resolveThinkingMarkers(
+            config: config,
+            autoDetected: autoDetectedMarkers
+        )
+
+        // Wait for any pending KV snapshot capture from the previous turn to
+        // complete before we restore from it — otherwise we'd race
+        // `Snapshot` writes against reads.
+        if kvCacheReuseEligible, let pendingSnapshotTask {
+            await pendingSnapshotTask.value
+        }
+        let resolvedSnapshot: MLXPromptCacheCoordinator.Snapshot? =
+            kvCacheReuseEligible ? existingSnapshot : nil
+
+        let prepared = try await MLXPromptCacheCoordinator.prepareInputAndCache(
+            container: container,
+            chatMessages: chatMessages,
+            messages: messages,
+            generateConfig: generateConfig,
+            kvCacheReuseEligible: kvCacheReuseEligible,
+            snapshot: resolvedSnapshot
+        )
+        if prepared.reuseLen > 0 {
+            continuation.yield(.kvCacheReuse(promptTokensReused: prepared.reuseLen))
+        }
+
+        let result = try await run(
+            container: container,
+            generationInput: prepared.generationInput,
+            cache: prepared.cache,
+            generateConfig: generateConfig,
+            config: config,
+            dialect: dialect,
+            markers: resolvedMarkers,
+            generationStream: generationStream,
+            continuation: continuation,
+            yieldHook: yieldHook
+        )
+
+        let snapshotInputs: MLXPromptCacheCoordinator.SnapshotCaptureInputs? =
+            if kvCacheReuseEligible,
+               result.completedNormally,
+               let ids = prepared.promptTokenIds
+            {
+                MLXPromptCacheCoordinator.SnapshotCaptureInputs(
+                    cache: prepared.cache,
+                    promptTokenIds: ids
+                )
+            } else {
+                nil
+            }
+
+        return GenerateResult(run: result, snapshotInputs: snapshotInputs)
+    }
+
+    /// Resolves the active thinking-marker pair from the per-request override
+    /// (`config.thinkingMarkers`), then the load-time auto-detected markers.
+    /// Returns `nil` when `config.maxThinkingTokens == 0` (issue #597) or when
+    /// neither source supplied markers — both cases keep `ThinkingParser` off.
+    ///
+    /// Lives on the driver because marker resolution is generation-time policy.
+    /// `MLXBackend.resolveThinkingMarkers` forwards to this for source-compat
+    /// with `MLXBackendHelpersTests`.
+    nonisolated static func resolveThinkingMarkers(
+        config: GenerationConfig,
+        autoDetected: ThinkingMarkers?
+    ) -> ThinkingMarkers? {
+        if config.maxThinkingTokens == 0 { return nil }
+        return config.thinkingMarkers ?? autoDetected
+    }
+
+    /// Non-static, `@MainActor` forwarder so call sites already inside the
+    /// driver's actor don't need to qualify the type.
+    func resolveThinkingMarkers(
+        config: GenerationConfig,
+        autoDetected: ThinkingMarkers?
+    ) -> ThinkingMarkers? {
+        Self.resolveThinkingMarkers(config: config, autoDetected: autoDetected)
     }
 
     /// Drives the MLX stream:

--- a/Sources/ManifoldMLX/MLXBackend.swift
+++ b/Sources/ManifoldMLX/MLXBackend.swift
@@ -9,9 +9,8 @@ import MLX
 import MLXLLM
 import MLXLMCommon
 import MLXVLM
-import MLXRandom
 import MLXHuggingFace
-import Tokenizers
+import Tokenizers // required by the #huggingFaceTokenizerLoader macro expansion
 import os
 import ManifoldInference
 
@@ -195,16 +194,20 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         self.enableKVCacheReuse = enableKVCacheReuse
     }
 
-    /// Resolves the active thinking-marker pair from the per-request override
-    /// (`config.thinkingMarkers`), then the load-time auto-detected markers.
-    /// Returns `nil` when `config.maxThinkingTokens == 0` (issue #597) or when
-    /// neither source supplied markers — both cases keep `ThinkingParser` off.
+    /// Forwards to `MLXGenerationDriver.resolveThinkingMarkers(...)`.
+    ///
+    /// The canonical implementation moved into the driver as part of Phase
+    /// 2.5/β. This forwarder is retained for source-compat with
+    /// `MLXBackendHelpersTests`, which exercises marker-resolution policy
+    /// through the backend's surface.
     static func resolveThinkingMarkers(
         config: GenerationConfig,
         autoDetected: ThinkingMarkers?
     ) -> ThinkingMarkers? {
-        if config.maxThinkingTokens == 0 { return nil }
-        return config.thinkingMarkers ?? autoDetected
+        MLXGenerationDriver.resolveThinkingMarkers(
+            config: config,
+            autoDetected: autoDetected
+        )
     }
 
     // MARK: - Model Lifecycle
@@ -339,15 +342,12 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         systemPrompt: String?,
         config: GenerationConfig
     ) throws -> GenerationStream {
-        let (
-            modelContainer,
-            pendingSnapshotTask,
-            kvCacheReuseEligible
-        ): (
-            any MLXModelContainerProtocol,
-            Task<Void, Never>?,
-            Bool
-        ) = try withStateLock {
+        // Single critical section: validate, flip `_isGenerating`, and
+        // snapshot every input the driver needs. The driver runs without
+        // touching backend state — so once we leave the lock, the driver call
+        // is decoupled from `setLoadOptions` / `setConversationHistory` /
+        // `setToolAwareHistory` racing in.
+        let snapshot: GenerationCallSnapshot = try withStateLock {
             guard _isModelLoaded, let container = _modelContainer else {
                 throw InferenceError.inferenceFailure("No model loaded")
             }
@@ -355,74 +355,20 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 throw InferenceError.alreadyGenerating
             }
             _isGenerating = true
-            return (container, _promptCacheState.pendingSnapshotTask, _kvCacheReuseEligible)
+            return GenerationCallSnapshot(
+                container: container,
+                loadOptions: _loadOptions,
+                conversationHistory: _conversationHistory,
+                toolAwareHistory: _toolAwareHistory,
+                structuredHistory: _structuredHistory,
+                dialect: _dialect,
+                autoDetectedMarkers: _autoDetectedThinkingMarkers,
+                kvCacheReuseEligible: _kvCacheReuseEligible,
+                pendingSnapshotTask: _promptCacheState.pendingSnapshotTask,
+                existingPromptCacheSnapshot: _promptCacheState.snapshot
+            )
         }
         Self.logger.debug("MLX generate started")
-
-        // Seed the MLX global RandomState before constructing GenerateParameters so the
-        // sampler's per-instance `RandomState()` (initialised from the default state)
-        // produces a deterministic token stream. `nil` skips seeding entirely — the
-        // process keeps whatever entropy MLX last picked up.
-        if let seed = config.seed {
-            MLXRandom.seed(seed)
-        }
-
-        // Snapshot load options under the lock — same pattern as the prompt-cache
-        // snapshot. Per-generation reads stay coherent even if `setLoadOptions(_:)`
-        // is called mid-flight from another actor.
-        let loadOptions = withStateLock { _loadOptions }
-        // KV cache quantization: nil = library default (FP16). 8 / 4 map to mlx's
-        // explicit kvBits levels. Group size 64 and quantizedKVStart 0 match mlx-lm
-        // Python conventions and have no exposure on the BCK API yet.
-        let kvBits: Int? = {
-            switch loadOptions.kvCacheQuantization {
-            case .f16: return nil
-            case .q8:  return 8
-            case .q4:  return 4
-            }
-        }()
-
-        // Honour `config.minP` and `config.repetitionPenalty` when set; fall back to the
-        // upstream defaults / `repeatPenalty` for callers that haven't migrated to the
-        // explicit knobs yet. `nil` on a context-size knob falls through to upstream's
-        // own default (20 in mlx-swift-lm) by passing the upstream default explicitly.
-        let generateConfig = GenerateParameters(
-            kvBits: kvBits,
-            temperature: config.temperature,
-            topP: config.topP,
-            topK: Int(config.topK ?? 0),
-            minP: config.minP ?? 0.0,
-            repetitionPenalty: config.repetitionPenalty ?? config.repeatPenalty,
-            repetitionContextSize: config.repetitionContextSize ?? 20,
-            presencePenalty: config.presencePenalty,
-            presenceContextSize: config.presenceContextSize ?? 20,
-            frequencyPenalty: config.frequencyPenalty,
-            frequencyContextSize: config.frequencyContextSize ?? 20,
-            prefillStepSize: loadOptions.prefillBatchSize ?? 512
-        )
-
-        // Build messages in chat format, using full conversation history when available
-        // so multi-turn exchanges retain context. Falls back to the bare prompt when
-        // setConversationHistory has not been called (e.g. direct unit-test calls).
-        let (conversationHistory, toolAwareHistory, structuredHistory, dialect, autoDetectedMarkers) = withStateLock {
-            (_conversationHistory, _toolAwareHistory, _structuredHistory, _dialect, _autoDetectedThinkingMarkers)
-        }
-
-        let effectiveSystemPrompt: String? = {
-            if let toolBlock = MLXChatMessageEncoder.buildQwenToolBlock(config: config, dialect: dialect) {
-                return (systemPrompt ?? "") + toolBlock
-            }
-            return systemPrompt
-        }()
-
-        let (chatMessages, messages) = try MLXChatMessageEncoder.buildChatMessages(
-            prompt: prompt,
-            effectiveSystemPrompt: effectiveSystemPrompt,
-            conversationHistory: conversationHistory,
-            toolAwareHistory: toolAwareHistory,
-            structuredHistory: structuredHistory,
-            dialect: dialect
-        )
 
         let (stream, continuation) = AsyncThrowingStream.makeStream(of: GenerationEvent.self)
         let generationStream = GenerationStream(stream)
@@ -433,61 +379,31 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             }
 
             do {
-                let resolvedMarkers = Self.resolveThinkingMarkers(
-                    config: config,
-                    autoDetected: autoDetectedMarkers
-                )
-
-                if kvCacheReuseEligible, let pendingSnapshotTask {
-                    await pendingSnapshotTask.value
-                }
-                let resolvedSnapshot: MLXPromptCacheCoordinator.Snapshot? =
-                    if kvCacheReuseEligible, let self {
-                        self.withStateLock { self._promptCacheState.snapshot }
-                    } else {
-                        nil
-                    }
-                let prepared = try await MLXPromptCacheCoordinator.prepareInputAndCache(
-                    container: modelContainer,
-                    chatMessages: chatMessages,
-                    messages: messages,
-                    generateConfig: generateConfig,
-                    kvCacheReuseEligible: kvCacheReuseEligible,
-                    snapshot: resolvedSnapshot
-                )
-                if prepared.reuseLen > 0 {
-                    continuation.yield(.kvCacheReuse(promptTokensReused: prepared.reuseLen))
-                }
-
                 let driver = MLXGenerationDriver()
-                let result = try await driver.run(
-                    container: modelContainer,
-                    generationInput: prepared.generationInput,
-                    cache: prepared.cache,
-                    generateConfig: generateConfig,
+                let result = try await driver.generate(
+                    prompt: prompt,
+                    systemPrompt: systemPrompt,
                     config: config,
-                    dialect: dialect,
-                    markers: resolvedMarkers,
+                    loadOptions: snapshot.loadOptions,
+                    container: snapshot.container,
+                    conversationHistory: snapshot.conversationHistory,
+                    toolAwareHistory: snapshot.toolAwareHistory,
+                    structuredHistory: snapshot.structuredHistory,
+                    dialect: snapshot.dialect,
+                    autoDetectedMarkers: snapshot.autoDetectedMarkers,
+                    kvCacheReuseEligible: snapshot.kvCacheReuseEligible,
+                    pendingSnapshotTask: snapshot.pendingSnapshotTask,
+                    existingSnapshot: snapshot.existingPromptCacheSnapshot,
                     generationStream: generationStream,
                     continuation: continuation,
                     yieldHook: MLXBackend._yieldHookForTesting
                 )
 
-                let snapshotInputs: MLXPromptCacheCoordinator.SnapshotCaptureInputs? =
-                    if kvCacheReuseEligible, result.completedNormally, let ids = prepared.promptTokenIds {
-                        MLXPromptCacheCoordinator.SnapshotCaptureInputs(
-                            cache: prepared.cache,
-                            promptTokenIds: ids
-                        )
-                    } else {
-                        nil
-                    }
-
                 if let self {
                     self.withStateLock { self._isGenerating = false }
                 }
                 generationStream.setPhase(.done)
-                if let self, let snapshotInputs {
+                if let self, let snapshotInputs = result.snapshotInputs {
                     self.scheduleSnapshotCaptureLocked(
                         cache: snapshotInputs.cache,
                         promptTokenIds: snapshotInputs.promptTokenIds
@@ -518,6 +434,22 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         }
 
         return generationStream
+    }
+
+    /// Coherent per-call snapshot of every piece of backend state the driver
+    /// reads. Captured under `stateLock` so the driver's view stays consistent
+    /// even if a `set*History` / `setLoadOptions` call lands mid-stream.
+    private struct GenerationCallSnapshot {
+        let container: any MLXModelContainerProtocol
+        let loadOptions: BackendLoadOptions
+        let conversationHistory: [(role: String, content: String)]
+        let toolAwareHistory: [ToolAwareHistoryEntry]?
+        let structuredHistory: [StructuredMessage]?
+        let dialect: MLXToolDialect
+        let autoDetectedMarkers: ThinkingMarkers?
+        let kvCacheReuseEligible: Bool
+        let pendingSnapshotTask: Task<Void, Never>?
+        let existingPromptCacheSnapshot: MLXPromptCacheCoordinator.Snapshot?
     }
 
     /// Schedules an off-main capture of the prompt KV cache for next-turn reuse.


### PR DESCRIPTION
## Summary

Phase 2.5/β of the cross-backend rework — shrinks `MLXBackend` to delegate every piece of per-generation setup to `MLXGenerationDriver`, mirroring how `LlamaBackend` already delegates to `LlamaGenerationDriver`. Predecessor 2.5/α (#1262) extracted the token loop into the new driver file and introduced the `LocalInferenceAdapter` protocol; this PR finishes the split by moving parameter assembly, chat-message encoding, prompt-cache prepare, marker resolution, and RNG seeding into the driver too.

## LOC delta

| File | Before | After |
|---|---|---|
| `Sources/ManifoldMLX/MLXBackend.swift` | 747 | 679 |
| `Sources/ManifoldMLX/MLX/MLXGenerationDriver.swift` | 214 | 394 |

The backend's `generate(...)` body collapses from ~185 lines to ~75 lines. The remainder of `MLXBackend` is irreducible lifecycle: state lock, model load/unload, capabilities, KV-cache snapshot scheduling, conversation-history receivers, `LoadProgressReporting`. That matches `LlamaBackend`'s shape (739 LOC, similar irreducible-lifecycle proportion).

## What moved into the driver

A new high-level entry point `MLXGenerationDriver.generate(prompt:systemPrompt:config:loadOptions:container:conversationHistory:toolAwareHistory:structuredHistory:dialect:autoDetectedMarkers:kvCacheReuseEligible:pendingSnapshotTask:existingSnapshot:generationStream:continuation:yieldHook:)` now owns:

- `MLXRandom.seed(_:)` call.
- `GenerateParameters` construction (kvBits mapping, sampler / repetition / presence / frequency knob fall-throughs, prefill batch size).
- Qwen tool-block system-prompt augmentation.
- `MLXChatMessageEncoder.buildChatMessages(...)` call.
- Thinking-marker resolution (the canonical implementation is now `MLXGenerationDriver.resolveThinkingMarkers`; `MLXBackend.resolveThinkingMarkers` is a forwarder for `MLXBackendHelpersTests` source-compat).
- Awaiting any pending KV-snapshot capture from the previous turn.
- `MLXPromptCacheCoordinator.prepareInputAndCache(...)` call and the `.kvCacheReuse` event emission.
- Calling into the existing `run(...)` inner loop.
- Computing the `SnapshotCaptureInputs` to hand back to the backend.

## What stayed on the backend

- `withStateLock` guard, `_isGenerating` transitions, validate-loaded preconditions.
- A single `GenerationCallSnapshot` (new private struct) captured under the lock so the driver's view of `_loadOptions`, history fields, dialect, markers, and KV-cache reuse state stays coherent against concurrent `setLoadOptions` / `set*History` calls.
- `AsyncThrowingStream` + `GenerationStream` construction.
- `Task { @MainActor }` lifecycle.
- `scheduleSnapshotCaptureLocked(...)` (touches `_promptCacheState.writeToken` — backend state).
- `generationStream.setPhase(.done / .failed)`, `continuation.finish(...)`, `_generationTask` install, cancellation wiring on `continuation.onTermination`.

## Behaviour parity

- No public API change: `MLXBackend.generate(prompt:systemPrompt:config:) throws -> GenerationStream` signature, the `_inject` test seam, `_yieldHookForTesting`, `loadOptionsForTesting`, and the `LoadProgressReporting` / `ConversationHistoryReceiver` / `StructuredHistoryReceiver` / `ToolCallingHistoryReceiver` conformances are all unchanged.
- `MLXBackend.resolveThinkingMarkers(config:autoDetected:)` keeps its public signature, forwarding to the driver's canonical implementation. `MLXBackendHelpersTests` continues to call through `MLXBackend.resolveThinkingMarkers`.
- The unused `MLXRandom` / `Tokenizers` direct imports are dropped from `MLXBackend.swift` (the `Tokenizers` import is kept because the `#huggingFaceTokenizerLoader()` macro expansion requires it in scope).
- `Sources/ManifoldInference/Protocols/LocalInferenceAdapter.swift` is untouched, per Phase 2.5/α's protocol contract.

## Test plan

- [x] `swift build --target ManifoldMLX` clean (MLX trait).
- [ ] Full pre-push gate (XCTest invocation + Swift Testing invocation) — running locally before marking ready.
- [ ] Trait-combo build sweep: `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz`.
- [ ] Existing `MLXBackendTests`, `MLXBackendGenerationTests`, `MLXBackendThinkingTests`, `MLXBackendHelpersTests`, `MLXPromptCacheCoordinatorTests` pass unchanged (behaviour-parity bar).
- [ ] `PublicAPIStabilityTest` and `CoverageRegressionGateTest` pass — the driver covers the deleted code paths.

## Refs

- Phase 2.5/α: #1262 (driver extracted, `LocalInferenceAdapter` introduced)
- Plan: `/Users/roryford/.claude/plans/put-together-a-plan-lucky-wadler.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)