### PR TITLE
refactor: expose model readiness stream waiter

### DIFF
--- a/Sources/ManifoldInference/Services/InferenceService.swift
+++ b/Sources/ManifoldInference/Services/InferenceService.swift
@@ -222,9 +222,37 @@ public final class InferenceService {
             pollIntervalNanoseconds: pollIntervalNanoseconds
         )
 
-        return await withTaskGroup(of: Bool.self) { group in
+        return await Self.waitUntilModelReady(
+            readinessUpdates: modelLoadReadinessUpdates(),
+            timeoutNanoseconds: timeoutNanoseconds
+        )
+    }
+
+    /// Waits for a supplied readiness stream to report that the model is ready.
+    ///
+    /// This overload is useful for hosts and tests that want the same generic
+    /// readiness semantics as ``waitUntilModelReady(maxPollCount:pollIntervalNanoseconds:)``
+    /// while injecting a synthetic stream at the Manifold boundary.
+    public nonisolated static func waitUntilModelReady(
+        readinessUpdates updates: AsyncStream<ModelLoadReadinessState>,
+        maxPollCount: Int = 300,
+        pollIntervalNanoseconds: UInt64 = 50_000_000
+    ) async -> Bool {
+        await waitUntilModelReady(
+            readinessUpdates: updates,
+            timeoutNanoseconds: modelReadyTimeoutNanoseconds(
+                maxPollCount: maxPollCount,
+                pollIntervalNanoseconds: pollIntervalNanoseconds
+            )
+        )
+    }
+
+    private nonisolated static func waitUntilModelReady(
+        readinessUpdates updates: AsyncStream<ModelLoadReadinessState>,
+        timeoutNanoseconds: UInt64
+    ) async -> Bool {
+        await withTaskGroup(of: Bool.self) { group in
             group.addTask {
-                let updates = await self.modelLoadReadinessUpdates()
                 for await state in updates {
                     if Task.isCancelled { return false }
                     switch state {

--- a/Tests/ManifoldInferenceTests/InferenceServiceObservationTests.swift
+++ b/Tests/ManifoldInferenceTests/InferenceServiceObservationTests.swift
@@ -228,6 +228,47 @@ final class InferenceServiceObservationTests: XCTestCase {
         _ = try? await loadTask.value
     }
 
+    func test_waitUntilModelReady_acceptsSyntheticReadinessStream() async {
+        let stream = AsyncStream<ModelLoadReadinessState> { continuation in
+            continuation.yield(.loading(progress: 0.5))
+            Task {
+                await Task.yield()
+                continuation.yield(.ready)
+                continuation.finish()
+            }
+        }
+
+        let ready = await InferenceService.waitUntilModelReady(
+            readinessUpdates: stream,
+            maxPollCount: 300,
+            pollIntervalNanoseconds: 50_000_000
+        )
+
+        XCTAssertTrue(ready)
+    }
+
+    func test_waitUntilModelReady_withSyntheticStreamCancelsPromptly() async {
+        let stream = AsyncStream<ModelLoadReadinessState> { continuation in
+            continuation.yield(.loading(progress: 0.5))
+        }
+        let task = Task {
+            await InferenceService.waitUntilModelReady(
+                readinessUpdates: stream,
+                maxPollCount: 300,
+                pollIntervalNanoseconds: 50_000_000
+            )
+        }
+
+        await Task.yield()
+        let cancelStart = ContinuousClock.now
+        task.cancel()
+        let ready = await task.value
+        let elapsed = ContinuousClock.now - cancelStart
+
+        XCTAssertFalse(ready)
+        XCTAssertLessThan(elapsed, .milliseconds(500))
+    }
+
     // MARK: - Helpers
 
     private func makeModelInfo() -> ModelInfo {


### PR DESCRIPTION
## Summary

- Adds model readiness stream state to `InferenceService`
- Adds `waitUntilModelReady` support over readiness streams, including synthetic streams for host-app test seams
- Covers readiness transitions, timeout, and cancellation behavior in `InferenceServiceObservationTests`

## Validation

- `swift test --quiet --filter InferenceServiceObservationTests`

Required by roryford/fireside#517 and roryford/fireside#519.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>