### PR TITLE
feat: add appData payload to TurnContext and CompletedTurn

### DIFF
--- a/Sources/ManifoldInference/Services/TurnContext.swift
+++ b/Sources/ManifoldInference/Services/TurnContext.swift
@@ -20,16 +20,24 @@ public struct TurnContext: Sendable {
     /// Tokenizer for cost estimation. Nil falls back to ``HeuristicTokenizer``
     /// inside ``ContextBudgetPlanner``.
     public let tokenizer: (any TokenizerProvider)?
+    /// Opaque host-app payload attached by ``ConversationRuntime/turnContextProvider``.
+    /// Nil when no provider is registered or when the provider returns nil for
+    /// this session. The value is passed through to ``CompletedTurn/appData``
+    /// so ``GenerationHook`` implementations can read it without a side-channel
+    /// registry.
+    public var appData: (any Sendable)?
 
     public init(
         sessionID: UUID,
         messageCount: Int,
         conversationText: String? = nil,
-        tokenizer: (any TokenizerProvider)? = nil
+        tokenizer: (any TokenizerProvider)? = nil,
+        appData: (any Sendable)? = nil
     ) {
         self.sessionID = sessionID
         self.messageCount = messageCount
         self.conversationText = conversationText
         self.tokenizer = tokenizer
+        self.appData = appData
     }
 }

--- a/Sources/ManifoldRuntime/Protocols/GenerationHook.swift
+++ b/Sources/ManifoldRuntime/Protocols/GenerationHook.swift
@@ -7,17 +7,24 @@ public struct CompletedTurn: Sendable {
     public let assistantMessage: ChatMessageRecord
     public let promptTokens: Int?
     public let completionTokens: Int?
+    /// Opaque host-app payload sourced from ``ConversationRuntime/turnContextProvider``.
+    /// Nil when no provider is registered or when the provider returns nil for
+    /// this session. Mirrors ``TurnContext/appData`` so hooks can act on
+    /// per-session app state without a separate registry.
+    public let appData: (any Sendable)?
 
     public init(
         sessionID: UUID,
         assistantMessage: ChatMessageRecord,
         promptTokens: Int?,
-        completionTokens: Int?
+        completionTokens: Int?,
+        appData: (any Sendable)? = nil
     ) {
         self.sessionID = sessionID
         self.assistantMessage = assistantMessage
         self.promptTokens = promptTokens
         self.completionTokens = completionTokens
+        self.appData = appData
     }
 }
 

--- a/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
@@ -156,7 +156,8 @@ public final class ConversationRuntime: Sendable {
         usageStore: (any UsageStore)? = nil,
         generationHooks: [any GenerationHook] = [],
         compressionPolicy: (any CompressionPolicy)? = nil,
-        historyProviders: [any HistoryProvider] = []
+        historyProviders: [any HistoryProvider] = [],
+        turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)? = nil
     ) {
         self.init(
             messageStore: messageStore,
@@ -170,7 +171,8 @@ public final class ConversationRuntime: Sendable {
             emptyResponseObserver: nil,
             generationHooks: generationHooks,
             compressionPolicy: compressionPolicy,
-            historyProviders: historyProviders
+            historyProviders: historyProviders,
+            turnContextProvider: turnContextProvider
         )
     }
 
@@ -190,7 +192,8 @@ public final class ConversationRuntime: Sendable {
         generationHooks: [any GenerationHook] = [],
         compressionPolicy: (any CompressionPolicy)? = nil,
         hookTimeout: Duration = .seconds(30),
-        historyProviders: [any HistoryProvider] = []
+        historyProviders: [any HistoryProvider] = [],
+        turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)? = nil
     ) {
         self.inferenceService = inferenceService
         self.auxiliaryInferenceService = auxiliaryInferenceService
@@ -215,7 +218,8 @@ public final class ConversationRuntime: Sendable {
             generationHooks: generationHooks,
             compressionPolicy: compressionPolicy,
             hookTimeout: hookTimeout,
-            historyProviders: historyProviders
+            historyProviders: historyProviders,
+            turnContextProvider: turnContextProvider
         )
     }
 

--- a/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
@@ -16,6 +16,11 @@ struct ConversationTurnExecutor: Sendable {
     private let compressionPolicy: (any CompressionPolicy)?
     private let hookTimeout: Duration
     private let historyAssembler: HistoryAssembler
+    /// Optional provider that attaches host-app data to each turn. Called with
+    /// the session UUID before context assembly; the returned value is stored on
+    /// ``TurnContext/appData`` and forwarded to ``CompletedTurn/appData`` so
+    /// ``GenerationHook`` implementations receive it without a side-channel.
+    private let turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)?
 
     init(
         persistence: ConversationPersistencePort,
@@ -30,7 +35,8 @@ struct ConversationTurnExecutor: Sendable {
         generationHooks: [any GenerationHook] = [],
         compressionPolicy: (any CompressionPolicy)? = nil,
         hookTimeout: Duration = .seconds(30),
-        historyProviders: [any HistoryProvider] = []
+        historyProviders: [any HistoryProvider] = [],
+        turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)? = nil
     ) {
         self.persistence = persistence
         self.inferenceService = inferenceService
@@ -45,6 +51,7 @@ struct ConversationTurnExecutor: Sendable {
         self.compressionPolicy = compressionPolicy
         self.hookTimeout = hookTimeout
         self.historyAssembler = HistoryAssembler(providers: historyProviders)
+        self.turnContextProvider = turnContextProvider
     }
 
     // MARK: Send flow
@@ -882,7 +889,8 @@ struct ConversationTurnExecutor: Sendable {
                 sessionID: sessionID,
                 assistantMessage: assistantMessage,
                 promptTokens: usage?.promptTokens,
-                completionTokens: usage?.completionTokens
+                completionTokens: usage?.completionTokens,
+                appData: turnContextProvider?(sessionID)
             )
             for hook in generationHooks {
                 let hookLabel = "\(type(of: hook))"
@@ -991,12 +999,14 @@ struct ConversationTurnExecutor: Sendable {
                 .lowercased()
             return joined.isEmpty ? nil : joined
         }()
-        return TurnContext(
+        var context = TurnContext(
             sessionID: sessionID,
             messageCount: history.count,
             conversationText: conversationText,
             tokenizer: nil
         )
+        context.appData = turnContextProvider?(sessionID)
+        return context
     }
 
     /// Reads the backend's context window size from the main actor.

--- a/Tests/ManifoldRuntimeTests/ConversationRuntimeAppDataTests.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationRuntimeAppDataTests.swift
@@ -1,0 +1,235 @@
+@preconcurrency import XCTest
+import Foundation
+@testable import ManifoldRuntime
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+/// Integration tests for the `turnContextProvider` / `appData` payload
+/// added in #1243.
+///
+/// Verifies that:
+///  - `TurnContext.appData` is `nil` by default.
+///  - A provider registered on `ConversationRuntime` surfaces its return value
+///    in `CompletedTurn.appData` delivered to a `GenerationHook`.
+///  - When no provider is registered, `CompletedTurn.appData` is `nil`.
+///
+/// Uses an in-memory `MessageStore` (no SwiftData required) and
+/// `MockInferenceBackend` from `ManifoldTestSupport`.
+@MainActor
+final class ConversationRuntimeAppDataTests: XCTestCase {
+
+    // MARK: - In-memory MessageStore
+
+    @MainActor
+    final class InMemoryMessageStore: MessageStore {
+        private(set) var messages: [UUID: ChatMessageRecord] = [:]
+        private var hooks: [any MessageStorePostWriteHook] = []
+
+        func insertMessage(_ message: ChatMessageRecord) async throws {
+            messages[message.id] = message
+            for hook in hooks {
+                await hook.messageDidWrite(message, in: message.sessionID)
+            }
+        }
+
+        func updateMessage(_ message: ChatMessageRecord) async throws {
+            guard messages[message.id] != nil else {
+                throw ChatPersistenceError.messageNotFound(message.id)
+            }
+            messages[message.id] = message
+        }
+
+        func deleteMessage(_ messageID: UUID) async throws {
+            guard messages.removeValue(forKey: messageID) != nil else {
+                throw ChatPersistenceError.messageNotFound(messageID)
+            }
+        }
+
+        func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
+            messages.values
+                .filter { $0.sessionID == sessionID }
+                .sorted { $0.timestamp < $1.timestamp }
+        }
+
+        func deleteMessages(for sessionID: UUID) async throws {
+            messages = messages.filter { $0.value.sessionID != sessionID }
+        }
+
+        func addPostWriteHook(_ hook: any MessageStorePostWriteHook) {
+            hooks.append(hook)
+        }
+    }
+
+    // MARK: - Recording hook
+
+    /// Hook that records every `CompletedTurn` it receives and signals
+    /// waiters so tests can await delivery deterministically.
+    actor RecordingHook: GenerationHook {
+        private(set) var receivedTurns: [CompletedTurn] = []
+        private var continuations: [CheckedContinuation<CompletedTurn, Never>] = []
+
+        func postGeneration(_ turn: CompletedTurn) async {
+            receivedTurns.append(turn)
+            for c in continuations { c.resume(returning: turn) }
+            continuations.removeAll()
+        }
+
+        func awaitNextTurn() async -> CompletedTurn {
+            await withCheckedContinuation { continuations.append($0) }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeRuntime(
+        mock: MockInferenceBackend? = nil,
+        generationHooks: [any GenerationHook] = [],
+        turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)? = nil
+    ) -> (runtime: ConversationRuntime, store: InMemoryMessageStore, mock: MockInferenceBackend) {
+        let backend = mock ?? MockInferenceBackend()
+        backend.isModelLoaded = true
+        let inference = InferenceService(backend: backend, name: "Mock")
+        let store = InMemoryMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference,
+            generationHooks: generationHooks,
+            turnContextProvider: turnContextProvider
+        )
+        return (runtime, store, backend)
+    }
+
+    enum TestError: Error { case deadlineElapsed }
+
+    private func awaitHookDelivery(
+        hook: RecordingHook,
+        deadline: Duration = .seconds(5)
+    ) async throws -> CompletedTurn {
+        try await withThrowingTaskGroup(of: CompletedTurn.self) { group in
+            group.addTask { await hook.awaitNextTurn() }
+            group.addTask {
+                try await Task.sleep(for: deadline)
+                throw TestError.deadlineElapsed
+            }
+            let turn = try await group.next()!
+            group.cancelAll()
+            return turn
+        }
+    }
+
+    // MARK: - Test 1: TurnContext.appData is nil by default
+
+    func test_turnContext_appData_isNilByDefault() {
+        let ctx = TurnContext(
+            sessionID: UUID(),
+            messageCount: 0
+        )
+        XCTAssertNil(ctx.appData, "appData must be nil when not supplied")
+    }
+
+    // MARK: - Test 2: appData roundtrips through init
+
+    func test_turnContext_appData_roundtrips() {
+        let payload = "hello"
+        let ctx = TurnContext(
+            sessionID: UUID(),
+            messageCount: 1,
+            appData: payload
+        )
+        XCTAssertEqual(ctx.appData as? String, payload)
+    }
+
+    // MARK: - Test 3: CompletedTurn.appData reflects provider return value
+
+    func test_completedTurn_appData_reflectsProvider() async throws {
+        let hook = RecordingHook()
+        let sessionID = UUID()
+        let expectedPayload = "per-session-data"
+
+        let mock = MockInferenceBackend()
+        mock.tokensToYield = ["Hello"]
+
+        let provider: @Sendable (UUID) -> (any Sendable)? = { id in
+            // Return different payloads per session so the test is not trivially true.
+            id == sessionID ? expectedPayload : nil
+        }
+
+        let (runtime, _, _) = makeRuntime(
+            mock: mock,
+            generationHooks: [hook],
+            turnContextProvider: provider
+        )
+
+        _ = try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hi", attachments: []),
+            config: TurnConfig()
+        ))
+
+        let deliveredTurn = try await awaitHookDelivery(hook: hook)
+
+        XCTAssertEqual(
+            deliveredTurn.appData as? String,
+            expectedPayload,
+            "CompletedTurn.appData must equal the provider's return value"
+        )
+    }
+
+    // MARK: - Test 4: CompletedTurn.appData is nil when no provider is set
+
+    func test_completedTurn_appData_isNilWithoutProvider() async throws {
+        let hook = RecordingHook()
+
+        let mock = MockInferenceBackend()
+        mock.tokensToYield = ["World"]
+
+        // No turnContextProvider — appData should be nil.
+        let (runtime, _, _) = makeRuntime(mock: mock, generationHooks: [hook])
+
+        let sessionID = UUID()
+        _ = try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hi", attachments: []),
+            config: TurnConfig()
+        ))
+
+        let deliveredTurn = try await awaitHookDelivery(hook: hook)
+
+        XCTAssertNil(
+            deliveredTurn.appData,
+            "CompletedTurn.appData must be nil when no turnContextProvider is registered"
+        )
+    }
+
+    // MARK: - Test 5: provider returning nil yields nil appData
+
+    func test_completedTurn_appData_isNilWhenProviderReturnsNil() async throws {
+        let hook = RecordingHook()
+
+        let mock = MockInferenceBackend()
+        mock.tokensToYield = ["ok"]
+
+        // Provider always returns nil.
+        let provider: @Sendable (UUID) -> (any Sendable)? = { _ in nil }
+
+        let (runtime, _, _) = makeRuntime(
+            mock: mock,
+            generationHooks: [hook],
+            turnContextProvider: provider
+        )
+
+        let sessionID = UUID()
+        _ = try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hi", attachments: []),
+            config: TurnConfig()
+        ))
+
+        let deliveredTurn = try await awaitHookDelivery(hook: hook)
+
+        XCTAssertNil(
+            deliveredTurn.appData,
+            "CompletedTurn.appData must be nil when the provider returns nil"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `appData: (any Sendable)?` to `TurnContext` and `CompletedTurn` so host apps can attach per-session data without a side-channel registry
- Adds `turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)?` to `ConversationRuntime` (public convenience init) and threads it through the package init and `ConversationTurnExecutor`
- All new parameters default to `nil` — zero call-site churn on existing consumers
- 5 new `XCTestCase` tests in `ConversationRuntimeAppDataTests` covering default-nil, roundtrip, provider-set, provider-nil, and no-provider paths

Closes #1243

## Test plan

- [ ] `swift build --build-tests --disable-default-traits` — green (verified locally)
- [ ] `scripts/test.sh --filter ManifoldRuntimeTests --disable-default-traits --skip-update`
- [ ] `scripts/test.sh --filter ManifoldInferenceTests --disable-default-traits --skip-update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)