### PR TITLE
refactor(cloud): cross-backend Phase 2/B/iii/δ — OpenAIBackend stream path through OpenAIStreamEventExtractor

### DIFF
--- a/Sources/ManifoldCloud/OpenAIBackend.swift
+++ b/Sources/ManifoldCloud/OpenAIBackend.swift
@@ -60,22 +60,16 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         // Adapter capabilities mirror what `OpenAIBackend.capabilities`
         // would resolve for the default model name (`gpt-4o-mini`). The
         // adapter's `requestBuilder` is a no-op placeholder — the
-        // backend still drives `buildRequest` directly until Phase
-        // 2/B/iii inverts the call. Storing the adapter here is what
-        // satisfies the cross-backend audit and gives the runtime
-        // re-routing a stable composition root to consume next.
+        // backend's `buildRequest` override is the canonical request
+        // builder, and the adapter-routed path below threads it through
+        // the routing's `buildRequest` closure (which forwards to
+        // `self.buildRequest`). The adapter itself remains the
+        // composition root the cross-backend audit recognises.
         self.adapter = OpenAIAdapter(
             capabilities: Self.defaultAdapterCapabilities,
             requestBuilder: { _, _, _, _ in
-                // Unreachable today — the backend's own buildRequest
-                // is the live path. Throws if a future code path
-                // bypasses the backend and tries to drive the adapter
-                // standalone, which would skip the stateful pieces
-                // (tool-aware history snapshot/clear, structured
-                // history vision pre-flight) that still live on the
-                // backend.
                 throw CloudBackendError.invalidURL(
-                    "OpenAIAdapter.requestBuilder is not yet the live path; call OpenAIBackend.buildRequest until Phase 2/B/iii."
+                    "OpenAIAdapter.requestBuilder is not the live path; the OpenAIBackend installs a CloudAdapterRouting that delegates to its own buildRequest override."
                 )
             }
         )
@@ -84,6 +78,40 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             urlSession: urlSession ?? URLSessionProvider.pinned,
             payloadHandler: CloudPayloadHandler.openAI
         )
+
+        // Phase 2/B/iii/δ — install adapter routing so the stream loop
+        // runs in `SSECloudBackend.parseResponseStreamRouted` and event
+        // extraction is driven by a fresh per-stream
+        // `OpenAIStreamEventExtractor`. This is the inversion the
+        // staged Phase 2/B preamble set up: the backend body stops
+        // overriding `parseResponseStream` and becomes a thin host
+        // around the adapter + extractor.
+        //
+        // The routing's `buildRequest` closure forwards to
+        // `self.buildRequest` (captured weakly) so all the stateful
+        // pieces — tool-aware-history snapshot/clear, structured-history
+        // vision pre-flight, manifest-gated parameter gating, just-in-
+        // time keychain key resolution — keep running on the backend
+        // where they own their state.
+        let weakSelfBox = WeakBackendBox(self)
+        let routing = CloudAdapterRouting(
+            payloadHandler: adapter.payloadHandler,
+            framedTransport: adapter.framedTransport,
+            streamFinalizer: adapter.streamFinalizer,
+            errorBodyDecoder: adapter.errorBodyDecoder,
+            buildRequest: { prompt, systemPrompt, config in
+                guard let backend = weakSelfBox.value else {
+                    throw CloudBackendError.backendDeallocated
+                }
+                return try backend.buildRequest(
+                    prompt: prompt,
+                    systemPrompt: systemPrompt,
+                    config: config
+                )
+            },
+            streamConsumerFactory: { OpenAIStreamEventExtractor() }
+        )
+        self.configure(adapterRouting: routing)
     }
 
     /// Static adapter capabilities used at init time. Mirrors the dynamic
@@ -364,268 +392,15 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
     }
 
     // MARK: - Stream Parsing
-
-    /// Parses OpenAI Chat Completions SSE with reasoning-model support.
-    ///
-    /// OpenAI-compatible reasoning models (o1/o3, DeepSeek R1, xAI Grok
-    /// reasoning, hosted Qwen reasoning) expose chain-of-thought text alongside
-    /// visible content via one of two Chat Completions delta shapes:
-    ///
-    /// ```json
-    /// {"choices":[{"delta":{"reasoning_content":"..."}}]}   // DeepSeek / compat
-    /// {"choices":[{"delta":{"reasoning":"..."}}]}           // OpenAI-native
-    /// ```
-    ///
-    /// We route reasoning fragments to ``GenerationEvent/thinkingToken(_:)``
-    /// and emit a single ``GenerationEvent/thinkingComplete`` on the first
-    /// transition from reasoning to visible `content` (or on stream end if
-    /// reasoning never handed off to content — truncated upstream). Streams
-    /// from non-reasoning models (plain gpt-4o-mini, etc.) never observe a
-    /// reasoning chunk and therefore never fire `.thinkingComplete`.
-    public override func parseResponseStream(
-        bytes: URLSession.AsyncBytes,
-        config: GenerationConfig,
-        continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
-    ) async throws {
-        let tokenStream = SSEStreamParser.parse(bytes: bytes, limits: effectiveSSEStreamLimits)
-        var state = ChatCompletionsStreamState()
-
-        do {
-            for try await payload in tokenStream {
-                if Task.isCancelled { break }
-                let outcome = processPayload(payload, state: &state, continuation: continuation)
-                if outcome == .breakLoop { break }
-                if outcome == .continueLoop { continue }
-                if let error = extractStreamError(from: payload) {
-                    throw error
-                }
-            }
-        } catch {
-            // Close any open thinking block before rethrowing so consumers
-            // see a clean handoff and don't hang in a thinking-only state.
-            state.thinking.flushIfOpen(into: continuation)
-            throw error
-        }
-
-        state.thinking.flushIfOpen(into: continuation)
-        // Stream end fallback: if the upstream closed without a `finish_reason`
-        // (some compat servers omit it), emit any buffered tool calls now so
-        // the orchestrator can dispatch them. On cancellation we deliberately
-        // skip this — dropping the consumer mid-stream must not produce
-        // phantom `.toolCall` events.
-        if !Task.isCancelled {
-            finaliseToolCalls(state: &state, continuation: continuation)
-        }
-    }
-
-    // MARK: - Stream Processing Steps
-
-    /// Per-payload processing state for the Chat Completions stream loop.
-    ///
-    /// Carries the thinking-block flag, the streaming tool-call accumulator,
-    /// and the one-shot finalisation flag so each step function can advance
-    /// the same conversation without binding to local closures.
-    struct ChatCompletionsStreamState {
-        var thinking = ThinkingBlockManager()
-        let toolAccumulator = StreamingToolCallAccumulator()
-        // Tracks whether we've finalised tool calls already (for non-streaming
-        // whole responses delivered as a single chunk, where `finish_reason`
-        // and the final `tool_calls[]` arrive in the same payload).
-        var finalisedToolCalls = false
-    }
-
-    /// Per-payload outcome that lets the outer loop honour the `continue` /
-    /// `break` semantics that the original monolithic implementation
-    /// expressed inline.
-    enum PayloadOutcome {
-        case proceed
-        case continueLoop
-        case breakLoop
-    }
-
-    private func processPayload(
-        _ payload: String,
-        state: inout ChatCompletionsStreamState,
-        continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
-    ) -> PayloadOutcome {
-        if processPrefillProgress(payload, continuation: continuation) {
-            return .continueLoop
-        }
-        processReasoning(payload, state: &state, continuation: continuation)
-        processVisibleContent(payload, state: &state, continuation: continuation)
-        processToolDeltas(payload, state: &state, continuation: continuation)
-        processWholeToolCalls(payload, state: &state, continuation: continuation)
-        processUsage(payload, continuation: continuation)
-        processFinishReason(payload, state: &state, continuation: continuation)
-        if isStreamEnd(payload) {
-            state.thinking.flushIfOpen(into: continuation)
-            return .breakLoop
-        }
-        return .proceed
-    }
-
-    private func processPrefillProgress(
-        _ payload: String,
-        continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
-    ) -> Bool {
-        guard let progress = Self.parsePrefillProgress(from: payload) else { return false }
-        continuation.yield(.prefillProgress(
-            nPast: progress.nPast,
-            nTotal: progress.nTotal,
-            tokensPerSecond: progress.tokensPerSecond
-        ))
-        return true
-    }
-
-    /// Reasoning delta: emit as thinkingToken, keep the block open. A single
-    /// chunk may legally carry both reasoning and content on some providers,
-    /// so the caller still runs the visible-content step after this.
-    private func processReasoning(
-        _ payload: String,
-        state: inout ChatCompletionsStreamState,
-        continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
-    ) {
-        guard let reasoning = Self.parseReasoningDelta(from: payload) else { return }
-        continuation.yield(.thinkingToken(reasoning))
-        state.thinking.open()
-    }
-
-    /// Visible content delta: close thinking first so consumers see a clean
-    /// handoff before the first visible token.
-    private func processVisibleContent(
-        _ payload: String,
-        state: inout ChatCompletionsStreamState,
-        continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
-    ) {
-        guard let token = extractToken(from: payload) else { return }
-        state.thinking.flushIfOpen(into: continuation)
-        continuation.yield(.token(token))
-    }
-
-    /// Tool-call deltas (streaming) — keyed by `index`. The first delta for
-    /// each `index` carries `id` + `function.name`; subsequent deltas carry
-    /// `function.arguments` fragments. Some compat servers do not re-emit
-    /// `id` on later deltas, so we sticky-buffer it.
-    private func processToolDeltas(
-        _ payload: String,
-        state: inout ChatCompletionsStreamState,
-        continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
-    ) {
-        for delta in Self.parseToolCallDeltas(from: payload) {
-            emitToolDelta(delta, state: &state, continuation: continuation)
-        }
-    }
-
-    private func emitToolDelta(
-        _ delta: ToolCallDelta,
-        state: inout ChatCompletionsStreamState,
-        continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
-    ) {
-        let key = "\(delta.index)"
-        let isNew = state.toolAccumulator.upsert(
-            key: key,
-            id: delta.id,
-            name: delta.name,
-            argumentsDelta: delta.argumentsDelta
-        )
-        if isNew {
-            state.thinking.flushIfOpen(into: continuation)
-        }
-        // Emit `.toolCallStart` once we have both an id and a name.
-        if let entry = state.toolAccumulator.entriesByKey[key],
-           !entry.started, !entry.name.isEmpty {
-            let resolvedId = state.toolAccumulator.resolvedId(forKey: key)
-            continuation.yield(.toolCallStart(callId: resolvedId, name: entry.name))
-            state.toolAccumulator.markStarted(key: key)
-        }
-        // Stream argument fragments under the resolved (sticky) id.
-        if let fragment = delta.argumentsDelta, !fragment.isEmpty {
-            let resolvedId = state.toolAccumulator.resolvedId(forKey: key)
-            continuation.yield(.toolCallArgumentsDelta(callId: resolvedId, textDelta: fragment))
-        }
-    }
-
-    /// Non-streaming whole-message tool_calls (`message.tool_calls[]`).
-    /// Skipped once the streaming path has already finalised, to avoid double
-    /// emission when both shapes appear in the same response.
-    private func processWholeToolCalls(
-        _ payload: String,
-        state: inout ChatCompletionsStreamState,
-        continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
-    ) {
-        guard !state.finalisedToolCalls else { return }
-        let wholeCalls = Self.parseWholeToolCalls(from: payload)
-        guard !wholeCalls.isEmpty else { return }
-        state.thinking.flushIfOpen(into: continuation)
-        for call in wholeCalls {
-            emitWholeToolCall(call, state: &state, continuation: continuation)
-        }
-    }
-
-    private func emitWholeToolCall(
-        _ call: WholeToolCall,
-        state: inout ChatCompletionsStreamState,
-        continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
-    ) {
-        let key = call.id.isEmpty ? UUID().uuidString : call.id
-        state.toolAccumulator.upsert(
-            key: key,
-            id: call.id,
-            name: call.name,
-            argumentsDelta: call.arguments
-        )
-        let resolvedId = state.toolAccumulator.resolvedId(forKey: key)
-        continuation.yield(.toolCallStart(callId: resolvedId, name: call.name))
-        state.toolAccumulator.markStarted(key: key)
-        if !call.arguments.isEmpty {
-            continuation.yield(.toolCallArgumentsDelta(
-                callId: resolvedId,
-                textDelta: call.arguments
-            ))
-        }
-    }
-
-    private func processUsage(
-        _ payload: String,
-        continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
-    ) {
-        guard let usage = extractUsage(from: payload) else { return }
-        handleUsage(usage)
-        if let prompt = usage.promptTokens,
-           let completion = usage.completionTokens {
-            continuation.yield(.usage(prompt: prompt, completion: completion))
-        }
-    }
-
-    /// `finish_reason: "tool_calls"` finalises any buffered streaming tool
-    /// calls. When the assistant turn ends with `stop` we still flush any
-    /// accumulated tool calls so callers in the non-stream path see a uniform
-    /// shape.
-    private func processFinishReason(
-        _ payload: String,
-        state: inout ChatCompletionsStreamState,
-        continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
-    ) {
-        guard let reason = Self.parseFinishReason(from: payload) else { return }
-        if reason == "tool_calls" || !state.toolAccumulator.entriesByKey.isEmpty {
-            finaliseToolCalls(state: &state, continuation: continuation)
-        }
-    }
-
-    private func finaliseToolCalls(
-        state: inout ChatCompletionsStreamState,
-        continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
-    ) {
-        guard !state.finalisedToolCalls else { return }
-        state.finalisedToolCalls = true
-        for entry in state.toolAccumulator.finalizedEntries() {
-            continuation.yield(.toolCall(ToolCall(
-                id: entry.callId,
-                toolName: entry.name,
-                arguments: entry.arguments
-            )))
-        }
-    }
+    //
+    // Phase 2/B/iii/δ deleted the inline `parseResponseStream` override and
+    // its `process*` step cluster. The adapter routing installed at
+    // `init(urlSession:)` time threads stream parsing through
+    // `SSECloudBackend.parseResponseStreamRouted`, which drives a fresh
+    // `OpenAIStreamEventExtractor` per generation. The extractor (shipped
+    // in #1269) owns the per-stream state — open-thinking flag, index-
+    // keyed tool-call delta buffer, once-only finalisation guard — that
+    // previously lived in `ChatCompletionsStreamState` on this class.
 
     // MARK: - SSE Payload Handler
 
@@ -843,6 +618,14 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         )
     }
 
+}
+
+/// Sendable weak reference used by the routing closure to call back into
+/// the backend's `buildRequest` without retaining `self`. Matches the
+/// `WeakBox` pattern used inside `SSECloudBackend.generate`.
+private final class WeakBackendBox: @unchecked Sendable {
+    weak var value: OpenAIBackend?
+    init(_ value: OpenAIBackend) { self.value = value }
 }
 
 #endif

--- a/Sources/ManifoldCloud/OpenAIStreamEventExtractor.swift
+++ b/Sources/ManifoldCloud/OpenAIStreamEventExtractor.swift
@@ -37,7 +37,7 @@ import ManifoldCloudCore
 /// ``OpenAIBackend``'s `processPayload` cluster one-for-one. The parity
 /// test (`OpenAIStreamEventExtractorParityTests`) drives both paths through
 /// the on-disk fixtures and asserts equal event sequences.
-public final class OpenAIStreamEventExtractor {
+public final class OpenAIStreamEventExtractor: CloudStreamEventConsumer, @unchecked Sendable {
 
     private var thinking = ThinkingBlockManager()
     private let toolAccumulator = StreamingArgumentAccumulator()

--- a/Sources/ManifoldCloudCore/CloudAdapterRouting.swift
+++ b/Sources/ManifoldCloudCore/CloudAdapterRouting.swift
@@ -57,18 +57,37 @@ public struct CloudAdapterRouting: Sendable {
         _ config: GenerationConfig
     ) throws -> URLRequest
 
+    /// Optional factory for a stateful per-stream event consumer.
+    ///
+    /// When non-nil, `SSECloudBackend.parseResponseStreamRouted` invokes
+    /// this factory at stream open and drives the resulting consumer with
+    /// each decoded frame payload (`consume(payload:)`) followed by a
+    /// single terminal `finish(cancelled:)`. The consumer takes over event
+    /// emission entirely — neither ``payloadHandler/extractEvents(from:)``
+    /// nor the envelope's thinking-handoff bookkeeping run on this path,
+    /// because both responsibilities belong to the consumer.
+    ///
+    /// When nil (default), the envelope falls back to the stateless
+    /// per-frame projection through ``payloadHandler``. The OpenAI Chat
+    /// Completions backend is the first migration onto this seam (Phase
+    /// 2/B/iii/δ); Claude, OpenAI Responses, and Ollama keep their inline
+    /// stream loops until Phase 3.
+    public let streamConsumerFactory: (@Sendable () -> any CloudStreamEventConsumer)?
+
     public init(
         payloadHandler: any SSEPayloadHandler,
         framedTransport: any FramedTransport,
         streamFinalizer: any StreamFinalizer,
         errorBodyDecoder: any ErrorBodyDecoder,
-        buildRequest: @escaping @Sendable (String, String?, GenerationConfig) throws -> URLRequest
+        buildRequest: @escaping @Sendable (String, String?, GenerationConfig) throws -> URLRequest,
+        streamConsumerFactory: (@Sendable () -> any CloudStreamEventConsumer)? = nil
     ) {
         self.payloadHandler = payloadHandler
         self.framedTransport = framedTransport
         self.streamFinalizer = streamFinalizer
         self.errorBodyDecoder = errorBodyDecoder
         self.buildRequest = buildRequest
+        self.streamConsumerFactory = streamConsumerFactory
     }
 }
 #endif

--- a/Sources/ManifoldCloudCore/CloudStreamEventConsumer.swift
+++ b/Sources/ManifoldCloudCore/CloudStreamEventConsumer.swift
@@ -1,0 +1,37 @@
+#if Ollama || CloudSaaS
+import Foundation
+import ManifoldInference
+
+/// Stateful per-stream consumer that maps SSE / NDJSON frame payloads to
+/// ``GenerationEvent`` sequences.
+///
+/// The stateless ``SSEPayloadHandler`` surface can only emit events whose
+/// decision is local to a single frame (`.token`, `.thinkingToken`, raw
+/// `.usage`). Real provider streams also carry events whose extraction
+/// requires cross-frame state — index-keyed tool-call delta buffers, the
+/// open-thinking flag, the once-only tool-call finalisation guard,
+/// `finish_reason`-triggered drains. `CloudStreamEventConsumer` is the
+/// envelope-facing surface for that state.
+///
+/// ### Lifecycle
+///
+/// `SSECloudBackend.parseResponseStreamRouted` obtains a fresh consumer at
+/// stream open by invoking ``CloudAdapterRouting/streamConsumerFactory``
+/// (when non-nil), drives ``consume(payload:)`` for each frame, and calls
+/// ``finish(cancelled:)`` exactly once at stream end. Implementations must
+/// keep all per-stream state internal so a second generation gets a clean
+/// instance — the factory pattern enforces this at the type system level.
+public protocol CloudStreamEventConsumer: AnyObject, Sendable {
+    /// Returns the event sequence to emit for one frame's decoded payload.
+    /// May emit zero events for non-content frames (heartbeats, role-only
+    /// chunks).
+    func consume(payload: String) -> [GenerationEvent]
+
+    /// Flushes pending state at stream end. Implementations yield any
+    /// open-thinking close (`.thinkingComplete`) and any buffered tool
+    /// calls the upstream never accompanied with an explicit
+    /// `finish_reason`. Pass `cancelled: true` to suppress phantom tool
+    /// emissions when the consumer is being dropped mid-stream.
+    func finish(cancelled: Bool) -> [GenerationEvent]
+}
+#endif

--- a/Sources/ManifoldCloudCore/SSECloudBackend.swift
+++ b/Sources/ManifoldCloudCore/SSECloudBackend.swift
@@ -597,76 +597,124 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
     ) async throws {
         let handler = routing.payloadHandler
         let finalizer = routing.streamFinalizer
+        let consumer = routing.streamConsumerFactory?()
         var wasThinking = false
+        var streamEnded = false
+        var threwMidStream: Error?
 
-        for await frame in routing.framedTransport.frames(from: bytes) {
-            if Task.isCancelled { break }
+        do {
+            for await frame in routing.framedTransport.frames(from: bytes) {
+                if Task.isCancelled { break }
 
-            // Decode the frame as UTF-8 for the payload handler API, which
-            // operates on `String`. `FramedTransport` ships `Data` so binary
-            // bytes survive transport intact; the handler chooses how to
-            // interpret. Empty / non-UTF-8 frames skip event extraction
-            // but still get inspected by the finalizer below in case the
-            // termination signal is binary.
-            let payload = String(data: frame, encoding: .utf8) ?? ""
+                // Decode the frame as UTF-8 for the payload handler API, which
+                // operates on `String`. `FramedTransport` ships `Data` so binary
+                // bytes survive transport intact; the handler chooses how to
+                // interpret. Empty / non-UTF-8 frames skip event extraction
+                // but still get inspected by the finalizer below in case the
+                // termination signal is binary.
+                let payload = String(data: frame, encoding: .utf8) ?? ""
 
-            if !payload.isEmpty {
-                for event in handler.extractEvents(from: payload) {
-                    switch event {
-                    case .thinkingToken:
-                        wasThinking = true
-                        continuation.yield(event)
-                    case .thinkingComplete:
-                        wasThinking = false
-                        continuation.yield(event)
-                    case .token:
-                        if wasThinking {
-                            continuation.yield(.thinkingComplete)
-                            wasThinking = false
+                if !payload.isEmpty {
+                    if let consumer {
+                        // Consumer-driven path: the consumer owns the full
+                        // event vocabulary (tokens, reasoning handoff, tool
+                        // calls, usage, prefill progress, finish-reason
+                        // drains). The envelope only forwards what the
+                        // consumer emits and still consults the handler for
+                        // in-stream errors + the finalizer/isStreamEnd
+                        // termination signals.
+                        for event in consumer.consume(payload: payload) {
+                            // Mirror the usage event back into envelope
+                            // bookkeeping so `lastUsage` stays accurate for
+                            // hosts that read it post-stream.
+                            if case .usage(let prompt, let completion) = event {
+                                handleUsage((promptTokens: prompt, completionTokens: completion))
+                            }
+                            continuation.yield(event)
                         }
-                        continuation.yield(event)
-                    default:
-                        continuation.yield(event)
+                    } else {
+                        for event in handler.extractEvents(from: payload) {
+                            switch event {
+                            case .thinkingToken:
+                                wasThinking = true
+                                continuation.yield(event)
+                            case .thinkingComplete:
+                                wasThinking = false
+                                continuation.yield(event)
+                            case .token:
+                                if wasThinking {
+                                    continuation.yield(.thinkingComplete)
+                                    wasThinking = false
+                                }
+                                continuation.yield(event)
+                            default:
+                                continuation.yield(event)
+                            }
+                        }
+
+                        if let usage = handler.extractUsage(from: payload) {
+                            handleUsage(usage)
+                            if let prompt = usage.promptTokens,
+                               let completion = usage.completionTokens {
+                                continuation.yield(.usage(prompt: prompt, completion: completion))
+                            }
+                        }
+                    }
+
+                    if let error = handler.extractStreamError(from: payload) {
+                        throw error
                     }
                 }
 
-                if let usage = handler.extractUsage(from: payload) {
-                    handleUsage(usage)
-                    if let prompt = usage.promptTokens,
+                // Finalizer takes precedence over the handler's `isStreamEnd`
+                // boolean — it's the richer signal (carries usage + stop
+                // reason on the terminal frame).
+                if case .streamComplete(let usage, _) = finalizer.finalize(frame: frame) {
+                    // On the consumer-driven path the consumer has already
+                    // emitted any payload-carried `.usage` event; the
+                    // finalizer signal is only used to break the loop. On
+                    // the legacy path the finalizer carries the canonical
+                    // terminal usage payload (Claude's split counts), so we
+                    // mirror it through `handleUsage` and yield once.
+                    if consumer == nil,
+                       let usage,
+                       let prompt = usage.promptTokens,
                        let completion = usage.completionTokens {
+                        handleUsage((promptTokens: prompt, completionTokens: completion))
                         continuation.yield(.usage(prompt: prompt, completion: completion))
                     }
+                    streamEnded = true
+                    break
                 }
 
-                if let error = handler.extractStreamError(from: payload) {
-                    throw error
+                // Fall back to the handler's stream-end boolean for
+                // backends whose finalizer isn't authoritative on every
+                // frame (e.g. providers where the stop sentinel is the
+                // SSE `[DONE]` marker rather than a JSON field).
+                if !payload.isEmpty, handler.isStreamEnd(payload) {
+                    streamEnded = true
+                    break
                 }
             }
+        } catch {
+            threwMidStream = error
+        }
 
-            // Finalizer takes precedence over the handler's `isStreamEnd`
-            // boolean — it's the richer signal (carries usage + stop
-            // reason on the terminal frame).
-            if case .streamComplete(let usage, _) = finalizer.finalize(frame: frame) {
-                if let usage,
-                   let prompt = usage.promptTokens,
-                   let completion = usage.completionTokens {
-                    // Bridge the finalizer's `TokenUsage` shape into
-                    // `handleUsage` so subclasses that override usage
-                    // merging (Claude's split prompt/completion) still see
-                    // the terminal payload.
-                    handleUsage((promptTokens: prompt, completionTokens: completion))
-                    continuation.yield(.usage(prompt: prompt, completion: completion))
-                }
-                break
+        // Flush the consumer regardless of how the loop exited. On natural
+        // termination this yields any open `.thinkingComplete` and tool
+        // calls upstream never accompanied with an explicit
+        // `finish_reason`. On cancellation / mid-stream error we still
+        // flush thinking but suppress phantom tool calls so the consumer
+        // doesn't synthesise events the model never committed to.
+        if let consumer {
+            let cancelled = Task.isCancelled || threwMidStream != nil || !streamEnded
+            for event in consumer.finish(cancelled: cancelled) {
+                continuation.yield(event)
             }
+        }
 
-            // Fall back to the handler's stream-end boolean for
-            // backends whose finalizer isn't authoritative on every
-            // frame (e.g. providers where the stop sentinel is the
-            // SSE `[DONE]` marker rather than a JSON field).
-            if !payload.isEmpty, handler.isStreamEnd(payload) {
-                break
-            }
+        if let threwMidStream {
+            throw threwMidStream
         }
     }
 

--- a/Tests/ManifoldBackendsTests/SSEStreamParserCohortTests.swift
+++ b/Tests/ManifoldBackendsTests/SSEStreamParserCohortTests.swift
@@ -86,16 +86,12 @@ final class SSEStreamParserCohortTests: XCTestCase {
     }
 
     // MARK: - OpenAIBackend.ChatCompletionsStreamState
-
-    func test_chatCompletionsStreamState_initialFlagsAreClean() {
-        let state = OpenAIBackend.ChatCompletionsStreamState()
-        XCTAssertFalse(state.finalisedToolCalls)
-        // Tool accumulator must start empty so the per-payload step can rely
-        // on `entriesByKey.isEmpty` as a "no streamed deltas seen" signal
-        // when `finish_reason` arrives in the same payload as a whole-call
-        // shape.
-        XCTAssertTrue(state.toolAccumulator.entriesByKey.isEmpty)
-    }
+    //
+    // Removed in Phase 2/B/iii/δ: the inline stream-state struct was deleted
+    // along with the `processPayload` cluster. Per-stream state now lives on
+    // `OpenAIStreamEventExtractor`, whose initial-state invariants are
+    // covered by `OpenAIStreamEventExtractorTests`
+    // (`test_extractor_isFreshPerInstance_finalisationGuardDoesNotLeakAcrossStreams`).
 }
 
 extension OpenAIResponsesBackend.ResponsesEventKind: Equatable {}


### PR DESCRIPTION
## Summary

The long-promised Phase 2/B/iii/δ flip. `OpenAIBackend` stops overriding
`parseResponseStream`; the stream loop now runs in
`SSECloudBackend.parseResponseStreamRouted` against a fresh
`OpenAIStreamEventExtractor` per generation (shipped in #1269). The
inline `process*` cluster — `processPayload`, `processPrefillProgress`,
`processReasoning`, `processVisibleContent`, `processToolDeltas`,
`processWholeToolCalls`, `processUsage`, `processFinishReason` — and the
helpers `emitToolDelta`, `emitWholeToolCall`, `finaliseToolCalls`, plus
the `ChatCompletionsStreamState` struct and `PayloadOutcome` enum, are
all deleted.

## LOC delta on `Sources/ManifoldCloud/OpenAIBackend.swift`

| | LOC |
|---|---|
| Pre-Phase-2 baseline | ~781 |
| Post-#1266-attempt peak | 882 |
| Pre-this-PR (main @ 11b2feb7) | 848 |
| **After this PR** | **631** |
| **Delta vs. main** | **-217** |

Net repo diff: +223 / -340 (includes new `CloudStreamEventConsumer.swift`
protocol file and the `streamConsumerFactory` field on
`CloudAdapterRouting`).

## What was deleted from `OpenAIBackend`

- `parseResponseStream(bytes:config:continuation:)` override
- `ChatCompletionsStreamState` struct
- `PayloadOutcome` enum
- `processPayload`, `processPrefillProgress`, `processReasoning`,
  `processVisibleContent`, `processToolDeltas`, `processWholeToolCalls`,
  `processUsage`, `processFinishReason`
- `emitToolDelta`, `emitWholeToolCall`, `finaliseToolCalls`

## What was kept (and why)

- The static parse helpers (`parseToken`, `parseUsage`,
  `parseReasoningDelta`, `parseToolCallDeltas`, `parseWholeToolCalls`,
  `parseFinishReason`, `parsePrefillProgress`, `legacyExtractToken`,
  `legacyExtractUsage`)
- The `ToolCallDelta`, `WholeToolCall`, `PrefillProgress` types
- The static `payloadHandler` property

These are the cross-module entry points consumed by
`OpenAIStreamEventExtractor`, `CloudPayloadHandler.openAI`, and the
fixture-driven tests in `Tests/ManifoldBackendsTests`. Moving them would
churn fixture-test imports for no behavioural gain.

## How the wiring works

1. **`CloudStreamEventConsumer` protocol** (new, `ManifoldCloudCore`) —
   the envelope-facing surface for stateful per-stream event extraction.
   Methods: `consume(payload:) -> [GenerationEvent]` and
   `finish(cancelled:) -> [GenerationEvent]`.
2. **`CloudAdapterRouting.streamConsumerFactory`** (new field) — optional
   `@Sendable () -> any CloudStreamEventConsumer`. When non-nil, the
   envelope invokes it once per generation to obtain a fresh consumer.
3. **`OpenAIStreamEventExtractor`** conforms to `CloudStreamEventConsumer`.
4. **`SSECloudBackend.parseResponseStreamRouted`** — drives
   `consume(payload:)` per frame and a single `finish(cancelled:)` at
   stream end. `handleUsage` mirrors any consumer-emitted `.usage` so
   post-stream `lastUsage` readers stay accurate. On cancellation /
   mid-stream error the consumer is flushed with `cancelled: true`,
   suppressing phantom `.toolCall` emissions.
5. **`OpenAIBackend.init(urlSession:)`** — installs
   `CloudAdapterRouting` at construction time. The routing's
   `buildRequest` closure forwards to `self.buildRequest` (captured
   weakly) so the stateful pre-flight — tool-aware history
   snapshot/clear, structured-history vision guard, manifest-gated
   parameters, JIT keychain — keeps running on the backend where it
   owns its state.

## Behavior-parity evidence

- `OpenAIStreamEventExtractorParityTests` (5 fixtures: streaming/simple-
  prompt, tool-calls/simple, usage/basic, reasoning/with-summary,
  finish-reason/length-stop) drives `OpenAIBackend` end-to-end through
  `MockURLProtocol` and compares the event sequence against the in-
  process extractor. After this flip both sides produce the same
  sequence (the inline path *is* the extractor now), so passing parity
  proves the migration is faithful.
- `ManifoldBackendsTests`: 193 tests pass, 0 failures, 2 skips
  (hardware-gated).
- `CrossBackendReplayParityTests`, `OpenAICompatEndpointTests`,
  `SSEPayloadReplayTests` — all green, no test changes needed.

## Source compatibility

Public `init(...)`, public methods, history setters, and the public
`adapter` property are unchanged. The only removed type at any
visibility level was `ChatCompletionsStreamState` (internal), which had
exactly one external reference: a single test case in
`SSEStreamParserCohortTests` asserting the struct's default-init
invariants. That case is removed in this PR; the same invariant is
covered by
`OpenAIStreamEventExtractorTests.test_extractor_isFreshPerInstance_finalisationGuardDoesNotLeakAcrossStreams`,
which exercises the live per-stream state instead of an internal struct.

## Sabotage check

Performed locally (and reverted before commit): in
`SSECloudBackend.parseResponseStreamRouted` I commented out the
`consumer.consume(payload: payload)` call. With the consumer disabled,
`OpenAIStreamEventExtractorParityTests` fails on every fixture (no
events emitted by the inline path), and `OpenAIBackendToolCallingTests`
fails because no `.toolCall` events are emitted. Re-enabling restored
the green sweep. This confirms the wiring is load-bearing: the migration
isn't being silently bypassed.

## Why open a new PR instead of rebasing #1266

#1266 contained a partial wire-up of routing for request building and
error decoding only — it could not flip the stream path because
`CloudPayloadHandler.openAI.extractEvents` was `.token`-only at the
time. #1269 closed that gap (`OpenAIStreamEventExtractor` ships with
inline parity proven against 5 on-disk fixtures), so the clean approach
is to land the resulting deletion on a fresh branch rather than carry
forward #1266's partial wiring. #1266 will be closed with a pointer here.

## Plan

`/Users/roryford/.claude/plans/put-together-a-plan-lucky-wadler.md`

## Test plan

- [x] `swift build --disable-default-traits` clean
- [x] `swift build --build-tests --disable-default-traits` clean
- [x] `ManifoldBackendsTests` — 193/193 pass
- [ ] Trait-combo sweep `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz`
- [ ] Full pre-push gate (2-invocation CLAUDE.md shape)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)