### PR TITLE
refactor: extract LlamaSamplingPolicy for hardware selection

### DIFF
--- a/Sources/ManifoldLlama/LlamaEmbeddingBackend.swift
+++ b/Sources/ManifoldLlama/LlamaEmbeddingBackend.swift
@@ -403,11 +403,11 @@ public final class LlamaEmbeddingBackend: EmbeddingBackend, @unchecked Sendable 
         defer { embeddingLoadLock.unlock() }
 
         var modelParams = llama_model_default_params()
-        #if targetEnvironment(simulator)
-        modelParams.n_gpu_layers = 0
-        #else
-        modelParams.n_gpu_layers = 99
-        #endif
+        // Shared policy with the generation-load path. This now honors
+        // `LLAMA_FORCE_CPU_ONLY=1` on device (previously generation-only),
+        // letting memory-constrained MoE embedders fall back to CPU instead
+        // of OOMing when the Metal command-buffer can't allocate.
+        modelParams.n_gpu_layers = LlamaSamplingPolicy.gpuLayerCount()
 
         guard let rawModel = llama_model_load_from_file(url.path, modelParams) else {
             throw InferenceError.modelLoadFailed(underlying: NSError(
@@ -446,7 +446,7 @@ public final class LlamaEmbeddingBackend: EmbeddingBackend, @unchecked Sendable 
         ctxParams.n_ctx = UInt32(requestedCtx)
         ctxParams.n_batch = UInt32(requestedCtx)
         ctxParams.n_ubatch = UInt32(requestedCtx)
-        ctxParams.n_threads = Int32(max(1, min(8, ProcessInfo.processInfo.processorCount - 2)))
+        ctxParams.n_threads = LlamaSamplingPolicy.threadCount()
         ctxParams.n_threads_batch = ctxParams.n_threads
 
         guard let ctx = llama_init_from_model(rawModel, ctxParams) else {

--- a/Sources/ManifoldLlama/LlamaModelLoader.swift
+++ b/Sources/ManifoldLlama/LlamaModelLoader.swift
@@ -106,23 +106,9 @@ final class LlamaModelLoader: @unchecked Sendable {
         progressHandler: (@Sendable (Double) async -> Void)? = nil
     ) throws -> LoadedResources {
         var modelParams = llama_model_default_params()
-        #if targetEnvironment(simulator)
-        modelParams.n_gpu_layers = 0   // Metal not reliable in simulator
-        #else
-        // Default: offload all layers to Metal. CPU-only is ~8× slower for
-        // even a 4B model (measured 2.28 s vs 0.28 s on `test_countTokens_…`
-        // against Qwen3-4B-Q4_K_M on M5/24 GB).
-        //
-        // Escape hatch for memory-constrained loads of very large MoE models:
-        // when the Metal command-buffer cannot allocate enough partial
-        // weights, set `LLAMA_FORCE_CPU_ONLY=1` to force CPU (mmap-paged)
-        // execution. Documented in `docs/LLAMA_CONTRACT.md`.
-        if ProcessInfo.processInfo.environment["LLAMA_FORCE_CPU_ONLY"] == "1" {
-            modelParams.n_gpu_layers = 0
-        } else {
-            modelParams.n_gpu_layers = 99  // Offload all layers to Metal
-        }
-        #endif
+        // Hardware-selection policy lives in `LlamaSamplingPolicy` so the
+        // generation-load and embedding-load paths cannot drift again.
+        modelParams.n_gpu_layers = LlamaSamplingPolicy.gpuLayerCount()
 
         // Wire up the progress callback when a handler is installed.
         // The C callback fires on the loader thread; we bridge to async by
@@ -170,7 +156,7 @@ final class LlamaModelLoader: @unchecked Sendable {
 
         var ctxParams = llama_context_default_params()
         ctxParams.n_ctx = UInt32(effectiveContextSize)
-        ctxParams.n_threads = Int32(max(1, min(8, ProcessInfo.processInfo.processorCount - 2)))
+        ctxParams.n_threads = LlamaSamplingPolicy.threadCount()
         ctxParams.n_threads_batch = ctxParams.n_threads
 
         // Apply BackendLoadOptions. Defaults prefer Q8 KV cache and Flash

--- a/Sources/ManifoldLlama/LlamaSamplingPolicy.swift
+++ b/Sources/ManifoldLlama/LlamaSamplingPolicy.swift
@@ -1,0 +1,47 @@
+#if Llama
+import Foundation
+
+/// Hardware-selection policy shared by the generation-load and embedding-load
+/// paths in `ManifoldLlama`. Both paths previously inlined the same logic for
+/// `n_gpu_layers` and `n_threads` / `n_threads_batch`; the duplication had
+/// drifted (the embedding path did not honor `LLAMA_FORCE_CPU_ONLY=1`).
+///
+/// Functions take their inputs (environment, processor count) as parameters
+/// so callers can unit-test the policy without mutating process state.
+internal enum LlamaSamplingPolicy {
+
+    /// Returns the `n_gpu_layers` value to use for a llama.cpp model load.
+    ///
+    /// - Simulator builds always return `0` — Metal is not reliable in the
+    ///   iOS Simulator and `MLXBackend`/`LlamaBackend` tests skip there.
+    /// - On device, `LLAMA_FORCE_CPU_ONLY=1` forces CPU-only execution. This
+    ///   is the escape hatch for memory-constrained loads of very large MoE
+    ///   models whose Metal command-buffer cannot allocate enough partial
+    ///   weights; CPU (mmap-paged) execution is ~8× slower but completes.
+    /// - Otherwise we offload all layers (`99`) to Metal.
+    ///
+    /// See `docs/LLAMA_CONTRACT.md` for the contract around the env var.
+    static func gpuLayerCount(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Int32 {
+        #if targetEnvironment(simulator)
+        return 0
+        #else
+        if environment["LLAMA_FORCE_CPU_ONLY"] == "1" {
+            return 0
+        }
+        return 99
+        #endif
+    }
+
+    /// Returns the `n_threads` (and `n_threads_batch`) value bounded into
+    /// `[1, 8]`. We reserve two cores for the OS / app so the inference loop
+    /// does not starve UI updates; the upper clamp avoids diminishing returns
+    /// past 8 hardware threads observed in profiling.
+    static func threadCount(
+        processorCount: Int = ProcessInfo.processInfo.processorCount
+    ) -> Int32 {
+        Int32(max(1, min(8, processorCount - 2)))
+    }
+}
+#endif

--- a/Tests/ManifoldBackendsTests/LlamaSamplingPolicyTests.swift
+++ b/Tests/ManifoldBackendsTests/LlamaSamplingPolicyTests.swift
@@ -1,0 +1,68 @@
+#if Llama
+import XCTest
+@testable import ManifoldLlama
+
+/// Unit tests for `LlamaSamplingPolicy` — verifies the consolidated
+/// hardware-selection logic shared between `LlamaModelLoader` and
+/// `LlamaEmbeddingBackend`. The policy takes its inputs as parameters so
+/// these tests don't have to mutate `ProcessInfo` env or hardware globals.
+final class LlamaSamplingPolicyTests: XCTestCase {
+
+    // MARK: - gpuLayerCount
+
+    #if targetEnvironment(simulator)
+    func test_gpuLayerCount_isZeroInSimulator_regardlessOfEnv() {
+        // In the simulator the policy hardcodes 0 — Metal is unreliable there
+        // and tests skip GPU paths anyway. The env-injection branch is dead
+        // code under simulator builds.
+        XCTAssertEqual(LlamaSamplingPolicy.gpuLayerCount(environment: [:]), 0)
+        XCTAssertEqual(
+            LlamaSamplingPolicy.gpuLayerCount(environment: ["LLAMA_FORCE_CPU_ONLY": "1"]),
+            0
+        )
+    }
+    #else
+    func test_gpuLayerCount_forceCPUEnvReturnsZero_onDevice() {
+        XCTAssertEqual(
+            LlamaSamplingPolicy.gpuLayerCount(environment: ["LLAMA_FORCE_CPU_ONLY": "1"]),
+            0
+        )
+    }
+
+    func test_gpuLayerCount_defaultsTo99_onDevice() {
+        XCTAssertEqual(LlamaSamplingPolicy.gpuLayerCount(environment: [:]), 99)
+        // A non-"1" value must not trigger the escape hatch.
+        XCTAssertEqual(
+            LlamaSamplingPolicy.gpuLayerCount(environment: ["LLAMA_FORCE_CPU_ONLY": "0"]),
+            99
+        )
+        XCTAssertEqual(
+            LlamaSamplingPolicy.gpuLayerCount(environment: ["LLAMA_FORCE_CPU_ONLY": "true"]),
+            99
+        )
+    }
+    #endif
+
+    // MARK: - threadCount
+
+    func test_threadCount_clampsToOneOnLowCoreCount() {
+        // processorCount - 2 = -1, which the policy must floor at 1.
+        XCTAssertEqual(LlamaSamplingPolicy.threadCount(processorCount: 1), 1)
+    }
+
+    func test_threadCount_reservesTwoCoresWithinBand() {
+        // 4 - 2 = 2 (within the [1, 8] band).
+        XCTAssertEqual(LlamaSamplingPolicy.threadCount(processorCount: 4), 2)
+    }
+
+    func test_threadCount_clampsToEightAtUpperBound() {
+        // 10 - 2 = 8 — exact upper-band match.
+        XCTAssertEqual(LlamaSamplingPolicy.threadCount(processorCount: 10), 8)
+    }
+
+    func test_threadCount_saturatesAtEightForLargeMachines() {
+        // 100 - 2 = 98, clamped down to 8.
+        XCTAssertEqual(LlamaSamplingPolicy.threadCount(processorCount: 100), 8)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Consolidates duplicated hardware-selection logic between `LlamaModelLoader` and `LlamaEmbeddingBackend` into a single `LlamaSamplingPolicy` value type. Closes a behavioural gap: the embedding-load path previously did not honor `LLAMA_FORCE_CPU_ONLY=1`, while the generation path did. After this PR, both honor it consistently.

## Behaviour change

`LLAMA_FORCE_CPU_ONLY=1` now forces CPU-only execution for embedding model loads as well as generation model loads. Memory-constrained MoE embedders that previously OOM'd on Metal can now fall back to mmap-paged CPU execution.

## Test plan
- [x] `swift build --build-tests --disable-default-traits`
- [x] `swift test --disable-default-traits --filter LlamaSamplingPolicyTests` (0 tests — `#if Llama` excludes the suite without the trait)
- [x] `swift test --traits Llama --filter LlamaSamplingPolicyTests` — 6/6 passing (env branches + threadCount clamps at 1/2/8/8)

Follow-up to #1344 (llama wrapper audit refresh).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>