### PR TITLE
feat: public stagedAttachments API on ChatViewModel

### DIFF
--- a/Sources/ManifoldUI/ViewModels/ChatViewModel+Messages.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel+Messages.swift
@@ -436,4 +436,34 @@ extension ChatViewModel {
     func clearDraftAttachments() {
         draftAttachments.removeAll()
     }
+
+    // MARK: - Public staged-attachment surface (issue #1302)
+
+    /// Image / vision parts currently staged for the next user turn.
+    ///
+    /// Mirrors the array the bundled ``ChatInputBar`` mutates internally so
+    /// hosts building custom composers can read the same source of truth.
+    public var stagedAttachments: [MessagePart] { draftAttachments }
+
+    /// Appends an attachment to the next user turn.
+    ///
+    /// Routes through the same internal path the bundled ``ChatInputBar``
+    /// uses (``stageDraftAttachment(_:)``) so image-placeholder generation
+    /// — and any other side effects added to that path in the future —
+    /// fire identically for host-supplied composers.
+    public func stageAttachment(_ part: MessagePart) {
+        stageDraftAttachment(part)
+    }
+
+    /// Removes a previously staged attachment by index. No-op when the
+    /// index is out of range so callers driving from indeterminate UI
+    /// state (drag sources, async pickers) do not have to pre-validate.
+    public func removeStagedAttachment(at index: Int) {
+        removeDraftAttachment(id: index)
+    }
+
+    /// Clears all staged attachments without sending the turn.
+    public func clearStagedAttachments() {
+        clearDraftAttachments()
+    }
 }

--- a/Tests/ManifoldUITests/ChatViewModelStagedAttachmentsTests.swift
+++ b/Tests/ManifoldUITests/ChatViewModelStagedAttachmentsTests.swift
@@ -1,0 +1,150 @@
+@preconcurrency import XCTest
+import Foundation
+@testable import ManifoldUI
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+/// Coverage for the public staged-attachment API on `ChatViewModel` introduced
+/// in issue #1302. Verifies that consumers building custom composers reach the
+/// same internal path the bundled `ChatInputBar` uses.
+@MainActor
+final class ChatViewModelStagedAttachmentsTests: XCTestCase {
+
+    private let oneGB: UInt64 = 1_024 * 1_024 * 1_024
+
+    private func makeViewModel() -> ChatViewModel {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        let service = InferenceService(backend: mock, name: "StagedAttachmentsMock")
+        return ChatViewModel(
+            inferenceService: service,
+            deviceCapability: DeviceCapabilityService(physicalMemory: 16 * oneGB),
+            modelStorage: ModelStorageService(),
+            memoryPressure: MemoryPressureHandler()
+        )
+    }
+
+    private func textPart(_ text: String) -> MessagePart { .text(text) }
+    private func imagePart(_ byte: UInt8) -> MessagePart {
+        // Distinct payloads keep `Hashable` ordering stable across the test.
+        .image(data: Data([byte, byte, byte, byte]), mimeType: "image/png")
+    }
+
+    // MARK: - Append / read
+
+    func test_stageAttachment_appendsToStagedList() {
+        let vm = makeViewModel()
+        XCTAssertTrue(vm.stagedAttachments.isEmpty)
+
+        vm.stageAttachment(textPart("hello"))
+
+        XCTAssertEqual(vm.stagedAttachments.count, 1)
+    }
+
+    func test_stagedAttachments_reflectsAppendsInOrder() {
+        let vm = makeViewModel()
+
+        let a = textPart("a")
+        let b = textPart("b")
+        let c = textPart("c")
+        vm.stageAttachment(a)
+        vm.stageAttachment(b)
+        vm.stageAttachment(c)
+
+        XCTAssertEqual(vm.stagedAttachments, [a, b, c])
+    }
+
+    // MARK: - Remove
+
+    func test_removeStagedAttachment_atValidIndex_removes() {
+        let vm = makeViewModel()
+        let a = textPart("a")
+        let b = textPart("b")
+        let c = textPart("c")
+        vm.stageAttachment(a)
+        vm.stageAttachment(b)
+        vm.stageAttachment(c)
+
+        vm.removeStagedAttachment(at: 1)
+
+        XCTAssertEqual(vm.stagedAttachments, [a, c])
+    }
+
+    func test_removeStagedAttachment_outOfRange_isNoOp() {
+        let vm = makeViewModel()
+        vm.stageAttachment(textPart("only"))
+        let before = vm.stagedAttachments
+
+        // Both upper-bound and far-out indices should be silent no-ops.
+        vm.removeStagedAttachment(at: 5)
+        vm.removeStagedAttachment(at: 1)
+        vm.removeStagedAttachment(at: Int.max)
+
+        XCTAssertEqual(vm.stagedAttachments, before)
+    }
+
+    // MARK: - Clear
+
+    func test_clearStagedAttachments_empties() {
+        let vm = makeViewModel()
+        vm.stageAttachment(textPart("a"))
+        vm.stageAttachment(textPart("b"))
+        XCTAssertFalse(vm.stagedAttachments.isEmpty)
+
+        vm.clearStagedAttachments()
+
+        XCTAssertTrue(vm.stagedAttachments.isEmpty)
+    }
+
+    // MARK: - Parity with the internal ChatInputBar path
+
+    /// `ChatInputBar` stages images by calling `stageDraftAttachment(_:)`,
+    /// which routes the part through `generatingImagePlaceholderIfNeeded()`
+    /// to assign a stable placeholder hash. The public API must produce the
+    /// same enriched part, not the caller's raw input — otherwise hosts
+    /// building a custom composer would lose the placeholder rendering the
+    /// bundled UI relies on.
+    func test_stageAttachment_publicPath_matchesInternalChatInputBarBehavior() {
+        // A minimal valid 1x1 PNG so `ImagePlaceholderHash.generate` returns a
+        // hash. Without a decodable image, the placeholder helper short-circuits
+        // to nil on both paths and the parity check would be trivially true.
+        let onePixelPNG = Data([
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+            0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+            0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+            0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41,
+            0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+            0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+            0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+            0x42, 0x60, 0x82
+        ])
+        let rawImage = MessagePart.image(
+            data: onePixelPNG,
+            mimeType: "image/png",
+            placeholderHash: nil
+        )
+
+        let viaPublic = makeViewModel()
+        viaPublic.stageAttachment(rawImage)
+        let viaInternal = makeViewModel()
+        viaInternal.stageDraftAttachment(rawImage)
+
+        // Whatever side effect the bundled ChatInputBar path produces (today:
+        // placeholder-hash generation via generatingImagePlaceholderIfNeeded),
+        // the public surface must produce the *same* staged part.
+        XCTAssertEqual(
+            viaPublic.stagedAttachments,
+            viaInternal.stagedAttachments,
+            "Public stageAttachment must route through the same internal path as ChatInputBar (stageDraftAttachment) so future side effects added there fire for host composers too"
+        )
+
+        // And the shared path must actually be doing the placeholder work,
+        // not handing the raw input through unchanged.
+        XCTAssertNotEqual(
+            viaPublic.stagedAttachments.first,
+            rawImage,
+            "Staged image must be enriched (placeholder hash) — if equal to raw input, both paths are bypassing generatingImagePlaceholderIfNeeded"
+        )
+    }
+}


### PR DESCRIPTION
Closes #1302.

## Summary

Adds a public push-path for staging vision/image attachments on the
next user turn, so consumers building custom composers (drag-and-drop
drop targets, share extensions, AppIntents prefills) no longer have
to route through the bundled `ChatInputBar` or wait for delivery to
see attachments on a `ChatMessage`.

## New public API on `ChatViewModel`

```swift
public var stagedAttachments: [MessagePart] { get }
public func stageAttachment(_ part: MessagePart)
public func removeStagedAttachment(at index: Int)
public func clearStagedAttachments()
```

## Behavioral parity

All four entry points delegate to the existing internal mutators
(`stageDraftAttachment(_:)`, `removeDraftAttachment(id:)`,
`clearDraftAttachments()`) that `ChatInputBar` already uses. The
key side effect today is `MessagePart.generatingImagePlaceholderIfNeeded()`
on staged images — the public path produces an identical staged
part, and any future side effects added to the shared internal
method automatically fire for host composers too.

`removeStagedAttachment(at:)` is a silent no-op on out-of-range
indices per the issue spec, so callers driving from indeterminate UI
state (async pickers, drag sources) do not have to pre-validate.

## Scope discipline

- `draftAttachments` storage stays `internal`; only the new public
  surface is added.
- `ChatInputBar` keeps calling the internal names — this PR is
  purely additive.
- No new validation, persistence, or normalization beyond what the
  existing internal path already performs.
- `inferenceService` and other internals stay `internal` (per CLAUDE.md).

## Test plan

New file `Tests/ManifoldUITests/ChatViewModelStagedAttachmentsTests.swift`:

- [x] `test_stageAttachment_appendsToStagedList`
- [x] `test_stagedAttachments_reflectsAppendsInOrder`
- [x] `test_removeStagedAttachment_atValidIndex_removes`
- [x] `test_removeStagedAttachment_outOfRange_isNoOp`
- [x] `test_clearStagedAttachments_empties`
- [x] `test_stageAttachment_publicPath_matchesInternalChatInputBarBehavior` — drives a real 1×1 PNG through both the public and internal paths and asserts they produce identical staged parts (including the generated placeholder hash)

Each method was sabotage-verified locally — every test fails when its method is broken, then restored.

Local gates run:
- `swift test --filter "ManifoldUITests.ChatViewModelStaged" --disable-default-traits --skip-update` → 6/6 pass
- `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace` → green