### PR TITLE
feat(persistence): CloudKit sync — makeCloudKitContainer convenience (#873)

### DIFF
--- a/Sources/ManifoldPersistenceSwiftData/ModelContainerFactory.swift
+++ b/Sources/ManifoldPersistenceSwiftData/ModelContainerFactory.swift
@@ -128,6 +128,49 @@ public enum ModelContainerFactory {
         return storeDirectory.appendingPathComponent("store.sqlite")
     }
 
+    /// Returns an on-disk `ModelContainer` configured for CloudKit sync.
+    ///
+    /// Drop-in replacement for ``makeContainer(configurations:)`` that opts
+    /// into SwiftData's automatic CloudKit mirroring. Conversations, sessions,
+    /// and all other model objects are synced to the user's private iCloud
+    /// database across their devices.
+    ///
+    /// ## Host app requirements
+    ///
+    /// 1. Add the **iCloud** capability in Xcode (Signing & Capabilities →
+    ///    iCloud → CloudKit) and create a container, e.g.
+    ///    `iCloud.com.yourapp.manifold`.
+    /// 2. Add the **Push Notifications** capability (required for CloudKit
+    ///    change notifications that wake the sync engine).
+    /// 3. Pass the container identifier here: `"iCloud.com.yourapp.manifold"`.
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// ManifoldBootstrap.build(
+    ///     makeModelContainer: {
+    ///         try ModelContainerFactory.makeCloudKitContainer(
+    ///             containerIdentifier: "iCloud.com.yourapp.manifold"
+    ///         )
+    ///     }
+    /// )
+    /// ```
+    ///
+    /// - Parameter containerIdentifier: The CloudKit container identifier from
+    ///   your app's entitlements (starts with `"iCloud."`).
+    /// - Returns: A `ModelContainer` backed by SwiftData's CloudKit sync engine.
+    /// - Throws: If `ModelContainer` initialisation fails (e.g. schema
+    ///   migration error, or CloudKit container not found in entitlements).
+    public static func makeCloudKitContainer(containerIdentifier: String) throws -> ModelContainer {
+        let config: ModelConfiguration
+        if let storeURL = defaultStoreURL() {
+            config = ModelConfiguration(url: storeURL, cloudKitDatabase: .private(containerIdentifier))
+        } else {
+            config = ModelConfiguration(cloudKitDatabase: .private(containerIdentifier))
+        }
+        return try makeContainer(configurations: [config])
+    }
+
     /// Returns an ephemeral in-memory `ModelContainer` configured with the
     /// current schema.
     ///


### PR DESCRIPTION
## Summary

Adds `ModelContainerFactory.makeCloudKitContainer(containerIdentifier:)` — a named convenience that makes CloudKit sync discoverable without requiring host developers to know SwiftData's `cloudKitDatabase:` parameter.

SwiftData's V8 schema has no `@Attribute(.unique)` constraints (CloudKit's hard incompatibility), so the schema is already compatible. This PR adds the discoverability layer.

## What it does

- Calls through to `makeContainer(configurations:)` with a `ModelConfiguration` that sets `cloudKitDatabase: .private(containerIdentifier)`.
- Picks up the per-app store URL from `defaultStoreURL()` when available (preventing the default-store collision documented in `makeContainer`).
- File protection is applied by `makeContainer` internally — no double-application.

## Host app requirements

1. Add the **iCloud** capability (Signing & Capabilities → iCloud → CloudKit) and create a container, e.g. `iCloud.com.yourapp.manifold`.
2. Add the **Push Notifications** capability (required for CloudKit change notifications).
3. Call:

```swift
ManifoldBootstrap.build(
    makeModelContainer: {
        try ModelContainerFactory.makeCloudKitContainer(
            containerIdentifier: "iCloud.com.yourapp.manifold"
        )
    }
)
```

## Testing

- Build: `swift build --target ManifoldPersistenceSwiftData --disable-default-traits` — clean.
- Persistence suite: 171 passed, 0 failures (6 skipped — existing iOS-only skips).

Closes #873.