### PR TITLE
feat: add isBuiltIn accessor on ModelInfo

### DIFF
--- a/Sources/ManifoldInference/Models/ModelInfo.swift
+++ b/Sources/ManifoldInference/Models/ModelInfo.swift
@@ -307,6 +307,21 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
     }
 }
 
+// MARK: - Ownership
+
+public extension ModelInfo {
+    /// `true` when this model is provided by the OS / framework and cannot be
+    /// deleted by the user. Consumer UI hides destructive affordances and
+    /// excludes built-ins from storage accounting.
+    ///
+    /// Currently equivalent to `modelType == .foundation`, but the semantic
+    /// ("the user does not own this file") is the contract consumers should
+    /// branch on, not the format.
+    var isBuiltIn: Bool {
+        modelType == .foundation
+    }
+}
+
 // MARK: - HuggingFace Factory
 
 extension ModelInfo {

--- a/Tests/ManifoldInferenceTests/ModelInfoTests.swift
+++ b/Tests/ManifoldInferenceTests/ModelInfoTests.swift
@@ -326,4 +326,30 @@ final class ModelInfoTests: XCTestCase {
 
         XCTAssertEqual(model?.name, "phi 3 mini 4bit")
     }
+
+    // MARK: - isBuiltIn
+
+    func test_isBuiltIn_trueForBuiltInFoundation() {
+        XCTAssertTrue(ModelInfo.builtInFoundation.isBuiltIn)
+    }
+
+    func test_isBuiltIn_falseForGGUFModel() throws {
+        let fileURL = tempDirectory.appendingPathComponent("user-model.gguf")
+        try writeGGUFFixture(at: fileURL, totalSize: 256)
+
+        let model = try XCTUnwrap(ModelInfo(ggufURL: fileURL))
+
+        XCTAssertFalse(model.isBuiltIn)
+    }
+
+    func test_isBuiltIn_falseForMLXModel() throws {
+        let mlxDir = tempDirectory.appendingPathComponent("user-mlx-model")
+        try FileManager.default.createDirectory(at: mlxDir, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: mlxDir.appendingPathComponent("config.json"))
+        try Data(repeating: 0x00, count: 1).write(to: mlxDir.appendingPathComponent("model.safetensors"))
+
+        let model = try XCTUnwrap(ModelInfo(mlxDirectory: mlxDir))
+
+        XCTAssertFalse(model.isBuiltIn)
+    }
 }


### PR DESCRIPTION
Closes #1297

## Summary

Adds a public computed property `isBuiltIn: Bool` on `ModelInfo` so consumer UI can branch on the ownership semantic ("the user does not own this file") instead of the underlying format. This lets consumers hide destructive affordances (delete buttons, etc.) and exclude built-ins from storage accounting without hard-coding `modelType == .foundation` at every call site.

## API

```swift
public extension ModelInfo {
    /// `true` when this model is provided by the OS / framework and cannot be
    /// deleted by the user. Consumer UI hides destructive affordances and
    /// excludes built-ins from storage accounting.
    ///
    /// Currently equivalent to `modelType == .foundation`, but the semantic
    /// ("the user does not own this file") is the contract consumers should
    /// branch on, not the format.
    var isBuiltIn: Bool { get }
}
```

Implementation is `modelType == .foundation` for now. The doc comment makes the contract explicit so future built-in sources (e.g. a system-provided MLX bundle) can be folded into the predicate without breaking callers.

## Backwards compatibility

Purely additive — new computed property on an existing public struct. No existing call sites or stored properties change.

## Tests

`Tests/ManifoldInferenceTests/ModelInfoTests.swift`:
- `test_isBuiltIn_trueForBuiltInFoundation` — asserts `ModelInfo.builtInFoundation.isBuiltIn == true`
- `test_isBuiltIn_falseForGGUFModel` — asserts a `.gguf` instance reports `false`
- `test_isBuiltIn_falseForMLXModel` — asserts an MLX-directory instance reports `false`

Sabotage check passed: flipping the predicate to `!=` failed all three tests; restoring the implementation made them green.

## Test plan
- [x] `swift build --build-tests --disable-default-traits`
- [x] `scripts/test.sh --filter ManifoldInferenceTests --disable-default-traits --skip-update` — 1506 passed, 0 failed, 5 XCTSkip
- [x] Sabotage check on the predicate