### PR TITLE
feat: add ManifoldKit.quickStart() one-call facade

### DIFF
--- a/Sources/ManifoldKit/QuickStart.swift
+++ b/Sources/ManifoldKit/QuickStart.swift
@@ -1,0 +1,139 @@
+// QuickStart — one-call bootstrap facade.
+//
+// Collapses the documented three-object dance (`ManifoldBootstrap.build(...)`
+// + `DefaultBackends.register(with:)` + `ChatViewModel(...)`) into a single
+// API call. The README's first code block depends on this remaining a
+// one-liner; do not grow it into a parameterised builder.
+//
+// The facade is intentionally non-configurable beyond `ManifoldConfiguration`
+// — adopters who need a custom inference service, a custom model container,
+// or a non-default backend mix should drop down to `ManifoldBootstrap.build`
+// directly. The whole point of `quickStart()` is "no decisions required."
+
+import Foundation
+import SwiftData
+import ManifoldInference
+import ManifoldRuntime
+import ManifoldPersistenceSwiftData
+import ManifoldBackends
+import ManifoldUI
+
+/// The umbrella namespace for ManifoldKit's high-level entry points.
+///
+/// Today this hosts ``ManifoldKit/ManifoldKit/quickStart(configuration:)``;
+/// future top-level conveniences will land here so adopters have one
+/// well-known place to look.
+@MainActor
+public enum ManifoldKit {
+
+    /// Bootstraps a working chat runtime with sensible defaults in one call.
+    ///
+    /// Internally this:
+    /// 1. Drives ``ManifoldBootstrap/build(configuration:inferenceService:imageGenerationService:diagnostics:makeModelContainer:)``
+    ///    to completion (consuming its progress milestones).
+    /// 2. Registers the compiled-in default backends via
+    ///    ``DefaultBackends/register(with:)``.
+    /// 3. Constructs a ``ChatViewModel`` wired to the bootstrap's shared
+    ///    ``InferenceService``, persistence stores, and ``ConversationRuntime``.
+    ///
+    /// Errors thrown by any step are reduced through ``ManifoldKitError/from(_:)``
+    /// so callers always see the unified error rim instead of raw
+    /// `URLError` / SwiftData errors.
+    ///
+    /// ```swift
+    /// let kit = try await ManifoldKit.quickStart()
+    /// // kit.viewModel — a configured ChatViewModel
+    /// // kit.bootstrap — keep alive for the lifetime of the app
+    /// ```
+    ///
+    /// - Parameter configuration: The framework configuration. Defaults to
+    ///   ``ManifoldInference/ManifoldConfiguration/default`` — fine for
+    ///   demos and tests, but production apps should pass an explicit
+    ///   configuration with their own bundle identifier.
+    /// - Returns: A ``QuickStartResult`` carrying both the bootstrap and the
+    ///   view model. The caller owns the bootstrap and must retain it for
+    ///   the lifetime of the chat runtime.
+    public static func quickStart(
+        configuration: ManifoldConfiguration = .default
+    ) async throws -> QuickStartResult {
+        try await _quickStart(
+            configuration: configuration,
+            makeModelContainer: { try ModelContainerFactory.makeContainer() }
+        )
+    }
+
+    /// Internal seam used by tests to inject a custom (or throwing) model
+    /// container factory. Production callers go through ``quickStart(configuration:)``.
+    static func _quickStart(
+        configuration: ManifoldConfiguration,
+        makeModelContainer: @MainActor @escaping () throws -> ModelContainer
+    ) async throws -> QuickStartResult {
+        do {
+            // Drive the bootstrap stream to completion. We don't surface
+            // milestones from the simple facade — `quickStart()` is the
+            // "no progress UI" path. Consumers that want a launch
+            // progress bar should call `ManifoldBootstrap.build` directly.
+            let (progress, task) = ManifoldBootstrap.build(
+                configuration: configuration,
+                makeModelContainer: makeModelContainer
+            )
+            for await _ in progress {
+                // Consume so the buffered stream doesn't grow unboundedly.
+                // The bootstrap task drives `continuation.finish()` itself.
+            }
+
+            let bootstrap = try await task.value
+
+            DefaultBackends.register(with: bootstrap.inferenceService)
+
+            let viewModel = ChatViewModel(
+                inferenceService: bootstrap.inferenceService,
+                conversationRuntime: bootstrap.conversationRuntime
+            )
+            viewModel.configure(persistence: bootstrap.persistence)
+            viewModel.configure(endpointStore: bootstrap.endpointStore)
+
+            return QuickStartResult(bootstrap: bootstrap, viewModel: viewModel)
+        } catch {
+            throw ManifoldKitError.from(error)
+        }
+    }
+}
+
+/// The pair returned by ``ManifoldKit/ManifoldKit/quickStart(configuration:)``.
+///
+/// `bootstrap` owns the inference service, SwiftData container, persistence
+/// adapters, and ``ConversationRuntime``. Retain it for the lifetime of the
+/// chat runtime — releasing it tears down the underlying services.
+///
+/// `viewModel` is the ``ChatViewModel`` wired against `bootstrap`. Pass it to
+/// `ChatView` (or your own SwiftUI surface) as you would a manually
+/// constructed view model.
+///
+/// `QuickStartResult` is `Sendable` because both fields are `@MainActor`
+/// reference types; the struct itself carries no mutable state.
+@MainActor
+public struct QuickStartResult: Sendable {
+    public let bootstrap: ManifoldBootstrap
+    public let viewModel: ChatViewModel
+
+    public init(bootstrap: ManifoldBootstrap, viewModel: ChatViewModel) {
+        self.bootstrap = bootstrap
+        self.viewModel = viewModel
+    }
+}
+
+// MARK: - ManifoldConfiguration.default
+
+extension ManifoldConfiguration {
+    /// A sensible default configuration for demos, tests, and getting-started
+    /// snippets.
+    ///
+    /// Equivalent to `ManifoldConfiguration()` — all init parameters take
+    /// their defaults. The bundle identifier is the framework default
+    /// (`com.manifoldkit`); production apps should override it so two apps
+    /// using ManifoldKit don't collide on the shared SwiftData store path.
+    public static var `default`: ManifoldConfiguration {
+        ManifoldConfiguration()
+    }
+}

--- a/Tests/ManifoldKitTests/QuickStartTests.swift
+++ b/Tests/ManifoldKitTests/QuickStartTests.swift
@@ -1,0 +1,83 @@
+// QuickStartTests.swift
+//
+// Exercises `ManifoldKit.quickStart()` — the one-call facade that collapses
+// the documented three-object bootstrap dance. The README's getting-started
+// snippet depends on this returning a working `ChatViewModel` + bootstrap
+// pair, and on errors surfacing through the unified `ManifoldKitError` rim
+// rather than raw underlying errors.
+
+import XCTest
+import SwiftData
+import ManifoldInference
+import ManifoldPersistenceSwiftData
+@testable import ManifoldKit
+
+@MainActor
+final class QuickStartTests: XCTestCase {
+
+    /// The happy path: `quickStart()` returns a bootstrap and a view model
+    /// that share the same inference service and have persistence wired up.
+    ///
+    /// We use the internal `_quickStart` seam with an in-memory SwiftData
+    /// container so the test doesn't touch the on-disk Application Support
+    /// store the default factory derives.
+    func test_quickStart_returnsBootstrappedViewModel() async throws {
+        let result = try await ManifoldKit._quickStart(
+            configuration: .default,
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+
+        // Bootstrap side: every service the facade promises was constructed.
+        // `ChatViewModel.inferenceService` is intentionally `internal` to
+        // ManifoldUI (see CLAUDE.md "Service sharing"), so we can't assert
+        // reference identity from this test target — instead we check that
+        // the bootstrap exposes the shared services the view model was
+        // configured against.
+        XCTAssertNotNil(result.bootstrap.persistence)
+        XCTAssertNotNil(result.bootstrap.conversationRuntime)
+        XCTAssertNotNil(result.bootstrap.endpointStore)
+
+        // View-model side: observable surface area is wired. `modelRegistry`
+        // is the documented sibling-module read seam (CLAUDE.md "Service
+        // sharing") and is populated from the inference service the
+        // bootstrap built.
+        XCTAssertNotNil(result.viewModel.modelRegistry)
+    }
+
+    /// Errors from any step in the bootstrap chain must be reduced through
+    /// `ManifoldKitError.from(_:)` rather than leaking the raw underlying
+    /// error. We force a failure by passing a throwing model-container
+    /// factory and assert the caught error is `ManifoldKitError`.
+    func test_quickStart_surfacesManifoldKitError_onFailure() async {
+        struct ForcedFailure: Error {}
+
+        do {
+            _ = try await ManifoldKit._quickStart(
+                configuration: .default,
+                makeModelContainer: { throw ForcedFailure() }
+            )
+            XCTFail("quickStart() must throw when the model container factory throws.")
+        } catch let error as ManifoldKitError {
+            // Unknown errors fall through to .unknown — that's the expected
+            // case for a synthetic test error that doesn't match any of the
+            // structured URLError / DecodingError / KeychainError shapes.
+            switch error {
+            case .unknown:
+                break
+            default:
+                XCTFail("Expected .unknown ManifoldKitError, got \(error).")
+            }
+        } catch {
+            XCTFail("Expected ManifoldKitError, got \(type(of: error)): \(error). The facade must wrap all underlying errors through ManifoldKitError.from(_:).")
+        }
+    }
+
+    /// Compile-time check that `QuickStartResult` is `Sendable`. The README's
+    /// snippet stores the result in a `@State` property or passes it across
+    /// task boundaries; losing Sendability would silently break that.
+    func test_QuickStartResult_isSendable() {
+        _requireSendable(QuickStartResult.self)
+    }
+
+    private func _requireSendable<T: Sendable>(_: T.Type) {}
+}


### PR DESCRIPTION
## Summary

DX overhaul Wave B foundation. Collapses the documented three-object bootstrap dance into a single API call so the README's getting-started snippet — landing in a later wave — can be a one-liner.

Today an adopter writes:

```swift
let (progress, task) = ManifoldBootstrap.build(configuration: config)
for await _ in progress { }
let bootstrap = try await task.value
DefaultBackends.register(with: bootstrap.inferenceService)
let viewModel = ChatViewModel(
    inferenceService: bootstrap.inferenceService,
    conversationRuntime: bootstrap.conversationRuntime
)
viewModel.configure(persistence: bootstrap.persistence)
viewModel.configure(endpointStore: bootstrap.endpointStore)
```

After this PR:

```swift
let kit = try await ManifoldKit.quickStart()
```

## Public API

```swift
@MainActor
public enum ManifoldKit {
    public static func quickStart(
        configuration: ManifoldConfiguration = .default
    ) async throws -> QuickStartResult
}

@MainActor
public struct QuickStartResult: Sendable {
    public let bootstrap: ManifoldBootstrap
    public let viewModel: ChatViewModel
}

extension ManifoldConfiguration {
    public static var `default`: ManifoldConfiguration { get }
}
```

## Backed-by analysis

The facade calls the existing public APIs and does not modify any of them:

- `ManifoldBootstrap.build(configuration:makeModelContainer:)` — drives the milestone stream to completion, then awaits the bootstrap task. Milestones are consumed (not surfaced) — adopters who want a launch progress UI continue to call `build` directly.
- `DefaultBackends.register(with: bootstrap.inferenceService)` — registers the compiled-in default registrars.
- `ChatViewModel.init(inferenceService:conversationRuntime:)` + `configure(persistence:)` + `configure(endpointStore:)` — the documented post-bootstrap wiring sequence.

Errors at any step are caught and reduced through the just-landed `ManifoldKitError.from(_:)` rim (W0).

One additive non-breaking change: a new `public static var default` on `ManifoldConfiguration` returning `ManifoldConfiguration()`. The previous-existing `ManifoldConfiguration.shared` is for installed-global access; `.default` is the value adopters explicitly opt into when they have no app-specific configuration yet.

## Test plan

`Tests/ManifoldKitTests/QuickStartTests.swift` — 3 XCTest cases, runs under `--disable-default-traits`:

- `test_quickStart_returnsBootstrappedViewModel` — calls `_quickStart` with an in-memory SwiftData container and asserts the bootstrap's persistence + conversation runtime + endpoint store + view model registry are all populated.
- `test_quickStart_surfacesManifoldKitError_onFailure` — injects a throwing model container factory and asserts the caught error is `ManifoldKitError` (specifically the `.unknown` case for a synthetic error). Without this wrapping, raw `Error` types would leak through.
- `test_QuickStartResult_isSendable` — compile-time check via `_requireSendable<T: Sendable>(_: T.Type)`.

The tests use an internal `_quickStart` seam that accepts a `makeModelContainer:` closure so we can drive the in-memory path without an internal-only test target dependency. The public `quickStart()` overload always uses `ModelContainerFactory.makeContainer()`.

## Test gate

- XCTest pre-push suite: 3,396 / 3,396 passed (17 XCTSkips, all pre-existing).
- Swift Testing pre-push suite: 83 / 83 passed.
- Trait-combo `swift build --build-tests` with all traits enabled: errors in `Tests/ManifoldE2ETests/VisionE2ETests.swift` and `QualityBaselineTests.swift` are pre-existing on `main` (confirmed via `git stash` + rebuild) and unrelated to this change.

## Out of scope

- README restructure — Wave C.
- `Example/Examples/MinimalExample` rewrite — next worker (W-B-A6).
- `quickStart` variants with custom backends / progress streams — kept off-surface deliberately; adopters who need control drop down to `ManifoldBootstrap.build` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)