### PR TITLE
fix(cloud): gate CloudSaaS-only types behind #if CloudSaaS in Ollama-only builds

### DIFF
--- a/Sources/ManifoldCloud/CloudMessageEncoder.swift
+++ b/Sources/ManifoldCloud/CloudMessageEncoder.swift
@@ -119,7 +119,11 @@ public enum CloudMessageEncoder: Sendable {
         guard !tools.isEmpty else { return [] }
         switch self {
         case .openAI, .openAIResponses:
+            #if CloudSaaS
             return tools.map(OpenAIToolEncoding.encodeToolDefinition)
+            #else
+            return []
+            #endif
         case .claude:
             #if CloudSaaS
             return tools.map(Self.claudeEncodeToolDefinition)
@@ -254,9 +258,17 @@ public enum CloudMessageEncoder: Sendable {
     private func encodeToolAwareEntry(_ entry: ToolAwareHistoryEntry) -> [[String: Any]] {
         switch self {
         case .openAI:
+            #if CloudSaaS
             return [OpenAIToolEncoding.encodeChatCompletionsEntry(entry)]
+            #else
+            return [["role": entry.role, "content": entry.content]]
+            #endif
         case .openAIResponses:
+            #if CloudSaaS
             return OpenAIToolEncoding.encodeResponsesEntries(entry)
+            #else
+            return [["role": entry.role, "content": entry.content]]
+            #endif
         case .claude:
             #if CloudSaaS
             return [Self.claudeEncodeToolAwareEntry(entry)]

--- a/Sources/ManifoldCloud/CloudPayloadHandler.swift
+++ b/Sources/ManifoldCloud/CloudPayloadHandler.swift
@@ -38,9 +38,17 @@ public enum CloudPayloadHandler: Sendable, SSEPayloadHandler {
         case .openAI:
             return OpenAIChatCompletionsPayloadParsing.extractToken(from: payload)
         case .openAIResponses:
+            #if CloudSaaS
             return OpenAIResponsesPayloadParsing.extractToken(from: payload)
+            #else
+            return nil
+            #endif
         case .claude:
+            #if CloudSaaS
             return ClaudePayloadParsingDispatch.extractToken(from: payload)
+            #else
+            return nil
+            #endif
         case .ollama:
             #if Ollama
             return OllamaPayloadParsingDispatch.extractToken(from: payload)
@@ -55,9 +63,17 @@ public enum CloudPayloadHandler: Sendable, SSEPayloadHandler {
         case .openAI:
             return OpenAIChatCompletionsPayloadParsing.extractEvents(from: payload)
         case .openAIResponses:
+            #if CloudSaaS
             return OpenAIResponsesPayloadParsing.extractEvents(from: payload)
+            #else
+            return []
+            #endif
         case .claude:
+            #if CloudSaaS
             return ClaudePayloadParsingDispatch.extractEvents(from: payload)
+            #else
+            return []
+            #endif
         case .ollama:
             #if Ollama
             return OllamaPayloadParsingDispatch.extractEvents(from: payload)
@@ -72,9 +88,17 @@ public enum CloudPayloadHandler: Sendable, SSEPayloadHandler {
         case .openAI:
             return OpenAIChatCompletionsPayloadParsing.extractUsage(from: payload)
         case .openAIResponses:
+            #if CloudSaaS
             return OpenAIResponsesPayloadParsing.extractUsage(from: payload)
+            #else
+            return nil
+            #endif
         case .claude:
+            #if CloudSaaS
             return ClaudePayloadParsingDispatch.extractUsage(from: payload)
+            #else
+            return nil
+            #endif
         case .ollama:
             #if Ollama
             return OllamaPayloadParsingDispatch.extractUsage(from: payload)
@@ -94,7 +118,11 @@ public enum CloudPayloadHandler: Sendable, SSEPayloadHandler {
             // Phase 2.
             return false
         case .claude:
+            #if CloudSaaS
             return ClaudePayloadParsingDispatch.isStreamEnd(payload)
+            #else
+            return false
+            #endif
         case .ollama:
             // Ollama signals termination via the `"done":true` flag, but
             // the existing backend stream loop reads that field directly
@@ -109,13 +137,21 @@ public enum CloudPayloadHandler: Sendable, SSEPayloadHandler {
         case .openAI, .ollama:
             return nil
         case .openAIResponses:
+            #if CloudSaaS
             // Adapter-routed Responses streams ride `NamedSSETransport`,
             // which wraps each event as `{__event, __data}`. Surface
             // `response.error` events as a thrown error so the routed
             // loop terminates the stream.
             return OpenAIResponsesPayloadParsing.extractStreamError(from: payload)
+            #else
+            return nil
+            #endif
         case .claude:
+            #if CloudSaaS
             return ClaudePayloadParsingDispatch.extractStreamError(from: payload)
+            #else
+            return nil
+            #endif
         }
     }
 }
@@ -126,6 +162,7 @@ public enum CloudPayloadHandler: Sendable, SSEPayloadHandler {
 // Once Phase 2 lifts the parser internals into the adapter composition,
 // these shims will collapse into the enum's `switch` arms directly.
 
+#if CloudSaaS
 enum ClaudePayloadParsingDispatch {
     static func extractToken(from payload: String) -> String? {
         ClaudePayloadParser.parseToken(from: payload)
@@ -153,6 +190,7 @@ enum ClaudePayloadParsingDispatch {
         ClaudePayloadParser.parseStreamError(from: payload)
     }
 }
+#endif
 
 #if Ollama
 enum OllamaPayloadParsingDispatch {
@@ -185,6 +223,7 @@ enum OllamaPayloadParsingDispatch {
 }
 #endif
 
+#if CloudSaaS
 enum OpenAIResponsesPayloadParsing {
     static func extractToken(from payload: String) -> String? {
         OpenAIResponsesBackend.parseDelta(from: payload)
@@ -215,4 +254,5 @@ enum OpenAIResponsesPayloadParsing {
         return CloudBackendError.serverError(statusCode: 500, message: message)
     }
 }
-#endif
+#endif // CloudSaaS
+#endif // Ollama || CloudSaaS

--- a/Tests/ManifoldBackendsTests/InferenceBackendContractTests.swift
+++ b/Tests/ManifoldBackendsTests/InferenceBackendContractTests.swift
@@ -276,9 +276,11 @@ final class InferenceBackendContractTests: XCTestCase {
             case "openai.chat_completions":
                 let shape = OpenAIDeltaToolCalls()
                 XCTAssertEqual(shape.shapeName, "openai.delta")
+            #if CloudSaaS
             case "openai.responses":
                 let shape = OpenAIResponsesItemIdToolCalls()
                 XCTAssertEqual(shape.shapeName, "openai_responses.item_id")
+            #endif
             #if Ollama
             case "ollama.chat":
                 let shape = OllamaWholeToolCalls()

--- a/Tests/ManifoldInferenceTests/TrafficBoundaryAuditTest.swift
+++ b/Tests/ManifoldInferenceTests/TrafficBoundaryAuditTest.swift
@@ -137,6 +137,13 @@ final class TrafficBoundaryAuditTest: XCTestCase {
         // Responses API. Same `URLRequest`-only contract as
         // `OpenAIAdapter.swift` above.
         "ManifoldCloud/OpenAIResponsesAdapter.swift",
+        // Phase 3/Ollama — adapter composition for the Ollama NDJSON path.
+        // Same `URLRequest`-only contract (security invariant S1); no
+        // `URLSession` is exposed.
+        "ManifoldCloud/OllamaAdapter.swift",
+        // Phase 3/Claude — adapter composition for the Anthropic Claude path.
+        // Same `URLRequest`-only contract as `OpenAIAdapter.swift` above.
+        "ManifoldCloud/ClaudeAdapter.swift",
 
         // I1 network seam closure (#1140) — centralised redirect-guard
         // delegate, composite delegate, and seam factory live in


### PR DESCRIPTION
## Summary

- **TrafficBoundaryAuditTest failure**: `OllamaAdapter.swift` and `ClaudeAdapter.swift` were missing from the `networkIOAllowlist` despite following the same `URLRequest`-only seam pattern as `OpenAIAdapter`/`OpenAIResponsesAdapter`. Added both with the same security-invariant commentary.
- **Ollama-only build breakage** (`--traits Ollama` without `CloudSaaS`): Three `#if CloudSaaS`-gated types were referenced without guards in files compiled under `#if Ollama || CloudSaaS`:
  - `CloudPayloadHandler`: `ClaudePayloadParsingDispatch` and `OpenAIResponsesPayloadParsing` dispatch shims called `ClaudePayloadParser` and `OpenAIResponsesBackend` — both `CloudSaaS`-only. Gated both shim enums and affected switch arms.
  - `CloudMessageEncoder`: `case .openAI, .openAIResponses:` arms in `encodeTools` and `encodeToolAwareEntry` called `OpenAIToolEncoding` without a guard. Added `#if CloudSaaS` with empty/fallback returns.
  - `InferenceBackendContractTests`: `case "openai.responses":` witness branch used `OpenAIResponsesItemIdToolCalls` without `#if CloudSaaS`.

## Test plan

- [x] Default-traits CI suite: 3154 tests, 0 failures (was 1 — `TrafficBoundaryAuditTest`)
- [x] Swift Testing suite: 83 tests, 0 failures
- [x] `ManifoldE2ETests` (no traits): 35/35 pass
- [x] `ManifoldE2ETests --traits Ollama`: 35/35 pass
- [x] `ManifoldBackendsTests --traits Ollama`: 80/80 pass
- [x] All-traits-on build (`MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz`): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)