### PR TITLE
feat!: remove pre-1.0 deprecated APIs

### DIFF
--- a/Sources/ManifoldInference/Models/ToolTypes.swift
+++ b/Sources/ManifoldInference/Models/ToolTypes.swift
@@ -301,18 +301,6 @@ public struct ToolResult: Sendable, Codable, Equatable, Hashable {
         self.errorKind = errorKind
     }
 
-    /// Legacy initializer retained for backwards compatibility.
-    ///
-    /// Maps `isError == true` to ``ErrorKind/permanent`` and `isError == false`
-    /// to `nil`. New code should pass an explicit ``ErrorKind`` via the primary
-    /// initializer so the failure class is preserved on the wire.
-    @available(*, deprecated, renamed: "init(callId:content:errorKind:)", message: "Use init(callId:content:errorKind:) and pass .permanent for legacy isError == true, or nil for success.")
-    public init(callId: String, content: String, isError: Bool) {
-        self.callId = callId
-        self.content = content
-        self.errorKind = isError ? .permanent : nil
-    }
-
     // MARK: Codable
 
     private enum CodingKeys: String, CodingKey {

--- a/Sources/ManifoldInference/Protocols/InferenceBackend.swift
+++ b/Sources/ManifoldInference/Protocols/InferenceBackend.swift
@@ -92,15 +92,6 @@ public struct GenerationConfig: Sendable, Codable {
     public var temperature: Float
     public var topP: Float
     public var repeatPenalty: Float
-    @available(*, deprecated, renamed: "maxOutputTokens", message: "Use maxOutputTokens (Int?) for the generation cap; maxTokens is legacy Int32 Codable compatibility only.")
-    public var maxTokens: Int32 {
-        get { _legacyMaxTokens }
-        set { _legacyMaxTokens = newValue }
-    }
-    /// Backing storage for the deprecated ``maxTokens`` field. Lives separately so the type's
-    /// own initializers and Codable conformance can read/write the legacy value without
-    /// tripping the deprecation warning. See PR #766 follow-up to #747.
-    @usableFromInline internal var _legacyMaxTokens: Int32 = 512
     public var topK: Int32?
     public var typicalP: Float?
 
@@ -320,57 +311,6 @@ public struct GenerationConfig: Sendable, Codable {
     /// per-request payloads; this is a per-request *contract*.
     public var requiredCapabilities: Set<GenerationCapabilityRequirement> = []
 
-    @available(*, deprecated, message: "Drop the maxTokens argument and use the primary GenerationConfig init with maxOutputTokens; this overload only preserves legacy maxTokens storage.")
-    public init(
-        temperature: Float = 0.7,
-        topP: Float = 0.9,
-        repeatPenalty: Float = 1.1,
-        maxTokens: Int32,
-        topK: Int32? = nil,
-        typicalP: Float? = nil,
-        minP: Float? = nil,
-        repetitionPenalty: Float? = nil,
-        seed: UInt64? = nil,
-        maxOutputTokens: Int? = 2048,
-        tools: [ToolDefinition] = [],
-        toolChoice: ToolChoice = .auto,
-        maxThinkingTokens: Int? = nil,
-        jsonMode: Bool = false,
-        streamPrefillProgress: Bool = false,
-        thinkingMarkers: ThinkingMarkers? = nil,
-        maxToolIterations: Int = 10,
-        grammar: String? = nil,
-        structuredOutput: StructuredOutputStrategy? = nil,
-        yieldEveryNTokens: Int = 8,
-        llamaDRY: LlamaDRYSamplerOptions? = nil,
-        llamaXTC: LlamaXTCSamplerOptions? = nil,
-        llamaMirostatV2: LlamaMirostatV2SamplerOptions? = nil
-    ) {
-        self.temperature = temperature
-        self.topP = topP
-        self.repeatPenalty = repeatPenalty
-        self._legacyMaxTokens = maxTokens
-        self.topK = topK
-        self.typicalP = typicalP
-        self.minP = minP
-        self.repetitionPenalty = repetitionPenalty
-        self.seed = seed
-        self.maxOutputTokens = maxOutputTokens
-        self.tools = tools
-        self.toolChoice = toolChoice
-        self.maxThinkingTokens = maxThinkingTokens
-        self.jsonMode = jsonMode
-        self.streamPrefillProgress = streamPrefillProgress
-        self.thinkingMarkers = thinkingMarkers
-        self.maxToolIterations = max(1, maxToolIterations)
-        self.grammar = grammar
-        self.structuredOutput = structuredOutput
-        self.yieldEveryNTokens = yieldEveryNTokens
-        self.llamaDRY = llamaDRY
-        self.llamaXTC = llamaXTC
-        self.llamaMirostatV2 = llamaMirostatV2
-    }
-
     public init(
         temperature: Float = 0.7,
         topP: Float = 0.9,
@@ -434,7 +374,7 @@ public struct GenerationConfig: Sendable, Codable {
     // MARK: Codable
 
     private enum CodingKeys: String, CodingKey {
-        case temperature, topP, repeatPenalty, maxTokens, topK, typicalP, maxOutputTokens
+        case temperature, topP, repeatPenalty, topK, typicalP, maxOutputTokens
         case tools, toolChoice, maxThinkingTokens, maxToolIterations, grammar
         case yieldEveryNTokens
         case streamPrefillProgress
@@ -453,9 +393,6 @@ public struct GenerationConfig: Sendable, Codable {
         temperature = try c.decode(Float.self, forKey: .temperature)
         topP = try c.decode(Float.self, forKey: .topP)
         repeatPenalty = try c.decode(Float.self, forKey: .repeatPenalty)
-        // maxTokens is deprecated; absent from payloads that never encoded it — fall back to 512.
-        // We write to the backing store directly to avoid the deprecation warning on the property.
-        _legacyMaxTokens = (try c.decodeIfPresent(Int32.self, forKey: .maxTokens)) ?? 512
         topK = try c.decodeIfPresent(Int32.self, forKey: .topK)
         typicalP = try c.decodeIfPresent(Float.self, forKey: .typicalP)
         maxOutputTokens = try c.decodeIfPresent(Int.self, forKey: .maxOutputTokens)
@@ -507,8 +444,6 @@ public struct GenerationConfig: Sendable, Codable {
         try c.encode(temperature, forKey: .temperature)
         try c.encode(topP, forKey: .topP)
         try c.encode(repeatPenalty, forKey: .repeatPenalty)
-        // Encode the legacy `maxTokens` wire field for backwards-compatible payloads.
-        try c.encode(_legacyMaxTokens, forKey: .maxTokens)
         try c.encodeIfPresent(topK, forKey: .topK)
         try c.encodeIfPresent(typicalP, forKey: .typicalP)
         try c.encodeIfPresent(maxOutputTokens, forKey: .maxOutputTokens)

--- a/Sources/ManifoldInference/Services/InferenceService.swift
+++ b/Sources/ManifoldInference/Services/InferenceService.swift
@@ -64,7 +64,6 @@ public enum ModelLoadReadinessState: Equatable, Sendable {
 /// - **Thermal gating**: `.background` requests are dropped when the device is
 ///   under `.serious` or `.critical` thermal pressure.
 /// - **Auto-drain**: the queue drains automatically when each stream terminates.
-///   `generationDidFinish()` is deprecated and is now a no-op.
 @Observable
 @MainActor
 public final class InferenceService {
@@ -531,9 +530,6 @@ public final class InferenceService {
         ensureProviderWired()
         return generation.hasQueuedRequests
     }
-
-    @available(*, deprecated, message: "Remove calls to generationDidFinish(); the queue auto-drains when the returned stream terminates, and this method is a no-op.")
-    public func generationDidFinish() {}
 
     public func resetConversation() {
         lifecycle.resetConversation()

--- a/Sources/ManifoldInference/ThinkingBlockFilter.swift
+++ b/Sources/ManifoldInference/ThinkingBlockFilter.swift
@@ -79,6 +79,3 @@ public struct ThinkingParser {
     }
 }
 
-@available(*, deprecated, renamed: "ThinkingParser",
-    message: "Use ThinkingParser; process(_:) returns [GenerationEvent] instead of a filtered String.")
-public typealias ThinkingBlockFilter = ThinkingParser

--- a/Tests/ManifoldCoreTests/MessagePartGeneratedImageTests.swift
+++ b/Tests/ManifoldCoreTests/MessagePartGeneratedImageTests.swift
@@ -89,7 +89,7 @@ final class MessagePartGeneratedImageTests: XCTestCase {
             .text("Here is what I generated:"),
             .thinking("Let me think about composition."),
             .toolCall(ToolCall(id: "c1", toolName: "render", arguments: "{}")),
-            .toolResult(ToolResult(callId: "c1", content: "ok", isError: false)),
+            .toolResult(ToolResult(callId: "c1", content: "ok")),
             .image(data: Data([0xFF]), mimeType: "image/jpeg"),
             .audio(url: URL(fileURLWithPath: "/Users/example/audio.m4a"), duration: 4, waveform: [0.1, 0.9]),
             .generatedImage(makePayload()),
@@ -129,7 +129,7 @@ final class MessagePartGeneratedImageTests: XCTestCase {
         XCTAssertNil(MessagePart.image(data: Data(), mimeType: "image/png").generatedImageContent)
         XCTAssertNil(MessagePart.audio(url: URL(fileURLWithPath: "/Users/example/audio.m4a"), duration: 1, waveform: nil).generatedImageContent)
         XCTAssertNil(MessagePart.toolCall(ToolCall(id: "c", toolName: "t", arguments: "{}")).generatedImageContent)
-        XCTAssertNil(MessagePart.toolResult(ToolResult(callId: "c", content: "x", isError: false)).generatedImageContent)
+        XCTAssertNil(MessagePart.toolResult(ToolResult(callId: "c", content: "x")).generatedImageContent)
     }
 
     // MARK: - Canonical JSON fixture (hand-written)
@@ -216,7 +216,7 @@ final class MessagePartGeneratedImageTests: XCTestCase {
         // hand-written so a renamed key (e.g. `text` → `t`) shows up as a
         // test failure rather than a silent migration.
         let toolCall = ToolCall(id: "c1", toolName: "search", arguments: "{\"q\":\"swift\"}")
-        let toolResult = ToolResult(callId: "c1", content: "ok", isError: false)
+        let toolResult = ToolResult(callId: "c1", content: "ok")
         let toolCallJSON = try XCTUnwrap(String(data: try JSONEncoder().encode(toolCall), encoding: .utf8))
         let toolResultJSON = try XCTUnwrap(String(data: try JSONEncoder().encode(toolResult), encoding: .utf8))
 

--- a/Tests/ManifoldCoreTests/MessagePartToolCasesTests.swift
+++ b/Tests/ManifoldCoreTests/MessagePartToolCasesTests.swift
@@ -36,8 +36,7 @@ final class MessagePartToolCasesTests: XCTestCase {
     func test_toolResult_codableRoundtrip_success() throws {
         let result = ToolResult(
             callId: "call_abc123",
-            content: #"{"temp":72}"#,
-            isError: false
+            content: #"{"temp":72}"#
         )
         let part: MessagePart = .toolResult(result)
 
@@ -48,12 +47,11 @@ final class MessagePartToolCasesTests: XCTestCase {
     }
 
     func test_toolResult_codableRoundtrip_errorFlag() throws {
-        // Agent A may later layer structured error kinds on top of isError; the
-        // Bool remains the wire contract and must round-trip faithfully.
+        // ErrorKind round-trips faithfully on the wire.
         let result = ToolResult(
             callId: "call_xyz",
             content: "timeout after 30s",
-            isError: true
+            errorKind: .permanent
         )
         let part: MessagePart = .toolResult(result)
 
@@ -71,7 +69,7 @@ final class MessagePartToolCasesTests: XCTestCase {
             .text("Let me check the weather."),
             .thinking("The user wants the current conditions."),
             .toolCall(ToolCall(id: "c1", toolName: "get_weather", arguments: #"{"city":"Paris"}"#)),
-            .toolResult(ToolResult(callId: "c1", content: #"{"temp":18}"#, isError: false)),
+            .toolResult(ToolResult(callId: "c1", content: #"{"temp":18}"#)),
             .image(data: Data([0xFF, 0xD8, 0xFF, 0xE0]), mimeType: "image/jpeg"),
             .text("It's 18°C in Paris."),
         ]
@@ -95,7 +93,7 @@ final class MessagePartToolCasesTests: XCTestCase {
 
     func test_textContent_returnsNil_forToolResult() {
         let part: MessagePart = .toolResult(
-            ToolResult(callId: "c1", content: "ok", isError: false)
+            ToolResult(callId: "c1", content: "ok")
         )
         XCTAssertNil(part.textContent,
             ".textContent must be nil for .toolResult")
@@ -112,7 +110,7 @@ final class MessagePartToolCasesTests: XCTestCase {
     }
 
     func test_toolResultContent_returnsAssociatedValue() {
-        let result = ToolResult(callId: "c1", content: "42", isError: false)
+        let result = ToolResult(callId: "c1", content: "42")
         let part: MessagePart = .toolResult(result)
 
         XCTAssertEqual(part.toolResultContent, result)

--- a/Tests/ManifoldInferenceTests/GenerationConfigTests.swift
+++ b/Tests/ManifoldInferenceTests/GenerationConfigTests.swift
@@ -100,7 +100,6 @@ final class GenerationConfigTests: XCTestCase {
             "temperature": 0.7,
             "topP": 0.9,
             "repeatPenalty": 1.1,
-            "maxTokens": 512,
             "jsonMode": true
         }
         """

--- a/Tests/ManifoldInferenceTests/GenerationConfigToolIterationsTests.swift
+++ b/Tests/ManifoldInferenceTests/GenerationConfigToolIterationsTests.swift
@@ -55,7 +55,7 @@ final class GenerationConfigToolIterationsTests: XCTestCase {
         // Payloads serialised before maxToolIterations was added must still
         // decode with the canonical default.
         let legacy = """
-        {"temperature":0.7,"topP":0.9,"repeatPenalty":1.1,"maxTokens":512,"tools":[],"toolChoice":{"type":"auto"},"jsonMode":false}
+        {"temperature":0.7,"topP":0.9,"repeatPenalty":1.1,"tools":[],"toolChoice":{"type":"auto"},"jsonMode":false}
         """.data(using: .utf8)!
 
         let decoded = try JSONDecoder().decode(GenerationConfig.self, from: legacy)
@@ -66,7 +66,7 @@ final class GenerationConfigToolIterationsTests: XCTestCase {
     func test_legacyPayload_withZeroField_clampedTo1() throws {
         // Defensive: a persisted zero (e.g. from a pre-release build) should
         // still yield loop-viable semantics after decode.
-        let legacy = #"{"temperature":0.7,"topP":0.9,"repeatPenalty":1.1,"maxTokens":512,"tools":[],"toolChoice":{"type":"auto"},"jsonMode":false,"maxToolIterations":0}"#.data(using: .utf8)!
+        let legacy = #"{"temperature":0.7,"topP":0.9,"repeatPenalty":1.1,"tools":[],"toolChoice":{"type":"auto"},"jsonMode":false,"maxToolIterations":0}"#.data(using: .utf8)!
 
         let decoded = try JSONDecoder().decode(GenerationConfig.self, from: legacy)
 

--- a/Tests/ManifoldInferenceTests/InferenceServiceFacadeTests.swift
+++ b/Tests/ManifoldInferenceTests/InferenceServiceFacadeTests.swift
@@ -114,7 +114,6 @@ final class InferenceServiceFacadeTests: XCTestCase {
         service.unloadModel()
         service.resetConversation()
         service.stopGeneration()
-        service.generationDidFinish()
     }
 
     // MARK: - Helpers

--- a/Tests/ManifoldInferenceTests/InferenceServiceQueueTests.swift
+++ b/Tests/ManifoldInferenceTests/InferenceServiceQueueTests.swift
@@ -169,10 +169,7 @@ final class InferenceServiceQueueTests: XCTestCase {
         // Consume first stream.
         for try await _ in stream1.events {}
 
-        // Signal the service that generation finished.
-        service.generationDidFinish()
-
-        // Second request should now be active.
+        // Second request should now be active (queue auto-drains on stream terminate).
         XCTAssertEqual(stream2.phase, .connecting)
 
         // Wait for the drain Task to call generate() for the second request.
@@ -243,7 +240,6 @@ final class InferenceServiceQueueTests: XCTestCase {
         await waitFor(mock.generateCallCount >= 1, description: "active generate() called")
         mock.release(at: 0, tokens: ["x"])
         for try await _ in streamActive.events {}
-        service.generationDidFinish()
 
         // userInitiated should run before background.
         XCTAssertEqual(streamUi.phase, .connecting,
@@ -281,7 +277,6 @@ final class InferenceServiceQueueTests: XCTestCase {
         await waitFor(mock.generateCallCount >= 1, description: "active generate() called")
         mock.release(at: 0)
         for try await _ in streamActive.events {}
-        service.generationDidFinish()
 
         // Should drain in priority order: userInitiated first.
         XCTAssertEqual(streamUi.phase, .connecting, "userInitiated should run first")
@@ -375,28 +370,6 @@ final class InferenceServiceQueueTests: XCTestCase {
         // stream1 may not have .failed set (it was active, not queued),
         // but its continuation was finished with an error.
         XCTAssertTrue(isFailed(stream2.phase), "Queued stream should be .failed after stopGeneration")
-    }
-
-    // MARK: - 8. generationDidFinish drains next request
-
-    func test_generationDidFinish_drainsNextRequest() async throws {
-        let (service, mock) = makeService()
-
-        let (_, stream1) = try service.enqueue(messages: [("user", "first")], priority: .normal)
-        let (_, stream2) = try service.enqueue(messages: [("user", "second")], priority: .normal)
-
-        XCTAssertEqual(stream2.phase, .queued)
-
-        // Complete first generation.
-        await waitFor(mock.generateCallCount >= 1, description: "first generate() called")
-        mock.release(at: 0)
-        for try await _ in stream1.events {}
-
-        service.generationDidFinish()
-
-        XCTAssertEqual(stream2.phase, .connecting,
-                       "Second request should start after generationDidFinish()")
-        XCTAssertTrue(service.isGenerating)
     }
 
     // MARK: - 9. discardRequests session mismatch cancels stale
@@ -572,11 +545,10 @@ final class InferenceServiceQueueTests: XCTestCase {
         }
     }
 
-    // MARK: - 17. Queue auto-drains without generationDidFinish()
+    // MARK: - 17. Queue auto-drains on stream terminate
 
-    /// Verifies that the queue drains automatically after stream1 is consumed,
-    /// without any explicit call to generationDidFinish().
-    func test_queue_autoDrains_withoutGenerationDidFinish() async throws {
+    /// Verifies that the queue drains automatically after stream1 is consumed.
+    func test_queue_autoDrains_onStreamTerminate() async throws {
         let (service, mock) = makeService()
 
         let (_, stream1) = try service.enqueue(
@@ -594,14 +566,13 @@ final class InferenceServiceQueueTests: XCTestCase {
         await waitFor(mock.generateCallCount >= 1, description: "first generate() called")
         mock.release(at: 0, tokens: ["a"])
 
-        // Consume stream1 fully — deliberately do NOT call generationDidFinish().
-        // The queue should auto-drain when the stream terminates.
+        // Consume stream1 fully — the queue should auto-drain when the stream terminates.
         for try await _ in stream1.events {}
 
         // The activeTask's defer fires on the main actor before `for try await`
         // returns, so auto-drain is synchronous from the test's perspective.
         XCTAssertEqual(stream2.phase, .connecting,
-                       "Queue should auto-drain after stream1 is consumed without generationDidFinish()")
+                       "Queue should auto-drain after stream1 is consumed")
         XCTAssertFalse(service.hasQueuedRequests,
                        "Service should report no queued requests after auto-drain")
         XCTAssertTrue(service.isGenerating,
@@ -642,15 +613,13 @@ final class InferenceServiceQueueTests: XCTestCase {
 
         for try await _ in stream1.events {}
         for try await _ in stream2.events {}
-
-        service.generationDidFinish()
     }
 
-    // MARK: - 19. Auto-drain: two requests, no generationDidFinish()
+    // MARK: - 19. Auto-drain: two requests
 
-    /// Enqueues two requests, consumes stream1 without calling generationDidFinish(),
-    /// and verifies that stream2 transitions to .connecting automatically.
-    func test_queueAutoDrains_withoutExplicitGenerationDidFinish() async throws {
+    /// Enqueues two requests, consumes stream1, and verifies that stream2
+    /// transitions to .connecting automatically.
+    func test_queueAutoDrains_withTwoRequests() async throws {
         let (service, mock) = makeService()
 
         let (_, stream1) = try service.enqueue(
@@ -669,7 +638,7 @@ final class InferenceServiceQueueTests: XCTestCase {
         await waitFor(mock.generateCallCount >= 1, description: "first generate() called")
         mock.release(at: 0, tokens: ["tok"])
 
-        // Consume stream1 without calling generationDidFinish().
+        // Consume stream1; the queue should auto-drain on stream terminate.
         var collected: [String] = []
         for try await event in stream1.events {
             if case .token(let text) = event {

--- a/Tests/ManifoldInferenceTests/InferenceServiceRegressionLockTests.swift
+++ b/Tests/ManifoldInferenceTests/InferenceServiceRegressionLockTests.swift
@@ -102,21 +102,6 @@ final class InferenceServiceRegressionLockTests: XCTestCase {
         XCTAssertNil(service.lastTokenUsage)
     }
 
-    // MARK: - generationDidFinish (deprecated no-op)
-
-    func test_generationDidFinish_isNoOp() throws {
-        let mock = GatedMockBackend()
-        let service = InferenceService(backend: mock, name: "Mock")
-        let (_, _) = try service.enqueue(messages: [("user", "hi")])
-
-        // Service should be generating.
-        XCTAssertTrue(service.isGenerating)
-
-        // Calling the deprecated method should be a no-op — state unchanged.
-        service.generationDidFinish()
-        XCTAssertTrue(service.isGenerating, "generationDidFinish() should be a no-op")
-    }
-
     // MARK: - declareSupport accumulation
 
     func test_declareSupport_accumulatesMultipleTypes() {

--- a/Tests/ManifoldInferenceTests/InferenceServiceTests.swift
+++ b/Tests/ManifoldInferenceTests/InferenceServiceTests.swift
@@ -513,7 +513,7 @@ final class InferenceServiceTests: XCTestCase {
                         "isGenerating should remain false — generate() no longer sets it")
     }
 
-    func test_generate_streamCompletesNormally_isGeneratingResetByFinish() async throws {
+    func test_generate_streamCompletesNormally_isGeneratingResetByAutoDrain() async throws {
         let mock = MockInferenceBackend()
         mock.isModelLoaded = true
         mock.tokensToYield = ["a", "b"]
@@ -523,9 +523,8 @@ final class InferenceServiceTests: XCTestCase {
 
         for try await _ in stream.events {}
 
-        service.generationDidFinish()
         XCTAssertFalse(service.isGenerating,
-                        "isGenerating should be false after generationDidFinish()")
+                        "isGenerating should be false after the stream terminates (queue auto-drains)")
     }
 
     func test_generate_streamErrorMidStream_isGeneratingManagedByQueue() async throws {

--- a/Tests/ManifoldInferenceTests/ThinkingParserTests.swift
+++ b/Tests/ManifoldInferenceTests/ThinkingParserTests.swift
@@ -19,7 +19,7 @@ private func countCompletions(_ events: [GenerationEvent]) -> Int {
 ///
 /// Each test processes one or more chunks and verifies both the visible text
 /// (.token events) and the thinking text (.thinkingToken events) emitted.
-final class ThinkingBlockFilterTests: XCTestCase {
+final class ThinkingParserTests: XCTestCase {
 
     // MARK: - Passthrough (no tags)
 

--- a/Tests/ManifoldInferenceTests/ToolCallContractTests.swift
+++ b/Tests/ManifoldInferenceTests/ToolCallContractTests.swift
@@ -173,7 +173,7 @@ final class ToolCallContractTests: XCTestCase {
         // Sabotage check: using `decode` instead of `decodeIfPresent` in init(from:)
         // causes a keyNotFound DecodingError here.
         let legacyJSON = """
-        {"temperature":0.7,"topP":0.9,"repeatPenalty":1.1,"maxTokens":512}
+        {"temperature":0.7,"topP":0.9,"repeatPenalty":1.1}
         """.data(using: .utf8)!
 
         let decoded = try JSONDecoder().decode(GenerationConfig.self, from: legacyJSON)

--- a/Tests/ManifoldInferenceTests/ToolResultErrorKindTests.swift
+++ b/Tests/ManifoldInferenceTests/ToolResultErrorKindTests.swift
@@ -98,33 +98,6 @@ final class ToolResultErrorKindTests: XCTestCase {
         XCTAssertTrue(decoded.isError)
     }
 
-    // MARK: - Deprecated initializer
-
-    func test_deprecatedInit_isErrorTrue_mapsToPermanent() {
-        // Intentionally exercise the deprecated initializer. `@available`
-        // deprecation warnings are expected; the initializer is retained for
-        // migration compatibility.
-        @available(*, deprecated)
-        func makeLegacy() -> ToolResult {
-            ToolResult(callId: "c", content: "x", isError: true)
-        }
-
-        let result = makeLegacy()
-        XCTAssertEqual(result.errorKind, .permanent)
-        XCTAssertTrue(result.isError)
-    }
-
-    func test_deprecatedInit_isErrorFalse_mapsToNil() {
-        @available(*, deprecated)
-        func makeLegacy() -> ToolResult {
-            ToolResult(callId: "c", content: "x", isError: false)
-        }
-
-        let result = makeLegacy()
-        XCTAssertNil(result.errorKind)
-        XCTAssertFalse(result.isError)
-    }
-
     // MARK: - Equatable / Hashable
 
     func test_resultsWithDifferentErrorKinds_areNotEqual() {

--- a/Tests/ManifoldUITests/GenerationExtensionTests.swift
+++ b/Tests/ManifoldUITests/GenerationExtensionTests.swift
@@ -359,9 +359,9 @@ final class GenerationExtensionTests: XCTestCase {
         XCTAssertFalse(vm.isGenerating, "isGenerating should be false after stream error")
     }
 
-    // MARK: - 7. generationDidFinish Cleans Up Service State
+    // MARK: - 7. Stream Termination Cleans Up Service State
 
-    func test_generationDidFinish_setsServiceIsGeneratingFalse() async {
+    func test_streamCompletion_setsServiceIsGeneratingFalse() async {
         let mock = MockInferenceBackend()
         mock.tokensToYield = ["Token"]
         let vm = await makeVM(backend: mock)
@@ -371,11 +371,11 @@ final class GenerationExtensionTests: XCTestCase {
 
         XCTAssertFalse(
             vm.inferenceService.isGenerating,
-            "InferenceService.isGenerating should be false after generation completes (generationDidFinish called)"
+            "InferenceService.isGenerating should be false after generation completes (queue auto-drains)"
         )
     }
 
-    func test_generationDidFinish_calledEvenOnError() async {
+    func test_streamError_clearsIsGenerating() async {
         let mock = MockInferenceBackend()
         mock.shouldThrowOnGenerate = InferenceError.inferenceFailure("fail")
         let vm = await makeVM(backend: mock)

--- a/Tests/ManifoldUITests/PostGenerationQueueTests.swift
+++ b/Tests/ManifoldUITests/PostGenerationQueueTests.swift
@@ -7,7 +7,7 @@ import ManifoldTestSupport
 /// Integration tests verifying post-generation queue behavior.
 ///
 /// These tests exercise the InferenceService queue from a consumer's
-/// perspective: enqueue requests, drain them via `generationDidFinish()`,
+/// perspective: enqueue requests, let them auto-drain on stream terminate,
 /// and verify ordering and lifecycle contracts.
 @MainActor
 final class PostGenerationQueueTests: XCTestCase {
@@ -96,14 +96,11 @@ final class PostGenerationQueueTests: XCTestCase {
         await Task.yield()
         mock.release(at: 0, tokens: ["primary-tok"])
 
-        // Consume the primary stream fully.
+        // Consume the primary stream fully — queue auto-drains on stream terminate.
         for try await _ in primaryStream.events {}
 
-        // Signal completion — this is the caller's responsibility.
-        service.generationDidFinish()
-
         XCTAssertFalse(service.isGenerating,
-                       "Service should be idle after generationDidFinish()")
+                       "Service should be idle after stream terminates")
 
         // Now enqueue a background request, simulating a post-generation task.
         let (_, bgStream) = try service.enqueue(
@@ -217,7 +214,6 @@ final class PostGenerationQueueTests: XCTestCase {
         await Task.yield()
         mock.release(at: 0, tokens: ["done"])
         for try await _ in activeStream.events {}
-        service.generationDidFinish()
 
         // The urgent request should be next, not bg1.
         XCTAssertEqual(urgentStream.phase, .connecting,
@@ -235,7 +231,7 @@ final class PostGenerationQueueTests: XCTestCase {
         for try await event in urgentStream.events {
             if case .token(let text) = event { executionOrder.append(text) }
         }
-        service.generationDidFinish()
+
 
         // Drain bg1.
         XCTAssertEqual(bg1Stream.phase, .connecting)
@@ -244,7 +240,7 @@ final class PostGenerationQueueTests: XCTestCase {
         for try await event in bg1Stream.events {
             if case .token(let text) = event { executionOrder.append(text) }
         }
-        service.generationDidFinish()
+
 
         // Drain bg2.
         XCTAssertEqual(bg2Stream.phase, .connecting)
@@ -253,7 +249,7 @@ final class PostGenerationQueueTests: XCTestCase {
         for try await event in bg2Stream.events {
             if case .token(let text) = event { executionOrder.append(text) }
         }
-        service.generationDidFinish()
+
 
         // Drain bg3.
         XCTAssertEqual(bg3Stream.phase, .connecting)
@@ -262,7 +258,7 @@ final class PostGenerationQueueTests: XCTestCase {
         for try await event in bg3Stream.events {
             if case .token(let text) = event { executionOrder.append(text) }
         }
-        service.generationDidFinish()
+
 
         XCTAssertEqual(executionOrder, ["urgent-tok", "bg1-tok", "bg2-tok", "bg3-tok"],
                        "Execution order should be: urgent first, then background in FIFO")


### PR DESCRIPTION
## Summary

Removes the five pre-1.0 deprecated symbols from the v1.0 cut list in #759. Each has been deprecated for at least one minor release with a documented migration path; carrying them past 1.0 just pins the public surface for no payoff.

### Removed symbols

- **`InferenceService.generationDidFinish()`** — no-op since v0.11.6 (queue auto-drains on stream terminate). Tests asserting the no-op are deleted; call sites in queue tests now rely on auto-drain.
- **`GenerationConfig.init(... maxTokens: Int32 ...)`** — the Int32-positional overload superseded by the primary init with `maxOutputTokens`. No production call sites in the tree; only legacy doc references.
- **`GenerationConfig.maxTokens`** (Int32 computed property), its backing `_legacyMaxTokens` storage, the `maxTokens` `CodingKey`, and the encode/decode branches. **Wire-format break**: persisted `GenerationConfig` JSON with a top-level `"maxTokens"` key silently drops that value on decode. Intentional for v1.0 — `maxOutputTokens` has been the canonical knob since v0.7.x and old payloads predate any current consumer.
- **`ToolResult.init(callId:content:isError:)`** — superseded by `init(callId:content:errorKind:)`. Migration: `isError: true` → `errorKind: .permanent`; `isError: false` → `errorKind: nil` (the default).
- **`ThinkingBlockFilter` typealias** — renamed to `ThinkingParser`. Only three references (the typealias declaration plus two doc-string mentions, none in production code). Test file `ThinkingBlockFilterTests.swift` renamed to `ThinkingParserTests.swift`.

### Wire-format break (call-out)

`GenerationConfig` Codable no longer reads or writes the `"maxTokens"` key. Anyone with persisted `GenerationConfig` JSON from a pre-v0.7 build will lose that field silently. The replacement `"maxOutputTokens"` key has been written by every encoder since #747, so the practical blast radius is near zero — but it is a documented wire-format change.

### Out of scope

- `OllamaBackend` deprecation messages (tied to #714, explicitly excluded by #759).
- Other `@available(*, deprecated)` symbols not in the v1.0 cut list (MCP OAuth, ConversationRuntime legacy paths, etc.).
- The `InferenceService.loadModel(from:)` single-arg overload mentioned in #759 — **it does not exist in the current codebase**. That entry in #759 is stale and should be removed from the issue body.

Refs #759

## Test plan

- [x] `scripts/test.sh` with the pre-push 11-suite XCTest filter set, `--disable-default-traits --skip-update` — 3382 passed / 17 skipped / 0 failed
- [x] `scripts/test.sh --filter ManifoldInferenceSwiftTestingTests --disable-default-traits --skip-update` — 83 passed
- [x] `swift build --disable-default-traits` — clean
- [x] `swift build --build-tests --disable-default-traits` — clean (one set of pre-existing deprecation warnings for an unrelated `enqueue` overload)

The all-traits-on trait-combo sweep hit two pre-existing compile errors in trait-gated E2E test files (`VisionE2ETests` referencing internal `MLXModelProbe`, and a Swift compiler "failed to produce diagnostic" in `QualityBaselineTests`). Both predate this branch — see #1352 and #1162.