### PR TITLE
fix(tests): unblock CI — drain pre-fired GenerationHook calls

### DIFF
--- a/Tests/ManifoldRuntimeTests/GenerationHookWillBeginTurnTests.swift
+++ b/Tests/ManifoldRuntimeTests/GenerationHookWillBeginTurnTests.swift
@@ -65,31 +65,47 @@ final class GenerationHookWillBeginTurnTests: XCTestCase {
         }
 
         private(set) var calls: [Call] = []
+        private var pendingWillBegin: [UUID] = []
+        private var pendingPostGen: [CompletedTurn] = []
         private var willBeginContinuations: [CheckedContinuation<UUID, Never>] = []
         private var postGenContinuations: [CheckedContinuation<CompletedTurn, Never>] = []
 
         func willBeginTurn(sessionID: UUID) async {
             calls.append(.willBeginTurn(sessionID))
-            for continuation in willBeginContinuations {
+            if willBeginContinuations.isEmpty {
+                // No awaiter yet — buffer so a later awaitNext call resolves immediately.
+                // Without this, the detached pre-turn hook fires before the test
+                // re-suspends, the continuation is registered too late, and
+                // withCheckedContinuation hangs forever.
+                pendingWillBegin.append(sessionID)
+            } else {
+                let continuation = willBeginContinuations.removeFirst()
                 continuation.resume(returning: sessionID)
             }
-            willBeginContinuations.removeAll()
         }
 
         func postGeneration(_ turn: CompletedTurn) async {
             calls.append(.postGeneration(turn.sessionID))
-            for continuation in postGenContinuations {
+            if postGenContinuations.isEmpty {
+                pendingPostGen.append(turn)
+            } else {
+                let continuation = postGenContinuations.removeFirst()
                 continuation.resume(returning: turn)
             }
-            postGenContinuations.removeAll()
         }
 
         func awaitNextWillBeginTurn() async -> UUID {
-            await withCheckedContinuation { willBeginContinuations.append($0) }
+            if !pendingWillBegin.isEmpty {
+                return pendingWillBegin.removeFirst()
+            }
+            return await withCheckedContinuation { willBeginContinuations.append($0) }
         }
 
         func awaitNextPostGeneration() async -> CompletedTurn {
-            await withCheckedContinuation { postGenContinuations.append($0) }
+            if !pendingPostGen.isEmpty {
+                return pendingPostGen.removeFirst()
+            }
+            return await withCheckedContinuation { postGenContinuations.append($0) }
         }
     }
 
@@ -230,26 +246,19 @@ final class GenerationHookWillBeginTurnTests: XCTestCase {
             config: TurnConfig()
         ))
 
-        // Wait for the second willBeginTurn to arrive — it fires at the start
-        // of the regenerate flow's detached task, before history fetch.
-        let callsBefore = await hook.calls
-        let priorWillBeginCount = callsBefore.filter {
-            if case .willBeginTurn = $0 { return true }
-            return false
-        }.count
-
-        // Wait for the second willBeginTurn (regenerate flow).
-        _ = try await withDeadline { await hook.awaitNextWillBeginTurn() }
+        // Drain events for the regenerate turn so its detached task fully runs
+        // (firing the second willBeginTurn at the start, postGeneration at the end).
+        _ = try await collectUntilAfterGeneration(from: runtime)
 
         let calls = await hook.calls
         let willBeginCalls = calls.filter {
             if case .willBeginTurn(let id) = $0 { return id == sessionID }
             return false
         }
-        XCTAssertGreaterThan(
+        XCTAssertEqual(
             willBeginCalls.count,
-            priorWillBeginCount,
-            "willBeginTurn must fire again on the regenerate flow"
+            2,
+            "willBeginTurn must fire once per turn — send + regenerate"
         )
     }
 


### PR DESCRIPTION
## Summary

CI has been stuck on main since `cb99eb60` (PR #1244) introduced `GenerationHookWillBeginTurnTests`. The XCTest job consistently stalls around test 1250/3204 — the suite hangs entirely, the post-`47ff3ac4` 240s stall watchdog kills the job on main, and the 30-min action timeout kills it on every open PR (#1307, #1291, #1299 all blocked by this, not their own diffs).

Root cause: the pre-turn hook fires from a `Task.detached` inside `ConversationTurnExecutor.runSendFlow` / `runRegenerateFlow`. `processTurn` returns to the test the moment the detached task is *dispatched* — by the time the `@MainActor` test reaches `await hook.awaitNextWillBeginTurn()`, the hook has often already fired. The recording-hook's `withCheckedContinuation` is registered too late and **never resumes**. Worse, the surrounding `withDeadline` helper uses `withThrowingTaskGroup` — when the deadline child throws, the group has to await the operation child, but `withCheckedContinuation` is not cancellable, so the entire task group hangs forever. The 5s deadline is a paper tiger.

Fix:
- Buffer pre-fired `sessionID`s / `CompletedTurn`s inside the recording hook. `awaitNext*` returns immediately if an event already arrived; otherwise registers a continuation as before.
- `test_willBeginTurn_firesOnRegenerateFlow` also had a latent assertion bug masked by the hang: it snapshotted `calls` after `processTurn` returned but before the detached task had run, then asserted growth — a race against the same detached fire. Replaced with a deterministic event drain that just asserts the final count.

## Test plan

- [x] Reproduced the hang locally: pre-fix, test 3 starts and never completes (xctest at 0% CPU in S state)
- [x] All 4 tests pass post-fix in **0.23s**
- [ ] CI green
- [ ] Unblocks #1307, #1291, #1299

Refs the original feature: #1244 (added `willBeginTurn`).