### PR TITLE
docs: fix QUICKSTART stream iteration and tools-version floor

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Specialised modules (`ManifoldUIModelManagement`, `ManifoldMCP`, `ManifoldVoice`
 
 ## Requirements
 
-- **Swift 6.1+** (`swift-tools-version: 6.1` in your `Package.swift`) — required for `.macOS(.v26)` / `.iOS(.v26)` platform entries.
+- **Swift 6.2+** (`swift-tools-version: 6.2` in your `Package.swift`) — required for `.macOS(.v26)` / `.iOS(.v26)` platform entries (`PackageDescription.SupportedPlatform.MacOSVersion.v26` was introduced in PackageDescription 6.2).
 - iOS 18+ / macOS 15+
 - Apple Foundation Models require iOS 26+ / macOS 26+
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -4,7 +4,7 @@ A one-page tutorial for getting from "empty SwiftUI project" to "working chat UI
 
 ## Prerequisites
 
-- Xcode 16+ on macOS, or Swift 6.1+ toolchain.
+- Xcode 16+ on macOS, or Swift 6.2+ toolchain (`swift-tools-version: 6.2` is required for `.macOS(.v26)` / `.iOS(.v26)` platform entries).
 - A SwiftUI app target on iOS 18+ / macOS 15+ (Apple Foundation Models require iOS 26+ / macOS 26+).
 - Familiarity with SwiftUI's `App` protocol and `@State`. No prior knowledge of MLX, llama.cpp, MCP, or any specific backend is assumed.
 
@@ -110,7 +110,7 @@ DefaultBackends.register(with: inference)
 try await inference.loadModel(from: .builtInFoundation, plan: .cloud())
 
 let stream = try inference.generate(messages: [("user", "Hello")])
-for try await event in stream {
+for try await event in stream.events {
     if case .token(let text) = event { print(text, terminator: "") }
 }
 ```


### PR DESCRIPTION
## Summary

Two one-line doc fixes surfaced by a 3-agent DX walkthrough — all three agents hit both bugs as their top friction when building a chat CLI from public docs only.

- **QUICKSTART stream iteration**: the "bring your own UI" snippet did `for try await event in stream { ... }`, but `GenerationStream` is not an `AsyncSequence`. Fixed to `for try await event in stream.events`.
- **Swift tools-version floor**: README and QUICKSTART claimed Swift 6.1+ was sufficient, but `PackageDescription.SupportedPlatform.MacOSVersion.v26` was introduced in PackageDescription 6.2. Consumers targeting `.macOS(.v26)` / `.iOS(.v26)` need swift-tools-version 6.2. Bumped both call-outs.

`docs:` prefix → no release bump (correct: docs-only).

## Test plan

- [x] `grep -rn "in stream {" docs/ README.md` returns zero hits
- [x] `grep -rn "6\.1" README.md docs/` returns zero hits
- [x] `docs/plans/744-manifoldserver.md` already used the correct `stream.events` form (left untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)