### PR TITLE
chore(ci): strip PR triggers from release-provenance-rehearsal workflow

### DIFF
--- a/.github/workflows/release-provenance-rehearsal.yml
+++ b/.github/workflows/release-provenance-rehearsal.yml
@@ -1,14 +1,12 @@
 name: Release Provenance Rehearsal (read-only)
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/release-provenance.yml"
-      - ".github/workflows/release-provenance-rehearsal.yml"
-      - "scripts/generate-sbom.sh"
-      - "scripts/check-swift-toolchain.sh"
-      - "Package.swift"
-      - "Package.resolved"
+  # Rehearsal is a dry-run of release-provenance.yml. It does not need to gate
+  # every PR — a weekly cron + manual dispatch is enough to catch breakage
+  # before the next tagged release. Per-PR runs added ~macos-15 minutes of
+  # 10×-billed CI to every change for no signal on the vast majority of PRs.
+  schedule:
+    - cron: "0 12 * * 1" # Mondays 12:00 UTC
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

`release-provenance-rehearsal.yml` is, by name, a *rehearsal* — it dry-runs the release provenance + SBOM generation flow to catch breakage before the next tagged release. There is no signal in gating every PR on it; the real workflow (`release-provenance.yml`) runs on `release: published`, so a weekly cron + `workflow_dispatch` gives plenty of lead time to fix issues before cutting a tag.

Removes one `macos-15` job (10x-billed) from the per-PR critical path.

## Change

- Replace `pull_request:` trigger with `schedule: cron "0 12 * * 1"` (Mondays 12:00 UTC).
- Keep `workflow_dispatch:` so a maintainer can rehearse on demand before cutting a release.
- No edits to `release-provenance.yml` — it stays on `release: published` + `workflow_dispatch`.

## Verification

- Grepped the repo for `release-provenance-rehearsal` references: only self-references inside the rehearsal workflow itself. No other workflow consumes its outputs.
- `release-provenance.yml` triggers verified intact (`release: published` + `workflow_dispatch`).

## Test plan

- [ ] Branch protection settings should be verified manually before merge — the in-repo search found no references, but GitHub branch protection rules live outside the repo. If any required check references this workflow, it must be removed there first or merges to `main` will block.
- [ ] After merge, confirm a no-op PR no longer queues a "Release Provenance Rehearsal" run.
- [ ] After merge, confirm the scheduled Monday run fires (or trigger one manually via `gh workflow run release-provenance-rehearsal.yml`).