### PR TITLE
fix(tests): purge try? XCTSkip / try? XCTUnwrap + add Tests/ audit

### DIFF
--- a/Tests/ManifoldBackendsTests/ModelManifestContractTests.swift
+++ b/Tests/ManifoldBackendsTests/ModelManifestContractTests.swift
@@ -15,49 +15,49 @@ final class ModelManifestContractTests: XCTestCase {
     // MARK: - Cloud backends — supportsThinking matches the manifest table
 
     #if CloudSaaS
-    func test_claude_sonnet4_manifestReflectsThinking() {
+    func test_claude_sonnet4_manifestReflectsThinking() throws {
         let backend = ClaudeBackend()
         backend.modelName = "claude-sonnet-4-5"
-        let manifest = try? XCTUnwrap(backend.manifest)
-        XCTAssertEqual(manifest?.supportsThinking, true,
+        let manifest = try XCTUnwrap(backend.manifest)
+        XCTAssertEqual(manifest.supportsThinking, true,
                        "Claude Sonnet 4.x is a thinking model — manifest must reflect that")
         // The capability flag derives from the manifest in our wiring.
         XCTAssertTrue(backend.capabilities.supportsThinking,
                       "BackendCapabilities must surface the manifest's thinking flag")
     }
 
-    func test_claude_3_5_sonnet_manifestDoesNotAdvertiseThinking() {
+    func test_claude_3_5_sonnet_manifestDoesNotAdvertiseThinking() throws {
         let backend = ClaudeBackend()
         backend.modelName = "claude-3-5-sonnet-20241022"
-        let manifest = try? XCTUnwrap(backend.manifest)
-        XCTAssertEqual(manifest?.supportsThinking, false,
+        let manifest = try XCTUnwrap(backend.manifest)
+        XCTAssertEqual(manifest.supportsThinking, false,
                        "Claude 3.5 Sonnet predates extended thinking")
         XCTAssertFalse(backend.capabilities.supportsThinking,
                        "BackendCapabilities must mirror the manifest")
     }
 
-    func test_openAI_o1_manifestRejectsSeed() {
+    func test_openAI_o1_manifestRejectsSeed() throws {
         let backend = OpenAIBackend()
         backend.modelName = "o1-mini"
-        let manifest = try? XCTUnwrap(backend.manifest)
-        XCTAssertEqual(manifest?.supportsSeed, false,
+        let manifest = try XCTUnwrap(backend.manifest)
+        XCTAssertEqual(manifest.supportsSeed, false,
                        "o1-mini rejects seed — manifest must declare that so the wire layer omits it")
     }
 
-    func test_openAI_gpt4o_manifestAcceptsSeed() {
+    func test_openAI_gpt4o_manifestAcceptsSeed() throws {
         let backend = OpenAIBackend()
         backend.modelName = "gpt-4o"
-        let manifest = try? XCTUnwrap(backend.manifest)
-        XCTAssertEqual(manifest?.supportsSeed, true)
+        let manifest = try XCTUnwrap(backend.manifest)
+        XCTAssertEqual(manifest.supportsSeed, true)
     }
 
-    func test_openAI_unknownModel_returnsConservativeManifest() {
+    func test_openAI_unknownModel_returnsConservativeManifest() throws {
         let backend = OpenAIBackend()
         backend.modelName = "made-up-3000"
-        let manifest = try? XCTUnwrap(backend.manifest)
-        XCTAssertEqual(manifest?.contextWindow, 8192,
+        let manifest = try XCTUnwrap(backend.manifest)
+        XCTAssertEqual(manifest.contextWindow, 8192,
                        "Unknown OpenAI model must fall back to the 8k default")
-        XCTAssertEqual(manifest?.supportsSeed, false,
+        XCTAssertEqual(manifest.supportsSeed, false,
                        "Unknown OpenAI model must not advertise seed")
     }
     #endif

--- a/Tests/ManifoldFuzzTests/SessionScriptRunnerTests.swift
+++ b/Tests/ManifoldFuzzTests/SessionScriptRunnerTests.swift
@@ -18,7 +18,7 @@ final class SessionScriptRunnerTests: XCTestCase {
         return (service, mock)
     }
 
-    func test_sendStep_enqueuesAndCapturesRecord() async {
+    func test_sendStep_enqueuesAndCapturesRecord() async throws {
         let (service, mock) = makeService(replying: ["hello", " there"])
         let runner = SessionScriptRunner(
             service: service,
@@ -33,9 +33,9 @@ final class SessionScriptRunnerTests: XCTestCase {
 
         XCTAssertEqual(capture.steps.count, 1)
         XCTAssertEqual(capture.steps[0].timeline, .executed)
-        let record = try? XCTUnwrap(capture.steps[0].record)
-        XCTAssertEqual(record?.raw, "hello there")
-        XCTAssertEqual(record?.model.id, "mock-1")
+        let record = try XCTUnwrap(capture.steps[0].record)
+        XCTAssertEqual(record.raw, "hello there")
+        XCTAssertEqual(record.model.id, "mock-1")
         XCTAssertEqual(mock.generateCallCount, 1)
     }
 

--- a/Tests/ManifoldInferenceTests/TestSuiteSilentSkipAuditTest.swift
+++ b/Tests/ManifoldInferenceTests/TestSuiteSilentSkipAuditTest.swift
@@ -1,0 +1,96 @@
+import XCTest
+
+/// Guards against the `try? XCTSkip*` / `try? XCTUnwrap` footgun.
+///
+/// These XCTest helpers signal their effect by **throwing**. `XCTSkipUnless`
+/// throws `XCTSkip` so the runner marks the test skipped; `XCTUnwrap` throws
+/// when the optional is nil so the test fails with a clear diagnostic.
+/// Wrapping either in `try?` swallows the throw and turns a load-bearing
+/// signal into a no-op:
+///
+/// - `try? XCTSkipUnless(...)` in `setUp` runs the test even when the gate
+///   condition is false. The 50-cycle `SessionDiscardOrderingTests` stress
+///   test silently ran in every per-PR CI invocation this way until it
+///   started stalling the parallel test stream past the 30-min step cap.
+/// - `try? XCTUnwrap(opt)` makes the test report success when `opt` is nil;
+///   the follow-up assertion sees `nil` and may pass anyway depending on
+///   what it compares to.
+///
+/// Both patterns are pure footguns — neither has a legitimate use. The
+/// `Sources/`-scope `SilentCatchAuditTest` already covers production code;
+/// this test extends the coverage to `Tests/` with no allowlist.
+final class TestSuiteSilentSkipAuditTest: XCTestCase {
+
+    private static let forbiddenPatterns: [String] = [
+        "try? XCTSkip",
+        "try? XCTUnwrap",
+        "try? XCTFail",
+    ]
+
+    func test_testsDirectoryContainsNoSilentXCTSkipOrUnwrap() throws {
+        let testsURL = try Self.locateTestsDirectory()
+        var offenders: [(file: String, line: Int, text: String)] = []
+
+        let swiftFiles = try Self.enumerateSwiftFiles(under: testsURL)
+        XCTAssertFalse(swiftFiles.isEmpty, "Tests directory yielded no .swift files — path probably wrong")
+
+        for fileURL in swiftFiles {
+            // Skip this file — it deliberately mentions the forbidden tokens.
+            if fileURL.lastPathComponent == "TestSuiteSilentSkipAuditTest.swift" { continue }
+
+            let relativePath = fileURL.path.replacingOccurrences(of: testsURL.path + "/", with: "")
+            let content = try String(contentsOf: fileURL, encoding: .utf8)
+            let lines = content.components(separatedBy: "\n")
+            for (index, rawLine) in lines.enumerated() {
+                let line = rawLine.trimmingCharacters(in: .whitespaces)
+                if line.hasPrefix("//") || line.hasPrefix("///") || line.hasPrefix("*") { continue }
+                for pattern in Self.forbiddenPatterns where line.contains(pattern) {
+                    offenders.append((file: relativePath, line: index + 1, text: line))
+                    break
+                }
+            }
+        }
+
+        if !offenders.isEmpty {
+            let formatted = offenders
+                .map { "  \($0.file):\($0.line)  \($0.text)" }
+                .joined(separator: "\n")
+            XCTFail("""
+                Forbidden silent-skip / silent-unwrap pattern found in Tests/.
+                These swallow the throw that XCTSkip/XCTUnwrap rely on. Use `try` (not `try?`) and make the enclosing function `throws`:
+
+                \(formatted)
+                """)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func locateTestsDirectory(filePath: StaticString = #filePath) throws -> URL {
+        var dir = URL(fileURLWithPath: "\(filePath)").deletingLastPathComponent()
+        while dir.path != "/" {
+            let candidate = dir.appendingPathComponent("Tests")
+            var isDir: ObjCBool = false
+            if FileManager.default.fileExists(atPath: candidate.path, isDirectory: &isDir), isDir.boolValue {
+                return candidate
+            }
+            dir.deleteLastPathComponent()
+        }
+        throw NSError(domain: "TestSuiteSilentSkipAuditTest", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "Could not locate Tests/ from #filePath"
+        ])
+    }
+
+    private static func enumerateSwiftFiles(under root: URL) throws -> [URL] {
+        var result: [URL] = []
+        guard let enumerator = FileManager.default.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            result.append(url)
+        }
+        return result
+    }
+}

--- a/Tests/ManifoldPersistenceSwiftDataTests/SchemaV3MigrationTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/SchemaV3MigrationTests.swift
@@ -15,10 +15,11 @@ import ManifoldInference
 /// Gated by `RUN_OPERATIONAL_TESTS=1` to keep per-PR CI fast.
 final class SchemaV3MigrationTests: XCTestCase {
 
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         // Gate: only run in operational CI or locally when opt-in.
-        try? XCTSkipUnless(
+        // `try?` here would swallow XCTSkip and run the test anyway.
+        try XCTSkipUnless(
             ProcessInfo.processInfo.environment["RUN_OPERATIONAL_TESTS"] == "1",
             "Set RUN_OPERATIONAL_TESTS=1 to run migration tests"
         )

--- a/Tests/ManifoldRuntimeTests/EndpointStoreContractTests.swift
+++ b/Tests/ManifoldRuntimeTests/EndpointStoreContractTests.swift
@@ -104,12 +104,11 @@ final class EndpointStoreContractTests: XCTestCase {
 
     // MARK: - EndpointStoreError
 
-    func test_endpointStoreError_errorDescription_includesUUID() {
+    func test_endpointStoreError_errorDescription_includesUUID() throws {
         let id = UUID()
         let error = EndpointStoreError.endpointNotFound(id)
-        let message = try? XCTUnwrap(error.errorDescription)
-        XCTAssertNotNil(message)
-        XCTAssertTrue(message!.contains(id.uuidString))
+        let message = try XCTUnwrap(error.errorDescription)
+        XCTAssertTrue(message.contains(id.uuidString))
     }
 
     func test_endpointStoreError_equatable_byUUID() {

--- a/Tests/ManifoldRuntimeTests/SoakRunnerTests.swift
+++ b/Tests/ManifoldRuntimeTests/SoakRunnerTests.swift
@@ -18,9 +18,10 @@ import ManifoldTestSupport
 @MainActor
 final class SoakRunnerTests: XCTestCase {
 
-    override func setUp() {
-        super.setUp()
-        try? XCTSkipUnless(
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // `try?` here would swallow XCTSkip and run the test anyway.
+        try XCTSkipUnless(
             ProcessInfo.processInfo.environment["RUN_OPERATIONAL_TESTS"] == "1",
             "Set RUN_OPERATIONAL_TESTS=1 to run soak tests"
         )


### PR DESCRIPTION
## Summary

Companion to #1307. Bundles the remaining `try? XCT*` audit findings and adds a hard check so this footgun can't recur.

**Stacked on #1307** — base is `fix/session-discard-skip-try`. Once #1307 lands, change base to `main` (or just merge through and rebase).

### What it fixes

`try?` wrapping XCTest helpers whose contract is to *throw* turns a load-bearing signal into a no-op. Two flavours found in `Tests/`:

**1. Silent `XCTSkipUnless` (same shape as #1307):**
- `Tests/ManifoldPersistenceSwiftDataTests/SchemaV3MigrationTests.swift:21`
- `Tests/ManifoldRuntimeTests/SoakRunnerTests.swift:23`

Both have `RUN_OPERATIONAL_TESTS=1` gates that have been **silently disarmed** — these operational/soak suites have been running in every per-PR CI invocation. Less catastrophic than the 50-cycle SessionDiscard stress test (#1307) but the same root cause.

**2. Silent `XCTUnwrap` — test reports green when unwrap is nil:**
- `Tests/ManifoldBackendsTests/ModelManifestContractTests.swift` (5 sites: lines 21, 32, 42, 50, 57)
- `Tests/ManifoldFuzzTests/SessionScriptRunnerTests.swift:36`
- `Tests/ManifoldRuntimeTests/EndpointStoreContractTests.swift:110`

Each call became `try XCTUnwrap(...)` with the test method marked `throws`; the awkward `?.` projections that followed are now plain `.` since the value is guaranteed non-nil after the unwrap.

### Hard check — `TestSuiteSilentSkipAuditTest`

New sibling of `SilentCatchAuditTest` (which only scans `Sources/`). Walks `Tests/` and fails on `try? XCTSkip*`, `try? XCTUnwrap`, or `try? XCTFail`. No allowlist — these patterns have no legitimate use. CLAUDE.md's `try?` ban now has teeth on the test tree too.

## Test plan

- [x] `swift build --build-tests --traits MCP,CloudSaaS,Fuzz` — clean (60s cold)
- [x] `swift test --filter ManifoldInferenceTests.TestSuiteSilentSkipAuditTest` — passes
- [x] Sabotage: temporarily reverted one fix → audit failed loudly with the file:line
- [x] Touched suites pass and properly skip when their gates are unset (SchemaV3 + Soak + SessionDiscard all report "Test skipped")

🤖 Generated with [Claude Code](https://claude.com/claude-code)