### PR TITLE
dx: add README pruning issue template + DX budget section + dx-debt label

### DIFF
--- a/.github/ISSUE_TEMPLATE/readme-prune.md
+++ b/.github/ISSUE_TEMPLATE/readme-prune.md
@@ -1,0 +1,29 @@
+---
+name: README pruning ritual
+about: Recurring DX audit — prune accreted README content and verify Hello World still leads
+title: 'dx: README pruning audit YYYY-Q?'
+labels: dx-debt
+assignees: []
+---
+
+READMEs accrete. New features get demo snippets, edge cases get caveats, and over a
+few cycles the "60-second adopter onboarding" promise erodes. This issue is the
+calendar reminder to reverse that drift before it compounds.
+
+## Checklist
+
+- [ ] `wc -l README.md` — note current line count vs last audit (target ≤700).
+- [ ] First H2 is still `## Hello World` (run `bash scripts/cold-start-human.sh`).
+- [ ] Hello World snippet still compiles (CI gate confirms; spot-check the README
+      block matches `Example/Examples/MinimalExample` patterns).
+- [ ] `docs/FeatureMatrix.md` reflects the current `Package.swift` traits
+      (`FeatureMatrixTests` asserts this — but eyeball the table for accuracy).
+- [ ] No new H2s in `README.md` that belong under `docs/` instead.
+- [ ] Identify at least one section to relocate to `docs/` or delete this cycle.
+
+## Context
+
+The DX overhaul (Waves 0–E) established a 60-second-onboarding goal: a new adopter
+should hit a working chat in under a minute by reading `## Hello World` and pasting
+the snippet. Every audit is a chance to verify that promise still holds and to ship
+a `dx:` PR against the [DX budget](../../CONTRIBUTING.md#dx-budget) for this cycle.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ you're making and follow the gates listed there. Cross-references point at
 - [Adding a macro](#adding-a-macro)
 - [Adding a setting / configuration flag](#adding-a-setting--configuration-flag)
 - [Commit style](#commit-style)
+- [DX budget](#dx-budget) — one `dx:` PR per minor cycle for DX debt
 - [Pull request process](#pull-request-process)
 - [PR hygiene](#pr-hygiene)
 - [Reporting bugs](#reporting-bugs)
@@ -344,6 +345,35 @@ The trimMessages fallback returned an empty array when the system prompt
 alone exceeded maxTokens. Always return at least the last user message so
 generation has something to work with.
 ```
+
+## DX budget
+
+The project allocates one `dx:`-prefixed PR per minor release cycle exclusively
+for developer-experience debt. This is calendar-driven, not opportunistic — DX
+work loses to feature work every time when it competes for the same slot, so it
+gets its own slot.
+
+What counts:
+
+- Pruning README accretion (target: ≤700 lines; current line count tracked per
+  audit).
+- Updating `docs/QUICKSTART.md` or `docs/FeatureMatrix.md` for clarity.
+- Fixing error messages users see but don't understand.
+- Smoothing rough edges in `Example/Examples/MinimalExample` or
+  `Example/Advanced/`.
+- Reviewing whether new traits or backends need matrix entries (the CI gate
+  enforces *presence*; humans judge accuracy).
+
+What doesn't count:
+
+- Adding new features and labeling them `dx:` to dodge release-note budget —
+  those are `feat:`.
+- Bug fixes — those are `fix:`.
+
+The DX budget issue is filed from the
+[README pruning ritual issue template](.github/ISSUE_TEMPLATE/readme-prune.md)
+at the start of each cycle. Maintainers can pick it up directly or label it
+`good first issue` for community contributors.
 
 ## Pull request process
 


### PR DESCRIPTION
## Why

Wave E (final) of the DX overhaul. Waves 0–D shipped **reactive** scaffolding that catches regressions; this wave closes the loop with **proactive** process so the DX surface stays healthy between feature cycles. Without an explicit budget the README will be 1020 lines again in six months.

## What shipped

1. **`.github/ISSUE_TEMPLATE/readme-prune.md`** — markdown issue template (labels: `dx-debt`) filed at the start of each minor cycle. Six-item checklist: line-count delta, `## Hello World` still leads, snippet still compiles, `FeatureMatrix` accuracy, no new top-level README H2s, at least one section to relocate per cycle.
2. **`CONTRIBUTING.md` § DX budget** — explains the one-`dx:`-PR-per-minor-cycle allocation, what counts (README pruning, docs, error-message polish, `MinimalExample` smoothing, matrix entries) and what doesn't (`feat:` in disguise, bug fixes). Linked from the TOC near Commit style.
3. **`dx-debt` GitHub label** — created via `gh label create dx-debt --description "DX overhaul follow-ups and editorial-discipline tickets" --color "0E8A16"` as part of this worker. Confirmed present via `gh label list`. The issue template's `labels: dx-debt` field now attaches automatically.

## Out of scope (deferred)

- Cron-scheduled auto-filing of the issue. Manual template is v1; a workflow that opens the issue each quarter is a future enhancement.
- No `Sources/`, `Tests/`, or `README.md` changes.

## Wave roundup — the 5-wave DX overhaul concludes here

- **Wave 0**: `ManifoldKitError` rim (#1362)
- **Wave A**: `dx:` commit type, PR template, FeatureMatrix, `check-readme.sh` strict (#1363 / #1364 / #1365 / #1366)
- **Wave B**: `ManifoldKit.quickStart()` + `MinimalExample` rewrite (#1369 / #1370)
- **Wave C**: README restructure + `Example/Advanced` rename (#1371 / #1372)
- **Wave D**: README snippet gate + tier-4 human cold-start (#1374 / #1375)
- **Wave E**: this PR

## Verification

- Rendered template — frontmatter present, six-item checkbox list, "Context" pointer to CONTRIBUTING.md § DX budget. ✓
- `grep -A 20 "DX budget" CONTRIBUTING.md` — section present, TOC entry added. ✓
- `gh label list | grep dx-debt` — label exists with green `#0E8A16` color. ✓
- `bash scripts/check-readme.sh` — passes (no README touched). ✓
- No source changes → Swift test gate not required.