### PR TITLE
fix: unblock all-traits test suite (KV cache reuse + stale paths + build errors)

### DIFF
--- a/Sources/ManifoldMLX/MLX/MLXGenerationDriver.swift
+++ b/Sources/ManifoldMLX/MLX/MLXGenerationDriver.swift
@@ -106,7 +106,10 @@ struct MLXGenerationDriver: LocalInferenceAdapter {
         autoDetectedMarkers: ThinkingMarkers?,
         kvCacheReuseEligible: Bool,
         pendingSnapshotTask: Task<Void, Never>?,
-        existingSnapshot: MLXPromptCacheCoordinator.Snapshot?,
+        // Re-reading the snapshot AFTER awaiting `pendingSnapshotTask` is load-bearing:
+        // the prior turn's snapshot task writes to backend state, and a value captured
+        // before the await is always stale on second turn. See driver lines 169-174.
+        currentSnapshot: @MainActor @Sendable () -> MLXPromptCacheCoordinator.Snapshot?,
         generationStream: GenerationStream,
         continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation,
         yieldHook: (@Sendable () async -> Void)?
@@ -168,12 +171,14 @@ struct MLXGenerationDriver: LocalInferenceAdapter {
 
         // Wait for any pending KV snapshot capture from the previous turn to
         // complete before we restore from it — otherwise we'd race
-        // `Snapshot` writes against reads.
+        // `Snapshot` writes against reads. Then re-read the snapshot from
+        // backend state: a value captured before the await is stale because
+        // the snapshot task writes there.
         if kvCacheReuseEligible, let pendingSnapshotTask {
             await pendingSnapshotTask.value
         }
         let resolvedSnapshot: MLXPromptCacheCoordinator.Snapshot? =
-            kvCacheReuseEligible ? existingSnapshot : nil
+            kvCacheReuseEligible ? currentSnapshot() : nil
 
         let prepared = try await MLXPromptCacheCoordinator.prepareInputAndCache(
             container: container,

--- a/Sources/ManifoldMLX/MLXBackend.swift
+++ b/Sources/ManifoldMLX/MLXBackend.swift
@@ -364,8 +364,7 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                 dialect: _dialect,
                 autoDetectedMarkers: _autoDetectedThinkingMarkers,
                 kvCacheReuseEligible: _kvCacheReuseEligible,
-                pendingSnapshotTask: _promptCacheState.pendingSnapshotTask,
-                existingPromptCacheSnapshot: _promptCacheState.snapshot
+                pendingSnapshotTask: _promptCacheState.pendingSnapshotTask
             )
         }
         Self.logger.debug("MLX generate started")
@@ -393,7 +392,12 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
                     autoDetectedMarkers: snapshot.autoDetectedMarkers,
                     kvCacheReuseEligible: snapshot.kvCacheReuseEligible,
                     pendingSnapshotTask: snapshot.pendingSnapshotTask,
-                    existingSnapshot: snapshot.existingPromptCacheSnapshot,
+                    // Closure re-reads the snapshot AFTER the driver awaits
+                    // `pendingSnapshotTask`, so we see the value the prior turn's
+                    // snapshot task wrote rather than the nil we'd have captured here.
+                    currentSnapshot: { [weak self] in
+                        self?.withStateLock { self?._promptCacheState.snapshot } ?? nil
+                    },
                     generationStream: generationStream,
                     continuation: continuation,
                     yieldHook: MLXBackend._yieldHookForTesting
@@ -449,7 +453,6 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         let autoDetectedMarkers: ThinkingMarkers?
         let kvCacheReuseEligible: Bool
         let pendingSnapshotTask: Task<Void, Never>?
-        let existingPromptCacheSnapshot: MLXPromptCacheCoordinator.Snapshot?
     }
 
     /// Schedules an off-main capture of the prompt KV cache for next-turn reuse.

--- a/Tests/ManifoldBackendsTests/MLXMemoryPressureMissingTests.swift
+++ b/Tests/ManifoldBackendsTests/MLXMemoryPressureMissingTests.swift
@@ -21,11 +21,12 @@ import XCTest
 /// into a single negation.
 final class MLXMemoryPressureMissingTests: XCTestCase {
 
-    /// Resolves the path to a sibling Swift source file under
-    /// `Sources/ManifoldBackends/`. `#filePath` points at this test file;
-    /// going up to the package root and then back down is the most robust
-    /// way to find the production source from a test target.
-    private func sourcePath(for fileName: String) -> String {
+    /// Resolves the path to a Swift source file under `Sources/<module>/`.
+    /// `#filePath` points at this test file; going up to the package root and
+    /// then back down is the most robust way to find the production source
+    /// from a test target. The family-target split (MLX → `ManifoldMLX/`,
+    /// Llama → `ManifoldLlama/`) means we pass the owning module explicitly.
+    private func sourcePath(module: String, fileName: String) -> String {
         let testFileURL = URL(fileURLWithPath: #filePath)
         let packageRoot = testFileURL
             .deletingLastPathComponent()  // Tests/ManifoldBackendsTests
@@ -33,20 +34,20 @@ final class MLXMemoryPressureMissingTests: XCTestCase {
             .deletingLastPathComponent()  // package root
         return packageRoot
             .appendingPathComponent("Sources")
-            .appendingPathComponent("ManifoldBackends")
+            .appendingPathComponent(module)
             .appendingPathComponent(fileName)
             .path
     }
 
-    private func readSource(_ fileName: String) throws -> String {
-        let path = sourcePath(for: fileName)
+    private func readSource(module: String, _ fileName: String) throws -> String {
+        let path = sourcePath(module: module, fileName: fileName)
         return try String(contentsOfFile: path, encoding: .utf8)
     }
 
     // FIXME: When MLX gains a memory-pressure handler, flip this assertion.
     // Confirms audit asymmetry: LlamaBackend has it (#415), MLX does not.
     func test_mlxBackend_hasNoMemoryPressureHandlerYet() throws {
-        let source = try readSource("MLXBackend.swift")
+        let source = try readSource(module: "ManifoldMLX", "MLXBackend.swift")
         XCTAssertFalse(
             source.contains("MemoryPressureHandler"),
             "MLXBackend.swift unexpectedly contains 'MemoryPressureHandler' — if the handler was added, flip this assertion to XCTAssertTrue and remove the FIXME above."
@@ -57,7 +58,7 @@ final class MLXMemoryPressureMissingTests: XCTestCase {
     /// `LlamaBackend`, the asymmetry the audit relies on no longer exists,
     /// and the eventual fix-up issue must be re-scoped.
     func test_llamaBackend_hasMemoryPressureHandler() throws {
-        let source = try readSource("LlamaBackend.swift")
+        let source = try readSource(module: "ManifoldLlama", "LlamaBackend.swift")
         XCTAssertTrue(
             source.contains("MemoryPressureHandler"),
             "LlamaBackend.swift no longer references 'MemoryPressureHandler' — the audit asymmetry has dissolved; revisit the perf-audit plan."

--- a/Tests/ManifoldE2ETests/QualityBaselineTests.swift
+++ b/Tests/ManifoldE2ETests/QualityBaselineTests.swift
@@ -220,23 +220,26 @@ final class QualityBaselineTests: XCTestCase {
             let totalDivergence = mismatches + lengthDelta
             let threshold = max(1, Int(Double(baseline.count) * 0.05))
 
-            XCTAssertLessThanOrEqual(
-                totalDivergence,
-                threshold,
-                """
-                Quality regression detected for '\(prompt)':
-                  baseline length : \(baseline.count)
-                  fresh length    : \(freshIDs.count)
-                  mismatched bytes: \(mismatches)
-                  length delta    : \(lengthDelta)
-                  total divergence: \(totalDivergence) (threshold: \(threshold))
-                  baseline text   : \(String(bytes: baseline, encoding: .utf8) ?? "<non-UTF8>")
-                  fresh text      : \(responseText)
-                  model           : \(modelURL.lastPathComponent)
-                Delete the baseline file at \(Self.baselineFileURL(forPrompt: prompt).path) \
-                and re-run to re-record if the change is intentional.
-                """
-            )
+            // Pre-compute the diagnostic message to keep the type checker happy.
+            // A direct multi-line interpolation against XCTAssertLessThanOrEqual's
+            // overload set times out the Swift 6 type checker.
+            // (Also: `baseline` is [Int] token IDs — `String(bytes:encoding:)` was a
+            // pre-existing semantic bug. Dropped the "baseline text" line; token-id
+            // counts above already capture the divergence shape.)
+            let baselinePath = Self.baselineFileURL(forPrompt: prompt).path
+            let diagnostic = """
+            Quality regression detected for '\(prompt)':
+              baseline length : \(baseline.count)
+              fresh length    : \(freshIDs.count)
+              mismatched ids  : \(mismatches)
+              length delta    : \(lengthDelta)
+              total divergence: \(totalDivergence) (threshold: \(threshold))
+              fresh text      : \(responseText)
+              model           : \(modelURL.lastPathComponent)
+            Delete the baseline file at \(baselinePath) and re-run to re-record \
+            if the change is intentional.
+            """
+            XCTAssertLessThanOrEqual(totalDivergence, threshold, diagnostic)
         } else {
             // No baseline yet — record this run and ask the developer to
             // commit the baseline file alongside intentional model updates.

--- a/Tests/ManifoldE2ETests/VisionE2ETests.swift
+++ b/Tests/ManifoldE2ETests/VisionE2ETests.swift
@@ -3,6 +3,7 @@ import XCTest
 import ManifoldInference
 @testable import ManifoldTestSupport
 @testable import ManifoldBackends
+@testable import ManifoldMLX  // MLXModelProbe is internal to ManifoldMLX, not re-exported by the umbrella
 
 /// Hardware-gated end-to-end tests for MLX VLM vision inference.
 ///


### PR DESCRIPTION
## Why

CI runs `swift test --disable-default-traits`, which never compiles the `#if MLX` / `#if Llama` blocks containing the five files touched here. The full-traits sweep that CLAUDE.md prescribes (`swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz`) was silently broken; running the full test sweep locally surfaced **2 build errors blocking compilation** and **4 test failures**. All pre-existed this branch; none affected CI status.

## What's fixed

### Build errors (`Tests/ManifoldE2ETests/`)

1. **`QualityBaselineTests.swift`** — Swift 6 type-checker timeout on a 10-way interpolated XCTAssert message, compounded by a semantic bug: `String(bytes: baseline, encoding: .utf8)` against `[Int]` token IDs has no valid overload (`baseline` is decoded token IDs, not bytes). Pre-computed the diagnostic into a `let`, dropped the broken "baseline text" line — the token-id counts already capture divergence shape.
2. **`VisionE2ETests.swift`** — `MLXModelProbe` not in scope. The probe is internal to `ManifoldMLX` and is not re-exported by the `ManifoldBackends` umbrella. Added `@testable import ManifoldMLX`.

### Behavioral failures (`Tests/ManifoldBackendsTests/MLXBackendGenerationTests`)

Three prompt-cache reuse tests asserted that the second turn would emit `.kvCacheReuse(N)` for the shared prefix; all observed `[]`.

Root cause: `MLXBackend.generate()` synchronously captured `_promptCacheState.snapshot` into `GenerationCallSnapshot` *before* the prior turn's snapshot-capture task had completed, so the value passed to the driver was always stale on the second turn. The driver correctly awaited `pendingSnapshotTask` (see `MLXGenerationDriver.swift:169-174`) but then read the pre-await capture instead of the freshly-written backend state.

Fix: replaced the `existingSnapshot: Snapshot?` driver parameter with `currentSnapshot: @MainActor @Sendable () -> Snapshot?` — a getter the driver invokes *after* the await. `MLXBackend` passes a closure that re-acquires the state lock and reads `_promptCacheState.snapshot` at the right moment.

### Stale-path failures (`Tests/ManifoldBackendsTests/MLXMemoryPressureMissingTests`)

Both tests read source files at `Sources/ManifoldBackends/{LlamaBackend,MLXBackend}.swift` to grep for `MemoryPressureHandler`. Both files moved to `Sources/ManifoldLlama/` and `Sources/ManifoldMLX/` as part of the v0.9.0 family-target split. Parameterised the path helper with the owning module.

## Verification

- `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` — exit 0.
- All-traits `swift test` sweep across 14 suites with traits `MLX,Llama,MCP,MCPBuiltinCatalog,Ollama,CloudSaaS,HuggingFace,Macros` → **4395 passed, 0 failed, 57 skipped** (was 4392/3/57 before this PR).
- CI's `--disable-default-traits` two-invocation pre-push gate remains green (3392/0/17 + 83/0/0).
- ManifoldE2ETests (35), MCP E2E streamable smoke (1), Ollama-trait suites (67) — all green.

## Out of scope

- Does not add a new CI workflow to run trait-combo. That requires a hardware-trait runner discussion (Ollama, real MLX/Llama models) — out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)