### PR TITLE
feat(hf): adopt Hub directory convention in diffusion download

### DIFF
--- a/Sources/ManifoldHuggingFace/DiffusionDownload.swift
+++ b/Sources/ManifoldHuggingFace/DiffusionDownload.swift
@@ -138,9 +138,17 @@ public extension HuggingFaceService {
         progress: @escaping @Sendable (DiffusionDownloadProgress) -> Void
     ) async throws -> ImageModelInfo {
 
+        // Adopt Hub's `<root>/models/<org>/<name>` directory convention so
+        // `HubApi.localRepoLocation` (used by mlx-swift-examples StableDiffusion)
+        // resolves files without a bridging symlink. The package-readiness
+        // manifest still lives at the staging/destination root — only the
+        // snapshot files relocate.
+        let hubLeafStaging = try Self.hubLeafDirectory(in: stagingDirectory, repoID: repoID)
+        try FileManager.default.createDirectory(at: hubLeafStaging, withIntermediateDirectories: true)
+
         // 1. Fetch manifest.
         let manifestRemoteURL = downloadURL(repoID: repoID, filePath: "model_index.json")
-        let manifestLocalURL = stagingDirectory.appendingPathComponent("model_index.json")
+        let manifestLocalURL = hubLeafStaging.appendingPathComponent("model_index.json")
         try await downloadFile(
             from: manifestRemoteURL,
             to: manifestLocalURL,
@@ -165,9 +173,16 @@ public extension HuggingFaceService {
         } else {
             fp16Available = []
         }
+        // Plan items resolve their `localURL` against the Hub leaf so the
+        // on-disk layout already matches what `HubApi.localRepoLocation`
+        // expects. `relativePath` stays unprefixed (it's the HF-side
+        // relative path used to fetch each file and to validate the
+        // package); the package-manifest writer below adds the
+        // `models/<repoID>/` prefix so the readiness check at discovery
+        // time finds the files at the correct location.
         let plan = try buildDiffusionDownloadPlan(
             manifest: manifest,
-            destinationDirectory: stagingDirectory,
+            destinationDirectory: hubLeafStaging,
             fp16AvailablePaths: fp16Available
         )
 
@@ -241,10 +256,15 @@ public extension HuggingFaceService {
         let format: ImageModelFormat = manifest.submodules.contains("transformer")
             ? .fluxSchnell : .mlxDiffusion
 
+        // `directoryURL` points at the Hub leaf so backends that resolve
+        // the parent for `HubApi(downloadBase:)` walk a stable three
+        // components up (drop `<name>`, `<org>`, `models`). The package
+        // manifest stays at the package root for discovery.
+        let hubLeafURL = try Self.hubLeafDirectory(in: destinationDirectory, repoID: repoID)
         let info = ImageModelInfo(
             id: repoID,
             name: resolvedDisplayName,
-            directoryURL: destinationDirectory,
+            directoryURL: hubLeafURL,
             format: format,
             fileSize: totalBytes,
             huggingFaceRepoID: repoID,
@@ -252,9 +272,11 @@ public extension HuggingFaceService {
         )
 
         Log.download.info("Writing package manifest (variant=\(info.variant.rawValue, privacy: .public))")
+        let hubPrefix = "models/\(repoID)/"
         try writePackageManifest(
             for: info,
-            files: ["model_index.json"] + plan.items.map(\.relativePath),
+            files: ([ "model_index.json" ] + plan.items.map(\.relativePath))
+                .map { hubPrefix + $0 },
             in: stagingDirectory
         )
         Log.download.info("Moving staging directory to destination")
@@ -264,6 +286,29 @@ public extension HuggingFaceService {
         try FileManager.default.moveItem(at: stagingDirectory, to: destinationDirectory)
         Log.download.info("Install complete")
         return info
+    }
+
+    /// Resolves the `<root>/models/<org>/<name>` path that Hub's
+    /// `localRepoLocation` produces for a given `org/name` repo ID.
+    /// Validates each path component before joining so a hostile repo ID
+    /// cannot escape `root`.
+    internal static func hubLeafDirectory(in root: URL, repoID: String) throws -> URL {
+        let parts = repoID.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+        guard parts.count >= 2 else {
+            throw HuggingFaceError.invalidDownloadedFile(
+                reason: "Repo ID must be in <org>/<name> form: \"\(repoID)\""
+            )
+        }
+        var url = root.appendingPathComponent("models", isDirectory: true)
+        for part in parts {
+            if part.isEmpty || part == "." || part == ".." || part.contains("\\") || part.hasPrefix(".") {
+                throw HuggingFaceError.invalidDownloadedFile(
+                    reason: "Unsafe path component in repo ID: \"\(part)\""
+                )
+            }
+            url = url.appendingPathComponent(part, isDirectory: true)
+        }
+        return url
     }
 
     private func writePackageManifest(

--- a/Sources/ManifoldInference/Services/ModelStorageService.swift
+++ b/Sources/ManifoldInference/Services/ModelStorageService.swift
@@ -295,10 +295,29 @@ public final class ModelStorageService: @unchecked Sendable {
         }
 
         guard let format = manifest.format else { return nil }
+        // Diffusion packages adopt Hub's `<root>/models/<org>/<name>` layout
+        // so backends can pass `HubApi(downloadBase:)` without a bridging
+        // symlink. The package readiness manifest stays at the package
+        // root; the `files` paths in it are stored with the
+        // `models/<repoID>/` prefix and verified above. The loaded
+        // `directoryURL` is the Hub leaf so loaders that probe `url/unet`
+        // etc. still work.
+        let directoryURL: URL
+        if let hfRepoID = manifest.huggingFaceRepoID,
+           manifest.files.allSatisfy({ $0.hasPrefix("models/\(hfRepoID)/") }) {
+            directoryURL = directory
+                .appendingPathComponent("models", isDirectory: true)
+                .appendingPathComponent(hfRepoID, isDirectory: true)
+        } else {
+            // Pre-Hub-layout packages: `directoryURL` is the package root.
+            // Kept for forward compatibility if a downstream consumer
+            // writes a manifest without the `models/<repoID>/` prefix.
+            directoryURL = directory
+        }
         return ImageModelInfo(
             id: manifest.id,
             name: manifest.displayName,
-            directoryURL: directory,
+            directoryURL: directoryURL,
             format: format,
             fileSize: packageSize(at: directory, files: manifest.files),
             huggingFaceRepoID: manifest.huggingFaceRepoID,

--- a/Sources/ManifoldMLX/MLXDiffusionBackend.swift
+++ b/Sources/ManifoldMLX/MLXDiffusionBackend.swift
@@ -42,14 +42,13 @@ public enum MLXDiffusionError: Error, LocalizedError {
 ///
 /// Other layouts throw ``MLXDiffusionError/unsupportedModelLayout``.
 ///
-/// ## PR 5 ↔ PR 6 alignment note
+/// ## Hub directory convention
 ///
-/// `HuggingFaceService.downloadDiffusionModel` stores weights with a slug-based
-/// directory name (e.g. `stabilityai__sdxl-turbo`). The StableDiffusion library
-/// resolves files via `HubApi.localRepoLocation`, which expects the Hub
-/// convention `<downloadBase>/models/stabilityai/sdxl-turbo`. `loadModel(from:)`
-/// bridges this via a temporary symlink. A follow-up PR can eliminate the
-/// symlink by adopting Hub's directory convention in the download path.
+/// `HuggingFaceService.downloadDiffusionModel` writes snapshots into Hub's
+/// `<root>/models/<org>/<name>` layout (e.g.
+/// `<root>/models/stabilityai/sdxl-turbo/unet/...`). `loadModel(from:)`
+/// derives the Hub `downloadBase` by walking three components up from the
+/// supplied `url` — no bridging symlink is required.
 ///
 /// ## Concurrency
 ///
@@ -97,9 +96,16 @@ public final class MLXDiffusionBackend: ImageGenerationBackend, @unchecked Senda
             throw MLXDiffusionError.insufficientMemory(plan.reasons)
         }
 
-        // Bridge slug-based download path to Hub's expected directory layout.
-        let (hubBase, cleanup) = try Self.makeHubBridge(for: preset, pointing: url)
-        defer { cleanup() }
+        // `url` is the Hub leaf (`.../models/<org>/<name>`). Walk three
+        // components up — `<name>`, `<org>`, `models` — to recover the
+        // `downloadBase` Hub uses to resolve `localRepoLocation`. The
+        // download path already produces this layout (see
+        // `DiffusionDownload.hubLeafDirectory(in:repoID:)`), which is
+        // why no symlink bridge is needed.
+        let hubBase = url
+            .deletingLastPathComponent() // drop <name>
+            .deletingLastPathComponent() // drop <org>
+            .deletingLastPathComponent() // drop "models"
 
         let hub = HubApi(downloadBase: hubBase, useOfflineMode: true)
         guard let generator = try preset.textToImageGenerator(
@@ -259,27 +265,6 @@ public final class MLXDiffusionBackend: ImageGenerationBackend, @unchecked Senda
             targetWidth:  isXL ? 1024 : 512,
             targetHeight: isXL ? 1024 : 512
         )
-    }
-
-    /// Creates a temporary symlink so Hub's path resolution finds the
-    /// weights in our slug-based download directory.
-    ///
-    /// Hub resolves: `<hubBase>/models/<repoID>` where slashes in repoID
-    /// are directory separators. We symlink that path to `modelDir`.
-    private static func makeHubBridge(
-        for preset: StableDiffusionConfiguration,
-        pointing modelDir: URL
-    ) throws -> (hubBase: URL, cleanup: () -> Void) {
-        let tmpBase = FileManager.default.temporaryDirectory
-            .appending(component: "BCKDiffusion-\(UUID().uuidString)")
-        // preset.id e.g. "stabilityai/sdxl-turbo" → two path components
-        let target = tmpBase.appending(component: "models").appending(component: preset.id)
-        try FileManager.default.createDirectory(
-            at: target.deletingLastPathComponent(),
-            withIntermediateDirectories: true
-        )
-        try FileManager.default.createSymbolicLink(at: target, withDestinationURL: modelDir)
-        return (tmpBase, { try? FileManager.default.removeItem(at: tmpBase) })
     }
 
     private static func makeParams(

--- a/Tests/ManifoldHuggingFaceTests/DiffusionDownloadTests.swift
+++ b/Tests/ManifoldHuggingFaceTests/DiffusionDownloadTests.swift
@@ -192,27 +192,34 @@ final class DiffusionDownloadTests: XCTestCase {
 
         XCTAssertEqual(info.format, .mlxDiffusion)
         XCTAssertEqual(info.huggingFaceRepoID, repoID)
-        XCTAssertEqual(info.directoryURL, tempDir)
+        // Hub layout: snapshot files live at `<root>/models/<org>/<name>/...`
+        // (see DiffusionDownload.hubLeafDirectory). `directoryURL` is the
+        // Hub leaf so `MLXDiffusionBackend` can derive `HubApi(downloadBase:)`
+        // by walking three components up without a symlink bridge.
+        let hubLeaf = tempDir
+            .appendingPathComponent("models", isDirectory: true)
+            .appendingPathComponent(repoID, isDirectory: true)
+        XCTAssertEqual(info.directoryURL, hubLeaf)
         XCTAssertGreaterThan(info.fileSize, 0)
 
         let fm = FileManager.default
-        XCTAssertTrue(fm.fileExists(atPath: tempDir.appendingPathComponent("model_index.json").path))
-        XCTAssertTrue(fm.fileExists(atPath: tempDir.appendingPathComponent("unet/config.json").path))
-        XCTAssertTrue(fm.fileExists(atPath: tempDir
+        XCTAssertTrue(fm.fileExists(atPath: hubLeaf.appendingPathComponent("model_index.json").path))
+        XCTAssertTrue(fm.fileExists(atPath: hubLeaf.appendingPathComponent("unet/config.json").path))
+        XCTAssertTrue(fm.fileExists(atPath: hubLeaf
             .appendingPathComponent("unet/diffusion_pytorch_model.safetensors").path))
-        XCTAssertTrue(fm.fileExists(atPath: tempDir.appendingPathComponent("vae/config.json").path))
-        XCTAssertTrue(fm.fileExists(atPath: tempDir
+        XCTAssertTrue(fm.fileExists(atPath: hubLeaf.appendingPathComponent("vae/config.json").path))
+        XCTAssertTrue(fm.fileExists(atPath: hubLeaf
             .appendingPathComponent("vae/diffusion_pytorch_model.safetensors").path))
-        XCTAssertTrue(fm.fileExists(atPath: tempDir.appendingPathComponent("text_encoder/config.json").path))
-        XCTAssertTrue(fm.fileExists(atPath: tempDir
+        XCTAssertTrue(fm.fileExists(atPath: hubLeaf.appendingPathComponent("text_encoder/config.json").path))
+        XCTAssertTrue(fm.fileExists(atPath: hubLeaf
             .appendingPathComponent("text_encoder/model.safetensors").path))
-        XCTAssertTrue(fm.fileExists(atPath: tempDir.appendingPathComponent("tokenizer/vocab.json").path))
-        XCTAssertTrue(fm.fileExists(atPath: tempDir.appendingPathComponent("tokenizer/merges.txt").path))
-        XCTAssertTrue(fm.fileExists(atPath: tempDir
+        XCTAssertTrue(fm.fileExists(atPath: hubLeaf.appendingPathComponent("tokenizer/vocab.json").path))
+        XCTAssertTrue(fm.fileExists(atPath: hubLeaf.appendingPathComponent("tokenizer/merges.txt").path))
+        XCTAssertTrue(fm.fileExists(atPath: hubLeaf
             .appendingPathComponent("scheduler/scheduler_config.json").path))
 
-        XCTAssertFalse(fm.fileExists(atPath: tempDir.appendingPathComponent("text_encoder_2").path))
-        XCTAssertFalse(fm.fileExists(atPath: tempDir.appendingPathComponent("tokenizer_2").path))
+        XCTAssertFalse(fm.fileExists(atPath: hubLeaf.appendingPathComponent("text_encoder_2").path))
+        XCTAssertFalse(fm.fileExists(atPath: hubLeaf.appendingPathComponent("tokenizer_2").path))
 
         XCTAssertGreaterThan(progressEvents.count, 0, "Progress callback should fire at least once")
         let finalEvent = progressEvents.last!
@@ -262,11 +269,14 @@ final class DiffusionDownloadTests: XCTestCase {
         )
 
         XCTAssertEqual(info.format, .mlxDiffusion)
+        let hubLeaf = tempDir
+            .appendingPathComponent("models", isDirectory: true)
+            .appendingPathComponent(repoID, isDirectory: true)
         let fm = FileManager.default
-        XCTAssertTrue(fm.fileExists(atPath: tempDir
+        XCTAssertTrue(fm.fileExists(atPath: hubLeaf
             .appendingPathComponent("text_encoder_2/model.safetensors").path))
-        XCTAssertTrue(fm.fileExists(atPath: tempDir.appendingPathComponent("tokenizer_2/vocab.json").path))
-        XCTAssertTrue(fm.fileExists(atPath: tempDir.appendingPathComponent("tokenizer_2/merges.txt").path))
+        XCTAssertTrue(fm.fileExists(atPath: hubLeaf.appendingPathComponent("tokenizer_2/vocab.json").path))
+        XCTAssertTrue(fm.fileExists(atPath: hubLeaf.appendingPathComponent("tokenizer_2/merges.txt").path))
     }
 
     func test_manifestFetchFails_surfacesError() async {

--- a/Tests/ManifoldInferenceTests/ModelStorageServiceTests.swift
+++ b/Tests/ManifoldInferenceTests/ModelStorageServiceTests.swift
@@ -93,7 +93,17 @@ final class ModelStorageServiceTests: XCTestCase {
     ) throws -> URL {
         let dir = service.modelsDirectory.appendingPathComponent(name, isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let files = [
+        // Mirror the on-disk Hub layout produced by
+        // `DiffusionDownload.hubLeafDirectory`: files live under
+        // `<package>/models/<org>/<name>/...`. The package manifest at the
+        // package root lists every file with that prefix so the readiness
+        // check in `ModelStorageService.imageModelInfoIfReady` walks the
+        // correct paths.
+        let repoID = "test-org/\(name)"
+        let hubLeaf = dir
+            .appendingPathComponent("models", isDirectory: true)
+            .appendingPathComponent(repoID, isDirectory: true)
+        let unprefixed = [
             "model_index.json",
             "unet/config.json",
             "unet/diffusion_pytorch_model.safetensors",
@@ -103,19 +113,20 @@ final class ModelStorageServiceTests: XCTestCase {
             "text_encoder/model.safetensors",
             "scheduler/scheduler_config.json",
         ]
-        for file in files where file != omitted {
-            let url = dir.appendingPathComponent(file)
+        for file in unprefixed where file != omitted {
+            let url = hubLeaf.appendingPathComponent(file)
             try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
             try Data("x".utf8).write(to: url)
         }
         if writeManifest {
+            let prefixed = unprefixed.map { "models/\(repoID)/" + $0 }
             let manifest = DownloadedModelPackageManifest(
                 packageKind: .diffusion,
-                id: "test-org/\(name)",
+                id: repoID,
                 displayName: "Diffusion \(name)",
                 format: .mlxDiffusion,
-                huggingFaceRepoID: "test-org/\(name)",
-                files: files
+                huggingFaceRepoID: repoID,
+                files: prefixed
             )
             let data = try JSONEncoder().encode(manifest)
             try data.write(to: dir.appendingPathComponent(DownloadedModelPackageManifest.fileName))
@@ -285,14 +296,25 @@ final class ModelStorageServiceTests: XCTestCase {
         )
     }
 
+    /// Maps a package root (the directory `discoverImageModels` iterates over)
+    /// to the Hub leaf URL exposed on the resulting `ImageModelInfo`. Mirrors
+    /// `createDiffusionPackage`'s `models/<repoID>/` layout.
+    private func hubLeafURL(forPackage packageURL: URL) -> URL {
+        let repoID = "test-org/\(packageURL.lastPathComponent)"
+        return packageURL
+            .appendingPathComponent("models", isDirectory: true)
+            .appendingPathComponent(repoID, isDirectory: true)
+    }
+
     func test_discoverImageModels_ignoresPartialPackageWithoutManifest() throws {
         let packageURL = try createDiffusionPackage(writeManifest: false)
+        let expectedDir = hubLeafURL(forPackage: packageURL)
 
         let imageModels = service.discoverImageModels()
 
         XCTAssertNil(
             imageModels.first {
-                $0.directoryURL.standardizedFileURL.path == packageURL.standardizedFileURL.path
+                $0.directoryURL.standardizedFileURL.path == expectedDir.standardizedFileURL.path
             },
             "Partially downloaded packages without readiness manifests must stay hidden"
         )
@@ -300,12 +322,13 @@ final class ModelStorageServiceTests: XCTestCase {
 
     func test_discoverImageModels_ignoresManifestWhenComponentMissing() throws {
         let packageURL = try createDiffusionPackage(omitFile: "vae/diffusion_pytorch_model.safetensors")
+        let expectedDir = hubLeafURL(forPackage: packageURL)
 
         let imageModels = service.discoverImageModels()
 
         XCTAssertNil(
             imageModels.first {
-                $0.directoryURL.standardizedFileURL.path == packageURL.standardizedFileURL.path
+                $0.directoryURL.standardizedFileURL.path == expectedDir.standardizedFileURL.path
             },
             "Readiness manifests are atomic: every listed component must exist"
         )
@@ -313,10 +336,11 @@ final class ModelStorageServiceTests: XCTestCase {
 
     func test_discoverImageModels_surfacesCompletePackageAsSingleEntry() throws {
         let packageURL = try createDiffusionPackage(named: "ready-diffusion-\(UUID().uuidString)")
+        let expectedDir = hubLeafURL(forPackage: packageURL)
 
         let imageModels = service.discoverImageModels()
         let match = imageModels.first {
-            $0.directoryURL.standardizedFileURL.path == packageURL.standardizedFileURL.path
+            $0.directoryURL.standardizedFileURL.path == expectedDir.standardizedFileURL.path
         }
 
         XCTAssertNotNil(match)
@@ -324,7 +348,7 @@ final class ModelStorageServiceTests: XCTestCase {
         XCTAssertEqual(match?.huggingFaceRepoID, match?.id)
         XCTAssertEqual(
             imageModels.filter {
-                $0.directoryURL.standardizedFileURL.path == packageURL.standardizedFileURL.path
+                $0.directoryURL.standardizedFileURL.path == expectedDir.standardizedFileURL.path
             }.count,
             1,
             "A multi-component package should appear as one logical model"


### PR DESCRIPTION
Closes #1315.

## What changed

`HuggingFaceService.downloadDiffusionModel` previously wrote snapshots flat into the caller's destination directory (`<root>/{unet,vae,text_encoder,...}/...`). The MLX StableDiffusion library resolves files via `HubApi.localRepoLocation`, which expects Hub's canonical `<downloadBase>/models/<org>/<name>/...` layout. `MLXDiffusionBackend.loadModel` bridged the two conventions with a per-call temporary symlink (`<tmp>/models/<repoID> -> packageDir`).

This PR makes the download path produce the Hub layout natively:

| | Before | After |
| --- | --- | --- |
| Snapshot files | `<root>/unet/...` | `<root>/models/<org>/<name>/unet/...` |
| `ImageModelInfo.directoryURL` | `<root>` | `<root>/models/<org>/<name>` |
| Hub base in `MLXDiffusionBackend` | `<tmp>` (symlinked) | `directoryURL` walked 3 components up |
| Package readiness manifest | `<root>/model-package-manifest.json` (unchanged location) | same; `files` entries now carry the `models/<repoID>/` prefix |

`ModelStorageService.imageModelInfoIfReady` was updated to derive `directoryURL` from `manifest.huggingFaceRepoID + "models/.../..."` when the prefix is present, keeping the per-component readiness check working against the new on-disk paths.

## Symlink code removed

- `Sources/ManifoldMLX/MLXDiffusionBackend.swift` lines 264-283 (the `makeHubBridge` static helper plus its single call site in `loadModel`). The call site is replaced with a three-step `deletingLastPathComponent()` chain plus a doc comment explaining the layout invariant.

## User impact: existing v0.16.2 packages need re-download

Diffusion packages installed on v0.16.2 sit at `<storageRoot>/<slug>/unet/...` with a manifest whose `files` are unprefixed. The updated `imageModelInfoIfReady` falls through to the legacy branch (`directoryURL = directory`) when no prefix is present, so old packages still surface in discovery — but `MLXDiffusionBackend.loadModel` now walks three components up from `directoryURL`, which on a pre-v0.16.2 package lands on the parent of `<storageRoot>` rather than a valid Hub base, and the load fails.

Since image generation just shipped in v0.16.2, the practical blast radius is small. Affected users delete the diffusion package and reinstall through the model picker; the new download writes the Hub layout from the first run.

(Backends that don't use `HubApi.downloadBase` — `FluxDiffusionBackend` and any future loader that probes `url/<submodule>` directly — keep working unchanged because `directoryURL` still points at a directory containing `unet/`, `vae/`, etc.)

## Test plan

- [x] `swift build --build-tests --disable-default-traits` (default-trait sanity, 64s)
- [x] `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` (all-traits-on sweep, 193s)
- [x] `scripts/test.sh --filter ManifoldHuggingFaceTests --filter ManifoldInferenceTests --traits HuggingFace --skip-update` (focused: 1713 passed, 5 skipped)
- [x] Pre-push two-invocation gate (XCTest filter batch + Swift Testing): 3255 + 83 passed, 17 skipped
- [ ] End-to-end download → generate on Apple Silicon with an SDXL Turbo / SD 2.1 package — **not run locally** (no image-gen model on disk this session). The unit/integration tests cover the path layout and discovery contract; the live-Metal path is mechanically simple after the layout change (the symlink was the only piece doing work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)