### PR TITLE
feat: add ModelRegistry.selectModel(_:) selection hook point

### DIFF
--- a/Sources/ManifoldInference/Services/ModelRegistry.swift
+++ b/Sources/ManifoldInference/Services/ModelRegistry.swift
@@ -96,6 +96,38 @@ public final class ModelRegistry {
         }
     }
 
+    // MARK: - Selection
+
+    /// Canonical programmatic entry point for changing ``selectedModel``.
+    ///
+    /// Equivalent to assigning `selectedModel = model`, plus validation: the
+    /// supplied model must already be in ``availableModels`` (or be
+    /// ``ModelInfo/builtInFoundation``, which is always accepted because hosts
+    /// may select it before a `refresh()` has populated the Foundation entry).
+    /// `nil` is always accepted and clears the current selection.
+    ///
+    /// - Returns: `true` when the selection was accepted (and applied);
+    ///   `false` when `model` is unknown to the registry — in which case the
+    ///   previous selection is left in place.
+    ///
+    /// `selectedModel` remains writable so SwiftUI two-way bindings keep
+    /// working; `selectModel(_:)` is the hook site for future logging,
+    /// telemetry, and auto-load wiring.
+    @discardableResult
+    public func selectModel(_ model: ModelInfo?) -> Bool {
+        // Hook site for future logging / validation / auto-load wiring.
+        guard let model else {
+            selectedModel = nil
+            return true
+        }
+        if model.id == ModelInfo.builtInFoundation.id
+            || availableModels.contains(where: { $0.id == model.id }) {
+            selectedModel = model
+            return true
+        }
+        return false
+    }
+
     // MARK: - Compatibility
 
     /// Reports whether the supplied local model type has a registered backend.

--- a/Tests/ManifoldInferenceTests/ModelRegistryTests.swift
+++ b/Tests/ManifoldInferenceTests/ModelRegistryTests.swift
@@ -133,6 +133,102 @@ final class ModelRegistryTests: XCTestCase {
         XCTAssertNil(registry.selectedModel)
     }
 
+    // MARK: - selectModel(_:)
+
+    func test_selectModel_acceptsKnownModel_andMutates() throws {
+        try createFakeGgufFile(named: "selectable.gguf")
+
+        let registry = ModelRegistry(
+            inferenceService: inferenceService,
+            modelStorage: modelStorage
+        )
+        try registry.refresh()
+
+        guard let known = registry.availableModels.first(where: { $0.fileName == "selectable.gguf" }) else {
+            return XCTFail("Pre-condition: model file should be discoverable")
+        }
+
+        let accepted = registry.selectModel(known)
+
+        XCTAssertTrue(accepted, "selectModel should return true for a known model")
+        XCTAssertEqual(registry.selectedModel?.id, known.id)
+    }
+
+    func test_selectModel_rejectsUnknownModel_andPreservesPriorSelection() throws {
+        try createFakeGgufFile(named: "known.gguf")
+
+        let registry = ModelRegistry(
+            inferenceService: inferenceService,
+            modelStorage: modelStorage
+        )
+        try registry.refresh()
+
+        guard let known = registry.availableModels.first(where: { $0.fileName == "known.gguf" }) else {
+            return XCTFail("Pre-condition: model file should be discoverable")
+        }
+        registry.selectedModel = known
+
+        // Construct a ModelInfo that doesn't exist in availableModels — point
+        // ggufURL at a file that was never registered.
+        let strayURL = modelsDirectory.appendingPathComponent("never-registered.gguf")
+        var stray = Data([0x47, 0x47, 0x55, 0x46])
+        stray.append(Data(repeating: 0xBB, count: 4092))
+        try stray.write(to: strayURL)
+        guard let unknown = ModelInfo(ggufURL: strayURL) else {
+            return XCTFail("Pre-condition: ModelInfo should construct from a GGUF-prefixed file")
+        }
+        // The stray file lives in the same directory, so refresh would include
+        // it — we deliberately don't refresh, so availableModels still lists
+        // only `known`.
+        XCTAssertFalse(
+            registry.availableModels.contains(where: { $0.id == unknown.id }),
+            "Pre-condition: unknown model must not be in availableModels"
+        )
+
+        let accepted = registry.selectModel(unknown)
+
+        XCTAssertFalse(accepted, "selectModel should return false for an unknown model")
+        XCTAssertEqual(
+            registry.selectedModel?.id,
+            known.id,
+            "Rejected selection must leave the prior selectedModel in place"
+        )
+    }
+
+    func test_selectModel_acceptsNil_andClears() throws {
+        try createFakeGgufFile(named: "to-clear.gguf")
+
+        let registry = ModelRegistry(
+            inferenceService: inferenceService,
+            modelStorage: modelStorage
+        )
+        try registry.refresh()
+        registry.selectedModel = registry.availableModels.first
+
+        let accepted = registry.selectModel(nil)
+
+        XCTAssertTrue(accepted, "selectModel(nil) is always accepted")
+        XCTAssertNil(registry.selectedModel)
+    }
+
+    func test_selectModel_acceptsBuiltInFoundation_evenWhenNotInAvailableModels() {
+        let registry = ModelRegistry(
+            inferenceService: inferenceService,
+            modelStorage: modelStorage
+        )
+
+        // availableModels is empty — no refresh, no foundation provider.
+        XCTAssertTrue(registry.availableModels.isEmpty)
+
+        let accepted = registry.selectModel(.builtInFoundation)
+
+        XCTAssertTrue(
+            accepted,
+            "builtInFoundation must be accepted regardless of availableModels"
+        )
+        XCTAssertEqual(registry.selectedModel?.id, ModelInfo.builtInFoundation.id)
+    }
+
     // MARK: - compatibility(for:)
 
     func test_compatibility_forwardsToInferenceService() {


### PR DESCRIPTION
## Summary

Adds `@discardableResult public func selectModel(_ model: ModelInfo?) -> Bool` on `ModelRegistry` as the canonical programmatic entry point for changing selection.

- Equivalent to assigning `selectedModel = model` plus validation
- Returns `false` and preserves prior selection when `model` is unknown
- Always accepts `nil` (clears selection) and `.builtInFoundation` (may be selected before `refresh()` populates it)
- `selectedModel` stays writable — SwiftUI two-way bindings keep working
- Method body carries a single hook-site comment for future logging / auto-load wiring; no speculative impl

Closes #1303

## Test plan

- [x] `test_selectModel_acceptsKnownModel_andMutates`
- [x] `test_selectModel_rejectsUnknownModel_andPreservesPriorSelection`
- [x] `test_selectModel_acceptsNil_andClears`
- [x] `test_selectModel_acceptsBuiltInFoundation_evenWhenNotInAvailableModels`

🤖 Generated with [Claude Code](https://claude.com/claude-code)