### PR TITLE
dx: add README/QUICKSTART Swift-snippet compilation gate

### DIFF
--- a/.github/workflows/readme-snippets.yml
+++ b/.github/workflows/readme-snippets.yml
@@ -1,0 +1,94 @@
+name: README Snippets
+
+# Compiles every `swift`-fenced code block in README.md and docs/QUICKSTART.md
+# against the current ManifoldKit package. Catches snippet drift the moment a
+# `feat:` PR renames a public type or removes an initializer that the docs
+# still copy-paste.
+#
+# Wave D-C1 of the DX overhaul. See:
+#   - scripts/extract-snippets.sh        (block extraction + skip policy)
+#   - scripts/extract-snippets-test.sh   (per-snippet swift build scaffold)
+#
+# Discrete workflow (not folded into ci.yml) because the failure mode is
+# orthogonal: README copy-paste correctness has nothing to do with the
+# library's own test suites. Failures on this workflow point the author at
+# the README/QUICKSTART block to fix, not at a Sources/ test target.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      # Any of these can invalidate a snippet:
+      #   - The docs themselves (a new fence may need a no-build tag).
+      #   - The umbrella module's public surface.
+      #   - The Hello World's transitive surface (QuickStart, ManifoldUI types).
+      #   - The scripts the gate runs.
+      - "README.md"
+      - "docs/QUICKSTART.md"
+      - "Sources/ManifoldKit/**"
+      - "Sources/ManifoldUI/**"
+      - "Sources/ManifoldInference/QuickStart*.swift"
+      - "Sources/ManifoldInference/ManifoldKitError.swift"
+      - "Package.swift"
+      - "Package.resolved"
+      - "scripts/extract-snippets.sh"
+      - "scripts/extract-snippets-test.sh"
+      - ".github/workflows/readme-snippets.yml"
+  push:
+    branches: [main]
+    paths:
+      - "README.md"
+      - "docs/QUICKSTART.md"
+      - "Sources/ManifoldKit/**"
+      - "Sources/ManifoldUI/**"
+      - "Sources/ManifoldInference/QuickStart*.swift"
+      - "Sources/ManifoldInference/ManifoldKitError.swift"
+      - "Package.swift"
+      - "Package.resolved"
+      - "scripts/extract-snippets.sh"
+      - "scripts/extract-snippets-test.sh"
+      - ".github/workflows/readme-snippets.yml"
+
+concurrency:
+  group: readme-snippets-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  readme-snippets:
+    runs-on: macos-15  # matches ci.yml — Apple Silicon arm64 standard runner
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          # Same pin as ci.yml — single source of toolchain truth.
+          xcode-version: "26.3"
+
+      - name: Cache SwiftPM dependencies
+        # Each per-snippet throwaway package re-resolves the same dependency
+        # set, so caching .build/checkouts + .build/repositories pays for
+        # itself even though the snippet-package's own .build is ephemeral.
+        # We key on Package.resolved exactly like ci.yml.
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            .build/artifacts
+            .build/checkouts
+            .build/repositories
+          key: ${{ runner.os }}-snippets-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-snippets-spm-
+
+      - name: README structure pre-flight
+        # Cheap tripwire — fails fast if the Hello World fence vanished.
+        run: scripts/check-readme.sh
+
+      - name: Compile README + QUICKSTART Swift snippets
+        run: scripts/extract-snippets-test.sh

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Add the package, then drop this into your app entry point. `ManifoldKit.quickSta
 
 ```swift
 import SwiftUI
+import SwiftData
 import ManifoldKit
 import ManifoldUI
 
@@ -159,7 +160,7 @@ For the full surface (protocols, services, views), browse `Sources/` or read the
 
 Register tools with `ToolRegistry` and pass `toolRegistry.definitions` as `GenerationConfig.tools`:
 
-```swift
+```swift,no-build
 let registry = ToolRegistry()
 registry.register(MyWeatherTool())
 
@@ -173,7 +174,7 @@ let (_, stream) = try inferenceService.enqueue(
 
 ## MCP
 
-```swift
+```swift,no-build
 import ManifoldInference
 import ManifoldMCP
 
@@ -188,7 +189,7 @@ For a complete walkthrough (descriptor setup, lifecycle, and built-in catalog), 
 
 Implement `InferenceBackend` and register it. The protocol takes a precomputed `ModelLoadPlan` so the caller's memory-admission verdict and effective context size flow through to the backend instead of being recomputed:
 
-```swift
+```swift,no-build
 class MyBackend: InferenceBackend, @unchecked Sendable {
     var isModelLoaded = false
     var isGenerating = false
@@ -215,7 +216,7 @@ inferenceService.registerBackendFactory { modelType in
 
 Cloud endpoints flow through storage-neutral `APIEndpointRecord` values. `APIConfigurationView` persists records through the runtime's `EndpointStore`:
 
-```swift
+```swift,no-build
 let endpoint = APIEndpointRecord(
     name: "My OpenAI",
     provider: .openAI,

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -35,6 +35,7 @@ The umbrella re-exports `ManifoldRuntime`, `ManifoldPersistenceSwiftData`, `Mani
 
 ```swift
 import SwiftUI
+import SwiftData
 import ManifoldKit
 import ManifoldUI
 
@@ -99,7 +100,7 @@ See [`docs/FeatureMatrix.md`](FeatureMatrix.md) for the full trait → capabilit
 
 If you don't want `ChatView` and prefer your own SwiftUI surface, skip `quickStart()` and depend on just `ManifoldInference` plus the backends you want. Construct an `InferenceService` directly, register the compiled backends, and stream `GenerationEvent.token` into your transcript:
 
-```swift
+```swift,no-build
 import ManifoldInference
 import ManifoldBackends
 
@@ -120,7 +121,7 @@ This keeps SwiftData, `ManifoldRuntime`, and `ManifoldUI` out of your app graph 
 
 `ManifoldKit.quickStart(configuration:)` accepts a `ManifoldConfiguration`. Override the bundle identifier so two ManifoldKit-based apps on the same machine don't collide on the shared SwiftData store path:
 
-```swift
+```swift,no-build
 result = try await ManifoldKit.quickStart(
     configuration: ManifoldConfiguration(
         appName: "My Chat App",
@@ -135,7 +136,7 @@ If you need a custom `ModelContainer` (e.g. for testing, or to attach a second s
 
 Every public throws from the bootstrap path normalises to [`ManifoldKitError`](../Sources/ManifoldInference/ManifoldKitError.swift). Catch it once at the call site and read `errorDescription` for a user-facing string:
 
-```swift
+```swift,no-build
 do {
     result = try await ManifoldKit.quickStart()
 } catch let e as ManifoldKitError {

--- a/scripts/check-readme.sh
+++ b/scripts/check-readme.sh
@@ -48,6 +48,16 @@
 # Usage:
 #   bash scripts/check-readme.sh                          # default (loose) — baseline checks only
 #   MANIFOLDKIT_README_STRICT=1 bash scripts/check-readme.sh   # also enforce structure anchors
+#
+# ── Snippet pre-flight (always on, cheap) ─────────────────────────────────
+#
+# In addition to the API-name lint above, we sanity-check that README.md
+# still contains at least one ```swift fenced block. A future PR that
+# accidentally strips the Hello World (e.g. a bad merge resolution) would
+# satisfy every other check; this is the cheapest possible tripwire for
+# "the canonical snippet vanished". The full compile gate lives in the
+# `.github/workflows/readme-snippets.yml` workflow and invokes
+# `scripts/extract-snippets-test.sh`.
 
 set -euo pipefail
 
@@ -174,6 +184,22 @@ if [[ ${bad_apis} -gt 0 ]]; then
     echo "Found ${bad_apis} reference(s) to deleted public API."
 else
     echo "✓ README contains no references to known-deleted public API."
+fi
+
+# ── Check 3: README contains at least one Swift snippet ──────────────────
+#
+# Cheap structural tripwire — the full compile gate runs in CI via
+# scripts/extract-snippets-test.sh. We just need to fail loudly if the
+# Hello World fence ever disappears.
+echo
+echo "── Check: README contains at least one \`\`\`swift block ──────────────"
+
+# Match opening fence ```swift (case-insensitive), tolerate trailing tags.
+if grep -niE '^```swift([,[:space:]]|$)' "${README_PATH}" > /dev/null 2>&1; then
+    echo "✓ README has at least one Swift fenced block."
+else
+    echo "::error file=README.md::No \`\`\`swift fenced block found. The Hello World snippet must remain in README.md."
+    failures=$((failures + 1))
 fi
 
 # ── Strict-mode checks (opt-in) ────────────────────────────────────────────

--- a/scripts/extract-snippets-test.sh
+++ b/scripts/extract-snippets-test.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# extract-snippets-test.sh — Compile every kept Swift snippet from README.md
+# and docs/QUICKSTART.md against the current ManifoldKit package.
+#
+# Companion to scripts/extract-snippets.sh. The extract script writes one
+# .swift per kept snippet into a working directory; this script scaffolds a
+# throwaway SwiftPM consumer per snippet, drops the snippet in, and runs
+# `swift build`. Failures print the source location (file:line) the snippet
+# was lifted from so the docs author can fix the original block.
+#
+# Why one package per snippet:
+#   - Snippets are independent SwiftUI apps (Hello World variants have `@main`
+#     on `App` types) and cannot coexist in one executable target.
+#   - Per-snippet isolation also lets the next snippet still build when an
+#     earlier one fails, so the report is complete instead of stopping at
+#     the first error.
+#
+# Each per-snippet package:
+#   - tools-version 6.2 (matches cold-start-conformance.sh)
+#   - platforms macOS .v15 (ManifoldKit's floor)
+#   - depends on the local ManifoldKit checkout via .package(name: ..., path: ...)
+#   - links the ManifoldKit umbrella product (covers ManifoldUI / Inference re-exports)
+#
+# Exit codes:
+#   0 — every snippet compiled.
+#   1 — at least one snippet failed; full per-snippet log dumped at the end.
+#   2 — extract step reported zero snippets (propagated from extract-snippets.sh).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="$(mktemp -d -t manifoldkit-snippet-build.XXXXXX)"
+SNIPPETS_DIR="$WORK/snippets"
+mkdir -p "$SNIPPETS_DIR"
+
+# Keep work dir for inspection on CI failure if SNIPPET_KEEP_WORK=1 is set.
+if [[ "${SNIPPET_KEEP_WORK:-0}" != "1" ]]; then
+    trap 'rm -rf "$WORK"' EXIT
+else
+    echo "SNIPPET_KEEP_WORK=1: work dir preserved at $WORK"
+fi
+
+echo "==> README/QUICKSTART snippet compile gate"
+echo "    ManifoldKit: $REPO_ROOT"
+echo "    work:        $WORK"
+
+# 1. Extract.
+bash "$SCRIPT_DIR/extract-snippets.sh" --out "$SNIPPETS_DIR"
+
+# 2. Build each.
+shopt -s nullglob
+snippets=("$SNIPPETS_DIR"/*.swift)
+shopt -u nullglob
+
+if [[ ${#snippets[@]} -eq 0 ]]; then
+    echo "::error::extract-snippets.sh wrote zero .swift files (only .skip)." >&2
+    exit 2
+fi
+
+passed=0
+failed=0
+fail_reports=()
+
+for snippet in "${snippets[@]}"; do
+    base="$(basename "$snippet" .swift)"
+    # Read source-location header for failure reports.
+    src_header=$(head -n 1 "$snippet")
+    src_location="${src_header#// Source: }"
+
+    pkg_dir="$WORK/$base"
+    mkdir -p "$pkg_dir/Sources/SnippetApp"
+
+    # SwiftPM derives package identity from the last path component of
+    # .package(path:); explicit name: keeps this worktree-portable.
+    cat > "$pkg_dir/Package.swift" <<EOF
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "Snippet_${base//-/_}",
+    platforms: [.macOS(.v15), .iOS(.v18)],
+    products: [
+        .executable(name: "SnippetApp", targets: ["SnippetApp"]),
+    ],
+    dependencies: [
+        .package(name: "ManifoldKit", path: "$REPO_ROOT"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "SnippetApp",
+            dependencies: [
+                .product(name: "ManifoldKit", package: "ManifoldKit"),
+                // ManifoldUI is re-exported by the umbrella, but the README
+                // Hello World imports it explicitly. Link it as a direct
+                // product too so the import resolves under both umbrella
+                // and direct-import patterns.
+                .product(name: "ManifoldUI", package: "ManifoldKit"),
+            ],
+            path: "Sources/SnippetApp"
+        ),
+    ]
+)
+EOF
+
+    # Drop the snippet in. If it lacks `import Foundation` but uses Foundation
+    # types, the build will catch it — we deliberately do NOT inject imports
+    # because the test is "does the published snippet compile as-published?".
+    cp "$snippet" "$pkg_dir/Sources/SnippetApp/Snippet.swift"
+
+    echo
+    echo "── ${base}  (from ${src_location})"
+
+    log="$pkg_dir/build.log"
+    if (cd "$pkg_dir" && swift build) > "$log" 2>&1; then
+        echo "   PASS"
+        passed=$((passed + 1))
+    else
+        echo "   FAIL — log:"
+        sed -n '1,80p' "$log" | sed 's/^/     /'
+        echo "   (full log: $log)"
+        failed=$((failed + 1))
+        fail_reports+=("$base  from  $src_location")
+    fi
+done
+
+echo
+echo "==================================================================="
+echo "Snippet compile summary: ${passed} passed, ${failed} failed."
+echo "==================================================================="
+
+if [[ $failed -gt 0 ]]; then
+    echo
+    echo "Failing snippets:"
+    for report in "${fail_reports[@]}"; do
+        echo "  - $report"
+    done
+    echo
+    echo "To investigate: rerun with SNIPPET_KEEP_WORK=1 to preserve $WORK."
+    exit 1
+fi
+
+exit 0

--- a/scripts/extract-snippets.sh
+++ b/scripts/extract-snippets.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# extract-snippets.sh — Extract fenced Swift code blocks from README.md and
+# docs/QUICKSTART.md into standalone .swift files for downstream compilation.
+#
+# Wave D-C1 of the DX overhaul: the README's Hello World snippet is the
+# single most important piece of copy-paste correctness in the repo. This
+# script (plus its companion compile gate) makes "a future PR silently
+# breaks the snippet" a CI failure rather than a Slack apology.
+#
+# What it does:
+#   - Walks README.md and docs/QUICKSTART.md.
+#   - Pulls out every fenced block tagged ```swift (case-insensitive).
+#   - Numbers them per-file (readme-001.swift, quickstart-001.swift, ...).
+#   - Writes each to --out <dir> (default /tmp/manifoldkit-snippets) with a
+#     `// Source: <relative-path>:<line>` header so failures point back to docs.
+#
+# Skip / include policy:
+#   - Blocks fenced as ```swift,no-build (or any ```swift* containing the
+#     literal token "no-build") are recorded with a `.skip` marker file
+#     instead of a `.swift` file. Use this sparingly — placeholder snippets
+#     with `/* ... */` or undefined identifiers, Package.swift fragments that
+#     a consumer must paste into their own manifest, etc. The Hello World
+#     snippet MUST never carry no-build.
+#   - Snippets whose first non-comment line starts with `.package(` or
+#     `.target(` are heuristically classified as Package.swift fragments and
+#     auto-skipped. These cannot be compiled standalone; their lint coverage
+#     belongs to `scripts/check-readme.sh` (version-pin freshness).
+#
+# Exit codes:
+#   0 — extracted at least one Swift block across all inputs.
+#   1 — usage error or I/O failure.
+#   2 — zero Swift blocks found across all inputs (defensive — if every
+#       snippet vanished we want a loud signal, not silent success).
+#
+# Portability: BSD awk/sed/grep only (macOS default toolchain). No grep -P.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="/tmp/manifoldkit-snippets"
+VERBOSE=0
+
+usage() {
+    cat <<EOF
+Usage: $0 [--out <dir>] [--verbose]
+
+Options:
+  --out <dir>     Output directory (default: /tmp/manifoldkit-snippets).
+  --verbose       Log each extracted block to stderr.
+  -h, --help      Show this help.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --out)
+            OUT_DIR="$2"
+            shift 2
+            ;;
+        --verbose)
+            VERBOSE=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+INPUTS=(
+    "README.md"
+    "docs/QUICKSTART.md"
+)
+
+mkdir -p "$OUT_DIR"
+# Clean any prior run so a deleted snippet doesn't linger as a stale file.
+rm -f "$OUT_DIR"/readme-*.swift "$OUT_DIR"/quickstart-*.swift \
+      "$OUT_DIR"/readme-*.skip "$OUT_DIR"/quickstart-*.skip 2>/dev/null || true
+
+total=0
+total_skipped=0
+
+# extract_one <path> <slug>
+#
+# Reads $path and emits one file per fenced ```swift block into $OUT_DIR.
+# Uses awk because Markdown fence parsing is line-oriented and benefits
+# from a single pass with state. BSD awk is the floor.
+extract_one() {
+    local rel_path="$1"
+    local slug="$2"
+    local abs_path="$REPO_ROOT/$rel_path"
+
+    if [[ ! -f "$abs_path" ]]; then
+        echo "::error::Input file not found: $abs_path" >&2
+        return 1
+    fi
+
+    # awk emits per-block markers prefixed with $$$BLOCK$$$ so this shell can
+    # iterate them. We avoid temp files inside awk to keep the script
+    # self-contained.
+    local awk_out
+    awk_out=$(awk '
+        BEGIN { in_block = 0; block_num = 0; start_line = 0; tag = ""; }
+        # Detect opening fence. Case-insensitive match on "swift" after ```.
+        # Tolerates ```swift, ```swift,no-build, ```Swift, ```swift foo, etc.
+        /^```/ {
+            if (in_block == 0) {
+                # Lowercase the line for tag matching without disturbing the
+                # captured fence tag itself.
+                lower = tolower($0)
+                # Strip the leading ``` then check the language token.
+                rest = substr(lower, 4)
+                # Match "swift" at the start, optionally followed by ,/space/EOL.
+                if (rest ~ /^swift([,[:space:]]|$)/) {
+                    in_block = 1
+                    block_num += 1
+                    start_line = NR + 1
+                    tag = rest
+                    print "$$$START$$$" block_num "|" start_line "|" tag
+                    next
+                }
+            } else {
+                # Closing fence.
+                in_block = 0
+                print "$$$END$$$" block_num
+                tag = ""
+                next
+            }
+        }
+        in_block == 1 { print "$$$BODY$$$" block_num "|" $0 }
+    ' "$abs_path")
+
+    # Reconstruct blocks in shell. We iterate the awk output, buffering
+    # body lines until we hit the END marker.
+    local cur_num=""
+    local cur_start=""
+    local cur_tag=""
+    local cur_body=""
+    local first_body_line=1
+
+    while IFS= read -r line; do
+        case "$line" in
+            '$$$START$$$'*)
+                payload="${line#'$$$START$$$'}"
+                cur_num="${payload%%|*}"
+                rest="${payload#*|}"
+                cur_start="${rest%%|*}"
+                cur_tag="${rest#*|}"
+                cur_body=""
+                first_body_line=1
+                ;;
+            '$$$BODY$$$'*)
+                payload="${line#'$$$BODY$$$'}"
+                body_line="${payload#*|}"
+                if [[ $first_body_line -eq 1 ]]; then
+                    cur_body="$body_line"
+                    first_body_line=0
+                else
+                    cur_body="$cur_body"$'\n'"$body_line"
+                fi
+                ;;
+            '$$$END$$$'*)
+                # Format index as 3-digit zero-padded.
+                idx=$(printf "%03d" "$cur_num")
+                out_base="$OUT_DIR/${slug}-${idx}"
+
+                # Decide skip / keep.
+                local skip_reason=""
+                # Explicit no-build tag.
+                case "$cur_tag" in
+                    *no-build*)
+                        skip_reason="explicit-no-build-tag"
+                        ;;
+                esac
+
+                # Heuristic: Package.swift fragment.
+                if [[ -z "$skip_reason" ]]; then
+                    # First non-blank, non-comment line.
+                    first_meaningful=$(printf '%s\n' "$cur_body" \
+                        | sed -E '/^[[:space:]]*$/d; /^[[:space:]]*\/\//d' \
+                        | head -n 1)
+                    case "$first_meaningful" in
+                        .package\(* | .target\(* )
+                            skip_reason="package-manifest-fragment"
+                            ;;
+                    esac
+                fi
+
+                if [[ -n "$skip_reason" ]]; then
+                    {
+                        printf '# Source: %s:%s\n' "$rel_path" "$cur_start"
+                        printf '# Skip reason: %s\n' "$skip_reason"
+                        printf '# Fence tag: %s\n' "$cur_tag"
+                        printf -- '---\n'
+                        printf '%s\n' "$cur_body"
+                    } > "${out_base}.skip"
+                    total_skipped=$((total_skipped + 1))
+                    if [[ $VERBOSE -eq 1 ]]; then
+                        echo "skip  ${out_base}.skip  (${skip_reason})  ${rel_path}:${cur_start}" >&2
+                    fi
+                else
+                    {
+                        printf '// Source: %s:%s\n' "$rel_path" "$cur_start"
+                        printf '%s\n' "$cur_body"
+                    } > "${out_base}.swift"
+                    total=$((total + 1))
+                    if [[ $VERBOSE -eq 1 ]]; then
+                        echo "keep  ${out_base}.swift  ${rel_path}:${cur_start}" >&2
+                    fi
+                fi
+
+                cur_num=""
+                cur_start=""
+                cur_tag=""
+                cur_body=""
+                ;;
+        esac
+    done <<<"$awk_out"
+}
+
+extract_one "README.md" "readme"
+extract_one "docs/QUICKSTART.md" "quickstart"
+
+echo "Extracted ${total} Swift snippet(s) and skipped ${total_skipped} fragment(s) into ${OUT_DIR}"
+
+if [[ $total -eq 0 ]]; then
+    echo "::error::No Swift snippets extracted from README.md or docs/QUICKSTART.md." >&2
+    echo "If the docs intentionally dropped all code blocks, remove this gate." >&2
+    exit 2
+fi
+
+exit 0


### PR DESCRIPTION
## Why

Wave D-C1 of the DX overhaul. The README's Hello World snippet (and its longer twin in `docs/QUICKSTART.md`) is the single most load-bearing piece of copy-paste correctness in the repo. Until now, nothing prevented drift — a renamed API or removed initializer would silently invalidate the snippet, and the first time we'd find out is when a new adopter hit "build failed."

This PR converts editorial discipline into a CI gate.

## What shipped

- **`scripts/extract-snippets.sh`** — extracts every fenced \`\`\`swift block from `README.md` and `docs/QUICKSTART.md` into standalone `.swift` files. Auto-skips Package.swift fragments by heuristic; honors `swift,no-build` tags for prose-illustration snippets that reference undefined identifiers or contain `/* ... */` placeholders.
- **`scripts/extract-snippets-test.sh`** — per-snippet `swift build` scaffold. Spins up a throwaway SwiftPM consumer per snippet (one package per snippet because the Hello World snippets carry `@main` on an `App` type) and reports per-snippet pass/fail with the source `file:line` for each failure.
- **`.github/workflows/readme-snippets.yml`** — discrete macOS-15 workflow, paths-filtered to the docs + the umbrella's public surface + the scripts themselves. Not folded into `ci.yml`; the failure mode is orthogonal.
- **`scripts/check-readme.sh`** — adds a cheap structural tripwire: README must contain at least one \`\`\`swift fence. The full compile gate lives in the new workflow.

## Real bug the gate caught

On the first compile run, **both Hello World snippets failed** with `value of type 'some View' has no member 'modelContainer'`. They were calling `.modelContainer(...)` without `import SwiftData`. Fixed in this PR by adding the missing import to both blocks.

Seven prose-illustration snippets (`ToolRegistry` with undefined `MyWeatherTool`, `MCPClient` with undefined `descriptor`/`registry`, the `class MyBackend` example with `/* ... */` body placeholders, `APIEndpointRecord` with undefined `runtime`, the BYO-UI block, and two error-handling fragments with undefined `result`/`error`) are tagged `swift,no-build` per the brief's allowed skip policy. **The Hello World blocks themselves are not skipped** — they are the load-bearing test.

## How to break it intentionally (verify the gate works)

Rename `quickStart()` to `quickStarte()` on a local branch and push. The `readme-snippets` job will fail on both Hello World snippets with a `no member 'quickStarte'` error pointing back to `README.md:12` and `docs/QUICKSTART.md:37`.

## Out of scope

- Tier-4 human cold-start gate — W-D-C2 ships in parallel.
- README/QUICKSTART content rewrites — owned by W-C-B1a (already merged). This PR only adds the missing `import SwiftData` because the gate caught it as a genuine bug; no editorial changes.

## Test plan

- [x] `bash scripts/extract-snippets.sh --verbose` extracts 14 fenced blocks, keeps 2 (both Hello Worlds), skips 12.
- [x] `bash scripts/extract-snippets-test.sh` reports 2 passed, 0 failed against the current package.
- [x] `bash scripts/check-readme.sh` (loose) — exit 0.
- [x] `MANIFOLDKIT_README_STRICT=1 bash scripts/check-readme.sh` — exit 0.
- [x] `actionlint .github/workflows/readme-snippets.yml` — clean.
- [ ] CI: `readme-snippets` job goes green on this PR.