### PR TITLE
ci: replace CodeQL default setup with manual-build workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,102 @@
+name: CodeQL
+
+# Replaces GitHub's "default setup" for code scanning. Default setup's Swift
+# autobuild runs `swift build` with default traits, which fails on this repo
+# because `mlx-swift-lm` (required ≥3.31) and `AnyLanguageModel` (pins
+# mlx-swift-lm <3) only coexist behind trait gates.
+#
+# Cost-shape choices:
+#   • Swift legs run on `macos-15` and are EXPENSIVE (~5–10 min × 10× macOS
+#     billing). Restricted to push-on-main + weekly cron, not per-PR.
+#   • actions + python run on `ubuntu-latest` (1× billing) on every PR; both
+#     finish in <1 min.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly baseline scan, Mondays 06:00 UTC. Keeps the Security tab fresh
+    # even on quiet weeks.
+    - cron: "0 6 * * 1"
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write   # required to upload SARIF results to the Security tab
+  actions: read
+
+jobs:
+  analyze-fast:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, python]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          queries: security-and-quality
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  analyze-swift:
+    name: Analyze (swift)
+    runs-on: macos-15
+    timeout-minutes: 30
+    # Swift CodeQL is too expensive for per-PR. Run on push to main + the
+    # weekly cron only. PR coverage comes from the fast (actions/python) leg.
+    if: github.event_name != 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.3"
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v5
+        with:
+          path: |
+            .build/artifacts
+            .build/checkouts
+            .build/repositories
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-codeql-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-codeql-spm-
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
+            ${{ runner.os }}-${{ runner.arch }}-spm-
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: swift
+          build-mode: manual
+          queries: security-and-quality
+
+      # `--disable-default-traits` matches what scripts/test.sh uses in CI.
+      # Trait-gated source (MLX, Llama, CloudSaaS, etc.) is excluded from the
+      # CodeQL database under this build — most security queries target
+      # patterns (force-unwraps, injection sinks, weak crypto) that don't
+      # require having every trait compiled. If you find Swift findings feel
+      # sparse, escalate to an all-traits build under a second matrix leg.
+      - name: Build Swift (manual mode for CodeQL tracer)
+        run: |
+          swift build --disable-default-traits --skip-update
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:swift"


### PR DESCRIPTION
## Summary

GitHub default setup's Swift autobuild runs a bare `swift build` with default traits, which fails on this repo because `mlx-swift-lm` (required ≥3.31) and `AnyLanguageModel` (pins `mlx-swift-lm <3`) only coexist behind trait gates. The initial default-setup run on `main` failed with the expected dependency resolution error.

This replaces default setup with a `.github/workflows/codeql.yml` that does a manual Swift build mirroring `scripts/test.sh` (`--disable-default-traits --skip-update`). Default setup has already been disabled via the API — this workflow takes over code scanning.

## Shape

- **`analyze-fast` (actions + python)** — `ubuntu-latest`, runs on every PR + push + weekly cron. <1 min per leg, ~free.
- **`analyze-swift`** — `macos-15`, push-to-`main` + weekly cron only (`if: github.event_name != 'pull_request'`). Skipping per-PR avoids ~5–10 macOS minutes per PR (10× billing), in line with the recent CI cost-reduction work.

Queries: `security-and-quality` (broader than default; narrow to `security` later if quality findings are noisy).

## Follow-ups

- [ ] Watch the first push-to-`main` Swift run land — if the manual build needs more than `--disable-default-traits`, tighten the flags.
- [ ] Triage the initial finding backlog in the Security tab.
- [ ] After a week or two of clean runs, promote `CodeQL` to a required status check on `main`.

## Test plan

- [ ] PR checks: `analyze-fast` matrix passes for both `actions` and `python`.
- [ ] `analyze-swift` is correctly skipped on the PR (not listed as a queued/failed check).
- [ ] After merge: push-to-`main` triggers `analyze-swift`; it completes green and findings (if any) appear in the Security tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)