### PR TITLE
refactor(ui): ChatSessionManager phase 1 cleanup — add missing contract tests

### DIFF
--- a/Tests/ManifoldUITests/ChatSessionManagerTests.swift
+++ b/Tests/ManifoldUITests/ChatSessionManagerTests.swift
@@ -243,4 +243,67 @@ final class ChatSessionManagerTests: XCTestCase {
         XCTAssertNil(m)
         XCTAssertNil(e)
     }
+
+    // MARK: - nil-closure safety
+
+    func test_teardown_nilClosures_doesNotCrash() async {
+        // A manager with no closures wired must not crash during teardown —
+        // optional chaining on each closure is the contract.
+        let mgr = ChatSessionManager()
+        _ = await mgr.teardown(
+            sessionID: UUID(),
+            promptTemplate: .chatML,
+            selectionState: SessionController.SessionSelectionState(
+                selectedModelID: nil, selectedEndpointID: nil
+            )
+        )
+        // Reaching this line is the assertion — no crash occurred.
+    }
+
+    func test_applySelection_whenBothClosuresNil_doesNotCrash() {
+        // applySelection must not crash when neither applyModelSelection nor
+        // applyEndpointSelection has been wired — closures are optional.
+        let mgr = ChatSessionManager()
+        mgr.applySelection(ChatSessionManager.TeardownResult(
+            resolvedModel: nil, resolvedEndpoint: nil
+        ))
+        // Reaching this line is the assertion — no crash occurred.
+    }
+
+    // MARK: - closure forwarding
+
+    func test_teardown_promptTemplateForwardedToApplyPromptTemplateClosure() async {
+        let mgr = silentMgr()
+        var receivedTemplate: PromptTemplate?
+        mgr.applyPromptTemplate = { receivedTemplate = $0 }
+
+        _ = await mgr.teardown(
+            sessionID: UUID(),
+            promptTemplate: .chatML,
+            selectionState: SessionController.SessionSelectionState(
+                selectedModelID: nil, selectedEndpointID: nil
+            )
+        )
+
+        XCTAssertEqual(receivedTemplate, .chatML,
+            "teardown must forward the supplied promptTemplate to applyPromptTemplate")
+    }
+
+    func test_teardown_sessionIDForwardedToDiscardRequestsClosure() async {
+        let mgr = silentMgr()
+        let expectedID = UUID()
+        var receivedID: UUID?
+        mgr.discardRequests = { receivedID = $0 }
+
+        _ = await mgr.teardown(
+            sessionID: expectedID,
+            promptTemplate: .chatML,
+            selectionState: SessionController.SessionSelectionState(
+                selectedModelID: nil, selectedEndpointID: nil
+            )
+        )
+
+        XCTAssertEqual(receivedID, expectedID,
+            "teardown must forward the supplied sessionID to discardRequests")
+    }
 }


### PR DESCRIPTION
Closes #1221 (phase 1).

## Summary

`ChatSessionManager` was already extracted from `ChatViewModel` and lives at `Sources/ManifoldUI/ViewModels/ChatSessionManager.swift`. The structural extraction was complete, but the existing test suite in `Tests/ManifoldUITests/ChatSessionManagerTests.swift` was missing four contract tests that formally close phase 1.

## New tests added

- `test_teardown_nilClosures_doesNotCrash` — confirms optional-chaining on every closure is safe when none are wired
- `test_applySelection_whenBothClosuresNil_doesNotCrash` — same nil-safety check for the `applySelection` path
- `test_teardown_promptTemplateForwardedToApplyPromptTemplateClosure` — asserts `teardown` forwards the exact `PromptTemplate` value to `applyPromptTemplate`
- `test_teardown_sessionIDForwardedToDiscardRequestsClosure` — asserts `teardown` forwards the exact `sessionID` to `discardRequests`

All 14 tests in the suite pass (`swift test --filter ChatSessionManagerTests --disable-default-traits`).

No production code changes — the class-level doc comment was already clean and declarative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)