### PR TITLE
fix(ci): make check-coverage.sh work on bash 3.2

### DIFF
--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -32,12 +32,11 @@ PACKAGE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PACKAGE_DIR"
 
 # ── Thresholds (integer percent) ─────────────────────────────────────────────
-declare -A THRESHOLDS=(
-  [ManifoldInference]=74
-  [ManifoldRuntime]=74
-  [ManifoldPersistenceSwiftData]=74
-  [ManifoldMCP]=75
-)
+# Parallel arrays instead of `declare -A` — bash 3.2 (the default on macOS
+# GitHub runners) parses `[ManifoldInference]=74` as arithmetic indexing and
+# fails under `set -u` with "ManifoldInference: unbound variable".
+MODULES=(ManifoldInference ManifoldRuntime ManifoldPersistenceSwiftData ManifoldMCP)
+THRESHOLDS=(74 74 74 75)
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 PROFDATA_ARG=""
@@ -120,9 +119,9 @@ REPORT=$(xcrun llvm-cov report \
 #   Executed  Lines  MissedLines  Cover%  Branches  MissedBranches  Cover%
 # We sum Lines ($8) and MissedLines ($9) per source directory prefix.
 
-declare -A COV_PERCENT
+COV_RESULTS=()
 
-for module in "${!THRESHOLDS[@]}"; do
+for module in "${MODULES[@]}"; do
   result=$(printf '%s\n' "$REPORT" | awk -v mod="${module}/" '
     $1 ~ "^" mod {
       total  += $8
@@ -137,7 +136,7 @@ for module in "${!THRESHOLDS[@]}"; do
       }
     }
   ')
-  COV_PERCENT[$module]="$result"
+  COV_RESULTS+=("$result")
 done
 
 # ── Print summary table ───────────────────────────────────────────────────────
@@ -151,9 +150,13 @@ echo "  ────────────────────────
 FAILED=0
 FAILED_MODULES=()
 
-for module in $(printf '%s\n' "${!THRESHOLDS[@]}" | sort); do
-  threshold=${THRESHOLDS[$module]}
-  data=${COV_PERCENT[$module]}
+# Build sorted index list so output matches the previous alphabetical order.
+SORTED_INDEXES=$(for i in "${!MODULES[@]}"; do printf '%s\t%d\n' "${MODULES[$i]}" "$i"; done | sort | awk '{print $2}')
+
+for i in $SORTED_INDEXES; do
+  module=${MODULES[$i]}
+  threshold=${THRESHOLDS[$i]}
+  data=${COV_RESULTS[$i]}
   pct=$(echo "$data" | awk '{print $1}')
   covered=$(echo "$data" | awk '{print $2}')
   total=$(echo "$data" | awk '{print $3}')


### PR DESCRIPTION
## Summary

The `Coverage thresholds` CI step has been failing since first execution with:

```
scripts/check-coverage.sh: line 35: ManifoldInference: unbound variable
```

Previously masked by the test-job watchdog killing the run before this step ran (fixed in #1322).

Root cause: macOS GitHub runners ship bash 3.2 as `/bin/bash`, which doesn't support associative arrays. Under `set -u`, `declare -A T=([Mod]=74)` parses `[Mod]=74` as arithmetic indexing rather than a string key, dereferences `Mod` as a variable, and fails.

Fix: replace `declare -A` with parallel `MODULES` / `THRESHOLDS` indexed arrays + a sorted-index loop. Same alphabetical output order, same behaviour, works on bash 3.2.

## Test plan

- [x] `/bin/bash -n scripts/check-coverage.sh` — syntax OK on bash 3.2
- [x] `/bin/bash scripts/check-coverage.sh` — script runs, reaches threshold loop, exits cleanly on missing profdata
- [ ] CI green on the Coverage Thresholds step