### PR TITLE
test(backends): Phase 4 — add MLX participant to LocalBackendContractTests

### DIFF
--- a/Tests/Fixtures/backends/mlx/README.md
+++ b/Tests/Fixtures/backends/mlx/README.md
@@ -1,0 +1,33 @@
+# MLX backend fixtures
+
+MLX generates non-deterministic token streams because the Metal GPU scheduler
+does not guarantee bit-for-bit reproducibility across runs. Fixtures for the
+`LocalBackendContractTests` MLX participant are therefore captured via
+`scripts/record-fixture.sh` on a specific model against Apple Silicon hardware
+and committed to this directory.
+
+## Capturing fixtures
+
+Run the following with `RUN_SLOW_TESTS=1` set and an MLX model checked out
+at the path your test expects:
+
+```
+RUN_SLOW_TESTS=1 scripts/record-fixture.sh mlx streaming/simple-prompt
+```
+
+The script calls `generate(prompt: "Hello", systemPrompt: nil, config: GenerationConfig())`
+through the backend and serialises each `GenerationEvent` as a JSON line into
+`streaming/simple-prompt/expected.jsonl`. Example output (model-dependent):
+
+```jsonl
+{"event":"token","text":"Hello"}
+{"event":"token","text":"!"}
+{"event":"token","text":" How"}
+```
+
+## Nightly tier
+
+The MLX contract participant skips generation scenarios unless
+`RUN_SLOW_TESTS=1` is set in the environment. Per-PR CI does not set this
+variable, so these fixtures are only required in the nightly tier where a
+real model and Apple Silicon hardware are present.

--- a/Tests/ManifoldBackendsTests/Conformance/MLXBackendConformanceTests.swift
+++ b/Tests/ManifoldBackendsTests/Conformance/MLXBackendConformanceTests.swift
@@ -1,0 +1,84 @@
+#if MLX
+import XCTest
+import ManifoldInference
+import ManifoldTestSupport
+@testable import ManifoldBackends
+@testable import ManifoldMLX
+
+/// MLXBackend conformance against the universal backend contract.
+///
+/// Universal invariants (``assertUniversalBackendContract``) exercise state
+/// that does not require a real model load — `isModelLoaded == false` and
+/// `isGenerating == false` on init. These run in every trait build that
+/// includes `MLX`, without hardware or `RUN_SLOW_TESTS` gates.
+///
+/// Generation-level behavioural assertions (fixture replay, streaming
+/// cancellation) live in ``LocalBackendContractTests`` and are gated behind
+/// `RUN_SLOW_TESTS=1` so they only execute in the nightly tier where a real
+/// model and Apple Silicon hardware are present.
+@MainActor
+final class MLXBackendConformanceTests: XCTestCase,
+                                        BackendContractMixin {
+
+    let contractBackendName = "MLXBackend"
+
+    func makeContractBackend() -> MLXBackend {
+        MLXBackend()
+    }
+
+    override class func setUp() {
+        super.setUp()
+        BackendContractChecks.resetCapabilityClaims()
+    }
+
+    // MARK: - Universal invariants
+
+    // Sabotage-evidence: assertAllInvariants trips on invariant 1 if
+    // MLXBackend.init() incorrectly sets isModelLoaded=true.
+    func test_contract_allInvariants() {
+        assertUniversalBackendContract()
+    }
+
+    // MARK: - Per-capability claims
+
+    /// MLXBackend declares `supportsToolCalling = true`. Full behavioural
+    /// proof lives in ``MLXBackendGenerationTests`` against a real Qwen
+    /// model. This claim records the obligation in the meta-contract registry
+    /// until the parameterised fixture suite covers it under `RUN_SLOW_TESTS=1`.
+    func test_contract_supportsToolCalling_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: contractBackendName,
+            flag: "supportsToolCalling"
+        )
+    }
+
+    /// MLXBackend declares `supportsThinking = true`. Behavioural proof lives
+    /// in ``MLXBackendThinkingTests``; this claim records the meta-contract
+    /// obligation.
+    func test_contract_supportsThinking_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: contractBackendName,
+            flag: "supportsThinking"
+        )
+    }
+
+    /// MLXBackend declares `supportsTokenCounting = true`. Behavioural proof
+    /// is exercised in the E2E suite against a loaded model; this claim records
+    /// the meta-contract obligation.
+    func test_contract_supportsTokenCounting_claim() {
+        BackendContractChecks.claimWithoutBehaviouralAssertion(
+            backendName: contractBackendName,
+            flag: "supportsTokenCounting"
+        )
+    }
+
+    // MARK: - Meta-contract (MUST be last)
+
+    func test_z_contract_metaContract() {
+        BackendContractChecks.assertCapabilityMetaContract(
+            backendName: contractBackendName,
+            capabilities: MLXBackend().capabilities
+        )
+    }
+}
+#endif

--- a/Tests/ManifoldBackendsTests/LocalBackendContractTests.swift
+++ b/Tests/ManifoldBackendsTests/LocalBackendContractTests.swift
@@ -1,6 +1,9 @@
 import XCTest
 import ManifoldInference
 import ManifoldTestSupport
+#if MLX
+@testable import ManifoldMLX
+#endif
 
 /// Parameterised contract suite for local inference backends.
 ///
@@ -37,6 +40,11 @@ final class LocalBackendContractTests: XCTestCase {
     /// backend that has already been loaded (or is pre-loaded, like
     /// ``MockInferenceBackend``).
     ///
+    /// When `requiresSlowTests` is `true`, scenarios that call `generate()`
+    /// skip themselves unless the `RUN_SLOW_TESTS=1` environment variable is
+    /// set. This keeps the per-PR CI lane fast by deferring hardware-gated
+    /// generation assertions to the nightly tier.
+    ///
     /// Marked `@unchecked Sendable` because the factory closure captures
     /// backend construction state. All captured types (MockInferenceBackend,
     /// stdlib values) are safe to construct on any thread.
@@ -44,6 +52,10 @@ final class LocalBackendContractTests: XCTestCase {
         let label: String
         let fixtureDirectory: String
         let capabilities: BackendCapabilities
+        /// When `true`, generation scenarios skip unless `RUN_SLOW_TESTS=1`.
+        /// Set for local backends that require real hardware and a model file
+        /// (MLX, Llama). `false` for scripted mocks.
+        let requiresSlowTests: Bool
         /// Factory that returns a backend ready to serve `generate()`.
         /// For ``MockInferenceBackend``, `isModelLoaded` is set to `true` by
         /// calling `loadModel()` inside this factory before returning.
@@ -69,6 +81,7 @@ final class LocalBackendContractTests: XCTestCase {
             supportsStreaming: true,
             isRemote: false
         ),
+        requiresSlowTests: false,
         makeBackend: {
             let backend = MockInferenceBackend()
             // MockInferenceBackend.loadModel only throws when shouldThrowOnLoad
@@ -87,16 +100,68 @@ final class LocalBackendContractTests: XCTestCase {
         }
     )
 
+    // MARK: - MLX participant
+
+    #if MLX
+    /// MLX participant for the contract suite.
+    ///
+    /// The `makeBackend` factory creates an `MLXBackend` in its initial
+    /// unconfigured state — no real model is loaded. This is intentional:
+    /// the `isGenerating == false on init` invariant and the
+    /// `capabilities` snapshot checks do not require a model. Scenarios
+    /// that call `generate()` are gated behind `RUN_SLOW_TESTS=1` so they
+    /// only run in the nightly tier where a real model is present.
+    ///
+    /// `MLXBackend.capabilities` before any `loadModel` call falls back to
+    /// the 8192-token conservative context default, which is reflected in the
+    /// participant's `capabilities` snapshot below.
+    private static let mlxParticipant = LocalParticipant(
+        label: "mlx.backend",
+        fixtureDirectory: "mlx",
+        capabilities: BackendCapabilities(
+            supportedParameters: [
+                .temperature, .topP, .topK, .repeatPenalty,
+                .minP, .repetitionPenalty, .presencePenalty, .frequencyPenalty,
+            ],
+            maxContextTokens: 8192,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsToolCalling: true,
+            supportsStructuredOutput: false,
+            supportsNativeJSONMode: false,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: true,
+            memoryStrategy: .resident,
+            maxOutputTokens: 4096,
+            supportsStreaming: true,
+            isRemote: false,
+            supportsKVCachePersistence: false,
+            supportsThinking: true,
+            supportsVision: false,
+            sharesMLXProcessResources: true
+        ),
+        requiresSlowTests: true,
+        makeBackend: {
+            // No model loaded — factory returns the backend in its zero state.
+            // Tests that exercise generate() must gate themselves behind
+            // RUN_SLOW_TESTS=1 and Metal availability (see the scenario methods).
+            MLXBackend()
+        }
+    )
+    #endif
+
     /// All participants registered for this suite.
     ///
-    /// Extend this list when adding MLX / Llama / Foundation participants.
-    /// Gate each additional entry with `#if MLX`, `#if Llama`, or
+    /// Extend this list when adding Llama / Foundation participants.
+    /// Gate each additional entry with `#if Llama`, or
     /// `#available(macOS 26, iOS 26, *)` as appropriate — the outer file has
     /// no trait guard, so per-participant guards are the only safe seam.
     private static var participants: [LocalParticipant] {
         var list: [LocalParticipant] = []
         list.append(mockParticipant)
-        // MLX participant: #if MLX — follow-up PR
+        #if MLX
+        list.append(mlxParticipant)
+        #endif
         // Llama participant: #if Llama — follow-up PR
         // Foundation participant: #available(macOS 26, iOS 26, *) — follow-up PR
         return list
@@ -108,10 +173,17 @@ final class LocalBackendContractTests: XCTestCase {
     /// events, and compares them against the on-disk `expected.jsonl` fixture.
     ///
     /// Runs for every participant whose capabilities claim
-    /// `supportsStreaming == true`. All registered participants in this PR
-    /// claim streaming.
+    /// `supportsStreaming == true`. Hardware-gated participants (MLX, Llama)
+    /// skip when `RUN_SLOW_TESTS != 1` or Metal is unavailable.
     func test_generate_simplePrompt_emitsTokensInOrder() async throws {
         for p in Self.participants where p.capabilities.supportsStreaming {
+            if p.requiresSlowTests {
+                try XCTSkipIf(
+                    ProcessInfo.processInfo.environment["RUN_SLOW_TESTS"] != "1",
+                    "[\(p.label)] contract scenarios require a real model — set RUN_SLOW_TESTS=1 and ensure a model is present"
+                )
+                try XCTSkipIf(isSimulator(), "[\(p.label)] Metal unavailable in simulator")
+            }
             let backend = await p.makeBackend()
             let stream = try backend.generate(
                 prompt: "Hello",
@@ -135,8 +207,19 @@ final class LocalBackendContractTests: XCTestCase {
     /// The mock sets `isGenerating = false` at the end of its emission task,
     /// before finishing the stream. This test drains the full stream and then
     /// asserts the flag.
+    ///
+    /// Hardware-gated participants (MLX, Llama) skip when `RUN_SLOW_TESTS != 1`
+    /// or Metal is unavailable, because they require a loaded model to call
+    /// `generate()` successfully.
     func test_generate_stopsGenerating_afterStreamEnd() async throws {
         for p in Self.participants where p.capabilities.supportsStreaming {
+            if p.requiresSlowTests {
+                try XCTSkipIf(
+                    ProcessInfo.processInfo.environment["RUN_SLOW_TESTS"] != "1",
+                    "[\(p.label)] contract scenarios require a real model — set RUN_SLOW_TESTS=1 and ensure a model is present"
+                )
+                try XCTSkipIf(isSimulator(), "[\(p.label)] Metal unavailable in simulator")
+            }
             let backend = await p.makeBackend()
             let stream = try backend.generate(
                 prompt: "ping",
@@ -207,6 +290,19 @@ final class LocalBackendContractTests: XCTestCase {
             20,
             "cancel mid-stream must halt emission before all 20 tokens are yielded"
         )
+    }
+
+    // MARK: - Hardware helpers
+
+    /// Returns `true` when running inside the iOS/macOS Simulator, where Metal
+    /// (and therefore MLX / Llama) is unavailable. Matches the check used by
+    /// ``AllBackendsAcceptPlanTests`` and ``LocalBackendRealDriverCoverageTest``.
+    private func isSimulator() -> Bool {
+        #if targetEnvironment(simulator)
+        return true
+        #else
+        return false
+        #endif
     }
 
     // MARK: - Fixture loading


### PR DESCRIPTION
## Summary

- Extends the Phase 4 `LocalBackendContractTests` scaffold (PR #1285) with an MLX participant, adding `mlx.backend` to the parameterised contract suite
- Adds `MLXBackendConformanceTests.swift` (`#if MLX` gated) that runs universal invariants (`isModelLoaded/isGenerating == false on init`, `generate-before-load throws`) without requiring hardware
- Gates `generate()` scenarios behind `RUN_SLOW_TESTS=1` and a simulator skip, deferring fixture replay to the nightly tier
- Adds fixture stubs at `Tests/Fixtures/backends/mlx/streaming/simple-prompt/.gitkeep` with a `README.md` explaining the capture workflow

## Changes

- **`LocalBackendContractTests.swift`**: adds `requiresSlowTests` to `LocalParticipant`, `mlxParticipant` static, per-participant skip guards in two scenario methods, and `isSimulator()` helper
- **`MLXBackendConformanceTests.swift`**: new conformance file — universal invariants + three `claimWithoutBehaviouralAssertion` calls for `supportsToolCalling`, `supportsThinking`, `supportsTokenCounting` + meta-contract assertion
- **`Tests/Fixtures/backends/mlx/`**: `README.md` + `.gitkeep` placeholder

## Test plan

- [ ] `swift build --build-tests --disable-default-traits` — passes (45s)
- [ ] `scripts/test.sh --filter ManifoldBackendsTests --disable-default-traits --skip-update` — 198 passed, 2 skipped (pre-existing), 0 failed
- [ ] With `--traits MLX`: `MLXBackendConformanceTests` universal invariants run; generation scenarios skip unless `RUN_SLOW_TESTS=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)