### PR TITLE
refactor(ui): tidy ChatViewModel decomposition follow-ups

### DIFF
--- a/Sources/ManifoldUI/ViewModels/ChatGenerationCoordinator.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatGenerationCoordinator.swift
@@ -35,7 +35,7 @@ final class ChatGenerationCoordinator {
     var onSetLastTurnState: (ChatViewModel.TurnState) -> Void = { _ in }
 
     /// Writes `ChatViewModel.backgroundTaskError`.
-    var onSetBackgroundTaskError: ((Error)?) -> Void = { _ in }
+    var onSetBackgroundTaskError: (Error?) -> Void = { _ in }
 
     /// Writes `ChatViewModel.messageIDsWithStreamingThinking`.
     var onSetMessageIDsWithStreamingThinking: (Set<UUID>) -> Void = { _ in }
@@ -198,6 +198,9 @@ final class ChatGenerationCoordinator {
         // task gets an immediate scheduling opportunity on the same actor.
         await Task.yield()
         while activeConversationStreamHandle != nil {
+            // TODO: replace busy-poll with a continuation-based seam signaled
+            // from the `streamFinished` handler. Safe today thanks to the 2s
+            // timeout in the awaitStreamCompletion test.
             // Sleep rather than yield so concurrent callers don't starve the
             // runtime event drain task that clears the handle.
             try? await Task.sleep(for: .milliseconds(1))
@@ -268,14 +271,13 @@ final class ChatGenerationCoordinator {
                 record.status = .sent
             }
             let messages = currentMessages()
-            if let idx = messages.firstIndex(where: { $0.id == record.id }) {
+            if messages.contains(where: { $0.id == record.id }) {
                 _ = mutateMessage(record.id) { msg in
                     msg.timestamp = record.timestamp
                     msg.promptTokens = record.promptTokens
                     msg.completionTokens = record.completionTokens
                     msg.status = record.status
                 }
-                _ = idx // suppress unused-variable warning
             } else {
                 appendMessage(record)
             }

--- a/Sources/ManifoldUI/ViewModels/ChatViewModel+RuntimeAdapter.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel+RuntimeAdapter.swift
@@ -38,12 +38,3 @@ extension ChatViewModel {
         generationCoordinator.runPostGenerationTasks(message: message, session: session)
     }
 }
-
-private extension ChatViewModel {
-    func markMostRecentUserMessageFailed() {
-        guard let idx = messages.lastIndex(where: { $0.role == .user && $0.sessionID == activeSessionID }) else {
-            return
-        }
-        messages[idx].status = .failed
-    }
-}

--- a/Tests/ManifoldUITests/ChatGenerationCoordinatorTests.swift
+++ b/Tests/ManifoldUITests/ChatGenerationCoordinatorTests.swift
@@ -66,14 +66,11 @@ final class ChatGenerationCoordinatorTests: XCTestCase {
 
     func test_transitionPhase_rejectIllegalTransition_doesNotCallCallback() {
         let coord = makeSilentCoordinator()
-        // Machine starts at .idle; streaming → idle is fine but idle → streaming
-        // is not legal (must go through waitingForFirstToken first).
-        // Actually idle → streaming is a state machine rejected path.
+        // Machine starts at .idle; idle → streaming is illegal (must go
+        // through .waitingForFirstToken first), so the callback must not fire.
         var callbackCount = 0
         coord.onTransitionPhase = { _ in callbackCount += 1; return true }
 
-        // streaming → idle would be valid but streaming is not the current state.
-        // idle → streaming is illegal per the state machine.
         coord.transitionPhase(to: .streaming)
 
         XCTAssertEqual(callbackCount, 0, "Illegal transition must not invoke onTransitionPhase")

--- a/Tests/ManifoldUITests/ChatSessionManagerTests.swift
+++ b/Tests/ManifoldUITests/ChatSessionManagerTests.swift
@@ -258,6 +258,7 @@ final class ChatSessionManagerTests: XCTestCase {
             )
         )
         // Reaching this line is the assertion — no crash occurred.
+        XCTAssertTrue(true, "teardown completed without crashing")
     }
 
     func test_applySelection_whenBothClosuresNil_doesNotCrash() {
@@ -268,6 +269,7 @@ final class ChatSessionManagerTests: XCTestCase {
             resolvedModel: nil, resolvedEndpoint: nil
         ))
         // Reaching this line is the assertion — no crash occurred.
+        XCTAssertTrue(true, "applySelection completed without crashing")
     }
 
     // MARK: - closure forwarding


### PR DESCRIPTION
## Summary

Pure cleanup PR addressing review nits from the just-merged #1288 (ChatSessionManager phase 1) and #1289 (ChatGenerationCoordinator extraction). No behavior changes.

### From #1289 review
- Delete dead `markMostRecentUserMessageFailed` on `ChatViewModel` — the caller moved into `ChatGenerationCoordinator` (which has its own private copy). Grep confirmed zero remaining callers on the ChatViewModel side.
- Add a `TODO` above the `awaitStreamCompletion` busy-poll noting a continuation-based seam (signaled from `streamFinished`) would be cleaner. The 2s timeout in the related test keeps the current sleep safe.
- Fix typo `((Error)?) -> Void` → `(Error?) -> Void` on `onSetBackgroundTaskError`. Same semantics, reads correctly.
- Drop the `_ = idx // suppress unused-variable warning` smell in `handle(.messageInserted)` — `idx` was genuinely unused, switched to `messages.contains(where:)`.
- Reword the self-contradictory comment in `test_transitionPhase_rejectIllegalTransition_doesNotCallCallback` to match the assertion (idle → streaming is illegal because it must transit `.waitingForFirstToken`).

### From #1288 review
- Add explicit `XCTAssertTrue(true, "did not crash")` to the two `ChatSessionManagerTests` whose contract was "reaching this line is the assertion", so a future linter that flags assertion-free tests doesn't strip them.

### Out of scope (intentionally not in this PR)
- `activityPhase.didSet` re-allocation question from #1289 review — behavior, not a nit.
- `InMemoryMessageStoreForTests` `@unchecked Sendable` — separate concern.

## Test plan
- [x] `swift build --build-tests --disable-default-traits`
- [x] `scripts/test.sh --filter ManifoldUITests --disable-default-traits --skip-update` — 521 passed, 0 failures. Pre-existing `ConsumerRuntimeHarnessTests` crash is unrelated (does not reference any changed file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)