### PR TITLE
feat(app-intents): AskManifoldIntent system surface for Siri and Shortcuts (#1379)

### DIFF
--- a/Example/Advanced/Intents/ManifoldDemoShortcuts.swift
+++ b/Example/Advanced/Intents/ManifoldDemoShortcuts.swift
@@ -1,12 +1,23 @@
 import AppIntents
+import ManifoldAppIntents
 
-/// Surfaces ``AskManifoldDemoIntent`` to Spotlight / Siri so users can
-/// invoke it by voice or from the keyboard without first opening the app.
+/// Surfaces ``AskManifoldDemoIntent`` and ``AskManifoldIntent`` to Spotlight /
+/// Siri so users can invoke them by voice or from the keyboard without opening
+/// the app first.
 ///
 /// Shortcuts defined here show up automatically when the app is first
 /// launched; users can rebind the trigger phrases in the Shortcuts app.
+///
+/// ## AppShortcutsProvider must live in the host bundle
+///
+/// The AppIntents build toolchain discovers shortcut phrase metadata at
+/// build time by scanning main-bundle and app-extension sources for
+/// `.stringsdata` extraction. Framework-only declarations (like
+/// `AskManifoldIntent` in `ManifoldAppIntents`) are not indexed — only the
+/// `AppShortcutsProvider` wrapper must be in the host bundle.
 public struct ManifoldDemoShortcuts: AppShortcutsProvider {
 
+    @available(iOS 18, macOS 15, *)
     public static var appShortcuts: [AppShortcut] {
         // Note: the `prompt` parameter is a plain `String`, which Siri's
         // phrase-binding syntax (`\(\.$prompt)`) does not allow — only
@@ -19,6 +30,18 @@ public struct ManifoldDemoShortcuts: AppShortcutsProvider {
             ],
             shortTitle: "Ask Manifold",
             systemImageName: "text.bubble"
+        )
+        // AskManifoldIntent is the library-provided intent that routes
+        // through whatever handler the host wired via
+        // ManifoldIntentConfiguration. Exposed alongside the demo-specific
+        // intent so integrators can see both patterns side by side.
+        AppShortcut(
+            intent: AskManifoldIntent(),
+            phrases: [
+                "Ask \(.applicationName) via Manifold"
+            ],
+            shortTitle: "Ask via Manifold",
+            systemImageName: "text.bubble.fill"
         )
     }
 }

--- a/Example/Advanced/Intents/RuntimeHandler.swift
+++ b/Example/Advanced/Intents/RuntimeHandler.swift
@@ -1,0 +1,44 @@
+import Foundation
+import ManifoldInference
+import ManifoldAppIntents
+
+#if canImport(AppIntents)
+import AppIntents
+
+/// Adapts the demo app's `InferenceService` to `AskManifoldHandler`.
+///
+/// `AskManifoldIntent` calls back through this actor so it stays decoupled
+/// from `ManifoldRuntime` / SwiftData — that dep line would otherwise drag
+/// persistence plumbing into every consumer of `ManifoldAppIntents`.
+///
+/// The implementation fires a single-shot `generate` call (no session
+/// persistence) because the intent surface is stateless from the system's
+/// perspective: Siri hands in a prompt and expects a reply string.
+@available(iOS 18, macOS 15, *)
+actor RuntimeHandler: AskManifoldHandler {
+
+    private let inferenceService: InferenceService
+
+    init(inferenceService: InferenceService) {
+        self.inferenceService = inferenceService
+    }
+
+    func ask(_ prompt: String) async throws -> String {
+        let stream = try inferenceService.generate(
+            messages: [(role: "user", content: prompt)]
+        )
+        var reply = ""
+        for try await event in stream.events {
+            if case .token(let chunk) = event {
+                reply += chunk
+            }
+        }
+        return reply
+    }
+
+    func displayName() async -> String {
+        "Manifold Demo"
+    }
+}
+
+#endif // canImport(AppIntents)

--- a/Example/Advanced/ManifoldDemoApp.swift
+++ b/Example/Advanced/ManifoldDemoApp.swift
@@ -9,6 +9,9 @@ import ManifoldTools
 #if canImport(ManifoldHuggingFace)
 import ManifoldHuggingFace
 #endif
+#if canImport(AppIntents)
+import ManifoldAppIntents
+#endif
 
 @main
 struct ManifoldDemoApp: App {
@@ -410,6 +413,19 @@ struct ManifoldDemoApp: App {
 
         self.chatViewModel = vm
         self.runtime = runtime
+
+        // Wire AskManifoldIntent so Siri / Shortcuts can route prompts
+        // through the demo's inference service. The handler is a plain actor
+        // adapter — no SwiftData or session dependency needed.
+        #if canImport(AppIntents)
+        if #available(iOS 18, macOS 15, *) {
+            Task {
+                await ManifoldIntentConfiguration.shared.configure(
+                    handler: RuntimeHandler(inferenceService: inferenceService)
+                )
+            }
+        }
+        #endif
     }
 
     /// Converts a ``PendingSharePayload`` (pure Foundation, extension-safe)

--- a/Sources/ManifoldAppIntents/AskManifoldIntent.swift
+++ b/Sources/ManifoldAppIntents/AskManifoldIntent.swift
@@ -80,6 +80,12 @@ public actor ManifoldIntentConfiguration {
     public var handler: (any AskManifoldHandler)? {
         _handler
     }
+
+    /// Removes the registered handler, leaving the configuration in its
+    /// initial unconfigured state. Intended for test teardown only.
+    func clearHandler() {
+        _handler = nil
+    }
 }
 
 // MARK: - AskManifoldIntent
@@ -161,6 +167,12 @@ public struct AskManifoldIntent: AppIntent {
 
         do {
             let reply = try await handler.ask(prompt)
+            guard !reply.isEmpty else {
+                // A conforming handler returned an empty string — surface this
+                // as a dialog rather than speaking "\(source) says: " verbatim.
+                Log.inference.warning("AskManifoldIntent: handler returned empty reply")
+                return .result(dialog: "I didn't get a response. Please try again.")
+            }
             let source = await handler.displayName()
             return .result(
                 dialog: IntentDialog(stringLiteral: "\(source) says: \(reply)")

--- a/Sources/ManifoldAppIntents/AskManifoldIntent.swift
+++ b/Sources/ManifoldAppIntents/AskManifoldIntent.swift
@@ -1,0 +1,183 @@
+import Foundation
+import ManifoldInference
+
+#if canImport(AppIntents)
+import AppIntents
+
+// MARK: - AskManifoldHandler
+
+/// Narrow seam between `AskManifoldIntent` and the host's conversation runtime.
+///
+/// A two-method protocol keeps the intent testable with a mock, lets hosts wire
+/// any backing implementation (including `ConversationRuntime`), and means
+/// `ManifoldAppIntents` never needs to know about sessions, stores, or
+/// persistence plumbing. Adding `ManifoldRuntime` to this target would drag
+/// SwiftData into every app that links here — this protocol sidesteps that.
+///
+/// ## Wiring to `ConversationRuntime`
+///
+/// ```swift
+/// actor RuntimeHandler: AskManifoldHandler {
+///     private let runtime: ConversationRuntime
+///
+///     init(runtime: ConversationRuntime) { self.runtime = runtime }
+///
+///     func ask(_ prompt: String) async throws -> String {
+///         try await runtime.sendAndAwaitReply(prompt)
+///     }
+///
+///     func displayName() async -> String { "My Chat" }
+/// }
+///
+/// await ManifoldIntentConfiguration.shared.configure(handler: RuntimeHandler(runtime: myRuntime))
+/// ```
+@available(iOS 18, macOS 15, *)
+public protocol AskManifoldHandler: Actor {
+    /// Send a prompt and return the full assistant reply.
+    ///
+    /// Called from `AskManifoldIntent.perform()` on a background actor. The
+    /// `Actor` constraint satisfies Swift 6 sendability — the intent framework
+    /// can call `perform()` on any thread.
+    func ask(_ prompt: String) async throws -> String
+
+    /// Short human-readable name surfaced in Siri readback.
+    ///
+    /// Example: "My App Chat" → Siri says "Here's what My App Chat says: …"
+    func displayName() async -> String
+}
+
+// MARK: - ManifoldIntentConfiguration
+
+/// Process-global registry that wires a host-supplied ``AskManifoldHandler``
+/// to `AskManifoldIntent`.
+///
+/// Call ``configure(handler:)`` once during startup (typically in `@main` or
+/// `AppDelegate.application(_:didFinishLaunchingWithOptions:)`):
+///
+/// ```swift
+/// await ManifoldIntentConfiguration.shared.configure(handler: myHandler)
+/// ```
+///
+/// Thread-safety is serialised through the actor, so it is safe to call from
+/// any execution context. Calling ``configure(handler:)`` more than once
+/// replaces the previous handler — latest registration wins, which makes it
+/// easy to swap handlers during testing.
+@available(iOS 18, macOS 15, *)
+public actor ManifoldIntentConfiguration {
+
+    public static let shared = ManifoldIntentConfiguration()
+
+    private var _handler: (any AskManifoldHandler)?
+
+    private init() {}
+
+    /// Registers the handler that `AskManifoldIntent` will call.
+    public func configure(handler: some AskManifoldHandler) {
+        _handler = handler
+    }
+
+    /// Returns the registered handler, or `nil` when none has been configured.
+    public var handler: (any AskManifoldHandler)? {
+        _handler
+    }
+}
+
+// MARK: - AskManifoldIntent
+
+/// System AppIntent that routes a prompt into the host app's configured
+/// ManifoldKit runtime and returns the assistant's reply.
+///
+/// ## Surfacing in Shortcuts / Siri
+///
+/// Declare an `AppShortcutsProvider` in your **host bundle** (not in the
+/// library) that references this intent:
+///
+/// ```swift
+/// import AppIntents
+/// import ManifoldAppIntents
+///
+/// struct MyAppShortcuts: AppShortcutsProvider {
+///     static var appShortcuts: [AppShortcut] {
+///         AppShortcut(
+///             intent: AskManifoldIntent(),
+///             phrases: ["Ask \(.applicationName)"],
+///             shortTitle: "Ask",
+///             systemImageName: "text.bubble"
+///         )
+///     }
+/// }
+/// ```
+///
+/// The `AppShortcutsProvider` **must live in the host bundle** — the AppIntents
+/// build toolchain scans main-bundle and app-extension sources for
+/// `.stringsdata` phrase extraction. Framework-only declarations are not
+/// indexed at build time. The intent type itself (`AskManifoldIntent`) can be
+/// library-declared; only the `AppShortcutsProvider` wrapper needs to be in
+/// the host bundle.
+///
+/// ## Configuration
+///
+/// Before the intent can run, call:
+///
+/// ```swift
+/// await ManifoldIntentConfiguration.shared.configure(handler: myHandler)
+/// ```
+///
+/// If no handler is configured when the intent fires, it returns a graceful
+/// error dialog rather than crashing.
+@available(iOS 18, macOS 15, *)
+public struct AskManifoldIntent: AppIntent {
+
+    public static let title: LocalizedStringResource = "Ask Manifold"
+
+    public static let description = IntentDescription(
+        "Sends a prompt to the Manifold-powered chat and returns the reply.",
+        categoryName: "Chat"
+    )
+
+    /// Defaults to `false` so Siri can speak the reply in a background context
+    /// (e.g. lock screen, CarPlay). Set to `true` in your `AppShortcutsProvider`
+    /// shortcut if you want the chat UI to open after the reply.
+    public static let openAppWhenRun: Bool = false
+
+    @Parameter(title: "Prompt", description: "What would you like to ask?")
+    public var prompt: String
+
+    public init() {}
+
+    public init(prompt: String) {
+        self.prompt = prompt
+    }
+
+    public func perform() async throws -> some IntentResult & ProvidesDialog {
+        guard let handler = await ManifoldIntentConfiguration.shared.handler else {
+            // Host hasn't called configure(). Return a useful error dialog
+            // instead of trapping — the intent framework reads this back
+            // through Siri or displays it in Shortcuts.
+            return .result(
+                dialog: "Manifold is not configured. Open the app and try again."
+            )
+        }
+
+        do {
+            let reply = try await handler.ask(prompt)
+            let source = await handler.displayName()
+            return .result(
+                dialog: IntentDialog(stringLiteral: "\(source) says: \(reply)")
+            )
+        } catch {
+            // Surface as a graceful dialog rather than rethrowing — thrown
+            // errors in AppIntents show a generic system error sheet, which is
+            // worse UX than a spoken message. Log the real error so it's
+            // visible in the unified log.
+            Log.inference.warning(
+                "AskManifoldIntent: handler threw — \(String(describing: error), privacy: .public)"
+            )
+            return .result(
+                dialog: "Something went wrong. Please try again."
+            )
+        }
+    }
+}
+
+#endif // canImport(AppIntents)

--- a/Tests/ManifoldAppIntentsTests/AskManifoldIntentTests.swift
+++ b/Tests/ManifoldAppIntentsTests/AskManifoldIntentTests.swift
@@ -37,6 +37,13 @@ actor MockAskManifoldHandler: AskManifoldHandler {
 @available(iOS 18, macOS 15, *)
 final class AskManifoldIntentTests: XCTestCase {
 
+    override func setUp() async throws {
+        // Reset the shared singleton so each test starts with no handler.
+        // Without this, tests that install a handler bleed state into
+        // subsequent tests — ordering determines which paths get exercised.
+        await ManifoldIntentConfiguration.shared.clearHandler()
+    }
+
     // MARK: - perform() with configured handler
 
     func test_perform_returnsDialogWhenHandlerConfigured() async throws {
@@ -61,43 +68,15 @@ final class AskManifoldIntentTests: XCTestCase {
 
     // MARK: - perform() without handler
 
-    func test_noHandlerDialog_freshConfiguration() async throws {
-        // Fresh config actor — no configure() called, so handler is nil.
-        let freshConfig = ManifoldIntentConfiguration()
-        let handler = await freshConfig.handler
-        XCTAssertNil(handler, "A freshly created ManifoldIntentConfiguration must have no handler")
-    }
-
     func test_perform_returnsGracefulDialogWhenHandlerNil() async throws {
-        // Install a nil-sentinel: we can't easily clear shared, but we can
-        // verify the intent's guard branch by calling perform() immediately
-        // after clearing with a fresh test-only mock, then observe the
-        // "not configured" dialog text. The shared singleton is stateful, so
-        // this test depends on test ordering only for the nil-path. We
-        // accept this coupling because the nil path is also tested via the
-        // freshConfig assertion above, which is ordering-independent.
-        //
-        // To force the nil path cleanly without adding a public clearHandler()
-        // we verify the guard branch text by reading the perform() source
-        // contract: the intent returns the exact string below when handler is nil.
-        let expectedSubstring = "not configured"
-        // We can only verify this cleanly if no prior test left a handler.
-        // Skip rather than fail if a handler is already registered — the
-        // positive path tests above cover the core behavior.
-        let currentHandler = await ManifoldIntentConfiguration.shared.handler
-        guard currentHandler == nil else {
-            // A prior test registered a handler. The nil-path dialog text is
-            // verified via code inspection; skip to avoid a false failure.
-            return
-        }
-
+        // setUp() clears shared, so no handler is configured at this point.
         var intent = AskManifoldIntent()
         intent.prompt = "test"
         let result = try await intent.perform()
         let dump = String(describing: result)
         XCTAssertTrue(
-            dump.contains(expectedSubstring),
-            "Expected 'not configured' dialog; got: \(dump)"
+            dump.contains("not configured"),
+            "Expected 'not configured' dialog when no handler is set; got: \(dump)"
         )
     }
 

--- a/Tests/ManifoldAppIntentsTests/AskManifoldIntentTests.swift
+++ b/Tests/ManifoldAppIntentsTests/AskManifoldIntentTests.swift
@@ -1,0 +1,171 @@
+#if AppIntents
+import XCTest
+import ManifoldInference
+@testable import ManifoldAppIntents
+
+#if canImport(AppIntents)
+import AppIntents
+
+// MARK: - Mock handler
+
+/// Simple mock that returns a fixed reply or throws a caller-supplied error.
+///
+/// `AskManifoldHandler` requires `Actor` isolation — an `actor` is the right
+/// shape here, not `@unchecked Sendable` on a class.
+@available(iOS 18, macOS 15, *)
+actor MockAskManifoldHandler: AskManifoldHandler {
+    let reply: String
+    let name: String
+    let errorToThrow: Error?
+
+    init(reply: String = "mock reply", name: String = "MockHandler", errorToThrow: Error? = nil) {
+        self.reply = reply
+        self.name = name
+        self.errorToThrow = errorToThrow
+    }
+
+    func ask(_ prompt: String) async throws -> String {
+        if let error = errorToThrow { throw error }
+        return reply
+    }
+
+    func displayName() async -> String { name }
+}
+
+// MARK: - Tests
+
+@available(iOS 18, macOS 15, *)
+final class AskManifoldIntentTests: XCTestCase {
+
+    // MARK: - perform() with configured handler
+
+    func test_perform_returnsDialogWhenHandlerConfigured() async throws {
+        let handler = MockAskManifoldHandler(reply: "42", name: "TestBot")
+        await ManifoldIntentConfiguration.shared.configure(handler: handler)
+
+        var intent = AskManifoldIntent()
+        intent.prompt = "What is the answer?"
+        // Must not throw — AskManifoldIntent catches all errors internally.
+        let result = try await intent.perform()
+
+        // `String(describing:)` of the IntentResultContainer reliably contains
+        // the dialog text even when public-API mirror extraction returns nil
+        // (see AppIntentToolExecutorTests for the full explanation of why
+        // IntentDialog storage is opaque on iOS 26 / macOS 26).
+        let dump = String(describing: result)
+        XCTAssertTrue(
+            dump.contains("TestBot") || dump.contains("42"),
+            "Expected dialog to contain handler name or reply; got: \(dump)"
+        )
+    }
+
+    // MARK: - perform() without handler
+
+    func test_noHandlerDialog_freshConfiguration() async throws {
+        // Fresh config actor — no configure() called, so handler is nil.
+        let freshConfig = ManifoldIntentConfiguration()
+        let handler = await freshConfig.handler
+        XCTAssertNil(handler, "A freshly created ManifoldIntentConfiguration must have no handler")
+    }
+
+    func test_perform_returnsGracefulDialogWhenHandlerNil() async throws {
+        // Install a nil-sentinel: we can't easily clear shared, but we can
+        // verify the intent's guard branch by calling perform() immediately
+        // after clearing with a fresh test-only mock, then observe the
+        // "not configured" dialog text. The shared singleton is stateful, so
+        // this test depends on test ordering only for the nil-path. We
+        // accept this coupling because the nil path is also tested via the
+        // freshConfig assertion above, which is ordering-independent.
+        //
+        // To force the nil path cleanly without adding a public clearHandler()
+        // we verify the guard branch text by reading the perform() source
+        // contract: the intent returns the exact string below when handler is nil.
+        let expectedSubstring = "not configured"
+        // We can only verify this cleanly if no prior test left a handler.
+        // Skip rather than fail if a handler is already registered — the
+        // positive path tests above cover the core behavior.
+        let currentHandler = await ManifoldIntentConfiguration.shared.handler
+        guard currentHandler == nil else {
+            // A prior test registered a handler. The nil-path dialog text is
+            // verified via code inspection; skip to avoid a false failure.
+            return
+        }
+
+        var intent = AskManifoldIntent()
+        intent.prompt = "test"
+        let result = try await intent.perform()
+        let dump = String(describing: result)
+        XCTAssertTrue(
+            dump.contains(expectedSubstring),
+            "Expected 'not configured' dialog; got: \(dump)"
+        )
+    }
+
+    // MARK: - perform() when handler throws
+
+    func test_perform_returnsGracefulDialogWhenHandlerThrows() async throws {
+        struct FakeError: Error, LocalizedError {
+            var errorDescription: String? { "backend unavailable" }
+        }
+        let handler = MockAskManifoldHandler(errorToThrow: FakeError())
+        await ManifoldIntentConfiguration.shared.configure(handler: handler)
+
+        var intent = AskManifoldIntent()
+        intent.prompt = "Will this fail?"
+        // Must NOT throw — handler errors are caught and turned into a dialog.
+        let result = try await intent.perform()
+
+        let dump = String(describing: result)
+        // The raw error message must not leak into the dialog — only the
+        // generic fallback text is acceptable.
+        XCTAssertFalse(
+            dump.contains("backend unavailable"),
+            "Raw error message must not leak into the Siri dialog; got: \(dump)"
+        )
+        XCTAssertTrue(
+            dump.contains("Something went wrong"),
+            "Expected graceful error dialog; got: \(dump)"
+        )
+    }
+
+    // MARK: - configure() latest-wins
+
+    func test_configure_latestHandlerWins() async throws {
+        let first = MockAskManifoldHandler(reply: "first reply", name: "FirstBot")
+        let second = MockAskManifoldHandler(reply: "second reply", name: "SecondBot")
+        await ManifoldIntentConfiguration.shared.configure(handler: first)
+        await ManifoldIntentConfiguration.shared.configure(handler: second)
+
+        // The registered handler after two calls must be the second one.
+        let registered = await ManifoldIntentConfiguration.shared.handler
+        // Cast to MockAskManifoldHandler to verify identity via displayName.
+        let resolvedName = await registered?.displayName()
+        XCTAssertEqual(
+            resolvedName,
+            "SecondBot",
+            "Expected second handler to win; got displayName: \(String(describing: resolvedName))"
+        )
+    }
+
+    // MARK: - displayName() appears in dialog
+
+    func test_perform_dialogContainsDisplayName() async throws {
+        let handler = MockAskManifoldHandler(reply: "hello world", name: "MyCustomBot")
+        await ManifoldIntentConfiguration.shared.configure(handler: handler)
+
+        var intent = AskManifoldIntent()
+        intent.prompt = "ping"
+        let result = try await intent.perform()
+
+        let dump = String(describing: result)
+        // displayName() must appear somewhere in the result representation so
+        // Siri can read back which service answered.
+        XCTAssertTrue(
+            dump.contains("MyCustomBot"),
+            "displayName() must appear in the intent result; got: \(dump)"
+        )
+    }
+}
+
+#endif // canImport(AppIntents)
+#endif // AppIntents


### PR DESCRIPTION
## Summary

- Adds `AskManifoldIntent: AppIntent` to `ManifoldAppIntents` — routes a Siri/Shortcuts prompt through a host-supplied `AskManifoldHandler` actor and returns the reply as an `IntentDialog`.
- Adds `ManifoldIntentConfiguration` — a process-global actor singleton that hosts call `configure(handler:)` once during startup to wire their runtime.
- Adds `AskManifoldHandler: Actor` protocol — a two-method seam (`ask(_:)` + `displayName()`) that decouples `ManifoldAppIntents` from `ManifoldRuntime` / SwiftData.
- Wires the demo app: new `RuntimeHandler` actor adapter + `ManifoldDemoShortcuts` exposes a second shortcut + `ManifoldDemoApp.installRuntime` calls `configure(handler:)`.
- 5 XCTest cases in `AskManifoldIntentTests`: configured-handler happy path, no-handler graceful dialog, handler-throws graceful dialog, latest-wins replacement, `displayName()` in dialog.

## AppShortcutsProvider must live in the host bundle — DX gotcha every integrator will hit

The AppIntents build toolchain discovers shortcut phrase metadata at **build time** by scanning main-bundle and app-extension sources for `.stringsdata` extraction. Framework-only `AppShortcutsProvider` declarations are **not** indexed — only the wrapper needs to be in the host bundle. The intent type itself (`AskManifoldIntent`) **can** be library-declared.

Every app that links `ManifoldAppIntents` must declare its own provider:

```swift
import AppIntents
import ManifoldAppIntents

@available(iOS 18, macOS 15, *)
struct MyAppShortcuts: AppShortcutsProvider {
    static var appShortcuts: [AppShortcut] {
        AppShortcut(
            intent: AskManifoldIntent(),
            phrases: ["Ask \(.applicationName)"],
            shortTitle: "Ask",
            systemImageName: "text.bubble"
        )
    }
}
```

## Minimal host-app wiring

```swift
// 1. Implement AskManifoldHandler — actor required for Swift 6 sendability.
actor RuntimeHandler: AskManifoldHandler {
    private let service: InferenceService

    init(service: InferenceService) { self.service = service }

    func ask(_ prompt: String) async throws -> String {
        let stream = try service.generate(messages: [(role: "user", content: prompt)])
        var reply = ""
        for try await event in stream.events {
            if case .token(let chunk) = event { reply += chunk }
        }
        return reply
    }

    func displayName() async -> String { "My App" }
}

// 2. Register during app startup (e.g. @main init or scene delegate).
await ManifoldIntentConfiguration.shared.configure(handler: RuntimeHandler(service: myService))
```

No `ManifoldRuntime` or SwiftData dependency needed — `ManifoldAppIntents` only depends on `ManifoldInference`.

## Test plan

- [x] `scripts/test.sh --profile spike --spike-module ManifoldAppIntentsTests` — build + suite passed
- [ ] Full `--profile local` before merge (required per CLAUDE.md pre-push policy)
- [ ] Manual Siri invocation on device to confirm dialog readback

🤖 Generated with [Claude Code](https://claude.com/claude-code)