### PR TITLE
test(backends): Phase 4 — LocalBackendContractTests scaffold with MockInferenceBackend participant

### DIFF
--- a/Tests/Fixtures/backends/mock/streaming/simple-prompt/expected.jsonl
+++ b/Tests/Fixtures/backends/mock/streaming/simple-prompt/expected.jsonl
@@ -1,0 +1,3 @@
+{"event":"token","text":"Hello"}
+{"event":"token","text":" "}
+{"event":"token","text":"world"}

--- a/Tests/ManifoldBackendsTests/ContractSuiteRuntimeBudgetTest.swift
+++ b/Tests/ManifoldBackendsTests/ContractSuiteRuntimeBudgetTest.swift
@@ -1,0 +1,161 @@
+#if CloudSaaS || Ollama
+import XCTest
+@testable import ManifoldInference
+
+/// Guards against CI regressions in the cloud-tier contract suite runtime.
+///
+/// Re-executes the same fixture-loading and payload-parsing work that
+/// ``InferenceBackendContractTests`` does and asserts the total wall-clock
+/// time stays under 15 seconds. The cloud-tier only runs fixture I/O and
+/// in-process parsing — no network calls — so 15 seconds is a generous
+/// ceiling that should absorb any CI load variance while still catching a
+/// pathological regression (e.g. reading an accidentally huge fixture file
+/// in a loop).
+///
+/// Gated on `#if CloudSaaS || Ollama` because that is the same condition
+/// wrapping ``InferenceBackendContractTests``. Without cloud traits, there
+/// are no cloud participants and nothing to measure.
+final class ContractSuiteRuntimeBudgetTest: XCTestCase {
+
+    func test_cloudTierContractSuite_completesUnder15Seconds() throws {
+        let clock = ContinuousClock()
+        let start = clock.now
+
+        // Re-run the same fixture corpus that InferenceBackendContractTests
+        // exercises: load and parse every `response.sse` / `response.ndjson`
+        // and `expected.jsonl` file for each cloud participant.
+        let participants = try buildParticipants()
+        for p in participants {
+            // Streaming/simple-prompt — always present for all participants.
+            _ = try loadPayloads(participant: p, scenario: "streaming/simple-prompt")
+            _ = try fixtureContents(for: p, scenario: "streaming/simple-prompt", file: "expected.jsonl")
+            // Usage/basic — always present.
+            _ = try loadPayloads(participant: p, scenario: "usage/basic")
+            // Tool-calls/simple — always present for tool-calling participants.
+            if p.supportsToolCalling {
+                _ = try loadPayloads(participant: p, scenario: "tool-calls/simple")
+            }
+        }
+
+        let elapsed = clock.now - start
+        // ContinuousClock.Duration has no direct comparison to Double in Swift
+        // 6.0; use .components to extract seconds.
+        let elapsedSeconds = Double(elapsed.components.seconds) +
+                             Double(elapsed.components.attoseconds) / 1e18
+        XCTAssertLessThan(
+            elapsedSeconds,
+            15.0,
+            """
+            Cloud-tier contract suite took \(String(format: "%.2f", elapsedSeconds))s — \
+            exceeds 15s budget. Investigate large fixture files or expensive parsing paths.
+            """
+        )
+    }
+
+    // MARK: - Budget-test helpers
+
+    /// Lightweight participant descriptor used only for budget accounting.
+    private struct BudgetParticipant {
+        let label: String
+        let fixtureDirectory: String
+        let wireFormat: WireFormat
+        let supportsToolCalling: Bool
+
+        enum WireFormat {
+            case sse, ndjson
+            var fileName: String {
+                switch self {
+                case .sse: return "response.sse"
+                case .ndjson: return "response.ndjson"
+                }
+            }
+        }
+    }
+
+    private func buildParticipants() throws -> [BudgetParticipant] {
+        var list: [BudgetParticipant] = []
+        #if CloudSaaS
+        list.append(BudgetParticipant(
+            label: "openai.chat_completions",
+            fixtureDirectory: "openai",
+            wireFormat: .sse,
+            supportsToolCalling: true
+        ))
+        list.append(BudgetParticipant(
+            label: "openai.responses",
+            fixtureDirectory: "openai_responses",
+            wireFormat: .sse,
+            supportsToolCalling: true
+        ))
+        list.append(BudgetParticipant(
+            label: "anthropic.messages",
+            fixtureDirectory: "claude",
+            wireFormat: .sse,
+            supportsToolCalling: true
+        ))
+        #endif
+        #if Ollama
+        list.append(BudgetParticipant(
+            label: "ollama.chat",
+            fixtureDirectory: "ollama",
+            wireFormat: .ndjson,
+            supportsToolCalling: true
+        ))
+        #endif
+        return list
+    }
+
+    private func loadPayloads(participant: BudgetParticipant, scenario: String) throws -> [String] {
+        let url = try fixtureURL(for: participant, scenario: scenario, file: participant.wireFormat.fileName)
+        let raw = try String(contentsOf: url, encoding: .utf8)
+        switch participant.wireFormat {
+        case .sse:
+            return raw.components(separatedBy: "\n").compactMap { line -> String? in
+                guard line.hasPrefix("data: ") else { return nil }
+                let payload = String(line.dropFirst("data: ".count))
+                return payload == "[DONE]" ? nil : payload
+            }
+        case .ndjson:
+            return raw.components(separatedBy: "\n").filter { !$0.isEmpty }
+        }
+    }
+
+    private func fixtureContents(
+        for participant: BudgetParticipant,
+        scenario: String,
+        file: String
+    ) throws -> String {
+        let url = try fixtureURL(for: participant, scenario: scenario, file: file)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private func fixtureURL(
+        for participant: BudgetParticipant,
+        scenario: String,
+        file: String,
+        filePath: StaticString = #filePath
+    ) throws -> URL {
+        let root = try Self.locateFixturesRoot(filePath: filePath)
+        return root
+            .appendingPathComponent("backends")
+            .appendingPathComponent(participant.fixtureDirectory)
+            .appendingPathComponent(scenario)
+            .appendingPathComponent(file)
+    }
+
+    private static func locateFixturesRoot(filePath: StaticString) throws -> URL {
+        var dir = URL(fileURLWithPath: "\(filePath)").deletingLastPathComponent()
+        while dir.path != "/" {
+            let candidate = dir.appendingPathComponent("Tests/Fixtures")
+            var isDir: ObjCBool = false
+            if FileManager.default.fileExists(atPath: candidate.path, isDirectory: &isDir), isDir.boolValue {
+                return candidate
+            }
+            dir.deleteLastPathComponent()
+        }
+        throw NSError(domain: "ContractSuiteRuntimeBudgetTest", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "Could not locate Tests/Fixtures/ from #filePath"
+        ])
+    }
+}
+#endif

--- a/Tests/ManifoldBackendsTests/LocalBackendContractTests.swift
+++ b/Tests/ManifoldBackendsTests/LocalBackendContractTests.swift
@@ -1,0 +1,245 @@
+import XCTest
+import ManifoldInference
+import ManifoldTestSupport
+
+/// Parameterised contract suite for local inference backends.
+///
+/// Phase 4 of the cross-backend unification plan. Parallel to
+/// ``InferenceBackendContractTests`` (which covers cloud backends via the
+/// ``CloudPayloadHandler`` + ``StreamFinalizer`` layer), this suite tests the
+/// ``InferenceBackend/generate(prompt:systemPrompt:config:)`` layer directly.
+///
+/// Local backends — MLX, Llama, Foundation — do not route through
+/// ``CloudPayloadHandler``; they implement `generate()` themselves. Their
+/// contract surface is the ``GenerationEvent`` stream that `generate()`
+/// produces. This suite verifies that stream against on-disk JSONL fixtures
+/// under `Tests/Fixtures/backends/<name>/streaming/simple-prompt/expected.jsonl`.
+///
+/// **Participants**: ``LocalParticipant`` enumerates all local backends. This
+/// PR registers only ``MockInferenceBackend`` as the first participant. MLX,
+/// Llama, and Foundation participants are added in follow-up PRs inside the
+/// `participants` computed property, gated by the appropriate trait or
+/// `#available` check.
+///
+/// **Always compiled**: the file has no outer `#if` guard because
+/// ``ManifoldTestSupport`` and ``ManifoldInference`` are always linked.
+/// Per-participant `#if`/`#available` guards live inside the `participants`
+/// property.
+final class LocalBackendContractTests: XCTestCase {
+
+    // MARK: - Participants
+
+    /// Static description of one local backend's contract surface.
+    ///
+    /// Unlike ``InferenceBackendContractTests.Participant``, there is no
+    /// `handler` or `finalizer` — local backends are exercised through the
+    /// `generate()` call directly. The ``makeBackend`` factory must return a
+    /// backend that has already been loaded (or is pre-loaded, like
+    /// ``MockInferenceBackend``).
+    ///
+    /// Marked `@unchecked Sendable` because the factory closure captures
+    /// backend construction state. All captured types (MockInferenceBackend,
+    /// stdlib values) are safe to construct on any thread.
+    struct LocalParticipant: @unchecked Sendable {
+        let label: String
+        let fixtureDirectory: String
+        let capabilities: BackendCapabilities
+        /// Factory that returns a backend ready to serve `generate()`.
+        /// For ``MockInferenceBackend``, `isModelLoaded` is set to `true` by
+        /// calling `loadModel()` inside this factory before returning.
+        let makeBackend: @Sendable () async -> any InferenceBackend
+    }
+
+    /// MockInferenceBackend participant.
+    ///
+    /// Scripted to yield `["Hello", " ", "world"]`, matching
+    /// `Tests/Fixtures/backends/mock/streaming/simple-prompt/expected.jsonl`.
+    private static let mockParticipant = LocalParticipant(
+        label: "mock",
+        fixtureDirectory: "mock",
+        capabilities: BackendCapabilities(
+            supportedParameters: [.temperature, .topP, .repeatPenalty],
+            maxContextTokens: 4096,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsToolCalling: false,
+            supportsStructuredOutput: false,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: false,
+            supportsStreaming: true,
+            isRemote: false
+        ),
+        makeBackend: {
+            let backend = MockInferenceBackend()
+            // MockInferenceBackend.loadModel only throws when shouldThrowOnLoad
+            // is set; the default factory never sets it, so this is safe to
+            // ignore via a do/catch rather than try?.
+            do {
+                try await backend.loadModel(
+                    from: URL(string: "unused:")!,
+                    plan: .testStub(effectiveContextSize: 512)
+                )
+            } catch {
+                // No-op: default MockInferenceBackend never throws on load.
+            }
+            backend.tokensToYield = ["Hello", " ", "world"]
+            return backend
+        }
+    )
+
+    /// All participants registered for this suite.
+    ///
+    /// Extend this list when adding MLX / Llama / Foundation participants.
+    /// Gate each additional entry with `#if MLX`, `#if Llama`, or
+    /// `#available(macOS 26, iOS 26, *)` as appropriate — the outer file has
+    /// no trait guard, so per-participant guards are the only safe seam.
+    private static var participants: [LocalParticipant] {
+        var list: [LocalParticipant] = []
+        list.append(mockParticipant)
+        // MLX participant: #if MLX — follow-up PR
+        // Llama participant: #if Llama — follow-up PR
+        // Foundation participant: #available(macOS 26, iOS 26, *) — follow-up PR
+        return list
+    }
+
+    // MARK: - Scenarios
+
+    /// Drives `backend.generate()` with a simple prompt, collects `.token`
+    /// events, and compares them against the on-disk `expected.jsonl` fixture.
+    ///
+    /// Runs for every participant whose capabilities claim
+    /// `supportsStreaming == true`. All registered participants in this PR
+    /// claim streaming.
+    func test_generate_simplePrompt_emitsTokensInOrder() async throws {
+        for p in Self.participants where p.capabilities.supportsStreaming {
+            let backend = await p.makeBackend()
+            let stream = try backend.generate(
+                prompt: "Hello",
+                systemPrompt: nil,
+                config: GenerationConfig()
+            )
+
+            var emitted: [GenerationEvent] = []
+            for try await event in stream.events {
+                emitted.append(event)
+            }
+
+            XCTAssertFalse(emitted.isEmpty, "[\(p.label)] expected at least one token event")
+            let fixture = try fixtureURL(for: p, scenario: "streaming/simple-prompt", file: "expected.jsonl")
+            XCTAssertEventsMatch(actual: emitted, fixtureURL: fixture)
+        }
+    }
+
+    /// After draining the stream completely, `isGenerating` must be `false`.
+    ///
+    /// The mock sets `isGenerating = false` at the end of its emission task,
+    /// before finishing the stream. This test drains the full stream and then
+    /// asserts the flag.
+    func test_generate_stopsGenerating_afterStreamEnd() async throws {
+        for p in Self.participants where p.capabilities.supportsStreaming {
+            let backend = await p.makeBackend()
+            let stream = try backend.generate(
+                prompt: "ping",
+                systemPrompt: nil,
+                config: GenerationConfig()
+            )
+
+            for try await _ in stream.events {}
+
+            XCTAssertFalse(backend.isGenerating, "[\(p.label)] isGenerating must be false after stream ends")
+        }
+    }
+
+    /// Cancelling the stream mid-way halts emission within a bounded deadline.
+    ///
+    /// Uses ``SlowMockBackend`` directly (not participant fixture path) because
+    /// this is a universal invariant about cooperative cancellation — it does
+    /// not depend on fixture content. The slow backend delays 5 seconds per
+    /// token; a 20-token stream would run for ~100s without cancellation.
+    /// We cancel early and verify fewer than 20 tokens were seen, proving the
+    /// stream stopped rather than exhausted.
+    func test_generate_cancelMidStream_haltsBelowBudget() async throws {
+        // A slow backend: 20 tokens at 5s per token = ~100s without cancellation.
+        let backend = SlowMockBackend(tokenCount: 20, delayMilliseconds: 5_000)
+
+        let stream = try backend.generate(
+            prompt: "count",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        // Collect tokens in a child Task whose return value is read after
+        // cancellation, avoiding the Swift 6 data-race on a mutable captured
+        // variable shared between the outer function and the Task closure.
+        let drainTask = Task<Int, Error> {
+            var count = 0
+            for try await event in stream.events {
+                if case .token = event {
+                    count += 1
+                }
+            }
+            return count
+        }
+
+        // Yield briefly so the stream emission task starts.
+        try await Task.sleep(for: .milliseconds(50))
+
+        // Cancel via the drain task rather than stopGeneration() because this
+        // tests cooperative cancellation (Task.isCancelled checks in the backend).
+        drainTask.cancel()
+
+        // Wait for cancellation to propagate. The 200ms window is generous
+        // given that SlowMockBackend checks Task.isCancelled before each token.
+        try await Task.sleep(for: .milliseconds(200))
+
+        // The task was cancelled; its result is either the count at
+        // cancellation time or a CancellationError. Both prove that not all
+        // 20 tokens were consumed.
+        let tokensSeen: Int
+        do {
+            tokensSeen = try await drainTask.value
+        } catch is CancellationError {
+            tokensSeen = 0
+        }
+
+        XCTAssertLessThan(
+            tokensSeen,
+            20,
+            "cancel mid-stream must halt emission before all 20 tokens are yielded"
+        )
+    }
+
+    // MARK: - Fixture loading
+
+    private func fixtureURL(
+        for participant: LocalParticipant,
+        scenario: String,
+        file: String,
+        filePath: StaticString = #filePath
+    ) throws -> URL {
+        let root = try Self.locateFixturesRoot(filePath: filePath)
+        return root
+            .appendingPathComponent("backends")
+            .appendingPathComponent(participant.fixtureDirectory)
+            .appendingPathComponent(scenario)
+            .appendingPathComponent(file)
+    }
+
+    /// Walks up from `#filePath` until a `Tests/Fixtures/` directory is found.
+    /// Mirrors the upwalk pattern used by ``InferenceBackendContractTests`` and
+    /// other audit tests so the suite works regardless of cwd.
+    private static func locateFixturesRoot(filePath: StaticString) throws -> URL {
+        var dir = URL(fileURLWithPath: "\(filePath)").deletingLastPathComponent()
+        while dir.path != "/" {
+            let candidate = dir.appendingPathComponent("Tests/Fixtures")
+            var isDir: ObjCBool = false
+            if FileManager.default.fileExists(atPath: candidate.path, isDirectory: &isDir), isDir.boolValue {
+                return candidate
+            }
+            dir.deleteLastPathComponent()
+        }
+        throw NSError(domain: "LocalBackendContractTests", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "Could not locate Tests/Fixtures/ from #filePath"
+        ])
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `LocalBackendContractTests.swift` as the Phase 4 parallel to `InferenceBackendContractTests` (which covers cloud backends via `CloudPayloadHandler`). The new suite tests the `InferenceBackend.generate()` layer directly — the surface that local backends (MLX, Llama, Foundation) implement.
- Registers `MockInferenceBackend` as the first participant with three capability-gated scenarios: token emission order (fixture comparison), `isGenerating` postcondition, and cooperative cancellation via `SlowMockBackend`.
- Adds `Tests/Fixtures/backends/mock/streaming/simple-prompt/expected.jsonl` with the `["Hello", " ", "world"]` scripted token stream.
- Adds `ContractSuiteRuntimeBudgetTest.swift` (gated `#if CloudSaaS || Ollama`) to assert cloud-tier fixture I/O completes in under 15 seconds.

## Design notes

- `LocalParticipant.makeBackend` is `async` — avoids synchronous semaphore hacks and matches OllamaBackendTests' async style.
- The `participants` computed property has gated comment stubs for MLX, Llama, and Foundation so follow-up PRs know exactly where to add.
- `ContractSuiteRuntimeBudgetTest` is a separate file so it can carry the `#if CloudSaaS || Ollama` guard without polluting the always-compiled `LocalBackendContractTests`.
- No `#if` outer guard on `LocalBackendContractTests` — `ManifoldTestSupport` and `ManifoldInference` are always linked.

## Backend checklist

- [x] MockInferenceBackend (always compiled)
- [ ] MLX — follow-up PR, gated `#if MLX`
- [ ] Llama — follow-up PR, gated `#if Llama`
- [ ] Foundation — follow-up PR, gated `#available(macOS 26, iOS 26, *)`

## Test plan

- [x] `swift build --build-tests --disable-default-traits` — Build complete
- [x] `swift test --filter LocalBackendContractTests --disable-default-traits` — 3/3 passed
- [x] `scripts/test.sh --filter ManifoldBackendsTests --disable-default-traits --skip-update` — 200 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)