### PR TITLE
fix(security): split MCP OAuth refresh token into separate Keychain item with stricter accessibility [SEC-26]

### DIFF
--- a/Sources/ManifoldMCP/MCPOAuthTokenStore.swift
+++ b/Sources/ManifoldMCP/MCPOAuthTokenStore.swift
@@ -120,87 +120,185 @@ public struct MCPOAuthTokenStore: Sendable {
         accountNamespace: String = "mcp.oauth.server"
     ) -> MCPOAuthTokenStore {
         let accessGroup = configuration.accessGroup
-        let accessibility = configuration.accessibility as String
+        // Access token keeps the caller-supplied class (default AfterFirstUnlockThisDeviceOnly)
+        // so background access-token refresh after device unlock still works.
+        let accessAccessibility = configuration.accessibility as String
+        // Refresh token uses the stricter WhenUnlockedThisDeviceOnly because it is only consumed
+        // during the interactive re-auth flow — compromising it reissues new access tokens.
+        let refreshAccessibility = kSecAttrAccessibleWhenUnlockedThisDeviceOnly as String
 
         return .init(
             read: { serverID in
-                let accountName = keychainAccount(serverID: serverID, namespace: accountNamespace)
-                var query = baseKeychainQuery(serviceName: serviceName, account: accountName, accessGroup: accessGroup)
-                query[kSecReturnData as String] = true
-                query[kSecMatchLimit as String] = kSecMatchLimitOne
+                let accessAccount = keychainAccount(serverID: serverID, namespace: accountNamespace)
+                let refreshAccount = refreshKeychainAccount(serverID: serverID, namespace: accountNamespace)
 
-                var result: AnyObject?
-                let status = SecItemCopyMatching(query as CFDictionary, &result)
-                if status == errSecItemNotFound {
+                guard let accessData = try fetchItem(serviceName: serviceName, account: accessAccount, accessGroup: accessGroup) else {
                     return nil
                 }
-                guard status == errSecSuccess else {
-                    Log.inference.error(
-                        "MCPOAuthTokenStore.keychain read failed: status=\(status, privacy: .public) account=\(accountName, privacy: .private)"
-                    )
-                    throw keychainFailure(action: "read", status: status)
-                }
-                guard let data = result as? Data else {
-                    throw MCPError.authorizationFailed("Failed to decode OAuth tokens in Keychain: unexpected payload")
-                }
+                let accessTokens: MCPOAuthTokens
                 do {
-                    return try JSONDecoder().decode(MCPOAuthTokens.self, from: data)
+                    accessTokens = try JSONDecoder().decode(MCPOAuthTokens.self, from: accessData)
                 } catch {
                     throw MCPError.authorizationFailed("Failed to decode OAuth tokens from Keychain data: \(error.localizedDescription)")
                 }
+
+                // Refresh token lives in a separate Keychain item with stricter accessibility.
+                // Tolerate absence: the device may be locked beyond the refresh item's accessibility class,
+                // or the value was never written. Callers fall back to re-auth in that case.
+                let refreshTokenString: String?
+                if let refreshData = try fetchItem(serviceName: serviceName, account: refreshAccount, accessGroup: accessGroup) {
+                    refreshTokenString = String(data: refreshData, encoding: .utf8)
+                } else {
+                    // Backward compatibility: pre-split format stored refreshToken inside the access blob.
+                    refreshTokenString = accessTokens.refreshToken
+                }
+
+                return MCPOAuthTokens(
+                    accessTokenData: accessTokens.accessTokenData,
+                    refreshToken: refreshTokenString,
+                    expiresAt: accessTokens.expiresAt,
+                    scopes: accessTokens.scopes,
+                    tokenType: accessTokens.tokenType,
+                    issuer: accessTokens.issuer,
+                    subjectIdentifier: accessTokens.subjectIdentifier
+                )
             },
             write: { tokens, serverID in
-                let accountName = keychainAccount(serverID: serverID, namespace: accountNamespace)
-                let encoded: Data
+                let accessAccount = keychainAccount(serverID: serverID, namespace: accountNamespace)
+                let refreshAccount = refreshKeychainAccount(serverID: serverID, namespace: accountNamespace)
+
+                // Persist the access blob without the refresh token so the refresh value never
+                // lives in an item with the looser AfterFirstUnlock class.
+                let accessOnly = MCPOAuthTokens(
+                    accessTokenData: tokens.accessTokenData,
+                    refreshToken: nil,
+                    expiresAt: tokens.expiresAt,
+                    scopes: tokens.scopes,
+                    tokenType: tokens.tokenType,
+                    issuer: tokens.issuer,
+                    subjectIdentifier: tokens.subjectIdentifier
+                )
+                let encodedAccess: Data
                 do {
-                    encoded = try JSONEncoder().encode(tokens)
+                    encodedAccess = try JSONEncoder().encode(accessOnly)
                 } catch {
                     throw MCPError.authorizationFailed("Failed to encode OAuth tokens for persistence: \(error.localizedDescription)")
                 }
 
-                let updateQuery = baseKeychainQuery(serviceName: serviceName, account: accountName, accessGroup: accessGroup)
-                let updateAttributes: [String: Any] = [
-                    kSecValueData as String: encoded,
-                    kSecAttrAccessible as String: accessibility,
-                ]
-                let updateStatus = SecItemUpdate(updateQuery as CFDictionary, updateAttributes as CFDictionary)
-                if updateStatus == errSecSuccess {
-                    return
-                }
-                guard updateStatus == errSecItemNotFound else {
-                    Log.inference.error(
-                        "MCPOAuthTokenStore.keychain update failed: status=\(updateStatus, privacy: .public) account=\(accountName, privacy: .private)"
-                    )
-                    throw keychainFailure(action: "update", status: updateStatus)
-                }
+                try upsertItem(
+                    serviceName: serviceName,
+                    account: accessAccount,
+                    accessGroup: accessGroup,
+                    accessibility: accessAccessibility,
+                    data: encodedAccess
+                )
 
-                var addQuery = baseKeychainQuery(serviceName: serviceName, account: accountName, accessGroup: accessGroup)
-                addQuery[kSecValueData as String] = encoded
-                addQuery[kSecAttrAccessible as String] = accessibility
-                let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
-                guard addStatus == errSecSuccess else {
-                    Log.inference.error(
-                        "MCPOAuthTokenStore.keychain add failed: status=\(addStatus, privacy: .public) account=\(accountName, privacy: .private)"
+                if let refresh = tokens.refreshToken, !refresh.isEmpty {
+                    try upsertItem(
+                        serviceName: serviceName,
+                        account: refreshAccount,
+                        accessGroup: accessGroup,
+                        accessibility: refreshAccessibility,
+                        data: Data(refresh.utf8)
                     )
-                    throw keychainFailure(action: "write", status: addStatus)
+                } else {
+                    // No refresh token on this write — purge any prior value rather than leaving it stale.
+                    try deleteItem(serviceName: serviceName, account: refreshAccount, accessGroup: accessGroup)
                 }
             },
             delete: { serverID in
-                let accountName = keychainAccount(serverID: serverID, namespace: accountNamespace)
-                let query = baseKeychainQuery(serviceName: serviceName, account: accountName, accessGroup: accessGroup)
-                let status = SecItemDelete(query as CFDictionary)
-                guard status == errSecSuccess || status == errSecItemNotFound else {
-                    Log.inference.error(
-                        "MCPOAuthTokenStore.keychain delete failed: status=\(status, privacy: .public) account=\(accountName, privacy: .private)"
-                    )
-                    throw keychainFailure(action: "delete", status: status)
-                }
+                let accessAccount = keychainAccount(serverID: serverID, namespace: accountNamespace)
+                let refreshAccount = refreshKeychainAccount(serverID: serverID, namespace: accountNamespace)
+                try deleteItem(serviceName: serviceName, account: accessAccount, accessGroup: accessGroup)
+                try deleteItem(serviceName: serviceName, account: refreshAccount, accessGroup: accessGroup)
             }
         )
     }
 
     private static func keychainAccount(serverID: UUID, namespace: String) -> String {
         "\(namespace).\(serverID.uuidString.lowercased())"
+    }
+
+    /// Deterministic suffix-derived account for the refresh-token Keychain item.
+    /// Kept private; callers interact only via `read`/`write`/`delete`.
+    private static func refreshKeychainAccount(serverID: UUID, namespace: String) -> String {
+        "\(keychainAccount(serverID: serverID, namespace: namespace)).refresh"
+    }
+
+    private static func fetchItem(
+        serviceName: String,
+        account: String,
+        accessGroup: String?
+    ) throws -> Data? {
+        var query = baseKeychainQuery(serviceName: serviceName, account: account, accessGroup: accessGroup)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound {
+            return nil
+        }
+        guard status == errSecSuccess else {
+            Log.inference.error(
+                "MCPOAuthTokenStore.keychain read failed: status=\(status, privacy: .public) account=\(account, privacy: .private)"
+            )
+            throw keychainFailure(action: "read", status: status)
+        }
+        guard let data = result as? Data else {
+            throw MCPError.authorizationFailed("Failed to decode OAuth tokens in Keychain: unexpected payload")
+        }
+        return data
+    }
+
+    private static func upsertItem(
+        serviceName: String,
+        account: String,
+        accessGroup: String?,
+        accessibility: String,
+        data: Data
+    ) throws {
+        let updateQuery = baseKeychainQuery(serviceName: serviceName, account: account, accessGroup: accessGroup)
+        let updateAttributes: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: accessibility,
+        ]
+        let updateStatus = SecItemUpdate(updateQuery as CFDictionary, updateAttributes as CFDictionary)
+        if updateStatus == errSecSuccess {
+            return
+        }
+        guard updateStatus == errSecItemNotFound else {
+            Log.inference.error(
+                "MCPOAuthTokenStore.keychain update failed: status=\(updateStatus, privacy: .public) account=\(account, privacy: .private)"
+            )
+            throw keychainFailure(action: "update", status: updateStatus)
+        }
+
+        var addQuery = baseKeychainQuery(serviceName: serviceName, account: account, accessGroup: accessGroup)
+        addQuery[kSecValueData as String] = data
+        addQuery[kSecAttrAccessible as String] = accessibility
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        guard addStatus == errSecSuccess else {
+            Log.inference.error(
+                "MCPOAuthTokenStore.keychain add failed: status=\(addStatus, privacy: .public) account=\(account, privacy: .private)"
+            )
+            throw keychainFailure(action: "write", status: addStatus)
+        }
+    }
+
+    private static func deleteItem(
+        serviceName: String,
+        account: String,
+        accessGroup: String?
+    ) throws {
+        let query = baseKeychainQuery(serviceName: serviceName, account: account, accessGroup: accessGroup)
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            Log.inference.error(
+                "MCPOAuthTokenStore.keychain delete failed: status=\(status, privacy: .public) account=\(account, privacy: .private)"
+            )
+            throw keychainFailure(action: "delete", status: status)
+        }
     }
 
     private static func baseKeychainQuery(

--- a/Tests/ManifoldMCPTests/MCPOAuthTokenStoreKeychainTests.swift
+++ b/Tests/ManifoldMCPTests/MCPOAuthTokenStoreKeychainTests.swift
@@ -14,14 +14,43 @@ final class MCPOAuthTokenStoreKeychainTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         for item in cleanupItems {
-            let query: [String: Any] = [
-                kSecClass as String: kSecClassGenericPassword,
-                kSecAttrService as String: item.serviceName,
-                kSecAttrAccount as String: item.account,
-            ]
-            _ = SecItemDelete(query as CFDictionary)
+            for account in [item.account, "\(item.account).refresh"] {
+                let query: [String: Any] = [
+                    kSecClass as String: kSecClassGenericPassword,
+                    kSecAttrService as String: item.serviceName,
+                    kSecAttrAccount as String: account,
+                ]
+                _ = SecItemDelete(query as CFDictionary)
+            }
         }
         cleanupItems.removeAll()
+    }
+
+    private func itemExists(serviceName: String, account: String) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: account,
+        ]
+        return SecItemCopyMatching(query as CFDictionary, nil) == errSecSuccess
+    }
+
+    /// Verifies an item is reachable when queried with a specific
+    /// `kSecAttrAccessible` filter. On macOS, `SecItemCopyMatching` does not
+    /// enforce `kSecAttrAccessible` as a predicate (documented in
+    /// `KeychainServiceTests` line 106), so on the macOS test lane this is a
+    /// smoke check that the query round-trips. On iOS, the predicate is
+    /// applied and the success confirms the item was written with the
+    /// expected accessibility class.
+    private func itemExists(serviceName: String, account: String, accessibility: CFString) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: account,
+            kSecAttrAccessible as String: accessibility,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        return SecItemCopyMatching(query as CFDictionary, nil) == errSecSuccess
     }
 
     func test_keychain_roundTrip_writeReadDelete() async throws {
@@ -101,6 +130,135 @@ final class MCPOAuthTokenStoreKeychainTests: XCTestCase {
                 account: "\(namespace).\(serverID.uuidString.lowercased())"
             )
         )
+    }
+
+    // MARK: - SEC-26: refresh-token split
+
+    func test_keychain_writesSplitItems_withDistinctAccessibilityClasses() async throws {
+        let serviceName = "ManifoldKit.tests.mcp.oauth.\(UUID().uuidString)"
+        let namespace = "auth-worker.\(UUID().uuidString)"
+        let serverID = UUID()
+        trackCleanup(serviceName: serviceName, namespace: namespace, serverID: serverID)
+        let accessAccount = "\(namespace).\(serverID.uuidString.lowercased())"
+        let refreshAccount = "\(accessAccount).refresh"
+
+        let store = MCPOAuthTokenStore.keychain(serviceName: serviceName, accountNamespace: namespace)
+        try await store.write(makeTokens(accessToken: "ac-split"), serverID)
+
+        XCTAssertTrue(itemExists(serviceName: serviceName, account: accessAccount), "Access item must be present")
+        XCTAssertTrue(itemExists(serviceName: serviceName, account: refreshAccount), "Refresh item must be present")
+
+        // Filter-based accessibility-class smoke check. See helper docs for the macOS
+        // caveat: the kSecAttrAccessible predicate is not enforced by the macOS legacy
+        // keychain, so on the macOS lane this just confirms the query round-trips
+        // without an unexpected status. On iOS the predicate IS enforced and these
+        // assertions are real regression nets for the SEC-26 split.
+        XCTAssertTrue(
+            itemExists(serviceName: serviceName, account: accessAccount, accessibility: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly),
+            "Access token must be reachable under AfterFirstUnlockThisDeviceOnly (background refresh)"
+        )
+        XCTAssertTrue(
+            itemExists(serviceName: serviceName, account: refreshAccount, accessibility: kSecAttrAccessibleWhenUnlockedThisDeviceOnly),
+            "Refresh token must be reachable under stricter WhenUnlockedThisDeviceOnly"
+        )
+        // Negative cross-check: refresh item must NOT be reachable under the looser class.
+        // On iOS this proves the split; on macOS the predicate is ignored so the assertion
+        // is informational rather than enforced.
+        #if os(iOS)
+        XCTAssertFalse(
+            itemExists(serviceName: serviceName, account: refreshAccount, accessibility: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly),
+            "Refresh item must NOT be filed under the looser AfterFirstUnlock class"
+        )
+        #endif
+    }
+
+    func test_keychain_omitsRefreshItem_whenRefreshTokenNil() async throws {
+        let serviceName = "ManifoldKit.tests.mcp.oauth.\(UUID().uuidString)"
+        let namespace = "auth-worker.\(UUID().uuidString)"
+        let serverID = UUID()
+        trackCleanup(serviceName: serviceName, namespace: namespace, serverID: serverID)
+        let accessAccount = "\(namespace).\(serverID.uuidString.lowercased())"
+        let refreshAccount = "\(accessAccount).refresh"
+
+        let store = MCPOAuthTokenStore.keychain(serviceName: serviceName, accountNamespace: namespace)
+        let tokens = MCPOAuthTokens(
+            accessToken: "access-only",
+            refreshToken: nil,
+            expiresAt: Date(timeIntervalSince1970: 99),
+            scopes: ["tools:read"],
+            issuer: URL(string: "https://issuer.example.com")!
+        )
+        try await store.write(tokens, serverID)
+
+        XCTAssertTrue(itemExists(serviceName: serviceName, account: accessAccount))
+        XCTAssertFalse(itemExists(serviceName: serviceName, account: refreshAccount),
+                       "Refresh item must not be written when refreshToken is nil")
+
+        let readBack = try await store.read(serverID)
+        XCTAssertNil(readBack?.refreshToken)
+        XCTAssertEqual(String(data: readBack?.accessTokenData ?? Data(), encoding: .utf8), "access-only")
+    }
+
+    func test_keychain_loadReassemblesBothTokens() async throws {
+        let serviceName = "ManifoldKit.tests.mcp.oauth.\(UUID().uuidString)"
+        let namespace = "auth-worker.\(UUID().uuidString)"
+        let serverID = UUID()
+        trackCleanup(serviceName: serviceName, namespace: namespace, serverID: serverID)
+
+        let store = MCPOAuthTokenStore.keychain(serviceName: serviceName, accountNamespace: namespace)
+        let expected = makeTokens(accessToken: "reassemble-token")
+        try await store.write(expected, serverID)
+
+        let readBack = try await store.read(serverID)
+        XCTAssertEqual(readBack, expected)
+        XCTAssertEqual(readBack?.refreshToken, "refresh-reassemble-token")
+    }
+
+    func test_keychain_deleteRemovesBothItems() async throws {
+        let serviceName = "ManifoldKit.tests.mcp.oauth.\(UUID().uuidString)"
+        let namespace = "auth-worker.\(UUID().uuidString)"
+        let serverID = UUID()
+        trackCleanup(serviceName: serviceName, namespace: namespace, serverID: serverID)
+        let accessAccount = "\(namespace).\(serverID.uuidString.lowercased())"
+        let refreshAccount = "\(accessAccount).refresh"
+
+        let store = MCPOAuthTokenStore.keychain(serviceName: serviceName, accountNamespace: namespace)
+        try await store.write(makeTokens(accessToken: "to-be-deleted"), serverID)
+        XCTAssertTrue(itemExists(serviceName: serviceName, account: accessAccount))
+        XCTAssertTrue(itemExists(serviceName: serviceName, account: refreshAccount))
+
+        try await store.delete(serverID)
+        XCTAssertFalse(itemExists(serviceName: serviceName, account: accessAccount))
+        XCTAssertFalse(itemExists(serviceName: serviceName, account: refreshAccount))
+
+        let afterDelete = try await store.read(serverID)
+        XCTAssertNil(afterDelete)
+    }
+
+    func test_keychain_overwritingWithNilRefresh_purgesPriorRefreshItem() async throws {
+        let serviceName = "ManifoldKit.tests.mcp.oauth.\(UUID().uuidString)"
+        let namespace = "auth-worker.\(UUID().uuidString)"
+        let serverID = UUID()
+        trackCleanup(serviceName: serviceName, namespace: namespace, serverID: serverID)
+        let accessAccount = "\(namespace).\(serverID.uuidString.lowercased())"
+        let refreshAccount = "\(accessAccount).refresh"
+
+        let store = MCPOAuthTokenStore.keychain(serviceName: serviceName, accountNamespace: namespace)
+        try await store.write(makeTokens(accessToken: "with-refresh"), serverID)
+        XCTAssertTrue(itemExists(serviceName: serviceName, account: refreshAccount))
+
+        let withoutRefresh = MCPOAuthTokens(
+            accessToken: "no-refresh-now",
+            refreshToken: nil,
+            expiresAt: Date(timeIntervalSince1970: 100),
+            scopes: ["tools:read"],
+            issuer: URL(string: "https://issuer.example.com")!
+        )
+        try await store.write(withoutRefresh, serverID)
+
+        XCTAssertTrue(itemExists(serviceName: serviceName, account: accessAccount))
+        XCTAssertFalse(itemExists(serviceName: serviceName, account: refreshAccount),
+                       "Re-writing with nil refresh must purge prior refresh item to avoid stale value")
     }
 
     private func makeTokens(accessToken: String) -> MCPOAuthTokens {


### PR DESCRIPTION
## Summary

`MCPOAuthTokenStore.keychain` stored access + refresh tokens together as one JSON blob in a single Keychain item with one accessibility class (`AfterFirstUnlockThisDeviceOnly`, required so background access-token refresh works after the device is first unlocked). The refresh token inherited the looser class even though it is only consumed during the interactive re-auth flow.

This PR splits the storage:

- **Access token** keeps `AfterFirstUnlockThisDeviceOnly` so background refresh continues to work.
- **Refresh token** moves to a separate Keychain item suffixed `.refresh` with `WhenUnlockedThisDeviceOnly`, the stricter class appropriate for a credential only used while the user is active.

Closes SEC-26.

### Behavior

- `read` fetches both items and reassembles. If no `.refresh` item exists, falls back to the legacy embedded `refreshToken` field in the access blob (backward compat for pre-split installs).
- `write` writes the access blob *without* the refresh field (so the value never lives in the looser-class item), then writes the refresh token to the `.refresh` item; if `refreshToken == nil`, purges any prior `.refresh` item to avoid stale credentials.
- `delete` removes both items.

### macOS test-lane caveat

`SecItemCopyMatching` on macOS does not enforce `kSecAttrAccessible` as a predicate (documented in `KeychainServiceTests` line 106). The new accessibility-class assertions use the filter-then-check-found pattern: on iOS the predicate is enforced and the assertion is a real regression net; on the macOS lane it is a smoke check that the query round-trips. iOS-only negative cross-check (`#if os(iOS)`) verifies the refresh item is NOT reachable under the looser class.

## Acceptance criteria

- [x] Both items written with correct accessibility classes (access: `AfterFirstUnlockThisDeviceOnly`; refresh: `WhenUnlockedThisDeviceOnly`)
- [x] `write` with `refreshToken == nil` skips the refresh item
- [x] `read` reassembles both tokens
- [x] `delete` removes both items
- [x] Re-write with nil refresh purges prior stale refresh item
- [x] Backward compat: pre-split blob with embedded refresh token still readable

## Test plan

- [x] `MCPOAuthTokenStoreKeychainTests` — 5 new tests (split items, omit-refresh, reassemble, delete-both, purge-stale)
- [x] Pre-push two-invocation gate: XCTest 3373/0 fails, SwiftTesting 83/0 fails