### PR TITLE
feat(app-intents): batch registration API for DiscoverableAppIntent (#1380)

### DIFF
--- a/Sources/ManifoldAppIntents/AppIntentToolExecutor.swift
+++ b/Sources/ManifoldAppIntents/AppIntentToolExecutor.swift
@@ -117,24 +117,10 @@ public struct AppIntentToolExecutor<Intent: AppIntent & Decodable>: ToolExecutor
 
     /// Approval policy for AppIntent-backed tools.
     ///
-    /// Use ``requiresUserApproval`` for side-effecting intents (the default),
-    /// and ``readOnlyAutoApprove`` only for deliberately read-only intents.
-    public enum ApprovalPolicy: Sendable {
-        /// Require an explicit ``ToolApprovalGate`` decision per call.
-        case requiresUserApproval
-
-        /// Skip approval prompts for read-only intents that are safe to run.
-        case readOnlyAutoApprove
-
-        var requiresApproval: Bool {
-            switch self {
-            case .requiresUserApproval:
-                true
-            case .readOnlyAutoApprove:
-                false
-            }
-        }
-    }
+    /// This is a typealias for the top-level ``AppIntentApprovalPolicy`` so that
+    /// batch-registration call sites (which can't name a concrete generic
+    /// parameter) and single-executor sites both share one stable type.
+    public typealias ApprovalPolicy = AppIntentApprovalPolicy
 
     public let definition: ToolDefinition
     public let requiresApproval: Bool

--- a/Sources/ManifoldAppIntents/DiscoverableAppIntent.swift
+++ b/Sources/ManifoldAppIntents/DiscoverableAppIntent.swift
@@ -22,9 +22,7 @@ public enum AppIntentApprovalPolicy: Sendable {
     /// without a confirmation step.
     case readOnlyAutoApprove
 
-    // Not public because callers shouldn't hard-code on the Bool shape;
-    // `AppIntentToolExecutor` is the single consumer.
-    var requiresApproval: Bool {
+    public var requiresApproval: Bool {
         switch self {
         case .requiresUserApproval: true
         case .readOnlyAutoApprove: false

--- a/Sources/ManifoldAppIntents/DiscoverableAppIntent.swift
+++ b/Sources/ManifoldAppIntents/DiscoverableAppIntent.swift
@@ -1,0 +1,138 @@
+import Foundation
+import ManifoldInference
+
+#if canImport(AppIntents)
+import AppIntents
+
+// MARK: - AppIntentApprovalPolicy
+
+/// Approval policy for AppIntent-backed tools.
+///
+/// Defined at top level (rather than nested inside the generic
+/// ``AppIntentToolExecutor``) so batch-registration call sites — which cannot
+/// name a concrete generic argument to access a nested enum — can reference the
+/// type directly. ``AppIntentToolExecutor/ApprovalPolicy`` is a typealias that
+/// points here, keeping the single-executor API unchanged.
+@available(iOS 26, macOS 26, *)
+public enum AppIntentApprovalPolicy: Sendable {
+    /// Require an explicit ``ToolApprovalGate`` decision per call.
+    case requiresUserApproval
+
+    /// Skip approval prompts for read-only intents that are safe to run
+    /// without a confirmation step.
+    case readOnlyAutoApprove
+
+    // Not public because callers shouldn't hard-code on the Bool shape;
+    // `AppIntentToolExecutor` is the single consumer.
+    var requiresApproval: Bool {
+        switch self {
+        case .requiresUserApproval: true
+        case .readOnlyAutoApprove: false
+        }
+    }
+}
+
+// MARK: - DiscoverableAppIntent
+
+/// Marker protocol for AppIntents that participate in batch registration.
+///
+/// Adopt `DiscoverableAppIntent` on any intent you want to hand to
+/// ``ToolRegistry/registerAppIntents(_:approvalPolicy:entityResolver:)``.
+/// The marker adds nothing over `AppIntent & Decodable` at the type level —
+/// it is an explicit declaration of registration intent that lets call sites
+/// build typed arrays without casting and lets tooling enumerate the batch
+/// surface without scanning every `AppIntent` in the module.
+///
+/// ### Example
+///
+/// ```swift
+/// struct SearchIntent: DiscoverableAppIntent {
+///     static let title: LocalizedStringResource = "Search"
+///     @Parameter(title: "Query") var query: String
+///     init() {}
+///     init(from decoder: Decoder) throws { … }
+///     func perform() async throws -> some IntentResult { … }
+/// }
+///
+/// // At app startup — zero boilerplate per intent:
+/// toolRegistry.registerAppIntents(
+///     [SearchIntent.self, SummarizeIntent.self],
+///     entityResolver: MyEntityResolver()
+/// )
+/// ```
+@available(iOS 26, macOS 26, *)
+public protocol DiscoverableAppIntent: AppIntent & Decodable {}
+
+// MARK: - ToolRegistry batch-registration extension
+
+@available(iOS 26, macOS 26, *)
+public extension ToolRegistry {
+
+    /// Registers multiple `DiscoverableAppIntent` types as tool executors.
+    ///
+    /// Each metatype in `intentTypes` is opened from its existential shell and
+    /// wrapped in a concrete ``AppIntentToolExecutor``, then handed to
+    /// ``ToolRegistry/register(_:)`` exactly as the single-executor path does.
+    /// A uniform `approvalPolicy` and `entityResolver` are applied to every
+    /// intent in the array; supply per-intent configuration by falling back to
+    /// individual ``AppIntentToolExecutor`` registrations for those intents.
+    ///
+    /// - Parameters:
+    ///   - intentTypes: Metatypes conforming to ``DiscoverableAppIntent``.
+    ///     Array order is preserved for diagnostics but registration is by name.
+    ///   - approvalPolicy: Applied uniformly to every intent.
+    ///     Defaults to ``AppIntentApprovalPolicy/requiresUserApproval``.
+    ///   - entityResolver: Used to resolve `AppEntity`-typed parameters.
+    ///     Defaults to ``DefaultAppEntityResolver``.
+    func registerAppIntents(
+        _ intentTypes: [any DiscoverableAppIntent.Type],
+        approvalPolicy: AppIntentApprovalPolicy = .requiresUserApproval,
+        entityResolver: any AppEntityResolver = DefaultAppEntityResolver()
+    ) {
+        for intentType in intentTypes {
+            register(_openAndMakeExecutor(intentType, approvalPolicy: approvalPolicy, entityResolver: entityResolver))
+        }
+    }
+
+    /// Convenience overload for callers that assemble metatype arrays at runtime
+    /// and cannot (or choose not to) adopt the ``DiscoverableAppIntent`` marker.
+    ///
+    /// Behaviour is identical to the ``DiscoverableAppIntent`` overload.
+    func registerAppIntents(
+        _ intentTypes: [any (AppIntent & Decodable).Type],
+        approvalPolicy: AppIntentApprovalPolicy = .requiresUserApproval,
+        entityResolver: any AppEntityResolver = DefaultAppEntityResolver()
+    ) {
+        for intentType in intentTypes {
+            register(_openAndMakeExecutor(intentType, approvalPolicy: approvalPolicy, entityResolver: entityResolver))
+        }
+    }
+}
+
+// MARK: - Existential-opening shim
+
+/// Opens the `any (AppIntent & Decodable).Type` existential into a concrete
+/// generic function so `AppIntentToolExecutor<I>` can be instantiated.
+///
+/// Swift generics require that the type parameter be known at compile time.
+/// The existential-opening trick (passing to a generic function) is the
+/// idiomatic Swift 5.7+ solution and avoids `@_disfavoredOverload` hacks or
+/// secondary protocol witnesses. The result is returned as `any ToolExecutor`
+/// so the caller can hand it directly to `ToolRegistry.register`.
+@available(iOS 26, macOS 26, *)
+private func _openAndMakeExecutor(
+    _ intentType: any (AppIntent & Decodable).Type,
+    approvalPolicy: AppIntentApprovalPolicy,
+    entityResolver: any AppEntityResolver
+) -> any ToolExecutor {
+    func _make<I: AppIntent & Decodable>(_ type: I.Type) -> any ToolExecutor {
+        AppIntentToolExecutor(
+            type,
+            approvalPolicy: approvalPolicy,
+            entityResolver: entityResolver
+        )
+    }
+    return _make(intentType)
+}
+
+#endif // canImport(AppIntents)

--- a/Tests/ManifoldAppIntentsTests/BatchRegistrationTests.swift
+++ b/Tests/ManifoldAppIntentsTests/BatchRegistrationTests.swift
@@ -1,0 +1,288 @@
+#if AppIntents
+import XCTest
+import ManifoldInference
+@testable import ManifoldAppIntents
+
+#if canImport(AppIntents)
+import AppIntents
+
+// MARK: - Fixtures
+
+/// Simple intent that adopts DiscoverableAppIntent — the primary marker path.
+@available(iOS 26, macOS 26, *)
+struct FooIntent: DiscoverableAppIntent {
+    static let title: LocalizedStringResource = "Foo"
+
+    @Parameter(title: "Value")
+    var value: String
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init()
+        self.value = try c.decode(String.self, forKey: .value)
+    }
+
+    private enum CodingKeys: String, CodingKey { case value }
+
+    func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        .result(value: "foo:\(value)")
+    }
+}
+
+/// Second intent that does NOT adopt DiscoverableAppIntent — used to exercise
+/// the `(AppIntent & Decodable).Type` heterogeneous overload.
+@available(iOS 26, macOS 26, *)
+struct BarIntent: AppIntent, Decodable {
+    static let title: LocalizedStringResource = "Bar"
+
+    @Parameter(title: "Count")
+    var count: Int
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init()
+        self.count = try c.decode(Int.self, forKey: .count)
+    }
+
+    private enum CodingKeys: String, CodingKey { case count }
+
+    func perform() async throws -> some IntentResult & ReturnsValue<Int> {
+        .result(value: count * 2)
+    }
+}
+
+/// Third intent that adopts DiscoverableAppIntent for batch-of-three tests.
+@available(iOS 26, macOS 26, *)
+struct BazIntent: DiscoverableAppIntent {
+    static let title: LocalizedStringResource = "Baz"
+
+    @Parameter(title: "Flag")
+    var flag: Bool
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init()
+        self.flag = try c.decode(Bool.self, forKey: .flag)
+    }
+
+    private enum CodingKeys: String, CodingKey { case flag }
+
+    func perform() async throws -> some IntentResult & ReturnsValue<Bool> {
+        .result(value: !flag)
+    }
+}
+
+// MARK: - Tests
+
+@available(iOS 26, macOS 26, *)
+final class BatchRegistrationTests: XCTestCase {
+
+    // MARK: - DiscoverableAppIntent conformance
+
+    /// Any DiscoverableAppIntent metatype must be assignable to both
+    /// `any AppIntent.Type` and `any Decodable.Type`, confirming the protocol
+    /// refines both bases at the type level.
+    func testDiscoverableAppIntentConformsToAppIntentAndDecodable() {
+        let intentType: any DiscoverableAppIntent.Type = FooIntent.self
+        let asAppIntent: any AppIntent.Type = intentType
+        let asDecodable: any Decodable.Type = intentType
+        // Accessing the metatypes is the conformance proof; equality assertions
+        // prevent the compiler from eliminating the casts as dead code.
+        XCTAssertTrue(asAppIntent == FooIntent.self)
+        XCTAssertTrue(asDecodable == FooIntent.self)
+    }
+
+    // MARK: - registerAppIntents (DiscoverableAppIntent overload)
+
+    /// Registering two DiscoverableAppIntent types must create one named
+    /// executor per type, each with a correctly snake-cased name.
+    @MainActor
+    func testRegisterDiscoverableIntentsCreatesOneExecutorPerType() {
+        let registry = ToolRegistry()
+        registry.registerAppIntents([FooIntent.self, BazIntent.self])
+
+        XCTAssertTrue(
+            registry.contains(name: "foo_intent"),
+            "foo_intent must be registered after batch call"
+        )
+        XCTAssertTrue(
+            registry.contains(name: "baz_intent"),
+            "baz_intent must be registered after batch call"
+        )
+
+        // Sabotage: remove BazIntent.self from the array above → baz_intent absent,
+        // XCTAssertTrue on baz_intent fails.
+    }
+
+    /// Each executor must carry the name derived from its own type, not a shared
+    /// name from the last (or first) element in the array.
+    @MainActor
+    func testEachBatchedExecutorCarriesItsOwnName() {
+        let registry = ToolRegistry()
+        registry.registerAppIntents([FooIntent.self, BazIntent.self])
+
+        let fooExec = registry.executor(for: "foo_intent")
+        let bazExec = registry.executor(for: "baz_intent")
+
+        XCTAssertEqual(
+            fooExec?.definition.name, "foo_intent",
+            "executor for FooIntent must carry the correct snake-cased name"
+        )
+        XCTAssertEqual(
+            bazExec?.definition.name, "baz_intent",
+            "executor for BazIntent must carry the correct snake-cased name"
+        )
+    }
+
+    // MARK: - registerAppIntents (heterogeneous (AppIntent & Decodable).Type overload)
+
+    /// The `(AppIntent & Decodable).Type` overload must register all types in the
+    /// array, including both DiscoverableAppIntent and plain conformances.
+    @MainActor
+    func testRegisterHeterogeneousTypesArray() {
+        let registry = ToolRegistry()
+        let types: [any (AppIntent & Decodable).Type] = [FooIntent.self, BarIntent.self]
+        registry.registerAppIntents(types)
+
+        XCTAssertTrue(registry.contains(name: "foo_intent"), "foo_intent must be registered")
+        XCTAssertTrue(registry.contains(name: "bar_intent"), "bar_intent must be registered")
+    }
+
+    // MARK: - End-to-end dispatch
+
+    /// Dispatching through ToolRegistry must reach the correct batch-registered
+    /// intent and return the expected result from its `perform()`.
+    @MainActor
+    func testBatchRegisteredFooIntentDispatchesCorrectly() async {
+        let registry = ToolRegistry()
+        registry.registerAppIntents(
+            [FooIntent.self, BazIntent.self],
+            approvalPolicy: .readOnlyAutoApprove
+        )
+
+        let nonce = "§BATCH§\(UUID().uuidString.prefix(8))"
+        let call = ToolCall(
+            id: "foo-1",
+            toolName: "foo_intent",
+            arguments: "{\"value\": \"\(nonce)\"}"
+        )
+
+        let result = await registry.dispatch(call)
+
+        XCTAssertNil(
+            result.errorKind,
+            "batch-registered intent must dispatch without error; got \(String(describing: result.errorKind)): \(result.content)"
+        )
+        // FooIntent prepends "foo:" to the value; the nonce must survive the
+        // perform → serialise round-trip.
+        XCTAssertTrue(
+            result.content.contains(nonce),
+            "result must echo the nonce; got \(result.content)"
+        )
+
+        // Sabotage check (manual): assert result.content.contains("WRONG") fails.
+    }
+
+    @MainActor
+    func testBatchRegisteredBarIntentDispatchesViaHeterogeneousOverload() async {
+        let registry = ToolRegistry()
+        let types: [any (AppIntent & Decodable).Type] = [FooIntent.self, BarIntent.self]
+        registry.registerAppIntents(types, approvalPolicy: .readOnlyAutoApprove)
+
+        let call = ToolCall(
+            id: "bar-1",
+            toolName: "bar_intent",
+            arguments: "{\"count\": 6}"
+        )
+
+        let result = await registry.dispatch(call)
+
+        XCTAssertNil(
+            result.errorKind,
+            "bar_intent dispatch must not error; got \(String(describing: result.errorKind)): \(result.content)"
+        )
+        // BarIntent returns count * 2 = 12.
+        XCTAssertTrue(
+            result.content.contains("12"),
+            "result must contain the doubled count (6*2=12); got \(result.content)"
+        )
+    }
+
+    // MARK: - approvalPolicy propagation
+
+    /// The uniform approvalPolicy must be applied to every executor in the
+    /// batch — not only the first or last.
+    @MainActor
+    func testReadOnlyAutoApprovePropagatesAcrossAllBatchedExecutors() {
+        let registry = ToolRegistry()
+        registry.registerAppIntents(
+            [FooIntent.self, BazIntent.self],
+            approvalPolicy: .readOnlyAutoApprove
+        )
+
+        let fooRequires = registry.executor(for: "foo_intent")?.requiresApproval
+        let bazRequires = registry.executor(for: "baz_intent")?.requiresApproval
+
+        XCTAssertEqual(fooRequires, false, "foo_intent should not require approval (readOnly)")
+        XCTAssertEqual(bazRequires, false, "baz_intent should not require approval (readOnly)")
+
+        // Sabotage: change .readOnlyAutoApprove to .requiresUserApproval above
+        // → both assertions flip to unexpected true.
+    }
+
+    @MainActor
+    func testRequiresUserApprovalIsDefaultForBatchRegistration() {
+        let registry = ToolRegistry()
+        registry.registerAppIntents([FooIntent.self])
+
+        let requires = registry.executor(for: "foo_intent")?.requiresApproval
+        XCTAssertEqual(requires, true, "batch-registered intents default to requiresUserApproval")
+    }
+
+    // MARK: - Empty array is a no-op
+
+    @MainActor
+    func testRegisterEmptyDiscoverableArrayIsNoOp() {
+        let registry = ToolRegistry()
+        registry.registerAppIntents([] as [any DiscoverableAppIntent.Type])
+        XCTAssertTrue(registry.definitions.isEmpty, "empty DiscoverableAppIntent array must produce no executors")
+    }
+
+    @MainActor
+    func testRegisterEmptyHeterogeneousArrayIsNoOp() {
+        let registry = ToolRegistry()
+        registry.registerAppIntents([] as [any (AppIntent & Decodable).Type])
+        XCTAssertTrue(registry.definitions.isEmpty, "empty heterogeneous array must produce no executors")
+    }
+
+    // MARK: - AppIntentApprovalPolicy top-level accessibility
+
+    /// AppIntentApprovalPolicy must be addressable at the top level — no
+    /// generic argument required — because batch-registration call sites don't
+    /// have a concrete Intent type to hang the nested type off.
+    func testApprovalPolicyIsAccessibleWithoutGenericArgument() {
+        let require: AppIntentApprovalPolicy = .requiresUserApproval
+        let readOnly: AppIntentApprovalPolicy = .readOnlyAutoApprove
+        XCTAssertTrue(require.requiresApproval)
+        XCTAssertFalse(readOnly.requiresApproval)
+    }
+
+    /// AppIntentToolExecutor.ApprovalPolicy must be a typealias pointing to
+    /// AppIntentApprovalPolicy — existing single-executor call sites must keep
+    /// compiling unchanged after this rename.
+    func testApprovalPolicyTypealiasIsCompatibleWithTopLevelType() {
+        let viaTopLevel: AppIntentApprovalPolicy = .requiresUserApproval
+        let viaNested: AppIntentToolExecutor<FooIntent>.ApprovalPolicy = .requiresUserApproval
+        // Same underlying type — the Bool values must agree.
+        XCTAssertEqual(viaTopLevel.requiresApproval, viaNested.requiresApproval)
+    }
+}
+
+#endif // canImport(AppIntents)
+#endif


### PR DESCRIPTION
## Summary

- Adds `DiscoverableAppIntent` marker protocol — adopt on intents you want to batch-register; refines `AppIntent & Decodable` with no additional requirements
- Adds two `ToolRegistry` extension methods: a typed `[any DiscoverableAppIntent.Type]` overload and a `[any (AppIntent & Decodable).Type]` convenience overload for runtime-assembled arrays
- Promotes `AppIntentToolExecutor.ApprovalPolicy` to a top-level `AppIntentApprovalPolicy` enum (with a `typealias` back on the executor) so batch call sites can reference the type without a concrete generic argument

**Dep boundary kept:** `DiscoverableAppIntent.swift` lives in `ManifoldAppIntents` and imports only `ManifoldInference` — no new edges introduced.

### Before

```swift
toolRegistry.register(AppIntentToolExecutor(SearchIntent.self, resolver: resolver))
toolRegistry.register(AppIntentToolExecutor(SummarizeIntent.self, resolver: resolver))
toolRegistry.register(AppIntentToolExecutor(TranslateIntent.self, resolver: resolver))
// ... N more lines
```

### After

```swift
// Adopt the marker once on each intent type:
struct SearchIntent: DiscoverableAppIntent { … }

// Register all at startup with one call:
toolRegistry.registerAppIntents(
    [SearchIntent.self, SummarizeIntent.self, TranslateIntent.self],
    entityResolver: MyEntityResolver()
)
```

## Test plan

- [x] `BatchRegistrationTests` — 12 new XCTest cases covering marker-protocol conformance, per-intent name derivation, both overloads, end-to-end dispatch, `approvalPolicy` propagation to every executor, empty-array no-op, and top-level `AppIntentApprovalPolicy` accessibility
- [x] All existing `ManifoldAppIntentsTests` still pass (56 total, 0 failures) under `--traits AppIntents`
- [x] Build verified under `--traits AppIntents` with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)