### PR TITLE
perf(ci): test-job path filter + cold-start-human cache + pre-flight build gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,53 @@ permissions:
   contents: read
 
 jobs:
+  # Pre-flight build gate. Surfaces compile errors in ~60-90s instead of
+  # ~4-5 min — the heavier `test` / `cold-start-tier2` / `cold-start-tier3` /
+  # `foundation-only-build` jobs run `needs: build-gate` and short-circuit if
+  # the build doesn't compile. The gate itself is the same `swift build
+  # --build-tests --disable-default-traits` that the test job runs implicitly
+  # on first invocation, but isolated so its failure mode is obvious in PR
+  # checks and so the downstream wait queue collapses on broken pushes.
+  #
+  # `test` is a required status check (branch protection). When build-gate
+  # fails and the downstream `test` job is skipped via `needs:`, GitHub
+  # reports `test` as skipped, which blocks merge — exactly the desired
+  # behavior for a broken build. No `if: always()` overrides; we want fan-out
+  # cancellation.
+  build-gate:
+    runs-on: macos-15  # match downstream jobs so the cache key collides
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.3"
+
+      - name: Cache SwiftPM dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            .build/artifacts
+            .build/checkouts
+            .build/repositories
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
+            ${{ runner.os }}-${{ runner.arch }}-spm-
+
+      - name: swift build --build-tests
+        # Matches the default-trait CI build surface the `test` job exercises.
+        # --skip-update mirrors the downstream test invocation; Package.resolved
+        # is the source of truth for the dependency graph, so the pre-flight
+        # never needs to recontact remotes.
+        run: swift build --build-tests --disable-default-traits --skip-update
+
   test:
+    needs: build-gate
     runs-on: macos-15  # Apple Silicon (arm64) standard runner to reduce spend
 
     steps:
@@ -324,6 +370,7 @@ jobs:
   # peels Hummingbird out of the default-trait build so only this job pays
   # the compile cost — and only when server code or the dep graph changes.
   server-tests:
+    needs: build-gate
     runs-on: macos-15  # match the `test` job runner so cache keys collide
 
     steps:
@@ -427,6 +474,7 @@ jobs:
   # `test` job skips the swift-syntax compile cost; this job picks them up
   # only when macro code or the dep graph changes.
   macros-tests:
+    needs: build-gate
     runs-on: macos-15  # match the `test` job runner so cache keys collide
 
     steps:
@@ -539,6 +587,7 @@ jobs:
   # symbol downstream-visible. Per `[[feedback_ci_path_filter_self_validation]]`
   # the script's own path is in the filter so script-only PRs still trigger.
   cold-start:
+    needs: build-gate
     runs-on: macos-15  # match the `test` job runner so cache keys collide
 
     steps:
@@ -593,6 +642,7 @@ jobs:
   # Same per-PR gating as `cold-start` above: only fires on Package.swift /
   # Package.resolved / script edits; nightly runs it unconditionally.
   cold-start-tier2:
+    needs: build-gate
     runs-on: macos-15  # match the `test` job runner so cache keys collide
 
     steps:
@@ -648,6 +698,7 @@ jobs:
   #
   # Same per-PR gating as the other cold-start jobs; nightly runs it daily.
   cold-start-tier3:
+    needs: build-gate
     runs-on: macos-15  # match the `test` job runner so cache keys collide
 
     steps:
@@ -702,6 +753,7 @@ jobs:
   # target whose code can flip the FoundationOnly bundle composition).
   # Nightly runs it unconditionally every day.
   foundation-only-build:
+    needs: build-gate
     runs-on: macos-15  # match the `test` job runner so cache keys collide
 
     steps:
@@ -758,6 +810,7 @@ jobs:
   # ManifoldPersistenceSwiftDataTests/ModelContainerFileProtectionTests suite to
   # keep runtime short.  See scripts/test-ios-simulator.sh for the full rationale.
   ci-ios-file-protection:
+    needs: build-gate
     runs-on: macos-15  # match the `test` job runner
 
     steps:

--- a/.github/workflows/cold-start-human.yml
+++ b/.github/workflows/cold-start-human.yml
@@ -90,5 +90,37 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
             ${{ runner.os }}-${{ runner.arch }}-spm-
 
+      # Cache the cold-start consumer's own build path across runs. The script
+      # honors MANIFOLDKIT_COLD_START_BUILD_CACHE_DIR by passing it as SwiftPM's
+      # --build-path; the consumer target itself rebuilds each run (mktemp
+      # source path changes its module fingerprint), but the entire ManifoldKit
+      # dependency closure (artifacts + checkouts + transitive object files) is
+      # reused. Local measurement: cold 90s → warm 12s (7.5× speed-up), with
+      # 1545 → 359 build steps (dep graph re-used, only consumer target
+      # recompiled). Restore-keys fall back to a partial-prefix hit so a
+      # Package.resolved bump warms from the previous resolved set instead of
+      # paying the full cold cost. Memory `feedback_ci_build_debug_cache`
+      # warned off caching `.build/debug` for the main test job because path
+      # fingerprints invalidate restored objects; that risk is real here too,
+      # but the cache path is owned by THIS workflow only and the consumer
+      # target is the only piece that recompiles per run — the dep graph
+      # restore is the dominant win. Keyed on Package.resolved AND the script
+      # contents (a script change can shift the consumer's Package.swift
+      # shape, which would invalidate cached dep object files).
+      - name: Cache cold-start consumer build path
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/manifoldkit-cold-start-human
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-cs-human-${{ hashFiles('Package.resolved', 'scripts/cold-start-human.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-cs-human-
+
       - name: Run tier-4 human cold-start gate
-        run: bash scripts/cold-start-human.sh
+        run: |
+          # Resolve cache path under $HOME so the cache step's `~/.cache/...`
+          # literal resolves to the same directory. GitHub Actions does not
+          # expand `~` in env: blocks, so we set the env var inline.
+          mkdir -p "$HOME/.cache/manifoldkit-cold-start-human"
+          export MANIFOLDKIT_COLD_START_BUILD_CACHE_DIR="$HOME/.cache/manifoldkit-cold-start-human"
+          bash scripts/cold-start-human.sh

--- a/scripts/cold-start-human.sh
+++ b/scripts/cold-start-human.sh
@@ -204,8 +204,25 @@ SWIFT_ENV=(
     GIT_CONFIG_VALUE_0=all
 )
 
+# Optional persistent build cache. When MANIFOLDKIT_COLD_START_BUILD_CACHE_DIR is
+# set we redirect SwiftPM's build path to that directory so a CI cache step can
+# warm-restore it across runs. The tmpdir-based consumer's *Package.swift* and
+# the snippet itself live in ${WORK} and are recreated each run, but the
+# resolved dep checkouts + compiled object files keyed under .build/arm64-apple-
+# macosx survive the next invocation. We accept that SwiftPM path-fingerprints
+# make the consumer-target object cache invalid (snippet path changes each run
+# under mktemp), but the dependency graph's checkouts and prebuilt artifacts
+# (notably the llama.cpp xcframework) still warm-restore — see PR body for the
+# measurement of where the win lands.
+BUILD_PATH_FLAG=()
+if [[ -n "${MANIFOLDKIT_COLD_START_BUILD_CACHE_DIR:-}" ]]; then
+    mkdir -p "${MANIFOLDKIT_COLD_START_BUILD_CACHE_DIR}"
+    BUILD_PATH_FLAG=(--build-path "${MANIFOLDKIT_COLD_START_BUILD_CACHE_DIR}")
+    echo "    Using persistent build cache: ${MANIFOLDKIT_COLD_START_BUILD_CACHE_DIR}"
+fi
+
 echo "==> swift build (Hello World snippet from README)"
-if ! env "${SWIFT_ENV[@]}" swift build --package-path "${WORK}" 2>&1 | tail -60; then
+if ! env "${SWIFT_ENV[@]}" swift build --package-path "${WORK}" "${BUILD_PATH_FLAG[@]}" 2>&1 | tail -60; then
     echo "::error file=README.md,line=${first_h2_line}::The Hello World snippet does not compile against the current ManifoldKit public API."
     echo "    Either the snippet drifted (e.g. deleted symbol, renamed type) or"
     echo "    a public symbol it relies on was removed without updating the README."
@@ -214,8 +231,13 @@ if ! env "${SWIFT_ENV[@]}" swift build --package-path "${WORK}" 2>&1 | tail -60;
 fi
 
 # Sanity: confirm SwiftPM actually built the target's object file.
-# Empty/skipped builds can exit 0 if no sources matched.
-if ! find "${WORK}/.build" -name 'HelloWorld.swift.o' -print -quit 2>/dev/null | grep -q .; then
+# Empty/skipped builds can exit 0 if no sources matched. Search the configured
+# build root: either the in-${WORK} default or the persistent cache dir.
+BUILD_SEARCH_ROOT="${WORK}/.build"
+if [[ -n "${MANIFOLDKIT_COLD_START_BUILD_CACHE_DIR:-}" ]]; then
+    BUILD_SEARCH_ROOT="${MANIFOLDKIT_COLD_START_BUILD_CACHE_DIR}"
+fi
+if ! find "${BUILD_SEARCH_ROOT}" -name 'HelloWorld.swift.o' -print -quit 2>/dev/null | grep -q .; then
     echo "::error::swift build exited 0 but did not produce HelloWorld.swift.o — check target wiring."
     exit 1
 fi


### PR DESCRIPTION
## Why

CI today spins up 13+ jobs per push, each paying ~95s of setup overhead (runner cold start + checkout + setup-swift + cache restore + Package resolve). The 10x macOS billing multiplier makes every minute of wall time count. Two concrete wins in this PR:

1. **Pre-flight `build-gate` job** — today, a compile error in any PR surfaces ~4-5 min into the `test` job (build phase). Adding a thin `swift build --build-tests --disable-default-traits` gate that other jobs `needs:` means build failures fail in ~60-90s and short-circuit the downstream jobs. Saves the full 4-5 min of wasted build cost across `test`, `server-tests`, `macros-tests`, `cold-start{,-tier2,-tier3}`, `foundation-only-build`, `ci-ios-file-protection` on any broken-build push.

2. **Cold-start-human consumer cache** — `scripts/cold-start-human.sh` (PR #1374, Wave D-C2) takes ~4-5 minutes because it `swift build`s a fresh SwiftPM consumer in a tmpdir from a cold cache. The consumer depends on the same packages as the main repo, so a SwiftPM `--build-path` redirected to a stable, cached directory lets the dep graph warm-restore.

## What

### 1. Pre-flight `build-gate` job (item 3 in brief)

New job in `ci.yml`:
```yaml
build-gate:
  runs-on: macos-15
  timeout-minutes: 10
  steps:
    - checkout / select-xcode / cache spm
    - run: swift build --build-tests --disable-default-traits --skip-update
```

Wired `needs: build-gate` onto every job in ci.yml that itself runs `swift build`: `test`, `server-tests`, `macros-tests`, `cold-start`, `cold-start-tier2`, `cold-start-tier3`, `foundation-only-build`, `ci-ios-file-protection`. Did NOT wire onto small non-build jobs (none exist in ci.yml).

**Required-check note.** `test` is a required status check on the `main` branch protection rule (`gh api repos/roryford/ManifoldKit/branches/main/protection/required_status_checks` confirms `contexts: [test, lint]`). When `build-gate` fails and `test` skips via `needs:`, GitHub reports `test` as skipped, which keeps the merge blocked — exactly the desired behavior for a broken build. No `if: always()` override needed.

### 2. Cold-start-human consumer cache (item 2 in brief)

`scripts/cold-start-human.sh` now honors `MANIFOLDKIT_COLD_START_BUILD_CACHE_DIR`. When set, the script passes it as SwiftPM's `--build-path` so the consumer's resolved checkouts and compiled object files persist across runs.

`.github/workflows/cold-start-human.yml` adds:
```yaml
- name: Cache cold-start consumer build path
  uses: actions/cache@v5
  with:
    path: |
      ~/.cache/manifoldkit-cold-start-human
    key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-cs-human-${{ hashFiles('Package.resolved', 'scripts/cold-start-human.sh') }}
    restore-keys: |
      ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-cs-human-
```

**Cache key strategy.**
- `Package.resolved` in the hash — dep graph changes invalidate the cache.
- `scripts/cold-start-human.sh` in the hash — script changes can shift the consumer's `Package.swift` shape, which would invalidate cached dep object files.
- `restore-keys` falls back to a partial-prefix hit so a `Package.resolved` bump warms from the prior resolved set instead of paying the full cold cost.

**Local measurement** (M-series, this branch, two consecutive runs):
- Run 1 (cold cache): 90s, 1545 build steps.
- Run 2 (warm cache): **12s**, 359 build steps. **7.5x speed-up.**

The consumer target itself rebuilds each run (mktemp source path changes its module fingerprint, per the SwiftPM path-fingerprint hazard noted in `feedback_ci_build_debug_cache`), but the entire ManifoldKit dep graph (artifacts + checkouts + transitive object files) reuses. The 359 vs 1545 step count makes the boundary visible.

**Memory hazard acknowledged.** `feedback_ci_build_debug_cache` warns off caching `.build/debug` for the main test job because path fingerprints invalidate restored objects while cache-write cost is paid on every PR. That risk is real here too, but: (a) the cache path is owned by THIS workflow only — no cross-pollination with `test`'s `.build`; (b) the consumer target is the only piece that recompiles per run; (c) the 90s -> 12s measurement shows the win is well past the cache-write tax. Distinct from the global `.build/debug` failure mode.

### 3. Path filter on main `test` job (item 1 in brief) — no change required

The brief asks to skip the `test` job on doc-only PRs via `paths-ignore`. The current `ci.yml` trigger already uses an include-only `paths:` filter listing source paths (`Sources/**`, `Tests/**`, `Package.swift`, `Package.resolved`, the script paths, `ci.yml` itself). Doc-only PRs touching only `README.md`, `CHANGELOG.md`, `docs/**`, or `.github/ISSUE_TEMPLATE/**` do NOT trigger ci.yml at all today — verified against recent doc-only merges (#1344 `docs: refresh llama wrapper audit`; #1023 `docs: condense CLAUDE.md developer guide`; release PRs touching only `README.md` + `CHANGELOG.md` + `version.txt`). GitHub's branch-protection semantics treat the required `test` check as "expected workflow did not fire" → satisfied.

No change needed.

## Time savings estimate per push

- **Broken-build push (typo / missing import / Swift 6 isolation error):** ~4-5 min wall + ~50 billed runner-minutes saved (test job alone costs ~340s × 10x macOS multiplier). Today's ~5 min wait collapses to ~90s.
- **Healthy push:** +~90s wall time on the critical path because downstream jobs now wait on build-gate before starting. This is the trade-off — broken pushes get fast feedback, healthy pushes pay the gate cost. Net wins assuming any non-zero broken-build rate.
- **cold-start-human gate (PR-only, README/Sources/ManifoldKit/Sources/ManifoldUI/Sources/ManifoldInference change):** 90s -> 12s = ~78s saved per fire, ~13 billed runner-minutes per fire.

## Verification

- [x] YAML validates (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [x] `swift build --build-tests --disable-default-traits --skip-update` completes locally (103s).
- [x] Sabotage 1: Hello World H2 removed from README → script exits 1 with the structural error (existing tier-4 gate still fires under the cache).
- [x] Cold-cache vs warm-cache measurement: 90s -> 12s (script reuses dep graph across runs).
- [ ] CI run on this PR — confirm `build-gate` fires before `test` starts and that the cold-start-human cache step appears with the expected key.

## Files

- `.github/workflows/ci.yml` — new `build-gate` job + `needs: build-gate` on 8 downstream jobs.
- `.github/workflows/cold-start-human.yml` — added `Cache cold-start consumer build path` step + env wiring for the script.
- `scripts/cold-start-human.sh` — `--build-path` redirect under `MANIFOLDKIT_COLD_START_BUILD_CACHE_DIR`; sanity find updated to scan the configured build root.