### PR TITLE
feat: add DX checklist to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -55,3 +55,11 @@
 - [ ] Public API changes have `///` doc comments
 - [ ] No hardcoded secrets, API keys, or personal data
 - [ ] Breaking change? (if yes, describe migration path below)
+
+## DX checklist
+
+- [ ] Did this change a public API a user might write in their README? If yes, updated the README snippet.
+- [ ] Did this add or change a trait, backend, or capability? If yes, updated `Sources/ManifoldKit/FeatureMatrix.swift` (when present).
+- [ ] Is this a breaking change for an existing consumer? If yes, added a migration note to `CHANGELOG.md` or `docs/`.
+- [ ] Did this change the `quickStart()` path or `MinimalExample`? If yes, the example still compiles and runs end-to-end.
+- [ ] Did this introduce a new public error type or surface? If yes, it conforms to `LocalizedError` with a user-facing `errorDescription`.


### PR DESCRIPTION
## What does this change?

Appends a `## DX checklist` section to `.github/pull_request_template.md` so feature PRs are prompted to consider documentation, examples, and migration debt at author time.

## Motivation

Part of the ManifoldKit DX overhaul. Author-time reminders catch consumer-facing regressions (stale README snippets, missing FeatureMatrix updates, undocumented breakage, broken MinimalExample, raw error types) before they hit reviewers or users.

## Release Note

N/A (docs/template change, no consumer-visible behavior).

## Testing

Visual review of the rendered template — checkboxes render as tickable `- [ ]` items. Docs-only change to a template file; the pre-push test gate does not apply.

## Sabotage evidence (regression-test PRs only)

- [x] N/A (not a regression-test PR)

## Checklist

- [x] Tests added or updated for new behaviour (N/A — template-only)
- [x] Public API changes have `///` doc comments (N/A)
- [x] No hardcoded secrets, API keys, or personal data
- [x] Breaking change? (no)