### PR TITLE
fix(security): classify full 127.0.0.0/8 as loopback in cert-pinning bypass [SEC-17]

### DIFF
--- a/Sources/ManifoldCloudCore/PinnedSessionDelegate.swift
+++ b/Sources/ManifoldCloudCore/PinnedSessionDelegate.swift
@@ -107,11 +107,18 @@ public final class PinnedSessionDelegate: NSObject, URLSessionDelegate {
         _defaultPinsLoaded = false
     }
 
-    /// Hosts that bypass pinning entirely (local development servers).
-    private static let bypassHosts: Set<String> = [
-        "localhost", "127.0.0.1", "::1"
-    ]
-    
+    /// Returns `true` if `host` is a loopback host whose connections bypass
+    /// certificate pinning (local development servers).
+    ///
+    /// Delegates to ``PrivateIPClassifier/isLoopbackHost(_:)`` so the full IPv4
+    /// loopback range `127.0.0.0/8` and IPv6 `::1` are classified semantically
+    /// rather than via a hand-curated literal allowlist. A literal set leaves
+    /// `127.0.0.2` (and the rest of `127.x.x.x`) without pins, falling through
+    /// to platform trust [SEC-17].
+    static func isBypassHost(_ host: String) -> Bool {
+        PrivateIPClassifier.isLoopbackHost(host)
+    }
+
     /// Known production hosts that must have non-empty pin sets configured.
     private static let requiredPinnedHosts: Set<String> = [
         "api.openai.com",
@@ -133,7 +140,7 @@ public final class PinnedSessionDelegate: NSObject, URLSessionDelegate {
         let host = challenge.protectionSpace.host
 
         // Bypass pinning for localhost / local network servers.
-        if Self.bypassHosts.contains(host) {
+        if Self.isBypassHost(host) {
             completionHandler(.performDefaultHandling, nil)
             return
         }

--- a/Sources/ManifoldInference/Utilities/PrivateIPClassifier.swift
+++ b/Sources/ManifoldInference/Utilities/PrivateIPClassifier.swift
@@ -55,6 +55,27 @@ package enum PrivateIPClassifier {
         return host == "localhost" || host == "127.0.0.1" || host == "::1"
     }
 
+    /// Returns `true` if `host` is a loopback host string.
+    ///
+    /// Recognises the literal `localhost`, the IPv6 loopback `::1`, and the
+    /// full IPv4 loopback range `127.0.0.0/8` (RFC 1122). Distinct from
+    /// ``isLocalhostURL(_:)``, which intentionally limits to the three canonical
+    /// loopback literals for URL-configuration validation. This helper is for
+    /// trust-decision call sites (e.g. certificate-pinning bypass) where every
+    /// `127.x.x.x` address must be treated as loopback — otherwise hosts like
+    /// `127.0.0.2` slip past a literal allowlist and fall through to platform
+    /// trust [SEC-17].
+    package static func isLoopbackHost(_ host: String) -> Bool {
+        let normalized = host.lowercased()
+        if normalized == "localhost" || normalized == "::1" {
+            return true
+        }
+        if let octets = parseIPv4Literal(normalized), octets[0] == 127 {
+            return true
+        }
+        return false
+    }
+
     // MARK: - IP Literal Classification
 
     /// Classifies an IP literal string as belonging to a blocked address range.

--- a/Tests/ManifoldBackendsTests/PinnedSessionDelegateTests.swift
+++ b/Tests/ManifoldBackendsTests/PinnedSessionDelegateTests.swift
@@ -67,6 +67,17 @@ final class PinnedSessionDelegateTests: XCTestCase {
         await verifyBypassHost("::1")
     }
 
+    // SEC-17: full 127.0.0.0/8 (RFC 1122) must bypass pinning, not just 127.0.0.1.
+    // A literal allowlist of {"localhost", "127.0.0.1", "::1"} leaves 127.0.0.2 and
+    // the rest of 127.x.x.x falling through to platform trust.
+    func test_bypassHost_ipv4Loopback_127_0_0_2_returnsDefaultHandling() async {
+        await verifyBypassHost("127.0.0.2")
+    }
+
+    func test_bypassHost_ipv4Loopback_127_255_255_254_returnsDefaultHandling() async {
+        await verifyBypassHost("127.255.255.254")
+    }
+
     // MARK: - Unknown Host (No Pins Configured)
 
     func test_unknownHost_noPins_returnsDefaultHandling() async {
@@ -186,7 +197,7 @@ final class PinnedSessionDelegateTests: XCTestCase {
         ManifoldConfiguration.shared = ManifoldConfiguration(customHostTrustPolicy: .requireExplicitPins)
         defer { ManifoldConfiguration.shared = savedConfig }
 
-        for host in ["localhost", "127.0.0.1", "::1"] {
+        for host in ["localhost", "127.0.0.1", "127.0.0.2", "::1"] {
             let delegate = PinnedSessionDelegate()
             let challenge = makeChallenge(host: host)
 

--- a/Tests/ManifoldInferenceTests/PrivateIPClassifierTests.swift
+++ b/Tests/ManifoldInferenceTests/PrivateIPClassifierTests.swift
@@ -36,6 +36,55 @@ final class PrivateIPClassifierTests: XCTestCase {
         XCTAssertFalse(PrivateIPClassifier.isLocalhostURL(URL(string: "http://127.0.0.2:8080")!))
     }
 
+    // MARK: - isLoopbackHost (SEC-17)
+
+    func test_isLoopbackHost_localhost_isTrue() {
+        XCTAssertTrue(PrivateIPClassifier.isLoopbackHost("localhost"))
+    }
+
+    func test_isLoopbackHost_127_0_0_1_isTrue() {
+        XCTAssertTrue(PrivateIPClassifier.isLoopbackHost("127.0.0.1"))
+    }
+
+    func test_isLoopbackHost_127_0_0_2_isTrue() {
+        // SEC-17: full 127.0.0.0/8 must be loopback, not just 127.0.0.1.
+        XCTAssertTrue(PrivateIPClassifier.isLoopbackHost("127.0.0.2"))
+    }
+
+    func test_isLoopbackHost_127_255_255_255_isTrue() {
+        XCTAssertTrue(PrivateIPClassifier.isLoopbackHost("127.255.255.255"))
+    }
+
+    func test_isLoopbackHost_ipv6Loopback_isTrue() {
+        XCTAssertTrue(PrivateIPClassifier.isLoopbackHost("::1"))
+    }
+
+    func test_isLoopbackHost_caseInsensitive() {
+        XCTAssertTrue(PrivateIPClassifier.isLoopbackHost("LOCALHOST"))
+    }
+
+    func test_isLoopbackHost_128_0_0_1_isFalse() {
+        // Off-by-one: first non-loopback /8.
+        XCTAssertFalse(PrivateIPClassifier.isLoopbackHost("128.0.0.1"))
+    }
+
+    func test_isLoopbackHost_126_255_255_255_isFalse() {
+        // Off-by-one: last address before loopback /8.
+        XCTAssertFalse(PrivateIPClassifier.isLoopbackHost("126.255.255.255"))
+    }
+
+    func test_isLoopbackHost_privateIP_isFalse() {
+        XCTAssertFalse(PrivateIPClassifier.isLoopbackHost("192.168.1.1"))
+    }
+
+    func test_isLoopbackHost_publicIP_isFalse() {
+        XCTAssertFalse(PrivateIPClassifier.isLoopbackHost("1.1.1.1"))
+    }
+
+    func test_isLoopbackHost_emptyString_isFalse() {
+        XCTAssertFalse(PrivateIPClassifier.isLoopbackHost(""))
+    }
+
     // MARK: - classifyIPLiteral: Allowed Addresses
 
     func test_publicIP_1_1_1_1_isNil() {


### PR DESCRIPTION
## Summary

`PinnedSessionDelegate.bypassHosts` was a literal set of `{"localhost", "127.0.0.1", "::1"}` — addresses elsewhere in 127.0.0.0/8 (loopback per RFC 1122) had no pins and fell through to platform trust. Replace the literal set with a semantic check that recognises the literal hostnames plus the full IPv4 loopback /8 and IPv6 `::1`.

- **`PrivateIPClassifier.isLoopbackHost(_:)`** — new package-visible helper. Recognises `localhost`, `::1`, and any `127.x.x.x` address.
- **`PinnedSessionDelegate.isBypassHost(_:)`** — replaces the literal `bypassHosts` set; delegates to `PrivateIPClassifier.isLoopbackHost`.
- Distinct from `PrivateIPClassifier.isLocalhostURL(_:)`, which intentionally limits to the three canonical literals for URL-configuration validation.

Closes SEC-17.

## Acceptance criteria

- [x] `127.0.0.2` is treated as loopback and bypasses pinning
- [x] `localhost`, `127.0.0.1`, `::1` continue to bypass (no regression)
- [x] `128.0.0.1` does NOT match (off-by-one)
- [x] Bypass survives under `requireExplicitPins` trust policy

## Test plan

- [x] `PrivateIPClassifierTests` — 11 new tests for `isLoopbackHost` (loopback, off-by-one, case-insensitive, IPv6, empty, private, public)
- [x] `PinnedSessionDelegateTests` — 2 new tests for `127.0.0.2` and `127.255.255.254` bypass; extended `test_bypassHosts_ignoreTrustPolicy_requireExplicitPins` to include `127.0.0.2`
- [x] Pre-push two-invocation gate: XCTest 3375/0 fails, SwiftTesting 83/0 fails