### PR TITLE
docs: cover all three cold-start conformance tiers in Tests/README

### DIFF
--- a/Tests/README.md
+++ b/Tests/README.md
@@ -146,6 +146,16 @@ This proves the assertion (a) exercises a real production code path, (b) is valu
 - **Ollama**: requires `localhost:11434` and `--traits Ollama`.
 - **Operational tier** (planned): nightly trait `Operational` for soak/migration/throughput/quality baseline.
 
+### Cold-start conformance gates
+
+Cold-start gates scaffold a fresh SwiftPM consumer in a tmpdir, depend on this repo via `.package(path:, name: "ManifoldKit", ...)`, and exercise the public surface from outside — catching breakage that in-tree tests miss because the in-tree compiler sees internals the fresh consumer cannot. Each gate's CI job in `.github/workflows/ci.yml` lists its own script path under `paths:` so edits to the gate re-trigger the gate (see `feedback_ci_path_filter_self_validation`).
+
+| Tier | Script | Surface |
+|---|---|---|
+| 1 | `scripts/cold-start-conformance.sh` | Low-level public API: `InferenceService`, backends, generation events. |
+| 2 | `scripts/cold-start-tier2-bootstrap.sh` | `ManifoldBootstrap` + `ChatViewModel` orchestration. |
+| 3 | `scripts/cold-start-tier3-chatview.sh` | `ManifoldUI` `ChatView` composition with `@State` view models, `.environment(_:)` injection, and the `apiConfiguration: () -> View` view-builder closure. |
+
 ## Who runs what
 
 | Audience | Suite |


### PR DESCRIPTION
## Summary

The tier-3 ChatView cold-start gate already shipped — script at `scripts/cold-start-tier3-chatview.sh`, CI job `cold-start-tier3` in `.github/workflows/ci.yml` (PRs #1166 + #1190). Issue #1313's only remaining gap was that `Tests/README.md` never named any of the three cold-start tiers.

This PR adds a "Cold-start conformance gates" subsection under Special cases that:

- Names each tier's script and the surface it exercises (low-level API → Bootstrap+ChatViewModel → ChatView composition).
- Notes the self-validating CI path-filter convention (`feedback_ci_path_filter_self_validation`) so future tiers follow the same shape.

No code change. No CI workflow change.

Closes #1313. Parent tracker #1115.

## Test plan

- [x] `bash scripts/cold-start-tier3-chatview.sh` passes locally (ran end-to-end).
- [x] Docs-only diff — `Tests/README.md` is the only file touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)