### PR TITLE
feat: add ModelLoadPlan.estimate for pre-download fit verdict

### DIFF
--- a/Sources/ManifoldInference/Services/ModelLoadPlan.swift
+++ b/Sources/ManifoldInference/Services/ModelLoadPlan.swift
@@ -392,8 +392,9 @@ public struct ModelLoadPlan: Sendable {
     ///   `.foundation` → `.external` via ``systemManaged(requestedContextSize:)``.
     ///
     /// The returned `ModelLoadPlan` carries the same `Outcome.verdict` / `reasons` shape as the
-    /// post-load path; UI badges can render `.allow` / `.clampContext` (synonymous with `.allow`
-    /// when `reasons` contains a clamp) / `.deny` directly off `verdict`.
+    /// post-load path; UI badges can render `.allow` / `.warn` / `.deny` directly off `verdict`,
+    /// and inspect `reasons` for clamp annotations (`.memoryCeilingReached`,
+    /// `.absoluteCeilingReached`) which can co-occur with `.allow`.
     public static func estimate(
         for model: DownloadableModel,
         requestedContextSize: Int,

--- a/Sources/ManifoldInference/Services/ModelLoadPlan.swift
+++ b/Sources/ManifoldInference/Services/ModelLoadPlan.swift
@@ -371,6 +371,77 @@ public struct ModelLoadPlan: Sendable {
         }
     }
 
+    /// Pre-flight fit verdict for a `DownloadableModel` (browse-time, pre-download).
+    ///
+    /// Unlike ``compute(for:requestedContextSize:environment:absoluteContextCeiling:headroomFraction:)``
+    /// which consumes an on-disk ``ModelInfo`` (with GGUF metadata, detected context length,
+    /// arch-derived KV/token), this overload only has the manifest-level fields a HuggingFace
+    /// listing exposes: ``DownloadableModel/sizeBytes``, ``DownloadableModel/modelType``, and a
+    /// quantization tag extracted from the filename. That means:
+    ///
+    /// - The trained-context ceiling is unknown — only the absolute ceiling and memory ceiling
+    ///   apply, so the clamp result can be *larger* than the post-download `compute(...)` would
+    ///   produce (the post-load path will tighten it once GGUF metadata is read).
+    /// - KV-bytes-per-token uses the conservative legacy 8 KB/token fallback
+    ///   (``GGUFKVCacheEstimator/legacyFallbackBytesPerToken``). Real architectures with grouped-
+    ///   query attention or small head dimensions are typically *cheaper* per token, so the
+    ///   estimate is at least as conservative as the post-load path for the same `(sizeBytes,
+    ///   strategy, available)` triple.
+    /// - `MemoryStrategy` is derived from ``DownloadableModel/modelType`` the same way the
+    ///   ``ModelInfo``-based overload does: `.gguf` → `.mappable`, `.mlx` → `.resident`,
+    ///   `.foundation` → `.external` via ``systemManaged(requestedContextSize:)``.
+    ///
+    /// The returned `ModelLoadPlan` carries the same `Outcome.verdict` / `reasons` shape as the
+    /// post-load path; UI badges can render `.allow` / `.clampContext` (synonymous with `.allow`
+    /// when `reasons` contains a clamp) / `.deny` directly off `verdict`.
+    public static func estimate(
+        for model: DownloadableModel,
+        requestedContextSize: Int,
+        environment: Environment = .current,
+        absoluteContextCeiling: Int = 128_000,
+        headroomFraction: Double = 0.40
+    ) -> ModelLoadPlan {
+        switch model.modelType {
+        case .foundation:
+            return systemManaged(requestedContextSize: requestedContextSize)
+        case .mlx, .gguf:
+            break
+        }
+
+        let strategy: MemoryStrategy = (model.modelType == .mlx) ? .resident : .mappable
+
+        // Manifests don't expose architecture or attention shape, so we cannot run
+        // `GGUFKVCacheEstimator.estimateBytesPerToken(...)`. Fall back to the legacy
+        // 8 KB/token estimate — conservative vs. real GQA architectures, which keeps
+        // pre-download verdicts at least as strict as the post-load `compute(...)`.
+        let kvBytesPerToken = GGUFKVCacheEstimator.legacyFallbackBytesPerToken
+
+        #if os(iOS) || os(visionOS)
+        // Mirror the iOS jetsam overhead reserve from the ModelInfo-based overload.
+        let appOverhead: UInt64 = environment.physicalMemoryBytes < 12_884_901_888
+            ? 838_860_800   // 800 MiB
+            : 0
+        #else
+        let appOverhead: UInt64 = 0
+        #endif
+
+        let inputs = Inputs(
+            modelFileSize: model.sizeBytes,
+            memoryStrategy: strategy,
+            requestedContextSize: requestedContextSize,
+            // Manifest path: no detected trained-context length. Post-load `compute(...)`
+            // tightens this once the GGUF header is read.
+            trainedContextLength: nil,
+            kvBytesPerToken: kvBytesPerToken,
+            availableMemoryBytes: environment.availableMemoryBytes(),
+            physicalMemoryBytes: environment.physicalMemoryBytes,
+            absoluteContextCeiling: absoluteContextCeiling,
+            headroomFraction: headroomFraction,
+            appOverheadBytes: appOverhead
+        )
+        return compute(inputs: inputs)
+    }
+
     /// For system-managed backends (Apple Foundation Models) where memory is owned
     /// by the OS and there's nothing to estimate. Always allows with stub fields.
     public static func systemManaged(requestedContextSize: Int) -> ModelLoadPlan {

--- a/Tests/ManifoldInferenceTests/ModelLoadPlanTests.swift
+++ b/Tests/ManifoldInferenceTests/ModelLoadPlanTests.swift
@@ -1009,6 +1009,225 @@ final class ModelLoadPlanTests: XCTestCase {
         XCTAssertEqual(inferred.inputs, explicit.inputs)
         XCTAssertEqual(inferred.inputs.memoryStrategy, .resident)
     }
+
+    // MARK: - estimate(for: DownloadableModel) — pre-download fit verdict
+
+    /// Helper: build a `DownloadableModel` for fit tests without going through the
+    /// curated catalogue. Filename is `.gguf` by default so quantization extraction
+    /// has a real input shape, even though `estimate(...)` ignores it.
+    private func makeDownloadable(
+        sizeBytes: UInt64,
+        modelType: ModelType = .gguf,
+        fileName: String = "test-Q4_K_M.gguf"
+    ) -> DownloadableModel {
+        DownloadableModel(
+            repoID: "test/repo",
+            fileName: fileName,
+            displayName: "Test Model",
+            modelType: modelType,
+            sizeBytes: sizeBytes
+        )
+    }
+
+    /// Small GGUF model on a 16 GB device with ample free memory → `.allow`, no clamp.
+    func test_estimate_smallModel_amplyMemory_allows() {
+        let oneGBLocal = oneGB
+        let model = makeDownloadable(sizeBytes: 2 * oneGBLocal)
+        let twelveGB = 12 * oneGBLocal
+        let env = ModelLoadPlan.Environment(
+            availableMemoryBytes: { twelveGB },
+            physicalMemoryBytes: 16 * oneGBLocal
+        )
+        let plan = ModelLoadPlan.estimate(
+            for: model,
+            requestedContextSize: 4096,
+            environment: env
+        )
+
+        XCTAssertEqual(plan.verdict, .allow)
+        XCTAssertEqual(plan.effectiveContextSize, 4096, "Ample memory must not clamp the requested context.")
+        // Strategy must come from the format → .gguf maps to .mappable.
+        XCTAssertEqual(plan.inputs.memoryStrategy, .mappable)
+        // No clamp reasons expected when nothing was tightened.
+        XCTAssertFalse(plan.reasons.contains { reason in
+            if case .memoryCeilingReached = reason { return true }
+            if case .absoluteCeilingReached = reason { return true }
+            return false
+        })
+    }
+
+    /// Tight memory → memory-derived ceiling tightens context below the request.
+    /// We pick numbers where the memory ceiling is well below 4096 tokens so the
+    /// clamp is visible and the verdict can still come out `.allow` (resident is small).
+    func test_estimate_clampsContext_whenMemoryTight() {
+        // 4 GB mappable file → residentBudget = min(1 GB, 1 GB) = 1 GB.
+        // available = 2 GB, headroom 0.40 → reserveAfterHeadroom = 1.2 GB.
+        // kvBudget = 1.2 GB − 1 GB = 0.2 GB; / 8 KB = ~26214 tokens (still > 4096).
+        // Force a tighter clamp by squeezing available further.
+        let model = makeDownloadable(sizeBytes: 4 * oneGB)
+        let available: UInt64 = 1_800_000_000  // 1.8 GB
+        let env = ModelLoadPlan.Environment(
+            availableMemoryBytes: { available },
+            physicalMemoryBytes: 16 * oneGB
+        )
+        let plan = ModelLoadPlan.estimate(
+            for: model,
+            requestedContextSize: 8192,
+            environment: env
+        )
+
+        XCTAssertLessThan(plan.effectiveContextSize, 8192,
+                          "Tight memory must clamp effective context below the request.")
+        XCTAssertTrue(plan.reasons.contains { reason in
+            if case .memoryCeilingReached = reason { return true }
+            return false
+        }, "A memory clamp must produce a .memoryCeilingReached reason. Got: \(plan.reasons)")
+    }
+
+    /// Oversized model (40 GB on 8 GB available) → `.deny` with an insufficient-resident
+    /// reason from the impossible-fit guard.
+    func test_estimate_oversized_denies_withMemoryReason() {
+        let oneGBLocal = oneGB
+        let model = makeDownloadable(sizeBytes: 40 * oneGBLocal)
+        let eightGB = 8 * oneGBLocal
+        let env = ModelLoadPlan.Environment(
+            availableMemoryBytes: { eightGB },
+            physicalMemoryBytes: 16 * oneGBLocal
+        )
+        let plan = ModelLoadPlan.estimate(
+            for: model,
+            requestedContextSize: 4096,
+            environment: env
+        )
+
+        XCTAssertEqual(plan.verdict, .deny)
+        XCTAssertTrue(plan.reasons.contains { reason in
+            if case .insufficientResident = reason { return true }
+            if case .insufficientKVCache = reason { return true }
+            return false
+        }, "Oversized denies must surface a memory-headroom reason. Got: \(plan.reasons)")
+    }
+
+    /// KV-cache fallback path: manifest has no arch hints, so estimate must use the
+    /// legacy 8 KB/token fallback. Verify by computing the expected outcome with that
+    /// exact constant and comparing verdict + total bytes.
+    func test_estimate_kvFallback_usesLegacy8KBPerToken() {
+        let model = makeDownloadable(sizeBytes: 4 * oneGB)
+        let available: UInt64 = 8 * oneGB
+        let env = ModelLoadPlan.Environment(
+            availableMemoryBytes: { available },
+            physicalMemoryBytes: 16 * oneGB
+        )
+        let plan = ModelLoadPlan.estimate(
+            for: model,
+            requestedContextSize: 4096,
+            environment: env
+        )
+
+        let expected = expectedOutcome(
+            modelFileSize: 4 * oneGB,
+            strategy: .mappable,
+            requested: 4096,
+            trained: nil,
+            kvBytesPerToken: 8_192,  // legacy fallback — what estimate() must use
+            available: available
+        )
+
+        XCTAssertEqual(plan.inputs.kvBytesPerToken, 8_192,
+                       "estimate() must populate kvBytesPerToken with the legacy 8 KB fallback for manifest-only inputs.")
+        XCTAssertEqual(plan.verdict, expected.verdict)
+        XCTAssertEqual(plan.effectiveContextSize, expected.effective)
+        XCTAssertEqual(plan.outcome.totalEstimatedBytes, expected.total)
+    }
+
+    /// `.foundation` short-circuit: estimate() returns the systemManaged stub regardless
+    /// of sizeBytes / environment.
+    func test_estimate_foundation_returnsSystemManaged() {
+        let model = makeDownloadable(sizeBytes: 0, modelType: .foundation, fileName: "apple-foundation")
+        let env = ModelLoadPlan.Environment(
+            availableMemoryBytes: { 0 },
+            physicalMemoryBytes: 0
+        )
+        let plan = ModelLoadPlan.estimate(for: model, requestedContextSize: 4096, environment: env)
+        let expected = ModelLoadPlan.systemManaged(requestedContextSize: 4096)
+
+        XCTAssertEqual(plan.verdict, .allow)
+        XCTAssertEqual(plan.outcome, expected.outcome)
+        XCTAssertEqual(plan.inputs, expected.inputs)
+    }
+
+    /// `.mlx` modelType must pick the `.resident` strategy (mirrors the ModelInfo overload).
+    func test_estimate_mlx_usesResidentStrategy() {
+        let oneGBLocal = oneGB
+        let model = makeDownloadable(sizeBytes: 2 * oneGBLocal, modelType: .mlx, fileName: "mlx-community/Test-4bit")
+        let twelveGB = 12 * oneGBLocal
+        let env = ModelLoadPlan.Environment(
+            availableMemoryBytes: { twelveGB },
+            physicalMemoryBytes: 16 * oneGBLocal
+        )
+        let plan = ModelLoadPlan.estimate(for: model, requestedContextSize: 4096, environment: env)
+
+        XCTAssertEqual(plan.inputs.memoryStrategy, .resident)
+    }
+
+    /// Verdict-parity sanity: a `DownloadableModel` and a same-sized GGUF `ModelInfo`
+    /// (no detected KV/token, no trained-context length) must agree on the allow/deny
+    /// verdict. `estimate(...)` may differ on the clamped context value because it
+    /// lacks the on-disk trained-context length, but the top-level fit decision must
+    /// match for inputs that don't depend on that field.
+    func test_estimate_verdictParity_withComputeForModelInfo_allow() {
+        let fileSize: UInt64 = 4 * oneGB
+        let available: UInt64 = 12 * oneGB
+        let env = ModelLoadPlan.Environment(
+            availableMemoryBytes: { available },
+            physicalMemoryBytes: 16 * oneGB
+        )
+
+        let dl = makeDownloadable(sizeBytes: fileSize)
+        let mi = ModelInfo(
+            name: "parity",
+            fileName: "parity.gguf",
+            url: URL(fileURLWithPath: "/tmp/parity.gguf"),
+            fileSize: fileSize,
+            modelType: .gguf,
+            detectedContextLength: nil,        // match estimate()'s manifest blindness
+            estimatedKVBytesPerToken: nil      // forces legacy 8 KB fallback in compute()
+        )
+
+        let estimatePlan = ModelLoadPlan.estimate(for: dl, requestedContextSize: 4096, environment: env)
+        let computePlan = ModelLoadPlan.compute(for: mi, requestedContextSize: 4096, environment: env)
+
+        XCTAssertEqual(estimatePlan.verdict, computePlan.verdict)
+        XCTAssertEqual(estimatePlan.verdict, .allow)
+    }
+
+    /// Verdict-parity sanity at the deny end: an oversized model must deny via both
+    /// entry points, regardless of clamp-value differences.
+    func test_estimate_verdictParity_withComputeForModelInfo_deny() {
+        let fileSize: UInt64 = 40 * oneGB
+        let available: UInt64 = 8 * oneGB
+        let env = ModelLoadPlan.Environment(
+            availableMemoryBytes: { available },
+            physicalMemoryBytes: 16 * oneGB
+        )
+
+        let dl = makeDownloadable(sizeBytes: fileSize)
+        let mi = ModelInfo(
+            name: "parity-big",
+            fileName: "parity-big.gguf",
+            url: URL(fileURLWithPath: "/tmp/parity-big.gguf"),
+            fileSize: fileSize,
+            modelType: .gguf,
+            detectedContextLength: nil,
+            estimatedKVBytesPerToken: nil
+        )
+
+        let estimatePlan = ModelLoadPlan.estimate(for: dl, requestedContextSize: 4096, environment: env)
+        let computePlan = ModelLoadPlan.compute(for: mi, requestedContextSize: 4096, environment: env)
+
+        XCTAssertEqual(estimatePlan.verdict, .deny)
+        XCTAssertEqual(estimatePlan.verdict, computePlan.verdict)
+    }
 }
 
 // MARK: - Convenience accessor (test-scoped, avoids repeating `plan.outcome.totalEstimatedBytes`)


### PR DESCRIPTION
Closes #1293

## Summary

Adds a new public static overload on `ModelLoadPlan`:

```swift
ModelLoadPlan.estimate(
    for: DownloadableModel,
    requestedContextSize: Int,
    environment: Environment = .current,
    absoluteContextCeiling: Int = 128_000,
    headroomFraction: Double = 0.40
) -> ModelLoadPlan
```

Returns a real `ModelLoadPlan` carrying the same `Outcome.verdict` (`.allow` / `.warn` / `.deny`) and `reasons` shape as the post-load `compute(for: ModelInfo, ...)` path, but sized from manifest-only fields the HuggingFace listing exposes (`sizeBytes`, `modelType`). Browse-time UI (download tiles, variant pickers) can now render the same fit verdict that the loader will produce later — without first pulling the file to disk.

## Design

- **Reuses existing admission machinery.** The new overload assembles an `Inputs` value and delegates to `compute(inputs:)`. No math is re-derived — verdict thresholds, the impossible-fit guard, headroom, and iOS jetsam overhead all flow through the same primary entry point.
- **`MemoryStrategy` from format.** Mirrors the `ModelInfo`-based overload: `.gguf -> .mappable`, `.mlx -> .resident`, `.foundation -> systemManaged(...)`.
- **KV bytes/token heuristic.** Manifests don't expose attention shape, so `GGUFKVCacheEstimator.estimateBytesPerToken(...)` cannot run. Falls back to `GGUFKVCacheEstimator.legacyFallbackBytesPerToken` (8 KB/token). Real GQA architectures are typically cheaper per token, so this keeps `estimate(...)` at least as conservative as the post-load `compute(...)`.
- **Trained-context length unknown.** `Inputs.trainedContextLength` is `nil` at estimate time — only the absolute ceiling and memory-derived ceiling apply. Post-load `compute(...)` may tighten the effective context further once the GGUF header is read.

## Verdict-parity gap

`estimate(...)` may differ from post-load `compute(...)` along two axes — both in the more-conservative direction:

1. **KV/token.** Manifest path always uses 8 KB/token. Post-load uses arch-derived KV/token when the GGUF header exposes block count + attention shape. Effect: estimate's memory ceiling is tighter, so it may clamp context where compute wouldn't.
2. **Trained-context length.** Manifest path has none. Effect: if requested > absolute ceiling, estimate clamps via the absolute ceiling; compute may clamp tighter via the trained ceiling. The clamp value can therefore differ, but the allow/deny verdict matches when `(sizeBytes, strategy, available)` are the same.

Tests `test_estimate_verdictParity_withComputeForModelInfo_allow` / `_deny` pin this property: with `detectedContextLength: nil` and `estimatedKVBytesPerToken: nil`, the two entry points agree on `.verdict`.

## Tests

8 new tests in `ModelLoadPlanTests.swift`:

- [x] `test_estimate_smallModel_amplyMemory_allows` — small model, ample memory -> `.allow`, no clamp
- [x] `test_estimate_clampsContext_whenMemoryTight` — fits with clamped context, asserts clamped value < requested + `.memoryCeilingReached` reason
- [x] `test_estimate_oversized_denies_withMemoryReason` — oversized -> `.deny` + memory-headroom reason
- [x] `test_estimate_kvFallback_usesLegacy8KBPerToken` — asserts `inputs.kvBytesPerToken == 8_192` and verdict-parity against hand-computed `expectedOutcome(...)`
- [x] `test_estimate_foundation_returnsSystemManaged` — `.foundation` short-circuit
- [x] `test_estimate_mlx_usesResidentStrategy` — `.mlx` -> `.resident`
- [x] `test_estimate_verdictParity_withComputeForModelInfo_allow` / `_deny` — parity sanity

## Test plan

- [x] `swift build --build-tests --disable-default-traits` (clean)
- [x] `scripts/test.sh --filter ManifoldInferenceTests --disable-default-traits --skip-update` (1511 passed, 5 skipped, 0 failed)
- [x] 8 new `test_estimate_*` cases observed in test log