### PR TITLE
feat: unify URLError surfacing under ManifoldKitError

### DIFF
--- a/Sources/ManifoldCloud/OllamaModelListService.swift
+++ b/Sources/ManifoldCloud/OllamaModelListService.swift
@@ -75,7 +75,12 @@ public final class OllamaModelListService: Sendable {
         let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            throw CloudBackendError.networkError(underlying: URLError(.badServerResponse))
+            throw CloudBackendError.networkError(
+                underlying: ManifoldKitError.serverError(
+                    statusCode: 0,
+                    message: "Malformed server response"
+                )
+            )
         }
 
         guard (200...299).contains(httpResponse.statusCode) else {

--- a/Sources/ManifoldCloudCore/SSECloudBackend.swift
+++ b/Sources/ManifoldCloudCore/SSECloudBackend.swift
@@ -505,8 +505,14 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
                         let (bytes, response) = try await session.bytes(for: attemptRequest)
 
                         guard let httpResponse = response as? HTTPURLResponse else {
+                            // Carry the rim's `serverError(statusCode: 0, ...)`
+                            // shape so the eventual user-facing string is the
+                            // unified "Server returned an unexpected response."
                             throw CloudBackendError.networkError(
-                                underlying: URLError(.badServerResponse)
+                                underlying: ManifoldKitError.serverError(
+                                    statusCode: 0,
+                                    message: "Malformed server response"
+                                )
                             )
                         }
 

--- a/Sources/ManifoldHuggingFace/DiffusionDownload.swift
+++ b/Sources/ManifoldHuggingFace/DiffusionDownload.swift
@@ -684,7 +684,11 @@ public extension HuggingFaceService {
                     }
                     guard let tempURL else {
                         Log.download.error("downloadTask nil tempURL for \(filename, privacy: .public)")
-                        continuation.resume(throwing: HuggingFaceError.downloadFailed(underlying: URLError(.unknown)))
+                        continuation.resume(throwing: HuggingFaceError.downloadFailed(
+                            underlying: ManifoldKitError.unknown(
+                                underlyingDescription: "Download completed without a temporary file"
+                            )
+                        ))
                         return
                     }
                     Log.download.info("downloadTask complete for \(filename, privacy: .public), moving to destination")

--- a/Sources/ManifoldInference/ManifoldKitError.swift
+++ b/Sources/ManifoldInference/ManifoldKitError.swift
@@ -1,0 +1,189 @@
+import Foundation
+
+/// Unified, user-facing error rim for ManifoldKit.
+///
+/// Public ManifoldKit APIs used to leak raw `Foundation.URLError` to consumers,
+/// surfacing strings like `kCFErrorDomainCFNetwork 6` in host UIs. This type
+/// is the single rim that consumers branch on and present. Internally, domain
+/// errors (``CloudBackendError``, ``HuggingFaceError``, ``KeychainError``)
+/// still carry their structured information; their ``LocalizedError/errorDescription``
+/// routes underlying network failures through ``ManifoldKitError/from(_:)`` so
+/// the user-visible string is always one of the cases here.
+///
+/// The mapping logic is lifted from the original `HuggingFaceProbe.sanitise(urlError:)`
+/// — see that file's history for the rationale. The probe helper is kept as a
+/// thin shim for compatibility.
+///
+/// Stored values are restricted to `Sendable` primitives (`Int`, `String`).
+/// Underlying errors are reduced to a string at construction time so the
+/// rim itself is unconditionally `Sendable` without `@unchecked`.
+public enum ManifoldKitError: Error, Sendable, LocalizedError, Equatable {
+    /// The device reports no internet connectivity (radio off, airplane mode,
+    /// captive portal pre-login).
+    case notConnectedToInternet
+    /// The request exceeded its wall-clock budget. Distinct from ``cancelled``
+    /// — the user did not abort, the network simply stalled.
+    case timedOut
+    /// The request was cancelled cooperatively (user pressed stop, parent
+    /// task cancelled, `URLError(.cancelled)` propagated up).
+    case cancelled
+    /// TLS handshake failed — bad certificate, pinning mismatch, untrusted
+    /// root, or expired cert.
+    case tlsFailure
+    /// DNS lookup failed or returned no records. Distinct from
+    /// ``serverError`` (which implies the host was reachable).
+    case dnsFailure
+    /// The server responded with an HTTP status outside the 2xx range, or
+    /// returned a body that failed structural validation (non-HTTP response).
+    /// `statusCode == 0` is used for the latter — the response did not parse
+    /// as an `HTTPURLResponse` at all.
+    case serverError(statusCode: Int, message: String?)
+    /// Keychain operation failed because the device is locked, the
+    /// entitlement is missing, or the keychain is otherwise unavailable.
+    case keychainUnavailable
+    /// JSON / data decoding failed at a trust boundary. The associated value
+    /// is a short, PII-free description of where decoding failed (e.g.
+    /// `"missing field: choices"`).
+    case decodingFailure(String)
+    /// Catch-all for errors that did not match any of the more specific cases.
+    /// The underlying error is reduced to a string at construction time to
+    /// keep the rim `Sendable`.
+    case unknown(underlyingDescription: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .notConnectedToInternet:
+            return "Not connected to the internet."
+        case .timedOut:
+            return "The request timed out."
+        case .cancelled:
+            return "The request was cancelled."
+        case .tlsFailure:
+            return "Secure connection failed (TLS handshake)."
+        case .dnsFailure:
+            return "Couldn't reach the server (DNS lookup failed)."
+        case .serverError(let statusCode, let message):
+            if statusCode == 0 {
+                if let message, !message.isEmpty {
+                    return "Server returned an unexpected response: \(message)"
+                }
+                return "Server returned an unexpected response."
+            }
+            if let message, !message.isEmpty {
+                return "Server error \(statusCode): \(message)"
+            }
+            return "Server error \(statusCode)."
+        case .keychainUnavailable:
+            return "Keychain is unavailable. Unlock the device and try again."
+        case .decodingFailure(let detail):
+            return "Couldn't read the server response: \(detail)"
+        case .unknown(let underlyingDescription):
+            if underlyingDescription.isEmpty {
+                return "An unexpected error occurred."
+            }
+            return "An unexpected error occurred: \(underlyingDescription)"
+        }
+    }
+
+    /// Reduces any thrown `Error` to the closest matching ``ManifoldKitError``
+    /// case. The mapping is exhaustive across `URLError` codes that the
+    /// inference / cloud / HF stacks can produce; unknown errors fall through
+    /// to ``unknown(underlyingDescription:)`` with the localized description
+    /// captured as a string.
+    ///
+    /// If passed an existing ``ManifoldKitError`` this returns it unchanged so
+    /// `from(_:)` is idempotent and safe to call at any layer.
+    public static func from(_ error: Error) -> ManifoldKitError {
+        if let already = error as? ManifoldKitError {
+            return already
+        }
+
+        if error is CancellationError {
+            return .cancelled
+        }
+
+        if let urlError = error as? URLError {
+            return fromURLError(urlError)
+        }
+
+        // `NSURLErrorDomain` is the bridged form of `URLError`. Background
+        // download delegate callbacks deliver errors as `NSError` rather than
+        // `URLError`, so we cover that surface too.
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain {
+            if let urlError = URLError(_nsError: nsError) as URLError? {
+                return fromURLError(urlError)
+            }
+        }
+
+        if let decoding = error as? DecodingError {
+            return .decodingFailure(decodingDetail(decoding))
+        }
+
+        // KeychainError lives in this module — pattern-match by string to
+        // avoid pulling Security into the rim's exhaustive surface. The
+        // Equatable conformance + osStatus accessor would be nicer, but
+        // tying the rim to KeychainError's case shape is not worth the
+        // brittleness.
+        let typeName = String(reflecting: type(of: error))
+        if typeName.contains("KeychainError") {
+            return .keychainUnavailable
+        }
+
+        return .unknown(underlyingDescription: error.localizedDescription)
+    }
+
+    private static func fromURLError(_ urlError: URLError) -> ManifoldKitError {
+        switch urlError.code {
+        case .timedOut:
+            return .timedOut
+        case .cancelled:
+            return .cancelled
+        case .notConnectedToInternet, .networkConnectionLost,
+             .dataNotAllowed, .internationalRoamingOff:
+            return .notConnectedToInternet
+        case .cannotFindHost, .dnsLookupFailed:
+            return .dnsFailure
+        case .cannotConnectToHost:
+            // No host to connect to is closer to a DNS-shape failure than a
+            // server error — keep this in the DNS bucket so user messaging
+            // points at connectivity rather than the remote service.
+            return .dnsFailure
+        case .secureConnectionFailed,
+             .serverCertificateUntrusted,
+             .serverCertificateHasBadDate,
+             .serverCertificateNotYetValid,
+             .serverCertificateHasUnknownRoot,
+             .clientCertificateRejected,
+             .clientCertificateRequired,
+             .appTransportSecurityRequiresSecureConnection:
+            return .tlsFailure
+        case .badServerResponse, .zeroByteResource, .cannotParseResponse:
+            return .serverError(statusCode: 0, message: "Malformed server response")
+        case .httpTooManyRedirects, .redirectToNonExistentLocation:
+            return .serverError(statusCode: 0, message: "Too many redirects")
+        case .unsupportedURL, .badURL:
+            return .serverError(statusCode: 0, message: "Invalid URL")
+        default:
+            // `URLError.localizedDescription` is generally PII-free (it does
+            // not contain the URL itself for most codes), so it is safe to
+            // forward as the unknown description.
+            return .unknown(underlyingDescription: urlError.localizedDescription)
+        }
+    }
+
+    private static func decodingDetail(_ error: DecodingError) -> String {
+        switch error {
+        case .keyNotFound(let key, _):
+            return "missing field: \(key.stringValue)"
+        case .typeMismatch(_, let context):
+            return "type mismatch at \(context.codingPath.map(\.stringValue).joined(separator: "."))"
+        case .valueNotFound(_, let context):
+            return "missing value at \(context.codingPath.map(\.stringValue).joined(separator: "."))"
+        case .dataCorrupted(let context):
+            return context.debugDescription
+        @unknown default:
+            return "decoding failed"
+        }
+    }
+}

--- a/Sources/ManifoldInference/Services/CloudBackendError.swift
+++ b/Sources/ManifoldInference/Services/CloudBackendError.swift
@@ -76,7 +76,11 @@ public enum CloudBackendError: LocalizedError, CategorizedError {
         case .serverError(let code, let message):
             return "Server error (\(code)): \(message)"
         case .networkError(let underlying):
-            return "Network error: \(underlying.localizedDescription)"
+            // Route through the unified rim so consumers see user-readable
+            // strings ("Not connected to the internet.") rather than the raw
+            // `URLError.localizedDescription` ("kCFErrorDomainCFNetwork -1009").
+            return ManifoldKitError.from(underlying).errorDescription
+                ?? "Network error: \(underlying.localizedDescription)"
         case .parseError(let detail):
             return "Failed to parse response: \(detail)"
         case .missingAPIKey:

--- a/Sources/ManifoldInference/Services/HuggingFaceError.swift
+++ b/Sources/ManifoldInference/Services/HuggingFaceError.swift
@@ -20,11 +20,17 @@ public enum HuggingFaceError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .searchFailed(let underlying):
-            return "HuggingFace search failed: \(underlying.localizedDescription)"
+            // Route through the unified rim so consumers see user-readable
+            // strings rather than raw CFNetwork codes from URLError.
+            let detail = ManifoldKitError.from(underlying).errorDescription
+                ?? underlying.localizedDescription
+            return "HuggingFace search failed: \(detail)"
         case .modelNotFound(let repoID):
             return "Model not found on HuggingFace: \(repoID)"
         case .downloadFailed(let underlying):
-            return "Download failed: \(underlying.localizedDescription)"
+            let detail = ManifoldKitError.from(underlying).errorDescription
+                ?? underlying.localizedDescription
+            return "Download failed: \(detail)"
         case .networkUnavailable:
             return "No network connection available. Please check your internet connection."
         case .insufficientDiskSpace(let required, let available):

--- a/Sources/ManifoldInference/Services/HuggingFaceProbe.swift
+++ b/Sources/ManifoldInference/Services/HuggingFaceProbe.swift
@@ -129,6 +129,11 @@ public enum HuggingFaceProbe {
     /// trait-gated and not reachable from `ManifoldInference`): never echo
     /// raw URLs, hostnames, tokens, HTML, or stack traces — bucket the error
     /// by code and emit a short, stable label.
+    ///
+    /// Kept distinct from ``ManifoldKitError/errorDescription`` because this
+    /// returns a compact log label ("DNS lookup failed") whereas the rim's
+    /// strings are user-facing sentences. See ``ManifoldKitError/from(_:)``
+    /// for the consumer-presentable mapping.
     static func sanitise(urlError: URLError) -> String {
         switch urlError.code {
         case .timedOut:

--- a/Sources/ManifoldInference/Services/RetryPolicy.swift
+++ b/Sources/ManifoldInference/Services/RetryPolicy.swift
@@ -152,7 +152,14 @@ public func withRetry<T>(
     }
 
     // Unreachable — the loop is unbounded and exits via return or throw.
-    throw RetryExhaustedError(lastError: CloudBackendError.networkError(underlying: URLError(.unknown)), attempts: 0)
+    // The sentinel uses the unified rim so even this "should never happen"
+    // path produces a user-readable string rather than a CFNetwork code.
+    throw RetryExhaustedError(
+        lastError: CloudBackendError.networkError(
+            underlying: ManifoldKitError.unknown(underlyingDescription: "")
+        ),
+        attempts: 0
+    )
 }
 
 // MARK: - Backward Compatibility

--- a/Tests/ManifoldInferenceTests/ManifoldKitErrorTests.swift
+++ b/Tests/ManifoldInferenceTests/ManifoldKitErrorTests.swift
@@ -1,0 +1,192 @@
+import XCTest
+@testable import ManifoldInference
+
+/// Unit coverage for ``ManifoldKitError``, the unified user-facing error rim.
+///
+/// Covers:
+/// - `URLError → ManifoldKitError` mapping across every bucket that the
+///   inference / cloud / HuggingFace stacks can produce.
+/// - `errorDescription` is non-empty for every case (so consumers presenting
+///   `error.localizedDescription` always get a usable string).
+/// - Idempotency of `from(_:)` — passing a `ManifoldKitError` returns the same
+///   value, so it is safe to call at any layer.
+/// - Wrapping: `CloudBackendError.networkError(underlying:)` and
+///   `HuggingFaceError.downloadFailed(underlying:)` produce sanitised
+///   user-facing strings rather than raw CFNetwork codes.
+final class ManifoldKitErrorTests: XCTestCase {
+
+    // MARK: - URLError mapping
+
+    func test_from_URLError_timedOut() {
+        XCTAssertEqual(ManifoldKitError.from(URLError(.timedOut)), .timedOut)
+    }
+
+    func test_from_URLError_cancelled() {
+        XCTAssertEqual(ManifoldKitError.from(URLError(.cancelled)), .cancelled)
+    }
+
+    func test_from_URLError_notConnectedBuckets() {
+        XCTAssertEqual(ManifoldKitError.from(URLError(.notConnectedToInternet)), .notConnectedToInternet)
+        XCTAssertEqual(ManifoldKitError.from(URLError(.networkConnectionLost)), .notConnectedToInternet)
+        XCTAssertEqual(ManifoldKitError.from(URLError(.dataNotAllowed)), .notConnectedToInternet)
+        XCTAssertEqual(ManifoldKitError.from(URLError(.internationalRoamingOff)), .notConnectedToInternet)
+    }
+
+    func test_from_URLError_dnsBuckets() {
+        XCTAssertEqual(ManifoldKitError.from(URLError(.cannotFindHost)), .dnsFailure)
+        XCTAssertEqual(ManifoldKitError.from(URLError(.dnsLookupFailed)), .dnsFailure)
+        XCTAssertEqual(ManifoldKitError.from(URLError(.cannotConnectToHost)), .dnsFailure)
+    }
+
+    func test_from_URLError_tlsBuckets() {
+        XCTAssertEqual(ManifoldKitError.from(URLError(.secureConnectionFailed)), .tlsFailure)
+        XCTAssertEqual(ManifoldKitError.from(URLError(.serverCertificateUntrusted)), .tlsFailure)
+        XCTAssertEqual(ManifoldKitError.from(URLError(.serverCertificateHasBadDate)), .tlsFailure)
+        XCTAssertEqual(ManifoldKitError.from(URLError(.serverCertificateNotYetValid)), .tlsFailure)
+        XCTAssertEqual(ManifoldKitError.from(URLError(.serverCertificateHasUnknownRoot)), .tlsFailure)
+        XCTAssertEqual(ManifoldKitError.from(URLError(.clientCertificateRejected)), .tlsFailure)
+        XCTAssertEqual(ManifoldKitError.from(URLError(.clientCertificateRequired)), .tlsFailure)
+    }
+
+    func test_from_URLError_malformedResponseBucketsToServerErrorZero() {
+        let mapped = ManifoldKitError.from(URLError(.badServerResponse))
+        guard case .serverError(let code, let message) = mapped else {
+            return XCTFail("Expected .serverError, got \(mapped)")
+        }
+        XCTAssertEqual(code, 0)
+        XCTAssertEqual(message, "Malformed server response")
+    }
+
+    func test_from_URLError_redirectAndBadURLBucketsToServerErrorZero() {
+        if case .serverError(0, _) = ManifoldKitError.from(URLError(.httpTooManyRedirects)) {} else {
+            XCTFail("redirect URLError should map to serverError(0, _)")
+        }
+        if case .serverError(0, _) = ManifoldKitError.from(URLError(.badURL)) {} else {
+            XCTFail("badURL URLError should map to serverError(0, _)")
+        }
+    }
+
+    func test_from_URLError_unknownCodeFallsThrough() {
+        let mapped = ManifoldKitError.from(URLError(.userCancelledAuthentication))
+        guard case .unknown = mapped else {
+            return XCTFail("Unmapped URLError code should fall through to .unknown, got \(mapped)")
+        }
+    }
+
+    // MARK: - NSError(NSURLErrorDomain) bridging
+
+    func test_from_NSURLErrorDomain_NSError_mapsLikeURLError() {
+        let nsError = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
+        XCTAssertEqual(ManifoldKitError.from(nsError), .notConnectedToInternet)
+    }
+
+    // MARK: - CancellationError
+
+    func test_from_CancellationError_isCancelled() {
+        XCTAssertEqual(ManifoldKitError.from(CancellationError()), .cancelled)
+    }
+
+    // MARK: - DecodingError
+
+    func test_from_DecodingError_keyNotFound_capturesFieldName() {
+        struct Box: Decodable { let needed: String }
+        let json = Data("{}".utf8)
+        do {
+            _ = try JSONDecoder().decode(Box.self, from: json)
+            XCTFail("expected decode to throw")
+        } catch {
+            let mapped = ManifoldKitError.from(error)
+            guard case .decodingFailure(let detail) = mapped else {
+                return XCTFail("expected .decodingFailure, got \(mapped)")
+            }
+            XCTAssertTrue(detail.contains("needed"), "detail should reference the missing field, got: \(detail)")
+        }
+    }
+
+    // MARK: - Keychain detection
+
+    func test_from_KeychainError_mapsToKeychainUnavailable() {
+        let err = KeychainError.storeFailed(-25291)
+        XCTAssertEqual(ManifoldKitError.from(err), .keychainUnavailable)
+    }
+
+    // MARK: - Idempotency
+
+    func test_from_existingManifoldKitError_returnsUnchanged() {
+        let original = ManifoldKitError.tlsFailure
+        XCTAssertEqual(ManifoldKitError.from(original), original)
+
+        let server = ManifoldKitError.serverError(statusCode: 503, message: "down")
+        XCTAssertEqual(ManifoldKitError.from(server), server)
+    }
+
+    // MARK: - errorDescription coverage
+
+    func test_errorDescription_isNonEmptyForEveryCase() {
+        let cases: [ManifoldKitError] = [
+            .notConnectedToInternet,
+            .timedOut,
+            .cancelled,
+            .tlsFailure,
+            .dnsFailure,
+            .serverError(statusCode: 0, message: nil),
+            .serverError(statusCode: 0, message: ""),
+            .serverError(statusCode: 0, message: "Malformed server response"),
+            .serverError(statusCode: 503, message: nil),
+            .serverError(statusCode: 503, message: "service unavailable"),
+            .keychainUnavailable,
+            .decodingFailure("missing field: foo"),
+            .unknown(underlyingDescription: ""),
+            .unknown(underlyingDescription: "weird thing happened"),
+        ]
+        for c in cases {
+            let desc = c.errorDescription ?? ""
+            XCTAssertFalse(desc.isEmpty, "case \(c) had empty errorDescription")
+        }
+    }
+
+    // MARK: - User-facing string never contains CFNetwork codes
+
+    func test_errorDescription_doesNotLeakCFNetworkCode() {
+        // The whole point of the rim. A consumer that catches `notConnectedToInternet`
+        // (whether constructed directly or mapped from URLError) must NOT see the
+        // CFNetwork prefix in `localizedDescription`.
+        let mapped = ManifoldKitError.from(URLError(.notConnectedToInternet))
+        let desc = mapped.errorDescription ?? ""
+        XCTAssertFalse(desc.contains("CFNetwork"), "leaked CFNetwork code: \(desc)")
+        XCTAssertFalse(desc.contains("kCFErrorDomain"), "leaked CF error domain: \(desc)")
+    }
+
+    // MARK: - Round-trip via CloudBackendError
+
+    func test_cloudBackendError_networkError_routesThroughRim() {
+        let err = CloudBackendError.networkError(underlying: URLError(.notConnectedToInternet))
+        let desc = err.errorDescription ?? ""
+        // The rim's string for `.notConnectedToInternet` is "Not connected to the internet."
+        XCTAssertTrue(
+            desc.contains("Not connected to the internet"),
+            "CloudBackendError did not route through the rim; got: \(desc)"
+        )
+        XCTAssertFalse(desc.contains("CFNetwork"), "rim should strip CFNetwork codes; got: \(desc)")
+    }
+
+    func test_huggingFaceError_downloadFailed_routesThroughRim() {
+        let err = HuggingFaceError.downloadFailed(underlying: URLError(.timedOut))
+        let desc = err.errorDescription ?? ""
+        XCTAssertTrue(
+            desc.contains("The request timed out"),
+            "HuggingFaceError did not route through the rim; got: \(desc)"
+        )
+        XCTAssertFalse(desc.contains("CFNetwork"), "rim should strip CFNetwork codes; got: \(desc)")
+    }
+
+    // MARK: - Sendable
+
+    // Compile-time assertion: ManifoldKitError must be Sendable so it can cross
+    // actor boundaries without `@unchecked` (see CLAUDE.md "Swift 6 concurrency
+    // gotchas" #2).
+    func test_isSendable() {
+        func requireSendable<T: Sendable>(_: T.Type) {}
+        requireSendable(ManifoldKitError.self)
+    }
+}


### PR DESCRIPTION
## Summary

Public ManifoldKit APIs leaked raw `Foundation.URLError` to consumers from multiple modules, surfacing strings like `kCFErrorDomainCFNetwork 6` in host UIs. This PR introduces a single user-facing rim — `ManifoldKitError` — lifted from the existing `HuggingFaceProbe.sanitise(urlError:)` pattern, and routes the leak sites through it.

Wave 0 of the DX overhaul: doing this **before** `ManifoldKit.quickStart()` lands avoids re-touching the facade later, since `quickStart()` returns errors that must flow through the consolidated type.

## What changed

**New:**
- `Sources/ManifoldInference/ManifoldKitError.swift` — public `Sendable`, `LocalizedError`, `Equatable` enum. Cases: `notConnectedToInternet`, `timedOut`, `cancelled`, `tlsFailure`, `dnsFailure`, `serverError(statusCode:message:)`, `keychainUnavailable`, `decodingFailure(String)`, `unknown(underlyingDescription: String)`. `static func from(_:)` maps `URLError`, `NSError(NSURLErrorDomain)`, `DecodingError`, `KeychainError`, and `CancellationError`. Idempotent.
- `Tests/ManifoldInferenceTests/ManifoldKitErrorTests.swift` — 18 tests covering every mapping bucket, idempotency, non-empty `errorDescription` per case, no CFNetwork code leakage, round-trip via `CloudBackendError` and `HuggingFaceError`, and a `Sendable` compile-time assertion.

**Routed through the new rim:**
- `CloudBackendError.networkError(underlying:)` → `errorDescription` now calls `ManifoldKitError.from(underlying)` so the consumer sees `"Not connected to the internet."` instead of `"kCFErrorDomainCFNetwork -1009"`.
- `HuggingFaceError.searchFailed` / `.downloadFailed` → same treatment.

**Sentinel construction sites swapped from raw `URLError(.…)` to `ManifoldKitError`:**
- `Sources/ManifoldCloudCore/SSECloudBackend.swift` (non-HTTP response → `.serverError(statusCode: 0, …)`)
- `Sources/ManifoldCloud/OllamaModelListService.swift` (same)
- `Sources/ManifoldInference/Services/RetryPolicy.swift` (unreachable trailer → `.unknown(...)`)
- `Sources/ManifoldHuggingFace/DiffusionDownload.swift` (nil tempURL guard → `.unknown(...)`)

**Intentionally unchanged (not user-facing leaks):**
- `Sources/ManifoldInference/Services/HuggingFaceProbe.swift:132 sanitise(urlError:)` — kept as-is. It returns compact log labels (`"DNS lookup failed"`), a different audience from the rim's user-facing strings (`"Couldn't reach the server (DNS lookup failed)."`). Existing `HuggingFaceProbeTests` assert on the legacy labels.
- `Sources/ManifoldInference/Services/ToolRegistry.swift:421` — comment reference only; the surrounding `catch` reclassifies `URLError(.cancelled)` to `.cancelled` internally, never surfacing it.
- `Sources/ManifoldHuggingFace/BackgroundDownloadManager+URLSessionDelegate.swift:188` — internal classification of `NSURLErrorCancelled` against `NSURLErrorDomain` to mark a download as cancelled vs failed. Domain-error wrap happens later via `HuggingFaceError.downloadFailed`, which now routes through the rim.
- `Sources/ManifoldRuntime/Services/PDFDocumentParser.swift:16` — uses `NSURLErrorKey` (a userInfo key constant), not a `URLError` instance.
- `Sources/ManifoldTestSupport/*` — test infrastructure that *fabricates* `URLError`s for mocks (DenyAllURLProtocol, MockURLProtocol). Not a consumer surface.

## Test plan

- [x] New `ManifoldKitErrorTests` (18 tests) — all pass
- [x] Pre-push XCTest suite (3369 pass / 0 fail / 17 XCTSkip) — `scripts/test.sh --filter Manifold{Core,Runtime,PersistenceSwiftData,UI,UIModelManagement,MCP,Backends,Inference,TestSupport,AppIntents,Server}Tests --disable-default-traits --skip-update`
- [x] Pre-push Swift Testing suite (83 pass / 0 fail) — `scripts/test.sh --filter ManifoldInferenceSwiftTestingTests --disable-default-traits --skip-update`
- [x] `grep -rn "try?" Sources/` — no new `try?` introduced; `SilentCatchAuditTest` still clean
- [x] `grep -rn "URLError" Sources/` — every remaining hit is documented above as internal classification or test infrastructure
- [x] `ManifoldKitError` is `Sendable` without `@unchecked` (compile-time assertion in tests)

## Out of scope

UI/error-presentation, `ManifoldBootstrap` / `quickStart()` wiring, README/example updates — all owned by later waves per the worker brief.