### PR TITLE
feat(mcp): enforce Foundation Models tool cap + settings UI counter

### DIFF
--- a/Sources/ManifoldFoundation/FoundationBackend.swift
+++ b/Sources/ManifoldFoundation/FoundationBackend.swift
@@ -139,7 +139,14 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
         // partially-decoded structure but we do not surface name/argument
         // deltas as separate events (parity with MLXBackend's inline parser).
         streamsToolCallArguments: false,
-        supportsGuidedStructuredOutput: true
+        supportsGuidedStructuredOutput: true,
+        // Apple's on-device model degrades sharply once the tool catalogue
+        // exceeds ~16 entries — the schema definitions consume an increasing
+        // fraction of its fixed context budget. Advertising more than 16 tools
+        // would leave less room for user content and reduce reasoning quality.
+        // ConversationTurnExecutor reads this cap and truncates the
+        // `GenerationConfig.tools` list before each turn.
+        maxAdvertisedToolCount: 16
     )
 
     // MARK: - Private

--- a/Sources/ManifoldInference/Protocols/BackendCapabilities.swift
+++ b/Sources/ManifoldInference/Protocols/BackendCapabilities.swift
@@ -154,6 +154,21 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
     /// sharing the MLX runtime) sets this to `true`.
     public let sharesMLXProcessResources: Bool
 
+    /// Hard cap on the number of tools that may be advertised to this backend
+    /// in a single generation turn.
+    ///
+    /// When non-`nil`, `ConversationTurnExecutor` truncates the tool list it
+    /// passes to `GenerationConfig.tools` to at most this many entries —
+    /// lexicographic order, so the selection is deterministic. Backends that
+    /// impose no limit leave this `nil`.
+    ///
+    /// ``FoundationBackend`` sets this to `16`: Apple's on-device model
+    /// degrades when the schema catalogue grows too large because it spends
+    /// an increasing share of its context budget re-reading tool definitions
+    /// rather than reasoning. `16` is the empirically-derived ceiling (see
+    /// `MCPToolFilter.foundationModelsToolCap`).
+    public let maxAdvertisedToolCount: Int?
+
     /// Preferred structured-output mechanism implied by this capability set.
     public var preferredStructuredOutputSupport: StructuredOutputSupport {
         if supportsGrammarConstrainedSampling {
@@ -194,7 +209,8 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         streamsToolCallArguments: Bool = false,
         supportsParallelToolCalls: Bool = false,
         supportsGuidedStructuredOutput: Bool = false,
-        sharesMLXProcessResources: Bool = false
+        sharesMLXProcessResources: Bool = false,
+        maxAdvertisedToolCount: Int? = nil
     ) {
         self.supportedParameters = supportedParameters
         self.maxContextTokens = maxContextTokens
@@ -217,6 +233,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         self.supportsParallelToolCalls = supportsParallelToolCalls
         self.supportsGuidedStructuredOutput = supportsGuidedStructuredOutput
         self.sharesMLXProcessResources = sharesMLXProcessResources
+        self.maxAdvertisedToolCount = maxAdvertisedToolCount
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -241,6 +258,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         case supportsParallelToolCalls
         case supportsGuidedStructuredOutput
         case sharesMLXProcessResources
+        case maxAdvertisedToolCount
     }
 
     public init(from decoder: Decoder) throws {
@@ -266,6 +284,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         supportsParallelToolCalls = (try c.decodeIfPresent(Bool.self, forKey: .supportsParallelToolCalls)) ?? false
         supportsGuidedStructuredOutput = (try c.decodeIfPresent(Bool.self, forKey: .supportsGuidedStructuredOutput)) ?? false
         sharesMLXProcessResources = (try c.decodeIfPresent(Bool.self, forKey: .sharesMLXProcessResources)) ?? false
+        maxAdvertisedToolCount = try c.decodeIfPresent(Int.self, forKey: .maxAdvertisedToolCount)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -291,5 +310,6 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         try c.encode(supportsParallelToolCalls, forKey: .supportsParallelToolCalls)
         try c.encode(supportsGuidedStructuredOutput, forKey: .supportsGuidedStructuredOutput)
         try c.encode(sharesMLXProcessResources, forKey: .sharesMLXProcessResources)
+        try c.encodeIfPresent(maxAdvertisedToolCount, forKey: .maxAdvertisedToolCount)
     }
 }

--- a/Sources/ManifoldMCP/MCPToolCountView.swift
+++ b/Sources/ManifoldMCP/MCPToolCountView.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+/// A settings-row component that shows how many MCP tools are currently registered
+/// and—when Apple Intelligence is available—how many of those fit within the
+/// Foundation Models tool cap.
+///
+/// Intended for use inside a `Form` or `List` settings screen. A typical placement
+/// is in a dedicated "MCP Servers" or "Tool Calling" section:
+///
+/// ```swift
+/// Section("Tool Calling") {
+///     MCPToolCountView(
+///         totalToolCount: source.currentToolNames().count,
+///         compatibleToolCount: compatibleNames.count
+///     )
+/// }
+/// ```
+///
+/// The "(16 max with Apple Intelligence)" footnote is only shown when the device
+/// is running iOS 26+ / macOS 26+, keeping the UI clean on older OS versions where
+/// Foundation Models is not available.
+public struct MCPToolCountView: View {
+
+    /// Total number of tools currently registered across all MCP servers.
+    public let totalToolCount: Int
+
+    /// Number of those tools whose JSON schemas are compatible with the
+    /// Foundation Models tool surface (non-nil only when the caller has
+    /// computed this value, e.g. via ``MCPToolSource/foundationModelsCompatibleNames(maxDepth:)``).
+    /// When `nil`, only the total count is displayed.
+    public let compatibleToolCount: Int?
+
+    public init(totalToolCount: Int, compatibleToolCount: Int? = nil) {
+        self.totalToolCount = totalToolCount
+        self.compatibleToolCount = compatibleToolCount
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("Tools enabled")
+                Spacer()
+                Text(countLabel)
+                    .foregroundStyle(.secondary)
+            }
+            if let note = appleIntelligenceNote {
+                Text(note)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Private helpers
+
+    private var countLabel: String {
+        if let compatibleToolCount {
+            return "\(compatibleToolCount) of \(totalToolCount)"
+        }
+        return "\(totalToolCount)"
+    }
+
+    /// Returns a localized footnote when the OS supports Foundation Models and
+    /// the tool list would be truncated by the 16-tool cap.
+    ///
+    /// The `#available` check prevents the note from appearing on older OS versions
+    /// where Apple Intelligence is not present — no hardcoded platform check.
+    private var appleIntelligenceNote: String? {
+        guard #available(iOS 26, macOS 26, *) else { return nil }
+        let cap = MCPToolFilter.foundationModelsToolCap
+        let effectiveTotal = compatibleToolCount ?? totalToolCount
+        if effectiveTotal > cap {
+            return "Up to \(cap) tools are used with Apple Intelligence."
+        }
+        return nil
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("Under cap") {
+    Form {
+        Section("Tool Calling") {
+            MCPToolCountView(totalToolCount: 8, compatibleToolCount: 8)
+        }
+    }
+}
+
+#Preview("Over cap") {
+    Form {
+        Section("Tool Calling") {
+            MCPToolCountView(totalToolCount: 25, compatibleToolCount: 20)
+        }
+    }
+}
+
+#Preview("No compatible count") {
+    Form {
+        Section("Tool Calling") {
+            MCPToolCountView(totalToolCount: 12)
+        }
+    }
+}
+#endif

--- a/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
@@ -1053,7 +1053,16 @@ struct ConversationTurnExecutor: Sendable {
     @MainActor
     private func readAdvertisedToolDefinitions() async -> [ToolDefinition] {
         guard let registry = inferenceService.toolRegistry else { return [] }
-        return registry.advertisedDefinitions
+        let definitions = registry.advertisedDefinitions
+        // When the active backend declares a hard cap on how many tools it can
+        // handle per turn, truncate the list before building the GenerationConfig.
+        // The definitions are already sorted alphabetically by ToolRegistry, so
+        // `prefix` always picks the same lexicographically-first N tools —
+        // deterministic ordering keeps the "X of Y tools enabled" UI stable.
+        if let cap = inferenceService.capabilities?.maxAdvertisedToolCount, definitions.count > cap {
+            return Array(definitions.prefix(cap))
+        }
+        return definitions
     }
 
     @MainActor

--- a/Tests/ManifoldRuntimeTests/FoundationBackendToolCapTests.swift
+++ b/Tests/ManifoldRuntimeTests/FoundationBackendToolCapTests.swift
@@ -1,0 +1,242 @@
+@preconcurrency import XCTest
+import Foundation
+@testable import ManifoldRuntime
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+/// Verifies that ``ConversationTurnExecutor`` honours the
+/// ``BackendCapabilities/maxAdvertisedToolCount`` cap when building the
+/// ``GenerationConfig/tools`` list for each turn.
+///
+/// The cap exists for backends like `FoundationBackend` that degrade when the
+/// tool catalogue exceeds a small number of entries. When set, the executor
+/// must truncate the advertised tool list to at most `cap` entries before
+/// enqueuing the generation request.
+@MainActor
+final class FoundationBackendToolCapTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeCapBackend(cap: Int) -> MockInferenceBackend {
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        // Mirror the FoundationBackend capability set, but with a configurable cap
+        // so this test does not require a real Apple Intelligence entitlement.
+        backend.capabilities = BackendCapabilities(
+            supportedParameters: [.temperature],
+            maxContextTokens: 4096,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsToolCalling: true,
+            maxAdvertisedToolCount: cap
+        )
+        return backend
+    }
+
+    private func makeRuntime(
+        backend: MockInferenceBackend,
+        registry: ToolRegistry
+    ) -> ConversationRuntime {
+        let inference = InferenceService(backend: backend, name: "Mock", toolRegistry: registry)
+        let store = CapTestMessageStore()
+        return ConversationRuntime(messageStore: store, inferenceService: inference)
+    }
+
+    private func makeToolRegistry(count: Int) -> ToolRegistry {
+        let registry = ToolRegistry()
+        for index in 0..<count {
+            let name = String(format: "tool_%02d", index)
+            registry.register(StubToolExecutor(name: name))
+        }
+        return registry
+    }
+
+    private func collectUntilStreamFinished(
+        from runtime: ConversationRuntime
+    ) async throws -> [ConversationEvent] {
+        var events: [ConversationEvent] = []
+        let task = Task {
+            for await event in runtime.events {
+                events.append(event)
+                if case .streamFinished = event { break }
+                if case .errorRaised = event { break }
+            }
+            return events
+        }
+        return try await withThrowingTaskGroup(of: [ConversationEvent].self) { group in
+            group.addTask { await task.value }
+            group.addTask {
+                try await Task.sleep(for: .seconds(5))
+                task.cancel()
+                throw CancellationError()
+            }
+            let first = try await group.next()
+            group.cancelAll()
+            return first ?? []
+        }
+    }
+
+    // MARK: - Tests
+
+    /// When the backend advertises a cap smaller than the number of registered
+    /// tools, the generation request must receive at most `cap` tools.
+    func test_toolCapIsEnforced_whenBackendHasMaxAdvertisedToolCount() async throws {
+        let cap = 3
+        let totalTools = 20
+        let backend = makeCapBackend(cap: cap)
+        let registry = makeToolRegistry(count: totalTools)
+        let runtime = makeRuntime(backend: backend, registry: registry)
+
+        let handle = try await runtime.processTurn(TurnInput(
+            sessionID: UUID(),
+            kind: .send(text: "use any tool")
+        ))
+
+        let events = try await collectUntilStreamFinished(from: runtime)
+        _ = events  // events consumed; we care about the backend's received config
+
+        let config = try XCTUnwrap(backend.lastConfig,
+            "backend.lastConfig must be set after a generation turn")
+
+        XCTAssertLessThanOrEqual(config.tools.count, cap,
+            "backend must not receive more than \(cap) tools (maxAdvertisedToolCount)")
+        XCTAssertEqual(config.tools.count, cap,
+            "backend should receive exactly \(cap) tools when more are registered")
+
+        // Sabotage check: removing the cap enforcement in readAdvertisedToolDefinitions
+        // would cause config.tools.count == 20, failing the assertion above.
+        _ = handle
+    }
+
+    /// When the backend has no tool cap (`maxAdvertisedToolCount == nil`), all
+    /// registered tools are forwarded unchanged.
+    func test_allToolsForwarded_whenNoCapIsSet() async throws {
+        let totalTools = 8
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.capabilities = BackendCapabilities(
+            supportedParameters: [.temperature],
+            maxContextTokens: 4096,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsToolCalling: true
+            // maxAdvertisedToolCount intentionally omitted (defaults to nil)
+        )
+        let registry = makeToolRegistry(count: totalTools)
+        let runtime = makeRuntime(backend: backend, registry: registry)
+
+        let handle = try await runtime.processTurn(TurnInput(
+            sessionID: UUID(),
+            kind: .send(text: "use any tool")
+        ))
+
+        let events = try await collectUntilStreamFinished(from: runtime)
+        _ = events
+
+        let config = try XCTUnwrap(backend.lastConfig)
+        XCTAssertEqual(config.tools.count, totalTools,
+            "all \(totalTools) tools must be forwarded when no cap is set")
+
+        _ = handle
+    }
+
+    /// When the registered tool count is already at or below the cap, the full
+    /// list is forwarded without truncation.
+    func test_toolsNotTruncated_whenCountBelowCap() async throws {
+        let cap = 16
+        let totalTools = 5
+        let backend = makeCapBackend(cap: cap)
+        let registry = makeToolRegistry(count: totalTools)
+        let runtime = makeRuntime(backend: backend, registry: registry)
+
+        let handle = try await runtime.processTurn(TurnInput(
+            sessionID: UUID(),
+            kind: .send(text: "use any tool")
+        ))
+
+        let events = try await collectUntilStreamFinished(from: runtime)
+        _ = events
+
+        let config = try XCTUnwrap(backend.lastConfig)
+        XCTAssertEqual(config.tools.count, totalTools,
+            "tool list must not be truncated when count (\(totalTools)) is below cap (\(cap))")
+
+        _ = handle
+    }
+
+    /// The truncated list uses the same alphabetic ordering as
+    /// ``ToolRegistry/advertisedDefinitions``, so the first `cap` entries are
+    /// always deterministic regardless of registration order.
+    func test_truncatedToolsAreAlphabeticallyFirst() async throws {
+        let cap = 2
+        let backend = makeCapBackend(cap: cap)
+        let registry = ToolRegistry()
+        // Register in reverse-alpha order to confirm ordering is applied first.
+        registry.register(StubToolExecutor(name: "zebra"))
+        registry.register(StubToolExecutor(name: "mango"))
+        registry.register(StubToolExecutor(name: "apple"))
+        registry.register(StubToolExecutor(name: "banana"))
+        let runtime = makeRuntime(backend: backend, registry: registry)
+
+        let handle = try await runtime.processTurn(TurnInput(
+            sessionID: UUID(),
+            kind: .send(text: "use any tool")
+        ))
+
+        let events = try await collectUntilStreamFinished(from: runtime)
+        _ = events
+
+        let config = try XCTUnwrap(backend.lastConfig)
+        XCTAssertEqual(config.tools.map(\.name), ["apple", "banana"],
+            "truncated list must contain the lexicographically-first \(cap) tools")
+
+        _ = handle
+    }
+}
+
+// MARK: - Minimal ToolExecutor stub
+
+/// Registers as a tool executor with no-op dispatch. Used to populate a
+/// ToolRegistry in tests without requiring a full MCP server setup.
+private struct StubToolExecutor: ToolExecutor, Sendable {
+    let definition: ToolDefinition
+
+    init(name: String) {
+        self.definition = ToolDefinition(
+            name: name,
+            description: "Stub tool \(name)",
+            parameters: .object(["type": .string("object")])
+        )
+    }
+
+    func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+        ToolResult(callId: "", content: "ok")
+    }
+}
+
+// MARK: - Minimal in-memory MessageStore for this test file
+
+private final class CapTestMessageStore: MessageStore, @unchecked Sendable {
+    private var messages: [UUID: ChatMessageRecord] = [:]
+
+    func insertMessage(_ message: ChatMessageRecord) async throws {
+        messages[message.id] = message
+    }
+
+    func updateMessage(_ message: ChatMessageRecord) async throws {
+        messages[message.id] = message
+    }
+
+    func deleteMessage(_ messageID: UUID) async throws {
+        messages.removeValue(forKey: messageID)
+    }
+
+    func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
+        messages.values.filter { $0.sessionID == sessionID }
+            .sorted { $0.timestamp < $1.timestamp }
+    }
+
+    func deleteMessages(for sessionID: UUID) async throws {
+        messages = messages.filter { $0.value.sessionID != sessionID }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `BackendCapabilities.maxAdvertisedToolCount: Int?` — a per-backend hard cap on how many tools may be advertised in a generation turn. `FoundationBackend` sets this to `16` (Apple's empirical ceiling before schema recitation dominates context).
- `ConversationTurnExecutor.readAdvertisedToolDefinitions()` now reads this cap and truncates `GenerationConfig.tools` to at most `cap` entries (alphabetically first, for deterministic ordering) before each enqueue.
- Adds `MCPToolCountView` in `ManifoldMCP` — a SwiftUI `Form`-row component showing "X of Y tools enabled" with a conditional "(up to 16 with Apple Intelligence)" footnote gated on `#available(iOS 26, macOS 26, *)`.
- Four new tests in `ManifoldRuntimeTests/FoundationBackendToolCapTests` cover: cap enforced, no-cap passthrough, below-cap no-truncation, and alphabetic ordering of the truncated list.

Closes #792

## Test plan

- [x] `scripts/test.sh --filter ManifoldMCPTests --disable-default-traits --skip-update --traits MCP` — 183 passed
- [x] `scripts/test.sh --filter ManifoldRuntimeTests --disable-default-traits --skip-update` — 301 passed (4 new)
- [x] Full CI shape: 3,339 passed, 0 failed
- [x] Swift Testing suite: 83 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)