### PR TITLE
perf(ci): move coverage threshold check from per-push to nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ on:
       - ".github/workflows/ci.yml"
       - "scripts/test.sh"
       - "scripts/ci-test-with-watchdog.sh"
-      - "scripts/check-coverage.sh"
       - "scripts/example-ui-tests.sh"
       - "scripts/ci-normalize-swiftpm-debug-cache.sh"
       - "scripts/cold-start*.sh"
@@ -28,7 +27,6 @@ on:
       - ".github/workflows/ci.yml"
       - "scripts/test.sh"
       - "scripts/ci-test-with-watchdog.sh"
-      - "scripts/check-coverage.sh"
       - "scripts/example-ui-tests.sh"
       - "scripts/ci-normalize-swiftpm-debug-cache.sh"
       - "scripts/cold-start*.sh"
@@ -298,28 +296,10 @@ jobs:
           STALL_SECONDS: "240"
         run: scripts/ci-test-with-watchdog.sh --filter ManifoldInferenceSwiftTestingTests --disable-default-traits --skip-update
 
-      # Coverage thresholds — runs a fresh swift test with --enable-code-coverage
-      # over the four critical modules and verifies each module's line coverage
-      # meets its threshold (set 10pp below the 2026-05-15 baseline).  Runs only
-      # on main-branch pushes so per-PR CI is not slowed by the extra build pass.
-      # The check is informational on first-push; raise thresholds as coverage
-      # improves.  See scripts/check-coverage.sh for threshold values and rationale.
-      - name: Coverage thresholds
-        if: github.ref == 'refs/heads/main'
-        timeout-minutes: 15
-        run: |
-          set -euo pipefail
-          swift test \
-            --filter ManifoldCoreTests \
-            --filter ManifoldRuntimeTests \
-            --filter ManifoldPersistenceSwiftDataTests \
-            --filter ManifoldInferenceTests \
-            --filter ManifoldMCPTests \
-            --disable-default-traits \
-            --traits MCP \
-            --enable-code-coverage \
-            --skip-update
-          scripts/check-coverage.sh
+      # Coverage thresholds run nightly in nightly-slow-tests.yml — they were
+      # moved out of per-main-push CI to reclaim ~130s of wall (~22 billed
+      # macOS-min) per push.  scripts/check-coverage.sh thresholds sit 10pp
+      # below the 2026-05-15 baseline, so a ≤24h detection delay is acceptable.
 
       - name: Report SwiftPM debug cache state
         if: always()

--- a/.github/workflows/nightly-slow-tests.yml
+++ b/.github/workflows/nightly-slow-tests.yml
@@ -94,6 +94,32 @@ jobs:
           scripts/test.sh --filter "ManifoldRuntimeTests.SessionDiscardOrderingTests" \
             --disable-default-traits --skip-update --min-passed 1
 
+      # Coverage thresholds — runs a fresh swift test with --enable-code-coverage
+      # over the four critical modules and verifies each module's line coverage
+      # meets its threshold (set 10pp below the 2026-05-15 baseline). Moved here
+      # from ci.yml's per-main-push step to reclaim ~130s wall (~22 billed
+      # macOS-min) per push; thresholds are conservative enough that a ≤24h
+      # detection delay is acceptable. See scripts/check-coverage.sh for
+      # threshold values and rationale.
+      - name: Coverage thresholds
+        id: test-coverage-thresholds
+        timeout-minutes: 15
+        env:
+          MANIFOLD_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-coverage-thresholds.log
+        run: |
+          set -euo pipefail
+          swift test \
+            --filter ManifoldCoreTests \
+            --filter ManifoldRuntimeTests \
+            --filter ManifoldPersistenceSwiftDataTests \
+            --filter ManifoldInferenceTests \
+            --filter ManifoldMCPTests \
+            --disable-default-traits \
+            --traits MCP \
+            --enable-code-coverage \
+            --skip-update
+          scripts/check-coverage.sh
+
       - name: Stage test diagnostics
         # Mirrors ci.yml: each step writes to a unique workspace log path so
         # diagnostics from earlier failures are preserved.
@@ -104,6 +130,7 @@ jobs:
           TRAFFIC_BOUNDARY_AUDIT_FAILED: ${{ steps.test-traffic-boundary-audit.outcome == 'failure' }}
           MCP_E2E_SMOKE_FAILED: ${{ steps.test-mcp-e2e-smoke.outcome == 'failure' }}
           OPERATIONAL_FAILED: ${{ steps.test-operational.outcome == 'failure' }}
+          COVERAGE_THRESHOLDS_FAILED: ${{ steps.test-coverage-thresholds.outcome == 'failure' }}
         run: |
           mkdir -p test-diagnostics
           {
@@ -115,6 +142,7 @@ jobs:
             echo "traffic-boundary-audit-failed=${TRAFFIC_BOUNDARY_AUDIT_FAILED}"
             echo "mcp-e2e-smoke-failed=${MCP_E2E_SMOKE_FAILED}"
             echo "operational-failed=${OPERATIONAL_FAILED}"
+            echo "coverage-thresholds-failed=${COVERAGE_THRESHOLDS_FAILED}"
           } > test-diagnostics/failed-steps.txt
 
       - name: Upload test diagnostics on failure


### PR DESCRIPTION
## Summary

- The Coverage thresholds step in `ci.yml` ran on every push to `main` as a third `swift test --enable-code-coverage` invocation. The same five filters had already run ~3 min earlier in the XCTest batch; SwiftPM rebuilt the test bundle with profiling instrumentation just to re-execute the suite.
- Measured at ~130s wall = ~22 billed macOS-min per push. With ~5-10 pushes/day to main, that's **110-220 billed min/day** reclaimed.
- Step moved to the existing `slow` job in `nightly-slow-tests.yml`, where the cold SwiftPM resolve is already amortized across other nightly invocations — no extra runner.
- `scripts/check-coverage.sh` dropped from `ci.yml`'s push/pull_request paths filter (the gate no longer runs there, so script edits shouldn't retrigger CI).

## Why nightly is acceptable

`scripts/check-coverage.sh` thresholds sit **10pp below** the 2026-05-15 baseline (per its own header comment). A real regression has plenty of slack before tripping, so ≤24h detection delay is well within the buffer the thresholds already build in.

## Caveats

- `scripts/check-coverage.sh` has no main-branch-specific behavior — no baseline-publishing, no codecov upload, just llvm-cov report + threshold compare. Safe to move with zero functional change.
- If `#1335` (revert `.build/debug` cache) lands first, this branch rebases cleanly — diffs don't overlap.

## Test plan

- [x] `actionlint .github/workflows/ci.yml .github/workflows/nightly-slow-tests.yml` passes locally
- [ ] After merge: `gh workflow run nightly-slow-tests.yml` to confirm the Coverage thresholds step fires inside the `slow` job and `scripts/check-coverage.sh` reports PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)