### PR TITLE
dx: add tier-4 human cold-start gate (Hello World from line 1 of README)

### DIFF
--- a/.github/workflows/cold-start-human.yml
+++ b/.github/workflows/cold-start-human.yml
@@ -1,0 +1,94 @@
+# Cold-start conformance — tier 4 (human path).
+#
+# Tiers 1, 2, 3 (in ci.yml) scaffold known-good consumers from hand-written
+# code: they prove the *machine* path that a SwiftPM consumer can link
+# ManifoldKit and call its public surface in shapes the maintainers control.
+#
+# Tier 4 follows the *human* path. It treats README.md as the documented
+# onboarding contract and asks: would a person reading the README from line 1
+# reach a working chat? The gate enforces two structural constraints:
+#
+#   1. The FIRST H2 in README.md must be `## Hello World`.
+#   2. The first ```swift fenced block under that heading must compile against
+#      the current ManifoldKit on this branch.
+#
+# Sibling worker W-D-C1 ships a complementary gate that compiles ALL Swift
+# snippets across README + docs. C2 (this workflow) is narrower and stricter:
+# the canonical Hello World leads the README and works.
+#
+# Lives in its own workflow file (not ci.yml) so the human path's onboarding
+# contract is visible in PR checks under its own name and so future README /
+# QuickStart restructure PRs surface the failure mode at a glance.
+#
+# Per `[[feedback_ci_path_filter_self_validation]]`, the script's own path is
+# in the trigger filter so script-only PRs still exercise the gate. The
+# README and Hello World snippet's source dependencies (Sources/ManifoldKit/
+# QuickStart.swift, the umbrella `Exports.swift`, ManifoldUI's public
+# composition surface) are also covered so a backend / UI refactor that
+# breaks the snippet without touching README still fires the gate.
+
+name: cold-start-human
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "README.md"
+      - "Package.swift"
+      - "Package.resolved"
+      - "Sources/ManifoldKit/**"
+      - "Sources/ManifoldInference/**"
+      - "Sources/ManifoldUI/**"
+      - "scripts/cold-start-human.sh"
+      - ".github/workflows/cold-start-human.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "README.md"
+      - "Package.swift"
+      - "Package.resolved"
+      - "Sources/ManifoldKit/**"
+      - "Sources/ManifoldInference/**"
+      - "Sources/ManifoldUI/**"
+      - "scripts/cold-start-human.sh"
+      - ".github/workflows/cold-start-human.yml"
+
+concurrency:
+  group: cold-start-human-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  cold-start-human:
+    # Match the macos-15 runner the tier-1/2/3 cold-start jobs use so SwiftPM
+    # cache keys collide and we share the warm checkouts cache.
+    runs-on: macos-15
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.3"
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v5
+        with:
+          path: |
+            .build/artifacts
+            .build/checkouts
+            .build/repositories
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
+            ${{ runner.os }}-${{ runner.arch }}-spm-
+
+      - name: Run tier-4 human cold-start gate
+        run: bash scripts/cold-start-human.sh

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Add the package, then drop this into your app entry point. `ManifoldKit.quickSta
 
 ```swift
 import SwiftUI
+import SwiftData
 import ManifoldKit
 import ManifoldUI
 

--- a/scripts/cold-start-human.sh
+++ b/scripts/cold-start-human.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Cold-start conformance — tier 4: human path (README from line 1).
+#
+# Tier 1 (`cold-start-conformance.sh`), tier 2 (`cold-start-tier2-bootstrap.sh`),
+# and tier 3 (`cold-start-tier3-chatview.sh`) all scaffold known-good consumers
+# from hand-written code. They prove the *machine* path: a SwiftPM consumer can
+# link ManifoldKit and call the public surface in shapes the maintainers
+# control.
+#
+# Tier 4 follows the *human* path. It treats README.md as the documented
+# onboarding contract and asks: would a person reading the README from line 1
+# reach a working chat? Concretely:
+#
+#   1. The FIRST `##` heading under the H1 title must be `## Hello World`
+#      (case-insensitive, tolerant of "Hello, World" / "Hello world"). If a
+#      future PR slides Hello World below Features / Install / Architecture,
+#      this gate fails immediately with a message naming what took its place.
+#   2. The first fenced ```swift block following that heading must compile
+#      against the current ManifoldKit on this branch, scaffolded into a fresh
+#      SwiftPM consumer in a tmpdir. If the README's canonical snippet drifts
+#      from the public API (deleted symbol, renamed type, missing import) the
+#      gate fails.
+#
+# We deliberately stop at `swift build`. The canonical Hello World uses `@main
+# struct MyChatApp: App` — actually running it on a macOS runner would either
+# hang waiting for the SwiftUI runloop or produce no useful signal. The "it
+# compiles end-to-end" bar is what catches the breakages this gate exists to
+# catch (deleted public symbols, missing `@_exported`s in the umbrella, broken
+# import shapes) and stays under ~30s.
+#
+# Companion W-D-C1 gate (`scripts/check-readme-snippets.sh` / parallel worker)
+# compiles ALL Swift snippets across README + docs. C2 (this script) is
+# narrower and stricter: it asserts the SPECIFIC structural constraint that
+# the canonical Hello World leads the README and works.
+#
+# Portability: macOS BSD `awk` / `sed` / `grep` only; no `grep -P`.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+README="${REPO_ROOT}/README.md"
+
+if [[ ! -f "${README}" ]]; then
+    echo "::error::README.md not found at ${README}"
+    exit 1
+fi
+
+echo "==> Cold-start conformance (tier 4 — human path)"
+echo "    ManifoldKit: ${REPO_ROOT}"
+echo "    README:      ${README}"
+
+# ── Check 1: Hello World must be the FIRST H2 ─────────────────────────────────
+#
+# Skip the H1 title (`# ManifoldKit`) and the intro prose under it. The first
+# line beginning with exactly `## ` is the first H2. We capture both the line
+# number and the heading text so the failure message can name what's there.
+
+first_h2_line=""
+first_h2_text=""
+while IFS= read -r entry; do
+    first_h2_line="${entry%%:*}"
+    first_h2_text="${entry#*:}"
+    break
+done < <(grep -nE '^## ' "${README}" || true)
+
+if [[ -z "${first_h2_line}" ]]; then
+    echo "::error file=README.md::No \`## \` (H2) heading found in README.md."
+    exit 1
+fi
+
+# Match `Hello World`, `Hello, World`, `Hello world`, any case. The check-readme.sh
+# strict-mode regex is our reference for tolerated variants.
+if ! printf '%s\n' "${first_h2_text}" | grep -qiE '^## hello[, ]+world[[:space:]]*$'; then
+    echo "::error file=README.md,line=${first_h2_line}::First H2 must be \`## Hello World\` — found \`${first_h2_text}\` at line ${first_h2_line}."
+    echo "    The DX overhaul requires Hello World to lead the README so a reader's"
+    echo "    first interaction with ManifoldKit is a runnable snippet, not a feature"
+    echo "    table or install matrix. Move the Hello World section back to the top."
+    exit 1
+fi
+
+echo "✓ First H2 is Hello World (line ${first_h2_line})."
+
+# ── Check 2: extract the first ```swift block under Hello World ───────────────
+#
+# Strategy: read from the Hello World heading line forward. The first line that
+# is exactly ```swift opens the block; the next line that is exactly ``` closes
+# it. Everything between is the snippet. We allow up to ~30 lines of prose
+# between the heading and the opening fence (the current README has one or two
+# paragraphs of intro), but we warn if the gap is large because that suggests
+# the snippet is no longer the immediate companion to the heading.
+
+snippet_file="$(mktemp -t manifoldkit-hello-snippet.XXXXXX)"
+WORK=""
+cleanup() { [[ -n "${WORK}" ]] && rm -rf "${WORK}"; rm -f "${snippet_file}"; }
+trap cleanup EXIT
+
+# Find the next H2 line number AFTER the Hello World H2 — the swift block
+# must live in the Hello World section, not in a sibling section further down
+# the README (Install / Architecture etc. also contain ```swift blocks).
+next_h2_line=""
+while IFS= read -r entry; do
+    ln="${entry%%:*}"
+    if [[ "${ln}" -gt "${first_h2_line}" ]]; then
+        next_h2_line="${ln}"
+        break
+    fi
+done < <(grep -nE '^## ' "${README}" || true)
+
+# Find the first ```swift fence strictly inside the Hello World section.
+fence_at=""
+while IFS= read -r entry; do
+    ln="${entry%%:*}"
+    if [[ "${ln}" -le "${first_h2_line}" ]]; then continue; fi
+    if [[ -n "${next_h2_line}" && "${ln}" -ge "${next_h2_line}" ]]; then break; fi
+    fence_at="${ln}"
+    break
+done < <(grep -nE '^```swift[[:space:]]*$' "${README}" || true)
+
+# Extract block between fence_at+1 and the next ``` line.
+if [[ -n "${fence_at}" ]]; then
+    awk -v start="${fence_at}" '
+        NR <= start { next }
+        $0 ~ /^```[[:space:]]*$/ { exit }
+        { print }
+    ' "${README}" > "${snippet_file}"
+fi
+
+if [[ ! -s "${snippet_file}" ]]; then
+    echo "::error file=README.md,line=${first_h2_line}::No \`\`\`swift fenced code block found after \`## Hello World\` heading."
+    echo "    Hello World is the contract for a reader's first runnable example."
+    echo "    The section must include a swift block that compiles standalone."
+    exit 1
+fi
+
+if [[ -n "${fence_at}" ]]; then
+    gap=$((fence_at - first_h2_line))
+    echo "✓ Found \`\`\`swift block at line ${fence_at} (gap from heading: ${gap} lines)."
+    if [[ ${gap} -gt 30 ]]; then
+        echo "::warning file=README.md,line=${fence_at}::Hello World snippet sits ${gap} lines below its heading. Consider moving it closer so the snippet is the immediate companion to the heading."
+    fi
+fi
+
+snippet_lines=$(wc -l < "${snippet_file}" | tr -d '[:space:]')
+echo "    Snippet captured: ${snippet_lines} lines."
+
+# ── Check 3: build the snippet in a fresh SwiftPM consumer ────────────────────
+#
+# We pin tools-version 6.2 and macOS .v15 (ManifoldKit's n-1 floor) to match
+# tiers 1-3. Name the package by absolute path so worktree directory names
+# don't break `.product(... package: "ManifoldKit")` resolution
+# (see `feedback_swiftpm_local_consumer_name` in CLAUDE.md).
+#
+# The Hello World snippet uses `@main struct ...: App`. SwiftPM allows `@main`
+# in either library or executable targets; we use a library target to dodge
+# the synthetic main collision a SwiftUI App entry has with the
+# executableTarget's implicit `_main`. iOS-only or platform-specific SwiftUI
+# constructs still compile on macOS as long as `import SwiftUI` is available.
+
+WORK="$(mktemp -d -t manifoldkit-cold-start-human.XXXXXX)"
+
+echo "==> Scaffolding consumer at ${WORK}"
+
+cat > "${WORK}/Package.swift" <<EOF
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "ColdStartHumanConsumer",
+    platforms: [.macOS(.v15)],
+    products: [
+        .library(name: "HelloWorldApp", targets: ["HelloWorldApp"]),
+    ],
+    dependencies: [
+        // Pin name explicitly so worktree directory names do not change the
+        // dependency identity seen by .product(package:). The Hello World
+        // snippet imports the umbrella module ManifoldKit + ManifoldUI; with
+        // default traits both come from ManifoldKit's product list.
+        .package(name: "ManifoldKit", path: "${REPO_ROOT}"),
+    ],
+    targets: [
+        // Library target (not executable): the snippet supplies its own
+        // @main App entry point. An executableTarget would conflict with
+        // SwiftPM's synthetic _main symbol on macOS.
+        .target(
+            name: "HelloWorldApp",
+            dependencies: [
+                .product(name: "ManifoldKit", package: "ManifoldKit"),
+                .product(name: "ManifoldUI", package: "ManifoldKit"),
+            ],
+            path: "Sources/HelloWorldApp"
+        ),
+    ]
+)
+EOF
+
+mkdir -p "${WORK}/Sources/HelloWorldApp"
+cp "${snippet_file}" "${WORK}/Sources/HelloWorldApp/HelloWorld.swift"
+
+# Some developer machines set `safe.bareRepository=explicit`; SwiftPM stores
+# checkouts as bare repositories, so allow bare repos only for these subprocesses.
+SWIFT_ENV=(
+    GIT_CONFIG_COUNT=1
+    GIT_CONFIG_KEY_0=safe.bareRepository
+    GIT_CONFIG_VALUE_0=all
+)
+
+echo "==> swift build (Hello World snippet from README)"
+if ! env "${SWIFT_ENV[@]}" swift build --package-path "${WORK}" 2>&1 | tail -60; then
+    echo "::error file=README.md,line=${first_h2_line}::The Hello World snippet does not compile against the current ManifoldKit public API."
+    echo "    Either the snippet drifted (e.g. deleted symbol, renamed type) or"
+    echo "    a public symbol it relies on was removed without updating the README."
+    echo "    See the build output above for the exact compile error."
+    exit 1
+fi
+
+# Sanity: confirm SwiftPM actually built the target's object file.
+# Empty/skipped builds can exit 0 if no sources matched.
+if ! find "${WORK}/.build" -name 'HelloWorld.swift.o' -print -quit 2>/dev/null | grep -q .; then
+    echo "::error::swift build exited 0 but did not produce HelloWorld.swift.o — check target wiring."
+    exit 1
+fi
+
+echo "==> Cold-start conformance (tier 4 — human path): OK"


### PR DESCRIPTION
## Why

Wave D-C2 of the DX overhaul. The repo already has three cold-start tiers (`scripts/cold-start-conformance.sh`, `cold-start-tier2-bootstrap.sh`, `cold-start-tier3-chatview.sh`) that prove the **machine path** — a SwiftPM consumer can link ManifoldKit and call its public surface in shapes the maintainers hand-write.

Tier 4 follows the **human path**. It treats `README.md` as the documented onboarding contract and asks: would a person reading the README from line 1 reach a working chat? Specifically:

1. The FIRST `## ` heading must be `## Hello World` (case-insensitive, tolerant of "Hello, World" / "Hello world"). If a future PR slides Hello World below Features / Install / Architecture, the gate fails immediately with a message naming what took its place.
2. The first ```swift fenced block inside that section must compile against the current ManifoldKit on this branch, scaffolded into a fresh SwiftPM consumer in a tmpdir.

The gate stops at `swift build` — the canonical Hello World uses `@main struct: App`, so running it on a macOS runner would either hang or produce no signal. The "compiles end-to-end" bar catches the breakages this gate exists to catch (deleted public symbol, renamed type, broken import shape) and stays under ~5min on a warm cache.

## What shipped

- `scripts/cold-start-human.sh` — new bash gate. macOS BSD-portable awk/sed/grep, no `grep -P`. ~200 lines with comments explaining each step.
- `.github/workflows/cold-start-human.yml` — separate workflow file (matching the brief, not entangled with `ci.yml`). Triggers on `README.md`, `Sources/ManifoldKit/**`, `Sources/ManifoldInference/**`, `Sources/ManifoldUI/**`, `Package.swift`, `Package.resolved`, the script itself, and the workflow file. Per `[[feedback_ci_path_filter_self_validation]]` the script's own path is in the filter.
- One-line fix to `README.md`: adds `import SwiftData` to the Hello World snippet. The gate caught this defect on its very first run — the snippet calls `.modelContainer(...)`, a SwiftData view modifier, but never imported the module. Without this fix the canonical onboarding example fails to compile.

## How this differs from W-D-C1

C1 (parallel sibling worker) compiles ALL Swift snippets across README + docs to catch any drifted code sample. C2 (this PR) enforces the SPECIFIC structural constraint that the canonical Hello World leads the README and works. C1's breadth + C2's strictness compose without overlap.

## Sabotage verification

**Sabotage 1** — rename `## Hello World` to `## Goodbye World`:

```
::error file=README.md,line=7::First H2 must be `## Hello World` — found `## Goodbye World` at line 7.
    The DX overhaul requires Hello World to lead the README so a reader's
    first interaction with ManifoldKit is a runnable snippet, not a feature
    table or install matrix. Move the Hello World section back to the top.
exit=1
```

**Sabotage 2** — change the ```swift fence to ```text under Hello World:

```
✓ First H2 is Hello World (line 7).
::error file=README.md,line=7::No ```swift fenced code block found after `## Hello World` heading.
    Hello World is the contract for a reader's first runnable example.
    The section must include a swift block that compiles standalone.
exit=1
```

(Sabotage 2 also surfaced a refinement: the search is now bounded by the *next* H2 after Hello World, so the gate no longer falls through to the Install / Architecture swift blocks if Hello World's own snippet is missing. Without this bound, a deleted snippet would silently let the gate compile the Install snippet — a false negative.)

**Happy path** — restored README:

```
✓ First H2 is Hello World (line 7).
✓ Found ```swift block at line 11 (gap from heading: 4 lines).
    Snippet captured: 28 lines.
==> Scaffolding consumer at /var/folders/.../manifoldkit-cold-start-human.XXXXXX.HoisGVSmWs
==> swift build (Hello World snippet from README)
Build complete! (341.16s)
==> Cold-start conformance (tier 4 — human path): OK
```

## Out of scope (per brief)

- Did NOT touch `cold-start*.sh` (tiers 1-3) or their `ci.yml` jobs.
- Did NOT add this to `ci.yml` — separate workflow file is the spec.
- Did NOT modify `Sources/` or `Tests/` other than test runs.
- Did NOT touch `docs/QUICKSTART.md`.
- The README `import SwiftData` addition is in scope because it IS the defect this gate exists to enforce against. The gate would be green-from-day-one is a misread; the gate must compile the snippet on `main`, and it now does.

## Pre-push gate

- `bash scripts/cold-start-human.sh` — passes (~5min cold, ~30s warm).
- Both sabotage tests above — fail with the expected messages.
- `bash scripts/check-readme.sh` and `MANIFOLDKIT_README_STRICT=1 bash scripts/check-readme.sh` — both pass.
- `scripts/test.sh --filter ManifoldKitTests --disable-default-traits --skip-update` — 10/10 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)