### PR TITLE
feat: add public MemoryPressureEvent stream on InferenceService (#1295)

### DIFF
--- a/Sources/ManifoldInference/Services/InferenceService.swift
+++ b/Sources/ManifoldInference/Services/InferenceService.swift
@@ -74,6 +74,18 @@ public final class InferenceService {
     private let lifecycle: ModelLifecycleCoordinator
     private let generation: GenerationQueue
 
+    // MARK: - Memory Pressure Broadcasting
+
+    /// Fan-out broadcaster for memory-pressure and model-lifecycle events.
+    private let pressureBroadcaster = MemoryPressureBroadcaster()
+
+    /// UUID of the most recently successfully loaded model.
+    ///
+    /// Updated immediately after a successful ``loadModel`` commit and cleared on
+    /// ``unloadModel``. Used to populate the `modelID` field of ``MemoryPressureEvent``
+    /// without threading `ModelInfo` all the way through the unload path.
+    private var loadedModelID: UUID?
+
     // MARK: - Public Type Aliases (preserve InferenceService.GenerationRequestToken syntax)
 
     public typealias GenerationRequestToken = ManifoldInference.GenerationRequestToken
@@ -163,6 +175,9 @@ public final class InferenceService {
         ensureProviderWired()
         generation.stopGeneration()
         try await lifecycle.loadModel(from: modelInfo, plan: plan)
+        // Track the loaded model so willUnload/didUnload can carry the same UUID.
+        loadedModelID = modelInfo.id
+        pressureBroadcaster.send(.didReload(modelID: modelInfo.id))
     }
 
     /// Loads a cloud API backend from an `APIEndpointRecord` configuration.
@@ -177,10 +192,36 @@ public final class InferenceService {
     /// Unloads the current model and frees all associated memory.
     ///
     /// Also cancels in-flight generation and preempts outstanding load requests.
+    ///
+    /// Emits ``MemoryPressureEvent/willUnload(modelID:reason:)`` before unloading and
+    /// ``MemoryPressureEvent/didUnload(modelID:reason:)`` after. The default reason is
+    /// ``UnloadReason/userRequested``; call ``unloadModel(reason:)`` from internal paths
+    /// where the trigger is known.
     public func unloadModel() {
+        unloadModel(reason: .userRequested)
+    }
+
+    /// Internal variant of ``unloadModel()`` that carries an explicit ``UnloadReason``
+    /// so pressure-driven unloads emit the correct event label.
+    ///
+    /// Package-visible so ``ChatViewModel`` can specify
+    /// ``UnloadReason/criticalMemoryPressure`` when reacting to OS notifications.
+    package func unloadModel(reason: UnloadReason) {
         ensureProviderWired()
+        guard lifecycle.isModelLoaded else {
+            // Nothing loaded — stop generation for safety but emit no lifecycle events.
+            generation.stopGeneration()
+            lifecycle.unloadModel()
+            return
+        }
+        // Prefer the tracked UUID from the load path; fall back to a synthetic one for
+        // backends installed via the debug init (which bypass loadModel(from:plan:)).
+        let modelID = loadedModelID ?? UUID()
+        pressureBroadcaster.send(.willUnload(modelID: modelID, reason: reason))
         generation.stopGeneration()
         lifecycle.unloadModel()
+        pressureBroadcaster.send(.didUnload(modelID: modelID, reason: reason))
+        loadedModelID = nil
     }
 
     /// Streams primary-model readiness transitions.
@@ -756,6 +797,57 @@ extension InferenceService: GenerationContextProvider {
 extension InferenceService {
     public func registeredBackendSnapshot() -> EnabledBackends {
         lifecycle.registeredBackendSnapshot()
+    }
+}
+
+// MARK: - Memory Pressure Events
+
+extension InferenceService {
+
+    /// A stream of memory-pressure and model-lifecycle events for this service.
+    ///
+    /// Multiple subscribers are supported; each receives an independent copy of
+    /// every event broadcast after the stream is created. Events are buffered up
+    /// to 64 entries per subscriber (newest-only once the buffer is full) so
+    /// slow consumers don't stall the broadcaster.
+    ///
+    /// ```swift
+    /// Task {
+    ///     for await event in inferenceService.memoryPressureEvents() {
+    ///         switch event {
+    ///         case .levelChanged(let level):
+    ///             updateMemoryIndicator(level)
+    ///         case .willUnload(let id, let reason):
+    ///             print("Model \(id) will unload: \(reason)")
+    ///         case .didUnload(let id, _):
+    ///             showReloadBanner()
+    ///         case .didReload(let id):
+    ///             hideReloadBanner()
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// - Returns: An ``AsyncStream`` that yields ``MemoryPressureEvent`` values
+    ///   until the service is deallocated or the subscriber cancels iteration.
+    public func memoryPressureEvents() -> AsyncStream<MemoryPressureEvent> {
+        pressureBroadcaster.makeStream()
+    }
+
+    /// Notifies the service of an OS memory-pressure level change so a
+    /// ``MemoryPressureEvent/levelChanged(_:)`` event is emitted on all subscribers.
+    ///
+    /// Call this from the memory-pressure monitoring integration point (e.g.,
+    /// ``ChatViewModel/handleMemoryPressure()``) after the OS fires a notification.
+    /// This keeps `InferenceService` decoupled from the OS notification source while
+    /// letting subscribers observe level transitions without polling.
+    ///
+    /// Package-visible — `ManifoldUI` wires this from ``ChatViewModel``; host apps
+    /// that drive their own pressure monitoring should call
+    /// ``InferenceService/memoryPressureEvents()`` and ``ChatViewModel/handleMemoryPressure()``
+    /// rather than calling this directly.
+    package func notifyPressureLevel(_ level: MemoryPressureLevel) {
+        pressureBroadcaster.send(.levelChanged(level))
     }
 }
 

--- a/Sources/ManifoldInference/Services/MemoryPressureBroadcaster.swift
+++ b/Sources/ManifoldInference/Services/MemoryPressureBroadcaster.swift
@@ -1,0 +1,78 @@
+import Foundation
+import os
+
+// MARK: - MemoryPressureBroadcaster
+
+/// Fan-out relay that delivers ``MemoryPressureEvent`` values to an arbitrary
+/// number of independent ``AsyncStream`` subscribers.
+///
+/// Each call to ``makeStream()`` returns a fresh stream backed by its own
+/// continuation. ``send(_:)`` iterates all live continuations under a lock
+/// so the caller never needs to coordinate with subscriber count.
+///
+/// Thread-safety is provided by `OSAllocatedUnfairLock`, which is available
+/// on macOS 15 / iOS 18 — the n-1 minimum for this codebase.
+final class MemoryPressureBroadcaster: @unchecked Sendable {
+
+    private struct Registration {
+        let key: UUID
+        let continuation: AsyncStream<MemoryPressureEvent>.Continuation
+    }
+
+    // All mutable state is guarded by `lock`.
+    private let lock = OSAllocatedUnfairLock(initialState: [UUID: AsyncStream<MemoryPressureEvent>.Continuation]())
+
+    // MARK: - Subscriber Creation
+
+    /// Creates a new ``AsyncStream<MemoryPressureEvent>`` and registers its
+    /// continuation with this broadcaster.
+    ///
+    /// The stream finishes automatically when the subscriber lets it go out of
+    /// scope (Swift's `AsyncStream` calls the `onTermination` handler, which
+    /// removes the continuation from the registry).
+    func makeStream() -> AsyncStream<MemoryPressureEvent> {
+        let key = UUID()
+        let stream = AsyncStream<MemoryPressureEvent>(bufferingPolicy: .bufferingNewest(64)) { [weak self] continuation in
+            guard let self else {
+                continuation.finish()
+                return
+            }
+            lock.withLock { continuations in
+                continuations[key] = continuation
+            }
+            continuation.onTermination = { [weak self] _ in
+                self?.lock.withLock { continuations in
+                    continuations.removeValue(forKey: key)
+                }
+            }
+        }
+        return stream
+    }
+
+    // MARK: - Broadcast
+
+    /// Sends `event` to every live subscriber.
+    func send(_ event: MemoryPressureEvent) {
+        let snapshot = lock.withLock { $0.values.map { $0 } }
+        for continuation in snapshot {
+            continuation.yield(event)
+        }
+    }
+
+    // MARK: - Teardown
+
+    /// Finishes all live streams and clears the registry.
+    ///
+    /// Call from the owning object's `deinit` to allow subscriber tasks to
+    /// terminate cleanly rather than waiting forever.
+    func finishAll() {
+        let snapshot = lock.withLock { continuations -> [AsyncStream<MemoryPressureEvent>.Continuation] in
+            let values = continuations.values.map { $0 }
+            continuations.removeAll()
+            return values
+        }
+        for continuation in snapshot {
+            continuation.finish()
+        }
+    }
+}

--- a/Sources/ManifoldInference/Services/MemoryPressureEvent.swift
+++ b/Sources/ManifoldInference/Services/MemoryPressureEvent.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+// MARK: - UnloadReason
+
+/// The reason a model was unloaded from memory.
+public enum UnloadReason: Sendable, Equatable {
+    /// The OS raised a critical memory-pressure notification.
+    case criticalMemoryPressure
+    /// The host application or user explicitly requested unloading.
+    case userRequested
+    /// The model was evicted while the app was in the background.
+    case backgroundEviction
+}
+
+// MARK: - MemoryPressureEvent
+
+/// An event emitted by ``InferenceService/memoryPressureEvents()`` that describes
+/// model lifecycle or OS memory-pressure transitions.
+///
+/// Consumers subscribe to this stream to drive UI (e.g., show a "model unloaded"
+/// banner), log telemetry, or trigger reload logic — without polling
+/// ``InferenceService/isModelLoaded``.
+///
+/// ```swift
+/// for await event in inferenceService.memoryPressureEvents() {
+///     switch event {
+///     case .willUnload(let id, let reason):
+///         print("Model \(id) will unload: \(reason)")
+///     case .didUnload(let id, _):
+///         showReloadPrompt(for: id)
+///     case .didReload(let id):
+///         hideReloadPrompt(for: id)
+///     case .levelChanged(let level):
+///         updateMemoryIndicator(level)
+///     }
+/// }
+/// ```
+public enum MemoryPressureEvent: Sendable, Equatable {
+    /// The OS memory-pressure level changed.
+    case levelChanged(MemoryPressureLevel)
+    /// A model is about to be unloaded. `modelID` matches the ``ModelInfo/id`` passed
+    /// to the originating ``InferenceService/loadModel(from:plan:)`` call, or a
+    /// synthetic sentinel UUID when loading was done through a cloud backend path that
+    /// carries no `ModelInfo`.
+    case willUnload(modelID: UUID, reason: UnloadReason)
+    /// A model was unloaded. Follows every ``willUnload`` with the same `modelID`.
+    case didUnload(modelID: UUID, reason: UnloadReason)
+    /// A model was successfully (re-)loaded. `modelID` matches the ``ModelInfo/id``
+    /// of the newly loaded model.
+    case didReload(modelID: UUID)
+}

--- a/Sources/ManifoldUI/ViewModels/ChatViewModel+MemoryPressure.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel+MemoryPressure.swift
@@ -21,12 +21,21 @@ extension ChatViewModel {
         guard !actions.isEmpty else { return }
         lastPressureLevel = level
 
+        // Notify InferenceService subscribers about the new OS level. Do this
+        // before acting on the level so subscribers see the level change before
+        // any resulting willUnload/didUnload events.
+        inferenceService.notifyPressureLevel(level)
+
         for action in actions {
             switch action {
             case .stopGeneration:
                 stopGeneration()
             case .unloadModel:
-                unloadModel()
+                // Use the pressure-specific overload so subscribers receive the
+                // correct UnloadReason instead of the generic .userRequested.
+                inferenceService.unloadModel(reason: .criticalMemoryPressure)
+                loadCoordinator.invalidatePendingLoadIntent(resetActivityPhase: true)
+                invalidateTokenCaches()
             case .setError(let error):
                 activeError = error
             case .clearMemoryPressureError:

--- a/Tests/ManifoldInferenceTests/MemoryPressureEventTests.swift
+++ b/Tests/ManifoldInferenceTests/MemoryPressureEventTests.swift
@@ -1,0 +1,225 @@
+import XCTest
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+/// Tests for the MemoryPressureEvent stream on InferenceService.
+///
+/// These tests exercise the public ``InferenceService/memoryPressureEvents()``
+/// stream and the package-internal wiring paths that drive ``willUnload``,
+/// ``didUnload``, ``didReload``, and ``levelChanged`` events.
+@MainActor
+final class MemoryPressureEventTests: XCTestCase {
+
+    // MARK: - levelChanged
+
+    /// `notifyPressureLevel` emits a `levelChanged` event to all subscribers.
+    func test_notifyPressureLevel_emitsLevelChangedEvent() async {
+        let service = makeService()
+        let stream = service.memoryPressureEvents()
+
+        service.notifyPressureLevel(.warning)
+
+        let event = await firstEvent(from: stream)
+        XCTAssertEqual(event, .levelChanged(.warning))
+    }
+
+    func test_notifyPressureLevel_critical_emitsCorrectLevel() async {
+        let service = makeService()
+        let stream = service.memoryPressureEvents()
+
+        service.notifyPressureLevel(.critical)
+
+        let event = await firstEvent(from: stream)
+        XCTAssertEqual(event, .levelChanged(.critical))
+    }
+
+    // MARK: - Multiple Subscribers
+
+    /// All active subscribers receive the same event.
+    func test_multipleSubscribers_eachReceiveSameEvent() async {
+        let service = makeService()
+        let streamA = service.memoryPressureEvents()
+        let streamB = service.memoryPressureEvents()
+
+        service.notifyPressureLevel(.warning)
+
+        let eventA = await firstEvent(from: streamA)
+        let eventB = await firstEvent(from: streamB)
+        XCTAssertEqual(eventA, .levelChanged(.warning))
+        XCTAssertEqual(eventB, .levelChanged(.warning))
+    }
+
+    // MARK: - willUnload / didUnload (userRequested)
+
+    /// `unloadModel()` emits `willUnload` then `didUnload` when a model is loaded.
+    func test_unloadModel_withLoadedBackend_emitsWillAndDidUnloadEvents() async {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        let service = InferenceService(backend: mock, name: "Mock")
+        let stream = service.memoryPressureEvents()
+
+        service.unloadModel()
+
+        var received: [MemoryPressureEvent] = []
+        // Collect two events with a tight deadline.
+        let collected = await collectEvents(from: stream, count: 2, timeoutNanoseconds: 1_000_000_000)
+        received = collected
+
+        guard received.count == 2 else {
+            XCTFail("Expected 2 events (willUnload + didUnload), got \(received.count)")
+            return
+        }
+
+        if case .willUnload(_, let reason) = received[0] {
+            XCTAssertEqual(reason, .userRequested)
+        } else {
+            XCTFail("First event should be willUnload, got \(received[0])")
+        }
+
+        if case .didUnload(_, let reason) = received[1] {
+            XCTAssertEqual(reason, .userRequested)
+        } else {
+            XCTFail("Second event should be didUnload, got \(received[1])")
+        }
+    }
+
+    /// `unloadModel()` emits no unload events when no model is currently loaded.
+    func test_unloadModel_withNoLoadedModel_emitsNoUnloadEvents() async {
+        let service = makeService()
+        let stream = service.memoryPressureEvents()
+
+        service.unloadModel()
+
+        // Give any spurious events a chance to appear.
+        service.notifyPressureLevel(.nominal) // sentinel
+
+        let event = await firstEvent(from: stream)
+        // The sentinel levelChanged should arrive; no willUnload or didUnload.
+        XCTAssertEqual(event, .levelChanged(.nominal))
+    }
+
+    // MARK: - criticalMemoryPressure reason
+
+    /// `unloadModel(reason:)` with `.criticalMemoryPressure` emits the correct reason.
+    func test_unloadModel_criticalPressureReason_emitsCorrectReason() async {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        let service = InferenceService(backend: mock, name: "Mock")
+        let stream = service.memoryPressureEvents()
+
+        service.unloadModel(reason: .criticalMemoryPressure)
+
+        let events = await collectEvents(from: stream, count: 2, timeoutNanoseconds: 1_000_000_000)
+        guard events.count == 2 else {
+            XCTFail("Expected 2 events, got \(events.count)")
+            return
+        }
+
+        if case .willUnload(_, let reason) = events[0] {
+            XCTAssertEqual(reason, .criticalMemoryPressure)
+        } else {
+            XCTFail("First event should be willUnload, got \(events[0])")
+        }
+
+        if case .didUnload(_, let reason) = events[1] {
+            XCTAssertEqual(reason, .criticalMemoryPressure)
+        } else {
+            XCTFail("Second event should be didUnload, got \(events[1])")
+        }
+    }
+
+    // MARK: - modelID consistency
+
+    /// The `modelID` in `willUnload` and `didUnload` events is consistent.
+    func test_willAndDidUnload_shareTheSameModelID() async {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        let service = InferenceService(backend: mock, name: "Mock")
+        let stream = service.memoryPressureEvents()
+
+        service.unloadModel()
+
+        let events = await collectEvents(from: stream, count: 2, timeoutNanoseconds: 1_000_000_000)
+        guard events.count == 2 else {
+            XCTFail("Expected 2 events, got \(events.count)")
+            return
+        }
+
+        guard case .willUnload(let willID, _) = events[0],
+              case .didUnload(let didID, _) = events[1] else {
+            XCTFail("Expected willUnload + didUnload, got \(events)")
+            return
+        }
+
+        XCTAssertEqual(willID, didID, "willUnload and didUnload should carry the same modelID")
+    }
+
+    // MARK: - MemoryPressureHandler integration
+
+    /// `MemoryPressureHandler.fireCallbacks(level:)` can be used in tests to
+    /// verify that a registered callback fires; here we confirm the broadcaster
+    /// is wired correctly by driving it through `notifyPressureLevel` (which is
+    /// what the handler's callback would ultimately call via ChatViewModel).
+    func test_broadcasterSend_firesRegisteredCallbacks() async {
+        let broadcaster = MemoryPressureBroadcaster()
+        let stream = broadcaster.makeStream()
+
+        broadcaster.send(.levelChanged(.critical))
+
+        let event = await firstEvent(from: stream)
+        XCTAssertEqual(event, .levelChanged(.critical))
+    }
+
+    func test_broadcaster_finishAll_terminatesStreams() async {
+        let broadcaster = MemoryPressureBroadcaster()
+        let stream = broadcaster.makeStream()
+
+        broadcaster.finishAll()
+
+        // The stream should terminate (yield nil) immediately.
+        var iterator = stream.makeAsyncIterator()
+        let event = await iterator.next()
+        XCTAssertNil(event, "Stream should finish after finishAll()")
+    }
+
+    // MARK: - Helpers
+
+    private func makeService() -> InferenceService {
+        InferenceService()
+    }
+
+    /// Collects up to `count` events from `stream` within `timeoutNanoseconds`.
+    ///
+    /// Returns fewer than `count` events if the stream terminates or the timeout
+    /// elapses first. Uses `withTaskGroup` so the timeout races against the
+    /// collection task.
+    private func collectEvents(
+        from stream: AsyncStream<MemoryPressureEvent>,
+        count: Int,
+        timeoutNanoseconds: UInt64
+    ) async -> [MemoryPressureEvent] {
+        await withTaskGroup(of: [MemoryPressureEvent].self) { group in
+            group.addTask {
+                var collected: [MemoryPressureEvent] = []
+                for await event in stream {
+                    collected.append(event)
+                    if collected.count >= count { break }
+                }
+                return collected
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+                return []
+            }
+            let result = await group.next() ?? []
+            group.cancelAll()
+            return result
+        }
+    }
+
+    /// Returns the first event yielded by `stream` within 1 second.
+    private func firstEvent(from stream: AsyncStream<MemoryPressureEvent>) async -> MemoryPressureEvent? {
+        let events = await collectEvents(from: stream, count: 1, timeoutNanoseconds: 1_000_000_000)
+        return events.first
+    }
+}


### PR DESCRIPTION
## Summary

Consumer apps currently have no event-driven way to observe model unload/reload lifecycle events or OS memory-pressure transitions — they must poll `InferenceService.isModelLoaded` or subscribe to `@Observable` property changes. This PR adds a public broadcast stream that delivers structured events for all of these state transitions.

- Adds `MemoryPressureEvent` enum (`.levelChanged`, `.willUnload`, `.didUnload`, `.didReload`) and `UnloadReason` enum (`criticalMemoryPressure`, `userRequested`, `backgroundEviction`) to `ManifoldInference`
- Adds `MemoryPressureBroadcaster` (package-internal) — a fan-out relay backed by `OSAllocatedUnfairLock` that delivers events to an arbitrary number of independent `AsyncStream` subscribers
- Adds `InferenceService.memoryPressureEvents() -> AsyncStream<MemoryPressureEvent>` (public) — the subscriber-facing API
- Adds `InferenceService.unloadModel(reason:)` (package) — called by `ChatViewModel` for pressure-triggered unloads so the correct `UnloadReason` is carried in events
- Adds `InferenceService.notifyPressureLevel(_:)` (package) — called by `ChatViewModel.handleMemoryPressure()` to emit `.levelChanged` events when the OS fires a notification
- Wires `ChatViewModel+MemoryPressure.swift` to call both new package methods so existing pressure-handling logic now also drives the public stream
- 9 new `XCTestCase` tests in `ManifoldInferenceTests/MemoryPressureEventTests.swift`

Usage:
```swift
Task {
    for await event in inferenceService.memoryPressureEvents() {
        switch event {
        case .levelChanged(let level): updateMemoryIndicator(level)
        case .willUnload(let id, let reason): print("Unloading \(id): \(reason)")
        case .didUnload(let id, _): showReloadBanner()
        case .didReload(let id): hideReloadBanner()
        }
    }
}
```

Closes #1295.

## Test plan

- [x] `swift build --disable-default-traits` — clean (no errors)
- [x] `scripts/test.sh --filter ManifoldInferenceTests --disable-default-traits --skip-update` — 1559 passed, 0 failed
- [x] All 9 new `MemoryPressureEventTests` pass
- [x] No force-unwraps in new source files
- [x] No `try?` in new source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)