### PR TITLE
fix(security): enforce SHA-256 checksums on curated GGUF entries [SEC-14]

### DIFF
--- a/Tests/ManifoldInferenceTests/CuratedModelChecksumAuditTest.swift
+++ b/Tests/ManifoldInferenceTests/CuratedModelChecksumAuditTest.swift
@@ -3,15 +3,21 @@ import XCTest
 
 /// Audits the curated model list for SHA-256 integrity metadata.
 ///
-/// Advisory tier (warning only):
-///   GGUF entries with `expectedSHA256 == nil` are enumerated and printed.
-///   This is intentionally a soft failure until all LFS pointer hashes
-///   are populated — see SEC-14.
-///
 /// Hard gate (XCTFail):
-///   Any populated `expectedSHA256` must be a 64-character lowercase hex
-///   string. An empty string or wrong-length value is silently useless and
-///   would pass validation while providing false confidence.
+///   Every `.gguf` entry in the real `CuratedModel.all` must carry a non-nil,
+///   64-character lowercase hex `expectedSHA256`. The empty-list-by-default
+///   case is the only exempt state — when an app ships an opinionated curated
+///   list, every GGUF entry is a supply-chain trust boundary and missing
+///   integrity metadata is a fail-the-build problem (SEC-14).
+///
+///   Any populated `expectedSHA256` must be 64-char lowercase hex. An empty
+///   string or wrong-length value would silently pass validation while
+///   providing false confidence.
+///
+/// Fixture tier:
+///   The fixture-based tests below exercise the audit FILTER logic itself
+///   (verified vs. unverified, GGUF vs. non-GGUF) with a synthetic
+///   `CuratedModel.all` so the predicate stays correct as the schema evolves.
 final class CuratedModelChecksumAuditTest: XCTestCase {
 
     // MARK: - Fixtures
@@ -72,22 +78,39 @@ final class CuratedModelChecksumAuditTest: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - Advisory: list models that still need hashes
+    // MARK: - Hard gate: real curated list must have checksums on every GGUF
 
-    /// This test is currently advisory — it prints models missing checksums
-    /// and will be promoted to a hard XCTFail once all LFS hashes are populated.
-    func test_allCuratedGGUFModelsHaveExpectedSHA256() {
+    /// Inspects the *real* `CuratedModel.all` as captured before setUp installed
+    /// the fixture. The empty default is exempt — apps that ship an opinionated
+    /// curated list MUST include `expectedSHA256` on every `.gguf` entry, or
+    /// CI fails here (SEC-14).
+    func test_realCuratedList_everyGGUFHasExpectedSHA256() {
+        guard !previousAll.isEmpty else {
+            // ManifoldKit ships an empty default list — apps populate it.
+            // Nothing to verify; promoting future additions to fail this gate
+            // is what the assertion below enforces once entries appear.
+            return
+        }
+
+        let missing = previousAll
+            .filter { $0.modelType == .gguf && $0.expectedSHA256 == nil }
+            .map(\.repoID)
+
+        XCTAssertTrue(
+            missing.isEmpty,
+            "Curated GGUF models are missing expectedSHA256 — populate from the HuggingFace LFS pointer (oid sha256:<hex>): \(missing.joined(separator: ", "))"
+        )
+    }
+
+    // MARK: - Filter logic: confirm verified/unverified classification
+
+    /// Exercises the audit filter against the synthetic fixture installed in
+    /// setUp. Guards the predicate so the hard gate above stays meaningful.
+    func test_auditFilter_classifiesFixtureCorrectly() {
         let missing = CuratedModel.all
             .filter { $0.modelType == .gguf && $0.expectedSHA256 == nil }
             .map(\.repoID)
 
-        if !missing.isEmpty {
-            // Change to XCTFail once all entries have hashes (SEC-14).
-            print("WARNING: curated GGUF models missing expectedSHA256: \(missing.joined(separator: ", "))")
-        }
-
-        // Verify the verified entry is NOT in the missing list — ensuring the
-        // filter only flags genuinely nil entries.
         let missingSet = Set(missing)
         XCTAssertFalse(
             missingSet.contains("example/verified-GGUF"),
@@ -95,7 +118,7 @@ final class CuratedModelChecksumAuditTest: XCTestCase {
         )
         XCTAssertTrue(
             missingSet.contains("example/unverified-GGUF"),
-            "Unverified model must appear in the missing-checksum list — sabotage check"
+            "Unverified model must appear in the missing-checksum list"
         )
     }
 


### PR DESCRIPTION
## Summary

Promotes the curated-model checksum audit from advisory (`print` warning) to a hard CI gate. Any populated `CuratedModel.all` entry of type `.gguf` that ships without `expectedSHA256` now fails `CuratedModelChecksumAuditTest`.

Closes SEC-14 from `SECURITY_REMEDIATION_PLAN_REVIEWED.md`.

## Current state of `CuratedModel.all`

**Empty by design.** ManifoldKit ships zero opinionated curated models — apps populate the list at startup. The hard gate is the tripwire for future additions: as soon as any consumer (or a future PR) adds a `.gguf` entry, that entry MUST carry a 64-char hex `expectedSHA256` derived from the HuggingFace LFS pointer (`oid sha256:<hex>`), or CI fails.

Because the list is empty today, no new checksums were scraped or added — that would be product curation, not a security fix.

## UI badge

**Already present.** `Sources/ManifoldUIModelManagement/Views/Models/DownloadableModelRow.swift` already renders `"Unverified source"` (caption2, secondary, with accessibility label) when `model.expectedSHA256 == nil`. No UI work needed.

## Audit test placement

`CuratedModelChecksumAuditTest` lives in `Tests/ManifoldInferenceTests/`, which is in the default CI lane (the pre-push two-invocation gate from `CLAUDE.md` runs `--filter ManifoldInferenceTests`). No wiring change needed.

## Acceptance checklist

- [x] Audit hard-fails for `.gguf` entries with `expectedSHA256 == nil` (when the real list is non-empty)
- [x] Empty-list-by-design case stays exempt (early `return` when `previousAll.isEmpty`)
- [x] Hex-validity tests retained (`test_populatedChecksums_areValid64CharHex`, `rejectsEmptyString`, `rejectsTooShortHex`)
- [x] Filter-logic fixture tests retained as a predicate guard
- [x] UI badge for unverified entries (already present, verified)
- [x] Sabotage check done manually: injecting `CuratedModel(modelType: .gguf, expectedSHA256: nil)` into `previousAll` makes `test_realCuratedList_everyGGUFHasExpectedSHA256` fail with the expected XCTAssertTrue message (verified by inspection; not committed)

## Test plan

- [x] `swift test --filter CuratedModelChecksumAuditTest --disable-default-traits --skip-update` — 6/6 passing
- [x] Pre-push XCTest gate: 3346 passed, 0 failed, 17 skipped (one unrelated SIGSEGV in `MockInferenceBackendConformanceTests` — pre-existing, in `ManifoldTestSupportTests`, not touched here)
- [x] Pre-push Swift Testing gate: 83/83 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)