### PR TITLE
test: widen WithTimeoutTests timing gap to deflake on loaded CI

### DIFF
--- a/Tests/ManifoldTestSupportTests/WithTimeoutTests.swift
+++ b/Tests/ManifoldTestSupportTests/WithTimeoutTests.swift
@@ -77,16 +77,15 @@ final class WithTimeoutTests: XCTestCase {
     func test_withTimeout_throwsOnNonCancellationAwareHang() async {
         // Use a DispatchSemaphore to model a gate that doesn't check Swift
         // cancellation (e.g. UIToolApprovalGate.awaitDecision awaiting user input).
-        // The latch is signalled 100 ms from now — long enough to prove the thread
-        // eventually resumes (preventing a permanently-leaked Task), short enough to
-        // avoid stalling the parallel runner near the CI step-timeout wall. The
-        // previous 1.5 s tail was blocking a cooperative-pool thread for the entire
-        // cleanup window, which caused the last 1-2 queued tests to miss the
-        // 30-minute step cap consistently.
+        // The latch is signalled 1 s from now — long enough to prove the thread
+        // eventually resumes (preventing a permanently-leaked Task) with a 5×
+        // safety margin over the 200 ms timeout so loaded macOS CI runners don't
+        // race the timeout's scheduler hop against the latch fire. An earlier
+        // 100 ms ↔ 50 ms (2×) gap flaked on PR #1337's first CI attempt.
         let latch = DispatchSemaphore(value: 0)
-        DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) { latch.signal() }
+        DispatchQueue.global().asyncAfter(deadline: .now() + 1.0) { latch.signal() }
 
-        let timeout: Duration = .milliseconds(50)
+        let timeout: Duration = .milliseconds(200)
         do {
             _ = try await withTimeout(timeout) {
                 await withCheckedContinuation { (cont: CheckedContinuation<Int, Never>) in


### PR DESCRIPTION
## Summary

`test_withTimeout_throwsOnNonCancellationAwareHang` failed once on CI (PR #1337 first attempt) and passed on rerun. The test asserted a 50 ms timeout fires before a 100 ms latch resolves — only a 2x gap. On a loaded macOS runner the timeout's scheduler hop can be delayed long enough that the latch fires first, returning a value instead of throwing `TimeoutError.timedOut`.

This widens the gap to 5x (200 ms timeout vs 1 s latch) without changing what the test asserts. Total wall-clock stays under a second.

- 2x → 5x safety margin against scheduling noise
- No production code touched; `withTimeout` itself is unchanged
- Other tests in the file already use safe ratios (60 s sleep vs 50 ms timeout; 5 s budget vs 1 ms work)

## Test plan

- [x] `swift test --filter WithTimeoutTests --disable-default-traits --skip-update` x5 — all passed (~0.28 s each)

Generated with [Claude Code](https://claude.com/claude-code)