### PR TITLE
fix(app-intents): wire dialog + entity resolution into streaming path

### DIFF
--- a/Sources/ManifoldAppIntents/AppIntentToolExecutor.swift
+++ b/Sources/ManifoldAppIntents/AppIntentToolExecutor.swift
@@ -211,27 +211,10 @@ public struct AppIntentToolExecutor<Intent: AppIntent & Decodable>: ToolExecutor
 
             let intent: Intent
             do {
-                // Encode/decode symmetrically with ISO-8601 dates. The
-                // synthesised JSON Schema advertises `Date` as
-                // `{ "type": "string", "format": "date-time" }`, so models
-                // emit ISO-8601 strings — `JSONDecoder`'s default
-                // `secondsSince2001` strategy would reject every one of them.
-                let encoder = JSONEncoder()
-                encoder.dateEncodingStrategy = .iso8601
-                let decoder = JSONDecoder()
-                decoder.dateDecodingStrategy = .iso8601
-                // Hand the resolved entities to the host's `init(from:)` via
-                // userInfo — see ``CodingUserInfoKey/manifoldResolvedEntities``.
-                if !resolvedEntities.isEmpty {
-                    // `JSONDecoder.userInfo` values must be Sendable in
-                    // strict-concurrency builds; wrap the heterogeneous
-                    // entity map in a small Sendable box. Entities flow
-                    // synchronously into `init(from:)` on the same actor, so
-                    // `@unchecked Sendable` is safe in this scope.
-                    decoder.userInfo[.manifoldResolvedEntities] = ResolvedEntityBox(values: resolvedEntities)
-                }
-                let argsData = try encoder.encode(preparedArguments)
-                intent = try decoder.decode(Intent.self, from: argsData)
+                intent = try decodeIntent(
+                    from: preparedArguments,
+                    resolvedEntities: resolvedEntities
+                )
             } catch {
                 return ToolResult(
                     callId: "",
@@ -245,21 +228,7 @@ public struct AppIntentToolExecutor<Intent: AppIntent & Decodable>: ToolExecutor
             let result = try await intent.perform()
             try Task.checkCancellation()
 
-            let dialog = Self.extractDialog(result)
-            let structured = Self.serialise(result)
-            // For pure `ProvidesDialog` results without a `ReturnsValue`,
-            // `serialise(_:)` falls back to `String(describing:)` which
-            // typically contains the dialog text already, but the model
-            // still benefits from the explicit mirror — surface the dialog
-            // in `content` so the model has something useful to read, and
-            // keep `dialog` populated so the host UI can speak it verbatim.
-            let content: String
-            if let dialog, Self.shouldMirrorDialogIntoContent(result) {
-                content = dialog
-            } else {
-                content = structured
-            }
-            return ToolResult(callId: "", content: content, errorKind: nil, dialog: dialog)
+            return Self.makeToolResult(from: result)
         } catch is CancellationError {
             return ToolResult(callId: "", content: "cancelled by user", errorKind: .cancelled)
         } catch {
@@ -531,14 +500,34 @@ public struct AppIntentToolExecutor<Intent: AppIntent & Decodable>: ToolExecutor
         do {
             try Task.checkCancellation()
 
+            // Mirror `execute(arguments:)` — pre-resolve entity parameters so
+            // streaming dispatch honours `@Parameter var book: Book`-style
+            // intents that arrive as `{ "id": ... }`. Without this the
+            // streaming path would throw a `JSONDecoder` error for any
+            // AppEntity parameter; see PR notes for the four-PR landing-wave
+            // drift that caused the regression.
+            let preparedArguments: JSONSchemaValue
+            let resolvedEntities: [String: Any]
+            do {
+                let (args, entities) = try await resolveEntityArguments(arguments)
+                preparedArguments = args
+                resolvedEntities = entities
+            } catch let error as EntityResolutionFailure {
+                return ToolResult(
+                    callId: "",
+                    content: error.message,
+                    errorKind: error.errorKind
+                )
+            }
+
+            try Task.checkCancellation()
+
             let intent: Intent
             do {
-                let encoder = JSONEncoder()
-                encoder.dateEncodingStrategy = .iso8601
-                let decoder = JSONDecoder()
-                decoder.dateDecodingStrategy = .iso8601
-                let argsData = try encoder.encode(arguments)
-                intent = try decoder.decode(Intent.self, from: argsData)
+                intent = try decodeIntent(
+                    from: preparedArguments,
+                    resolvedEntities: resolvedEntities
+                )
             } catch {
                 return ToolResult(
                     callId: "",
@@ -552,8 +541,11 @@ public struct AppIntentToolExecutor<Intent: AppIntent & Decodable>: ToolExecutor
             let result = try await intent.perform()
             try Task.checkCancellation()
 
-            let content = Self.serialise(result)
-            return ToolResult(callId: "", content: content, errorKind: nil)
+            // Same dialog/structured branching as the single-shot path so
+            // `ProvidesDialog` intents see their dialog text on
+            // `ToolResult.dialog` and (for pure-dialog results) mirrored into
+            // `content`.
+            return Self.makeToolResult(from: result)
         } catch is CancellationError {
             return ToolResult(callId: "", content: "cancelled by user", errorKind: .cancelled)
         } catch {
@@ -570,6 +562,64 @@ public struct AppIntentToolExecutor<Intent: AppIntent & Decodable>: ToolExecutor
                 errorKind: .permanent
             )
         }
+    }
+
+    // MARK: - Shared decode + result-assembly helpers
+
+    /// Encode the (entity-stripped) argument payload back to JSON, hand the
+    /// resolved entities to the decoder via `userInfo`, and decode into a
+    /// fresh `Intent`. Shared by ``execute(arguments:)`` and
+    /// ``runStreaming(arguments:)`` so the two dispatch paths can't drift on
+    /// date-strategy / userInfo wiring — the divergence between them was the
+    /// regression this PR closes.
+    private func decodeIntent(
+        from arguments: JSONSchemaValue,
+        resolvedEntities: [String: Any]
+    ) throws -> Intent {
+        // Encode/decode symmetrically with ISO-8601 dates. The synthesised
+        // JSON Schema advertises `Date` as
+        // `{ "type": "string", "format": "date-time" }`, so models emit
+        // ISO-8601 strings — `JSONDecoder`'s default `secondsSince2001`
+        // strategy would reject every one of them.
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        // Hand the resolved entities to the host's `init(from:)` via
+        // userInfo — see ``CodingUserInfoKey/manifoldResolvedEntities``.
+        if !resolvedEntities.isEmpty {
+            // `JSONDecoder.userInfo` values must be Sendable in
+            // strict-concurrency builds; wrap the heterogeneous entity map
+            // in a small Sendable box. Entities flow synchronously into
+            // `init(from:)` on the same actor, so `@unchecked Sendable` is
+            // safe in this scope.
+            decoder.userInfo[.manifoldResolvedEntities] = ResolvedEntityBox(values: resolvedEntities)
+        }
+        let argsData = try encoder.encode(arguments)
+        return try decoder.decode(Intent.self, from: argsData)
+    }
+
+    /// Assemble the terminal ``ToolResult`` for a successful `perform()`
+    /// outcome. Shared by single-shot and streaming dispatch so both paths
+    /// emit identical `content` / `dialog` shapes for `ProvidesDialog` and
+    /// `ReturnsValue` results.
+    ///
+    /// For pure `ProvidesDialog` results without a `ReturnsValue`,
+    /// ``serialise(_:)`` falls back to `String(describing:)` which typically
+    /// contains the dialog text already, but the model still benefits from
+    /// the explicit mirror — surface the dialog in `content` so the model
+    /// has something useful to read, and keep `dialog` populated so the host
+    /// UI can speak it verbatim.
+    static func makeToolResult(from result: some IntentResult) -> ToolResult {
+        let dialog = extractDialog(result)
+        let structured = serialise(result)
+        let content: String
+        if let dialog, shouldMirrorDialogIntoContent(result) {
+            content = dialog
+        } else {
+            content = structured
+        }
+        return ToolResult(callId: "", content: content, errorKind: nil, dialog: dialog)
     }
 
     // MARK: - Helpers

--- a/Tests/ManifoldAppIntentsTests/AppIntentStreamingTests.swift
+++ b/Tests/ManifoldAppIntentsTests/AppIntentStreamingTests.swift
@@ -94,6 +94,105 @@ struct NilFractionIntent: ProgressReportingAppIntent, Decodable {
     }
 }
 
+/// Streaming + AppEntity: re-uses `Book` / `BookQuery` / `InMemoryBookResolver`
+/// from `AppEntityParameterTests.swift`. The intent declares the entity via
+/// `@Parameter` and reads it back through `decoder.resolvedAppEntity`, which is
+/// only populated when the executor runs entity resolution + userInfo wiring
+/// — exactly what the streaming path was missing before this PR.
+///
+/// Conforms to `ProgressReportingAppIntent` so dispatch routes through the
+/// `runStreaming` inner loop (the non-progress branch falls back to the
+/// default wrapper which calls `execute(arguments:)` and would mask the
+/// streaming-path regression we're trying to lock in).
+@available(iOS 26, macOS 26, *)
+struct StreamingDescribeBookIntent: ProgressReportingAppIntent, Decodable {
+    static let title: LocalizedStringResource = "Streaming Describe Book"
+
+    @Parameter(title: "Book")
+    var book: Book
+
+    init() { self.book = Book(id: "", title: "") }
+
+    init(from decoder: Decoder) throws {
+        self.init()
+        if let resolved: Book = decoder.resolvedAppEntity("book") {
+            self.book = resolved
+        } else {
+            throw DecodingError.valueNotFound(
+                Book.self,
+                .init(codingPath: [], debugDescription: "missing resolved book")
+            )
+        }
+    }
+
+    func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        .result(value: "Streamed: \(book.title)")
+    }
+}
+
+/// Streaming + ProvidesDialog (compound) — distinct dialog and value text so
+/// the two channels can be asserted independently.
+///
+/// Conforms to `ProgressReportingAppIntent` so dispatch routes through
+/// `runStreaming` rather than the non-progress fallback wrapper.
+@available(iOS 26, macOS 26, *)
+struct StreamingCompoundDialogIntent: ProgressReportingAppIntent, Decodable {
+    static let title: LocalizedStringResource = "Streaming Compound Dialog"
+
+    @Parameter(title: "Topic")
+    var topic: String
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init()
+        self.topic = try c.decode(String.self, forKey: .topic)
+    }
+
+    private enum CodingKeys: String, CodingKey { case topic }
+
+    func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog {
+        .result(
+            value: "structured-\(topic)",
+            dialog: IntentDialog(stringLiteral: "Spoken-\(topic)")
+        )
+    }
+}
+
+/// Streaming + AppEntity + progress reporting in the same intent. Emits one
+/// progress event before returning so the test can assert both the entity
+/// resolves AND progress still flows through `executeStreaming`'s
+/// reporter-drain sibling task.
+@available(iOS 26, macOS 26, *)
+struct StreamingEntityProgressIntent: ProgressReportingAppIntent, Decodable {
+    static let title: LocalizedStringResource = "Streaming Entity Progress"
+
+    @Parameter(title: "Book")
+    var book: Book
+
+    init() { self.book = Book(id: "", title: "") }
+
+    init(from decoder: Decoder) throws {
+        self.init()
+        if let resolved: Book = decoder.resolvedAppEntity("book") {
+            self.book = resolved
+        } else {
+            throw DecodingError.valueNotFound(
+                Book.self,
+                .init(codingPath: [], debugDescription: "missing resolved book")
+            )
+        }
+    }
+
+    func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        if let reporter = IntentProgressReporter.current {
+            await reporter.report(message: "describing \(book.title)", fraction: 0.5)
+        }
+        return .result(value: "Done: \(book.title)")
+    }
+}
+
 /// Slow-cancellation intent — sleeps long enough that the outer task can
 /// cancel mid-flight; `perform()` checks cancellation between sleeps.
 @available(iOS 26, macOS 26, *)
@@ -286,6 +385,135 @@ final class AppIntentStreamingTests: XCTestCase {
         }
         XCTAssertEqual(message, "indeterminate indet")
         XCTAssertNil(fraction, "nil fraction must round-trip as nil, not 0.0")
+    }
+
+    // MARK: streaming feature-parity with single-shot path
+
+    /// Regression: PR #1383 added entity resolution + userInfo wiring to the
+    /// single-shot `execute(arguments:)` path; the streaming inner loop
+    /// (`runStreaming`) was not updated and threw a decode error for any
+    /// AppEntity parameter. The shared `decodeIntent` helper introduced in
+    /// this PR closes that drift — both paths now go through the same
+    /// resolve-then-decode sequence.
+    func testStreamingResolvesAppEntityParameter() async throws {
+        let executor = AppIntentToolExecutor(
+            StreamingDescribeBookIntent.self,
+            approvalPolicy: .readOnlyAutoApprove,
+            entityResolver: InMemoryBookResolver()
+        )
+        let args = JSONSchemaValue.object([
+            "book": .object(["id": .string("b1")]),
+        ])
+
+        var events: [ToolExecutionEvent] = []
+        for try await event in executor.executeStreaming(arguments: args) {
+            events.append(event)
+        }
+
+        guard let last = events.last, case .completed(let result) = last else {
+            return XCTFail("terminal event must be .completed, got \(events)")
+        }
+        XCTAssertNil(
+            result.errorKind,
+            "streaming + AppEntity must resolve cleanly; got \(String(describing: result.errorKind)): \(result.content)"
+        )
+        XCTAssertTrue(
+            result.content.contains("Dune"),
+            "result body must include the resolved title; got \(result.content)"
+        )
+    }
+
+    /// Regression: PR #1385 wired `ToolResult.dialog` into the single-shot
+    /// path; the streaming inner loop dropped it on the floor by calling
+    /// `ToolResult(callId:content:errorKind:)` without the `dialog:` argument.
+    /// The shared `makeToolResult` helper now powers both paths.
+    ///
+    /// Note on sabotage-verification: on the iOS 26 / macOS 26 SDK
+    /// `extractDialog` returns nil for `IntentDialog` (private storage —
+    /// see `testPureDialogIntentExtractionFallsThroughOnPublicAPI`), so the
+    /// streaming-pre-fix and post-fix observable dialog values are both nil
+    /// here. This test is a forward-looking equivalence guard: when Apple
+    /// promotes `IntentDialog` rendering to a public surface (or hosts use
+    /// a Mirror-discoverable dialog), any streaming/single-shot drift will
+    /// trip the equality assertion below.
+    func testStreamingPopulatesDialogForProvidesDialogIntent() async throws {
+        let executor = AppIntentToolExecutor(
+            StreamingCompoundDialogIntent.self,
+            approvalPolicy: .readOnlyAutoApprove
+        )
+        let args = JSONSchemaValue.object(["topic": .string("Mars")])
+
+        var events: [ToolExecutionEvent] = []
+        for try await event in executor.executeStreaming(arguments: args) {
+            events.append(event)
+        }
+
+        guard let last = events.last, case .completed(let result) = last else {
+            return XCTFail("terminal event must be .completed, got \(events)")
+        }
+        XCTAssertNil(result.errorKind)
+        // Dialog extraction on iOS 26 / macOS 26 may yield nil (the dialog
+        // storage is private framework chrome — see PR #1385); the contract
+        // we actually want to lock in is "streaming uses the same
+        // `extractDialog`-aware code path as `execute`". The single-shot
+        // path for the same fixture is documented as nil-on-current-SDKs in
+        // `AppIntentToolExecutorTests.testCompoundDialogIntent`, so we
+        // assert the SAME outcome here — proving the streaming branch is
+        // not silently dropping a dialog the single-shot path would carry.
+        let singleShot = try await executor.execute(arguments: args)
+        XCTAssertEqual(
+            result.dialog,
+            singleShot.dialog,
+            "streaming dialog must match single-shot dialog; streaming=\(String(describing: result.dialog)), singleShot=\(String(describing: singleShot.dialog))"
+        )
+        // Content must carry the structured value, not the dialog (compound
+        // result — `shouldMirrorDialogIntoContent` returns false because the
+        // `ReturnsValue` payload is present).
+        XCTAssertTrue(
+            result.content.contains("structured-Mars"),
+            "compound result must surface the structured value in content; got \(result.content)"
+        )
+    }
+
+    /// Regression: combines #1383 (entity resolution) with #1384 (progress
+    /// reporter). If a future change reorders the entity-resolve /
+    /// progress-install sequence in `executeStreaming`, this test catches
+    /// the breakage: progress depends on `IntentProgressReporter.current`
+    /// being installed before `perform()`, and the entity depends on
+    /// `decoder.userInfo` being populated before `init(from:)` runs.
+    func testStreamingEntityAndProgressBothFlow() async throws {
+        let executor = AppIntentToolExecutor(
+            StreamingEntityProgressIntent.self,
+            approvalPolicy: .readOnlyAutoApprove,
+            entityResolver: InMemoryBookResolver()
+        )
+        let args = JSONSchemaValue.object([
+            "book": .object(["id": .string("b2")]),
+        ])
+
+        var events: [ToolExecutionEvent] = []
+        for try await event in executor.executeStreaming(arguments: args) {
+            events.append(event)
+        }
+
+        XCTAssertEqual(events.count, 2, "expected [.progress, .completed], got \(events)")
+        guard case .progress(let message, let fraction) = events[0] else {
+            return XCTFail("first event must be .progress, got \(events[0])")
+        }
+        XCTAssertEqual(message, "describing Foundation")
+        XCTAssertEqual(fraction, 0.5)
+
+        guard case .completed(let result) = events[1] else {
+            return XCTFail("terminal event must be .completed, got \(events[1])")
+        }
+        XCTAssertNil(
+            result.errorKind,
+            "entity must resolve AND progress must flow; got \(String(describing: result.errorKind)): \(result.content)"
+        )
+        XCTAssertTrue(
+            result.content.contains("Foundation"),
+            "result must reference the resolved entity title; got \(result.content)"
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

Closes the streaming-path feature-parity gap noted at the end of the four-PR landing wave (#1381 / #1383 / #1384 / #1385). No GitHub issue exists for this — deliberate, small follow-up.

`runStreaming` (the inner loop behind `executeStreaming` for `ProgressReportingAppIntent`s) was kept as the simpler legacy shape from #1384 during the sequential rebase. It never picked up:

- **#1383 — AppEntity resolution + `userInfo` wiring.** Streaming dispatch of any intent with `@Parameter var book: Book` (an `AppEntity`) threw `JSONDecoder` decode errors because `Book` isn't directly `Decodable`. The single-shot `execute(arguments:)` path pre-resolves via `resolveEntityArguments` and threads the entity through `decoder.userInfo[.manifoldResolvedEntities]`.
- **#1385 — `ToolResult.dialog` extraction.** Streaming returned `ToolResult(callId:content:errorKind:)` without `dialog:`, silently dropping the dialog channel for `ProvidesDialog` intents. The single-shot path uses `extractDialog` + `shouldMirrorDialogIntoContent` to pick between dialog and structured content.

## What this PR does

**Source (`AppIntentToolExecutor.swift`)** — extracts two private helpers so the two dispatch paths converge:

- `decodeIntent(from:resolvedEntities:)` — encode+decode dance with ISO-8601 date strategy and `ResolvedEntityBox` userInfo wiring. Both paths call it.
- `makeToolResult(from:)` — runs `extractDialog`, `serialise`, `shouldMirrorDialogIntoContent` to assemble the terminal `ToolResult`. Both paths call it.

`runStreaming` now mirrors `execute`: `resolveEntityArguments` → `decodeIntent` → `perform()` → `makeToolResult`. Error classification (`EntityResolutionFailure` → `invalidArguments` / `permissionDenied` / `permanent`, `looksLikeAuthorizationFailure` → `permissionDenied`) stays identical between paths.

The shared-helper extraction is the actual fix — without it the two paths will drift again the next time someone touches one.

**Tests (`Tests/ManifoldAppIntentsTests/AppIntentStreamingTests.swift`)** — three regression cases:

1. `testStreamingResolvesAppEntityParameter` — `@Parameter var book: Book` dispatched via `executeStreaming`; asserts terminal `.completed` has `errorKind == nil` and content references the resolved book. **Sabotage-verified red against pre-fix source.**
2. `testStreamingPopulatesDialogForProvidesDialogIntent` — compound `ReturnsValue<String> & ProvidesDialog` intent via `executeStreaming`; asserts streaming `dialog` equals single-shot `dialog` and content carries the structured value. Structural equivalence guard — not sabotage-verifiable on macOS 26 because `extractDialog` returns nil for `IntentDialog` on the current SDK (documented in `testPureDialogIntentExtractionFallsThroughOnPublicAPI`), but locks in the equivalence for future SDKs / Mirror-discoverable dialogs.
3. `testStreamingEntityAndProgressBothFlow` — `ProgressReportingAppIntent` that also takes an `AppEntity`; asserts the entity resolves AND a progress event still flows before `.completed`. **Sabotage-verified red against pre-fix source.** Catches future reordering of the entity-resolve / progress-install sequence.

Fixtures conform to `ProgressReportingAppIntent` so dispatch routes through `runStreaming` rather than the non-progress fallback wrapper (which calls `execute` and would mask the regression).

## Validation

```
swift build --traits AppIntents                                                            # Build complete
swift test --traits AppIntents --filter ManifoldAppIntentsTests                            # 44/44 pass (41 + 3 new)
swift test --filter ManifoldInferenceTests --disable-default-traits --skip-update          # 1609/1609 pass (5 expected skips)
```

`ManifoldInferenceTests` covers `SilentCatchAuditTest` — no `try?` introduced in the refactor.

## Test plan

- [x] `swift build --traits AppIntents` — green
- [x] `swift test --traits AppIntents --filter ManifoldAppIntentsTests` — 44/44
- [x] `swift test --filter ManifoldInferenceTests --disable-default-traits --skip-update` — 1609/1609 (5 skips)
- [x] Sabotage-verify (1) and (3) red against pre-fix source

🤖 Generated with [Claude Code](https://claude.com/claude-code)