### PR TITLE
feat: extend ModelCapabilities with codeGeneration and multilingual axes

### DIFF
--- a/Sources/ManifoldInference/Services/ModelCapabilityProbe.swift
+++ b/Sources/ManifoldInference/Services/ModelCapabilityProbe.swift
@@ -14,6 +14,18 @@ public struct ModelCapabilities: Sendable, Equatable {
     /// True when `config.json` contains a top-level `audio_config` object.
     /// An explicit JSON `null` does not count — the key must map to an object.
     public let supportsAudio: Bool
+    /// True when the checkpoint advertises itself as a code-specialised model.
+    /// Inferred conservatively from durable signals: HF model-card front-matter
+    /// `pipeline_tag` / `tags` (`README.md`), `tags` arrays in `config.json`,
+    /// or an `architectures` entry whose name contains "code"/"coder". Display
+    /// names are deliberately not consulted — they drift.
+    public let supportsCodeGeneration: Bool
+    /// True when the checkpoint advertises ≥ 2 supported natural languages.
+    /// Inferred from the HF model-card front-matter `language` field
+    /// (`README.md`) when it is a list of two or more entries, or from a
+    /// `language` array in `config.json` of the same shape. Single-language
+    /// declarations do not count.
+    public let supportsMultilingual: Bool
     /// First non-nil of `max_position_embeddings`, `n_ctx`,
     /// `text_config.max_position_embeddings`, or `text_config.n_ctx`.
     /// `nil` when none of those keys are present (e.g. embedding-only models).
@@ -22,10 +34,14 @@ public struct ModelCapabilities: Sendable, Equatable {
     public init(
         supportsVision: Bool,
         supportsAudio: Bool,
+        supportsCodeGeneration: Bool = false,
+        supportsMultilingual: Bool = false,
         contextLength: Int?
     ) {
         self.supportsVision = supportsVision
         self.supportsAudio = supportsAudio
+        self.supportsCodeGeneration = supportsCodeGeneration
+        self.supportsMultilingual = supportsMultilingual
         self.contextLength = contextLength
     }
 }
@@ -99,10 +115,218 @@ public enum ModelCapabilityProbe {
             ?? (textConfig?["max_position_embeddings"] as? Int)
             ?? (textConfig?["n_ctx"] as? Int)
 
+        // README.md front-matter is the canonical place for HF-side metadata
+        // (`language`, `tags`, `pipeline_tag`). config.json sometimes mirrors
+        // a subset of these as extra fields. Both feed the code/multilingual
+        // inference; either source being present is sufficient. Missing
+        // README is normal (some snapshots strip it) so we treat it as the
+        // absence of a positive signal rather than an error.
+        let cardMetadata = readModelCardMetadata(in: modelDirectory)
+
+        let supportsCodeGeneration = inferCodeGeneration(
+            config: config,
+            card: cardMetadata
+        )
+        let supportsMultilingual = inferMultilingual(
+            config: config,
+            card: cardMetadata
+        )
+
         return ModelCapabilities(
             supportsVision: supportsVision,
             supportsAudio: supportsAudio,
+            supportsCodeGeneration: supportsCodeGeneration,
+            supportsMultilingual: supportsMultilingual,
             contextLength: contextLength
         )
+    }
+
+    // MARK: - Code / multilingual heuristics
+
+    /// Tags / pipeline / language extracted from `README.md` YAML front-matter.
+    /// Empty when the README is missing, has no front-matter, or fails to
+    /// parse — the probe deliberately under-reports rather than guessing.
+    private struct ModelCardMetadata {
+        var tags: [String] = []
+        var pipelineTag: String?
+        var languages: [String] = []
+    }
+
+    private static func readModelCardMetadata(in directory: URL) -> ModelCardMetadata {
+        let readmeURL = directory.appendingPathComponent("README.md")
+        guard FileManager.default.fileExists(atPath: readmeURL.path),
+              let data = try? Data(contentsOf: readmeURL),
+              let contents = String(data: data, encoding: .utf8)
+        else {
+            return ModelCardMetadata()
+        }
+        return parseFrontMatter(contents)
+    }
+
+    /// Hand-rolled YAML front-matter parser limited to the three fields we
+    /// consult. Full YAML is overkill — HF cards stick to a tight subset
+    /// (`key: value` and `key:\n  - item` block lists) and a real YAML
+    /// dependency would pull a parser into a module that otherwise has none.
+    private static func parseFrontMatter(_ contents: String) -> ModelCardMetadata {
+        var metadata = ModelCardMetadata()
+        // Front-matter must be the literal first bytes of the file, fenced by
+        // `---` lines. Anything else (BOM, blank line) means no front-matter.
+        guard contents.hasPrefix("---") else { return metadata }
+        let afterOpen = contents.dropFirst(3)
+        guard let closeRange = afterOpen.range(of: "\n---") else { return metadata }
+        let body = String(afterOpen[afterOpen.startIndex..<closeRange.lowerBound])
+
+        let lines = body.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        var index = 0
+        while index < lines.count {
+            let line = lines[index]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            // Skip blank lines and YAML comments.
+            if trimmed.isEmpty || trimmed.hasPrefix("#") {
+                index += 1
+                continue
+            }
+            // Top-level keys are unindented; nested keys start with whitespace.
+            // We only care about top-level here.
+            guard line.first.map({ !$0.isWhitespace }) == true,
+                  let colonIndex = line.firstIndex(of: ":")
+            else {
+                index += 1
+                continue
+            }
+            let key = String(line[line.startIndex..<colonIndex]).trimmingCharacters(in: .whitespaces)
+            let rawValue = String(line[line.index(after: colonIndex)...]).trimmingCharacters(in: .whitespaces)
+
+            switch key {
+            case "tags":
+                let (values, consumed) = collectListValue(inline: rawValue, lines: lines, after: index)
+                metadata.tags = values
+                index += consumed
+            case "language", "languages":
+                let (values, consumed) = collectListValue(inline: rawValue, lines: lines, after: index)
+                metadata.languages = values
+                index += consumed
+            case "pipeline_tag":
+                metadata.pipelineTag = unquote(rawValue)
+                index += 1
+            default:
+                index += 1
+            }
+        }
+        return metadata
+    }
+
+    /// Resolves a YAML scalar/inline-list/block-list value into a flat string
+    /// array. Returns the number of lines consumed (≥ 1) so the caller can
+    /// advance past any block-list entries.
+    private static func collectListValue(
+        inline: String,
+        lines: [String],
+        after startIndex: Int
+    ) -> ([String], Int) {
+        // Inline scalar: `tags: foo`
+        if !inline.isEmpty, !inline.hasPrefix("[") {
+            return ([unquote(inline)], 1)
+        }
+        // Inline flow-style list: `tags: [foo, bar]`
+        if inline.hasPrefix("[") {
+            let inner = inline.dropFirst().dropLast(inline.hasSuffix("]") ? 1 : 0)
+            let items = inner.split(separator: ",").map {
+                unquote($0.trimmingCharacters(in: .whitespaces))
+            }
+            return (items.filter { !$0.isEmpty }, 1)
+        }
+        // Block list: subsequent indented `- item` lines.
+        var items: [String] = []
+        var consumed = 1
+        var cursor = startIndex + 1
+        while cursor < lines.count {
+            let line = lines[cursor]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty {
+                cursor += 1
+                consumed += 1
+                continue
+            }
+            // A non-indented non-list line ends the block.
+            guard line.first?.isWhitespace == true, trimmed.hasPrefix("- ") else {
+                break
+            }
+            let value = String(trimmed.dropFirst(2)).trimmingCharacters(in: .whitespaces)
+            items.append(unquote(value))
+            cursor += 1
+            consumed += 1
+        }
+        return (items, consumed)
+    }
+
+    private static func unquote(_ value: String) -> String {
+        var v = value
+        if (v.hasPrefix("\"") && v.hasSuffix("\"")) || (v.hasPrefix("'") && v.hasSuffix("'")), v.count >= 2 {
+            v = String(v.dropFirst().dropLast())
+        }
+        return v
+    }
+
+    private static func inferCodeGeneration(
+        config: [String: Any],
+        card: ModelCardMetadata
+    ) -> Bool {
+        // README front-matter is the primary signal: `pipeline_tag` or a `tags`
+        // entry containing "code". HF's own taxonomy uses kebab-case
+        // ("text-generation", "code-generation") and lowercases tag values.
+        if let pipeline = card.pipelineTag?.lowercased(),
+           pipeline.contains("code") {
+            return true
+        }
+        if card.tags.contains(where: { $0.lowercased().contains("code") }) {
+            return true
+        }
+        // Fallback: some configs duplicate `tags` as a JSON array. Same rule.
+        if let configTags = config["tags"] as? [String],
+           configTags.contains(where: { $0.lowercased().contains("code") }) {
+            return true
+        }
+        // Last resort: `architectures` is a JSON array of class names like
+        // `["CodeLlamaForCausalLM"]`. Most coders reuse the base arch name
+        // (CodeLlama → LlamaForCausalLM) so this only fires for the handful
+        // that ship a distinct class. Conservative by design.
+        if let archs = config["architectures"] as? [String] {
+            // Substring "coder" matches both "...CoderForCausalLM" (positive)
+            // and "...DecoderForCausalLM" (negative). Strip "decoder" before
+            // testing so the false positive is impossible without re-implementing
+            // a regex engine for one needle.
+            let stripsDecoder: (String) -> String = { $0.lowercased().replacingOccurrences(of: "decoder", with: "") }
+            if archs.contains(where: { stripsDecoder($0).contains("coder") }) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func inferMultilingual(
+        config: [String: Any],
+        card: ModelCardMetadata
+    ) -> Bool {
+        // ≥ 2 distinct language codes in the README front-matter is the
+        // canonical HF declaration. We dedupe case-insensitively because
+        // some cards list both "en" and "English".
+        let cardLanguages = Set(card.languages.map { $0.lowercased() })
+        if cardLanguages.count >= 2 {
+            return true
+        }
+        // Mirror the same rule for an optional `language` array on config.json
+        // (rare, but some checkpoints include it).
+        if let configLanguages = config["language"] as? [String] {
+            let set = Set(configLanguages.map { $0.lowercased() })
+            if set.count >= 2 {
+                return true
+            }
+        }
+        // An explicit `multilingual` tag is a final, unambiguous signal.
+        if card.tags.contains(where: { $0.lowercased() == "multilingual" }) {
+            return true
+        }
+        return false
     }
 }

--- a/Sources/ManifoldInference/Services/ModelCapabilityProbe.swift
+++ b/Sources/ManifoldInference/Services/ModelCapabilityProbe.swift
@@ -273,18 +273,20 @@ public enum ModelCapabilityProbe {
         card: ModelCardMetadata
     ) -> Bool {
         // README front-matter is the primary signal: `pipeline_tag` or a `tags`
-        // entry containing "code". HF's own taxonomy uses kebab-case
-        // ("text-generation", "code-generation") and lowercases tag values.
-        if let pipeline = card.pipelineTag?.lowercased(),
-           pipeline.contains("code") {
+        // entry containing the "code" / "coding" / "codegen" token. HF's
+        // taxonomy uses kebab-case ("text-generation", "code-generation") and
+        // lowercases tag values. We tokenize on non-alphanumerics so that
+        // "encoder", "encoder-decoder", and similar non-code tokens do NOT
+        // match the bare "code" substring.
+        if let pipeline = card.pipelineTag, pipelineOrTagSuggestsCode(pipeline) {
             return true
         }
-        if card.tags.contains(where: { $0.lowercased().contains("code") }) {
+        if card.tags.contains(where: pipelineOrTagSuggestsCode) {
             return true
         }
         // Fallback: some configs duplicate `tags` as a JSON array. Same rule.
         if let configTags = config["tags"] as? [String],
-           configTags.contains(where: { $0.lowercased().contains("code") }) {
+           configTags.contains(where: pipelineOrTagSuggestsCode) {
             return true
         }
         // Last resort: `architectures` is a JSON array of class names like
@@ -302,6 +304,16 @@ public enum ModelCapabilityProbe {
             }
         }
         return false
+    }
+
+    /// Whole-token match for code-related HF taxonomy values. Splits the raw
+    /// tag/pipeline string on non-alphanumerics so `encoder` (contains "code"
+    /// as a substring) does not register, while `code`, `code-generation`,
+    /// `text-to-code`, and `codegen` do.
+    private static func pipelineOrTagSuggestsCode(_ raw: String) -> Bool {
+        let needles: Set<String> = ["code", "coder", "coding", "codegen"]
+        let tokens = raw.lowercased().split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+        return tokens.contains(where: { needles.contains(String($0)) })
     }
 
     private static func inferMultilingual(

--- a/Tests/ManifoldInferenceTests/ModelCapabilityProbeTests.swift
+++ b/Tests/ManifoldInferenceTests/ModelCapabilityProbeTests.swift
@@ -238,6 +238,209 @@ final class ModelCapabilityProbeTests: XCTestCase {
         }
     }
 
+    // MARK: - Code generation inference
+
+    func testProbe_codeGeneration_defaultsFalseForPlainLLM() throws {
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        { "model_type": "llama", "max_position_embeddings": 8192 }
+        """#, to: dir)
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertFalse(caps.supportsCodeGeneration)
+        XCTAssertFalse(caps.supportsMultilingual)
+    }
+
+    func testProbe_codeGeneration_trueWhenReadmeTagsIncludeCode() throws {
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        { "model_type": "qwen2", "max_position_embeddings": 32768 }
+        """#, to: dir)
+        // HF coder cards include a `code` (and often `code-generation`) tag.
+        try writeConfig(#"""
+        ---
+        language:
+          - en
+        tags:
+          - code
+          - text-generation
+        pipeline_tag: text-generation
+        ---
+
+        # Qwen2.5-Coder-7B
+        """#, to: dir, named: "README.md")
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertTrue(caps.supportsCodeGeneration)
+    }
+
+    func testProbe_codeGeneration_trueWhenPipelineTagContainsCode() throws {
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        { "model_type": "llama", "max_position_embeddings": 8192 }
+        """#, to: dir)
+        try writeConfig(#"""
+        ---
+        pipeline_tag: text-to-code
+        ---
+        """#, to: dir, named: "README.md")
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertTrue(caps.supportsCodeGeneration)
+    }
+
+    func testProbe_codeGeneration_trueWhenArchitectureContainsCoder() throws {
+        // Fallback path: no README, but `architectures` advertises a coder class.
+        // Substring is "coder" specifically to avoid matching "decoder".
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        {
+            "model_type": "deepseek",
+            "architectures": ["DeepseekCoderForCausalLM"],
+            "max_position_embeddings": 16384
+        }
+        """#, to: dir)
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertTrue(caps.supportsCodeGeneration)
+    }
+
+    func testProbe_codeGeneration_falseForDecoderOnlyArchitecture() throws {
+        // Guard: "decoder" in the class name must NOT trip the "coder" needle.
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        {
+            "model_type": "llama",
+            "architectures": ["LlamaDecoderForCausalLM"],
+            "max_position_embeddings": 8192
+        }
+        """#, to: dir)
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertFalse(caps.supportsCodeGeneration)
+    }
+
+    func testProbe_codeGeneration_trueFromConfigTags() throws {
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        {
+            "model_type": "llama",
+            "tags": ["code-generation"],
+            "max_position_embeddings": 8192
+        }
+        """#, to: dir)
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertTrue(caps.supportsCodeGeneration)
+    }
+
+    // MARK: - Multilingual inference
+
+    func testProbe_multilingual_trueWhenReadmeListsTwoOrMoreLanguages() throws {
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        { "model_type": "llama", "max_position_embeddings": 8192 }
+        """#, to: dir)
+        try writeConfig(#"""
+        ---
+        language:
+          - en
+          - fr
+          - de
+        ---
+        """#, to: dir, named: "README.md")
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertTrue(caps.supportsMultilingual)
+    }
+
+    func testProbe_multilingual_falseForSingleLanguage() throws {
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        { "model_type": "llama", "max_position_embeddings": 8192 }
+        """#, to: dir)
+        try writeConfig(#"""
+        ---
+        language:
+          - en
+        ---
+        """#, to: dir, named: "README.md")
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertFalse(caps.supportsMultilingual)
+    }
+
+    func testProbe_multilingual_trueFromExplicitTag() throws {
+        // Some HF cards declare `language: multilingual` plus a `multilingual`
+        // tag rather than enumerating every language. Honour the tag.
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        { "model_type": "xlmr", "max_position_embeddings": 512 }
+        """#, to: dir)
+        try writeConfig(#"""
+        ---
+        tags:
+          - multilingual
+        ---
+        """#, to: dir, named: "README.md")
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertTrue(caps.supportsMultilingual)
+    }
+
+    func testProbe_multilingual_trueFromInlineFlowList() throws {
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        { "model_type": "llama", "max_position_embeddings": 8192 }
+        """#, to: dir)
+        try writeConfig(#"""
+        ---
+        language: [en, es, pt]
+        ---
+        """#, to: dir, named: "README.md")
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertTrue(caps.supportsMultilingual)
+    }
+
+    func testProbe_multilingual_falseWhenReadmeMissing() throws {
+        // No README at all and no config-level language array — the probe
+        // must report nothing rather than guessing from `model_type`.
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        { "model_type": "qwen2", "max_position_embeddings": 32768 }
+        """#, to: dir)
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertFalse(caps.supportsMultilingual)
+    }
+
+    func testProbe_multilingual_trueFromConfigLanguageArray() throws {
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        {
+            "model_type": "llama",
+            "language": ["en", "fr"],
+            "max_position_embeddings": 8192
+        }
+        """#, to: dir)
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertTrue(caps.supportsMultilingual)
+    }
+
     func testProbe_throwsWhenConfigIsNotAJSONObject() throws {
         let dir = try makeFixtureDirectory()
         try writeConfig(#"["not", "an", "object"]"#, to: dir)

--- a/Tests/ManifoldInferenceTests/ModelCapabilityProbeTests.swift
+++ b/Tests/ManifoldInferenceTests/ModelCapabilityProbeTests.swift
@@ -340,6 +340,63 @@ final class ModelCapabilityProbeTests: XCTestCase {
         XCTAssertTrue(caps.supportsCodeGeneration)
     }
 
+    func testProbe_codeGeneration_falseForEncoderTag() throws {
+        // Regression: "encoder" contains "code" as a substring but is NOT a
+        // code-generation signal. Whole-token matching must reject it.
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        { "model_type": "bert", "max_position_embeddings": 512 }
+        """#, to: dir)
+        try writeConfig(#"""
+        ---
+        tags:
+          - encoder
+          - feature-extraction
+        pipeline_tag: feature-extraction
+        ---
+        """#, to: dir, named: "README.md")
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertFalse(caps.supportsCodeGeneration)
+    }
+
+    func testProbe_codeGeneration_falseForEncoderDecoderTag() throws {
+        // Regression: "encoder-decoder" tokenizes to ["encoder", "decoder"];
+        // neither is a code-generation token. Must stay false.
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        { "model_type": "t5", "max_position_embeddings": 1024 }
+        """#, to: dir)
+        try writeConfig(#"""
+        ---
+        tags:
+          - encoder-decoder
+        ---
+        """#, to: dir, named: "README.md")
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertFalse(caps.supportsCodeGeneration)
+    }
+
+    func testProbe_codeGeneration_trueForTextToCodePipeline() throws {
+        // Confirms whole-token matching still accepts hyphenated code tags.
+        let dir = try makeFixtureDirectory()
+        try writeConfig(#"""
+        { "model_type": "llama", "max_position_embeddings": 8192 }
+        """#, to: dir)
+        try writeConfig(#"""
+        ---
+        pipeline_tag: text-to-code
+        ---
+        """#, to: dir, named: "README.md")
+
+        let caps = try ModelCapabilityProbe.probe(modelDirectory: dir)
+
+        XCTAssertTrue(caps.supportsCodeGeneration)
+    }
+
     // MARK: - Multilingual inference
 
     func testProbe_multilingual_trueWhenReadmeListsTwoOrMoreLanguages() throws {


### PR DESCRIPTION
## Summary

- Adds `supportsCodeGeneration` and `supportsMultilingual` to `ModelCapabilities` (`Sources/ManifoldInference/Services/ModelCapabilityProbe.swift`).
- `ModelCapabilityProbe.probe(modelDirectory:)` now populates both axes from durable Hugging Face metadata — README.md YAML front-matter (`tags`, `pipeline_tag`, `language`), with optional `config.json` mirrors and an `architectures` `coder`-substring fallback. Display names are deliberately not consulted (they drift).
- Conservative by design: a "decoder"-class architecture does not flip the code flag; a single-language card does not flip the multilingual flag.
- New init parameters default to `false`, so existing call sites (e.g. `BackendVisionCapabilityTests`) keep compiling unchanged.

## Why

Per the issue, every consumer building a model browser ends up re-implementing filename heuristics to badge coder-tuned and multilingual checkpoints. The signal is in MK's existing probe pipeline; codifying the axes here prevents per-app regex drift.

## Heuristics summary

- **Code generation**: `pipeline_tag` containing `code`, OR a `tags` entry containing `code` (README or config), OR an `architectures` class whose lowercased name contains `coder` after stripping `decoder`.
- **Multilingual**: ≥ 2 distinct language codes in README `language` front-matter (block or inline-flow list), OR a `config.json` `language` array of ≥ 2 entries, OR an explicit `multilingual` tag.

## Tests

- 9 new XCTest cases in `Tests/ManifoldInferenceTests/ModelCapabilityProbeTests.swift` covering: plain-LLM defaults, README tag/pipeline detection, architecture fallback, the `decoder` non-match guard, config-level tags, block + inline-flow language lists, single-language negative, explicit `multilingual` tag, README-missing negative, and config-level `language` array.
- Pre-push gates: both CI shapes green locally (XCTest 3213 passed / 17 skipped; Swift Testing 83 passed).

## Test plan

- [x] `scripts/test.sh --filter ManifoldCoreTests ... --disable-default-traits --skip-update`
- [x] `scripts/test.sh --filter ManifoldInferenceSwiftTestingTests --disable-default-traits --skip-update`
- [x] Existing `BackendVisionCapabilityTests` call sites still build with old positional/labeled init form.

Closes #1298