### PR TITLE
feat(app-intents): streaming progress channel for long-running intents

### DIFF
--- a/Sources/ManifoldAppIntents/AppIntentToolExecutor.swift
+++ b/Sources/ManifoldAppIntents/AppIntentToolExecutor.swift
@@ -435,6 +435,143 @@ public struct AppIntentToolExecutor<Intent: AppIntent & Decodable>: ToolExecutor
         }
     }
 
+    // MARK: - Streaming
+
+    /// Streaming dispatch for AppIntents.
+    ///
+    /// When `Intent` adopts ``ProgressReportingAppIntent`` (and its
+    /// ``ProgressReportingAppIntent/supportsProgressReporting`` flag is `true`),
+    /// the executor installs an ``IntentProgressReporter`` into the
+    /// ``IntentProgressReporter/current`` task-local before invoking
+    /// ``AppIntent/perform()``. Progress events the intent emits inside
+    /// `perform()` are forwarded onto the returned stream as
+    /// ``ToolExecutionEvent/progress(message:fraction:)`` chunks; the terminal
+    /// ``ToolExecutionEvent/completed(_:)`` carries the same ``ToolResult``
+    /// the single-shot ``execute(arguments:)`` would have returned.
+    ///
+    /// Intents that do not adopt the progress protocol fall through to the
+    /// default ``ToolExecutor/executeStreaming(arguments:)`` wrapper —
+    /// behaviour is identical to the single-shot path with one terminal
+    /// `.completed` event.
+    ///
+    /// Cancellation: the stream's `onTermination` cancels the wrapping task,
+    /// which propagates into both `perform()` and the reporter drain loop via
+    /// structured concurrency. On cancellation the terminal event is a
+    /// ``ToolResult`` with ``ToolResult/ErrorKind/cancelled``, matching the
+    /// single-shot contract — the stream finishes cleanly, no throw.
+    public func executeStreaming(arguments: JSONSchemaValue) -> AsyncThrowingStream<ToolExecutionEvent, Error> {
+        // Fall through to the protocol default when this intent did not opt
+        // into progress reporting. Keeps the streaming path uniform for
+        // callers without paying for a reporter we'd never feed.
+        guard let progressType = Intent.self as? any ProgressReportingAppIntent.Type,
+              progressType.supportsProgressReporting
+        else {
+            return AsyncThrowingStream { continuation in
+                let task = Task {
+                    do {
+                        let result = try await self.execute(arguments: arguments)
+                        continuation.yield(.completed(result))
+                        continuation.finish()
+                    } catch {
+                        continuation.finish(throwing: error)
+                    }
+                }
+                continuation.onTermination = { _ in task.cancel() }
+            }
+        }
+
+        return AsyncThrowingStream { continuation in
+            let reporter = IntentProgressReporter()
+
+            // Drain the reporter's progress stream onto the outer continuation
+            // in a sibling task so the executor can run `perform()` and forward
+            // chunks concurrently. The drain finishes when `reporter.finish()`
+            // closes the underlying AsyncStream, which we call after
+            // `perform()` returns or throws.
+            let drainTask = Task {
+                for await event in reporter.events {
+                    continuation.yield(event)
+                }
+            }
+
+            let workTask = Task {
+                // Install the reporter into the task-local so the running
+                // intent can pull it via `IntentProgressReporter.current`
+                // without a parameter on `perform()`.
+                let result = await IntentProgressReporter.$current.withValue(reporter) {
+                    await self.runStreaming(arguments: arguments)
+                }
+                // Close the progress stream so the drain task exits.
+                await reporter.finish()
+                // Make sure the drain has flushed any in-flight yields before
+                // we emit the terminal event — preserves the documented
+                // ordering invariant (progress events strictly precede
+                // .completed).
+                _ = await drainTask.value
+                continuation.yield(.completed(result))
+                continuation.finish()
+            }
+
+            continuation.onTermination = { _ in
+                workTask.cancel()
+                drainTask.cancel()
+            }
+        }
+    }
+
+    /// Streaming inner loop — runs the intent, classifies the outcome, and
+    /// returns the terminal ``ToolResult`` the caller will wrap as
+    /// ``ToolExecutionEvent/completed(_:)``.
+    ///
+    /// Factored out so the cancellation/error classification stays in lockstep
+    /// with the single-shot ``execute(arguments:)`` path — both call
+    /// ``serialise(_:)`` and ``looksLikeAuthorizationFailure(_:)`` the same
+    /// way.
+    private func runStreaming(arguments: JSONSchemaValue) async -> ToolResult {
+        do {
+            try Task.checkCancellation()
+
+            let intent: Intent
+            do {
+                let encoder = JSONEncoder()
+                encoder.dateEncodingStrategy = .iso8601
+                let decoder = JSONDecoder()
+                decoder.dateDecodingStrategy = .iso8601
+                let argsData = try encoder.encode(arguments)
+                intent = try decoder.decode(Intent.self, from: argsData)
+            } catch {
+                return ToolResult(
+                    callId: "",
+                    content: "Failed to decode AppIntent arguments: \(error.localizedDescription)",
+                    errorKind: .invalidArguments
+                )
+            }
+
+            try Task.checkCancellation()
+
+            let result = try await intent.perform()
+            try Task.checkCancellation()
+
+            let content = Self.serialise(result)
+            return ToolResult(callId: "", content: content, errorKind: nil)
+        } catch is CancellationError {
+            return ToolResult(callId: "", content: "cancelled by user", errorKind: .cancelled)
+        } catch {
+            if Self.looksLikeAuthorizationFailure(error) {
+                return ToolResult(
+                    callId: "",
+                    content: error.localizedDescription,
+                    errorKind: .permissionDenied
+                )
+            }
+            return ToolResult(
+                callId: "",
+                content: error.localizedDescription,
+                errorKind: .permanent
+            )
+        }
+    }
+
     // MARK: - Helpers
 
     /// Tool name derived from the intent's type — `AskManifoldDemoIntent`

--- a/Sources/ManifoldAppIntents/IntentProgressReporter.swift
+++ b/Sources/ManifoldAppIntents/IntentProgressReporter.swift
@@ -1,0 +1,139 @@
+import Foundation
+import ManifoldInference
+
+#if canImport(AppIntents)
+import AppIntents
+#endif
+
+#if canImport(AppIntents)
+
+// MARK: - ProgressReportingAppIntent
+
+/// Marker conformance for AppIntents that emit interim progress events while
+/// ``AppIntent/perform()`` runs.
+///
+/// Adopters keep their existing `perform()` implementation and, at sensible
+/// checkpoints, pull the task-local
+/// ``IntentProgressReporter/current`` reporter and call
+/// ``IntentProgressReporter/report(message:fraction:)``. Each call is forwarded
+/// to the surrounding ``AppIntentToolExecutor/executeStreaming(arguments:)``
+/// stream as a ``ToolExecutionEvent/progress(message:fraction:)`` chunk.
+///
+/// ```swift
+/// struct DownloadModelIntent: ProgressReportingAppIntent, Decodable {
+///     static let title: LocalizedStringResource = "Download Model"
+///     static var supportsProgressReporting: Bool { true }
+///
+///     @Parameter(title: "Model ID")
+///     var modelId: String
+///
+///     func perform() async throws -> some IntentResult {
+///         let reporter = IntentProgressReporter.current
+///         for step in 1...4 {
+///             try await doStep(step)
+///             await reporter?.report(
+///                 message: "Step \(step) of 4",
+///                 fraction: Double(step) / 4.0
+///             )
+///         }
+///         return .result()
+///     }
+/// }
+/// ```
+///
+/// Non-streaming intents simply do not adopt this protocol; the default
+/// ``ToolExecutor/executeStreaming(arguments:)`` wrapper still yields a single
+/// `.completed` event so callers can use the streaming API uniformly.
+@available(iOS 26, macOS 26, *)
+public protocol ProgressReportingAppIntent: AppIntent {
+
+    /// Compile-time flag that the executor reads to decide whether to install a
+    /// task-local ``IntentProgressReporter`` before invoking
+    /// ``AppIntent/perform()``.
+    ///
+    /// Defaults to `true` via a protocol extension — adopters generally do not
+    /// need to set this explicitly. Override to `false` only when temporarily
+    /// disabling progress reporting on a type that still needs to satisfy the
+    /// protocol for some other reason.
+    static var supportsProgressReporting: Bool { get }
+}
+
+@available(iOS 26, macOS 26, *)
+extension ProgressReportingAppIntent {
+    public static var supportsProgressReporting: Bool { true }
+}
+
+// MARK: - IntentProgressReporter
+
+/// Actor-isolated drain that ``ProgressReportingAppIntent/perform()`` pulls
+/// from the task-local ``current`` slot and forwards progress events into.
+///
+/// `AppIntentToolExecutor` installs an instance into the task-local before
+/// invoking `perform()`, attaches the reporter's
+/// `AsyncStream<ToolExecutionEvent>` to its outer
+/// `AsyncThrowingStream<ToolExecutionEvent, Error>`, and finishes the reporter
+/// once `perform()` returns. Intents see a single static
+/// ``current`` accessor — they don't need to thread the reporter through their
+/// method signatures.
+///
+/// The actor isolation is deliberate: `perform()` may suspend on background
+/// executors (downloads, file I/O), and an `actor` makes
+/// ``report(message:fraction:)`` safe to call from any task without an
+/// `@unchecked Sendable` hack.
+@available(iOS 26, macOS 26, *)
+public actor IntentProgressReporter {
+
+    /// Task-local handle the running intent pulls from inside `perform()`.
+    ///
+    /// `nil` outside of a streaming-aware dispatch (e.g. when the intent runs
+    /// under the legacy single-shot ``ToolExecutor/execute(arguments:)`` path,
+    /// or directly outside ManifoldKit). Intents that opt into streaming
+    /// should treat the optional as soft — calling `report(...)` on the
+    /// optional is a no-op when nil, which preserves correctness under both
+    /// streaming and non-streaming dispatch paths.
+    @TaskLocal public static var current: IntentProgressReporter?
+
+    private let continuation: AsyncStream<ToolExecutionEvent>.Continuation
+    private let stream: AsyncStream<ToolExecutionEvent>
+
+    /// Creates a reporter and its backing stream.
+    ///
+    /// The executor owns both ends: the reporter is published via the
+    /// task-local for the intent to push into, while ``events`` is drained by
+    /// the executor and forwarded onto the outer caller-visible stream.
+    public init() {
+        var sink: AsyncStream<ToolExecutionEvent>.Continuation!
+        self.stream = AsyncStream(bufferingPolicy: .unbounded) { continuation in
+            sink = continuation
+        }
+        self.continuation = sink
+    }
+
+    /// Emits a progress event into the surrounding executor stream.
+    ///
+    /// - Parameters:
+    ///   - message: Human-readable status string. Should be safe to render
+    ///     directly in UI.
+    ///   - fraction: Optional 0.0...1.0 completion fraction. Pass `nil` when
+    ///     the total is unknown (open-ended fetch, single-step ping).
+    public func report(message: String, fraction: Double? = nil) {
+        continuation.yield(.progress(message: message, fraction: fraction))
+    }
+
+    /// The progress event sequence the executor drains.
+    ///
+    /// Marked `nonisolated` because `AsyncStream` itself is `Sendable` and
+    /// each yield is funneled through the actor-isolated ``report(message:fraction:)``;
+    /// the consumer side has no shared mutable state.
+    public nonisolated var events: AsyncStream<ToolExecutionEvent> { stream }
+
+    /// Closes the backing stream so the executor's drain loop terminates.
+    ///
+    /// Called by the executor after `perform()` returns (or throws); intents
+    /// must not call this themselves.
+    public func finish() {
+        continuation.finish()
+    }
+}
+
+#endif // canImport(AppIntents)

--- a/Sources/ManifoldInference/Models/ToolTypes.swift
+++ b/Sources/ManifoldInference/Models/ToolTypes.swift
@@ -371,6 +371,42 @@ public struct ToolResult: Sendable, Codable, Equatable, Hashable {
     }
 }
 
+// MARK: - ToolExecutionEvent
+
+/// One element of a ``ToolExecutor/executeStreaming(arguments:)`` stream.
+///
+/// Streaming-aware executors yield zero or more ``progress(message:fraction:)``
+/// chunks for long-running work (downloads, multi-step queries, paginated
+/// fetches), then yield exactly one terminal ``completed(_:)`` carrying the
+/// same ``ToolResult`` a non-streaming `execute(arguments:)` would return.
+///
+/// ## Contract
+///
+/// - **Order**: any number of `.progress` events, followed by exactly one
+///   `.completed`. `.completed` is always last; nothing follows it.
+/// - **Cardinality**: `.completed` appears exactly once per successful stream.
+///   On thrown errors the stream finishes with an error and no `.completed`
+///   is yielded — mirror the single-shot `execute` contract.
+/// - **Sendability**: ``ToolResult`` is `Sendable`, so this enum is `Sendable`
+///   and safe to ferry across actor boundaries inside an `AsyncThrowingStream`.
+///
+/// ``ToolResult/ErrorKind`` is unchanged — streaming is additive on top of the
+/// existing single-shot vocabulary, not a new failure mode.
+public enum ToolExecutionEvent: Sendable {
+
+    /// Interim progress chunk.
+    ///
+    /// - Parameters:
+    ///   - message: Human-readable status (e.g. `"Fetched 12 of 47 records"`).
+    ///   - fraction: Optional 0.0...1.0 completion fraction. `nil` when the
+    ///     work has no known total (open-ended streams, single-step queries
+    ///     that just want to ping liveness).
+    case progress(message: String, fraction: Double?)
+
+    /// Terminal value. Always exactly one per stream, always last.
+    case completed(ToolResult)
+}
+
 // MARK: - ToolChoice
 
 /// Controls how the backend selects which tool to call, if any.

--- a/Sources/ManifoldInference/Services/ToolExecutor.swift
+++ b/Sources/ManifoldInference/Services/ToolExecutor.swift
@@ -151,6 +151,28 @@ public protocol ToolExecutor: Sendable {
     /// by the orchestrator; aggregate internally and only throw once you
     /// have decided to abandon the buffer.
     func execute(arguments: JSONSchemaValue) async throws -> ToolResult
+
+    /// Streaming variant of ``execute(arguments:)``.
+    ///
+    /// Yields zero or more ``ToolExecutionEvent/progress(message:fraction:)``
+    /// chunks for long-running work, then exactly one
+    /// ``ToolExecutionEvent/completed(_:)`` carrying the same terminal
+    /// ``ToolResult`` that ``execute(arguments:)`` would have returned.
+    ///
+    /// The default implementation in ``ToolExecutor`` wraps
+    /// ``execute(arguments:)`` and yields only the terminal value — so existing
+    /// non-streaming executors do not need to opt in. Executors that can emit
+    /// interim progress override this directly.
+    ///
+    /// ## Cancellation
+    ///
+    /// The stream's `onTermination` cancels the wrapping `Task` so the
+    /// underlying ``execute(arguments:)`` observes cancellation through
+    /// structured concurrency and bails out cooperatively (mirroring the
+    /// single-shot contract — see ``ToolExecutor`` cooperative cancellation
+    /// section). The continuation is finished cleanly with the cancellation
+    /// error; no orphaned task remains.
+    func executeStreaming(arguments: JSONSchemaValue) -> AsyncThrowingStream<ToolExecutionEvent, Error>
 }
 
 extension ToolExecutor {
@@ -161,6 +183,28 @@ extension ToolExecutor {
     /// Default: sequential dispatch. Stateless executors should override
     /// to `true` to opt into parallel batch dispatch.
     public var supportsConcurrentDispatch: Bool { false }
+
+    /// Default streaming implementation: yield the single-shot result as one
+    /// terminal ``ToolExecutionEvent/completed(_:)``.
+    ///
+    /// Non-streaming executors keep their existing
+    /// ``execute(arguments:)`` implementation and inherit this wrapper for
+    /// free. Streaming-aware executors override the method on their concrete
+    /// type.
+    public func executeStreaming(arguments: JSONSchemaValue) -> AsyncThrowingStream<ToolExecutionEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    let result = try await self.execute(arguments: arguments)
+                    continuation.yield(.completed(result))
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
 }
 
 // MARK: - TypedToolExecutor

--- a/Sources/ManifoldInference/Services/ToolRegistry.swift
+++ b/Sources/ManifoldInference/Services/ToolRegistry.swift
@@ -391,6 +391,12 @@ public protocol JSONSchemaValidating: Sendable {
         }
 
         // 5. Execute, stamp callId, and apply the size policy.
+        // TODO(streaming): forward `executor.executeStreaming(arguments:)`
+        // progress chunks onto a new `GenerationEvent.toolProgress(...)` so the
+        // orchestrator can surface interim status to UI / the model without
+        // changing the terminal ToolResult contract. Single-shot path stays
+        // unchanged — see ToolExecutionEvent + executeStreaming in
+        // Sources/ManifoldInference/Services/ToolExecutor.swift.
         let outcome: ToolResult
         do {
             let raw = try await executor.execute(arguments: dispatchArguments)

--- a/Tests/ManifoldAppIntentsTests/AppIntentStreamingTests.swift
+++ b/Tests/ManifoldAppIntentsTests/AppIntentStreamingTests.swift
@@ -1,0 +1,293 @@
+#if AppIntents
+import XCTest
+import ManifoldInference
+@testable import ManifoldAppIntents
+
+#if canImport(AppIntents)
+import AppIntents
+
+// MARK: - Fixtures
+
+/// Non-streaming intent — used to verify the default `executeStreaming`
+/// wrapper yields exactly one `.completed` event with the same body as the
+/// single-shot `execute(arguments:)` would return.
+@available(iOS 26, macOS 26, *)
+struct StreamingEchoIntent: AppIntent, Decodable {
+
+    static let title: LocalizedStringResource = "Echo"
+
+    @Parameter(title: "Value")
+    var value: String
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init()
+        self.value = try c.decode(String.self, forKey: .value)
+    }
+
+    private enum CodingKeys: String, CodingKey { case value }
+
+    func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        .result(value: value)
+    }
+}
+
+/// Two-checkpoint progress intent. Reports two `.progress` events with known
+/// messages and fractions, then returns. Streams should emit
+/// `[.progress, .progress, .completed]` in order.
+@available(iOS 26, macOS 26, *)
+struct ProgressIntent: ProgressReportingAppIntent, Decodable {
+
+    static let title: LocalizedStringResource = "Progress"
+
+    @Parameter(title: "Label")
+    var label: String
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init()
+        self.label = try c.decode(String.self, forKey: .label)
+    }
+
+    private enum CodingKeys: String, CodingKey { case label }
+
+    func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        // Pull the task-local reporter. nil-tolerant: if the executor didn't
+        // install one (e.g. legacy single-shot dispatch) the calls are no-ops.
+        if let reporter = IntentProgressReporter.current {
+            await reporter.report(message: "step-1 \(label)", fraction: 0.5)
+            await reporter.report(message: "step-2 \(label)", fraction: 1.0)
+        }
+        return .result(value: label)
+    }
+}
+
+/// Nil-fraction variant — verifies optional fraction round-trips through
+/// reporter → drain → stream without being coerced to a default value.
+@available(iOS 26, macOS 26, *)
+struct NilFractionIntent: ProgressReportingAppIntent, Decodable {
+
+    static let title: LocalizedStringResource = "NilFraction"
+
+    @Parameter(title: "Tag")
+    var tag: String
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init()
+        self.tag = try c.decode(String.self, forKey: .tag)
+    }
+
+    private enum CodingKeys: String, CodingKey { case tag }
+
+    func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        if let reporter = IntentProgressReporter.current {
+            await reporter.report(message: "indeterminate \(tag)", fraction: nil)
+        }
+        return .result(value: tag)
+    }
+}
+
+/// Slow-cancellation intent — sleeps long enough that the outer task can
+/// cancel mid-flight; `perform()` checks cancellation between sleeps.
+@available(iOS 26, macOS 26, *)
+struct SlowProgressIntent: ProgressReportingAppIntent, Decodable {
+
+    static let title: LocalizedStringResource = "Slow"
+
+    @Parameter(title: "Token")
+    var token: String
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init()
+        self.token = try c.decode(String.self, forKey: .token)
+    }
+
+    private enum CodingKeys: String, CodingKey { case token }
+
+    func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        if let reporter = IntentProgressReporter.current {
+            await reporter.report(message: "starting", fraction: 0.0)
+        }
+        // Long enough that the test will cancel before completion. Loop with
+        // short sleeps so the cancellation observation is prompt.
+        for _ in 0..<200 {
+            try await Task.sleep(nanoseconds: 50_000_000) // 50ms
+            try Task.checkCancellation()
+        }
+        return .result(value: token)
+    }
+}
+
+// MARK: - Tests
+
+@available(iOS 26, macOS 26, *)
+final class AppIntentStreamingTests: XCTestCase {
+
+    // MARK: default-impl coverage
+
+    func testDefaultStreamingYieldsOnlyCompletedEvent() async throws {
+        // Non-streaming intent goes through the protocol-extension default,
+        // which must wrap the single-shot `execute` into one `.completed`.
+        let executor = AppIntentToolExecutor(StreamingEchoIntent.self)
+        let args = JSONSchemaValue.object(["value": .string("ping")])
+
+        var events: [ToolExecutionEvent] = []
+        for try await event in executor.executeStreaming(arguments: args) {
+            events.append(event)
+        }
+
+        XCTAssertEqual(events.count, 1, "non-streaming intent must yield exactly one event")
+        guard case .completed(let result) = events[0] else {
+            return XCTFail("only event must be .completed, got \(events[0])")
+        }
+        XCTAssertNil(result.errorKind)
+        XCTAssertTrue(result.content.contains("ping"))
+
+        // Sabotage check (manual): asserting events.count == 2 here fails as expected.
+    }
+
+    // MARK: progress-reporting intent
+
+    func testProgressReportingIntentEmitsProgressThenCompleted() async throws {
+        let executor = AppIntentToolExecutor(ProgressIntent.self)
+        let args = JSONSchemaValue.object(["label": .string("hello")])
+
+        var events: [ToolExecutionEvent] = []
+        for try await event in executor.executeStreaming(arguments: args) {
+            events.append(event)
+        }
+
+        XCTAssertEqual(events.count, 3, "expected [.progress, .progress, .completed], got \(events)")
+
+        guard case .progress(let m1, let f1) = events[0] else {
+            return XCTFail("first event must be .progress, got \(events[0])")
+        }
+        XCTAssertEqual(m1, "step-1 hello")
+        XCTAssertEqual(f1, 0.5)
+
+        guard case .progress(let m2, let f2) = events[1] else {
+            return XCTFail("second event must be .progress, got \(events[1])")
+        }
+        XCTAssertEqual(m2, "step-2 hello")
+        XCTAssertEqual(f2, 1.0)
+
+        guard case .completed(let result) = events[2] else {
+            return XCTFail("terminal event must be .completed, got \(events[2])")
+        }
+        XCTAssertNil(result.errorKind)
+        XCTAssertTrue(result.content.contains("hello"))
+    }
+
+    // MARK: cancellation
+
+    /// Documented cancellation semantics: when the **collector task** is
+    /// cancelled, the stream terminates promptly without orphaning the work
+    /// task — `onTermination` cancels both `workTask` and the reporter drain.
+    /// The collector may observe any prefix of progress events plus an
+    /// optional terminal `.completed`; the contract guarantees the iterator
+    /// returns within a bounded time and the underlying work cooperates with
+    /// cancellation (so resources aren't leaked).
+    ///
+    /// We pick "stream finishes; no orphaned task" over "always synthesise a
+    /// terminal .completed(.cancelled)" because once the consumer has stopped
+    /// reading, yielding a terminal event has no recipient and only races
+    /// with `onTermination`. Producers that need to surface `.cancelled` to
+    /// the model do so via the single-shot path (`execute(arguments:)`),
+    /// which is what `ToolRegistry.dispatch` calls today.
+    func testCancellationTerminatesStreamWithoutHanging() async throws {
+        let executor = AppIntentToolExecutor(SlowProgressIntent.self)
+        let args = JSONSchemaValue.object(["token": .string("x")])
+
+        let collector = Task<[ToolExecutionEvent], Error> {
+            var events: [ToolExecutionEvent] = []
+            for try await event in executor.executeStreaming(arguments: args) {
+                events.append(event)
+            }
+            return events
+        }
+
+        // Give perform() a moment to emit the initial progress event and
+        // enter its sleep loop, then cancel.
+        try await Task.sleep(nanoseconds: 100_000_000) // 100ms
+        collector.cancel()
+
+        // Guard the test against a hang: race the collector against a
+        // bounded timeout. If cancellation didn't propagate, this fails.
+        let bounded = Task<Void, Error> {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    _ = try? await collector.value
+                }
+                group.addTask {
+                    try await Task.sleep(nanoseconds: 2_000_000_000) // 2s ceiling
+                    throw CancellationError()
+                }
+                // Take whichever finishes first.
+                try await group.next()
+                group.cancelAll()
+            }
+        }
+
+        do {
+            try await bounded.value
+        } catch {
+            XCTFail("cancelled stream did not terminate within 2s: \(error)")
+        }
+    }
+
+    /// Sanity check: producer-side completion of the slow intent (no
+    /// cancellation, just wait for it) emits the initial `.progress` chunk
+    /// before any terminal event. Pairs with the cancellation test above by
+    /// proving the slow intent's progress channel is wired correctly.
+    func testSlowIntentEmitsInitialProgress() async throws {
+        // Override the sleep loop to be short — we just need to confirm the
+        // event order. Re-use NilFractionIntent style by adding a tiny
+        // wrapper inline here would balloon the fixture surface; instead we
+        // assert against the first event of SlowProgressIntent and cancel
+        // the collector once we've seen it.
+        let executor = AppIntentToolExecutor(SlowProgressIntent.self)
+        let args = JSONSchemaValue.object(["token": .string("y")])
+
+        var stream = executor.executeStreaming(arguments: args).makeAsyncIterator()
+        let first = try await stream.next()
+        guard case .progress(let message, let fraction) = first else {
+            return XCTFail("first event must be .progress, got \(String(describing: first))")
+        }
+        XCTAssertEqual(message, "starting")
+        XCTAssertEqual(fraction, 0.0)
+        // Drop the iterator so onTermination cancels the underlying tasks.
+    }
+
+    // MARK: nil fraction round-trip
+
+    func testProgressEventRoundTripsNilFraction() async throws {
+        let executor = AppIntentToolExecutor(NilFractionIntent.self)
+        let args = JSONSchemaValue.object(["tag": .string("indet")])
+
+        var events: [ToolExecutionEvent] = []
+        for try await event in executor.executeStreaming(arguments: args) {
+            events.append(event)
+        }
+
+        XCTAssertEqual(events.count, 2, "expected [.progress, .completed], got \(events)")
+
+        guard case .progress(let message, let fraction) = events[0] else {
+            return XCTFail("first event must be .progress, got \(events[0])")
+        }
+        XCTAssertEqual(message, "indeterminate indet")
+        XCTAssertNil(fraction, "nil fraction must round-trip as nil, not 0.0")
+    }
+}
+
+#endif // canImport(AppIntents)
+#endif


### PR DESCRIPTION
## Summary

Adds an opt-in streaming variant on `ToolExecutor` so AppIntents performing long-running work (downloads, multi-step queries, paginated fetches) can surface interim progress without breaking the existing single-shot contract.

### Design

- **`ToolExecutionEvent`** (`ManifoldInference/Models/ToolTypes.swift`): `case progress(message:fraction:)` + `case completed(ToolResult)`. Sendable; carries the same `ToolResult` shape as before — `ErrorKind` is **not** touched (1.0 vocabulary freeze respected).
- **`ToolExecutor.executeStreaming(arguments:)`** with a protocol-extension default that wraps `execute(arguments:)` into a one-event stream. **Non-streaming executors don't need to opt in** — existing conformances stay untouched and inherit the wrapper.
- **`ProgressReportingAppIntent`** marker protocol + **`IntentProgressReporter`** actor, surfaced via a `@TaskLocal static var current` so the intent's `perform()` can pull the reporter and call `report(message:fraction:)` without parameter threading.
- **`AppIntentToolExecutor.executeStreaming`** installs the reporter into the task-local when `Intent` adopts the marker protocol, drains its progress events into the outer stream, then yields the terminal `.completed`. Otherwise falls through to the default extension — identical behaviour to the single-shot path.
- **Cancellation**: stream `onTermination` cancels both the work task and the reporter drain task; bounded-time termination verified by test. Non-cancellation `perform()` errors flow through the same classification path as `execute(arguments:)` (`.invalidArguments`, `.permissionDenied`, `.permanent`).

### Deferred

Orchestrator wiring — forwarding `.progress` chunks onto a new `GenerationEvent.toolProgress(...)` so UI and the model can observe interim status — is deliberately out of scope. A `TODO(streaming):` comment at the dispatch site in `ToolRegistry.dispatch` marks the integration point.

### Tests

`Tests/ManifoldAppIntentsTests/AppIntentStreamingTests.swift` (5 new tests):

- `testDefaultStreamingYieldsOnlyCompletedEvent` — protocol-extension default yields exactly one `.completed`, matching `execute(arguments:)`.
- `testProgressReportingIntentEmitsProgressThenCompleted` — two `.progress` events followed by `.completed`, order preserved.
- `testProgressEventRoundTripsNilFraction` — `fraction: nil` round-trips as nil, not coerced.
- `testCancellationTerminatesStreamWithoutHanging` — cancelling the collector terminates the stream within 2s; no orphaned work task.
- `testSlowIntentEmitsInitialProgress` — sanity check on producer-side ordering for the cancellation fixture.

### Validation

- `swift build --traits AppIntents` — clean
- `swift test --traits AppIntents --filter ManifoldAppIntentsTests` — 20/20 passing (12 pre-existing + 5 new + 3 pre-existing E2E)
- `swift test --filter ManifoldInferenceTests --disable-default-traits --skip-update` — 1609/1609 passing; protocol-extension default doesn't regress any existing `ToolExecutor` user

## Test plan

- [x] `swift build --traits AppIntents`
- [x] `swift test --traits AppIntents --filter ManifoldAppIntentsTests`
- [x] `swift test --filter ManifoldInferenceTests --disable-default-traits --skip-update`
- [ ] CI green across all suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)