### PR TITLE
fix: lock lastLoggedPct counter in DiffusionDownload progress observer

### DIFF
--- a/Sources/ManifoldHuggingFace/DiffusionDownload.swift
+++ b/Sources/ManifoldHuggingFace/DiffusionDownload.swift
@@ -712,7 +712,10 @@ public extension HuggingFaceService {
                 if let onChunk {
                     // task.progress uses a 0-100 unit scale, not bytes.
                     // Observe countOfBytesReceived directly for real byte counts.
-                    var lastLoggedPct = -10
+                    // KVO callbacks fire on URLSession's delegate queue, not the caller's
+                    // actor, so the throttling counter needs a real lock (CLAUDE.md
+                    // Swift-6 gotcha #2 — @unchecked Sendable is not a fix here).
+                    let lastLoggedPct = OSAllocatedUnfairLock<Int>(initialState: -10)
                     state.setObservation(task.observe(\.countOfBytesReceived) { [weak task] _, _ in
                         guard let task else { return }
                         let received = task.countOfBytesReceived
@@ -721,8 +724,12 @@ public extension HuggingFaceService {
                         let safeExpected: Int64 = expected > 0 ? expected : 0
                         if safeExpected > 0 {
                             let pct = Int(Double(received) / Double(safeExpected) * 100)
-                            if pct >= lastLoggedPct + 10 {
-                                lastLoggedPct = pct
+                            let shouldLog = lastLoggedPct.withLock { current -> Bool in
+                                guard pct >= current + 10 else { return false }
+                                current = pct
+                                return true
+                            }
+                            if shouldLog {
                                 Log.download.debug("\(filename, privacy: .public): \(pct)% (\(received)/\(safeExpected) bytes)")
                             }
                         }


### PR DESCRIPTION
## Why

The KVO closure observing `task.countOfBytesReceived` (line 716 of `DiffusionDownload.swift`) fires on URLSession's delegate queue, not the caller's actor. The captured `var lastLoggedPct = -10` was therefore subject to a race — Swift 6 surfaces this as `sendable-closure-captures` warnings on the read and the mutation.

The race itself pre-dates the W0 `ManifoldKitError` PR (#1362); SourceKit re-analyzed the file after W0 edited an adjacent line, which surfaced the latent warning. Deferred from the W0 review per "don't bundle surrounding cleanup" discipline; cleaning it up now.

## What

Per CLAUDE.md gotcha #2 ("`@unchecked Sendable` is not a race fix" for escaping callbacks that fire on another thread), the throttling counter is now an `OSAllocatedUnfairLock<Int>` and the read-modify-write happens atomically via `withLock`. No behavior change — the 10% throttle still emits exactly one log line per increment.

`os` is already imported in the file, so the change is +10/-3 lines.

## Test plan

- [x] `swift build --traits HuggingFace` — clean (no sendable warning at line 711/716/724/725).
- [x] `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` — exit 0.
- [ ] CI's full test job confirms no regressions in HuggingFace-adjacent paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)