### PR TITLE
feat: add public NetworkActivity observable for HuggingFace traffic

### DIFF
--- a/Sources/ManifoldHuggingFace/BackgroundDownloadManager+URLSessionDelegate.swift
+++ b/Sources/ManifoldHuggingFace/BackgroundDownloadManager+URLSessionDelegate.swift
@@ -32,6 +32,11 @@ extension BackgroundDownloadManager: URLSessionDownloadDelegate {
                     bytesDownloaded: totalBytesWritten,
                     totalBytes: totalBytesExpectedToWrite
                 )
+                self.updateActivityProgress(
+                    modelID: context.modelID,
+                    bytesDownloaded: totalBytesWritten,
+                    totalBytes: totalBytesExpectedToWrite
+                )
             }
         }
     }
@@ -110,6 +115,7 @@ extension BackgroundDownloadManager: URLSessionDownloadDelegate {
 
                     self.activeDownloads[context.modelID]?.markCompleted(localURL: destination)
                     self.removePendingDownload(id: context.modelID)
+                    self.endActivityIfNeeded(modelID: context.modelID)
                 }
                 self.unregisterActiveTempPath(tempURL)
                 self.removeTaskTracking(taskID: taskID, modelID: context.modelID)
@@ -124,6 +130,7 @@ extension BackgroundDownloadManager: URLSessionDownloadDelegate {
                 } else {
                     self.activeDownloads[context.modelID]?.markFailed(error: error.localizedDescription)
                     self.removePendingDownload(id: context.modelID)
+                    self.endActivityIfNeeded(modelID: context.modelID)
                 }
                 self.unregisterActiveTempPath(tempURL)
                 self.removeTaskTracking(taskID: taskID, modelID: context.modelID)
@@ -168,6 +175,7 @@ extension BackgroundDownloadManager: URLSessionDownloadDelegate {
                 // Pending metadata is removed on cancellation — retryDownload is not
                 // offered for cancelled downloads (only .failed shows a Retry button).
                 self.removePendingDownload(id: context.modelID)
+                self.endActivityIfNeeded(modelID: context.modelID)
             } else {
                 // Persist resume data for single-file downloads so retryDownload(id:) can
                 // resume from where the download stopped rather than restarting from scratch.
@@ -188,6 +196,7 @@ extension BackgroundDownloadManager: URLSessionDownloadDelegate {
                     // the model and reach the resume-data path. removePendingDownload is
                     // called only after a successful retry or a fresh-start retry begins.
                     self.activeDownloads[context.modelID]?.markFailed(error: errorDesc)
+                    self.endActivityIfNeeded(modelID: context.modelID)
                 }
             }
             self.removeTaskTracking(taskID: taskID, modelID: context.modelID)

--- a/Sources/ManifoldHuggingFace/BackgroundDownloadManager.swift
+++ b/Sources/ManifoldHuggingFace/BackgroundDownloadManager.swift
@@ -162,6 +162,18 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
     @ObservationIgnored
     private let tempScanDirectory: URL
 
+    /// Activity center used to broadcast in-flight download state. Defaults
+    /// to ``NetworkActivityCenter/shared`` so integrators can bind a single
+    /// observable without threading dependencies through their app graph.
+    @ObservationIgnored
+    private let activityCenter: NetworkActivityCenter
+
+    /// Per-model activity tokens. Issued when `startDownload` accepts a new
+    /// transfer and released the moment the model transitions out of an
+    /// active status (completed / failed / cancelled).
+    @ObservationIgnored
+    private var activityTokens: [String: NetworkActivityToken] = [:]
+
     // MARK: - Init
 
     public init(
@@ -169,10 +181,12 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
         sessionIdentifier: String? = nil,
         persistenceDirectory: URL? = nil,
         tempScanDirectory: URL? = nil,
-        userDefaults: UserDefaults = .standard
+        userDefaults: UserDefaults = .standard,
+        activityCenter: NetworkActivityCenter = .shared
     ) {
         self.storageService = storageService
         self._sessionIdentifier = sessionIdentifier ?? Self.sessionIdentifier
+        self.activityCenter = activityCenter
         let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
             ?? FileManager.default.temporaryDirectory
         let resolvedPersistenceDirectory = persistenceDirectory
@@ -229,6 +243,7 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
 
         let state = DownloadState(model: model)
         activeDownloads[model.id] = state
+        beginActivityIfNeeded(modelID: model.id)
 
         switch plan {
         case .singleFile(let url, let expectedChecksum):
@@ -289,6 +304,7 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
             Log.download.error("Refusing to retry \(id): persisted fileName failed validation: \(error.localizedDescription)")
             activeDownloads[id]?.markFailed(error: "Download metadata is invalid; please re-add the model.")
             removePendingDownload(id: id)
+            endActivityIfNeeded(modelID: id)
             return
         }
 
@@ -306,6 +322,7 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
         // Reset to queued so the UI reflects that a new attempt is underway.
         let state = DownloadState(model: model)
         activeDownloads[model.id] = state
+        beginActivityIfNeeded(modelID: model.id)
 
         let snapshotFiles = decodePendingSnapshotFiles(info["snapshotFiles"], repoID: repoID)
 
@@ -318,6 +335,7 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
             } catch {
                 Log.download.error("Failed to restart snapshot download for \(id): \(error.localizedDescription)")
                 activeDownloads[model.id]?.markFailed(error: error.localizedDescription)
+                endActivityIfNeeded(modelID: model.id)
             }
             return
         }
@@ -374,12 +392,14 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
         guard model.modelType != .mlx || model.packageKind == nil else {
             Log.download.error("Cannot retry snapshot download \(model.id) without persisted package metadata")
             activeDownloads[model.id]?.markFailed(error: "Download metadata is incomplete; please re-add the model.")
+            endActivityIfNeeded(modelID: model.id)
             return
         }
         let url = huggingFaceDownloadURL(repoID: model.repoID, filePath: model.fileName)
         guard url.host == "huggingface.co" else {
             Log.download.error("Failed to build retry URL for \(model.id)")
             activeDownloads[model.id]?.markFailed(error: "Could not construct download URL for retry")
+            endActivityIfNeeded(modelID: model.id)
             return
         }
         do {
@@ -387,6 +407,7 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
         } catch {
             Log.download.error("Failed to start fresh retry download for \(model.id): \(error.localizedDescription)")
             activeDownloads[model.id]?.markFailed(error: error.localizedDescription)
+            endActivityIfNeeded(modelID: model.id)
         }
     }
 
@@ -429,6 +450,7 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
                 }
                 self.activeDownloads[id]?.markCancelled()
                 self.removePendingDownload(id: id)
+                self.endActivityIfNeeded(modelID: id)
                 // Mark the snapshot as cancelling rather than removing it immediately.
                 // URLSession delegate callbacks can still arrive after task.cancel() is
                 // called; deferring cleanup here prevents a cancelled download from
@@ -715,6 +737,11 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
             bytesDownloaded: totalDownloaded,
             totalBytes: totalExpected
         )
+        updateActivityProgress(
+            modelID: modelID,
+            bytesDownloaded: totalDownloaded,
+            totalBytes: totalExpected
+        )
     }
 
     @MainActor
@@ -806,6 +833,7 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
         activeDownloads[modelID]?.markCompleted(localURL: finalURL)
         removePendingDownload(id: modelID)
         snapshotDownloads.removeValue(forKey: modelID)
+        endActivityIfNeeded(modelID: modelID)
     }
 
     // internal: required by BackgroundDownloadManager+URLSessionDelegate.swift
@@ -816,6 +844,7 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
                 return
             }
             activeDownloads[modelID]?.markFailed(error: error)
+            endActivityIfNeeded(modelID: modelID)
             return
         }
 
@@ -833,6 +862,7 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
         }
 
         activeDownloads[modelID]?.markFailed(error: error)
+        endActivityIfNeeded(modelID: modelID)
         snapshotDownloads.removeValue(forKey: modelID)
         do {
             try FileManager.default.removeItem(at: snapshot.stagingDirectory)
@@ -975,6 +1005,43 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
 
     @MainActor internal func consumeResumeData(for id: String) -> Data? {
         pendingStore.consumeResumeData(for: id)
+    }
+
+    // MARK: - NetworkActivityCenter integration
+
+    /// Issues an activity token for `modelID` if one isn't already in flight.
+    /// Idempotent so retries / snapshot fan-out don't double-register.
+    @MainActor
+    internal func beginActivityIfNeeded(modelID: String) {
+        guard activityTokens[modelID] == nil else { return }
+        activityTokens[modelID] = activityCenter.begin(
+            kind: .download(modelID: modelID),
+            host: "huggingface.co"
+        )
+    }
+
+    /// Closes the activity token for `modelID` if one is outstanding. Safe
+    /// to call from every mark-* terminal state — extra calls are no-ops.
+    @MainActor
+    internal func endActivityIfNeeded(modelID: String) {
+        guard let token = activityTokens.removeValue(forKey: modelID) else { return }
+        activityCenter.end(token)
+    }
+
+    /// Forwards progress to the activity center so the public observable
+    /// reports rich download bytes / throughput, not just "data flowing".
+    @MainActor
+    internal func updateActivityProgress(
+        modelID: String,
+        bytesDownloaded: Int64,
+        totalBytes: Int64
+    ) {
+        guard let token = activityTokens[modelID] else { return }
+        activityCenter.updateDownload(
+            token,
+            bytesReceived: bytesDownloaded,
+            totalBytes: totalBytes > 0 ? totalBytes : nil
+        )
     }
 
     internal func migrateFromUserDefaults() {

--- a/Sources/ManifoldHuggingFace/HuggingFaceService.swift
+++ b/Sources/ManifoldHuggingFace/HuggingFaceService.swift
@@ -7,13 +7,42 @@ import os
 /// Concrete `HuggingFaceServiceProtocol` backed by the `swift-huggingface` SDK.
 public final class HuggingFaceService: HuggingFaceServiceProtocol {
     private let hubClient: HubClient
+    private let activityCenter: NetworkActivityCenter
 
     /// Creates a service backed by the given Hugging Face Hub client.
     ///
-    /// - Parameter hubClient: The Hub client used for API requests and repo operations.
-    ///   Defaults to `.default`, which uses the shared Hub configuration.
-    public init(hubClient: HubClient = .default) {
+    /// - Parameters:
+    ///   - hubClient: The Hub client used for API requests and repo operations.
+    ///     Defaults to `.default`, which uses the shared Hub configuration.
+    ///   - activityCenter: Center to notify on metadata fetch start/end so the
+    ///     framework-wide network indicator reflects HF traffic even when the
+    ///     SDK bypasses ``URLSessionFactory``. Defaults to ``NetworkActivityCenter/shared``.
+    public init(
+        hubClient: HubClient = .default,
+        activityCenter: NetworkActivityCenter = .shared
+    ) {
         self.hubClient = hubClient
+        self.activityCenter = activityCenter
+    }
+
+    /// Wraps a `hubClient.*` call with begin/end on the activity center so
+    /// consumer observers see metadata fetches alongside downloads.
+    ///
+    /// Hops to `@MainActor` for both the begin and the end — the center is
+    /// `@MainActor`-isolated and SDK calls happen on whatever context the
+    /// caller is on.
+    private func trackingMetadataFetch<T>(
+        host: String = "huggingface.co",
+        _ body: () async throws -> T
+    ) async rethrows -> T {
+        let center = activityCenter
+        let token = await MainActor.run { center.begin(kind: .metadata, host: host) }
+        defer {
+            // `Task { @MainActor }` is fire-and-forget — token release does
+            // not need to block the caller's return.
+            Task { @MainActor in center.end(token) }
+        }
+        return try await body()
     }
 
     public func searchModels(query: String, limit: Int = 40) async throws -> [DownloadableModel] {
@@ -21,14 +50,16 @@ public final class HuggingFaceService: HuggingFaceServiceProtocol {
 
         let response: PaginatedResponse<Model>
         do {
-            response = try await hubClient.listModels(
-                search: query,
-                sort: "downloads",
-                direction: .descending,
-                limit: limit,
-                full: true,
-                pipelineTag: "text-generation"
-            )
+            response = try await trackingMetadataFetch {
+                try await hubClient.listModels(
+                    search: query,
+                    sort: "downloads",
+                    direction: .descending,
+                    limit: limit,
+                    full: true,
+                    pipelineTag: "text-generation"
+                )
+            }
         } catch {
             Log.network.error("HuggingFace search failed: \(error.localizedDescription)")
             throw HuggingFaceError.searchFailed(underlying: error)
@@ -41,11 +72,13 @@ public final class HuggingFaceService: HuggingFaceServiceProtocol {
             for model in downloadableRepos {
                 group.addTask {
                     do {
-                        let detailed = try await self.hubClient.getModel(
-                            model.id,
-                            full: true,
-                            filesMetadata: true
-                        )
+                        let detailed = try await self.trackingMetadataFetch {
+                            try await self.hubClient.getModel(
+                                model.id,
+                                full: true,
+                                filesMetadata: true
+                            )
+                        }
                         return self.convertModelToDownloadables(detailed)
                     } catch {
                         Log.network.warning("Failed to fetch details for \(model.id): \(error)")
@@ -77,11 +110,13 @@ public final class HuggingFaceService: HuggingFaceServiceProtocol {
 
         let model: Model
         do {
-            model = try await hubClient.getModel(
-                repoIdentifier,
-                full: true,
-                filesMetadata: true
-            )
+            model = try await trackingMetadataFetch {
+                try await hubClient.getModel(
+                    repoIdentifier,
+                    full: true,
+                    filesMetadata: true
+                )
+            }
         } catch {
             Log.network.error("Failed to fetch model \(repoID): \(error.localizedDescription)")
             throw HuggingFaceError.modelNotFound(repoID: repoID)
@@ -108,11 +143,13 @@ public final class HuggingFaceService: HuggingFaceServiceProtocol {
             }
             let detailed: Model
             do {
-                detailed = try await hubClient.getModel(
-                    repoIdentifier,
-                    full: true,
-                    filesMetadata: true
-                )
+                detailed = try await trackingMetadataFetch {
+                    try await hubClient.getModel(
+                        repoIdentifier,
+                        full: true,
+                        filesMetadata: true
+                    )
+                }
             } catch {
                 Log.network.error("Failed to fetch MLX snapshot for \(model.repoID): \(error.localizedDescription)")
                 throw HuggingFaceError.modelNotFound(repoID: model.repoID)

--- a/Sources/ManifoldInference/Networking/CompositeURLSessionDelegate.swift
+++ b/Sources/ManifoldInference/Networking/CompositeURLSessionDelegate.swift
@@ -53,16 +53,27 @@ public final class CompositeURLSessionDelegate: NSObject, @unchecked Sendable {
     /// ``downloadDelegate`` but for non-download data tasks.
     public weak var dataDelegate: URLSessionDataDelegate?
 
+    /// Strong reference for delegates the factory creates itself (e.g.
+    /// ``NetworkActivityTrackingDelegate``). External callers continue to
+    /// pass their own delegate via ``dataDelegate`` and own its lifetime.
+    /// The factory wires the same instance into both slots so forwarding
+    /// works through the existing `dataDelegate` plumbing.
+    private let ownedDataDelegate: URLSessionDataDelegate?
+
     public init(
         redirectGuard: RedirectGuardDelegate,
         serverTrustHandler: URLSessionDelegate? = nil,
         downloadDelegate: URLSessionDownloadDelegate? = nil,
-        dataDelegate: URLSessionDataDelegate? = nil
+        dataDelegate: URLSessionDataDelegate? = nil,
+        ownedDataDelegate: URLSessionDataDelegate? = nil
     ) {
         self.redirectGuard = redirectGuard
         self.serverTrustHandler = serverTrustHandler
         self.downloadDelegate = downloadDelegate
-        self.dataDelegate = dataDelegate
+        // Prefer the owned delegate when both are supplied: it sits on top
+        // of the caller's delegate (which it forwards to internally).
+        self.ownedDataDelegate = ownedDataDelegate
+        self.dataDelegate = ownedDataDelegate ?? dataDelegate
     }
 }
 

--- a/Sources/ManifoldInference/Networking/NetworkActivityCenter.swift
+++ b/Sources/ManifoldInference/Networking/NetworkActivityCenter.swift
@@ -94,11 +94,12 @@ public struct NetworkActivityToken: Sendable, Hashable {
 /// ## Funnel points
 ///
 /// - ``URLSessionFactory/ephemeral(hopCap:resourceTimeout:additionalDataDelegate:activityCenter:)``
-///   and ``URLSessionFactory/background(identifier:hopCap:additionalDownloadDelegate:activityCenter:)``
-///   wire a tracking delegate that emits begin/end for every data + download
-///   task that flows through the factory.
-/// - `BackgroundDownloadManager` (in `ManifoldHuggingFace`) overrides the
-///   delegate-driven entries with rich per-model download state.
+///   wires a tracking delegate that emits begin/end for every data task
+///   that flows through the factory.
+/// - `BackgroundDownloadManager` (in `ManifoldHuggingFace`) bypasses the
+///   ephemeral data-tracker and posts rich per-model `.downloading` state
+///   directly — its own background `URLSession` already carries the
+///   per-task state needed for bytes/total/throughput.
 /// - `HuggingFaceService` wraps SDK calls that bypass `URLSessionFactory`.
 ///
 /// ## Concurrency
@@ -116,7 +117,7 @@ public final class NetworkActivityCenter {
     /// The reference itself is immutable, so non-isolated callers can read
     /// `.shared` to pass into a factory; every *method* on the returned
     /// instance remains `@MainActor`-isolated.
-    public nonisolated(unsafe) static let shared = NetworkActivityCenter()
+    public nonisolated static let shared = NetworkActivityCenter()
 
     /// Current coalesced activity. ``NetworkActivity/idle`` when no requests
     /// are in flight. When several tasks are active, downloads win over

--- a/Sources/ManifoldInference/Networking/NetworkActivityCenter.swift
+++ b/Sources/ManifoldInference/Networking/NetworkActivityCenter.swift
@@ -1,0 +1,289 @@
+import Foundation
+import Observation
+import os
+
+/// Public, framework-owned summary of in-flight network activity.
+///
+/// Consumer apps that surface a "is ManifoldKit talking to the network right
+/// now?" indicator (status pill, trust sheet, settings light) bind to
+/// ``NetworkActivityCenter/shared`` instead of building a parallel observer
+/// that drifts away from MK's actual networking the moment a new code path
+/// (manifest fetch, resume probe, HEAD check) is added inside MK.
+///
+/// The center is a strict superset of `BackgroundDownloadManager.activeDownloads`:
+/// it also reports HuggingFace metadata fetches, redirect / probe traffic, and
+/// any future generic data-task that flows through ``URLSessionFactory``.
+public enum NetworkActivity: Sendable, Equatable {
+
+    /// No active network traffic.
+    case idle
+
+    /// A short-lived probe / HEAD-check is in flight.
+    case probing(host: String)
+
+    /// A model download is making progress.
+    ///
+    /// - Parameters:
+    ///   - modelID: The owning ``DownloadableModel/id``.
+    ///   - bytesReceived: Bytes transferred so far across all files in the
+    ///     download.
+    ///   - totalBytes: Total expected bytes when the manifest is known;
+    ///     `nil` while the server hasn't reported a `Content-Length`.
+    ///   - throughputBytesPerSecond: Rolling mean throughput over the last
+    ///     measurement window.
+    case downloading(
+        modelID: String,
+        bytesReceived: Int64,
+        totalBytes: Int64?,
+        throughputBytesPerSecond: Double
+    )
+
+    /// A metadata-style fetch (search, repo listing, manifest read) is in
+    /// flight against `host`.
+    case fetchingMetadata(host: String)
+}
+
+/// Classifier for a single in-flight unit of network work.
+///
+/// Promoted to the public surface so external consumers (CLI tools, alternate
+/// download orchestrators) that need to plug into the center can describe
+/// their traffic without reaching into MK internals.
+public enum NetworkActivityKind: Sendable, Equatable {
+    case probe
+    case metadata
+    case download(modelID: String)
+    case generic
+}
+
+/// Opaque handle returned by ``NetworkActivityCenter/begin(kind:host:)``.
+///
+/// Callers retain the token for the lifetime of the request and pass it to
+/// ``NetworkActivityCenter/end(_:)`` (or `updateDownload`) so the center can
+/// distinguish overlapping calls. The token is intentionally `Sendable` and
+/// value-typed so it can cross actor boundaries without ceremony.
+public struct NetworkActivityToken: Sendable, Hashable {
+    internal let id: UUID
+    internal init(id: UUID = UUID()) {
+        self.id = id
+    }
+}
+
+/// `@Observable @MainActor` source of truth for live network activity.
+///
+/// Bind from SwiftUI via the shared singleton:
+///
+/// ```swift
+/// import ManifoldInference
+///
+/// struct NetworkPill: View {
+///     @State private var center = NetworkActivityCenter.shared
+///     var body: some View {
+///         switch center.current {
+///         case .idle:                       EmptyView()
+///         case .probing(let host):          Label("Probing \(host)", systemImage: "antenna.radiowaves.left.and.right")
+///         case .downloading(_, let got, let total, _):
+///             ProgressView(value: Double(got), total: Double(total ?? got))
+///         case .fetchingMetadata(let host): Label("Fetching from \(host)", systemImage: "icloud.and.arrow.down")
+///         }
+///     }
+/// }
+/// ```
+///
+/// Non-SwiftUI consumers can drive a stream via ``updates()``.
+///
+/// ## Funnel points
+///
+/// - ``URLSessionFactory/ephemeral(hopCap:resourceTimeout:additionalDataDelegate:activityCenter:)``
+///   and ``URLSessionFactory/background(identifier:hopCap:additionalDownloadDelegate:activityCenter:)``
+///   wire a tracking delegate that emits begin/end for every data + download
+///   task that flows through the factory.
+/// - `BackgroundDownloadManager` (in `ManifoldHuggingFace`) overrides the
+///   delegate-driven entries with rich per-model download state.
+/// - `HuggingFaceService` wraps SDK calls that bypass `URLSessionFactory`.
+///
+/// ## Concurrency
+///
+/// State is `@MainActor`-isolated. Off-actor callers (URLSession delegate
+/// queue, SDK callbacks) hop in via `Task { @MainActor in ... }`. The center
+/// itself never touches the network — it is a passive aggregator.
+@Observable
+@MainActor
+public final class NetworkActivityCenter {
+
+    /// Shared process-wide instance. ``URLSessionFactory`` and
+    /// `BackgroundDownloadManager` route activity here by default.
+    ///
+    /// The reference itself is immutable, so non-isolated callers can read
+    /// `.shared` to pass into a factory; every *method* on the returned
+    /// instance remains `@MainActor`-isolated.
+    public nonisolated(unsafe) static let shared = NetworkActivityCenter()
+
+    /// Current coalesced activity. ``NetworkActivity/idle`` when no requests
+    /// are in flight. When several tasks are active, downloads win over
+    /// metadata, which wins over probes — the integrator's status indicator
+    /// should reflect the most user-visible work first.
+    public private(set) var current: NetworkActivity = .idle
+
+    /// Number of in-flight requests across all kinds.
+    public var inFlightCount: Int { entries.count }
+
+    /// Distinct hostnames currently in flight, sorted for stable rendering.
+    public var activeHosts: [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for entry in entries.values where !entry.host.isEmpty {
+            if seen.insert(entry.host).inserted {
+                result.append(entry.host)
+            }
+        }
+        return result.sorted()
+    }
+
+    private struct Entry {
+        let kind: NetworkActivityKind
+        let host: String
+        var bytesReceived: Int64
+        var totalBytes: Int64?
+        var throughput: Double
+        var lastSampleAt: Date
+        var lastSampleBytes: Int64
+    }
+
+    private var entries: [UUID: Entry] = [:]
+
+    /// Continuations for ``updates()``. Stored in a dictionary so each
+    /// subscriber can clean up independently when its `Task` is cancelled.
+    private var subscribers: [UUID: AsyncStream<NetworkActivity>.Continuation] = [:]
+
+    /// Designated initialiser. Public so test suites can spin up isolated
+    /// centers without relying on the shared singleton.
+    ///
+    /// Marked `nonisolated` so the `static let shared` initialiser can run
+    /// at process start without hopping to `@MainActor`. All mutation API
+    /// on the resulting instance remains `@MainActor`-isolated.
+    public nonisolated init() {}
+
+    // MARK: - Tracking API
+
+    /// Records the start of a new in-flight request and returns a token to
+    /// pair with ``end(_:)``.
+    @discardableResult
+    public func begin(kind: NetworkActivityKind, host: String) -> NetworkActivityToken {
+        let token = NetworkActivityToken()
+        entries[token.id] = Entry(
+            kind: kind,
+            host: host,
+            bytesReceived: 0,
+            totalBytes: nil,
+            throughput: 0,
+            lastSampleAt: Date(),
+            lastSampleBytes: 0
+        )
+        recomputeCurrent()
+        return token
+    }
+
+    /// Records the end of a previously-begun request. Safe to call with a
+    /// stale token — unknown tokens are ignored, which makes
+    /// "begin from delegate / end from cancel" races a no-op rather than a
+    /// crash.
+    public func end(_ token: NetworkActivityToken) {
+        guard entries.removeValue(forKey: token.id) != nil else { return }
+        recomputeCurrent()
+    }
+
+    /// Updates byte counters for a download token and refreshes throughput.
+    public func updateDownload(
+        _ token: NetworkActivityToken,
+        bytesReceived: Int64,
+        totalBytes: Int64?
+    ) {
+        guard var entry = entries[token.id] else { return }
+        let now = Date()
+        let elapsed = now.timeIntervalSince(entry.lastSampleAt)
+        // Throughput is sampled on every progress callback. Skip the divide
+        // when elapsed time is below 50ms — the resulting figure would be
+        // dominated by jitter from the URLSession delegate queue cadence.
+        if elapsed >= 0.05 {
+            let delta = max(0, bytesReceived - entry.lastSampleBytes)
+            entry.throughput = Double(delta) / elapsed
+            entry.lastSampleAt = now
+            entry.lastSampleBytes = bytesReceived
+        }
+        entry.bytesReceived = bytesReceived
+        entry.totalBytes = totalBytes
+        entries[token.id] = entry
+        recomputeCurrent()
+    }
+
+    // MARK: - Subscriber API
+
+    /// Async stream of state transitions. Emits the current state once on
+    /// subscribe so late observers don't miss in-flight activity.
+    public func updates() -> AsyncStream<NetworkActivity> {
+        AsyncStream { continuation in
+            let id = UUID()
+            subscribers[id] = continuation
+            continuation.yield(current)
+            continuation.onTermination = { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.subscribers.removeValue(forKey: id)
+                }
+            }
+        }
+    }
+
+    // MARK: - Internals
+
+    private func recomputeCurrent() {
+        let next = computeCurrent()
+        guard next != current else { return }
+        current = next
+        for continuation in subscribers.values {
+            continuation.yield(next)
+        }
+    }
+
+    private func computeCurrent() -> NetworkActivity {
+        if entries.isEmpty { return .idle }
+
+        // Prefer the most user-visible in-flight work: an active download
+        // dominates a metadata fetch dominates a probe. Within downloads we
+        // pick the entry with the highest `bytesReceived` so the indicator
+        // tracks the largest live transfer.
+        var bestDownload: Entry?
+        var bestMetadata: Entry?
+        var bestProbe: Entry?
+        for entry in entries.values {
+            switch entry.kind {
+            case .download:
+                if bestDownload == nil || entry.bytesReceived > (bestDownload?.bytesReceived ?? -1) {
+                    bestDownload = entry
+                }
+            case .metadata:
+                bestMetadata = bestMetadata ?? entry
+            case .probe:
+                bestProbe = bestProbe ?? entry
+            case .generic:
+                // Generic data traffic shows up as a metadata-style hint —
+                // hosts are still meaningful for a trust UI.
+                bestMetadata = bestMetadata ?? entry
+            }
+        }
+        if let download = bestDownload, case .download(let modelID) = download.kind {
+            return .downloading(
+                modelID: modelID,
+                bytesReceived: download.bytesReceived,
+                totalBytes: download.totalBytes,
+                throughputBytesPerSecond: download.throughput
+            )
+        }
+        if let metadata = bestMetadata {
+            return .fetchingMetadata(host: metadata.host)
+        }
+        if let probe = bestProbe {
+            return .probing(host: probe.host)
+        }
+        return .idle
+    }
+}

--- a/Sources/ManifoldInference/Networking/NetworkActivityTrackingDelegate.swift
+++ b/Sources/ManifoldInference/Networking/NetworkActivityTrackingDelegate.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// `URLSessionDataDelegate` that reports request lifecycle to
+/// ``NetworkActivityCenter``.
+///
+/// Wired into the data-delegate slot of ``CompositeURLSessionDelegate`` by
+/// ``URLSessionFactory/ephemeral(hopCap:resourceTimeout:additionalDataDelegate:activityCenter:)``.
+/// Begin events fire when the server delivers either the first headers
+/// (`didReceive response:`) or the first body byte (`didReceive data:`),
+/// whichever arrives first — both are guaranteed to precede
+/// `didCompleteWithError`, which fires end.
+///
+/// ## Why first response, not task creation
+///
+/// `URLSession` exposes no "task is about to start" delegate callback. Hooking
+/// from the caller (right before `task.resume()`) would catch creation but
+/// duplicate the responsibility across every call site. Reporting on first
+/// response keeps the funnel inside the session delegate where the redirect
+/// guard already lives, so any future production caller is covered for free.
+///
+/// ## Forwarding
+///
+/// All callbacks are forwarded to ``downstream`` so the caller-supplied
+/// data delegate (e.g. an SSE consumer) still sees them. This delegate is
+/// purely additive.
+final class NetworkActivityTrackingDelegate: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+
+    /// Center to notify. Defaults to ``NetworkActivityCenter/shared``.
+    private let center: NetworkActivityCenter
+
+    /// Optional caller-supplied data delegate. Forwarded after the tracking
+    /// hook fires.
+    weak var downstream: URLSessionDataDelegate?
+
+    /// Maps `URLSessionTask.taskIdentifier` to the activity token issued for
+    /// that task. Reads/writes are serialised on ``lock`` — URLSession may
+    /// deliver delegate callbacks on its own queue, off the main actor.
+    private let lock = NSLock()
+    private var tokens: [Int: NetworkActivityToken] = [:]
+
+    init(center: NetworkActivityCenter, downstream: URLSessionDataDelegate? = nil) {
+        self.center = center
+        self.downstream = downstream
+    }
+
+    // MARK: - URLSessionDataDelegate
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        ensureBegin(for: dataTask)
+        if let downstream {
+            downstream.urlSession?(
+                session,
+                dataTask: dataTask,
+                didReceive: response,
+                completionHandler: completionHandler
+            )
+        } else {
+            completionHandler(.allow)
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive data: Data
+    ) {
+        ensureBegin(for: dataTask)
+        downstream?.urlSession?(session, dataTask: dataTask, didReceive: data)
+    }
+
+    // MARK: - URLSessionTaskDelegate (forwarded via Composite)
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        endIfActive(for: task)
+        downstream?.urlSession?(session, task: task, didCompleteWithError: error)
+    }
+
+    // MARK: - Helpers
+
+    private func ensureBegin(for task: URLSessionTask) {
+        lock.lock()
+        if tokens[task.taskIdentifier] != nil {
+            lock.unlock()
+            return
+        }
+        let host = task.originalRequest?.url?.host ?? ""
+        // Place a sentinel in the map *before* hopping to the main actor so a
+        // late callback on the same task cannot double-begin while the hop is
+        // queued. The real token replaces the sentinel below.
+        let placeholder = NetworkActivityToken()
+        tokens[task.taskIdentifier] = placeholder
+        lock.unlock()
+        let center = self.center
+        Task { @MainActor in
+            // `.generic` keeps the call site honest: the tracking delegate
+            // doesn't know whether a given task is a probe, a manifest fetch,
+            // or generic SSE traffic. Callers that need precise kinds invoke
+            // `NetworkActivityCenter.begin(kind:host:)` directly.
+            let realToken = center.begin(kind: .generic, host: host)
+            self.replaceToken(at: task.taskIdentifier, with: realToken, placeholder: placeholder)
+        }
+    }
+
+    private func replaceToken(
+        at taskID: Int,
+        with token: NetworkActivityToken,
+        placeholder: NetworkActivityToken
+    ) {
+        lock.lock()
+        // Only swap when the placeholder is still in place. If endIfActive
+        // already removed the slot the request finished before our hop landed
+        // — close the just-issued token immediately so the center doesn't
+        // leak a phantom in-flight entry.
+        if tokens[taskID] == placeholder {
+            tokens[taskID] = token
+            lock.unlock()
+        } else {
+            lock.unlock()
+            Task { @MainActor in
+                self.center.end(token)
+            }
+        }
+    }
+
+    private func endIfActive(for task: URLSessionTask) {
+        lock.lock()
+        let token = tokens.removeValue(forKey: task.taskIdentifier)
+        lock.unlock()
+        guard let token else { return }
+        let center = self.center
+        Task { @MainActor in
+            center.end(token)
+        }
+    }
+}

--- a/Sources/ManifoldInference/Networking/URLSessionFactory.swift
+++ b/Sources/ManifoldInference/Networking/URLSessionFactory.swift
@@ -47,17 +47,28 @@ public enum URLSessionFactory {
     public static func ephemeral(
         hopCap: Int = 3,
         resourceTimeout: TimeInterval = defaultResourceTimeout,
-        additionalDataDelegate: URLSessionDataDelegate? = nil
+        additionalDataDelegate: URLSessionDataDelegate? = nil,
+        activityCenter: NetworkActivityCenter? = NetworkActivityCenter.shared
     ) -> URLSession {
         let config = URLSessionConfiguration.ephemeral
         config.timeoutIntervalForRequest = defaultRequestTimeout
         config.timeoutIntervalForResource = resourceTimeout
         config.tlsMinimumSupportedProtocolVersion = .TLSv12
+        // Slot the tracking delegate ahead of the caller's data delegate so
+        // every request emits begin/end to the shared activity center. When
+        // `activityCenter` is nil (tests that want to assert *no* tracking)
+        // we skip the wrapper entirely. The tracker is stashed in
+        // ``CompositeURLSessionDelegate/ownedDataDelegate`` so it survives
+        // past `additionalDataDelegate`'s weak reference.
+        let tracker: NetworkActivityTrackingDelegate? = activityCenter.map { center in
+            NetworkActivityTrackingDelegate(center: center, downstream: additionalDataDelegate)
+        }
         let composite = CompositeURLSessionDelegate(
             redirectGuard: RedirectGuardDelegate(hopCap: hopCap),
             serverTrustHandler: nil,
             downloadDelegate: nil,
-            dataDelegate: additionalDataDelegate
+            dataDelegate: tracker == nil ? additionalDataDelegate : nil,
+            ownedDataDelegate: tracker
         )
         return URLSession(configuration: config, delegate: composite, delegateQueue: nil)
     }

--- a/Tests/ManifoldInferenceTests/NetworkActivityCenterTests.swift
+++ b/Tests/ManifoldInferenceTests/NetworkActivityCenterTests.swift
@@ -30,7 +30,7 @@ final class NetworkActivityCenterTests: XCTestCase {
             redirectGuard: RedirectGuardDelegate(hopCap: 3),
             serverTrustHandler: nil,
             downloadDelegate: nil,
-            dataDelegate: tracker == nil ? nil : nil,
+            dataDelegate: nil,
             ownedDataDelegate: tracker
         )
         return URLSession(configuration: config, delegate: composite, delegateQueue: nil)

--- a/Tests/ManifoldInferenceTests/NetworkActivityCenterTests.swift
+++ b/Tests/ManifoldInferenceTests/NetworkActivityCenterTests.swift
@@ -1,0 +1,198 @@
+import XCTest
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+/// Unit coverage for ``NetworkActivityCenter`` and the
+/// ``URLSessionFactory`` wiring that funnels in-flight requests into it.
+///
+/// Every test instantiates its own `NetworkActivityCenter` so observations
+/// cannot leak between tests under `swift test --parallel`. Stubs use a
+/// UUID-based hostname per test so they cannot cross-contaminate other
+/// suites (`MockURLProtocol.reset()` is process-wide — never called).
+@MainActor
+final class NetworkActivityCenterTests: XCTestCase {
+
+    private func uniqueURL(prefix: String = "net-act") -> URL {
+        URL(string: "https://\(prefix)-\(UUID().uuidString).test/path")!
+    }
+
+    private func makeStubbedSession(activityCenter: NetworkActivityCenter?) -> URLSession {
+        // We can't use `URLSessionFactory.ephemeral` directly because we need
+        // `MockURLProtocol` in the config — the factory's session won't see
+        // the stub. Instead we install the tracking delegate manually via a
+        // composite, mirroring what the factory builds internally.
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self] + (config.protocolClasses ?? [])
+        let tracker: NetworkActivityTrackingDelegate? = activityCenter.map {
+            NetworkActivityTrackingDelegate(center: $0)
+        }
+        let composite = CompositeURLSessionDelegate(
+            redirectGuard: RedirectGuardDelegate(hopCap: 3),
+            serverTrustHandler: nil,
+            downloadDelegate: nil,
+            dataDelegate: tracker == nil ? nil : nil,
+            ownedDataDelegate: tracker
+        )
+        return URLSession(configuration: config, delegate: composite, delegateQueue: nil)
+    }
+
+    // MARK: - Direct API
+
+    func test_idle_when_no_requests() {
+        let center = NetworkActivityCenter()
+        XCTAssertEqual(center.current, .idle)
+        XCTAssertEqual(center.inFlightCount, 0)
+        XCTAssertTrue(center.activeHosts.isEmpty)
+    }
+
+    func test_begin_and_end_round_trip() {
+        let center = NetworkActivityCenter()
+        let token = center.begin(kind: .metadata, host: "huggingface.co")
+        XCTAssertEqual(center.inFlightCount, 1)
+        XCTAssertEqual(center.activeHosts, ["huggingface.co"])
+        XCTAssertEqual(center.current, .fetchingMetadata(host: "huggingface.co"))
+        center.end(token)
+        XCTAssertEqual(center.current, .idle)
+        XCTAssertEqual(center.inFlightCount, 0)
+    }
+
+    func test_download_dominates_metadata_in_summary() {
+        let center = NetworkActivityCenter()
+        let probeToken = center.begin(kind: .probe, host: "probe.test")
+        let metaToken = center.begin(kind: .metadata, host: "meta.test")
+        let downloadToken = center.begin(
+            kind: .download(modelID: "vendor/model"),
+            host: "huggingface.co"
+        )
+        // Drive the download token forward so `bytesReceived` is non-zero.
+        center.updateDownload(downloadToken, bytesReceived: 1024, totalBytes: 4096)
+
+        guard case let .downloading(modelID, bytes, total, _) = center.current else {
+            XCTFail("expected .downloading, got \(center.current)")
+            return
+        }
+        XCTAssertEqual(modelID, "vendor/model")
+        XCTAssertEqual(bytes, 1024)
+        XCTAssertEqual(total, 4096)
+        XCTAssertEqual(center.inFlightCount, 3)
+        XCTAssertEqual(center.activeHosts.sorted(), ["huggingface.co", "meta.test", "probe.test"])
+
+        center.end(downloadToken)
+        XCTAssertEqual(center.current, .fetchingMetadata(host: "meta.test"))
+        center.end(metaToken)
+        XCTAssertEqual(center.current, .probing(host: "probe.test"))
+        center.end(probeToken)
+        XCTAssertEqual(center.current, .idle)
+    }
+
+    func test_end_is_idempotent_for_stale_token() {
+        let center = NetworkActivityCenter()
+        let token = center.begin(kind: .probe, host: "host.test")
+        center.end(token)
+        // Second call must not crash and must not flip current.
+        center.end(token)
+        XCTAssertEqual(center.current, .idle)
+    }
+
+    // MARK: - URLSession wiring
+
+    func test_session_traffic_increments_then_decrements_on_success() async throws {
+        let center = NetworkActivityCenter()
+        let url = uniqueURL()
+        MockURLProtocol.stub(
+            url: url,
+            response: .immediate(data: Data("{}".utf8), statusCode: 200)
+        )
+        defer { MockURLProtocol.unstub(url: url) }
+
+        let session = makeStubbedSession(activityCenter: center)
+        defer { session.invalidateAndCancel() }
+
+        let (_, _) = try await session.data(from: url)
+
+        // The tracker hops to MainActor; give it one runloop tick to drain.
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(center.inFlightCount, 0)
+        XCTAssertEqual(center.current, .idle)
+    }
+
+    func test_session_traffic_decrements_on_network_error() async {
+        let center = NetworkActivityCenter()
+        let url = uniqueURL()
+        MockURLProtocol.stub(
+            url: url,
+            response: .error(URLError(.notConnectedToInternet))
+        )
+        defer { MockURLProtocol.unstub(url: url) }
+
+        let session = makeStubbedSession(activityCenter: center)
+        defer { session.invalidateAndCancel() }
+
+        do {
+            _ = try await session.data(from: url)
+            XCTFail("expected the stub to surface a URLError")
+        } catch {
+            // Expected — we asserted on the *side-effect* below.
+        }
+
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(center.inFlightCount, 0)
+        XCTAssertEqual(center.current, .idle)
+    }
+
+    func test_session_decrements_on_cancel() async {
+        let center = NetworkActivityCenter()
+        let url = uniqueURL()
+        // 5-second delay so the cancel beats the response.
+        MockURLProtocol.stub(
+            url: url,
+            response: .delayedFirstByte(
+                data: Data("{}".utf8),
+                firstByteDelay: 5,
+                statusCode: 200
+            )
+        )
+        defer { MockURLProtocol.unstub(url: url) }
+
+        let session = makeStubbedSession(activityCenter: center)
+        defer { session.invalidateAndCancel() }
+
+        let task = Task { try await session.data(from: url) }
+        // Let the request start, then cancel.
+        try? await Task.sleep(nanoseconds: 30_000_000)
+        task.cancel()
+        _ = try? await task.value
+
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertEqual(center.inFlightCount, 0)
+        XCTAssertEqual(center.current, .idle)
+    }
+
+    // MARK: - Async subscriber
+
+    func test_updates_stream_emits_initial_state() async {
+        let center = NetworkActivityCenter()
+        let stream = center.updates()
+
+        var iterator = stream.makeAsyncIterator()
+        let first = await iterator.next()
+        XCTAssertEqual(first, .idle)
+    }
+
+    func test_updates_stream_emits_transitions() async {
+        let center = NetworkActivityCenter()
+        let stream = center.updates()
+        var iterator = stream.makeAsyncIterator()
+        // Drain initial idle.
+        _ = await iterator.next()
+
+        let token = center.begin(kind: .metadata, host: "transitions.test")
+        let next = await iterator.next()
+        XCTAssertEqual(next, .fetchingMetadata(host: "transitions.test"))
+
+        center.end(token)
+        let final = await iterator.next()
+        XCTAssertEqual(final, .idle)
+    }
+}

--- a/Tests/ManifoldInferenceTests/TrafficBoundaryAuditTest.swift
+++ b/Tests/ManifoldInferenceTests/TrafficBoundaryAuditTest.swift
@@ -152,6 +152,11 @@ final class TrafficBoundaryAuditTest: XCTestCase {
         "ManifoldInference/Networking/RedirectGuardDelegate.swift",
         "ManifoldInference/Networking/CompositeURLSessionDelegate.swift",
         "ManifoldInference/Networking/URLSessionFactory.swift",
+        // NetworkActivity observable funnel (#1292) — implements
+        // URLSessionDataDelegate so it can record begin/end of every task
+        // that flows through `URLSessionFactory.ephemeral`. No new outbound
+        // calls; this file only *observes* the existing seam.
+        "ManifoldInference/Networking/NetworkActivityTrackingDelegate.swift",
 
         // HuggingFace reachability probe (#1296). Single `GET` to
         // `https://huggingface.co/api/models?limit=1` routed through
@@ -308,7 +313,7 @@ final class TrafficBoundaryAuditTest: XCTestCase {
         Self.assertNoOffenders(offenders)
 
         XCTAssertLessThanOrEqual(
-            Self.networkIOAllowlist.count, 41,
+            Self.networkIOAllowlist.count, 42,
             "networkIOAllowlist exceeds cap. Each new entry weakens the rule — re-architect rather than expand the list."
         )
     }


### PR DESCRIPTION
## Summary

Introduces `NetworkActivityCenter` — a public `@Observable @MainActor` source of truth for in-flight framework traffic. Consumer apps that market a privacy-forward, local-first experience can now bind a single observable for status pills, trust sheets, and "is the framework talking to the network?" surfaces instead of building parallel observers that drift the moment a new code path is added inside ManifoldKit.

- **API.** `NetworkActivityCenter.shared.current: NetworkActivity` exposes a coalesced summary (`.idle`, `.probing(host:)`, `.downloading(modelID:bytesReceived:totalBytes:throughputBytesPerSecond:)`, `.fetchingMetadata(host:)`). `inFlightCount` and `activeHosts` are also published; `updates()` returns an `AsyncStream` for non-SwiftUI consumers.
- **Funnels.** `URLSessionFactory.ephemeral` wires a `NetworkActivityTrackingDelegate` through the existing composite-delegate seam so every request that flows through the factory emits begin/end automatically. `BackgroundDownloadManager` posts rich per-model `.downloading` state with bytes / total / throughput. `HuggingFaceService` wraps SDK metadata calls (`listModels`, `getModel`) so HF traffic that bypasses URLSessionFactory still surfaces as `.fetchingMetadata(host:)`.
- **Coalescing.** Downloads dominate metadata fetches dominate probes — the indicator tracks the most user-visible work.
- **Tests.** `NetworkActivityCenterTests` covers direct begin/end, dominance ordering, idempotent stale-token end, session traffic increment+decrement under success/error/cancel, and the async update stream. Uses `MockURLProtocol` with UUID-based hostnames per test (`MockURLProtocol.reset()` never called, per project convention).
- **Audit.** Added `NetworkActivityTrackingDelegate.swift` to `TrafficBoundaryAuditTest.networkIOAllowlist` (cap bumped 41 → 42) — observes the existing seam, no new outbound calls.

Closes #1292

## Test plan

- [x] `scripts/test.sh --filter ManifoldCoreTests --filter ManifoldRuntimeTests --filter ManifoldPersistenceSwiftDataTests --filter ManifoldUITests --filter ManifoldUIModelManagementTests --filter ManifoldMCPTests --filter ManifoldBackendsTests --filter ManifoldInferenceTests --filter ManifoldTestSupportTests --filter ManifoldAppIntentsTests --filter ManifoldServerTests --disable-default-traits --skip-update` — 3228 passed, 17 skipped, 0 failed
- [x] `scripts/test.sh --filter ManifoldInferenceSwiftTestingTests --disable-default-traits --skip-update` — 83 passed
- [x] `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` — clean
- [x] New `NetworkActivityCenterTests` — 9/9 passing