### PR TITLE
feat: wire GGUF manifest verification into download flow

### DIFF
--- a/Sources/ManifoldHuggingFace/BackgroundDownloadManager+URLSessionDelegate.swift
+++ b/Sources/ManifoldHuggingFace/BackgroundDownloadManager+URLSessionDelegate.swift
@@ -111,6 +111,27 @@ extension BackgroundDownloadManager: URLSessionDownloadDelegate {
                     }
 
                     try FileManager.default.moveItem(at: tempURL, to: destination)
+
+                    // Verify against a sidecar manifest when one is present next to the
+                    // destination file. Missing manifests are silently skipped; verification
+                    // failure re-enters the catch block which marks the download failed and
+                    // removes the destination file.
+                    if model.modelType == .gguf {
+                        do {
+                            try self.verifyGGUFManifestIfPresent(at: destination)
+                        } catch {
+                            // The file is already at its final location — remove it before
+                            // surfacing the error so a corrupt/tampered GGUF is never left
+                            // in the models directory.
+                            do {
+                                try FileManager.default.removeItem(at: destination)
+                            } catch let removeError {
+                                Log.download.error("Failed to remove GGUF after manifest verification failure: \(removeError.localizedDescription)")
+                            }
+                            throw error
+                        }
+                    }
+
                     Log.download.info("Download complete: \(model.displayName) → \(destination.lastPathComponent)")
 
                     self.activeDownloads[context.modelID]?.markCompleted(localURL: destination)

--- a/Sources/ManifoldHuggingFace/BackgroundDownloadManager.swift
+++ b/Sources/ManifoldHuggingFace/BackgroundDownloadManager.swift
@@ -556,6 +556,42 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
         )
     }
 
+    // MARK: - GGUF Manifest Verification
+
+    /// Verifier used after a GGUF download completes to check an optional sidecar
+    /// manifest. Exposed as `internal` so tests can inject an accepting verifier.
+    @ObservationIgnored
+    internal var ggufManifestVerifier: GGUFSignedManifestVerifier = GGUFSignedManifestVerifier()
+
+    /// Checks for a sidecar manifest alongside a freshly-downloaded GGUF file.
+    ///
+    /// The sidecar convention: if `<file>.manifest.json` exists next to the
+    /// downloaded GGUF, its contents are treated as a ``GGUFSignedManifest`` and
+    /// the file digest is verified against it. Missing manifests are silently
+    /// skipped so existing downloads without a manifest continue to work.
+    ///
+    /// Call this *after* the GGUF file has been moved to its final destination
+    /// so the file hash is computed against the canonical on-disk bytes.
+    ///
+    /// - Parameter fileURL: Final on-disk URL of the downloaded GGUF.
+    /// - Throws: ``GGUFSignedManifestVerificationError`` when a manifest is present
+    ///   but verification fails (unsigned, signature rejected, digest mismatch, …).
+    internal func verifyGGUFManifestIfPresent(at fileURL: URL) throws {
+        let manifestURL = fileURL.appendingPathExtension("manifest.json")
+        guard FileManager.default.fileExists(atPath: manifestURL.path) else {
+            // No sidecar manifest — skip verification without logging noise.
+            return
+        }
+        let manifestData: Data
+        do {
+            manifestData = try Data(contentsOf: manifestURL)
+        } catch {
+            Log.download.error("Failed to read GGUF manifest at \(manifestURL.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            throw error
+        }
+        try ggufManifestVerifier.verify(fileURL: fileURL, manifestData: manifestData)
+    }
+
     // MARK: - Download Coordination
 
     @MainActor

--- a/Tests/ManifoldHuggingFaceTests/GGUFManifestVerificationTests.swift
+++ b/Tests/ManifoldHuggingFaceTests/GGUFManifestVerificationTests.swift
@@ -1,0 +1,143 @@
+@preconcurrency import XCTest
+import CryptoKit
+@testable import ManifoldInference
+#if HuggingFace
+@testable import ManifoldHuggingFace
+
+// MARK: - Helpers
+
+private struct AcceptingSignatureVerifier: GGUFSignedManifestSignatureVerifying {
+    func verify(signature _: GGUFSignedManifest.Signature, canonicalPayload _: Data) throws -> Bool {
+        true
+    }
+}
+
+/// Unit tests for the sidecar GGUF manifest verification wired into
+/// BackgroundDownloadManager's single-file download completion path.
+///
+/// These tests exercise `verifyGGUFManifestIfPresent(at:)` directly — they do
+/// not create a real URLSession background task, so they are fast and deterministic.
+@MainActor
+final class GGUFManifestVerificationTests: XCTestCase {
+
+    private var tempDirectory: URL!
+    private var manager: BackgroundDownloadManager!
+    private var suiteName: String!
+    private var testDefaults: UserDefaults!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GGUFManifestVerificationTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+
+        suiteName = "com.manifoldkit.test.ggufmanifest.\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)!
+
+        manager = BackgroundDownloadManager(
+            storageService: ModelStorageService(baseDirectory: tempDirectory),
+            sessionIdentifier: "com.manifoldkit.test.ggufmanifest.\(UUID().uuidString)",
+            userDefaults: testDefaults
+        )
+        // Inject an accepting signature verifier so tests can focus on digest
+        // logic without tripping the fail-closed default signature policy.
+        manager.ggufManifestVerifier = GGUFSignedManifestVerifier(
+            signatureVerifier: AcceptingSignatureVerifier()
+        )
+    }
+
+    override func tearDown() async throws {
+        if let tempDirectory {
+            try? FileManager.default.removeItem(at: tempDirectory)
+        }
+        if let suiteName {
+            testDefaults?.removePersistentDomain(forName: suiteName)
+        }
+        tempDirectory = nil
+        manager = nil
+        testDefaults = nil
+        suiteName = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - No sidecar manifest
+
+    func test_verifyGGUFManifestIfPresent_noManifest_passes() throws {
+        let fileURL = tempDirectory.appendingPathComponent("model.gguf")
+        try Data("fake gguf bytes".utf8).write(to: fileURL)
+        // No manifest file alongside it — verification should succeed silently.
+        XCTAssertNoThrow(try manager.verifyGGUFManifestIfPresent(at: fileURL))
+    }
+
+    // MARK: - Matching digest
+
+    func test_verifyGGUFManifestIfPresent_matchingDigest_passes() throws {
+        let content = Data("GGUF model weights".utf8)
+        let fileURL = tempDirectory.appendingPathComponent("model.gguf")
+        try content.write(to: fileURL)
+
+        let manifest = makeManifest(path: "model.gguf", sha256: sha256Hex(content))
+        let manifestURL = fileURL.appendingPathExtension("manifest.json")
+        try JSONEncoder().encode(manifest).write(to: manifestURL)
+
+        XCTAssertNoThrow(try manager.verifyGGUFManifestIfPresent(at: fileURL))
+    }
+
+    // MARK: - Digest mismatch → error
+
+    func test_verifyGGUFManifestIfPresent_digestMismatch_throws() throws {
+        let originalContent = Data("original weights".utf8)
+        let tamperedContent = Data("tampered weights".utf8)
+
+        let fileURL = tempDirectory.appendingPathComponent("model.gguf")
+        // Write tampered bytes to the file but record the original digest in the manifest.
+        try tamperedContent.write(to: fileURL)
+
+        let manifest = makeManifest(path: "model.gguf", sha256: sha256Hex(originalContent))
+        let manifestURL = fileURL.appendingPathExtension("manifest.json")
+        try JSONEncoder().encode(manifest).write(to: manifestURL)
+
+        XCTAssertThrowsError(try manager.verifyGGUFManifestIfPresent(at: fileURL)) { error in
+            guard case GGUFSignedManifestVerificationError.digestMismatch(let path, _, _) = error else {
+                XCTFail("Expected digestMismatch, got \(error)")
+                return
+            }
+            XCTAssertEqual(path, "model.gguf")
+        }
+    }
+
+    // MARK: - Manifest present but unsigned → error (fail-closed)
+
+    func test_verifyGGUFManifestIfPresent_unsignedManifest_throws() throws {
+        // Even with an accepting verifier, an *unsigned* manifest (nil signature)
+        // must be rejected — the policy is fail-closed on unsigned input.
+        let content = Data("GGUF model weights".utf8)
+        let fileURL = tempDirectory.appendingPathComponent("model.gguf")
+        try content.write(to: fileURL)
+
+        let manifest = GGUFSignedManifest(
+            payload: .init(files: [.init(path: "model.gguf", sha256: sha256Hex(content))]),
+            signature: nil
+        )
+        let manifestURL = fileURL.appendingPathExtension("manifest.json")
+        try JSONEncoder().encode(manifest).write(to: manifestURL)
+
+        XCTAssertThrowsError(try manager.verifyGGUFManifestIfPresent(at: fileURL)) { error in
+            XCTAssertEqual(error as? GGUFSignedManifestVerificationError, .unsignedManifest)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeManifest(path: String, sha256: String) -> GGUFSignedManifest {
+        GGUFSignedManifest(
+            payload: .init(files: [.init(path: path, sha256: sha256)]),
+            signature: .init(algorithm: "placeholder-ed25519", keyID: "test-key", value: "sig")
+        )
+    }
+
+    private func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Closes #367.

Wires the existing `GGUFSignedManifestVerifier` infrastructure into the single-file GGUF download completion path inside `BackgroundDownloadManager`.

**What was added:**

- `BackgroundDownloadManager.verifyGGUFManifestIfPresent(at:)` — looks for a `<filename>.gguf.manifest.json` sidecar file alongside the downloaded GGUF. If present, reads the manifest and calls `GGUFSignedManifestVerifier.verify(fileURL:manifestData:)`. If absent, returns without error (backwards-compatible with all existing downloads).
- On verification failure the downloaded GGUF is deleted before the error is re-thrown, so a tampered or corrupted file never remains in the models directory.
- The method is called in the `didFinishDownloadingTo` delegate handler, immediately after the file is moved to its final destination, only for `.gguf` model types.
- `ggufManifestVerifier` is exposed as `internal` so tests can inject an accepting signature verifier and focus on digest logic independently of the fail-closed default signature policy.

**Sidecar convention:** `<model-filename>.manifest.json` placed alongside the GGUF in the models directory. For example, a file at `Models/mistral-7b.gguf` is paired with `Models/mistral-7b.gguf.manifest.json`. Distributors that want integrity enforcement ship the manifest alongside the model file (e.g. as an extra HuggingFace repo file).

**No manifest = no error** — the opt-in design means the change is safe to ship before any manifests are published.

## Test plan

- [x] `test_verifyGGUFManifestIfPresent_noManifest_passes` — no sidecar, no error
- [x] `test_verifyGGUFManifestIfPresent_matchingDigest_passes` — sidecar present, digest correct
- [x] `test_verifyGGUFManifestIfPresent_digestMismatch_throws` — sidecar present, file tampered → `digestMismatch` error
- [x] `test_verifyGGUFManifestIfPresent_unsignedManifest_throws` — manifest with nil signature → `unsignedManifest` error (fail-closed)
- [x] Full `ManifoldHuggingFaceTests` suite (167 tests): all pass
- [x] `ManifoldInferenceTests` suite (1578 tests + 5 skips): no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)