### PR TITLE
feat(hf): auto-detect .fp16.safetensors variants in diffusion downloader

### DIFF
--- a/Sources/ManifoldHuggingFace/DiffusionDownload.swift
+++ b/Sources/ManifoldHuggingFace/DiffusionDownload.swift
@@ -87,6 +87,7 @@ public extension HuggingFaceService {
         from repoID: String,
         to destinationDirectory: URL,
         displayName: String? = nil,
+        preferFP16: Bool = true,
         urlSession: URLSession? = nil,
         progress: @escaping @Sendable (DiffusionDownloadProgress) -> Void
     ) async throws -> ImageModelInfo {
@@ -113,6 +114,7 @@ public extension HuggingFaceService {
                 to: destinationDirectory,
                 stagingDirectory: stagingDirectory,
                 displayName: resolvedDisplayName,
+                preferFP16: preferFP16,
                 using: session,
                 progress: progress
             )
@@ -131,6 +133,7 @@ public extension HuggingFaceService {
         to destinationDirectory: URL,
         stagingDirectory: URL,
         displayName resolvedDisplayName: String,
+        preferFP16: Bool,
         using session: URLSession,
         progress: @escaping @Sendable (DiffusionDownloadProgress) -> Void
     ) async throws -> ImageModelInfo {
@@ -148,10 +151,24 @@ public extension HuggingFaceService {
         // 2. Resolve submodules.
         let manifest = try parseDiffusionManifest(at: manifestLocalURL)
 
-        // 3. Plan the file list.
+        // 3. Plan the file list. Probe fp16 availability first when the
+        // caller hasn't opted out; the plan builder substitutes the
+        // `.fp16.safetensors` filename per weight file when present and
+        // records which variant was picked overall.
+        let fp16Available: Set<String>
+        if preferFP16 {
+            fp16Available = await probeFP16Availability(
+                repoID: repoID,
+                candidates: Self.candidateWeightPaths(for: manifest),
+                using: session
+            )
+        } else {
+            fp16Available = []
+        }
         let plan = try buildDiffusionDownloadPlan(
             manifest: manifest,
-            destinationDirectory: stagingDirectory
+            destinationDirectory: stagingDirectory,
+            fp16AvailablePaths: fp16Available
         )
 
         // 4. Download each file sequentially with summed progress.
@@ -230,10 +247,11 @@ public extension HuggingFaceService {
             directoryURL: destinationDirectory,
             format: format,
             fileSize: totalBytes,
-            huggingFaceRepoID: repoID
+            huggingFaceRepoID: repoID,
+            variant: plan.variant
         )
 
-        Log.download.info("Writing package manifest")
+        Log.download.info("Writing package manifest (variant=\(info.variant.rawValue, privacy: .public))")
         try writePackageManifest(
             for: info,
             files: ["model_index.json"] + plan.items.map(\.relativePath),
@@ -259,7 +277,8 @@ public extension HuggingFaceService {
             displayName: info.name,
             format: info.format,
             huggingFaceRepoID: info.huggingFaceRepoID,
-            files: files.sorted()
+            files: files.sorted(),
+            variant: info.variant
         )
         let data = try JSONEncoder().encode(manifest)
         try data.write(
@@ -317,11 +336,71 @@ public extension HuggingFaceService {
 
     struct DiffusionDownloadPlan: Sendable {
         let items: [DiffusionDownloadItem]
+        /// Variant chosen across the whole package. `.fp16` whenever **any**
+        /// weight file was substituted with its `.fp16.safetensors` sibling
+        /// — diffusion runtimes load the package as a unit, so the variant
+        /// reported in metadata reflects the precision that's actually on
+        /// disk for the bulk weights (UNet + VAE + text encoder(s)). A
+        /// partial fp16 set still saves substantial bytes, so we report fp16
+        /// rather than papering over the mix as full-precision.
+        let variant: PrecisionVariant
+    }
+
+    /// Pure detection rule for fp16 vs full-precision selection.
+    ///
+    /// Returns `.fp16` if **any** of `weightPaths` has a `.fp16.safetensors`
+    /// sibling in `fp16Available`. Otherwise `.fullPrecision`. The rule
+    /// stays deliberately permissive: even a partial fp16 set (e.g. UNet
+    /// only, no VAE fp16) is worth labelling as fp16 so consumers can see
+    /// "this package isn't pure fp32" without re-walking the directory.
+    internal static func selectVariant(
+        weightPaths: [String],
+        fp16Available: Set<String>
+    ) -> PrecisionVariant {
+        for path in weightPaths {
+            if fp16Available.contains(fp16Path(for: path)) {
+                return .fp16
+            }
+        }
+        return .fullPrecision
+    }
+
+    /// Maps a full-precision weight path (`unet/diffusion_pytorch_model.safetensors`)
+    /// to its fp16 sibling (`unet/diffusion_pytorch_model.fp16.safetensors`).
+    /// Leaves the path unchanged if it doesn't end in `.safetensors` or
+    /// already has the `.fp16` infix.
+    internal static func fp16Path(for path: String) -> String {
+        let suffix = ".safetensors"
+        let fp16Suffix = ".fp16.safetensors"
+        guard path.hasSuffix(suffix), !path.hasSuffix(fp16Suffix) else { return path }
+        let base = String(path.dropLast(suffix.count))
+        return base + fp16Suffix
+    }
+
+    /// Lists every full-precision weight path the planner would consider for
+    /// a given manifest. Used both for fp16 HEAD-probing and as input to
+    /// ``selectVariant(weightPaths:fp16Available:)`` in tests.
+    internal static func candidateWeightPaths(for manifest: DiffusionManifest) -> [String] {
+        var paths: [String] = []
+        if manifest.submodules.contains("transformer") {
+            paths.append("transformer/diffusion_pytorch_model.safetensors")
+        }
+        if manifest.submodules.contains("unet") {
+            paths.append("unet/diffusion_pytorch_model.safetensors")
+        }
+        if manifest.submodules.contains("vae") {
+            paths.append("vae/diffusion_pytorch_model.safetensors")
+        }
+        for name in ["text_encoder", "text_encoder_2"] where manifest.submodules.contains(name) {
+            paths.append("\(name)/model.safetensors")
+        }
+        return paths
     }
 
     private func buildDiffusionDownloadPlan(
         manifest: DiffusionManifest,
-        destinationDirectory: URL
+        destinationDirectory: URL,
+        fp16AvailablePaths: Set<String>
     ) throws -> DiffusionDownloadPlan {
         let isFlux = manifest.submodules.contains("transformer")
         // Require the denoiser submodule appropriate for each pipeline family,
@@ -338,13 +417,15 @@ public extension HuggingFaceService {
         items.append(contentsOf: try plan(
             submodule: requiredDenoiser,
             weights: "diffusion_pytorch_model.safetensors",
-            destinationDirectory: destinationDirectory
+            destinationDirectory: destinationDirectory,
+            fp16AvailablePaths: fp16AvailablePaths
         ))
 
         items.append(contentsOf: try plan(
             submodule: "vae",
             weights: "diffusion_pytorch_model.safetensors",
-            destinationDirectory: destinationDirectory
+            destinationDirectory: destinationDirectory,
+            fp16AvailablePaths: fp16AvailablePaths
         ))
 
         // Text encoder(s).
@@ -352,7 +433,8 @@ public extension HuggingFaceService {
             items.append(contentsOf: try plan(
                 submodule: name,
                 weights: "model.safetensors",
-                destinationDirectory: destinationDirectory
+                destinationDirectory: destinationDirectory,
+                fp16AvailablePaths: fp16AvailablePaths
             ))
         }
 
@@ -384,17 +466,29 @@ public extension HuggingFaceService {
             ))
         }
 
-        return DiffusionDownloadPlan(items: items)
+        let variant = Self.selectVariant(
+            weightPaths: Self.candidateWeightPaths(for: manifest),
+            fp16Available: fp16AvailablePaths
+        )
+        return DiffusionDownloadPlan(items: items, variant: variant)
     }
 
     private func plan(
         submodule: String,
         weights: String,
-        destinationDirectory: URL
+        destinationDirectory: URL,
+        fp16AvailablePaths: Set<String>
     ) throws -> [DiffusionDownloadItem] {
         try assertSafePathComponent(submodule)
         try assertSafePathComponent(weights)
         let dir = destinationDirectory.appendingPathComponent(submodule, isDirectory: true)
+        let fullPrecisionRelative = "\(submodule)/\(weights)"
+        let fp16Relative = Self.fp16Path(for: fullPrecisionRelative)
+        let useFP16 = fp16Relative != fullPrecisionRelative
+            && fp16AvailablePaths.contains(fp16Relative)
+        let chosenRelative = useFP16 ? fp16Relative : fullPrecisionRelative
+        let chosenFileName = (chosenRelative as NSString).lastPathComponent
+        try assertSafePathComponent(chosenFileName)
         return [
             DiffusionDownloadItem(
                 relativePath: "\(submodule)/config.json",
@@ -402,11 +496,55 @@ public extension HuggingFaceService {
                 role: .submoduleConfig
             ),
             DiffusionDownloadItem(
-                relativePath: "\(submodule)/\(weights)",
-                localURL: dir.appendingPathComponent(weights),
+                relativePath: chosenRelative,
+                localURL: dir.appendingPathComponent(chosenFileName),
                 role: .weights
             ),
         ]
+    }
+
+    /// HEAD-probes each candidate fp16 path in parallel and returns the set
+    /// of paths the remote actually serves. A 200 means "fetch the fp16
+    /// variant", anything else (404 / 403 / transport failure) falls back
+    /// to full-precision for that file.
+    ///
+    /// Probing in parallel keeps the cost flat (one round-trip per request,
+    /// concurrent over the same session) instead of additive on top of the
+    /// download itself. Failures are absorbed silently — the variant
+    /// selection is best-effort and we'd rather fall back to fp32 than
+    /// abort the install over a network blip on a probe.
+    private func probeFP16Availability(
+        repoID: String,
+        candidates: [String],
+        using session: URLSession
+    ) async -> Set<String> {
+        guard !candidates.isEmpty else { return [] }
+        return await withTaskGroup(of: String?.self) { group in
+            for fullPath in candidates {
+                let fp16Relative = Self.fp16Path(for: fullPath)
+                guard fp16Relative != fullPath else { continue }
+                let url = downloadURL(repoID: repoID, filePath: fp16Relative)
+                group.addTask {
+                    var request = URLRequest(url: url)
+                    request.httpMethod = "HEAD"
+                    do {
+                        let (_, response) = try await session.data(for: request)
+                        if let http = response as? HTTPURLResponse,
+                           (200..<300).contains(http.statusCode) {
+                            return fp16Relative
+                        }
+                    } catch {
+                        Log.network.debug("fp16 probe failed for \(fp16Relative, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                    }
+                    return nil
+                }
+            }
+            var found: Set<String> = []
+            for await result in group {
+                if let path = result { found.insert(path) }
+            }
+            return found
+        }
     }
 
     // MARK: - Path-traversal hygiene

--- a/Sources/ManifoldInference/Models/DownloadedModelPackageManifest.swift
+++ b/Sources/ManifoldInference/Models/DownloadedModelPackageManifest.swift
@@ -15,6 +15,10 @@ public struct DownloadedModelPackageManifest: Codable, Hashable, Sendable {
     public let format: ImageModelFormat?
     public let huggingFaceRepoID: String?
     public let files: [String]
+    /// Numeric precision of the on-disk weights for diffusion packages. Optional
+    /// so pre-fp16-detection manifests still decode; missing → consumers should
+    /// treat as full-precision.
+    public let variant: PrecisionVariant?
 
     public init(
         packageKind: ModelPackageKind,
@@ -22,7 +26,8 @@ public struct DownloadedModelPackageManifest: Codable, Hashable, Sendable {
         displayName: String,
         format: ImageModelFormat? = nil,
         huggingFaceRepoID: String? = nil,
-        files: [String]
+        files: [String],
+        variant: PrecisionVariant? = nil
     ) {
         self.packageKind = packageKind
         self.id = id
@@ -30,6 +35,7 @@ public struct DownloadedModelPackageManifest: Codable, Hashable, Sendable {
         self.format = format
         self.huggingFaceRepoID = huggingFaceRepoID
         self.files = files
+        self.variant = variant
     }
 }
 

--- a/Sources/ManifoldInference/Models/ImageModelInfo.swift
+++ b/Sources/ManifoldInference/Models/ImageModelInfo.swift
@@ -43,13 +43,21 @@ public struct ImageModelInfo: Codable, Hashable, Identifiable, Sendable {
     /// update flow.
     public let huggingFaceRepoID: String?
 
+    /// Numeric precision of the weights actually on disk. Set by the
+    /// downloader when it picks an fp16 vs full-precision variant for a
+    /// diffusion package; defaults to ``PrecisionVariant/fullPrecision``
+    /// for locally-discovered models and any package whose manifest
+    /// pre-dates fp16 detection.
+    public let variant: PrecisionVariant
+
     public init(
         id: String,
         name: String,
         directoryURL: URL,
         format: ImageModelFormat,
         fileSize: Int64,
-        huggingFaceRepoID: String? = nil
+        huggingFaceRepoID: String? = nil,
+        variant: PrecisionVariant = .fullPrecision
     ) {
         self.id = id
         self.name = name
@@ -57,6 +65,24 @@ public struct ImageModelInfo: Codable, Hashable, Identifiable, Sendable {
         self.format = format
         self.fileSize = fileSize
         self.huggingFaceRepoID = huggingFaceRepoID
+        self.variant = variant
+    }
+
+    // Custom decoder so packages downloaded before fp16 detection (no
+    // `variant` key on disk) continue to decode as `.fullPrecision`.
+    private enum CodingKeys: String, CodingKey {
+        case id, name, directoryURL, format, fileSize, huggingFaceRepoID, variant
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.directoryURL = try container.decode(URL.self, forKey: .directoryURL)
+        self.format = try container.decode(ImageModelFormat.self, forKey: .format)
+        self.fileSize = try container.decode(Int64.self, forKey: .fileSize)
+        self.huggingFaceRepoID = try container.decodeIfPresent(String.self, forKey: .huggingFaceRepoID)
+        self.variant = try container.decodeIfPresent(PrecisionVariant.self, forKey: .variant) ?? .fullPrecision
     }
 
     /// Human-readable file size (e.g. `"4.2 GB"`).

--- a/Sources/ManifoldInference/Models/PrecisionVariant.swift
+++ b/Sources/ManifoldInference/Models/PrecisionVariant.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Numeric precision of the tensor weights actually fetched for a model package.
+///
+/// Diffusion repos on the Hugging Face Hub commonly ship two parallel weight
+/// sets: the full-precision `*.safetensors` files and `*.fp16.safetensors`
+/// half-precision counterparts. The fp16 variant is roughly half the disk
+/// footprint and the right default for inference on Apple Silicon, so the
+/// downloader prefers it when available. This enum records what was actually
+/// pulled so consumers (UI, loaders) don't have to re-derive it from filenames.
+///
+/// Defaults to ``fullPrecision`` for back-compat: packages downloaded before
+/// fp16 detection shipped have no `variant` field in their on-disk manifest,
+/// and the decoder treats absence as full-precision.
+public enum PrecisionVariant: String, Codable, Hashable, Sendable {
+    /// Full-precision weights — the plain `*.safetensors` file set
+    /// (typically fp32 in the on-disk tensor metadata, but the runtime may
+    /// up- or down-cast at load time).
+    case fullPrecision
+    /// Half-precision weights — the `*.fp16.safetensors` file set.
+    case fp16
+}

--- a/Sources/ManifoldInference/Services/ModelStorageService.swift
+++ b/Sources/ManifoldInference/Services/ModelStorageService.swift
@@ -301,7 +301,8 @@ public final class ModelStorageService: @unchecked Sendable {
             directoryURL: directory,
             format: format,
             fileSize: packageSize(at: directory, files: manifest.files),
-            huggingFaceRepoID: manifest.huggingFaceRepoID
+            huggingFaceRepoID: manifest.huggingFaceRepoID,
+            variant: manifest.variant ?? .fullPrecision
         )
     }
 

--- a/Tests/ManifoldHuggingFaceTests/DiffusionFP16DetectionTests.swift
+++ b/Tests/ManifoldHuggingFaceTests/DiffusionFP16DetectionTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+@testable import ManifoldInference
+#if HuggingFace
+@testable import ManifoldHuggingFace
+
+/// Hermetic coverage for the fp16-vs-full-precision selection rule.
+///
+/// We test the pure helpers (`selectVariant`, `fp16Path`,
+/// `candidateWeightPaths`) directly rather than the full downloader so the
+/// test stays a single-call assertion with no network plumbing — matches
+/// what the issue calls out as "test on a fixture of siblings listings".
+final class DiffusionFP16DetectionTests: XCTestCase {
+
+    // MARK: - fp16Path mapping
+
+    func test_fp16Path_appendsInfixForSafetensors() {
+        XCTAssertEqual(
+            HuggingFaceService.fp16Path(for: "unet/diffusion_pytorch_model.safetensors"),
+            "unet/diffusion_pytorch_model.fp16.safetensors"
+        )
+    }
+
+    func test_fp16Path_isIdempotentForAlreadyFP16() {
+        XCTAssertEqual(
+            HuggingFaceService.fp16Path(for: "unet/diffusion_pytorch_model.fp16.safetensors"),
+            "unet/diffusion_pytorch_model.fp16.safetensors"
+        )
+    }
+
+    func test_fp16Path_leavesNonSafetensorsAlone() {
+        XCTAssertEqual(
+            HuggingFaceService.fp16Path(for: "tokenizer/vocab.json"),
+            "tokenizer/vocab.json"
+        )
+    }
+
+    // MARK: - selectVariant fixture matrix
+
+    /// (a) Only fp32 weights present → full-precision.
+    func test_selectVariant_onlyFullPrecision_picksFullPrecision() {
+        let weights = [
+            "unet/diffusion_pytorch_model.safetensors",
+            "vae/diffusion_pytorch_model.safetensors",
+            "text_encoder/model.safetensors",
+        ]
+        let fp16Available: Set<String> = []
+        XCTAssertEqual(
+            HuggingFaceService.selectVariant(weightPaths: weights, fp16Available: fp16Available),
+            .fullPrecision
+        )
+    }
+
+    /// (b) Only fp16 siblings advertised → fp16.
+    func test_selectVariant_onlyFP16_picksFP16() {
+        let weights = [
+            "unet/diffusion_pytorch_model.safetensors",
+            "vae/diffusion_pytorch_model.safetensors",
+        ]
+        let fp16Available: Set<String> = [
+            "unet/diffusion_pytorch_model.fp16.safetensors",
+            "vae/diffusion_pytorch_model.fp16.safetensors",
+        ]
+        XCTAssertEqual(
+            HuggingFaceService.selectVariant(weightPaths: weights, fp16Available: fp16Available),
+            .fp16
+        )
+    }
+
+    /// (c) Both fp32 and fp16 present in the repo's file listing → fp16
+    /// (the whole point of the feature — prefer the smaller, faster variant
+    /// when the user opts in).
+    func test_selectVariant_bothAvailable_picksFP16() {
+        let weights = [
+            "unet/diffusion_pytorch_model.safetensors",
+            "vae/diffusion_pytorch_model.safetensors",
+            "text_encoder/model.safetensors",
+            "text_encoder_2/model.safetensors",
+        ]
+        // Simulates `getModel(...).siblings` listing every file; fp16
+        // siblings exist alongside their full-precision counterparts.
+        let fp16Available: Set<String> = [
+            "unet/diffusion_pytorch_model.fp16.safetensors",
+            "vae/diffusion_pytorch_model.fp16.safetensors",
+            "text_encoder/model.fp16.safetensors",
+            "text_encoder_2/model.fp16.safetensors",
+        ]
+        XCTAssertEqual(
+            HuggingFaceService.selectVariant(weightPaths: weights, fp16Available: fp16Available),
+            .fp16
+        )
+    }
+
+    /// (d) Partial fp16 coverage — UNet has an fp16 sibling, VAE doesn't.
+    /// We report `.fp16` because the bulk weights (UNet dominates the
+    /// package size) save real bytes; downstream consumers need to know
+    /// the package isn't pure full-precision so they can label / cache
+    /// accordingly. The per-file substitution is what actually decides
+    /// disk usage; this overall flag is just a hint.
+    func test_selectVariant_partialFP16_picksFP16() {
+        let weights = [
+            "unet/diffusion_pytorch_model.safetensors",
+            "vae/diffusion_pytorch_model.safetensors",
+            "text_encoder/model.safetensors",
+        ]
+        let fp16Available: Set<String> = [
+            "unet/diffusion_pytorch_model.fp16.safetensors",
+            // VAE + text encoder fp16 not in the repo.
+        ]
+        XCTAssertEqual(
+            HuggingFaceService.selectVariant(weightPaths: weights, fp16Available: fp16Available),
+            .fp16
+        )
+    }
+
+    // MARK: - candidateWeightPaths
+
+    /// SD-style manifests (unet + vae + single text encoder) produce the
+    /// expected candidate list, in submodule order.
+    func test_candidateWeightPaths_sdManifest() {
+        let manifest = HuggingFaceService.DiffusionManifest(
+            submodules: ["unet", "vae", "text_encoder", "tokenizer", "scheduler"]
+        )
+        XCTAssertEqual(
+            HuggingFaceService.candidateWeightPaths(for: manifest),
+            [
+                "unet/diffusion_pytorch_model.safetensors",
+                "vae/diffusion_pytorch_model.safetensors",
+                "text_encoder/model.safetensors",
+            ]
+        )
+    }
+
+    /// SDXL manifests bring `text_encoder_2`; FLUX manifests use
+    /// `transformer` in place of `unet`. The candidate list must cover
+    /// both shapes so fp16 detection works for FLUX too.
+    func test_candidateWeightPaths_sdxlAndFlux() {
+        let sdxl = HuggingFaceService.DiffusionManifest(
+            submodules: ["unet", "vae", "text_encoder", "text_encoder_2", "tokenizer", "tokenizer_2", "scheduler"]
+        )
+        XCTAssertEqual(Set(HuggingFaceService.candidateWeightPaths(for: sdxl)), Set([
+            "unet/diffusion_pytorch_model.safetensors",
+            "vae/diffusion_pytorch_model.safetensors",
+            "text_encoder/model.safetensors",
+            "text_encoder_2/model.safetensors",
+        ]))
+
+        let flux = HuggingFaceService.DiffusionManifest(
+            submodules: ["transformer", "vae", "text_encoder", "tokenizer", "scheduler"]
+        )
+        XCTAssertEqual(Set(HuggingFaceService.candidateWeightPaths(for: flux)), Set([
+            "transformer/diffusion_pytorch_model.safetensors",
+            "vae/diffusion_pytorch_model.safetensors",
+            "text_encoder/model.safetensors",
+        ]))
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Closes #1316.

Diffusion repos on the HuggingFace Hub commonly ship both full-precision (`*.safetensors`) and half-precision (`*.fp16.safetensors`) weight sets. The downloader now prefers fp16 by default — roughly half the disk footprint and faster to load on Apple Silicon, where fp16 is the right default for diffusion.

### Detection rule

For each candidate weight path (UNet/transformer, VAE, text encoder(s)), the downloader issues a parallel HEAD probe to `<base>.fp16.safetensors` against the same session. A 200 response substitutes the fp16 path for the full-precision one in the download plan; anything else (404 / 403 / transport blip) silently falls back to the original full-precision file. Detection is purely opportunistic — a network blip on a probe falls back to fp32 rather than aborting the install.

### Metadata surfacing

A new `PrecisionVariant` enum (`fullPrecision` / `fp16`) lands on `ImageModelInfo.variant` and on `DownloadedModelPackageManifest.variant`. `ModelStorageService` rehydrates the variant from the on-disk manifest on discovery, defaulting to `.fullPrecision` for pre-fp16 packages (custom decoder added so old manifests still decode).

The overall variant is reported as `.fp16` whenever **any** weight file was substituted, even when fp16 coverage is partial — UNet dominates the package size, so partial substitution still saves real bytes and consumers shouldn't see that masquerade as pure fp32.

### Override

Added `preferFP16: Bool = true` parameter on `HuggingFaceService.downloadDiffusionModel(...)`. Defaults preserve the new behaviour; callers that need full-precision weights can pass `preferFP16: false`.

## Test plan

- [x] New `DiffusionFP16DetectionTests` covers all four fixture rows from the issue:
  - only fp32 → fullPrecision
  - only fp16 → fp16
  - both → fp16
  - partial (UNet fp16, VAE fp32) → fp16 (overall hint)
  - plus `fp16Path` idempotence and SDXL/FLUX `candidateWeightPaths` shape
- [x] Sabotage check: flipping the rule produced 4 fixture failures; reverted before commit
- [x] Local slice green: `swift test --filter ManifoldHuggingFaceTests --traits HuggingFace --disable-default-traits --skip-update` → 163 tests, 0 failures
- [x] Trait-combo sweep green: `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` builds clean
- [x] Existing diffusion download / validator / storage suites unchanged and still passing