### PR TITLE
fix: deflake MockBackendLifecycleTests.test_backToBackMakeStream_clearsTaskBetweenRuns

### DIFF
--- a/Sources/ManifoldTestSupport/MockBackendLifecycle.swift
+++ b/Sources/ManifoldTestSupport/MockBackendLifecycle.swift
@@ -86,6 +86,17 @@ package final class MockBackendLifecycle: @unchecked Sendable {
         return generationTask != nil
     }
 
+    /// Test-only: snapshot the currently-recorded task, if any. Tests use
+    /// this to `await task.value` *after* draining the stream, which is a
+    /// real happens-before edge with the task body's last statement
+    /// (`clearTaskIfMatches`). Polling `hasActiveTask` with `Task.sleep`
+    /// races the clearing hop on loaded CI runners — see #1329.
+    package var currentTask: Task<Void, Never>? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return generationTask
+    }
+
     /// Cancels the recorded task and clears the slot. Safe to call from
     /// `deinit` (the lock is released before `task.cancel()` so the task's
     /// own state-flip cannot deadlock).

--- a/Tests/ManifoldBackendsTests/MockBackendLifecycleTests.swift
+++ b/Tests/ManifoldBackendsTests/MockBackendLifecycleTests.swift
@@ -180,24 +180,31 @@ final class MockBackendLifecycleTests: XCTestCase {
     func test_backToBackMakeStream_clearsTaskBetweenRuns() async throws {
         let lifecycle = MockBackendLifecycle()
 
-        // Run #1 — drain to completion.
+        // Run #1 — capture the underlying task from inside `onFinish`,
+        // which runs on the same task hop *before* the body's final
+        // `clearTaskIfMatches` statement. That snapshot lets us
+        // `await task.value` after draining, which is a real
+        // happens-before edge with the clearing hop — replacing the
+        // `Task.sleep` poll that flaked on loaded CI runners (see #1329).
+        let capturedTask = TaskHolder()
         let stream1 = lifecycle.makeStream(
-            onFinish: { },
+            onFinish: { [weak lifecycle] in
+                // Inside `onFinish`, the slot still holds the current
+                // task (the identity-aware clear runs *after* this
+                // callback returns).
+                capturedTask.set(lifecycle?.currentTask)
+            },
             body: { continuation in
                 continuation.yield(.token("a"))
             }
         )
         for try await _ in stream1.events { }
+        let task1 = try XCTUnwrap(
+            capturedTask.value,
+            "Task slot must be populated when onFinish fires"
+        )
+        await task1.value
 
-        // Give the task's completion block a moment to run its
-        // identity-aware clear. (`for try await` returns after
-        // `continuation.finish()`, but the task body's last statement —
-        // `self?.clearTaskIfMatches(t)` — runs immediately after on the
-        // same task hop.)
-        let deadline = ContinuousClock().now.advanced(by: .milliseconds(500))
-        while lifecycle.hasActiveTask && ContinuousClock().now < deadline {
-            try await Task.sleep(for: .milliseconds(5))
-        }
         XCTAssertFalse(
             lifecycle.hasActiveTask,
             "Task slot must be cleared after the body's natural completion"
@@ -248,6 +255,21 @@ private final class AtomicCounter: @unchecked Sendable {
     func increment() {
         lock.lock(); defer { lock.unlock() }
         _value += 1
+    }
+}
+
+/// Box that lets `onFinish` capture the running `Task` so the test body can
+/// `await task.value` deterministically after draining the stream.
+private final class TaskHolder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value: Task<Void, Never>?
+    var value: Task<Void, Never>? {
+        lock.lock(); defer { lock.unlock() }
+        return _value
+    }
+    func set(_ task: Task<Void, Never>?) {
+        lock.lock(); defer { lock.unlock() }
+        _value = task
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace `Task.sleep` poll on `lifecycle.hasActiveTask` with a deterministic happens-before edge: capture the running `Task` from inside `onFinish`, then `await task.value` after draining. Task completion strictly follows the body's last statement (`clearTaskIfMatches`), eliminating the CI race.
- Add a package-level `currentTask` accessor on `MockBackendLifecycle` so the test fixture can snapshot the task slot from inside `onFinish` without widening the helper's production surface.

## Mechanism

`MockBackendLifecycle.makeStream`'s task body runs:
1. `body(continuation)`
2. `onFinish()`            <- test snapshots `currentTask` here
3. `continuation.finish()` <- consumer's `for try await` exits here
4. `clearTaskIfMatches(t)` <- racy hop the old poll waited for

Awaiting `task.value` (captured at step 2) after the drain blocks until the whole task — including step 4 — completes.

## Test plan

- [x] Targeted test 60x locally: 60/60 pass (previous shape flaked ~40% on same hardware)
- [x] Full XCTest suites pre-push gate: 3219 passed, 0 failed, 17 skipped
- [x] Swift Testing suite pre-push gate: 83 passed, 0 failed

Closes #1329

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>